### PR TITLE
simulator: support change peer v2

### DIFF
--- a/server/api/trend_test.go
+++ b/server/api/trend_test.go
@@ -62,7 +62,7 @@ func TestTrend(t *testing.T) {
 	newPeerID := op.Step(0).(operator.AddLearner).PeerID
 	region5 = region5.Clone(core.WithAddPeer(&metapb.Peer{Id: newPeerID, StoreId: 3, Role: metapb.PeerRole_Learner}), core.WithIncConfVer())
 	mustRegionHeartbeat(re, svr, region5)
-	region5 = region5.Clone(core.WithPromoteLearner(newPeerID), core.WithRemoveStorePeer(2), core.WithIncConfVer())
+	region5 = region5.Clone(core.WithRole(newPeerID, metapb.PeerRole_Voter), core.WithRemoveStorePeer(2), core.WithIncConfVer())
 	mustRegionHeartbeat(re, svr, region5)
 
 	op, err = svr.GetHandler().GetOperator(6)
@@ -71,7 +71,7 @@ func TestTrend(t *testing.T) {
 	newPeerID = op.Step(0).(operator.AddLearner).PeerID
 	region6 = region6.Clone(core.WithAddPeer(&metapb.Peer{Id: newPeerID, StoreId: 3, Role: metapb.PeerRole_Learner}), core.WithIncConfVer())
 	mustRegionHeartbeat(re, svr, region6)
-	region6 = region6.Clone(core.WithPromoteLearner(newPeerID), core.WithLeader(region6.GetStorePeer(2)), core.WithRemoveStorePeer(1), core.WithIncConfVer())
+	region6 = region6.Clone(core.WithRole(newPeerID, metapb.PeerRole_Voter), core.WithLeader(region6.GetStorePeer(2)), core.WithRemoveStorePeer(1), core.WithIncConfVer())
 	mustRegionHeartbeat(re, svr, region6)
 
 	var trend Trend

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -325,45 +325,12 @@ func WithAddPeer(peer *metapb.Peer) RegionCreateOption {
 	}
 }
 
-// WithPromoteLearner promotes the learner.
-func WithPromoteLearner(peerID uint64) RegionCreateOption {
+// WithRole changes the role.
+func WithRole(peerID uint64, role metapb.PeerRole) RegionCreateOption {
 	return func(region *RegionInfo) {
 		for _, p := range region.GetPeers() {
 			if p.GetId() == peerID {
-				p.Role = metapb.PeerRole_Voter
-			}
-		}
-	}
-}
-
-// WithPromoteLearnerEnter promotes the learner to the joint enter stage.
-func WithPromoteLearnerEnter(peerID uint64) RegionCreateOption {
-	return func(region *RegionInfo) {
-		for _, p := range region.GetPeers() {
-			if p.GetId() == peerID {
-				p.Role = metapb.PeerRole_IncomingVoter
-			}
-		}
-	}
-}
-
-// WithDemoteVoter demotes the voter.
-func WithDemoteVoter(peerID uint64) RegionCreateOption {
-	return func(region *RegionInfo) {
-		for _, p := range region.GetPeers() {
-			if p.GetId() == peerID {
-				p.Role = metapb.PeerRole_Learner
-			}
-		}
-	}
-}
-
-// WithDemoteVoterEnter demotes the voter to the joint enter stage.
-func WithDemoteVoterEnter(peerID uint64) RegionCreateOption {
-	return func(region *RegionInfo) {
-		for _, p := range region.GetPeers() {
-			if p.GetId() == peerID {
-				p.Role = metapb.PeerRole_DemotingVoter
+				p.Role = role
 			}
 		}
 	}

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -336,6 +336,39 @@ func WithPromoteLearner(peerID uint64) RegionCreateOption {
 	}
 }
 
+// WithPromoteLearnerEnter promotes the learner to the joint enter stage.
+func WithPromoteLearnerEnter(peerID uint64) RegionCreateOption {
+	return func(region *RegionInfo) {
+		for _, p := range region.GetPeers() {
+			if p.GetId() == peerID {
+				p.Role = metapb.PeerRole_IncomingVoter
+			}
+		}
+	}
+}
+
+// WithDemoteVoter demotes the voter.
+func WithDemoteVoter(peerID uint64) RegionCreateOption {
+	return func(region *RegionInfo) {
+		for _, p := range region.GetPeers() {
+			if p.GetId() == peerID {
+				p.Role = metapb.PeerRole_Learner
+			}
+		}
+	}
+}
+
+// WithDemoteVoterEnter demotes the voter to the joint enter stage.
+func WithDemoteVoterEnter(peerID uint64) RegionCreateOption {
+	return func(region *RegionInfo) {
+		for _, p := range region.GetPeers() {
+			if p.GetId() == peerID {
+				p.Role = metapb.PeerRole_DemotingVoter
+			}
+		}
+	}
+}
+
 // WithReplacePeerStore replaces a peer's storeID with another ID.
 func WithReplacePeerStore(oldStoreID, newStoreID uint64) RegionCreateOption {
 	return func(region *RegionInfo) {

--- a/server/schedule/operator_controller_test.go
+++ b/server/schedule/operator_controller_test.go
@@ -638,7 +638,7 @@ func (suite *operatorControllerTestSuite) TestDispatchUnfinishedStep() {
 		suite.Equal(2, stream.MsgLength())
 
 		region4 := region3.Clone(
-			core.WithPromoteLearner(3),
+			core.WithRole(3, metapb.PeerRole_Voter),
 			core.WithIncConfVer(),
 		)
 		suite.True(steps[1].IsFinish(region4))

--- a/tools/pd-simulator/simulator/task.go
+++ b/tools/pd-simulator/simulator/task.go
@@ -1,4 +1,4 @@
-// Copyright 2017 TiKV Project Authors.
+// Copyright 2022 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package simulator
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/docker/go-units"
@@ -25,19 +26,22 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/tools/pd-analysis/analysis"
+	"github.com/tikv/pd/tools/pd-simulator/simulator/simutil"
+	"go.uber.org/zap"
 )
 
-var (
-	chunkSize                = int64(4 * units.KiB)
-	maxSnapGeneratorPoolSize = uint32(2)
-	maxSnapReceivePoolSize   = uint32(4)
-	compressionRatio         = int64(2)
+const (
+	removeSpeed              = 100 * units.MiB
+	chunkSize                = 4 * units.KiB
+	maxSnapGeneratorPoolSize = 2
+	maxSnapReceivePoolSize   = 4
+	compressionRatio         = 2
 )
 
 type snapAction int
 
 const (
-	generate = iota
+	generate snapAction = iota
 	receive
 )
 
@@ -49,68 +53,418 @@ const (
 	finished
 )
 
-// Task running in node.
-type Task interface {
-	Desc() string
-	RegionID() uint64
-	Step(r *RaftEngine)
-	IsFinished() bool
+func responseToTask(engine *RaftEngine, resp *pdpb.RegionHeartbeatResponse) *Task {
+	var (
+		regionID = resp.GetRegionId()
+		region   = engine.GetRegion(regionID)
+		op       operator
+		desc     string
+	)
+
+	switch {
+	case resp.GetChangePeer() != nil:
+		op, desc = changePeerToOperator(region, resp.GetChangePeer())
+	case resp.GetChangePeerV2() != nil:
+		cps := resp.GetChangePeerV2().GetChanges()
+		if len(cps) == 0 {
+			desc = fmt.Sprintf("leave joint state for region %d", regionID)
+			op = &changePeerV2Leave{}
+		} else if len(cps) == 1 {
+			op, desc = changePeerToOperator(region, cps[0])
+		} else {
+			subDesc := make([]string, 0, len(cps))
+			cp2 := &changePeerV2Enter{}
+			for _, cp := range cps {
+				peer := cp.GetPeer()
+				subOp, _ := changePeerToOperator(region, cp)
+				switch subOp.(type) {
+				case *promoteLearner:
+					subDesc = append(subDesc, fmt.Sprintf("promote peer %+v", peer))
+					cp2.promoteLearners = append(cp2.promoteLearners, peer)
+				case *demoteVoter:
+					subDesc = append(subDesc, fmt.Sprintf("demote peer %+v", peer))
+					cp2.demoteVoters = append(cp2.demoteVoters, cp.GetPeer())
+				default:
+					simutil.Logger.Error("cannot exec AddPeer or RemovePeer when using joint state")
+					return nil
+				}
+			}
+			desc = fmt.Sprintf("%s for region %d", strings.Join(subDesc, ", "), regionID)
+			op = cp2
+		}
+	case resp.GetTransferLeader() != nil:
+		fromPeerStoreID := region.GetLeader().GetStoreId()
+		toPeers := resp.GetTransferLeader().GetPeers()
+		if len(toPeers) == 0 {
+			toPeers = []*metapb.Peer{resp.GetTransferLeader().GetPeer()}
+		}
+		desc = fmt.Sprintf("transfer leader from store %d to store %d", fromPeerStoreID, toPeers[0].GetStoreId())
+		op = &transferLeader{
+			fromPeerStoreID: fromPeerStoreID,
+			toPeers:         toPeers,
+		}
+	case resp.GetMerge() != nil:
+		targetRegion := resp.GetMerge().GetTarget()
+		desc = fmt.Sprintf("merge region %d into %d", regionID, targetRegion.GetId())
+		op = &mergeRegion{targetRegion: targetRegion}
+	case resp.GetSplitRegion() != nil:
+		// TODO: support split region
+		simutil.Logger.Error("split region scheduling is currently not supported")
+		return nil
+	default:
+		return nil
+	}
+
+	if op == nil {
+		return nil
+	}
+
+	return &Task{
+		operator:   op,
+		desc:       desc,
+		regionID:   regionID,
+		epoch:      resp.GetRegionEpoch(),
+		isFinished: false,
+	}
 }
 
-func responseToTask(resp *pdpb.RegionHeartbeatResponse, r *RaftEngine) Task {
-	regionID := resp.GetRegionId()
-	region := r.GetRegion(regionID)
-	epoch := resp.GetRegionEpoch()
-
-	//  change peer
-	if resp.GetChangePeer() != nil {
-		changePeer := resp.GetChangePeer()
-		switch changePeer.GetChangeType() {
-		case eraftpb.ConfChangeType_AddNode:
+func changePeerToOperator(region *core.RegionInfo, cp *pdpb.ChangePeer) (operator, string) {
+	regionID := region.GetID()
+	peer := cp.GetPeer()
+	switch cp.GetChangeType() {
+	case eraftpb.ConfChangeType_AddNode:
+		if region.GetPeer(peer.GetId()) == nil {
 			return &addPeer{
-				regionID: regionID,
-				epoch:    epoch,
-				peer:     changePeer.GetPeer(),
-			}
-		case eraftpb.ConfChangeType_RemoveNode:
-			return &removePeer{
-				regionID: regionID,
-				size:     region.GetApproximateSize(),
-				keys:     region.GetApproximateKeys(),
-				speed:    100 * 1000 * 1000,
-				epoch:    epoch,
-				peer:     changePeer.GetPeer(),
-			}
-		case eraftpb.ConfChangeType_AddLearnerNode:
-			return &addLearner{
-				regionID: regionID,
-				size:     region.GetApproximateSize(),
-				keys:     region.GetApproximateKeys(),
-				epoch:    epoch,
-				peer:     changePeer.GetPeer(),
-				// This two variables are used to simulate sending and receiving snapshot processes.
+				peer:          peer,
+				size:          region.GetApproximateSize(),
+				keys:          region.GetApproximateKeys(),
 				sendingStat:   newSnapshotState(region.GetApproximateSize(), generate),
 				receivingStat: newSnapshotState(region.GetApproximateSize(), receive),
-			}
+			}, fmt.Sprintf("add voter %+v for region %d", peer, regionID)
+		} else {
+			return &promoteLearner{peer: peer}, fmt.Sprintf("promote learner %+v for region %d", peer, regionID)
 		}
-	} else if resp.GetTransferLeader() != nil {
-		changePeer := resp.GetTransferLeader().GetPeer()
-		fromPeer := region.GetLeader()
-		return &transferLeader{
-			regionID: regionID,
-			epoch:    epoch,
-			fromPeer: fromPeer,
-			peer:     changePeer,
+	case eraftpb.ConfChangeType_AddLearnerNode:
+		if region.GetPeer(peer.GetId()) == nil {
+			return &addPeer{
+				peer:          peer,
+				size:          region.GetApproximateSize(),
+				keys:          region.GetApproximateKeys(),
+				sendingStat:   newSnapshotState(region.GetApproximateSize(), generate),
+				receivingStat: newSnapshotState(region.GetApproximateSize(), receive),
+			}, fmt.Sprintf("add learner %+v for region %d", peer, regionID)
+		} else {
+			return &demoteVoter{peer: peer}, fmt.Sprintf("demote voter %+v for region %d", peer, regionID)
 		}
-	} else if resp.GetMerge() != nil {
-		targetRegion := resp.GetMerge().GetTarget()
-		return &mergeRegion{
-			regionID:     regionID,
-			epoch:        epoch,
-			targetRegion: targetRegion,
+	case eraftpb.ConfChangeType_RemoveNode:
+		return &removePeer{
+			peer:  peer,
+			size:  region.GetApproximateSize(),
+			speed: removeSpeed,
+		}, fmt.Sprintf("remove peer %+v for region %d", peer, regionID)
+	default:
+		return nil, ""
+	}
+}
+
+// Simulate the execution of the Operator.
+type operator interface {
+	// Returns new region if the execution is finished, otherwise returns nil.
+	tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool)
+}
+
+type Task struct {
+	operator
+	desc       string
+	regionID   uint64
+	epoch      *metapb.RegionEpoch
+	isFinished bool
+}
+
+func (t *Task) Desc() string {
+	return t.desc
+}
+
+func (t *Task) RegionID() uint64 {
+	return t.regionID
+}
+
+func (t *Task) Step(engine *RaftEngine) (isFinished bool) {
+	if t.isFinished {
+		return true
+	}
+
+	region := engine.GetRegion(t.regionID)
+	if region == nil || region.GetRegionEpoch().GetConfVer() > t.epoch.ConfVer || region.GetRegionEpoch().GetVersion() > t.epoch.Version {
+		t.isFinished = true
+		return
+	}
+
+	var newRegion *core.RegionInfo
+	newRegion, t.isFinished = t.tick(engine, region)
+
+	if newRegion != nil {
+		engine.SetRegion(newRegion)
+		engine.recordRegionChange(newRegion)
+	}
+
+	return t.isFinished
+}
+
+type mergeRegion struct {
+	targetRegion *metapb.Region
+}
+
+func (m *mergeRegion) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	targetRegion := engine.GetRegion(m.targetRegion.Id)
+
+	var startKey, endKey []byte
+	if bytes.Equal(m.targetRegion.GetEndKey(), region.GetStartKey()) {
+		startKey = targetRegion.GetStartKey()
+		endKey = region.GetEndKey()
+	} else {
+		startKey = region.GetStartKey()
+		endKey = targetRegion.GetEndKey()
+	}
+
+	epoch := targetRegion.Clone().GetRegionEpoch()
+	if region.GetRegionEpoch().GetConfVer() > epoch.GetConfVer() {
+		epoch.ConfVer = region.GetRegionEpoch().GetConfVer()
+	}
+	if region.GetRegionEpoch().GetVersion() > epoch.GetVersion() {
+		epoch.Version = region.GetRegionEpoch().GetVersion()
+	}
+	epoch.Version++
+
+	newRegion = targetRegion.Clone(
+		core.WithStartKey(startKey),
+		core.WithEndKey(endKey),
+		core.SetRegionConfVer(epoch.ConfVer),
+		core.SetRegionVersion(epoch.Version),
+		core.SetApproximateSize(targetRegion.GetApproximateSize()+region.GetApproximateSize()),
+		core.SetApproximateKeys(targetRegion.GetApproximateKeys()+region.GetApproximateKeys()),
+	)
+	engine.schedulerStats.taskStats.incMergeRegion()
+	return newRegion, true
+}
+
+type transferLeader struct {
+	fromPeerStoreID uint64
+	toPeers         []*metapb.Peer
+}
+
+func (t *transferLeader) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	isFinished = true
+	toPeer := t.toPeers[0]
+	if region.GetPeer(toPeer.GetId()) == nil {
+		return
+	}
+
+	newRegion = region.Clone(core.WithLeader(toPeer))
+	engine.schedulerStats.taskStats.incTransferLeader(t.fromPeerStoreID, toPeer.GetStoreId())
+	return
+}
+
+func checkAndCreateChangePeerOption(engine *RaftEngine, region *core.RegionInfo,
+	peer *metapb.Peer, from, to metapb.PeerRole) []core.RegionCreateOption {
+	if peer.GetRole() != from {
+		simutil.Logger.Error(
+			"unexpected role",
+			zap.String("role", peer.GetRole().String()),
+			zap.String("expected", from.String()))
+		return nil
+	}
+
+	opts := []core.RegionCreateOption{core.WithIncConfVer()}
+	switch to {
+	case metapb.PeerRole_Voter:
+		engine.schedulerStats.taskStats.incPromoteLearner(region.GetID())
+		return append(opts, core.WithPromoteLearner(peer.GetId()))
+	case metapb.PeerRole_Learner:
+		engine.schedulerStats.taskStats.incDemoteVoter(region.GetID())
+		return append(opts, core.WithDemoteVoter(peer.GetId()))
+	case metapb.PeerRole_IncomingVoter:
+		return append(opts, core.WithPromoteLearnerEnter(peer.GetId()))
+	case metapb.PeerRole_DemotingVoter:
+		return append(opts, core.WithDemoteVoterEnter(peer.GetId()))
+	default:
+		return nil
+	}
+}
+
+type promoteLearner struct {
+	peer *metapb.Peer
+}
+
+func (pl *promoteLearner) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	isFinished = true
+	peer := region.GetPeer(pl.peer.GetId())
+	opts := checkAndCreateChangePeerOption(engine, region, peer, metapb.PeerRole_Learner, metapb.PeerRole_Voter)
+	if len(opts) > 0 {
+		newRegion = region.Clone(opts...)
+	}
+	return
+}
+
+type demoteVoter struct {
+	peer *metapb.Peer
+}
+
+func (dv *demoteVoter) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	isFinished = true
+	peer := region.GetPeer(dv.peer.GetId())
+	opts := checkAndCreateChangePeerOption(engine, region, peer, metapb.PeerRole_Voter, metapb.PeerRole_Learner)
+	if len(opts) > 0 {
+		newRegion = region.Clone(opts...)
+	}
+	return
+}
+
+type changePeerV2Enter struct {
+	promoteLearners []*metapb.Peer
+	demoteVoters    []*metapb.Peer
+}
+
+func (ce *changePeerV2Enter) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	isFinished = true
+	var opts []core.RegionCreateOption
+	for _, pl := range ce.promoteLearners {
+		peer := region.GetPeer(pl.GetId())
+		subOpts := checkAndCreateChangePeerOption(engine, region, peer, metapb.PeerRole_Learner, metapb.PeerRole_IncomingVoter)
+		if len(subOpts) == 0 {
+			return
+		}
+		opts = append(opts, subOpts...)
+	}
+	for _, dv := range ce.demoteVoters {
+		peer := region.GetPeer(dv.GetId())
+		subOpts := checkAndCreateChangePeerOption(engine, region, peer, metapb.PeerRole_Voter, metapb.PeerRole_DemotingVoter)
+		if len(subOpts) == 0 {
+			return
+		}
+		opts = append(opts, subOpts...)
+	}
+	newRegion = region.Clone(opts...)
+	return
+}
+
+type changePeerV2Leave struct{}
+
+func (cl *changePeerV2Leave) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	isFinished = true
+	var opts []core.RegionCreateOption
+	for _, peer := range region.GetPeers() {
+		switch peer.GetRole() {
+		case metapb.PeerRole_IncomingVoter:
+			opts = append(opts, checkAndCreateChangePeerOption(engine, region, peer, metapb.PeerRole_IncomingVoter, metapb.PeerRole_Voter)...)
+		case metapb.PeerRole_DemotingVoter:
+			opts = append(opts, checkAndCreateChangePeerOption(engine, region, peer, metapb.PeerRole_IncomingVoter, metapb.PeerRole_Voter)...)
 		}
 	}
-	return nil
+	if len(opts) < 4 {
+		simutil.Logger.Error("fewer than two peers should not need to leave the joint state")
+		return
+	}
+	newRegion = region.Clone(opts...)
+	return
+}
+
+type addPeer struct {
+	peer          *metapb.Peer
+	size          int64
+	keys          int64
+	sendingStat   *snapshotStat
+	receivingStat *snapshotStat
+}
+
+func (a *addPeer) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	// Check
+	sendNode := engine.conn.Nodes[region.GetLeader().GetStoreId()]
+	if sendNode == nil {
+		return nil, true
+	}
+	recvNode := engine.conn.Nodes[a.peer.GetStoreId()]
+	if recvNode == nil {
+		return nil, true
+	}
+	// Step 1: Generate Pending Peers
+	if region.GetPeer(a.peer.GetId()) == nil {
+		switch a.peer.GetRole() {
+		case metapb.PeerRole_Voter:
+			engine.schedulerStats.taskStats.incAddVoter(region.GetID())
+		case metapb.PeerRole_Learner:
+			engine.schedulerStats.taskStats.incAddLearner(region.GetID())
+		}
+		pendingPeers := append(region.GetPendingPeers(), a.peer)
+		return region.Clone(core.WithAddPeer(a.peer), core.WithIncConfVer(), core.WithPendingPeers(pendingPeers)), false
+	}
+	// Step 2: Process Snapshot
+	if !processSnapshot(sendNode, a.sendingStat) {
+		return nil, false
+	}
+	engine.schedulerStats.snapshotStats.incSendSnapshot(sendNode.Id)
+	if !processSnapshot(recvNode, a.receivingStat) {
+		return nil, false
+	}
+	engine.schedulerStats.snapshotStats.incReceiveSnapshot(recvNode.Id)
+	recvNode.incUsedSize(uint64(region.GetApproximateSize()))
+	// Step 3: Remove the Pending state
+	newRegion = region.Clone(removePendingPeer(region, a.peer))
+	isFinished = true
+
+	// analysis
+	if analysis.GetTransferCounter().IsValid {
+		analysis.GetTransferCounter().AddTarget(region.GetID(), a.peer.GetStoreId())
+	}
+
+	return
+}
+
+type removePeer struct {
+	peer  *metapb.Peer
+	size  int64
+	speed int64
+}
+
+func (r *removePeer) tick(engine *RaftEngine, region *core.RegionInfo) (newRegion *core.RegionInfo, isFinished bool) {
+	// Step 1: Delete data
+	r.size -= r.speed
+	if r.size > 0 {
+		return nil, false
+	}
+	// Step 2: Remove Peer
+	newRegion = region.Clone(
+		core.WithIncConfVer(),
+		core.WithRemoveStorePeer(r.peer.GetStoreId()),
+		removePendingPeer(region, r.peer),
+		removeDownPeers(region, r.peer))
+	isFinished = true
+	// analysis
+	if analysis.GetTransferCounter().IsValid {
+		analysis.GetTransferCounter().AddSource(region.GetID(), r.peer.GetStoreId())
+	}
+
+	return
+}
+
+func removePendingPeer(region *core.RegionInfo, removePeer *metapb.Peer) core.RegionCreateOption {
+	pendingPeers := make([]*metapb.Peer, 0, len(region.GetPendingPeers()))
+	for _, peer := range region.GetPendingPeers() {
+		if peer.GetId() != removePeer.GetId() {
+			pendingPeers = append(pendingPeers, peer)
+		}
+	}
+	return core.WithPendingPeers(pendingPeers)
+}
+
+func removeDownPeers(region *core.RegionInfo, removePeer *metapb.Peer) core.RegionCreateOption {
+	downPeers := make([]*pdpb.PeerStats, 0, len(region.GetDownPeers()))
+	for _, peer := range region.GetDownPeers() {
+		if peer.GetPeer().GetId() != removePeer.GetId() {
+			downPeers = append(downPeers, peer)
+		}
+	}
+	return core.WithDownPeers(downPeers)
 }
 
 type snapshotStat struct {
@@ -130,299 +484,6 @@ func newSnapshotState(size int64, action snapAction) *snapshotStat {
 		status:     pending,
 		start:      time.Now(),
 	}
-}
-
-type mergeRegion struct {
-	regionID     uint64
-	epoch        *metapb.RegionEpoch
-	targetRegion *metapb.Region
-	finished     bool
-}
-
-func (m *mergeRegion) Desc() string {
-	return fmt.Sprintf("merge region %d into %d", m.regionID, m.targetRegion.GetId())
-}
-
-func (m *mergeRegion) Step(r *RaftEngine) {
-	if m.finished {
-		return
-	}
-
-	region := r.GetRegion(m.regionID)
-	// If region equals to nil, it means that the region has already been merged.
-	if region == nil || region.GetRegionEpoch().GetConfVer() > m.epoch.ConfVer || region.GetRegionEpoch().GetVersion() > m.epoch.Version {
-		m.finished = true
-		return
-	}
-
-	targetRegion := r.GetRegion(m.targetRegion.Id)
-	var startKey, endKey []byte
-	if bytes.Equal(m.targetRegion.EndKey, region.GetStartKey()) {
-		startKey = targetRegion.GetStartKey()
-		endKey = region.GetEndKey()
-	} else {
-		startKey = region.GetStartKey()
-		endKey = targetRegion.GetEndKey()
-	}
-
-	epoch := targetRegion.GetRegionEpoch()
-	if m.epoch.ConfVer > m.targetRegion.RegionEpoch.ConfVer {
-		epoch.ConfVer = m.epoch.ConfVer
-	}
-
-	if m.epoch.Version > m.targetRegion.RegionEpoch.Version {
-		epoch.Version = m.epoch.Version
-	}
-	epoch.Version++
-	mergeRegion := targetRegion.Clone(
-		core.WithStartKey(startKey),
-		core.WithEndKey(endKey),
-		core.SetRegionConfVer(epoch.ConfVer),
-		core.SetRegionVersion(epoch.Version),
-		core.SetApproximateSize(targetRegion.GetApproximateSize()+region.GetApproximateSize()),
-		core.SetApproximateKeys(targetRegion.GetApproximateKeys()+region.GetApproximateKeys()),
-	)
-	r.SetRegion(mergeRegion)
-	r.recordRegionChange(mergeRegion)
-	r.schedulerStats.taskStats.incMergeRegion()
-	m.finished = true
-}
-
-func (m *mergeRegion) RegionID() uint64 {
-	return m.regionID
-}
-
-func (m *mergeRegion) IsFinished() bool {
-	return m.finished
-}
-
-type transferLeader struct {
-	regionID uint64
-	epoch    *metapb.RegionEpoch
-	fromPeer *metapb.Peer
-	peer     *metapb.Peer
-	finished bool
-}
-
-func (t *transferLeader) Desc() string {
-	return fmt.Sprintf("transfer leader from store %d to store %d", t.fromPeer.GetStoreId(), t.peer.GetStoreId())
-}
-
-func (t *transferLeader) Step(r *RaftEngine) {
-	if t.finished {
-		return
-	}
-	region := r.GetRegion(t.regionID)
-	if region.GetRegionEpoch().GetVersion() > t.epoch.Version || region.GetRegionEpoch().GetConfVer() > t.epoch.ConfVer {
-		t.finished = true
-		return
-	}
-	var newRegion *core.RegionInfo
-	if region.GetPeer(t.peer.GetId()) != nil {
-		newRegion = region.Clone(core.WithLeader(t.peer))
-	} else {
-		// This branch will be executed
-		t.finished = true
-		return
-	}
-	t.finished = true
-	r.SetRegion(newRegion)
-	r.recordRegionChange(newRegion)
-	fromPeerID := t.fromPeer.GetId()
-	toPeerID := t.peer.GetId()
-	r.schedulerStats.taskStats.incTransferLeader(fromPeerID, toPeerID)
-}
-
-func (t *transferLeader) RegionID() uint64 {
-	return t.regionID
-}
-
-func (t *transferLeader) IsFinished() bool {
-	return t.finished
-}
-
-type addPeer struct {
-	regionID uint64
-	epoch    *metapb.RegionEpoch
-	peer     *metapb.Peer
-	finished bool
-}
-
-func (a *addPeer) Desc() string {
-	return fmt.Sprintf("add peer %+v for region %d", a.peer, a.regionID)
-}
-
-func (a *addPeer) Step(r *RaftEngine) {
-	if a.finished {
-		return
-	}
-	region := r.GetRegion(a.regionID)
-	if region.GetRegionEpoch().GetVersion() > a.epoch.Version || region.GetRegionEpoch().GetConfVer() > a.epoch.ConfVer {
-		a.finished = true
-		return
-	}
-
-	var opts []core.RegionCreateOption
-	if region.GetPeer(a.peer.GetId()) == nil {
-		opts = append(opts, core.WithAddPeer(a.peer))
-		r.schedulerStats.taskStats.incAddPeer(region.GetID())
-	} else {
-		opts = append(opts, core.WithPromoteLearner(a.peer.GetId()))
-		r.schedulerStats.taskStats.incPromoteLeaner(region.GetID())
-	}
-	opts = append(opts, core.WithIncConfVer())
-	newRegion := region.Clone(opts...)
-	r.SetRegion(newRegion)
-	r.recordRegionChange(newRegion)
-	a.finished = true
-}
-
-func (a *addPeer) RegionID() uint64 {
-	return a.regionID
-}
-
-func (a *addPeer) IsFinished() bool {
-	return a.finished
-}
-
-type removePeer struct {
-	regionID uint64
-	size     int64
-	keys     int64
-	speed    int64
-	epoch    *metapb.RegionEpoch
-	peer     *metapb.Peer
-	finished bool
-}
-
-func (a *removePeer) Desc() string {
-	return fmt.Sprintf("remove peer %+v for region %d", a.peer, a.regionID)
-}
-
-func (a *removePeer) Step(r *RaftEngine) {
-	if a.finished {
-		return
-	}
-	region := r.GetRegion(a.regionID)
-	if region.GetRegionEpoch().GetVersion() > a.epoch.Version || region.GetRegionEpoch().GetConfVer() > a.epoch.ConfVer {
-		a.finished = true
-		return
-	}
-
-	regionSize := uint64(region.GetApproximateSize())
-	a.size -= a.speed
-	if a.size < 0 {
-		for _, peer := range region.GetPeers() {
-			if peer.GetId() == a.peer.GetId() {
-				storeID := peer.GetStoreId()
-				var downPeers []*pdpb.PeerStats
-				if r.conn.Nodes[storeID] == nil {
-					for _, downPeer := range region.GetDownPeers() {
-						if downPeer.Peer.StoreId != storeID {
-							downPeers = append(downPeers, downPeer)
-						}
-					}
-				}
-				newRegion := region.Clone(
-					core.WithRemoveStorePeer(storeID),
-					core.WithIncConfVer(),
-					core.WithDownPeers(downPeers),
-				)
-				r.SetRegion(newRegion)
-				r.recordRegionChange(newRegion)
-				r.schedulerStats.taskStats.incRemovePeer(region.GetID())
-				if r.conn.Nodes[storeID] == nil {
-					a.finished = true
-					return
-				}
-				r.conn.Nodes[storeID].decUsedSize(regionSize)
-				break
-			}
-		}
-		a.finished = true
-		if analysis.GetTransferCounter().IsValid {
-			analysis.GetTransferCounter().AddSource(a.regionID, a.peer.StoreId)
-		}
-	}
-}
-
-func (a *removePeer) RegionID() uint64 {
-	return a.regionID
-}
-
-func (a *removePeer) IsFinished() bool {
-	return a.finished
-}
-
-type addLearner struct {
-	regionID      uint64
-	size          int64
-	keys          int64
-	epoch         *metapb.RegionEpoch
-	peer          *metapb.Peer
-	finished      bool
-	sendingStat   *snapshotStat
-	receivingStat *snapshotStat
-}
-
-func (a *addLearner) Desc() string {
-	return fmt.Sprintf("add learner %+v for region %d", a.peer, a.regionID)
-}
-
-func (a *addLearner) Step(r *RaftEngine) {
-	if a.finished {
-		return
-	}
-	region := r.GetRegion(a.regionID)
-	if region.GetRegionEpoch().GetVersion() > a.epoch.Version || region.GetRegionEpoch().GetConfVer() > a.epoch.ConfVer {
-		a.finished = true
-		return
-	}
-
-	snapshotSize := region.GetApproximateSize()
-	sendNode := r.conn.Nodes[region.GetLeader().GetStoreId()]
-	if sendNode == nil {
-		a.finished = true
-		return
-	}
-	if !processSnapshot(sendNode, a.sendingStat) {
-		return
-	}
-	r.schedulerStats.snapshotStats.incSendSnapshot(sendNode.Id)
-
-	recvNode := r.conn.Nodes[a.peer.GetStoreId()]
-	if recvNode == nil {
-		a.finished = true
-		return
-	}
-	if !processSnapshot(recvNode, a.receivingStat) {
-		return
-	}
-	r.schedulerStats.snapshotStats.incReceiveSnapshot(recvNode.Id)
-
-	if region.GetPeer(a.peer.GetId()) == nil {
-		newRegion := region.Clone(
-			core.WithAddPeer(a.peer),
-			core.WithIncConfVer(),
-		)
-		r.SetRegion(newRegion)
-		r.recordRegionChange(newRegion)
-		r.schedulerStats.taskStats.incAddLeaner(region.GetID())
-		recvNode.incUsedSize(uint64(snapshotSize))
-		a.finished = true
-	}
-
-	if analysis.GetTransferCounter().IsValid {
-		analysis.GetTransferCounter().AddTarget(a.regionID, a.peer.StoreId)
-	}
-}
-
-func (a *addLearner) RegionID() uint64 {
-	return a.regionID
-}
-
-func (a *addLearner) IsFinished() bool {
-	return a.finished
 }
 
 func processSnapshot(n *Node, stat *snapshotStat) bool {

--- a/tools/pd-simulator/simulator/task.go
+++ b/tools/pd-simulator/simulator/task.go
@@ -1,4 +1,4 @@
-// Copyright 2022 TiKV Project Authors.
+// Copyright 2017 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -295,21 +295,17 @@ func checkAndCreateChangePeerOption(engine *RaftEngine, region *core.RegionInfo,
 		return nil
 	}
 	// create option
-	opts := []core.RegionCreateOption{core.WithIncConfVer()}
 	switch to {
 	case metapb.PeerRole_Voter: // Learner/IncomingVoter -> Voter
 		engine.schedulerStats.taskStats.incPromoteLearner(region.GetID())
-		return append(opts, core.WithPromoteLearner(peer.GetId()))
 	case metapb.PeerRole_Learner: // Voter/DemotingVoter -> Learner
 		engine.schedulerStats.taskStats.incDemoteVoter(region.GetID())
-		return append(opts, core.WithDemoteVoter(peer.GetId()))
 	case metapb.PeerRole_IncomingVoter: // Learner -> IncomingVoter, only in joint state
-		return append(opts, core.WithPromoteLearnerEnter(peer.GetId()))
 	case metapb.PeerRole_DemotingVoter: // Voter -> DemotingVoter, only in joint state
-		return append(opts, core.WithDemoteVoterEnter(peer.GetId()))
 	default:
 		return nil
 	}
+	return []core.RegionCreateOption{core.WithRole(peer.GetId(), to), core.WithIncConfVer()}
 }
 
 type promoteLearner struct {

--- a/tools/pd-simulator/simulator/task.go
+++ b/tools/pd-simulator/simulator/task.go
@@ -86,7 +86,7 @@ func responseToTask(engine *RaftEngine, resp *pdpb.RegionHeartbeatResponse) *Tas
 					cp2.promoteLearners = append(cp2.promoteLearners, peer)
 				case *demoteVoter:
 					subDesc = append(subDesc, fmt.Sprintf("demote peer %+v", peer))
-					cp2.demoteVoters = append(cp2.demoteVoters, cp.GetPeer())
+					cp2.demoteVoters = append(cp2.demoteVoters, peer)
 				default:
 					simutil.Logger.Error("cannot exec AddPeer or RemovePeer when using joint state")
 					return nil


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5469 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

Refactor `task.go`

* Split `AddVoter` and `PromoteLearner`
* Merge `AddVoter` and `AddLearner`
  * `PendingPeer` will now be added first, and will be removed after the simulated snap transfer is complete.
* Support original `ChangePeer` in v2 (`ChangePeerV2` and `len(Changes) == 1`)
  * Support `DemoteVoter`, and check if the Peer is not the Leader
* Support enter joint state (`ChangePeerV2` and `len(Changes) > 1`)
* Support leave joint state (`ChangePeerV2` and `len(Changes) == 0`)
* `TransferLeader` adds `Voter` checks
* `TransferLeader` supports the parsing field `Peers` (used to let TiKV find the optimal Peer by itself)
* `RemovePeer` now always also removes the corresponding `DownPeer` and `PendingPeer`

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
