### PR TITLE
log: add pluggable_logger and implement http_logger for it

### DIFF
--- a/pkg/logutil/http_logger.go
+++ b/pkg/logutil/http_logger.go
@@ -52,13 +52,17 @@ func (l *HTTPLogger) AddCloseCallback(fs ...func()) {
 func (l *HTTPLogger) Plug(names ...string) {
 	l.AddCloseCallback(func() {
 		for _, name := range names {
-			pl := GetOrCreatePluggableLogger(name)
-			pl.SetLogger(nil)
+			pl := GetPluggableLogger(name, false)
+			if pl != nil {
+				pl.SetLogger(nil)
+			}
 		}
 	})
 	for _, name := range names {
-		pl := GetOrCreatePluggableLogger(name)
-		pl.SetLogger(l.logger)
+		pl := GetPluggableLogger(name, false)
+		if pl != nil {
+			pl.SetLogger(l.logger)
+		}
 	}
 }
 

--- a/pkg/logutil/http_logger.go
+++ b/pkg/logutil/http_logger.go
@@ -60,6 +60,7 @@ func (l *HTTPLogger) Plug(names ...string) {
 			}
 		}
 	})
+	l.writer.WriteHeader(http.StatusOK)
 	for _, name := range names {
 		pl := GetPluggableLogger(name, false)
 		if pl != nil {

--- a/pkg/logutil/http_logger.go
+++ b/pkg/logutil/http_logger.go
@@ -67,7 +67,6 @@ func (l *HTTPLogger) Plug(names ...string) {
 
 // Close will call close callbacks and close all output.
 func (l *HTTPLogger) Close() {
-	defer l.writer.WriteHeader(http.StatusOK)
 	defer l.logger.Sync()
 	for _, f := range l.closeCallbacks {
 		f()

--- a/pkg/logutil/http_logger.go
+++ b/pkg/logutil/http_logger.go
@@ -53,14 +53,14 @@ func (l *HTTPLogger) Plug(names ...string) {
 		for _, name := range names {
 			pl := GetPluggableLogger(name, false)
 			if pl != nil {
-				pl.SetLogger(nil)
+				pl.UnplugLogger(l.logger)
 			}
 		}
 	})
 	for _, name := range names {
 		pl := GetPluggableLogger(name, false)
 		if pl != nil {
-			pl.SetLogger(l.logger)
+			pl.PlugLogger(l.logger)
 		}
 	}
 }

--- a/pkg/logutil/http_logger.go
+++ b/pkg/logutil/http_logger.go
@@ -31,11 +31,10 @@ type HTTPLogger struct {
 // NewHTTPLogger returns a HTTPLogger.
 func NewHTTPLogger(conf *log.Config, w http.ResponseWriter) (*HTTPLogger, error) {
 	syncer := zapcore.AddSync(w)
-	logger, props, err := log.InitLoggerWithWriteSyncer(conf, syncer, zap.AddStacktrace(zapcore.FatalLevel))
+	logger, _, err := log.InitLoggerWithWriteSyncer(conf, syncer, zap.AddStacktrace(zapcore.FatalLevel))
 	if err != nil {
 		return nil, err
 	}
-	props.Level.SetLevel(zapcore.DebugLevel)
 	return &HTTPLogger{
 		writer:         w,
 		logger:         logger,

--- a/pkg/logutil/http_logger.go
+++ b/pkg/logutil/http_logger.go
@@ -1,0 +1,72 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"net/http"
+
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// HTTPLogger is a Logger that outputs logs to ResponseWriter.
+type HTTPLogger struct {
+	writer         http.ResponseWriter
+	logger         *zap.Logger
+	closeCallbacks []func()
+}
+
+// NewHTTPLogger returns a HTTPLogger.
+func NewHTTPLogger(conf *log.Config, w http.ResponseWriter) (*HTTPLogger, error) {
+	syncer := zapcore.AddSync(w)
+	logger, props, err := log.InitLoggerWithWriteSyncer(conf, syncer, zap.AddStacktrace(zapcore.FatalLevel))
+	if err != nil {
+		return nil, err
+	}
+	props.Level.SetLevel(zapcore.DebugLevel)
+	return &HTTPLogger{
+		writer:         w,
+		logger:         logger,
+		closeCallbacks: make([]func(), 0),
+	}, nil
+}
+
+// AddCloseCallback adds some callbacks when closing.
+func (l *HTTPLogger) AddCloseCallback(fs ...func()) {
+	l.closeCallbacks = append(l.closeCallbacks, fs...)
+}
+
+// Plug will plug the HTTPLogger into PluggableLogger.
+func (l *HTTPLogger) Plug(names ...string) {
+	l.AddCloseCallback(func() {
+		for _, name := range names {
+			pl := GetOrCreatePluggableLogger(name)
+			pl.SetLogger(nil)
+		}
+	})
+	for _, name := range names {
+		pl := GetOrCreatePluggableLogger(name)
+		pl.SetLogger(l.logger)
+	}
+}
+
+// Close will call close callbacks and close all output.
+func (l *HTTPLogger) Close() {
+	defer l.writer.WriteHeader(http.StatusOK)
+	defer l.logger.Sync()
+	for _, f := range l.closeCallbacks {
+		f()
+	}
+}

--- a/pkg/logutil/http_logger.go
+++ b/pkg/logutil/http_logger.go
@@ -50,7 +50,7 @@ func (l *HTTPLogger) AddCloseCallback(fs ...func()) {
 }
 
 // Plug will plug the HTTPLogger into PluggableLogger.
-func (l *HTTPLogger) Plug(names ...string) {
+func (l *HTTPLogger) Plug(names ...string) (count int) {
 	l.AddCloseCallback(func() {
 		for _, name := range names {
 			pl := GetPluggableLogger(name, false)
@@ -59,12 +59,16 @@ func (l *HTTPLogger) Plug(names ...string) {
 			}
 		}
 	})
+
 	for _, name := range names {
 		pl := GetPluggableLogger(name, false)
 		if pl != nil {
 			pl.PlugLogger(l.logger)
+			count++
 		}
 	}
+
+	return count
 }
 
 // Close will call close callbacks and close all output.

--- a/pkg/logutil/http_logger_test.go
+++ b/pkg/logutil/http_logger_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil

--- a/pkg/logutil/http_logger_test.go
+++ b/pkg/logutil/http_logger_test.go
@@ -12,3 +12,80 @@
 // limitations under the License.
 
 package logutil
+
+import (
+	"bytes"
+	"go.uber.org/zap"
+	"net/http"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/log"
+)
+
+var _ = Suite(&testHTTPLoggerSuite{})
+
+type testHTTPLoggerSuite struct {
+	writer *testResponseWriter
+	logger *HTTPLogger
+}
+
+func (s *testHTTPLoggerSuite) SetUpSuite(c *C) {
+	writer := newTestResponseWriter()
+	lg, err := NewHTTPLogger(&log.Config{
+		Level:               "info",
+		DisableTimestamp:    true,
+		DisableCaller:       true,
+		DisableStacktrace:   true,
+		DisableErrorVerbose: true,
+	}, writer)
+	c.Assert(err, IsNil)
+
+	s.writer = writer
+	s.logger = lg
+}
+
+func (s *testHTTPLoggerSuite) TestClose(c *C) {
+	closed := false
+	s.logger.AddCloseCallback(func() {
+		closed = true
+	})
+	s.logger.Close()
+	c.Assert(closed, IsTrue)
+}
+
+func (s *testHTTPLoggerSuite) TestLogger(c *C) {
+	pl := GetPluggableLogger("http", true)
+	s.logger.Plug("http")
+	pl.Info("world", zap.Int64("answer", 42))
+	s.logger.Close()
+	c.Assert(s.writer.GetCode(), Equals, http.StatusOK)
+	c.Assert(s.writer.String(), Equals, "[INFO] [world] [answer=42]\n")
+}
+
+type testResponseWriter struct {
+	*bytes.Buffer
+	Code int
+}
+
+func newTestResponseWriter() *testResponseWriter {
+	return &testResponseWriter{
+		Buffer: new(bytes.Buffer),
+		Code:   0,
+	}
+}
+
+func (*testResponseWriter) Header() http.Header {
+	return nil
+}
+
+func (w *testResponseWriter) WriteHeader(statusCode int) {
+	w.Code = statusCode
+}
+
+func (w *testResponseWriter) GetCode() int {
+	return w.Code
+}
+
+func (w *testResponseWriter) String() string {
+	return w.Buffer.String()
+}

--- a/pkg/logutil/http_logger_test.go
+++ b/pkg/logutil/http_logger_test.go
@@ -29,7 +29,7 @@ type testHTTPLoggerSuite struct {
 	logger *HTTPLogger
 }
 
-func (s *testHTTPLoggerSuite) SetUpSuite(c *C) {
+func (s *testHTTPLoggerSuite) SetUpTest(c *C) {
 	writer := newTestResponseWriter()
 	lg, err := NewHTTPLogger(&log.Config{
 		Level:               "info",

--- a/pkg/logutil/http_logger_test.go
+++ b/pkg/logutil/http_logger_test.go
@@ -55,7 +55,7 @@ func (s *testHTTPLoggerSuite) TestClose(c *C) {
 
 func (s *testHTTPLoggerSuite) TestLogger(c *C) {
 	pl := GetPluggableLogger("http", true)
-	s.logger.Plug("http")
+	c.Assert(s.logger.Plug("http"), Equals, 1)
 	pl.Info("world", zap.Int64("answer", 42))
 	s.logger.Close()
 	c.Assert(s.writer.GetCode(), Equals, http.StatusOK)

--- a/pkg/logutil/http_logger_test.go
+++ b/pkg/logutil/http_logger_test.go
@@ -15,11 +15,11 @@ package logutil
 
 import (
 	"bytes"
-	"go.uber.org/zap"
 	"net/http"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
 )
 
 var _ = Suite(&testHTTPLoggerSuite{})

--- a/pkg/logutil/http_logger_test.go
+++ b/pkg/logutil/http_logger_test.go
@@ -53,9 +53,14 @@ func (s *testHTTPLoggerSuite) TestClose(c *C) {
 	c.Assert(closed, IsTrue)
 }
 
+func (s *testHTTPLoggerSuite) TestNotExist(c *C) {
+	err := s.logger.Plug("not_exist_1", "not_exist_2")
+	c.Assert(err, ErrorMatches, "these names do not exist: not_exist_1,not_exist_2")
+}
+
 func (s *testHTTPLoggerSuite) TestLogger(c *C) {
 	pl := GetPluggableLogger("http", true)
-	c.Assert(s.logger.Plug("http"), Equals, 1)
+	c.Assert(s.logger.Plug("http"), IsNil)
 	pl.Info("world", zap.Int64("answer", 42))
 	s.logger.Close()
 	c.Assert(s.writer.GetCode(), Equals, http.StatusOK)

--- a/pkg/logutil/log.go
+++ b/pkg/logutil/log.go
@@ -254,13 +254,14 @@ func (lg *wrapLogrus) V(l int) bool {
 	return int(lg.Logger.Level) <= logrusLevel
 }
 
-var once sync.Once
+var (
+	initLoggerOnce sync.Once
+	initLoggerErr  error
+)
 
 // InitLogger initializes PD's logger.
 func InitLogger(cfg *zaplog.Config) error {
-	var err error
-
-	once.Do(func() {
+	initLoggerOnce.Do(func() {
 		log.SetLevel(StringToLogLevel(cfg.Level))
 		log.AddHook(&contextHook{})
 
@@ -281,9 +282,9 @@ func InitLogger(cfg *zaplog.Config) error {
 			return
 		}
 
-		err = InitFileLog(&cfg.File)
+		initLoggerErr = InitFileLog(&cfg.File)
 	})
-	return err
+	return initLoggerErr
 }
 
 // LogPanic logs the panic reason and stack, then exit the process.

--- a/pkg/logutil/pluggable_logger.go
+++ b/pkg/logutil/pluggable_logger.go
@@ -47,36 +47,53 @@ func (l *PluggableLogger) SetLogger(logger *zap.Logger) {
 	l.logger.Store(logger)
 }
 
+// Debug logs a message at DebugLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
 func (l PluggableLogger) Debug(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Debug(msg, fields...)
 	}
 }
 
+// Info logs a message at InfoLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
 func (l PluggableLogger) Info(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Info(msg, fields...)
 	}
 }
 
+// Warn logs a message at WarnLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
 func (l PluggableLogger) Warn(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Warn(msg, fields...)
 	}
 }
 
+// Error logs a message at ErrorLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
 func (l PluggableLogger) Error(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Error(msg, fields...)
 	}
 }
 
+// Panic logs a message at PanicLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
+//
+// The logger then panics, even if logging at PanicLevel is disabled.
 func (l PluggableLogger) Panic(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Panic(msg, fields...)
 	}
 }
 
+// Fatal logs a message at FatalLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
+//
+// The logger then calls os.Exit(1), even if logging at FatalLevel is
+// disabled.
 func (l PluggableLogger) Fatal(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Fatal(msg, fields...)

--- a/pkg/logutil/pluggable_logger.go
+++ b/pkg/logutil/pluggable_logger.go
@@ -27,13 +27,13 @@ type PluggableLogger struct {
 }
 
 // GetName gets the pluggable logger's name.
-func (l PluggableLogger) GetName() string {
+func (l *PluggableLogger) GetName() string {
 	return l.name
 }
 
 // GetLogger gets the logger. If it is nil,
 // it means that the current related log does not need to be output.
-func (l PluggableLogger) GetLogger() *zap.Logger {
+func (l *PluggableLogger) GetLogger() *zap.Logger {
 	logger := l.logger.Load().(*zap.Logger)
 	if logger == nil {
 		return nil
@@ -49,7 +49,7 @@ func (l *PluggableLogger) SetLogger(logger *zap.Logger) {
 
 // Debug logs a message at DebugLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (l PluggableLogger) Debug(msg string, fields ...zap.Field) {
+func (l *PluggableLogger) Debug(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Debug(msg, fields...)
 	}
@@ -57,7 +57,7 @@ func (l PluggableLogger) Debug(msg string, fields ...zap.Field) {
 
 // Info logs a message at InfoLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (l PluggableLogger) Info(msg string, fields ...zap.Field) {
+func (l *PluggableLogger) Info(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Info(msg, fields...)
 	}
@@ -65,7 +65,7 @@ func (l PluggableLogger) Info(msg string, fields ...zap.Field) {
 
 // Warn logs a message at WarnLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (l PluggableLogger) Warn(msg string, fields ...zap.Field) {
+func (l *PluggableLogger) Warn(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Warn(msg, fields...)
 	}
@@ -73,7 +73,7 @@ func (l PluggableLogger) Warn(msg string, fields ...zap.Field) {
 
 // Error logs a message at ErrorLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (l PluggableLogger) Error(msg string, fields ...zap.Field) {
+func (l *PluggableLogger) Error(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Error(msg, fields...)
 	}
@@ -83,7 +83,7 @@ func (l PluggableLogger) Error(msg string, fields ...zap.Field) {
 // at the log site, as well as any fields accumulated on the logger.
 //
 // The logger then panics, even if logging at PanicLevel is disabled.
-func (l PluggableLogger) Panic(msg string, fields ...zap.Field) {
+func (l *PluggableLogger) Panic(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Panic(msg, fields...)
 	}
@@ -94,7 +94,7 @@ func (l PluggableLogger) Panic(msg string, fields ...zap.Field) {
 //
 // The logger then calls os.Exit(1), even if logging at FatalLevel is
 // disabled.
-func (l PluggableLogger) Fatal(msg string, fields ...zap.Field) {
+func (l *PluggableLogger) Fatal(msg string, fields ...zap.Field) {
 	if logger := l.GetLogger(); logger != nil {
 		logger.Fatal(msg, fields...)
 	}

--- a/pkg/logutil/pluggable_logger.go
+++ b/pkg/logutil/pluggable_logger.go
@@ -1,0 +1,111 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+)
+
+// PluggableLogger is a pluggable zap.Logger.
+type PluggableLogger struct {
+	name   string
+	logger atomic.Value // zap.Logger
+}
+
+// GetName gets the pluggable logger's name.
+func (l PluggableLogger) GetName() string {
+	return l.name
+}
+
+// GetLogger gets the logger. If it is nil,
+// it means that the current related log does not need to be output.
+func (l PluggableLogger) GetLogger() *zap.Logger {
+	logger := l.logger.Load().(*zap.Logger)
+	if logger == nil {
+		return nil
+	}
+	return logger.WithOptions(zap.AddCallerSkip(1))
+}
+
+// SetLogger sets the logger. If it is nil,
+// it means that the current related log does not need to be output.
+func (l *PluggableLogger) SetLogger(logger *zap.Logger) {
+	l.logger.Store(logger)
+}
+
+func (l PluggableLogger) Debug(msg string, fields ...zap.Field) {
+	if logger := l.GetLogger(); logger != nil {
+		logger.Debug(msg, fields...)
+	}
+}
+
+func (l PluggableLogger) Info(msg string, fields ...zap.Field) {
+	if logger := l.GetLogger(); logger != nil {
+		logger.Info(msg, fields...)
+	}
+}
+
+func (l PluggableLogger) Warn(msg string, fields ...zap.Field) {
+	if logger := l.GetLogger(); logger != nil {
+		logger.Warn(msg, fields...)
+	}
+}
+
+func (l PluggableLogger) Error(msg string, fields ...zap.Field) {
+	if logger := l.GetLogger(); logger != nil {
+		logger.Error(msg, fields...)
+	}
+}
+
+func (l PluggableLogger) Panic(msg string, fields ...zap.Field) {
+	if logger := l.GetLogger(); logger != nil {
+		logger.Panic(msg, fields...)
+	}
+}
+
+func (l PluggableLogger) Fatal(msg string, fields ...zap.Field) {
+	if logger := l.GetLogger(); logger != nil {
+		logger.Fatal(msg, fields...)
+	}
+}
+
+type loggerManager struct {
+	sync.Mutex
+	Loggers map[string]*PluggableLogger
+}
+
+var globalLoggerManager loggerManager
+
+func init() {
+	globalLoggerManager.Lock()
+	defer globalLoggerManager.Unlock()
+	globalLoggerManager.Loggers = make(map[string]*PluggableLogger)
+}
+
+// NewPluggableLogger gets a pluggable zap.Logger.
+func GetOrCreatePluggableLogger(name string) *PluggableLogger {
+	globalLoggerManager.Lock()
+	defer globalLoggerManager.Unlock()
+	l, ok := globalLoggerManager.Loggers[name]
+	if !ok {
+		l = new(PluggableLogger)
+		l.name = name
+		l.logger.Store(nil)
+		globalLoggerManager.Loggers[name] = l
+	}
+	return l
+}

--- a/pkg/logutil/pluggable_logger_test.go
+++ b/pkg/logutil/pluggable_logger_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil

--- a/pkg/logutil/pluggable_logger_test.go
+++ b/pkg/logutil/pluggable_logger_test.go
@@ -12,3 +12,56 @@
 // limitations under the License.
 
 package logutil
+
+import (
+	"bytes"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/log"
+)
+
+var _ = Suite(&testPluggableLoggerSuite{})
+
+type testPluggableLoggerSuite struct {
+	testLoggerManager loggerManager
+}
+
+func (s *testPluggableLoggerSuite) SetUpSuite(c *C) {
+	s.testLoggerManager.Init()
+}
+
+func (s *testPluggableLoggerSuite) TestLoggerManager(c *C) {
+	// Get a logger that does not exist.
+	c.Assert(s.testLoggerManager.GetPluggableLogger("test", false), IsNil)
+	// Create PluggableLogger.
+	logger := s.testLoggerManager.GetPluggableLogger("test", true)
+	c.Assert(logger.GetLogger(), IsNil)
+	c.Assert(logger.GetName(), Equals, "test")
+	// Plug logger.
+	s.testLoggerManager.GetPluggableLogger("test", false).SetLogger(zap.NewNop())
+	c.Assert(logger.GetLogger(), NotNil)
+	logger.Debug("noop")
+	// Unplug logger.
+	s.testLoggerManager.GetPluggableLogger("test", false).SetLogger(nil)
+	c.Assert(logger.GetLogger(), IsNil)
+	logger.Debug("noop")
+}
+
+func (s *testPluggableLoggerSuite) TestPluggableLogger(c *C) {
+	pl := s.testLoggerManager.GetPluggableLogger("foo", true)
+	buffer := new(bytes.Buffer)
+	lg, _, err := log.InitLoggerWithWriteSyncer(&log.Config{
+		Level:               "info",
+		DisableTimestamp:    true,
+		DisableCaller:       true,
+		DisableStacktrace:   true,
+		DisableErrorVerbose: true,
+	}, zapcore.AddSync(buffer))
+	c.Assert(err, IsNil)
+	pl.SetLogger(lg)
+	pl.Info("bar", zap.Int64("int64", 42))
+	c.Assert(lg.Sync(), IsNil)
+	c.Assert(buffer.String(), Equals, "[INFO] [bar] [int64=42]\n")
+}

--- a/pkg/logutil/pluggable_logger_test.go
+++ b/pkg/logutil/pluggable_logger_test.go
@@ -61,7 +61,7 @@ func (s *testPluggableLoggerSuite) TestPluggableLogger(c *C) {
 	}, zapcore.AddSync(buffer))
 	c.Assert(err, IsNil)
 	pl.SetLogger(lg)
-	pl.Info("bar", zap.Int64("int64", 42))
+	pl.Info("world", zap.Int64("answer", 42))
 	c.Assert(lg.Sync(), IsNil)
-	c.Assert(buffer.String(), Equals, "[INFO] [bar] [int64=42]\n")
+	c.Assert(buffer.String(), Equals, "[INFO] [world] [answer=42]\n")
 }

--- a/pkg/logutil/pluggable_logger_test.go
+++ b/pkg/logutil/pluggable_logger_test.go
@@ -40,11 +40,12 @@ func (s *testPluggableLoggerSuite) TestLoggerManager(c *C) {
 	c.Assert(logger.GetLogger(), IsNil)
 	c.Assert(logger.GetName(), Equals, "test")
 	// Plug logger.
-	s.testLoggerManager.GetPluggableLogger("test", false).SetLogger(zap.NewNop())
+	nop := zap.NewNop()
+	s.testLoggerManager.GetPluggableLogger("test", false).PlugLogger(nop)
 	c.Assert(logger.GetLogger(), NotNil)
 	logger.Debug("noop")
 	// Unplug logger.
-	s.testLoggerManager.GetPluggableLogger("test", false).SetLogger(nil)
+	s.testLoggerManager.GetPluggableLogger("test", false).UnplugLogger(nop)
 	c.Assert(logger.GetLogger(), IsNil)
 	logger.Debug("noop")
 }
@@ -60,8 +61,9 @@ func (s *testPluggableLoggerSuite) TestPluggableLogger(c *C) {
 		DisableErrorVerbose: true,
 	}, zapcore.AddSync(buffer))
 	c.Assert(err, IsNil)
-	pl.SetLogger(lg)
+	pl.PlugLogger(lg)
 	pl.Info("world", zap.Int64("answer", 42))
 	c.Assert(lg.Sync(), IsNil)
 	c.Assert(buffer.String(), Equals, "[INFO] [world] [answer=42]\n")
+	pl.UnplugLogger(lg)
 }

--- a/pkg/logutil/pluggable_logger_test.go
+++ b/pkg/logutil/pluggable_logger_test.go
@@ -15,11 +15,11 @@ package logutil
 
 import (
 	"bytes"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var _ = Suite(&testPluggableLoggerSuite{})

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tikv/pd/pkg/logutil"
 	"github.com/tikv/pd/server"
 	"github.com/unrolled/render"
+	"go.uber.org/zap/zapcore"
 )
 
 type logHandler struct {
@@ -78,12 +79,16 @@ const defaultGetLogSecond = 600 // 10 minutes
 // @Summary Get logs.
 // @Param name query []string true "name" collectionFormat(multi)
 // @Param second query integer false "duration of getting"
+// @Param format query string false "log format" Enums(text, json)
+// @Param level query string false "log level" Enums(debug, info, warn, error, panic, fatal)
 // @Produce plain
 // @Success 200 {string} string "Finished getting logs."
 // @Failure 400 {string} string "The input is invalid."
 // @Router /admin/log [get]
 func (h *logHandler) GetLog(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
+
+	// get second
 	var second int64
 	if secondStr := query.Get("second"); secondStr != "" {
 		var err error
@@ -92,35 +97,53 @@ func (h *logHandler) GetLog(w http.ResponseWriter, r *http.Request) {
 			h.rd.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		if second <= 0 {
+			h.rd.JSON(w, http.StatusBadRequest, "duration is less than 0.")
+			return
+		}
 	}
 	if second == 0 {
 		second = defaultGetLogSecond
 	}
-	if second < 0 {
-		h.rd.JSON(w, http.StatusBadRequest, "duration is less than 0.")
-		return
-	}
 
+	// get names
 	names := query["name"]
 	if len(names) == 0 {
 		h.rd.JSON(w, http.StatusBadRequest, "empty name.")
 		return
 	}
 
+	// get format and level
 	logConfig := h.svr.GetConfig().Log
-	logConfig.Format = "json"
-	logConfig.Level = "debug"
+	logConfig.Format = "json" // default
+	logConfig.Level = "debug" // default
+	if format := query.Get("format"); format != "" {
+		if format == "text" || format == "json" {
+			logConfig.Format = format
+		} else {
+			h.rd.JSON(w, http.StatusBadRequest, "wrong log format.")
+			return
+		}
+	}
+	if level := query.Get("level"); level != "" {
+		var logLevel zapcore.Level
+		if err := logLevel.Set(level); err == nil {
+			logConfig.Level = level
+		} else {
+			h.rd.JSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
 	httpLogger, err := logutil.NewHTTPLogger(&logConfig, w)
 	if err != nil {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-
-	count := httpLogger.Plug(names...)
 	defer httpLogger.Close()
 
-	if count != len(names) {
-		h.rd.JSON(w, http.StatusBadRequest, "some loggers do not exist.")
+	if err := httpLogger.Plug(names...); err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -105,6 +105,7 @@ func (h *logHandler) GetLog(w http.ResponseWriter, r *http.Request) {
 
 	logConfig := h.svr.GetConfig().Log
 	logConfig.Format = "json"
+	logConfig.Level = "debug"
 	httpLogger, err := logutil.NewHTTPLogger(&logConfig, w)
 	if err != nil {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -48,7 +48,7 @@ func newLogHandler(svr *server.Server, rd *render.Render) *logHandler {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Failure 503 {string} string "PD server has no leader."
 // @Router /admin/log [post]
-func (h *logHandler) SetGlobalLevel(w http.ResponseWriter, r *http.Request) {
+func (h *logHandler) SetLogLevel(w http.ResponseWriter, r *http.Request) {
 	var level string
 	data, err := ioutil.ReadAll(r.Body)
 	r.Body.Close()

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -72,12 +72,14 @@ func (h *logHandler) SetGlobalLevel(w http.ResponseWriter, r *http.Request) {
 	h.rd.JSON(w, http.StatusOK, "The log level is updated.")
 }
 
+const defaultGetLogSecond = 600 // 10 minutes
+
 // @Tags admin
 // @Summary Get logs.
-// @Param name query string true "name"
-// @Param second query integer false "duration of getting"
+// @Param name query []string true "name"
+// @Param second query integer false "duration of getting" collectionFormat(multi)
 // @Produce text
-// @Success 200 {string} string "Finished."
+// @Success 200 {string} string "Finished getting logs."
 // @Failure 400 {string} string "The input is invalid."
 // @Router /admin/log [get]
 func (h *logHandler) GetLog(w http.ResponseWriter, r *http.Request) {
@@ -91,9 +93,13 @@ func (h *logHandler) GetLog(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if second <= 0 {
+		second = defaultGetLogSecond
+	}
+
 	names := query["name"]
 	if len(names) == 0 {
-		h.rd.JSON(w, http.StatusBadRequest, "empty names.")
+		h.rd.JSON(w, http.StatusBadRequest, "empty name.")
 		return
 	}
 

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -104,6 +104,7 @@ func (h *logHandler) GetLog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logConfig := h.svr.GetConfig().Log
+	logConfig.Format = "json"
 	httpLogger, err := logutil.NewHTTPLogger(&logConfig, w)
 	if err != nil {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())

--- a/server/api/log.go
+++ b/server/api/log.go
@@ -76,9 +76,9 @@ const defaultGetLogSecond = 600 // 10 minutes
 
 // @Tags admin
 // @Summary Get logs.
-// @Param name query []string true "name"
-// @Param second query integer false "duration of getting" collectionFormat(multi)
-// @Produce text
+// @Param name query []string true "name" collectionFormat(multi)
+// @Param second query integer false "duration of getting"
+// @Produce plain
 // @Success 200 {string} string "Finished getting logs."
 // @Failure 400 {string} string "The input is invalid."
 // @Router /admin/log [get]

--- a/server/api/log_test.go
+++ b/server/api/log_test.go
@@ -57,19 +57,15 @@ func (s *testLogSuite) TestSetLogLevel(c *C) {
 }
 
 func (s *testLogSuite) TestGetLog(c *C) {
-	pl := logutil.GetPluggableLogger("api", true)
+	pl := logutil.GetPluggableLogger("test_api", true)
 	answerCh := make(chan int64, 1)
 	go func() {
 		defer close(answerCh)
-		resp := make(map[string]interface{})
-		err := readJSON(testDialClient, s.urlPrefix+"/log?name=api&second=5", resp)
-		if err != nil {
-			return
+		var resp struct {
+			Answer int64 `json:"answer"`
 		}
-		if answer, ok := resp["answer"].(json.Number); ok {
-			if answer, err := answer.Int64(); err == nil {
-				answerCh <- answer
-			}
+		if err := readJSON(testDialClient, s.urlPrefix+"/log?name=test_api&second=3", &resp); err == nil {
+			answerCh <- resp.Answer
 		}
 	}()
 	time.Sleep(1 * time.Second)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -198,7 +198,8 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 	clusterRouter.HandleFunc("/admin/replication_mode/wait-async", adminHandler.UpdateWaitAsyncTime).Methods("POST")
 
 	logHandler := newLogHandler(svr, rd)
-	apiRouter.HandleFunc("/admin/log", logHandler.Handle).Methods("POST")
+	apiRouter.HandleFunc("/admin/log", logHandler.GetLog).Methods("GET")
+	apiRouter.HandleFunc("/admin/log", logHandler.SetGlobalLevel).Methods("POST")
 
 	replicationModeHandler := newReplicationModeHandler(svr, rd)
 	clusterRouter.HandleFunc("/replication_mode/status", replicationModeHandler.GetStatus)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -199,7 +199,7 @@ func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.R
 
 	logHandler := newLogHandler(svr, rd)
 	apiRouter.HandleFunc("/admin/log", logHandler.GetLog).Methods("GET")
-	apiRouter.HandleFunc("/admin/log", logHandler.SetGlobalLevel).Methods("POST")
+	apiRouter.HandleFunc("/admin/log", logHandler.SetLogLevel).Methods("POST")
 
 	replicationModeHandler := newReplicationModeHandler(svr, rd)
 	clusterRouter.HandleFunc("/replication_mode/status", replicationModeHandler.GetStatus)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

There are some debug logs, because there are so many, we don't want it to be printed in the log file. But they are often very helpful for troubleshooting certain problems. Currently, we can only obtain them by changing the log level. This PR aims to improve this solution.

### What is changed and how it works?

* add pluggable_logger: Use the different pluggable_logger to print the debug log. The pluggable_logger will not have any side effects when the actual output is not set. The actual output can be set to GlobalLogger, HTTPLogger or FileLogger, etc.
* implement http_logger for pluggable_logger: When accessing `/admin/log` through API, a set of pluggable_logger output can be obtained through API within a specified time.

[example](https://github.com/HunDunDM/pd/compare/logger...HunDunDM:debug_log): `/pd/api/v1/admin/log?name=hot_region&second=60`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
