### PR TITLE
tso: fix the corner case that may cause TSO fallback

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1332,7 +1332,7 @@ func (s *Server) campaignLeader() {
 	}
 	defer func() {
 		s.tsoAllocatorManager.ResetAllocatorGroup(tso.GlobalDCLocation)
-		failpoint.Inject("updateAfterReset", func() {
+		failpoint.Inject("updateAfterResetTSO", func() {
 			allocator, err := s.tsoAllocatorManager.GetAllocator(tso.GlobalDCLocation)
 			if err != nil {
 				panic(err)

--- a/server/server.go
+++ b/server/server.go
@@ -1333,12 +1333,7 @@ func (s *Server) campaignLeader() {
 	defer func() {
 		s.tsoAllocatorManager.ResetAllocatorGroup(tso.GlobalDCLocation)
 		failpoint.Inject("updateAfterResetTSO", func() {
-			allocator, err := s.tsoAllocatorManager.GetAllocator(tso.GlobalDCLocation)
-			if err != nil {
-				panic(err)
-			}
-			err = allocator.UpdateTSO()
-			if err != nil {
+			if err = alllocator.UpdateTSO(); err != nil {
 				panic(err)
 			}
 		})

--- a/server/tso/tso.go
+++ b/server/tso/tso.go
@@ -297,6 +297,9 @@ func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, ts
 // 1. The saved time is monotonically increasing.
 // 2. The physical time is monotonically increasing.
 // 3. The physical time is always less than the saved timestamp.
+//
+// NOTICE: this function should be called after the TSO in memory has been initialized
+// and should not be called when the TSO in memory has been reset anymore.
 func (t *timestampOracle) UpdateTimestamp(leadership *election.Leadership) error {
 	prevPhysical, prevLogical := t.getTSO()
 	tsoGauge.WithLabelValues("tso", t.dcLocation).Set(float64(prevPhysical.UnixNano() / int64(time.Millisecond)))

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -187,7 +187,8 @@ func (s *clientTestSuite) TestLeaderTransfer(c *C) {
 	wg.Wait()
 }
 
-func (s *clientTestSuite) TestUpdateAfterReset(c *C) {
+// More details can be found in this issue: https://github.com/tikv/pd/issues/4884
+func (s *clientTestSuite) TestUpdateAfterResetTSO(c *C) {
 	cluster, err := tests.NewTestCluster(s.ctx, 2)
 	c.Assert(err, IsNil)
 	defer cluster.Destroy()
@@ -200,11 +201,11 @@ func (s *clientTestSuite) TestUpdateAfterReset(c *C) {
 		return err == nil
 	})
 	// Transfer leader to trigger the TSO resetting.
-	c.Assert(failpoint.Enable("github.com/tikv/pd/server/updateAfterReset", "return(true)"), IsNil)
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/updateAfterResetTSO", "return(true)"), IsNil)
 	oldLeaderName := cluster.WaitLeader()
 	err = cluster.GetServer(oldLeaderName).ResignLeader()
 	c.Assert(err, IsNil)
-	c.Assert(failpoint.Disable("github.com/tikv/pd/server/updateAfterReset"), IsNil)
+	c.Assert(failpoint.Disable("github.com/tikv/pd/server/updateAfterResetTSO"), IsNil)
 	newLeaderName := cluster.WaitLeader()
 	c.Assert(newLeaderName, Not(Equals), oldLeaderName)
 	// Request a new TSO.

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -187,6 +187,43 @@ func (s *clientTestSuite) TestLeaderTransfer(c *C) {
 	wg.Wait()
 }
 
+func (s *clientTestSuite) TestUpdateAfterReset(c *C) {
+	cluster, err := tests.NewTestCluster(s.ctx, 2)
+	c.Assert(err, IsNil)
+	defer cluster.Destroy()
+
+	endpoints := s.runServer(c, cluster)
+	cli := setupCli(c, s.ctx, endpoints)
+
+	testutil.WaitUntil(c, func() bool {
+		_, _, err := cli.GetTS(context.TODO())
+		return err == nil
+	})
+	// Transfer leader to trigger the TSO resetting.
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/updateAfterReset", "return(true)"), IsNil)
+	oldLeaderName := cluster.WaitLeader()
+	err = cluster.GetServer(oldLeaderName).ResignLeader()
+	c.Assert(err, IsNil)
+	c.Assert(failpoint.Disable("github.com/tikv/pd/server/updateAfterReset"), IsNil)
+	newLeaderName := cluster.WaitLeader()
+	c.Assert(newLeaderName, Not(Equals), oldLeaderName)
+	// Request a new TSO.
+	testutil.WaitUntil(c, func() bool {
+		_, _, err := cli.GetTS(context.TODO())
+		return err == nil
+	})
+	// Transfer leader back.
+	c.Assert(failpoint.Enable("github.com/tikv/pd/server/tso/delaySyncTimestamp", `return(true)`), IsNil)
+	err = cluster.GetServer(newLeaderName).ResignLeader()
+	c.Assert(err, IsNil)
+	// Should NOT panic here.
+	testutil.WaitUntil(c, func() bool {
+		_, _, err := cli.GetTS(context.TODO())
+		return err == nil
+	})
+	c.Assert(failpoint.Disable("github.com/tikv/pd/server/tso/delaySyncTimestamp"), IsNil)
+}
+
 func (s *clientTestSuite) TestTSOAllocatorLeader(c *C) {
 	dcLocationConfig := map[string]string{
 		"pd1": "dc-1",


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #4884.

This bug will occur when the following conditions are met:

1. PD-0 resigns the leader.
2. PD-0 updates the TSO right after resetting it concurrently and leaves the non-empty TSO in memory.
3. PD-0 becomes the leader again.
4. PD-0 receives a TSO request after the leadership is available and before the TSO synchronization is done.
5. A smaller TSO will be generated with this request.
6. BOOM!!!

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
tso: fix the corner case that may cause TSO fallback
```

Do not update the TSO in memory if it's zero.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fix the corner case that may cause TSO fallback.
```
