### PR TITLE
test: increase test lease time to tolerate higher delayed time

### DIFF
--- a/server/testutil.go
+++ b/server/testutil.go
@@ -70,7 +70,7 @@ func NewTestSingleConfig(c *assertutil.Checker) *config.Config {
 
 		InitialClusterState: embed.ClusterStateFlagNew,
 
-		LeaderLease:     1,
+		LeaderLease:     10,
 		TSOSaveInterval: typeutil.NewDuration(200 * time.Millisecond),
 	}
 

--- a/tools/pd-simulator/simulator/config.go
+++ b/tools/pd-simulator/simulator/config.go
@@ -34,7 +34,7 @@ const (
 	defaultStoreIOMBPerSecond = 40
 	defaultStoreVersion       = "2.1.0"
 	// server
-	defaultLeaderLease                 = 1
+	defaultLeaderLease                 = 3
 	defaultTSOSaveInterval             = 200 * time.Millisecond
 	defaultTickInterval                = 100 * time.Millisecond
 	defaultElectionInterval            = 3 * time.Second


### PR DESCRIPTION
Signed-off-by: bufferflies <1045931706@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
close #4442
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
It set default  lease time to 10s(1s) for test and 3s for simulator  to keep consitence with develop.
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

Code changes

Side effects


Related changes


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
