### PR TITLE
checker: set high priority for making up replicas

### DIFF
--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -68,6 +68,7 @@ func (r *ReplicaChecker) Check(region *core.RegionInfo) *operator.Operator {
 	}
 	if op := r.checkMakeUpReplica(region); op != nil {
 		checkerCounter.WithLabelValues("replica_checker", "new-operator").Inc()
+		op.SetPriorityLevel(core.HighPriority)
 		return op
 	}
 	if op := r.checkRemoveExtraReplica(region); op != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Making up replicas should be a high priority.

### What is changed and how it works?

This PR sets the `make-up-replica` operator to high priority.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- Set the `make-up-replica` operator to high priority 
