### PR TITLE
config: support mode setting

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -149,6 +149,8 @@ func (h *confHandler) updateConfig(cfg *config.Config, key string, value interfa
 		return h.updateSchedule(cfg, kp[len(kp)-1], value)
 	case "replication":
 		return h.updateReplication(cfg, kp[len(kp)-1], value)
+	case "schedule-mode":
+		return h.updateScheduleMode(cfg, kp[len(kp)-1], value)
 	case "replication-mode":
 		if len(kp) < 2 {
 			return errors.Errorf("cannot update config prefix %s", kp[0])
@@ -194,6 +196,23 @@ func (h *confHandler) updateReplication(config *config.Config, key string, value
 	if updated {
 		err = h.svr.SetReplicationConfig(config.Replication)
 	}
+	return err
+}
+
+func (h *confHandler) updateScheduleMode(config *config.Config, key string, value interface{}) error {
+	updated, found, err := jsonutil.AddKeyValue(&config.ScheduleMode, key, value)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return errors.Errorf("config item %s not found", key)
+	}
+
+	if updated {
+		err = h.svr.SetScheduleModeConfig(config.ScheduleMode)
+	}
+
 	return err
 }
 

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/logutil"
 	"github.com/tikv/pd/pkg/typeutil"
+	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/statistics/buckets"
@@ -43,6 +44,9 @@ func (c *RaftCluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 
 // HandleAskSplit handles the split request.
 func (c *RaftCluster) HandleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSplitResponse, error) {
+	if c.GetOpts().GetMode() == config.Suspend {
+		return nil, errors.New("scheduling mode is suspend")
+	}
 	if c.GetUnsafeRecoveryController().IsRunning() {
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
@@ -105,6 +109,9 @@ func (c *RaftCluster) ValidRequestRegion(reqRegion *metapb.Region) error {
 
 // HandleAskBatchSplit handles the batch split request.
 func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*pdpb.AskBatchSplitResponse, error) {
+	if c.GetOpts().GetMode() == config.Suspend {
+		return nil, errors.New("scheduling mode is suspend")
+	}
 	if c.GetUnsafeRecoveryController().IsRunning() {
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -586,7 +586,7 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	if err := c.PDServerCfg.adjust(configMetaData.Child("pd-server")); err != nil {
 		return err
 	}
-	if err := c.ScheduleMode.adjust(configMetaData.Child("mode")); err != nil {
+	if err := c.ScheduleMode.adjust(configMetaData.Child("schedule-mode")); err != nil {
 		return err
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -756,6 +756,7 @@ type ScheduleConfig struct {
 	// overwrite the auto-tuned value by pd-ctl, when the value
 	// is overwritten, the value is fixed until it is deleted.
 	// Default: manual
+	// WARN: StoreLimitMode is deprecated.
 	StoreLimitMode string `toml:"store-limit-mode" json:"store-limit-mode"`
 
 	// Controls the time interval between write hot regions info into leveldb.
@@ -770,6 +771,9 @@ type ScheduleConfig struct {
 
 	// EnableDiagnostic is the the option to enable using diagnostic
 	EnableDiagnostic bool `toml:"enable-diagnostic" json:"enable-diagnostic,string"`
+
+	// Mode is a state of scheduling. Different mode have different strategies in configuration.
+	Mode string `toml:"mode" json:"mode"`
 }
 
 // Clone returns a cloned scheduling configuration.
@@ -820,6 +824,7 @@ const (
 	defaultHotRegionsReservedDays      = 7
 	// It means we skip the preparing stage after the 48 hours no matter if the store has finished preparing stage.
 	defaultMaxStorePreparingTime = 48 * time.Hour
+	defaultMode                  = Normal
 )
 
 func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
@@ -886,7 +891,9 @@ func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
 	if !meta.IsDefined("region-score-formula-version") && !reloading {
 		adjustString(&c.RegionScoreFormulaVersion, defaultRegionScoreFormulaVersion)
 	}
-
+	if !meta.IsDefined("mode") {
+		adjustString(&c.Mode, defaultMode)
+	}
 	adjustSchedulers(&c.Schedulers, DefaultSchedulers)
 
 	for k, b := range c.migrateConfigurationMap() {
@@ -982,6 +989,9 @@ func (c *ScheduleConfig) Validate() error {
 	}
 	if c.LeaderSchedulePolicy != "count" && c.LeaderSchedulePolicy != "size" {
 		return errors.Errorf("leader-schedule-policy %v is invalid", c.LeaderSchedulePolicy)
+	}
+	if !isValidMode(c.Mode) {
+		return errors.Errorf("mode %v is invalid", c.Mode)
 	}
 	for _, scheduleConfig := range c.Schedulers {
 		if !IsSchedulerRegistered(scheduleConfig.Type) {

--- a/server/config/mode.go
+++ b/server/config/mode.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/tikv/pd/server/storage/endpoint"
+)
+
+// Scheduling mode
+const (
+	Normal  = "normal"
+	Suspend = "suspend"
+	Scaling = "scaling"
+)
+
+func isValidMode(mode string) bool {
+	switch mode {
+	case Normal, Suspend, Scaling:
+		return true
+	default:
+		return false
+	}
+}
+
+// SwitchMode switches the scheduling mode.
+func (o *PersistOptions) SwitchMode(storage endpoint.ConfigStorage, oldCfg *ScheduleConfig, mode string) (ScheduleConfig, error) {
+	// save the current mode setting
+	if err := storage.SaveScheduleMode(oldCfg.Mode, oldCfg); err != nil {
+		return ScheduleConfig{}, err
+	}
+	if !isValidMode(mode) {
+		return ScheduleConfig{}, errors.Errorf("mode %v is invalid", mode)
+	}
+	newCfg := &ScheduleConfig{}
+	existed, err := storage.LoadScheduleMode(mode, newCfg)
+	if err != nil {
+		return ScheduleConfig{}, err
+	}
+	if !existed {
+		newCfg = oldCfg.Clone()
+		getDefaultModeConfig(newCfg, mode)
+	}
+	return *newCfg, nil
+}
+
+func getDefaultModeConfig(newCfg *ScheduleConfig, mode string) {
+	switch mode {
+	case Suspend:
+		newCfg.MergeScheduleLimit = 0
+		newCfg.LeaderScheduleLimit = 0
+		newCfg.RegionScheduleLimit = 0
+		newCfg.HotRegionScheduleLimit = 0
+		newCfg.ReplicaScheduleLimit = 0
+	case Scaling:
+		for storeID := range newCfg.StoreLimit {
+			newCfg.StoreLimit[storeID] = StoreLimitConfig{AddPeer: 200, RemovePeer: 200}
+		}
+	}
+	newCfg.Mode = mode
+}

--- a/server/config/mode.go
+++ b/server/config/mode.go
@@ -42,7 +42,7 @@ func (o *PersistOptions) SwitchMode(storage endpoint.ConfigStorage, oldMode, new
 	}
 	// if the new mode setting doesn't exist, init a new one.
 	if !existed {
-		// We must have the Normal config.
+		// We must have the Normal config because when we first switch the mode, the normal mode settings will be persisted.
 		_, err := storage.LoadScheduleMode(Normal, newCfg)
 		if err != nil {
 			return err

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -464,6 +464,11 @@ func (o *PersistOptions) GetStoreLimitMode() string {
 	return o.GetScheduleConfig().StoreLimitMode
 }
 
+// GetMode returns the scheduling mode of PD.
+func (o *PersistOptions) GetMode() string {
+	return o.GetScheduleConfig().Mode
+}
+
 // GetTolerantSizeRatio gets the tolerant size ratio.
 func (o *PersistOptions) GetTolerantSizeRatio() float64 {
 	return o.GetScheduleConfig().TolerantSizeRatio
@@ -678,6 +683,15 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 	isExist, err := storage.LoadConfig(cfg)
 	if err != nil {
 		return err
+	}
+	if isValidMode(cfg.Schedule.Mode) {
+		exist, err := storage.LoadScheduleMode(cfg.Schedule.Mode, &cfg.Schedule)
+		if err != nil {
+			return err
+		}
+		if cfg.Schedule.Mode != Normal && !exist {
+			getDefaultModeConfig(&cfg.Schedule, cfg.Schedule.Mode)
+		}
 	}
 	o.adjustScheduleCfg(&cfg.Schedule)
 	cfg.PDServerCfg.MigrateDeprecatedFlags()

--- a/server/storage/endpoint/key_path.go
+++ b/server/storage/endpoint/key_path.go
@@ -59,6 +59,10 @@ func scheduleConfigPath(scheduleName string) string {
 	return path.Join(customScheduleConfigPath, scheduleName)
 }
 
+func scheduleModePath(modeName string) string {
+	return path.Join(configPath, modeName)
+}
+
 // StorePath returns the store meta info key path with the given store ID.
 func StorePath(storeID uint64) string {
 	return path.Join(clusterPath, "s", fmt.Sprintf("%020d", storeID))

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -18,12 +18,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 )
 
@@ -73,4 +78,113 @@ func TestRateLimitConfigReload(t *testing.T) {
 	re.NotNil(leader)
 	re.True(leader.GetServer().GetServiceMiddlewarePersistOptions().IsRateLimitEnabled())
 	re.Len(leader.GetServer().GetServiceMiddlewarePersistOptions().GetRateLimitConfig().LimiterConfig, 1)
+}
+
+func TestSwitchMode(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+	leader := cluster.GetServer(cluster.GetLeader())
+	re.NotNil(leader)
+	re.NoError(leader.BootstrapCluster())
+	// To put store.
+	svr := &server.GrpcServer{Server: leader.GetServer()}
+	putStore(svr, leader, 1)
+	// default mode
+	addr := leader.GetAddr() + "/pd/api/v1/config"
+	cfg := getConfig(re, addr)
+	re.Equal(config.Normal, cfg.ScheduleMode.Mode)
+	re.Equal(uint64(2048), cfg.Schedule.RegionScheduleLimit)
+
+	changeModeConfig(re, addr, "normal", true)
+	cfg = getConfig(re, addr)
+	re.True(cfg.ScheduleMode.EnableAutoTune)
+	changeModeConfig(re, addr, "normal", false)
+	cfg = getConfig(re, addr)
+	re.False(cfg.ScheduleMode.EnableAutoTune)
+
+	// change mode from normal to suspend is ok
+	changeModeConfig(re, addr, "suspend")
+	cfg = getConfig(re, addr)
+	re.Equal(config.Suspend, cfg.ScheduleMode.Mode)
+	re.Equal(uint64(0), cfg.Schedule.RegionScheduleLimit)
+	re.Equal(uint64(0), cfg.Schedule.LeaderScheduleLimit)
+	re.Equal(uint64(0), cfg.Schedule.ReplicaScheduleLimit)
+	re.Equal(uint64(0), cfg.Schedule.HotRegionScheduleLimit)
+	re.Equal(uint64(0), cfg.Schedule.MergeScheduleLimit)
+
+	// change mode from suspend to scaling is ok
+	changeModeConfig(re, addr, "scaling")
+	cfg = getConfig(re, addr)
+	re.Equal(config.Scaling, cfg.ScheduleMode.Mode)
+	re.Equal(uint64(2048), cfg.Schedule.RegionScheduleLimit)
+	// change mode from scaling to normal is ok
+	changeModeConfig(re, addr, "normal")
+	// change mode from normal to scaling is ok
+	changeModeConfig(re, addr, "scaling")
+	cfg = getConfig(re, addr)
+	re.Equal(config.Scaling, cfg.ScheduleMode.Mode)
+	re.Equal(200.0, cfg.Schedule.StoreLimit[1].AddPeer)
+	re.Equal(200.0, cfg.Schedule.StoreLimit[1].RemovePeer)
+
+	// change mode from scaling to normal is ok
+	changeModeConfig(re, addr, "normal")
+	cfg = getConfig(re, addr)
+	re.Equal(config.Normal, cfg.ScheduleMode.Mode)
+	re.Equal(uint64(2048), cfg.Schedule.RegionScheduleLimit)
+	re.Equal(15.0, cfg.Schedule.StoreLimit[1].AddPeer)
+	re.Equal(15.0, cfg.Schedule.StoreLimit[1].RemovePeer)
+
+	// add a new store
+	putStore(svr, leader, 2)
+	// the store limit should use the value in scaling mode.
+	changeModeConfig(re, addr, "scaling")
+	cfg = getConfig(re, addr)
+	re.Equal(config.Scaling, cfg.ScheduleMode.Mode)
+	re.Equal(uint64(2048), cfg.Schedule.RegionScheduleLimit)
+	re.Equal(200.0, cfg.Schedule.StoreLimit[2].AddPeer)
+	re.Equal(200.0, cfg.Schedule.StoreLimit[2].RemovePeer)
+}
+
+func changeModeConfig(re *require.Assertions, addr, mode string, enableAutoTune ...bool) {
+	input := map[string]interface{}{"mode": mode}
+	if len(enableAutoTune) != 0 {
+		input["enable-auto-tune"] = enableAutoTune[0]
+	}
+	data, _ := json.Marshal(input)
+	req, _ := http.NewRequest(http.MethodPost, addr, bytes.NewBuffer(data))
+	resp, err := dialClient.Do(req)
+	re.NoError(err)
+	defer resp.Body.Close()
+	re.Equal(http.StatusOK, resp.StatusCode)
+}
+
+func getConfig(re *require.Assertions, addr string) config.Config {
+	var cfg config.Config
+	reqGet, _ := http.NewRequest(http.MethodGet, addr, nil)
+	resp, err := dialClient.Do(reqGet)
+	re.NoError(err)
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	re.NoError(err)
+	err = json.Unmarshal(bodyBytes, &cfg)
+	re.NoError(err)
+	return cfg
+}
+
+func putStore(svr *server.GrpcServer, leader *tests.TestServer, storeID uint64) {
+	putStoreRequest := &pdpb.PutStoreRequest{
+		Header: &pdpb.RequestHeader{ClusterId: leader.GetClusterID()},
+		Store: &metapb.Store{
+			Id:      storeID,
+			Address: fmt.Sprintf("mock-%d", storeID),
+			Version: "6.1.0",
+		},
+	}
+	svr.PutStore(context.Background(), putStoreRequest)
 }

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -101,10 +101,10 @@ func TestSwitchMode(t *testing.T) {
 	re.Equal(config.Normal, cfg.ScheduleMode.Mode)
 	re.Equal(uint64(2048), cfg.Schedule.RegionScheduleLimit)
 
-	changeModeConfig(re, addr, "normal", true)
+	changeModeConfig(re, addr, "normal", "true")
 	cfg = getConfig(re, addr)
 	re.True(cfg.ScheduleMode.EnableAutoTune)
-	changeModeConfig(re, addr, "normal", false)
+	changeModeConfig(re, addr, "normal", "false")
 	cfg = getConfig(re, addr)
 	re.False(cfg.ScheduleMode.EnableAutoTune)
 
@@ -151,7 +151,7 @@ func TestSwitchMode(t *testing.T) {
 	re.Equal(200.0, cfg.Schedule.StoreLimit[2].RemovePeer)
 }
 
-func changeModeConfig(re *require.Assertions, addr, mode string, enableAutoTune ...bool) {
+func changeModeConfig(re *require.Assertions, addr, mode string, enableAutoTune ...string) {
 	input := map[string]interface{}{"mode": mode}
 	if len(enableAutoTune) != 0 {
 		input["enable-auto-tune"] = enableAutoTune[0]


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5443.

### What is changed and how does it work?
This PR support manually switching mode in different situations. Three modes are added:
- Normal: the default mode if we don't do anything.
- Suspend: in this mode, all scheduling will be stopped.
- Scaling: in this mode, the store limit of all stores will be changed to 200 to accelerate the scaling process.

And we use a new config item `schedule-mode` to manage the mode. It includes two configurations: `mode` and `auto-tune`. The latter will be used in the future to support auto switch modes.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
