### PR TITLE
filter: replace fmt.Sprint with strconv.parseUint64

### DIFF
--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -16,6 +16,7 @@ package filter
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -36,7 +37,7 @@ func SelectSourceStores(stores []*core.StoreInfo, filters []Filter, opt *config.
 	return filterStoresBy(stores, func(s *core.StoreInfo) bool {
 		return slice.AllOf(filters, func(i int) bool {
 			if !filters[i].Source(opt, s) {
-				sourceID := fmt.Sprintf("%d", s.GetID())
+				sourceID := strconv.FormatUint(s.GetID(), 10)
 				targetID := ""
 				filterCounter.WithLabelValues("filter-source", s.GetAddress(),
 					sourceID, filters[i].Scope(), filters[i].Type(), sourceID, targetID).Inc()
@@ -54,10 +55,10 @@ func SelectTargetStores(stores []*core.StoreInfo, filters []Filter, opt *config.
 			filter := filters[i]
 			if !filter.Target(opt, s) {
 				cfilter, ok := filter.(comparingFilter)
-				targetID := fmt.Sprintf("%d", s.GetID())
+				targetID := strconv.FormatUint(s.GetID(), 10)
 				sourceID := ""
 				if ok {
-					sourceID = fmt.Sprintf("%d", cfilter.GetSourceStoreID())
+					sourceID = strconv.FormatUint(cfilter.GetSourceStoreID(), 10)
 				}
 				filterCounter.WithLabelValues("filter-target", s.GetAddress(),
 					targetID, filters[i].Scope(), filters[i].Type(), sourceID, targetID).Inc()
@@ -98,7 +99,7 @@ type comparingFilter interface {
 // Source checks if store can pass all Filters as source store.
 func Source(opt *config.PersistOptions, store *core.StoreInfo, filters []Filter) bool {
 	storeAddress := store.GetAddress()
-	storeID := fmt.Sprintf("%d", store.GetID())
+	storeID := strconv.FormatUint(store.GetID(), 10)
 	for _, filter := range filters {
 		if !filter.Source(opt, store) {
 			sourceID := storeID
@@ -114,14 +115,14 @@ func Source(opt *config.PersistOptions, store *core.StoreInfo, filters []Filter)
 // Target checks if store can pass all Filters as target store.
 func Target(opt *config.PersistOptions, store *core.StoreInfo, filters []Filter) bool {
 	storeAddress := store.GetAddress()
-	storeID := fmt.Sprintf("%d", store.GetID())
+	storeID := strconv.FormatUint(store.GetID(), 10)
 	for _, filter := range filters {
 		if !filter.Target(opt, store) {
 			cfilter, ok := filter.(comparingFilter)
 			targetID := storeID
 			sourceID := ""
 			if ok {
-				sourceID = fmt.Sprintf("%d", cfilter.GetSourceStoreID())
+				sourceID = strconv.FormatUint(cfilter.GetSourceStoreID(), 10)
 			}
 			filterCounter.WithLabelValues("filter-target", storeAddress,
 				targetID, filter.Scope(), filter.Type(), sourceID, targetID).Inc()


### PR DESCRIPTION
Signed-off-by: bufferflies <1045931706@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
related #3744， repalce fmt.Sprintf  with strconv.ParseUint to imporve filter performance . 

![image](https://user-images.githubusercontent.com/23159587/130030337-8e2dc714-ea35-484f-a8a0-89f83ac44a03.png)

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
some itoa  test: https://gist.github.com/evalphobia/caee1602969a640a4530
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- bench test


Code changes

Side effects

Related changes


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
replace fmt.Sprint with strconv.parseUint64
```
