### PR TITLE
*: close the response body when finished with it

### DIFF
--- a/server/api/member_test.go
+++ b/server/api/member_test.go
@@ -147,8 +147,8 @@ func changeLeaderPeerUrls(c *C, leader *pdpb.Member, id uint64, urls []string) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := testDialClient.Do(req)
 	c.Assert(err, IsNil)
-	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, Equals, 204)
+	resp.Body.Close()
 }
 
 type testResignAPISuite struct {

--- a/server/api/member_test.go
+++ b/server/api/member_test.go
@@ -147,6 +147,7 @@ func changeLeaderPeerUrls(c *C, leader *pdpb.Member, id uint64, urls []string) {
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := testDialClient.Do(req)
 	c.Assert(err, IsNil)
+	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, Equals, 204)
 }
 

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -286,7 +286,6 @@ func (h *schedulerHandler) redirectSchedulerDelete(name, schedulerName string) e
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return errs.ErrSchedulerNotFound.FastGenByArgs()
 	}

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -286,6 +286,7 @@ func (h *schedulerHandler) redirectSchedulerDelete(name, schedulerName string) e
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return errs.ErrSchedulerNotFound.FastGenByArgs()
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1337,12 +1337,12 @@ func (s *Server) ReplicateFileToAllMembers(ctx context.Context, name string, dat
 			log.Warn("failed to replicate file", zap.String("name", name), zap.String("member", member.GetName()), errs.ZapError(err))
 			return errs.ErrSendRequest.Wrap(err).GenWithStackByCause()
 		}
+		// Since we don't read the body, we can close it immediately.
+		res.Body.Close()
 		if res.StatusCode != http.StatusOK {
 			log.Warn("failed to replicate file", zap.String("name", name), zap.String("member", member.GetName()), zap.Int("status-code", res.StatusCode))
-			res.Body.Close()
 			return errs.ErrSendRequest.FastGenByArgs()
 		}
-		res.Body.Close()
 	}
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1337,6 +1337,7 @@ func (s *Server) ReplicateFileToAllMembers(ctx context.Context, name string, dat
 			log.Warn("failed to replicate file", zap.String("name", name), zap.String("member", member.GetName()), errs.ZapError(err))
 			return errs.ErrSendRequest.Wrap(err).GenWithStackByCause()
 		}
+		defer res.Body.Close()
 		if res.StatusCode != http.StatusOK {
 			log.Warn("failed to replicate file", zap.String("name", name), zap.String("member", member.GetName()), zap.Int("status-code", res.StatusCode))
 			return errs.ErrSendRequest.FastGenByArgs()

--- a/server/server.go
+++ b/server/server.go
@@ -1337,11 +1337,12 @@ func (s *Server) ReplicateFileToAllMembers(ctx context.Context, name string, dat
 			log.Warn("failed to replicate file", zap.String("name", name), zap.String("member", member.GetName()), errs.ZapError(err))
 			return errs.ErrSendRequest.Wrap(err).GenWithStackByCause()
 		}
-		defer res.Body.Close()
 		if res.StatusCode != http.StatusOK {
 			log.Warn("failed to replicate file", zap.String("name", name), zap.String("member", member.GetName()), zap.Int("status-code", res.StatusCode))
+			res.Body.Close()
 			return errs.ErrSendRequest.FastGenByArgs()
 		}
+		res.Body.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

According to the [overview of package "net/http"](https://golang.org/pkg/net/http/#Response), the client must close the response body when finished with it. This could be detected by:

```shell
golangci-lint run -E bodyclose
```

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
