### PR TITLE
cluster: if a tombstone store still has peers, it cannot be removed

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1200,6 +1200,10 @@ func (c *RaftCluster) RemoveTombStoneRecords() error {
 
 	for _, store := range c.GetStores() {
 		if store.IsTombstone() {
+			if store.GetRegionCount() > 0 {
+				log.Warn("skip removing tombstone", zap.Stringer("store", store.GetMeta()))
+				continue
+			}
 			// the store has already been tombstone
 			err := c.deleteStoreLocked(store)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

Related #3076

### What is changed and how it works?

* cluster: if a tombstone store still has peers, it cannot be removed

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
curl -X POST 'http://{pd_ip}:{pd_port}/pd/api/v1/store/{store_id}/state?state=Tombstone'
pd-ctl remove-tombstone
```

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- If a tombstone store still has peers, make it cannot be removed.
