### PR TITLE
pdctl: fix the issue that duration fields of dr-autosync cannot be set

### DIFF
--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -583,6 +583,11 @@ func (s *configTestSuite) TestReplicationMode(c *C) {
 	c.Assert(err, IsNil)
 	conf.DRAutoSync.PrimaryReplicas = 5
 	check()
+
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "replication-mode", "dr-auto-sync", "wait-store-timeout", "10m")
+	c.Assert(err, IsNil)
+	conf.DRAutoSync.WaitStoreTimeout = typeutil.NewDuration(time.Minute * 10)
+	check()
 }
 
 func (s *configTestSuite) TestUpdateDefaultReplicaConfig(c *C) {

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -395,7 +395,7 @@ func setReplicationModeCommandFunc(cmd *cobra.Command, args []string) {
 		postJSON(cmd, replicationModePrefix, map[string]interface{}{"replication-mode": args[0]})
 	} else if len(args) == 3 {
 		t := findFieldByJSONTag(reflect.TypeOf(config.ReplicationModeConfig{}), []string{args[0], args[1]})
-		if t != nil && t.Kind() != reflect.String {
+		if t != nil && t.Kind() == reflect.Int {
 			// convert to number for numberic fields.
 			arg2, err := strconv.ParseInt(args[2], 10, 64)
 			if err != nil {


### PR DESCRIPTION


Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Issue Number: close #4651

### What is changed and how it works?

pdctl was trying to convert duration to number. The condition is not correct: it should only convert int fields.

```commit-message
pdctl: fix the issue that duration fields of dr-autosync cannot be set
```

### Check List

Tests
- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
Fix the issue that duration fields of dr-autosync cannot be set
```
