### PR TITLE
server: Defer region Clone to String() method

### DIFF
--- a/server/core/region.go
+++ b/server/core/region.go
@@ -1122,9 +1122,6 @@ func RegionToHexMeta(meta *metapb.Region) HexRegionMeta {
 	if meta == nil {
 		return HexRegionMeta{}
 	}
-	meta = proto.Clone(meta).(*metapb.Region)
-	meta.StartKey = HexRegionKey(meta.StartKey)
-	meta.EndKey = HexRegionKey(meta.EndKey)
 	return HexRegionMeta{meta}
 }
 
@@ -1134,20 +1131,17 @@ type HexRegionMeta struct {
 }
 
 func (h HexRegionMeta) String() string {
-	return strings.TrimSpace(proto.CompactTextString(h.Region))
+	var meta = proto.Clone(h.Region).(*metapb.Region)
+	meta.StartKey = HexRegionKey(meta.StartKey)
+	meta.EndKey = HexRegionKey(meta.EndKey)
+	return strings.TrimSpace(proto.CompactTextString(meta))
 }
 
 // RegionsToHexMeta converts regions' meta keys to hex format. Used for formating
 // region in logs.
 func RegionsToHexMeta(regions []*metapb.Region) HexRegionsMeta {
 	hexRegionMetas := make([]*metapb.Region, len(regions))
-	for i, region := range regions {
-		meta := proto.Clone(region).(*metapb.Region)
-		meta.StartKey = HexRegionKey(meta.StartKey)
-		meta.EndKey = HexRegionKey(meta.EndKey)
-
-		hexRegionMetas[i] = meta
-	}
+	copy(hexRegionMetas, regions)
 	return hexRegionMetas
 }
 
@@ -1158,7 +1152,11 @@ type HexRegionsMeta []*metapb.Region
 func (h HexRegionsMeta) String() string {
 	var b strings.Builder
 	for _, r := range h {
-		b.WriteString(proto.CompactTextString(r))
+		meta := proto.Clone(r).(*metapb.Region)
+		meta.StartKey = HexRegionKey(meta.StartKey)
+		meta.EndKey = HexRegionKey(meta.EndKey)
+
+		b.WriteString(proto.CompactTextString(meta))
 	}
 	return strings.TrimSpace(b.String())
 }


### PR DESCRIPTION
server: Defer region Clone to String() method so that it doesn't trigger if the logging isn't actually happening

Signed-off-by: Fred Wulff <frew@cs.stanford.edu>

### What problem does this PR solve?

In running `perf` on our pd node, we see a lot of the time under the cluster lock in https://github.com/tikv/pd/blob/master/server/core/region_tree.go#L99 - the zap library defers the String() method of a Stringer until it's actually doing the logging (so in this case would never execute it since Debug logging is not enabled), but currently the heavyweight proto Clone() method is called on creation. I verified that HexRegionMeta is only used by logging calls, so the change in the actual contents shouldn't affect anything unexpected.

### What is changed and how it works?

HexRegionMeta now does the clone and hex-ification in String() rather than constructor

### Check List

Tests

- Has not been tested - let me know if there's something that would be useful.

Side effects

- Theoretically possible it decreases performance, but I can't find anywhere where the String() method is called more than once per object.

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

- No release note
