### PR TITLE
storage: optimize the storage interface

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -357,7 +357,7 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 	start = time.Now()
 
 	// used to load region from kv storage to cache storage.
-	if err := c.storage.LoadRegionsOnce(c.ctx, c.core.CheckAndPutRegion); err != nil {
+	if err := storage.TryLoadRegionsOnce(c.ctx, c.storage, c.core.CheckAndPutRegion); err != nil {
 		return nil, err
 	}
 	log.Info("load regions",

--- a/server/server.go
+++ b/server/server.go
@@ -1517,19 +1517,14 @@ func (s *Server) reloadConfigFromKV() error {
 		return err
 	}
 	s.loadRateLimitConfig()
-	switchableStorage, ok := s.storage.(interface {
-		SwitchToRegionStorage()
-		SwitchToDefaultStorage()
-	})
-	if !ok {
-		return nil
-	}
-	if s.persistOptions.IsUseRegionStorage() {
-		switchableStorage.SwitchToRegionStorage()
-		log.Info("server enable region storage")
-	} else {
-		switchableStorage.SwitchToDefaultStorage()
-		log.Info("server disable region storage")
+	useRegionStorage := s.persistOptions.IsUseRegionStorage()
+	regionStorage := storage.TrySwitchRegionStorage(s.storage, useRegionStorage)
+	if regionStorage != nil {
+		if useRegionStorage {
+			log.Info("server enable region storage")
+		} else {
+			log.Info("server disable region storage")
+		}
 	}
 	return nil
 }

--- a/server/storage/endpoint/meta.go
+++ b/server/storage/endpoint/meta.go
@@ -44,7 +44,6 @@ type MetaStorage interface {
 type RegionStorage interface {
 	LoadRegion(regionID uint64, region *metapb.Region) (ok bool, err error)
 	LoadRegions(ctx context.Context, f func(region *core.RegionInfo) []*core.RegionInfo) error
-	LoadRegionsOnce(ctx context.Context, f func(region *core.RegionInfo) []*core.RegionInfo) error
 	SaveRegion(region *metapb.Region) error
 	DeleteRegion(region *metapb.Region) error
 	Flush() error
@@ -216,11 +215,6 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 			return nil
 		}
 	}
-}
-
-// LoadRegionsOnce loads all regions from storage to RegionsInfo.
-func (se *StorageEndpoint) LoadRegionsOnce(ctx context.Context, f func(region *core.RegionInfo) []*core.RegionInfo) error {
-	return se.LoadRegions(ctx, f)
 }
 
 // SaveRegion saves one region to storage.

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -83,23 +83,60 @@ func NewCoreStorage(defaultStorage Storage, regionStorage endpoint.RegionStorage
 	}
 }
 
-// GetRegionStorage gets the internal region storage.
-func (ps *coreStorage) GetRegionStorage() endpoint.RegionStorage {
-	return ps.regionStorage
+// TryGetLocalRegionStorage gets the local region storage. Returns nil if not present.
+func TryGetLocalRegionStorage(s Storage) endpoint.RegionStorage {
+	switch ps := s.(type) {
+	case *coreStorage:
+		return ps.regionStorage
+	case *levelDBBackend, *memoryStorage:
+		return ps
+	default:
+		return nil
+	}
 }
 
-// SwitchToRegionStorage switches the region storage to regionStorage,
-// after calling this, all region info will be read/saved by the internal
-// regionStorage, and in most cases it's LevelDB-backend.
-func (ps *coreStorage) SwitchToRegionStorage() {
-	atomic.StoreInt32(&ps.useRegionStorage, 1)
-}
+// TrySwitchRegionStorage try to switch whether the RegionStorage uses local or not,
+// and returns the RegionStorage used after the switch.
+// Returns nil if it cannot be switched.
+func TrySwitchRegionStorage(s Storage, useLocalRegionStorage bool) endpoint.RegionStorage {
+	ps, ok := s.(*coreStorage)
+	if !ok {
+		return nil
+	}
 
-// SwitchToDefaultStorage switches the region storage to defaultStorage,
-// after calling this, all region info will be read/saved by the internal
-// defaultStorage, and in most cases it's etcd-backend.
-func (ps *coreStorage) SwitchToDefaultStorage() {
+	if useLocalRegionStorage {
+		// Switch the region storage to regionStorage, all region info will be read/saved by the internal
+		// regionStorage, and in most cases it's LevelDB-backend.
+		atomic.StoreInt32(&ps.useRegionStorage, 1)
+		return ps.regionStorage
+	}
+	// Switch the region storage to defaultStorage, all region info will be read/saved by the internal
+	// defaultStorage, and in most cases it's etcd-backend.
 	atomic.StoreInt32(&ps.useRegionStorage, 0)
+	return ps.Storage
+}
+
+// TryLoadRegionsOnce loads all regions from storage to RegionsInfo.
+// If the underlying storage is the local region storage, it will only load once.
+func TryLoadRegionsOnce(ctx context.Context, s Storage, f func(region *core.RegionInfo) []*core.RegionInfo) error {
+	ps, ok := s.(*coreStorage)
+	if !ok {
+		return s.LoadRegions(ctx, f)
+	}
+
+	if atomic.LoadInt32(&ps.useRegionStorage) == 0 {
+		return ps.Storage.LoadRegions(ctx, f)
+	}
+
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	if !ps.regionLoaded {
+		if err := ps.regionStorage.LoadRegions(ctx, f); err != nil {
+			return err
+		}
+		ps.regionLoaded = true
+	}
+	return nil
 }
 
 // LoadRegion loads one region from storage.
@@ -116,23 +153,6 @@ func (ps *coreStorage) LoadRegions(ctx context.Context, f func(region *core.Regi
 		return ps.regionStorage.LoadRegions(ctx, f)
 	}
 	return ps.Storage.LoadRegions(ctx, f)
-}
-
-// LoadRegionsOnce loads all regions from storage to RegionsInfo. If the underlying storage is the region storage,
-// it will only load once.
-func (ps *coreStorage) LoadRegionsOnce(ctx context.Context, f func(region *core.RegionInfo) []*core.RegionInfo) error {
-	if atomic.LoadInt32(&ps.useRegionStorage) == 0 {
-		return ps.Storage.LoadRegions(ctx, f)
-	}
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
-	if !ps.regionLoaded {
-		if err := ps.regionStorage.LoadRegions(ctx, f); err != nil {
-			return err
-		}
-		ps.regionLoaded = true
-	}
-	return nil
 }
 
 // SaveRegion saves one region to storage.

--- a/server/storage/storage_test.go
+++ b/server/storage/storage_test.go
@@ -253,7 +253,7 @@ func TestLoadRegionsToCache(t *testing.T) {
 
 	n := 10
 	regions := mustSaveRegions(re, storage, n)
-	re.NoError(storage.LoadRegionsOnce(context.Background(), cache.SetRegion))
+	re.NoError(TryLoadRegionsOnce(context.Background(), storage, cache.SetRegion))
 
 	re.Equal(n, cache.GetRegionCount())
 	for _, region := range cache.GetMetaRegions() {
@@ -262,7 +262,7 @@ func TestLoadRegionsToCache(t *testing.T) {
 
 	n = 20
 	mustSaveRegions(re, storage, n)
-	re.NoError(storage.LoadRegionsOnce(context.Background(), cache.SetRegion))
+	re.NoError(TryLoadRegionsOnce(context.Background(), storage, cache.SetRegion))
 	re.Equal(n, cache.GetRegionCount())
 }
 

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -756,13 +756,13 @@ func TestLoadClusterInfo(t *testing.T) {
 	re.NoError(err)
 	re.Nil(raftCluster)
 
-	storage := rc.GetStorage()
+	testStorage := rc.GetStorage()
 	basicCluster := rc.GetBasicCluster()
 	opt := rc.GetOpts()
 	// Save meta, stores and regions.
 	n := 10
 	meta := &metapb.Cluster{Id: 123}
-	re.NoError(storage.SaveMeta(meta))
+	re.NoError(testStorage.SaveMeta(meta))
 	stores := make([]*metapb.Store, 0, n)
 	for i := 0; i < n; i++ {
 		store := &metapb.Store{Id: uint64(i)}
@@ -770,7 +770,7 @@ func TestLoadClusterInfo(t *testing.T) {
 	}
 
 	for _, store := range stores {
-		re.NoError(storage.SaveStore(store))
+		re.NoError(testStorage.SaveStore(store))
 	}
 
 	regions := make([]*metapb.Region, 0, n)
@@ -785,12 +785,12 @@ func TestLoadClusterInfo(t *testing.T) {
 	}
 
 	for _, region := range regions {
-		re.NoError(storage.SaveRegion(region))
+		re.NoError(testStorage.SaveRegion(region))
 	}
-	re.NoError(storage.Flush())
+	re.NoError(testStorage.Flush())
 
 	raftCluster = cluster.NewRaftCluster(ctx, svr.ClusterID(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient())
-	raftCluster.InitCluster(mockid.NewIDAllocator(), opt, storage, basicCluster)
+	raftCluster.InitCluster(mockid.NewIDAllocator(), opt, testStorage, basicCluster)
 	raftCluster, err = raftCluster.LoadClusterInfo()
 	re.NoError(err)
 	re.NotNil(raftCluster)
@@ -819,9 +819,9 @@ func TestLoadClusterInfo(t *testing.T) {
 	}
 
 	for _, region := range regions {
-		re.NoError(storage.SaveRegion(region))
+		re.NoError(testStorage.SaveRegion(region))
 	}
-	raftCluster.GetStorage().LoadRegionsOnce(ctx, raftCluster.GetBasicCluster().PutRegion)
+	re.NoError(storage.TryLoadRegionsOnce(ctx, testStorage, raftCluster.GetBasicCluster().PutRegion))
 	re.Equal(n, raftCluster.GetRegionCount())
 }
 


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #3453

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

Currently, in the interface definition of `RegionStorage`, `LoadRegions` and `LoadRegionsOnce` are repeated, and the implementation of the `LoadRegionsOnce` is not always consistent with the definition. In addition, some interface conversions based on `coreStorage` are tricky.

```commit-message
storage: optimize the storage interface
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
