### PR TITLE
pd-ctl: support command to show region labels

### DIFF
--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -31,19 +31,20 @@ import (
 )
 
 var (
-	configPrefix          = "pd/api/v1/config"
-	schedulePrefix        = "pd/api/v1/config/schedule"
-	replicatePrefix       = "pd/api/v1/config/replicate"
-	labelPropertyPrefix   = "pd/api/v1/config/label-property"
-	clusterVersionPrefix  = "pd/api/v1/config/cluster-version"
-	rulesPrefix           = "pd/api/v1/config/rules"
-	rulesBatchPrefix      = "pd/api/v1/config/rules/batch"
-	rulePrefix            = "pd/api/v1/config/rule"
-	ruleGroupPrefix       = "pd/api/v1/config/rule_group"
-	ruleGroupsPrefix      = "pd/api/v1/config/rule_groups"
-	replicationModePrefix = "pd/api/v1/config/replication-mode"
-	ruleBundlePrefix      = "pd/api/v1/config/placement-rule"
-	pdServerPrefix        = "pd/api/v1/config/pd-server"
+	configPrefix           = "pd/api/v1/config"
+	schedulePrefix         = "pd/api/v1/config/schedule"
+	replicatePrefix        = "pd/api/v1/config/replicate"
+	labelPropertyPrefix    = "pd/api/v1/config/label-property"
+	clusterVersionPrefix   = "pd/api/v1/config/cluster-version"
+	rulesPrefix            = "pd/api/v1/config/rules"
+	rulesBatchPrefix       = "pd/api/v1/config/rules/batch"
+	rulePrefix             = "pd/api/v1/config/rule"
+	ruleGroupPrefix        = "pd/api/v1/config/rule_group"
+	ruleGroupsPrefix       = "pd/api/v1/config/rule_groups"
+	replicationModePrefix  = "pd/api/v1/config/replication-mode"
+	ruleBundlePrefix       = "pd/api/v1/config/placement-rule"
+	pdServerPrefix         = "pd/api/v1/config/pd-server"
+	regionLabelRulesPrefix = "pd/api/v1/config/region-label/rules"
 )
 
 // NewConfigCommand return a config subcommand of rootCmd
@@ -62,7 +63,7 @@ func NewConfigCommand() *cobra.Command {
 // NewShowConfigCommand return a show subcommand of configCmd
 func NewShowConfigCommand() *cobra.Command {
 	sc := &cobra.Command{
-		Use:   "show [replication|label-property|all]",
+		Use:   "show [replication|label-property|region-label|all]",
 		Short: "show replication and schedule config of PD",
 		Run:   showConfigCommandFunc,
 	}
@@ -73,6 +74,7 @@ func NewShowConfigCommand() *cobra.Command {
 	sc.AddCommand(NewShowClusterVersionCommand())
 	sc.AddCommand(newShowReplicationModeCommand())
 	sc.AddCommand(NewShowServerConfigCommand())
+	sc.AddCommand(NewShowRegionLabelCommand())
 	return sc
 }
 
@@ -124,6 +126,16 @@ func NewShowClusterVersionCommand() *cobra.Command {
 		Run:   showClusterVersionCommandFunc,
 	}
 	return sc
+}
+
+// NewShowRegionLabelCommand returns a show region label subcommand of show subcommand.
+func NewShowRegionLabelCommand() *cobra.Command {
+	l := &cobra.Command{
+		Use:   "region-label",
+		Short: "show region labels config",
+		Run:   showRegionLabelsCommandFunc,
+	}
+	return l
 }
 
 func newShowReplicationModeCommand() *cobra.Command {
@@ -317,6 +329,15 @@ func showServerCommandFunc(cmd *cobra.Command, args []string) {
 	r, err := doRequest(cmd, pdServerPrefix, http.MethodGet, http.Header{})
 	if err != nil {
 		cmd.Printf("Failed to get server config: %s\n", err)
+		return
+	}
+	cmd.Println(r)
+}
+
+func showRegionLabelsCommandFunc(cmd *cobra.Command, args []string) {
+	r, err := doRequest(cmd, regionLabelRulesPrefix, http.MethodGet, http.Header{})
+	if err != nil {
+		cmd.Printf("Failed to get region labels: %s\n", err)
 		return
 	}
 	cmd.Println(r)


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4713 

### What is changed and how it works?
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
pd-ctl: support command to show region labels
```

### Check List



Tests

<!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)

```
./bin/pd-ctl -i -u http://127.0.0.1:2379
» config show --help
show replication and schedule config of PD

Usage:
  pd-ctl config show [replication|label-property|region-label|all] [flags]
  pd-ctl config show [command]

Available Commands:
  all              show all config of PD
  cluster-version  show the cluster version
  label-property   show label property config
  region-label     show region labels
  replication      show replication config of PD
  replication-mode show replication mode config
  schedule         show schedule config of PD
  server           show PD server config

Flags:
  -h, --help   help for show

Use "pd-ctl config show [command] --help" for more information about a command.
» config show region-label

```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
pd-ctl: support command to show region labels
```
