### PR TITLE
*: refactor server entry point to support multi-mode service

### DIFF
--- a/pkg/basic_server/basic_server.go
+++ b/pkg/basic_server/basic_server.go
@@ -1,4 +1,4 @@
-// Copyright 2022 TiKV Project Authors.
+// Copyright 2023 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/basic_server/basic_server.go
+++ b/pkg/basic_server/basic_server.go
@@ -23,12 +23,12 @@ import (
 
 // Server defines the common basic behaviors of a server
 type Server interface {
-	// Name returns the unique etcd Name for this server in etcd cluster.
+	// Name returns the unique Name for this server in the cluster.
 	Name() string
 	// Context returns the context of server.
 	Context() context.Context
 
-	// Run runs the pd server.
+	// Run runs the server.
 	Run() error
 	// Close closes the server.
 	Close()

--- a/pkg/basic_server/basic_server.go
+++ b/pkg/basic_server/basic_server.go
@@ -1,0 +1,40 @@
+// Copyright 2022 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package basicsvr
+
+import (
+	"context"
+	"net/http"
+
+	"go.etcd.io/etcd/clientv3"
+)
+
+// Server defines the common basic behaviors of a server
+type Server interface {
+	// Name returns the unique etcd Name for this server in etcd cluster.
+	Name() string
+	// Context returns the context of server.
+	Context() context.Context
+
+	// Run runs the pd server.
+	Run() error
+	// Close closes the server.
+	Close()
+
+	// GetClient returns builtin etcd client.
+	GetClient() *clientv3.Client
+	// GetHTTPClient returns builtin etcd client.
+	GetHTTPClient() *http.Client
+}


### PR DESCRIPTION
Signed-off-by: Bin Shi <binshi.bing@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: Ref #5836

### What is changed and how does it work?
A service in different mode has different config struct and initialization logic, so we need to abstract an interface to create server.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
A service in different mode has different config struct and initialization logic, so we need to abstract an interface to create server.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->
- Manual test (add detailed scripts or steps below)
  I did some compatibility test manually by verifying that the all-in-one pd-server can start normally w/o and w/ parameter.

Related changes

None.

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
