### PR TITLE
api: fix resign myself error

### DIFF
--- a/server/api/member.go
+++ b/server/api/member.go
@@ -275,7 +275,7 @@ func newLeaderHandler(svr *server.Server, rd *render.Render) *leaderHandler {
 // @Tags leader
 // @Summary Get the leader PD server of the cluster.
 // @Produce json
-// @Success 200 {string} string "The transfer command is submitted."
+// @Success 200 {object} pdpb.Member
 // @Router /leader [get]
 func (h *leaderHandler) Get(w http.ResponseWriter, r *http.Request) {
 	h.rd.JSON(w, http.StatusOK, h.svr.GetLeader())
@@ -284,7 +284,7 @@ func (h *leaderHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Tags leader
 // @Summary Transfer etcd leadership to another PD server.
 // @Produce json
-// @Success 200 {string} string "The transfer command is submitted."
+// @Success 200 {string} string "The resign command is submitted."
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /leader/resign [post]
 func (h *leaderHandler) Resign(w http.ResponseWriter, r *http.Request) {
@@ -294,7 +294,7 @@ func (h *leaderHandler) Resign(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.rd.JSON(w, http.StatusOK, "The transfer command is submitted.")
+	h.rd.JSON(w, http.StatusOK, "The resign command is submitted.")
 }
 
 // @Tags leader

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -275,6 +275,12 @@ func (m *Member) ResignEtcdLeader(ctx context.Context, from string, nextEtcdLead
 	if err != nil {
 		return err
 	}
+
+	// Do nothing when I am the only member of cluster.
+	if len(res.Members) == 1 && res.Members[0].ID == m.id && nextEtcdLeader == "" {
+		return nil
+	}
+
 	for _, member := range res.Members {
 		if (nextEtcdLeader == "" && member.ID != m.id) || (nextEtcdLeader != "" && member.Name == nextEtcdLeader) {
 			etcdLeaderIDs = append(etcdLeaderIDs, member.GetID())


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

This PR is to solve #3517.


### What is changed and how it works?

There's no need to resign member when only one member left in etcd cluster, therefore the `ResignEtcdLeader()` should just return in this scenario.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
Origin:  
![image](https://user-images.githubusercontent.com/16649269/113300758-d66b4680-9330-11eb-8a17-0ac49958d862.png)
Fixed:
![image](https://user-images.githubusercontent.com/16649269/113300916-03b7f480-9331-11eb-8e1f-bbfea5a0ebc9.png)

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
