### PR TITLE
id: fix the bug that id may be duplicated

### DIFF
--- a/server/id/id.go
+++ b/server/id/id.go
@@ -58,8 +58,6 @@ func (alloc *AllocatorImpl) Alloc() (uint64, error) {
 		if err := alloc.generateLocked(); err != nil {
 			return 0, err
 		}
-
-		alloc.base = alloc.end - allocStep
 	}
 
 	alloc.base++
@@ -116,6 +114,7 @@ func (alloc *AllocatorImpl) generateLocked() error {
 	log.Info("idAllocator allocates a new id", zap.Uint64("alloc-id", end))
 	idGauge.WithLabelValues("idalloc").Set(float64(end))
 	alloc.end = end
+	alloc.base = end - allocStep
 	return nil
 }
 

--- a/tests/server/id/id_test.go
+++ b/tests/server/id/id_test.go
@@ -51,11 +51,11 @@ func (s *testAllocIDSuite) SetUpSuite(c *C) {
 func (s *testAllocIDSuite) TearDownSuite(c *C) {
 	s.cancel()
 }
+
 func (s *testAllocIDSuite) TestID(c *C) {
-	var err error
 	cluster, err := tests.NewTestCluster(s.ctx, 1)
-	defer cluster.Destroy()
 	c.Assert(err, IsNil)
+	defer cluster.Destroy()
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -96,10 +96,9 @@ func (s *testAllocIDSuite) TestID(c *C) {
 }
 
 func (s *testAllocIDSuite) TestCommand(c *C) {
-	var err error
 	cluster, err := tests.NewTestCluster(s.ctx, 1)
-	defer cluster.Destroy()
 	c.Assert(err, IsNil)
+	defer cluster.Destroy()
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -121,10 +120,9 @@ func (s *testAllocIDSuite) TestCommand(c *C) {
 }
 
 func (s *testAllocIDSuite) TestMonotonicID(c *C) {
-	var err error
 	cluster, err := tests.NewTestCluster(s.ctx, 2)
-	defer cluster.Destroy()
 	c.Assert(err, IsNil)
+	defer cluster.Destroy()
 
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
@@ -162,5 +160,34 @@ func (s *testAllocIDSuite) TestMonotonicID(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(id, Greater, last3)
 		last3 = id
+	}
+}
+
+func (s *testAllocIDSuite) TestPDRestart(c *C) {
+	cluster, err := tests.NewTestCluster(s.ctx, 1)
+	c.Assert(err, IsNil)
+	defer cluster.Destroy()
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+	cluster.WaitLeader()
+	leaderServer := cluster.GetServer(cluster.GetLeader())
+
+	var last uint64
+	for i := uint64(0); i < 10; i++ {
+		id, err := leaderServer.GetAllocator().Alloc()
+		c.Assert(err, IsNil)
+		c.Assert(id, Greater, last)
+		last = id
+	}
+
+	c.Assert(leaderServer.Stop(), IsNil)
+	c.Assert(leaderServer.Run(), IsNil)
+
+	for i := uint64(0); i < 10; i++ {
+		id, err := leaderServer.GetAllocator().Alloc()
+		c.Assert(err, IsNil)
+		c.Assert(id, Greater, last)
+		last = id
 	}
 }

--- a/tests/server/id/id_test.go
+++ b/tests/server/id/id_test.go
@@ -183,6 +183,7 @@ func (s *testAllocIDSuite) TestPDRestart(c *C) {
 
 	c.Assert(leaderServer.Stop(), IsNil)
 	c.Assert(leaderServer.Run(), IsNil)
+	cluster.WaitLeader()
 
 	for i := uint64(0); i < 10; i++ {
 		id, err := leaderServer.GetAllocator().Alloc()


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

* After the PD restarts, the id will be allocated from 1 again. This bug was introduced by #3305.
* Close [tidb#22117](https://github.com/pingcap/tidb/issues/22117)

### What is changed and how it works?

* id: fix the bug that id may be duplicated

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
