### PR TITLE
rules: optimize the implementation of FitRegion

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -163,11 +163,6 @@ func (mc *Cluster) initRuleManager() {
 	}
 }
 
-// FitRegion fits a region to the rules it matches.
-func (mc *Cluster) FitRegion(region *core.RegionInfo) *placement.RegionFit {
-	return mc.RuleManager.FitRegion(mc.BasicCluster, region)
-}
-
 // GetRuleManager returns the ruleManager of the cluster.
 func (mc *Cluster) GetRuleManager() *placement.RuleManager {
 	return mc.RuleManager

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1506,11 +1506,6 @@ func (c *RaftCluster) GetRuleManager() *placement.RuleManager {
 	return c.ruleManager
 }
 
-// FitRegion tries to fit the region with placement rules.
-func (c *RaftCluster) FitRegion(region *core.RegionInfo) *placement.RegionFit {
-	return c.GetRuleManager().FitRegion(c, region)
-}
-
 // GetRegionLabeler returns the region labeler.
 func (c *RaftCluster) GetRegionLabeler() *labeler.RegionLabeler {
 	c.RLock()

--- a/server/schedule/checker/priority_checker.go
+++ b/server/schedule/checker/priority_checker.go
@@ -80,7 +80,7 @@ func (p *PriorityChecker) Check(region *core.RegionInfo) (fit *placement.RegionF
 
 // checkRegionInPlacementRule check region in placement rule mode
 func (p *PriorityChecker) checkRegionInPlacementRule(region *core.RegionInfo) (makeupCount int, fit *placement.RegionFit) {
-	fit = p.cluster.FitRegion(region)
+	fit = opt.FitRegion(p.cluster, region)
 	if len(fit.RuleFits) == 0 {
 		return
 	}

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -59,7 +59,7 @@ func (c *RuleChecker) GetType() string {
 // Check checks if the region matches placement rules and returns Operator to
 // fix it.
 func (c *RuleChecker) Check(region *core.RegionInfo) *operator.Operator {
-	fit := c.cluster.FitRegion(region)
+	fit := opt.FitRegion(c.cluster, region)
 	return c.CheckWithFit(region, fit)
 }
 

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -462,14 +462,9 @@ func (f labelConstraintFilter) Target(opt *config.PersistOptions, store *core.St
 	return placement.MatchLabelConstraints(store, f.constraints)
 }
 
-// RegionFitter is the interface that can fit a region against placement rules.
-type RegionFitter interface {
-	FitRegion(*core.RegionInfo) *placement.RegionFit
-}
-
 type ruleFitFilter struct {
 	scope    string
-	fitter   RegionFitter
+	cluster  opt.Cluster
 	region   *core.RegionInfo
 	oldFit   *placement.RegionFit
 	srcStore uint64
@@ -478,12 +473,12 @@ type ruleFitFilter struct {
 // newRuleFitFilter creates a filter that ensures after replace a peer with new
 // one, the isolation level will not decrease. Its function is the same as
 // distinctScoreFilter but used when placement rules is enabled.
-func newRuleFitFilter(scope string, fitter RegionFitter, region *core.RegionInfo, oldStoreID uint64) Filter {
+func newRuleFitFilter(scope string, cluster opt.Cluster, region *core.RegionInfo, oldStoreID uint64) Filter {
 	return &ruleFitFilter{
 		scope:    scope,
-		fitter:   fitter,
+		cluster:  cluster,
 		region:   region,
-		oldFit:   fitter.FitRegion(region),
+		oldFit:   opt.FitRegion(cluster, region),
 		srcStore: oldStoreID,
 	}
 }
@@ -496,15 +491,15 @@ func (f *ruleFitFilter) Type() string {
 	return "rule-fit-filter"
 }
 
-func (f *ruleFitFilter) Source(opt *config.PersistOptions, store *core.StoreInfo) bool {
+func (f *ruleFitFilter) Source(options *config.PersistOptions, store *core.StoreInfo) bool {
 	return true
 }
 
-func (f *ruleFitFilter) Target(opt *config.PersistOptions, store *core.StoreInfo) bool {
+func (f *ruleFitFilter) Target(options *config.PersistOptions, store *core.StoreInfo) bool {
 	region := createRegionForRuleFit(f.region.GetStartKey(), f.region.GetEndKey(),
 		f.region.GetPeers(), f.region.GetLeader(),
 		core.WithReplacePeerStore(f.srcStore, store.GetID()))
-	newFit := f.fitter.FitRegion(region)
+	newFit := opt.FitRegion(f.cluster, region)
 	return placement.CompareRegionFit(f.oldFit, newFit) <= 0
 }
 
@@ -515,7 +510,7 @@ func (f *ruleFitFilter) GetSourceStoreID() uint64 {
 
 type ruleLeaderFitFilter struct {
 	scope            string
-	fitter           RegionFitter
+	cluster          opt.Cluster
 	region           *core.RegionInfo
 	oldFit           *placement.RegionFit
 	srcLeaderStoreID uint64
@@ -523,12 +518,12 @@ type ruleLeaderFitFilter struct {
 
 // newRuleLeaderFitFilter creates a filter that ensures after transfer leader with new store,
 // the isolation level will not decrease.
-func newRuleLeaderFitFilter(scope string, fitter RegionFitter, region *core.RegionInfo, srcLeaderStoreID uint64) Filter {
+func newRuleLeaderFitFilter(scope string, cluster opt.Cluster, region *core.RegionInfo, srcLeaderStoreID uint64) Filter {
 	return &ruleLeaderFitFilter{
 		scope:            scope,
-		fitter:           fitter,
+		cluster:          cluster,
 		region:           region,
-		oldFit:           fitter.FitRegion(region),
+		oldFit:           opt.FitRegion(cluster, region),
 		srcLeaderStoreID: srcLeaderStoreID,
 	}
 }
@@ -541,11 +536,11 @@ func (f *ruleLeaderFitFilter) Type() string {
 	return "rule-fit-leader-filter"
 }
 
-func (f *ruleLeaderFitFilter) Source(opt *config.PersistOptions, store *core.StoreInfo) bool {
+func (f *ruleLeaderFitFilter) Source(options *config.PersistOptions, store *core.StoreInfo) bool {
 	return true
 }
 
-func (f *ruleLeaderFitFilter) Target(opt *config.PersistOptions, store *core.StoreInfo) bool {
+func (f *ruleLeaderFitFilter) Target(options *config.PersistOptions, store *core.StoreInfo) bool {
 	targetPeer := f.region.GetStorePeer(store.GetID())
 	if targetPeer == nil {
 		log.Warn("ruleLeaderFitFilter couldn't find peer on target Store", zap.Uint64("target-store", store.GetID()))
@@ -554,7 +549,7 @@ func (f *ruleLeaderFitFilter) Target(opt *config.PersistOptions, store *core.Sto
 	copyRegion := createRegionForRuleFit(f.region.GetStartKey(), f.region.GetEndKey(),
 		f.region.GetPeers(), f.region.GetLeader(),
 		core.WithLeader(targetPeer))
-	newFit := f.fitter.FitRegion(copyRegion)
+	newFit := opt.FitRegion(f.cluster, copyRegion)
 	return placement.CompareRegionFit(f.oldFit, newFit) <= 0
 }
 

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -125,7 +125,7 @@ func NewBuilder(desc string, cluster opt.Cluster, region *core.RegionInfo, opts 
 	// placement rules
 	var rules []*placement.Rule
 	if err == nil && cluster.GetOpts().IsPlacementRulesEnabled() {
-		fit := cluster.FitRegion(region)
+		fit := opt.FitRegion(cluster, region)
 		for _, rf := range fit.RuleFits {
 			rules = append(rules, rf.Rule)
 		}

--- a/server/schedule/opt/healthy.go
+++ b/server/schedule/opt/healthy.go
@@ -62,7 +62,7 @@ func AllowBalanceEmptyRegion(cluster Cluster) func(*core.RegionInfo) bool {
 // rules is disabled, it should have enough replicas and no any learner peer.
 func IsRegionReplicated(cluster Cluster, region *core.RegionInfo) bool {
 	if cluster.GetOpts().IsPlacementRulesEnabled() {
-		return cluster.FitRegion(region).IsSatisfied()
+		return FitRegion(cluster, region).IsSatisfied()
 	}
 	return len(region.GetLearners()) == 0 && len(region.GetPeers()) == cluster.GetOpts().GetMaxReplicas()
 }

--- a/server/schedule/opt/opts.go
+++ b/server/schedule/opt/opts.go
@@ -41,10 +41,15 @@ type Cluster interface {
 
 	GetOpts() *config.PersistOptions
 	AllocID() (uint64, error)
-	FitRegion(*core.RegionInfo) *placement.RegionFit
+	GetRuleManager() *placement.RuleManager
 	RemoveScheduler(name string) error
 	IsFeatureSupported(f versioninfo.Feature) bool
 	AddSuspectRegions(ids ...uint64)
+}
+
+// FitRegion tries to fit the region with placement rules.
+func FitRegion(c Cluster, region *core.RegionInfo) *placement.RegionFit {
+	return c.GetRuleManager().FitRegion(c, region)
 }
 
 // cacheCluster include cache info


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

```go
// FitRegion tries to fit the region with placement rules.
func (c *RaftCluster) FitRegion(region *core.RegionInfo) *placement.RegionFit {
	return c.GetRuleManager().FitRegion(c, region)
}
```

Due to the above code, `CacheCluster` in #4003 has no real effect. It is called `RaftCluster.GetStores`, not `CacheCluster.GetStores`.

### What is changed and how it works?

Implementation of abstract FitRegion.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
