### PR TITLE
tests: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/encryption/master_key_test.go
+++ b/pkg/encryption/master_key_test.go
@@ -99,8 +99,7 @@ func TestNewFileMasterKeyMissingPath(t *testing.T) {
 func TestNewFileMasterKeyMissingFile(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	dir, err := os.MkdirTemp("", "test_key_files")
-	re.NoError(err)
+	dir := t.TempDir()
 	path := dir + "/key"
 	config := &encryptionpb.MasterKey{
 		Backend: &encryptionpb.MasterKey_File{
@@ -109,15 +108,14 @@ func TestNewFileMasterKeyMissingFile(t *testing.T) {
 			},
 		},
 	}
-	_, err = NewMasterKey(config, nil)
+	_, err := NewMasterKey(config, nil)
 	re.Error(err)
 }
 
 func TestNewFileMasterKeyNotHexString(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	dir, err := os.MkdirTemp("", "test_key_files")
-	re.NoError(err)
+	dir := t.TempDir()
 	path := dir + "/key"
 	os.WriteFile(path, []byte("not-a-hex-string"), 0600)
 	config := &encryptionpb.MasterKey{
@@ -127,15 +125,14 @@ func TestNewFileMasterKeyNotHexString(t *testing.T) {
 			},
 		},
 	}
-	_, err = NewMasterKey(config, nil)
+	_, err := NewMasterKey(config, nil)
 	re.Error(err)
 }
 
 func TestNewFileMasterKeyLengthMismatch(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	dir, err := os.MkdirTemp("", "test_key_files")
-	re.NoError(err)
+	dir := t.TempDir()
 	path := dir + "/key"
 	os.WriteFile(path, []byte("2f07ec61e5a50284f47f2b402a962ec6"), 0600)
 	config := &encryptionpb.MasterKey{
@@ -145,7 +142,7 @@ func TestNewFileMasterKeyLengthMismatch(t *testing.T) {
 			},
 		},
 	}
-	_, err = NewMasterKey(config, nil)
+	_, err := NewMasterKey(config, nil)
 	re.Error(err)
 }
 
@@ -153,8 +150,7 @@ func TestNewFileMasterKey(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
 	key := "2f07ec61e5a50284f47f2b402a962ec672e500b26cb3aa568bb1531300c74806"
-	dir, err := os.MkdirTemp("", "test_key_files")
-	re.NoError(err)
+	dir := t.TempDir()
 	path := dir + "/key"
 	os.WriteFile(path, []byte(key), 0600)
 	config := &encryptionpb.MasterKey{

--- a/pkg/etcdutil/etcdutil.go
+++ b/pkg/etcdutil/etcdutil.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
+	"testing"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -182,10 +182,10 @@ func EtcdKVPutWithTTL(ctx context.Context, c *clientv3.Client, key string, value
 }
 
 // NewTestSingleConfig is used to create a etcd config for the unit test purpose.
-func NewTestSingleConfig() *embed.Config {
+func NewTestSingleConfig(t *testing.T) *embed.Config {
 	cfg := embed.NewConfig()
 	cfg.Name = "test_etcd"
-	cfg.Dir, _ = os.MkdirTemp("/tmp", "test_etcd")
+	cfg.Dir = t.TempDir()
 	cfg.WalDir = ""
 	cfg.Logger = "zap"
 	cfg.LogOutputs = []string{"stdout"}
@@ -201,10 +201,4 @@ func NewTestSingleConfig() *embed.Config {
 	cfg.InitialCluster = fmt.Sprintf("%s=%s", cfg.Name, &cfg.LPUrls[0])
 	cfg.ClusterState = embed.ClusterStateFlagNew
 	return cfg
-}
-
-// CleanConfig is used to clean the etcd data for the unit test purpose.
-func CleanConfig(cfg *embed.Config) {
-	// Clean data directory
-	os.RemoveAll(cfg.Dir)
 }

--- a/pkg/etcdutil/etcdutil_test.go
+++ b/pkg/etcdutil/etcdutil_test.go
@@ -30,11 +30,10 @@ import (
 func TestMemberHelpers(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	cfg1 := NewTestSingleConfig()
+	cfg1 := NewTestSingleConfig(t)
 	etcd1, err := embed.StartEtcd(cfg1)
 	defer func() {
 		etcd1.Close()
-		CleanConfig(cfg1)
 	}()
 	re.NoError(err)
 
@@ -55,7 +54,7 @@ func TestMemberHelpers(t *testing.T) {
 
 	// Test AddEtcdMember
 	// Make a new etcd config.
-	cfg2 := NewTestSingleConfig()
+	cfg2 := NewTestSingleConfig(t)
 	cfg2.Name = "etcd2"
 	cfg2.InitialCluster = cfg1.InitialCluster + fmt.Sprintf(",%s=%s", cfg2.Name, &cfg2.LPUrls[0])
 	cfg2.ClusterState = embed.ClusterStateFlagExisting
@@ -68,7 +67,6 @@ func TestMemberHelpers(t *testing.T) {
 	etcd2, err := embed.StartEtcd(cfg2)
 	defer func() {
 		etcd2.Close()
-		CleanConfig(cfg2)
 	}()
 	re.NoError(err)
 	re.Equal(uint64(etcd2.Server.ID()), addResp.Member.ID)
@@ -113,11 +111,10 @@ func TestMemberHelpers(t *testing.T) {
 func TestEtcdKVGet(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	cfg := NewTestSingleConfig()
+	cfg := NewTestSingleConfig(t)
 	etcd, err := embed.StartEtcd(cfg)
 	defer func() {
 		etcd.Close()
-		CleanConfig(cfg)
 	}()
 	re.NoError(err)
 
@@ -165,11 +162,10 @@ func TestEtcdKVGet(t *testing.T) {
 func TestEtcdKVPutWithTTL(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	cfg := NewTestSingleConfig()
+	cfg := NewTestSingleConfig(t)
 	etcd, err := embed.StartEtcd(cfg)
 	defer func() {
 		etcd.Close()
-		CleanConfig(cfg)
 	}()
 	re.NoError(err)
 

--- a/server/election/leadership_test.go
+++ b/server/election/leadership_test.go
@@ -29,11 +29,10 @@ const defaultLeaseTimeout = 1
 
 func TestLeadership(t *testing.T) {
 	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig()
+	cfg := etcdutil.NewTestSingleConfig(t)
 	etcd, err := embed.StartEtcd(cfg)
 	defer func() {
 		etcd.Close()
-		etcdutil.CleanConfig(cfg)
 	}()
 	re.NoError(err)
 

--- a/server/election/lease_test.go
+++ b/server/election/lease_test.go
@@ -27,11 +27,10 @@ import (
 
 func TestLease(t *testing.T) {
 	re := require.New(t)
-	cfg := etcdutil.NewTestSingleConfig()
+	cfg := etcdutil.NewTestSingleConfig(t)
 	etcd, err := embed.StartEtcd(cfg)
 	defer func() {
 		etcd.Close()
-		etcdutil.CleanConfig(cfg)
 	}()
 	re.NoError(err)
 

--- a/server/region_syncer/client_test.go
+++ b/server/region_syncer/client_test.go
@@ -16,7 +16,6 @@ package syncer
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -34,9 +33,7 @@ import (
 // For issue https://github.com/tikv/pd/issues/3936
 func TestLoadRegion(t *testing.T) {
 	re := require.New(t)
-	tempDir, err := os.MkdirTemp(os.TempDir(), "region_syncer_load_region")
-	re.NoError(err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	rs, err := storage.NewStorageWithLevelDBBackend(context.Background(), tempDir, nil)
 	re.NoError(err)
 
@@ -64,9 +61,7 @@ func TestLoadRegion(t *testing.T) {
 
 func TestErrorCode(t *testing.T) {
 	re := require.New(t)
-	tempDir, err := os.MkdirTemp(os.TempDir(), "region_syncer_err")
-	re.NoError(err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	rs, err := storage.NewStorageWithLevelDBBackend(context.Background(), tempDir, nil)
 	re.NoError(err)
 	server := &mockServer{

--- a/server/storage/kv/kv_test.go
+++ b/server/storage/kv/kv_test.go
@@ -17,7 +17,6 @@ package kv
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"path"
 	"sort"
 	"strconv"
@@ -31,8 +30,7 @@ import (
 
 func TestEtcd(t *testing.T) {
 	re := require.New(t)
-	cfg := newTestSingleConfig()
-	defer cleanConfig(cfg)
+	cfg := newTestSingleConfig(t)
 	etcd, err := embed.StartEtcd(cfg)
 	re.NoError(err)
 	defer etcd.Close()
@@ -51,9 +49,7 @@ func TestEtcd(t *testing.T) {
 
 func TestLevelDB(t *testing.T) {
 	re := require.New(t)
-	dir, err := os.MkdirTemp("/tmp", "leveldb_kv")
-	re.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	kv, err := NewLevelDBKV(dir)
 	re.NoError(err)
 
@@ -121,10 +117,10 @@ func testRange(re *require.Assertions, kv Base) {
 	}
 }
 
-func newTestSingleConfig() *embed.Config {
+func newTestSingleConfig(t *testing.T) *embed.Config {
 	cfg := embed.NewConfig()
 	cfg.Name = "test_etcd"
-	cfg.Dir, _ = os.MkdirTemp("/tmp", "test_etcd")
+	cfg.Dir = t.TempDir()
 	cfg.WalDir = ""
 	cfg.Logger = "zap"
 	cfg.LogOutputs = []string{"stdout"}
@@ -140,9 +136,4 @@ func newTestSingleConfig() *embed.Config {
 	cfg.InitialCluster = fmt.Sprintf("%s=%s", cfg.Name, &cfg.LPUrls[0])
 	cfg.ClusterState = embed.ClusterStateFlagNew
 	return cfg
-}
-
-func cleanConfig(cfg *embed.Config) {
-	// Clean data directory
-	os.RemoveAll(cfg.Dir)
 }

--- a/tests/client/client_tls_test.go
+++ b/tests/client/client_tls_test.go
@@ -62,28 +62,22 @@ func TestTLSReloadAtomicReplace(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "cert-tmp")
-	re.NoError(err)
+	tmpDir := t.TempDir()
 	os.RemoveAll(tmpDir)
-	defer os.RemoveAll(tmpDir)
 
-	certsDir, err := os.MkdirTemp(os.TempDir(), "cert-to-load")
-	re.NoError(err)
-	defer os.RemoveAll(certsDir)
+	certsDir := t.TempDir()
 
-	certsDirExp, err := os.MkdirTemp(os.TempDir(), "cert-expired")
-	re.NoError(err)
-	defer os.RemoveAll(certsDirExp)
+	certsDirExp := t.TempDir()
 
 	cloneFunc := func() transport.TLSInfo {
 		tlsInfo, terr := copyTLSFiles(testTLSInfo, certsDir)
 		re.NoError(terr)
-		_, err = copyTLSFiles(testTLSInfoExpired, certsDirExp)
+		_, err := copyTLSFiles(testTLSInfoExpired, certsDirExp)
 		re.NoError(err)
 		return tlsInfo
 	}
 	replaceFunc := func() {
-		err = os.Rename(certsDir, tmpDir)
+		err := os.Rename(certsDir, tmpDir)
 		re.NoError(err)
 		err = os.Rename(certsDirExp, certsDir)
 		re.NoError(err)
@@ -93,7 +87,7 @@ func TestTLSReloadAtomicReplace(t *testing.T) {
 		// 'certsDirExp' does not exist
 	}
 	revertFunc := func() {
-		err = os.Rename(tmpDir, certsDirExp)
+		err := os.Rename(tmpDir, certsDirExp)
 		re.NoError(err)
 
 		err = os.Rename(certsDir, tmpDir)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5152 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
