### PR TITLE
schedulers: speed up exit

### DIFF
--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -364,6 +364,11 @@ func (l *balanceLeaderScheduler) Schedule(cluster schedule.Cluster, dryRun bool)
 
 	result := make([]*operator.Operator, 0, batch)
 	for sourceCandidate.hasStore() || targetCandidate.hasStore() {
+		// if coordinator is stopping, speed up exit
+		if l.BaseScheduler.OpController.Ctx().Err() != nil {
+			break
+		}
+
 		// first choose source
 		if sourceCandidate.hasStore() {
 			op := createTransferLeaderOperator(sourceCandidate, transferOut, l, plan, usedRegions)

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -168,6 +168,10 @@ func (s *balanceRegionScheduler) Schedule(cluster schedule.Cluster, dryRun bool)
 	for _, plan.source = range stores {
 		retryLimit := s.retryQuota.GetLimit(plan.source)
 		for i := 0; i < retryLimit; i++ {
+			if s.BaseScheduler.OpController.Ctx().Err() != nil {
+				break
+			}
+
 			schedulerCounter.WithLabelValues(s.GetName(), "total").Inc()
 			// Priority pick the region that has a pending peer.
 			// Pending region may means the disk is overload, remove the pending region firstly.

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -562,6 +562,10 @@ func (bs *balanceSolver) solve() []*operator.Operator {
 			bs.cur.mainPeerStat = mainPeerStat
 
 			for _, dstStore := range bs.filterDstStores() {
+				if bs.sche.OpController.Ctx().Err() != nil {
+					goto fastExit
+				}
+
 				bs.cur.dstStore = dstStore
 				bs.calcProgressiveRank()
 				tryUpdateBestSolution(isUniformFirstPriority)
@@ -594,6 +598,8 @@ func (bs *balanceSolver) solve() []*operator.Operator {
 			}
 		}
 	}
+
+fastExit:
 	searchRevertRegions = bs.allowSearchRevertRegions()
 	bs.sche.searchRevertRegions[bs.resourceTy] = searchRevertRegions
 	if searchRevertRegions {
@@ -660,6 +666,10 @@ func (bs *balanceSolver) filterSrcStores() map[uint64]*statistics.StoreLoadDetai
 	confSrcToleranceRatio := bs.sche.conf.GetSrcToleranceRatio()
 	confEnableForTiFlash := bs.sche.conf.GetEnableForTiFlash()
 	for id, detail := range bs.stLoadDetail {
+		if bs.sche.OpController.Ctx().Err() != nil {
+			break
+		}
+
 		srcToleranceRatio := confSrcToleranceRatio
 		if detail.IsTiFlash() {
 			if !confEnableForTiFlash {
@@ -863,6 +873,10 @@ func (bs *balanceSolver) pickDstStores(filters []filter.Filter, candidates []*st
 	confDstToleranceRatio := bs.sche.conf.GetDstToleranceRatio()
 	confEnableForTiFlash := bs.sche.conf.GetEnableForTiFlash()
 	for _, detail := range candidates {
+		if bs.sche.OpController.Ctx().Err() != nil {
+			break
+		}
+
 		store := detail.StoreInfo
 		dstToleranceRatio := confDstToleranceRatio
 		if detail.IsTiFlash() {


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5274

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```in scheduler loop,  try to read exit signal.
     if coordinator's ctx has been closed, don't do more schedule. 
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)
For our cluster with more than 2000 tikv-servers,  pd transfer leader can be done in 1 second.  

Code changes


Side effects


Related changes
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
speed up scheduler exit  
```
