### PR TITLE
replication: add acid_consistant flag in HTTP response

### DIFF
--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -177,7 +177,7 @@ type HTTPReplicationStatus struct {
 		LabelKey        string  `json:"label_key"`
 		State           string  `json:"state"`
 		StateID         uint64  `json:"state_id,omitempty"`
-		ACIDConsistant  bool    `json:"acid_consistant"`
+		ACIDConsistent  bool    `json:"acid_consistent"`
 		TotalRegions    int     `json:"total_regions,omitempty"`
 		SyncedRegions   int     `json:"synced_regions,omitempty"`
 		RecoverProgress float32 `json:"recover_progress,omitempty"`
@@ -196,7 +196,7 @@ func (m *ModeManager) GetReplicationStatusHTTP() *HTTPReplicationStatus {
 		status.DrAutoSync.LabelKey = m.config.DRAutoSync.LabelKey
 		status.DrAutoSync.State = m.drAutoSync.State
 		status.DrAutoSync.StateID = m.drAutoSync.StateID
-		status.DrAutoSync.ACIDConsistant = m.drAutoSync.State != drStateSyncRecover
+		status.DrAutoSync.ACIDConsistent = m.drAutoSync.State != drStateSyncRecover
 		status.DrAutoSync.RecoverProgress = m.drAutoSync.RecoverProgress
 		status.DrAutoSync.TotalRegions = m.drAutoSync.TotalRegions
 		status.DrAutoSync.SyncedRegions = m.drAutoSync.SyncedRegions

--- a/server/replication/replication_mode.go
+++ b/server/replication/replication_mode.go
@@ -177,6 +177,7 @@ type HTTPReplicationStatus struct {
 		LabelKey        string  `json:"label_key"`
 		State           string  `json:"state"`
 		StateID         uint64  `json:"state_id,omitempty"`
+		ACIDConsistant  bool    `json:"acid_consistant"`
 		TotalRegions    int     `json:"total_regions,omitempty"`
 		SyncedRegions   int     `json:"synced_regions,omitempty"`
 		RecoverProgress float32 `json:"recover_progress,omitempty"`
@@ -195,6 +196,7 @@ func (m *ModeManager) GetReplicationStatusHTTP() *HTTPReplicationStatus {
 		status.DrAutoSync.LabelKey = m.config.DRAutoSync.LabelKey
 		status.DrAutoSync.State = m.drAutoSync.State
 		status.DrAutoSync.StateID = m.drAutoSync.StateID
+		status.DrAutoSync.ACIDConsistant = m.drAutoSync.State != drStateSyncRecover
 		status.DrAutoSync.RecoverProgress = m.drAutoSync.RecoverProgress
 		status.DrAutoSync.TotalRegions = m.drAutoSync.TotalRegions
 		status.DrAutoSync.SyncedRegions = m.drAutoSync.SyncedRegions


### PR DESCRIPTION
fix #4940

Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Issue Number: Close #4940

### What is changed and how does it work?

add a new flag to indicate if the state can make sure the data in DR is ACID consistant.

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Manual test (add detailed scripts or steps below)

Code changes

- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

```release-note
None
```
