### PR TITLE
Add show command under pd-ctl scheduler config

### DIFF
--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -255,8 +255,6 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 	// test hot region config
 	echo = mustExec([]string{"-u", pdAddr, "scheduler", "config", "evict-leader-scheduler"}, nil)
 	c.Assert(strings.Contains(echo, "[404] scheduler not found"), IsTrue)
-	var conf map[string]interface{}
-	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "list"}, &conf)
 	expected1 := map[string]interface{}{
 		"min-hot-byte-rate":          float64(100),
 		"min-hot-key-rate":           float64(10),
@@ -277,6 +275,10 @@ func (s *schedulerTestSuite) TestScheduler(c *C) {
 		"strict-picking-store":       "true",
 		"enable-for-tiflash":         "true",
 	}
+	var conf map[string]interface{}
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "list"}, &conf)
+	c.Assert(conf, DeepEquals, expected1)
+	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "show"}, &conf)
 	c.Assert(conf, DeepEquals, expected1)
 	mustExec([]string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "src-tolerance-ratio", "1.02"}, nil)
 	expected1["src-tolerance-ratio"] = 1.02

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
 	"github.com/tikv/pd/server/schedulers"
 )
@@ -423,14 +424,22 @@ func newConfigHotRegionCommand() *cobra.Command {
 		Short: "balance-hot-region-scheduler config",
 		Run:   listSchedulerConfigCommandFunc,
 	}
+
+	// Deprecated: 'list' command will be deprecated in future version, use 'show' command instead.
 	c.AddCommand(&cobra.Command{
 		Use:   "list",
+		Short: "list the config item (will be deprecated in feature version, use show command instead)",
+		Run:   listSchedulerConfigCommandFunc,
+	}, &cobra.Command{
+		Use:   "show",
 		Short: "list the config item",
-		Run:   listSchedulerConfigCommandFunc})
-	c.AddCommand(&cobra.Command{
+		Run:   listSchedulerConfigCommandFunc,
+	}, &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "set the config item",
-		Run:   func(cmd *cobra.Command, args []string) { postSchedulerConfigCommandFunc(cmd, c.Name(), args) }})
+		Run:   func(cmd *cobra.Command, args []string) { postSchedulerConfigCommandFunc(cmd, c.Name(), args) },
+	})
+
 	return c
 }
 
@@ -512,6 +521,9 @@ func listSchedulerConfigCommandFunc(cmd *cobra.Command, args []string) {
 	}
 	p := cmd.Name()
 	if p == "list" {
+		p = cmd.Parent().Name()
+		log.Info("The list command will be deprecated in future version, use show command instead")
+	} else if p == "show" {
 		p = cmd.Parent().Name()
 	}
 	path := path.Join(schedulerConfigPrefix, p, "list")

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
 	"github.com/tikv/pd/server/schedulers"
 )
@@ -425,7 +424,7 @@ func newConfigHotRegionCommand() *cobra.Command {
 		Run:   listSchedulerConfigCommandFunc,
 	}
 
-	// Deprecated: 'list' command will be deprecated in future version, use 'show' command instead.
+	// Deprecated: list command will be deprecated in future version, use show command instead.
 	c.AddCommand(&cobra.Command{
 		Use:   "list",
 		Short: "list the config item (will be deprecated in feature version, use show command instead)",
@@ -520,10 +519,7 @@ func listSchedulerConfigCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	p := cmd.Name()
-	if p == "list" {
-		p = cmd.Parent().Name()
-		log.Info("The list command will be deprecated in future version, use show command instead")
-	} else if p == "show" {
+	if p == "list" || p == "show" {
 		p = cmd.Parent().Name()
 	}
 	path := path.Join(schedulerConfigPrefix, p, "list")


### PR DESCRIPTION
Signed-off-by: Hua Lu <hua.lu@pingcap.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
Resolves #3951 

### What is changed and how it works?
- Add new command `show` under `pd-ctl scheduler config balance-hot-region-scheduler` with same behavior as `list`
- Add deprecated warning message when execute `list` command under `pd-ctl scheduler config balance-hot-region-scheduler`
- Modify short description of `list` with deprecate message.
- Add test case for `show` command, usage the same logic as `list` command

### Check List
Tests
- Unit test
- Manual test (add detailed scripts or steps below)
   - Compare outputs from `pd-ctl scheduler config balance-hot-region-scheduler show` and `pd-ctl scheduler config balance-hot-region-scheduler list`
   - Check `pd-ctl scheduler config balance-hot-region-scheduler list` has deprecated message printed.


Code changes
- Has configuration change

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- Need to cherry-pick to the release branch

### Release note
```release-note
None
```
