### PR TITLE
id: make id allocator general purpose

### DIFF
--- a/server/id/id.go
+++ b/server/id/id.go
@@ -55,7 +55,7 @@ type allocatorImpl struct {
 }
 
 // NewAllocator creates a new ID Allocator.
-func NewAllocator(client *clientv3.Client, rootPath, allocPath, label, member string) Allocator {
+func NewAllocator(client *clientv3.Client, rootPath string, allocPath string, label string, member string) Allocator {
 	return &allocatorImpl{
 		client:    client,
 		rootPath:  rootPath,

--- a/server/id/id.go
+++ b/server/id/id.go
@@ -50,8 +50,8 @@ type allocatorImpl struct {
 	rootPath  string
 	allocPath string
 	label     string
-	metrics   *metrics
 	member    string
+	metrics   *metrics
 }
 
 // metrics is a collection of idAllocator's metrics

--- a/server/id/id.go
+++ b/server/id/id.go
@@ -66,8 +66,8 @@ func NewAllocator(client *clientv3.Client, rootPath, allocPath, label, member st
 		rootPath:  rootPath,
 		allocPath: allocPath,
 		label:     label,
-		metrics:   &metrics{idGauge: idGauge.WithLabelValues(label)},
 		member:    member,
+		metrics:   &metrics{idGauge: idGauge.WithLabelValues(label)},
 	}
 }
 

--- a/server/id/id_test.go
+++ b/server/id/id_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package id
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/pd/pkg/etcdutil"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/embed"
+)
+
+const (
+	rootPath   = "/pd"
+	leaderPath = "/pd/leader"
+	allocPath  = "alloc_id"
+	label      = "idalloc"
+	memberVal  = "member"
+)
+
+// TestMultipleAllocator tests situation where multiple allocators that
+// share rootPath and member val can update their id concurrently.
+func TestMultipleAllocator(t *testing.T) {
+	re := require.New(t)
+	cfg := etcdutil.NewTestSingleConfig(t)
+	etcd, err := embed.StartEtcd(cfg)
+	defer func() {
+		etcd.Close()
+	}()
+	re.NoError(err)
+
+	ep := cfg.LCUrls[0].String()
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{ep},
+	})
+	re.NoError(err)
+
+	<-etcd.Server.ReadyNotify()
+
+	// put memberValue to leaderPath to simulate an election success.
+	_, err = client.Put(context.Background(), leaderPath, memberVal)
+	re.NoError(err)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 3; i++ {
+		iStr := strconv.Itoa(i)
+		wg.Add(1)
+		// allocators share rootPath and memberVal, but have different allocPaths and labels
+		allocator := NewAllocator(client, rootPath, allocPath+iStr, label+iStr, memberVal)
+		go func(re *require.Assertions, allocator Allocator) {
+			defer wg.Done()
+			testAllocator(re, allocator)
+		}(re, allocator)
+	}
+	wg.Wait()
+}
+
+// testAllocator keep updated given allocator and check if values are expected
+func testAllocator(re *require.Assertions, allocator Allocator) {
+	startID, err := allocator.Alloc()
+	re.NoError(err)
+	for i := startID + 1; i < startID+allocStep*2; i++ {
+		id, err := allocator.Alloc()
+		re.NoError(err)
+		re.Equal(i, id)
+	}
+}

--- a/server/id/id_test.go
+++ b/server/id/id_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 // TestMultipleAllocator tests situation where multiple allocators that
-// share rootPath and member val can update their id concurrently.
+// share rootPath and member val update their ids concurrently.
 func TestMultipleAllocator(t *testing.T) {
 	re := require.New(t)
 	cfg := etcdutil.NewTestSingleConfig(t)
@@ -53,7 +53,7 @@ func TestMultipleAllocator(t *testing.T) {
 
 	<-etcd.Server.ReadyNotify()
 
-	// put memberValue to leaderPath to simulate an election success.
+	// Put memberValue to leaderPath to simulate an election success.
 	_, err = client.Put(context.Background(), leaderPath, memberVal)
 	re.NoError(err)
 
@@ -61,7 +61,7 @@ func TestMultipleAllocator(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		iStr := strconv.Itoa(i)
 		wg.Add(1)
-		// allocators share rootPath and memberVal, but have different allocPaths and labels
+		// All allocators share rootPath and memberVal, but they have different allocPaths and labels.
 		allocator := NewAllocator(client, rootPath, allocPath+iStr, label+iStr, memberVal)
 		go func(re *require.Assertions, allocator Allocator) {
 			defer wg.Done()
@@ -71,11 +71,11 @@ func TestMultipleAllocator(t *testing.T) {
 	wg.Wait()
 }
 
-// testAllocator keep updated given allocator and check if values are expected
+// testAllocator sequentially updates given allocator and check if values are expected.
 func testAllocator(re *require.Assertions, allocator Allocator) {
 	startID, err := allocator.Alloc()
 	re.NoError(err)
-	for i := startID + 1; i < startID+allocStep*2; i++ {
+	for i := startID + 1; i < startID+allocStep*20; i++ {
 		id, err := allocator.Alloc()
 		re.NoError(err)
 		re.Equal(i, id)

--- a/server/id/metrics.go
+++ b/server/id/metrics.go
@@ -24,8 +24,6 @@ var (
 			Name:      "id",
 			Help:      "Record of id allocator.",
 		}, []string{"type"})
-
-	idallocGauge = idGauge.WithLabelValues("idalloc")
 )
 
 func init() {

--- a/server/server.go
+++ b/server/server.go
@@ -81,6 +81,9 @@ const (
 	pdRootPath      = "/pd"
 	pdAPIPrefix     = "/pd/"
 	pdClusterIDPath = "/pd/cluster_id"
+	// idAllocPath for idAllocator to save persistent window's end.
+	idAllocPath  = "alloc_id"
+	idAllocLabel = "idalloc"
 )
 
 // EtcdStartTimeout the timeout of the startup etcd.
@@ -381,7 +384,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.member.SetMemberDeployPath(s.member.ID())
 	s.member.SetMemberBinaryVersion(s.member.ID(), versioninfo.PDReleaseVersion)
 	s.member.SetMemberGitHash(s.member.ID(), versioninfo.PDGitHash)
-	s.idAllocator = id.NewAllocator(s.client, s.rootPath, "alloc_id", "idalloc", s.member.MemberValue())
+	s.idAllocator = id.NewAllocator(s.client, s.rootPath, idAllocPath, idAllocLabel, s.member.MemberValue())
 	s.tsoAllocatorManager = tso.NewAllocatorManager(
 		s.member, s.rootPath, s.cfg,
 		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() })

--- a/server/server.go
+++ b/server/server.go
@@ -384,7 +384,13 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.member.SetMemberDeployPath(s.member.ID())
 	s.member.SetMemberBinaryVersion(s.member.ID(), versioninfo.PDReleaseVersion)
 	s.member.SetMemberGitHash(s.member.ID(), versioninfo.PDGitHash)
-	s.idAllocator = id.NewAllocator(s.client, s.rootPath, idAllocPath, idAllocLabel, s.member.MemberValue())
+	s.idAllocator = id.NewAllocator(&id.AllocatorParams{
+		Client:    s.client,
+		RootPath:  s.rootPath,
+		AllocPath: idAllocPath,
+		Label:     idAllocLabel,
+		Member:    s.member.MemberValue(),
+	})
 	s.tsoAllocatorManager = tso.NewAllocatorManager(
 		s.member, s.rootPath, s.cfg,
 		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() })

--- a/server/server.go
+++ b/server/server.go
@@ -381,7 +381,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.member.SetMemberDeployPath(s.member.ID())
 	s.member.SetMemberBinaryVersion(s.member.ID(), versioninfo.PDReleaseVersion)
 	s.member.SetMemberGitHash(s.member.ID(), versioninfo.PDGitHash)
-	s.idAllocator = id.NewAllocator(s.client, s.rootPath, s.member.MemberValue())
+	s.idAllocator = id.NewAllocator(s.client, s.rootPath, "alloc_id", "idalloc", s.member.MemberValue())
 	s.tsoAllocatorManager = tso.NewAllocatorManager(
 		s.member, s.rootPath, s.cfg,
 		func() time.Duration { return s.persistOptions.GetMaxResetTSGap() })


### PR DESCRIPTION
Signed-off-by: David <8039876+AmoebaProtozoa@users.noreply.github.com>

### What problem does this PR solve?

The current implementation of id allocator permits only one id allocator due to fixed alloc path `$rootPath/alloc_id` and metrics label.
This PR attempts to make it more general purpose by parametrize its alloc path and metrics label.
Issue Number: Close #5294 

### What is changed and how does it work?

```commit-message
make id allocator general purpose
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit tests

### Release note

```release-note
None.
```
