### PR TITLE
checker: fix the operator priority

### DIFF
--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -135,7 +135,12 @@ func (c *RuleChecker) addRulePeer(region *core.RegionInfo, rf *placement.RuleFit
 		return nil, errors.New("no store to add peer")
 	}
 	peer := &metapb.Peer{StoreId: store, Role: rf.Rule.Role.MetaPeerRole()}
-	return operator.CreateAddPeerOperator("add-rule-peer", c.cluster, region, peer, operator.OpReplica)
+	op, err := operator.CreateAddPeerOperator("add-rule-peer", c.cluster, region, peer, operator.OpReplica)
+	if err != nil {
+		return nil, err
+	}
+	op.SetPriorityLevel(core.HighPriority)
+	return op, nil
 }
 
 func (c *RuleChecker) replaceRulePeer(region *core.RegionInfo, rf *placement.RuleFit, peer *metapb.Peer, status string) (*operator.Operator, error) {
@@ -147,7 +152,12 @@ func (c *RuleChecker) replaceRulePeer(region *core.RegionInfo, rf *placement.Rul
 		return nil, errors.New("no store to replace peer")
 	}
 	newPeer := &metapb.Peer{StoreId: store, Role: rf.Rule.Role.MetaPeerRole()}
-	return operator.CreateMovePeerOperator("replace-rule-"+status+"-peer", c.cluster, region, operator.OpReplica, peer.StoreId, newPeer)
+	op, err := operator.CreateMovePeerOperator("replace-rule-"+status+"-peer", c.cluster, region, operator.OpReplica, peer.StoreId, newPeer)
+	if err != nil {
+		return nil, err
+	}
+	op.SetPriorityLevel(core.HighPriority)
+	return op, nil
 }
 
 func (c *RuleChecker) fixLooseMatchPeer(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit, peer *metapb.Peer) (*operator.Operator, error) {

--- a/server/schedule/checker/rule_checker_test.go
+++ b/server/schedule/checker/rule_checker_test.go
@@ -85,6 +85,7 @@ func (s *testRuleCheckerSuite) TestAddRulePeer(c *C) {
 	op := s.rc.Check(s.cluster.GetRegion(1))
 	c.Assert(op, NotNil)
 	c.Assert(op.Desc(), Equals, "add-rule-peer")
+	c.Assert(op.GetPriorityLevel(), Equals, core.HighPriority)
 	c.Assert(op.Step(0).(operator.AddLearner).ToStore, Equals, uint64(3))
 }
 
@@ -137,6 +138,7 @@ func (s *testRuleCheckerSuite) TestFixPeer(c *C) {
 	op = s.rc.Check(r)
 	c.Assert(op, NotNil)
 	c.Assert(op.Desc(), Equals, "replace-rule-down-peer")
+	c.Assert(op.GetPriorityLevel(), Equals, core.HighPriority)
 	var add operator.AddLearner
 	c.Assert(op.Step(0), FitsTypeOf, add)
 	s.cluster.SetStoreUp(2)
@@ -144,6 +146,7 @@ func (s *testRuleCheckerSuite) TestFixPeer(c *C) {
 	op = s.rc.Check(s.cluster.GetRegion(1))
 	c.Assert(op, NotNil)
 	c.Assert(op.Desc(), Equals, "replace-rule-offline-peer")
+	c.Assert(op.GetPriorityLevel(), Equals, core.HighPriority)
 	c.Assert(op.Step(0), FitsTypeOf, add)
 }
 


### PR DESCRIPTION


### What problem does this PR solve?

To keep consistent with the original implementation.

### What is changed and how it works?

This PR adds back the high priority for some kinds of operators.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the priority problems for some kinds of operators
```
