### PR TITLE
config: fix the bool field about `trace-region-flow`

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1031,7 +1031,7 @@ type PDServerConfig struct {
 	// There are some values supported: "auto", "none", or a specific address, default: "auto"
 	DashboardAddress string `toml:"dashboard-address" json:"dashboard-address"`
 	// TraceRegionFlow the option to update flow information of regions
-	TraceRegionFlow bool `toml:"trace-region-flow" json:"trace-region-flow"`
+	TraceRegionFlow bool `toml:"trace-region-flow" json:"trace-region-flow,string"`
 }
 
 func (c *PDServerConfig) adjust(meta *configMetaData) error {

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -93,6 +93,12 @@ func (s *configTestSuite) TestConfig(c *C) {
 	c.Assert(&cfg.Schedule, DeepEquals, scheduleConfig)
 	c.Assert(&cfg.Replication, DeepEquals, svr.GetReplicationConfig())
 
+	// config set trace-region-flow <value>
+	args = []string{"-u", pdAddr, "config", "set", "trace-region-flow", "false"}
+	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(svr.GetPDServerConfig().TraceRegionFlow, Equals, false)
+
 	// config show schedule
 	args = []string{"-u", pdAddr, "config", "show", "schedule"}
 	_, output, err = pdctl.ExecuteCommandC(cmd, args...)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

cannot set the filed with `pd-ctl`

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
