### PR TITLE
statistics: make `HotThresholdRatio` configurable

### DIFF
--- a/pkg/mock/mockcluster/config.go
+++ b/pkg/mock/mockcluster/config.go
@@ -111,6 +111,11 @@ func (mc *Cluster) SetHotRegionCacheHitsThreshold(v int) {
 	mc.updateScheduleConfig(func(s *config.ScheduleConfig) { s.HotRegionCacheHitsThreshold = uint64(v) })
 }
 
+// SetHotThresholdRatio updates the HotThresholdRatio configuration.
+func (mc *Cluster) SetHotThresholdRatio(v int) {
+	mc.updateScheduleConfig(func(s *config.ScheduleConfig) { s.HotThresholdRatio = float64(v) })
+}
+
 // SetEnablePlacementRules updates the EnablePlacementRules configuration.
 func (mc *Cluster) SetEnablePlacementRules(v bool) {
 	mc.updateReplicationConfig(func(r *config.ReplicationConfig) { r.EnablePlacementRules = v })

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -64,7 +64,7 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 	clus := &Cluster{
 		BasicCluster:       core.NewBasicCluster(),
 		IDAllocator:        mockid.NewIDAllocator(),
-		HotStat:            statistics.NewHotStat(ctx),
+		HotStat:            statistics.NewHotStat(ctx, opts),
 		HotBucketCache:     buckets.NewBucketsCache(ctx),
 		PersistOptions:     opts,
 		suspectRegions:     map[uint64]struct{}{},

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -228,7 +228,7 @@ func (c *RaftCluster) InitCluster(
 	c.core, c.opt, c.storage, c.id = basicCluster, opt, storage, id
 	c.ctx, c.cancel = context.WithCancel(c.serverCtx)
 	c.labelLevelStats = statistics.NewLabelStatistics()
-	c.hotStat = statistics.NewHotStat(c.ctx,c.opt)
+	c.hotStat = statistics.NewHotStat(c.ctx, c.opt)
 	c.hotBuckets = buckets.NewBucketsCache(c.ctx)
 	c.progressManager = progress.NewManager()
 	c.changedRegions = make(chan *core.RegionInfo, defaultChangedRegionsLimit)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -228,7 +228,7 @@ func (c *RaftCluster) InitCluster(
 	c.core, c.opt, c.storage, c.id = basicCluster, opt, storage, id
 	c.ctx, c.cancel = context.WithCancel(c.serverCtx)
 	c.labelLevelStats = statistics.NewLabelStatistics()
-	c.hotStat = statistics.NewHotStat(c.ctx)
+	c.hotStat = statistics.NewHotStat(c.ctx,c.opt)
 	c.hotBuckets = buckets.NewBucketsCache(c.ctx)
 	c.progressManager = progress.NewManager()
 	c.changedRegions = make(chan *core.RegionInfo, defaultChangedRegionsLimit)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -776,6 +776,9 @@ type ScheduleConfig struct {
 
 	// EnableWitness is the option to enable using witness
 	EnableWitness bool `toml:"enable-witness" json:"enable-witness,string"`
+
+	// HotThresholdRatio is used to calculate hot thresholds
+	HotThresholdRatio float64 `toml:"hot-threshold-ratio" json:"hot-threshold-ratio,omitempty"`
 }
 
 // Clone returns a cloned scheduling configuration.
@@ -817,6 +820,7 @@ const (
 	// defaultHotRegionCacheHitsThreshold is the low hit number threshold of the
 	// hot region.
 	defaultHotRegionCacheHitsThreshold = 3
+	defaultHotThresholdRatio           = 0.8
 	defaultSchedulerMaxWaitingOperator = 5
 	defaultLeaderSchedulePolicy        = "count"
 	defaultStoreLimitMode              = "manual"
@@ -862,6 +866,9 @@ func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
 	}
 	if !meta.IsDefined("hot-region-cache-hits-threshold") {
 		adjustUint64(&c.HotRegionCacheHitsThreshold, defaultHotRegionCacheHitsThreshold)
+	}
+	if !meta.IsDefined("hot-threshold-ratio") {
+		adjustFloat64(&c.HotThresholdRatio, defaultHotThresholdRatio)
 	}
 	if !meta.IsDefined("tolerant-size-ratio") {
 		adjustFloat64(&c.TolerantSizeRatio, defaultTolerantSizeRatio)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -990,6 +990,9 @@ func (c *ScheduleConfig) Validate() error {
 	if c.TolerantSizeRatio < 0 {
 		return errors.New("tolerant-size-ratio should be non-negative")
 	}
+	if c.HotThresholdRatio < 0 {
+		return errors.New("hot-threshold-ratio should be non-negative")
+	}
 	if c.LowSpaceRatio < 0 || c.LowSpaceRatio > 1 {
 		return errors.New("low-space-ratio should between 0 and 1")
 	}

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -598,6 +598,11 @@ func (o *PersistOptions) GetHotRegionCacheHitsThreshold() int {
 	return int(o.GetScheduleConfig().HotRegionCacheHitsThreshold)
 }
 
+// GetHotThresholdRatio returns HotThresholdRatio.
+func (o *PersistOptions) GetHotThresholdRatio() float64 {
+	return o.GetScheduleConfig().HotThresholdRatio
+}
+
 // GetStoresLimit gets the stores' limit.
 func (o *PersistOptions) GetStoresLimit() map[uint64]StoreLimitConfig {
 	return o.GetScheduleConfig().StoreLimit

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1738,7 +1738,7 @@ func TestHotCacheCheckRegionFlowWithDifferentThreshold(t *testing.T) {
 		}
 	}
 	items := tc.AddLeaderRegionWithWriteInfo(201, 1, rate*statistics.WriteReportInterval, 0, 0, statistics.WriteReportInterval, []uint64{2, 3}, 1)
-	re.Equal(float64(rate)*statistics.HotThresholdRatio, tc.HotCache.GetThresholds(statistics.Write, items[0].StoreID)[0])
+	re.Equal(float64(rate)*opt.GetHotThresholdRatio(), tc.HotCache.GetThresholds(statistics.Write, items[0].StoreID)[0])
 	// Threshold of store 1,2,3 is 409.6 units.KiB and others are 1 units.KiB
 	// Make the hot threshold of some store is high and the others are low
 	rate = 10 * units.KiB

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1012,6 +1012,7 @@ func TestHotReadRegionScheduleByteRateOnly(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	opt := config.NewTestOptions()
+	opt.GetScheduleConfig().HotThresholdRatio = 1.0
 	tc := mockcluster.NewCluster(ctx, opt)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 	scheduler, err := schedule.CreateScheduler(statistics.Read.String(), schedule.NewOperatorController(ctx, nil, nil), storage.NewStorageWithMemoryBackend(), nil)
@@ -1386,6 +1387,7 @@ func TestHotCacheUpdateCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	opt := config.NewTestOptions()
+	opt.GetScheduleConfig().HotThresholdRatio = 1.0
 	tc := mockcluster.NewCluster(ctx, opt)
 	tc.SetHotRegionCacheHitsThreshold(0)
 

--- a/server/schedulers/hot_region_test.go
+++ b/server/schedulers/hot_region_test.go
@@ -1012,9 +1012,9 @@ func TestHotReadRegionScheduleByteRateOnly(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	opt := config.NewTestOptions()
-	opt.GetScheduleConfig().HotThresholdRatio = 1.0
 	tc := mockcluster.NewCluster(ctx, opt)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
+	tc.SetHotThresholdRatio(1.0)
 	scheduler, err := schedule.CreateScheduler(statistics.Read.String(), schedule.NewOperatorController(ctx, nil, nil), storage.NewStorageWithMemoryBackend(), nil)
 	re.NoError(err)
 	hb := scheduler.(*hotScheduler)
@@ -1387,9 +1387,9 @@ func TestHotCacheUpdateCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	opt := config.NewTestOptions()
-	opt.GetScheduleConfig().HotThresholdRatio = 1.0
 	tc := mockcluster.NewCluster(ctx, opt)
 	tc.SetHotRegionCacheHitsThreshold(0)
+	tc.SetHotThresholdRatio(1.0)
 
 	// For read flow
 	addRegionInfo(tc, statistics.Read, []testRegionInfo{

--- a/server/statistics/hot_cache.go
+++ b/server/statistics/hot_cache.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/tikv/pd/pkg/movingaverage"
+	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/core"
 )
 
@@ -30,11 +31,11 @@ type HotCache struct {
 }
 
 // NewHotCache creates a new hot spot cache.
-func NewHotCache(ctx context.Context) *HotCache {
+func NewHotCache(ctx context.Context, opt *config.PersistOptions) *HotCache {
 	w := &HotCache{
 		ctx:        ctx,
-		writeCache: NewHotPeerCache(Write),
-		readCache:  NewHotPeerCache(Read),
+		writeCache: NewHotPeerCache(Write, opt),
+		readCache:  NewHotPeerCache(Read, opt),
 	}
 	go w.updateItems(w.readCache.taskQueue, w.runReadTask)
 	go w.updateItems(w.writeCache.taskQueue, w.runWriteTask)

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -304,14 +304,14 @@ func (f *hotPeerCache) calcHotThresholds(storeID uint64) []float64 {
 	}
 	f.thresholdsOfStore[storeID] = t
 	statKinds := f.kind.RegionStats()
+	hotThresholdRatio := f.opt.GetHotThresholdRatio()
 	for dim, kind := range statKinds {
-		t.rates[dim] = MinHotThresholds[kind]
+		t.rates[dim] = MinHotThresholds[kind] * hotThresholdRatio
 	}
 	tn, ok := f.peersOfStore[storeID]
 	if !ok || tn.Len() < TopNN {
 		return t.rates
 	}
-	hotThresholdRatio := f.opt.GetHotThresholdRatio()
 	for i := range t.rates {
 		t.rates[i] = math.Max(tn.GetTopNMin(i).(*HotPeerStat).GetLoad(i)*hotThresholdRatio, t.rates[i])
 	}

--- a/server/statistics/hot_peer_cache.go
+++ b/server/statistics/hot_peer_cache.go
@@ -313,7 +313,8 @@ func (f *hotPeerCache) calcHotThresholds(storeID uint64) []float64 {
 		return t.rates
 	}
 	for i := range t.rates {
-		t.rates[i] = math.Max(tn.GetTopNMin(i).(*HotPeerStat).GetLoad(i)*hotThresholdRatio, t.rates[i])
+		topn := tn.GetTopNMin(i).(*HotPeerStat).GetLoad(i)
+		t.rates[i] = math.Max(topn*math.Min(hotThresholdRatio, 1.0), t.rates[i])
 	}
 	return t.rates
 }

--- a/server/statistics/hot_stat.go
+++ b/server/statistics/hot_stat.go
@@ -27,9 +27,9 @@ type HotStat struct {
 }
 
 // NewHotStat creates the container to hold cluster's hotspot statistics.
-func NewHotStat(ctx context.Context,opt *config.PersistOptions) *HotStat {
+func NewHotStat(ctx context.Context, opt *config.PersistOptions) *HotStat {
 	return &HotStat{
-		HotCache:    NewHotCache(ctx,opt),
+		HotCache:    NewHotCache(ctx, opt),
 		StoresStats: NewStoresStats(),
 	}
 }

--- a/server/statistics/hot_stat.go
+++ b/server/statistics/hot_stat.go
@@ -16,6 +16,8 @@ package statistics
 
 import (
 	"context"
+
+	"github.com/tikv/pd/server/config"
 )
 
 // HotStat contains cluster's hotspot statistics.
@@ -25,9 +27,9 @@ type HotStat struct {
 }
 
 // NewHotStat creates the container to hold cluster's hotspot statistics.
-func NewHotStat(ctx context.Context) *HotStat {
+func NewHotStat(ctx context.Context,opt *config.PersistOptions) *HotStat {
 	return &HotStat{
-		HotCache:    NewHotCache(ctx),
+		HotCache:    NewHotCache(ctx,opt),
 		StoresStats: NewStoresStats(),
 	}
 }

--- a/server/statistics/metrics.go
+++ b/server/statistics/metrics.go
@@ -178,6 +178,14 @@ var (
 			Name:      "hot_peers_summary",
 			Help:      "Hot peers summary for each store",
 		}, []string{"type", "store"})
+
+	hotThreshold = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "hotcache",
+			Name:      "threshold",
+			Help:      "The threshold of hot region",
+		}, []string{"type", "dim", "store"})
 )
 
 var (
@@ -205,4 +213,5 @@ func init() {
 	prometheus.MustRegister(regionAbnormalPeerDuration)
 	prometheus.MustRegister(hotCacheFlowQueueStatusGauge)
 	prometheus.MustRegister(hotPeerSummary)
+	prometheus.MustRegister(hotThreshold)
 }

--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -218,7 +218,10 @@ func TestConfig(t *testing.T) {
 			return scheduleConfig.HotRegionScheduleLimit
 		}}, {"hot-region-cache-hits-threshold", uint64(5), func(scheduleConfig *config.ScheduleConfig) interface{} {
 			return scheduleConfig.HotRegionCacheHitsThreshold
-		}}, {"enable-remove-down-replica", false, func(scheduleConfig *config.ScheduleConfig) interface{} {
+		}}, {"hot-threshold-ratio", 1.2, func(scheduleConfig *config.ScheduleConfig) interface{} {
+			return scheduleConfig.HotThresholdRatio
+		}},
+		{"enable-remove-down-replica", false, func(scheduleConfig *config.ScheduleConfig) interface{} {
 			return scheduleConfig.EnableRemoveDownReplica
 		}},
 		{"enable-debug-metrics", true, func(scheduleConfig *config.ScheduleConfig) interface{} {


### PR DESCRIPTION
Signed-off-by: lhy1024 <admin@liudos.us>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5692

### What is changed and how does it work?

The current threshold for hotspot statistics, when the number of hot regions is too large, we will use the value of top60 as the threshold. This top60 will count the hot regions within three minutes.

For clusters with drastic load changes, hotspot statistics will consume a lot of memory. As a temporary means, we need to be able to configure the threshold of statistics
![image](https://user-images.githubusercontent.com/19542290/205207721-2d3160ff-2291-4f83-8f15-3b3aff3fdd74.png)

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
