### PR TITLE
*: sort out the usage of core.Storage and kv.Base

### DIFF
--- a/pkg/component/manager.go
+++ b/pkg/component/manager.go
@@ -27,13 +27,13 @@ import (
 // Manager is used to manage components.
 type Manager struct {
 	sync.RWMutex
-	storage *core.Storage
+	storage core.Storage
 	// component -> addresses
 	Addresses map[string][]string `json:"address"`
 }
 
 // NewManager creates a new component manager.
-func NewManager(storage *core.Storage) *Manager {
+func NewManager(storage core.Storage) *Manager {
 	return &Manager{
 		storage:   storage,
 		Addresses: make(map[string][]string),

--- a/pkg/component/manager_test.go
+++ b/pkg/component/manager_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 )
 
 func Test(t *testing.T) {
@@ -32,7 +31,7 @@ var _ = Suite(&testManagerSuite{})
 type testManagerSuite struct{}
 
 func (s *testManagerSuite) TestManager(c *C) {
-	m := NewManager(core.NewStorage(kv.NewMemoryKV()))
+	m := NewManager(core.NewMemoryStorage())
 	// register legal address
 	c.Assert(m.Register("c1", "127.0.0.1:1"), IsNil)
 	c.Assert(m.Register("c1", "127.0.0.1:2"), IsNil)

--- a/pkg/dashboard/adapter/manager.go
+++ b/pkg/dashboard/adapter/manager.go
@@ -98,7 +98,7 @@ func (m *Manager) updateInfo() {
 	if !m.srv.GetMember().IsLeader() {
 		m.isLeader = false
 		m.members = nil
-		if err := m.srv.GetPersistOptions().Reload(m.srv.GetStorage()); err != nil {
+		if err := m.srv.GetPersistOptions().Reload(m.srv.GetEtcdStorage()); err != nil {
 			log.Warn("failed to reload persist options")
 		}
 		return

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -29,7 +29,6 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/core/storelimit"
-	"github.com/tikv/pd/server/kv"
 	"github.com/tikv/pd/server/schedule/labeler"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/statistics"
@@ -69,7 +68,7 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 	if clus.PersistOptions.GetReplicationConfig().EnablePlacementRules {
 		clus.initRuleManager()
 	}
-	clus.RegionLabeler, _ = labeler.NewRegionLabeler(core.NewStorage(kv.NewMemoryKV()))
+	clus.RegionLabeler, _ = labeler.NewRegionLabeler(core.NewMemoryStorage())
 	return clus
 }
 
@@ -158,7 +157,7 @@ func (mc *Cluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
 
 func (mc *Cluster) initRuleManager() {
 	if mc.RuleManager == nil {
-		mc.RuleManager = placement.NewRuleManager(core.NewStorage(kv.NewMemoryKV()), mc, mc.GetOpts())
+		mc.RuleManager = placement.NewRuleManager(core.NewMemoryStorage(), mc, mc.GetOpts())
 		mc.RuleManager.Initialize(int(mc.GetReplicationConfig().MaxReplicas), mc.GetReplicationConfig().LocationLabels)
 	}
 }

--- a/plugin/scheduler_example/evict_leader.go
+++ b/plugin/scheduler_example/evict_leader.go
@@ -66,7 +66,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(EvictLeaderType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(EvictLeaderType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &evictLeaderSchedulerConfig{StoreIDWitRanges: make(map[uint64][]core.KeyRange), storage: storage}
 		if err := decoder(conf); err != nil {
 			return nil, err
@@ -91,7 +91,7 @@ func SchedulerArgs() []string {
 
 type evictLeaderSchedulerConfig struct {
 	mu               sync.RWMutex
-	storage          *core.Storage
+	storage          core.Storage
 	StoreIDWitRanges map[uint64][]core.KeyRange `json:"store-id-ranges"`
 	cluster          opt.Cluster
 }

--- a/server/api/service_gc_safepoint.go
+++ b/server/api/service_gc_safepoint.go
@@ -47,13 +47,13 @@ type listServiceGCSafepoint struct {
 // @Failure 500 {string} string "PD server failed to proceed the request."
 // @Router /gc/safepoint [get]
 func (h *serviceGCSafepointHandler) List(w http.ResponseWriter, r *http.Request) {
-	storage := h.svr.GetStorage()
+	storage := h.svr.GetEtcdStorage()
 	gcSafepoint, err := storage.LoadGCSafePoint()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	ssps, err := storage.GetAllServiceGCSafePoints()
+	ssps, err := storage.LoadAllServiceGCSafePoints()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -74,7 +74,7 @@ func (h *serviceGCSafepointHandler) List(w http.ResponseWriter, r *http.Request)
 // @Router /gc/safepoint/{service_id} [delete]
 // @Tags rule
 func (h *serviceGCSafepointHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	storage := h.svr.GetStorage()
+	storage := h.svr.GetEtcdStorage()
 	serviceID := mux.Vars(r)["service_id"]
 	err := storage.RemoveServiceGCSafePoint(serviceID)
 	if err != nil {

--- a/server/api/service_gc_safepoint_test.go
+++ b/server/api/service_gc_safepoint_test.go
@@ -52,7 +52,7 @@ func (s *testServiceGCSafepointSuite) TearDownSuite(c *C) {
 func (s *testServiceGCSafepointSuite) TestRegionStats(c *C) {
 	sspURL := s.urlPrefix + "/gc/safepoint"
 
-	storage := s.svr.GetStorage()
+	storage := s.svr.GetEtcdStorage()
 	list := &listServiceGCSafepoint{
 		ServiceGCSafepoints: []*core.ServiceSafePoint{
 			{
@@ -90,7 +90,7 @@ func (s *testServiceGCSafepointSuite) TestRegionStats(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(res.StatusCode, Equals, http.StatusOK)
 
-	left, err := storage.GetAllServiceGCSafePoints()
+	left, err := storage.LoadAllServiceGCSafePoints()
 	c.Assert(err, IsNil)
 	c.Assert(left, DeepEquals, list.ServiceGCSafepoints[1:])
 }

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/id"
-	"github.com/tikv/pd/server/kv"
 	"github.com/tikv/pd/server/schedule/labeler"
 	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
@@ -62,7 +61,7 @@ func (s *testClusterInfoSuite) SetUpTest(c *C) {
 func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	n, np := uint64(3), uint64(3)
 	stores := newTestStores(n, "2.0.0")
@@ -182,7 +181,7 @@ func (s *testClusterInfoSuite) TestStoreHeartbeat(c *C) {
 func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	stores := newTestStores(3, "2.0.0")
 	for _, store := range stores {
@@ -214,7 +213,7 @@ func (s *testClusterInfoSuite) TestFilterUnhealthyStore(c *C) {
 func (s *testClusterInfoSuite) TestSetOfflineStore(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	// Put 4 stores.
 	for _, store := range newTestStores(4, "2.0.0") {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
@@ -260,7 +259,7 @@ func (s *testClusterInfoSuite) TestSetOfflineStore(c *C) {
 func (s *testClusterInfoSuite) TestReuseAddress(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	// Put 4 stores.
 	for _, store := range newTestStores(4, "2.0.0") {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
@@ -301,7 +300,7 @@ func getTestDeployPath(storeID uint64) string {
 func (s *testClusterInfoSuite) TestUpStore(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	// Put 3 stores.
 	for _, store := range newTestStores(3, "2.0.0") {
@@ -334,7 +333,7 @@ func (s *testClusterInfoSuite) TestUpStore(c *C) {
 func (s *testClusterInfoSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	// Put 3 new 4.0.9 stores.
 	for _, store := range newTestStores(3, "4.0.9") {
@@ -357,7 +356,7 @@ func (s *testClusterInfoSuite) TestDeleteStoreUpdatesClusterVersion(c *C) {
 func (s *testClusterInfoSuite) TestRegionHeartbeatHotStat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	newTestStores(4, "2.0.0")
 	peers := []*metapb.Peer{
 		{
@@ -414,7 +413,7 @@ func (s *testClusterInfoSuite) TestRegionHeartbeatHotStat(c *C) {
 func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	n, np := uint64(3), uint64(3)
 
@@ -627,7 +626,7 @@ func (s *testClusterInfoSuite) TestRegionHeartbeat(c *C) {
 func (s *testClusterInfoSuite) TestRegionFlowChanged(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	regions := []*core.RegionInfo{core.NewTestRegionInfo([]byte{}, []byte{})}
 	processRegions := func(regions []*core.RegionInfo) {
 		for _, r := range regions {
@@ -647,7 +646,7 @@ func (s *testClusterInfoSuite) TestRegionFlowChanged(c *C) {
 func (s *testClusterInfoSuite) TestConcurrentRegionHeartbeat(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	regions := []*core.RegionInfo{core.NewTestRegionInfo([]byte{}, []byte{})}
 	regions = core.SplitRegions(regions)
@@ -683,7 +682,7 @@ func (s *testClusterInfoSuite) TestRegionLabelIsolationLevel(c *C) {
 	cfg.LocationLabels = []string{"zone"}
 	opt.SetReplicationConfig(cfg)
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	for i := uint64(1); i <= 4; i++ {
 		var labels []*metapb.StoreLabel
@@ -758,7 +757,7 @@ func heartbeatRegions(c *C, cluster *RaftCluster, regions []*core.RegionInfo) {
 func (s *testClusterInfoSuite) TestHeartbeatSplit(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	// 1: [nil, nil)
 	region1 := core.NewRegionInfo(&metapb.Region{Id: 1, RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1}}, nil)
@@ -797,7 +796,7 @@ func (s *testClusterInfoSuite) TestHeartbeatSplit(c *C) {
 func (s *testClusterInfoSuite) TestRegionSplitAndMerge(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
 	regions := []*core.RegionInfo{core.NewTestRegionInfo([]byte{}, []byte{})}
 
@@ -830,9 +829,9 @@ func (s *testClusterInfoSuite) TestRegionSplitAndMerge(c *C) {
 func (s *testClusterInfoSuite) TestOfflineAndMerge(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	cluster.ruleManager = placement.NewRuleManager(storage, cluster, cluster.GetOpts())
 	if opt.IsPlacementRulesEnabled() {
 		err := cluster.ruleManager.Initialize(opt.GetMaxReplicas(), opt.GetLocationLabels())
@@ -977,7 +976,7 @@ func (s *testRegionsInfoSuite) Test(c *C) {
 	regions := newTestRegions(n, np)
 	_, opts, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	tc := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opts, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	tc := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opts, core.NewMemoryStorage(), core.NewBasicCluster())
 	cache := tc.core.Regions
 
 	for i := uint64(0); i < n; i++ {
@@ -1094,7 +1093,7 @@ func (s *testGetStoresSuite) SetUpSuite(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	s.cluster = cluster
 
 	stores := newTestStores(200, "2.0.0")
@@ -1127,7 +1126,7 @@ func newTestScheduleConfig() (*config.ScheduleConfig, *config.PersistOptions, er
 }
 
 func newTestCluster(ctx context.Context, opt *config.PersistOptions) *testCluster {
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage, core.NewBasicCluster())
 	rc.ruleManager = placement.NewRuleManager(storage, rc, rc.GetOpts())
 	if opt.IsPlacementRulesEnabled() {
@@ -1141,9 +1140,10 @@ func newTestCluster(ctx context.Context, opt *config.PersistOptions) *testCluste
 	return &testCluster{RaftCluster: rc}
 }
 
-func newTestRaftCluster(ctx context.Context, id id.Allocator, opt *config.PersistOptions, storage *core.Storage, basicCluster *core.BasicCluster) *RaftCluster {
+func newTestRaftCluster(ctx context.Context, id id.Allocator, opt *config.PersistOptions, storage *core.MemoryStorage, basicCluster *core.BasicCluster) *RaftCluster {
 	rc := &RaftCluster{ctx: ctx}
-	rc.InitCluster(id, opt, storage, basicCluster)
+	regionStorage, _ := core.NewRegionStorage(ctx, storage, "", nil)
+	rc.InitCluster(id, opt, storage, regionStorage, basicCluster)
 	return rc
 }
 
@@ -1210,7 +1210,7 @@ func checkRegion(c *C, a *core.RegionInfo, b *core.RegionInfo) {
 	}
 }
 
-func checkRegionsKV(c *C, s *core.Storage, regions []*core.RegionInfo) {
+func checkRegionsKV(c *C, s core.Storage, regions []*core.RegionInfo) {
 	if s != nil {
 		for _, region := range regions {
 			var meta metapb.Region

--- a/server/cluster/cluster_worker_test.go
+++ b/server/cluster/cluster_worker_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 	_ "github.com/tikv/pd/server/schedulers"
 )
 
@@ -44,7 +43,7 @@ func (s *testClusterWorkerSuite) SetUpTest(c *C) {
 func (s *testClusterWorkerSuite) TestReportSplit(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	left := &metapb.Region{Id: 1, StartKey: []byte("a"), EndKey: []byte("b")}
 	right := &metapb.Region{Id: 2, StartKey: []byte("b"), EndKey: []byte("c")}
 	_, err = cluster.HandleReportSplit(&pdpb.ReportSplitRequest{Left: left, Right: right})
@@ -56,7 +55,7 @@ func (s *testClusterWorkerSuite) TestReportSplit(c *C) {
 func (s *testClusterWorkerSuite) TestReportBatchSplit(c *C) {
 	_, opt, err := newTestScheduleConfig()
 	c.Assert(err, IsNil)
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	regions := []*metapb.Region{
 		{Id: 1, StartKey: []byte(""), EndKey: []byte("a")},
 		{Id: 2, StartKey: []byte("a"), EndKey: []byte("b")},

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -30,7 +30,6 @@ import (
 	"github.com/tikv/pd/pkg/logutil"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/hbstream"
 	"github.com/tikv/pd/server/schedule/operator"
@@ -679,7 +678,7 @@ func (c *coordinator) removeOptScheduler(o *config.PersistOptions, name string) 
 	for i, schedulerCfg := range v.Schedulers {
 		// To create a temporary scheduler is just used to get scheduler's name
 		decoder := schedule.ConfigSliceDecoder(schedulerCfg.Type, schedulerCfg.Args)
-		tmp, err := schedule.CreateScheduler(schedulerCfg.Type, schedule.NewOperatorController(c.ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), decoder)
+		tmp, err := schedule.CreateScheduler(schedulerCfg.Type, schedule.NewOperatorController(c.ctx, nil, nil), core.NewMemoryStorage(), decoder)
 		if err != nil {
 			return err
 		}

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/core/storelimit"
-	"github.com/tikv/pd/server/kv"
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/hbstream"
 	"github.com/tikv/pd/server/schedule/operator"
@@ -645,12 +644,12 @@ func (s *testCoordinatorSuite) TestAddScheduler(c *C) {
 	c.Assert(tc.addLeaderRegion(3, 3, 1, 2), IsNil)
 
 	oc := co.opController
-	gls, err := schedule.CreateScheduler(schedulers.GrantLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(schedulers.GrantLeaderType, []string{"0"}))
+	gls, err := schedule.CreateScheduler(schedulers.GrantLeaderType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(schedulers.GrantLeaderType, []string{"0"}))
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(gls), NotNil)
 	c.Assert(co.removeScheduler(gls.GetName()), NotNil)
 
-	gls, err = schedule.CreateScheduler(schedulers.GrantLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(schedulers.GrantLeaderType, []string{"1"}))
+	gls, err = schedule.CreateScheduler(schedulers.GrantLeaderType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(schedulers.GrantLeaderType, []string{"1"}))
 	c.Assert(err, IsNil)
 	c.Assert(co.addScheduler(gls), IsNil)
 
@@ -1106,7 +1105,7 @@ func (s *testScheduleControllerSuite) TestController(c *C) {
 
 	c.Assert(tc.addLeaderRegion(1, 1), IsNil)
 	c.Assert(tc.addLeaderRegion(2, 2), IsNil)
-	scheduler, err := schedule.CreateScheduler(schedulers.BalanceLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(schedulers.BalanceLeaderType, []string{"", ""}))
+	scheduler, err := schedule.CreateScheduler(schedulers.BalanceLeaderType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(schedulers.BalanceLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	lb := &mockLimitScheduler{
 		Scheduler: scheduler,
@@ -1190,7 +1189,7 @@ func (s *testScheduleControllerSuite) TestInterval(c *C) {
 	_, co, cleanup := prepare(nil, nil, nil, c)
 	defer cleanup()
 
-	lb, err := schedule.CreateScheduler(schedulers.BalanceLeaderType, co.opController, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(schedulers.BalanceLeaderType, []string{"", ""}))
+	lb, err := schedule.CreateScheduler(schedulers.BalanceLeaderType, co.opController, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(schedulers.BalanceLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	sc := newScheduleController(co, lb)
 

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/raft_serverpb"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 )
 
 var _ = Suite(&testUnsafeRecoverSuite{})
@@ -44,7 +43,7 @@ func (s *testUnsafeRecoverSuite) SetUpTest(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationOneHealthyRegion(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		3: "",
@@ -78,7 +77,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationOneHealthyRegion(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationOneUnhealthyRegion(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		2: "",
@@ -110,7 +109,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationOneUnhealthyRegion(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationEmptyRange(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		3: "",
@@ -154,7 +153,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationEmptyRange(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationEmptyRangeAtTheEnd(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		3: "",
@@ -200,7 +199,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationEmptyRangeAtTheEnd(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationUseNewestRanges(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		3: "",
@@ -293,7 +292,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationUseNewestRanges(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationMembershipChange(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		4: "",
@@ -380,7 +379,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationMembershipChange(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationPromotingLearner(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		2: "",
@@ -413,7 +412,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationPromotingLearner(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanGenerationKeepingOneReplica(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.failedStores = map[uint64]string{
 		3: "",
@@ -464,7 +463,7 @@ func (s *testUnsafeRecoverSuite) TestPlanGenerationKeepingOneReplica(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestReportCollection(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.stage = collectingClusterInfo
 	recoveryController.failedStores = map[uint64]string{
@@ -514,7 +513,7 @@ func (s *testUnsafeRecoverSuite) TestReportCollection(c *C) {
 
 func (s *testUnsafeRecoverSuite) TestPlanExecution(c *C) {
 	_, opt, _ := newTestScheduleConfig()
-	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewStorage(kv.NewMemoryKV()), core.NewBasicCluster())
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, core.NewMemoryStorage(), core.NewBasicCluster())
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.stage = recovering
 	recoveryController.failedStores = map[uint64]string{

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/BurntSushi/toml"
 	. "github.com/pingcap/check"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 )
 
 func Test(t *testing.T) {
@@ -67,7 +66,7 @@ func (s *testConfigSuite) TestBadFormatJoinAddr(c *C) {
 func (s *testConfigSuite) TestReloadConfig(c *C) {
 	opt, err := newTestScheduleOption()
 	c.Assert(err, IsNil)
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	scheduleCfg := opt.GetScheduleConfig()
 	scheduleCfg.MaxSnapshotCount = 10
 	opt.SetMaxReplicas(5)
@@ -107,7 +106,7 @@ func (s *testConfigSuite) TestReloadUpgrade(c *C) {
 		Schedule:    *opt.GetScheduleConfig(),
 		Replication: *opt.GetReplicationConfig(),
 	}
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	c.Assert(storage.SaveConfig(old), IsNil)
 
 	newOpt, err := newTestScheduleOption()
@@ -127,7 +126,7 @@ func (s *testConfigSuite) TestReloadUpgrade2(c *C) {
 	old := &OldConfig{
 		Replication: *opt.GetReplicationConfig(),
 	}
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	c.Assert(storage.SaveConfig(old), IsNil)
 
 	newOpt, err := newTestScheduleOption()

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -578,7 +578,7 @@ func (o *PersistOptions) DeleteLabelProperty(typ, labelKey, labelValue string) {
 }
 
 // Persist saves the configuration to the storage.
-func (o *PersistOptions) Persist(storage *core.Storage) error {
+func (o *PersistOptions) Persist(storage core.Storage) error {
 	cfg := &Config{
 		Schedule:        *o.GetScheduleConfig(),
 		Replication:     *o.GetReplicationConfig(),
@@ -595,7 +595,7 @@ func (o *PersistOptions) Persist(storage *core.Storage) error {
 }
 
 // Reload reloads the configuration from the storage.
-func (o *PersistOptions) Reload(storage *core.Storage) error {
+func (o *PersistOptions) Reload(storage core.Storage) error {
 	cfg := &Config{}
 	// pass nil to initialize cfg to default values (all items undefined)
 	cfg.Adjust(nil, true)

--- a/server/core/etcd_storage.go
+++ b/server/core/etcd_storage.go
@@ -1,0 +1,79 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/tikv/pd/server/kv"
+	"go.etcd.io/etcd/clientv3"
+)
+
+// Because the etcd storage inside the PD server is initialized with a root path,
+// so we only define some key suffixes here rather than the full key paths.
+const (
+	clusterPath                = "raft"
+	configPath                 = "config"
+	schedulePath               = "schedule"
+	gcPath                     = "gc"
+	rulesPath                  = "rules"
+	ruleGroupPath              = "rule_group"
+	regionLabelPath            = "region_label"
+	replicationPath            = "replication_mode"
+	componentPath              = "component"
+	customScheduleConfigPath   = "scheduler_config"
+	encryptionKeysPath         = "encryption_keys"
+	gcWorkerServiceSafePointID = "gc_worker"
+)
+
+// ClusterStatePath returns the path to save an option.
+func ClusterStatePath(option string) string {
+	return path.Join(clusterPath, "status", option)
+}
+
+// EncryptionKeysPath returns the path to save encryption keys.
+func EncryptionKeysPath() string {
+	return path.Join(encryptionKeysPath, "keys")
+}
+
+func storePath(storeID uint64) string {
+	return path.Join(clusterPath, "s", fmt.Sprintf("%020d", storeID))
+}
+
+func regionPath(regionID uint64) string {
+	return path.Join(clusterPath, "r", fmt.Sprintf("%020d", regionID))
+}
+
+func storeLeaderWeightPath(storeID uint64) string {
+	return path.Join(schedulePath, "store_weight", fmt.Sprintf("%020d", storeID), "leader")
+}
+
+func storeRegionWeightPath(storeID uint64) string {
+	return path.Join(schedulePath, "store_weight", fmt.Sprintf("%020d", storeID), "region")
+}
+
+var _ Storage = (*EtcdStorage)(nil)
+
+// EtcdStorage is a storage that stores data in etcd,
+// which is used by the PD server.
+type EtcdStorage struct {
+	defaultStorage
+}
+
+// NewEtcdStorage is used to create a new etcd storage.
+func NewEtcdStorage(client *clientv3.Client, rootPatch string) *EtcdStorage {
+	return &EtcdStorage{defaultStorage{kv.NewEtcdKVBase(client, rootPatch), nil}}
+}

--- a/server/core/leveldb_storage.go
+++ b/server/core/leveldb_storage.go
@@ -1,0 +1,126 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/tikv/pd/pkg/encryption"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server/encryptionkm"
+	"github.com/tikv/pd/server/kv"
+)
+
+var _ Storage = (*LevelDBStorage)(nil)
+
+const (
+	// defaultBatchSize is the batch size to save the regions to region storage.
+	defaultBatchSize = 100
+	// defaultFlushRegionRate is the ttl to sync the regions to region storage.
+	defaultFlushRegionRate = 3 * time.Second
+)
+
+// LevelDBStorage is a storage that stores data in LevelDB,
+// which is used in the region-related storage.
+type LevelDBStorage struct {
+	defaultStorage
+	mu           sync.RWMutex
+	batchRegions map[string]*metapb.Region
+	batchSize    int
+	cacheSize    int
+	flushRate    time.Duration
+	flushTime    time.Time
+}
+
+// NewLevelDBStorage is used to create a new LevelDB storage.
+func NewLevelDBStorage(path string, encryptionKeyManager *encryptionkm.KeyManager) (*LevelDBStorage, error) {
+	levelDB, err := kv.NewLeveldbKV(path)
+	if err != nil {
+		return nil, err
+	}
+	return &LevelDBStorage{
+		defaultStorage: defaultStorage{levelDB, encryptionKeyManager},
+		batchRegions:   make(map[string]*metapb.Region, defaultBatchSize),
+		batchSize:      defaultBatchSize,
+		flushRate:      defaultFlushRegionRate,
+	}, nil
+}
+
+// SaveRegion saves one region to storage.
+func (s *LevelDBStorage) SaveRegion(region *metapb.Region) error {
+	region, err := encryption.EncryptRegion(region, s.encryptionKeyManager)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cacheSize < s.batchSize-1 {
+		s.batchRegions[regionPath(region.GetId())] = region
+		s.cacheSize++
+
+		s.flushTime = time.Now().Add(s.flushRate)
+		return nil
+	}
+	s.batchRegions[regionPath(region.GetId())] = region
+	err = s.flush()
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *LevelDBStorage) flush() error {
+	if err := s.SaveRegions(s.batchRegions); err != nil {
+		return err
+	}
+	s.cacheSize = 0
+	s.batchRegions = make(map[string]*metapb.Region, s.batchSize)
+	return nil
+}
+
+// FlushRegion saves the cache region to region storage.
+func (s *LevelDBStorage) FlushRegion() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.flush()
+}
+
+// SaveRegions stores some regions.
+func (s *LevelDBStorage) SaveRegions(regions map[string]*metapb.Region) error {
+	batch := new(leveldb.Batch)
+
+	for key, r := range regions {
+		value, err := proto.Marshal(r)
+		if err != nil {
+			return errs.ErrProtoMarshal.Wrap(err).GenWithStackByCause()
+		}
+		batch.Put([]byte(key), value)
+	}
+
+	if err := s.Base.(*kv.LeveldbKV).Write(batch, nil); err != nil {
+		return errs.ErrLevelDBWrite.Wrap(err).GenWithStackByCause()
+	}
+	return nil
+}
+
+// Close closes the LevelDB storage.
+func (s *LevelDBStorage) Close() error {
+	return s.Base.(*kv.LeveldbKV).Close()
+}

--- a/server/core/memory_storage.go
+++ b/server/core/memory_storage.go
@@ -1,0 +1,32 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"github.com/tikv/pd/server/kv"
+)
+
+var _ Storage = (*MemoryStorage)(nil)
+
+// MemoryStorage is a storage that stores data in a memory B-Tree without any locks,
+// which should only be used in tests.
+type MemoryStorage struct {
+	defaultStorage
+}
+
+// NewMemoryStorage is used to create a new memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{defaultStorage{kv.NewMemoryKV(), nil}}
+}

--- a/server/handler.go
+++ b/server/handler.go
@@ -208,7 +208,7 @@ func (h *Handler) AddScheduler(name string, args ...string) error {
 		return err
 	}
 
-	s, err := schedule.CreateScheduler(name, c.GetOperatorController(), h.s.storage, schedule.ConfigSliceDecoder(name, args))
+	s, err := schedule.CreateScheduler(name, c.GetOperatorController(), h.s.GetEtcdStorage(), schedule.ConfigSliceDecoder(name, args))
 	if err != nil {
 		return err
 	}

--- a/server/kv/levedb_kv.go
+++ b/server/kv/levedb_kv.go
@@ -15,9 +15,7 @@
 package kv
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"github.com/tikv/pd/pkg/errs"
@@ -75,22 +73,4 @@ func (kv *LeveldbKV) Save(key, value string) error {
 // Remove deletes a key-value pair for a given key.
 func (kv *LeveldbKV) Remove(key string) error {
 	return errors.WithStack(kv.Delete([]byte(key), nil))
-}
-
-// SaveRegions stores some regions.
-func (kv *LeveldbKV) SaveRegions(regions map[string]*metapb.Region) error {
-	batch := new(leveldb.Batch)
-
-	for key, r := range regions {
-		value, err := proto.Marshal(r)
-		if err != nil {
-			return errs.ErrProtoMarshal.Wrap(err).GenWithStackByCause()
-		}
-		batch.Put([]byte(key), value)
-	}
-
-	if err := kv.Write(batch, nil); err != nil {
-		return errs.ErrLevelDBWrite.Wrap(err).GenWithStackByCause()
-	}
-	return nil
 }

--- a/server/kv/mem_kv.go
+++ b/server/kv/mem_kv.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 
 	"github.com/google/btree"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 )
 
 type memoryKV struct {
@@ -51,6 +53,12 @@ func (kv *memoryKV) Load(key string) (string, error) {
 }
 
 func (kv *memoryKV) LoadRange(key, endKey string, limit int) ([]string, []string, error) {
+	failpoint.Inject("withRangeLimit", func(val failpoint.Value) {
+		rangeLimit, ok := val.(int)
+		if ok && limit > rangeLimit {
+			failpoint.Return(nil, nil, errors.Errorf("limit %d exceed max rangeLimit %d", limit, rangeLimit))
+		}
+	})
 	kv.RLock()
 	defer kv.RUnlock()
 	keys := make([]string, 0, limit)

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -119,7 +119,7 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 		defer s.wg.Done()
 		// used to load region from kv storage to cache storage.
 		bc := s.server.GetBasicCluster()
-		storage := s.server.GetStorage()
+		storage := s.server.GetRegionStorage()
 		log.Info("region syncer start load region")
 		start := time.Now()
 		err := storage.LoadRegionsOnce(ctx, bc.CheckAndPutRegion)

--- a/server/region_syncer/history_buffer_test.go
+++ b/server/region_syncer/history_buffer_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 )
 
 var _ = Suite(&testHistoryBuffer{})
@@ -38,7 +37,7 @@ func (t *testHistoryBuffer) TestBufferSize(c *C) {
 	}
 
 	// size equals 1
-	h := newHistoryBuffer(1, kv.NewMemoryKV())
+	h := newHistoryBuffer(1, core.NewMemoryStorage())
 	c.Assert(h.len(), Equals, 0)
 	for _, r := range regions {
 		h.Record(r)
@@ -48,7 +47,7 @@ func (t *testHistoryBuffer) TestBufferSize(c *C) {
 	c.Assert(h.get(99), IsNil)
 
 	// size equals 2
-	h = newHistoryBuffer(2, kv.NewMemoryKV())
+	h = newHistoryBuffer(2, core.NewMemoryStorage())
 	for _, r := range regions {
 		h.Record(r)
 	}
@@ -58,7 +57,7 @@ func (t *testHistoryBuffer) TestBufferSize(c *C) {
 	c.Assert(h.get(98), IsNil)
 
 	// size equals 100
-	kvMem := kv.NewMemoryKV()
+	kvMem := core.NewMemoryStorage()
 	h1 := newHistoryBuffer(100, kvMem)
 	for i := 0; i < 6; i++ {
 		h1.Record(regions[i])
@@ -81,7 +80,7 @@ func (t *testHistoryBuffer) TestBufferSize(c *C) {
 
 	c.Assert(h2.nextIndex(), Equals, uint64(107))
 	c.Assert(h2.get(h2.nextIndex()), IsNil)
-	s, err := h2.kv.Load(historyKey)
+	s, err := h2.storage.Load(historyKey)
 	c.Assert(err, IsNil)
 	// flush in index 106
 	c.Assert(s, Equals, "106")

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -59,7 +59,7 @@ type Server interface {
 	ClusterID() uint64
 	GetMemberInfo() *pdpb.Member
 	GetLeader() *pdpb.Member
-	GetStorage() *core.Storage
+	GetRegionStorage() *core.RegionStorage
 	Name() string
 	GetRegions() []*core.RegionInfo
 	GetTLSConfig() *grpcutil.TLSConfig
@@ -89,7 +89,7 @@ type RegionSyncer struct {
 func NewRegionSyncer(s Server) *RegionSyncer {
 	syncer := &RegionSyncer{
 		server:    s,
-		history:   newHistoryBuffer(defaultHistoryBufferSize, s.GetStorage().GetRegionStorage()),
+		history:   newHistoryBuffer(defaultHistoryBufferSize, s.GetRegionStorage().GetLevelDBStorage()),
 		limit:     ratelimit.NewBucketWithRate(defaultBucketRate, defaultBucketCapacity),
 		tlsConfig: s.GetTLSConfig(),
 	}

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -63,7 +63,7 @@ type ModeManager struct {
 
 	sync.RWMutex
 	config         config.ReplicationModeConfig
-	storage        *core.Storage
+	storage        core.Storage
 	cluster        opt.Cluster
 	fileReplicater FileReplicater
 
@@ -82,7 +82,7 @@ type ModeManager struct {
 }
 
 // NewReplicationModeManager creates the replicate mode manager.
-func NewReplicationModeManager(config config.ReplicationModeConfig, storage *core.Storage, cluster opt.Cluster, fileReplicater FileReplicater) (*ModeManager, error) {
+func NewReplicationModeManager(config config.ReplicationModeConfig, storage core.Storage, cluster opt.Cluster, fileReplicater FileReplicater) (*ModeManager, error) {
 	m := &ModeManager{
 		initTime:              time.Now(),
 		config:                config,

--- a/server/replication/replication_mode_test.go
+++ b/server/replication/replication_mode_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 )
 
 func TestReplicationMode(t *testing.T) {
@@ -49,7 +48,7 @@ func (s *testReplicationMode) TearDownTest(c *C) {
 }
 
 func (s *testReplicationMode) TestInitial(c *C) {
-	store := core.NewStorage(kv.NewMemoryKV())
+	store := core.NewMemoryStorage()
 	conf := config.ReplicationModeConfig{ReplicationMode: modeMajority}
 	cluster := mockcluster.NewCluster(s.ctx, config.NewTestOptions())
 	rep, err := NewReplicationModeManager(conf, store, cluster, nil)
@@ -79,7 +78,7 @@ func (s *testReplicationMode) TestInitial(c *C) {
 }
 
 func (s *testReplicationMode) TestStatus(c *C) {
-	store := core.NewStorage(kv.NewMemoryKV())
+	store := core.NewMemoryStorage()
 	conf := config.ReplicationModeConfig{ReplicationMode: modeDRAutoSync, DRAutoSync: config.DRAutoSyncReplicationConfig{
 		LabelKey:        "dr-label",
 		WaitSyncTimeout: typeutil.Duration{Duration: time.Minute},
@@ -149,7 +148,7 @@ func (rep *mockFileReplicator) ReplicateFileToAllMembers(context.Context, string
 }
 
 func (s *testReplicationMode) TestStateSwitch(c *C) {
-	store := core.NewStorage(kv.NewMemoryKV())
+	store := core.NewMemoryStorage()
 	conf := config.ReplicationModeConfig{ReplicationMode: modeDRAutoSync, DRAutoSync: config.DRAutoSyncReplicationConfig{
 		LabelKey:         "zone",
 		Primary:          "zone1",
@@ -265,7 +264,7 @@ func (s *testReplicationMode) TestStateSwitch(c *C) {
 }
 
 func (s *testReplicationMode) TestAsynctimeout(c *C) {
-	store := core.NewStorage(kv.NewMemoryKV())
+	store := core.NewMemoryStorage()
 	conf := config.ReplicationModeConfig{ReplicationMode: modeDRAutoSync, DRAutoSync: config.DRAutoSyncReplicationConfig{
 		LabelKey:         "zone",
 		Primary:          "zone1",
@@ -317,7 +316,7 @@ func (s *testReplicationMode) TestRecoverProgress(c *C) {
 	regionScanBatchSize = 10
 	regionMinSampleSize = 5
 
-	store := core.NewStorage(kv.NewMemoryKV())
+	store := core.NewMemoryStorage()
 	conf := config.ReplicationModeConfig{ReplicationMode: modeDRAutoSync, DRAutoSync: config.DRAutoSyncReplicationConfig{
 		LabelKey:         "zone",
 		Primary:          "zone1",
@@ -377,7 +376,7 @@ func (s *testReplicationMode) TestRecoverProgressWithSplitAndMerge(c *C) {
 	regionScanBatchSize = 10
 	regionMinSampleSize = 5
 
-	store := core.NewStorage(kv.NewMemoryKV())
+	store := core.NewMemoryStorage()
 	conf := config.ReplicationModeConfig{ReplicationMode: modeDRAutoSync, DRAutoSync: config.DRAutoSyncReplicationConfig{
 		LabelKey:         "zone",
 		Primary:          "zone1",

--- a/server/schedule/labeler/labeler.go
+++ b/server/schedule/labeler/labeler.go
@@ -31,14 +31,14 @@ import (
 
 // RegionLabeler is utility to label regions.
 type RegionLabeler struct {
-	storage *core.Storage
+	storage core.Storage
 	sync.RWMutex
 	labelRules map[string]*LabelRule
 	rangeList  rangelist.List // sorted LabelRules of the type `KeyRange`
 }
 
 // NewRegionLabeler creates a Labeler instance.
-func NewRegionLabeler(storage *core.Storage) (*RegionLabeler, error) {
+func NewRegionLabeler(storage core.Storage) (*RegionLabeler, error) {
 	l := &RegionLabeler{
 		storage:    storage,
 		labelRules: make(map[string]*LabelRule),

--- a/server/schedule/labeler/labeler_test.go
+++ b/server/schedule/labeler/labeler_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 )
 
 func TestT(t *testing.T) {
@@ -32,12 +31,12 @@ func TestT(t *testing.T) {
 var _ = Suite(&testLabelerSuite{})
 
 type testLabelerSuite struct {
-	store   *core.Storage
+	store   core.Storage
 	labeler *RegionLabeler
 }
 
 func (s *testLabelerSuite) SetUpTest(c *C) {
-	s.store = core.NewStorage(kv.NewMemoryKV())
+	s.store = core.NewMemoryStorage()
 	var err error
 	s.labeler, err = NewRegionLabeler(s.store)
 	c.Assert(err, IsNil)

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -36,8 +36,8 @@ import (
 // RuleManager is responsible for the lifecycle of all placement Rules.
 // It is thread safe.
 type RuleManager struct {
-	storage *core.Storage
 	sync.RWMutex
+	storage     core.Storage
 	initialized bool
 	ruleConfig  *ruleConfig
 	ruleList    ruleList
@@ -50,7 +50,7 @@ type RuleManager struct {
 }
 
 // NewRuleManager creates a RuleManager instance.
-func NewRuleManager(storage *core.Storage, storeSetInformer core.StoreSetInformer, opt *config.PersistOptions) *RuleManager {
+func NewRuleManager(storage core.Storage, storeSetInformer core.StoreSetInformer, opt *config.PersistOptions) *RuleManager {
 	return &RuleManager{
 		storage:          storage,
 		storeSetInformer: storeSetInformer,

--- a/server/schedule/placement/rule_manager_test.go
+++ b/server/schedule/placement/rule_manager_test.go
@@ -16,22 +16,22 @@ package placement
 
 import (
 	"encoding/hex"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 )
 
 var _ = Suite(&testManagerSuite{})
 
 type testManagerSuite struct {
-	store   *core.Storage
+	store   core.Storage
 	manager *RuleManager
 }
 
 func (s *testManagerSuite) SetUpTest(c *C) {
-	s.store = core.NewStorage(kv.NewMemoryKV())
+	s.store = core.NewMemoryStorage()
 	var err error
 	s.manager = NewRuleManager(s.store, nil, nil)
 	err = s.manager.Initialize(3, []string{"zone", "rack", "host"})

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -88,7 +88,7 @@ func ConfigSliceDecoder(name string, args []string) ConfigDecoder {
 }
 
 // CreateSchedulerFunc is for creating scheduler.
-type CreateSchedulerFunc func(opController *OperatorController, storage *core.Storage, dec ConfigDecoder) (Scheduler, error)
+type CreateSchedulerFunc func(opController *OperatorController, storage core.Storage, dec ConfigDecoder) (Scheduler, error)
 
 var schedulerMap = make(map[string]CreateSchedulerFunc)
 var schedulerArgsToDecoder = make(map[string]ConfigSliceDecoderBuilder)
@@ -113,7 +113,7 @@ func RegisterSliceDecoderBuilder(typ string, builder ConfigSliceDecoderBuilder) 
 }
 
 // CreateScheduler creates a scheduler with registered creator func.
-func CreateScheduler(typ string, opController *OperatorController, storage *core.Storage, dec ConfigDecoder) (Scheduler, error) {
+func CreateScheduler(typ string, opController *OperatorController, storage core.Storage, dec ConfigDecoder) (Scheduler, error) {
 	fn, ok := schedulerMap[typ]
 	if !ok {
 		return nil, errs.ErrSchedulerCreateFuncNotRegistered.FastGenByArgs(typ)

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -55,7 +55,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(BalanceLeaderType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(BalanceLeaderType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &balanceLeaderSchedulerConfig{}
 		if err := decoder(conf); err != nil {
 			return nil, err

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -46,7 +46,7 @@ func init() {
 			return nil
 		}
 	})
-	schedule.RegisterScheduler(BalanceRegionType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(BalanceRegionType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &balanceRegionSchedulerConfig{}
 		if err := decoder(conf); err != nil {
 			return nil, err

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/hbstream"
 	"github.com/tikv/pd/server/schedule/operator"
@@ -207,7 +206,7 @@ func (s *testBalanceLeaderSchedulerSuite) SetUpTest(c *C) {
 	s.opt = config.NewTestOptions()
 	s.tc = mockcluster.NewCluster(s.ctx, s.opt)
 	s.oc = schedule.NewOperatorController(s.ctx, s.tc, nil)
-	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
+	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	s.lb = lb
 }
@@ -524,29 +523,29 @@ func (s *testBalanceLeaderRangeSchedulerSuite) TestSingleRangeBalance(c *C) {
 	s.tc.UpdateStoreLeaderWeight(3, 1)
 	s.tc.UpdateStoreLeaderWeight(4, 2)
 	s.tc.AddLeaderRegionWithRange(1, "a", "g", 1, 2, 3, 4)
-	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
+	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	ops := lb.Schedule(s.tc)
 	c.Assert(ops, NotNil)
 	c.Assert(ops, HasLen, 1)
 	c.Assert(ops[0].Counters, HasLen, 2)
 	c.Assert(ops[0].FinishedCounters, HasLen, 3)
-	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"h", "n"}))
+	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"h", "n"}))
 	c.Assert(err, IsNil)
 	c.Assert(lb.Schedule(s.tc), IsNil)
-	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"b", "f"}))
+	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"b", "f"}))
 	c.Assert(err, IsNil)
 	c.Assert(lb.Schedule(s.tc), IsNil)
-	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", "a"}))
+	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", "a"}))
 	c.Assert(err, IsNil)
 	c.Assert(lb.Schedule(s.tc), IsNil)
-	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"g", ""}))
+	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"g", ""}))
 	c.Assert(err, IsNil)
 	c.Assert(lb.Schedule(s.tc), IsNil)
-	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", "f"}))
+	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", "f"}))
 	c.Assert(err, IsNil)
 	c.Assert(lb.Schedule(s.tc), IsNil)
-	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"b", ""}))
+	lb, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"b", ""}))
 	c.Assert(err, IsNil)
 	c.Assert(lb.Schedule(s.tc), IsNil)
 }
@@ -565,7 +564,7 @@ func (s *testBalanceLeaderRangeSchedulerSuite) TestMultiRangeBalance(c *C) {
 	s.tc.UpdateStoreLeaderWeight(3, 1)
 	s.tc.UpdateStoreLeaderWeight(4, 2)
 	s.tc.AddLeaderRegionWithRange(1, "a", "g", 1, 2, 3, 4)
-	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", "g", "o", "t"}))
+	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", "g", "o", "t"}))
 	c.Assert(err, IsNil)
 	c.Assert(lb.Schedule(s.tc)[0].RegionID(), Equals, uint64(1))
 	s.tc.RemoveRegion(s.tc.GetRegion(1))
@@ -605,7 +604,7 @@ func (s *testBalanceRegionSchedulerSuite) TestBalance(c *C) {
 	tc.DisableFeature(versioninfo.JointConsensus)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
 
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	opt.SetMaxReplicas(1)
@@ -643,7 +642,7 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas3(c *C) {
 	tc.DisableFeature(versioninfo.JointConsensus)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
 
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	s.checkReplica3(c, tc, sb)
@@ -708,7 +707,7 @@ func (s *testBalanceRegionSchedulerSuite) TestReplicas5(c *C) {
 	tc.DisableFeature(versioninfo.JointConsensus)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
 
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	s.checkReplica5(c, tc, sb)
@@ -802,7 +801,7 @@ func (s *testBalanceRegionSchedulerSuite) TestBalance1(c *C) {
 		core.SetApproximateKeys(200),
 	)
 
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	tc.AddRegionStore(1, 11)
@@ -848,7 +847,7 @@ func (s *testBalanceRegionSchedulerSuite) TestStoreWeight(c *C) {
 	tc.DisableFeature(versioninfo.JointConsensus)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
 
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	opt.SetMaxReplicas(1)
 
@@ -876,7 +875,7 @@ func (s *testBalanceRegionSchedulerSuite) TestReplacePendingRegion(c *C) {
 	tc.DisableFeature(versioninfo.JointConsensus)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
 
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	s.checkReplacePendingRegion(c, tc, sb)
@@ -892,7 +891,7 @@ func (s *testBalanceRegionSchedulerSuite) TestOpInfluence(c *C) {
 	tc.DisableFeature(versioninfo.JointConsensus)
 	stream := hbstream.NewTestHeartbeatStreams(s.ctx, tc.ID, tc, false /* no need to run */)
 	oc := schedule.NewOperatorController(s.ctx, tc, stream)
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	opt.SetMaxReplicas(1)
 	// Add stores 1,2,3,4.
@@ -940,7 +939,7 @@ func (s *testBalanceRegionSchedulerSuite) TestShouldNotBalance(c *C) {
 	tc := mockcluster.NewCluster(s.ctx, opt)
 	tc.DisableFeature(versioninfo.JointConsensus)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	region := tc.MockRegionInfo(1, 0, []uint64{2, 3, 4}, nil, nil)
 	tc.PutRegion(region)
@@ -957,7 +956,7 @@ func (s *testBalanceRegionSchedulerSuite) TestEmptyRegion(c *C) {
 	tc := mockcluster.NewCluster(s.ctx, opt)
 	tc.DisableFeature(versioninfo.JointConsensus)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
-	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	tc.AddRegionStore(1, 10)
 	tc.AddRegionStore(2, 9)
@@ -1015,7 +1014,7 @@ func (s *testRandomMergeSchedulerSuite) TestMerge(c *C) {
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, true /* need to run */)
 	oc := schedule.NewOperatorController(ctx, tc, stream)
 
-	mb, err := schedule.CreateScheduler(RandomMergeType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(RandomMergeType, []string{"", ""}))
+	mb, err := schedule.CreateScheduler(RandomMergeType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(RandomMergeType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	tc.AddRegionStore(1, 4)
@@ -1106,7 +1105,7 @@ func (s *testScatterRangeSuite) TestBalance(c *C) {
 	}
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
 
-	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_50", "t"}))
+	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_50", "t"}))
 	c.Assert(err, IsNil)
 
 	scheduleAndApplyOperator(tc, hb, 100)
@@ -1173,7 +1172,7 @@ func (s *testScatterRangeSuite) TestBalanceLeaderLimit(c *C) {
 
 	// test not allow schedule leader
 	tc.SetLeaderScheduleLimit(0)
-	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_50", "t"}))
+	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_50", "t"}))
 	c.Assert(err, IsNil)
 
 	scheduleAndApplyOperator(tc, hb, 100)
@@ -1197,7 +1196,7 @@ func (s *testScatterRangeSuite) TestConcurrencyUpdateConfig(c *C) {
 	opt := config.NewTestOptions()
 	tc := mockcluster.NewCluster(s.ctx, opt)
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
-	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_50", "t"}))
+	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_50", "t"}))
 	sche := hb.(*scatterRangeScheduler)
 	c.Assert(err, IsNil)
 	ch := make(chan struct{})
@@ -1269,7 +1268,7 @@ func (s *testScatterRangeSuite) TestBalanceWhenRegionNotHeartbeat(c *C) {
 	}
 
 	oc := schedule.NewOperatorController(s.ctx, nil, nil)
-	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_09", "t"}))
+	hb, err := schedule.CreateScheduler(ScatterRangeType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(ScatterRangeType, []string{"s_00", "s_09", "t"}))
 	c.Assert(err, IsNil)
 
 	scheduleAndApplyOperator(tc, hb, 100)

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -68,7 +68,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(EvictLeaderType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(EvictLeaderType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &evictLeaderSchedulerConfig{StoreIDWithRanges: make(map[uint64][]core.KeyRange), storage: storage}
 		if err := decoder(conf); err != nil {
 			return nil, err
@@ -80,7 +80,7 @@ func init() {
 
 type evictLeaderSchedulerConfig struct {
 	mu                sync.RWMutex
-	storage           *core.Storage
+	storage           core.Storage
 	StoreIDWithRanges map[uint64][]core.KeyRange `json:"store-id-ranges"`
 	cluster           opt.Cluster
 }

--- a/server/schedulers/evict_slow_store.go
+++ b/server/schedulers/evict_slow_store.go
@@ -59,7 +59,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(EvictSlowStoreType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(EvictSlowStoreType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &evictSlowStoreSchedulerConfig{storage: storage, EvictedStores: make([]uint64, 0)}
 		if err := decoder(conf); err != nil {
 			return nil, err
@@ -69,7 +69,7 @@ func init() {
 }
 
 type evictSlowStoreSchedulerConfig struct {
-	storage       *core.Storage
+	storage       core.Storage
 	EvictedStores []uint64 `json:"evict-stores"`
 }
 

--- a/server/schedulers/grant_leader.go
+++ b/server/schedulers/grant_leader.go
@@ -63,7 +63,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(GrantLeaderType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(GrantLeaderType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &grantLeaderSchedulerConfig{StoreIDWithRanges: make(map[uint64][]core.KeyRange), storage: storage}
 		conf.cluster = opController.GetCluster()
 		if err := decoder(conf); err != nil {
@@ -75,7 +75,7 @@ func init() {
 
 type grantLeaderSchedulerConfig struct {
 	mu                sync.RWMutex
-	storage           *core.Storage
+	storage           core.Storage
 	StoreIDWithRanges map[uint64][]core.KeyRange `json:"store-id-ranges"`
 	cluster           opt.Cluster
 }

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -43,7 +43,7 @@ func init() {
 			return nil
 		}
 	})
-	schedule.RegisterScheduler(HotRegionType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(HotRegionType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := initHotRegionScheduleConfig()
 
 		var data map[string]interface{}

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -110,7 +110,7 @@ func (conf *hotRegionSchedulerConfig) getValidConf() *hotRegionSchedulerConfig {
 
 type hotRegionSchedulerConfig struct {
 	sync.RWMutex
-	storage            *core.Storage
+	storage            core.Storage
 	lastQuerySupported bool
 
 	MinHotByteRate  float64 `json:"min-hot-byte-rate"`

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -49,7 +49,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(LabelType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(LabelType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &labelSchedulerConfig{}
 		if err := decoder(conf); err != nil {
 			return nil, err

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -50,7 +50,7 @@ func init() {
 			return nil
 		}
 	})
-	schedule.RegisterScheduler(RandomMergeType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(RandomMergeType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &randomMergeSchedulerConfig{}
 		if err := decoder(conf); err != nil {
 			return nil, err

--- a/server/schedulers/scatter_range.go
+++ b/server/schedulers/scatter_range.go
@@ -51,7 +51,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(ScatterRangeType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(ScatterRangeType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &scatterRangeSchedulerConfig{
 			storage: storage,
 		}
@@ -75,7 +75,7 @@ const (
 
 type scatterRangeSchedulerConfig struct {
 	mu        sync.RWMutex
-	storage   *core.Storage
+	storage   core.Storage
 	RangeName string `json:"range-name"`
 	StartKey  string `json:"start-key"`
 	EndKey    string `json:"end-key"`

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/operator"
 	"github.com/tikv/pd/server/schedule/opt"
@@ -53,7 +52,7 @@ func (s *testShuffleLeaderSuite) TestShuffle(c *C) {
 	opt := config.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 
-	sl, err := schedule.CreateScheduler(ShuffleLeaderType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(ShuffleLeaderType, []string{"", ""}))
+	sl, err := schedule.CreateScheduler(ShuffleLeaderType, schedule.NewOperatorController(ctx, nil, nil), core.NewMemoryStorage(), schedule.ConfigSliceDecoder(ShuffleLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	c.Assert(sl.Schedule(tc), IsNil)
 
@@ -99,7 +98,7 @@ func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 
 	// The label scheduler transfers leader out of store1.
 	oc := schedule.NewOperatorController(ctx, nil, nil)
-	sl, err := schedule.CreateScheduler(LabelType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(LabelType, []string{"", ""}))
+	sl, err := schedule.CreateScheduler(LabelType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(LabelType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	op := sl.Schedule(tc)
 	testutil.CheckTransferLeaderFrom(c, op[0], operator.OpLeader, 1)
@@ -111,13 +110,13 @@ func (s *testRejectLeaderSuite) TestRejectLeader(c *C) {
 
 	// As store3 is disconnected, store1 rejects leader. Balancer will not create
 	// any operators.
-	bs, err := schedule.CreateScheduler(BalanceLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
+	bs, err := schedule.CreateScheduler(BalanceLeaderType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	op = bs.Schedule(tc)
 	c.Assert(op, IsNil)
 
 	// Can't evict leader from store2, neither.
-	el, err := schedule.CreateScheduler(EvictLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"2"}))
+	el, err := schedule.CreateScheduler(EvictLeaderType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"2"}))
 	c.Assert(err, IsNil)
 	op = el.Schedule(tc)
 	c.Assert(op, IsNil)
@@ -144,7 +143,7 @@ func (s *testRejectLeaderSuite) TestRemoveRejectLeader(c *C) {
 	tc.AddRegionStore(1, 0)
 	tc.AddRegionStore(2, 1)
 	oc := schedule.NewOperatorController(ctx, tc, nil)
-	el, err := schedule.CreateScheduler(EvictLeaderType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
+	el, err := schedule.CreateScheduler(EvictLeaderType, oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
 	c.Assert(err, IsNil)
 	tc.DeleteStore(tc.GetStore(1))
 	succ, _ := el.(*evictLeaderScheduler).conf.removeStore(1)
@@ -163,7 +162,7 @@ func (s *testShuffleHotRegionSchedulerSuite) TestBalance(c *C) {
 	tc.SetMaxReplicas(3)
 	tc.SetLocationLabels([]string{"zone", "host"})
 	tc.DisableFeature(versioninfo.JointConsensus)
-	hb, err := schedule.CreateScheduler(ShuffleHotRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder("shuffle-hot-region", []string{"", ""}))
+	hb, err := schedule.CreateScheduler(ShuffleHotRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewMemoryStorage(), schedule.ConfigSliceDecoder("shuffle-hot-region", []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	s.checkBalance(c, tc, hb)
@@ -222,7 +221,7 @@ func (s *testHotRegionSchedulerSuite) TestAbnormalReplica(c *C) {
 	opt := config.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	tc.SetHotRegionScheduleLimit(0)
-	hb, err := schedule.CreateScheduler(HotReadRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), nil)
+	hb, err := schedule.CreateScheduler(HotReadRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewMemoryStorage(), nil)
 	c.Assert(err, IsNil)
 
 	tc.AddRegionStore(1, 3)
@@ -261,7 +260,7 @@ func (s *testEvictLeaderSuite) TestEvictLeader(c *C) {
 	tc.AddLeaderRegion(2, 2, 1)
 	tc.AddLeaderRegion(3, 3, 1)
 
-	sl, err := schedule.CreateScheduler(EvictLeaderType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
+	sl, err := schedule.CreateScheduler(EvictLeaderType, schedule.NewOperatorController(ctx, nil, nil), core.NewMemoryStorage(), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
 	c.Assert(err, IsNil)
 	c.Assert(sl.IsScheduleAllowed(tc), IsTrue)
 	op := sl.Schedule(tc)
@@ -273,7 +272,7 @@ func (s *testEvictLeaderSuite) TestEvictLeaderWithUnhealthyPeer(c *C) {
 	defer cancel()
 	opt := config.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
-	sl, err := schedule.CreateScheduler(EvictLeaderType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
+	sl, err := schedule.CreateScheduler(EvictLeaderType, schedule.NewOperatorController(ctx, nil, nil), core.NewMemoryStorage(), schedule.ConfigSliceDecoder(EvictLeaderType, []string{"1"}))
 	c.Assert(err, IsNil)
 
 	// Add stores 1, 2, 3
@@ -312,7 +311,7 @@ func (s *testShuffleRegionSuite) TestShuffle(c *C) {
 	opt := config.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 
-	sl, err := schedule.CreateScheduler(ShuffleRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(ShuffleRegionType, []string{"", ""}))
+	sl, err := schedule.CreateScheduler(ShuffleRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewMemoryStorage(), schedule.ConfigSliceDecoder(ShuffleRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	c.Assert(sl.IsScheduleAllowed(tc), IsTrue)
 	c.Assert(sl.Schedule(tc), IsNil)
@@ -376,7 +375,7 @@ func (s *testShuffleRegionSuite) TestRole(c *C) {
 	}, peers[0])
 	tc.PutRegion(region)
 
-	sl, err := schedule.CreateScheduler(ShuffleRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(ShuffleRegionType, []string{"", ""}))
+	sl, err := schedule.CreateScheduler(ShuffleRegionType, schedule.NewOperatorController(ctx, nil, nil), core.NewMemoryStorage(), schedule.ConfigSliceDecoder(ShuffleRegionType, []string{"", ""}))
 	c.Assert(err, IsNil)
 
 	conf := sl.(*shuffleRegionScheduler).conf
@@ -398,7 +397,7 @@ func (s *testSpecialUseSuite) TestSpecialUseHotRegion(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	oc := schedule.NewOperatorController(ctx, nil, nil)
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	cd := schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""})
 	bs, err := schedule.CreateScheduler(BalanceRegionType, oc, storage, cd)
 	c.Assert(err, IsNil)
@@ -451,7 +450,7 @@ func (s *testSpecialUseSuite) TestSpecialUseReserved(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	oc := schedule.NewOperatorController(ctx, nil, nil)
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	cd := schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""})
 	bs, err := schedule.CreateScheduler(BalanceRegionType, oc, storage, cd)
 	c.Assert(err, IsNil)
@@ -498,7 +497,7 @@ func (s *testBalanceLeaderSchedulerWithRuleEnabledSuite) SetUpTest(c *C) {
 	s.tc = mockcluster.NewCluster(s.ctx, s.opt)
 	s.tc.SetEnablePlacementRules(true)
 	s.oc = schedule.NewOperatorController(s.ctx, nil, nil)
-	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
+	lb, err := schedule.CreateScheduler(BalanceLeaderType, s.oc, core.NewMemoryStorage(), schedule.ConfigSliceDecoder(BalanceLeaderType, []string{"", ""}))
 	c.Assert(err, IsNil)
 	s.lb = lb
 }
@@ -627,7 +626,7 @@ func (s *testEvictSlowStoreSuite) TestEvictSlowStore(c *C) {
 	tc.UpdateLeaderCount(2, 16)
 
 	oc := schedule.NewOperatorController(ctx, nil, nil)
-	storage := core.NewStorage(kv.NewMemoryKV())
+	storage := core.NewMemoryStorage()
 	es, err := schedule.CreateScheduler(EvictSlowStoreType, oc, storage, schedule.ConfigSliceDecoder(EvictSlowStoreType, []string{}))
 	c.Assert(err, IsNil)
 	bs, err := schedule.CreateScheduler(BalanceLeaderType, oc, storage, schedule.ConfigSliceDecoder(BalanceLeaderType, []string{}))

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -57,7 +57,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(ShuffleHotRegionType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(ShuffleHotRegionType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &shuffleHotRegionSchedulerConfig{Limit: uint64(1)}
 		if err := decoder(conf); err != nil {
 			return nil, err

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -48,7 +48,7 @@ func init() {
 		}
 	})
 
-	schedule.RegisterScheduler(ShuffleLeaderType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(ShuffleLeaderType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &shuffleLeaderSchedulerConfig{}
 		if err := decoder(conf); err != nil {
 			return nil, err

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -49,7 +49,7 @@ func init() {
 			return nil
 		}
 	})
-	schedule.RegisterScheduler(ShuffleRegionType, func(opController *schedule.OperatorController, storage *core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
+	schedule.RegisterScheduler(ShuffleRegionType, func(opController *schedule.OperatorController, storage core.Storage, decoder schedule.ConfigDecoder) (schedule.Scheduler, error) {
 		conf := &shuffleRegionSchedulerConfig{storage: storage}
 		if err := decoder(conf); err != nil {
 			return nil, err

--- a/server/schedulers/shuffle_region_config.go
+++ b/server/schedulers/shuffle_region_config.go
@@ -37,7 +37,7 @@ var allRoles = []string{roleLeader, roleFollower, roleLearner}
 
 type shuffleRegionSchedulerConfig struct {
 	sync.RWMutex
-	storage *core.Storage
+	storage core.Storage
 
 	Ranges []core.KeyRange `json:"ranges"`
 	Roles  []string        `json:"roles"` // can include `leader`, `follower`, `learner`.

--- a/server/statistics/region_collection_test.go
+++ b/server/statistics/region_collection_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/kv"
 	"github.com/tikv/pd/server/schedule/placement"
 )
 
@@ -33,12 +32,12 @@ func TestStatistics(t *testing.T) {
 var _ = Suite(&testRegionStatisticsSuite{})
 
 type testRegionStatisticsSuite struct {
-	store   *core.Storage
+	store   core.Storage
 	manager *placement.RuleManager
 }
 
 func (t *testRegionStatisticsSuite) SetUpTest(c *C) {
-	t.store = core.NewStorage(kv.NewMemoryKV())
+	t.store = core.NewMemoryStorage()
 	var err error
 	t.manager = placement.NewRuleManager(t.store, nil, nil)
 	err = t.manager.Initialize(3, []string{"zone", "rack", "host"})

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -1003,7 +1003,7 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 	c.Assert(min, Equals, uint64(3))
 
 	// Update only the TTL of the minimum safepoint
-	oldMinSsp, err := s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	oldMinSsp, err := s.srv.GetEtcdStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(oldMinSsp.ServiceID, Equals, "c")
 	c.Assert(oldMinSsp.SafePoint, Equals, uint64(3))
@@ -1011,7 +1011,7 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 		"c", 2000, 3)
 	c.Assert(err, IsNil)
 	c.Assert(min, Equals, uint64(3))
-	minSsp, err := s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	minSsp, err := s.srv.GetEtcdStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.ServiceID, Equals, "c")
 	c.Assert(oldMinSsp.SafePoint, Equals, uint64(3))
@@ -1022,7 +1022,7 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 		"c", 1, 3)
 	c.Assert(err, IsNil)
 	c.Assert(min, Equals, uint64(3))
-	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	minSsp, err = s.srv.GetEtcdStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.ServiceID, Equals, "c")
 	c.Assert(minSsp.ExpiredAt, Less, oldMinSsp.ExpiredAt)
@@ -1032,7 +1032,7 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 		"c", math.MaxInt64, 3)
 	c.Assert(err, IsNil)
 	c.Assert(min, Equals, uint64(3))
-	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	minSsp, err = s.srv.GetEtcdStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.ServiceID, Equals, "c")
 	c.Assert(minSsp.ExpiredAt, Equals, int64(math.MaxInt64))
@@ -1084,20 +1084,20 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 		}
 		value, err := json.Marshal(gcWorkerSsp)
 		c.Assert(err, IsNil)
-		err = s.srv.GetStorage().Save(gcWorkerKey, string(value))
+		err = s.srv.GetEtcdStorage().Save(gcWorkerKey, string(value))
 		c.Assert(err, IsNil)
 	}
 
-	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	minSsp, err = s.srv.GetEtcdStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.ServiceID, Equals, "gc_worker")
 	c.Assert(minSsp.SafePoint, Equals, uint64(10))
 	c.Assert(minSsp.ExpiredAt, Equals, int64(math.MaxInt64))
 
 	// Force delete gc_worker, then the min service safepoint is 11 of "a".
-	err = s.srv.GetStorage().Remove(gcWorkerKey)
+	err = s.srv.GetEtcdStorage().Remove(gcWorkerKey)
 	c.Assert(err, IsNil)
-	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	minSsp, err = s.srv.GetEtcdStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.SafePoint, Equals, uint64(11))
 	// After calling LoadMinServiceGCS when "gc_worker"'s service safepoint is missing, "gc_worker"'s service safepoint
@@ -1107,7 +1107,7 @@ func (s *testClientSuite) TestUpdateServiceGCSafePoint(c *C) {
 		"a", 1000, 14)
 	c.Assert(err, IsNil)
 
-	minSsp, err = s.srv.GetStorage().LoadMinServiceGCSafePoint(time.Now())
+	minSsp, err = s.srv.GetEtcdStorage().LoadMinServiceGCSafePoint(time.Now())
 	c.Assert(err, IsNil)
 	c.Assert(minSsp.ServiceID, Equals, "gc_worker")
 	c.Assert(minSsp.SafePoint, Equals, uint64(11))


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Part of https://github.com/tikv/pd/issues/3453. Trying to sort out the usage of `core.Storage` and `kv.Base`.

### What is changed and how it works?

#### Background

As https://github.com/tikv/pd/issues/3453 said, we have the unified `kv.Base` and `core.Storage` inside the PD. However, both of them have some design and usage problems.

#### Details

Let's make some basic points before any further discussion.

1. `kv.Base` is the abstraction of the lowest level KV storage, which should provide some fundamental KV operations such as `Load(key)` and `Save(key, value)` etc.
2. `core.Storage` is the abstraction of the concrete `kv.Base` usage. So `kv.Base` should be the backend of a `core.Storage`.
3. The upper service use `core.Storage` to store data and defines some special operations that rely on it.

Base on the three rules, these changes are made.

> Change `core.Storage` into an interface.

Since different storages may have different implementations on the same method, it's better to make `core.Storage` an interface rather than an all-in-one hodgepodge. For example, we have two storages for the region info now, one is etcd and another one is LevelDB. `SaveRegion` is a method that both storages need to implement in different ways.

> Introduce three kinds of storage.

For now, we have three kinds of storage.

* `EtcdStorage`, the storage that stores data in etcd, which is used by the PD server. Most PD data is stored in this one.
* `LevelDBStorage`, the storage that stores data in LevelDB, which is used in the region-related storage.
* `MemoryStorage`, the storage that stores data in a memory B-Tree without any locks, which should only be used in tests.

Specifying a certain storage type will help us use these three storages more properly, which will also make the developer know which storage this service is using while reading the source code.

> Make `RegionStorage` an independent service based on any given storage and the `LevelDBStorage`.

`RegionStorage` should act more like a storage user rather than the storage itself, which is misleading in nowadays code. The related region Load/Save methods are moved into the `RegionStorage`. Also, the switch between the `core.Storage` (usually `EtcdStorage`) is moved into it.

#### Compromises

 * `HotRegionStorage` is still constructed based on the LevelDB KV Base rather than the `LevelDBStorage` due to some special LevelDB operations use, such as `Batch` and `Write`.

#### Review Guide

You can focus on the changes of `server/core/*`, especially the `server/core/storage.go` and `server/core/region_storage.go`. Many other differences are caused by the interface change.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
