### PR TITLE
tso: fix the TSO reset bug after leader change

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -359,6 +359,7 @@ func (s *Server) startServer(ctx context.Context) error {
 		s.member, s.rootPath, s.cfg.TSOSaveInterval.Duration, s.cfg.TSOUpdatePhysicalInterval.Duration,
 		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() },
 		s.GetTLSConfig())
+	// Set up the Global TSO Allocator here, it will be initialized once the PD campaigns leader successfully.
 	s.tsoAllocatorManager.SetUpAllocator(ctx, tso.GlobalDCLocation, s.member.GetLeadership())
 	if zone, exist := s.cfg.Labels[config.ZoneLabel]; exist && zone != "" && s.cfg.EnableLocalTSO {
 		if err = s.tsoAllocatorManager.SetLocalTSOConfig(zone); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -1206,12 +1206,12 @@ func (s *Server) campaignLeader() {
 	go s.member.KeepLeader(ctx)
 	log.Info("campaign pd leader ok", zap.String("campaign-pd-leader-name", s.Name()))
 
-	log.Info("initializing the global TSO allocator")
 	alllocator, err := s.tsoAllocatorManager.GetAllocator(tso.GlobalDCLocation)
 	if err != nil {
 		log.Error("failed to get the global TSO allocator", errs.ZapError(err))
 		return
 	}
+	log.Info("initializing the global TSO allocator")
 	if err := alllocator.Initialize(0); err != nil {
 		log.Error("failed to initialize the global TSO allocator", errs.ZapError(err))
 		return

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -284,6 +284,7 @@ func CalSuffixBits(maxSuffix int32) int {
 }
 
 // SetUpAllocator is used to set up an allocator, which will initialize the allocator and put it into allocator daemon.
+// One TSO Allocator should only be set once, and may be initialized and reset multiple times depending on the election.
 func (am *AllocatorManager) SetUpAllocator(parentCtx context.Context, dcLocation string, leadership *election.Leadership) {
 	am.mu.Lock()
 	defer am.mu.Unlock()

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -290,7 +290,10 @@ func (am *AllocatorManager) SetUpAllocator(parentCtx context.Context, dcLocation
 		log.Warn("tso update physical interval is non-default",
 			zap.Duration("update-physical-interval", am.updatePhysicalInterval))
 	}
-	if _, exist := am.mu.allocatorGroups[dcLocation]; exist {
+	if ag, exist := am.mu.allocatorGroups[dcLocation]; exist {
+		// Since the parentCtx will change every time due to the different leader loops,
+		// we should update it here.
+		ag.parentCtx = parentCtx
 		return
 	}
 	var allocator Allocator

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -291,10 +291,7 @@ func (am *AllocatorManager) SetUpAllocator(parentCtx context.Context, dcLocation
 		log.Warn("tso update physical interval is non-default",
 			zap.Duration("update-physical-interval", am.updatePhysicalInterval))
 	}
-	if ag, exist := am.mu.allocatorGroups[dcLocation]; exist {
-		// Since the parentCtx will change every time due to the different leader loops,
-		// we should update it here.
-		ag.parentCtx = parentCtx
+	if _, exist := am.mu.allocatorGroups[dcLocation]; exist {
 		return
 	}
 	var allocator Allocator


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close #3423.

### What is changed and how it works?

If a PD leader resigns and becomes leader again, due to the old closed `parentCtx`, the Global TSO Allocator will be reset immediately. To fix this bug, we need to update the `parentCtx` every time we set up the Global TSO Allocator.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- - No release note -->
