### PR TITLE
schedulers: add random-split-scheduler

### DIFF
--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -220,6 +220,11 @@ func (h *schedulerHandler) Post(w http.ResponseWriter, r *http.Request) {
 			h.r.JSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+	case schedulers.RandomSplitName:
+		if err := h.AddRandomSplitScheduler(); err != nil {
+			h.r.JSON(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 	default:
 		h.r.JSON(w, http.StatusBadRequest, "unknown scheduler")
 		return

--- a/server/handler.go
+++ b/server/handler.go
@@ -286,6 +286,11 @@ func (h *Handler) AddRandomMergeScheduler() error {
 	return h.AddScheduler(schedulers.RandomMergeType)
 }
 
+// AddRandomSplitScheduler adds a random-split-scheduler.
+func (h *Handler) AddRandomSplitScheduler() error {
+	return h.AddScheduler(schedulers.RandomSplitType)
+}
+
 // GetOperator returns the region operator.
 func (h *Handler) GetOperator(regionID uint64) (*operator.Operator, error) {
 	c, err := h.GetOperatorController()

--- a/server/schedulers/random_split.go
+++ b/server/schedulers/random_split.go
@@ -1,0 +1,148 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
+	"github.com/tikv/pd/server/schedule/filter"
+	"github.com/tikv/pd/server/schedule/operator"
+	"github.com/tikv/pd/server/schedule/opt"
+)
+
+const (
+	// RandomSplitName is random split scheduler name.
+	RandomSplitName = "random-split-scheduler"
+	// RandomSplitType is random split scheduler type.
+	RandomSplitType = "random-split"
+)
+
+func init() {
+	schedule.RegisterSliceDecoderBuilder(RandomSplitType, func(args []string) schedule.ConfigDecoder {
+		return func(v interface{}) error {
+			conf, ok := v.(*randomSplitSchedulerConfig)
+			if !ok {
+				return errs.ErrScheduleConfigNotExist.FastGenByArgs()
+			}
+			ranges, err := getKeyRanges(args)
+			if err != nil {
+				return err
+			}
+			conf.Ranges = ranges
+			conf.Name = RandomSplitName
+			return nil
+		}
+	})
+	schedule.RegisterScheduler(RandomSplitType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+		conf := &randomSplitSchedulerConfig{}
+		if err := decoder(conf); err != nil {
+			return nil, err
+		}
+		return newRandomSplitScheduler(opController, conf), nil
+	})
+}
+
+type randomSplitSchedulerConfig struct {
+	Name   string          `json:"name"`
+	Ranges []core.KeyRange `json:"ranges"`
+}
+
+type randomSplitScheduler struct {
+	*BaseScheduler
+	conf    *randomSplitSchedulerConfig
+	filters []filter.Filter
+}
+
+// newRandomSplitScheduler creates an admin scheduler that randomly picks a region then splits it.
+// Splitting a region is not a heavy operation. Its cost is similar to transferring a leader, so we use the
+// same limit and config as shuffle-leader-scheduler.
+func newRandomSplitScheduler(opController *schedule.OperatorController, conf *randomSplitSchedulerConfig) schedule.Scheduler {
+	filters := []filter.Filter{
+		&filter.StoreStateFilter{ActionScope: conf.Name, TransferLeader: true},
+		filter.NewSpecialUseFilter(conf.Name),
+	}
+	base := NewBaseScheduler(opController)
+	return &randomSplitScheduler{
+		BaseScheduler: base,
+		conf:          conf,
+		filters:       filters,
+	}
+}
+
+func (s *randomSplitScheduler) GetName() string {
+	return s.conf.Name
+}
+
+func (s *randomSplitScheduler) GetType() string {
+	return RandomSplitType
+}
+
+func (s *randomSplitScheduler) EncodeConfig() ([]byte, error) {
+	return schedule.EncodeConfig(s.conf)
+}
+
+func (s *randomSplitScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+	allowed := s.OpController.OperatorCount(operator.OpSplit) < cluster.GetOpts().GetLeaderScheduleLimit()
+	if !allowed {
+		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpSplit.String()).Inc()
+	}
+	return allowed
+}
+
+func (s *randomSplitScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
+
+	store := filter.NewCandidates(cluster.GetStores()).
+		FilterSource(cluster.GetOpts(), s.filters...).
+		RandomPick()
+	if store == nil {
+		schedulerCounter.WithLabelValues(s.GetName(), "no-store").Inc()
+		return nil
+	}
+	region := cluster.RandLeaderRegion(store.GetID(), s.conf.Ranges, opt.HealthRegion(cluster))
+	if region == nil {
+		schedulerCounter.WithLabelValues(s.GetName(), "no-region").Inc()
+		return nil
+	}
+
+	if !s.allowSplit(cluster, region) {
+		schedulerCounter.WithLabelValues(s.GetName(), "not-allowed").Inc()
+		return nil
+	}
+
+	op, err := operator.CreateSplitRegionOperator(RandomSplitType, region, operator.OpAdmin, pdpb.CheckPolicy_APPROXIMATE, nil)
+	if err != nil {
+		log.Debug("fail to create split region operator", errs.ZapError(err))
+		return nil
+	}
+	op.SetPriorityLevel(core.HighPriority)
+	op.Counters = append(op.Counters, schedulerCounter.WithLabelValues(s.GetName(), "new-operator"))
+	return []*operator.Operator{op}
+}
+
+func (s *randomSplitScheduler) allowSplit(cluster opt.Cluster, region *core.RegionInfo) bool {
+	if !opt.IsRegionHealthy(cluster, region) {
+		return false
+	}
+	if !opt.IsRegionReplicated(cluster, region) {
+		return false
+	}
+	if cluster.IsRegionHot(region) {
+		return false
+	}
+	return true
+}

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -134,6 +134,7 @@ func NewAddSchedulerCommand() *cobra.Command {
 	c.AddCommand(NewBalanceHotRegionSchedulerCommand())
 	c.AddCommand(NewRandomMergeSchedulerCommand())
 	c.AddCommand(NewLabelSchedulerCommand())
+	c.AddCommand(NewRandomSplitSchedulerCommand())
 	return c
 }
 
@@ -301,6 +302,16 @@ func NewLabelSchedulerCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "label-scheduler",
 		Short: "add a scheduler to schedule regions according to the label",
+		Run:   addSchedulerCommandFunc,
+	}
+	return c
+}
+
+// NewRandomSplitSchedulerCommand returns a command to add a random-split-scheduler.
+func NewRandomSplitSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "random-split-scheduler",
+		Short: "add a scheduler to split regions randomly",
 		Run:   addSchedulerCommandFunc,
 	}
 	return c


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>
is:pr is:open 
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Sometimes we want to test the stability of TiDB under a frequent region scheduling scenario, for example, test the stability of TiKV client or test the stability of TiKV's configuration changes and splitting or merging regions. PD has `shuffle-leader-scheduler`, `shuffle-region-scheduler` and `random-merge-scheduler` which helps us to create such a scenario but it lacks the `random-split-scheduler` and it's not sufficient to rely on auto-splitting in TiKV.

### What is changed and how it works?

Add a `random-split-scheduler` that randomly picks a leader region and splits it. Its limit and configuration is the same as `shuffle-leader-scheduler` because they have a similar cost.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```


