### PR TITLE
metrics: support showing the store limit in Grafana

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -63,8 +63,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 11,
-  "iteration": 1608795246154,
+  "id": 25,
+  "iteration": 1618283470402,
   "links": [],
   "panels": [
     {
@@ -957,7 +957,7 @@
           "fontSize": "90%",
           "gridPos": {
             "h": 7,
-            "w": 6,
+            "w": 4,
             "x": 0,
             "y": 14
           },
@@ -1009,14 +1009,132 @@
           "type": "table"
         },
         {
+          "columns": [],
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 4,
+            "y": 14
+          },
+          "id": 1433,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 4,
+            "desc": true
+          },
+          "styles": [
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "link": false,
+              "mappingType": 1,
+              "pattern": "Time",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "__name__",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "instance",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "job",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "limit (opm)",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "mappingType": 1,
+              "pattern": "Value",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "pd_cluster_store_limit",
+              "format": "table",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Store limit",
+          "transform": "table",
+          "type": "table"
+        },
+        {
           "cacheTimeout": null,
           "columns": [],
           "datasource": "${DS_TEST-CLUSTER}",
           "fontSize": "100%",
           "gridPos": {
             "h": 3,
-            "w": 6,
-            "x": 6,
+            "w": 5,
+            "x": 9,
             "y": 14
           },
           "hideTimeOverride": true,
@@ -1083,8 +1201,8 @@
           "fontSize": "100%",
           "gridPos": {
             "h": 7,
-            "w": 6,
-            "x": 12,
+            "w": 5,
+            "x": 14,
             "y": 14
           },
           "hideTimeOverride": true,
@@ -1160,8 +1278,8 @@
           "fontSize": "100%",
           "gridPos": {
             "h": 7,
-            "w": 6,
-            "x": 18,
+            "w": 5,
+            "x": 19,
             "y": 14
           },
           "hideTimeOverride": true,
@@ -1253,8 +1371,8 @@
           },
           "gridPos": {
             "h": 2,
-            "w": 6,
-            "x": 6,
+            "w": 5,
+            "x": 9,
             "y": 17
           },
           "hideTimeOverride": true,
@@ -1338,8 +1456,8 @@
           },
           "gridPos": {
             "h": 2,
-            "w": 6,
-            "x": 6,
+            "w": 5,
+            "x": 9,
             "y": 19
           },
           "hideTimeOverride": true,
@@ -9916,24 +10034,25 @@
       {
         "allValue": null,
         "current": {
+          "isNone": true,
+          "text": "None",
+          "value": ""
         },
         "datasource": "${DS_TEST-CLUSTER}",
+        "definition": "",
         "hide": 2,
         "includeAll": false,
         "label": "tidb_cluster",
         "multi": false,
         "name": "tidb_cluster",
-        "options": [
-
-        ],
+        "options": [],
         "query": "label_values(pd_cluster_status, tidb_cluster)",
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [
-
-        ],
+        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1258,7 +1258,6 @@ func (c *RaftCluster) collectMetrics() {
 
 	c.coordinator.collectSchedulerMetrics()
 	c.coordinator.collectHotSpotMetrics()
-	c.coordinator.opController.CollectStoreLimitMetrics()
 	c.collectClusterMetrics()
 	c.collectHealthStatus()
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -1680,6 +1681,9 @@ func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
 	for i := 0; i < persistLimitRetryTimes; i++ {
 		if err = c.opt.Persist(c.storage); err == nil {
 			log.Info("store limit removed", zap.Uint64("store-id", storeID))
+			id := strconv.FormatUint(storeID, 10)
+			statistics.StoreLimitGauge.WithLabelValues(id, "add-peer").Set(0)
+			statistics.StoreLimitGauge.WithLabelValues(id, "remove-peer").Set(0)
 			return
 		}
 		time.Sleep(persistLimitWaitTime)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1682,8 +1682,8 @@ func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
 		if err = c.opt.Persist(c.storage); err == nil {
 			log.Info("store limit removed", zap.Uint64("store-id", storeID))
 			id := strconv.FormatUint(storeID, 10)
-			statistics.StoreLimitGauge.WithLabelValues(id, "add-peer").Set(0)
-			statistics.StoreLimitGauge.WithLabelValues(id, "remove-peer").Set(0)
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
 			return
 		}
 		time.Sleep(persistLimitWaitTime)

--- a/server/schedule/metrics.go
+++ b/server/schedule/metrics.go
@@ -50,22 +50,6 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 16),
 		}, []string{"type"})
 
-	storeLimitAvailableGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "pd",
-			Subsystem: "schedule",
-			Name:      "store_limit_available",
-			Help:      "available limit rate of store.",
-		}, []string{"store", "limit_type"})
-
-	storeLimitRateGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "pd",
-			Subsystem: "schedule",
-			Name:      "store_limit_rate",
-			Help:      "the limit rate of store.",
-		}, []string{"store", "limit_type"})
-
 	storeLimitCostCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "pd",
@@ -79,8 +63,6 @@ func init() {
 	prometheus.MustRegister(operatorCounter)
 	prometheus.MustRegister(operatorDuration)
 	prometheus.MustRegister(operatorWaitDuration)
-	prometheus.MustRegister(storeLimitAvailableGauge)
-	prometheus.MustRegister(storeLimitRateGauge)
 	prometheus.MustRegister(storeLimitCostCounter)
 	prometheus.MustRegister(operatorWaitCounter)
 }

--- a/server/statistics/metrics.go
+++ b/server/statistics/metrics.go
@@ -72,6 +72,14 @@ var (
 			Help:      "Status of the scheduling configurations.",
 		}, []string{"type"})
 
+	StoreLimitGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "cluster",
+			Name:      "store_limit",
+			Help:      "Status of the store limit.",
+		}, []string{"store", "type"})
+
 	regionLabelLevelGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
@@ -152,6 +160,7 @@ func init() {
 	prometheus.MustRegister(clusterStatusGauge)
 	prometheus.MustRegister(placementStatusGauge)
 	prometheus.MustRegister(configStatusGauge)
+	prometheus.MustRegister(StoreLimitGauge)
 	prometheus.MustRegister(regionLabelLevelGauge)
 	prometheus.MustRegister(readByteHist)
 	prometheus.MustRegister(readKeyHist)

--- a/server/statistics/metrics.go
+++ b/server/statistics/metrics.go
@@ -72,6 +72,7 @@ var (
 			Help:      "Status of the scheduling configurations.",
 		}, []string{"type"})
 
+	// StoreLimitGauge is used to record the current store limit.
 	StoreLimitGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",

--- a/server/statistics/store_collection.go
+++ b/server/statistics/store_collection.go
@@ -186,6 +186,12 @@ func (s *storeStatistics) Collect() {
 	for name, value := range s.LabelCounter {
 		placementStatusGauge.WithLabelValues(labelType, name).Set(float64(value))
 	}
+
+	for storeID, limit := range s.opt.GetScheduleConfig().StoreLimit {
+		id := strconv.FormatUint(storeID, 10)
+		StoreLimitGauge.WithLabelValues(id, "add-peer").Set(limit.AddPeer)
+		StoreLimitGauge.WithLabelValues(id, "remove-peer").Set(limit.RemovePeer)
+	}
 }
 
 func (s *storeStatistics) resetStoreStatistics(storeAddress string, id string) {


### PR DESCRIPTION
### What problem does this PR solve?

Closes #3546 

### What is changed and how it works?

After this PR:
<img width="1847" alt="Screen Shot 2021-04-13 at 12 14 12 PM" src="https://user-images.githubusercontent.com/35896542/114496097-cec17100-9c51-11eb-9912-283187ef6d79.png">
We can get the current store limit directly from Grafana. Some examples are listed as follow:

change the limit of store 1
<img width="387" alt="Screen Shot 2021-04-13 at 12 09 39 PM" src="https://user-images.githubusercontent.com/35896542/114495748-34f9c400-9c51-11eb-9921-e603ae0ef77a.png">

offline store 1
<img width="383" alt="Screen Shot 2021-04-13 at 12 04 18 PM" src="https://user-images.githubusercontent.com/35896542/114495873-71c5bb00-9c51-11eb-8a90-354bbdc85056.png">



### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test 

Related changes

- Need to cherry-pick to the release branch

### Release note

- Support showing the store limit in Grafana
