### PR TITLE
pd-ctl: expose GetRootCmd for integration tests, clean up interfaces

### DIFF
--- a/tests/dashboard/service_test.go
+++ b/tests/dashboard/service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 
 	// Register schedulers.
 	_ "github.com/tikv/pd/server/schedulers"
@@ -135,7 +136,7 @@ func (s *dashboardTestSuite) testDashboard(c *C, internalProxy bool) {
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)
 
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	cluster.WaitLeader()
 	servers := cluster.GetServers()

--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -63,8 +63,6 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	ci := &metapb.Cluster{}
 	c.Assert(json.Unmarshal(output, ci), IsNil)
 	c.Assert(ci, DeepEquals, cluster.GetCluster())
-	echo := pdctl.GetEcho([]string{"-u", pdAddr, "--cacert=ca.pem", "cluster"})
-	c.Assert(strings.Contains(echo, "no such file or directory"), IsTrue)
 
 	// cluster info
 	args = []string{"-u", pdAddr, "cluster"}
@@ -94,4 +92,9 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	output, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
 	c.Assert(output, NotNil)
+
+	// does not exist
+	args = []string{"-u", pdAddr, "--cacert=ca.pem", "cluster"}
+	_, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, ErrorMatches, ".*no such file or directory.*")
 }

--- a/tests/pdctl/cluster/cluster_test.go
+++ b/tests/pdctl/cluster/cluster_test.go
@@ -26,6 +26,7 @@ import (
 	clusterpkg "github.com/tikv/pd/server/cluster"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -53,7 +54,7 @@ func (s *clusterTestSuite) TestClusterAndPing(c *C) {
 	pdAddr := cluster.GetConfig().GetClientURL()
 	i := strings.Index(pdAddr, "//")
 	pdAddr = pdAddr[i+2:]
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 	defer cluster.Destroy()
 
 	// cluster

--- a/tests/pdctl/completion/completion_test.go
+++ b/tests/pdctl/completion/completion_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -29,7 +30,7 @@ var _ = Suite(&completionTestSuite{})
 type completionTestSuite struct{}
 
 func (s *completionTestSuite) TestCompletion(c *C) {
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	// completion command
 	args := []string{"completion", "bash"}

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -68,7 +69,7 @@ func (s *configTestSuite) TestConfig(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:    1,
@@ -236,7 +237,7 @@ func (s *configTestSuite) TestPlacementRules(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,
@@ -324,7 +325,7 @@ func (s *configTestSuite) TestPlacementRuleGroups(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,
@@ -388,7 +389,7 @@ func (s *configTestSuite) TestPlacementRuleBundle(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,
@@ -526,7 +527,7 @@ func (s *configTestSuite) TestReplicationMode(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,
@@ -582,7 +583,7 @@ func (s *configTestSuite) TestUpdateDefaultReplicaConfig(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:    1,

--- a/tests/pdctl/health/health_test.go
+++ b/tests/pdctl/health/health_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tikv/pd/server/cluster"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -49,7 +50,7 @@ func (s *healthTestSuite) TestHealth(c *C) {
 	leaderServer := tc.GetServer(tc.GetLeader())
 	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 	pdAddr := tc.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 	defer tc.Destroy()
 
 	client := tc.GetEtcdClient()

--- a/tests/pdctl/helper.go
+++ b/tests/pdctl/helper.go
@@ -17,8 +17,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/gogo/protobuf/proto"
@@ -32,36 +30,11 @@ import (
 	"github.com/tikv/pd/server/versioninfo"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tools/pd-ctl/pdctl"
-	"github.com/tikv/pd/tools/pd-ctl/pdctl/command"
 )
 
 // InitCommand is used to initialize command.
 func InitCommand() *cobra.Command {
-	commandFlags := pdctl.CommandFlags{}
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().StringVarP(&commandFlags.URL, "pd", "u", "", "")
-	rootCmd.Flags().StringVar(&commandFlags.CAPath, "cacert", "", "")
-	rootCmd.Flags().StringVar(&commandFlags.CertPath, "cert", "", "")
-	rootCmd.Flags().StringVar(&commandFlags.KeyPath, "key", "", "")
-	rootCmd.AddCommand(
-		command.NewConfigCommand(),
-		command.NewRegionCommand(),
-		command.NewStoreCommand(),
-		command.NewStoresCommand(),
-		command.NewMemberCommand(),
-		command.NewExitCommand(),
-		command.NewLabelCommand(),
-		command.NewPingCommand(),
-		command.NewOperatorCommand(),
-		command.NewSchedulerCommand(),
-		command.NewTSOCommand(),
-		command.NewHotSpotCommand(),
-		command.NewClusterCommand(),
-		command.NewHealthCommand(),
-		command.NewLogCommand(),
-		command.NewPluginCommand(),
-		command.NewCompletionCommand(),
-	)
+	rootCmd := pdctl.GetRootCmd()
 	return rootCmd
 }
 
@@ -70,7 +43,6 @@ func ExecuteCommand(root *cobra.Command, args ...string) (output []byte, err err
 	buf := new(bytes.Buffer)
 	root.SetOutput(buf)
 	root.SetArgs(args)
-
 	err = root.Execute()
 	return buf.Bytes(), err
 }
@@ -137,18 +109,4 @@ func MustPutRegion(c *check.C, cluster *tests.TestCluster, regionID, storeID uin
 	err := cluster.HandleRegionHeartbeat(r)
 	c.Assert(err, check.IsNil)
 	return r
-}
-
-// GetEcho is used to get echo from stdout.
-func GetEcho(args []string) string {
-	filename := filepath.Join(os.TempDir(), "stdout")
-	old := os.Stdout
-	temp, _ := os.Create(filename)
-	os.Stdout = temp
-	pdctl.Start(args)
-	temp.Close()
-	os.Stdout = old
-	out, _ := os.ReadFile(filename)
-	_ = os.Remove(filename)
-	return string(out)
 }

--- a/tests/pdctl/helper.go
+++ b/tests/pdctl/helper.go
@@ -29,14 +29,7 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/versioninfo"
 	"github.com/tikv/pd/tests"
-	"github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
-
-// InitCommand is used to initialize command.
-func InitCommand() *cobra.Command {
-	rootCmd := pdctl.GetRootCmd()
-	return rootCmd
-}
 
 // ExecuteCommand is used for test purpose.
 func ExecuteCommand(root *cobra.Command, args ...string) (output []byte, err error) {

--- a/tests/pdctl/hot/hot_test.go
+++ b/tests/pdctl/hot/hot_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tikv/pd/server/statistics"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -53,7 +54,7 @@ func (s *hotTestSuite) TestHot(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,

--- a/tests/pdctl/label/label_test.go
+++ b/tests/pdctl/label/label_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -50,7 +51,7 @@ func (s *labelTestSuite) TestLabel(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	stores := []*metapb.Store{
 		{

--- a/tests/pdctl/log/log_test.go
+++ b/tests/pdctl/log/log_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -46,7 +47,7 @@ func (s *logTestSuite) TestLog(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,

--- a/tests/pdctl/member/member_test.go
+++ b/tests/pdctl/member/member_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -53,7 +54,7 @@ func (s *memberTestSuite) TestMember(c *C) {
 	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 	pdAddr := cluster.GetConfig().GetClientURL()
 	c.Assert(err, IsNil)
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 	svr := cluster.GetServer("pd2")
 	id := svr.GetServerID()
 	name := svr.GetServer().Name()

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -59,7 +60,7 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	stores := []*metapb.Store{
 		{

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -219,8 +219,9 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	output, err = pdctl.ExecuteCommand(cmd, "operator", "add", "transfer-region", "1", "2", "leader", "3", "follower")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
-	echo := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
-	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "operator", "remove", "1")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Success!"), IsTrue)
 
 	_, err = pdctl.ExecuteCommand(cmd, "config", "set", "enable-placement-rules", "false")
 	c.Assert(err, IsNil)
@@ -237,7 +238,7 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 	c.Assert(strings.Contains(string(output), "scatter-region"), IsTrue)
 
 	// test echo, as the scatter region result is random, both region 1 and region 3 can be the region to be scattered
-	echo1 := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "1"})
-	echo2 := pdctl.GetEcho([]string{"-u", pdAddr, "operator", "remove", "3"})
-	c.Assert(strings.Contains(echo1, "Success!") || strings.Contains(echo2, "Success!"), IsTrue)
+	output1, _ := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "operator", "remove", "1")
+	output2, _ := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "operator", "remove", "3")
+	c.Assert(strings.Contains(string(output1), "Success!") || strings.Contains(string(output2), "Success!"), IsTrue)
 }

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -60,7 +61,7 @@ func (s *regionTestSuite) TestRegionKeyFormat(c *C) {
 	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 	pdctl.MustPutStore(c, leaderServer.GetServer(), store)
 
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 	output, e := pdctl.ExecuteCommand(cmd, "-u", url, "region", "key", "--format=raw", " ")
 	c.Assert(e, IsNil)
 	c.Assert(strings.Contains(string(output), "unknown flag"), IsFalse)
@@ -75,7 +76,7 @@ func (s *regionTestSuite) TestRegion(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -60,8 +60,10 @@ func (s *regionTestSuite) TestRegionKeyFormat(c *C) {
 	c.Assert(leaderServer.BootstrapCluster(), IsNil)
 	pdctl.MustPutStore(c, leaderServer.GetServer(), store)
 
-	echo := pdctl.GetEcho([]string{"-u", url, "region", "key", "--format=raw", " "})
-	c.Assert(strings.Contains(echo, "unknown flag"), IsFalse)
+	cmd := pdctl.InitCommand()
+	output, e := pdctl.ExecuteCommand(cmd, "-u", url, "region", "key", "--format=raw", " ")
+	c.Assert(e, IsNil)
+	c.Assert(strings.Contains(string(output), "unknown flag"), IsFalse)
 }
 
 func (s *regionTestSuite) TestRegion(c *C) {

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -49,7 +50,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	stores := []*metapb.Store{
 		{

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -240,7 +240,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "shuffle-region-scheduler"}, &roles)
 	c.Assert(roles, DeepEquals, []string{"learner"})
 
-	// test echo
+	// test balance region config
 	echo := mustExec([]string{"-u", pdAddr, "scheduler", "add", "balance-region-scheduler"}, nil)
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
 	echo = mustExec([]string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"}, nil)

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -74,13 +74,14 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 		},
 	}
 
-	mustExec := func(args []string, v interface{}) {
+	mustExec := func(args []string, v interface{}) string {
 		output, err := pdctl.ExecuteCommand(cmd, args...)
 		c.Assert(err, IsNil)
 		if v == nil {
-			return
+			return string(output)
 		}
 		c.Assert(json.Unmarshal(output, v), IsNil)
+		return ""
 	}
 
 	checkSchedulerCommand := func(args []string, expected map[string]bool) {
@@ -240,21 +241,21 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	c.Assert(roles, DeepEquals, []string{"learner"})
 
 	// test echo
-	echo := pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "add", "balance-region-scheduler"})
+	echo := mustExec([]string{"-u", pdAddr, "scheduler", "add", "balance-region-scheduler"}, nil)
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"})
+	echo = mustExec([]string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"}, nil)
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"})
+	echo = mustExec([]string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"}, nil)
 	c.Assert(strings.Contains(echo, "Success!"), IsFalse)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "add", "evict-leader-scheduler", "1"})
+	echo = mustExec([]string{"-u", pdAddr, "scheduler", "add", "evict-leader-scheduler", "1"}, nil)
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "remove", "evict-leader-scheduler-1"})
+	echo = mustExec([]string{"-u", pdAddr, "scheduler", "remove", "evict-leader-scheduler-1"}, nil)
 	c.Assert(strings.Contains(echo, "Success!"), IsTrue)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "remove", "evict-leader-scheduler-1"})
+	echo = mustExec([]string{"-u", pdAddr, "scheduler", "remove", "evict-leader-scheduler-1"}, nil)
 	c.Assert(strings.Contains(echo, "404"), IsTrue)
 
 	// test hot region config
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "scheduler", "config", "evict-leader-scheduler"})
+	echo = mustExec([]string{"-u", pdAddr, "scheduler", "config", "evict-leader-scheduler"}, nil)
 	c.Assert(strings.Contains(echo, "[404] scheduler not found"), IsTrue)
 	var conf map[string]interface{}
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "list"}, &conf)

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -223,17 +223,23 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(strings.Contains(string(output), "rate should be a number that > 0"), IsTrue)
 
 	// store limit <type>
-	echo := pdctl.GetEcho([]string{"-u", pdAddr, "store", "limit"})
+	args = []string{"-u", pdAddr, "store", "limit"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+
 	allAddPeerLimit := make(map[string]map[string]interface{})
-	json.Unmarshal([]byte(echo), &allAddPeerLimit)
+	json.Unmarshal([]byte(output), &allAddPeerLimit)
 	c.Assert(allAddPeerLimit["1"]["add-peer"].(float64), Equals, float64(20))
 	c.Assert(allAddPeerLimit["3"]["add-peer"].(float64), Equals, float64(20))
 	_, ok := allAddPeerLimit["2"]["add-peer"]
 	c.Assert(ok, Equals, false)
 
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "store", "limit", "remove-peer"})
+	args = []string{"-u", pdAddr, "store", "limit", "remove-peer"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+
 	allRemovePeerLimit := make(map[string]map[string]interface{})
-	json.Unmarshal([]byte(echo), &allRemovePeerLimit)
+	json.Unmarshal([]byte(output), &allRemovePeerLimit)
 	c.Assert(allRemovePeerLimit["1"]["remove-peer"].(float64), Equals, float64(20))
 	c.Assert(allRemovePeerLimit["3"]["remove-peer"].(float64), Equals, float64(25))
 	_, ok = allRemovePeerLimit["2"]["add-peer"]
@@ -273,12 +279,20 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(len([]*api.StoreInfo{storeInfo}), Equals, 1)
 
 	// It should be called after stores remove-tombstone.
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit"})
-	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit", "remove-peer"})
-	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
-	echo = pdctl.GetEcho([]string{"-u", pdAddr, "stores", "show", "limit", "add-peer"})
-	c.Assert(strings.Contains(echo, "PANIC"), IsFalse)
+	args = []string{"-u", pdAddr, "stores", "show", "limit"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "PANIC"), IsFalse)
+
+	args = []string{"-u", pdAddr, "stores", "show", "limit", "remove-peer"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "PANIC"), IsFalse)
+
+	args = []string{"-u", pdAddr, "stores", "show", "limit", "add-peer"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "PANIC"), IsFalse)
 	// store limit-scene
 	args = []string{"-u", pdAddr, "store", "limit-scene"}
 	output, err = pdctl.ExecuteCommand(cmd, args...)

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tikv/pd/server/core/storelimit"
 	"github.com/tikv/pd/tests"
 	"github.com/tikv/pd/tests/pdctl"
+	cmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -50,7 +51,7 @@ func (s *storeTestSuite) TestStore(c *C) {
 	c.Assert(err, IsNil)
 	cluster.WaitLeader()
 	pdAddr := cluster.GetConfig().GetClientURL()
-	cmd := pdctl.InitCommand()
+	cmd := cmd.GetRootCmd()
 
 	stores := []*metapb.Store{
 		{

--- a/tests/pdctl/tso/tso_test.go
+++ b/tests/pdctl/tso/tso_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/tests/pdctl"
+	pdctlCmd "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
 func Test(t *testing.T) {
@@ -37,7 +38,7 @@ func (s *tsoTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *tsoTestSuite) TestTSO(c *C) {
-	cmd := pdctl.InitCommand()
+	cmd := pdctlCmd.GetRootCmd()
 
 	const (
 		physicalShiftBits = 18

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -26,24 +26,7 @@ import (
 	"github.com/tikv/pd/tools/pd-ctl/pdctl/command"
 )
 
-// CommandFlags are flags that used in all Commands
-type CommandFlags struct {
-	URL      string
-	CAPath   string
-	CertPath string
-	KeyPath  string
-	Help     bool
-	// Deprecated: the default mode is detach mode now.
-	Detach   bool
-	Interact bool
-	Version  bool
-}
-
 var (
-	commandFlags = CommandFlags{
-		URL: "http://127.0.0.1:2379",
-	}
-
 	readlineCompleter *readline.PrefixCompleter
 )
 
@@ -51,30 +34,17 @@ func init() {
 	cobra.EnablePrefixMatching = true
 }
 
-func pdctlRun(cmd *cobra.Command, args []string) {
-	if commandFlags.Version {
-		server.PrintPDInfo()
-		return
-	}
-	if commandFlags.Interact {
-		loop()
-	}
-}
-
-func getBasicCmd() *cobra.Command {
+func GetRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "pd-ctl",
 		Short: "Placement Driver control",
 	}
 
-	rootCmd.PersistentFlags().BoolVarP(&commandFlags.Detach, "detach", "d", true, "Run pdctl without readline.")
-	rootCmd.PersistentFlags().BoolVarP(&commandFlags.Interact, "interact", "i", false, "Run pdctl with readline.")
-	rootCmd.PersistentFlags().BoolVarP(&commandFlags.Version, "version", "V", false, "Print version information and exit.")
-	rootCmd.PersistentFlags().StringVarP(&commandFlags.URL, "pd", "u", commandFlags.URL, "address of pd")
-	rootCmd.PersistentFlags().StringVar(&commandFlags.CAPath, "cacert", commandFlags.CAPath, "path of file that contains list of trusted SSL CAs")
-	rootCmd.PersistentFlags().StringVar(&commandFlags.CertPath, "cert", commandFlags.CertPath, "path of file that contains X509 certificate in PEM format")
-	rootCmd.PersistentFlags().StringVar(&commandFlags.KeyPath, "key", commandFlags.KeyPath, "path of file that contains X509 key in PEM format")
-	rootCmd.PersistentFlags().BoolVarP(&commandFlags.Help, "help", "h", false, "help message")
+	rootCmd.PersistentFlags().StringP("pd", "u", "http://127.0.0.1:2379", "address of pd")
+	rootCmd.PersistentFlags().String("cacert", "", "path of file that contains list of trusted SSL CAs")
+	rootCmd.PersistentFlags().String("cert", "", "path of file that contains X509 certificate in PEM format")
+	rootCmd.PersistentFlags().String("key", "", "path of file that contains X509 key in PEM format")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "help message")
 
 	rootCmd.AddCommand(
 		command.NewConfigCommand(),
@@ -100,70 +70,59 @@ func getBasicCmd() *cobra.Command {
 	rootCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
 	rootCmd.SilenceErrors = true
 
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		CAPath, err := cmd.Flags().GetString("cacert")
+		if err == nil && len(CAPath) != 0 {
+			certPath, err := cmd.Flags().GetString("cert")
+			if err != nil {
+				return err
+			}
+
+			keyPath, err := cmd.Flags().GetString("key")
+			if err != nil {
+				return err
+			}
+
+			if err := command.InitHTTPSClient(CAPath, certPath, keyPath); err != nil {
+				rootCmd.Println(err)
+				return err
+			}
+		}
+		return nil
+	}
+
 	return rootCmd
 }
 
-func getInteractCmd(args []string) *cobra.Command {
-	rootCmd := getBasicCmd()
+// MainStart start main command
+func MainStart(args []string) {
+	rootCmd := GetRootCmd()
 
-	rootCmd.SetArgs(args)
-	rootCmd.ParseFlags(args)
-	rootCmd.SetOutput(os.Stdout)
-	hiddenFlag(rootCmd)
+	rootCmd.Flags().BoolP("interact", "i", false, "Run pdctl with readline.")
+	rootCmd.Flags().BoolP("version", "V", false, "Print version information and exit.")
+	// TODO: deprecated
+	rootCmd.Flags().BoolP("detach", "d", true, "Run pdctl without readline.")
 
-	return rootCmd
-}
-
-func getMainCmd(args []string) *cobra.Command {
-	rootCmd := getBasicCmd()
-	rootCmd.Run = pdctlRun
+	rootCmd.Run = func(cmd *cobra.Command, args []string) {
+		if v, err := cmd.Flags().GetBool("version"); err == nil && v {
+			server.PrintPDInfo()
+			return
+		}
+		if v, err := cmd.Flags().GetBool("interact"); err == nil && v {
+			loop()
+		}
+	}
 
 	rootCmd.SetArgs(args)
 	rootCmd.ParseFlags(args)
 	rootCmd.SetOutput(os.Stdout)
 
 	readlineCompleter = readline.NewPrefixCompleter(genCompleter(rootCmd)...)
-	rootCmd.LocalFlags().MarkHidden("detach")
-	return rootCmd
-}
-
-// Hide the flags in help and usage messages.
-func hiddenFlag(cmd *cobra.Command) {
-	cmd.LocalFlags().MarkHidden("pd")
-	cmd.LocalFlags().MarkHidden("cacert")
-	cmd.LocalFlags().MarkHidden("cert")
-	cmd.LocalFlags().MarkHidden("key")
-	cmd.LocalFlags().MarkHidden("detach")
-	cmd.LocalFlags().MarkHidden("interact")
-	cmd.LocalFlags().MarkHidden("version")
-}
-
-// MainStart start main command
-func MainStart(args []string) {
-	if err := startCmd(getMainCmd, args); err != nil {
-		os.Exit(1)
-	}
-}
-
-// Start start interact command
-func Start(args []string) {
-	_ = startCmd(getInteractCmd, args)
-}
-
-func startCmd(getCmd func([]string) *cobra.Command, args []string) error {
-	rootCmd := getCmd(args)
-	if len(commandFlags.CAPath) != 0 {
-		if err := command.InitHTTPSClient(commandFlags.CAPath, commandFlags.CertPath, commandFlags.KeyPath); err != nil {
-			rootCmd.Println(err)
-			return err
-		}
-	}
 
 	if err := rootCmd.Execute(); err != nil {
 		rootCmd.Println(err)
-		return err
+		os.Exit(1)
 	}
-	return nil
 }
 
 func loop() {
@@ -179,6 +138,9 @@ func loop() {
 		panic(err)
 	}
 	defer l.Close()
+
+	rootCmd := GetRootCmd()
+	rootCmd.SetOutput(os.Stdout)
 
 	for {
 		line, err := l.Readline()
@@ -198,7 +160,14 @@ func loop() {
 			fmt.Printf("parse command err: %v\n", err)
 			continue
 		}
-		Start(args)
+
+		rootCmd.SetArgs(args)
+		rootCmd.ParseFlags(args)
+
+		if err := rootCmd.Execute(); err != nil {
+			rootCmd.Println(err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -34,6 +34,7 @@ func init() {
 	cobra.EnablePrefixMatching = true
 }
 
+// GetRootCmd is exposed for integration tests. But it can be embedded into another suite, too.
 func GetRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "pd-ctl",

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -45,7 +45,6 @@ func GetRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().String("cacert", "", "path of file that contains list of trusted SSL CAs")
 	rootCmd.PersistentFlags().String("cert", "", "path of file that contains X509 certificate in PEM format")
 	rootCmd.PersistentFlags().String("key", "", "path of file that contains X509 key in PEM format")
-	rootCmd.PersistentFlags().BoolP("help", "h", false, "help message")
 
 	rootCmd.AddCommand(
 		command.NewConfigCommand(),


### PR DESCRIPTION
### What problem does this PR solve?

close #3419 

Changes:

1. Unite `getBasicCmd`, `getMainCmd` and `getInteractCmd` into `GetRootCmd`. Removed `GetEcho`, `Start`, `pdctlRun`, `startCmd`. Only `MainStart` is left.
2. Removed unused `detach` flag, `hiddenFlag` function.
3. Make flags like `cacert` and more local

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note

- No release note
