### PR TITLE
placement: add bundle APIs to allow updating group and rule configurations with a single request

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -105,6 +105,15 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	clusterRouter.HandleFunc("/config/rule_group/{id}", rulesHandler.DeleteGroupConfig).Methods("DELETE")
 	clusterRouter.HandleFunc("/config/rule_groups", rulesHandler.GetAllGroupConfigs).Methods("GET")
 
+	clusterRouter.HandleFunc("/config/placement-rule", rulesHandler.GetAllGroupBundles).Methods("GET")
+	clusterRouter.HandleFunc("/config/placement-rule", rulesHandler.SetAllGroupBundles).Methods("POST")
+	// {group} can be a regular expression, we should enable path encode to
+	// support special characters.
+	escapeRouter := clusterRouter.NewRoute().Subrouter().UseEncodedPath()
+	clusterRouter.HandleFunc("/config/placement-rule/{group}", rulesHandler.GetGroupBundle).Methods("GET")
+	clusterRouter.HandleFunc("/config/placement-rule/{group}", rulesHandler.SetGroupBundle).Methods("POST")
+	escapeRouter.HandleFunc("/config/placement-rule/{group}", rulesHandler.DeleteGroupBundle).Methods("DELETE")
+
 	storeHandler := newStoreHandler(handler, rd)
 	clusterRouter.HandleFunc("/store/{id}", storeHandler.Get).Methods("GET")
 	clusterRouter.HandleFunc("/store/{id}", storeHandler.Delete).Methods("DELETE")

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -615,3 +615,80 @@ func (s *testRuleSuite) TestBatch(c *C) {
 		}
 	}
 }
+
+func (s *testRuleSuite) TestBundle(c *C) {
+	// GetAll
+	b1 := placement.GroupBundle{
+		ID: "pd",
+		Rules: []*placement.Rule{
+			{GroupID: "pd", ID: "default", Role: "voter", Count: 3},
+		},
+	}
+	var bundles []placement.GroupBundle
+	err := readJSON(testDialClient, s.urlPrefix+"/placement-rule", &bundles)
+	c.Assert(err, IsNil)
+	c.Assert(bundles, HasLen, 1)
+	compareBundle(c, bundles[0], b1)
+
+	// Set
+	b2 := placement.GroupBundle{
+		ID:       "foo",
+		Index:    42,
+		Override: true,
+		Rules: []*placement.Rule{
+			{GroupID: "foo", ID: "bar", Index: 1, Override: true, Role: "voter", Count: 1},
+		},
+	}
+	data, err := json.Marshal(b2)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule/foo", data)
+	c.Assert(err, IsNil)
+
+	// Get
+	var bundle placement.GroupBundle
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/foo", &bundle)
+	c.Assert(err, IsNil)
+	compareBundle(c, bundle, b2)
+
+	// GetAll again
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule", &bundles)
+	c.Assert(err, IsNil)
+	c.Assert(bundles, HasLen, 2)
+	compareBundle(c, bundles[0], b1)
+	compareBundle(c, bundles[1], b2)
+
+	// Delete
+	_, err = doDelete(testDialClient, s.urlPrefix+"/placement-rule/pd")
+	c.Assert(err, IsNil)
+
+	// GetAll again
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule", &bundles)
+	c.Assert(err, IsNil)
+	c.Assert(bundles, HasLen, 1)
+	compareBundle(c, bundles[0], b2)
+
+	// SetAll
+	b2.Rules = append(b2.Rules, &placement.Rule{GroupID: "foo", ID: "baz", Index: 2, Role: "follower", Count: 1})
+	b2.Index, b2.Override = 0, false
+	data, err = json.Marshal([]placement.GroupBundle{b1, b2})
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule", data)
+	c.Assert(err, IsNil)
+
+	// GetAll again
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule", &bundles)
+	c.Assert(err, IsNil)
+	c.Assert(bundles, HasLen, 2)
+	compareBundle(c, bundles[0], b2)
+	compareBundle(c, bundles[1], b1)
+}
+
+func compareBundle(c *C, b1, b2 placement.GroupBundle) {
+	c.Assert(b1.ID, Equals, b2.ID)
+	c.Assert(b1.Index, Equals, b2.Index)
+	c.Assert(b1.Override, Equals, b2.Override)
+	c.Assert(len(b1.Rules), Equals, len(b2.Rules))
+	for i := range b1.Rules {
+		compareRule(c, b1.Rules[i], b2.Rules[i])
+	}
+}

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -53,6 +53,19 @@ func (s *testRuleSuite) TearDownSuite(c *C) {
 	s.cleanup()
 }
 
+func (s *testRuleSuite) TearDownTest(c *C) {
+	def := placement.GroupBundle{
+		ID: "pd",
+		Rules: []*placement.Rule{
+			{GroupID: "pd", ID: "default", Role: "voter", Count: 3},
+		},
+	}
+	data, err := json.Marshal([]placement.GroupBundle{def})
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule", data)
+	c.Assert(err, IsNil)
+}
+
 func (s *testRuleSuite) TestSet(c *C) {
 	rule := placement.Rule{GroupID: "a", ID: "10", StartKeyHex: "1111", EndKeyHex: "3333", Role: "voter", Count: 1}
 	successData, err := json.Marshal(rule)

--- a/server/schedule/placement/rule.go
+++ b/server/schedule/placement/rule.go
@@ -101,6 +101,11 @@ func (g *RuleGroup) isDefault() bool {
 	return g.Index == 0 && !g.Override
 }
 
+func (g *RuleGroup) String() string {
+	b, _ := json.Marshal(g)
+	return string(b)
+}
+
 // Rules are ordered by (GroupID, Index, ID).
 func compareRule(a, b *Rule) int {
 	switch {
@@ -158,4 +163,17 @@ func prepareRulesForApply(rules []*Rule) []*Rule {
 		}
 	}
 	return append(res, rules[j:]...)
+}
+
+// GroupBundle represents a rule group and all rules belong to the group.
+type GroupBundle struct {
+	ID       string  `json:"group_id"`
+	Index    int     `json:"group_index"`
+	Override bool    `json:"group_override"`
+	Rules    []*Rule `json:"rules"`
+}
+
+func (g GroupBundle) String() string {
+	b, _ := json.Marshal(g)
+	return string(b)
 }

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -428,7 +429,11 @@ func (m *RuleManager) SetRuleGroup(group *RuleGroup) error {
 	defer m.Unlock()
 	p := m.ruleConfig.beginPatch()
 	p.setGroup(group)
-	return m.tryCommitPatch(p)
+	if err := m.tryCommitPatch(p); err != nil {
+		return err
+	}
+	log.Info("group config updated", zap.String("group", fmt.Sprint(group)))
+	return nil
 }
 
 // DeleteRuleGroup removes a RuleGroup.
@@ -437,5 +442,148 @@ func (m *RuleManager) DeleteRuleGroup(id string) error {
 	defer m.Unlock()
 	p := m.ruleConfig.beginPatch()
 	p.deleteGroup(id)
-	return m.tryCommitPatch(p)
+	if err := m.tryCommitPatch(p); err != nil {
+		return err
+	}
+	log.Info("group config reset", zap.String("group", id))
+	return nil
+}
+
+// GetAllGroupBundles returns all rules and groups configuration. Rules are
+// grouped by groups.
+func (m *RuleManager) GetAllGroupBundles() []GroupBundle {
+	m.RLock()
+	defer m.RUnlock()
+	var bundles []GroupBundle
+	for _, g := range m.ruleConfig.groups {
+		bundles = append(bundles, GroupBundle{
+			ID:       g.ID,
+			Index:    g.Index,
+			Override: g.Override,
+		})
+	}
+	for _, r := range m.ruleConfig.rules {
+		for i := range bundles {
+			if bundles[i].ID == r.GroupID {
+				bundles[i].Rules = append(bundles[i].Rules, r)
+			}
+		}
+	}
+	sort.Slice(bundles, func(i, j int) bool {
+		return bundles[i].Index < bundles[j].Index ||
+			(bundles[i].Index == bundles[j].Index && bundles[i].ID < bundles[j].ID)
+	})
+	for _, b := range bundles {
+		sortRules(b.Rules)
+	}
+	return bundles
+}
+
+// GetGroupBundle returns a group and all rules belong to it.
+func (m *RuleManager) GetGroupBundle(id string) (b GroupBundle) {
+	m.RLock()
+	defer m.RUnlock()
+	b.ID = id
+	if g := m.ruleConfig.groups[id]; g != nil {
+		b.Index, b.Override = g.Index, g.Override
+	}
+	for _, r := range m.ruleConfig.rules {
+		if r.GroupID == id {
+			b.Rules = append(b.Rules, r)
+		}
+	}
+	sortRules(b.Rules)
+	return
+}
+
+// SetAllGroupBundles resets full configuration. All old configurations are dropped.
+func (m *RuleManager) SetAllGroupBundles(groups []GroupBundle) error {
+	m.Lock()
+	defer m.Unlock()
+	p := m.ruleConfig.beginPatch()
+	for k := range m.ruleConfig.rules {
+		p.deleteRule(k[0], k[1])
+	}
+	for id := range m.ruleConfig.groups {
+		p.deleteGroup(id)
+	}
+	for _, g := range groups {
+		p.setGroup(&RuleGroup{
+			ID:       g.ID,
+			Index:    g.Index,
+			Override: g.Override,
+		})
+		for _, r := range g.Rules {
+			if err := m.adjustRule(r); err != nil {
+				return err
+			}
+			p.setRule(r)
+		}
+	}
+	if err := m.tryCommitPatch(p); err != nil {
+		return err
+	}
+	log.Info("full config reset", zap.String("config", fmt.Sprint(groups)))
+	return nil
+}
+
+// SetGroupBundle resets a Group and all rules belong to it. All old rules
+// belong to the Group are dropped.
+func (m *RuleManager) SetGroupBundle(group GroupBundle) error {
+	m.Lock()
+	defer m.Unlock()
+	p := m.ruleConfig.beginPatch()
+	for k := range m.ruleConfig.rules {
+		if k[0] == group.ID {
+			p.deleteRule(k[0], k[1])
+		}
+	}
+	p.setGroup(&RuleGroup{
+		ID:       group.ID,
+		Index:    group.Index,
+		Override: group.Override,
+	})
+	for _, r := range group.Rules {
+		if err := m.adjustRule(r); err != nil {
+			return err
+		}
+		p.setRule(r)
+	}
+	if err := m.tryCommitPatch(p); err != nil {
+		return err
+	}
+	log.Info("group is reset", zap.String("group", fmt.Sprint(group)))
+	return nil
+}
+
+// DeleteGroupBundle removes a Group and all rules belong to it. If `regex` is
+// true, `id` is a regexp expression.
+func (m *RuleManager) DeleteGroupBundle(id string, regex bool) error {
+	m.Lock()
+	defer m.Unlock()
+	matchID := func(a string) bool { return a == id }
+	if regex {
+		r, err := regexp.Compile(id)
+		if err != nil {
+			return err
+		}
+		matchID = func(a string) bool { return r.MatchString(a) }
+	}
+
+	p := m.ruleConfig.beginPatch()
+	for k := range m.ruleConfig.rules {
+		if matchID(k[0]) {
+			p.deleteRule(k[0], k[1])
+		}
+	}
+	for _, g := range m.ruleConfig.groups {
+		if matchID(g.ID) {
+			p.deleteGroup(g.ID)
+		}
+	}
+	if err := m.tryCommitPatch(p); err != nil {
+		return err
+	}
+	log.Info("groups are removed", zap.String("id", id), zap.Bool("regexp", regex))
+	return nil
 }

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -486,13 +486,13 @@ func (m *RuleManager) GetGroupBundle(id string) (b GroupBundle) {
 	b.ID = id
 	if g := m.ruleConfig.groups[id]; g != nil {
 		b.Index, b.Override = g.Index, g.Override
-	}
-	for _, r := range m.ruleConfig.rules {
-		if r.GroupID == id {
-			b.Rules = append(b.Rules, r)
+		for _, r := range m.ruleConfig.rules {
+			if r.GroupID == id {
+				b.Rules = append(b.Rules, r)
+			}
 		}
+		sortRules(b.Rules)
 	}
-	sortRules(b.Rules)
 	return
 }
 
@@ -533,9 +533,11 @@ func (m *RuleManager) SetGroupBundle(group GroupBundle) error {
 	m.Lock()
 	defer m.Unlock()
 	p := m.ruleConfig.beginPatch()
-	for k := range m.ruleConfig.rules {
-		if k[0] == group.ID {
-			p.deleteRule(k[0], k[1])
+	if _, ok := m.ruleConfig.groups[group.ID]; ok {
+		for k := range m.ruleConfig.rules {
+			if k[0] == group.ID {
+				p.deleteRule(k[0], k[1])
+			}
 		}
 	}
 	p.setGroup(&RuleGroup{


### PR DESCRIPTION
### What problem does this PR solve?

With placement rule API, we can update Rule config and RuleGroup config separately. But a common requirement is to update the Group configuration and the configuration of all Rules in the Group at the same time.

Some previous discussion can be found in https://github.com/tikv/pd/issues/2680

### What is changed and how it works?

Introduce a new series of APIs:

- `GET /config/placement-rule` read all rules by groups

return:
```
[
  {
    "group_id": "foo",
    "index": 0,
    "override": false,
    "rules":  [ /* rules in group foo */ ]
  },
  {
    "group_id": "bar",
    "index": 1,
    "override": true,
    "rules":  [ /* rules in group bar */ ]
  },
  ... other groups
]
```

- `GET /config/placement-rule/{group}` read rules from a group

returns

```
{
  "group_id": "foo",
  "index": 0,
  "override": false,
  "rules":  [ /* rules in group foo */ ]
},
```

- `POST /config/placement-rule/{group}` update a group

sends

```
{
  "group_id": "foo",
  "index": 1,
  "override": true,
  "rules":  [ /* rules  */ ]
},
```
It performs in a `replace` semantic which means it works just like first remove all old rules then set the received rules and finally the rules in the group will be the same as received config.

- `POST /config/placement-rule` update full configuration

sends

```
[
  {
    "group_id": "foo",
    "index": 0,
    "override": false,
    "rules":  [ /* rules in group foo */ ]
  },
  {
    "group_id": "bar",
    "index": 1,
    "override": true,
    "rules":  [ /* rules in group bar */ ]
  },
  ... other groups
]
```

It also performs in `replace` semantic too, which means all existing configurations will be dropped and replaced by received configurations.

- `DELETE /config/placement-rules/{group}` remove a group

It removes both configuration of the group and also all rules belong to the group. 

- `DELETE /config/placement-rules/{pattern}?regexp` remove groups by parttern

It removes groups that have ID match the pattern.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test

Code changes
- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note
- Add placement APIs to allow updating group and rule configurations with a single request
