### PR TITLE
scheduler: fix target filter in hot scheduler when source peer is leader

### DIFF
--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -670,12 +670,8 @@ func NewPlacementSafeguard(scope string, opt *config.PersistOptions, cluster *co
 // NewPlacementLeaderSafeguard creates a filter that ensures after transfer a leader with
 // existed peer, the placement restriction will not become worse.
 // Note that it only worked when PlacementRules enabled otherwise it will always permit the sourceStore.
-func NewPlacementLeaderSafeguard(scope string, opt *config.PersistOptions, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, sourceStore *core.StoreInfo, allowMoveLeaders ...bool) Filter {
+func NewPlacementLeaderSafeguard(scope string, opt *config.PersistOptions, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, sourceStore *core.StoreInfo, allowMoveLeader bool) Filter {
 	if opt.IsPlacementRulesEnabled() {
-		var allowMoveLeader bool
-		if len(allowMoveLeaders) != 0 {
-			allowMoveLeader = allowMoveLeaders[0]
-		}
 		return newRuleLeaderFitFilter(scope, cluster, ruleManager, region, sourceStore.GetID(), allowMoveLeader)
 	}
 	return nil

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -645,8 +645,9 @@ func (f *ruleLeaderFitFilter) Target(options *config.PersistOptions, store *core
 			return statusStoreNotMatchRule
 		}
 		newRegionOptions = []core.RegionCreateOption{
+			core.WithReplacePeerStore(f.srcLeaderStoreID, targetStoreID),
 			core.WithLeader(&metapb.Peer{Id: sourcePeer.GetId(), StoreId: targetStoreID}),
-			core.WithReplacePeerStore(f.srcLeaderStoreID, targetStoreID)}
+		}
 	}
 	copyRegion := createRegionForRuleFit(f.region.GetStartKey(), f.region.GetEndKey(),
 		f.region.GetPeers(), f.region.GetLeader(), newRegionOptions...,

--- a/server/schedulers/balance_leader.go
+++ b/server/schedulers/balance_leader.go
@@ -454,7 +454,7 @@ func (l *balanceLeaderScheduler) transferLeaderOut(plan *solver) *operator.Opera
 	targets := plan.GetFollowerStores(plan.region)
 	finalFilters := l.filters
 	opts := plan.GetOpts()
-	if leaderFilter := filter.NewPlacementLeaderSafeguard(l.GetName(), opts, plan.GetBasicCluster(), plan.GetRuleManager(), plan.region, plan.source); leaderFilter != nil {
+	if leaderFilter := filter.NewPlacementLeaderSafeguard(l.GetName(), opts, plan.GetBasicCluster(), plan.GetRuleManager(), plan.region, plan.source, false /*allowMoveLeader*/); leaderFilter != nil {
 		finalFilters = append(l.filters, leaderFilter)
 	}
 	targets = filter.SelectTargetStores(targets, finalFilters, opts, nil)
@@ -498,7 +498,7 @@ func (l *balanceLeaderScheduler) transferLeaderIn(plan *solver) *operator.Operat
 	}
 	finalFilters := l.filters
 	opts := plan.GetOpts()
-	if leaderFilter := filter.NewPlacementLeaderSafeguard(l.GetName(), opts, plan.GetBasicCluster(), plan.GetRuleManager(), plan.region, plan.source); leaderFilter != nil {
+	if leaderFilter := filter.NewPlacementLeaderSafeguard(l.GetName(), opts, plan.GetBasicCluster(), plan.GetRuleManager(), plan.region, plan.source, false /*allowMoveLeader*/); leaderFilter != nil {
 		finalFilters = append(l.filters, leaderFilter)
 	}
 	target := filter.NewCandidates([]*core.StoreInfo{plan.target}).

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -840,7 +840,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 		}
 
 	case transferLeader:
-		if !bs.cur.mainPeerStat.IsLeader() { // move leader and transfer leader
+		if !bs.cur.mainPeerStat.IsLeader() { // source peer must be leader whether it is move leader or transfer leader
 			return nil
 		}
 		filters = []filter.Filter{
@@ -870,7 +870,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 				}
 			}
 		} else {
-			if leaderFilter := filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.GetOpts(), bs.GetBasicCluster(), bs.GetRuleManager(), bs.cur.region, srcStore); leaderFilter != nil {
+			if leaderFilter := filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.GetOpts(), bs.GetBasicCluster(), bs.GetRuleManager(), bs.cur.region, srcStore, false /*allowMoveLeader*/); leaderFilter != nil {
 				filters = append(filters, leaderFilter)
 			}
 			for _, peer := range bs.cur.region.GetFollowers() {

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -849,6 +849,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 		}
 		if bs.rwTy == statistics.Read {
 			peers := bs.cur.region.GetPeers()
+			moveLeaderFilters := []filter.Filter{&filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true}}
 			if leaderFilter := filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.GetOpts(), bs.GetBasicCluster(), bs.GetRuleManager(), bs.cur.region, srcStore, true /*allowMoveLeader*/); leaderFilter != nil {
 				filters = append(filters, leaderFilter)
 			}
@@ -864,8 +865,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 					continue
 				}
 				// move leader
-				if filter.Target(bs.GetOpts(), detail.StoreInfo,
-					[]filter.Filter{&filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true}}) {
+				if filter.Target(bs.GetOpts(), detail.StoreInfo, moveLeaderFilters) {
 					candidates = append(candidates, detail)
 				}
 			}

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1384,6 +1384,7 @@ func TestHotReadWithEvictLeaderScheduler(t *testing.T) {
 	hb.(*hotScheduler).conf.ReadPriorities = []string{BytePriority, KeyPriority}
 	tc := mockcluster.NewCluster(ctx, opt)
 	tc.SetHotRegionCacheHitsThreshold(0)
+	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 	tc.AddRegionStore(1, 20)
 	tc.AddRegionStore(2, 20)
 	tc.AddRegionStore(3, 20)
@@ -1402,6 +1403,7 @@ func TestHotReadWithEvictLeaderScheduler(t *testing.T) {
 	ops, _ := hb.Schedule(tc, false)
 	re.Len(ops, 1)
 	clearPendingInfluence(hb.(*hotScheduler))
+	testutil.CheckTransferPeerWithLeaderTransfer(re, ops[0], operator.OpHotRegion|operator.OpLeader, 1, 4)
 	// two dim are both enough uniform among three stores
 	tc.SetStoreEvictLeader(4, true)
 	ops, _ = hb.Schedule(tc, false)

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1370,6 +1370,45 @@ func TestSkipUniformStore(t *testing.T) {
 	clearPendingInfluence(hb.(*hotScheduler))
 }
 
+func TestHotReadWithEvictLeaderScheduler(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	statistics.Denoising = false
+	opt := config.NewTestOptions()
+	hb, err := schedule.CreateScheduler(statistics.Read.String(), schedule.NewOperatorController(ctx, nil, nil), storage.NewStorageWithMemoryBackend(), nil)
+	re.NoError(err)
+	hb.(*hotScheduler).conf.SetSrcToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetDstToleranceRatio(1)
+	hb.(*hotScheduler).conf.SetStrictPickingStore(false)
+	hb.(*hotScheduler).conf.ReadPriorities = []string{BytePriority, KeyPriority}
+	tc := mockcluster.NewCluster(ctx, opt)
+	tc.SetHotRegionCacheHitsThreshold(0)
+	tc.AddRegionStore(1, 20)
+	tc.AddRegionStore(2, 20)
+	tc.AddRegionStore(3, 20)
+	tc.AddRegionStore(4, 20)
+	tc.AddRegionStore(5, 20)
+	tc.AddRegionStore(6, 20)
+
+	// no uniform among four stores
+	tc.UpdateStorageReadStats(1, 10.05*units.MB*statistics.StoreHeartBeatReportInterval, 10.05*units.MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageReadStats(2, 10.05*units.MB*statistics.StoreHeartBeatReportInterval, 10.05*units.MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageReadStats(3, 10.05*units.MB*statistics.StoreHeartBeatReportInterval, 10.05*units.MB*statistics.StoreHeartBeatReportInterval)
+	tc.UpdateStorageReadStats(4, 0.0*units.MB*statistics.StoreHeartBeatReportInterval, 0.0*units.MB*statistics.StoreHeartBeatReportInterval)
+	addRegionInfo(tc, statistics.Read, []testRegionInfo{
+		{1, []uint64{1, 5, 6}, 0.05 * units.MB, 0.05 * units.MB, 0},
+	})
+	ops, _ := hb.Schedule(tc, false)
+	re.Len(ops, 1)
+	clearPendingInfluence(hb.(*hotScheduler))
+	// two dim are both enough uniform among three stores
+	tc.SetStoreEvictLeader(4,true)
+	ops, _ = hb.Schedule(tc, false)
+	re.Len(ops, 0)
+	clearPendingInfluence(hb.(*hotScheduler))
+}
+
 func TestHotCacheUpdateCache(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1403,7 +1403,7 @@ func TestHotReadWithEvictLeaderScheduler(t *testing.T) {
 	re.Len(ops, 1)
 	clearPendingInfluence(hb.(*hotScheduler))
 	// two dim are both enough uniform among three stores
-	tc.SetStoreEvictLeader(4,true)
+	tc.SetStoreEvictLeader(4, true)
 	ops, _ = hb.Schedule(tc, false)
 	re.Len(ops, 0)
 	clearPendingInfluence(hb.(*hotScheduler))


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5492 
### What is changed and how does it work?

For the read load, there are actually two kinds, one is to read data from the leader, and the other is to read data from the follower, which includes stale read and follower read.

For strong read, there are two kinds of operators, including transfer-leader and move-leader, move-leader is a combination of transfer-leader and move-peer; for stale read and follower read, we only have one kind of operator, that is, move-peer.

In the previous strategy, for the move-peer operator, if the role of the source peer is leader, it will be changed to move-leader. That is to say, the judgment and filtering of the move-leader operator are completely based on the move-peer. So, we don't consider whether the target store can receive the leader peer. For example, if there is an evict leader scheduler on the target node, then it will appear lots of `create-operators-fail` in the scheduler event. 

![image](https://user-images.githubusercontent.com/19542290/190133663-f5884528-c085-4a2d-bce3-e4131b9ff796.png)

This is not the worst. The move-leader was originally used to schedule strong read. Obviously, the stddev and expectation should be calculated according to the distribution of the load on the leader. However, since the move-leader operator is generated based on the move-peer in the previous strategy, the calculation of stddev and expectation are also based on peers rather than leaders, so when a node has an evict leader scheduler, its variance will never be balanced, so it will always try to schedule.
```
[2022/09/11 14:10:27.654 +00:00] [Info] [hot_region.go:570] ["filter uniform store"] [type=transfer-leader] [src=8] [dst=1] [equal=true] ["src first stddev"=0.15777655162390164] ["dst first stddev"=0.15777655162390164] ["src second stddev"=0.0431061068388591] ["dst second stddev"=0.0431061068388591]

[2022/09/11 14:10:27.655 +00:00] [Info] [hot_region.go:570] ["filter uniform store"] [type=move-peer] [src=6] [dst=4] [equal=true] ["src first stddev"=0.4794498183238738] ["dst first stddev"=0.4794498183238738] ["src second stddev"=0.44969963724264195] ["dst second stddev"=0.44969963724264195]
```

In the new strategy, we decide the type of schedule generated according to the role of the source peer, in another word, the generation of move-leader is no longer based on move-peer but transfer-leader. 

For source peers whose roles are leader, we will try to select all stores, for those stores that contain followers, the transfer-leader will be generated, if it does not contain followers, the move-leader will be generated; for source peers whose roles are follower, we will only generate move-peer.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test

a cluster with 6 nodes but a node is evicted leader, strict-pick-store is false.

there are both uniform workloads before this pr and after this pr, but there is a lot of operators before this pr.
![image](https://user-images.githubusercontent.com/19542290/190089930-0ac50384-1af4-4177-9015-cc16805548ce.png)
![image](https://user-images.githubusercontent.com/19542290/190090010-208702e7-b05c-44a1-968c-6dbcce941a14.png)



### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
