### PR TITLE
tso: check leadership before generating a Global TSO response

### DIFF
--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/tsoutil"
-	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/election"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -134,19 +133,9 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 	if err := gta.SyncMaxTS(ctx, dcLocationMap, maxTSO); err != nil {
 		return pdpb.Timestamp{}, err
 	}
-	// 4. Persist MaxTS into memory, and etcd if needed
-	var (
-		currentGlobalTSO pdpb.Timestamp
-		err              error
-	)
-	if currentGlobalTSO, err = gta.getCurrentTSO(); err != nil {
-		return pdpb.Timestamp{}, err
-	}
-	if tsoutil.CompareTimestamp(&currentGlobalTSO, maxTSO) < 0 {
-		// Update the Global TSO in memory
-		if err := gta.timestampOracle.resetUserTimestamp(gta.leadership, tsoutil.GenerateTS(maxTSO), true); err != nil {
-			log.Warn("update the global tso in memory failed", errs.ZapError(err))
-		}
+	// 4. Check leadership again before we returning the response.
+	if !gta.leadership.Check() {
+		return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("not the pd leader anymore")
 	}
 	// 5.Differentiate the logical part to make the TSO unique globally by giving it a unique suffix in the whole cluster
 	maxTSO.Logical = gta.timestampOracle.differentiateLogical(maxTSO.Logical, suffixBits)
@@ -306,14 +295,6 @@ func (gta *GlobalTSOAllocator) checkSyncedDCs(dcLocationMap map[string]DCLocatio
 	}
 	log.Debug("check unsynced dc-locations", zap.Strings("unsynced-DCs", unsyncedDCs), zap.Strings("synced-DCs", syncedDCs))
 	return len(unsyncedDCs) == 0, unsyncedDCs
-}
-
-func (gta *GlobalTSOAllocator) getCurrentTSO() (pdpb.Timestamp, error) {
-	currentPhysical, currentLogical := gta.timestampOracle.getTSO()
-	if currentPhysical == typeutil.ZeroTime {
-		return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("timestamp in memory isn't initialized")
-	}
-	return *tsoutil.GenerateTimestamp(currentPhysical, uint64(currentLogical)), nil
 }
 
 // Reset is used to reset the TSO allocator.

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -357,7 +357,7 @@ func (t *timestampOracle) getTS(leadership *election.Leadership, count uint32, s
 		}
 		// In case lease expired after the first check.
 		if !leadership.Check() {
-			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("not the pd or local tso allocator leader")
+			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("not the pd or local tso allocator leader anymore")
 		}
 		resp.SuffixBits = uint32(suffixBits)
 		return resp, nil


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Part of #3633.

### What is changed and how it works?

* Make sure the PD leadership before we return a Global TSO response.
* Remove TSO resetting process in Global TSO generation.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
