### PR TITLE
schedule/placement/fit: remove the recursion in pick peers for on rule

### DIFF
--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -241,7 +241,7 @@ func (w *fitWorker) fixRuleWithCandidates(candidates []*fitPeer, index int, coun
 	var better bool
 
 	for binaryInt := (1<<count - 1); binaryInt <= limit; binaryInt++ {
-		// there should be exactly `count` number in current binary number `m`
+		// there should be exactly `count` number in current binary number `binaryInt`
 		if !seletedBitEqualsTo(binaryInt, count) {
 			continue
 		}

--- a/server/schedule/placement/fit_test.go
+++ b/server/schedule/placement/fit_test.go
@@ -187,3 +187,36 @@ func TestIsolationScore(t *testing.T) {
 		testCase.checker(score1, score2)
 	}
 }
+
+func TestPickPeersFromBinaryInt(t *testing.T) {
+	re := require.New(t)
+	var candidates []*fitPeer
+	for id := uint64(1); id <= 10; id++ {
+		candidates = append(candidates, &fitPeer{
+			Peer: &metapb.Peer{Id: id},
+		})
+	}
+	testCases := []struct {
+		binary        string
+		expectedPeers []uint64
+	}{
+		{"0", []uint64{}},
+		{"1", []uint64{1}},
+		{"101", []uint64{1, 3}},
+		{"111", []uint64{1, 2, 3}},
+		{"1011", []uint64{1, 2, 4}},
+		{"100011", []uint64{1, 2, 6}},
+		{"1000001111", []uint64{1, 2, 3, 4, 10}},
+	}
+
+	for _, c := range testCases {
+		binaryNumber, err := strconv.ParseUint(c.binary, 2, 64)
+		re.Nil(err)
+		selected := pickPeersFromBinaryInt(candidates, uint(binaryNumber))
+		re.Len(selected, len(c.expectedPeers))
+		for id := 0; id < len(selected); id++ {
+			re.Equal(selected[id].Id, c.expectedPeers[id])
+		}
+	}
+
+}

--- a/server/schedule/placement/fit_test.go
+++ b/server/schedule/placement/fit_test.go
@@ -218,5 +218,4 @@ func TestPickPeersFromBinaryInt(t *testing.T) {
 			re.Equal(selected[id].Id, c.expectedPeers[id])
 		}
 	}
-
 }

--- a/server/schedule/placement/fit_test.go
+++ b/server/schedule/placement/fit_test.go
@@ -211,7 +211,7 @@ func TestPickPeersFromBinaryInt(t *testing.T) {
 
 	for _, c := range testCases {
 		binaryNumber, err := strconv.ParseUint(c.binary, 2, 64)
-		re.Nil(err)
+		re.NoError(err)
 		selected := pickPeersFromBinaryInt(candidates, uint(binaryNumber))
 		re.Len(selected, len(c.expectedPeers))
 		for id := 0; id < len(selected); id++ {


### PR DESCRIPTION
Signed-off-by: shirly <AndreMouche@126.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5268 


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

- benchmark

#### current branch

```
➜  placement git:(improve_fit) go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=100x
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8              100          24242994 ns/op         1334621 B/op      55080 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    3.437s
```

#### Master

```
➜  placement git:(master) go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=100x
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8              100          48844034 ns/op         2627012 B/op     107788 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    6.110s
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
 None.
```
