### PR TITLE
placement: add override parameter to setallgroups

### DIFF
--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -431,6 +431,7 @@ func (h *ruleHandler) GetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 
 // @Tags rule
 // @Summary Update all rules and groups configuration.
+// @Param override query bool false "if override all rules" default(false)
 // @Produce json
 // @Success 200 {string} string "Update rules and groups successfully."
 // @Failure 400 {string} string "The input is invalid."
@@ -459,7 +460,8 @@ func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 			}
 		}
 	}
-	if err := cluster.GetRuleManager().SetAllGroupBundles(groups); err != nil {
+	_, override := r.URL.Query()["override"]
+	if err := cluster.GetRuleManager().SetAllGroupBundles(groups, override); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -431,7 +431,7 @@ func (h *ruleHandler) GetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 
 // @Tags rule
 // @Summary Update all rules and groups configuration.
-// @Param override query bool false "if override all rules" default(false)
+// @Param partial query bool false "if partially update rules" default(false)
 // @Produce json
 // @Success 200 {string} string "Update rules and groups successfully."
 // @Failure 400 {string} string "The input is invalid."
@@ -460,8 +460,8 @@ func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 			}
 		}
 	}
-	_, override := r.URL.Query()["override"]
-	if err := cluster.GetRuleManager().SetAllGroupBundles(groups, override); err != nil {
+	_, partial := r.URL.Query()["partial"]
+	if err := cluster.GetRuleManager().SetAllGroupBundles(groups, !partial); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -427,21 +427,26 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "set", "--in="+fname)
 	c.Assert(err, IsNil)
 
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "get", "pe")
+	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
-	err = json.Unmarshal(output, &bundle)
-	c.Assert(err, IsNil)
-	c.Assert(bundle, DeepEquals, placement.GroupBundle{ID: "pe", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pe", ID: "default", Role: "voter", Count: 3}}})
+	b, _ = ioutil.ReadFile(fname)
+	c.Assert(json.Unmarshal(b, &bundles), IsNil)
+	c.Assert(bundles, DeepEquals, []placement.GroupBundle{
+		{ID: "pd", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pd", ID: "default", Role: "voter", Count: 3}}},
+		{ID: "pe", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pe", ID: "default", Role: "voter", Count: 3}}},
+	})
 
 	// test delete
 	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "delete", "pd")
 	c.Assert(err, IsNil)
 
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "get", "pd")
+	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
-	err = json.Unmarshal(output, &bundle)
-	c.Assert(err, IsNil)
-	c.Assert(bundle, DeepEquals, placement.GroupBundle{ID: "pd", Index: 0, Override: false})
+	b, _ = ioutil.ReadFile(fname)
+	c.Assert(json.Unmarshal(b, &bundles), IsNil)
+	c.Assert(bundles, DeepEquals, []placement.GroupBundle{
+		{ID: "pe", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pe", ID: "default", Role: "voter", Count: 3}}},
+	})
 
 	// test delete regexp
 	bundle.ID = "pf"
@@ -455,11 +460,13 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "delete", "--regexp", ".*f")
 	c.Assert(err, IsNil)
 
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "get", "pf")
+	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
-	err = json.Unmarshal(output, &bundle)
-	c.Assert(err, IsNil)
-	c.Assert(bundle, DeepEquals, placement.GroupBundle{ID: "pf", Index: 0, Override: false})
+	b, _ = ioutil.ReadFile(fname)
+	c.Assert(json.Unmarshal(b, &bundles), IsNil)
+	c.Assert(bundles, DeepEquals, []placement.GroupBundle{
+		{ID: "pe", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pe", ID: "default", Role: "voter", Count: 3}}},
+	})
 
 	// test save
 	bundle.Rules = []*placement.Rule{{GroupID: "pf", ID: "default", Role: "voter", Count: 3}}
@@ -475,9 +482,25 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	b, err = ioutil.ReadFile(fname)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(b, &bundles), IsNil)
-	c.Assert(bundles, HasLen, 2)
 	c.Assert(bundles, DeepEquals, []placement.GroupBundle{
-		{ID: "pd", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pd", ID: "default", Role: "voter", Count: 3}}},
+		{ID: "pe", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pe", ID: "default", Role: "voter", Count: 3}}},
+		{ID: "pf", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pf", ID: "default", Role: "voter", Count: 3}}},
+	})
+
+	// partial update, so still one group is left, no error
+	bundles = []placement.GroupBundle{{ID: "pe", Rules: []*placement.Rule{}}}
+	b, err = json.Marshal(bundles)
+	c.Assert(err, IsNil)
+	c.Assert(ioutil.WriteFile(fname, b, 0644), IsNil)
+	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "save", "--in="+fname, "--partial")
+	c.Assert(err, IsNil)
+
+	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
+	c.Assert(err, IsNil)
+	b, err = ioutil.ReadFile(fname)
+	c.Assert(err, IsNil)
+	c.Assert(json.Unmarshal(b, &bundles), IsNil)
+	c.Assert(bundles, DeepEquals, []placement.GroupBundle{
 		{ID: "pf", Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: "pf", ID: "default", Role: "voter", Count: 3}}},
 	})
 }

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -486,6 +486,7 @@ func NewPlacementRulesCommand() *cobra.Command {
 		Run:   saveRuleBundle,
 	}
 	ruleBundleSave.Flags().String("in", "rules.json", "the file contains all group configs and all rules")
+	ruleBundleSave.Flags().Bool("partial", false, "do not drop all old configurations, partial update")
 	ruleBundle.AddCommand(ruleBundleGet, ruleBundleSet, ruleBundleDelete, ruleBundleLoad, ruleBundleSave)
 	c.AddCommand(enable, disable, show, load, save, ruleGroup, ruleBundle)
 	return c
@@ -721,7 +722,7 @@ func delRuleBundle(cmd *cobra.Command, args []string) {
 
 	reqPath := path.Join(ruleBundlePrefix, url.PathEscape(args[0]))
 
-	if f := cmd.Flag("regexp"); f != nil {
+	if ok, _ := cmd.Flags().GetBool("regexp"); ok {
 		reqPath += "?regexp"
 	}
 
@@ -769,7 +770,12 @@ func saveRuleBundle(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	res, err := doRequest(cmd, ruleBundlePrefix, http.MethodPost, WithBody("application/json", bytes.NewReader(content)))
+	path := ruleBundlePrefix
+	if ok, _ := cmd.Flags().GetBool("partial"); !ok {
+		path += "?override=true"
+	}
+
+	res, err := doRequest(cmd, path, http.MethodPost, WithBody("application/json", bytes.NewReader(content)))
 	if err != nil {
 		cmd.Printf("failed to save rule bundles %s: %s\n", content, err)
 		return

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -771,8 +771,8 @@ func saveRuleBundle(cmd *cobra.Command, args []string) {
 	}
 
 	path := ruleBundlePrefix
-	if ok, _ := cmd.Flags().GetBool("partial"); !ok {
-		path += "?override=true"
+	if ok, _ := cmd.Flags().GetBool("partial"); ok {
+		path += "?partial=true"
 	}
 
 	res, err := doRequest(cmd, path, http.MethodPost, WithBody("application/json", bytes.NewReader(content)))


### PR DESCRIPTION
### What problem does this PR solve?

Add `partial` parameter and `partial` option to `pd-ctl`. Refer to https://github.com/tikv/pd/issues/2680#issuecomment-694600556.

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

- add partial parameter to the post request of `/config/placement-rule`
