### PR TITLE
tools: hide some barely used configurations

### DIFF
--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -88,9 +88,19 @@ func (s *configTestSuite) TestConfig(c *C) {
 	cfg := config.Config{}
 	c.Assert(json.Unmarshal(output, &cfg), IsNil)
 	scheduleConfig := svr.GetScheduleConfig()
+
+	// hidden config
 	scheduleConfig.Schedulers = nil
 	scheduleConfig.SchedulersPayload = nil
 	scheduleConfig.StoreLimit = nil
+	scheduleConfig.SchedulerMaxWaitingOperator = 0
+	scheduleConfig.EnableRemoveDownReplica = false
+	scheduleConfig.EnableReplaceOfflineReplica = false
+	scheduleConfig.EnableMakeUpReplica = false
+	scheduleConfig.EnableRemoveExtraReplica = false
+	scheduleConfig.EnableLocationReplacement = false
+	scheduleConfig.StoreLimitMode = ""
+
 	c.Assert(&cfg.Schedule, DeepEquals, scheduleConfig)
 	c.Assert(&cfg.Replication, DeepEquals, svr.GetReplicationConfig())
 

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -219,9 +219,10 @@ func showConfigCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	delete(scheduleConfig, "schedulers-v2")
-	delete(scheduleConfig, "schedulers-payload")
-	delete(scheduleConfig, "store-limit")
+	for _, config := range hideConfig {
+		delete(scheduleConfig, config)
+	}
+
 	data["schedule"] = scheduleConfig
 	r, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
@@ -229,6 +230,21 @@ func showConfigCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	cmd.Println(string(r))
+}
+
+var hideConfig = []string{
+	"schedulers-v2",
+	"schedulers-payload",
+	"store-limit",
+	"enable-remove-down-replica",
+	"enable-replace-offline-replica",
+	"enable-make-up-replica",
+	"enable-remove-extra-replica",
+	"enable-location-replacement",
+	"enable-one-way-merge",
+	"enable-debug-metrics",
+	"store-limit-mode",
+	"scheduler-max-waiting-operator",
 }
 
 func showScheduleConfigCommandFunc(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

There are too many configurations that are barely used, we can hide these configurations to improve UE.

### What is changed and how it works?

This PR deletes some fields for the output of pd-ctl config show command.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test 

After this PR:
```
» config show
{
  "replication": {
    "enable-placement-rules": "true",
    "isolation-level": "",
    "location-labels": "",
    "max-replicas": 3,
    "strictly-match-label": "false"
  },
  "schedule": {
    "enable-cross-table-merge": "true",
    "enable-joint-consensus": "true",
    "high-space-ratio": 0.7,
    "hot-region-cache-hits-threshold": 3,
    "hot-region-schedule-limit": 4,
    "leader-schedule-limit": 4,
    "leader-schedule-policy": "count",
    "low-space-ratio": 0.8,
    "max-merge-region-keys": 200000,
    "max-merge-region-size": 20,
    "max-pending-peer-count": 16,
    "max-snapshot-count": 3,
    "max-store-down-time": "30m0s",
    "merge-schedule-limit": 8,
    "patrol-region-interval": "100ms",
    "region-schedule-limit": 2048,
    "region-score-formula-version": "v2",
    "replica-schedule-limit": 64,
    "split-merge-interval": "1h0m0s",
    "tolerant-size-ratio": 0
  }
}
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
