### PR TITLE
step: fix merge region failed caused by mismatch confver

### DIFF
--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -414,7 +414,7 @@ func (bsw BatchSwitchWitness) Influence(opInfluence OpInfluence, region *core.Re
 
 // Timeout returns duration that current step may take.
 func (bsw BatchSwitchWitness) Timeout(regionSize int64) time.Duration {
-	count := uint64(len(bsw.ToWitnesses)+len(bsw.ToNonWitnesses)) + 1
+	count := len(bsw.ToNonWitnesses)) + 1
 	return slowStepWaitDuration(regionSize) * time.Duration(count)
 }
 

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -414,7 +414,7 @@ func (bsw BatchSwitchWitness) Influence(opInfluence OpInfluence, region *core.Re
 
 // Timeout returns duration that current step may take.
 func (bsw BatchSwitchWitness) Timeout(regionSize int64) time.Duration {
-	count := len(bsw.ToNonWitnesses)) + 1
+	count := uint64(len(bsw.ToNonWitnesses)) + 1
 	return slowStepWaitDuration(regionSize) * time.Duration(count)
 }
 

--- a/server/schedule/operator/step.go
+++ b/server/schedule/operator/step.go
@@ -415,7 +415,7 @@ func (bsw BatchSwitchWitness) Influence(opInfluence OpInfluence, region *core.Re
 // Timeout returns duration that current step may take.
 func (bsw BatchSwitchWitness) Timeout(regionSize int64) time.Duration {
 	count := uint64(len(bsw.ToWitnesses)+len(bsw.ToNonWitnesses)) + 1
-	return fastStepWaitDuration(regionSize) * time.Duration(count)
+	return slowStepWaitDuration(regionSize) * time.Duration(count)
 }
 
 // GetCmd returns the schedule command for heartbeat response.
@@ -534,7 +534,11 @@ func (pl PromoteLearner) ConfVerChanged(region *core.RegionInfo) uint64 {
 }
 
 func (pl PromoteLearner) String() string {
-	return fmt.Sprintf("promote learner peer %v on store %v to voter", pl.PeerID, pl.ToStore)
+	info := "learner peer"
+	if pl.IsWitness {
+		info = "witness learner peer"
+	}
+	return fmt.Sprintf("promote %v %v on store %v to voter", info, pl.PeerID, pl.ToStore)
 }
 
 // IsFinish checks if current step is finished. It is also used by ChangePeerV2Leave.
@@ -765,14 +769,19 @@ type DemoteVoter struct {
 }
 
 func (dv DemoteVoter) String() string {
-	return fmt.Sprintf("demote voter peer %v on store %v to learner", dv.PeerID, dv.ToStore)
+	info := "voter peer"
+	if dv.IsWitness {
+		info = "witness voter peer"
+	}
+	return fmt.Sprintf("demote %v %v on store %v to learner", info, dv.PeerID, dv.ToStore)
 }
 
 // ConfVerChanged returns the delta value for version increased by this step.
 func (dv DemoteVoter) ConfVerChanged(region *core.RegionInfo) uint64 {
 	peer := region.GetStorePeer(dv.ToStore)
-	// the demoting peer may be removed later.
-	return typeutil.BoolToUint64(peer == nil || (peer.GetId() == dv.PeerID && peer.GetRole() == metapb.PeerRole_Learner))
+	// the demoting peer may be removed later, and when merging witness region the two witnesses may be not on the same store,
+	// witness scheduling will occur, cause a voter witness -> non-witness learner -> voter.
+	return typeutil.BoolToUint64(peer == nil || (peer.GetId() == dv.PeerID && peer.GetRole() == metapb.PeerRole_Learner) || (dv.IsWitness && !peer.GetIsWitness()))
 }
 
 // IsFinish checks if current step is finished.
@@ -825,8 +834,9 @@ func (cpe ChangePeerV2Enter) ConfVerChanged(region *core.RegionInfo) uint64 {
 	}
 	for _, dv := range cpe.DemoteVoters {
 		peer := region.GetStorePeer(dv.ToStore)
-		// the demoting peer may be removed later.
-		if peer != nil && (peer.GetId() != dv.PeerID || !core.IsLearnerOrDemotingVoter(peer)) {
+		// the demoting peer may be removed later, and when merging witness region the two witnesses may be not on the same store,
+		// witness scheduling will occur, cause a voter witness -> non-witness learner -> voter.
+		if peer != nil && (peer.GetId() != dv.PeerID || (!core.IsLearnerOrDemotingVoter(peer) && !(dv.IsWitness && !peer.GetIsWitness()))) {
 			return 0
 		}
 	}


### PR DESCRIPTION
ref tikv/pd#5656

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5656

### What is changed and how does it work?

When region A's witness and region B's witness not on the same store. It will gen the op with

step1:  Demote witness voter -> witness learner
step2: switch witness learner -> non-witness leaner
step3: Promote non-witness learner -> voter

When calculating the conf ver change, after the third step is executed, the conf ver change condition of the first step is not satisfied, resulting in the difference between the actual region conf ver change and the calculated one.

So add witness change as a condition to solve this.


<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/
pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
step: fix merge region failed caused by mismatch confver
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test 
   - test with sysbench prepare

Code changes

- None

Side effects

- None

Related changes

- None

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
