### PR TITLE
schedulers: evict-slow-store-scheduler uses the correct name and type

### DIFF
--- a/server/schedulers/evict_slow_store.go
+++ b/server/schedulers/evict_slow_store.go
@@ -131,7 +131,7 @@ func (s *evictSlowStoreScheduler) schedulerEvictLeader(cluster opt.Cluster) []*o
 	storeMap := map[uint64][]core.KeyRange{
 		s.conf.EvictedStores[0]: {core.NewKeyRange("", "")},
 	}
-	return scheduleEvictLeaderBatch(s.GetName(), cluster, storeMap, EvictLeaderBatchSize)
+	return scheduleEvictLeaderBatch(s.GetName(), s.GetType(), cluster, storeMap, EvictLeaderBatchSize)
 }
 
 func (s *evictSlowStoreScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -651,4 +651,5 @@ func (s *testEvictSlowStoreSuite) TestEvictSlowStore(c *C) {
 	c.Check(es.Schedule(tc), IsNil)
 	op = bs.Schedule(tc)
 	testutil.CheckTransferLeader(c, op[0], operator.OpLeader, 2, 1)
+	c.Assert(op[0].Desc(), Equals, EvictSlowStoreType)
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

close #4376

### What is changed and how it works?

`evict-slow-store-scheduler` uses the correct `name` and `type`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
