### PR TITLE
 ctl: pd-ctl cmd will work well in char device mode

### DIFF
--- a/tools/pd-ctl/main.go
+++ b/tools/pd-ctl/main.go
@@ -57,7 +57,10 @@ func main() {
 			fmt.Println(err)
 			return
 		}
-		input = strings.Split(strings.TrimSpace(string(b)), " ")
+		s := strings.TrimSpace(string(b))
+		if s != "" {
+			input = strings.Split(s, " ")
+		}
 	}
 
 	pdctl.MainStart(append(os.Args[1:], input...))

--- a/tools/pd-ctl/main.go
+++ b/tools/pd-ctl/main.go
@@ -53,6 +53,7 @@ func main() {
 		in, err := pdctl.ReadStdin(os.Stdin)
 		if err != nil {
 			fmt.Println(err)
+			return
 		}
 		inputs = in
 	}

--- a/tools/pd-ctl/main.go
+++ b/tools/pd-ctl/main.go
@@ -16,10 +16,8 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/tikv/pd/tools/pd-ctl/pdctl"
@@ -49,19 +47,14 @@ func main() {
 		}
 	}()
 
-	var input []string
+	var inputs []string
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		b, err := io.ReadAll(os.Stdin)
+		in, err := pdctl.ReadStdin(os.Stdin)
 		if err != nil {
 			fmt.Println(err)
-			return
 		}
-		s := strings.TrimSpace(string(b))
-		if s != "" {
-			input = strings.Split(s, " ")
-		}
+		inputs = in
 	}
-
-	pdctl.MainStart(append(os.Args[1:], input...))
+	pdctl.MainStart(append(os.Args[1:], inputs...))
 }

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -198,3 +198,15 @@ func genCompleter(cmd *cobra.Command) []readline.PrefixCompleterInterface {
 	}
 	return pc
 }
+
+// ReadStdin convert stdin to string array
+func ReadStdin(r io.Reader) (input []string, err error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	if s := strings.TrimSpace(string(b)); s != "" {
+		input = strings.Split(s, " ")
+	}
+	return input, nil
+}

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -205,7 +205,7 @@ func ReadStdin(r io.Reader) (input []string, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if s := strings.TrimSpace(string(b)); s != "" {
+	if s := strings.TrimSpace(string(b)); len(s) > 0 {
 		input = strings.Split(s, " ")
 	}
 	return input, nil

--- a/tools/pd-ctl/pdctl/ctl_test.go
+++ b/tools/pd-ctl/pdctl/ctl_test.go
@@ -15,6 +15,8 @@
 package pdctl
 
 import (
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -65,6 +67,33 @@ func TestGenCompleter(t *testing.T) {
 
 		if inPrefixArray == false {
 			t.Errorf("%s not in prefix array", cmd)
+		}
+	}
+}
+
+func TestReadStdin(t *testing.T) {
+	s := []struct {
+		in      io.Reader
+		targets []string
+	}{{
+		in:      strings.NewReader(""),
+		targets: []string{},
+	}, {
+		in:      strings.NewReader("a b c"),
+		targets: []string{"a", "b", "c"},
+	}}
+	for _, v := range s {
+		in, err := ReadStdin(v.in)
+		if err != nil {
+			t.Errorf("ReadStdin err:%v", err)
+		}
+		if len(v.targets) != len(in) {
+			t.Errorf("ReadStdin =  %v, want %s, nil", in, v.targets)
+		}
+		for i, target := range v.targets {
+			if target != in[i] {
+				t.Errorf("ReadStdin = %v, want %s, nil", in, v.targets)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
close #4478
<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
String split mention If s does not contain sep and sep is not empty, Split returns a
slice of length 1 whose only element is s. It will add args if the arg is nil in char device mode.
So it needs to check the args is nil. 
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

![image](https://user-images.githubusercontent.com/23159587/146721890-2ee7775e-527e-4f0b-af7e-78b5c205a2d5.png)

Code changes


Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
pdctl args lens is wrong in char device mode.
```
