### PR TITLE
*: make flow-round-by-digit compatible with trace-region-flow

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -659,8 +659,8 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		}
 		// Once flow has changed, will update the cache.
 		// Because keys and bytes are strongly related, only bytes are judged.
-		if c.traceRegionFlow && (region.GetRoundBytesWritten() != origin.GetRoundBytesWritten() ||
-			region.GetRoundBytesRead() != origin.GetRoundBytesRead()) {
+		if region.GetRoundBytesWritten() != origin.GetRoundBytesWritten() ||
+			region.GetRoundBytesRead() != origin.GetRoundBytesRead() {
 			saveCache, needSync = true, true
 		}
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -622,13 +622,6 @@ func (s *testClusterInfoSuite) TestRegionFlowChanged(c *C) {
 	processRegions(regions)
 	newRegion := cluster.GetRegion(region.GetID())
 	c.Assert(newRegion.GetBytesRead(), Equals, uint64(1000))
-
-	// do not trace the flow changes
-	cluster.traceRegionFlow = false
-	processRegions([]*core.RegionInfo{region})
-	newRegion = cluster.GetRegion(region.GetID())
-	c.Assert(region.GetBytesRead(), Equals, uint64(0))
-	c.Assert(newRegion.GetBytesRead(), Not(Equals), uint64(0))
 }
 
 func (s *testClusterInfoSuite) TestConcurrentRegionHeartbeat(c *C) {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1077,8 +1077,8 @@ type PDServerConfig struct {
 	MetricStorage string `toml:"metric-storage" json:"metric-storage"`
 	// There are some values supported: "auto", "none", or a specific address, default: "auto"
 	DashboardAddress string `toml:"dashboard-address" json:"dashboard-address"`
-	// TraceRegionFlow the option to update flow information of regions
-	// WARN: TraceRegionFlow is deprecate
+	// TraceRegionFlow the option to update flow information of regions.
+	// WARN: TraceRegionFlow is deprecated.
 	TraceRegionFlow bool `toml:"trace-region-flow" json:"trace-region-flow,string,omitempty"`
 	// FlowRoundByDigit used to discretization processing flow information.
 	FlowRoundByDigit int `toml:"flow-round-by-digit" json:"flow-round-by-digit"`
@@ -1118,7 +1118,7 @@ func (c *PDServerConfig) migrateConfigurationFromFile(meta *configMetaData) erro
 		}
 	case defineOld && !defineNew:
 		if !c.TraceRegionFlow {
-			c.FlowRoundByDigit = math.MaxInt64
+			c.FlowRoundByDigit = math.MaxInt8
 		}
 	}
 	return nil
@@ -1127,7 +1127,7 @@ func (c *PDServerConfig) migrateConfigurationFromFile(meta *configMetaData) erro
 // MigrateDeprecatedFlags updates new flags according to deprecated flags.
 func (c *PDServerConfig) MigrateDeprecatedFlags() {
 	if !c.TraceRegionFlow {
-		c.FlowRoundByDigit = math.MaxInt64
+		c.FlowRoundByDigit = math.MaxInt8
 	}
 	// json omity the false. next time will not persist to the kv.
 	c.TraceRegionFlow = false

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1077,8 +1078,8 @@ type PDServerConfig struct {
 	// There are some values supported: "auto", "none", or a specific address, default: "auto"
 	DashboardAddress string `toml:"dashboard-address" json:"dashboard-address"`
 	// TraceRegionFlow the option to update flow information of regions
-	// TODO: deprecate
-	TraceRegionFlow bool `toml:"trace-region-flow" json:"trace-region-flow,string"`
+	// WARN: TraceRegionFlow is deprecate
+	TraceRegionFlow bool `toml:"trace-region-flow" json:"trace-region-flow,string,omitempty"`
 	// FlowRoundByDigit used to discretization processing flow information.
 	FlowRoundByDigit int `toml:"flow-round-by-digit" json:"flow-round-by-digit"`
 }
@@ -1103,7 +1104,33 @@ func (c *PDServerConfig) adjust(meta *configMetaData) error {
 	if !meta.IsDefined("flow-round-by-digit") {
 		adjustInt(&c.FlowRoundByDigit, defaultFlowRoundByDigit)
 	}
+	c.migrateConfigurationFromFile(meta)
 	return c.Validate()
+}
+
+func (c *PDServerConfig) migrateConfigurationFromFile(meta *configMetaData) error {
+	oldName, newName := "trace-region-flow", "flow-round-by-digit"
+	defineOld, defineNew := meta.IsDefined(oldName), meta.IsDefined(newName)
+	switch {
+	case defineOld && defineNew:
+		if c.TraceRegionFlow && (c.FlowRoundByDigit == defaultFlowRoundByDigit) {
+			return errors.Errorf("config item %s and %s(deprecated) are conflict", newName, oldName)
+		}
+	case defineOld && !defineNew:
+		if !c.TraceRegionFlow {
+			c.FlowRoundByDigit = math.MaxInt64
+		}
+	}
+	return nil
+}
+
+// MigrateDeprecatedFlags updates new flags according to deprecated flags.
+func (c *PDServerConfig) MigrateDeprecatedFlags() {
+	if !c.TraceRegionFlow {
+		c.FlowRoundByDigit = math.MaxInt64
+	}
+	// json omity the false. next time will not persist to the kv.
+	c.TraceRegionFlow = false
 }
 
 // Clone returns a cloned PD server config.

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -285,7 +285,7 @@ func (s *testConfigSuite) TestMigrateFlags(c *C) {
 		return cfg, err
 	}
 	cfg, err := load(`
-[server]
+[pd-server]
 trace-region-flow = false
 [schedule]
 disable-remove-down-replica = true
@@ -294,7 +294,7 @@ disable-remove-extra-replica = true
 enable-remove-extra-replica = false
 `)
 	c.Assert(err, IsNil)
-	c.Assert(cfg.PDServerCfg.FlowRoundByDigit, Equals, math.MaxInt64)
+	c.Assert(cfg.PDServerCfg.FlowRoundByDigit, Equals, math.MaxInt8)
 	c.Assert(cfg.Schedule.EnableReplaceOfflineReplica, IsTrue)
 	c.Assert(cfg.Schedule.EnableRemoveDownReplica, IsFalse)
 	c.Assert(cfg.Schedule.EnableMakeUpReplica, IsFalse)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -16,6 +16,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"strings"
@@ -284,6 +285,8 @@ func (s *testConfigSuite) TestMigrateFlags(c *C) {
 		return cfg, err
 	}
 	cfg, err := load(`
+[server]
+trace-region-flow = false
 [schedule]
 disable-remove-down-replica = true
 enable-make-up-replica = false
@@ -291,6 +294,7 @@ disable-remove-extra-replica = true
 enable-remove-extra-replica = false
 `)
 	c.Assert(err, IsNil)
+	c.Assert(cfg.PDServerCfg.FlowRoundByDigit, Equals, math.MaxInt64)
 	c.Assert(cfg.Schedule.EnableReplaceOfflineReplica, IsTrue)
 	c.Assert(cfg.Schedule.EnableRemoveDownReplica, IsFalse)
 	c.Assert(cfg.Schedule.EnableMakeUpReplica, IsFalse)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -580,6 +580,7 @@ func (o *PersistOptions) Reload(storage *core.Storage) error {
 		return err
 	}
 	o.adjustScheduleCfg(&cfg.Schedule)
+	cfg.PDServerCfg.MigrateDeprecatedFlags()
 	if isExist {
 		o.schedule.Store(&cfg.Schedule)
 		o.replication.Store(&cfg.Replication)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

deprecate `trace-region-flow`

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
situation 1
```
### old server
➜  pd git:(remove-trace-flow) ✗ ./bin/pd-ctl config set trace-region-flow false
Success!
➜  pd git:(remove-trace-flow) ✗ ./bin/pd-ctl config show all |grep flow        
"trace-region-flow": "false"

### start new binary
➜  pd git:(remove-trace-flow) ✗ ./bin/pd-ctl config show all |grep flow
"flow-round-by-digit": 9223372036854775807
➜  pd git:(remove-trace-flow) ✗ ./bin/pd-ctl config set flow-round-by-digit 9
Success!
➜  pd git:(remove-trace-flow) ✗ ./bin/pd-ctl config show all |grep flow      
"flow-round-by-digit": 9
### restart new binary
➜  pd git:(remove-trace-flow) ✗ ./bin/pd-ctl config show all |grep flow      
"flow-round-by-digit": 9
```

situation 2
```
### old server
➜  pd git:(remove-trace-flow) ./bin/pd-ctl config show all |grep flow
    "trace-region-flow": "true"
### restart with new binary
➜  pd git:(remove-trace-flow) ./bin/pd-ctl config show all |grep flow
    "flow-round-by-digit": 3
### restart with new binary
➜  pd git:(remove-trace-flow) ./bin/pd-ctl config show all |grep flow
    "flow-round-by-digit": 3
```
### Release note


```release-note
 Deprecate  `trace-region-flow`, and use new config `flow-round-by-digit`
```
