### PR TITLE
checker: skip generating operator if fit is cached for rule checker

### DIFF
--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -68,12 +68,12 @@ func (c *RuleChecker) Check(region *core.RegionInfo) *operator.Operator {
 func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.RegionFit) *operator.Operator {
 	// If the fit is fetched from cache, it seems that the region doesn't need cache
 	if fit.IsCached() {
-		checkerCounter.WithLabelValues("rule_checker", "cache").Inc()
+		checkerCounter.WithLabelValues("rule_checker", "get-cache").Inc()
 		return nil
 	}
 
 	failpoint.Inject("assertCache", func() {
-		panic("shouldn't be here")
+		panic("cached should be used")
 	})
 
 	checkerCounter.WithLabelValues("rule_checker", "check").Inc()
@@ -103,6 +103,7 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 	if fit.IsSatisfied() && len(region.GetDownPeers()) == 0 {
 		// If there is no need to fix, we will cache the fit
 		c.ruleManager.SetRegionFitCache(region, fit)
+		checkerCounter.WithLabelValues("rule_checker", "set-cache").Inc()
 	}
 	return nil
 }

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -100,8 +100,10 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 			return op
 		}
 	}
-	// If there is no need to fix, we will cache the fit
-	c.ruleManager.SetRegionFitCache(region, fit)
+	if fit.IsSatisfied() && len(region.GetDownPeers()) == 0 {
+		// If there is no need to fix, we will cache the fit
+		c.ruleManager.SetRegionFitCache(region, fit)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

If the fit is fetched from cache, the rule checker will skip checking instead of generating operator.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
