### PR TITLE
Makefile: use the absolute path to cd during the check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ifneq ($(DASHBOARD), 0)
 endif
 
 ROOT_PATH := $(shell pwd)
-BUILD_BIN_PATH := $$ROOT_PATH/bin
+BUILD_BIN_PATH := $(ROOT_PATH)/bin
 
 build: pd-server pd-ctl pd-recover
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ ifneq ($(DASHBOARD), 0)
 	LDFLAGS += -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildGitHash=$(shell scripts/describe-dashboard.sh git-hash)"
 endif
 
-BUILD_BIN_PATH := $(shell pwd)/bin
+ROOT_PATH := $(shell pwd)
+BUILD_BIN_PATH := $$ROOT_PATH/bin
 
 build: pd-server pd-ctl pd-recover
 
@@ -129,7 +130,7 @@ dashboard-replace-distro-info:
 PD_PKG := github.com/tikv/pd
 PACKAGES := $(shell go list ./...)
 
-GO_TOOLS_BIN_PATH := $(shell pwd)/.tools/bin
+GO_TOOLS_BIN_PATH := $(ROOT_PATH)/.tools/bin
 PATH := $(GO_TOOLS_BIN_PATH):$(PATH)
 SHELL := env PATH='$(PATH)' GOBIN='$(GO_TOOLS_BIN_PATH)' $(shell which bash)
 
@@ -152,14 +153,14 @@ static: install-tools
 	@ echo "revive ..."
 	@ revive -formatter friendly -config revive.toml $(PACKAGES)
 
-	@ for mod in $(SUBMODULES); do cd $$mod && $(MAKE) static && cd - > /dev/null; done
+	@ for mod in $(SUBMODULES); do cd $$mod && $(MAKE) static && cd $(ROOT_PATH) > /dev/null; done
 
 tidy:
 	@ go mod tidy
 	git diff go.mod go.sum | cat
 	git diff --quiet go.mod go.sum
 
-	@ for mod in $(SUBMODULES); do cd $$mod && $(MAKE) tidy && cd - > /dev/null; done
+	@ for mod in $(SUBMODULES); do cd $$mod && $(MAKE) tidy && cd $(ROOT_PATH) > /dev/null; done
 
 generate-errdoc: install-tools
 	@echo "generating errors.toml..."
@@ -219,7 +220,7 @@ ci-test-job: install-tools dashboard-ui
 
 ci-test-job-submod: install-tools dashboard-ui
 	@$(FAILPOINT_ENABLE)
-	@ for mod in $(SUBMODULES); do cd $$mod && $(MAKE) ci-test-job && cd - > /dev/null && cat $$mod/covprofile >> covprofile; done
+	@ for mod in $(SUBMODULES); do cd $$mod && $(MAKE) ci-test-job && cd $(ROOT_PATH) > /dev/null && cat $$mod/covprofile >> covprofile; done
 	@$(FAILPOINT_DISABLE)
 
 TSO_INTEGRATION_TEST_PKGS := $(PD_PKG)/tests/server/tso


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4399.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Use the absolute path to cd during the check.
```

Sometimes we may encounter the error like:

```shell
revive ...
make[1]: Entering directory '/home/runner/work/pd/pd/client'
cd .. && make install-tools
make[2]: Entering directory '/home/runner/work/pd/pd'
make[2]: Leaving directory '/home/runner/work/pd/pd'
make[1]: Leaving directory '/home/runner/work/pd/pd/client'
make[1]: Entering directory '/home/runner/work/pd/pd/tests/mcs'
cd ../../ && make install-tools
make[2]: Entering directory '/home/runner/work/pd/pd'
make[2]: Leaving directory '/home/runner/work/pd/pd'
level=error msg="Running error: context loading failed: no go files to analyze"
make[1]: *** [Makefile:21: static] Error 5
make[1]: Leaving directory '/home/runner/work/pd/pd/tests/mcs'
/usr/bin/bash: line 1: cd: ./tests/client: No such file or directory
make: *** [Makefile:154: static] Error 1
```

To prevent `cd -` to cause some unexpected results, this PR changes it to an absolute path to the repo root path.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- No code

### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
None.
```
