### PR TITLE
client: revise pdclient dc dispatcher

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -202,6 +202,8 @@ func NewClientWithContext(ctx context.Context, pdAddrs []string, security Securi
 	}
 
 	c.createTSODispatcher(globalDCLocation)
+	dispatcher, _ := c.tsoDispatcher.Load(globalDCLocation)
+	go c.handleDispatcher(c.ctx, globalDCLocation, dispatcher.(chan *tsoRequest))
 	c.wg.Add(2)
 	go c.tsLoop()
 	go c.tsCancelLoop()
@@ -318,91 +320,7 @@ func (c *client) tsLoop() {
 				// The only case that will make the dispatcher goroutine exit
 				// is that the loopCtx is done, otherwise there is no circumstance
 				// this goroutine should exit.
-				go func(dc string, tsoDispatcher chan *tsoRequest) {
-					var (
-						err      error
-						ctx      context.Context
-						cancel   context.CancelFunc
-						stream   pdpb.PD_TsoClient
-						opts     []opentracing.StartSpanOption
-						requests = make([]*tsoRequest, maxMergeTSORequests+1)
-					)
-					defer func() {
-						if cancel != nil {
-							cancel()
-						}
-					}()
-					for {
-						// If the tso stream for the corresponding dc-location has not been created yet or needs to be re-created,
-						// we will try to create the stream first.
-						if stream == nil {
-							ctx, cancel = context.WithCancel(loopCtx)
-							done := make(chan struct{})
-							go c.checkStreamTimeout(ctx, cancel, done)
-							stream, err = pdpb.NewPDClient(c.getClientConnByDCLocation(dc)).Tso(ctx)
-							done <- struct{}{}
-							if err != nil {
-								select {
-								case <-loopCtx.Done():
-									return
-								default:
-								}
-								log.Error("[pd] create tso stream error", zap.String("dc-location", dc), errs.ZapError(errs.ErrClientCreateTSOStream, err))
-								c.ScheduleCheckLeader()
-								cancel()
-								c.revokeTSORequest(errors.WithStack(err), tsoDispatcher)
-								select {
-								case <-time.After(time.Second):
-								case <-loopCtx.Done():
-									return
-								}
-								continue
-							}
-						}
-						select {
-						case first := <-tsoDispatcher:
-							pendingPlus1 := len(tsoDispatcher) + 1
-							requests[0] = first
-							for i := 1; i < pendingPlus1; i++ {
-								requests[i] = <-tsoDispatcher
-							}
-							done := make(chan struct{})
-							dl := deadline{
-								timer:  time.After(c.timeout),
-								done:   done,
-								cancel: cancel,
-							}
-							tsDeadlineCh, ok := c.tsDeadline.Load(dc)
-							for !ok || tsDeadlineCh == nil {
-								c.scheduleCheckTSDeadline()
-								time.Sleep(time.Millisecond * 100)
-								tsDeadlineCh, ok = c.tsDeadline.Load(dc)
-							}
-							select {
-							case tsDeadlineCh.(chan deadline) <- dl:
-							case <-loopCtx.Done():
-								return
-							}
-							opts = extractSpanReference(requests[:pendingPlus1], opts[:0])
-							err = c.processTSORequests(stream, dc, requests[:pendingPlus1], opts)
-							close(done)
-						case <-loopCtx.Done():
-							return
-						}
-						// If error happens during tso stream handling, reset stream and run the next trial.
-						if err != nil {
-							select {
-							case <-loopCtx.Done():
-								return
-							default:
-							}
-							log.Error("[pd] getTS error", zap.String("dc-location", dc), errs.ZapError(errs.ErrClientGetTSO, err))
-							c.ScheduleCheckLeader()
-							cancel()
-							stream = nil
-						}
-					}
-				}(dcLocation, dispatcher.(chan *tsoRequest))
+				go c.handleDispatcher(loopCtx, dcLocation, dispatcher.(chan *tsoRequest))
 			}
 			return true
 		})
@@ -425,6 +343,92 @@ func (c *client) checkTSODispatcher(dcLocation string) bool {
 
 func (c *client) createTSODispatcher(dcLocation string) {
 	c.tsoDispatcher.Store(dcLocation, make(chan *tsoRequest, maxMergeTSORequests))
+}
+
+func (c *client) handleDispatcher(loopCtx context.Context, dc string, tsoDispatcher chan *tsoRequest) {
+	var (
+		err      error
+		ctx      context.Context
+		cancel   context.CancelFunc
+		stream   pdpb.PD_TsoClient
+		opts     []opentracing.StartSpanOption
+		requests = make([]*tsoRequest, maxMergeTSORequests+1)
+	)
+	defer func() {
+		if cancel != nil {
+			cancel()
+		}
+	}()
+	for {
+		// If the tso stream for the corresponding dc-location has not been created yet or needs to be re-created,
+		// we will try to create the stream first.
+		if stream == nil {
+			ctx, cancel = context.WithCancel(loopCtx)
+			done := make(chan struct{})
+			go c.checkStreamTimeout(ctx, cancel, done)
+			stream, err = pdpb.NewPDClient(c.getClientConnByDCLocation(dc)).Tso(ctx)
+			done <- struct{}{}
+			if err != nil {
+				select {
+				case <-loopCtx.Done():
+					return
+				default:
+				}
+				log.Error("[pd] create tso stream error", zap.String("dc-location", dc), errs.ZapError(errs.ErrClientCreateTSOStream, err))
+				c.ScheduleCheckLeader()
+				cancel()
+				c.revokeTSORequest(errors.WithStack(err), tsoDispatcher)
+				select {
+				case <-time.After(time.Second):
+				case <-loopCtx.Done():
+					return
+				}
+				continue
+			}
+		}
+		select {
+		case first := <-tsoDispatcher:
+			pendingPlus1 := len(tsoDispatcher) + 1
+			requests[0] = first
+			for i := 1; i < pendingPlus1; i++ {
+				requests[i] = <-tsoDispatcher
+			}
+			done := make(chan struct{})
+			dl := deadline{
+				timer:  time.After(c.timeout),
+				done:   done,
+				cancel: cancel,
+			}
+			tsDeadlineCh, ok := c.tsDeadline.Load(dc)
+			for !ok || tsDeadlineCh == nil {
+				c.scheduleCheckTSDeadline()
+				time.Sleep(time.Millisecond * 100)
+				tsDeadlineCh, ok = c.tsDeadline.Load(dc)
+			}
+			select {
+			case tsDeadlineCh.(chan deadline) <- dl:
+			case <-loopCtx.Done():
+				return
+			}
+			opts = extractSpanReference(requests[:pendingPlus1], opts[:0])
+			err = c.processTSORequests(stream, dc, requests[:pendingPlus1], opts)
+			close(done)
+		case <-loopCtx.Done():
+			return
+		}
+		// If error happens during tso stream handling, reset stream and run the next trial.
+		if err != nil {
+			select {
+			case <-loopCtx.Done():
+				return
+			default:
+			}
+			log.Error("[pd] getTS error", zap.String("dc-location", dc), errs.ZapError(errs.ErrClientGetTSO, err))
+			c.ScheduleCheckLeader()
+			cancel()
+			stream = nil
+		}
+	}
 }
 
 func extractSpanReference(requests []*tsoRequest, opts []opentracing.StartSpanOption) []opentracing.StartSpanOption {

--- a/client/client.go
+++ b/client/client.go
@@ -201,6 +201,7 @@ func NewClientWithContext(ctx context.Context, pdAddrs []string, security Securi
 		checkTSDeadlineCh: make(chan struct{}),
 	}
 
+	c.createTSODispatcher(globalDCLocation)
 	c.wg.Add(2)
 	go c.tsLoop()
 	go c.tsCancelLoop()


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

In low-cpu resource env, the dispatcher for the `global` might haven't been initialized after the global tso has been requested.

### What is changed and how it works?

During `NewClient.....`, we can create global dispatcher before `tsloop`

### Check List

<!-- Remove the items that are not applicable. -->


### Release note

*  No release note
