### PR TITLE
api,pd-ctl: foramte scanRegions api and fix a index out of range bug in relevant pdctl command

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -308,10 +308,10 @@ func (h *regionsHandler) GetAll(w http.ResponseWriter, r *http.Request) {
 }
 
 // @Tags region
-// @Summary List regions start from a key.
-// @Param key query string true "Region start key"
-// @Param endkey query string true "Range end key"
-// @Param limit query integer false "Limit count" default(16)
+// @Summary List regions in a given range [startKey, endKey).
+// @Param key query string true "Region range start key"
+// @Param endkey query string true "Region range end key"
+// @Param limit query integer false "Limit count" default(16) without endKey, default(-1) with endKey
 // @Produce json
 // @Success 200 {object} RegionsInfo
 // @Failure 400 {string} string "The input is invalid."
@@ -709,7 +709,7 @@ func (h *regionsHandler) GetTopSize(w http.ResponseWriter, r *http.Request) {
 // @Param body body object true "json params"
 // @Param limit query integer false "Limit count" default(256)
 // @Produce json
-// @Success 200 {string} string "Accelerate regions scheduling in a given range[startKey,endKey)"
+// @Success 200 {string} string "Accelerate regions scheduling in a given range [startKey, endKey)"
 // @Failure 400 {string} string "The input is invalid."
 // @Router /regions/accelerate-schedule [post]
 func (h *regionsHandler) AccelerateRegionsScheduleInRange(w http.ResponseWriter, r *http.Request) {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -427,7 +427,7 @@ func (s *testGetRegionSuite) TestRegionKey(c *C) {
 	c.Assert(r.GetID(), Equals, RegionInfo.ID)
 }
 
-func (s *testGetRegionSuite) TestScanRegionByKey(c *C) {
+func (s *testGetRegionSuite) TestScanRegionByKeys(c *C) {
 	r1 := newTestRegionInfo(2, 1, []byte("a"), []byte("b"))
 	r2 := newTestRegionInfo(3, 1, []byte("b"), []byte("c"))
 	r3 := newTestRegionInfo(4, 2, []byte("c"), []byte("e"))

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -145,6 +145,8 @@ func (s *regionTestSuite) TestRegion(c *C) {
 		// region check learner-peer command
 		{[]string{"region", "check", "learner-peer"}, []*core.RegionInfo{r3}},
 		// region keys --format=raw <start_key> <end_key> <limit> command
+		{[]string{"region", "keys", "--format=raw", "b"}, []*core.RegionInfo{r2, r3, r4}},
+		// region keys --format=raw <start_key> <end_key> <limit> command
 		{[]string{"region", "keys", "--format=raw", "b", "", "2"}, []*core.RegionInfo{r2, r3}},
 		// region keys --format=hex <start_key> <end_key> <limit> command
 		{[]string{"region", "keys", "--format=hex", "63", "", "2"}, []*core.RegionInfo{r3, r4}},

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -375,11 +375,11 @@ func decodeKey(text string) (string, error) {
 	return string(buf), nil
 }
 
-// NewRegionsByKeysCommand returns regions in a given range[startkey, endkey) subcommand of regionCmd.
+// NewRegionsByKeysCommand returns regions in a given range [startkey, endkey) subcommand of regionCmd.
 func NewRegionsByKeysCommand() *cobra.Command {
 	r := &cobra.Command{
 		Use:   "keys [--format=raw|encode|hex] <start_key> <end_key> <limit>",
-		Short: "show regions in a given range[startkey, endkey)",
+		Short: "show regions in a given range [startkey, endkey)",
 		Run:   showRegionsByKeysCommandFunc,
 	}
 
@@ -392,19 +392,22 @@ func showRegionsByKeysCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Println(cmd.UsageString())
 		return
 	}
-	key, err := parseKey(cmd.Flags(), args[0])
+	startKey, err := parseKey(cmd.Flags(), args[0])
 	if err != nil {
 		cmd.Println("Error: ", err)
 		return
 	}
-	key = url.QueryEscape(key)
-	endKey, err := parseKey(cmd.Flags(), args[1])
-	if err != nil {
-		cmd.Println("Error: ", err)
-		return
+	startKey = url.QueryEscape(startKey)
+	prefix := regionsKeyPrefix + "?key=" + startKey
+	if len(args) >= 2 {
+		endKey, err := parseKey(cmd.Flags(), args[1])
+		if err != nil {
+			cmd.Println("Error: ", err)
+			return
+		}
+		endKey = url.QueryEscape(endKey)
+		prefix += "&end_key=" + endKey
 	}
-	endKey = url.QueryEscape(endKey)
-	prefix := regionsKeyPrefix + "?key=" + key + "&end_key=" + endKey
 	if len(args) == 3 {
 		if _, err = strconv.Atoi(args[2]); err != nil {
 			cmd.Println("limit should be a number")


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
Tracking Issue: #4400

This is a supplementary work of #4142.
* fix a index out of range error in pd-ctl `region keys` command 
     > when query regions start from `a` by `region keys --formate=raw a`, the length of args is 1, privious code use args[1] without check length.
* update comment.

<!-- Add the issue link with a summary if it exists. -->

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix an index out of range bug of the region keys command in pd-ctl
```
