### PR TITLE
core: change scoreV2 to adapt the higher disk capacity and amp . 

### DIFF
--- a/server/core/store.go
+++ b/server/core/store.go
@@ -374,7 +374,7 @@ func (s *StoreInfo) regionScoreV2(delta int64, lowSpaceRatio float64) float64 {
 	var (
 		K, M float64 = 1, 256 // Experience value to control the weight of the available influence on score
 		F    float64 = 50     // Experience value to prevent some nodes from running out of disk space prematurely.
-		B            = 1e7
+		B            = 1e10
 	)
 	F = math.Max(F, C*(1-lowSpaceRatio))
 	var score float64

--- a/server/core/store_test.go
+++ b/server/core/store_test.go
@@ -142,8 +142,8 @@ func (s *testStoreSuite) TestLowSpaceScoreV2(c *C) {
 		small:  NewStoreInfoWithAvailable(2, 10*gb, 100*gb, 1.4),
 	}, {
 		// store1 and store2 has same available ratio less than 0.2
-		bigger: NewStoreInfoWithAvailable(1, 10*gb, 1000*gb, 1.4),
-		small:  NewStoreInfoWithAvailable(2, 1*gb, 100*gb, 1.4),
+		bigger: NewStoreInfoWithAvailable(1, 20*gb, 1000*gb, 1.4),
+		small:  NewStoreInfoWithAvailable(2, 10*gb, 500*gb, 1.4),
 	}, {
 		// store1 and store2 has same available ratio
 		// but the store1 ratio less than store2 ((50-10)/50=0.8<(200-100)/200=0.5)
@@ -164,6 +164,10 @@ func (s *testStoreSuite) TestLowSpaceScoreV2(c *C) {
 		// but store1 has higher amp, so store1(60g) has more regionSize (40g)
 		bigger: NewStoreInfoWithAvailable(1, 80*gb, 100*gb, 3),
 		small:  NewStoreInfoWithAvailable(2, 60*gb, 100*gb, 1),
+	}, {
+		// store1's capacity is less than store2's capacity, but store2 has more available space,
+		bigger: NewStoreInfoWithAvailable(1, 2*gb, 100*gb, 3),
+		small:  NewStoreInfoWithAvailable(2, 100*gb, 10*1000*gb, 3),
 	}}
 	for _, v := range testdata {
 		score1 := v.bigger.regionScoreV2(0, 0.8)

--- a/server/core/test_util.go
+++ b/server/core/test_util.go
@@ -84,7 +84,7 @@ func NewTestRegionInfo(start, end []byte) *RegionInfo {
 	}}
 }
 
-// NewStoreInfoWithAvailable is create with available and capacity
+// NewStoreInfoWithAvailable is created with available and capacity
 func NewStoreInfoWithAvailable(id, available, capacity uint64, amp float64) *StoreInfo {
 	stats := &pdpb.StoreStats{}
 	stats.Capacity = capacity


### PR DESCRIPTION
Signed-off-by: bufferflies <1045931706@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed


If you want to open the **Challenge Program** pull request, please use the following template:
https://raw.githubusercontent.com/tikv/.github/master/.github/PULL_REQUEST_TEMPLATE/challenge-program.md
You can use it with query parameters: https://github.com/tikv/pd/compare/master...${you branch}?template=challenge-program.md
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4805

### What is changed and how it works?
<!--

You could use "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
 if  the biggest store's capacity is more than 2T , the store's score may be closed to the up score as b(1e7). so the smallest store will not be balanced even if they has less available capacity.
```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- Unit test

Code changes

Side effects

Related changes

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
