### PR TITLE
*: clean up useless parameters

### DIFF
--- a/pkg/autoscaling/calculation_test.go
+++ b/pkg/autoscaling/calculation_test.go
@@ -304,9 +304,9 @@ func (s *calculationTestSuite) TestScaleOutGroupLabel(c *C) {
 	strategy := &Strategy{}
 	err := json.Unmarshal(jsonStr, strategy)
 	c.Assert(err, IsNil)
-	plan := findBestGroupToScaleOut(strategy, 0, nil, TiKV)
+	plan := findBestGroupToScaleOut(strategy, nil, TiKV)
 	c.Assert(plan.Labels["specialUse"], Equals, "hotRegion")
-	plan = findBestGroupToScaleOut(strategy, 0, nil, TiDB)
+	plan = findBestGroupToScaleOut(strategy, nil, TiDB)
 	c.Assert(plan.Labels["specialUse"], Equals, "")
 }
 
@@ -357,20 +357,20 @@ func (s *calculationTestSuite) TestStrategyChangeCount(c *C) {
 	// exist two scaled TiKVs and plan does not change due to the limit of resource count
 	groups, err := getScaledTiKVGroups(cluster, instances)
 	c.Assert(err, IsNil)
-	plans := calculateScaleOutPlan(strategy, TiKV, scaleOutQuota, instances, groups)
+	plans := calculateScaleOutPlan(strategy, TiKV, scaleOutQuota, groups)
 	c.Assert(plans[0].Count, Equals, uint64(2))
 
 	// change the resource count to 3 and plan increates one more tikv
 	groups, err = getScaledTiKVGroups(cluster, instances)
 	c.Assert(err, IsNil)
 	*strategy.Resources[0].Count = 3
-	plans = calculateScaleOutPlan(strategy, TiKV, scaleOutQuota, instances, groups)
+	plans = calculateScaleOutPlan(strategy, TiKV, scaleOutQuota, groups)
 	c.Assert(plans[0].Count, Equals, uint64(3))
 
 	// change the resource count to 1 and plan decreases to 1 tikv due to the limit of resource count
 	groups, err = getScaledTiKVGroups(cluster, instances)
 	c.Assert(err, IsNil)
 	*strategy.Resources[0].Count = 1
-	plans = calculateScaleOutPlan(strategy, TiKV, scaleOutQuota, instances, groups)
+	plans = calculateScaleOutPlan(strategy, TiKV, scaleOutQuota, groups)
 	c.Assert(plans[0].Count, Equals, uint64(1))
 }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -14,7 +14,6 @@
 package api
 
 import (
-	"context"
 	"net/http"
 	"net/http/pprof"
 	"strings"
@@ -47,7 +46,7 @@ func createIndentRender() *render.Render {
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 // @BasePath /pd/api/v1
-func createRouter(ctx context.Context, prefix string, svr *server.Server) *mux.Router {
+func createRouter(prefix string, svr *server.Server) *mux.Router {
 	rd := createIndentRender()
 
 	rootRouter := mux.NewRouter().PathPrefix(prefix).Subrouter()

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -32,7 +32,7 @@ func NewHandler(ctx context.Context, svr *server.Server) (http.Handler, server.S
 		IsCore: true,
 	}
 	router := mux.NewRouter()
-	r := createRouter(ctx, apiPrefix, svr)
+	r := createRouter(apiPrefix, svr)
 	router.PathPrefix(apiPrefix).Handler(negroni.New(
 		serverapi.NewRuntimeServiceValidator(svr, group),
 		serverapi.NewRedirector(svr),

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -198,7 +198,7 @@ func (s *testClusterInfoSuite) TestReuseAddress(c *C) {
 			Address:    storeInfo.GetAddress(),
 			State:      metapb.StoreState_Up,
 			Version:    storeInfo.GetVersion(),
-			DeployPath: fmt.Sprintf("test/store%d", storeID),
+			DeployPath: getTestDeployPath(storeID),
 		}
 
 		if storeInfo.IsPhysicallyDestroyed() || storeInfo.IsTombstone() {
@@ -208,7 +208,10 @@ func (s *testClusterInfoSuite) TestReuseAddress(c *C) {
 			c.Assert(cluster.PutStore(newStore), NotNil)
 		}
 	}
+}
 
+func getTestDeployPath(storeID uint64) string {
+	return fmt.Sprintf("test/store%d", storeID)
 }
 
 func (s *testClusterInfoSuite) TestUpStore(c *C) {
@@ -962,7 +965,7 @@ func newTestStores(n uint64, version string) []*core.StoreInfo {
 			Address:    fmt.Sprintf("127.0.0.1:%d", i),
 			State:      metapb.StoreState_Up,
 			Version:    version,
-			DeployPath: fmt.Sprintf("test/store%d", i),
+			DeployPath: getTestDeployPath(i),
 		}
 		stores = append(stores, core.NewStoreInfo(store))
 	}

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -300,7 +300,7 @@ func prepare(setCfg func(*config.ScheduleConfig), setTc func(*testCluster), run 
 	}
 }
 
-func (s *testCoordinatorSuite) checkRegion(c *C, tc *testCluster, co *coordinator, regionID uint64, expectCheckerIsBusy bool, expectAddOperator int) {
+func (s *testCoordinatorSuite) checkRegion(c *C, tc *testCluster, co *coordinator, regionID uint64, expectAddOperator int) {
 	ops := co.checkers.CheckRegion(tc.GetRegion(regionID))
 	if ops == nil {
 		c.Assert(expectAddOperator, Equals, 0)
@@ -319,10 +319,10 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	c.Assert(tc.addRegionStore(2, 2), IsNil)
 	c.Assert(tc.addRegionStore(1, 1), IsNil)
 	c.Assert(tc.addLeaderRegion(1, 2, 3), IsNil)
-	s.checkRegion(c, tc, co, 1, false, 1)
+	s.checkRegion(c, tc, co, 1, 1)
 	waitOperator(c, co, 1)
 	testutil.CheckAddPeer(c, co.opController.GetOperator(1), operator.OpReplica, 1)
-	s.checkRegion(c, tc, co, 1, false, 0)
+	s.checkRegion(c, tc, co, 1, 0)
 
 	r := tc.GetRegion(1)
 	p := &metapb.Peer{Id: 1, StoreId: 1, Role: metapb.PeerRole_Learner}
@@ -331,7 +331,7 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 		core.WithPendingPeers(append(r.GetPendingPeers(), p)),
 	)
 	c.Assert(tc.putRegion(r), IsNil)
-	s.checkRegion(c, tc, co, 1, false, 0)
+	s.checkRegion(c, tc, co, 1, 0)
 	co.stop()
 	co.wg.Wait()
 
@@ -344,15 +344,15 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	c.Assert(tc.addRegionStore(2, 2), IsNil)
 	c.Assert(tc.addRegionStore(1, 1), IsNil)
 	c.Assert(tc.putRegion(r), IsNil)
-	s.checkRegion(c, tc, co, 1, false, 0)
+	s.checkRegion(c, tc, co, 1, 0)
 	r = r.Clone(core.WithPendingPeers(nil))
 	c.Assert(tc.putRegion(r), IsNil)
-	s.checkRegion(c, tc, co, 1, false, 1)
+	s.checkRegion(c, tc, co, 1, 1)
 	waitOperator(c, co, 1)
 	op := co.opController.GetOperator(1)
 	c.Assert(op.Len(), Equals, 1)
 	c.Assert(op.Step(0).(operator.PromoteLearner).ToStore, Equals, uint64(1))
-	s.checkRegion(c, tc, co, 1, false, 0)
+	s.checkRegion(c, tc, co, 1, 0)
 }
 
 func (s *testCoordinatorSuite) TestCheckerIsBusy(c *C) {
@@ -385,7 +385,7 @@ func (s *testCoordinatorSuite) TestCheckerIsBusy(c *C) {
 
 		}
 	}
-	s.checkRegion(c, tc, co, num, true, 0)
+	s.checkRegion(c, tc, co, num, 0)
 }
 
 func (s *testCoordinatorSuite) TestReplica(c *C) {

--- a/server/encryptionkm/key_manager.go
+++ b/server/encryptionkm/key_manager.go
@@ -318,7 +318,7 @@ func (m *KeyManager) loadKeysImpl() (keys *encryptionpb.KeyDictionary, err error
 }
 
 // loadKeys reload keys from etcd storage.
-func (m *KeyManager) loadKeys() (keys *encryptionpb.KeyDictionary, err error) {
+func (m *KeyManager) loadKeys() (*encryptionpb.KeyDictionary, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.loadKeysImpl()

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -128,7 +128,7 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 				}
 				// TODO: change it to the info level once the TiKV doesn't use it in a unary way.
 				log.Debug("create TSO forward stream", zap.String("forwarded-host", forwardedHost))
-				forwardStream, cancel, err = s.createTsoForwardStream(client, forwardedHost)
+				forwardStream, cancel, err = s.createTsoForwardStream(client)
 				if err != nil {
 					return err
 				}
@@ -536,7 +536,7 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 					return err
 				}
 				log.Info("create region heartbeat forward stream", zap.String("forwarded-host", forwardedHost))
-				forwardStream, cancel, err = s.createHeartbeatForwardStream(client, forwardedHost)
+				forwardStream, cancel, err = s.createHeartbeatForwardStream(client)
 				if err != nil {
 					return err
 				}
@@ -1471,7 +1471,7 @@ func (s *Server) isLocalRequest(forwardedHost string) bool {
 	return false
 }
 
-func (s *Server) createTsoForwardStream(client *grpc.ClientConn, addr string) (pdpb.PD_TsoClient, context.CancelFunc, error) {
+func (s *Server) createTsoForwardStream(client *grpc.ClientConn) (pdpb.PD_TsoClient, context.CancelFunc, error) {
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(s.ctx)
 	go checkStream(ctx, cancel, done)
@@ -1480,7 +1480,7 @@ func (s *Server) createTsoForwardStream(client *grpc.ClientConn, addr string) (p
 	return forwardStream, cancel, err
 }
 
-func (s *Server) createHeartbeatForwardStream(client *grpc.ClientConn, addr string) (pdpb.PD_RegionHeartbeatClient, context.CancelFunc, error) {
+func (s *Server) createHeartbeatForwardStream(client *grpc.ClientConn) (pdpb.PD_RegionHeartbeatClient, context.CancelFunc, error) {
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(s.ctx)
 	go checkStream(ctx, cancel, done)

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -107,7 +107,7 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 			checkerCounter.WithLabelValues("rule_checker", "replace-down").Inc()
 			return c.replaceRulePeer(region, rf, peer, downStatus)
 		}
-		if c.isOfflinePeer(region, peer) {
+		if c.isOfflinePeer(peer) {
 			checkerCounter.WithLabelValues("rule_checker", "replace-offline").Inc()
 			return c.replaceRulePeer(region, rf, peer, offlineStatus)
 		}
@@ -256,7 +256,7 @@ func (c *RuleChecker) isDownPeer(region *core.RegionInfo, peer *metapb.Peer) boo
 	return false
 }
 
-func (c *RuleChecker) isOfflinePeer(region *core.RegionInfo, peer *metapb.Peer) bool {
+func (c *RuleChecker) isOfflinePeer(peer *metapb.Peer) bool {
 	store := c.cluster.GetStore(peer.GetStoreId())
 	if store == nil {
 		log.Warn("lost the store, maybe you are recovering the PD cluster", zap.Uint64("store-id", peer.StoreId))

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -638,12 +638,12 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas3(c *C) {
 	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
-	s.checkReplica3(c, tc, opt, sb)
+	s.checkReplica3(c, tc, sb)
 	tc.SetEnablePlacementRules(true)
-	s.checkReplica3(c, tc, opt, sb)
+	s.checkReplica3(c, tc, sb)
 }
 
-func (s *testBalanceRegionSchedulerSuite) checkReplica3(c *C, tc *mockcluster.Cluster, opt *config.PersistOptions, sb schedule.Scheduler) {
+func (s *testBalanceRegionSchedulerSuite) checkReplica3(c *C, tc *mockcluster.Cluster, sb schedule.Scheduler) {
 	// Store 1 has the largest region score, so the balance scheduler tries to replace peer in store 1.
 	tc.AddLabelsStore(1, 16, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	tc.AddLabelsStore(2, 15, map[string]string{"zone": "z1", "rack": "r2", "host": "h1"})
@@ -703,12 +703,12 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas5(c *C) {
 	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
-	s.checkReplica5(c, tc, opt, sb)
+	s.checkReplica5(c, tc, sb)
 	tc.SetEnablePlacementRules(true)
-	s.checkReplica5(c, tc, opt, sb)
+	s.checkReplica5(c, tc, sb)
 }
 
-func (s *testBalanceRegionSchedulerSuite) checkReplica5(c *C, tc *mockcluster.Cluster, opt *config.PersistOptions, sb schedule.Scheduler) {
+func (s *testBalanceRegionSchedulerSuite) checkReplica5(c *C, tc *mockcluster.Cluster, sb schedule.Scheduler) {
 	tc.AddLabelsStore(1, 4, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	tc.AddLabelsStore(2, 5, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
 	tc.AddLabelsStore(3, 6, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -367,7 +367,7 @@ func filterHotPeers(
 	return ret
 }
 
-func (h *hotScheduler) addPendingInfluence(op *operator.Operator, srcStore, dstStore uint64, infl Influence, opTy opType) bool {
+func (h *hotScheduler) addPendingInfluence(op *operator.Operator, srcStore, dstStore uint64, infl Influence) bool {
 	regionID := op.RegionID()
 	_, ok := h.regionPendings[regionID]
 	if ok {
@@ -555,7 +555,7 @@ func (bs *balanceSolver) solve() []*operator.Operator {
 
 	for i := 0; i < len(ops); i++ {
 		// TODO: multiple operators need to be atomic.
-		if !bs.sche.addPendingInfluence(ops[i], best.srcStoreID, best.dstStoreID, infls[i], bs.opTy) {
+		if !bs.sche.addPendingInfluence(ops[i], best.srcStoreID, best.dstStoreID, infls[i]) {
 			return nil
 		}
 	}

--- a/server/schedulers/hot_test.go
+++ b/server/schedulers/hot_test.go
@@ -142,12 +142,12 @@ func (s *testHotWriteRegionSchedulerSuite) TestByteRateOnly(c *C) {
 	c.Assert(err, IsNil)
 	tc.SetHotRegionCacheHitsThreshold(0)
 
-	s.checkByteRateOnly(c, tc, opt, hb)
+	s.checkByteRateOnly(c, tc, hb)
 	tc.SetEnablePlacementRules(true)
-	s.checkByteRateOnly(c, tc, opt, hb)
+	s.checkByteRateOnly(c, tc, hb)
 }
 
-func (s *testHotWriteRegionSchedulerSuite) checkByteRateOnly(c *C, tc *mockcluster.Cluster, opt *config.PersistOptions, hb schedule.Scheduler) {
+func (s *testHotWriteRegionSchedulerSuite) checkByteRateOnly(c *C, tc *mockcluster.Cluster, hb schedule.Scheduler) {
 	// Add stores 1, 2, 3, 4, 5, 6  with region counts 3, 2, 2, 2, 0, 0.
 
 	tc.AddLabelsStore(1, 3, map[string]string{"zone": "z1", "host": "h1"})

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -149,12 +149,12 @@ func (s *testShuffleHotRegionSchedulerSuite) TestBalance(c *C) {
 	hb, err := schedule.CreateScheduler(ShuffleHotRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder("shuffle-hot-region", []string{"", ""}))
 	c.Assert(err, IsNil)
 
-	s.checkBalance(c, tc, opt, hb)
+	s.checkBalance(c, tc, hb)
 	tc.SetEnablePlacementRules(true)
-	s.checkBalance(c, tc, opt, hb)
+	s.checkBalance(c, tc, hb)
 }
 
-func (s *testShuffleHotRegionSchedulerSuite) checkBalance(c *C, tc *mockcluster.Cluster, opt *config.PersistOptions, hb schedule.Scheduler) {
+func (s *testShuffleHotRegionSchedulerSuite) checkBalance(c *C, tc *mockcluster.Cluster, hb schedule.Scheduler) {
 	// Add stores 1, 2, 3, 4, 5, 6  with hot peer counts 3, 2, 2, 2, 0, 0.
 	tc.AddLabelsStore(1, 3, map[string]string{"zone": "z1", "host": "h1"})
 	tc.AddLabelsStore(2, 2, map[string]string{"zone": "z2", "host": "h2"})

--- a/tests/client/client_tls_test.go
+++ b/tests/client/client_tls_test.go
@@ -115,7 +115,7 @@ func (s *clientTLSTestSuite) TestTLSReloadAtomicReplace(c *C) {
 		c.Assert(err, IsNil)
 
 	}
-	s.testTLSReload(c, cloneFunc, replaceFunc, revertFunc, false)
+	s.testTLSReload(c, cloneFunc, replaceFunc, revertFunc)
 
 }
 
@@ -123,8 +123,7 @@ func (s *clientTLSTestSuite) testTLSReload(
 	c *C,
 	cloneFunc func() transport.TLSInfo,
 	replaceFunc func(),
-	revertFunc func(),
-	useIP bool) {
+	revertFunc func()) {
 	tlsInfo := cloneFunc()
 	// 1. start cluster with valid certs
 	clus, err := tests.NewTestCluster(s.ctx, 1, func(conf *config.Config, serverName string) {

--- a/tests/server/cluster/cluster_work_test.go
+++ b/tests/server/cluster/cluster_work_test.go
@@ -55,7 +55,7 @@ func (s *clusterWorkerTestSuite) TestValidRequestRegion(c *C) {
 	leaderServer := cluster.GetServer(cluster.GetLeader())
 	grpcPDClient := testutil.MustNewGrpcClient(c, leaderServer.GetAddr())
 	clusterID := leaderServer.GetClusterID()
-	bootstrapCluster(c, clusterID, grpcPDClient, "127.0.0.1:0")
+	bootstrapCluster(c, clusterID, grpcPDClient)
 	rc := leaderServer.GetRaftCluster()
 
 	r1 := core.NewRegionInfo(&metapb.Region{
@@ -96,7 +96,7 @@ func (s *clusterWorkerTestSuite) TestAskSplit(c *C) {
 	leaderServer := cluster.GetServer(cluster.GetLeader())
 	grpcPDClient := testutil.MustNewGrpcClient(c, leaderServer.GetAddr())
 	clusterID := leaderServer.GetClusterID()
-	bootstrapCluster(c, clusterID, grpcPDClient, "127.0.0.1:0")
+	bootstrapCluster(c, clusterID, grpcPDClient)
 	rc := leaderServer.GetRaftCluster()
 	opt := rc.GetOpts()
 	opt.SetSplitMergeInterval(time.Hour)
@@ -141,7 +141,7 @@ func (s *clusterWorkerTestSuite) TestSuspectRegions(c *C) {
 	leaderServer := cluster.GetServer(cluster.GetLeader())
 	grpcPDClient := testutil.MustNewGrpcClient(c, leaderServer.GetAddr())
 	clusterID := leaderServer.GetClusterID()
-	bootstrapCluster(c, clusterID, grpcPDClient, "127.0.0.1:0")
+	bootstrapCluster(c, clusterID, grpcPDClient)
 	rc := leaderServer.GetRaftCluster()
 	opt := rc.GetOpts()
 	opt.SetSplitMergeInterval(time.Hour)

--- a/tools/pd-analysis/analysis/transfer_counter.go
+++ b/tools/pd-analysis/analysis/transfer_counter.go
@@ -140,7 +140,7 @@ func (c *TransferCounter) prepare() {
 // to the stack. If there is an edge of `v->u`, then the corresponding looped flow
 // is marked and removed. When all the output edges of the point v are traversed,
 // pop the point v out of the stack.
-func (c *TransferCounter) dfs(cur int, curFlow uint64, path []int) {
+func (c *TransferCounter) dfs(cur int, path []int) {
 	// push stack
 	path = append(path, cur)
 	c.visited[cur] = true
@@ -169,7 +169,7 @@ func (c *TransferCounter) dfs(cur int, curFlow uint64, path []int) {
 				c.graphMat[cur][target] -= curMinFlow
 			}
 		} else if !c.visited[target] {
-			c.dfs(target, flow, path)
+			c.dfs(target, path)
 		}
 	}
 	// pop stack
@@ -183,7 +183,7 @@ func (c *TransferCounter) Result() {
 	}
 
 	for i := 0; i < c.scheduledStoreNum; i++ {
-		c.dfs(i, 1<<16, make([]int, 0))
+		c.dfs(i, make([]int, 0))
 	}
 
 	for _, value := range c.loopResultCount {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Clean up useless parameters that are detected by:

```shell
golangci-lint run -E unparam
```

### What is changed and how it works?

Clean up useless parameters.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

<!-- - No release note -->
