### PR TITLE
tso: write dc-location config into etcd with lease

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -353,7 +353,7 @@ func (s *Server) startServer(ctx context.Context) error {
 		s.member, s.rootPath, s.cfg.TSOSaveInterval.Duration,
 		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() },
 	)
-	if err = s.tsoAllocatorManager.SetLocalTSOConfig(s.cfg.LocalTSO); err != nil {
+	if err = s.tsoAllocatorManager.SetLocalTSOConfig(ctx, s.cfg.LocalTSO); err != nil {
 		return err
 	}
 	kvBase := kv.NewEtcdKVBase(s.client, s.rootPath)

--- a/tests/server/tso/manager_test.go
+++ b/tests/server/tso/manager_test.go
@@ -15,8 +15,10 @@ package tso_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
@@ -86,5 +88,63 @@ func (s *testManagerSuite) TestClusterDCLocations(c *C) {
 			}
 		}
 		c.Assert(obtainedServerNumber, Equals, testCase.serverNumber)
+	}
+}
+
+// TestClusterDCLocationsChange is used to test the changing behavior
+// of a cluster's dc-locations.
+func (s *testManagerSuite) TestClusterDCLocationsChange(c *C) {
+	testCase := struct {
+		dcLocationNumber int
+		dcLocationConfig map[string]string
+		serversToDelete  []string
+	}{
+		dcLocationNumber: 3,
+		dcLocationConfig: map[string]string{
+			"pd1": "dc-1",
+			"pd2": "dc-1",
+			"pd3": "dc-2",
+			"pd4": "dc-2",
+			"pd5": "dc-3",
+			"pd6": "dc-3",
+		},
+		serversToDelete: []string{"pd1", "pd2"},
+	}
+	serverNumber := len(testCase.dcLocationConfig)
+	cluster, err := tests.NewTestCluster(s.ctx, serverNumber, func(conf *config.Config, serverName string) {
+		conf.LocalTSO.EnableLocalTSO = true
+		conf.LocalTSO.DCLocation = testCase.dcLocationConfig[serverName]
+	})
+	defer cluster.Destroy()
+	c.Assert(err, IsNil)
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+
+	serverNameMap := make(map[uint64]string)
+	for _, server := range cluster.GetServers() {
+		serverNameMap[server.GetServerID()] = server.GetServer().Name()
+	}
+	for i, serverToDelete := range testCase.serversToDelete {
+		err = cluster.GetServer(serverToDelete).Destroy()
+		c.Assert(err, IsNil)
+		// Wait for the lease expiring
+		time.Sleep(time.Second * 5)
+		// Start to check every server's GetClusterDCLocations() result
+		for _, server := range cluster.GetServers() {
+			// Skip the servers which has been deleted already
+			if slice.AnyOf(
+				testCase.serversToDelete,
+				func(i int) bool {
+					return testCase.serversToDelete[i] == server.GetServer().Name()
+				}) {
+				continue
+			}
+			dcLocationMap, err := server.GetTSOAllocatorManager().GetClusterDCLocations()
+			c.Assert(err, IsNil)
+			// After deleting all of the servers from dc-1, the dcLocationNumber should be 2
+			c.Assert(len(dcLocationMap), Equals, testCase.dcLocationNumber-i)
+			c.Assert(len(dcLocationMap[testCase.dcLocationConfig[serverToDelete]]), Equals, 1-i)
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

After #2939 being megerd, we now can persist the `dc-location` config in the cluster. However, if a server is done, the corresponding `dc-location` will remain in the etcd though it's not accessible anymore. To make this config in etcd change dynamically according to the lifetime of a server, we need to make some changes.

### What is changed and how it works?

Now `AllocatorManager` will write `dc-location` config into etcd with `lease`, that is, if a server is done, then the lease will expire which will make its `dc-location` info be deleted as soon as possible.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
