### PR TITLE
step: fix non-witness ConfVerChanged impl

### DIFF
--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -285,7 +285,7 @@ type BecomeNonWitness struct {
 // ConfVerChanged returns the delta value for version increased by this step.
 func (bn BecomeNonWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
 	peer := region.GetStorePeer(bn.StoreID)
-	return typeutil.BoolToUint64((peer.GetId() == bn.PeerID) && !peer.GetIsWitness() && (region.GetPendingPeer(peer.GetId()) == nil))
+	return typeutil.BoolToUint64((peer.GetId() == bn.PeerID) && !peer.GetIsWitness())
 }
 
 func (bn BecomeNonWitness) String() string {

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -285,6 +285,9 @@ type BecomeNonWitness struct {
 // ConfVerChanged returns the delta value for version increased by this step.
 func (bn BecomeNonWitness) ConfVerChanged(region *core.RegionInfo) uint64 {
 	peer := region.GetStorePeer(bn.StoreID)
+	// After TiKV has applied this raftcmd, the region ConfVer will be changed immediately,
+	// non-witness will be in pending state until apply snapshot completes, will check
+	// pending stat in `IsFinish`.
 	return typeutil.BoolToUint64((peer.GetId() == bn.PeerID) && !peer.GetIsWitness())
 }
 


### PR DESCRIPTION
ref tikv/tikv#12876

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5823

### What is changed and how does it work?

When PD sends RaftCmd (batch switch witness) to TiKV, TiKV applied, the region confver will change imm, but non-witness peer is pending (waiting for snapshot), it shouldn't used to judge ConfVerChanged, so remove it.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
step: fix non-witness ConfVerChanged impl
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test

Code changes

- step.go

Side effects

- None

Related changes

- None

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
