### PR TITLE
*: use context to manage RaftCluster

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -57,11 +57,10 @@ type Cluster struct {
 
 // NewCluster creates a new Cluster
 func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
-	mockQuit := make(chan struct{})
 	clus := &Cluster{
 		BasicCluster:     core.NewBasicCluster(),
 		IDAllocator:      mockid.NewIDAllocator(),
-		HotStat:          statistics.NewHotStat(ctx, mockQuit),
+		HotStat:          statistics.NewHotStat(ctx),
 		PersistOptions:   opts,
 		suspectRegions:   map[uint64]struct{}{},
 		disabledFeatures: make(map[versioninfo.Feature]struct{}),

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -409,6 +409,16 @@ func (c *RaftCluster) IsRunning() bool {
 	return c.running
 }
 
+// Context returns the context of RaftCluster.
+func (c *RaftCluster) Context() context.Context {
+	c.RLock()
+	defer c.RUnlock()
+	if c.running {
+		return c.ctx
+	}
+	return nil
+}
+
 // GetOperatorController returns the operator controller.
 func (c *RaftCluster) GetOperatorController() *schedule.OperatorController {
 	c.RLock()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -85,7 +85,11 @@ type Server interface {
 // region 1 -> /1/raft/r/1, value is metapb.Region
 type RaftCluster struct {
 	sync.RWMutex
-	ctx context.Context
+
+	serverCtx context.Context
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
 
 	running bool
 
@@ -111,8 +115,6 @@ type RaftCluster struct {
 	suspectRegions   *cache.TTLUint64 // suspectRegions are regions that may need fix
 	suspectKeyRanges *cache.TTLString // suspect key-range regions that may need fix
 
-	wg           sync.WaitGroup
-	quit         chan struct{}
 	regionSyncer *syncer.RegionSyncer
 
 	ruleManager   *placement.RuleManager
@@ -139,7 +141,7 @@ type Status struct {
 // NewRaftCluster create a new cluster.
 func NewRaftCluster(ctx context.Context, root string, clusterID uint64, regionSyncer *syncer.RegionSyncer, etcdClient *clientv3.Client, httpClient *http.Client) *RaftCluster {
 	return &RaftCluster{
-		ctx:          ctx,
+		serverCtx:    ctx,
 		running:      false,
 		clusterID:    clusterID,
 		clusterRoot:  root,
@@ -204,12 +206,10 @@ func (c *RaftCluster) loadBootstrapTime() (time.Time, error) {
 
 // InitCluster initializes the raft cluster.
 func (c *RaftCluster) InitCluster(id id.Allocator, opt *config.PersistOptions, storage *core.Storage, basicCluster *core.BasicCluster) {
-	c.core = basicCluster
-	c.opt = opt
-	c.storage = storage
-	c.id = id
+	c.core, c.opt, c.storage, c.id = basicCluster, opt, storage, id
+	c.ctx, c.cancel = context.WithCancel(c.serverCtx)
 	c.labelLevelStats = statistics.NewLabelStatistics()
-	c.hotStat = statistics.NewHotStat(c.ctx, c.quit)
+	c.hotStat = statistics.NewHotStat(c.ctx)
 	c.prepareChecker = newPrepareChecker()
 	c.changedRegions = make(chan *core.RegionInfo, defaultChangedRegionsLimit)
 	c.suspectRegions = cache.NewIDTTL(c.ctx, time.Minute, 3*time.Minute)
@@ -226,8 +226,9 @@ func (c *RaftCluster) Start(s Server) error {
 		log.Warn("raft cluster has already been started")
 		return nil
 	}
-	c.quit = make(chan struct{})
+
 	c.InitCluster(s.GetAllocator(), s.GetPersistOptions(), s.GetStorage(), s.GetBasicCluster())
+
 	cluster, err := c.LoadClusterInfo()
 	if err != nil {
 		return err
@@ -324,7 +325,7 @@ func (c *RaftCluster) runBackgroundJobs(interval time.Duration) {
 
 	for {
 		select {
-		case <-c.quit:
+		case <-c.ctx.Done():
 			log.Info("metrics are reset")
 			c.resetMetrics()
 			log.Info("background jobs has been stopped")
@@ -346,7 +347,7 @@ func (c *RaftCluster) runStatsBackgroundJobs() {
 
 	for {
 		select {
-		case <-c.quit:
+		case <-c.ctx.Done():
 			log.Info("statistics background jobs has been stopped")
 			return
 		case <-ticker.C:
@@ -375,13 +376,13 @@ func (c *RaftCluster) runCoordinator() {
 func (c *RaftCluster) syncRegions() {
 	defer logutil.LogPanic()
 	defer c.wg.Done()
-	c.regionSyncer.RunServer(c.changedRegionNotifier(), c.quit)
+	c.regionSyncer.RunServer(c.ctx, c.changedRegionNotifier())
 }
 
 func (c *RaftCluster) runReplicationMode() {
 	defer logutil.LogPanic()
 	defer c.wg.Done()
-	c.replicationMode.Run(c.quit)
+	c.replicationMode.Run(c.ctx)
 }
 
 // Stop stops the cluster.
@@ -395,7 +396,7 @@ func (c *RaftCluster) Stop() {
 
 	c.running = false
 	c.coordinator.stop()
-	close(c.quit)
+	c.cancel()
 	c.Unlock()
 	c.wg.Wait()
 	log.Info("raftcluster is stopped")

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1142,7 +1142,7 @@ func newTestCluster(ctx context.Context, opt *config.PersistOptions) *testCluste
 }
 
 func newTestRaftCluster(ctx context.Context, id id.Allocator, opt *config.PersistOptions, storage *core.Storage, basicCluster *core.BasicCluster) *RaftCluster {
-	rc := &RaftCluster{ctx: ctx}
+	rc := &RaftCluster{serverCtx: ctx}
 	rc.InitCluster(id, opt, storage, basicCluster)
 	return rc
 }

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -47,8 +47,7 @@ import (
 var (
 	// ErrNotLeader is returned when current server is not the leader and not possible to process request.
 	// TODO: work as proxy.
-	ErrNotLeader = status.Errorf(codes.Unavailable, "not leader")
-	// ErrNotStarted is returned when current server is starting.
+	ErrNotLeader  = status.Errorf(codes.Unavailable, "not leader")
 	ErrNotStarted = status.Errorf(codes.Unavailable, "server not started")
 )
 
@@ -1241,7 +1240,11 @@ func (s *Server) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
 	if s.IsClosed() || s.cluster == nil {
 		return ErrNotStarted
 	}
-	return s.cluster.GetRegionSyncer().Sync(stream)
+	ctx := s.cluster.Context()
+	if ctx == nil {
+		return ErrNotStarted
+	}
+	return s.cluster.GetRegionSyncer().Sync(ctx, stream)
 }
 
 // UpdateGCSafePoint implements gRPC PDServer.

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -47,7 +47,8 @@ import (
 var (
 	// ErrNotLeader is returned when current server is not the leader and not possible to process request.
 	// TODO: work as proxy.
-	ErrNotLeader  = status.Errorf(codes.Unavailable, "not leader")
+	ErrNotLeader = status.Errorf(codes.Unavailable, "not leader")
+	// ErrNotStarted is returned when current server is starting.
 	ErrNotStarted = status.Errorf(codes.Unavailable, "server not started")
 )
 

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -43,6 +43,7 @@ const (
 )
 
 var (
+	// ErrNotStarted is returned when current server is starting.
 	ErrNotStarted = status.Errorf(codes.Unavailable, "server not started")
 )
 

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -346,17 +346,17 @@ const (
 )
 
 // Run starts the background job.
-func (m *ModeManager) Run(quit chan struct{}) {
+func (m *ModeManager) Run(ctx context.Context) {
 	// Wait for a while when just start, in case tikv do not connect in time.
 	select {
 	case <-time.After(idleTimeout):
-	case <-quit:
+	case <-ctx.Done():
 		return
 	}
 	for {
 		select {
 		case <-time.After(tickInterval):
-		case <-quit:
+		case <-ctx.Done():
 			return
 		}
 		m.tickDR()

--- a/server/statistics/hot_cache_task.go
+++ b/server/statistics/hot_cache_task.go
@@ -130,11 +130,9 @@ func (t *collectRegionStatsTask) runTask(flow *hotPeerCache) {
 }
 
 // TODO: do we need a wait-return timeout?
-func (t *collectRegionStatsTask) waitRet(ctx context.Context, quit <-chan struct{}) map[uint64][]*HotPeerStat {
+func (t *collectRegionStatsTask) waitRet(ctx context.Context) map[uint64][]*HotPeerStat {
 	select {
 	case <-ctx.Done():
-		return nil
-	case <-quit:
 		return nil
 	case ret := <-t.ret:
 		return ret
@@ -164,11 +162,9 @@ func (t *isRegionHotTask) runTask(flow *hotPeerCache) {
 }
 
 // TODO: do we need a wait-return timeout?
-func (t *isRegionHotTask) waitRet(ctx context.Context, quit <-chan struct{}) bool {
+func (t *isRegionHotTask) waitRet(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():
-		return false
-	case <-quit:
 		return false
 	case r := <-t.ret:
 		return r

--- a/server/statistics/hot_stat.go
+++ b/server/statistics/hot_stat.go
@@ -25,9 +25,9 @@ type HotStat struct {
 }
 
 // NewHotStat creates the container to hold cluster's hotspot statistics.
-func NewHotStat(ctx context.Context, quit <-chan struct{}) *HotStat {
+func NewHotStat(ctx context.Context) *HotStat {
 	return &HotStat{
-		HotCache:    NewHotCache(ctx, quit),
+		HotCache:    NewHotCache(ctx),
 		StoresStats: NewStoresStats(),
 	}
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

close #4293

### What is changed and how it works?

* `RaftCluster` uses its own `ctx` to replace the original `quit`.
* `RegionSyncer` can stop immediately when `ctx` is `Done` during service.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
