### PR TITLE
statistics: filter regions by hotDegree

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -110,12 +110,12 @@ func (mc *Cluster) IsRegionHot(region *core.RegionInfo) bool {
 
 // RegionReadStats returns hot region's read stats.
 func (mc *Cluster) RegionReadStats() map[uint64][]*statistics.HotPeerStat {
-	return mc.HotCache.RegionStats(statistics.ReadFlow)
+	return mc.HotCache.RegionStats(statistics.ReadFlow, mc.GetHotRegionCacheHitsThreshold())
 }
 
 // RegionWriteStats returns hot region's write stats.
 func (mc *Cluster) RegionWriteStats() map[uint64][]*statistics.HotPeerStat {
-	return mc.HotCache.RegionStats(statistics.WriteFlow)
+	return mc.HotCache.RegionStats(statistics.WriteFlow, mc.GetHotRegionCacheHitsThreshold())
 }
 
 // RandHotRegionFromStore random picks a hot region in specify store.

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -109,11 +109,13 @@ func (mc *Cluster) IsRegionHot(region *core.RegionInfo) bool {
 }
 
 // RegionReadStats returns hot region's read stats.
+// The result only includes peers that are hot enough.
 func (mc *Cluster) RegionReadStats() map[uint64][]*statistics.HotPeerStat {
 	return mc.HotCache.RegionStats(statistics.ReadFlow, mc.GetHotRegionCacheHitsThreshold())
 }
 
 // RegionWriteStats returns hot region's write stats.
+// The result only includes peers that are hot enough.
 func (mc *Cluster) RegionWriteStats() map[uint64][]*statistics.HotPeerStat {
 	return mc.HotCache.RegionStats(statistics.WriteFlow, mc.GetHotRegionCacheHitsThreshold())
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1442,12 +1442,14 @@ func (c *RaftCluster) GetStoresLoads() map[uint64][]float64 {
 }
 
 // RegionReadStats returns hot region's read stats.
+// The result only includes peers that are hot enough.
 func (c *RaftCluster) RegionReadStats() map[uint64][]*statistics.HotPeerStat {
 	// RegionStats is a thread-safe method
 	return c.hotStat.RegionStats(statistics.ReadFlow, c.GetOpts().GetHotRegionCacheHitsThreshold())
 }
 
 // RegionWriteStats returns hot region's write stats.
+// The result only includes peers that are hot enough.
 func (c *RaftCluster) RegionWriteStats() map[uint64][]*statistics.HotPeerStat {
 	// RegionStats is a thread-safe method
 	return c.hotStat.RegionStats(statistics.WriteFlow, c.GetOpts().GetHotRegionCacheHitsThreshold())

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1444,13 +1444,13 @@ func (c *RaftCluster) GetStoresLoads() map[uint64][]float64 {
 // RegionReadStats returns hot region's read stats.
 func (c *RaftCluster) RegionReadStats() map[uint64][]*statistics.HotPeerStat {
 	// RegionStats is a thread-safe method
-	return c.hotStat.RegionStats(statistics.ReadFlow)
+	return c.hotStat.RegionStats(statistics.ReadFlow, c.GetOpts().GetHotRegionCacheHitsThreshold())
 }
 
 // RegionWriteStats returns hot region's write stats.
 func (c *RaftCluster) RegionWriteStats() map[uint64][]*statistics.HotPeerStat {
 	// RegionStats is a thread-safe method
-	return c.hotStat.RegionStats(statistics.WriteFlow)
+	return c.hotStat.RegionStats(statistics.WriteFlow, c.GetOpts().GetHotRegionCacheHitsThreshold())
 }
 
 // CheckWriteStatus checks the write status, returns whether need update statistics and item.

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -662,7 +662,7 @@ func (s *testHotReadRegionSchedulerSuite) TestByteRateOnly(c *C) {
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, uint64(2))
 	// check hot items
-	stats := tc.HotCache.RegionStats(statistics.ReadFlow)
+	stats := tc.HotCache.RegionStats(statistics.ReadFlow, 0)
 	c.Assert(len(stats), Equals, 2)
 	for _, ss := range stats {
 		for _, s := range ss {
@@ -885,7 +885,7 @@ func (s *testHotCacheSuite) TestUpdateCache(c *C) {
 		// lower than hot read flow rate, but higher than write flow rate
 		{11, []uint64{1, 2, 3}, 7 * KB, 0},
 	})
-	stats := tc.RegionStats(statistics.ReadFlow)
+	stats := tc.RegionStats(statistics.ReadFlow, 0)
 	c.Assert(len(stats[1]), Equals, 2)
 	c.Assert(len(stats[2]), Equals, 1)
 	c.Assert(len(stats[3]), Equals, 0)
@@ -894,7 +894,7 @@ func (s *testHotCacheSuite) TestUpdateCache(c *C) {
 		{3, []uint64{2, 1, 3}, 20 * KB, 0},
 		{11, []uint64{1, 2, 3}, 7 * KB, 0},
 	})
-	stats = tc.RegionStats(statistics.ReadFlow)
+	stats = tc.RegionStats(statistics.ReadFlow, 0)
 	c.Assert(len(stats[1]), Equals, 1)
 	c.Assert(len(stats[2]), Equals, 2)
 	c.Assert(len(stats[3]), Equals, 0)
@@ -904,7 +904,7 @@ func (s *testHotCacheSuite) TestUpdateCache(c *C) {
 		{5, []uint64{1, 2, 3}, 20 * KB, 0},
 		{6, []uint64{1, 2, 3}, 0.8 * KB, 0},
 	})
-	stats = tc.RegionStats(statistics.WriteFlow)
+	stats = tc.RegionStats(statistics.WriteFlow, 0)
 	c.Assert(len(stats[1]), Equals, 2)
 	c.Assert(len(stats[2]), Equals, 2)
 	c.Assert(len(stats[3]), Equals, 2)
@@ -912,7 +912,7 @@ func (s *testHotCacheSuite) TestUpdateCache(c *C) {
 	addRegionInfo(tc, write, []testRegionInfo{
 		{5, []uint64{1, 2, 5}, 20 * KB, 0},
 	})
-	stats = tc.RegionStats(statistics.WriteFlow)
+	stats = tc.RegionStats(statistics.WriteFlow, 0)
 
 	c.Assert(len(stats[1]), Equals, 2)
 	c.Assert(len(stats[2]), Equals, 2)
@@ -929,13 +929,13 @@ func (s *testHotCacheSuite) TestKeyThresholds(c *C) {
 			{1, []uint64{1, 2, 3}, 0, 1},
 			{2, []uint64{1, 2, 3}, 0, 1 * KB},
 		})
-		stats := tc.RegionStats(statistics.ReadFlow)
+		stats := tc.RegionStats(statistics.ReadFlow, 0)
 		c.Assert(stats[1], HasLen, 1)
 		addRegionInfo(tc, write, []testRegionInfo{
 			{3, []uint64{4, 5, 6}, 0, 1},
 			{4, []uint64{4, 5, 6}, 0, 1 * KB},
 		})
-		stats = tc.RegionStats(statistics.WriteFlow)
+		stats = tc.RegionStats(statistics.WriteFlow, 0)
 		c.Assert(stats[4], HasLen, 1)
 		c.Assert(stats[5], HasLen, 1)
 		c.Assert(stats[6], HasLen, 1)
@@ -960,7 +960,7 @@ func (s *testHotCacheSuite) TestKeyThresholds(c *C) {
 
 		{ // read
 			addRegionInfo(tc, read, regions)
-			stats := tc.RegionStats(statistics.ReadFlow)
+			stats := tc.RegionStats(statistics.ReadFlow, 0)
 			c.Assert(len(stats[1]), Greater, 500)
 
 			// for AntiCount
@@ -968,12 +968,12 @@ func (s *testHotCacheSuite) TestKeyThresholds(c *C) {
 			addRegionInfo(tc, read, regions)
 			addRegionInfo(tc, read, regions)
 			addRegionInfo(tc, read, regions)
-			stats = tc.RegionStats(statistics.ReadFlow)
+			stats = tc.RegionStats(statistics.ReadFlow, 0)
 			c.Assert(len(stats[1]), Equals, 500)
 		}
 		{ // write
 			addRegionInfo(tc, write, regions)
-			stats := tc.RegionStats(statistics.WriteFlow)
+			stats := tc.RegionStats(statistics.WriteFlow, 0)
 			c.Assert(len(stats[1]), Greater, 500)
 			c.Assert(len(stats[2]), Greater, 500)
 			c.Assert(len(stats[3]), Greater, 500)
@@ -983,7 +983,7 @@ func (s *testHotCacheSuite) TestKeyThresholds(c *C) {
 			addRegionInfo(tc, write, regions)
 			addRegionInfo(tc, write, regions)
 			addRegionInfo(tc, write, regions)
-			stats = tc.RegionStats(statistics.WriteFlow)
+			stats = tc.RegionStats(statistics.WriteFlow, 0)
 			c.Assert(len(stats[1]), Equals, 500)
 			c.Assert(len(stats[2]), Equals, 500)
 			c.Assert(len(stats[3]), Equals, 500)
@@ -1006,7 +1006,7 @@ func (s *testHotCacheSuite) TestByteAndKey(c *C) {
 	}
 	{ // read
 		addRegionInfo(tc, read, regions)
-		stats := tc.RegionStats(statistics.ReadFlow)
+		stats := tc.RegionStats(statistics.ReadFlow, 0)
 		c.Assert(len(stats[1]), Equals, 500)
 
 		addRegionInfo(tc, read, []testRegionInfo{
@@ -1015,12 +1015,12 @@ func (s *testHotCacheSuite) TestByteAndKey(c *C) {
 			{10003, []uint64{1, 2, 3}, 10 * KB, 500 * KB},
 			{10004, []uint64{1, 2, 3}, 500 * KB, 500 * KB},
 		})
-		stats = tc.RegionStats(statistics.ReadFlow)
+		stats = tc.RegionStats(statistics.ReadFlow, 0)
 		c.Assert(len(stats[1]), Equals, 503)
 	}
 	{ // write
 		addRegionInfo(tc, write, regions)
-		stats := tc.RegionStats(statistics.WriteFlow)
+		stats := tc.RegionStats(statistics.WriteFlow, 0)
 		c.Assert(len(stats[1]), Equals, 500)
 		c.Assert(len(stats[2]), Equals, 500)
 		c.Assert(len(stats[3]), Equals, 500)
@@ -1030,7 +1030,7 @@ func (s *testHotCacheSuite) TestByteAndKey(c *C) {
 			{10003, []uint64{1, 2, 3}, 10 * KB, 500 * KB},
 			{10004, []uint64{1, 2, 3}, 500 * KB, 500 * KB},
 		})
-		stats = tc.RegionStats(statistics.WriteFlow)
+		stats = tc.RegionStats(statistics.WriteFlow, 0)
 		c.Assert(len(stats[1]), Equals, 503)
 		c.Assert(len(stats[2]), Equals, 503)
 		c.Assert(len(stats[3]), Equals, 503)

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -123,14 +123,12 @@ func (s *shuffleHotRegionScheduler) Schedule(cluster opt.Cluster) []*operator.Op
 
 func (s *shuffleHotRegionScheduler) dispatch(typ rwType, cluster opt.Cluster) []*operator.Operator {
 	storesLoads := cluster.GetStoresLoads()
-	minHotDegree := cluster.GetOpts().GetHotRegionCacheHitsThreshold()
 	switch typ {
 	case read:
 		s.stLoadInfos[readLeader] = summaryStoresLoad(
 			storesLoads,
 			map[uint64]Influence{},
 			cluster.RegionReadStats(),
-			minHotDegree,
 			read, core.LeaderKind)
 		return s.randomSchedule(cluster, s.stLoadInfos[readLeader])
 	case write:
@@ -138,7 +136,6 @@ func (s *shuffleHotRegionScheduler) dispatch(typ rwType, cluster opt.Cluster) []
 			storesLoads,
 			map[uint64]Influence{},
 			cluster.RegionWriteStats(),
-			minHotDegree,
 			write, core.LeaderKind)
 		return s.randomSchedule(cluster, s.stLoadInfos[writeLeader])
 	}

--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -66,21 +66,21 @@ func (w *HotCache) Update(item *HotPeerStat) {
 }
 
 // RegionStats returns hot items according to kind
-func (w *HotCache) RegionStats(kind FlowKind) map[uint64][]*HotPeerStat {
+func (w *HotCache) RegionStats(kind FlowKind, minHotDegree int) map[uint64][]*HotPeerStat {
 	switch kind {
 	case WriteFlow:
-		return w.writeFlow.RegionStats()
+		return w.writeFlow.RegionStats(minHotDegree)
 	case ReadFlow:
-		return w.readFlow.RegionStats()
+		return w.readFlow.RegionStats(minHotDegree)
 	}
 	return nil
 }
 
 // RandHotRegionFromStore random picks a hot region in specify store.
-func (w *HotCache) RandHotRegionFromStore(storeID uint64, kind FlowKind, hotDegree int) *HotPeerStat {
-	if stats, ok := w.RegionStats(kind)[storeID]; ok {
+func (w *HotCache) RandHotRegionFromStore(storeID uint64, kind FlowKind, minHotDegree int) *HotPeerStat {
+	if stats, ok := w.RegionStats(kind, minHotDegree)[storeID]; ok {
 		for _, i := range rand.Perm(len(stats)) {
-			if stats[i].HotDegree >= hotDegree {
+			if stats[i].HotDegree >= minHotDegree {
 				return stats[i]
 			}
 		}
@@ -89,9 +89,9 @@ func (w *HotCache) RandHotRegionFromStore(storeID uint64, kind FlowKind, hotDegr
 }
 
 // IsRegionHot checks if the region is hot.
-func (w *HotCache) IsRegionHot(region *core.RegionInfo, hotDegree int) bool {
-	return w.writeFlow.IsRegionHot(region, hotDegree) ||
-		w.readFlow.IsRegionHot(region, hotDegree)
+func (w *HotCache) IsRegionHot(region *core.RegionInfo, minHotDegree int) bool {
+	return w.writeFlow.IsRegionHot(region, minHotDegree) ||
+		w.readFlow.IsRegionHot(region, minHotDegree)
 }
 
 // CollectMetrics collects the hot cache metrics.

--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -78,12 +78,8 @@ func (w *HotCache) RegionStats(kind FlowKind, minHotDegree int) map[uint64][]*Ho
 
 // RandHotRegionFromStore random picks a hot region in specify store.
 func (w *HotCache) RandHotRegionFromStore(storeID uint64, kind FlowKind, minHotDegree int) *HotPeerStat {
-	if stats, ok := w.RegionStats(kind, minHotDegree)[storeID]; ok {
-		for _, i := range rand.Perm(len(stats)) {
-			if stats[i].HotDegree >= minHotDegree {
-				return stats[i]
-			}
-		}
+	if stats, ok := w.RegionStats(kind, minHotDegree)[storeID]; ok && len(stats) > 0 {
+		return stats[rand.Intn(len(stats))]
 	}
 	return nil
 }

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -69,15 +69,17 @@ func NewHotStoresStats(kind FlowKind) *hotPeerCache {
 }
 
 // RegionStats returns hot items
-func (f *hotPeerCache) RegionStats() map[uint64][]*HotPeerStat {
+func (f *hotPeerCache) RegionStats(minHotDegree int) map[uint64][]*HotPeerStat {
 	res := make(map[uint64][]*HotPeerStat)
 	for storeID, peers := range f.peersOfStore {
 		values := peers.GetAll()
-		stat := make([]*HotPeerStat, len(values))
-		res[storeID] = stat
-		for i := range values {
-			stat[i] = values[i].(*HotPeerStat)
+		stat := make([]*HotPeerStat, 0, len(values))
+		for _, v := range values {
+			if peer := v.(*HotPeerStat); peer.HotDegree >= minHotDegree {
+				stat = append(stat, peer)
+			}
 		}
+		res[storeID] = stat
 	}
 	return res
 }

--- a/server/statistics/hot_peer_cache_test.go
+++ b/server/statistics/hot_peer_cache_test.go
@@ -52,7 +52,7 @@ func (t *testHotPeerCache) TestStoreTimeUnsync(c *C) {
 
 		checkAndUpdate(c, cache, region, 3)
 		{
-			stats := cache.RegionStats()
+			stats := cache.RegionStats(0)
 			c.Assert(stats, HasLen, 3)
 			for _, s := range stats {
 				c.Assert(s, HasLen, 1)

--- a/server/statistics/region_stat_informer.go
+++ b/server/statistics/region_stat_informer.go
@@ -18,9 +18,11 @@ import "github.com/tikv/pd/server/core"
 // RegionStatInformer provides access to a shared informer of statistics.
 type RegionStatInformer interface {
 	IsRegionHot(region *core.RegionInfo) bool
-	// RegionWriteStats return the storeID -> write stat of peers on this store
+	// RegionWriteStats return the storeID -> write stat of peers on this store.
+	// The result only includes peers that are hot enough.
 	RegionWriteStats() map[uint64][]*HotPeerStat
-	// RegionReadStats return the storeID -> read stat of peers on this store
+	// RegionReadStats return the storeID -> read stat of peers on this store.
+	// The result only includes peers that are hot enough.
 	RegionReadStats() map[uint64][]*HotPeerStat
 	RandHotRegionFromStore(store uint64, kind FlowKind) *core.RegionInfo
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Check minHotDegree inside `HotPeerCache` and only return regions that are hot enough so we don't have to consider hotDegree in schedulers.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test

### Release note
- No release note
