### PR TITLE
schedulers: unify hot region scheduler's influence

### DIFF
--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -426,8 +426,7 @@ func (c *coordinator) stop() {
 type hasHotStatus interface {
 	GetHotReadStatus() *statistics.StoreHotPeersInfos
 	GetHotWriteStatus() *statistics.StoreHotPeersInfos
-	GetWritePendingInfluence() map[uint64]*schedulers.Influence
-	GetReadPendingInfluence() map[uint64]*schedulers.Influence
+	GetPendingInfluence() map[uint64]*schedulers.Influence
 }
 
 func (c *coordinator) getHotWriteRegions() *statistics.StoreHotPeersInfos {
@@ -505,7 +504,7 @@ func (c *coordinator) collectHotSpotMetrics() {
 	c.RUnlock()
 	stores := c.cluster.GetStores()
 	status := s.Scheduler.(hasHotStatus).GetHotWriteStatus()
-	pendings := s.Scheduler.(hasHotStatus).GetWritePendingInfluence()
+	pendings := s.Scheduler.(hasHotStatus).GetPendingInfluence()
 	for _, s := range stores {
 		storeAddress := s.GetAddress()
 		storeID := s.GetID()
@@ -542,7 +541,6 @@ func (c *coordinator) collectHotSpotMetrics() {
 
 	// Collects hot read region metrics.
 	status = s.Scheduler.(hasHotStatus).GetHotReadStatus()
-	pendings = s.Scheduler.(hasHotStatus).GetReadPendingInfluence()
 	for _, s := range stores {
 		storeAddress := s.GetAddress()
 		storeID := s.GetID()

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -99,7 +99,6 @@ type hotScheduler struct {
 
 	// temporary states but exported to API or metrics
 	stLoadInfos [resourceTypeLen]map[uint64]*storeLoadDetail
-	// pendingSums indicates the [resourceType] storeID -> pending Influence
 	// This stores the pending Influence for each store by resource type.
 	pendingSums map[uint64]*Influence
 	// config of hot scheduler

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -1092,15 +1092,7 @@ func (h *hotScheduler) GetHotWriteStatus() *statistics.StoreHotPeersInfos {
 	}
 }
 
-func (h *hotScheduler) GetWritePendingInfluence() map[uint64]*Influence {
-	return h.copyPendingInfluence()
-}
-
-func (h *hotScheduler) GetReadPendingInfluence() map[uint64]*Influence {
-	return h.copyPendingInfluence()
-}
-
-func (h *hotScheduler) copyPendingInfluence() map[uint64]*Influence {
+func (h *hotScheduler) GetPendingInfluence() map[uint64]*Influence {
 	h.RLock()
 	defer h.RUnlock()
 	ret := make(map[uint64]*Influence, len(h.pendingSums))

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -102,10 +102,6 @@ type hotScheduler struct {
 	// pendingSums indicates the [resourceType] storeID -> pending Influence
 	// This stores the pending Influence for each store by resource type.
 	pendingSums map[uint64]*Influence
-	// regionReadStat records storeID -> []HotPeerStat for read type
-	regionReadStat map[uint64][]*statistics.HotPeerStat
-	// regionWriteStat records storeID -> []HotPeerStat for write type
-	regionWriteStat map[uint64][]*statistics.HotPeerStat
 	// config of hot scheduler
 	conf *hotRegionSchedulerConfig
 }
@@ -212,28 +208,28 @@ func (h *hotScheduler) prepareForBalance(cluster opt.Cluster) {
 	h.summaryPendingInfluence()
 
 	storesLoads := cluster.GetStoresLoads()
-	h.regionReadStat = cluster.RegionReadStats()
-	h.regionWriteStat = cluster.RegionWriteStats()
 
 	{ // update read statistics
+		regionRead := cluster.RegionReadStats()
 		h.stLoadInfos[readLeader] = summaryStoresLoad(
 			storesLoads,
 			h.pendingSums,
-			h.regionReadStat,
+			regionRead,
 			read, core.LeaderKind)
 	}
 
 	{ // update write statistics
+		regionWrite := cluster.RegionWriteStats()
 		h.stLoadInfos[writeLeader] = summaryStoresLoad(
 			storesLoads,
 			h.pendingSums,
-			h.regionWriteStat,
+			regionWrite,
 			write, core.LeaderKind)
 
 		h.stLoadInfos[writePeer] = summaryStoresLoad(
 			storesLoads,
 			h.pendingSums,
-			h.regionWriteStat,
+			regionWrite,
 			write, core.RegionKind)
 	}
 }

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -1247,9 +1247,7 @@ func (s *testInfluenceSerialSuite) TestInfluenceByRWType(c *C) {
 }
 
 func nearlyAbout(f1, f2 float64) bool {
-	if f1-f2 < 0.1*KB {
-		return true
-	} else if f2-f1 < 0.1*KB {
+	if f1-f2 < 0.1*KB || f2-f1 < 0.1*KB {
 		return true
 	}
 	return false

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -36,10 +36,16 @@ func init() {
 	schedulePeerPr = 1.0
 }
 
+type testHotSchedulerSuite struct{}
+type testInfluenceSerialSuite struct{}
+type testHotCacheSuite struct{}
+type testHotReadRegionSchedulerSuite struct{}
+
 var _ = Suite(&testHotWriteRegionSchedulerSuite{})
 var _ = Suite(&testHotSchedulerSuite{})
-
-type testHotSchedulerSuite struct{}
+var _ = Suite(&testHotReadRegionSchedulerSuite{})
+var _ = Suite(&testHotCacheSuite{})
+var _ = SerialSuites(&testInfluenceSerialSuite{})
 
 func (s *testHotSchedulerSuite) TestGCPendingOpInfos(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -624,10 +630,6 @@ func (s *testHotWriteRegionSchedulerSuite) TestWithRuleEnabled(c *C) {
 	}
 }
 
-var _ = Suite(&testHotReadRegionSchedulerSuite{})
-
-type testHotReadRegionSchedulerSuite struct{}
-
 func (s *testHotReadRegionSchedulerSuite) TestByteRateOnly(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -884,10 +886,6 @@ func (s *testHotReadRegionSchedulerSuite) TestWithPendingInfluence(c *C) {
 		}
 	}
 }
-
-var _ = Suite(&testHotCacheSuite{})
-
-type testHotCacheSuite struct{}
 
 func (s *testHotCacheSuite) TestUpdateCache(c *C) {
 	opt := config.NewTestOptions()
@@ -1172,4 +1170,89 @@ func (s *testHotCacheSuite) TestCheckRegionFlowWithDifferentThreshold(c *C) {
 			c.Check(item.IsNeedDelete(), IsFalse)
 		}
 	}
+}
+
+func (s *testInfluenceSerialSuite) TestInfluenceByRWType(c *C) {
+	originValue := schedulePeerPr
+	defer func() {
+		schedulePeerPr = originValue
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	statistics.Denoising = false
+	opt := config.NewTestOptions()
+	hb, err := schedule.CreateScheduler(HotWriteRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
+	c.Assert(err, IsNil)
+	hb.(*hotScheduler).conf.SetDstToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetSrcToleranceRatio(1)
+	tc := mockcluster.NewCluster(opt)
+	tc.SetHotRegionCacheHitsThreshold(0)
+	tc.DisableFeature(versioninfo.JointConsensus)
+	tc.AddRegionStore(1, 20)
+	tc.AddRegionStore(2, 20)
+	tc.AddRegionStore(3, 20)
+	tc.AddRegionStore(4, 20)
+	tc.UpdateStorageWrittenStats(1, 99*MB*statistics.StoreHeartBeatReportInterval, 99*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(2, 50*MB*statistics.StoreHeartBeatReportInterval, 98*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(3, 2*MB*statistics.StoreHeartBeatReportInterval, 2*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(4, 1*MB*statistics.StoreHeartBeatReportInterval, 1*MB*statistics.StoreHeartBeatReportInterval)
+	addRegionInfo(tc, write, []testRegionInfo{
+		{1, []uint64{2, 1, 3}, 0.5 * MB, 0.5 * MB},
+	})
+	addRegionInfo(tc, read, []testRegionInfo{
+		{1, []uint64{2, 1, 3}, 0.5 * MB, 0.5 * MB},
+	})
+	// must move peer
+	schedulePeerPr = 1.0
+	// must move peer from 1 to 4
+	op := hb.Schedule(tc)[0]
+	c.Assert(op, NotNil)
+	hb.(*hotScheduler).summaryPendingInfluence()
+	writePendingInfluence := hb.(*hotScheduler).pendingSums[write]
+	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteKeys], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteBytes], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(writePendingInfluence[4].Loads[statistics.RegionWriteKeys], 0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(writePendingInfluence[4].Loads[statistics.RegionWriteBytes], 0.5*MB), IsTrue)
+	readPendingInfluence := hb.(*hotScheduler).pendingSums[read]
+	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadKeys], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadBytes], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(readPendingInfluence[4].Loads[statistics.RegionReadKeys], 0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(readPendingInfluence[4].Loads[statistics.RegionReadBytes], 0.5*MB), IsTrue)
+
+	addRegionInfo(tc, write, []testRegionInfo{
+		{2, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
+		{3, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
+		{4, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
+	})
+	addRegionInfo(tc, read, []testRegionInfo{
+		{2, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
+		{3, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
+		{4, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
+	})
+	// must transfer leader
+	schedulePeerPr = 0
+	// must transfer leader from 1 to 3
+	op = hb.Schedule(tc)[0]
+	c.Assert(op, NotNil)
+	hb.(*hotScheduler).summaryPendingInfluence()
+	writePendingInfluence = hb.(*hotScheduler).pendingSums[write]
+	// assert read/write influence is the sum of write peer and write leader
+	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteKeys], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteBytes], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(writePendingInfluence[3].Loads[statistics.RegionWriteKeys], 0.7*MB), IsTrue)
+	c.Assert(nearlyAbout(writePendingInfluence[3].Loads[statistics.RegionWriteBytes], 0.7*MB), IsTrue)
+	readPendingInfluence = hb.(*hotScheduler).pendingSums[read]
+	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadKeys], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadBytes], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(readPendingInfluence[3].Loads[statistics.RegionReadKeys], 0.7*MB), IsTrue)
+	c.Assert(nearlyAbout(readPendingInfluence[3].Loads[statistics.RegionReadBytes], 0.7*MB), IsTrue)
+}
+
+func nearlyAbout(f1, f2 float64) bool {
+	if f1-f2 < 0.1*KB {
+		return true
+	} else if f2-f1 < 0.1*KB {
+		return true
+	}
+	return false
 }

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -1208,16 +1208,15 @@ func (s *testInfluenceSerialSuite) TestInfluenceByRWType(c *C) {
 	op := hb.Schedule(tc)[0]
 	c.Assert(op, NotNil)
 	hb.(*hotScheduler).summaryPendingInfluence()
-	writePendingInfluence := hb.(*hotScheduler).pendingSums[write]
-	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteKeys], -0.5*MB), IsTrue)
-	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteBytes], -0.5*MB), IsTrue)
-	c.Assert(nearlyAbout(writePendingInfluence[4].Loads[statistics.RegionWriteKeys], 0.5*MB), IsTrue)
-	c.Assert(nearlyAbout(writePendingInfluence[4].Loads[statistics.RegionWriteBytes], 0.5*MB), IsTrue)
-	readPendingInfluence := hb.(*hotScheduler).pendingSums[read]
-	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadKeys], -0.5*MB), IsTrue)
-	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadBytes], -0.5*MB), IsTrue)
-	c.Assert(nearlyAbout(readPendingInfluence[4].Loads[statistics.RegionReadKeys], 0.5*MB), IsTrue)
-	c.Assert(nearlyAbout(readPendingInfluence[4].Loads[statistics.RegionReadBytes], 0.5*MB), IsTrue)
+	pendingInfluence := hb.(*hotScheduler).pendingSums
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionWriteKeys], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionWriteBytes], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[4].Loads[statistics.RegionWriteKeys], 0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[4].Loads[statistics.RegionWriteBytes], 0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionReadKeys], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionReadBytes], -0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[4].Loads[statistics.RegionReadKeys], 0.5*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[4].Loads[statistics.RegionReadBytes], 0.5*MB), IsTrue)
 
 	addRegionInfo(tc, write, []testRegionInfo{
 		{2, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
@@ -1235,17 +1234,16 @@ func (s *testInfluenceSerialSuite) TestInfluenceByRWType(c *C) {
 	op = hb.Schedule(tc)[0]
 	c.Assert(op, NotNil)
 	hb.(*hotScheduler).summaryPendingInfluence()
-	writePendingInfluence = hb.(*hotScheduler).pendingSums[write]
+	pendingInfluence = hb.(*hotScheduler).pendingSums
 	// assert read/write influence is the sum of write peer and write leader
-	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteKeys], -1.2*MB), IsTrue)
-	c.Assert(nearlyAbout(writePendingInfluence[1].Loads[statistics.RegionWriteBytes], -1.2*MB), IsTrue)
-	c.Assert(nearlyAbout(writePendingInfluence[3].Loads[statistics.RegionWriteKeys], 0.7*MB), IsTrue)
-	c.Assert(nearlyAbout(writePendingInfluence[3].Loads[statistics.RegionWriteBytes], 0.7*MB), IsTrue)
-	readPendingInfluence = hb.(*hotScheduler).pendingSums[read]
-	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadKeys], -1.2*MB), IsTrue)
-	c.Assert(nearlyAbout(readPendingInfluence[1].Loads[statistics.RegionReadBytes], -1.2*MB), IsTrue)
-	c.Assert(nearlyAbout(readPendingInfluence[3].Loads[statistics.RegionReadKeys], 0.7*MB), IsTrue)
-	c.Assert(nearlyAbout(readPendingInfluence[3].Loads[statistics.RegionReadBytes], 0.7*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionWriteKeys], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionWriteBytes], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[3].Loads[statistics.RegionWriteKeys], 0.7*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[3].Loads[statistics.RegionWriteBytes], 0.7*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionReadKeys], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[1].Loads[statistics.RegionReadBytes], -1.2*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[3].Loads[statistics.RegionReadKeys], 0.7*MB), IsTrue)
+	c.Assert(nearlyAbout(pendingInfluence[3].Loads[statistics.RegionReadBytes], 0.7*MB), IsTrue)
 }
 
 func nearlyAbout(f1, f2 float64) bool {

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -145,12 +145,6 @@ func getKeyRanges(args []string) ([]core.KeyRange, error) {
 	return ranges, nil
 }
 
-// InfluenceSummary records influence by read and write
-type InfluenceSummary struct {
-	ReadInfluence  Influence
-	WriteInfluence Influence
-}
-
 // Influence records operator influence.
 type Influence struct {
 	Loads []float64

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -145,6 +145,12 @@ func getKeyRanges(args []string) ([]core.KeyRange, error) {
 	return ranges, nil
 }
 
+// InfluenceSummary records influence by read and write
+type InfluenceSummary struct {
+	ReadInfluence  Influence
+	WriteInfluence Influence
+}
+
 // Influence records operator influence.
 type Influence struct {
 	Loads []float64


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
Currently, the pending influence holding by hot region scheduler is classified by the `resourceType`, not `read/write type`.
This will cause the write-peer and write-leader can't see each other's influence(either do read-peer and read-leader in the future)

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
1. unify hot region scheduler's influence
2. make read/write pending influence can be summarized by each hot schedule operator

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

* No release not
