### PR TITLE
tools: fix tso bench cannot exit

### DIFF
--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -118,7 +118,13 @@ func bench(mainCtx context.Context) {
 	wg.Add(1)
 	go showStats(ctx, durCh)
 
-	time.Sleep(*duration)
+	timer := time.NewTimer(*duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
 	cancel()
 
 	wg.Wait()


### PR DESCRIPTION
### What problem does this PR solve?

After running tso-bench, Ctrl-C cannot exit.

### What is changed and how it works?

Use a timer to check if the test exceeds the time.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
