### PR TITLE
server/api:support offline a store with physically destroyed 

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -91,6 +91,11 @@ error = '''
 store %v is paused for leader transfer
 '''
 
+["PD:core:ErrStoreDestroyed"]
+error = '''
+store %v has been physically destroyed
+'''
+
 ["PD:core:ErrStoreNotFound"]
 error = '''
 store %v not found

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce
-	github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c
+	github.com/pingcap/kvproto v0.0.0-20210118091648-29d65899faf7
 	github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8
 	github.com/pingcap/sysutil v0.0.0-20201130064824-f0c8aa6a6966
 	github.com/prometheus/client_golang v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,8 @@ github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce h1:Y1kCxlCtlPTMt
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c h1:ggbmqi1uOA926t5SEEo0nvBi/sCsJASIrOaiO25ufv4=
-github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20210118091648-29d65899faf7 h1:74r4YTCSKC3aainPaXovtz+VwioQvej0mQj1xDDPN64=
+github.com/pingcap/kvproto v0.0.0-20210118091648-29d65899faf7/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -51,6 +51,7 @@ var (
 	ErrStoreNotFound       = errors.Normalize("store %v not found", errors.RFCCodeText("PD:core:ErrStoreNotFound"))
 	ErrPauseLeaderTransfer = errors.Normalize("store %v is paused for leader transfer", errors.RFCCodeText("PD:core:ErrPauseLeaderTransfer"))
 	ErrStoreTombstone      = errors.Normalize("store %v has been removed", errors.RFCCodeText("PD:core:ErrStoreTombstone"))
+	ErrStoreDestroyed      = errors.Normalize("store %v has been physically destroyed", errors.RFCCodeText("PD:core:ErrStoreDestroyed"))
 )
 
 // client errors

--- a/server/api/operator_test.go
+++ b/server/api/operator_test.go
@@ -105,7 +105,7 @@ func (s *testOperatorSuite) TestAddRemovePeer(c *C) {
 	c.Assert(strings.Contains(operator, "add learner peer 2 on store 4"), IsTrue)
 
 	// Fail to add peer to tombstone store.
-	err = s.svr.GetRaftCluster().BuryStore(3, true)
+	err = s.svr.GetRaftCluster().RemoveStore(3, true)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, fmt.Sprintf("%s/operators", s.urlPrefix), []byte(`{"name":"add-peer", "region_id": 1, "store_id": 3}`))
 	c.Assert(err, NotNil)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1030,7 +1030,7 @@ func (c *RaftCluster) RemoveStore(storeID uint64, physicallyDestroyed bool) erro
 	}
 
 	if store.IsPhysicallyDestroyed() {
-		return errors.Errorf("The store is already physically destroyed")
+		return errs.ErrStoreDestroyed.FastGenByArgs(storeID)
 	}
 
 	newStore := store.Clone(core.OfflineStore(physicallyDestroyed))

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -932,8 +932,8 @@ func (c *RaftCluster) putStoreImpl(store *metapb.Store, force bool) error {
 
 	// Store address can not be the same as other stores.
 	for _, s := range c.GetStores() {
-		// It's OK to start a new store on the same address if the old store has been removed.
-		if s.IsTombstone() {
+		// It's OK to start a new store on the same address if the old store has been removed or physically destroyed.
+		if s.IsTombstone() || s.IsPhysicallyDestroyed() {
 			continue
 		}
 		if s.GetID() != store.GetId() && s.GetAddress() == store.GetAddress() {
@@ -1011,7 +1011,7 @@ func (c *RaftCluster) checkStoreLabels(s *core.StoreInfo) error {
 
 // RemoveStore marks a store as offline in cluster.
 // State transition: Up -> Offline.
-func (c *RaftCluster) RemoveStore(storeID uint64) error {
+func (c *RaftCluster) RemoveStore(storeID uint64, physicallyDestroyed bool) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -1021,7 +1021,7 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 	}
 
 	// Remove an offline store should be OK, nothing to do.
-	if store.IsOffline() {
+	if store.IsOffline() && store.IsPhysicallyDestroyed() == physicallyDestroyed {
 		return nil
 	}
 
@@ -1029,10 +1029,15 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 		return errs.ErrStoreTombstone.FastGenByArgs(storeID)
 	}
 
-	newStore := store.Clone(core.SetStoreState(metapb.StoreState_Offline))
+	if store.IsPhysicallyDestroyed() {
+		return errors.Errorf("The store is already physically destroyed")
+	}
+
+	newStore := store.Clone(core.OfflineStore(physicallyDestroyed))
 	log.Warn("store has been offline",
 		zap.Uint64("store-id", newStore.GetID()),
-		zap.String("store-address", newStore.GetAddress()))
+		zap.String("store-address", newStore.GetAddress()),
+		zap.Bool("physically-destroyed", newStore.IsPhysicallyDestroyed()))
 	err := c.putStoreLocked(newStore)
 	if err == nil {
 		c.SetStoreLimit(storeID, storelimit.RemovePeer, storelimit.Unlimited)
@@ -1040,11 +1045,10 @@ func (c *RaftCluster) RemoveStore(storeID uint64) error {
 	return err
 }
 
-// BuryStore marks a store as tombstone in cluster.
-// State transition:
-// Case 1: Up -> Tombstone (if force is true);
-// Case 2: Offline -> Tombstone.
-func (c *RaftCluster) BuryStore(storeID uint64, force bool) error {
+// buryStore marks a store as tombstone in cluster.
+// The store should be empty before calling this func
+// State transition: Offline -> Tombstone.
+func (c *RaftCluster) buryStore(storeID uint64) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -1059,16 +1063,15 @@ func (c *RaftCluster) BuryStore(storeID uint64, force bool) error {
 	}
 
 	if store.IsUp() {
-		if !force {
-			return errs.ErrStoreIsUp.FastGenByArgs()
-		}
-		log.Warn("force bury store", zap.Stringer("store", store.GetMeta()))
+		return errs.ErrStoreIsUp.FastGenByArgs()
 	}
 
 	newStore := store.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
 	log.Warn("store has been Tombstone",
 		zap.Uint64("store-id", newStore.GetID()),
-		zap.String("store-address", newStore.GetAddress()))
+		zap.String("store-address", newStore.GetAddress()),
+		zap.String("state", store.GetState().String()),
+		zap.Bool("physically-destroyed", store.IsPhysicallyDestroyed()))
 	err := c.putStoreLocked(newStore)
 	c.onStoreVersionChangeLocked()
 	if err == nil {
@@ -1171,7 +1174,7 @@ func (c *RaftCluster) checkStores() {
 		// If the store is empty, it can be buried.
 		regionCount := c.core.GetStoreRegionCount(offlineStore.GetId())
 		if regionCount == 0 {
-			if err := c.BuryStore(offlineStore.GetId(), false); err != nil {
+			if err := c.buryStore(offlineStore.GetId()); err != nil {
 				log.Error("bury store failed",
 					zap.Stringer("store", offlineStore),
 					errs.ZapError(err))

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -135,8 +135,15 @@ func (s *testClusterInfoSuite) TestSetOfflineStore(c *C) {
 	}
 	// store 1: up -> offline
 	c.Assert(cluster.RemoveStore(1, false), IsNil)
+	store := cluster.GetStore(1)
+	c.Assert(store.IsOffline(), IsTrue)
+	c.Assert(store.IsPhysicallyDestroyed(), IsFalse)
+
 	// store 1: set physically to true success
 	c.Assert(cluster.RemoveStore(1, true), IsNil)
+	store = cluster.GetStore(1)
+	c.Assert(store.IsOffline(), IsTrue)
+	c.Assert(store.IsPhysicallyDestroyed(), IsTrue)
 
 	// store 2:up -> offline & physically destroyed
 	c.Assert(cluster.RemoveStore(2, true), IsNil)
@@ -162,6 +169,44 @@ func (s *testClusterInfoSuite) TestSetOfflineStore(c *C) {
 			c.Assert(cluster.buryStore(storeID), IsNil)
 		}
 	}
+}
+
+func (s *testClusterInfoSuite) TestReuseAddress(c *C) {
+	_, opt, err := newTestScheduleConfig()
+	c.Assert(err, IsNil)
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	// Put 4 stores.
+	for _, store := range newTestStores(4, "2.0.0") {
+		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
+	}
+	// store 1: up
+	// store 2: offline
+	c.Assert(cluster.RemoveStore(2, false), IsNil)
+	// store 3: offline and physically destroyed
+	c.Assert(cluster.RemoveStore(3, true), IsNil)
+	// store 4: tombstone
+	c.Assert(cluster.RemoveStore(4, true), IsNil)
+	c.Assert(cluster.buryStore(4), IsNil)
+
+	for id := uint64(1); id <= 4; id++ {
+		storeInfo := cluster.GetStore(id)
+		storeID := storeInfo.GetID() + 1000
+		newStore := &metapb.Store{
+			Id:         storeID,
+			Address:    storeInfo.GetAddress(),
+			State:      metapb.StoreState_Up,
+			Version:    storeInfo.GetVersion(),
+			DeployPath: fmt.Sprintf("test/store%d", storeID),
+		}
+
+		if storeInfo.IsPhysicallyDestroyed() || storeInfo.IsTombstone() {
+			// try to start a new store with the same address with store which is physically destryed or tombstone should be success
+			c.Assert(cluster.PutStore(newStore), IsNil)
+		} else {
+			c.Assert(cluster.PutStore(newStore), NotNil)
+		}
+	}
+
 }
 
 func (s *testClusterInfoSuite) TestSetStoreState(c *C) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -125,6 +125,45 @@ func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 	}
 }
 
+func (s *testClusterInfoSuite) TestSetOfflineStore(c *C) {
+	_, opt, err := newTestScheduleConfig()
+	c.Assert(err, IsNil)
+	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	// Put 4 stores.
+	for _, store := range newTestStores(4, "2.0.0") {
+		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
+	}
+	// store 1: up -> offline
+	c.Assert(cluster.RemoveStore(1, false), IsNil)
+	// store 1: set physically to true success
+	c.Assert(cluster.RemoveStore(1, true), IsNil)
+
+	// store 2:up -> offline & physically destroyed
+	c.Assert(cluster.RemoveStore(2, true), IsNil)
+	// store 2: set physically destroyed to false failed
+	c.Assert(cluster.RemoveStore(2, false), NotNil)
+	c.Assert(cluster.RemoveStore(2, true), IsNil)
+
+	// store 3: up to offline
+	c.Assert(cluster.RemoveStore(3, false), IsNil)
+	c.Assert(cluster.RemoveStore(3, false), IsNil)
+
+	cluster.checkStores()
+	// store 1,2,3 shuold be to tombstone
+	for storeID := uint64(1); storeID <= 3; storeID++ {
+		c.Assert(cluster.GetStore(storeID).IsTombstone(), IsTrue)
+	}
+	// test bury store
+	for storeID := uint64(0); storeID <= 4; storeID++ {
+		store := cluster.GetStore(storeID)
+		if store == nil || store.IsUp() {
+			c.Assert(cluster.buryStore(storeID), NotNil)
+		} else {
+			c.Assert(cluster.buryStore(storeID), IsNil)
+		}
+	}
+}
+
 func (s *testClusterInfoSuite) TestSetStoreState(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
@@ -134,11 +173,12 @@ func (s *testClusterInfoSuite) TestSetStoreState(c *C) {
 	for _, store := range newTestStores(4, "2.0.0") {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
 	}
-	// Store 3 and 4 offline normally.
+	// Store 3 and 4 offline with physically destroyed.
 	for _, id := range []uint64{3, 4} {
-		c.Assert(cluster.RemoveStore(id), IsNil)
-		c.Assert(cluster.BuryStore(id, false), IsNil)
+		c.Assert(cluster.RemoveStore(id, true), IsNil)
 	}
+	cluster.checkStores()
+
 	// Change the status of 3 directly back to Up.
 	c.Assert(cluster.SetStoreState(3, metapb.StoreState_Up), IsNil)
 	// Update store 1 2 3
@@ -167,8 +207,8 @@ func (s *testClusterInfoSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {
 	c.Assert(cluster.GetClusterVersion(), Equals, "4.0.9")
 
 	// Bury the other store.
-	c.Assert(cluster.RemoveStore(3), IsNil)
-	c.Assert(cluster.BuryStore(3, false), IsNil)
+	c.Assert(cluster.RemoveStore(3, true), IsNil)
+	cluster.checkStores()
 	c.Assert(cluster.GetClusterVersion(), Equals, "5.0.0")
 }
 

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -139,6 +139,11 @@ func (s *StoreInfo) IsTombstone() bool {
 	return s.GetState() == metapb.StoreState_Tombstone
 }
 
+// IsPhysicallyDestroyed checks if the store's physically destroyed.
+func (s *StoreInfo) IsPhysicallyDestroyed() bool {
+	return s.GetMeta().GetPhysicallyDestroyed()
+}
+
 // DownTime returns the time elapsed since last heartbeat.
 func (s *StoreInfo) DownTime() time.Duration {
 	return time.Since(s.GetLastHeartbeatTS())

--- a/server/core/store_option.go
+++ b/server/core/store_option.go
@@ -82,6 +82,16 @@ func SetStoreState(state metapb.StoreState) StoreCreateOption {
 	}
 }
 
+// OfflineStore offline a store
+func OfflineStore(physicallyDestroyed bool) StoreCreateOption {
+	return func(store *StoreInfo) {
+		meta := proto.Clone(store.meta).(*metapb.Store)
+		meta.State = metapb.StoreState_Offline
+		meta.PhysicallyDestroyed = physicallyDestroyed
+		store.meta = meta
+	}
+}
+
 // PauseLeaderTransfer prevents the store from been selected as source or
 // target store of TransferLeader.
 func PauseLeaderTransfer() StoreCreateOption {

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -113,7 +113,7 @@ func (s *StoresStats) GetStoresLoads() map[uint64][]float64 {
 
 func (s *StoresStats) storeIsUnhealthy(cluster core.StoreSetInformer, storeID uint64) bool {
 	store := cluster.GetStore(storeID)
-	return store.IsTombstone() || store.IsUnhealthy()
+	return store.IsTombstone() || store.IsUnhealthy() || store.IsPhysicallyDestroyed()
 }
 
 // FilterUnhealthyStore filter unhealthy store

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -735,7 +735,7 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	c.Assert(stores, DeepEquals, stores)
 
 	// Mark the store as offline.
-	err = cluster.RemoveStore(store.GetId())
+	err = cluster.RemoveStore(store.GetId(), false)
 	c.Assert(err, IsNil)
 	offlineStore := proto.Clone(store).(*metapb.Store)
 	offlineStore.State = metapb.StoreState_Offline
@@ -757,25 +757,28 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	}
 	c.Assert(contains, IsTrue)
 
-	// Mark the store as tombstone.
-	err = cluster.BuryStore(store.GetId(), true)
+	// Mark the store as physically destroyed and offline.
+	err = cluster.RemoveStore(store.GetId(), true)
 	c.Assert(err, IsNil)
-	tombstoneStore := proto.Clone(store).(*metapb.Store)
-	tombstoneStore.State = metapb.StoreState_Tombstone
+	physicallyDestroyedStoreID := store.GetId()
 
-	// Get a tombstone store should fail.
-	n, err = s.client.GetStore(context.Background(), store.GetId())
+	// Get a physically destroyed and offline store
+	// It should be Tombstone(become Tombstone automically) or Offline
+	n, err = s.client.GetStore(context.Background(), physicallyDestroyedStoreID)
 	c.Assert(err, IsNil)
-	c.Assert(n, IsNil)
-
+	if n != nil { // store is still offline and physically destroyed
+		c.Assert(n.GetState(), Equals, metapb.StoreState_Offline)
+		c.Assert(n.PhysicallyDestroyed, IsTrue)
+	}
 	// Should return tombstone stores.
 	contains = false
 	stores, err = s.client.GetAllStores(context.Background())
 	c.Assert(err, IsNil)
 	for _, store := range stores {
-		if store.GetId() == tombstoneStore.GetId() {
+		if store.GetId() == physicallyDestroyedStoreID {
 			contains = true
-			c.Assert(store, DeepEquals, tombstoneStore)
+			c.Assert(store.GetState(), Not(Equals), metapb.StoreState_Up)
+			c.Assert(store.PhysicallyDestroyed, IsTrue)
 		}
 	}
 	c.Assert(contains, IsTrue)
@@ -784,7 +787,10 @@ func (s *testClientSuite) TestGetStore(c *C) {
 	stores, err = s.client.GetAllStores(context.Background(), pd.WithExcludeTombstone())
 	c.Assert(err, IsNil)
 	for _, store := range stores {
-		c.Assert(store, Not(Equals), tombstoneStore)
+		if store.GetId() == physicallyDestroyedStoreID {
+			c.Assert(store.GetState(), Equals, metapb.StoreState_Offline)
+			c.Assert(store.PhysicallyDestroyed, IsTrue)
+		}
 	}
 }
 


### PR DESCRIPTION

Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

It is part of #3076 
This PR support to offline a store and set it physically destroyed which means this store can never up and we can start a new store with the same address 

### What is changed and how it works?

- The API to offline a store
```
DELETE /store/{id}?force=${force}
```
force is a boolean value:
- true: means the store shouldn't be up again and PD can remove it, also we can up a new store with the same address
- false: means the store is offline, it can be up again.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


Code changes

- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))



Related changes

https://github.com/pingcap/kvproto/pull/711

### Release note

Offline a store with force true means the store shouldn't be up again and PD can remove it, also we can up a new store with the same address
