### PR TITLE
scheduler: use pending amp in hot region scheduler

### DIFF
--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -187,6 +187,26 @@ func SetReadKeys(v uint64) RegionCreateOption {
 	}
 }
 
+// SetReadQuery sets the read query for the region.
+func SetReadQuery(v uint64) RegionCreateOption {
+	q := &pdpb.QueryStats{
+		Coprocessor: v / 3,
+		Get:         v / 3,
+		Scan:        v / 3,
+	}
+	return SetQueryStats(q)
+}
+
+// SetWrittenQuery sets the write query for the region.
+func SetWrittenQuery(v uint64) RegionCreateOption {
+	q := &pdpb.QueryStats{
+		Put:         v / 3,
+		Delete:      v / 3,
+		DeleteRange: v / 3,
+	}
+	return SetQueryStats(q)
+}
+
 // SetQueryStats sets the query stats for the region.
 func SetQueryStats(v *pdpb.QueryStats) RegionCreateOption {
 	return func(region *RegionInfo) {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -69,6 +69,8 @@ const (
 
 // schedulePeerPr the probability of schedule the hot peer.
 var schedulePeerPr = 0.66
+
+// pendingAmpFactor will amplify the impact of pending influence, making scheduling slower or even serial when two stores are close together
 var pendingAmpFactor = 8.0
 
 type hotScheduler struct {
@@ -514,7 +516,7 @@ func (bs *balanceSolver) tryAddPendingInfluence() bool {
 	switch {
 	case bs.isForWriteLeader():
 		maxZombieDur = bs.sche.conf.GetRegionsStatZombieDuration()
-	case bs.rwTy == write && bs.opTy == movePeer:
+	case bs.isForWritePeer():
 		if bs.best.srcDetail.Info.IsTiFlash {
 			maxZombieDur = bs.sche.conf.GetRegionsStatZombieDuration()
 		} else {
@@ -528,6 +530,10 @@ func (bs *balanceSolver) tryAddPendingInfluence() bool {
 
 func (bs *balanceSolver) isForWriteLeader() bool {
 	return bs.rwTy == write && bs.opTy == transferLeader
+}
+
+func (bs *balanceSolver) isForWritePeer() bool {
+	return bs.rwTy == write && bs.opTy == movePeer
 }
 
 // filterSrcStores compare the min rate and the ratio * expectation rate, if two dim rate is greater than

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -931,7 +931,7 @@ func (bs *balanceSolver) isTolerance(src, dst *storeLoadPred, dim int) bool {
 	pendingAmp := (1 + pendingAmpFactor*srcRate/(srcRate-dstRate))
 	srcPending := src.pending().Loads[dim]
 	dstPending := dst.pending().Loads[dim]
-	hotPendingStatus.WithLabelValues(bs.rwTy.String(), strconv.FormatUint(bs.cur.srcStoreID, 10), strconv.FormatUint(bs.cur.dstStoreID, 10)).Set(float64(pendingAmp))
+	hotPendingStatus.WithLabelValues(bs.rwTy.String(), strconv.FormatUint(bs.cur.srcStoreID, 10), strconv.FormatUint(bs.cur.dstStoreID, 10)).Set(pendingAmp)
 	return srcRate-pendingAmp*srcPending > dstRate+pendingAmp*dstPending
 }
 

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -416,9 +416,10 @@ func (bs *balanceSolver) adjustConfig(origins []string, getPriorities func(*prio
 	withQuery := slice.AnyOf(origins, func(i int) bool {
 		return origins[i] == QueryPriority
 	})
-	lows := getPriorities(&lowConfig)
+	compatibles := getPriorities(&compatibleConfig)
 	if !querySupport && withQuery {
-		return prioritiesToDim(lows)
+		schedulerCounter.WithLabelValues(bs.sche.GetName(), "use-compatible-config").Inc()
+		return prioritiesToDim(compatibles)
 	}
 
 	defaults := getPriorities(&defaultConfig)
@@ -430,8 +431,10 @@ func (bs *balanceSolver) adjustConfig(origins []string, getPriorities func(*prio
 	}
 
 	if !querySupport {
-		return prioritiesToDim(lows)
+		schedulerCounter.WithLabelValues(bs.sche.GetName(), "use-compatible-config").Inc()
+		return prioritiesToDim(compatibles)
 	}
+	schedulerCounter.WithLabelValues(bs.sche.GetName(), "use-default-config").Inc()
 	return prioritiesToDim(defaults)
 }
 

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -50,7 +50,7 @@ var defaultConfig = prioritiesConfig{
 }
 
 // because tikv below 5.2.0 does not report query information, we will use byte and key as the scheduling dimensions
-var lowConfig = prioritiesConfig{
+var compatibleConfig = prioritiesConfig{
 	readLeader:  []string{BytePriority, KeyPriority},
 	writeLeader: []string{KeyPriority, BytePriority},
 	writePeer:   []string{BytePriority, KeyPriority},

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -83,9 +83,10 @@ type hotRegionSchedulerConfig struct {
 	SrcToleranceRatio      float64  `json:"src-tolerance-ratio"`
 	DstToleranceRatio      float64  `json:"dst-tolerance-ratio"`
 	ReadPriorities         []string `json:"read-priorities"`
-	WriteLeaderPriorities  []string `json:"write-leader-priorities"`
-	WritePeerPriorities    []string `json:"write-peer-priorities"`
-	StrictPickingStore     bool     `json:"strict-picking-store,string"`
+	// For first priority of write leader, it is better to consider key rate or query rather than byte
+	WriteLeaderPriorities []string `json:"write-leader-priorities"`
+	WritePeerPriorities   []string `json:"write-peer-priorities"`
+	StrictPickingStore    bool     `json:"strict-picking-store,string"`
 }
 
 func (conf *hotRegionSchedulerConfig) EncodeConfig() ([]byte, error) {

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -422,7 +422,6 @@ func (s *testHotWriteRegionSchedulerSuite) TestByteRateOnlyWithTiFlash(c *C) {
 		hotRegionBytesSum += r.byteRate
 		hotRegionKeysSum += r.keyRate
 		hotRegionQuerySum += r.queryRate
-
 	}
 	// Will transfer a hot learner from store 8, because the total count of peers
 	// which is hot for store 8 is larger than other TiFlash stores.

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1412,19 +1412,12 @@ func (s *testInfluenceSerialSuite) TestInfluenceByRWType(c *C) {
 	c.Assert(nearlyAbout(pendingInfluence[4].Loads[statistics.RegionReadBytes], 0.5*MB), IsTrue)
 
 	// consider pending amp, there are nine regions or more.
-	addRegionInfo(tc, write, []testRegionInfo{
-		{2, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{3, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{4, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{5, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{6, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{7, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{8, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{9, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{10, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{11, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-		{12, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
-	})
+	for i := 2; i < 13; i++ {
+		addRegionInfo(tc, write, []testRegionInfo{
+			{uint64(i), []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
+		})
+	}
+
 	addRegionInfo(tc, read, []testRegionInfo{
 		{2, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},
 		{3, []uint64{1, 2, 3}, 0.7 * MB, 0.7 * MB},

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1905,6 +1905,15 @@ func (s *testHotSchedulerSuite) TestCompatibility(c *C) {
 		{statistics.KeyDim, statistics.ByteDim},
 		{statistics.ByteDim, statistics.KeyDim},
 	})
+	// config error value
+	hb.(*hotScheduler).conf.ReadPriorities = []string{"hahaha"}
+	hb.(*hotScheduler).conf.WriteLeaderPriorities = []string{"hahaha", "byte"}
+	hb.(*hotScheduler).conf.WritePeerPriorities = []string{"qps", "byte", "key"}
+	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
+		{statistics.QueryDim, statistics.ByteDim},
+		{statistics.KeyDim, statistics.ByteDim},
+		{statistics.ByteDim, statistics.KeyDim},
+	})
 	// low version
 	tc.DisableFeature(versioninfo.HotScheduleWithQuery)
 	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
@@ -1925,6 +1934,15 @@ func (s *testHotSchedulerSuite) TestCompatibility(c *C) {
 	hb.(*hotScheduler).conf.ReadPriorities = []string{"qps", "byte"}
 	hb.(*hotScheduler).conf.WriteLeaderPriorities = []string{"qps", "byte"}
 	hb.(*hotScheduler).conf.WritePeerPriorities = []string{"qps", "byte"}
+	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
+		{statistics.ByteDim, statistics.KeyDim},
+		{statistics.KeyDim, statistics.ByteDim},
+		{statistics.ByteDim, statistics.KeyDim},
+	})
+	// config error value
+	hb.(*hotScheduler).conf.ReadPriorities = []string{"error", "error"}
+	hb.(*hotScheduler).conf.WriteLeaderPriorities = []string{}
+	hb.(*hotScheduler).conf.WritePeerPriorities = []string{"qps", "byte", "key"}
 	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
 		{statistics.ByteDim, statistics.KeyDim},
 		{statistics.KeyDim, statistics.ByteDim},

--- a/server/schedulers/metrics.go
+++ b/server/schedulers/metrics.go
@@ -111,6 +111,14 @@ var scatterRangeRegionCounter = prometheus.NewCounterVec(
 		Help:      "Counter of scatter range region scheduler.",
 	}, []string{"type", "store"})
 
+var hotPendingStatus = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "pd",
+		Subsystem: "scheduler",
+		Name:      "hot_pending",
+		Help:      "Counter of direction of balance related schedulers.",
+	}, []string{"type", "source", "target"})
+
 func init() {
 	prometheus.MustRegister(schedulerCounter)
 	prometheus.MustRegister(schedulerStatus)
@@ -124,4 +132,5 @@ func init() {
 	prometheus.MustRegister(scatterRangeRegionCounter)
 	prometheus.MustRegister(opInfluenceStatus)
 	prometheus.MustRegister(tolerantResourceStatus)
+	prometheus.MustRegister(hotPendingStatus)
 }

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -192,9 +192,9 @@ func (s *testShuffleHotRegionSchedulerSuite) checkBalance(c *C, tc *mockcluster.
 	//|     1     |       1      |        2       |       3        |      512KB    |
 	//|     2     |       1      |        3       |       4        |      512KB    |
 	//|     3     |       1      |        2       |       4        |      512KB    |
-	tc.AddLeaderRegionWithWriteInfo(1, 1, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{2, 3})
-	tc.AddLeaderRegionWithWriteInfo(2, 1, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{3, 4})
-	tc.AddLeaderRegionWithWriteInfo(3, 1, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{2, 4})
+	tc.AddLeaderRegionWithWriteInfo(1, 1, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{2, 3})
+	tc.AddLeaderRegionWithWriteInfo(2, 1, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{3, 4})
+	tc.AddLeaderRegionWithWriteInfo(3, 1, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{2, 4})
 	tc.SetHotRegionCacheHitsThreshold(0)
 
 	// try to get an operator
@@ -232,9 +232,9 @@ func (s *testHotRegionSchedulerSuite) TestAbnormalReplica(c *C) {
 	tc.UpdateStorageReadBytes(2, 4.5*MB*statistics.StoreHeartBeatReportInterval)
 	tc.UpdateStorageReadBytes(3, 4.5*MB*statistics.StoreHeartBeatReportInterval)
 
-	tc.AddRegionWithReadInfo(1, 1, 512*KB*statistics.ReadReportInterval, 0, statistics.ReadReportInterval, []uint64{2})
-	tc.AddRegionWithReadInfo(2, 2, 512*KB*statistics.ReadReportInterval, 0, statistics.ReadReportInterval, []uint64{1, 3})
-	tc.AddRegionWithReadInfo(3, 1, 512*KB*statistics.ReadReportInterval, 0, statistics.ReadReportInterval, []uint64{2, 3})
+	tc.AddRegionWithReadInfo(1, 1, 512*KB*statistics.ReadReportInterval, 0, 0, statistics.ReadReportInterval, []uint64{2})
+	tc.AddRegionWithReadInfo(2, 2, 512*KB*statistics.ReadReportInterval, 0, 0, statistics.ReadReportInterval, []uint64{1, 3})
+	tc.AddRegionWithReadInfo(3, 1, 512*KB*statistics.ReadReportInterval, 0, 0, statistics.ReadReportInterval, []uint64{2, 3})
 	tc.SetHotRegionCacheHitsThreshold(0)
 	c.Assert(tc.IsRegionHot(tc.GetRegion(1)), IsTrue)
 	c.Assert(hb.IsScheduleAllowed(tc), IsFalse)
@@ -401,11 +401,11 @@ func (s *testSpecialUseSuite) TestSpecialUseHotRegion(c *C) {
 	tc.UpdateStorageWrittenBytes(3, 6*MB*statistics.StoreHeartBeatReportInterval)
 	tc.UpdateStorageWrittenBytes(4, 0)
 	tc.UpdateStorageWrittenBytes(5, 0)
-	tc.AddLeaderRegionWithWriteInfo(1, 1, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{2, 3})
-	tc.AddLeaderRegionWithWriteInfo(2, 1, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{2, 3})
-	tc.AddLeaderRegionWithWriteInfo(3, 1, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{2, 3})
-	tc.AddLeaderRegionWithWriteInfo(4, 2, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{1, 3})
-	tc.AddLeaderRegionWithWriteInfo(5, 3, 512*KB*statistics.WriteReportInterval, 0, statistics.WriteReportInterval, []uint64{1, 2})
+	tc.AddLeaderRegionWithWriteInfo(1, 1, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{2, 3})
+	tc.AddLeaderRegionWithWriteInfo(2, 1, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{2, 3})
+	tc.AddLeaderRegionWithWriteInfo(3, 1, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{2, 3})
+	tc.AddLeaderRegionWithWriteInfo(4, 2, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{1, 3})
+	tc.AddLeaderRegionWithWriteInfo(5, 3, 512*KB*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{1, 2})
 	ops = hs.Schedule(tc)
 	c.Assert(ops, HasLen, 1)
 	testutil.CheckTransferPeer(c, ops[0], operator.OpHotRegion, 1, 4)

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -325,7 +325,7 @@ func (lp *storeLoadPred) pending() *storeLoad {
 	}
 	return &storeLoad{
 		Loads: loads,
-		Count: mx.Count,
+		Count: 0,
 	}
 }
 

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -326,6 +326,18 @@ func (lp *storeLoadPred) max() *storeLoad {
 	return maxLoad(&lp.Current, &lp.Future)
 }
 
+func (lp *storeLoadPred) pending() *storeLoad {
+	mx, mn := lp.max(), lp.min()
+	loads := make([]float64, len(mx.Loads))
+	for i := range loads {
+		loads[i] = mx.Loads[i] - mn.Loads[i]
+	}
+	return &storeLoad{
+		Loads: loads,
+		Count: mx.Count,
+	}
+}
+
 func (lp *storeLoadPred) diff() *storeLoad {
 	mx, mn := lp.max(), lp.min()
 	loads := make([]float64, len(mx.Loads))


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

In the past, for two stores with large differences, it was easy to have redundant scheduling behavior, because as the difference between the two stores approached, the speed might not come down in time, so we limited the speed by adding pending amps, and the closer the two stores were, the fewer regions were allowed to be scheduled at the same time.

Before
![image](https://user-images.githubusercontent.com/19542290/128167898-0013f044-c1ff-4c83-830b-b7230a4838ed.png)

After
![image](https://user-images.githubusercontent.com/19542290/128167936-5b1b4b70-4a77-4793-81c2-0dd1f0021f3a.png)



### What is changed and how it works?

isTolerance checks source store and target store by checking the difference value with pendingAmpFactor * pendingPeer. This will make the hot region scheduling slow even serialized running when each 2 store's pending influence is close.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
