### PR TITLE
autoscaling: fix count in resource to be optional

### DIFF
--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -288,12 +288,13 @@ func getCPUByResourceType(strategy *Strategy, resourceType string) uint64 {
 }
 
 func getCountByResourceType(strategy *Strategy, resourceType string) *uint64 {
+	var zero uint64 = 0
 	for _, res := range strategy.Resources {
 		if res.ResourceType == resourceType {
 			return res.Count
 		}
 	}
-	return nil
+	return &zero
 }
 
 func getScaledGroupsByComponent(rc *cluster.RaftCluster, component ComponentType, healthyInstances []instance) ([]*Plan, error) {

--- a/pkg/autoscaling/calculation.go
+++ b/pkg/autoscaling/calculation.go
@@ -237,7 +237,7 @@ func calculateScaleOutPlan(rc *cluster.RaftCluster, strategy *Strategy, componen
 
 	// A new group created
 	if len(groups) == 0 {
-		if group.Count+scaleOutCount <= resCount {
+		if resCount == nil || group.Count+scaleOutCount <= *resCount {
 			group.Count += scaleOutCount
 			return []*Plan{&group}
 		}
@@ -246,7 +246,7 @@ func calculateScaleOutPlan(rc *cluster.RaftCluster, strategy *Strategy, componen
 
 	// update the existed group
 	for i, g := range groups {
-		if g.ResourceType == group.ResourceType && group.Count+scaleOutCount <= resCount {
+		if g.ResourceType == group.ResourceType && (resCount == nil || group.Count+scaleOutCount <= *resCount) {
 			group.Count += scaleOutCount
 			groups[i] = &group
 		}
@@ -287,13 +287,13 @@ func getCPUByResourceType(strategy *Strategy, resourceType string) uint64 {
 	return 0
 }
 
-func getCountByResourceType(strategy *Strategy, resourceType string) uint64 {
+func getCountByResourceType(strategy *Strategy, resourceType string) *uint64 {
 	for _, res := range strategy.Resources {
 		if res.ResourceType == resourceType {
 			return res.Count
 		}
 	}
-	return 0
+	return nil
 }
 
 func getScaledGroupsByComponent(rc *cluster.RaftCluster, component ComponentType, healthyInstances []instance) ([]*Plan, error) {

--- a/pkg/autoscaling/types.go
+++ b/pkg/autoscaling/types.go
@@ -57,8 +57,8 @@ type Resource struct {
 	// The basic unit of memory is byte.
 	Memory uint64 `json:"memory"`
 	// The basic unit of storage is byte.
-	Storage uint64 `json:"storage"`
-	Count   uint64 `json:"count"`
+	Storage uint64  `json:"storage"`
+	Count   *uint64 `json:"count,omitempty"`
 }
 
 // Plan is the final result of auto scaling, which indicates how to scale in or scale out.


### PR DESCRIPTION
Signed-off-by: Howard Lau <howardlau1999@hotmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

The API definition says that the `count` field in a resource is optional. It means a resource is unlimited when the field is unset.

### What is changed and how it works?

Change the type of `count` from `uint64` to `*uint64`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- No code

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note 
