### PR TITLE
tso: add avg latency metric in tso-bench

### DIFF
--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -184,6 +184,7 @@ const (
 type stats struct {
 	maxDur          time.Duration
 	minDur          time.Duration
+	totalDur        time.Duration
 	count           int
 	milliCnt        int
 	twoMilliCnt     int
@@ -207,6 +208,7 @@ func newStats() *stats {
 
 func (s *stats) update(dur time.Duration) {
 	s.count++
+	s.totalDur += dur
 
 	if dur > s.maxDur {
 		s.maxDur = dur
@@ -280,6 +282,7 @@ func (s *stats) merge(other *stats) {
 	}
 
 	s.count += other.count
+	s.totalDur += other.totalDur
 	s.milliCnt += other.milliCnt
 	s.twoMilliCnt += other.twoMilliCnt
 	s.fiveMilliCnt += other.fiveMilliCnt
@@ -295,8 +298,8 @@ func (s *stats) merge(other *stats) {
 
 func (s *stats) Counter() string {
 	return fmt.Sprintf(
-		"count:%d, max:%d, min:%d, >1ms:%d, >2ms:%d, >5ms:%d, >10ms:%d, >30ms:%d >50ms:%d >100ms:%d >200ms:%d >400ms:%d >800ms:%d >1s:%d",
-		s.count, s.maxDur.Nanoseconds()/int64(time.Millisecond), s.minDur.Nanoseconds()/int64(time.Millisecond),
+		"count:%d, max:%d, min:%d, avg:%d, >1ms:%d, >2ms:%d, >5ms:%d, >10ms:%d, >30ms:%d >50ms:%d >100ms:%d >200ms:%d >400ms:%d >800ms:%d >1s:%d",
+		s.count, s.maxDur.Nanoseconds()/int64(time.Millisecond), s.minDur.Nanoseconds()/int64(time.Millisecond), s.totalDur.Nanoseconds()/int64(s.count)/int64(time.Millisecond),
 		s.milliCnt, s.twoMilliCnt, s.fiveMilliCnt, s.tenMSCnt, s.thirtyCnt, s.fiftyCnt, s.oneHundredCnt, s.twoHundredCnt, s.fourHundredCnt,
 		s.eightHundredCnt, s.oneThousandCnt)
 }


### PR DESCRIPTION
Signed-off-by: ZenoTan <zenotan1998@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
Add avg latency metric in tso-bench.

### What is changed and how it works?
Store avg latency in metrics, output it in the report.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
