### PR TITLE
Add unsafe-recover commands

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -131,6 +131,11 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	clusterRouter.HandleFunc("/stores/limit", storesHandler.SetAllLimit).Methods("POST")
 	clusterRouter.HandleFunc("/stores/limit/scene", storesHandler.SetStoreLimitScene).Methods("POST")
 	clusterRouter.HandleFunc("/stores/limit/scene", storesHandler.GetStoreLimitScene).Methods("GET")
+	clusterRouter.HandleFunc("/stores/unsafe-recover",
+		storesHandler.UnsafeRecover).Methods("POST")
+	clusterRouter.HandleFunc("/stores/unsafe-recover/show", storesHandler.GetUnsafeRecoverStatus).Methods("GET")
+	clusterRouter.HandleFunc("/stores/unsafe-recover/history",
+		storesHandler.GetUnsafeRecoverHistory).Methods("GET")
 
 	labelsHandler := newLabelsHandler(svr, rd)
 	clusterRouter.HandleFunc("/labels", labelsHandler.Get).Methods("GET")

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -608,6 +608,33 @@ func (h *storesHandler) GetStoreLimitScene(w http.ResponseWriter, r *http.Reques
 }
 
 // @Tags store
+// @Summary Recover failed stores unsafely.
+// @Produce json
+// @Router /stores/unsafe-recover [POST]
+func (h *storesHandler) UnsafeRecover(w http.ResponseWriter, r *http.Request) {
+	h.rd.JSON(w, http.StatusBadRequest, "Unimplemented")
+	return
+}
+
+// @Tags store
+// @Summary Recover failed stores unsafely.
+// @Produce json
+// @Router /stores/unsafe-recover [POST]
+func (h *storesHandler) GetUnsafeRecoverStatus(w http.ResponseWriter, r *http.Request) {
+	h.rd.JSON(w, http.StatusBadRequest, "Unimplemented")
+	return
+}
+
+// @Tags store
+// @Summary Recover failed stores unsafely.
+// @Produce json
+// @Router /stores/unsafe-recover [POST]
+func (h *storesHandler) GetUnsafeRecoverHistory(w http.ResponseWriter, r *http.Request) {
+	h.rd.JSON(w, http.StatusBadRequest, "Unimplemented")
+	return
+}
+
+// @Tags store
 // @Summary Get stores in the cluster.
 // @Param state query array true "Specify accepted store states."
 // @Produce json

--- a/tests/pdctl/store/store_test.go
+++ b/tests/pdctl/store/store_test.go
@@ -344,4 +344,18 @@ func (s *storeTestSuite) TestStore(c *C) {
 	err = json.Unmarshal(output, scene)
 	c.Assert(err, IsNil)
 	c.Assert(scene.Idle, Equals, 100)
+
+	// store unsafe-recover
+	args = []string{"-u", pdAddr, "store", "unsafe-recover", "s1,s2,s3"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Unimplemented"), IsTrue)
+	args = []string{"-u", pdAddr, "store", "unsafe-recover", "show"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Unimplemented"), IsTrue)
+	args = []string{"-u", pdAddr, "store", "unsafe-recover", "history"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), "Unimplemented"), IsTrue)
 }

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -45,6 +45,7 @@ func NewStoreCommand() *cobra.Command {
 	s.AddCommand(NewRemoveTombStoneCommand())
 	s.AddCommand(NewStoreLimitSceneCommand())
 	s.AddCommand(NewStoreCheckCommand())
+	s.AddCommand(NewUnsafeRecoverCommand())
 	s.Flags().String("jq", "", "jq query")
 	s.Flags().StringSlice("state", nil, "state filter")
 	return s
@@ -199,6 +200,73 @@ func NewStoreLimitSceneCommand() *cobra.Command {
 		Long:  "show or set the limit value for a scene, <type> can be 'add-peer'(default) or 'remove-peer'",
 		Run:   storeLimitSceneCommandFunc,
 	}
+}
+
+// Returns the unsafe recover command for the store command.
+func NewUnsafeRecoverCommand() *cobra.Command {
+	sc := &cobra.Command{
+		Use:   "unsafe-recover [<type>]",
+		Short: "Recover failed stores unsafely",
+		Long:  "Recover failed stores unsafely, <type> can be a list of store e.g. '<s1,s2,...>' or 'show' or 'history'",
+		Run:   unsafeRecoverCommandFunc,
+	}
+	sc.AddCommand(NewUnsafeRecoverShowCommand())
+	sc.AddCommand(NewUnsafeRecoverHistoryCommand())
+	return sc
+}
+
+// Returns the unsafe-recover show command for the unsafe-recover command.
+func NewUnsafeRecoverShowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show the status of ongoing unsafe recoveries",
+		Run:   unsafeRecoverShowCommandFunc,
+	}
+}
+
+// Returns the unsafe-recover history command for the unsafe-recover command.
+func NewUnsafeRecoverHistoryCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "history",
+		Short: "Show the history log",
+		Run:   unsafeRecoverHistoryCommandFunc,
+	}
+}
+
+func unsafeRecoverCommandFunc(cmd *cobra.Command, args []string) {
+    var resp string
+    var err error
+    prefix := fmt.Sprintf("%s/unsafe-recover", storesPrefix)
+    resp, err = doRequest(cmd, prefix, http.MethodPost)
+    if err != nil {
+	cmd.Println(err)
+	return
+    }
+    cmd.Println(resp)
+}
+
+func unsafeRecoverShowCommandFunc(cmd *cobra.Command, args []string) {
+    var resp string
+    var err error
+    prefix := fmt.Sprintf("%s/unsafe-recover/show", storesPrefix)
+    resp, err = doRequest(cmd, prefix, http.MethodGet)
+    if err != nil {
+	cmd.Println(err)
+	return
+    }
+    cmd.Println(resp)
+}
+
+func unsafeRecoverHistoryCommandFunc(cmd *cobra.Command, args []string) {
+    var resp string
+    var err error
+    prefix := fmt.Sprintf("%s/unsafe-recover/history", storesPrefix)
+    resp, err = doRequest(cmd, prefix, http.MethodGet)
+    if err != nil {
+	cmd.Println(err)
+	return
+    }
+    cmd.Println(resp)
 }
 
 func storeLimitSceneCommandFunc(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Signed-off-by: v01dstar <yang.zhang@pingcap.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

TL;DR:  Adding unsafe-recover commands as part of https://github.com/tikv/tikv/issues/10483

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- Has HTTP API interfaces change 

Side effects: N/A

Related changes: This is the first PR for this project

### Release note

None
