### PR TITLE
statistics: merge HotCache and StoreStats

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -43,8 +43,7 @@ type Cluster struct {
 	*core.BasicCluster
 	*mockid.IDAllocator
 	*placement.RuleManager
-	*statistics.HotCache
-	*statistics.StoresStats
+	*statistics.HotStat
 	*config.PersistOptions
 	ID               uint64
 	suspectRegions   map[uint64]struct{}
@@ -56,8 +55,7 @@ func NewCluster(opts *config.PersistOptions) *Cluster {
 	clus := &Cluster{
 		BasicCluster:     core.NewBasicCluster(),
 		IDAllocator:      mockid.NewIDAllocator(),
-		HotCache:         statistics.NewHotCache(),
-		StoresStats:      statistics.NewStoresStats(),
+		HotStat:          statistics.NewHotStat(),
 		PersistOptions:   opts,
 		suspectRegions:   map[uint64]struct{}{},
 		disabledFeatures: make(map[versioninfo.Feature]struct{}),
@@ -92,7 +90,7 @@ func (mc *Cluster) LoadRegion(regionID uint64, followerIds ...uint64) {
 
 // GetStoresStats gets stores statistics.
 func (mc *Cluster) GetStoresStats() *statistics.StoresStats {
-	return mc.StoresStats
+	return mc.HotStat.StoresStats
 }
 
 // GetStoreRegionCount gets region count with a given store.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -108,7 +108,7 @@ func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 		}
 		c.Assert(cluster.putStoreLocked(store), IsNil)
 		c.Assert(cluster.HandleStoreHeartbeat(storeStats), IsNil)
-		c.Assert(cluster.storesStats.GetRollingStoreStats(store.GetID()), NotNil)
+		c.Assert(cluster.hotStat.GetRollingStoreStats(store.GetID()), NotNil)
 	}
 
 	for _, store := range stores {
@@ -121,7 +121,7 @@ func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 		newStore := store.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
 		c.Assert(cluster.putStoreLocked(newStore), IsNil)
 		c.Assert(cluster.HandleStoreHeartbeat(storeStats), IsNil)
-		c.Assert(cluster.storesStats.GetRollingStoreStats(store.GetID()), IsNil)
+		c.Assert(cluster.hotStat.GetRollingStoreStats(store.GetID()), IsNil)
 	}
 }
 

--- a/server/statistics/hotstat.go
+++ b/server/statistics/hotstat.go
@@ -1,0 +1,28 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+// HotStat contains cluster's hotspot statistics.
+type HotStat struct {
+	*HotCache
+	*StoresStats
+}
+
+// NewHotStat creates the container to hold cluster's hotspot statistics.
+func NewHotStat() *HotStat {
+	return &HotStat{
+		HotCache:    NewHotCache(),
+		StoresStats: NewStoresStats(),
+	}
+}


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
`HotCache` and `StoreStats` are always used together. Wrap them up can make it easier to use.

### What is changed and how it works?
wrap `HotCache` and `StoreStats` with `HotStat`.

### Check List

Tests
- Unit test


### Release note
- No release note
