### PR TITLE
core: fix the wrong statistics of the region tree

### DIFF
--- a/server/core/region_tree.go
+++ b/server/core/region_tree.go
@@ -151,8 +151,8 @@ func (t *regionTree) remove(region *RegionInfo) {
 		return
 	}
 
-	t.totalSize -= region.approximateSize
-	regionWriteBytesRate, regionWriteKeysRate := region.GetWriteRate()
+	t.totalSize -= result.(*regionItem).region.GetApproximateSize()
+	regionWriteBytesRate, regionWriteKeysRate := result.(*regionItem).region.GetWriteRate()
 	t.totalWriteBytesRate -= regionWriteBytesRate
 	t.totalWriteKeysRate -= regionWriteKeysRate
 	t.tree.Remove(result)

--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -129,7 +129,7 @@ func TestRegionTreeStat(t *testing.T) {
 	re.Equal(int64(4), tree.totalSize)
 	updateNewItem(tree, newRegionWithStat("b", "e", 5, 6))
 	re.Equal(int64(6), tree.totalSize)
-	tree.remove(newRegionWithStat("a", "b", 1, 2))
+	tree.remove(newRegionWithStat("a", "b", 2, 2))
 	re.Equal(int64(5), tree.totalSize)
 	tree.remove(newRegionWithStat("f", "g", 1, 2))
 	re.Equal(int64(5), tree.totalSize)


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/5318

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fix the issue that the statistics of the region tree may be not accurate
```
