### PR TITLE
autoscaling: skip calculating plans for non-autoscaling components

### DIFF
--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -62,7 +62,7 @@ func calculate(rc *cluster.RaftCluster, cfg *config.PDServerConfig, strategy *St
 	}
 	querier := NewPrometheusQuerier(client)
 
-	var components map[ComponentType]struct{}
+	components := map[ComponentType]struct{}{}
 	for _, rule := range strategy.Rules {
 		switch rule.Component {
 		case "tidb":
@@ -227,6 +227,10 @@ func calculateScaleOutPlan(rc *cluster.RaftCluster, strategy *Strategy, componen
 	group := findBestGroupToScaleOut(rc, strategy, scaleOutQuota, groups, component)
 
 	resCPU := float64(getCPUByResourceType(strategy, group.ResourceType))
+	if math.Abs(resCPU) <= 1e-6 {
+		log.Error("resource CPU is zero, exiting calculation")
+		return nil
+	}
 	resCount := getCountByResourceType(strategy, group.ResourceType)
 	scaleOutCount := typeutil.MinUint64(uint64(math.Ceil(scaleOutQuota/resCPU)), MaxScaleOutStep)
 

--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -101,7 +101,7 @@ func getPlans(rc *cluster.RaftCluster, querier Querier, strategy *Strategy, comp
 	}
 
 	currentQuota, err := getTotalCPUQuota(querier, component, instances, now)
-	if err != nil {
+	if err != nil || currentQuota == 0 {
 		log.Error("cannot get total CPU quota", errs.ZapError(err))
 		return nil
 	}

--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -62,12 +62,22 @@ func calculate(rc *cluster.RaftCluster, cfg *config.PDServerConfig, strategy *St
 	}
 	querier := NewPrometheusQuerier(client)
 
-	if tikvPlans := getPlans(rc, querier, strategy, TiKV); tikvPlans != nil {
-		plans = append(plans, tikvPlans...)
+	var components map[ComponentType]struct{}
+	for _, rule := range strategy.Rules {
+		switch rule.Component {
+		case "tidb":
+			components[TiDB] = struct{}{}
+		case "tikv":
+			components[TiKV] = struct{}{}
+		}
 	}
-	if tidbPlans := getPlans(rc, querier, strategy, TiDB); tidbPlans != nil {
-		plans = append(plans, tidbPlans...)
+
+	for comp := range components {
+		if compPlans := getPlans(rc, querier, strategy, comp); compPlans != nil {
+			plans = append(plans, compPlans...)
+		}
 	}
+
 	return plans
 }
 

--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -255,6 +255,10 @@ func calculateScaleInPlan(rc *cluster.RaftCluster, strategy *Strategy, component
 	}
 	group := findBestGroupToScaleIn(rc, strategy, scaleInQuota, groups)
 	resCPU := float64(getCPUByResourceType(strategy, group.ResourceType))
+	if math.Abs(resCPU) <= 1e-6 {
+		log.Error("resource CPU is zero, exiting calculation")
+		return nil
+	}
 	scaleInCount := typeutil.MinUint64(uint64(math.Ceil(scaleInQuota/resCPU)), MaxScaleInStep)
 	for i, g := range groups {
 		if g.ResourceType == group.ResourceType {


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Autoscaling API will panic if some components are not for autoscaling because of division by zero.

### What is changed and how it works?

Skip calculating plans for non-autoscaling components

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
