### PR TITLE
config: fix the panic caused by invalid input of `pd-ctl`

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -963,6 +963,9 @@ func (c *ScheduleConfig) Validate() error {
 	if c.LowSpaceRatio <= c.HighSpaceRatio {
 		return errors.New("low-space-ratio should be larger than high-space-ratio")
 	}
+	if c.LeaderSchedulePolicy != "count" && c.LeaderSchedulePolicy != "size" {
+		return errors.Errorf("leader-schedule-policy %v is invalid", c.LeaderSchedulePolicy)
+	}
 	for _, scheduleConfig := range c.Schedulers {
 		if !IsSchedulerRegistered(scheduleConfig.Type) {
 			return errors.Errorf("create func of %v is not registered, maybe misspelled", scheduleConfig.Type)
@@ -1201,6 +1204,9 @@ func (c *PDServerConfig) Validate() error {
 		if err := ValidateURLWithScheme(c.DashboardAddress); err != nil {
 			return err
 		}
+	}
+	if c.KeyType != "table" && c.KeyType != "raw" && c.KeyType != "txn" {
+		return errors.Errorf("key-type %v is invalid", c.KeyType)
 	}
 	if c.FlowRoundByDigit < 0 {
 		return errs.ErrConfigItem.GenWithStack("flow round by digit cannot be negative number")

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -261,6 +261,16 @@ func TestConfig(t *testing.T) {
 	args1 = []string{"-u", pdAddr, "config", "set", "enable-placement-rules", "true"}
 	_, err = pdctl.ExecuteCommand(cmd, args1...)
 	re.NoError(err)
+
+	// test invalid value
+	argsInvalid := []string{"-u", pdAddr, "config", "set", "leader-schedule-policy", "aaa"}
+	output, err = pdctl.ExecuteCommand(cmd, argsInvalid...)
+	re.NoError(err)
+	re.Contains(string(output), "is invalid")
+	argsInvalid = []string{"-u", pdAddr, "config", "set", "key-type", "aaa"}
+	output, err = pdctl.ExecuteCommand(cmd, argsInvalid...)
+	re.NoError(err)
+	re.Contains(string(output), "is invalid")
 }
 
 func TestPlacementRules(t *testing.T) {

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -81,7 +81,7 @@ func doRequest(cmd *cobra.Command, prefix string, method string, customHeader ht
 
 	endpoints := getEndpoints(cmd)
 	err := tryURLs(cmd, endpoints, func(endpoint string) error {
-		return doGet(endpoint, prefix, method, &resp, customHeader, b)
+		return do(endpoint, prefix, method, &resp, customHeader, b)
 	})
 	return resp, err
 }
@@ -95,7 +95,7 @@ func doRequestSingleEndpoint(cmd *cobra.Command, endpoint, prefix, method string
 	var resp string
 
 	err := requestURL(cmd, endpoint, func(endpoint string) error {
-		return doGet(endpoint, prefix, method, &resp, customHeader, b)
+		return do(endpoint, prefix, method, &resp, customHeader, b)
 	})
 	return resp, err
 }
@@ -198,8 +198,8 @@ func postJSON(cmd *cobra.Command, prefix string, input map[string]interface{}) {
 	cmd.Println("Success!")
 }
 
-// doGet send a get request to server.
-func doGet(endpoint, prefix, method string, resp *string, customHeader http.Header, b *bodyOption) error {
+// do send a request to server. Default is Get.
+func do(endpoint, prefix, method string, resp *string, customHeader http.Header, b *bodyOption) error {
 	var err error
 	url := endpoint + "/" + prefix
 	if method == "" {


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5253.

### What is changed and how does it work?

This PR checks the correctness of `leader-schedule-policy` and `key-type` before updating them. 

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fix the issue that PD may panic because of the invalid input of pd-ctl
```
