### PR TITLE
schedule: fix panic during hot schedule

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -732,7 +732,6 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 	if srcStore == nil {
 		return nil
 	}
-
 	switch bs.opTy {
 	case movePeer:
 		filters = []filter.Filter{
@@ -742,7 +741,9 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 			filter.NewPlacementSafeguard(bs.sche.GetName(), bs.cluster, bs.cur.region, srcStore),
 		}
 
-		candidates = bs.cluster.GetStores()
+		for storeID := range bs.stLoadDetail {
+			candidates = append(candidates, bs.cluster.GetStore(storeID))
+		}
 
 	case transferLeader:
 		filters = []filter.Filter{
@@ -753,7 +754,15 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 			filters = append(filters, leaderFilter)
 		}
 
-		candidates = bs.cluster.GetFollowerStores(bs.cur.region)
+		regionStores := make(map[uint64]*core.StoreInfo, 0)
+		for _, store := range bs.cluster.GetFollowerStores(bs.cur.region) {
+			regionStores[store.GetID()] = store
+		}
+		for storeID := range bs.stLoadDetail {
+			if store, ok := regionStores[storeID]; ok {
+				candidates = append(candidates, store)
+			}
+		}
 
 	default:
 		return nil

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -754,12 +754,8 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*storeLoadDetail {
 			filters = append(filters, leaderFilter)
 		}
 
-		regionStores := make(map[uint64]*core.StoreInfo, 0)
 		for _, store := range bs.cluster.GetFollowerStores(bs.cur.region) {
-			regionStores[store.GetID()] = store
-		}
-		for storeID := range bs.stLoadDetail {
-			if store, ok := regionStores[storeID]; ok {
+			if _, ok := bs.stLoadDetail[store.GetID()]; ok {
 				candidates = append(candidates, store)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

`hot-region` scheduler may cause PD panic in the following order:

1.  load `storesLoads` before hot region scheduling
```golang
	storesLoads := cluster.GetStoresLoads()
```
2. receive new `PutStore` request
```golang
// put Store in grpc_service.go
if err := rc.PutStore(store); err != nil {
	return nil, status.Errorf(codes.Unknown, err.Error())
}
```
3. select candidates from `raft.cluster`
```golang
candidates = bs.cluster.GetStores()
```

This will cause make `pickDstStores` panic in following code because `stLoadDetail` didn't have the storeID which candidates hold as it was newly put before.
```golang
detail := bs.stLoadDetail[store.GetID()]
```


<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Make the candidates should be searched from `stLoadDetail` during hot region schedule

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

* No release note