### PR TITLE
*: solve the error.toml.before permission problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ default*
 /.tools/bin
 docs/swagger/*
 !docs/swagger/placeholder.go
+*.before

--- a/scripts/check-errdoc.sh
+++ b/scripts/check-errdoc.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 PingCAP, Inc.
+# Copyright 2020 TiKV Project Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ set -euo pipefail
 
 cd -P .
 
-cp errors.toml /tmp/errors.toml.before
+cp errors.toml errors.toml.before
 errdoc-gen --source . --module github.com/tikv/pd --output errors.toml
-diff -q errors.toml /tmp/errors.toml.before
+diff -q errors.toml errors.toml.before
+rm errors.toml.before


### PR DESCRIPTION
### What problem does this PR solve?

Multiple users cannot run tests due to the permission of error.toml.before.

### What is changed and how it works?

This PR changes the file path from /tmp to the current directory and remove the file after comparision.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->
- No code

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
