### PR TITLE
config: add separte configuration for hot scheudle for read and write

### DIFF
--- a/pkg/mock/mockcluster/config.go
+++ b/pkg/mock/mockcluster/config.go
@@ -110,6 +110,16 @@ func (mc *Cluster) SetHotRegionCacheHitsThreshold(v int) {
 	mc.updateScheduleConfig(func(s *config.ScheduleConfig) { s.HotRegionCacheHitsThreshold = uint64(v) })
 }
 
+// SetHotReadRegionCacheHitsThreshold updates the HotReadRegionCacheHitsThreshold configuration
+func (mc *Cluster) SetHotReadRegionCacheHitsThreshold(v int) {
+	mc.updateScheduleConfig(func(s *config.ScheduleConfig) { s.HotReadRegionCacheHitsThreshold = uint64(v) })
+}
+
+// SetHotWriteRegionCacheHitsThreshold updates theHotWriteRegionCacheHitsThreshold configuration
+func (mc *Cluster) SetHotWriteRegionCacheHitsThreshold(v int) {
+	mc.updateScheduleConfig(func(s *config.ScheduleConfig) { s.HotWriteRegionCacheHitsThreshold = uint64(v) })
+}
+
 // SetEnablePlacementRules updates the EnablePlacementRules configuration.
 func (mc *Cluster) SetEnablePlacementRules(v bool) {
 	mc.updateReplicationConfig(func(r *config.ReplicationConfig) { r.EnablePlacementRules = v })

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -107,7 +107,15 @@ func (mc *Cluster) GetStore(storeID uint64) *core.StoreInfo {
 
 // IsRegionHot checks if the region is hot.
 func (mc *Cluster) IsRegionHot(region *core.RegionInfo) bool {
-	return mc.HotCache.IsRegionHot(region, mc.GetHotRegionCacheHitsThreshold())
+	readDegree := mc.GetHotReadRegionCacheHitsThreshold()
+	writeDegree := mc.GetHotWriteRegionCacheHitsThreshold()
+	if readDegree < 1 {
+		readDegree = mc.GetHotRegionCacheHitsThreshold()
+	}
+	if writeDegree < 1 {
+		writeDegree = mc.GetHotWriteRegionCacheHitsThreshold()
+	}
+	return mc.HotCache.IsRegionHot(region, readDegree, writeDegree)
 }
 
 // RegionReadStats returns hot region's read stats.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -920,7 +920,15 @@ func (c *RaftCluster) GetStore(storeID uint64) *core.StoreInfo {
 func (c *RaftCluster) IsRegionHot(region *core.RegionInfo) bool {
 	c.RLock()
 	defer c.RUnlock()
-	return c.hotStat.IsRegionHot(region, c.opt.GetHotRegionCacheHitsThreshold())
+	readDegree := c.opt.GetHotReadRegionCacheHitsThreshold()
+	if readDegree < 1 {
+		readDegree = c.opt.GetHotRegionCacheHitsThreshold()
+	}
+	writeDegree := c.opt.GetHotWriteRegionCacheHitsThreshold()
+	if writeDegree < 1 {
+		writeDegree = c.opt.GetHotWriteRegionCacheHitsThreshold()
+	}
+	return c.hotStat.IsRegionHot(region, readDegree, writeDegree)
 }
 
 // GetAdjacentRegions returns regions' information that are adjacent with the specific region ID.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -652,6 +652,14 @@ type ScheduleConfig struct {
 	// If the number of times a region hits the hot cache is greater than this
 	// threshold, it is considered a hot region.
 	HotRegionCacheHitsThreshold uint64 `toml:"hot-region-cache-hits-threshold" json:"hot-region-cache-hits-threshold"`
+	// HotReadRegionCacheHitsThreshold is the cache hits threshold of the hot read region.
+	// If the number of times a region hits the hot cache is greater than this
+	// threshold, it is considered a hot read region.
+	HotReadRegionCacheHitsThreshold uint64 `toml:"hot-read-region-cache-hits-threshold" json:"hot-read-region-cache-hits-threshold"`
+	// HotWriteRegionCacheHitsThreshold is the cache hits threshold of the hot write region.
+	// If the number of times a region hits the hot cache is greater than this
+	// threshold, it is considered a hot write region.
+	HotWriteRegionCacheHitsThreshold uint64 `toml:"hot-write-region-cache-hits-threshold" json:"hot-write-region-cache-hits-threshold"`
 	// StoreBalanceRate is the maximum of balance rate for each store.
 	// WARN: StoreBalanceRate is deprecated.
 	StoreBalanceRate float64 `toml:"store-balance-rate" json:"store-balance-rate,omitempty"`
@@ -766,12 +774,14 @@ const (
 	defaultRegionScoreFormulaVersion = "v2"
 	// defaultHotRegionCacheHitsThreshold is the low hit number threshold of the
 	// hot region.
-	defaultHotRegionCacheHitsThreshold = 3
-	defaultSchedulerMaxWaitingOperator = 5
-	defaultLeaderSchedulePolicy        = "count"
-	defaultStoreLimitMode              = "manual"
-	defaultEnableJointConsensus        = true
-	defaultEnableCrossTableMerge       = true
+	defaultHotRegionCacheHitsThreshold      = 3
+	defaultHotReadRegionCacheHitsThreshold  = 0
+	defaultHotWriteRegionCacheHitsThreshold = 0
+	defaultSchedulerMaxWaitingOperator      = 5
+	defaultLeaderSchedulePolicy             = "count"
+	defaultStoreLimitMode                   = "manual"
+	defaultEnableJointConsensus             = true
+	defaultEnableCrossTableMerge            = true
 )
 
 func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
@@ -807,6 +817,12 @@ func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
 	}
 	if !meta.IsDefined("hot-region-cache-hits-threshold") {
 		adjustUint64(&c.HotRegionCacheHitsThreshold, defaultHotRegionCacheHitsThreshold)
+	}
+	if !meta.IsDefined("hot-read-region-cache-hits-threshold") {
+		adjustUint64(&c.HotReadRegionCacheHitsThreshold, defaultHotReadRegionCacheHitsThreshold)
+	}
+	if !meta.IsDefined("hot-write-region-cache-hits-threshold") {
+		adjustUint64(&c.HotWriteRegionCacheHitsThreshold, defaultHotWriteRegionCacheHitsThreshold)
 	}
 	if !meta.IsDefined("tolerant-size-ratio") {
 		adjustFloat64(&c.TolerantSizeRatio, defaultTolerantSizeRatio)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -186,6 +186,8 @@ leader-schedule-limit = 0
 	c.Assert(cfg.Schedule.MaxMergeRegionSize, Equals, uint64(0))
 	c.Assert(cfg.Schedule.EnableOneWayMerge, Equals, true)
 	c.Assert(cfg.Schedule.LeaderScheduleLimit, Equals, uint64(0))
+	c.Assert(cfg.Schedule.HotReadRegionCacheHitsThreshold, Equals, uint64(defaultHotReadRegionCacheHitsThreshold))
+	c.Assert(cfg.Schedule.HotWriteRegionCacheHitsThreshold, Equals, uint64(defaultHotWriteRegionCacheHitsThreshold))
 	// When undefined, use default values.
 	c.Assert(cfg.PreVote, IsTrue)
 	c.Assert(cfg.Schedule.MaxMergeRegionKeys, Equals, uint64(defaultMaxMergeRegionKeys))
@@ -289,12 +291,16 @@ disable-remove-down-replica = true
 enable-make-up-replica = false
 disable-remove-extra-replica = true
 enable-remove-extra-replica = false
+hot-read-region-cache-hits-threshold = 6
+hot-write-region-cache-hits-threshold = 4
 `)
 	c.Assert(err, IsNil)
 	c.Assert(cfg.Schedule.EnableReplaceOfflineReplica, IsTrue)
 	c.Assert(cfg.Schedule.EnableRemoveDownReplica, IsFalse)
 	c.Assert(cfg.Schedule.EnableMakeUpReplica, IsFalse)
 	c.Assert(cfg.Schedule.EnableRemoveExtraReplica, IsFalse)
+	c.Assert(cfg.Schedule.HotReadRegionCacheHitsThreshold, Equals, uint64(6))
+	c.Assert(cfg.Schedule.HotWriteRegionCacheHitsThreshold, Equals, uint64(4))
 	b, err := json.Marshal(cfg)
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(b), "disable-replace-offline-replica"), IsFalse)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -495,6 +495,16 @@ func (o *PersistOptions) GetHotRegionCacheHitsThreshold() int {
 	return int(o.GetScheduleConfig().HotRegionCacheHitsThreshold)
 }
 
+// GetHotReadRegionCacheHitsThreshold is a threshold to decide if a region is read hot
+func (o *PersistOptions) GetHotReadRegionCacheHitsThreshold() int {
+	return int(o.GetScheduleConfig().HotReadRegionCacheHitsThreshold)
+}
+
+// GetHotWriteRegionCacheHitsThreshold is a threshold to decide if a region is write hot
+func (o *PersistOptions) GetHotWriteRegionCacheHitsThreshold() int {
+	return int(o.GetScheduleConfig().HotWriteRegionCacheHitsThreshold)
+}
+
 // GetStoresLimit gets the stores' limit.
 func (o *PersistOptions) GetStoresLimit() map[uint64]StoreLimitConfig {
 	return o.GetScheduleConfig().StoreLimit

--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -170,9 +170,9 @@ func (w *HotCache) HotRegionsFromStore(storeID uint64, kind FlowKind, minHotDegr
 }
 
 // IsRegionHot checks if the region is hot.
-func (w *HotCache) IsRegionHot(region *core.RegionInfo, minHotDegree int) bool {
-	return w.writeFlow.isRegionHotWithAnyPeers(region, minHotDegree) ||
-		w.readFlow.isRegionHotWithAnyPeers(region, minHotDegree)
+func (w *HotCache) IsRegionHot(region *core.RegionInfo, readHotDegree, writeHotDegree int) bool {
+	return w.writeFlow.isRegionHotWithAnyPeers(region, writeHotDegree) ||
+		w.readFlow.isRegionHotWithAnyPeers(region, readHotDegree)
 }
 
 // CollectMetrics collects the hot cache metrics.


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Currently, the threshold for the hot spot hit cache for read and write is both controlled by `hot-region-cache-hits-threshold`. As the hot read peer stat is reported by store heartbeat while the hot write peer stat is reported by region stat, the threshold for read and write should be controlled by different configuration.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
Add `hot-read-region-cache-hits-threshold` and `hot-write-region-cache-hits-threshold`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
