### PR TITLE
config, cheker: add switch to control whether use regionFit cache

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -158,7 +158,7 @@ func (mc *Cluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
 
 func (mc *Cluster) initRuleManager() {
 	if mc.RuleManager == nil {
-		mc.RuleManager = placement.NewRuleManager(core.NewStorage(kv.NewMemoryKV()), mc)
+		mc.RuleManager = placement.NewRuleManager(core.NewStorage(kv.NewMemoryKV()), mc, mc.GetOpts())
 		mc.RuleManager.Initialize(int(mc.GetReplicationConfig().MaxReplicas), mc.GetReplicationConfig().LocationLabels)
 	}
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -234,7 +234,7 @@ func (c *RaftCluster) Start(s Server) error {
 		return nil
 	}
 
-	c.ruleManager = placement.NewRuleManager(c.storage, c)
+	c.ruleManager = placement.NewRuleManager(c.storage, c, c.GetOpts())
 	if c.opt.IsPlacementRulesEnabled() {
 		err = c.ruleManager.Initialize(c.opt.GetMaxReplicas(), c.opt.GetLocationLabels())
 		if err != nil {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -783,7 +783,7 @@ func (s *testClusterInfoSuite) TestOfflineAndMerge(c *C) {
 	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
 
 	storage := core.NewStorage(kv.NewMemoryKV())
-	cluster.ruleManager = placement.NewRuleManager(storage, cluster)
+	cluster.ruleManager = placement.NewRuleManager(storage, cluster, cluster.GetOpts())
 	if opt.IsPlacementRulesEnabled() {
 		err := cluster.ruleManager.Initialize(opt.GetMaxReplicas(), opt.GetLocationLabels())
 		if err != nil {
@@ -1079,7 +1079,7 @@ func newTestScheduleConfig() (*config.ScheduleConfig, *config.PersistOptions, er
 func newTestCluster(ctx context.Context, opt *config.PersistOptions) *testCluster {
 	storage := core.NewStorage(kv.NewMemoryKV())
 	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage, core.NewBasicCluster())
-	rc.ruleManager = placement.NewRuleManager(storage, rc)
+	rc.ruleManager = placement.NewRuleManager(storage, rc, rc.GetOpts())
 	if opt.IsPlacementRulesEnabled() {
 		err := rc.ruleManager.Initialize(opt.GetMaxReplicas(), opt.GetLocationLabels())
 		if err != nil {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1026,6 +1026,9 @@ type ReplicationConfig struct {
 	// When PlacementRules feature is enabled. MaxReplicas, LocationLabels and IsolationLabels are not used any more.
 	EnablePlacementRules bool `toml:"enable-placement-rules" json:"enable-placement-rules,string"`
 
+	// EnablePlacementRuleCache controls whether use cache during rule checker
+	EnablePlacementRulesCache bool `toml:"enable-placement-rules-cache" json:"enable-placement-rules-cache,string"`
+
 	// IsolationLevel is used to isolate replicas explicitly and forcibly if it's not empty.
 	// Its value must be empty or one of LocationLabels.
 	// Example:

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -144,6 +144,11 @@ func (o *PersistOptions) IsPlacementRulesEnabled() bool {
 	return o.GetReplicationConfig().EnablePlacementRules
 }
 
+// IsPlacementRulesCacheEnabled returns if the placement rules cache is enabled
+func (o *PersistOptions) IsPlacementRulesCacheEnabled() bool {
+	return o.GetReplicationConfig().EnablePlacementRulesCache
+}
+
 // SetPlacementRuleEnabled set PlacementRuleEnabled
 func (o *PersistOptions) SetPlacementRuleEnabled(enabled bool) {
 	v := o.GetReplicationConfig().Clone()

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -72,7 +72,7 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 		return nil
 	}
 	// If the fit is fetched from cache, it seems that the region doesn't need cache
-	if fit.IsCached() {
+	if c.cluster.GetOpts().IsPlacementRulesCacheEnabled() && fit.IsCached() {
 		failpoint.Inject("assertShouldNotCache", func() {
 			panic("cached shouldn't be used")
 		})
@@ -112,7 +112,7 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 			return op
 		}
 	}
-	if fit.IsSatisfied() && len(region.GetDownPeers()) == 0 {
+	if c.cluster.GetOpts().IsPlacementRulesCacheEnabled() && fit.IsSatisfied() && len(region.GetDownPeers()) == 0 {
 		// If there is no need to fix, we will cache the fit
 		c.ruleManager.SetRegionFitCache(region, fit)
 		checkerCounter.WithLabelValues("rule_checker", "set-cache").Inc()

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/tikv/pd/server/config"
 	"regexp"
 	"sort"
 	"strings"
@@ -45,13 +46,15 @@ type RuleManager struct {
 	keyType          string
 	storeSetInformer core.StoreSetInformer
 	cache            *RegionRuleFitCacheManager
+	opt              *config.PersistOptions
 }
 
 // NewRuleManager creates a RuleManager instance.
-func NewRuleManager(storage *core.Storage, storeSetInformer core.StoreSetInformer) *RuleManager {
+func NewRuleManager(storage *core.Storage, storeSetInformer core.StoreSetInformer, opt *config.PersistOptions) *RuleManager {
 	return &RuleManager{
 		storage:          storage,
 		storeSetInformer: storeSetInformer,
+		opt:              opt,
 		ruleConfig:       newRuleConfig(),
 		cache:            NewRegionRuleFitCacheManager(),
 	}
@@ -310,8 +313,10 @@ func (m *RuleManager) GetRulesForApplyRegion(region *core.RegionInfo) []*Rule {
 func (m *RuleManager) FitRegion(storeSet StoreSet, region *core.RegionInfo) *RegionFit {
 	regionStores := getStoresByRegion(storeSet, region)
 	rules := m.GetRulesForApplyRegion(region)
-	if ok, fit := m.cache.CheckAndGetCache(region, rules, regionStores); fit != nil && ok {
-		return fit
+	if m.opt.IsPlacementRulesCacheEnabled() {
+		if ok, fit := m.cache.CheckAndGetCache(region, rules, regionStores); fit != nil && ok {
+			return fit
+		}
 	}
 	fit := FitRegion(regionStores, region, rules)
 	fit.regionStores = regionStores

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -33,7 +33,7 @@ type testManagerSuite struct {
 func (s *testManagerSuite) SetUpTest(c *C) {
 	s.store = core.NewStorage(kv.NewMemoryKV())
 	var err error
-	s.manager = NewRuleManager(s.store, nil)
+	s.manager = NewRuleManager(s.store, nil, nil)
 	err = s.manager.Initialize(3, []string{"zone", "rack", "host"})
 	c.Assert(err, IsNil)
 }
@@ -110,7 +110,7 @@ func (s *testManagerSuite) TestSaveLoad(c *C) {
 		c.Assert(s.manager.SetRule(r.Clone()), IsNil)
 	}
 
-	m2 := NewRuleManager(s.store, nil)
+	m2 := NewRuleManager(s.store, nil, nil)
 	err := m2.Initialize(3, []string{"no", "labels"})
 	c.Assert(err, IsNil)
 	c.Assert(m2.GetAllRules(), HasLen, 3)
@@ -125,7 +125,7 @@ func (s *testManagerSuite) TestSetAfterGet(c *C) {
 	rule.Count = 1
 	s.manager.SetRule(rule)
 
-	m2 := NewRuleManager(s.store, nil)
+	m2 := NewRuleManager(s.store, nil, nil)
 	err := m2.Initialize(100, []string{})
 	c.Assert(err, IsNil)
 	rule = m2.GetRule("pd", "default")

--- a/server/statistics/region_collection_test.go
+++ b/server/statistics/region_collection_test.go
@@ -40,7 +40,7 @@ type testRegionStatisticsSuite struct {
 func (t *testRegionStatisticsSuite) SetUpTest(c *C) {
 	t.store = core.NewStorage(kv.NewMemoryKV())
 	var err error
-	t.manager = placement.NewRuleManager(t.store, nil)
+	t.manager = placement.NewRuleManager(t.store, nil, nil)
 	err = t.manager.Initialize(3, []string{"zone", "rack", "host"})
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What is changed and how it works?
Add `enable-placement-rules-cache` in config and let it control whether rule checker should use cache

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Add `enable-placement-rules-cache` in config, which will be helpful to reduce cpu cost for scheduling calculation if placement-rule is enabled.
```
