### PR TITLE
tso: test: refine and add a test for EnableLocalTSO

### DIFF
--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -1150,3 +1150,8 @@ func (am *AllocatorManager) transferLocalAllocator(dcLocation string, serverID u
 func (am *AllocatorManager) nextLeaderKey(dcLocation string) string {
 	return path.Join(am.rootPath, dcLocation, "next-leader")
 }
+
+// EnableLocalTSO returns the value of AllocatorManager.enableLocalTSO.
+func (am *AllocatorManager) EnableLocalTSO() bool {
+	return am.enableLocalTSO
+}

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -533,31 +533,36 @@ func (am *AllocatorManager) campaignAllocatorLeader(
 // AllocatorDaemon is used to update every allocator's TSO and check whether we have
 // any new local allocator that needs to be set up.
 func (am *AllocatorManager) AllocatorDaemon(serverCtx context.Context) {
-	var (
-		tsTicker      = time.NewTicker(am.updatePhysicalInterval)
-		patrolTicker  = &time.Ticker{}
-		checkerTicker = &time.Ticker{}
-	)
-	defer tsTicker.Stop()
-	// Local TSO related daemon goroutines only work when enableLocalTSO is true.
+	// allocatorPatroller should only work when enableLocalTSO is true to
+	// set up the new Local TSO Allocator in time.
+	var patrolTicker = &time.Ticker{}
 	if am.enableLocalTSO {
 		patrolTicker = time.NewTicker(patrolStep)
 		defer patrolTicker.Stop()
-		checkerTicker = time.NewTicker(PriorityCheck)
-		defer checkerTicker.Stop()
 	}
+	tsTicker := time.NewTicker(am.updatePhysicalInterval)
+	defer tsTicker.Stop()
+	checkerTicker := time.NewTicker(PriorityCheck)
+	defer checkerTicker.Stop()
 
 	for {
 		select {
-		case <-tsTicker.C:
-			am.allocatorUpdater()
 		case <-patrolTicker.C:
+			// Inspect the cluster dc-location info and set up the new Local TSO Allocator in time.
 			am.allocatorPatroller(serverCtx)
+		case <-tsTicker.C:
+			// Update the initialized TSO Allocator to advance TSO.
+			am.allocatorUpdater()
 		case <-checkerTicker.C:
-			// ClusterDCLocationChecker and PriorityChecker are time consuming and low frequent to run,
-			// we should run them concurrently to speed up the progress.
+			// Check and maintain the cluster's meta info about dc-location distribution.
 			go am.ClusterDCLocationChecker()
-			go am.PriorityChecker()
+			// We won't have any Local TSO Allocator set up in PD without enabling Local TSO.
+			if am.enableLocalTSO {
+				// Check the election priority of every Local TSO Allocator this PD is holding.
+				go am.PriorityChecker()
+			}
+			// PS: ClusterDCLocationChecker and PriorityChecker are time consuming and low frequent to run,
+			// we should run them concurrently to speed up the progress.
 		case <-serverCtx.Done():
 			return
 		}

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -549,7 +549,7 @@ func (c *TestCluster) WaitAllocatorLeader(dcLocation string, ops ...WaitOption) 
 		counter := make(map[string]int)
 		running := 0
 		for _, s := range c.servers {
-			if s.state == Running {
+			if s.state == Running && s.GetTSOAllocatorManager().EnableLocalTSO() {
 				running++
 			}
 			serverName := s.GetAllocatorLeader(dcLocation).GetName()

--- a/tests/server/tso/allocator_test.go
+++ b/tests/server/tso/allocator_test.go
@@ -50,14 +50,16 @@ func (s *testAllocatorSuite) TearDownSuite(c *C) {
 func (s *testAllocatorSuite) TestAllocatorLeader(c *C) {
 	// There will be three Local TSO Allocator leaders elected
 	dcLocationConfig := map[string]string{
-		"pd1": "dc-1",
-		"pd2": "dc-2",
-		"pd3": "dc-3",
+		"pd2": "dc-1",
+		"pd4": "dc-2",
+		"pd6": "dc-3",
 	}
 	dcLocationNum := len(dcLocationConfig)
-	cluster, err := tests.NewTestCluster(s.ctx, dcLocationNum, func(conf *config.Config, serverName string) {
-		conf.EnableLocalTSO = true
-		conf.Labels[config.ZoneLabel] = dcLocationConfig[serverName]
+	cluster, err := tests.NewTestCluster(s.ctx, dcLocationNum*2, func(conf *config.Config, serverName string) {
+		if zoneLabel, ok := dcLocationConfig[serverName]; ok {
+			conf.EnableLocalTSO = true
+			conf.Labels[config.ZoneLabel] = zoneLabel
+		}
 	})
 	defer cluster.Destroy()
 	c.Assert(err, IsNil)
@@ -101,6 +103,10 @@ func (s *testAllocatorSuite) TestAllocatorLeader(c *C) {
 	for _, server := range cluster.GetServers() {
 		// Filter out Global TSO Allocator
 		allocators := server.GetTSOAllocatorManager().GetAllocators(tso.FilterDCLocation(tso.GlobalDCLocation))
+		if _, ok := dcLocationConfig[server.GetServer().Name()]; !ok {
+			c.Assert(len(allocators), Equals, 0)
+			continue
+		}
 		c.Assert(len(allocators), Equals, dcLocationNum)
 		for _, allocator := range allocators {
 			allocatorFollower, _ := allocator.(*tso.LocalTSOAllocator)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

#3634 makes the TSO Allocator Manager only run the Local TSO daemons when `EnableLocalTSO` is true. This PR fixes some problems the previous change has and adds a test for it.

### What is changed and how it works?

* `am.ClusterDCLocationChecker()` should run even `EnableLocalTSO` is false to check and maintain the cluster DC info because this kind of PDs could also become PD leaders to allocate the Global TSO.
* Add a test case for this change. 6 PDs while only 3 of them enable Local TSO.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
