### PR TITLE
client: fix the pd client could be blocked in some cases

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -140,8 +140,8 @@ func WithRetry(retry uint64) RegionsOption {
 
 type tsoRequest struct {
 	start      time.Time
-	client     *client
-	ctx        context.Context
+	clientCtx  context.Context
+	requestCtx context.Context
 	done       chan error
 	physical   int64
 	logical    int64
@@ -428,7 +428,7 @@ func (c *client) createTSODispatcher(dcLocation string) {
 
 func extractSpanReference(requests []*tsoRequest, opts []opentracing.StartSpanOption) []opentracing.StartSpanOption {
 	for _, req := range requests {
-		if span := opentracing.SpanFromContext(req.ctx); span != nil {
+		if span := opentracing.SpanFromContext(req.requestCtx); span != nil {
 			opts = append(opts, opentracing.ChildOf(span.Context()))
 		}
 	}
@@ -507,7 +507,7 @@ func tsLessEqual(physical, logical, thatPhysical, thatLogical int64) bool {
 
 func (c *client) finishTSORequest(requests []*tsoRequest, physical, firstLogical int64, err error) {
 	for i := 0; i < len(requests); i++ {
-		if span := opentracing.SpanFromContext(requests[i].ctx); span != nil {
+		if span := opentracing.SpanFromContext(requests[i].requestCtx); span != nil {
 			span.Finish()
 		}
 		requests[i].physical, requests[i].logical = physical, firstLogical+int64(i)
@@ -567,8 +567,8 @@ func (c *client) GetLocalTSAsync(ctx context.Context, dcLocation string) TSFutur
 		ctx = opentracing.ContextWithSpan(ctx, span)
 	}
 	req := tsoReqPool.Get().(*tsoRequest)
-	req.ctx = ctx
-	req.client = c
+	req.requestCtx = ctx
+	req.clientCtx = c.ctx
 	req.start = time.Now()
 	req.dcLocation = dcLocation
 	c.waitForDispatcher()
@@ -630,10 +630,10 @@ func (req *tsoRequest) Wait() (physical int64, logical int64, err error) {
 		cmdDurationWait.Observe(now.Sub(start).Seconds())
 		cmdDurationTSO.Observe(now.Sub(req.start).Seconds())
 		return
-	case <-req.ctx.Done():
-		return 0, 0, errors.WithStack(req.ctx.Err())
-	case <-req.client.ctx.Done():
-		return 0, 0, errors.WithStack(req.client.ctx.Err())
+	case <-req.requestCtx.Done():
+		return 0, 0, errors.WithStack(req.requestCtx.Err())
+	case <-req.clientCtx.Done():
+		return 0, 0, errors.WithStack(req.clientCtx.Err())
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: leoppro <zhaoyilin@pingcap.com>
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Fix the PD client could be blocked in some cases

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

There are two levels of context in PD client: `client context` and `tso request context`.
the `tsoRequest.Wait()` function could be blocked when the `client context` is canceled because the `Wait()` function haven't listened the `client context`

### Benchmark
the version of PD server: v4.0.8

before this PR:

```
Start benchmark #0, duration: 5s
Create 3 client(s) for benchmark
count:768290, max:9, min:0, avg:0, >1ms:34372, >2ms:2037, >5ms:457, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:800952, max:9, min:0, avg:0, >1ms:96750, >2ms:13593, >5ms:1495, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:745906, max:8, min:0, avg:0, >1ms:12877, >2ms:3652, >5ms:1330, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:759058, max:4, min:0, avg:0, >1ms:11232, >2ms:5776, >5ms:0, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0

Total:
count:3074206, max:9, min:0, avg:0, >1ms:155231, >2ms:25058, >5ms:3282, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:3074206, >1ms:5.05%, >2ms:0.82%, >5ms:0.11%, >10ms:0.00%, >30ms:0.00% >50ms:0.00% >100ms:0.00% >200ms:0.00% >400ms:0.00% >800ms:0.00% >1s:0.00%
```

after this PR:

```
Start benchmark #0, duration: 5s
Create 3 client(s) for benchmark
count:1361814, max:7, min:0, avg:1, >1ms:900605, >2ms:204456, >5ms:2896, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:1357623, max:11, min:0, avg:1, >1ms:931611, >2ms:151281, >5ms:3936, >10ms:1, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:737217, max:7, min:0, avg:0, >1ms:3830, >2ms:3444, >5ms:1028, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:1033124, max:8, min:0, avg:0, >1ms:430725, >2ms:83313, >5ms:460, >10ms:0, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0

Total:
count:4489778, max:11, min:0, avg:1, >1ms:2266771, >2ms:442494, >5ms:8320, >10ms:1, >30ms:0 >50ms:0 >100ms:0 >200ms:0 >400ms:0 >800ms:0 >1s:0
count:4489778, >1ms:50.49%, >2ms:9.86%, >5ms:0.19%, >10ms:0.00%, >30ms:0.00% >50ms:0.00% >100ms:0.00% >200ms:0.00% >400ms:0.00% >800ms:0.00% >1s:0.00%
```


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->

- Fix the pd client could be blocked in some cases