### PR TITLE
server/core/region.go: tiny refactor set_region

### DIFF
--- a/server/core/region.go
+++ b/server/core/region.go
@@ -658,7 +658,6 @@ func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 // overlaps: Other regions that overlap with the specified region, excluding itself.
 func (r *RegionsInfo) SetRegion(region *RegionInfo) (overlaps []*RegionInfo) {
 	var item *regionItem // Pointer to the *RegionInfo of this ID.
-	//var origin *RegionInfo // This is the original region information of this ID.
 	rangeChanged := true // This Region is new, or its range has changed.
 	if item = r.regions.Get(region.GetID()); item != nil {
 		// If this ID already exists, use the existing regionItem and pick out the origin.

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -90,9 +90,9 @@ func classifyVoterAndLearner(region *RegionInfo) {
 	region.voters = voters
 }
 
-// peersEqual returns true when the peers are not changed, which may caused by: the region leader not changed,
+// peersEqualTo returns true when the peers are not changed, which may caused by: the region leader not changed,
 // peer transferred, new peer was created, learners changed, pendingPeers changed.
-func (r *RegionInfo) peersEqual(region *RegionInfo) bool {
+func (r *RegionInfo) peersEqualTo(region *RegionInfo) bool {
 	return r.leader.GetId() == region.leader.GetId() &&
 		SortedPeersEqual(r.GetVoters(), region.GetVoters()) &&
 		SortedPeersEqual(r.GetLearners(), region.GetLearners()) &&
@@ -672,14 +672,14 @@ func (r *RegionsInfo) SetRegion(region *RegionInfo) (overlaps []*RegionInfo) {
 			r.tree.updateStat(origin, region)
 		}
 
-		if !rangeChanged && origin.peersEqual(region) {
+		if !rangeChanged && origin.peersEqualTo(region) {
 			// If the peers are not changed, only the statistical on the sub regionTree needs to be updated.
 			r.updateSubTreeStat(origin, region)
 			// Update the RegionInfo in the regionItem.
 			item.region = region
 			return
 		}
-		// If the peers have changed, the sub regionTree needs to be cleaned up.
+		// If the range or peers have changed, the sub regionTree needs to be cleaned up.
 		// TODO: Improve performance by deleting only the different peers.
 		r.removeRegionFromSubTree(origin)
 		// Update the RegionInfo in the regionItem.

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -504,25 +504,25 @@ func (*testRegionKey) TestShouldRemoveFromSubTree(c *C) {
 		StartKey: []byte(fmt.Sprintf("%20d", 10)),
 		EndKey:   []byte(fmt.Sprintf("%20d", 20)),
 	}, peer1)
-	c.Assert(region.peersEqual(origin), IsTrue)
+	c.Assert(region.peersEqualTo(origin), IsTrue)
 
 	region.leader = peer2
-	c.Assert(region.peersEqual(origin), IsFalse)
+	c.Assert(region.peersEqualTo(origin), IsFalse)
 
 	region.leader = peer1
 	region.pendingPeers = append(region.pendingPeers, peer4)
-	c.Assert(region.peersEqual(origin), IsFalse)
+	c.Assert(region.peersEqualTo(origin), IsFalse)
 
 	region.pendingPeers = nil
 	region.learners = append(region.learners, peer2)
-	c.Assert(region.peersEqual(origin), IsFalse)
+	c.Assert(region.peersEqualTo(origin), IsFalse)
 
 	origin.learners = append(origin.learners, peer2, peer3)
 	region.learners = append(region.learners, peer4)
-	c.Assert(region.peersEqual(origin), IsTrue)
+	c.Assert(region.peersEqualTo(origin), IsTrue)
 
 	region.voters[2].StoreId = 4
-	c.Assert(region.peersEqual(origin), IsFalse)
+	c.Assert(region.peersEqualTo(origin), IsFalse)
 }
 
 func checkRegions(c *C, regions *RegionsInfo) {

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -487,7 +487,6 @@ func (*testRegionKey) TestSetRegion(c *C) {
 }
 
 func (*testRegionKey) TestShouldRemoveFromSubTree(c *C) {
-	regions := NewRegionsInfo()
 	peer1 := &metapb.Peer{StoreId: uint64(1), Id: uint64(1)}
 	peer2 := &metapb.Peer{StoreId: uint64(2), Id: uint64(2)}
 	peer3 := &metapb.Peer{StoreId: uint64(3), Id: uint64(3)}
@@ -505,25 +504,25 @@ func (*testRegionKey) TestShouldRemoveFromSubTree(c *C) {
 		StartKey: []byte(fmt.Sprintf("%20d", 10)),
 		EndKey:   []byte(fmt.Sprintf("%20d", 20)),
 	}, peer1)
-	c.Assert(regions.shouldRemoveFromSubTree(region, origin), IsFalse)
+	c.Assert(region.peersEqual(origin), IsTrue)
 
 	region.leader = peer2
-	c.Assert(regions.shouldRemoveFromSubTree(region, origin), IsTrue)
+	c.Assert(region.peersEqual(origin), IsFalse)
 
 	region.leader = peer1
 	region.pendingPeers = append(region.pendingPeers, peer4)
-	c.Assert(regions.shouldRemoveFromSubTree(region, origin), IsTrue)
+	c.Assert(region.peersEqual(origin), IsFalse)
 
 	region.pendingPeers = nil
 	region.learners = append(region.learners, peer2)
-	c.Assert(regions.shouldRemoveFromSubTree(region, origin), IsTrue)
+	c.Assert(region.peersEqual(origin), IsFalse)
 
 	origin.learners = append(origin.learners, peer2, peer3)
 	region.learners = append(region.learners, peer4)
-	c.Assert(regions.shouldRemoveFromSubTree(region, origin), IsFalse)
+	c.Assert(region.peersEqual(origin), IsTrue)
 
 	region.voters[2].StoreId = 4
-	c.Assert(regions.shouldRemoveFromSubTree(region, origin), IsTrue)
+	c.Assert(region.peersEqual(origin), IsFalse)
 }
 
 func checkRegions(c *C, regions *RegionsInfo) {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
The function [SetRegion](https://github.com/tikv/pd/blob/master/server/core/region.go#L645) is not very friendly to our reviewers, exp: too many `{}` in `{}`,  the max degree of `{}` is 4. 

### What is changed and how it works?
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
 This PR tidy refactor the function [SetRegion](https://github.com/tikv/pd/blob/master/server/core/region.go#L645) to make it more friendly to our reviewers and maintainers, exp: we decrease the max degree of `{}` from 4 to 2 and try to return as early as possible. The function is still very long and it is not the perfect refactor, however, we are trying to make it better. Feel free to refactor it ～～

And we  use closure to avoid the performance loss, now the benchmark function ```BenchmarkRegionTreeUpdate-8` `BenchmarkRegionTreeUpdateUnordered-8 `  works well :

```
core git:(server/core/set_region) go test -bench BenchmarkRegion
OK: 23 passed
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/core
cpu: VirtualApple @ 2.50GHz
BenchmarkRegionTreeUpdate-8              1000000              1227 ns/op
BenchmarkRegionTreeUpdateUnordered-8     2931008               432.0 ns/op
PASS
ok      github.com/tikv/pd/server/core  28.238s

➜  core git:(master) go test -bench BenchmarkRegion
OK: 23 passed
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/core
cpu: VirtualApple @ 2.50GHz
BenchmarkRegionTreeUpdate-8              1000000              1262 ns/op
BenchmarkRegionTreeUpdateUnordered-8     2857729               502.2 ns/op
PASS
ok      github.com/tikv/pd/server/core  27.978s
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
