### PR TITLE
tso: do not fail the Global TSO sync when update memory

### DIFF
--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -142,7 +142,7 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 	if tsoutil.CompareTimestamp(&currentGlobalTSO, maxTSO) < 0 {
 		// Update the global TSO in memory
 		if err := gta.SetTSO(tsoutil.GenerateTS(maxTSO)); err != nil {
-			return pdpb.Timestamp{}, err
+			log.Warn("update the global tso in memory failed", errs.ZapError(err))
 		}
 	}
 	return *maxTSO, nil


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Before returning the `maxTSO` as the result, we need to update the Global TSO in memory even in etcd to make it persistent, but because the setting process is not atomic completely, the TSO in memory may be greater after we call `ResetUserTimestamp` then failed the whole synchronization, which will reduce the success rate of obtaining the Global TSO.

### What is changed and how it works?

Actually, it's ok to let `SetTSO` fail when we update the Global TSO in memory. To make it not fail the Global TSO sync when update memory, I replace the err returning with a warning log.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
