### PR TITLE
schedule: fix the bug that the joint state checker cannot fix the region containing offline-peer

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -466,6 +466,11 @@ error = '''
 failed to unmarshal proto
 '''
 
+["PD:schedule:ErrCreateOperator"]
+error = '''
+unable to create operator, %s
+'''
+
 ["PD:schedule:ErrMergeOperator"]
 error = '''
 merge operator error, %s

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -73,6 +73,7 @@ var (
 	ErrUnexpectedOperatorStatus = errors.Normalize("operator with unexpected status", errors.RFCCodeText("PD:schedule:ErrUnexpectedOperatorStatus"))
 	ErrUnknownOperatorStep      = errors.Normalize("unknown operator step found", errors.RFCCodeText("PD:schedule:ErrUnknownOperatorStep"))
 	ErrMergeOperator            = errors.Normalize("merge operator error, %s", errors.RFCCodeText("PD:schedule:ErrMergeOperator"))
+	ErrCreateOperator           = errors.Normalize("unable to create operator, %s", errors.RFCCodeText("PD:schedule:ErrCreateOperator"))
 )
 
 // scheduler errors

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -537,7 +537,7 @@ func (b *Builder) setTargetLeaderIfNotExist() {
 
 	for _, targetLeaderStoreID := range b.targetPeers.IDs() {
 		peer := b.targetPeers[targetLeaderStoreID]
-		if !b.allowLeader(peer, false) {
+		if !b.allowLeader(peer, b.forceTargetLeader) {
 			continue
 		}
 		// if role info is given, store having role follower should not be target leader.

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -50,14 +50,14 @@ func CreateRemovePeerOperator(desc string, cluster opt.Cluster, kind OpKind, reg
 
 // CreateTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store.
 func CreateTransferLeaderOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+	return NewBuilder(desc, cluster, region, SkipOriginJointStateCheck).
 		SetLeader(targetStoreID).
 		Build(kind)
 }
 
 // CreateForceTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store forcible.
 func CreateForceTransferLeaderOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+	return NewBuilder(desc, cluster, region, SkipOriginJointStateCheck).
 		SetLeader(targetStoreID).
 		EnableForceTargetLeader().
 		Build(kind)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

close #3494 

### What is changed and how it works?

* operator: allow the joint state region to create `transfer-leader` operator
* operator: force to find the target leader, when creating the leave joint state operator

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- fix the bug that the `joint-state-checker` cannot fix the region containing `offline-peer`
