### PR TITLE
movingaverage: add max filter

### DIFF
--- a/pkg/movingaverage/max_filter.go
+++ b/pkg/movingaverage/max_filter.go
@@ -1,0 +1,62 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package movingaverage
+
+import "github.com/montanaflynn/stats"
+
+// MaxFilter works as a maximum filter with specified window size.
+// There are at most `size` data points for calculating.
+type MaxFilter struct {
+	records []float64
+	size    uint64
+	count   uint64
+}
+
+// NewMaxFilter returns a MaxFilter.
+func NewMaxFilter(size int) *MaxFilter {
+	return &MaxFilter{
+		records: make([]float64, size),
+		size:    uint64(size),
+	}
+}
+
+// Add adds a data point.
+func (r *MaxFilter) Add(n float64) {
+	r.records[r.count%r.size] = n
+	r.count++
+}
+
+// Get returns the maximum of the data set.
+func (r *MaxFilter) Get() float64 {
+	if r.count == 0 {
+		return 0
+	}
+	records := r.records
+	if r.count < r.size {
+		records = r.records[:r.count]
+	}
+	max, _ := stats.Max(records)
+	return max
+}
+
+// Reset cleans the data set.
+func (r *MaxFilter) Reset() {
+	r.count = 0
+}
+
+// Set = Reset + Add.
+func (r *MaxFilter) Set(n float64) {
+	r.records[0] = n
+	r.count = 1
+}

--- a/pkg/movingaverage/max_filter_test.go
+++ b/pkg/movingaverage/max_filter_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package movingaverage
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testMaxFilter{})
+
+type testMaxFilter struct{}
+
+func (t *testMaxFilter) TestMaxFilter(c *C) {
+	var empty float64 = 0
+	data := []float64{2, 1, 3, 4, 1, 1, 3, 3, 2, 0, 5}
+	expected := []float64{2, 2, 3, 4, 4, 4, 4, 4, 3, 3, 5}
+
+	mf := NewMaxFilter(5)
+	c.Assert(mf.Get(), Equals, empty)
+
+	checkReset(c, mf, empty)
+	checkAdd(c, mf, data, expected)
+	checkSet(c, mf, data, expected)
+}

--- a/pkg/movingaverage/max_filter_test.go
+++ b/pkg/movingaverage/max_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 TiKV Project Authors.
+// Copyright 2020 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/movingaverage/median_filter_test.go
+++ b/pkg/movingaverage/median_filter_test.go
@@ -38,14 +38,14 @@ func addRandData(ma MovingAvg, n int, mx float64) {
 
 // checkReset checks the Reset works properly.
 // emptyValue is the moving average of empty data set.
-func (t *testMovingAvg) checkReset(c *C, ma MovingAvg, emptyValue float64) {
+func checkReset(c *C, ma MovingAvg, emptyValue float64) {
 	addRandData(ma, 100, 1000)
 	ma.Reset()
 	c.Assert(ma.Get(), Equals, emptyValue)
 }
 
 // checkAddGet checks Add works properly.
-func (t *testMovingAvg) checkAdd(c *C, ma MovingAvg, data []float64, expected []float64) {
+func checkAdd(c *C, ma MovingAvg, data []float64, expected []float64) {
 	c.Assert(len(data), Equals, len(expected))
 	for i, x := range data {
 		ma.Add(x)
@@ -54,19 +54,19 @@ func (t *testMovingAvg) checkAdd(c *C, ma MovingAvg, data []float64, expected []
 }
 
 // checkSet checks Set = Reset + Add
-func (t *testMovingAvg) checkSet(c *C, ma MovingAvg, data []float64, expected []float64) {
+func checkSet(c *C, ma MovingAvg, data []float64, expected []float64) {
 	c.Assert(len(data), Equals, len(expected))
 
 	// Reset + Add
 	addRandData(ma, 100, 1000)
 	ma.Reset()
-	t.checkAdd(c, ma, data, expected)
+	checkAdd(c, ma, data, expected)
 
 	// Set
 	addRandData(ma, 100, 1000)
 	ma.Set(data[0])
 	c.Assert(ma.Get(), Equals, expected[0])
-	t.checkAdd(c, ma, data[1:], expected[1:])
+	checkAdd(c, ma, data[1:], expected[1:])
 }
 
 func (t *testMovingAvg) TestMedianFilter(c *C) {
@@ -77,7 +77,7 @@ func (t *testMovingAvg) TestMedianFilter(c *C) {
 	mf := NewMedianFilter(5)
 	c.Assert(mf.Get(), Equals, empty)
 
-	t.checkReset(c, mf, empty)
-	t.checkAdd(c, mf, data, expected)
-	t.checkSet(c, mf, data, expected)
+	checkReset(c, mf, empty)
+	checkAdd(c, mf, data, expected)
+	checkSet(c, mf, data, expected)
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What is changed and how it works?
Add `MaxFilter` that returns the maximum value in a past time window.

### Check List
- Unit test

### Release note
- No release note
