### PR TITLE
*: fix a potential panic when updating the errors dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200908071351-a715a95c7de2
 	github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12
 	github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9
-	github.com/pingcap/errors v0.11.5-0.20200902104258-eba4f1d8f6de
+	github.com/pingcap/errors v0.11.5-0.20200917111840-a15ef68f753d
 	github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d
 	github.com/pingcap/kvproto v0.0.0-20200916031750-f9473f2c5379
 	github.com/pingcap/log v0.0.0-20200511115504-543df19646ad

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9 h1:KH4f4Si9XK6/IW5
 github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9/go.mod h1:4b2X8xSqxIroj/IZ9MX/VGZhAwc11wB9wRIzHvz6SeM=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/pingcap/errors v0.11.5-0.20200902104258-eba4f1d8f6de h1:mW8hC2yXTpflfyTeJgcN4aJQfwcYODde8YgjBgAy6do=
-github.com/pingcap/errors v0.11.5-0.20200902104258-eba4f1d8f6de/go.mod h1:g4vx//d6VakjJ0mk7iLBlKA8LFavV/sAVINT/1PFxeQ=
+github.com/pingcap/errors v0.11.5-0.20200917111840-a15ef68f753d h1:TH18wFO5Nq/zUQuWu9ms2urgZnLP69XJYiI2JZAkUGc=
+github.com/pingcap/errors v0.11.5-0.20200917111840-a15ef68f753d/go.mod h1:g4vx//d6VakjJ0mk7iLBlKA8LFavV/sAVINT/1PFxeQ=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d h1:F8vp38kTAckN+v8Jlc98uMBvKIzr1a+UhnLyVYn8Q5Q=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=

--- a/server/election/leadership.go
+++ b/server/election/leadership.go
@@ -105,7 +105,7 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string) error {
 		return errs.ErrEtcdTxn.Wrap(err).GenWithStackByCause()
 	}
 	if !resp.Succeeded {
-		return errs.ErrEtcdTxn.Wrap(err).GenWithStackByCause()
+		return errs.ErrEtcdTxn.FastGenByArgs()
 	}
 	log.Info("write leaderDate to leaderPath ok", zap.String("leaderPath", ls.leaderKey), zap.String("purpose", ls.purpose))
 	return nil

--- a/server/kv/etcd_kv.go
+++ b/server/kv/etcd_kv.go
@@ -94,7 +94,7 @@ func (kv *etcdKVBase) Save(key, value string) error {
 		return e
 	}
 	if !resp.Succeeded {
-		return errs.ErrEtcdTxn.GenWithStackByArgs()
+		return errs.ErrEtcdTxn.FastGenByArgs()
 	}
 	return nil
 }
@@ -110,7 +110,7 @@ func (kv *etcdKVBase) Remove(key string) error {
 		return err
 	}
 	if !resp.Succeeded {
-		return errs.ErrEtcdTxn.GenWithStackByArgs()
+		return errs.ErrEtcdTxn.FastGenByArgs()
 	}
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

After updating the errors dependency, the PD will panic. Due to https://github.com/pingcap/errors/pull/26, when we wrap nil, it will return nil which causes panic of PD.

### What is changed and how it works?

This PR fixes a potential panic when updating the errors dependency

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

- Fix a panic problem when using the latest errors