### PR TITLE
add ttl config to disable tikv split

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -606,7 +606,7 @@ error = '''
 scheduler not found
 '''
 
-["PD:scheduler:ErrSchedulerTikvSplitDisabled"]
+["PD:scheduler:ErrSchedulerTiKVSplitDisabled"]
 error = '''
 tikv split region disabled
 '''

--- a/errors.toml
+++ b/errors.toml
@@ -606,6 +606,11 @@ error = '''
 scheduler not found
 '''
 
+["PD:scheduler:ErrSchedulerTikvSplitDisabled"]
+error = '''
+tikv split region disabled
+'''
+
 ["PD:semver:ErrSemverNewVersion"]
 error = '''
 new version error

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -88,7 +88,7 @@ var (
 	ErrCacheOverflow                    = errors.Normalize("cache overflow", errors.RFCCodeText("PD:scheduler:ErrCacheOverflow"))
 	ErrInternalGrowth                   = errors.Normalize("unknown interval growth type error", errors.RFCCodeText("PD:scheduler:ErrInternalGrowth"))
 	ErrSchedulerCreateFuncNotRegistered = errors.Normalize("create func of %v is not registered", errors.RFCCodeText("PD:scheduler:ErrSchedulerCreateFuncNotRegistered"))
-	ErrSchedulerTikvSplitDisabled       = errors.Normalize("tikv split region disabled", errors.RFCCodeText("PD:scheduler:ErrSchedulerTikvSplitDisabled"))
+	ErrSchedulerTiKVSplitDisabled       = errors.Normalize("tikv split region disabled", errors.RFCCodeText("PD:scheduler:ErrSchedulerTiKVSplitDisabled"))
 )
 
 // checker errors

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -88,6 +88,7 @@ var (
 	ErrCacheOverflow                    = errors.Normalize("cache overflow", errors.RFCCodeText("PD:scheduler:ErrCacheOverflow"))
 	ErrInternalGrowth                   = errors.Normalize("unknown interval growth type error", errors.RFCCodeText("PD:scheduler:ErrInternalGrowth"))
 	ErrSchedulerCreateFuncNotRegistered = errors.Normalize("create func of %v is not registered", errors.RFCCodeText("PD:scheduler:ErrSchedulerCreateFuncNotRegistered"))
+	ErrSchedulerTikvSplitDisabled       = errors.Normalize("tikv split region disabled", errors.RFCCodeText("PD:scheduler:ErrSchedulerTikvSplitDisabled"))
 )
 
 // checker errors

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -404,7 +404,7 @@ func (suite *configTestSuite) TestConfigTTL() {
 	suite.NoError(err)
 	err = tu.CheckPostJSON(testDialClient, createTTLUrl(suite.urlPrefix, 1), postData, tu.StatusOK(re))
 	suite.NoError(err)
-	suite.Equal(true, suite.svr.GetPersistOptions().IsTikvRegionSplitEnabled())
+	suite.True(suite.svr.GetPersistOptions().IsTikvRegionSplitEnabled())
 }
 
 func (suite *configTestSuite) TestTTLConflict() {

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -123,6 +123,8 @@ func (suite *configTestSuite) TestConfigAll() {
 	cfg.ClusterVersion = *v
 	suite.Equal(cfg, newCfg1)
 
+	// revert this to avoid it affects TestConfigTTL
+	l["schedule.enable-tikv-split-region"] = "true"
 	postData, err = json.Marshal(l)
 	suite.NoError(err)
 	err = tu.CheckPostJSON(testDialClient, addr, postData, tu.StatusOK(re))

--- a/server/api/config_test.go
+++ b/server/api/config_test.go
@@ -96,6 +96,7 @@ func (suite *configTestSuite) TestConfigAll() {
 	// the new way
 	l = map[string]interface{}{
 		"schedule.tolerant-size-ratio":            2.5,
+		"schedule.enable-tikv-split-region":       "false",
 		"replication.location-labels":             "idc,host",
 		"pd-server.metric-storage":                "http://127.0.0.1:1234",
 		"log.level":                               "warn",
@@ -110,6 +111,7 @@ func (suite *configTestSuite) TestConfigAll() {
 	newCfg1 := &config.Config{}
 	err = tu.ReadGetJSON(re, testDialClient, addr, newCfg1)
 	suite.NoError(err)
+	cfg.Schedule.EnableTiKVSplitRegion = false
 	cfg.Schedule.TolerantSizeRatio = 2.5
 	cfg.Replication.LocationLabels = []string{"idc", "host"}
 	cfg.PDServerCfg.MetricStorage = "http://127.0.0.1:1234"

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -46,7 +46,7 @@ func (c *RaftCluster) HandleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSp
 	if c.GetUnsafeRecoveryController().IsRunning() {
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
-	if c.opt.IsTikvRegionSplitDisabled() {
+	if !c.opt.IsTikvRegionSplitEnabled() {
 		return nil, errs.ErrSchedulerTikvSplitDisabled
 	}
 	reqRegion := request.GetRegion()
@@ -108,7 +108,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	if c.GetUnsafeRecoveryController().IsRunning() {
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
-	if c.opt.IsTikvRegionSplitDisabled() {
+	if !c.opt.IsTikvRegionSplitEnabled() {
 		return nil, errs.ErrSchedulerTikvSplitDisabled
 	}
 	reqRegion := request.GetRegion()

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -46,6 +46,9 @@ func (c *RaftCluster) HandleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSp
 	if c.GetUnsafeRecoveryController().IsRunning() {
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
+	if c.opt.IsTikvRegionSplitDisabled() {
+		return nil, errs.ErrSchedulerTikvSplitDisabled
+	}
 	reqRegion := request.GetRegion()
 	err := c.ValidRequestRegion(reqRegion)
 	if err != nil {
@@ -104,6 +107,9 @@ func (c *RaftCluster) ValidRequestRegion(reqRegion *metapb.Region) error {
 func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*pdpb.AskBatchSplitResponse, error) {
 	if c.GetUnsafeRecoveryController().IsRunning() {
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
+	}
+	if c.opt.IsTikvRegionSplitDisabled() {
+		return nil, errs.ErrSchedulerTikvSplitDisabled
 	}
 	reqRegion := request.GetRegion()
 	splitCount := request.GetSplitCount()

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -47,7 +47,7 @@ func (c *RaftCluster) HandleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSp
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
 	if !c.opt.IsTikvRegionSplitEnabled() {
-		return nil, errs.ErrSchedulerTiKVSplitDisabled
+		return nil, errs.ErrSchedulerTiKVSplitDisabled.FastGenByArgs()
 	}
 	reqRegion := request.GetRegion()
 	err := c.ValidRequestRegion(reqRegion)
@@ -109,7 +109,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
 	if !c.opt.IsTikvRegionSplitEnabled() {
-		return nil, errs.ErrSchedulerTiKVSplitDisabled
+		return nil, errs.ErrSchedulerTiKVSplitDisabled.FastGenByArgs()
 	}
 	reqRegion := request.GetRegion()
 	splitCount := request.GetSplitCount()

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -47,7 +47,7 @@ func (c *RaftCluster) HandleAskSplit(request *pdpb.AskSplitRequest) (*pdpb.AskSp
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
 	if !c.opt.IsTikvRegionSplitEnabled() {
-		return nil, errs.ErrSchedulerTikvSplitDisabled
+		return nil, errs.ErrSchedulerTiKVSplitDisabled
 	}
 	reqRegion := request.GetRegion()
 	err := c.ValidRequestRegion(reqRegion)
@@ -109,7 +109,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 		return nil, errs.ErrUnsafeRecoveryIsRunning.FastGenByArgs()
 	}
 	if !c.opt.IsTikvRegionSplitEnabled() {
-		return nil, errs.ErrSchedulerTikvSplitDisabled
+		return nil, errs.ErrSchedulerTiKVSplitDisabled
 	}
 	reqRegion := request.GetRegion()
 	splitCount := request.GetSplitCount()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -742,7 +742,7 @@ type ScheduleConfig struct {
 	EnableJointConsensus bool `toml:"enable-joint-consensus" json:"enable-joint-consensus,string"`
 	// EnableTiKVSplitRegion is the option to enable tikv split region.
 	// on ebs-based BR we need to disable it with TTL
-	EnableTiKVSplitRegion bool `toml:"enable-tikv-split-region" json:"enable-tikv-split-region"`
+	EnableTiKVSplitRegion bool `toml:"enable-tikv-split-region" json:"enable-tikv-split-region,string"`
 
 	// Schedulers support for loading customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -810,6 +810,7 @@ const (
 	defaultLeaderSchedulePolicy        = "count"
 	defaultStoreLimitMode              = "manual"
 	defaultEnableJointConsensus        = true
+	defaultEnableTiKVSplitRegion       = true
 	defaultEnableCrossTableMerge       = true
 	defaultHotRegionsWriteInterval     = 10 * time.Minute
 	defaultHotRegionsReservedDays      = 7
@@ -865,8 +866,9 @@ func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
 	if !meta.IsDefined("enable-joint-consensus") {
 		c.EnableJointConsensus = defaultEnableJointConsensus
 	}
-	// we don't want user to change it at any time, it's used by tools like BR
-	c.EnableTiKVSplitRegion = true
+	if !meta.IsDefined("enable-tikv-split-region") {
+		c.EnableTiKVSplitRegion = defaultEnableTiKVSplitRegion
+	}
 	if !meta.IsDefined("enable-cross-table-merge") {
 		c.EnableCrossTableMerge = defaultEnableCrossTableMerge
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -740,6 +740,9 @@ type ScheduleConfig struct {
 	EnableDebugMetrics bool `toml:"enable-debug-metrics" json:"enable-debug-metrics,string"`
 	// EnableJointConsensus is the option to enable using joint consensus as a operator step.
 	EnableJointConsensus bool `toml:"enable-joint-consensus" json:"enable-joint-consensus,string"`
+	// EnableTiKVSplitRegion is the option to enable tikv split region.
+	// on ebs-based BR we need to disable it with TTL
+	EnableTiKVSplitRegion bool `json:"-"`
 
 	// Schedulers support for loading customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade
@@ -862,6 +865,8 @@ func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
 	if !meta.IsDefined("enable-joint-consensus") {
 		c.EnableJointConsensus = defaultEnableJointConsensus
 	}
+	// we don't want user to change it at any time, it's used by tools like BR
+	c.EnableTiKVSplitRegion = true
 	if !meta.IsDefined("enable-cross-table-merge") {
 		c.EnableCrossTableMerge = defaultEnableCrossTableMerge
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -742,7 +742,7 @@ type ScheduleConfig struct {
 	EnableJointConsensus bool `toml:"enable-joint-consensus" json:"enable-joint-consensus,string"`
 	// EnableTiKVSplitRegion is the option to enable tikv split region.
 	// on ebs-based BR we need to disable it with TTL
-	EnableTiKVSplitRegion bool `json:"-"`
+	EnableTiKVSplitRegion bool `toml:"-" json:"-"`
 
 	// Schedulers support for loading customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -742,7 +742,7 @@ type ScheduleConfig struct {
 	EnableJointConsensus bool `toml:"enable-joint-consensus" json:"enable-joint-consensus,string"`
 	// EnableTiKVSplitRegion is the option to enable tikv split region.
 	// on ebs-based BR we need to disable it with TTL
-	EnableTiKVSplitRegion bool `toml:"-" json:"-"`
+	EnableTiKVSplitRegion bool `toml:"enable-tikv-split-region" json:"enable-tikv-split-region"`
 
 	// Schedulers support for loading customized schedulers
 	Schedulers SchedulerConfigs `toml:"schedulers" json:"schedulers-v2"` // json v2 is for the sake of compatible upgrade

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -744,13 +744,14 @@ func (o *PersistOptions) getTTLUintOr(key string, defaultValue uint64) uint64 {
 	return defaultValue
 }
 
-func (o *PersistOptions) getTTLBool(key string) (bool, bool, error) {
+func (o *PersistOptions) getTTLBool(key string) (result bool, contains bool, err error) {
 	stringForm, ok := o.GetTTLData(key)
 	if !ok {
-		return false, false, nil
+		return
 	}
-	r, err := strconv.ParseBool(stringForm)
-	return r, true, err
+	result, err = strconv.ParseBool(stringForm)
+	contains = true
+	return
 }
 
 func (o *PersistOptions) getTTLBoolOr(key string, defaultValue bool) bool {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -201,12 +201,11 @@ const (
 	schedulerMaxWaitingOperatorKey = "schedule.scheduler-max-waiting-operator"
 	enableLocationReplacement      = "schedule.enable-location-replacement"
 	// it's related to schedule, but it's not an explicit config
-	// todo: do we need this prefix??
-	disableTikvSplitRegion = "schedule.disable-tikv-split-region"
+	enableTikvSplitRegion = "schedule.enable-tikv-split-region"
 
-	// we don't disable tikv region split on default
+	// enable tikv region split on default
 	// on ebs-based BR we need to disable it with TTL
-	defaultDisableTikvSplitRegion = 0
+	defaultEnableTikvSplitRegion = 1
 )
 
 var supportedTTLConfigs = []string{
@@ -221,7 +220,7 @@ var supportedTTLConfigs = []string{
 	hotRegionScheduleLimitKey,
 	schedulerMaxWaitingOperatorKey,
 	enableLocationReplacement,
-	disableTikvSplitRegion,
+	enableTikvSplitRegion,
 	"default-add-peer",
 	"default-remove-peer",
 }
@@ -527,9 +526,9 @@ func (o *PersistOptions) IsRemoveExtraReplicaEnabled() bool {
 	return o.GetScheduleConfig().EnableRemoveExtraReplica
 }
 
-// IsTikvRegionSplitDisabled returns whether tikv split region is disabled.
-func (o *PersistOptions) IsTikvRegionSplitDisabled() bool {
-	return o.getTTLUintOr(disableTikvSplitRegion, defaultDisableTikvSplitRegion) == 1
+// IsTikvRegionSplitEnabled returns whether tikv split region is disabled.
+func (o *PersistOptions) IsTikvRegionSplitEnabled() bool {
+	return o.getTTLUintOr(enableTikvSplitRegion, defaultEnableTikvSplitRegion) == 1
 }
 
 // IsLocationReplacementEnabled returns if location replace is enabled.

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -201,7 +201,7 @@ const (
 	schedulerMaxWaitingOperatorKey = "schedule.scheduler-max-waiting-operator"
 	enableLocationReplacement      = "schedule.enable-location-replacement"
 	// it's related to schedule, but it's not an explicit config
-	enableTikvSplitRegion = "schedule.enable-tikv-split-region"
+	enableTiKVSplitRegion = "schedule.enable-tikv-split-region"
 
 	// enable tikv region split on default
 	// on ebs-based BR we need to disable it with TTL
@@ -220,7 +220,7 @@ var supportedTTLConfigs = []string{
 	hotRegionScheduleLimitKey,
 	schedulerMaxWaitingOperatorKey,
 	enableLocationReplacement,
-	enableTikvSplitRegion,
+	enableTiKVSplitRegion,
 	"default-add-peer",
 	"default-remove-peer",
 }
@@ -528,7 +528,7 @@ func (o *PersistOptions) IsRemoveExtraReplicaEnabled() bool {
 
 // IsTikvRegionSplitEnabled returns whether tikv split region is disabled.
 func (o *PersistOptions) IsTikvRegionSplitEnabled() bool {
-	return o.getTTLUintOr(enableTikvSplitRegion, defaultEnableTikvSplitRegion) == 1
+	return o.getTTLUintOr(enableTiKVSplitRegion, defaultEnableTikvSplitRegion) == 1
 }
 
 // IsLocationReplacementEnabled returns if location replace is enabled.

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -527,6 +527,7 @@ func (o *PersistOptions) IsRemoveExtraReplicaEnabled() bool {
 	return o.GetScheduleConfig().EnableRemoveExtraReplica
 }
 
+// IsTikvRegionSplitDisabled returns whether tikv split region is disabled.
 func (o *PersistOptions) IsTikvRegionSplitDisabled() bool {
 	return o.getTTLUintOr(disableTikvSplitRegion, defaultDisableTikvSplitRegion) == 1
 }

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -200,6 +200,13 @@ const (
 	hotRegionScheduleLimitKey      = "schedule.hot-region-schedule-limit"
 	schedulerMaxWaitingOperatorKey = "schedule.scheduler-max-waiting-operator"
 	enableLocationReplacement      = "schedule.enable-location-replacement"
+	// it's related to schedule, but it's not an explicit config
+	// todo: do we need this prefix??
+	disableTikvSplitRegion = "schedule.disable-tikv-split-region"
+
+	// we don't disable tikv region split on default
+	// on ebs-based BR we need to disable it with TTL
+	defaultDisableTikvSplitRegion = 0
 )
 
 var supportedTTLConfigs = []string{
@@ -214,6 +221,7 @@ var supportedTTLConfigs = []string{
 	hotRegionScheduleLimitKey,
 	schedulerMaxWaitingOperatorKey,
 	enableLocationReplacement,
+	disableTikvSplitRegion,
 	"default-add-peer",
 	"default-remove-peer",
 }
@@ -517,6 +525,10 @@ func (o *PersistOptions) IsMakeUpReplicaEnabled() bool {
 // IsRemoveExtraReplicaEnabled returns if remove extra replica is enabled.
 func (o *PersistOptions) IsRemoveExtraReplicaEnabled() bool {
 	return o.GetScheduleConfig().EnableRemoveExtraReplica
+}
+
+func (o *PersistOptions) IsTikvRegionSplitDisabled() bool {
+	return o.getTTLUintOr(disableTikvSplitRegion, defaultDisableTikvSplitRegion) == 1
 }
 
 // IsLocationReplacementEnabled returns if location replace is enabled.

--- a/tests/server/cluster/cluster_work_test.go
+++ b/tests/server/cluster/cluster_work_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/tests"
@@ -100,9 +101,6 @@ func TestAskSplit(t *testing.T) {
 		Region: regions[0].GetMeta(),
 	}
 
-	_, err = rc.HandleAskSplit(req)
-	re.NoError(err)
-
 	req1 := &pdpb.AskBatchSplitRequest{
 		Header: &pdpb.RequestHeader{
 			ClusterId: clusterID,
@@ -110,6 +108,18 @@ func TestAskSplit(t *testing.T) {
 		Region:     regions[0].GetMeta(),
 		SplitCount: 10,
 	}
+
+	re.NoError(leaderServer.GetServer().SaveTTLConfig(map[string]interface{}{"schedule.enable-tikv-split-region": 0}, time.Minute))
+	_, err = rc.HandleAskSplit(req)
+	re.ErrorIs(err, errs.ErrSchedulerTiKVSplitDisabled)
+	_, err = rc.HandleAskBatchSplit(req1)
+	re.ErrorIs(err, errs.ErrSchedulerTiKVSplitDisabled)
+	re.NoError(leaderServer.GetServer().SaveTTLConfig(map[string]interface{}{"schedule.enable-tikv-split-region": 0}, 0))
+	// wait ttl config takes effect
+	time.Sleep(time.Second)
+
+	_, err = rc.HandleAskSplit(req)
+	re.NoError(err)
 
 	_, err = rc.HandleAskBatchSplit(req1)
 	re.NoError(err)

--- a/tests/server/cluster/cluster_work_test.go
+++ b/tests/server/cluster/cluster_work_test.go
@@ -16,6 +16,7 @@ package cluster_test
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 	"time"
@@ -111,9 +112,9 @@ func TestAskSplit(t *testing.T) {
 
 	re.NoError(leaderServer.GetServer().SaveTTLConfig(map[string]interface{}{"schedule.enable-tikv-split-region": 0}, time.Minute))
 	_, err = rc.HandleAskSplit(req)
-	re.ErrorIs(err, errs.ErrSchedulerTiKVSplitDisabled)
+	re.True(errors.Is(err, errs.ErrSchedulerTiKVSplitDisabled))
 	_, err = rc.HandleAskBatchSplit(req1)
-	re.ErrorIs(err, errs.ErrSchedulerTiKVSplitDisabled)
+	re.True(errors.Is(err, errs.ErrSchedulerTiKVSplitDisabled))
 	re.NoError(leaderServer.GetServer().SaveTTLConfig(map[string]interface{}{"schedule.enable-tikv-split-region": 0}, 0))
 	// wait ttl config takes effect
 	time.Sleep(time.Second)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5486

ref: https://github.com/pingcap/tidb/issues/35489


### What is changed and how does it work?
- add a ttl configuration to disable tikv split
<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- [x] Manual test (add detailed scripts or steps below)
  - max region size set to 10k
  - insert data until trigger region split
  - disable tikv split for 60s
  - insert data, see tikv report warning that `ErrSchedulerTikvSplitDisabled`
  - after ttl expired, insert some data, tikv can split normally.
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
