### PR TITLE
Support to pause scheduling on specific regions

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -266,6 +266,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(clusterRouter, "GetLearnerPeerRegions", "/regions/check/learner-peer", regionsHandler.GetLearnerPeerRegions, setMethods("GET"))
 	registerFunc(clusterRouter, "GetEmptyRegion", "/regions/check/empty-region", regionsHandler.GetEmptyRegion, setMethods("GET"))
 	registerFunc(clusterRouter, "GetOfflinePeer", "/regions/check/offline-peer", regionsHandler.GetOfflinePeer, setMethods("GET"))
+	registerFunc(clusterRouter, "GetPinnedRegions", "/regions/check/pinned-region", regionsHandler.GetPinnedRegions, setMethods("GET"))
 
 	registerFunc(clusterRouter, "GetSizeHistogram", "/regions/check/hist-size", regionsHandler.GetSizeHistogram, setMethods("GET"))
 	registerFunc(clusterRouter, "GetKeysHistogram", "/regions/check/hist-keys", regionsHandler.GetKeysHistogram, setMethods("GET"))
@@ -273,6 +274,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(clusterRouter, "AccelerateRegionsSchedule", "/regions/accelerate-schedule", regionsHandler.AccelerateRegionsScheduleInRange, setMethods("POST"))
 	registerFunc(clusterRouter, "ScatterRegions", "/regions/scatter", regionsHandler.ScatterRegions, setMethods("POST"))
 	registerFunc(clusterRouter, "SplitRegions", "/regions/split", regionsHandler.SplitRegions, setMethods("POST"))
+	registerFunc(clusterRouter, "PinRegions", "/regions/pin", regionsHandler.PinRegions, setMethods("POST"))
 	registerFunc(clusterRouter, "GetRangeHoles", "/regions/range-holes", regionsHandler.GetRangeHoles, setMethods("GET"))
 	registerFunc(clusterRouter, "CheckRegionsReplicated", "/regions/replicated", regionsHandler.CheckRegionsReplicated, setMethods("GET"), setQueries("startKey", "{startKey}", "endKey", "{endKey}"))
 

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -84,6 +84,11 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		return nil
 	}
 
+	if m.cluster.IsRegionPinned(region) {
+		checkerCounter.WithLabelValues("merge_checker", "pinned").Inc()
+		return nil
+	}
+
 	expireTime := m.startTime.Add(m.opts.GetSplitMergeInterval())
 	if time.Now().Before(expireTime) {
 		checkerCounter.WithLabelValues("merge_checker", "recently-start").Inc()
@@ -169,6 +174,11 @@ func (m *MergeChecker) Check(region *core.RegionInfo) []*operator.Operator {
 func (m *MergeChecker) checkTarget(region, adjacent *core.RegionInfo) bool {
 	if adjacent == nil {
 		checkerCounter.WithLabelValues("merge_checker", "adj-not-exist").Inc()
+		return false
+	}
+
+	if m.cluster.IsRegionPinned(adjacent) {
+		checkerCounter.WithLabelValues("merge_checker", "adj-pinned").Inc()
 		return false
 	}
 

--- a/server/schedule/checker/merge_checker_test.go
+++ b/server/schedule/checker/merge_checker_test.go
@@ -165,6 +165,12 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
 	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
 
+	// Test pin region.
+	s.cluster.PinRegions([]uint64{s.regions[2].GetID()}, time.Minute)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, IsNil)
+	s.cluster.PinRegions([]uint64{s.regions[2].GetID()}, 0)
+
 	// Enable one way merge
 	s.cluster.SetEnableOneWayMerge(true)
 	ops = s.mc.Check(s.regions[2])
@@ -179,6 +185,15 @@ func (s *testMergeCheckerSuite) TestBasic(c *C) {
 	// Now it merges to next region.
 	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
 	c.Assert(ops[1].RegionID(), Equals, s.regions[3].GetID())
+
+	// Test pin next region.
+	s.cluster.PinRegions([]uint64{s.regions[3].GetID()}, time.Minute)
+	ops = s.mc.Check(s.regions[2])
+	c.Assert(ops, NotNil)
+	// Now it merges to prev region.
+	c.Assert(ops[0].RegionID(), Equals, s.regions[2].GetID())
+	c.Assert(ops[1].RegionID(), Equals, s.regions[1].GetID())
+	s.cluster.PinRegions([]uint64{s.regions[3].GetID()}, 0)
 
 	// merge cannot across rule key.
 	s.cluster.SetEnablePlacementRules(true)

--- a/server/schedule/checker/split_checker.go
+++ b/server/schedule/checker/split_checker.go
@@ -56,6 +56,11 @@ func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 		return nil
 	}
 
+	if c.cluster.IsRegionPinned(region) {
+		checkerCounter.WithLabelValues("split_checker", "pinned").Inc()
+		return nil
+	}
+
 	start, end := region.GetStartKey(), region.GetEndKey()
 	// We may consider to merge labeler split keys and rule split keys together
 	// before creating operator. It can help to reduce operator count. However,

--- a/server/schedule/cluster.go
+++ b/server/schedule/cluster.go
@@ -33,4 +33,5 @@ type Cluster interface {
 
 	RemoveScheduler(name string) error
 	AddSuspectRegions(ids ...uint64)
+	IsRegionPinned(region *core.RegionInfo) bool
 }

--- a/server/schedule/healthy.go
+++ b/server/schedule/healthy.go
@@ -44,3 +44,8 @@ func IsRegionReplicated(cluster Cluster, region *core.RegionInfo) bool {
 func ReplicatedRegion(cluster Cluster) func(*core.RegionInfo) bool {
 	return func(region *core.RegionInfo) bool { return IsRegionReplicated(cluster, region) }
 }
+
+// NonPinnedRegion returns a function that checks if a region is not pinned.
+func NonPinnedRegion(cluster Cluster) func(*core.RegionInfo) bool {
+	return func(region *core.RegionInfo) bool { return !cluster.IsRegionPinned(region) }
+}

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -171,18 +171,22 @@ func (s *balanceRegionScheduler) Schedule(cluster schedule.Cluster) []*operator.
 			schedulerCounter.WithLabelValues(s.GetName(), "total").Inc()
 			// Priority pick the region that has a pending peer.
 			// Pending region may means the disk is overload, remove the pending region firstly.
-			plan.region = cluster.RandPendingRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthyAllowPending, schedule.ReplicatedRegion(cluster), allowBalanceEmptyRegion)
+			plan.region = cluster.RandPendingRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthyAllowPending,
+				schedule.ReplicatedRegion(cluster), schedule.NonPinnedRegion(cluster), allowBalanceEmptyRegion)
 			if plan.region == nil {
 				// Then pick the region that has a follower in the source store.
-				plan.region = cluster.RandFollowerRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthy, schedule.ReplicatedRegion(cluster), allowBalanceEmptyRegion)
+				plan.region = cluster.RandFollowerRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthy,
+					schedule.ReplicatedRegion(cluster), schedule.NonPinnedRegion(cluster), allowBalanceEmptyRegion)
 			}
 			if plan.region == nil {
 				// Then pick the region has the leader in the source store.
-				plan.region = cluster.RandLeaderRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthy, schedule.ReplicatedRegion(cluster), allowBalanceEmptyRegion)
+				plan.region = cluster.RandLeaderRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthy,
+					schedule.ReplicatedRegion(cluster), schedule.NonPinnedRegion(cluster), allowBalanceEmptyRegion)
 			}
 			if plan.region == nil {
 				// Finally pick learner.
-				plan.region = cluster.RandLearnerRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthy, schedule.ReplicatedRegion(cluster), allowBalanceEmptyRegion)
+				plan.region = cluster.RandLearnerRegion(plan.SourceStoreID(), s.conf.Ranges, schedule.IsRegionHealthy,
+					schedule.ReplicatedRegion(cluster), schedule.NonPinnedRegion(cluster), allowBalanceEmptyRegion)
 			}
 			if plan.region == nil {
 				schedulerCounter.WithLabelValues(s.GetName(), "no-region").Inc()

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -664,6 +664,11 @@ func (bs *balanceSolver) isRegionAvailable(region *core.RegionInfo) bool {
 		return false
 	}
 
+	if bs.IsRegionPinned(region) {
+		schedulerCounter.WithLabelValues(bs.sche.GetName(), "pinned-region").Inc()
+		return false
+	}
+
 	return true
 }
 

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -148,5 +148,8 @@ func (s *randomMergeScheduler) allowMerge(cluster schedule.Cluster, region, targ
 	if cluster.IsRegionHot(region) || cluster.IsRegionHot(target) {
 		return false
 	}
+	if cluster.IsRegionPinned(region) || cluster.IsRegionPinned(target) {
+		return false
+	}
 	return checker.AllowMerge(cluster, region, target)
 }

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -171,6 +171,9 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster schedule.Cluster, loa
 		if srcRegion == nil || len(srcRegion.GetDownPeers()) != 0 || len(srcRegion.GetPendingPeers()) != 0 {
 			continue
 		}
+		if cluster.IsRegionPinned(srcRegion) {
+			continue
+		}
 		srcStoreID := srcRegion.GetLeader().GetStoreId()
 		srcStore := cluster.GetStore(srcStoreID)
 		if srcStore == nil {

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -115,7 +115,7 @@ func (s *shuffleLeaderScheduler) Schedule(cluster schedule.Cluster) []*operator.
 		schedulerCounter.WithLabelValues(s.GetName(), "no-target-store").Inc()
 		return nil
 	}
-	region := cluster.RandFollowerRegion(targetStore.GetID(), s.conf.Ranges, schedule.IsRegionHealthy)
+	region := cluster.RandFollowerRegion(targetStore.GetID(), s.conf.Ranges, schedule.IsRegionHealthy, schedule.NonPinnedRegion(cluster))
 	if region == nil {
 		schedulerCounter.WithLabelValues(s.GetName(), "no-follower").Inc()
 		return nil

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -135,13 +135,16 @@ func (s *shuffleRegionScheduler) scheduleRemovePeer(cluster schedule.Cluster) (*
 	for _, source := range candidates.Stores {
 		var region *core.RegionInfo
 		if s.conf.IsRoleAllow(roleFollower) {
-			region = cluster.RandFollowerRegion(source.GetID(), s.conf.GetRanges(), schedule.IsRegionHealthy, schedule.ReplicatedRegion(cluster))
+			region = cluster.RandFollowerRegion(source.GetID(), s.conf.GetRanges(), schedule.IsRegionHealthy,
+				schedule.ReplicatedRegion(cluster), schedule.NonPinnedRegion(cluster))
 		}
 		if region == nil && s.conf.IsRoleAllow(roleLeader) {
-			region = cluster.RandLeaderRegion(source.GetID(), s.conf.GetRanges(), schedule.IsRegionHealthy, schedule.ReplicatedRegion(cluster))
+			region = cluster.RandLeaderRegion(source.GetID(), s.conf.GetRanges(), schedule.IsRegionHealthy,
+				schedule.ReplicatedRegion(cluster), schedule.NonPinnedRegion(cluster))
 		}
 		if region == nil && s.conf.IsRoleAllow(roleLearner) {
-			region = cluster.RandLearnerRegion(source.GetID(), s.conf.GetRanges(), schedule.IsRegionHealthy, schedule.ReplicatedRegion(cluster))
+			region = cluster.RandLearnerRegion(source.GetID(), s.conf.GetRanges(), schedule.IsRegionHealthy,
+				schedule.ReplicatedRegion(cluster), schedule.NonPinnedRegion(cluster))
 		}
 		if region != nil {
 			return region, region.GetStorePeer(source.GetID())


### PR DESCRIPTION
### What problem does this PR solve?

Currently Pd can only pause scheduler for whole cluster, which does not work well for [online bulk load](https://github.com/tikv/rfcs/blob/master/text/0072-online-bulk-load-for-rawkv.md). This PR add support to pause scheduling on specific regions.

### What is changed and how it works?
1. Add a TTLCache in RaftCluster struct to store pinned regions.
2. Modify most schedulers and checkers to skip pinned regions when calc operators.
3. Add rest api to pin regions by key range or regions id with given duration, as well as list currently pinned regions.
4. The pin api should be used immediately after split and scatter in most case.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test

### Release note
```release-note
Support to pause scheduling on specific regions
```