### PR TITLE
bug fix: when store limit mode auto, calculate rate is on minutes, no…

### DIFF
--- a/server/cluster/store_limiter.go
+++ b/server/cluster/store_limiter.go
@@ -88,13 +88,13 @@ func (s *StoreLimiter) calculateRate(limitType storelimit.Type, state LoadState)
 	rate := float64(0)
 	switch state {
 	case LoadStateIdle:
-		rate = float64(s.scene[limitType].Idle) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].Idle)
 	case LoadStateLow:
-		rate = float64(s.scene[limitType].Low) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].Low)
 	case LoadStateNormal:
-		rate = float64(s.scene[limitType].Normal) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].Normal)
 	case LoadStateHigh:
-		rate = float64(s.scene[limitType].High) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].High)
 	}
 	return rate
 }


### PR DESCRIPTION
…t seconds

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
when store limit mode is auto, tidb calculate limit rate on seconds and add it to schedule config mistakely.
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
