### PR TITLE
*: add retry mechanism for connecting leader

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -420,11 +420,7 @@ func (c *client) createTsoStream(ctx context.Context, cancel context.CancelFunc,
 	return stream, err
 }
 
-func (c *client) checkAllocator(dispatcherCtx context.Context, forwardCancel context.CancelFunc, dc, url string,
-	streamCh chan struct {
-		cancel context.CancelFunc
-		stream pdpb.PD_TsoClient
-	}, changedCh chan bool) {
+func (c *client) checkAllocator(dispatcherCtx context.Context, forwardCancel context.CancelFunc, dc, url string, streamCh streamCh, changedCh chan bool) {
 	defer func() {
 		// cancel the forward stream
 		forwardCancel()
@@ -492,22 +488,22 @@ func (c *client) createTSODispatcher(dcLocation string) {
 	c.tsoDispatcher.Store(dcLocation, dispatcher)
 }
 
+type streamCh chan struct {
+	cancel context.CancelFunc
+	stream pdpb.PD_TsoClient
+}
+
 func (c *client) handleDispatcher(dispatcherCtx context.Context, dc string, tsoDispatcher chan *tsoRequest) {
 	var (
-		err        error
-		cctx       context.Context
-		cancel     context.CancelFunc
-		stream     pdpb.PD_TsoClient
-		opts       []opentracing.StartSpanOption
-		requests   = make([]*tsoRequest, maxMergeTSORequests+1)
-		needUpdate = false
-		streamCh   chan struct {
-			cancel context.CancelFunc
-			stream pdpb.PD_TsoClient
-		}
-		changedCh chan bool
-		// the number of retrying to connect leader
-		retryTimes uint64
+		err           error
+		cancel        context.CancelFunc
+		stream        pdpb.PD_TsoClient
+		opts          []opentracing.StartSpanOption
+		requests      = make([]*tsoRequest, maxMergeTSORequests+1)
+		needUpdate    = false
+		streamCh      streamCh
+		changedCh     chan bool
+		connectionCtx connectionContext
 	)
 	defer func() {
 		log.Info("[pd] exit tso dispatcher", zap.String("dc-location", dc))
@@ -531,57 +527,11 @@ func (c *client) handleDispatcher(dispatcherCtx context.Context, dc string, tsoD
 				}
 				needUpdate = false
 			}
-			cc, url := c.getAllocatorClientConnByDCLocation(dc)
-			cctx, cancel = context.WithCancel(dispatcherCtx)
-			stream, err = c.createTsoStream(cctx, cancel, pdpb.NewPDClient(cc))
-			failpoint.Inject("unreachableNetwork", func() {
-				cancel()
-				stream = nil
-				err = status.New(codes.Unavailable, "unavailable").Err()
-			})
-			if err != nil && c.enableForwarding {
-				rpcErr, ok := status.FromError(err)
-				// encounter the network error
-				if ok && isNetworkError(rpcErr.Code()) {
-					retryTimes++
-					// retry several times before falling back to the follower when the network problem happens
-					if retryTimes >= maxRetryTimes {
-						// TODO: we need to choose the follower in the same dc with the leader.
-						followerClient, addr := c.followerClient()
-						if followerClient != nil {
-							log.Info("fall back to use follower to forward tso stream", zap.String("dc", dc), zap.String("addr", addr))
-							// create the follower stream
-							if addr, ok = c.getAllocatorLeaderAddrByDCLocation(dc); !ok {
-								cancel()
-								continue
-							}
-							cctx, cancel = context.WithCancel(dispatcherCtx)
-							cctx = grpcutil.BuildForwardContext(cctx, addr)
-							stream, err = c.createTsoStream(cctx, cancel, followerClient)
-							if err == nil {
-								streamCh = make(chan struct {
-									cancel context.CancelFunc
-									stream pdpb.PD_TsoClient
-								})
-								changedCh = make(chan bool)
-								// the goroutine is used to check the network and change back to the original stream
-								go c.checkAllocator(dispatcherCtx, cancel, dc, url, streamCh, changedCh)
-							}
-						}
-					} else {
-						// not reach the max retry time, sleep for a while and retry
-						time.Sleep(retryInterval)
-						cancel()
-						continue
-					}
-				}
-			}
 
-			if err == nil {
-				retryTimes = 0
-			}
+			connectionCtx, err = c.tryConnect(dispatcherCtx, dc)
+			stream, cancel, streamCh, changedCh = connectionCtx.stream, connectionCtx.cancel, connectionCtx.streamCh, connectionCtx.changeCh
 
-			if err != nil {
+			if err != nil || stream == nil {
 				select {
 				case <-dispatcherCtx.Done():
 					return
@@ -589,7 +539,6 @@ func (c *client) handleDispatcher(dispatcherCtx context.Context, dc string, tsoD
 				}
 				log.Error("[pd] create tso stream error", zap.String("dc-location", dc), errs.ZapError(errs.ErrClientCreateTSOStream, err))
 				c.ScheduleCheckLeader()
-				cancel()
 				c.revokeTSORequest(errors.WithStack(err), tsoDispatcher)
 				select {
 				case <-time.After(time.Second):
@@ -655,6 +604,76 @@ func (c *client) handleDispatcher(dispatcherCtx context.Context, dc string, tsoD
 			}
 		}
 	}
+}
+
+type connectionContext struct {
+	stream   pdpb.PD_TsoClient
+	cancel   context.CancelFunc
+	streamCh streamCh
+	changeCh chan bool
+}
+
+func (c *client) tryConnect(dispatcherCtx context.Context, dc string) (connectionContext, error) {
+	var (
+		url        string
+		networkErr uint64
+		err        error
+		cc         *grpc.ClientConn
+		stream     pdpb.PD_TsoClient
+	)
+	// retry several times before falling back to the follower when the network problem happens
+	for i := 0; i < maxRetryTimes; i++ {
+		cc, url = c.getAllocatorClientConnByDCLocation(dc)
+		cctx, cancel := context.WithCancel(dispatcherCtx)
+		stream, err = c.createTsoStream(cctx, cancel, pdpb.NewPDClient(cc))
+		failpoint.Inject("unreachableNetwork", func() {
+			stream = nil
+			err = status.New(codes.Unavailable, "unavailable").Err()
+		})
+		if stream != nil && err == nil {
+			return connectionContext{stream, cancel, nil, nil}, nil
+		}
+
+		if err != nil && c.enableForwarding {
+			if rpcErr, ok := status.FromError(err); ok && isNetworkError(rpcErr.Code()) {
+				networkErr++
+			}
+		}
+
+		cancel()
+		select {
+		case <-dispatcherCtx.Done():
+			return connectionContext{}, err
+		case <-time.After(retryInterval):
+		}
+	}
+
+	if networkErr == maxRetryTimes {
+		// encounter the network error
+		followerClient, addr := c.followerClient()
+		if followerClient != nil {
+			log.Info("fall back to use follower to forward tso stream", zap.String("dc", dc), zap.String("addr", addr))
+			target, ok := c.getAllocatorLeaderAddrByDCLocation(dc)
+			if !ok {
+				return connectionContext{}, errors.Errorf("cannot find the allocator leader in %s", dc)
+			}
+
+			// create the follower stream
+			cctx, cancel := context.WithCancel(dispatcherCtx)
+			cctx = grpcutil.BuildForwardContext(cctx, target)
+			stream, err1 := c.createTsoStream(cctx, cancel, followerClient)
+			if err1 == nil {
+				streamCh := make(streamCh)
+				changedCh := make(chan bool)
+				// the goroutine is used to check the network and change back to the original stream
+				go c.checkAllocator(dispatcherCtx, cancel, dc, url, streamCh, changedCh)
+				return connectionContext{stream, cancel, streamCh, changedCh}, nil
+			}
+			cancel()
+			return connectionContext{}, err1
+		}
+	}
+	return connectionContext{}, err
 }
 
 func extractSpanReference(requests []*tsoRequest, opts []opentracing.StartSpanOption) []opentracing.StartSpanOption {

--- a/client/client.go
+++ b/client/client.go
@@ -615,11 +615,11 @@ type connectionContext struct {
 
 func (c *client) tryConnect(dispatcherCtx context.Context, dc string) (connectionContext, error) {
 	var (
-		url        string
-		networkErr uint64
-		err        error
-		cc         *grpc.ClientConn
-		stream     pdpb.PD_TsoClient
+		url           string
+		networkErrNum uint64
+		err           error
+		cc            *grpc.ClientConn
+		stream        pdpb.PD_TsoClient
 	)
 	// retry several times before falling back to the follower when the network problem happens
 	for i := 0; i < maxRetryTimes; i++ {
@@ -636,7 +636,7 @@ func (c *client) tryConnect(dispatcherCtx context.Context, dc string) (connectio
 
 		if err != nil && c.enableForwarding {
 			if rpcErr, ok := status.FromError(err); ok && isNetworkError(rpcErr.Code()) {
-				networkErr++
+				networkErrNum++
 			}
 		}
 
@@ -648,7 +648,7 @@ func (c *client) tryConnect(dispatcherCtx context.Context, dc string) (connectio
 		}
 	}
 
-	if networkErr == maxRetryTimes {
+	if networkErrNum == maxRetryTimes {
 		// encounter the network error
 		followerClient, addr := c.followerClient()
 		if followerClient != nil {

--- a/pkg/grpcutil/grpcutil.go
+++ b/pkg/grpcutil/grpcutil.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"net/url"
 
+	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"go.etcd.io/etcd/pkg/transport"
 	"google.golang.org/grpc"
@@ -110,5 +111,14 @@ func GetClientConn(ctx context.Context, addr string, tlsCfg *tls.Config, do ...g
 // It is used in client side.
 func BuildForwardContext(ctx context.Context, addr string) context.Context {
 	md := metadata.Pairs(ForwardMetadataKey, addr)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func ResetForwardContext(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		log.Error("failed to get forwarding metadata")
+	}
+	md.Set(ForwardMetadataKey, "")
 	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/pkg/grpcutil/grpcutil.go
+++ b/pkg/grpcutil/grpcutil.go
@@ -114,6 +114,7 @@ func BuildForwardContext(ctx context.Context, addr string) context.Context {
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
+// ResetForwardContext is going to reset the forwarded host in metadata.
 func ResetForwardContext(ctx context.Context) context.Context {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -117,23 +117,23 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 			return errors.WithStack(err)
 		}
 
-		targetAddr := getTargetAddr(stream.Context())
-		if !s.isLocalRequest(targetAddr) {
-			if forwardStream == nil || lastReceiverAddr != targetAddr {
+		forwardedHost := getForwardedHost(stream.Context())
+		if !s.isLocalRequest(forwardedHost) {
+			if forwardStream == nil || lastReceiverAddr != forwardedHost {
 				if cancel != nil {
 					cancel()
 				}
-				client, err := s.getDelegateClient(s.ctx, targetAddr)
+				client, err := s.getDelegateClient(s.ctx, forwardedHost)
 				if err != nil {
 					return err
 				}
 				// TODO: change it to the info level once the TiKV doesn't use it in a unary way.
-				log.Debug("create TSO forward stream", zap.String("target-addr", targetAddr))
-				forwardStream, cancel, err = s.createTsoForwardStream(client, targetAddr)
+				log.Debug("create TSO forward stream", zap.String("forwarded-host", forwardedHost))
+				forwardStream, cancel, err = s.createTsoForwardStream(client, forwardedHost)
 				if err != nil {
 					return err
 				}
-				lastReceiverAddr = targetAddr
+				lastReceiverAddr = forwardedHost
 				errCh = make(chan error, 1)
 				go forwardTsoClientToServer(forwardStream, stream, errCh)
 			}
@@ -180,12 +180,13 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 
 // Bootstrap implements gRPC PDServer.
 func (s *Server) Bootstrap(ctx context.Context, request *pdpb.BootstrapRequest) (*pdpb.BootstrapResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).Bootstrap(ctx, request)
 	}
 
@@ -215,12 +216,13 @@ func (s *Server) Bootstrap(ctx context.Context, request *pdpb.BootstrapRequest) 
 
 // IsBootstrapped implements gRPC PDServer.
 func (s *Server) IsBootstrapped(ctx context.Context, request *pdpb.IsBootstrappedRequest) (*pdpb.IsBootstrappedResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).IsBootstrapped(ctx, request)
 	}
 
@@ -237,12 +239,13 @@ func (s *Server) IsBootstrapped(ctx context.Context, request *pdpb.IsBootstrappe
 
 // AllocID implements gRPC PDServer.
 func (s *Server) AllocID(ctx context.Context, request *pdpb.AllocIDRequest) (*pdpb.AllocIDResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).AllocID(ctx, request)
 	}
 
@@ -264,12 +267,13 @@ func (s *Server) AllocID(ctx context.Context, request *pdpb.AllocIDRequest) (*pd
 
 // GetStore implements gRPC PDServer.
 func (s *Server) GetStore(ctx context.Context, request *pdpb.GetStoreRequest) (*pdpb.GetStoreResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetStore(ctx, request)
 	}
 
@@ -311,12 +315,13 @@ func checkStore(rc *cluster.RaftCluster, storeID uint64) *pdpb.Error {
 
 // PutStore implements gRPC PDServer.
 func (s *Server) PutStore(ctx context.Context, request *pdpb.PutStoreRequest) (*pdpb.PutStoreResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).PutStore(ctx, request)
 	}
 
@@ -356,12 +361,13 @@ func (s *Server) PutStore(ctx context.Context, request *pdpb.PutStoreRequest) (*
 
 // GetAllStores implements gRPC PDServer.
 func (s *Server) GetAllStores(ctx context.Context, request *pdpb.GetAllStoresRequest) (*pdpb.GetAllStoresResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetAllStores(ctx, request)
 	}
 
@@ -397,12 +403,13 @@ func (s *Server) GetAllStores(ctx context.Context, request *pdpb.GetAllStoresReq
 
 // StoreHeartbeat implements gRPC PDServer.
 func (s *Server) StoreHeartbeat(ctx context.Context, request *pdpb.StoreHeartbeatRequest) (*pdpb.StoreHeartbeatResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).StoreHeartbeat(ctx, request)
 	}
 
@@ -515,22 +522,22 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 			return errors.WithStack(err)
 		}
 
-		targetAddr := getTargetAddr(stream.Context())
-		if !s.isLocalRequest(targetAddr) {
-			if forwardStream == nil || lastReceiverAddr != targetAddr {
+		forwardedHost := getForwardedHost(stream.Context())
+		if !s.isLocalRequest(forwardedHost) {
+			if forwardStream == nil || lastReceiverAddr != forwardedHost {
 				if cancel != nil {
 					cancel()
 				}
-				client, err := s.getDelegateClient(s.ctx, targetAddr)
+				client, err := s.getDelegateClient(s.ctx, forwardedHost)
 				if err != nil {
 					return err
 				}
-				log.Info("create region heartbeat forward stream", zap.String("target-addr", targetAddr))
-				forwardStream, cancel, err = s.createHeartbeatForwardStream(client, targetAddr)
+				log.Info("create region heartbeat forward stream", zap.String("forwarded-host", forwardedHost))
+				forwardStream, cancel, err = s.createHeartbeatForwardStream(client, forwardedHost)
 				if err != nil {
 					return err
 				}
-				lastReceiverAddr = targetAddr
+				lastReceiverAddr = forwardedHost
 				errCh = make(chan error, 1)
 				go forwardRegionHeartbeatClientToServer(forwardStream, server, errCh)
 			}
@@ -616,12 +623,13 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 
 // GetRegion implements gRPC PDServer.
 func (s *Server) GetRegion(ctx context.Context, request *pdpb.GetRegionRequest) (*pdpb.GetRegionResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetRegion(ctx, request)
 	}
 
@@ -648,12 +656,13 @@ func (s *Server) GetRegion(ctx context.Context, request *pdpb.GetRegionRequest) 
 
 // GetPrevRegion implements gRPC PDServer
 func (s *Server) GetPrevRegion(ctx context.Context, request *pdpb.GetRegionRequest) (*pdpb.GetRegionResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetPrevRegion(ctx, request)
 	}
 
@@ -681,12 +690,13 @@ func (s *Server) GetPrevRegion(ctx context.Context, request *pdpb.GetRegionReque
 
 // GetRegionByID implements gRPC PDServer.
 func (s *Server) GetRegionByID(ctx context.Context, request *pdpb.GetRegionByIDRequest) (*pdpb.GetRegionResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetRegionByID(ctx, request)
 	}
 
@@ -713,12 +723,13 @@ func (s *Server) GetRegionByID(ctx context.Context, request *pdpb.GetRegionByIDR
 
 // ScanRegions implements gRPC PDServer.
 func (s *Server) ScanRegions(ctx context.Context, request *pdpb.ScanRegionsRequest) (*pdpb.ScanRegionsResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).ScanRegions(ctx, request)
 	}
 
@@ -752,12 +763,13 @@ func (s *Server) ScanRegions(ctx context.Context, request *pdpb.ScanRegionsReque
 
 // AskSplit implements gRPC PDServer.
 func (s *Server) AskSplit(ctx context.Context, request *pdpb.AskSplitRequest) (*pdpb.AskSplitResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).AskSplit(ctx, request)
 	}
 
@@ -789,12 +801,13 @@ func (s *Server) AskSplit(ctx context.Context, request *pdpb.AskSplitRequest) (*
 
 // AskBatchSplit implements gRPC PDServer.
 func (s *Server) AskBatchSplit(ctx context.Context, request *pdpb.AskBatchSplitRequest) (*pdpb.AskBatchSplitResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).AskBatchSplit(ctx, request)
 	}
 
@@ -830,12 +843,13 @@ func (s *Server) AskBatchSplit(ctx context.Context, request *pdpb.AskBatchSplitR
 
 // ReportSplit implements gRPC PDServer.
 func (s *Server) ReportSplit(ctx context.Context, request *pdpb.ReportSplitRequest) (*pdpb.ReportSplitResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).ReportSplit(ctx, request)
 	}
 
@@ -859,12 +873,13 @@ func (s *Server) ReportSplit(ctx context.Context, request *pdpb.ReportSplitReque
 
 // ReportBatchSplit implements gRPC PDServer.
 func (s *Server) ReportBatchSplit(ctx context.Context, request *pdpb.ReportBatchSplitRequest) (*pdpb.ReportBatchSplitResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).ReportBatchSplit(ctx, request)
 	}
 
@@ -889,12 +904,13 @@ func (s *Server) ReportBatchSplit(ctx context.Context, request *pdpb.ReportBatch
 
 // GetClusterConfig implements gRPC PDServer.
 func (s *Server) GetClusterConfig(ctx context.Context, request *pdpb.GetClusterConfigRequest) (*pdpb.GetClusterConfigResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetClusterConfig(ctx, request)
 	}
 
@@ -914,12 +930,13 @@ func (s *Server) GetClusterConfig(ctx context.Context, request *pdpb.GetClusterC
 
 // PutClusterConfig implements gRPC PDServer.
 func (s *Server) PutClusterConfig(ctx context.Context, request *pdpb.PutClusterConfigRequest) (*pdpb.PutClusterConfigResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).PutClusterConfig(ctx, request)
 	}
 
@@ -945,12 +962,13 @@ func (s *Server) PutClusterConfig(ctx context.Context, request *pdpb.PutClusterC
 
 // ScatterRegion implements gRPC PDServer.
 func (s *Server) ScatterRegion(ctx context.Context, request *pdpb.ScatterRegionRequest) (*pdpb.ScatterRegionResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).ScatterRegion(ctx, request)
 	}
 
@@ -1016,12 +1034,13 @@ func (s *Server) ScatterRegion(ctx context.Context, request *pdpb.ScatterRegionR
 
 // GetGCSafePoint implements gRPC PDServer.
 func (s *Server) GetGCSafePoint(ctx context.Context, request *pdpb.GetGCSafePointRequest) (*pdpb.GetGCSafePointResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetGCSafePoint(ctx, request)
 	}
 
@@ -1055,12 +1074,13 @@ func (s *Server) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
 
 // UpdateGCSafePoint implements gRPC PDServer.
 func (s *Server) UpdateGCSafePoint(ctx context.Context, request *pdpb.UpdateGCSafePointRequest) (*pdpb.UpdateGCSafePointResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).UpdateGCSafePoint(ctx, request)
 	}
 
@@ -1105,12 +1125,13 @@ func (s *Server) UpdateServiceGCSafePoint(ctx context.Context, request *pdpb.Upd
 	s.serviceSafePointLock.Lock()
 	defer s.serviceSafePointLock.Unlock()
 
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).UpdateServiceGCSafePoint(ctx, request)
 	}
 
@@ -1173,12 +1194,13 @@ func (s *Server) UpdateServiceGCSafePoint(ctx context.Context, request *pdpb.Upd
 
 // GetOperator gets information about the operator belonging to the specify region.
 func (s *Server) GetOperator(ctx context.Context, request *pdpb.GetOperatorRequest) (*pdpb.GetOperatorResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetOperator(ctx, request)
 	}
 
@@ -1258,12 +1280,13 @@ func (s *Server) incompatibleVersion(tag string) *pdpb.ResponseHeader {
 //    with its current TSO in memory to make sure their local TSOs are not less
 //    than MaxTS by writing MaxTS into memory to finish the global TSO synchronization.
 func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) (*pdpb.SyncMaxTSResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).SyncMaxTS(ctx, request)
 	}
 
@@ -1323,12 +1346,13 @@ func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) 
 
 // SplitRegions split regions by the given split keys
 func (s *Server) SplitRegions(ctx context.Context, request *pdpb.SplitRegionsRequest) (*pdpb.SplitRegionsResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).SplitRegions(ctx, request)
 	}
 
@@ -1346,12 +1370,13 @@ func (s *Server) SplitRegions(ctx context.Context, request *pdpb.SplitRegionsReq
 // GetDCLocationInfo gets the dc-location info of the given dc-location from PD leader's TSO allocator manager, and will collect current max
 // Local TSO if the NeedSyncMaxTSO flag in dc-location info is true.
 func (s *Server) GetDCLocationInfo(ctx context.Context, request *pdpb.GetDCLocationInfoRequest) (*pdpb.GetDCLocationInfoResponse, error) {
-	targetAddr := getTargetAddr(ctx)
-	if !s.isLocalRequest(targetAddr) {
-		client, err := s.getDelegateClient(ctx, targetAddr)
+	forwardedHost := getForwardedHost(ctx)
+	if !s.isLocalRequest(forwardedHost) {
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
+		ctx = grpcutil.ResetForwardContext(ctx)
 		return pdpb.NewPDClient(client).GetDCLocationInfo(ctx, request)
 	}
 
@@ -1402,27 +1427,27 @@ func (s *Server) validateInternalRequest(header *pdpb.RequestHeader, onlyAllowLe
 	return nil
 }
 
-func (s *Server) getDelegateClient(ctx context.Context, targetAddr string) (*grpc.ClientConn, error) {
-	client, ok := s.clientConns.Load(targetAddr)
+func (s *Server) getDelegateClient(ctx context.Context, forwardedHost string) (*grpc.ClientConn, error) {
+	client, ok := s.clientConns.Load(forwardedHost)
 	if !ok {
 		tlsConfig, err := s.GetTLSConfig().ToTLSConfig()
 		if err != nil {
 			return nil, err
 		}
-		cc, err := grpcutil.GetClientConn(ctx, targetAddr, tlsConfig)
+		cc, err := grpcutil.GetClientConn(ctx, forwardedHost, tlsConfig)
 		if err != nil {
 			return nil, err
 		}
 		client = cc
-		s.clientConns.Store(targetAddr, cc)
+		s.clientConns.Store(forwardedHost, cc)
 	}
 	return client.(*grpc.ClientConn), nil
 }
 
-func getTargetAddr(ctx context.Context) string {
+func getForwardedHost(ctx context.Context) string {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		log.Info("get metadata error")
+		log.Error("failed to get forwarding metadata")
 	}
 	if t, ok := md[grpcutil.ForwardMetadataKey]; ok {
 		return t[0]
@@ -1430,13 +1455,13 @@ func getTargetAddr(ctx context.Context) string {
 	return ""
 }
 
-func (s *Server) isLocalRequest(targetAddr string) bool {
-	if targetAddr == "" {
+func (s *Server) isLocalRequest(forwardedHost string) bool {
+	if forwardedHost == "" {
 		return true
 	}
 	memberAddrs := s.GetMember().Member().GetClientUrls()
 	for _, addr := range memberAddrs {
-		if addr == targetAddr {
+		if addr == forwardedHost {
 			return true
 		}
 	}
@@ -1446,7 +1471,6 @@ func (s *Server) isLocalRequest(targetAddr string) bool {
 func (s *Server) createTsoForwardStream(client *grpc.ClientConn, addr string) (pdpb.PD_TsoClient, context.CancelFunc, error) {
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(s.ctx)
-	ctx = grpcutil.BuildForwardContext(ctx, addr)
 	go checkStream(ctx, cancel, done)
 	forwardStream, err := pdpb.NewPDClient(client).Tso(ctx)
 	done <- struct{}{}
@@ -1471,7 +1495,6 @@ func forwardTsoClientToServer(forwardStream pdpb.PD_TsoClient, stream pdpb.PD_Ts
 func (s *Server) createHeartbeatForwardStream(client *grpc.ClientConn, addr string) (pdpb.PD_RegionHeartbeatClient, context.CancelFunc, error) {
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(s.ctx)
-	ctx = grpcutil.BuildForwardContext(ctx, addr)
 	go checkStream(ctx, cancel, done)
 	forwardStream, err := pdpb.NewPDClient(client).RegionHeartbeat(ctx)
 	done <- struct{}{}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -127,7 +127,8 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 				if err != nil {
 					return err
 				}
-				log.Info("create TSO forward stream", zap.String("target-addr", targetAddr))
+				// TODO: change it to the info level once the TiKV doesn't use it in a unary way.
+				log.Debug("create TSO forward stream", zap.String("target-addr", targetAddr))
 				forwardStream, cancel, err = s.createTsoForwardStream(client, targetAddr)
 				if err != nil {
 					return err

--- a/tests/server/tso/global_tso_test.go
+++ b/tests/server/tso/global_tso_test.go
@@ -521,8 +521,8 @@ func (s *testSynchronizedGlobalTSO) testGetTimestamp(ctx context.Context, c *C, 
 	}
 	pdClient, ok := s.dcClientMap[dcLocation]
 	c.Assert(ok, IsTrue)
-	targetAddr := cluster.GetServer(s.leaderServer.GetAllocatorLeader(dcLocation).GetName()).GetAddr()
-	ctx = grpcutil.BuildForwardContext(ctx, targetAddr)
+	forwardedHost := cluster.GetServer(s.leaderServer.GetAllocatorLeader(dcLocation).GetName()).GetAddr()
+	ctx = grpcutil.BuildForwardContext(ctx, forwardedHost)
 	tsoClient, err := pdClient.Tso(ctx)
 	c.Assert(err, IsNil)
 	defer tsoClient.CloseSend()


### PR DESCRIPTION
### What problem does this PR solve?

We need to retry several times when the leader connection is failed to avoid unnecessary forwarding.
BTW, since TiKV uses TSO stream in a unary way, it will print lots of logs in the follower which is responsible to forward the requests when there is a network problem.

### What is changed and how it works?

This PR adds the retry mechanism for connecting the leader when there is a network problem and changes TSO stream log to debug level. 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

- Add the retry mechanism for connecting leader and change the noisy log to debug level
