### PR TITLE
metrics: Add check for unhealthy stores

### DIFF
--- a/metrics/alertmanager/pd.rules.yml
+++ b/metrics/alertmanager/pd.rules.yml
@@ -49,6 +49,21 @@ groups:
       value: '{{ $value }}'
       summary: PD_cluster_lost_connect_tikv_nums
 
+  - alert: PD_cluster_unhealthy_tikv_nums
+    expr: (sum ( pd_cluster_status{type="store_unhealth_count"} ) by (instance)
+      > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
+    for: 1m
+    labels:
+      env: ENV_LABELS_ENV
+      expr: (sum ( pd_cluster_status{type="store_unhealth_count"} ) by (instance)
+        > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
+      level: warning
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{
+        $value }}'
+      summary: PD_cluster_unhealth_tikv_nums
+      value: '{{ $value }}'
+
   - alert: PD_cluster_low_space
     expr: (sum(pd_cluster_status{type="store_low_space_count"}) by (instance) > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m


### PR DESCRIPTION
### What problem does this PR solve?

When the filesystem of a TiKV node of a v5.3.0 cluster becomes read-only (e.g. due to filesystem errors, or simulated with `fsfreeze(8)` it seems to `store_disconneced_count` for 10m and then to `store_unhealth_count` for another 20m before eventually ending up in `store_down_count`.

Issue Number: Close #5611

See also https://github.com/pingcap/monitoring/pull/172

### What is changed and how does it work?

It looks like there isn't a check for `store_unhealth_count`, so that's what this PR tries to add.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
