### PR TITLE
cluster: check if region is valid before handling it

### DIFF
--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -35,13 +35,6 @@ func (c *RaftCluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 		return err
 	}
 
-	// If the region peer count is 0, then we should not handle this.
-	if len(region.GetPeers()) == 0 {
-		log.Warn("invalid region, zero region peer count",
-			logutil.ZapRedactStringer("region-meta", core.RegionToHexMeta(region.GetMeta())))
-		return errors.Errorf("invalid region, zero region peer count: %v", logutil.RedactStringer(core.RegionToHexMeta(region.GetMeta())))
-	}
-
 	c.RLock()
 	co := c.coordinator
 	c.RUnlock()


### PR DESCRIPTION
### What problem does this PR solve?

Currently, we first handle the region heartbeat then check if the region is valid.

### What is changed and how it works?

This PR moves the check logic to `RegionHeartbeat`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
