### PR TITLE
tso: migrate tso key to new one

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -326,6 +326,11 @@ error = '''
 etcd KV put failed
 '''
 
+["PD:etcd:ErrEtcdKVTxn"]
+error = '''
+etcd KV txn failed
+'''
+
 ["PD:etcd:ErrEtcdMemberList"]
 error = '''
 etcd member list failed

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -208,6 +208,7 @@ var (
 	ErrEtcdKVPut         = errors.Normalize("etcd KV put failed", errors.RFCCodeText("PD:etcd:ErrEtcdKVPut"))
 	ErrEtcdKVDelete      = errors.Normalize("etcd KV delete failed", errors.RFCCodeText("PD:etcd:ErrEtcdKVDelete"))
 	ErrEtcdKVGet         = errors.Normalize("etcd KV get failed", errors.RFCCodeText("PD:etcd:ErrEtcdKVGet"))
+	ErrEtcdKVTxn         = errors.Normalize("etcd KV txn failed", errors.RFCCodeText("PD:etcd:ErrEtcdKVTxn"))
 	ErrEtcdKVGetResponse = errors.Normalize("etcd invalid get value response %v, must only one", errors.RFCCodeText("PD:etcd:ErrEtcdKVGetResponse"))
 	ErrEtcdGetCluster    = errors.Normalize("etcd get cluster from remote peer failed", errors.RFCCodeText("PD:etcd:ErrEtcdGetCluster"))
 	ErrEtcdMoveLeader    = errors.Normalize("etcd move leader error", errors.RFCCodeText("PD:etcd:ErrEtcdMoveLeader"))

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"go.etcd.io/etcd/clientv3"
@@ -302,7 +303,7 @@ func (m *Member) getMemberLeaderPriorityPath(id uint64) string {
 
 // GetDCLocationPathPrefix returns the dc-location path prefix of the cluster.
 func (m *Member) GetDCLocationPathPrefix() string {
-	return path.Join(m.rootPath, dcLocationConfigEtcdPrefix)
+	return path.Join(m.rootPath, endpoint.MicroserviceKey, endpoint.TSOServiceKey, "default", dcLocationConfigEtcdPrefix)
 }
 
 // GetDCLocationPath returns the dc-location path of a member with the given member ID.

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -303,7 +303,7 @@ func (m *Member) getMemberLeaderPriorityPath(id uint64) string {
 
 // GetDCLocationPathPrefix returns the dc-location path prefix of the cluster.
 func (m *Member) GetDCLocationPathPrefix() string {
-	return path.Join(m.rootPath, endpoint.MicroserviceKey, endpoint.TSOServiceKey, "default", dcLocationConfigEtcdPrefix)
+	return path.Join(m.rootPath, endpoint.TSOMicroserviceKey, "default", dcLocationConfigEtcdPrefix)
 }
 
 // GetDCLocationPath returns the dc-location path of a member with the given member ID.

--- a/pkg/storage/endpoint/key_path.go
+++ b/pkg/storage/endpoint/key_path.go
@@ -48,10 +48,8 @@ const (
 
 	// tso storage endpoint has prefix `tso`
 
-	// MicroserviceKey is the key to indicate the microservice.
-	MicroserviceKey = "ms"
-	// TSOServiceKey is the key to indicate the TSO service.
-	TSOServiceKey = "tso"
+	// TSOMicroserviceKey is the key to indicate the TSO microservice.
+	TSOMicroserviceKey = "ms/tso"
 	// LocalTSOKey is the key to indicate the local TSO.
 	LocalTSOKey = "lts"
 	// LocalTSOAllocatorKey is the key to indicate the local TSO allocator.
@@ -234,16 +232,16 @@ func encodeKeyspaceID(spaceID uint32) string {
 // TimestampPath returns the path to the timestamp of the given keyspace group.
 func TimestampPath(keyspaceGroupName string, dcLocationKey ...string) string {
 	if len(dcLocationKey) != 0 && dcLocationKey[0] != "global" {
-		return buildPath(false, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName, LocalTSOKey, dcLocationKey[0], timestampKey}...)
+		return buildPath(false, []string{TSOMicroserviceKey, keyspaceGroupName, LocalTSOKey, dcLocationKey[0], timestampKey}...)
 	}
-	return buildPath(false, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName, GlobalTSOKey, timestampKey}...)
+	return buildPath(false, []string{TSOMicroserviceKey, keyspaceGroupName, GlobalTSOKey, timestampKey}...)
 }
 
 func timestampPrefix(keyspaceGroupName string, dcLocationKey ...string) string {
 	if len(dcLocationKey) != 0 && dcLocationKey[0] != "global" {
-		return buildPath(true, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName, LocalTSOKey, dcLocationKey[0]}...)
+		return buildPath(true, []string{TSOMicroserviceKey, keyspaceGroupName, LocalTSOKey, dcLocationKey[0]}...)
 	}
-	return buildPath(true, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName}...)
+	return buildPath(true, []string{TSOMicroserviceKey, keyspaceGroupName}...)
 }
 
 func buildPath(withSuffix bool, str ...string) string {

--- a/pkg/storage/endpoint/key_path.go
+++ b/pkg/storage/endpoint/key_path.go
@@ -45,12 +45,20 @@ const (
 	// resource group storage endpoint has prefix `resource_group`
 	resourceGroupSettingsPath = "settings"
 	resourceGroupStatesPath   = "states"
+
 	// tso storage endpoint has prefix `tso`
-	microserviceKey = "microservice"
-	tsoServiceKey   = "tso"
-	timestampKey    = "timestamp"
-	// localTSOSuffix is the same as `localTSOSuffixEtcdPrefix` defined in `pkg/tso/allocator_manager.go`.
-	localTSOSuffix = "lts"
+
+	// MicroserviceKey is the key to indicate the microservice.
+	MicroserviceKey = "ms"
+	// TSOServiceKey is the key to indicate the TSO service.
+	TSOServiceKey = "tso"
+	// LocalTSOKey is the key to indicate the local TSO.
+	LocalTSOKey = "lts"
+	// LocalTSOAllocatorKey is the key to indicate the local TSO allocator.
+	LocalTSOAllocatorKey = "lta"
+	// GlobalTSOKey is the key to indicate the global TSO.
+	GlobalTSOKey = "gts"
+	timestampKey = "timestamp"
 
 	// we use uint64 to represent ID, the max length of uint64 is 20.
 	keyLen = 20
@@ -223,18 +231,19 @@ func encodeKeyspaceID(spaceID uint32) string {
 	return fmt.Sprintf("%08d", spaceID)
 }
 
-func timestampPath(keyspaceGroupName string, dcLocationKey ...string) string {
-	if len(dcLocationKey) != 0 {
-		return buildPath(false, []string{microserviceKey, tsoServiceKey, keyspaceGroupName, localTSOSuffix, dcLocationKey[0], timestampKey}...)
+// TimestampPath returns the path to the timestamp of the given keyspace group.
+func TimestampPath(keyspaceGroupName string, dcLocationKey ...string) string {
+	if len(dcLocationKey) != 0 && dcLocationKey[0] != "global" {
+		return buildPath(false, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName, LocalTSOKey, dcLocationKey[0], timestampKey}...)
 	}
-	return buildPath(false, []string{microserviceKey, tsoServiceKey, keyspaceGroupName, timestampKey}...)
+	return buildPath(false, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName, GlobalTSOKey, timestampKey}...)
 }
 
 func timestampPrefix(keyspaceGroupName string, dcLocationKey ...string) string {
-	if len(dcLocationKey) != 0 {
-		return buildPath(true, []string{microserviceKey, tsoServiceKey, keyspaceGroupName, localTSOSuffix, dcLocationKey[0]}...)
+	if len(dcLocationKey) != 0 && dcLocationKey[0] != "global" {
+		return buildPath(true, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName, LocalTSOKey, dcLocationKey[0]}...)
 	}
-	return buildPath(true, []string{microserviceKey, tsoServiceKey, keyspaceGroupName}...)
+	return buildPath(true, []string{MicroserviceKey, TSOServiceKey, keyspaceGroupName}...)
 }
 
 func buildPath(withSuffix bool, str ...string) string {

--- a/pkg/storage/endpoint/tso.go
+++ b/pkg/storage/endpoint/tso.go
@@ -25,8 +25,8 @@ import (
 )
 
 // TSOStorage defines the storage operations on the TSO.
-// global tso: key is `/microservice/tso/{keyspaceGroupName}/timestamp`
-// local tso: key is `/microservice/tso/{keyspaceGroupName}/lts/{dcLocation}/timestamp`
+// global tso: key is `/ms/tso/{keyspaceGroupName}/gts/timestamp`
+// local tso: key is `/ms/tso/{keyspaceGroupName}/lts/{dcLocation}/timestamp`
 // FIXME: When we upgrade from the old version, there may be compatibility issues.
 type TSOStorage interface {
 	LoadTimestamp(keyspaceGroupName string, dcLocationKey ...string) (time.Time, error)
@@ -68,7 +68,7 @@ func (se *StorageEndpoint) LoadTimestamp(keyspaceGroupName string, dcLocationKey
 
 // SaveTimestamp saves the timestamp to the storage.
 func (se *StorageEndpoint) SaveTimestamp(keyspaceGroupName string, ts time.Time, dcLocationKey ...string) error {
-	key := timestampPath(keyspaceGroupName, dcLocationKey...)
+	key := TimestampPath(keyspaceGroupName, dcLocationKey...)
 	data := typeutil.Uint64ToBytes(uint64(ts.UnixNano()))
 	return se.Save(key, string(data))
 }

--- a/pkg/tso/allocator_manager.go
+++ b/pkg/tso/allocator_manager.go
@@ -360,13 +360,13 @@ func (am *AllocatorManager) getAllocatorPath(dcLocation string) string {
 // Add a prefix to the root path to prevent being conflicted
 // with other system key paths such as leader, member, alloc_id, raft, etc.
 func (am *AllocatorManager) getGlobalTSOAllocatorPath() string {
-	return path.Join(am.rootPath, endpoint.MicroserviceKey, endpoint.TSOServiceKey, defaultKeyspaceGroup, endpoint.GlobalTSOKey)
+	return path.Join(am.rootPath, endpoint.TSOMicroserviceKey, defaultKeyspaceGroup, endpoint.GlobalTSOKey)
 }
 
 // Add a prefix to the root path to prevent being conflicted
 // with other system key paths such as leader, member, alloc_id, raft, etc.
 func (am *AllocatorManager) getLocalTSOAllocatorPath() string {
-	return path.Join(am.rootPath, endpoint.MicroserviceKey, endpoint.TSOServiceKey, defaultKeyspaceGroup, endpoint.LocalTSOKey)
+	return path.Join(am.rootPath, endpoint.TSOMicroserviceKey, defaultKeyspaceGroup, endpoint.LocalTSOKey)
 }
 
 // similar logic with leaderLoop in server/server.go
@@ -812,7 +812,7 @@ func (am *AllocatorManager) getMaxLocalTSOSuffix() (int32, error) {
 
 // GetLocalTSOSuffixPathPrefix returns the etcd key prefix of the Local TSO suffix for the given dc-location.
 func (am *AllocatorManager) GetLocalTSOSuffixPathPrefix() string {
-	return path.Join(am.rootPath, endpoint.MicroserviceKey, endpoint.TSOServiceKey, defaultKeyspaceGroup, endpoint.LocalTSOAllocatorKey)
+	return path.Join(am.rootPath, endpoint.TSOMicroserviceKey, defaultKeyspaceGroup, endpoint.LocalTSOAllocatorKey)
 }
 
 // GetLocalTSOSuffixPath returns the etcd key of the Local TSO suffix for the given dc-location.

--- a/pkg/tso/tso_test.go
+++ b/pkg/tso/tso_test.go
@@ -62,7 +62,7 @@ func TestMigrateGlobalTSO(t *testing.T) {
 
 	resp, err = client.Get(context.Background(), oldGlobalPath)
 	re.NoError(err)
-	re.Empty(resp.Kvs)
+	re.NotEmpty(resp.Kvs)
 
 	newLocalPath := path.Join(rootPath, "ms", "tso", "default", "lts", "dc1", "timestamp")
 	resp, err = client.Get(context.Background(), newLocalPath)
@@ -73,7 +73,7 @@ func TestMigrateGlobalTSO(t *testing.T) {
 
 	resp, err = client.Get(context.Background(), oldLocalPath)
 	re.NoError(err)
-	re.Empty(resp.Kvs)
+	re.NotEmpty(resp.Kvs)
 }
 
 func TestMigrateLocalTSO(t *testing.T) {
@@ -123,7 +123,7 @@ func TestMigrateLocalTSO(t *testing.T) {
 
 	resp, err = client.Get(context.Background(), oldGlobalPath)
 	re.NoError(err)
-	re.Empty(resp.Kvs)
+	re.NotEmpty(resp.Kvs)
 
 	newLocalPath := path.Join(rootPath, "ms", "tso", "default", "lts", "dc1", "timestamp")
 	resp, err = client.Get(context.Background(), newLocalPath)
@@ -134,5 +134,5 @@ func TestMigrateLocalTSO(t *testing.T) {
 
 	resp, err = client.Get(context.Background(), oldLocalPath)
 	re.NoError(err)
-	re.Empty(resp.Kvs)
+	re.NotEmpty(resp.Kvs)
 }

--- a/pkg/tso/tso_test.go
+++ b/pkg/tso/tso_test.go
@@ -1,0 +1,138 @@
+package tso
+
+import (
+	"context"
+	"path"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/embed"
+)
+
+func TestMigrateGlobalTSO(t *testing.T) {
+	re := require.New(t)
+
+	cfg := etcdutil.NewTestSingleConfig(t)
+	etcd, err := embed.StartEtcd(cfg)
+	re.NoError(err)
+	defer etcd.Close()
+
+	ep := cfg.LCUrls[0].String()
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{ep},
+	})
+	re.NoError(err)
+	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
+	s := storage.NewStorageWithEtcdBackend(client, rootPath)
+
+	oldGlobalPath := path.Join(rootPath, "timestamp")
+	globalTS := uint64(time.Now().UnixNano())
+	_, err = client.Put(context.Background(), oldGlobalPath, string(typeutil.Uint64ToBytes(globalTS)))
+	re.NoError(err)
+	oldLocalPath := path.Join(rootPath, "lts", "dc1", "timestamp")
+	localTS := uint64(time.Now().UnixNano())
+	_, err = client.Put(context.Background(), oldLocalPath, string(typeutil.Uint64ToBytes(localTS)))
+	re.NoError(err)
+
+	tso := &timestampOracle{
+		client:                 client,
+		rootPath:               rootPath,
+		storage:                s,
+		saveInterval:           3 * time.Second,
+		updatePhysicalInterval: defaultTSOUpdatePhysicalInterval,
+		dcLocation:             GlobalDCLocation,
+		tsoMux:                 &tsoObject{},
+	}
+
+	err = tso.SyncTimestamp()
+	re.NoError(err)
+
+	newGlobalPath := path.Join(rootPath, "ms", "tso", "default", "gts", "timestamp")
+	resp, err := client.Get(context.Background(), newGlobalPath)
+	re.NoError(err)
+	ts, err := typeutil.ParseTimestamp(resp.Kvs[0].Value)
+	re.NoError(err)
+	re.Greater(uint64(ts.UnixNano()), globalTS)
+
+	resp, err = client.Get(context.Background(), oldGlobalPath)
+	re.NoError(err)
+	re.Empty(resp.Kvs)
+
+	newLocalPath := path.Join(rootPath, "ms", "tso", "default", "lts", "dc1", "timestamp")
+	resp, err = client.Get(context.Background(), newLocalPath)
+	re.NoError(err)
+	ts1, err := typeutil.ParseTimestamp(resp.Kvs[0].Value)
+	re.NoError(err)
+	re.Equal(localTS, uint64(ts1.UnixNano()))
+
+	resp, err = client.Get(context.Background(), oldLocalPath)
+	re.NoError(err)
+	re.Empty(resp.Kvs)
+}
+
+func TestMigrateLocalTSO(t *testing.T) {
+	re := require.New(t)
+
+	cfg := etcdutil.NewTestSingleConfig(t)
+	etcd, err := embed.StartEtcd(cfg)
+	re.NoError(err)
+	defer etcd.Close()
+
+	ep := cfg.LCUrls[0].String()
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{ep},
+	})
+	re.NoError(err)
+	rootPath := path.Join("/pd", strconv.FormatUint(100, 10))
+	s := storage.NewStorageWithEtcdBackend(client, rootPath)
+
+	oldGlobalPath := path.Join(rootPath, "timestamp")
+	globalTS := uint64(time.Now().UnixNano())
+	_, err = client.Put(context.Background(), oldGlobalPath, string(typeutil.Uint64ToBytes(globalTS)))
+	re.NoError(err)
+	oldLocalPath := path.Join(rootPath, "lts", "dc1", "timestamp")
+	localTS := uint64(time.Now().UnixNano())
+	_, err = client.Put(context.Background(), oldLocalPath, string(typeutil.Uint64ToBytes(localTS)))
+	re.NoError(err)
+
+	tso := &timestampOracle{
+		client:                 client,
+		rootPath:               rootPath,
+		storage:                s,
+		saveInterval:           3 * time.Second,
+		updatePhysicalInterval: defaultTSOUpdatePhysicalInterval,
+		dcLocation:             "dc1",
+		tsoMux:                 &tsoObject{},
+	}
+
+	err = tso.SyncTimestamp()
+	re.NoError(err)
+
+	newGlobalPath := path.Join(rootPath, "ms", "tso", "default", "gts", "timestamp")
+	resp, err := client.Get(context.Background(), newGlobalPath)
+	re.NoError(err)
+	ts, err := typeutil.ParseTimestamp(resp.Kvs[0].Value)
+	re.NoError(err)
+	re.Equal(globalTS, uint64(ts.UnixNano()))
+
+	resp, err = client.Get(context.Background(), oldGlobalPath)
+	re.NoError(err)
+	re.Empty(resp.Kvs)
+
+	newLocalPath := path.Join(rootPath, "ms", "tso", "default", "lts", "dc1", "timestamp")
+	resp, err = client.Get(context.Background(), newLocalPath)
+	re.NoError(err)
+	ts1, err := typeutil.ParseTimestamp(resp.Kvs[0].Value)
+	re.NoError(err)
+	re.Greater(uint64(ts1.UnixNano()), localTS)
+
+	resp, err = client.Get(context.Background(), oldLocalPath)
+	re.NoError(err)
+	re.Empty(resp.Kvs)
+}

--- a/tools/pd-backup/pdbackup/backup.go
+++ b/tools/pd-backup/pdbackup/backup.go
@@ -74,7 +74,7 @@ func GetBackupInfo(client *clientv3.Client, pdAddr string) (*BackupInfo, error) 
 
 	backInfo.AllocIDMax = allocIDMax
 
-	timestampPath := path.Join(rootPath, "timestamp")
+	timestampPath := path.Join(rootPath, "ms", "tso", "default", "gts", "timestamp")
 	resp, err = etcdutil.EtcdKVGet(client, timestampPath)
 	if err != nil {
 		return nil, err

--- a/tools/pd-backup/pdbackup/backup_test.go
+++ b/tools/pd-backup/pdbackup/backup_test.go
@@ -133,7 +133,7 @@ func (s *backupTestSuite) BeforeTest(suiteName, testName string) {
 
 	var (
 		rootPath               = path.Join(pdRootPath, strconv.FormatUint(clusterID, 10))
-		timestampPath          = path.Join(rootPath, "timestamp")
+		timestampPath          = path.Join(rootPath, "ms", "tso", "default", "gts", "timestamp")
 		allocTimestampMaxBytes = typeutil.Uint64ToBytes(allocTimestampMax)
 	)
 	_, err = s.etcdClient.Put(ctx, timestampPath, string(allocTimestampMaxBytes))


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5836.

### What is changed and how does it work?
Before this PR, we have the following keys in etcd after enabling local TSO feature:
```
/pd/7198087827415338272/dc-location/9320049945780417218
/pd/7198087827415338272/lta/dc-1
/pd/7198087827415338272/lta/dc-1/timestamp
/pd/7198087827415338272/lts/dc-1
/pd/7198087827415338272/timestamp
```
After this PR 
```
/pd/7198087827415338272/dc-location/9320049945780417218 -> /pd/7198091555267330021/ms/tso/default/dc-location/9320049945780417218
/pd/7198087827415338272/lta/dc-1 -> /pd/7198091555267330021/ms/tso/default/lts/dc-1
/pd/7198087827415338272/lta/dc-1/timestamp -> /pd/7198091555267330021/ms/tso/default/lts/dc-1/timestamp
/pd/7198087827415338272/lts/dc-1 -> /pd/7198091555267330021/ms/tso/default/lta/dc-1
/pd/7198087827415338272/timestamp -> /pd/7198091555267330021/ms/tso/default/gts/timestamp
```


<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
