### PR TITLE
scheduler: fix the hot scheduler panic due to region with no leader

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -471,7 +471,7 @@ func (bs *balanceSolver) solve() []*operator.Operator {
 		for _, srcPeerStat := range bs.filterHotPeers() {
 			bs.cur.srcPeerStat = srcPeerStat
 			bs.cur.region = bs.getRegion()
-			if bs.cur.region == nil {
+			if bs.cur.region == nil || bs.cur.region.GetLeader() == nil {
 				continue
 			}
 			for _, dstDetail := range bs.filterDstStores() {
@@ -1058,7 +1058,7 @@ func (bs *balanceSolver) buildOperator() (op *operator.Operator, infl *statistic
 		sourceLabel = strconv.FormatUint(srcStoreID, 10)
 		targetLabel = strconv.FormatUint(dstPeer.GetStoreId(), 10)
 
-		if bs.rwTy == statistics.Read && bs.cur.region.GetLeader().StoreId == srcStoreID { // move read leader
+		if bs.rwTy == statistics.Read && bs.cur.region.GetLeader().GetStoreId() == srcStoreID { // move read leader
 			op, err = operator.CreateMoveLeaderOperator(
 				"move-hot-read-leader",
 				bs.cluster,

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -996,6 +996,18 @@ func (s *testHotReadRegionSchedulerSuite) TestByteRateOnly(c *C) {
 	testutil.CheckTransferPeerWithLeaderTransfer(c, op, operator.OpHotRegion, 1, 5)
 	hb.(*hotScheduler).clearPendingInfluence()
 
+	// test if region lose leader can cause PD panic
+	r1 := tc.GetRegion(3)
+	tc.PutRegion(core.NewRegionInfo(r1.GetMeta(), nil,
+		core.SetReadBytes(r1.GetBytesRead()),
+		core.SetReadKeys(r1.GetKeysRead()),
+		core.SetReadQuery(r1.GetReadQueryNum()),
+		core.SetReportInterval(r1.GetInterval().GetEndTimestamp()),
+	))
+	_ = hb.Schedule(tc)[0]
+	hb.(*hotScheduler).clearPendingInfluence()
+	tc.PutRegion(r1)
+
 	// assume handle the transfer leader operator rather than move leader
 	tc.AddRegionWithReadInfo(3, 3, 512*KB*statistics.ReadReportInterval, 0, 0, statistics.ReadReportInterval, []uint64{1, 2})
 	// After transfer a hot region leader from store 1 to store 3


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5005 

### What is changed and how does it work?

Fixes the panic problem by calling `GetStoreId()` instead of using `StoreId` directly.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fix the issue that the hot region may cause panic due to no leader
```
