### PR TITLE
Update TiDB Dashboard to $GITHUB_REF1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/aws/aws-sdk-go v1.35.3
 	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,6 @@ github.com/VividCortex/mysqlerr v0.0.0-20200629151747-c28746d985dd/go.mod h1:f3H
 github.com/Xeoncross/go-aesctr-with-hmac v0.0.0-20200623134604-12b17a7ff502 h1:L8IbaI/W6h5Cwgh0n4zGeZpVK78r/jBf9ASurHo9+/o=
 github.com/Xeoncross/go-aesctr-with-hmac v0.0.0-20200623134604-12b17a7ff502/go.mod h1:pmnBM9bxWSiHvC/gSWunUIyDvGn33EkP2CUjxFKtTTM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alvaroloes/enumer v1.1.2/go.mod h1:FxrjvuXoDAx9isTJrv4c+T410zFi0DtXIT0m65DJ+Wo=

--- a/workflow/1
+++ b/workflow/1
@@ -1,0 +1,3 @@
+ACTOR=nektos/act
+git config user.name "$ACTOR"
+git config user.email "$ACTOR@pingcap.com"

--- a/workflow/update_dashboard
+++ b/workflow/update_dashboard
@@ -1,0 +1,10 @@
+go get -d "github.com/pingcap/tidb-dashboard@$GITHUB_REF1"
+go mod tidy
+git add go.mod go.sum
+if git status | grep -q "Changes to be committed"
+then
+  git commit --message "Update from https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA, release version: $GITHUB_REF1"
+  echo "::set-output name=committed::1"
+else
+  echo "No changes detected"
+fi


### PR DESCRIPTION
Update TiDB dashboard from https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA, release version is $GITHUB_REF1