### PR TITLE
server/api: do not support setting store to Tombstone by any API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce
-	github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c
+	github.com/pingcap/kvproto v0.0.0-20210118091648-29d65899faf7
 	github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8
 	github.com/pingcap/sysutil v0.0.0-20201130064824-f0c8aa6a6966
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,8 @@ github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce h1:Y1kCxlCtlPTMt
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c h1:ggbmqi1uOA926t5SEEo0nvBi/sCsJASIrOaiO25ufv4=
-github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20210118091648-29d65899faf7 h1:74r4YTCSKC3aainPaXovtz+VwioQvej0mQj1xDDPN64=
+github.com/pingcap/kvproto v0.0.0-20210118091648-29d65899faf7/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=

--- a/server/api/operator_test.go
+++ b/server/api/operator_test.go
@@ -105,7 +105,7 @@ func (s *testOperatorSuite) TestAddRemovePeer(c *C) {
 	c.Assert(strings.Contains(operator, "add learner peer 2 on store 4"), IsTrue)
 
 	// Fail to add peer to tombstone store.
-	err = s.svr.GetRaftCluster().SetStoreState(3, metapb.StoreState_Tombstone)
+	err = s.svr.GetRaftCluster().RemoveStore(3, true)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, fmt.Sprintf("%s/operators", s.urlPrefix), []byte(`{"name":"add-peer", "region_id": 1, "store_id": 3}`))
 	c.Assert(err, NotNil)

--- a/server/api/operator_test.go
+++ b/server/api/operator_test.go
@@ -104,7 +104,6 @@ func (s *testOperatorSuite) TestAddRemovePeer(c *C) {
 	operator = mustReadURL(c, regionURL)
 	c.Assert(strings.Contains(operator, "add learner peer 2 on store 4"), IsTrue)
 
-	// Fail to add peer to tombstone store.
 	err = s.svr.GetRaftCluster().RemoveStore(3, true)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, fmt.Sprintf("%s/operators", s.urlPrefix), []byte(`{"name":"add-peer", "region_id": 1, "store_id": 3}`))

--- a/server/api/operator_test.go
+++ b/server/api/operator_test.go
@@ -105,7 +105,7 @@ func (s *testOperatorSuite) TestAddRemovePeer(c *C) {
 	c.Assert(strings.Contains(operator, "add learner peer 2 on store 4"), IsTrue)
 
 	// Fail to add peer to tombstone store.
-	err = s.svr.GetRaftCluster().BuryStore(3, true)
+	err = s.svr.GetRaftCluster().SetStoreState(3, metapb.StoreState_Tombstone)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, fmt.Sprintf("%s/operators", s.urlPrefix), []byte(`{"name":"add-peer", "region_id": 1, "store_id": 3}`))
 	c.Assert(err, NotNil)

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -171,6 +171,7 @@ func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Tags store
 // @Summary Take down a store from the cluster.
 // @Param id path integer true "Store Id"
+// @Param force query string true "force" Enums(true, false), when force is true it means the store is physically destroyed and can never up gain
 // @Produce json
 // @Success 200 {string} string "The store is set as Offline."
 // @Failure 400 {string} string "The input is invalid."
@@ -196,13 +197,13 @@ func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.rd.JSON(w, http.StatusOK, "The store is set as Offline or Tombstone.")
+	h.rd.JSON(w, http.StatusOK, "The store is set as Offline.")
 }
 
 // @Tags store
 // @Summary Set the store's state.
 // @Param id path integer true "Store Id"
-// @Param state query string true "state" Enums(Up, Offline, Tombstone)
+// @Param state query string true "state" Enums(Up, Offline)
 // @Produce json
 // @Success 200 {string} string "The store's state is updated."
 // @Failure 400 {string} string "The input is invalid."

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -37,8 +37,7 @@ import (
 // MetaStore contains meta information about a store.
 type MetaStore struct {
 	*metapb.Store
-	StateName           string `json:"state_name"`
-	PhysicallyDestoryed bool   `json:"physically_destroyed"`
+	StateName string `json:"state_name"`
 }
 
 // StoreStatus contains status about a store.
@@ -77,9 +76,8 @@ const (
 func newStoreInfo(opt *config.ScheduleConfig, store *core.StoreInfo) *StoreInfo {
 	s := &StoreInfo{
 		Store: &MetaStore{
-			Store:               store.GetMeta(),
-			StateName:           store.GetState().String(),
-			PhysicallyDestoryed: store.IsPhysicallyDestoryAndOffline(),
+			Store:     store.GetMeta(),
+			StateName: store.GetState().String(),
 		},
 		Status: &StoreStatus{
 			Capacity:           typeutil.ByteSize(store.GetCapacity()),

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -187,11 +187,7 @@ func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 	_, force := r.URL.Query()["force"]
-	if force {
-		err = rc.BuryStore(storeID, force)
-	} else {
-		err = rc.RemoveStore(storeID)
-	}
+	err = rc.RemoveStore(storeID, force)
 
 	if errors.ErrorEqual(err, errs.ErrStoreNotFound.FastGenByArgs(storeID)) {
 		h.rd.JSON(w, http.StatusNotFound, err.Error())

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -37,7 +37,8 @@ import (
 // MetaStore contains meta information about a store.
 type MetaStore struct {
 	*metapb.Store
-	StateName string `json:"state_name"`
+	StateName           string `json:"state_name"`
+	PhysicallyDestoryed bool   `json:"physically_destroyed"`
 }
 
 // StoreStatus contains status about a store.
@@ -76,8 +77,9 @@ const (
 func newStoreInfo(opt *config.ScheduleConfig, store *core.StoreInfo) *StoreInfo {
 	s := &StoreInfo{
 		Store: &MetaStore{
-			Store:     store.GetMeta(),
-			StateName: store.GetState().String(),
+			Store:               store.GetMeta(),
+			StateName:           store.GetState().String(),
+			PhysicallyDestoryed: store.IsPhysicallyDestoryAndOffline(),
 		},
 		Status: &StoreStatus{
 			Capacity:           typeutil.ByteSize(store.GetCapacity()),
@@ -249,6 +251,7 @@ func (h *storeHandler) responseStoreErr(w http.ResponseWriter, err error, storeI
 		h.rd.JSON(w, http.StatusGone, err.Error())
 		return
 	}
+
 	if err != nil {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 	}

--- a/server/api/store_test.go
+++ b/server/api/store_test.go
@@ -307,6 +307,9 @@ func (s *testStoreSuite) TestStoreSetState(c *C) {
 	info = StoreInfo{}
 	err = postJSON(testDialClient, url+"/state?state=Foo", nil)
 	c.Assert(err, NotNil)
+	err = postJSON(testDialClient, url+"/state?state=Tombstone", nil)
+	c.Assert(err, NotNil)
+
 	err = readJSON(testDialClient, url, &info)
 	c.Assert(err, IsNil)
 	c.Assert(info.Store.State, Equals, metapb.StoreState_Offline)
@@ -318,6 +321,11 @@ func (s *testStoreSuite) TestStoreSetState(c *C) {
 	err = readJSON(testDialClient, url, &info)
 	c.Assert(err, IsNil)
 	c.Assert(info.Store.State, Equals, metapb.StoreState_Up)
+
+	// store not found
+	info = StoreInfo{}
+	err = postJSON(testDialClient, s.urlPrefix+"/store/10086"+"/state?state=Offline", nil)
+	c.Assert(err, NotNil)
 }
 
 func (s *testStoreSuite) TestUrlStoreFilter(c *C) {

--- a/server/api/store_test.go
+++ b/server/api/store_test.go
@@ -254,6 +254,38 @@ func (s *testStoreSuite) TestStoreDelete(c *C) {
 		status, _ := requestStatusBody(c, testDialClient, http.MethodDelete, url)
 		c.Assert(status, Equals, t.status)
 	}
+
+	// store 6 origin status:offline
+	url := fmt.Sprintf("%s/store/6", s.urlPrefix)
+	store := new(StoreInfo)
+	err := readJSON(testDialClient, url, store)
+	c.Assert(err, IsNil)
+	c.Assert(store.Store.PhysicallyDestoryed, Equals, false)
+	c.Assert(store.Store.State, Equals, metapb.StoreState_Offline)
+
+	// up store success because it is offline but not physically destroyed
+	status, _ := requestStatusBody(c, testDialClient, http.MethodPost, fmt.Sprintf("%s/state?state=Up", url))
+	c.Assert(status, Equals, http.StatusOK)
+
+	status, _ = requestStatusBody(c, testDialClient, http.MethodGet, url)
+	c.Assert(status, Equals, http.StatusOK)
+	store = new(StoreInfo)
+	err = readJSON(testDialClient, url, store)
+	c.Assert(err, IsNil)
+	c.Assert(store.Store.State, Equals, metapb.StoreState_Up)
+	c.Assert(store.Store.PhysicallyDestoryed, Equals, false)
+
+	// offline store with physically destroyed
+	status, _ = requestStatusBody(c, testDialClient, http.MethodDelete, fmt.Sprintf("%s?force=true", url))
+	c.Assert(status, Equals, http.StatusOK)
+	err = readJSON(testDialClient, url, store)
+	c.Assert(err, IsNil)
+	c.Assert(store.Store.State, Equals, metapb.StoreState_Offline)
+	c.Assert(store.Store.PhysicallyDestoryed, Equals, true)
+
+	// try to up store again failed because it is physically destroyed
+	status, _ = requestStatusBody(c, testDialClient, http.MethodPost, fmt.Sprintf("%s/state?state=Up", url))
+	c.Assert(status, Equals, http.StatusGone)
 }
 
 func (s *testStoreSuite) TestStoreSetState(c *C) {

--- a/server/api/store_test.go
+++ b/server/api/store_test.go
@@ -260,7 +260,7 @@ func (s *testStoreSuite) TestStoreDelete(c *C) {
 	store := new(StoreInfo)
 	err := readJSON(testDialClient, url, store)
 	c.Assert(err, IsNil)
-	c.Assert(store.Store.PhysicallyDestoryed, Equals, false)
+	c.Assert(store.Store.PhysicallyDestroyed, Equals, false)
 	c.Assert(store.Store.State, Equals, metapb.StoreState_Offline)
 
 	// up store success because it is offline but not physically destroyed
@@ -273,7 +273,7 @@ func (s *testStoreSuite) TestStoreDelete(c *C) {
 	err = readJSON(testDialClient, url, store)
 	c.Assert(err, IsNil)
 	c.Assert(store.Store.State, Equals, metapb.StoreState_Up)
-	c.Assert(store.Store.PhysicallyDestoryed, Equals, false)
+	c.Assert(store.Store.PhysicallyDestroyed, Equals, false)
 
 	// offline store with physically destroyed
 	status, _ = requestStatusBody(c, testDialClient, http.MethodDelete, fmt.Sprintf("%s?force=true", url))
@@ -281,11 +281,14 @@ func (s *testStoreSuite) TestStoreDelete(c *C) {
 	err = readJSON(testDialClient, url, store)
 	c.Assert(err, IsNil)
 	c.Assert(store.Store.State, Equals, metapb.StoreState_Offline)
-	c.Assert(store.Store.PhysicallyDestoryed, Equals, true)
+	c.Assert(store.Store.PhysicallyDestroyed, Equals, true)
 
 	// try to up store again failed because it is physically destroyed
 	status, _ = requestStatusBody(c, testDialClient, http.MethodPost, fmt.Sprintf("%s/state?state=Up", url))
 	c.Assert(status, Equals, http.StatusGone)
+	// reset store 6
+	s.cleanup()
+	s.SetUpSuite(c)
 }
 
 func (s *testStoreSuite) TestStoreSetState(c *C) {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1154,7 +1154,7 @@ func (c *RaftCluster) putStoreLocked(store *core.StoreInfo) error {
 	}
 
 	if store.IsPhysicallyDestoryAndOffline() && c.curPhysicallyDestroyedAndOfflineStoreID != store.GetID() {
-		return errors.Errorf("Somestore(store ID:%v) is offline and pyhically destroyed, please wait unitil the previous store comes to Tombstone", c.curPhysicallyDestroyedAndOfflineStoreID)
+		return errors.Errorf("Somestore(store ID:%v) is offline and pyhically destroyed, please wait until the previous store comes to Tombstone", c.curPhysicallyDestroyedAndOfflineStoreID)
 	}
 	if c.storage != nil {
 		if err := c.storage.SaveStore(store.GetMeta()); err != nil {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1123,7 +1123,6 @@ func (c *RaftCluster) UpStore(storeID uint64) error {
 		zap.Uint64("store-id", storeID),
 		zap.Stringer("old-state", store.GetState()))
 	return c.putStoreLocked(newStore)
-
 }
 
 // SetStoreWeight sets up a store's leader/region balance weight.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -136,16 +136,21 @@ func (s *testClusterInfoSuite) TestSetStoreState(c *C) {
 	}
 	// Store 3 and 4 offline normally.
 	for _, id := range []uint64{3, 4} {
-		c.Assert(cluster.SetStoreState(id, metapb.StoreState_Tombstone), IsNil)
+		c.Assert(cluster.RemoveStore(id, false), IsNil)
 	}
 	// Change the status of 3 directly back to Up.
-	c.Assert(cluster.SetStoreState(3, metapb.StoreState_Up), IsNil)
+	c.Assert(cluster.UpStore(3), IsNil)
 	// Update store 1 2 3
 	for _, store := range newTestStores(3, "3.0.0") {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
 	}
-	// Since the store 4 version is too low, setting it to Up should fail.
-	c.Assert(cluster.SetStoreState(4, metapb.StoreState_Up), NotNil)
+	c.Assert(cluster.GetClusterVersion(), Equals, "2.0.0")
+	c.Assert(cluster.RemoveStore(3, false), IsNil)
+	c.Assert(cluster.RemoveStore(3, true), IsNil)
+	c.Assert(cluster.UpStore(3), NotNil)
+	c.Assert(cluster.RemoveStore(3, false), NotNil)
+	cluster.checkStores()
+	c.Assert(cluster.GetClusterVersion(), Equals, "3.0.0")
 }
 
 func (s *testClusterInfoSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -136,8 +136,7 @@ func (s *testClusterInfoSuite) TestSetStoreState(c *C) {
 	}
 	// Store 3 and 4 offline normally.
 	for _, id := range []uint64{3, 4} {
-		c.Assert(cluster.RemoveStore(id), IsNil)
-		c.Assert(cluster.BuryStore(id, false), IsNil)
+		c.Assert(cluster.SetStoreState(id, metapb.StoreState_Tombstone), IsNil)
 	}
 	// Change the status of 3 directly back to Up.
 	c.Assert(cluster.SetStoreState(3, metapb.StoreState_Up), IsNil)
@@ -165,11 +164,6 @@ func (s *testClusterInfoSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
 	}
 	c.Assert(cluster.GetClusterVersion(), Equals, "4.0.9")
-
-	// Bury the other store.
-	c.Assert(cluster.RemoveStore(3), IsNil)
-	c.Assert(cluster.BuryStore(3, false), IsNil)
-	c.Assert(cluster.GetClusterVersion(), Equals, "5.0.0")
 }
 
 func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -146,19 +146,19 @@ func (s *testClusterInfoSuite) TestSetStoreState(c *C) {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
 	}
 	c.Assert(cluster.GetClusterVersion(), Equals, "2.0.0")
-	c.Assert(cluster.RemoveStore(3, false), IsNil)
-	c.Assert(cluster.RemoveStore(3, true), IsNil)
-	c.Assert(cluster.RemoveStore(3, true), IsNil)
-	c.Assert(cluster.UpStore(3), NotNil)
-	// try to make store 4 physically destroyed and offline failed because store 3 is still offline and physically destroyed.
-	c.Assert(cluster.RemoveStore(4, true), NotNil)
-	// try to make store 3 from physically destroyed to normall should be failed.
-	c.Assert(cluster.RemoveStore(3, false), NotNil)
+	for _, storeID := range []uint64{3, 4} {
+		c.Assert(cluster.RemoveStore(storeID, false), IsNil)
+		c.Assert(cluster.RemoveStore(storeID, true), IsNil)
+		c.Assert(cluster.RemoveStore(storeID, true), IsNil)
+		c.Assert(cluster.UpStore(storeID), NotNil)
+		// try to make store from physically destroyed to normall should be failed.
+		c.Assert(cluster.RemoveStore(storeID, false), NotNil)
+	}
 
 	for _, store := range stores {
 		newStore := store.GetMeta()
-		if store.GetID() == cluster.curPhysicallyDestroyedAndOfflineStoreID {
-			// try to start a new store with the same address with store 3 should be success
+		if cluster.GetStore(newStore.Id).IsPhysicallyDestoryAndOffline() {
+			// try to start a new store with the same address with store which is physically destryed should be success
 			newStore.Id = store.GetID() + 1000
 			c.Assert(cluster.PutStore(newStore), IsNil)
 		} else {

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -47,6 +47,7 @@ type StoreInfo struct {
 	leaderWeight        float64
 	regionWeight        float64
 	available           map[storelimit.Type]func() bool
+	physicallyDestroyed bool // true means this store is physicall destroyed, which can not restart or be connected
 }
 
 // NewStoreInfo creates StoreInfo with meta data.
@@ -132,6 +133,11 @@ func (s *StoreInfo) IsUp() bool {
 // IsOffline checks if the store's state is Offline.
 func (s *StoreInfo) IsOffline() bool {
 	return s.GetState() == metapb.StoreState_Offline
+}
+
+// IsPhysicallyDestoryAndOffline checks if the store is offline and physically destroyed
+func (s *StoreInfo) IsPhysicallyDestoryAndOffline() bool {
+	return s.GetState() == metapb.StoreState_Offline && s.physicallyDestroyed
 }
 
 // IsTombstone checks if the store's state is Tombstone.

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -47,7 +47,6 @@ type StoreInfo struct {
 	leaderWeight        float64
 	regionWeight        float64
 	available           map[storelimit.Type]func() bool
-	physicallyDestroyed bool // true means this store is physicall destroyed, which can not restart or be connected
 }
 
 // NewStoreInfo creates StoreInfo with meta data.
@@ -137,7 +136,7 @@ func (s *StoreInfo) IsOffline() bool {
 
 // IsPhysicallyDestoryAndOffline checks if the store is offline and physically destroyed
 func (s *StoreInfo) IsPhysicallyDestoryAndOffline() bool {
-	return s.GetState() == metapb.StoreState_Offline && s.physicallyDestroyed
+	return s.GetState() == metapb.StoreState_Offline && s.GetMeta().GetPhysicallyDestroyed()
 }
 
 // IsTombstone checks if the store's state is Tombstone.

--- a/server/core/store_option.go
+++ b/server/core/store_option.go
@@ -87,8 +87,8 @@ func OfflineStore(physicallyDestroyed bool) StoreCreateOption {
 	return func(store *StoreInfo) {
 		meta := proto.Clone(store.meta).(*metapb.Store)
 		meta.State = metapb.StoreState_Offline
+		meta.PhysicallyDestroyed = physicallyDestroyed
 		store.meta = meta
-		store.physicallyDestroyed = physicallyDestroyed
 	}
 }
 

--- a/server/core/store_option.go
+++ b/server/core/store_option.go
@@ -82,6 +82,16 @@ func SetStoreState(state metapb.StoreState) StoreCreateOption {
 	}
 }
 
+// OfflineStore sets the state to offline with option physicallyDestroyed
+func OfflineStore(physicallyDestroyed bool) StoreCreateOption {
+	return func(store *StoreInfo) {
+		meta := proto.Clone(store.meta).(*metapb.Store)
+		meta.State = metapb.StoreState_Offline
+		store.meta = meta
+		store.physicallyDestroyed = physicallyDestroyed
+	}
+}
+
 // PauseLeaderTransfer prevents the store from been selected as source or
 // target store of TransferLeader.
 func PauseLeaderTransfer() StoreCreateOption {

--- a/server/server.go
+++ b/server/server.go
@@ -828,7 +828,7 @@ func (s *Server) SetReplicationConfig(cfg config.ReplicationConfig) error {
 		} else {
 			// NOTE: can be removed after placement rules feature is enabled by default.
 			for _, s := range raftCluster.GetStores() {
-				if !s.IsTombstone() && core.IsTiFlashStore(s.GetMeta()) {
+				if !(s.IsTombstone()) && core.IsTiFlashStore(s.GetMeta()) {
 					return errors.New("cannot disable placement rules with TiFlash nodes")
 				}
 			}

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -113,7 +113,7 @@ func (s *StoresStats) GetStoresLoads() map[uint64][]float64 {
 
 func (s *StoresStats) storeIsUnhealthy(cluster core.StoreSetInformer, storeID uint64) bool {
 	store := cluster.GetStore(storeID)
-	return store.IsTombstone() || store.IsUnhealthy()
+	return store.IsTombstone() || store.IsPhysicallyDestoryAndOffline() || store.IsUnhealthy()
 }
 
 // FilterUnhealthyStore filter unhealthy store

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -757,25 +757,28 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	}
 	c.Assert(contains, IsTrue)
 
-	// Mark the store as tombstone.
+	// Mark the store as physically destroyed and offline.
 	err = cluster.RemoveStore(store.GetId(), true)
 	c.Assert(err, IsNil)
-	tombstoneStore := proto.Clone(store).(*metapb.Store)
-	tombstoneStore.State = metapb.StoreState_Tombstone
+	physicallyDestroyedStoreID := store.GetId()
+	// tombstoneStore := proto.Clone(store).(*metapb.Store)
+	// tombstoneStore.State = metapb.StoreState_Tombstone
 
-	// Get a tombstone store should fail.
-	n, err = s.client.GetStore(context.Background(), store.GetId())
+	// Get a physically destroyed and offline store
+	// It should be Tombstone(become Tombstone automically) or Offline
+	n, err = s.client.GetStore(context.Background(), physicallyDestroyedStoreID)
 	c.Assert(err, IsNil)
-	c.Assert(n, IsNil)
-
+	if n != nil { // store is still offline and physically destroyed
+		c.Assert(n.GetState(), Equals, metapb.StoreState_Offline)
+	}
 	// Should return tombstone stores.
 	contains = false
 	stores, err = s.client.GetAllStores(context.Background())
 	c.Assert(err, IsNil)
 	for _, store := range stores {
-		if store.GetId() == tombstoneStore.GetId() {
+		if store.GetId() == physicallyDestroyedStoreID {
 			contains = true
-			c.Assert(store, DeepEquals, tombstoneStore)
+			c.Assert(store.GetState(), Not(Equals), metapb.StoreState_Up)
 		}
 	}
 	c.Assert(contains, IsTrue)
@@ -784,7 +787,9 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	stores, err = s.client.GetAllStores(context.Background(), pd.WithExcludeTombstone())
 	c.Assert(err, IsNil)
 	for _, store := range stores {
-		c.Assert(store, Not(Equals), tombstoneStore)
+		if store.GetId() == physicallyDestroyedStoreID {
+			c.Assert(store.GetState(), Equals, metapb.StoreState_Offline)
+		}
 	}
 }
 

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -735,7 +735,7 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	c.Assert(stores, DeepEquals, stores)
 
 	// Mark the store as offline.
-	err = cluster.RemoveStore(store.GetId())
+	err = cluster.RemoveStore(store.GetId(), false)
 	c.Assert(err, IsNil)
 	offlineStore := proto.Clone(store).(*metapb.Store)
 	offlineStore.State = metapb.StoreState_Offline
@@ -758,7 +758,7 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	c.Assert(contains, IsTrue)
 
 	// Mark the store as tombstone.
-	err = cluster.BuryStore(store.GetId(), true)
+	err = cluster.SetStoreState(store.GetId(), metapb.StoreState_Tombstone)
 	c.Assert(err, IsNil)
 	tombstoneStore := proto.Clone(store).(*metapb.Store)
 	tombstoneStore.State = metapb.StoreState_Tombstone

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -758,7 +758,7 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	c.Assert(contains, IsTrue)
 
 	// Mark the store as tombstone.
-	err = cluster.SetStoreState(store.GetId(), metapb.StoreState_Tombstone)
+	err = cluster.RemoveStore(store.GetId(), true)
 	c.Assert(err, IsNil)
 	tombstoneStore := proto.Clone(store).(*metapb.Store)
 	tombstoneStore.State = metapb.StoreState_Tombstone

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -223,7 +223,9 @@ func testPutStore(c *C, clusterID uint64, rc *cluster.RaftCluster, grpcPDClient 
 func resetStoreState(c *C, rc *cluster.RaftCluster, storeID uint64, state metapb.StoreState) {
 	store := rc.GetStore(storeID)
 	c.Assert(store, NotNil)
-	newStore := store.Clone(core.SetStoreState(state))
+	newStore := store.Clone(core.OfflineStore(false))
+	newStore = newStore.Clone(core.SetStoreState(state))
+
 	rc.GetCacheCluster().PutStore(newStore)
 	if state == metapb.StoreState_Offline {
 		rc.SetStoreLimit(storeID, storelimit.RemovePeer, storelimit.Unlimited)

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -282,10 +282,10 @@ func testRemoveStore(c *C, clusterID uint64, rc *cluster.RaftCluster, grpcPDClie
 		testStateAndLimit(c, clusterID, rc, grpcPDClient, store, beforeState, func(cluster *cluster.RaftCluster) error {
 			return cluster.RemoveStore(store.GetId(), false)
 		}, metapb.StoreState_Offline)
-		// Case 2: remove store with physically destroyed should be falied because there is a physically destroyed and offline store already.
+		// Case 2: remove store with physically destroyed should be success
 		testStateAndLimit(c, clusterID, rc, grpcPDClient, store, beforeState, func(cluster *cluster.RaftCluster) error {
 			return cluster.RemoveStore(store.GetId(), true)
-		})
+		}, metapb.StoreState_Offline)
 	}
 	{
 		beforeState := metapb.StoreState_Tombstone // When store is tombstone


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

To close issue https://github.com/tikv/pd/issues/3076

This PR does not support setting a store's state to Tombstone in any API anymore. 

And for the situation in which the  previous API supported, we can use the following API instead:

####  For the situation that the store is physically destroyed and we want to start a new store with the same address: 

When the store is physically destroyed, we can delete it directly:
```
delete /store/{id}?force=true
```
then we can never up the store again, also we can directly start a new store with the same address.


### What is changed and how it works?

We have changed two API
- the API to update the store's state does not support `Tombstone` anymore:
```
POST /store/{id}/state?state=${state}
```
state query string true "state" Enums(Up, Offline), `Tombstone` is not supported anymore

- The API to offline a store
```
DELETE /store/{id}?force=${force}
```
force is a boolean value:
- true: means the store shouldn't be up again and PD can remove it, also we can up a new store with the same address
- false: means the store is offline, it can be up again.


### Check List

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


Code changes


- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))



### Release note

API: Do not support setting the store to Tombstone by any API 