### PR TITLE
schedule/placement/fit: check the logic with low complexity(O(1)) before the one with higher complexity

### DIFF
--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -217,8 +217,7 @@ func (w *fitWorker) fitRule(index int) bool {
 		// 2. Role match, or can match after transformed.
 		// 3. Not selected by other rules.
 		for _, p := range w.peers {
-			if MatchLabelConstraints(p.store, w.rules[index].LabelConstraints) &&
-				!p.selected {
+			if !p.selected && MatchLabelConstraints(p.store, w.rules[index].LabelConstraints) {
 				candidates = append(candidates, p)
 			}
 		}

--- a/server/schedule/placement/fit_region_test.go
+++ b/server/schedule/placement/fit_region_test.go
@@ -277,15 +277,7 @@ func BenchmarkFitRegionCrossRegion(b *testing.B) {
 
 func BenchmarkFitRegionWithMoreRulesAndStoreLabels(b *testing.B) {
 	region := mockRegion(5, 0)
-	rules := []*Rule{
-		{
-			GroupID:        "pd",
-			ID:             "default",
-			Role:           Leader,
-			Count:          1,
-			LocationLabels: []string{},
-		},
-	}
+	rules := []*Rule{}
 	// create 100 rules, with each rule has 101 LabelConstraints.
 	for i := 0; i < 100; i++ {
 		rule := &Rule{
@@ -327,7 +319,7 @@ func BenchmarkFitRegionWithMoreRulesAndStoreLabels(b *testing.B) {
 		}
 		label := &metapb.StoreLabel{Key: "exclusive", Value: "exclusive"}
 		labels = append(labels, label)
-		store := core.NewStoreInfo(&metapb.Store{Id: uint64(storeID)}, core.SetLastHeartbeatTS(time.Now()), core.SetStoreLabels(labels))
+		store := core.NewStoreInfo(&metapb.Store{Id: storeID}, core.SetLastHeartbeatTS(time.Now()), core.SetStoreLabels(labels))
 		lists = append(lists, store)
 	}
 	mm := make(map[uint64]*core.StoreInfo)

--- a/server/schedule/placement/fit_region_test.go
+++ b/server/schedule/placement/fit_region_test.go
@@ -274,3 +274,73 @@ func BenchmarkFitRegionCrossRegion(b *testing.B) {
 		fitRegion(storesSet.GetStores(), region, rules)
 	}
 }
+
+func BenchmarkFitRegionWithMoreRulesAndStoreLabels(b *testing.B) {
+	region := mockRegion(5, 0)
+	rules := []*Rule{
+		{
+			GroupID:        "pd",
+			ID:             "default",
+			Role:           Leader,
+			Count:          1,
+			LocationLabels: []string{},
+		},
+	}
+	// create 100 rules, with each rule has 101 LabelConstraints.
+	for i := 0; i < 100; i++ {
+		rule := &Rule{
+			GroupID:          "pd",
+			ID:               fmt.Sprintf("%v", i),
+			Role:             Follower,
+			Count:            3,
+			LocationLabels:   []string{},
+			LabelConstraints: []LabelConstraint{},
+		}
+		values := []string{}
+		for id := 1; id < 100; id++ {
+			values = append(values, fmt.Sprintf("value_%08d", id))
+			labelContaint := LabelConstraint{
+				Key:    fmt.Sprintf("key_%08d", id),
+				Op:     NotIn,
+				Values: values,
+			}
+			rule.LabelConstraints = append(rule.LabelConstraints, labelContaint)
+		}
+		// add an exclusive containt.
+		values = append(values, "exclusive")
+		labelContaint := LabelConstraint{
+			Key:    "exclusive",
+			Op:     In,
+			Values: values,
+		}
+		rule.LabelConstraints = append(rule.LabelConstraints, labelContaint)
+		rules = append(rules, rule)
+	}
+	// create stores, with each stores has 101 labels(1 exclusive label).
+	lists := make([]*core.StoreInfo, 0)
+	for _, peer := range region.GetPeers() {
+		storeID := peer.StoreId
+		labels := []*metapb.StoreLabel{}
+		for labID := 0; labID < 100; labID++ {
+			label := &metapb.StoreLabel{Key: fmt.Sprintf("store_%08d", labID), Value: fmt.Sprintf("value_%08d", labID)}
+			labels = append(labels, label)
+		}
+		label := &metapb.StoreLabel{Key: "exclusive", Value: "exclusive"}
+		labels = append(labels, label)
+		store := core.NewStoreInfo(&metapb.Store{Id: uint64(storeID)}, core.SetLastHeartbeatTS(time.Now()), core.SetStoreLabels(labels))
+		lists = append(lists, store)
+	}
+	mm := make(map[uint64]*core.StoreInfo)
+	for _, store := range lists {
+		mm[store.GetID()] = store
+	}
+	storesSet := mockStoresSet{
+		stores:     mm,
+		storelists: lists,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fitRegion(storesSet.GetStores(), region, rules)
+	}
+}

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/syncutil"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
@@ -693,12 +694,9 @@ func (m *RuleManager) IsInitialized() bool {
 // checkRule check the rule whether will have RuleFit after FitRegion
 // in order to reduce the calculation.
 func checkRule(rule *Rule, stores []*core.StoreInfo) bool {
-	for _, store := range stores {
-		if MatchLabelConstraints(store, rule.LabelConstraints) {
-			return true
-		}
-	}
-	return false
+	return slice.AnyOf(stores, func(id int) bool {
+		return MatchLabelConstraints(stores[id], rule.LabelConstraints)
+	})
 }
 
 // SetKeyType will update keyType for adjustRule()

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -694,8 +694,8 @@ func (m *RuleManager) IsInitialized() bool {
 // checkRule check the rule whether will have RuleFit after FitRegion
 // in order to reduce the calculation.
 func checkRule(rule *Rule, stores []*core.StoreInfo) bool {
-	return slice.AnyOf(stores, func(id int) bool {
-		return MatchLabelConstraints(stores[id], rule.LabelConstraints)
+	return slice.AnyOf(stores, func(idx int) bool {
+		return MatchLabelConstraints(stores[idx], rule.LabelConstraints)
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5243 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- benchmark test
 The benchmark test improve the speed of operators **_10x+_** than the master branch.
#### current branch:
```
➜  placement git:(fit_region_improve) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=10x  
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8               10          46847242 ns/op         2639625 B/op     108312 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    1.417s
➜  placement git:(fit_region_improve) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=10x  
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8               10          47522592 ns/op         2639390 B/op     108312 allocs/op
```

#### master
```
➜  placement git:(master) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=10x  
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8               10         306751529 ns/op        14921219 B/op     620041 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    4.724s
➜  placement git:(master) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=10x  
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8               10         279511112 ns/op        14920983 B/op     620041 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    3.973s
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
