### PR TITLE
schdueler: fix unstable transfer leader in hot scheduler and add some log

### DIFF
--- a/server/statistics/hot_peer.go
+++ b/server/statistics/hot_peer.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/tikv/pd/pkg/movingaverage"
+	"go.uber.org/zap"
 )
 
 const (
@@ -112,6 +113,31 @@ func (stat *HotPeerStat) Less(k int, than TopNItem) bool {
 	default:
 		return stat.GetByteRate() < rhs.GetByteRate()
 	}
+}
+
+// Log is used to output some info
+func (stat *HotPeerStat) Log(str string, level func(msg string, fields ...zap.Field)) {
+	level(str,
+		zap.Uint64("interval", stat.interval),
+		zap.Uint64("region-id", stat.RegionID),
+		zap.Uint64("store", stat.StoreID),
+		zap.Float64("byte-rate", stat.GetByteRate()),
+		zap.Float64("byte-rate-instant", stat.ByteRate),
+		zap.Float64("byte-rate-threshold", stat.thresholds[byteDim]),
+		zap.Float64("key-rate", stat.GetKeyRate()),
+		zap.Float64("key-rate-instant", stat.KeyRate),
+		zap.Float64("key-rate-threshold", stat.thresholds[keyDim]),
+		zap.Int("hot-degree", stat.HotDegree),
+		zap.Int("hot-anti-count", stat.AntiCount),
+		zap.Bool("just-transfer-leader", stat.justTransferLeader),
+		zap.Bool("is-leader", stat.isLeader),
+		zap.Bool("need-delete", stat.IsNeedDelete()),
+		zap.String("type", stat.Kind.String()))
+}
+
+// IsJustTransferLeader indicates the item belong to the leader.
+func (stat *HotPeerStat) IsJustTransferLeader() bool {
+	return stat.justTransferLeader
 }
 
 // IsNeedDelete to delete the item in cache.

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -94,6 +94,7 @@ func (f *hotPeerCache) Update(item *HotPeerStat) {
 		if stores, ok := f.storesOfRegion[item.RegionID]; ok {
 			delete(stores, item.StoreID)
 		}
+		item.Log("region heartbeat delete from cache", log.Debug)
 	} else {
 		peers, ok := f.peersOfStore[item.StoreID]
 		if !ok {
@@ -108,6 +109,7 @@ func (f *hotPeerCache) Update(item *HotPeerStat) {
 			f.storesOfRegion[item.RegionID] = stores
 		}
 		stores[item.StoreID] = struct{}{}
+		item.Log("region heartbeat update", log.Debug)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

To close #3504

### What is changed and how it works?

This pr will skip the region which just transfer leader in `filterHotPeer`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
Before 
![image](https://user-images.githubusercontent.com/19542290/112109982-39e8cc00-8bed-11eb-9a81-39ea1031e019.png)

- Manual test (add detailed scripts or steps below)

#### Test 1

repeat test in #3504 and hot region is stable
![image](https://user-images.githubusercontent.com/19542290/112100337-f2a80e80-8bdf-11eb-9cf1-63010350e029.png)

#### Test 2

Enable Load base split and those new regions can be scheduled.
![image](https://user-images.githubusercontent.com/19542290/112100465-1ff4bc80-8be0-11eb-8e04-53724c4fea30.png)



Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note 
