### PR TITLE
scheduler: revert low space threshold hard limit

### DIFF
--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -14,7 +14,6 @@
 package core
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -99,31 +98,6 @@ func (s *testConcurrencySuite) TestCloneStore(c *C) {
 var _ = Suite(&testStoreSuite{})
 
 type testStoreSuite struct{}
-
-func (s *testStoreSuite) TestLowSpaceThreshold(c *C) {
-	stats := &pdpb.StoreStats{}
-	stats.Capacity = 10 * (1 << 40) // 10 TB
-	stats.Available = 1 * (1 << 40) // 1 TB
-
-	store := NewStoreInfo(
-		&metapb.Store{Id: 1},
-		SetStoreStats(stats),
-	)
-	threshold := store.GetSpaceThreshold(0.8, lowSpaceThreshold)
-	c.Assert(threshold, Equals, float64(lowSpaceThreshold))
-	c.Assert(store.IsLowSpace(0.8), Equals, false)
-	stats = &pdpb.StoreStats{}
-	stats.Capacity = 100 * (1 << 20) // 100 MB
-	stats.Available = 10 * (1 << 20) // 10 MB
-
-	store = NewStoreInfo(
-		&metapb.Store{Id: 1},
-		SetStoreStats(stats),
-	)
-	threshold = store.GetSpaceThreshold(0.8, lowSpaceThreshold)
-	c.Assert(fmt.Sprintf("%.2f", threshold), Equals, fmt.Sprintf("%.2f", 100*0.2))
-	c.Assert(store.IsLowSpace(0.8), Equals, true)
-}
 
 func (s *testStoreSuite) TestRegionScore(c *C) {
 	stats := &pdpb.StoreStats{}


### PR DESCRIPTION
### What problem does this PR solve?

The previous PR uses a hard limit for low space. If the capacity beyond 500G, it will use 100G as its low space threshold. It doesn't seem reasonable.

### What is changed and how it works?

This PR changes back to the original way to control low space.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- Change back to the original way to control the low space threshold
