### PR TITLE
cluster: calculate speed until cluster is prepared

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1449,7 +1449,7 @@ func (c *RaftCluster) checkStores() {
 						zap.Stringer("store", store.GetMeta()),
 						errs.ZapError(err))
 				}
-			} else {
+			} else if c.IsPrepared() {
 				threshold := c.getThreshold(stores, store)
 				log.Debug("store serving threshold", zap.Uint64("store-id", storeID), zap.Float64("threshold", threshold))
 				regionSize := float64(store.GetRegionSize())

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -496,6 +496,13 @@ func (c *RaftCluster) GetOperatorController() *schedule.OperatorController {
 	return c.coordinator.opController
 }
 
+// SetPrepared set the prepare check to prepared. Only for test purpose.
+func (c *RaftCluster) SetPrepared() {
+	c.coordinator.prepareChecker.Lock()
+	defer c.coordinator.prepareChecker.Unlock()
+	c.coordinator.prepareChecker.prepared = true
+}
+
 // GetRegionScatter returns the region scatter.
 func (c *RaftCluster) GetRegionScatter() *schedule.RegionScatterer {
 	return c.coordinator.regionScatterer

--- a/server/cluster/coordinator.go
+++ b/server/cluster/coordinator.go
@@ -618,9 +618,6 @@ func (c *coordinator) resetHotSpotMetrics() {
 }
 
 func (c *coordinator) shouldRun() bool {
-	failpoint.Inject("hasPrepared", func() {
-		failpoint.Return(true)
-	})
 	return c.prepareChecker.check(c.cluster.GetBasicCluster())
 }
 


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5025

### What is changed and how does it work?

The reason why the speed isn't accurate is that when the leader changes, the check stores won't wait for all regions' heartbeats to finish. So it will push a small store region size into the statistics window. Then in the later 10 mins, PD will use the latest store region size, which could be big after the heartbeat finish, minus that one to get the delta for calculating the speed. After the 10min passed away, the first value of the statistics window will be removed, then the speed becomes normal.
<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test 

After：
![origin_img_v2_41cbe360-ffc6-474d-816d-ee6d38e2781g](https://user-images.githubusercontent.com/35896542/170226233-96d5a255-6eb8-4661-92ed-93bc0a039481.jpg)
![middle_img_v2_4abd4eba-a75d-42d7-9e18-9ea394ca349g](https://user-images.githubusercontent.com/35896542/170236871-21fc7cba-4319-46f9-8dd9-1bdee5203e4a.jpg)



Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fix the issue that the store online speed is not accurate when the PD leader transfers.
```
