### PR TITLE
*: check if GetStore returns nil

### DIFF
--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -94,8 +94,12 @@ func (s *ReplicaStrategy) SelectStoreToFix(coLocationStores []*core.StoreInfo, o
 func (s *ReplicaStrategy) SelectStoreToImprove(coLocationStores []*core.StoreInfo, old uint64) uint64 {
 	// trick to avoid creating a slice with `old` removed.
 	s.swapStoreToFirst(coLocationStores, old)
+	oldStore := s.cluster.GetStore(old)
+	if oldStore == nil {
+		return 0
+	}
 	filters := []filter.Filter{
-		filter.NewLocationImprover(s.checkerName, s.locationLabels, coLocationStores, s.cluster.GetStore(old)),
+		filter.NewLocationImprover(s.checkerName, s.locationLabels, coLocationStores, oldStore),
 	}
 	if len(s.locationLabels) > 0 && s.isolationLevel != "" {
 		filters = append(filters, filter.NewIsolationFilter(s.checkerName, s.isolationLevel, s.locationLabels, coLocationStores[1:]))

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -279,6 +279,9 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string) *
 	// Group peers by the engine of their stores
 	for _, peer := range region.GetPeers() {
 		store := r.cluster.GetStore(peer.GetStoreId())
+		if store == nil {
+			return nil
+		}
 		if ordinaryFilter.Target(r.cluster.GetOpts(), store) {
 			ordinaryPeers[peer.GetId()] = peer
 		} else {
@@ -426,6 +429,9 @@ func (r *RegionScatterer) selectAvailableLeaderStore(group string, peers map[uin
 	leaderCandidateStores := make([]uint64, 0)
 	for storeID := range peers {
 		store := r.cluster.GetStore(storeID)
+		if store == nil {
+			return 0
+		}
 		engine := store.GetLabelValue(core.EngineKey)
 		if len(engine) < 1 {
 			leaderCandidateStores = append(leaderCandidateStores, storeID)
@@ -450,6 +456,9 @@ func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint6
 	for _, peer := range peers {
 		storeID := peer.GetStoreId()
 		store := r.cluster.GetStore(storeID)
+		if store == nil {
+			continue
+		}
 		if ordinaryFilter.Target(r.cluster.GetOpts(), store) {
 			r.ordinaryEngine.selectedPeer.Put(storeID, group)
 			scatterDistributionCounter.WithLabelValues(

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -154,7 +154,11 @@ func (s *shuffleRegionScheduler) scheduleRemovePeer(cluster opt.Cluster) (*core.
 }
 
 func (s *shuffleRegionScheduler) scheduleAddPeer(cluster opt.Cluster, region *core.RegionInfo, oldPeer *metapb.Peer) *metapb.Peer {
-	scoreGuard := filter.NewPlacementSafeguard(s.GetName(), cluster, region, cluster.GetStore(oldPeer.GetStoreId()))
+	store := cluster.GetStore(oldPeer.GetStoreId())
+	if store == nil {
+		return nil
+	}
+	scoreGuard := filter.NewPlacementSafeguard(s.GetName(), cluster, region, store)
 	excludedFilter := filter.NewExcludedFilter(s.GetName(), nil, region.GetStoreIds())
 
 	target := filter.NewCandidates(cluster.GetStores()).

--- a/server/statistics/store.go
+++ b/server/statistics/store.go
@@ -120,7 +120,7 @@ func (s *StoresStats) FilterUnhealthyStore(cluster core.StoreSetInformer) {
 	defer s.Unlock()
 	for storeID := range s.rollingStoresStats {
 		store := cluster.GetStore(storeID)
-		if store.IsTombstone() || store.IsUnhealthy() || store.IsPhysicallyDestroyed() {
+		if store == nil || store.IsTombstone() || store.IsUnhealthy() || store.IsPhysicallyDestroyed() {
 			delete(s.rollingStoresStats, storeID)
 		}
 	}

--- a/server/statistics/store_test.go
+++ b/server/statistics/store_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/tikv/pd/server/core"
+)
+
+var _ = Suite(&testStoreSuite{})
+
+type testStoreSuite struct{}
+
+func (s *testStoreSuite) TestFilterUnhealtyStore(c *C) {
+	stats := NewStoresStats()
+	cluster := core.NewBasicCluster()
+	for i := uint64(1); i <= 5; i++ {
+		cluster.PutStore(core.NewStoreInfo(&metapb.Store{Id: i}, core.SetLastHeartbeatTS(time.Now())))
+		stats.Observe(i, &pdpb.StoreStats{})
+	}
+	c.Assert(stats.GetStoresLoads(), HasLen, 5)
+
+	cluster.PutStore(cluster.GetStore(1).Clone(core.SetLastHeartbeatTS(time.Now().Add(-24 * time.Hour))))
+	cluster.PutStore(cluster.GetStore(2).Clone(core.TombstoneStore()))
+	cluster.DeleteStore(cluster.GetStore(3))
+
+	stats.FilterUnhealthyStore(cluster)
+	loads := stats.GetStoresLoads()
+	c.Assert(loads, HasLen, 2)
+	c.Assert(loads[4], NotNil)
+	c.Assert(loads[5], NotNil)
+}


### PR DESCRIPTION
close #4344

Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
If we use `remove tombstone`, `GetStore` may return nil. We should check it.

### What is changed and how it works?

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Related changes
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix panic issue after TiKV node scales in
```
