### PR TITLE
tests: fix error in TestGlobalAndLocalTSO

### DIFF
--- a/client/base_client.go
+++ b/client/base_client.go
@@ -146,13 +146,9 @@ func (c *baseClient) leaderLoop() {
 		case <-ctx.Done():
 			return
 		}
-		skipUpdateLeader := false
 		failpoint.Inject("skipUpdateLeader", func() {
-			skipUpdateLeader = true
+			failpoint.Continue()
 		})
-		if skipUpdateLeader {
-			continue
-		}
 		if err := c.updateLeader(); err != nil {
 			log.Error("[pd] failed updateLeader", errs.ZapError(err))
 		}

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -334,6 +334,8 @@ func (s *clientTestSuite) TestGlobalAndLocalTSO(c *C) {
 	c.Assert(err, NotNil)
 
 	// assert global tso after resign leader
+	c.Assert(failpoint.Enable("github.com/tikv/pd/client/skipUpdateLeader", `return(true)`), IsNil)
+	defer failpoint.Disable("github.com/tikv/pd/client/skipUpdateLeader")
 	err = cluster.ResignLeader()
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

ref https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/pd_test/detail/pd_test/19200/pipeline/

TestGlobalAndLocalTSO is not stable. This request fix it.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

* No release note