### PR TITLE
*: generate the error metafile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ dashboard-ui: export GO111MODULE=on
 dashboard-ui:
 	./scripts/embed-dashboard-ui.sh
 
+# Generate the meta file of errors
+gen-error-meta:
+	go run tools/gen-error-meta/main.go
+
 # Tools
 pd-ctl: export GO111MODULE=on
 pd-ctl:

--- a/error.toml
+++ b/error.toml
@@ -1,0 +1,160 @@
+[error.PD:network:ErrHTTPRequestURL]
+error = '''wrong url in user http request'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:network:ErrGRPCTso]
+error = '''grpc tso request fail'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:network:ErrGRPCHeartbeat]
+error = '''grpc heartbeat request fail'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:network:ErrGRPCClose]
+error = '''grpc close connection fail'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:network:ErrGRPCSend]
+error = '''grpc send message fail'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:network:ErrHTTPErrorResponse]
+error = '''make http error response fail'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:network:ErrHTTPRedirect]
+error = '''http redirect many times'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:storage:ErrStorageDelete]
+error = '''delete config from storage error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:storage:ErrStorageEtcdLoad]
+error = '''load config from storage etcd error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:storage:ErrStorageEtcdSave]
+error = '''save config to storage etcd error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:storage:ErrStorageEtcdDelete]
+error = '''delete config from storage etcd error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:storage:ErrStorageLoad]
+error = '''load config from storage error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:storage:ErrStorageSave]
+error = '''save config to storage error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalRuleInvalid]
+error = '''invalid rule found'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalRuleDuplicate]
+error = '''duplicate rule found'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalRuleMismatch]
+error = '''rule key mismatch'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalOperatorNotFound]
+error = '''operator not found'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalSchedulerDuplicate]
+error = '''duplicate scheduler found'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalRegionKey]
+error = '''wrong region key range'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalSchedulerNotFound]
+error = '''scheduler not found'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalOperatorMerge]
+error = '''merge operator should be pair'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalStoreNotFound]
+error = '''store id {placeholder} not found'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalSchedulerConfig]
+error = '''wrong scheduler config'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalOperatorNotStart]
+error = '''operator not start'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalOperatorNotEnd]
+error = '''operator not end'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalStepUnknown]
+error = '''operator step is unknown'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalClusterVersionChange]
+error = '''cluster version change same time'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalCacheRegionOverflow]
+error = '''cache region overflow'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:internal:ErrInternalVersionFeatureNotExist]
+error = '''version feature not exist'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:format:ErrFormatParseClusterVersion]
+error = '''parse cluster version error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:format:ErrFormatParseURL]
+error = '''parse url error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:format:ErrFormatParseHistoryIndex]
+error = '''parse history index error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:format:ErrFormatParseCmd]
+error = '''parse cmd error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:other:ErrOtherInitLog]
+error = '''init log fail'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:other:ErrOtherDashboardServer]
+error = '''dashboard server error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:other:ErrOtherPrometheusPush]
+error = '''push to prometheus error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:other:ErrOtherPluginLoadActionUnknown]
+error = '''unknown action to load plugin'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:other:ErrOtherPluginFuncNotFound]
+error = '''plugin function not found'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:other:ErrOtherSystemTime]
+error = '''system time error'''
+description = '''N/A'''
+workaround = '''N/A'''
+[error.PD:io:ErrIORead]
+error = '''io read error'''
+description = '''N/A'''
+workaround = '''N/A'''

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -16,19 +16,20 @@ package errors
 import "github.com/pingcap/errors"
 
 var (
-	reg = errors.NewRegistry("PD")
+	// Reg use to represent the registry of PD.
+	Reg = errors.NewRegistry("PD")
 	// ClassIO is IO error class
-	ClassIO = reg.RegisterErrorClass(1, "io")
+	ClassIO = Reg.RegisterErrorClass(1, "io")
 	// ClassNetwork is network error class
-	ClassNetwork = reg.RegisterErrorClass(2, "network")
+	ClassNetwork = Reg.RegisterErrorClass(2, "network")
 	// ClassStorage is storage error class
-	ClassStorage = reg.RegisterErrorClass(3, "storage")
+	ClassStorage = Reg.RegisterErrorClass(3, "storage")
 	// ClassInternal is internal error class
-	ClassInternal = reg.RegisterErrorClass(4, "internal")
+	ClassInternal = Reg.RegisterErrorClass(4, "internal")
 	// ClassFormat is format error class
-	ClassFormat = reg.RegisterErrorClass(5, "format")
+	ClassFormat = Reg.RegisterErrorClass(5, "format")
 	// ClassOther is other error class
-	ClassOther = reg.RegisterErrorClass(6, "other")
+	ClassOther = Reg.RegisterErrorClass(6, "other")
 )
 
 var (

--- a/tools/gen-error-meta/main.go
+++ b/tools/gen-error-meta/main.go
@@ -1,0 +1,32 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/pingcap/pd/v4/pkg/errors"
+)
+
+func main() {
+	f, err := os.Create("error.toml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = errors.Reg.ExportTo(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Closes #2661.

### What is changed and how it works?

This PR adds a makefile target to generate the metafile of errors. The output example can be found in `error.toml`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

- Manual test (add detailed scripts or steps below)

Run `make gen-error-meta` and check the `error.toml`.

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
