### PR TITLE
check cluster version on store tombstone

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1042,7 +1042,6 @@ func (c *RaftCluster) BuryStore(storeID uint64, force bool) error {
 
 	// Bury a tombstone store should be OK, nothing to do.
 	if store.IsTombstone() {
-		c.onStoreVersionChangeLocked()
 		return nil
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1042,6 +1042,7 @@ func (c *RaftCluster) BuryStore(storeID uint64, force bool) error {
 
 	// Bury a tombstone store should be OK, nothing to do.
 	if store.IsTombstone() {
+		c.onStoreVersionChangeLocked()
 		return nil
 	}
 
@@ -1057,6 +1058,7 @@ func (c *RaftCluster) BuryStore(storeID uint64, force bool) error {
 		zap.Uint64("store-id", newStore.GetID()),
 		zap.String("store-address", newStore.GetAddress()))
 	err := c.putStoreLocked(newStore)
+	c.onStoreVersionChangeLocked()
 	if err == nil {
 		c.RemoveStoreLimit(storeID)
 	}
@@ -1312,6 +1314,10 @@ func (c *RaftCluster) AllocID() (uint64, error) {
 func (c *RaftCluster) OnStoreVersionChange() {
 	c.RLock()
 	defer c.RUnlock()
+	c.onStoreVersionChangeLocked()
+}
+
+func (c *RaftCluster) onStoreVersionChangeLocked() {
 	var minVersion *semver.Version
 	stores := c.GetStores()
 	for _, s := range stores {

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -168,45 +168,6 @@ func (s *clusterTestSuite) TestGetPutConfig(c *C) {
 	c.Assert(meta.GetMaxPeerCount(), Equals, uint32(5))
 }
 
-func (s *clusterTestSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {
-	tc, err := tests.NewTestCluster(s.ctx, 1)
-	defer tc.Destroy()
-	c.Assert(err, IsNil)
-
-	err = tc.RunInitialServers()
-	c.Assert(err, IsNil)
-
-	tc.WaitLeader()
-	leaderServer := tc.GetServer(tc.GetLeader())
-	grpcPDClient := testutil.MustNewGrpcClient(c, leaderServer.GetAddr())
-	clusterID := leaderServer.GetClusterID()
-	bootstrapCluster(c, clusterID, grpcPDClient, "127.0.0.1:1", "4.0.9")
-	rc := leaderServer.GetRaftCluster()
-	c.Assert(rc, NotNil)
-
-	// Put 2 new stores.
-	for _, id := range []uint64{2, 3} {
-		addr := fmt.Sprintf("127.0.0.1:%d", id)
-		store := newMetaStore(id, addr, "4.0.9", metapb.StoreState_Up, fmt.Sprintf("test/store%d", id))
-		_, err = putStore(c, grpcPDClient, clusterID, store)
-		c.Assert(err, IsNil)
-	}
-	c.Assert(rc.GetClusterVersion(), Equals, "4.0.9")
-
-	// Upgrade 2 stores to 5.0.0.
-	for _, id := range []uint64{2, 3} {
-		addr := fmt.Sprintf("127.0.0.1:%d", id)
-		store := newMetaStore(id, addr, "5.0.0", metapb.StoreState_Up, fmt.Sprintf("test/store%d", id))
-		_, err = putStore(c, grpcPDClient, clusterID, store)
-		c.Assert(err, IsNil)
-	}
-	c.Assert(rc.GetClusterVersion(), Equals, "4.0.9")
-
-	// Delete the other store.
-	rc.BuryStore(1, true)
-	c.Assert(rc.GetClusterVersion(), Equals, "5.0.0")
-}
-
 func testPutStore(c *C, clusterID uint64, rc *cluster.RaftCluster, grpcPDClient pdpb.PDClient, store *metapb.Store) {
 	// Update store.
 	_, err := putStore(c, grpcPDClient, clusterID, store)
@@ -844,23 +805,19 @@ func newIsBootstrapRequest(clusterID uint64) *pdpb.IsBootstrappedRequest {
 	return req
 }
 
-func newBootstrapRequest(c *C, clusterID uint64, storeAddr string, storeVersion ...string) *pdpb.BootstrapRequest {
+func newBootstrapRequest(c *C, clusterID uint64, storeAddr string) *pdpb.BootstrapRequest {
 	req := &pdpb.BootstrapRequest{
 		Header: testutil.NewRequestHeader(clusterID),
 		Store:  &metapb.Store{Id: 1, Address: storeAddr},
 		Region: &metapb.Region{Id: 2, Peers: []*metapb.Peer{{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter}}},
 	}
 
-	if len(storeVersion) != 0 {
-		req.Store.Version = storeVersion[0]
-	}
-
 	return req
 }
 
 // helper function to check and bootstrap.
-func bootstrapCluster(c *C, clusterID uint64, grpcPDClient pdpb.PDClient, storeAddr string, storeVersion ...string) {
-	req := newBootstrapRequest(c, clusterID, storeAddr, storeVersion...)
+func bootstrapCluster(c *C, clusterID uint64, grpcPDClient pdpb.PDClient, storeAddr string) {
+	req := newBootstrapRequest(c, clusterID, storeAddr)
 	_, err := grpcPDClient.Bootstrap(context.Background(), req)
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?
Check and update cluster version on a store becomes tombstone.

Tests

- Unit test

Code changes

Side effects

Related changes

### Release note

* check cluster version on stores become tombstone
