### PR TITLE
build: bump alpine image to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apk add --no-cache \
     bash \
     curl \
     gcc \
-    g++
+    g++ \
+    binutils-gold
 
 # Install jq for pd-ctl
 RUN cd / && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 
 RUN make
 
-FROM alpine:3.5
+FROM alpine:3.17
 
 COPY --from=builder /go/src/github.com/tikv/pd/bin/pd-server /pd-server
 COPY --from=builder /go/src/github.com/tikv/pd/bin/pd-ctl /pd-ctl


### PR DESCRIPTION
Signed-off-by: David <8039876+AmoebaProtozoa@users.noreply.github.com>

<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5968

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

current runner image from docker file is based on alpine 3.5, which reached end of life more than 4 years ago (2018-11-01) and does not support arm build. This PR bumps it to a more recent 3.17, same as golang:1.19-alpine used in builder.

further more, `binutils-gold` is added to avoid errors like `fatal error: cannot find 'ld'`, similar issues can be seen here: https://github.com/golang/go/issues/52399
![image](https://user-images.githubusercontent.com/8039876/218313474-b3bbc5a4-322b-46f4-9a72-848ce99b3be8.png)


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)
`make docker-image` now finished successfully on m1 mac.
![image](https://user-images.githubusercontent.com/8039876/218313599-be69c137-65f9-4a7f-a47b-d5637cef0da2.png)

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None
```
