### PR TITLE
core: change score calculator in few disk space to avoid offline earlier

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -308,6 +308,7 @@ func (s *StoreInfo) regionScoreV2(delta int64, deviation int) float64 {
 	var (
 		K, M float64 = 1, 256 // Experience value to control the weight of the available influence on score
 		F    float64 = 20     // Experience value to prevent some nodes from running out of disk space prematurely.
+		B            = 1e5
 	)
 
 	var score float64
@@ -319,7 +320,7 @@ func (s *StoreInfo) regionScoreV2(delta int64, deviation int) float64 {
 		score = (K + M*(math.Log(C)-math.Log(A-F+1))/(C-A+F-1)) * R
 	} else {
 		// When remaining space is less then F, the score is mainly determined by available space.
-		score = (K+M*math.Log(C)/C)*R + (F-A)*(K+M*math.Log(F)/F)
+		score = (K+M*math.Log(C)/C)*R + B*(F-A)*(K+M*math.Log(F)/F)
 	}
 	return score / math.Max(s.GetRegionWeight(), minWeight)
 }

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -248,7 +248,7 @@ func (s *StoreInfo) LeaderScore(policy SchedulePolicy, delta int64) float64 {
 func (s *StoreInfo) RegionScore(version string, highSpaceRatio, lowSpaceRatio float64, delta int64, deviation int) float64 {
 	switch version {
 	case "v2":
-		return s.regionScoreV2(delta, deviation)
+		return s.regionScoreV2(delta, deviation, lowSpaceRatio)
 	case "v1":
 		fallthrough
 	default:
@@ -301,16 +301,16 @@ func (s *StoreInfo) regionScoreV1(highSpaceRatio, lowSpaceRatio float64, delta i
 	return score / math.Max(s.GetRegionWeight(), minWeight)
 }
 
-func (s *StoreInfo) regionScoreV2(delta int64, deviation int) float64 {
+func (s *StoreInfo) regionScoreV2(delta int64, deviation int, lowSpaceRatio float64) float64 {
 	A := float64(float64(s.GetAvgAvailable())-float64(deviation)*float64(s.GetAvailableDeviation())) / gb
 	C := float64(s.GetCapacity()) / gb
 	R := float64(s.GetRegionSize() + delta)
 	var (
 		K, M float64 = 1, 256 // Experience value to control the weight of the available influence on score
 		F    float64 = 20     // Experience value to prevent some nodes from running out of disk space prematurely.
-		B            = 1e5
+		B            = 1e7
 	)
-
+	F = math.Max(F, C*(1-lowSpaceRatio))
 	var score float64
 	if A >= C || C < 1 {
 		score = R
@@ -320,7 +320,8 @@ func (s *StoreInfo) regionScoreV2(delta int64, deviation int) float64 {
 		score = (K + M*(math.Log(C)-math.Log(A-F+1))/(C-A+F-1)) * R
 	} else {
 		// When remaining space is less then F, the score is mainly determined by available space.
-		score = (K+M*math.Log(C)/C)*R + B*(F-A)*(K+M*math.Log(F)/F)
+		// store's score will increase rapidly after it has few space. and it will reach similar score when they has no space
+		score = (K+M*math.Log(C)/C)*R + B*(F-A)/F
 	}
 	return score / math.Max(s.GetRegionWeight(), minWeight)
 }

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -307,7 +307,7 @@ func (s *StoreInfo) regionScoreV2(delta int64, deviation int, lowSpaceRatio floa
 	R := float64(s.GetRegionSize() + delta)
 	var (
 		K, M float64 = 1, 256 // Experience value to control the weight of the available influence on score
-		F    float64 = 20     // Experience value to prevent some nodes from running out of disk space prematurely.
+		F    float64 = 50     // Experience value to prevent some nodes from running out of disk space prematurely.
 		B            = 1e7
 	)
 	F = math.Max(F, C*(1-lowSpaceRatio))


### PR DESCRIPTION


### What problem does this PR solve?
issue: #3589

### What is changed and how it works?
core regionScoreV2 calculator, store's score will increase rapidly when it disk space less than F 
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->
- Integration test
- Manual test (add detailed scripts or steps below)

Code changes


Side effects


Related changes
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
- modify score calculator to satisfy isomerous stores
<!-- - No release note -->
