### PR TITLE
tests: use only one PD client during the TestGlobalAndLocalTSO

### DIFF
--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -333,7 +333,6 @@ func (s *clientTestSuite) TestGlobalAndLocalTSO(c *C) {
 	c.Assert(failpoint.Disable("github.com/tikv/pd/client/skipUpdateMember"), IsNil)
 
 	// Test the TSO follower proxy while enabling the Local TSO.
-	cli = setupCli(c, s.ctx, endpoints)
 	cli.UpdateOption(pd.EnableTSOFollowerProxy, true)
 	requestGlobalAndLocalTSO(c, wg, dcLocationConfig, cli)
 	cli.UpdateOption(pd.EnableTSOFollowerProxy, false)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Use only one PD client during the `TestGlobalAndLocalTSO`.

### What is changed and how it works?

Since the TSO Follower Proxy could be enabled/disabled online, there is no need to create a new PD client to test it.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
