### PR TITLE
schedule: tune waiting region length

### DIFF
--- a/server/schedule/checker_controller.go
+++ b/server/schedule/checker_controller.go
@@ -26,7 +26,7 @@ import (
 )
 
 // DefaultCacheSize is the default length of waiting list.
-const DefaultCacheSize = 1000
+const DefaultCacheSize = 128
 
 // CheckerController is used to manage all checkers.
 type CheckerController struct {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

The regions in the waring list are checked every tick. When there are many regions need to fix, it costs too much CPU.

Part of https://github.com/tikv/pd/issues/3744

### What is changed and how it works?

Update cache size to a smaller value.

### Check List


Tests
- Unit test



### Release note
```release-note
None
```
