### PR TITLE
region_syncer: fix blocking bugs through ctx

### DIFF
--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -134,9 +134,9 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 				log.Error("cannot establish connection with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), errs.ZapError(err))
 				continue
 			}
+			defer conn.Close()
 			break
 		}
-		defer conn.Close()
 
 		// Start syncing data.
 		for {

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -273,7 +273,9 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 func (s *RegionSyncer) bindStream(name string, stream ServerStream) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.mu.streams[name] = stream
+	if s.mu.clientCtx != nil {
+		s.mu.streams[name] = stream
+	}
 }
 
 func (s *RegionSyncer) broadcast(regions *pdpb.SyncRegionResponse) {

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -115,8 +115,8 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 			return
 		case first := <-regionNotifier:
 			requests = append(requests, first.GetMeta())
-			stats = append(stats, first.GetStat())
-			leaders = append(leaders, first.GetLeader())
+			stats := append(stats, first.GetStat())
+			leaders := append(leaders, first.GetLeader())
 			startIndex := s.history.GetNextIndex()
 			s.history.Record(first)
 			pending := len(regionNotifier)
@@ -143,8 +143,6 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 			s.broadcast(alive)
 		}
 		requests = requests[:0]
-		stats = stats[:0]
-		leaders = leaders[:0]
 	}
 }
 
@@ -233,7 +231,6 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 				lastIndex += len(metas)
 				if err := stream.Send(resp); err != nil {
 					log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
-					return err
 				}
 				metas = metas[:0]
 				stats = stats[:0]

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -69,10 +69,9 @@ type Server interface {
 type RegionSyncer struct {
 	mu struct {
 		sync.RWMutex
-		streams            map[string]ServerStream
-		regionSyncerCtx    context.Context
-		regionSyncerCancel context.CancelFunc
-		closed             chan struct{}
+		streams      map[string]ServerStream
+		clientCtx    context.Context
+		clientCancel context.CancelFunc
 	}
 	server    Server
 	wg        sync.WaitGroup
@@ -94,7 +93,6 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 		tlsConfig: s.GetTLSConfig(),
 	}
 	syncer.mu.streams = make(map[string]ServerStream)
-	syncer.mu.closed = make(chan struct{})
 	return syncer
 }
 

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -100,14 +100,14 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 
 // RunServer runs the server of the region syncer.
 // regionNotifier is used to get the changed regions.
-func (s *RegionSyncer) RunServer(regionNotifier <-chan *core.RegionInfo, quit chan struct{}) {
+func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *core.RegionInfo) {
 	var requests []*metapb.Region
 	var stats []*pdpb.RegionStat
 	var leaders []*metapb.Peer
 	ticker := time.NewTicker(syncerKeepAliveInterval)
 	for {
 		select {
-		case <-quit:
+		case <-ctx.Done():
 			log.Info("region syncer has been stopped")
 			return
 		case first := <-regionNotifier:

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -345,17 +345,17 @@ const (
 )
 
 // Run starts the background job.
-func (m *ModeManager) Run(quit chan struct{}) {
+func (m *ModeManager) Run(ctx context.Context) {
 	// Wait for a while when just start, in case tikv do not connect in time.
 	select {
 	case <-time.After(idleTimeout):
-	case <-quit:
+	case <-ctx.Done():
 		return
 	}
 	for {
 		select {
 		case <-time.After(tickInterval):
-		case <-quit:
+		case <-ctx.Done():
 			return
 		}
 		m.tickDR()

--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -27,7 +27,6 @@ const queueCap = 20000
 // HotCache is a cache hold hot regions.
 type HotCache struct {
 	ctx            context.Context
-	quit           <-chan struct{}
 	readFlowQueue  chan FlowItemTask
 	writeFlowQueue chan FlowItemTask
 	writeFlow      *hotPeerCache
@@ -35,10 +34,9 @@ type HotCache struct {
 }
 
 // NewHotCache creates a new hot spot cache.
-func NewHotCache(ctx context.Context, quit <-chan struct{}) *HotCache {
+func NewHotCache(ctx context.Context) *HotCache {
 	w := &HotCache{
 		ctx:            ctx,
-		quit:           quit,
 		readFlowQueue:  make(chan FlowItemTask, queueCap),
 		writeFlowQueue: make(chan FlowItemTask, queueCap),
 		writeFlow:      NewHotStoresStats(WriteFlow),
@@ -101,14 +99,14 @@ func (w *HotCache) RegionStats(kind FlowKind, minHotDegree int) map[uint64][]*Ho
 		if !succ {
 			return nil
 		}
-		return task.waitRet(w.ctx, w.quit)
+		return task.waitRet(w.ctx)
 	case ReadFlow:
 		task := newCollectRegionStatsTask(minHotDegree)
 		succ := w.CheckReadAsync(task)
 		if !succ {
 			return nil
 		}
-		return task.waitRet(w.ctx, w.quit)
+		return task.waitRet(w.ctx)
 	}
 	return nil
 }
@@ -128,7 +126,7 @@ func (w *HotCache) IsRegionHot(region *core.RegionInfo, minHotDegree int) bool {
 	succ1 := w.CheckWriteAsync(writeIsRegionHotTask)
 	succ2 := w.CheckReadAsync(readIsRegionHotTask)
 	if succ1 && succ2 {
-		return writeIsRegionHotTask.waitRet(w.ctx, w.quit) || readIsRegionHotTask.waitRet(w.ctx, w.quit)
+		return writeIsRegionHotTask.waitRet(w.ctx) || readIsRegionHotTask.waitRet(w.ctx)
 	}
 	return false
 }
@@ -183,8 +181,6 @@ func (w *HotCache) updateItems(queue <-chan FlowItemTask, runTask func(task Flow
 	for {
 		select {
 		case <-w.ctx.Done():
-			return
-		case <-w.quit:
 			return
 		case task := <-queue:
 			runTask(task)

--- a/server/statistics/hot_cache_task.go
+++ b/server/statistics/hot_cache_task.go
@@ -129,11 +129,9 @@ func (t *collectRegionStatsTask) runTask(flow *hotPeerCache) {
 }
 
 // TODO: do we need a wait-return timeout?
-func (t *collectRegionStatsTask) waitRet(ctx context.Context, quit <-chan struct{}) map[uint64][]*HotPeerStat {
+func (t *collectRegionStatsTask) waitRet(ctx context.Context) map[uint64][]*HotPeerStat {
 	select {
 	case <-ctx.Done():
-		return nil
-	case <-quit:
 		return nil
 	case ret := <-t.ret:
 		return ret
@@ -163,11 +161,9 @@ func (t *isRegionHotTask) runTask(flow *hotPeerCache) {
 }
 
 // TODO: do we need a wait-return timeout?
-func (t *isRegionHotTask) waitRet(ctx context.Context, quit <-chan struct{}) bool {
+func (t *isRegionHotTask) waitRet(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():
-		return false
-	case <-quit:
 		return false
 	case r := <-t.ret:
 		return r

--- a/server/statistics/hotstat.go
+++ b/server/statistics/hotstat.go
@@ -24,9 +24,9 @@ type HotStat struct {
 }
 
 // NewHotStat creates the container to hold cluster's hotspot statistics.
-func NewHotStat(ctx context.Context, quit <-chan struct{}) *HotStat {
+func NewHotStat(ctx context.Context) *HotStat {
 	return &HotStat{
-		HotCache:    NewHotCache(ctx, quit),
+		HotCache:    NewHotCache(ctx),
 		StoresStats: NewStoresStats(),
 	}
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

ref #3697 

The region_syncer server sometimes takes 10 minutes to exit. The following possibilities were discovered:

* When the code is executed in the following order, the `ctx` corresponding to `Mark 3` will not be canceled normally. Therefore, the client cannot immediately disconnect from the server.
  * Mark 1: `StartSyncWithLeader`
  * Mark 2: `StopSyncWithLeader`
  * Mark 3: `establish` success
* The client has just established a connection with the server, and `syncHistoryRegion` is in progress. This step currently needs to send all data to end and cannot be aborted.

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the bug that region_syncer blocks leader changes.
```
