### PR TITLE
autoscaling/prometheus.go tidbSumCPUUsageMetricsPattern problem

### DIFF
--- a/pkg/autoscaling/prometheus.go
+++ b/pkg/autoscaling/prometheus.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	tikvSumCPUUsageMetricsPattern = `sum(increase(tikv_thread_cpu_seconds_total[%s])) by (instance, kubernetes_namespace)`
-	tidbSumCPUUsageMetricsPattern = `sum(increase(process_cpu_seconds_total{job="tidb"}[%s])) by (instance, kubernetes_namespace)`
+	tidbSumCPUUsageMetricsPattern = `sum(increase(process_cpu_seconds_total{component="tidb"}[%s])) by (instance, kubernetes_namespace)`
 	tikvCPUQuotaMetricsPattern    = `tikv_server_cpu_cores_quota`
 	tidbCPUQuotaMetricsPattern    = `tidb_server_maxprocs`
 	instanceLabelName             = "instance"


### PR DESCRIPTION

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
autoscaling about tidbSumCPUUsageMetricsPattern is wrong , result is empty.
![image](https://user-images.githubusercontent.com/79236369/108352361-b15bc200-7221-11eb-93a5-41efbf52d1a9.png)

### What is changed and how it works?
tidbSumCPUUsageMetricsPattern base on component="tidb",will return the correctt result
![image](https://user-images.githubusercontent.com/79236369/108352644-1ca59400-7222-11eb-9f26-849bd3e10e00.png)

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
