### PR TITLE
server/auth: implement user & user manager.

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -21,6 +21,16 @@ error = '''
 role name may only contain alphanumeric and underscores, and may only start with an alphabetic character.
 '''
 
+["PD:auth:ErrInvalidUserName"]
+error = '''
+user name may only contain alphanumeric and underscores, and may only start with an alphabetic character.
+'''
+
+["PD:auth:ErrPasswordMismatch"]
+error = '''
+given password doesn't match the hash
+'''
+
 ["PD:auth:ErrRoleExists"]
 error = '''
 role already exists: %s
@@ -39,6 +49,26 @@ role %s doesn't have permission: %s
 ["PD:auth:ErrRoleNotFound"]
 error = '''
 role not found: %s
+'''
+
+["PD:auth:ErrUserExists"]
+error = '''
+user already exists: %s
+'''
+
+["PD:auth:ErrUserHasPermission"]
+error = '''
+role %s already has permission: %s
+'''
+
+["PD:auth:ErrUserMissingPermission"]
+error = '''
+role %s doesn't have permission: %s
+'''
+
+["PD:auth:ErrUserNotFound"]
+error = '''
+user not found: %s
 '''
 
 ["PD:autoscaling:ErrEmptyMetricsResponse"]

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -290,10 +290,16 @@ var (
 
 // auth
 var (
-	ErrInvalidPermissionAction = errors.Normalize("invalid permission action: %s", errors.RFCCodeText("PD:auth:ErrInvalidPermissionAction"))
+	ErrInvalidUserName         = errors.Normalize("user name may only contain alphanumeric and underscores, and may only start with an alphabetic character.", errors.RFCCodeText("PD:auth:ErrInvalidUserName"))
+	ErrUserNotFound            = errors.Normalize("user not found: %s", errors.RFCCodeText("PD:auth:ErrUserNotFound"))
+	ErrUserExists              = errors.Normalize("user already exists: %s", errors.RFCCodeText("PD:auth:ErrUserExists"))
+	ErrUserHasRole             = errors.Normalize("role %s already has permission: %s", errors.RFCCodeText("PD:auth:ErrUserHasPermission"))
+	ErrUserMissingRole         = errors.Normalize("role %s doesn't have permission: %s", errors.RFCCodeText("PD:auth:ErrUserMissingPermission"))
+	ErrPasswordMismatch        = errors.Normalize("given password doesn't match the hash", errors.RFCCodeText("PD:auth:ErrPasswordMismatch"))
+	ErrInvalidRoleName         = errors.Normalize("role name may only contain alphanumeric and underscores, and may only start with an alphabetic character.", errors.RFCCodeText("PD:auth:ErrInvalidRoleName"))
 	ErrRoleNotFound            = errors.Normalize("role not found: %s", errors.RFCCodeText("PD:auth:ErrRoleNotFound"))
 	ErrRoleExists              = errors.Normalize("role already exists: %s", errors.RFCCodeText("PD:auth:ErrRoleExists"))
-	ErrInvalidRoleName         = errors.Normalize("role name may only contain alphanumeric and underscores, and may only start with an alphabetic character.", errors.RFCCodeText("PD:auth:ErrInvalidRoleName"))
 	ErrRoleHasPermission       = errors.Normalize("role %s already has permission: %s", errors.RFCCodeText("PD:auth:ErrRoleHasPermission"))
 	ErrRoleMissingPermission   = errors.Normalize("role %s doesn't have permission: %s", errors.RFCCodeText("PD:auth:ErrRoleMissingPermission"))
+	ErrInvalidPermissionAction = errors.Normalize("invalid permission action: %s", errors.RFCCodeText("PD:auth:ErrInvalidPermissionAction"))
 )

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -272,7 +272,8 @@ func (m *userManager) UpdateCache() error {
 	m.users = make(map[string]*User)
 	for i := range keys {
 		value := values[i]
-		user, err := NewUserFromJSON(value)
+
+		user, err := UnmarshalUser(value)
 		if err != nil {
 			return err
 		}
@@ -493,7 +494,7 @@ func (m *roleManager) UpdateCache() error {
 	m.roles = make(map[string]*Role)
 	for i := range keys {
 		value := values[i]
-		role, err := NewRoleFromJSON(value)
+		role, err := UnmarshalRole(value)
 		if err != nil {
 			return err
 		}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -24,9 +24,261 @@ import (
 	"go.etcd.io/etcd/clientv3"
 )
 
+const (
+	userPrefix = "users"
+	rolePrefix = "roles"
+)
+
 // RBACManager is used for the rbac storage, cache, management and enforcing logic.
 type RBACManager struct {
+	userManager
 	roleManager
+}
+
+// NewRBACManager creates a new RBACManager.
+func NewRBACManager(kv kv.Base) *RBACManager {
+	return &RBACManager{
+		userManager{
+			kv:    kv,
+			users: make(map[string]*User),
+		},
+		roleManager{
+			kv:    kv,
+			roles: make(map[string]*Role),
+		}}
+}
+
+type userManager struct {
+	kv    kv.Base
+	mu    sync.RWMutex
+	users map[string]*User
+}
+
+// newUserManager creates a new roleManager for debug purposes.
+func newUserManager(kv kv.Base) *userManager {
+	return &userManager{kv: kv, users: make(map[string]*User)}
+}
+
+// GetUser returns a user.
+func (m *userManager) GetUser(name string) (*User, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	user, ok := m.users[name]
+	if !ok {
+		return nil, errs.ErrUserNotFound.FastGenByArgs(name)
+	}
+
+	return user, nil
+}
+
+// GetUsers returns all available roles.
+func (m *userManager) GetUsers() map[string]*User {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.users
+}
+
+// CreateUser creates a new user.
+func (m *userManager) CreateUser(name string, password string) error {
+	_, err := m.GetUser(name)
+	if err == nil {
+		return errs.ErrUserExists.GenWithStackByArgs(name)
+	}
+
+	user, err := NewUser(name, GenerateHash(password))
+	if err != nil {
+		return err
+	}
+
+	userJSON, err := json.Marshal(user)
+	if err != nil {
+		return errs.ErrJSONMarshal.Wrap(err).GenWithStackByCause()
+	}
+	userPath := path.Join(userPrefix, name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Add user to kv.
+	err = m.kv.Save(userPath, string(userJSON))
+	if err != nil {
+		return err
+	}
+
+	// Add user to memory cache.
+	m.users[name] = user
+
+	return nil
+}
+
+// DeleteUser deletes a user.
+func (m *userManager) DeleteUser(name string) error {
+	_, err := m.GetUser(name)
+	if err != nil {
+		return err
+	}
+
+	userPath := path.Join(userPrefix, name)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Delete user from kv.
+	err = m.kv.Remove(userPath)
+	if err != nil {
+		return err
+	}
+
+	// Delete user from memory cache.
+	delete(m.users, name)
+
+	return nil
+}
+
+// ChangePassword changes password of a user.
+func (m *userManager) ChangePassword(name string, password string) error {
+	user, err := m.GetUser(name)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	user.Hash = GenerateHash(password)
+
+	// Update user in kv
+	userJSON, err := json.Marshal(user)
+	if err != nil {
+		return errs.ErrJSONMarshal.Wrap(err).GenWithStackByCause()
+	}
+	userPath := path.Join(userPrefix, name)
+
+	err = m.kv.Save(userPath, string(userJSON))
+	if err != nil {
+		return err
+	}
+
+	// No need to update user in memory cache again.
+	return nil
+}
+
+// SetRoles sets roles of a user.
+func (m *userManager) SetRoles(name string, roles []string) error {
+	user, err := m.GetUser(name)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	user.RoleKeys = roles
+
+	// Update user in kv
+	userJSON, err := json.Marshal(user)
+	if err != nil {
+		return errs.ErrJSONMarshal.Wrap(err).GenWithStackByCause()
+	}
+	userPath := path.Join(userPrefix, name)
+
+	err = m.kv.Save(userPath, string(userJSON))
+	if err != nil {
+		return err
+	}
+
+	// No need to update user in memory cache again.
+	return nil
+}
+
+// AddRole adds a role to a user.
+func (m *userManager) AddRole(name string, role string) error {
+	user, err := m.GetUser(name)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ok := user.appendRole(role); !ok {
+		return errs.ErrUserHasRole.FastGenByArgs(name, role)
+	}
+
+	userJSON, err := json.Marshal(role)
+	if err != nil {
+		return errs.ErrJSONMarshal.Wrap(err).GenWithStackByCause()
+	}
+	userPath := path.Join(userPrefix, name)
+
+	// Update user in kv.
+	err = m.kv.Save(userPath, string(userJSON))
+	if err != nil {
+		return err
+	}
+
+	// Update user in memory cache.
+	m.users[name] = user
+
+	return nil
+}
+
+// RemoveRole removes a role from a user.
+func (m *userManager) RemoveRole(name string, role string) error {
+	user, err := m.GetUser(name)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if ok := user.removeRole(role); !ok {
+		return errs.ErrUserMissingRole.FastGenByArgs(name, role)
+	}
+
+	userJSON, err := json.Marshal(role)
+	if err != nil {
+		return errs.ErrJSONMarshal.Wrap(err).GenWithStackByCause()
+	}
+	userPath := path.Join(userPrefix, name)
+
+	// Update user in kv.
+	err = m.kv.Save(userPath, string(userJSON))
+	if err != nil {
+		return err
+	}
+
+	// Update user in memory cache.
+	m.users[name] = user
+
+	return nil
+}
+
+// UpdateCache refreshes in-memory cache of users.
+func (m *userManager) UpdateCache() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	userPath := strings.Join([]string{userPrefix, ""}, "/")
+
+	keys, values, err := m.kv.LoadRange(userPath, clientv3.GetPrefixRangeEnd(userPath), 0)
+	if err != nil {
+		return err
+	}
+
+	m.users = make(map[string]*User)
+	for i := range keys {
+		value := values[i]
+		user, err := NewUserFromJSON(value)
+		if err != nil {
+			return err
+		}
+		m.users[user.Username] = user
+	}
+	return nil
 }
 
 type roleManager struct {
@@ -35,7 +287,7 @@ type roleManager struct {
 	roles map[string]*Role
 }
 
-// newRoleManager creates a new roleManager.
+// newRoleManager creates a new roleManager for debug purposes.
 func newRoleManager(kv kv.Base) *roleManager {
 	return &roleManager{kv: kv, roles: make(map[string]*Role)}
 }
@@ -223,6 +475,7 @@ func (m *roleManager) RemovePermission(name string, permission Permission) error
 	return nil
 }
 
+// UpdateCache refreshes in-memory cache of roles.
 func (m *roleManager) UpdateCache() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -32,10 +32,11 @@ func Test(t *testing.T) {
 var _ = Suite(&testAuthSuite{})
 
 type testAuthSuite struct{}
-type testFunc func(*C, *roleManager)
+type testUserFunc func(*C, *userManager)
+type testRoleFunc func(*C, *roleManager)
 
 func (s *testAuthSuite) TestRoleManager(c *C) {
-	testFuncs := []testFunc{
+	testFuncs := []testRoleFunc{
 		s.testGetRole,
 		s.testGetRoles,
 		s.testCreateRole,
@@ -52,6 +53,156 @@ func (s *testAuthSuite) TestRoleManager(c *C) {
 		c.Assert(err, IsNil)
 		f(c, manager)
 	}
+}
+
+func (s *testAuthSuite) TestUserManager(c *C) {
+	testFuncs := []testUserFunc{
+		s.testGetUser,
+		s.testGetUsers,
+		s.testCreateUser,
+		s.testDeleteUser,
+		s.testChangePassword,
+		s.testSetRoles,
+		s.testAddRole,
+		s.testRemoveRole,
+	}
+	for _, f := range testFuncs {
+		k := kv.NewMemoryKV()
+		initKV(c, k)
+		manager := newUserManager(k)
+		err := manager.UpdateCache()
+		c.Assert(err, IsNil)
+		f(c, manager)
+	}
+}
+
+func (s *testAuthSuite) testGetUser(c *C, m *userManager) {
+	expectedUser := User{
+		Username: "bob",
+		Hash:     "da7655b5bf67039c3e76a99d8e6fb6969370bbc0fa440cae699cf1a3e2f1e0a1",
+		RoleKeys: []string{"reader", "writer"},
+	}
+	user, err := m.GetUser("bob")
+	c.Assert(err, IsNil)
+	c.Assert(user, DeepEquals, &expectedUser)
+	_, err = m.GetUser("john")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserNotFound.Equal(err), IsTrue)
+}
+
+func (s *testAuthSuite) testGetUsers(c *C, m *userManager) {
+	expectedUsers := []User{
+		{
+			Username: "alice",
+			Hash:     "13dc8554575637802eec3c0117f41591a990e1a2d37160018c48c9125063838a",
+			RoleKeys: []string{"reader"}},
+		{
+			Username: "bob",
+			Hash:     "da7655b5bf67039c3e76a99d8e6fb6969370bbc0fa440cae699cf1a3e2f1e0a1",
+			RoleKeys: []string{"reader", "writer"}},
+		{
+			Username: "lambda",
+			Hash:     "f9f967e71dff16bd5ce92e62d50140503a3ce399f294b1848adb210149bc1fd0",
+			RoleKeys: []string{"admin"},
+		},
+	}
+	users := m.GetUsers()
+	c.Assert(len(users), Equals, 3)
+	for _, user := range users {
+		hasUser := false
+		for _, expectedUser := range expectedUsers {
+			if user.Username == expectedUser.Username &&
+				user.Hash == expectedUser.Hash &&
+				reflect.DeepEqual(user.RoleKeys, expectedUser.RoleKeys) {
+				hasUser = true
+				break
+			}
+		}
+		c.Assert(hasUser, IsTrue)
+	}
+}
+
+func (s *testAuthSuite) testCreateUser(c *C, m *userManager) {
+	expectedUser := User{Username: "jane", Hash: "100e060425c270b01138bc4ed9b498897d2ec525baa766d9a57004b318e99e19", RoleKeys: []string{}}
+	err := m.CreateUser("bob", "bobpass")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserExists.Equal(err), IsTrue)
+	err = m.CreateUser("!", "!pass")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrInvalidUserName.Equal(err), IsTrue)
+
+	_, err = m.GetUser("jane")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserNotFound.Equal(err), IsTrue)
+	err = m.CreateUser("jane", "janepass")
+	c.Assert(err, IsNil)
+	user, err := m.GetUser("jane")
+	c.Assert(err, IsNil)
+	c.Assert(user, DeepEquals, &expectedUser)
+}
+
+func (s *testAuthSuite) testDeleteUser(c *C, m *userManager) {
+	err := m.DeleteUser("john")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserNotFound.Equal(err), IsTrue)
+
+	err = m.DeleteUser("alice")
+	c.Assert(err, IsNil)
+	err = m.DeleteUser("alice")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserNotFound.Equal(err), IsTrue)
+}
+
+func (s *testAuthSuite) testChangePassword(c *C, m *userManager) {
+	err := m.ChangePassword("john", "johnpass")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserNotFound.Equal(err), IsTrue)
+
+	user, err := m.GetUser("alice")
+	c.Assert(err, IsNil)
+	c.Assert(user.ComparePassword("alicepass"), IsNil)
+
+	err = m.ChangePassword("alice", "testpass")
+	c.Assert(err, IsNil)
+
+	user, err = m.GetUser("alice")
+	c.Assert(err, IsNil)
+	c.Assert(user.ComparePassword("testpass"), IsNil)
+}
+
+func (s *testAuthSuite) testSetRoles(c *C, m *userManager) {
+	err := m.SetRoles("alice", []string{"writer", "admin"})
+	c.Assert(err, IsNil)
+
+	user, err := m.GetUser("alice")
+	c.Assert(err, IsNil)
+	c.Assert(user.GetRoleKeys(), DeepEquals, []string{"writer", "admin"})
+}
+
+func (s *testAuthSuite) testAddRole(c *C, m *userManager) {
+	err := m.AddRole("alice", "reader")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserHasRole.Equal(err), IsTrue)
+
+	err = m.AddRole("alice", "writer")
+	c.Assert(err, IsNil)
+
+	user, err := m.GetUser("alice")
+	c.Assert(err, IsNil)
+	c.Assert(user.GetRoleKeys(), DeepEquals, []string{"reader", "writer"})
+}
+
+func (s *testAuthSuite) testRemoveRole(c *C, m *userManager) {
+	err := m.RemoveRole("alice", "writer")
+	c.Assert(err, NotNil)
+	c.Assert(errs.ErrUserMissingRole.Equal(err), IsTrue)
+
+	err = m.RemoveRole("alice", "reader")
+	c.Assert(err, IsNil)
+
+	user, err := m.GetUser("alice")
+	c.Assert(err, IsNil)
+	c.Assert(user.GetRoleKeys(), DeepEquals, []string{})
 }
 
 func (s *testAuthSuite) testGetRole(c *C, m *roleManager) {
@@ -243,10 +394,34 @@ func initKV(c *C, k kv.Base) {
 			{Resource: "users", Action: "update"},
 		}},
 	}
+	users := []struct {
+		Username string   `json:"username"`
+		Hash     string   `json:"hash"`
+		Roles    []string `json:"roles"`
+	}{
+		{
+			Username: "alice",
+			Hash:     "13dc8554575637802eec3c0117f41591a990e1a2d37160018c48c9125063838a", // pass: alicepass
+			Roles:    []string{"reader"}},
+		{
+			Username: "bob",
+			Hash:     "da7655b5bf67039c3e76a99d8e6fb6969370bbc0fa440cae699cf1a3e2f1e0a1", // pass: bobpass
+			Roles:    []string{"reader", "writer"}},
+		{
+			Username: "lambda",
+			Hash:     "f9f967e71dff16bd5ce92e62d50140503a3ce399f294b1848adb210149bc1fd0", // pass: lambdapass
+			Roles:    []string{"admin"}},
+	}
 	for _, role := range roles {
 		value, err := json.Marshal(role)
 		c.Assert(err, IsNil)
 		err = k.Save(path.Join(rolePrefix, role.Name), string(value))
+		c.Assert(err, IsNil)
+	}
+	for _, user := range users {
+		value, err := json.Marshal(user)
+		c.Assert(err, IsNil)
+		err = k.Save(path.Join(userPrefix, user.Username), string(value))
 		c.Assert(err, IsNil)
 	}
 }

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -15,7 +15,6 @@ package auth
 
 import (
 	"encoding/json"
-	"path"
 	"reflect"
 	"testing"
 
@@ -415,13 +414,13 @@ func initKV(c *C, k kv.Base) {
 	for _, role := range roles {
 		value, err := json.Marshal(role)
 		c.Assert(err, IsNil)
-		err = k.Save(path.Join(rolePrefix, role.Name), string(value))
+		err = k.Save(GetRolePath(role.Name), string(value))
 		c.Assert(err, IsNil)
 	}
 	for _, user := range users {
 		value, err := json.Marshal(user)
 		c.Assert(err, IsNil)
-		err = k.Save(path.Join(userPrefix, user.Username), string(value))
+		err = k.Save(GetUserPath(user.Username), string(value))
 		c.Assert(err, IsNil)
 	}
 }

--- a/server/auth/role.go
+++ b/server/auth/role.go
@@ -36,8 +36,8 @@ func NewRole(name string) (*Role, error) {
 	return &Role{Name: name, Permissions: make([]Permission, 0)}, nil
 }
 
-// NewRoleFromJSON safely deserialize a json string to a role instance.
-func NewRoleFromJSON(j string) (*Role, error) {
+// UnmarshalRole safely deserialize a json string to a role instance.
+func UnmarshalRole(j string) (*Role, error) {
 	role := Role{Permissions: make([]Permission, 0)}
 	err := json.Unmarshal([]byte(j), &role)
 	if err != nil {

--- a/server/auth/role.go
+++ b/server/auth/role.go
@@ -19,10 +19,6 @@ import (
 	"github.com/tikv/pd/pkg/errs"
 )
 
-const (
-	rolePrefix = "roles"
-)
-
 // Role records role info.
 // Read-Only once created.
 type Role struct {

--- a/server/auth/role_test.go
+++ b/server/auth/role_test.go
@@ -55,7 +55,7 @@ func (s *testRoleSuite) TestRole(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(j), Equals, marshalledRole)
 
-	unmarshalledRole, err := NewRoleFromJSON(string(j))
+	unmarshalledRole, err := UnmarshalRole(string(j))
 	c.Assert(err, IsNil)
 	c.Assert(unmarshalledRole, DeepEquals, role)
 

--- a/server/auth/user.go
+++ b/server/auth/user.go
@@ -23,7 +23,7 @@ import (
 // Read-Only once created.
 type User struct {
 	Username string   `json:"username"`
-	Hash     string   `json:"hash"`
+	Hash     string   `json:"hash"` // sha256 hash for password
 	RoleKeys []string `json:"roles"`
 }
 
@@ -37,8 +37,8 @@ func NewUser(username string, hash string) (*User, error) {
 	return &User{Username: username, Hash: hash, RoleKeys: make([]string, 0)}, nil
 }
 
-// NewUserFromJSON safely deserialize a json string to a user instance.
-func NewUserFromJSON(j string) (*User, error) {
+// UnmarshalUser safely deserialize a json string to a user instance.
+func UnmarshalUser(j string) (*User, error) {
 	user := User{RoleKeys: make([]string, 0)}
 	err := json.Unmarshal([]byte(j), &user)
 	if err != nil {

--- a/server/auth/user.go
+++ b/server/auth/user.go
@@ -1,0 +1,107 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"encoding/json"
+
+	"github.com/tikv/pd/pkg/errs"
+)
+
+// User records user info.
+// Read-Only once created.
+type User struct {
+	Username string   `json:"username"`
+	Hash     string   `json:"hash"`
+	RoleKeys []string `json:"roles"`
+}
+
+// NewUser safely creates a new user instance.
+func NewUser(username string, hash string) (*User, error) {
+	ok := validateName(username)
+	if !ok {
+		return nil, errs.ErrInvalidUserName.FastGenByArgs(username)
+	}
+
+	return &User{Username: username, Hash: hash, RoleKeys: make([]string, 0)}, nil
+}
+
+// NewUserFromJSON safely deserialize a json string to a user instance.
+func NewUserFromJSON(j string) (*User, error) {
+	user := User{RoleKeys: make([]string, 0)}
+	err := json.Unmarshal([]byte(j), &user)
+	if err != nil {
+		return nil, errs.ErrJSONUnmarshal.Wrap(err).GenWithStackByCause()
+	}
+
+	ok := validateName(user.Username)
+	if !ok {
+		return nil, errs.ErrInvalidUserName.FastGenByArgs(user.Username)
+	}
+
+	return &user, nil
+}
+
+// Clone creates a deep copy of user instance.
+func (u *User) Clone() *User {
+	return &User{Username: u.Username, Hash: u.Hash, RoleKeys: u.RoleKeys}
+}
+
+// GetUsername returns username of this user.
+func (u *User) GetUsername() string {
+	return u.Username
+}
+
+// GetRoleKeys returns role keys of this user.
+func (u *User) GetRoleKeys() []string {
+	return u.RoleKeys
+}
+
+// ComparePassword checks whether given string matches the password of this user.
+func (u *User) ComparePassword(candidate string) error {
+	return compareHashAndPassword(u.Hash, candidate)
+}
+
+// hasRole checks whether this user has a specific role.
+func (u *User) hasRole(name string) bool {
+	for _, k := range u.RoleKeys {
+		if k == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// appendPermission appends a permission to this role.
+func (u *User) appendRole(role string) bool {
+	if ok := u.hasRole(role); ok {
+		return false
+	}
+
+	u.RoleKeys = append(u.RoleKeys, role)
+	return true
+}
+
+// removePermission deletes a permission from this role.
+func (u *User) removeRole(role string) bool {
+	for i, perm := range u.RoleKeys {
+		if perm == role {
+			u.RoleKeys[i] = u.RoleKeys[len(u.RoleKeys)-1]
+			u.RoleKeys = u.RoleKeys[:len(u.RoleKeys)-1]
+			return true
+		}
+	}
+	return false
+}

--- a/server/auth/user_test.go
+++ b/server/auth/user_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"encoding/json"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testUserSuite{})
+
+type testUserSuite struct{}
+
+func (s *testUserSuite) TestUser(c *C) {
+	_, err := NewUser("00test", "")
+	c.Assert(err, NotNil)
+	user, err := NewUser("test", "a0705ec8c6c0dab42344570b50608935174f84b5c365e9ff2b3ed92e0fc8e037")
+	c.Assert(err, IsNil)
+	user.RoleKeys = []string{"reader", "writer"}
+
+	c.Assert(user.GetUsername(), Equals, "test")
+	c.Assert(user.GetRoleKeys(), DeepEquals, []string{"reader", "writer"})
+	c.Assert(user.hasRole("reader"), IsTrue)
+	c.Assert(user.hasRole("admin"), IsFalse)
+	c.Assert(user.appendRole("reader"), IsFalse)
+	c.Assert(user.appendRole("admin"), IsTrue)
+	c.Assert(user.hasRole("admin"), IsTrue)
+
+	c.Assert(user.Clone(), DeepEquals, user)
+
+	c.Assert(user.ComparePassword("somethingwrong"), NotNil)
+	c.Assert(user.ComparePassword("ItsaCrazilysEcurepass"), IsNil)
+
+	marshalledUser := "{\"username\":\"test\"," +
+		"\"hash\":\"a0705ec8c6c0dab42344570b50608935174f84b5c365e9ff2b3ed92e0fc8e037\"," +
+		"\"roles\":[\"reader\",\"writer\",\"admin\"]}"
+	j, err := json.Marshal(user)
+	c.Assert(err, IsNil)
+	c.Assert(string(j), Equals, marshalledUser)
+
+	unmarshalledUser, err := NewUserFromJSON(string(j))
+	c.Assert(err, IsNil)
+	c.Assert(unmarshalledUser, DeepEquals, user)
+
+	c.Assert(user.removeRole("somebody"), IsFalse)
+	c.Assert(user.removeRole("reader"), IsTrue)
+	c.Assert(user.removeRole("writer"), IsTrue)
+	c.Assert(user.removeRole("admin"), IsTrue)
+	c.Assert(user.GetRoleKeys(), DeepEquals, []string{})
+}

--- a/server/auth/user_test.go
+++ b/server/auth/user_test.go
@@ -50,7 +50,7 @@ func (s *testUserSuite) TestUser(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(string(j), Equals, marshalledUser)
 
-	unmarshalledUser, err := NewUserFromJSON(string(j))
+	unmarshalledUser, err := UnmarshalUser(string(j))
 	c.Assert(err, IsNil)
 	c.Assert(unmarshalledUser, DeepEquals, user)
 

--- a/server/auth/util.go
+++ b/server/auth/util.go
@@ -14,12 +14,30 @@
 package auth
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"regexp"
+
+	"github.com/tikv/pd/pkg/errs"
 )
 
 var (
 	patName = regexp.MustCompile("^([A-Za-z])[A-Za-z0-9_]*$")
 )
+
+func compareHashAndPassword(hash string, password string) error {
+	hashFromPlain := GenerateHash(password)
+	if hash == hashFromPlain {
+		return nil
+	}
+	return errs.ErrPasswordMismatch.FastGenByArgs()
+}
+
+// GenerateHash generates hash for a given password.
+func GenerateHash(password string) string {
+	hashFromPassword := sha256.Sum256([]byte(password))
+	return hex.EncodeToString(hashFromPassword[:])
+}
 
 func validateName(name string) bool {
 	return patName.MatchString(name)

--- a/server/auth/util.go
+++ b/server/auth/util.go
@@ -17,12 +17,18 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"regexp"
+	"strings"
 
 	"github.com/tikv/pd/pkg/errs"
 )
 
 var (
 	patName = regexp.MustCompile("^([A-Za-z])[A-Za-z0-9_]*$")
+)
+
+const (
+	userPrefix = "users"
+	rolePrefix = "roles"
 )
 
 func compareHashAndPassword(hash string, password string) error {
@@ -41,4 +47,14 @@ func GenerateHash(password string) string {
 
 func validateName(name string) bool {
 	return patName.MatchString(name)
+}
+
+// GetUserPath generates kv path based on given name.
+func GetUserPath(name string) string {
+	return strings.Join([]string{userPrefix, name}, "/")
+}
+
+// GetRolePath generates kv path based on given name.
+func GetRolePath(name string) string {
+	return strings.Join([]string{rolePrefix, name}, "/")
 }

--- a/server/auth/util_test.go
+++ b/server/auth/util_test.go
@@ -21,6 +21,19 @@ var _ = Suite(&testUtilSuite{})
 
 type testUtilSuite struct{}
 
+func (s *testUtilSuite) TestGenerateHash(c *C) {
+	hash := GenerateHash("ItsaCrazilysEcurepass")
+	c.Assert(hash, Equals, "a0705ec8c6c0dab42344570b50608935174f84b5c365e9ff2b3ed92e0fc8e037")
+}
+
+func (s *testUtilSuite) TestCompareHashAndPasswordSuite(c *C) {
+	err := compareHashAndPassword("a0705ec8c6c0dab42344570b50608935174f84b5c365e9ff2b3ed92e0fc8e037", "ItsaCrazilysEcurepass")
+	c.Assert(err, IsNil)
+
+	err = compareHashAndPassword("a0705ec8c6c0dab42344570b50608935174f84b5c365e9ff2b3ed92e0fc8e037", "blablabla")
+	c.Assert(err, NotNil)
+}
+
 func (s *testUtilSuite) TestValidateName(c *C) {
 	ok := validateName("123abc")
 	c.Assert(ok, IsFalse)

--- a/server/auth/util_test.go
+++ b/server/auth/util_test.go
@@ -44,3 +44,13 @@ func (s *testUtilSuite) TestValidateName(c *C) {
 	ok = validateName("fo_o123")
 	c.Assert(ok, IsTrue)
 }
+
+func (s *testUtilSuite) TestGetUserPath(c *C) {
+	c.Assert(GetUserPath(""), Equals, "users/")
+	c.Assert(GetUserPath("john"), Equals, "users/john")
+}
+
+func (s *testUtilSuite) TestGetRolePath(c *C) {
+	c.Assert(GetRolePath(""), Equals, "roles/")
+	c.Assert(GetRolePath("john"), Equals, "roles/john")
+}


### PR DESCRIPTION
Signed-off-by: PhotonQuantum <self@lightquantum.me>

### What problem does this PR solve?

ref: https://github.com/tikv/tikv/issues/8621
server/auth: implement user & user manager.

Related PR: #3256 

### What is changed and how it works?

server/auth `userManager` is implemented to handle user-related CRUD operations, including querying users in memory, loading them from etcd and persisting them to etcd.

### Check List

Tests

- Unit test

Code changes

- Has persistent data change (etcd)

### Release note

- No release note