### PR TITLE
schedulers: fix the panic issue about remove evict leader scheduler from a nonexistent store

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -538,7 +538,7 @@ func (s *StoresInfo) PauseLeaderTransfer(storeID uint64) error {
 func (s *StoresInfo) ResumeLeaderTransfer(storeID uint64) {
 	store, ok := s.stores[storeID]
 	if !ok {
-		log.Fatal("try to clean a store's pause state, but it is not found",
+		log.Warn("try to clean a store's pause state, but it is not found. It may be cleanup",
 			zap.Uint64("store-id", storeID), errs.ZapError(errs.ErrStoreNotFound.FastGenByArgs(storeID)))
 	}
 	s.stores[storeID] = store.Clone(ResumeLeaderTransfer())

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -540,6 +540,7 @@ func (s *StoresInfo) ResumeLeaderTransfer(storeID uint64) {
 	if !ok {
 		log.Warn("try to clean a store's pause state, but it is not found. It may be cleanup",
 			zap.Uint64("store-id", storeID), errs.ZapError(errs.ErrStoreNotFound.FastGenByArgs(storeID)))
+		return
 	}
 	s.stores[storeID] = store.Clone(ResumeLeaderTransfer())
 }

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -539,7 +539,7 @@ func (s *StoresInfo) ResumeLeaderTransfer(storeID uint64) {
 	store, ok := s.stores[storeID]
 	if !ok {
 		log.Warn("try to clean a store's pause state, but it is not found. It may be cleanup",
-			zap.Uint64("store-id", storeID), errs.ZapError(errs.ErrStoreNotFound.FastGenByArgs(storeID)))
+			zap.Uint64("store-id", storeID))
 		return
 	}
 	s.stores[storeID] = store.Clone(ResumeLeaderTransfer())

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -137,7 +137,7 @@ func (conf *evictLeaderSchedulerConfig) getRanges(id uint64) []string {
 	return res
 }
 
-func (conf *evictLeaderSchedulerConfig) mayBeRemoveStoreFromConfig(id uint64) (succ bool, last bool) {
+func (conf *evictLeaderSchedulerConfig) removeStore(id uint64) (succ bool, last bool) {
 	conf.mu.Lock()
 	defer conf.mu.Unlock()
 	_, exists := conf.StoreIDWithRanges[id]
@@ -335,7 +335,7 @@ func (handler *evictLeaderHandler) DeleteConfig(w http.ResponseWriter, r *http.R
 	}
 
 	var resp interface{}
-	succ, last := handler.config.mayBeRemoveStoreFromConfig(id)
+	succ, last := handler.config.removeStore(id)
 	if succ {
 		err = handler.config.Persist()
 		if err != nil {

--- a/server/schedulers/grant_leader.go
+++ b/server/schedulers/grant_leader.go
@@ -132,7 +132,7 @@ func (conf *grantLeaderSchedulerConfig) getRanges(id uint64) []string {
 	return res
 }
 
-func (conf *grantLeaderSchedulerConfig) mayBeRemoveStoreFromConfig(id uint64) (succ bool, last bool) {
+func (conf *grantLeaderSchedulerConfig) removeStore(id uint64) (succ bool, last bool) {
 	conf.mu.Lock()
 	defer conf.mu.Unlock()
 	_, exists := conf.StoreIDWithRanges[id]
@@ -289,7 +289,7 @@ func (handler *grantLeaderHandler) DeleteConfig(w http.ResponseWriter, r *http.R
 	}
 
 	var resp interface{}
-	succ, last := handler.config.mayBeRemoveStoreFromConfig(id)
+	succ, last := handler.config.removeStore(id)
 	if succ {
 		err = handler.config.Persist()
 		if err != nil {

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -145,7 +145,7 @@ func (s *testRejectLeaderSuite) TestRemoveRejectLeader(c *C) {
 	el, err := schedule.CreateScheduler(EvictLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
 	c.Assert(err, IsNil)
 	tc.DeleteStore(tc.GetStore(1))
-	succ, _ := el.(*evictLeaderScheduler).conf.mayBeRemoveStoreFromConfig(1)
+	succ, _ := el.(*evictLeaderScheduler).conf.removeStore(1)
 	c.Assert(succ, IsTrue)
 }
 

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -134,6 +134,21 @@ func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 	testutil.CheckTransferLeader(c, op[0], operator.OpLeader, 1, 2)
 }
 
+func (s *testRejectLeaderSuite) TestRemoveRejectLeader(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opts := config.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opts)
+	tc.AddRegionStore(1, 0)
+	tc.AddRegionStore(2, 1)
+	oc := schedule.NewOperatorController(ctx, tc, nil)
+	el, err := schedule.CreateScheduler(EvictLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
+	c.Assert(err, IsNil)
+	tc.DeleteStore(tc.GetStore(1))
+	succ, _ := el.(*evictLeaderScheduler).conf.mayBeRemoveStoreFromConfig(1)
+	c.Assert(succ, IsTrue)
+}
+
 var _ = Suite(&testShuffleHotRegionSchedulerSuite{})
 
 type testShuffleHotRegionSchedulerSuite struct{}


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
close: https://github.com/tikv/pd/issues/3660 

Fix the probles:
1. create a cluster with 4 TiKV using TiUP
2. add evict leader scheduler for one store, e.g. store 2
3. delete store 2 and remove tombstone by using pd-ctl
4. remove evict leader scheduler by using pd-ctl
Panic!

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the panic issue about remove evict leader scheduler from a nonexistent store
```
