### PR TITLE
resource_controller: load RU config from the remote server when initializing controller

### DIFF
--- a/client/resource_group/controller/config.go
+++ b/client/resource_group/controller/config.go
@@ -106,13 +106,13 @@ type Config struct {
 
 // DefaultConfig returns the default configuration.
 func DefaultConfig() *Config {
-	cfg := generateConfig(
+	return GenerateConfig(
 		defaultRequestUnitConfig(),
 	)
-	return cfg
 }
 
-func generateConfig(ruConfig *RequestUnitConfig) *Config {
+// GenerateConfig generates the configuration by the given request unit configuration.
+func GenerateConfig(ruConfig *RequestUnitConfig) *Config {
 	cfg := &Config{
 		ReadBaseCost:   RequestUnit(ruConfig.ReadBaseCost),
 		ReadBytesCost:  RequestUnit(ruConfig.ReadCostPerByte),

--- a/client/resource_group/controller/controller.go
+++ b/client/resource_group/controller/controller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -24,11 +25,13 @@ import (
 	"github.com/pingcap/errors"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/log"
+	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/client/errs"
 	"go.uber.org/zap"
 )
 
 const (
+	requestUnitConfigPath  = "resource_group/ru_config"
 	defaultMaxWaitDuration = time.Second
 	maxRetry               = 3
 	maxNotificationChanLen = 200
@@ -50,6 +53,7 @@ type ResourceGroupProvider interface {
 	ModifyResourceGroup(ctx context.Context, metaGroup *rmpb.ResourceGroup) (string, error)
 	DeleteResourceGroup(ctx context.Context, resourceGroupName string) (string, error)
 	AcquireTokenBuckets(ctx context.Context, request *rmpb.TokenBucketsRequest) ([]*rmpb.TokenBucketResponse, error)
+	LoadGlobalConfig(ctx context.Context, names []string, configPath string) ([]pd.GlobalConfigItem, int64, error)
 }
 
 var _ ResourceGroupKVInterceptor = (*ResourceGroupsController)(nil)
@@ -91,14 +95,20 @@ type ResourceGroupsController struct {
 }
 
 // NewResourceGroupController returns a new ResourceGroupsController which impls ResourceGroupKVInterceptor
-func NewResourceGroupController(clientUniqueID uint64, provider ResourceGroupProvider, requestUnitConfig *RequestUnitConfig) (*ResourceGroupsController, error) {
-	// TODO: initialize `requestUnitConfig`` from the remote manager server.
-	var config *Config
-	if requestUnitConfig != nil {
-		config = generateConfig(requestUnitConfig)
-	} else {
-		config = DefaultConfig()
+func NewResourceGroupController(
+	ctx context.Context,
+	clientUniqueID uint64,
+	provider ResourceGroupProvider,
+	requestUnitConfig *RequestUnitConfig,
+) (*ResourceGroupsController, error) {
+	var err error
+	if requestUnitConfig == nil {
+		if requestUnitConfig, err = loadRequestUnitConfig(ctx, provider); err != nil {
+			return nil, err
+		}
 	}
+	// TODO: do we need to reload the config from remote server periodically?
+	config := GenerateConfig(requestUnitConfig)
 	return &ResourceGroupsController{
 		clientUniqueID:        clientUniqueID,
 		provider:              provider,
@@ -108,6 +118,27 @@ func NewResourceGroupController(clientUniqueID uint64, provider ResourceGroupPro
 		tokenBucketUpdateChan: make(chan *groupCostController, maxNotificationChanLen),
 		calculators:           []ResourceCalculator{newKVCalculator(config), newSQLCalculator(config)},
 	}, nil
+}
+
+func loadRequestUnitConfig(ctx context.Context, provider ResourceGroupProvider) (*RequestUnitConfig, error) {
+	items, _, err := provider.LoadGlobalConfig(ctx, nil, requestUnitConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, errors.Errorf("failed to load the ru config from remote server")
+	}
+	ruConfig := &RequestUnitConfig{}
+	err = json.Unmarshal(items[0].PayLoad, ruConfig)
+	if err != nil {
+		return nil, err
+	}
+	return ruConfig, nil
+}
+
+// GetConfig returns the config of controller. It's only used for test.
+func (c *ResourceGroupsController) GetConfig() *Config {
+	return c.config
 }
 
 // Start starts ResourceGroupController service.

--- a/client/resource_group/controller/controller.go
+++ b/client/resource_group/controller/controller.go
@@ -101,9 +101,10 @@ func NewResourceGroupController(
 	provider ResourceGroupProvider,
 	requestUnitConfig *RequestUnitConfig,
 ) (*ResourceGroupsController, error) {
-	var err error
 	if requestUnitConfig == nil {
-		if requestUnitConfig, err = loadRequestUnitConfig(ctx, provider); err != nil {
+		var err error
+		requestUnitConfig, err = loadRequestUnitConfig(ctx, provider)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/client/resource_group/controller/controller.go
+++ b/client/resource_group/controller/controller.go
@@ -107,7 +107,6 @@ func NewResourceGroupController(
 			return nil, err
 		}
 	}
-	// TODO: do we need to reload the config from remote server periodically?
 	config := GenerateConfig(requestUnitConfig)
 	return &ResourceGroupsController{
 		clientUniqueID:        clientUniqueID,

--- a/tests/mcs/resource_manager/resource_manager_test.go
+++ b/tests/mcs/resource_manager/resource_manager_test.go
@@ -301,7 +301,7 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupController() {
 		CPUMsCost:        1,
 	}
 
-	controller, _ := controller.NewResourceGroupController(1, cli, cfg)
+	controller, _ := controller.NewResourceGroupController(suite.ctx, 1, cli, cfg)
 	controller.Start(suite.ctx)
 
 	testCases := []struct {
@@ -699,4 +699,38 @@ func (suite *resourceManagerClientTestSuite) TestResourceManagerClientFailover()
 
 	// Cleanup the resource group.
 	suite.cleanupResourceGroups()
+}
+
+func (suite *resourceManagerClientTestSuite) TestLoadRequestUnitConfig() {
+	re := suite.Require()
+	cli := suite.client
+	// Test load from resource manager.
+	ctr, err := controller.NewResourceGroupController(suite.ctx, 1, cli, nil)
+	re.NoError(err)
+	config := ctr.GetConfig()
+	re.NotNil(config)
+	expectedConfig := controller.DefaultConfig()
+	re.Equal(expectedConfig.ReadBaseCost, config.ReadBaseCost)
+	re.Equal(expectedConfig.ReadBytesCost, config.ReadBytesCost)
+	re.Equal(expectedConfig.WriteBaseCost, config.WriteBaseCost)
+	re.Equal(expectedConfig.WriteBytesCost, config.WriteBytesCost)
+	re.Equal(expectedConfig.CPUMsCost, config.CPUMsCost)
+	// Test init from given config.
+	ruConfig := &controller.RequestUnitConfig{
+		ReadBaseCost:     1,
+		ReadCostPerByte:  2,
+		WriteBaseCost:    3,
+		WriteCostPerByte: 4,
+		CPUMsCost:        5,
+	}
+	ctr, err = controller.NewResourceGroupController(suite.ctx, 1, cli, ruConfig)
+	re.NoError(err)
+	config = ctr.GetConfig()
+	re.NotNil(config)
+	expectedConfig = controller.GenerateConfig(ruConfig)
+	re.Equal(expectedConfig.ReadBaseCost, config.ReadBaseCost)
+	re.Equal(expectedConfig.ReadBytesCost, config.ReadBytesCost)
+	re.Equal(expectedConfig.WriteBaseCost, config.WriteBaseCost)
+	re.Equal(expectedConfig.WriteBytesCost, config.WriteBytesCost)
+	re.Equal(expectedConfig.CPUMsCost, config.CPUMsCost)
 }


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #6038. Should merge after #6041.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- Load RU config from the remote server when initializing controller. 
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
