### PR TITLE
statistics: fix anticount and cold peer statistics

### DIFF
--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -592,7 +592,7 @@ func TestRegionHeartbeatHotStat(t *testing.T) {
 		EndKey:      []byte{byte(1 + 1)},
 		RegionEpoch: &metapb.RegionEpoch{ConfVer: 2, Version: 2},
 	}
-	region := core.NewRegionInfo(regionMeta, leader, core.WithInterval(&pdpb.TimeInterval{StartTimestamp: 0, EndTimestamp: 10}),
+	region := core.NewRegionInfo(regionMeta, leader, core.WithInterval(&pdpb.TimeInterval{StartTimestamp: 0, EndTimestamp: statistics.RegionHeartBeatReportInterval}),
 		core.SetWrittenBytes(30000*10),
 		core.SetWrittenKeys(300000*10))
 	err = cluster.processRegionHeartbeat(region)

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -155,8 +155,7 @@ func TestStoreHeartbeat(t *testing.T) {
 	re.Nil(cluster.HandleStoreHeartbeat(hotHeartBeat))
 	time.Sleep(20 * time.Millisecond)
 	storeStats = cluster.hotStat.RegionStats(statistics.Read, 1)
-	re.Len(storeStats[1], 1)
-	re.Equal(uint64(1), storeStats[1][0].RegionID)
+	re.Len(storeStats[1], 0)
 	storeStats = cluster.hotStat.RegionStats(statistics.Read, 3)
 	re.Empty(storeStats[1])
 	// after 2 hot heartbeats, wo can find region 1 peer again

--- a/server/statistics/hot_peer.go
+++ b/server/statistics/hot_peer.go
@@ -235,3 +235,10 @@ func (stat *HotPeerStat) GetStores() []uint64 {
 func (stat *HotPeerStat) IsLearner() bool {
 	return stat.isLearner
 }
+
+func (stat *HotPeerStat) defaultAntiCount() int {
+	if stat.Kind == Read {
+		return hotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
+	}
+	return hotRegionAntiCount
+}

--- a/server/statistics/hot_peer.go
+++ b/server/statistics/hot_peer.go
@@ -185,7 +185,7 @@ func (stat *HotPeerStat) GetThresholds() []float64 {
 	return stat.thresholds
 }
 
-// Clone clones the HotPeerStat
+// Clone clones the HotPeerStat.
 func (stat *HotPeerStat) Clone() *HotPeerStat {
 	ret := *stat
 	ret.Loads = make([]float64, RegionStatCount)

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -228,7 +228,7 @@ func (f *hotPeerCache) checkColdPeer(storeID uint64, reportRegions map[uint64]*c
 				StoreID:  storeID,
 				RegionID: regionID,
 				Kind:     f.kind,
-				// use oldItem.thresholds to make the newItem won't affect the threshold
+				// use 0 to make the cold newItem won't affect the loads.
 				Loads:          make([]float64, len(oldItem.Loads)),
 				LastUpdateTime: time.Now(),
 				isLeader:       oldItem.isLeader,
@@ -528,11 +528,4 @@ func initItem(item *HotPeerStat) {
 func inheritItem(newItem, oldItem *HotPeerStat) {
 	newItem.HotDegree = oldItem.HotDegree
 	newItem.AntiCount = oldItem.AntiCount
-}
-
-func (item *HotPeerStat) defaultAntiCount() int {
-	if item.Kind == Read {
-		return hotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
-	}
-	return hotRegionAntiCount
 }

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -89,7 +89,7 @@ func (f *hotPeerCache) RegionStats(minHotDegree int) map[uint64][]*HotPeerStat {
 		values := peers.GetAll()
 		stat := make([]*HotPeerStat, 0, len(values))
 		for _, v := range values {
-			if peer := v.(*HotPeerStat); peer.HotDegree >= minHotDegree && !peer.inCold {
+			if peer := v.(*HotPeerStat); peer.HotDegree >= minHotDegree && !peer.inCold && peer.AntiCount == peer.defaultAntiCount() {
 				stat = append(stat, peer)
 			}
 		}
@@ -229,7 +229,7 @@ func (f *hotPeerCache) checkColdPeer(storeID uint64, reportRegions map[uint64]*c
 				RegionID: regionID,
 				Kind:     f.kind,
 				// use oldItem.thresholds to make the newItem won't affect the threshold
-				Loads:          oldItem.thresholds,
+				Loads:          make([]float64, len(oldItem.Loads)),
 				LastUpdateTime: time.Now(),
 				isLeader:       oldItem.isLeader,
 				isLearner:      oldItem.isLearner,
@@ -511,23 +511,28 @@ func coldItem(newItem, oldItem *HotPeerStat) {
 
 func hotItem(newItem, oldItem *HotPeerStat) {
 	newItem.HotDegree = oldItem.HotDegree + 1
-	newItem.AntiCount = hotRegionAntiCount
-	newItem.allowInherited = true
-	if newItem.Kind == Read {
-		newItem.AntiCount = hotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
+	if oldItem.AntiCount < oldItem.defaultAntiCount() {
+		newItem.AntiCount = oldItem.AntiCount + 1
+	} else {
+		newItem.AntiCount = oldItem.AntiCount
 	}
+	newItem.allowInherited = true
 }
 
 func initItem(item *HotPeerStat) {
 	item.HotDegree = 1
-	item.AntiCount = hotRegionAntiCount
+	item.AntiCount = item.defaultAntiCount()
 	item.allowInherited = true
-	if item.Kind == Read {
-		item.AntiCount = hotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
-	}
 }
 
 func inheritItem(newItem, oldItem *HotPeerStat) {
 	newItem.HotDegree = oldItem.HotDegree
 	newItem.AntiCount = oldItem.AntiCount
+}
+
+func (item *HotPeerStat) defaultAntiCount() int {
+	if item.Kind == Read {
+		return hotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
+	}
+	return hotRegionAntiCount
 }

--- a/server/statistics/hot_peer_cache_test.go
+++ b/server/statistics/hot_peer_cache_test.go
@@ -331,6 +331,7 @@ func TestUpdateHotPeerStat(t *testing.T) {
 	re.Equal(0, newItem.AntiCount)
 	// sum of interval is larger than report interval, and hot
 	oldItem = newItem
+	oldItem.AntiCount = oldItem.defaultAntiCount()
 	newItem = cache.updateHotPeerStat(nil, newItem, oldItem, []float64{60.0, 60.0, 60.0}, 4*time.Second)
 	re.Equal(1, newItem.HotDegree)
 	re.Equal(2*m, newItem.AntiCount)


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5478

### What is changed and how does it work?

1. The cold peer needs to wait the same time as the cooling interval before being activated again 

2. For unreported peers, the padding load uses 0 instead of the threshold

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
