### PR TITLE
Fix data race, ref #4857

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -573,6 +573,8 @@ func (c *RaftCluster) RemoveSuspectRegion(id uint64) {
 
 // GetUnsafeRecoveryController returns the unsafe recovery controller.
 func (c *RaftCluster) GetUnsafeRecoveryController() *unsafeRecoveryController {
+	c.RLock()
+	defer c.RUnlock()
 	return c.unsafeRecoveryController
 }
 

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -669,7 +669,11 @@ func (s *testUnsafeRecoverSuite) TestSplitPaused(c *C) {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
 	}
 	recoveryController := newUnsafeRecoveryController(cluster)
-	cluster.unsafeRecoveryController = recoveryController
+	{
+		cluster.Lock()
+		cluster.unsafeRecoveryController = recoveryController
+		cluster.Unlock()
+	}
 	failedStores := map[uint64]string{
 		1: "",
 	}

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -669,11 +669,9 @@ func (s *testUnsafeRecoverSuite) TestSplitPaused(c *C) {
 		c.Assert(cluster.PutStore(store.GetMeta()), IsNil)
 	}
 	recoveryController := newUnsafeRecoveryController(cluster)
-	{
-		cluster.Lock()
-		cluster.unsafeRecoveryController = recoveryController
-		cluster.Unlock()
-	}
+	cluster.Lock()
+	cluster.unsafeRecoveryController = recoveryController
+	cluster.Unlock()
 	failedStores := map[uint64]string{
 		1: "",
 	}


### PR DESCRIPTION
Signed-off-by: v01dstar <yang.zhang@pingcap.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4857 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Acquire reader lock while reading the unsafe recovery controller, acquire writer lock while modifying it.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

N/A

Side effects

N/A

Related changes

- PR introduced the bug https://github.com/tikv/pd/pull/4475

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
