### PR TITLE
tools: improve the output of scheduler config when there is no scheduler

### DIFF
--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -250,6 +250,8 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	c.Assert(strings.Contains(echo, "404"), IsTrue)
 
 	// test hot region config
+	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "config", "evict-leader-scheduler"})
+	c.Assert(strings.Contains(echo, "[404] scheduler not found"), IsTrue)
 	var conf map[string]interface{}
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "list"}, &conf)
 	expected1 := map[string]interface{}{

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -505,6 +506,9 @@ func listSchedulerConfigCommandFunc(cmd *cobra.Command, args []string) {
 	path := path.Join(schedulerConfigPrefix, p, "list")
 	r, err := doRequest(cmd, path, http.MethodGet)
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			err = errors.New("[404] scheduler not found")
+		}
 		cmd.Println(err)
 		return
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Closes https://github.com/tikv/pd/issues/3241

### What is changed and how it works?

This PR improves the output when there is no such scheduler.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

- Improve the output of `scheduler config` when there is no scheduler
