### PR TITLE
operator: fix data race

### DIFF
--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -700,8 +700,6 @@ func (b *Builder) execChangePeerV2(needEnter bool, needTransferLeader bool) {
 	b.steps = append(b.steps, ChangePeerV2Leave(step))
 }
 
-var stateFilter = &filter.StoreStateFilter{ActionScope: "operator-builder", TransferLeader: true}
-
 // check if the peer is allowed to become the leader.
 func (b *Builder) allowLeader(peer *metapb.Peer, ignoreClusterLimit bool) bool {
 	// these peer roles are not allowed to become leader.
@@ -723,6 +721,7 @@ func (b *Builder) allowLeader(peer *metapb.Peer, ignoreClusterLimit bool) bool {
 		return true
 	}
 
+	stateFilter := &filter.StoreStateFilter{ActionScope: "operator-builder", TransferLeader: true}
 	// store state filter
 	if !stateFilter.Target(b.cluster.GetOpts(), store) {
 		return false


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/pd_test/detail/pd_test/12810/pipeline

```
 WARNING: DATA RACE

[2020-11-04T08:01:36.332Z] Write at 0x0000028a9638 by goroutine 146:

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/filter.(*StoreStateFilter).isTombstone-fm()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/filter/filters.go:250 +0x55

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/filter.(*StoreStateFilter).anyConditionMatch()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/filter/filters.go:343 +0x1a5

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/filter.(*StoreStateFilter).Target()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/filter/filters.go:365 +0x104

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).allowLeader()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:727 +0x1a3

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).planReplaceLeaders()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:854 +0x3ff

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).planReplace()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:811 +0x5f7

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).peerPlan()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:777 +0x6e

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).buildStepsWithoutJointConsensus()

[2020-11-04T08:01:36.332Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:590 +0xf0

[2020-11-04T08:01:36.332Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).Build()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:328 +0x3a8

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/operator.CreateMovePeerOperator()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/create_operator.go:85 +0xcd

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedulers.(*balanceRegionScheduler).transferPeer()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedulers/balance_region.go:229 +0xe2b

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedulers.(*balanceRegionScheduler).Schedule()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedulers/balance_region.go:184 +0x11fc

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*scheduleController).Schedule()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:740 +0xe4

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*coordinator).runScheduler()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:691 +0x411

[2020-11-04T08:01:36.333Z] 

[2020-11-04T08:01:36.333Z] Previous write at 0x0000028a9638 by goroutine 240:

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/filter.(*StoreStateFilter).isTombstone-fm()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/filter/filters.go:250 +0x55

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/filter.(*StoreStateFilter).anyConditionMatch()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/filter/filters.go:343 +0x1a5

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/filter.(*StoreStateFilter).Target()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/filter/filters.go:365 +0x104

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).allowLeader()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:727 +0x1a3

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).prepareBuild()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:421 +0x13e3

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/operator.(*Builder).Build()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/builder.go:321 +0x7a

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedule/operator.CreateTransferLeaderOperator()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedule/operator/create_operator.go:55 +0xb2

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedulers.(*balanceLeaderScheduler).createOperator()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedulers/balance_leader.go:283 +0x799

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedulers.(*balanceLeaderScheduler).transferLeaderOut()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedulers/balance_leader.go:214 +0x520

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/schedulers.(*balanceLeaderScheduler).Schedule()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/schedulers/balance_leader.go:163 +0x158a

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*scheduleController).Schedule()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:740 +0xe4

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*coordinator).runScheduler()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:691 +0x411

[2020-11-04T08:01:36.333Z] 

[2020-11-04T08:01:36.333Z] Goroutine 146 (running) created at:

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*coordinator).addScheduler()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:549 +0x47f

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*coordinator).run()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:300 +0x204e

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*testCoordinatorSuite).TestDispatch()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator_test.go:208 +0x811

[2020-11-04T08:01:36.333Z]   runtime.call32()

[2020-11-04T08:01:36.333Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a

[2020-11-04T08:01:36.333Z]   reflect.Value.Call()

[2020-11-04T08:01:36.333Z]       /usr/local/go/src/reflect/value.go:321 +0xd3

[2020-11-04T08:01:36.333Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:850 +0x9aa

[2020-11-04T08:01:36.333Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:739 +0x113

[2020-11-04T08:01:36.333Z] 

[2020-11-04T08:01:36.333Z] Goroutine 240 (running) created at:

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*coordinator).addScheduler()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:549 +0x47f

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*coordinator).run()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator.go:300 +0x204e

[2020-11-04T08:01:36.333Z]   github.com/tikv/pd/server/cluster.(*testCoordinatorSuite).TestDispatch()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/src/github.com/pingcap/pd/server/cluster/coordinator_test.go:208 +0x811

[2020-11-04T08:01:36.333Z]   runtime.call32()

[2020-11-04T08:01:36.333Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a

[2020-11-04T08:01:36.333Z]   reflect.Value.Call()

[2020-11-04T08:01:36.333Z]       /usr/local/go/src/reflect/value.go:321 +0xd3

[2020-11-04T08:01:36.333Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:850 +0x9aa

[2020-11-04T08:01:36.333Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()

[2020-11-04T08:01:36.333Z]       /home/jenkins/agent/workspace/pd_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:739 +0x113

[2020-11-04T08:01:36.333Z] ==================
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
