### PR TITLE
checker: skip merge regions that are marked nomerge

### DIFF
--- a/server/api/region_label_test.go
+++ b/server/api/region_label_test.go
@@ -77,6 +77,7 @@ func (s *testRegionLabelSuite) TestGetSet(c *C) {
 	c.Assert(err, IsNil)
 	err = readJSON(testDialClient, s.urlPrefix+"rules", &resp)
 	c.Assert(err, IsNil)
+	sort.Slice(resp, func(i, j int) bool { return resp[i].ID < resp[j].ID })
 	c.Assert(resp, DeepEquals, []*labeler.LabelRule{rules[0], rules[2]})
 
 	patch := labeler.LabelRulePatch{

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -171,7 +171,7 @@ func AllowMerge(cluster opt.Cluster, region *core.RegionInfo, adjacent *core.Reg
 
 	// The interface probe is used here to get the rule manager and region
 	// labeler because AllowMerge is also used by the random merge scheduler,
-	// where it is not easy to get references to concret objects.
+	// where it is not easy to get references to concrete objects.
 	// We can consider using dependency injection techniques to optimize in
 	// the future.
 

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tikv/pd/pkg/logutil"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule/labeler"
 	"github.com/tikv/pd/server/schedule/operator"
 	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
@@ -167,15 +168,30 @@ func AllowMerge(cluster opt.Cluster, region *core.RegionInfo, adjacent *core.Reg
 	} else {
 		return false
 	}
+
+	// The interface probe is used here to get the rule manager and region
+	// labeler because AllowMerge is also used by the random merge scheduler,
+	// where it is not easy to get references to concret objects.
+	// We can consider using dependency injection techniques to optimize in
+	// the future.
+
 	if cluster.GetOpts().IsPlacementRulesEnabled() {
-		type withRuleManager interface {
-			GetRuleManager() *placement.RuleManager
-		}
-		cl, ok := cluster.(withRuleManager)
+		cl, ok := cluster.(interface{ GetRuleManager() *placement.RuleManager })
 		if !ok || len(cl.GetRuleManager().GetSplitKeys(start, end)) > 0 {
 			return false
 		}
 	}
+
+	if cl, ok := cluster.(interface{ GetRegionLabeler() *labeler.RegionLabeler }); ok {
+		l := cl.GetRegionLabeler()
+		if len(l.GetSplitKeys(start, end)) > 0 {
+			return false
+		}
+		if l.GetRegionLabel(region, labeler.NoMerge) != "" || l.GetRegionLabel(adjacent, labeler.NoMerge) != "" {
+			return false
+		}
+	}
+
 	policy := cluster.GetOpts().GetKeyType()
 	switch policy {
 	case core.Table:

--- a/server/schedule/labeler/labels.go
+++ b/server/schedule/labeler/labels.go
@@ -1,0 +1,20 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labeler
+
+const (
+	// NoMerge is the label for the regions that should not merge.
+	NoMerge = "nomerge"
+)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Fix https://github.com/tikv/pd/issues/4001

### What is changed and how it works?

When regions are marked `nomerge`, don't merge them.
Also fixed an unstable test.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test

### Release note
```release-note
Support using region labels to control specific regions from being merged.
```
