### PR TITLE
config: provide instance-level config persistence

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -330,6 +330,8 @@ func (s *Server) startEtcd(ctx context.Context) error {
 		time.Sleep(1500 * time.Millisecond)
 	})
 	s.member = member.NewMember(etcd, client, etcdServerID)
+	// Init the instance options once we get the member ID
+	s.persistOptions.InitInstanceOptions(s.GetMember().ID(), s.cfg)
 	return nil
 }
 
@@ -359,7 +361,7 @@ func (s *Server) startServer(ctx context.Context) error {
 		s.member, s.rootPath, s.cfg.TSOSaveInterval.Duration, s.cfg.TSOUpdatePhysicalInterval.Duration,
 		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() },
 		s.GetTLSConfig())
-	if zone, exist := s.cfg.Labels[config.ZoneLabel]; exist && zone != "" && s.cfg.EnableLocalTSO {
+	if zone, exist := s.persistOptions.GetLabel(s.member.ID(), config.ZoneLabel); exist && zone != "" && s.persistOptions.GetEnableLocalTSOConfig(s.member.ID()) {
 		if err = s.tsoAllocatorManager.SetLocalTSOConfig(zone); err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close #3418.

### What is changed and how it works?

Provide instance-level config persistence feature for `labels` and `enable-local-tso` configs.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
