### PR TITLE
operator: split SwitchWitness from ChangePeer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce
-	github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172
+	github.com/pingcap/kvproto v0.0.0-20221104101942-09d82b914df1
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81
 	github.com/pingcap/sysutil v0.0.0-20211208032423-041a72e5860d
 	github.com/pingcap/tidb-dashboard v0.0.0-20221103012625-46facc4b7f6d

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce h1:Y1kCxlCtlPTMt
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172 h1:FYgKV9znRQmzVrrJDZ0gUfMIvKLAMU1tu1UKJib8bEQ=
-github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
+github.com/pingcap/kvproto v0.0.0-20221104101942-09d82b914df1 h1:iJXUNA0LoOYuuMJ6U0tJGg2gCo/8xGZVhKLvuUWNjzw=
+github.com/pingcap/kvproto v0.0.0-20221104101942-09d82b914df1/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=

--- a/server/schedule/checker/rule_checker_test.go
+++ b/server/schedule/checker/rule_checker_test.go
@@ -364,10 +364,50 @@ func (suite *ruleCheckerTestSuite) TestFixRuleWitness3() {
 	op := suite.rc.Check(r)
 	suite.NotNil(op)
 	suite.Equal("fix-non-witness-peer", op.Desc())
-	suite.Equal(uint64(3), op.Step(0).(operator.BecomeNonWitness).StoreID)
+	suite.Equal(uint64(3), op.Step(0).(operator.RemovePeer).FromStore)
+	suite.Equal(uint64(3), op.Step(1).(operator.AddLearner).ToStore)
 }
 
 func (suite *ruleCheckerTestSuite) TestFixRuleWitness4() {
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"A": "leader"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"B": "voter"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"C": "learner"})
+	suite.cluster.AddLeaderRegion(1, 1, 2, 3)
+
+	r := suite.cluster.GetRegion(1)
+	// set peer3 to witness learner
+	r = r.Clone(core.WithLearners([]*metapb.Peer{r.GetPeer(3)}))
+	r = r.Clone(core.WithWitnesses([]*metapb.Peer{r.GetPeer(3)}))
+
+	suite.ruleManager.SetRule(&placement.Rule{
+		GroupID:   "pd",
+		ID:        "default",
+		Index:     100,
+		Override:  true,
+		Role:      placement.Voter,
+		Count:     2,
+		IsWitness: false,
+	})
+	suite.ruleManager.SetRule(&placement.Rule{
+		GroupID:   "pd",
+		ID:        "r1",
+		Index:     100,
+		Override:  false,
+		Role:      placement.Learner,
+		Count:     1,
+		IsWitness: false,
+		LabelConstraints: []placement.LabelConstraint{
+			{Key: "C", Op: "in", Values: []string{"learner"}},
+		},
+	})
+
+	op := suite.rc.Check(r)
+	suite.NotNil(op)
+	suite.Equal("fix-non-witness-peer", op.Desc())
+	suite.Equal(uint64(3), op.Step(0).(operator.BecomeNonWitness).StoreID)
+}
+
+func (suite *ruleCheckerTestSuite) TestFixRuleWitness5() {
 	suite.cluster.AddLabelsStore(1, 1, map[string]string{"A": "leader"})
 	suite.cluster.AddLabelsStore(2, 1, map[string]string{"B": "voter"})
 	suite.cluster.AddLabelsStore(3, 1, map[string]string{"C": "voter"})

--- a/server/schedule/checker/rule_checker_test.go
+++ b/server/schedule/checker/rule_checker_test.go
@@ -379,27 +379,30 @@ func (suite *ruleCheckerTestSuite) TestFixRuleWitness4() {
 	r = r.Clone(core.WithLearners([]*metapb.Peer{r.GetPeer(3)}))
 	r = r.Clone(core.WithWitnesses([]*metapb.Peer{r.GetPeer(3)}))
 
-	suite.ruleManager.SetRule(&placement.Rule{
-		GroupID:   "pd",
-		ID:        "default",
-		Index:     100,
-		Override:  true,
-		Role:      placement.Voter,
-		Count:     2,
-		IsWitness: false,
-	})
-	suite.ruleManager.SetRule(&placement.Rule{
-		GroupID:   "pd",
-		ID:        "r1",
-		Index:     100,
-		Override:  false,
-		Role:      placement.Learner,
-		Count:     1,
-		IsWitness: false,
-		LabelConstraints: []placement.LabelConstraint{
-			{Key: "C", Op: "in", Values: []string{"learner"}},
+	err := suite.ruleManager.SetRules([]*placement.Rule{
+		{
+			GroupID:   "pd",
+			ID:        "default",
+			Index:     100,
+			Override:  true,
+			Role:      placement.Voter,
+			Count:     2,
+			IsWitness: false,
+		},
+		{
+			GroupID:   "pd",
+			ID:        "r1",
+			Index:     100,
+			Override:  false,
+			Role:      placement.Learner,
+			Count:     1,
+			IsWitness: false,
+			LabelConstraints: []placement.LabelConstraint{
+				{Key: "C", Op: "in", Values: []string{"learner"}},
+			},
 		},
 	})
+	suite.NoError(err)
 
 	op := suite.rc.Check(r)
 	suite.NotNil(op)

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -739,6 +739,7 @@ func (b *Builder) buildStepsWithoutJointConsensus(kind OpKind) (OpKind, error) {
 		}
 		if plan.nonWitness != nil {
 			b.execSwitchToNonWitness(plan.nonWitness)
+			kind |= OpRegion
 		}
 	}
 

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -280,7 +280,7 @@ func (b *Builder) BecomeNonWitness(storeID uint64) *Builder {
 		b.targetPeers.Set(&metapb.Peer{
 			Id:        peer.GetId(),
 			StoreId:   peer.GetStoreId(),
-			Role:      metapb.PeerRole_Learner,
+			Role:      peer.GetRole(),
 			IsWitness: false,
 		})
 	}

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -455,10 +455,10 @@ func (b *Builder) prepareBuild() (string, error) {
 			}
 		}
 
-		// Demote voter to learner before switch witness to non-witness if needed.
 		isOriginPeerWitness := core.IsWitness(o)
 		isTargetPeerWitness := core.IsWitness(n)
 		if isOriginPeerWitness && !isTargetPeerWitness {
+			// Demote voter to learner before switch witness to non-witness if needed.
 			if !core.IsLearner(n) {
 				n.Role = metapb.PeerRole_Learner
 				n.IsWitness = true

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -838,21 +838,23 @@ func (b *Builder) execBatchSwitchWitnesses() {
 	}
 
 	step := BatchSwitchWitness{
-		toWitnesses:    make([]BecomeWitness, 0, len(b.toWitness)),
-		toNonWitnesses: make([]BecomeNonWitness, 0, len(b.toNonWitness)),
+		ToWitnesses:    make([]BecomeWitness, 0, len(b.toWitness)),
+		ToNonWitnesses: make([]BecomeNonWitness, 0, len(b.toNonWitness)),
 	}
 
 	for _, w := range b.toWitness.IDs() {
 		peer := b.toWitness[w]
-		step.toWitnesses = append(step.toWitnesses, BecomeWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
+		step.ToWitnesses = append(step.ToWitnesses, BecomeWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
 	}
 	b.toWitness = newPeersMap()
 
 	for _, nw := range b.toNonWitness.IDs() {
 		peer := b.toNonWitness[nw]
-		step.toNonWitnesses = append(step.toNonWitnesses, BecomeNonWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
+		step.ToNonWitnesses = append(step.ToNonWitnesses, BecomeNonWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
 	}
 	b.toNonWitness = newPeersMap()
+
+	b.steps = append(b.steps, step)
 }
 
 // check if the peer is allowed to become the leader.

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -77,11 +77,11 @@ type Builder struct {
 	forceTargetLeader bool
 
 	// intermediate states
-	currentPeers                         peersMap
-	currentLeaderStoreID                 uint64
-	toAdd, toRemove, toPromote, toDemote peersMap       // pending tasks.
-	steps                                []OpStep       // generated steps.
-	peerAddStep                          map[uint64]int // record at which step a peer is created.
+	currentPeers                                                  peersMap
+	currentLeaderStoreID                                          uint64
+	toAdd, toRemove, toPromote, toDemote, toWitness, toNonWitness peersMap       // pending tasks.
+	steps                                                         []OpStep       // generated steps.
+	peerAddStep                                                   map[uint64]int // record at which step a peer is created.
 
 	// comparison function
 	stepPlanPreferFuncs []func(stepPlan) int // for buildStepsWithoutJointConsensus
@@ -247,15 +247,35 @@ func (b *Builder) DemoteVoter(storeID uint64) *Builder {
 	return b
 }
 
-// BecomeNonWitness records a remove witness attr operation in Builder.
+// BecomeWitness records a switch to witness operation in Builder.
+func (b *Builder) BecomeWitness(storeID uint64) *Builder {
+	if b.err != nil {
+		return b
+	}
+	if peer, ok := b.targetPeers[storeID]; !ok {
+		b.err = errors.Errorf("cannot switch peer to witness %d: not found", storeID)
+	} else if core.IsWitness(peer) {
+		b.err = errors.Errorf("cannot switch peer to witness %d: is already witness", storeID)
+	} else {
+		b.targetPeers.Set(&metapb.Peer{
+			Id:        peer.GetId(),
+			StoreId:   peer.GetStoreId(),
+			Role:      peer.GetRole(),
+			IsWitness: true,
+		})
+	}
+	return b
+}
+
+// BecomeNonWitness records a switch to non-witness operation in Builder.
 func (b *Builder) BecomeNonWitness(storeID uint64) *Builder {
 	if b.err != nil {
 		return b
 	}
 	if peer, ok := b.targetPeers[storeID]; !ok {
-		b.err = errors.Errorf("cannot set non-witness attr to peer %d: not found", storeID)
+		b.err = errors.Errorf("cannot switch peer to non-witness %d: not found", storeID)
 	} else if !core.IsWitness(peer) {
-		b.err = errors.Errorf("cannot set non-witness attr to peer %d: is already non-witness", storeID)
+		b.err = errors.Errorf("cannot switch peer to non-witness %d: is already non-witness", storeID)
 	} else {
 		b.targetPeers.Set(&metapb.Peer{
 			Id:        peer.GetId(),
@@ -402,6 +422,8 @@ func (b *Builder) prepareBuild() (string, error) {
 	b.toRemove = newPeersMap()
 	b.toPromote = newPeersMap()
 	b.toDemote = newPeersMap()
+	b.toNonWitness = newPeersMap()
+	b.toWitness = newPeersMap()
 
 	voterCount := 0
 	for _, peer := range b.targetPeers {
@@ -413,7 +435,7 @@ func (b *Builder) prepareBuild() (string, error) {
 		return "", errors.New("cannot create operator: target peers have no voter")
 	}
 
-	// Diff `originPeers` and `targetPeers` to initialize `toAdd`, `toRemove`, `toPromote`, `toDemote`.
+	// Diff `originPeers` and `targetPeers` to initialize `toAdd`, `toRemove`, `toPromote`, `toDemote`, `toWitness`, `toNonWitness`.
 	// Note: Use `toDemote` only when `useJointConsensus` is true. Otherwise use `toAdd`, `toRemove` instead.
 	for _, o := range b.originPeers {
 		n := b.targetPeers[o.GetStoreId()]
@@ -441,10 +463,22 @@ func (b *Builder) prepareBuild() (string, error) {
 		} else if !isOriginPeerLearner && isTargetPeerLearner {
 			// voter -> learner
 			if b.useJointConsensus {
+				if core.IsWitness(o) && !core.IsWitness(n) {
+					n.IsWitness = true
+					b.toNonWitness.Set(n)
+				} else if !core.IsWitness(o) && core.IsWitness(n) {
+					b.toWitness.Set(n)
+				}
 				b.toDemote.Set(n)
 			} else {
 				b.toRemove.Set(o)
 				// the targetPeers loop below will add `b.toAdd.Set(n)`
+			}
+		} else {
+			if core.IsWitness(o) && !core.IsWitness(n) {
+				b.toNonWitness.Set(n)
+			} else if !core.IsWitness(o) && core.IsWitness(n) {
+				b.toWitness.Set(n)
 			}
 		}
 	}
@@ -484,8 +518,9 @@ func (b *Builder) prepareBuild() (string, error) {
 		}
 	}
 
+	// TODO:
 	if len(b.toAdd)+len(b.toRemove)+len(b.toPromote) <= 1 && len(b.toDemote) == 0 &&
-		!(len(b.toRemove) == 1 && len(b.targetPeers) == 1) {
+		!(len(b.toRemove) == 1 && len(b.targetPeers) == 1) && len(b.toWitness)+len(b.toNonWitness) <= 1 {
 		// If only one peer changed and the change type is not demote, joint consensus is not used.
 		// Unless the changed is 2 voters to 1 voter, see https://github.com/tikv/pd/issues/4411 .
 		b.useJointConsensus = false
@@ -586,6 +621,8 @@ func (b *Builder) buildStepsWithJointConsensus(kind OpKind) (OpKind, error) {
 		kind |= OpRegion
 	}
 
+	b.execBatchSwitchWitnesses()
+
 	return kind, nil
 }
 
@@ -653,7 +690,7 @@ func (b *Builder) preferOldPeerAsLeader(targetLeaderStoreID uint64) int {
 func (b *Builder) buildStepsWithoutJointConsensus(kind OpKind) (OpKind, error) {
 	b.initStepPlanPreferFuncs()
 
-	for len(b.toAdd) > 0 || len(b.toRemove) > 0 || len(b.toPromote) > 0 || len(b.toDemote) > 0 {
+	for len(b.toAdd) > 0 || len(b.toRemove) > 0 || len(b.toPromote) > 0 || len(b.toDemote) > 0 || len(b.toNonWitness) > 0 || len(b.toWitness) > 0 {
 		plan := b.peerPlan()
 		if plan.IsEmpty() {
 			return kind, errors.New("fail to build operator: plan is empty, maybe no valid leader")
@@ -676,6 +713,12 @@ func (b *Builder) buildStepsWithoutJointConsensus(kind OpKind) (OpKind, error) {
 		if plan.remove != nil {
 			b.execRemovePeer(plan.remove)
 			kind |= OpRegion
+		}
+		if plan.witness != nil {
+			b.execSwitchToWitness(plan.witness)
+		}
+		if plan.nonWitness != nil {
+			b.execSwitchToNonWitness(plan.nonWitness)
 		}
 	}
 
@@ -779,6 +822,39 @@ func (b *Builder) execChangePeerV2(needEnter bool, needTransferLeader bool) {
 	}
 }
 
+func (b *Builder) execSwitchToNonWitness(peer *metapb.Peer) {
+	b.steps = append(b.steps, BecomeNonWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
+	delete(b.toNonWitness, peer.GetStoreId())
+}
+
+func (b *Builder) execSwitchToWitness(peer *metapb.Peer) {
+	b.steps = append(b.steps, BecomeWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
+	delete(b.toWitness, peer.GetStoreId())
+}
+
+func (b *Builder) execBatchSwitchWitnesses() {
+	if len(b.toNonWitness)+len(b.toWitness) == 0 {
+		return
+	}
+
+	step := BatchSwitchWitness{
+		toWitnesses:    make([]BecomeWitness, 0, len(b.toWitness)),
+		toNonWitnesses: make([]BecomeNonWitness, 0, len(b.toNonWitness)),
+	}
+
+	for _, w := range b.toWitness.IDs() {
+		peer := b.toWitness[w]
+		step.toWitnesses = append(step.toWitnesses, BecomeWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
+	}
+	b.toWitness = newPeersMap()
+
+	for _, nw := range b.toNonWitness.IDs() {
+		peer := b.toNonWitness[nw]
+		step.toNonWitnesses = append(step.toNonWitnesses, BecomeNonWitness{StoreID: peer.GetStoreId(), PeerID: peer.GetId()})
+	}
+	b.toNonWitness = newPeersMap()
+}
+
 // check if the peer is allowed to become the leader.
 func (b *Builder) allowLeader(peer *metapb.Peer, ignoreClusterLimit bool) bool {
 	// these peer roles are not allowed to become leader.
@@ -830,6 +906,7 @@ func (b *Builder) allowLeader(peer *metapb.Peer, ignoreClusterLimit bool) bool {
 // 7. demote voter.
 // 8. remove voter/learner.
 // 9. add voter/learner.
+// 10. switch a witness learner to non-witness learner
 // Plan 1-5 (replace plans) do not change voter/learner count, so they have higher priority.
 type stepPlan struct {
 	leaderBeforeAdd    uint64 // leader before adding peer.
@@ -838,15 +915,17 @@ type stepPlan struct {
 	remove             *metapb.Peer
 	promote            *metapb.Peer
 	demote             *metapb.Peer
+	witness            *metapb.Peer
+	nonWitness         *metapb.Peer
 }
 
 func (p stepPlan) String() string {
-	return fmt.Sprintf("stepPlan{leaderBeforeAdd=%v,add={%s},promote={%s},leaderBeforeRemove=%v,demote={%s},remove={%s}}",
-		p.leaderBeforeAdd, p.add, p.promote, p.leaderBeforeRemove, p.demote, p.remove)
+	return fmt.Sprintf("stepPlan{leaderBeforeAdd=%v,add={%s},promote={%s},leaderBeforeRemove=%v,demote={%s},remove={%s},witness={%s},nonWitness={%s}}",
+		p.leaderBeforeAdd, p.add, p.promote, p.leaderBeforeRemove, p.demote, p.remove, p.witness, p.nonWitness)
 }
 
 func (p stepPlan) IsEmpty() bool {
-	return p.promote == nil && p.demote == nil && p.add == nil && p.remove == nil
+	return p.promote == nil && p.demote == nil && p.add == nil && p.remove == nil && p.witness == nil && p.nonWitness == nil
 }
 
 func (b *Builder) peerPlan() stepPlan {
@@ -865,6 +944,12 @@ func (b *Builder) peerPlan() stepPlan {
 		return p
 	}
 	if p := b.planAddPeer(); !p.IsEmpty() {
+		return p
+	}
+	if p := b.planWitness(); !p.IsEmpty() {
+		return p
+	}
+	if p := b.planNonWitness(); !p.IsEmpty() {
 		return p
 	}
 	return stepPlan{}
@@ -987,6 +1072,22 @@ func (b *Builder) planRemovePeer() stepPlan {
 		}
 	}
 	return best
+}
+
+func (b *Builder) planWitness() stepPlan {
+	for _, i := range b.toWitness.IDs() {
+		peer := b.toWitness[i]
+		return stepPlan{witness: peer}
+	}
+	return stepPlan{}
+}
+
+func (b *Builder) planNonWitness() stepPlan {
+	for _, i := range b.toNonWitness.IDs() {
+		peer := b.toNonWitness[i]
+		return stepPlan{nonWitness: peer}
+	}
+	return stepPlan{}
 }
 
 func (b *Builder) planAddPeer() stepPlan {

--- a/server/schedule/operator/builder.go
+++ b/server/schedule/operator/builder.go
@@ -526,9 +526,8 @@ func (b *Builder) prepareBuild() (string, error) {
 	// Although switch witness may have nothing to do with conf change (except switch witness voter to non-witness voter:
 	// it will domote to learner first, then switch witness, finally promote the non-witness learner to voter back),
 	// the logic here is reused for batch switch.
-	if len(b.toAdd)+len(b.toRemove)+len(b.toPromote) <= 1 && len(b.toDemote) == 0 &&
-		!(len(b.toRemove) == 1 && len(b.targetPeers) == 1) &&
-		len(b.toWitness)+len(b.toNonWitness)+len(b.toPromoteAfterSwitchToNonWitness) <= 1 {
+	if len(b.toAdd)+len(b.toRemove)+len(b.toPromote)+len(b.toWitness)+len(b.toNonWitness)+len(b.toPromoteAfterSwitchToNonWitness) <= 1 &&
+		len(b.toDemote) == 0 && !(len(b.toRemove) == 1 && len(b.targetPeers) == 1) {
 		// If only one peer changed and the change type is not demote, joint consensus is not used.
 		// Unless the changed is 2 voters to 1 voter, see https://github.com/tikv/pd/issues/4411 .
 		b.useJointConsensus = false

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -158,8 +158,9 @@ func CreateMergeRegionOperator(desc string, ci ClusterInformer, source *core.Reg
 		peers := make(map[uint64]*metapb.Peer)
 		for _, p := range target.GetPeers() {
 			peers[p.GetStoreId()] = &metapb.Peer{
-				StoreId: p.GetStoreId(),
-				Role:    p.GetRole(),
+				StoreId:   p.GetStoreId(),
+				Role:      p.GetRole(),
+				IsWitness: p.GetIsWitness(),
 			}
 		}
 		matchOp, err := NewBuilder("", ci, source).
@@ -197,7 +198,7 @@ func isRegionMatch(a, b *core.RegionInfo) bool {
 	}
 	for _, pa := range a.GetPeers() {
 		pb := b.GetStorePeer(pa.GetStoreId())
-		if pb == nil || core.IsLearner(pb) != core.IsLearner(pa) {
+		if pb == nil || core.IsLearner(pb) != core.IsLearner(pa) || core.IsWitness(pb) != core.IsWitness(pa) {
 			return false
 		}
 	}

--- a/server/schedule/operator/create_operator.go
+++ b/server/schedule/operator/create_operator.go
@@ -294,12 +294,14 @@ func CreateLeaveJointStateOperator(desc string, ci ClusterInformer, origin *core
 
 // CreateWitnessPeerOperator creates an operator that set a follower or learner peer with witness
 func CreateWitnessPeerOperator(desc string, ci ClusterInformer, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
-	brief := fmt.Sprintf("create witness: region %v peer %v on store %v", region.GetID(), peer.Id, peer.StoreId)
-	return NewOperator(desc, brief, region.GetID(), region.GetRegionEpoch(), OpRegion, region.GetApproximateSize(), BecomeWitness{StoreID: peer.StoreId, PeerID: peer.Id}), nil
+	return NewBuilder(desc, ci, region).
+		BecomeWitness(peer.GetStoreId()).
+		Build(0)
 }
 
 // CreateNonWitnessPeerOperator creates an operator that set a peer with non-witness
 func CreateNonWitnessPeerOperator(desc string, ci ClusterInformer, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
-	brief := fmt.Sprintf("promote to non-witness: region %v peer %v on store %v", region.GetID(), peer.Id, peer.StoreId)
-	return NewOperator(desc, brief, region.GetID(), region.GetRegionEpoch(), OpRegion, region.GetApproximateSize(), BecomeNonWitness{StoreID: peer.StoreId, PeerID: peer.Id}), nil
+	return NewBuilder(desc, ci, region).
+		BecomeNonWitness(peer.GetStoreId()).
+		Build(0)
 }

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -272,16 +272,18 @@ func (suite *createOperatorTestSuite) TestCreateMergeRegionOperator() {
 				{Id: 6, StoreId: 3, Role: metapb.PeerRole_Voter, IsWitness: true},
 				{Id: 5, StoreId: 2, Role: metapb.PeerRole_Voter},
 			},
-			OpMerge,
+			OpMerge | OpRegion,
 			false,
 			[]OpStep{
 				ChangePeerV2Enter{
-					PromoteLearners: []PromoteLearner{},
-					DemoteVoters:    []DemoteVoter{{ToStore: 2, PeerID: 2, IsWitness: true}},
+					DemoteVoters: []DemoteVoter{{ToStore: 2, PeerID: 2, IsWitness: true}},
 				},
 				BatchSwitchWitness{
 					ToWitnesses:    []BecomeWitness{{PeerID: 3, StoreID: 3}},
 					ToNonWitnesses: []BecomeNonWitness{{PeerID: 2, StoreID: 2}},
+				},
+				ChangePeerV2Enter{
+					PromoteLearners: []PromoteLearner{{PeerID: 2, ToStore: 2, IsWitness: false}},
 				},
 			},
 		},
@@ -1211,13 +1213,16 @@ func (suite *createOperatorTestSuite) TestCreateNonWitnessPeerOperator() {
 				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
 				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter, IsWitness: true},
 			},
-			0,
+			OpRegion,
 			false,
 			[]OpStep{
 				ChangePeerV2Enter{
 					DemoteVoters: []DemoteVoter{{ToStore: 2, PeerID: 2, IsWitness: true}},
 				},
 				BecomeNonWitness{StoreID: 2, PeerID: 2},
+				ChangePeerV2Enter{
+					PromoteLearners: []PromoteLearner{{ToStore: 2, PeerID: 2, IsWitness: false}},
+				},
 			},
 		},
 	}

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -275,6 +275,10 @@ func (suite *createOperatorTestSuite) TestCreateMergeRegionOperator() {
 			OpMerge,
 			false,
 			[]OpStep{
+				ChangePeerV2Enter{
+					PromoteLearners: []PromoteLearner{},
+					DemoteVoters:    []DemoteVoter{{ToStore: 2, PeerID: 2, IsWitness: true}},
+				},
 				BatchSwitchWitness{
 					ToWitnesses:    []BecomeWitness{{PeerID: 3, StoreID: 3}},
 					ToNonWitnesses: []BecomeNonWitness{{PeerID: 2, StoreID: 2}},

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -265,14 +265,21 @@ func (suite *createOperatorTestSuite) TestCreateMergeRegionOperator() {
 			[]*metapb.Peer{
 				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
 				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter, IsWitness: true},
+				{Id: 3, StoreId: 3, Role: metapb.PeerRole_Voter},
 			},
 			[]*metapb.Peer{
 				{Id: 4, StoreId: 1, Role: metapb.PeerRole_Voter},
-				{Id: 3, StoreId: 2, Role: metapb.PeerRole_Voter},
+				{Id: 6, StoreId: 3, Role: metapb.PeerRole_Voter, IsWitness: true},
+				{Id: 5, StoreId: 2, Role: metapb.PeerRole_Voter},
 			},
-			0,
-			true,
-			nil,
+			OpMerge,
+			false,
+			[]OpStep{
+				BatchSwitchWitness{
+					ToWitnesses:    []BecomeWitness{{PeerID: 3, StoreID: 3}},
+					ToNonWitnesses: []BecomeNonWitness{{PeerID: 2, StoreID: 2}},
+				},
+			},
 		},
 	}
 

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -237,6 +237,43 @@ func (suite *createOperatorTestSuite) TestCreateMergeRegionOperator() {
 			true,
 			nil,
 		},
+		{
+			[]*metapb.Peer{
+				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
+				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter, IsWitness: true},
+			},
+			[]*metapb.Peer{
+				{Id: 4, StoreId: 1, Role: metapb.PeerRole_Voter},
+				{Id: 3, StoreId: 3, Role: metapb.PeerRole_Voter, IsWitness: true},
+			},
+			OpMerge | OpRegion,
+			false,
+			[]OpStep{
+				AddLearner{ToStore: 3},
+				ChangePeerV2Enter{
+					PromoteLearners: []PromoteLearner{{ToStore: 3}},
+					DemoteVoters:    []DemoteVoter{{ToStore: 2}},
+				},
+				ChangePeerV2Leave{
+					PromoteLearners: []PromoteLearner{{ToStore: 3}},
+					DemoteVoters:    []DemoteVoter{{ToStore: 2}},
+				},
+				RemovePeer{FromStore: 2},
+			},
+		},
+		{
+			[]*metapb.Peer{
+				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
+				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter, IsWitness: true},
+			},
+			[]*metapb.Peer{
+				{Id: 4, StoreId: 1, Role: metapb.PeerRole_Voter},
+				{Id: 3, StoreId: 2, Role: metapb.PeerRole_Voter},
+			},
+			0,
+			true,
+			nil,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/server/schedule/operator/create_operator_test.go
+++ b/server/schedule/operator/create_operator_test.go
@@ -1202,7 +1202,7 @@ func (suite *createOperatorTestSuite) TestCreateNonWitnessPeerOperator() {
 				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
 				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Learner, IsWitness: true},
 			},
-			0,
+			OpRegion,
 			false,
 			[]OpStep{
 				BecomeNonWitness{StoreID: 2, PeerID: 2},

--- a/server/schedule/operator/kind.go
+++ b/server/schedule/operator/kind.go
@@ -38,7 +38,7 @@ const (
 	OpSplit
 	// Initiated by hot region scheduler.
 	OpHotRegion
-	// Include peer addition or removal. This means that this operator may take a long time.
+	// Include peer addition or removal or switch witness. This means that this operator may take a long time.
 	OpRegion
 	// Include leader transfer.
 	OpLeader

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -1089,7 +1089,7 @@ func createResponse(change *pdpb.ChangePeer, useConfChangeV2 bool) *pdpb.RegionH
 func switchWitness(peerID uint64, isWitness bool) *pdpb.RegionHeartbeatResponse {
 	return &pdpb.RegionHeartbeatResponse{
 		SwitchWitnesses: &pdpb.BatchSwitchWitness{
-			SwitchWitnesses: []*pdpb.SwitchWitness{&pdpb.SwitchWitness{PeerId: peerID, IsWitness: isWitness}},
+			SwitchWitnesses: []*pdpb.SwitchWitness{{PeerId: peerID, IsWitness: isWitness}},
 		},
 	}
 }

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -324,18 +324,18 @@ func (bn BecomeNonWitness) GetCmd(region *core.RegionInfo, useConfChangeV2 bool)
 }
 
 type BatchSwitchWitness struct {
-	toWitnesses    []BecomeWitness
-	toNonWitnesses []BecomeNonWitness
+	ToWitnesses    []BecomeWitness
+	ToNonWitnesses []BecomeNonWitness
 }
 
 func (bsw BatchSwitchWitness) String() string {
 	b := &strings.Builder{}
 	_, _ = b.WriteString("batch switch witness")
-	for _, w := range bsw.toWitnesses {
+	for _, w := range bsw.ToWitnesses {
 		_, _ = fmt.Fprintf(b, ", switch peer %v on store %v to witness", w.PeerID, w.StoreID)
 	}
-	for _, nw := range bsw.toNonWitnesses {
-		_, _ = fmt.Fprintf(b, ", switch peer %v on store %v to non witness", nw.PeerID, nw.StoreID)
+	for _, nw := range bsw.ToNonWitnesses {
+		_, _ = fmt.Fprintf(b, ", switch peer %v on store %v to non-witness", nw.PeerID, nw.StoreID)
 	}
 	return b.String()
 }
@@ -347,12 +347,12 @@ func (bsw BatchSwitchWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
 
 // IsFinish checks if current step is finished.
 func (bsw BatchSwitchWitness) IsFinish(region *core.RegionInfo) bool {
-	for _, w := range bsw.toWitnesses {
+	for _, w := range bsw.ToWitnesses {
 		if !w.IsFinish(region) {
 			return false
 		}
 	}
-	for _, nw := range bsw.toNonWitnesses {
+	for _, nw := range bsw.ToNonWitnesses {
 		if !nw.IsFinish(region) {
 			return false
 		}
@@ -361,12 +361,12 @@ func (bsw BatchSwitchWitness) IsFinish(region *core.RegionInfo) bool {
 }
 
 func (bsw BatchSwitchWitness) CheckInProgress(ci ClusterInformer, region *core.RegionInfo) error {
-	for _, w := range bsw.toWitnesses {
+	for _, w := range bsw.ToWitnesses {
 		if err := w.CheckInProgress(ci, region); err != nil {
 			return err
 		}
 	}
-	for _, nw := range bsw.toNonWitnesses {
+	for _, nw := range bsw.ToNonWitnesses {
 		if err := nw.CheckInProgress(ci, region); err != nil {
 			return err
 		}
@@ -375,25 +375,25 @@ func (bsw BatchSwitchWitness) CheckInProgress(ci ClusterInformer, region *core.R
 }
 
 func (bsw BatchSwitchWitness) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
-	for _, w := range bsw.toWitnesses {
+	for _, w := range bsw.ToWitnesses {
 		w.Influence(opInfluence, region)
 	}
-	for _, nw := range bsw.toNonWitnesses {
+	for _, nw := range bsw.ToNonWitnesses {
 		nw.Influence(opInfluence, region)
 	}
 }
 
 func (bsw BatchSwitchWitness) Timeout(regionSize int64) time.Duration {
-	count := uint64(len(bsw.toWitnesses)+len(bsw.toNonWitnesses)) + 1
+	count := uint64(len(bsw.ToWitnesses)+len(bsw.ToNonWitnesses)) + 1
 	return fastStepWaitDuration(regionSize) * time.Duration(count)
 }
 
 func (bsw BatchSwitchWitness) GetCmd(region *core.RegionInfo, useConfChangeV2 bool) *pdpb.RegionHeartbeatResponse {
-	switches := make([]*pdpb.SwitchWitness, 0, len(bsw.toWitnesses)+len(bsw.toNonWitnesses))
-	for _, w := range bsw.toWitnesses {
+	switches := make([]*pdpb.SwitchWitness, 0, len(bsw.ToWitnesses)+len(bsw.ToNonWitnesses))
+	for _, w := range bsw.ToWitnesses {
 		switches = append(switches, w.GetCmd(region, useConfChangeV2).SwitchWitnesses.SwitchWitnesses...)
 	}
-	for _, nw := range bsw.toNonWitnesses {
+	for _, nw := range bsw.ToNonWitnesses {
 		switches = append(switches, nw.GetCmd(region, useConfChangeV2).SwitchWitnesses.SwitchWitnesses...)
 	}
 	return &pdpb.RegionHeartbeatResponse{

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -212,17 +212,16 @@ func (ap AddPeer) GetCmd(region *core.RegionInfo, useConfChangeV2 bool) *pdpb.Re
 
 // BecomeWitness is an OpStep that makes a peer become a witness.
 type BecomeWitness struct {
-	StoreID, PeerID uint64
+	PeerID, StoreID uint64
 }
 
 // ConfVerChanged returns the delta value for version increased by this step.
 func (bw BecomeWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
-	peer := region.GetStorePeer(bw.StoreID)
-	return typeutil.BoolToUint64(peer.GetId() == bw.PeerID)
+	return 0
 }
 
 func (bw BecomeWitness) String() string {
-	return fmt.Sprintf("change peer %v on store %v to witness", bw.PeerID, bw.StoreID)
+	return fmt.Sprintf("convert peer %v on store %v to witness", bw.PeerID, bw.StoreID)
 }
 
 // IsFinish checks if current step is finished.
@@ -264,26 +263,22 @@ func (bw BecomeWitness) Timeout(regionSize int64) time.Duration {
 }
 
 // GetCmd returns the schedule command for heartbeat response.
-func (bw BecomeWitness) GetCmd(region *core.RegionInfo, useConfChangeV2 bool) *pdpb.RegionHeartbeatResponse {
-	if core.IsLearner(region.GetStorePeer(bw.StoreID)) {
-		return createResponse(addLearnerNode(bw.PeerID, bw.StoreID, true), useConfChangeV2)
-	}
-	return createResponse(addNode(bw.PeerID, bw.StoreID, true), useConfChangeV2)
+func (bw BecomeWitness) GetCmd(_ *core.RegionInfo, _ bool) *pdpb.RegionHeartbeatResponse {
+	return switchWitness(bw.PeerID, true)
 }
 
 // BecomeNonWitness is an OpStep that makes a peer become a non-witness.
 type BecomeNonWitness struct {
-	StoreID, PeerID uint64
+	PeerID, StoreID uint64
 }
 
 // ConfVerChanged returns the delta value for version increased by this step.
 func (bn BecomeNonWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
-	peer := region.GetStorePeer(bn.StoreID)
-	return typeutil.BoolToUint64(peer.GetId() == bn.PeerID)
+	return 0
 }
 
 func (bn BecomeNonWitness) String() string {
-	return fmt.Sprintf("change peer %v on store %v to non-witness", bn.PeerID, bn.StoreID)
+	return fmt.Sprintf("convert peer %v on store %v to non-witness", bn.PeerID, bn.StoreID)
 }
 
 // IsFinish checks if current step is finished.
@@ -325,7 +320,87 @@ func (bn BecomeNonWitness) Timeout(regionSize int64) time.Duration {
 
 // GetCmd returns the schedule command for heartbeat response.
 func (bn BecomeNonWitness) GetCmd(region *core.RegionInfo, useConfChangeV2 bool) *pdpb.RegionHeartbeatResponse {
-	return createResponse(addLearnerNode(bn.PeerID, bn.StoreID, false), useConfChangeV2)
+	return switchWitness(bn.PeerID, false)
+}
+
+type BatchSwitchWitness struct {
+	toWitnesses    []BecomeWitness
+	toNonWitnesses []BecomeNonWitness
+}
+
+func (bsw BatchSwitchWitness) String() string {
+	b := &strings.Builder{}
+	_, _ = b.WriteString("batch switch witness")
+	for _, w := range bsw.toWitnesses {
+		_, _ = fmt.Fprintf(b, ", switch peer %v on store %v to witness", w.PeerID, w.StoreID)
+	}
+	for _, nw := range bsw.toNonWitnesses {
+		_, _ = fmt.Fprintf(b, ", switch peer %v on store %v to non witness", nw.PeerID, nw.StoreID)
+	}
+	return b.String()
+}
+
+// ConfVerChanged returns the delta value for version increased by this step.
+func (bsw BatchSwitchWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
+	return 0 // switch witness never change the conf version
+}
+
+// IsFinish checks if current step is finished.
+func (bsw BatchSwitchWitness) IsFinish(region *core.RegionInfo) bool {
+	for _, w := range bsw.toWitnesses {
+		if !w.IsFinish(region) {
+			return false
+		}
+	}
+	for _, nw := range bsw.toNonWitnesses {
+		if !nw.IsFinish(region) {
+			return false
+		}
+	}
+	return true
+}
+
+func (bsw BatchSwitchWitness) CheckInProgress(ci ClusterInformer, region *core.RegionInfo) error {
+	for _, w := range bsw.toWitnesses {
+		if err := w.CheckInProgress(ci, region); err != nil {
+			return err
+		}
+	}
+	for _, nw := range bsw.toNonWitnesses {
+		if err := nw.CheckInProgress(ci, region); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (bsw BatchSwitchWitness) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
+	for _, w := range bsw.toWitnesses {
+		w.Influence(opInfluence, region)
+	}
+	for _, nw := range bsw.toNonWitnesses {
+		nw.Influence(opInfluence, region)
+	}
+}
+
+func (bsw BatchSwitchWitness) Timeout(regionSize int64) time.Duration {
+	count := uint64(len(bsw.toWitnesses)+len(bsw.toNonWitnesses)) + 1
+	return fastStepWaitDuration(regionSize) * time.Duration(count)
+}
+
+func (bsw BatchSwitchWitness) GetCmd(region *core.RegionInfo, useConfChangeV2 bool) *pdpb.RegionHeartbeatResponse {
+	switches := make([]*pdpb.SwitchWitness, 0, len(bsw.toWitnesses)+len(bsw.toNonWitnesses))
+	for _, w := range bsw.toWitnesses {
+		switches = append(switches, w.GetCmd(region, useConfChangeV2).SwitchWitnesses.SwitchWitnesses...)
+	}
+	for _, nw := range bsw.toNonWitnesses {
+		switches = append(switches, nw.GetCmd(region, useConfChangeV2).SwitchWitnesses.SwitchWitnesses...)
+	}
+	return &pdpb.RegionHeartbeatResponse{
+		SwitchWitnesses: &pdpb.BatchSwitchWitness{
+			SwitchWitnesses: switches,
+		},
+	}
 }
 
 // AddLearner is an OpStep that adds a region learner peer.
@@ -646,11 +721,7 @@ type DemoteVoter struct {
 }
 
 func (dv DemoteVoter) String() string {
-	info := "non-witness"
-	if dv.IsWitness {
-		info = "witness"
-	}
-	return fmt.Sprintf("demote voter peer %v on store %v to %v learner", dv.PeerID, dv.ToStore, info)
+	return fmt.Sprintf("demote voter peer %v on store %v to learner", dv.PeerID, dv.ToStore)
 }
 
 // ConfVerChanged returns the delta value for version increased by this step.
@@ -665,9 +736,6 @@ func (dv DemoteVoter) IsFinish(region *core.RegionInfo) bool {
 	if peer := region.GetStoreLearner(dv.ToStore); peer != nil {
 		if peer.GetId() != dv.PeerID {
 			log.Warn("obtain unexpected peer", zap.String("expect", dv.String()), zap.Uint64("obtain-learner", peer.GetId()))
-			return false
-		}
-		if peer.IsWitness != dv.IsWitness {
 			return false
 		}
 		return region.GetPendingLearner(peer.GetId()) == nil
@@ -1015,5 +1083,13 @@ func createResponse(change *pdpb.ChangePeer, useConfChangeV2 bool) *pdpb.RegionH
 	}
 	return &pdpb.RegionHeartbeatResponse{
 		ChangePeer: change,
+	}
+}
+
+func switchWitness(peerID uint64, isWitness bool) *pdpb.RegionHeartbeatResponse {
+	return &pdpb.RegionHeartbeatResponse{
+		SwitchWitnesses: &pdpb.BatchSwitchWitness{
+			SwitchWitnesses: []*pdpb.SwitchWitness{&pdpb.SwitchWitness{PeerId: peerID, IsWitness: isWitness}},
+		},
 	}
 }

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -221,7 +221,7 @@ func (bw BecomeWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
 }
 
 func (bw BecomeWitness) String() string {
-	return fmt.Sprintf("convert peer %v on store %v to witness", bw.PeerID, bw.StoreID)
+	return fmt.Sprintf("switch peer %v on store %v to witness", bw.PeerID, bw.StoreID)
 }
 
 // IsFinish checks if current step is finished.
@@ -278,7 +278,7 @@ func (bn BecomeNonWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
 }
 
 func (bn BecomeNonWitness) String() string {
-	return fmt.Sprintf("convert peer %v on store %v to non-witness", bn.PeerID, bn.StoreID)
+	return fmt.Sprintf("switch peer %v on store %v to non-witness", bn.PeerID, bn.StoreID)
 }
 
 // IsFinish checks if current step is finished.

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -323,6 +323,7 @@ func (bn BecomeNonWitness) GetCmd(region *core.RegionInfo, useConfChangeV2 bool)
 	return switchWitness(bn.PeerID, false)
 }
 
+// BatchSwitchWitness is an OpStep that batch switch witness.
 type BatchSwitchWitness struct {
 	ToWitnesses    []BecomeWitness
 	ToNonWitnesses []BecomeNonWitness
@@ -360,6 +361,7 @@ func (bsw BatchSwitchWitness) IsFinish(region *core.RegionInfo) bool {
 	return true
 }
 
+// CheckInProgress checks if the step is in the progress of advancing.
 func (bsw BatchSwitchWitness) CheckInProgress(ci ClusterInformer, region *core.RegionInfo) error {
 	for _, w := range bsw.ToWitnesses {
 		if err := w.CheckInProgress(ci, region); err != nil {
@@ -374,6 +376,7 @@ func (bsw BatchSwitchWitness) CheckInProgress(ci ClusterInformer, region *core.R
 	return nil
 }
 
+// Influence calculates the store difference that current step makes.
 func (bsw BatchSwitchWitness) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 	for _, w := range bsw.ToWitnesses {
 		w.Influence(opInfluence, region)
@@ -383,11 +386,13 @@ func (bsw BatchSwitchWitness) Influence(opInfluence OpInfluence, region *core.Re
 	}
 }
 
+// Timeout returns duration that current step may take.
 func (bsw BatchSwitchWitness) Timeout(regionSize int64) time.Duration {
 	count := uint64(len(bsw.ToWitnesses)+len(bsw.ToNonWitnesses)) + 1
 	return fastStepWaitDuration(regionSize) * time.Duration(count)
 }
 
+// GetCmd returns the schedule command for heartbeat response.
 func (bsw BatchSwitchWitness) GetCmd(region *core.RegionInfo, useConfChangeV2 bool) *pdpb.RegionHeartbeatResponse {
 	switches := make([]*pdpb.SwitchWitness, 0, len(bsw.ToWitnesses)+len(bsw.ToNonWitnesses))
 	for _, w := range bsw.ToWitnesses {

--- a/server/schedule/operator/step_test.go
+++ b/server/schedule/operator/step_test.go
@@ -526,6 +526,40 @@ func (suite *operatorStepTestSuite) TestChangePeerV2Leave() {
 	suite.check(cpl, desc, testCases)
 }
 
+func (suite *operatorStepTestSuite) TestConvertToWitness() {
+	step := BecomeWitness{StoreID: 2, PeerID: 2}
+	testCases := []testCase{
+		{
+			[]*metapb.Peer{
+				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
+				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Learner},
+			},
+			0,
+			false,
+			suite.NoError,
+		},
+		{
+			[]*metapb.Peer{
+				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
+				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter},
+			},
+			0,
+			false,
+			suite.NoError,
+		},
+		{
+			[]*metapb.Peer{
+				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
+				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter, IsWitness: true},
+			},
+			0,
+			true,
+			suite.NoError,
+		},
+	}
+	suite.check(step, "convert peer 2 on store 2 to witness", testCases)
+}
+
 func (suite *operatorStepTestSuite) check(step OpStep, desc string, testCases []testCase) {
 	suite.Equal(desc, step.String())
 	for _, testCase := range testCases {

--- a/server/schedule/operator/step_test.go
+++ b/server/schedule/operator/step_test.go
@@ -526,7 +526,7 @@ func (suite *operatorStepTestSuite) TestChangePeerV2Leave() {
 	suite.check(cpl, desc, testCases)
 }
 
-func (suite *operatorStepTestSuite) TestConvertToWitness() {
+func (suite *operatorStepTestSuite) TestSwitchToWitness() {
 	step := BecomeWitness{StoreID: 2, PeerID: 2}
 	testCases := []testCase{
 		{
@@ -557,7 +557,7 @@ func (suite *operatorStepTestSuite) TestConvertToWitness() {
 			suite.NoError,
 		},
 	}
-	suite.check(step, "convert peer 2 on store 2 to witness", testCases)
+	suite.check(step, "switch peer 2 on store 2 to witness", testCases)
 }
 
 func (suite *operatorStepTestSuite) check(step OpStep, desc string, testCases []testCase) {

--- a/server/schedule/operator/step_test.go
+++ b/server/schedule/operator/step_test.go
@@ -552,7 +552,7 @@ func (suite *operatorStepTestSuite) TestSwitchToWitness() {
 				{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
 				{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter, IsWitness: true},
 			},
-			0,
+			1,
 			true,
 			suite.NoError,
 		},

--- a/tests/client/go.mod
+++ b/tests/client/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00
-	github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172
+	github.com/pingcap/kvproto v0.0.0-20221104101942-09d82b914df1
 	github.com/stretchr/testify v1.7.0
 	github.com/tikv/pd v0.0.0-00010101000000-000000000000
 	github.com/tikv/pd/client v0.0.0-00010101000000-000000000000

--- a/tests/client/go.sum
+++ b/tests/client/go.sum
@@ -390,8 +390,9 @@ github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 h1:C3N3itkduZXDZ
 github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172 h1:FYgKV9znRQmzVrrJDZ0gUfMIvKLAMU1tu1UKJib8bEQ=
 github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
+github.com/pingcap/kvproto v0.0.0-20221104101942-09d82b914df1 h1:iJXUNA0LoOYuuMJ6U0tJGg2gCo/8xGZVhKLvuUWNjzw=
+github.com/pingcap/kvproto v0.0.0-20221104101942-09d82b914df1/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=


### PR DESCRIPTION
Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5633

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
Split ConvertWitness from ChangePeer
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Split ConvertWitness from ChangePeer
```
