### PR TITLE
server: fix the bug that causes wrong statistics for over/undersized regions

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -792,6 +792,11 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	// Mark isNew if the region in cache does not have leader.
 	isNew, saveKV, saveCache, needSync := regionGuide(region, origin)
 	if !saveKV && !saveCache && !isNew {
+		// Due to some config changes need to update the region stats as well,
+		// so we do some extra checks here.
+		if c.regionStats != nil && c.regionStats.RegionStatsNeedUpdate(region) {
+			c.regionStats.Observe(region, c.getRegionStoresLocked(region))
+		}
 		return nil
 	}
 

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -261,14 +261,14 @@ func (o *PersistOptions) SetSplitMergeInterval(splitMergeInterval time.Duration)
 }
 
 // SetMaxMergeRegionSize sets the max merge region size.
-func (o *PersistOptions) SetMaxMergeRegionSize(maxMergeRegionSize uint64)  {
+func (o *PersistOptions) SetMaxMergeRegionSize(maxMergeRegionSize uint64) {
 	v := o.GetScheduleConfig().Clone()
 	v.MaxMergeRegionSize = maxMergeRegionSize
 	o.SetScheduleConfig(v)
 }
 
-// SetMaxMergeRegionSize sets the max merge region keys.
-func (o *PersistOptions) SetMaxMergeRegionKeys(maxMergeRegionKeys uint64)  {
+// SetMaxMergeRegionKeys sets the max merge region keys.
+func (o *PersistOptions) SetMaxMergeRegionKeys(maxMergeRegionKeys uint64) {
 	v := o.GetScheduleConfig().Clone()
 	v.MaxMergeRegionKeys = maxMergeRegionKeys
 	o.SetScheduleConfig(v)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -260,6 +260,20 @@ func (o *PersistOptions) SetSplitMergeInterval(splitMergeInterval time.Duration)
 	o.SetScheduleConfig(v)
 }
 
+// SetMaxMergeRegionSize sets the max merge region size.
+func (o *PersistOptions) SetMaxMergeRegionSize(maxMergeRegionSize uint64)  {
+	v := o.GetScheduleConfig().Clone()
+	v.MaxMergeRegionSize = maxMergeRegionSize
+	o.SetScheduleConfig(v)
+}
+
+// SetMaxMergeRegionSize sets the max merge region keys.
+func (o *PersistOptions) SetMaxMergeRegionKeys(maxMergeRegionKeys uint64)  {
+	v := o.GetScheduleConfig().Clone()
+	v.MaxMergeRegionKeys = maxMergeRegionKeys
+	o.SetScheduleConfig(v)
+}
+
 // SetStoreLimit sets a store limit for a given type and rate.
 func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePerMin float64) {
 	v := o.GetScheduleConfig().Clone()

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -229,6 +229,17 @@ func (r *RegionInfo) NeedMerge(mergeSize int64, mergeKeys int64) bool {
 	return r.GetApproximateSize() <= mergeSize && r.GetApproximateKeys() <= mergeKeys
 }
 
+// IsOversized indicates whether the region is oversized.
+func (r *RegionInfo) IsOversized(maxSize int64, maxKeys int64) bool {
+	return r.GetApproximateSize() >= maxSize || r.GetApproximateKeys() >= maxKeys
+}
+
+// IsUndersized indicates whether the region is undersized.
+// PS: This is an alias of `NeedMerge`.
+func (r *RegionInfo) IsUndersized(minSize int64, minKeys int64) bool {
+	return r.NeedMerge(minSize, minKeys)
+}
+
 // GetTerm returns the current term of the region
 func (r *RegionInfo) GetTerm() uint64 {
 	return r.term

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -234,12 +234,6 @@ func (r *RegionInfo) IsOversized(maxSize int64, maxKeys int64) bool {
 	return r.GetApproximateSize() >= maxSize || r.GetApproximateKeys() >= maxKeys
 }
 
-// IsUndersized indicates whether the region is undersized.
-// PS: This is an alias of `NeedMerge`.
-func (r *RegionInfo) IsUndersized(minSize int64, minKeys int64) bool {
-	return r.NeedMerge(minSize, minKeys)
-}
-
 // GetTerm returns the current term of the region
 func (r *RegionInfo) GetTerm() uint64 {
 	return r.term

--- a/server/statistics/region_collection.go
+++ b/server/statistics/region_collection.go
@@ -140,14 +140,12 @@ func (r *RegionStatistics) deleteOfflineEntry(deleteIndex RegionStatisticType, r
 // due to some special state types.
 func (r *RegionStatistics) RegionStatsNeedUpdate(region *core.RegionInfo) bool {
 	regionID := region.GetID()
-	maxSize := int64(r.storeConfigManager.GetStoreConfig().GetRegionMaxSize())
-	maxKeys := int64(r.storeConfigManager.GetStoreConfig().GetRegionMaxKeys())
-	if r.IsRegionStatsType(regionID, OversizedRegion) != region.IsOversized(maxSize, maxKeys) {
+	if r.IsRegionStatsType(regionID, OversizedRegion) !=
+		region.IsOversized(int64(r.storeConfigManager.GetStoreConfig().GetRegionMaxSize()), int64(r.storeConfigManager.GetStoreConfig().GetRegionMaxKeys())) {
 		return true
 	}
-	minSize := int64(r.opt.GetMaxMergeRegionSize())
-	minKeys := int64(r.opt.GetMaxMergeRegionKeys())
-	return r.IsRegionStatsType(regionID, UndersizedRegion) != region.IsUndersized(minSize, minKeys)
+	return r.IsRegionStatsType(regionID, UndersizedRegion) !=
+		region.NeedMerge(int64(r.opt.GetMaxMergeRegionSize()), int64(r.opt.GetMaxMergeRegionKeys()))
 }
 
 // Observe records the current regions' status.
@@ -205,7 +203,7 @@ func (r *RegionStatistics) Observe(region *core.RegionInfo, stores []*core.Store
 			int64(r.storeConfigManager.GetStoreConfig().GetRegionMaxSize()),
 			int64(r.storeConfigManager.GetStoreConfig().GetRegionMaxKeys()),
 		),
-		UndersizedRegion: region.IsUndersized(
+		UndersizedRegion: region.NeedMerge(
 			int64(r.opt.GetMaxMergeRegionSize()),
 			int64(r.opt.GetMaxMergeRegionKeys()),
 		),

--- a/server/statistics/region_collection.go
+++ b/server/statistics/region_collection.go
@@ -105,12 +105,8 @@ func (r *RegionStatistics) GetRegionStatsByType(typ RegionStatisticType) []*core
 func (r *RegionStatistics) IsRegionStatsType(regionID uint64, typ RegionStatisticType) bool {
 	r.RLock()
 	defer r.RUnlock()
-	for _, r := range r.stats[typ] {
-		if r.GetID() == regionID {
-			return true
-		}
-	}
-	return false
+	_, exist := r.stats[typ][regionID]
+	return exist
 }
 
 // GetOfflineRegionStatsByType gets the status of the offline region by types. The regions here need to be cloned, otherwise, it may cause data race problems.


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5107.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix the bug that causes wrong statistics for over/undersized regions.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
