### PR TITLE
metrics: add metrics for auto scaling

### DIFF
--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -62,10 +62,12 @@ func getPlans(rc *cluster.RaftCluster, strategy *Strategy, component ComponentTy
 
 	// TODO: add metrics to show why it triggers scale in/out.
 	if usage > maxThreshold {
+		componentScaleEventGuage.WithLabelValues(component.String(), "scale-out").Set(usage)
 		scaleOutQuota := (totalCPUUseTime - totalCPUTime*maxThreshold) / MetricsTimeDuration.Seconds()
 		return calculateScaleOutPlan(rc, strategy, component, scaleOutQuota, currentQuota)
 	}
 	if usage < minThreshold {
+		componentScaleEventGuage.WithLabelValues(component.String(), "scale-in").Set(usage)
 		scaleInQuota := (totalCPUTime*minThreshold - totalCPUUseTime) / MetricsTimeDuration.Seconds()
 		return calculateScaleInPlan(rc, strategy, component, scaleInQuota), 0
 	}

--- a/pkg/autoscaling/metrics.go
+++ b/pkg/autoscaling/metrics.go
@@ -1,0 +1,30 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoscaling
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	componentScaleEventGuage = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "auto_scaling",
+			Name:      "component_scale_event",
+			Help:      "The scale event of the component",
+		}, []string{"component", "event"})
+)
+
+func init() {
+	prometheus.MustRegister(componentScaleEventGuage)
+}


### PR DESCRIPTION

### What problem does this PR solve?

Resolve #2746

### What is changed and how it works?

This PR is going to add metrics to indicate why the cluster scale in/out.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/pingcap/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
