### PR TITLE
scheduler: do not balance the empty regions

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -15,6 +15,7 @@ package mockcluster
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -585,7 +586,11 @@ func (mc *Cluster) CheckLabelProperty(typ string, labels []*metapb.StoreLabel) b
 
 // PutRegionStores mocks method.
 func (mc *Cluster) PutRegionStores(id uint64, stores ...uint64) {
-	meta := &metapb.Region{Id: id}
+	meta := &metapb.Region{
+		Id:       id,
+		StartKey: []byte(strconv.FormatUint(id, 10)),
+		EndKey:   []byte(strconv.FormatUint(id+1, 10)),
+	}
 	for _, s := range stores {
 		meta.Peers = append(meta.Peers, &metapb.Peer{StoreId: s})
 	}

--- a/server/schedule/opt/healthy.go
+++ b/server/schedule/opt/healthy.go
@@ -13,7 +13,12 @@
 
 package opt
 
-import "github.com/tikv/pd/server/core"
+import (
+	"github.com/tikv/pd/server/core"
+)
+
+// BalanceEmptyRegionThreshold is a threshold which allow balance the empty region if the region number is less than this threshold.
+var balanceEmptyRegionThreshold = 50
 
 // IsRegionHealthy checks if a region is healthy for scheduling. It requires the
 // region does not have any down or pending peers. And when placement rules
@@ -31,6 +36,12 @@ func IsHealthyAllowPending(cluster Cluster, region *core.RegionInfo) bool {
 	return len(region.GetDownPeers()) == 0
 }
 
+// IsEmptyRegionAllowBalance checks if a region is an empty region and can be balanced.
+func IsEmptyRegionAllowBalance(cluster Cluster, region *core.RegionInfo) bool {
+	return region.GetApproximateSize() > core.EmptyRegionApproximateSize ||
+		(region.GetApproximateSize() <= core.EmptyRegionApproximateSize && cluster.GetRegionCount() < balanceEmptyRegionThreshold)
+}
+
 // HealthRegion returns a function that checks if a region is healthy for
 // scheduling. It requires the region does not have any down or pending peers,
 // and does not have any learner peers when placement rules is disabled.
@@ -43,6 +54,11 @@ func HealthRegion(cluster Cluster) func(*core.RegionInfo) bool {
 // to have pending peers.
 func HealthAllowPending(cluster Cluster) func(*core.RegionInfo) bool {
 	return func(region *core.RegionInfo) bool { return IsHealthyAllowPending(cluster, region) }
+}
+
+// AllowBalanceEmptyRegion returns a function that checks if a region is an empty region and can be balanced.
+func AllowBalanceEmptyRegion(cluster Cluster) func(*core.RegionInfo) bool {
+	return func(region *core.RegionInfo) bool { return IsEmptyRegionAllowBalance(cluster, region) }
 }
 
 // IsRegionReplicated checks if a region is fully replicated. When placement

--- a/server/schedule/opt/healthy.go
+++ b/server/schedule/opt/healthy.go
@@ -38,8 +38,7 @@ func IsHealthyAllowPending(cluster Cluster, region *core.RegionInfo) bool {
 
 // IsEmptyRegionAllowBalance checks if a region is an empty region and can be balanced.
 func IsEmptyRegionAllowBalance(cluster Cluster, region *core.RegionInfo) bool {
-	return region.GetApproximateSize() > core.EmptyRegionApproximateSize ||
-		(region.GetApproximateSize() <= core.EmptyRegionApproximateSize && cluster.GetRegionCount() < balanceEmptyRegionThreshold)
+	return region.GetApproximateSize() > core.EmptyRegionApproximateSize || cluster.GetRegionCount() < balanceEmptyRegionThreshold
 }
 
 // HealthRegion returns a function that checks if a region is healthy for

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -171,6 +171,13 @@ func (s *balanceRegionScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 			}
 			log.Debug("select region", zap.String("scheduler", s.GetName()), zap.Uint64("region-id", region.GetID()))
 
+			// Skip the empty region
+			if region.GetApproximateSize() <= core.EmptyRegionApproximateSize {
+				log.Debug("region is empty", zap.String("scheduler", s.GetName()), zap.Uint64("region-id", region.GetID()))
+				schedulerCounter.WithLabelValues(s.GetName(), "empty-region").Inc()
+				continue
+			}
+
 			// Skip hot regions.
 			if cluster.IsRegionHot(region) {
 				log.Debug("region is hot", zap.String("scheduler", s.GetName()), zap.Uint64("region-id", region.GetID()))

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -960,6 +960,12 @@ func (s *testBalanceRegionSchedulerSuite) TestEmptyRegion(c *C) {
 	)
 	tc.PutRegion(region)
 	operators := sb.Schedule(tc)
+	c.Assert(operators, NotNil)
+
+	for i := uint64(10); i < 60; i++ {
+		tc.PutRegionStores(i, 1, 3, 4)
+	}
+	operators = sb.Schedule(tc)
 	c.Assert(operators, IsNil)
 }
 

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -932,6 +932,37 @@ func (s *testBalanceRegionSchedulerSuite) TestShouldNotBalance(c *C) {
 	}
 }
 
+func (s *testBalanceRegionSchedulerSuite) TestEmptyRegion(c *C) {
+	opt := config.NewTestOptions()
+	tc := mockcluster.NewCluster(opt)
+	tc.DisableFeature(versioninfo.JointConsensus)
+	oc := schedule.NewOperatorController(s.ctx, nil, nil)
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	c.Assert(err, IsNil)
+	tc.AddRegionStore(1, 10)
+	tc.AddRegionStore(2, 9)
+	tc.AddRegionStore(3, 10)
+	tc.AddRegionStore(4, 10)
+	region := core.NewRegionInfo(
+		&metapb.Region{
+			Id:       5,
+			StartKey: []byte("a"),
+			EndKey:   []byte("b"),
+			Peers: []*metapb.Peer{
+				{Id: 6, StoreId: 1},
+				{Id: 7, StoreId: 3},
+				{Id: 8, StoreId: 4},
+			},
+		},
+		&metapb.Peer{Id: 7, StoreId: 3},
+		core.SetApproximateSize(1),
+		core.SetApproximateKeys(1),
+	)
+	tc.PutRegion(region)
+	operators := sb.Schedule(tc)
+	c.Assert(operators, IsNil)
+}
+
 var _ = Suite(&testRandomMergeSchedulerSuite{})
 
 type testRandomMergeSchedulerSuite struct{}


### PR DESCRIPTION
### What problem does this PR solve?

After `drop table` or such kind of operation, there might be a large number of empty regions which cannot be merged immediately. The balance region scheduler will balance them if the stores' size have the difference. In this case, it may cause a lot of balance operation which affect the performance.

### What is changed and how it works?

This PR will skip the empty region when selecting the region.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
