### PR TITLE
server: warn useless config change when placement rules enabled

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -806,6 +807,15 @@ func (s *Server) SetReplicationConfig(cfg config.ReplicationConfig) error {
 					return errors.New("cannot disable placement rules with TiFlash nodes")
 				}
 			}
+		}
+	}
+	if cfg.EnablePlacementRules {
+		// replication.MaxReplicas and replication.LocationLabels won't work when placement rule is enabled
+		if cfg.MaxReplicas != old.MaxReplicas {
+			return errors.New("cannot update MaxReplicas when placement rules feature is enabled, please update rule instead")
+		}
+		if !reflect.DeepEqual(cfg.LocationLabels, old.LocationLabels) {
+			return errors.New("cannot update LocationLabels when placement rules feature is enabled, please update rule instead")
 		}
 	}
 

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -393,6 +393,14 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
+	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "max-replicas", "1")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "please update rule instead"), IsTrue)
+
+	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "location-labels", "dc,rack")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "please update rule instead"), IsTrue)
+
 	// test get
 	var bundle placement.GroupBundle
 	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "get", "pd")


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
After placement rues enabled, updating `max-replicas` or `location-labels` won't work. User may not know it and get confused if they did not read doc carefully.

### What is changed and how it works?
Give some warning when user want to update config.

### Check List

Tests
- Unit test

### Release note
- No release note
