### PR TITLE
schdeuler: Set resource with step for collecting plan

### DIFF
--- a/server/schedule/plan/plan.go
+++ b/server/schedule/plan/plan.go
@@ -23,6 +23,10 @@ type Plan interface {
 
 	Clone(ops ...Option) Plan // generate plan for clone option
 	SetResource(interface{})
+	// SetResourceWithStep is used to set resource for specific step.
+	// The meaning of step is different for different plans.
+	// Such as balancePlan, pickSource = 0, pickRegion = 1, pickTarget = 2
+	SetResourceWithStep(resource interface{}, step int)
 	SetStatus(*Status)
 }
 
@@ -81,5 +85,12 @@ func SetStatus(status *Status) Option {
 func SetResource(resource interface{}) Option {
 	return func(plan Plan) {
 		plan.SetResource(resource)
+	}
+}
+
+// SetResourceWithStep is used to generate Resource for plan
+func SetResourceWithStep(resource interface{}, step int) Option {
+	return func(plan Plan) {
+		plan.SetResourceWithStep(resource, step)
 	}
 }

--- a/server/schedulers/balance_plan.go
+++ b/server/schedulers/balance_plan.go
@@ -63,6 +63,11 @@ func (p *balanceSchedulerPlan) SetResource(resource interface{}) {
 	}
 }
 
+func (p *balanceSchedulerPlan) SetResourceWithStep(resource interface{}, step int) {
+	p.step = step
+	p.SetResource(resource)
+}
+
 func (p *balanceSchedulerPlan) GetResource(step int) uint64 {
 	if p.step < step {
 		return 0

--- a/server/schedulers/balance_plan_test.go
+++ b/server/schedulers/balance_plan_test.go
@@ -248,3 +248,27 @@ func (suite *balanceSchedulerPlanAnalyzeTestSuite) TestAnalyzerResult5() {
 			5: plan.NewStatus(plan.StatusCreateOperatorFailed),
 		}))
 }
+
+func (suite *balanceSchedulerPlanAnalyzeTestSuite) TestAnalyzerResult6() {
+	basePlan := NewBalanceSchedulerPlan()
+	collector := plan.NewCollector(basePlan)
+	collector.Collect(plan.SetResourceWithStep(suite.stores[0], 2), plan.SetStatus(plan.NewStatus(plan.StatusStoreDown)))
+	collector.Collect(plan.SetResourceWithStep(suite.stores[1], 2), plan.SetStatus(plan.NewStatus(plan.StatusStoreDown)))
+	collector.Collect(plan.SetResourceWithStep(suite.stores[2], 2), plan.SetStatus(plan.NewStatus(plan.StatusStoreDown)))
+	collector.Collect(plan.SetResourceWithStep(suite.stores[3], 2), plan.SetStatus(plan.NewStatus(plan.StatusStoreDown)))
+	collector.Collect(plan.SetResourceWithStep(suite.stores[4], 2), plan.SetStatus(plan.NewStatus(plan.StatusStoreDown)))
+	basePlan.source = suite.stores[0]
+	basePlan.step++
+	collector.Collect(plan.SetResource(suite.regions[0]), plan.SetStatus(plan.NewStatus(plan.StatusRegionNoLeader)))
+	statuses, isNormal, err := BalancePlanSummary(collector.GetPlans())
+	suite.NoError(err)
+	suite.False(isNormal)
+	suite.True(suite.check(statuses,
+		map[uint64]*plan.Status{
+			1: plan.NewStatus(plan.StatusStoreDown),
+			2: plan.NewStatus(plan.StatusStoreDown),
+			3: plan.NewStatus(plan.StatusStoreDown),
+			4: plan.NewStatus(plan.StatusStoreDown),
+			5: plan.NewStatus(plan.StatusStoreDown),
+		}))
+}


### PR DESCRIPTION
Signed-off-by: Cabinfever_B <cabinfeveroier@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5539
If we determine  which stores cannot be targets at the beginning of the scheduling,  we should set resource with step. 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
