### PR TITLE
test: check port whether be in used during Alloc

### DIFF
--- a/pkg/tempurl/tempurl.go
+++ b/pkg/tempurl/tempurl.go
@@ -50,8 +50,9 @@ func tryAllocTestURL() string {
 	if err != nil {
 		log.Fatal("close failed", zap.Error(err))
 	}
-	err = checkPortInUse(addr)
+	err = checkAddressInUse(addr[len("http://"):])
 	if err != nil {
+		log.Error("checkPortInUse", zap.Error(err))
 		return ""
 	}
 	testAddrMutex.Lock()
@@ -63,15 +64,10 @@ func tryAllocTestURL() string {
 	return addr
 }
 
-func checkPortInUse(address string) error {
-	// Since the host is always 127.0.0.1, 1 sec timeout is enough
-	timeout := time.Second
-	conn, err := net.DialTimeout("tcp", address, timeout)
+func checkAddressInUse(address string) error {
+	l, err := net.Listen("tcp", address)
 	if err != nil {
 		return err
 	}
-	if conn != nil {
-		defer conn.Close()
-	}
-	return nil
+	return l.Close()
 }

--- a/pkg/tempurl/tempurl.go
+++ b/pkg/tempurl/tempurl.go
@@ -50,7 +50,10 @@ func tryAllocTestURL() string {
 	if err != nil {
 		log.Fatal("close failed", zap.Error(err))
 	}
-
+	err = checkPortInUse(addr)
+	if err != nil {
+		return ""
+	}
 	testAddrMutex.Lock()
 	defer testAddrMutex.Unlock()
 	if _, ok := testAddrMap[addr]; ok {
@@ -58,4 +61,17 @@ func tryAllocTestURL() string {
 	}
 	testAddrMap[addr] = struct{}{}
 	return addr
+}
+
+func checkPortInUse(address string) error {
+	// Since the host is always 127.0.0.1, 1 sec timeout is enough
+	timeout := time.Second
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	if err != nil {
+		return err
+	}
+	if conn != nil {
+		defer conn.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
After adding "-p 1" in unit test, we still can meet the "address already in use" error. See detail [here](https://internal.pingcap.net/idc-jenkins/blue/rest/organizations/jenkins/pipelines/pd_test/runs/7221/nodes/38/steps/106/log/?start=0).


<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
Adding Dial method to check port whether have been in used during tempurl.Alloc. If the address have been used, discard the address and try next round.


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
