### PR TITLE
cgroup: refine the handling of error 'no cpu controller detected'

### DIFF
--- a/pkg/cgroup/cgroup_cpu.go
+++ b/pkg/cgroup/cgroup_cpu.go
@@ -21,6 +21,8 @@ import (
 	"github.com/pingcap/errors"
 )
 
+var errNoCPUControllerDetected = errors.New("no cpu controller detected")
+
 // Helper function for getCgroupCPU. Root is always "/", except in tests.
 func getCgroupCPUHelper(root string) (CPUUsage, error) {
 	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "cpu,cpuacct")
@@ -30,7 +32,7 @@ func getCgroupCPUHelper(root string) (CPUUsage, error) {
 
 	// No CPU controller detected
 	if path == "" {
-		return CPUUsage{}, errors.New("no cpu controller detected")
+		return CPUUsage{}, errNoCPUControllerDetected
 	}
 
 	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu,cpuacct")

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -42,9 +42,13 @@ func TestGetCgroupCPU(t *testing.T) {
 		}()
 	}
 	cpu, err := GetCgroupCPU()
-	require.NoError(t, err)
-	require.NotZero(t, cpu.Period)
-	require.Less(t, int64(1), cpu.Period)
+	if err == errNoCPUControllerDetected {
+		require.False(t, InContainer(), "Please check linux version > v4.7.x. This is related to cgroup compatibility.")
+	} else {
+		require.NoError(t, err)
+		require.NotZero(t, cpu.Period)
+		require.Less(t, int64(1), cpu.Period)
+	}
 	close(exit)
 	wg.Wait()
 }

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux && enable_flaky_tests
+//go:build linux
 
 package cgroup
 
@@ -89,7 +89,7 @@ func TestGetCgroupCPU(t *testing.T) {
 		if checkKernelVersionNewerThan(t, 4, 7) {
 			require.NoError(t, err, "linux version > v4.7 and err still happens")
 		} else {
-			log.Info("the error is ignored because the kernel is too old")
+			log.Info("the 'no cpu controller detected' error is ignored because the kernel is too old")
 		}
 	} else {
 		require.NoError(t, err)

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -57,10 +57,8 @@ func checkKernelVersionNewerThan(t *testing.T, major, minor int) bool {
 	versionNewerThanFlag := false
 	if mustConvInt(kernelVersionParts[0]) > major {
 		versionNewerThanFlag = true
-	} else {
-		if mustConvInt(kernelVersionParts[0]) == major && mustConvInt(kernelVersionParts[1]) > minor {
-			versionNewerThanFlag = true
-		}
+	} else if mustConvInt(kernelVersionParts[0]) == major && mustConvInt(kernelVersionParts[1]) > minor {
+		versionNewerThanFlag = true
 	}
 	return versionNewerThanFlag
 }

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -21,7 +21,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestGetCgroupCPU(t *testing.T) {
@@ -42,9 +44,12 @@ func TestGetCgroupCPU(t *testing.T) {
 		}()
 	}
 	cpu, err := GetCgroupCPU()
+	log.Info("InContainer()", zap.Bool("InContainer", InContainer()))
 	if err == errNoCPUControllerDetected {
+		log.Info("errNoCPUControllerDetected", zap.Bool("errNoCPUControllerDetected", true))
 		require.False(t, InContainer(), "Please check linux version > v4.7.x. This is related to cgroup compatibility.")
 	} else {
+		log.Info("errNoCPUControllerDetected", zap.Bool("errNoCPUControllerDetected", false))
 		require.NoError(t, err)
 		require.NotZero(t, cpu.Period)
 		require.Less(t, int64(1), cpu.Period)

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -17,14 +17,54 @@
 package cgroup
 
 import (
+	"fmt"
+	"regexp"
 	"runtime"
+	"strconv"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
+
+func checkKernelVersionNewerThan(t *testing.T, major, minor int) bool {
+	u := syscall.Utsname{}
+	err := syscall.Uname(&u)
+	require.NoError(t, err)
+	releaseBs := make([]byte, 0, len(u.Release))
+	for _, v := range u.Release {
+		if v == 0 {
+			break
+		}
+		releaseBs = append(releaseBs, byte(v))
+	}
+	releaseStr := string(releaseBs)
+	log.Info("kernel release string", zap.String("release-str", releaseStr))
+	versionInfoRE := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
+	kernelVerion := versionInfoRE.FindAllString(releaseStr, 1)
+	require.Equal(t, 1, len(kernelVerion), fmt.Sprintf("release str is %s", releaseStr))
+	kernelVersionPartRE := regexp.MustCompile(`[0-9]+`)
+	kernelVersionParts := kernelVersionPartRE.FindAllString(kernelVerion[0], -1)
+	require.Equal(t, 3, len(kernelVersionParts), fmt.Sprintf("kernel verion str is %s", kernelVerion[0]))
+	log.Info("parsed kernel version parts", zap.String("major", kernelVersionParts[0]), zap.String("minor", kernelVersionParts[1]), zap.String("patch", kernelVersionParts[2]))
+	mustConvInt := func(s string) int {
+		i, err := strconv.Atoi(s)
+		require.NoError(t, err, s)
+		return i
+	}
+	versionNewerThanFlag := false
+	if mustConvInt(kernelVersionParts[0]) > major {
+		versionNewerThanFlag = true
+	} else {
+		if mustConvInt(kernelVersionParts[0]) == major && mustConvInt(kernelVersionParts[1]) > minor {
+			versionNewerThanFlag = true
+		}
+	}
+	return versionNewerThanFlag
+}
 
 func TestGetCgroupCPU(t *testing.T) {
 	exit := make(chan struct{})
@@ -44,12 +84,14 @@ func TestGetCgroupCPU(t *testing.T) {
 		}()
 	}
 	cpu, err := GetCgroupCPU()
-	log.Info("InContainer()", zap.Bool("InContainer", InContainer()))
 	if err == errNoCPUControllerDetected {
-		log.Info("errNoCPUControllerDetected", zap.Bool("errNoCPUControllerDetected", true))
-		require.False(t, InContainer(), "Please check linux version > v4.7.x. This is related to cgroup compatibility.")
+		// for more information, please refer https://github.com/pingcap/tidb/pull/41347
+		if checkKernelVersionNewerThan(t, 4, 7) {
+			require.NoError(t, err, "linux version > v4.7 and err still happens")
+		} else {
+			log.Info("the error is ignored because the kernel is too old")
+		}
 	} else {
-		log.Info("errNoCPUControllerDetected", zap.Bool("errNoCPUControllerDetected", false))
 		require.NoError(t, err)
 		require.NotZero(t, cpu.Period)
 		require.Less(t, int64(1), cpu.Period)

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -89,7 +89,7 @@ func TestGetCgroupCPU(t *testing.T) {
 		if checkKernelVersionNewerThan(t, 4, 7) {
 			require.NoError(t, err, "linux version > v4.7 and err still happens")
 		} else {
-			log.Info("the 'no cpu controller detected' error is ignored because the kernel is too old")
+			log.Warn("the 'no cpu controller detected' error is ignored because the kernel is too old")
 		}
 	} else {
 		require.NoError(t, err)

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -88,7 +88,7 @@ func TestGetCgroupCPU(t *testing.T) {
 		if checkKernelVersionNewerThan(t, 4, 7) {
 			require.NoError(t, err, "linux version > v4.7 and err still happens")
 		} else {
-			t.Log("the 'no cpu controller detected' error is ignored because the kernel is too old")
+			t.Logf("the error '%s' is ignored because the kernel is too old", err)
 		}
 	} else {
 		require.NoError(t, err)

--- a/pkg/cgroup/cgroup_cpu_test.go
+++ b/pkg/cgroup/cgroup_cpu_test.go
@@ -25,9 +25,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func checkKernelVersionNewerThan(t *testing.T, major, minor int) bool {
@@ -42,14 +40,15 @@ func checkKernelVersionNewerThan(t *testing.T, major, minor int) bool {
 		releaseBs = append(releaseBs, byte(v))
 	}
 	releaseStr := string(releaseBs)
-	log.Info("kernel release string", zap.String("release-str", releaseStr))
+	t.Log("kernel release string:", releaseStr)
 	versionInfoRE := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
 	kernelVerion := versionInfoRE.FindAllString(releaseStr, 1)
 	require.Equal(t, 1, len(kernelVerion), fmt.Sprintf("release str is %s", releaseStr))
 	kernelVersionPartRE := regexp.MustCompile(`[0-9]+`)
 	kernelVersionParts := kernelVersionPartRE.FindAllString(kernelVerion[0], -1)
 	require.Equal(t, 3, len(kernelVersionParts), fmt.Sprintf("kernel verion str is %s", kernelVerion[0]))
-	log.Info("parsed kernel version parts", zap.String("major", kernelVersionParts[0]), zap.String("minor", kernelVersionParts[1]), zap.String("patch", kernelVersionParts[2]))
+	t.Logf("parsed kernel version parts: major %s, minor %s, patch %s",
+		kernelVersionParts[0], kernelVersionParts[1], kernelVersionParts[2])
 	mustConvInt := func(s string) int {
 		i, err := strconv.Atoi(s)
 		require.NoError(t, err, s)
@@ -89,7 +88,7 @@ func TestGetCgroupCPU(t *testing.T) {
 		if checkKernelVersionNewerThan(t, 4, 7) {
 			require.NoError(t, err, "linux version > v4.7 and err still happens")
 		} else {
-			log.Warn("the 'no cpu controller detected' error is ignored because the kernel is too old")
+			t.Log("the 'no cpu controller detected' error is ignored because the kernel is too old")
 		}
 	} else {
 		require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5953

### What is changed and how does it work?

Ignore error 'no cpu controller detected' on old kernel but still panic on new kernel. (Thanks a lot for the advice from @nolouch)
Remove TestGetCgroupCPU from the flaky test list.

Reference:
https://github.com/pingcap/tidb/pull/41347
https://github.com/pingcap/tidb/pull/41475

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
