### PR TITLE
metrics: replace histogram with gauge in patrol region

### DIFF
--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -157,7 +157,7 @@ func (c *coordinator) patrolRegions() {
 		// Updates the label level isolation statistics.
 		c.cluster.updateRegionsLabelLevelStats(regions)
 		if len(key) == 0 {
-			patrolCheckRegionsHistogram.Observe(time.Since(start).Seconds())
+			patrolCheckRegionsGauge.Set(time.Since(start).Seconds())
 			start = time.Now()
 		}
 	}

--- a/server/cluster/metrics.go
+++ b/server/cluster/metrics.go
@@ -51,8 +51,8 @@ var (
 	patrolCheckRegionsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
-			Subsystem: "patrol",
-			Name:      "checks_regions",
+			Subsystem: "checker",
+			Name:      "patrol_regions_time",
 			Help:      "Time spent of patrol checks region.",
 		})
 

--- a/server/cluster/metrics.go
+++ b/server/cluster/metrics.go
@@ -48,13 +48,12 @@ var (
 			Help:      "Status of the hotspot.",
 		}, []string{"address", "store", "type"})
 
-	patrolCheckRegionsHistogram = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
+	patrolCheckRegionsGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Namespace: "pd",
 			Subsystem: "patrol",
 			Name:      "checks_regions",
-			Help:      "Bucketed histogram of time spend(s) of patrol checks region.",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 15),
+			Help:      "Time spent of patrol checks region.",
 		})
 
 	clusterStateCPUGauge = prometheus.NewGauge(
@@ -78,7 +77,7 @@ func init() {
 	prometheus.MustRegister(healthStatusGauge)
 	prometheus.MustRegister(schedulerStatusGauge)
 	prometheus.MustRegister(hotSpotStatusGauge)
-	prometheus.MustRegister(patrolCheckRegionsHistogram)
+	prometheus.MustRegister(patrolCheckRegionsGauge)
 	prometheus.MustRegister(clusterStateCPUGauge)
 	prometheus.MustRegister(clusterStateCurrent)
 }


### PR DESCRIPTION
### What problem does this PR solve?

We only need to record the latest time spent on patrol regions. No need to use histogram.

### What is changed and how it works?

This PR replaces histogram with gauge in patrol region.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
