### PR TITLE
statistics: remove mutex in hotPeerCache

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -57,7 +57,7 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 	clus := &Cluster{
 		BasicCluster:     core.NewBasicCluster(),
 		IDAllocator:      mockid.NewIDAllocator(),
-		HotStat:          statistics.NewHotStat(ctx),
+		HotStat:          statistics.NewHotStat(ctx, nil),
 		PersistOptions:   opts,
 		suspectRegions:   map[uint64]struct{}{},
 		disabledFeatures: make(map[versioninfo.Feature]struct{}),

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -54,10 +54,11 @@ type Cluster struct {
 
 // NewCluster creates a new Cluster
 func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
+	mockQuit := make(chan struct{})
 	clus := &Cluster{
 		BasicCluster:     core.NewBasicCluster(),
 		IDAllocator:      mockid.NewIDAllocator(),
-		HotStat:          statistics.NewHotStat(ctx, nil),
+		HotStat:          statistics.NewHotStat(ctx, mockQuit),
 		PersistOptions:   opts,
 		suspectRegions:   map[uint64]struct{}{},
 		disabledFeatures: make(map[versioninfo.Feature]struct{}),

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -572,19 +572,20 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	c.RLock()
 	storage := c.storage
 	coreCluster := c.core
+	hotStat := c.hotStat
 	c.RUnlock()
 
 	origin, err := coreCluster.PreCheckPutRegion(region)
 	if err != nil {
 		return err
 	}
-	c.hotStat.CheckWriteAsync(statistics.NewCheckExpiredItemTask(region))
-	c.hotStat.CheckReadAsync(statistics.NewCheckExpiredItemTask(region))
+	hotStat.CheckWriteAsync(statistics.NewCheckExpiredItemTask(region))
+	hotStat.CheckReadAsync(statistics.NewCheckExpiredItemTask(region))
 	reportInterval := region.GetInterval()
 	interval := reportInterval.GetEndTimestamp() - reportInterval.GetStartTimestamp()
 	for _, peer := range region.GetPeers() {
 		peerInfo := core.NewPeerInfo(peer, region.GetWriteLoads(), interval)
-		c.hotStat.CheckWriteAsync(statistics.NewCheckPeerTask(peerInfo, region))
+		hotStat.CheckWriteAsync(statistics.NewCheckPeerTask(peerInfo, region))
 	}
 
 	// Save to storage if meta is updated.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -44,12 +44,23 @@ func Test(t *testing.T) {
 
 var _ = Suite(&testClusterInfoSuite{})
 
-type testClusterInfoSuite struct{}
+type testClusterInfoSuite struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (s *testClusterInfoSuite) TearDownTest(c *C) {
+	s.cancel()
+}
+
+func (s *testClusterInfoSuite) SetUpTest(c *C) {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+}
 
 func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	n, np := uint64(3), uint64(3)
 	stores := newTestStores(n, "2.0.0")
@@ -161,7 +172,7 @@ func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	stores := newTestStores(3, "2.0.0")
 	for _, store := range stores {
@@ -193,7 +204,7 @@ func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 func (s *testClusterInfoSuite) TestSetOfflineStore(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	// Put 4 stores.
 	for _, store := range newTestStores(4, "2.0.0") {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
@@ -239,7 +250,7 @@ func (s *testClusterInfoSuite) TestSetOfflineStore(c *C) {
 func (s *testClusterInfoSuite) TestReuseAddress(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	// Put 4 stores.
 	for _, store := range newTestStores(4, "2.0.0") {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
@@ -280,7 +291,7 @@ func getTestDeployPath(storeID uint64) string {
 func (s *testClusterInfoSuite) TestUpStore(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	// Put 3 stores.
 	for _, store := range newTestStores(3, "2.0.0") {
@@ -314,7 +325,7 @@ func (s *testClusterInfoSuite) TestUpStore(c *C) {
 func (s *testClusterInfoSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	// Put 3 new 4.0.9 stores.
 	for _, store := range newTestStores(3, "4.0.9") {
@@ -337,7 +348,7 @@ func (s *testClusterInfoSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {
 func (s *testClusterInfoSuite) TestRegionHeartbeatHotStat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	newTestStores(4, "2.0.0")
 	peers := []*metapb.Peer{
 		{
@@ -394,7 +405,7 @@ func (s *testClusterInfoSuite) TestRegionHeartbeatHotStat(c *C) {
 func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	n, np := uint64(3), uint64(3)
 
@@ -607,7 +618,7 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 func (s *testClusterInfoSuite) TestRegionFlowChanged(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	regions := []*core.RegionInfo{core.NewTestRegionInfo([]byte{}, []byte{})}
 	processRegions := func(regions []*core.RegionInfo) {
 		for _, r := range regions {
@@ -627,7 +638,7 @@ func (s *testClusterInfoSuite) TestRegionFlowChanged(c *C) {
 func (s *testClusterInfoSuite) TestConcurrentRegionHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	regions := []*core.RegionInfo{core.NewTestRegionInfo([]byte{}, []byte{})}
 	regions = core.SplitRegions(regions)
@@ -688,7 +699,7 @@ func heartbeatRegions(c *C, cluster *RaftCluster, regions []*core.RegionInfo) {
 func (s *testClusterInfoSuite) TestHeartbeatSplit(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	// 1: [nil, nil)
 	region1 := core.NewRegionInfo(&metapb.Region{Id: 1, RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1}}, nil)
@@ -727,7 +738,7 @@ func (s *testClusterInfoSuite) TestHeartbeatSplit(c *C) {
 func (s *testClusterInfoSuite) TestRegionSplitAndMerge(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	regions := []*core.RegionInfo{core.NewTestRegionInfo([]byte{}, []byte{})}
 
@@ -760,7 +771,7 @@ func (s *testClusterInfoSuite) TestRegionSplitAndMerge(c *C) {
 func (s *testClusterInfoSuite) TestOfflineAndMerge(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	storage := core.NewStorage(kv.NewMemoryKV())
 	cluster.ruleManager = placement.NewRuleManager(storage, cluster)
@@ -822,7 +833,7 @@ func (s *testClusterInfoSuite) TestOfflineAndMerge(c *C) {
 func (s *testClusterInfoSuite) TestUpdateStorePendingPeerCount(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	tc := newTestCluster(opt)
+	tc := newTestCluster(s.ctx, opt)
 	stores := newTestStores(5, "2.0.0")
 	for _, s := range stores {
 		c.Assert(tc.putStoreLocked(s), IsNil)
@@ -889,14 +900,25 @@ func (s *testStoresInfoSuite) TestStores(c *C) {
 
 var _ = Suite(&testRegionsInfoSuite{})
 
-type testRegionsInfoSuite struct{}
+type testRegionsInfoSuite struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (s *testRegionsInfoSuite) TearDownTest(c *C) {
+	s.cancel()
+}
+
+func (s *testRegionsInfoSuite) SetUpTest(c *C) {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+}
 
 func (s *testRegionsInfoSuite) Test(c *C) {
 	n, np := uint64(10), uint64(3)
 	regions := newTestRegions(n, np)
 	_, opts, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	tc := newTestRaftCluster(mockid.NewIDAllocator(), opts, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	tc := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opts, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	cache := tc.core.Regions
 
 	for i := uint64(0); i < n; i++ {
@@ -1000,13 +1022,20 @@ func (s *testClusterUtilSuite) TestCheckStaleRegion(c *C) {
 var _ = Suite(&testGetStoresSuite{})
 
 type testGetStoresSuite struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
 	cluster *RaftCluster
+}
+
+func (s *testGetStoresSuite) TearDownTest(c *C) {
+	s.cancel()
 }
 
 func (s *testGetStoresSuite) SetUpSuite(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 	s.cluster = cluster
 
 	stores := newTestStores(200, "2.0.0")
@@ -1038,9 +1067,9 @@ func newTestScheduleConfig() (*config.ScheduleConfig, *config.PersistOptions, er
 	return &cfg.Schedule, opt, nil
 }
 
-func newTestCluster(opt *config.PersistOptions) *testCluster {
+func newTestCluster(ctx context.Context, opt *config.PersistOptions) *testCluster {
 	storage := core.NewStorage(kv.NewMemoryKV())
-	rc := newTestRaftCluster(mockid.NewIDAllocator(), opt, storage, core.NewBasicCluster())
+	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage, core.NewBasicCluster())
 	rc.ruleManager = placement.NewRuleManager(storage, rc)
 	if opt.IsPlacementRulesEnabled() {
 		err := rc.ruleManager.Initialize(opt.GetMaxReplicas(), opt.GetLocationLabels())
@@ -1052,8 +1081,8 @@ func newTestCluster(opt *config.PersistOptions) *testCluster {
 	return &testCluster{RaftCluster: rc}
 }
 
-func newTestRaftCluster(id id.Allocator, opt *config.PersistOptions, storage *core.Storage, basicCluster *core.BasicCluster) *RaftCluster {
-	rc := &RaftCluster{ctx: context.TODO()}
+func newTestRaftCluster(ctx context.Context, id id.Allocator, opt *config.PersistOptions, storage *core.Storage, basicCluster *core.BasicCluster) *RaftCluster {
+	rc := &RaftCluster{ctx: ctx}
 	rc.InitCluster(id, opt, storage, basicCluster)
 	return rc
 }

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -283,7 +283,7 @@ func prepare(setCfg func(*config.ScheduleConfig), setTc func(*testCluster), run 
 	if setCfg != nil {
 		setCfg(cfg)
 	}
-	tc := newTestCluster(opt)
+	tc := newTestCluster(ctx, opt)
 	hbStreams := hbstream.NewTestHeartbeatStreams(ctx, tc.getClusterID(), tc, true /* need to run */)
 	if setTc != nil {
 		setTc(tc)
@@ -335,7 +335,7 @@ func (s *testCoordinatorSuite) TestCheckRegion(c *C) {
 	co.stop()
 	co.wg.Wait()
 
-	tc = newTestCluster(opt)
+	tc = newTestCluster(s.ctx, opt)
 	co = newCoordinator(s.ctx, tc.RaftCluster, hbStreams)
 	co.run()
 

--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -170,6 +170,9 @@ func (w *HotCache) updateItems(ctx context.Context) {
 }
 
 func update(item *HotPeerStat, flow *hotPeerCache) {
+	if item == nil {
+		return
+	}
 	flow.Update(item)
 	if item.IsNeedDelete() {
 		incMetrics("remove_item", item.StoreID, item.Kind)

--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -27,96 +27,22 @@ const queueCap = 1000
 
 // HotCache is a cache hold hot regions.
 type HotCache struct {
-	readFlowQueue  chan *FlowItem
-	writeFlowQueue chan *FlowItem
+	readFlowQueue  chan FlowItemTask
+	writeFlowQueue chan FlowItemTask
 	writeFlow      *hotPeerCache
 	readFlow       *hotPeerCache
-}
-
-// FlowItem indicates the item in the flow, it is a wrapper for peerInfo, expiredItems or coldItem.
-type FlowItem struct {
-	peerInfo             *core.PeerInfo
-	regionInfo           *core.RegionInfo
-	expiredStat          *HotPeerStat
-	unReportStatsCollect *unReportStatsCollect
-	minDegree            int
-	ret                  chan map[uint64][]*HotPeerStat
-}
-
-type unReportStatsCollect struct {
-	storeID   uint64
-	regionIDs map[uint64]struct{}
-	interval  uint64
-}
-
-// NewUnReportStatsCollect creates information for unreported stats
-func NewUnReportStatsCollect(storeID uint64, regionIDs map[uint64]struct{}, interval uint64) *FlowItem {
-	return &FlowItem{
-		peerInfo:    nil,
-		regionInfo:  nil,
-		expiredStat: nil,
-		unReportStatsCollect: &unReportStatsCollect{
-			storeID:   storeID,
-			regionIDs: regionIDs,
-			interval:  interval,
-		},
-	}
-}
-
-// NewPeerInfoItem creates FlowItem for PeerInfo
-func NewPeerInfoItem(peerInfo *core.PeerInfo, regionInfo *core.RegionInfo) *FlowItem {
-	return &FlowItem{
-		peerInfo:             peerInfo,
-		regionInfo:           regionInfo,
-		expiredStat:          nil,
-		unReportStatsCollect: nil,
-	}
-}
-
-// NewExpiredStatItem creates Expired stat
-func NewExpiredStatItem(expiredStat *HotPeerStat) *FlowItem {
-	return &FlowItem{
-		peerInfo:             nil,
-		regionInfo:           nil,
-		expiredStat:          expiredStat,
-		unReportStatsCollect: nil,
-	}
-}
-
-func newMinDegreeStats(minDegree int) *FlowItem {
-	return &FlowItem{
-		minDegree: minDegree,
-		ret:       make(chan map[uint64][]*HotPeerStat),
-	}
 }
 
 // NewHotCache creates a new hot spot cache.
 func NewHotCache(ctx context.Context) *HotCache {
 	w := &HotCache{
-		readFlowQueue:  make(chan *FlowItem, queueCap),
-		writeFlowQueue: make(chan *FlowItem, queueCap),
+		readFlowQueue:  make(chan FlowItemTask, queueCap),
+		writeFlowQueue: make(chan FlowItemTask, queueCap),
 		writeFlow:      NewHotStoresStats(WriteFlow),
 		readFlow:       NewHotStoresStats(ReadFlow),
 	}
 	go w.updateItems(ctx)
 	return w
-}
-
-// ExpiredItems returns the items which are already expired.
-func (w *HotCache) ExpiredItems(region *core.RegionInfo) (expiredItems []*HotPeerStat) {
-	expiredItems = append(expiredItems, w.ExpiredReadItems(region)...)
-	expiredItems = append(expiredItems, w.ExpiredWriteItems(region)...)
-	return
-}
-
-// ExpiredReadItems returns the read items which are already expired.
-func (w *HotCache) ExpiredReadItems(region *core.RegionInfo) []*HotPeerStat {
-	return w.readFlow.CollectExpiredItems(region)
-}
-
-// ExpiredWriteItems returns the write items which are already expired.
-func (w *HotCache) ExpiredWriteItems(region *core.RegionInfo) []*HotPeerStat {
-	return w.writeFlow.CollectExpiredItems(region)
 }
 
 // CheckWritePeerSync checks the write status, returns update items.
@@ -132,30 +58,22 @@ func (w *HotCache) CheckReadPeerSync(peer *core.PeerInfo, region *core.RegionInf
 }
 
 // CheckWriteAsync puts the flowItem into queue, and check it asynchronously
-func (w *HotCache) CheckWriteAsync(item *FlowItem) {
-	w.writeFlowQueue <- item
+func (w *HotCache) CheckWriteAsync(task FlowItemTask) {
+	w.writeFlowQueue <- task
 }
 
 // CheckReadAsync puts the flowItem into queue, and check it asynchronously
-func (w *HotCache) CheckReadAsync(item *FlowItem) {
-	w.readFlowQueue <- item
+func (w *HotCache) CheckReadAsync(task FlowItemTask) {
+	w.readFlowQueue <- task
 }
 
 // Update updates the cache.
 func (w *HotCache) Update(item *HotPeerStat) {
 	switch item.Kind {
 	case WriteFlow:
-		w.writeFlow.Update(item)
+		update(item, w.writeFlow)
 	case ReadFlow:
-		w.readFlow.Update(item)
-	}
-
-	if item.IsNeedDelete() {
-		w.incMetrics("remove_item", item.StoreID, item.Kind)
-	} else if item.IsNew() {
-		w.incMetrics("add_item", item.StoreID, item.Kind)
-	} else {
-		w.incMetrics("update_item", item.StoreID, item.Kind)
+		update(item, w.readFlow)
 	}
 }
 
@@ -163,13 +81,13 @@ func (w *HotCache) Update(item *HotPeerStat) {
 func (w *HotCache) RegionStats(kind FlowKind, minHotDegree int) map[uint64][]*HotPeerStat {
 	switch kind {
 	case WriteFlow:
-		item := newMinDegreeStats(minHotDegree)
-		w.writeFlowQueue <- item
-		return <-item.ret
+		task := newCollectRegionStatsTask(minHotDegree)
+		w.writeFlowQueue <- task
+		return <-task.(*collectRegionStatsTask).ret
 	case ReadFlow:
-		item := newMinDegreeStats(minHotDegree)
-		w.readFlowQueue <- item
-		return <-item.ret
+		task := newCollectRegionStatsTask(minHotDegree)
+		w.readFlowQueue <- task
+		return <-task.(*collectRegionStatsTask).ret
 	}
 	return nil
 }
@@ -199,7 +117,19 @@ func (w *HotCache) ResetMetrics() {
 	hotCacheStatusGauge.Reset()
 }
 
-func (w *HotCache) incMetrics(name string, storeID uint64, kind FlowKind) {
+// ExpiredReadItems returns the read items which are already expired.
+// This is used for mockcluster.
+func (w *HotCache) ExpiredReadItems(region *core.RegionInfo) []*HotPeerStat {
+	return w.readFlow.CollectExpiredItems(region)
+}
+
+// ExpiredWriteItems returns the write items which are already expired.
+// This is used for mockcluster.
+func (w *HotCache) ExpiredWriteItems(region *core.RegionInfo) []*HotPeerStat {
+	return w.writeFlow.CollectExpiredItems(region)
+}
+
+func incMetrics(name string, storeID uint64, kind FlowKind) {
 	store := storeTag(storeID)
 	switch kind {
 	case WriteFlow:
@@ -225,35 +155,27 @@ func (w *HotCache) updateItems(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case item, ok := <-w.writeFlowQueue:
-			if ok && item != nil {
-				w.updateItem(item, w.writeFlow)
+		case task, ok := <-w.writeFlowQueue:
+			if ok && task != nil {
+				task.runTask(w.writeFlow)
 			}
 			hotCacheFlowQueueStatusGauge.WithLabelValues(WriteFlow.String()).Set(float64(len(w.writeFlowQueue)))
-		case item, ok := <-w.readFlowQueue:
-			if ok && item != nil {
-				w.updateItem(item, w.readFlow)
+		case task, ok := <-w.readFlowQueue:
+			if ok && task != nil {
+				task.runTask(w.readFlow)
 			}
 			hotCacheFlowQueueStatusGauge.WithLabelValues(ReadFlow.String()).Set(float64(len(w.readFlowQueue)))
 		}
 	}
 }
 
-func (w *HotCache) updateItem(item *FlowItem, flow *hotPeerCache) {
-	if item.peerInfo != nil && item.regionInfo != nil {
-		stat := flow.CheckPeerFlow(item.peerInfo, item.regionInfo)
-		if stat != nil {
-			w.Update(stat)
-		}
-	} else if item.expiredStat != nil {
-		w.Update(item.expiredStat)
-	} else if item.unReportStatsCollect != nil {
-		handle := item.unReportStatsCollect
-		stats := flow.CheckColdPeer(handle.storeID, handle.regionIDs, handle.interval)
-		for _, stat := range stats {
-			w.Update(stat)
-		}
-	} else if item.ret != nil {
-		item.ret <- flow.RegionStats(item.minDegree)
+func update(item *HotPeerStat, flow *hotPeerCache) {
+	flow.Update(item)
+	if item.IsNeedDelete() {
+		incMetrics("remove_item", item.StoreID, item.Kind)
+	} else if item.IsNew() {
+		incMetrics("add_item", item.StoreID, item.Kind)
+	} else {
+		incMetrics("update_item", item.StoreID, item.Kind)
 	}
 }

--- a/server/statistics/hot_cache_task.go
+++ b/server/statistics/hot_cache_task.go
@@ -1,0 +1,122 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import "github.com/tikv/pd/server/core"
+
+type flowItemTaskKind uint32
+
+const (
+	CheckPeerTaskType flowItemTaskKind = iota
+	CheckExpiredTaskType
+	CollectUnReportedPeerTaskType
+	CollectRegionStatsTaskType
+)
+
+type FlowItemTask interface {
+	taskType() flowItemTaskKind
+	runTask(flow *hotPeerCache)
+}
+
+type checkPeerTask struct {
+	peerInfo   *core.PeerInfo
+	regionInfo *core.RegionInfo
+}
+
+// NewCheckPeerTask ...
+func NewCheckPeerTask(peerInfo *core.PeerInfo, regionInfo *core.RegionInfo) FlowItemTask {
+	return &checkPeerTask{
+		peerInfo:   peerInfo,
+		regionInfo: regionInfo,
+	}
+}
+
+func (t *checkPeerTask) taskType() flowItemTaskKind {
+	return CheckPeerTaskType
+}
+
+func (t *checkPeerTask) runTask(flow *hotPeerCache) {
+	stat := flow.CheckPeerFlow(t.peerInfo, t.regionInfo)
+	if stat != nil {
+		update(stat, flow)
+	}
+}
+
+type checkExpiredTask struct {
+	region *core.RegionInfo
+}
+
+// NewCheckExpiredItemTask ...
+func NewCheckExpiredItemTask(region *core.RegionInfo) FlowItemTask {
+	return &checkExpiredTask{
+		region: region,
+	}
+}
+
+func (t *checkExpiredTask) taskType() flowItemTaskKind {
+	return CheckExpiredTaskType
+}
+
+func (t *checkExpiredTask) runTask(flow *hotPeerCache) {
+	expiredStats := flow.CollectExpiredItems(t.region)
+	for _, stat := range expiredStats {
+		update(stat, flow)
+	}
+}
+
+type collectUnReportedPeerTask struct {
+	storeID   uint64
+	regionIDs map[uint64]struct{}
+	interval  uint64
+}
+
+// NewCollectUnReportedPeerTask ...
+func NewCollectUnReportedPeerTask(storeID uint64, regionIDs map[uint64]struct{}, interval uint64) FlowItemTask {
+	return &collectUnReportedPeerTask{
+		storeID:   storeID,
+		regionIDs: regionIDs,
+		interval:  interval,
+	}
+}
+
+func (t *collectUnReportedPeerTask) taskType() flowItemTaskKind {
+	return CollectUnReportedPeerTaskType
+}
+
+func (t *collectUnReportedPeerTask) runTask(flow *hotPeerCache) {
+	stats := flow.CheckColdPeer(t.storeID, t.regionIDs, t.interval)
+	for _, stat := range stats {
+		update(stat, flow)
+	}
+}
+
+type collectRegionStatsTask struct {
+	minDegree int
+	ret       chan map[uint64][]*HotPeerStat
+}
+
+func newCollectRegionStatsTask(minDegree int) FlowItemTask {
+	return &collectRegionStatsTask{
+		minDegree: minDegree,
+		ret:       make(chan map[uint64][]*HotPeerStat),
+	}
+}
+
+func (t *collectRegionStatsTask) taskType() flowItemTaskKind {
+	return CollectRegionStatsTaskType
+}
+
+func (t *collectRegionStatsTask) runTask(flow *hotPeerCache) {
+	t.ret <- flow.RegionStats(t.minDegree)
+}

--- a/server/statistics/hot_cache_task.go
+++ b/server/statistics/hot_cache_task.go
@@ -35,7 +35,7 @@ type checkPeerTask struct {
 	regionInfo *core.RegionInfo
 }
 
-// NewCheckPeerTask ...
+// NewCheckPeerTask creates task to update peerInfo
 func NewCheckPeerTask(peerInfo *core.PeerInfo, regionInfo *core.RegionInfo) FlowItemTask {
 	return &checkPeerTask{
 		peerInfo:   peerInfo,
@@ -58,7 +58,7 @@ type checkExpiredTask struct {
 	region *core.RegionInfo
 }
 
-// NewCheckExpiredItemTask ...
+// NewCheckExpiredItemTask creates task to collect expired items
 func NewCheckExpiredItemTask(region *core.RegionInfo) FlowItemTask {
 	return &checkExpiredTask{
 		region: region,
@@ -82,7 +82,7 @@ type collectUnReportedPeerTask struct {
 	interval  uint64
 }
 
-// NewCollectUnReportedPeerTask ...
+// NewCollectUnReportedPeerTask creates task to collect unreported peers
 func NewCollectUnReportedPeerTask(storeID uint64, regionIDs map[uint64]struct{}, interval uint64) FlowItemTask {
 	return &collectUnReportedPeerTask{
 		storeID:   storeID,

--- a/server/statistics/hot_cache_task.go
+++ b/server/statistics/hot_cache_task.go
@@ -18,12 +18,13 @@ import "github.com/tikv/pd/server/core"
 type flowItemTaskKind uint32
 
 const (
-	CheckPeerTaskType flowItemTaskKind = iota
-	CheckExpiredTaskType
-	CollectUnReportedPeerTaskType
-	CollectRegionStatsTaskType
+	checkPeerTaskType flowItemTaskKind = iota
+	checkExpiredTaskType
+	collectUnReportedPeerTaskType
+	collectRegionStatsTaskType
 )
 
+// FlowItemTask indicates the task in flowItem queue
 type FlowItemTask interface {
 	taskType() flowItemTaskKind
 	runTask(flow *hotPeerCache)
@@ -43,7 +44,7 @@ func NewCheckPeerTask(peerInfo *core.PeerInfo, regionInfo *core.RegionInfo) Flow
 }
 
 func (t *checkPeerTask) taskType() flowItemTaskKind {
-	return CheckPeerTaskType
+	return checkPeerTaskType
 }
 
 func (t *checkPeerTask) runTask(flow *hotPeerCache) {
@@ -65,7 +66,7 @@ func NewCheckExpiredItemTask(region *core.RegionInfo) FlowItemTask {
 }
 
 func (t *checkExpiredTask) taskType() flowItemTaskKind {
-	return CheckExpiredTaskType
+	return checkExpiredTaskType
 }
 
 func (t *checkExpiredTask) runTask(flow *hotPeerCache) {
@@ -91,7 +92,7 @@ func NewCollectUnReportedPeerTask(storeID uint64, regionIDs map[uint64]struct{},
 }
 
 func (t *collectUnReportedPeerTask) taskType() flowItemTaskKind {
-	return CollectUnReportedPeerTaskType
+	return collectUnReportedPeerTaskType
 }
 
 func (t *collectUnReportedPeerTask) runTask(flow *hotPeerCache) {
@@ -114,7 +115,7 @@ func newCollectRegionStatsTask(minDegree int) FlowItemTask {
 }
 
 func (t *collectRegionStatsTask) taskType() flowItemTaskKind {
-	return CollectRegionStatsTaskType
+	return collectRegionStatsTaskType
 }
 
 func (t *collectRegionStatsTask) runTask(flow *hotPeerCache) {

--- a/server/statistics/hotstat.go
+++ b/server/statistics/hotstat.go
@@ -13,7 +13,9 @@
 
 package statistics
 
-import "context"
+import (
+	"context"
+)
 
 // HotStat contains cluster's hotspot statistics.
 type HotStat struct {
@@ -22,9 +24,9 @@ type HotStat struct {
 }
 
 // NewHotStat creates the container to hold cluster's hotspot statistics.
-func NewHotStat(ctx context.Context) *HotStat {
+func NewHotStat(ctx context.Context, quit <-chan struct{}) *HotStat {
 	return &HotStat{
-		HotCache:    NewHotCache(ctx),
+		HotCache:    NewHotCache(ctx, quit),
 		StoresStats: NewStoresStats(),
 	}
 }

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -35,16 +35,22 @@ func Test(t *testing.T) {
 
 var _ = Suite(&schedulerTestSuite{})
 
-type schedulerTestSuite struct{}
+type schedulerTestSuite struct {
+	context context.Context
+	cancel  context.CancelFunc
+}
 
 func (s *schedulerTestSuite) SetUpSuite(c *C) {
 	server.EnableZap = true
+	s.context, s.cancel = context.WithCancel(context.Background())
+}
+
+func (s *schedulerTestSuite) TearDownSuite(c *C) {
+	s.cancel()
 }
 
 func (s *schedulerTestSuite) TestScheduler(c *C) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cluster, err := tests.NewTestCluster(ctx, 1)
+	cluster, err := tests.NewTestCluster(s.context, 1)
 	c.Assert(err, IsNil)
 	err = cluster.RunInitialServers()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

try to remove mutex

Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

We use mutex in hotPeerCache which may cause mutex contention.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

This request remove the mutex and refactor `flowItem` with a proper way.


### Tests

I used `pd-heartbeat-bench` to test pd heartbeat (1 server / 6 cpu), here is the result

```
v5.0.0

Update speed of each category:
  Requests/sec:      8263.3143
  Save-Tree/sec:        0.0000
  Save-KV/sec:          0.0000
  Save-Space/sec:       0.0000
  Save-Flow/sec:     4131.6572
  Skip/sec:          4131.6572
```

```
master

Update speed of each category:
  Requests/sec:      6137.2065
  Save-Tree/sec:        0.0000
  Save-KV/sec:          0.0000
  Save-Space/sec:       0.0000
  Save-Flow/sec:     3068.6033
  Skip/sec:          3068.6033
```

```
This request

Update speed of each category:
  Requests/sec:     10228.7168
  Save-Tree/sec:        0.0000
  Save-KV/sec:          0.0000
  Save-Space/sec:       0.0000
  Save-Flow/sec:     5114.3584
  Skip/sec:          5114.3584
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
