### PR TITLE
mockcluster: use realistic store size and region size in unit tests

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -549,6 +549,7 @@ func (mc *Cluster) UpdateStoreStatus(id uint64) {
 		core.SetPendingPeerCount(pendingPeerCount),
 		core.SetLeaderSize(leaderSize),
 		core.SetRegionSize(regionSize),
+		core.SetLastHeartbeatTS(time.Now()),
 	)
 	mc.PutStore(newStore)
 }

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -32,6 +32,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultStoreCapacity = 100 * (1 << 30) // 100GiB
+	defaultRegionSize    = 96 * (1 << 20)  // 96MiB
+	mb                   = (1 << 20)       // 1MiB
+)
+
 // Cluster is used to mock clusterInfo for test use.
 type Cluster struct {
 	*core.BasicCluster
@@ -206,13 +212,14 @@ func (mc *Cluster) SetStoreBusy(storeID uint64, busy bool) {
 // AddLeaderStore adds store with specified count of leader.
 func (mc *Cluster) AddLeaderStore(storeID uint64, leaderCount int, leaderSizes ...int64) {
 	stats := &pdpb.StoreStats{}
-	stats.Capacity = 1000 * (1 << 20)
-	stats.Available = stats.Capacity - uint64(leaderCount)*10
+	stats.Capacity = defaultStoreCapacity
+	stats.UsedSize = uint64(leaderCount) * defaultRegionSize
+	stats.Available = stats.Capacity - uint64(leaderCount)*defaultRegionSize
 	var leaderSize int64
 	if len(leaderSizes) != 0 {
 		leaderSize = leaderSizes[0]
 	} else {
-		leaderSize = int64(leaderCount) * 10
+		leaderSize = int64(leaderCount) * defaultRegionSize / mb
 	}
 
 	store := core.NewStoreInfo(
@@ -230,8 +237,9 @@ func (mc *Cluster) AddLeaderStore(storeID uint64, leaderCount int, leaderSizes .
 // AddRegionStore adds store with specified count of region.
 func (mc *Cluster) AddRegionStore(storeID uint64, regionCount int) {
 	stats := &pdpb.StoreStats{}
-	stats.Capacity = 1000 * (1 << 20)
-	stats.Available = stats.Capacity - uint64(regionCount)*10
+	stats.Capacity = defaultStoreCapacity
+	stats.UsedSize = uint64(regionCount) * defaultRegionSize
+	stats.Available = stats.Capacity - uint64(regionCount)*defaultRegionSize
 	store := core.NewStoreInfo(
 		&metapb.Store{Id: storeID, Labels: []*metapb.StoreLabel{
 			{
@@ -241,7 +249,7 @@ func (mc *Cluster) AddRegionStore(storeID uint64, regionCount int) {
 		}},
 		core.SetStoreStats(stats),
 		core.SetRegionCount(regionCount),
-		core.SetRegionSize(int64(regionCount)*10),
+		core.SetRegionSize(int64(regionCount)*defaultRegionSize/mb),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
 	mc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
@@ -269,8 +277,9 @@ func (mc *Cluster) AddLabelsStore(storeID uint64, regionCount int, labels map[st
 		newLabels = append(newLabels, &metapb.StoreLabel{Key: k, Value: v})
 	}
 	stats := &pdpb.StoreStats{}
-	stats.Capacity = 1000 * (1 << 20)
-	stats.Available = stats.Capacity - uint64(regionCount)*10
+	stats.Capacity = defaultStoreCapacity
+	stats.Available = stats.Capacity - uint64(regionCount)*defaultRegionSize
+	stats.UsedSize = uint64(regionCount) * defaultRegionSize
 	store := core.NewStoreInfo(
 		&metapb.Store{
 			Id:     storeID,
@@ -278,7 +287,7 @@ func (mc *Cluster) AddLabelsStore(storeID uint64, regionCount int, labels map[st
 		},
 		core.SetStoreStats(stats),
 		core.SetRegionCount(regionCount),
-		core.SetRegionSize(int64(regionCount)*10),
+		core.SetRegionSize(int64(regionCount)*defaultRegionSize/mb),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
 	mc.SetStoreLimit(storeID, storelimit.AddPeer, 60)
@@ -289,7 +298,7 @@ func (mc *Cluster) AddLabelsStore(storeID uint64, regionCount int, labels map[st
 // AddLeaderRegion adds region with specified leader and followers.
 func (mc *Cluster) AddLeaderRegion(regionID uint64, leaderStoreID uint64, followerStoreIDs ...uint64) *core.RegionInfo {
 	origin := mc.newMockRegionInfo(regionID, leaderStoreID, followerStoreIDs...)
-	region := origin.Clone(core.SetApproximateSize(10), core.SetApproximateKeys(10))
+	region := origin.Clone(core.SetApproximateSize(defaultRegionSize/mb), core.SetApproximateKeys(10))
 	mc.PutRegion(region)
 	return region
 }
@@ -297,7 +306,7 @@ func (mc *Cluster) AddLeaderRegion(regionID uint64, leaderStoreID uint64, follow
 // AddRegionWithLearner adds region with specified leader, followers and learners.
 func (mc *Cluster) AddRegionWithLearner(regionID uint64, leaderStoreID uint64, followerStoreIDs, learnerStoreIDs []uint64) *core.RegionInfo {
 	origin := mc.MockRegionInfo(regionID, leaderStoreID, followerStoreIDs, learnerStoreIDs, nil)
-	region := origin.Clone(core.SetApproximateSize(10), core.SetApproximateKeys(10))
+	region := origin.Clone(core.SetApproximateSize(defaultRegionSize/mb), core.SetApproximateKeys(10))
 	mc.PutRegion(region)
 	return region
 }
@@ -395,7 +404,7 @@ func (mc *Cluster) UpdateLeaderCount(storeID uint64, leaderCount int) {
 	store := mc.GetStore(storeID)
 	newStore := store.Clone(
 		core.SetLeaderCount(leaderCount),
-		core.SetLeaderSize(int64(leaderCount)*10),
+		core.SetLeaderSize(int64(leaderCount)*defaultRegionSize/mb),
 	)
 	mc.PutStore(newStore)
 }
@@ -405,7 +414,7 @@ func (mc *Cluster) UpdateRegionCount(storeID uint64, regionCount int) {
 	store := mc.GetStore(storeID)
 	newStore := store.Clone(
 		core.SetRegionCount(regionCount),
-		core.SetRegionSize(int64(regionCount)*10),
+		core.SetRegionSize(int64(regionCount)*defaultRegionSize/mb),
 	)
 	mc.PutStore(newStore)
 }
@@ -430,7 +439,7 @@ func (mc *Cluster) UpdatePendingPeerCount(storeID uint64, pendingPeerCount int) 
 func (mc *Cluster) UpdateStorageRatio(storeID uint64, usedRatio, availableRatio float64) {
 	store := mc.GetStore(storeID)
 	newStats := proto.Clone(store.GetStoreStats()).(*pdpb.StoreStats)
-	newStats.Capacity = 1000 * (1 << 20)
+	newStats.Capacity = defaultStoreCapacity
 	newStats.UsedSize = uint64(float64(newStats.Capacity) * usedRatio)
 	newStats.Available = uint64(float64(newStats.Capacity) * availableRatio)
 	newStore := store.Clone(core.SetStoreStats(newStats))
@@ -530,9 +539,9 @@ func (mc *Cluster) UpdateStoreStatus(id uint64) {
 	regionSize := mc.Regions.GetStoreRegionSize(id)
 	store := mc.Stores.GetStore(id)
 	stats := &pdpb.StoreStats{}
-	stats.Capacity = 1000 * (1 << 20)
-	stats.Available = stats.Capacity - uint64(store.GetRegionSize())
-	stats.UsedSize = uint64(store.GetRegionSize())
+	stats.Capacity = defaultStoreCapacity
+	stats.Available = stats.Capacity - uint64(store.GetRegionSize()*mb)
+	stats.UsedSize = uint64(store.GetRegionSize() * mb)
 	newStore := store.Clone(
 		core.SetStoreStats(stats),
 		core.SetLeaderCount(leaderCount),

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -61,8 +61,9 @@ func (c *testCluster) addRegionStore(storeID uint64, regionCount int, regionSize
 	}
 
 	stats := &pdpb.StoreStats{}
-	stats.Capacity = 1000 * (1 << 20)
-	stats.Available = stats.Capacity - regionSize
+	stats.Capacity = 100 * (1 << 30)
+	stats.UsedSize = regionSize * (1 << 20)
+	stats.Available = stats.Capacity - stats.UsedSize
 	newStore := core.NewStoreInfo(&metapb.Store{Id: storeID},
 		core.SetStoreStats(stats),
 		core.SetRegionCount(regionCount),

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -352,6 +352,8 @@ func (t *testOperatorControllerSuite) TestStoreLimit(c *C) {
 	tc.AddLeaderStore(2, 0)
 	for i := uint64(1); i <= 1000; i++ {
 		tc.AddLeaderRegion(i, i)
+		// make it small region
+		tc.PutRegion(tc.GetRegion(i).Clone(core.SetApproximateSize(10)))
 	}
 
 	tc.SetStoreLimit(2, storelimit.AddPeer, 60)
@@ -415,6 +417,7 @@ func (t *testOperatorControllerSuite) TestDispatchOutdatedRegion(c *C) {
 
 	cluster.AddLeaderStore(1, 2)
 	cluster.AddLeaderStore(2, 0)
+	cluster.SetAllStoresLimit(storelimit.RemovePeer, 600)
 	cluster.AddLeaderRegion(1, 1, 2)
 	steps := []operator.OpStep{
 		operator.TransferLeader{FromStore: 1, ToStore: 2},

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -45,57 +45,57 @@ type testBalanceSpeedCase struct {
 }
 
 func (s *testBalanceSuite) TestShouldBalance(c *C) {
+	// store size = 100GiB
+	// region size = 96MiB
+	const R = 96
 	tests := []testBalanceSpeedCase{
-		// all store capacity is 1024MB
-		// size = count * 10
-
 		// target size is zero
-		{2, 0, 1, true, core.BySize},
-		{2, 0, 10, false, core.BySize},
+		{2, 0, R / 10, true, core.BySize},
+		{2, 0, R, false, core.BySize},
 		// all in high space stage
-		{10, 5, 1, true, core.BySize},
-		{10, 5, 20, false, core.BySize},
-		{10, 10, 1, false, core.BySize},
-		{10, 10, 20, false, core.BySize},
+		{10, 5, R / 10, true, core.BySize},
+		{10, 5, 2 * R, false, core.BySize},
+		{10, 10, R / 10, false, core.BySize},
+		{10, 10, 2 * R, false, core.BySize},
 		// all in transition stage
-		{70, 50, 1, true, core.BySize},
-		{70, 50, 50, false, core.BySize},
-		{70, 70, 1, false, core.BySize},
+		{700, 680, R / 10, true, core.BySize},
+		{700, 680, 5 * R, false, core.BySize},
+		{700, 700, R / 10, false, core.BySize},
 		// all in low space stage
-		{90, 80, 1, true, core.BySize},
-		{90, 80, 50, false, core.BySize},
-		{90, 90, 1, false, core.BySize},
+		{900, 890, R / 10, true, core.BySize},
+		{900, 890, 5 * R, false, core.BySize},
+		{900, 900, R / 10, false, core.BySize},
 		// one in high space stage, other in transition stage
-		{65, 55, 5, true, core.BySize},
-		{65, 50, 50, false, core.BySize},
+		{650, 550, R, true, core.BySize},
+		{650, 500, 50 * R, false, core.BySize},
 		// one in transition space stage, other in low space stage
-		{80, 70, 5, true, core.BySize},
-		{80, 70, 50, false, core.BySize},
+		{800, 700, R, true, core.BySize},
+		{800, 700, 50 * R, false, core.BySize},
 
 		// default leader tolerant ratio is 5, when schedule by count
 		// target size is zero
-		{2, 0, 1, false, core.ByCount},
-		{2, 0, 10, false, core.ByCount},
+		{2, 0, R / 10, false, core.ByCount},
+		{2, 0, R, false, core.ByCount},
 		// all in high space stage
-		{10, 5, 1, true, core.ByCount},
-		{10, 5, 20, true, core.ByCount},
-		{10, 6, 20, false, core.ByCount},
-		{10, 10, 1, false, core.ByCount},
-		{10, 10, 20, false, core.ByCount},
+		{10, 5, R / 10, true, core.ByCount},
+		{10, 5, 2 * R, true, core.ByCount},
+		{10, 6, 2 * R, false, core.ByCount},
+		{10, 10, R / 10, false, core.ByCount},
+		{10, 10, 2 * R, false, core.ByCount},
 		// all in transition stage
-		{70, 50, 1, true, core.ByCount},
-		{70, 50, 50, true, core.ByCount},
-		{70, 70, 1, false, core.ByCount},
+		{70, 50, R / 10, true, core.ByCount},
+		{70, 50, 5 * R, true, core.ByCount},
+		{70, 70, R / 10, false, core.ByCount},
 		// all in low space stage
-		{90, 80, 1, true, core.ByCount},
-		{90, 80, 50, true, core.ByCount},
-		{90, 90, 1, false, core.ByCount},
+		{90, 80, R / 10, true, core.ByCount},
+		{90, 80, 5 * R, true, core.ByCount},
+		{90, 90, R / 10, false, core.ByCount},
 		// one in high space stage, other in transition stage
-		{65, 55, 5, true, core.ByCount},
-		{65, 50, 50, true, core.ByCount},
+		{65, 55, R / 2, true, core.ByCount},
+		{65, 50, 5 * R, true, core.ByCount},
 		// one in transition space stage, other in low space stage
-		{80, 70, 5, true, core.ByCount},
-		{80, 70, 50, true, core.ByCount},
+		{80, 70, R / 2, true, core.ByCount},
+		{80, 70, 5 * R, true, core.ByCount},
 	}
 
 	opt := config.NewTestOptions()
@@ -240,10 +240,10 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalanceLeaderSchedulePolicy(c *C) 
 	// Leader Count:    10      10      10      10
 	// Leader Size :    10000   100    	100    	100
 	// Region1:         L       F       F       F
-	s.tc.AddLeaderStore(1, 10, 10000)
-	s.tc.AddLeaderStore(2, 10, 100)
-	s.tc.AddLeaderStore(3, 10, 100)
-	s.tc.AddLeaderStore(4, 10, 100)
+	s.tc.AddLeaderStore(1, 10, 10000*MB)
+	s.tc.AddLeaderStore(2, 10, 100*MB)
+	s.tc.AddLeaderStore(3, 10, 100*MB)
+	s.tc.AddLeaderStore(4, 10, 100*MB)
 	s.tc.AddLeaderRegion(1, 1, 2, 3, 4)
 	c.Assert(s.tc.GetScheduleConfig().LeaderSchedulePolicy, Equals, core.ByCount.String()) // default by count
 	c.Check(s.schedule(), IsNil)
@@ -399,10 +399,10 @@ func (s *testBalanceLeaderSchedulerSuite) TestBalancePolicy(c *C) {
 	// Stores:       1    2     3    4
 	// LeaderCount: 20   66     6   20
 	// LeaderSize:  66   20    20    6
-	s.tc.AddLeaderStore(1, 20, 60)
-	s.tc.AddLeaderStore(2, 66, 20)
-	s.tc.AddLeaderStore(3, 6, 20)
-	s.tc.AddLeaderStore(4, 20, 1)
+	s.tc.AddLeaderStore(1, 20, 600*MB)
+	s.tc.AddLeaderStore(2, 66, 200*MB)
+	s.tc.AddLeaderStore(3, 6, 20*MB)
+	s.tc.AddLeaderStore(4, 20, 1*MB)
 	s.tc.AddLeaderRegion(1, 2, 1, 3, 4)
 	s.tc.AddLeaderRegion(2, 1, 2, 3, 4)
 	s.tc.SetLeaderSchedulePolicy("count")


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Currently, we use 1GB storage size and 10M region size for tests. It is different from the real configuration.

### What is changed and how it works?
Use 100GiB storage size and 96MiB region size by default.

### Check List

Tests
- Unit test

### Release note
- No release note
