### PR TITLE
Revert "filter: use `labelConstraintFilter` instead (#5235)"

### DIFF
--- a/server/schedule/checker/replica_strategy.go
+++ b/server/schedule/checker/replica_strategy.go
@@ -55,7 +55,7 @@ func (s *ReplicaStrategy) SelectStoreToAdd(coLocationStores []*core.StoreInfo, e
 	filters := []filter.Filter{
 		filter.NewExcludedFilter(s.checkerName, nil, s.region.GetStoreIDs()),
 		filter.NewStorageThresholdFilter(s.checkerName),
-		filter.NewLabelConstaintFilter(s.checkerName, filter.NotHotOrReserved, true),
+		filter.NewSpecialUseFilter(s.checkerName),
 		&filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, AllowTemporaryStates: true},
 	}
 	if len(s.locationLabels) > 0 && s.isolationLevel != "" {

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -371,7 +371,7 @@ func (c *RuleChecker) strategy(region *core.RegionInfo, rule *placement.Rule) *R
 		isolationLevel: rule.IsolationLevel,
 		locationLabels: rule.LocationLabels,
 		region:         region,
-		extraFilters:   []filter.Filter{filter.NewLabelConstaintFilter(c.name, rule.LabelConstraints, false)},
+		extraFilters:   []filter.Filter{filter.NewLabelConstaintFilter(c.name, rule.LabelConstraints)},
 	}
 }
 

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -429,26 +429,15 @@ func (f *StoreStateFilter) Target(opts *config.PersistOptions, store *core.Store
 	return true
 }
 
-var (
-	// NotHotOrReserved means the store label should not contains either "specialUse": "hotRegion" or "specialUse": "reserved".
-	NotHotOrReserved = []placement.LabelConstraint{{Key: SpecialUseKey, Op: placement.NotIn, Values: []string{SpecialUseHotRegion, SpecialUseReserved}}}
-	// NotReserved means the store label should not contains "specialUse": "reserved".
-	NotReserved = []placement.LabelConstraint{{Key: SpecialUseKey, Op: placement.NotIn, Values: []string{SpecialUseReserved}}}
-	// NotTiFlashEngine means the store label should not contains "engine": "tiflash".
-	NotTiFlashEngine = []placement.LabelConstraint{{Key: core.EngineKey, Op: placement.NotIn, Values: []string{core.EngineTiFlash}}}
-)
-
 // labelConstraintFilter is a filter that selects stores satisfy the constraints.
 type labelConstraintFilter struct {
-	scope string
-	// When it is true, we can pick up the store as the source store no matter if the label is matched.
-	allowBalanceLowSpace bool
-	constraints          []placement.LabelConstraint
+	scope       string
+	constraints []placement.LabelConstraint
 }
 
 // NewLabelConstaintFilter creates a filter that selects stores satisfy the constraints.
-func NewLabelConstaintFilter(scope string, constraints []placement.LabelConstraint, allowBalanceLowSpace bool) Filter {
-	return labelConstraintFilter{scope: scope, constraints: constraints, allowBalanceLowSpace: allowBalanceLowSpace}
+func NewLabelConstaintFilter(scope string, constraints []placement.LabelConstraint) Filter {
+	return labelConstraintFilter{scope: scope, constraints: constraints}
 }
 
 // Scope returns the scheduler or the checker which the filter acts on.
@@ -463,9 +452,6 @@ func (f labelConstraintFilter) Type() string {
 
 // Source filters stores when select them as schedule source.
 func (f labelConstraintFilter) Source(opt *config.PersistOptions, store *core.StoreInfo) bool {
-	if f.allowBalanceLowSpace && store.IsLowSpace(opt.GetLowSpaceRatio()) {
-		return true
-	}
 	return placement.MatchLabelConstraints(store, f.constraints)
 }
 
@@ -592,6 +578,104 @@ func NewPlacementLeaderSafeguard(scope string, opt *config.PersistOptions, clust
 	return nil
 }
 
+type engineFilter struct {
+	scope      string
+	constraint placement.LabelConstraint
+}
+
+// NewEngineFilter creates a filter that only keeps allowedEngines.
+func NewEngineFilter(scope string, allowedEngines ...string) Filter {
+	return &engineFilter{
+		scope:      scope,
+		constraint: placement.LabelConstraint{Key: core.EngineKey, Op: placement.In, Values: allowedEngines},
+	}
+}
+
+func (f *engineFilter) Scope() string {
+	return f.scope
+}
+
+func (f *engineFilter) Type() string {
+	return "engine-filter"
+}
+
+func (f *engineFilter) Source(opt *config.PersistOptions, store *core.StoreInfo) bool {
+	return f.constraint.MatchStore(store)
+}
+
+func (f *engineFilter) Target(opt *config.PersistOptions, store *core.StoreInfo) bool {
+	return f.constraint.MatchStore(store)
+}
+
+type ordinaryEngineFilter struct {
+	scope      string
+	constraint placement.LabelConstraint
+}
+
+// NewOrdinaryEngineFilter creates a filter that only keeps ordinary engine stores.
+func NewOrdinaryEngineFilter(scope string) Filter {
+	return &ordinaryEngineFilter{
+		scope:      scope,
+		constraint: placement.LabelConstraint{Key: core.EngineKey, Op: placement.NotIn, Values: allSpecialEngines},
+	}
+}
+
+func (f *ordinaryEngineFilter) Scope() string {
+	return f.scope
+}
+
+func (f *ordinaryEngineFilter) Type() string {
+	return "ordinary-engine-filter"
+}
+
+func (f *ordinaryEngineFilter) Source(opt *config.PersistOptions, store *core.StoreInfo) bool {
+	return f.constraint.MatchStore(store)
+}
+
+func (f *ordinaryEngineFilter) Target(opt *config.PersistOptions, store *core.StoreInfo) bool {
+	return f.constraint.MatchStore(store)
+}
+
+type specialUseFilter struct {
+	scope      string
+	constraint placement.LabelConstraint
+}
+
+// NewSpecialUseFilter creates a filter that filters out normal stores.
+// By default, all stores that are not marked with a special use will be filtered out.
+// Specify the special use label if you want to include the special stores.
+func NewSpecialUseFilter(scope string, allowUses ...string) Filter {
+	var values []string
+	for _, v := range allSpecialUses {
+		if slice.NoneOf(allowUses, func(i int) bool { return allowUses[i] == v }) {
+			values = append(values, v)
+		}
+	}
+	return &specialUseFilter{
+		scope:      scope,
+		constraint: placement.LabelConstraint{Key: SpecialUseKey, Op: placement.In, Values: values},
+	}
+}
+
+func (f *specialUseFilter) Scope() string {
+	return f.scope
+}
+
+func (f *specialUseFilter) Type() string {
+	return "special-use-filter"
+}
+
+func (f *specialUseFilter) Source(opt *config.PersistOptions, store *core.StoreInfo) bool {
+	if store.IsLowSpace(opt.GetLowSpaceRatio()) {
+		return true
+	}
+	return !f.constraint.MatchStore(store)
+}
+
+func (f *specialUseFilter) Target(opt *config.PersistOptions, store *core.StoreInfo) bool {
+	return !f.constraint.MatchStore(store)
+}
+
 const (
 	// SpecialUseKey is the label used to indicate special use storage.
 	SpecialUseKey = "specialUse"
@@ -600,6 +684,9 @@ const (
 	// SpecialUseReserved is the reserved value of special use label
 	SpecialUseReserved = "reserved"
 )
+
+var allSpecialUses = []string{SpecialUseHotRegion, SpecialUseReserved}
+var allSpecialEngines = []string{core.EngineTiFlash}
 
 type isolationFilter struct {
 	scope          string

--- a/server/schedule/filter/filters_test.go
+++ b/server/schedule/filter/filters_test.go
@@ -88,7 +88,7 @@ func TestLabelConstraintsFilter(t *testing.T) {
 		{"_id", "notExists", []string{}, true},
 	}
 	for _, testCase := range testCases {
-		filter := NewLabelConstaintFilter("", []placement.LabelConstraint{{Key: testCase.key, Op: placement.LabelConstraintOp(testCase.op), Values: testCase.values}}, false)
+		filter := NewLabelConstaintFilter("", []placement.LabelConstraint{{Key: testCase.key, Op: placement.LabelConstraintOp(testCase.op), Values: testCase.values}})
 		re.Equal(testCase.res, filter.Source(testCluster.GetOpts(), store))
 	}
 }

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -203,7 +203,7 @@ func newBalanceLeaderScheduler(opController *schedule.OperatorController, conf *
 	}
 	s.filters = []filter.Filter{
 		&filter.StoreStateFilter{ActionScope: s.GetName(), TransferLeader: true},
-		filter.NewLabelConstaintFilter(s.GetName(), filter.NotHotOrReserved, true),
+		filter.NewSpecialUseFilter(s.GetName()),
 	}
 	return s
 }

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -95,7 +95,7 @@ func newBalanceRegionScheduler(opController *schedule.OperatorController, conf *
 	}
 	scheduler.filters = []filter.Filter{
 		&filter.StoreStateFilter{ActionScope: scheduler.GetName(), MoveRegion: true},
-		filter.NewLabelConstaintFilter(scheduler.GetName(), filter.NotHotOrReserved, true),
+		filter.NewSpecialUseFilter(scheduler.GetName()),
 	}
 	return scheduler
 }
@@ -220,7 +220,7 @@ func (s *balanceRegionScheduler) transferPeer(plan *balancePlan) *operator.Opera
 		filter.NewExcludedFilter(s.GetName(), nil, plan.region.GetStoreIDs()),
 		filter.NewPlacementSafeguard(s.GetName(), plan.GetOpts(), plan.GetBasicCluster(), plan.GetRuleManager(), plan.region, plan.source),
 		filter.NewRegionScoreFilter(s.GetName(), plan.source, plan.GetOpts()),
-		filter.NewLabelConstaintFilter(s.GetName(), filter.NotHotOrReserved, true),
+		filter.NewSpecialUseFilter(s.GetName()),
 		&filter.StoreStateFilter{ActionScope: s.GetName(), MoveRegion: true},
 	}
 

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -730,7 +730,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 		filters = []filter.Filter{
 			&filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true},
 			filter.NewExcludedFilter(bs.sche.GetName(), bs.cur.region.GetStoreIDs(), bs.cur.region.GetStoreIDs()),
-			filter.NewLabelConstaintFilter(bs.sche.GetName(), filter.NotReserved, true),
+			filter.NewSpecialUseFilter(bs.sche.GetName(), filter.SpecialUseHotRegion),
 			filter.NewPlacementSafeguard(bs.sche.GetName(), bs.GetOpts(), bs.GetBasicCluster(), bs.GetRuleManager(), bs.cur.region, srcStore),
 		}
 
@@ -741,7 +741,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 	case transferLeader:
 		filters = []filter.Filter{
 			&filter.StoreStateFilter{ActionScope: bs.sche.GetName(), TransferLeader: true},
-			filter.NewLabelConstaintFilter(bs.sche.GetName(), filter.NotReserved, true),
+			filter.NewSpecialUseFilter(bs.sche.GetName(), filter.SpecialUseHotRegion),
 		}
 		if leaderFilter := filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.GetOpts(), bs.GetBasicCluster(), bs.GetRuleManager(), bs.cur.region, srcStore); leaderFilter != nil {
 			filters = append(filters, leaderFilter)

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -74,7 +74,7 @@ type shuffleLeaderScheduler struct {
 func newShuffleLeaderScheduler(opController *schedule.OperatorController, conf *shuffleLeaderSchedulerConfig) schedule.Scheduler {
 	filters := []filter.Filter{
 		&filter.StoreStateFilter{ActionScope: conf.Name, TransferLeader: true},
-		filter.NewLabelConstaintFilter(conf.Name, filter.NotHotOrReserved, true),
+		filter.NewSpecialUseFilter(conf.Name),
 	}
 	base := NewBaseScheduler(opController)
 	return &shuffleLeaderScheduler{

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -70,7 +70,7 @@ type shuffleRegionScheduler struct {
 func newShuffleRegionScheduler(opController *schedule.OperatorController, conf *shuffleRegionSchedulerConfig) schedule.Scheduler {
 	filters := []filter.Filter{
 		&filter.StoreStateFilter{ActionScope: ShuffleRegionName, MoveRegion: true},
-		filter.NewLabelConstaintFilter(ShuffleRegionName, filter.NotHotOrReserved, true),
+		filter.NewSpecialUseFilter(ShuffleRegionName),
 	}
 	base := NewBaseScheduler(opController)
 	return &shuffleRegionScheduler{


### PR DESCRIPTION
This reverts commit c1a6652908d9ecc1b80e8f5cec208e490d6215b7.

Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5257.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
