### PR TITLE
tso: fix the incorrect use of GetLocalAllocatorLeaders

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -68,7 +68,7 @@ func (s *Server) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb.Get
 	}
 
 	tsoAllocatorManager := s.GetTSOAllocatorManager()
-	tsoAllocatorLeaders, err := tsoAllocatorManager.GetLocalAllocatorLeadersMember()
+	tsoAllocatorLeaders, err := tsoAllocatorManager.GetLocalAllocatorLeaders()
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, err.Error())
 	}
@@ -945,7 +945,7 @@ func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) 
 		return nil, fmt.Errorf("empty cluster dc-Location found, checker may not work properly")
 	}
 	// Get all Local TSO Allocator leaders
-	allocatorLeaders, err := tsoAllocatorManager.GetLocalAllocatorLeaders()
+	allocatorLeaders, err := tsoAllocatorManager.GetHoldingLocalAllocatorLeaders()
 	if err != nil {
 		return nil, err
 	}

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -627,8 +627,8 @@ func (am *AllocatorManager) GetAllocators(filters ...AllocatorGroupFilter) []All
 	return allocators
 }
 
-// GetLocalAllocatorLeaders returns all Local TSO Allocator leaders this server holds.
-func (am *AllocatorManager) GetLocalAllocatorLeaders() ([]*LocalTSOAllocator, error) {
+// GetHoldingLocalAllocatorLeaders returns all Local TSO Allocator leaders this server holds.
+func (am *AllocatorManager) GetHoldingLocalAllocatorLeaders() ([]*LocalTSOAllocator, error) {
 	localAllocators := am.GetAllocators(
 		FilterDCLocation(config.GlobalDCLocation),
 		FilterUnavailableLeadership())
@@ -643,8 +643,8 @@ func (am *AllocatorManager) GetLocalAllocatorLeaders() ([]*LocalTSOAllocator, er
 	return localAllocatorLeaders, nil
 }
 
-// GetLocalAllocatorLeadersMember returns all Local TSO Allocator's leader member info.
-func (am *AllocatorManager) GetLocalAllocatorLeadersMember() (map[string]*pdpb.Member, error) {
+// GetLocalAllocatorLeaders returns all Local TSO Allocator leaders' member info.
+func (am *AllocatorManager) GetLocalAllocatorLeaders() (map[string]*pdpb.Member, error) {
 	localAllocators := am.GetAllocators(FilterDCLocation(config.GlobalDCLocation))
 	localAllocatorLeaderMember := make(map[string]*pdpb.Member)
 	for _, allocator := range localAllocators {

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -157,7 +157,7 @@ func (gta *GlobalTSOAllocator) syncMaxTS(ctx context.Context, dcLocationMap map[
 	maxRetryCount := 1
 	for i := 0; i < maxRetryCount; i++ {
 		// Collect all allocator leaders' client URLs
-		allocatorLeaders, err := gta.allocatorManager.GetLocalAllocatorLeadersMember()
+		allocatorLeaders, err := gta.allocatorManager.GetLocalAllocatorLeaders()
 		if err != nil {
 			return err
 		}

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -157,17 +157,17 @@ func (gta *GlobalTSOAllocator) syncMaxTS(ctx context.Context, dcLocationMap map[
 	maxRetryCount := 1
 	for i := 0; i < maxRetryCount; i++ {
 		// Collect all allocator leaders' client URLs
-		allocatorLeaders, err := gta.allocatorManager.GetLocalAllocatorLeaders()
+		allocatorLeaders, err := gta.allocatorManager.GetLocalAllocatorLeadersMember()
 		if err != nil {
 			return err
 		}
 		leaderURLs := make([]string, 0, len(allocatorLeaders))
 		for _, allocator := range allocatorLeaders {
 			// Check if its client URLs are empty
-			if len(allocator.GetMember().GetClientUrls()) < 1 {
+			if len(allocator.GetClientUrls()) < 1 {
 				continue
 			}
-			leaderURL := allocator.GetMember().GetClientUrls()[0]
+			leaderURL := allocator.GetClientUrls()[0]
 			if slice.NoneOf(leaderURLs, func(i int) bool { return leaderURLs[i] == leaderURL }) {
 				leaderURLs = append(leaderURLs, leaderURL)
 			}


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

`GetLocalAllocatorLeaders` can only get all the Local TSO Allocator leaders that the current server holds. But the Global TSO generation needs PD to know all Local TSO Allocator leaders in the cluster. 

### What is changed and how it works?

* Replace the `GetLocalAllocatorLeaders` with `GetAllLocalAllocatorLeaders`.
* Refine the method names.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
