### PR TITLE
scheduler: simplify pending influence

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -92,10 +92,10 @@ type hotScheduler struct {
 
 	// states across multiple `Schedule` calls
 	pendings map[*pendingInfluence]struct{}
-	// regionPendings stores regionID -> [opType]Operator
+	// regionPendings stores regionID -> Operator
 	// this records regionID which have pending Operator by operation type. During filterHotPeers, the hot peers won't
 	// be selected if its owner region is tracked in this attribute.
-	regionPendings map[uint64][2]*operator.Operator
+	regionPendings map[uint64]*operator.Operator
 
 	// temporary states but exported to API or metrics
 	stLoadInfos [resourceTypeLen]map[uint64]*storeLoadDetail
@@ -114,7 +114,7 @@ func newHotScheduler(opController *schedule.OperatorController, conf *hotRegionS
 		peerLimit:      1,
 		types:          []rwType{write, read},
 		r:              rand.New(rand.NewSource(time.Now().UnixNano())),
-		regionPendings: make(map[uint64][2]*operator.Operator),
+		regionPendings: make(map[uint64]*operator.Operator),
 		conf:           conf,
 	}
 	ret.pendings = map[*pendingInfluence]struct{}{}
@@ -243,24 +243,13 @@ func (h *hotScheduler) summaryPendingInfluence() {
 // gcRegionPendings check the region whether it need to be deleted from regionPendings depended on whether it have
 // ended operator
 func (h *hotScheduler) gcRegionPendings() {
-	for regionID, pendings := range h.regionPendings {
-		empty := true
-		for ty, op := range pendings {
-			if op != nil && op.IsEnd() {
-				if time.Now().After(op.GetCreateTime().Add(h.conf.GetMaxZombieDuration())) {
-					log.Debug("gc pending influence in hot region scheduler", zap.Uint64("region-id", regionID), zap.Time("create", op.GetCreateTime()), zap.Time("now", time.Now()), zap.Duration("zombie", h.conf.GetMaxZombieDuration()))
-					schedulerStatus.WithLabelValues(h.GetName(), "pending_op_infos").Dec()
-					pendings[ty] = nil
-				}
+	for regionID, op := range h.regionPendings {
+		if op != nil && op.IsEnd() {
+			if time.Now().After(op.GetCreateTime().Add(h.conf.GetMaxZombieDuration())) {
+				log.Debug("gc pending influence in hot region scheduler", zap.Uint64("region-id", regionID), zap.Time("create", op.GetCreateTime()), zap.Time("now", time.Now()), zap.Duration("zombie", h.conf.GetMaxZombieDuration()))
+				schedulerStatus.WithLabelValues(h.GetName(), "pending_op_infos").Dec()
+				delete(h.regionPendings, regionID)
 			}
-			if pendings[ty] != nil {
-				empty = false
-			}
-		}
-		if empty {
-			delete(h.regionPendings, regionID)
-		} else {
-			h.regionPendings[regionID] = pendings
 		}
 	}
 }
@@ -388,12 +377,7 @@ func (h *hotScheduler) addPendingInfluence(op *operator.Operator, srcStore, dstS
 
 	influence := newPendingInfluence(op, srcStore, dstStore, infl)
 	h.pendings[influence] = struct{}{}
-	h.regionPendings[regionID] = [2]*operator.Operator{nil, nil}
-	{
-		tmp := h.regionPendings[regionID]
-		tmp[opTy] = op
-		h.regionPendings[regionID] = tmp
-	}
+	h.regionPendings[regionID] = op
 
 	schedulerStatus.WithLabelValues(h.GetName(), "pending_op_infos").Inc()
 	return true
@@ -684,12 +668,12 @@ func (bs *balanceSolver) isRegionAvailable(region *core.RegionInfo) bool {
 		return false
 	}
 
-	if pendings, ok := bs.sche.regionPendings[region.GetID()]; ok {
+	if op, ok := bs.sche.regionPendings[region.GetID()]; ok {
 		if bs.opTy == transferLeader {
 			return false
 		}
-		if pendings[movePeer] != nil ||
-			(pendings[transferLeader] != nil && !pendings[transferLeader].IsEnd()) {
+		if op.Kind()&operator.OpRegion != 0 ||
+			(op.Kind()&operator.OpLeader != 0 && !op.IsEnd()) {
 			return false
 		}
 	}
@@ -1128,7 +1112,7 @@ func (h *hotScheduler) calcPendingWeight(op *operator.Operator) float64 {
 func (h *hotScheduler) clearPendingInfluence() {
 	h.pendings = map[*pendingInfluence]struct{}{}
 	h.pendingSums = nil
-	h.regionPendings = make(map[uint64][2]*operator.Operator)
+	h.regionPendings = make(map[uint64]*operator.Operator)
 }
 
 // rwType : the perspective of balance


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

For a region to have only one operator at a time, it is not necessary to use [opLen]pendingInfluence

### What is changed and how it works?

replace `[opLen]pendingInfluence` with  simple pending influence 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
