### PR TITLE
api, pd-ctl: fix the region range hole end key check and add some help info

### DIFF
--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -536,6 +536,7 @@ func (s *testGetRegionRangeHolesSuite) TestRegionRangeHoles(c *C) {
 		{"", core.HexRegionKeyStr(r1.GetStartKey())},
 		{core.HexRegionKeyStr(r1.GetEndKey()), core.HexRegionKeyStr(r3.GetStartKey())},
 		{core.HexRegionKeyStr(r4.GetEndKey()), core.HexRegionKeyStr(r6.GetStartKey())},
+		{core.HexRegionKeyStr(r6.GetEndKey()), ""},
 	})
 }
 

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -1143,6 +1143,10 @@ func (r *RegionsInfo) GetRangeHoles() [][]string {
 		lastEndKey = region.GetEndKey()
 		return true
 	})
+	// If the last end key is not empty, it means there is a range hole at the end.
+	if len(lastEndKey) > 0 {
+		rangeHoles = append(rangeHoles, []string{HexRegionKeyStr(lastEndKey), ""})
+	}
 	return rangeHoles
 }
 

--- a/tests/pdctl/region/region_test.go
+++ b/tests/pdctl/region/region_test.go
@@ -201,5 +201,6 @@ func (s *regionTestSuite) TestRegion(c *C) {
 	c.Assert(*rangeHoles, DeepEquals, [][]string{
 		{"", core.HexRegionKeyStr(r1.GetStartKey())},
 		{core.HexRegionKeyStr(r4.GetEndKey()), core.HexRegionKeyStr(r5.GetStartKey())},
+		{core.HexRegionKeyStr(r5.GetEndKey()), ""},
 	})
 }

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -519,12 +519,33 @@ func showRegionWithStoreCommandFunc(cmd *cobra.Command, args []string) {
 	cmd.Println(r)
 }
 
+const (
+	rangeHolesLongDesc = `There are some cases that the region range is not continuous, for example, the region doest't send the heartbeat to PD after a spliting.
+This command will output all empty ranges without any region info.`
+	rangeHolesExample = `
+  If PD now holds the region ranges info like ["", "a"], ["b", "x"], ["x", "z"]. The the output will be like:
+
+  [
+    [
+      "a",
+      "b"
+    ],
+    [
+      "z",
+      ""
+    ],
+  ]
+`
+)
+
 // NewRangesWithRangeHolesCommand returns ranges with range-holes subcommand of regionCmd
 func NewRangesWithRangeHolesCommand() *cobra.Command {
 	r := &cobra.Command{
-		Use:   "range-holes",
-		Short: "show all empty ranges without any region info",
-		Run:   showRangesWithRangeHolesCommandFunc,
+		Use:     "range-holes",
+		Short:   "show all empty ranges without any region info.",
+		Long:    rangeHolesLongDesc,
+		Example: rangeHolesExample,
+		Run:     showRangesWithRangeHolesCommandFunc,
 	}
 	return r
 }

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -520,7 +520,7 @@ func showRegionWithStoreCommandFunc(cmd *cobra.Command, args []string) {
 }
 
 const (
-	rangeHolesLongDesc = `There are some cases that the region range is not continuous, for example, the region doest't send the heartbeat to PD after a spliting.
+	rangeHolesLongDesc = `There are some cases that the region range is not continuous, for example, the region doesn't send the heartbeat to PD after a splitting.
 This command will output all empty ranges without any region info.`
 	rangeHolesExample = `
   If PD now holds the region ranges info like ["", "a"], ["b", "x"], ["x", "z"]. The the output will be like:


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close #4496, close #4216.

### What is changed and how it works?

* Check if the last end key is not empty.
* Add some help info for the `region range-holes` command.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```shell
❯ ./bin/pd-ctl region range-holes -h
There are some cases that the region range is not continuous, for example, the region doest't send the heartbeat to PD after a spliting.
This command will output all empty ranges without any region info.

Usage:
  pd-ctl region range-holes [flags]

Examples:

  If PD now holds the region ranges info like ["", "a"], ["b", "x"], ["x", "z"]. The the output will be like:

  [
    [
      "a",
      "b"
    ],
    [
      "z",
      ""
    ],
  ]


Flags:
  -h, --help   help for range-holes

Global Flags:
      --cacert string   path of file that contains list of trusted SSL CAs
      --cert string     path of file that contains X509 certificate in PEM format
      --key string      path of file that contains X509 key in PEM format
  -u, --pd string       address of pd (default "http://127.0.0.1:2379")
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
