### PR TITLE
server, pd-ctl: support setting roles in transfer-region operator

### DIFF
--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -153,7 +153,7 @@ func (h *operatorHandler) Post(w http.ResponseWriter, r *http.Request) {
 		}
 		storeIDsAndPeerRoles, ok := parseStoreIDsAndPeerRoles(input["to_store_ids"], input["peer_roles"])
 		if !ok {
-			h.r.JSON(w, http.StatusBadRequest, "invalid store ids to transfer region to")
+			h.r.JSON(w, http.StatusBadRequest, "invalid store ids or peer roles")
 			return
 		}
 		if len(storeIDsAndPeerRoles) == 0 {

--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -348,16 +348,17 @@ func parseStoreIDsAndPeerRoles(rawStoreIDs interface{}, rawPeerRoles interface{}
 	peerRoles, ok = rawPeerRoles.([]interface{})
 	if !ok {
 		peerRoles = nil
+	} else if len(peerRoles) != len(storeIDs) {
+		return nil, false
 	}
 
-	hasRoles := len(peerRoles) >= len(storeIDs)
 	result := make(map[uint64]placement.PeerRoleType)
 	for i, storeID := range storeIDs {
 		id, ok := storeID.(float64)
 		if !ok {
 			return nil, false
 		}
-		if hasRoles {
+		if peerRoles != nil {
 			role, ok := peerRoles[i].(string)
 			if ok {
 				result[uint64(id)] = placement.PeerRoleType(role)

--- a/server/api/operator_test.go
+++ b/server/api/operator_test.go
@@ -214,7 +214,7 @@ func (s *testTransferRegionOperatorSuite) TestTransferRegionOperator(c *C) {
 
 	err = postJSON(testDialClient, fmt.Sprintf("%s/operators", s.urlPrefix), []byte(`{"name":"transfer-region", "region_id": 1, "to_store_ids": [2, 3], "peer_roles": ["follower", "follower"]}`))
 	c.Assert(err, NotNil)
-	c.Assert(strings.Contains(err.Error(), "no valid leader"), IsTrue)
+	c.Assert(strings.Contains(err.Error(), "expected at least one voter or leader, got none"), IsTrue)
 
 	_, err = doDelete(testDialClient, regionURL)
 	c.Assert(err, IsNil)
@@ -229,19 +229,12 @@ func (s *testTransferRegionOperatorSuite) TestTransferRegionOperator(c *C) {
 	err = postJSON(testDialClient, fmt.Sprintf("%s/operators", s.urlPrefix), []byte(`{"name":"transfer-region", "region_id": 1, "to_store_ids": [1, 2, 3], "peer_roles": ["follower", "learner", "voter"]}`))
 	c.Assert(err, IsNil)
 	operator = mustReadURL(c, regionURL)
-	isEitherStepsOne :=
-		strings.Contains(operator, "add learner peer 4 on store 3") &&
-			strings.Contains(operator, "promote learner peer 4 on store 3 to voter") &&
-			strings.Contains(operator, "remove peer on store 2") &&
-			strings.Contains(operator, "add learner peer 5 on store 2") &&
-			strings.Contains(operator, "transfer leader from store 1 to store 3")
-	isEitherStepsTwo :=
-		strings.Contains(operator, "add learner peer 5 on store 3") &&
-			strings.Contains(operator, "promote learner peer 5 on store 3 to voter") &&
-			strings.Contains(operator, "remove peer on store 2") &&
-			strings.Contains(operator, "add learner peer 4 on store 2") &&
-			strings.Contains(operator, "transfer leader from store 1 to store 3")
-	c.Assert(isEitherStepsOne || isEitherStepsTwo, IsTrue)
+	println(operator)
+	c.Assert(strings.Contains(operator, "add learner peer 4 on store 3"), IsTrue)
+	c.Assert(strings.Contains(operator, "promote learner peer 4 on store 3 to voter"), IsTrue)
+	c.Assert(strings.Contains(operator, "remove peer on store 2"), IsTrue)
+	c.Assert(strings.Contains(operator, "add learner peer 3 on store 2"), IsTrue)
+	c.Assert(strings.Contains(operator, "transfer leader from store 1 to store 3"), IsTrue)
 
 	_, err = doDelete(testDialClient, regionURL)
 	c.Assert(err, IsNil)

--- a/server/handler.go
+++ b/server/handler.go
@@ -495,15 +495,13 @@ func (h *Handler) AddTransferRegionOperator(regionID uint64, storeIDsAndRoles ma
 				return errors.New("peer role must be provided when placement rules enabled")
 			}
 		}
+	} else if len(storeIDsAndRoles) > c.GetOpts().GetMaxReplicas() {
+		return errors.Errorf("the number of stores is %v, beyond the max replicas", len(storeIDsAndRoles))
 	}
 
 	region := c.GetRegion(regionID)
 	if region == nil {
 		return ErrRegionNotFound(regionID)
-	}
-
-	if len(storeIDsAndRoles) > c.GetOpts().GetMaxReplicas() {
-		return errors.Errorf("the number of stores is %v, beyond the max replicas", len(storeIDsAndRoles))
 	}
 
 	var store *core.StoreInfo

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -71,7 +71,7 @@ func CreateMoveRegionOperator(desc string, cluster opt.Cluster, region *core.Reg
 		case placement.Leader:
 			builder = builder.SetLeader(key)
 		case placement.Follower:
-			builder.targetFollowerStoreIDs[key] = struct{}{}
+			builder = builder.AddFollower(key)
 		}
 	}
 	return builder.Build(kind)

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -206,9 +206,23 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
 	c.Assert(strings.Contains(echo, "Success!"), IsFalse)
 
+	// operator add transfer-region <region_id> <store_id> [peer_role] ...
+	// placement rules enabled
 	_, _, err = pdctl.ExecuteCommandC(cmd, "config", "set", "enable-placement-rules", "true")
 	c.Assert(err, IsNil)
 	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "3")
 	c.Assert(err, IsNil)
-	c.Assert(strings.Contains(string(output), "not supported"), IsTrue)
+	c.Assert(strings.Contains(string(output), "peer role must be provided when placement rules enabled"), IsTrue) // placement rules enabled
+	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "follower", "3", "leader")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
+	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "random")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "invalid peer role"), IsTrue)
+	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "3", "leader")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "invalid syntax"), IsTrue)
+	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "leader", "follower")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "invalid syntax"), IsTrue)
 }

--- a/tools/pd-ctl/pdctl/command/operator.go
+++ b/tools/pd-ctl/pdctl/command/operator.go
@@ -443,7 +443,7 @@ func parseUint64sAndRoles(args []string) (uint64, []uint64, []string, error) {
 		return regionID, storeIDs, nil, err
 	}
 
-	storeIDs, peerRoles := make([]uint64, 0, len(args)), make([]string, 0, len(args))
+	storeIDs, peerRoles := make([]uint64, 0), make([]string, 0)
 	for i, arg := range args[1:] {
 		if i%2 == 0 {
 			storeID, err := strconv.ParseUint(arg, 10, 64)


### PR DESCRIPTION
The transfer-region operator needs to accept roles alongside stores to support placement rules feature.

Signed-off-by: PhotonQuantum <self@lightquantum.me>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

fixes #2533 .

### What is changed and how it works?

pd-ctl is modified to accept peer roles and send them to backend.

To handle the provided roles, `operator.Builder` now has a new property called `targetFollowerStoreIDs` to specify those peers that mustn't be leaders, and make sure that any of them won't be the leader in the final state. 

`operator.CreateMoveRegionOperator` is modified to specify the target leader and target followers before building the operator.

`handler.AddTransferRegionOperator` is also modified to set learners.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

Code changes

- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

- `transfer-region` operator is now supported when placement rules feature is enabled, and users must specify roles of stores explicitly in this case.

> P.S.
>
> There's a possibility that the builder generates a redundant leader transfer when joint consensus is disabled. I'm not familiar with Raft, thus I can't eliminate the extra transfer right now without compromising reliability for now.