### PR TITLE
client: do not return error when a ctx.Done signal arrives

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -750,7 +750,8 @@ tsoBatchLoop:
 		// Start to collect the TSO requests.
 		maxBatchWaitInterval := c.option.getMaxTSOBatchWaitInterval()
 		if err = tbc.fetchPendingRequests(dispatcherCtx, maxBatchWaitInterval); err != nil {
-			log.Error("[pd] fetch pending tso requests error", zap.String("dc-location", dc), errs.ZapError(errs.ErrClientGetTSO, err))
+			// This error will only be returned when the dispatcherCtx is done.
+			log.Info("[pd] stop fetching the pending tso requests", zap.String("dc-location", dc))
 			return
 		}
 		if maxBatchWaitInterval >= 0 {

--- a/client/client.go
+++ b/client/client.go
@@ -774,7 +774,7 @@ tsoBatchLoop:
 				log.Info("[pd] tso stream is not ready", zap.String("dc", dc))
 				c.updateConnectionCtxs(dispatcherCtx, dc, &connectionCtxs)
 				if retryTimeConsuming >= c.option.timeout {
-					err = errs.ErrClientCreateTSOStream.FastGenByArgs()
+					err = errs.ErrClientCreateTSOStream.FastGenByArgs("retry timeout")
 					log.Error("[pd] create tso stream error", zap.String("dc-location", dc), errs.ZapError(err))
 					c.ScheduleCheckLeader()
 					c.finishTSORequest(tbc.getCollectedRequests(), 0, 0, 0, errors.WithStack(err))

--- a/client/client.go
+++ b/client/client.go
@@ -750,8 +750,13 @@ tsoBatchLoop:
 		// Start to collect the TSO requests.
 		maxBatchWaitInterval := c.option.getMaxTSOBatchWaitInterval()
 		if err = tbc.fetchPendingRequests(dispatcherCtx, maxBatchWaitInterval); err != nil {
-			// This error will only be returned when the dispatcherCtx is done.
-			log.Info("[pd] stop fetching the pending tso requests", zap.String("dc-location", dc))
+			if err == context.Canceled {
+				log.Info("[pd] stop fetching the pending tso requests due to context canceled",
+					zap.String("dc-location", dc))
+			} else {
+				log.Error("[pd] fetch pending tso requests error",
+					zap.String("dc-location", dc), errs.ZapError(errs.ErrClientGetTSO, err))
+			}
 			return
 		}
 		if maxBatchWaitInterval >= 0 {

--- a/errors.toml
+++ b/errors.toml
@@ -48,7 +48,7 @@ checker not found
 
 ["PD:client:ErrClientCreateTSOStream"]
 error = '''
-create TSO stream failed
+create TSO stream failed, %s
 '''
 
 ["PD:client:ErrClientGetLeader"]

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -60,7 +60,7 @@ var (
 
 // client errors
 var (
-	ErrClientCreateTSOStream = errors.Normalize("create TSO stream failed", errors.RFCCodeText("PD:client:ErrClientCreateTSOStream"))
+	ErrClientCreateTSOStream = errors.Normalize("create TSO stream failed, %s", errors.RFCCodeText("PD:client:ErrClientCreateTSOStream"))
 	ErrClientGetTSOTimeout   = errors.Normalize("get TSO timeout", errors.RFCCodeText("PD:client:ErrClientGetTSOTimeout"))
 	ErrClientGetTSO          = errors.Normalize("get TSO failed, %v", errors.RFCCodeText("PD:client:ErrClientGetTSO"))
 	ErrClientGetLeader       = errors.Normalize("get leader from %v error", errors.RFCCodeText("PD:client:ErrClientGetLeader"))


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Issue Number: Close https://github.com/tikv/pd/issues/4629

### What is changed and how it works?
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Do not return error when a `ctx.Done` signal arrives.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

After this PR:

```shell
[2022/02/11 16:05:58.289 +08:00] [INFO] [client.go:754] ["[pd] stop fetching the pending tso requests due to context canceled"] [dc-location=global]
[2022/02/11 16:05:58.289 +08:00] [INFO] [client.go:692] ["[pd] exit tso dispatcher"] [dc-location=global]
```

Before this PR:

```shell
[2022/02/11 16:07:07.509 +08:00] [ERROR] [client.go:753] ["[pd] fetch pending tso requests error"] [dc-location=global] [error="[PD:client:ErrClientGetTSO]context canceled"]
[2022/02/11 16:07:07.509 +08:00] [INFO] [client.go:692] ["[pd] exit tso dispatcher"] [dc-location=global]
```

### Release note

```release-note
Fix the unexpected error log when closing a PD client normally.
```
