### PR TITLE
server/cluster: automatic gc tombstone store

### DIFF
--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -270,6 +270,12 @@ func TestSetOfflineStore(t *testing.T) {
 			re.NoError(cluster.BuryStore(storeID, false))
 		}
 	}
+	// test clean up tombstone store
+	toCleanStore := cluster.GetStore(1).Clone().GetMeta()
+	toCleanStore.LastHeartbeat = time.Now().Add(-40 * 24 * time.Hour).UnixNano()
+	cluster.PutStore(toCleanStore)
+	cluster.checkStores()
+	re.Nil(cluster.GetStore(1))
 }
 
 func TestSetOfflineWithReplica(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/5348

### What is changed and how does it work?

In a long-running cluster, there are too many tombstones. introduce auto gc mechanism.
<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
server/cluster: automatic gc tombstone store
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

```release-note
cluster: automatic gc tombstone store
```
