### PR TITLE
balance_region: remove the unnecessary retry when try to pick a region to transfer

### DIFF
--- a/server/schedule/filter/status.go
+++ b/server/schedule/filter/status.go
@@ -42,6 +42,8 @@ var (
 	// region filter status
 	statusRegionPendingPeer   = plan.NewStatus(plan.StatusRegionUnhealthy, "region has pending peers")
 	statusRegionDownPeer      = plan.NewStatus(plan.StatusRegionUnhealthy, "region has down peers")
+	statusRegionHot           = plan.NewStatus(plan.StatusRegionHot)
+	statusRegionWithNoLeader  = plan.NewStatus(plan.StatusRegionWithNoLeader)
 	statusRegionEmpty         = plan.NewStatus(plan.StatusRegionEmpty)
 	statusRegionRule          = plan.NewStatus(plan.StatusRuleNotMatch)
 	statusRegionNotReplicated = plan.NewStatus(plan.StatusRegionNotReplicated)

--- a/server/schedule/plan/status.go
+++ b/server/schedule/plan/status.go
@@ -48,6 +48,7 @@ const (
 	StatusRegionEmpty
 	// StatusRegionNotReplicated represents the region does not have enough replicas.
 	StatusRegionNotReplicated
+	// StatusRegionWithNoLeader represents the region does not have leader.
 	StatusRegionWithNoLeader
 
 	// StatusLabelNotMatch represents the location label of placement rule is not match the store's label.

--- a/server/schedule/plan/status.go
+++ b/server/schedule/plan/status.go
@@ -48,6 +48,7 @@ const (
 	StatusRegionEmpty
 	// StatusRegionNotReplicated represents the region does not have enough replicas.
 	StatusRegionNotReplicated
+	StatusRegionWithNoLeader
 
 	// StatusLabelNotMatch represents the location label of placement rule is not match the store's label.
 	StatusLabelNotMatch

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -169,7 +169,6 @@ func (s *balanceRegionScheduler) Schedule(cluster schedule.Cluster, dryRun bool)
 	}
 
 	filtersExceptPending := append(baseRegionFilters, pendingFilter)
-
 	pickFromFollowerRegionFunc := func(storeID uint64) *core.RegionInfo {
 		return filter.SelectOneRegion(cluster.RandFollowerRegions(storeID, s.conf.Ranges),
 			filtersExceptPending...)
@@ -181,7 +180,6 @@ func (s *balanceRegionScheduler) Schedule(cluster schedule.Cluster, dryRun bool)
 	}
 
 	pickFromLearnerFunc := func(storeID uint64) *core.RegionInfo {
-
 		return filter.SelectOneRegion(cluster.RandLearnerRegions(storeID, s.conf.Ranges),
 			filtersExceptPending...)
 	}
@@ -209,7 +207,6 @@ func (s *balanceRegionScheduler) Schedule(cluster schedule.Cluster, dryRun bool)
 					break
 				}
 			}
-
 			if plan.region == nil {
 				schedulerCounter.WithLabelValues(s.GetName(), "no-region").Inc()
 				break


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5397 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->
benchmark
#### current-branch
```
wuxuelian@fun-2 ~/go/pd/server/schedulers                                                                                                                                                                    [14:18:23] 
> $ go test -benchmem -run=^$ -bench ^Benchmark  -benchtime=100x                                                                                                                            [±balance_region_speedup ●]
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedulers
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkPlacementRule-12  100          50000943 ns/op        24047141 B/op     708799 allocs/op
BenchmarkLabel-12                    100           7949532 ns/op         2518519 B/op      28179 allocs/op
BenchmarkNoLabel-12                  100           8786278 ns/op         1570206 B/op      21677 allocs/op
BenchmarkTombStore-12                100           8777006 ns/op         1570173 B/op      21677 allocs/op
```

#### master
```
> $ go test -benchmem -run=^$ -bench ^Benchmark  -benchtime=100x                                                                                                                                            [±master ●]
goos: darwin
goarch: amd64
pkg: github.com/tikv/pd/server/schedulers
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkPlacementRule-12    100          52804382 ns/op        24047187 B/op     708797 allocs/op
BenchmarkLabel-12                    100           9142366 ns/op         2518413 B/op      28176 allocs/op
BenchmarkNoLabel-12                  100           9116922 ns/op         1570108 B/op      21674 allocs/op
BenchmarkTombStore-12                100           9027190 ns/op         1570099 B/op      21674 allocs/op
```

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
 None.
```
