### PR TITLE
checker: allow location placement get worse when fix replica

### DIFF
--- a/pkg/mock/mockcluster/config.go
+++ b/pkg/mock/mockcluster/config.go
@@ -128,6 +128,11 @@ func (mc *Cluster) SetLocationLabels(v []string) {
 	mc.updateReplicationConfig(func(r *config.ReplicationConfig) { r.LocationLabels = v })
 }
 
+// SetIsolationLevel updates the IsolationLevel configuration.
+func (mc *Cluster) SetIsolationLevel(v string) {
+	mc.updateReplicationConfig(func(r *config.ReplicationConfig) { r.IsolationLevel = v })
+}
+
 func (mc *Cluster) updateScheduleConfig(f func(*config.ScheduleConfig)) {
 	s := mc.GetScheduleConfig().Clone()
 	f(s)

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -237,7 +237,7 @@ func (r *ReplicaChecker) fixPeer(region *core.RegionInfo, storeID uint64, status
 	}
 
 	regionStores := r.cluster.GetRegionStores(region)
-	target := r.strategy(region).SelectStoreToReplace(regionStores, storeID)
+	target := r.strategy(region).SelectStoreToFix(regionStores, storeID)
 	if target == 0 {
 		reason := fmt.Sprintf("no-store-%s", status)
 		checkerCounter.WithLabelValues("replica_checker", reason).Inc()

--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -80,13 +80,12 @@ func (s *ReplicaStrategy) SelectStoreToAdd(coLocationStores []*core.StoreInfo, e
 	return target.GetID()
 }
 
-// SelectStoreToReplace returns a store to replace oldStore. The location
-// placement after scheduling should be not worse than original.
-func (s *ReplicaStrategy) SelectStoreToReplace(coLocationStores []*core.StoreInfo, old uint64) uint64 {
+// SelectStoreToFix returns a store to replace down/offline old peer. The location
+// placement after scheduling is allowed to be worse than original.
+func (s *ReplicaStrategy) SelectStoreToFix(coLocationStores []*core.StoreInfo, old uint64) uint64 {
 	// trick to avoid creating a slice with `old` removed.
 	s.swapStoreToFirst(coLocationStores, old)
-	safeGuard := filter.NewLocationSafeguard(s.checkerName, s.locationLabels, coLocationStores, s.cluster.GetStore(old))
-	return s.SelectStoreToAdd(coLocationStores[1:], safeGuard)
+	return s.SelectStoreToAdd(coLocationStores[1:])
 }
 
 // SelectStoreToImprove returns a store to replace oldStore. The location

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -145,7 +145,7 @@ func (c *RuleChecker) addRulePeer(region *core.RegionInfo, rf *placement.RuleFit
 
 func (c *RuleChecker) replaceRulePeer(region *core.RegionInfo, rf *placement.RuleFit, peer *metapb.Peer, status string) (*operator.Operator, error) {
 	ruleStores := c.getRuleFitStores(rf)
-	store := c.strategy(region, rf.Rule).SelectStoreToReplace(ruleStores, peer.GetStoreId())
+	store := c.strategy(region, rf.Rule).SelectStoreToFix(ruleStores, peer.GetStoreId())
 	if store == 0 {
 		checkerCounter.WithLabelValues("rule_checker", "no-store-replace").Inc()
 		c.regionWaitingList.Put(region.GetID(), nil)


### PR DESCRIPTION
### What problem does this PR solve?

Fix https://github.com/tikv/pd/issues/3705

### What is changed and how it works?
Root cause of the bug:

Before 4.0, PD can first remove the down replica then add a new peer replica.
In 5.0, we restricted that down replicas can only be repaired by replacing in order to maintain a sufficient number of replicas during the process. And replacing comes with the restriction that the isolation level could not be worse than before.

- Rename `SelectStoreToReplace` to `SelectStoreToFix` and remove the use of `LocationSafeguard` filter.
- add tests.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test

Related changes
- Need to cherry-pick to the release branch (release-5.0)

### Release note
```release-note
Fix the issue that when all tikv in a zone are offline or down, PD does not move replicas to another zone
```
