### PR TITLE
config: joint-consensus is disabled by default due to experimentation

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -753,7 +753,7 @@ const (
 	defaultSchedulerMaxWaitingOperator = 5
 	defaultLeaderSchedulePolicy        = "count"
 	defaultStoreLimitMode              = "manual"
-	defaultEnableJointConsensus        = true
+	defaultEnableJointConsensus        = false
 	defaultEnableCrossTableMerge       = true
 )
 

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -490,6 +490,7 @@ func (o *PersistOptions) IsUseJointConsensus() bool {
 	return o.GetScheduleConfig().EnableJointConsensus
 }
 
+// SetEnableJointConsensus sets whether to enable joint-consensus. It's only used to test.
 func (o *PersistOptions) SetEnableJointConsensus(enableJointConsensus bool) {
 	v := o.GetScheduleConfig().Clone()
 	v.EnableJointConsensus = enableJointConsensus

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -490,6 +490,12 @@ func (o *PersistOptions) IsUseJointConsensus() bool {
 	return o.GetScheduleConfig().EnableJointConsensus
 }
 
+func (o *PersistOptions) SetEnableJointConsensus(enableJointConsensus bool) {
+	v := o.GetScheduleConfig().Clone()
+	v.EnableJointConsensus = enableJointConsensus
+	o.SetScheduleConfig(v)
+}
+
 // GetHotRegionCacheHitsThreshold is a threshold to decide if a region is hot.
 func (o *PersistOptions) GetHotRegionCacheHitsThreshold() int {
 	return int(o.GetScheduleConfig().HotRegionCacheHitsThreshold)

--- a/server/schedule/operator/builder_test.go
+++ b/server/schedule/operator/builder_test.go
@@ -31,6 +31,7 @@ type testBuilderSuite struct {
 
 func (s *testBuilderSuite) SetUpTest(c *C) {
 	opts := config.NewTestOptions()
+	opts.SetEnableJointConsensus(true)
 	s.cluster = mockcluster.NewCluster(opts)
 	s.cluster.SetLabelPropertyConfig(config.LabelPropertyConfig{
 		opt.RejectLeader: {{Key: "noleader", Value: "true"}},

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -37,6 +37,7 @@ type testCreateOperatorSuite struct {
 
 func (s *testCreateOperatorSuite) SetUpTest(c *C) {
 	opts := config.NewTestOptions()
+	opts.SetEnableJointConsensus(true)
 	s.cluster = mockcluster.NewCluster(opts)
 	s.cluster.SetLabelPropertyConfig(config.LabelPropertyConfig{
 		opt.RejectLeader: {{Key: "noleader", Value: "true"}},

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -573,6 +573,7 @@ func (t *testOperatorControllerSuite) TestDispatchUnfinishedStep(c *C) {
 
 func (t *testOperatorControllerSuite) TestStoreLimitWithMerge(c *C) {
 	cfg := config.NewTestOptions()
+	cfg.SetEnableJointConsensus(true)
 	tc := mockcluster.NewCluster(cfg)
 	tc.SetMaxMergeRegionSize(2)
 	tc.SetMaxMergeRegionKeys(2)


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What is changed and how it works?

* config: joint-consensus is disabled by default due to experimentation

### Check List

<!-- Remove the items that are not applicable. -->

Code changes

- Has configuration change

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
