### PR TITLE
server: change log level for the stale region when loading

### DIFF
--- a/server/cluster_info.go
+++ b/server/cluster_info.go
@@ -89,7 +89,7 @@ func loadClusterInfo(id core.IDAllocator, kv *core.KV, opt *scheduleOption) (*cl
 		defer c.Unlock()
 		origin, err := c.core.PreCheckPutRegion(region)
 		if err != nil {
-			log.Warn("region is stale", zap.Error(err), zap.Stringer("origin", origin.GetMeta()))
+			log.Debug("region is stale", zap.Error(err), zap.Stringer("origin", origin.GetMeta()))
 			// return the state region to delete.
 			return []*metapb.Region{region.GetMeta()}
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Related to https://github.com/tikv/pd/issues/2427, but for release-3.0

### What is changed and how it works?

This PR changes the log level of the stale region when loading.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- Change the log level of the stale region when loading regions
