### PR TITLE
tso: fix the bugs of TSO fallback and Local TSO physical time advancing too fast

### DIFF
--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -76,6 +76,7 @@ func NewGlobalTSOAllocator(
 			updatePhysicalInterval: am.updatePhysicalInterval,
 			maxResetTSGap:          am.maxResetTSGap,
 			dcLocation:             GlobalDCLocation,
+			tsoMux:                 &tsoObject{},
 		},
 	}
 	return gta

--- a/server/tso/local_allocator.go
+++ b/server/tso/local_allocator.go
@@ -62,6 +62,7 @@ func NewLocalTSOAllocator(
 			updatePhysicalInterval: am.updatePhysicalInterval,
 			maxResetTSGap:          am.maxResetTSGap,
 			dcLocation:             dcLocation,
+			tsoMux:                 &tsoObject{},
 		},
 		rootPath: leadership.GetLeaderKey(),
 	}

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -60,7 +60,7 @@ type timestampOracle struct {
 	// tso info stored in the memory
 	tsoMux struct {
 		sync.RWMutex
-		tso *tsoObject
+		tsoObject
 	}
 	// last timestamp window stored in etcd
 	lastSavedTime atomic.Value // stored as time.Time
@@ -72,30 +72,31 @@ func (t *timestampOracle) setTSOPhysical(next time.Time) {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
 	// make sure the ts won't fall back
-	if t.tsoMux.tso == nil || typeutil.SubTimeByWallClock(next, t.tsoMux.tso.physical) > 0 {
-		t.tsoMux.tso = &tsoObject{physical: next}
+	if typeutil.SubTimeByWallClock(next, t.tsoMux.physical) >= updateTimestampGuard {
+		t.tsoMux.physical = next
+		t.tsoMux.logical = 0
 	}
 }
 
 func (t *timestampOracle) getTSO() (time.Time, int64) {
 	t.tsoMux.RLock()
 	defer t.tsoMux.RUnlock()
-	if t.tsoMux.tso == nil {
+	if t.tsoMux.physical == typeutil.ZeroTime {
 		return typeutil.ZeroTime, 0
 	}
-	return t.tsoMux.tso.physical, t.tsoMux.tso.logical
+	return t.tsoMux.physical, t.tsoMux.logical
 }
 
 // generateTSO will add the TSO's logical part with the given count and returns the new TSO result.
 func (t *timestampOracle) generateTSO(count int64, suffixBits int) (physical int64, logical int64) {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
-	if t.tsoMux.tso == nil {
+	if t.tsoMux.physical == typeutil.ZeroTime {
 		return 0, 0
 	}
-	physical = t.tsoMux.tso.physical.UnixNano() / int64(time.Millisecond)
-	t.tsoMux.tso.logical += count
-	logical = t.tsoMux.tso.logical
+	physical = t.tsoMux.physical.UnixNano() / int64(time.Millisecond)
+	t.tsoMux.logical += count
+	logical = t.tsoMux.logical
 	if suffixBits > 0 && t.suffix >= 0 {
 		logical = t.differentiateLogical(logical, suffixBits)
 	}
@@ -199,7 +200,7 @@ func (t *timestampOracle) SyncTimestamp(leadership *election.Leadership) error {
 func (t *timestampOracle) isInitialized() bool {
 	t.tsoMux.RLock()
 	defer t.tsoMux.RUnlock()
-	return t.tsoMux.tso != nil
+	return t.tsoMux.physical == typeutil.ZeroTime
 }
 
 // resetUserTimestamp update the TSO in memory with specified TSO by an atomicly way.
@@ -213,21 +214,21 @@ func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, ts
 	nextPhysical, nextLogical := tsoutil.ParseTS(tso)
 	var err error
 	// do not update if next logical time is less/before than prev
-	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.tso.physical) == 0 && int64(nextLogical) <= t.tsoMux.tso.logical {
+	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.physical) == 0 && int64(nextLogical) <= t.tsoMux.logical {
 		tsoCounter.WithLabelValues("err_reset_small_counter", t.dcLocation).Inc()
 		if !ignoreSmaller {
 			err = errs.ErrResetUserTimestamp.FastGenByArgs("the specified counter is smaller than now")
 		}
 	}
 	// do not update if next physical time is less/before than prev
-	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.tso.physical) < 0 {
+	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.physical) < 0 {
 		tsoCounter.WithLabelValues("err_reset_small_ts", t.dcLocation).Inc()
 		if !ignoreSmaller {
 			err = errs.ErrResetUserTimestamp.FastGenByArgs("the specified ts is smaller than now")
 		}
 	}
 	// do not update if physical time is too greater than prev
-	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.tso.physical) >= t.maxResetTSGap() {
+	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.physical) >= t.maxResetTSGap() {
 		tsoCounter.WithLabelValues("err_reset_large_ts", t.dcLocation).Inc()
 		err = errs.ErrResetUserTimestamp.FastGenByArgs("the specified ts is too larger than now")
 	}
@@ -243,11 +244,8 @@ func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, ts
 		}
 	}
 	// save into memory
-	if t.tsoMux.tso == nil {
-		t.tsoMux.tso = &tsoObject{}
-	}
-	t.tsoMux.tso.physical = nextPhysical
-	t.tsoMux.tso.logical = int64(nextLogical)
+	t.tsoMux.physical = nextPhysical
+	t.tsoMux.logical = int64(nextLogical)
 	tsoCounter.WithLabelValues("reset_tso_ok", t.dcLocation).Inc()
 	return nil
 }
@@ -373,5 +371,6 @@ func (t *timestampOracle) ResetTimestamp() {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
 	log.Info("reset the timestamp in memory")
-	t.tsoMux.tso = nil
+	t.tsoMux.physical = typeutil.ZeroTime
+	t.tsoMux.logical = 0
 }

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -198,10 +198,10 @@ func (t *timestampOracle) SyncTimestamp(leadership *election.Leadership) error {
 func (t *timestampOracle) isInitialized() bool {
 	t.tsoMux.RLock()
 	defer t.tsoMux.RUnlock()
-	return t.tsoMux.physical == typeutil.ZeroTime
+	return t.tsoMux.physical != typeutil.ZeroTime
 }
 
-// resetUserTimestamp update the TSO in memory with specified TSO by an atomicly way.
+// resetUserTimestamp update the TSO in memory with specified TSO by an atomically way.
 func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, tso uint64, ignoreSmaller bool) error {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -43,8 +43,9 @@ const (
 	MaxSuffixBits = 4
 )
 
-// tsoObject is used to store the current TSO in memory.
+// tsoObject is used to store the current TSO in memory with a RWMutex lock.
 type tsoObject struct {
+	sync.RWMutex
 	physical time.Time
 	logical  int64
 }
@@ -58,10 +59,7 @@ type timestampOracle struct {
 	updatePhysicalInterval time.Duration
 	maxResetTSGap          func() time.Duration
 	// tso info stored in the memory
-	tsoMux struct {
-		sync.RWMutex
-		tsoObject
-	}
+	tsoMux *tsoObject
 	// last timestamp window stored in etcd
 	lastSavedTime atomic.Value // stored as time.Time
 	suffix        int

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -243,7 +243,11 @@ func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, ts
 		}
 	}
 	// save into memory
-	t.tsoMux.tso = &tsoObject{physical: nextPhysical, logical: int64(nextLogical)}
+	if t.tsoMux.tso == nil {
+		t.tsoMux.tso = &tsoObject{}
+	}
+	t.tsoMux.tso.physical = nextPhysical
+	t.tsoMux.tso.logical = int64(nextLogical)
 	tsoCounter.WithLabelValues("reset_tso_ok", t.dcLocation).Inc()
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

* Fix the bug that causes TSO fallback.
* Fix the problem of Local TSO physical time advancing too fast.

### What is changed and how it works?

`typeutil.SubTimeByWallClock` will use the nanosecond to compare the physical time, though the smallest unit of TSO is millisecond, there is a possibility that on the millisecond level it's the same but on nanosecond level is different when updating the physical time of TSO while restoring the logical time, which will be a fallback for TSO (physical time remains unchanged, logical time goes to 0).

If `enable-local-tso` is false, this bug won't happen because we will call `setTSOPhysical` every `50ms` at least, the interval is big enough to avoid this problem. However, in Local TSO, the TSO may be written frequently by the Global TSO synchronization, which makes this bug more likely to occur.

* Not add `updateTimestampGuard` before resetting anymore.
* Always set `t.tsoMux.tso.physical` and `t.tsoMux.tso.logical` at the same time.
* No longer using the pointer to store a `tsoObject` atomically with an `RWMutex` Lock.
* Only update physical time while the difference is big enough, in this case, it's `updateTimestampGuard`, which is `1ms` by default.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
