### PR TITLE
cluster: no more redundant etcd writes when `ReportMinResolvedTS` is called

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2326,11 +2326,9 @@ func (c *RaftCluster) SetMinResolvedTS(storeID, minResolvedTS uint64) error {
 		return errs.ErrStoreNotFound.FastGenByArgs(storeID)
 	}
 
-	newStore := store.Clone(
-		core.SetMinResolvedTS(minResolvedTS),
-	)
-
-	return c.putStoreLocked(newStore)
+	newStore := store.Clone(core.SetMinResolvedTS(minResolvedTS))
+	c.core.PutStore(newStore)
+	return nil
 }
 
 func (c *RaftCluster) checkAndUpdateMinResolvedTS() (uint64, bool) {


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5965

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

no more redundant etcd writes when `SetMinResolvedTS` is called

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
  - This PR is based on c64be1f858c4c79356fecdc0f232ba786b1c9d70
  - Make `putStoreLocked` called by `SetMinResolvedTS` slower [7a47041](https://github.com/HunDunDM/pd/commit/7a47041234ec37d92774fee2e8f78080e7d865da)
  - `tiup playground v6.5.0 --kv=15 --db=1 --pd=1 --tiflash=0 --pd.binpath=bin/pd-server`
  - The problem can be reproduced in grafana
    - <img width="714" alt="image" src="https://user-images.githubusercontent.com/19789302/218397521-f76b8c1a-3f3b-4e6c-8651-48ae0de98556.png">
    - <img width="713" alt="image" src="https://user-images.githubusercontent.com/19789302/218397660-978c8c6a-0112-4d2b-9144-314e3b465e76.png">
  - `putStoreLocked` was removed in this PR and replaced with `c.core.PutStore(newStore)`, so it can be considered fixed.

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Fixed an issue where ETCD write delay could cause PD OOM.
```
