### PR TITLE
operator: allows to skip placement rules checks

### DIFF
--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -67,7 +67,7 @@ type Builder struct {
 	targetLeaderStoreIDs []uint64 // This field is only used during multi-target evict leader, and will not be filtered during `Build`.
 	err                  error
 
-	// skip origin check flags
+	// skip check flags
 	skipOriginJointStateCheck bool
 	skipPlacementRulesCheck   bool
 
@@ -781,7 +781,7 @@ func (b *Builder) allowLeader(peer *metapb.Peer, ignoreClusterLimit bool) bool {
 	}
 
 	// placement rules
-	if len(b.rules) == 0 {
+	if b.skipPlacementRulesCheck || len(b.rules) == 0 {
 		return true
 	}
 	for _, r := range b.rules {

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -69,6 +69,7 @@ type Builder struct {
 
 	// skip origin check flags
 	skipOriginJointStateCheck bool
+	skipPlacementRulesCheck   bool
 
 	// build flags
 	useJointConsensus bool
@@ -92,6 +93,11 @@ type BuilderOption func(*Builder)
 // SkipOriginJointStateCheck lets the builder skip the joint state check for origin peers.
 func SkipOriginJointStateCheck(b *Builder) {
 	b.skipOriginJointStateCheck = true
+}
+
+// SkipPlacementRulesCheck lets the builder skip the placement rules check for origin and target peers.
+func SkipPlacementRulesCheck(b *Builder) {
+	b.skipPlacementRulesCheck = true
 }
 
 // NewBuilder creates a Builder.
@@ -138,7 +144,7 @@ func NewBuilder(desc string, ci ClusterInformer, region *core.RegionInfo, opts .
 
 	// placement rules
 	var rules []*placement.Rule
-	if err == nil && b.GetOpts().IsPlacementRulesEnabled() {
+	if err == nil && !b.skipPlacementRulesCheck && b.GetOpts().IsPlacementRulesEnabled() {
 		fit := b.GetRuleManager().FitRegion(b.GetBasicCluster(), region)
 		for _, rf := range fit.RuleFits {
 			rules = append(rules, rf.Rule)

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -67,7 +67,7 @@ func CreateTransferLeaderOperator(desc string, ci ClusterInformer, region *core.
 
 // CreateForceTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store forcible.
 func CreateForceTransferLeaderOperator(desc string, ci ClusterInformer, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
-	return NewBuilder(desc, ci, region, SkipOriginJointStateCheck).
+	return NewBuilder(desc, ci, region, SkipOriginJointStateCheck, SkipPlacementRulesCheck).
 		SetLeader(targetStoreID).
 		EnableForceTargetLeader().
 		Build(kind)
@@ -225,7 +225,7 @@ const OpDescLeaveJointState = "leave-joint-state"
 
 // CreateLeaveJointStateOperator creates an operator that let region leave joint state.
 func CreateLeaveJointStateOperator(desc string, ci ClusterInformer, origin *core.RegionInfo) (*Operator, error) {
-	b := NewBuilder(desc, ci, origin, SkipOriginJointStateCheck)
+	b := NewBuilder(desc, ci, origin, SkipOriginJointStateCheck, SkipPlacementRulesCheck)
 
 	if b.err == nil && !core.IsInJointState(origin.GetPeers()...) {
 		b.err = errors.Errorf("cannot build leave joint state operator for region which is not in joint state")

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -16,11 +16,13 @@ package operator
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/server/config"
@@ -1077,4 +1079,62 @@ func (suite *createOperatorTestSuite) TestMoveRegionWithoutJointConsensus() {
 			}
 		}
 	}
+}
+
+// Ref https://github.com/tikv/pd/issues/5401
+func TestCreateLeaveJointStateOperatorWithoutFitRules(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := config.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	re.NoError(cluster.SetRules([]*placement.Rule{
+		{
+			GroupID:     "pd",
+			ID:          "default",
+			StartKeyHex: hex.EncodeToString([]byte("")),
+			EndKeyHex:   hex.EncodeToString([]byte("")),
+			Role:        placement.Voter,
+			Count:       1,
+		},
+		{
+			GroupID:     "t1",
+			ID:          "t1",
+			StartKeyHex: hex.EncodeToString([]byte("a")),
+			EndKeyHex:   hex.EncodeToString([]byte("b")),
+			Role:        placement.Voter,
+			Count:       1,
+		},
+		{
+			GroupID:     "t2",
+			ID:          "t2",
+			StartKeyHex: hex.EncodeToString([]byte("b")),
+			EndKeyHex:   hex.EncodeToString([]byte("c")),
+			Role:        placement.Voter,
+			Count:       1,
+		},
+	}))
+	cluster.AddLabelsStore(1, 0, map[string]string{"zone": "z1"})
+	cluster.AddLabelsStore(2, 0, map[string]string{"zone": "z2"})
+	cluster.AddLabelsStore(3, 0, map[string]string{"zone": "z3"})
+	cluster.AddLabelsStore(4, 0, map[string]string{"zone": "z4"})
+	originPeers := []*metapb.Peer{
+		{Id: 3, StoreId: 3, Role: metapb.PeerRole_DemotingVoter},
+		{Id: 4, StoreId: 4, Role: metapb.PeerRole_IncomingVoter},
+	}
+
+	region := core.NewRegionInfo(&metapb.Region{Id: 1, Peers: originPeers, StartKey: []byte("a"), EndKey: []byte("c")}, originPeers[0])
+	op, err := CreateLeaveJointStateOperator("test", cluster, region)
+	re.NoError(err)
+	re.Equal(OpLeader, op.Kind())
+	re.Len(op.steps, 2)
+	step0 := op.steps[0].(TransferLeader)
+	re.Equal(uint64(2), step0.FromStore)
+	re.Equal(uint64(3), step0.ToStore)
+	step1 := op.steps[1].(ChangePeerV2Leave)
+	re.Len(step1.PromoteLearners, 1)
+	re.Len(step1.DemoteVoters, 1)
+	re.Equal(uint64(3), step1.PromoteLearners[0].ToStore)
+	re.Equal(uint64(2), step1.DemoteVoters[0].ToStore)
 }

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -1115,10 +1115,10 @@ func TestCreateLeaveJointStateOperatorWithoutFitRules(t *testing.T) {
 			Count:       1,
 		},
 	}))
-	cluster.AddLabelsStore(1, 0, map[string]string{"zone": "z1"})
-	cluster.AddLabelsStore(2, 0, map[string]string{"zone": "z2"})
-	cluster.AddLabelsStore(3, 0, map[string]string{"zone": "z3"})
-	cluster.AddLabelsStore(4, 0, map[string]string{"zone": "z4"})
+	cluster.AddRegionStore(1, 1)
+	cluster.AddRegionStore(2, 1)
+	cluster.AddRegionStore(3, 1)
+	cluster.AddRegionStore(4, 1)
 	originPeers := []*metapb.Peer{
 		{Id: 3, StoreId: 3, Role: metapb.PeerRole_DemotingVoter},
 		{Id: 4, StoreId: 4, Role: metapb.PeerRole_IncomingVoter},
@@ -1130,11 +1130,11 @@ func TestCreateLeaveJointStateOperatorWithoutFitRules(t *testing.T) {
 	re.Equal(OpLeader, op.Kind())
 	re.Len(op.steps, 2)
 	step0 := op.steps[0].(TransferLeader)
-	re.Equal(uint64(2), step0.FromStore)
-	re.Equal(uint64(3), step0.ToStore)
+	re.Equal(uint64(3), step0.FromStore)
+	re.Equal(uint64(4), step0.ToStore)
 	step1 := op.steps[1].(ChangePeerV2Leave)
 	re.Len(step1.PromoteLearners, 1)
 	re.Len(step1.DemoteVoters, 1)
-	re.Equal(uint64(3), step1.PromoteLearners[0].ToStore)
-	re.Equal(uint64(2), step1.DemoteVoters[0].ToStore)
+	re.Equal(uint64(4), step1.PromoteLearners[0].ToStore)
+	re.Equal(uint64(3), step1.DemoteVoters[0].ToStore)
 }


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5401 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

Allows skipping placement rules checks when creating operators.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fixed the bug where the Learner Peer of TiFlash Replica might not be created.
```
