### PR TITLE
election: fix the data race of the leadership resetting

### DIFF
--- a/server/election/lease.go
+++ b/server/election/lease.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/etcdutil"
+	"github.com/tikv/pd/pkg/typeutil"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 )
@@ -71,7 +72,7 @@ func (l *lease) Close() error {
 		return nil
 	}
 	// Reset expire time.
-	l.expireTime.Store(time.Time{})
+	l.expireTime.Store(typeutil.ZeroTime)
 	// Try to revoke lease to make subsequent elections faster.
 	ctx, cancel := context.WithTimeout(l.client.Ctx(), revokeLeaseTimeout)
 	defer cancel()
@@ -85,7 +86,8 @@ func (l *lease) IsExpired() bool {
 	if l == nil {
 		return true
 	}
-	if l.expireTime.Load() == nil {
+	expireTime := l.expireTime.Load()
+	if expireTime == nil || expireTime == typeutil.ZeroTime {
 		return false
 	}
 	return time.Now().After(l.expireTime.Load().(time.Time))

--- a/server/election/lease.go
+++ b/server/election/lease.go
@@ -86,8 +86,7 @@ func (l *lease) IsExpired() bool {
 	if l == nil {
 		return true
 	}
-	expireTime := l.expireTime.Load()
-	if expireTime == nil || expireTime == typeutil.ZeroTime {
+	if l.expireTime.Load() == nil {
 		return false
 	}
 	return time.Now().After(l.expireTime.Load().(time.Time))

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -933,7 +933,7 @@ func (am *AllocatorManager) ResetAllocatorGroup(dcLocation string) {
 	defer am.mu.Unlock()
 	if allocatorGroup, exist := am.mu.allocatorGroups[dcLocation]; exist {
 		allocatorGroup.allocator.Reset()
-		// Reset if it still has the leadership.
+		// Reset if it still has the leadership. Otherwise the data race may occur because of the re-campaigning.
 		if allocatorGroup.leadership.Check() {
 			allocatorGroup.leadership.Reset()
 		}

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -933,7 +933,10 @@ func (am *AllocatorManager) ResetAllocatorGroup(dcLocation string) {
 	defer am.mu.Unlock()
 	if allocatorGroup, exist := am.mu.allocatorGroups[dcLocation]; exist {
 		allocatorGroup.allocator.Reset()
-		allocatorGroup.leadership.Reset()
+		// Reset if it still has the leadership.
+		if allocatorGroup.leadership.Check() {
+			allocatorGroup.leadership.Reset()
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Fix the data race of the leadership resetting.

![image](https://user-images.githubusercontent.com/1446531/132672244-1485d490-6412-4091-953c-96907dc7ab42.png)

ref: https://ci2.pingcap.net/blue/rest/organizations/jenkins/pipelines/pd_test/runs/2203/nodes/50/steps/94/log/?start=0

### What is changed and how it works?

Make sure the leadership is not expired before resetting it.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
