### PR TITLE
*: make TestScatterGroupInConcurrency more stable

### DIFF
--- a/server/schedule/region_scatterer_test.go
+++ b/server/schedule/region_scatterer_test.go
@@ -299,6 +299,8 @@ func (s *testScatterRegionSuite) TestScatterGroupInConcurrency(c *C) {
 	// Add 5 stores.
 	for i := uint64(1); i <= 5; i++ {
 		tc.AddRegionStore(i, 0)
+		// prevent store from being disconnected
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
 	}
 
 	testcases := []struct {


### PR DESCRIPTION


### What problem does this PR solve?
Closes #3872.

### What is changed and how it works?
If `TestScatterGroupInConcurrency` runs over 20 seconds, the store will become disconnected which fails the test.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
