### PR TITLE
tso: refine the Global TSO synchronization algorithm

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -317,7 +317,7 @@ func adjustFloat64(v *float64, defValue float64) {
 }
 
 func adjustDuration(v *typeutil.Duration, defValue time.Duration) {
-	if v.Duration == 0 {
+	if v.Duration <= 0 {
 		v.Duration = defValue
 	}
 }

--- a/server/tso/local_allocator.go
+++ b/server/tso/local_allocator.go
@@ -93,7 +93,7 @@ func (lta *LocalTSOAllocator) UpdateTSO() error {
 
 // SetTSO sets the physical part with given TSO.
 func (lta *LocalTSOAllocator) SetTSO(tso uint64) error {
-	return lta.timestampOracle.ResetUserTimestamp(lta.leadership, tso)
+	return lta.timestampOracle.resetUserTimestamp(lta.leadership, tso, false)
 }
 
 // GenerateTSO is used to generate a given number of TSOs.
@@ -151,7 +151,7 @@ func (lta *LocalTSOAllocator) WriteTSO(maxTS *pdpb.Timestamp) error {
 	if tsoutil.CompareTimestamp(&currentTSO, maxTS) >= 0 {
 		return nil
 	}
-	return lta.SetTSO(tsoutil.GenerateTS(maxTS))
+	return lta.timestampOracle.resetUserTimestamp(lta.leadership, tsoutil.GenerateTS(maxTS), true)
 }
 
 // EnableAllocatorLeader sets the Local TSO Allocator itself to a leader.


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close #3126, close #3127, close #3161.

This PR basically refines the Global TSO synchronization algorithm from two parts.

* Make the `resetUserTimestamp` method atomically set the TSO in memory.
* Allow the `resetUserTimestamp` method to ignore and skip the smaller TSO error check.
* Make the `syncMaxTS` method handle the gRPC response more precisely.

### What is changed and how it works?

* Rewrite the `resetUserTimestamp` method.
* Update the `syncMaxTS` method.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
