### PR TITLE
metrics: add more percentiles for PD server TSO handle time

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -9104,20 +9104,38 @@
           "steppedLine": false,
           "targets": [
             {
+              "expr": "histogram_quantile(0.90, sum(rate(pd_server_handle_tso_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\"}[30s])) by (type, le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "90% tso",
+              "refId": "A",
+              "step": 2
+            },
+            {
               "expr": "histogram_quantile(0.99, sum(rate(pd_server_handle_tso_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\"}[30s])) by (type, le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "99%  tso",
-              "refId": "A",
+              "legendFormat": "99% tso",
+              "refId": "B",
+              "step": 2
+            },
+            {
+              "expr": "histogram_quantile(0.999, sum(rate(pd_server_handle_tso_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\"}[30s])) by (type, le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "99.9% tso",
+              "refId": "C",
               "step": 2
             },
             {
               "expr": "histogram_quantile(0.99999, sum(rate(pd_server_handle_tso_duration_seconds_bucket{tidb_cluster=\"$tidb_cluster\"}[30s])) by (type, le))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "99.999%  tso",
-              "refId": "B"
+              "legendFormat": "99.999% tso",
+              "refId": "D"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Add more percentiles for PD server TSO handle time to align with the TiDB duration metrics.

### What is changed and how it works?

Add more percentiles for PD server TSO handle time.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

![image](https://user-images.githubusercontent.com/1446531/134864138-228b38c9-0fb8-4012-ba4f-474c467ec564.png)

### Release note

```release-note
None.
```
