### PR TITLE
tools: fix cannot kill bench process when using the wrong address

### DIFF
--- a/tools/pd-tso-bench/main.go
+++ b/tools/pd-tso-bench/main.go
@@ -87,7 +87,7 @@ func bench(mainCtx context.Context) {
 	fmt.Printf("Create %d client(s) for benchmark\n", *clientNumber)
 	pdClients := make([]pd.Client, *clientNumber)
 	for idx := range pdClients {
-		pdCli, err := pd.NewClient([]string{*pdAddrs}, pd.SecurityOption{
+		pdCli, err := pd.NewClientWithContext(mainCtx, []string{*pdAddrs}, pd.SecurityOption{
 			CAPath:   *caPath,
 			CertPath: *certPath,
 			KeyPath:  *keyPath,


### PR DESCRIPTION
### What problem does this PR solve?

Just as the title says.

### What is changed and how it works?

Use `NewClientWithContext` instead of `NewClient`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test 


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
