### PR TITLE
statistics: fix task might get stuck and hold raftcluster mutex

### DIFF
--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -137,14 +137,8 @@ func (w *HotCache) IsRegionHot(region *core.RegionInfo, minHotDegree int) bool {
 func (w *HotCache) CollectMetrics() {
 	writeMetricsTask := newCollectMetricsTask("write")
 	readMetricsTask := newCollectMetricsTask("read")
-	succ1 := w.CheckWriteAsync(writeMetricsTask)
-	succ2 := w.CheckReadAsync(readMetricsTask)
-	if succ1 {
-		writeMetricsTask.waitDone(w.ctx, w.quit)
-	}
-	if succ2 {
-		readMetricsTask.waitDone(w.ctx, w.quit)
-	}
+	w.CheckWriteAsync(writeMetricsTask)
+	w.CheckReadAsync(readMetricsTask)
 }
 
 // ResetMetrics resets the hot cache metrics.
@@ -200,6 +194,7 @@ func (w *HotCache) updateItems(queue <-chan FlowItemTask, runTask func(task Flow
 
 func (w *HotCache) runReadTask(task FlowItemTask) {
 	if task != nil {
+		// TODO: do we need a run-task timeout to protect the queue won't be stucked by a task?
 		task.runTask(w.readFlow)
 		hotCacheFlowQueueStatusGauge.WithLabelValues(ReadFlow.String()).Set(float64(len(w.readFlowQueue)))
 	}
@@ -207,6 +202,7 @@ func (w *HotCache) runReadTask(task FlowItemTask) {
 
 func (w *HotCache) runWriteTask(task FlowItemTask) {
 	if task != nil {
+		// TODO: do we need a run-task timeout to protect the queue won't be stucked by a task?
 		task.runTask(w.writeFlow)
 		hotCacheFlowQueueStatusGauge.WithLabelValues(WriteFlow.String()).Set(float64(len(w.writeFlowQueue)))
 	}


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

statistics task will hold raftCluster mutex during running which is unnecessary. Also the waiting return channel didn't have buffer which may also block the running the task.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
Fix these problems.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
