### PR TITLE
filter: add label for filterCounter

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -6232,7 +6232,7 @@
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{scope}}-store-{{source}}-{{type}}-target-{{target}}",
+              "legendFormat": "{{scope}}-{{type}}-{{source}}-{{target}}",
               "refId": "B"
             },
             {
@@ -6240,7 +6240,7 @@
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{scope}}-store-{{source}}-{{type}}-target-{{target}}",
+              "legendFormat": "{{scope}}-{{type}}-{{source}}-{{target}}",
               "refId": "C"
             },
             {
@@ -6248,7 +6248,7 @@
               "format": "time_series",
               "hide": true,
               "intervalFactor": 2,
-              "legendFormat": "{{scope}}-store-{{source}}-{{type}}-target-{{target}}",
+              "legendFormat": "{{scope}}-{{type}}-{{source}}-{{target}}",
               "refId": "D"
             }
           ],

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -6226,6 +6226,30 @@
               "metric": "pd_scheduler_event_count",
               "refId": "A",
               "step": 4
+            },
+            {
+              "expr": "sum(delta(pd_schedule_filter{action=\"filter-target\",type=\"distinct-filter\"}[1m])) by (source, target, type, scope)",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{scope}}-store-{{source}}-{{type}}-target-{{target}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(delta(pd_schedule_filter{action=\"filter-target\",type=\"rule-fit-filter\"}[1m])) by (source, target, type, scope)",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{scope}}-store-{{source}}-{{type}}-target-{{target}}",
+              "refId": "C"
+            },
+            {
+              "expr": "sum(delta(pd_schedule_filter{action=\"filter-target\",type=\"rule-fit-leader-filter\"}[1m])) by (source, target, type, scope)",
+              "format": "time_series",
+              "hide": true,
+              "intervalFactor": 2,
+              "legendFormat": "{{scope}}-store-{{source}}-{{type}}-target-{{target}}",
+              "refId": "D"
             }
           ],
           "thresholds": [],

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -501,22 +501,22 @@ func (f *ruleFitFilter) GetSourceStoreID() uint64 {
 }
 
 type ruleLeaderFitFilter struct {
-	scope          string
-	fitter         RegionFitter
-	region         *core.RegionInfo
-	oldFit         *placement.RegionFit
-	srcLeaderStore uint64
+	scope            string
+	fitter           RegionFitter
+	region           *core.RegionInfo
+	oldFit           *placement.RegionFit
+	srcLeaderStoreID uint64
 }
 
 // newRuleLeaderFitFilter creates a filter that ensures after transfer leader with new store,
 // the isolation level will not decrease.
-func newRuleLeaderFitFilter(scope string, fitter RegionFitter, region *core.RegionInfo, srcLeaderStore uint64) Filter {
+func newRuleLeaderFitFilter(scope string, fitter RegionFitter, region *core.RegionInfo, srcLeaderStoreID uint64) Filter {
 	return &ruleLeaderFitFilter{
-		scope:          scope,
-		fitter:         fitter,
-		region:         region,
-		oldFit:         fitter.FitRegion(region),
-		srcLeaderStore: srcLeaderStore,
+		scope:            scope,
+		fitter:           fitter,
+		region:           region,
+		oldFit:           fitter.FitRegion(region),
+		srcLeaderStoreID: srcLeaderStoreID,
 	}
 }
 
@@ -546,7 +546,7 @@ func (f *ruleLeaderFitFilter) Target(opt *config.PersistOptions, store *core.Sto
 }
 
 func (f *ruleLeaderFitFilter) GetSourceStoreID() uint64 {
-	return f.srcLeaderStore
+	return f.srcLeaderStoreID
 }
 
 // NewPlacementSafeguard creates a filter that ensures after replace a peer with new

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -56,7 +56,7 @@ func SelectTargetStores(stores []*core.StoreInfo, filters []Filter, opt *config.
 				targetID := fmt.Sprintf("%d", s.GetID())
 				sourceID := ""
 				if ok {
-					sourceID = fmt.Sprintf("%d", cfilter.GetOldStoreID())
+					sourceID = fmt.Sprintf("%d", cfilter.GetSourceStoreID())
 				}
 				filterCounter.WithLabelValues("filter-target", s.GetAddress(),
 					targetID, filters[i].Scope(), filters[i].Type(), sourceID, targetID).Inc()
@@ -90,8 +90,8 @@ type Filter interface {
 // ComparingFilter is an interface to filter target store by comparing source and target stores
 type ComparingFilter interface {
 	Filter
-	// GetOldStoreID returns the source store when comparing.
-	GetOldStoreID() uint64
+	// GetSourceStoreID returns the source store when comparing.
+	GetSourceStoreID() uint64
 }
 
 // Source checks if store can pass all Filters as source store.
@@ -120,7 +120,7 @@ func Target(opt *config.PersistOptions, store *core.StoreInfo, filters []Filter)
 			targetID := storeID
 			sourceID := ""
 			if ok {
-				sourceID = fmt.Sprintf("%d", cfilter.GetOldStoreID())
+				sourceID = fmt.Sprintf("%d", cfilter.GetSourceStoreID())
 			}
 			filterCounter.WithLabelValues("filter-target", storeAddress,
 				targetID, filter.Scope(), filter.Type(), sourceID, targetID).Inc()
@@ -260,8 +260,8 @@ func (f *distinctScoreFilter) Target(opt *config.PersistOptions, store *core.Sto
 	}
 }
 
-// GetOldStoreID implements the ComparingFilter
-func (f *distinctScoreFilter) GetOldStoreID() uint64 {
+// GetSourceStoreID implements the ComparingFilter
+func (f *distinctScoreFilter) GetSourceStoreID() uint64 {
 	return f.oldStore
 }
 
@@ -495,8 +495,8 @@ func (f *ruleFitFilter) Target(opt *config.PersistOptions, store *core.StoreInfo
 	return placement.CompareRegionFit(f.oldFit, newFit) <= 0
 }
 
-// GetOldStoreID implements the ComparingFilter
-func (f *ruleFitFilter) GetOldStoreID() uint64 {
+// GetSourceStoreID implements the ComparingFilter
+func (f *ruleFitFilter) GetSourceStoreID() uint64 {
 	return f.oldStore
 }
 
@@ -545,7 +545,7 @@ func (f *ruleLeaderFitFilter) Target(opt *config.PersistOptions, store *core.Sto
 	return placement.CompareRegionFit(f.oldFit, newFit) <= 0
 }
 
-func (f *ruleLeaderFitFilter) GetOldStoreID() uint64 {
+func (f *ruleLeaderFitFilter) GetSourceStoreID() uint64 {
 	return f.oldLeaderStoreID
 }
 

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -510,13 +510,13 @@ type ruleLeaderFitFilter struct {
 
 // newRuleLeaderFitFilter creates a filter that ensures after transfer leader with new store,
 // the isolation level will not decrease.
-func newRuleLeaderFitFilter(scope string, fitter RegionFitter, region *core.RegionInfo, oldLeaderStoreID uint64) Filter {
+func newRuleLeaderFitFilter(scope string, fitter RegionFitter, region *core.RegionInfo, srcLeaderStore uint64) Filter {
 	return &ruleLeaderFitFilter{
 		scope:          scope,
 		fitter:         fitter,
 		region:         region,
 		oldFit:         fitter.FitRegion(region),
-		srcLeaderStore: oldLeaderStoreID,
+		srcLeaderStore: srcLeaderStore,
 	}
 }
 

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -52,7 +52,7 @@ func SelectTargetStores(stores []*core.StoreInfo, filters []Filter, opt *config.
 		return slice.AllOf(filters, func(i int) bool {
 			filter := filters[i]
 			if !filter.Target(opt, s) {
-				cfilter, ok := filter.(ComparingFilter)
+				cfilter, ok := filter.(comparingFilter)
 				targetID := fmt.Sprintf("%d", s.GetID())
 				sourceID := ""
 				if ok {
@@ -87,8 +87,8 @@ type Filter interface {
 	Target(opt *config.PersistOptions, store *core.StoreInfo) bool
 }
 
-// ComparingFilter is an interface to filter target store by comparing source and target stores
-type ComparingFilter interface {
+// comparingFilter is an interface to filter target store by comparing source and target stores
+type comparingFilter interface {
 	Filter
 	// GetSourceStoreID returns the source store when comparing.
 	GetSourceStoreID() uint64
@@ -116,7 +116,7 @@ func Target(opt *config.PersistOptions, store *core.StoreInfo, filters []Filter)
 	storeID := fmt.Sprintf("%d", store.GetID())
 	for _, filter := range filters {
 		if !filter.Target(opt, store) {
-			cfilter, ok := filter.(ComparingFilter)
+			cfilter, ok := filter.(comparingFilter)
 			targetID := storeID
 			sourceID := ""
 			if ok {

--- a/server/schedule/filter/metrics.go
+++ b/server/schedule/filter/metrics.go
@@ -22,7 +22,7 @@ var (
 			Subsystem: "schedule",
 			Name:      "filter",
 			Help:      "Counter of the filter",
-		}, []string{"action", "address", "store", "scope", "type", "source"})
+		}, []string{"action", "address", "store", "scope", "type", "source", "target"})
 )
 
 func init() {

--- a/server/schedule/filter/metrics.go
+++ b/server/schedule/filter/metrics.go
@@ -22,7 +22,7 @@ var (
 			Subsystem: "schedule",
 			Name:      "filter",
 			Help:      "Counter of the filter",
-		}, []string{"action", "address", "store", "scope", "type"})
+		}, []string{"action", "address", "store", "scope", "type", "source-store"})
 )
 
 func init() {

--- a/server/schedule/filter/metrics.go
+++ b/server/schedule/filter/metrics.go
@@ -22,7 +22,7 @@ var (
 			Subsystem: "schedule",
 			Name:      "filter",
 			Help:      "Counter of the filter",
-		}, []string{"action", "address", "store", "scope", "type", "source-store"})
+		}, []string{"action", "address", "store", "scope", "type", "source"})
 )
 
 func init() {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Add label for `filterCounter`. If the `Filter` filter the `target` by comparing origin store and target store, we can record the origin store id into metrics.

Then we can query the metrics like this:

![image](https://user-images.githubusercontent.com/13427348/103976594-1eefe980-51b2-11eb-88ac-2c9180a9254c.png)

By this way, we can easily judge whether the filter is reasonable.
 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

* No release note 