### PR TITLE
metrics: let tso processing time not include consumption on the network

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -169,6 +169,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		if elapsed > slowThreshold {
 			log.Warn("get timestamp too slow", zap.Duration("cost", elapsed))
 		}
+		tsoHandleDuration.Observe(time.Since(start).Seconds())
 		response := &pdpb.TsoResponse{
 			Header:    s.header(),
 			Timestamp: &ts,
@@ -177,7 +178,6 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 		if err := stream.Send(response); err != nil {
 			return errors.WithStack(err)
 		}
-		tsoHandleDuration.Observe(time.Since(start).Seconds())
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Sometimes we see the handle tso duration is high in the PD side, which usually caused by the network.
![image](https://user-images.githubusercontent.com/6428910/112428964-f621ce00-8d76-11eb-8275-8c0f2cdda693.png)

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
 - metrics: let tso processing time not include consumption on the network
