### PR TITLE
build: use the new env setting method in github action

### DIFF
--- a/.github/workflows/check-dashboard.yaml
+++ b/.github/workflows/check-dashboard.yaml
@@ -33,8 +33,8 @@ jobs:
           go mod download
           DASHBOARD_DIR=$(go list -f "{{.Dir}}" -m github.com/pingcap-incubator/tidb-dashboard)
           DASHBOARD_RELEASE_VERSION=$(grep -v '^#' "${DASHBOARD_DIR}/release-version")
-          echo ::set-env name=DASHBOARD_DIR::"$DASHBOARD_DIR"
-          echo ::set-env name=DASHBOARD_RELEASE_VERSION::"$DASHBOARD_RELEASE_VERSION"
+          echo DASHBOARD_DIR="$DASHBOARD_DIR" >> $GITHUB_ENV
+          echo DASHBOARD_RELEASE_VERSION="$DASHBOARD_RELEASE_VERSION" >> $GITHUB_ENV
       - name: Fetch UI source specified by release version
         run: |
           rm -rf /tmp/dashboard

--- a/.github/workflows/check-dashboard.yaml
+++ b/.github/workflows/check-dashboard.yaml
@@ -2,11 +2,13 @@ on:
   push:
     branches:
       - master
+      - release-4.0
     paths:
       - "go.mod"
   pull_request:
     branches:
       - master
+      - release-4.0
     paths:
       - "go.mod"
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/tikv/pd
 
-go 1.13
-
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
@@ -51,6 +49,8 @@ require (
 	google.golang.org/grpc v1.26.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
+
+go 1.13
 
 replace (
 	github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/tikv/pd
 
+go 1.13
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
@@ -49,8 +51,6 @@ require (
 	google.golang.org/grpc v1.26.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
-
-go 1.13
 
 replace (
 	github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.2.0


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

* Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

### What is changed and how it works?

* build: use the new env setting method in github action

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- No code

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
