### PR TITLE
placement: unify the code style in RuleManager

### DIFF
--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -267,7 +267,7 @@ func (m *RuleManager) FitRegion(stores StoreSet, region *core.RegionInfo) *Regio
 }
 
 func (m *RuleManager) beginPatch() *ruleConfigPatch {
-	return m.beginPatch()
+	return m.ruleConfig.beginPatch()
 }
 
 func (m *RuleManager) tryCommitPatch(patch *ruleConfigPatch) error {

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -191,7 +191,7 @@ func (m *RuleManager) SetRule(rule *Rule) error {
 	}
 	m.Lock()
 	defer m.Unlock()
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	p.setRule(rule)
 	if err := m.tryCommitPatch(p); err != nil {
 		return err
@@ -204,7 +204,7 @@ func (m *RuleManager) SetRule(rule *Rule) error {
 func (m *RuleManager) DeleteRule(group, id string) error {
 	m.Lock()
 	defer m.Unlock()
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	p.deleteRule(group, id)
 	if err := m.tryCommitPatch(p); err != nil {
 		return err
@@ -266,6 +266,10 @@ func (m *RuleManager) FitRegion(stores StoreSet, region *core.RegionInfo) *Regio
 	return FitRegion(stores, region, rules)
 }
 
+func (m *RuleManager) beginPatch() *ruleConfigPatch {
+	return m.beginPatch()
+}
+
 func (m *RuleManager) tryCommitPatch(patch *ruleConfigPatch) error {
 	patch.adjust()
 
@@ -324,7 +328,7 @@ func (m *RuleManager) savePatch(p *ruleConfig) error {
 func (m *RuleManager) SetRules(rules []*Rule) error {
 	m.Lock()
 	defer m.Unlock()
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	for _, r := range rules {
 		if err := m.adjustRule(r); err != nil {
 			return err
@@ -353,7 +357,7 @@ const (
 // distinguished by the field `Action`.
 type RuleOp struct {
 	*Rule                       // information of the placement rule to add/delete
-	Action           RuleOpType `json:"action"`              // the operation type
+	Action           RuleOpType `json:"action"` // the operation type
 	DeleteByIDPrefix bool       `json:"delete_by_id_prefix"` // if action == delete, delete by the prefix of id
 }
 
@@ -377,7 +381,7 @@ func (m *RuleManager) Batch(todo []RuleOp) error {
 	m.Lock()
 	defer m.Unlock()
 
-	patch := m.ruleConfig.beginPatch()
+	patch := m.beginPatch()
 	for _, t := range todo {
 		switch t.Action {
 		case RuleOpAdd:
@@ -429,7 +433,7 @@ func (m *RuleManager) GetRuleGroups() []*RuleGroup {
 func (m *RuleManager) SetRuleGroup(group *RuleGroup) error {
 	m.Lock()
 	defer m.Unlock()
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	p.setGroup(group)
 	if err := m.tryCommitPatch(p); err != nil {
 		return err
@@ -442,7 +446,7 @@ func (m *RuleManager) SetRuleGroup(group *RuleGroup) error {
 func (m *RuleManager) DeleteRuleGroup(id string) error {
 	m.Lock()
 	defer m.Unlock()
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	p.deleteGroup(id)
 	if err := m.tryCommitPatch(p); err != nil {
 		return err
@@ -502,7 +506,7 @@ func (m *RuleManager) GetGroupBundle(id string) (b GroupBundle) {
 func (m *RuleManager) SetAllGroupBundles(groups []GroupBundle) error {
 	m.Lock()
 	defer m.Unlock()
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	for k := range m.ruleConfig.rules {
 		p.deleteRule(k[0], k[1])
 	}
@@ -534,7 +538,7 @@ func (m *RuleManager) SetAllGroupBundles(groups []GroupBundle) error {
 func (m *RuleManager) SetGroupBundle(group GroupBundle) error {
 	m.Lock()
 	defer m.Unlock()
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	if _, ok := m.ruleConfig.groups[group.ID]; ok {
 		for k := range m.ruleConfig.rules {
 			if k[0] == group.ID {
@@ -574,7 +578,7 @@ func (m *RuleManager) DeleteGroupBundle(id string, regex bool) error {
 		matchID = func(a string) bool { return r.MatchString(a) }
 	}
 
-	p := m.ruleConfig.beginPatch()
+	p := m.beginPatch()
 	for k := range m.ruleConfig.rules {
 		if matchID(k[0]) {
 			p.deleteRule(k[0], k[1])

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -357,7 +357,7 @@ const (
 // distinguished by the field `Action`.
 type RuleOp struct {
 	*Rule                       // information of the placement rule to add/delete
-	Action           RuleOpType `json:"action"` // the operation type
+	Action           RuleOpType `json:"action"`              // the operation type
 	DeleteByIDPrefix bool       `json:"delete_by_id_prefix"` // if action == delete, delete by the prefix of id
 }
 


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Unify the code style for RuleManager during matian ruleConfig. Now a standard rule operation pattern would be like:

```golang
patch := ruleManager.beginPatch()
patch.setRule() / patch.DeleteRule()
ruleManager.tryCommitPatch(patch)
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
