### PR TITLE
[DNM] tempurl: fix the problem that make tests fail due to a used port

### DIFF
--- a/pkg/tempurl/tempurl.go
+++ b/pkg/tempurl/tempurl.go
@@ -46,8 +46,7 @@ func tryAllocTestURL() string {
 		log.Fatal("listen failed", zap.Error(err))
 	}
 	addr := fmt.Sprintf("http://%s", l.Addr())
-	err = l.Close()
-	if err != nil {
+	if err = l.Close(); err != nil {
 		log.Fatal("close failed", zap.Error(err))
 	}
 


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Try to fix the problem that make the CI tests randomly fail due to port duplication.

```
listen tcp 127.0.0.1:12081: bind: address already in use ("listen tcp 127.0.0.1:12081: bind: address already in use")
```
 
### What is changed and how it works?

It seems that `127.0.0.1:0` does not generate port numbers completely unused. So I try to make some changes to see why.

### Check List

Tests

- Unit test

Code changes

- Has `tempurl` change.

### Release note

* Fix the problem that make the CI tests randomly fail due to port duplication.
