### PR TITLE
regionlabel: don't return 404 when the id is not existed

### DIFF
--- a/server/api/region_label.go
+++ b/server/api/region_label.go
@@ -81,7 +81,6 @@ func (h *regionLabelHandler) Patch(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Success 200 {array} labeler.LabelRule
 // @Failure 400 {string} string "The input is invalid."
-// @Failure 404 {string} string "The rule does not exist."
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /config/region-label/rule/ids [get]
 func (h *regionLabelHandler) GetRulesByIDs(w http.ResponseWriter, r *http.Request) {
@@ -92,11 +91,7 @@ func (h *regionLabelHandler) GetRulesByIDs(w http.ResponseWriter, r *http.Reques
 	}
 	rules, err := cluster.GetRegionLabeler().GetLabelRules(ids)
 	if err != nil {
-		if errs.ErrRegionRuleNotFound.Equal(err) {
-			h.rd.JSON(w, http.StatusNotFound, err.Error())
-		} else {
-			h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		}
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	h.rd.JSON(w, http.StatusOK, rules)

--- a/server/schedule/labeler/labeler.go
+++ b/server/schedule/labeler/labeler.go
@@ -166,8 +166,6 @@ func (l *RegionLabeler) GetLabelRules(ids []string) ([]*LabelRule, error) {
 	for _, id := range ids {
 		if rule, ok := l.labelRules[id]; ok {
 			rules = append(rules, rule)
-		} else {
-			return nil, errs.ErrRegionRuleNotFound.FastGenByArgs(id)
 		}
 	}
 	return rules, nil

--- a/server/schedule/labeler/labeler_test.go
+++ b/server/schedule/labeler/labeler_test.go
@@ -119,8 +119,9 @@ func (s *testLabelerSuite) TestGetSetRule(c *C) {
 	err = s.labeler.DeleteLabelRule("rule2")
 	c.Assert(err, IsNil)
 	c.Assert(s.labeler.GetLabelRule("rule2"), IsNil)
-	_, err = s.labeler.GetLabelRules([]string{"rule1", "rule2"})
-	c.Assert(err, NotNil)
+	byIDs, err = s.labeler.GetLabelRules([]string{"rule1", "rule2"})
+	c.Assert(err, IsNil)
+	c.Assert(byIDs, DeepEquals, []*LabelRule{rules[0]})
 
 	// patch
 	patch := LabelRulePatch{


### PR DESCRIPTION
### What problem does this PR solve?

After adding some testings, I realize that TiDB doesn't know how many rules PD has. Once we need to update some rules, we need to provide all IDs related to the table and partitions. In this case, we should return the existed rules and omit the other invalid rule's ID.
Otherwise, we can only get the rule one by one or get all rules stored in PD which may not be a good choice.

### What is changed and how it works?

Just as the title says.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- Has HTTP API interfaces change
### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
