### PR TITLE
schedule: add split checker for region splits

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/core/storelimit"
 	"github.com/tikv/pd/server/kv"
+	"github.com/tikv/pd/server/schedule/labeler"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/statistics"
 	"github.com/tikv/pd/server/versioninfo"
@@ -46,6 +47,7 @@ type Cluster struct {
 	*core.BasicCluster
 	*mockid.IDAllocator
 	*placement.RuleManager
+	*labeler.RegionLabeler
 	*statistics.HotStat
 	*config.PersistOptions
 	ID               uint64
@@ -67,6 +69,7 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 	if clus.PersistOptions.GetReplicationConfig().EnablePlacementRules {
 		clus.initRuleManager()
 	}
+	clus.RegionLabeler, _ = labeler.NewRegionLabeler(core.NewStorage(kv.NewMemoryKV()))
 	return clus
 }
 
@@ -168,6 +171,11 @@ func (mc *Cluster) FitRegion(region *core.RegionInfo) *placement.RegionFit {
 // GetRuleManager returns the ruleManager of the cluster.
 func (mc *Cluster) GetRuleManager() *placement.RuleManager {
 	return mc.RuleManager
+}
+
+// GetRegionLabeler returns the region labeler of the cluster.
+func (mc *Cluster) GetRegionLabeler() *labeler.RegionLabeler {
+	return mc.RegionLabeler
 }
 
 // SetStoreUp sets store state to be up.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/id"
 	"github.com/tikv/pd/server/kv"
+	"github.com/tikv/pd/server/schedule/labeler"
 	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/statistics"
@@ -1085,6 +1086,7 @@ func newTestCluster(ctx context.Context, opt *config.PersistOptions) *testCluste
 			panic(err)
 		}
 	}
+	rc.regionLabeler, _ = labeler.NewRegionLabeler(storage)
 
 	return &testCluster{RaftCluster: rc}
 }

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -78,7 +78,7 @@ func newCoordinator(ctx context.Context, cluster *RaftCluster, hbStreams *hbstre
 		ctx:             ctx,
 		cancel:          cancel,
 		cluster:         cluster,
-		checkers:        schedule.NewCheckerController(ctx, cluster, cluster.ruleManager, opController),
+		checkers:        schedule.NewCheckerController(ctx, cluster, cluster.ruleManager, cluster.regionLabeler, opController),
 		regionScatterer: schedule.NewRegionScatterer(ctx, cluster),
 		regionSplitter:  schedule.NewRegionSplitter(cluster, schedule.NewSplitRegionsHandler(cluster, opController)),
 		schedulers:      make(map[string]*scheduleController),

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/pkg/errs"
@@ -70,10 +69,8 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 	c.record.refresh(c.cluster)
 
 	if len(fit.RuleFits) == 0 {
-		checkerCounter.WithLabelValues("rule_checker", "fix-range").Inc()
-		// If the region matches no rules, the most possible reason is it spans across
-		// multiple rules.
-		return c.fixRange(region)
+		checkerCounter.WithLabelValues("rule_checker", "need-split").Inc()
+		return nil
 	}
 	op, err := c.fixOrphanPeers(region, fit)
 	if err == nil && op != nil {
@@ -91,21 +88,6 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 		}
 	}
 	return nil
-}
-
-func (c *RuleChecker) fixRange(region *core.RegionInfo) *operator.Operator {
-	keys := c.ruleManager.GetSplitKeys(region.GetStartKey(), region.GetEndKey())
-	if len(keys) == 0 {
-		return nil
-	}
-
-	op, err := operator.CreateSplitRegionOperator("rule-split-region", region, 0, pdpb.CheckPolicy_USEKEY, keys)
-	if err != nil {
-		log.Debug("create split region operator failed", errs.ZapError(err))
-		return nil
-	}
-
-	return op
 }
 
 func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (*operator.Operator, error) {

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -70,6 +70,8 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 
 	if len(fit.RuleFits) == 0 {
 		checkerCounter.WithLabelValues("rule_checker", "need-split").Inc()
+		// If the region matches no rules, the most possible reason is it spans across
+		// multiple rules.
 		return nil
 	}
 	op, err := c.fixOrphanPeers(region, fit)

--- a/server/schedule/checker/rule_checker_test.go
+++ b/server/schedule/checker/rule_checker_test.go
@@ -16,7 +16,6 @@ package checker
 
 import (
 	"context"
-	"encoding/hex"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -56,27 +55,6 @@ func (s *testRuleCheckerSuite) SetUpTest(c *C) {
 	s.cluster.SetEnablePlacementRules(true)
 	s.ruleManager = s.cluster.RuleManager
 	s.rc = NewRuleChecker(s.cluster, s.ruleManager, cache.NewDefaultCache(10))
-}
-
-func (s *testRuleCheckerSuite) TestFixRange(c *C) {
-	s.cluster.AddLeaderStore(1, 1)
-	s.cluster.AddLeaderStore(2, 1)
-	s.cluster.AddLeaderStore(3, 1)
-	s.ruleManager.SetRule(&placement.Rule{
-		GroupID:     "test",
-		ID:          "test",
-		StartKeyHex: "AA",
-		EndKeyHex:   "FF",
-		Role:        placement.Voter,
-		Count:       1,
-	})
-	s.cluster.AddLeaderRegionWithRange(1, "", "", 1, 2, 3)
-	op := s.rc.Check(s.cluster.GetRegion(1))
-	c.Assert(op, NotNil)
-	c.Assert(op.Len(), Equals, 1)
-	splitKeys := op.Step(0).(operator.SplitRegion).SplitKeys
-	c.Assert(hex.EncodeToString(splitKeys[0]), Equals, "aa")
-	c.Assert(hex.EncodeToString(splitKeys[1]), Equals, "ff")
 }
 
 func (s *testRuleCheckerSuite) TestAddRulePeer(c *C) {

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -50,15 +50,16 @@ func (c *SplitChecker) GetType() string {
 func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 	checkerCounter.WithLabelValues("split_checker", "check").Inc()
 
+	start, end := region.GetStartKey(), region.GetEndKey()
 	// We may consider to merge labeler split keys and rule split keys together
 	// before creating operator. It can help to reduce operator count. However,
 	// handle them separately helps to understand the reason for the split.
 	desc := "labeler-split-region"
-	keys := c.labeler.GetSplitKeys(region.GetStartKey(), region.GetEndKey())
+	keys := c.labeler.GetSplitKeys(start, end)
 
 	if len(keys) == 0 && c.cluster.GetOpts().IsPlacementRulesEnabled() {
 		desc = "rule-split-region"
-		keys = c.ruleManager.GetSplitKeys(region.GetStartKey(), region.GetEndKey())
+		keys = c.ruleManager.GetSplitKeys(start, end)
 	}
 
 	if len(keys) == 0 {

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -1,0 +1,74 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule/labeler"
+	"github.com/tikv/pd/server/schedule/operator"
+	"github.com/tikv/pd/server/schedule/opt"
+	"github.com/tikv/pd/server/schedule/placement"
+)
+
+// SplitChecker splits regions when the key range spans across rule/label boundary.
+type SplitChecker struct {
+	cluster     opt.Cluster
+	ruleManager *placement.RuleManager
+	labeler     *labeler.RegionLabeler
+}
+
+// NewSplitChecker creates a new SplitChecker.
+func NewSplitChecker(cluster opt.Cluster, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler) *SplitChecker {
+	return &SplitChecker{
+		cluster:     cluster,
+		ruleManager: ruleManager,
+		labeler:     labeler,
+	}
+}
+
+// GetType returns the checker type.
+func (c *SplitChecker) GetType() string {
+	return "split-checker"
+}
+
+// Check checks whether the region need to split and returns Operator to fix.
+func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
+	checkerCounter.WithLabelValues("split_checker", "check").Inc()
+
+	// We may consider to merge labeler split keys and rule split keys together
+	// before creating operator. It can help to reduce operator count. However,
+	// handle them separately helps to understand the reason for the split.
+	desc := "labeler-split-region"
+	keys := c.labeler.GetSplitKeys(region.GetStartKey(), region.GetEndKey())
+
+	if len(keys) == 0 && c.cluster.GetOpts().IsPlacementRulesEnabled() {
+		desc = "rule-split-region"
+		keys = c.ruleManager.GetSplitKeys(region.GetStartKey(), region.GetEndKey())
+	}
+
+	if len(keys) == 0 {
+		return nil
+	}
+
+	op, err := operator.CreateSplitRegionOperator(desc, region, 0, pdpb.CheckPolicy_USEKEY, keys)
+	if err != nil {
+		log.Debug("create split region operator failed", errs.ZapError(err))
+		return nil
+	}
+	return op
+}

--- a/server/schedule/checker/split_checker_test.go
+++ b/server/schedule/checker/split_checker_test.go
@@ -1,0 +1,88 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"context"
+	"encoding/hex"
+
+	. "github.com/pingcap/check"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/server/schedule/labeler"
+	"github.com/tikv/pd/server/schedule/operator"
+	"github.com/tikv/pd/server/schedule/placement"
+)
+
+var _ = Suite(&testSplitCheckerSuite{})
+
+type testSplitCheckerSuite struct {
+	cluster     *mockcluster.Cluster
+	ruleManager *placement.RuleManager
+	labeler     *labeler.RegionLabeler
+	sc          *SplitChecker
+	ctx         context.Context
+	cancel      context.CancelFunc
+}
+
+func (s *testSplitCheckerSuite) SetUpSuite(c *C) {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+}
+
+func (s *testSplitCheckerSuite) TearDownTest(c *C) {
+	s.cancel()
+}
+
+func (s *testSplitCheckerSuite) SetUpTest(c *C) {
+	cfg := config.NewTestOptions()
+	cfg.GetReplicationConfig().EnablePlacementRules = true
+	s.cluster = mockcluster.NewCluster(s.ctx, cfg)
+	s.ruleManager = s.cluster.RuleManager
+	s.labeler = s.cluster.RegionLabeler
+	s.sc = NewSplitChecker(s.cluster, s.ruleManager, s.labeler)
+}
+
+func (s *testSplitCheckerSuite) TestSplit(c *C) {
+	s.cluster.AddLeaderStore(1, 1)
+	s.ruleManager.SetRule(&placement.Rule{
+		GroupID:     "test",
+		ID:          "test",
+		StartKeyHex: "aa",
+		EndKeyHex:   "cc",
+		Role:        placement.Voter,
+		Count:       1,
+	})
+	s.cluster.AddLeaderRegionWithRange(1, "", "", 1)
+	op := s.sc.Check(s.cluster.GetRegion(1))
+	c.Assert(op, NotNil)
+	c.Assert(op.Len(), Equals, 1)
+	splitKeys := op.Step(0).(operator.SplitRegion).SplitKeys
+	c.Assert(hex.EncodeToString(splitKeys[0]), Equals, "aa")
+	c.Assert(hex.EncodeToString(splitKeys[1]), Equals, "cc")
+
+	// region label has higher priority.
+	s.labeler.SetLabelRule(&labeler.LabelRule{
+		ID:       "test",
+		Labels:   []labeler.RegionLabel{{Key: "test", Value: "test"}},
+		RuleType: labeler.KeyRange,
+		Rule:     map[string]interface{}{"start_key": "bb", "end_key": "dd"},
+	})
+	op = s.sc.Check(s.cluster.GetRegion(1))
+	c.Assert(op, NotNil)
+	c.Assert(op.Len(), Equals, 1)
+	splitKeys = op.Step(0).(operator.SplitRegion).SplitKeys
+	c.Assert(hex.EncodeToString(splitKeys[0]), Equals, "bb")
+	c.Assert(hex.EncodeToString(splitKeys[1]), Equals, "dd")
+}

--- a/server/schedule/labeler/labeler.go
+++ b/server/schedule/labeler/labeler.go
@@ -140,6 +140,13 @@ func (l *RegionLabeler) buildRangeList() {
 	l.rangeList = builder.Build()
 }
 
+// GetSplitKeys returns all split keys in the range (start, end).
+func (l *RegionLabeler) GetSplitKeys(start, end []byte) [][]byte {
+	l.RLock()
+	defer l.RUnlock()
+	return l.rangeList.GetSplitKeys(start, end)
+}
+
 // GetAllLabelRules returns all the rules.
 func (l *RegionLabeler) GetAllLabelRules() []*LabelRule {
 	l.RLock()


### PR DESCRIPTION
### What problem does this PR solve?

Fix https://github.com/tikv/pd/issues/4000

Now that both placement rules and region labels need to split region based on key range, we can extract it to create a `SplitChecker` to handle region splits in the same place.

### What is changed and how it works?

- add split checker
- remove region split logic from rule checker
- add test

### Check List

Tests
- Unit test

### Release note

```release-note
None
```
