### PR TITLE
schedulers/evict_slow_store: return directly  when there is more than 1 slow store.

### DIFF
--- a/server/schedulers/evict_slow_store.go
+++ b/server/schedulers/evict_slow_store.go
@@ -80,9 +80,6 @@ func (conf *evictSlowStoreSchedulerConfig) evictStore() uint64 {
 }
 
 func (conf *evictSlowStoreSchedulerConfig) setStoreAndPersist(id uint64) error {
-	if id == conf.evictStore() {
-		return nil
-	}
 	conf.EvictedStores = []uint64{id}
 	return conf.Persist()
 }

--- a/server/schedulers/evict_slow_store.go
+++ b/server/schedulers/evict_slow_store.go
@@ -80,6 +80,9 @@ func (conf *evictSlowStoreSchedulerConfig) evictStore() uint64 {
 }
 
 func (conf *evictSlowStoreSchedulerConfig) setStoreAndPersist(id uint64) error {
+	if id == conf.evictStore() {
+		return nil
+	}
 	conf.EvictedStores = []uint64{id}
 	return conf.Persist()
 }
@@ -111,8 +114,9 @@ func (s *evictSlowStoreScheduler) EncodeConfig() ([]byte, error) {
 }
 
 func (s *evictSlowStoreScheduler) Prepare(cluster schedule.Cluster) error {
-	if len(s.conf.EvictedStores) != 0 {
-		return s.prepareEvictLeader(cluster)
+	evictStore := s.conf.evictStore()
+	if evictStore != 0 {
+		return cluster.SlowStoreEvicted(evictStore)
 	}
 	return nil
 }
@@ -121,8 +125,14 @@ func (s *evictSlowStoreScheduler) Cleanup(cluster schedule.Cluster) {
 	s.cleanupEvictLeader(cluster)
 }
 
-func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster schedule.Cluster) error {
-	return cluster.SlowStoreEvicted(s.conf.EvictedStores[0])
+func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster schedule.Cluster, storeID uint64) error {
+	err := s.conf.setStoreAndPersist(storeID)
+	if err != nil {
+		log.Info("evict-slow-store-scheduler persist config failed")
+		return err
+	}
+
+	return cluster.SlowStoreEvicted(storeID)
 }
 
 func (s *evictSlowStoreScheduler) cleanupEvictLeader(cluster schedule.Cluster) {
@@ -175,36 +185,35 @@ func (s *evictSlowStoreScheduler) Schedule(cluster schedule.Cluster) []*operator
 		return ops
 	}
 
-	slowStores := make([]*core.StoreInfo, 0)
+	var slowStore *core.StoreInfo
+
 	for _, store := range cluster.GetStores() {
 		if store.IsRemoved() {
 			continue
 		}
 
 		if (store.IsPreparing() || store.IsServing()) && store.IsSlow() {
-			slowStores = append(slowStores, store)
+			// If there is more than onw slow store do nothing.
+			if slowStore != nil {
+				return ops
+			}
+			slowStore = store
 		}
+	}
+
+	if slowStore == nil || slowStore.GetSlowScore() < slowStoreEvictThreshold {
+		return ops
 	}
 
 	// If there is only one slow store, evict leaders from that store.
-	if len(slowStores) == 1 && slowStores[0].GetSlowScore() >= slowStoreEvictThreshold {
-		store := slowStores[0]
-		log.Info("detected slow store, start to evict leaders",
-			zap.Uint64("store-id", store.GetID()))
-		err := s.conf.setStoreAndPersist(store.GetID())
-		if err != nil {
-			log.Info("evict-slow-store-scheduler persist config failed")
-			return ops
-		}
-		err = s.prepareEvictLeader(cluster)
-		if err != nil {
-			log.Info("prepare for evicting leader failed", zap.Error(err), zap.Uint64("store-id", store.GetID()))
-			return ops
-		}
-		ops = s.schedulerEvictLeader(cluster)
+	log.Info("detected slow store, start to evict leaders",
+		zap.Uint64("store-id", slowStore.GetID()))
+	err := s.prepareEvictLeader(cluster, slowStore.GetID())
+	if err != nil {
+		log.Info("prepare for evicting leader failed", zap.Error(err), zap.Uint64("store-id", slowStore.GetID()))
+		return ops
 	}
-
-	return ops
+	return s.schedulerEvictLeader(cluster)
 }
 
 // newEvictSlowStoreScheduler creates a scheduler that detects and evicts slow stores.

--- a/server/schedulers/evict_slow_store.go
+++ b/server/schedulers/evict_slow_store.go
@@ -125,7 +125,7 @@ func (s *evictSlowStoreScheduler) Cleanup(cluster schedule.Cluster) {
 func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster schedule.Cluster, storeID uint64) error {
 	err := s.conf.setStoreAndPersist(storeID)
 	if err != nil {
-		log.Info("evict-slow-store-scheduler persist config failed")
+		log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64("store-id", storeID))
 		return err
 	}
 
@@ -190,7 +190,7 @@ func (s *evictSlowStoreScheduler) Schedule(cluster schedule.Cluster) []*operator
 		}
 
 		if (store.IsPreparing() || store.IsServing()) && store.IsSlow() {
-			// If there is more than onw slow store do nothing.
+			// Do nothing if there is more than one slow store.
 			if slowStore != nil {
 				return ops
 			}

--- a/server/schedulers/evict_slow_store.go
+++ b/server/schedulers/evict_slow_store.go
@@ -145,13 +145,13 @@ func (s *evictSlowStoreScheduler) cleanupEvictLeader(cluster schedule.Cluster) {
 
 func (s *evictSlowStoreScheduler) schedulerEvictLeader(cluster schedule.Cluster) []*operator.Operator {
 	storeMap := map[uint64][]core.KeyRange{
-		s.conf.EvictedStores[0]: {core.NewKeyRange("", "")},
+		s.conf.evictStore(): {core.NewKeyRange("", "")},
 	}
 	return scheduleEvictLeaderBatch(s.GetName(), s.GetType(), cluster, storeMap, EvictLeaderBatchSize)
 }
 
 func (s *evictSlowStoreScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
-	if len(s.conf.EvictedStores) != 0 {
+	if s.conf.evictStore() != 0 {
 		allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
 		if !allowed {
 			operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()

--- a/server/schedulers/evict_slow_store_test.go
+++ b/server/schedulers/evict_slow_store_test.go
@@ -1,0 +1,146 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/pkg/testutil"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/schedule"
+	"github.com/tikv/pd/server/schedule/operator"
+	"github.com/tikv/pd/server/storage"
+)
+
+var _ = Suite(&testEvictSlowStoreSuite{})
+
+type testEvictSlowStoreSuite struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	tc     *mockcluster.Cluster
+	es     schedule.Scheduler
+	bs     schedule.Scheduler
+	oc     *schedule.OperatorController
+}
+
+func (s *testEvictSlowStoreSuite) SetUpTest(c *C) {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	opt := config.NewTestOptions()
+	s.tc = mockcluster.NewCluster(s.ctx, opt)
+
+	// Add stores 1, 2
+	s.tc.AddLeaderStore(1, 0)
+	s.tc.AddLeaderStore(2, 0)
+	s.tc.AddLeaderStore(3, 0)
+	// Add regions 1, 2 with leaders in stores 1, 2
+	s.tc.AddLeaderRegion(1, 1, 2)
+	s.tc.AddLeaderRegion(2, 2, 1)
+	s.tc.UpdateLeaderCount(2, 16)
+
+	s.oc = schedule.NewOperatorController(s.ctx, nil, nil)
+	storage := storage.NewStorageWithMemoryBackend()
+	var err error
+	s.es, err = schedule.CreateScheduler(EvictSlowStoreType, s.oc, storage, schedule.ConfigSliceDecoder(EvictSlowStoreType, []string{}))
+	c.Assert(err, IsNil)
+	s.bs, err = schedule.CreateScheduler(BalanceLeaderType, s.oc, storage, schedule.ConfigSliceDecoder(BalanceLeaderType, []string{}))
+	c.Assert(err, IsNil)
+}
+
+func (s *testEvictSlowStoreSuite) TestEvictSlowStore(c *C) {
+	defer s.cancel()
+	storeInfo := s.tc.GetStore(1)
+	newStoreInfo := storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().SlowScore = 100
+	})
+	s.tc.PutStore(newStoreInfo)
+	c.Assert(s.es.IsScheduleAllowed(s.tc), IsTrue)
+	// Add evict leader scheduler to store 1
+	op := s.es.Schedule(s.tc)
+	testutil.CheckMultiTargetTransferLeader(c, op[0], operator.OpLeader, 1, []uint64{2})
+	c.Assert(op[0].Desc(), Equals, EvictSlowStoreType)
+	// Cannot balance leaders to store 1
+	op = s.bs.Schedule(s.tc)
+	c.Assert(op, HasLen, 0)
+	newStoreInfo = storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().SlowScore = 0
+	})
+	s.tc.PutStore(newStoreInfo)
+	// Evict leader scheduler of store 1 should be removed, then leader can be balanced to store 1
+	c.Check(s.es.Schedule(s.tc), IsNil)
+	op = s.bs.Schedule(s.tc)
+	testutil.CheckTransferLeader(c, op[0], operator.OpLeader, 2, 1)
+
+	// no slow store need to evict.
+	op = s.es.Schedule(s.tc)
+	c.Assert(op, IsNil)
+
+	es2, ok := s.es.(*evictSlowStoreScheduler)
+	c.Assert(ok, IsTrue)
+	c.Assert(es2.conf.evictStore(), Equals, uint64(0))
+
+	// check the value from storage.
+	sches, vs, err := es2.conf.storage.LoadAllScheduleConfig()
+	c.Assert(err, IsNil)
+	valueStr := ""
+	for id, sche := range sches {
+		if strings.EqualFold(sche, EvictSlowStoreName) {
+			valueStr = vs[id]
+		}
+	}
+
+	var persistValue evictSlowStoreSchedulerConfig
+	err = json.Unmarshal([]byte(valueStr), &persistValue)
+	c.Assert(err, IsNil)
+	c.Assert(persistValue.EvictedStores, DeepEquals, es2.conf.EvictedStores)
+	c.Assert(persistValue.evictStore(), Equals, uint64(0))
+}
+
+func (s *testEvictSlowStoreSuite) TestEvictSlowStorePrepare(c *C) {
+	defer s.cancel()
+	es2, ok := s.es.(*evictSlowStoreScheduler)
+	c.Assert(ok, IsTrue)
+	c.Assert(es2.conf.evictStore(), Equals, uint64(0))
+	// prepare with no evict store.
+	s.es.Prepare(s.tc)
+
+	es2.conf.setStoreAndPersist(1)
+	c.Assert(es2.conf.evictStore(), Equals, uint64(1))
+	// prepare with evict store.
+	s.es.Prepare(s.tc)
+}
+
+func (s *testEvictSlowStoreSuite) TestEvictSlowStorePersistFail(c *C) {
+	defer s.cancel()
+	persisFail := "github.com/tikv/pd/server/schedulers/persistFail"
+	c.Assert(failpoint.Enable(persisFail, "return(true)"), IsNil)
+	storeInfo := s.tc.GetStore(1)
+	newStoreInfo := storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().SlowScore = 100
+	})
+	s.tc.PutStore(newStoreInfo)
+	c.Assert(s.es.IsScheduleAllowed(s.tc), IsTrue)
+	// Add evict leader scheduler to store 1
+	op := s.es.Schedule(s.tc)
+	c.Assert(op, IsNil)
+	c.Assert(failpoint.Disable(persisFail), IsNil)
+	op = s.es.Schedule(s.tc)
+	c.Assert(op, NotNil)
+}

--- a/server/schedulers/scheduler_test.go
+++ b/server/schedulers/scheduler_test.go
@@ -16,8 +16,6 @@ package schedulers
 
 import (
 	"context"
-	"encoding/json"
-	"strings"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -545,72 +543,4 @@ func (s *testBalanceLeaderSchedulerWithRuleEnabledSuite) TestBalanceLeaderWithCo
 			c.Assert(s.schedule(), HasLen, 0)
 		}
 	}
-}
-
-var _ = Suite(&testEvictSlowStoreSuite{})
-
-type testEvictSlowStoreSuite struct{}
-
-func (s *testEvictSlowStoreSuite) TestEvictSlowStore(c *C) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	opt := config.NewTestOptions()
-	tc := mockcluster.NewCluster(ctx, opt)
-
-	// Add stores 1, 2
-	tc.AddLeaderStore(1, 0)
-	tc.AddLeaderStore(2, 0)
-	tc.AddLeaderStore(3, 0)
-	// Add regions 1, 2 with leaders in stores 1, 2
-	tc.AddLeaderRegion(1, 1, 2)
-	tc.AddLeaderRegion(2, 2, 1)
-	tc.UpdateLeaderCount(2, 16)
-
-	oc := schedule.NewOperatorController(ctx, nil, nil)
-	storage := storage.NewStorageWithMemoryBackend()
-	es, err := schedule.CreateScheduler(EvictSlowStoreType, oc, storage, schedule.ConfigSliceDecoder(EvictSlowStoreType, []string{}))
-	c.Assert(err, IsNil)
-	bs, err := schedule.CreateScheduler(BalanceLeaderType, oc, storage, schedule.ConfigSliceDecoder(BalanceLeaderType, []string{}))
-	c.Assert(err, IsNil)
-	storeInfo := tc.GetStore(1)
-	newStoreInfo := storeInfo.Clone(func(store *core.StoreInfo) {
-		store.GetStoreStats().SlowScore = 100
-	})
-	tc.PutStore(newStoreInfo)
-	c.Assert(es.IsScheduleAllowed(tc), IsTrue)
-	// Add evict leader scheduler to store 1
-	op := es.Schedule(tc)
-	testutil.CheckMultiTargetTransferLeader(c, op[0], operator.OpLeader, 1, []uint64{2})
-	c.Assert(op[0].Desc(), Equals, EvictSlowStoreType)
-	// Cannot balance leaders to store 1
-	op = bs.Schedule(tc)
-	c.Assert(op, HasLen, 0)
-	newStoreInfo = storeInfo.Clone(func(store *core.StoreInfo) {
-		store.GetStoreStats().SlowScore = 0
-	})
-	tc.PutStore(newStoreInfo)
-	// Evict leader scheduler of store 1 should be removed, then leader can be balanced to store 1
-	c.Check(es.Schedule(tc), IsNil)
-	op = bs.Schedule(tc)
-	testutil.CheckTransferLeader(c, op[0], operator.OpLeader, 2, 1)
-
-	es2, ok := es.(*evictSlowStoreScheduler)
-	c.Assert(ok, IsTrue)
-	c.Assert(es2.conf.evictStore(), Equals, uint64(0))
-
-	// check the value from storage.
-	sches, vs, err := es2.conf.storage.LoadAllScheduleConfig()
-	c.Assert(err, IsNil)
-	valueStr := ""
-	for id, sche := range sches {
-		if strings.EqualFold(sche, EvictSlowStoreName) {
-			valueStr = vs[id]
-		}
-	}
-
-	var persistValue evictSlowStoreSchedulerConfig
-	err = json.Unmarshal([]byte(valueStr), &persistValue)
-	c.Assert(err, IsNil)
-	c.Assert(persistValue.EvictedStores, DeepEquals, es2.conf.EvictedStores)
-	c.Assert(persistValue.evictStore(), Equals, uint64(0))
 }


### PR DESCRIPTION

Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4802 


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
