### PR TITLE
server/schedule: use ChangePeerV2 to demote single voter directly

### DIFF
--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -409,6 +409,20 @@ func (df DemoteFollower) CheckInProgress(cluster opt.Cluster, region *core.Regio
 // Influence calculates the store difference that current step makes.
 func (df DemoteFollower) Influence(opInfluence OpInfluence, region *core.RegionInfo) {}
 
+// GetRequest get the ChangePeerV2 request
+func (df DemoteFollower) GetRequest() *pdpb.ChangePeerV2 {
+	return &pdpb.ChangePeerV2{
+		Changes: []*pdpb.ChangePeer{{
+			ChangeType: eraftpb.ConfChangeType_AddLearnerNode,
+			Peer: &metapb.Peer{
+				Id:      df.PeerID,
+				StoreId: df.ToStore,
+				Role:    metapb.PeerRole_Learner,
+			},
+		}},
+	}
+}
+
 // DemoteVoter is very similar to DemoteFollower. But it allows Demote Leader.
 // Note: It is not an OpStep, only a sub step in ChangePeerV2Enter and ChangePeerV2Leave.
 type DemoteVoter struct {

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -660,7 +660,9 @@ func (oc *OperatorController) SendScheduleCommand(region *core.RegionInfo, step 
 	case operator.PromoteLearner:
 		cmd = addNode(st.PeerID, st.ToStore)
 	case operator.DemoteFollower:
-		cmd = addLearnerNode(st.PeerID, st.ToStore)
+		cmd = &pdpb.RegionHeartbeatResponse{
+			ChangePeerV2: st.GetRequest(),
+		}
 	case operator.RemovePeer:
 		cmd = &pdpb.RegionHeartbeatResponse{
 			ChangePeer: &pdpb.ChangePeer{


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
ref #4444.
ref https://github.com/tikv/tikv/issues/11463.

### What is changed and how it works?

 Change the field `ChangePeer` to `ChangePeerV2` if demoting a voter directlry. This can avoid breaking compatibility.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

- No code

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the problem that demoting a follower to learner isn't working.
```
