### PR TITLE
tso, election: remove some unnecessary logs from the TSO hot path

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -611,11 +611,6 @@ error = '''
 get local allocator failed, %s
 '''
 
-["PD:tso:ErrInvalidTimestamp"]
-error = '''
-invalid timestamp
-'''
-
 ["PD:tso:ErrLogicOverflow"]
 error = '''
 logic part overflow

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -9124,7 +9124,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "PD server TSO handle time + Client revc time",
+          "title": "PD server TSO handle time",
           "tooltip": {
             "msResolution": false,
             "shared": true,

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -37,7 +37,6 @@ var (
 	ErrSyncMaxTS          = errors.Normalize("sync max ts failed, %s", errors.RFCCodeText("PD:tso:ErrSyncMaxTS"))
 	ErrResetUserTimestamp = errors.Normalize("reset user timestamp failed, %s", errors.RFCCodeText("PD:tso:ErrResetUserTimestamp"))
 	ErrGenerateTimestamp  = errors.Normalize("generate timestamp failed, %s", errors.RFCCodeText("PD:tso:ErrGenerateTimestamp"))
-	ErrInvalidTimestamp   = errors.Normalize("invalid timestamp", errors.RFCCodeText("PD:tso:ErrInvalidTimestamp"))
 	ErrLogicOverflow      = errors.Normalize("logic part overflow", errors.RFCCodeText("PD:tso:ErrLogicOverflow"))
 )
 

--- a/pkg/errs/errs_test.go
+++ b/pkg/errs/errs_test.go
@@ -84,12 +84,12 @@ func (s *testErrorSuite) TestError(c *C) {
 	lg := newZapTestLogger(conf)
 	log.ReplaceGlobals(lg.Logger, nil)
 
-	rfc := `[error="[PD:tso:ErrInvalidTimestamp]invalid timestamp"]`
+	rfc := `[error="[PD:member:ErrEtcdLeaderNotFound]etcd leader not found`
 	log.Error("test", zap.Error(ErrEtcdLeaderNotFound.FastGenByArgs()))
 	c.Assert(strings.Contains(lg.Message(), rfc), IsTrue)
 	err := errors.New("test error")
 	log.Error("test", ZapError(ErrEtcdLeaderNotFound, err))
-	rfc = `[error="[PD:tso:ErrInvalidTimestamp]test error"]`
+	rfc = `[error="[PD:member:ErrEtcdLeaderNotFound]test error"]`
 	c.Assert(strings.Contains(lg.Message(), rfc), IsTrue)
 }
 

--- a/pkg/errs/errs_test.go
+++ b/pkg/errs/errs_test.go
@@ -85,10 +85,10 @@ func (s *testErrorSuite) TestError(c *C) {
 	log.ReplaceGlobals(lg.Logger, nil)
 
 	rfc := `[error="[PD:tso:ErrInvalidTimestamp]invalid timestamp"]`
-	log.Error("test", zap.Error(ErrInvalidTimestamp.FastGenByArgs()))
+	log.Error("test", zap.Error(ErrEtcdLeaderNotFound.FastGenByArgs()))
 	c.Assert(strings.Contains(lg.Message(), rfc), IsTrue)
 	err := errors.New("test error")
-	log.Error("test", ZapError(ErrInvalidTimestamp, err))
+	log.Error("test", ZapError(ErrEtcdLeaderNotFound, err))
 	rfc = `[error="[PD:tso:ErrInvalidTimestamp]test error"]`
 	c.Assert(strings.Contains(lg.Message(), rfc), IsTrue)
 }

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -43,8 +43,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const slowThreshold = 5 * time.Millisecond
-
 // gRPC errors
 var (
 	// ErrNotLeader is returned when current server is not the leader and not possible to process request.
@@ -166,10 +164,6 @@ func (s *Server) Tso(stream pdpb.PD_TsoServer) error {
 			return status.Errorf(codes.Unknown, err.Error())
 		}
 
-		elapsed := time.Since(start)
-		if elapsed > slowThreshold {
-			log.Warn("get timestamp too slow", zap.Duration("cost", elapsed))
-		}
 		tsoHandleDuration.Observe(time.Since(start).Seconds())
 		response := &pdpb.TsoResponse{
 			Header:    s.header(),

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -104,10 +104,6 @@ func (gta *GlobalTSOAllocator) getSyncRTT() int64 {
 func (gta *GlobalTSOAllocator) estimateMaxTS(count uint32, suffixBits int) (*pdpb.Timestamp, bool, error) {
 	physical, logical, lastUpdateTime := gta.timestampOracle.generateTSO(int64(count), 0)
 	if physical == 0 {
-		log.Error("invalid global tso in memory, unable to estimate maxTSO",
-			zap.Any("timestamp-physical", physical),
-			zap.Any("timestamp-logical", logical),
-			errs.ZapError(errs.ErrInvalidTimestamp))
 		return &pdpb.Timestamp{}, false, errs.ErrGenerateTimestamp.FastGenByArgs("timestamp in memory isn't initialized")
 	}
 	estimatedMaxTSO := &pdpb.Timestamp{

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -362,7 +362,6 @@ func (t *timestampOracle) getTS(leadership *election.Leadership, count uint32, s
 		if currentPhysical == typeutil.ZeroTime {
 			// If it's leader, maybe SyncTimestamp hasn't completed yet
 			if leadership.Check() {
-				log.Info("this PD is a new leader, but sync hasn't been completed yet, wait for a while")
 				time.Sleep(200 * time.Millisecond)
 				continue
 			}

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -358,7 +358,7 @@ func (t *timestampOracle) getTS(leadership *election.Leadership, count uint32, s
 		return resp, errs.ErrGenerateTimestamp.FastGenByArgs("tso count should be positive")
 	}
 	for i := 0; i < maxRetryCount; i++ {
-		currentPhysical, currentLogical := t.getTSO()
+		currentPhysical, _ := t.getTSO()
 		if currentPhysical == typeutil.ZeroTime {
 			// If it's leader, maybe SyncTimestamp hasn't completed yet
 			if leadership.Check() {
@@ -366,10 +366,6 @@ func (t *timestampOracle) getTS(leadership *election.Leadership, count uint32, s
 				continue
 			}
 			tsoCounter.WithLabelValues("not_leader_anymore", t.dcLocation).Inc()
-			log.Error("invalid timestamp",
-				zap.Any("timestamp-physical", currentPhysical),
-				zap.Any("timestamp-logical", currentLogical),
-				errs.ZapError(errs.ErrInvalidTimestamp))
 			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("timestamp in memory isn't initialized")
 		}
 		// Get a new TSO result with the given count


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Remove some unnecessary logs from the TSO hot path.

```go
log.Warn("get timestamp too slow", zap.Duration("cost", elapsed))
```

This indicator can be observed through metrics, so it is not necessary to hit the log here.

```go
log.Info("this PD is a new leader, but sync hasn't been completed yet, wait for a while")
```

In past experience, this log has not been very helpful and may be very noisy.

```go
log.Error("invalid timestamp",
				zap.Any("timestamp-physical", currentPhysical),
				zap.Any("timestamp-logical", currentLogical),
				errs.ZapError(errs.ErrInvalidTimestamp))
```

Ditto.

### What is changed and how it works?

Remove some unnecessary logs from the TSO hot path.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
