### PR TITLE
autoscaling: add some comments and fix duration expression conversion

### DIFF
--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -38,7 +38,9 @@ const (
 // TODO: adjust the value or make it configurable.
 var (
 	// MetricsTimeDuration is used to get the metrics of a certain time period.
-	MetricsTimeDuration = 5 * time.Second
+	// This must be long enough to cover at least 2 scrape intervals
+	// Or you will get nothing when querying CPU usage
+	MetricsTimeDuration = 60 * time.Second
 	// MaxScaleOutStep is used to indicate the maxium number of instance for scaling out operations at once.
 	MaxScaleOutStep uint64 = 1
 	// MaxScaleInStep is used to indicate the maxium number of instance for scaling in operations at once.

--- a/pkg/autoscaling/prometheus_test.go
+++ b/pkg/autoscaling/prometheus_test.go
@@ -324,3 +324,32 @@ func (s *testPrometheusQuerierSuite) TestGetInstanceNameFromAddress(c *C) {
 		}
 	}
 }
+
+func (s *testPrometheusQuerierSuite) TestGetDurationExpression(c *C) {
+	testcases := []struct {
+		duration           time.Duration
+		expectedExpression string
+	}{
+		{
+			duration:           30 * time.Second,
+			expectedExpression: "30s",
+		},
+		{
+			duration:           60 * time.Second,
+			expectedExpression: "60s",
+		},
+		{
+			duration:           2 * time.Minute,
+			expectedExpression: "120s",
+		},
+		{
+			duration:           90 * time.Second,
+			expectedExpression: "90s",
+		},
+	}
+
+	for _, testcase := range testcases {
+		expression := getDurationExpression(testcase.duration)
+		c.Assert(expression, Equals, testcase.expectedExpression)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

If the query metrics duration is longer than 1 minute, Prometheus cannot parse the duration expression generated by `time.Duration.String()` method. And if the duration is too short, nothing returns from Prometheus.

### What is changed and how it works?

Convert duration to string expression using our own method.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
