### PR TITLE
autoscaling: use map for labels in autoscaling response

### DIFF
--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -373,15 +373,9 @@ func buildPlans(planMap map[string]map[string]struct{}, resourceTypeMap map[stri
 			Component:    componentType.String(),
 			Count:        uint64(len(groupInstances)),
 			ResourceType: resourceType,
-			Labels: []*metapb.StoreLabel{
-				{
-					Key:   groupLabelKey,
-					Value: groupName,
-				},
-				{
-					Key:   resourceTypeLabelKey,
-					Value: resourceType,
-				},
+			Labels: map[string]string{
+				groupLabelKey:        groupName,
+				resourceTypeLabelKey: resourceType,
 			},
 		})
 	}
@@ -404,17 +398,12 @@ func findBestGroupToScaleOut(rc *cluster.RaftCluster, strategy *Strategy, scaleO
 		Component:    component.String(),
 		Count:        0,
 		ResourceType: resources[0].ResourceType,
-		Labels: []*metapb.StoreLabel{
-			{
-				Key: groupLabelKey,
-				// TODO: we need to make this label not duplicated when we implement the heterogeneous logic.
-				Value: autoScalingGroupLabelKeyPrefix + component.String(),
-			},
-			{
-				Key:   resourceTypeLabelKey,
-				Value: resources[0].ResourceType,
-			},
+		Labels: map[string]string{
+			// TODO: we need to make this label not duplicated when we implement the heterogeneous logic.
+			groupLabelKey:        autoScalingGroupLabelKeyPrefix + component.String(),
+			resourceTypeLabelKey: resources[0].ResourceType,
 		},
 	}
+
 	return group
 }

--- a/pkg/autoscaling/calculation_test.go
+++ b/pkg/autoscaling/calculation_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
@@ -116,15 +115,9 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 					Component:    TiKV.String(),
 					Count:        2,
 					ResourceType: "a",
-					Labels: []*metapb.StoreLabel{
-						{
-							Key:   groupLabelKey,
-							Value: fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
-						},
-						{
-							Key:   resourceTypeLabelKey,
-							Value: "a",
-						},
+					Labels: map[string]string{
+						groupLabelKey:        fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
+						resourceTypeLabelKey: "a",
 					},
 				},
 			},
@@ -168,15 +161,9 @@ func (s *calculationTestSuite) TestGetScaledTiKVGroups(c *C) {
 					Component:    TiKV.String(),
 					Count:        1,
 					ResourceType: "a",
-					Labels: []*metapb.StoreLabel{
-						{
-							Key:   groupLabelKey,
-							Value: fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
-						},
-						{
-							Key:   resourceTypeLabelKey,
-							Value: "a",
-						},
+					Labels: map[string]string{
+						groupLabelKey:        fmt.Sprintf("%s-0", autoScalingGroupLabelKeyPrefix),
+						resourceTypeLabelKey: "a",
 					},
 				},
 			},

--- a/pkg/autoscaling/types.go
+++ b/pkg/autoscaling/types.go
@@ -19,7 +19,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/pkg/etcdutil"
 	"go.etcd.io/etcd/clientv3"
 )
@@ -64,10 +63,10 @@ type Resource struct {
 
 // Plan is the final result of auto scaling, which indicates how to scale in or scale out.
 type Plan struct {
-	Component    string               `json:"component"`
-	Count        uint64               `json:"count"`
-	ResourceType string               `json:"resource_type"`
-	Labels       []*metapb.StoreLabel `json:"labels"`
+	Component    string            `json:"component"`
+	Count        uint64            `json:"count"`
+	ResourceType string            `json:"resource_type"`
+	Labels       map[string]string `json:"labels"`
 }
 
 // ComponentType distinguishes different kinds of components.


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Change the type of `labels` in autoscaling API response from `[]*metapb.StoreLabel` to `map[string]string`

### What is changed and how it works?

Change the type of `labels` in autoscaling API response from `[]*metapb.StoreLabel` to `map[string]string`


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- Has HTTP API interfaces change


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
