### PR TITLE
*: remove light learner/peer

### DIFF
--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -651,7 +651,7 @@ func (b *Builder) execDemoteFollower(peer *metapb.Peer) {
 
 func (b *Builder) execAddPeer(peer *metapb.Peer) {
 	if b.lightWeight {
-		b.steps = append(b.steps, AddLearner{ToStore: peer.GetStoreId(), PeerID: peer.GetId(), IsLightWeight: true})
+		b.steps = append(b.steps, AddLearner{ToStore: peer.GetStoreId(), PeerID: peer.GetId(), IsLightWeight: b.lightWeight})
 	} else {
 		b.steps = append(b.steps, AddLearner{ToStore: peer.GetStoreId(), PeerID: peer.GetId()})
 	}

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -651,7 +651,7 @@ func (b *Builder) execDemoteFollower(peer *metapb.Peer) {
 
 func (b *Builder) execAddPeer(peer *metapb.Peer) {
 	if b.lightWeight {
-		b.steps = append(b.steps, AddLightLearner{ToStore: peer.GetStoreId(), PeerID: peer.GetId()})
+		b.steps = append(b.steps, AddLearner{ToStore: peer.GetStoreId(), PeerID: peer.GetId(), IsLightWeight: true})
 	} else {
 		b.steps = append(b.steps, AddLearner{ToStore: peer.GetStoreId(), PeerID: peer.GetId()})
 	}

--- a/server/schedule/operator/builder_test.go
+++ b/server/schedule/operator/builder_test.go
@@ -439,14 +439,10 @@ func (s *testBuilderSuite) TestBuild(c *C) {
 				c.Assert(step.ToStore, Equals, tc.steps[i].(TransferLeader).ToStore)
 			case AddPeer:
 				c.Assert(step.ToStore, Equals, tc.steps[i].(AddPeer).ToStore)
-			case AddLightPeer:
-				c.Assert(step.ToStore, Equals, tc.steps[i].(AddLightPeer).ToStore)
 			case RemovePeer:
 				c.Assert(step.FromStore, Equals, tc.steps[i].(RemovePeer).FromStore)
 			case AddLearner:
 				c.Assert(step.ToStore, Equals, tc.steps[i].(AddLearner).ToStore)
-			case AddLightLearner:
-				c.Assert(step.ToStore, Equals, tc.steps[i].(AddLightLearner).ToStore)
 			case PromoteLearner:
 				c.Assert(step.ToStore, Equals, tc.steps[i].(PromoteLearner).ToStore)
 			case DemoteFollower:

--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -334,11 +334,7 @@ func (o *Operator) History() []OpHistory {
 			})
 		case AddPeer:
 			addPeerStores = append(addPeerStores, s.ToStore)
-		case AddLightPeer:
-			addPeerStores = append(addPeerStores, s.ToStore)
 		case AddLearner:
-			addPeerStores = append(addPeerStores, s.ToStore)
-		case AddLightLearner:
 			addPeerStores = append(addPeerStores, s.ToStore)
 		case RemovePeer:
 			removePeerStores = append(removePeerStores, s.FromStore)

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -84,6 +84,7 @@ func (tl TransferLeader) Influence(opInfluence OpInfluence, region *core.RegionI
 // AddPeer is an OpStep that adds a region peer.
 type AddPeer struct {
 	ToStore, PeerID uint64
+	IsLightWeight   bool
 }
 
 // ConfVerChanged returns the delta value for version increased by this step.
@@ -115,6 +116,9 @@ func (ap AddPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	regionSize := region.GetApproximateSize()
 	to.RegionSize += regionSize
 	to.RegionCount++
+	if ap.IsLightWeight {
+		return
+	}
 	to.AdjustStepCost(storelimit.AddPeer, regionSize)
 }
 
@@ -130,6 +134,7 @@ func (ap AddPeer) CheckSafety(region *core.RegionInfo) error {
 // AddLearner is an OpStep that adds a region learner peer.
 type AddLearner struct {
 	ToStore, PeerID uint64
+	IsLightWeight   bool
 }
 
 // ConfVerChanged returns the delta value for version increased by this step.
@@ -176,6 +181,9 @@ func (al AddLearner) Influence(opInfluence OpInfluence, region *core.RegionInfo)
 	regionSize := region.GetApproximateSize()
 	to.RegionSize += regionSize
 	to.RegionCount++
+	if al.IsLightWeight {
+		return
+	}
 	to.AdjustStepCost(storelimit.AddPeer, regionSize)
 }
 
@@ -346,100 +354,6 @@ func (sr SplitRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo
 // CheckSafety checks if the step meets the safety properties.
 func (sr SplitRegion) CheckSafety(region *core.RegionInfo) error {
 	return nil
-}
-
-// AddLightPeer is an OpStep that adds a region peer without considering the influence.
-type AddLightPeer struct {
-	ToStore, PeerID uint64
-}
-
-// ConfVerChanged returns the delta value for version increased by this step.
-func (ap AddLightPeer) ConfVerChanged(region *core.RegionInfo) uint64 {
-	peer := region.GetStoreVoter(ap.ToStore)
-	return typeutil.BoolToUint64(peer.GetId() == ap.PeerID)
-}
-
-func (ap AddLightPeer) String() string {
-	return fmt.Sprintf("add peer %v on store %v", ap.PeerID, ap.ToStore)
-}
-
-// IsFinish checks if current step is finished.
-func (ap AddLightPeer) IsFinish(region *core.RegionInfo) bool {
-	if peer := region.GetStoreVoter(ap.ToStore); peer != nil {
-		if peer.GetId() != ap.PeerID {
-			log.Warn("obtain unexpected peer", zap.String("expect", ap.String()), zap.Uint64("obtain-voter", peer.GetId()))
-			return false
-		}
-		return region.GetPendingVoter(peer.GetId()) == nil
-	}
-	return false
-}
-
-// CheckSafety checks if the step meets the safety properties.
-func (ap AddLightPeer) CheckSafety(region *core.RegionInfo) error {
-	peer := region.GetStorePeer(ap.ToStore)
-	if peer != nil && peer.GetId() != ap.PeerID {
-		return errors.Errorf("peer %d has already existed in store %d, the operator is trying to add peer %d on the same store", peer.GetId(), ap.ToStore, ap.PeerID)
-	}
-	return nil
-}
-
-// Influence calculates the store difference that current step makes.
-func (ap AddLightPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
-	to := opInfluence.GetStoreInfluence(ap.ToStore)
-
-	to.RegionSize += region.GetApproximateSize()
-	to.RegionCount++
-}
-
-// AddLightLearner is an OpStep that adds a region learner peer without considering the influence.
-type AddLightLearner struct {
-	ToStore, PeerID uint64
-}
-
-// ConfVerChanged returns the delta value for version increased by this step.
-func (al AddLightLearner) ConfVerChanged(region *core.RegionInfo) uint64 {
-	peer := region.GetStorePeer(al.ToStore)
-	return typeutil.BoolToUint64(peer.GetId() == al.PeerID)
-}
-
-func (al AddLightLearner) String() string {
-	return fmt.Sprintf("add learner peer %v on store %v", al.PeerID, al.ToStore)
-}
-
-// IsFinish checks if current step is finished.
-func (al AddLightLearner) IsFinish(region *core.RegionInfo) bool {
-	if peer := region.GetStoreLearner(al.ToStore); peer != nil {
-		if peer.GetId() != al.PeerID {
-			log.Warn("obtain unexpected peer", zap.String("expect", al.String()), zap.Uint64("obtain-learner", peer.GetId()))
-			return false
-		}
-		return region.GetPendingLearner(peer.GetId()) == nil
-	}
-	return false
-}
-
-// CheckSafety checks if the step meets the safety properties.
-func (al AddLightLearner) CheckSafety(region *core.RegionInfo) error {
-	peer := region.GetStorePeer(al.ToStore)
-	if peer == nil {
-		return nil
-	}
-	if peer.GetId() != al.PeerID {
-		return errors.Errorf("peer %d has already existed in store %d, the operator is trying to add peer %d on the same store", peer.GetId(), al.ToStore, al.PeerID)
-	}
-	if !core.IsLearner(peer) {
-		return errors.New("peer already is a voter")
-	}
-	return nil
-}
-
-// Influence calculates the store difference that current step makes.
-func (al AddLightLearner) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
-	to := opInfluence.GetStoreInfluence(al.ToStore)
-
-	to.RegionSize += region.GetApproximateSize()
-	to.RegionCount++
 }
 
 // DemoteFollower is an OpStep that demotes a region follower peer to learner.

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -651,19 +651,7 @@ func (oc *OperatorController) SendScheduleCommand(region *core.RegionInfo, step 
 			return
 		}
 		cmd = addNode(st.PeerID, st.ToStore)
-	case operator.AddLightPeer:
-		if region.GetStorePeer(st.ToStore) != nil {
-			// The newly added peer is pending.
-			return
-		}
-		cmd = addNode(st.PeerID, st.ToStore)
 	case operator.AddLearner:
-		if region.GetStorePeer(st.ToStore) != nil {
-			// The newly added peer is pending.
-			return
-		}
-		cmd = addLearnerNode(st.PeerID, st.ToStore)
-	case operator.AddLightLearner:
 		if region.GetStorePeer(st.ToStore) != nil {
 			// The newly added peer is pending.
 			return

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -489,7 +489,7 @@ func (t *testOperatorControllerSuite) TestDispatchUnfinishedStep(c *C) {
 			operator.RemovePeer{FromStore: 1},
 		},
 		{
-			operator.AddLightLearner{ToStore: 3, PeerID: 3},
+			operator.AddLearner{ToStore: 3, PeerID: 3, IsLightWeight: true},
 			operator.PromoteLearner{ToStore: 3, PeerID: 3},
 			operator.TransferLeader{ToStore: 3},
 			operator.RemovePeer{FromStore: 1},

--- a/server/schedule/test_util.go
+++ b/server/schedule/test_util.go
@@ -37,15 +37,6 @@ func ApplyOperatorStep(region *core.RegionInfo, op *operator.Operator) *core.Reg
 				StoreId: s.ToStore,
 			}
 			region = region.Clone(core.WithAddPeer(peer))
-		case operator.AddLightPeer:
-			if region.GetStorePeer(s.ToStore) != nil {
-				panic("Add peer that exists")
-			}
-			peer := &metapb.Peer{
-				Id:      s.PeerID,
-				StoreId: s.ToStore,
-			}
-			region = region.Clone(core.WithAddPeer(peer))
 		case operator.RemovePeer:
 			if region.GetStorePeer(s.FromStore) == nil {
 				panic("Remove peer that doesn't exist")
@@ -55,16 +46,6 @@ func ApplyOperatorStep(region *core.RegionInfo, op *operator.Operator) *core.Reg
 			}
 			region = region.Clone(core.WithRemoveStorePeer(s.FromStore))
 		case operator.AddLearner:
-			if region.GetStorePeer(s.ToStore) != nil {
-				panic("Add learner that exists")
-			}
-			peer := &metapb.Peer{
-				Id:      s.PeerID,
-				StoreId: s.ToStore,
-				Role:    metapb.PeerRole_Learner,
-			}
-			region = region.Clone(core.WithAddPeer(peer))
-		case operator.AddLightLearner:
 			if region.GetStorePeer(s.ToStore) != nil {
 				panic("Add learner that exists")
 			}


### PR DESCRIPTION
### What problem does this PR solve?

This PR removes the light learner/peer.

### What is changed and how it works?

Use a flag `IsLightWeight` to represent the learner/peer without the limitation of store limit.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
