### PR TITLE
api: fix invalid interface conversion

### DIFF
--- a/pkg/typeutil/conversion.go
+++ b/pkg/typeutil/conversion.go
@@ -51,3 +51,20 @@ func BoolToInt(b bool) int {
 	}
 	return 0
 }
+
+// JSONToUint64Slice converts JSON slice to uint64 slice.
+func JSONToUint64Slice(from interface{}) ([]uint64, bool) {
+	items, ok := from.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	to := make([]uint64, 0, len(items))
+	for _, item := range items {
+		id, ok := item.(float64)
+		if !ok {
+			return nil, false
+		}
+		to = append(to, uint64(id))
+	}
+	return to, true
+}

--- a/pkg/typeutil/conversion_test.go
+++ b/pkg/typeutil/conversion_test.go
@@ -15,6 +15,9 @@
 package typeutil
 
 import (
+	"encoding/json"
+	"reflect"
+
 	. "github.com/pingcap/check"
 )
 
@@ -34,4 +37,24 @@ func (s *testUint64BytesSuite) TestUint64ToBytes(c *C) {
 	b := Uint64ToBytes(a)
 	str := "\x00\x00\x00\x00\x00\x00\x03\xe8"
 	c.Assert(b, DeepEquals, []byte(str))
+}
+
+var _ = Suite(&testJSONSuite{})
+
+type testJSONSuite struct{}
+
+func (s *testJSONSuite) TestJSONToUint64Slice(c *C) {
+	type testArray struct {
+		Array []uint64 `json:"array"`
+	}
+	a := testArray{
+		Array: []uint64{1, 2, 3},
+	}
+	bytes, _ := json.Marshal(a)
+	var t map[string]interface{}
+	err := json.Unmarshal(bytes, &t)
+	c.Assert(err, IsNil)
+	res, ok := JSONToUint64Slice(t["array"])
+	c.Assert(ok, IsTrue)
+	c.Assert(reflect.TypeOf(res[0]).Kind(), Equals, reflect.Uint64)
 }

--- a/pkg/typeutil/conversion_test.go
+++ b/pkg/typeutil/conversion_test.go
@@ -54,7 +54,26 @@ func (s *testJSONSuite) TestJSONToUint64Slice(c *C) {
 	var t map[string]interface{}
 	err := json.Unmarshal(bytes, &t)
 	c.Assert(err, IsNil)
+	// valid case
 	res, ok := JSONToUint64Slice(t["array"])
 	c.Assert(ok, IsTrue)
 	c.Assert(reflect.TypeOf(res[0]).Kind(), Equals, reflect.Uint64)
+	// invalid case
+	_, ok = t["array"].([]uint64)
+	c.Assert(ok, IsFalse)
+
+	// invalid type
+	type testArray1 struct {
+		Array []string `json:"array"`
+	}
+	a1 := testArray1{
+		Array: []string{"1", "2", "3"},
+	}
+	bytes, _ = json.Marshal(a1)
+	var t1 map[string]interface{}
+	err = json.Unmarshal(bytes, &t1)
+	c.Assert(err, IsNil)
+	res, ok = JSONToUint64Slice(t1["array"])
+	c.Assert(ok, IsFalse)
+	c.Assert(res, IsNil)
 }

--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/tikv/pd/pkg/apiutil"
+	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/schedule/operator"
 	"github.com/tikv/pd/server/schedule/placement"
@@ -286,8 +287,7 @@ func (h *operatorHandler) Post(w http.ResponseWriter, r *http.Request) {
 		// support both receiving key ranges or regionIDs
 		startKey, _ := input["start_key"].(string)
 		endKey, _ := input["end_key"].(string)
-		regionIDs, _ := input["region_ids"].([]interface{})
-		ids, ok := toUint64Slice(regionIDs)
+		ids, ok := typeutil.JSONToUint64Slice(input["region_ids"])
 		if !ok {
 			h.r.JSON(w, http.StatusBadRequest, "region_ids is invalid")
 			return

--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -286,14 +286,19 @@ func (h *operatorHandler) Post(w http.ResponseWriter, r *http.Request) {
 		// support both receiving key ranges or regionIDs
 		startKey, _ := input["start_key"].(string)
 		endKey, _ := input["end_key"].(string)
-		regionIDs, _ := input["region_ids"].([]uint64)
-		group, _ := input["group"].(string)
-		retryLimit, ok := input["retry_limit"].(int)
+		regionIDs, _ := input["region_ids"].([]interface{})
+		ids, ok := toUint64Slice(regionIDs)
 		if !ok {
-			// retry 5 times if retryLimit not defined
-			retryLimit = 5
+			h.r.JSON(w, http.StatusBadRequest, "region_ids is invalid")
+			return
 		}
-		processedPercentage, err := h.AddScatterRegionsOperators(regionIDs, startKey, endKey, group, retryLimit)
+		group, _ := input["group"].(string)
+		// retry 5 times if retryLimit not defined
+		retryLimit := 5
+		if rl, ok := input["retry_limit"].(float64); ok {
+			retryLimit = int(rl)
+		}
+		processedPercentage, err := h.AddScatterRegionsOperators(ids, startKey, endKey, group, retryLimit)
 		errorMessage := ""
 		if err != nil {
 			errorMessage = err.Error()

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/replication_modepb"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/apiutil"
+	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule"
@@ -829,8 +830,7 @@ func (h *regionsHandler) ScatterRegions(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	} else {
-		regionIDs := input["regions_id"].([]interface{})
-		ids, ok := toUint64Slice(regionIDs)
+		ids, ok := typeutil.JSONToUint64Slice(input["regions_id"])
 		if !ok {
 			h.rd.JSON(w, http.StatusBadRequest, "regions_id is invalid")
 			return

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -336,6 +336,10 @@ func (s *testRegionSuite) TestScatterRegions(c *C) {
 	op3 := s.svr.GetRaftCluster().GetOperatorController().GetOperator(603)
 	// At least one operator used to scatter region
 	c.Assert(op1 != nil || op2 != nil || op3 != nil, IsTrue)
+
+	body = `{"regions_id": [601, 602, 603]}`
+	err = postJSON(testDialClient, fmt.Sprintf("%s/regions/scatter", s.urlPrefix), []byte(body))
+	c.Assert(err, IsNil)
 }
 
 func (s *testRegionSuite) TestSplitRegions(c *C) {
@@ -344,7 +348,7 @@ func (s *testRegionSuite) TestSplitRegions(c *C) {
 	mustRegionHeartbeat(c, s.svr, r1)
 	mustPutStore(c, s.svr, 13, metapb.StoreState_Up, []*metapb.StoreLabel{})
 	newRegionID := uint64(11)
-	body := fmt.Sprintf(`{"retry_limit":%v, "split_keys": ["%s","%s","%s"]}`, 0,
+	body := fmt.Sprintf(`{"retry_limit":%v, "split_keys": ["%s","%s","%s"]}`, 3,
 		hex.EncodeToString([]byte("bbb")),
 		hex.EncodeToString([]byte("ccc")),
 		hex.EncodeToString([]byte("ddd")))

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -174,3 +174,19 @@ func doJSON(client *http.Client, req *http.Request, checkOpts ...func([]byte, in
 	}
 	return nil
 }
+
+func toUint64Slice(from interface{}) ([]uint64, bool) {
+	items, ok := from.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	to := make([]uint64, 0, len(items))
+	for _, item := range items {
+		id, ok := item.(float64)
+		if !ok {
+			return nil, false
+		}
+		to = append(to, uint64(id))
+	}
+	return to, true
+}

--- a/server/api/util.go
+++ b/server/api/util.go
@@ -174,19 +174,3 @@ func doJSON(client *http.Client, req *http.Request, checkOpts ...func([]byte, in
 	}
 	return nil
 }
-
-func toUint64Slice(from interface{}) ([]uint64, bool) {
-	items, ok := from.([]interface{})
-	if !ok {
-		return nil, false
-	}
-	to := make([]uint64, 0, len(items))
-	for _, item := range items {
-		id, ok := item.(float64)
-		if !ok {
-			return nil, false
-		}
-		to = append(to, uint64(id))
-	}
-	return to, true
-}


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?

Fix #4617.

### What is changed and how it works?

Correctly convert `[]interface{}` to `[]uint64` after JSON `Unmarshal`.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the Region ID list cannot be converted to `uint64`
```
