### PR TITLE
metrics: update grafana template

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -8164,7 +8164,7 @@
                 "query": {
                   "datasourceId": 1,
                   "model": {
-                    "expr": "delta(etcd_disk_wal_fsync_duration_seconds_count{tidb_cluster=\"$tidb_cluster\"}[1m])",
+                    "expr": "delta(etcd_disk_wal_fsync_duration_seconds_count{tidb_cluster=\"$tidb_cluster\", job=\"pd\"}[1m])",
                     "intervalFactor": 2,
                     "legendFormat": "{{instance}} etch disk wal fsync rate",
                     "refId": "A",
@@ -8233,7 +8233,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "delta(etcd_disk_wal_fsync_duration_seconds_count{tidb_cluster=\"$tidb_cluster\"}[1m])",
+              "expr": "delta(etcd_disk_wal_fsync_duration_seconds_count{tidb_cluster=\"$tidb_cluster\", job=\"pd\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

In some cluster, there may be some other etcd instance or other components using etcd. To avoid metrics been affected and lead to false alarms. We can restrict metrics by using `job`.

### What is changed and how it works?
Add `job="pd"` in expresssion.

### Check List

Tests
- No code

### Release note

```release-note
None
```
