### PR TITLE
*: unify the root key path joining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,6 @@ static: install-tools
 	@revive -formatter friendly -config revive.toml $(PACKAGES)
 
 tidy:
-	@echo "go mod tidy"
 	go mod tidy
 	git diff --quiet go.mod go.sum
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -96,8 +96,7 @@ type RaftCluster struct {
 
 	running bool
 
-	clusterID   uint64
-	clusterRoot string
+	clusterID uint64
 
 	// cached cluster info
 	core    *core.BasicCluster
@@ -142,12 +141,11 @@ type Status struct {
 }
 
 // NewRaftCluster create a new cluster.
-func NewRaftCluster(ctx context.Context, root string, clusterID uint64, regionSyncer *syncer.RegionSyncer, etcdClient *clientv3.Client, httpClient *http.Client) *RaftCluster {
+func NewRaftCluster(ctx context.Context, clusterID uint64, regionSyncer *syncer.RegionSyncer, etcdClient *clientv3.Client, httpClient *http.Client) *RaftCluster {
 	return &RaftCluster{
 		serverCtx:    ctx,
 		running:      false,
 		clusterID:    clusterID,
-		clusterRoot:  root,
 		regionSyncer: regionSyncer,
 		httpClient:   httpClient,
 		etcdClient:   etcdClient,
@@ -193,11 +191,10 @@ func (c *RaftCluster) GetReplicationConfig() *config.ReplicationConfig {
 }
 
 // loadBootstrapTime loads the saved bootstrap time from etcd. It returns zero
-// value of time.Time when there is error or the cluster is not bootstrapped
-// yet.
+// value of time.Time when there is error or the cluster is not bootstrapped yet.
 func (c *RaftCluster) loadBootstrapTime() (time.Time, error) {
 	var t time.Time
-	data, err := c.storage.Load(endpoint.ClusterStatePath("raft_bootstrap_time"))
+	data, err := c.storage.Load(endpoint.ClusterBootstrapTimeKey())
 	if err != nil {
 		return t, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -56,6 +56,7 @@ import (
 	"github.com/tikv/pd/server/schedule/hbstream"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/storage"
+	"github.com/tikv/pd/server/storage/endpoint"
 	"github.com/tikv/pd/server/storage/kv"
 	"github.com/tikv/pd/server/tso"
 	"github.com/tikv/pd/server/versioninfo"
@@ -389,7 +390,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	defaultStorage := storage.NewStorageWithEtcdBackend(s.client, s.rootPath)
 	s.storage = storage.NewCoreStorage(defaultStorage, regionStorage)
 	s.basicCluster = core.NewBasicCluster()
-	s.cluster = cluster.NewRaftCluster(ctx, s.GetClusterRootPath(), s.clusterID, syncer.NewRegionSyncer(s), s.client, s.httpClient)
+	s.cluster = cluster.NewRaftCluster(ctx, s.clusterID, syncer.NewRegionSyncer(s), s.client, s.httpClient)
 	s.hbStreams = hbstream.NewHeartbeatStreams(ctx, s.clusterID, s.cluster)
 	// initial hot_region_storage in here.
 	hotRegionPath := filepath.Join(s.cfg.DataDir, "hot-region")
@@ -587,13 +588,15 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	clusterRootPath := s.GetClusterRootPath()
+	clusterRootPath := endpoint.ClusterRootPath(s.rootPath)
 
 	var ops []clientv3.Op
 	ops = append(ops, clientv3.OpPut(clusterRootPath, string(clusterValue)))
 
 	// Set bootstrap time
-	bootstrapKey := makeBootstrapTimeKey(clusterRootPath)
+	// Because we will write the cluster meta into etcd directly,
+	// so we need to handle the root key path manually here.
+	bootstrapKey := s.appendToRootPath(endpoint.ClusterBootstrapTimeKey())
 	nano := time.Now().UnixNano()
 
 	timeData := typeutil.Uint64ToBytes(uint64(nano))
@@ -601,7 +604,7 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 
 	// Set store meta
 	storeMeta := req.GetStore()
-	storePath := makeStoreKey(clusterRootPath, storeMeta.GetId())
+	storePath := s.appendToRootPath(endpoint.StorePath(storeMeta.GetId()))
 	storeValue, err := storeMeta.Marshal()
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -614,7 +617,7 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	}
 
 	// Set region meta with region id.
-	regionPath := makeRegionKey(clusterRootPath, req.GetRegion().GetId())
+	regionPath := s.appendToRootPath(endpoint.RegionPath(req.GetRegion().GetId()))
 	ops = append(ops, clientv3.OpPut(regionPath, string(regionValue)))
 
 	// TODO: we must figure out a better way to handle bootstrap failed, maybe intervene manually.
@@ -645,6 +648,10 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	return &pdpb.BootstrapResponse{
 		ReplicationStatus: s.cluster.GetReplicationMode().GetReplicationStatus(),
 	}, nil
+}
+
+func (s *Server) appendToRootPath(key string) string {
+	return path.Join(s.rootPath, key)
 }
 
 func (s *Server) createRaftCluster() error {
@@ -1044,16 +1051,6 @@ func (s *Server) GetClusterVersion() semver.Version {
 // GetTLSConfig get the security config.
 func (s *Server) GetTLSConfig() *grpcutil.TLSConfig {
 	return &s.cfg.Security.TLSConfig
-}
-
-// GetServerRootPath returns the server root path.
-func (s *Server) GetServerRootPath() string {
-	return s.rootPath
-}
-
-// GetClusterRootPath returns the cluster root path.
-func (s *Server) GetClusterRootPath() string {
-	return path.Join(s.rootPath, "raft")
 }
 
 // GetRaftCluster gets Raft cluster.

--- a/server/storage/endpoint/key_path.go
+++ b/server/storage/endpoint/key_path.go
@@ -33,9 +33,14 @@ const (
 	gcWorkerServiceSafePointID = "gc_worker"
 )
 
-// ClusterStatePath returns the path to save an option.
-func ClusterStatePath(option string) string {
-	return path.Join(clusterPath, "status", option)
+// ClusterRootPath appends the `clusterPath` to the rootPath.
+func ClusterRootPath(rootPath string) string {
+	return path.Join(rootPath, clusterPath)
+}
+
+// ClusterBootstrapTimeKey returns the path to save the cluster bootstrap timestamp.
+func ClusterBootstrapTimeKey() string {
+	return path.Join(clusterPath, "status", "raft_bootstrap_time")
 }
 
 func scheduleConfigPath(scheduleName string) string {

--- a/server/storage/endpoint/key_path.go
+++ b/server/storage/endpoint/key_path.go
@@ -33,9 +33,14 @@ const (
 	gcWorkerServiceSafePointID = "gc_worker"
 )
 
+// AppendToRootPath appends the given key to the rootPath.
+func AppendToRootPath(rootPath string, key string) string {
+	return path.Join(rootPath, key)
+}
+
 // ClusterRootPath appends the `clusterPath` to the rootPath.
 func ClusterRootPath(rootPath string) string {
-	return path.Join(rootPath, clusterPath)
+	return AppendToRootPath(rootPath, clusterPath)
 }
 
 // ClusterBootstrapTimeKey returns the path to save the cluster bootstrap timestamp.

--- a/server/util.go
+++ b/server/util.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"path"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -121,22 +120,6 @@ func initOrGetClusterID(c *clientv3.Client, key string) (uint64, error) {
 	}
 
 	return typeutil.BytesToUint64(response.Kvs[0].Value)
-}
-
-func makeStoreKey(clusterRootPath string, storeID uint64) string {
-	return path.Join(clusterRootPath, "s", fmt.Sprintf("%020d", storeID))
-}
-
-func makeRegionKey(clusterRootPath string, regionID uint64) string {
-	return path.Join(clusterRootPath, "r", fmt.Sprintf("%020d", regionID))
-}
-
-func makeRaftClusterStatusPrefix(clusterRootPath string) string {
-	return path.Join(clusterRootPath, "status")
-}
-
-func makeBootstrapTimeKey(clusterRootPath string) string {
-	return path.Join(makeRaftClusterStatusPrefix(clusterRootPath), "raft_bootstrap_time")
 }
 
 func checkBootstrapRequest(clusterID uint64, req *pdpb.BootstrapRequest) error {

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -645,7 +645,7 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	tc.WaitLeader()
 	leaderServer := tc.GetServer(tc.GetLeader())
 	svr := leaderServer.GetServer()
-	rc := cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
+	rc := cluster.NewRaftCluster(s.ctx, svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
 
 	// Cluster is not bootstrapped.
 	rc.InitCluster(svr.GetAllocator(), svr.GetPersistOptions(), svr.GetStorage(), svr.GetBasicCluster())
@@ -686,7 +686,7 @@ func (s *clusterTestSuite) TestLoadClusterInfo(c *C) {
 	}
 	c.Assert(storage.Flush(), IsNil)
 
-	raftCluster = cluster.NewRaftCluster(s.ctx, svr.GetClusterRootPath(), svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
+	raftCluster = cluster.NewRaftCluster(s.ctx, svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
 	raftCluster.InitCluster(mockid.NewIDAllocator(), opt, storage, basicCluster)
 	raftCluster, err = raftCluster.LoadClusterInfo()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Close https://github.com/tikv/pd/issues/4284.

### What is changed and how it works?

Use `server/storage/endpoint/key_path.go` to manage the key path joining.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
