### PR TITLE
testing: make TestStoreOverloaded stable

### DIFF
--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -989,6 +989,7 @@ func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
 	// scheduling one time needs 1/10 seconds
 	opt.SetAllStoresLimit(storelimit.AddPeer, 600)
 	opt.SetAllStoresLimit(storelimit.RemovePeer, 600)
+	time.Sleep(time.Second)
 	for i := 0; i < 10; i++ {
 		ops := lb.Schedule(tc)
 		c.Assert(ops, HasLen, 1)
@@ -997,7 +998,7 @@ func (s *testOperatorControllerSuite) TestStoreOverloaded(c *C) {
 		c.Assert(oc.RemoveOperator(op), IsTrue)
 	}
 	// sleep 1 seconds to make sure that the token is filled up
-	time.Sleep(1 * time.Second)
+	time.Sleep(time.Second)
 	for i := 0; i < 100; i++ {
 		c.Assert(lb.Schedule(tc), NotNil)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

This PR is trying to make `TestStoreOverloaded` more stable. 

### What is changed and how it works?

Just sleep 1s before scheduling.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
