### PR TITLE
scheduler: unify leaderSolver and peerSolver in hot read scheduler

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -636,7 +636,7 @@ func (bs *balanceSolver) tryAddPendingInfluence() bool {
 	default:
 		maxZombieDur = bs.sche.conf.GetStoreStatZombieDuration()
 	}
-	return bs.sche.tryAddPendingInfluence(bs.ops[0], bs.best.srcStoreID, bs.best.dstStoreID, bs.infl)
+	return bs.sche.tryAddPendingInfluence(bs.ops[0], bs.best.srcStoreID, bs.best.dstStoreID, bs.infl, maxZombieDur)
 }
 
 // filterSrcStores compare the min rate and the ratio * expectation rate, if two dim rate is greater than

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -377,11 +377,17 @@ func (h *hotScheduler) balanceHotReadRegions(cluster opt.Cluster) []*operator.Op
 		schedulerCounter.WithLabelValues(h.GetName(), "skip").Inc()
 		return nil
 	}
-	if len(leaderOps) == 0 && peerSolver.tryAddPendingInfluence() {
-		return peerOps
+	if len(leaderOps) == 0 {
+		if peerSolver.tryAddPendingInfluence() {
+			return peerOps
+		}
+		return nil
 	}
-	if len(peerOps) == 0 && leaderSolver.tryAddPendingInfluence() {
-		return leaderOps
+	if len(peerOps) == 0 {
+		if leaderSolver.tryAddPendingInfluence() {
+			return leaderOps
+		}
+		return nil
 	}
 	leaderSolver.cur = leaderSolver.best
 	if leaderSolver.betterThan(peerSolver.best) {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -381,12 +381,14 @@ func (h *hotScheduler) balanceHotReadRegions(cluster opt.Cluster) []*operator.Op
 		if peerSolver.tryAddPendingInfluence() {
 			return peerOps
 		}
+		schedulerCounter.WithLabelValues(h.GetName(), "skip").Inc()
 		return nil
 	}
 	if len(peerOps) == 0 {
 		if leaderSolver.tryAddPendingInfluence() {
 			return leaderOps
 		}
+		schedulerCounter.WithLabelValues(h.GetName(), "skip").Inc()
 		return nil
 	}
 	leaderSolver.cur = leaderSolver.best

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -486,22 +486,6 @@ type solution struct {
 	progressiveRank int64
 }
 
-func (bs *balanceSolver) tryAddPendingInfluence() bool {
-	if bs.best == nil || len(bs.ops) == 0 {
-		return false
-	}
-	// Depending on the source of the statistics used, a different ZombieDuration will be used.
-	// If the statistics are from the sum of Regions, there will be a longer ZombieDuration.
-	var maxZombieDur time.Duration
-	switch {
-	case bs.rwTy == write && bs.opTy == transferLeader:
-		maxZombieDur = bs.sche.conf.GetRegionsStatZombieDuration()
-	default:
-		maxZombieDur = bs.sche.conf.GetStoreStatZombieDuration()
-	}
-	return bs.sche.tryAddPendingInfluence(bs.ops[0], bs.best.srcStoreID, bs.best.dstStoreID, bs.infl)
-}
-
 func (bs *balanceSolver) init() {
 	switch toResourceType(bs.rwTy, bs.opTy) {
 	case writePeer:
@@ -637,6 +621,22 @@ func (bs *balanceSolver) solve() []*operator.Operator {
 		}
 	}
 	return bs.ops
+}
+
+func (bs *balanceSolver) tryAddPendingInfluence() bool {
+	if bs.best == nil || len(bs.ops) == 0 {
+		return false
+	}
+	// Depending on the source of the statistics used, a different ZombieDuration will be used.
+	// If the statistics are from the sum of Regions, there will be a longer ZombieDuration.
+	var maxZombieDur time.Duration
+	switch {
+	case bs.rwTy == write && bs.opTy == transferLeader:
+		maxZombieDur = bs.sche.conf.GetRegionsStatZombieDuration()
+	default:
+		maxZombieDur = bs.sche.conf.GetStoreStatZombieDuration()
+	}
+	return bs.sche.tryAddPendingInfluence(bs.ops[0], bs.best.srcStoreID, bs.best.dstStoreID, bs.infl)
 }
 
 // filterSrcStores compare the min rate and the ratio * expectation rate, if two dim rate is greater than

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -907,11 +907,11 @@ func (s *testHotReadRegionSchedulerSuite) TestWithPendingInfluence(c *C) {
 
 			op1 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op1, operator.OpHotRegion, 1, 4)
-			// After move-peer, store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5,5.5)
+			// After move-peer, store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5, 5.5)
 
 			op2 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op2, operator.OpHotRegion, 1, 4)
-			// After move-peer,  store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
+			// After move-peer, store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
 
 			ops := hb.Schedule(tc)
 			c.Logf("%v", ops)

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -892,36 +892,40 @@ func (s *testHotReadRegionSchedulerSuite) TestWithPendingInfluence(c *C) {
 			})
 		}
 
+		// Before schedule, store byte/key rate: 7.1 | 6.1 | 6 | 5
+		// Min and max from storeLoadPred. They will be generated in the comparison of current and future.
 		for i := 0; i < 20; i++ {
 			hb.(*hotScheduler).clearPendingInfluence()
 
 			op1 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op1, operator.OpHotRegion, 1, 4)
-			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5,5.5)
+			// After move-peer, store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5,5.5)
 
 			op2 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op2, operator.OpHotRegion, 1, 4)
-			// store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
+			// After move-peer,  store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
 
 			ops := hb.Schedule(tc)
 			c.Logf("%v", ops)
 			c.Assert(ops, HasLen, 0)
 		}
+
+		// Before schedule, store byte/key rate: 7.1 | 6.1 | 6 | 5
 		for i := 0; i < 20; i++ {
 			hb.(*hotScheduler).clearPendingInfluence()
 
 			op1 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op1, operator.OpHotRegion, 1, 4)
-			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5, 5.5)
+			// After move-peer, store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5, 5.5)
 
 			op2 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op2, operator.OpHotRegion, 1, 4)
-			// store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
+			// After move-peer, store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
 			c.Assert(op2.Cancel(), IsTrue)
 
 			op2 = hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op2, operator.OpHotRegion, 1, 4)
-			// store byte/key rate (min, max): (6.1, 7.1) | 6.1 | (6, 6.5) | (5, 5.5)
+			// After move-peer, store byte/key rate (min, max): (6.1, 7.1) | 6.1 | (6, 6.5) | (5, 5.5)
 
 			c.Assert(op1.Cancel(), IsTrue)
 			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5, 5.5)

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -734,9 +734,14 @@ func (s *testHotReadRegionSchedulerSuite) TestByteRateOnly(c *C) {
 		}
 	}
 
-	testutil.CheckTransferLeader(c, hb.Schedule(tc)[0], operator.OpHotRegion, 1, 3)
+	op := hb.Schedule(tc)[0]
+
+	// move leader from store 1 to store 5
+	// it is better than transfer leader from store 1 to store 3
+	testutil.CheckTransferPeerWithLeaderTransfer(c, op, operator.OpHotRegion, 1, 5)
 	hb.(*hotScheduler).clearPendingInfluence()
-	// assume handle the operator
+
+	// assume handle the transfer leader operator rather than move leader
 	tc.AddRegionWithReadInfo(3, 3, 512*KB*statistics.ReadReportInterval, 0, statistics.ReadReportInterval, []uint64{1, 2})
 	// After transfer a hot region leader from store 1 to store 3
 	// the three region leader will be evenly distributed in three stores
@@ -891,12 +896,12 @@ func (s *testHotReadRegionSchedulerSuite) TestWithPendingInfluence(c *C) {
 			hb.(*hotScheduler).clearPendingInfluence()
 
 			op1 := hb.Schedule(tc)[0]
-			testutil.CheckTransferLeader(c, op1, operator.OpLeader, 1, 3)
-			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | (6, 6.5) | 5
+			testutil.CheckTransferPeer(c, op1, operator.OpHotRegion, 1, 4)
+			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5,5.5)
 
 			op2 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op2, operator.OpHotRegion, 1, 4)
-			// store byte/key rate (min, max): (6.1, 7.1) | 6.1 | (6, 6.5) | (5, 5.5)
+			// store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
 
 			ops := hb.Schedule(tc)
 			c.Logf("%v", ops)
@@ -906,14 +911,13 @@ func (s *testHotReadRegionSchedulerSuite) TestWithPendingInfluence(c *C) {
 			hb.(*hotScheduler).clearPendingInfluence()
 
 			op1 := hb.Schedule(tc)[0]
-			testutil.CheckTransferLeader(c, op1, operator.OpLeader, 1, 3)
-			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | (6, 6.5) | 5
+			testutil.CheckTransferPeer(c, op1, operator.OpHotRegion, 1, 4)
+			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | 6 | (5, 5.5)
 
 			op2 := hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op2, operator.OpHotRegion, 1, 4)
-			// store bytekey rate (min, max): (6.1, 7.1) | 6.1 | (6, 6.5) | (5, 5.5)
+			// store byte/key rate (min, max): (6.1, 7.1) | 6.1 | 6 | (5, 6)
 			c.Assert(op2.Cancel(), IsTrue)
-			// store byte/key rate (min, max): (6.6, 7.1) | 6.1 | (6, 6.5) | 5
 
 			op2 = hb.Schedule(tc)[0]
 			testutil.CheckTransferPeer(c, op2, operator.OpHotRegion, 1, 4)


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Previously, we gave priority to the transfer leader and only used the move leader when there was no transfer leader, which is not necessarily the optimal solution, so this pr will be compared uniformly and then selected

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
unify leaderSolver and peerSolver in hot read scheduler
```
