### PR TITLE
api: fix wrong follower handle header

### DIFF
--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -31,7 +31,7 @@ import (
 const (
 	RedirectorHeader    = "PD-Redirector"
 	AllowFollowerHandle = "PD-Allow-follower-handle"
-	FollowerHandle      = "PD-Follwer-handle"
+	FollowerHandle      = "PD-Follower-handle"
 )
 
 const (
@@ -90,8 +90,9 @@ func NewRedirector(s *server.Server) negroni.Handler {
 
 func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	allowFollowerHandle := len(r.Header.Get(AllowFollowerHandle)) > 0
-	if !h.s.IsClosed() && (allowFollowerHandle || h.s.GetMember().IsLeader()) {
-		if allowFollowerHandle {
+	isLeader := h.s.GetMember().IsLeader()
+	if !h.s.IsClosed() && (allowFollowerHandle || isLeader) {
+		if !isLeader {
 			w.Header().Add(FollowerHandle, "true")
 		}
 		next(w, r)


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

* When the request contains the header `PD-Allow-follower-handle`, even if the leader responds to the request, it also contains the header `PD-Follwer-handle`.

### What is changed and how it works?

* Fix typo
* The `PD-Follower-handle` header is set only when the follower responds to the api.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

* api: fix wrong follower handle header
