### PR TITLE
schedulers:  decrease target filter calculate

### DIFF
--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -32,6 +32,15 @@ import (
 
 // revive:disable:unused-parameter
 
+// SelectBadTargetStores selects stores that one of checkers not pass
+func SelectBadTargetStores(stores []*core.StoreInfo, filters []Filter, opt *config.PersistOptions) []*core.StoreInfo {
+	return filterStoresBy(stores, func(s *core.StoreInfo) bool {
+		return slice.AnyOf(filters, func(i int) bool {
+			return !filters[i].Target(opt, s)
+		})
+	})
+}
+
 // SelectSourceStores selects stores that be selected as source store from the list.
 func SelectSourceStores(stores []*core.StoreInfo, filters []Filter, opt *config.PersistOptions) []*core.StoreInfo {
 	return filterStoresBy(stores, func(s *core.StoreInfo) bool {

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -143,7 +143,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 	leaderSchedulePolicy := cluster.GetOpts().GetLeaderSchedulePolicy()
 	opInfluence := l.opController.GetOpInfluence(cluster)
 	kind := core.NewScheduleKind(core.LeaderKind, leaderSchedulePolicy)
-	plan := newBalancePlan(kind, cluster, opInfluence)
+	plan := newBalancePlan(kind, cluster, opInfluence, nil)
 
 	stores := cluster.GetStores()
 	sources := filter.SelectSourceStores(stores, l.filters, cluster.GetOpts())

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -126,7 +126,7 @@ func (s *testBalanceSuite) TestShouldBalance(c *C) {
 		tc.PutRegion(region)
 		tc.SetLeaderSchedulePolicy(t.kind.String())
 		kind := core.NewScheduleKind(core.LeaderKind, t.kind)
-		plan := newBalancePlan(kind, tc, oc.GetOpInfluence(tc))
+		plan := newBalancePlan(kind, tc, oc.GetOpInfluence(tc), nil)
 		plan.source, plan.target, plan.region = tc.GetStore(1), tc.GetStore(2), tc.GetRegion(1)
 		c.Assert(plan.shouldBalance(""), Equals, t.expectedResult)
 	}
@@ -138,7 +138,7 @@ func (s *testBalanceSuite) TestShouldBalance(c *C) {
 			region := tc.GetRegion(1).Clone(core.SetApproximateSize(t.regionSize))
 			tc.PutRegion(region)
 			kind := core.NewScheduleKind(core.RegionKind, t.kind)
-			plan := newBalancePlan(kind, tc, oc.GetOpInfluence(tc))
+			plan := newBalancePlan(kind, tc, oc.GetOpInfluence(tc), nil)
 			plan.source, plan.target, plan.region = tc.GetStore(1), tc.GetStore(2), tc.GetRegion(1)
 			c.Assert(plan.shouldBalance(""), Equals, t.expectedResult)
 		}
@@ -185,7 +185,7 @@ func (s *testBalanceSuite) TestTolerantRatio(c *C) {
 	}
 	for i, t := range tbl {
 		tc.SetTolerantSizeRatio(t.ratio)
-		plan := newBalancePlan(t.kind, tc, operator.OpInfluence{})
+		plan := newBalancePlan(t.kind, tc, operator.OpInfluence{}, nil)
 		plan.region = region
 		c.Assert(plan.getTolerantResource(), Equals, t.expectTolerantResource(t.kind), Commentf("case #%d", i+1))
 	}

--- a/server/schedulers/utils.go
+++ b/server/schedulers/utils.go
@@ -53,14 +53,17 @@ type balancePlan struct {
 
 	sourceScore float64
 	targetScore float64
+
+	excludeTarget []*core.StoreInfo
 }
 
-func newBalancePlan(kind core.ScheduleKind, cluster opt.Cluster, opInfluence operator.OpInfluence) *balancePlan {
+func newBalancePlan(kind core.ScheduleKind, cluster opt.Cluster, opInfluence operator.OpInfluence, excludeTarget []*core.StoreInfo) *balancePlan {
 	return &balancePlan{
 		kind:              kind,
 		cluster:           cluster,
 		opInfluence:       opInfluence,
 		tolerantSizeRatio: adjustTolerantRatio(cluster, kind),
+		excludeTarget:     excludeTarget,
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
related #3744，remove some repeat target filter 
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
scheduler move some target filter such as StoreStateFilter, RegionScoreFilter, SpecialFilter at scheduler start 
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

origin 
![image](https://user-images.githubusercontent.com/23159587/132174142-20672c78-97fa-4ccb-8bd2-ee999a6b433f.png)

this PR:
![image](https://user-images.githubusercontent.com/23159587/132174026-9319b6db-a79e-442e-8c0c-2e14d2052637.png)

import double performance 

Code changes

Side effects


Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
decrease target filter calculate to improve balance region scheduler  performance
```
