### PR TITLE
unsafe recovery: Pause all schedulers and checkers when doing unsafe recovery 

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -686,6 +686,16 @@ error = '''
 invalid data, must 8 bytes, but %d
 '''
 
+["PD:unsaferecovery:ErrUnsafeRecoveryInvalidInput"]
+error = '''
+invalid input %s
+'''
+
+["PD:unsaferecovery:ErrUnsafeRecoveryIsRunning"]
+error = '''
+unsafe recovery is running
+'''
+
 ["PD:url:ErrQueryUnescape"]
 error = '''
 inverse transformation of QueryEscape error

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -323,3 +323,9 @@ var (
 var (
 	ErrBindJSON = errors.Normalize("bind JSON error", errors.RFCCodeText("PD:gin:ErrBindJSON"))
 )
+
+// unsafe recovery errors
+var (
+	ErrUnsafeRecoveryIsRunning    = errors.Normalize("unsafe recovery is running", errors.RFCCodeText("PD:unsaferecovery:ErrUnsafeRecoveryIsRunning"))
+	ErrUnsafeRecoveryInvalidInput = errors.Normalize("invalid input %s", errors.RFCCodeText("PD:unsaferecovery:ErrUnsafeRecoveryInvalidInput"))
+)

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -59,13 +59,7 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 	for _, store := range storeSlice {
 		stores[store] = ""
 	}
-	timeout := int64(600)
-	rawTimeout, exists := input["timeout"]
-	if exists {
-		timeout = int64(rawTimeout.(float64))
-	}
-
-	if err := rc.GetUnsafeRecoveryController().RemoveFailedStores(stores, timeout); err != nil {
+	if err := rc.GetUnsafeRecoveryController().RemoveFailedStores(stores); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/tikv/pd/pkg/apiutil"
+	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server"
 	"github.com/unrolled/render"
 )
@@ -36,6 +37,8 @@ func newUnsafeOperationHandler(svr *server.Server, rd *render.Render) *unsafeOpe
 
 // @Tags unsafe
 // @Summary Remove failed stores unsafely.
+// @Accept json
+// @Param body body object true "json params"
 // @Produce json
 // Success 200 {string} string "Request has been accepted."
 // Failure 400 {string} string "The input is invalid."
@@ -43,15 +46,26 @@ func newUnsafeOperationHandler(svr *server.Server, rd *render.Render) *unsafeOpe
 // @Router /admin/unsafe/remove-failed-stores [POST]
 func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *http.Request) {
 	rc := getCluster(r)
-	var stores map[uint64]string
-	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &stores); err != nil {
+	var input map[string]interface{}
+	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
-	if len(stores) == 0 {
-		h.rd.JSON(w, http.StatusBadRequest, "No store specified")
+	storeSlice, ok := typeutil.JSONToUint64Slice(input["stores"])
+	if !ok {
+		h.rd.JSON(w, http.StatusBadRequest, "Store ids are invalid")
 		return
 	}
-	if err := rc.GetUnsafeRecoveryController().RemoveFailedStores(stores); err != nil {
+	stores := make(map[uint64]string)
+	for _, store := range storeSlice {
+		stores[store] = ""
+	}
+	timeout := int64(600)
+	rawTimeout, exists := input["timeout"]
+	if exists {
+		timeout = int64(rawTimeout.(float64))
+	}
+
+	if err := rc.GetUnsafeRecoveryController().RemoveFailedStores(stores, timeout); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -45,9 +45,16 @@ func (s *testUnsafeAPISuite) TearDownSuite(c *C) {
 }
 
 func (s *testUnsafeAPISuite) TestRemoveFailedStores(c *C) {
-	input := map[uint64]string{1: ""}
-	data, err := json.Marshal(input)
-	c.Assert(err, IsNil)
+	input := map[string]interface{}{"stores": []uint64{}}
+	data, _ := json.Marshal(input)
+	err := postJSON(testDialClient, s.urlPrefix+"/remove-failed-stores", data)
+	c.Assert(err.Error(), Equals, "\"[PD:unsaferecovery:ErrUnsafeRecoveryInvalidInput]invalid input no store specified\"\n")
+	input = map[string]interface{}{"stores": []string{"abc", "def"}}
+	data, _ = json.Marshal(input)
+	err = postJSON(testDialClient, s.urlPrefix+"/remove-failed-stores", data)
+	c.Assert(err.Error(), Equals, "\"Store ids are invalid\"\n")
+	input = map[string]interface{}{"stores": []uint64{1, 2}, "timeout": 3600}
+	data, _ = json.Marshal(input)
 	err = postJSON(testDialClient, s.urlPrefix+"/remove-failed-stores", data)
 	c.Assert(err, IsNil)
 	// Test show

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -53,7 +53,7 @@ func (s *testUnsafeAPISuite) TestRemoveFailedStores(c *C) {
 	data, _ = json.Marshal(input)
 	err = postJSON(testDialClient, s.urlPrefix+"/remove-failed-stores", data)
 	c.Assert(err.Error(), Equals, "\"Store ids are invalid\"\n")
-	input = map[string]interface{}{"stores": []uint64{1, 2}, "timeout": 3600}
+	input = map[string]interface{}{"stores": []uint64{1, 2}}
 	data, _ = json.Marshal(input)
 	err = postJSON(testDialClient, s.urlPrefix+"/remove-failed-stores", data)
 	c.Assert(err, IsNil)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -465,6 +465,11 @@ func (c *RaftCluster) IsSchedulerDisabled(name string) (bool, error) {
 	return c.coordinator.isSchedulerDisabled(name)
 }
 
+// IsSchedulerAllowed checks if a scheduler is allowed.
+func (c *RaftCluster) IsSchedulerAllowed(name string) (bool, error) {
+	return c.coordinator.isSchedulerAllowed(name)
+}
+
 // IsSchedulerExisted checks if a scheduler is existed.
 func (c *RaftCluster) IsSchedulerExisted(name string) (bool, error) {
 	return c.coordinator.isSchedulerExisted(name)

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -42,6 +42,9 @@ func (c *RaftCluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 
 // HandleAskSplit handles the split request.
 func (c *RaftCluster) HandleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSplitResponse, error) {
+	if c.GetUnsafeRecoveryController() != nil && c.GetUnsafeRecoveryController().IsRunning() {
+		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
+	}
 	reqRegion := request.GetRegion()
 	err := c.ValidRequestRegion(reqRegion)
 	if err != nil {
@@ -94,6 +97,9 @@ func (c *RaftCluster) ValidRequestRegion(reqRegion *metapb.Region) error {
 
 // HandleAskBatchSplit handles the batch split request.
 func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*pdpb.AskBatchSplitResponse, error) {
+	if c.GetUnsafeRecoveryController() != nil && c.GetUnsafeRecoveryController().IsRunning() {
+		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
+	}
 	reqRegion := request.GetRegion()
 	splitCount := request.GetSplitCount()
 	err := c.ValidRequestRegion(reqRegion)

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -896,6 +896,18 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 	waitPromoteLearner(c, stream, region, 3)
 }
 
+func (s *testCoordinatorSuite) TestPauseScheduler(c *C) {
+	_, co, cleanup := prepare(nil, nil, func(co *coordinator) { co.run() }, c)
+	defer cleanup()
+	co.pauseOrResumeScheduler(schedulers.BalanceLeaderName, 60)
+	paused, err := co.isSchedulerPaused(schedulers.BalanceLeaderName)
+	c.Assert(err, IsNil)
+	c.Assert(paused, Equals, true)
+	allowed, err := co.isSchedulerAllowed(schedulers.BalanceLeaderName)
+	c.Assert(err, IsNil)
+	c.Assert(allowed, Equals, false)
+}
+
 func BenchmarkPatrolRegion(b *testing.B) {
 	mergeLimit := uint64(4100)
 	regionNum := 10000

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -906,9 +906,6 @@ func (s *testCoordinatorSuite) TestPauseScheduler(c *C) {
 	c.Assert(paused, Equals, true)
 	allowed, _ := co.isSchedulerAllowed(schedulers.BalanceLeaderName)
 	c.Assert(allowed, Equals, false)
-	co.cluster = nil
-	_, err = co.isSchedulerPaused(schedulers.BalanceLeaderName)
-	c.Assert(err, NotNil)
 }
 
 func BenchmarkPatrolRegion(b *testing.B) {

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -899,13 +899,16 @@ func (s *testCoordinatorSuite) TestRestart(c *C) {
 func (s *testCoordinatorSuite) TestPauseScheduler(c *C) {
 	_, co, cleanup := prepare(nil, nil, func(co *coordinator) { co.run() }, c)
 	defer cleanup()
+	_, err := co.isSchedulerAllowed("test")
+	c.Assert(err, NotNil)
 	co.pauseOrResumeScheduler(schedulers.BalanceLeaderName, 60)
-	paused, err := co.isSchedulerPaused(schedulers.BalanceLeaderName)
-	c.Assert(err, IsNil)
+	paused, _ := co.isSchedulerPaused(schedulers.BalanceLeaderName)
 	c.Assert(paused, Equals, true)
-	allowed, err := co.isSchedulerAllowed(schedulers.BalanceLeaderName)
-	c.Assert(err, IsNil)
+	allowed, _ := co.isSchedulerAllowed(schedulers.BalanceLeaderName)
 	c.Assert(allowed, Equals, false)
+	co.cluster = nil
+	_, err = co.isSchedulerPaused(schedulers.BalanceLeaderName)
+	c.Assert(err, NotNil)
 }
 
 func BenchmarkPatrolRegion(b *testing.B) {

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -79,26 +79,34 @@ func newUnsafeRecoveryController(cluster *RaftCluster) *unsafeRecoveryController
 	}
 }
 
+// IsRunning returns whether there is ongoing unsafe recovery process. If yes, further unsafe
+// recovery requests, schedulers, checkers, AskSplit and AskBatchSplit requests are blocked.
+func (u *unsafeRecoveryController) IsRunning() bool {
+	u.RLock()
+	defer u.RUnlock()
+	return u.stage != ready && u.stage != finished
+}
+
 // RemoveFailedStores removes failed stores from the cluster.
-func (u *unsafeRecoveryController) RemoveFailedStores(failedStores map[uint64]string) error {
+func (u *unsafeRecoveryController) RemoveFailedStores(failedStores map[uint64]string, timeout int64) error {
+	if u.IsRunning() {
+		return errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
+	}
 	u.Lock()
 	defer u.Unlock()
 	if len(failedStores) == 0 {
-		return errors.Errorf("No store specified")
-	}
-	if u.stage != ready && u.stage != finished {
-		return errors.Errorf("Another request is working in progress")
+		return errs.ErrUnsafeRecoveryInvalidInput.FastGenByArgs("no store specified")
 	}
 	u.reset()
 	for failedStore := range failedStores {
 		store := u.cluster.GetStore(failedStore)
 		if store != nil && (store.IsPreparing() || store.IsServing()) && !store.IsDisconnected() {
-			return errors.Errorf("Store %v is up and connected", failedStore)
+			return errs.ErrUnsafeRecoveryInvalidInput.FastGenByArgs(fmt.Sprintf("store %v is up and connected", failedStore))
 		}
 	}
 	for failedStore := range failedStores {
 		err := u.cluster.BuryStore(failedStore, true)
-		if !errors.ErrorEqual(err, errs.ErrStoreNotFound.FastGenByArgs(failedStore)) {
+		if err != nil && !errors.ErrorEqual(err, errs.ErrStoreNotFound.FastGenByArgs(failedStore)) {
 			return err
 		}
 	}
@@ -165,6 +173,7 @@ func (u *unsafeRecoveryController) HandleStoreHeartbeat(heartbeat *pdpb.StoreHea
 				u.executionReports[heartbeat.Stats.StoreId] = heartbeat.StoreReport
 				u.numStoresPlanExecuted++
 				if u.numStoresPlanExecuted == len(u.storeRecoveryPlans) {
+					u.cluster.PauseOrResumeScheduler("all", 0)
 					log.Info("Recover finished.")
 					go func() {
 						for _, history := range u.History() {

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -88,7 +88,7 @@ func (u *unsafeRecoveryController) IsRunning() bool {
 }
 
 // RemoveFailedStores removes failed stores from the cluster.
-func (u *unsafeRecoveryController) RemoveFailedStores(failedStores map[uint64]string, timeout int64) error {
+func (u *unsafeRecoveryController) RemoveFailedStores(failedStores map[uint64]string) error {
 	if u.IsRunning() {
 		return errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/raft_serverpb"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule/hbstream"
 	"github.com/tikv/pd/server/storage"
 )
 
@@ -520,6 +521,8 @@ func (s *testUnsafeRecoverSuite) TestReportCollection(c *C) {
 func (s *testUnsafeRecoverSuite) TestPlanExecution(c *C) {
 	_, opt, _ := newTestScheduleConfig()
 	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
+	// Manually fill the coordinator up to allow calling on cluster.PauseOrResumeSchedulers().
+	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.getClusterID(), cluster, true))
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.stage = recovering
 	recoveryController.failedStores = map[uint64]string{
@@ -626,6 +629,8 @@ func (s *testUnsafeRecoverSuite) TestPlanExecution(c *C) {
 func (s *testUnsafeRecoverSuite) TestRemoveFailedStores(c *C) {
 	_, opt, _ := newTestScheduleConfig()
 	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
+	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.getClusterID(), cluster, true))
+	cluster.coordinator.run()
 	stores := newTestStores(2, "5.3.0")
 	stores[1] = stores[1].Clone(core.SetLastHeartbeatTS(time.Now()))
 	for _, store := range stores {
@@ -637,13 +642,42 @@ func (s *testUnsafeRecoverSuite) TestRemoveFailedStores(c *C) {
 		3: "",
 	}
 
-	c.Assert(recoveryController.RemoveFailedStores(failedStores), IsNil)
+	c.Assert(recoveryController.RemoveFailedStores(failedStores, 60), IsNil)
 	c.Assert(cluster.GetStore(uint64(1)).IsRemoved(), IsTrue)
+	for _, s := range cluster.GetSchedulers() {
+		paused, err := cluster.IsSchedulerAllowed(s)
+		c.Assert(err, IsNil)
+		c.Assert(paused, IsTrue)
+	}
 
 	// Store 2's last heartbeat is recent, and is not allowed to be removed.
 	failedStores = map[uint64]string{
 		2: "",
 	}
 
-	c.Assert(recoveryController.RemoveFailedStores(failedStores), NotNil)
+	c.Assert(recoveryController.RemoveFailedStores(failedStores, 60), NotNil)
+}
+
+func (s *testUnsafeRecoverSuite) TestSplitPaused(c *C) {
+	_, opt, _ := newTestScheduleConfig()
+	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
+	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.getClusterID(), cluster, true))
+	cluster.coordinator.run()
+	stores := newTestStores(2, "5.3.0")
+	stores[1] = stores[1].Clone(core.SetLastHeartbeatTS(time.Now()))
+	for _, store := range stores {
+		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
+	}
+	recoveryController := newUnsafeRecoveryController(cluster)
+	cluster.unsafeRecoveryController = recoveryController
+	failedStores := map[uint64]string{
+		1: "",
+	}
+	c.Assert(recoveryController.RemoveFailedStores(failedStores, 60), IsNil)
+	askSplitReq := &pdpb.AskSplitRequest{}
+	_, err := cluster.HandleAskSplit(askSplitReq)
+	c.Assert(err.Error(), Equals, "[PD:unsaferecovery:ErrUnsafeRecoveryIsRunning]unsafe recovery is running")
+	askBatchSplitReq := &pdpb.AskBatchSplitRequest{}
+	_, err = cluster.HandleAskBatchSplit(askBatchSplitReq)
+	c.Assert(err.Error(), Equals, "[PD:unsaferecovery:ErrUnsafeRecoveryIsRunning]unsafe recovery is running")
 }

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -642,7 +642,7 @@ func (s *testUnsafeRecoverSuite) TestRemoveFailedStores(c *C) {
 		3: "",
 	}
 
-	c.Assert(recoveryController.RemoveFailedStores(failedStores, 60), IsNil)
+	c.Assert(recoveryController.RemoveFailedStores(failedStores), IsNil)
 	c.Assert(cluster.GetStore(uint64(1)).IsRemoved(), IsTrue)
 	for _, s := range cluster.GetSchedulers() {
 		paused, err := cluster.IsSchedulerAllowed(s)
@@ -655,7 +655,7 @@ func (s *testUnsafeRecoverSuite) TestRemoveFailedStores(c *C) {
 		2: "",
 	}
 
-	c.Assert(recoveryController.RemoveFailedStores(failedStores, 60), NotNil)
+	c.Assert(recoveryController.RemoveFailedStores(failedStores), NotNil)
 }
 
 func (s *testUnsafeRecoverSuite) TestSplitPaused(c *C) {
@@ -673,7 +673,7 @@ func (s *testUnsafeRecoverSuite) TestSplitPaused(c *C) {
 	failedStores := map[uint64]string{
 		1: "",
 	}
-	c.Assert(recoveryController.RemoveFailedStores(failedStores, 60), IsNil)
+	c.Assert(recoveryController.RemoveFailedStores(failedStores), IsNil)
 	askSplitReq := &pdpb.AskSplitRequest{}
 	_, err := cluster.HandleAskSplit(askSplitReq)
 	c.Assert(err.Error(), Equals, "[PD:unsaferecovery:ErrUnsafeRecoveryIsRunning]unsafe recovery is running")

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1089,7 +1089,12 @@ func (s *GrpcServer) AskSplit(ctx context.Context, request *pdpb.AskSplitRequest
 	}
 	split, err := rc.HandleAskSplit(req)
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.AskSplitResponse{
+			Header: s.errorHeader(&pdpb.Error{
+				Type:    pdpb.ErrorType_UNKNOWN,
+				Message: err.Error(),
+			}),
+		}, nil
 	}
 
 	return &pdpb.AskSplitResponse{
@@ -1127,7 +1132,12 @@ func (s *GrpcServer) AskBatchSplit(ctx context.Context, request *pdpb.AskBatchSp
 	}
 	split, err := rc.HandleAskBatchSplit(req)
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.AskBatchSplitResponse{
+			Header: s.errorHeader(&pdpb.Error{
+				Type:    pdpb.ErrorType_UNKNOWN,
+				Message: err.Error(),
+			}),
+		}, nil
 	}
 
 	return &pdpb.AskBatchSplitResponse{

--- a/tests/pdctl/unsafe/unsafe_operation_test.go
+++ b/tests/pdctl/unsafe/unsafe_operation_test.go
@@ -49,6 +49,12 @@ func (s *unsafeOperationTestSuite) TestRemoveFailedStores(c *C) {
 	args := []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3"}
 	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
+	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "3600"}
+	_, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, IsNil)
+	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "abc"}
+	_, err = pdctl.ExecuteCommand(cmd, args...)
+	c.Assert(err, Not(IsNil))
 	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "show"}
 	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)

--- a/tests/pdctl/unsafe/unsafe_operation_test.go
+++ b/tests/pdctl/unsafe/unsafe_operation_test.go
@@ -49,12 +49,6 @@ func (s *unsafeOperationTestSuite) TestRemoveFailedStores(c *C) {
 	args := []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3"}
 	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)
-	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "3600"}
-	_, err = pdctl.ExecuteCommand(cmd, args...)
-	c.Assert(err, IsNil)
-	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "abc"}
-	_, err = pdctl.ExecuteCommand(cmd, args...)
-	c.Assert(err, Not(IsNil))
 	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "show"}
 	_, err = pdctl.ExecuteCommand(cmd, args...)
 	c.Assert(err, IsNil)

--- a/tools/pd-ctl/pdctl/command/unsafe_command.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command.go
@@ -42,7 +42,6 @@ func NewRemoveFailedStoresCommand() *cobra.Command {
 		Short: "Remove failed stores unsafely",
 		Run:   removeFailedStoresCommandFunc,
 	}
-	cmd.PersistentFlags().Float64("timeout", 600, "timeout in seconds")
 	cmd.AddCommand(NewRemoveFailedStoresShowCommand())
 	cmd.AddCommand(NewRemoveFailedStoresHistoryCommand())
 	return cmd
@@ -84,13 +83,6 @@ func removeFailedStoresCommandFunc(cmd *cobra.Command, args []string) {
 	}
 	postInput := map[string]interface{}{
 		"stores": stores,
-	}
-	timeout, err := cmd.Flags().GetFloat64("timeout")
-	if err != nil {
-		cmd.Usage()
-		return
-	} else if timeout != 600 {
-		postInput["timeout"] = timeout
 	}
 	postJSON(cmd, prefix, postInput)
 }


### PR DESCRIPTION
Signed-off-by: v01dstar <yang.zhang@pingcap.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
Issue Number: ref #4242 which is part of tikv/tikv#10483

Split/merge and conf change can cause PD make wrong decisions during unsafe recovery. Previously, we expect the user to stop all the schedulers themselves, but that is not reliable, Unsafe Recovery should be responsible for pausing all the schedulers.

### What is changed and how it works?

Pause all the schedulers before collecting store reports. Note that, to avoid reporting stale info, tikv also need to do its own parts, such as making sure apply index is equal to commit index.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

- N/A

Side effects

- All schedulers are paused until the recovery is finished or timed out.

Related changes

- N/A

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
