### PR TITLE
bug fix: calculate limit rate bases on minute when mode is auto

### DIFF
--- a/server/cluster/store_limiter.go
+++ b/server/cluster/store_limiter.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
-	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/storelimit"
 	"go.uber.org/zap"
@@ -88,13 +87,13 @@ func (s *StoreLimiter) calculateRate(limitType storelimit.Type, state LoadState)
 	rate := float64(0)
 	switch state {
 	case LoadStateIdle:
-		rate = float64(s.scene[limitType].Idle) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].Idle)
 	case LoadStateLow:
-		rate = float64(s.scene[limitType].Low) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].Low)
 	case LoadStateNormal:
-		rate = float64(s.scene[limitType].Normal) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].Normal)
 	case LoadStateHigh:
-		rate = float64(s.scene[limitType].High) / schedule.StoreBalanceBaseTime
+		rate = float64(s.scene[limitType].High)
 	}
 	return rate
 }


### PR DESCRIPTION
Signed-off-by: 1150310621 <2604947873@qq.com>

### What problem does this PR solve?
when store limit mode is auto, tidb calculate limit rate on seconds and add it to schedule config mistakely.

### What is changed and how it works?
return the calculated rate without divide by the store balance base time

### Release note

- Fix the unit of store limit rate when the mode is auto