### PR TITLE
Update TiDB Dashboard to v2021.11.08.1 [release-5.3]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20211029081837-3c7bd947cf9b
 	github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7
 	github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5
-	github.com/pingcap/tidb-dashboard v0.0.0-20211031170437-08e58c069a2a
+	github.com/pingcap/tidb-dashboard v0.0.0-20211107164327-80363dfbe884
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuR
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5 h1:7rvAtZe/ZUzOKzgriNPQoBNvleJXBk4z7L3Z47+tS98=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5/go.mod h1:XsOaV712rUk63aOEKYP9PhXTIE3FMNHmC2r1wX5wElY=
-github.com/pingcap/tidb-dashboard v0.0.0-20211031170437-08e58c069a2a h1:7h09Qj0s6sSDwpWsz1uJUOg14HyNLWdF1iSEVhlzxw8=
-github.com/pingcap/tidb-dashboard v0.0.0-20211031170437-08e58c069a2a/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
+github.com/pingcap/tidb-dashboard v0.0.0-20211107164327-80363dfbe884 h1:6/yOhY2X0oNidvVK1PdjVoSThfUQ+GK/1UaHeXZfnrM=
+github.com/pingcap/tidb-dashboard v0.0.0-20211107164327-80363dfbe884/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Signed-off-by: baurine <2008.hbl@gmail.com>

### What problem does this PR solve?

Update TiDB Dashboard to v2021.11.08.1.

Upstream commit: https://github.com/pingcap/tidb-dashboard/commit/80363dfbe88469e288d0a0a68204c64ee31ef9cd .

**TiDB Dashboard related PRs:**

- https://github.com/pingcap/tidb-dashboard/pull/1038
- https://github.com/pingcap/tidb-dashboard/pull/1043
- https://github.com/pingcap/tidb-dashboard/pull/1044
- https://github.com/pingcap/tidb-dashboard/pull/1048

### Release note

```release-note
None
```