### PR TITLE
schedule: `isRegionHealthy` only care pending peer and down peer

### DIFF
--- a/server/schedule/opt/healthy.go
+++ b/server/schedule/opt/healthy.go
@@ -21,8 +21,7 @@ import (
 var balanceEmptyRegionThreshold = 50
 
 // IsRegionHealthy checks if a region is healthy for scheduling. It requires the
-// region does not have any down or pending peers. And when placement rules
-// feature is disabled, it requires the region does not have any learner peer.
+// region does not have any down or pending peers. 
 func IsRegionHealthy(cluster Cluster, region *core.RegionInfo) bool {
 	return IsHealthyAllowPending(cluster, region) && len(region.GetPendingPeers()) == 0
 }
@@ -30,9 +29,6 @@ func IsRegionHealthy(cluster Cluster, region *core.RegionInfo) bool {
 // IsHealthyAllowPending checks if a region is healthy for scheduling.
 // Differs from IsRegionHealthy, it allows the region to have pending peers.
 func IsHealthyAllowPending(cluster Cluster, region *core.RegionInfo) bool {
-	if !cluster.GetOpts().IsPlacementRulesEnabled() && len(region.GetLearners()) > 0 {
-		return false
-	}
 	return len(region.GetDownPeers()) == 0
 }
 

--- a/server/schedule/opt/healthy.go
+++ b/server/schedule/opt/healthy.go
@@ -21,7 +21,7 @@ import (
 var balanceEmptyRegionThreshold = 50
 
 // IsRegionHealthy checks if a region is healthy for scheduling. It requires the
-// region does not have any down or pending peers. 
+// region does not have any down or pending peers.
 func IsRegionHealthy(cluster Cluster, region *core.RegionInfo) bool {
 	return IsHealthyAllowPending(cluster, region) && len(region.GetPendingPeers()) == 0
 }

--- a/server/schedule/opt/healthy_test.go
+++ b/server/schedule/opt/healthy_test.go
@@ -73,13 +73,14 @@ func (s *testRegionHealthySuite) TestIsRegionHealthy(c *C) {
 		replicated2          bool
 	}
 
+	// healthy only check down peer and pending peer
 	cases := []testCase{
 		{region(peers(1, 2, 3)), true, true, true, true, true, true},
 		{region(peers(1, 2, 3), core.WithPendingPeers(peers(1))), false, true, true, false, true, true},
-		{region(peers(1, 2, 3), core.WithLearners(peers(1))), false, false, false, true, true, false},
+		{region(peers(1, 2, 3), core.WithLearners(peers(1))), true, true, false, true, true, false},
 		{region(peers(1, 2, 3), core.WithDownPeers([]*pdpb.PeerStats{{Peer: peers(1)[0]}})), false, false, true, false, false, true},
 		{region(peers(1, 2)), true, true, false, true, true, false},
-		{region(peers(1, 2, 3, 4), core.WithLearners(peers(1))), false, false, false, true, true, false},
+		{region(peers(1, 2, 3, 4), core.WithLearners(peers(1))), true, true, false, true, true, false},
 	}
 
 	opt := config.NewTestOptions()


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
close #3896 

### What is changed and how it works?

The current implementation, when using only `isRegionHealthy`, unexpect schedule regions with learners when enabling placement rules.

However, in addition to `isRegionHealthy`, there is also `isReplicated`, which are often used together. When used together, it is actually okay because it will be checked in `isReplicated`.

Only when `isRegionHealthy` is used alone, such as in evict-leader, balance-leader, shuffle-leader, grant-leader and random-merge leaders, only `opt. HealthRegion`, but not `isReplicated`. There is not much difference whether it is allowed or not here.

So, to simplify the semantics and ensure consistent behavior, let `isRegionHealthy` only determine pending peer and down peer.


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
