### PR TITLE
*: remove opt package totally

### DIFF
--- a/plugin/scheduler_example/evict_leader.go
+++ b/plugin/scheduler_example/evict_leader.go
@@ -29,7 +29,6 @@ import (
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedulers"
 	"github.com/unrolled/render"
 )
@@ -93,7 +92,7 @@ type evictLeaderSchedulerConfig struct {
 	mu               sync.RWMutex
 	storage          *core.Storage
 	StoreIDWitRanges map[uint64][]core.KeyRange `json:"store-id-ranges"`
-	cluster          opt.Cluster
+	cluster          schedule.Cluster
 }
 
 func (conf *evictLeaderSchedulerConfig) BuildWithArgs(args []string) error {
@@ -184,7 +183,7 @@ func (s *evictLeaderScheduler) EncodeConfig() ([]byte, error) {
 	return schedule.EncodeConfig(s.conf)
 }
 
-func (s *evictLeaderScheduler) Prepare(cluster opt.Cluster) error {
+func (s *evictLeaderScheduler) Prepare(cluster schedule.Cluster) error {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	var res error
@@ -196,7 +195,7 @@ func (s *evictLeaderScheduler) Prepare(cluster opt.Cluster) error {
 	return res
 }
 
-func (s *evictLeaderScheduler) Cleanup(cluster opt.Cluster) {
+func (s *evictLeaderScheduler) Cleanup(cluster schedule.Cluster) {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	for id := range s.conf.StoreIDWitRanges {
@@ -204,7 +203,7 @@ func (s *evictLeaderScheduler) Cleanup(cluster opt.Cluster) {
 	}
 }
 
-func (s *evictLeaderScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (s *evictLeaderScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
@@ -212,7 +211,7 @@ func (s *evictLeaderScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (s *evictLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+func (s *evictLeaderScheduler) Schedule(cluster schedule.Cluster) []*operator.Operator {
 	ops := make([]*operator.Operator, 0, len(s.conf.StoreIDWitRanges))
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -427,6 +427,13 @@ func (c *RaftCluster) GetOperatorController() *schedule.OperatorController {
 	return c.coordinator.opController
 }
 
+// GetBasicCluster returns the basic cluster.
+func (c *RaftCluster) GetBasicCluster() *core.BasicCluster {
+	c.RLock()
+	defer c.RUnlock()
+	return c.core
+}
+
 // GetRegionScatter returns the region scatter.
 func (c *RaftCluster) GetRegionScatter() *schedule.RegionScatterer {
 	c.RLock()
@@ -483,28 +490,9 @@ func (c *RaftCluster) SetStorage(s *core.Storage) {
 	c.storage = s
 }
 
-// GetBasicCluster returns the basic cluster.
-// There is no need a lock since it won't changed.
-func (c *RaftCluster) GetBasicCluster() *core.BasicCluster {
-	return c.core
-}
-
 // GetOpts returns cluster's configuration.
-// There is no need a lock since it won't changed.
 func (c *RaftCluster) GetOpts() *config.PersistOptions {
 	return c.opt
-}
-
-// GetAllocator returns cluster's id allocator.
-// There is no need a lock since it won't changed.
-func (c *RaftCluster) GetAllocator() id.Allocator {
-	return c.id
-}
-
-// GetRuleManager returns the rule manager reference.
-// There is no need a lock since it won't changed.
-func (c *RaftCluster) GetRuleManager() *placement.RuleManager {
-	return c.ruleManager
 }
 
 // AddSuspectRegions adds regions to suspect list.
@@ -1414,6 +1402,13 @@ func (c *RaftCluster) getStoresWithoutLabelLocked(region *core.RegionInfo, key, 
 	return stores
 }
 
+// GetAllocator returns cluster's id allocator.
+func (c *RaftCluster) GetAllocator() id.Allocator {
+	c.RLock()
+	defer c.RUnlock()
+	return c.id
+}
+
 // OnStoreVersionChange changes the version of the cluster when needed.
 func (c *RaftCluster) OnStoreVersionChange() {
 	c.RLock()
@@ -1534,6 +1529,13 @@ func (c *RaftCluster) putRegion(region *core.RegionInfo) error {
 	}
 	c.core.PutRegion(region)
 	return nil
+}
+
+// GetRuleManager returns the rule manager reference.
+func (c *RaftCluster) GetRuleManager() *placement.RuleManager {
+	c.RLock()
+	defer c.RUnlock()
+	return c.ruleManager
 }
 
 // GetRegionLabeler returns the region labeler.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -427,13 +427,6 @@ func (c *RaftCluster) GetOperatorController() *schedule.OperatorController {
 	return c.coordinator.opController
 }
 
-// GetBasicCluster returns the basic cluster.
-func (c *RaftCluster) GetBasicCluster() *core.BasicCluster {
-	c.RLock()
-	defer c.RUnlock()
-	return c.core
-}
-
 // GetRegionScatter returns the region scatter.
 func (c *RaftCluster) GetRegionScatter() *schedule.RegionScatterer {
 	c.RLock()
@@ -490,9 +483,28 @@ func (c *RaftCluster) SetStorage(s *core.Storage) {
 	c.storage = s
 }
 
+// GetBasicCluster returns the basic cluster.
+// There is no need a lock since it won't changed.
+func (c *RaftCluster) GetBasicCluster() *core.BasicCluster {
+	return c.core
+}
+
 // GetOpts returns cluster's configuration.
+// There is no need a lock since it won't changed.
 func (c *RaftCluster) GetOpts() *config.PersistOptions {
 	return c.opt
+}
+
+// GetAllocator returns cluster's id allocator.
+// There is no need a lock since it won't changed.
+func (c *RaftCluster) GetAllocator() id.Allocator {
+	return c.id
+}
+
+// GetRuleManager returns the rule manager reference.
+// There is no need a lock since it won't changed.
+func (c *RaftCluster) GetRuleManager() *placement.RuleManager {
+	return c.ruleManager
 }
 
 // AddSuspectRegions adds regions to suspect list.
@@ -1402,11 +1414,6 @@ func (c *RaftCluster) getStoresWithoutLabelLocked(region *core.RegionInfo, key, 
 	return stores
 }
 
-// AllocID allocs ID.
-func (c *RaftCluster) AllocID() (uint64, error) {
-	return c.id.Alloc()
-}
-
 // OnStoreVersionChange changes the version of the cluster when needed.
 func (c *RaftCluster) OnStoreVersionChange() {
 	c.RLock()
@@ -1527,13 +1534,6 @@ func (c *RaftCluster) putRegion(region *core.RegionInfo) error {
 	}
 	c.core.PutRegion(region)
 	return nil
-}
-
-// GetRuleManager returns the rule manager reference.
-func (c *RaftCluster) GetRuleManager() *placement.RuleManager {
-	c.RLock()
-	defer c.RUnlock()
-	return c.ruleManager
 }
 
 // GetRegionLabeler returns the region labeler.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1404,8 +1404,6 @@ func (c *RaftCluster) getStoresWithoutLabelLocked(region *core.RegionInfo, key, 
 
 // GetAllocator returns cluster's id allocator.
 func (c *RaftCluster) GetAllocator() id.Allocator {
-	c.RLock()
-	defer c.RUnlock()
 	return c.id
 }
 

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/hbstream"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedulers"
 	"github.com/tikv/pd/server/statistics"
 )
@@ -46,7 +45,7 @@ func newTestOperator(regionID uint64, regionEpoch *metapb.RegionEpoch, kind oper
 }
 
 func (c *testCluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
-	id, err := c.AllocID()
+	id, err := c.GetAllocator().Alloc()
 	if err != nil {
 		return nil, err
 	}
@@ -1095,7 +1094,7 @@ type mockLimitScheduler struct {
 	kind    operator.OpKind
 }
 
-func (s *mockLimitScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (s *mockLimitScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	return s.counter.OperatorCount(s.kind) < s.limit
 }
 

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -312,7 +312,7 @@ func (u *unsafeRecoveryController) generateRecoveryPlan() {
 				newRegion.StartKey = lastEnd
 				newRegion.EndKey = overlapRegion.StartKey
 				if _, inUse := inUseRegions[region.Id]; inUse {
-					newRegion.Id, _ = u.cluster.AllocID()
+					newRegion.Id, _ = u.cluster.GetAllocator().Alloc()
 					creates = append(creates, newRegion)
 				} else {
 					inUseRegions[region.Id] = true
@@ -337,7 +337,7 @@ func (u *unsafeRecoveryController) generateRecoveryPlan() {
 			newRegion.StartKey = lastEnd
 			newRegion.EndKey = region.EndKey
 			if _, inUse := inUseRegions[region.Id]; inUse {
-				newRegion.Id, _ = u.cluster.AllocID()
+				newRegion.Id, _ = u.cluster.GetAllocator().Alloc()
 				creates = append(creates, newRegion)
 			} else {
 				inUseRegions[region.Id] = true
@@ -374,7 +374,7 @@ func (u *unsafeRecoveryController) generateRecoveryPlan() {
 			newRegion := &metapb.Region{}
 			newRegion.StartKey = lastEnd
 			newRegion.EndKey = region.StartKey
-			newRegion.Id, _ = u.cluster.AllocID()
+			newRegion.Id, _ = u.cluster.GetAllocator().Alloc()
 			newRegion.RegionEpoch = &metapb.RegionEpoch{ConfVer: 1, Version: 1}
 			creates = append(creates, newRegion)
 		}
@@ -384,7 +384,7 @@ func (u *unsafeRecoveryController) generateRecoveryPlan() {
 	if !bytes.Equal(lastEnd, []byte("")) {
 		newRegion := &metapb.Region{}
 		newRegion.StartKey = lastEnd
-		newRegion.Id, _ = u.cluster.AllocID()
+		newRegion.Id, _ = u.cluster.GetAllocator().Alloc()
 		creates = append(creates, newRegion)
 	}
 	var allStores []uint64
@@ -393,7 +393,7 @@ func (u *unsafeRecoveryController) generateRecoveryPlan() {
 	}
 	for idx, create := range creates {
 		storeID := allStores[idx%len(allStores)]
-		peerID, _ := u.cluster.AllocID()
+		peerID, _ := u.cluster.GetAllocator().Alloc()
 		create.Peers = []*metapb.Peer{{Id: peerID, StoreId: storeID, Role: metapb.PeerRole_Voter}}
 		storeRecoveryPlan, exists := u.storeRecoveryPlans[storeID]
 		if !exists {

--- a/server/schedule/checker/checker_controller.go
+++ b/server/schedule/checker/checker_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/labeler"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
 )
 
@@ -33,7 +32,7 @@ const DefaultCacheSize = 1000
 
 // Controller is used to manage all checkers.
 type Controller struct {
-	cluster           opt.Cluster
+	cluster           schedule.Cluster
 	opts              *config.PersistOptions
 	opController      *schedule.OperatorController
 	learnerChecker    *LearnerChecker
@@ -48,7 +47,7 @@ type Controller struct {
 
 // NewController create a new Controller.
 // TODO: isSupportMerge should be removed.
-func NewController(ctx context.Context, cluster opt.Cluster, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler, opController *schedule.OperatorController) *Controller {
+func NewController(ctx context.Context, cluster schedule.Cluster, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler, opController *schedule.OperatorController) *Controller {
 	regionWaitingList := cache.NewDefaultCache(DefaultCacheSize)
 	return &Controller{
 		cluster:           cluster,

--- a/server/schedule/checker/joint_state_checker.go
+++ b/server/schedule/checker/joint_state_checker.go
@@ -18,18 +18,18 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 )
 
 // JointStateChecker ensures region is in joint state will leave.
 type JointStateChecker struct {
 	PauseController
-	cluster opt.Cluster
+	cluster schedule.Cluster
 }
 
 // NewJointStateChecker creates a joint state checker.
-func NewJointStateChecker(cluster opt.Cluster) *JointStateChecker {
+func NewJointStateChecker(cluster schedule.Cluster) *JointStateChecker {
 	return &JointStateChecker{
 		cluster: cluster,
 	}

--- a/server/schedule/checker/learner_checker.go
+++ b/server/schedule/checker/learner_checker.go
@@ -18,18 +18,18 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 )
 
 // LearnerChecker ensures region has a learner will be promoted.
 type LearnerChecker struct {
 	PauseController
-	cluster opt.Cluster
+	cluster schedule.Cluster
 }
 
 // NewLearnerChecker creates a learner checker.
-func NewLearnerChecker(cluster opt.Cluster) *LearnerChecker {
+func NewLearnerChecker(cluster schedule.Cluster) *LearnerChecker {
 	return &LearnerChecker{
 		cluster: cluster,
 	}

--- a/server/schedule/checker/priority_inspector.go
+++ b/server/schedule/checker/priority_inspector.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/schedule/opt"
+	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/placement"
 )
 
@@ -29,13 +29,13 @@ const defaultPriorityQueueSize = 1280
 
 // PriorityInspector ensures high priority region should run first
 type PriorityInspector struct {
-	cluster opt.Cluster
+	cluster schedule.Cluster
 	opts    *config.PersistOptions
 	queue   *cache.PriorityQueue
 }
 
 // NewPriorityInspector creates a priority inspector.
-func NewPriorityInspector(cluster opt.Cluster) *PriorityInspector {
+func NewPriorityInspector(cluster schedule.Cluster) *PriorityInspector {
 	return &PriorityInspector{
 		cluster: cluster,
 		opts:    cluster.GetOpts(),

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -23,8 +23,8 @@ import (
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -44,13 +44,13 @@ const (
 // Location management, mainly used for cross data center deployment.
 type ReplicaChecker struct {
 	PauseController
-	cluster           opt.Cluster
+	cluster           schedule.Cluster
 	opts              *config.PersistOptions
 	regionWaitingList cache.Cache
 }
 
 // NewReplicaChecker creates a replica checker.
-func NewReplicaChecker(cluster opt.Cluster, regionWaitingList cache.Cache) *ReplicaChecker {
+func NewReplicaChecker(cluster schedule.Cluster, regionWaitingList cache.Cache) *ReplicaChecker {
 	return &ReplicaChecker{
 		cluster:           cluster,
 		opts:              cluster.GetOpts(),

--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -17,8 +17,8 @@ package checker
 import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/filter"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -26,7 +26,7 @@ import (
 // exists to allow replica_checker and rule_checker to reuse common logics.
 type ReplicaStrategy struct {
 	checkerName    string // replica-checker / rule-checker
-	cluster        opt.Cluster
+	cluster        schedule.Cluster
 	locationLabels []string
 	isolationLevel string
 	region         *core.RegionInfo

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -25,9 +25,9 @@ import (
 	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
 	"go.uber.org/zap"
 )
@@ -35,7 +35,7 @@ import (
 // RuleChecker fix/improve region by placement rules.
 type RuleChecker struct {
 	PauseController
-	cluster           opt.Cluster
+	cluster           schedule.Cluster
 	ruleManager       *placement.RuleManager
 	name              string
 	regionWaitingList cache.Cache
@@ -43,7 +43,7 @@ type RuleChecker struct {
 }
 
 // NewRuleChecker creates a checker instance.
-func NewRuleChecker(cluster opt.Cluster, ruleManager *placement.RuleManager, regionWaitingList cache.Cache) *RuleChecker {
+func NewRuleChecker(cluster schedule.Cluster, ruleManager *placement.RuleManager, regionWaitingList cache.Cache) *RuleChecker {
 	return &RuleChecker{
 		cluster:           cluster,
 		ruleManager:       ruleManager,
@@ -395,7 +395,7 @@ func (o *recorder) incOfflineLeaderCount(storeID uint64) {
 // Offline is triggered manually and only appears when the node makes some adjustments. here is an operator timeout / 2.
 var offlineCounterTTL = 5 * time.Minute
 
-func (o *recorder) refresh(cluster opt.Cluster) {
+func (o *recorder) refresh(cluster schedule.Cluster) {
 	// re-count the offlineLeaderCounter if the store is already tombstone or store is gone.
 	if len(o.offlineLeaderCounter) > 0 && time.Since(o.lastUpdateTime) > offlineCounterTTL {
 		needClean := false

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -19,22 +19,22 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/labeler"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
 )
 
 // SplitChecker splits regions when the key range spans across rule/label boundary.
 type SplitChecker struct {
 	PauseController
-	cluster     opt.Cluster
+	cluster     schedule.Cluster
 	ruleManager *placement.RuleManager
 	labeler     *labeler.RegionLabeler
 }
 
 // NewSplitChecker creates a new SplitChecker.
-func NewSplitChecker(cluster opt.Cluster, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler) *SplitChecker {
+func NewSplitChecker(cluster schedule.Cluster, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler) *SplitChecker {
 	return &SplitChecker{
 		cluster:     cluster,
 		ruleManager: ruleManager,

--- a/server/schedule/cluster.go
+++ b/server/schedule/cluster.go
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package opt
+package schedule
 
 import (
-	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/schedule/placement"
+	"github.com/tikv/pd/server/schedule/operator"
 	"github.com/tikv/pd/server/statistics"
 )
 
 // Cluster provides an overview of a cluster's regions distribution.
-// TODO: This interface should be moved to a better place.
 type Cluster interface {
 	core.RegionSetInformer
 	core.StoreSetInformer
@@ -31,10 +29,8 @@ type Cluster interface {
 	statistics.RegionStatInformer
 	statistics.StoreStatInformer
 
-	GetOpts() *config.PersistOptions
-	AllocID() (uint64, error)
-	GetRuleManager() *placement.RuleManager
+	operator.ClusterInfo
+
 	RemoveScheduler(name string) error
 	AddSuspectRegions(ids ...uint64)
-	GetBasicCluster() *core.BasicCluster
 }

--- a/server/schedule/cluster.go
+++ b/server/schedule/cluster.go
@@ -29,7 +29,7 @@ type Cluster interface {
 	statistics.RegionStatInformer
 	statistics.StoreStatInformer
 
-	operator.ClusterInfo
+	operator.ClusterInformer
 
 	RemoveScheduler(name string) error
 	AddSuspectRegions(ids ...uint64)

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/core/storelimit"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
 	"go.uber.org/zap"
 )
@@ -464,23 +463,25 @@ func (f labelConstraintFilter) Target(opt *config.PersistOptions, store *core.St
 }
 
 type ruleFitFilter struct {
-	scope    string
-	cluster  opt.Cluster
-	region   *core.RegionInfo
-	oldFit   *placement.RegionFit
-	srcStore uint64
+	scope       string
+	cluster     *core.BasicCluster
+	ruleManager *placement.RuleManager
+	region      *core.RegionInfo
+	oldFit      *placement.RegionFit
+	srcStore    uint64
 }
 
 // newRuleFitFilter creates a filter that ensures after replace a peer with new
 // one, the isolation level will not decrease. Its function is the same as
 // distinctScoreFilter but used when placement rules is enabled.
-func newRuleFitFilter(scope string, cluster opt.Cluster, region *core.RegionInfo, oldStoreID uint64) Filter {
+func newRuleFitFilter(scope string, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, oldStoreID uint64) Filter {
 	return &ruleFitFilter{
-		scope:    scope,
-		cluster:  cluster,
-		region:   region,
-		oldFit:   cluster.GetRuleManager().FitRegion(cluster, region),
-		srcStore: oldStoreID,
+		scope:       scope,
+		cluster:     cluster,
+		ruleManager: ruleManager,
+		region:      region,
+		oldFit:      ruleManager.FitRegion(cluster, region),
+		srcStore:    oldStoreID,
 	}
 }
 
@@ -500,7 +501,7 @@ func (f *ruleFitFilter) Target(options *config.PersistOptions, store *core.Store
 	region := createRegionForRuleFit(f.region.GetStartKey(), f.region.GetEndKey(),
 		f.region.GetPeers(), f.region.GetLeader(),
 		core.WithReplacePeerStore(f.srcStore, store.GetID()))
-	newFit := f.cluster.GetRuleManager().FitRegion(f.cluster, region)
+	newFit := f.ruleManager.FitRegion(f.cluster, region)
 	return placement.CompareRegionFit(f.oldFit, newFit) <= 0
 }
 
@@ -511,7 +512,8 @@ func (f *ruleFitFilter) GetSourceStoreID() uint64 {
 
 type ruleLeaderFitFilter struct {
 	scope            string
-	cluster          opt.Cluster
+	cluster          *core.BasicCluster
+	ruleManager      *placement.RuleManager
 	region           *core.RegionInfo
 	oldFit           *placement.RegionFit
 	srcLeaderStoreID uint64
@@ -519,12 +521,13 @@ type ruleLeaderFitFilter struct {
 
 // newRuleLeaderFitFilter creates a filter that ensures after transfer leader with new store,
 // the isolation level will not decrease.
-func newRuleLeaderFitFilter(scope string, cluster opt.Cluster, region *core.RegionInfo, srcLeaderStoreID uint64) Filter {
+func newRuleLeaderFitFilter(scope string, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, srcLeaderStoreID uint64) Filter {
 	return &ruleLeaderFitFilter{
 		scope:            scope,
 		cluster:          cluster,
+		ruleManager:      ruleManager,
 		region:           region,
-		oldFit:           cluster.GetRuleManager().FitRegion(cluster, region),
+		oldFit:           ruleManager.FitRegion(cluster, region),
 		srcLeaderStoreID: srcLeaderStoreID,
 	}
 }
@@ -550,7 +553,7 @@ func (f *ruleLeaderFitFilter) Target(options *config.PersistOptions, store *core
 	copyRegion := createRegionForRuleFit(f.region.GetStartKey(), f.region.GetEndKey(),
 		f.region.GetPeers(), f.region.GetLeader(),
 		core.WithLeader(targetPeer))
-	newFit := f.cluster.GetRuleManager().FitRegion(f.cluster, copyRegion)
+	newFit := f.ruleManager.FitRegion(f.cluster, copyRegion)
 	return placement.CompareRegionFit(f.oldFit, newFit) <= 0
 }
 
@@ -560,19 +563,19 @@ func (f *ruleLeaderFitFilter) GetSourceStoreID() uint64 {
 
 // NewPlacementSafeguard creates a filter that ensures after replace a peer with new
 // peer, the placement restriction will not become worse.
-func NewPlacementSafeguard(scope string, cluster opt.Cluster, region *core.RegionInfo, sourceStore *core.StoreInfo) Filter {
-	if cluster.GetOpts().IsPlacementRulesEnabled() {
-		return newRuleFitFilter(scope, cluster, region, sourceStore.GetID())
+func NewPlacementSafeguard(scope string, opt *config.PersistOptions, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, sourceStore *core.StoreInfo) Filter {
+	if opt.IsPlacementRulesEnabled() {
+		return newRuleFitFilter(scope, cluster, ruleManager, region, sourceStore.GetID())
 	}
-	return NewLocationSafeguard(scope, cluster.GetOpts().GetLocationLabels(), cluster.GetRegionStores(region), sourceStore)
+	return NewLocationSafeguard(scope, opt.GetLocationLabels(), cluster.GetRegionStores(region), sourceStore)
 }
 
 // NewPlacementLeaderSafeguard creates a filter that ensures after transfer a leader with
 // existed peer, the placement restriction will not become worse.
 // Note that it only worked when PlacementRules enabled otherwise it will always permit the sourceStore.
-func NewPlacementLeaderSafeguard(scope string, cluster opt.Cluster, region *core.RegionInfo, sourceStore *core.StoreInfo) Filter {
-	if cluster.GetOpts().IsPlacementRulesEnabled() {
-		return newRuleLeaderFitFilter(scope, cluster, region, sourceStore.GetID())
+func NewPlacementLeaderSafeguard(scope string, opt *config.PersistOptions, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, sourceStore *core.StoreInfo) Filter {
+	if opt.IsPlacementRulesEnabled() {
+		return newRuleLeaderFitFilter(scope, cluster, ruleManager, region, sourceStore.GetID())
 	}
 	return nil
 }

--- a/server/schedule/filter/filters_test.go
+++ b/server/schedule/filter/filters_test.go
@@ -138,7 +138,7 @@ func (s *testFiltersSuite) TestRuleFitFilter(c *C) {
 		testCluster.AddLabelsStore(tc.storeID, tc.regionCount, tc.labels)
 	}
 	for _, tc := range testCases {
-		filter := newRuleFitFilter("", testCluster, region, 1)
+		filter := newRuleFitFilter("", testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, 1)
 		c.Assert(filter.Source(testCluster.GetOpts(), testCluster.GetStore(tc.storeID)), Equals, tc.sourceRes)
 		c.Assert(filter.Target(testCluster.GetOpts(), testCluster.GetStore(tc.storeID)), Equals, tc.targetRes)
 	}
@@ -279,13 +279,13 @@ func (s *testFiltersSuite) TestPlacementGuard(c *C) {
 	}}, &metapb.Peer{StoreId: 1, Id: 1})
 	store := testCluster.GetStore(1)
 
-	c.Assert(NewPlacementSafeguard("", testCluster, region, store),
+	c.Assert(NewPlacementSafeguard("", testCluster.GetOpts(), testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, store),
 		FitsTypeOf,
 		NewLocationSafeguard("", []string{"zone"}, testCluster.GetRegionStores(region), store))
 	testCluster.SetEnablePlacementRules(true)
-	c.Assert(NewPlacementSafeguard("", testCluster, region, store),
+	c.Assert(NewPlacementSafeguard("", testCluster.GetOpts(), testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, store),
 		FitsTypeOf,
-		newRuleFitFilter("", testCluster, region, 1))
+		newRuleFitFilter("", testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, 1))
 }
 
 func BenchmarkCloneRegionTest(b *testing.B) {

--- a/server/schedule/healthy.go
+++ b/server/schedule/healthy.go
@@ -16,7 +16,6 @@ package schedule
 
 import (
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/schedule/opt"
 )
 
 // IsRegionHealthy checks if a region is healthy for scheduling. It requires the
@@ -34,7 +33,7 @@ func IsRegionHealthyAllowPending(region *core.RegionInfo) bool {
 // IsRegionReplicated checks if a region is fully replicated. When placement
 // rules is enabled, its peers should fit corresponding rules. When placement
 // rules is disabled, it should have enough replicas and no any learner peer.
-func IsRegionReplicated(cluster opt.Cluster, region *core.RegionInfo) bool {
+func IsRegionReplicated(cluster Cluster, region *core.RegionInfo) bool {
 	if cluster.GetOpts().IsPlacementRulesEnabled() {
 		return cluster.GetRuleManager().FitRegion(cluster, region).IsSatisfied()
 	}
@@ -42,6 +41,6 @@ func IsRegionReplicated(cluster opt.Cluster, region *core.RegionInfo) bool {
 }
 
 // ReplicatedRegion returns a function that checks if a region is fully replicated.
-func ReplicatedRegion(cluster opt.Cluster) func(*core.RegionInfo) bool {
+func ReplicatedRegion(cluster Cluster) func(*core.RegionInfo) bool {
 	return func(region *core.RegionInfo) bool { return IsRegionReplicated(cluster, region) }
 }

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -21,12 +21,21 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/pkg/typeutil"
+	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/id"
 	"github.com/tikv/pd/server/schedule/filter"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/versioninfo"
 )
+
+// ClusterInfo provides the necessary information for building operator.
+type ClusterInfo interface {
+	GetBasicCluster() *core.BasicCluster
+	GetOpts() *config.PersistOptions
+	GetRuleManager() *placement.RuleManager
+	GetAllocator() id.Allocator
+}
 
 // Builder is used to create operators. Usage:
 //     op, err := NewBuilder(desc, cluster, region).
@@ -38,8 +47,8 @@ import (
 // according to various constraints.
 type Builder struct {
 	// basic info
+	ClusterInfo
 	desc          string
-	cluster       opt.Cluster
 	regionID      uint64
 	regionEpoch   *metapb.RegionEpoch
 	rules         []*placement.Rule
@@ -82,10 +91,10 @@ func SkipOriginJointStateCheck(b *Builder) {
 }
 
 // NewBuilder creates a Builder.
-func NewBuilder(desc string, cluster opt.Cluster, region *core.RegionInfo, opts ...BuilderOption) *Builder {
+func NewBuilder(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, opts ...BuilderOption) *Builder {
 	b := &Builder{
 		desc:        desc,
-		cluster:     cluster,
+		ClusterInfo: clusterInfo,
 		regionID:    region.GetID(),
 		regionEpoch: region.GetRegionEpoch(),
 	}
@@ -124,8 +133,8 @@ func NewBuilder(desc string, cluster opt.Cluster, region *core.RegionInfo, opts 
 
 	// placement rules
 	var rules []*placement.Rule
-	if err == nil && cluster.GetOpts().IsPlacementRulesEnabled() {
-		fit := cluster.GetRuleManager().FitRegion(cluster, region)
+	if err == nil && b.GetOpts().IsPlacementRulesEnabled() {
+		fit := b.GetRuleManager().FitRegion(b.GetBasicCluster(), region)
 		for _, rf := range fit.RuleFits {
 			rules = append(rules, rf.Rule)
 		}
@@ -140,14 +149,14 @@ func NewBuilder(desc string, cluster opt.Cluster, region *core.RegionInfo, opts 
 	}
 
 	// build flags
-	supportJointConsensus := versioninfo.IsFeatureSupported(cluster.GetOpts().GetClusterVersion(), versioninfo.JointConsensus)
+	supportJointConsensus := versioninfo.IsFeatureSupported(b.GetOpts().GetClusterVersion(), versioninfo.JointConsensus)
 
 	b.rules = rules
 	b.originPeers = originPeers
 	b.unhealthyPeers = unhealthyPeers
 	b.originLeaderStoreID = originLeaderStoreID
 	b.targetPeers = originPeers.Copy()
-	b.useJointConsensus = supportJointConsensus && cluster.GetOpts().IsUseJointConsensus()
+	b.useJointConsensus = supportJointConsensus && b.GetOpts().IsUseJointConsensus()
 	b.err = err
 	return b
 }
@@ -411,7 +420,7 @@ func (b *Builder) prepareBuild() (string, error) {
 		if o == nil || (!b.useJointConsensus && !core.IsLearner(o) && core.IsLearner(n)) {
 			if n.GetId() == 0 {
 				// Allocate peer ID if need.
-				id, err := b.cluster.AllocID()
+				id, err := b.GetAllocator().Alloc()
 				if err != nil {
 					return "", err
 				}
@@ -584,7 +593,7 @@ func (b *Builder) preferLeaderRoleAsLeader(targetLeaderStoreID uint64) int {
 }
 
 func (b *Builder) preferUpStoreAsLeader(targetLeaderStoreID uint64) int {
-	store := b.cluster.GetStore(targetLeaderStoreID)
+	store := b.GetBasicCluster().GetStore(targetLeaderStoreID)
 	return typeutil.BoolToInt(store != nil && store.IsUp())
 }
 
@@ -675,9 +684,9 @@ func (b *Builder) execAddPeer(peer *metapb.Peer) {
 func (b *Builder) execRemovePeer(peer *metapb.Peer) {
 	removeStoreID := peer.GetStoreId()
 	var isDownStore bool
-	store := b.cluster.GetStore(removeStoreID)
+	store := b.GetBasicCluster().GetStore(removeStoreID)
 	if store != nil {
-		isDownStore = store.DownTime() > b.cluster.GetOpts().GetMaxStoreDownTime()
+		isDownStore = store.DownTime() > b.GetOpts().GetMaxStoreDownTime()
 	}
 	b.steps = append(b.steps, RemovePeer{FromStore: removeStoreID, PeerID: peer.GetId(), IsDownStore: isDownStore})
 	delete(b.currentPeers, removeStoreID)
@@ -743,7 +752,7 @@ func (b *Builder) allowLeader(peer *metapb.Peer, ignoreClusterLimit bool) bool {
 	if peer.GetStoreId() == b.currentLeaderStoreID {
 		return true
 	}
-	store := b.cluster.GetStore(peer.GetStoreId())
+	store := b.GetBasicCluster().GetStore(peer.GetStoreId())
 	if store == nil {
 		return false
 	}
@@ -754,7 +763,7 @@ func (b *Builder) allowLeader(peer *metapb.Peer, ignoreClusterLimit bool) bool {
 
 	stateFilter := &filter.StoreStateFilter{ActionScope: "operator-builder", TransferLeader: true}
 	// store state filter
-	if !stateFilter.Target(b.cluster.GetOpts(), store) {
+	if !stateFilter.Target(b.GetOpts(), store) {
 		return false
 	}
 
@@ -984,11 +993,11 @@ func (b *Builder) comparePlan(best, next stepPlan) stepPlan {
 }
 
 func (b *Builder) labelMatch(x, y uint64) int {
-	sx, sy := b.cluster.GetStore(x), b.cluster.GetStore(y)
+	sx, sy := b.GetBasicCluster().GetStore(x), b.GetBasicCluster().GetStore(y)
 	if sx == nil || sy == nil {
 		return 0
 	}
-	labels := b.cluster.GetOpts().GetLocationLabels()
+	labels := b.GetOpts().GetLocationLabels()
 	for i, l := range labels {
 		if sx.GetLabelValue(l) != sy.GetLabelValue(l) {
 			return i
@@ -1020,7 +1029,7 @@ func (b *Builder) planPreferReplaceByNearest(p stepPlan) int {
 // Avoid generating snapshots from offline stores.
 func (b *Builder) planPreferUpStoreAsLeader(p stepPlan) int {
 	if p.add != nil {
-		store := b.cluster.GetStore(p.leaderBeforeAdd)
+		store := b.GetBasicCluster().GetStore(p.leaderBeforeAdd)
 		return typeutil.BoolToInt(store != nil && store.IsUp())
 	}
 	return 1

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -29,8 +29,8 @@ import (
 	"github.com/tikv/pd/server/versioninfo"
 )
 
-// ClusterInfo provides the necessary information for building operator.
-type ClusterInfo interface {
+// ClusterInformer provides the necessary information for building operator.
+type ClusterInformer interface {
 	GetBasicCluster() *core.BasicCluster
 	GetOpts() *config.PersistOptions
 	GetRuleManager() *placement.RuleManager
@@ -47,7 +47,7 @@ type ClusterInfo interface {
 // according to various constraints.
 type Builder struct {
 	// basic info
-	ClusterInfo
+	ClusterInformer
 	desc          string
 	regionID      uint64
 	regionEpoch   *metapb.RegionEpoch
@@ -91,12 +91,12 @@ func SkipOriginJointStateCheck(b *Builder) {
 }
 
 // NewBuilder creates a Builder.
-func NewBuilder(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, opts ...BuilderOption) *Builder {
+func NewBuilder(desc string, ci ClusterInformer, region *core.RegionInfo, opts ...BuilderOption) *Builder {
 	b := &Builder{
-		desc:        desc,
-		ClusterInfo: clusterInfo,
-		regionID:    region.GetID(),
-		regionEpoch: region.GetRegionEpoch(),
+		desc:            desc,
+		ClusterInformer: ci,
+		regionID:        region.GetID(),
+		regionEpoch:     region.GetRegionEpoch(),
 	}
 
 	// options

--- a/server/schedule/operator/builder_test.go
+++ b/server/schedule/operator/builder_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/versioninfo"
 )
 
 var _ = Suite(&testBuilderSuite{})
@@ -119,6 +118,7 @@ func (s *testBuilderSuite) TestPrepareBuild(c *C) {
 	_, err := s.newBuilder().SetPeers(map[uint64]*metapb.Peer{4: {StoreId: 4, Role: metapb.PeerRole_Learner}}).prepareBuild()
 	c.Assert(err, NotNil)
 
+	// use joint consensus
 	builder := s.newBuilder().SetPeers(map[uint64]*metapb.Peer{
 		1: {StoreId: 1, Role: metapb.PeerRole_Learner},
 		3: {StoreId: 3},
@@ -141,7 +141,6 @@ func (s *testBuilderSuite) TestPrepareBuild(c *C) {
 	c.Assert(builder.currentLeaderStoreID, Equals, uint64(1))
 
 	// do not use joint consensus
-	s.cluster.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 	builder = s.newBuilder().SetPeers(map[uint64]*metapb.Peer{
 		1: {StoreId: 1, Role: metapb.PeerRole_Learner},
 		2: {StoreId: 2},

--- a/server/schedule/operator/builder_test.go
+++ b/server/schedule/operator/builder_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/versioninfo"
 )
 
 var _ = Suite(&testBuilderSuite{})
@@ -118,7 +119,6 @@ func (s *testBuilderSuite) TestPrepareBuild(c *C) {
 	_, err := s.newBuilder().SetPeers(map[uint64]*metapb.Peer{4: {StoreId: 4, Role: metapb.PeerRole_Learner}}).prepareBuild()
 	c.Assert(err, NotNil)
 
-	// use joint consensus
 	builder := s.newBuilder().SetPeers(map[uint64]*metapb.Peer{
 		1: {StoreId: 1, Role: metapb.PeerRole_Learner},
 		3: {StoreId: 3},
@@ -141,6 +141,7 @@ func (s *testBuilderSuite) TestPrepareBuild(c *C) {
 	c.Assert(builder.currentLeaderStoreID, Equals, uint64(1))
 
 	// do not use joint consensus
+	s.cluster.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 	builder = s.newBuilder().SetPeers(map[uint64]*metapb.Peer{
 		1: {StoreId: 1, Role: metapb.PeerRole_Learner},
 		2: {StoreId: 2},

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -30,51 +30,51 @@ import (
 )
 
 // CreateAddPeerOperator creates an operator that adds a new peer.
-func CreateAddPeerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, peer *metapb.Peer, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region).
+func CreateAddPeerOperator(desc string, ci ClusterInformer, region *core.RegionInfo, peer *metapb.Peer, kind OpKind) (*Operator, error) {
+	return NewBuilder(desc, ci, region).
 		AddPeer(peer).
 		Build(kind)
 }
 
 // CreateDemoteVoterOperator creates an operator that demotes a voter
-func CreateDemoteVoterOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region).
+func CreateDemoteVoterOperator(desc string, ci ClusterInformer, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, ci, region).
 		DemoteVoter(peer.GetStoreId()).
 		Build(0)
 }
 
 // CreatePromoteLearnerOperator creates an operator that promotes a learner.
-func CreatePromoteLearnerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region).
+func CreatePromoteLearnerOperator(desc string, ci ClusterInformer, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, ci, region).
 		PromoteLearner(peer.GetStoreId()).
 		Build(0)
 }
 
 // CreateRemovePeerOperator creates an operator that removes a peer from region.
-func CreateRemovePeerOperator(desc string, clusterInfo ClusterInfo, kind OpKind, region *core.RegionInfo, storeID uint64) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region).
+func CreateRemovePeerOperator(desc string, ci ClusterInformer, kind OpKind, region *core.RegionInfo, storeID uint64) (*Operator, error) {
+	return NewBuilder(desc, ci, region).
 		RemovePeer(storeID).
 		Build(kind)
 }
 
 // CreateTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store.
-func CreateTransferLeaderOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, targetStoreIDs []uint64, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region, SkipOriginJointStateCheck).
+func CreateTransferLeaderOperator(desc string, ci ClusterInformer, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, targetStoreIDs []uint64, kind OpKind) (*Operator, error) {
+	return NewBuilder(desc, ci, region, SkipOriginJointStateCheck).
 		SetLeader(targetStoreID).
 		SetLeaders(targetStoreIDs).
 		Build(kind)
 }
 
 // CreateForceTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store forcible.
-func CreateForceTransferLeaderOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region, SkipOriginJointStateCheck).
+func CreateForceTransferLeaderOperator(desc string, ci ClusterInformer, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
+	return NewBuilder(desc, ci, region, SkipOriginJointStateCheck).
 		SetLeader(targetStoreID).
 		EnableForceTargetLeader().
 		Build(kind)
 }
 
 // CreateMoveRegionOperator creates an operator that moves a region to specified stores.
-func CreateMoveRegionOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, roles map[uint64]placement.PeerRoleType) (*Operator, error) {
+func CreateMoveRegionOperator(desc string, ci ClusterInformer, region *core.RegionInfo, kind OpKind, roles map[uint64]placement.PeerRoleType) (*Operator, error) {
 	// construct the peers from roles
 	peers := make(map[uint64]*metapb.Peer)
 	for storeID, role := range roles {
@@ -83,21 +83,21 @@ func CreateMoveRegionOperator(desc string, clusterInfo ClusterInfo, region *core
 			Role:    role.MetaPeerRole(),
 		}
 	}
-	builder := NewBuilder(desc, clusterInfo, region).SetPeers(peers).SetExpectedRoles(roles)
+	builder := NewBuilder(desc, ci, region).SetPeers(peers).SetExpectedRoles(roles)
 	return builder.Build(kind)
 }
 
 // CreateMovePeerOperator creates an operator that replaces an old peer with a new peer.
-func CreateMovePeerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region).
+func CreateMovePeerOperator(desc string, ci ClusterInformer, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, ci, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
 		Build(kind)
 }
 
 // CreateReplaceLeaderPeerOperator creates an operator that replaces an old peer with a new peer, and move leader from old store firstly.
-func CreateReplaceLeaderPeerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer, leader *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region).
+func CreateReplaceLeaderPeerOperator(desc string, ci ClusterInformer, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer, leader *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, ci, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
 		SetLeader(leader.GetStoreId()).
@@ -105,8 +105,8 @@ func CreateReplaceLeaderPeerOperator(desc string, clusterInfo ClusterInfo, regio
 }
 
 // CreateMoveLeaderOperator creates an operator that replaces an old leader with a new leader.
-func CreateMoveLeaderOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, clusterInfo, region).
+func CreateMoveLeaderOperator(desc string, ci ClusterInformer, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, ci, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
 		SetLeader(peer.GetStoreId()).
@@ -137,7 +137,7 @@ func CreateSplitRegionOperator(desc string, region *core.RegionInfo, kind OpKind
 }
 
 // CreateMergeRegionOperator creates an operator that merge two region into one.
-func CreateMergeRegionOperator(desc string, clusterInfo ClusterInfo, source *core.RegionInfo, target *core.RegionInfo, kind OpKind) ([]*Operator, error) {
+func CreateMergeRegionOperator(desc string, ci ClusterInformer, source *core.RegionInfo, target *core.RegionInfo, kind OpKind) ([]*Operator, error) {
 	if core.IsInJointState(source.GetPeers()...) || core.IsInJointState(target.GetPeers()...) {
 		return nil, errors.Errorf("cannot merge regions which are in joint state")
 	}
@@ -151,7 +151,7 @@ func CreateMergeRegionOperator(desc string, clusterInfo ClusterInfo, source *cor
 				Role:    p.GetRole(),
 			}
 		}
-		matchOp, err := NewBuilder("", clusterInfo, source).
+		matchOp, err := NewBuilder("", ci, source).
 			SetPeers(peers).
 			Build(kind)
 		if err != nil {
@@ -193,7 +193,7 @@ func isRegionMatch(a, b *core.RegionInfo) bool {
 }
 
 // CreateScatterRegionOperator creates an operator that scatters the specified region.
-func CreateScatterRegionOperator(desc string, clusterInfo ClusterInfo, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64) (*Operator, error) {
+func CreateScatterRegionOperator(desc string, ci ClusterInformer, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64) (*Operator, error) {
 	// randomly pick a leader.
 	var ids []uint64
 	for id, peer := range targetPeers {
@@ -208,7 +208,7 @@ func CreateScatterRegionOperator(desc string, clusterInfo ClusterInfo, origin *c
 	if targetLeader != 0 {
 		leader = targetLeader
 	}
-	return NewBuilder(desc, clusterInfo, origin).
+	return NewBuilder(desc, ci, origin).
 		SetPeers(targetPeers).
 		SetLeader(leader).
 		EnableLightWeight().
@@ -218,8 +218,8 @@ func CreateScatterRegionOperator(desc string, clusterInfo ClusterInfo, origin *c
 }
 
 // CreateLeaveJointStateOperator creates an operator that let region leave joint state.
-func CreateLeaveJointStateOperator(desc string, clusterInfo ClusterInfo, origin *core.RegionInfo) (*Operator, error) {
-	b := NewBuilder(desc, clusterInfo, origin, SkipOriginJointStateCheck)
+func CreateLeaveJointStateOperator(desc string, ci ClusterInformer, origin *core.RegionInfo) (*Operator, error) {
+	b := NewBuilder(desc, ci, origin, SkipOriginJointStateCheck)
 
 	if b.err == nil && !core.IsInJointState(origin.GetPeers()...) {
 		b.err = errors.Errorf("cannot build leave joint state operator for region which is not in joint state")

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -25,57 +25,56 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/schedule/placement"
 	"go.uber.org/zap"
 )
 
 // CreateAddPeerOperator creates an operator that adds a new peer.
-func CreateAddPeerOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, peer *metapb.Peer, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+func CreateAddPeerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, peer *metapb.Peer, kind OpKind) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region).
 		AddPeer(peer).
 		Build(kind)
 }
 
 // CreateDemoteVoterOperator creates an operator that demotes a voter
-func CreateDemoteVoterOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+func CreateDemoteVoterOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region).
 		DemoteVoter(peer.GetStoreId()).
 		Build(0)
 }
 
 // CreatePromoteLearnerOperator creates an operator that promotes a learner.
-func CreatePromoteLearnerOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+func CreatePromoteLearnerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region).
 		PromoteLearner(peer.GetStoreId()).
 		Build(0)
 }
 
 // CreateRemovePeerOperator creates an operator that removes a peer from region.
-func CreateRemovePeerOperator(desc string, cluster opt.Cluster, kind OpKind, region *core.RegionInfo, storeID uint64) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+func CreateRemovePeerOperator(desc string, clusterInfo ClusterInfo, kind OpKind, region *core.RegionInfo, storeID uint64) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region).
 		RemovePeer(storeID).
 		Build(kind)
 }
 
 // CreateTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store.
-func CreateTransferLeaderOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, targetStoreIDs []uint64, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, cluster, region, SkipOriginJointStateCheck).
+func CreateTransferLeaderOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, targetStoreIDs []uint64, kind OpKind) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region, SkipOriginJointStateCheck).
 		SetLeader(targetStoreID).
 		SetLeaders(targetStoreIDs).
 		Build(kind)
 }
 
 // CreateForceTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store forcible.
-func CreateForceTransferLeaderOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, cluster, region, SkipOriginJointStateCheck).
+func CreateForceTransferLeaderOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region, SkipOriginJointStateCheck).
 		SetLeader(targetStoreID).
 		EnableForceTargetLeader().
 		Build(kind)
 }
 
 // CreateMoveRegionOperator creates an operator that moves a region to specified stores.
-func CreateMoveRegionOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, kind OpKind, roles map[uint64]placement.PeerRoleType) (*Operator, error) {
+func CreateMoveRegionOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, roles map[uint64]placement.PeerRoleType) (*Operator, error) {
 	// construct the peers from roles
 	peers := make(map[uint64]*metapb.Peer)
 	for storeID, role := range roles {
@@ -84,21 +83,21 @@ func CreateMoveRegionOperator(desc string, cluster opt.Cluster, region *core.Reg
 			Role:    role.MetaPeerRole(),
 		}
 	}
-	builder := NewBuilder(desc, cluster, region).SetPeers(peers).SetExpectedRoles(roles)
+	builder := NewBuilder(desc, clusterInfo, region).SetPeers(peers).SetExpectedRoles(roles)
 	return builder.Build(kind)
 }
 
 // CreateMovePeerOperator creates an operator that replaces an old peer with a new peer.
-func CreateMovePeerOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+func CreateMovePeerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
 		Build(kind)
 }
 
 // CreateReplaceLeaderPeerOperator creates an operator that replaces an old peer with a new peer, and move leader from old store firstly.
-func CreateReplaceLeaderPeerOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer, leader *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+func CreateReplaceLeaderPeerOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer, leader *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
 		SetLeader(leader.GetStoreId()).
@@ -106,8 +105,8 @@ func CreateReplaceLeaderPeerOperator(desc string, cluster opt.Cluster, region *c
 }
 
 // CreateMoveLeaderOperator creates an operator that replaces an old leader with a new leader.
-func CreateMoveLeaderOperator(desc string, cluster opt.Cluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
-	return NewBuilder(desc, cluster, region).
+func CreateMoveLeaderOperator(desc string, clusterInfo ClusterInfo, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
+	return NewBuilder(desc, clusterInfo, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
 		SetLeader(peer.GetStoreId()).
@@ -138,7 +137,7 @@ func CreateSplitRegionOperator(desc string, region *core.RegionInfo, kind OpKind
 }
 
 // CreateMergeRegionOperator creates an operator that merge two region into one.
-func CreateMergeRegionOperator(desc string, cluster opt.Cluster, source *core.RegionInfo, target *core.RegionInfo, kind OpKind) ([]*Operator, error) {
+func CreateMergeRegionOperator(desc string, clusterInfo ClusterInfo, source *core.RegionInfo, target *core.RegionInfo, kind OpKind) ([]*Operator, error) {
 	if core.IsInJointState(source.GetPeers()...) || core.IsInJointState(target.GetPeers()...) {
 		return nil, errors.Errorf("cannot merge regions which are in joint state")
 	}
@@ -152,7 +151,7 @@ func CreateMergeRegionOperator(desc string, cluster opt.Cluster, source *core.Re
 				Role:    p.GetRole(),
 			}
 		}
-		matchOp, err := NewBuilder("", cluster, source).
+		matchOp, err := NewBuilder("", clusterInfo, source).
 			SetPeers(peers).
 			Build(kind)
 		if err != nil {
@@ -194,7 +193,7 @@ func isRegionMatch(a, b *core.RegionInfo) bool {
 }
 
 // CreateScatterRegionOperator creates an operator that scatters the specified region.
-func CreateScatterRegionOperator(desc string, cluster opt.Cluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64) (*Operator, error) {
+func CreateScatterRegionOperator(desc string, clusterInfo ClusterInfo, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64) (*Operator, error) {
 	// randomly pick a leader.
 	var ids []uint64
 	for id, peer := range targetPeers {
@@ -209,7 +208,7 @@ func CreateScatterRegionOperator(desc string, cluster opt.Cluster, origin *core.
 	if targetLeader != 0 {
 		leader = targetLeader
 	}
-	return NewBuilder(desc, cluster, origin).
+	return NewBuilder(desc, clusterInfo, origin).
 		SetPeers(targetPeers).
 		SetLeader(leader).
 		EnableLightWeight().
@@ -219,8 +218,8 @@ func CreateScatterRegionOperator(desc string, cluster opt.Cluster, origin *core.
 }
 
 // CreateLeaveJointStateOperator creates an operator that let region leave joint state.
-func CreateLeaveJointStateOperator(desc string, cluster opt.Cluster, origin *core.RegionInfo) (*Operator, error) {
-	b := NewBuilder(desc, cluster, origin, SkipOriginJointStateCheck)
+func CreateLeaveJointStateOperator(desc string, clusterInfo ClusterInfo, origin *core.RegionInfo) (*Operator, error) {
+	b := NewBuilder(desc, clusterInfo, origin, SkipOriginJointStateCheck)
 
 	if b.err == nil && !core.IsInJointState(origin.GetPeers()...) {
 		b.err = errors.Errorf("cannot build leave joint state operator for region which is not in joint state")

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -159,8 +159,6 @@ func (s *testCreateOperatorSuite) TestCreateSplitRegionOperator(c *C) {
 }
 
 func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
-	// use joint consensus
-	s.cluster.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.JointConsensus))
 	type testCase struct {
 		sourcePeers   []*metapb.Peer // first is leader
 		targetPeers   []*metapb.Peer // first is leader
@@ -566,8 +564,6 @@ func (s *testCreateOperatorSuite) TestCreateLeaveJointStateOperator(c *C) {
 }
 
 func (s *testCreateOperatorSuite) TestCreateMoveRegionOperator(c *C) {
-	// use joint consensus
-	s.cluster.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.JointConsensus))
 	type testCase struct {
 		name            string
 		originPeers     []*metapb.Peer // first is leader

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -159,6 +159,8 @@ func (s *testCreateOperatorSuite) TestCreateSplitRegionOperator(c *C) {
 }
 
 func (s *testCreateOperatorSuite) TestCreateMergeRegionOperator(c *C) {
+	// use joint consensus
+	s.cluster.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.JointConsensus))
 	type testCase struct {
 		sourcePeers   []*metapb.Peer // first is leader
 		targetPeers   []*metapb.Peer // first is leader
@@ -564,6 +566,8 @@ func (s *testCreateOperatorSuite) TestCreateLeaveJointStateOperator(c *C) {
 }
 
 func (s *testCreateOperatorSuite) TestCreateMoveRegionOperator(c *C) {
+	// use joint consensus
+	s.cluster.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.JointConsensus))
 	type testCase struct {
 		name            string
 		originPeers     []*metapb.Peer // first is leader

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -30,14 +30,12 @@ import (
 	"go.uber.org/zap"
 )
 
-type checkStoreStateFn func(id uint64) error
-
 // OpStep describes the basic scheduling steps that can not be subdivided.
 type OpStep interface {
 	fmt.Stringer
 	ConfVerChanged(region *core.RegionInfo) uint64
 	IsFinish(region *core.RegionInfo) bool
-	CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error
+	CheckInProgress(ci ClusterInformer, region *core.RegionInfo) error
 	Influence(opInfluence OpInfluence, region *core.RegionInfo)
 }
 
@@ -69,7 +67,7 @@ func (tl TransferLeader) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (tl TransferLeader) CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error {
+func (tl TransferLeader) CheckInProgress(ci ClusterInformer, region *core.RegionInfo) error {
 	errList := make([]error, 0, len(tl.ToStores)+1)
 	for _, storeID := range append(tl.ToStores, tl.ToStore) {
 		peer := region.GetStorePeer(tl.ToStore)
@@ -81,7 +79,7 @@ func (tl TransferLeader) CheckInProgress(f checkStoreStateFn, region *core.Regio
 			errList = append(errList, errors.New("peer already is a learner"))
 			continue
 		}
-		if err := f(storeID); err != nil {
+		if err := validateStore(ci, storeID); err != nil {
 			errList = append(errList, err)
 			continue
 		}
@@ -143,8 +141,8 @@ func (ap AddPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (ap AddPeer) CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error {
-	if err := f(ap.ToStore); err != nil {
+func (ap AddPeer) CheckInProgress(ci ClusterInformer, region *core.RegionInfo) error {
+	if err := validateStore(ci, ap.ToStore); err != nil {
 		return err
 	}
 	peer := region.GetStorePeer(ap.ToStore)
@@ -183,8 +181,8 @@ func (al AddLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (al AddLearner) CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error {
-	if err := f(al.ToStore); err != nil {
+func (al AddLearner) CheckInProgress(ci ClusterInformer, region *core.RegionInfo) error {
+	if err := validateStore(ci, al.ToStore); err != nil {
 		return err
 	}
 	peer := region.GetStorePeer(al.ToStore)
@@ -240,7 +238,7 @@ func (pl PromoteLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (pl PromoteLearner) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
+func (pl PromoteLearner) CheckInProgress(_ ClusterInformer, region *core.RegionInfo) error {
 	peer := region.GetStorePeer(pl.ToStore)
 	if peer.GetId() != pl.PeerID {
 		return errors.New("peer does not exist")
@@ -281,7 +279,7 @@ func (rp RemovePeer) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (rp RemovePeer) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
+func (rp RemovePeer) CheckInProgress(_ ClusterInformer, region *core.RegionInfo) error {
 	if rp.FromStore == region.GetLeader().GetStoreId() {
 		return errors.New("cannot remove leader peer")
 	}
@@ -333,7 +331,7 @@ func (mr MergeRegion) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (mr MergeRegion) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
+func (mr MergeRegion) CheckInProgress(_ ClusterInformer, region *core.RegionInfo) error {
 	return nil
 }
 
@@ -383,7 +381,7 @@ func (sr SplitRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (sr SplitRegion) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
+func (sr SplitRegion) CheckInProgress(_ ClusterInformer, region *core.RegionInfo) error {
 	return nil
 }
 
@@ -473,7 +471,7 @@ func (cpe ChangePeerV2Enter) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpe ChangePeerV2Enter) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
+func (cpe ChangePeerV2Enter) CheckInProgress(_ ClusterInformer, region *core.RegionInfo) error {
 	inJointState, notInJointState := false, false
 	for _, pl := range cpe.PromoteLearners {
 		peer := region.GetStorePeer(pl.ToStore)
@@ -613,7 +611,7 @@ func (cpl ChangePeerV2Leave) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpl ChangePeerV2Leave) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
+func (cpl ChangePeerV2Leave) CheckInProgress(_ ClusterInformer, region *core.RegionInfo) error {
 	inJointState, notInJointState, demoteLeader := false, false, false
 	leaderStoreID := region.GetLeader().GetStoreId()
 
@@ -673,3 +671,14 @@ func (cpl ChangePeerV2Leave) CheckInProgress(_ checkStoreStateFn, region *core.R
 
 // Influence calculates the store difference that current step makes.
 func (cpl ChangePeerV2Leave) Influence(opInfluence OpInfluence, region *core.RegionInfo) {}
+
+func validateStore(ci ClusterInformer, id uint64) error {
+	store := ci.GetBasicCluster().GetStore(id)
+	if store == nil {
+		return errors.New("target store does not exist")
+	}
+	if store.DownTime() > ci.GetOpts().GetMaxStoreDownTime() {
+		return errors.New("target store is down")
+	}
+	return nil
+}

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/core/storelimit"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -36,7 +35,7 @@ type OpStep interface {
 	fmt.Stringer
 	ConfVerChanged(region *core.RegionInfo) uint64
 	IsFinish(region *core.RegionInfo) bool
-	CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error
+	CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error
 	Influence(opInfluence OpInfluence, region *core.RegionInfo)
 }
 
@@ -68,7 +67,7 @@ func (tl TransferLeader) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (tl TransferLeader) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
+func (tl TransferLeader) CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error {
 	errList := make([]error, 0, len(tl.ToStores)+1)
 	for _, storeID := range append(tl.ToStores, tl.ToStore) {
 		peer := region.GetStorePeer(tl.ToStore)
@@ -80,7 +79,7 @@ func (tl TransferLeader) CheckInProgress(cluster opt.Cluster, region *core.Regio
 			errList = append(errList, errors.New("peer already is a learner"))
 			continue
 		}
-		if err := validateStore(cluster, storeID); err != nil {
+		if err := checkFn(storeID); err != nil {
 			errList = append(errList, err)
 			continue
 		}
@@ -142,8 +141,8 @@ func (ap AddPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (ap AddPeer) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
-	if err := validateStore(cluster, ap.ToStore); err != nil {
+func (ap AddPeer) CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error {
+	if err := checkFn(ap.ToStore); err != nil {
 		return err
 	}
 	peer := region.GetStorePeer(ap.ToStore)
@@ -182,8 +181,8 @@ func (al AddLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (al AddLearner) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
-	if err := validateStore(cluster, al.ToStore); err != nil {
+func (al AddLearner) CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error {
+	if err := checkFn(al.ToStore); err != nil {
 		return err
 	}
 	peer := region.GetStorePeer(al.ToStore)
@@ -239,7 +238,7 @@ func (pl PromoteLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (pl PromoteLearner) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
+func (pl PromoteLearner) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
 	peer := region.GetStorePeer(pl.ToStore)
 	if peer.GetId() != pl.PeerID {
 		return errors.New("peer does not exist")
@@ -280,7 +279,7 @@ func (rp RemovePeer) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (rp RemovePeer) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
+func (rp RemovePeer) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
 	if rp.FromStore == region.GetLeader().GetStoreId() {
 		return errors.New("cannot remove leader peer")
 	}
@@ -332,7 +331,7 @@ func (mr MergeRegion) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (mr MergeRegion) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
+func (mr MergeRegion) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
 	return nil
 }
 
@@ -382,7 +381,7 @@ func (sr SplitRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (sr SplitRegion) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
+func (sr SplitRegion) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
 	return nil
 }
 
@@ -472,7 +471,7 @@ func (cpe ChangePeerV2Enter) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpe ChangePeerV2Enter) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
+func (cpe ChangePeerV2Enter) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
 	inJointState, notInJointState := false, false
 	for _, pl := range cpe.PromoteLearners {
 		peer := region.GetStorePeer(pl.ToStore)
@@ -612,7 +611,7 @@ func (cpl ChangePeerV2Leave) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpl ChangePeerV2Leave) CheckInProgress(cluster opt.Cluster, region *core.RegionInfo) error {
+func (cpl ChangePeerV2Leave) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
 	inJointState, notInJointState, demoteLeader := false, false, false
 	leaderStoreID := region.GetLeader().GetStoreId()
 
@@ -672,14 +671,3 @@ func (cpl ChangePeerV2Leave) CheckInProgress(cluster opt.Cluster, region *core.R
 
 // Influence calculates the store difference that current step makes.
 func (cpl ChangePeerV2Leave) Influence(opInfluence OpInfluence, region *core.RegionInfo) {}
-
-func validateStore(cluster opt.Cluster, id uint64) error {
-	store := cluster.GetStore(id)
-	if store == nil {
-		return errors.New("target store does not exist")
-	}
-	if store.DownTime() > cluster.GetOpts().GetMaxStoreDownTime() {
-		return errors.New("target store is down")
-	}
-	return nil
-}

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -30,12 +30,14 @@ import (
 	"go.uber.org/zap"
 )
 
+type checkStoreStateFn func(id uint64) error
+
 // OpStep describes the basic scheduling steps that can not be subdivided.
 type OpStep interface {
 	fmt.Stringer
 	ConfVerChanged(region *core.RegionInfo) uint64
 	IsFinish(region *core.RegionInfo) bool
-	CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error
+	CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error
 	Influence(opInfluence OpInfluence, region *core.RegionInfo)
 }
 
@@ -67,7 +69,7 @@ func (tl TransferLeader) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (tl TransferLeader) CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error {
+func (tl TransferLeader) CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error {
 	errList := make([]error, 0, len(tl.ToStores)+1)
 	for _, storeID := range append(tl.ToStores, tl.ToStore) {
 		peer := region.GetStorePeer(tl.ToStore)
@@ -79,7 +81,7 @@ func (tl TransferLeader) CheckInProgress(checkFn func(id uint64) error, region *
 			errList = append(errList, errors.New("peer already is a learner"))
 			continue
 		}
-		if err := checkFn(storeID); err != nil {
+		if err := f(storeID); err != nil {
 			errList = append(errList, err)
 			continue
 		}
@@ -141,8 +143,8 @@ func (ap AddPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (ap AddPeer) CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error {
-	if err := checkFn(ap.ToStore); err != nil {
+func (ap AddPeer) CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error {
+	if err := f(ap.ToStore); err != nil {
 		return err
 	}
 	peer := region.GetStorePeer(ap.ToStore)
@@ -181,8 +183,8 @@ func (al AddLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (al AddLearner) CheckInProgress(checkFn func(id uint64) error, region *core.RegionInfo) error {
-	if err := checkFn(al.ToStore); err != nil {
+func (al AddLearner) CheckInProgress(f checkStoreStateFn, region *core.RegionInfo) error {
+	if err := f(al.ToStore); err != nil {
 		return err
 	}
 	peer := region.GetStorePeer(al.ToStore)
@@ -238,7 +240,7 @@ func (pl PromoteLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (pl PromoteLearner) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
+func (pl PromoteLearner) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
 	peer := region.GetStorePeer(pl.ToStore)
 	if peer.GetId() != pl.PeerID {
 		return errors.New("peer does not exist")
@@ -279,7 +281,7 @@ func (rp RemovePeer) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (rp RemovePeer) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
+func (rp RemovePeer) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
 	if rp.FromStore == region.GetLeader().GetStoreId() {
 		return errors.New("cannot remove leader peer")
 	}
@@ -331,7 +333,7 @@ func (mr MergeRegion) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (mr MergeRegion) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
+func (mr MergeRegion) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
 	return nil
 }
 
@@ -381,7 +383,7 @@ func (sr SplitRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (sr SplitRegion) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
+func (sr SplitRegion) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
 	return nil
 }
 
@@ -471,7 +473,7 @@ func (cpe ChangePeerV2Enter) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpe ChangePeerV2Enter) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
+func (cpe ChangePeerV2Enter) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
 	inJointState, notInJointState := false, false
 	for _, pl := range cpe.PromoteLearners {
 		peer := region.GetStorePeer(pl.ToStore)
@@ -611,7 +613,7 @@ func (cpl ChangePeerV2Leave) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpl ChangePeerV2Leave) CheckInProgress(_ func(id uint64) error, region *core.RegionInfo) error {
+func (cpl ChangePeerV2Leave) CheckInProgress(_ checkStoreStateFn, region *core.RegionInfo) error {
 	inJointState, notInJointState, demoteLeader := false, false, false
 	leaderStoreID := region.GetLeader().GetStoreId()
 

--- a/server/schedule/operator/step_test.go
+++ b/server/schedule/operator/step_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/server/config"
@@ -421,15 +420,6 @@ func (s *testStepSuite) check(c *C, step OpStep, desc string, cases []testCase) 
 		region := core.NewRegionInfo(&metapb.Region{Id: 1, Peers: tc.Peers}, tc.Peers[0])
 		c.Assert(step.ConfVerChanged(region), Equals, tc.ConfVerChanged)
 		c.Assert(step.IsFinish(region), Equals, tc.IsFinish)
-		c.Assert(step.CheckInProgress(func(id uint64) error {
-			store := s.cluster.GetStore(id)
-			if store == nil {
-				return errors.New("target store does not exist")
-			}
-			if store.DownTime() > s.cluster.GetOpts().GetMaxStoreDownTime() {
-				return errors.New("target store is down")
-			}
-			return nil
-		}, region), tc.CheckInProgres)
+		c.Assert(step.CheckInProgress(s.cluster, region), tc.CheckInProgres)
 	}
 }

--- a/server/schedule/operator/step_test.go
+++ b/server/schedule/operator/step_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/server/config"
@@ -420,6 +421,15 @@ func (s *testStepSuite) check(c *C, step OpStep, desc string, cases []testCase) 
 		region := core.NewRegionInfo(&metapb.Region{Id: 1, Peers: tc.Peers}, tc.Peers[0])
 		c.Assert(step.ConfVerChanged(region), Equals, tc.ConfVerChanged)
 		c.Assert(step.IsFinish(region), Equals, tc.IsFinish)
-		c.Assert(step.CheckInProgress(s.cluster, region), tc.CheckInProgres)
+		c.Assert(step.CheckInProgress(func(id uint64) error {
+			store := s.cluster.GetStore(id)
+			if store == nil {
+				return errors.New("target store does not exist")
+			}
+			if store.DownTime() > s.cluster.GetOpts().GetMaxStoreDownTime() {
+				return errors.New("target store is down")
+			}
+			return nil
+		}, region), tc.CheckInProgres)
 	}
 }

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -160,7 +160,7 @@ func (oc *OperatorController) Dispatch(region *core.RegionInfo, source string) {
 }
 
 func (oc *OperatorController) checkStaleOperator(op *operator.Operator, step operator.OpStep, region *core.RegionInfo) bool {
-	checkFn := func(id uint64) error {
+	checkStoreStateFn := func(id uint64) error {
 		store := oc.cluster.GetStore(id)
 		if store == nil {
 			return errors.New("target store does not exist")
@@ -171,7 +171,7 @@ func (oc *OperatorController) checkStaleOperator(op *operator.Operator, step ope
 		return nil
 	}
 
-	err := step.CheckInProgress(checkFn, region)
+	err := step.CheckInProgress(checkStoreStateFn, region)
 	if err != nil {
 		if oc.RemoveOperator(op, zap.String("reason", err.Error())) {
 			operatorCounter.WithLabelValues(op.Desc(), "stale").Inc()

--- a/server/schedule/range_cluster.go
+++ b/server/schedule/range_cluster.go
@@ -18,19 +18,18 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/tikv/pd/server/core"
-	"github.com/tikv/pd/server/schedule/opt"
 )
 
 // RangeCluster isolates the cluster by range.
 type RangeCluster struct {
-	opt.Cluster
+	Cluster
 	subCluster        *core.BasicCluster // Collect all regions belong to the range.
 	tolerantSizeRatio float64
 }
 
 // GenRangeCluster gets a range cluster by specifying start key and end key.
 // The cluster can only know the regions within [startKey, endKey].
-func GenRangeCluster(cluster opt.Cluster, startKey, endKey []byte) *RangeCluster {
+func GenRangeCluster(cluster Cluster, startKey, endKey []byte) *RangeCluster {
 	subCluster := core.NewBasicCluster()
 	for _, r := range cluster.ScanRegions(startKey, endKey, -1) {
 		subCluster.Regions.SetRegion(r)

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -31,7 +31,6 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -118,14 +117,14 @@ func (s *selectedStores) getDistributionByGroupLocked(group string) (map[uint64]
 type RegionScatterer struct {
 	ctx            context.Context
 	name           string
-	cluster        opt.Cluster
+	cluster        Cluster
 	ordinaryEngine engineContext
 	specialEngines map[string]engineContext
 }
 
 // NewRegionScatterer creates a region scatterer.
 // RegionScatter is used for the `Lightning`, it will scatter the specified regions before import data.
-func NewRegionScatterer(ctx context.Context, cluster opt.Cluster) *RegionScatterer {
+func NewRegionScatterer(ctx context.Context, cluster Cluster) *RegionScatterer {
 	return &RegionScatterer{
 		ctx:            ctx,
 		name:           regionScatterName,
@@ -365,7 +364,7 @@ func (r *RegionScatterer) selectCandidates(region *core.RegionInfo, sourceStoreI
 	filters := []filter.Filter{
 		filter.NewExcludedFilter(r.name, nil, selectedStores),
 	}
-	scoreGuard := filter.NewPlacementSafeguard(r.name, r.cluster, region, sourceStore)
+	scoreGuard := filter.NewPlacementSafeguard(r.name, r.cluster.GetOpts(), r.cluster.GetBasicCluster(), r.cluster.GetRuleManager(), region, sourceStore)
 	filters = append(filters, context.filters...)
 	filters = append(filters, scoreGuard)
 	stores := r.cluster.GetStores()

--- a/server/schedule/region_splitter.go
+++ b/server/schedule/region_splitter.go
@@ -28,7 +28,6 @@ import (
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -44,7 +43,7 @@ type SplitRegionsHandler interface {
 }
 
 // NewSplitRegionsHandler return SplitRegionsHandler
-func NewSplitRegionsHandler(cluster opt.Cluster, oc *OperatorController) SplitRegionsHandler {
+func NewSplitRegionsHandler(cluster Cluster, oc *OperatorController) SplitRegionsHandler {
 	return &splitRegionsHandler{
 		cluster: cluster,
 		oc:      oc,
@@ -53,12 +52,12 @@ func NewSplitRegionsHandler(cluster opt.Cluster, oc *OperatorController) SplitRe
 
 // RegionSplitter handles split regions
 type RegionSplitter struct {
-	cluster opt.Cluster
+	cluster Cluster
 	handler SplitRegionsHandler
 }
 
 // NewRegionSplitter return a region splitter
-func NewRegionSplitter(cluster opt.Cluster, handler SplitRegionsHandler) *RegionSplitter {
+func NewRegionSplitter(cluster Cluster, handler SplitRegionsHandler) *RegionSplitter {
 	return &RegionSplitter{
 		cluster: cluster,
 		handler: handler,
@@ -177,7 +176,7 @@ func (r *RegionSplitter) checkRegionValid(region *core.RegionInfo) bool {
 }
 
 type splitRegionsHandler struct {
-	cluster opt.Cluster
+	cluster Cluster
 	oc      *OperatorController
 }
 

--- a/server/schedule/scheduler.go
+++ b/server/schedule/scheduler.go
@@ -26,7 +26,6 @@ import (
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -39,10 +38,10 @@ type Scheduler interface {
 	EncodeConfig() ([]byte, error)
 	GetMinInterval() time.Duration
 	GetNextInterval(interval time.Duration) time.Duration
-	Prepare(cluster opt.Cluster) error
-	Cleanup(cluster opt.Cluster)
-	Schedule(cluster opt.Cluster) []*operator.Operator
-	IsScheduleAllowed(cluster opt.Cluster) bool
+	Prepare(cluster Cluster) error
+	Cleanup(cluster Cluster)
+	Schedule(cluster Cluster) []*operator.Operator
+	IsScheduleAllowed(cluster Cluster) bool
 }
 
 // EncodeConfig encode the custom config for each scheduler.

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -26,7 +26,6 @@ import (
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -130,7 +129,7 @@ func (s *balanceRegionScheduler) EncodeConfig() ([]byte, error) {
 	return schedule.EncodeConfig(s.conf)
 }
 
-func (s *balanceRegionScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (s *balanceRegionScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	allowed := s.opController.OperatorCount(operator.OpRegion) < cluster.GetOpts().GetRegionScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpRegion.String()).Inc()
@@ -138,7 +137,7 @@ func (s *balanceRegionScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (s *balanceRegionScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+func (s *balanceRegionScheduler) Schedule(cluster schedule.Cluster) []*operator.Operator {
 	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
 	stores := cluster.GetStores()
 	opts := cluster.GetOpts()
@@ -219,15 +218,15 @@ func (s *balanceRegionScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 func (s *balanceRegionScheduler) transferPeer(plan *balancePlan) *operator.Operator {
 	filters := []filter.Filter{
 		filter.NewExcludedFilter(s.GetName(), nil, plan.region.GetStoreIds()),
-		filter.NewPlacementSafeguard(s.GetName(), plan.cluster, plan.region, plan.source),
-		filter.NewRegionScoreFilter(s.GetName(), plan.source, plan.cluster.GetOpts()),
+		filter.NewPlacementSafeguard(s.GetName(), plan.GetOpts(), plan.GetBasicCluster(), plan.GetRuleManager(), plan.region, plan.source),
+		filter.NewRegionScoreFilter(s.GetName(), plan.source, plan.GetOpts()),
 		filter.NewSpecialUseFilter(s.GetName()),
 		&filter.StoreStateFilter{ActionScope: s.GetName(), MoveRegion: true},
 	}
 
-	candidates := filter.NewCandidates(plan.cluster.GetStores()).
-		FilterTarget(plan.cluster.GetOpts(), filters...).
-		Sort(filter.RegionScoreComparer(plan.cluster.GetOpts()))
+	candidates := filter.NewCandidates(plan.GetStores()).
+		FilterTarget(plan.GetOpts(), filters...).
+		Sort(filter.RegionScoreComparer(plan.GetOpts()))
 
 	for _, plan.target = range candidates.Stores {
 		regionID := plan.region.GetID()
@@ -242,7 +241,7 @@ func (s *balanceRegionScheduler) transferPeer(plan *balancePlan) *operator.Opera
 
 		oldPeer := plan.region.GetStorePeer(sourceID)
 		newPeer := &metapb.Peer{StoreId: plan.target.GetID(), Role: oldPeer.Role}
-		op, err := operator.CreateMovePeerOperator(BalanceRegionType, plan.cluster, plan.region, operator.OpRegion, oldPeer.GetStoreId(), newPeer)
+		op, err := operator.CreateMovePeerOperator(BalanceRegionType, plan, plan.region, operator.OpRegion, oldPeer.GetStoreId(), newPeer)
 		if err != nil {
 			schedulerCounter.WithLabelValues(s.GetName(), "create-operator-fail").Inc()
 			return nil
@@ -264,11 +263,11 @@ func (s *balanceRegionScheduler) transferPeer(plan *balancePlan) *operator.Opera
 }
 
 // isEmptyRegionAllowBalance checks if a region is an empty region and can be balanced.
-func isEmptyRegionAllowBalance(cluster opt.Cluster, region *core.RegionInfo) bool {
+func isEmptyRegionAllowBalance(cluster schedule.Cluster, region *core.RegionInfo) bool {
 	return region.GetApproximateSize() > core.EmptyRegionApproximateSize || cluster.GetRegionCount() < balanceEmptyRegionThreshold
 }
 
 // isAllowBalanceEmptyRegion returns a function that checks if a region is an empty region and can be balanced.
-func isAllowBalanceEmptyRegion(cluster opt.Cluster) func(*core.RegionInfo) bool {
+func isAllowBalanceEmptyRegion(cluster schedule.Cluster) func(*core.RegionInfo) bool {
 	return func(region *core.RegionInfo) bool { return isEmptyRegionAllowBalance(cluster, region) }
 }

--- a/server/schedulers/base_scheduler.go
+++ b/server/schedulers/base_scheduler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server/schedule"
-	"github.com/tikv/pd/server/schedule/opt"
 )
 
 // options for interval of schedulers
@@ -88,7 +87,7 @@ func (s *BaseScheduler) GetNextInterval(interval time.Duration) time.Duration {
 }
 
 // Prepare does some prepare work
-func (s *BaseScheduler) Prepare(cluster opt.Cluster) error { return nil }
+func (s *BaseScheduler) Prepare(cluster schedule.Cluster) error { return nil }
 
 // Cleanup does some cleanup work
-func (s *BaseScheduler) Cleanup(cluster opt.Cluster) {}
+func (s *BaseScheduler) Cleanup(cluster schedule.Cluster) {}

--- a/server/schedulers/grant_leader.go
+++ b/server/schedulers/grant_leader.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/unrolled/render"
 )
 
@@ -77,7 +76,7 @@ type grantLeaderSchedulerConfig struct {
 	mu                sync.RWMutex
 	storage           *core.Storage
 	StoreIDWithRanges map[uint64][]core.KeyRange `json:"store-id-ranges"`
-	cluster           opt.Cluster
+	cluster           schedule.Cluster
 }
 
 func (conf *grantLeaderSchedulerConfig) BuildWithArgs(args []string) error {
@@ -198,7 +197,7 @@ func (s *grantLeaderScheduler) EncodeConfig() ([]byte, error) {
 	return schedule.EncodeConfig(s.conf)
 }
 
-func (s *grantLeaderScheduler) Prepare(cluster opt.Cluster) error {
+func (s *grantLeaderScheduler) Prepare(cluster schedule.Cluster) error {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	var res error
@@ -210,7 +209,7 @@ func (s *grantLeaderScheduler) Prepare(cluster opt.Cluster) error {
 	return res
 }
 
-func (s *grantLeaderScheduler) Cleanup(cluster opt.Cluster) {
+func (s *grantLeaderScheduler) Cleanup(cluster schedule.Cluster) {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	for id := range s.conf.StoreIDWithRanges {
@@ -218,7 +217,7 @@ func (s *grantLeaderScheduler) Cleanup(cluster opt.Cluster) {
 	}
 }
 
-func (s *grantLeaderScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (s *grantLeaderScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
@@ -226,7 +225,7 @@ func (s *grantLeaderScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (s *grantLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+func (s *grantLeaderScheduler) Schedule(cluster schedule.Cluster) []*operator.Operator {
 	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -29,7 +29,6 @@ import (
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/tikv/pd/server/statistics"
 	"github.com/tikv/pd/server/versioninfo"
 	"github.com/unrolled/render"
@@ -351,7 +350,7 @@ func (conf *hotRegionSchedulerConfig) persistLocked() error {
 	return conf.storage.SaveScheduleConfig(HotRegionName, data)
 }
 
-func (conf *hotRegionSchedulerConfig) checkQuerySupport(cluster opt.Cluster) bool {
+func (conf *hotRegionSchedulerConfig) checkQuerySupport(cluster schedule.Cluster) bool {
 	querySupport := versioninfo.IsFeatureSupported(cluster.GetOpts().GetClusterVersion(), versioninfo.HotScheduleWithQuery)
 	conf.Lock()
 	defer conf.Unlock()

--- a/server/schedulers/label.go
+++ b/server/schedulers/label.go
@@ -22,7 +22,6 @@ import (
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"go.uber.org/zap"
 )
 
@@ -91,7 +90,7 @@ func (s *labelScheduler) EncodeConfig() ([]byte, error) {
 	return schedule.EncodeConfig(s.conf)
 }
 
-func (s *labelScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (s *labelScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
@@ -99,7 +98,7 @@ func (s *labelScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (s *labelScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+func (s *labelScheduler) Schedule(cluster schedule.Cluster) []*operator.Operator {
 	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
 	stores := cluster.GetStores()
 	rejectLeaderStores := make(map[uint64]struct{})

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tikv/pd/server/schedule/checker"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 )
 
 const (
@@ -91,7 +90,7 @@ func (s *randomMergeScheduler) EncodeConfig() ([]byte, error) {
 	return schedule.EncodeConfig(s.conf)
 }
 
-func (s *randomMergeScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (s *randomMergeScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	allowed := s.OpController.OperatorCount(operator.OpMerge) < cluster.GetOpts().GetMergeScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpMerge.String()).Inc()
@@ -99,7 +98,7 @@ func (s *randomMergeScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (s *randomMergeScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster) []*operator.Operator {
 	schedulerCounter.WithLabelValues(s.GetName(), "schedule").Inc()
 
 	store := filter.NewCandidates(cluster.GetStores()).
@@ -138,7 +137,7 @@ func (s *randomMergeScheduler) Schedule(cluster opt.Cluster) []*operator.Operato
 	return ops
 }
 
-func (s *randomMergeScheduler) allowMerge(cluster opt.Cluster, region, target *core.RegionInfo) bool {
+func (s *randomMergeScheduler) allowMerge(cluster schedule.Cluster, region, target *core.RegionInfo) bool {
 	if !schedule.IsRegionHealthy(region) || !schedule.IsRegionHealthy(target) {
 		return false
 	}

--- a/server/schedulers/scatter_range.go
+++ b/server/schedulers/scatter_range.go
@@ -26,7 +26,6 @@ import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 	"github.com/unrolled/render"
 )
 
@@ -193,11 +192,11 @@ func (l *scatterRangeScheduler) EncodeConfig() ([]byte, error) {
 	return schedule.EncodeConfig(l.config)
 }
 
-func (l *scatterRangeScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (l *scatterRangeScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	return l.allowBalanceLeader(cluster) || l.allowBalanceRegion(cluster)
 }
 
-func (l *scatterRangeScheduler) allowBalanceLeader(cluster opt.Cluster) bool {
+func (l *scatterRangeScheduler) allowBalanceLeader(cluster schedule.Cluster) bool {
 	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(l.GetType(), operator.OpLeader.String()).Inc()
@@ -205,7 +204,7 @@ func (l *scatterRangeScheduler) allowBalanceLeader(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (l *scatterRangeScheduler) allowBalanceRegion(cluster opt.Cluster) bool {
+func (l *scatterRangeScheduler) allowBalanceRegion(cluster schedule.Cluster) bool {
 	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetRegionScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(l.GetType(), operator.OpRegion.String()).Inc()
@@ -213,7 +212,7 @@ func (l *scatterRangeScheduler) allowBalanceRegion(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (l *scatterRangeScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+func (l *scatterRangeScheduler) Schedule(cluster schedule.Cluster) []*operator.Operator {
 	schedulerCounter.WithLabelValues(l.GetName(), "schedule").Inc()
 	// isolate a new cluster according to the key range
 	c := schedule.GenRangeCluster(cluster, l.config.GetStartKey(), l.config.GetEndKey())

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -21,7 +21,6 @@ import (
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/operator"
-	"github.com/tikv/pd/server/schedule/opt"
 )
 
 const (
@@ -95,7 +94,7 @@ func (s *shuffleLeaderScheduler) EncodeConfig() ([]byte, error) {
 	return schedule.EncodeConfig(s.conf)
 }
 
-func (s *shuffleLeaderScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
+func (s *shuffleLeaderScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
@@ -103,7 +102,7 @@ func (s *shuffleLeaderScheduler) IsScheduleAllowed(cluster opt.Cluster) bool {
 	return allowed
 }
 
-func (s *shuffleLeaderScheduler) Schedule(cluster opt.Cluster) []*operator.Operator {
+func (s *shuffleLeaderScheduler) Schedule(cluster schedule.Cluster) []*operator.Operator {
 	// We shuffle leaders between stores by:
 	// 1. random select a valid store.
 	// 2. transfer a leader to the store.

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -173,21 +173,21 @@ func testPutStore(c *C, clusterID uint64, rc *cluster.RaftCluster, grpcPDClient 
 	_, err = putStore(grpcPDClient, clusterID, store)
 	c.Assert(err, IsNil)
 
-	rc.AllocID()
-	id, err := rc.AllocID()
+	rc.GetAllocator().Alloc()
+	id, err := rc.GetAllocator().Alloc()
 	c.Assert(err, IsNil)
 	// Put new store with a duplicated address when old store is up will fail.
 	_, err = putStore(grpcPDClient, clusterID, newMetaStore(id, store.GetAddress(), "2.1.0", metapb.StoreState_Up, getTestDeployPath(id)))
 	c.Assert(err, NotNil)
 
-	id, err = rc.AllocID()
+	id, err = rc.GetAllocator().Alloc()
 	c.Assert(err, IsNil)
 	// Put new store with a duplicated address when old store is offline will fail.
 	resetStoreState(c, rc, store.GetId(), metapb.StoreState_Offline)
 	_, err = putStore(grpcPDClient, clusterID, newMetaStore(id, store.GetAddress(), "2.1.0", metapb.StoreState_Up, getTestDeployPath(id)))
 	c.Assert(err, NotNil)
 
-	id, err = rc.AllocID()
+	id, err = rc.GetAllocator().Alloc()
 	c.Assert(err, IsNil)
 	// Put new store with a duplicated address when old store is tombstone is OK.
 	resetStoreState(c, rc, store.GetId(), metapb.StoreState_Tombstone)
@@ -195,7 +195,7 @@ func testPutStore(c *C, clusterID uint64, rc *cluster.RaftCluster, grpcPDClient 
 	_, err = putStore(grpcPDClient, clusterID, newMetaStore(id, store.GetAddress(), "2.1.0", metapb.StoreState_Up, getTestDeployPath(id)))
 	c.Assert(err, IsNil)
 
-	id, err = rc.AllocID()
+	id, err = rc.GetAllocator().Alloc()
 	c.Assert(err, IsNil)
 	deployPath := getTestDeployPath(id)
 	// Put a new store.


### PR DESCRIPTION
### What problem does this PR solve?

Close #4340.

### What is changed and how it works?

This PR moves the `Cluster` interface into the `schedule` package and creates a new subinterface `ClusterInfo` to get necessary cluster information in `operator` package. Also, this PR remove some locks which could be unnecessary. It needs to be reviewed carefully.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
