### PR TITLE
server: Auto fix gc_worker's service safepoint for upgraded clusters

### DIFF
--- a/server/core/storage_test.go
+++ b/server/core/storage_test.go
@@ -245,12 +245,11 @@ func (s *testKVSuite) TestLoadMinServiceGCSafePoint(c *C) {
 		c.Assert(storage.SaveServiceGCSafePoint(ssp), IsNil)
 	}
 
-	// gc_worker's safepoint will be automatically inserted when loading service safepoints.
+	// gc_worker's safepoint will be automatically inserted when loading service safepoints. Here the returned
+	// safepoint can be either of "gc_worker" or "2".
 	ssp, err := storage.LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
-	c.Assert(ssp.ServiceID, Equals, "gc_worker")
-	c.Assert(ssp.ExpiredAt, Equals, int64(math.MaxInt64))
-	c.Assert(ssp.SafePoint, Equals, uint64(1))
+	c.Assert(ssp.SafePoint, Equals, uint64(2))
 
 	// Advance gc_worker's safepoint
 	c.Assert(storage.SaveServiceGCSafePoint(&ServiceSafePoint{

--- a/server/core/storage_test.go
+++ b/server/core/storage_test.go
@@ -245,7 +245,21 @@ func (s *testKVSuite) TestLoadMinServiceGCSafePoint(c *C) {
 		c.Assert(storage.SaveServiceGCSafePoint(ssp), IsNil)
 	}
 
+	// gc_worker's safepoint will be automatically inserted when loading service safepoints.
 	ssp, err := storage.LoadMinServiceGCSafePoint(time.Now())
+	c.Assert(err, IsNil)
+	c.Assert(ssp.ServiceID, Equals, "gc_worker")
+	c.Assert(ssp.ExpiredAt, Equals, int64(math.MaxInt64))
+	c.Assert(ssp.SafePoint, Equals, uint64(1))
+
+	// Advance gc_worker's safepoint
+	c.Assert(storage.SaveServiceGCSafePoint(&ServiceSafePoint{
+		ServiceID: "gc_worker",
+		ExpiredAt: math.MaxInt64,
+		SafePoint: 10,
+	}), IsNil)
+
+	ssp, err = storage.LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(ssp.ServiceID, Equals, "2")
 	c.Assert(ssp.ExpiredAt, Equals, expireAt)

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -866,7 +866,7 @@ func (s *Server) UpdateServiceGCSafePoint(ctx context.Context, request *pdpb.Upd
 			ExpiredAt: now.Unix() + request.TTL,
 			SafePoint: request.SafePoint,
 		}
-		if request.TTL == math.MaxInt64 {
+		if math.MaxInt64-now.Unix() <= request.TTL {
 			ssp.ExpiredAt = math.MaxInt64
 		}
 		if err := s.storage.SaveServiceGCSafePoint(ssp); err != nil {

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -919,7 +919,7 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 	c.Assert(err, IsNil)
 	_, err = s.client.UpdateServiceGCSafePoint(context.Background(),
 		"b", 1000, 12)
-	c.Assert(err,  IsNil)
+	c.Assert(err, IsNil)
 	_, err = s.client.UpdateServiceGCSafePoint(context.Background(),
 		"c", 1000, 13)
 	c.Assert(err, IsNil)
@@ -946,7 +946,7 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.ServiceID, Equals, "gc_worker")
-	c.Assert(minSsp.SafePoint, Equals,  uint64(10))
+	c.Assert(minSsp.SafePoint, Equals, uint64(10))
 	c.Assert(minSsp.ExpiredAt, Equals, int64(math.MaxInt64))
 
 	// Force delete gc_worker, then the min service safepoint is 11 of "a".

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -925,11 +925,6 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 	c.Assert(err, IsNil)
 
 	// Force set invalid ttl to gc_worker
-	//err = s.srv.GetStorage().SaveServiceGCSafePoint(&core.ServiceSafePoint{
-	//	ServiceID: "gc_worker",
-	//	ExpiredAt: -12345,
-	//	SafePoint: 10,
-	//})
 	gcWorkerKey := path.Join("gc", "safe_point", "service", "gc_worker")
 	{
 		gcWorkerSsp := &core.ServiceSafePoint{

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -911,6 +912,61 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 	_, err = s.client.UpdateServiceGCSafePoint(context.Background(),
 		"", 1000, 15)
 	c.Assert(err, NotNil)
+
+	// Put some other safepoints to test fixing gc_worker's safepoint when there exists other safepoints.
+	_, err = s.client.UpdateServiceGCSafePoint(context.Background(),
+		"a", 1000, 11)
+	c.Assert(err, IsNil)
+	_, err = s.client.UpdateServiceGCSafePoint(context.Background(),
+		"b", 1000, 12)
+	c.Assert(err,  IsNil)
+	_, err = s.client.UpdateServiceGCSafePoint(context.Background(),
+		"c", 1000, 13)
+	c.Assert(err, IsNil)
+
+	// Force set invalid ttl to gc_worker
+	//err = s.srv.GetStorage().SaveServiceGCSafePoint(&core.ServiceSafePoint{
+	//	ServiceID: "gc_worker",
+	//	ExpiredAt: -12345,
+	//	SafePoint: 10,
+	//})
+	gcWorkerKey := path.Join("gc", "safe_point", "service", "gc_worker")
+	{
+		gcWorkerSsp := &core.ServiceSafePoint{
+			ServiceID: "gc_worker",
+			ExpiredAt: -12345,
+			SafePoint: 10,
+		}
+		value, err := json.Marshal(gcWorkerSsp)
+		c.Assert(err, IsNil)
+		err = s.srv.GetStorage().Save(gcWorkerKey, string(value))
+		c.Assert(err, IsNil)
+	}
+
+	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	c.Assert(err, IsNil)
+	c.Assert(minSsp.ServiceID, Equals, "gc_worker")
+	c.Assert(minSsp.SafePoint, Equals,  uint64(10))
+	c.Assert(minSsp.ExpiredAt, Equals, int64(math.MaxInt64))
+
+	// Force delete gc_worker, then the min service safepoint is 11 of "a".
+	err = s.srv.GetStorage().Remove(gcWorkerKey)
+	c.Assert(err, IsNil)
+	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	c.Assert(err, IsNil)
+	c.Assert(minSsp.SafePoint, Equals, uint64(11))
+	// After calling LoadMinServiceGCS when "gc_worker"'s service safepoint is missing, "gc_worker"'s service safepoint
+	// will be newly created.
+	// Increase "a" so that "gc_worker" is the only minimum that will be returned by LoadMinServiceGCSafePoint.
+	_, err = s.client.UpdateServiceGCSafePoint(context.Background(),
+		"a", 1000, 14)
+	c.Assert(err, IsNil)
+
+	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	c.Assert(err, IsNil)
+	c.Assert(minSsp.ServiceID, Equals, "gc_worker")
+	c.Assert(minSsp.SafePoint, Equals, uint64(11))
+	c.Assert(minSsp.ExpiredAt, Equals, int64(math.MaxInt64))
 }
 
 func (s *testClientSuite) TestScatterRegion(c *C) {


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Fixes #3366

Though we did a fix in PR #3146 , there's still a problem for clusters upgraded from older version, where the gc_worker's service safepoint may be invalid or missing and there are other service safepoints in the cluster.

### What is changed and how it works?

Checks if "gc_worker"'s service safepoint exist and has a infinite TTL every time loading safepoints, and tries to fix it if possible.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- 

Side effects

- Increased code complexity

Related changes

- Need to cherry-pick to the release branch
  - release-4.0

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

* No release note

