### PR TITLE
checker: update TTL according to SplitMergeInterval

### DIFF
--- a/pkg/cache/ttl.go
+++ b/pkg/cache/ttl.go
@@ -167,6 +167,23 @@ func (c *ttlCache) doGC() {
 	}
 }
 
+// UpdateTTL updates the TTL for the cache.
+func (c *ttlCache) UpdateTTL(duration time.Duration) {
+	c.Lock()
+	defer c.Unlock()
+	if c.ttl == duration {
+		return
+	}
+
+	for key := range c.items {
+		c.items[key] = ttlCacheItem{
+			value:  c.items[key].value,
+			expire: time.Now().Add(duration),
+		}
+	}
+	c.ttl = duration
+}
+
 // TTLUint64 is simple TTL saves only uint64s.
 type TTLUint64 struct {
 	*ttlCache

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -90,6 +90,7 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		return nil
 	}
 
+	m.splitCache.UpdateTTL(m.opts.GetSplitMergeInterval())
 	if m.splitCache.Exists(region.GetID()) {
 		checkerCounter.WithLabelValues("merge_checker", "recently-split").Inc()
 		return nil

--- a/server/schedule/checker/merge_checker_test.go
+++ b/server/schedule/checker/merge_checker_test.go
@@ -227,6 +227,18 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	c.Assert(ops, IsNil)
 	ops = s.mc.Check(s.regions[3])
 	c.Assert(ops, IsNil)
+
+	s.cluster.SetSplitMergeInterval(500 * time.Millisecond)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, IsNil)
+	ops = s.mc.Check(s.regions[3])
+	c.Assert(ops, IsNil)
+
+	time.Sleep(500 * time.Millisecond)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	ops = s.mc.Check(s.regions[3])
+	c.Assert(ops, NotNil)
 }
 
 func (s *testMergeCheckerSuite) checkSteps(c *C, op *operator.Operator, steps []operator.OpStep) {


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Close #4614.

### What is changed and how it works?

Update TTL when split-merge-interval is changed.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
