### PR TITLE
Fix "Got too many pings" GRPC error in sync region client-side

### DIFF
--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -72,9 +72,8 @@ func (s *RegionSyncer) establish(addr string) (*grpc.ClientConn, error) {
 		tlsCfg,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(msgSize)),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                keepaliveTime,
-			Timeout:             keepaliveTimeout,
-			PermitWithoutStream: true,
+			Time:    keepaliveTime,
+			Timeout: keepaliveTimeout,
 		}),
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: backoff.Config{


### PR DESCRIPTION
Signed-off-by: Xintao <hunterlxt@live.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

fix "Got too many pings" GRPC error in sync region client. We should ensure that the grpc parameters are consistent on the client and server sides. Etcd server cannot set `PermitWithoutStream` so it's false by default.

close https://github.com/tikv/pd/issues/3230

### What is changed and how it works?

make `PermitWithoutStream` false in region_syncer client.

### Check List

<!-- Remove the items that are not applicable. -->

Related changes

- Need to cherry-pick to the release branch

### Release note

- Fix "Got too many pings" GRPC error in sync region client-side
