### PR TITLE
cluster: fix the bug that region statistics are not updated after flow-round-by-digit change

### DIFF
--- a/server/core/region.go
+++ b/server/core/region.go
@@ -567,7 +567,8 @@ func GenerateRegionGuideFunc(enableLog bool) RegionGuideFunc {
 			// Once flow has changed, will update the cache.
 			// Because keys and bytes are strongly related, only bytes are judged.
 			if region.GetRoundBytesWritten() != origin.GetRoundBytesWritten() ||
-				region.GetRoundBytesRead() != origin.GetRoundBytesRead() {
+				region.GetRoundBytesRead() != origin.GetRoundBytesRead() ||
+				region.flowRoundDivisor != origin.flowRoundDivisor {
 				saveCache, needSync = true, true
 			}
 

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -568,7 +568,7 @@ func GenerateRegionGuideFunc(enableLog bool) RegionGuideFunc {
 			// Because keys and bytes are strongly related, only bytes are judged.
 			if region.GetRoundBytesWritten() != origin.GetRoundBytesWritten() ||
 				region.GetRoundBytesRead() != origin.GetRoundBytesRead() ||
-				region.flowRoundDivisor != origin.flowRoundDivisor {
+				region.flowRoundDivisor < origin.flowRoundDivisor {
 				saveCache, needSync = true, true
 			}
 

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -39,8 +39,9 @@ func WithDownPeers(downPeers []*pdpb.PeerStats) RegionCreateOption {
 
 // WithFlowRoundByDigit set the digit, which use to round to the nearest number
 func WithFlowRoundByDigit(digit int) RegionCreateOption {
+	flowRoundDivisor := uint64(math.Pow10(digit))
 	return func(region *RegionInfo) {
-		region.flowRoundDivisor = uint64(math.Pow10(digit))
+		region.flowRoundDivisor = flowRoundDivisor
 	}
 }
 

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -283,6 +283,11 @@ func (s *testRegionGuideSuite) TestNeedSync(c *C) {
 			needSync: true,
 		},
 		{
+			optionsA: []RegionCreateOption{SetWrittenBytes(250), WithFlowRoundByDigit(2)},
+			optionsB: []RegionCreateOption{SetWrittenBytes(349), WithFlowRoundByDigit(2)},
+			needSync: false,
+		},
+		{
 			optionsA: []RegionCreateOption{SetWrittenBytes(200), WithFlowRoundByDigit(4)},
 			optionsB: []RegionCreateOption{SetWrittenBytes(300), WithFlowRoundByDigit(4)},
 			needSync: false,

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -262,19 +262,19 @@ func (s *testRegionGuideSuite) TestNeedSync(c *C) {
 		needSync bool
 	}{
 		{
-			optionsA: []RegionCreateOption{WithLeader(nil)},
+			optionsB: []RegionCreateOption{WithLeader(nil)},
 			needSync: true,
 		},
 		{
-			optionsA: []RegionCreateOption{WithLeader(meta.Peers[1])},
+			optionsB: []RegionCreateOption{WithLeader(meta.Peers[1])},
 			needSync: true,
 		},
 		{
-			optionsA: []RegionCreateOption{WithPendingPeers(meta.Peers[1:2])},
+			optionsB: []RegionCreateOption{WithPendingPeers(meta.Peers[1:2])},
 			needSync: true,
 		},
 		{
-			optionsA: []RegionCreateOption{WithDownPeers([]*pdpb.PeerStats{{Peer: meta.Peers[1], DownSeconds: 600}})},
+			optionsB: []RegionCreateOption{WithDownPeers([]*pdpb.PeerStats{{Peer: meta.Peers[1], DownSeconds: 600}})},
 			needSync: true,
 		},
 		{
@@ -300,6 +300,11 @@ func (s *testRegionGuideSuite) TestNeedSync(c *C) {
 		{
 			optionsA: []RegionCreateOption{SetWrittenBytes(100000), WithFlowRoundByDigit(127)},
 			optionsB: []RegionCreateOption{SetWrittenBytes(0), WithFlowRoundByDigit(2)},
+			needSync: false,
+		},
+		{
+			optionsA: []RegionCreateOption{SetWrittenBytes(0), WithFlowRoundByDigit(2)},
+			optionsB: []RegionCreateOption{SetWrittenBytes(100000), WithFlowRoundByDigit(127)},
 			needSync: true,
 		},
 	}

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -232,6 +232,81 @@ func (s *testRegionInfoSuite) TestRegionWriteRate(c *C) {
 	}
 }
 
+var _ = Suite(&testRegionGuideSuite{})
+
+type testRegionGuideSuite struct {
+	RegionGuide RegionGuideFunc
+}
+
+func (s *testRegionGuideSuite) SetUpSuite(c *C) {
+	s.RegionGuide = GenerateRegionGuideFunc(false)
+}
+
+func (s *testRegionGuideSuite) TestNeedSync(c *C) {
+	meta := &metapb.Region{
+		Id:          1000,
+		StartKey:    []byte("a"),
+		EndKey:      []byte("z"),
+		RegionEpoch: &metapb.RegionEpoch{ConfVer: 100, Version: 100},
+		Peers: []*metapb.Peer{
+			{Id: 11, StoreId: 1, Role: metapb.PeerRole_Voter},
+			{Id: 12, StoreId: 1, Role: metapb.PeerRole_Voter},
+			{Id: 13, StoreId: 1, Role: metapb.PeerRole_Voter},
+		},
+	}
+	region := NewRegionInfo(meta, meta.Peers[0])
+
+	testcases := []struct {
+		optionsA []RegionCreateOption
+		optionsB []RegionCreateOption
+		needSync bool
+	}{
+		{
+			optionsA: []RegionCreateOption{WithLeader(nil)},
+			needSync: true,
+		},
+		{
+			optionsA: []RegionCreateOption{WithLeader(meta.Peers[1])},
+			needSync: true,
+		},
+		{
+			optionsA: []RegionCreateOption{WithPendingPeers(meta.Peers[1:2])},
+			needSync: true,
+		},
+		{
+			optionsA: []RegionCreateOption{WithDownPeers([]*pdpb.PeerStats{{Peer: meta.Peers[1], DownSeconds: 600}})},
+			needSync: true,
+		},
+		{
+			optionsA: []RegionCreateOption{SetWrittenBytes(200), WithFlowRoundByDigit(2)},
+			optionsB: []RegionCreateOption{SetWrittenBytes(300), WithFlowRoundByDigit(2)},
+			needSync: true,
+		},
+		{
+			optionsA: []RegionCreateOption{SetWrittenBytes(200), WithFlowRoundByDigit(4)},
+			optionsB: []RegionCreateOption{SetWrittenBytes(300), WithFlowRoundByDigit(4)},
+			needSync: false,
+		},
+		{
+			optionsA: []RegionCreateOption{SetWrittenBytes(100000), WithFlowRoundByDigit(4)},
+			optionsB: []RegionCreateOption{SetWrittenBytes(200), WithFlowRoundByDigit(2)},
+			needSync: true,
+		},
+		{
+			optionsA: []RegionCreateOption{SetWrittenBytes(100000), WithFlowRoundByDigit(127)},
+			optionsB: []RegionCreateOption{SetWrittenBytes(0), WithFlowRoundByDigit(2)},
+			needSync: true,
+		},
+	}
+
+	for _, t := range testcases {
+		regionA := region.Clone(t.optionsA...)
+		regionB := region.Clone(t.optionsB...)
+		_, _, _, needSync := s.RegionGuide(regionA, regionB)
+		c.Assert(needSync, Equals, t.needSync)
+	}
+}
+
 var _ = Suite(&testRegionMapSuite{})
 
 type testRegionMapSuite struct{}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -667,13 +667,13 @@ func (s *heartbeatServer) Recv() (*pdpb.RegionHeartbeatRequest, error) {
 // RegionHeartbeat implements gRPC PDServer.
 func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 	var (
-		server                       = &heartbeatServer{stream: stream}
-		regionFlowRoundByDigitOption = core.WithFlowRoundByDigit(s.persistOptions.GetPDServerConfig().FlowRoundByDigit)
-		forwardStream                pdpb.PD_RegionHeartbeatClient
-		cancel                       context.CancelFunc
-		lastForwardedHost            string
-		lastBind                     time.Time
-		errCh                        chan error
+		server            = &heartbeatServer{stream: stream}
+		flowRoundOption   = core.WithFlowRoundByDigit(s.persistOptions.GetPDServerConfig().FlowRoundByDigit)
+		forwardStream     pdpb.PD_RegionHeartbeatClient
+		cancel            context.CancelFunc
+		lastForwardedHost string
+		lastBind          time.Time
+		errCh             chan error
 	)
 	defer func() {
 		// cancel the forward stream
@@ -750,11 +750,11 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 			regionHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "report", "bind").Inc()
 			s.hbStreams.BindStream(storeID, server)
 			// refresh FlowRoundByDigit
-			regionFlowRoundByDigitOption = core.WithFlowRoundByDigit(s.persistOptions.GetPDServerConfig().FlowRoundByDigit)
+			flowRoundOption = core.WithFlowRoundByDigit(s.persistOptions.GetPDServerConfig().FlowRoundByDigit)
 			lastBind = time.Now()
 		}
 
-		region := core.RegionFromHeartbeat(request, regionFlowRoundByDigitOption)
+		region := core.RegionFromHeartbeat(request, flowRoundOption)
 		if region.GetLeader() == nil {
 			log.Error("invalid request, the leader is nil", zap.Reflect("request", request), errs.ZapError(errs.ErrLeaderNil))
 			regionHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "report", "invalid-leader").Inc()

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -666,14 +666,14 @@ func (s *heartbeatServer) Recv() (*pdpb.RegionHeartbeatRequest, error) {
 
 // RegionHeartbeat implements gRPC PDServer.
 func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
-	server := &heartbeatServer{stream: stream}
-	FlowRoundByDigit := s.persistOptions.GetPDServerConfig().FlowRoundByDigit
 	var (
-		forwardStream     pdpb.PD_RegionHeartbeatClient
-		cancel            context.CancelFunc
-		lastForwardedHost string
-		lastBind          time.Time
-		errCh             chan error
+		server                       = &heartbeatServer{stream: stream}
+		regionFlowRoundByDigitOption = core.WithFlowRoundByDigit(s.persistOptions.GetPDServerConfig().FlowRoundByDigit)
+		forwardStream                pdpb.PD_RegionHeartbeatClient
+		cancel                       context.CancelFunc
+		lastForwardedHost            string
+		lastBind                     time.Time
+		errCh                        chan error
 	)
 	defer func() {
 		// cancel the forward stream
@@ -750,11 +750,11 @@ func (s *Server) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
 			regionHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "report", "bind").Inc()
 			s.hbStreams.BindStream(storeID, server)
 			// refresh FlowRoundByDigit
-			FlowRoundByDigit = s.persistOptions.GetPDServerConfig().FlowRoundByDigit
+			regionFlowRoundByDigitOption = core.WithFlowRoundByDigit(s.persistOptions.GetPDServerConfig().FlowRoundByDigit)
 			lastBind = time.Now()
 		}
 
-		region := core.RegionFromHeartbeat(request, core.WithFlowRoundByDigit(FlowRoundByDigit))
+		region := core.RegionFromHeartbeat(request, regionFlowRoundByDigitOption)
 		if region.GetLeader() == nil {
 			log.Error("invalid request, the leader is nil", zap.Reflect("request", request), errs.ZapError(errs.ErrLeaderNil))
 			regionHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "report", "invalid-leader").Inc()


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

fix #4295 

### What is changed and how it works?

A change in `flowRoundDivisor` also considers that the flow statistics have changed.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the bug that region statistics are not updated after `flow-round-by-digit` change.
```
