### PR TITLE
Prevent PD from crashing due to epoch comparison error (#5449)

### DIFF
--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -43,51 +43,51 @@ const (
 )
 
 // Stage transition graph: for more details, please check `unsafeRecoveryController.HandleStoreHeartbeat()`
-//                      +-----------+           +-----------+
-//  +-----------+       |           |           |           |
-//  |           |       |  collect  |           | tombstone |
-//  |   idle    |------>|  Report   |-----+---->|  tiflash  |-----+
-//  |           |       |           |     |     |  learner  |     |
-//  +-----------+       +-----------+     |     |           |     |
-//                                        |     +-----------+     |
-//                                        |           |           |
-//                                        |           |           |
-//                                        |           v           |
-//                                        |     +-----------+     |
-//                                        |     |           |     |
-//                                        |     |   force   |     |
-//                                        |     | LeaderFor |-----+
-//                                        |     |CommitMerge|     |
-//                                        |     |           |     |
-//                                        |     +-----------+     |
-//                                        |           |           |
-//                                        |           |           |
-//                                        |           v           |
-//                                        |     +-----------+     |     +-----------+
-//                                        |     |           |     |     |           |        +-----------+
-//                                        |     |  force    |     |     | exitForce |        |           |
-//                                        |     |  Leader   |-----+---->|  Leader   |------->|  failed   |
-//                                        |     |           |     |     |           |        |           |
-//                                        |     +-----------+     |     +-----------+        +-----------+
-//                                        |           |           |
-//                                        |           |           |
-//                                        |           v           |
-//                                        |     +-----------+     |
-//                                        |     |           |     |
-//                                        |     |  demote   |     |
-//                                        +-----|  Voter    |-----|
-//                                              |           |     |
-//                                              +-----------+     |
-//                                                    |           |
-//                                                    |           |
-//                                                    v           |
-//                      +-----------+           +-----------+     |
-//  +-----------+       |           |           |           |     |
-//  |           |       | exitForce |           |  create   |     |
-//  | finished  |<------|  Leader   |<----------|  Region   |-----+
-//  |           |       |           |           |           |
-//  +-----------+       +-----------+           +-----------+
 //
+//	                    +-----------+           +-----------+
+//	+-----------+       |           |           |           |
+//	|           |       |  collect  |           | tombstone |
+//	|   idle    |------>|  Report   |-----+---->|  tiflash  |-----+
+//	|           |       |           |     |     |  learner  |     |
+//	+-----------+       +-----------+     |     |           |     |
+//	                                      |     +-----------+     |
+//	                                      |           |           |
+//	                                      |           |           |
+//	                                      |           v           |
+//	                                      |     +-----------+     |
+//	                                      |     |           |     |
+//	                                      |     |   force   |     |
+//	                                      |     | LeaderFor |-----+
+//	                                      |     |CommitMerge|     |
+//	                                      |     |           |     |
+//	                                      |     +-----------+     |
+//	                                      |           |           |
+//	                                      |           |           |
+//	                                      |           v           |
+//	                                      |     +-----------+     |     +-----------+
+//	                                      |     |           |     |     |           |        +-----------+
+//	                                      |     |  force    |     |     | exitForce |        |           |
+//	                                      |     |  Leader   |-----+---->|  Leader   |------->|  failed   |
+//	                                      |     |           |     |     |           |        |           |
+//	                                      |     +-----------+     |     +-----------+        +-----------+
+//	                                      |           |           |
+//	                                      |           |           |
+//	                                      |           v           |
+//	                                      |     +-----------+     |
+//	                                      |     |           |     |
+//	                                      |     |  demote   |     |
+//	                                      +-----|  Voter    |-----|
+//	                                            |           |     |
+//	                                            +-----------+     |
+//	                                                  |           |
+//	                                                  |           |
+//	                                                  v           |
+//	                    +-----------+           +-----------+     |
+//	+-----------+       |           |           |           |     |
+//	|           |       | exitForce |           |  create   |     |
+//	| finished  |<------|  Leader   |<----------|  Region   |-----+
+//	|           |       |           |           |           |
+//	+-----------+       +-----------+           +-----------+
 const (
 	idle unsafeRecoveryStage = iota
 	collectReport
@@ -394,25 +394,7 @@ func (u *unsafeRecoveryController) HandleStoreHeartbeat(heartbeat *pdpb.StoreHea
 	u.dispatchPlan(heartbeat, resp)
 }
 
-<<<<<<< HEAD
-func (u *unsafeRecoveryController) handleErr() bool {
-	if u.err != nil {
-		if u.stage == exitForceLeader {
-			u.changeStage(failed)
-			return true
-		}
-		u.storePlanExpires = make(map[uint64]time.Time)
-		u.storeRecoveryPlans = make(map[uint64]*pdpb.RecoveryPlan)
-		u.timeout = time.Now().Add(storeRequestInterval)
-		u.changeStage(exitForceLeader)
-	}
-	return false
-}
-
-/// It dispatches recovery plan if any.
-=======
 // It dispatches recovery plan if any.
->>>>>>> 26c31db95 (Prevent PD from crashing due to epoch comparison error (#5449))
 func (u *unsafeRecoveryController) dispatchPlan(heartbeat *pdpb.StoreHeartbeatRequest, resp *pdpb.StoreHeartbeatResponse) {
 	storeID := heartbeat.Stats.StoreId
 	now := time.Now()

--- a/server/cluster/unsafe_recovery_controller.go
+++ b/server/cluster/unsafe_recovery_controller.go
@@ -257,8 +257,21 @@ func (u *unsafeRecoveryController) checkTimeout() bool {
 	}
 
 	if time.Now().After(u.timeout) {
-		u.err = errors.Errorf("Exceeds timeout %v", u.timeout)
-		return u.handleErr()
+		ret := u.HandleErr(errors.Errorf("Exceeds timeout %v", u.timeout))
+		u.timeout = time.Now().Add(storeRequestInterval * 2)
+		return ret
+	}
+	return false
+}
+
+func (u *unsafeRecoveryController) HandleErr(err error) bool {
+	// Keep the earliest error.
+	if u.err == nil {
+		u.err = err
+	}
+	if u.stage == exitForceLeader {
+		u.changeStage(failed)
+		return true
 	}
 	return false
 }
@@ -277,53 +290,60 @@ func (u *unsafeRecoveryController) HandleStoreHeartbeat(heartbeat *pdpb.StoreHea
 		return
 	}
 
-	allCollected, err := u.collectReport(heartbeat)
-	if err != nil {
-		u.err = err
-		if u.handleErr() {
-			return
-		}
-	}
+	allCollected := u.collectReport(heartbeat)
 
 	if allCollected {
-		newestRegionTree, peersMap, err := u.buildUpFromReports()
-		if err != nil {
-			u.err = err
-			if u.handleErr() {
-				return
-			}
+		newestRegionTree, peersMap, buildErr := u.buildUpFromReports()
+		if buildErr != nil && u.HandleErr(buildErr) {
+			return
 		}
 
 		// clean up previous plan
 		u.storePlanExpires = make(map[uint64]time.Time)
 		u.storeRecoveryPlans = make(map[uint64]*pdpb.RecoveryPlan)
 
-		stage := u.stage
+		var stage unsafeRecoveryStage
+		if u.err == nil {
+			stage = u.stage
+		} else {
+			stage = exitForceLeader
+		}
 		reCheck := false
+		hasPlan := false
+		var err error
 		for {
 			switch stage {
 			case collectReport:
 				fallthrough
 			case tombstoneTiFlashLearner:
-				if u.generateTombstoneTiFlashLearnerPlan(newestRegionTree, peersMap) {
+				if hasPlan, err = u.generateTombstoneTiFlashLearnerPlan(newestRegionTree, peersMap); hasPlan && err == nil {
 					u.changeStage(tombstoneTiFlashLearner)
+					break
+				}
+				if err != nil {
 					break
 				}
 				fallthrough
 			case forceLeaderForCommitMerge:
-				if u.generateForceLeaderPlan(newestRegionTree, peersMap, true) {
+				if hasPlan, err = u.generateForceLeaderPlan(newestRegionTree, peersMap, true); hasPlan && err == nil {
 					u.changeStage(forceLeaderForCommitMerge)
+					break
+				}
+				if err != nil {
 					break
 				}
 				fallthrough
 			case forceLeader:
-				if u.generateForceLeaderPlan(newestRegionTree, peersMap, false) {
+				if hasPlan, err = u.generateForceLeaderPlan(newestRegionTree, peersMap, false); hasPlan && err == nil {
 					u.changeStage(forceLeader)
+					break
+				}
+				if err != nil {
 					break
 				}
 				fallthrough
 			case demoteFailedVoter:
-				if u.generateDemoteFailedVoterPlan(newestRegionTree, peersMap) {
+				if hasPlan = u.generateDemoteFailedVoterPlan(newestRegionTree, peersMap); hasPlan {
 					u.changeStage(demoteFailedVoter)
 					break
 				} else if !reCheck {
@@ -333,27 +353,38 @@ func (u *unsafeRecoveryController) HandleStoreHeartbeat(heartbeat *pdpb.StoreHea
 				}
 				fallthrough
 			case createEmptyRegion:
-				if u.generateCreateEmptyRegionPlan(newestRegionTree, peersMap) {
+				if hasPlan, err = u.generateCreateEmptyRegionPlan(newestRegionTree, peersMap); hasPlan && err == nil {
 					u.changeStage(createEmptyRegion)
+					break
+				}
+				if err != nil {
 					break
 				}
 				fallthrough
 			case exitForceLeader:
 				// no need to generate plan, empty recovery plan triggers exit force leader on TiKV side
-				if u.generateExitForceLeaderPlan() {
+				if hasPlan = u.generateExitForceLeaderPlan(); hasPlan {
 					u.changeStage(exitForceLeader)
 				}
 			default:
 				panic("unreachable")
 			}
 
-			hasPlan := len(u.storeRecoveryPlans) != 0
-			if u.err != nil {
-				if u.handleErr() {
+			if err != nil {
+				if u.HandleErr(err) {
 					return
 				}
+				u.storePlanExpires = make(map[uint64]time.Time)
+				u.storeRecoveryPlans = make(map[uint64]*pdpb.RecoveryPlan)
+				// Clear the reports etc.
+				u.changeStage(exitForceLeader)
+				return
 			} else if !hasPlan {
-				u.changeStage(finished)
+				if u.err != nil {
+					u.changeStage(failed)
+				} else {
+					u.changeStage(finished)
+				}
 				return
 			}
 			break
@@ -363,6 +394,7 @@ func (u *unsafeRecoveryController) HandleStoreHeartbeat(heartbeat *pdpb.StoreHea
 	u.dispatchPlan(heartbeat, resp)
 }
 
+<<<<<<< HEAD
 func (u *unsafeRecoveryController) handleErr() bool {
 	if u.err != nil {
 		if u.stage == exitForceLeader {
@@ -378,6 +410,9 @@ func (u *unsafeRecoveryController) handleErr() bool {
 }
 
 /// It dispatches recovery plan if any.
+=======
+// It dispatches recovery plan if any.
+>>>>>>> 26c31db95 (Prevent PD from crashing due to epoch comparison error (#5449))
 func (u *unsafeRecoveryController) dispatchPlan(heartbeat *pdpb.StoreHeartbeatRequest, resp *pdpb.StoreHeartbeatResponse) {
 	storeID := heartbeat.Stats.StoreId
 	now := time.Now()
@@ -400,21 +435,22 @@ func (u *unsafeRecoveryController) dispatchPlan(heartbeat *pdpb.StoreHeartbeatRe
 }
 
 // It collects and checks if store reports have been fully collected.
-func (u *unsafeRecoveryController) collectReport(heartbeat *pdpb.StoreHeartbeatRequest) (bool, error) {
+func (u *unsafeRecoveryController) collectReport(heartbeat *pdpb.StoreHeartbeatRequest) bool {
 	storeID := heartbeat.Stats.StoreId
 	if _, isFailedStore := u.failedStores[storeID]; isFailedStore {
-		return false, errors.Errorf("Receive heartbeat from failed store %d", storeID)
+		u.HandleErr(errors.Errorf("Receive heartbeat from failed store %d", storeID))
+		return false
 	}
 
 	if heartbeat.StoreReport == nil {
-		return false, nil
+		return false
 	}
 
 	if heartbeat.StoreReport.GetStep() != u.step {
 		log.Info("Unsafe recovery receives invalid store report",
 			zap.Uint64("store-id", storeID), zap.Uint64("expected-step", u.step), zap.Uint64("obtained-step", heartbeat.StoreReport.GetStep()))
 		// invalid store report, ignore
-		return false, nil
+		return false
 	}
 
 	if report, exists := u.storeReports[storeID]; exists {
@@ -423,11 +459,11 @@ func (u *unsafeRecoveryController) collectReport(heartbeat *pdpb.StoreHeartbeatR
 		if report == nil {
 			u.numStoresReported++
 			if u.numStoresReported == len(u.storeReports) {
-				return true, nil
+				return true
 			}
 		}
 	}
-	return false, nil
+	return false
 }
 
 // Gets the stage of the current unsafe recovery.
@@ -499,10 +535,10 @@ func (u *unsafeRecoveryController) changeStage(stage unsafeRecoveryStage) {
 	u.output = append(u.output, output)
 	data, err := json.Marshal(output)
 	if err != nil {
-		u.err = err
-		return
+		log.Error("Unsafe recovery fail to marshal json object", zap.Error(err))
+	} else {
+		log.Info(string(data))
 	}
-	log.Info(string(data))
 
 	// reset store reports to nil instead of delete, because it relays on the item
 	// to decide which store it needs to collect the report from.
@@ -694,7 +730,7 @@ func (r *regionItem) IsInitialized() bool {
 func (r *regionItem) IsEpochStale(other *regionItem) bool {
 	re := r.Region().GetRegionEpoch()
 	oe := other.Region().GetRegionEpoch()
-	return re.GetVersion() < oe.GetVersion() || re.GetConfVer() < oe.GetConfVer()
+	return re.GetVersion() < oe.GetVersion() || (re.GetVersion() == oe.GetVersion() && re.GetConfVer() < oe.GetConfVer())
 }
 
 func (r *regionItem) IsRaftStale(origin *regionItem, u *unsafeRecoveryController) bool {
@@ -885,18 +921,19 @@ func (u *unsafeRecoveryController) selectLeader(peersMap map[uint64][]*regionIte
 	return leader
 }
 
-func (u *unsafeRecoveryController) generateTombstoneTiFlashLearnerPlan(newestRegionTree *regionTree, peersMap map[uint64][]*regionItem) bool {
+func (u *unsafeRecoveryController) generateTombstoneTiFlashLearnerPlan(newestRegionTree *regionTree, peersMap map[uint64][]*regionItem) (bool, error) {
 	if u.err != nil {
-		return false
+		return false, nil
 	}
 	hasPlan := false
 
+	var err error
 	newestRegionTree.tree.Ascend(func(item btree.Item) bool {
 		region := item.(*regionItem).Region()
 		if !u.canElectLeader(region, false) {
 			leader := u.selectLeader(peersMap, region)
 			if leader == nil {
-				u.err = errors.Errorf("can't select leader for region %d: %v", region.GetId(), logutil.RedactStringer(core.RegionToHexMeta(region)))
+				err = errors.Errorf("can't select leader for region %d: %v", region.GetId(), logutil.RedactStringer(core.RegionToHexMeta(region)))
 				return false
 			}
 			storeID := leader.storeID
@@ -910,12 +947,12 @@ func (u *unsafeRecoveryController) generateTombstoneTiFlashLearnerPlan(newestReg
 		}
 		return true
 	})
-	return hasPlan
+	return hasPlan, err
 }
 
-func (u *unsafeRecoveryController) generateForceLeaderPlan(newestRegionTree *regionTree, peersMap map[uint64][]*regionItem, forCommitMerge bool) bool {
+func (u *unsafeRecoveryController) generateForceLeaderPlan(newestRegionTree *regionTree, peersMap map[uint64][]*regionItem, forCommitMerge bool) (bool, error) {
 	if u.err != nil {
-		return false
+		return false, nil
 	}
 	hasPlan := false
 
@@ -928,6 +965,7 @@ func (u *unsafeRecoveryController) generateForceLeaderPlan(newestRegionTree *reg
 		return false
 	}
 
+	var err error
 	// Check the regions in newest Region Tree to see if it can still elect leader
 	// considering the failed stores
 	newestRegionTree.tree.Ascend(func(item btree.Item) bool {
@@ -944,14 +982,14 @@ func (u *unsafeRecoveryController) generateForceLeaderPlan(newestRegionTree *reg
 				// propose an empty raft log on being leader
 				return true
 			} else if !forCommitMerge && report.HasCommitMerge {
-				u.err = errors.Errorf("unexpected commit merge state for report %v", report)
+				err = errors.Errorf("unexpected commit merge state for report %v", report)
 				return false
 			}
 			// the peer with largest log index/term may have lower commit/apply index, namely, lower epoch version
 			// so find which peer should to be the leader instead of using peer info in the region tree.
 			leader := u.selectLeader(peersMap, region)
 			if leader == nil {
-				u.err = errors.Errorf("can't select leader for region %d: %v", region.GetId(), logutil.RedactStringer(core.RegionToHexMeta(region)))
+				err = errors.Errorf("can't select leader for region %d: %v", region.GetId(), logutil.RedactStringer(core.RegionToHexMeta(region)))
 				return false
 			}
 			storeRecoveryPlan := u.getRecoveryPlan(leader.storeID)
@@ -979,7 +1017,7 @@ func (u *unsafeRecoveryController) generateForceLeaderPlan(newestRegionTree *reg
 		}
 	}
 
-	return hasPlan
+	return hasPlan, err
 }
 
 func (u *unsafeRecoveryController) generateDemoteFailedVoterPlan(newestRegionTree *regionTree, peersMap map[uint64][]*regionItem) bool {
@@ -1040,9 +1078,9 @@ func (u *unsafeRecoveryController) generateDemoteFailedVoterPlan(newestRegionTre
 	return hasPlan
 }
 
-func (u *unsafeRecoveryController) generateCreateEmptyRegionPlan(newestRegionTree *regionTree, peersMap map[uint64][]*regionItem) bool {
+func (u *unsafeRecoveryController) generateCreateEmptyRegionPlan(newestRegionTree *regionTree, peersMap map[uint64][]*regionItem) (bool, error) {
 	if u.err != nil {
-		return false
+		return false, nil
 	}
 	hasPlan := false
 
@@ -1073,6 +1111,7 @@ func (u *unsafeRecoveryController) generateCreateEmptyRegionPlan(newestRegionTre
 		return 0
 	}
 
+	var err error
 	// There may be ranges that are covered by no one. Find these empty ranges, create new
 	// regions that cover them and evenly distribute newly created regions among all stores.
 	lastEnd := []byte("")
@@ -1085,13 +1124,13 @@ func (u *unsafeRecoveryController) generateCreateEmptyRegionPlan(newestRegionTre
 				storeID = getRandomStoreID()
 				// can't create new region on tiflash store, choose a random one
 				if storeID == 0 {
-					u.err = errors.New("can't find available store(exclude tiflash) to create new region")
+					err = errors.New("can't find available store(exclude tiflash) to create new region")
 					return false
 				}
 			}
-			newRegion, err := createRegion(lastEnd, region.StartKey, storeID)
-			if err != nil {
-				u.err = err
+			newRegion, createRegionErr := createRegion(lastEnd, region.StartKey, storeID)
+			if createRegionErr != nil {
+				err = createRegionErr
 				return false
 			}
 			// paranoid check: shouldn't overlap with any of the peers
@@ -1104,7 +1143,7 @@ func (u *unsafeRecoveryController) generateCreateEmptyRegionPlan(newestRegionTre
 						(len(newRegion.EndKey) == 0 || bytes.Compare(peer.Region().StartKey, newRegion.EndKey) < 0)) ||
 						((len(peer.Region().EndKey) == 0 || bytes.Compare(newRegion.StartKey, peer.Region().EndKey) < 0) &&
 							(len(newRegion.EndKey) == 0 || (len(peer.Region().EndKey) != 0 && bytes.Compare(peer.Region().EndKey, newRegion.EndKey) <= 0))) {
-						u.err = errors.Errorf(
+						err = errors.Errorf(
 							"Find overlap peer %v with newly created empty region %v",
 							logutil.RedactStringer(core.RegionToHexMeta(peer.Region())),
 							logutil.RedactStringer(core.RegionToHexMeta(newRegion)),
@@ -1122,8 +1161,8 @@ func (u *unsafeRecoveryController) generateCreateEmptyRegionPlan(newestRegionTre
 		lastStoreID = storeID
 		return true
 	})
-	if u.err != nil {
-		return false
+	if err != nil {
+		return false, err
 	}
 
 	if !bytes.Equal(lastEnd, []byte("")) || newestRegionTree.size() == 0 {
@@ -1131,21 +1170,19 @@ func (u *unsafeRecoveryController) generateCreateEmptyRegionPlan(newestRegionTre
 			// the last store id is invalid, so choose a random one
 			lastStoreID = getRandomStoreID()
 			if lastStoreID == 0 {
-				u.err = errors.New("can't find available store(exclude tiflash) to create new region")
-				return false
+				return false, errors.New("can't find available store(exclude tiflash) to create new region")
 			}
 		}
 		newRegion, err := createRegion(lastEnd, []byte(""), lastStoreID)
 		if err != nil {
-			u.err = err
-			return false
+			return false, err
 		}
 		storeRecoveryPlan := u.getRecoveryPlan(lastStoreID)
 		storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, newRegion)
 		u.recordAffectedRegion(newRegion)
 		hasPlan = true
 	}
-	return hasPlan
+	return hasPlan, nil
 }
 
 func (u *unsafeRecoveryController) generateExitForceLeaderPlan() bool {


### PR DESCRIPTION
Signed-off-by: v01dstar <yang.zhang@pingcap.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5418 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
PD crashed because:
1. Region 1 and region 2 are ordered differently while creating the newest peer map and the newest region tree, since r1.Ver < r2.Ver but r1.ConfVer > r2.ConfVer. So, an error was reported while building the tree.
2. While handling the error, previous implementation cleans up the reports and then tries to read it again which results in seg fault.

To fix it:
1. Give Epoch.Ver and Epoch.ConfVer different priorities.
2. Do not clean up reports if PD is exiting force leader due to failures.

```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

N/A

Side effects

No

Related changes

N/A

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
