### PR TITLE
scheduler: fix write leader max zombie duration

### DIFF
--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -656,6 +656,9 @@ func (bs *balanceSolver) calcMaxZombieDur() time.Duration {
 	switch bs.resourceTy {
 	case writeLeader:
 		if bs.firstPriority == statistics.QueryDim {
+			// We use store query info rather than total of hot write leader to guide hot write leader scheduler
+			// when its first priority is QueryDim`, because `Write-peer` does not have `QueryDim`.
+			// The reason is similar with `tikvCollector.GetLoads`
 			return bs.sche.conf.GetStoreStatZombieDuration()
 		}
 		return bs.sche.conf.GetRegionsStatZombieDuration()

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -634,7 +634,11 @@ func (bs *balanceSolver) tryAddPendingInfluence() bool {
 	var maxZombieDur time.Duration
 	switch bs.resourceTy {
 	case writeLeader:
-		maxZombieDur = bs.sche.conf.GetRegionsStatZombieDuration()
+		if bs.firstPriority == statistics.QueryDim {
+			maxZombieDur = bs.sche.conf.GetStoreStatZombieDuration()
+		} else {
+			maxZombieDur = bs.sche.conf.GetRegionsStatZombieDuration()
+		}
 	case writePeer:
 		if bs.best.srcStore.IsTiFlash() {
 			maxZombieDur = bs.sche.conf.GetRegionsStatZombieDuration()

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -657,8 +657,8 @@ func (bs *balanceSolver) calcMaxZombieDur() time.Duration {
 	case writeLeader:
 		if bs.firstPriority == statistics.QueryDim {
 			// We use store query info rather than total of hot write leader to guide hot write leader scheduler
-			// when its first priority is QueryDim`, because `Write-peer` does not have `QueryDim`.
-			// The reason is similar with `tikvCollector.GetLoads`
+			// when its first priority is `QueryDim`, because `Write-peer` does not have `QueryDim`.
+			// The reason is the same with `tikvCollector.GetLoads`.
 			return bs.sche.conf.GetStoreStatZombieDuration()
 		}
 		return bs.sche.conf.GetRegionsStatZombieDuration()

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -657,15 +657,13 @@ func (bs *balanceSolver) calcMaxZombieDur() time.Duration {
 	case writeLeader:
 		if bs.firstPriority == statistics.QueryDim {
 			return bs.sche.conf.GetStoreStatZombieDuration()
-		} else {
-			return bs.sche.conf.GetRegionsStatZombieDuration()
 		}
+		return bs.sche.conf.GetRegionsStatZombieDuration()
 	case writePeer:
 		if bs.best.srcStore.IsTiFlash() {
 			return bs.sche.conf.GetRegionsStatZombieDuration()
-		} else {
-			return bs.sche.conf.GetStoreStatZombieDuration()
 		}
+		return bs.sche.conf.GetStoreStatZombieDuration()
 	default:
 		return bs.sche.conf.GetStoreStatZombieDuration()
 	}

--- a/server/statistics/store_load.go
+++ b/server/statistics/store_load.go
@@ -166,6 +166,11 @@ func (s *StoreSummaryInfo) IsTiFlash() bool {
 	return s.isTiFlash
 }
 
+// SetEngineAsTiFlash set whether store is TiFlash, it is only used in tests.
+func (s *StoreSummaryInfo) SetEngineAsTiFlash() {
+	s.isTiFlash = true
+}
+
 // GetPendingInfluence returns the current pending influence.
 func GetPendingInfluence(stores []*core.StoreInfo) map[uint64]*Influence {
 	stInfos := SummaryStoreInfos(stores)


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?


Issue Number: Ref #4949

`maxZombieDur` is not correct when the first priority is query in hot write scheduler, query is reported by store heartbeat rather than region heartbeat, so the interval should be base store heartbeat rather than region heartbeat

It's the same reason with [`tikvCollector.GetLoads`](https://github.com/tikv/pd/blob/bca2afae417921c9e31fd2c208eea485d4d3597d/server/statistics/collector.go#L52)

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
