### PR TITLE
tso: ensure cluster TSO consistency after Local TSO is turned off

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -245,6 +245,9 @@ const (
 	DefaultTSOUpdatePhysicalInterval = 50 * time.Millisecond
 	maxTSOUpdatePhysicalInterval     = 10 * time.Second
 	minTSOUpdatePhysicalInterval     = 50 * time.Millisecond
+
+	// DefaultTSOSaveInterval is the default value of the config `TSOSaveInterval`.
+	DefaultTSOSaveInterval = time.Duration(defaultLeaderLease) * time.Second
 )
 
 // Special keys for Labels
@@ -526,7 +529,7 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 
 	adjustInt64(&c.LeaderLease, defaultLeaderLease)
 
-	adjustDuration(&c.TSOSaveInterval, time.Duration(defaultLeaderLease)*time.Second)
+	adjustDuration(&c.TSOSaveInterval, DefaultTSOSaveInterval)
 
 	adjustDuration(&c.TSOUpdatePhysicalInterval, DefaultTSOUpdatePhysicalInterval)
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -241,13 +241,11 @@ const (
 	defaultDRWaitSyncTimeout  = time.Minute
 	defaultDRWaitAsyncTimeout = 2 * time.Minute
 
+	defaultTSOSaveInterval = time.Duration(defaultLeaderLease) * time.Second
 	// DefaultTSOUpdatePhysicalInterval is the default value of the config `TSOUpdatePhysicalInterval`.
 	DefaultTSOUpdatePhysicalInterval = 50 * time.Millisecond
 	maxTSOUpdatePhysicalInterval     = 10 * time.Second
 	minTSOUpdatePhysicalInterval     = 50 * time.Millisecond
-
-	// DefaultTSOSaveInterval is the default value of the config `TSOSaveInterval`.
-	DefaultTSOSaveInterval = time.Duration(defaultLeaderLease) * time.Second
 )
 
 // Special keys for Labels
@@ -529,7 +527,7 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 
 	adjustInt64(&c.LeaderLease, defaultLeaderLease)
 
-	adjustDuration(&c.TSOSaveInterval, DefaultTSOSaveInterval)
+	adjustDuration(&c.TSOSaveInterval, defaultTSOSaveInterval)
 
 	adjustDuration(&c.TSOUpdatePhysicalInterval, DefaultTSOUpdatePhysicalInterval)
 

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -149,7 +149,7 @@ func (t *timestampOracle) loadTimestamp() (time.Time, error) {
 			log.Error("parse timestamp window that from etcd failed", zap.String("dc-location", t.dcLocation), zap.String("ts-window-key", key), zap.Time("max-ts-window", maxTSWindow), zap.Error(err))
 			continue
 		}
-		if typeutil.SubTimeByWallClock(tsWindow, maxTSWindow) > 0 {
+		if typeutil.SubRealTimeByWallClock(tsWindow, maxTSWindow) > 0 {
 			maxTSWindow = tsWindow
 		}
 	}

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -16,6 +16,7 @@ package tso
 import (
 	"fmt"
 	"path"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -122,15 +123,33 @@ func (t *timestampOracle) getTimestampPath() string {
 	return path.Join(t.rootPath, timestampKey)
 }
 
+// loadTimestamp will get all time windows of Local/Global TSOs from etcd and return the biggest one.
+// For the Global TSO, loadTimestamp will get all Local and Global TSO time windows persisted in etcd and choose the biggest one.
+// For the Local TSO, loadTimestamp will only get its own dc-location time window persisted before.
 func (t *timestampOracle) loadTimestamp() (time.Time, error) {
-	data, err := etcdutil.GetValue(t.client, t.getTimestampPath())
+	resp, err := etcdutil.EtcdKVGet(
+		t.client,
+		t.rootPath,
+		clientv3.WithPrefix())
 	if err != nil {
 		return typeutil.ZeroTime, err
 	}
-	if len(data) == 0 {
-		return typeutil.ZeroTime, nil
+	maxTSWindow := typeutil.ZeroTime
+	for _, kv := range resp.Kvs {
+		key := strings.TrimSpace(string(kv.Key))
+		if !strings.HasSuffix(key, timestampKey) {
+			continue
+		}
+		tsWindow, err := typeutil.ParseTimestamp(kv.Value)
+		if err != nil {
+			log.Error("parse timestamp window that from etcd failed", zap.String("dc-location", t.dcLocation), zap.String("ts-window-key", key), zap.Time("max-ts-window", maxTSWindow), zap.Error(err))
+			continue
+		}
+		if typeutil.SubTimeByWallClock(tsWindow, maxTSWindow) > 0 {
+			maxTSWindow = tsWindow
+		}
 	}
-	return typeutil.ParseTimestamp(data)
+	return maxTSWindow, nil
 }
 
 // save timestamp, if lastTs is 0, we think the timestamp doesn't exist, so create it,

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -1,0 +1,117 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tso_test
+
+import (
+	"context"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/tikv/pd/pkg/grpcutil"
+	"github.com/tikv/pd/pkg/testutil"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/tests"
+)
+
+var _ = Suite(&testTSOSuite{})
+
+type testTSOSuite struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (s *testTSOSuite) SetUpSuite(c *C) {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	server.EnableZap = true
+}
+
+func (s *testTSOSuite) TearDownSuite(c *C) {
+	s.cancel()
+}
+
+func (s *testTSOSuite) TestLoadTimestamp(c *C) {
+	dcLocationConfig := map[string]string{
+		"pd1": "dc-1",
+		"pd2": "dc-2",
+		"pd3": "dc-3",
+	}
+	dcLocationNum := len(dcLocationConfig)
+	cluster, err := tests.NewTestCluster(s.ctx, dcLocationNum, func(conf *config.Config, serverName string) {
+		conf.EnableLocalTSO = true
+		conf.Labels[config.ZoneLabel] = dcLocationConfig[serverName]
+	})
+	defer cluster.Destroy()
+	c.Assert(err, IsNil)
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+
+	cluster.WaitAllLeaders(c, dcLocationConfig)
+	leaderServer := cluster.GetServer(cluster.GetLeader())
+
+	dcClientMap := make(map[string]pdpb.PDClient)
+	lastTSMap := make(map[string]*pdpb.Timestamp)
+	for _, dcLocation := range dcLocationConfig {
+		pdName := leaderServer.GetAllocatorLeader(dcLocation).GetName()
+		dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
+	}
+	for _, dcLocation := range dcLocationConfig {
+		req := &pdpb.TsoRequest{
+			Header:     testutil.NewRequestHeader(leaderServer.GetClusterID()),
+			Count:      tsoCount,
+			DcLocation: dcLocation,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		ctx = grpcutil.BuildForwardContext(ctx, cluster.GetServer(leaderServer.GetAllocatorLeader(dcLocation).GetName()).GetAddr())
+		lastTSMap[dcLocation] = testGetLocalTimestamp(c, ctx, dcClientMap[dcLocation], req)
+		cancel()
+	}
+
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/tso/systemTimeSlow", `return(true)`), IsNil)
+
+	// Reboot the cluster.
+	err = cluster.StopAll()
+	c.Assert(err, IsNil)
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+
+	cluster.WaitAllLeaders(c, dcLocationConfig)
+	leaderServer = cluster.GetServer(cluster.GetLeader())
+
+	// Re-create the PD client map.
+	for _, dcLocation := range dcLocationConfig {
+		pdName := leaderServer.GetAllocatorLeader(dcLocation).GetName()
+		dcClientMap[dcLocation] = testutil.MustNewGrpcClient(c, cluster.GetServer(pdName).GetAddr())
+	}
+	for _, dcLocation := range dcLocationConfig {
+		req := &pdpb.TsoRequest{
+			Header:     testutil.NewRequestHeader(leaderServer.GetClusterID()),
+			Count:      tsoCount,
+			DcLocation: dcLocation,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		ctx = grpcutil.BuildForwardContext(ctx, cluster.GetServer(leaderServer.GetAllocatorLeader(dcLocation).GetName()).GetAddr())
+		lastTS, ok := lastTSMap[dcLocation]
+		c.Assert(ok, IsTrue)
+		ts := testGetLocalTimestamp(c, ctx, dcClientMap[dcLocation], req)
+		cancel()
+
+		// The new physical time of TSO is at least as large as the previous DefaultTSOSaveInterval time interval
+		c.Assert(ts.GetPhysical()-lastTS.GetPhysical(), Greater, config.DefaultTSOSaveInterval.Milliseconds())
+	}
+
+	failpoint.Disable("github.com/tikv/pd/server/tso/systemTimeSlow")
+}


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Part of #3633. We need to ensure the TSO consistency when the Local/Global cluster back to a single-point normal TSO. 

### What is changed and how it works?

* For the Global TSO, `loadTimestamp` will get all Local and Global TSO time windows persisted in etcd and choose the biggest one.
* For the Local TSO, `loadTimestamp` will only get its own dc-location time window persisted before.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
