### PR TITLE
config: fix load config from file

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -179,6 +179,9 @@
 ## Whether or not to enable placement rules.
 # enable-placement-rules = true
 
+## Whether or not to enable placement rule cache controls whether use cache during rule
+# enable-placement-rules-cache = true
+
 [dashboard]
 ## Configurations below are for the TiDB Dashboard embedded in the PD.
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -236,6 +236,7 @@ const (
 
 	defaultStrictlyMatchLabel   = false
 	defaultEnablePlacementRules = true
+	defaultEnablePlacementRulesCache = false
 	defaultEnableGRPCGateway    = true
 	defaultDisableErrorVerbose  = true
 
@@ -1071,6 +1072,9 @@ func (c *ReplicationConfig) adjust(meta *configMetaData) error {
 	adjustUint64(&c.MaxReplicas, defaultMaxReplicas)
 	if !meta.IsDefined("enable-placement-rules") {
 		c.EnablePlacementRules = defaultEnablePlacementRules
+	}
+	if !meta.IsDefined("enable-placement-rules-cache") {
+		c.EnablePlacementRulesCache = defaultEnablePlacementRulesCache
 	}
 	if !meta.IsDefined("strictly-match-label") {
 		c.StrictlyMatchLabel = defaultStrictlyMatchLabel

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -613,6 +613,8 @@ func (o *PersistOptions) Reload(storage *core.Storage) error {
 		o.replicationMode.Store(&cfg.ReplicationMode)
 		o.labelProperty.Store(cfg.LabelProperty)
 		o.SetClusterVersion(&cfg.ClusterVersion)
+		o.SetPlacementRuleEnabled(cfg.Replication.EnablePlacementRules)
+		o.SetPlacementRulesCacheEnabled(cfg.Replication.EnablePlacementRulesCache)
 	}
 	return nil
 }

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -595,6 +595,7 @@ func (o *PersistOptions) Persist(storage *core.Storage) error {
 }
 
 // Reload reloads the configuration from the storage.
+// It will be called by pkg dashboard's adapter.(*Manager).updateInfo periodically
 func (o *PersistOptions) Reload(storage *core.Storage) error {
 	cfg := &Config{}
 	// pass nil to initialize cfg to default values (all items undefined)
@@ -606,6 +607,7 @@ func (o *PersistOptions) Reload(storage *core.Storage) error {
 	}
 	o.adjustScheduleCfg(&cfg.Schedule)
 	cfg.PDServerCfg.MigrateDeprecatedFlags()
+	// reload will ignore all items of config file defined but follows
 	if isExist {
 		o.schedule.Store(&cfg.Schedule)
 		o.replication.Store(&cfg.Replication)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -607,7 +607,6 @@ func (o *PersistOptions) Reload(storage *core.Storage) error {
 	}
 	o.adjustScheduleCfg(&cfg.Schedule)
 	cfg.PDServerCfg.MigrateDeprecatedFlags()
-	// reload will ignore all items of config file defined but follows
 	if isExist {
 		o.schedule.Store(&cfg.Schedule)
 		o.replication.Store(&cfg.Replication)
@@ -615,8 +614,6 @@ func (o *PersistOptions) Reload(storage *core.Storage) error {
 		o.replicationMode.Store(&cfg.ReplicationMode)
 		o.labelProperty.Store(cfg.LabelProperty)
 		o.SetClusterVersion(&cfg.ClusterVersion)
-		o.SetPlacementRuleEnabled(cfg.Replication.EnablePlacementRules)
-		o.SetPlacementRulesCacheEnabled(cfg.Replication.EnablePlacementRulesCache)
 	}
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -498,6 +498,7 @@ func (s *Server) Run() error {
 		return err
 	}
 
+	s.initConfig()
 	s.startServerLoop(s.ctx)
 
 	return nil
@@ -1346,6 +1347,16 @@ func (s *Server) reloadConfigFromKV() error {
 		s.storage.SwitchToDefaultStorage()
 		log.Info("server disable region storage")
 	}
+	return nil
+}
+
+// persit config to the etcd, and persistOptions.Reload will flush config periodically
+func (s *Server) initConfig() error {
+	c := s.GetConfig()
+	if err := s.storage.SaveConfig(c); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/tests/pdctl/operator/operator_test.go
+++ b/tests/pdctl/operator/operator_test.go
@@ -200,6 +200,8 @@ func (s *operatorTestSuite) TestOperator(c *C) {
 
 	_, err = pdctl.ExecuteCommand(cmd, "config", "set", "enable-placement-rules", "true")
 	c.Assert(err, IsNil)
+	_, err = pdctl.ExecuteCommand(cmd, "config", "set", "enable-placement-rules-cache", "true")
+	c.Assert(err, IsNil)
 	output, err = pdctl.ExecuteCommand(cmd, "operator", "add", "transfer-region", "1", "2", "3")
 	c.Assert(err, IsNil)
 	c.Assert(strings.Contains(string(output), "not supported"), IsTrue)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
close https://github.com/pingcap/tidb/issues/29523

### What is changed and how it works?
1. fix `(o *PersistOptions) Reload()` to make persistent config work

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tidb-ansible`](https://github.com/pingcap/tidb-ansible):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
