### PR TITLE
server/auth: implement role & role manager

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -11,6 +11,31 @@ error = '''
 redirect failed
 '''
 
+["PD:auth:ErrInvalidName"]
+error = '''
+key name may only contain alphanumeric and underscores, and may only start with an alphabetic character.
+'''
+
+["PD:auth:ErrRoleExists"]
+error = '''
+role already exists: %s
+'''
+
+["PD:auth:ErrRoleHasPermission"]
+error = '''
+role %s already has permission: %s
+'''
+
+["PD:auth:ErrRoleMissingPermission"]
+error = '''
+role %s doesn't have permission: %s
+'''
+
+["PD:auth:ErrRoleNotFound"]
+error = '''
+role not found: %s
+'''
+
 ["PD:autoscaling:ErrEmptyMetricsResponse"]
 error = '''
 metrics response from Prometheus is empty

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -287,3 +287,12 @@ var (
 	ErrEncryptionSaveDataKeys       = errors.Normalize("failed to save data keys", errors.RFCCodeText("PD:encryption:ErrEncryptionSaveDataKeys"))
 	ErrEncryptionKMS                = errors.Normalize("KMS error", errors.RFCCodeText("PD:ErrEncryptionKMS"))
 )
+
+// auth
+var (
+	ErrRoleNotFound          = errors.Normalize("role not found: %s", errors.RFCCodeText("PD:auth:ErrRoleNotFound"))
+	ErrRoleExists            = errors.Normalize("role already exists: %s", errors.RFCCodeText("PD:auth:ErrRoleExists"))
+	ErrInvalidName           = errors.Normalize("key name may only contain alphanumeric and underscores, and may only start with an alphabetic character.", errors.RFCCodeText("PD:auth:ErrInvalidName"))
+	ErrRoleHasPermission     = errors.Normalize("role %s already has permission: %s", errors.RFCCodeText("PD:auth:ErrRoleHasPermission"))
+	ErrRoleMissingPermission = errors.Normalize("role %s doesn't have permission: %s", errors.RFCCodeText("PD:auth:ErrRoleMissingPermission"))
+)

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -1,0 +1,240 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissionKeys and
+// limitations under the License.
+//
+
+package auth
+
+import (
+	"encoding/json"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server/kv"
+	"go.etcd.io/etcd/clientv3"
+)
+
+// RBACManager is used for the rbac storage, cache, management and enforcing logic.
+type RBACManager struct {
+	roleManager
+}
+
+type roleManager struct {
+	kv    kv.Base
+	mu    sync.RWMutex
+	roles map[string]*Role
+}
+
+// newRoleManager creates a new roleManager.
+func newRoleManager(kv kv.Base) *roleManager {
+	return &roleManager{kv: kv, roles: make(map[string]*Role)}
+}
+
+// GetRole returns a role.
+func (m *roleManager) GetRole(name string) (*Role, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	role, ok := m.roles[name]
+	if !ok {
+		return nil, errs.ErrRoleNotFound.FastGenByArgs(name)
+	}
+
+	return role, nil
+}
+
+// GetRoles returns all available roles.
+func (m *roleManager) GetRoles() map[string]*Role {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.roles
+}
+
+// CreateRole creates a new role.
+func (m *roleManager) CreateRole(name string) error {
+	_, err := m.GetRole(name)
+	if err == nil {
+		return errs.ErrRoleExists.GenWithStackByArgs(name)
+	}
+
+	role, err := NewRole(name)
+	if err != nil {
+		return err
+	}
+
+	roleJSON, err := json.Marshal(role)
+	if err != nil {
+		return err
+	}
+	rolePath := path.Join(rolePrefix, name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Add role to kv.
+	err = m.kv.Save(rolePath, string(roleJSON))
+	if err != nil {
+		return err
+	}
+
+	// Add role to memory cache.
+	m.roles[name] = role
+
+	return nil
+}
+
+// DeleteRole deletes a role.
+func (m *roleManager) DeleteRole(name string) error {
+	_, err := m.GetRole(name)
+	if err != nil {
+		return err
+	}
+
+	rolePath := path.Join(rolePrefix, name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Delete role from kv.
+	err = m.kv.Remove(rolePath)
+	if err != nil {
+		return err
+	}
+
+	// Delete role from memory cache.
+	delete(m.roles, name)
+
+	return nil
+}
+
+// SetPermissions sets permissions of a role.
+func (m *roleManager) SetPermissions(name string, permissions map[Permission]struct{}) error {
+	role, err := m.GetRole(name)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	role.Permissions = permissions
+
+	// Update role in kv
+	roleJSON, err := json.Marshal(role)
+	if err != nil {
+		return err
+	}
+	rolePath := path.Join(rolePrefix, name)
+
+	err = m.kv.Save(rolePath, string(roleJSON))
+	if err != nil {
+		return err
+	}
+
+	// No need to update role in memory cache again.
+
+	return nil
+}
+
+// AddPermission adds a permission to a role.
+func (m *roleManager) AddPermission(name string, permission Permission) error {
+	role, err := m.GetRole(name)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := role.Permissions[permission]; ok {
+		return errs.ErrRoleHasPermission.FastGenByArgs(name, permission)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	role.Permissions[permission] = struct{}{}
+
+	roleJSON, err := json.Marshal(role)
+	if err != nil {
+		return err
+	}
+	rolePath := path.Join(rolePrefix, name)
+
+	// Update user in kv.
+	err = m.kv.Save(rolePath, string(roleJSON))
+	if err != nil {
+		return err
+	}
+
+	// Update user in memory cache.
+	m.roles[name] = role
+
+	return nil
+}
+
+// RemovePermission removes a permission from a role.
+func (m *roleManager) RemovePermission(name string, permission Permission) error {
+	role, err := m.GetRole(name)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := role.Permissions[permission]; !ok {
+		return errs.ErrRoleMissingPermission.FastGenByArgs(name, permission)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(role.Permissions, permission)
+
+	roleJSON, err := json.Marshal(role)
+	if err != nil {
+		return err
+	}
+	rolePath := path.Join(rolePrefix, name)
+
+	// Update user in kv.
+	err = m.kv.Save(rolePath, string(roleJSON))
+	if err != nil {
+		return err
+	}
+
+	// Update user in memory cache.
+	m.roles[name] = role
+
+	return nil
+}
+
+func (m *roleManager) UpdateCache() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rolePath := strings.Join([]string{rolePrefix, ""}, "/")
+
+	keys, values, err := m.kv.LoadRange(rolePath, clientv3.GetPrefixRangeEnd(rolePath), 0)
+	if err != nil {
+		return err
+	}
+
+	m.roles = make(map[string]*Role)
+	for i := range keys {
+		value := values[i]
+		role, err := NewRoleFromJSON(value)
+		if err != nil {
+			return err
+		}
+		m.roles[role.Name] = role
+	}
+	return nil
+}

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -1,0 +1,304 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissionKeys and
+// limitations under the License.
+//
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/tempurl"
+	"github.com/tikv/pd/server/kv"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/embed"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"encoding/json"
+	. "github.com/pingcap/check"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testAuthSuite{})
+
+type testAuthSuite struct{}
+type testFunc func(*C, *roleManager)
+
+func (s *testAuthSuite) TestRoleManager(c *C) {
+	cfg := newTestSingleConfig()
+	defer cleanConfig(cfg)
+	etcd, err := embed.StartEtcd(cfg)
+	c.Assert(err, IsNil)
+	defer etcd.Close()
+
+	ep := cfg.LCUrls[0].String()
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{ep},
+	})
+	c.Assert(err, IsNil)
+	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
+
+	manager := newRoleManager(kv.NewEtcdKVBase(client, rootPath))
+	testFuncs := []testFunc{
+		s.testGetRole,
+		s.testGetRoles,
+		s.testCreateRole,
+		s.testDeleteRole,
+		s.testSetPermissions,
+		s.testAddPermission,
+		s.testRemovePermission,
+	}
+	for _, f := range testFuncs {
+		initKV(c, client, rootPath)
+		err = manager.UpdateCache()
+		c.Assert(err, IsNil)
+		f(c, manager)
+	}
+}
+
+func (s *testAuthSuite) testGetRole(c *C, m *roleManager) {
+	expectedRole := Role{
+		Name: "reader",
+		Permissions: map[Permission]struct{}{
+			{Resource: "store", Action: "get"}:   {},
+			{Resource: "store", Action: "list"}:  {},
+			{Resource: "region", Action: "get"}:  {},
+			{Resource: "region", Action: "list"}: {},
+		},
+	}
+	role, err := m.GetRole("reader")
+	c.Assert(err, IsNil)
+	c.Assert(role, DeepEquals, &expectedRole)
+	_, err = m.GetRole("somebody")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrRoleNotFound.Equal(err), IsTrue)
+}
+
+func (s *testAuthSuite) testGetRoles(c *C, m *roleManager) {
+	expectedRoles := []Role{
+		{Name: "reader", Permissions: map[Permission]struct{}{
+			{Resource: "store", Action: "get"}:   {},
+			{Resource: "store", Action: "list"}:  {},
+			{Resource: "region", Action: "get"}:  {},
+			{Resource: "region", Action: "list"}: {},
+		}},
+		{Name: "writer", Permissions: map[Permission]struct{}{
+			{Resource: "store", Action: "update"}:  {},
+			{Resource: "store", Action: "delete"}:  {},
+			{Resource: "region", Action: "update"}: {},
+			{Resource: "region", Action: "delete"}: {},
+		}},
+		{Name: "admin", Permissions: map[Permission]struct{}{
+			{Resource: "store", Action: "get"}:     {},
+			{Resource: "store", Action: "list"}:    {},
+			{Resource: "store", Action: "update"}:  {},
+			{Resource: "store", Action: "delete"}:  {},
+			{Resource: "region", Action: "get"}:    {},
+			{Resource: "region", Action: "list"}:   {},
+			{Resource: "region", Action: "update"}: {},
+			{Resource: "region", Action: "delete"}: {},
+			{Resource: "users", Action: "get"}:     {},
+			{Resource: "users", Action: "list"}:    {},
+			{Resource: "users", Action: "update"}:  {},
+			{Resource: "users", Action: "delete"}:  {},
+		}},
+	}
+	roles := m.GetRoles()
+	c.Assert(len(roles), Equals, 3)
+	for _, role := range roles {
+		hasRole := false
+		for _, expectedRole := range expectedRoles {
+			if role.Name == expectedRole.Name &&
+				reflect.DeepEqual(role.Permissions, expectedRole.Permissions) {
+				hasRole = true
+				break
+			}
+		}
+		c.Assert(hasRole, IsTrue)
+	}
+}
+
+func (s *testAuthSuite) testCreateRole(c *C, m *roleManager) {
+	expectedRole := Role{Name: "nobody", Permissions: map[Permission]struct{}{}}
+	err := m.CreateRole("reader")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrRoleExists.Equal(err), IsTrue)
+	err = m.CreateRole("!")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrInvalidName.Equal(err), IsTrue)
+
+	_, err = m.GetRole("nobody")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrRoleNotFound.Equal(err), IsTrue)
+	err = m.CreateRole("nobody")
+	c.Assert(err, IsNil)
+	role, err := m.GetRole("nobody")
+	c.Assert(err, IsNil)
+	c.Assert(role, DeepEquals, &expectedRole)
+}
+
+func (s *testAuthSuite) testDeleteRole(c *C, m *roleManager) {
+	err := m.DeleteRole("somebody")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrRoleNotFound.Equal(err), IsTrue)
+
+	err = m.DeleteRole("reader")
+	c.Assert(err, IsNil)
+
+	err = m.DeleteRole("reader")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrRoleNotFound.Equal(err), IsTrue)
+}
+
+func (s *testAuthSuite) testSetPermissions(c *C, m *roleManager) {
+	err := m.SetPermissions("reader", map[Permission]struct{}{
+		{Resource: "region", Action: "get"}: {},
+		{Resource: "store", Action: "list"}: {},
+	})
+	c.Assert(err, IsNil)
+
+	role, err := m.GetRole("reader")
+	c.Assert(err, IsNil)
+	c.Assert(role.GetPermissions(), DeepEquals, map[Permission]struct{}{
+		{Resource: "region", Action: "get"}: {},
+		{Resource: "store", Action: "list"}: {},
+	})
+}
+
+func (s *testAuthSuite) testAddPermission(c *C, m *roleManager) {
+	err := m.AddPermission("reader", Permission{Resource: "region", Action: "get"})
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrRoleHasPermission.Equal(err), IsTrue)
+
+	err = m.AddPermission("reader", Permission{Resource: "region", Action: "update"})
+	c.Assert(err, IsNil)
+
+	role, err := m.GetRole("reader")
+	c.Assert(err, IsNil)
+	c.Assert(role.GetPermissions(), DeepEquals, map[Permission]struct{}{
+		{Resource: "region", Action: "get"}:    {},
+		{Resource: "region", Action: "list"}:   {},
+		{Resource: "region", Action: "update"}: {},
+		{Resource: "store", Action: "get"}:     {},
+		{Resource: "store", Action: "list"}:    {},
+	})
+}
+
+func (s *testAuthSuite) testRemovePermission(c *C, m *roleManager) {
+	err := m.RemovePermission("reader", Permission{Resource: "region", Action: "update"})
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrRoleMissingPermission.Equal(err), IsTrue)
+
+	err = m.RemovePermission("reader", Permission{Resource: "region", Action: "get"})
+	c.Assert(err, IsNil)
+
+	role, err := m.GetRole("reader")
+	c.Assert(err, IsNil)
+	c.Assert(role.GetPermissions(), DeepEquals, map[Permission]struct{}{
+		{Resource: "region", Action: "list"}: {},
+		{Resource: "store", Action: "get"}:   {},
+		{Resource: "store", Action: "list"}:  {},
+	})
+}
+
+func initKV(c *C, client *clientv3.Client, rootPath string) {
+	_, err := client.Delete(context.TODO(), rootPath, clientv3.WithPrefix())
+	c.Assert(err, IsNil)
+
+	rolePrefix := path.Join(rootPath, "roles")
+
+	roles := []struct {
+		Name        string `json:"name"`
+		Permissions []struct {
+			Resource string `json:"resource"`
+			Action   string `json:"action"`
+		} `json:"permissions"`
+	}{
+		{Name: "reader", Permissions: []struct {
+			Resource string `json:"resource"`
+			Action   string `json:"action"`
+		}{
+			{Resource: "region", Action: "get"},
+			{Resource: "region", Action: "list"},
+			{Resource: "store", Action: "get"},
+			{Resource: "store", Action: "list"},
+		}},
+		{Name: "writer", Permissions: []struct {
+			Resource string `json:"resource"`
+			Action   string `json:"action"`
+		}{
+			{Resource: "region", Action: "delete"},
+			{Resource: "region", Action: "update"},
+			{Resource: "store", Action: "delete"},
+			{Resource: "store", Action: "update"},
+		}},
+		{Name: "admin", Permissions: []struct {
+			Resource string `json:"resource"`
+			Action   string `json:"action"`
+		}{
+			{Resource: "region", Action: "delete"},
+			{Resource: "region", Action: "get"},
+			{Resource: "region", Action: "list"},
+			{Resource: "region", Action: "update"},
+			{Resource: "store", Action: "update"},
+			{Resource: "store", Action: "delete"},
+			{Resource: "store", Action: "get"},
+			{Resource: "store", Action: "list"},
+			{Resource: "users", Action: "delete"},
+			{Resource: "users", Action: "get"},
+			{Resource: "users", Action: "list"},
+			{Resource: "users", Action: "update"},
+		}},
+	}
+	for _, role := range roles {
+		value, err := json.Marshal(role)
+		c.Assert(err, IsNil)
+		_, err = client.Put(context.TODO(), path.Join(rolePrefix, role.Name), string(value))
+		c.Assert(err, IsNil)
+	}
+}
+
+func newTestSingleConfig() *embed.Config {
+	cfg := embed.NewConfig()
+	cfg.Name = "test_etcd"
+	cfg.Dir, _ = ioutil.TempDir("/tmp", "test_etcd")
+	cfg.WalDir = ""
+	cfg.Logger = "zap"
+	cfg.LogOutputs = []string{"stdout"}
+
+	pu, _ := url.Parse(tempurl.Alloc())
+	cfg.LPUrls = []url.URL{*pu}
+	cfg.APUrls = cfg.LPUrls
+	cu, _ := url.Parse(tempurl.Alloc())
+	cfg.LCUrls = []url.URL{*cu}
+	cfg.ACUrls = cfg.LCUrls
+
+	cfg.StrictReconfigCheck = false
+	cfg.InitialCluster = fmt.Sprintf("%s=%s", cfg.Name, &cfg.LPUrls[0])
+	cfg.ClusterState = embed.ClusterStateFlagNew
+	return cfg
+}
+
+func cleanConfig(cfg *embed.Config) {
+	// Clean data directory
+	_ = os.RemoveAll(cfg.Dir)
+}

--- a/server/auth/permission.go
+++ b/server/auth/permission.go
@@ -1,0 +1,73 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissionKeys and
+// limitations under the License.
+//
+
+package auth
+
+import (
+	"strings"
+
+	"github.com/pingcap/errors"
+)
+
+var (
+	// ErrInvalidAction is error info for invalid action.
+	ErrInvalidAction = func(action Action) error { return errors.Errorf("invalid action: %s", action) }
+)
+
+// Action represents rbac actions.
+type Action string
+
+// All available actions types.
+const (
+	GET    Action = "get"
+	LIST   Action = "list"
+	CREATE Action = "create"
+	UPDATE Action = "update"
+	DELETE Action = "delete"
+)
+
+// Permission represents a permission to a specific pair of resource and action.
+type Permission struct {
+	Resource string `json:"resource"`
+	Action   Action `json:"action"`
+}
+
+// NewPermission safely creates a new permission instance.
+func NewPermission(resource string, action Action) (*Permission, error) {
+	err := validateAction(action)
+	if err != nil {
+		return nil, err
+	}
+	return &Permission{Resource: resource, Action: action}, nil
+}
+
+// String implements Stringer interface.
+func (p *Permission) String() string {
+	var builder strings.Builder
+	builder.WriteString(string(p.Action))
+	builder.WriteString("(")
+	builder.WriteString(p.Resource)
+	builder.WriteString(")")
+
+	return builder.String()
+}
+
+func validateAction(action Action) error {
+	switch action {
+	case GET, LIST, CREATE, UPDATE, DELETE:
+		return nil
+	default:
+		return ErrInvalidAction(action)
+	}
+}

--- a/server/auth/role.go
+++ b/server/auth/role.go
@@ -1,0 +1,129 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissionKeys and
+// limitations under the License.
+//
+
+package auth
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+var (
+	rolePrefix = "roles"
+)
+
+// Role records role info.
+// Read-Only once created.
+type Role struct {
+	Name        string
+	Permissions map[Permission]struct{}
+}
+
+// jsonRole is used as an intermediate model when marshaling/unmarshaling json data
+// because we need to convert map[Permission]struct{} from/to []Permission first.
+type jsonRole struct {
+	Name        string       `json:"name"`
+	Permissions []Permission `json:"permissions"`
+}
+
+// MarshalJSON implements Marshaler interface.
+func (r *Role) MarshalJSON() ([]byte, error) {
+	permissions := make([]Permission, 0, len(r.Permissions))
+	for p := range r.Permissions {
+		permissions = append(permissions, p)
+	}
+	sortPermissions(permissions)
+
+	_r := jsonRole{Name: r.Name, Permissions: permissions}
+	return json.Marshal(_r)
+}
+
+// UnmarshalJSON implements Unmarshaler interface.
+func (r *Role) UnmarshalJSON(bytes []byte) error {
+	var _r jsonRole
+
+	err := json.Unmarshal(bytes, &_r)
+	if err != nil {
+		return err
+	}
+
+	r.Name = _r.Name
+	for _, permission := range _r.Permissions {
+		r.Permissions[permission] = struct{}{}
+	}
+
+	return nil
+}
+
+// NewRole safely creates a new role instance.
+func NewRole(name string) (*Role, error) {
+	err := validateName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Role{Name: name, Permissions: make(map[Permission]struct{})}, nil
+}
+
+// NewRoleFromJSON safely deserialize a json string to a role instance.
+func NewRoleFromJSON(j string) (*Role, error) {
+	role := Role{Permissions: make(map[Permission]struct{})}
+	err := json.Unmarshal([]byte(j), &role)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateName(role.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &role, nil
+}
+
+// Clone creates a deep copy of role instance.
+func (r *Role) Clone() *Role {
+	return &Role{Name: r.Name, Permissions: r.Permissions}
+}
+
+// GetName returns name of this role.
+func (r *Role) GetName() string {
+	return r.Name
+}
+
+// GetPermissions returns permissions of this role.
+func (r *Role) GetPermissions() map[Permission]struct{} {
+	return r.Permissions
+}
+
+// HasPermission checks whether this user has a specific permission.
+func (r *Role) HasPermission(permission Permission) bool {
+	for p := range r.Permissions {
+		if p == permission {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sortPermissions is used to ensure that identical sets of permissions always yield the same json output.
+func sortPermissions(permissions []Permission) {
+	sort.Slice(permissions, func(i, j int) bool {
+		if permissions[i].Resource != permissions[j].Resource {
+			return permissions[i].Resource < permissions[j].Resource
+		}
+		return permissions[i].Action < permissions[j].Action
+	})
+}

--- a/server/auth/role_test.go
+++ b/server/auth/role_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissionKeys and
+// limitations under the License.
+//
+
+package auth
+
+import (
+	"encoding/json"
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testRoleSuite{})
+
+type testRoleSuite struct{}
+
+func (s *testRoleSuite) TestRole(c *C) {
+	_, err := NewRole("00test")
+	c.Assert(err, NotNil)
+	role, err := NewRole("test")
+	c.Assert(err, IsNil)
+	p1, err := NewPermission("storage", "get")
+	c.Assert(err, IsNil)
+	p2, err := NewPermission("region", "list")
+	c.Assert(err, IsNil)
+	p3, err := NewPermission("region", "get")
+	c.Assert(err, IsNil)
+	p4, err := NewPermission("region", "delete")
+	c.Assert(err, IsNil)
+	role.Permissions = map[Permission]struct{}{*p1: {}, *p2: {}, *p3: {}}
+
+	c.Assert(role.GetName(), Equals, "test")
+	c.Assert(role.GetPermissions(), DeepEquals, map[Permission]struct{}{*p1: {}, *p2: {}, *p3: {}})
+	c.Assert(role.HasPermission(*p1), IsTrue)
+	c.Assert(role.HasPermission(*p4), IsFalse)
+
+	c.Assert(role.Clone(), DeepEquals, role)
+
+	marshalledRole := "{\"name\":\"test\",\"permissions\":" +
+		"[{\"resource\":\"region\",\"action\":\"get\"}," +
+		"{\"resource\":\"region\",\"action\":\"list\"}," +
+		"{\"resource\":\"storage\",\"action\":\"get\"}]}"
+	j, err := json.Marshal(role)
+	c.Assert(err, IsNil)
+	c.Assert(string(j), Equals, marshalledRole)
+
+	unmarshalledRole, err := NewRoleFromJSON(string(j))
+	c.Assert(err, IsNil)
+	c.Assert(unmarshalledRole, DeepEquals, role)
+}

--- a/server/auth/util.go
+++ b/server/auth/util.go
@@ -1,0 +1,32 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissionKeys and
+// limitations under the License.
+//
+
+package auth
+
+import (
+	"regexp"
+
+	"github.com/tikv/pd/pkg/errs"
+)
+
+var (
+	patName = regexp.MustCompile("^([A-Za-z])[A-Za-z0-9_]*$")
+)
+
+func validateName(name string) error {
+	if patName.MatchString(name) {
+		return nil
+	}
+	return errs.ErrInvalidName.FastGenByArgs()
+}

--- a/server/auth/util_test.go
+++ b/server/auth/util_test.go
@@ -1,0 +1,34 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissionKeys and
+// limitations under the License.
+//
+
+package auth
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testUtilSuite{})
+
+type testUtilSuite struct{}
+
+func (s *testUtilSuite) TestValidateName(c *C) {
+	err := validateName("123abc")
+	c.Assert(err, NotNil)
+
+	err = validateName("fo1-/23")
+	c.Assert(err, NotNil)
+
+	err = validateName("fo_o123")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Signed-off-by: PhotonQuantum <self@lightquantum.me>

### What problem does this PR solve?

ref: https://github.com/tikv/tikv/issues/8621
server/auth: implement role & role manager.

This PR is split from #3224, and moved from #3248.

I'm still working on the RFC document about this change (RBAC support for TiDB PD), and I'll submit it as soon as it's completed. In the meantime, a draft written in Chinese is available at [here](https://docs.google.com/document/d/1yZ1pjUqJZAFl4-ynHMaA-IrVbLojXjJKxZPs1hYlPbs/edit?usp=sharing).

### What is changed and how it works?

server/auth `roleManager` is implemented to handle role-related CRUD operations, including querying roles in memory, loading them from etcd and persisting them to etcd.

### Check List

Tests

- Unit test

Code changes

- Has persistent data change (etcd)

### Release note

- No release note