### PR TITLE
server: fix goroutine leak in allocatorLeaderLoop

### DIFF
--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -291,6 +291,12 @@ func (am *AllocatorManager) getAllocatorPath(dcLocation string) string {
 
 // similar logic with leaderLoop in server/server.go
 func (am *AllocatorManager) allocatorLeaderLoop(ctx context.Context, allocator *LocalTSOAllocator) {
+	var checkTicker *time.Ticker
+	defer func() {
+		if checkTicker != nil {
+			checkTicker.Stop()
+		}
+	}()
 	for {
 		select {
 		case <-ctx.Done():
@@ -319,8 +325,9 @@ func (am *AllocatorManager) allocatorLeaderLoop(ctx context.Context, allocator *
 				zap.String("wait-duration", checkStep.String()))
 			// Because the checkStep is long, we use select here to check whether the ctx is done
 			// to prevent the leak of goroutine.
-			checkTicker := time.NewTicker(checkStep)
-			defer checkTicker.Stop()
+			if checkTicker == nil {
+				checkTicker = time.NewTicker(checkStep)
+			}
 			select {
 			case <-ctx.Done():
 				log.Info("server is closed, return local tso allocator leader loop",


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
Revising the defer `Stop` in order to avoid goroutine leak.


<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
