### PR TITLE
*: avoid making empty slices

### DIFF
--- a/pkg/autoscaling/prometheus_test.go
+++ b/pkg/autoscaling/prometheus_test.go
@@ -126,7 +126,7 @@ func (c *normalClient) buildCPUMockData(component ComponentType) {
 	cpuUsageQuery := fmt.Sprintf(cpuUsagePromQLTemplate[component], mockDuration)
 	cpuQuotaQuery := cpuQuotaPromQLTemplate[component]
 
-	results := make([]result, 0)
+	var results []result
 	for i := 0; i < instanceCount; i++ {
 		results = append(results, result{
 			Value: []interface{}{time.Now().Unix(), fmt.Sprintf("%f", mockResultValue)},

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -616,7 +616,7 @@ func (c *coordinator) pauseOrResumeScheduler(name string, t int64) error {
 	if c.cluster == nil {
 		return errs.ErrNotBootstrapped.FastGenByArgs()
 	}
-	s := make([]*scheduleController, 0)
+	var s []*scheduleController
 	if name != "all" {
 		sc, ok := c.schedulers[name]
 		if !ok {

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -666,7 +666,7 @@ func NewIsolationFilter(scope, isolationLevel string, locationLabels []string, r
 	}
 	// Collect all constraints for given isolationLevel
 	for _, regionStore := range regionStores {
-		constraintList := make([]string, 0)
+		var constraintList []string
 		for i := 0; i <= isolationLevelIdx; i++ {
 			constraintList = append(constraintList, regionStore.GetLabelValue(locationLabels[i]))
 		}

--- a/server/schedule/region_splitter.go
+++ b/server/schedule/region_splitter.go
@@ -245,7 +245,7 @@ func (r *splitKeyResults) getSplitRegions() map[uint64][]byte {
 }
 
 func (r *splitKeyResults) getUnProcessedKeys(splitKeys [][]byte) [][]byte {
-	unProcessedKeys := make([][]byte, 0)
+	var unProcessedKeys [][]byte
 	for _, splitKey := range splitKeys {
 		processed := false
 		for _, regionStartKey := range r.newRegions {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -288,7 +288,7 @@ func summaryStoresLoad(
 		keyRate := storeKeyRate[id]
 
 		// Find all hot peers first
-		hotPeers := make([]*statistics.HotPeerStat, 0)
+		var hotPeers []*statistics.HotPeerStat
 		{
 			byteSum := 0.0
 			keySum := 0.0
@@ -363,7 +363,7 @@ func filterHotPeers(
 	minHotDegree int,
 	peers []*statistics.HotPeerStat,
 ) []*statistics.HotPeerStat {
-	ret := make([]*statistics.HotPeerStat, 0)
+	var ret []*statistics.HotPeerStat
 	for _, peer := range peers {
 		if (kind == core.LeaderKind && !peer.IsLeader()) ||
 			peer.HotDegree < minHotDegree {

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -784,7 +784,7 @@ func (am *AllocatorManager) resetAllocatorGroup(dcLocation string) {
 func (am *AllocatorManager) getAllocatorGroups(filters ...AllocatorGroupFilter) []*allocatorGroup {
 	am.mu.RLock()
 	defer am.mu.RUnlock()
-	allocatorGroups := make([]*allocatorGroup, 0)
+	var allocatorGroups []*allocatorGroup
 	for _, ag := range am.mu.allocatorGroups {
 		if ag == nil {
 			continue

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -269,7 +269,7 @@ func (gta *GlobalTSOAllocator) syncMaxTS(ctx context.Context, dcLocationMap map[
 }
 
 func (gta *GlobalTSOAllocator) checkSyncedDCs(dcLocationMap map[string][]uint64, syncedDCs []string) bool {
-	unsyncedDCs := make([]string, 0)
+	var unsyncedDCs []string
 	for dcLocation := range dcLocationMap {
 		if slice.NoneOf(syncedDCs, func(i int) bool { return syncedDCs[i] == dcLocation }) {
 			unsyncedDCs = append(unsyncedDCs, dcLocation)

--- a/tools/pd-analysis/analysis/transfer_counter.go
+++ b/tools/pd-analysis/analysis/transfer_counter.go
@@ -120,7 +120,7 @@ func (c *TransferCounter) prepare() {
 		c.unIndexMap[storeID] = index
 	}
 
-	c.graphMat = make([][]uint64, 0)
+	c.graphMat = nil
 	for i := 0; i < c.scheduledStoreNum; i++ {
 		tmp := make([]uint64, c.scheduledStoreNum)
 		c.graphMat = append(c.graphMat, tmp)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Making empty slices is somewhat dangerous in some cases. https://github.com/tikv/pd/issues/3272 gives an example.

### What is changed and how it works?

replace `x = make([]T, 0)` with `var x []T`.

### Check List
Tests
- Unit test
- 
### Release note
- No release note
