### PR TITLE
config: Enlarge max request bytes

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -204,7 +204,11 @@ const (
 	defaultCompactionMode          = "periodic"
 	defaultAutoCompactionRetention = "1h"
 	defaultQuotaBackendBytes       = typeutil.ByteSize(8 * 1024 * 1024 * 1024) // 8GB
-	defaultMaxRequestBytes         = uint(150 * 1024 * 1024)                   // 150MB
+
+	// The max bytes for grpc message
+	// Unsafe recovery report is included in store heartbeat, and assume that each peer report occupies about 500KB at most,
+	// then 150MB can fit for store reports that have about 300k regions which is something of a huge amount of regiona on one TiKV.
+	defaultMaxRequestBytes = uint(150 * 1024 * 1024) // 150MB
 
 	defaultName                = "pd"
 	defaultClientUrls          = "http://127.0.0.1:2379"

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -205,8 +205,8 @@ const (
 	defaultAutoCompactionRetention = "1h"
 	defaultQuotaBackendBytes       = typeutil.ByteSize(8 * 1024 * 1024 * 1024) // 8GB
 
-	// The max bytes for grpc message
-	// Unsafe recovery report is included in store heartbeat, and assume that each peer report occupies about 500KB at most,
+	// The default max bytes for grpc message
+	// Unsafe recovery report is included in store heartbeat, and assume that each peer report occupies about 500B at most,
 	// then 150MB can fit for store reports that have about 300k regions which is something of a huge amount of regiona on one TiKV.
 	defaultMaxRequestBytes = uint(150 * 1024 * 1024) // 150MB
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -204,7 +204,7 @@ const (
 	defaultCompactionMode          = "periodic"
 	defaultAutoCompactionRetention = "1h"
 	defaultQuotaBackendBytes       = typeutil.ByteSize(8 * 1024 * 1024 * 1024) // 8GB
-	defaultMaxRequestBytes         = uint(1.5 * 1024 * 1024)                   // 1.5MB
+	defaultMaxRequestBytes         = uint(150 * 1024 * 1024)                   // 150MB
 
 	defaultName                = "pd"
 	defaultClientUrls          = "http://127.0.0.1:2379"


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5008 

Too small max request bytes make grpc always fail.
![tJwb4zTI7h](https://user-images.githubusercontent.com/13497871/169745755-d883796f-1045-47bb-943c-5b07fb369b64.png)


### What is changed and how does it work?

Assume that each peer report occupies about 500KB at most, then 150MB can fit for store reports that have 30w regions information. 

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Enlarge max request bytes to fit the large store report for unsafe recovery
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- No code

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
