### PR TITLE
movingaverage: support concurrency safe queue in AvgOverTime

### DIFF
--- a/pkg/movingaverage/avg_over_time.go
+++ b/pkg/movingaverage/avg_over_time.go
@@ -15,8 +15,6 @@ package movingaverage
 
 import (
 	"time"
-
-	"github.com/phf/go-queue/queue"
 )
 
 type deltaWithInterval struct {
@@ -30,7 +28,7 @@ type deltaWithInterval struct {
 // stores recent changes that happened in the last avgInterval,
 // then calculates the change rate by (sum of changes) / (sum of intervals).
 type AvgOverTime struct {
-	que         *queue.Queue      // The element is `deltaWithInterval`, sum of all elements' interval is less than `avgInterval`
+	que         *SafeQueue        // The element is `deltaWithInterval`, sum of all elements' interval is less than `avgInterval`
 	margin      deltaWithInterval // The last element from `PopFront` in `que`
 	deltaSum    float64           // Including `margin` and all elements in `que`
 	intervalSum time.Duration     // Including `margin` and all elements in `que`
@@ -40,7 +38,7 @@ type AvgOverTime struct {
 // NewAvgOverTime returns an AvgOverTime with given interval.
 func NewAvgOverTime(interval time.Duration) *AvgOverTime {
 	return &AvgOverTime{
-		que: queue.New(),
+		que: NewSafeQueue(),
 		margin: deltaWithInterval{
 			delta:    0,
 			interval: 0,

--- a/pkg/movingaverage/avg_over_time.go
+++ b/pkg/movingaverage/avg_over_time.go
@@ -15,6 +15,8 @@ package movingaverage
 
 import (
 	"time"
+
+	"github.com/phf/go-queue/queue"
 )
 
 type deltaWithInterval struct {
@@ -28,7 +30,7 @@ type deltaWithInterval struct {
 // stores recent changes that happened in the last avgInterval,
 // then calculates the change rate by (sum of changes) / (sum of intervals).
 type AvgOverTime struct {
-	que         *SafeQueue        // The element is `deltaWithInterval`, sum of all elements' interval is less than `avgInterval`
+	que         *queue.Queue      // The element is `deltaWithInterval`, sum of all elements' interval is less than `avgInterval`
 	margin      deltaWithInterval // The last element from `PopFront` in `que`
 	deltaSum    float64           // Including `margin` and all elements in `que`
 	intervalSum time.Duration     // Including `margin` and all elements in `que`
@@ -38,7 +40,7 @@ type AvgOverTime struct {
 // NewAvgOverTime returns an AvgOverTime with given interval.
 func NewAvgOverTime(interval time.Duration) *AvgOverTime {
 	return &AvgOverTime{
-		que: NewSafeQueue(),
+		que: queue.New(),
 		margin: deltaWithInterval{
 			delta:    0,
 			interval: 0,

--- a/pkg/movingaverage/queue.go
+++ b/pkg/movingaverage/queue.go
@@ -1,4 +1,4 @@
-// Copyright 2020 TiKV Project Authors.
+// Copyright 2021 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/movingaverage/queue.go
+++ b/pkg/movingaverage/queue.go
@@ -1,0 +1,54 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package movingaverage
+
+import (
+	"sync"
+
+	"github.com/phf/go-queue/queue"
+)
+
+// SafeQueue is a concurrency safe queue
+type SafeQueue struct {
+	mu  sync.Mutex
+	que *queue.Queue
+}
+
+// NewSafeQueue return a SafeQueue
+func NewSafeQueue() *SafeQueue {
+	sq := &SafeQueue{}
+	sq.que = queue.New()
+	return sq
+}
+
+// Init implement init
+func (sq *SafeQueue) Init() {
+	sq.mu.Lock()
+	defer sq.mu.Unlock()
+	sq.que.Init()
+}
+
+// PushBack implement PushBack
+func (sq *SafeQueue) PushBack(v interface{}) {
+	sq.mu.Lock()
+	defer sq.mu.Unlock()
+	sq.que.PushBack(v)
+}
+
+// PopFront implement PopFront
+func (sq *SafeQueue) PopFront() interface{} {
+	sq.mu.Lock()
+	defer sq.mu.Unlock()
+	return sq.que.PopFront()
+}

--- a/pkg/movingaverage/queue_test.go
+++ b/pkg/movingaverage/queue_test.go
@@ -1,0 +1,28 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package movingaverage
+
+import (
+	. "github.com/pingcap/check"
+)
+
+func (t *testMovingAvg) TestQueue(c *C) {
+	sq := NewSafeQueue()
+	sq.PushBack(1)
+	sq.PushBack(2)
+	v1 := sq.PopFront()
+	v2 := sq.PopFront()
+	c.Assert(1, Equals, v1.(int))
+	c.Assert(2, Equals, v2.(int))
+}

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -269,3 +269,10 @@ func WithReplacePeerStore(oldStoreID, newStoreID uint64) RegionCreateOption {
 		}
 	}
 }
+
+// WithInterval sets the interval
+func WithInterval(interval *pdpb.TimeInterval) RegionCreateOption {
+	return func(region *RegionInfo) {
+		region.interval = interval
+	}
+}


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What is changed and how it works?
support concurrency safe queue in AvgOverTime


### Check list

Benchmark Test with concurrency queue
```sh
$ go test -bench=BenchmarkCheckRegionFlow -benchtime=10s                                                     
OK: 11 passed
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/statistics
BenchmarkCheckRegionFlow-4       5084605              1996 ns/op
PASS
ok      github.com/tikv/pd/server/statistics    13.584s
```

Benchmark Test with origin queue
```sh
$ go test -bench=BenchmarkCheckRegionFlow -benchtime=10s
OK: 11 passed
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/statistics
BenchmarkCheckRegionFlow-4       6700020              1814 ns/op
PASS
ok      github.com/tikv/pd/server/statistics    15.019s
```

### Release note

* No release note