### PR TITLE
schedule: refine the operator priority

### DIFF
--- a/plugin/scheduler_example/evict_leader.go
+++ b/plugin/scheduler_example/evict_leader.go
@@ -235,7 +235,7 @@ func (s *evictLeaderScheduler) Schedule(cluster schedule.Cluster, dryRun bool) (
 			log.Debug("fail to create evict leader operator", errs.ZapError(err))
 			continue
 		}
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 		ops = append(ops, op)
 	}
 

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -1016,7 +1016,7 @@ func TestOperatorCount(t *testing.T) {
 		re.Equal(uint64(1), oc.OperatorCount(operator.OpRegion)) // 1:region 2:leader
 		re.Equal(uint64(1), oc.OperatorCount(operator.OpLeader))
 		op2 := newTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpRegion)
-		op2.SetPriorityLevel(core.HighPriority)
+		op2.SetPriorityLevel(core.High)
 		oc.AddWaitingOperator(op2)
 		re.Equal(uint64(2), oc.OperatorCount(operator.OpRegion)) // 1:region 2:region
 		re.Equal(uint64(0), oc.OperatorCount(operator.OpLeader))
@@ -1099,7 +1099,7 @@ func TestStoreOverloadedWithReplace(t *testing.T) {
 	op1 := newTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), operator.OpRegion, operator.AddPeer{ToStore: 1, PeerID: 1})
 	re.True(oc.AddOperator(op1))
 	op2 := newTestOperator(1, tc.GetRegion(1).GetRegionEpoch(), operator.OpRegion, operator.AddPeer{ToStore: 2, PeerID: 2})
-	op2.SetPriorityLevel(core.HighPriority)
+	op2.SetPriorityLevel(core.High)
 	re.True(oc.AddOperator(op2))
 	op3 := newTestOperator(1, tc.GetRegion(2).GetRegionEpoch(), operator.OpRegion, operator.AddPeer{ToStore: 1, PeerID: 3})
 	re.False(oc.AddOperator(op3))
@@ -1211,7 +1211,7 @@ func TestController(t *testing.T) {
 	// add a PriorityKind operator will remove old operator
 	{
 		op3 := newTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpHotRegion)
-		op3.SetPriorityLevel(core.HighPriority)
+		op3.SetPriorityLevel(core.High)
 		re.Equal(1, oc.AddWaitingOperator(op11))
 		re.False(sc.AllowSchedule(false))
 		re.Equal(1, oc.AddWaitingOperator(op3))
@@ -1225,7 +1225,7 @@ func TestController(t *testing.T) {
 		re.Equal(1, oc.AddWaitingOperator(op2))
 		re.False(sc.AllowSchedule(false))
 		op4 := newTestOperator(2, tc.GetRegion(2).GetRegionEpoch(), operator.OpAdmin)
-		op4.SetPriorityLevel(core.HighPriority)
+		op4.SetPriorityLevel(core.High)
 		re.Equal(1, oc.AddWaitingOperator(op4))
 		re.True(sc.AllowSchedule(false))
 		re.True(oc.RemoveOperator(op4))

--- a/server/core/kind.go
+++ b/server/core/kind.go
@@ -22,7 +22,7 @@ const (
 	Low PriorityLevel = iota
 	Medium
 	High
-	VeryHigh
+	Urgent
 )
 
 // ScheduleKind distinguishes resources and schedule policy.

--- a/server/core/kind.go
+++ b/server/core/kind.go
@@ -19,9 +19,10 @@ type PriorityLevel int
 
 // Built-in priority level
 const (
-	LowPriority PriorityLevel = iota
-	NormalPriority
-	HighPriority
+	Low PriorityLevel = iota
+	Medium
+	High
+	VeryHigh
 )
 
 // ScheduleKind distinguishes resources and schedule policy.

--- a/server/schedule/checker/joint_state_checker.go
+++ b/server/schedule/checker/joint_state_checker.go
@@ -55,7 +55,7 @@ func (c *JointStateChecker) Check(region *core.RegionInfo) *operator.Operator {
 		if op.Len() > 1 {
 			checkerCounter.WithLabelValues("joint_state_checker", "transfer-leader").Inc()
 		}
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 	}
 	return op
 }

--- a/server/schedule/checker/replica_checker.go
+++ b/server/schedule/checker/replica_checker.go
@@ -72,17 +72,17 @@ func (r *ReplicaChecker) Check(region *core.RegionInfo) *operator.Operator {
 	}
 	if op := r.checkDownPeer(region); op != nil {
 		checkerCounter.WithLabelValues("replica_checker", "new-operator").Inc()
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 		return op
 	}
 	if op := r.checkOfflinePeer(region); op != nil {
 		checkerCounter.WithLabelValues("replica_checker", "new-operator").Inc()
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 		return op
 	}
 	if op := r.checkMakeUpReplica(region); op != nil {
 		checkerCounter.WithLabelValues("replica_checker", "new-operator").Inc()
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 		return op
 	}
 	if op := r.checkRemoveExtraReplica(region); op != nil {

--- a/server/schedule/checker/rule_checker.go
+++ b/server/schedule/checker/rule_checker.go
@@ -186,7 +186,7 @@ func (c *RuleChecker) addRulePeer(region *core.RegionInfo, rf *placement.RuleFit
 	if err != nil {
 		return nil, err
 	}
-	op.SetPriorityLevel(core.HighPriority)
+	op.SetPriorityLevel(core.High)
 	return op, nil
 }
 
@@ -235,7 +235,7 @@ func (c *RuleChecker) replaceUnexpectRulePeer(region *core.RegionInfo, rf *place
 	if newLeader != nil {
 		c.record.incOfflineLeaderCount(newLeader.GetStoreId())
 	}
-	op.SetPriorityLevel(core.HighPriority)
+	op.SetPriorityLevel(core.High)
 	return op, nil
 }
 

--- a/server/schedule/checker/rule_checker_test.go
+++ b/server/schedule/checker/rule_checker_test.go
@@ -67,7 +67,7 @@ func (suite *ruleCheckerTestSuite) TestAddRulePeer() {
 	op := suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.NotNil(op)
 	suite.Equal("add-rule-peer", op.Desc())
-	suite.Equal(core.HighPriority, op.GetPriorityLevel())
+	suite.Equal(core.High, op.GetPriorityLevel())
 	suite.Equal(uint64(3), op.Step(0).(operator.AddLearner).ToStore)
 }
 
@@ -120,7 +120,7 @@ func (suite *ruleCheckerTestSuite) TestFixPeer() {
 	op = suite.rc.Check(r)
 	suite.NotNil(op)
 	suite.Equal("replace-rule-down-peer", op.Desc())
-	suite.Equal(core.HighPriority, op.GetPriorityLevel())
+	suite.Equal(core.High, op.GetPriorityLevel())
 	var add operator.AddLearner
 	suite.IsType(add, op.Step(0))
 	suite.cluster.SetStoreUp(2)
@@ -128,7 +128,7 @@ func (suite *ruleCheckerTestSuite) TestFixPeer() {
 	op = suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.NotNil(op)
 	suite.Equal("replace-rule-offline-peer", op.Desc())
-	suite.Equal(core.HighPriority, op.GetPriorityLevel())
+	suite.Equal(core.High, op.GetPriorityLevel())
 	suite.IsType(add, op.Step(0))
 
 	suite.cluster.SetStoreUp(2)
@@ -850,7 +850,7 @@ func (suite *ruleCheckerTestSuite) TestPendingList() {
 	op = suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.NotNil(op)
 	suite.Equal("add-rule-peer", op.Desc())
-	suite.Equal(core.HighPriority, op.GetPriorityLevel())
+	suite.Equal(core.High, op.GetPriorityLevel())
 	suite.Equal(uint64(3), op.Step(0).(operator.AddLearner).ToStore)
 	_, exist = suite.rc.pendingList.Get(1)
 	suite.False(exist)

--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -60,9 +60,9 @@ type Operator struct {
 
 // NewOperator creates a new operator.
 func NewOperator(desc, brief string, regionID uint64, regionEpoch *metapb.RegionEpoch, kind OpKind, approximateSize int64, steps ...OpStep) *Operator {
-	level := core.NormalPriority
+	level := core.Medium
 	if kind&OpAdmin != 0 {
-		level = core.HighPriority
+		level = core.VeryHigh
 	}
 	return &Operator{
 		desc:            desc,

--- a/server/schedule/operator/operator.go
+++ b/server/schedule/operator/operator.go
@@ -62,7 +62,7 @@ type Operator struct {
 func NewOperator(desc, brief string, regionID uint64, regionEpoch *metapb.RegionEpoch, kind OpKind, approximateSize int64, steps ...OpStep) *Operator {
 	level := core.Medium
 	if kind&OpAdmin != 0 {
-		level = core.VeryHigh
+		level = core.Urgent
 	}
 	return &Operator{
 		desc:            desc,

--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -114,7 +114,7 @@ func (suite *operatorTestSuite) TestOperator() {
 		RemovePeer{FromStore: 3},
 	}
 	op := suite.newTestOperator(1, OpAdmin|OpLeader|OpRegion, steps...)
-	suite.Equal(core.HighPriority, op.GetPriorityLevel())
+	suite.Equal(core.VeryHigh, op.GetPriorityLevel())
 	suite.checkSteps(op, steps)
 	op.Start()
 	suite.Nil(op.Check(region))
@@ -130,6 +130,7 @@ func (suite *operatorTestSuite) TestOperator() {
 		RemovePeer{FromStore: 2},
 	}
 	op = suite.newTestOperator(1, OpLeader|OpRegion, steps...)
+	suite.Equal(core.Medium, op.GetPriorityLevel())
 	suite.checkSteps(op, steps)
 	op.Start()
 	suite.Equal(RemovePeer{FromStore: 2}, op.Check(region))

--- a/server/schedule/operator/operator_test.go
+++ b/server/schedule/operator/operator_test.go
@@ -114,7 +114,7 @@ func (suite *operatorTestSuite) TestOperator() {
 		RemovePeer{FromStore: 3},
 	}
 	op := suite.newTestOperator(1, OpAdmin|OpLeader|OpRegion, steps...)
-	suite.Equal(core.VeryHigh, op.GetPriorityLevel())
+	suite.Equal(core.Urgent, op.GetPriorityLevel())
 	suite.checkSteps(op, steps)
 	op.Start()
 	suite.Nil(op.Check(region))

--- a/server/schedule/operator_controller.go
+++ b/server/schedule/operator_controller.go
@@ -831,6 +831,10 @@ func (oc *OperatorController) ExceedStoreLimit(ops ...*operator.Operator) bool {
 
 // exceedStoreLimitLocked returns true if the store exceeds the cost limit after adding the operator. Otherwise, returns false.
 func (oc *OperatorController) exceedStoreLimitLocked(ops ...*operator.Operator) bool {
+	// The operator with Urgent priority, like admin operators, should ignore the store limit check.
+	if len(ops) != 0 && ops[0].GetPriorityLevel() == core.Urgent {
+		return false
+	}
 	opInfluence := NewTotalOpInfluence(ops, oc.cluster)
 	for storeID := range opInfluence.StoresInfluence {
 		for _, v := range storelimit.TypeNameValue {

--- a/server/schedule/region_scatterer.go
+++ b/server/schedule/region_scatterer.go
@@ -372,7 +372,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string) *
 	if op != nil {
 		scatterCounter.WithLabelValues("success", "").Inc()
 		r.Put(targetPeers, targetLeader, group)
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 	}
 	return op
 }

--- a/server/schedule/waiting_operator_test.go
+++ b/server/schedule/waiting_operator_test.go
@@ -42,12 +42,12 @@ func addOperators(wop WaitingOperator) {
 	op = operator.NewTestOperator(uint64(2), &metapb.RegionEpoch{}, operator.OpRegion, []operator.OpStep{
 		operator.RemovePeer{FromStore: uint64(2)},
 	}...)
-	op.SetPriorityLevel(core.HighPriority)
+	op.SetPriorityLevel(core.High)
 	wop.PutOperator(op)
 	op = operator.NewTestOperator(uint64(3), &metapb.RegionEpoch{}, operator.OpRegion, []operator.OpStep{
 		operator.RemovePeer{FromStore: uint64(3)},
 	}...)
-	op.SetPriorityLevel(core.LowPriority)
+	op.SetPriorityLevel(core.Low)
 	wop.PutOperator(op)
 }
 
@@ -101,7 +101,7 @@ func TestRandomBucketsWithMergeRegion(t *testing.T) {
 			operator.RemovePeer{FromStore: uint64(3)},
 		}...)
 		op.SetDesc("testOperatorHigh")
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 		rb.PutOperator(op)
 
 		for i := 0; i < 2; i++ {

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -348,7 +348,7 @@ func scheduleEvictLeaderOnce(name, typ string, cluster schedule.Cluster, conf ev
 			log.Debug("fail to create evict leader operator", errs.ZapError(err))
 			continue
 		}
-		op.SetPriorityLevel(core.High)
+		op.SetPriorityLevel(core.Urgent)
 		op.Counters = append(op.Counters, schedulerCounter.WithLabelValues(name, "new-operator"))
 		ops = append(ops, op)
 	}

--- a/server/schedulers/evict_leader.go
+++ b/server/schedulers/evict_leader.go
@@ -348,7 +348,7 @@ func scheduleEvictLeaderOnce(name, typ string, cluster schedule.Cluster, conf ev
 			log.Debug("fail to create evict leader operator", errs.ZapError(err))
 			continue
 		}
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 		op.Counters = append(op.Counters, schedulerCounter.WithLabelValues(name, "new-operator"))
 		ops = append(ops, op)
 	}

--- a/server/schedulers/grant_hot_region.go
+++ b/server/schedulers/grant_hot_region.go
@@ -388,5 +388,6 @@ func (s *grantHotRegionScheduler) transfer(cluster schedule.Cluster, regionID ui
 	} else {
 		op, err = operator.CreateMovePeerOperator(GrantHotRegionType+"-move", cluster, srcRegion, operator.OpRegion|operator.OpLeader, srcStore.GetID(), dstStore)
 	}
+	op.SetPriorityLevel(core.High)
 	return
 }

--- a/server/schedulers/grant_leader.go
+++ b/server/schedulers/grant_leader.go
@@ -252,7 +252,7 @@ func (s *grantLeaderScheduler) Schedule(cluster schedule.Cluster, dryRun bool) (
 			continue
 		}
 		op.Counters = append(op.Counters, schedulerCounter.WithLabelValues(s.GetName(), "new-operator"))
-		op.SetPriorityLevel(core.HighPriority)
+		op.SetPriorityLevel(core.High)
 		ops = append(ops, op)
 	}
 

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -1383,7 +1383,7 @@ func (bs *balanceSolver) createWriteOperator(region *core.RegionInfo, srcStoreID
 }
 
 func (bs *balanceSolver) decorateOperator(op *operator.Operator, isRevert bool, sourceLabel, targetLabel, typ, dim string) {
-	op.SetPriorityLevel(core.HighPriority)
+	op.SetPriorityLevel(core.High)
 	op.FinishedCounters = append(op.FinishedCounters,
 		hotDirectionCounter.WithLabelValues(typ, bs.rwTy.String(), sourceLabel, "out", dim),
 		hotDirectionCounter.WithLabelValues(typ, bs.rwTy.String(), targetLabel, "in", dim),

--- a/server/schedulers/random_merge.go
+++ b/server/schedulers/random_merge.go
@@ -137,6 +137,8 @@ func (s *randomMergeScheduler) Schedule(cluster schedule.Cluster, dryRun bool) (
 		log.Debug("fail to create merge region operator", errs.ZapError(err))
 		return nil, nil
 	}
+	ops[0].SetPriorityLevel(core.Low)
+	ops[1].SetPriorityLevel(core.Low)
 	ops[0].Counters = append(ops[0].Counters, schedulerCounter.WithLabelValues(s.GetName(), "new-operator"))
 	return ops, nil
 }

--- a/server/schedulers/shuffle_hot_region.go
+++ b/server/schedulers/shuffle_hot_region.go
@@ -209,6 +209,7 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster schedule.Cluster, loa
 			log.Debug("fail to create move leader operator", errs.ZapError(err))
 			return nil
 		}
+		op.SetPriorityLevel(core.Low)
 		op.Counters = append(op.Counters, schedulerCounter.WithLabelValues(s.GetName(), "new-operator"))
 		return []*operator.Operator{op}
 	}

--- a/server/schedulers/shuffle_leader.go
+++ b/server/schedulers/shuffle_leader.go
@@ -128,7 +128,7 @@ func (s *shuffleLeaderScheduler) Schedule(cluster schedule.Cluster, dryRun bool)
 		log.Debug("fail to create shuffle leader operator", errs.ZapError(err))
 		return nil, nil
 	}
-	op.SetPriorityLevel(core.HighPriority)
+	op.SetPriorityLevel(core.Low)
 	op.Counters = append(op.Counters, schedulerCounter.WithLabelValues(s.GetName(), "new-operator"))
 	return []*operator.Operator{op}, nil
 }

--- a/server/schedulers/shuffle_region.go
+++ b/server/schedulers/shuffle_region.go
@@ -124,7 +124,7 @@ func (s *shuffleRegionScheduler) Schedule(cluster schedule.Cluster, dryRun bool)
 		return nil, nil
 	}
 	op.Counters = append(op.Counters, schedulerCounter.WithLabelValues(s.GetName(), "new-operator"))
-	op.SetPriorityLevel(core.HighPriority)
+	op.SetPriorityLevel(core.Low)
 	return []*operator.Operator{op}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5388

### What is changed and how does it work?

This PR does the following things:
1. For admin operators, we use Urgent priority. These operators will also pass the store limit check.
2. For shuffle/random operators, which are used in the testing environment, we use Low priority.
3. For hot/replica/evict/grant operators, we use High priority.
4. The others use Medium priority.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
