### PR TITLE
api, ctl: support get the top CPU usage regions

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -111,6 +111,7 @@ type RegionInfo struct {
 	Leader          MetaPeer      `json:"leader,omitempty"`
 	DownPeers       []PDPeerStats `json:"down_peers,omitempty"`
 	PendingPeers    []MetaPeer    `json:"pending_peers,omitempty"`
+	CPUUsage        uint64        `json:"cpu_usage"`
 	WrittenBytes    uint64        `json:"written_bytes"`
 	ReadBytes       uint64        `json:"read_bytes"`
 	WrittenKeys     uint64        `json:"written_keys"`
@@ -158,6 +159,7 @@ func InitRegion(r *core.RegionInfo, s *RegionInfo) *RegionInfo {
 	s.Leader = fromPeer(r.GetLeader())
 	s.DownPeers = fromPeerStatsSlice(r.GetDownPeers())
 	s.PendingPeers = fromPeerSlice(r.GetPendingPeers())
+	s.CPUUsage = r.GetCPUUsage()
 	s.WrittenBytes = r.GetBytesWritten()
 	s.WrittenKeys = r.GetKeysWritten()
 	s.ReadBytes = r.GetBytesRead()
@@ -767,6 +769,19 @@ func (h *regionsHandler) GetTopSizeRegions(w http.ResponseWriter, r *http.Reques
 func (h *regionsHandler) GetTopKeysRegions(w http.ResponseWriter, r *http.Request) {
 	h.GetTopNRegions(w, r, func(a, b *core.RegionInfo) bool {
 		return a.GetApproximateKeys() < b.GetApproximateKeys()
+	})
+}
+
+// @Tags     region
+// @Summary  List regions with the highest CPU usage.
+// @Param    limit  query  integer  false  "Limit count"  default(16)
+// @Produce  json
+// @Success  200  {object}  RegionsInfo
+// @Failure  400  {string}  string  "The input is invalid."
+// @Router   /regions/cpu [get]
+func (h *regionsHandler) GetTopCPURegions(w http.ResponseWriter, r *http.Request) {
+	h.GetTopNRegions(w, r, func(a, b *core.RegionInfo) bool {
+		return a.GetCPUUsage() < b.GetCPUUsage()
 	})
 }
 

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -324,6 +324,24 @@ func (suite *regionTestSuite) TestTopSize() {
 	suite.checkTopRegions(fmt.Sprintf("%s/regions/size?limit=%d", suite.urlPrefix, 2), []uint64{7, 8})
 }
 
+func (suite *regionTestSuite) TestTopCPU() {
+	re := suite.Require()
+	baseOpt := []core.RegionCreateOption{core.SetRegionConfVer(3), core.SetRegionVersion(3)}
+	opt := core.SetCPUUsage(500)
+	r1 := newTestRegionInfo(10, 1, []byte("a"), []byte("b"), append(baseOpt, opt)...)
+	mustRegionHeartbeat(re, suite.svr, r1)
+	opt = core.SetCPUUsage(300)
+	r2 := newTestRegionInfo(11, 1, []byte("b"), []byte("c"), append(baseOpt, opt)...)
+	mustRegionHeartbeat(re, suite.svr, r2)
+	opt = core.SetCPUUsage(100)
+	r3 := newTestRegionInfo(12, 1, []byte("c"), []byte("d"), append(baseOpt, opt)...)
+	mustRegionHeartbeat(re, suite.svr, r3)
+	// query with limit
+	suite.checkTopRegions(fmt.Sprintf("%s/regions/cpu?limit=%d", suite.urlPrefix, 2), []uint64{10, 11})
+	// query without limit
+	suite.checkTopRegions(fmt.Sprintf("%s/regions/cpu", suite.urlPrefix), []uint64{10, 11, 12})
+}
+
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRange() {
 	re := suite.Require()
 	r1 := newTestRegionInfo(557, 13, []byte("a1"), []byte("a2"))

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -328,18 +328,16 @@ func (suite *regionTestSuite) TestTopCPU() {
 	re := suite.Require()
 	baseOpt := []core.RegionCreateOption{core.SetRegionConfVer(3), core.SetRegionVersion(3)}
 	opt := core.SetCPUUsage(500)
-	r1 := newTestRegionInfo(10, 1, []byte("a"), []byte("b"), append(baseOpt, opt)...)
+	r1 := newTestRegionInfo(10, 1, []byte("d"), []byte("e"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r1)
 	opt = core.SetCPUUsage(300)
-	r2 := newTestRegionInfo(11, 1, []byte("b"), []byte("c"), append(baseOpt, opt)...)
+	r2 := newTestRegionInfo(11, 1, []byte("e"), []byte("f"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r2)
 	opt = core.SetCPUUsage(100)
-	r3 := newTestRegionInfo(12, 1, []byte("c"), []byte("d"), append(baseOpt, opt)...)
+	r3 := newTestRegionInfo(12, 1, []byte("f"), []byte("g"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r3)
 	// query with limit
 	suite.checkTopRegions(fmt.Sprintf("%s/regions/cpu?limit=%d", suite.urlPrefix, 2), []uint64{10, 11})
-	// query without limit
-	suite.checkTopRegions(fmt.Sprintf("%s/regions/cpu", suite.urlPrefix), []uint64{10, 11, 12})
 }
 
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRange() {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -291,7 +291,8 @@ func (suite *regionTestSuite) TestStoreRegions() {
 	suite.Len(regionIDs, r6.Count)
 }
 
-func (suite *regionTestSuite) TestTopFlow() {
+func (suite *regionTestSuite) TestTop() {
+	// Top flow.
 	re := suite.Require()
 	r1 := newTestRegionInfo(1, 1, []byte("a"), []byte("b"), core.SetWrittenBytes(1000), core.SetReadBytes(1000), core.SetRegionConfVer(1), core.SetRegionVersion(1))
 	mustRegionHeartbeat(re, suite.svr, r1)
@@ -306,38 +307,32 @@ func (suite *regionTestSuite) TestTopFlow() {
 	suite.checkTopRegions(fmt.Sprintf("%s/regions/confver?limit=2", suite.urlPrefix), []uint64{3, 2})
 	suite.checkTopRegions(fmt.Sprintf("%s/regions/version", suite.urlPrefix), []uint64{2, 3, 1})
 	suite.checkTopRegions(fmt.Sprintf("%s/regions/version?limit=2", suite.urlPrefix), []uint64{2, 3})
-}
-
-func (suite *regionTestSuite) TestTopSize() {
-	re := suite.Require()
+	// Top size.
 	baseOpt := []core.RegionCreateOption{core.SetRegionConfVer(3), core.SetRegionVersion(3)}
 	opt := core.SetApproximateSize(1000)
-	r1 := newTestRegionInfo(7, 1, []byte("a"), []byte("b"), append(baseOpt, opt)...)
+	r1 = newTestRegionInfo(1, 1, []byte("a"), []byte("b"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r1)
 	opt = core.SetApproximateSize(900)
-	r2 := newTestRegionInfo(8, 1, []byte("b"), []byte("c"), append(baseOpt, opt)...)
+	r2 = newTestRegionInfo(2, 1, []byte("b"), []byte("c"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r2)
 	opt = core.SetApproximateSize(800)
-	r3 := newTestRegionInfo(9, 1, []byte("c"), []byte("d"), append(baseOpt, opt)...)
+	r3 = newTestRegionInfo(3, 1, []byte("c"), []byte("d"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r3)
-	// query with limit
-	suite.checkTopRegions(fmt.Sprintf("%s/regions/size?limit=%d", suite.urlPrefix, 2), []uint64{7, 8})
-}
-
-func (suite *regionTestSuite) TestTopCPU() {
-	re := suite.Require()
-	baseOpt := []core.RegionCreateOption{core.SetRegionConfVer(3), core.SetRegionVersion(3)}
-	opt := core.SetCPUUsage(500)
-	r1 := newTestRegionInfo(10, 1, []byte("d"), []byte("e"), append(baseOpt, opt)...)
+	suite.checkTopRegions(fmt.Sprintf("%s/regions/size?limit=2", suite.urlPrefix), []uint64{1, 2})
+	suite.checkTopRegions(fmt.Sprintf("%s/regions/size", suite.urlPrefix), []uint64{1, 2, 3})
+	// Top CPU usage.
+	baseOpt = []core.RegionCreateOption{core.SetRegionConfVer(4), core.SetRegionVersion(4)}
+	opt = core.SetCPUUsage(100)
+	r1 = newTestRegionInfo(1, 1, []byte("a"), []byte("b"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r1)
 	opt = core.SetCPUUsage(300)
-	r2 := newTestRegionInfo(11, 1, []byte("e"), []byte("f"), append(baseOpt, opt)...)
+	r2 = newTestRegionInfo(2, 1, []byte("b"), []byte("c"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r2)
-	opt = core.SetCPUUsage(100)
-	r3 := newTestRegionInfo(12, 1, []byte("f"), []byte("g"), append(baseOpt, opt)...)
+	opt = core.SetCPUUsage(500)
+	r3 = newTestRegionInfo(3, 1, []byte("c"), []byte("d"), append(baseOpt, opt)...)
 	mustRegionHeartbeat(re, suite.svr, r3)
-	// query with limit
-	suite.checkTopRegions(fmt.Sprintf("%s/regions/cpu?limit=%d", suite.urlPrefix, 2), []uint64{10, 11})
+	suite.checkTopRegions(fmt.Sprintf("%s/regions/cpu?limit=2", suite.urlPrefix), []uint64{3, 2})
+	suite.checkTopRegions(fmt.Sprintf("%s/regions/cpu", suite.urlPrefix), []uint64{3, 2, 1})
 }
 
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRange() {

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -251,6 +251,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(clusterRouter, "/regions/version", regionsHandler.GetTopVersionRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/regions/size", regionsHandler.GetTopSizeRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/regions/keys", regionsHandler.GetTopKeysRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
+	registerFunc(clusterRouter, "/regions/cpu", regionsHandler.GetTopCPURegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/regions/check/miss-peer", regionsHandler.GetMissPeerRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/regions/check/extra-peer", regionsHandler.GetExtraPeerRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/regions/check/pending-peer", regionsHandler.GetPendingPeerRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -54,6 +54,7 @@ type RegionInfo struct {
 	leader            *metapb.Peer
 	downPeers         []*pdpb.PeerStats
 	pendingPeers      []*metapb.Peer
+	cpuUsage          uint64
 	writtenBytes      uint64
 	writtenKeys       uint64
 	readBytes         uint64
@@ -153,6 +154,7 @@ func RegionFromHeartbeat(heartbeat *pdpb.RegionHeartbeatRequest, opts ...RegionC
 		leader:            heartbeat.GetLeader(),
 		downPeers:         heartbeat.GetDownPeers(),
 		pendingPeers:      heartbeat.GetPendingPeers(),
+		cpuUsage:          heartbeat.GetCpuUsage(),
 		writtenBytes:      heartbeat.GetBytesWritten(),
 		writtenKeys:       heartbeat.GetKeysWritten(),
 		readBytes:         heartbeat.GetBytesRead(),
@@ -218,6 +220,7 @@ func (r *RegionInfo) Clone(opts ...RegionCreateOption) *RegionInfo {
 		leader:            typeutil.DeepClone(r.leader, RegionPeerFactory),
 		downPeers:         downPeers,
 		pendingPeers:      pendingPeers,
+		cpuUsage:          r.cpuUsage,
 		writtenBytes:      r.writtenBytes,
 		writtenKeys:       r.writtenKeys,
 		readBytes:         r.readBytes,
@@ -491,6 +494,12 @@ func (r *RegionInfo) GetDownPeers() []*pdpb.PeerStats {
 // GetPendingPeers returns the pending peers of the region.
 func (r *RegionInfo) GetPendingPeers() []*metapb.Peer {
 	return r.pendingPeers
+}
+
+// GetCPUUsage returns the CPU usage of the region since the last heartbeat.
+// The number range is [0, N * 100], where N is the number of CPU cores.
+func (r *RegionInfo) GetCPUUsage() uint64 {
+	return r.cpuUsage
 }
 
 // GetBytesRead returns the read bytes of the region.

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -498,6 +498,9 @@ func (r *RegionInfo) GetPendingPeers() []*metapb.Peer {
 
 // GetCPUUsage returns the CPU usage of the region since the last heartbeat.
 // The number range is [0, N * 100], where N is the number of CPU cores.
+// However, since the TiKV basically only meters the CPU usage inside the
+// Unified Read Pool, it should be considered as an indicator of Region read
+// CPU overhead for now.
 func (r *RegionInfo) GetCPUUsage() uint64 {
 	return r.cpuUsage
 }

--- a/server/core/region_option.go
+++ b/server/core/region_option.go
@@ -170,6 +170,13 @@ func WithDecConfVer() RegionCreateOption {
 	}
 }
 
+// SetCPUUsage sets the CPU usage of the region.
+func SetCPUUsage(v uint64) RegionCreateOption {
+	return func(region *RegionInfo) {
+		region.cpuUsage = v
+	}
+}
+
 // SetWrittenBytes sets the written bytes for the region.
 func SetWrittenBytes(v uint64) RegionCreateOption {
 	return func(region *RegionInfo) {

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -41,6 +41,7 @@ var (
 	regionsVersionPrefix    = "pd/api/v1/regions/version"
 	regionsSizePrefix       = "pd/api/v1/regions/size"
 	regionTopKeysPrefix     = "pd/api/v1/regions/keys"
+	regionTopCPUPrefix      = "pd/api/v1/regions/cpu"
 	regionsKeyPrefix        = "pd/api/v1/regions/key"
 	regionsSiblingPrefix    = "pd/api/v1/regions/sibling"
 	regionsRangeHolesPrefix = "pd/api/v1/regions/range-holes"
@@ -109,6 +110,14 @@ func NewRegionCommand() *cobra.Command {
 	}
 	topKeys.Flags().String("jq", "", "jq query")
 	r.AddCommand(topKeys)
+
+	topCPU := &cobra.Command{
+		Use:   `topcpu <limit> [--jq="<query string>"]`,
+		Short: "show regions with top CPU usage",
+		Run:   showRegionsTopCommand(regionTopCPUPrefix),
+	}
+	topCPU.Flags().String("jq", "", "jq query")
+	r.AddCommand(topCPU)
 
 	scanRegion := &cobra.Command{
 		Use:   `scan [--jq="<query string>"]`,


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Issue Number: Close #4042.

### What is changed and how does it work?

```commit-message
Since the region CPU metering is on by default now on TiKV side, this PR supports to get the top CPU usage regions with command `pd-ctl region topcpu`.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test

<img width="508" alt="图片" src="https://user-images.githubusercontent.com/1446531/201012332-7701ba0e-b059-4fce-960e-13cff6191848.png">

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
