### PR TITLE
api: auto fill group id in rules when unset

### DIFF
--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -454,7 +454,7 @@ func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 				h.rd.JSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
-			if len(rule.GroupID) != 0 {
+			if len(rule.GroupID) == 0 {
 				rule.GroupID = g.ID
 			}
 			if rule.GroupID != g.ID {
@@ -535,6 +535,9 @@ func (h *ruleHandler) SetGroupBundle(w http.ResponseWriter, r *http.Request) {
 	var group placement.GroupBundle
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &group); err != nil {
 		return
+	}
+	if len(group.ID) == 0 {
+		group.ID = groupID
 	}
 	if group.ID != groupID {
 		h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("group id %s does not match request URI %s", group.ID, groupID))

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -454,6 +454,9 @@ func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 				h.rd.JSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
+			if len(rule.GroupID) != 0 {
+				rule.GroupID = g.ID
+			}
 			if rule.GroupID != g.ID {
 				h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("rule group %s does not match group ID %s", rule.GroupID, g.ID))
 				return
@@ -541,6 +544,9 @@ func (h *ruleHandler) SetGroupBundle(w http.ResponseWriter, r *http.Request) {
 		if err := h.checkRule(rule); err != nil {
 			h.rd.JSON(w, http.StatusBadRequest, err.Error())
 			return
+		}
+		if len(rule.GroupID) == 0 {
+			rule.GroupID = groupID
 		}
 		if rule.GroupID != groupID {
 			h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("rule group %s does not match group ID %s", rule.GroupID, groupID))

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -709,8 +709,8 @@ func (s *testRuleSuite) TestBundle(c *C) {
 	compareBundle(c, bundles[0], b1)
 
 	// Set
+	id := "rule-without-group-id"
 	b4 := placement.GroupBundle{
-		ID:    "rule-without-group-id",
 		Index: 4,
 		Rules: []*placement.Rule{
 			{ID: "bar", Index: 1, Override: true, Role: "voter", Count: 1},
@@ -718,18 +718,19 @@ func (s *testRuleSuite) TestBundle(c *C) {
 	}
 	data, err = json.Marshal(b4)
 	c.Assert(err, IsNil)
-	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule/"+b4.ID, data)
+	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule/"+id, data)
 	c.Assert(err, IsNil)
 
+	b4.ID = id
 	b4.Rules[0].GroupID = b4.ID
 
 	// Get
-	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/"+b4.ID, &bundle)
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/"+id, &bundle)
 	c.Assert(err, IsNil)
 	compareBundle(c, bundle, b4)
 
 	// GetAll again
-	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/", &bundles)
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule", &bundles)
 	c.Assert(err, IsNil)
 	c.Assert(bundles, HasLen, 2)
 	compareBundle(c, bundles[0], b1)
@@ -745,13 +746,13 @@ func (s *testRuleSuite) TestBundle(c *C) {
 	}
 	data, err = json.Marshal([]placement.GroupBundle{b1, b4, b5})
 	c.Assert(err, IsNil)
-	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule/", data)
+	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule", data)
 	c.Assert(err, IsNil)
 
 	b5.Rules[0].GroupID = b5.ID
 
 	// GetAll again
-	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/", &bundles)
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule", &bundles)
 	c.Assert(err, IsNil)
 	c.Assert(bundles, HasLen, 3)
 	compareBundle(c, bundles[0], b1)

--- a/server/api/rule_test.go
+++ b/server/api/rule_test.go
@@ -707,6 +707,57 @@ func (s *testRuleSuite) TestBundle(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(bundles, HasLen, 1)
 	compareBundle(c, bundles[0], b1)
+
+	// Set
+	b4 := placement.GroupBundle{
+		ID:    "rule-without-group-id",
+		Index: 4,
+		Rules: []*placement.Rule{
+			{ID: "bar", Index: 1, Override: true, Role: "voter", Count: 1},
+		},
+	}
+	data, err = json.Marshal(b4)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule/"+b4.ID, data)
+	c.Assert(err, IsNil)
+
+	b4.Rules[0].GroupID = b4.ID
+
+	// Get
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/"+b4.ID, &bundle)
+	c.Assert(err, IsNil)
+	compareBundle(c, bundle, b4)
+
+	// GetAll again
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/", &bundles)
+	c.Assert(err, IsNil)
+	c.Assert(bundles, HasLen, 2)
+	compareBundle(c, bundles[0], b1)
+	compareBundle(c, bundles[1], b4)
+
+	// SetAll
+	b5 := placement.GroupBundle{
+		ID:    "rule-without-group-id-2",
+		Index: 5,
+		Rules: []*placement.Rule{
+			{ID: "bar", Index: 1, Override: true, Role: "voter", Count: 1},
+		},
+	}
+	data, err = json.Marshal([]placement.GroupBundle{b1, b4, b5})
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/placement-rule/", data)
+	c.Assert(err, IsNil)
+
+	b5.Rules[0].GroupID = b5.ID
+
+	// GetAll again
+	err = readJSON(testDialClient, s.urlPrefix+"/placement-rule/", &bundles)
+	c.Assert(err, IsNil)
+	c.Assert(bundles, HasLen, 3)
+	compareBundle(c, bundles[0], b1)
+	compareBundle(c, bundles[1], b4)
+	compareBundle(c, bundles[2], b5)
+
 }
 
 func (s *testRuleSuite) TestBundleBadRequest(c *C) {


### PR DESCRIPTION
Signed-off-by: Zheming Li <nkdudu@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

#3054 

### What is changed and how it works?

- Using `GroupBundle.ID` to auto fill `GroupId` field in Rule when unset.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- Has HTTP API interfaces change


### Release note

- No release note
