### PR TITLE
Add jq for region check command

### DIFF
--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -51,7 +51,7 @@ var (
 // NewRegionCommand returns a region subcommand of rootCmd
 func NewRegionCommand() *cobra.Command {
 	r := &cobra.Command{
-		Use:   `region <region_id> [-jq="<query string>"]`,
+		Use:   `region <region_id> [--jq="<query string>"]`,
 		Short: "show the region status",
 		Run:   showRegionCommandFunc,
 	}
@@ -354,10 +354,12 @@ func showRegionsByKeysCommandFunc(cmd *cobra.Command, args []string) {
 // NewRegionWithCheckCommand returns a region with check subcommand of regionCmd
 func NewRegionWithCheckCommand() *cobra.Command {
 	r := &cobra.Command{
-		Use:   "check [miss-peer|extra-peer|down-peer|learner-peer|pending-peer|offline-peer|empty-region|oversized-region|undersized-region|hist-size|hist-keys]",
+		Use:   `check [miss-peer|extra-peer|down-peer|learner-peer|pending-peer|offline-peer|empty-region|oversized-region|undersized-region|hist-size|hist-keys] [--jq="<query string>"]`,
 		Short: "show the region with check specific status",
 		Run:   showRegionWithCheckCommandFunc,
 	}
+
+	r.Flags().String("jq", "", "jq query")
 	return r
 }
 
@@ -394,6 +396,11 @@ func showRegionWithCheckCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Printf("Failed to get region: %s\n", err)
 		return
 	}
+	if flag := cmd.Flag("jq"); flag != nil && flag.Value.String() != "" {
+		printWithJQFilter(r, flag.Value.String())
+		return
+	}
+
 	cmd.Println(r)
 }
 


### PR DESCRIPTION
Signed-off-by: Hua Lu <hualu@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?
Issue Number: Close #5585 

### What is changed and how does it work?
```commit-message
- parse response string with jq query
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)
  - Build pd-ctl
  - Execute `pd-ctl region check empty-region --jq=".regions[].id"` and check the result
![image](https://user-images.githubusercontent.com/74505524/197402018-8e961a40-45bc-4aa6-8d8d-4778a039c5f0.png)


Code changes

Side effects

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):

### Release note
None
