### PR TITLE
dr-autosync: do not switch to async when there is not enough peers

### DIFF
--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -482,7 +482,7 @@ func (m *ModeManager) tickDR() {
 			m.drSwitchToAsync(stores[primaryUp])
 		}
 	case drStateSyncRecover:
-		if !canSync {
+		if !canSync && hasMajority {
 			m.drSwitchToAsync(stores[primaryUp])
 		} else {
 			m.updateProgress()


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Issue Number: Close #4737

### What is changed and how it works?
- In `sync_recover` state, if there is not majority peers, don't switch state.
- update test to make it more easy to read

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None
```
