### PR TITLE
Prevent PD from crashing due to epoch comparison error

### DIFF
--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -360,7 +360,6 @@ func (u *unsafeRecoveryController) HandleStoreHeartbeat(heartbeat *pdpb.StoreHea
 				if hasPlan, err = u.generateCreateEmptyRegionPlan(newestRegionTree, peersMap); hasPlan && err == nil {
 					u.changeStage(createEmptyRegion)
 					break
-
 				}
 				if err != nil {
 					break

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -492,7 +492,6 @@ func (u *unsafeRecoveryController) changeStage(stage unsafeRecoveryStage) {
 		output.Info = "Unsafe recovery enters exit force leader stage"
 		if u.err != nil {
 			output.Details = append(output.Details, fmt.Sprintf("triggered by error: %v", u.err.Error()))
-			u.err = nil
 		}
 	case finished:
 		if u.step > 1 {
@@ -517,7 +516,7 @@ func (u *unsafeRecoveryController) changeStage(stage unsafeRecoveryStage) {
 	u.output = append(u.output, output)
 	data, err := json.Marshal(output)
 	if err != nil {
-		log.Error("Unsafe recovery fail to marshal json object", zap.String("err", err.Error()))
+		log.Error("Unsafe recovery fail to marshal json object", zap.Error(err))
 	} else {
 		log.Info(string(data))
 	}

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -492,6 +492,7 @@ func (u *unsafeRecoveryController) changeStage(stage unsafeRecoveryStage) {
 		output.Info = "Unsafe recovery enters exit force leader stage"
 		if u.err != nil {
 			output.Details = append(output.Details, fmt.Sprintf("triggered by error: %v", u.err.Error()))
+			u.err = nil
 		}
 	case finished:
 		if u.step > 1 {

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -298,7 +298,7 @@ func (u *unsafeRecoveryController) HandleStoreHeartbeat(heartbeat *pdpb.StoreHea
 
 	if allCollected {
 		newestRegionTree, peersMap, buildErr := u.buildUpFromReports()
-		if u.HandleErr(buildErr) {
+		if buildErr != nil && u.HandleErr(buildErr) {
 			return
 		}
 

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -262,7 +262,7 @@ func (u *unsafeRecoveryController) checkTimeout() bool {
 
 	if time.Now().After(u.timeout) {
 		ret := u.HandleErr(errors.Errorf("Exceeds timeout %v", u.timeout))
-		time.Now().Add(storeRequestInterval)
+		u.timeout = time.Now().Add(storeRequestInterval * 2)
 		return ret
 	}
 	return false

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -499,6 +499,7 @@ func (u *unsafeRecoveryController) changeStage(stage unsafeRecoveryStage) {
 		output.Info = "Unsafe recovery enters exit force leader stage"
 		if u.err != nil {
 			output.Details = append(output.Details, fmt.Sprintf("triggered by error: %v", u.err.Error()))
+			u.err = nil
 		}
 	case finished:
 		if u.step > 1 {
@@ -523,10 +524,10 @@ func (u *unsafeRecoveryController) changeStage(stage unsafeRecoveryStage) {
 	u.output = append(u.output, output)
 	data, err := json.Marshal(output)
 	if err != nil {
-		u.err = err
-		return
+		log.Error("Unsafe recovery fail to marshal json object", zap.String("err", err.Error()))
+	} else {
+		log.Info(string(data))
 	}
-	log.Info(string(data))
 
 	// reset store reports to nil instead of delete, because it relays on the item
 	// to decide which store it needs to collect the report from.

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -306,6 +306,7 @@ func TestFailed(t *testing.T) {
 		re.NotNil(resp.RecoveryPlan)
 		applyRecoveryPlan(re, storeID, reports, resp)
 	}
+	re.Equal(exitForceLeader, recoveryController.GetStage())
 
 	for storeID, report := range reports {
 		req := newStoreHeartbeat(storeID, report)
@@ -314,7 +315,7 @@ func TestFailed(t *testing.T) {
 		recoveryController.HandleStoreHeartbeat(req, resp)
 		applyRecoveryPlan(re, storeID, reports, resp)
 	}
-	re.Equal(failed, recoveryController.GetStage())
+	re.Equal(finished, recoveryController.GetStage())
 }
 
 func TestForceLeaderFail(t *testing.T) {

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -296,26 +296,15 @@ func TestFailed(t *testing.T) {
 	resp := &pdpb.StoreHeartbeatResponse{}
 	recoveryController.HandleStoreHeartbeat(req, resp)
 	re.Nil(resp.RecoveryPlan)
-	re.Equal(exitForceLeader, recoveryController.GetStage())
 
 	for storeID, report := range reports {
 		req := newStoreHeartbeat(storeID, report)
 		req.StoreReport = report
 		resp := &pdpb.StoreHeartbeatResponse{}
 		recoveryController.HandleStoreHeartbeat(req, resp)
-		re.NotNil(resp.RecoveryPlan)
-		applyRecoveryPlan(re, storeID, reports, resp)
+		re.Nil(resp.RecoveryPlan)
 	}
-	re.Equal(exitForceLeader, recoveryController.GetStage())
-
-	for storeID, report := range reports {
-		req := newStoreHeartbeat(storeID, report)
-		req.StoreReport = report
-		resp := &pdpb.StoreHeartbeatResponse{}
-		recoveryController.HandleStoreHeartbeat(req, resp)
-		applyRecoveryPlan(re, storeID, reports, resp)
-	}
-	re.Equal(finished, recoveryController.GetStage())
+	re.Equal(failed, recoveryController.GetStage())
 }
 
 func TestForceLeaderFail(t *testing.T) {

--- a/server/cluster/unsafe_recovery_controller_test.go
+++ b/server/cluster/unsafe_recovery_controller_test.go
@@ -1055,10 +1055,8 @@ func TestTimeout(t *testing.T) {
 
 	time.Sleep(time.Second)
 	req := newStoreHeartbeat(1, nil)
+	req.StoreReport = &pdpb.StoreReport{Step: 1}
 	resp := &pdpb.StoreHeartbeatResponse{}
-	recoveryController.HandleStoreHeartbeat(req, resp)
-	re.Equal(exitForceLeader, recoveryController.GetStage())
-	req.StoreReport = &pdpb.StoreReport{Step: 2}
 	recoveryController.HandleStoreHeartbeat(req, resp)
 	re.Equal(failed, recoveryController.GetStage())
 }


### PR DESCRIPTION
Signed-off-by: v01dstar <yang.zhang@pingcap.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5418 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
PD crashed because:
1. Region 1 and region 2 are ordered differently while creating the newest peer map and the newest region tree, since r1.Ver < r2.Ver but r1.ConfVer > r2.ConfVer. So, an error was reported while building the tree.
2. While handling the error, previous implementation cleans up the reports and then tries to read it again which results in seg fault.

To fix it:
1. Give Epoch.Ver and Epoch.ConfVer different priorities.
2. Do not clean up reports if PD is exiting force leader due to failures.

```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

N/A

Side effects

No

Related changes

N/A

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
