### PR TITLE
election: fix the panic bug of lease

### DIFF
--- a/server/election/leadership_test.go
+++ b/server/election/leadership_test.go
@@ -104,4 +104,10 @@ func (s *testLeadershipSuite) TestLeadership(c *C) {
 
 	c.Assert(leadership1.Check(), IsFalse)
 	c.Assert(leadership2.Check(), IsTrue)
+
+	// Test resetting the leadership.
+	leadership1.Reset()
+	leadership2.Reset()
+	c.Assert(leadership1.Check(), IsFalse)
+	c.Assert(leadership2.Check(), IsFalse)
 }

--- a/server/election/lease.go
+++ b/server/election/lease.go
@@ -67,6 +67,9 @@ func (l *lease) Grant(leaseTimeout int64) error {
 
 // Close releases the lease.
 func (l *lease) Close() error {
+	if l == nil {
+		return nil
+	}
 	// Reset expire time.
 	l.expireTime.Store(time.Time{})
 	// Try to revoke lease to make subsequent elections faster.
@@ -79,6 +82,9 @@ func (l *lease) Close() error {
 // IsExpired checks if the lease is expired. If it returns true,
 // current leader should step down and try to re-elect again.
 func (l *lease) IsExpired() bool {
+	if l == nil {
+		return true
+	}
 	if l.expireTime.Load() == nil {
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

https://github.com/tikv/pd/pull/4044 makes `(*Leadership).Reset()` will set its `lease` to `nil`, which will cause panic due to the `nil` pointer when we call some methods of the `lease`.

### What is changed and how it works?

Check `lease` itself before we deref it.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
