### PR TITLE
Fix config parsing for store-limit

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -145,6 +145,14 @@
 ## PD avoids migrating data to this store as much as possible.
 # low-space-ratio = 0.8
 
+## Configure a specific store limit. This is mostly useful for GitOps because
+## store IDs must be known before the first PD start and these values only take effect then.
+# [schedule.store-limit.100]
+## AddPeer indicates the type of store limit that limits the adding peer rate.
+# add-peer = 30.0
+## RemovePeer indicates the type of store limit that limits the removing peer rate.
+# remove-peer = 30.0
+
 ## The default version of balance Region score calculation.
 # region-score-formula-version = "v2"
 

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -476,7 +476,15 @@ func (o *PersistConfig) IsSchedulingHalted() bool {
 
 // GetStoresLimit gets the stores' limit.
 func (o *PersistConfig) GetStoresLimit() map[uint64]sc.StoreLimitConfig {
-	return o.GetScheduleConfig().StoreLimit
+	config := make(map[uint64]sc.StoreLimitConfig, len(o.GetScheduleConfig().StoreLimit))
+	for storeID, cfg := range o.GetScheduleConfig().StoreLimit {
+		id, err := strconv.ParseUint(storeID, 10, 64)
+		if err != nil {
+			continue
+		}
+		config[id] = cfg
+	}
+	return config
 }
 
 // TTL related methods.
@@ -513,7 +521,8 @@ func (o *PersistConfig) GetHotRegionScheduleLimit() uint64 {
 
 // GetStoreLimit returns the limit of a store.
 func (o *PersistConfig) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitConfig) {
-	if limit, ok := o.GetScheduleConfig().StoreLimit[storeID]; ok {
+	storeIDStr := strconv.FormatUint(storeID, 10)
+	if limit, ok := o.GetScheduleConfig().StoreLimit[storeIDStr]; ok {
 		return limit
 	}
 	cfg := o.GetScheduleConfig().Clone()
@@ -521,9 +530,9 @@ func (o *PersistConfig) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitCon
 		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
 		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
 	}
-	cfg.StoreLimit[storeID] = limitCfg
+	cfg.StoreLimit[storeIDStr] = limitCfg
 	o.SetScheduleConfig(cfg)
-	return o.GetScheduleConfig().StoreLimit[storeID]
+	return o.GetScheduleConfig().StoreLimit[storeIDStr]
 }
 
 // GetStoreLimitByType returns the limit of a store with a given type.

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"math"
 	"strconv"
 	"time"
 
@@ -577,11 +578,12 @@ func (c *ScheduleConfig) Validate() error {
 		if err != nil {
 			return errors.Annotatef(err, "invalid schedule.store-limit key %q", storeID)
 		}
-		if storeID != strconv.FormatUint(id, 10) {
+		if id == 0 || storeID != strconv.FormatUint(id, 10) {
 			return errors.Errorf("invalid schedule.store-limit key %q", storeID)
 		}
-		if limit.AddPeer <= 0 || limit.RemovePeer <= 0 {
-			return errors.Errorf("schedule.store-limit.%s add-peer and remove-peer should be positive", storeID)
+		if limit.AddPeer <= 0 || math.IsNaN(limit.AddPeer) || math.IsInf(limit.AddPeer, 0) ||
+			limit.RemovePeer <= 0 || math.IsNaN(limit.RemovePeer) || math.IsInf(limit.RemovePeer, 0) {
+			return errors.Errorf("schedule.store-limit.%s rates must be finite and positive", storeID)
 		}
 	}
 	return nil

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -228,7 +229,7 @@ type ScheduleConfig struct {
 	// WARN: StoreBalanceRate is deprecated.
 	StoreBalanceRate float64 `toml:"store-balance-rate" json:"store-balance-rate,omitempty"`
 	// StoreLimit is the limit of scheduling for stores.
-	StoreLimit map[uint64]StoreLimitConfig `toml:"store-limit" json:"store-limit"`
+	StoreLimit map[string]StoreLimitConfig `toml:"store-limit" json:"store-limit"`
 	// TolerantSizeRatio is the ratio of buffer size for balance scheduler.
 	TolerantSizeRatio float64 `toml:"tolerant-size-ratio" json:"tolerant-size-ratio"`
 	//
@@ -340,9 +341,9 @@ type ScheduleConfig struct {
 // Clone returns a cloned scheduling configuration.
 func (c *ScheduleConfig) Clone() *ScheduleConfig {
 	schedulers := append(c.Schedulers[:0:0], c.Schedulers...)
-	var storeLimit map[uint64]StoreLimitConfig
+	var storeLimit map[string]StoreLimitConfig
 	if c.StoreLimit != nil {
-		storeLimit = make(map[uint64]StoreLimitConfig, len(c.StoreLimit))
+		storeLimit = make(map[string]StoreLimitConfig, len(c.StoreLimit))
 		for k, v := range c.StoreLimit {
 			storeLimit[k] = v
 		}
@@ -472,7 +473,7 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	}
 
 	if c.StoreLimit == nil {
-		c.StoreLimit = make(map[uint64]StoreLimitConfig)
+		c.StoreLimit = make(map[string]StoreLimitConfig)
 	}
 
 	if !meta.IsDefined("hot-regions-reserved-days") {
@@ -570,6 +571,11 @@ func (c *ScheduleConfig) Validate() error {
 	}
 	if c.PatrolRegionWorkerCount > maxPatrolRegionWorkerCount || c.PatrolRegionWorkerCount < 1 {
 		return errors.Errorf("patrol-region-worker-count should be between 1 and %d", maxPatrolRegionWorkerCount)
+	}
+	for storeID := range c.StoreLimit {
+		if _, err := strconv.ParseUint(storeID, 10, 64); err != nil {
+			return errors.Annotatef(err, "invalid schedule.store-limit key %q", storeID)
+		}
 	}
 	return nil
 }

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -572,9 +572,16 @@ func (c *ScheduleConfig) Validate() error {
 	if c.PatrolRegionWorkerCount > maxPatrolRegionWorkerCount || c.PatrolRegionWorkerCount < 1 {
 		return errors.Errorf("patrol-region-worker-count should be between 1 and %d", maxPatrolRegionWorkerCount)
 	}
-	for storeID := range c.StoreLimit {
-		if _, err := strconv.ParseUint(storeID, 10, 64); err != nil {
+	for storeID, limit := range c.StoreLimit {
+		id, err := strconv.ParseUint(storeID, 10, 64)
+		if err != nil {
 			return errors.Annotatef(err, "invalid schedule.store-limit key %q", storeID)
+		}
+		if storeID != strconv.FormatUint(id, 10) {
+			return errors.Errorf("invalid schedule.store-limit key %q", storeID)
+		}
+		if limit.AddPeer <= 0 || limit.RemovePeer <= 0 {
+			return errors.Errorf("schedule.store-limit.%s add-peer and remove-peer should be positive", storeID)
 		}
 	}
 	return nil

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -522,11 +522,15 @@ func (h *storesHandler) GetAllStoresLimit(w http.ResponseWriter, r *http.Request
 		returned := make(map[uint64]sc.StoreLimitConfig, len(limits))
 		rc := getCluster(r)
 		for storeID, v := range limits {
-			store := rc.GetStore(storeID)
+			id, err := strconv.ParseUint(storeID, 10, 64)
+			if err != nil {
+				continue
+			}
+			store := rc.GetStore(id)
 			if store == nil || store.IsRemoved() {
 				continue
 			}
-			returned[storeID] = v
+			returned[id] = v
 		}
 		h.rd.JSON(w, http.StatusOK, returned)
 		return

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2320,8 +2320,9 @@ func (c *RaftCluster) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 // AddStoreLimit add a store limit for a given store ID.
 func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 	storeID := store.GetId()
+	storeIDStr := strconv.FormatUint(storeID, 10)
 	cfg := c.opt.GetScheduleConfig().Clone()
-	if _, ok := cfg.StoreLimit[storeID]; ok {
+	if _, ok := cfg.StoreLimit[storeIDStr]; ok {
 		return
 	}
 
@@ -2336,7 +2337,7 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 		}
 	}
 
-	cfg.StoreLimit[storeID] = slc
+	cfg.StoreLimit[storeIDStr] = slc
 	c.opt.SetScheduleConfig(cfg)
 	var err error
 	for range persistLimitRetryTimes {
@@ -2355,7 +2356,7 @@ func (c *RaftCluster) RemoveStoreLimit(storeID uint64) {
 	for _, limitType := range storelimit.TypeNameValue {
 		c.ResetStoreLimit(storeID, limitType)
 	}
-	delete(cfg.StoreLimit, storeID)
+	delete(cfg.StoreLimit, strconv.FormatUint(storeID, 10))
 	c.opt.SetScheduleConfig(cfg)
 	var err error
 	for range persistLimitRetryTimes {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -151,7 +151,7 @@ func TestValidation(t *testing.T) {
 	cfg.Schedule.StoreLimit["foo"] = sc.StoreLimitConfig{}
 	re.Error(cfg.Schedule.Validate())
 	delete(cfg.Schedule.StoreLimit, "foo")
-	cfg.Schedule.StoreLimit["100"] = sc.StoreLimitConfig{}
+	cfg.Schedule.StoreLimit["100"] = sc.StoreLimitConfig{AddPeer: 1, RemovePeer: 1}
 	re.NoError(cfg.Schedule.Validate())
 	// check quota
 	re.Equal(defaultQuotaBackendBytes, cfg.QuotaBackendBytes)
@@ -705,4 +705,46 @@ func TestStoreLimitRejectsNonNumericKey(t *testing.T) {
 	err = cfg.Adjust(&meta, false)
 	re.Error(err)
 	re.Contains(err.Error(), `invalid schedule.store-limit key "foo"`)
+}
+
+func TestStoreLimitRejectsInvalidConfig(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cfgData string
+	}{
+		{
+			name: "non-canonical store ID",
+			cfgData: `
+	[schedule.store-limit.00100]
+	add-peer = 30.0
+	remove-peer = 40.0
+	`,
+		},
+		{
+			name: "missing rate",
+			cfgData: `
+	[schedule.store-limit.100]
+	add-peer = 30.0
+	`,
+		},
+		{
+			name: "non-positive rates",
+			cfgData: `
+	[schedule.store-limit.100]
+	add-peer = -1.0
+	remove-peer = 0.0
+	`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			cfg := NewConfig()
+			meta, err := toml.Decode(testCase.cfgData, &cfg)
+			re.NoError(err)
+			re.Error(cfg.Adjust(&meta, false))
+		})
+	}
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -721,6 +721,14 @@ func TestStoreLimitRejectsInvalidConfig(t *testing.T) {
 	`,
 		},
 		{
+			name: "zero store ID",
+			cfgData: `
+	[schedule.store-limit.0]
+	add-peer = 30.0
+	remove-peer = 40.0
+	`,
+		},
+		{
 			name: "missing rate",
 			cfgData: `
 	[schedule.store-limit.100]
@@ -733,6 +741,22 @@ func TestStoreLimitRejectsInvalidConfig(t *testing.T) {
 	[schedule.store-limit.100]
 	add-peer = -1.0
 	remove-peer = 0.0
+	`,
+		},
+		{
+			name: "NaN rate",
+			cfgData: `
+	[schedule.store-limit.100]
+	add-peer = nan
+	remove-peer = 40.0
+	`,
+		},
+		{
+			name: "infinite rate",
+			cfgData: `
+	[schedule.store-limit.100]
+	add-peer = 30.0
+	remove-peer = inf
 	`,
 		},
 	}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -146,6 +146,13 @@ func TestValidation(t *testing.T) {
 	re.NoError(cfg.Schedule.Validate())
 	cfg.Schedule.TolerantSizeRatio = -0.6
 	re.Error(cfg.Schedule.Validate())
+	cfg.Schedule.TolerantSizeRatio = 0.6
+	re.NoError(cfg.Schedule.Validate())
+	cfg.Schedule.StoreLimit["foo"] = sc.StoreLimitConfig{}
+	re.Error(cfg.Schedule.Validate())
+	delete(cfg.Schedule.StoreLimit, "foo")
+	cfg.Schedule.StoreLimit["100"] = sc.StoreLimitConfig{}
+	re.NoError(cfg.Schedule.Validate())
 	// check quota
 	re.Equal(defaultQuotaBackendBytes, cfg.QuotaBackendBytes)
 	// check request bytes
@@ -666,7 +673,6 @@ func TestAdjustMetaServiceGroups(t *testing.T) {
 
 func TestStoreLimit(t *testing.T) {
 	re := require.New(t)
-	registerDefaultSchedulers()
 
 	cfgData := `
 	[schedule.store-limit.100]
@@ -680,6 +686,23 @@ func TestStoreLimit(t *testing.T) {
 	err = cfg.Adjust(&meta, false)
 	re.NoError(err)
 
-	re.Equal(30.0, cfg.Schedule.StoreLimit[100].AddPeer)
-	re.Equal(40.0, cfg.Schedule.StoreLimit[100].RemovePeer)
+	re.Equal(30.0, cfg.Schedule.StoreLimit["100"].AddPeer)
+	re.Equal(40.0, cfg.Schedule.StoreLimit["100"].RemovePeer)
+}
+
+func TestStoreLimitRejectsNonNumericKey(t *testing.T) {
+	re := require.New(t)
+
+	cfgData := `
+	[schedule.store-limit.foo]
+	add-peer = 30.0
+	remove-peer = 40.0
+	`
+	cfg := NewConfig()
+	meta, err := toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+
+	err = cfg.Adjust(&meta, false)
+	re.Error(err)
+	re.Contains(err.Error(), `invalid schedule.store-limit key "foo"`)
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -663,3 +663,23 @@ func TestAdjustMetaServiceGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestStoreLimit(t *testing.T) {
+	re := require.New(t)
+	registerDefaultSchedulers()
+
+	cfgData := `
+	[schedule.store-limit.100]
+	add-peer = 30.0
+	remove-peer = 40.0
+	`
+	cfg := NewConfig()
+	meta, err := toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+
+	err = cfg.Adjust(&meta, false)
+	re.NoError(err)
+
+	re.Equal(30.0, cfg.Schedule.StoreLimit[100].AddPeer)
+	re.Equal(40.0, cfg.Schedule.StoreLimit[100].RemovePeer)
+}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -738,7 +738,6 @@ func TestStoreLimitRejectsInvalidConfig(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			re := require.New(t)
 			cfg := NewConfig()

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -392,23 +392,24 @@ func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, rate
 	v := o.GetScheduleConfig().Clone()
 	var slc sc.StoreLimitConfig
 	var rate float64
+	storeIDStr := strconv.FormatUint(storeID, 10)
 	switch typ {
 	case storelimit.AddPeer:
-		if _, ok := v.StoreLimit[storeID]; !ok {
+		if _, ok := v.StoreLimit[storeIDStr]; !ok {
 			rate = sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
 		} else {
-			rate = v.StoreLimit[storeID].RemovePeer
+			rate = v.StoreLimit[storeIDStr].RemovePeer
 		}
 		slc = sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
 	case storelimit.RemovePeer:
-		if _, ok := v.StoreLimit[storeID]; !ok {
+		if _, ok := v.StoreLimit[storeIDStr]; !ok {
 			rate = sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
 		} else {
-			rate = v.StoreLimit[storeID].AddPeer
+			rate = v.StoreLimit[storeIDStr].AddPeer
 		}
 		slc = sc.StoreLimitConfig{AddPeer: rate, RemovePeer: ratePerMin}
 	}
-	v.StoreLimit[storeID] = slc
+	v.StoreLimit[storeIDStr] = slc
 	o.SetScheduleConfig(v)
 }
 
@@ -490,7 +491,8 @@ func (o *PersistOptions) GetHotRegionScheduleLimit() uint64 {
 
 // GetStoreLimit returns the limit of a store.
 func (o *PersistOptions) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitConfig) {
-	if limit, ok := o.GetScheduleConfig().StoreLimit[storeID]; ok {
+	storeIDStr := strconv.FormatUint(storeID, 10)
+	if limit, ok := o.GetScheduleConfig().StoreLimit[storeIDStr]; ok {
 		return limit
 	}
 	cfg := o.GetScheduleConfig().Clone()
@@ -498,9 +500,9 @@ func (o *PersistOptions) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitCo
 		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
 		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
 	}
-	cfg.StoreLimit[storeID] = limitCfg
+	cfg.StoreLimit[storeIDStr] = limitCfg
 	o.SetScheduleConfig(cfg)
-	return o.GetScheduleConfig().StoreLimit[storeID]
+	return o.GetScheduleConfig().StoreLimit[storeIDStr]
 }
 
 // GetStoreLimitByType returns the limit of a store with a given type.
@@ -521,7 +523,7 @@ func (o *PersistOptions) GetStoreLimitByType(storeID uint64, typ storelimit.Type
 
 // GetAllStoresLimit returns the limit of all stores.
 func (o *PersistOptions) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
-	return o.GetScheduleConfig().StoreLimit
+	return o.GetStoresLimit()
 }
 
 // GetStoreLimitVersion returns the limit version of store.
@@ -674,7 +676,15 @@ func (o *PersistOptions) GetPatrolRegionWorkerCount() int {
 
 // GetStoresLimit gets the stores' limit.
 func (o *PersistOptions) GetStoresLimit() map[uint64]sc.StoreLimitConfig {
-	return o.GetScheduleConfig().StoreLimit
+	config := make(map[uint64]sc.StoreLimitConfig, len(o.GetScheduleConfig().StoreLimit))
+	for storeID, cfg := range o.GetScheduleConfig().StoreLimit {
+		id, err := strconv.ParseUint(storeID, 10, 64)
+		if err != nil {
+			continue
+		}
+		config[id] = cfg
+	}
+	return config
 }
 
 // GetSchedulers gets the scheduler configurations.

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -1217,7 +1217,7 @@ func TestTiFlashWithPlacementRules(t *testing.T) {
 	re.NoError(err)
 	re.Equal(pdpb.ErrorType_OK, resp.GetHeader().GetError().GetType())
 	// test TiFlash store limit
-	expect := map[uint64]sc.StoreLimitConfig{11: {AddPeer: 30, RemovePeer: 30}}
+	expect := map[string]sc.StoreLimitConfig{"11": {AddPeer: 30, RemovePeer: 30}}
 	re.Equal(expect, svr.GetScheduleConfig().StoreLimit)
 
 	// cannot disable placement rules with TiFlash nodes
@@ -1470,7 +1470,7 @@ func TestUpgradeStoreLimit(t *testing.T) {
 	// restart PD
 	// Here we use an empty storelimit to simulate the upgrade progress.
 	scheduleCfg := rc.GetScheduleConfig().Clone()
-	scheduleCfg.StoreLimit = map[uint64]sc.StoreLimitConfig{}
+	scheduleCfg.StoreLimit = map[string]sc.StoreLimitConfig{}
 	re.NoError(leaderServer.GetServer().SetScheduleConfig(*scheduleCfg))
 	err = leaderServer.Stop()
 	re.NoError(err)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Adding support for configuring store-limit using config file
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #5497

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix config parsing for store-limit
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

- Has configuration change

Side effects
NA

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fix configuration parsing for store-limit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-store scheduling limits are supported via `schedule.store-limit.<store-id>`, including optional `add-peer` and `remove-peer` rate limits.
* **Bug Fixes**
  * Improved handling of per-store limit keys: listings and parsing now safely skip malformed keys, and validation enforces canonical numeric store IDs plus strictly positive, finite rates.
  * Store-limit values are now consistently keyed/persisted by store ID.
* **Documentation**
  * Added a commented per-store configuration template under the existing schedule settings.
* **Tests**
  * Expanded validation/parsing coverage and updated upgrade-related expectations for store-limit configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
