### PR TITLE
*: support list and watch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -189,3 +189,5 @@ require (
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.
 // After the PR to kvproto is merged, remember to comment this out and run `go mod tidy`.
 // replace github.com/pingcap/kvproto => github.com/$YourPrivateRepo $YourPrivateBranch
+
+replace github.com/pingcap/kvproto => github.com/rleungx/kvproto v0.0.0-20230109095105-0fb3bc985ef7

--- a/go.sum
+++ b/go.sum
@@ -170,7 +170,6 @@ github.com/goccy/go-graphviz v0.0.9/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQF
 github.com/goccy/go-json v0.9.7 h1:IcB+Aqpx/iMHu5Yooh7jEzJk1JZ7Pjtmys2ukPr7EeM=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -185,7 +184,6 @@ github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -364,9 +362,6 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce h1:Y1kCxlCtlPTMtVcOkjUcuQKh+YrluSo7+7YMCQSzy30=
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20230105060948-64890fa4f6c1 h1:jw4NjEiCleRJPPpHM7K6l8OKzOjnZAj62eKteCAY6ro=
-github.com/pingcap/kvproto v0.0.0-20230105060948-64890fa4f6c1/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
@@ -404,6 +399,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rleungx/kvproto v0.0.0-20230109095105-0fb3bc985ef7 h1:8VXLh6iFWKUvtidWCK3Rd9+kk7BgJp7O//BlRUD1wqA=
+github.com/rleungx/kvproto v0.0.0-20230109095105-0fb3bc985ef7/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -692,11 +689,9 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c h1:hrpEMCZ2O7DR5gC1n2AJGVhrwiEjOi35+jxtIuZpTMo=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
-google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/server/region_syncer/client.go
+++ b/server/region_syncer/client.go
@@ -16,6 +16,7 @@ package syncer
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -35,8 +36,9 @@ import (
 )
 
 const (
-	keepaliveTime    = 10 * time.Second
-	keepaliveTimeout = 3 * time.Second
+	keepaliveTime      = 10 * time.Second
+	keepaliveTimeout   = 3 * time.Second
+	regionStatResource = "regionstat"
 )
 
 // StopSyncWithLeader stop to sync the region with leader.
@@ -103,6 +105,204 @@ func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (C
 	}
 
 	return syncStream, nil
+}
+
+func (s *RegionSyncer) watchRegion(ctx context.Context, conn *grpc.ClientConn) (WatchClientStream, error) {
+	cli := pdpb.NewPDClient(conn)
+	stream, err := cli.Watch(ctx, &pdpb.WatchRequest{
+		Header:   &pdpb.RequestHeader{ClusterId: s.server.ClusterID()},
+		Revision: s.history.GetNextIndex(),
+		Resource: regionStatResource,
+		Name:     s.server.Name(),
+	})
+	return stream, err
+}
+
+func (s *RegionSyncer) listRegion(ctx context.Context, conn *grpc.ClientConn) (ListClientStream, error) {
+	cli := pdpb.NewPDClient(conn)
+	stream, err := cli.List(ctx, &pdpb.ListRequest{
+		Header:   &pdpb.RequestHeader{ClusterId: s.server.ClusterID()},
+		Revision: 0,
+		Resource: regionStatResource,
+		Name:     s.server.Name(),
+	})
+	return stream, err
+}
+
+// StartWatchLeader will start to watch the leader for region changes.
+func (s *RegionSyncer) StartWatchLeader(addr string) {
+	s.wg.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.clientCtx, s.mu.clientCancel = context.WithCancel(s.server.LoopContext())
+	ctx := s.mu.clientCtx
+
+	go func() {
+		defer s.wg.Done()
+		bc := s.server.GetBasicCluster()
+		regionStorage := s.server.GetStorage()
+		log.Info("region syncer start load region")
+		start := time.Now()
+		err := storage.TryLoadRegionsOnce(ctx, regionStorage, bc.CheckAndPutRegion)
+		log.Info("region syncer finished load region", zap.Duration("time-cost", time.Since(start)))
+		if err != nil {
+			log.Warn("failed to load regions.", errs.ZapError(err))
+		}
+		// establish client.
+		var conn *grpc.ClientConn
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			conn, err = s.establish(ctx, addr)
+			if err != nil {
+				log.Error("cannot establish connection with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), errs.ZapError(err))
+				continue
+			}
+			break
+		}
+		defer conn.Close()
+		var done bool
+		// need to do full synchronization
+		if s.history.GetNextIndex() == 0 {
+			for {
+				if done {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				stream, err := s.listRegion(ctx, conn)
+				if err != nil {
+					if ev, ok := status.FromError(err); ok {
+						if ev.Code() == codes.Canceled {
+							return
+						}
+					}
+
+					log.Error("server failed to establish list stream with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), errs.ZapError(err))
+					time.Sleep(time.Second)
+					continue
+				}
+				for {
+					resp, err := stream.Recv()
+					if err == io.EOF {
+						done = true
+						break
+					}
+					if err != nil {
+						log.Error("synchronize the full regions with leader meet error", errs.ZapError(errs.ErrGRPCRecv, err))
+						if err = stream.CloseSend(); err != nil {
+							log.Error("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
+						}
+						time.Sleep(time.Second)
+						break
+					}
+					if s.history.GetNextIndex() != resp.GetRevision() {
+						log.Warn("list revision not match the leader",
+							zap.String("server", s.server.Name()),
+							zap.Uint64("own", s.history.GetNextIndex()),
+							zap.Uint64("leader", resp.GetRevision()),
+							zap.Int("records-length", len(resp.GetItems())))
+						// reset index
+						s.history.ResetWithIndex(resp.GetRevision())
+					}
+					items := resp.GetItems()
+					for _, item := range items {
+						regionStat := item.GetRegionStat()
+						region := core.NewRegionInfo(regionStat.GetRegion(), regionStat.GetLeader(),
+							core.SetWrittenBytes(regionStat.GetRegionStats().BytesWritten),
+							core.SetWrittenKeys(regionStat.GetRegionStats().KeysWritten),
+							core.SetReadBytes(regionStat.GetRegionStats().BytesRead),
+							core.SetReadKeys(regionStat.GetRegionStats().KeysRead),
+							core.SetFromHeartbeat(false))
+						s.save(bc, regionStorage, region, regionStat)
+					}
+				}
+			}
+		}
+		// Start to watch.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			stream, err := s.watchRegion(ctx, conn)
+			if err != nil {
+				if ev, ok := status.FromError(err); ok {
+					if ev.Code() == codes.Canceled {
+						return
+					}
+				}
+				log.Error("server failed to establish watch stream with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), errs.ZapError(err))
+				time.Sleep(time.Second)
+				continue
+			}
+
+			log.Info("server starts to synchronize increment with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), zap.Uint64("request-index", s.history.GetNextIndex()))
+			for {
+				resp, err := stream.Recv()
+				if err != nil {
+					log.Error("synchronize the incremental regions leader meet error", errs.ZapError(errs.ErrGRPCRecv, err))
+					if err = stream.CloseSend(); err != nil {
+						log.Error("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
+					}
+					time.Sleep(time.Second)
+					break
+				}
+				if s.history.GetNextIndex() != resp.GetRevision() {
+					log.Warn("watch revision not match the leader",
+						zap.String("server", s.server.Name()),
+						zap.Uint64("own", s.history.GetNextIndex()),
+						zap.Uint64("leader", resp.GetRevision()),
+						zap.Int("records-length", len(resp.GetEvents())))
+					// reset index
+					s.history.ResetWithIndex(resp.GetRevision())
+				}
+				event := resp.GetEvents()
+				for _, e := range event {
+					regionStat := e.Item.GetRegionStat()
+					region := core.NewRegionInfo(regionStat.GetRegion(), regionStat.GetLeader(),
+						core.SetWrittenBytes(regionStat.GetRegionStats().BytesWritten),
+						core.SetWrittenKeys(regionStat.GetRegionStats().KeysWritten),
+						core.SetReadBytes(regionStat.GetRegionStats().BytesRead),
+						core.SetReadKeys(regionStat.GetRegionStats().KeysRead),
+						core.SetFromHeartbeat(false))
+					s.save(bc, regionStorage, region, regionStat)
+				}
+			}
+		}
+	}()
+}
+
+func (s *RegionSyncer) save(bc *core.BasicCluster, regionStorage storage.Storage, region *core.RegionInfo, regionStat *pdpb.RegionStats) {
+	origin, _, err := bc.PreCheckPutRegion(region)
+	if err != nil {
+		log.Debug("region is stale", zap.Stringer("origin", origin.GetMeta()), errs.ZapError(err))
+		return
+	}
+	_, saveKV, _, _ := regionGuide(region, origin)
+	overlaps := bc.PutRegion(region)
+
+	if regionStat.GetBuckets() != nil {
+		if old := origin.GetBuckets(); regionStat.GetBuckets().GetVersion() > old.GetVersion() {
+			region.UpdateBuckets(regionStat.GetBuckets(), old)
+		}
+	}
+	if saveKV {
+		err = regionStorage.SaveRegion(region.GetMeta())
+	}
+	if err == nil {
+		s.history.Record(region)
+	}
+	for _, old := range overlaps {
+		_ = regionStorage.DeleteRegion(old.GetMeta())
+	}
 }
 
 var regionGuide = core.GenerateRegionGuideFunc(false)

--- a/tests/client/go.mod
+++ b/tests/client/go.mod
@@ -166,3 +166,5 @@ replace (
 	google.golang.org/grpc v1.43.0 => google.golang.org/grpc v1.26.0
 	google.golang.org/protobuf v1.26.0 => github.com/golang/protobuf v1.3.4
 )
+
+replace github.com/pingcap/kvproto => github.com/rleungx/kvproto v0.0.0-20230109095105-0fb3bc985ef7

--- a/tests/client/go.sum
+++ b/tests/client/go.sum
@@ -145,7 +145,6 @@ github.com/goccy/go-graphviz v0.0.9/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQF
 github.com/goccy/go-json v0.9.7 h1:IcB+Aqpx/iMHu5Yooh7jEzJk1JZ7Pjtmys2ukPr7EeM=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -159,7 +158,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -326,10 +324,6 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 h1:C3N3itkduZXDZFh4N3vQ5HEtld3S+Y+StULhWVvumU0=
 github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
-github.com/pingcap/kvproto v0.0.0-20230105060948-64890fa4f6c1 h1:jw4NjEiCleRJPPpHM7K6l8OKzOjnZAj62eKteCAY6ro=
-github.com/pingcap/kvproto v0.0.0-20230105060948-64890fa4f6c1/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
@@ -366,6 +360,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/rleungx/kvproto v0.0.0-20230109095105-0fb3bc985ef7 h1:8VXLh6iFWKUvtidWCK3Rd9+kk7BgJp7O//BlRUD1wqA=
+github.com/rleungx/kvproto v0.0.0-20230109095105-0fb3bc985ef7/go.mod h1:OYtxs0786qojVTmkVeufx93xe+jUgm56GUYRIKnmaGI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -628,11 +624,9 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c h1:hrpEMCZ2O7DR5gC1n2AJGVhrwiEjOi35+jxtIuZpTMo=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
-google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5825.

### What is changed and how does it work?
This PR adds `List` and `Watch` methods for the server and adds a new way to synchronize regions among the PD servers. The main changes of this PR are listed as follows:
- implement the `List` and `Watch` in `grpc_service.go`
- add `StartWatchLeader` on the client side, which plays the same role as the original `StartSyncWithLeader`.
- add `RunWatchServer` on the server side, which plays the same role as the original `RunServer`
- split the original sync process into two phases: list and watch. If the local history index is 0, it will first call `listRegion` to get all regions, otherwise, it will only call `watchRegion` with a given history index

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test (TODO)

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
