### PR TITLE
cluster: calculate StoreWriteRate based on the stats of RegionHeartbeat

### DIFF
--- a/server/api/hot_status.go
+++ b/server/api/hot_status.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/statistics"
 	"github.com/unrolled/render"
 )
@@ -131,13 +132,23 @@ func (h *hotStatusHandler) GetHotStores(w http.ResponseWriter, r *http.Request) 
 		QueryWriteStats: make(map[uint64]float64),
 		QueryReadStats:  make(map[uint64]float64),
 	}
-	for id, loads := range h.GetStoresLoads() {
-		stats.BytesWriteStats[id] = loads[statistics.StoreWriteBytes]
-		stats.BytesReadStats[id] = loads[statistics.StoreReadBytes]
-		stats.KeysWriteStats[id] = loads[statistics.StoreWriteKeys]
-		stats.KeysReadStats[id] = loads[statistics.StoreReadKeys]
-		stats.QueryWriteStats[id] = loads[statistics.StoreWriteQuery]
-		stats.QueryReadStats[id] = loads[statistics.StoreReadQuery]
+	stores, _ := h.GetStores()
+	storesLoads := h.GetStoresLoads()
+	for _, store := range stores {
+		id := store.GetID()
+		if loads, ok := storesLoads[id]; ok {
+			if core.IsTiFlashStore(store.GetMeta()) {
+				stats.BytesWriteStats[id] = loads[statistics.StoreRegionsWriteBytes]
+				stats.KeysWriteStats[id] = loads[statistics.StoreRegionsWriteKeys]
+			} else {
+				stats.BytesWriteStats[id] = loads[statistics.StoreWriteBytes]
+				stats.KeysWriteStats[id] = loads[statistics.StoreWriteKeys]
+			}
+			stats.BytesReadStats[id] = loads[statistics.StoreReadBytes]
+			stats.KeysReadStats[id] = loads[statistics.StoreReadKeys]
+			stats.QueryWriteStats[id] = loads[statistics.StoreWriteQuery]
+			stats.QueryReadStats[id] = loads[statistics.StoreReadQuery]
+		}
 	}
 	h.rd.JSON(w, http.StatusOK, stats)
 }

--- a/server/core/basic_cluster.go
+++ b/server/core/basic_cluster.go
@@ -258,7 +258,7 @@ func (bc *BasicCluster) GetStoreLeaderRegionSize(storeID uint64) int64 {
 func (bc *BasicCluster) GetStoreRegionSize(storeID uint64) int64 {
 	bc.RLock()
 	defer bc.RUnlock()
-	return bc.Regions.GetStoreLeaderRegionSize(storeID) + bc.Regions.GetStoreFollowerRegionSize(storeID) + bc.Regions.GetStoreLearnerRegionSize(storeID)
+	return bc.Regions.GetStoreRegionSize(storeID)
 }
 
 // GetAverageRegionSize returns the average region approximate size.
@@ -266,6 +266,42 @@ func (bc *BasicCluster) GetAverageRegionSize() int64 {
 	bc.RLock()
 	defer bc.RUnlock()
 	return bc.Regions.GetAverageRegionSize()
+}
+
+// GetStoresLeaderWriteRate get total write rate of each store's leaders.
+func (bc *BasicCluster) GetStoresLeaderWriteRate() (storeIDs []uint64, bytesRates, keysRates []float64) {
+	bc.RLock()
+	defer bc.RUnlock()
+	count := len(bc.Stores.stores)
+	storeIDs = make([]uint64, 0, count)
+	bytesRates = make([]float64, 0, count)
+	keysRates = make([]float64, 0, count)
+	for _, store := range bc.Stores.stores {
+		id := store.GetID()
+		bytesRate, keysRate := bc.Regions.GetStoreLeaderWriteRate(id)
+		storeIDs = append(storeIDs, id)
+		bytesRates = append(bytesRates, bytesRate)
+		keysRates = append(keysRates, keysRate)
+	}
+	return
+}
+
+// GetStoresWriteRate get total write rate of each store's regions.
+func (bc *BasicCluster) GetStoresWriteRate() (storeIDs []uint64, bytesRates, keysRates []float64) {
+	bc.RLock()
+	defer bc.RUnlock()
+	count := len(bc.Stores.stores)
+	storeIDs = make([]uint64, 0, count)
+	bytesRates = make([]float64, 0, count)
+	keysRates = make([]float64, 0, count)
+	for _, store := range bc.Stores.stores {
+		id := store.GetID()
+		bytesRate, keysRate := bc.Regions.GetStoreWriteRate(id)
+		storeIDs = append(storeIDs, id)
+		bytesRates = append(bytesRates, bytesRate)
+		keysRates = append(keysRates, keysRate)
+	}
+	return
 }
 
 // PutStore put a store.

--- a/server/statistics/kind.go
+++ b/server/statistics/kind.go
@@ -61,6 +61,9 @@ const (
 	StoreDiskReadRate
 	StoreDiskWriteRate
 
+	StoreRegionsWriteBytes // Same as StoreWriteBytes, but it is counted by RegionHeartbeat.
+	StoreRegionsWriteKeys  // Same as StoreWriteKeys, but it is counted by RegionHeartbeat.
+
 	StoreStatCount
 )
 
@@ -84,6 +87,10 @@ func (k StoreStatKind) String() string {
 		return "store_disk_read_rate"
 	case StoreDiskWriteRate:
 		return "store_disk_write_rate"
+	case StoreRegionsWriteBytes:
+		return "store_regions_write_bytes"
+	case StoreRegionsWriteKeys:
+		return "store_regions_write_keys"
 	}
 
 	return "unknown StoreStatKind"

--- a/server/statistics/store_collection.go
+++ b/server/statistics/store_collection.go
@@ -120,6 +120,8 @@ func (s *storeStatistics) Observe(store *core.StoreInfo, stats *StoresStats) {
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_cpu_usage").Set(storeFlowStats.GetLoad(StoreCPUUsage))
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_disk_read_rate").Set(storeFlowStats.GetLoad(StoreDiskReadRate))
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_disk_write_rate").Set(storeFlowStats.GetLoad(StoreDiskWriteRate))
+	storeStatusGauge.WithLabelValues(storeAddress, id, "store_regions_write_rate_bytes").Set(storeFlowStats.GetLoad(StoreRegionsWriteBytes))
+	storeStatusGauge.WithLabelValues(storeAddress, id, "store_regions_write_rate_keys").Set(storeFlowStats.GetLoad(StoreRegionsWriteKeys))
 
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_write_rate_bytes_instant").Set(storeFlowStats.GetInstantLoad(StoreWriteBytes))
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_read_rate_bytes_instant").Set(storeFlowStats.GetInstantLoad(StoreReadBytes))
@@ -127,6 +129,8 @@ func (s *storeStatistics) Observe(store *core.StoreInfo, stats *StoresStats) {
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_read_rate_keys_instant").Set(storeFlowStats.GetInstantLoad(StoreReadKeys))
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_write_query_rate_instant").Set(storeFlowStats.GetInstantLoad(StoreWriteQuery))
 	storeStatusGauge.WithLabelValues(storeAddress, id, "store_read_query_rate_instant").Set(storeFlowStats.GetInstantLoad(StoreReadQuery))
+	storeStatusGauge.WithLabelValues(storeAddress, id, "store_regions_write_rate_bytes_instant").Set(storeFlowStats.GetInstantLoad(StoreRegionsWriteBytes))
+	storeStatusGauge.WithLabelValues(storeAddress, id, "store_regions_write_rate_keys_instant").Set(storeFlowStats.GetInstantLoad(StoreRegionsWriteKeys))
 }
 
 func (s *storeStatistics) Collect() {

--- a/server/statistics/util.go
+++ b/server/statistics/util.go
@@ -22,6 +22,12 @@ const (
 	StoreHeartBeatReportInterval = 10
 	// RegionHeartBeatReportInterval is the heartbeat report interval of a region.
 	RegionHeartBeatReportInterval = 60
+	// DefaultAotSize is default size of average over time.
+	DefaultAotSize = 2
+	// DefaultWriteMfSize is default size of write median filter.
+	DefaultWriteMfSize = 5
+	// DefaultReadMfSize is default size of read median filter.
+	DefaultReadMfSize = 3
 )
 
 func storeTag(id uint64) string {

--- a/tests/pdctl/hot/hot_test.go
+++ b/tests/pdctl/hot/hot_test.go
@@ -57,15 +57,22 @@ func (s *hotTestSuite) TestHot(c *C) {
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := pdctlCmd.GetRootCmd()
 
-	store := &metapb.Store{
+	store1 := &metapb.Store{
 		Id:            1,
 		State:         metapb.StoreState_Up,
 		LastHeartbeat: time.Now().UnixNano(),
 	}
+	store2 := &metapb.Store{
+		Id:            2,
+		State:         metapb.StoreState_Up,
+		LastHeartbeat: time.Now().UnixNano(),
+		Labels:        []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}},
+	}
 
 	leaderServer := cluster.GetServer(cluster.GetLeader())
 	c.Assert(leaderServer.BootstrapCluster(), IsNil)
-	pdctl.MustPutStore(c, leaderServer.GetServer(), store)
+	pdctl.MustPutStore(c, leaderServer.GetServer(), store1)
+	pdctl.MustPutStore(c, leaderServer.GetServer(), store2)
 	defer cluster.Destroy()
 
 	// test hot store
@@ -88,6 +95,10 @@ func (s *hotTestSuite) TestHot(c *C) {
 		rc.GetStoresStats().Observe(ss.GetID(), newStats)
 	}
 
+	for i := statistics.RegionsStatsRollingWindowsSize; i > 0; i-- {
+		rc.GetStoresStats().ObserveRegionsStats([]uint64{2}, []float64{float64(bytesWritten)}, []float64{float64(keysWritten)})
+	}
+
 	args := []string{"-u", pdAddr, "hot", "store"}
 	output, err := pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
@@ -97,6 +108,8 @@ func (s *hotTestSuite) TestHot(c *C) {
 	c.Assert(hotStores.BytesReadStats[1], Equals, float64(bytesRead)/statistics.StoreHeartBeatReportInterval)
 	c.Assert(hotStores.KeysWriteStats[1], Equals, float64(keysWritten)/statistics.StoreHeartBeatReportInterval)
 	c.Assert(hotStores.KeysReadStats[1], Equals, float64(keysRead)/statistics.StoreHeartBeatReportInterval)
+	c.Assert(hotStores.BytesWriteStats[2], Equals, float64(bytesWritten))
+	c.Assert(hotStores.KeysWriteStats[2], Equals, float64(keysWritten))
 
 	// test hot region
 	args = []string{"-u", pdAddr, "config", "set", "hot-region-cache-hits-threshold", "0"}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

related #3671 

### What is changed and how it works?

Count the `write-rate` in the `RegionTree`, and then observe it regularly in `StoreStats`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

- Possible performance regression

Related changes

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
