### PR TITLE
metrics: add server info metric

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -83,6 +83,14 @@ var (
 			Help:      "Bucketed histogram of processing time (s) of handled store heartbeat requests.",
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 12),
 		}, []string{"address", "store"})
+
+	serverInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "info",
+			Help:      "Indicate the pd server info, and the value is the start timestamp (s).",
+		}, []string{"version", "hash"})
 )
 
 func init() {
@@ -94,4 +102,5 @@ func init() {
 	prometheus.MustRegister(tsoHandleDuration)
 	prometheus.MustRegister(regionHeartbeatHandleDuration)
 	prometheus.MustRegister(storeHeartbeatHandleDuration)
+	prometheus.MustRegister(serverInfo)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -347,6 +347,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	// It may lose accuracy if use float64 to store uint64. So we store the
 	// cluster id in label.
 	metadataGauge.WithLabelValues(fmt.Sprintf("cluster%d", s.clusterID)).Set(0)
+	serverInfo.WithLabelValues(versioninfo.PDReleaseVersion, versioninfo.PDGitHash).Set(float64(time.Now().Unix()))
 
 	s.rootPath = path.Join(pdRootPath, strconv.FormatUint(s.clusterID, 10))
 	s.member.MemberInfo(s.cfg, s.Name(), s.rootPath)


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

### What problem does this PR solve?

Add PD server info in Prometheus metrics. This is use for DBaaS metrics.

related PR: https://github.com/pingcap/tidb/pull/22556

### What is changed and how it works?

N/A

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```shell
# start the pd-server first, also start the prometheus server
▶ bin/pd-server
# query the metrics info:
▶ curl '127.0.0.1:9090/api/v1/query?query=pd_server_info&time=2021-01-27T06:15:00.781Z'
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"pd_server_info","hash":"cbb89ec085979727cf1250aef92fe3c6ff4e63ee","instance":"127.0.0.1:2379","job":"pd","version":"v4.0.0-rc.2-434-gcbb89ec0-dirty"},"value":[1611728100.781,"1611728088"]}]}}%
```

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- N/A