### PR TITLE
api: add status query parameter for the scheduler API

### DIFF
--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -60,7 +60,7 @@ func (h *schedulerHandler) List(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get("status")
 	switch status {
 	case "paused":
-		var pausedScehdulers []string
+		var pausedSchedulers []string
 		for _, scheduler := range schedulers {
 			paused, err := h.IsSchedulerPaused(scheduler)
 			if err != nil {
@@ -69,14 +69,14 @@ func (h *schedulerHandler) List(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if paused {
-				pausedScehdulers = append(pausedScehdulers, scheduler)
+				pausedSchedulers = append(pausedSchedulers, scheduler)
 			}
 		}
-		h.r.JSON(w, http.StatusOK, pausedScehdulers)
+		h.r.JSON(w, http.StatusOK, pausedSchedulers)
 		return
 	default:
+		h.r.JSON(w, http.StatusOK, schedulers)
 	}
-	h.r.JSON(w, http.StatusOK, schedulers)
 }
 
 // FIXME: details of input json body params

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -45,7 +45,7 @@ func newSchedulerHandler(svr *server.Server, r *render.Render) *schedulerHandler
 }
 
 // @Tags scheduler
-// @Summary List running schedulers.
+// @Summary List all schedulers by status.
 // @Produce json
 // @Success 200 {array} string
 // @Failure 500 {string} string "PD server failed to proceed the request."
@@ -55,6 +55,26 @@ func (h *schedulerHandler) List(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.r.JSON(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+
+	status := r.URL.Query().Get("status")
+	switch status {
+	case "paused":
+		var pausedScehdulers []string
+		for _, scheduler := range schedulers {
+			paused, err := h.IsSchedulerPaused(scheduler)
+			if err != nil {
+				h.r.JSON(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+
+			if paused {
+				pausedScehdulers = append(pausedScehdulers, scheduler)
+			}
+		}
+		h.r.JSON(w, http.StatusOK, pausedScehdulers)
+		return
+	default:
 	}
 	h.r.JSON(w, http.StatusOK, schedulers)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Closes #3052.

### What is changed and how it works?

This PR supports the status query parameter for the scheduler API. For now, it only supports the `paused` status. If there is no status query parameter, the default behavior is the same as before.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
