### PR TITLE
resource_manager: fix missing kvCPUTime when sqlCPUTime is 0

### DIFF
--- a/pkg/mcs/resource_manager/server/manager.go
+++ b/pkg/mcs/resource_manager/server/manager.go
@@ -204,8 +204,10 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				writeByteMetrics.Observe(consumption.WriteBytes)
 			}
 			// CPU time info.
-			if consumption.SqlLayerCpuTimeMs != 0 {
-				sqlCPUMetrics.Observe(consumption.SqlLayerCpuTimeMs)
+			if consumption.TotalCpuTimeMs > 0 {
+				if consumption.SqlLayerCpuTimeMs > 0 {
+					sqlCPUMetrics.Observe(consumption.SqlLayerCpuTimeMs)
+				}
 				kvCPUMetrics.Observe(consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs)
 			}
 			// RPC count info.


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5854

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
Collect kvCPUTime metrics when sqlCPUTime is 0.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->


Code changes


Side effects


Related changes


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
