### PR TITLE
tso: add a local TSO prefix to prevent being conflicted with other system key paths

### DIFF
--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -47,8 +47,8 @@ const (
 	patrolStep                  = 1 * time.Second
 	defaultAllocatorLeaderLease = 3
 	leaderTickInterval          = 50 * time.Millisecond
-	localTSOAllocatorEtcdPrefix = "local-tso-allocator"
-	localTSOSuffixEtcdPrefix    = "local-tso-suffix"
+	localTSOAllocatorEtcdPrefix = "lta"
+	localTSOSuffixEtcdPrefix    = "lts"
 )
 
 var (

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -47,6 +47,7 @@ const (
 	patrolStep                  = 1 * time.Second
 	defaultAllocatorLeaderLease = 3
 	leaderTickInterval          = 50 * time.Millisecond
+	localTSOAllocatorEtcdPrefix = "local-tso-allocator"
 	localTSOSuffixEtcdPrefix    = "local-tso-suffix"
 )
 
@@ -328,7 +329,13 @@ func (am *AllocatorManager) getAllocatorPath(dcLocation string) string {
 	if dcLocation == GlobalDCLocation {
 		return am.rootPath
 	}
-	return path.Join(am.rootPath, dcLocation)
+	return path.Join(am.getLocalTSOAllocatorPath(), dcLocation)
+}
+
+// Add a prefix to the root path to prevent being conflicted
+// with other system key paths such as leader, member, alloc_id, raft, etc.
+func (am *AllocatorManager) getLocalTSOAllocatorPath() string {
+	return path.Join(am.rootPath, localTSOAllocatorEtcdPrefix)
 }
 
 // similar logic with leaderLoop in server/server.go
@@ -1145,7 +1152,7 @@ func (am *AllocatorManager) transferLocalAllocator(dcLocation string, serverID u
 }
 
 func (am *AllocatorManager) nextLeaderKey(dcLocation string) string {
-	return path.Join(am.rootPath, dcLocation, "next-leader")
+	return path.Join(am.getAllocatorPath(dcLocation), "next-leader")
 }
 
 // EnableLocalTSO returns the value of AllocatorManager.enableLocalTSO.

--- a/tests/server/tso/allocator_test.go
+++ b/tests/server/tso/allocator_test.go
@@ -56,7 +56,7 @@ func (s *testAllocatorSuite) TestAllocatorLeader(c *C) {
 	dcLocationConfig := map[string]string{
 		"pd2": "dc-1",
 		"pd4": "dc-2",
-		"pd6": "dc-3",
+		"pd6": "leader", /* Test dc-location name is same as the special key */
 	}
 	dcLocationNum := len(dcLocationConfig)
 	cluster, err := tests.NewTestCluster(s.ctx, dcLocationNum*2, func(conf *config.Config, serverName string) {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close https://github.com/tikv/pd/issues/4109.

### What is changed and how it works?

Add a prefix to the root path to prevent being conflicted with other system key paths such as leader, member, alloc_id, raft, etc.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Breaking backward compatibility

**Since the Local TSO has not been released yet, I think it's ok to break the backward compatibility.**

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
