### PR TITLE
Fix the bug that PD might panic if there is down store with 10 minutes

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -633,7 +633,7 @@ func (mc *Cluster) SetStoreLabel(storeID uint64, labels map[string]string) {
 	mc.PutStore(newStore)
 }
 
-// SetStoreLabel set the last heartbeat to the target store
+// SetStoreLastHeartbeatInterval set the last heartbeat to the target store
 func (mc *Cluster) SetStoreLastHeartbeatInterval(storeID uint64, interval time.Duration) {
 	store := mc.GetStore(storeID)
 	newStore := store.Clone(

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -632,3 +632,12 @@ func (mc *Cluster) SetStoreLabel(storeID uint64, labels map[string]string) {
 	newStore := store.Clone(core.SetStoreLabels(newLabels))
 	mc.PutStore(newStore)
 }
+
+// SetStoreLabel set the last heartbeat to the target store
+func (mc *Cluster) SetStoreLastHeartbeatInterval(storeID uint64, interval time.Duration) {
+	store := mc.GetStore(storeID)
+	newStore := store.Clone(
+		core.SetStoreState(metapb.StoreState_Up),
+		core.SetLastHeartbeatTS(time.Now().Add(-interval)))
+	mc.PutStore(newStore)
+}

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -198,6 +198,33 @@ func (f *healthFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
 	return f.filter(opt, store)
 }
 
+type connectedFilter struct{ scope string }
+
+// NewConnectedFilter creates a Filter that filters all stores that are disconnected.
+func NewConnectedFilter(scope string) Filter {
+	return &connectedFilter{scope: scope}
+}
+
+func (f *connectedFilter) Scope() string {
+	return f.scope
+}
+
+func (f *connectedFilter) Type() string {
+	return "connected-filter"
+}
+
+func (f *connectedFilter) filter(opt opt.Options, store *core.StoreInfo) bool {
+	return !store.IsDisconnected()
+}
+
+func (f *connectedFilter) Source(opt opt.Options, store *core.StoreInfo) bool {
+	return f.filter(opt, store)
+}
+
+func (f *connectedFilter) Target(opt opt.Options, store *core.StoreInfo) bool {
+	return f.filter(opt, store)
+}
+
 type pendingPeerCountFilter struct{ scope string }
 
 // NewPendingPeerCountFilter creates a Filter that filters all stores that are

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -779,7 +779,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 		filters = []filter.Filter{
 			filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true},
 			filter.NewExcludedFilter(bs.sche.GetName(), bs.cur.region.GetStoreIds(), bs.cur.region.GetStoreIds()),
-			filter.NewHealthFilter(bs.sche.GetName()),
+			filter.NewConnectedFilter(bs.sche.GetName()),
 			filter.NewSpecialUseFilter(bs.sche.GetName(), filter.SpecialUseHotRegion),
 			scoreGuard,
 		}
@@ -789,7 +789,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 	case transferLeader:
 		filters = []filter.Filter{
 			filter.StoreStateFilter{ActionScope: bs.sche.GetName(), TransferLeader: true},
-			filter.NewHealthFilter(bs.sche.GetName()),
+			filter.NewConnectedFilter(bs.sche.GetName()),
 			filter.NewSpecialUseFilter(bs.sche.GetName(), filter.SpecialUseHotRegion),
 		}
 

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -364,7 +364,6 @@ func (s *testHotWriteRegionSchedulerSuite) TestUnhealthyStore(c *C) {
 	tc.AddRegionStore(2, 20)
 	tc.AddRegionStore(3, 20)
 	tc.AddRegionStore(4, 20)
-	tc.AddRegionStore(5, 20)
 
 	tc.UpdateStorageWrittenStats(1, 10.5*MB*statistics.StoreHeartBeatReportInterval, 10.5*MB*statistics.StoreHeartBeatReportInterval)
 	tc.UpdateStorageWrittenStats(2, 10*MB*statistics.StoreHeartBeatReportInterval, 10*MB*statistics.StoreHeartBeatReportInterval)
@@ -389,13 +388,6 @@ func (s *testHotWriteRegionSchedulerSuite) TestUnhealthyStore(c *C) {
 	// test dst
 	for _, interval := range intervals {
 		tc.SetStoreLastHeartbeatInterval(4, interval)
-		hb.(*hotScheduler).clearPendingInfluence()
-		hb.Schedule(tc)
-		// no panic
-	}
-	// test src
-	for _, interval := range intervals {
-		tc.SetStoreLastHeartbeatInterval(1, interval)
 		hb.(*hotScheduler).clearPendingInfluence()
 		hb.Schedule(tc)
 		// no panic

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -348,6 +348,53 @@ func (s *testHotWriteRegionSchedulerSuite) TestWithKeyRate(c *C) {
 	}
 }
 
+func (s *testHotWriteRegionSchedulerSuite) TestUnhealthyStore(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	statistics.Denoising = false
+	opt := mockoption.NewScheduleOptions()
+	hb, err := schedule.CreateScheduler(HotWriteRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
+	c.Assert(err, IsNil)
+	hb.(*hotScheduler).conf.SetDstToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetSrcToleranceRatio(1)
+	opt.HotRegionCacheHitsThreshold = 0
+
+	tc := mockcluster.NewCluster(opt)
+	tc.AddRegionStore(1, 20)
+	tc.AddRegionStore(2, 20)
+	tc.AddRegionStore(3, 20)
+	tc.AddRegionStore(4, 20)
+	tc.AddRegionStore(5, 20)
+
+	tc.UpdateStorageWrittenStats(1, 10.5*MB*statistics.StoreHeartBeatReportInterval, 10.5*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(2, 10*MB*statistics.StoreHeartBeatReportInterval, 10*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(3, 9.5*MB*statistics.StoreHeartBeatReportInterval, 9.5*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(4, 0*MB*statistics.StoreHeartBeatReportInterval, 0*MB*statistics.StoreHeartBeatReportInterval)
+	addRegionInfo(tc, write, []testRegionInfo{
+		{1, []uint64{1, 2, 3}, 0.5 * MB, 0.5 * MB},
+		{2, []uint64{2, 1, 3}, 0.5 * MB, 0.5 * MB},
+		{3, []uint64{3, 2, 1}, 0.5 * MB, 0.5 * MB},
+	})
+
+	intervals := []time.Duration{
+		9 * time.Second,
+		10 * time.Second,
+		19 * time.Second,
+		20 * time.Second,
+		9 * time.Minute,
+		10 * time.Minute,
+		29 * time.Minute,
+		30 * time.Minute,
+	}
+
+	for _, interval := range intervals {
+		tc.SetStoreLastHeartbeatInterval(4,interval)
+		hb.(*hotScheduler).clearPendingInfluence()
+		hb.Schedule(tc)
+		// no panic
+	}
+}
+
 func (s *testHotWriteRegionSchedulerSuite) TestLeader(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -386,9 +386,16 @@ func (s *testHotWriteRegionSchedulerSuite) TestUnhealthyStore(c *C) {
 		29 * time.Minute,
 		30 * time.Minute,
 	}
-
+	// test dst
 	for _, interval := range intervals {
-		tc.SetStoreLastHeartbeatInterval(4,interval)
+		tc.SetStoreLastHeartbeatInterval(4, interval)
+		hb.(*hotScheduler).clearPendingInfluence()
+		hb.Schedule(tc)
+		// no panic
+	}
+	// test src
+	for _, interval := range intervals {
+		tc.SetStoreLastHeartbeatInterval(1, interval)
 		hb.(*hotScheduler).clearPendingInfluence()
 		hb.Schedule(tc)
 		// no panic


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix the bug that PD might panic if there is down store with 10 minutes
#3053 

### What is changed and how it works?

replace healthy filter with Connected filter

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- Fix the bug that PD might panic if there is down store with 10 minutes
