### PR TITLE
checker: merge-region should consider the peer on an offline store

### DIFF
--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -145,9 +145,10 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		return nil
 	}
 
-	// Check whether the store of the target region leader has been deleted.
-	if m.cluster.GetStore(target.GetLeader().GetStoreId()) == nil {
-		checkerCounter.WithLabelValues("merge_checker", "target-store-deleted").Inc()
+	// Check whether the store of the target region leader is normal.
+	store := m.cluster.GetStore(target.GetLeader().GetStoreId())
+	if store == nil || store.IsOffline() {
+		checkerCounter.WithLabelValues("merge_checker", "target-store-offline").Inc()
 		return nil
 	}
 

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -111,7 +111,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		return nil
 	}
 
-	// skip region has down peers or pending peers or learner peers
+	// skip region has down peers or pending peers
 	if !opt.IsRegionHealthy(region) {
 		checkerCounter.WithLabelValues("merge_checker", "special-peer").Inc()
 		return nil
@@ -142,6 +142,12 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 
 	if target == nil {
 		checkerCounter.WithLabelValues("merge_checker", "no-target").Inc()
+		return nil
+	}
+
+	// Check whether the store of the target region leader has been deleted.
+	if m.cluster.GetStore(target.GetLeader().GetStoreId()) == nil {
+		checkerCounter.WithLabelValues("merge_checker", "target-store-deleted").Inc()
 		return nil
 	}
 

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -234,8 +234,10 @@ func checkPeerStore(cluster opt.Cluster, region, adjacent *core.RegionInfo) bool
 	for _, peer := range adjacent.GetPeers() {
 		storeID := peer.GetStoreId()
 		store := cluster.GetStore(storeID)
-		if _, ok := regionStoreIDs[storeID]; (store == nil || store.IsOffline()) && !ok {
-			return false
+		if store == nil || store.IsOffline() {
+			if _, ok := regionStoreIDs[storeID]; !ok {
+				return false
+			}
 		}
 	}
 	return true

--- a/server/schedule/checker/merge_checker_test.go
+++ b/server/schedule/checker/merge_checker_test.go
@@ -178,6 +178,19 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
 	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
 
+	// Test the target region's store is deleted.
+	s.cluster.SetEnablePlacementRules(false)
+	storeToDelete := s.cluster.GetStore(4)
+	c.Assert(storeToDelete, NotNil)
+	s.cluster.DeleteStore(storeToDelete)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, IsNil)
+	s.cluster.PutStore(storeToDelete)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
+
 	// merge cannot across rule key.
 	s.cluster.SetEnablePlacementRules(true)
 	s.cluster.RuleManager.SetRule(&placement.Rule{

--- a/server/schedule/checker/merge_checker_test.go
+++ b/server/schedule/checker/merge_checker_test.go
@@ -163,6 +163,58 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
 	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
 
+	// Test the peer store check.
+	store := s.cluster.GetStore(1)
+	c.Assert(store, NotNil)
+	// Test the peer store is deleted.
+	s.cluster.DeleteStore(store)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, IsNil)
+	// Test the store is normal.
+	s.cluster.PutStore(store)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
+	// Test the store is offline.
+	s.cluster.SetStoreOffline(store.GetID())
+	ops = s.mc.Check(s.regions[2])
+	// Only target region have a peer on the offline store,
+	// so it's not ok to merge.
+	c.Assert(ops, IsNil)
+	// Test the store is up.
+	s.cluster.SetStoreUp(store.GetID())
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
+	store = s.cluster.GetStore(5)
+	c.Assert(store, NotNil)
+	// Test the peer store is deleted.
+	s.cluster.DeleteStore(store)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, IsNil)
+	// Test the store is normal.
+	s.cluster.PutStore(store)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
+	// Test the store is offline.
+	s.cluster.SetStoreOffline(store.GetID())
+	ops = s.mc.Check(s.regions[2])
+	// Both regions have peers on the offline store,
+	// so it's ok to merge.
+	c.Assert(ops, NotNil)
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
+	// Test the store is up.
+	s.cluster.SetStoreUp(store.GetID())
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
+
 	// Enable one way merge
 	s.cluster.SetEnableOneWayMerge(true)
 	ops = s.mc.Check(s.regions[2])
@@ -175,31 +227,6 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	ops = s.mc.Check(s.regions[2])
 	c.Assert(ops, NotNil)
 	// Now it merges to next region.
-	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
-	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
-
-	// Test the target region's store check.
-	s.cluster.SetEnablePlacementRules(false)
-	store := s.cluster.GetStore(4)
-	c.Assert(store, NotNil)
-	s.cluster.DeleteStore(store)
-	// Test the store is deleted.
-	ops = s.mc.Check(s.regions[2])
-	c.Assert(ops, IsNil)
-	// Test the store is normal.
-	s.cluster.PutStore(store)
-	ops = s.mc.Check(s.regions[2])
-	c.Assert(ops, NotNil)
-	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
-	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
-	// Test the store is offline.
-	s.cluster.SetStoreOffline(store.GetID())
-	ops = s.mc.Check(s.regions[2])
-	c.Assert(ops, IsNil)
-	// Test the store is up.
-	s.cluster.SetStoreUp(store.GetID())
-	ops = s.mc.Check(s.regions[2])
-	c.Assert(ops, NotNil)
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
 	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
 

--- a/server/schedule/checker/merge_checker_test.go
+++ b/server/schedule/checker/merge_checker_test.go
@@ -178,14 +178,26 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
 	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
 
-	// Test the target region's store is deleted.
+	// Test the target region's store check.
 	s.cluster.SetEnablePlacementRules(false)
-	storeToDelete := s.cluster.GetStore(4)
-	c.Assert(storeToDelete, NotNil)
-	s.cluster.DeleteStore(storeToDelete)
+	store := s.cluster.GetStore(4)
+	c.Assert(store, NotNil)
+	s.cluster.DeleteStore(store)
+	// Test the store is deleted.
 	ops = s.mc.Check(s.regions[2])
 	c.Assert(ops, IsNil)
-	s.cluster.PutStore(storeToDelete)
+	// Test the store is normal.
+	s.cluster.PutStore(store)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
+	// Test the store is offline.
+	s.cluster.SetStoreOffline(store.GetID())
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, IsNil)
+	// Test the store is up.
+	s.cluster.SetStoreUp(store.GetID())
 	ops = s.mc.Check(s.regions[2])
 	c.Assert(ops, NotNil)
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close #4119.

### What is changed and how it works?

Make `merge_checker.go` check whether there is a peer of the adjacent region on an offline store, while the source region has no peer on it. This is to prevent from bringing any other peer into an offline store to slow down the offline process.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Make merge-region not to merge a region into the offline store.
```
