### PR TITLE
tso: fix the Global TSO fallback bug

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1308,8 +1308,17 @@ func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) 
 			}
 			syncedDCs = append(syncedDCs, allocator.GetDCLocation())
 		}
-		// Found a bigger maxLocalTS, return it directly.
-		if tsoutil.CompareTimestamp(maxLocalTS, request.GetMaxTs()) > 0 {
+		// Found a bigger or equal maxLocalTS, return it directly.
+		cmpResult := tsoutil.CompareTimestamp(maxLocalTS, request.GetMaxTs())
+		if cmpResult >= 0 {
+			// Found an equal maxLocalTS, plus 1 to logical part before returning it.
+			// For example, we have a Global TSO t1 and a Local TSO t2, they have the
+			// same physical and logical parts. After being differentiating with suffix,
+			// there will be (t1.logical << suffixNum + 0) < (t2.logical << suffixNum + N),
+			// where N is bigger than 0, which will cause a Global TSO fallback than the previous Local TSO.
+			if cmpResult == 0 {
+				maxLocalTS.Logical += 1
+			}
 			return &pdpb.SyncMaxTSResponse{
 				Header:     s.header(),
 				MaxLocalTs: maxLocalTS,

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -178,7 +178,7 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 	)
 	for i := 0; i < maxRetryCount; i++ {
 		// TODO: add a switch to control whether to enable the MaxTSO estimation.
-		// 1. Estimate a MaxTS among all Local TSO Allocator leaders according to the RTT if enableGlobalTSOEstimation.
+		// 1. Estimate a MaxTS among all Local TSO Allocator leaders according to the RTT.
 		estimatedMaxTSO, shouldRetry, err = gta.estimateMaxTS(count, suffixBits)
 		if err != nil {
 			return pdpb.Timestamp{}, err


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>


### What problem does this PR solve?

Close #3732.

### What is changed and how it works?

Plus 1 to the logical part to prevent the Global TSO fallback than the previous Local TSO after being differentiating with a suffix.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
