### PR TITLE
config: fix the store limit cannot be persisted

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -56,7 +56,10 @@ var backgroundJobInterval = 10 * time.Second
 const (
 	clientTimeout              = 3 * time.Second
 	defaultChangedRegionsLimit = 10000
-	persistLimitRetryTime      = 10
+	// persistLimitRetryTime is used to reduce the probability of the persistent error
+	// since the once the store is add or remove, we shouldn't return an error even if the store limit is failed to persist.
+	persistLimitRetryTime = 5
+	persistLimitWaitTime  = 100 * time.Millisecond
 )
 
 // Server is the interface for cluster.
@@ -1036,7 +1039,9 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 		zap.String("store-address", newStore.GetAddress()))
 	err := c.putStoreLocked(newStore)
 	if err == nil {
-		c.SetStoreLimit(storeID, storelimit.RemovePeer, storelimit.Unlimited)
+		// TODO: if the persist operation encounters error, the "Unlimited" will be rollback.
+		// And considering the store state has changed, RemoveStore is actually successful.
+		_ = c.SetStoreLimit(storeID, storelimit.RemovePeer, storelimit.Unlimited)
 	}
 	return err
 }
@@ -1645,8 +1650,10 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 	var err error
 	for i := 0; i < persistLimitRetryTime; i++ {
 		if err = c.opt.Persist(c.storage); err == nil {
+			log.Info("store limit added", zap.Uint64("store-id", storeID))
 			return
 		}
+		time.Sleep(persistLimitWaitTime)
 	}
 	log.Error("persist store limit meet error", errs.ZapError(err))
 }
@@ -1662,25 +1669,30 @@ func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
 	var err error
 	for i := 0; i < persistLimitRetryTime; i++ {
 		if err = c.opt.Persist(c.storage); err == nil {
+			log.Info("store limit removed", zap.Uint64("store-id", storeID))
 			return
 		}
+		time.Sleep(persistLimitWaitTime)
 	}
 	log.Error("persist store limit meet error", errs.ZapError(err))
 }
 
 // SetStoreLimit sets a store limit for a given type and rate.
-func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
+func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) error {
 	old := c.opt.GetScheduleConfig().Clone()
 	c.opt.SetStoreLimit(storeID, typ, ratePerMin)
 	if err := c.opt.Persist(c.storage); err != nil {
 		// roll back the store limit
 		c.opt.SetScheduleConfig(old)
 		log.Error("persist store limit meet error", errs.ZapError(err))
+		return err
 	}
+	log.Info("store limit changed", zap.Uint64("store-id", storeID), zap.String("type", typ.String()), zap.Float64("rate-per-min", ratePerMin))
+	return nil
 }
 
 // SetAllStoresLimit sets all store limit for a given type and rate.
-func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) {
+func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) error {
 	old := c.opt.GetScheduleConfig().Clone()
 	oldAdd := config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 	oldRemove := config.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
@@ -1691,7 +1703,10 @@ func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64)
 		config.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAdd)
 		config.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemove)
 		log.Error("persist store limit meet error", errs.ZapError(err))
+		return err
 	}
+	log.Info("all store limit changed", zap.String("type", typ.String()), zap.Float64("rate-per-min", ratePerMin))
+	return nil
 }
 
 // SetAllStoresLimitTTL sets all store limit for a given type and rate with ttl.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -56,10 +56,10 @@ var backgroundJobInterval = 10 * time.Second
 const (
 	clientTimeout              = 3 * time.Second
 	defaultChangedRegionsLimit = 10000
-	// persistLimitRetryTime is used to reduce the probability of the persistent error
+	// persistLimitRetryTimes is used to reduce the probability of the persistent error
 	// since the once the store is add or remove, we shouldn't return an error even if the store limit is failed to persist.
-	persistLimitRetryTime = 5
-	persistLimitWaitTime  = 100 * time.Millisecond
+	persistLimitRetryTimes = 5
+	persistLimitWaitTime   = 100 * time.Millisecond
 )
 
 // Server is the interface for cluster.
@@ -1648,7 +1648,7 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 	cfg.StoreLimit[storeID] = sc
 	c.opt.SetScheduleConfig(cfg)
 	var err error
-	for i := 0; i < persistLimitRetryTime; i++ {
+	for i := 0; i < persistLimitRetryTimes; i++ {
 		if err = c.opt.Persist(c.storage); err == nil {
 			log.Info("store limit added", zap.Uint64("store-id", storeID))
 			return
@@ -1667,7 +1667,7 @@ func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
 	delete(cfg.StoreLimit, storeID)
 	c.opt.SetScheduleConfig(cfg)
 	var err error
-	for i := 0; i < persistLimitRetryTime; i++ {
+	for i := 0; i < persistLimitRetryTimes; i++ {
 		if err = c.opt.Persist(c.storage); err == nil {
 			log.Info("store limit removed", zap.Uint64("store-id", storeID))
 			return

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -245,14 +245,14 @@ func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, rate
 	switch typ {
 	case storelimit.AddPeer:
 		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+			rate = DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
 		} else {
 			rate = v.StoreLimit[storeID].RemovePeer
 		}
 		sc = StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
 	case storelimit.RemovePeer:
 		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+			rate = DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 		} else {
 			rate = v.StoreLimit[storeID].AddPeer
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -394,8 +394,7 @@ func (h *Handler) SetAllStoresLimit(ratePerMin float64, limitType storelimit.Typ
 	if err != nil {
 		return err
 	}
-	c.SetAllStoresLimit(limitType, ratePerMin)
-	return nil
+	return c.SetAllStoresLimit(limitType, ratePerMin)
 }
 
 // SetAllStoresLimitTTL is used to set limit of all stores with ttl
@@ -418,7 +417,8 @@ func (h *Handler) SetLabelStoresLimit(ratePerMin float64, limitType storelimit.T
 		for _, label := range labels {
 			for _, sl := range store.GetLabels() {
 				if label.Key == sl.Key && label.Value == sl.Value {
-					c.SetStoreLimit(store.GetID(), limitType, ratePerMin)
+					// TODO: need to handle some of stores are persisted, and some of stores are not.
+					_ = c.SetStoreLimit(store.GetID(), limitType, ratePerMin)
 				}
 			}
 		}
@@ -441,8 +441,7 @@ func (h *Handler) SetStoreLimit(storeID uint64, ratePerMin float64, limitType st
 	if err != nil {
 		return err
 	}
-	c.SetStoreLimit(storeID, limitType, ratePerMin)
-	return nil
+	return c.SetStoreLimit(storeID, limitType, ratePerMin)
 }
 
 // AddTransferLeaderOperator adds an operator to transfer leader to the store.

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -193,6 +193,13 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(limit2, Equals, float64(20))
 	c.Assert(limit3, Equals, float64(20))
 
+	c.Assert(leaderServer.Stop(), IsNil)
+	c.Assert(leaderServer.Run(), IsNil)
+	cluster.WaitLeader()
+	storesLimit := leaderServer.GetPersistOptions().GetAllStoresLimit()
+	c.Assert(storesLimit[1].AddPeer, Equals, float64(20))
+	c.Assert(storesLimit[1].RemovePeer, Equals, float64(20))
+
 	// store limit all <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}
 	_, _, err = pdctl.ExecuteCommandC(cmd, args...)


### PR DESCRIPTION
### What problem does this PR solve?

The store limit cannot persist due to we only change the value in the memory. Close #3382.

### What is changed and how it works?

This PR persists the store limit once it changes and if persistence fails, we will roll back to the original one.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


Related changes

- Need to cherry-pick to the release branch

### Release note

- Fix the issue that the store limit cannot be persisted
