### PR TITLE
tso: fix a global TSO generation bug

### DIFF
--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -106,10 +106,12 @@ func (gta *GlobalTSOAllocator) SetTSO(tso uint64) error {
 func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error) {
 	// To check if we have any dc-location configured in the cluster
 	dcLocationMap := gta.allocatorManager.GetClusterDCLocations()
-	// No dc-locations configured in the cluster
+	// No dc-locations configured in the cluster, use the normal TSO generation way.
 	if len(dcLocationMap) == 0 {
 		return gta.timestampOracle.getTS(gta.leadership, count, 0)
 	}
+
+	// Have dc-locations configured in the cluster, use the Global TSO generation way.
 	// Send maxTS to all Local TSO Allocator leaders to prewrite
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -119,15 +121,13 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 		return pdpb.Timestamp{}, err
 	}
 	maxTSO.Logical += int64(count)
-	maxTSO.Logical = gta.timestampOracle.differentiateLogical(maxTSO.Logical, gta.allocatorManager.GetSuffixBits())
-	// If the maxTSO's logical part is bigger than maxLogical, just add a updateTimestampGuard
-	// to the physical time and empty the logical part. We just need to make sure it's bigger than
-	// all the other Local TSOs. And because the Global TSO's suffix will always be zero,
-	// so there's no need to differentiate it again here.
 	if maxTSO.GetLogical() > maxLogical {
 		maxTSO.Physical += updateTimestampGuard.Milliseconds()
-		maxTSO.Logical = 0
+		// Equivalent to setting the logical part to zero and adding the given count
+		maxTSO.Logical = int64(count)
 	}
+	// Differentiate the logical part to make the TSO unique globally by giving it a unique suffix in the whole cluster
+	maxTSO.Logical = gta.timestampOracle.differentiateLogical(maxTSO.Logical, gta.allocatorManager.GetSuffixBits())
 	// Sync the MaxTS with all Local TSO Allocator leaders then
 	if err := gta.SyncMaxTS(ctx, dcLocationMap, maxTSO); err != nil {
 		return pdpb.Timestamp{}, err

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -531,7 +531,6 @@ func (c *TestCluster) WaitAllocatorLeader(dcLocation string) string {
 		}
 		for serverName, num := range counter {
 			if num == running && c.GetServer(serverName).IsAllocatorLeader(dcLocation) {
-				time.Sleep(WaitLeaderReturnDelay)
 				return serverName
 			}
 		}

--- a/tests/server/tso/global_tso_test.go
+++ b/tests/server/tso/global_tso_test.go
@@ -121,7 +121,7 @@ func (s *testNormalGlobalTSOSuite) testGetNormalGlobalTimestamp(c *C, pdCli pdpb
 	c.Assert(err, IsNil)
 	c.Assert(resp.GetCount(), Equals, req.GetCount())
 	res := resp.GetTimestamp()
-	c.Assert(res.GetLogical(), Greater, int64(req.GetCount()))
+	c.Assert(res.GetLogical(), GreaterEqual, int64(req.GetCount()))
 	return res
 }
 
@@ -519,7 +519,7 @@ func (s *testSynchronizedGlobalTSO) testGetTimestamp(ctx context.Context, c *C, 
 	c.Assert(resp.GetCount(), Equals, uint32(n))
 	res := resp.GetTimestamp()
 	c.Assert(res.GetPhysical(), Greater, int64(0))
-	c.Assert(res.GetLogical(), Greater, int64(req.GetCount()))
+	c.Assert(res.GetLogical(), GreaterEqual, int64(req.GetCount()))
 	return res
 }
 

--- a/tests/server/tso/global_tso_test.go
+++ b/tests/server/tso/global_tso_test.go
@@ -121,6 +121,7 @@ func (s *testNormalGlobalTSOSuite) testGetNormalGlobalTimestamp(c *C, pdCli pdpb
 	c.Assert(err, IsNil)
 	c.Assert(resp.GetCount(), Equals, req.GetCount())
 	res := resp.GetTimestamp()
+	c.Assert(res.GetPhysical(), Greater, int64(0))
 	c.Assert(res.GetLogical(), GreaterEqual, int64(req.GetCount()))
 	return res
 }
@@ -267,6 +268,9 @@ func (s *testNormalGlobalTSOSuite) TestDelaySyncTimestamp(c *C) {
 	resp, err := tsoClient.Recv()
 	c.Assert(err, IsNil)
 	c.Assert(resp.GetCount(), Equals, uint32(1))
+	res := resp.GetTimestamp()
+	c.Assert(res.GetPhysical(), Greater, int64(0))
+	c.Assert(res.GetLogical(), GreaterEqual, int64(req.GetCount()))
 	failpoint.Disable("github.com/tikv/pd/server/tso/delaySyncTimestamp")
 }
 
@@ -326,10 +330,9 @@ func (s *testTimeFallBackSuite) testGetTimestamp(c *C, n uint32) *pdpb.Timestamp
 	resp, err := tsoClient.Recv()
 	c.Assert(err, IsNil)
 	c.Assert(resp.GetCount(), Equals, uint32(n))
-
 	res := resp.GetTimestamp()
 	c.Assert(tsoutil.CompareTimestamp(res, tsoutil.GenerateTimestamp(time.Now(), 0)), Equals, 1)
-
+	c.Assert(res.GetLogical(), GreaterEqual, int64(req.GetCount()))
 	return res
 }
 
@@ -451,13 +454,13 @@ func (s *testSynchronizedGlobalTSO) TestSynchronizedGlobalTSO(c *C) {
 
 	waitAllLeaders(s.ctx, c, cluster, dcLocationConfig)
 
-	for _, dcLocation := range dcLocationConfig {
-		pdName := cluster.WaitAllocatorLeader(dcLocation)
-		s.dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
-	}
 	s.leaderServer = cluster.GetServer(cluster.GetLeader())
 	c.Assert(s.leaderServer, NotNil)
 	s.dcClientMap[config.GlobalDCLocation] = testutil.MustNewGrpcClient(c, s.leaderServer.GetAddr())
+	for _, dcLocation := range dcLocationConfig {
+		pdName := s.leaderServer.GetAllocatorLeader(dcLocation).GetName()
+		s.dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -479,26 +482,6 @@ func (s *testSynchronizedGlobalTSO) TestSynchronizedGlobalTSO(c *C) {
 	for _, newLocalTSO := range newLocalTSOs {
 		c.Assert(tsoutil.CompareTimestamp(globalTSO, newLocalTSO), Equals, -1)
 	}
-
-	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			last := &pdpb.Timestamp{
-				Physical: 0,
-				Logical:  0,
-			}
-			for j := 0; j < 30; j++ {
-				globalTSO := s.testGetTimestamp(ctx, c, tsoCount, config.GlobalDCLocation)
-				// Check whether the TSO fallbacks
-				c.Assert(tsoutil.CompareTimestamp(globalTSO, last), Equals, 1)
-				last = globalTSO
-				time.Sleep(10 * time.Millisecond)
-			}
-		}()
-	}
-	wg.Wait()
 }
 
 func (s *testSynchronizedGlobalTSO) testGetTimestamp(ctx context.Context, c *C, n uint32, dcLocation string) *pdpb.Timestamp {
@@ -542,13 +525,13 @@ func (s *testSynchronizedGlobalTSO) TestSynchronizedGlobalTSOOverflow(c *C) {
 
 	waitAllLeaders(s.ctx, c, cluster, dcLocationConfig)
 
-	for _, dcLocation := range dcLocationConfig {
-		pdName := cluster.WaitAllocatorLeader(dcLocation)
-		s.dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
-	}
 	s.leaderServer = cluster.GetServer(cluster.GetLeader())
 	c.Assert(s.leaderServer, NotNil)
 	s.dcClientMap[config.GlobalDCLocation] = testutil.MustNewGrpcClient(c, s.leaderServer.GetAddr())
+	for _, dcLocation := range dcLocationConfig {
+		pdName := s.leaderServer.GetAllocatorLeader(dcLocation).GetName()
+		s.dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/tests/server/tso/global_tso_test.go
+++ b/tests/server/tso/global_tso_test.go
@@ -121,7 +121,7 @@ func (s *testNormalGlobalTSOSuite) testGetNormalGlobalTimestamp(c *C, pdCli pdpb
 	c.Assert(err, IsNil)
 	c.Assert(resp.GetCount(), Equals, req.GetCount())
 	res := resp.GetTimestamp()
-	c.Assert(res.GetLogical(), Greater, int64(0))
+	c.Assert(res.GetLogical(), Greater, int64(req.GetCount()))
 	return res
 }
 
@@ -308,11 +308,11 @@ func (s *testTimeFallBackSuite) TearDownSuite(c *C) {
 	s.cluster.Destroy()
 }
 
-func (s *testTimeFallBackSuite) testGetTimestamp(c *C, n int) *pdpb.Timestamp {
+func (s *testTimeFallBackSuite) testGetTimestamp(c *C, n uint32) *pdpb.Timestamp {
 	clusterID := s.server.GetClusterID()
 	req := &pdpb.TsoRequest{
 		Header:     testutil.NewRequestHeader(clusterID),
-		Count:      uint32(n),
+		Count:      n,
 		DcLocation: config.GlobalDCLocation,
 	}
 
@@ -479,12 +479,32 @@ func (s *testSynchronizedGlobalTSO) TestSynchronizedGlobalTSO(c *C) {
 	for _, newLocalTSO := range newLocalTSOs {
 		c.Assert(tsoutil.CompareTimestamp(globalTSO, newLocalTSO), Equals, -1)
 	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			last := &pdpb.Timestamp{
+				Physical: 0,
+				Logical:  0,
+			}
+			for j := 0; j < 30; j++ {
+				globalTSO := s.testGetTimestamp(ctx, c, tsoCount, config.GlobalDCLocation)
+				// Check whether the TSO fallbacks
+				c.Assert(tsoutil.CompareTimestamp(globalTSO, last), Equals, 1)
+				last = globalTSO
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
-func (s *testSynchronizedGlobalTSO) testGetTimestamp(ctx context.Context, c *C, n int, dcLocation string) *pdpb.Timestamp {
+func (s *testSynchronizedGlobalTSO) testGetTimestamp(ctx context.Context, c *C, n uint32, dcLocation string) *pdpb.Timestamp {
 	req := &pdpb.TsoRequest{
 		Header:     testutil.NewRequestHeader(s.leaderServer.GetClusterID()),
-		Count:      tsoCount,
+		Count:      n,
 		DcLocation: dcLocation,
 	}
 	pdClient, ok := s.dcClientMap[dcLocation]
@@ -498,6 +518,41 @@ func (s *testSynchronizedGlobalTSO) testGetTimestamp(ctx context.Context, c *C, 
 	c.Assert(err, IsNil)
 	c.Assert(resp.GetCount(), Equals, uint32(n))
 	res := resp.GetTimestamp()
-	c.Assert(res.GetLogical(), Greater, int64(0))
+	c.Assert(res.GetPhysical(), Greater, int64(0))
+	c.Assert(res.GetLogical(), Greater, int64(req.GetCount()))
 	return res
+}
+
+func (s *testSynchronizedGlobalTSO) TestSynchronizedGlobalTSOOverflow(c *C) {
+	dcLocationConfig := map[string]string{
+		"pd1": "dc-1",
+		"pd2": "dc-2",
+		"pd3": "dc-3",
+	}
+	dcLocationNum := len(dcLocationConfig)
+	cluster, err := tests.NewTestCluster(s.ctx, dcLocationNum, func(conf *config.Config, serverName string) {
+		conf.LocalTSO.EnableLocalTSO = true
+		conf.LocalTSO.DCLocation = dcLocationConfig[serverName]
+	})
+	defer cluster.Destroy()
+	c.Assert(err, IsNil)
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+
+	waitAllLeaders(s.ctx, c, cluster, dcLocationConfig)
+
+	for _, dcLocation := range dcLocationConfig {
+		pdName := cluster.WaitAllocatorLeader(dcLocation)
+		s.dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
+	}
+	s.leaderServer = cluster.GetServer(cluster.GetLeader())
+	c.Assert(s.leaderServer, NotNil)
+	s.dcClientMap[config.GlobalDCLocation] = testutil.MustNewGrpcClient(c, s.leaderServer.GetAddr())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/tso/globalTSOOverflow", `return(true)`), IsNil)
+	s.testGetTimestamp(ctx, c, tsoCount, config.GlobalDCLocation)
+	failpoint.Disable("github.com/tikv/pd/server/tso/globalTSOOverflow")
 }

--- a/tests/server/tso/local_tso_test.go
+++ b/tests/server/tso/local_tso_test.go
@@ -67,12 +67,12 @@ func (s *testLocalTSOSuite) TestLocalTSO(c *C) {
 
 	waitAllLeaders(s.ctx, c, cluster, dcLocationConfig)
 
+	leaderServer := cluster.GetServer(cluster.GetLeader())
 	dcClientMap := make(map[string]pdpb.PDClient)
 	for _, dcLocation := range dcLocationConfig {
-		pdName := cluster.WaitAllocatorLeader(dcLocation)
+		pdName := leaderServer.GetAllocatorLeader(dcLocation).GetName()
 		dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
 	}
-	leaderServer := cluster.GetServer(cluster.GetLeader())
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -155,7 +155,8 @@ func (s *testLocalTSOSuite) TestLocalTSOAfterMemberChanged(c *C) {
 
 	waitAllLeaders(s.ctx, c, cluster, dcLocationConfig)
 
-	leaderCli := testutil.MustNewGrpcClient(c, cluster.GetServer(cluster.GetLeader()).GetAddr())
+	leaderServer := cluster.GetServer(cluster.GetLeader())
+	leaderCli := testutil.MustNewGrpcClient(c, leaderServer.GetAddr())
 	req := &pdpb.TsoRequest{
 		Header:     testutil.NewRequestHeader(cluster.GetCluster().GetId()),
 		Count:      tsoCount,
@@ -186,7 +187,7 @@ func (s *testLocalTSOSuite) TestLocalTSOAfterMemberChanged(c *C) {
 
 	dcClientMap := make(map[string]pdpb.PDClient)
 	for _, dcLocation := range dcLocationConfig {
-		pdName := cluster.WaitAllocatorLeader(dcLocation)
+		pdName := leaderServer.GetAllocatorLeader(dcLocation).GetName()
 		dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
 	}
 	var wg sync.WaitGroup

--- a/tests/server/tso/local_tso_test.go
+++ b/tests/server/tso/local_tso_test.go
@@ -120,7 +120,8 @@ func testGetLocalTimestamp(c *C, pdCli pdpb.PDClient, req *pdpb.TsoRequest) *pdp
 	c.Assert(err, IsNil)
 	c.Assert(resp.GetCount(), Equals, req.GetCount())
 	res := resp.GetTimestamp()
-	c.Assert(res.GetLogical(), Greater, int64(0))
+	c.Assert(res.GetPhysical(), Greater, int64(0))
+	c.Assert(res.GetLogical(), Greater, int64(req.GetCount()))
 	return res
 }
 

--- a/tests/server/tso/local_tso_test.go
+++ b/tests/server/tso/local_tso_test.go
@@ -121,7 +121,7 @@ func testGetLocalTimestamp(c *C, pdCli pdpb.PDClient, req *pdpb.TsoRequest) *pdp
 	c.Assert(resp.GetCount(), Equals, req.GetCount())
 	res := resp.GetTimestamp()
 	c.Assert(res.GetPhysical(), Greater, int64(0))
-	c.Assert(res.GetLogical(), Greater, int64(req.GetCount()))
+	c.Assert(res.GetLogical(), GreaterEqual, int64(req.GetCount()))
 	return res
 }
 


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Fix a bug that will cause the Global TSO generation to be critically wrong. If `maxTSO.Logical` is bigger than `maxLogical`, it will be set to zero but without adding the count.

### What is changed and how it works?

Add the count to `maxTSO.Logical` after being set to zero.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
