### PR TITLE
tso: fix the Global TSO sync panic and add retry mechanism

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1311,6 +1311,9 @@ func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) 
 			}
 			syncedDCs = append(syncedDCs, allocator.GetDCLocation())
 		}
+		if maxLocalTS == nil {
+			return nil, status.Errorf(codes.Unknown, "local tso allocator leaders have changed during the sync, should retry")
+		}
 		// Found a bigger or equal maxLocalTS, return it directly.
 		cmpResult := tsoutil.CompareTimestamp(maxLocalTS, request.GetMaxTs())
 		if cmpResult >= 0 {

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1277,6 +1277,9 @@ func (s *Server) incompatibleVersion(tag string) *pdpb.ResponseHeader {
 	})
 }
 
+// Only used for the TestLocalAllocatorLeaderChange.
+var mockLocalAllocatorLeaderChangeFlag = false
+
 // SyncMaxTS will check whether MaxTS is the biggest one among all Local TSOs this PD is holding when skipCheck is set,
 // and write it into all Local TSO Allocators then if it's indeed the biggest one.
 func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) (*pdpb.SyncMaxTSResponse, error) {
@@ -1311,8 +1314,20 @@ func (s *Server) SyncMaxTS(ctx context.Context, request *pdpb.SyncMaxTSRequest) 
 			}
 			syncedDCs = append(syncedDCs, allocator.GetDCLocation())
 		}
+
+		failpoint.Inject("mockLocalAllocatorLeaderChange", func() {
+			if !mockLocalAllocatorLeaderChangeFlag {
+				maxLocalTS = nil
+				request.MaxTs = nil
+				mockLocalAllocatorLeaderChangeFlag = true
+			}
+		})
+
 		if maxLocalTS == nil {
 			return nil, status.Errorf(codes.Unknown, "local tso allocator leaders have changed during the sync, should retry")
+		}
+		if request.GetMaxTs() == nil {
+			return nil, status.Errorf(codes.Unknown, "empty maxTS in the request, should retry")
 		}
 		// Found a bigger or equal maxLocalTS, return it directly.
 		cmpResult := tsoutil.CompareTimestamp(maxLocalTS, request.GetMaxTs())

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -256,6 +256,10 @@ func (gta *GlobalTSOAllocator) precheckLogical(maxTSO *pdpb.Timestamp, suffixBit
 			globalTSOOverflowFlag = false
 		}
 	})
+	// Make sure the physical time is not empty again.
+	if maxTSO.GetPhysical() == 0 {
+		return false
+	}
 	// Check if the logical part will reach the overflow condition after being differenitated.
 	if differentiatedLogical := gta.timestampOracle.differentiateLogical(maxTSO.Logical, suffixBits); differentiatedLogical >= maxLogical {
 		log.Error("estimated logical part outside of max logical interval, please check ntp time",

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -173,11 +173,11 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 	defer cancel()
 	for i := 0; i < maxRetryCount; i++ {
 		var (
-			globalTSOResp          pdpb.Timestamp  = pdpb.Timestamp{}
-			estimatedMaxTSO        *pdpb.Timestamp = &pdpb.Timestamp{}
-			suffixBits             int             = gta.allocatorManager.GetSuffixBits()
-			shouldRetry, skipCheck bool
 			err                    error
+			shouldRetry, skipCheck bool
+			globalTSOResp          pdpb.Timestamp
+			estimatedMaxTSO        *pdpb.Timestamp
+			suffixBits             = gta.allocatorManager.GetSuffixBits()
 		)
 		// TODO: add a switch to control whether to enable the MaxTSO estimation.
 		// 1. Estimate a MaxTS among all Local TSO Allocator leaders according to the RTT.

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -171,19 +171,20 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 	// (whit synchronization with other Local TSO Allocators)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var (
-		globalTSOResp          pdpb.Timestamp  = pdpb.Timestamp{}
-		estimatedMaxTSO        *pdpb.Timestamp = &pdpb.Timestamp{}
-		suffixBits             int             = gta.allocatorManager.GetSuffixBits()
-		shouldRetry, skipCheck bool
-		err                    error
-	)
 	for i := 0; i < maxRetryCount; i++ {
+		var (
+			globalTSOResp          pdpb.Timestamp  = pdpb.Timestamp{}
+			estimatedMaxTSO        *pdpb.Timestamp = &pdpb.Timestamp{}
+			suffixBits             int             = gta.allocatorManager.GetSuffixBits()
+			shouldRetry, skipCheck bool
+			err                    error
+		)
 		// TODO: add a switch to control whether to enable the MaxTSO estimation.
 		// 1. Estimate a MaxTS among all Local TSO Allocator leaders according to the RTT.
 		estimatedMaxTSO, shouldRetry, err = gta.estimateMaxTS(count, suffixBits)
 		if err != nil {
-			return pdpb.Timestamp{}, err
+			log.Error("global tso allocator estimates MaxTS failed", errs.ZapError(err))
+			continue
 		}
 		if shouldRetry {
 			time.Sleep(gta.timestampOracle.updatePhysicalInterval)
@@ -195,7 +196,8 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 		// we need to validate it first before we write it into every Local TSO Allocator's memory.
 		globalTSOResp = *estimatedMaxTSO
 		if err = gta.SyncMaxTS(ctx, dcLocationMap, &globalTSOResp, skipCheck); err != nil {
-			return pdpb.Timestamp{}, err
+			log.Error("global tso allocator synchronizes MaxTS failed", errs.ZapError(err))
+			continue
 		}
 		// 3. If skipCheck is false and the maxTSO is bigger than estimatedMaxTSO,
 		// we need to redo the setting phase with the bigger one and skip the check safely.
@@ -218,15 +220,16 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 		// 4. Persist MaxTS into memory, and etcd if needed
 		var currentGlobalTSO *pdpb.Timestamp
 		if currentGlobalTSO, err = gta.getCurrentTSO(); err != nil {
-			return pdpb.Timestamp{}, err
+			log.Error("global tso allocator gets the current global tso in memory failed", errs.ZapError(err))
+			continue
 		}
 		if tsoutil.CompareTimestamp(currentGlobalTSO, &globalTSOResp) < 0 {
 			tsoCounter.WithLabelValues("global_tso_persist", gta.timestampOracle.dcLocation).Inc()
 			// Update the Global TSO in memory
 			if err = gta.timestampOracle.resetUserTimestamp(gta.leadership, tsoutil.GenerateTS(&globalTSOResp), true); err != nil {
 				tsoCounter.WithLabelValues("global_tso_persist_err", gta.timestampOracle.dcLocation).Inc()
-				log.Error("update the global tso in memory failed", errs.ZapError(err))
-				return pdpb.Timestamp{}, err
+				log.Error("global tso allocator update the global tso in memory failed", errs.ZapError(err))
+				continue
 			}
 		}
 		// 5. Check leadership again before we returning the response.
@@ -240,7 +243,7 @@ func (gta *GlobalTSOAllocator) GenerateTSO(count uint32) (pdpb.Timestamp, error)
 		return globalTSOResp, nil
 	}
 	tsoCounter.WithLabelValues("exceeded_max_retry", gta.timestampOracle.dcLocation).Inc()
-	return globalTSOResp, errs.ErrGenerateTimestamp.FastGenByArgs("maximum number of retries exceeded")
+	return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("global tso allocator maximum number of retries exceeded")
 }
 
 // Only used for test


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close #3866.

### What is changed and how it works?

* Check whether `maxLocalTS` is nil before using it to compare.
* Add retry mechanism for the Global TSO generation. 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
