### PR TITLE
kv, tests: use failpoint to mock the memory KV range limit

### DIFF
--- a/server/kv/mem_kv.go
+++ b/server/kv/mem_kv.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 
 	"github.com/google/btree"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 )
 
 type memoryKV struct {
@@ -51,6 +53,12 @@ func (kv *memoryKV) Load(key string) (string, error) {
 }
 
 func (kv *memoryKV) LoadRange(key, endKey string, limit int) ([]string, []string, error) {
+	failpoint.Inject("withRangeLimit", func(val failpoint.Value) {
+		rangeLimit, ok := val.(int)
+		if ok && limit > rangeLimit {
+			failpoint.Return(nil, nil, errors.Errorf("limit %d exceed max rangeLimit %d", limit, rangeLimit))
+		}
+	})
 	kv.RLock()
 	defer kv.RUnlock()
 	keys := make([]string, 0, limit)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Part of #3453. Trying to sort out the usage of `core.Storage` and `kv.Base`.

### What is changed and how it works?

There is no need to introduce a `KVWithMaxRangeLimit` here. I think injecting a failpoint is a more suitable way.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

```release-note
None.
```
