### PR TITLE
api: Add pause or resume checker REST api

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -41,6 +41,11 @@ error = '''
 unsupported metrics type %v
 '''
 
+["PD:checker:ErrCheckerNotFound"]
+error = '''
+checker not found
+'''
+
 ["PD:client:ErrClientCreateTSOStream"]
 error = '''
 create TSO stream failed

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -86,6 +86,11 @@ var (
 	ErrSchedulerCreateFuncNotRegistered = errors.Normalize("create func of %v is not registered", errors.RFCCodeText("PD:scheduler:ErrSchedulerCreateFuncNotRegistered"))
 )
 
+// checker errors
+var (
+	ErrCheckerNotFound = errors.Normalize("checker not found", errors.RFCCodeText("PD:checker:ErrCheckerNotFound"))
+)
+
 // placement errors
 var (
 	ErrRuleContent   = errors.Normalize("invalid rule content, %s", errors.RFCCodeText("PD:placement:ErrRuleContent"))

--- a/server/api/checker.go
+++ b/server/api/checker.go
@@ -39,7 +39,7 @@ func newCheckerHandler(svr *server.Server, r *render.Render) *checkerHandler {
 // @Tags checker
 // @Summary Pause or resume region merge.
 // @Accept json
-// @Param name path string true "The name of the scheduler."
+// @Param name path string true "The name of the checker."
 // @Param body body object true "json params"
 // @Produce json
 // @Success 200 {string} string "Pause or resume the scheduler successfully."
@@ -67,4 +67,31 @@ func (c *checkerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request) {
 	} else {
 		c.r.JSON(w, http.StatusOK, "Pause the checker successfully.")
 	}
+}
+
+// FIXME: details of input json body params
+// @Tags checker
+// @Summary Get if checker is paused
+// @Param name path string true "The name of the scheduler."
+// @Produce json
+// @Success 200 {string} string "Pause or resume the scheduler successfully."
+// @Failure 400 {string} string "Bad format request."
+// @Failure 500 {string} string "PD server failed to proceed the request."
+// @Router /checker/{name} [get]
+func (c *checkerHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
+	var input map[string]int
+	if err := apiutil.ReadJSONRespondError(c.r, w, r.Body, &input); err != nil {
+		return
+	}
+
+	name := mux.Vars(r)["name"]
+	isPaused, err := c.IsCheckerPaused(name)
+	if err != nil {
+		c.r.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	output := map[string]bool{
+		"paused": isPaused,
+	}
+	c.r.JSON(w, http.StatusOK, output)
 }

--- a/server/api/checker.go
+++ b/server/api/checker.go
@@ -1,0 +1,65 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/tikv/pd/pkg/apiutil"
+	"github.com/tikv/pd/server"
+	"github.com/unrolled/render"
+	"net/http"
+)
+
+type checkerHandler struct {
+	*server.Handler
+	r *render.Render
+}
+
+func newCheckerHandler(svr *server.Server, r *render.Render) *checkerHandler {
+	return &checkerHandler{
+		Handler: svr.GetHandler(),
+		r:       r,
+	}
+}
+
+// FIXME: details of input json body params
+// @Tags checker
+// @Summary Pause or resume region merge.
+// @Accept json
+// @Param name path string true "The name of the scheduler."
+// @Param body body object true "json params"
+// @Produce json
+// @Success 200 {string} string "Pause or resume the scheduler successfully."
+// @Failure 400 {string} string "Bad format request."
+// @Failure 500 {string} string "PD server failed to proceed the request."
+// @Router /checker/{name} [post]
+func (c *checkerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request) {
+	var input map[string]int
+	if err := apiutil.ReadJSONRespondError(c.r, w, r.Body, &input); err != nil {
+		return
+	}
+
+	name := mux.Vars(r)["name"]
+	t, ok := input["delay"]
+	if !ok {
+		c.r.JSON(w, http.StatusBadRequest, "missing pause time")
+		return
+	}
+	if err := c.PauseOrResumeChecker(name, int64(t)); err != nil {
+		c.r.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.r.JSON(w, http.StatusOK, "Pause or resume merge successfully.")
+}

--- a/server/api/checker.go
+++ b/server/api/checker.go
@@ -79,11 +79,6 @@ func (c *checkerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /checker/{name} [get]
 func (c *checkerHandler) GetStatus(w http.ResponseWriter, r *http.Request) {
-	var input map[string]int
-	if err := apiutil.ReadJSONRespondError(c.r, w, r.Body, &input); err != nil {
-		return
-	}
-
 	name := mux.Vars(r)["name"]
 	isPaused, err := c.IsCheckerPaused(name)
 	if err != nil {

--- a/server/api/checker.go
+++ b/server/api/checker.go
@@ -75,7 +75,6 @@ func (c *checkerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request) {
 // @Param name path string true "The name of the scheduler."
 // @Produce json
 // @Success 200 {string} string "Pause or resume the scheduler successfully."
-// @Failure 400 {string} string "Bad format request."
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /checker/{name} [get]
 func (c *checkerHandler) GetStatus(w http.ResponseWriter, r *http.Request) {

--- a/server/api/checker.go
+++ b/server/api/checker.go
@@ -15,11 +15,12 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/tikv/pd/pkg/apiutil"
 	"github.com/tikv/pd/server"
 	"github.com/unrolled/render"
-	"net/http"
 )
 
 type checkerHandler struct {

--- a/server/api/checker.go
+++ b/server/api/checker.go
@@ -58,6 +58,10 @@ func (c *checkerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request) {
 		c.r.JSON(w, http.StatusBadRequest, "missing pause time")
 		return
 	}
+	if t < 0 {
+		c.r.JSON(w, http.StatusBadRequest, "delay cannot be negative")
+		return
+	}
 	if err := c.PauseOrResumeChecker(name, int64(t)); err != nil {
 		c.r.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/api/checker.go
+++ b/server/api/checker.go
@@ -62,5 +62,9 @@ func (c *checkerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request) {
 		c.r.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	c.r.JSON(w, http.StatusOK, "Pause or resume merge successfully.")
+	if t == 0 {
+		c.r.JSON(w, http.StatusOK, "Resume the checker successfully.")
+	} else {
+		c.r.JSON(w, http.StatusOK, "Pause the checker successfully.")
+	}
 }

--- a/server/api/checker_test.go
+++ b/server/api/checker_test.go
@@ -83,6 +83,7 @@ func (s *testCheckerSuite) testGetStatus(name string, c *C) {
 	c.Assert(resp["paused"], Equals, true)
 	// resumed
 	err = handler.PauseOrResumeChecker(name, 1)
+	c.Assert(err, IsNil)
 	time.Sleep(time.Second)
 	resp = make(map[string]interface{})
 	err = readJSON(testDialClient, fmt.Sprintf("%s/%s", s.urlPrefix, name), &resp)
@@ -95,8 +96,13 @@ func (s *testCheckerSuite) testPauseOrResume(name string, c *C) {
 
 	// test pause.
 	input := make(map[string]interface{})
-	input["delay"] = 30
+	input["delay"] = -10
 	pauseArgs, err := json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
+	c.Assert(err, NotNil)
+	input["delay"] = 30
+	pauseArgs, err = json.Marshal(input)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
 	c.Assert(err, IsNil)

--- a/server/api/checker_test.go
+++ b/server/api/checker_test.go
@@ -80,7 +80,7 @@ func (s *testCheckerSuite) TestAPI(c *C) {
 }
 
 func (s *testCheckerSuite) testPauseOrResume(name string, body []byte, extraTest func(string, *C), c *C) {
-	//handler := s.svr.GetHandler()
+	handler := s.svr.GetHandler()
 
 	// test pause.
 	input := make(map[string]interface{})
@@ -89,18 +89,18 @@ func (s *testCheckerSuite) testPauseOrResume(name string, body []byte, extraTest
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
 	c.Assert(err, IsNil)
-	//isPaused, err := handler.IsCheckerPaused(createdName)
-	//c.Assert(err, IsNil)
-	//c.Assert(isPaused, Equals, true)
+	isPaused, err := handler.IsCheckerPaused(name)
+	c.Assert(err, IsNil)
+	c.Assert(isPaused, Equals, true)
 	input["delay"] = 1
 	pauseArgs, err = json.Marshal(input)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
 	c.Assert(err, IsNil)
 	time.Sleep(time.Second)
-	//isPaused, err = handler.IsCheckerPaused(createdName)
-	//c.Assert(err, IsNil)
-	//c.Assert(isPaused, Equals, false)
+	isPaused, err = handler.IsCheckerPaused(name)
+	c.Assert(err, IsNil)
+	c.Assert(isPaused, Equals, false)
 
 	// test resume.
 	input = make(map[string]interface{})
@@ -114,9 +114,9 @@ func (s *testCheckerSuite) testPauseOrResume(name string, body []byte, extraTest
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
 	c.Assert(err, IsNil)
-	//isPaused, err = handler.IsCheckerPaused(createdName)
-	//c.Assert(err, IsNil)
-	//c.Assert(isPaused, Equals, false)
+	isPaused, err = handler.IsCheckerPaused(name)
+	c.Assert(err, IsNil)
+	c.Assert(isPaused, Equals, false)
 
 	if extraTest != nil {
 		extraTest(name, c)

--- a/server/api/checker_test.go
+++ b/server/api/checker_test.go
@@ -1,0 +1,124 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/tikv/pd/server"
+	_ "github.com/tikv/pd/server/schedulers"
+)
+
+var _ = Suite(&testCheckerSuite{})
+
+type testCheckerSuite struct {
+	svr       *server.Server
+	cleanup   cleanUpFunc
+	urlPrefix string
+}
+
+func (s *testCheckerSuite) SetUpSuite(c *C) {
+	s.svr, s.cleanup = mustNewServer(c)
+	mustWaitLeader(c, []*server.Server{s.svr})
+
+	addr := s.svr.GetAddr()
+	s.urlPrefix = fmt.Sprintf("%s%s/api/v1/checker", addr, apiPrefix)
+
+	mustBootstrapCluster(c, s.svr)
+	mustPutStore(c, s.svr, 1, metapb.StoreState_Up, nil)
+	mustPutStore(c, s.svr, 2, metapb.StoreState_Up, nil)
+}
+
+func (s *testCheckerSuite) TearDownSuite(c *C) {
+	s.cleanup()
+}
+
+func (s *testCheckerSuite) TestAPI(c *C) {
+	type arg struct {
+		opt   string
+		value interface{}
+	}
+	cases := []struct {
+		name          string
+		args          []arg
+		extraTestFunc func(name string, c *C)
+	}{
+		{name: "learner"},
+		{name: "replica"},
+		{name: "rule"},
+		{name: "split"},
+		{name: "merge"},
+		{name: "joint-state"},
+		{name: "priority"},
+	}
+	for _, ca := range cases {
+		input := make(map[string]interface{})
+		input["name"] = ca.name
+		for _, a := range ca.args {
+			input[a.opt] = a.value
+		}
+		body, err := json.Marshal(input)
+		c.Assert(err, IsNil)
+		s.testPauseOrResume(ca.name, body, ca.extraTestFunc, c)
+	}
+}
+
+func (s *testCheckerSuite) testPauseOrResume(name string, body []byte, extraTest func(string, *C), c *C) {
+	//handler := s.svr.GetHandler()
+
+	// test pause.
+	input := make(map[string]interface{})
+	input["delay"] = 30
+	pauseArgs, err := json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
+	c.Assert(err, IsNil)
+	//isPaused, err := handler.IsCheckerPaused(createdName)
+	//c.Assert(err, IsNil)
+	//c.Assert(isPaused, Equals, true)
+	input["delay"] = 1
+	pauseArgs, err = json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
+	c.Assert(err, IsNil)
+	time.Sleep(time.Second)
+	//isPaused, err = handler.IsCheckerPaused(createdName)
+	//c.Assert(err, IsNil)
+	//c.Assert(isPaused, Equals, false)
+
+	// test resume.
+	input = make(map[string]interface{})
+	input["delay"] = 30
+	pauseArgs, err = json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
+	c.Assert(err, IsNil)
+	input["delay"] = 0
+	pauseArgs, err = json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
+	c.Assert(err, IsNil)
+	//isPaused, err = handler.IsCheckerPaused(createdName)
+	//c.Assert(err, IsNil)
+	//c.Assert(isPaused, Equals, false)
+
+	if extraTest != nil {
+		extraTest(name, c)
+	}
+}

--- a/server/api/checker_test.go
+++ b/server/api/checker_test.go
@@ -49,6 +49,8 @@ func (s *testCheckerSuite) TearDownSuite(c *C) {
 }
 
 func (s *testCheckerSuite) TestAPI(c *C) {
+	s.testErrCases(c)
+
 	cases := []struct {
 		name string
 	}{
@@ -64,6 +66,35 @@ func (s *testCheckerSuite) TestAPI(c *C) {
 		s.testGetStatus(ca.name, c)
 		s.testPauseOrResume(ca.name, c)
 	}
+}
+
+func (s *testCheckerSuite) testErrCases(c *C) {
+	// missing args
+	input := make(map[string]interface{})
+	pauseArgs, err := json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/merge", pauseArgs)
+	c.Assert(err, NotNil)
+
+	// negative delay
+	input["delay"] = -10
+	pauseArgs, err = json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/merge", pauseArgs)
+	c.Assert(err, NotNil)
+
+	// wrong name
+	name := "dummy"
+	input["delay"] = 30
+	pauseArgs, err = json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
+	c.Assert(err, NotNil)
+	input["delay"] = 0
+	pauseArgs, err = json.Marshal(input)
+	c.Assert(err, IsNil)
+	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
+	c.Assert(err, NotNil)
 }
 
 func (s *testCheckerSuite) testGetStatus(name string, c *C) {
@@ -93,38 +124,11 @@ func (s *testCheckerSuite) testGetStatus(name string, c *C) {
 
 func (s *testCheckerSuite) testPauseOrResume(name string, c *C) {
 	handler := s.svr.GetHandler()
-
-	// test err cases
-
-	// missing args
 	input := make(map[string]interface{})
-	pauseArgs, err := json.Marshal(input)
-	c.Assert(err, IsNil)
-	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
-	c.Assert(err, NotNil)
-
-	// negative delay
-	input["delay"] = -10
-	pauseArgs, err = json.Marshal(input)
-	c.Assert(err, IsNil)
-	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
-	c.Assert(err, NotNil)
-
-	// wrong name
-	input["delay"] = 30
-	pauseArgs, err = json.Marshal(input)
-	c.Assert(err, IsNil)
-	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
-	c.Assert(err, NotNil)
-	input["delay"] = 0
-	pauseArgs, err = json.Marshal(input)
-	c.Assert(err, IsNil)
-	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
-	c.Assert(err, NotNil)
 
 	// test pause.
 	input["delay"] = 30
-	pauseArgs, err = json.Marshal(input)
+	pauseArgs, err := json.Marshal(input)
 	c.Assert(err, IsNil)
 	err = postJSON(testDialClient, s.urlPrefix+"/"+name, pauseArgs)
 	c.Assert(err, IsNil)

--- a/server/api/checker_test.go
+++ b/server/api/checker_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/server"
-	_ "github.com/tikv/pd/server/schedulers"
 )
 
 var _ = Suite(&testCheckerSuite{})

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -72,6 +72,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	apiRouter.HandleFunc("/schedulers", schedulerHandler.Post).Methods("POST")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.Delete).Methods("DELETE")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.PauseOrResume).Methods("POST")
+	apiRouter.HandleFunc("/merge", schedulerHandler.PauseOrResumeMerge).Methods("POST")
 
 	schedulerConfigHandler := newSchedulerConfigHandler(svr, rd)
 	apiRouter.PathPrefix("/scheduler-config").Handler(schedulerConfigHandler)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -72,7 +72,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	apiRouter.HandleFunc("/schedulers", schedulerHandler.Post).Methods("POST")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.Delete).Methods("DELETE")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.PauseOrResume).Methods("POST")
-	apiRouter.HandleFunc("/checker/{name}", schedulerHandler.PauseOrResumeChecker).Methods("POST")
+	apiRouter.HandleFunc("/checker/{name}", schedulerHandler.CheckerHandler).Methods("POST")
 
 	schedulerConfigHandler := newSchedulerConfigHandler(svr, rd)
 	apiRouter.PathPrefix("/scheduler-config").Handler(schedulerConfigHandler)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -72,7 +72,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	apiRouter.HandleFunc("/schedulers", schedulerHandler.Post).Methods("POST")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.Delete).Methods("DELETE")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.PauseOrResume).Methods("POST")
-	apiRouter.HandleFunc("/merge", schedulerHandler.PauseOrResumeMerge).Methods("POST")
+	apiRouter.HandleFunc("/checker/{name}", schedulerHandler.PauseOrResumeChecker).Methods("POST")
 
 	schedulerConfigHandler := newSchedulerConfigHandler(svr, rd)
 	apiRouter.PathPrefix("/scheduler-config").Handler(schedulerConfigHandler)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -67,12 +67,14 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	apiRouter.HandleFunc("/operators/{region_id}", operatorHandler.Get).Methods("GET")
 	apiRouter.HandleFunc("/operators/{region_id}", operatorHandler.Delete).Methods("DELETE")
 
+	checkerHandler := newCheckerHandler(svr, rd)
+	apiRouter.HandleFunc("/checker/{name}", checkerHandler.PauseOrResume).Methods("POST")
+
 	schedulerHandler := newSchedulerHandler(svr, rd)
 	apiRouter.HandleFunc("/schedulers", schedulerHandler.List).Methods("GET")
 	apiRouter.HandleFunc("/schedulers", schedulerHandler.Post).Methods("POST")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.Delete).Methods("DELETE")
 	apiRouter.HandleFunc("/schedulers/{name}", schedulerHandler.PauseOrResume).Methods("POST")
-	apiRouter.HandleFunc("/checker/{name}", schedulerHandler.CheckerHandler).Methods("POST")
 
 	schedulerConfigHandler := newSchedulerConfigHandler(svr, rd)
 	apiRouter.PathPrefix("/scheduler-config").Handler(schedulerConfigHandler)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -69,6 +69,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 
 	checkerHandler := newCheckerHandler(svr, rd)
 	apiRouter.HandleFunc("/checker/{name}", checkerHandler.PauseOrResume).Methods("POST")
+	apiRouter.HandleFunc("/checker/{name}", checkerHandler.GetStatus).Methods("GET")
 
 	schedulerHandler := newSchedulerHandler(svr, rd)
 	apiRouter.HandleFunc("/schedulers", schedulerHandler.List).Methods("GET")

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -324,27 +324,30 @@ func (h *schedulerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request)
 	h.r.JSON(w, http.StatusOK, "Pause or resume the scheduler successfully.")
 }
 
-// @Tags merge
+// FIXME: details of input json body params
+// @Tags checker
 // @Summary Pause or resume region merge.
 // @Accept json
+// @Param name path string true "The name of the scheduler."
 // @Param body body object true "json params"
 // @Produce json
 // @Success 200 {string} string "Pause or resume the scheduler successfully."
 // @Failure 400 {string} string "Bad format request."
 // @Failure 500 {string} string "PD server failed to proceed the request."
-// @Router /merge [post]
-func (h *schedulerHandler) PauseOrResumeMerge(w http.ResponseWriter, r *http.Request) {
+// @Router /checker/{name} [post]
+func (h *schedulerHandler) PauseOrResumeChecker(w http.ResponseWriter, r *http.Request) {
 	var input map[string]int
 	if err := apiutil.ReadJSONRespondError(h.r, w, r.Body, &input); err != nil {
 		return
 	}
 
+	name := mux.Vars(r)["name"]
 	t, ok := input["delay"]
 	if !ok {
 		h.r.JSON(w, http.StatusBadRequest, "missing pause time")
 		return
 	}
-	if err := h.PauseOrResumeMergeHandler(int64(t)); err != nil {
+	if err := h.PauseOrResumeCheckerHandler(name, int64(t)); err != nil {
 		h.r.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -324,6 +324,33 @@ func (h *schedulerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request)
 	h.r.JSON(w, http.StatusOK, "Pause or resume the scheduler successfully.")
 }
 
+// @Tags merge
+// @Summary Pause or resume region merge.
+// @Accept json
+// @Param body body object true "json params"
+// @Produce json
+// @Success 200 {string} string "Pause or resume the scheduler successfully."
+// @Failure 400 {string} string "Bad format request."
+// @Failure 500 {string} string "PD server failed to proceed the request."
+// @Router /merge [post]
+func (h *schedulerHandler) PauseOrResumeMerge(w http.ResponseWriter, r *http.Request) {
+	var input map[string]int
+	if err := apiutil.ReadJSONRespondError(h.r, w, r.Body, &input); err != nil {
+		return
+	}
+
+	t, ok := input["delay"]
+	if !ok {
+		h.r.JSON(w, http.StatusBadRequest, "missing pause time")
+		return
+	}
+	if err := h.PauseOrResumeMergeHandler(int64(t)); err != nil {
+		h.r.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.r.JSON(w, http.StatusOK, "Pause or resume merge successfully.")
+}
+
 type schedulerConfigHandler struct {
 	svr *server.Server
 	rd  *render.Render

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -335,7 +335,7 @@ func (h *schedulerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request)
 // @Failure 400 {string} string "Bad format request."
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /checker/{name} [post]
-func (h *schedulerHandler) PauseOrResumeChecker(w http.ResponseWriter, r *http.Request) {
+func (h *schedulerHandler) CheckerHandler(w http.ResponseWriter, r *http.Request) {
 	var input map[string]int
 	if err := apiutil.ReadJSONRespondError(h.r, w, r.Body, &input); err != nil {
 		return

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -324,36 +324,6 @@ func (h *schedulerHandler) PauseOrResume(w http.ResponseWriter, r *http.Request)
 	h.r.JSON(w, http.StatusOK, "Pause or resume the scheduler successfully.")
 }
 
-// FIXME: details of input json body params
-// @Tags checker
-// @Summary Pause or resume region merge.
-// @Accept json
-// @Param name path string true "The name of the scheduler."
-// @Param body body object true "json params"
-// @Produce json
-// @Success 200 {string} string "Pause or resume the scheduler successfully."
-// @Failure 400 {string} string "Bad format request."
-// @Failure 500 {string} string "PD server failed to proceed the request."
-// @Router /checker/{name} [post]
-func (h *schedulerHandler) CheckerHandler(w http.ResponseWriter, r *http.Request) {
-	var input map[string]int
-	if err := apiutil.ReadJSONRespondError(h.r, w, r.Body, &input); err != nil {
-		return
-	}
-
-	name := mux.Vars(r)["name"]
-	t, ok := input["delay"]
-	if !ok {
-		h.r.JSON(w, http.StatusBadRequest, "missing pause time")
-		return
-	}
-	if err := h.PauseOrResumeCheckerHandler(name, int64(t)); err != nil {
-		h.r.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	h.r.JSON(w, http.StatusOK, "Pause or resume merge successfully.")
-}
-
 type schedulerConfigHandler struct {
 	svr *server.Server
 	rd  *render.Render

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1629,11 +1629,11 @@ func (c *RaftCluster) PauseOrResumeScheduler(name string, t int64) error {
 	return c.coordinator.pauseOrResumeScheduler(name, t)
 }
 
-// PauseOrResumeMerge pauses or resumes merge.
-func (c *RaftCluster) PauseOrResumeMerge(t int64) error {
+// PauseOrResumeChecker pauses or resumes checker.
+func (c *RaftCluster) PauseOrResumeChecker(name string, t int64) error {
 	c.RLock()
 	defer c.RUnlock()
-	return c.coordinator.pauseOrResumeMerge(t)
+	return c.coordinator.pauseOrResumeChecker(name, t)
 }
 
 // IsSchedulerPaused checks if a scheduler is paused.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1657,6 +1657,12 @@ func (c *RaftCluster) IsSchedulerExisted(name string) (bool, error) {
 	return c.coordinator.isSchedulerExisted(name)
 }
 
+func (c *RaftCluster) IsCheckerPaused(name string) (bool, error) {
+	c.RLock()
+	defer c.RUnlock()
+	return c.coordinator.isCheckerPaused(name)
+}
+
 // GetStoreLimiter returns the dynamic adjusting limiter
 func (c *RaftCluster) GetStoreLimiter() *StoreLimiter {
 	return c.limiter

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1629,13 +1629,6 @@ func (c *RaftCluster) PauseOrResumeScheduler(name string, t int64) error {
 	return c.coordinator.pauseOrResumeScheduler(name, t)
 }
 
-// PauseOrResumeChecker pauses or resumes checker.
-func (c *RaftCluster) PauseOrResumeChecker(name string, t int64) error {
-	c.RLock()
-	defer c.RUnlock()
-	return c.coordinator.pauseOrResumeChecker(name, t)
-}
-
 // IsSchedulerPaused checks if a scheduler is paused.
 func (c *RaftCluster) IsSchedulerPaused(name string) (bool, error) {
 	c.RLock()
@@ -1657,6 +1650,14 @@ func (c *RaftCluster) IsSchedulerExisted(name string) (bool, error) {
 	return c.coordinator.isSchedulerExisted(name)
 }
 
+// PauseOrResumeChecker pauses or resumes checker.
+func (c *RaftCluster) PauseOrResumeChecker(name string, t int64) error {
+	c.RLock()
+	defer c.RUnlock()
+	return c.coordinator.pauseOrResumeChecker(name, t)
+}
+
+// IsCheckerPaused returns if checker is paused
 func (c *RaftCluster) IsCheckerPaused(name string) (bool, error) {
 	c.RLock()
 	defer c.RUnlock()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1629,6 +1629,13 @@ func (c *RaftCluster) PauseOrResumeScheduler(name string, t int64) error {
 	return c.coordinator.pauseOrResumeScheduler(name, t)
 }
 
+// PauseOrResumeMerge pauses or resumes merge.
+func (c *RaftCluster) PauseOrResumeMerge(t int64) error {
+	c.RLock()
+	defer c.RUnlock()
+	return c.coordinator.pauseOrResumeMerge(t)
+}
+
 // IsSchedulerPaused checks if a scheduler is paused.
 func (c *RaftCluster) IsSchedulerPaused(name string) (bool, error) {
 	c.RLock()

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -713,14 +713,15 @@ func (c *coordinator) pauseOrResumeScheduler(name string, t int64) error {
 	return err
 }
 
-func (c *coordinator) pauseOrResumeMerge(t int64) error {
+func (c *coordinator) pauseOrResumeChecker(name string, t int64) error {
 	c.Lock()
 	defer c.Unlock()
 	if c.cluster == nil {
 		return errs.ErrNotBootstrapped.FastGenByArgs()
 	}
-	m := c.checkers.GetMergeChecker()
-	m.PauseOrResume(t)
+	if err := c.checkers.PauseOrResume(name, t); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -719,10 +719,7 @@ func (c *coordinator) pauseOrResumeChecker(name string, t int64) error {
 	if c.cluster == nil {
 		return errs.ErrNotBootstrapped.FastGenByArgs()
 	}
-	if err := c.checkers.PauseOrResume(name, t); err != nil {
-		return err
-	}
-	return nil
+	return c.checkers.PauseOrResume(name, t)
 }
 
 func (c *coordinator) isSchedulerPaused(name string) (bool, error) {

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -713,6 +713,17 @@ func (c *coordinator) pauseOrResumeScheduler(name string, t int64) error {
 	return err
 }
 
+func (c *coordinator) pauseOrResumeMerge(t int64) error {
+	c.Lock()
+	defer c.Unlock()
+	if c.cluster == nil {
+		return errs.ErrNotBootstrapped.FastGenByArgs()
+	}
+	m := c.checkers.GetMergeChecker()
+	m.PauseOrResume(t)
+	return nil
+}
+
 func (c *coordinator) isSchedulerPaused(name string) (bool, error) {
 	c.RLock()
 	defer c.RUnlock()

--- a/server/handler.go
+++ b/server/handler.go
@@ -242,6 +242,24 @@ func (h *Handler) PauseOrResumeScheduler(name string, t int64) error {
 	return err
 }
 
+// PauseOrResumeMergeHandler pauses merge for delay seconds or resume merge
+// t == 0 : resume merge.
+// t > 0 : merge delays t seconds.
+func (h *Handler) PauseOrResumeMergeHandler(t int64) error {
+	c, err := h.GetRaftCluster()
+	if err != nil {
+		return err
+	}
+	if err = c.PauseOrResumeMerge(t); err != nil {
+		if t == 0 {
+			log.Error("can not resume merge", errs.ZapError(err))
+		} else {
+			log.Error("can not pause merge", errs.ZapError(err))
+		}
+	}
+	return err
+}
+
 // AddBalanceLeaderScheduler adds a balance-leader-scheduler.
 func (h *Handler) AddBalanceLeaderScheduler() error {
 	return h.AddScheduler(schedulers.BalanceLeaderType)

--- a/server/handler.go
+++ b/server/handler.go
@@ -252,9 +252,9 @@ func (h *Handler) PauseOrResumeChecker(name string, t int64) error {
 	}
 	if err = c.PauseOrResumeChecker(name, t); err != nil {
 		if t == 0 {
-			log.Error("can not resume merge", errs.ZapError(err))
+			log.Error("can not resume checker", zap.String("checker-name", name), errs.ZapError(err))
 		} else {
-			log.Error("can not pause merge", errs.ZapError(err))
+			log.Error("can not pause checker", zap.String("checker-name", name), errs.ZapError(err))
 		}
 	}
 	return err

--- a/server/handler.go
+++ b/server/handler.go
@@ -242,15 +242,15 @@ func (h *Handler) PauseOrResumeScheduler(name string, t int64) error {
 	return err
 }
 
-// PauseOrResumeMergeHandler pauses merge for delay seconds or resume merge
-// t == 0 : resume merge.
-// t > 0 : merge delays t seconds.
-func (h *Handler) PauseOrResumeMergeHandler(t int64) error {
+// PauseOrResumeCheckerHandler pauses checker for delay seconds or resume checker
+// t == 0 : resume checker.
+// t > 0 : checker delays t seconds.
+func (h *Handler) PauseOrResumeCheckerHandler(name string, t int64) error {
 	c, err := h.GetRaftCluster()
 	if err != nil {
 		return err
 	}
-	if err = c.PauseOrResumeMerge(t); err != nil {
+	if err = c.PauseOrResumeChecker(name, t); err != nil {
 		if t == 0 {
 			log.Error("can not resume merge", errs.ZapError(err))
 		} else {

--- a/server/handler.go
+++ b/server/handler.go
@@ -146,6 +146,15 @@ func (h *Handler) GetSchedulers() ([]string, error) {
 	return c.GetSchedulers(), nil
 }
 
+// IsCheckerPaused returns if checker is paused
+func (h *Handler) IsCheckerPaused(name string) (bool, error) {
+	rc, err := h.GetRaftCluster()
+	if err != nil {
+		return false, err
+	}
+	return rc.IsCheckerPaused(name)
+}
+
 // GetStores returns all stores in the cluster.
 func (h *Handler) GetStores() ([]*core.StoreInfo, error) {
 	rc := h.s.GetRaftCluster()

--- a/server/handler.go
+++ b/server/handler.go
@@ -242,10 +242,10 @@ func (h *Handler) PauseOrResumeScheduler(name string, t int64) error {
 	return err
 }
 
-// PauseOrResumeCheckerHandler pauses checker for delay seconds or resume checker
+// PauseOrResumeChecker pauses checker for delay seconds or resume checker
 // t == 0 : resume checker.
 // t > 0 : checker delays t seconds.
-func (h *Handler) PauseOrResumeCheckerHandler(name string, t int64) error {
+func (h *Handler) PauseOrResumeChecker(name string, t int64) error {
 	c, err := h.GetRaftCluster()
 	if err != nil {
 		return err

--- a/server/schedule/checker/checker_pause.go
+++ b/server/schedule/checker/checker_pause.go
@@ -19,17 +19,19 @@ import (
 	"time"
 )
 
-// CheckerPause sets and stores delay time in checkers.
-type CheckerPause struct {
+// Pause sets and stores delay time in checkers.
+type Pause struct {
 	delayUntil int64
 }
 
-func (c *CheckerPause) IsPaused() bool {
+// IsPaused check if checker is paused
+func (c *Pause) IsPaused() bool {
 	delayUntil := atomic.LoadInt64(&c.delayUntil)
 	return time.Now().Unix() < delayUntil
 }
 
-func (c *CheckerPause) PauseOrResume(t int64) {
+// PauseOrResume pause or resume the checker
+func (c *Pause) PauseOrResume(t int64) {
 	delayUntil := time.Now().Unix() + t
 	atomic.StoreInt64(&c.delayUntil, delayUntil)
 }

--- a/server/schedule/checker/checker_pause.go
+++ b/server/schedule/checker/checker_pause.go
@@ -1,3 +1,17 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package checker
 
 import (

--- a/server/schedule/checker/checker_pause.go
+++ b/server/schedule/checker/checker_pause.go
@@ -1,0 +1,21 @@
+package checker
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// CheckerPause sets and stores delay time in checkers.
+type CheckerPause struct {
+	delayUntil int64
+}
+
+func (c *CheckerPause) IsPaused() bool {
+	delayUntil := atomic.LoadInt64(&c.delayUntil)
+	return time.Now().Unix() < delayUntil
+}
+
+func (c *CheckerPause) PauseOrResume(t int64) {
+	delayUntil := time.Now().Unix() + t
+	atomic.StoreInt64(&c.delayUntil, delayUntil)
+}

--- a/server/schedule/checker/checker_pause.go
+++ b/server/schedule/checker/checker_pause.go
@@ -19,19 +19,19 @@ import (
 	"time"
 )
 
-// Pause sets and stores delay time in checkers.
-type Pause struct {
+// PauseController sets and stores delay time in checkers.
+type PauseController struct {
 	delayUntil int64
 }
 
 // IsPaused check if checker is paused
-func (c *Pause) IsPaused() bool {
+func (c *PauseController) IsPaused() bool {
 	delayUntil := atomic.LoadInt64(&c.delayUntil)
 	return time.Now().Unix() < delayUntil
 }
 
 // PauseOrResume pause or resume the checker
-func (c *Pause) PauseOrResume(t int64) {
+func (c *PauseController) PauseOrResume(t int64) {
 	delayUntil := time.Now().Unix() + t
 	atomic.StoreInt64(&c.delayUntil, delayUntil)
 }

--- a/server/schedule/checker/joint_state_checker.go
+++ b/server/schedule/checker/joint_state_checker.go
@@ -24,7 +24,7 @@ import (
 
 // JointStateChecker ensures region is in joint state will leave.
 type JointStateChecker struct {
-	CheckerPause
+	Pause
 	cluster opt.Cluster
 }
 

--- a/server/schedule/checker/joint_state_checker.go
+++ b/server/schedule/checker/joint_state_checker.go
@@ -24,6 +24,7 @@ import (
 
 // JointStateChecker ensures region is in joint state will leave.
 type JointStateChecker struct {
+	CheckerPause
 	cluster opt.Cluster
 }
 
@@ -37,6 +38,10 @@ func NewJointStateChecker(cluster opt.Cluster) *JointStateChecker {
 // Check verifies a region's role, creating an Operator if need.
 func (c *JointStateChecker) Check(region *core.RegionInfo) *operator.Operator {
 	checkerCounter.WithLabelValues("joint_state_checker", "check").Inc()
+	if c.IsPaused() {
+		checkerCounter.WithLabelValues("joint_state_checker", "skipped").Inc()
+		return nil
+	}
 	if !core.IsInJointState(region.GetPeers()...) {
 		return nil
 	}

--- a/server/schedule/checker/joint_state_checker.go
+++ b/server/schedule/checker/joint_state_checker.go
@@ -39,7 +39,7 @@ func NewJointStateChecker(cluster opt.Cluster) *JointStateChecker {
 func (c *JointStateChecker) Check(region *core.RegionInfo) *operator.Operator {
 	checkerCounter.WithLabelValues("joint_state_checker", "check").Inc()
 	if c.IsPaused() {
-		checkerCounter.WithLabelValues("joint_state_checker", "skipped").Inc()
+		checkerCounter.WithLabelValues("joint_state_checker", "paused").Inc()
 		return nil
 	}
 	if !core.IsInJointState(region.GetPeers()...) {

--- a/server/schedule/checker/joint_state_checker.go
+++ b/server/schedule/checker/joint_state_checker.go
@@ -24,7 +24,7 @@ import (
 
 // JointStateChecker ensures region is in joint state will leave.
 type JointStateChecker struct {
-	Pause
+	PauseController
 	cluster opt.Cluster
 }
 

--- a/server/schedule/checker/learner_checker.go
+++ b/server/schedule/checker/learner_checker.go
@@ -24,6 +24,7 @@ import (
 
 // LearnerChecker ensures region has a learner will be promoted.
 type LearnerChecker struct {
+	CheckerPause
 	cluster opt.Cluster
 }
 
@@ -36,6 +37,10 @@ func NewLearnerChecker(cluster opt.Cluster) *LearnerChecker {
 
 // Check verifies a region's role, creating an Operator if need.
 func (l *LearnerChecker) Check(region *core.RegionInfo) *operator.Operator {
+	if l.IsPaused() {
+		checkerCounter.WithLabelValues("learner_checker", "skipped").Inc()
+		return nil
+	}
 	for _, p := range region.GetLearners() {
 		op, err := operator.CreatePromoteLearnerOperator("promote-learner", l.cluster, region, p)
 		if err != nil {

--- a/server/schedule/checker/learner_checker.go
+++ b/server/schedule/checker/learner_checker.go
@@ -24,7 +24,7 @@ import (
 
 // LearnerChecker ensures region has a learner will be promoted.
 type LearnerChecker struct {
-	CheckerPause
+	Pause
 	cluster opt.Cluster
 }
 

--- a/server/schedule/checker/learner_checker.go
+++ b/server/schedule/checker/learner_checker.go
@@ -24,7 +24,7 @@ import (
 
 // LearnerChecker ensures region has a learner will be promoted.
 type LearnerChecker struct {
-	Pause
+	PauseController
 	cluster opt.Cluster
 }
 

--- a/server/schedule/checker/learner_checker.go
+++ b/server/schedule/checker/learner_checker.go
@@ -38,7 +38,7 @@ func NewLearnerChecker(cluster opt.Cluster) *LearnerChecker {
 // Check verifies a region's role, creating an Operator if need.
 func (l *LearnerChecker) Check(region *core.RegionInfo) *operator.Operator {
 	if l.IsPaused() {
-		checkerCounter.WithLabelValues("learner_checker", "skipped").Inc()
+		checkerCounter.WithLabelValues("learner_checker", "paused").Inc()
 		return nil
 	}
 	for _, p := range region.GetLearners() {

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -43,7 +43,7 @@ const (
 
 // MergeChecker ensures region to merge with adjacent region when size is small
 type MergeChecker struct {
-	Pause
+	PauseController
 	cluster    opt.Cluster
 	opts       *config.PersistOptions
 	splitCache *cache.TTLUint64

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -43,7 +43,7 @@ const (
 
 // MergeChecker ensures region to merge with adjacent region when size is small
 type MergeChecker struct {
-	CheckerPause
+	Pause
 	cluster    opt.Cluster
 	opts       *config.PersistOptions
 	splitCache *cache.TTLUint64

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -80,7 +80,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 	checkerCounter.WithLabelValues("merge_checker", "check").Inc()
 
 	if m.IsPaused() {
-		checkerCounter.WithLabelValues("merge_checker", "skipped").Inc()
+		checkerCounter.WithLabelValues("merge_checker", "paused").Inc()
 		return nil
 	}
 

--- a/server/schedule/checker/priority_checker.go
+++ b/server/schedule/checker/priority_checker.go
@@ -29,6 +29,7 @@ const defaultPriorityQueueSize = 1280
 
 // PriorityChecker ensures high priority region should run first
 type PriorityChecker struct {
+	CheckerPause
 	cluster opt.Cluster
 	opts    *config.PersistOptions
 	queue   *cache.PriorityQueue
@@ -67,6 +68,10 @@ func NewRegionEntry(regionID uint64) *RegionPriorityEntry {
 
 // Check check region's replicas, it will put into priority queue if the region lack of replicas.
 func (p *PriorityChecker) Check(region *core.RegionInfo) (fit *placement.RegionFit) {
+	if p.IsPaused() {
+		checkerCounter.WithLabelValues("priority_checker", "skipped").Inc()
+		return nil
+	}
 	var makeupCount int
 	if p.opts.IsPlacementRulesEnabled() {
 		makeupCount, fit = p.checkRegionInPlacementRule(region)

--- a/server/schedule/checker/priority_checker.go
+++ b/server/schedule/checker/priority_checker.go
@@ -69,7 +69,7 @@ func NewRegionEntry(regionID uint64) *RegionPriorityEntry {
 // Check check region's replicas, it will put into priority queue if the region lack of replicas.
 func (p *PriorityChecker) Check(region *core.RegionInfo) (fit *placement.RegionFit) {
 	if p.IsPaused() {
-		checkerCounter.WithLabelValues("priority_checker", "skipped").Inc()
+		checkerCounter.WithLabelValues("priority_checker", "paused").Inc()
 		return nil
 	}
 	var makeupCount int

--- a/server/schedule/checker/priority_checker.go
+++ b/server/schedule/checker/priority_checker.go
@@ -29,7 +29,7 @@ const defaultPriorityQueueSize = 1280
 
 // PriorityChecker ensures high priority region should run first
 type PriorityChecker struct {
-	Pause
+	PauseController
 	cluster opt.Cluster
 	opts    *config.PersistOptions
 	queue   *cache.PriorityQueue

--- a/server/schedule/checker/priority_checker.go
+++ b/server/schedule/checker/priority_checker.go
@@ -29,7 +29,7 @@ const defaultPriorityQueueSize = 1280
 
 // PriorityChecker ensures high priority region should run first
 type PriorityChecker struct {
-	CheckerPause
+	Pause
 	cluster opt.Cluster
 	opts    *config.PersistOptions
 	queue   *cache.PriorityQueue

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -43,6 +43,7 @@ const (
 // Unhealthy replica management, mainly used for disaster recovery of TiKV.
 // Location management, mainly used for cross data center deployment.
 type ReplicaChecker struct {
+	CheckerPause
 	cluster           opt.Cluster
 	opts              *config.PersistOptions
 	regionWaitingList cache.Cache
@@ -65,6 +66,10 @@ func (r *ReplicaChecker) GetType() string {
 // Check verifies a region's replicas, creating an operator.Operator if need.
 func (r *ReplicaChecker) Check(region *core.RegionInfo) *operator.Operator {
 	checkerCounter.WithLabelValues("replica_checker", "check").Inc()
+	if r.IsPaused() {
+		checkerCounter.WithLabelValues("replica_checker", "skipped").Inc()
+		return nil
+	}
 	if op := r.checkDownPeer(region); op != nil {
 		checkerCounter.WithLabelValues("replica_checker", "new-operator").Inc()
 		op.SetPriorityLevel(core.HighPriority)

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -43,7 +43,7 @@ const (
 // Unhealthy replica management, mainly used for disaster recovery of TiKV.
 // Location management, mainly used for cross data center deployment.
 type ReplicaChecker struct {
-	Pause
+	PauseController
 	cluster           opt.Cluster
 	opts              *config.PersistOptions
 	regionWaitingList cache.Cache

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -43,7 +43,7 @@ const (
 // Unhealthy replica management, mainly used for disaster recovery of TiKV.
 // Location management, mainly used for cross data center deployment.
 type ReplicaChecker struct {
-	CheckerPause
+	Pause
 	cluster           opt.Cluster
 	opts              *config.PersistOptions
 	regionWaitingList cache.Cache

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -67,7 +67,7 @@ func (r *ReplicaChecker) GetType() string {
 func (r *ReplicaChecker) Check(region *core.RegionInfo) *operator.Operator {
 	checkerCounter.WithLabelValues("replica_checker", "check").Inc()
 	if r.IsPaused() {
-		checkerCounter.WithLabelValues("replica_checker", "skipped").Inc()
+		checkerCounter.WithLabelValues("replica_checker", "paused").Inc()
 		return nil
 	}
 	if op := r.checkDownPeer(region); op != nil {

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -34,7 +34,7 @@ import (
 
 // RuleChecker fix/improve region by placement rules.
 type RuleChecker struct {
-	CheckerPause
+	Pause
 	cluster           opt.Cluster
 	ruleManager       *placement.RuleManager
 	name              string

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -68,7 +68,7 @@ func (c *RuleChecker) Check(region *core.RegionInfo) *operator.Operator {
 // CheckWithFit is similar with Checker with placement.RegionFit
 func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.RegionFit) (op *operator.Operator) {
 	if c.IsPaused() {
-		checkerCounter.WithLabelValues("rule_checker", "skipped").Inc()
+		checkerCounter.WithLabelValues("rule_checker", "paused").Inc()
 		return nil
 	}
 	// If the fit is fetched from cache, it seems that the region doesn't need cache

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -34,6 +34,7 @@ import (
 
 // RuleChecker fix/improve region by placement rules.
 type RuleChecker struct {
+	CheckerPause
 	cluster           opt.Cluster
 	ruleManager       *placement.RuleManager
 	name              string
@@ -66,6 +67,10 @@ func (c *RuleChecker) Check(region *core.RegionInfo) *operator.Operator {
 
 // CheckWithFit is similar with Checker with placement.RegionFit
 func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.RegionFit) (op *operator.Operator) {
+	if c.IsPaused() {
+		checkerCounter.WithLabelValues("rule_checker", "skipped").Inc()
+		return nil
+	}
 	// If the fit is fetched from cache, it seems that the region doesn't need cache
 	if fit.IsCached() {
 		failpoint.Inject("assertShouldNotCache", func() {

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -34,7 +34,7 @@ import (
 
 // RuleChecker fix/improve region by placement rules.
 type RuleChecker struct {
-	Pause
+	PauseController
 	cluster           opt.Cluster
 	ruleManager       *placement.RuleManager
 	name              string

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -27,6 +27,7 @@ import (
 
 // SplitChecker splits regions when the key range spans across rule/label boundary.
 type SplitChecker struct {
+	CheckerPause
 	cluster     opt.Cluster
 	ruleManager *placement.RuleManager
 	labeler     *labeler.RegionLabeler
@@ -49,6 +50,11 @@ func (c *SplitChecker) GetType() string {
 // Check checks whether the region need to split and returns Operator to fix.
 func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 	checkerCounter.WithLabelValues("split_checker", "check").Inc()
+
+	if c.IsPaused() {
+		checkerCounter.WithLabelValues("split_checker", "skipped").Inc()
+		return nil
+	}
 
 	start, end := region.GetStartKey(), region.GetEndKey()
 	// We may consider to merge labeler split keys and rule split keys together

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -27,7 +27,7 @@ import (
 
 // SplitChecker splits regions when the key range spans across rule/label boundary.
 type SplitChecker struct {
-	CheckerPause
+	Pause
 	cluster     opt.Cluster
 	ruleManager *placement.RuleManager
 	labeler     *labeler.RegionLabeler

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -52,7 +52,7 @@ func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 	checkerCounter.WithLabelValues("split_checker", "check").Inc()
 
 	if c.IsPaused() {
-		checkerCounter.WithLabelValues("split_checker", "skipped").Inc()
+		checkerCounter.WithLabelValues("split_checker", "paused").Inc()
 		return nil
 	}
 

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -27,7 +27,7 @@ import (
 
 // SplitChecker splits regions when the key range spans across rule/label boundary.
 type SplitChecker struct {
-	Pause
+	PauseController
 	cluster     opt.Cluster
 	ruleManager *placement.RuleManager
 	labeler     *labeler.RegionLabeler

--- a/server/schedule/checker_controller.go
+++ b/server/schedule/checker_controller.go
@@ -154,25 +154,25 @@ func (c *CheckerController) RemovePriorityRegions(id uint64) {
 	c.priorityChecker.RemovePriorityRegion(id)
 }
 
-// PauseOrResume pause or resume a specific checker
-func (c *CheckerController) PauseOrResume(name string, t int64) error {
+// GetPauseController returns pause controller of the checker
+func (c *CheckerController) GetPauseController(name string) (*checker.PauseController, error) {
 	switch name {
 	case "learner":
-		c.learnerChecker.PauseOrResume(t)
+		return &c.learnerChecker.PauseController, nil
 	case "replica":
-		c.replicaChecker.PauseOrResume(t)
+		return &c.replicaChecker.PauseController, nil
 	case "rule":
-		c.ruleChecker.PauseOrResume(t)
+		return &c.ruleChecker.PauseController, nil
 	case "split":
-		c.splitChecker.PauseOrResume(t)
+		return &c.splitChecker.PauseController, nil
 	case "merge":
-		c.mergeChecker.PauseOrResume(t)
+		return &c.mergeChecker.PauseController, nil
 	case "joint-state":
-		c.jointStateChecker.PauseOrResume(t)
+		return &c.jointStateChecker.PauseController, nil
 	case "priority":
-		c.priorityChecker.PauseOrResume(t)
+		return &c.priorityChecker.PauseController, nil
 	default:
-		return errs.ErrCheckerNotFound.FastGenByArgs()
+		return nil, errs.ErrCheckerNotFound.FastGenByArgs()
 	}
-	return nil
 }
+

--- a/server/schedule/checker_controller.go
+++ b/server/schedule/checker_controller.go
@@ -176,4 +176,3 @@ func (c *CheckerController) PauseOrResume(name string, t int64) error {
 	}
 	return nil
 }
-


### PR DESCRIPTION
Signed-off-by: Peng Guanwen <pg999w@outlook.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

When TiKV is in import mode, we don't want PD to merge regions. This PR add a new API to stop region merge for a given time.

### What is changed and how it works?

A new PD REST API `/checker/{name}` with a paramenter `{delay}` is added. When called, PD will not trigger corresponding checker in the following `{delay}` seconds.

### Check List

<!-- At least one of them must be included. -->

- Unit test
- Integration test

Code changes

- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Add a `/checker/{name}` API to pause region merge.
```
