### PR TITLE
pd-ctl: try to fix interactive mode

### DIFF
--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -135,6 +135,24 @@ func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoComplet
 	}
 	defer l.Close()
 
+	getREPLCmd := func() *cobra.Command {
+		rootCmd := GetRootCmd()
+		persistentFlags.VisitAll(func(flag *pflag.Flag) {
+			if flag.Changed {
+				rootCmd.PersistentFlags().Set(flag.Name, flag.Value.String())
+			}
+		})
+		rootCmd.LocalFlags().MarkHidden("pd")
+		rootCmd.LocalFlags().MarkHidden("cacert")
+		rootCmd.LocalFlags().MarkHidden("cert")
+		rootCmd.LocalFlags().MarkHidden("key")
+		rootCmd.LocalFlags().MarkHidden("detach")
+		rootCmd.LocalFlags().MarkHidden("interact")
+		rootCmd.LocalFlags().MarkHidden("version")
+		rootCmd.SetOutput(os.Stdout)
+		return rootCmd
+	}
+
 	for {
 		line, err := l.Readline()
 		if err != nil {
@@ -154,15 +172,9 @@ func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoComplet
 			continue
 		}
 
-		rootCmd := GetRootCmd()
-		persistentFlags.VisitAll(func(flag *pflag.Flag) {
-			if flag.Changed {
-				rootCmd.PersistentFlags().Set(flag.Name, flag.Value.String())
-			}
-		})
+		rootCmd := getREPLCmd()
 		rootCmd.SetArgs(args)
 		rootCmd.ParseFlags(args)
-		rootCmd.SetOutput(os.Stdout)
 		if err := rootCmd.Execute(); err != nil {
 			rootCmd.Println(err)
 			os.Exit(1)

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -146,9 +146,6 @@ func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoComplet
 		rootCmd.LocalFlags().MarkHidden("cacert")
 		rootCmd.LocalFlags().MarkHidden("cert")
 		rootCmd.LocalFlags().MarkHidden("key")
-		rootCmd.LocalFlags().MarkHidden("detach")
-		rootCmd.LocalFlags().MarkHidden("interact")
-		rootCmd.LocalFlags().MarkHidden("version")
 		rootCmd.SetOutput(os.Stdout)
 		return rootCmd
 	}

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -177,7 +177,6 @@ func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoComplet
 		rootCmd.ParseFlags(args)
 		if err := rootCmd.Execute(); err != nil {
 			rootCmd.Println(err)
-			os.Exit(1)
 		}
 	}
 }

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -100,7 +100,7 @@ func MainStart(args []string) {
 	// TODO: deprecated
 	rootCmd.Flags().BoolP("detach", "d", true, "Run pdctl without readline.")
 
-	rootCmd.Run = func(cmd *cobra.Command, localArgs []string) {
+	rootCmd.Run = func(cmd *cobra.Command, args []string) {
 		if v, err := cmd.Flags().GetBool("version"); err == nil && v {
 			server.PrintPDInfo()
 			return


### PR DESCRIPTION
### What problem does this PR solve?

Seems cobra command does not support interactive mode, that is we need to init a new command every new line in the REPL. 

### What is changed and how it works?

1. `readlineCompleter` global variables are removed, it is now inlined and created-as-need.
2. `PersistentFlags` from the root command will be inherited in the REPL, pd address for example.
3. Start a new command every new evaluation round.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```
pd-ctl -i -u http://127.0.0.1:34/
store --help
store
```

Interactive should print normally, and show connection refused on port 34.

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix broken interactive pd-ctl mode
```
