### PR TITLE
checker: rename priority checker to inspector

### DIFF
--- a/server/api/checker_test.go
+++ b/server/api/checker_test.go
@@ -60,7 +60,6 @@ func (s *testCheckerSuite) TestAPI(c *C) {
 		{name: "split"},
 		{name: "merge"},
 		{name: "joint-state"},
-		{name: "priority"},
 	}
 	for _, ca := range cases {
 		s.testGetStatus(ca.name, c)

--- a/server/schedule/checker/priority_inspector.go
+++ b/server/schedule/checker/priority_inspector.go
@@ -27,26 +27,20 @@ import (
 // the default value of priority queue size
 const defaultPriorityQueueSize = 1280
 
-// PriorityChecker ensures high priority region should run first
-type PriorityChecker struct {
-	PauseController
+// PriorityInspector ensures high priority region should run first
+type PriorityInspector struct {
 	cluster opt.Cluster
 	opts    *config.PersistOptions
 	queue   *cache.PriorityQueue
 }
 
-// NewPriorityChecker creates a priority checker.
-func NewPriorityChecker(cluster opt.Cluster) *PriorityChecker {
-	return &PriorityChecker{
+// NewPriorityInspector creates a priority inspector.
+func NewPriorityInspector(cluster opt.Cluster) *PriorityInspector {
+	return &PriorityInspector{
 		cluster: cluster,
 		opts:    cluster.GetOpts(),
 		queue:   cache.NewPriorityQueue(defaultPriorityQueueSize),
 	}
-}
-
-// GetType returns PriorityChecker's type
-func (p *PriorityChecker) GetType() string {
-	return "priority-checker"
 }
 
 // RegionPriorityEntry records region priority info
@@ -66,25 +60,21 @@ func NewRegionEntry(regionID uint64) *RegionPriorityEntry {
 	return &RegionPriorityEntry{regionID: regionID, Last: time.Now(), Attempt: 1}
 }
 
-// Check check region's replicas, it will put into priority queue if the region lack of replicas.
-func (p *PriorityChecker) Check(region *core.RegionInfo) (fit *placement.RegionFit) {
-	if p.IsPaused() {
-		checkerCounter.WithLabelValues("priority_checker", "paused").Inc()
-		return nil
-	}
+// Inspect inspects region's replicas, it will put into priority queue if the region lack of replicas.
+func (p *PriorityInspector) Inspect(region *core.RegionInfo) (fit *placement.RegionFit) {
 	var makeupCount int
 	if p.opts.IsPlacementRulesEnabled() {
-		makeupCount, fit = p.checkRegionInPlacementRule(region)
+		makeupCount, fit = p.inspectRegionInPlacementRule(region)
 	} else {
-		makeupCount = p.checkRegionInReplica(region)
+		makeupCount = p.inspectRegionInReplica(region)
 	}
 	priority := 0 - makeupCount
 	p.addOrRemoveRegion(priority, region.GetID())
 	return
 }
 
-// checkRegionInPlacementRule check region in placement rule mode
-func (p *PriorityChecker) checkRegionInPlacementRule(region *core.RegionInfo) (makeupCount int, fit *placement.RegionFit) {
+// inspectRegionInPlacementRule inspects region in placement rule mode
+func (p *PriorityInspector) inspectRegionInPlacementRule(region *core.RegionInfo) (makeupCount int, fit *placement.RegionFit) {
 	fit = opt.FitRegion(p.cluster, region)
 	if len(fit.RuleFits) == 0 {
 		return
@@ -100,15 +90,15 @@ func (p *PriorityChecker) checkRegionInPlacementRule(region *core.RegionInfo) (m
 	return
 }
 
-// checkReplicas check region in replica mode
-func (p *PriorityChecker) checkRegionInReplica(region *core.RegionInfo) (makeupCount int) {
+// inspectReplicas inspects region in replica mode
+func (p *PriorityInspector) inspectRegionInReplica(region *core.RegionInfo) (makeupCount int) {
 	return p.opts.GetMaxReplicas() - len(region.GetPeers())
 }
 
 // addOrRemoveRegion add or remove region from queue
 // it will remove if region's priority equal 0
 // it's Attempt will increase if region's priority equal last
-func (p *PriorityChecker) addOrRemoveRegion(priority int, regionID uint64) {
+func (p *PriorityInspector) addOrRemoveRegion(priority int, regionID uint64) {
 	if priority < 0 {
 		if entry := p.queue.Get(regionID); entry != nil && entry.Priority == priority {
 			e := entry.Value.(*RegionPriorityEntry)
@@ -123,7 +113,7 @@ func (p *PriorityChecker) addOrRemoveRegion(priority int, regionID uint64) {
 }
 
 // GetPriorityRegions returns all regions in priority queue that needs rerun
-func (p *PriorityChecker) GetPriorityRegions() (ids []uint64) {
+func (p *PriorityInspector) GetPriorityRegions() (ids []uint64) {
 	entries := p.queue.Elems()
 	for _, e := range entries {
 		re := e.Value.(*RegionPriorityEntry)
@@ -137,6 +127,6 @@ func (p *PriorityChecker) GetPriorityRegions() (ids []uint64) {
 }
 
 // RemovePriorityRegion removes priority region from priority queue
-func (p *PriorityChecker) RemovePriorityRegion(regionID uint64) {
+func (p *PriorityInspector) RemovePriorityRegion(regionID uint64) {
 	p.queue.Remove(regionID)
 }

--- a/server/schedule/checker_controller.go
+++ b/server/schedule/checker_controller.go
@@ -42,7 +42,7 @@ type CheckerController struct {
 	splitChecker      *checker.SplitChecker
 	mergeChecker      *checker.MergeChecker
 	jointStateChecker *checker.JointStateChecker
-	priorityChecker   *checker.PriorityChecker
+	priorityInspector *checker.PriorityInspector
 	regionWaitingList cache.Cache
 }
 
@@ -60,7 +60,7 @@ func NewCheckerController(ctx context.Context, cluster opt.Cluster, ruleManager 
 		splitChecker:      checker.NewSplitChecker(cluster, ruleManager, labeler),
 		mergeChecker:      checker.NewMergeChecker(ctx, cluster),
 		jointStateChecker: checker.NewJointStateChecker(cluster),
-		priorityChecker:   checker.NewPriorityChecker(cluster),
+		priorityInspector: checker.NewPriorityInspector(cluster),
 		regionWaitingList: regionWaitingList,
 	}
 }
@@ -80,15 +80,13 @@ func (c *CheckerController) CheckRegion(region *core.RegionInfo) []*operator.Ope
 	}
 
 	if c.opts.IsPlacementRulesEnabled() {
-		fit := c.priorityChecker.Check(region)
-		if fit != nil { // priority checker is not paused
-			if op := c.ruleChecker.CheckWithFit(region, fit); op != nil {
-				if opController.OperatorCount(operator.OpReplica) < c.opts.GetReplicaScheduleLimit() {
-					return []*operator.Operator{op}
-				}
-				operator.OperatorLimitCounter.WithLabelValues(c.ruleChecker.GetType(), operator.OpReplica.String()).Inc()
-				c.regionWaitingList.Put(region.GetID(), nil)
+		fit := c.priorityInspector.Inspect(region)
+		if op := c.ruleChecker.CheckWithFit(region, fit); op != nil {
+			if opController.OperatorCount(operator.OpReplica) < c.opts.GetReplicaScheduleLimit() {
+				return []*operator.Operator{op}
 			}
+			operator.OperatorLimitCounter.WithLabelValues(c.ruleChecker.GetType(), operator.OpReplica.String()).Inc()
+			c.regionWaitingList.Put(region.GetID(), nil)
 		}
 	} else {
 		if op := c.learnerChecker.Check(region); op != nil {
@@ -144,12 +142,12 @@ func (c *CheckerController) RemoveWaitingRegion(id uint64) {
 
 // GetPriorityRegions returns the region in priority queue
 func (c *CheckerController) GetPriorityRegions() []uint64 {
-	return c.priorityChecker.GetPriorityRegions()
+	return c.priorityInspector.GetPriorityRegions()
 }
 
 // RemovePriorityRegions removes priority region from priority queue
 func (c *CheckerController) RemovePriorityRegions(id uint64) {
-	c.priorityChecker.RemovePriorityRegion(id)
+	c.priorityInspector.RemovePriorityRegion(id)
 }
 
 // GetPauseController returns pause controller of the checker
@@ -167,8 +165,6 @@ func (c *CheckerController) GetPauseController(name string) (*checker.PauseContr
 		return &c.mergeChecker.PauseController, nil
 	case "joint-state":
 		return &c.jointStateChecker.PauseController, nil
-	case "priority":
-		return &c.priorityChecker.PauseController, nil
 	default:
 		return nil, errs.ErrCheckerNotFound.FastGenByArgs()
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Here is a bug that when we pause the priority checker, it will skip the rule checker also. BTW, the name for the priority checker is a little bit confusing.

### What is changed and how it works?

This PR renames the priority checker to the priority inspector. And if we call a checker, we think it will return operators.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
