### PR TITLE
election, member, tso: fix the leader check bug and refine the logic

### DIFF
--- a/server/election/leadership.go
+++ b/server/election/leadership.go
@@ -107,9 +107,11 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string) error {
 		Commit()
 	log.Info("check campaign resp", zap.Any("resp", resp))
 	if err != nil {
+		ls.getLease().Close()
 		return errs.ErrEtcdTxn.Wrap(err).GenWithStackByCause()
 	}
 	if !resp.Succeeded {
+		ls.getLease().Close()
 		return errs.ErrEtcdTxn.FastGenByArgs()
 	}
 	log.Info("write leaderData to leaderPath ok", zap.String("leaderPath", ls.leaderKey), zap.String("purpose", ls.purpose))

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -980,7 +980,7 @@ func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) 
 		for _, allocator := range allocatorLeaders {
 			// No longer leader, just skip here because
 			// the global allocator will check if all DCs are handled.
-			if !allocator.IsStillAllocatorLeader() {
+			if !allocator.IsAllocatorLeader() {
 				continue
 			}
 			currentLocalTSO, err := allocator.GetCurrentTSO()
@@ -1000,7 +1000,7 @@ func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) 
 	}
 	// The second phase of synchronization: do the writing
 	for _, allocator := range allocatorLeaders {
-		if !allocator.IsStillAllocatorLeader() {
+		if !allocator.IsAllocatorLeader() {
 			continue
 		}
 		if err := allocator.WriteTSO(request.GetMaxTs()); err != nil {
@@ -1033,7 +1033,7 @@ func (s *Server) GetDCLocations(ctx context.Context, request *pdpb.GetDCLocation
 	if err := s.validateInternalRequest(request.GetHeader(), false); err != nil {
 		return nil, err
 	}
-	if !s.member.IsStillLeader() {
+	if !s.member.IsLeader() {
 		return nil, fmt.Errorf("receiving pd member[%v] is not pd leader", s.member.ID())
 	}
 	return &pdpb.GetDCLocationsResponse{

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -157,7 +157,7 @@ func (m *Member) KeepLeader(ctx context.Context) {
 // IsStillLeader returns whether the PD leader is still a PD leader
 // by checking its leadership's lease.
 func (m *Member) IsStillLeader() bool {
-	return m.leadership.Check()
+	return m.leadership.Check() && m.GetLeader().GetMemberId() == m.member.GetMemberId()
 }
 
 // CheckLeader checks returns true if it is needed to check later.

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -94,10 +94,9 @@ func (m *Member) Client() *clientv3.Client {
 	return m.client
 }
 
-// IsLeader returns whether the server is PD leader or not.
+// IsLeader returns whether the server is PD leader or not by checking its leadership's lease and leader info.
 func (m *Member) IsLeader() bool {
-	// If server is not started. Both leaderID and ID could be 0.
-	return m.GetLeaderID() == m.ID()
+	return m.leadership.Check() && m.GetLeader().GetMemberId() == m.member.GetMemberId()
 }
 
 // GetLeaderID returns current PD leader's member ID.
@@ -152,12 +151,6 @@ func (m *Member) CampaignLeader(leaseTimeout int64) error {
 // KeepLeader is used to keep the PD leader's leadership.
 func (m *Member) KeepLeader(ctx context.Context) {
 	m.leadership.Keep(ctx)
-}
-
-// IsStillLeader returns whether the PD leader is still a PD leader
-// by checking its leadership's lease.
-func (m *Member) IsStillLeader() bool {
-	return m.leadership.Check() && m.GetLeader().GetMemberId() == m.member.GetMemberId()
 }
 
 // CheckLeader checks returns true if it is needed to check later.

--- a/server/server.go
+++ b/server/server.go
@@ -1234,7 +1234,7 @@ func (s *Server) campaignLeader() {
 	for {
 		select {
 		case <-leaderTicker.C:
-			if !s.member.IsStillLeader() {
+			if !s.member.IsLeader() {
 				log.Info("no longer a leader because lease has expired, pd leader will step down")
 				return
 			}

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -415,7 +415,7 @@ func (am *AllocatorManager) campaignAllocatorLeader(loopCtx context.Context, all
 	for {
 		select {
 		case <-leaderTicker.C:
-			if !allocator.IsStillAllocatorLeader() {
+			if !allocator.IsAllocatorLeader() {
 				log.Info("no longer a local tso allocator leader because lease has expired, local tso allocator leader will step down",
 					zap.String("dc-location", allocator.dcLocation),
 					zap.Int("suffix", suffix),
@@ -554,7 +554,7 @@ func (am *AllocatorManager) ClusterDCLocationChecker() {
 		}
 	}
 	// Only leader can write the TSO suffix to etcd in order to make it consistent in the cluster
-	if am.member.IsStillLeader() {
+	if am.member.IsLeader() {
 		for dcLocation, info := range am.mu.clusterDCLocations {
 			if info.suffix > 0 {
 				continue
@@ -886,7 +886,7 @@ func (am *AllocatorManager) isLeaderAwareOfDCLocation(ctx context.Context, dcLoc
 }
 
 func (am *AllocatorManager) getLeaderDCLocations(ctx context.Context) (map[string]int32, error) {
-	if am.member.IsStillLeader() {
+	if am.member.IsLeader() {
 		return am.GetSuffixDCLocations(), nil
 	}
 

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -301,6 +301,7 @@ func (am *AllocatorManager) allocatorLeaderLoop(ctx context.Context, allocator *
 		default:
 		}
 
+		// Check whether the Local TSO Allocator has the leader already
 		allocatorLeader, rev, checkAgain := allocator.CheckAllocatorLeader()
 		if checkAgain {
 			continue

--- a/server/tso/local_allocator.go
+++ b/server/tso/local_allocator.go
@@ -165,9 +165,9 @@ func (lta *LocalTSOAllocator) KeepAllocatorLeader(ctx context.Context) {
 	lta.leadership.Keep(ctx)
 }
 
-// IsStillAllocatorLeader returns whether the allocator is still a
-// Local TSO Allocator leader by checking its leadership's lease.
-func (lta *LocalTSOAllocator) IsStillAllocatorLeader() bool {
+// IsAllocatorLeader returns whether the allocator is still a
+// Local TSO Allocator leader by checking its leadership's lease and leader info.
+func (lta *LocalTSOAllocator) IsAllocatorLeader() bool {
 	return lta.leadership.Check() && lta.GetAllocatorLeader().GetMemberId() == lta.GetMember().GetMemberId()
 }
 

--- a/server/tso/local_allocator.go
+++ b/server/tso/local_allocator.go
@@ -168,7 +168,7 @@ func (lta *LocalTSOAllocator) KeepAllocatorLeader(ctx context.Context) {
 // IsStillAllocatorLeader returns whether the allocator is still a
 // Local TSO Allocator leader by checking its leadership's lease.
 func (lta *LocalTSOAllocator) IsStillAllocatorLeader() bool {
-	return lta.leadership.Check()
+	return lta.leadership.Check() && lta.GetAllocatorLeader().GetMemberId() == lta.GetMember().GetMemberId()
 }
 
 // isSameLeader checks whether a server is the leader itself.

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -245,7 +245,7 @@ func (s *TestServer) IsAllocatorLeader(dcLocation string) bool {
 	if err != nil {
 		return false
 	}
-	return !s.server.IsClosed() && allocator.(*tso.LocalTSOAllocator).IsStillAllocatorLeader()
+	return !s.server.IsClosed() && allocator.(*tso.LocalTSOAllocator).IsAllocatorLeader()
 }
 
 // GetEtcdLeader returns the builtin etcd leader.
@@ -363,7 +363,7 @@ func (s *TestServer) BootstrapCluster() error {
 // If it exceeds the maximum number of loops, it will return nil.
 func (s *TestServer) WaitLeader() bool {
 	for i := 0; i < 100; i++ {
-		if s.server.GetMember().IsStillLeader() {
+		if s.server.GetMember().IsLeader() {
 			return true
 		}
 		time.Sleep(WaitLeaderCheckInterval)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

If you check the leader immediately after the campaign failed by `leadership.Check()`, it will return true wrongly because the lease is not expired yet. And to be more specific, this bug could cause a PD to make a non-leader Local TSO Allocator participate in a Global TSO synchronization, which will make the synchronization fail, right after the campaign failed. This PR will fix this problem.

Also, I rearrange the logic in `allocatorLeaderLoop` to reduce the RPC requests and etcd IO, which should improve the performance.

### What is changed and how it works?

* Merge `IsStillLeader` and `IsLeader` methods, they are doing the same thing.
* Improve the leader check to make it more precise.
* Rearrange the logic in `allocatorLeaderLoop` to reduce the RPC requests and etcd IO.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
