### PR TITLE
dashboard: update to v2021.10.29.1 to fix tidb-dashboard panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20210819164333-bd5706b9d9f2
 	github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7
 	github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5
-	github.com/pingcap/tidb-dashboard v0.0.0-20211008050453-a25c25809529
+	github.com/pingcap/tidb-dashboard v0.0.0-20211029025604-e5ca8c579b01
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuR
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5 h1:7rvAtZe/ZUzOKzgriNPQoBNvleJXBk4z7L3Z47+tS98=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5/go.mod h1:XsOaV712rUk63aOEKYP9PhXTIE3FMNHmC2r1wX5wElY=
-github.com/pingcap/tidb-dashboard v0.0.0-20211008050453-a25c25809529 h1:EVU+6dwm/kVb0kHsh+Wdgu2RGcpK1o9eUZI5QFzZPR4=
-github.com/pingcap/tidb-dashboard v0.0.0-20211008050453-a25c25809529/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
+github.com/pingcap/tidb-dashboard v0.0.0-20211029025604-e5ca8c579b01 h1:iQpD8whnNQoggfIO8ayKpYDHbxpufnERJ5URv42qmk0=
+github.com/pingcap/tidb-dashboard v0.0.0-20211029025604-e5ca8c579b01/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Signed-off-by: Suhaha <jklopsdfw@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
Fix dashboard tikv client's incorrect address cache. It will cause a panic:
```
[Recovery] 2021/10/29 - 13:00:59 panic recovered:
interface conversion: interface {} is []topology.StoreInfo, not []string
/usr/local/go/src/runtime/iface.go:261 (0x43352e)
	panicdottypeE: panic(&TypeAssertionError{iface, have, want, ""})
/root/tidb-dashboard/pkg/tikv/client.go:114 (0xd007e4)
	(*Client).getMemberAddrs: return cached.([]string), nil
/root/tidb-dashboard/pkg/tikv/client.go:132 (0xd0082e)
	(*Client).checkValidAddress: addrs, err := c.getMemberAddrs()
/root/tidb-dashboard/pkg/tikv/client.go:84 (0xcffb2a)
	(*Client).Get: err := c.checkValidAddress(fmt.Sprintf("%s:%d", host, statusPort))
/root/tidb-dashboard/pkg/apiserver/debugapi/http_client.go:99 (0xd14c2e)
	(*tikvImplement).Get: Get(payload.Host, payload.Port, fmt.Sprintf("%s?%s", payload.Path(), payload.Query()))
...
```

Known impact versions: 5.2.2

### What is changed and how it works?

Update tidb-dashboard version, related pr https://github.com/pingcap/tidb-dashboard/pull/1030

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix dashboard tikv client's incorrect address cache
```
