### PR TITLE
labeler: add index to support rule override

### DIFF
--- a/server/schedule/labeler/rules.go
+++ b/server/schedule/labeler/rules.go
@@ -23,6 +23,7 @@ type RegionLabel struct {
 // LabelRule is the rule to assign labels to a region.
 type LabelRule struct {
 	ID       string        `json:"id"`
+	Index    int           `json:"index"`
 	Labels   []RegionLabel `json:"labels"`
 	RuleType string        `json:"rule_type"`
 	Rule     interface{}   `json:"rule"`


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Fix https://github.com/tikv/pd/issues/4031

### What is changed and how it works?
Add `Index` field to `RegionLabelRule`. When multiple rules defines label with the same key, only the one with the maximum index takes effect. When there are multiple rules have an index equal to maximum value, the returned value is undefined behavior.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
