### PR TITLE
server: Fix the bug that infinite TTL for service safepoint doesn't work

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -829,6 +830,9 @@ func (s *Server) UpdateServiceGCSafePoint(ctx context.Context, request *pdpb.Upd
 			ServiceID: string(request.ServiceId),
 			ExpiredAt: now.Unix() + request.TTL,
 			SafePoint: request.SafePoint,
+		}
+		if request.TTL == math.MaxInt64 {
+			ssp.ExpiredAt = math.MaxInt64
 		}
 		if err := s.storage.SaveServiceGCSafePoint(ssp); err != nil {
 			return nil, err

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -827,8 +827,17 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.ServiceID, Equals, "c")
-	c.Assert(oldMinSsp.SafePoint, Equals, uint64(3))
 	c.Assert(minSsp.ExpiredAt, Less, oldMinSsp.ExpiredAt)
+
+	// TTL can be infinite
+	min, err = s.client.UpdateServiceGCSafePoint(context.Background(),
+		"c", math.MaxInt64, 3)
+	c.Assert(err, IsNil)
+	c.Assert(min, Equals, uint64(3))
+	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	c.Assert(err, IsNil)
+	c.Assert(minSsp.ServiceID, Equals, "c")
+	c.Assert(minSsp.ExpiredAt, Equals, int64(math.MaxInt64))
 }
 
 func (s *testClientSuite) TestScatterRegion(c *C) {


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

Fix infinite TTL doesn't work

Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Fixes #3128 

### What is changed and how it works?

In the original code the expire time of service safepoints are calculated by `time.Unit() + TTL`, and we use MaxInt64 to represent infinite TTL. Then it overflows to a minus value and expires immediately. This PR fixes the issue.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- 

Side effects

- 

Related changes

- Need to cherry-pick to the release branch
  - release-4.0

### Release note

* Fix a bug that service safe points with  infinite TTL may disappear.