### PR TITLE
api: add Self-protection framework and HTTP handler

### DIFF
--- a/pkg/apiutil/apiutil.go
+++ b/pkg/apiutil/apiutil.go
@@ -132,10 +132,8 @@ func ErrorResp(rd *render.Render, w http.ResponseWriter, err error) {
 // GetHTTPRouteName return mux route name registered for ServiceName
 func GetHTTPRouteName(req *http.Request) (string, bool) {
 	route := mux.CurrentRoute(req)
-	if route != nil {
-		if route.GetName() != "" {
-			return route.GetName(), true
-		}
+	if route != nil && route.GetName() != "" {
+		return route.GetName(), true
 	}
 	return "", false
 }

--- a/pkg/apiutil/apiutil.go
+++ b/pkg/apiutil/apiutil.go
@@ -129,8 +129,8 @@ func ErrorResp(rd *render.Render, w http.ResponseWriter, err error) {
 	}
 }
 
-// GetHTTPRouteName return mux route name registered for ServiceName
-func GetHTTPRouteName(req *http.Request) (string, bool) {
+// GetRouteName return mux route name registered for ServiceName
+func GetRouteName(req *http.Request) (string, bool) {
 	route := mux.CurrentRoute(req)
 	if route != nil && route.GetName() != "" {
 		return route.GetName(), true

--- a/pkg/apiutil/apiutil.go
+++ b/pkg/apiutil/apiutil.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/gorilla/mux"
 	"github.com/pingcap/errcode"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -126,4 +127,15 @@ func ErrorResp(rd *render.Render, w http.ResponseWriter, err error) {
 	} else {
 		rd.JSON(w, http.StatusInternalServerError, err.Error())
 	}
+}
+
+// GetHTTPRouteName return mux route name registered for ServiceName
+func GetHTTPRouteName(req *http.Request) (string, bool) {
+	route := mux.CurrentRoute(req)
+	if route != nil {
+		if route.GetName() != "" {
+			return route.GetName(), true
+		}
+	}
+	return "", false
 }

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -91,11 +91,12 @@ func NewSelfProtector(s *server.Server) negroni.Handler {
 
 func (protector *selfProtector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	handler := protector.s.GetSelfProtectionHandler()
-	if handler == nil || handler.HandleHTTPSelfProtection(r) {
-		failpoint.Inject("addSelfProtectionHTTPHeader", func() {
-			w.Header().Add("self-protection", "ok")
-		})
 
+	failpoint.Inject("addSelfProtectionHTTPHeader", func() {
+		w.Header().Add("self-protection", "ok")
+	})
+
+	if handler == nil || handler.HandleHTTPSelfProtection(r) {
 		next(w, r)
 	} else {
 		// current plan will only deny request when over the speed limit

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -90,13 +90,13 @@ func NewSelfProtector(s *server.Server) negroni.Handler {
 }
 
 func (protector *selfProtector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	handler := protector.s.GetSelfProtectionHandler()
+	handler := protector.s.GetSelfProtectionManager()
 
 	failpoint.Inject("addSelfProtectionHTTPHeader", func() {
 		w.Header().Add("self-protection", "ok")
 	})
 
-	if handler == nil || handler.HandleHTTPSelfProtection(r) {
+	if handler == nil || handler.ProcessHTTPSelfProtection(r) {
 		next(w, r)
 	} else {
 		// current plan will only deny request when over the speed limit

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -92,7 +92,6 @@ func NewSelfProtector(s *server.Server) negroni.Handler {
 func (protector *selfProtector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	handler := protector.s.GetSelfProtectionHandler()
 	if handler == nil || handler.HandleHTTPSelfProtection(r) {
-
 		failpoint.Inject("addSelfProtectionHTTPHeader", func() {
 			w.Header().Add("self-protection", "ok")
 		})

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/server"
@@ -91,11 +92,15 @@ func NewSelfProtector(s *server.Server) negroni.Handler {
 func (protector *selfProtector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	handler := protector.s.GetSelfProtectionHandler()
 	if handler == nil || handler.HandleHTTPSelfProtection(r) {
-		// One line below is used for middleware testing only
-		w.Header().Add("self-protection", "ok")
+
+		failpoint.Inject("addSelfProtectionHTTPHeader", func() {
+			w.Header().Add("self-protection", "ok")
+		})
 
 		next(w, r)
 	} else {
+		// current plan will only deny request when over the speed limit
+		// todo: support more HTTP Status code
 		http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 	}
 }

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -91,6 +91,9 @@ func NewSelfProtector(s *server.Server) negroni.Handler {
 func (protector *selfProtector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	handler := protector.s.GetSelfProtectionHandler()
 	if handler == nil || handler.HandleHTTPSelfProtection(r) {
+		// One line below is used for middleware testing only
+		w.Header().Add("self-protection", "ok")
+
 		next(w, r)
 	} else {
 		http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -79,6 +79,24 @@ func IsServiceAllowed(s *server.Server, group server.ServiceGroup) bool {
 	return false
 }
 
+type selfProtector struct {
+	s *server.Server
+}
+
+// NewSelfProtector handle self-protection
+func NewSelfProtector(s *server.Server) negroni.Handler {
+	return &selfProtector{s: s}
+}
+
+func (protector *selfProtector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	handler := protector.s.GetSelfProtectionHandler()
+	if handler == nil || handler.HandleHTTPSelfProtection(r) {
+		next(w, r)
+	} else {
+		http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+	}
+}
+
 type redirector struct {
 	s *server.Server
 }

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -37,6 +37,7 @@ func NewHandler(ctx context.Context, svr *server.Server) (http.Handler, server.S
 	router.PathPrefix(apiPrefix).Handler(negroni.New(
 		serverapi.NewRuntimeServiceValidator(svr, group),
 		serverapi.NewRedirector(svr),
+		serverapi.NewSelfProtector(svr),
 		negroni.Wrap(r)),
 	)
 

--- a/server/self_protection.go
+++ b/server/self_protection.go
@@ -36,7 +36,7 @@ func NewSelfProtectionManager(server *Server) *selfProtectionManager {
 
 // ProcessHTTPSelfProtection is used to process http api self protection
 func (h *selfProtectionManager) ProcessHTTPSelfProtection(req *http.Request) bool {
-	serviceName, foundName := apiutil.GetHTTPRouteName(req)
+	serviceName, foundName := apiutil.GetRouteName(req)
 	// if path is not registered in router, go on processing
 	if !foundName {
 		return true

--- a/server/self_protection.go
+++ b/server/self_protection.go
@@ -20,23 +20,23 @@ import (
 	"github.com/tikv/pd/pkg/apiutil"
 )
 
-// SelfProtectionHandler is a framework to handle self protection mechanism
+// SelfProtectionManager is a framework to handle self protection mechanism
 // Self-protection granularity is a logical service
-type SelfProtectionHandler struct {
+type SelfProtectionManager struct {
 	// ServiceHandlers is a map to store handler owned by different services
 	ServiceHandlers map[string]*serviceSelfProtectionHandler
 }
 
-// NewSelfProtectionHandler returns a new SelfProtectionHandler with config
-func NewSelfProtectionHandler(server *Server) *SelfProtectionHandler {
-	handler := &SelfProtectionHandler{
+// NewSelfProtectionManager returns a new SelfProtectionManager with config
+func NewSelfProtectionManager(server *Server) *SelfProtectionManager {
+	handler := &SelfProtectionManager{
 		ServiceHandlers: make(map[string]*serviceSelfProtectionHandler),
 	}
 	return handler
 }
 
-// HandleHTTPSelfProtection is used to handle http api self protection
-func (h *SelfProtectionHandler) HandleHTTPSelfProtection(req *http.Request) bool {
+// ProcessHTTPSelfProtection is used to process http api self protection
+func (h *SelfProtectionManager) ProcessHTTPSelfProtection(req *http.Request) bool {
 	serviceName, findName := apiutil.GetHTTPRouteName(req)
 	// if path is not registered in router, go on process
 	if !findName {
@@ -49,26 +49,26 @@ func (h *SelfProtectionHandler) HandleHTTPSelfProtection(req *http.Request) bool
 		return true
 	}
 
-	httpHandler := &HTTPServiceSelfProtectionHandler{
+	httpHandler := &HTTPServiceSelfProtectionManager{
 		req:     req,
 		handler: serviceHandler,
 	}
 	return httpHandler.Handle()
 }
 
-// ServiceSelfProtectionHandler is a interface for define self-protection handler by service granularity
-type ServiceSelfProtectionHandler interface {
+// ServiceSelfProtectionManager is a interface for define self-protection handler by service granularity
+type ServiceSelfProtectionManager interface {
 	Handle() bool
 }
 
-// HTTPServiceSelfProtectionHandler implement ServiceSelfProtectionHandler to handle http
-type HTTPServiceSelfProtectionHandler struct {
+// HTTPServiceSelfProtectionManager implement ServiceSelfProtectionManager to handle http
+type HTTPServiceSelfProtectionManager struct {
 	req     *http.Request
 	handler *serviceSelfProtectionHandler
 }
 
-// Handle implement ServiceSelfProtectionHandler defined function
-func (h *HTTPServiceSelfProtectionHandler) Handle() bool {
+// Handle implement ServiceSelfProtectionManager defined function
+func (h *HTTPServiceSelfProtectionManager) Handle() bool {
 	// to be implemented
 	return true
 }

--- a/server/self_protection.go
+++ b/server/self_protection.go
@@ -20,55 +20,39 @@ import (
 	"github.com/tikv/pd/pkg/apiutil"
 )
 
-// SelfProtectionManager is a framework to handle self protection mechanism
+// selfProtectionManager is a framework to handle self protection mechanism
 // Self-protection granularity is a logical service
-type SelfProtectionManager struct {
+type selfProtectionManager struct {
 	// ServiceHandlers is a map to store handler owned by different services
 	ServiceHandlers map[string]*serviceSelfProtectionHandler
 }
 
 // NewSelfProtectionManager returns a new SelfProtectionManager with config
-func NewSelfProtectionManager(server *Server) *SelfProtectionManager {
-	handler := &SelfProtectionManager{
+func NewSelfProtectionManager(server *Server) *selfProtectionManager {
+	return &selfProtectionManager{
 		ServiceHandlers: make(map[string]*serviceSelfProtectionHandler),
 	}
-	return handler
 }
 
 // ProcessHTTPSelfProtection is used to process http api self protection
-func (h *SelfProtectionManager) ProcessHTTPSelfProtection(req *http.Request) bool {
-	serviceName, findName := apiutil.GetHTTPRouteName(req)
-	// if path is not registered in router, go on process
-	if !findName {
+func (h *selfProtectionManager) ProcessHTTPSelfProtection(req *http.Request) bool {
+	serviceName, foundName := apiutil.GetHTTPRouteName(req)
+	// if path is not registered in router, go on processing
+	if !foundName {
 		return true
 	}
 
 	serviceHandler, ok := h.ServiceHandlers[serviceName]
-	// if there is no service handler, go on process
+	// if there is no service handler, go on processing
 	if !ok {
 		return true
 	}
 
-	httpHandler := &HTTPServiceSelfProtectionManager{
-		req:     req,
-		handler: serviceHandler,
-	}
-	return httpHandler.Handle()
+	return HandleServiceHTTPSelfProtection(req, serviceHandler)
 }
 
-// ServiceSelfProtectionManager is a interface for define self-protection handler by service granularity
-type ServiceSelfProtectionManager interface {
-	Handle() bool
-}
-
-// HTTPServiceSelfProtectionManager implement ServiceSelfProtectionManager to handle http
-type HTTPServiceSelfProtectionManager struct {
-	req     *http.Request
-	handler *serviceSelfProtectionHandler
-}
-
-// Handle implement ServiceSelfProtectionManager defined function
-func (h *HTTPServiceSelfProtectionManager) Handle() bool {
+// HandleServiceHTTPSelfProtection is used to implement self-protection HTTP handler by service granularity
+func HandleServiceHTTPSelfProtection(req *http.Request, handler *serviceSelfProtectionHandler) bool {
 	// to be implemented
 	return true
 }

--- a/server/self_protection.go
+++ b/server/self_protection.go
@@ -1,0 +1,80 @@
+// Copyright 2021 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/tikv/pd/pkg/apiutil"
+)
+
+// SelfProtectionHandler is a framework to handle self protection mechanism
+// Self-protection granularity is a logical service
+type SelfProtectionHandler struct {
+	// ServiceHandlers a
+	ServiceHandlers map[string]*serviceSelfProtectionHandler
+}
+
+// NewSelfProtectionHandler returns a new SelfProtectionHandler with config
+func NewSelfProtectionHandler(server *Server) *SelfProtectionHandler {
+	handler := &SelfProtectionHandler{
+		ServiceHandlers: make(map[string]*serviceSelfProtectionHandler),
+	}
+	return handler
+}
+
+// HandleHTTPSelfProtection is used to handle http api self protection
+func (h *SelfProtectionHandler) HandleHTTPSelfProtection(req *http.Request) bool {
+	serviceName, findName := apiutil.GetHTTPRouteName(req)
+	// if path is not registered in router, go on process
+	if !findName {
+		return true
+	}
+
+	serviceHandler, ok := h.ServiceHandlers[serviceName]
+	// if there is no service handler, go on process
+	if !ok {
+		return true
+	}
+
+	httpHandler := &HTTPServiceSelfProtectionHandler{
+		req:     req,
+		handler: serviceHandler,
+	}
+	return httpHandler.Handle()
+}
+
+// ServiceSelfProtectionHandler is a interface for define self-protection handler by service granularity
+type ServiceSelfProtectionHandler interface {
+	Handle() bool
+}
+
+// HTTPServiceSelfProtectionHandler implement ServiceSelfProtectionHandler to handle http
+type HTTPServiceSelfProtectionHandler struct {
+	req     *http.Request
+	handler *serviceSelfProtectionHandler
+}
+
+// Handle implement ServiceSelfProtectionHandler defined function
+func (h *HTTPServiceSelfProtectionHandler) Handle() bool {
+	// to be implemented
+	return true
+}
+
+// serviceSelfProtectionHandler is a handler which is independent communication mode
+type serviceSelfProtectionHandler struct {
+	// todo APIRateLimiter
+	// todo AuditLogger
+}

--- a/server/self_protection.go
+++ b/server/self_protection.go
@@ -23,7 +23,7 @@ import (
 // SelfProtectionHandler is a framework to handle self protection mechanism
 // Self-protection granularity is a logical service
 type SelfProtectionHandler struct {
-	// ServiceHandlers a
+	// ServiceHandlers is a map to store handler owned by different services
 	ServiceHandlers map[string]*serviceSelfProtectionHandler
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -149,8 +149,8 @@ type Server struct {
 	// tsoDispatcher is used to dispatch different TSO requests to
 	// the corresponding forwarding TSO channel.
 	tsoDispatcher sync.Map /* Store as map[string]chan *tsoRequest */
-	// SelfProtectionHandler is used for PD self-pretection
-	selfProtectionHandler *SelfProtectionHandler
+	// SelfProtectionManager is used for PD self-pretection
+	selfProtectionManager *SelfProtectionManager
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -240,7 +240,7 @@ func CreateServer(ctx context.Context, cfg *config.Config, serviceBuilders ...Ha
 	}
 
 	s.handler = newHandler(s)
-	s.selfProtectionHandler = NewSelfProtectionHandler(s)
+	s.selfProtectionManager = NewSelfProtectionManager(s)
 
 	// Adjust etcd config.
 	etcdCfg, err := s.cfg.GenEmbedEtcdConfig()
@@ -671,9 +671,9 @@ func (s *Server) stopRaftCluster() {
 	s.cluster.Stop()
 }
 
-// GetSelfProtectionHandler returns the selfProt ectionHandler
-func (s *Server) GetSelfProtectionHandler() *SelfProtectionHandler {
-	return s.selfProtectionHandler
+// GetSelfProtectionManager returns the selfProt ectionHandler
+func (s *Server) GetSelfProtectionManager() *SelfProtectionManager {
+	return s.selfProtectionManager
 }
 
 // GetAddr returns the server urls for clients.

--- a/server/server.go
+++ b/server/server.go
@@ -149,6 +149,8 @@ type Server struct {
 	// tsoDispatcher is used to dispatch different TSO requests to
 	// the corresponding forwarding TSO channel.
 	tsoDispatcher sync.Map /* Store as map[string]chan *tsoRequest */
+	// SelfProtectionHandler is used for PD self-pretection
+	selfProtectionHandler *SelfProtectionHandler
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -238,6 +240,7 @@ func CreateServer(ctx context.Context, cfg *config.Config, serviceBuilders ...Ha
 	}
 
 	s.handler = newHandler(s)
+	s.selfProtectionHandler = NewSelfProtectionHandler(s)
 
 	// Adjust etcd config.
 	etcdCfg, err := s.cfg.GenEmbedEtcdConfig()
@@ -666,6 +669,11 @@ func (s *Server) createRaftCluster() error {
 func (s *Server) stopRaftCluster() {
 	failpoint.Inject("raftclusterIsBusy", func() {})
 	s.cluster.Stop()
+}
+
+// GetAddr returns the server urls for clients.
+func (s *Server) GetSelfProtectionHandler() *SelfProtectionHandler {
+	return s.selfProtectionHandler
 }
 
 // GetAddr returns the server urls for clients.

--- a/server/server.go
+++ b/server/server.go
@@ -671,7 +671,7 @@ func (s *Server) stopRaftCluster() {
 	s.cluster.Stop()
 }
 
-// GetAddr returns the server urls for clients.
+// GetSelfProtectionHandler returns the selfProt ectionHandler
 func (s *Server) GetSelfProtectionHandler() *SelfProtectionHandler {
 	return s.selfProtectionHandler
 }

--- a/server/server.go
+++ b/server/server.go
@@ -150,7 +150,7 @@ type Server struct {
 	// the corresponding forwarding TSO channel.
 	tsoDispatcher sync.Map /* Store as map[string]chan *tsoRequest */
 	// SelfProtectionManager is used for PD self-pretection
-	selfProtectionManager *SelfProtectionManager
+	selfProtectionManager *selfProtectionManager
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -672,7 +672,7 @@ func (s *Server) stopRaftCluster() {
 }
 
 // GetSelfProtectionManager returns the selfProt ectionHandler
-func (s *Server) GetSelfProtectionManager() *SelfProtectionManager {
+func (s *Server) GetSelfProtectionManager() *selfProtectionManager {
 	return s.selfProtectionManager
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -243,7 +243,7 @@ func (s *testServerHandlerSuite) TestMuxRouterName(c *C) {
 	handler := func(ctx context.Context, s *Server) (http.Handler, ServiceGroup, error) {
 		r := mux.NewRouter()
 		r.HandleFunc("/pd/apis/mok/v1/router", func(w http.ResponseWriter, r *http.Request) {
-			RouterName, _ := apiutil.GetHTTPRouteName(r)
+			RouterName, _ := apiutil.GetRouteName(r)
 			c.Assert(RouterName, Equals, "Mux Router")
 		}).Name("Mux Router")
 		info := ServiceGroup{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,11 +21,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gorilla/mux"
 	. "github.com/pingcap/check"
+	"github.com/tikv/pd/pkg/apiutil"
 	"github.com/tikv/pd/pkg/assertutil"
 	"github.com/tikv/pd/pkg/etcdutil"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server/config"
+	"github.com/urfave/negroni"
 	"go.etcd.io/etcd/embed"
 	"go.etcd.io/etcd/pkg/types"
 	"go.uber.org/goleak"
@@ -234,4 +237,43 @@ func (s *testServerHandlerSuite) TestRegisterServerHandler(c *C) {
 	c.Assert(err, IsNil)
 	bodyString := string(bodyBytes)
 	c.Assert(bodyString, Equals, "Hello World\n")
+}
+
+func (s *testServerHandlerSuite) TestMuxRouterName(c *C) {
+	handler := func(ctx context.Context, s *Server) (http.Handler, ServiceGroup, error) {
+		r := mux.NewRouter()
+		r.HandleFunc("/pd/apis/mok/v1/router", func(w http.ResponseWriter, r *http.Request) {
+			RouterName, _ := apiutil.GetHTTPRouteName(r)
+			fmt.Fprintln(w, RouterName)
+		}).Name("Mux Router")
+		info := ServiceGroup{
+			Name:    "mok",
+			Version: "v1",
+		}
+		router := mux.NewRouter()
+		router.PathPrefix("/pd").Handler(negroni.New(
+			negroni.Wrap(r)),
+		)
+		return router, info, nil
+	}
+	cfg := NewTestSingleConfig(checkerWithNilAssert(c))
+	ctx, cancel := context.WithCancel(context.Background())
+	svr, err := CreateServer(ctx, cfg, handler)
+	c.Assert(err, IsNil)
+	defer func() {
+		cancel()
+		svr.Close()
+		testutil.CleanServer(svr.cfg.DataDir)
+	}()
+	err = svr.Run()
+	c.Assert(err, IsNil)
+	resp, err := http.Get(fmt.Sprintf("%s/pd/apis/mok/v1/router", svr.GetAddr()))
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	c.Assert(err, IsNil)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	c.Assert(err, IsNil)
+	bodyString := string(bodyBytes)
+	c.Assert(bodyString, Equals, "Mux Router\n")
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -244,7 +244,7 @@ func (s *testServerHandlerSuite) TestMuxRouterName(c *C) {
 		r := mux.NewRouter()
 		r.HandleFunc("/pd/apis/mok/v1/router", func(w http.ResponseWriter, r *http.Request) {
 			RouterName, _ := apiutil.GetHTTPRouteName(r)
-			fmt.Fprintln(w, RouterName)
+			c.Assert(RouterName, Equals, "Mux Router")
 		}).Name("Mux Router")
 		info := ServiceGroup{
 			Name:    "mok",
@@ -271,9 +271,5 @@ func (s *testServerHandlerSuite) TestMuxRouterName(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 	c.Assert(err, IsNil)
-	bodyBytes, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
-	c.Assert(err, IsNil)
-	bodyString := string(bodyBytes)
-	c.Assert(bodyString, Equals, "Mux Router\n")
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -270,6 +270,5 @@ func (s *testServerHandlerSuite) TestMuxRouterName(c *C) {
 	resp, err := http.Get(fmt.Sprintf("%s/pd/apis/mok/v1/router", svr.GetAddr()))
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
-	c.Assert(err, IsNil)
 	resp.Body.Close()
 }

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/tikv/pd/pkg/apiutil/serverapi"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/pkg/typeutil"
@@ -121,10 +122,7 @@ func (s *testSelfProtectorSuite) SetUpSuite(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	server.EnableZap = true
 	s.cleanup = cancel
-	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, serverName string) {
-		conf.TickInterval = typeutil.Duration{Duration: 50 * time.Millisecond}
-		conf.ElectionInterval = typeutil.Duration{Duration: 250 * time.Millisecond}
-	})
+	cluster, err := tests.NewTestCluster(ctx, 3)
 	c.Assert(err, IsNil)
 	c.Assert(cluster.RunInitialServers(), IsNil)
 	c.Assert(cluster.WaitLeader(), Not(HasLen), 0)
@@ -139,7 +137,9 @@ func (s *testSelfProtectorSuite) TearDownSuite(c *C) {
 func (s *testSelfProtectorSuite) TestSelfProtect(c *C) {
 	leader := s.cluster.GetServer(s.cluster.GetLeader())
 	header := mustRequestSuccess(c, leader.GetServer())
+	c.Assert(failpoint.Enable("github.com/tikv/pd/pkg/apiutil/serverapi/addSelfProtectionHTTPHeader", `return(true)`), IsNil)
 	c.Assert(header.Get("self-protection"), Equals, "ok")
+	c.Assert(failpoint.Disable("github.com/tikv/pd/pkg/apiutil/serverapi/addSelfProtectionHTTPHeader"), IsNil)
 }
 
 var _ = Suite(&testRedirectorSuite{})

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -110,6 +110,38 @@ func (s *serverTestSuite) TestReconnect(c *C) {
 	}
 }
 
+var _ = Suite(&testSelfProtectorSuite{})
+
+type testSelfProtectorSuite struct {
+	cleanup func()
+	cluster *tests.TestCluster
+}
+
+func (s *testSelfProtectorSuite) SetUpSuite(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server.EnableZap = true
+	s.cleanup = cancel
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, serverName string) {
+		conf.TickInterval = typeutil.Duration{Duration: 50 * time.Millisecond}
+		conf.ElectionInterval = typeutil.Duration{Duration: 250 * time.Millisecond}
+	})
+	c.Assert(err, IsNil)
+	c.Assert(cluster.RunInitialServers(), IsNil)
+	c.Assert(cluster.WaitLeader(), Not(HasLen), 0)
+	s.cluster = cluster
+}
+
+func (s *testSelfProtectorSuite) TearDownSuite(c *C) {
+	s.cleanup()
+	s.cluster.Destroy()
+}
+
+func (s *testSelfProtectorSuite) TestSelfProtect(c *C) {
+	leader := s.cluster.GetServer(s.cluster.GetLeader())
+	header := mustRequestSuccess(c, leader.GetServer())
+	c.Assert(header.Get("self-protection"), Equals, "ok")
+}
+
 var _ = Suite(&testRedirectorSuite{})
 
 type testRedirectorSuite struct {

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -135,9 +135,9 @@ func (s *testSelfProtectorSuite) TearDownSuite(c *C) {
 }
 
 func (s *testSelfProtectorSuite) TestSelfProtect(c *C) {
+	c.Assert(failpoint.Enable("github.com/tikv/pd/pkg/apiutil/serverapi/addSelfProtectionHTTPHeader", "return(true)"), IsNil)
 	leader := s.cluster.GetServer(s.cluster.GetLeader())
 	header := mustRequestSuccess(c, leader.GetServer())
-	c.Assert(failpoint.Enable("github.com/tikv/pd/pkg/apiutil/serverapi/addSelfProtectionHTTPHeader", `return(true)`), IsNil)
 	c.Assert(header.Get("self-protection"), Equals, "ok")
 	c.Assert(failpoint.Disable("github.com/tikv/pd/pkg/apiutil/serverapi/addSelfProtectionHTTPHeader"), IsNil)
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
close #4483

This PR is going to support HTTP middleware for self-protection framework

<!-- Add the issue link with a summary if it exists. -->


### What is changed and how it works?

Considering HTTP and gRPC, it's better to handle the self-protection mechanism overlaying gRPC and HTTP.
As we know, PD has lots of services for other components. So The granularity of the self-protection mechanism must be service level, even service-component level. 
Based on the above considerations
> 1. need a map to store different service handlers.
> 2. HTTP and gRPC have different own actions to extract information for the service handler.

According to HTTP API, the identification is the URL path. But one URL path may have one more method for access to different services. Joining URL and method together to identify service is not harmonious.
> register mux router for the service and get router name to find the service self-protection handler

Then support middleware for HTTP
> `selfProtector` is used to implement negroni.Handler
> add `selfProtector` middleware into server handlers by negroni

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Integration test

Code changes

- Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
> `http.StatusTooManyRequests` HTTP error code will be added

Side effects

- Possible performance regression

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
PD self-protection mechanism
```
