### PR TITLE
autoscaling: get resource type from instance label

### DIFF
--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -289,7 +289,6 @@ func getScaledGroupsByComponent(rc *cluster.RaftCluster, component ComponentType
 	}
 }
 
-// TODO: error handling while processing labels
 func getScaledTiKVGroups(informer core.StoreSetInformer, healthyInstances []instance) ([]*Plan, error) {
 	planMap := make(map[string]map[string]struct{}, len(healthyInstances))
 	resourceTypeMap := make(map[string]string)
@@ -320,7 +319,6 @@ func getScaledTiKVGroups(informer core.StoreSetInformer, healthyInstances []inst
 	return buildPlans(planMap, resourceTypeMap, TiKV), nil
 }
 
-// TODO: error handling while processing labels
 func getScaledTiDBGroups(etcdClient *clientv3.Client, healthyInstances []instance) ([]*Plan, error) {
 	planMap := make(map[string]map[string]struct{}, len(healthyInstances))
 	resourceTypeMap := make(map[string]string)

--- a/pkg/autoscaling/calculation_test.go
+++ b/pkg/autoscaling/calculation_test.go
@@ -49,10 +49,12 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 	case2 := mockcluster.NewCluster(mockoption.NewScheduleOptions())
 	case2.AddLabelsStore(1, 1, map[string]string{})
 	case2.AddLabelsStore(2, 1, map[string]string{
-		groupLabelKey: fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
+		groupLabelKey:        fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
+		resourceTypeLabelKey: "a",
 	})
 	case2.AddLabelsStore(3, 1, map[string]string{
-		groupLabelKey: fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
+		groupLabelKey:        fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
+		resourceTypeLabelKey: "a",
 	})
 
 	// case3 indicates the tikv cluster with other group existed
@@ -109,8 +111,9 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 			},
 			expectedPlan: []*Plan{
 				{
-					Component: TiKV.String(),
-					Count:     2,
+					Component:    TiKV.String(),
+					Count:        2,
+					ResourceType: "a",
 					Labels: []*metapb.StoreLabel{
 						{
 							Key:   groupLabelKey,
@@ -154,8 +157,9 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 			},
 			expectedPlan: []*Plan{
 				{
-					Component: TiKV.String(),
-					Count:     1,
+					Component:    TiKV.String(),
+					Count:        1,
+					ResourceType: "a",
 					Labels: []*metapb.StoreLabel{
 						{
 							Key:   groupLabelKey,

--- a/pkg/autoscaling/calculation_test.go
+++ b/pkg/autoscaling/calculation_test.go
@@ -72,6 +72,7 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 		informer         core.StoreSetInformer
 		healthyInstances []instance
 		expectedPlan     []*Plan
+		errChecker       Checker
 	}{
 		{
 			name:     "no scaled tikv group",
@@ -91,6 +92,7 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 				},
 			},
 			expectedPlan: nil,
+			errChecker:   IsNil,
 		},
 		{
 			name:     "exist 1 scaled tikv group",
@@ -126,6 +128,7 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 					},
 				},
 			},
+			errChecker: IsNil,
 		},
 		{
 			name:     "exist 1 tikv scaled group with inconsistency healthy instances",
@@ -145,6 +148,7 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 				},
 			},
 			expectedPlan: nil,
+			errChecker:   NotNil,
 		},
 		{
 			name:     "exist 1 tikv scaled group with less healthy instances",
@@ -176,6 +180,7 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 					},
 				},
 			},
+			errChecker: IsNil,
 		},
 		{
 			name:     "existed other tikv group",
@@ -195,14 +200,16 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 				},
 			},
 			expectedPlan: nil,
+			errChecker:   IsNil,
 		},
 	}
 
 	for _, testcase := range testcases {
 		c.Log(testcase.name)
-		plans := getScaledTiKVGroups(testcase.informer, testcase.healthyInstances)
+		plans, err := getScaledTiKVGroups(testcase.informer, testcase.healthyInstances)
 		if testcase.expectedPlan == nil {
 			c.Assert(plans, IsNil)
+			c.Assert(err, testcase.errChecker)
 		} else {
 			c.Assert(plans, DeepEquals, testcase.expectedPlan)
 		}

--- a/pkg/autoscaling/calculation_test.go
+++ b/pkg/autoscaling/calculation_test.go
@@ -119,6 +119,10 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 							Key:   groupLabelKey,
 							Value: fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
 						},
+						{
+							Key:   resourceTypeLabelKey,
+							Value: "a",
+						},
 					},
 				},
 			},
@@ -164,6 +168,10 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 						{
 							Key:   groupLabelKey,
 							Value: fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
+						},
+						{
+							Key:   resourceTypeLabelKey,
+							Value: "a",
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

PD does not have resource type information for each group when making auto-scaling decisions.

### What is changed and how it works?

We assume that every instance added by auto-scaling has a label `resource-type` and we associate the group name with `resource-type` to provide the missing information.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
