### PR TITLE
api: support temporary configuration

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -47,7 +47,7 @@ func newConfHandler(svr *server.Server, rd *render.Render) *confHandler {
 }
 
 // @Tags config
-// @Summary Update temporary configuration. Note that this is a temporary api and only support for lightning and BR. Don't call this API.
+// @Summary Update temporary configuration. Note that this is a temporary api and only support for lightning and BR. Don't call this API and it will be removed in release-5.0.
 // @Produce json
 // @Success 200 {object} config.Config
 // @Router /config/ttl [post]

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -47,7 +47,6 @@ func newConfHandler(svr *server.Server, rd *render.Render) *confHandler {
 }
 
 func (h *confHandler) SetTTLConfig(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r.Context())
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -61,7 +60,7 @@ func (h *confHandler) SetTTLConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	rc.SaveTTLConfig(input, time.Duration(ttls)*time.Second)
+	h.svr.SaveTTLConfig(input, time.Duration(ttls)*time.Second)
 	h.rd.JSON(w, http.StatusOK, "success")
 }
 

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -46,6 +46,11 @@ func newConfHandler(svr *server.Server, rd *render.Render) *confHandler {
 	}
 }
 
+// @Tags config
+// @Summary Update temporary configuration. Note that this is a temporary api and only support for lightning and BR. Don't call this API.
+// @Produce json
+// @Success 200 {object} config.Config
+// @Router /config/ttl [post]
 func (h *confHandler) SetTTLConfig(w http.ResponseWriter, r *http.Request) {
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -48,7 +48,7 @@ func newConfHandler(svr *server.Server, rd *render.Render) *confHandler {
 
 // @Tags config
 // @Summary Update temporary configuration.
-// @Warning Note that this is a temporary api and only support for lightning and BR. Don't call this API
+// @Description Note that this is a temporary api and only support for lightning and BR. Don't call this API yet.
 // @Produce json
 // @Success 200 {string} string "The config is updated."
 // @Router /config/ttl [post]

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -47,9 +47,10 @@ func newConfHandler(svr *server.Server, rd *render.Render) *confHandler {
 }
 
 // @Tags config
-// @Summary Update temporary configuration. Note that this is a temporary api and only support for lightning and BR. Don't call this API and it will be removed in release-5.0.
+// @Summary Update temporary configuration.
+// @Warning Note that this is a temporary api and only support for lightning and BR. Don't call this API
 // @Produce json
-// @Success 200 {object} config.Config
+// @Success 200 {string} string "The config is updated."
 // @Router /config/ttl [post]
 func (h *confHandler) SetTTLConfig(w http.ResponseWriter, r *http.Request) {
 	var input map[string]interface{}
@@ -66,7 +67,7 @@ func (h *confHandler) SetTTLConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	h.svr.SaveTTLConfig(input, time.Duration(ttls)*time.Second)
-	h.rd.JSON(w, http.StatusOK, "success")
+	h.rd.JSON(w, http.StatusOK, "The config is updated.")
 }
 
 // @Tags config

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -275,3 +275,20 @@ func (s *testConfigSuite) TestConfigDefault(c *C) {
 	c.Assert(defaultCfg.Schedule.RegionScheduleLimit, Equals, uint64(2048))
 	c.Assert(defaultCfg.PDServerCfg.MetricStorage, Equals, "")
 }
+
+func (s *testConfigSuite) TestConfigTTL(c *C) {
+	addr := fmt.Sprintf("%s/config", s.urlPrefix)
+	r := map[string]int{"max-snapshot-count": 999}
+	postData, err := json.Marshal(r)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, addr+"?ttlSecond=10", postData)
+	c.Assert(err, IsNil)
+	cfg := &config.Config{}
+	err = readJSON(testDialClient, addr, cfg)
+	c.Assert(err, IsNil)
+	c.Assert(cfg.Schedule.MaxSnapshotCount, Equals, uint64(999))
+	time.Sleep(20 * time.Second)
+	err = readJSON(testDialClient, addr, cfg)
+	c.Assert(err, IsNil)
+	c.Assert(cfg.Schedule.MaxSnapshotCount, Not(Equals), uint64(999))
+}

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -277,13 +277,27 @@ func (s *testConfigSuite) TestConfigDefault(c *C) {
 }
 
 func (s *testConfigSuite) TestConfigTTL(c *C) {
-	addr := fmt.Sprintf("%s/config/ttl?ttlSecond=3", s.urlPrefix)
-	r := map[string]int{"max-snapshot-count": 999}
+	addr := fmt.Sprintf("%s/config/ttl?ttlSecond=5", s.urlPrefix)
+	r := map[string]int{
+		"max-snapshot-count":      999,
+		"store-limit-add-peer":    999,
+		"max-merge-region-size":   999,
+		"max-merge-region-keys":   999,
+		"store-limit-remove-peer": 999,
+	}
 	postData, err := json.Marshal(r)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, addr, postData)
 	c.Assert(err, IsNil)
 	c.Assert(s.svr.GetPersistOptions().GetMaxSnapshotCount(), Equals, uint64(999))
-	time.Sleep(6 * time.Second)
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).AddPeer, Equals, float64(999))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).RemovePeer, Equals, float64(999))
+	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionSize(), Equals, uint64(999))
+	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionKeys(), Equals, uint64(999))
+	time.Sleep(10 * time.Second)
 	c.Assert(s.svr.GetPersistOptions().GetMaxSnapshotCount(), Not(Equals), uint64(999))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).AddPeer, Not(Equals), float64(999))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).RemovePeer, Not(Equals), float64(999))
+	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionSize(), Not(Equals), uint64(999))
+	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionKeys(), Not(Equals), uint64(999))
 }

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -277,27 +277,27 @@ func (s *testConfigSuite) TestConfigDefault(c *C) {
 }
 
 func (s *testConfigSuite) TestConfigTTL(c *C) {
-	addr := fmt.Sprintf("%s/config/ttl?ttlSecond=5", s.urlPrefix)
-	r := map[string]int{
-		"max-snapshot-count":      999,
-		"store-limit-add-peer":    999,
-		"max-merge-region-size":   999,
-		"max-merge-region-keys":   999,
-		"store-limit-remove-peer": 999,
+	addr := fmt.Sprintf("%s/config/ttl?ttlSecond=3", s.urlPrefix)
+	r := map[string]interface{}{
+		"schedule.max-snapshot-count":             999,
+		"schedule.enable-location-replacement":    false,
+		"schedule.max-merge-region-size":          999,
+		"schedule.max-merge-region-keys":          999,
+		"schedule.scheduler-max-waiting-operator": 999,
 	}
 	postData, err := json.Marshal(r)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, addr, postData)
 	c.Assert(err, IsNil)
 	c.Assert(s.svr.GetPersistOptions().GetMaxSnapshotCount(), Equals, uint64(999))
-	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).AddPeer, Equals, float64(999))
-	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).RemovePeer, Equals, float64(999))
+	c.Assert(s.svr.GetPersistOptions().IsLocationReplacementEnabled(), Equals, false)
 	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionSize(), Equals, uint64(999))
 	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionKeys(), Equals, uint64(999))
-	time.Sleep(10 * time.Second)
+	c.Assert(s.svr.GetPersistOptions().GetSchedulerMaxWaitingOperator(), Equals, uint64(999))
+	time.Sleep(5 * time.Second)
 	c.Assert(s.svr.GetPersistOptions().GetMaxSnapshotCount(), Not(Equals), uint64(999))
-	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).AddPeer, Not(Equals), float64(999))
-	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(1).RemovePeer, Not(Equals), float64(999))
+	c.Assert(s.svr.GetPersistOptions().IsLocationReplacementEnabled(), Equals, true)
 	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionSize(), Not(Equals), uint64(999))
 	c.Assert(s.svr.GetPersistOptions().GetMaxMergeRegionKeys(), Not(Equals), uint64(999))
+	c.Assert(s.svr.GetPersistOptions().GetSchedulerMaxWaitingOperator(), Not(Equals), uint64(999))
 }

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -277,7 +277,7 @@ func (s *testConfigSuite) TestConfigDefault(c *C) {
 }
 
 func (s *testConfigSuite) TestConfigTTL(c *C) {
-	addr := fmt.Sprintf("%s/config/ttl?ttlSecond=3", s.urlPrefix)
+	addr := fmt.Sprintf("%s/config?ttlSecond=3", s.urlPrefix)
 	r := map[string]interface{}{
 		"schedule.max-snapshot-count":             999,
 		"schedule.enable-location-replacement":    false,

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -277,18 +277,13 @@ func (s *testConfigSuite) TestConfigDefault(c *C) {
 }
 
 func (s *testConfigSuite) TestConfigTTL(c *C) {
-	addr := fmt.Sprintf("%s/config", s.urlPrefix)
+	addr := fmt.Sprintf("%s/config/ttl?ttlSecond=3", s.urlPrefix)
 	r := map[string]int{"max-snapshot-count": 999}
 	postData, err := json.Marshal(r)
 	c.Assert(err, IsNil)
-	err = postJSON(testDialClient, addr+"?ttlSecond=10", postData)
+	err = postJSON(testDialClient, addr, postData)
 	c.Assert(err, IsNil)
-	cfg := &config.Config{}
-	err = readJSON(testDialClient, addr, cfg)
-	c.Assert(err, IsNil)
-	c.Assert(cfg.Schedule.MaxSnapshotCount, Equals, uint64(999))
-	time.Sleep(20 * time.Second)
-	err = readJSON(testDialClient, addr, cfg)
-	c.Assert(err, IsNil)
-	c.Assert(cfg.Schedule.MaxSnapshotCount, Not(Equals), uint64(999))
+	c.Assert(s.svr.GetPersistOptions().GetMaxSnapshotCount(), Equals, uint64(999))
+	time.Sleep(6 * time.Second)
+	c.Assert(s.svr.GetPersistOptions().GetMaxSnapshotCount(), Not(Equals), uint64(999))
 }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -76,7 +76,6 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	apiRouter.HandleFunc("/cluster/status", clusterHandler.GetClusterStatus).Methods("GET")
 
 	confHandler := newConfHandler(svr, rd)
-	apiRouter.HandleFunc("/config/ttl", confHandler.SetTTLConfig).Methods("POST")
 	apiRouter.HandleFunc("/config", confHandler.Get).Methods("GET")
 	apiRouter.HandleFunc("/config", confHandler.Post).Methods("POST")
 	apiRouter.HandleFunc("/config/default", confHandler.GetDefault).Methods("GET")
@@ -90,6 +89,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	apiRouter.HandleFunc("/config/cluster-version", confHandler.SetClusterVersion).Methods("POST")
 	apiRouter.HandleFunc("/config/replication-mode", confHandler.GetReplicationMode).Methods("GET")
 	apiRouter.HandleFunc("/config/replication-mode", confHandler.SetReplicationMode).Methods("POST")
+	apiRouter.HandleFunc("/config/ttl", confHandler.SetTTLConfig).Methods("POST")
 
 	rulesHandler := newRulesHandler(svr, rd)
 	clusterRouter.HandleFunc("/config/rules", rulesHandler.GetAll).Methods("GET")

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -76,6 +76,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	apiRouter.HandleFunc("/cluster/status", clusterHandler.GetClusterStatus).Methods("GET")
 
 	confHandler := newConfHandler(svr, rd)
+	apiRouter.HandleFunc("/config/ttl", confHandler.SetTTLConfig).Methods("POST")
 	apiRouter.HandleFunc("/config", confHandler.Get).Methods("GET")
 	apiRouter.HandleFunc("/config", confHandler.Post).Methods("POST")
 	apiRouter.HandleFunc("/config/default", confHandler.GetDefault).Methods("GET")

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -89,7 +89,6 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	apiRouter.HandleFunc("/config/cluster-version", confHandler.SetClusterVersion).Methods("POST")
 	apiRouter.HandleFunc("/config/replication-mode", confHandler.GetReplicationMode).Methods("GET")
 	apiRouter.HandleFunc("/config/replication-mode", confHandler.SetReplicationMode).Methods("POST")
-	apiRouter.HandleFunc("/config/ttl", confHandler.SetTTLConfig).Methods("POST")
 
 	rulesHandler := newRulesHandler(svr, rd)
 	clusterRouter.HandleFunc("/config/rules", rulesHandler.GetAll).Methods("GET")

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -343,6 +343,7 @@ func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
 // FIXME: details of input json body params
 // @Tags store
 // @Summary Set the store's limit.
+// @Param ttlSecond query integer false "ttl". ttl param is only for BR and lightning now. Don't use it.
 // @Param id path integer true "Store Id"
 // @Param body body object true "json params"
 // @Produce json
@@ -445,6 +446,7 @@ func (h *storesHandler) RemoveTombStone(w http.ResponseWriter, r *http.Request) 
 // @Tags store
 // @Summary Set limit of all stores in the cluster.
 // @Accept json
+// @Param ttlSecond query integer false "ttl". ttl param is only for BR and lightning now. Don't use it.
 // @Param body body object true "json params"
 // @Produce json
 // @Success 200 {string} string "Set store limit successfully."

--- a/server/api/store_test.go
+++ b/server/api/store_test.go
@@ -395,3 +395,54 @@ func (s *testStoreSuite) TestGetAllLimit(c *C) {
 		}
 	}
 }
+
+func (s *testStoreSuite) TestStoreLimitTTL(c *C) {
+	// add peer
+	url := fmt.Sprintf("%s/store/1/limit?ttlSecond=%v", s.urlPrefix, 5)
+	data := map[string]interface{}{
+		"type": "add-peer",
+		"rate": 999,
+	}
+	postData, err := json.Marshal(data)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, url, postData)
+	c.Assert(err, IsNil)
+	// remove peer
+	data = map[string]interface{}{
+		"type": "remove-peer",
+		"rate": 998,
+	}
+	postData, err = json.Marshal(data)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, url, postData)
+	c.Assert(err, IsNil)
+	// all store limit add peer
+	url = fmt.Sprintf("%s/stores/limit?ttlSecond=%v", s.urlPrefix, 3)
+	data = map[string]interface{}{
+		"type": "add-peer",
+		"rate": 997,
+	}
+	postData, err = json.Marshal(data)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, url, postData)
+	c.Assert(err, IsNil)
+	// all store limit remove peer
+	data = map[string]interface{}{
+		"type": "remove-peer",
+		"rate": 996,
+	}
+	postData, err = json.Marshal(data)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, url, postData)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(1)).AddPeer, Equals, float64(999))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(1)).RemovePeer, Equals, float64(998))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(2)).AddPeer, Equals, float64(997))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(2)).RemovePeer, Equals, float64(996))
+	time.Sleep(5 * time.Second)
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(1)).AddPeer, Not(Equals), float64(999))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(1)).RemovePeer, Not(Equals), float64(998))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(2)).AddPeer, Not(Equals), float64(997))
+	c.Assert(s.svr.GetPersistOptions().GetStoreLimit(uint64(2)).RemovePeer, Not(Equals), float64(996))
+}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1635,12 +1635,6 @@ func (c *RaftCluster) GetEtcdClient() *clientv3.Client {
 	return c.etcdClient
 }
 
-func (c *RaftCluster) SaveTTLConfig(data map[string]interface{}, ttl time.Duration) {
-	for k, v := range data {
-		c.opt.SetTTLData(k, v, ttl)
-	}
-}
-
 var healthURL = "/pd/api/v1/ping"
 
 // CheckHealth checks if members are healthy.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1625,6 +1625,11 @@ func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64)
 	c.opt.SetAllStoresLimit(typ, ratePerMin)
 }
 
+// SetAllStoresLimitTTL sets all store limit for a given type and rate with ttl.
+func (c *RaftCluster) SetAllStoresLimitTTL(typ storelimit.Type, ratePerMin float64, ttl time.Duration) {
+	c.opt.SetAllStoresLimitTTL(c.ctx, typ, ratePerMin, ttl)
+}
+
 // GetClusterVersion returns the current cluster version.
 func (c *RaftCluster) GetClusterVersion() string {
 	return c.opt.GetClusterVersion().String()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1635,6 +1635,12 @@ func (c *RaftCluster) GetEtcdClient() *clientv3.Client {
 	return c.etcdClient
 }
 
+func (c *RaftCluster) SaveTTLConfig(data map[string]interface{}, ttl time.Duration) {
+	for k, v := range data {
+		c.opt.SetTTLData(k, v, ttl)
+	}
+}
+
 var healthURL = "/pd/api/v1/ping"
 
 // CheckHealth checks if members are healthy.

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -559,6 +559,7 @@ func (o *PersistOptions) CheckLabelProperty(typ string, labels []*metapb.StoreLa
 	return false
 }
 
+// SetTTLData set temporary configuration
 func (o *PersistOptions) SetTTLData(ctx context.Context, key string, value interface{}, ttl time.Duration) {
 	if data, ok := o.ttl[key]; ok {
 		data.Clear()

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -550,12 +550,12 @@ func (o *PersistOptions) CheckLabelProperty(typ string, labels []*metapb.StoreLa
 	return false
 }
 
-func (o *PersistOptions) SetTTLData(key string, value interface{}, ttl time.Duration) {
+func (o *PersistOptions) SetTTLData(ctx context.Context, key string, value interface{}, ttl time.Duration) {
 	if data, ok := o.ttl[key]; ok {
 		data.Clear()
 	}
-	o.ttl[key] = cache.NewStringTTL(context.Background(), 1*time.Minute, ttl)
-	o.ttl[key].Put(key, value)
+	o.ttl[key] = cache.NewStringTTL(ctx, 5*time.Second, ttl)
+	o.ttl[key].Put(key, uint64(value.(float64)))
 }
 
 func (o *PersistOptions) getTTLData(key string) (interface{}, bool) {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -15,7 +15,6 @@ package config
 
 import (
 	"context"
-	"github.com/tikv/pd/pkg/cache"
 	"reflect"
 	"sync/atomic"
 	"time"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/core"

--- a/server/handler.go
+++ b/server/handler.go
@@ -415,6 +415,16 @@ func (h *Handler) SetAllStoresLimit(ratePerMin float64, limitType storelimit.Typ
 	return nil
 }
 
+// SetAllStoresLimitTTL is used to set limit of all stores with ttl
+func (h *Handler) SetAllStoresLimitTTL(ratePerMin float64, limitType storelimit.Type, ttl time.Duration) error {
+	c, err := h.GetRaftCluster()
+	if err != nil {
+		return err
+	}
+	c.SetAllStoresLimitTTL(limitType, ratePerMin, ttl)
+	return nil
+}
+
 // SetLabelStoresLimit is used to set limit of label stores.
 func (h *Handler) SetLabelStoresLimit(ratePerMin float64, limitType storelimit.Type, labels []*metapb.StoreLabel) error {
 	c, err := h.GetRaftCluster()
@@ -894,4 +904,11 @@ func (h *Handler) PluginUnload(pluginPath string) error {
 // GetAddr returns the server urls for clients.
 func (h *Handler) GetAddr() string {
 	return h.s.GetAddr()
+}
+
+// SetStoreLimitTTL set storeLimit with ttl
+func (h *Handler) SetStoreLimitTTL(data string, value float64, ttl time.Duration) {
+	h.s.SaveTTLConfig(map[string]interface{}{
+		data: value,
+	}, ttl)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1272,3 +1272,10 @@ func (s *Server) ReplicateFileToAllMembers(ctx context.Context, name string, dat
 func (s *Server) PersistFile(name string, data []byte) error {
 	return ioutil.WriteFile(filepath.Join(s.GetConfig().DataDir, name), data, 0644)
 }
+
+// SaveTTLConfig save ttl config
+func (s *Server) SaveTTLConfig(data map[string]interface{}, ttl time.Duration) {
+	for k, v := range data {
+		s.persistOptions.SetTTLData(s.ctx, k, v, ttl)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

1. Provide a temporary API to support temporary configuration for some configurations.

2. Make `/store/{id}/limit` and `/stores/limit` support ttl param.  

**Note that this API is only supported for lightning and BR as a temporary way. Don't call this API.**

As the temporary configuration only is saved in the memory, a recommended way to use API is calling it with short interval (once a minute) and long ttl (10 minutes).


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
