### PR TITLE
core: optimize the processing speed of RegionHeartbeat

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -573,20 +573,23 @@ func (c *RaftCluster) HandleStoreHeartbeat(stats *pdpb.StoreStats) error {
 // processRegionHeartbeat updates the region information.
 func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	c.RLock()
+	hotStat := c.hotStat
+	storage := c.storage
 	origin, err := c.core.PreCheckPutRegion(region)
+	c.RUnlock()
 	if err != nil {
-		c.RUnlock()
 		return err
 	}
-	expiredStats := c.hotStat.ExpiredItems(region)
+
+	expiredStats := hotStat.ExpiredItems(region)
 	// Put expiredStats into read/write queue to update stats
 	if len(expiredStats) > 0 {
 		for _, stat := range expiredStats {
 			item := statistics.NewExpiredStatItem(stat)
 			if stat.Kind == statistics.WriteFlow {
-				c.hotStat.CheckWriteAsync(item)
+				hotStat.CheckWriteAsync(item)
 			} else {
-				c.hotStat.CheckReadAsync(item)
+				hotStat.CheckReadAsync(item)
 			}
 		}
 	}
@@ -595,9 +598,8 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	for _, peer := range region.GetPeers() {
 		peerInfo := core.NewPeerInfo(peer, region.GetWriteLoads(), interval)
 		item := statistics.NewPeerInfoItem(peerInfo, region)
-		c.hotStat.CheckWriteAsync(item)
+		hotStat.CheckWriteAsync(item)
 	}
-	c.RUnlock()
 
 	// Save to storage if meta is updated.
 	// Save to cache if meta or leader is updated, or contains any down/pending peer.
@@ -680,6 +682,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		time.Sleep(500 * time.Millisecond)
 	})
 
+	var overlaps []*core.RegionInfo
 	c.Lock()
 	if saveCache {
 		// To prevent a concurrent heartbeat of another region from overriding the up-to-date region info by a stale one,
@@ -690,17 +693,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 			c.Unlock()
 			return err
 		}
-		overlaps := c.core.PutRegion(region)
-		if c.storage != nil {
-			for _, item := range overlaps {
-				if err := c.storage.DeleteRegion(item.GetMeta()); err != nil {
-					log.Error("failed to delete region from storage",
-						zap.Uint64("region-id", item.GetID()),
-						logutil.ZapRedactStringer("region-meta", core.RegionToHexMeta(item.GetMeta())),
-						errs.ZapError(err))
-				}
-			}
-		}
+		overlaps = c.core.PutRegion(region)
 		for _, item := range overlaps {
 			if c.regionStats != nil {
 				c.regionStats.ClearDefunctRegion(item.GetID())
@@ -733,19 +726,30 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	}
 	c.Unlock()
 
-	// If there are concurrent heartbeats from the same region, the last write will win even if
-	// writes to storage in the critical area. So don't use mutex to protect it.
-	if saveKV && c.storage != nil {
-		if err := c.storage.SaveRegion(region.GetMeta()); err != nil {
-			// Not successfully saved to storage is not fatal, it only leads to longer warm-up
-			// after restart. Here we only log the error then go on updating cache.
-			log.Error("failed to save region to storage",
-				zap.Uint64("region-id", region.GetID()),
-				logutil.ZapRedactStringer("region-meta", core.RegionToHexMeta(region.GetMeta())),
-				errs.ZapError(err))
+	if storage != nil {
+		// If there are concurrent heartbeats from the same region, the last write will win even if
+		// writes to storage in the critical area. So don't use mutex to protect it.
+		// Not successfully saved to storage is not fatal, it only leads to longer warm-up
+		// after restart. Here we only log the error then go on updating cache.
+		for _, item := range overlaps {
+			if err := storage.DeleteRegion(item.GetMeta()); err != nil {
+				log.Error("failed to delete region from storage",
+					zap.Uint64("region-id", item.GetID()),
+					logutil.ZapRedactStringer("region-meta", core.RegionToHexMeta(item.GetMeta())),
+					errs.ZapError(err))
+			}
 		}
-		regionEventCounter.WithLabelValues("update_kv").Inc()
+		if saveKV {
+			if err := storage.SaveRegion(region.GetMeta()); err != nil {
+				log.Error("failed to save region to storage",
+					zap.Uint64("region-id", region.GetID()),
+					logutil.ZapRedactStringer("region-meta", core.RegionToHexMeta(region.GetMeta())),
+					errs.ZapError(err))
+			}
+			regionEventCounter.WithLabelValues("update_kv").Inc()
+		}
 	}
+
 	if saveKV || needSync {
 		select {
 		case c.changedRegions <- region:

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -576,7 +576,6 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	hotStat := c.hotStat
 	storage := c.storage
 	coreCluster := c.core
-	traceRegionFlow := c.traceRegionFlow
 	c.RUnlock()
 
 	origin, err := coreCluster.PreCheckPutRegion(region)
@@ -663,7 +662,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 			saveCache = true
 		}
 
-		if traceRegionFlow && (region.GetBytesWritten() != origin.GetBytesWritten() ||
+		if c.traceRegionFlow && (region.GetBytesWritten() != origin.GetBytesWritten() ||
 			region.GetBytesRead() != origin.GetBytesRead() ||
 			region.GetKeysWritten() != origin.GetKeysWritten() ||
 			region.GetKeysRead() != origin.GetKeysRead()) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -926,7 +926,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 		c.Assert(cache.SearchRegion(regionKey), IsNil)
 		checkRegions(c, cache, regions[0:i])
 
-		cache.AddRegion(region)
+		cache.SetRegion(region)
 		checkRegion(c, cache.GetRegion(i), region)
 		checkRegion(c, cache.SearchRegion(regionKey), region)
 		checkRegions(c, cache, regions[0:(i+1)])
@@ -952,7 +952,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 		// Reset leader to peer 0.
 		newRegion = region.Clone(core.WithLeader(region.GetPeers()[0]))
 		regions[i] = newRegion
-		cache.AddRegion(newRegion)
+		cache.SetRegion(newRegion)
 		checkRegion(c, cache.GetRegion(i), newRegion)
 		checkRegions(c, cache, regions[0:(i+1)])
 		checkRegion(c, cache.SearchRegion(regionKey), newRegion)
@@ -971,7 +971,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 	// check overlaps
 	// clone it otherwise there are two items with the same key in the tree
 	overlapRegion := regions[n-1].Clone(core.WithStartKey(regions[n-2].GetStartKey()))
-	cache.AddRegion(overlapRegion)
+	cache.SetRegion(overlapRegion)
 	c.Assert(cache.GetRegion(n-2), IsNil)
 	c.Assert(cache.GetRegion(n-1), NotNil)
 

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -456,10 +456,10 @@ func (rm regionMap) Get(id uint64) *regionItem {
 	return rm[id]
 }
 
-// Add uses RegionInfo to generate a new regionItem.
+// AddNew uses RegionInfo to generate a new regionItem.
 // If the regionItem already exists, it will be overwritten.
 // Note: Do not use this function when you only need to update the RegionInfo and do not need a new regionItem.
-func (rm regionMap) Add(region *RegionInfo) *regionItem {
+func (rm regionMap) AddNew(region *RegionInfo) *regionItem {
 	item := &regionItem{region: region}
 	rm[region.GetID()] = item
 	return item
@@ -572,7 +572,7 @@ func (r *RegionsInfo) addRegion(item *regionItem, region *RegionInfo, rangeChang
 	var overlaps []*RegionInfo
 	var origin *RegionInfo
 	if item == nil {
-		item = r.regions.Add(region)
+		item = r.regions.AddNew(region)
 	} else {
 		origin = item.region
 		item.region = region

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -505,7 +505,7 @@ func (r *RegionsInfo) SetRegion(region *RegionInfo) []*RegionInfo {
 			r.removeRegionFromSubTree(origin)
 		}
 	}
-	return r.AddRegion(region)
+	return r.addRegion(region)
 }
 
 // Len returns the RegionsInfo length
@@ -523,8 +523,8 @@ func (r *RegionsInfo) GetOverlaps(region *RegionInfo) []*RegionInfo {
 	return r.tree.getOverlaps(region)
 }
 
-// AddRegion adds RegionInfo to regionTree and regionMap, also update leaders and followers by region peers
-func (r *RegionsInfo) AddRegion(region *RegionInfo) []*RegionInfo {
+// addRegion adds RegionInfo to regionTree and regionMap, also update leaders and followers by region peers
+func (r *RegionsInfo) addRegion(region *RegionInfo) []*RegionInfo {
 	// the regions which are overlapped with the specified region range.
 	var overlaps []*RegionInfo
 	// when the value is true, add the region to the tree. otherwise use the region replace the origin region in the tree.

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -162,14 +162,14 @@ type testRegionMapSuite struct{}
 func (s *testRegionMapSuite) TestRegionMap(c *C) {
 	rm := newRegionMap()
 	s.check(c, rm)
-	rm.Add(s.regionInfo(1))
+	rm.AddNew(s.regionInfo(1))
 	s.check(c, rm, 1)
 
-	rm.Add(s.regionInfo(2))
-	rm.Add(s.regionInfo(3))
+	rm.AddNew(s.regionInfo(2))
+	rm.AddNew(s.regionInfo(3))
 	s.check(c, rm, 1, 2, 3)
 
-	rm.Add(s.regionInfo(3))
+	rm.AddNew(s.regionInfo(3))
 	rm.Delete(4)
 	s.check(c, rm, 1, 2, 3)
 
@@ -177,7 +177,7 @@ func (s *testRegionMapSuite) TestRegionMap(c *C) {
 	rm.Delete(1)
 	s.check(c, rm, 2)
 
-	rm.Add(s.regionInfo(3))
+	rm.AddNew(s.regionInfo(3))
 	s.check(c, rm, 2, 3)
 }
 

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -415,7 +415,7 @@ func BenchmarkRandomRegion(b *testing.B) {
 			StartKey: []byte(fmt.Sprintf("%20d", i)),
 			EndKey:   []byte(fmt.Sprintf("%20d", i+1)),
 		}, peer)
-		regions.AddRegion(region)
+		regions.SetRegion(region)
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -468,6 +468,6 @@ func BenchmarkAddRegion(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		regions.AddRegion(items[i])
+		regions.SetRegion(items[i])
 	}
 }

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -162,14 +162,14 @@ type testRegionMapSuite struct{}
 func (s *testRegionMapSuite) TestRegionMap(c *C) {
 	rm := newRegionMap()
 	s.check(c, rm)
-	rm.Put(s.regionInfo(1))
+	rm.Add(s.regionInfo(1))
 	s.check(c, rm, 1)
 
-	rm.Put(s.regionInfo(2))
-	rm.Put(s.regionInfo(3))
+	rm.Add(s.regionInfo(2))
+	rm.Add(s.regionInfo(3))
 	s.check(c, rm, 1, 2, 3)
 
-	rm.Put(s.regionInfo(3))
+	rm.Add(s.regionInfo(3))
 	rm.Delete(4)
 	s.check(c, rm, 1, 2, 3)
 
@@ -177,7 +177,7 @@ func (s *testRegionMapSuite) TestRegionMap(c *C) {
 	rm.Delete(1)
 	s.check(c, rm, 2)
 
-	rm.Put(s.regionInfo(3))
+	rm.Add(s.regionInfo(3))
 	s.check(c, rm, 2, 3)
 }
 
@@ -194,7 +194,7 @@ func (s *testRegionMapSuite) regionInfo(id uint64) *RegionInfo {
 func (s *testRegionMapSuite) check(c *C, rm regionMap, ids ...uint64) {
 	// Check Get.
 	for _, id := range ids {
-		c.Assert(rm.Get(id).GetID(), Equals, id)
+		c.Assert(rm.Get(id).region.GetID(), Equals, id)
 	}
 	// Check Len.
 	c.Assert(rm.Len(), Equals, len(ids))
@@ -205,7 +205,7 @@ func (s *testRegionMapSuite) check(c *C, rm regionMap, ids ...uint64) {
 	}
 	set1 := make(map[uint64]struct{})
 	for _, r := range rm {
-		set1[r.GetID()] = struct{}{}
+		set1[r.region.GetID()] = struct{}{}
 	}
 	c.Assert(set1, DeepEquals, expect)
 }

--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -97,10 +97,11 @@ func (t *regionTree) getOverlaps(region *RegionInfo) []*RegionInfo {
 // update updates the tree with the region.
 // It finds and deletes all the overlapped regions first, and then
 // insert the region.
-func (t *regionTree) update(region *RegionInfo) []*RegionInfo {
+func (t *regionTree) update(item *regionItem) []*RegionInfo {
+	region := item.region
 	t.totalSize += region.approximateSize
-
 	overlaps := t.getOverlaps(region)
+
 	for _, old := range overlaps {
 		log.Debug("overlapping region",
 			zap.Uint64("region-id", old.GetID()),
@@ -110,8 +111,7 @@ func (t *regionTree) update(region *RegionInfo) []*RegionInfo {
 		t.totalSize -= old.approximateSize
 	}
 
-	t.tree.ReplaceOrInsert(&regionItem{region: region})
-
+	t.tree.ReplaceOrInsert(item)
 	return overlaps
 }
 

--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -123,11 +123,11 @@ func (s *testRegionSuite) newRegionWithStat(start, end string, size, keys int64)
 func (s *testRegionSuite) TestRegionTreeStat(c *C) {
 	tree := newRegionTree()
 	c.Assert(tree.totalSize, Equals, int64(0))
-	tree.update(s.newRegionWithStat("a", "b", 1, 2))
+	updateNewItem(tree, s.newRegionWithStat("a", "b", 1, 2))
 	c.Assert(tree.totalSize, Equals, int64(1))
-	tree.update(s.newRegionWithStat("b", "c", 3, 4))
+	updateNewItem(tree, s.newRegionWithStat("b", "c", 3, 4))
 	c.Assert(tree.totalSize, Equals, int64(4))
-	tree.update(s.newRegionWithStat("b", "e", 5, 6))
+	updateNewItem(tree, s.newRegionWithStat("b", "e", 5, 6))
 	c.Assert(tree.totalSize, Equals, int64(6))
 	tree.remove(s.newRegionWithStat("a", "b", 1, 2))
 	c.Assert(tree.totalSize, Equals, int64(5))
@@ -137,10 +137,10 @@ func (s *testRegionSuite) TestRegionTreeStat(c *C) {
 
 func (s *testRegionSuite) TestRegionTreeMerge(c *C) {
 	tree := newRegionTree()
-	tree.update(s.newRegionWithStat("a", "b", 1, 2))
-	tree.update(s.newRegionWithStat("b", "c", 3, 4))
+	updateNewItem(tree, s.newRegionWithStat("a", "b", 1, 2))
+	updateNewItem(tree, s.newRegionWithStat("b", "c", 3, 4))
 	c.Assert(tree.totalSize, Equals, int64(4))
-	tree.update(s.newRegionWithStat("a", "c", 5, 5))
+	updateNewItem(tree, s.newRegionWithStat("a", "c", 5, 5))
 	c.Assert(tree.totalSize, Equals, int64(5))
 }
 
@@ -154,8 +154,8 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 	regionC := NewTestRegionInfo([]byte("c"), []byte("d"))
 	regionD := NewTestRegionInfo([]byte("d"), []byte{})
 
-	tree.update(regionA)
-	tree.update(regionC)
+	updateNewItem(tree, regionA)
+	updateNewItem(tree, regionC)
 	c.Assert(tree.search([]byte{}), IsNil)
 	c.Assert(tree.search([]byte("a")), Equals, regionA)
 	c.Assert(tree.search([]byte("b")), IsNil)
@@ -167,13 +167,13 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 	c.Assert(tree.searchPrev([]byte("b")), IsNil)
 	c.Assert(tree.searchPrev([]byte("c")), IsNil)
 
-	tree.update(regionB)
+	updateNewItem(tree, regionB)
 	// search previous region
 	c.Assert(tree.searchPrev([]byte("c")), Equals, regionB)
 	c.Assert(tree.searchPrev([]byte("b")), Equals, regionA)
 
 	tree.remove(regionC)
-	tree.update(regionD)
+	updateNewItem(tree, regionD)
 	c.Assert(tree.search([]byte{}), IsNil)
 	c.Assert(tree.search([]byte("a")), Equals, regionA)
 	c.Assert(tree.search([]byte("b")), Equals, regionB)
@@ -196,7 +196,7 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 
 	// region with the same range and different region id will not be delete.
 	region0 := newRegionItem([]byte{}, []byte("a")).region
-	tree.update(region0)
+	updateNewItem(tree, region0)
 	c.Assert(tree.search([]byte{}), Equals, region0)
 	anotherRegion0 := newRegionItem([]byte{}, []byte("a")).region
 	anotherRegion0.meta.Id = 123
@@ -205,7 +205,7 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 
 	// overlaps with 0, A, B, C.
 	region0D := newRegionItem([]byte(""), []byte("d")).region
-	tree.update(region0D)
+	updateNewItem(tree, region0D)
 	c.Assert(tree.search([]byte{}), Equals, region0D)
 	c.Assert(tree.search([]byte("a")), Equals, region0D)
 	c.Assert(tree.search([]byte("b")), Equals, region0D)
@@ -214,7 +214,7 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 
 	// overlaps with D.
 	regionE := newRegionItem([]byte("e"), []byte{}).region
-	tree.update(regionE)
+	updateNewItem(tree, regionE)
 	c.Assert(tree.search([]byte{}), Equals, region0D)
 	c.Assert(tree.search([]byte("a")), Equals, region0D)
 	c.Assert(tree.search([]byte("b")), Equals, region0D)
@@ -225,7 +225,7 @@ func (s *testRegionSuite) TestRegionTree(c *C) {
 
 func updateRegions(c *C, tree *regionTree, regions []*RegionInfo) {
 	for _, region := range regions {
-		tree.update(region)
+		updateNewItem(tree, region)
 		c.Assert(tree.search(region.GetStartKey()), Equals, region)
 		if len(region.GetEndKey()) > 0 {
 			end := region.GetEndKey()[0]
@@ -271,16 +271,16 @@ func (s *testRegionSuite) TestRandomRegion(c *C) {
 	c.Assert(r, IsNil)
 
 	regionA := NewTestRegionInfo([]byte(""), []byte("g"))
-	tree.update(regionA)
+	updateNewItem(tree, regionA)
 	ra := tree.RandomRegion([]KeyRange{NewKeyRange("", "")})
 	c.Assert(ra, DeepEquals, regionA)
 
 	regionB := NewTestRegionInfo([]byte("g"), []byte("n"))
 	regionC := NewTestRegionInfo([]byte("n"), []byte("t"))
 	regionD := NewTestRegionInfo([]byte("t"), []byte(""))
-	tree.update(regionB)
-	tree.update(regionC)
-	tree.update(regionD)
+	updateNewItem(tree, regionB)
+	updateNewItem(tree, regionC)
+	updateNewItem(tree, regionD)
 
 	rb := tree.RandomRegion([]KeyRange{NewKeyRange("g", "n")})
 	c.Assert(rb, DeepEquals, regionB)
@@ -312,7 +312,7 @@ func (s *testRegionSuite) TestRandomRegionDiscontinuous(c *C) {
 
 	// test for single region
 	regionA := NewTestRegionInfo([]byte("c"), []byte("f"))
-	tree.update(regionA)
+	updateNewItem(tree, regionA)
 	ra := tree.RandomRegion([]KeyRange{NewKeyRange("c", "e")})
 	c.Assert(ra, IsNil)
 	ra = tree.RandomRegion([]KeyRange{NewKeyRange("c", "f")})
@@ -327,7 +327,7 @@ func (s *testRegionSuite) TestRandomRegionDiscontinuous(c *C) {
 	c.Assert(ra, DeepEquals, regionA)
 
 	regionB := NewTestRegionInfo([]byte("n"), []byte("x"))
-	tree.update(regionB)
+	updateNewItem(tree, regionB)
 	rb := tree.RandomRegion([]KeyRange{NewKeyRange("g", "x")})
 	c.Assert(rb, DeepEquals, regionB)
 	rb = tree.RandomRegion([]KeyRange{NewKeyRange("g", "y")})
@@ -338,15 +338,20 @@ func (s *testRegionSuite) TestRandomRegionDiscontinuous(c *C) {
 	c.Assert(rb, IsNil)
 
 	regionC := NewTestRegionInfo([]byte("z"), []byte(""))
-	tree.update(regionC)
+	updateNewItem(tree, regionC)
 	rc := tree.RandomRegion([]KeyRange{NewKeyRange("y", "")})
 	c.Assert(rc, DeepEquals, regionC)
 	regionD := NewTestRegionInfo([]byte(""), []byte("a"))
-	tree.update(regionD)
+	updateNewItem(tree, regionD)
 	rd := tree.RandomRegion([]KeyRange{NewKeyRange("", "b")})
 	c.Assert(rd, DeepEquals, regionD)
 
 	checkRandomRegion(c, tree, []*RegionInfo{regionA, regionB, regionC, regionD}, []KeyRange{NewKeyRange("", "")})
+}
+
+func updateNewItem(tree *regionTree, region *RegionInfo) {
+	item := &regionItem{region: region}
+	tree.update(item)
 }
 
 func checkRandomRegion(c *C, tree *regionTree, regions []*RegionInfo, ranges []KeyRange) {
@@ -376,7 +381,7 @@ func BenchmarkRegionTreeUpdate(b *testing.B) {
 	tree := newRegionTree()
 	for i := 0; i < b.N; i++ {
 		item := &RegionInfo{meta: &metapb.Region{StartKey: []byte(fmt.Sprintf("%20d", i)), EndKey: []byte(fmt.Sprintf("%20d", i+1))}}
-		tree.update(item)
+		updateNewItem(tree, item)
 	}
 }
 
@@ -401,6 +406,6 @@ func BenchmarkRegionTreeUpdateUnordered(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tree.update(items[i])
+		updateNewItem(tree, items[i])
 	}
 }

--- a/server/schedule/range_cluster.go
+++ b/server/schedule/range_cluster.go
@@ -32,7 +32,7 @@ type RangeCluster struct {
 func GenRangeCluster(cluster opt.Cluster, startKey, endKey []byte) *RangeCluster {
 	subCluster := core.NewBasicCluster()
 	for _, r := range cluster.ScanRegions(startKey, endKey, -1) {
-		subCluster.Regions.AddRegion(r)
+		subCluster.Regions.SetRegion(r)
 	}
 	return &RangeCluster{
 		Cluster:    cluster,

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -129,7 +129,7 @@ func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 			break
 		}
 	}
-	tc.Regions.AddRegion(region)
+	tc.Regions.SetRegion(region)
 	op = sl.Schedule(tc)
 	testutil.CheckTransferLeader(c, op[0], operator.OpLeader, 1, 2)
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

* The current heartbeat processing speed can be increased.

### What is changed and how it works?

* Move `hotStat` out of the read lock
* Move `storage.DeleteRegion` out of the write lock
* Simple processing logic is used for RegionHeartbeat that only has statistics updated.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
