### PR TITLE
api: introduce API v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ docker-image:
 
 swagger-spec: install-tools
 	go mod vendor
-	swag init --parseVendor -generalInfo server/api/router.go --exclude vendor/github.com/pingcap/tidb-dashboard --output docs/swagger
+	swag init --parseVendor --generalInfo server/api/router.go --exclude vendor/github.com/pingcap/tidb-dashboard --output docs/swagger
 	go mod tidy
 	rm -rf vendor
 

--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tikv/pd/pkg/swaggerserver"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/api"
+	"github.com/tikv/pd/server/apiv2"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/join"
 	"go.uber.org/zap"
@@ -92,7 +93,7 @@ func main() {
 
 	// Creates server.
 	ctx, cancel := context.WithCancel(context.Background())
-	serviceBuilders := []server.HandlerBuilder{api.NewHandler, swaggerserver.NewHandler, autoscaling.NewHandler}
+	serviceBuilders := []server.HandlerBuilder{api.NewHandler, apiv2.NewV2Handler, swaggerserver.NewHandler, autoscaling.NewHandler}
 	serviceBuilders = append(serviceBuilders, dashboard.GetServiceBuilders()...)
 	svr, err := server.CreateServer(ctx, cfg, serviceBuilders...)
 	if err != nil {

--- a/errors.toml
+++ b/errors.toml
@@ -596,6 +596,11 @@ error = '''
 service with path [%s] already registered
 '''
 
+["PD:strconv:ErrStrconvParseBool"]
+error = '''
+parse bool error
+'''
+
 ["PD:strconv:ErrStrconvParseFloat"]
 error = '''
 parse float error

--- a/errors.toml
+++ b/errors.toml
@@ -276,6 +276,11 @@ error = '''
 etcd member list failed
 '''
 
+["PD:etcd:ErrEtcdMemberRemove"]
+error = '''
+etcd remove member failed
+'''
+
 ["PD:etcd:ErrEtcdMoveLeader"]
 error = '''
 etcd move leader error
@@ -319,6 +324,11 @@ start etcd failed
 ["PD:filepath:ErrFilePathAbs"]
 error = '''
 failed to convert a path to absolute path
+'''
+
+["PD:gin:ErrBindJSON"]
+error = '''
+bind JSON error
 '''
 
 ["PD:grpc:ErrCloseGRPCConn"]
@@ -589,6 +599,11 @@ cannot set invalid configuration
 ["PD:server:ErrLeaderNil"]
 error = '''
 leader is nil
+'''
+
+["PD:server:ErrServerNotStarted"]
+error = '''
+server not started
 '''
 
 ["PD:server:ErrServiceRegistered"]

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-semver v0.3.0
 	github.com/docker/go-units v0.4.0
+	github.com/gin-gonic/gin v1.7.4
 	github.com/go-echarts/go-echarts v1.0.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.4
@@ -37,6 +38,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.2.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
+	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/http-swagger v0.0.0-20200308142732-58ac5e232fba
 	github.com/swaggo/swag v1.6.6-0.20200529100950-7c765ddd0476
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/aws/aws-sdk-go v1.35.3/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+
 github.com/axw/gocov v1.0.0 h1:YsqYR66hUmilVr23tu8USgnJIJvnwh3n7j5zRn7x4LU=
 github.com/axw/gocov v1.0.0/go.mod h1:LvQpEYiwwIb2nYkXY2fDWhg9/AsYqkhmrCshjlUJECE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
-github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -497,6 +495,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14 h1:PyYN9JH5jY9j6av01SpfRMb+1DWg/i3MbGOKPxJ2wjM=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14/go.mod h1:gxQT6pBGRuIGunNf/+tSOB5OHvguWi8Tbt82WOkf35E=
+github.com/swaggo/gin-swagger v1.2.0 h1:YskZXEiv51fjOMTsXrOetAjrMDfFaXD79PEoQBOe2W0=
 github.com/swaggo/gin-swagger v1.2.0/go.mod h1:qlH2+W7zXGZkczuL+r2nEBR2JTT+/lX05Nn6vPhc7OI=
 github.com/swaggo/http-swagger v0.0.0-20200308142732-58ac5e232fba h1:lUPlXKqgbqT2SVg2Y+eT9mu5wbqMnG+i/+Q9nK7C0Rs=
 github.com/swaggo/http-swagger v0.0.0-20200308142732-58ac5e232fba/go.mod h1:O1lAbCgAAX/KZ80LM/OXwtWFI/5TvZlwxSg8Cq08PV0=

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/server"
 	"github.com/urfave/negroni"
 	"go.uber.org/zap"
@@ -173,18 +174,9 @@ func copyHeader(dst, src http.Header) {
 	for k, vv := range src {
 		values := dst[k]
 		for _, v := range vv {
-			if !contains(values, v) {
+			if !slice.Contains(values, v) {
 				dst.Add(k, v)
 			}
 		}
 	}
-}
-
-func contains(s []string, x string) bool {
-	for _, n := range s {
-		if x == n {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/apiutil/serverapi/middleware.go
+++ b/pkg/apiutil/serverapi/middleware.go
@@ -166,7 +166,6 @@ func (p *customReverseProxies) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 		return
 	}
-
 	http.Error(w, errRedirectFailed, http.StatusInternalServerError)
 }
 

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -318,4 +318,6 @@ var (
 )
 
 // gin errors
-var ErrBindJSON = errors.Normalize("bind JSON error", errors.RFCCodeText("PD:gin:ErrBindJSON"))
+var (
+	ErrBindJSON = errors.Normalize("bind JSON error", errors.RFCCodeText("PD:gin:ErrBindJSON"))
+)

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -208,6 +208,7 @@ var (
 
 // strconv errors
 var (
+	ErrStrconvParseBool  = errors.Normalize("parse bool error", errors.RFCCodeText("PD:strconv:ErrStrconvParseBool"))
 	ErrStrconvParseInt   = errors.Normalize("parse int error", errors.RFCCodeText("PD:strconv:ErrStrconvParseInt"))
 	ErrStrconvParseUint  = errors.Normalize("parse uint error", errors.RFCCodeText("PD:strconv:ErrStrconvParseUint"))
 	ErrStrconvParseFloat = errors.Normalize("parse float error", errors.RFCCodeText("PD:strconv:ErrStrconvParseFloat"))

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -145,6 +145,7 @@ var (
 	ErrLeaderNil             = errors.Normalize("leader is nil", errors.RFCCodeText("PD:server:ErrLeaderNil"))
 	ErrCancelStartEtcd       = errors.Normalize("etcd start canceled", errors.RFCCodeText("PD:server:ErrCancelStartEtcd"))
 	ErrConfigItem            = errors.Normalize("cannot set invalid configuration", errors.RFCCodeText("PD:server:ErrConfiguration"))
+	ErrServerNotStarted      = errors.Normalize("server not started", errors.RFCCodeText("PD:server:ErrServerNotStarted"))
 )
 
 // logutil errors
@@ -198,6 +199,7 @@ var (
 	ErrEtcdWatcherCancel = errors.Normalize("watcher canceled", errors.RFCCodeText("PD:etcd:ErrEtcdWatcherCancel"))
 	ErrCloseEtcdClient   = errors.Normalize("close etcd client failed", errors.RFCCodeText("PD:etcd:ErrCloseEtcdClient"))
 	ErrEtcdMemberList    = errors.Normalize("etcd member list failed", errors.RFCCodeText("PD:etcd:ErrEtcdMemberList"))
+	ErrEtcdMemberRemove  = errors.Normalize("etcd remove member failed", errors.RFCCodeText("PD:etcd:ErrEtcdMemberRemove"))
 )
 
 // dashboard errors
@@ -314,3 +316,6 @@ var (
 	ErrCryptoX509KeyPair        = errors.Normalize("x509 keypair error", errors.RFCCodeText("PD:crypto:ErrCryptoX509KeyPair"))
 	ErrCryptoAppendCertsFromPEM = errors.Normalize("cert pool append certs error", errors.RFCCodeText("PD:crypto:ErrCryptoAppendCertsFromPEM"))
 )
+
+// gin errors
+var ErrBindJSON = errors.Normalize("bind JSON error", errors.RFCCodeText("PD:gin:ErrBindJSON"))

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -104,7 +104,10 @@ func RemoveEtcdMember(client *clientv3.Client, id uint64) (*clientv3.MemberRemov
 	ctx, cancel := context.WithTimeout(client.Ctx(), DefaultRequestTimeout)
 	rmResp, err := client.MemberRemove(ctx, id)
 	cancel()
-	return rmResp, errors.WithStack(err)
+	if err != nil {
+		return rmResp, errs.ErrEtcdMemberRemove.Wrap(err).GenWithStackByCause()
+	}
+	return rmResp, nil
 }
 
 // EtcdKVGet returns the etcd GetResponse by given key or key prefix

--- a/pkg/slice/slice.go
+++ b/pkg/slice/slice.go
@@ -14,7 +14,10 @@
 
 package slice
 
-import "reflect"
+import (
+	"reflect"
+	"strings"
+)
 
 // AnyOf returns true if any element in the slice matches the predict func.
 func AnyOf(s interface{}, p func(int) bool) bool {
@@ -38,4 +41,19 @@ func AllOf(s interface{}, p func(int) bool) bool {
 		return !p(i)
 	}
 	return NoneOf(s, np)
+}
+
+func Contains(slice interface{}, value interface{}) bool {
+	if reflect.TypeOf(slice).Kind() == reflect.Slice || reflect.TypeOf(slice).Kind() == reflect.Array {
+		sliceValue := reflect.ValueOf(slice)
+		for i := 0; i < sliceValue.Len(); i++ {
+			if value == sliceValue.Index(i).Interface() {
+				return true
+			}
+		}
+	}
+	if reflect.TypeOf(slice).Kind() == reflect.String && reflect.TypeOf(value).Kind() == reflect.String {
+		return strings.Contains(slice.(string), value.(string))
+	}
+	return false
 }

--- a/pkg/slice/slice_test.go
+++ b/pkg/slice/slice_test.go
@@ -50,3 +50,17 @@ func (s *testSliceSuite) Test(c *C) {
 		c.Assert(slice.AllOf(t.a, even), Equals, t.allOf)
 	}
 }
+
+func (s *testSliceSuite) TestSliceContains(c *C) {
+	ss := []string{"a", "b", "c"}
+	c.Assert(slice.Contains(ss, "a"), IsTrue)
+	c.Assert(slice.Contains(ss, "d"), IsFalse)
+
+	us := []uint64{1, 2, 3}
+	c.Assert(slice.Contains(us, uint64(1)), IsTrue)
+	c.Assert(slice.Contains(us, uint64(4)), IsFalse)
+
+	is := []int64{1, 2, 3}
+	c.Assert(slice.Contains(is, int64(1)), IsTrue)
+	c.Assert(slice.Contains(is, int64(4)), IsFalse)
+}

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tikv/pd/pkg/apiutil"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/etcdutil"
+	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/server"
 	"github.com/unrolled/render"
 	"go.uber.org/zap"
@@ -71,17 +72,15 @@ func getMembers(svr *server.Server) (*pdpb.GetMembersResponse, error) {
 		return nil, errors.WithStack(err)
 	}
 	for _, m := range members.GetMembers() {
-		m.DcLocation = ""
-		binaryVersion, e := svr.GetMember().GetMemberBinaryVersion(m.GetMemberId())
+		var e error
+		m.BinaryVersion, e = svr.GetMember().GetMemberBinaryVersion(m.GetMemberId())
 		if e != nil {
 			log.Error("failed to load binary version", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
 		}
-		m.BinaryVersion = binaryVersion
-		deployPath, e := svr.GetMember().GetMemberDeployPath(m.GetMemberId())
+		m.DeployPath, e = svr.GetMember().GetMemberDeployPath(m.GetMemberId())
 		if e != nil {
 			log.Error("failed to load deploy path", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
 		}
-		m.DeployPath = deployPath
 		if svr.GetMember().GetEtcdLeader() == 0 {
 			log.Warn("no etcd leader, skip get leader priority", zap.Uint64("member", m.GetMemberId()))
 			continue
@@ -92,22 +91,15 @@ func getMembers(svr *server.Server) (*pdpb.GetMembersResponse, error) {
 			continue
 		}
 		m.LeaderPriority = int32(leaderPriority)
-		gitHash, e := svr.GetMember().GetMemberGitHash(m.GetMemberId())
+		m.GitHash, e = svr.GetMember().GetMemberGitHash(m.GetMemberId())
 		if e != nil {
 			log.Error("failed to load git hash", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
 			continue
 		}
-		m.GitHash = gitHash
-		found := false
 		for dcLocation, serverIDs := range dclocationDistribution {
-			for _, serverID := range serverIDs {
-				if serverID == m.MemberId {
-					m.DcLocation = dcLocation
-					found = true
-					break
-				}
-			}
+			found := slice.Contains(serverIDs, m.MemberId)
 			if found {
+				m.DcLocation = dcLocation
 				break
 			}
 		}

--- a/server/apiv2/handlers/members.go
+++ b/server/apiv2/handlers/members.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server"
+	"go.uber.org/zap"
+)
+
+// GetMembers returns the PD members.
+func GetMembers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		svr := c.MustGet("server").(*server.Server)
+		members, err := svr.GetMembers()
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		dclocationDistribution, err := svr.GetTSOAllocatorManager().GetClusterDCLocationsFromEtcd()
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		for _, m := range members {
+			m.DcLocation = ""
+			binaryVersion, e := svr.GetMember().GetMemberBinaryVersion(m.GetMemberId())
+			if e != nil {
+				log.Error("failed to load binary version", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
+			}
+			m.BinaryVersion = binaryVersion
+			deployPath, e := svr.GetMember().GetMemberDeployPath(m.GetMemberId())
+			if e != nil {
+				log.Error("failed to load deploy path", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
+			}
+			m.DeployPath = deployPath
+			if svr.GetMember().GetEtcdLeader() == 0 {
+				log.Warn("no etcd leader, skip get leader priority", zap.Uint64("member", m.GetMemberId()))
+				continue
+			}
+			leaderPriority, e := svr.GetMember().GetMemberLeaderPriority(m.GetMemberId())
+			if e != nil {
+				log.Error("failed to load leader priority", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
+				continue
+			}
+			m.LeaderPriority = int32(leaderPriority)
+			gitHash, e := svr.GetMember().GetMemberGitHash(m.GetMemberId())
+			if e != nil {
+				log.Error("failed to load git hash", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
+				continue
+			}
+			m.GitHash = gitHash
+			found := false
+			for dcLocation, serverIDs := range dclocationDistribution {
+				for _, serverID := range serverIDs {
+					if serverID == m.MemberId {
+						m.DcLocation = dcLocation
+						found = true
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
+		}
+		var etcdLeader, pdLeader *pdpb.Member
+		leaderID := svr.GetMember().GetEtcdLeader()
+		for _, m := range members {
+			if m.MemberId == leaderID {
+				etcdLeader = m
+				break
+			}
+		}
+
+		tsoAllocatorManager := svr.GetTSOAllocatorManager()
+		tsoAllocatorLeaders, err := tsoAllocatorManager.GetLocalAllocatorLeaders()
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		leader := svr.GetMember().GetLeader()
+		for _, m := range members {
+			if m.MemberId == leader.GetMemberId() {
+				pdLeader = m
+				break
+			}
+		}
+
+		c.IndentedJSON(http.StatusOK, gin.H{
+			"members":               members,
+			"leader":                pdLeader,
+			"etcd_leader":           etcdLeader,
+			"tso_allocator_leaders": tsoAllocatorLeaders,
+		})
+	}
+}

--- a/server/apiv2/handlers/members.go
+++ b/server/apiv2/handlers/members.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/etcdutil"
 	"github.com/tikv/pd/server"
 	"go.uber.org/zap"
 )
@@ -104,4 +105,113 @@ func GetMembers() gin.HandlerFunc {
 			"tso_allocator_leaders": tsoAllocatorLeaders,
 		})
 	}
+}
+
+type updateParams struct {
+	LeaderPriority float64 `json:"leader_priority"`
+}
+
+func UpdateMemberByName() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		svr := c.MustGet("server").(*server.Server)
+
+		// Get etcd ID by name.
+		id, err := getMemberIDByName(svr, c.Param("name"))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		if id == 0 {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
+		var p updateParams
+		if err := c.BindJSON(&p); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error": errs.ErrBindJSON.Wrap(err).GenWithStackByCause(),
+			})
+			return
+		}
+		err = svr.GetMember().SetMemberLeaderPriority(id, int(p.LeaderPriority))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		c.JSON(
+			http.StatusOK,
+			nil,
+		)
+	}
+}
+
+// DeleteMemberByName will delete the PD member according to the given member's name.
+func DeleteMemberByName() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		svr := c.MustGet("server").(*server.Server)
+
+		// Get etcd ID by name.
+		id, err := getMemberIDByName(svr, c.Param("name"))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		if id == 0 {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
+		if err := deleteMemberByID(svr, id); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		c.JSON(
+			http.StatusOK,
+			nil,
+		)
+	}
+}
+
+func getMemberIDByName(svr *server.Server, name string) (id uint64, err error) {
+	members, err := svr.GetMembers()
+	if err != nil {
+		return
+	}
+	for _, m := range members {
+		if name == m.Name {
+			id = m.GetMemberId()
+			break
+		}
+	}
+	return
+}
+
+func deleteMemberByID(svr *server.Server, id uint64) error {
+	// Delete config.
+	err := svr.GetMember().DeleteMemberLeaderPriority(id)
+	if err != nil {
+		return err
+	}
+
+	// Delete dc-location info.
+	err = svr.GetMember().DeleteMemberDCLocationInfo(id)
+	if err != nil {
+		return err
+	}
+
+	client := svr.GetClient()
+	_, err = etcdutil.RemoveEtcdMember(client, id)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/server/apiv2/handlers/regions.go
+++ b/server/apiv2/handlers/regions.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server/cluster"
+)
+
+// GetRegions returns the regions.
+func GetRegions() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rc := c.MustGet("cluster").(*cluster.RaftCluster)
+		regions := rc.GetRegions()
+		RegionsInfo := &RegionsInfo{
+			Regions: make([]*RegionInfo, 0, len(regions)),
+		}
+		for _, r := range regions {
+			RegionsInfo.Regions = append(RegionsInfo.Regions, newRegionInfo(r))
+		}
+		RegionsInfo.Count = len(RegionsInfo.Regions)
+		c.IndentedJSON(http.StatusOK, RegionsInfo)
+	}
+}
+
+// GetRegionByID returns the region according to the given ID.
+func GetRegionByID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rc := c.MustGet("cluster").(*cluster.RaftCluster)
+		idParam := c.Param("id")
+		id, err := strconv.ParseUint(idParam, 10, 64)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause().Error())
+			return
+		}
+		region := rc.GetRegion(id)
+		if region == nil {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
+		c.IndentedJSON(http.StatusOK, newRegionInfo(region))
+	}
+}

--- a/server/apiv2/handlers/stores.go
+++ b/server/apiv2/handlers/stores.go
@@ -36,12 +36,7 @@ func GetStores() gin.HandlerFunc {
 			storeID := s.GetId()
 			store := rc.GetStore(storeID)
 			if store == nil {
-				c.AbortWithStatusJSON(
-					http.StatusInternalServerError,
-					gin.H{
-						"error": errs.ErrStoreNotFound.FastGenByArgs(storeID).Error(),
-					},
-				)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrStoreNotFound.FastGenByArgs(storeID).Error())
 				return
 			}
 
@@ -49,12 +44,7 @@ func GetStores() gin.HandlerFunc {
 			StoresInfo.Stores = append(StoresInfo.Stores, storeInfo)
 		}
 		StoresInfo.Count = len(StoresInfo.Stores)
-		c.IndentedJSON(
-			http.StatusOK,
-			gin.H{
-				"stores": StoresInfo,
-			},
-		)
+		c.IndentedJSON(http.StatusOK, StoresInfo)
 	}
 }
 
@@ -75,31 +65,17 @@ func GetStoreByID() gin.HandlerFunc {
 		idParam := c.Param("id")
 		id, err := strconv.ParseUint(idParam, 10, 64)
 		if err != nil {
-			c.AbortWithStatusJSON(
-				http.StatusBadRequest,
-				gin.H{
-					"error": errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause().Error(),
-				},
-			)
+			c.AbortWithStatusJSON(http.StatusBadRequest, errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause().Error())
+			return
 		}
 		store := rc.GetStore(id)
 		if store == nil {
-			c.AbortWithStatusJSON(
-				http.StatusInternalServerError,
-				gin.H{
-					"error": errs.ErrStoreNotFound.FastGenByArgs(id).Error(),
-				},
-			)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrStoreNotFound.FastGenByArgs(id).Error())
 			return
 		}
 
 		storeInfo := newStoreInfo(rc.GetOpts().GetScheduleConfig(), store)
-		c.IndentedJSON(
-			http.StatusOK,
-			gin.H{
-				"store": storeInfo,
-			},
-		)
+		c.IndentedJSON(http.StatusOK, storeInfo)
 	}
 }
 
@@ -110,12 +86,8 @@ func DeleteStoreByID() gin.HandlerFunc {
 		idParam := c.Param("id")
 		id, err := strconv.ParseUint(idParam, 10, 64)
 		if err != nil {
-			c.AbortWithStatusJSON(
-				http.StatusBadRequest,
-				gin.H{
-					"error": errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause().Error(),
-				},
-			)
+			c.AbortWithStatusJSON(http.StatusBadRequest, errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause().Error())
+			return
 		}
 
 		var force bool
@@ -123,29 +95,17 @@ func DeleteStoreByID() gin.HandlerFunc {
 		if forceQuery != "" {
 			force, err = strconv.ParseBool(forceQuery)
 			if err != nil {
-				c.IndentedJSON(
-					http.StatusBadRequest,
-					gin.H{
-						"error": errs.ErrStrconvParseBool.Wrap(err).FastGenWithCause().Error(),
-					},
-				)
+				c.AbortWithStatusJSON(http.StatusBadRequest, errs.ErrStrconvParseBool.Wrap(err).FastGenWithCause().Error())
+				return
 			}
 		}
 
 		err = rc.RemoveStore(id, force)
 		if err != nil {
-			c.AbortWithStatusJSON(
-				http.StatusBadRequest,
-				gin.H{
-					"error": err.Error(),
-				},
-			)
+			c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
 			return
 		}
 
-		c.JSON(
-			http.StatusOK,
-			nil,
-		)
+		c.JSON(http.StatusOK, nil)
 	}
 }

--- a/server/apiv2/handlers/stores.go
+++ b/server/apiv2/handlers/stores.go
@@ -1,0 +1,151 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server/cluster"
+)
+
+// GetStores returns the stores.
+func GetStores() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rc := c.MustGet("cluster").(*cluster.RaftCluster)
+		stores := rc.GetMetaStores()
+		StoresInfo := &StoresInfo{
+			Stores: make([]*StoreInfo, 0, len(stores)),
+		}
+
+		for _, s := range stores {
+			storeID := s.GetId()
+			store := rc.GetStore(storeID)
+			if store == nil {
+				c.AbortWithStatusJSON(
+					http.StatusInternalServerError,
+					gin.H{
+						"error": errs.ErrStoreNotFound.FastGenByArgs(storeID).Error(),
+					},
+				)
+				return
+			}
+
+			storeInfo := newStoreInfo(rc.GetOpts().GetScheduleConfig(), store)
+			StoresInfo.Stores = append(StoresInfo.Stores, storeInfo)
+		}
+		StoresInfo.Count = len(StoresInfo.Stores)
+		c.IndentedJSON(
+			http.StatusOK,
+			gin.H{
+				"stores": StoresInfo,
+			},
+		)
+	}
+}
+
+// GetStoreByID returns the store according to the given ID.
+// @Tags store
+// @version 2.0
+// @Summary Get a store's information.
+// @Param id path integer true "Store Id"
+// @Produce json
+// @Success 200 {object} StoreInfo
+// @Failure 400 {string} string "The input is invalid."
+// @Failure 404 {string} string "The store does not exist."
+// @Failure 500 {string} string "PD server failed to proceed the request."
+// @Router /stores/{id} [get]
+func GetStoreByID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rc := c.MustGet("cluster").(*cluster.RaftCluster)
+		idParam := c.Param("id")
+		id, err := strconv.ParseUint(idParam, 10, 64)
+		if err != nil {
+			c.AbortWithStatusJSON(
+				http.StatusBadRequest,
+				gin.H{
+					"error": errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause().Error(),
+				},
+			)
+		}
+		store := rc.GetStore(id)
+		if store == nil {
+			c.AbortWithStatusJSON(
+				http.StatusInternalServerError,
+				gin.H{
+					"error": errs.ErrStoreNotFound.FastGenByArgs(id).Error(),
+				},
+			)
+			return
+		}
+
+		storeInfo := newStoreInfo(rc.GetOpts().GetScheduleConfig(), store)
+		c.IndentedJSON(
+			http.StatusOK,
+			gin.H{
+				"store": storeInfo,
+			},
+		)
+	}
+}
+
+// DeleteStoreByID will delete the store according to the given ID.
+func DeleteStoreByID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rc := c.MustGet("cluster").(*cluster.RaftCluster)
+		idParam := c.Param("id")
+		id, err := strconv.ParseUint(idParam, 10, 64)
+		if err != nil {
+			c.AbortWithStatusJSON(
+				http.StatusBadRequest,
+				gin.H{
+					"error": errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause().Error(),
+				},
+			)
+		}
+
+		var force bool
+		forceQuery := c.Query("force")
+		if forceQuery != "" {
+			force, err = strconv.ParseBool(forceQuery)
+			if err != nil {
+				c.IndentedJSON(
+					http.StatusBadRequest,
+					gin.H{
+						"error": errs.ErrStrconvParseBool.Wrap(err).FastGenWithCause().Error(),
+					},
+				)
+			}
+		}
+
+		err = rc.RemoveStore(id, force)
+		if err != nil {
+			c.AbortWithStatusJSON(
+				http.StatusBadRequest,
+				gin.H{
+					"error": err.Error(),
+				},
+			)
+			return
+		}
+
+		c.JSON(
+			http.StatusOK,
+			nil,
+		)
+	}
+}

--- a/server/apiv2/handlers/stores.go
+++ b/server/apiv2/handlers/stores.go
@@ -39,7 +39,7 @@ func GetStores() gin.HandlerFunc {
 			storeID := s.GetId()
 			store := rc.GetStore(storeID)
 			if store == nil {
-				c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrStoreNotFound.FastGenByArgs(storeID).Error())
+				c.AbortWithStatus(http.StatusNotFound)
 				return
 			}
 
@@ -75,7 +75,7 @@ func GetStoreByID() gin.HandlerFunc {
 		}
 		store := rc.GetStore(id)
 		if store == nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrStoreNotFound.FastGenByArgs(id).Error())
+			c.AbortWithStatus(http.StatusNotFound)
 			return
 		}
 

--- a/server/apiv2/handlers/types.go
+++ b/server/apiv2/handlers/types.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/tikv/pd/pkg/typeutil"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/server/core"
+)
+
+const (
+	disconnectedName = "Disconnected"
+	downStateName    = "Down"
+)
+
+// StoresInfo records stores' info.
+type StoresInfo struct {
+	Count  int          `json:"count"`
+	Stores []*StoreInfo `json:"stores"`
+}
+
+// MetaStore contains meta information about a store.
+type MetaStore struct {
+	*metapb.Store
+	StateName string `json:"state_name"`
+}
+
+// StoreStatus contains status about a store.
+type StoreStatus struct {
+	Capacity        typeutil.ByteSize  `json:"capacity"`
+	Available       typeutil.ByteSize  `json:"available"`
+	UsedSize        typeutil.ByteSize  `json:"used_size"`
+	LeaderCount     int                `json:"leader_count"`
+	LeaderWeight    float64            `json:"leader_weight"`
+	LeaderScore     float64            `json:"leader_score"`
+	LeaderSize      int64              `json:"leader_size"`
+	RegionCount     int                `json:"region_count"`
+	RegionWeight    float64            `json:"region_weight"`
+	RegionScore     float64            `json:"region_score"`
+	RegionSize      int64              `json:"region_size"`
+	SlowScore       uint64             `json:"slow_score"`
+	StartTS         *time.Time         `json:"start_ts,omitempty"`
+	LastHeartbeatTS *time.Time         `json:"last_heartbeat_ts,omitempty"`
+	Uptime          *typeutil.Duration `json:"uptime,omitempty"`
+}
+
+// StoreInfo contains information about a store.
+type StoreInfo struct {
+	Store  *MetaStore   `json:"store"`
+	Status *StoreStatus `json:"status"`
+}
+
+func newStoreInfo(cfg *config.ScheduleConfig, store *core.StoreInfo) *StoreInfo {
+	s := &StoreInfo{
+		Store: &MetaStore{
+			Store:     store.GetMeta(),
+			StateName: store.GetState().String(),
+		},
+		Status: &StoreStatus{
+			Capacity:     typeutil.ByteSize(store.GetCapacity()),
+			Available:    typeutil.ByteSize(store.GetAvailable()),
+			UsedSize:     typeutil.ByteSize(store.GetUsedSize()),
+			LeaderCount:  store.GetLeaderCount(),
+			LeaderWeight: store.GetLeaderWeight(),
+			LeaderScore:  store.LeaderScore(core.StringToSchedulePolicy(cfg.LeaderSchedulePolicy), 0),
+			LeaderSize:   store.GetLeaderSize(),
+			RegionCount:  store.GetRegionCount(),
+			RegionWeight: store.GetRegionWeight(),
+			RegionScore:  store.RegionScore(cfg.RegionScoreFormulaVersion, cfg.HighSpaceRatio, cfg.LowSpaceRatio, 0),
+			RegionSize:   store.GetRegionSize(),
+			SlowScore:    store.GetSlowScore(),
+		},
+	}
+
+	if store.GetStoreStats() != nil {
+		startTS := store.GetStartTime()
+		s.Status.StartTS = &startTS
+	}
+	if lastHeartbeat := store.GetLastHeartbeatTS(); !lastHeartbeat.IsZero() {
+		s.Status.LastHeartbeatTS = &lastHeartbeat
+	}
+	if upTime := store.GetUptime(); upTime > 0 {
+		duration := typeutil.NewDuration(upTime)
+		s.Status.Uptime = &duration
+	}
+
+	if store.GetState() == metapb.StoreState_Up {
+		if store.DownTime() > cfg.MaxStoreDownTime.Duration {
+			s.Store.StateName = downStateName
+		} else if store.IsDisconnected() {
+			s.Store.StateName = disconnectedName
+		}
+	}
+	return s
+}

--- a/server/apiv2/handlers/types.go
+++ b/server/apiv2/handlers/types.go
@@ -1,3 +1,17 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package handlers
 
 import (

--- a/server/apiv2/handlers/types.go
+++ b/server/apiv2/handlers/types.go
@@ -53,8 +53,9 @@ type MetaStore struct {
 	// The last heartbeat timestamp of the store.
 	LastHeartbeat int64 `json:"last_heartbeat,omitempty"`
 	// If the store is physically destroyed, which means it can never up again.
-	PhysicallyDestroyed bool   `json:"physically_destroyed,omitempty"`
-	HeartbeatStatus     string `json:"heartbeat_status"`
+	PhysicallyDestroyed bool             `json:"physically_destroyed,omitempty"`
+	NodeState           metapb.NodeState `json:"node_state"`
+	HeartbeatStatus     string           `json:"heartbeat_status"`
 }
 
 func NewMetaStore(store *metapb.Store, heartbeatStatus string) *MetaStore {
@@ -70,6 +71,7 @@ func NewMetaStore(store *metapb.Store, heartbeatStatus string) *MetaStore {
 	metaStore.DeployPath = store.GetDeployPath()
 	metaStore.LastHeartbeat = store.GetLastHeartbeat()
 	metaStore.PhysicallyDestroyed = store.GetPhysicallyDestroyed()
+	metaStore.NodeState = store.GetNodeState()
 	return metaStore
 }
 

--- a/server/apiv2/handlers/types.go
+++ b/server/apiv2/handlers/types.go
@@ -53,9 +53,9 @@ type MetaStore struct {
 	// The last heartbeat timestamp of the store.
 	LastHeartbeat int64 `json:"last_heartbeat,omitempty"`
 	// If the store is physically destroyed, which means it can never up again.
-	PhysicallyDestroyed bool             `json:"physically_destroyed,omitempty"`
-	NodeState           metapb.NodeState `json:"node_state"`
-	HeartbeatStatus     string           `json:"heartbeat_status"`
+	PhysicallyDestroyed bool   `json:"physically_destroyed,omitempty"`
+	NodeState           string `json:"node_state"`
+	HeartbeatStatus     string `json:"heartbeat_status"`
 }
 
 func NewMetaStore(store *metapb.Store, heartbeatStatus string) *MetaStore {
@@ -71,7 +71,7 @@ func NewMetaStore(store *metapb.Store, heartbeatStatus string) *MetaStore {
 	metaStore.DeployPath = store.GetDeployPath()
 	metaStore.LastHeartbeat = store.GetLastHeartbeat()
 	metaStore.PhysicallyDestroyed = store.GetPhysicallyDestroyed()
-	metaStore.NodeState = store.GetNodeState()
+	metaStore.NodeState = store.GetNodeState().String()
 	return metaStore
 }
 

--- a/server/apiv2/middlewares/bootstrap_checker.go
+++ b/server/apiv2/middlewares/bootstrap_checker.go
@@ -1,0 +1,42 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server"
+)
+
+// BootstrapChecker is a middleware to check if raft cluster is started.
+func BootstrapChecker() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		svr := c.MustGet("server").(*server.Server)
+		rc := svr.GetRaftCluster()
+		if rc == nil {
+			c.AbortWithStatusJSON(
+				http.StatusInternalServerError,
+				gin.H{
+					"error": errs.ErrNotBootstrapped.FastGenByArgs().Error(),
+				},
+			)
+			return
+		}
+		c.Set("cluster", rc)
+		c.Next()
+	}
+}

--- a/server/apiv2/middlewares/bootstrap_checker.go
+++ b/server/apiv2/middlewares/bootstrap_checker.go
@@ -28,12 +28,7 @@ func BootstrapChecker() gin.HandlerFunc {
 		svr := c.MustGet("server").(*server.Server)
 		rc := svr.GetRaftCluster()
 		if rc == nil {
-			c.AbortWithStatusJSON(
-				http.StatusInternalServerError,
-				gin.H{
-					"error": errs.ErrNotBootstrapped.FastGenByArgs().Error(),
-				},
-			)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrNotBootstrapped.FastGenByArgs().Error())
 			return
 		}
 		c.Set("cluster", rc)

--- a/server/apiv2/middlewares/redirector.go
+++ b/server/apiv2/middlewares/redirector.go
@@ -40,12 +40,7 @@ func Redirector() gin.HandlerFunc {
 		// Prevent more than one redirection.
 		if name := c.Request.Header.Get(serverapi.RedirectorHeader); len(name) != 0 {
 			log.Error("redirect but server is not leader", zap.String("from", name), zap.String("server", svr.Name()), errs.ZapError(errs.ErrRedirect))
-			c.AbortWithStatusJSON(
-				http.StatusInternalServerError,
-				gin.H{
-					"error": errs.ErrRedirect.FastGenByArgs().Error(),
-				},
-			)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrRedirect.FastGenByArgs().Error())
 			return
 		}
 
@@ -53,12 +48,7 @@ func Redirector() gin.HandlerFunc {
 
 		leader := svr.GetMember().GetLeader()
 		if leader == nil {
-			c.AbortWithStatusJSON(
-				http.StatusServiceUnavailable,
-				gin.H{
-					"error": errs.ErrLeaderNil.FastGenByArgs().Error(),
-				},
-			)
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, errs.ErrLeaderNil.FastGenByArgs().Error())
 			return
 		}
 		clientUrls := leader.GetClientUrls()
@@ -66,12 +56,7 @@ func Redirector() gin.HandlerFunc {
 		for _, item := range clientUrls {
 			u, err := url.Parse(item)
 			if err != nil {
-				c.AbortWithStatusJSON(
-					http.StatusInternalServerError,
-					gin.H{
-						"error": errs.ErrURLParse.Wrap(err).GenWithStackByCause().Error(),
-					},
-				)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrURLParse.Wrap(err).GenWithStackByCause().Error())
 				return
 			}
 

--- a/server/apiv2/middlewares/redirector.go
+++ b/server/apiv2/middlewares/redirector.go
@@ -1,0 +1,85 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middlewares
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap/log"
+	"github.com/tikv/pd/pkg/apiutil/serverapi"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/server"
+	"go.uber.org/zap"
+)
+
+// Redirector is a middleware to redirect the request to the right place.
+func Redirector() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		svr := c.MustGet("server").(*server.Server)
+		allowFollowerHandle := len(c.Request.Header.Get(serverapi.AllowFollowerHandle)) > 0
+		isLeader := svr.GetMember().IsLeader()
+		if !svr.IsClosed() && (allowFollowerHandle || isLeader) {
+			c.Next()
+			return
+		}
+
+		// Prevent more than one redirection.
+		if name := c.Request.Header.Get(serverapi.RedirectorHeader); len(name) != 0 {
+			log.Error("redirect but server is not leader", zap.String("from", name), zap.String("server", svr.Name()), errs.ZapError(errs.ErrRedirect))
+			c.AbortWithStatusJSON(
+				http.StatusInternalServerError,
+				gin.H{
+					"error": errs.ErrRedirect.FastGenByArgs().Error(),
+				},
+			)
+			return
+		}
+
+		c.Request.Header.Set(serverapi.RedirectorHeader, svr.Name())
+
+		leader := svr.GetMember().GetLeader()
+		if leader == nil {
+			c.AbortWithStatusJSON(
+				http.StatusServiceUnavailable,
+				gin.H{
+					"error": errs.ErrLeaderNil.FastGenByArgs().Error(),
+				},
+			)
+			return
+		}
+		clientUrls := leader.GetClientUrls()
+		urls := make([]url.URL, 0, len(clientUrls))
+		for _, item := range clientUrls {
+			u, err := url.Parse(item)
+			if err != nil {
+				c.AbortWithStatusJSON(
+					http.StatusInternalServerError,
+					gin.H{
+						"error": errs.ErrURLParse.Wrap(err).GenWithStackByCause().Error(),
+					},
+				)
+				return
+			}
+
+			urls = append(urls, *u)
+		}
+
+		client := svr.GetHTTPClient()
+		serverapi.NewCustomReverseProxies(client, urls).ServeHTTP(c.Writer, c.Request)
+		c.Abort()
+	}
+}

--- a/server/apiv2/router.go
+++ b/server/apiv2/router.go
@@ -1,0 +1,67 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiv2
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	gs "github.com/swaggo/gin-swagger"
+	"github.com/swaggo/gin-swagger/swaggerFiles"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/apiv2/handlers"
+	"github.com/tikv/pd/server/apiv2/middlewares"
+)
+
+var group = server.ServiceGroup{
+	Name:       "core",
+	IsCore:     true,
+	Version:    "v2",
+	PathPrefix: apiV2Prefix,
+}
+
+const apiV2Prefix = "/pd/api/v2/"
+
+// NewV2Handler creates a HTTP handler for API.
+// @title Placement Driver Core API
+// @version 2.0
+// @description This is placement driver.
+// @contact.name Placement Driver Support
+// @contact.url https://github.com/tikv/pd/issues
+// @contact.email info@pingcap.com
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+// @BasePath /pd/api/v2
+func NewV2Handler(_ context.Context, svr *server.Server) (http.Handler, server.ServiceGroup, error) {
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("server", svr)
+		c.Next()
+	})
+	router.Use(middlewares.Redirector())
+	root := router.Group(apiV2Prefix)
+	meta := root.Group("meta")
+	meta.Use(middlewares.BootstrapChecker())
+	meta.GET("/stores", handlers.GetStores())
+	meta.GET("/stores/:id", handlers.GetStoreByID())
+	meta.DELETE("/stores/:id", handlers.DeleteStoreByID())
+
+	root.GET("/members", handlers.GetMembers())
+	router.GET("/swagger/*any", gs.WrapHandler(swaggerFiles.Handler))
+
+	return router, group, nil
+}

--- a/server/apiv2/router.go
+++ b/server/apiv2/router.go
@@ -59,10 +59,13 @@ func NewV2Handler(_ context.Context, svr *server.Server) (http.Handler, server.S
 	meta.GET("/stores", handlers.GetStores())
 	meta.GET("/stores/:id", handlers.GetStoreByID())
 	meta.DELETE("/stores/:id", handlers.DeleteStoreByID())
+	meta.PUT("/stores/:id", handlers.UpdateStoreByID())
 
 	root.GET("/members", handlers.GetMembers())
+	root.GET("/members/:name", handlers.GetMemberByName())
 	root.DELETE("/members/:name", handlers.DeleteMemberByName())
 	root.PUT("/members/:name", handlers.UpdateMemberByName())
+
 	router.GET("/swagger/*any", gs.WrapHandler(swaggerFiles.Handler))
 
 	return router, group, nil

--- a/server/apiv2/router.go
+++ b/server/apiv2/router.go
@@ -59,12 +59,15 @@ func NewV2Handler(_ context.Context, svr *server.Server) (http.Handler, server.S
 	meta.GET("/stores", handlers.GetStores())
 	meta.GET("/stores/:id", handlers.GetStoreByID())
 	meta.DELETE("/stores/:id", handlers.DeleteStoreByID())
-	meta.PUT("/stores/:id", handlers.UpdateStoreByID())
+	meta.PATCH("/stores/:id", handlers.UpdateStoreByID())
+
+	meta.GET("/regions", handlers.GetRegions())
+	meta.GET("/regions/:id", handlers.GetRegionByID())
 
 	root.GET("/members", handlers.GetMembers())
 	root.GET("/members/:name", handlers.GetMemberByName())
 	root.DELETE("/members/:name", handlers.DeleteMemberByName())
-	root.PUT("/members/:name", handlers.UpdateMemberByName())
+	root.PATCH("/members/:name", handlers.UpdateMemberByName())
 
 	router.GET("/swagger/*any", gs.WrapHandler(swaggerFiles.Handler))
 

--- a/server/apiv2/router.go
+++ b/server/apiv2/router.go
@@ -61,6 +61,8 @@ func NewV2Handler(_ context.Context, svr *server.Server) (http.Handler, server.S
 	meta.DELETE("/stores/:id", handlers.DeleteStoreByID())
 
 	root.GET("/members", handlers.GetMembers())
+	root.DELETE("/members/:name", handlers.DeleteMemberByName())
+	root.PUT("/members/:name", handlers.UpdateMemberByName())
 	router.GET("/swagger/*any", gs.WrapHandler(swaggerFiles.Handler))
 
 	return router, group, nil

--- a/server/cluster/cluster_stat.go
+++ b/server/cluster/cluster_stat.go
@@ -195,15 +195,6 @@ func (cst *StatEntries) Append(stat *StatEntry) bool {
 	return entries.Append(stat, ThreadsCollected...)
 }
 
-func contains(slice []uint64, value uint64) bool {
-	for i := range slice {
-		if slice[i] == value {
-			return true
-		}
-	}
-	return false
-}
-
 // CPU returns the cpu usage of the cluster
 func (cst *StatEntries) CPU(excludes ...uint64) float64 {
 	cst.m.Lock()
@@ -216,7 +207,7 @@ func (cst *StatEntries) CPU(excludes ...uint64) float64 {
 
 	sum := 0.0
 	for sid, stat := range cst.stats {
-		if contains(excludes, sid) {
+		if slice.Contains(excludes, sid) {
 			continue
 		}
 		if time.Since(stat.updated) > cst.ttl {

--- a/server/core/store.go
+++ b/server/core/store.go
@@ -167,6 +167,16 @@ func (s *StoreInfo) IsRemoved() bool {
 	return s.GetNodeState() == metapb.NodeState_Removed
 }
 
+// IsInStates checks if the store's state belongs to the given list.
+func (s *StoreInfo) IsInStates(states []string) bool {
+	for _, state := range states {
+		if s.GetNodeState().String() == state {
+			return true
+		}
+	}
+	return false
+}
+
 // GetSlowScore returns the slow score of the store.
 func (s *StoreInfo) GetSlowScore() uint64 {
 	s.mu.RLock()

--- a/server/member/member.go
+++ b/server/member/member.go
@@ -316,10 +316,11 @@ func (m *Member) SetMemberLeaderPriority(id uint64, priority int) error {
 	key := m.getMemberLeaderPriorityPath(id)
 	res, err := m.leadership.LeaderTxn().Then(clientv3.OpPut(key, strconv.Itoa(priority))).Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.ErrEtcdTxnInternal.Wrap(err).GenWithStackByCause()
 	}
 	if !res.Succeeded {
-		return errors.New("save etcd leader priority failed, maybe not pd leader")
+		log.Error("save etcd leader priority failed, maybe not pd leader")
+		return errs.ErrEtcdTxnConflict.FastGenByArgs()
 	}
 	return nil
 }
@@ -329,10 +330,11 @@ func (m *Member) DeleteMemberLeaderPriority(id uint64) error {
 	key := m.getMemberLeaderPriorityPath(id)
 	res, err := m.leadership.LeaderTxn().Then(clientv3.OpDelete(key)).Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.ErrEtcdTxnInternal.Wrap(err).GenWithStackByCause()
 	}
 	if !res.Succeeded {
-		return errors.New("delete etcd leader priority failed, maybe not pd leader")
+		log.Error("delete etcd leader priority failed, maybe not pd leader")
+		return errs.ErrEtcdTxnConflict.FastGenByArgs()
 	}
 	return nil
 }
@@ -342,10 +344,11 @@ func (m *Member) DeleteMemberDCLocationInfo(id uint64) error {
 	key := m.GetDCLocationPath(id)
 	res, err := m.leadership.LeaderTxn().Then(clientv3.OpDelete(key)).Commit()
 	if err != nil {
-		return errors.WithStack(err)
+		return errs.ErrEtcdTxnInternal.Wrap(err).GenWithStackByCause()
 	}
 	if !res.Succeeded {
-		return errors.New("delete dc-location info failed, maybe not pd leader")
+		log.Error("delete dc-location info failed, maybe not pd leader")
+		return errs.ErrEtcdTxnConflict.FastGenByArgs()
 	}
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -799,7 +799,7 @@ func (s *Server) StartTimestamp() int64 {
 // GetMembers returns PD server list.
 func (s *Server) GetMembers() ([]*pdpb.Member, error) {
 	if s.IsClosed() {
-		return nil, errors.New("server not started")
+		return nil, errs.ErrServerNotStarted.FastGenByArgs()
 	}
 	members, err := cluster.GetMembers(s.GetClient())
 	return members, err

--- a/tests/client/go.sum
+++ b/tests/client/go.sum
@@ -507,6 +507,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14 h1:PyYN9JH5jY9j6av01SpfRMb+1DWg/i3MbGOKPxJ2wjM=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14/go.mod h1:gxQT6pBGRuIGunNf/+tSOB5OHvguWi8Tbt82WOkf35E=
+github.com/swaggo/gin-swagger v1.2.0 h1:YskZXEiv51fjOMTsXrOetAjrMDfFaXD79PEoQBOe2W0=
 github.com/swaggo/gin-swagger v1.2.0/go.mod h1:qlH2+W7zXGZkczuL+r2nEBR2JTT+/lX05Nn6vPhc7OI=
 github.com/swaggo/http-swagger v0.0.0-20200308142732-58ac5e232fba h1:lUPlXKqgbqT2SVg2Y+eT9mu5wbqMnG+i/+Q9nK7C0Rs=
 github.com/swaggo/http-swagger v0.0.0-20200308142732-58ac5e232fba/go.mod h1:O1lAbCgAAX/KZ80LM/OXwtWFI/5TvZlwxSg8Cq08PV0=

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/api"
+	"github.com/tikv/pd/server/apiv2"
 	"github.com/tikv/pd/server/cluster"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
@@ -81,7 +82,7 @@ func NewTestServer(ctx context.Context, cfg *config.Config) (*TestServer, error)
 	if err != nil {
 		return nil, err
 	}
-	serviceBuilders := []server.HandlerBuilder{api.NewHandler, swaggerserver.NewHandler, autoscaling.NewHandler}
+	serviceBuilders := []server.HandlerBuilder{api.NewHandler, apiv2.NewV2Handler, swaggerserver.NewHandler, autoscaling.NewHandler}
 	serviceBuilders = append(serviceBuilders, dashboard.GetServiceBuilders()...)
 	svr, err := server.CreateServer(ctx, cfg, serviceBuilders...)
 	if err != nil {

--- a/tests/server/apiv2/handlers/members_test.go
+++ b/tests/server/apiv2/handlers/members_test.go
@@ -1,0 +1,121 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"math/rand"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/tikv/pd/pkg/typeutil"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/tests"
+)
+
+// dialClient used to dial http request.
+var dialClient = &http.Client{
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+	},
+}
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testMemberAPISuite{})
+
+type testMemberAPISuite struct {
+	cleanup context.CancelFunc
+	cluster *tests.TestCluster
+}
+
+func (s *testMemberAPISuite) SetUpSuite(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server.EnableZap = true
+	s.cleanup = cancel
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, serverName string) {
+		conf.EnableLocalTSO = true
+		conf.Labels = map[string]string{
+			config.ZoneLabel: "dc-1",
+		}
+		conf.TickInterval = typeutil.Duration{Duration: 50 * time.Millisecond}
+		conf.ElectionInterval = typeutil.Duration{Duration: 250 * time.Millisecond}
+	})
+	c.Assert(err, IsNil)
+	c.Assert(cluster.RunInitialServers(), IsNil)
+	c.Assert(cluster.WaitLeader(), Not(HasLen), 0)
+	leaderServer := cluster.GetServer(cluster.GetLeader())
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	s.cluster = cluster
+}
+
+func (s *testMemberAPISuite) TearDownSuite(c *C) {
+	s.cleanup()
+	s.cluster.Destroy()
+}
+
+func (s *testMemberAPISuite) TestMemberList(c *C) {
+	for _, url := range s.cluster.GetConfig().GetClientURLs() {
+		addr := url + "/pd/api/v2/members"
+		resp, err := dialClient.Get(addr)
+		c.Assert(err, IsNil)
+		buf, err := io.ReadAll(resp.Body)
+		c.Assert(err, IsNil)
+		resp.Body.Close()
+		checkListResponse(c, buf, s.cluster)
+	}
+}
+
+func (s *testMemberAPISuite) TestMemberLeader(c *C) {
+	leader := s.cluster.GetServer(s.cluster.GetLeader()).GetServer()
+	addr := s.cluster.GetConfig().InitialServers[rand.Intn(len(s.cluster.GetServers()))].ClientURLs + "/pd/api/v2/members"
+	resp, err := dialClient.Get(addr)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+
+	got := make(map[string]*pdpb.Member)
+	// ignore the error since we only use some fields of the result
+	json.Unmarshal(buf, &got)
+	c.Assert(got["leader"].GetClientUrls(), DeepEquals, []string{leader.GetConfig().ClientUrls})
+	c.Assert(got["leader"].GetMemberId(), Equals, leader.GetMember().ID())
+	c.Assert(got["etcd_leader"].GetClientUrls(), DeepEquals, []string{leader.GetConfig().ClientUrls})
+	c.Assert(got["etcd_leader"].GetMemberId(), Equals, leader.GetMember().ID())
+}
+
+func relaxEqualStings(c *C, a, b []string) {
+	sort.Strings(a)
+	sortedStringA := strings.Join(a, "")
+
+	sort.Strings(b)
+	sortedStringB := strings.Join(b, "")
+
+	c.Assert(sortedStringA, Equals, sortedStringB)
+}
+
+func checkListResponse(c *C, body []byte, cluster *tests.TestCluster) {
+	got := make(map[string][]*pdpb.Member)
+	// ignore the error since we only use some fields of the result
+	json.Unmarshal(body, &got)
+
+	c.Assert(len(got["members"]), Equals, len(cluster.GetConfig().InitialServers))
+	for _, member := range got["members"] {
+		for _, s := range cluster.GetConfig().InitialServers {
+			if member.GetName() != s.Name {
+				continue
+			}
+			c.Assert(member.DcLocation, Equals, "dc-1")
+			relaxEqualStings(c, member.ClientUrls, strings.Split(s.ClientURLs, ","))
+			relaxEqualStings(c, member.PeerUrls, strings.Split(s.PeerURLs, ","))
+		}
+	}
+}

--- a/tests/server/apiv2/handlers/members_test.go
+++ b/tests/server/apiv2/handlers/members_test.go
@@ -115,7 +115,7 @@ func (s *testMembersAPISuite) TestUpdateLeaderPriority(c *C) {
 	data := map[string]float64{"leader_priority": 5}
 	putData, err := json.Marshal(data)
 	c.Assert(err, IsNil)
-	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(putData))
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewBuffer(putData))
 	c.Assert(err, IsNil)
 	resp, err := dialClient.Do(req)
 	c.Assert(err, IsNil)

--- a/tests/server/apiv2/handlers/regions_test.go
+++ b/tests/server/apiv2/handlers/regions_test.go
@@ -1,0 +1,122 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/apiv2/handlers"
+	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/tests"
+)
+
+const regionsPrefix = "/pd/api/v2/meta/regions"
+
+var _ = Suite(&testRegionsAPISuite{})
+
+type testRegionsAPISuite struct {
+	cleanup      context.CancelFunc
+	cluster      *tests.TestCluster
+	leaderServer *tests.TestServer
+}
+
+func (s *testRegionsAPISuite) SetUpSuite(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server.EnableZap = true
+	s.cleanup = cancel
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	c.Assert(err, IsNil)
+	c.Assert(cluster.RunInitialServers(), IsNil)
+	c.Assert(cluster.WaitLeader(), Not(HasLen), 0)
+	s.leaderServer = cluster.GetServer(cluster.GetLeader())
+	c.Assert(s.leaderServer.BootstrapCluster(), IsNil)
+	s.putRegion(1, 1, []byte(""), []byte("a"))
+	s.putRegion(2, 1, []byte("a"), []byte("b"))
+	s.putRegion(3, 1, []byte("b"), []byte(""))
+	s.cluster = cluster
+}
+
+func (s *testRegionsAPISuite) TearDownSuite(c *C) {
+	s.cleanup()
+	s.cluster.Destroy()
+}
+
+func (s *testRegionsAPISuite) putRegion(regionID, storeID uint64, start, end []byte, opts ...core.RegionCreateOption) {
+	leader := &metapb.Peer{
+		Id:      regionID,
+		StoreId: storeID,
+	}
+	metaRegion := &metapb.Region{
+		Id:          regionID,
+		StartKey:    start,
+		EndKey:      end,
+		Peers:       []*metapb.Peer{leader},
+		RegionEpoch: &metapb.RegionEpoch{ConfVer: 1, Version: 1},
+	}
+	newOpts := []core.RegionCreateOption{
+		core.SetApproximateKeys(1000),
+		core.SetApproximateSize(10),
+		core.SetWrittenBytes(100 * 1024 * 1024),
+		core.SetWrittenKeys(1 * 1024 * 1024),
+		core.SetReadBytes(200 * 1024 * 1024),
+		core.SetReadKeys(2 * 1024 * 1024),
+	}
+	newOpts = append(newOpts, opts...)
+	region := core.NewRegionInfo(metaRegion, leader, newOpts...)
+	s.leaderServer.GetRaftCluster().HandleRegionHeartbeat(region)
+}
+
+func (s *testRegionsAPISuite) TestRegionGet(c *C) {
+	resp, err := dialClient.Get(s.leaderServer.GetServer().GetAddr() + regionsPrefix + "/1")
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	got := &handlers.RegionInfo{}
+	c.Assert(json.Unmarshal(buf, &got), IsNil)
+	checkRegionsInfo(c, []*handlers.RegionInfo{got}, []*metapb.Region{s.leaderServer.GetRegionInfoByID(1).GetMeta()})
+	c.Assert(got.ApproximateKeys, Equals, uint64(1000))
+	c.Assert(got.ApproximateSize, Equals, uint64(10))
+	c.Assert(got.WrittenBytes, Equals, uint64(100*1024*1024))
+	c.Assert(got.WrittenKeys, Equals, uint64(1*1024*1024))
+	c.Assert(got.ReadBytes, Equals, uint64(200*1024*1024))
+	c.Assert(got.ReadKeys, Equals, uint64(2*1024*1024))
+}
+
+func (s *testRegionsAPISuite) TestRegionsGet(c *C) {
+	resp, err := dialClient.Get(s.leaderServer.GetServer().GetAddr() + regionsPrefix)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	got := &handlers.RegionsInfo{}
+	c.Assert(json.Unmarshal(buf, &got), IsNil)
+	checkRegionsInfo(c, got.Regions, []*metapb.Region{
+		s.leaderServer.GetRegionInfoByID(1).GetMeta(),
+		s.leaderServer.GetRegionInfoByID(2).GetMeta(),
+		s.leaderServer.GetRegionInfoByID(3).GetMeta(),
+	})
+}
+
+func checkRegionsInfo(c *C, rs []*handlers.RegionInfo, want []*metapb.Region) {
+	c.Assert(len(rs), Equals, len(want))
+	mapWant := make(map[uint64]*metapb.Region)
+	for _, r := range want {
+		if _, ok := mapWant[r.Id]; !ok {
+			mapWant[r.Id] = r
+		}
+	}
+	for _, r := range rs {
+		obtained := r
+		expected := mapWant[obtained.ID]
+		c.Assert(obtained.ID, DeepEquals, expected.GetId())
+		c.Assert(obtained.StartKey, DeepEquals, core.HexRegionKeyStr(expected.GetStartKey()))
+		c.Assert(obtained.EndKey, DeepEquals, core.HexRegionKeyStr(expected.GetEndKey()))
+		c.Assert(obtained.RegionEpoch, DeepEquals, expected.GetRegionEpoch())
+		c.Assert(obtained.Peers[0].ID, DeepEquals, expected.GetPeers()[0].Id)
+		c.Assert(obtained.Peers[0].StoreID, DeepEquals, expected.GetPeers()[0].StoreId)
+	}
+}

--- a/tests/server/apiv2/handlers/stores_test.go
+++ b/tests/server/apiv2/handlers/stores_test.go
@@ -100,7 +100,7 @@ func (s *testStoresAPISuite) TearDownSuite(c *C) {
 	s.cluster.Destroy()
 }
 
-func (s *testStoresAPISuite) TestStoresList(c *C) {
+func (s *testStoresAPISuite) TestStoresGet(c *C) {
 	url := s.leaderServer.GetServer().GetAddr() + storesPrefix
 	resp, err := dialClient.Get(url)
 	c.Assert(err, IsNil)
@@ -197,7 +197,7 @@ func setStoreState(c *C, url, state string, expectStatusCode int) {
 	data := map[string]string{"state": state}
 	putData, err := json.Marshal(data)
 	c.Assert(err, IsNil)
-	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(putData))
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewBuffer(putData))
 	c.Assert(err, IsNil)
 	resp, err := dialClient.Do(req)
 	c.Assert(err, IsNil)

--- a/tests/server/apiv2/handlers/stores_test.go
+++ b/tests/server/apiv2/handlers/stores_test.go
@@ -1,0 +1,220 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/docker/go-units"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/apiv2/handlers"
+	"github.com/tikv/pd/tests"
+)
+
+const storesPrefix = "/pd/api/v2/meta/stores"
+
+var _ = Suite(&testStoresAPISuite{})
+
+type testStoresAPISuite struct {
+	cleanup      context.CancelFunc
+	cluster      *tests.TestCluster
+	leaderServer *tests.TestServer
+	grpcServer   *server.GrpcServer
+}
+
+func (s *testStoresAPISuite) SetUpSuite(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server.EnableZap = true
+	s.cleanup = cancel
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	c.Assert(err, IsNil)
+	c.Assert(cluster.RunInitialServers(), IsNil)
+	c.Assert(cluster.WaitLeader(), Not(HasLen), 0)
+	s.leaderServer = cluster.GetServer(cluster.GetLeader())
+	c.Assert(s.leaderServer.BootstrapCluster(), IsNil)
+	clusterID := s.leaderServer.GetClusterID()
+	storesReqs := []*pdpb.PutStoreRequest{
+		{
+			Header: &pdpb.RequestHeader{ClusterId: clusterID},
+			Store: &metapb.Store{
+				Id:      1,
+				Address: "mock-1",
+				State:   metapb.StoreState_Up,
+			},
+		},
+		{
+			Header: &pdpb.RequestHeader{ClusterId: clusterID},
+			Store: &metapb.Store{
+				Id:      4,
+				Address: "mock-4",
+				State:   metapb.StoreState_Up,
+			},
+		},
+		{
+			Header: &pdpb.RequestHeader{ClusterId: clusterID},
+			Store: &metapb.Store{
+				Id:      6,
+				Address: "mock-6",
+				State:   metapb.StoreState_Offline,
+			},
+		},
+		{
+			Header: &pdpb.RequestHeader{ClusterId: clusterID},
+			Store: &metapb.Store{
+				Id:      7,
+				Address: "mock-7",
+				State:   metapb.StoreState_Tombstone,
+			},
+		},
+	}
+
+	s.grpcServer = &server.GrpcServer{Server: s.leaderServer.GetServer()}
+	for _, store := range storesReqs {
+		_, err = s.grpcServer.PutStore(context.Background(), store)
+		c.Assert(err, IsNil)
+	}
+	s.cluster = cluster
+}
+
+func (s *testStoresAPISuite) TearDownSuite(c *C) {
+	s.cleanup()
+	s.cluster.Destroy()
+}
+
+func (s *testStoresAPISuite) TestStoresList(c *C) {
+	url := s.leaderServer.GetServer().GetAddr() + storesPrefix
+	resp, err := dialClient.Get(url)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	got := &handlers.StoresInfo{}
+	c.Assert(json.Unmarshal(buf, &got), IsNil)
+	checkStoresInfo(c, got.Stores, s.leaderServer.GetStores())
+
+	resp, err = dialClient.Get(url + "?state=Up")
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	buf, err = io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	got = &handlers.StoresInfo{}
+	c.Assert(json.Unmarshal(buf, &got), IsNil)
+	checkStoresInfo(c, got.Stores, []*metapb.Store{s.leaderServer.GetStore(1).GetMeta(), s.leaderServer.GetStore(4).GetMeta()})
+
+	resp, err = dialClient.Get(url + "?state=Offline")
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	buf, err = io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	got = &handlers.StoresInfo{}
+	c.Assert(json.Unmarshal(buf, &got), IsNil)
+	checkStoresInfo(c, got.Stores, []*metapb.Store{s.leaderServer.GetStore(6).GetMeta()})
+}
+
+func (s *testStoresAPISuite) TestStoreGet(c *C) {
+	s.grpcServer.StoreHeartbeat(
+		context.Background(), &pdpb.StoreHeartbeatRequest{
+			Header: &pdpb.RequestHeader{ClusterId: s.leaderServer.GetClusterID()},
+			Stats: &pdpb.StoreStats{
+				StoreId:   1,
+				Capacity:  1798985089024,
+				Available: 1709868695552,
+				UsedSize:  85150956358,
+			},
+		},
+	)
+
+	resp, err := dialClient.Get(s.leaderServer.GetServer().GetAddr() + storesPrefix + "/1")
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	got := &handlers.StoreInfo{}
+	c.Assert(json.Unmarshal(buf, &got), IsNil)
+	checkStoresInfo(c, []*handlers.StoreInfo{got}, []*metapb.Store{s.leaderServer.GetStore(1).GetMeta()})
+	capacity, _ := units.RAMInBytes("1.636TiB")
+	available, _ := units.RAMInBytes("1.555TiB")
+	c.Assert(int64(got.Status.Capacity), Equals, capacity)
+	c.Assert(int64(got.Status.Available), Equals, available)
+}
+
+func (s *testStoresAPISuite) TestStoreSetState(c *C) {
+	url := s.leaderServer.GetServer().GetAddr() + storesPrefix
+	c.Assert(getStoreState(c, url+"/1"), Equals, "Up")
+	setStoreState(c, url+"/1", "Offline", http.StatusOK)
+
+	// store not found
+	setStoreState(c, url+"/2", "Offline", http.StatusNotFound)
+
+	// Invalid state.
+	invalidStates := []string{"Foo", "Tombstone"}
+	for _, state := range invalidStates {
+		setStoreState(c, url+"/1", state, http.StatusBadRequest)
+	}
+
+	// Set back to Up.
+	setStoreState(c, url+"/1", "Up", http.StatusOK)
+	c.Assert(getStoreState(c, url+"/1"), Equals, "Up")
+}
+
+func checkStoresInfo(c *C, ss []*handlers.StoreInfo, want []*metapb.Store) {
+	c.Assert(len(ss), Equals, len(want))
+	mapWant := make(map[uint64]*metapb.Store)
+	for _, s := range want {
+		if _, ok := mapWant[s.Id]; !ok {
+			mapWant[s.Id] = s
+		}
+	}
+	for _, s := range ss {
+		obtained := s.Store.Store
+		expected := mapWant[obtained.Id]
+		// Ignore lastHeartbeat
+		obtained.LastHeartbeat, expected.LastHeartbeat = 0, 0
+		c.Assert(obtained, DeepEquals, expected)
+	}
+}
+
+func setStoreState(c *C, url, state string, expectStatusCode int) {
+	data := map[string]string{"state": state}
+	putData, err := json.Marshal(data)
+	c.Assert(err, IsNil)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(putData))
+	c.Assert(err, IsNil)
+	resp, err := dialClient.Do(req)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, Equals, expectStatusCode)
+}
+
+func getStoreState(c *C, url string) string {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	c.Assert(err, IsNil)
+	resp, err := dialClient.Do(req)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	buf, err := io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	got := &handlers.StoreInfo{}
+	c.Assert(json.Unmarshal(buf, &got), IsNil)
+	return got.Store.Store.State.String()
+}

--- a/tests/server/apiv2/middlewares/redirector_test.go
+++ b/tests/server/apiv2/middlewares/redirector_test.go
@@ -1,0 +1,192 @@
+// Copyright 2018 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redirector_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/tikv/pd/pkg/apiutil/serverapi"
+	"github.com/tikv/pd/pkg/testutil"
+	"github.com/tikv/pd/pkg/typeutil"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/tests"
+)
+
+// dialClient used to dial http request.
+var dialClient = &http.Client{
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+	},
+}
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testRedirectorSuite{})
+
+type testRedirectorSuite struct {
+	cleanup context.CancelFunc
+	cluster *tests.TestCluster
+}
+
+func (s *testRedirectorSuite) SetUpSuite(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	server.EnableZap = true
+	s.cleanup = cancel
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, serverName string) {
+		conf.TickInterval = typeutil.Duration{Duration: 50 * time.Millisecond}
+		conf.ElectionInterval = typeutil.Duration{Duration: 250 * time.Millisecond}
+	})
+	c.Assert(err, IsNil)
+	c.Assert(cluster.RunInitialServers(), IsNil)
+	c.Assert(cluster.WaitLeader(), Not(HasLen), 0)
+	leaderServer := cluster.GetServer(cluster.GetLeader())
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	s.cluster = cluster
+}
+
+func (s *testRedirectorSuite) TearDownSuite(c *C) {
+	s.cleanup()
+	s.cluster.Destroy()
+}
+
+func (s *testRedirectorSuite) TestRedirect(c *C) {
+	leader := s.cluster.GetServer(s.cluster.GetLeader())
+	c.Assert(leader, NotNil)
+	request, err := http.NewRequest(http.MethodGet, leader.GetServer().GetAddr()+"/pd/api/v2/members", nil)
+	c.Assert(err, IsNil)
+	header := mustRequestSuccess(c, request)
+	header.Del("Date")
+	for _, svr := range s.cluster.GetServers() {
+		if svr != leader {
+			h := mustRequestSuccess(c, request)
+			h.Del("Date")
+			c.Assert(header, DeepEquals, h)
+		}
+	}
+}
+
+func (s *testRedirectorSuite) TestRedirectAfterStop(c *C) {
+	// Make connections to followers.
+	// Make sure they proxy requests to the leader.
+	leader := s.cluster.GetLeader()
+	for name, s := range s.cluster.GetServers() {
+		if name != leader {
+			request, err := http.NewRequest(http.MethodGet, s.GetConfig().AdvertiseClientUrls+"/pd/api/v2/members", nil)
+			c.Assert(err, IsNil)
+			_ = mustRequestSuccess(c, request)
+		}
+	}
+
+	// Close the leader and wait for a new one.
+	err := s.cluster.GetServer(leader).Stop()
+	c.Assert(err, IsNil)
+	defer s.cluster.GetServer(leader).Run()
+	newLeader := s.cluster.WaitLeader()
+	c.Assert(newLeader, Not(HasLen), 0)
+
+	// Make sure they proxy requests to the new leader.
+	for name, s := range s.cluster.GetServers() {
+		if name != leader {
+			testutil.WaitUntil(c, func() bool {
+				res, err := http.Get(s.GetConfig().AdvertiseClientUrls + "/pd/api/v2/members")
+				c.Assert(err, IsNil)
+				defer res.Body.Close()
+				return res.StatusCode == http.StatusOK
+			})
+		}
+	}
+
+	// Close the new leader and then we have only one node.
+	err = s.cluster.GetServer(newLeader).Stop()
+	c.Assert(err, IsNil)
+	defer s.cluster.GetServer(newLeader).Run()
+
+	// Request will fail with no leader.
+	for name, s := range s.cluster.GetServers() {
+		if name != leader && name != newLeader {
+			testutil.WaitUntil(c, func() bool {
+				res, err := http.Get(s.GetConfig().AdvertiseClientUrls + "/pd/api/v2/")
+				c.Assert(err, IsNil)
+				defer res.Body.Close()
+				return res.StatusCode == http.StatusServiceUnavailable
+			})
+		}
+	}
+}
+
+func (s *testRedirectorSuite) TestAllowFollowerHandle(c *C) {
+	// Find a follower.
+	var follower *server.Server
+	leader := s.cluster.GetServer(s.cluster.GetLeader())
+	for _, svr := range s.cluster.GetServers() {
+		if svr != leader {
+			follower = svr.GetServer()
+			break
+		}
+	}
+
+	addr := follower.GetAddr() + "/pd/api/v2/members"
+	request, err := http.NewRequest(http.MethodGet, addr, nil)
+	c.Assert(err, IsNil)
+	request.Header.Add(serverapi.AllowFollowerHandle, "true")
+	header := mustRequestSuccess(c, request)
+	c.Assert(header.Get(serverapi.RedirectorHeader), Equals, "")
+}
+
+func (s *testRedirectorSuite) TestNotLeader(c *C) {
+	// Find a follower.
+	var follower *server.Server
+	leader := s.cluster.GetServer(s.cluster.GetLeader())
+	for _, svr := range s.cluster.GetServers() {
+		if svr != leader {
+			follower = svr.GetServer()
+			break
+		}
+	}
+
+	addr := follower.GetAddr() + "/pd/api/v2/members"
+	// Request to follower without redirectorHeader is OK.
+	request, err := http.NewRequest(http.MethodGet, addr, nil)
+	c.Assert(err, IsNil)
+	_ = mustRequestSuccess(c, request)
+
+	// Request to follower with redirectorHeader will fail.
+	request.RequestURI = ""
+	request.Header.Set(serverapi.RedirectorHeader, "pd")
+	resp, err := dialClient.Do(request)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, Not(Equals), http.StatusOK)
+	_, err = io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+}
+
+func mustRequestSuccess(c *C, req *http.Request) http.Header {
+	resp, err := dialClient.Do(req)
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	return resp.Header
+}

--- a/tests/server/apiv2/middlewares/redirector_test.go
+++ b/tests/server/apiv2/middlewares/redirector_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package redirector_test
+package middlewares_test
 
 import (
 	"context"


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Close #4640.

<!-- Add the issue link with a summary if it exists. -->

### What is changed and how it works?
This PR tries to support the v2 HTTP API which is RESTful and more standard. The reason why it is needed can be found in the above issue. Fow now, this PR only supports two kinds of APIs with the common prefix `/pd/api/v2`:
- `/meta/stores`
- `/members`

**Notice: They are very likely to be changed in the next few days.** 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Introduce the v2 HTTP API
```
