### PR TITLE
Fix hot peer cache threshold unstable when interval unstable

### DIFF
--- a/server/statistics/hot_peer.go
+++ b/server/statistics/hot_peer.go
@@ -46,8 +46,12 @@ func (d *dimStat) Add(delta float64, interval time.Duration) {
 	d.Rolling.Add(delta, interval)
 }
 
+func (d *dimStat) isLastAverageHot(thresholds [dimLen]float64) bool {
+	return d.LastAverage.Get() >= thresholds[d.typ]
+}
+
 func (d *dimStat) isHot(thresholds [dimLen]float64) bool {
-	return d.LastAverage.IsFull() && d.LastAverage.Get() >= thresholds[d.typ]
+	return d.Rolling.Get() >= thresholds[d.typ]
 }
 
 func (d *dimStat) isFull() bool {
@@ -156,8 +160,9 @@ func (stat *HotPeerStat) Clone() *HotPeerStat {
 	return &ret
 }
 
-func (stat *HotPeerStat) isHot() bool {
-	return stat.rollingByteRate.isHot(stat.thresholds) || stat.rollingKeyRate.isHot(stat.thresholds)
+func (stat *HotPeerStat) isFullAndHot() bool {
+	return (stat.rollingByteRate.isFull() && stat.rollingByteRate.isLastAverageHot(stat.thresholds)) ||
+		(stat.rollingKeyRate.isFull() && stat.rollingKeyRate.isLastAverageHot(stat.thresholds))
 }
 
 func (stat *HotPeerStat) clearLastAverage() {

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -423,14 +423,14 @@ func (f *hotPeerCache) updateHotPeerStat(newItem, oldItem *HotPeerStat, bytes, k
 		newItem.AntiCount = oldItem.AntiCount
 	} else {
 		if f.isOldColdPeer(oldItem, newItem.StoreID) {
-			if newItem.isHot() {
+			if newItem.isFullAndHot() {
 				newItem.HotDegree = 1
 				newItem.AntiCount = hotRegionAntiCount
 			} else {
 				newItem.needDelete = true
 			}
 		} else {
-			if newItem.isHot() {
+			if newItem.isFullAndHot() {
 				newItem.HotDegree = oldItem.HotDegree + 1
 				newItem.AntiCount = hotRegionAntiCount
 			} else {

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -385,11 +385,11 @@ func (f *hotPeerCache) updateHotPeerStat(newItem, oldItem *HotPeerStat, bytes, k
 		if interval == 0 {
 			return nil
 		}
+		isHot := bytes/interval.Seconds() >= newItem.thresholds[byteDim] || keys/interval.Seconds() >= newItem.thresholds[keyDim]
+		if !isHot {
+			return nil
+		}
 		if interval.Seconds() >= RegionHeartBeatReportInterval {
-			isHot := bytes/interval.Seconds() >= newItem.thresholds[byteDim] || keys/interval.Seconds() >= newItem.thresholds[keyDim]
-			if !isHot {
-				return nil
-			}
 			newItem.HotDegree = 1
 			newItem.AntiCount = hotRegionAntiCount
 		}

--- a/server/statistics/hot_peer_cache_test.go
+++ b/server/statistics/hot_peer_cache_test.go
@@ -274,7 +274,10 @@ func (t *testHotPeerCache) TestUpdateHotPeerStat(c *C) {
 func (t *testHotPeerCache) TestThresholdWithUpdateHotPeerStat(c *C) {
 	byteRate := minHotThresholds[ReadFlow][byteDim] * 2
 	expectThreshold := byteRate * HotThresholdRatio
+	t.testMetrics(c, 120., byteRate, expectThreshold)
 	t.testMetrics(c, 60., byteRate, expectThreshold)
+	t.testMetrics(c, 30., byteRate, expectThreshold)
+	t.testMetrics(c, 17., byteRate, expectThreshold)
 	t.testMetrics(c, 1., byteRate, expectThreshold)
 }
 func (t *testHotPeerCache) testMetrics(c *C, interval, byteRate, expectThreshold float64) {


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Before PR, we add peer to the hot peer cache when its interval is less than normal, which causes topn will increase a lot when the heartbeat interval is unstable. We calculate the threshold by the 60th item in the hot peer cache, so the threshold will reduce to the default threshold while a lot of peers are added to the hot peer cache.

### What is changed and how it works?

we add peer to the hot peer cache when its interval is less than normal only when it is hot too.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
