### PR TITLE
core: sort peers when creating RegionsInfo

### DIFF
--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -37,47 +37,46 @@ type testRegionInfoSuite struct{}
 
 func (s *testRegionInfoSuite) TestSortedEqual(c *C) {
 	testcases := []struct {
-		idsA    []uint64
-		idsB    []uint64
+		idsA    []int
+		idsB    []int
 		isEqual bool
 	}{
 		{
-			[]uint64{},
-			[]uint64{},
+			[]int{},
+			[]int{},
 			true,
 		},
 		{
-			[]uint64{},
-			[]uint64{1, 2},
+			[]int{},
+			[]int{1, 2},
 			false,
 		},
 		{
-			[]uint64{1, 2},
-			[]uint64{1, 2},
+			[]int{1, 2},
+			[]int{1, 2},
 			true,
 		},
 		{
-			[]uint64{1, 2},
-			[]uint64{2, 1},
+			[]int{1, 2},
+			[]int{2, 1},
 			true,
 		},
 		{
-			[]uint64{1, 2},
-			[]uint64{1, 2, 3},
+			[]int{1, 2},
+			[]int{1, 2, 3},
 			false,
 		},
 		{
-			[]uint64{1, 2, 3},
-			[]uint64{2, 3, 1},
+			[]int{1, 2, 3},
+			[]int{2, 3, 1},
 			true,
 		},
 		{
-			[]uint64{1, 3},
-			[]uint64{1, 2},
+			[]int{1, 3},
+			[]int{1, 2},
 			false,
 		},
 	}
-
 	meta := &metapb.Region{
 		Id: 100,
 		Peers: []*metapb.Peer{
@@ -92,29 +91,62 @@ func (s *testRegionInfoSuite) TestSortedEqual(c *C) {
 			{
 				Id:      2,
 				StoreId: 20,
+				Role:    metapb.PeerRole_Learner,
 			},
 			{
 				Id:      4,
 				StoreId: 40,
+				Role:    metapb.PeerRole_IncomingVoter,
 			},
 		},
 	}
-
-	region := NewRegionInfo(meta, meta.Peers[0])
-
+	pickPeers := func(ids []int) []*metapb.Peer {
+		peers := make([]*metapb.Peer, 0, len(ids))
+		for _, i := range ids {
+			peers = append(peers, meta.Peers[i])
+		}
+		return peers
+	}
+	pickPeerStats := func(ids []int) []*pdpb.PeerStats {
+		peers := make([]*pdpb.PeerStats, 0, len(ids))
+		for _, i := range ids {
+			peers = append(peers, &pdpb.PeerStats{Peer: meta.Peers[i]})
+		}
+		return peers
+	}
+	// test NewRegionInfo
 	for _, t := range testcases {
-		downPeersA := make([]*pdpb.PeerStats, 0)
-		downPeersB := make([]*pdpb.PeerStats, 0)
-		pendingPeersA := make([]*metapb.Peer, 0)
-		pendingPeersB := make([]*metapb.Peer, 0)
-		for _, i := range t.idsA {
-			downPeersA = append(downPeersA, &pdpb.PeerStats{Peer: meta.Peers[i]})
-			pendingPeersA = append(pendingPeersA, meta.Peers[i])
-		}
-		for _, i := range t.idsB {
-			downPeersB = append(downPeersB, &pdpb.PeerStats{Peer: meta.Peers[i]})
-			pendingPeersB = append(pendingPeersB, meta.Peers[i])
-		}
+		regionA := NewRegionInfo(&metapb.Region{Id: 100, Peers: pickPeers(t.idsA)}, nil)
+		regionB := NewRegionInfo(&metapb.Region{Id: 100, Peers: pickPeers(t.idsB)}, nil)
+		c.Assert(SortedPeersEqual(regionA.GetVoters(), regionB.GetVoters()), Equals, t.isEqual)
+		c.Assert(SortedPeersEqual(regionA.GetVoters(), regionB.GetVoters()), Equals, t.isEqual)
+	}
+
+	// test Region
+	for _, t := range testcases {
+		regionA := RegionFromHeartbeat(&pdpb.RegionHeartbeatRequest{
+			Region:       &metapb.Region{Id: 100, Peers: pickPeers(t.idsA)},
+			DownPeers:    pickPeerStats(t.idsA),
+			PendingPeers: pickPeers(t.idsA),
+		})
+		regionB := RegionFromHeartbeat(&pdpb.RegionHeartbeatRequest{
+			Region:       &metapb.Region{Id: 100, Peers: pickPeers(t.idsB)},
+			DownPeers:    pickPeerStats(t.idsB),
+			PendingPeers: pickPeers(t.idsB),
+		})
+		c.Assert(SortedPeersEqual(regionA.GetVoters(), regionB.GetVoters()), Equals, t.isEqual)
+		c.Assert(SortedPeersEqual(regionA.GetVoters(), regionB.GetVoters()), Equals, t.isEqual)
+		c.Assert(SortedPeersEqual(regionA.GetPendingPeers(), regionB.GetPendingPeers()), Equals, t.isEqual)
+		c.Assert(SortedPeersStatsEqual(regionA.GetDownPeers(), regionB.GetDownPeers()), Equals, t.isEqual)
+	}
+
+	// test Clone
+	region := NewRegionInfo(meta, meta.Peers[0])
+	for _, t := range testcases {
+		downPeersA := pickPeerStats(t.idsA)
+		downPeersB := pickPeerStats(t.idsB)
+		pendingPeersA := pickPeers(t.idsA)
+		pendingPeersB := pickPeers(t.idsB)
 
 		regionA := region.Clone(WithDownPeers(downPeersA), WithPendingPeers(pendingPeersA))
 		regionB := region.Clone(WithDownPeers(downPeersB), WithPendingPeers(pendingPeersB))
@@ -311,10 +343,10 @@ func (*testRegionKey) TestShouldRemoveFromSubTree(c *C) {
 	}, peer1)
 
 	origin := NewRegionInfo(&metapb.Region{
-		Id:       uint64(2),
+		Id:       uint64(1),
 		Peers:    []*metapb.Peer{peer1, peer2, peer3},
-		StartKey: []byte(fmt.Sprintf("%20d", 20)),
-		EndKey:   []byte(fmt.Sprintf("%20d", 30)),
+		StartKey: []byte(fmt.Sprintf("%20d", 10)),
+		EndKey:   []byte(fmt.Sprintf("%20d", 20)),
 	}, peer1)
 	c.Assert(regions.shouldRemoveFromSubTree(region, origin), Equals, false)
 
@@ -329,7 +361,7 @@ func (*testRegionKey) TestShouldRemoveFromSubTree(c *C) {
 	region.learners = append(region.learners, peer2)
 	c.Assert(regions.shouldRemoveFromSubTree(region, origin), Equals, true)
 
-	origin.learners = append(origin.learners, peer3, peer2)
+	origin.learners = append(origin.learners, peer2, peer3)
 	region.learners = append(region.learners, peer4)
 	c.Assert(regions.shouldRemoveFromSubTree(region, origin), Equals, false)
 

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -122,7 +122,7 @@ func (s *testRegionInfoSuite) TestSortedEqual(c *C) {
 		c.Assert(SortedPeersEqual(regionA.GetVoters(), regionB.GetVoters()), Equals, t.isEqual)
 	}
 
-	// test Region
+	// test RegionFromHeartbeat
 	for _, t := range testcases {
 		regionA := RegionFromHeartbeat(&pdpb.RegionHeartbeatRequest{
 			Region:       &metapb.Region{Id: 100, Peers: pickPeers(t.idsA)},


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

Peers need to be sorted every time in `shouldRemoveFromSubTree`.

### What is changed and how it works?

Sort Peers at the time of creation, and use `SortedPeersEqual` to compare Peers.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
