### PR TITLE
tso, config, test: persist dc-location config in the cluster

### DIFF
--- a/server/member/member.go
+++ b/server/member/member.go
@@ -88,6 +88,11 @@ func (m *Member) Etcd() *embed.Etcd {
 	return m.etcd
 }
 
+// Client returns the etcd client.
+func (m *Member) Client() *clientv3.Client {
+	return m.client
+}
+
 // IsLeader returns whether the server is PD leader or not.
 func (m *Member) IsLeader() bool {
 	// If server is not started. Both leaderID and ID could be 0.

--- a/server/server.go
+++ b/server/server.go
@@ -353,6 +353,9 @@ func (s *Server) startServer(ctx context.Context) error {
 		s.member, s.rootPath, s.cfg.TSOSaveInterval.Duration,
 		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() },
 	)
+	if err = s.tsoAllocatorManager.SetLocalTSOConfig(s.cfg.LocalTSO); err != nil {
+		return err
+	}
 	kvBase := kv.NewEtcdKVBase(s.client, s.rootPath)
 	path := filepath.Join(s.cfg.DataDir, "region-meta")
 	regionStorage, err := core.NewRegionStorage(ctx, path)

--- a/tests/server/tso/manager_test.go
+++ b/tests/server/tso/manager_test.go
@@ -67,15 +67,20 @@ func (s *testManagerSuite) TestClusterDCLocations(c *C) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 
+	serverNameMap := make(map[uint64]string)
+	for _, server := range cluster.GetServers() {
+		serverNameMap[server.GetServerID()] = server.GetServer().Name()
+	}
+	// Start to check every server's GetClusterDCLocations() result
 	for _, server := range cluster.GetServers() {
 		obtainedServerNumber := 0
 		dcLocationMap, err := server.GetTSOAllocatorManager().GetClusterDCLocations()
 		c.Assert(err, IsNil)
 		c.Assert(len(dcLocationMap), Equals, testCase.dcLocationNumber)
-		for obtainedDCLocation, serverNames := range dcLocationMap {
-			obtainedServerNumber += len(serverNames)
-			for _, serverName := range serverNames {
-				expectedDCLocation, exist := testCase.dcLocationConfig[serverName]
+		for obtainedDCLocation, serverIDs := range dcLocationMap {
+			obtainedServerNumber += len(serverIDs)
+			for _, serverID := range serverIDs {
+				expectedDCLocation, exist := testCase.dcLocationConfig[serverNameMap[serverID]]
 				c.Assert(exist, IsTrue)
 				c.Assert(obtainedDCLocation, Equals, expectedDCLocation)
 			}

--- a/tests/server/tso/manager_test.go
+++ b/tests/server/tso/manager_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tso_test
+
+import (
+	"context"
+
+	. "github.com/pingcap/check"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/tests"
+)
+
+var _ = Suite(&testManagerSuite{})
+
+type testManagerSuite struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (s *testManagerSuite) SetUpSuite(c *C) {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	server.EnableZap = true
+}
+
+func (s *testManagerSuite) TearDownSuite(c *C) {
+	s.cancel()
+}
+
+// TestClusterDCLocations will write different dc-locations to each server
+// and test whether we can get the whole dc-location config from each server.
+func (s *testManagerSuite) TestClusterDCLocations(c *C) {
+	testCase := struct {
+		serverNumber     int
+		dcLocationNumber int
+		dcLocationConfig map[string]string
+	}{
+		serverNumber:     6,
+		dcLocationNumber: 3,
+		dcLocationConfig: map[string]string{
+			"pd1": "dc-1",
+			"pd2": "dc-1",
+			"pd3": "dc-2",
+			"pd4": "dc-2",
+			"pd5": "dc-3",
+			"pd6": "dc-3",
+		},
+	}
+	cluster, err := tests.NewTestCluster(s.ctx, testCase.serverNumber, func(conf *config.Config, serverName string) {
+		conf.LocalTSO.EnableLocalTSO = true
+		conf.LocalTSO.DCLocation = testCase.dcLocationConfig[serverName]
+	})
+	defer cluster.Destroy()
+	c.Assert(err, IsNil)
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+
+	for _, server := range cluster.GetServers() {
+		obtainedServerNumber := 0
+		dcLocationMap, err := server.GetTSOAllocatorManager().GetClusterDCLocations()
+		c.Assert(err, IsNil)
+		c.Assert(len(dcLocationMap), Equals, testCase.dcLocationNumber)
+		for obtainedDCLocation, serverNames := range dcLocationMap {
+			obtainedServerNumber += len(serverNames)
+			for _, serverName := range serverNames {
+				expectedDCLocation, exist := testCase.dcLocationConfig[serverName]
+				c.Assert(exist, IsTrue)
+				c.Assert(obtainedDCLocation, Equals, expectedDCLocation)
+			}
+		}
+		c.Assert(obtainedServerNumber, Equals, testCase.serverNumber)
+	}
+}


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Part of #2759. Each PD server of a cluster needs to know the topology of DC in order to elect the corresponding Local TSO Allocator. We need to write the dc-location config into etcd to persist it in the cluster.

### What is changed and how it works?

Write the dc-location config into etcd during the server initialization.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
