### PR TITLE
core: update region score v2 formula

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -319,7 +319,7 @@ func (s *StoreInfo) regionScoreV2(delta int64, deviation int) float64 {
 		score = (K + M*(math.Log(C)-math.Log(A-F+1))/(C-A+F-1)) * R
 	} else {
 		// When remaining space is less then F, the score is mainly determined by available space.
-		score = (K+M*math.Log(C)/C)*R + (F-A)*(K+M*math.Log(F)/F)
+		score = (K + M*math.Log(C)/(C)) * (R + (F-A)*(C/F))
 	}
 	return score / math.Max(s.GetRegionWeight(), minWeight)
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Ref: https://github.com/tikv/pd/issues/3544
The influence weight of available size is not enough in the near out of space stage.

### What is changed and how it works?
Update formula to increase influence weight of available size.

simulator result (`stores=1200_1200_1200&amps=1.05_1.05_1.37&f=20`)

old formula

![image](https://user-images.githubusercontent.com/12077877/113814511-5b78b480-97a4-11eb-8dd6-b3c11a8de922.png)

new formula

![image](https://user-images.githubusercontent.com/12077877/113814525-62072c00-97a4-11eb-9e20-95fec4e8fef1.png)


### Check List

<!-- Remove the items that are not applicable. -->

Tests
- no test yet

### Release note
- No release note
