### PR TITLE
cluster: break loop when checker is busy

### DIFF
--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -117,7 +117,7 @@ func (c *coordinator) patrolRegions() {
 			}
 			checkerIsBusy, ops := c.checkers.CheckRegion(region)
 			if checkerIsBusy {
-				continue
+				break
 			}
 			if len(ops) > 0 {
 				c.opController.AddWaitingOperator(ops...)


### PR DESCRIPTION
… busy

Signed-off-by: Cabinfever_B <cabinfeveroier@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
fix #3827 
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
Use `break` instead of `continue` when checker is busy

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

Code changes


Side effects

- Possible performance regression

Related changes

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
should break the suspect region range loop when checker is busy
```
