### PR TITLE
command: Align TSO output format

### DIFF
--- a/tests/pdctl/tso/tso_test.go
+++ b/tests/pdctl/tso/tso_test.go
@@ -55,6 +55,6 @@ func (s *tsoTestSuite) TestTSO(c *C) {
 	logicalTime := t & logicalBits
 	physical := t >> physicalShiftBits
 	physicalTime := time.Unix(int64(physical/1000), int64(physical%1000)*time.Millisecond.Nanoseconds())
-	str := fmt.Sprintln("system: ", physicalTime) + fmt.Sprintln("logic: ", logicalTime)
+	str := fmt.Sprintln("system: ", physicalTime) + fmt.Sprintln("logic:  ", logicalTime)
 	c.Assert(str, Equals, string(output))
 }

--- a/tools/pd-ctl/pdctl/command/tso_command.go
+++ b/tools/pd-ctl/pdctl/command/tso_command.go
@@ -43,5 +43,5 @@ func showTSOCommandFunc(cmd *cobra.Command, args []string) {
 
 	physicalTime, logical := tsoutil.ParseTS(ts)
 	cmd.Println("system: ", physicalTime)
-	cmd.Println("logic: ", logical)
+	cmd.Println("logic:  ", logical)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Before:
```
$ ./bin/pd-ctl tso 425223599947776000
system:  2021-05-27 09:08:24 +0200 CEST
logic:  0
```

After:
```
$ ./bin/pd-ctl tso 425223599947776000
system:  2021-05-27 09:08:24 +0200 CEST
logic:   0
```

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Look at `pd-ctl tso <tso>` output

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
