### PR TITLE
schedulers: split transfer-witness-leader's limit from balance-leader

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -670,8 +670,6 @@ type ScheduleConfig struct {
 	MaxStorePreparingTime typeutil.Duration `toml:"max-store-preparing-time" json:"max-store-preparing-time"`
 	// LeaderScheduleLimit is the max coexist leader schedules.
 	LeaderScheduleLimit uint64 `toml:"leader-schedule-limit" json:"leader-schedule-limit"`
-	// WitnessLeaderScheduleLimit is the max coexist witness leader schedules.
-	WitnessLeaderScheduleLimit uint64 `toml:"witness-leader-schedule-limit" json:"witness-leader-schedule-limit"`
 	// LeaderSchedulePolicy is the option to balance leader, there are some policies supported: ["count", "size"], default: "count"
 	LeaderSchedulePolicy string `toml:"leader-schedule-policy" json:"leader-schedule-policy"`
 	// RegionScheduleLimit is the max coexist region schedules.
@@ -802,26 +800,25 @@ func (c *ScheduleConfig) Clone() *ScheduleConfig {
 }
 
 const (
-	defaultMaxReplicas                = 3
-	defaultMaxSnapshotCount           = 64
-	defaultMaxPendingPeerCount        = 64
-	defaultMaxMergeRegionSize         = 20
-	defaultSplitMergeInterval         = time.Hour
-	defaultSwitchWitnessInterval      = time.Hour
-	defaultEnableDiagnostic           = false
-	defaultPatrolRegionInterval       = 10 * time.Millisecond
-	defaultMaxStoreDownTime           = 30 * time.Minute
-	defaultLeaderScheduleLimit        = 4
-	defaultWitnessLeaderScheduleLimit = 2048
-	defaultRegionScheduleLimit        = 2048
-	defaultWitnessScheduleLimit       = 4
-	defaultReplicaScheduleLimit       = 64
-	defaultMergeScheduleLimit         = 8
-	defaultHotRegionScheduleLimit     = 4
-	defaultTolerantSizeRatio          = 0
-	defaultLowSpaceRatio              = 0.8
-	defaultHighSpaceRatio             = 0.7
-	defaultRegionScoreFormulaVersion  = "v2"
+	defaultMaxReplicas               = 3
+	defaultMaxSnapshotCount          = 64
+	defaultMaxPendingPeerCount       = 64
+	defaultMaxMergeRegionSize        = 20
+	defaultSplitMergeInterval        = time.Hour
+	defaultSwitchWitnessInterval     = time.Hour
+	defaultEnableDiagnostic          = false
+	defaultPatrolRegionInterval      = 10 * time.Millisecond
+	defaultMaxStoreDownTime          = 30 * time.Minute
+	defaultLeaderScheduleLimit       = 4
+	defaultRegionScheduleLimit       = 2048
+	defaultWitnessScheduleLimit      = 4
+	defaultReplicaScheduleLimit      = 64
+	defaultMergeScheduleLimit        = 8
+	defaultHotRegionScheduleLimit    = 4
+	defaultTolerantSizeRatio         = 0
+	defaultLowSpaceRatio             = 0.8
+	defaultHighSpaceRatio            = 0.7
+	defaultRegionScoreFormulaVersion = "v2"
 	// defaultHotRegionCacheHitsThreshold is the low hit number threshold of the
 	// hot region.
 	defaultHotRegionCacheHitsThreshold = 3
@@ -855,9 +852,6 @@ func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
 	adjustDuration(&c.MaxStorePreparingTime, defaultMaxStorePreparingTime)
 	if !meta.IsDefined("leader-schedule-limit") {
 		adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
-	}
-	if !meta.IsDefined("witness-leader-schedule-limit") {
-		adjustUint64(&c.WitnessLeaderScheduleLimit, defaultWitnessLeaderScheduleLimit)
 	}
 	if !meta.IsDefined("region-schedule-limit") {
 		adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -670,6 +670,8 @@ type ScheduleConfig struct {
 	MaxStorePreparingTime typeutil.Duration `toml:"max-store-preparing-time" json:"max-store-preparing-time"`
 	// LeaderScheduleLimit is the max coexist leader schedules.
 	LeaderScheduleLimit uint64 `toml:"leader-schedule-limit" json:"leader-schedule-limit"`
+	// WitnessLeaderScheduleLimit is the max coexist witness leader schedules.
+	WitnessLeaderScheduleLimit uint64 `toml:"witness-leader-schedule-limit" json:"witness-leader-schedule-limit"`
 	// LeaderSchedulePolicy is the option to balance leader, there are some policies supported: ["count", "size"], default: "count"
 	LeaderSchedulePolicy string `toml:"leader-schedule-policy" json:"leader-schedule-policy"`
 	// RegionScheduleLimit is the max coexist region schedules.
@@ -800,25 +802,26 @@ func (c *ScheduleConfig) Clone() *ScheduleConfig {
 }
 
 const (
-	defaultMaxReplicas               = 3
-	defaultMaxSnapshotCount          = 64
-	defaultMaxPendingPeerCount       = 64
-	defaultMaxMergeRegionSize        = 20
-	defaultSplitMergeInterval        = time.Hour
-	defaultSwitchWitnessInterval     = time.Hour
-	defaultEnableDiagnostic          = false
-	defaultPatrolRegionInterval      = 10 * time.Millisecond
-	defaultMaxStoreDownTime          = 30 * time.Minute
-	defaultLeaderScheduleLimit       = 4
-	defaultRegionScheduleLimit       = 2048
-	defaultWitnessScheduleLimit      = 4
-	defaultReplicaScheduleLimit      = 64
-	defaultMergeScheduleLimit        = 8
-	defaultHotRegionScheduleLimit    = 4
-	defaultTolerantSizeRatio         = 0
-	defaultLowSpaceRatio             = 0.8
-	defaultHighSpaceRatio            = 0.7
-	defaultRegionScoreFormulaVersion = "v2"
+	defaultMaxReplicas                = 3
+	defaultMaxSnapshotCount           = 64
+	defaultMaxPendingPeerCount        = 64
+	defaultMaxMergeRegionSize         = 20
+	defaultSplitMergeInterval         = time.Hour
+	defaultSwitchWitnessInterval      = time.Hour
+	defaultEnableDiagnostic           = false
+	defaultPatrolRegionInterval       = 10 * time.Millisecond
+	defaultMaxStoreDownTime           = 30 * time.Minute
+	defaultLeaderScheduleLimit        = 4
+	defaultWitnessLeaderScheduleLimit = 2048
+	defaultRegionScheduleLimit        = 2048
+	defaultWitnessScheduleLimit       = 4
+	defaultReplicaScheduleLimit       = 64
+	defaultMergeScheduleLimit         = 8
+	defaultHotRegionScheduleLimit     = 4
+	defaultTolerantSizeRatio          = 0
+	defaultLowSpaceRatio              = 0.8
+	defaultHighSpaceRatio             = 0.7
+	defaultRegionScoreFormulaVersion  = "v2"
 	// defaultHotRegionCacheHitsThreshold is the low hit number threshold of the
 	// hot region.
 	defaultHotRegionCacheHitsThreshold = 3
@@ -852,6 +855,9 @@ func (c *ScheduleConfig) adjust(meta *configMetaData, reloading bool) error {
 	adjustDuration(&c.MaxStorePreparingTime, defaultMaxStorePreparingTime)
 	if !meta.IsDefined("leader-schedule-limit") {
 		adjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
+	}
+	if !meta.IsDefined("witness-leader-schedule-limit") {
+		adjustUint64(&c.WitnessLeaderScheduleLimit, defaultWitnessLeaderScheduleLimit)
 	}
 	if !meta.IsDefined("region-schedule-limit") {
 		adjustUint64(&c.RegionScheduleLimit, defaultRegionScheduleLimit)

--- a/server/schedule/operator/kind.go
+++ b/server/schedule/operator/kind.go
@@ -42,32 +42,36 @@ const (
 	OpRegion
 	// Include leader transfer.
 	OpLeader
+	// Include witness leader transfer.
+	OpWitnessLeader
 	// Include witness transfer.
 	OpWitness
 	opMax
 )
 
 var flagToName = map[OpKind]string{
-	OpLeader:    "leader",
-	OpRegion:    "region",
-	OpSplit:     "split",
-	OpAdmin:     "admin",
-	OpHotRegion: "hot-region",
-	OpReplica:   "replica",
-	OpMerge:     "merge",
-	OpRange:     "range",
-	OpWitness:   "witness",
+	OpLeader:        "leader",
+	OpRegion:        "region",
+	OpSplit:         "split",
+	OpAdmin:         "admin",
+	OpHotRegion:     "hot-region",
+	OpReplica:       "replica",
+	OpMerge:         "merge",
+	OpRange:         "range",
+	OpWitness:       "witness",
+	OpWitnessLeader: "witness-leader",
 }
 
 var nameToFlag = map[string]OpKind{
-	"leader":     OpLeader,
-	"region":     OpRegion,
-	"split":      OpSplit,
-	"admin":      OpAdmin,
-	"hot-region": OpHotRegion,
-	"replica":    OpReplica,
-	"merge":      OpMerge,
-	"range":      OpRange,
+	"leader":         OpLeader,
+	"region":         OpRegion,
+	"split":          OpSplit,
+	"admin":          OpAdmin,
+	"hot-region":     OpHotRegion,
+	"replica":        OpReplica,
+	"merge":          OpMerge,
+	"range":          OpRange,
+	"witness-leader": OpWitnessLeader,
 }
 
 func (k OpKind) String() string {

--- a/server/schedulers/transfer_witness_leader.go
+++ b/server/schedulers/transfer_witness_leader.go
@@ -133,7 +133,7 @@ func (s *trasferWitnessLeaderScheduler) scheduleTransferWitnessLeader(name, typ 
 	for _, t := range targets {
 		targetIDs = append(targetIDs, t.GetID())
 	}
-	return operator.CreateTransferLeaderOperator(typ, cluster, region, region.GetLeader().GetStoreId(), target.GetID(), targetIDs, operator.OpLeader)
+	return operator.CreateTransferLeaderOperator(typ, cluster, region, region.GetLeader().GetStoreId(), target.GetID(), targetIDs, operator.OpWitnessLeader)
 }
 
 // RecvRegionInfo receives a checked region from coordinator

--- a/server/schedulers/transfer_witness_leader.go
+++ b/server/schedulers/transfer_witness_leader.go
@@ -80,12 +80,7 @@ func (s *trasferWitnessLeaderScheduler) GetType() string {
 }
 
 func (s *trasferWitnessLeaderScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
-	// TODO: make sure the restriction is reasonable
-	allowed := s.OpController.OperatorCount(operator.OpWitnessLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
-	if !allowed {
-		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpWitnessLeader.String()).Inc()
-	}
-	return allowed
+	return true
 }
 
 func (s *trasferWitnessLeaderScheduler) Schedule(cluster schedule.Cluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {

--- a/server/schedulers/transfer_witness_leader.go
+++ b/server/schedulers/transfer_witness_leader.go
@@ -33,7 +33,7 @@ const (
 	TransferWitnessLeaderType = "transfer-witness-leader"
 	// TransferWitnessLeaderBatchSize is the number of operators to to transfer
 	// leaders by one scheduling
-	transferWitnessLeaderBatchSize = 3
+	transferWitnessLeaderBatchSize = 10
 	// TransferWitnessLeaderRecvMaxRegionSize is the max number of region can receive
 	// TODO: make it a reasonable value
 	transferWitnessLeaderRecvMaxRegionSize = 1000
@@ -81,9 +81,9 @@ func (s *trasferWitnessLeaderScheduler) GetType() string {
 
 func (s *trasferWitnessLeaderScheduler) IsScheduleAllowed(cluster schedule.Cluster) bool {
 	// TODO: make sure the restriction is reasonable
-	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
+	allowed := s.OpController.OperatorCount(operator.OpWitnessLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
 	if !allowed {
-		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
+		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpWitnessLeader.String()).Inc()
 	}
 	return allowed
 }


### PR DESCRIPTION
ref tikv/pd#5638

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5638

### What is changed and how does it work?

Separate the limit configuration of `transfer-witness-leader` and `balance-leader`. Otherwise, when the witness becomes the leader, the op could not be created in time because the quota was full. The client will return a backoff error: `is_witness`.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
schedulers: split transfer-witness-leader's limit from balance-leader
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)


Code changes

- Has configuration change


Side effects

- None

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
