### PR TITLE
*: fix missing calls to .Error()

### DIFF
--- a/server/api/label.go
+++ b/server/api/label.go
@@ -86,7 +86,7 @@ func (h *labelsHandler) GetStores(w http.ResponseWriter, r *http.Request) {
 		storeID := s.GetId()
 		store := rc.GetStore(storeID)
 		if store == nil {
-			h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID))
+			h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID).Error())
 			return
 		}
 

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -322,5 +322,5 @@ func (h *schedulerConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		sh.ServeHTTP(w, r)
 		return
 	}
-	h.rd.JSON(w, http.StatusNotAcceptable, errNoImplement)
+	h.rd.JSON(w, http.StatusNotAcceptable, errNoImplement.Error())
 }

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -155,7 +155,7 @@ func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	store := rc.GetStore(storeID)
 	if store == nil {
-		h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID))
+		h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID).Error())
 		return
 	}
 
@@ -353,7 +353,7 @@ func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
 
 	store := rc.GetStore(storeID)
 	if store == nil {
-		h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID))
+		h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID).Error())
 		return
 	}
 
@@ -561,7 +561,7 @@ func (h *storesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		storeID := s.GetId()
 		store := rc.GetStore(storeID)
 		if store == nil {
-			h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID))
+			h.rd.JSON(w, http.StatusInternalServerError, server.ErrStoreNotFound(storeID).Error())
 			return
 		}
 


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>


### What problem does this PR solve?

We should call `.Error` to convert `error` to `string`, otherwise we will get an empty result.

### What is changed and how it works?

Add missing `.Error()` call for API error responses.

### Check List

Tests

<!-- At least one of them must be included. -->

- No test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
