### PR TITLE
config: fix goroutine leak risk

### DIFF
--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -35,6 +35,7 @@ import (
 type PersistOptions struct {
 	// configuration -> ttl value
 	ttl             map[string]*cache.TTLString
+	ttlCancel       map[string]context.CancelFunc
 	schedule        atomic.Value
 	replication     atomic.Value
 	pdServerConfig  atomic.Value
@@ -53,6 +54,7 @@ func NewPersistOptions(cfg *Config) *PersistOptions {
 	o.labelProperty.Store(cfg.LabelProperty)
 	o.SetClusterVersion(&cfg.ClusterVersion)
 	o.ttl = make(map[string]*cache.TTLString, 6)
+	o.ttlCancel = make(map[string]context.CancelFunc, 6)
 	return o
 }
 
@@ -597,12 +599,15 @@ func (o *PersistOptions) CheckLabelProperty(typ string, labels []*metapb.StoreLa
 }
 
 // SetTTLData set temporary configuration
-func (o *PersistOptions) SetTTLData(ctx context.Context, key string, value interface{}, ttl time.Duration) {
+func (o *PersistOptions) SetTTLData(parCtx context.Context, key string, value interface{}, ttl time.Duration) {
 	if data, ok := o.ttl[key]; ok {
 		data.Clear()
+		o.ttlCancel[key]()
 	}
+	ctx, cancel := context.WithCancel(parCtx)
 	o.ttl[key] = cache.NewStringTTL(ctx, 5*time.Second, ttl)
 	o.ttl[key].Put(key, value)
+	o.ttlCancel[key] = cancel
 }
 
 func (o *PersistOptions) getTTLData(key string) (interface{}, bool) {


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?


The `SetTTLData` may have goroutine leak as `NewStringTTL` would create an extra goroutine to do the gc work. When updating an existed key, we need to call the cancel function to close the extra goroutine.
```golang
// SetTTLData set temporary configuration
func (o *PersistOptions) SetTTLData(ctx context.Context, key string, value interface{}, ttl time.Duration) {
	if data, ok := o.ttl[key]; ok {
		data.Clear()
                // the goroutine would leak here
	}
	o.ttl[key] = cache.NewStringTTL(ctx, 5*time.Second, ttl)
	o.ttl[key].Put(key, value)
}
```

As the origin context is directly use the server context, this request fix it by replace a new context which is success from the server context and maintained its cancel function.



### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
