### PR TITLE
*: reduce call when comparing key

### DIFF
--- a/pkg/rangetree/range_tree.go
+++ b/pkg/rangetree/range_tree.go
@@ -76,9 +76,10 @@ func (r *RangeTree) GetOverlaps(item RangeItem) []RangeItem {
 	}
 
 	var overlaps []RangeItem
+	endKey := item.GetEndKey()
 	r.tree.AscendGreaterOrEqual(result, func(i btree.Item) bool {
 		over := i.(RangeItem)
-		if len(item.GetEndKey()) > 0 && bytes.Compare(item.GetEndKey(), over.GetStartKey()) <= 0 {
+		if len(endKey) > 0 && bytes.Compare(endKey, over.GetStartKey()) <= 0 {
 			return false
 		}
 		overlaps = append(overlaps, over)

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -702,7 +702,7 @@ func (rm regionMap) Get(id uint64) *regionItem {
 // If the regionItem already exists, it will be overwritten.
 // Note: Do not use this function when you only need to update the RegionInfo and do not need a new regionItem.
 func (rm regionMap) AddNew(region *RegionInfo) *regionItem {
-	item := &regionItem{region: region}
+	item := &regionItem{RegionInfo: region}
 	rm[region.GetID()] = item
 	return item
 }
@@ -738,7 +738,7 @@ func NewRegionsInfo() *RegionsInfo {
 // GetRegion returns the RegionInfo with regionID
 func (r *RegionsInfo) GetRegion(regionID uint64) *RegionInfo {
 	if item := r.regions.Get(regionID); item != nil {
-		return item.region
+		return item.RegionInfo
 	}
 	return nil
 }
@@ -750,7 +750,7 @@ func (r *RegionsInfo) SetRegion(region *RegionInfo) (overlaps []*RegionInfo) {
 	rangeChanged := true // This Region is new, or its range has changed.
 	if item = r.regions.Get(region.GetID()); item != nil {
 		// If this ID already exists, use the existing regionItem and pick out the origin.
-		origin := item.region
+		origin := item.RegionInfo
 		rangeChanged = !origin.rangeEqualsTo(region)
 		if rangeChanged {
 			// Delete itself in regionTree so that overlaps will not contain itself.
@@ -765,14 +765,14 @@ func (r *RegionsInfo) SetRegion(region *RegionInfo) (overlaps []*RegionInfo) {
 			// If the peers are not changed, only the statistical on the sub regionTree needs to be updated.
 			r.updateSubTreeStat(origin, region)
 			// Update the RegionInfo in the regionItem.
-			item.region = region
+			item.RegionInfo = region
 			return
 		}
 		// If the range or peers have changed, the sub regionTree needs to be cleaned up.
 		// TODO: Improve performance by deleting only the different peers.
 		r.removeRegionFromSubTree(origin)
 		// Update the RegionInfo in the regionItem.
-		item.region = region
+		item.RegionInfo = region
 	} else {
 		// If this ID does not exist, generate a new regionItem and save it in the regionMap.
 		item = r.regions.AddNew(region)
@@ -963,7 +963,7 @@ func (r *RegionsInfo) GetPrevRegionByKey(regionKey []byte) *RegionInfo {
 func (r *RegionsInfo) GetRegions() []*RegionInfo {
 	regions := make([]*RegionInfo, 0, r.regions.Len())
 	for _, item := range r.regions {
-		regions = append(regions, item.region)
+		regions = append(regions, item.RegionInfo)
 	}
 	return regions
 }
@@ -1027,7 +1027,7 @@ func (r *RegionsInfo) GetStoreWriteRate(storeID uint64) (bytesRate, keysRate flo
 func (r *RegionsInfo) GetMetaRegions() []*metapb.Region {
 	regions := make([]*metapb.Region, 0, r.regions.Len())
 	for _, item := range r.regions {
-		regions = append(regions, typeutil.DeepClone(item.region.meta, RegionFactory))
+		regions = append(regions, typeutil.DeepClone(item.meta, RegionFactory))
 	}
 	return regions
 }
@@ -1110,7 +1110,7 @@ func (r *RegionsInfo) RandLearnerRegions(storeID uint64, ranges []KeyRange, n in
 // GetLeader returns leader RegionInfo by storeID and regionID (now only used in test)
 func (r *RegionsInfo) GetLeader(storeID uint64, region *RegionInfo) *RegionInfo {
 	if leaders, ok := r.leaders[storeID]; ok {
-		return leaders.find(region).region
+		return leaders.find(region).RegionInfo
 	}
 	return nil
 }
@@ -1118,7 +1118,7 @@ func (r *RegionsInfo) GetLeader(storeID uint64, region *RegionInfo) *RegionInfo 
 // GetFollower returns follower RegionInfo by storeID and regionID (now only used in test)
 func (r *RegionsInfo) GetFollower(storeID uint64, region *RegionInfo) *RegionInfo {
 	if followers, ok := r.followers[storeID]; ok {
-		return followers.find(region).region
+		return followers.find(region).RegionInfo
 	}
 	return nil
 }
@@ -1215,11 +1215,11 @@ func (r *RegionsInfo) GetAdjacentRegions(region *RegionInfo) (*RegionInfo, *Regi
 	p, n := r.tree.getAdjacentRegions(region)
 	var prev, next *RegionInfo
 	// check key to avoid key range hole
-	if p != nil && bytes.Equal(p.region.GetEndKey(), region.GetStartKey()) {
-		prev = r.GetRegion(p.region.GetID())
+	if p != nil && bytes.Equal(p.GetEndKey(), region.GetStartKey()) {
+		prev = r.GetRegion(p.GetID())
 	}
-	if n != nil && bytes.Equal(region.GetEndKey(), n.region.GetStartKey()) {
-		next = r.GetRegion(n.region.GetID())
+	if n != nil && bytes.Equal(region.GetEndKey(), n.GetStartKey()) {
+		next = r.GetRegion(n.GetID())
 	}
 	return prev, next
 }

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -401,7 +401,7 @@ func regionInfo(id uint64) *RegionInfo {
 func check(re *require.Assertions, rm regionMap, ids ...uint64) {
 	// Check Get.
 	for _, id := range ids {
-		re.Equal(id, rm.Get(id).region.GetID())
+		re.Equal(id, rm.Get(id).GetID())
 	}
 	// Check Len.
 	re.Equal(len(ids), rm.Len())
@@ -412,7 +412,7 @@ func check(re *require.Assertions, rm regionMap, ids ...uint64) {
 	}
 	set1 := make(map[uint64]struct{})
 	for _, r := range rm {
-		set1[r.region.GetID()] = struct{}{}
+		set1[r.GetID()] = struct{}{}
 	}
 	re.Equal(expect, set1)
 }

--- a/server/core/region_tree_test.go
+++ b/server/core/region_tree_test.go
@@ -185,28 +185,28 @@ func TestRegionTree(t *testing.T) {
 	// check get adjacent regions
 	prev, next := tree.getAdjacentRegions(regionA)
 	re.Nil(prev)
-	re.Equal(regionB, next.region)
+	re.Equal(regionB, next.RegionInfo)
 	prev, next = tree.getAdjacentRegions(regionB)
-	re.Equal(regionA, prev.region)
-	re.Equal(regionD, next.region)
+	re.Equal(regionA, prev.RegionInfo)
+	re.Equal(regionD, next.RegionInfo)
 	prev, next = tree.getAdjacentRegions(regionC)
-	re.Equal(regionB, prev.region)
-	re.Equal(regionD, next.region)
+	re.Equal(regionB, prev.RegionInfo)
+	re.Equal(regionD, next.RegionInfo)
 	prev, next = tree.getAdjacentRegions(regionD)
-	re.Equal(regionB, prev.region)
+	re.Equal(regionB, prev.RegionInfo)
 	re.Nil(next)
 
 	// region with the same range and different region id will not be delete.
-	region0 := newRegionItem([]byte{}, []byte("a")).region
+	region0 := newRegionItem([]byte{}, []byte("a")).RegionInfo
 	updateNewItem(tree, region0)
 	re.Equal(region0, tree.search([]byte{}))
-	anotherRegion0 := newRegionItem([]byte{}, []byte("a")).region
+	anotherRegion0 := newRegionItem([]byte{}, []byte("a")).RegionInfo
 	anotherRegion0.meta.Id = 123
 	tree.remove(anotherRegion0)
 	re.Equal(region0, tree.search([]byte{}))
 
 	// overlaps with 0, A, B, C.
-	region0D := newRegionItem([]byte(""), []byte("d")).region
+	region0D := newRegionItem([]byte(""), []byte("d")).RegionInfo
 	updateNewItem(tree, region0D)
 	re.Equal(region0D, tree.search([]byte{}))
 	re.Equal(region0D, tree.search([]byte("a")))
@@ -215,7 +215,7 @@ func TestRegionTree(t *testing.T) {
 	re.Equal(regionD, tree.search([]byte("d")))
 
 	// overlaps with D.
-	regionE := newRegionItem([]byte("e"), []byte{}).region
+	regionE := newRegionItem([]byte("e"), []byte{}).RegionInfo
 	updateNewItem(tree, regionE)
 	re.Equal(region0D, tree.search([]byte{}))
 	re.Equal(region0D, tree.search([]byte("a")))
@@ -240,7 +240,7 @@ func updateRegions(re *require.Assertions, tree *regionTree, regions []*RegionIn
 func TestRegionTreeSplitAndMerge(t *testing.T) {
 	re := require.New(t)
 	tree := newRegionTree()
-	regions := []*RegionInfo{newRegionItem([]byte{}, []byte{}).region}
+	regions := []*RegionInfo{newRegionItem([]byte{}, []byte{}).RegionInfo}
 
 	// Byte will underflow/overflow if n > 7.
 	n := 7
@@ -355,7 +355,7 @@ func TestRandomRegionDiscontinuous(t *testing.T) {
 }
 
 func updateNewItem(tree *regionTree, region *RegionInfo) {
-	item := &regionItem{region: region}
+	item := &regionItem{RegionInfo: region}
 	tree.update(item)
 }
 
@@ -379,7 +379,7 @@ func checkRandomRegion(re *require.Assertions, tree *regionTree, regions []*Regi
 }
 
 func newRegionItem(start, end []byte) *regionItem {
-	return &regionItem{region: NewTestRegionInfo(start, end)}
+	return &regionItem{RegionInfo: NewTestRegionInfo(start, end)}
 }
 
 type mockRegionTreeData struct {


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5606.

### What is changed and how does it work?
```
go test -benchmem -count 5 -run=^$ -bench ^BenchmarkLoadRegionsByVolume$ github.com/tikv/pd/server/storage

name                                       old time/op    new time/op    delta
LoadRegionsByVolume/input_size_10000-40      0.05ns ±13%    0.04ns ±25%     ~     (p=0.056 n=5+5)
LoadRegionsByVolume/input_size_100000-40     0.60ns ± 9%    0.47ns ± 6%  -21.15%  (p=0.008 n=5+5)
LoadRegionsByVolume/input_size_1000000-40     6.84s ± 3%     5.35s ± 6%  -21.84%  (p=0.008 n=5+5)

name                                       old alloc/op   new alloc/op   delta
LoadRegionsByVolume/input_size_10000-40       0.00B          0.00B          ~     (all equal)
LoadRegionsByVolume/input_size_100000-40      0.00B          0.00B          ~     (all equal)
LoadRegionsByVolume/input_size_1000000-40     934MB ± 0%     933MB ± 0%   -0.01%  (p=0.032 n=5+5)

name                                       old allocs/op  new allocs/op  delta
LoadRegionsByVolume/input_size_10000-40        0.00           0.00          ~     (all equal)
LoadRegionsByVolume/input_size_100000-40       0.00           0.00          ~     (all equal)
LoadRegionsByVolume/input_size_1000000-40     15.2M ± 0%     15.2M ± 0%     ~     (p=0.421 n=5+5)
```
```
go test -benchmem -count 5 -run=^$ -bench ^BenchmarkLoadRegionsByRandomMerge$ github.com/tikv/pd/server/storage

name                                        old time/op    new time/op    delta
LoadRegionsByRandomMerge/merge_ratio_0-40      6.47s ± 6%     5.33s ± 5%  -17.62%  (p=0.008 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_20-40     7.99s ± 3%     7.01s ± 4%  -12.32%  (p=0.008 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_40-40     9.69s ± 5%     8.64s ± 4%  -10.86%  (p=0.008 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_60-40     11.1s ± 2%      9.9s ± 5%  -10.40%  (p=0.008 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_80-40     12.4s ± 3%     11.2s ± 5%   -9.74%  (p=0.008 n=5+5)

name                                        old alloc/op   new alloc/op   delta
LoadRegionsByRandomMerge/merge_ratio_0-40      934MB ± 0%     933MB ± 0%   -0.01%  (p=0.032 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_20-40    1.01GB ± 0%    1.01GB ± 0%     ~     (p=0.056 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_40-40    1.10GB ± 0%    1.10GB ± 0%   +0.06%  (p=0.032 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_60-40    1.17GB ± 0%    1.17GB ± 0%   +0.08%  (p=0.008 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_80-40    1.25GB ± 0%    1.25GB ± 0%   +0.09%  (p=0.016 n=5+5)

name                                        old allocs/op  new allocs/op  delta
LoadRegionsByRandomMerge/merge_ratio_0-40      15.2M ± 0%     15.2M ± 0%     ~     (p=0.151 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_20-40     18.0M ± 0%     18.0M ± 0%     ~     (p=0.421 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_40-40     20.7M ± 0%     20.7M ± 0%     ~     (p=0.151 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_60-40     23.3M ± 0%     23.3M ± 0%   +0.00%  (p=0.008 n=5+5)
LoadRegionsByRandomMerge/merge_ratio_80-40     25.8M ± 0%     25.8M ± 0%     ~     (p=0.151 n=5+5)
```

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
