### PR TITLE
*: fix scheduling can not immediately start after transfer leader

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -747,9 +747,9 @@ func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) error {
 	return nil
 }
 
-// NeedCollect return true if need to collect regions
-func (c *RaftCluster) NeedCollect() bool {
-	return c.coordinator.prepareChecker.needCollect()
+// IsPrepared return true if the prepare checker is ready.
+func (c *RaftCluster) IsPrepared() bool {
+	return c.coordinator.prepareChecker.isPrepared()
 }
 
 var regionGuide = core.GenerateRegionGuideFunc(true)
@@ -818,7 +818,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		regionEventCounter.WithLabelValues("update_cache").Inc()
 	}
 
-	if c.NeedCollect() && isNew {
+	if !c.IsPrepared() && isNew {
 		c.coordinator.prepareChecker.collect(region)
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -813,7 +813,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		regionEventCounter.WithLabelValues("update_cache").Inc()
 	}
 
-	if isNew {
+	if !c.coordinator.prepareChecker.isPrepared() || isNew {
 		c.coordinator.prepareChecker.collect(region)
 	}
 
@@ -865,12 +865,6 @@ func (c *RaftCluster) updateStoreStatusLocked(id uint64) {
 	leaderRegionSize := c.core.GetStoreLeaderRegionSize(id)
 	regionSize := c.core.GetStoreRegionSize(id)
 	c.core.UpdateStoreStatus(id, leaderCount, regionCount, pendingPeerCount, leaderRegionSize, regionSize)
-}
-
-func (c *RaftCluster) getClusterID() uint64 {
-	c.RLock()
-	defer c.RUnlock()
-	return c.meta.GetId()
 }
 
 func (c *RaftCluster) putMetaLocked(meta *metapb.Cluster) error {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -747,8 +747,8 @@ func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) error {
 	return nil
 }
 
-// IsPreapred return if the prepare checker is ready.
-func (c *RaftCluster) IsPreapred() bool {
+// IsPrepared return if the prepare checker is ready.
+func (c *RaftCluster) IsPrepared() bool {
 	return c.coordinator.prepareChecker.isPrepared()
 }
 
@@ -818,7 +818,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		regionEventCounter.WithLabelValues("update_cache").Inc()
 	}
 
-	if !c.IsPreapred() || isNew {
+	if !c.IsPrepared() && isNew {
 		c.coordinator.prepareChecker.collect(region)
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -747,9 +747,9 @@ func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) error {
 	return nil
 }
 
-// IsPrepared return true if the prepare checker is ready.
-func (c *RaftCluster) IsPrepared() bool {
-	return c.coordinator.prepareChecker.isPrepared()
+// NeedCollect return true if need to collect regions
+func (c *RaftCluster) NeedCollect() bool {
+	return c.coordinator.prepareChecker.needCollect()
 }
 
 var regionGuide = core.GenerateRegionGuideFunc(true)
@@ -818,7 +818,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		regionEventCounter.WithLabelValues("update_cache").Inc()
 	}
 
-	if !c.IsPrepared() && isNew {
+	if c.NeedCollect() && isNew {
 		c.coordinator.prepareChecker.collect(region)
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -747,6 +747,11 @@ func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) error {
 	return nil
 }
 
+// IsPreapred return if the prepare checker is ready.
+func (c *RaftCluster) IsPreapred() bool {
+	return c.coordinator.prepareChecker.isPrepared()
+}
+
 var regionGuide = core.GenerateRegionGuideFunc(true)
 
 // processRegionHeartbeat updates the region information.
@@ -813,7 +818,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		regionEventCounter.WithLabelValues("update_cache").Inc()
 	}
 
-	if !c.coordinator.prepareChecker.isPrepared() || isNew {
+	if !c.IsPreapred() || isNew {
 		c.coordinator.prepareChecker.collect(region)
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -747,7 +747,7 @@ func (c *RaftCluster) processReportBuckets(buckets *metapb.Buckets) error {
 	return nil
 }
 
-// IsPrepared return if the prepare checker is ready.
+// IsPrepared return true if the prepare checker is ready.
 func (c *RaftCluster) IsPrepared() bool {
 	return c.coordinator.prepareChecker.isPrepared()
 }

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -42,7 +42,6 @@ import (
 )
 
 const (
-	runSchedulerCheckInterval  = 3 * time.Second
 	checkSuspectRangesInterval = 100 * time.Millisecond
 	collectFactor              = 0.8
 	collectTimeout             = 5 * time.Minute
@@ -55,6 +54,8 @@ const (
 	// PluginUnload means action for unload plugin
 	PluginUnload = "PluginUnload"
 )
+
+var runSchedulerCheckInterval = 3 * time.Second
 
 // coordinator is used to manage all schedulers and checkers to decide if the region needs to be scheduled.
 type coordinator struct {
@@ -310,6 +311,9 @@ func (c *coordinator) runUntilStop() {
 }
 
 func (c *coordinator) run() {
+	failpoint.Inject("runSchedulerCheckInterval", func() {
+		runSchedulerCheckInterval = 100 * time.Millisecond
+	})
 	ticker := time.NewTicker(runSchedulerCheckInterval)
 	defer ticker.Stop()
 	log.Info("coordinator starts to collect cluster information")

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -42,6 +42,7 @@ import (
 )
 
 const (
+	runSchedulerCheckInterval  = 3 * time.Second
 	checkSuspectRangesInterval = 100 * time.Millisecond
 	collectFactor              = 0.8
 	collectTimeout             = 5 * time.Minute
@@ -54,8 +55,6 @@ const (
 	// PluginUnload means action for unload plugin
 	PluginUnload = "PluginUnload"
 )
-
-var runSchedulerCheckInterval = 3 * time.Second
 
 // coordinator is used to manage all schedulers and checkers to decide if the region needs to be scheduled.
 type coordinator struct {
@@ -311,10 +310,10 @@ func (c *coordinator) runUntilStop() {
 }
 
 func (c *coordinator) run() {
-	failpoint.Inject("runSchedulerCheckInterval", func() {
-		runSchedulerCheckInterval = 100 * time.Millisecond
-	})
 	ticker := time.NewTicker(runSchedulerCheckInterval)
+	failpoint.Inject("changeCoordinatorTicker", func() {
+		ticker = time.NewTicker(100 * time.Millisecond)
+	})
 	defer ticker.Stop()
 	log.Info("coordinator starts to collect cluster information")
 	for {

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -193,7 +193,7 @@ func (s *testCoordinatorSuite) TestBasic(c *C) {
 func (s *testCoordinatorSuite) TestDispatch(c *C) {
 	tc, co, cleanup := prepare(nil, nil, nil, c)
 	defer cleanup()
-	co.prepareChecker.isPrepared = true
+	co.prepareChecker.prepared = true
 	// Transfer peer from store 4 to store 1.
 	c.Assert(tc.addRegionStore(4, 40), IsNil)
 	c.Assert(tc.addRegionStore(3, 30), IsNil)
@@ -286,7 +286,7 @@ func prepare(setCfg func(*config.ScheduleConfig), setTc func(*testCluster), run 
 		setCfg(cfg)
 	}
 	tc := newTestCluster(ctx, opt)
-	hbStreams := hbstream.NewTestHeartbeatStreams(ctx, tc.getClusterID(), tc, true /* need to run */)
+	hbStreams := hbstream.NewTestHeartbeatStreams(ctx, tc.meta.GetId(), tc, true /* need to run */)
 	if setTc != nil {
 		setTc(tc)
 	}

--- a/server/cluster/prepare_checker.go
+++ b/server/cluster/prepare_checker.go
@@ -70,8 +70,8 @@ func (checker *prepareChecker) collect(region *core.RegionInfo) {
 	checker.sum++
 }
 
-func (checker *prepareChecker) isPrepared() bool {
+func (checker *prepareChecker) needCollect() bool {
 	checker.RLock()
 	defer checker.RUnlock()
-	return checker.prepared
+	return time.Since(checker.start) <= collectTimeout && !checker.prepared
 }

--- a/server/cluster/prepare_checker.go
+++ b/server/cluster/prepare_checker.go
@@ -40,7 +40,11 @@ func newPrepareChecker() *prepareChecker {
 func (checker *prepareChecker) check(c *core.BasicCluster) bool {
 	checker.RLock()
 	defer checker.RUnlock()
-	if checker.prepared || time.Since(checker.start) > collectTimeout {
+	if checker.prepared {
+		return true
+	}
+	if time.Since(checker.start) > collectTimeout {
+		checker.prepared = true
 		return true
 	}
 	// The number of active regions should be more than total region of all stores * collectFactor
@@ -70,8 +74,8 @@ func (checker *prepareChecker) collect(region *core.RegionInfo) {
 	checker.sum++
 }
 
-func (checker *prepareChecker) needCollect() bool {
+func (checker *prepareChecker) isPrepared() bool {
 	checker.RLock()
 	defer checker.RUnlock()
-	return time.Since(checker.start) <= collectTimeout && !checker.prepared
+	return checker.prepared
 }

--- a/server/cluster/prepare_checker.go
+++ b/server/cluster/prepare_checker.go
@@ -26,7 +26,7 @@ type prepareChecker struct {
 	reactiveRegions map[uint64]int
 	start           time.Time
 	sum             int
-	isPrepared      bool
+	prepared        bool
 }
 
 func newPrepareChecker() *prepareChecker {
@@ -40,7 +40,7 @@ func newPrepareChecker() *prepareChecker {
 func (checker *prepareChecker) check(c *core.BasicCluster) bool {
 	checker.RLock()
 	defer checker.RUnlock()
-	if checker.isPrepared || time.Since(checker.start) > collectTimeout {
+	if checker.prepared || time.Since(checker.start) > collectTimeout {
 		return true
 	}
 	// The number of active regions should be more than total region of all stores * collectFactor
@@ -57,7 +57,7 @@ func (checker *prepareChecker) check(c *core.BasicCluster) bool {
 			return false
 		}
 	}
-	checker.isPrepared = true
+	checker.prepared = true
 	return true
 }
 
@@ -68,4 +68,10 @@ func (checker *prepareChecker) collect(region *core.RegionInfo) {
 		checker.reactiveRegions[p.GetStoreId()]++
 	}
 	checker.sum++
+}
+
+func (checker *prepareChecker) isPrepared() bool {
+	checker.RLock()
+	defer checker.RUnlock()
+	return checker.prepared
 }

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -522,7 +522,7 @@ func (s *testUnsafeRecoverSuite) TestPlanExecution(c *C) {
 	_, opt, _ := newTestScheduleConfig()
 	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
 	// Manually fill the coordinator up to allow calling on cluster.PauseOrResumeSchedulers().
-	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.getClusterID(), cluster, true))
+	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.meta.GetId(), cluster, true))
 	recoveryController := newUnsafeRecoveryController(cluster)
 	recoveryController.stage = recovering
 	recoveryController.failedStores = map[uint64]string{
@@ -629,7 +629,7 @@ func (s *testUnsafeRecoverSuite) TestPlanExecution(c *C) {
 func (s *testUnsafeRecoverSuite) TestRemoveFailedStores(c *C) {
 	_, opt, _ := newTestScheduleConfig()
 	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
-	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.getClusterID(), cluster, true))
+	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.meta.GetId(), cluster, true))
 	cluster.coordinator.run()
 	stores := newTestStores(2, "5.3.0")
 	stores[1] = stores[1].Clone(core.SetLastHeartbeatTS(time.Now()))
@@ -661,7 +661,7 @@ func (s *testUnsafeRecoverSuite) TestRemoveFailedStores(c *C) {
 func (s *testUnsafeRecoverSuite) TestSplitPaused(c *C) {
 	_, opt, _ := newTestScheduleConfig()
 	cluster := newTestRaftCluster(s.ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
-	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.getClusterID(), cluster, true))
+	cluster.coordinator = newCoordinator(s.ctx, cluster, hbstream.NewTestHeartbeatStreams(s.ctx, cluster.meta.GetId(), cluster, true))
 	cluster.coordinator.run()
 	stores := newTestStores(2, "5.3.0")
 	stores[1] = stores[1].Clone(core.SetLastHeartbeatTS(time.Now()))

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -61,7 +61,8 @@ type RegionInfo struct {
 	QueryStats        *pdpb.QueryStats
 	flowRoundDivisor  uint64
 	// buckets is not thread unsafe, it should be accessed by the request `report buckets` with greater version.
-	buckets unsafe.Pointer
+	buckets       unsafe.Pointer
+	fromHeartbeat bool
 }
 
 // NewRegionInfo creates RegionInfo with region's meta and leader peer.
@@ -540,6 +541,11 @@ func (r *RegionInfo) GetReplicationStatus() *replication_modepb.RegionReplicatio
 	return r.replicationStatus
 }
 
+// IsFromHeartbeat returns whether the region info is from the region heartbeat.
+func (r *RegionInfo) IsFromHeartbeat() bool {
+	return r.fromHeartbeat
+}
+
 // RegionGuideFunc is a function that determines which follow-up operations need to be performed based on the origin
 // and new region information.
 type RegionGuideFunc func(region, origin *RegionInfo) (isNew, saveKV, saveCache, needSync bool)
@@ -623,6 +629,9 @@ func GenerateRegionGuideFunc(enableLog bool) RegionGuideFunc {
 				(region.GetReplicationStatus().GetState() != origin.GetReplicationStatus().GetState() ||
 					region.GetReplicationStatus().GetStateId() != origin.GetReplicationStatus().GetStateId()) {
 				saveCache = true
+			}
+			if !origin.IsFromHeartbeat() {
+				isNew = true
 			}
 		}
 		return

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -315,3 +315,10 @@ func WithInterval(interval *pdpb.TimeInterval) RegionCreateOption {
 		region.interval = interval
 	}
 }
+
+// SetFromHeartbeat sets if the region info comes from the region heartbeat.
+func SetFromHeartbeat(fromHeartbeat bool) RegionCreateOption {
+	return func(region *RegionInfo) {
+		region.fromHeartbeat = fromHeartbeat
+	}
+}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -877,7 +877,7 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 			lastBind = time.Now()
 		}
 
-		region := core.RegionFromHeartbeat(request, flowRoundOption)
+		region := core.RegionFromHeartbeat(request, flowRoundOption, core.SetFromHeartbeat(true))
 		if region.GetLeader() == nil {
 			log.Error("invalid request, the leader is nil", zap.Reflect("request", request), errs.ZapError(errs.ErrLeaderNil))
 			regionHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "report", "invalid-leader").Inc()

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -204,9 +204,10 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 							core.SetWrittenKeys(stats[i].KeysWritten),
 							core.SetReadBytes(stats[i].BytesRead),
 							core.SetReadKeys(stats[i].KeysRead),
+							core.SetFromHeartbeat(false),
 						)
 					} else {
-						region = core.NewRegionInfo(r, regionLeader)
+						region = core.NewRegionInfo(r, regionLeader, core.SetFromHeartbeat(false))
 					}
 
 					origin, err := bc.PreCheckPutRegion(region)

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -233,7 +233,7 @@ func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
 
 	// ensure flush to region storage
 	time.Sleep(3 * time.Second)
-	c.Assert(leaderServer.GetRaftCluster().IsPreapred(), IsTrue)
+	c.Assert(leaderServer.GetRaftCluster().IsPrepared(), IsTrue)
 
 	// join new PD
 	pd2, err := cluster.Join(s.ctx)
@@ -252,7 +252,7 @@ func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
 		c.Assert(err, IsNil)
 	}
 	time.Sleep(time.Second)
-	c.Assert(rc.IsPreapred(), IsTrue)
+	c.Assert(rc.IsPrepared(), IsTrue)
 }
 
 func initRegions(regionLen int) []*core.RegionInfo {

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -210,6 +210,51 @@ func (s *regionSyncerTestSuite) TestFullSyncWithAddMember(c *C) {
 	c.Assert(loadRegions, HasLen, regionLen)
 }
 
+func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/cluster/runSchedulerCheckInterval", `return(true)`), IsNil)
+	defer failpoint.Disable("github.com/tikv/pd/server/cluster/runSchedulerCheckInterval")
+	cluster, err := tests.NewTestCluster(s.ctx, 1, func(conf *config.Config, serverName string) { conf.PDServerCfg.UseRegionStorage = true })
+	defer cluster.Destroy()
+	c.Assert(err, IsNil)
+
+	err = cluster.RunInitialServers()
+	c.Assert(err, IsNil)
+	cluster.WaitLeader()
+	leaderServer := cluster.GetServer(cluster.GetLeader())
+	c.Assert(leaderServer.BootstrapCluster(), IsNil)
+	rc := leaderServer.GetServer().GetRaftCluster()
+	c.Assert(rc, NotNil)
+	regionLen := 110
+	regions := initRegions(regionLen)
+	for _, region := range regions {
+		err = rc.HandleRegionHeartbeat(region)
+		c.Assert(err, IsNil)
+	}
+
+	// ensure flush to region storage
+	time.Sleep(3 * time.Second)
+	c.Assert(leaderServer.GetRaftCluster().IsPreapred(), IsTrue)
+
+	// join new PD
+	pd2, err := cluster.Join(s.ctx)
+	c.Assert(err, IsNil)
+	err = pd2.Run()
+	c.Assert(err, IsNil)
+	// waiting for synchronization to complete
+	time.Sleep(3 * time.Second)
+	err = cluster.ResignLeader()
+	c.Assert(err, IsNil)
+	c.Assert(cluster.WaitLeader(), Equals, "pd2")
+	leaderServer = cluster.GetServer(cluster.GetLeader())
+	rc = leaderServer.GetServer().GetRaftCluster()
+	for _, region := range regions {
+		err = rc.HandleRegionHeartbeat(region)
+		c.Assert(err, IsNil)
+	}
+	time.Sleep(time.Second)
+	c.Assert(rc.IsPreapred(), IsTrue)
+}
+
 func initRegions(regionLen int) []*core.RegionInfo {
 	allocator := &idAllocator{allocator: mockid.NewIDAllocator()}
 	regions := make([]*core.RegionInfo, 0, regionLen)

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -211,8 +211,8 @@ func (s *regionSyncerTestSuite) TestFullSyncWithAddMember(c *C) {
 }
 
 func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
-	c.Assert(failpoint.Enable("github.com/tikv/pd/server/cluster/runSchedulerCheckInterval", `return(true)`), IsNil)
-	defer failpoint.Disable("github.com/tikv/pd/server/cluster/runSchedulerCheckInterval")
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/cluster/changeCoordinatorTicker", `return(true)`), IsNil)
+	defer failpoint.Disable("github.com/tikv/pd/server/cluster/changeCoordinatorTicker")
 	cluster, err := tests.NewTestCluster(s.ctx, 1, func(conf *config.Config, serverName string) { conf.PDServerCfg.UseRegionStorage = true })
 	defer cluster.Destroy()
 	c.Assert(err, IsNil)

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -233,7 +233,7 @@ func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
 
 	// ensure flush to region storage
 	time.Sleep(3 * time.Second)
-	c.Assert(leaderServer.GetRaftCluster().IsPrepared(), IsTrue)
+	c.Assert(leaderServer.GetRaftCluster().NeedCollect(), IsFalse)
 
 	// join new PD
 	pd2, err := cluster.Join(s.ctx)
@@ -252,7 +252,7 @@ func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
 		c.Assert(err, IsNil)
 	}
 	time.Sleep(time.Second)
-	c.Assert(rc.IsPrepared(), IsTrue)
+	c.Assert(rc.NeedCollect(), IsFalse)
 }
 
 func initRegions(regionLen int) []*core.RegionInfo {

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -233,7 +233,7 @@ func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
 
 	// ensure flush to region storage
 	time.Sleep(3 * time.Second)
-	c.Assert(leaderServer.GetRaftCluster().NeedCollect(), IsFalse)
+	c.Assert(leaderServer.GetRaftCluster().IsPrepared(), IsTrue)
 
 	// join new PD
 	pd2, err := cluster.Join(s.ctx)
@@ -252,7 +252,7 @@ func (s *regionSyncerTestSuite) TestPrepareChecker(c *C) {
 		c.Assert(err, IsNil)
 	}
 	time.Sleep(time.Second)
-	c.Assert(rc.NeedCollect(), IsFalse)
+	c.Assert(rc.IsPrepared(), IsTrue)
 }
 
 func initRegions(regionLen int) []*core.RegionInfo {


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4769.

### What is changed and how does it work?

This PR uses the flag to distinguish if the region's heartbeat is new when transferring the PD leader.
<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fix the issue that scheduling cannot immediately start after PD leader transfers
```
