### PR TITLE
election: fix the unstable TestLeadership test (again)

### DIFF
--- a/server/election/leadership_test.go
+++ b/server/election/leadership_test.go
@@ -109,9 +109,6 @@ func (s *testLeadershipSuite) TestLeadership(c *C) {
 	leadership1.Reset()
 	leadership2.Reset()
 	c.Assert(leadership1.Check(), IsFalse)
-	// Since `go leadership2.Keep(ctx)` could renew this lease concurrently,
-	// we may need to wait for a while.
-	time.Sleep(defaultLeaseTimeout * time.Second)
 	c.Assert(leadership2.Check(), IsFalse)
 
 	// Try to keep the reset leadership.

--- a/server/election/lease.go
+++ b/server/election/lease.go
@@ -107,7 +107,7 @@ func (l *lease) KeepAlive(ctx context.Context) {
 		case t := <-timeCh:
 			if t.After(maxExpire) {
 				maxExpire = t
-				// Check again to make sure the lease is still need to be renew.
+				// Check again to make sure the `expireTime` still needs to be updated.
 				select {
 				case <-ctx.Done():
 					return


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/4782.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
election: fix the unstable TestLeadership test (again).
```

`keepAliveWorker` may update the `expireTime` concurrently while the `Reset` set it to zero. We need to make sure that the  `expireTime` won't be updated anymore when the context is canceled.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
