### PR TITLE
server/api/*test: fix ci-lint caused by bodyclose

### DIFF
--- a/server/api/pprof_test.go
+++ b/server/api/pprof_test.go
@@ -48,6 +48,7 @@ func (s *ProfSuite) TearDownSuite(c *C) {
 func (s *ProfSuite) TestGetZip(c *C) {
 	rsp, err := testDialClient.Get(s.urlPrefix + "/pprof/zip?" + "seconds=5s")
 	c.Assert(err, IsNil)
+	defer rsp.Body.Close()
 	body, err := ioutil.ReadAll(rsp.Body)
 	c.Assert(err, IsNil)
 	c.Assert(body, NotNil)

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -142,6 +142,7 @@ func (s *testStatsSuite) TestRegionStats(c *C) {
 	}
 	res, err := testDialClient.Get(statsURL)
 	c.Assert(err, IsNil)
+	defer res.Body.Close()
 	stats := &statistics.RegionStats{}
 	err = apiutil.ReadJSON(res.Body, stats)
 	c.Assert(err, IsNil)
@@ -150,6 +151,7 @@ func (s *testStatsSuite) TestRegionStats(c *C) {
 	args := fmt.Sprintf("?start_key=%s&end_key=%s", url.QueryEscape("\x01\x02"), url.QueryEscape("xyz\x00\x00"))
 	res, err = testDialClient.Get(statsURL + args)
 	c.Assert(err, IsNil)
+	defer res.Body.Close()
 	stats = &statistics.RegionStats{}
 	err = apiutil.ReadJSON(res.Body, stats)
 	c.Assert(err, IsNil)
@@ -171,6 +173,7 @@ func (s *testStatsSuite) TestRegionStats(c *C) {
 	args = fmt.Sprintf("?start_key=%s&end_key=%s", url.QueryEscape("a"), url.QueryEscape("x"))
 	res, err = testDialClient.Get(statsURL + args)
 	c.Assert(err, IsNil)
+	defer res.Body.Close()
 	stats = &statistics.RegionStats{}
 	err = apiutil.ReadJSON(res.Body, stats)
 	c.Assert(err, IsNil)

--- a/server/api/util_test.go
+++ b/server/api/util_test.go
@@ -41,6 +41,7 @@ func (s *testUtilSuite) TestJsonRespondErrorOk(c *C) {
 	c.Assert(input["zone"], Equals, output["zone"])
 	c.Assert(input["host"], Equals, output["host"])
 	result := response.Result()
+	defer result.Body.Close()
 	c.Assert(result.StatusCode, Equals, 200)
 }
 
@@ -55,6 +56,7 @@ func (s *testUtilSuite) TestJsonRespondErrorBadInput(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "json: cannot unmarshal object into Go value of type []string")
 	result := response.Result()
+	defer result.Body.Close()
 	c.Assert(result.StatusCode, Equals, 400)
 
 	{
@@ -64,6 +66,7 @@ func (s *testUtilSuite) TestJsonRespondErrorBadInput(c *C) {
 		c.Assert(err, NotNil)
 		c.Assert(err.Error(), Equals, "unexpected end of JSON input")
 		result := response.Result()
+		defer result.Body.Close()
 		c.Assert(result.StatusCode, Equals, 400)
 	}
 }


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

This PR will fix the failure caused by `golangci-lint`, the details:

```
go version
go version go1.17.6 darwin/amd64

golangci-lint --version
golangci-lint has version v1.44.0 
```

the error imformation after running `make check`
```
make check
gofmt ...
golangci-lint ...
server/api/util_test.go:43:27: response body must be closed (bodyclose)
        result := response.Result()
                                 ^
server/api/util_test.go:57:27: response body must be closed (bodyclose)
        result := response.Result()
                                 ^
server/api/util_test.go:66:28: response body must be closed (bodyclose)
                result := response.Result()
                                         ^
make: *** [static] Error 1
```

### What problem does this PR solve?

This PR will fix the above failure.

### What is changed and how it works?
It closed the related bodies(This PR only changes the test file)
Now we can run the command `make check` successfully in the above environment。

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- No code


### Release note

```release-note
NONE
```