### PR TITLE
schedule: prevent merge operators occupying schedule limit

### DIFF
--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -373,13 +373,14 @@ func (s *testCoordinatorSuite) TestCheckerIsBusy(c *C) {
 				c.Assert(co.opController.AddWaitingOperator(op), Equals, 1)
 			case operator.OpRegion | operator.OpMerge:
 				if regionID%2 == 1 {
-					ops, err := operator.CreateMergeRegionOperator("merge-region", co.cluster, tc.GetRegion(regionID), tc.GetRegion(regionID-1), operator.OpMerge)
+					ops, err := operator.CreateMergeRegionOperator("merge-region", co.cluster, tc.GetRegion(regionID), tc.GetRegion(regionID-1), 0)
 					c.Assert(err, IsNil)
 					c.Assert(co.opController.AddWaitingOperator(ops...), Equals, len(ops))
 				}
 			}
 		}
 	}
+	c.Assert(co.opController.OperatorCount(operator.OpMerge), Equals, uint64(5))
 	s.checkRegion(c, tc, co, num, 0)
 }
 

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -153,7 +153,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 	log.Debug("try to merge region",
 		logutil.ZapRedactStringer("from", core.RegionToHexMeta(region.GetMeta())),
 		logutil.ZapRedactStringer("to", core.RegionToHexMeta(target.GetMeta())))
-	ops, err := operator.CreateMergeRegionOperator("merge-region", m.cluster, region, target, operator.OpMerge)
+	ops, err := operator.CreateMergeRegionOperator("merge-region", m.cluster, region, target, 0)
 	if err != nil {
 		log.Warn("create merge region operator failed", errs.ZapError(err))
 		return nil

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -170,7 +170,7 @@ func CreateMergeRegionOperator(desc string, cluster opt.Cluster, source *core.Re
 
 	brief := fmt.Sprintf("merge: region %v to %v", source.GetID(), target.GetID())
 	op1 := NewOperator(desc, brief, source.GetID(), source.GetRegionEpoch(), kind|OpMerge, steps...)
-	op2 := NewOperator(desc, brief, target.GetID(), target.GetRegionEpoch(), kind&OpAdmin|OpPlaceholder, MergeRegion{
+	op2 := NewOperator(desc, brief, target.GetID(), target.GetRegionEpoch(), kind|OpPlaceholder, MergeRegion{
 		FromRegion: source.GetMeta(),
 		ToRegion:   target.GetMeta(),
 		IsPassive:  true,

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -170,12 +170,13 @@ func CreateMergeRegionOperator(desc string, cluster opt.Cluster, source *core.Re
 
 	brief := fmt.Sprintf("merge: region %v to %v", source.GetID(), target.GetID())
 	op1 := NewOperator(desc, brief, source.GetID(), source.GetRegionEpoch(), kind|OpMerge, steps...)
-	op2 := NewOperator(desc, brief, target.GetID(), target.GetRegionEpoch(), kind|OpMerge, MergeRegion{
+	op2 := NewOperator(desc, brief, target.GetID(), target.GetRegionEpoch(), kind&OpAdmin|OpPlaceholder, MergeRegion{
 		FromRegion: source.GetMeta(),
 		ToRegion:   target.GetMeta(),
 		IsPassive:  true,
 	})
 
+	// The sequence of operator is important, should be [src, target].
 	return []*Operator{op1, op2}, nil
 }
 

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -162,7 +162,8 @@ func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
 	type testCase struct {
 		sourcePeers   []*metapb.Peer // first is leader
 		targetPeers   []*metapb.Peer // first is leader
-		kind          OpKind
+		sourceKind    OpKind
+		targetkind    OpKind
 		expectedError bool
 		prepareSteps  []OpStep
 	}
@@ -177,6 +178,7 @@ func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
 				{Id: 4, StoreId: 2, Role: metapb.PeerRole_Voter},
 			},
 			OpMerge,
+			OpPlaceholder,
 			false,
 			[]OpStep{},
 		},
@@ -190,6 +192,7 @@ func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
 				{Id: 3, StoreId: 3, Role: metapb.PeerRole_Voter},
 			},
 			OpMerge | OpLeader | OpRegion,
+			OpPlaceholder,
 			false,
 			[]OpStep{
 				AddLearner{ToStore: 3},
@@ -215,6 +218,7 @@ func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
 				{Id: 4, StoreId: 2, Role: metapb.PeerRole_Voter},
 			},
 			0,
+			0,
 			true,
 			nil,
 		},
@@ -227,6 +231,7 @@ func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
 				{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter},
 				{Id: 4, StoreId: 2, Role: metapb.PeerRole_IncomingVoter},
 			},
+			0,
 			0,
 			true,
 			nil,
@@ -243,9 +248,9 @@ func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
 		}
 		c.Assert(err, IsNil)
 		c.Assert(ops, HasLen, 2)
-		c.Assert(ops[0].kind, Equals, tc.kind)
+		c.Assert(ops[0].kind, Equals, tc.sourceKind)
 		c.Assert(ops[0].Len(), Equals, len(tc.prepareSteps)+1)
-		c.Assert(ops[1].kind, Equals, tc.kind)
+		c.Assert(ops[1].kind, Equals, tc.targetkind)
 		c.Assert(ops[1].Len(), Equals, 1)
 		c.Assert(ops[1].Step(0).(MergeRegion), DeepEquals, MergeRegion{source.GetMeta(), target.GetMeta(), true})
 

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -192,7 +192,7 @@ func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
 				{Id: 3, StoreId: 3, Role: metapb.PeerRole_Voter},
 			},
 			OpMerge | OpLeader | OpRegion,
-			OpPlaceholder,
+			OpPlaceholder | OpLeader | OpRegion,
 			false,
 			[]OpStep{
 				AddLearner{ToStore: 3},

--- a/server/schedule/operator/kind.go
+++ b/server/schedule/operator/kind.go
@@ -27,6 +27,9 @@ type OpKind uint32
 const (
 	// Initiated by admin.
 	OpAdmin OpKind = 1 << iota
+	// Only one of merge operators takes effect, the other one is used as a placeholder.
+	// This operator is no meaning for limit.
+	OpPlaceholder
 	// Initiated by merge checker or merge scheduler. Note that it may not include region merge.
 	// the order describe the operator's producer and is very helpful to decouple scheduler or checker limit
 	OpMerge
@@ -46,25 +49,27 @@ const (
 )
 
 var flagToName = map[OpKind]string{
-	OpLeader:    "leader",
-	OpRegion:    "region",
-	OpSplit:     "split",
-	OpAdmin:     "admin",
-	OpHotRegion: "hot-region",
-	OpReplica:   "replica",
-	OpMerge:     "merge",
-	OpRange:     "range",
+	OpLeader:      "leader",
+	OpRegion:      "region",
+	OpSplit:       "split",
+	OpAdmin:       "admin",
+	OpHotRegion:   "hot-region",
+	OpReplica:     "replica",
+	OpMerge:       "merge",
+	OpRange:       "range",
+	OpPlaceholder: "placeholder",
 }
 
 var nameToFlag = map[string]OpKind{
-	"leader":     OpLeader,
-	"region":     OpRegion,
-	"split":      OpSplit,
-	"admin":      OpAdmin,
-	"hot-region": OpHotRegion,
-	"replica":    OpReplica,
-	"merge":      OpMerge,
-	"range":      OpRange,
+	"leader":      OpLeader,
+	"region":      OpRegion,
+	"split":       OpSplit,
+	"admin":       OpAdmin,
+	"hot-region":  OpHotRegion,
+	"replica":     OpReplica,
+	"merge":       OpMerge,
+	"range":       OpRange,
+	"placeholder": OpPlaceholder,
 }
 
 func (k OpKind) String() string {

--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -126,9 +126,9 @@ func (o *Operator) Kind() OpKind {
 	return o.kind
 }
 
-// SchedulerKind return the highest OpKind even if the operator has many OpKind
-// fix #3778
-func (o *Operator) SchedulerKind() OpKind {
+// ScheduleKind return the highest OpKind even if the operator has many OpKind
+// fix https://github.com/tikv/pd/issues/3778
+func (o *Operator) ScheduleKind() OpKind {
 	// LowBit ref: https://en.wikipedia.org/wiki/Find_first_set
 	// 6(110) ==> 2(10)
 	// 5(101) ==> 1(01)

--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -394,8 +394,14 @@ func (s *testOperatorSuite) TestSchedulerKind(c *C) {
 			op:     s.newTestOperator(1, OpAdmin|OpMerge|OpRegion),
 			expect: OpAdmin,
 		}, {
+			op:     s.newTestOperator(1, OpAdmin|OpPlaceholder|OpRegion),
+			expect: OpAdmin,
+		}, {
 			op:     s.newTestOperator(1, OpMerge|OpLeader|OpRegion),
 			expect: OpMerge,
+		}, {
+			op:     s.newTestOperator(1, OpPlaceholder|OpRegion),
+			expect: OpPlaceholder,
 		}, {
 			op:     s.newTestOperator(1, OpReplica|OpRegion),
 			expect: OpReplica,
@@ -417,6 +423,6 @@ func (s *testOperatorSuite) TestSchedulerKind(c *C) {
 		},
 	}
 	for _, v := range testdata {
-		c.Assert(v.op.SchedulerKind(), Equals, v.expect)
+		c.Assert(v.op.ScheduleKind(), Equals, v.expect)
 	}
 }

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -545,6 +545,12 @@ func (oc *OperatorController) buryOperator(op *operator.Operator, extraFields ..
 		_ = op.Cancel()
 	}
 
+	// Do nothing for placeholder, it's only used by merge.
+	if op.Kind()&operator.OpPlaceholder == 1 {
+		oc.opRecords.Put(op)
+		return
+	}
+
 	switch st {
 	case operator.SUCCESS:
 		log.Info("operator finish",
@@ -768,7 +774,7 @@ func (oc *OperatorController) updateCounts(operators map[uint64]*operator.Operat
 		delete(oc.counts, k)
 	}
 	for _, op := range operators {
-		oc.counts[op.SchedulerKind()]++
+		oc.counts[op.ScheduleKind()]++
 	}
 }
 

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -717,7 +717,7 @@ func (t *testOperatorControllerSuite) TestAddWaitingOperator(c *C) {
 	target := newRegionInfo(0, "0a", "0b", 1, 1, []uint64{101, 1}, []uint64{101, 1})
 	// now there is one operator being allowed to add, if it is a merge operator
 	// both of the pair are allowed
-	ops, err := operator.CreateMergeRegionOperator("merge-region", cluster, source, target, operator.OpMerge)
+	ops, err := operator.CreateMergeRegionOperator("merge-region", cluster, source, target, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ops, HasLen, 2)
 	c.Assert(controller.AddWaitingOperator(ops...), Equals, 2)

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -814,7 +814,7 @@ func (s *testBalanceRegionSchedulerSuite) TestBalance1(c *C) {
 	tc.AddLeaderRegion(2, 1, 2, 3)
 
 	// add two merge operator to let the count of opRegion to 2.
-	ops, err := operator.CreateMergeRegionOperator("merge-region", tc, source, target, operator.OpMerge)
+	ops, err := operator.CreateMergeRegionOperator("merge-region", tc, source, target, 0)
 	c.Assert(err, IsNil)
 	oc.SetOperator(ops[0])
 	oc.SetOperator(ops[1])


### PR DESCRIPTION
### What problem does this PR solve?

Another improvement for #3807.

### What is changed and how it works?

This PR introduces a new operator kind named `OpPlaceholder`, which will not waste the merge schedule limit.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
