### PR TITLE
tso: make next-leader-key guaranteed by etcd txn

### DIFF
--- a/server/election/leadership.go
+++ b/server/election/leadership.go
@@ -100,9 +100,9 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...cl
 	if err := ls.getLease().Grant(leaseTimeout); err != nil {
 		return err
 	}
-	// The leader key must not exist, so the CreateRevision is 0.
 	finalCmps := make([]clientv3.Cmp, 0, len(cmps)+1)
 	finalCmps = append(finalCmps, cmps...)
+	// The leader key must not exist, so the CreateRevision is 0.
 	finalCmps = append(finalCmps, clientv3.Compare(clientv3.CreateRevision(ls.leaderKey), "=", 0))
 	resp, err := kv.NewSlowLogTxn(ls.client).
 		If(finalCmps...).

--- a/server/election/leadership.go
+++ b/server/election/leadership.go
@@ -102,9 +102,7 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...cl
 	}
 	// The leader key must not exist, so the CreateRevision is 0.
 	finalCmps := make([]clientv3.Cmp, 0, len(cmps)+1)
-	for _, cmp := range cmps {
-		finalCmps = append(finalCmps, cmp)
-	}
+	finalCmps = append(finalCmps, cmps...)
 	finalCmps = append(finalCmps, clientv3.Compare(clientv3.CreateRevision(ls.leaderKey), "=", 0))
 	resp, err := kv.NewSlowLogTxn(ls.client).
 		If(finalCmps...).

--- a/server/election/leadership.go
+++ b/server/election/leadership.go
@@ -89,7 +89,7 @@ func (ls *Leadership) GetLeaderKey() string {
 }
 
 // Campaign is used to campaign the leader with given lease and returns a leadership
-func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string) error {
+func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...clientv3.Cmp) error {
 	ls.leaderValue = leaderData
 	// Create a new lease to campaign
 	ls.setLease(&lease{
@@ -101,9 +101,12 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string) error {
 		return err
 	}
 	// The leader key must not exist, so the CreateRevision is 0.
-	resp, err := kv.NewSlowLogTxn(ls.client).
-		If(clientv3.Compare(clientv3.CreateRevision(ls.leaderKey), "=", 0)).
-		Then(clientv3.OpPut(ls.leaderKey, leaderData, clientv3.WithLease(ls.getLease().ID))).
+	txn := kv.NewSlowLogTxn(ls.client).
+		If(clientv3.Compare(clientv3.CreateRevision(ls.leaderKey), "=", 0))
+	for _, cmp := range cmps {
+		txn = txn.If(cmp)
+	}
+	resp, err := txn.Then(clientv3.OpPut(ls.leaderKey, leaderData, clientv3.WithLease(ls.getLease().ID))).
 		Commit()
 	log.Info("check campaign resp", zap.Any("resp", resp))
 	if err != nil {

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -426,7 +426,7 @@ func (am *AllocatorManager) campaignAllocatorLeader(loopCtx context.Context, all
 		zap.String("dc-location", allocator.dcLocation),
 		zap.Any("dc-location-info", dcLocationInfo),
 		zap.String("name", am.member.Member().Name))
-	cmps := make([]clientv3.Cmp, 0, 0)
+	cmps := make([]clientv3.Cmp, 0)
 	nextLeaderKey := path.Join(am.rootPath, allocator.dcLocation, "next-leader")
 	if !isNextLeader {
 		cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(nextLeaderKey), "=", 0))

--- a/server/tso/local_allocator.go
+++ b/server/tso/local_allocator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tikv/pd/pkg/tsoutil"
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/election"
+	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 )
 
@@ -156,8 +157,8 @@ func (lta *LocalTSOAllocator) EnableAllocatorLeader() {
 }
 
 // CampaignAllocatorLeader is used to campaign a Local TSO Allocator's leadership.
-func (lta *LocalTSOAllocator) CampaignAllocatorLeader(leaseTimeout int64) error {
-	return lta.leadership.Campaign(leaseTimeout, lta.allocatorManager.member.MemberValue())
+func (lta *LocalTSOAllocator) CampaignAllocatorLeader(leaseTimeout int64, cmps ...clientv3.Cmp) error {
+	return lta.leadership.Campaign(leaseTimeout, lta.allocatorManager.member.MemberValue(), cmps...)
 }
 
 // KeepAllocatorLeader is used to keep the PD leader's leadership.

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -607,6 +607,19 @@ func (c *TestCluster) Destroy() {
 	}
 }
 
+// CheckClusterDCLocation will force the cluster to do the dc-location check in order to speed up the test.
+func (c *TestCluster) CheckClusterDCLocation() {
+	wg := sync.WaitGroup{}
+	for _, server := range c.GetServers() {
+		wg.Add(1)
+		go func(ser *TestServer) {
+			ser.GetTSOAllocatorManager().ClusterDCLocationChecker()
+			wg.Done()
+		}(server)
+	}
+	wg.Wait()
+}
+
 // WaitOp represent the wait configuration
 type WaitOp struct {
 	retryTimes   int

--- a/tests/server/tso/manager_test.go
+++ b/tests/server/tso/manager_test.go
@@ -244,22 +244,11 @@ func (s *testPrioritySuite) TestNextLeaderGuarantee(c *C) {
 
 	cluster.WaitLeader()
 	// To speed up the test, we force to do the check
-	checkLeader := func() {
-		wg := sync.WaitGroup{}
-		for _, server := range cluster.GetServers() {
-			wg.Add(1)
-			go func(ser *tests.TestServer) {
-				ser.GetTSOAllocatorManager().ClusterDCLocationChecker()
-				wg.Done()
-			}(server)
-		}
-		wg.Wait()
-	}
-	checkLeader()
+	triggerCheckLeader(cluster)
 	leaderName := cluster.WaitAllocatorLeader("dc-1")
 	c.Assert(leaderName, Equals, "")
 	c.Assert(failpoint.Disable("github.com/tikv/pd/server/tso/injectNextLeaderKey"), IsNil)
-	checkLeader()
+	triggerCheckLeader(cluster)
 	leaderName = cluster.WaitAllocatorLeader("dc-1")
 	c.Assert(leaderName, Equals, "pd1")
 }
@@ -277,4 +266,16 @@ func waitAllocatorPriorityCheck(cluster *tests.TestCluster) {
 	// Because the leader changing may take quite a long period,
 	// so we sleep longer here to wait.
 	time.Sleep(waitAllocatorPriorityCheckInterval)
+}
+
+func triggerCheckLeader(cluster *tests.TestCluster, ) {
+	wg := sync.WaitGroup{}
+	for _, server := range cluster.GetServers() {
+		wg.Add(1)
+		go func(ser *tests.TestServer) {
+			ser.GetTSOAllocatorManager().ClusterDCLocationChecker()
+			wg.Done()
+		}(server)
+	}
+	wg.Wait()
 }

--- a/tests/server/tso/manager_test.go
+++ b/tests/server/tso/manager_test.go
@@ -245,7 +245,7 @@ func (s *testPrioritySuite) TestNextLeaderGuarantee(c *C) {
 	cluster.WaitLeader()
 	// To speed up the test, we force to do the check
 	triggerCheckLeader(cluster)
-	leaderName := cluster.WaitAllocatorLeader("dc-1")
+	leaderName := cluster.WaitAllocatorLeader("dc-1", tests.WithRetryTimes(12), tests.WithWaitInterval(5*time.Second))
 	c.Assert(leaderName, Equals, "")
 	c.Assert(failpoint.Disable("github.com/tikv/pd/server/tso/injectNextLeaderKey"), IsNil)
 	triggerCheckLeader(cluster)
@@ -268,7 +268,7 @@ func waitAllocatorPriorityCheck(cluster *tests.TestCluster) {
 	time.Sleep(waitAllocatorPriorityCheckInterval)
 }
 
-func triggerCheckLeader(cluster *tests.TestCluster, ) {
+func triggerCheckLeader(cluster *tests.TestCluster) {
 	wg := sync.WaitGroup{}
 	for _, server := range cluster.GetServers() {
 		wg.Add(1)

--- a/tests/server/tso/manager_test.go
+++ b/tests/server/tso/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/tikv/pd/pkg/etcdutil"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server"
@@ -223,6 +224,44 @@ func (s *testPrioritySuite) TestAllocatorPriority(c *C) {
 		currentLeaderName := cluster.WaitAllocatorLeader(dcLocation)
 		c.Assert(currentLeaderName, Equals, serverName)
 	}
+}
+
+func (s *testPrioritySuite) TestNextLeaderGuarantee(c *C) {
+	dcLocationConfig := map[string]string{
+		"pd1": "dc-1",
+	}
+	serverNumber := len(dcLocationConfig)
+	cluster, err := tests.NewTestCluster(s.ctx, serverNumber, func(conf *config.Config, serverName string) {
+		conf.LocalTSO.EnableLocalTSO = true
+		conf.LocalTSO.DCLocation = dcLocationConfig[serverName]
+	})
+	defer cluster.Destroy()
+	c.Assert(err, IsNil)
+
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/tso/injectNextLeaderKey", "return(true)"), IsNil)
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+
+	cluster.WaitLeader()
+	// To speed up the test, we force to do the check
+	checkLeader := func() {
+		wg := sync.WaitGroup{}
+		for _, server := range cluster.GetServers() {
+			wg.Add(1)
+			go func(ser *tests.TestServer) {
+				ser.GetTSOAllocatorManager().ClusterDCLocationChecker()
+				wg.Done()
+			}(server)
+		}
+		wg.Wait()
+	}
+	checkLeader()
+	leaderName := cluster.WaitAllocatorLeader("dc-1")
+	c.Assert(leaderName, Equals, "")
+	c.Assert(failpoint.Disable("github.com/tikv/pd/server/tso/injectNextLeaderKey"), IsNil)
+	checkLeader()
+	leaderName = cluster.WaitAllocatorLeader("dc-1")
+	c.Assert(leaderName, Equals, "pd1")
 }
 
 func waitAllocatorPriorityCheck(cluster *tests.TestCluster) {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

close https://github.com/tikv/pd/issues/3386

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

During `leaderCampaign`, the `next-leader-key` should be considered as `Cmp` so that the`next-leader-key` will be guaranteed 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
* No release note