### PR TITLE
scheduler: fix anticount and improving the Robustness of Hotspot Statistics

### DIFF
--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -517,11 +517,17 @@ func coldItem(newItem, oldItem *HotPeerStat) {
 func hotItem(newItem, oldItem *HotPeerStat) {
 	newItem.HotDegree = oldItem.HotDegree + 1
 	newItem.AntiCount = hotRegionAntiCount
+	if newItem.Kind == ReadFlow {
+		newItem.AntiCount = hotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
+	}
 }
 
 func initItemDegree(item *HotPeerStat) {
 	item.HotDegree = 1
 	item.AntiCount = hotRegionAntiCount
+	if item.Kind == ReadFlow {
+		item.AntiCount = hotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
+	}
 }
 
 func inheritItemDegree(newItem, oldItem *HotPeerStat) {

--- a/server/statistics/util.go
+++ b/server/statistics/util.go
@@ -27,7 +27,7 @@ const (
 	// DefaultWriteMfSize is default size of write median filter.
 	DefaultWriteMfSize = 5
 	// DefaultReadMfSize is default size of read median filter.
-	DefaultReadMfSize = 3
+	DefaultReadMfSize = 5
 )
 
 func storeTag(id uint64) string {


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

it is similiar with  #3707, After getting the hot read peer information from store heartbeat, a region that previously took two minutes to get cold will take only 20 seconds to get cold, so that the balance leader scheduler will go to the balance hotspot for a more variable load.

for read-peer/write-peer/write-store, the period of filter is 5, but it is 3 for read store.

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
