### PR TITLE
 replication: sync replication mode with sync_timeout

### DIFF
--- a/pkg/typeutil/clock.go
+++ b/pkg/typeutil/clock.go
@@ -1,0 +1,29 @@
+package typeutil
+
+import (
+	"time"
+)
+
+var (
+	// RealtimeClock is a settable system-wide clock that measures real (i.e., wall-clock) time.
+	// Setting this clock requires appropriate privileges. This clock is affected by
+	// discontinuous jumps in the system time (e.g., if the system administrator manually
+	// changes the clock), and by the incremental adjustments performed by adjtime(3) and NTP.
+	RealtimeClock Clock
+
+	// MonotonicClock is a nonsettable system-wide clock that represents monotonic time since—as described
+	// by POSIX—"some unspecified point in the past". On Linux, that point corresponds to the number of seconds
+	// that the system has been running since it was booted.
+	MonotonicClock Clock
+
+	// MonotonicRawClock is similar to MonotonicClock, but provides access to a raw hardware-based
+	// time that is not subject to NTP adjustments or the incremental adjustments performed by adjtime(3).
+	// This clock does not count time that the system is suspended.
+	MonotonicRawClock Clock
+)
+
+// Clock represents a clock which can be queried for a time.Time
+type Clock interface {
+	Now() time.Time
+	Elapsed() time.Duration
+}

--- a/pkg/typeutil/clock_linux.go
+++ b/pkg/typeutil/clock_linux.go
@@ -1,0 +1,36 @@
+package typeutil
+
+import (
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const (
+	clockRealtime = iota
+	clockMonotonic
+	clockMonotonicRaw
+)
+
+func init() {
+	RealtimeClock = &clock{clockID: clockRealtime}
+	MonotonicClock = &clock{clockID: clockMonotonic}
+	MonotonicRawClock = &clock{clockID: clockMonotonicRaw}
+}
+
+type clock struct {
+	clockID uintptr
+}
+
+func (c *clock) Now() time.Time {
+	var ts syscall.Timespec
+	syscall.Syscall(syscall.SYS_CLOCK_GETTIME, c.clockID, uintptr(unsafe.Pointer(&ts)), 0)
+	sec, nsec := ts.Unix()
+	return time.Unix(sec, nsec)
+}
+
+var epoch = time.Unix(0, 0)
+
+func (c *clock) Elapsed() time.Duration {
+	return c.Now().Sub(epoch)
+}

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -172,6 +172,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	adminHandler := newAdminHandler(svr, rd)
 	clusterRouter.HandleFunc("/admin/cache/region/{id}", adminHandler.HandleDropCacheRegion).Methods("DELETE")
 	clusterRouter.HandleFunc("/admin/reset-ts", adminHandler.ResetTS).Methods("POST")
+	clusterRouter.HandleFunc("/admin/replication_mode/status", adminHandler.UpdateSyncStatusTime).Methods("PUT")
 	apiRouter.HandleFunc("/admin/persist-file/{file_name}", adminHandler.persistFile).Methods("POST")
 
 	logHandler := newlogHandler(svr, rd)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -172,7 +172,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	adminHandler := newAdminHandler(svr, rd)
 	clusterRouter.HandleFunc("/admin/cache/region/{id}", adminHandler.HandleDropCacheRegion).Methods("DELETE")
 	clusterRouter.HandleFunc("/admin/reset-ts", adminHandler.ResetTS).Methods("POST")
-	clusterRouter.HandleFunc("/admin/replication_mode/status", adminHandler.UpdateSyncStatusTime).Methods("PUT")
+	clusterRouter.HandleFunc("/admin/replication_mode/status", adminHandler.UpdateSyncStatusTime).Methods("POST")
 	apiRouter.HandleFunc("/admin/persist-file/{file_name}", adminHandler.persistFile).Methods("POST")
 
 	logHandler := newlogHandler(svr, rd)

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -295,7 +295,7 @@ func (m *ModeManager) drSwitchToAsyncWithLock() error {
 		return err
 	}
 	m.drAutoSync = dr
-	log.Info("switched to async state", zap.String("replicate-mode", modeDRAutoSync), zap.Duration("cost", time.Now().Sub(startTime)))
+	log.Info("switched to async state", zap.String("replicate-mode", modeDRAutoSync), zap.Duration("cost", time.Since(startTime)))
 	return nil
 }
 
@@ -322,7 +322,7 @@ func (m *ModeManager) drSwitchToSyncRecoverWithLock() error {
 	}
 	m.drAutoSync = dr
 	m.drRecoverKey, m.drRecoverCount = nil, 0
-	log.Info("switched to sync_recover state", zap.String("replicate-mode", modeDRAutoSync), zap.Duration("cost", time.Now().Sub(startTime)))
+	log.Info("switched to sync_recover state", zap.String("replicate-mode", modeDRAutoSync), zap.Duration("cost", time.Since(startTime)))
 	return nil
 }
 
@@ -344,7 +344,7 @@ func (m *ModeManager) drSwitchToSync() error {
 		return err
 	}
 	m.drAutoSync = dr
-	log.Info("switched to sync state", zap.String("replicate-mode", modeDRAutoSync), zap.Duration("cost", time.Now().Sub(startTime)))
+	log.Info("switched to sync state", zap.String("replicate-mode", modeDRAutoSync), zap.Duration("cost", time.Since(startTime)))
 	return nil
 }
 

--- a/server/replication/replication_mode_test.go
+++ b/server/replication/replication_mode_test.go
@@ -152,6 +152,10 @@ func (rep *mockFileReplicator) GetMembers(context.Context, *pdpb.GetMembersReque
 	}, nil
 }
 
+func (rep *mockFileReplicator) PersistFile(name string, data []byte) error {
+	return nil
+}
+
 func (s *testReplicationMode) TestStateSwitch(c *C) {
 	store := core.NewStorage(kv.NewMemoryKV())
 	conf := config.ReplicationModeConfig{ReplicationMode: modeDRAutoSync, DRAutoSync: config.DRAutoSyncReplicationConfig{

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -645,7 +645,7 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	tc.WaitLeader()
 	leaderServer := tc.GetServer(tc.GetLeader())
 	svr := leaderServer.GetServer()
-	rc := cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
+	rc := cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient(), nil)
 
 	// Cluster is not bootstrapped.
 	rc.InitCluster(svr.GetAllocator(), svr.GetPersistOptions(), svr.GetStorage(), svr.GetBasicCluster())
@@ -686,7 +686,7 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	}
 	c.Assert(storage.Flush(), IsNil)
 
-	raftCluster = cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
+	raftCluster = cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient(), nil)
 	raftCluster.InitCluster(mockid.NewIDAllocator(), opt, storage, basicCluster)
 	raftCluster, err = raftCluster.LoadClusterInfo()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/pingcap/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
close https://github.com/pingcap/pd/issues/2490

### What is changed and how it works?

* Add a goroutine for getting the replication status from the pd leader periodically
* Add an HTTP API for getting the replication status and update the last time for sync replication status from followers
* Replicate the status file with timeout

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Code changes

- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/pingcap/pd/blob/master/docs/development.md#updating-api-documentation))

Side effects

- Possible performance regression
- Increased code complexity

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
* replication_mode: sync replication status mode with sync_timeout
