### PR TITLE
statistics: more friendly output

### DIFF
--- a/server/api/trend.go
+++ b/server/api/trend.go
@@ -140,21 +140,21 @@ func (h *trendHandler) getTrendStores() ([]trendStore, error) {
 			LastHeartbeatTS: info.Status.LastHeartbeatTS,
 			Uptime:          info.Status.Uptime,
 		}
-		s.HotReadFlow, s.HotReadRegionFlows = h.getStoreFlow(readStats, statistics.RegionReadBytes, store.GetID())
-		s.HotWriteFlow, s.HotWriteRegionFlows = h.getStoreFlow(writeStats, statistics.RegionWriteBytes, store.GetID())
+		s.HotReadFlow, s.HotReadRegionFlows = h.getStoreFlow(readStats, store.GetID())
+		s.HotWriteFlow, s.HotWriteRegionFlows = h.getStoreFlow(writeStats, store.GetID())
 		trendStores = append(trendStores, s)
 	}
 	return trendStores, nil
 }
 
-func (h *trendHandler) getStoreFlow(stats statistics.StoreHotPeersStat, regionStatKind statistics.RegionStatKind, storeID uint64) (storeFlow float64, regionFlows []float64) {
+func (h *trendHandler) getStoreFlow(stats statistics.StoreHotPeersStat, storeID uint64) (storeByteFlow float64, regionByteFlows []float64) {
 	if stats == nil {
 		return
 	}
 	if stat, ok := stats[storeID]; ok {
-		storeFlow = stat.TotalBytesRate
+		storeByteFlow = stat.TotalBytesRate
 		for _, flow := range stat.Stats {
-			regionFlows = append(regionFlows, flow.ByteRate)
+			regionByteFlows = append(regionByteFlows, flow.ByteRate)
 		}
 	}
 	return

--- a/server/api/trend.go
+++ b/server/api/trend.go
@@ -152,9 +152,9 @@ func (h *trendHandler) getStoreFlow(stats statistics.StoreHotPeersStat, regionSt
 		return
 	}
 	if stat, ok := stats[storeID]; ok {
-		storeFlow = stat.TotalLoads[regionStatKind]
+		storeFlow = stat.TotalBytesRate
 		for _, flow := range stat.Stats {
-			regionFlows = append(regionFlows, flow.GetLoad(regionStatKind))
+			regionFlows = append(regionFlows, flow.ByteRate)
 		}
 	}
 	return

--- a/server/statistics/hot_regions_stat.go
+++ b/server/statistics/hot_regions_stat.go
@@ -13,9 +13,25 @@
 
 package statistics
 
+import (
+	"time"
+)
+
 // HotPeersStat records all hot regions statistics
 type HotPeersStat struct {
-	TotalLoads []float64     `json:"total_loads"`
-	Count      int           `json:"regions_count"`
-	Stats      []HotPeerStat `json:"statistics"`
+	TotalLoads     []float64         `json:"-"`
+	TotalBytesRate float64           `json:"total_flow_bytes"`
+	TotalKeysRate  float64           `json:"total_flow_keys"`
+	Count          int               `json:"regions_count"`
+	Stats          []HotPeerStatShow `json:"statistics"`
+}
+
+type HotPeerStatShow struct {
+	StoreID        uint64    `json:"store_id"`
+	RegionID       uint64    `json:"region_id"`
+	HotDegree      int       `json:"hot_degree"`
+	ByteRate       float64   `json:"flow_bytes"`
+	KeyRate        float64   `json:"flow_keys"`
+	AntiCount      int       `json:"anti_count"`
+	LastUpdateTime time.Time `json:"last_update_time"`
 }

--- a/server/statistics/hot_regions_stat.go
+++ b/server/statistics/hot_regions_stat.go
@@ -26,6 +26,7 @@ type HotPeersStat struct {
 	Stats          []HotPeerStatShow `json:"statistics"`
 }
 
+// HotPeerStatShow records the hot region statistics for output
 type HotPeerStatShow struct {
 	StoreID        uint64    `json:"store_id"`
 	RegionID       uint64    `json:"region_id"`


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

After #3591, we use []float64 to represent hot peer loads, but output is no friendly.

![image](https://user-images.githubusercontent.com/19542290/120517735-5a11e400-c403-11eb-94b9-c46f8aadb42f.png)

After this pr:

![image](https://user-images.githubusercontent.com/19542290/120520892-ed98e400-c406-11eb-8f79-ae69e6094915.png)

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
 None.
```
