### PR TITLE
server/schedulers/balance_leader: source and target can share 1 candidatestores

### DIFF
--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -288,7 +288,7 @@ func (cs *candidateStores) hasStore() bool {
 	return (cs.index < l) || (l > 0 && cs.reverseIndex >= 0)
 }
 
-func (cs *candidateStores) getOriginStore() *core.StoreInfo {
+func (cs *candidateStores) getForwardStore() *core.StoreInfo {
 	if cs.index < len(cs.stores) {
 		return cs.stores[cs.index]
 	}
@@ -389,7 +389,7 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster) []*operator.
 	}
 
 	for {
-		source := storesCandidate.getOriginStore()
+		source := storesCandidate.getForwardStore()
 		if source != nil {
 			plan.source, plan.target = source, nil
 			if createOpWithPlan(true) {

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -630,7 +630,7 @@ func (s *testBalanceLeaderRangeSchedulerSuite) TestReSortStores(c *C) {
 	}
 	candidateStores := make([]*core.StoreInfo, 0)
 	// order by score desc.
-	cs := newCandidateStores(append(candidateStores, stores...), false, getScore)
+	cs := newCandidateStores(append(candidateStores, stores...), getScore)
 	// in candidate,the order stores:1(104),5(100),4(100),6,3,2
 	// store 4 should in pos 2
 	c.Assert(cs.binarySearch(stores[3]), Equals, 2)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #[5189](https://github.com/tikv/pd/issues/5189)

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
-  bench mark test
- 
#### master
```
schedulers git:(master) ✗ go test -benchmem -run=^$ -bench ^BenchmarkBalanceLeader$ -benchtime=100x
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedulers
cpu: VirtualApple @ 2.50GHz
BenchmarkBalanceLeader-8             100         107248906 ns/op         3620522 B/op      52344 allocs/op
PASS
ok      github.com/tikv/pd/server/schedulers    30.150s
```

#### current branch 
```
schedulers git:(balance_leader_share_candidatestores) ✗ go test -benchmem -run=^$ -bench ^BenchmarkBalanceLeader$ -benchtime=100x
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedulers
cpu: VirtualApple @ 2.50GHz
BenchmarkBalanceLeader-8             100          42963967 ns/op         3135231 B/op      45180 allocs/op
PASS
ok      github.com/tikv/pd/server/schedulers    22.796s
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
