### PR TITLE
scheduler: fix the bug that balance-hot-region-scheduler does not store config when it starts

### DIFF
--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -709,6 +709,15 @@ func TestAddScheduler(t *testing.T) {
 	re.NoError(err)
 	re.NoError(co.addScheduler(gls))
 
+	hb, err := schedule.CreateScheduler(schedulers.HotRegionType, oc, storage.NewStorageWithMemoryBackend(), schedule.ConfigJSONDecoder([]byte("{}")))
+	re.NoError(err)
+	conf, err = hb.EncodeConfig()
+	re.NoError(err)
+	data = make(map[string]interface{})
+	re.NoError(json.Unmarshal(conf, &data))
+	re.Contains(data, "enable-for-tiflash")
+	re.Equal("true", data["enable-for-tiflash"].(string))
+
 	// Transfer all leaders to store 1.
 	waitOperator(re, co, 2)
 	region2 := tc.GetRegion(2)

--- a/server/schedulers/hot_region.go
+++ b/server/schedulers/hot_region.go
@@ -134,6 +134,10 @@ func (h *hotScheduler) GetType() string {
 	return HotRegionType
 }
 
+func (h *hotScheduler) EncodeConfig() ([]byte, error) {
+	return h.conf.EncodeConfig()
+}
+
 func (h *hotScheduler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.conf.ServeHTTP(w, r)
 }

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -2618,3 +2618,17 @@ func TestExpect(t *testing.T) {
 		re.Equal(testCase.allow, bs.checkDstByPriorityAndTolerance(srcToDst(testCase.load), srcToDst(testCase.expect), toleranceRatio))
 	}
 }
+
+// ref https://github.com/tikv/pd/issues/5701
+func TestEncodeConfig(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := config.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	sche, err := schedule.CreateScheduler(HotRegionType, schedule.NewOperatorController(ctx, tc, nil), storage.NewStorageWithMemoryBackend(), schedule.ConfigJSONDecoder([]byte("null")))
+	re.NoError(err)
+	data, err := sche.EncodeConfig()
+	re.NoError(err)
+	re.NotEqual("null", string(data))
+}


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5701 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
