### PR TITLE
placement: forbid mutiple leader replicas, and require at least one leader

### DIFF
--- a/server/schedule/placement/rule_list.go
+++ b/server/schedule/placement/rule_list.go
@@ -148,6 +148,8 @@ func buildRuleList(rules map[[2]string]*Rule) (ruleList, error) {
 					strings.ToUpper(hex.EncodeToString(endKey))))
 			}
 
+			rr = prepareRulesForApply(rr) // clone internally
+
 			err := checkApplyRules(rr)
 			if err != nil {
 				return ruleList{}, errs.ErrBuildRuleList.FastGenByArgs(fmt.Sprintf("%s for range {%s, %s}",
@@ -162,7 +164,7 @@ func buildRuleList(rules map[[2]string]*Rule) (ruleList, error) {
 			rl.ranges = append(rl.ranges, rangeRules{
 				startKey:   p.key,
 				rules:      rr,
-				applyRules: prepareRulesForApply(rr), // clone internally
+				applyRules: rr,
 			})
 		}
 	}

--- a/server/schedule/placement/rule_list.go
+++ b/server/schedule/placement/rule_list.go
@@ -140,11 +140,11 @@ func buildRuleList(rules map[[2]string]*Rule) (ruleList, error) {
 						strings.ToUpper(hex.EncodeToString(p.key)),
 						strings.ToUpper(hex.EncodeToString(endKey))))
 				}
-				if (leaderCount + voterCount) < 1 {
-					return ruleList{}, errs.ErrBuildRuleList.FastGenByArgs(fmt.Sprintf("needs at least one leader or voter for range {%s, %s}",
-						strings.ToUpper(hex.EncodeToString(p.key)),
-						strings.ToUpper(hex.EncodeToString(endKey))))
-				}
+			}
+			if (leaderCount + voterCount) < 1 {
+				return ruleList{}, errs.ErrBuildRuleList.FastGenByArgs(fmt.Sprintf("needs at least one leader or voter for range {%s, %s}",
+					strings.ToUpper(hex.EncodeToString(p.key)),
+					strings.ToUpper(hex.EncodeToString(endKey))))
 			}
 			if i != len(points)-1 {
 				rr = append(rr[:0:0], rr...) // clone

--- a/server/schedule/placement/rule_list.go
+++ b/server/schedule/placement/rule_list.go
@@ -148,9 +148,12 @@ func buildRuleList(rules map[[2]string]*Rule) (ruleList, error) {
 					strings.ToUpper(hex.EncodeToString(endKey))))
 			}
 
-			rr = prepareRulesForApply(rr) // clone internally
+			if i != len(points)-1 {
+				rr = append(rr[:0:0], rr...) // clone
+			}
 
-			err := checkApplyRules(rr)
+			arr := prepareRulesForApply(rr) // clone internally
+			err := checkApplyRules(arr)
 			if err != nil {
 				return ruleList{}, errs.ErrBuildRuleList.FastGenByArgs(fmt.Sprintf("%s for range {%s, %s}",
 					err,
@@ -158,13 +161,10 @@ func buildRuleList(rules map[[2]string]*Rule) (ruleList, error) {
 					strings.ToUpper(hex.EncodeToString(endKey))))
 			}
 
-			if i != len(points)-1 {
-				rr = append(rr[:0:0], rr...) // clone
-			}
 			rl.ranges = append(rl.ranges, rangeRules{
 				startKey:   p.key,
 				rules:      rr,
-				applyRules: rr,
+				applyRules: arr,
 			})
 		}
 	}

--- a/server/schedule/placement/rule_list.go
+++ b/server/schedule/placement/rule_list.go
@@ -128,12 +128,20 @@ func buildRuleList(rules map[[2]string]*Rule) (ruleList, error) {
 
 			// check multiple leaders
 			leaderCount := 0
+			voterCount := 0
 			for _, rule := range rr {
 				if rule.Role == Leader {
 					leaderCount += rule.Count
+				} else if rule.Role == Voter {
+					voterCount += rule.Count
 				}
 				if leaderCount > 1 {
 					return ruleList{}, errs.ErrBuildRuleList.FastGenByArgs(fmt.Sprintf("multiple leader replicas for range {%s, %s}",
+						strings.ToUpper(hex.EncodeToString(p.key)),
+						strings.ToUpper(hex.EncodeToString(endKey))))
+				}
+				if (leaderCount + voterCount) < 1 {
+					return ruleList{}, errs.ErrBuildRuleList.FastGenByArgs(fmt.Sprintf("needs at least one leader or voter for range {%s, %s}",
 						strings.ToUpper(hex.EncodeToString(p.key)),
 						strings.ToUpper(hex.EncodeToString(endKey))))
 				}

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -170,6 +170,9 @@ func (m *RuleManager) adjustRule(r *Rule) error {
 	if r.Count <= 0 {
 		return errs.ErrRuleContent.FastGenByArgs(fmt.Sprintf("invalid count %d", r.Count))
 	}
+	if r.Role == Leader && r.Count > 1 {
+		return errs.ErrRuleContent.FastGenByArgs(fmt.Sprintf("define multiple leaders by count %d", r.Count))
+	}
 	for _, c := range r.LabelConstraints {
 		if !validateOp(c.Op) {
 			return errs.ErrRuleContent.FastGenByArgs(fmt.Sprintf("invalid op %s", c.Op))

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -275,6 +275,68 @@ func (s *testManagerSuite) TestGroupConfig(c *C) {
 	c.Assert(s.manager.GetRuleGroups(), DeepEquals, []*RuleGroup{g2})
 }
 
+func (s *testManagerSuite) TestCheckRulesRaft(c *C) {
+	err := checkRulesRaft([]*Rule{
+		{
+			Role:  Leader,
+			Count: 1,
+		},
+	})
+	c.Assert(err, Equals, "")
+
+	err = checkRulesRaft([]*Rule{
+		{
+			Role:  Voter,
+			Count: 1,
+		},
+	})
+	c.Assert(err, Equals, "")
+
+	err = checkRulesRaft([]*Rule{
+		{
+			Role:  Leader,
+			Count: 1,
+		},
+		{
+			Role:  Voter,
+			Count: 1,
+		},
+	})
+	c.Assert(err, Equals, "")
+
+	err = checkRulesRaft([]*Rule{
+		{
+			Role:  Leader,
+			Count: 3,
+		},
+	})
+	c.Assert(err, Equals, "multiple leader replicas")
+
+	err = checkRulesRaft([]*Rule{
+		{
+			Role:  Leader,
+			Count: 1,
+		},
+		{
+			Role:  Leader,
+			Count: 1,
+		},
+	})
+	c.Assert(err, Equals, "multiple leader replicas")
+
+	err = checkRulesRaft([]*Rule{
+		{
+			Role:  Learner,
+			Count: 1,
+		},
+		{
+			Role:  Follower,
+			Count: 1,
+		},
+	})
+	c.Assert(err, Equals, "needs at least one leader or voter")
+}
+
 func (s *testManagerSuite) dhex(hk string) []byte {
 	k, err := hex.DecodeString(hk)
 	if err != nil {

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -79,6 +79,19 @@ func (s *testManagerSuite) TestSaveLoad(c *C) {
 	for _, r := range rules {
 		s.manager.SetRule(r)
 	}
+
+	c.Assert(s.manager.SetRule(&Rule{GroupID: "foo", ID: "baz", Role: "leader", Count: 2}), ErrorMatches, ".*define multiple leaders by count 2.*")
+	c.Assert(s.manager.Batch([]RuleOp{
+		{
+			Rule:   &Rule{GroupID: "g2", ID: "foo1", Role: "leader", Count: 1},
+			Action: RuleOpAdd,
+		},
+		{
+			Rule:   &Rule{GroupID: "g2", ID: "foo2", Role: "leader", Count: 1},
+			Action: RuleOpAdd,
+		},
+	}), ErrorMatches, ".*multiple leader replicas.*")
+
 	m2 := NewRuleManager(s.store)
 	err := m2.Initialize(3, []string{"no", "labels"})
 	c.Assert(err, IsNil)

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -83,17 +83,16 @@ func (s *testManagerSuite) TestLeaderCheck(c *C) {
 			Action: RuleOpAdd,
 		},
 	}), ErrorMatches, ".*multiple leader replicas.*")
-
 }
 
 func (s *testManagerSuite) TestSaveLoad(c *C) {
 	rules := []*Rule{
 		{GroupID: "pd", ID: "default", Role: "voter", Count: 5},
-		{GroupID: "foo", ID: "bar", StartKeyHex: "", EndKeyHex: "abcd", Role: "learner", Count: 1},
-		{GroupID: "foo", ID: "baz", Role: "voter", Count: 1},
+		{GroupID: "foo", ID: "baz", StartKeyHex: "", EndKeyHex: "abcd", Role: "voter", Count: 1},
+		{GroupID: "foo", ID: "bar", Role: "learner", Count: 1},
 	}
 	for _, r := range rules {
-		s.manager.SetRule(r)
+		c.Assert(s.manager.SetRule(r), IsNil)
 	}
 
 	m2 := NewRuleManager(s.store)
@@ -101,8 +100,8 @@ func (s *testManagerSuite) TestSaveLoad(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(m2.GetAllRules(), HasLen, 3)
 	c.Assert(m2.GetRule("pd", "default"), DeepEquals, rules[0])
-	c.Assert(m2.GetRule("foo", "bar"), DeepEquals, rules[1])
-	c.Assert(m2.GetRule("foo", "baz"), DeepEquals, rules[2])
+	c.Assert(m2.GetRule("foo", "baz"), DeepEquals, rules[1])
+	c.Assert(m2.GetRule("foo", "bar"), DeepEquals, rules[2])
 }
 
 func (s *testManagerSuite) checkRules(c *C, rules []*Rule, expect [][2]string) {

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -275,24 +275,24 @@ func (s *testManagerSuite) TestGroupConfig(c *C) {
 	c.Assert(s.manager.GetRuleGroups(), DeepEquals, []*RuleGroup{g2})
 }
 
-func (s *testManagerSuite) TestCheckRulesRaft(c *C) {
-	err := checkRulesRaft([]*Rule{
+func (s *testManagerSuite) TestCheckApplyRules(c *C) {
+	err := checkApplyRules([]*Rule{
 		{
 			Role:  Leader,
 			Count: 1,
 		},
 	})
-	c.Assert(err, Equals, "")
+	c.Assert(err, IsNil)
 
-	err = checkRulesRaft([]*Rule{
+	err = checkApplyRules([]*Rule{
 		{
 			Role:  Voter,
 			Count: 1,
 		},
 	})
-	c.Assert(err, Equals, "")
+	c.Assert(err, IsNil)
 
-	err = checkRulesRaft([]*Rule{
+	err = checkApplyRules([]*Rule{
 		{
 			Role:  Leader,
 			Count: 1,
@@ -302,17 +302,17 @@ func (s *testManagerSuite) TestCheckRulesRaft(c *C) {
 			Count: 1,
 		},
 	})
-	c.Assert(err, Equals, "")
+	c.Assert(err, IsNil)
 
-	err = checkRulesRaft([]*Rule{
+	err = checkApplyRules([]*Rule{
 		{
 			Role:  Leader,
 			Count: 3,
 		},
 	})
-	c.Assert(err, Equals, "multiple leader replicas")
+	c.Assert(err, ErrorMatches, "multiple leader replicas")
 
-	err = checkRulesRaft([]*Rule{
+	err = checkApplyRules([]*Rule{
 		{
 			Role:  Leader,
 			Count: 1,
@@ -322,9 +322,9 @@ func (s *testManagerSuite) TestCheckRulesRaft(c *C) {
 			Count: 1,
 		},
 	})
-	c.Assert(err, Equals, "multiple leader replicas")
+	c.Assert(err, ErrorMatches, "multiple leader replicas")
 
-	err = checkRulesRaft([]*Rule{
+	err = checkApplyRules([]*Rule{
 		{
 			Role:  Learner,
 			Count: 1,
@@ -334,7 +334,7 @@ func (s *testManagerSuite) TestCheckRulesRaft(c *C) {
 			Count: 1,
 		},
 	})
-	c.Assert(err, Equals, "needs at least one leader or voter")
+	c.Assert(err, ErrorMatches, "needs at least one leader or voter")
 }
 
 func (s *testManagerSuite) dhex(hk string) []byte {


### PR DESCRIPTION
### What problem does this PR solve?

This PR comes from the discussion between me and @djshow832. As the PD community pointed out that it is invalid to define multiple leaders over the same range. Now it is forbidden.

First, `adjustRule` will filter out rules like `{role=leader, count=3}`. Then, when building the rule list, a loop is used to avoid cases like two rules `{role=leader, count=1}, {role=leader, count=1}` over the same range.

**EDIT**: Suggested by @djshow832 , now it also checks if there is still one leader after add/del. In another word, it is only valid iff `(leader+voter) >= 1 && leader <= 1`.

### Check List

Tests

- Unit test
- Integration test

### Release note

- Forbid adding multiple leaders over the same range.
