### PR TITLE
cherry pick #3451 to release-4.0

### DIFF
--- a/pkg/typeutil/comparison.go
+++ b/pkg/typeutil/comparison.go
@@ -1,0 +1,24 @@
+// Copyright 2016 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import "time"
+
+// MinDuration returns the min value between two variables whose type are time.Duration.
+func MinDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -75,7 +75,7 @@ func newCoordinator(ctx context.Context, cluster *RaftCluster, hbStreams opt.Hea
 		cancel:          cancel,
 		cluster:         cluster,
 		checkers:        schedule.NewCheckerController(ctx, cluster, cluster.ruleManager, opController),
-		regionScatterer: schedule.NewRegionScatterer(cluster),
+		regionScatterer: schedule.NewRegionScatterer(ctx, cluster),
 		schedulers:      make(map[string]*scheduleController),
 		opController:    opController,
 		hbStreams:       hbStreams,

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -408,6 +408,8 @@ type StoreStateFilter struct {
 	TransferLeader bool
 	// Set true if the schedule involves any move region operation.
 	MoveRegion bool
+	// Set true if the scatter move the region
+	ScatterRegion bool
 	// Reason is used to distinguish the reason of store state filter
 	Reason string
 }
@@ -485,6 +487,10 @@ func (f StoreStateFilter) Target(opts opt.Options, store *core.StoreInfo) bool {
 			f.Reason = "reject-leader"
 			return false
 		}
+	}
+
+	if f.ScatterRegion {
+		return true
 	}
 
 	if f.MoveRegion {

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -14,14 +14,19 @@
 package schedule
 
 import (
+	"context"
+	"fmt"
 	"math"
-	"math/rand"
 	"sync"
+	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
+	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
@@ -31,61 +36,38 @@ import (
 
 const regionScatterName = "region-scatter"
 
+var gcInterval = time.Minute
+var gcTTL = time.Minute * 3
+
 type selectedStores struct {
-	mu sync.Mutex
-	// If checkExist is true, after each putting operation, an entry with the key constructed by group and storeID would be put
-	// into "stores" map. And the entry with the same key (storeID, group) couldn't be put before "stores" being reset
-	checkExist bool
-	// TODO: support auto-gc for the stores
-	stores map[string]map[uint64]struct{} // group -> StoreID -> struct{}
-	// TODO: support auto-gc for the groupDistribution
-	groupDistribution map[string]map[uint64]uint64 // group -> StoreID -> count
+	mu                sync.RWMutex
+	groupDistribution *cache.TTLString // value type: map[uint64]uint64, group -> StoreID -> count
 }
 
-func newSelectedStores(checkExist bool) *selectedStores {
+func newSelectedStores(ctx context.Context) *selectedStores {
 	return &selectedStores{
-		checkExist:        checkExist,
-		stores:            make(map[string]map[uint64]struct{}),
-		groupDistribution: make(map[string]map[uint64]uint64),
+		groupDistribution: cache.NewStringTTL(ctx, gcInterval, gcTTL),
 	}
 }
 
-func (s *selectedStores) put(id uint64, group string) bool {
+// Put plus count by storeID and group
+func (s *selectedStores) Put(id uint64, group string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.checkExist {
-		placed, ok := s.stores[group]
-		if !ok {
-			placed = map[uint64]struct{}{}
-		}
-		if _, ok := placed[id]; ok {
-			return false
-		}
-		placed[id] = struct{}{}
-		s.stores[group] = placed
-	}
-	distribution, ok := s.groupDistribution[group]
+	distribution, ok := s.getDistributionByGroupLocked(group)
 	if !ok {
-		distribution = make(map[uint64]uint64)
+		distribution = map[uint64]uint64{}
+		distribution[id] = 0
 	}
 	distribution[id] = distribution[id] + 1
-	s.groupDistribution[group] = distribution
-	return true
+	s.groupDistribution.Put(group, distribution)
 }
 
-func (s *selectedStores) reset() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.checkExist {
-		return
-	}
-	s.stores = make(map[string]map[uint64]struct{})
-}
-
-func (s *selectedStores) get(id uint64, group string) uint64 {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	distribution, ok := s.groupDistribution[group]
+// Get the count by storeID and group
+func (s *selectedStores) Get(id uint64, group string) uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	distribution, ok := s.getDistributionByGroupLocked(group)
 	if !ok {
 		return 0
 	}
@@ -96,23 +78,24 @@ func (s *selectedStores) get(id uint64, group string) uint64 {
 	return count
 }
 
-func (s *selectedStores) newFilters(scope, group string) []filter.Filter {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.checkExist {
-		return nil
+// GetGroupDistribution get distribution group by `group`
+func (s *selectedStores) GetGroupDistribution(group string) (map[uint64]uint64, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.getDistributionByGroupLocked(group)
+}
+
+// getDistributionByGroupLocked should be called with lock
+func (s *selectedStores) getDistributionByGroupLocked(group string) (map[uint64]uint64, bool) {
+	if result, ok := s.groupDistribution.Get(group); ok {
+		return result.(map[uint64]uint64), true
 	}
-	cloned := make(map[uint64]struct{})
-	if groupPlaced, ok := s.stores[group]; ok {
-		for id := range groupPlaced {
-			cloned[id] = struct{}{}
-		}
-	}
-	return []filter.Filter{filter.NewExcludedFilter(scope, nil, cloned)}
+	return nil, false
 }
 
 // RegionScatterer scatters regions.
 type RegionScatterer struct {
+	ctx            context.Context
 	name           string
 	cluster        opt.Cluster
 	ordinaryEngine engineContext
@@ -121,11 +104,12 @@ type RegionScatterer struct {
 
 // NewRegionScatterer creates a region scatterer.
 // RegionScatter is used for the `Lightning`, it will scatter the specified regions before import data.
-func NewRegionScatterer(cluster opt.Cluster) *RegionScatterer {
+func NewRegionScatterer(ctx context.Context, cluster opt.Cluster) *RegionScatterer {
 	return &RegionScatterer{
+		ctx:            ctx,
 		name:           regionScatterName,
 		cluster:        cluster,
-		ordinaryEngine: newEngineContext(filter.NewOrdinaryEngineFilter(regionScatterName)),
+		ordinaryEngine: newEngineContext(ctx, filter.NewOrdinaryEngineFilter(regionScatterName)),
 		specialEngines: make(map[string]engineContext),
 	}
 }
@@ -136,19 +120,112 @@ type engineContext struct {
 	selectedLeader *selectedStores
 }
 
-func newEngineContext(filters ...filter.Filter) engineContext {
-	filters = append(filters, &filter.StoreStateFilter{ActionScope: regionScatterName})
+func newEngineContext(ctx context.Context, filters ...filter.Filter) engineContext {
+	filters = append(filters, &filter.StoreStateFilter{ActionScope: regionScatterName, MoveRegion: true, ScatterRegion: true})
 	return engineContext{
 		filters:        filters,
-		selectedPeer:   newSelectedStores(true),
-		selectedLeader: newSelectedStores(false),
+		selectedPeer:   newSelectedStores(ctx),
+		selectedLeader: newSelectedStores(ctx),
 	}
 }
 
-// Scatter relocates the region. If the group is defined, the regions's leader with the same group would be scattered
+const maxSleepDuration = 1 * time.Minute
+const initialSleepDuration = 100 * time.Millisecond
+const maxRetryLimit = 30
+
+// ScatterRegionsByRange directly scatter regions by ScatterRegions
+func (r *RegionScatterer) ScatterRegionsByRange(startKey, endKey []byte, group string, retryLimit int) ([]*operator.Operator, map[uint64]error, error) {
+	regions := r.cluster.ScanRegions(startKey, endKey, -1)
+	if len(regions) < 1 {
+		return nil, nil, errors.New("empty region")
+	}
+	failures := make(map[uint64]error, len(regions))
+	regionMap := make(map[uint64]*core.RegionInfo, len(regions))
+	for _, region := range regions {
+		regionMap[region.GetID()] = region
+	}
+	// If there existed any region failed to relocated after retry, add it into unProcessedRegions
+	ops, err := r.ScatterRegions(regionMap, failures, group, retryLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ops, failures, nil
+}
+
+// ScatterRegionsByID directly scatter regions by ScatterRegions
+func (r *RegionScatterer) ScatterRegionsByID(regionsID []uint64, group string, retryLimit int) ([]*operator.Operator, map[uint64]error, error) {
+	if len(regionsID) < 1 {
+		return nil, nil, errors.New("empty region")
+	}
+	failures := make(map[uint64]error, len(regionsID))
+	var regions []*core.RegionInfo
+	for _, id := range regionsID {
+		region := r.cluster.GetRegion(id)
+		if region == nil {
+			failures[id] = errors.New(fmt.Sprintf("failed to find region %v", id))
+			continue
+		}
+		regions = append(regions, region)
+	}
+	regionMap := make(map[uint64]*core.RegionInfo, len(regions))
+	for _, region := range regions {
+		regionMap[region.GetID()] = region
+	}
+	// If there existed any region failed to relocated after retry, add it into unProcessedRegions
+	ops, err := r.ScatterRegions(regionMap, failures, group, retryLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ops, failures, nil
+}
+
+// ScatterRegions relocates the regions. If the group is defined, the regions' leader with the same group would be scattered
+// in a group level instead of cluster level.
+// RetryTimes indicates the retry times if any of the regions failed to relocate during scattering. There will be
+// time.Sleep between each retry.
+// Failures indicates the regions which are failed to be relocated, the key of the failures indicates the regionID
+// and the value of the failures indicates the failure error.
+func (r *RegionScatterer) ScatterRegions(regions map[uint64]*core.RegionInfo, failures map[uint64]error, group string, retryLimit int) ([]*operator.Operator, error) {
+	if len(regions) < 1 {
+		return nil, errors.New("empty region")
+	}
+	if retryLimit > maxRetryLimit {
+		retryLimit = maxRetryLimit
+	}
+	ops := make([]*operator.Operator, 0, len(regions))
+	for currentRetry := 0; currentRetry <= retryLimit; currentRetry++ {
+		for _, region := range regions {
+			op, err := r.Scatter(region, group)
+			failpoint.Inject("scatterFail", func() {
+				if region.GetID() == 1 {
+					err = errors.New("mock error")
+				}
+			})
+			if err != nil {
+				failures[region.GetID()] = err
+				continue
+			}
+			if op != nil {
+				ops = append(ops, op)
+			}
+			delete(regions, region.GetID())
+			delete(failures, region.GetID())
+		}
+		// all regions have been relocated, break the loop.
+		if len(regions) < 1 {
+			break
+		}
+		// Wait for a while if there are some regions failed to be relocated
+		time.Sleep(typeutil.MinDuration(maxSleepDuration, time.Duration(math.Pow(2, float64(currentRetry)))*initialSleepDuration))
+	}
+	return ops, nil
+}
+
+// Scatter relocates the region. If the group is defined, the regions' leader with the same group would be scattered
 // in a group level instead of cluster level.
 func (r *RegionScatterer) Scatter(region *core.RegionInfo, group string) (*operator.Operator, error) {
 	if !opt.IsRegionReplicated(r.cluster, region) {
+		//r.cluster.AddSuspectRegions(region.GetID())
 		return nil, errors.Errorf("region %d is not fully replicated", region.GetID())
 	}
 
@@ -156,47 +233,39 @@ func (r *RegionScatterer) Scatter(region *core.RegionInfo, group string) (*opera
 		return nil, errors.Errorf("region %d has no leader", region.GetID())
 	}
 
+	if r.cluster.IsRegionHot(region) {
+		return nil, errors.Errorf("region %d is hot", region.GetID())
+	}
+
 	return r.scatterRegion(region, group), nil
 }
 
 func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string) *operator.Operator {
 	ordinaryFilter := filter.NewOrdinaryEngineFilter(r.name)
-	var ordinaryPeers []*metapb.Peer
-	specialPeers := make(map[string][]*metapb.Peer)
+	ordinaryPeers := make(map[uint64]*metapb.Peer)
+	specialPeers := make(map[string]map[uint64]*metapb.Peer)
 	// Group peers by the engine of their stores
 	for _, peer := range region.GetPeers() {
 		store := r.cluster.GetStore(peer.GetStoreId())
 		if ordinaryFilter.Target(r.cluster, store) {
-			ordinaryPeers = append(ordinaryPeers, peer)
+			ordinaryPeers[peer.GetId()] = peer
 		} else {
 			engine := store.GetLabelValue(filter.EngineKey)
-			specialPeers[engine] = append(specialPeers[engine], peer)
+			if _, ok := specialPeers[engine]; !ok {
+				specialPeers[engine] = make(map[uint64]*metapb.Peer)
+			}
+			specialPeers[engine][peer.GetId()] = peer
 		}
 	}
 
 	targetPeers := make(map[uint64]*metapb.Peer)
-
-	scatterWithSameEngine := func(peers []*metapb.Peer, context engineContext) {
-		stores := r.collectAvailableStores(group, region, context)
+	selectedStores := make(map[uint64]struct{})
+	scatterWithSameEngine := func(peers map[uint64]*metapb.Peer, context engineContext) {
 		for _, peer := range peers {
-			if len(stores) == 0 {
-				context.selectedPeer.reset()
-				stores = r.collectAvailableStores(group, region, context)
-			}
-			if context.selectedPeer.put(peer.GetStoreId(), group) {
-				delete(stores, peer.GetStoreId())
-				targetPeers[peer.GetStoreId()] = peer
-				continue
-			}
-			newPeer := r.selectPeerToReplace(group, stores, region, peer, context)
-			if newPeer == nil {
-				targetPeers[peer.GetStoreId()] = peer
-				continue
-			}
-			// Remove it from stores and mark it as selected.
-			delete(stores, newPeer.GetStoreId())
-			context.selectedPeer.put(newPeer.GetStoreId(), group)
+			candidates := r.selectCandidates(region, peer.GetStoreId(), selectedStores, context)
+			newPeer := r.selectStore(group, peer, peer.GetStoreId(), candidates, context)
 			targetPeers[newPeer.GetStoreId()] = newPeer
+			selectedStores[newPeer.GetStoreId()] = struct{}{}
 		}
 	}
 
@@ -207,90 +276,87 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string) *
 	targetLeader := r.selectAvailableLeaderStores(group, targetPeers, r.ordinaryEngine)
 
 	for engine, peers := range specialPeers {
-		context, ok := r.specialEngines[engine]
+		ctx, ok := r.specialEngines[engine]
 		if !ok {
-			context = newEngineContext(filter.NewEngineFilter(r.name, engine))
-			r.specialEngines[engine] = context
+			ctx = newEngineContext(r.ctx, filter.NewEngineFilter(r.name, engine))
+			r.specialEngines[engine] = ctx
 		}
-		scatterWithSameEngine(peers, context)
+		scatterWithSameEngine(peers, ctx)
 	}
 
 	op, err := operator.CreateScatterRegionOperator("scatter-region", r.cluster, region, targetPeers, targetLeader)
 	if err != nil {
+		for _, peer := range region.GetPeers() {
+			targetPeers[peer.GetStoreId()] = peer
+		}
+		r.Put(targetPeers, region.GetLeader().GetStoreId(), group)
 		log.Debug("fail to create scatter region operator", errs.ZapError(err))
 		return nil
 	}
+	r.Put(targetPeers, targetLeader, group)
 	op.SetPriorityLevel(core.HighPriority)
 	return op
 }
 
-func (r *RegionScatterer) selectPeerToReplace(group string, stores map[uint64]*core.StoreInfo, region *core.RegionInfo, oldPeer *metapb.Peer, context engineContext) *metapb.Peer {
-	// scoreGuard guarantees that the distinct score will not decrease.
-	regionStores := r.cluster.GetRegionStores(region)
-	storeID := oldPeer.GetStoreId()
-	sourceStore := r.cluster.GetStore(storeID)
+func (r *RegionScatterer) selectCandidates(region *core.RegionInfo, sourceStoreID uint64, selectedStores map[uint64]struct{}, context engineContext) []uint64 {
+	sourceStore := r.cluster.GetStore(sourceStoreID)
 	if sourceStore == nil {
-		log.Error("failed to get the store", zap.Uint64("store-id", storeID), errs.ZapError(errs.ErrGetSourceStore))
+		log.Error("failed to get the store", zap.Uint64("store-id", sourceStoreID), errs.ZapError(errs.ErrGetSourceStore))
 		return nil
+	}
+	filters := []filter.Filter{
+		filter.NewExcludedFilter("scatter-region", nil, selectedStores),
 	}
 	var scoreGuard filter.Filter
 	if r.cluster.IsPlacementRulesEnabled() {
-		scoreGuard = filter.NewRuleFitFilter(r.name, r.cluster, region, oldPeer.GetStoreId())
+		scoreGuard = filter.NewRuleFitFilter(r.name, r.cluster, region, sourceStoreID)
 	} else {
+		regionStores := make([]*core.StoreInfo, 0)
+		for _, peer := range region.GetPeers() {
+			store := r.cluster.GetStore(peer.GetStoreId())
+			regionStores = append(regionStores, store)
+		}
 		scoreGuard = filter.NewDistinctScoreFilter(r.name, r.cluster.GetLocationLabels(), regionStores, sourceStore)
 	}
-
-	candidates := make([]*core.StoreInfo, 0, len(stores))
-	for _, store := range stores {
-		if !scoreGuard.Target(r.cluster, store) {
-			continue
-		}
-		candidates = append(candidates, store)
-	}
-
-	if len(candidates) == 0 {
-		return nil
-	}
-
-	minPeer := uint64(math.MaxUint64)
-	var selectedCandidateID uint64
-	for _, candidate := range candidates {
-		count := context.selectedPeer.get(candidate.GetID(), group)
-		if count < minPeer {
-			minPeer = count
-			selectedCandidateID = candidate.GetID()
-		}
-	}
-	if selectedCandidateID < 1 {
-		target := candidates[rand.Intn(len(candidates))]
-		return &metapb.Peer{
-			StoreId:   target.GetID(),
-			IsLearner: oldPeer.GetIsLearner(),
-		}
-	}
-
-	return &metapb.Peer{
-		StoreId:   selectedCandidateID,
-		IsLearner: oldPeer.GetIsLearner(),
-	}
-}
-
-func (r *RegionScatterer) collectAvailableStores(group string, region *core.RegionInfo, context engineContext) map[uint64]*core.StoreInfo {
-	filters := []filter.Filter{
-		filter.NewExcludedFilter(r.name, nil, region.GetStoreIds()),
-		&filter.StoreStateFilter{ActionScope: r.name, MoveRegion: true},
-	}
+	//scoreGuard := filter.NewRuleFitFilter(r.name, r.cluster, region, sourceStore.GetID())
 	filters = append(filters, context.filters...)
-	filters = append(filters, context.selectedPeer.newFilters(r.name, group)...)
-
+	filters = append(filters, scoreGuard)
 	stores := r.cluster.GetStores()
-	targets := make(map[uint64]*core.StoreInfo, len(stores))
+	candidates := make([]uint64, 0)
 	for _, store := range stores {
 		if filter.Target(r.cluster, store, filters) && !store.IsBusy() {
-			targets[store.GetID()] = store
+			candidates = append(candidates, store.GetID())
 		}
 	}
-	return targets
+	return candidates
+}
+
+func (r *RegionScatterer) selectStore(group string, peer *metapb.Peer, sourceStoreID uint64, candidates []uint64, context engineContext) *metapb.Peer {
+	if len(candidates) < 1 {
+		return peer
+	}
+	var newPeer *metapb.Peer
+	minCount := uint64(math.MaxUint64)
+	for _, storeID := range candidates {
+		count := context.selectedPeer.Get(storeID, group)
+		if count < minCount {
+			minCount = count
+			newPeer = &metapb.Peer{
+				StoreId:   storeID,
+				IsLearner: peer.GetIsLearner(),
+			}
+		}
+	}
+	// if the source store have the least count, we don't need to scatter this peer
+	for _, storeID := range candidates {
+		if storeID == sourceStoreID && context.selectedPeer.Get(sourceStoreID, group) <= minCount {
+			return peer
+		}
+	}
+	if newPeer == nil {
+		return peer
+	}
+	return newPeer
 }
 
 // selectAvailableLeaderStores select the target leader store from the candidates. The candidates would be collected by
@@ -299,14 +365,31 @@ func (r *RegionScatterer) selectAvailableLeaderStores(group string, peers map[ui
 	minStoreGroupLeader := uint64(math.MaxUint64)
 	id := uint64(0)
 	for storeID := range peers {
-		storeGroupLeaderCount := context.selectedLeader.get(storeID, group)
+		if id == 0 {
+			id = storeID
+		}
+		storeGroupLeaderCount := context.selectedLeader.Get(storeID, group)
 		if minStoreGroupLeader > storeGroupLeaderCount {
 			minStoreGroupLeader = storeGroupLeaderCount
 			id = storeID
 		}
 	}
-	if id != 0 {
-		context.selectedLeader.put(id, group)
-	}
 	return id
+}
+
+// Put put the final distribution in the context no matter the operator was created
+func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint64, group string) {
+	ordinaryFilter := filter.NewOrdinaryEngineFilter(r.name)
+	// Group peers by the engine of their stores
+	for _, peer := range peers {
+		storeID := peer.GetStoreId()
+		store := r.cluster.GetStore(storeID)
+		if ordinaryFilter.Target(r.cluster, store) {
+			r.ordinaryEngine.selectedPeer.Put(storeID, group)
+		} else {
+			engine := store.GetLabelValue(filter.EngineKey)
+			r.specialEngines[engine].selectedPeer.Put(storeID, group)
+		}
+	}
+	r.ordinaryEngine.selectedLeader.Put(leaderStoreID, group)
 }

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -196,15 +196,10 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "scatter-region"), IsTrue)
 
-	// test echo
-	echo := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
-	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "add", "scatter-region", "1"})
-	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
-	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
-	c.Assert(strings.Contains(echo, "Success!"), IsFalse)
+	// test echo, as the scatter region result is random, both region 1 and region 3 can be the region to be scattered
+	echo1 := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
+	echo2 := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "3"})
+	c.Assert(strings.Contains(echo1, "Success!") || strings.Contains(echo2, "Success!"), IsTrue)
 
 	_, _, err = pdctl.ExecuteCommandC(cmd, "config", "set", "enable-placement-rules", "true")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
ref https://github.com/tikv/pd/issues/3450
cherry-pick: https://github.com/tikv/pd/pull/3451
Also the code in region scatter is too complex to maintain.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
refactor the region scatter to make it simple and fix the reference bug.

After this pr, the result was like following: 

```sh
mysql> create table t(id int);
Query OK, 0 rows affected (0.09 sec)

mysql> SPLIT TABLE t BETWEEN (0) AND (1000000000) REGIONS 200;                                +--------------------+----------------------+
| TOTAL_SPLIT_REGION | SCATTER_FINISH_RATIO |
+--------------------+----------------------+
|                199 |                    1 |
+--------------------+----------------------+
1 row in set (11.89 sec)

mysql> select count(s.region_id) cnt, s.index_name, p.store_id from INFORMATION_SCHEMA.TIKV_REGION_STATUS s join INFORMATION_SCHEMA.tikv_region_peers p on s.region_id = p.region_id where s.table_name = 't' and p.is_leader = 0 group by index_name, p.store_id order by index_name,cnt desc;
+-----+------------+----------+
| cnt | index_name | store_id |
+-----+------------+----------+
|  70 | NULL       |        1 |
|  67 | NULL       |        4 |
|  67 | NULL       |        6 |
|  66 | NULL       |        7 |
|  65 | NULL       |        5 |
|  65 | NULL       |        8 |
+-----+------------+----------+
6 rows in set (0.02 sec)
```

For the detail test result, please see:
https://docs.google.com/document/d/1cGZU2DCm0UuIueqAQP8TGqTivyavCvB_QiwIzqvP_rA/edit?usp=sharing

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

* No release note 