### PR TITLE
server:return qps data to tidbdashborad 

### DIFF
--- a/pkg/dashboard/keyvisual/input/core.go
+++ b/pkg/dashboard/keyvisual/input/core.go
@@ -63,6 +63,14 @@ func (rs RegionsInfo) GetValues(tag regionpkg.StatTag) []uint64 {
 		for i, region := range rs {
 			values[i] = region.GetKeysRead()
 		}
+	case regionpkg.WriteQueryNum:
+		for i, region := range rs {
+			values[i] = region.GetWriteQueryNum()
+		}
+	case regionpkg.ReadQueryNum:
+		for i, region := range rs {
+			values[i] = region.GetReadQueryNum()
+		}
 	case regionpkg.Integration:
 		for i, region := range rs {
 			values[i] = region.GetBytesWritten() + region.GetBytesRead()

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -113,6 +113,8 @@ type RegionInfo struct {
 	ReadBytes       uint64        `json:"read_bytes"`
 	WrittenKeys     uint64        `json:"written_keys"`
 	ReadKeys        uint64        `json:"read_keys"`
+	WriteQueryNum   uint64        `json:"write_query_num"`
+	ReadQueryNum    uint64        `json:"read_query_num"`
 	ApproximateSize int64         `json:"approximate_size"`
 	ApproximateKeys int64         `json:"approximate_keys"`
 	Buckets         []string      `json:"buckets,omitempty"`
@@ -158,8 +160,10 @@ func InitRegion(r *core.RegionInfo, s *RegionInfo) *RegionInfo {
 	s.PendingPeers = fromPeerSlice(r.GetPendingPeers())
 	s.WrittenBytes = r.GetBytesWritten()
 	s.WrittenKeys = r.GetKeysWritten()
+	s.WriteQueryNum = r.GetWriteQueryNum()
 	s.ReadBytes = r.GetBytesRead()
 	s.ReadKeys = r.GetKeysRead()
+	s.ReadQueryNum = r.GetReadQueryNum()
 	s.ApproximateSize = r.GetApproximateSize()
 	s.ApproximateKeys = r.GetApproximateKeys()
 	s.ReplicationStatus = fromPBReplicationStatus(r.GetReplicationStatus())

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -122,6 +122,17 @@ func newTestRegionInfo(regionID, storeID uint64, start, end []byte, opts ...core
 		core.SetWrittenKeys(1 * 1024 * 1024),
 		core.SetReadBytes(200 * 1024 * 1024),
 		core.SetReadKeys(2 * 1024 * 1024),
+		core.SetQueryStats(&pdpb.QueryStats{
+			GC:                     10,
+			Get:                    10,
+			Scan:                   10,
+			Coprocessor:            10,
+			Delete:                 10,
+			DeleteRange:            10,
+			Put:                    10,
+			Prewrite:               10,
+			AcquirePessimisticLock: 10,
+		}),
 	}
 	newOpts = append(newOpts, opts...)
 	region := core.NewRegionInfo(metaRegion, leader, newOpts...)
@@ -146,8 +157,10 @@ func (s *testRegionSuite) TestRegion(c *C) {
 	c.Assert(readJSON(testDialClient, url, &r1m), IsNil)
 	c.Assert(r1m["written_bytes"].(float64), Equals, float64(r.GetBytesWritten()))
 	c.Assert(r1m["written_keys"].(float64), Equals, float64(r.GetKeysWritten()))
+	c.Assert(r1m["write_query_num"].(float64), Equals, float64(r.GetWriteQueryNum()))
 	c.Assert(r1m["read_bytes"].(float64), Equals, float64(r.GetBytesRead()))
 	c.Assert(r1m["read_keys"].(float64), Equals, float64(r.GetKeysRead()))
+	c.Assert(r1m["read_query_num"].(float64), Equals, float64(r.GetReadQueryNum()))
 	keys := r1m["buckets"].([]interface{})
 	c.Assert(keys, HasLen, 2)
 	c.Assert(keys[0].(string), Equals, core.HexRegionKeyStr([]byte("a")))


### PR DESCRIPTION
Signed-off-by: qidi1 <1083369179@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Currently，Keyviz has `keys` and `bytes` dimensions. In some situations, it cannot find the hotspot that the CPU is high caused by QPS, the `keys` and `bytes` may be 0. For example:

```sql
create table t(id int);
insert into table t values (1)(2)....(1000);
// random read out bound，suppose there are many requests.
select * from t where id = 1000 + rand(0,1000)
```

## 
Issue Number:  #pingcap/tidb-dashboard/issues/1209
### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
 Return QPS data in PD.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test 


Related changes


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```

## Manual test
We ran a small cluster locally. On the cluster, test data was generated using the tiup bench tool. The results are shown in the figure below.
![image](https://user-images.githubusercontent.com/38561029/167781781-8c1a0c60-5604-49c7-9efb-f8a2a779beb1.png)
![image](https://user-images.githubusercontent.com/38561029/167781794-d9c2c352-57d2-4594-9de3-58f5d7675c6d.png)


