### PR TITLE
api: add part of deprecated APIs back

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -369,5 +369,10 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 		}), setAuditBackend("test"))
 	})
 
+	// Deprecated: use /pd/api/v1/health instead.
+	rootRouter.Handle("/health", newHealthHandler(svr, rd)).Methods("GET")
+	// Deprecated: use /pd/api/v1/ping instead.
+	rootRouter.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {}).Methods("GET")
+
 	return rootRouter
 }

--- a/server/server.go
+++ b/server/server.go
@@ -214,6 +214,12 @@ func combineBuilderServerHTTPService(ctx context.Context, svr *Server, serviceBu
 			// If PathPrefix is not specified, register into apiService,
 			// and finally apiService is registered in userHandlers.
 			router.PathPrefix(pathPrefix).Handler(handler)
+			if info.IsCore {
+				// Deprecated
+				router.Path("/pd/health").Handler(handler)
+				// Deprecated
+				router.Path("/pd/ping").Handler(handler)
+			}
 		}
 	}
 	apiService.UseHandler(router)


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #4679.

### What is changed and how it works?
`tidb-operator` still uses `/pd/health` according to https://github.com/tikv/pd/issues/4679#issuecomment-1052144141. This PR is going to temporarily add them back. Once we update the `tidb-operator`, we will remove it again.
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
