### PR TITLE
server: check the store version when changing tombstone status

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1625,7 +1625,12 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]config.StoreLimitConfig {
 
 // AddStoreLimit add a store limit for a given store ID.
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
+	storeID := store.GetId()
 	cfg := c.opt.GetScheduleConfig().Clone()
+	if _, ok := cfg.StoreLimit[storeID]; ok {
+		return
+	}
+
 	sc := config.StoreLimitConfig{
 		AddPeer:    config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
 		RemovePeer: config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
@@ -1636,7 +1641,7 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 			RemovePeer: config.DefaultTiFlashStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
 		}
 	}
-	storeID := store.GetId()
+
 	cfg.StoreLimit[storeID] = sc
 	c.opt.SetScheduleConfig(cfg)
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -297,7 +297,7 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 		zap.Duration("cost", time.Since(start)),
 	)
 	for _, store := range c.GetStores() {
-		c.storesStats.CreateRollingStoreStats(store.GetID())
+		c.storesStats.GetOrCreateRollingStoreStats(store.GetID())
 	}
 	return c, nil
 }
@@ -1148,7 +1148,7 @@ func (c *RaftCluster) putStoreLocked(store *core.StoreInfo) error {
 		}
 	}
 	c.core.PutStore(store)
-	c.storesStats.CreateRollingStoreStats(store.GetID())
+	c.storesStats.GetOrCreateRollingStoreStats(store.GetID())
 	return nil
 }
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -50,7 +50,7 @@ func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	n, np := uint64(3), uint64(3)
-	stores := newTestStores(n)
+	stores := newTestStores(n, "2.0.0")
 	storeMetasAfterHeartbeat := make([]*metapb.Store, 0, n)
 	regions := newTestRegions(n, np)
 
@@ -98,7 +98,7 @@ func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 	c.Assert(err, IsNil)
 	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
-	stores := newTestStores(3)
+	stores := newTestStores(3, "2.0.0")
 	for _, store := range stores {
 		storeStats := &pdpb.StoreStats{
 			StoreId:     store.GetID(),
@@ -132,7 +132,7 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 
 	n, np := uint64(3), uint64(3)
 
-	stores := newTestStores(3)
+	stores := newTestStores(3, "2.0.0")
 	regions := newTestRegions(n, np)
 
 	for _, store := range stores {
@@ -514,7 +514,7 @@ func (s *testClusterInfoSuite) TestUpdateStorePendingPeerCount(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	tc := newTestCluster(opt)
-	stores := newTestStores(5)
+	stores := newTestStores(5, "2.0.0")
 	for _, s := range stores {
 		c.Assert(tc.putStoreLocked(s), IsNil)
 	}
@@ -551,7 +551,7 @@ type testStoresInfoSuite struct{}
 func (s *testStoresInfoSuite) TestStores(c *C) {
 	n := uint64(10)
 	cache := core.NewStoresInfo()
-	stores := newTestStores(n)
+	stores := newTestStores(n, "2.0.0")
 
 	for i, store := range stores {
 		id := store.GetID()
@@ -700,7 +700,7 @@ func (s *testGetStoresSuite) SetUpSuite(c *C) {
 	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	s.cluster = cluster
 
-	stores := newTestStores(200)
+	stores := newTestStores(200, "2.0.0")
 
 	for _, store := range stores {
 		c.Assert(s.cluster.putStoreLocked(store), IsNil)
@@ -750,11 +750,15 @@ func newTestRaftCluster(id id.Allocator, opt *config.PersistOptions, storage *co
 }
 
 // Create n stores (0..n).
-func newTestStores(n uint64) []*core.StoreInfo {
+func newTestStores(n uint64, version string) []*core.StoreInfo {
 	stores := make([]*core.StoreInfo, 0, n)
 	for i := uint64(1); i <= n; i++ {
 		store := &metapb.Store{
-			Id: i,
+			Id:         i,
+			Address:    fmt.Sprintf("127.0.0.1:%d", i),
+			State:      metapb.StoreState_Up,
+			Version:    version,
+			DeployPath: fmt.Sprintf("test/store%d", i),
 		}
 		stores = append(stores, core.NewStoreInfo(store))
 	}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -242,14 +242,12 @@ func (s *Server) PutStore(ctx context.Context, request *pdpb.PutStoreRequest) (*
 		return nil, status.Errorf(codes.FailedPrecondition, "placement rules is disabled")
 	}
 
-	if err := rc.PutStore(store, false); err != nil {
+	if err := rc.PutStore(store); err != nil {
 		return nil, status.Errorf(codes.Unknown, err.Error())
 	}
 
 	log.Info("put store ok", zap.Stringer("store", store))
-	rc.OnStoreVersionChange()
 	CheckPDVersion(s.persistOptions)
-	rc.AddStoreLimit(store)
 
 	return &pdpb.PutStoreResponse{
 		Header:            s.header(),

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -45,7 +45,9 @@ func NewStoresStats() *StoresStats {
 func (s *StoresStats) CreateRollingStoreStats(storeID uint64) {
 	s.Lock()
 	defer s.Unlock()
-	s.rollingStoresStats[storeID] = newRollingStoreStats()
+	if _, ok := s.rollingStoresStats[storeID]; !ok {
+		s.rollingStoresStats[storeID] = newRollingStoreStats()
+	}
 }
 
 // RemoveRollingStoreStats removes RollingStoreStats with a given store ID.

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -41,15 +41,6 @@ func NewStoresStats() *StoresStats {
 	}
 }
 
-// CreateRollingStoreStats creates RollingStoreStats with a given store ID.
-func (s *StoresStats) CreateRollingStoreStats(storeID uint64) {
-	s.Lock()
-	defer s.Unlock()
-	if _, ok := s.rollingStoresStats[storeID]; !ok {
-		s.rollingStoresStats[storeID] = newRollingStoreStats()
-	}
-}
-
 // RemoveRollingStoreStats removes RollingStoreStats with a given store ID.
 func (s *StoresStats) RemoveRollingStoreStats(storeID uint64) {
 	s.Lock()

--- a/server/statistics/store_collection_test.go
+++ b/server/statistics/store_collection_test.go
@@ -47,7 +47,7 @@ func (t *testStoreStatisticsSuite) TestStoreStatistics(c *C) {
 	stores := make([]*core.StoreInfo, 0, len(metaStores))
 	for _, m := range metaStores {
 		s := core.NewStoreInfo(m, core.SetLastHeartbeatTS(time.Now()))
-		storesStats.CreateRollingStoreStats(m.GetId())
+		storesStats.GetOrCreateRollingStoreStats(m.GetId())
 		stores = append(stores, s)
 	}
 

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -367,7 +367,7 @@ func (s *clusterTestSuite) TestRaftClusterMultipleRestart(c *C) {
 	store := newMetaStore(storeID, "127.0.0.1:4", "2.1.0", metapb.StoreState_Offline, fmt.Sprintf("test/store%d", storeID))
 	rc := leaderServer.GetRaftCluster()
 	c.Assert(rc, NotNil)
-	err = rc.PutStore(store, false)
+	err = rc.PutStore(store)
 	c.Assert(err, IsNil)
 	c.Assert(tc, NotNil)
 


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

* When changing a `Tombstone` store to `Up` or `Offline`, if the `cluster-version` has been upgraded at this time, the operation should fail.

### What is changed and how it works?

* The store of lower version is no longer allowed to change from `Tombstone` back to `Up`.
* Fix the bug that restarting the store will cause store-limit and statistics to be reset.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- The store of lower version is no longer allowed to change from `Tombstone` back to `Up`.
- Fix the bug that restarting the store will cause store-limit and statistics to be reset.
