### PR TITLE
pd-ctl: set exit code for invalid command

### DIFF
--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -136,26 +136,30 @@ func hiddenFlag(cmd *cobra.Command) {
 
 // MainStart start main command
 func MainStart(args []string) {
-	startCmd(getMainCmd, args)
+	if err := startCmd(getMainCmd, args); err != nil {
+		os.Exit(1)
+	}
 }
 
 // Start start interact command
 func Start(args []string) {
-	startCmd(getInteractCmd, args)
+	_ = startCmd(getInteractCmd, args)
 }
 
-func startCmd(getCmd func([]string) *cobra.Command, args []string) {
+func startCmd(getCmd func([]string) *cobra.Command, args []string) error {
 	rootCmd := getCmd(args)
 	if len(commandFlags.CAPath) != 0 {
 		if err := command.InitHTTPSClient(commandFlags.CAPath, commandFlags.CertPath, commandFlags.KeyPath); err != nil {
 			rootCmd.Println(err)
-			return
+			return err
 		}
 	}
 
 	if err := rootCmd.Execute(); err != nil {
 		rootCmd.Println(err)
+		return err
 	}
+	return nil
 }
 
 func loop() {


### PR DESCRIPTION
Signed-off-by: Shenjun Ma <mashenjun0902@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
Issue Number: close #3333 
Problem Summary: When under non-interactive mode, `pd-ctl` should exits with a non-zero code for invalid commands.
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
modify `func startCmd` to return error.
modify `func MainStart` to check the returned error and set exit code correspondingly.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1. build `pd-ctl`
2. check the exist code as follow:
``` 
./pd-ctl unknown command 
unknown command "unknown" for "pd-ctl" 
echo $? 
1
```
### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
`pd-ctl` exits with a non-zero code for invalid commands under non-interactive mode.
