### PR TITLE
test, tso: fix test and the Global TSO Allocator initialization bug

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1216,6 +1216,7 @@ func (s *Server) campaignLeader() {
 		log.Error("failed to initialize the global TSO allocator", errs.ZapError(err))
 		return
 	}
+	defer s.tsoAllocatorManager.ResetAllocatorGroup(config.GlobalDCLocation)
 	// Check the cluster dc-location after the PD leader is elected
 	go s.tsoAllocatorManager.ClusterDCLocationChecker()
 

--- a/server/server.go
+++ b/server/server.go
@@ -1203,10 +1203,8 @@ func (s *Server) campaignLeader() {
 	log.Info("campaign pd leader ok", zap.String("campaign-pd-leader-name", s.Name()))
 
 	log.Info("setting up the global TSO allocator")
-	if err := s.tsoAllocatorManager.SetUpAllocator(ctx, config.GlobalDCLocation, s.member.GetLeadership()); err != nil {
-		log.Error("failed to set up the global TSO allocator", errs.ZapError(err))
-		return
-	}
+	s.tsoAllocatorManager.SetUpAllocator(ctx, config.GlobalDCLocation, s.member.GetLeadership())
+	defer s.tsoAllocatorManager.ResetAllocatorGroup(config.GlobalDCLocation)
 	alllocator, err := s.tsoAllocatorManager.GetAllocator(config.GlobalDCLocation)
 	if err != nil {
 		log.Error("failed to get the global TSO allocator", errs.ZapError(err))
@@ -1216,7 +1214,6 @@ func (s *Server) campaignLeader() {
 		log.Error("failed to initialize the global TSO allocator", errs.ZapError(err))
 		return
 	}
-	defer s.tsoAllocatorManager.ResetAllocatorGroup(config.GlobalDCLocation)
 	// Check the cluster dc-location after the PD leader is elected
 	go s.tsoAllocatorManager.ClusterDCLocationChecker()
 

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -309,11 +309,7 @@ func (am *AllocatorManager) SetUpAllocator(parentCtx context.Context, dcLocation
 	switch dcLocation {
 	// For Global TSO Allocator
 	case config.GlobalDCLocation:
-		// Because Global TSO Allocator only depends on PD leader's leadership,
-		// so we can directly initialize it here.
-		if err := am.mu.allocatorGroups[dcLocation].allocator.Initialize(0); err != nil {
-			return err
-		}
+		return nil
 	// For Local TSO Allocator
 	default:
 		// Join in a Local TSO Allocator election
@@ -899,8 +895,8 @@ func (am *AllocatorManager) deleteAllocatorGroup(dcLocation string) {
 	if allocatorGroup, exist := am.mu.allocatorGroups[dcLocation]; exist {
 		allocatorGroup.allocator.Reset()
 		allocatorGroup.leadership.Reset()
+		delete(am.mu.allocatorGroups, dcLocation)
 	}
-	delete(am.mu.allocatorGroups, dcLocation)
 }
 
 // HandleTSORequest forwards TSO allocation requests to correct TSO Allocators.

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -135,6 +135,7 @@ func (s *TestServer) Destroy() error {
 func (s *TestServer) ResignLeader() error {
 	s.Lock()
 	defer s.Unlock()
+	s.server.GetMember().ResetLeader()
 	return s.server.GetMember().ResignEtcdLeader(s.server.Context(), s.server.Name(), "")
 }
 
@@ -517,7 +518,7 @@ func (c *TestCluster) WaitLeader(ops ...WaitOption) string {
 // ResignLeader resigns the leader of the cluster.
 func (c *TestCluster) ResignLeader() error {
 	leader := c.GetLeader()
-	if len(leader) != 0 {
+	if leader != "" {
 		return c.servers[leader].ResignLeader()
 	}
 	return errors.New("no leader")


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

* Fix a bug that causes `TestLeaderTransfer` test to cost too much time and refine the code logic.
* Fix the Global TSO Allocator initialization bug which will cause the new PD leader after transferring will be unable to provide TSO service.

### What is changed and how it works?

* Fix `TestLeaderTransfer` test which will take too long time to run before by using `ResignLeader()`.
* Move Global TSO Allocator initialization to `campaignLeader()`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
