### PR TITLE
schedule: use public stores cache in placement rules cache

### DIFF
--- a/server/schedule/placement/region_rule_cache.go
+++ b/server/schedule/placement/region_rule_cache.go
@@ -35,22 +35,24 @@ import (
 // 6. any store label is changed
 // 7. any store state is changed
 type RegionRuleFitCacheManager struct {
-	mu     syncutil.RWMutex
-	caches map[uint64]*RegionRuleFitCache
+	mu           syncutil.RWMutex
+	regionCaches map[uint64]*regionRuleFitCache
+	storeCaches  map[uint64]*storeCache
 }
 
 // NewRegionRuleFitCacheManager returns RegionRuleFitCacheManager
 func NewRegionRuleFitCacheManager() *RegionRuleFitCacheManager {
 	return &RegionRuleFitCacheManager{
-		caches: map[uint64]*RegionRuleFitCache{},
+		regionCaches: make(map[uint64]*regionRuleFitCache),
+		storeCaches:  make(map[uint64]*storeCache),
 	}
 }
 
-// Invalid invalid cache by regionID
+// Invalid cache by regionID
 func (manager *RegionRuleFitCacheManager) Invalid(regionID uint64) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
-	delete(manager.caches, regionID)
+	delete(manager.regionCaches, regionID)
 }
 
 // CheckAndGetCache checks whether the region and rules are changed for the stored cache
@@ -63,7 +65,7 @@ func (manager *RegionRuleFitCacheManager) CheckAndGetCache(region *core.RegionIn
 	}
 	manager.mu.RLock()
 	defer manager.mu.RUnlock()
-	if cache, ok := manager.caches[region.GetID()]; ok && cache.bestFit != nil {
+	if cache, ok := manager.regionCaches[region.GetID()]; ok && cache.bestFit != nil {
 		if cache.IsUnchanged(region, rules, stores) {
 			return true, cache.bestFit
 		}
@@ -79,26 +81,26 @@ func (manager *RegionRuleFitCacheManager) SetCache(region *core.RegionInfo, fit 
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	fit.SetCached(true)
-	manager.caches[region.GetID()] = toRegionRuleFitCache(region, fit)
+	manager.regionCaches[region.GetID()] = manager.toRegionRuleFitCache(region, fit)
 }
 
-// RegionRuleFitCache stores regions RegionFit result and involving variables
-type RegionRuleFitCache struct {
+// regionRuleFitCache stores regions RegionFit result and involving variables
+type regionRuleFitCache struct {
 	region       regionCache
-	regionStores []storeCache
+	regionStores []*storeCache
 	rules        []ruleCache
 	bestFit      *RegionFit
 }
 
 // IsUnchanged checks whether the region and rules unchanged for the cache
-func (cache *RegionRuleFitCache) IsUnchanged(region *core.RegionInfo, rules []*Rule, stores []*core.StoreInfo) bool {
+func (cache *regionRuleFitCache) IsUnchanged(region *core.RegionInfo, rules []*Rule, stores []*core.StoreInfo) bool {
 	if !ValidateRegion(region) || !ValidateStores(stores) {
 		return false
 	}
 	return cache.isRegionUnchanged(region) && rulesEqual(cache.rules, rules) && storesEqual(cache.regionStores, stores)
 }
 
-func (cache *RegionRuleFitCache) isRegionUnchanged(region *core.RegionInfo) bool {
+func (cache *regionRuleFitCache) isRegionUnchanged(region *core.RegionInfo) bool {
 	return region.GetLeader().StoreId == cache.region.leaderStoreID &&
 		cache.region.epochEqual(region)
 }
@@ -114,7 +116,7 @@ func rulesEqual(ruleCaches []ruleCache, rules []*Rule) bool {
 	})
 }
 
-func storesEqual(a []storeCache, b []*core.StoreInfo) bool {
+func storesEqual(a []*storeCache, b []*core.StoreInfo) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -125,10 +127,10 @@ func storesEqual(a []storeCache, b []*core.StoreInfo) bool {
 	})
 }
 
-func toRegionRuleFitCache(region *core.RegionInfo, fit *RegionFit) *RegionRuleFitCache {
-	return &RegionRuleFitCache{
+func (manager *RegionRuleFitCacheManager) toRegionRuleFitCache(region *core.RegionInfo, fit *RegionFit) *regionRuleFitCache {
+	return &regionRuleFitCache{
 		region:       toRegionCache(region),
-		regionStores: toStoreCacheList(fit.regionStores),
+		regionStores: manager.toStoreCacheList(fit.regionStores),
 		rules:        toRuleCacheList(fit.rules),
 		bestFit:      fit,
 	}
@@ -175,17 +177,22 @@ func (s storeCache) storeEqual(store *core.StoreInfo) bool {
 		labelEqual(s.labels, store.GetLabels())
 }
 
-func toStoreCacheList(stores []*core.StoreInfo) (c []storeCache) {
+func (manager *RegionRuleFitCacheManager) toStoreCacheList(stores []*core.StoreInfo) (c []*storeCache) {
 	for _, s := range stores {
-		m := make(map[string]string)
-		for _, label := range s.GetLabels() {
-			m[label.GetKey()] = label.GetValue()
+		sCache, ok := manager.storeCaches[s.GetID()]
+		if !(ok && sCache.storeEqual(s)) {
+			m := make(map[string]string)
+			for _, label := range s.GetLabels() {
+				m[label.GetKey()] = label.GetValue()
+			}
+			sCache = &storeCache{
+				storeID: s.GetID(),
+				labels:  m,
+				state:   s.GetState(),
+			}
+			manager.storeCaches[s.GetID()] = sCache
 		}
-		c = append(c, storeCache{
-			storeID: s.GetID(),
-			labels:  m,
-			state:   s.GetState(),
-		})
+		c = append(c, sCache)
 	}
 	return c
 }

--- a/server/schedule/placement/region_rule_cache.go
+++ b/server/schedule/placement/region_rule_cache.go
@@ -180,7 +180,7 @@ func (s storeCache) storeEqual(store *core.StoreInfo) bool {
 func (manager *RegionRuleFitCacheManager) toStoreCacheList(stores []*core.StoreInfo) (c []*storeCache) {
 	for _, s := range stores {
 		sCache, ok := manager.storeCaches[s.GetID()]
-		if !(ok && sCache.storeEqual(s)) {
+		if !ok || !sCache.storeEqual(s) {
 			m := make(map[string]string)
 			for _, label := range s.GetLabels() {
 				m[label.GetKey()] = label.GetValue()

--- a/server/schedule/placement/region_rule_cache_test.go
+++ b/server/schedule/placement/region_rule_cache_test.go
@@ -17,6 +17,7 @@ package placement
 import (
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -29,7 +30,8 @@ func TestRegionRuleFitCache(t *testing.T) {
 	originRegion := mockRegion(3, 0)
 	originRules := addExtraRules(0)
 	originStores := mockStores(3)
-	cache := mockRegionRuleFitCache(originRegion, originRules, originStores)
+	cacheManager := NewRegionRuleFitCacheManager()
+	cache := cacheManager.mockRegionRuleFitCache(originRegion, originRules, originStores)
 	testCases := []struct {
 		name      string
 		region    *core.RegionInfo
@@ -192,10 +194,30 @@ func TestRegionRuleFitCache(t *testing.T) {
 	re.False(cache.IsUnchanged(originRegion, originRules, originStores))
 }
 
-func mockRegionRuleFitCache(region *core.RegionInfo, rules []*Rule, regionStores []*core.StoreInfo) *RegionRuleFitCache {
-	return &RegionRuleFitCache{
+func TestPublicStoreCaches(t *testing.T) {
+	re := require.New(t)
+	cacheManager := NewRegionRuleFitCacheManager()
+
+	stores1 := mockStores(3)
+	rules1 := addExtraRules(0)
+	region1 := mockRegion(3, 0)
+	cache1 := cacheManager.mockRegionRuleFitCache(region1, rules1, stores1)
+
+	stores2 := mockStores(3)
+	rules2 := addExtraRules(0)
+	region2 := mockRegion(3, 0)
+	cache2 := cacheManager.mockRegionRuleFitCache(region2, rules2, stores2)
+
+	for i, storeCache1 := range cache1.regionStores {
+		storeCache2 := cache2.regionStores[i]
+		re.Equal(unsafe.Pointer(storeCache2), unsafe.Pointer(storeCache1))
+	}
+}
+
+func (manager *RegionRuleFitCacheManager) mockRegionRuleFitCache(region *core.RegionInfo, rules []*Rule, regionStores []*core.StoreInfo) *regionRuleFitCache {
+	return &regionRuleFitCache{
 		region:       toRegionCache(region),
-		regionStores: toStoreCacheList(regionStores),
+		regionStores: manager.toStoreCacheList(regionStores),
 		rules:        toRuleCacheList(rules),
 		bestFit: &RegionFit{
 			regionStores: regionStores,

--- a/server/schedule/placement/region_rule_cache_test.go
+++ b/server/schedule/placement/region_rule_cache_test.go
@@ -226,6 +226,7 @@ func (manager *RegionRuleFitCacheManager) mockRegionRuleFitCache(region *core.Re
 	}
 }
 
+// nolint
 func mockStores(num int) []*core.StoreInfo {
 	stores := make([]*core.StoreInfo, 0, num)
 	now := time.Now()
@@ -236,6 +237,7 @@ func mockStores(num int) []*core.StoreInfo {
 	return stores
 }
 
+// nolint
 func mockStoresNoHeartbeat(num int) []*core.StoreInfo {
 	stores := make([]*core.StoreInfo, 0, num)
 	for i := 1; i <= num; i++ {

--- a/server/schedule/placement/rule_manager.go
+++ b/server/schedule/placement/rule_manager.go
@@ -353,10 +353,10 @@ func (m *RuleManager) InvalidCache(regionID uint64) {
 // SetPlaceholderRegionFitCache sets a placeholder region fit cache information
 // Only used for testing
 func (m *RuleManager) SetPlaceholderRegionFitCache(region *core.RegionInfo) {
-	placeholderCache := &RegionRuleFitCache{region: toRegionCache(region)}
+	placeholderCache := &regionRuleFitCache{region: toRegionCache(region)}
 	m.cache.mu.Lock()
 	defer m.cache.mu.Unlock()
-	m.cache.caches[region.GetID()] = placeholderCache
+	m.cache.regionCaches[region.GetID()] = placeholderCache
 }
 
 // CheckIsCachedDirectly returns whether the region's fit is cached
@@ -364,7 +364,7 @@ func (m *RuleManager) SetPlaceholderRegionFitCache(region *core.RegionInfo) {
 func (m *RuleManager) CheckIsCachedDirectly(regionID uint64) bool {
 	m.cache.mu.RLock()
 	defer m.cache.mu.RUnlock()
-	_, ok := m.cache.caches[regionID]
+	_, ok := m.cache.regionCaches[regionID]
 	return ok
 }
 


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5864

There is `labels map[string]string` in `storeCache`. When the store has longer or more labels, each region cache will use a lot of memory.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

part of #5860

use public stores cache in placement rules cache.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
