### PR TITLE
*: let location-labels works if only exist the default rule

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -846,21 +846,35 @@ func (s *Server) SetReplicationConfig(cfg config.ReplicationConfig) error {
 	var rule *placement.Rule
 	if cfg.EnablePlacementRules {
 		// replication.MaxReplicas won't work when placement rule is enabled and not only have one default rule.
-		if cfg.MaxReplicas != old.MaxReplicas {
-			rules := s.GetRaftCluster().GetRuleManager().GetAllRules()
-			if !(len(rules) == 1 && len(rules[0].StartKey) == 0 && len(rules[0].EndKey) == 0) {
-				return errors.New("cannot update MaxReplicas when placement rules feature is enabled and not only default rule exists, please update rule instead")
+		rules := s.GetRaftCluster().GetRuleManager().GetAllRules()
+
+		CheckInDefaultRule := func() error {
+			// replication config  won't work when placement rule is enabled and exceeds one default rule
+			if !(len(rules) == 1 &&
+				len(rules[0].StartKey) == 0 && len(rules[0].EndKey) == 0 &&
+				rules[0].GroupID == "pd" && rules[0].ID == "default") {
+				return errors.New("cannot update MaxReplicas or LocationLabels when placement rules feature is enabled and not only default rule exists, please update rule instead")
 			}
 			rule = rules[0]
+			if !(rule.Count == int(old.MaxReplicas) && reflect.DeepEqual(rule.LocationLabels, []string(old.LocationLabels))) {
+				fmt.Println(rule.Count, old.MaxReplicas, old.LocationLabels, rule.LocationLabels)
+				return errors.New("cannot to update replication config, the default rules do not consistent with replication config, please update rule instead")
+			}
+
+			return nil
 		}
-		// replication.LocationLabels won't work when placement rule is enabled
-		if !reflect.DeepEqual(cfg.LocationLabels, old.LocationLabels) {
-			return errors.New("cannot update LocationLabels when placement rules feature is enabled, please update rule instead")
+
+		if !(cfg.MaxReplicas == old.MaxReplicas && reflect.DeepEqual(cfg.LocationLabels, old.LocationLabels)) {
+			if err := CheckInDefaultRule(); err != nil {
+				return err
+			}
+			rule = rules[0]
 		}
 	}
 
 	if rule != nil {
 		rule.Count = int(cfg.MaxReplicas)
+		rule.LocationLabels = cfg.LocationLabels
 		if err := s.GetRaftCluster().GetRuleManager().SetRule(rule); err != nil {
 			log.Error("failed to update rule count",
 				errs.ZapError(err))

--- a/server/server.go
+++ b/server/server.go
@@ -857,7 +857,6 @@ func (s *Server) SetReplicationConfig(cfg config.ReplicationConfig) error {
 			}
 			rule = rules[0]
 			if !(rule.Count == int(old.MaxReplicas) && reflect.DeepEqual(rule.LocationLabels, []string(old.LocationLabels))) {
-				fmt.Println(rule.Count, old.MaxReplicas, old.LocationLabels, rule.LocationLabels)
 				return errors.New("cannot to update replication config, the default rules do not consistent with replication config, please update rule instead")
 			}
 

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -393,10 +393,6 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
-	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "location-labels", "dc,rack")
-	c.Assert(err, IsNil)
-	c.Assert(strings.Contains(string(output), "please update rule instead"), IsTrue)
-
 	// test get
 	var bundle placement.GroupBundle
 	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-bundle", "get", "pd")

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -564,7 +564,7 @@ func (s *configTestSuite) TestReplicationMode(c *C) {
 	check()
 }
 
-func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
+func (s *configTestSuite) TestUpdateDefaultReplicaConfig(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cluster, err := tests.NewTestCluster(ctx, 1)
@@ -594,6 +594,15 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 		c.Assert(replicationCfg.MaxReplicas, Equals, expect)
 	}
 
+	checkLocaltionLabels := func(expect int) {
+		args := []string{"-u", pdAddr, "config", "show", "replication"}
+		output, err := pdctl.ExecuteCommand(cmd, args...)
+		c.Assert(err, IsNil)
+		replicationCfg := config.ReplicationConfig{}
+		c.Assert(json.Unmarshal(output, &replicationCfg), IsNil)
+		c.Assert(len(replicationCfg.LocationLabels), Equals, expect)
+	}
+
 	checkRuleCount := func(expect int) {
 		args := []string{"-u", pdAddr, "config", "placement-rules", "show", "--group", "pd", "--id", "default"}
 		output, err := pdctl.ExecuteCommand(cmd, args...)
@@ -603,11 +612,25 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 		c.Assert(rule.Count, Equals, expect)
 	}
 
+	checkRuleLocationLabels := func(expect int) {
+		args := []string{"-u", pdAddr, "config", "placement-rules", "show", "--group", "pd", "--id", "default"}
+		output, err := pdctl.ExecuteCommand(cmd, args...)
+		c.Assert(err, IsNil)
+		rule := placement.Rule{}
+		c.Assert(json.Unmarshal(output, &rule), IsNil)
+		c.Assert(len(rule.LocationLabels), Equals, expect)
+	}
+
 	// update successfully when placement rules is not enabled.
 	output, err := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "2")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 	checkMaxReplicas(2)
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "location-labels", "zone,host")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
+	checkLocaltionLabels(2)
+	checkRuleLocationLabels(2)
 
 	// update successfully when only one default rule exists.
 	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
@@ -619,6 +642,12 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 	checkMaxReplicas(3)
 	checkRuleCount(3)
+
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "location-labels", "host")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
+	checkLocaltionLabels(1)
+	checkRuleLocationLabels(1)
 
 	// update unsuccessfully when many rule exists.
 	f, _ := ioutil.TempFile("/tmp", "pd_tests")
@@ -649,4 +678,6 @@ func (s *configTestSuite) TestUpdateMaxReplicas(c *C) {
 	c.Assert(strings.Contains(string(output), "please update rule instead"), IsTrue)
 	checkMaxReplicas(3)
 	checkRuleCount(3)
+	checkLocaltionLabels(1)
+	checkRuleLocationLabels(1)
 }


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Compatible with 4.0 default behavior，the default config can set with :
```
config set max-replicas xxx
config set location-labels xxx,xxx
```
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
