### PR TITLE
scripts: make check_missing_tests compatible with macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ test-with-cover: install-go-tools dashboard-ui
 	done
 	@$(FAILPOINT_DISABLE)
 
-check: install-go-tools check-all check-plugin errdoc check_missing_tests
+check: install-go-tools check-all check-plugin errdoc check-missing-tests
 
 check-all: static lint tidy
 	@echo "checking"
@@ -193,7 +193,7 @@ errdoc: install-go-tools
 	@echo "generator errors.toml"
 	./scripts/check-errdoc.sh
 
-check_missing_tests:
+check-missing-tests:
 	./scripts/check-missing-tests.sh
 
 simulator: export GO111MODULE=on

--- a/scripts/check-missing-tests.sh
+++ b/scripts/check-missing-tests.sh
@@ -3,7 +3,7 @@
 # Check if there are any packages foget to add `TestingT` when use "github.com/pingcap/check".
 
 res=$(diff <(grep -rl --include=\*_test.go "github.com/pingcap/check" . | xargs -L 1 dirname | sort -u) \
-     <(grep -rl --include=\*_test.go -E "^\s*(check\.)?TestingT\(" . | xargs  -L 1 dirname | sort -u))
+     <(grep -rl --include=\*_test.go -E "^\s*(check\.)?TestingT\(" . | xargs -L 1 dirname | sort -u))
 
 if [ "$res" ]; then
   echo "following packages may be lost TestingT:"

--- a/scripts/check-missing-tests.sh
+++ b/scripts/check-missing-tests.sh
@@ -2,8 +2,8 @@
 
 # Check if there are any packages foget to add `TestingT` when use "github.com/pingcap/check".
 
-res=$(diff <(grep -rl --include=\*_test.go "github.com/pingcap/check" | xargs dirname | sort -u) \
-     <(grep -rl --include=\*_test.go -E "^\s*(check\.)?TestingT\(" | xargs dirname | sort -u))
+res=$(diff <(grep -rl --include=\*_test.go "github.com/pingcap/check" . | xargs -L 1 dirname | sort -u) \
+     <(grep -rl --include=\*_test.go -E "^\s*(check\.)?TestingT\(" . | xargs  -L 1 dirname | sort -u))
 
 if [ "$res" ]; then
   echo "following packages may be lost TestingT:"


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

In macOS, there are two problems with the `scripts/check-missing-tests.sh`.

* If you don't specify a directory, `grep` will try to search in the standard input, but the recursive search does not make sense there.

<img width="346" alt="图片" src="https://user-images.githubusercontent.com/1446531/100978014-c1e29180-357c-11eb-8da9-fedaecfabcf6.png">

* `dirname` on macOS only takes a single pathname.

<img width="349" alt="图片" src="https://user-images.githubusercontent.com/1446531/100978190-01a97900-357d-11eb-8598-4d948d19712c.png">

### What is changed and how it works?

Update the `check-missing-tests.sh`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
