### PR TITLE
scheduler: low space tikv can not balance 

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -346,7 +346,6 @@ func (s *StoreInfo) regionScoreV2(delta int64, lowSpaceRatio float64) float64 {
 	A := float64(s.GetAvgAvailable()) / gb
 	C := float64(s.GetCapacity()) / gb
 	R := float64(s.GetRegionSize() + delta)
-	log.Info("score v2", zap.Float64("A", A), zap.Float64("C", C), zap.Float64("R", R))
 	if R < 0 {
 		R = float64(s.GetRegionSize())
 	}

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -343,7 +343,7 @@ func (s *StoreInfo) regionScoreV1(highSpaceRatio, lowSpaceRatio float64, delta i
 }
 
 func (s *StoreInfo) regionScoreV2(delta int64, lowSpaceRatio float64) float64 {
-	A := float64(s.GetAvgAvailable())
+	A := float64(s.GetAvgAvailable()) / gb
 	C := float64(s.GetCapacity()) / gb
 	R := float64(s.GetRegionSize() + delta)
 	if R < 0 {

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -346,6 +346,7 @@ func (s *StoreInfo) regionScoreV2(delta int64, lowSpaceRatio float64) float64 {
 	A := float64(s.GetAvgAvailable()) / gb
 	C := float64(s.GetCapacity()) / gb
 	R := float64(s.GetRegionSize() + delta)
+	log.Info("score v2", zap.Float64("A", A), zap.Float64("C", C), zap.Float64("R", R))
 	if R < 0 {
 		R = float64(s.GetRegionSize())
 	}

--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -134,21 +134,36 @@ func (s *testStoreSuite) TestLowSpaceScoreV2(c *C) {
 		small  *StoreInfo
 	}{{
 		// store1 and store2 has same store available ratio and store1 less 50gb
-		bigger: NewStoreInfoWithAvailable(1, 20*gb, 100*gb),
-		small:  NewStoreInfoWithAvailable(2, 200*gb, 1000*gb),
+		bigger: NewStoreInfoWithAvailable(1, 20*gb, 100*gb, 1.4),
+		small:  NewStoreInfoWithAvailable(2, 200*gb, 1000*gb, 1.4),
 	}, {
 		// store1 and store2 has same available space and less than 50gb
-		bigger: NewStoreInfoWithAvailable(1, 10*gb, 1000*gb),
-		small:  NewStoreInfoWithAvailable(2, 10*gb, 100*gb),
+		bigger: NewStoreInfoWithAvailable(1, 10*gb, 1000*gb, 1.4),
+		small:  NewStoreInfoWithAvailable(2, 10*gb, 100*gb, 1.4),
 	}, {
 		// store1 and store2 has same available ratio less than 0.2
-		bigger: NewStoreInfoWithAvailable(1, 10*gb, 1000*gb),
-		small:  NewStoreInfoWithAvailable(2, 1*gb, 100*gb),
+		bigger: NewStoreInfoWithAvailable(1, 10*gb, 1000*gb, 1.4),
+		small:  NewStoreInfoWithAvailable(2, 1*gb, 100*gb, 1.4),
 	}, {
 		// store1 and store2 has same available ratio
 		// but the store1 ratio less than store2(10/50=0.1<100/200=0.5)
-		bigger: NewStoreInfoWithAvailable(1, 10*gb, 100*gb),
-		small:  NewStoreInfoWithAvailable(2, 100*gb, 1000*gb),
+		bigger: NewStoreInfoWithAvailable(1, 10*gb, 100*gb, 1.4),
+		small:  NewStoreInfoWithAvailable(2, 100*gb, 1000*gb, 1.4),
+	}, {
+		// store1 and store2 has same usedSize and capacity,
+		// but the bigger's amp is bigger
+		bigger: NewStoreInfoWithAvailable(1, 10*gb, 100*gb, 1.5),
+		small:  NewStoreInfoWithAvailable(2, 10*gb, 100*gb, 1.4),
+	}, {
+		// store1 and store2 has same  capacity and regionSize（40g），
+		// but store1 has less available space size
+		bigger: NewStoreInfoWithAvailable(1, 60*gb, 100*gb, 1),
+		small:  NewStoreInfoWithAvailable(2, 80*gb, 100*gb, 2),
+	}, {
+		// store1 and store2 has same  capacity and store2(40g) has twice usedSize than store1(20g)
+		// but store1 has higher amp ,so store1(60g) has more regionSize(40g)
+		bigger: NewStoreInfoWithAvailable(1, 80*gb, 100*gb, 3),
+		small:  NewStoreInfoWithAvailable(2, 60*gb, 100*gb, 1),
 	}}
 	for _, v := range testdata {
 		score1 := v.bigger.regionScoreV2(0, 0.8)

--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -146,7 +146,7 @@ func (s *testStoreSuite) TestLowSpaceScoreV2(c *C) {
 		small:  NewStoreInfoWithAvailable(2, 1*gb, 100*gb, 1.4),
 	}, {
 		// store1 and store2 has same available ratio
-		// but the store1 ratio less than store2(10/50=0.1<100/200=0.5)
+		// but the store1 ratio less than store2 ((50-10)/50=0.8<(200-100)/200=0.5)
 		bigger: NewStoreInfoWithAvailable(1, 10*gb, 100*gb, 1.4),
 		small:  NewStoreInfoWithAvailable(2, 100*gb, 1000*gb, 1.4),
 	}, {
@@ -155,13 +155,13 @@ func (s *testStoreSuite) TestLowSpaceScoreV2(c *C) {
 		bigger: NewStoreInfoWithAvailable(1, 10*gb, 100*gb, 1.5),
 		small:  NewStoreInfoWithAvailable(2, 10*gb, 100*gb, 1.4),
 	}, {
-		// store1 and store2 has same  capacity and regionSize（40g），
+		// store1 and store2 has same capacity and regionSize（40g),
 		// but store1 has less available space size
 		bigger: NewStoreInfoWithAvailable(1, 60*gb, 100*gb, 1),
 		small:  NewStoreInfoWithAvailable(2, 80*gb, 100*gb, 2),
 	}, {
-		// store1 and store2 has same  capacity and store2(40g) has twice usedSize than store1(20g)
-		// but store1 has higher amp ,so store1(60g) has more regionSize(40g)
+		// store1 and store2 has same capacity and store2 (40g) has twice usedSize than store1 (20g)
+		// but store1 has higher amp, so store1(60g) has more regionSize (40g)
 		bigger: NewStoreInfoWithAvailable(1, 80*gb, 100*gb, 3),
 		small:  NewStoreInfoWithAvailable(2, 60*gb, 100*gb, 1),
 	}}

--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -150,12 +150,12 @@ func (s *testStoreSuite) TestLowSpaceScoreV2(c *C) {
 		bigger: NewStoreInfoWithAvailable(1, 10*gb, 100*gb, 1.4),
 		small:  NewStoreInfoWithAvailable(2, 100*gb, 1000*gb, 1.4),
 	}, {
-		// store1 and store2 has same usedSize and capacity,
+		// store1 and store2 has same usedSize and capacity
 		// but the bigger's amp is bigger
 		bigger: NewStoreInfoWithAvailable(1, 10*gb, 100*gb, 1.5),
 		small:  NewStoreInfoWithAvailable(2, 10*gb, 100*gb, 1.4),
 	}, {
-		// store1 and store2 has same capacity and regionSize（40g),
+		// store1 and store2 has same capacity and regionSize（40g)
 		// but store1 has less available space size
 		bigger: NewStoreInfoWithAvailable(1, 60*gb, 100*gb, 1),
 		small:  NewStoreInfoWithAvailable(2, 80*gb, 100*gb, 2),

--- a/server/core/test_util.go
+++ b/server/core/test_util.go
@@ -85,13 +85,12 @@ func NewTestRegionInfo(start, end []byte) *RegionInfo {
 }
 
 // NewStoreInfoWithAvailable is create with store
-func NewStoreInfoWithAvailable(id, available, capacity uint64) *StoreInfo {
-	amp := uint64(2)
+func NewStoreInfoWithAvailable(id, available, capacity uint64, amp float64) *StoreInfo {
 	stats := &pdpb.StoreStats{}
 	stats.Capacity = capacity
 	stats.Available = available
 	usedSize := capacity - available
-	regionSize := (usedSize * amp) * 1000 / gb
+	regionSize := (float64(usedSize) * amp) / mb
 	store := NewStoreInfo(
 		&metapb.Store{
 			Id: id,

--- a/server/core/test_util.go
+++ b/server/core/test_util.go
@@ -84,6 +84,25 @@ func NewTestRegionInfo(start, end []byte) *RegionInfo {
 	}}
 }
 
+// NewStoreInfoWithAvailable is create with store
+func NewStoreInfoWithAvailable(id, available, capacity uint64) *StoreInfo {
+	amp := uint64(2)
+	stats := &pdpb.StoreStats{}
+	stats.Capacity = capacity
+	stats.Available = available
+	usedSize := capacity - available
+	regionSize := (usedSize * amp) * 1000 / gb
+	store := NewStoreInfo(
+		&metapb.Store{
+			Id: id,
+		},
+		SetStoreStats(stats),
+		SetRegionCount(int(regionSize/96)),
+		SetRegionSize(int64(regionSize)),
+	)
+	return store
+}
+
 // NewStoreInfoWithLabel is create a store with specified labels.
 func NewStoreInfoWithLabel(id uint64, regionCount int, labels map[string]string) *StoreInfo {
 	storeLabels := make([]*metapb.StoreLabel, 0, len(labels))

--- a/server/core/test_util.go
+++ b/server/core/test_util.go
@@ -84,7 +84,7 @@ func NewTestRegionInfo(start, end []byte) *RegionInfo {
 	}}
 }
 
-// NewStoreInfoWithAvailable is create with store
+// NewStoreInfoWithAvailable is create with available and capacity
 func NewStoreInfoWithAvailable(id, available, capacity uint64, amp float64) *StoreInfo {
 	stats := &pdpb.StoreStats{}
 	stats.Capacity = capacity


### PR DESCRIPTION
Signed-off-by: bufferflies <1045931706@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
close: #4323
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
available space unit is not same 
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

capacity
  store1,store4: 161gb
  others: 215gb
available ratio and score
![image](https://user-images.githubusercontent.com/23159587/141400684-77a2b94d-d2d5-45ba-9bea-3cda28241305.png)

balance:
![image](https://user-images.githubusercontent.com/23159587/141400916-1049e344-31a6-4fca-bd95-c5b8837d3ffb.png)

there is no balance roll back 




Code changes

Side effects

Related changes

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
