### PR TITLE
schedule/placement/fit: stop searching once the number of candidates was not enough

### DIFF
--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -242,7 +242,10 @@ func (w *fitWorker) enumPeers(candidates, selected []*fitPeer, index int, count 
 	}
 
 	var better bool
-	for i, p := range candidates {
+	// make sure the left number of candidates should be enough.
+	indexLimit := len(candidates) - (count - len(selected))
+	for i := 0; i <= indexLimit; i++ {
+		p := candidates[i]
 		p.selected = true
 		better = w.enumPeers(candidates[i+1:], append(selected, p), index, count) || better
 		p.selected = false


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5245  

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- benchmark test
 The benchmark test improve the speed of operators **_2x+_** than the master branch.
#### current branch:
```
 placement git:(schedule/placement/fit_improve_2) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionMorePeers  -benchtime=20x  
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionMorePeers-8                         20              1092 ns/op             560 B/op         14 allocs/op
BenchmarkFitRegionMorePeersEquals-8                   20              1356 ns/op             624 B/op         20 allocs/op
BenchmarkFitRegionMorePeersSplitRules-8               20              1665 ns/op             744 B/op         24 allocs/op
```

#### master
```
➜  placement git:(master) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionMorePeers  -benchtime=20x  
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionMorePeers-8                         20              2075 ns/op             864 B/op         23 allocs/op
BenchmarkFitRegionMorePeersEquals-8                   20              2208 ns/op             832 B/op         30 allocs/op
BenchmarkFitRegionMorePeersSplitRules-8               20              3442 ns/op            1336 B/op         42 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    1.067s
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
