### PR TITLE
checker: support demote voter in rule checker

### DIFF
--- a/server/core/peer.go
+++ b/server/core/peer.go
@@ -23,6 +23,11 @@ func IsLearner(peer *metapb.Peer) bool {
 	return peer.GetRole() == metapb.PeerRole_Learner
 }
 
+// IsVoter judges whether the Peer's Role is Voter
+func IsVoter(peer *metapb.Peer) bool {
+	return peer.GetRole() == metapb.PeerRole_Voter
+}
+
 // IsVoterOrIncomingVoter judges whether peer role will become Voter.
 // The peer is not nil and the role is equal to IncomingVoter or Voter.
 func IsVoterOrIncomingVoter(peer *metapb.Peer) bool {

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -238,6 +238,10 @@ func (c *RuleChecker) fixLooseMatchPeer(region *core.RegionInfo, fit *placement.
 		checkerCounter.WithLabelValues("rule_checker", "no-new-leader").Inc()
 		return nil, errors.New("no new leader")
 	}
+	if core.IsVoter(peer) && rf.Rule.Role == placement.Learner {
+		checkerCounter.WithLabelValues("rule_checker", "demote-voter-role").Inc()
+		return operator.CreateDemoteVoterOperator("fix-demote-voter", c.cluster, region, peer)
+	}
 	return nil, nil
 }
 

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -37,6 +37,13 @@ func CreateAddPeerOperator(desc string, cluster opt.Cluster, region *core.Region
 		Build(kind)
 }
 
+// CreateDemoteVoterOperator creates an operator that demotes a voter
+func CreateDemoteVoterOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, cluster, region).
+		DemoteVoter(peer.GetStoreId()).
+		Build(0)
+}
+
 // CreatePromoteLearnerOperator creates an operator that promotes a learner.
 func CreatePromoteLearnerOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, cluster, region).

--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -209,7 +209,6 @@ func (w *fitWorker) fitRule(index int) bool {
 		// 3. Not selected by other rules.
 		for _, p := range w.peers {
 			if MatchLabelConstraints(p.store, w.rules[index].LabelConstraints) &&
-				p.matchRoleLoose(w.rules[index].Role) &&
 				!p.selected {
 				candidates = append(candidates, p)
 			}
@@ -316,13 +315,6 @@ func (p *fitPeer) matchRoleStrict(role PeerRoleType) bool {
 		return core.IsLearner(p.Peer)
 	}
 	return false
-}
-
-func (p *fitPeer) matchRoleLoose(role PeerRoleType) bool {
-	// non-learner cannot become learner. All other roles can migrate to
-	// others by scheduling. For example, Leader->Follower, Learner->Leader
-	// are possible, but Voter->Learner is impossible.
-	return role != Learner || core.IsLearner(p.Peer)
 }
 
 func isolationScore(peers []*fitPeer, labels []string) float64 {


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

close https://github.com/tikv/pd/issues/4140

### What is changed and how it works?
Rule checker didn't support to demote voters in order to satisfy the learner rule. This request fixes it by making voter and learner rules as loose match during `FitRegion`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
