### PR TITLE
tso: only run Local TSO related daemons when EnableLocalTSO

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -362,9 +362,8 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.member.SetMemberGitHash(s.member.ID(), versioninfo.PDGitHash)
 	s.idAllocator = id.NewAllocator(s.client, s.rootPath, s.member.MemberValue())
 	s.tsoAllocatorManager = tso.NewAllocatorManager(
-		s.member, s.rootPath, s.cfg.TSOSaveInterval.Duration, s.cfg.TSOUpdatePhysicalInterval.Duration,
-		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() },
-		s.GetTLSConfig())
+		s.member, s.rootPath, s.cfg,
+		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() })
 	// Set up the Global TSO Allocator here, it will be initialized once the PD campaigns leader successfully.
 	s.tsoAllocatorManager.SetUpAllocator(ctx, tso.GlobalDCLocation, s.member.GetLeadership())
 	if zone, exist := s.cfg.Labels[config.ZoneLabel]; exist && zone != "" && s.cfg.EnableLocalTSO {

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -1077,15 +1077,15 @@ func (am *AllocatorManager) getDCLocationInfoFromLeader(ctx context.Context, dcL
 func (am *AllocatorManager) GetMaxLocalTSO(ctx context.Context) (*pdpb.Timestamp, error) {
 	// Sync the max local TSO from the other Local TSO Allocators who has been initialized
 	clusterDCLocations := am.GetClusterDCLocations()
-	maxTSO := &pdpb.Timestamp{}
-	if len(clusterDCLocations) == 0 {
-		return maxTSO, nil
-	}
 	for dcLocation := range clusterDCLocations {
 		allocatorGroup, ok := am.getAllocatorGroup(dcLocation)
 		if !(ok && allocatorGroup.leadership.Check()) {
 			delete(clusterDCLocations, dcLocation)
 		}
+	}
+	maxTSO := &pdpb.Timestamp{}
+	if len(clusterDCLocations) == 0 {
+		return maxTSO, nil
 	}
 	globalAllocator, err := am.GetAllocator(GlobalDCLocation)
 	if err != nil {

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -534,11 +534,10 @@ func (am *AllocatorManager) campaignAllocatorLeader(
 // any new local allocator that needs to be set up.
 func (am *AllocatorManager) AllocatorDaemon(serverCtx context.Context) {
 	var (
-		tsTicker      = &time.Ticker{}
+		tsTicker      = time.NewTicker(am.updatePhysicalInterval)
 		patrolTicker  = &time.Ticker{}
 		checkerTicker = &time.Ticker{}
 	)
-	tsTicker = time.NewTicker(am.updatePhysicalInterval)
 	defer tsTicker.Stop()
 	// Local TSO related daemon goroutines only work when enableLocalTSO is true.
 	if am.enableLocalTSO {
@@ -552,7 +551,7 @@ func (am *AllocatorManager) AllocatorDaemon(serverCtx context.Context) {
 		select {
 		case <-tsTicker.C:
 			am.allocatorUpdater()
-		case <-patrolTicker.C:
+		case <-tsTicker.C:
 			am.allocatorPatroller(serverCtx)
 		case <-checkerTicker.C:
 			// ClusterDCLocationChecker and PriorityChecker are time consuming and low frequent to run,


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Only run Local TSO related daemons when `EnableLocalTSO` is true.

### What is changed and how it works?

Check `EnableLocalTSO` flag before running these daemons.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
