### PR TITLE
server: revert #3756, recover #3313, fix panic

### DIFF
--- a/server/api/component.go
+++ b/server/api/component.go
@@ -47,7 +47,7 @@ func newComponentHandler(svr *server.Server, rd *render.Render) *componentHandle
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /component [post]
 func (h *componentHandler) Register(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	input := make(map[string]string)
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -76,7 +76,7 @@ func (h *componentHandler) Register(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /component [delete]
 func (h *componentHandler) UnRegister(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	vars := mux.Vars(r)
 	component := vars["component"]
 	addr := vars["addr"]
@@ -93,7 +93,7 @@ func (h *componentHandler) UnRegister(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} Addresses
 // @Router /component [get]
 func (h *componentHandler) GetAllAddress(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	addrs := rc.GetComponentManager().GetAllComponentAddrs()
 	h.rd.JSON(w, http.StatusOK, addrs)
 }
@@ -105,7 +105,7 @@ func (h *componentHandler) GetAllAddress(w http.ResponseWriter, r *http.Request)
 // @Failure 404 {string} string "The component does not exist."
 // @Router /component/{type} [get]
 func (h *componentHandler) GetAddress(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	vars := mux.Vars(r)
 	component := vars["type"]
 	addrs := rc.GetComponentManager().GetComponentAddrs(component)

--- a/server/api/label.go
+++ b/server/api/label.go
@@ -42,7 +42,7 @@ func newLabelsHandler(svr *server.Server, rd *render.Render) *labelsHandler {
 // @Success 200 {array} metapb.StoreLabel
 // @Router /labels [get]
 func (h *labelsHandler) Get(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	var labels []*metapb.StoreLabel
 	m := make(map[string]struct{})
 	stores := rc.GetStores()
@@ -67,7 +67,7 @@ func (h *labelsHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /labels/stores [get]
 func (h *labelsHandler) GetStores(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	name := r.URL.Query().Get("name")
 	value := r.URL.Query().Get("value")
 	filter, err := newStoresLabelFilter(name, value)

--- a/server/api/middleware.go
+++ b/server/api/middleware.go
@@ -36,7 +36,7 @@ func newClusterMiddleware(s *server.Server) clusterMiddleware {
 func (m clusterMiddleware) Middleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc := m.s.GetRaftCluster()
-		if rc == nil || !rc.IsRunning() {
+		if rc == nil {
 			m.rd.JSON(w, http.StatusInternalServerError, errs.ErrNotBootstrapped.FastGenByArgs().Error())
 			return
 		}

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -201,7 +201,7 @@ func newRegionHandler(svr *server.Server, rd *render.Render) *regionHandler {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /region/id/{id} [get]
 func (h *regionHandler) GetRegionByID(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 
 	vars := mux.Vars(r)
 	regionIDStr := vars["id"]
@@ -222,7 +222,7 @@ func (h *regionHandler) GetRegionByID(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} RegionInfo
 // @Router /region/key/{key} [get]
 func (h *regionHandler) GetRegionByKey(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	vars := mux.Vars(r)
 	key := vars["key"]
 	key, err := url.QueryUnescape(key)
@@ -263,7 +263,7 @@ func convertToAPIRegions(regions []*core.RegionInfo) *RegionsInfo {
 // @Success 200 {object} RegionsInfo
 // @Router /regions [get]
 func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	regions := rc.GetRegions()
 	regionsInfo := convertToAPIRegions(regions)
 	h.rd.JSON(w, http.StatusOK, regionsInfo)
@@ -278,7 +278,7 @@ func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/key [get]
 func (h *regionsHandler) ScanRegions(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	startKey := r.URL.Query().Get("key")
 
 	limit := defaultRegionLimit
@@ -304,7 +304,7 @@ func (h *regionsHandler) ScanRegions(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} RegionsInfo
 // @Router /regions/count [get]
 func (h *regionsHandler) GetRegionCount(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	count := rc.GetRegionCount()
 	h.rd.JSON(w, http.StatusOK, &RegionsInfo{Count: count})
 }
@@ -317,7 +317,7 @@ func (h *regionsHandler) GetRegionCount(w http.ResponseWriter, r *http.Request) 
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/store/{id} [get]
 func (h *regionsHandler) GetStoreRegions(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 
 	vars := mux.Vars(r)
 	id, err := strconv.Atoi(vars["id"])
@@ -483,7 +483,7 @@ func (h *regionsHandler) GetSizeHistogram(w http.ResponseWriter, r *http.Request
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	regions := rc.GetRegions()
 	histSizes := make([]int64, 0, len(regions))
 	for _, region := range regions {
@@ -507,7 +507,7 @@ func (h *regionsHandler) GetKeysHistogram(w http.ResponseWriter, r *http.Request
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	regions := rc.GetRegions()
 	histKeys := make([]int64, 0, len(regions))
 	for _, region := range regions {
@@ -561,7 +561,7 @@ func calHist(bound int, list *[]int64) *[]*histItem {
 // @Failure 404 {string} string "The region does not exist."
 // @Router /regions/sibling/{id} [get]
 func (h *regionsHandler) GetRegionSiblings(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 
 	vars := mux.Vars(r)
 	id, err := strconv.Atoi(vars["id"])
@@ -658,7 +658,7 @@ func (h *regionsHandler) GetTopSize(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/accelerate-schedule [post]
 func (h *regionsHandler) AccelerateRegionsScheduleInRange(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -700,7 +700,7 @@ func (h *regionsHandler) AccelerateRegionsScheduleInRange(w http.ResponseWriter,
 }
 
 func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, less func(a, b *core.RegionInfo) bool) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	limit := defaultRegionLimit
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
 		var err error
@@ -727,7 +727,7 @@ func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, 
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/scatter [post]
 func (h *regionsHandler) ScatterRegions(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -803,7 +803,7 @@ func (h *regionsHandler) ScatterRegions(w http.ResponseWriter, r *http.Request) 
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/split [post]
 func (h *regionsHandler) SplitRegions(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return

--- a/server/api/replication_mode.go
+++ b/server/api/replication_mode.go
@@ -38,5 +38,5 @@ func newReplicationModeHandler(svr *server.Server, rd *render.Render) *replicati
 // @Success 200 {object} replication.HTTPReplicationStatus
 // @Router /replication_mode/status [get]
 func (h *replicationModeHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
-	h.rd.JSON(w, http.StatusOK, getCluster(r).GetReplicationMode().GetReplicationStatusHTTP())
+	h.rd.JSON(w, http.StatusOK, h.svr.GetRaftCluster().GetReplicationMode().GetReplicationStatusHTTP())
 }

--- a/server/api/rule.go
+++ b/server/api/rule.go
@@ -50,7 +50,7 @@ func newRulesHandler(svr *server.Server, rd *render.Render) *ruleHandler {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules [get]
 func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -69,7 +69,7 @@ func (h *ruleHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rules [get]
 func (h *ruleHandler) SetAll(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -104,7 +104,7 @@ func (h *ruleHandler) SetAll(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules/group/{group} [get]
 func (h *ruleHandler) GetAllByGroup(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -124,7 +124,7 @@ func (h *ruleHandler) GetAllByGroup(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules/region/{region} [get]
 func (h *ruleHandler) GetAllByRegion(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -153,7 +153,7 @@ func (h *ruleHandler) GetAllByRegion(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rules/key/{key} [get]
 func (h *ruleHandler) GetAllByKey(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -178,7 +178,7 @@ func (h *ruleHandler) GetAllByKey(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rule/{group}/{id} [get]
 func (h *ruleHandler) Get(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -203,7 +203,7 @@ func (h *ruleHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule [post]
 func (h *ruleHandler) Set(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -256,7 +256,7 @@ func (h *ruleHandler) syncReplicateConfigWithDefaultRule(rule *placement.Rule) e
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule/{group}/{id} [delete]
 func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -284,7 +284,7 @@ func (h *ruleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rules/batch [post]
 func (h *ruleHandler) Batch(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -314,7 +314,7 @@ func (h *ruleHandler) Batch(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rule_group/{id} [get]
 func (h *ruleHandler) GetGroupConfig(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -339,7 +339,7 @@ func (h *ruleHandler) GetGroupConfig(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule_group [post]
 func (h *ruleHandler) SetGroupConfig(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -367,7 +367,7 @@ func (h *ruleHandler) SetGroupConfig(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/rule_group/{id} [delete]
 func (h *ruleHandler) DeleteGroupConfig(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -391,7 +391,7 @@ func (h *ruleHandler) DeleteGroupConfig(w http.ResponseWriter, r *http.Request) 
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/rule_groups [get]
 func (h *ruleHandler) GetAllGroupConfigs(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -407,7 +407,7 @@ func (h *ruleHandler) GetAllGroupConfigs(w http.ResponseWriter, r *http.Request)
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/placement-rule [get]
 func (h *ruleHandler) GetAllGroupBundles(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -426,7 +426,7 @@ func (h *ruleHandler) GetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/placement-rule [post]
 func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -456,7 +456,7 @@ func (h *ruleHandler) SetAllGroupBundles(w http.ResponseWriter, r *http.Request)
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/placement-rule/{group} [get]
 func (h *ruleHandler) GetGroupBundle(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -475,7 +475,7 @@ func (h *ruleHandler) GetGroupBundle(w http.ResponseWriter, r *http.Request) {
 // @Failure 412 {string} string "Placement rules feature is disabled."
 // @Router /config/placement-rule [delete]
 func (h *ruleHandler) DeleteGroupBundle(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return
@@ -503,7 +503,7 @@ func (h *ruleHandler) DeleteGroupBundle(w http.ResponseWriter, r *http.Request) 
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/placement-rule/{group} [post]
 func (h *ruleHandler) SetGroupBundle(w http.ResponseWriter, r *http.Request) {
-	cluster := getCluster(r)
+	cluster := h.svr.GetRaftCluster()
 	if !cluster.GetOpts().IsPlacementRulesEnabled() {
 		h.rd.JSON(w, http.StatusPreconditionFailed, errPlacementDisabled.Error())
 		return

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -40,7 +40,7 @@ func newStatsHandler(svr *server.Server, rd *render.Render) *statsHandler {
 // @Success 200 {object} statistics.RegionStats
 // @Router /stats/region [get]
 func (h *statsHandler) Region(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc := h.svr.GetRaftCluster()
 	startKey, endKey := r.URL.Query().Get("start_key"), r.URL.Query().Get("end_key")
 	stats := rc.GetRegionStats([]byte(startKey), []byte(endKey))
 	h.rd.JSON(w, http.StatusOK, stats)

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -147,7 +147,7 @@ func newStoreHandler(handler *server.Handler, rd *render.Render) *storeHandler {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id} [get]
 func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc, _ := h.GetRaftCluster()
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -177,7 +177,7 @@ func (h *storeHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id} [delete]
 func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc, _ := h.GetRaftCluster()
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -207,7 +207,7 @@ func (h *storeHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/state [post]
 func (h *storeHandler) SetState(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc, _ := h.GetRaftCluster()
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -260,7 +260,7 @@ func (h *storeHandler) responseStoreErr(w http.ResponseWriter, err error, storeI
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/label [post]
 func (h *storeHandler) SetLabels(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc, _ := h.GetRaftCluster()
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -306,7 +306,7 @@ func (h *storeHandler) SetLabels(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/weight [post]
 func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc, _ := h.GetRaftCluster()
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -360,7 +360,7 @@ func (h *storeHandler) SetWeight(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /store/{id}/limit [post]
 func (h *storeHandler) SetLimit(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc, _ := h.GetRaftCluster()
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -440,7 +440,8 @@ func newStoresHandler(handler *server.Handler, rd *render.Render) *storesHandler
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /stores/remove-tombstone [delete]
 func (h *storesHandler) RemoveTombStone(w http.ResponseWriter, r *http.Request) {
-	err := getCluster(r).RemoveTombStoneRecords()
+	rc, _ := h.GetRaftCluster()
+	err := rc.RemoveTombStoneRecords()
 	if err != nil {
 		apiutil.ErrorResp(h.rd, w, err)
 		return
@@ -553,7 +554,7 @@ func (h *storesHandler) GetAllLimit(w http.ResponseWriter, r *http.Request) {
 	}
 	if !includeTombstone {
 		returned := make(map[uint64]config.StoreLimitConfig, len(limits))
-		rc := getCluster(r)
+		rc, _ := h.GetRaftCluster()
 		for storeID, v := range limits {
 			store := rc.GetStore(storeID)
 			if store == nil || store.IsTombstone() {
@@ -615,7 +616,7 @@ func (h *storesHandler) GetStoreLimitScene(w http.ResponseWriter, r *http.Reques
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /stores [get]
 func (h *storesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rc := getCluster(r)
+	rc, _ := h.GetRaftCluster()
 	stores := rc.GetMetaStores()
 	StoresInfo := &StoresInfo{
 		Stores: make([]*StoreInfo, 0, len(stores)),

--- a/server/server.go
+++ b/server/server.go
@@ -432,8 +432,6 @@ func (s *Server) Close() {
 
 	log.Info("closing server")
 
-	s.stopServerLoop()
-
 	if s.client != nil {
 		if err := s.client.Close(); err != nil {
 			log.Error("close etcd client meet error", errs.ZapError(errs.ErrCloseEtcdClient, err))
@@ -447,6 +445,8 @@ func (s *Server) Close() {
 	if s.member.Etcd() != nil {
 		s.member.Close()
 	}
+
+	s.stopServerLoop()
 
 	if s.hbStreams != nil {
 		s.hbStreams.Close()


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

### What problem does this PR solve?

It is known that my #3313 has raised some panics in CI. After some investigations, I think I found the cause. This PR reverted the changes back and fixed the potential race cases.

### What is changed and how it works?

**What is the problem**:

According to [CI log](https://ci.pingcap.net/blue/organizations/jenkins/br_ghpr_unit_and_integration_test/detail/br_ghpr_unit_and_integration_test/4494/pipeline/#step-301-log-213), it is clear that API requests have passed the middleware check. 

But it may be nil if server is about to close or is already stopped, [link](https://github.com/tikv/pd/blob/3a7f0d6dec16fc342b2f21349419e5d5f500d0dc/server/server.go#L1040-L1042). It is not ensured that server is not closed or stopping while serving RPC services.

Maybe it is running while executing middleware checks, but later it is stopped/closed when the real service is serving. But the real service assumes that it is non-nil, because middleware checks have passed.

In short, PD can serve RPC while closing servers. That is the root cause.

### Check List

Tests

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix panic if request PD RPC server fast enough
```
