### PR TITLE
*: fix the misleading docker image address

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker build -t tikv/pd .
 Or you can also use following command to get PD from Docker hub:
 
 ```bash
-docker pull tikv/pd
+docker pull pingcap/pd
 ```
 
 Run a single node with Docker:


### PR DESCRIPTION
### What problem does this PR solve?

Currently we still use `pingcap/pd` in docker hub to save our image. Closes #3354.

### What is changed and how it works?

This PR changes it back.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

- No code

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
