### PR TITLE
Makefile: don't rely on hardcoded path for bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ OVERALLS := overalls
 BUILD_BIN_PATH := $(shell pwd)/bin
 GO_TOOLS_BIN_PATH := $(shell pwd)/.tools/bin
 PATH := $(GO_TOOLS_BIN_PATH):$(PATH)
-SHELL := env PATH='$(PATH)' GOBIN='$(GO_TOOLS_BIN_PATH)' /bin/bash
+SHELL := env PATH='$(PATH)' GOBIN='$(GO_TOOLS_BIN_PATH)' $(shell which bash)
 
 FAILPOINT_ENABLE  := $$(find $$PWD/ -type d | grep -vE "\.git" | xargs failpoint-ctl enable)
 FAILPOINT_DISABLE := $$(find $$PWD/ -type d | grep -vE "\.git" | xargs failpoint-ctl disable)


### PR DESCRIPTION

### What problem does this PR solve?

Not all systems have bash installed in `/bin/bash`.
```
[dvaneeden@freebsd-tidb ~]$ which bash
/usr/local/bin/bash
[dvaneeden@freebsd-tidb ~]$ uname -sr
FreeBSD 13.0-RELEASE
```




<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Instead of hardcoding this as `/bin/bash` use `$(shell which bash)`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->


- Manual test (add detailed scripts or steps below)
Run a `gmake build` on FreeBSD 13.0




### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
