### PR TITLE
server: return GetMembers error as a gRPC error to let TiKV retry

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -105,9 +105,8 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	// at startup and needs to get the cluster ID with the first request (i.e. GetMembers).
 	members, err := s.Server.GetMembers()
 	if err != nil {
-		return &pdpb.GetMembersResponse{
-			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
-		}, nil
+		// Should return a gRPC error to let the client, e.g, TiKV, retry.
+		return nil, status.Errorf(codes.Unknown, err.Error())
 	}
 
 	var etcdLeader, pdLeader *pdpb.Member
@@ -122,9 +121,7 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	tsoAllocatorManager := s.GetTSOAllocatorManager()
 	tsoAllocatorLeaders, err := tsoAllocatorManager.GetLocalAllocatorLeaders()
 	if err != nil {
-		return &pdpb.GetMembersResponse{
-			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
-		}, nil
+		return nil, status.Errorf(codes.Unknown, err.Error())
 	}
 
 	leader := s.member.GetLeader()


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5309. Close #5409.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Return GetMembers error as a gRPC error to let TiKV retry.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

Related changes

https://github.com/tikv/pd/pull/5310.

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
