### PR TITLE
server/schedule: priority to fit healthy peers

### DIFF
--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -174,7 +174,11 @@ func newFitWorker(stores []*core.StoreInfo, region *core.RegionInfo, rules []*Ru
 		})
 	}
 	// Sort peers to keep the match result deterministic.
-	sort.Slice(peers, func(i, j int) bool { return peers[i].GetId() < peers[j].GetId() })
+	sort.Slice(peers, func(i, j int) bool {
+		// Put healthy peers in front to priority to fit healthy peers.
+		si, sj := stateScore(region, peers[i].GetId()), stateScore(region, peers[j].GetId())
+		return si > sj || (si == sj && peers[i].GetId() < peers[j].GetId())
+	})
 
 	return &fitWorker{
 		stores:        stores,
@@ -351,4 +355,15 @@ func needIsolation(rules []*Rule) bool {
 		}
 	}
 	return false
+}
+
+func stateScore(region *core.RegionInfo, peerID uint64) int {
+	switch {
+	case region.GetDownPeer(peerID) != nil:
+		return 0
+	case region.GetPendingPeer(peerID) != nil:
+		return 1
+	default:
+		return 2
+	}
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

fixes #4233 
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?

Adjust the peers order in `newFitWorker` to put healthy peers in front
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
NONE
```
