### PR TITLE
schedule/placement/fit: cache the match info for rules to peers

### DIFF
--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -155,7 +155,6 @@ func fitRegion(stores []*core.StoreInfo, region *core.RegionInfo, rules []*Rule)
 }
 
 type fitWorker struct {
-	stores  []*core.StoreInfo
 	bestFit RegionFit  // update during execution
 	peers   []*fitPeer // p.selected is updated during execution.
 	rules   []*Rule
@@ -193,7 +192,6 @@ func newFitWorker(stores []*core.StoreInfo, region *core.RegionInfo, rules []*Ru
 	}
 
 	return &fitWorker{
-		stores:          stores,
 		bestFit:         RegionFit{RuleFits: make([]*RuleFit, len(rules))},
 		peers:           peers,
 		rulesMatchCache: matchRules,
@@ -225,7 +223,12 @@ func (w *fitWorker) fitRule(index int) bool {
 
 	var candidates []*fitPeer
 	if matchPeers, exist := w.rulesMatchCache[index]; exist {
+		// Only consider stores:
+		// 1. Match label constraints
+		// 2. Role match, or can match after transformed.
+		// 3. Not selected by other rules.
 		for idx, p := range w.peers {
+			// Not selected by other rules.
 			if p.selected {
 				continue
 			}

--- a/server/schedule/placement/fit.go
+++ b/server/schedule/placement/fit.go
@@ -184,11 +184,9 @@ func newFitWorker(stores []*core.StoreInfo, region *core.RegionInfo, rules []*Ru
 
 	matchRules := make(map[int]map[int]bool, len(rules))
 	for id, rule := range rules {
-		matchPeers := make(map[int]bool, 0)
 		if checkRule(rule, stores) {
 			matchRules[id] = make(map[int]bool)
 		}
-		matchRules[id] = matchPeers
 	}
 
 	return &fitWorker{


### PR DESCRIPTION
### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5276 


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

- benchmark
#### current branch
```
➜  placement git:(fit_cache) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=100x
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8              100           5371767 ns/op          356880 B/op      12879 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    1.601s
```

#### master
```
➜  placement git:(master) ✗ go test -benchmem -run=^$ -bench ^BenchmarkFitRegionWithMoreRulesAndStoreLabels -benchtime=100x
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedule/placement
cpu: VirtualApple @ 2.50GHz
BenchmarkFitRegionWithMoreRulesAndStoreLabels-8              100          47968061 ns/op         2627010 B/op     107788 allocs/op
PASS
ok      github.com/tikv/pd/server/schedule/placement    5.801s
```

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
