### PR TITLE
scheduler: fix json tag for hot region scheduler config

### DIFF
--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -83,7 +83,7 @@ type hotRegionSchedulerConfig struct {
 	DstToleranceRatio      float64  `json:"dst-tolerance-ratio"`
 	ReadPriorities         []string `json:"read-priorities"`
 	WritePriorities        []string `json:"write-priorities"`
-	StrictPickingStore     bool     `json:"strict-picking-store"`
+	StrictPickingStore     bool     `json:"strict-picking-store,string"`
 }
 
 func (conf *hotRegionSchedulerConfig) EncodeConfig() ([]byte, error) {

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -272,7 +272,7 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 		"dst-tolerance-ratio":        1.05,
 		"read-priorities":            []interface{}{"qps", "byte"},
 		"write-priorities":           []interface{}{"byte", "key"},
-		"strict-picking-store":       true,
+		"strict-picking-store":       "true",
 	}
 	c.Assert(conf, DeepEquals, expected1)
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "src-tolerance-ratio", "1.02"}, nil)


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

fix json tag for hot region scheduler config which will cause pd-ctl setting failed.

![image](https://user-images.githubusercontent.com/13427348/127853879-e1bfb626-0931-48a3-8be6-8a74fe833a47.png)


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
