### PR TITLE
Add a new "clean" command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,4 +218,6 @@ failpoint-disable:
 	# Restoring failpoints...
 	@$(FAILPOINT_DISABLE)
 
-.PHONY: all ci vendor clean-test tidy
+clean: clean-test failpoint-disable deadlock-disable
+
+.PHONY: all ci vendor clean-test tidy clean

--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,14 @@ stores-dump:
 	CGO_ENABLED=0 go build -o bin/stores-dump tools/stores-dump/main.go
 
 clean-test:
+	# Cleaning test tmp...
 	rm -rf /tmp/test_pd*
 	rm -rf /tmp/pd-tests*
 	rm -rf /tmp/test_etcd*
+
+clean-bin:
+	# Cleaning binary files...
+	rm -rf bin/
 
 deadlock-enable: install-go-tools
 	@$(DEADLOCK_ENABLE)
@@ -218,6 +223,6 @@ failpoint-disable:
 	# Restoring failpoints...
 	@$(FAILPOINT_DISABLE)
 
-clean: clean-test failpoint-disable deadlock-disable
+clean: clean-bin clean-test failpoint-disable deadlock-disable
 
-.PHONY: all ci vendor clean-test tidy clean
+.PHONY: all ci vendor tidy clean-test clean-bin clean


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Sometimes if you cancel `make test` during the process, you will find that your workspace being filled with `*.bak` and failpoint files. So I add a new `clean` command to help clean these test intermediate files.

### What is changed and how it works?

Add a new command to `Makefile`.

### Check List

Tests

- No code

Code changes

- Has `Makefile` change

### Release note

No release note.
