### PR TITLE
server/scheduler: Do not remove the down peer until the normal peers are enough

### DIFF
--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -220,7 +220,7 @@ func (r *ReplicaChecker) checkLocationReplacement(region *core.RegionInfo) *oper
 
 func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, storeID uint64, status string) *operator.Operator {
 	// Check the number of replicas first.
-	if len(region.GetPeers()) > r.opts.GetMaxReplicas() {
+	if len(region.GetVoters()) > r.opts.GetMaxReplicas() {
 		removeExtra := fmt.Sprintf("remove-extra-%s-replica", status)
 		op, err := operator.CreateRemovePeerOperator(removeExtra, r.cluster, operator.OpReplica, region, storeID)
 		if err != nil {

--- a/server/schedule/checker/replica_checker_test.go
+++ b/server/schedule/checker/replica_checker_test.go
@@ -148,6 +148,52 @@ func (s *testReplicaCheckerSuite) TestOfflineWithOneReplica(c *C) {
 	c.Assert(op.Desc(), Equals, "replace-offline-replica")
 }
 
+func (s *testReplicaCheckerSuite) testDownPeer(c *C, aliveRole metapb.PeerRole) *operator.Operator {
+	s.cluster.SetMaxReplicas(2)
+	s.cluster.SetStoreUp(1)
+	downStoreID := uint64(3)
+	peers := []*metapb.Peer{
+		{
+			Id:      4,
+			StoreId: 1,
+			Role:    aliveRole,
+		},
+		{
+			Id:      14,
+			StoreId: downStoreID,
+		},
+		{
+			Id:      15,
+			StoreId: 4,
+		},
+	}
+	r := core.NewRegionInfo(&metapb.Region{Id: 2, Peers: peers}, peers[0])
+	s.cluster.PutRegion(r)
+	s.cluster.SetStoreDown(downStoreID)
+	downPeer := &pdpb.PeerStats{
+		Peer: &metapb.Peer{
+			Id:      14,
+			StoreId: downStoreID,
+		},
+		DownSeconds: 24 * 60 * 60,
+	}
+	r = r.Clone(core.WithDownPeers(append(r.GetDownPeers(), downPeer)))
+	c.Assert(len(r.GetDownPeers()), Equals, 1)
+	return s.rc.Check(r)
+}
+
+func (s *testReplicaCheckerSuite) TestDownPeer(c *C) {
+	// down a peer, the number of normal peers(except learner) is enough.
+	op := s.testDownPeer(c, metapb.PeerRole_Voter)
+	c.Assert(op, NotNil)
+	c.Assert(op.Desc(), Equals, "remove-extra-down-replica")
+
+	// down a peer,the number of peers(except learner) is not enough.
+	op = s.testDownPeer(c, metapb.PeerRole_Learner)
+	c.Assert(op, NotNil)
+	c.Assert(op.Desc(), Equals, "replace-down-replica")
+}
+
 func (s *testReplicaCheckerSuite) TestBasic(c *C) {
 	opt := config.NewTestOptions()
 	tc := mockcluster.NewCluster(opt)


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Issue Number: close #3117 

### What is changed and how it works?

Do not remove the down peer until the normal peers are enough

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)



### Release note

Do not remove the down peer until the normal peers are enough
