### PR TITLE
id: fix the id allocator is not monotonic

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1223,6 +1223,10 @@ func (s *Server) campaignLeader() {
 		log.Error("failed to load persistOptions from etcd", errs.ZapError(err))
 		return
 	}
+	if err := s.idAllocator.Generate(); err != nil {
+		log.Error("failed to sync id from etcd", errs.ZapError(err))
+		return
+	}
 	s.member.EnableLeader()
 
 	CheckPDVersion(s.persistOptions)


### PR DESCRIPTION
### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

This PR tries to make the id monotonic since there are many components that depend on this property. ref: https://github.com/tikv/pd/issues/3303

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
