### PR TITLE
tso: refine the err handling and log of TSO

### DIFF
--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -14,6 +14,7 @@
 package tso
 
 import (
+	"fmt"
 	"path"
 	"sync"
 	"sync/atomic"
@@ -361,7 +362,7 @@ func (t *timestampOracle) getTS(leadership *election.Leadership, count uint32, s
 		resp.SuffixBits = uint32(suffixBits)
 		return resp, nil
 	}
-	return resp, errs.ErrGenerateTimestamp.FastGenByArgs("maximum number of retries exceeded")
+	return resp, errs.ErrGenerateTimestamp.FastGenByArgs(fmt.Sprintf("generate %s tso maximum number of retries exceeded", t.dcLocation))
 }
 
 // ResetTimestamp is used to reset the timestamp in memory.


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

For now, we only know that the sync is failed and which DCs are unsynced, but we don't know which phase it failed on.

```
[2021/04/22 00:41:32.000 +00:00] [ERROR] [client.go:473] ["[pd] getTS error"] [dc-location=global] [error="[PD:client:ErrClientGetTSO]rpc error: code = Unknown desc = [PD:tso:ErrSyncMaxTS]sync max ts failed, unsynced dc-locations found, synced dc-locations: [cross-region-chaos-1619051746-dc-1 cross-region-chaos-1619051746-dc-3], unsynced dc-locations: [cross-region-chaos-1619051746-dc-2]"] [stack="github.com/pingcap/log.Error\n\t/go/pkg/mod/github.com/pingcap/log@v0.0.0-20201112100606-8f1e84a3abc8/global.go:42\ngithub.com/tikv/pd/client.(*client).handleDispatcher\n\t/go/pkg/mod/github.com/tikv/pd@v1.1.0-beta.0.20210225143804-1f200cbcd647/client/client.go:473"]
```

### What is changed and how it works?

Add more info in the `SyncMaxTS` log and error.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
