### PR TITLE
schedulers: avoid recalculate tolerantRatio

### DIFF
--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -171,22 +171,38 @@ func (s *testBalanceSuite) TestTolerantRatio(c *C) {
 	tbl := []struct {
 		ratio                  float64
 		kind                   core.ScheduleKind
-		expectTolerantResource func() int64
+		expectTolerantResource func(core.ScheduleKind) int64
 	}{
-		{0, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.ByCount}, func() int64 { return int64(leaderTolerantSizeRatio) }},
-		{0, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.BySize}, func() int64 { return int64(adjustTolerantRatio(tc) * float64(regionSize)) }},
-		{0, core.ScheduleKind{Resource: core.RegionKind, Policy: core.ByCount}, func() int64 { return int64(adjustTolerantRatio(tc) * float64(regionSize)) }},
-		{0, core.ScheduleKind{Resource: core.RegionKind, Policy: core.BySize}, func() int64 { return int64(adjustTolerantRatio(tc) * float64(regionSize)) }},
-		{10, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.ByCount}, func() int64 { return int64(tc.GetScheduleConfig().TolerantSizeRatio) }},
-		{10, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.BySize}, func() int64 { return int64(adjustTolerantRatio(tc) * float64(regionSize)) }},
-		{10, core.ScheduleKind{Resource: core.RegionKind, Policy: core.ByCount}, func() int64 { return int64(adjustTolerantRatio(tc) * float64(regionSize)) }},
-		{10, core.ScheduleKind{Resource: core.RegionKind, Policy: core.BySize}, func() int64 { return int64(adjustTolerantRatio(tc) * float64(regionSize)) }},
+		{0, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.ByCount}, func(k core.ScheduleKind) int64 {
+			return int64(leaderTolerantSizeRatio)
+		}},
+		{0, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.BySize}, func(k core.ScheduleKind) int64 {
+			return int64(adjustTolerantRatio(tc, k) * float64(regionSize))
+		}},
+		{0, core.ScheduleKind{Resource: core.RegionKind, Policy: core.ByCount}, func(k core.ScheduleKind) int64 {
+			return int64(adjustTolerantRatio(tc, k) * float64(regionSize))
+		}},
+		{0, core.ScheduleKind{Resource: core.RegionKind, Policy: core.BySize}, func(k core.ScheduleKind) int64 {
+			return int64(adjustTolerantRatio(tc, k) * float64(regionSize))
+		}},
+		{10, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.ByCount}, func(k core.ScheduleKind) int64 {
+			return int64(tc.GetScheduleConfig().TolerantSizeRatio)
+		}},
+		{10, core.ScheduleKind{Resource: core.LeaderKind, Policy: core.BySize}, func(k core.ScheduleKind) int64 {
+			return int64(adjustTolerantRatio(tc, k) * float64(regionSize))
+		}},
+		{10, core.ScheduleKind{Resource: core.RegionKind, Policy: core.ByCount}, func(k core.ScheduleKind) int64 {
+			return int64(adjustTolerantRatio(tc, k) * float64(regionSize))
+		}},
+		{10, core.ScheduleKind{Resource: core.RegionKind, Policy: core.BySize}, func(k core.ScheduleKind) int64 {
+			return int64(adjustTolerantRatio(tc, k) * float64(regionSize))
+		}},
 	}
 	for i, t := range tbl {
 		tc.SetTolerantSizeRatio(t.ratio)
 		plan := newBalancePlan(t.kind, tc, operator.OpInfluence{})
 		plan.region = region
-		c.Assert(plan.getTolerantResource(), Equals, t.expectTolerantResource(), Commentf("case #%d", i+1))
+		c.Assert(plan.getTolerantResource(), Equals, t.expectTolerantResource(t.kind), Commentf("case #%d", i+1))
 	}
 }
 

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -37,9 +37,10 @@ const (
 )
 
 type balancePlan struct {
-	kind        core.ScheduleKind
-	cluster     opt.Cluster
-	opInfluence operator.OpInfluence
+	kind              core.ScheduleKind
+	cluster           opt.Cluster
+	opInfluence       operator.OpInfluence
+	tolerantSizeRatio float64
 
 	source *core.StoreInfo
 	target *core.StoreInfo
@@ -51,9 +52,10 @@ type balancePlan struct {
 
 func newBalancePlan(kind core.ScheduleKind, cluster opt.Cluster, opInfluence operator.OpInfluence) *balancePlan {
 	return &balancePlan{
-		kind:        kind,
-		cluster:     cluster,
-		opInfluence: opInfluence,
+		kind:              kind,
+		cluster:           cluster,
+		opInfluence:       opInfluence,
+		tolerantSizeRatio: adjustTolerantRatio(cluster, kind),
 	}
 }
 
@@ -119,24 +121,24 @@ func (p *balancePlan) shouldBalance(scheduleName string) bool {
 
 func (p *balancePlan) getTolerantResource() int64 {
 	if p.kind.Resource == core.LeaderKind && p.kind.Policy == core.ByCount {
-		tolerantSizeRatio := p.cluster.GetOpts().GetTolerantSizeRatio()
-		if tolerantSizeRatio == 0 {
-			tolerantSizeRatio = leaderTolerantSizeRatio
-		}
-		leaderCount := int64(1.0 * tolerantSizeRatio)
-		return leaderCount
+		return int64(p.tolerantSizeRatio)
 	}
-
 	regionSize := p.region.GetApproximateSize()
 	if regionSize < p.cluster.GetAverageRegionSize() {
 		regionSize = p.cluster.GetAverageRegionSize()
 	}
-	regionSize = int64(float64(regionSize) * adjustTolerantRatio(p.cluster))
-	return regionSize
+	return int64(float64(regionSize) * p.tolerantSizeRatio)
 }
 
-func adjustTolerantRatio(cluster opt.Cluster) float64 {
+func adjustTolerantRatio(cluster opt.Cluster, kind core.ScheduleKind) float64 {
 	tolerantSizeRatio := cluster.GetOpts().GetTolerantSizeRatio()
+	if kind.Resource == core.LeaderKind && kind.Policy == core.ByCount {
+		if tolerantSizeRatio == 0 {
+			return leaderTolerantSizeRatio
+		}
+		return tolerantSizeRatio
+	}
+
 	if tolerantSizeRatio == 0 {
 		var maxRegionCount float64
 		stores := cluster.GetStores()


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Improve `GetStoreRegionCount`
Part of https://github.com/tikv/pd/issues/3744

### What is changed and how it works?
Calculate `tolerantSizeRatio` when the `balancePlan` is created and reuse it later.

### Check List

Tests
- Unit test

### Release note

```release-note
None
```
