### PR TITLE
Feature/low space radio

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -339,7 +339,7 @@ func (s *StoreInfo) AvailableRatio() float64 {
 }
 
 // IsLowSpace checks if the store is lack of space. not check if region count less
-// than initialMaxRegionCounts and available space  more than minimumSpace
+// than initialMaxRegionCounts and available space more than minimumSpace
 func (s *StoreInfo) IsLowSpace(lowSpaceRatio float64) bool {
 	if s.GetStoreStats() == nil {
 		return false

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -28,9 +28,12 @@ import (
 
 const (
 	// Interval to save store meta (including heartbeat ts) to etcd.
-	storePersistInterval = 5 * time.Minute
-	mb                   = 1 << 20 // megabyte
-	gb                   = 1 << 30
+	storePersistInterval   = 5 * time.Minute
+	mb                     = 1 << 20 // megabyte
+	gb                     = 1 << 30
+	initialMaxRegionCounts = 30          // exclude storage Threshold Filter when region less than 30 regions
+	minimumSpace           = 10737418240 // 10GB
+
 )
 
 // StoreInfo contains information about a store.
@@ -337,7 +340,13 @@ func (s *StoreInfo) AvailableRatio() float64 {
 
 // IsLowSpace checks if the store is lack of space.
 func (s *StoreInfo) IsLowSpace(lowSpaceRatio float64) bool {
-	return s.GetStoreStats() != nil && s.AvailableRatio() < 1-lowSpaceRatio
+	if s.GetStoreStats() == nil {
+		return false
+	}
+	if s.regionCount < initialMaxRegionCounts && s.GetAvailable() > minimumSpace {
+		return false
+	}
+	return s.AvailableRatio() < 1-lowSpaceRatio
 }
 
 // ResourceCount returns count of leader/region in the store.

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -338,7 +338,8 @@ func (s *StoreInfo) AvailableRatio() float64 {
 	return float64(s.GetAvailable()) / float64(s.GetCapacity())
 }
 
-// IsLowSpace checks if the store is lack of space.
+// IsLowSpace checks if the store is lack of space. not check if region count less
+// than initialMaxRegionCounts and available space  more than minimumSpace
 func (s *StoreInfo) IsLowSpace(lowSpaceRatio float64) bool {
 	if s.GetStoreStats() == nil {
 		return false


### PR DESCRIPTION
What problem does this PR solve?
Fix #3444

What is changed and how it works?
The bug was introduced by #3444
when TIDB deploy, the system will create 21 regions , pd can not replicate regions because of disk available radio . we hope the new system should work well even if the disk available radio do not satisfy the restriction。 so I modify the IsLowSpace's method, when the disk space exceed than 10G and the region count less than 30, pd should replicate

Check List
Tests

Unit test
Code changes

Related changes

Need to cherry-pick to the release branch
Release note
 -  No release note

