### PR TITLE
*: make `TestWatch` stable

### DIFF
--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -1439,11 +1439,11 @@ func TestWatch(t *testing.T) {
 
 	key := "test"
 	wg := sync.WaitGroup{}
+	ch, err := client.Watch(ctx, []byte(key))
+	re.NoError(err)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ch, err := client.Watch(ctx, []byte(key))
-		re.NoError(err)
 		var events []*meta_storagepb.Event
 		for e := range ch {
 			events = append(events, e...)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6071.

### What is changed and how does it work?
The watch might start after other etcd operations, which may cause test timeout.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test
Successfully run 100 times in the local environment.

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
