### PR TITLE
schedule: fix race for region scatter

### DIFF
--- a/server/schedule/region_scatterer_test.go
+++ b/server/schedule/region_scatterer_test.go
@@ -462,7 +462,7 @@ func (s *testScatterRegionSuite) TestRegionFromDifferentGroups(c *C) {
 		max := uint64(0)
 		min := uint64(math.MaxUint64)
 		for i := uint64(1); i <= uint64(storeCount); i++ {
-			count := ss.totalCountByStore(i)
+			count := ss.TotalCountByStore(i)
 			if count > max {
 				max = count
 			}


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
As `totalCountByStore` calling the function `getDistributionByGroupLocked`, this function should be procteded by rw mutex otherwise it will cause data race panic

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
Add mutex to protect it.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix pd may get panic during scattering region
```
