### PR TITLE
config: add `EnableWatch` config

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -482,7 +482,10 @@ func (c *RaftCluster) runCoordinator() {
 func (c *RaftCluster) syncRegions() {
 	defer logutil.LogPanic()
 	defer c.wg.Done()
-	c.regionSyncer.RunServer(c.ctx, c.changedRegionNotifier())
+	if !c.GetOpts().IsWatchEnabled() {
+		c.regionSyncer.RunServer(c.ctx, c.changedRegionNotifier())
+	}
+	// TODO: support watch mechanism
 }
 
 func (c *RaftCluster) runReplicationMode() {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -233,6 +233,7 @@ const (
 	defaultLeaderPriorityCheckInterval = time.Minute
 
 	defaultUseRegionStorage  = true
+	defaultEnableWatch       = false
 	defaultTraceRegionFlow   = true
 	defaultFlowRoundByDigit  = 3 // KB
 	maxTraceFlowRoundByDigit = 5 // 0.1 MB
@@ -1169,12 +1170,17 @@ type PDServerConfig struct {
 	FlowRoundByDigit int `toml:"flow-round-by-digit" json:"flow-round-by-digit"`
 	// MinResolvedTSPersistenceInterval is the interval to save the min resolved ts.
 	MinResolvedTSPersistenceInterval typeutil.Duration `toml:"min-resolved-ts-persistence-interval" json:"min-resolved-ts-persistence-interval"`
+	// EnableWatch enables the watch mechanism.
+	EnableWatch bool `toml:"enable-watch" json:"enable-watch,string"`
 }
 
 func (c *PDServerConfig) adjust(meta *configMetaData) error {
 	adjustDuration(&c.MaxResetTSGap, defaultMaxResetTSGap)
 	if !meta.IsDefined("use-region-storage") {
 		c.UseRegionStorage = defaultUseRegionStorage
+	}
+	if !meta.IsDefined("enable-watch") {
+		c.EnableWatch = defaultEnableWatch
 	}
 	if !meta.IsDefined("key-type") {
 		c.KeyType = defaultKeyType

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -60,6 +60,7 @@ func TestReloadConfig(t *testing.T) {
 	scheduleCfg.MaxSnapshotCount = 10
 	opt.SetMaxReplicas(5)
 	opt.GetPDServerConfig().UseRegionStorage = true
+	opt.GetPDServerConfig().EnableWatch = true
 	re.NoError(opt.Persist(storage))
 
 	// Add a new default enable scheduler "shuffle-leader"
@@ -74,6 +75,7 @@ func TestReloadConfig(t *testing.T) {
 	schedulers := newOpt.GetSchedulers()
 	re.Len(schedulers, len(DefaultSchedulers))
 	re.True(newOpt.IsUseRegionStorage())
+	re.True(newOpt.IsWatchEnabled())
 	for i, s := range schedulers {
 		re.Equal(DefaultSchedulers[i].Type, s.Type)
 		re.False(s.Disable)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -537,6 +537,11 @@ func (o *PersistOptions) IsUseRegionStorage() bool {
 	return o.GetPDServerConfig().UseRegionStorage
 }
 
+// IsWatchEnabled returns if the watch is enabled.
+func (o *PersistOptions) IsWatchEnabled() bool {
+	return o.GetPDServerConfig().EnableWatch
+}
+
 // IsRemoveDownReplicaEnabled returns if remove down replica is enabled.
 func (o *PersistOptions) IsRemoveDownReplicaEnabled() bool {
 	return o.GetScheduleConfig().EnableRemoveDownReplica

--- a/server/region_syncer/server.go
+++ b/server/region_syncer/server.go
@@ -102,13 +102,15 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 		limit:     ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
 		tlsConfig: s.GetTLSConfig(),
 	}
-	syncer.mu.streams = make(map[string]ServerStream)
 	return syncer
 }
 
 // RunServer runs the server of the region syncer.
 // regionNotifier is used to get the changed regions.
 func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *core.RegionInfo) {
+	s.mu.Lock()
+	s.mu.streams = make(map[string]ServerStream)
+	s.mu.Unlock()
 	var requests []*metapb.Region
 	var stats []*pdpb.RegionStat
 	var leaders []*metapb.Peer

--- a/server/server.go
+++ b/server/server.go
@@ -1350,7 +1350,10 @@ func (s *Server) leaderLoop() {
 			go s.tsoAllocatorManager.ClusterDCLocationChecker()
 			syncer := s.cluster.GetRegionSyncer()
 			if s.persistOptions.IsUseRegionStorage() {
-				syncer.StartSyncWithLeader(leader.GetClientUrls()[0])
+				if !s.persistOptions.IsWatchEnabled() {
+					syncer.StartSyncWithLeader(leader.GetClientUrls()[0])
+				}
+				// TODO: enable watch mechanism.
 			}
 			log.Info("start to watch pd leader", zap.Stringer("pd-leader", leader))
 			// WatchLeader will keep looping and never return unless the PD leader has changed.

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -759,6 +759,7 @@ func TestSetScheduleOpt(t *testing.T) {
 	replicationCfg.MaxReplicas = 5
 	scheduleCfg.MaxSnapshotCount = 10
 	pdServerCfg.UseRegionStorage = true
+	pdServerCfg.EnableWatch = true
 	typ, labelKey, labelValue := "testTyp", "testKey", "testValue"
 	re.NoError(svr.SetScheduleConfig(*scheduleCfg))
 	re.NoError(svr.SetPDServerConfig(*pdServerCfg))
@@ -767,6 +768,7 @@ func TestSetScheduleOpt(t *testing.T) {
 	re.Equal(5, persistOptions.GetMaxReplicas())
 	re.Equal(uint64(10), persistOptions.GetMaxSnapshotCount())
 	re.True(persistOptions.IsUseRegionStorage())
+	re.True(persistOptions.IsWatchEnabled())
 	re.Equal("testKey", persistOptions.GetLabelPropertyConfig()[typ][0].Key)
 	re.Equal("testValue", persistOptions.GetLabelPropertyConfig()[typ][0].Value)
 	re.NoError(svr.DeleteLabelProperty(typ, labelKey, labelValue))


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5825.

### What is changed and how does it work?
This PR can be reviewed after #5846 is merged. It adds a config named `EnableWatch` to change the synchronizing way between the original one and the watch mechanism.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
