### PR TITLE
scheduler: use compatible config after upgrading for hot-region

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -45,9 +45,20 @@ func init() {
 	})
 	schedule.RegisterScheduler(HotRegionType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := initHotRegionScheduleConfig()
-		if err := decoder(conf); err != nil {
+
+		var data map[string]interface{}
+		if err := decoder(&data); err != nil {
 			return nil, err
 		}
+		if len(data) != 0 {
+			// After upgrading, use compatible config.
+			// For clusters with the initial version >= v5.2, it will be overwritten by the default config.
+			compatibleConfig.apply(conf)
+			if err := decoder(conf); err != nil {
+				return nil, err
+			}
+		}
+
 		conf.storage = storage
 		return newHotScheduler(opController, conf), nil
 	})
@@ -396,7 +407,7 @@ func (bs *balanceSolver) init() {
 	// For write, they are different
 	switch bs.rwTy {
 	case read:
-		bs.firstPriority, bs.secondPriority = bs.adjustConfig(bs.sche.conf.GetReadPriorities(), getReadLeaderPriorities)
+		bs.firstPriority, bs.secondPriority = bs.adjustConfig(bs.sche.conf.GetReadPriorities(), getReadPriorities)
 	case write:
 		switch bs.opTy {
 		case transferLeader:

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -53,7 +53,7 @@ func init() {
 		if len(data) != 0 {
 			// After upgrading, use compatible config.
 			// For clusters with the initial version >= v5.2, it will be overwritten by the default config.
-			compatibleConfig.apply(conf)
+			conf.apply(compatibleConfig)
 			if err := decoder(conf); err != nil {
 				return nil, err
 			}

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -75,7 +75,7 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		StrictPickingStore:     true,
 		EnableForTiFlash:       true,
 	}
-	defaultConfig.apply(cfg)
+	cfg.apply(defaultConfig)
 	return cfg
 }
 
@@ -318,10 +318,10 @@ type prioritiesConfig struct {
 	writePeer   []string
 }
 
-func (p prioritiesConfig) apply(cfg *hotRegionSchedulerConfig) {
-	cfg.ReadPriorities = append(p.read[:0:0], p.read...)
-	cfg.WriteLeaderPriorities = append(p.writeLeader[:0:0], p.writeLeader...)
-	cfg.WritePeerPriorities = append(p.writePeer[:0:0], p.writePeer...)
+func (conf *hotRegionSchedulerConfig) apply(p prioritiesConfig) {
+	conf.ReadPriorities = append(p.read[:0:0], p.read...)
+	conf.WriteLeaderPriorities = append(p.writeLeader[:0:0], p.writeLeader...)
+	conf.WritePeerPriorities = append(p.writePeer[:0:0], p.writePeer...)
 }
 
 func getReadPriorities(c *prioritiesConfig) []string {

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -308,7 +308,6 @@ func (conf *hotRegionSchedulerConfig) persist() error {
 	data, err := schedule.EncodeConfig(conf)
 	if err != nil {
 		return err
-
 	}
 	return conf.storage.SaveScheduleConfig(HotRegionName, data)
 }

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -44,21 +44,21 @@ const (
 )
 
 var defaultConfig = prioritiesConfig{
-	readLeader:  []string{QueryPriority, BytePriority},
+	read:        []string{QueryPriority, BytePriority},
 	writeLeader: []string{KeyPriority, BytePriority},
 	writePeer:   []string{BytePriority, KeyPriority},
 }
 
 // because tikv below 5.2.0 does not report query information, we will use byte and key as the scheduling dimensions
 var compatibleConfig = prioritiesConfig{
-	readLeader:  []string{BytePriority, KeyPriority},
+	read:        []string{BytePriority, KeyPriority},
 	writeLeader: []string{KeyPriority, BytePriority},
 	writePeer:   []string{BytePriority, KeyPriority},
 }
 
 // params about hot region.
 func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
-	return &hotRegionSchedulerConfig{
+	cfg := &hotRegionSchedulerConfig{
 		MinHotByteRate:         100,
 		MinHotKeyRate:          10,
 		MinHotQueryRate:        10,
@@ -72,12 +72,11 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		MinorDecRatio:          0.99,
 		SrcToleranceRatio:      1.05, // Tolerate 5% difference
 		DstToleranceRatio:      1.05, // Tolerate 5% difference
-		ReadPriorities:         defaultConfig.readLeader,
-		WriteLeaderPriorities:  defaultConfig.writeLeader,
-		WritePeerPriorities:    defaultConfig.writePeer,
 		StrictPickingStore:     true,
 		EnableForTiFlash:       true,
 	}
+	defaultConfig.apply(cfg)
+	return cfg
 }
 
 type hotRegionSchedulerConfig struct {
@@ -315,13 +314,19 @@ func (conf *hotRegionSchedulerConfig) persist() error {
 }
 
 type prioritiesConfig struct {
-	readLeader  []string
+	read        []string
 	writeLeader []string
 	writePeer   []string
 }
 
-func getReadLeaderPriorities(c *prioritiesConfig) []string {
-	return c.readLeader
+func (p prioritiesConfig) apply(cfg *hotRegionSchedulerConfig) {
+	cfg.ReadPriorities = append(p.read[:0:0], p.read...)
+	cfg.WriteLeaderPriorities = append(p.writeLeader[:0:0], p.writeLeader...)
+	cfg.WritePeerPriorities = append(p.writePeer[:0:0], p.writePeer...)
+}
+
+func getReadPriorities(c *prioritiesConfig) []string {
+	return c.read
 }
 
 func getWriteLeaderPriorities(c *prioritiesConfig) []string {

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -59,15 +59,16 @@ func newHotWriteScheduler(opController *schedule.OperatorController, conf *hotRe
 }
 
 type testHotSchedulerSuite struct{}
+type testHotReadRegionSchedulerSuite struct{}
+type testHotWriteRegionSchedulerSuite struct{}
 type testInfluenceSerialSuite struct{}
 type testHotCacheSuite struct{}
-type testHotReadRegionSchedulerSuite struct{}
 
-var _ = Suite(&testHotWriteRegionSchedulerSuite{})
 var _ = Suite(&testHotSchedulerSuite{})
 var _ = Suite(&testHotReadRegionSchedulerSuite{})
-var _ = Suite(&testHotCacheSuite{})
+var _ = Suite(&testHotWriteRegionSchedulerSuite{})
 var _ = SerialSuites(&testInfluenceSerialSuite{})
+var _ = Suite(&testHotCacheSuite{})
 
 func (s *testHotSchedulerSuite) TestGCPendingOpInfos(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -149,8 +150,6 @@ func newTestRegion(id uint64) *core.RegionInfo {
 	peers := []*metapb.Peer{{Id: id*100 + 1, StoreId: 1}, {Id: id*100 + 2, StoreId: 2}, {Id: id*100 + 3, StoreId: 3}}
 	return core.NewRegionInfo(&metapb.Region{Id: id, Peers: peers}, peers[0])
 }
-
-type testHotWriteRegionSchedulerSuite struct{}
 
 func (s *testHotWriteRegionSchedulerSuite) TestByteRateOnly(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1735,7 +1734,7 @@ func loadsEqual(loads1, loads2 []float64) bool {
 	return true
 }
 
-func (s *testHotSchedulerSuite) TestHotReadPeerSchedule(c *C) {
+func (s *testHotReadRegionSchedulerSuite) TestHotReadPeerSchedule(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	opt := config.NewTestOptions()
@@ -1850,7 +1849,7 @@ func (s *testHotSchedulerSuite) TestHotScheduleWithPriority(c *C) {
 	hb.(*hotScheduler).clearPendingInfluence()
 }
 
-func (s *testHotSchedulerSuite) TestHotWriteLeaderScheduleWithPriority(c *C) {
+func (s *testHotWriteRegionSchedulerSuite) TestHotWriteLeaderScheduleWithPriority(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	statistics.Denoising = false
@@ -1947,6 +1946,64 @@ func (s *testHotSchedulerSuite) TestCompatibility(c *C) {
 	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
 		{statistics.ByteDim, statistics.KeyDim},
 		{statistics.KeyDim, statistics.ByteDim},
+		{statistics.ByteDim, statistics.KeyDim},
+	})
+}
+
+func (s *testHotSchedulerSuite) TestCompatibilityConfig(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := config.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+
+	// From new or 3.x cluster
+	hb, err := schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, tc, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder("hot-region", nil))
+	c.Assert(err, IsNil)
+	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
+		{statistics.QueryDim, statistics.ByteDim},
+		{statistics.KeyDim, statistics.ByteDim},
+		{statistics.ByteDim, statistics.KeyDim},
+	})
+
+	// from 4.0 or 5.0 or 5.1 cluster
+	var data []byte
+	storage := core.NewStorage(kv.NewMemoryKV())
+	data, err = schedule.EncodeConfig(map[string]interface{}{
+		"min-hot-byte-rate":         100,
+		"min-hot-key-rate":          10,
+		"max-zombie-rounds":         3,
+		"max-peer-number":           1000,
+		"byte-rate-rank-step-ratio": 0.05,
+		"key-rate-rank-step-ratio":  0.05,
+		"count-rank-step-ratio":     0.01,
+		"great-dec-ratio":           0.95,
+		"minor-dec-ratio":           0.99,
+		"src-tolerance-ratio":       1.05,
+		"dst-tolerance-ratio":       1.05,
+	})
+	err = storage.SaveScheduleConfig(HotRegionName, data)
+	c.Assert(err, IsNil)
+	hb, err = schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, tc, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigJSONDecoder(data))
+	c.Assert(err, IsNil)
+	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
+		{statistics.ByteDim, statistics.KeyDim},
+		{statistics.KeyDim, statistics.ByteDim},
+		{statistics.ByteDim, statistics.KeyDim},
+	})
+
+	// From configured cluster
+	storage = core.NewStorage(kv.NewMemoryKV())
+	cfg := initHotRegionScheduleConfig()
+	cfg.ReadPriorities = []string{"query", "key"}
+	cfg.WriteLeaderPriorities = []string{"query", "key"}
+	data, err = schedule.EncodeConfig(cfg)
+	err = storage.SaveScheduleConfig(HotRegionName, data)
+	c.Assert(err, IsNil)
+	hb, err = schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigJSONDecoder(data))
+	c.Assert(err, IsNil)
+	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
+		{statistics.QueryDim, statistics.KeyDim},
+		{statistics.QueryDim, statistics.KeyDim},
 		{statistics.ByteDim, statistics.KeyDim},
 	})
 }

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1965,6 +1965,16 @@ func (s *testHotSchedulerSuite) TestCompatibilityConfig(c *C) {
 		{statistics.ByteDim, statistics.KeyDim},
 	})
 
+	// Config file is not currently supported
+	hb, err = schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, tc, nil), core.NewStorage(kv.NewMemoryKV()),
+		schedule.ConfigSliceDecoder("hot-region", []string{"read-priorities=byte,query"}))
+	c.Assert(err, IsNil)
+	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
+		{statistics.QueryDim, statistics.ByteDim},
+		{statistics.KeyDim, statistics.ByteDim},
+		{statistics.ByteDim, statistics.KeyDim},
+	})
+
 	// from 4.0 or 5.0 or 5.1 cluster
 	var data []byte
 	storage := core.NewStorage(kv.NewMemoryKV())
@@ -1994,7 +2004,7 @@ func (s *testHotSchedulerSuite) TestCompatibilityConfig(c *C) {
 	// From configured cluster
 	storage = core.NewStorage(kv.NewMemoryKV())
 	cfg := initHotRegionScheduleConfig()
-	cfg.ReadPriorities = []string{"query", "key"}
+	cfg.ReadPriorities = []string{"key", "query"}
 	cfg.WriteLeaderPriorities = []string{"query", "key"}
 	data, err = schedule.EncodeConfig(cfg)
 	err = storage.SaveScheduleConfig(HotRegionName, data)
@@ -2002,7 +2012,7 @@ func (s *testHotSchedulerSuite) TestCompatibilityConfig(c *C) {
 	hb, err = schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigJSONDecoder(data))
 	c.Assert(err, IsNil)
 	checkPriority(c, hb.(*hotScheduler), tc, [3][2]int{
-		{statistics.QueryDim, statistics.KeyDim},
+		{statistics.KeyDim, statistics.QueryDim},
 		{statistics.QueryDim, statistics.KeyDim},
 		{statistics.ByteDim, statistics.KeyDim},
 	})

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1991,6 +1991,7 @@ func (s *testHotSchedulerSuite) TestCompatibilityConfig(c *C) {
 		"src-tolerance-ratio":       1.05,
 		"dst-tolerance-ratio":       1.05,
 	})
+	c.Assert(err, IsNil)
 	err = storage.SaveScheduleConfig(HotRegionName, data)
 	c.Assert(err, IsNil)
 	hb, err = schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, tc, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigJSONDecoder(data))
@@ -2007,6 +2008,7 @@ func (s *testHotSchedulerSuite) TestCompatibilityConfig(c *C) {
 	cfg.ReadPriorities = []string{"key", "query"}
 	cfg.WriteLeaderPriorities = []string{"query", "key"}
 	data, err = schedule.EncodeConfig(cfg)
+	c.Assert(err, IsNil)
 	err = storage.SaveScheduleConfig(HotRegionName, data)
 	c.Assert(err, IsNil)
 	hb, err = schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigJSONDecoder(data))


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

scheduler: use compatible config after upgrading for hot-region

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
