### PR TITLE
member: delete its dc-location info while deleting a member

### DIFF
--- a/server/api/member.go
+++ b/server/api/member.go
@@ -133,8 +133,8 @@ func (h *memberHandler) DeleteByName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Delete dc-location.
-	err = h.svr.GetMember().DeleteDCLocation(id)
+	// Delete dc-location info.
+	err = h.svr.GetMember().DeleteMemberDCLocationInfo(id)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -172,8 +172,8 @@ func (h *memberHandler) DeleteByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Delete dc-location.
-	err = h.svr.GetMember().DeleteDCLocation(id)
+	// Delete dc-location info.
+	err = h.svr.GetMember().DeleteMemberDCLocationInfo(id)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -133,6 +133,13 @@ func (h *memberHandler) DeleteByName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Delete dc-location.
+	err = h.svr.GetMember().DeleteDCLocation(id)
+	if err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
 	// Remove member by id
 	_, err = etcdutil.RemoveEtcdMember(client, id)
 	if err != nil {
@@ -160,6 +167,13 @@ func (h *memberHandler) DeleteByID(w http.ResponseWriter, r *http.Request) {
 
 	// Delete config.
 	err = h.svr.GetMember().DeleteMemberLeaderPriority(id)
+	if err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Delete dc-location.
+	err = h.svr.GetMember().DeleteDCLocation(id)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -298,12 +298,14 @@ func (m *Member) getMemberLeaderPriorityPath(id uint64) string {
 	return path.Join(m.rootPath, fmt.Sprintf("member/%d/leader_priority", id))
 }
 
+// GetDCLocationPathPrefix returns the dc-location path prefix of the cluster.
 func (m *Member) GetDCLocationPathPrefix() string {
 	return path.Join(m.rootPath, dcLocationConfigEtcdPrefix)
 }
 
+// GetDCLocationPath returns the dc-location path of a member with the given member ID.
 func (m *Member) GetDCLocationPath(id uint64) string {
-	return path.Join(m.rootPath, dcLocationConfigEtcdPrefix, fmt.Sprint(id))
+	return path.Join(m.GetDCLocationPathPrefix(), fmt.Sprint(id))
 }
 
 // SetMemberLeaderPriority saves a member's priority to be elected as the etcd leader.
@@ -332,15 +334,15 @@ func (m *Member) DeleteMemberLeaderPriority(id uint64) error {
 	return nil
 }
 
-// DeleteDCLocation removes a member's dc-location.
-func (m *Member) DeleteDCLocation(id uint64) error {
+// DeleteMemberDCLocationInfo removes a member's dc-location info.
+func (m *Member) DeleteMemberDCLocationInfo(id uint64) error {
 	key := m.GetDCLocationPath(id)
 	res, err := m.leadership.LeaderTxn().Then(clientv3.OpDelete(key)).Commit()
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	if !res.Succeeded {
-		return errors.New("delete dc-location failed, maybe not pd leader")
+		return errors.New("delete dc-location info failed, maybe not pd leader")
 	}
 	return nil
 }

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -40,7 +40,8 @@ import (
 
 const (
 	// The timeout to wait transfer etcd leader to complete.
-	moveLeaderTimeout = 5 * time.Second
+	moveLeaderTimeout          = 5 * time.Second
+	dcLocationConfigEtcdPrefix = "dc-location"
 )
 
 // Member is used for the election related logic.
@@ -297,6 +298,14 @@ func (m *Member) getMemberLeaderPriorityPath(id uint64) string {
 	return path.Join(m.rootPath, fmt.Sprintf("member/%d/leader_priority", id))
 }
 
+func (m *Member) GetDCLocationPathPrefix() string {
+	return path.Join(m.rootPath, dcLocationConfigEtcdPrefix)
+}
+
+func (m *Member) GetDCLocationPath(id uint64) string {
+	return path.Join(m.rootPath, dcLocationConfigEtcdPrefix, fmt.Sprint(id))
+}
+
 // SetMemberLeaderPriority saves a member's priority to be elected as the etcd leader.
 func (m *Member) SetMemberLeaderPriority(id uint64, priority int) error {
 	key := m.getMemberLeaderPriorityPath(id)
@@ -305,7 +314,7 @@ func (m *Member) SetMemberLeaderPriority(id uint64, priority int) error {
 		return errors.WithStack(err)
 	}
 	if !res.Succeeded {
-		return errors.New("save leader priority failed, maybe not leader")
+		return errors.New("save etcd leader priority failed, maybe not pd leader")
 	}
 	return nil
 }
@@ -319,6 +328,19 @@ func (m *Member) DeleteMemberLeaderPriority(id uint64) error {
 	}
 	if !res.Succeeded {
 		return errors.New("delete etcd leader priority failed, maybe not pd leader")
+	}
+	return nil
+}
+
+// DeleteDCLocation removes a member's dc-location.
+func (m *Member) DeleteDCLocation(id uint64) error {
+	key := m.GetDCLocationPath(id)
+	res, err := m.leadership.LeaderTxn().Then(clientv3.OpDelete(key)).Commit()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !res.Succeeded {
+		return errors.New("delete dc-location failed, maybe not pd leader")
 	}
 	return nil
 }

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -40,7 +40,6 @@ import (
 const (
 	checkStep                   = 1 * time.Minute
 	patrolStep                  = 1 * time.Second
-	dcLocationConfigEtcdPrefix  = "dc-location"
 	defaultAllocatorLeaderLease = 3
 	leaderTickInterval          = 50 * time.Millisecond
 )
@@ -119,19 +118,19 @@ func NewAllocatorManager(
 // cluster know the DC-level topology for later Local TSO Allocator campaign.
 func (am *AllocatorManager) SetLocalTSOConfig(localTSOConfig config.LocalTSOConfig) error {
 	serverName := am.member.Member().Name
-	serverID := fmt.Sprint(am.member.ID())
+	serverID := am.member.ID()
 	log.Info("write dc-location into etcd",
 		zap.String("dc-location", localTSOConfig.DCLocation),
 		zap.String("server-name", serverName),
-		zap.String("server-id", serverID))
+		zap.Uint64("server-id", serverID))
 	if !localTSOConfig.EnableLocalTSO {
 		log.Info("pd server doesn't enable local tso, skip writing dc-location into etcd",
 			zap.String("server-name", serverName),
-			zap.String("server-id", serverID))
+			zap.Uint64("server-id", serverID))
 		return nil
 	}
 	// The key-value pair in etcd will be like: serverID -> dcLocation
-	dcLocationKey := path.Join(am.getLocalTSOConfigPath(), serverID)
+	dcLocationKey := am.member.GetDCLocationPath(serverID)
 	resp, err := kv.
 		NewSlowLogTxn(am.member.Client()).
 		Then(clientv3.OpPut(dcLocationKey, localTSOConfig.DCLocation)).
@@ -143,7 +142,7 @@ func (am *AllocatorManager) SetLocalTSOConfig(localTSOConfig config.LocalTSOConf
 		log.Warn("write dc-location into etcd failed",
 			zap.String("dc-location", localTSOConfig.DCLocation),
 			zap.String("server-name", serverName),
-			zap.String("server-id", serverID))
+			zap.Uint64("server-id", serverID))
 		return errs.ErrEtcdTxn.FastGenByArgs()
 	}
 	am.ClusterDCLocationChecker()
@@ -161,10 +160,6 @@ func (am *AllocatorManager) GetClusterDCLocations() map[string][]uint64 {
 		copy(dcLocationMap[dcLocation], members)
 	}
 	return dcLocationMap
-}
-
-func (am *AllocatorManager) getLocalTSOConfigPath() string {
-	return path.Join(am.rootPath, dcLocationConfigEtcdPrefix)
 }
 
 // SetUpAllocator is used to set up an allocator, which will initialize the allocator and put it into allocator daemon.
@@ -427,7 +422,7 @@ func (am *AllocatorManager) allocatorPatroller(serverCtx context.Context) {
 func (am *AllocatorManager) ClusterDCLocationChecker() {
 	resp, err := etcdutil.EtcdKVGet(
 		am.member.Client(),
-		am.getLocalTSOConfigPath(),
+		am.member.GetDCLocationPathPrefix(),
 		clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Riptide3 <riptide.yzy@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Close #3239. In this issue we want a method (e.g. a `pd-ctl` command) to delete the old `dc-location` info persisted in the etcd, however, we may only use it when a PD is deleted.

This PR modified the process of deleting a PD member to automatically delete its `dc-location` info also. So we can achieve the same goal without introducing a redundant command.

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
