### PR TITLE
scheduler: fix scatter range scheduler limit

### DIFF
--- a/server/schedulers/scatter_range.go
+++ b/server/schedulers/scatter_range.go
@@ -193,6 +193,15 @@ func (l *scatterRangeScheduler) EncodeConfig() ([]byte, error) {
 }
 
 func (l *scatterRangeScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+	return l.allowBalanceLeader(cluster) || l.allowBalanceRegion(cluster)
+}
+
+func (l *scatterRangeScheduler) allowBalanceLeader(cluster opt.Cluster) bool {
+	// TODO: add metrics for leader limit
+	return l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetLeaderScheduleLimit()
+}
+
+func (l *scatterRangeScheduler) allowBalanceRegion(cluster opt.Cluster) bool {
 	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetRegionScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(l.GetType(), operator.OpRegion.String()).Inc()
@@ -205,26 +214,32 @@ func (l *scatterRangeScheduler) Schedule(cluster opt.Cluster) []*operator.Operat
 	// isolate a new cluster according to the key range
 	c := schedule.GenRangeCluster(cluster, l.config.GetStartKey(), l.config.GetEndKey())
 	c.SetTolerantSizeRatio(2)
-	ops := l.balanceLeader.Schedule(c)
-	if len(ops) > 0 {
-		ops[0].SetDesc(fmt.Sprintf("scatter-range-leader-%s", l.config.RangeName))
-		ops[0].AttachKind(operator.OpRange)
-		ops[0].Counters = append(ops[0].Counters,
-			schedulerCounter.WithLabelValues(l.GetName(), "new-operator"),
-			schedulerCounter.WithLabelValues(l.GetName(), "new-leader-operator"))
-		return ops
+	if l.allowBalanceLeader(cluster) {
+		ops := l.balanceLeader.Schedule(c)
+		if len(ops) > 0 {
+			ops[0].SetDesc(fmt.Sprintf("scatter-range-leader-%s", l.config.RangeName))
+			ops[0].AttachKind(operator.OpRange)
+			ops[0].Counters = append(ops[0].Counters,
+				schedulerCounter.WithLabelValues(l.GetName(), "new-operator"),
+				schedulerCounter.WithLabelValues(l.GetName(), "new-leader-operator"))
+			return ops
+		}
+		schedulerCounter.WithLabelValues(l.GetName(), "no-need-balance-leader").Inc()
 	}
-	ops = l.balanceRegion.Schedule(c)
-	if len(ops) > 0 {
-		ops[0].SetDesc(fmt.Sprintf("scatter-range-region-%s", l.config.RangeName))
-		ops[0].AttachKind(operator.OpRange)
-		ops[0].Counters = append(ops[0].Counters,
-			schedulerCounter.WithLabelValues(l.GetName(), "new-operator"),
-			schedulerCounter.WithLabelValues(l.GetName(), "new-region-operator"),
-		)
-		return ops
+	if l.allowBalanceRegion(cluster) {
+		ops := l.balanceRegion.Schedule(c)
+		if len(ops) > 0 {
+			ops[0].SetDesc(fmt.Sprintf("scatter-range-region-%s", l.config.RangeName))
+			ops[0].AttachKind(operator.OpRange)
+			ops[0].Counters = append(ops[0].Counters,
+				schedulerCounter.WithLabelValues(l.GetName(), "new-operator"),
+				schedulerCounter.WithLabelValues(l.GetName(), "new-region-operator"),
+			)
+			return ops
+		}
+		schedulerCounter.WithLabelValues(l.GetName(), "no-need-balance-region").Inc()
 	}
-	schedulerCounter.WithLabelValues(l.GetName(), "no-need").Inc()
+
 	return nil
 }
 

--- a/server/schedulers/scatter_range.go
+++ b/server/schedulers/scatter_range.go
@@ -197,8 +197,11 @@ func (l *scatterRangeScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 }
 
 func (l *scatterRangeScheduler) allowBalanceLeader(cluster opt.Cluster) bool {
-	// TODO: add metrics for leader limit
-	return l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetLeaderScheduleLimit()
+	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetLeaderScheduleLimit()
+	if !allowed {
+		operator.OperatorLimitCounter.WithLabelValues(l.GetType(), operator.OpLeader.String()).Inc()
+	}
+	return allowed
 }
 
 func (l *scatterRangeScheduler) allowBalanceRegion(cluster opt.Cluster) bool {


### PR DESCRIPTION
### What problem does this PR solve?

Closes https://github.com/tikv/pd/issues/3356

### What is changed and how it works?

This PR fixes the limit constriction for scatter range scheduler.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->

- Fix the limit constriction of the scatter range scheduler