### PR TITLE
pd-server: log explanation of error instead of generic ErrParseFlags

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -55,7 +55,7 @@ func main() {
 	case flag.ErrHelp:
 		exit(0)
 	default:
-		log.Fatal("parse cmd flags error", errs.ZapError(errs.ErrParseFlags))
+		log.Fatal("parse cmd flags error", errs.ZapError(err))
 	}
 
 	if cfg.ConfigCheck {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Fixes #3445 
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Simply log the error returned by cfg.Parse() instead of substituting errs.ErrParseFlags.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
$ cat pd.toml
[schedule]
low-space-ratio = 0.01
```

Before:
```
$ ./bin/pd-server -config=./pd.toml
[2021/02/25 11:26:03.020 -08:00] [FATAL] [main.go:58] ["parse cmd flags error"] [error="[PD:main:ErrParseFlags]parse flags error"] [stack="github.com/pingcap/log.Fatal\n\t/Users/kolbe/Devel/go/pkg/mod/github.com/pingcap/log@v0.0.0-20201112100606-8f1e84a3abc8/global.go:59\nmain.main\n\t/Users/kolbe/Devel/git/pingcap/pd
/cmd/pd-server/main.go:58\nruntime.main\n\t/usr/local/Cellar/go/1.15.6/libexec/src/runtime/proc.go:204"]
```

After:
```
$ ./bin/pd-server -config=./pd.toml
[2021/02/25 11:30:59.343 -08:00] [FATAL] [main.go:58] ["parse cmd flags error"] [error="low-space-ratio should be larger than high-space-ratio"] [errorVerbose="low-space-ratio should be larger than high-space-ratio\ngithub.com/tikv/pd/server/config.(*ScheduleConfig).Validate\n\t/Users/kolbe/Devel/git/pingcap/pd/server
/config/config.go:914\ngithub.com/tikv/pd/server/config.(*ScheduleConfig).adjust\n\t/Users/kolbe/Devel/git/pingcap/pd/server/config/config.go:855\ngithub.com/tikv/pd/server/config.(*Config).Adjust\n\t/Users/kolbe/Devel/git/pingcap/pd/server/config/config.go:557\ngithub.com/tikv/pd/server/config.(*Config).Parse\n\t/Use
rs/kolbe/Devel/git/pingcap/pd/server/config/config.go:408\nmain.main\n\t/Users/kolbe/Devel/git/pingcap/pd/cmd/pd-server/main.go:44\nruntime.main\n\t/usr/local/Cellar/go/1.15.6/libexec/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/Cellar/go/1.15.6/libexec/src/runtime/asm_amd64.s:1374"] [stack="github.com/pingca
p/log.Fatal\n\t/Users/kolbe/Devel/go/pkg/mod/github.com/pingcap/log@v0.0.0-20201112100606-8f1e84a3abc8/global.go:59\nmain.main\n\t/Users/kolbe/Devel/git/pingcap/pd/cmd/pd-server/main.go:58\nruntime.main\n\t/usr/local/Cellar/go/1.15.6/libexec/src/runtime/proc.go:204"]
```

Code changes

- Has configuration change
- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

n/a

Related changes

n/a

### Release note

- No release note
