### PR TITLE
operator: When replacing-down-peer, it should not stop at the step of leave-joint-state

### DIFF
--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -755,7 +755,7 @@ func (dv DemoteVoter) IsFinish(region *core.RegionInfo) bool {
 			log.Warn("obtain unexpected peer", zap.String("expect", dv.String()), zap.Uint64("obtain-learner", peer.GetId()))
 			return false
 		}
-		return region.GetPendingLearner(peer.GetId()) == nil
+		return peer.GetId() == dv.PeerID
 	}
 	return false
 }

--- a/server/schedule/operator/step_test.go
+++ b/server/schedule/operator/step_test.go
@@ -569,8 +569,8 @@ func (suite *operatorStepTestSuite) check(step OpStep, desc string, testCases []
 		err := step.CheckInProgress(suite.cluster, region)
 		testCase.CheckInProgress(err)
 		_ = step.GetCmd(region, true)
-		switch step.(type) {
-		case ChangePeerV2Leave:
+
+		if _, ok := step.(ChangePeerV2Leave); ok {
 			// Ref https://github.com/tikv/pd/issues/5788
 			pendingPeers := region.GetLearners()
 			region = region.Clone(core.WithPendingPeers(pendingPeers))

--- a/server/schedule/operator/step_test.go
+++ b/server/schedule/operator/step_test.go
@@ -569,5 +569,12 @@ func (suite *operatorStepTestSuite) check(step OpStep, desc string, testCases []
 		err := step.CheckInProgress(suite.cluster, region)
 		testCase.CheckInProgress(err)
 		_ = step.GetCmd(region, true)
+		switch step.(type) {
+		case ChangePeerV2Leave:
+			// Ref https://github.com/tikv/pd/issues/5788
+			pendingPeers := region.GetLearners()
+			region = region.Clone(core.WithPendingPeers(pendingPeers))
+			suite.Equal(testCase.IsFinish, step.IsFinish(region))
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5788

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

Rolled back some code from #5568 and added unittest.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fixed an issue that `replace-down-peer` could be too slow.
```
