### PR TITLE
placement: early exit searching during FitRegion

### DIFF
--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -195,7 +195,7 @@ func (w *fitWorker) fitRule(index int) bool {
 	if index >= len(w.rules) {
 		// If there is no isolation level and we already find one solution, we can early exit searching instead of
 		// searching the whole cases.
-		if w.bestFit.IsSatisfied() && !w.needIsolation {
+		if !w.needIsolation && w.bestFit.IsSatisfied() {
 			w.exit = true
 		}
 		return false

--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -347,7 +347,7 @@ func isolationScore(peers []*fitPeer, labels []string) float64 {
 
 func needIsolation(rules []*Rule) bool {
 	for _, rule := range rules {
-		if len(rule.IsolationLevel) > 0 {
+		if len(rule.LocationLabels) > 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

FitRegion will search all possible solutions which will consume much cpu resources while for some common cases the best solution is quite similar for other cases.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

early exit searching for some common cases in order to save cpu resource.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual Bnechmark Test

#### early exit

```sh
3 default peers
BenchmarkFitRegion-4   	 1054921	      1053 ns/op

5 peers
BenchmarkFitRegion-4   	  657933	      1582 ns/op

3 peers with 1 learner
BenchmarkFitRegion-4   	  763387	      1586 ns/op

3 peers in each zone
BenchmarkFitRegion-4   	  696102	      1553 ns/op
```

#### origin

```sh
3 default peers
BenchmarkFitRegionMoreStores-4   	  829810	      1274 ns/op

5 peers
BenchmarkFitRegionMoreStores-4   	  437342	      2740 ns/op

3 peers with 1 learner
BenchmarkFitRegionMoreStores-4   	  157977	      6533 ns/op

3 peers in each zone
BenchmarkFitRegionMoreStores-4   	   46964	     21685 ns/op
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
