### PR TITLE
checker: guranteee rule checker won't miss generating operator during replace peer

### DIFF
--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -112,7 +112,7 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 			return op
 		}
 	}
-	if fit.IsSatisfied() && len(region.GetDownPeers()) == 0 {
+	if placement.ValidateFit(fit) && placement.ValidateRegion(region) && placement.ValidateStores(fit.GetRegionStores()) {
 		// If there is no need to fix, we will cache the fit
 		c.ruleManager.SetRegionFitCache(region, fit)
 		checkerCounter.WithLabelValues("rule_checker", "set-cache").Inc()

--- a/server/schedule/checker/rule_checker_test.go
+++ b/server/schedule/checker/rule_checker_test.go
@@ -761,3 +761,29 @@ func (s *testRuleCheckerSuite) TestDemoteVoter(c *C) {
 	c.Assert(op, NotNil)
 	c.Assert(op.Desc(), Equals, "fix-demote-voter")
 }
+
+func (s *testRuleCheckerSuite) TestOfflineAndDownStore(c *C) {
+	s.cluster.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
+	s.cluster.AddLabelsStore(2, 1, map[string]string{"zone": "z4"})
+	s.cluster.AddLabelsStore(3, 1, map[string]string{"zone": "z1"})
+	s.cluster.AddLabelsStore(4, 1, map[string]string{"zone": "z4"})
+	region := s.cluster.AddLeaderRegion(1, 1, 2, 3)
+	op := s.rc.Check(region)
+	c.Assert(op, IsNil)
+	// assert rule checker should generate replace offline peer operator after cached
+	s.cluster.SetStoreOffline(1)
+	op = s.rc.Check(region)
+	c.Assert(op, NotNil)
+	c.Assert(op.Desc(), Equals, "replace-rule-offline-peer")
+	// re-cache the regionFit
+	s.cluster.SetStoreUp(1)
+	op = s.rc.Check(region)
+	c.Assert(op, IsNil)
+
+	// assert rule checker should generate replace down peer operator after cached
+	s.cluster.SetStoreDown(2)
+	region = region.Clone(core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(2), DownSeconds: 60000}}))
+	op = s.rc.Check(region)
+	c.Assert(op, NotNil)
+	c.Assert(op.Desc(), Equals, "replace-rule-down-peer")
+}

--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -77,6 +77,11 @@ func (f *RegionFit) GetRuleFit(peerID uint64) *RuleFit {
 	return nil
 }
 
+// GetRegionStores returns region's stores
+func (f *RegionFit) GetRegionStores() []*core.StoreInfo {
+	return f.regionStores
+}
+
 // CompareRegionFit determines the superiority of 2 fits.
 // It returns 1 when the first fit result is better.
 func CompareRegionFit(a, b *RegionFit) int {

--- a/server/schedule/placement/region_rule_cache.go
+++ b/server/schedule/placement/region_rule_cache.go
@@ -59,6 +59,9 @@ func (manager *RegionRuleFitCacheManager) Invalid(regionID uint64) {
 func (manager *RegionRuleFitCacheManager) CheckAndGetCache(region *core.RegionInfo,
 	rules []*Rule,
 	stores []*core.StoreInfo) (bool, *RegionFit) {
+	if !ValidateRegion(region) || !ValidateStores(stores) {
+		return false, nil
+	}
 	manager.mu.RLock()
 	defer manager.mu.RUnlock()
 	if cache, ok := manager.caches[region.GetID()]; ok && cache.bestFit != nil {
@@ -71,7 +74,7 @@ func (manager *RegionRuleFitCacheManager) CheckAndGetCache(region *core.RegionIn
 
 // SetCache stores RegionFit cache
 func (manager *RegionRuleFitCacheManager) SetCache(region *core.RegionInfo, fit *RegionFit) {
-	if !validateRegion(region) || !validateFit(fit) {
+	if !ValidateRegion(region) || !ValidateFit(fit) || !ValidateStores(fit.regionStores) {
 		return
 	}
 	manager.mu.Lock()
@@ -94,10 +97,6 @@ func (cache *RegionRuleFitCache) IsUnchanged(region *core.RegionInfo, rules []*R
 }
 
 func (cache *RegionRuleFitCache) isRegionUnchanged(region *core.RegionInfo) bool {
-	// we only cache region when it is valid
-	if !validateRegion(region) {
-		return false
-	}
 	return region.GetLeader().StoreId == cache.region.leaderStoreID &&
 		cache.region.epochEqual(region)
 }
@@ -122,14 +121,6 @@ func storesEqual(a []storeCache, b []*core.StoreInfo) bool {
 			return a[i].storeEqual(b[j])
 		})
 	})
-}
-
-func validateRegion(region *core.RegionInfo) bool {
-	return region != nil && region.GetLeader() != nil && len(region.GetDownPeers()) == 0 && region.GetRegionEpoch() != nil
-}
-
-func validateFit(fit *RegionFit) bool {
-	return fit != nil && fit.rules != nil && len(fit.rules) > 0 && fit.regionStores != nil && len(fit.regionStores) > 0
 }
 
 func toRegionRuleFitCache(region *core.RegionInfo, fit *RegionFit) *RegionRuleFitCache {
@@ -230,4 +221,23 @@ func toRegionCache(r *core.RegionInfo) regionCache {
 		confVer:       r.GetRegionEpoch().ConfVer,
 		version:       r.GetRegionEpoch().Version,
 	}
+}
+
+// validateStores checks whether store isn't offline, unhealthy and disconnected.
+// Only Up store should be cached in RegionFitCache
+func ValidateStores(stores []*core.StoreInfo) bool {
+	return slice.NoneOf(stores, func(i int) bool {
+		return stores[i].IsOffline() && stores[i].IsUnhealthy() && stores[i].IsDisconnected()
+	})
+}
+
+// validateRegion checks whether region is healthy
+func ValidateRegion(region *core.RegionInfo) bool {
+	return region != nil && region.GetLeader() != nil && len(region.GetDownPeers()) == 0 && region.GetRegionEpoch() != nil
+}
+
+// validateFit checks whether regionFit is valid
+func ValidateFit(fit *RegionFit) bool {
+	return fit != nil && fit.rules != nil && len(fit.rules) > 0 && fit.regionStores != nil && len(fit.regionStores) > 0 &&
+		fit.IsSatisfied()
 }


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

This requests add more strict conditions in order to guarantee that the rule checker won't miss generating operator during replace peer


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
