### PR TITLE
election: use the RWMutex to avoid panic of the election

### DIFF
--- a/server/election/leadership.go
+++ b/server/election/leadership.go
@@ -118,15 +118,15 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...cl
 
 // Keep will keep the leadership available by update the lease's expired time continuously
 func (ls *Leadership) Keep(ctx context.Context) {
-	ls.leaseMutex.RLock()
-	if ls.leaseMutex.lease == nil {
-		ls.leaseMutex.RUnlock()
+	ls.leaseMutex.Lock()
+	lease := ls.leaseMutex.lease
+	if lease == nil {
+		ls.leaseMutex.Unlock()
 		return
 	}
-	lease := ls.leaseMutex.lease
-	ls.leaseMutex.RUnlock()
-
 	ls.keepAliveCtx, ls.keepAliceCancelFunc = context.WithCancel(ctx)
+	ls.leaseMutex.Unlock()
+	// Release the lock before we keep alive the lease because this function won't return in general.
 	lease.KeepAlive(ls.keepAliveCtx)
 }
 

--- a/server/election/lease.go
+++ b/server/election/lease.go
@@ -49,6 +49,9 @@ type lease struct {
 
 // Grant uses `lease.Grant` to initialize the lease and expireTime.
 func (l *lease) Grant(leaseTimeout int64) error {
+	if l == nil {
+		return errs.ErrEtcdGrantLease.GenWithStackByCause("lease is nil")
+	}
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(l.client.Ctx(), requestTimeout)
 	leaseResp, err := l.lease.Grant(ctx, leaseTimeout)
@@ -94,6 +97,9 @@ func (l *lease) IsExpired() bool {
 
 // KeepAlive auto renews the lease and update expireTime.
 func (l *lease) KeepAlive(ctx context.Context) {
+	if l == nil {
+		return
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

![image](https://user-images.githubusercontent.com/1446531/133256364-59fdf7e0-0706-47a7-bacf-00361aa0ce31.png)

ref: https://ci2.pingcap.net/blue/organizations/jenkins/pd_test/detail/pd_test/2339/pipeline/51/

### What is changed and how it works?

Use the `RWMutex` to avoid panic of the election.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
