### PR TITLE
scheduler: use qps priority with multi priorities in hot region scheduler 

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -219,7 +219,7 @@ func (h *hotScheduler) gcRegionPendings() {
 }
 
 // summaryStoresLoad Load information of all available stores.
-// it will filtered the hot peer and calculate the current and future stat(rate,count) for each store
+// it will filter the hot peer and calculate the current and future stat(rate,count) for each store
 func summaryStoresLoad(
 	stores []*core.StoreInfo,
 	storesLoads map[uint64][]float64,
@@ -1096,7 +1096,7 @@ func (bs *balanceSolver) buildOperator() (op *operator.Operator, infl *Influence
 
 	dim := ""
 	if bs.firstPriorityIsBetter && bs.secondPriorityIsBetter {
-		dim = "both"
+		dim = "all"
 	} else if bs.firstPriorityIsBetter {
 		dim = dimToString(bs.firstPriority)
 	} else if bs.secondPriorityIsBetter {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -594,7 +594,7 @@ func (bs *balanceSolver) filterSrcStores() map[uint64]*storeLoadDetail {
 
 func (bs *balanceSolver) checkSrcByDimPriorityAndTolerance(minLoad, expectLoad *storeLoad) bool {
 	return slice.AllOf(minLoad.Loads, func(i int) bool {
-		if statistics.IsSelectedDim(i) {
+		if bs.isSelectedDim(i) {
 			return minLoad.Loads[i] > bs.sche.conf.GetSrcToleranceRatio()*expectLoad.Loads[i]
 		}
 		return true
@@ -785,7 +785,7 @@ func (bs *balanceSolver) pickDstStores(filters []filter.Filter, candidates []*st
 func (bs *balanceSolver) checkDstByPriorityAndTolerance(maxLoad, expect *storeLoad) bool {
 	dstToleranceRatio := bs.sche.conf.GetDstToleranceRatio()
 	return slice.AllOf(maxLoad.Loads, func(i int) bool {
-		if statistics.IsSelectedDim(i) {
+		if bs.isSelectedDim(i) {
 			return maxLoad.Loads[i]*dstToleranceRatio < expect.Loads[i]
 		}
 		return true

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -773,7 +773,6 @@ func (bs *balanceSolver) pickDstStores(filters []filter.Filter, candidates []*st
 				hotSchedulerResultCounter.WithLabelValues("src-store-failed", strconv.FormatUint(id, 10)).Inc()
 			}
 		}
-
 	}
 	return ret
 }

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -55,7 +55,7 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		MaxPeerNum:             1000,
 		SrcToleranceRatio:      1.05, // Tolerate 5% difference
 		DstToleranceRatio:      1.05, // Tolerate 5% difference
-		ReadPriorities:         []string{BytePriority, KeyPriority},
+		ReadPriorities:         []string{QueryPriority, BytePriority},
 		WritePriorities:        []string{BytePriority, KeyPriority},
 	}
 }

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -685,6 +685,7 @@ func (s *testHotReadRegionSchedulerSuite) TestByteRateOnly(c *C) {
 	tc.DisableFeature(versioninfo.JointConsensus)
 	hb, err := schedule.CreateScheduler(HotReadRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
 	c.Assert(err, IsNil)
+	hb.(*hotScheduler).conf.ReadPriorities = []string{BytePriority, KeyPriority}
 	tc.SetHotRegionCacheHitsThreshold(0)
 
 	// Add stores 1, 2, 3, 4, 5 with region counts 3, 2, 2, 2, 0.
@@ -790,6 +791,7 @@ func (s *testHotReadRegionSchedulerSuite) TestWithKeyRate(c *C) {
 	c.Assert(err, IsNil)
 	hb.(*hotScheduler).conf.SetSrcToleranceRatio(1)
 	hb.(*hotScheduler).conf.SetDstToleranceRatio(1)
+	hb.(*hotScheduler).conf.ReadPriorities = []string{BytePriority, KeyPriority}
 
 	tc := mockcluster.NewCluster(ctx, opt)
 	tc.SetHotRegionCacheHitsThreshold(0)
@@ -1435,6 +1437,7 @@ func (s *testHotSchedulerSuite) TestHotReadPeerSchedule(c *C) {
 	sche, err := schedule.CreateScheduler(HotReadRegionType, schedule.NewOperatorController(ctx, tc, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigJSONDecoder([]byte("null")))
 	c.Assert(err, IsNil)
 	hb := sche.(*hotScheduler)
+	hb.conf.ReadPriorities = []string{BytePriority, KeyPriority}
 
 	tc.UpdateStorageReadStats(1, 20*MB, 20*MB)
 	tc.UpdateStorageReadStats(2, 19*MB, 19*MB)

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -286,11 +286,7 @@ func (load storeLoad) ToLoadPred(rwTy rwType, infl *Influence) *storeLoadPred {
 
 func stLdRate(dim int) func(ld *storeLoad) float64 {
 	return func(ld *storeLoad) float64 {
-		switch dim {
-		case statistics.ByteDim, statistics.KeyDim, statistics.QueryDim:
-			return ld.Loads[dim]
-		}
-		return 0
+		return ld.Loads[dim]
 	}
 }
 

--- a/server/statistics/hot_peer.go
+++ b/server/statistics/hot_peer.go
@@ -30,34 +30,6 @@ const (
 	DimLen
 )
 
-// DimToString returns string with dim
-func DimToString(dim int) string {
-	switch dim {
-	case ByteDim:
-		return "byte"
-	case KeyDim:
-		return "key"
-	case QueryDim:
-		return "qps"
-	default:
-		return ""
-	}
-}
-
-// StringToDim returns dim with string
-func StringToDim(name string) int {
-	switch name {
-	case DimToString(ByteDim):
-		return ByteDim
-	case DimToString(KeyDim):
-		return KeyDim
-	case DimToString(QueryDim):
-		return QueryDim
-	default:
-		return DimLen
-	}
-}
-
 // IsSelectedDim return whether the dim is selected for hot scheduler
 func IsSelectedDim(dim int) bool {
 	// TODO: configure

--- a/server/statistics/hot_peer.go
+++ b/server/statistics/hot_peer.go
@@ -30,12 +30,6 @@ const (
 	DimLen
 )
 
-// IsSelectedDim return whether the dim is selected for hot scheduler
-func IsSelectedDim(dim int) bool {
-	// TODO: configure
-	return dim == ByteDim || dim == KeyDim
-}
-
 type dimStat struct {
 	typ         RegionStatKind
 	Rolling     *movingaverage.TimeMedian  // it's used to statistic hot degree and average speed.

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -433,10 +433,7 @@ func (f *hotPeerCache) updateNewHotPeerStat(newItem *HotPeerStat, deltaLoads []f
 		return nil
 	}
 	isHot := slice.AnyOf(regionStats, func(i int) bool {
-		if IsSelectedDim(i) {
-			return deltaLoads[regionStats[i]]/interval.Seconds() >= newItem.thresholds[i]
-		}
-		return false
+		return deltaLoads[regionStats[i]]/interval.Seconds() >= newItem.thresholds[i]
 	})
 	if !isHot {
 		return nil

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -270,13 +270,18 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 		"minor-dec-ratio":            0.99,
 		"src-tolerance-ratio":        1.05,
 		"dst-tolerance-ratio":        1.05,
-		"read-priorities":            []interface{}{"byte", "key"},
+		"read-priorities":            []interface{}{"qps", "byte"},
 		"write-priorities":           []interface{}{"byte", "key"},
 	}
 	c.Assert(conf, DeepEquals, expected1)
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "src-tolerance-ratio", "1.02"}, nil)
 	expected1["src-tolerance-ratio"] = 1.02
 	var conf1 map[string]interface{}
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
+	c.Assert(conf1, DeepEquals, expected1)
+
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "read-priorities", "byte,key"}, nil)
+	expected1["read-priorities"] = []interface{}{"byte", "key"}
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
 	c.Assert(conf1, DeepEquals, expected1)
 

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -551,9 +551,6 @@ func postSchedulerConfigCommandFunc(cmd *cobra.Command, schedulerName string, ar
 			cmd.Println("priorities shouldn't be repeated")
 			return
 		}
-		if len(priorities) != 2 {
-			cmd.Println("priorities should be two dims")
-		}
 	} else {
 		input[key] = val
 	}


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

The current hotspot identification mainly uses byte and key dimensions, which are not very fit for load requests with high CPU overhead but low hard disk overhead, we plan to add QPS dimension to better describe the distribution of CPU resources.

### What is changed and how it works?

use qps dimension  as the first priority in  hot region scheduler

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- 
### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
use qps dimension  as the first priority in  hot region scheduler
```
