### PR TITLE
config: fix the default value of log.format

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -252,6 +252,8 @@ const (
 	DefaultTSOUpdatePhysicalInterval = 50 * time.Millisecond
 	maxTSOUpdatePhysicalInterval     = 10 * time.Second
 	minTSOUpdatePhysicalInterval     = 50 * time.Millisecond
+
+	defaultLogFormat = "text"
 )
 
 // Special keys for Labels
@@ -594,6 +596,10 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	c.ReplicationMode.adjust(configMetaData.Child("replication-mode"))
 
 	c.Security.Encryption.Adjust()
+
+	if len(c.Log.Format) == 0 {
+		c.Log.Format = defaultLogFormat
+	}
 
 	return nil
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -159,6 +159,8 @@ func (s *testConfigSuite) TestValidation(c *C) {
 	c.Assert(cfg.QuotaBackendBytes, Equals, defaultQuotaBackendBytes)
 	// check request bytes
 	c.Assert(cfg.MaxRequestBytes, Equals, defaultMaxRequestBytes)
+
+	c.Assert(cfg.Log.Format, Equals, defaultLogFormat)
 }
 
 func (s *testConfigSuite) TestAdjust(c *C) {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4753


https://github.com/tikv/pd/pull/4532 removed the code to initialize the default value of `log.format`. This PR adds it back.

### What is changed and how it works?

```commit-message
config: fix the default value of log.format
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->
```release-note
None.
```
