### PR TITLE
simulator/cases: import-data only count the newly regions of the table

### DIFF
--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -23,7 +23,7 @@ import (
 var (
 	tablePrefix  = []byte{'t'}
 	metaPrefix   = []byte{'m'}
-	recordPrefix = []byte{'r'}
+	recordPrefix = []byte("_r")
 )
 
 const (

--- a/tools/pd-simulator/simulator/cases/import_data.go
+++ b/tools/pd-simulator/simulator/cases/import_data.go
@@ -61,14 +61,14 @@ func newImportData() *Case {
 	simCase.TableNumber = 10
 	// Events description
 	e := &WriteFlowOnSpotDescriptor{}
-	table2 := string(codec.EncodeBytes(codec.GenerateTableKey(2)))
-	table3 := string(codec.EncodeBytes(codec.GenerateTableKey(3)))
+	table12 := string(codec.EncodeBytes(codec.GenerateTableKey(12)))
+	table13 := string(codec.EncodeBytes(codec.GenerateTableKey(13)))
 	e.Step = func(tick int64) map[string]int64 {
 		if tick > int64(getRegionNum())/10 {
 			return nil
 		}
 		return map[string]int64{
-			table2: 32 * MB,
+			table12: 32 * MB,
 		}
 	}
 	simCase.Events = []EventDescriptor{e}
@@ -81,8 +81,8 @@ func newImportData() *Case {
 		leaderTotal := 0
 		peerTotal := 0
 		res := make([]*core.RegionInfo, 0, 100)
-		regions.ScanRangeWithIterator([]byte(table2), func(region *core.RegionInfo) bool {
-			if bytes.Compare(region.GetEndKey(), []byte(table3)) < 0 {
+		regions.ScanRangeWithIterator([]byte(table12), func(region *core.RegionInfo) bool {
+			if bytes.Compare(region.GetEndKey(), []byte(table13)) < 0 {
 				res = append(res, regions.GetRegion(region.GetID()))
 				return true
 			}

--- a/tools/pd-simulator/simulator/config.go
+++ b/tools/pd-simulator/simulator/config.go
@@ -41,6 +41,7 @@ type SimConfig struct {
 
 // NewSimConfig create a new configuration of the simulator.
 func NewSimConfig(serverLogLevel string) *SimConfig {
+	config.DefaultStoreLimit = config.StoreLimit{AddPeer: 2000, RemovePeer: 2000}
 	cfg := &config.Config{
 		Name:       "pd",
 		ClientUrls: tempurl.Alloc(),

--- a/tools/pd-simulator/simulator/simutil/key.go
+++ b/tools/pd-simulator/simulator/simutil/key.go
@@ -122,7 +122,6 @@ func GenerateTiDBEncodedSplitKey(start, end []byte) ([]byte, error) {
 	}
 
 	var err error
-
 	start, err = mustDecodeMvccKey(start)
 	if err != nil {
 		return nil, err

--- a/tools/pd-simulator/simulator/simutil/key.go
+++ b/tools/pd-simulator/simulator/simutil/key.go
@@ -122,6 +122,7 @@ func GenerateTiDBEncodedSplitKey(start, end []byte) ([]byte, error) {
 	}
 
 	var err error
+
 	start, err = mustDecodeMvccKey(start)
 	if err != nil {
 		return nil, err
@@ -134,10 +135,11 @@ func GenerateTiDBEncodedSplitKey(start, end []byte) ([]byte, error) {
 
 	// make the start key and end key in same length.
 	if len(end) == 0 {
-		end = make([]byte, 0, len(start))
-		for i := range end {
-			end[i] = 0xFF
+		_, tableID, err := codec.DecodeInt(start[1:])
+		if err != nil {
+			return nil, err
 		}
+		return GenerateTableKey(tableID+1, 0), nil
 	} else if len(start) < len(end) {
 		pad := make([]byte, len(end)-len(start))
 		start = append(start, pad...)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
we count the old regions in the statistics for the table, This is not the result I want.
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```
❯ ./bin/pd-simulator -regionNum=10000 -case="import-data" -simLog=info
["import data information"]:
[table-leader="1001 leader: [store 1]:97.60% [store 4]:2.40%"] 
[table-peer="3003 peer:  [store 1]:32.53% [store 2]:0.60% [store 3]:0.50% [store 4]:32.43% [store 5]:0.20% [store 6]:0.23% [store 7]:0.30% [store 8]:0.43% [store 9]:32.43% [store 10]:0.33%"]
[total-leader="11000 leader: [store 1]:9.13% [store 2]:9.13% [store 3]:9.06% [store 4]:9.15% [store 5]:9.14% [store 6]:9.11% [store 7]:9.05% [store 8]:9.12% [store 9]:9.14% [store 10]:9.11%"]
[total-peer="33000 peer: [store 1]:10.08% [store 2]:9.97% [store 3]:9.97% [store 4]:10.08% [store 5]:9.97% [store 6]:9.97% [store 7]:9.97% [store 8]:9.97% [store 9]:10.08% [store 10]:9.97%"]

OK [import-data] total iteration: 1001, time cost: 1m46.775680649s
Add Peer (task) 0
Remove Peer (task) 2202
Add Learner (task) 2212
Promote Learner (task) 2207
Transfer Leader (task) 73
Merge Region (task) 0
Send Maximum (snapshot) 257
Receive Maximum (snapshot) 412
Send Minimum (snapshot) 156
Receive Minimum (snapshot) 261
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
