### PR TITLE
server: make leader can lost lease as soon as possible

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -365,6 +365,7 @@ func (c *RaftCluster) Stop() {
 	c.coordinator.stop()
 	c.Unlock()
 	c.wg.Wait()
+	log.Info("raftcluster is stopped")
 }
 
 // IsRunning return if the cluster is running.

--- a/server/server.go
+++ b/server/server.go
@@ -1257,7 +1257,7 @@ func (s *Server) campaignLeader() {
 	}
 	// EnableLeader to accept the remaining service, such as GetStore, GetRegion.
 	s.member.EnableLeader()
-	// Check the cluster dc-location after the PD leader is elected
+	// Check the cluster dc-location after the PD leader is elected.
 	go s.tsoAllocatorManager.ClusterDCLocationChecker()
 	defer func() {
 		// as soon as cancel the leadership keepalive, then other member have chance

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/tikv/pd/pkg/etcdutil"
 	"github.com/tikv/pd/pkg/testutil"
@@ -238,12 +239,31 @@ func (s *memberTestSuite) TestLeaderResign(c *C) {
 	c.Assert(leader3, Equals, leader1)
 }
 
+func (s *memberTestSuite) TestLeaderResignWithBlock(c *C) {
+	cluster, err := tests.NewTestCluster(s.ctx, 3)
+	defer cluster.Destroy()
+	c.Assert(err, IsNil)
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+
+	leader1 := cluster.WaitLeader()
+	addr1 := cluster.GetServer(leader1).GetConfig().ClientUrls
+
+	err = failpoint.Enable("github.com/tikv/pd/server/raftclusterIsBusy", `pause`)
+	defer failpoint.Disable("github.com/tikv/pd/server/raftclusterIsBusy")
+	c.Assert(err, IsNil)
+	s.post(c, addr1+"/pd/api/v1/leader/resign", "")
+	leader2 := s.waitLeaderChange(c, cluster, leader1)
+	c.Log("leader2:", leader2)
+	c.Assert(leader2, Not(Equals), leader1)
+}
+
 func (s *memberTestSuite) waitLeaderChange(c *C, cluster *tests.TestCluster, old string) string {
 	var leader string
 	testutil.WaitUntil(c, func(c *C) bool {
 		leader = cluster.GetLeader()
 		if leader == old || leader == "" {
-			time.Sleep(time.Second)
 			return false
 		}
 		return true

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -251,8 +251,8 @@ func (s *memberTestSuite) TestLeaderResignWithBlock(c *C) {
 	addr1 := cluster.GetServer(leader1).GetConfig().ClientUrls
 
 	err = failpoint.Enable("github.com/tikv/pd/server/raftclusterIsBusy", `pause`)
-	defer failpoint.Disable("github.com/tikv/pd/server/raftclusterIsBusy")
 	c.Assert(err, IsNil)
+	defer failpoint.Disable("github.com/tikv/pd/server/raftclusterIsBusy")
 	s.post(c, addr1+"/pd/api/v1/leader/resign", "")
 	leader2 := s.waitLeaderChange(c, cluster, leader1)
 	c.Log("leader2:", leader2)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Fix https://github.com/tikv/pd/issues/3697
When the store's number is 180. we resign pd leader  may need one minute or more to finish elect the new leader:
![image](https://user-images.githubusercontent.com/6428910/119088013-8c523780-ba3a-11eb-991f-9d1359f9835f.png)

details replay: https://gist.github.com/disksing/a1bf78007b674da7e15b52a9e25eb3a5 

### What is changed and how it works?

make leader can be lost lease as soon as possible

### Check List

<!-- Remove the items that are not applicable. -->

Tests

- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the issue that leader re-election be slow when there are many stores
```
