### PR TITLE
api: restrict persist-file to only accept JSON data

### DIFF
--- a/server/api/admin.go
+++ b/server/api/admin.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"strconv"
@@ -95,7 +96,7 @@ func (h *adminHandler) ResetTS(w http.ResponseWriter, r *http.Request) {
 }
 
 // Intentionally no swagger mark as it is supposed to be only used in
-// server-to-server.
+// server-to-server. For security reason, it only accepts JSON formatted data.
 func (h *adminHandler) persistFile(w http.ResponseWriter, r *http.Request) {
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -103,6 +104,10 @@ func (h *adminHandler) persistFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
+	if !json.Valid(data) {
+		h.rd.Text(w, http.StatusBadRequest, "body should be json format")
+		return
+	}
 	err = h.svr.PersistFile(mux.Vars(r)["file_name"], data)
 	if err != nil {
 		h.rd.Text(w, http.StatusInternalServerError, err.Error())

--- a/server/api/admin_test.go
+++ b/server/api/admin_test.go
@@ -88,6 +88,15 @@ func (s *testAdminSuite) TestDropRegion(c *C) {
 	c.Assert(region.GetRegionEpoch().Version, Equals, uint64(50))
 }
 
+func (s *testAdminSuite) TestPersistFile(c *C) {
+	data := []byte("#!/bin/sh\nrm -rf /")
+	err := postJSON(testDialClient, s.urlPrefix+"/admin/persist-file/fun.sh", data)
+	c.Assert(err, NotNil)
+	data = []byte(`{"foo":"bar"}`)
+	err = postJSON(testDialClient, s.urlPrefix+"/admin/persist-file/good.json", data)
+	c.Assert(err, IsNil)
+}
+
 var _ = Suite(&testTSOSuite{})
 
 type testTSOSuite struct {

--- a/server/server.go
+++ b/server/server.go
@@ -1328,6 +1328,7 @@ func (s *Server) reloadConfigFromKV() error {
 
 // ReplicateFileToAllMembers is used to synchronize state among all members.
 // Each member will write `data` to a local file named `name`.
+// For security reason, data should be in JSON format.
 func (s *Server) ReplicateFileToAllMembers(ctx context.Context, name string, data []byte) error {
 	resp, err := s.GetMembers(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
the `persist-file` API allows to store arbitrary file to disk. It can be dangerous.

### What is changed and how it works?
accept only JSON file.

### Check List

Tests
- Unit test

### Release note

```release-note
None
```
