### PR TITLE
scripts: add a helper for running with tls

### DIFF
--- a/scripts/run-tls
+++ b/scripts/run-tls
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ABSPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )/.."
+pushd "$(dirname "$0")/.." >/dev/null
+make
+data_dir=./run/pd1
+mkdir -p "$data_dir"
+popd >/dev/null
+
+"$ABSPATH/bin/pd-server" --name=pd1 \
+	    --data-dir="$ABSPATH/$data_dir" \
+	    --client-urls="https://127.0.0.1:2379" \
+	    --peer-urls="https://127.0.0.1:2380" \
+	    --initial-cluster="pd1=https://127.0.0.1:2380" \
+	    "$@"


### PR DESCRIPTION
### What problem does this PR solve?

Add a helper for running locally with TLS


### Check List

Tests

I tested with certs generated by [this PR](https://github.com/tikv/tikv/pull/8829) which is the same as the PingCAP docs. Using grpc_cli with the tikv-ctl certs.

Code changes: None
Side effectsL None

Related changes

- [TiKV PR](https://github.com/tikv/tikv/pull/8829) - but this is not required

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

No release note
