### PR TITLE
grpc-service: Add_split_and_scatter_region

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -107,6 +107,8 @@ type Client interface {
 	ScatterRegions(ctx context.Context, regionsID []uint64, opts ...RegionsOption) (*pdpb.ScatterRegionResponse, error)
 	// SplitRegions split regions by given split keys
 	SplitRegions(ctx context.Context, splitKeys [][]byte, opts ...RegionsOption) (*pdpb.SplitRegionsResponse, error)
+	// SplitAndScatterRegions split regions by given split keys and scatter new regions
+	SplitAndScatterRegions(ctx context.Context, splitKeys [][]byte, opts ...RegionsOption) (*pdpb.SplitAndScatterRegionsResponse, error)
 	// GetOperator gets the status of operator of the specified region.
 	GetOperator(ctx context.Context, regionID uint64) (*pdpb.GetOperatorResponse, error)
 	// UpdateOption updates the client option.
@@ -1692,6 +1694,32 @@ func (c *client) scatterRegionsWithOptions(ctx context.Context, regionsID []uint
 	if resp.Header.GetError() != nil {
 		return nil, errors.Errorf("scatter regions %v failed: %s", regionsID, resp.Header.GetError().String())
 	}
+	return resp, nil
+}
+
+func (c *client) SplitAndScatterRegions(ctx context.Context, splitKeys [][]byte, opts ...RegionsOption) (*pdpb.SplitAndScatterRegionsResponse, error) {
+	start := time.Now()
+	defer func() { cmdDurationSplitAndScatterRegions.Observe(time.Since(start).Seconds()) }()
+	options := &RegionsOp{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	ctx, cancel := context.WithTimeout(ctx, c.option.timeout)
+	req := &pdpb.SplitAndScatterRegionsRequest{
+		Header:     c.requestHeader(),
+		SplitKeys:  splitKeys,
+		Group:      options.group,
+		RetryLimit: options.retryLimit,
+	}
+
+	ctx = grpcutil.BuildForwardContext(ctx, c.GetLeaderAddr())
+	resp, err := c.getClient().SplitAndScatterRegions(ctx, req)
+	cancel()
+
+	if err != nil {
+		return nil, err
+	}
+
 	return resp, nil
 }
 

--- a/client/metrics.go
+++ b/client/metrics.go
@@ -98,6 +98,7 @@ var (
 	cmdDurationScatterRegions           = cmdDuration.WithLabelValues("scatter_regions")
 	cmdDurationGetOperator              = cmdDuration.WithLabelValues("get_operator")
 	cmdDurationSplitRegions             = cmdDuration.WithLabelValues("split_regions")
+	cmdDurationSplitAndScatterRegions   = cmdDuration.WithLabelValues("split_and_scatter_regions")
 
 	cmdFailDurationGetRegion                  = cmdFailedDuration.WithLabelValues("get_region")
 	cmdFailDurationTSO                        = cmdFailedDuration.WithLabelValues("tso")


### PR DESCRIPTION

### What problem does this PR solve?

Close pingcap/tidb#29034

### What is changed and how it works?

Add a method splitAndScatterRegions in grpc-service

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
 Let pd handle split and scatter regions directly
```