### PR TITLE
region_scatterer: fix the bug that could generate schedule with too few peers

### DIFF
--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -273,7 +273,7 @@ func (r *RegionScatterer) Scatter(region *core.RegionInfo, group string) (*opera
 
 func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string) *operator.Operator {
 	ordinaryFilter := filter.NewOrdinaryEngineFilter(r.name)
-	ordinaryPeers := make(map[uint64]*metapb.Peer)
+	ordinaryPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
 	specialPeers := make(map[string]map[uint64]*metapb.Peer)
 	// Group peers by the engine of their stores
 	for _, peer := range region.GetPeers() {
@@ -292,8 +292,8 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string) *
 		}
 	}
 
-	targetPeers := make(map[uint64]*metapb.Peer)                                          // StoreID -> Peer
-	selectedStores := make(map[uint64]struct{})                                           // StoreID set
+	targetPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))                  // StoreID -> Peer
+	selectedStores := make(map[uint64]struct{}, len(region.GetPeers()))                   // StoreID set
 	scatterWithSameEngine := func(peers map[uint64]*metapb.Peer, context engineContext) { // peers: StoreID -> Peer
 		for _, peer := range peers {
 			if _, ok := selectedStores[peer.GetStoreId()]; ok {

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -322,6 +322,14 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string) *
 		scatterWithSameEngine(peers, ctx)
 	}
 
+	// If the number of target peers is too small, change it back to the original.
+	if peers := region.GetPeers(); len(peers) != len(targetPeers) {
+		targetPeers = make(map[uint64]*metapb.Peer, len(peers))
+		for _, peer := range peers {
+			targetPeers[peer.GetStoreId()] = peer
+		}
+	}
+
 	if isSameDistribution(region, targetPeers, targetLeader) {
 		scatterCounter.WithLabelValues("unnecessary", "").Inc()
 		r.Put(targetPeers, targetLeader, group)

--- a/server/schedule/region_scatterer_test.go
+++ b/server/schedule/region_scatterer_test.go
@@ -17,6 +17,7 @@ package schedule
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"math"
 	"math/rand"
 	"time"
@@ -489,4 +490,53 @@ func (s *testScatterRegionSuite) TestRegionFromDifferentGroups(c *C) {
 		c.Assert(max-min, LessEqual, uint64(2))
 	}
 	check(scatterer.ordinaryEngine.selectedPeer)
+}
+
+func (s *testScatterRegionSuite) TestSelectedStores(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := config.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	// Add 4 stores.
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		// prevent store from being disconnected
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+	group := "group"
+	scatterer := NewRegionScatterer(ctx, tc)
+
+	// Put a lot of regions in Store 1/2/3.
+	for i := uint64(1); i < 100; i++ {
+		region := tc.AddLeaderRegion(i+10, i%3+1, (i+1)%3+1, (i+2)%3+1)
+		peers := make(map[uint64]*metapb.Peer, 3)
+		for _, peer := range region.GetPeers() {
+			peers[peer.GetStoreId()] = peer
+		}
+		scatterer.Put(peers, i%3+1, group)
+	}
+
+	// Try to scatter a region with peer store id 2/3/4
+	for i := uint64(1); i < 20; i++ {
+		region := tc.AddLeaderRegion(i+200, i%3+2, (i+1)%3+2, (i+2)%3+2)
+		op := scatterer.scatterRegion(region, group)
+		c.Assert(checkPeerCountChanged(op), IsFalse)
+	}
+}
+
+func checkPeerCountChanged(op *operator.Operator) bool {
+	if op == nil {
+		return false
+	}
+	add, remove := 0, 0
+	for i := 0; i < op.Len(); i++ {
+		step := op.Step(i)
+		switch step.(type) {
+		case operator.AddPeer, operator.AddLearner:
+			add++
+		case operator.RemovePeer:
+			remove++
+		}
+	}
+	return add != remove
 }

--- a/server/schedule/region_scatterer_test.go
+++ b/server/schedule/region_scatterer_test.go
@@ -492,6 +492,8 @@ func (s *testScatterRegionSuite) TestRegionFromDifferentGroups(c *C) {
 	check(scatterer.ordinaryEngine.selectedPeer)
 }
 
+// TestSelectedStores tests if the peer count has changed due to the picking strategy.
+// Ref https://github.com/tikv/pd/issues/4565
 func (s *testScatterRegionSuite) TestSelectedStores(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -520,11 +522,11 @@ func (s *testScatterRegionSuite) TestSelectedStores(c *C) {
 	for i := uint64(1); i < 20; i++ {
 		region := tc.AddLeaderRegion(i+200, i%3+2, (i+1)%3+2, (i+2)%3+2)
 		op := scatterer.scatterRegion(region, group)
-		c.Assert(checkPeerCountChanged(op), IsFalse)
+		c.Assert(isPeerCountChanged(op), IsFalse)
 	}
 }
 
-func checkPeerCountChanged(op *operator.Operator) bool {
+func isPeerCountChanged(op *operator.Operator) bool {
 	if op == nil {
 		return false
 	}

--- a/server/schedule/region_scatterer_test.go
+++ b/server/schedule/region_scatterer_test.go
@@ -17,13 +17,13 @@ package schedule
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"math"
 	"math/rand"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->

close #4565

### What is changed and how it works?

If an originPeer is already in `selectStore`, `continue` directly. Otherwise, it will end up picking a `targetPeer` which is either itself or some other store that is not in the initial peer list. Since entering the select phase, it is guaranteed that it is not in the `selectStore`, so it is always guaranteed that the worst-case selection itself is feasible at this time. In the end, the number of peers before and after can be guaranteed to remain unchanged.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

When not modified, the following operator may be generated:

scatter-region {rm peer: store [3]} (kind:region,leader, region:201(0,0), createAt:2022-01-13 18:24:32.375399 +0800 CST m=+0.014571751, startAt:0001-01-01 00:00:00 +0000 UTC, currentStep:0, steps:[transfer leader from store 3 to store 4, remove peer on store 3])

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the bug that the region scatterer may generate the schedule with too few peers.
```
