### PR TITLE
benchmark: load-regions

### DIFF
--- a/server/storage/storage_test.go
+++ b/server/storage/storage_test.go
@@ -285,7 +285,7 @@ func TestLoadRegionsExceedRangeLimit(t *testing.T) {
 
 const (
 	keyChars = "abcdefghijklmnopqrstuvwxyz"
-	keyLen   = 10
+	keyLen   = 20
 )
 
 func generateKeys(size int) []string {
@@ -335,7 +335,7 @@ func anotherSaveRegions(lb *levelDBBackend, n int, merge bool) error {
 		var region *metapb.Region
 		if i == 0 {
 			region = &metapb.Region{
-				StartKey: []byte("aaaaaaaaaa"),
+				StartKey: []byte("aaaaaaaaaaaaaaaaaaaa"),
 				EndKey: []byte(keys[i]),
 			}
 		} else {

--- a/server/storage/storage_test.go
+++ b/server/storage/storage_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -362,7 +361,8 @@ func anotherSaveRegions(lb *levelDBBackend, n int, merge bool) error {
 
 func benchmarkLoadRegions(n int, b *testing.B, merge bool) {
 	ctx := context.Background()
-	lb, err := newLevelDBBackend(ctx, "./tmp", nil)
+	dir := b.TempDir()
+	lb, err := newLevelDBBackend(ctx, dir, nil)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -373,10 +373,6 @@ func benchmarkLoadRegions(n int, b *testing.B, merge bool) {
 	cluster := core.NewBasicCluster()
 	defer func() {
 		err = lb.Close()
-		if err != nil {
-			b.Fatal(err)
-		}
-		err = os.RemoveAll("./tmp")
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Signed-off-by: LLThomas <zs033@qq.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #4994

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
This pull request add two benchmark function.
1. "BenchmarkLoadRegionsByVolume" will benchmark the LoadRegions() based on the number of regions (10000, 100000, 1000000).
2. "BenchmarkLoadRegionsByRandomMerge" will benchmark the LoadRegions() based on randomly merged regions.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
