### PR TITLE
draft: schedulers: big hot region should be splited before it is balanced.

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -255,7 +255,7 @@ func (h *hotScheduler) summaryPendingInfluence() {
 		weight, needGC := h.calcPendingInfluence(p.op, maxZombieDur)
 
 		if status := p.op.CheckAndGetStatus(); operator.IsEndStatus(status) {
-			hotSplittingStatus.WithLabelValues(h.GetType()).Add(-1)
+			hotSplittingStatus.WithLabelValues(h.GetType()).Dec()
 			delete(h.regionSplitPendings, id)
 		}
 

--- a/server/schedulers/hot_region_config.go
+++ b/server/schedulers/hot_region_config.go
@@ -78,6 +78,7 @@ func initHotRegionScheduleConfig() *hotRegionSchedulerConfig {
 		StrictPickingStore:     true,
 		EnableForTiFlash:       true,
 		ForbidRWType:           "none",
+		RegionSizeThreshold:    512,
 	}
 	cfg.apply(defaultConfig)
 	return cfg
@@ -138,6 +139,9 @@ type hotRegionSchedulerConfig struct {
 	EnableForTiFlash bool `json:"enable-for-tiflash,string"`
 	// forbid read or write scheduler, only for test
 	ForbidRWType string `json:"forbid-rw-type,omitempty"`
+	// the max region size threshold for hot region
+	// if the region size of the scheduled region is larger than this threshold, it will be replaced by splitting operator first.
+	RegionSizeThreshold int64 `json:"region-size-threshold"`
 }
 
 func (conf *hotRegionSchedulerConfig) EncodeConfig() ([]byte, error) {

--- a/server/schedulers/metrics.go
+++ b/server/schedulers/metrics.go
@@ -112,6 +112,14 @@ var hotPendingStatus = prometheus.NewGaugeVec(
 		Help:      "Counter of direction of balance related schedulers.",
 	}, []string{"type", "source", "target"})
 
+var hotSplittingStatus = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "pd",
+		Subsystem: "scheduler",
+		Name:      "hot_spliting",
+		Help:      "Counter of hot region spliting.",
+	}, []string{"type"})
+
 func init() {
 	prometheus.MustRegister(schedulerCounter)
 	prometheus.MustRegister(schedulerStatus)
@@ -125,4 +133,5 @@ func init() {
 	prometheus.MustRegister(opInfluenceStatus)
 	prometheus.MustRegister(tolerantResourceStatus)
 	prometheus.MustRegister(hotPendingStatus)
+	prometheus.MustRegister(hotSplittingStatus)
 }

--- a/server/schedulers/metrics.go
+++ b/server/schedulers/metrics.go
@@ -112,8 +112,8 @@ var hotPendingStatus = prometheus.NewGaugeVec(
 		Help:      "Counter of direction of balance related schedulers.",
 	}, []string{"type", "source", "target"})
 
-var hotSplittingStatus = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
+var hotSplittingStatus = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
 		Namespace: "pd",
 		Subsystem: "scheduler",
 		Name:      "hot_spliting",


### PR DESCRIPTION
Signed-off-by: bufferflies <1045931706@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4877

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


Code changes


Side effects


Related changes

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
big hot region should be splited before it is balanced.
```
