### PR TITLE
scheduler: set different priorities for write-leader and write-peer

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -481,19 +481,11 @@ func (bs *balanceSolver) init() {
 		Count: maxCur.Count * bs.sche.conf.GetCountRankStepRatio(),
 	}
 
-	priorities := bs.sche.conf.ReadPriorities
+	// For read, transfer-leader and move-peer have the same priority config
+	// For write, they are different
+	bs.firstPriority, bs.secondPriority = bs.priorities(bs.rwTy, movePeer)
 	if bs.rwTy == write {
-		priorities = bs.sche.conf.WritePriorities
-	}
-	bs.firstPriority = stringToDim(priorities[0])
-	bs.secondPriority = stringToDim(priorities[1])
-
-	if bs.rwTy == write {
-		bs.writeLeaderFirstPriority = statistics.KeyDim
-		if bs.firstPriority == statistics.QueryDim {
-			bs.writeLeaderFirstPriority = statistics.QueryDim
-		}
-		bs.writeLeaderSecondPriority = statistics.ByteDim
+		bs.writeLeaderFirstPriority, bs.writeLeaderSecondPriority = bs.priorities(bs.rwTy, transferLeader)
 	}
 
 	bs.isSelectedDim = func(dim int) bool {
@@ -1296,4 +1288,18 @@ func dimToString(dim int) string {
 	default:
 		return ""
 	}
+}
+
+func (bs *balanceSolver) priorities(rw rwType, op opType) (int, int) {
+	var priorities []string
+	if rw == read {
+		priorities = bs.sche.conf.ReadPriorities
+	} else {
+		if op == transferLeader {
+			priorities = bs.sche.conf.WriteLeaderPriorities
+		} else {
+			priorities = bs.sche.conf.WritePeerPriorities
+		}
+	}
+	return stringToDim(priorities[0]), stringToDim(priorities[1])
 }

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -1292,6 +1292,6 @@ func dimToString(dim int) string {
 	}
 }
 
-func prioritiesTodim(priorities []string) (int, int) {
+func prioritiesTodim(priorities []string) (firstPriority int, secondPriority int) {
 	return stringToDim(priorities[0]), stringToDim(priorities[1])
 }

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -483,9 +483,11 @@ func (bs *balanceSolver) init() {
 
 	// For read, transfer-leader and move-peer have the same priority config
 	// For write, they are different
-	bs.firstPriority, bs.secondPriority = bs.priorities(bs.rwTy, movePeer)
-	if bs.rwTy == write {
-		bs.writeLeaderFirstPriority, bs.writeLeaderSecondPriority = bs.priorities(bs.rwTy, transferLeader)
+	if bs.rwTy == read {
+		bs.firstPriority, bs.secondPriority = prioritiesTodim(bs.sche.conf.ReadPriorities)
+	} else {
+		bs.firstPriority, bs.secondPriority = prioritiesTodim(bs.sche.conf.WritePeerPriorities)
+		bs.writeLeaderFirstPriority, bs.writeLeaderSecondPriority = prioritiesTodim(bs.sche.conf.WritePeerPriorities)
 	}
 
 	bs.isSelectedDim = func(dim int) bool {
@@ -1290,16 +1292,6 @@ func dimToString(dim int) string {
 	}
 }
 
-func (bs *balanceSolver) priorities(rw rwType, op opType) (int, int) {
-	var priorities []string
-	if rw == read {
-		priorities = bs.sche.conf.ReadPriorities
-	} else {
-		if op == transferLeader {
-			priorities = bs.sche.conf.WriteLeaderPriorities
-		} else {
-			priorities = bs.sche.conf.WritePeerPriorities
-		}
-	}
+func prioritiesTodim(priorities []string) (int, int) {
 	return stringToDim(priorities[0]), stringToDim(priorities[1])
 }

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -487,7 +487,7 @@ func (bs *balanceSolver) init() {
 		bs.firstPriority, bs.secondPriority = prioritiesTodim(bs.sche.conf.ReadPriorities)
 	} else {
 		bs.firstPriority, bs.secondPriority = prioritiesTodim(bs.sche.conf.WritePeerPriorities)
-		bs.writeLeaderFirstPriority, bs.writeLeaderSecondPriority = prioritiesTodim(bs.sche.conf.WritePeerPriorities)
+		bs.writeLeaderFirstPriority, bs.writeLeaderSecondPriority = prioritiesTodim(bs.sche.conf.WriteLeaderPriorities)
 	}
 
 	bs.isSelectedDim = func(dim int) bool {

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -56,7 +56,8 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		SrcToleranceRatio:      1.05, // Tolerate 5% difference
 		DstToleranceRatio:      1.05, // Tolerate 5% difference
 		ReadPriorities:         []string{QueryPriority, BytePriority},
-		WritePriorities:        []string{BytePriority, KeyPriority},
+		WriteLeaderPriorities:  []string{KeyPriority, BytePriority},
+		WritePeerPriorities:    []string{BytePriority, KeyPriority},
 		StrictPickingStore:     true,
 	}
 }
@@ -82,7 +83,8 @@ type hotRegionSchedulerConfig struct {
 	SrcToleranceRatio      float64  `json:"src-tolerance-ratio"`
 	DstToleranceRatio      float64  `json:"dst-tolerance-ratio"`
 	ReadPriorities         []string `json:"read-priorities"`
-	WritePriorities        []string `json:"write-priorities"`
+	WriteLeaderPriorities  []string `json:"write-leader-priorities"`
+	WritePeerPriorities    []string `json:"write-peer-priorities"`
 	StrictPickingStore     bool     `json:"strict-picking-store"`
 }
 

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1478,12 +1478,12 @@ func (s *testHotSchedulerSuite) TestHotScheduleWithPriority(c *C) {
 		{1, []uint64{1, 2, 3}, 2 * MB, 1 * MB},
 		{6, []uint64{4, 2, 3}, 1 * MB, 2 * MB},
 	})
-	hb.(*hotScheduler).conf.WritePriorities = []string{BytePriority, KeyPriority}
+	hb.(*hotScheduler).conf.WritePeerPriorities = []string{BytePriority, KeyPriority}
 	ops := hb.Schedule(tc)
 	c.Assert(len(ops), Equals, 1)
 	testutil.CheckTransferPeer(c, ops[0], operator.OpHotRegion, 1, 5)
 	hb.(*hotScheduler).clearPendingInfluence()
-	hb.(*hotScheduler).conf.WritePriorities = []string{KeyPriority, BytePriority}
+	hb.(*hotScheduler).conf.WritePeerPriorities = []string{KeyPriority, BytePriority}
 	ops = hb.Schedule(tc)
 	c.Assert(len(ops), Equals, 1)
 	testutil.CheckTransferPeer(c, ops[0], operator.OpHotRegion, 4, 5)
@@ -1519,7 +1519,7 @@ func (s *testHotSchedulerSuite) TestHotScheduleWithPriority(c *C) {
 	tc.UpdateStorageWrittenStats(3, 6*MB*statistics.StoreHeartBeatReportInterval, 6*MB*statistics.StoreHeartBeatReportInterval)
 	tc.UpdateStorageWrittenStats(4, 6*MB*statistics.StoreHeartBeatReportInterval, 6*MB*statistics.StoreHeartBeatReportInterval)
 	tc.UpdateStorageWrittenStats(5, 1*MB*statistics.StoreHeartBeatReportInterval, 1*MB*statistics.StoreHeartBeatReportInterval)
-	hb.(*hotScheduler).conf.WritePriorities = []string{BytePriority, KeyPriority}
+	hb.(*hotScheduler).conf.WritePeerPriorities = []string{BytePriority, KeyPriority}
 	ops = hb.Schedule(tc)
 	c.Assert(len(ops), Equals, 1)
 	testutil.CheckTransferPeer(c, ops[0], operator.OpHotRegion, 1, 5)
@@ -1530,7 +1530,7 @@ func (s *testHotSchedulerSuite) TestHotScheduleWithPriority(c *C) {
 	tc.UpdateStorageWrittenStats(3, 6*MB*statistics.StoreHeartBeatReportInterval, 6*MB*statistics.StoreHeartBeatReportInterval)
 	tc.UpdateStorageWrittenStats(4, 1*MB*statistics.StoreHeartBeatReportInterval, 10*MB*statistics.StoreHeartBeatReportInterval)
 	tc.UpdateStorageWrittenStats(5, 1*MB*statistics.StoreHeartBeatReportInterval, 1*MB*statistics.StoreHeartBeatReportInterval)
-	hb.(*hotScheduler).conf.WritePriorities = []string{KeyPriority, BytePriority}
+	hb.(*hotScheduler).conf.WritePeerPriorities = []string{KeyPriority, BytePriority}
 	ops = hb.Schedule(tc)
 	c.Assert(len(ops), Equals, 1)
 	testutil.CheckTransferPeer(c, ops[0], operator.OpHotRegion, 4, 5)

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1535,25 +1535,43 @@ func (s *testHotSchedulerSuite) TestHotScheduleWithPriority(c *C) {
 	c.Assert(len(ops), Equals, 1)
 	testutil.CheckTransferPeer(c, ops[0], operator.OpHotRegion, 4, 5)
 	hb.(*hotScheduler).clearPendingInfluence()
-	// test write leader priority schedule
-	hb, err = schedule.CreateScheduler(HotWriteRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
+}
+func (s *testHotSchedulerSuite) TestHotWriteLeaderScheduleWithPriority(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	statistics.Denoising = false
+	opt := config.NewTestOptions()
+	hb, err := schedule.CreateScheduler(HotWriteRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
 	c.Assert(err, IsNil)
-	tc.UpdateStorageWrittenStats(1, 10*MB*statistics.StoreHeartBeatReportInterval, 10*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageWrittenStats(2, 1*MB*statistics.StoreHeartBeatReportInterval, 10*MB*statistics.StoreHeartBeatReportInterval)
-	tc.UpdateStorageWrittenStats(3, 10*MB*statistics.StoreHeartBeatReportInterval, 1*MB*statistics.StoreHeartBeatReportInterval)
+	hb.(*hotScheduler).conf.SetDstToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetSrcToleranceRatio(1)
+
+	tc := mockcluster.NewCluster(ctx, opt)
+	tc.DisableFeature(versioninfo.JointConsensus)
+	tc.SetHotRegionCacheHitsThreshold(0)
+	tc.AddRegionStore(1, 20)
+	tc.AddRegionStore(2, 20)
+	tc.AddRegionStore(3, 20)
+	tc.UpdateStorageWrittenStats(1, 31*MB*statistics.StoreHeartBeatReportInterval, 31*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(2, 10*MB*statistics.StoreHeartBeatReportInterval, 1*MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageWrittenStats(3, 1*MB*statistics.StoreHeartBeatReportInterval, 10*MB*statistics.StoreHeartBeatReportInterval)
+
 	addRegionInfo(tc, write, []testRegionInfo{
-		{1, []uint64{1, 2, 3}, 1 * MB, 1 * MB},
-		{2, []uint64{1, 2, 3}, 1 * MB, 1 * MB},
-		{3, []uint64{1, 2, 3}, 1 * MB, 1 * MB},
+		{1, []uint64{1, 2, 3}, 10 * MB, 10 * MB},
+		{2, []uint64{1, 2, 3}, 10 * MB, 10 * MB},
+		{3, []uint64{1, 2, 3}, 10 * MB, 10 * MB},
+		{4, []uint64{2, 1, 3}, 10 * MB, 0 * MB},
+		{5, []uint64{3, 2, 1}, 0 * MB, 10 * MB},
 	})
+	old := schedulePeerPr
 	schedulePeerPr = 0.0
 	hb.(*hotScheduler).conf.WriteLeaderPriorities = []string{KeyPriority, BytePriority}
-	ops = hb.Schedule(tc)
+	ops := hb.Schedule(tc)
 	c.Assert(len(ops), Equals, 1)
 	testutil.CheckTransferLeader(c, ops[0], operator.OpHotRegion, 1, 2)
 	hb.(*hotScheduler).conf.WriteLeaderPriorities = []string{BytePriority, KeyPriority}
 	ops = hb.Schedule(tc)
 	c.Assert(len(ops), Equals, 1)
 	testutil.CheckTransferLeader(c, ops[0], operator.OpHotRegion, 1, 3)
-	schedulePeerPr = 0.66
+	schedulePeerPr = old
 }

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -310,7 +310,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
 	c.Assert(conf1, DeepEquals, expected1)
 
-	// write-priorities is  divided into write-leader-priorities and write-peer-priorities
+	// write-priorities is divided into write-leader-priorities and write-peer-priorities
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "write-priorities", "key,byte"}, nil)
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
 	c.Assert(conf1, DeepEquals, expected1)

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -271,7 +271,8 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 		"src-tolerance-ratio":        1.05,
 		"dst-tolerance-ratio":        1.05,
 		"read-priorities":            []interface{}{"qps", "byte"},
-		"write-priorities":           []interface{}{"byte", "key"},
+		"write-leader-priorities":    []interface{}{"key", "byte"},
+		"write-peer-priorities":      []interface{}{"byte", "key"},
 		"strict-picking-store":       true,
 	}
 	c.Assert(conf, DeepEquals, expected1)
@@ -306,6 +307,15 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
 	c.Assert(conf1, DeepEquals, expected1)
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "read-priorities", "key,key,byte"}, nil)
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
+	c.Assert(conf1, DeepEquals, expected1)
+
+	// write-priorities is  divided into write-leader-priorities and write-peer-priorities
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "write-priorities", "key,byte"}, nil)
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
+	c.Assert(conf1, DeepEquals, expected1)
+	// cannot set qps as write-peer-priorities
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "write-peer-priorities", "qps,byte"}, nil)
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler"}, &conf1)
 	c.Assert(conf1, DeepEquals, expected1)
 

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -528,7 +528,7 @@ func postSchedulerConfigCommandFunc(cmd *cobra.Command, schedulerName string, ar
 	if err != nil {
 		val = value
 	}
-	if schedulerName == "balance-hot-region-scheduler" && (key == "read-priorities" || key == "write-priorities") {
+	if schedulerName == "balance-hot-region-scheduler" && (key == "read-priorities" || key == "write-leader-priorities" || key == "write-peer-priorities") {
 		priorities := make([]string, 0)
 		prioritiesMap := make(map[string]struct{})
 		for _, priority := range strings.Split(value, ",") {
@@ -537,6 +537,10 @@ func postSchedulerConfigCommandFunc(cmd *cobra.Command, schedulerName string, ar
 					schedulers.BytePriority,
 					schedulers.QueryPriority,
 					schedulers.KeyPriority))
+				return
+			}
+			if priority == schedulers.QueryPriority && key == "write-peer-priorities" {
+				cmd.Println("For hotspot scheduling of write peers, it is not reasonable to use the qps dimension.")
 				return
 			}
 			priorities = append(priorities, priority)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

write-leader and write-peer need to have different priorities because write leader needs to have balanced metrics that reflect the leader, such as sum of key or qps, but write-peer does not, and write-peer does not necessarily have data on qps.

### What is changed and how it works?

set different priorities for write-leader and write-peer

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
