### PR TITLE
api: save cluster in request context

### DIFF
--- a/server/api/admin.go
+++ b/server/api/admin.go
@@ -44,7 +44,7 @@ func newAdminHandler(svr *server.Server, rd *render.Render) *adminHandler {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /admin/cache/region/{id} [delete]
 func (h *adminHandler) HandleDropCacheRegion(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	regionIDStr := vars["id"]
 	regionID, err := strconv.ParseUint(regionIDStr, 10, 64)
@@ -114,7 +114,6 @@ func (h *adminHandler) persistFile(w http.ResponseWriter, r *http.Request) {
 // Intentionally no swagger mark as it is supposed to be only used in
 // server-to-server.
 func (h *adminHandler) UpdateWaitAsyncTime(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -129,15 +128,7 @@ func (h *adminHandler) UpdateWaitAsyncTime(w http.ResponseWriter, r *http.Reques
 		h.rd.JSON(w, http.StatusBadRequest, "invalid member id")
 		return
 	}
-	cluster, err := handler.GetRaftCluster()
-	if err != nil {
-		if err == server.ErrServerNotStarted {
-			h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		} else {
-			h.rd.JSON(w, http.StatusForbidden, err.Error())
-		}
-		return
-	}
+	cluster := getCluster(r)
 	cluster.GetReplicationMode().UpdateMemberWaitAsyncTime(memberID)
 	h.rd.JSON(w, http.StatusOK, nil)
 }

--- a/server/api/component.go
+++ b/server/api/component.go
@@ -47,7 +47,7 @@ func newComponentHandler(svr *server.Server, rd *render.Render) *componentHandle
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /component [post]
 func (h *componentHandler) Register(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	input := make(map[string]string)
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -76,7 +76,7 @@ func (h *componentHandler) Register(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /component [delete]
 func (h *componentHandler) UnRegister(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	component := vars["component"]
 	addr := vars["addr"]
@@ -93,7 +93,7 @@ func (h *componentHandler) UnRegister(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} Addresses
 // @Router /component [get]
 func (h *componentHandler) GetAllAddress(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	addrs := rc.GetComponentManager().GetAllComponentAddrs()
 	h.rd.JSON(w, http.StatusOK, addrs)
 }
@@ -105,7 +105,7 @@ func (h *componentHandler) GetAllAddress(w http.ResponseWriter, r *http.Request)
 // @Failure 404 {string} string "The component does not exist."
 // @Router /component/{type} [get]
 func (h *componentHandler) GetAddress(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	component := vars["type"]
 	addrs := rc.GetComponentManager().GetComponentAddrs(component)

--- a/server/api/label.go
+++ b/server/api/label.go
@@ -42,7 +42,7 @@ func newLabelsHandler(svr *server.Server, rd *render.Render) *labelsHandler {
 // @Success 200 {array} metapb.StoreLabel
 // @Router /labels [get]
 func (h *labelsHandler) Get(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	var labels []*metapb.StoreLabel
 	m := make(map[string]struct{})
 	stores := rc.GetStores()
@@ -67,7 +67,7 @@ func (h *labelsHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /labels/stores [get]
 func (h *labelsHandler) GetStores(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	name := r.URL.Query().Get("name")
 	value := r.URL.Query().Get("value")
 	filter, err := newStoresLabelFilter(name, value)

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -201,7 +201,7 @@ func newRegionHandler(svr *server.Server, rd *render.Render) *regionHandler {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /region/id/{id} [get]
 func (h *regionHandler) GetRegionByID(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 
 	vars := mux.Vars(r)
 	regionIDStr := vars["id"]
@@ -222,7 +222,7 @@ func (h *regionHandler) GetRegionByID(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} RegionInfo
 // @Router /region/key/{key} [get]
 func (h *regionHandler) GetRegionByKey(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	key := vars["key"]
 	key, err := url.QueryUnescape(key)
@@ -263,7 +263,7 @@ func convertToAPIRegions(regions []*core.RegionInfo) *RegionsInfo {
 // @Success 200 {object} RegionsInfo
 // @Router /regions [get]
 func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	regions := rc.GetRegions()
 	regionsInfo := convertToAPIRegions(regions)
 	h.rd.JSON(w, http.StatusOK, regionsInfo)
@@ -278,7 +278,7 @@ func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/key [get]
 func (h *regionsHandler) ScanRegions(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	startKey := r.URL.Query().Get("key")
 
 	limit := defaultRegionLimit
@@ -304,7 +304,7 @@ func (h *regionsHandler) ScanRegions(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} RegionsInfo
 // @Router /regions/count [get]
 func (h *regionsHandler) GetRegionCount(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	count := rc.GetRegionCount()
 	h.rd.JSON(w, http.StatusOK, &RegionsInfo{Count: count})
 }
@@ -317,7 +317,7 @@ func (h *regionsHandler) GetRegionCount(w http.ResponseWriter, r *http.Request) 
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/store/{id} [get]
 func (h *regionsHandler) GetStoreRegions(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 
 	vars := mux.Vars(r)
 	id, err := strconv.Atoi(vars["id"])
@@ -483,7 +483,7 @@ func (h *regionsHandler) GetSizeHistogram(w http.ResponseWriter, r *http.Request
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	regions := rc.GetRegions()
 	histSizes := make([]int64, 0, len(regions))
 	for _, region := range regions {
@@ -507,7 +507,7 @@ func (h *regionsHandler) GetKeysHistogram(w http.ResponseWriter, r *http.Request
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	regions := rc.GetRegions()
 	histKeys := make([]int64, 0, len(regions))
 	for _, region := range regions {
@@ -561,7 +561,7 @@ func calHist(bound int, list *[]int64) *[]*histItem {
 // @Failure 404 {string} string "The region does not exist."
 // @Router /regions/sibling/{id} [get]
 func (h *regionsHandler) GetRegionSiblings(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 
 	vars := mux.Vars(r)
 	id, err := strconv.Atoi(vars["id"])
@@ -658,7 +658,7 @@ func (h *regionsHandler) GetTopSize(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/accelerate-schedule [post]
 func (h *regionsHandler) AccelerateRegionsScheduleInRange(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -700,7 +700,7 @@ func (h *regionsHandler) AccelerateRegionsScheduleInRange(w http.ResponseWriter,
 }
 
 func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, less func(a, b *core.RegionInfo) bool) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	limit := defaultRegionLimit
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
 		var err error
@@ -727,7 +727,7 @@ func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, 
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/scatter [post]
 func (h *regionsHandler) ScatterRegions(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -803,7 +803,7 @@ func (h *regionsHandler) ScatterRegions(w http.ResponseWriter, r *http.Request) 
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/split [post]
 func (h *regionsHandler) SplitRegions(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return

--- a/server/api/replication_mode.go
+++ b/server/api/replication_mode.go
@@ -38,5 +38,5 @@ func newReplicationModeHandler(svr *server.Server, rd *render.Render) *replicati
 // @Success 200 {object} replication.HTTPReplicationStatus
 // @Router /replication_mode/status [get]
 func (h *replicationModeHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
-	h.rd.JSON(w, http.StatusOK, h.svr.GetRaftCluster().GetReplicationMode().GetReplicationStatusHTTP())
+	h.rd.JSON(w, http.StatusOK, getCluster(r).GetReplicationMode().GetReplicationStatusHTTP())
 }

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -50,7 +50,7 @@ func newRulesHandler(svr *server.Server, rd *render.Render) *ruleHandler {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules [get]
 func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -69,7 +69,7 @@ func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rules [get]
 func (h *ruleHandler) SetAll(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -104,7 +104,7 @@ func (h *ruleHandler) SetAll(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules/group/{group} [get]
 func (h *ruleHandler) GetAllByGroup(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -124,7 +124,7 @@ func (h *ruleHandler) GetAllByGroup(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules/region/{region} [get]
 func (h *ruleHandler) GetAllByRegion(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -153,7 +153,7 @@ func (h *ruleHandler) GetAllByRegion(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules/key/{key} [get]
 func (h *ruleHandler) GetAllByKey(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -178,7 +178,7 @@ func (h *ruleHandler) GetAllByKey(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rule/{group}/{id} [get]
 func (h *ruleHandler) Get(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -203,7 +203,7 @@ func (h *ruleHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule [post]
 func (h *ruleHandler) Set(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -256,7 +256,7 @@ func (h *ruleHandler) syncReplicateConfigWithDefaultRule(rule *placement.Rule) e
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule/{group}/{id} [delete]
 func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -284,7 +284,7 @@ func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rules/batch [post]
 func (h *ruleHandler) Batch(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -314,7 +314,7 @@ func (h *ruleHandler) Batch(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rule_group/{id} [get]
 func (h *ruleHandler) GetGroupConfig(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -339,7 +339,7 @@ func (h *ruleHandler) GetGroupConfig(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule_group [post]
 func (h *ruleHandler) SetGroupConfig(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -367,7 +367,7 @@ func (h *ruleHandler) SetGroupConfig(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule_group/{id} [delete]
 func (h *ruleHandler) DeleteGroupConfig(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -391,7 +391,7 @@ func (h *ruleHandler) DeleteGroupConfig(w http.ResponseWriter, r *http.Request) 
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rule_groups [get]
 func (h *ruleHandler) GetAllGroupConfigs(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -407,7 +407,7 @@ func (h *ruleHandler) GetAllGroupConfigs(w http.ResponseWriter, r *http.Request)
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/placement-rule [get]
 func (h *ruleHandler) GetAllGroupBundles(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -426,7 +426,7 @@ func (h *ruleHandler) GetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/placement-rule [post]
 func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -456,7 +456,7 @@ func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/placement-rule/{group} [get]
 func (h *ruleHandler) GetGroupBundle(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -475,7 +475,7 @@ func (h *ruleHandler) GetGroupBundle(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/placement-rule [delete]
 func (h *ruleHandler) DeleteGroupBundle(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -503,7 +503,7 @@ func (h *ruleHandler) DeleteGroupBundle(w http.ResponseWriter, r *http.Request) 
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/placement-rule/{group} [post]
 func (h *ruleHandler) SetGroupBundle(w http.ResponseWriter, r *http.Request) {
-	cluster := h.svr.GetRaftCluster()
+	cluster := getCluster(r)
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -40,7 +40,7 @@ func newStatsHandler(svr *server.Server, rd *render.Render) *statsHandler {
 // @Success 200 {object} statistics.RegionStats
 // @Router /stats/region [get]
 func (h *statsHandler) Region(w http.ResponseWriter, r *http.Request) {
-	rc := h.svr.GetRaftCluster()
+	rc := getCluster(r)
 	startKey, endKey := r.URL.Query().Get("start_key"), r.URL.Query().Get("end_key")
 	stats := rc.GetRegionStats([]byte(startKey), []byte(endKey))
 	h.rd.JSON(w, http.StatusOK, stats)

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -147,7 +147,7 @@ func newStoreHandler(handler *server.Handler, rd *render.Render) *storeHandler {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id} [get]
 func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -177,7 +177,7 @@ func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id} [delete]
 func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -207,7 +207,7 @@ func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/state [post]
 func (h *storeHandler) SetState(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -260,7 +260,7 @@ func (h *storeHandler) responseStoreErr(w http.ResponseWriter, err error, storeI
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/label [post]
 func (h *storeHandler) SetLabels(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -306,7 +306,7 @@ func (h *storeHandler) SetLabels(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/weight [post]
 func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -360,7 +360,7 @@ func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/limit [post]
 func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
+	rc := getCluster(r)
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -440,8 +440,7 @@ func newStoresHandler(handler *server.Handler, rd *render.Render) *storesHandler
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /stores/remove-tombstone [delete]
 func (h *storesHandler) RemoveTombStone(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
-	err := rc.RemoveTombStoneRecords()
+	err := getCluster(r).RemoveTombStoneRecords()
 	if err != nil {
 		apiutil.ErrorResp(h.rd, w, err)
 		return
@@ -554,7 +553,7 @@ func (h *storesHandler) GetAllLimit(w http.ResponseWriter, r *http.Request) {
 	}
 	if !includeTombstone {
 		returned := make(map[uint64]config.StoreLimitConfig, len(limits))
-		rc, _ := h.GetRaftCluster()
+		rc := getCluster(r)
 		for storeID, v := range limits {
 			store := rc.GetStore(storeID)
 			if store == nil || store.IsTombstone() {
@@ -616,7 +615,7 @@ func (h *storesHandler) GetStoreLimitScene(w http.ResponseWriter, r *http.Reques
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /stores [get]
 func (h *storesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rc, _ := h.GetRaftCluster()
+	rc := getCluster(r)
 	stores := rc.GetMetaStores()
 	StoresInfo := &StoresInfo{
 		Stores: make([]*StoreInfo, 0, len(stores)),


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
ref https://github.com/tikv/pd/issues/3753
We use middleware to verify the cluster is created. But the `GetRaftCluster` can return `nil` after the check. For example, when the server is closing.

It can potentially cause server panic.

### What is changed and how it works?

In middleware, save the `RaftCluster` in request context. So that later we can always take a `RaftCluster` and use.

### Check List

Tests
- Unit test

### Release note
```release-note
None
```
