### PR TITLE
test: move check package into test packages

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -40,6 +40,9 @@ import (
 )
 
 func main() {
+	if flag.Lookup("check.v") != nil {
+		panic("check.v flag set")
+	}
 	cfg := config.NewConfig()
 	err := cfg.Parse(os.Args[1:])
 

--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -40,9 +40,6 @@ import (
 )
 
 func main() {
-	if flag.Lookup("check.v") != nil {
-		panic("check.v flag set")
-	}
 	cfg := config.NewConfig()
 	err := cfg.Parse(os.Args[1:])
 

--- a/pkg/assertutil/assertutil.go
+++ b/pkg/assertutil/assertutil.go
@@ -20,6 +20,7 @@ type Checker struct {
 	FailNow func()
 }
 
+// NewChecker creates Checker with FailNow function.
 func NewChecker(failNow func()) *Checker {
 	return &Checker{
 		FailNow: failNow,
@@ -30,6 +31,7 @@ func (c *Checker) failNow() {
 	c.FailNow()
 }
 
+// AssertNil calls the injected IsNil assertion.
 func (c *Checker) AssertNil(obtained interface{}) {
 	if c.IsNil == nil {
 		c.failNow()

--- a/pkg/assertutil/assertutil.go
+++ b/pkg/assertutil/assertutil.go
@@ -1,16 +1,28 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package assertutil
 
-// Checker accepts the injection of check functions and context from test files
+// Checker accepts the injection of check functions and context from test files.
+// Any check function should be set before usage unless the test will fail.
 type Checker struct {
-	IsNil     func(obtained interface{})
-	Equal     func(obtained, expected interface{})
-	DeepEqual func(obtained, expected interface{})
-	FailNow   func()
+	IsNil   func(obtained interface{})
+	FailNow func()
 }
 
-func NewChecker(failnow func()) *Checker {
+func NewChecker(failNow func()) *Checker {
 	return &Checker{
-		FailNow: failnow,
+		FailNow: failNow,
 	}
 }
 
@@ -23,18 +35,4 @@ func (c *Checker) AssertNil(obtained interface{}) {
 		c.failNow()
 	}
 	c.IsNil(obtained)
-}
-
-func (c *Checker) AssertEqual(obtained, expected interface{}) {
-	if c.Equal == nil {
-		c.failNow()
-	}
-	c.Equal(obtained, expected)
-}
-
-func (c *Checker) AssertDeepEqual(obtained, expected interface{}) {
-	if c.DeepEqual == nil {
-		c.failNow()
-	}
-	c.DeepEqual(obtained, expected)
 }

--- a/pkg/assertutil/assertutil.go
+++ b/pkg/assertutil/assertutil.go
@@ -35,6 +35,7 @@ func (c *Checker) failNow() {
 func (c *Checker) AssertNil(obtained interface{}) {
 	if c.IsNil == nil {
 		c.failNow()
+		return
 	}
 	c.IsNil(obtained)
 }

--- a/pkg/assertutil/assertutil.go
+++ b/pkg/assertutil/assertutil.go
@@ -1,0 +1,40 @@
+package assertutil
+
+// Checker accepts the injection of check functions and context from test files
+type Checker struct {
+	IsNil     func(obtained interface{})
+	Equal     func(obtained, expected interface{})
+	DeepEqual func(obtained, expected interface{})
+	FailNow   func()
+}
+
+func NewChecker(failnow func()) *Checker {
+	return &Checker{
+		FailNow: failnow,
+	}
+}
+
+func (c *Checker) failNow() {
+	c.FailNow()
+}
+
+func (c *Checker) AssertNil(obtained interface{}) {
+	if c.IsNil == nil {
+		c.failNow()
+	}
+	c.IsNil(obtained)
+}
+
+func (c *Checker) AssertEqual(obtained, expected interface{}) {
+	if c.Equal == nil {
+		c.failNow()
+	}
+	c.Equal(obtained, expected)
+}
+
+func (c *Checker) AssertDeepEqual(obtained, expected interface{}) {
+	if c.DeepEqual == nil {
+		c.failNow()
+	}
+	c.DeepEqual(obtained, expected)
+}

--- a/pkg/assertutil/assertutil_test.go
+++ b/pkg/assertutil/assertutil_test.go
@@ -1,0 +1,39 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assertutil
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/pingcap/check"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+var _ = check.Suite(&testAssertUtilSuite{})
+
+type testAssertUtilSuite struct{}
+
+func (s *testAssertUtilSuite) TestNilFail(c *check.C) {
+	var failErr error
+	checker := NewChecker(func() {
+		failErr = errors.New("called assert func not exist")
+	})
+	c.Assert(checker.IsNil, check.IsNil)
+	checker.AssertNil(nil)
+	c.Assert(failErr, check.NotNil)
+}

--- a/server/api/server_test.go
+++ b/server/api/server_test.go
@@ -78,7 +78,7 @@ var zapLogOnce sync.Once
 func mustNewCluster(c *C, num int, opts ...func(cfg *config.Config)) ([]*config.Config, []*server.Server, cleanUpFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	svrs := make([]*server.Server, 0, num)
-	cfgs := server.NewTestMultiConfig(c, num)
+	cfgs := server.NewTestMultiConfig(checkerWithNilAssert(c), num)
 
 	ch := make(chan *server.Server, num)
 	for _, cfg := range cfgs {

--- a/server/api/version_test.go
+++ b/server/api/version_test.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tikv/pd/pkg/assertutil"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
+	"github.com/tikv/pd/pkg/assertutil"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/config"

--- a/server/api/version_test.go
+++ b/server/api/version_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tikv/pd/pkg/assertutil"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/tikv/pd/pkg/testutil"
@@ -29,6 +31,14 @@ import (
 )
 
 var _ = Suite(&testVersionSuite{})
+
+func checkerWithNilAssert(c *C) *assertutil.Checker {
+	checker := assertutil.NewChecker(c.FailNow)
+	checker.IsNil = func(obtained interface{}) {
+		c.Assert(obtained, IsNil)
+	}
+	return checker
+}
 
 type testVersionSuite struct{}
 
@@ -41,7 +51,7 @@ func (s *testVersionSuite) TestGetVersion(c *C) {
 	temp, _ := os.Create(fname)
 	os.Stdout = temp
 
-	cfg := server.NewTestSingleConfig(c)
+	cfg := server.NewTestSingleConfig(checkerWithNilAssert(c))
 	reqCh := make(chan struct{})
 	go func() {
 		<-reqCh

--- a/server/join/join_test.go
+++ b/server/join/join_test.go
@@ -16,6 +16,8 @@ package join
 import (
 	"testing"
 
+	"github.com/tikv/pd/pkg/assertutil"
+
 	. "github.com/pingcap/check"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server"
@@ -29,9 +31,17 @@ var _ = Suite(&testJoinServerSuite{})
 
 type testJoinServerSuite struct{}
 
+func checkerWithNilAssert(c *C) *assertutil.Checker {
+	checker := assertutil.NewChecker(c.FailNow)
+	checker.IsNil = func(obtained interface{}) {
+		c.Assert(obtained, IsNil)
+	}
+	return checker
+}
+
 // A PD joins itself.
 func (s *testJoinServerSuite) TestPDJoinsItself(c *C) {
-	cfg := server.NewTestSingleConfig(c)
+	cfg := server.NewTestSingleConfig(checkerWithNilAssert(c))
 	defer testutil.CleanServer(cfg.DataDir)
 	cfg.Join = cfg.AdvertiseClientUrls
 	c.Assert(PrepareJoinCluster(cfg), NotNil)

--- a/server/join/join_test.go
+++ b/server/join/join_test.go
@@ -16,9 +16,8 @@ package join
 import (
 	"testing"
 
-	"github.com/tikv/pd/pkg/assertutil"
-
 	. "github.com/pingcap/check"
+	"github.com/tikv/pd/pkg/assertutil"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server"
 )

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/tikv/pd/pkg/assertutil"
+
 	. "github.com/pingcap/check"
 	"github.com/tikv/pd/pkg/etcdutil"
 	"github.com/tikv/pd/pkg/testutil"
@@ -52,6 +54,14 @@ func mustWaitLeader(c *C, svrs []*Server) *Server {
 	return leader
 }
 
+func checkerWithNilAssert(c *C) *assertutil.Checker {
+	checker := assertutil.NewChecker(c.FailNow)
+	checker.IsNil = func(obtained interface{}) {
+		c.Assert(obtained, IsNil)
+	}
+	return checker
+}
+
 var _ = Suite(&testLeaderServerSuite{})
 
 type testLeaderServerSuite struct {
@@ -65,7 +75,7 @@ func (s *testLeaderServerSuite) SetUpSuite(c *C) {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.svrs = make(map[string]*Server)
 
-	cfgs := NewTestMultiConfig(c, 3)
+	cfgs := NewTestMultiConfig(checkerWithNilAssert(c), 3)
 
 	ch := make(chan *Server, 3)
 	for i := 0; i < 3; i++ {
@@ -144,7 +154,7 @@ func newTestServersWithCfgs(ctx context.Context, c *C, cfgs []*config.Config) ([
 func (s *testServerSuite) TestCheckClusterID(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cfgs := NewTestMultiConfig(c, 2)
+	cfgs := NewTestMultiConfig(checkerWithNilAssert(c), 2)
 	for i, cfg := range cfgs {
 		cfg.DataDir = fmt.Sprintf("/tmp/test_pd_check_clusterID_%d", i)
 		// Clean up before testing.
@@ -201,7 +211,7 @@ func (s *testServerHandlerSuite) TestRegisterServerHandler(c *C) {
 		}
 		return mux, info, nil
 	}
-	cfg := NewTestSingleConfig(c)
+	cfg := NewTestSingleConfig(checkerWithNilAssert(c))
 	ctx, cancel := context.WithCancel(context.Background())
 	svr, err := CreateServer(ctx, cfg, mokHandler)
 	c.Assert(err, IsNil)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -20,9 +20,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/tikv/pd/pkg/assertutil"
-
 	. "github.com/pingcap/check"
+	"github.com/tikv/pd/pkg/assertutil"
 	"github.com/tikv/pd/pkg/etcdutil"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server/config"

--- a/server/testutil.go
+++ b/server/testutil.go
@@ -21,10 +21,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/check"
 	"github.com/pingcap/log"
+	"github.com/tikv/pd/pkg/assertutil"
 	"github.com/tikv/pd/pkg/tempurl"
-	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/config"
 	"go.etcd.io/etcd/embed"
@@ -37,7 +36,7 @@ import (
 type CleanupFunc func()
 
 // NewTestServer creates a pd server for testing.
-func NewTestServer(c *check.C) (*Server, CleanupFunc, error) {
+func NewTestServer(c *assertutil.Checker) (*Server, CleanupFunc, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cfg := NewTestSingleConfig(c)
 	s, err := CreateServer(ctx, cfg)
@@ -53,7 +52,7 @@ func NewTestServer(c *check.C) (*Server, CleanupFunc, error) {
 	cleanup := func() {
 		cancel()
 		s.Close()
-		testutil.CleanServer(cfg.DataDir)
+		os.RemoveAll(cfg.DataDir)
 	}
 	return s, cleanup, nil
 }
@@ -62,7 +61,7 @@ var zapLogOnce sync.Once
 
 // NewTestSingleConfig is only for test to create one pd.
 // Because PD client also needs this, so export here.
-func NewTestSingleConfig(c *check.C) *config.Config {
+func NewTestSingleConfig(c *assertutil.Checker) *config.Config {
 	cfg := &config.Config{
 		Name:       "pd",
 		ClientUrls: tempurl.Alloc(),
@@ -83,19 +82,19 @@ func NewTestSingleConfig(c *check.C) *config.Config {
 	cfg.ElectionInterval = typeutil.NewDuration(3 * time.Second)
 	cfg.LeaderPriorityCheckInterval = typeutil.NewDuration(100 * time.Millisecond)
 	err := cfg.SetupLogger()
-	c.Assert(err, check.IsNil)
+	c.AssertNil(err)
 	zapLogOnce.Do(func() {
 		log.ReplaceGlobals(cfg.GetZapLogger(), cfg.GetZapLogProperties())
 	})
 
-	c.Assert(cfg.Adjust(nil, false), check.IsNil)
+	c.AssertNil(cfg.Adjust(nil, false))
 
 	return cfg
 }
 
 // NewTestMultiConfig is only for test to create multiple pd configurations.
 // Because PD client also needs this, so export here.
-func NewTestMultiConfig(c *check.C, count int) []*config.Config {
+func NewTestMultiConfig(c *assertutil.Checker, count int) []*config.Config {
 	cfgs := make([]*config.Config, count)
 
 	clusters := []string{}

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tikv/pd/pkg/assertutil"
+
 	"github.com/gogo/protobuf/proto"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
@@ -519,9 +521,17 @@ type testClientSuite struct {
 	regionHeartbeat pdpb.PD_RegionHeartbeatClient
 }
 
+func checkerWithNilAssert(c *C) *assertutil.Checker {
+	checker := assertutil.NewChecker(c.FailNow)
+	checker.IsNil = func(obtained interface{}) {
+		c.Assert(obtained, IsNil)
+	}
+	return checker
+}
+
 func (s *testClientSuite) SetUpSuite(c *C) {
 	var err error
-	s.srv, s.cleanup, err = server.NewTestServer(c)
+	s.srv, s.cleanup, err = server.NewTestServer(checkerWithNilAssert(c))
 	c.Assert(err, IsNil)
 	s.grpcPDClient = testutil.MustNewGrpcClient(c, s.srv.GetAddr())
 

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -25,14 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tikv/pd/pkg/assertutil"
-
 	"github.com/gogo/protobuf/proto"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/pkg/assertutil"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/pkg/tsoutil"

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -24,12 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tikv/pd/pkg/assertutil"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/tikv/pd/pkg/assertutil"
 	"github.com/tikv/pd/pkg/etcdutil"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server"

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tikv/pd/pkg/assertutil"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -42,6 +44,14 @@ func Test(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func checkerWithNilAssert(c *C) *assertutil.Checker {
+	checker := assertutil.NewChecker(c.FailNow)
+	checker.IsNil = func(obtained interface{}) {
+		c.Assert(obtained, IsNil)
+	}
+	return checker
 }
 
 var _ = Suite(&memberTestSuite{})
@@ -320,7 +330,7 @@ type leaderTestSuite struct {
 
 func (s *leaderTestSuite) SetUpSuite(c *C) {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	s.cfg = server.NewTestSingleConfig(c)
+	s.cfg = server.NewTestSingleConfig(checkerWithNilAssert(c))
 	s.wg.Add(1)
 	s.done = make(chan bool)
 	svr, err := server.CreateServer(s.ctx, s.cfg)


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

PD imports [check](https://github.com/pingcap/check) in some un-test packages. This makes a flag pollution like `check.v` appears in production environment, more details can be found in pingcap/tidb#27156.

This PR removes the imports of check lib not in test packages.

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch
  - 5.0

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Please add a release note.

If you don't think this PR needs a release note then fill it with None.
```
