### PR TITLE
tools: fix the microsecond precision problem of pd-tso-bench

### DIFF
--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -303,7 +303,7 @@ func (s *stats) merge(other *stats) {
 
 func (s *stats) Counter() string {
 	return fmt.Sprintf(
-		"count:%d, max:%.4f, min:%.4f, avg:%.4f\n<1ms: %d, >1ms:%d, >2ms:%d, >5ms:%d, >10ms:%d, >30ms:%d, >50ms:%d, >100ms:%d, >200ms:%d, >400ms:%d, >800ms:%d, >1s:%d",
+		"count: %d, max: %.4fms, min: %.4fms, avg: %.4fms\n<1ms: %d, >1ms: %d, >2ms: %d, >5ms: %d, >10ms: %d, >30ms: %d, >50ms: %d, >100ms: %d, >200ms: %d, >400ms: %d, >800ms: %d, >1s: %d",
 		s.count, float64(s.maxDur.Nanoseconds())/float64(time.Millisecond), float64(s.minDur.Nanoseconds())/float64(time.Millisecond), float64(s.totalDur.Nanoseconds())/float64(s.count)/float64(time.Millisecond),
 		s.belowMilliCnt, s.milliCnt, s.twoMilliCnt, s.fiveMilliCnt, s.tenMSCnt, s.thirtyCnt, s.fiftyCnt, s.oneHundredCnt, s.twoHundredCnt, s.fourHundredCnt,
 		s.eightHundredCnt, s.oneThousandCnt)
@@ -311,7 +311,7 @@ func (s *stats) Counter() string {
 
 func (s *stats) Percentage() string {
 	return fmt.Sprintf(
-		"count:%d, <1ms:%2.2f%%, >1ms:%2.2f%%, >2ms:%2.2f%%, >5ms:%2.2f%%, >10ms:%2.2f%%, >30ms:%2.2f%%, >50ms:%2.2f%%, >100ms:%2.2f%%, >200ms:%2.2f%%, >400ms:%2.2f%%, >800ms:%2.2f%%, >1s:%2.2f%%", s.count,
+		"count: %d, <1ms: %2.2f%%, >1ms: %2.2f%%, >2ms: %2.2f%%, >5ms: %2.2f%%, >10ms: %2.2f%%, >30ms: %2.2f%%, >50ms: %2.2f%%, >100ms: %2.2f%%, >200ms: %2.2f%%, >400ms: %2.2f%%, >800ms: %2.2f%%, >1s: %2.2f%%", s.count,
 		s.calculate(s.belowMilliCnt), s.calculate(s.milliCnt), s.calculate(s.twoMilliCnt), s.calculate(s.fiveMilliCnt), s.calculate(s.tenMSCnt), s.calculate(s.thirtyCnt), s.calculate(s.fiftyCnt),
 		s.calculate(s.oneHundredCnt), s.calculate(s.twoHundredCnt), s.calculate(s.fourHundredCnt), s.calculate(s.eightHundredCnt), s.calculate(s.oneThousandCnt))
 }

--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -187,6 +187,7 @@ type stats struct {
 	minDur          time.Duration
 	totalDur        time.Duration
 	count           int
+	belowMilliCnt   int
 	milliCnt        int
 	twoMilliCnt     int
 	fiveMilliCnt    int
@@ -272,6 +273,8 @@ func (s *stats) update(dur time.Duration) {
 		s.milliCnt++
 		return
 	}
+
+	s.belowMilliCnt++
 }
 
 func (s *stats) merge(other *stats) {
@@ -284,6 +287,7 @@ func (s *stats) merge(other *stats) {
 
 	s.count += other.count
 	s.totalDur += other.totalDur
+	s.belowMilliCnt += other.belowMilliCnt
 	s.milliCnt += other.milliCnt
 	s.twoMilliCnt += other.twoMilliCnt
 	s.fiveMilliCnt += other.fiveMilliCnt
@@ -299,16 +303,16 @@ func (s *stats) merge(other *stats) {
 
 func (s *stats) Counter() string {
 	return fmt.Sprintf(
-		"count:%d, max:%d, min:%d, avg:%d, >1ms:%d, >2ms:%d, >5ms:%d, >10ms:%d, >30ms:%d >50ms:%d >100ms:%d >200ms:%d >400ms:%d >800ms:%d >1s:%d",
-		s.count, s.maxDur.Nanoseconds()/int64(time.Millisecond), s.minDur.Nanoseconds()/int64(time.Millisecond), s.totalDur.Nanoseconds()/int64(s.count)/int64(time.Millisecond),
-		s.milliCnt, s.twoMilliCnt, s.fiveMilliCnt, s.tenMSCnt, s.thirtyCnt, s.fiftyCnt, s.oneHundredCnt, s.twoHundredCnt, s.fourHundredCnt,
+		"count:%d, max:%.4f, min:%.4f, avg:%.4f\n<1ms: %d, >1ms:%d, >2ms:%d, >5ms:%d, >10ms:%d, >30ms:%d, >50ms:%d, >100ms:%d, >200ms:%d, >400ms:%d, >800ms:%d, >1s:%d",
+		s.count, float64(s.maxDur.Nanoseconds())/float64(time.Millisecond), float64(s.minDur.Nanoseconds())/float64(time.Millisecond), float64(s.totalDur.Nanoseconds())/float64(s.count)/float64(time.Millisecond),
+		s.belowMilliCnt, s.milliCnt, s.twoMilliCnt, s.fiveMilliCnt, s.tenMSCnt, s.thirtyCnt, s.fiftyCnt, s.oneHundredCnt, s.twoHundredCnt, s.fourHundredCnt,
 		s.eightHundredCnt, s.oneThousandCnt)
 }
 
 func (s *stats) Percentage() string {
 	return fmt.Sprintf(
-		"count:%d, >1ms:%2.2f%%, >2ms:%2.2f%%, >5ms:%2.2f%%, >10ms:%2.2f%%, >30ms:%2.2f%% >50ms:%2.2f%% >100ms:%2.2f%% >200ms:%2.2f%% >400ms:%2.2f%% >800ms:%2.2f%% >1s:%2.2f%%", s.count,
-		s.calculate(s.milliCnt), s.calculate(s.twoMilliCnt), s.calculate(s.fiveMilliCnt), s.calculate(s.tenMSCnt), s.calculate(s.thirtyCnt), s.calculate(s.fiftyCnt),
+		"count:%d, <1ms:%2.2f%%, >1ms:%2.2f%%, >2ms:%2.2f%%, >5ms:%2.2f%%, >10ms:%2.2f%%, >30ms:%2.2f%%, >50ms:%2.2f%%, >100ms:%2.2f%%, >200ms:%2.2f%%, >400ms:%2.2f%%, >800ms:%2.2f%%, >1s:%2.2f%%", s.count,
+		s.calculate(s.belowMilliCnt), s.calculate(s.milliCnt), s.calculate(s.twoMilliCnt), s.calculate(s.fiveMilliCnt), s.calculate(s.tenMSCnt), s.calculate(s.thirtyCnt), s.calculate(s.fiftyCnt),
 		s.calculate(s.oneHundredCnt), s.calculate(s.twoHundredCnt), s.calculate(s.fourHundredCnt), s.calculate(s.eightHundredCnt), s.calculate(s.oneThousandCnt))
 }
 

--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -187,7 +187,7 @@ type stats struct {
 	minDur          time.Duration
 	totalDur        time.Duration
 	count           int
-	belowMilliCnt   int
+	submilliCnt     int
 	milliCnt        int
 	twoMilliCnt     int
 	fiveMilliCnt    int
@@ -274,7 +274,7 @@ func (s *stats) update(dur time.Duration) {
 		return
 	}
 
-	s.belowMilliCnt++
+	s.submilliCnt++
 }
 
 func (s *stats) merge(other *stats) {
@@ -287,7 +287,7 @@ func (s *stats) merge(other *stats) {
 
 	s.count += other.count
 	s.totalDur += other.totalDur
-	s.belowMilliCnt += other.belowMilliCnt
+	s.submilliCnt += other.submilliCnt
 	s.milliCnt += other.milliCnt
 	s.twoMilliCnt += other.twoMilliCnt
 	s.fiveMilliCnt += other.fiveMilliCnt
@@ -305,14 +305,14 @@ func (s *stats) Counter() string {
 	return fmt.Sprintf(
 		"count: %d, max: %.4fms, min: %.4fms, avg: %.4fms\n<1ms: %d, >1ms: %d, >2ms: %d, >5ms: %d, >10ms: %d, >30ms: %d, >50ms: %d, >100ms: %d, >200ms: %d, >400ms: %d, >800ms: %d, >1s: %d",
 		s.count, float64(s.maxDur.Nanoseconds())/float64(time.Millisecond), float64(s.minDur.Nanoseconds())/float64(time.Millisecond), float64(s.totalDur.Nanoseconds())/float64(s.count)/float64(time.Millisecond),
-		s.belowMilliCnt, s.milliCnt, s.twoMilliCnt, s.fiveMilliCnt, s.tenMSCnt, s.thirtyCnt, s.fiftyCnt, s.oneHundredCnt, s.twoHundredCnt, s.fourHundredCnt,
+		s.submilliCnt, s.milliCnt, s.twoMilliCnt, s.fiveMilliCnt, s.tenMSCnt, s.thirtyCnt, s.fiftyCnt, s.oneHundredCnt, s.twoHundredCnt, s.fourHundredCnt,
 		s.eightHundredCnt, s.oneThousandCnt)
 }
 
 func (s *stats) Percentage() string {
 	return fmt.Sprintf(
 		"count: %d, <1ms: %2.2f%%, >1ms: %2.2f%%, >2ms: %2.2f%%, >5ms: %2.2f%%, >10ms: %2.2f%%, >30ms: %2.2f%%, >50ms: %2.2f%%, >100ms: %2.2f%%, >200ms: %2.2f%%, >400ms: %2.2f%%, >800ms: %2.2f%%, >1s: %2.2f%%", s.count,
-		s.calculate(s.belowMilliCnt), s.calculate(s.milliCnt), s.calculate(s.twoMilliCnt), s.calculate(s.fiveMilliCnt), s.calculate(s.tenMSCnt), s.calculate(s.thirtyCnt), s.calculate(s.fiftyCnt),
+		s.calculate(s.submilliCnt), s.calculate(s.milliCnt), s.calculate(s.twoMilliCnt), s.calculate(s.fiveMilliCnt), s.calculate(s.tenMSCnt), s.calculate(s.thirtyCnt), s.calculate(s.fiftyCnt),
 		s.calculate(s.oneHundredCnt), s.calculate(s.twoHundredCnt), s.calculate(s.fourHundredCnt), s.calculate(s.eightHundredCnt), s.calculate(s.oneThousandCnt))
 }
 


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Fix the microsecond precision bug of `pd-tso-bench`. 

### What is changed and how it works?

* Count the latency that is less than 1 millisecond.
* Use `float64` to calculate.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test

![image](https://user-images.githubusercontent.com/1446531/131473108-f016b77d-c982-461e-8424-b62ea7d8efb9.png)


### Release note


```release-note
None.
```
