### PR TITLE
*: no one is using the returned command

### DIFF
--- a/tests/dashboard/service_test.go
+++ b/tests/dashboard/service_test.go
@@ -154,14 +154,14 @@ func (s *serverTestSuite) testDashboard(c *C, internalProxy bool) {
 		}
 	}
 	args := []string{"-u", leaderAddr, "config", "set", "dashboard-address", dashboardAddress2}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	s.checkServiceIsStarted(c, internalProxy, servers, leader)
 	c.Assert(leader.GetServer().GetPersistOptions().GetDashboardAddress(), Equals, dashboardAddress2)
 
 	// pd-ctl set stop
 	args = []string{"-u", leaderAddr, "config", "set", "dashboard-address", "none"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	s.checkServiceIsStopped(c, servers)
 }

--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -58,7 +58,7 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 
 	// cluster
 	args := []string{"-u", pdAddr, "cluster"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	ci := &metapb.Cluster{}
 	c.Assert(json.Unmarshal(output, ci), IsNil)
@@ -68,7 +68,7 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 
 	// cluster info
 	args = []string{"-u", pdAddr, "cluster"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	ci = &metapb.Cluster{}
 	c.Assert(json.Unmarshal(output, ci), IsNil)
@@ -76,7 +76,7 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 
 	// cluster status
 	args = []string{"-u", pdAddr, "cluster", "status"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	cs := &clusterpkg.Status{}
 	c.Assert(json.Unmarshal(output, cs), IsNil)
@@ -91,7 +91,7 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 
 	// ping
 	args = []string{"-u", pdAddr, "ping"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(output, NotNil)
 }

--- a/tests/pdctl/completion/completion_test.go
+++ b/tests/pdctl/completion/completion_test.go
@@ -33,11 +33,11 @@ func (s *completionTestSuite) TestCompletion(c *C) {
 
 	// completion command
 	args := []string{"completion", "bash"}
-	_, _, err := pdctl.ExecuteCommandC(cmd, args...)
+	_, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 
 	// completion command
 	args = []string{"completion", "zsh"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 }

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -83,7 +83,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config show
 	args := []string{"-u", pdAddr, "config", "show"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	cfg := config.Config{}
 	c.Assert(json.Unmarshal(output, &cfg), IsNil)
@@ -96,13 +96,13 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config set trace-region-flow <value>
 	args = []string{"-u", pdAddr, "config", "set", "trace-region-flow", "false"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(svr.GetPDServerConfig().TraceRegionFlow, Equals, false)
 
 	// config show schedule
 	args = []string{"-u", pdAddr, "config", "show", "schedule"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	scheduleCfg := config.ScheduleConfig{}
 	c.Assert(json.Unmarshal(output, &scheduleCfg), IsNil)
@@ -110,7 +110,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config show replication
 	args = []string{"-u", pdAddr, "config", "show", "replication"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	replicationCfg := config.ReplicationConfig{}
 	c.Assert(json.Unmarshal(output, &replicationCfg), IsNil)
@@ -118,7 +118,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config show cluster-version
 	args1 := []string{"-u", pdAddr, "config", "show", "cluster-version"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
+	output, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	clusterVersion := semver.Version{}
 	c.Assert(json.Unmarshal(output, &clusterVersion), IsNil)
@@ -126,10 +126,10 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config set cluster-version <value>
 	args2 := []string{"-u", pdAddr, "config", "set", "cluster-version", "2.1.0-rc.5"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args2...)
+	_, err = pdctl.ExecuteCommand(cmd, args2...)
 	c.Assert(err, IsNil)
 	c.Assert(clusterVersion, Not(DeepEquals), svr.GetClusterVersion())
-	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
+	output, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	clusterVersion = semver.Version{}
 	c.Assert(json.Unmarshal(output, &clusterVersion), IsNil)
@@ -137,7 +137,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config show label-property
 	args1 = []string{"-u", pdAddr, "config", "show", "label-property"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
+	output, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	labelPropertyCfg := config.LabelPropertyConfig{}
 	c.Assert(json.Unmarshal(output, &labelPropertyCfg), IsNil)
@@ -145,10 +145,10 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config set label-property <type> <key> <value>
 	args2 = []string{"-u", pdAddr, "config", "set", "label-property", "reject-leader", "zone", "cn"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args2...)
+	_, err = pdctl.ExecuteCommand(cmd, args2...)
 	c.Assert(err, IsNil)
 	c.Assert(labelPropertyCfg, Not(DeepEquals), svr.GetLabelProperty())
-	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
+	output, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	labelPropertyCfg = config.LabelPropertyConfig{}
 	c.Assert(json.Unmarshal(output, &labelPropertyCfg), IsNil)
@@ -156,10 +156,10 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// config delete label-property <type> <key> <value>
 	args3 := []string{"-u", pdAddr, "config", "delete", "label-property", "reject-leader", "zone", "cn"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args3...)
+	_, err = pdctl.ExecuteCommand(cmd, args3...)
 	c.Assert(err, IsNil)
 	c.Assert(labelPropertyCfg, Not(DeepEquals), svr.GetLabelProperty())
-	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
+	output, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	labelPropertyCfg = config.LabelPropertyConfig{}
 	c.Assert(json.Unmarshal(output, &labelPropertyCfg), IsNil)
@@ -187,11 +187,11 @@ func (s *configTestSuite) TestConfig(c *C) {
 	for _, item := range testItems {
 		// write
 		args1 = []string{"-u", pdAddr, "config", "set", item.name, reflect.TypeOf(item.value).String()}
-		_, _, err = pdctl.ExecuteCommandC(cmd, args1...)
+		_, err = pdctl.ExecuteCommand(cmd, args1...)
 		c.Assert(err, IsNil)
 		// read
 		args2 = []string{"-u", pdAddr, "config", "show"}
-		_, output, err = pdctl.ExecuteCommandC(cmd, args2...)
+		output, err = pdctl.ExecuteCommand(cmd, args2...)
 		c.Assert(err, IsNil)
 		cfg = config.Config{}
 		c.Assert(json.Unmarshal(output, &cfg), IsNil)
@@ -201,20 +201,20 @@ func (s *configTestSuite) TestConfig(c *C) {
 
 	// test error or deprecated config name
 	args1 = []string{"-u", pdAddr, "config", "set", "foo-bar", "1"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
+	output, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "not found"), IsTrue)
 	args1 = []string{"-u", pdAddr, "config", "set", "disable-remove-down-replica", "true"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args1...)
+	output, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "already been deprecated"), IsTrue)
 
 	// set enable-placement-rules twice, make sure it does not return error.
 	args1 = []string{"-u", pdAddr, "config", "set", "enable-placement-rules", "true"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args1...)
+	_, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 	args1 = []string{"-u", pdAddr, "config", "set", "enable-placement-rules", "true"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args1...)
+	_, err = pdctl.ExecuteCommand(cmd, args1...)
 	c.Assert(err, IsNil)
 }
 
@@ -239,13 +239,13 @@ func (s *configTestSuite) TestPlacementRules(c *C) {
 	pdctl.MustPutStore(c, svr, store.Id, store.State, store.Labels)
 	defer cluster.Destroy()
 
-	_, output, err := pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
+	output, err := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
 	// test show
 	var rules []placement.Rule
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "show")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "show")
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, &rules)
 	c.Assert(err, IsNil)
@@ -257,7 +257,7 @@ func (s *configTestSuite) TestPlacementRules(c *C) {
 	f.Close()
 
 	// test load
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "load", "--out="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "load", "--out="+fname)
 	c.Assert(err, IsNil)
 	b, _ := ioutil.ReadFile(fname)
 	c.Assert(json.Unmarshal(b, &rules), IsNil)
@@ -278,12 +278,12 @@ func (s *configTestSuite) TestPlacementRules(c *C) {
 	})
 	b, _ = json.Marshal(rules)
 	ioutil.WriteFile(fname, b, 0644)
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
 	c.Assert(err, IsNil)
 
 	// test show group
 	var rules2 []placement.Rule
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "show", "--group=pd")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "show", "--group=pd")
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, &rules2)
 	c.Assert(err, IsNil)
@@ -295,9 +295,9 @@ func (s *configTestSuite) TestPlacementRules(c *C) {
 	rules[0].Count = 0
 	b, _ = json.Marshal(rules)
 	ioutil.WriteFile(fname, b, 0644)
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
 	c.Assert(err, IsNil)
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "show", "--group=pd")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "show", "--group=pd")
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, &rules)
 	c.Assert(err, IsNil)
@@ -326,29 +326,29 @@ func (s *configTestSuite) TestPlacementRuleGroups(c *C) {
 	pdctl.MustPutStore(c, svr, store.Id, store.State, store.Labels)
 	defer cluster.Destroy()
 
-	_, output, err := pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
+	output, err := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
 	// test show
 	var group placement.RuleGroup
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show", "pd")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show", "pd")
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, &group)
 	c.Assert(err, IsNil)
 	c.Assert(group, DeepEquals, placement.RuleGroup{ID: "pd"})
 
 	// test set
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "set", "pd", "42", "true")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "set", "pd", "42", "true")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "set", "group2", "100", "false")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "set", "group2", "100", "false")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
 	// show all
 	var groups []placement.RuleGroup
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show")
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, &groups)
 	c.Assert(err, IsNil)
@@ -358,12 +358,12 @@ func (s *configTestSuite) TestPlacementRuleGroups(c *C) {
 	})
 
 	// delete
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "delete", "group2")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "delete", "group2")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
 	// show again
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show", "group2")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show", "group2")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "404"), IsTrue)
 }
@@ -389,17 +389,17 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	pdctl.MustPutStore(c, svr, store.Id, store.State, store.Labels)
 	defer cluster.Destroy()
 
-	_, output, err := pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
+	output, err := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "location-labels", "dc,rack")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "location-labels", "dc,rack")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "please update rule instead"), IsTrue)
 
 	// test get
 	var bundle placement.GroupBundle
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "get", "pd")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "get", "pd")
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, &bundle)
 	c.Assert(err, IsNil)
@@ -415,7 +415,7 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 
 	// test load
 	var bundles []placement.GroupBundle
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
 	b, _ := ioutil.ReadFile(fname)
 	c.Assert(json.Unmarshal(b, &bundles), IsNil)
@@ -428,10 +428,10 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	b, err = json.Marshal(bundle)
 	c.Assert(err, IsNil)
 	c.Assert(ioutil.WriteFile(fname, b, 0644), IsNil)
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "set", "--in="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "set", "--in="+fname)
 	c.Assert(err, IsNil)
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
 	b, _ = ioutil.ReadFile(fname)
 	c.Assert(json.Unmarshal(b, &bundles), IsNil)
@@ -441,10 +441,10 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	})
 
 	// test delete
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "delete", "pd")
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "delete", "pd")
 	c.Assert(err, IsNil)
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
 	b, _ = ioutil.ReadFile(fname)
 	c.Assert(json.Unmarshal(b, &bundles), IsNil)
@@ -458,13 +458,13 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	b, err = json.Marshal(bundle)
 	c.Assert(err, IsNil)
 	c.Assert(ioutil.WriteFile(fname, b, 0644), IsNil)
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "set", "--in="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "set", "--in="+fname)
 	c.Assert(err, IsNil)
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "delete", "--regexp", ".*f")
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "delete", "--regexp", ".*f")
 	c.Assert(err, IsNil)
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
 	b, _ = ioutil.ReadFile(fname)
 	c.Assert(json.Unmarshal(b, &bundles), IsNil)
@@ -478,10 +478,10 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	b, err = json.Marshal(bundles)
 	c.Assert(err, IsNil)
 	c.Assert(ioutil.WriteFile(fname, b, 0644), IsNil)
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "save", "--in="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "save", "--in="+fname)
 	c.Assert(err, IsNil)
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
 	b, err = ioutil.ReadFile(fname)
 	c.Assert(err, IsNil)
@@ -496,10 +496,10 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	b, err = json.Marshal(bundles)
 	c.Assert(err, IsNil)
 	c.Assert(ioutil.WriteFile(fname, b, 0644), IsNil)
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "save", "--in="+fname, "--partial")
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "save", "--in="+fname, "--partial")
 	c.Assert(err, IsNil)
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "load", "--out="+fname)
 	c.Assert(err, IsNil)
 	b, err = ioutil.ReadFile(fname)
 	c.Assert(err, IsNil)
@@ -539,7 +539,7 @@ func (s *configTestSuite) TestReplicationMode(c *C) {
 		},
 	}
 	check := func() {
-		_, output, err := pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "show", "replication-mode")
+		output, err := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "show", "replication-mode")
 		c.Assert(err, IsNil)
 		var conf2 config.ReplicationModeConfig
 		json.Unmarshal(output, &conf2)
@@ -548,17 +548,17 @@ func (s *configTestSuite) TestReplicationMode(c *C) {
 
 	check()
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync")
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync")
 	c.Assert(err, IsNil)
 	conf.ReplicationMode = "dr-auto-sync"
 	check()
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync", "label-key", "foobar")
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync", "label-key", "foobar")
 	c.Assert(err, IsNil)
 	conf.DRAutoSync.LabelKey = "foobar"
 	check()
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync", "primary-replicas", "5")
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync", "primary-replicas", "5")
 	c.Assert(err, IsNil)
 	conf.DRAutoSync.PrimaryReplicas = 5
 	check()
@@ -587,7 +587,7 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 
 	checkMaxReplicas := func(expect uint64) {
 		args := []string{"-u", pdAddr, "config", "show", "replication"}
-		_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+		output, err := pdctl.ExecuteCommand(cmd, args...)
 		c.Assert(err, IsNil)
 		replicationCfg := config.ReplicationConfig{}
 		c.Assert(json.Unmarshal(output, &replicationCfg), IsNil)
@@ -596,7 +596,7 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 
 	checkRuleCount := func(expect int) {
 		args := []string{"-u", pdAddr, "config", "placement-rules", "show", "--group", "pd", "--id", "default"}
-		_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+		output, err := pdctl.ExecuteCommand(cmd, args...)
 		c.Assert(err, IsNil)
 		rule := placement.Rule{}
 		c.Assert(json.Unmarshal(output, &rule), IsNil)
@@ -604,17 +604,17 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 	}
 
 	// update successfully when placement rules is not enabled.
-	_, output, err := pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "max-replicas", "2")
+	output, err := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "2")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 	checkMaxReplicas(2)
 
 	// update successfully when only one default rule exists.
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "max-replicas", "3")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "3")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 	checkMaxReplicas(3)
@@ -639,12 +639,12 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 	b, err := json.Marshal(rules)
 	c.Assert(err, IsNil)
 	ioutil.WriteFile(fname, b, 0644)
-	_, _, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "save", "--in="+fname)
 	c.Assert(err, IsNil)
 	checkMaxReplicas(3)
 	checkRuleCount(3)
 
-	_, output, err = pdctl.ExecuteCommandC(cmd, "-u", pdAddr, "config", "set", "max-replicas", "4")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "4")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "please update rule instead"), IsTrue)
 	checkMaxReplicas(3)

--- a/tests/pdctl/health/health_test.go
+++ b/tests/pdctl/health/health_test.go
@@ -72,7 +72,7 @@ func (s *healthTestSuite) TestHealth(c *C) {
 
 	// health command
 	args := []string{"-u", pdAddr, "health"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	h := make([]api.Health, len(healths))
 	c.Assert(json.Unmarshal(output, &h), IsNil)

--- a/tests/pdctl/helper.go
+++ b/tests/pdctl/helper.go
@@ -66,14 +66,14 @@ func InitCommand() *cobra.Command {
 	return rootCmd
 }
 
-// ExecuteCommandC is used for test purpose.
-func ExecuteCommandC(root *cobra.Command, args ...string) (c *cobra.Command, output []byte, err error) {
+// ExecuteCommand is used for test purpose.
+func ExecuteCommand(root *cobra.Command, args ...string) (output []byte, err error) {
 	buf := new(bytes.Buffer)
 	root.SetOutput(buf)
 	root.SetArgs(args)
 
-	c, err = root.ExecuteC()
-	return c, buf.Bytes(), err
+	err = root.Execute()
+	return buf.Bytes(), err
 }
 
 // CheckStoresInfo is used to check the test results.

--- a/tests/pdctl/hot/hot_test.go
+++ b/tests/pdctl/hot/hot_test.go
@@ -87,7 +87,7 @@ func (s *hotTestSuite) TestHot(c *C) {
 	}
 
 	args := []string{"-u", pdAddr, "hot", "store"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	hotStores := api.HotStoreStats{}
 	c.Assert(json.Unmarshal(output, &hotStores), IsNil)
@@ -98,7 +98,7 @@ func (s *hotTestSuite) TestHot(c *C) {
 
 	// test hot region
 	args = []string{"-u", pdAddr, "config", "set", "hot-region-cache-hits-threshold", "0"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 
 	statistics.Denoising = false
@@ -107,7 +107,7 @@ func (s *hotTestSuite) TestHot(c *C) {
 
 	testHot := func(hotRegionID, hotStoreID uint64, hotType string) {
 		args = []string{"-u", pdAddr, "hot", hotType}
-		_, output, e := pdctl.ExecuteCommandC(cmd, args...)
+		output, e := pdctl.ExecuteCommand(cmd, args...)
 		hotRegion := statistics.StoreHotPeersInfos{}
 		c.Assert(e, IsNil)
 		c.Assert(json.Unmarshal(output, &hotRegion), IsNil)

--- a/tests/pdctl/label/label_test.go
+++ b/tests/pdctl/label/label_test.go
@@ -100,7 +100,7 @@ func (s *labelTestSuite) TestLabel(c *C) {
 
 	// label command
 	args := []string{"-u", pdAddr, "label"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	labels := make([]*metapb.StoreLabel, 0, len(stores))
 	c.Assert(json.Unmarshal(output, &labels), IsNil)
@@ -124,7 +124,7 @@ func (s *labelTestSuite) TestLabel(c *C) {
 
 	// label store <name> command
 	args = []string{"-u", pdAddr, "label", "store", "zone", "us-west"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	storesInfo := new(api.StoresInfo)
 	c.Assert(json.Unmarshal(output, &storesInfo), IsNil)

--- a/tests/pdctl/log/log_test.go
+++ b/tests/pdctl/log/log_test.go
@@ -85,7 +85,7 @@ func (s *logTestSuite) TestLog(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		_, _, err = pdctl.ExecuteCommandC(cmd, testCase.cmd...)
+		_, err = pdctl.ExecuteCommand(cmd, testCase.cmd...)
 		c.Assert(err, IsNil)
 		c.Assert(svr.GetConfig().Log.Level, Equals, testCase.expect)
 	}

--- a/tests/pdctl/member/member_test.go
+++ b/tests/pdctl/member/member_test.go
@@ -62,7 +62,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 
 	// member leader show
 	args := []string{"-u", pdAddr, "member", "leader", "show"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	leader := pdpb.Member{}
 	c.Assert(json.Unmarshal(output, &leader), IsNil)
@@ -70,7 +70,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 
 	// member leader transfer <member_name>
 	args = []string{"-u", pdAddr, "member", "leader", "transfer", "pd2"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	testutil.WaitUntil(c, func(c *C) bool {
 		return c.Check("pd2", Equals, svr.GetLeader().GetName())
@@ -79,7 +79,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 	// member leader resign
 	cluster.WaitLeader()
 	args = []string{"-u", pdAddr, "member", "leader", "resign"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(strings.Contains(string(output), "Success"), IsTrue)
 	c.Assert(err, IsNil)
 	testutil.WaitUntil(c, func(c *C) bool {
@@ -89,7 +89,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 	// member leader_priority <member_name> <priority>
 	cluster.WaitLeader()
 	args = []string{"-u", pdAddr, "member", "leader_priority", name, "100"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	priority, err := svr.GetServer().GetMember().GetMemberLeaderPriority(id)
 	c.Assert(err, IsNil)
@@ -102,7 +102,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(members.Members), Equals, 3)
 	args = []string{"-u", pdAddr, "member", "delete", "name", name}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	members, err = etcdutil.ListEtcdMembers(client)
 	c.Assert(err, IsNil)
@@ -110,7 +110,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 
 	// member delete id <member_id>
 	args = []string{"-u", pdAddr, "member", "delete", "id", fmt.Sprint(id)}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	members, err = etcdutil.ListEtcdMembers(client)
 	c.Assert(err, IsNil)

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -164,39 +164,39 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	}
 
 	for _, testCase := range testCases {
-		_, _, e := pdctl.ExecuteCommandC(cmd, testCase.cmd...)
+		_, e := pdctl.ExecuteCommand(cmd, testCase.cmd...)
 		c.Assert(e, IsNil)
-		_, output, e := pdctl.ExecuteCommandC(cmd, testCase.show...)
+		output, e := pdctl.ExecuteCommand(cmd, testCase.show...)
 		c.Assert(e, IsNil)
 		c.Assert(strings.Contains(string(output), testCase.expect), IsTrue)
-		_, _, e = pdctl.ExecuteCommandC(cmd, testCase.reset...)
+		_, e = pdctl.ExecuteCommand(cmd, testCase.reset...)
 		c.Assert(e, IsNil)
 	}
 
 	// operator add merge-region <source_region_id> <target_region_id>
 	args := []string{"-u", pdAddr, "operator", "add", "merge-region", "1", "3"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "operator", "show"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "merge region 1 into region 3"), IsTrue)
 	args = []string{"-u", pdAddr, "operator", "remove", "1"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "operator", "remove", "3"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 
 	// operator add scatter-region <region_id>
 	args = []string{"-u", pdAddr, "operator", "add", "scatter-region", "3"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "operator", "add", "scatter-region", "1"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "operator", "show", "region"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "scatter-region"), IsTrue)
 
@@ -210,21 +210,21 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
 	c.Assert(strings.Contains(echo, "Success!"), IsFalse)
 
-	_, _, err = pdctl.ExecuteCommandC(cmd, "config", "set", "enable-placement-rules", "true")
+	_, err = pdctl.ExecuteCommand(cmd, "config", "set", "enable-placement-rules", "true")
 	c.Assert(err, IsNil)
-	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "3")
+	output, err = pdctl.ExecuteCommand(cmd, "operator", "add", "transfer-region", "1", "2", "3")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "not supported"), IsTrue)
-	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "follower", "3")
+	output, err = pdctl.ExecuteCommand(cmd, "operator", "add", "transfer-region", "1", "2", "follower", "3")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "not match"), IsTrue)
-	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "follower", "leader", "3", "follower")
+	output, err = pdctl.ExecuteCommand(cmd, "operator", "add", "transfer-region", "1", "2", "follower", "leader", "3", "follower")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "invalid"), IsTrue)
-	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "leader", "2", "follower", "3")
+	output, err = pdctl.ExecuteCommand(cmd, "operator", "add", "transfer-region", "1", "leader", "2", "follower", "3")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "invalid"), IsTrue)
-	_, output, err = pdctl.ExecuteCommandC(cmd, "operator", "add", "transfer-region", "1", "2", "leader", "3", "follower")
+	output, err = pdctl.ExecuteCommand(cmd, "operator", "add", "transfer-region", "1", "2", "leader", "3", "follower")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 }

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -145,7 +145,7 @@ func (s *regionTestSuite) TestRegion(c *C) {
 
 	for _, testCase := range testRegionsCases {
 		args := append([]string{"-u", pdAddr}, testCase.args...)
-		_, output, e := pdctl.ExecuteCommandC(cmd, args...)
+		output, e := pdctl.ExecuteCommand(cmd, args...)
 		c.Assert(e, IsNil)
 		regionsInfo := api.RegionsInfo{}
 		c.Assert(json.Unmarshal(output, &regionsInfo), IsNil)
@@ -168,7 +168,7 @@ func (s *regionTestSuite) TestRegion(c *C) {
 
 	for _, testCase := range testRegionCases {
 		args := append([]string{"-u", pdAddr}, testCase.args...)
-		_, output, e := pdctl.ExecuteCommandC(cmd, args...)
+		output, e := pdctl.ExecuteCommand(cmd, args...)
 		c.Assert(e, IsNil)
 		regionInfo := api.RegionInfo{}
 		c.Assert(json.Unmarshal(output, &regionInfo), IsNil)

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -71,7 +71,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	}
 
 	mustExec := func(args []string, v interface{}) {
-		_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+		output, err := pdctl.ExecuteCommand(cmd, args...)
 		c.Assert(err, IsNil)
 		if v == nil {
 			return

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -82,7 +82,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store command
 	args := []string{"-u", pdAddr, "store"}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	storesInfo := new(api.StoresInfo)
 	c.Assert(json.Unmarshal(output, &storesInfo), IsNil)
@@ -90,7 +90,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store --state=<query states> command
 	args = []string{"-u", pdAddr, "store", "--state", "Up,Tombstone"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	storesInfo = new(api.StoresInfo)
 	c.Assert(json.Unmarshal(output, &storesInfo), IsNil)
@@ -98,7 +98,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store <store_id> command
 	args = []string{"-u", pdAddr, "store", "1"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	storeInfo := new(api.StoreInfo)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
@@ -107,10 +107,10 @@ func (s *storeTestSuite) TestStore(c *C) {
 	// store label <store_id> <key> <value> [<key> <value>]... [flags] command
 	c.Assert(storeInfo.Store.Labels, IsNil)
 	args = []string{"-u", pdAddr, "store", "label", "1", "zone", "cn"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "1"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
 	label := storeInfo.Store.Labels[0]
@@ -119,10 +119,10 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store label <store_id> <key> <value> <key> <value>... command
 	args = []string{"-u", pdAddr, "store", "label", "1", "zone", "us", "language", "English"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "1"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
 	label0 := storeInfo.Store.Labels[0]
@@ -134,10 +134,10 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store label <store_id> <key> <value> <key> <value>... -f command
 	args = []string{"-u", pdAddr, "store", "label", "1", "zone", "uk", "-f"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "1"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
 	label0 = storeInfo.Store.Labels[0]
@@ -149,10 +149,10 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(storeInfo.Status.LeaderWeight, Equals, float64(1))
 	c.Assert(storeInfo.Status.RegionWeight, Equals, float64(1))
 	args = []string{"-u", pdAddr, "store", "weight", "1", "5", "10"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "1"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
 	c.Assert(storeInfo.Status.LeaderWeight, Equals, float64(5))
@@ -160,7 +160,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store limit <store_id> <rate>
 	args = []string{"-u", pdAddr, "store", "limit", "1", "10"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	limit := leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
 	c.Assert(limit, Equals, float64(10))
@@ -169,7 +169,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store limit <store_id> <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "1", "5", "remove-peer"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.RemovePeer)
 	c.Assert(limit, Equals, float64(5))
@@ -178,7 +178,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store limit all <rate>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "20"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	limit1 := leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
 	limit2 := leaderServer.GetRaftCluster().GetStoreLimitByType(2, storelimit.AddPeer)
@@ -202,7 +202,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store limit all <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	limit1 = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.RemovePeer)
 	limit3 = leaderServer.GetRaftCluster().GetStoreLimitByType(3, storelimit.RemovePeer)
@@ -213,14 +213,14 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store limit all <key> <value> <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "zone", "uk", "20", "remove-peer"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	limit1 = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.RemovePeer)
 	c.Assert(limit1, Equals, float64(20))
 
 	// store limit all 0 is invalid
 	args = []string{"-u", pdAddr, "store", "limit", "all", "0"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "rate should be a number that > 0"), IsTrue)
 
@@ -244,31 +244,31 @@ func (s *storeTestSuite) TestStore(c *C) {
 	// store delete <store_id> command
 	c.Assert(storeInfo.Store.State, Equals, metapb.StoreState_Up)
 	args = []string{"-u", pdAddr, "store", "delete", "1"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "1"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
 	c.Assert(storeInfo.Store.State, Equals, metapb.StoreState_Offline)
 
 	// store delete addr <address>
 	args = []string{"-u", pdAddr, "store", "delete", "addr", "tikv3"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(string(output), Equals, "Success!\n")
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "3"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(json.Unmarshal(output, &storeInfo), IsNil)
 	c.Assert(storeInfo.Store.State, Equals, metapb.StoreState_Offline)
 
 	// store remove-tombstone
 	args = []string{"-u", pdAddr, "store", "remove-tombstone"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	storesInfo = new(api.StoresInfo)
 	c.Assert(json.Unmarshal(output, &storesInfo), IsNil)
@@ -283,7 +283,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
 	// store limit-scene
 	args = []string{"-u", pdAddr, "store", "limit-scene"}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	scene := &storelimit.Scene{}
 	err = json.Unmarshal(output, scene)
@@ -292,11 +292,11 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store limit-scene <scene> <rate>
 	args = []string{"-u", pdAddr, "store", "limit-scene", "idle", "200"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "limit-scene"}
 	scene = &storelimit.Scene{}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, scene)
 	c.Assert(err, IsNil)
@@ -304,11 +304,11 @@ func (s *storeTestSuite) TestStore(c *C) {
 
 	// store limit-scene <scene> <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit-scene", "idle", "100", "remove-peer"}
-	_, _, err = pdctl.ExecuteCommandC(cmd, args...)
+	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	args = []string{"-u", pdAddr, "store", "limit-scene", "remove-peer"}
 	scene = &storelimit.Scene{}
-	_, output, err = pdctl.ExecuteCommandC(cmd, args...)
+	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(output, scene)
 	c.Assert(err, IsNil)

--- a/tests/pdctl/tso/tso_test.go
+++ b/tests/pdctl/tso/tso_test.go
@@ -47,7 +47,7 @@ func (s *tsoTestSuite) TestTSO(c *C) {
 	// tso command
 	ts := "395181938313123110"
 	args := []string{"-u", "127.0.0.1", "tso", ts}
-	_, output, err := pdctl.ExecuteCommandC(cmd, args...)
+	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	t, e := strconv.ParseUint(ts, 10, 64)
 	c.Assert(e, IsNil)


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

### What problem does this PR solve?

Nobody is using the returned command struct. Remove it. It is equivalent according to https://github.com/spf13/cobra/blob/master/command.go#L899-L902.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- No code

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
