### PR TITLE
tso: fix the TSO fallback caused by resetUserTimestamp

### DIFF
--- a/pkg/typeutil/time.go
+++ b/pkg/typeutil/time.go
@@ -31,11 +31,11 @@ func ParseTimestamp(data []byte) (time.Time, error) {
 // SubRealTimeByWallClock returns the duration between two different time.Time structs.
 // You should use it to compare the real-world system time.
 // And DO NOT USE IT TO COMPARE two TSOs' physical times directly in some cases.
-func SubRealTimeByWallClock(after time.Time, before time.Time) time.Duration {
+func SubRealTimeByWallClock(after, before time.Time) time.Duration {
 	return time.Duration(after.UnixNano() - before.UnixNano())
 }
 
 // SubTSOPhysicalByWallClock returns the duration between two different TSOs' physical times with millisecond precision.
-func SubTSOPhysicalByWallClock(after time.Time, before time.Time) int64 {
-	return SubRealTimeByWallClock(after, before).Milliseconds()
+func SubTSOPhysicalByWallClock(after, before time.Time) int64 {
+	return after.UnixNano()/int64(time.Millisecond) - before.UnixNano()/int64(time.Millisecond)
 }

--- a/pkg/typeutil/time.go
+++ b/pkg/typeutil/time.go
@@ -37,5 +37,5 @@ func SubRealTimeByWallClock(after time.Time, before time.Time) time.Duration {
 
 // SubTSOPhysicalByWallClock returns the duration between two different TSOs' physical times with millisecond precision.
 func SubTSOPhysicalByWallClock(after time.Time, before time.Time) int64 {
-	return time.Duration(after.UnixNano() - before.UnixNano()).Milliseconds()
+	return SubRealTimeByWallClock(after, before).Milliseconds()
 }

--- a/pkg/typeutil/time.go
+++ b/pkg/typeutil/time.go
@@ -28,7 +28,14 @@ func ParseTimestamp(data []byte) (time.Time, error) {
 	return time.Unix(0, int64(nano)), nil
 }
 
-// SubTimeByWallClock returns the duration between two different timestamps.
-func SubTimeByWallClock(after time.Time, before time.Time) time.Duration {
+// SubRealTimeByWallClock returns the duration between two different time.Time structs.
+// You should use it to compare the real-world system time.
+// And DO NOT USE IT TO COMPARE two TSOs' physical times directly in some cases.
+func SubRealTimeByWallClock(after time.Time, before time.Time) time.Duration {
 	return time.Duration(after.UnixNano() - before.UnixNano())
+}
+
+// SubTSOPhysicalByWallClock returns the duration between two different TSOs' physical times with millisecond precision.
+func SubTSOPhysicalByWallClock(after time.Time, before time.Time) int64 {
+	return time.Duration(after.UnixNano() - before.UnixNano()).Milliseconds()
 }

--- a/pkg/typeutil/time_test.go
+++ b/pkg/typeutil/time_test.go
@@ -39,23 +39,24 @@ func (s *testTimeSuite) TestParseTimestamp(c *C) {
 }
 
 func (s *testTimeSuite) TestSubTimeByWallClock(c *C) {
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 100; i++ {
 		r := rand.Int63n(1000)
 		t1 := time.Now()
 		// Add r seconds.
 		t2 := t1.Add(time.Second * time.Duration(r))
 		duration := SubRealTimeByWallClock(t2, t1)
 		c.Assert(duration, Equals, time.Second*time.Duration(r))
+		milliseconds := SubTSOPhysicalByWallClock(t2, t1)
+		c.Assert(milliseconds, Equals, r*time.Second.Milliseconds())
 		// Add r millionseconds.
 		t3 := t1.Add(time.Millisecond * time.Duration(r))
-		milliseconds := SubTSOPhysicalByWallClock(t3, t1)
+		milliseconds = SubTSOPhysicalByWallClock(t3, t1)
 		c.Assert(milliseconds, Equals, r)
 		// Add r nanoseconds.
 		t4 := t1.Add(time.Duration(-r))
 		duration = SubRealTimeByWallClock(t4, t1)
 		c.Assert(duration, Equals, time.Duration(-r))
-		milliseconds = SubTSOPhysicalByWallClock(t4, t1)
-		c.Assert(milliseconds, Equals, int64(0))
+		// For the millisecond comparsion, please see TestSmallTimeDifference.
 	}
 }
 
@@ -66,6 +67,10 @@ func (s *testTimeSuite) TestSmallTimeDifference(c *C) {
 	c.Assert(err, IsNil)
 	duration := SubRealTimeByWallClock(t1, t2)
 	c.Assert(duration, Equals, time.Duration(82)*time.Microsecond)
+	duration = SubRealTimeByWallClock(t2, t1)
+	c.Assert(duration, Equals, time.Duration(-82)*time.Microsecond)
 	milliseconds := SubTSOPhysicalByWallClock(t1, t2)
 	c.Assert(milliseconds, Equals, int64(1))
+	milliseconds = SubTSOPhysicalByWallClock(t2, t1)
+	c.Assert(milliseconds, Equals, int64(-1))
 }

--- a/pkg/typeutil/time_test.go
+++ b/pkg/typeutil/time_test.go
@@ -56,7 +56,7 @@ func (s *testTimeSuite) TestSubTimeByWallClock(c *C) {
 		t4 := t1.Add(time.Duration(-r))
 		duration = SubRealTimeByWallClock(t4, t1)
 		c.Assert(duration, Equals, time.Duration(-r))
-		// For the millisecond comparsion, please see TestSmallTimeDifference.
+		// For the millisecond comparison, please see TestSmallTimeDifference.
 	}
 }
 

--- a/pkg/typeutil/time_test.go
+++ b/pkg/typeutil/time_test.go
@@ -42,11 +42,19 @@ func (s *testTimeSuite) TestSubTimeByWallClock(c *C) {
 	for i := 0; i < 3; i++ {
 		r := rand.Int63n(1000)
 		t1 := time.Now()
+		// Add r seconds.
 		t2 := t1.Add(time.Second * time.Duration(r))
 		duration := SubRealTimeByWallClock(t2, t1)
 		c.Assert(duration, Equals, time.Second*time.Duration(r))
+		// Add r millionseconds.
 		t3 := t1.Add(time.Millisecond * time.Duration(r))
 		milliseconds := SubTSOPhysicalByWallClock(t3, t1)
 		c.Assert(milliseconds, Equals, r)
+		// Add r nanoseconds.
+		t4 := t1.Add(time.Duration(-r))
+		duration = SubRealTimeByWallClock(t4, t1)
+		c.Assert(duration, Equals, time.Duration(-r))
+		milliseconds = SubTSOPhysicalByWallClock(t4, t1)
+		c.Assert(milliseconds, Equals, int64(0))
 	}
 }

--- a/pkg/typeutil/time_test.go
+++ b/pkg/typeutil/time_test.go
@@ -40,10 +40,13 @@ func (s *testTimeSuite) TestParseTimestamp(c *C) {
 
 func (s *testTimeSuite) TestSubTimeByWallClock(c *C) {
 	for i := 0; i < 3; i++ {
-		r := rand.Int31n(1000)
+		r := rand.Int63n(1000)
 		t1 := time.Now()
 		t2 := t1.Add(time.Second * time.Duration(r))
-		duration := SubTimeByWallClock(t2, t1)
+		duration := SubRealTimeByWallClock(t2, t1)
 		c.Assert(duration, Equals, time.Second*time.Duration(r))
+		t3 := t1.Add(time.Millisecond * time.Duration(r))
+		milliseconds := SubTSOPhysicalByWallClock(t3, t1)
+		c.Assert(milliseconds, Equals, r)
 	}
 }

--- a/pkg/typeutil/time_test.go
+++ b/pkg/typeutil/time_test.go
@@ -58,3 +58,14 @@ func (s *testTimeSuite) TestSubTimeByWallClock(c *C) {
 		c.Assert(milliseconds, Equals, int64(0))
 	}
 }
+
+func (s *testTimeSuite) TestSmallTimeDifference(c *C) {
+	t1, err := time.Parse("2006-01-02 15:04:05.999", "2021-04-26 00:44:25.682")
+	c.Assert(err, IsNil)
+	t2, err := time.Parse("2006-01-02 15:04:05.999", "2021-04-26 00:44:25.681918")
+	c.Assert(err, IsNil)
+	duration := SubRealTimeByWallClock(t1, t2)
+	c.Assert(duration, Equals, time.Duration(82)*time.Microsecond)
+	milliseconds := SubTSOPhysicalByWallClock(t1, t2)
+	c.Assert(milliseconds, Equals, int64(1))
+}

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -75,7 +75,7 @@ func (t *timestampOracle) setTSOPhysical(next time.Time) {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
 	// make sure the ts won't fall back
-	if typeutil.SubTSOPhysicalByWallClock(next, t.tsoMux.physical) >= 0 {
+	if typeutil.SubTSOPhysicalByWallClock(next, t.tsoMux.physical) > 0 {
 		t.tsoMux.physical = next
 		t.tsoMux.logical = 0
 	}

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	timestampKey = "timestamp"
-	// updateTimestampGuard is the min physical timestamp interval.
+	// updateTimestampGuard is the min physical timestamp updating interval for the TSO.
 	updateTimestampGuard = time.Millisecond
 	// maxLogical is the max upper limit for logical time.
 	// When a TSO's logical time reaches this limit,
@@ -48,8 +48,9 @@ const (
 type tsoObject struct {
 	sync.RWMutex
 	// time.Time has a minimum unit of nanoseconds,
-	// however the minimum unit of the physical part of TSO is milliseconds,
-	// so you MUST use updateTimestampGuard or millisecond as the minimum unit when comparing the Duration.
+	// however the minimum unit of the physical part of TSO is one millisecond, a.k.a 1ms,
+	// so you MUST use millisecond as the minimum unit when comparing two TSOs' physical times,
+	// and `typeutil.SubTSOPhysicalByWallClock` is used to do this SPECIFICALLY.
 	physical time.Time
 	logical  int64
 }

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	timestampKey = "timestamp"
-	// updateTimestampGuard is the min timestamp interval.
+	// updateTimestampGuard is the min physical timestamp interval.
 	updateTimestampGuard = time.Millisecond
 	// maxLogical is the max upper limit for logical time.
 	// When a TSO's logical time reaches this limit,
@@ -47,6 +47,9 @@ const (
 // tsoObject is used to store the current TSO in memory with a RWMutex lock.
 type tsoObject struct {
 	sync.RWMutex
+	// time.Time has a minimum unit of nanoseconds,
+	// however the minimum unit of the physical part of TSO is milliseconds,
+	// so you MUST use updateTimestampGuard or millisecond as the minimum unit when comparing the Duration.
 	physical time.Time
 	logical  int64
 }
@@ -71,7 +74,7 @@ func (t *timestampOracle) setTSOPhysical(next time.Time) {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
 	// make sure the ts won't fall back
-	if typeutil.SubTimeByWallClock(next, t.tsoMux.physical) >= updateTimestampGuard {
+	if typeutil.SubTimeByWallClock(next, t.tsoMux.physical).Milliseconds() >= 0 {
 		t.tsoMux.physical = next
 		t.tsoMux.logical = 0
 	}
@@ -171,7 +174,6 @@ func (t *timestampOracle) SyncTimestamp(leadership *election.Leadership) error {
 	failpoint.Inject("systemTimeSlow", func() {
 		next = next.Add(-time.Hour)
 	})
-
 	// If the current system time minus the saved etcd timestamp is less than `updateTimestampGuard`,
 	// the timestamp allocation will start from the saved etcd timestamp temporarily.
 	if typeutil.SubTimeByWallClock(next, last) < updateTimestampGuard {
@@ -203,6 +205,8 @@ func (t *timestampOracle) isInitialized() bool {
 }
 
 // resetUserTimestamp update the TSO in memory with specified TSO by an atomically way.
+// When ignoreSmaller is true, resetUserTimestamp will ignore the smaller tso resetting error and do nothing.
+// It's used to write MaxTS during the Global TSO synchronization whitout failing the writing as much as possible.
 func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, tso uint64, ignoreSmaller bool) error {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
@@ -210,39 +214,41 @@ func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, ts
 		tsoCounter.WithLabelValues("err_lease_reset_ts", t.dcLocation).Inc()
 		return errs.ErrResetUserTimestamp.FastGenByArgs("lease expired")
 	}
-	nextPhysical, nextLogical := tsoutil.ParseTS(tso)
-	var err error
-	// do not update if next logical time is less/before than prev
-	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.physical) == 0 && int64(nextLogical) <= t.tsoMux.logical {
-		tsoCounter.WithLabelValues("err_reset_small_counter", t.dcLocation).Inc()
-		if !ignoreSmaller {
-			err = errs.ErrResetUserTimestamp.FastGenByArgs("the specified counter is smaller than now")
-		}
-	}
+	var (
+		nextPhysical, nextLogical = tsoutil.ParseTS(tso)
+		logicalDifference         = int64(nextLogical) - t.tsoMux.logical
+		physicalDifference        = typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.physical).Milliseconds()
+	)
 	// do not update if next physical time is less/before than prev
-	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.physical) < 0 {
+	if physicalDifference < 0 {
 		tsoCounter.WithLabelValues("err_reset_small_ts", t.dcLocation).Inc()
-		if !ignoreSmaller {
-			err = errs.ErrResetUserTimestamp.FastGenByArgs("the specified ts is smaller than now")
+		if ignoreSmaller {
+			return nil
 		}
+		return errs.ErrResetUserTimestamp.FastGenByArgs("the specified ts is smaller than now")
+	}
+	// do not update if next logical time is less/before/equal than prev
+	if physicalDifference == 0 && logicalDifference <= 0 {
+		tsoCounter.WithLabelValues("err_reset_small_counter", t.dcLocation).Inc()
+		if ignoreSmaller {
+			return nil
+		}
+		return errs.ErrResetUserTimestamp.FastGenByArgs("the specified counter is smaller than now")
 	}
 	// do not update if physical time is too greater than prev
-	if typeutil.SubTimeByWallClock(nextPhysical, t.tsoMux.physical) >= t.maxResetTSGap() {
+	if physicalDifference >= t.maxResetTSGap().Milliseconds() {
 		tsoCounter.WithLabelValues("err_reset_large_ts", t.dcLocation).Inc()
-		err = errs.ErrResetUserTimestamp.FastGenByArgs("the specified ts is too larger than now")
-	}
-	if err != nil {
-		return err
+		return errs.ErrResetUserTimestamp.FastGenByArgs("the specified ts is too larger than now")
 	}
 	// save into etcd only if nextPhysical is close to lastSavedTime
 	if typeutil.SubTimeByWallClock(t.lastSavedTime.Load().(time.Time), nextPhysical) <= updateTimestampGuard {
 		save := nextPhysical.Add(t.saveInterval)
-		if err = t.saveTimestamp(leadership, save); err != nil {
+		if err := t.saveTimestamp(leadership, save); err != nil {
 			tsoCounter.WithLabelValues("err_save_reset_ts", t.dcLocation).Inc()
 			return err
 		}
 	}
-	// save into memory
+	// save into memory only if nextPhysical or nextLogical is greater.
 	t.tsoMux.physical = nextPhysical
 	t.tsoMux.logical = int64(nextLogical)
 	tsoCounter.WithLabelValues("reset_tso_ok", t.dcLocation).Inc()
@@ -276,7 +282,7 @@ func (t *timestampOracle) UpdateTimestamp(leadership *election.Leadership) error
 
 	jetLag := typeutil.SubTimeByWallClock(now, prevPhysical)
 	if jetLag > 3*t.updatePhysicalInterval {
-		log.Warn("clock offset", zap.Duration("jet-lag", jetLag), zap.Time("prev-physical", prevPhysical), zap.Time("now", now))
+		log.Warn("clock offset", zap.Duration("jet-lag", jetLag), zap.Time("prev-physical", prevPhysical), zap.Time("now", now), zap.Duration("update-physical-interval", t.updatePhysicalInterval))
 		tsoCounter.WithLabelValues("slow_save", t.dcLocation).Inc()
 	}
 


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Fix the TSO fallback caused by `resetUserTimestamp`.

### What is changed and how it works?

In the previous code, we use the nanosecond to compare the next physical with TSO physical in memory, which will cause a TSO fallback in such case:

```
     second    |ms |ns  logical
now  1619094171|741|10     15
next 1619094171|741|00     10
```

While also `ignoreSmaller` flag is true, the next TSO will escape from the comparison check and make a TSO fallback eventually.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
