### PR TITLE
moving_filter: fix data race with cache result

### DIFF
--- a/pkg/movingaverage/median_filter.go
+++ b/pkg/movingaverage/median_filter.go
@@ -23,20 +23,18 @@ type MedianFilter struct {
 	// It is not thread safe to read and write records at the same time.
 	// If there are concurrent read and write, the read may get an old value.
 	// And we should avoid concurrent write.
-	records   []float64
-	size      uint64
-	count     uint64
-	isUpdated bool
-	result    float64
+	records []float64
+	size    uint64
+	count   uint64
+	result  float64
 }
 
 // NewMedianFilter returns a MedianFilter.
 func NewMedianFilter(size int) *MedianFilter {
 	return &MedianFilter{
-		records:   make([]float64, size),
-		size:      uint64(size),
-		isUpdated: false,
-		result:    0,
+		records: make([]float64, size),
+		size:    uint64(size),
+		result:  0,
 	}
 }
 
@@ -44,37 +42,29 @@ func NewMedianFilter(size int) *MedianFilter {
 func (r *MedianFilter) Add(n float64) {
 	r.records[r.count%r.size] = n
 	r.count++
-	r.isUpdated = true
-}
-
-// Get returns the median of the data set.
-func (r *MedianFilter) Get() float64 {
-	if !r.isUpdated {
-		return r.result
-	}
-	if r.count == 0 {
-		return 0
-	}
 	records := r.records
 	if r.count < r.size {
 		records = r.records[:r.count]
 	}
 	r.result = pie.Median(records)
-	r.isUpdated = false
+}
+
+// Get returns the median of the data set.
+func (r *MedianFilter) Get() float64 {
 	return r.result
 }
 
 // Reset cleans the data set.
 func (r *MedianFilter) Reset() {
 	r.count = 0
-	r.isUpdated = true
+	r.result = 0
 }
 
 // Set = Reset + Add.
 func (r *MedianFilter) Set(n float64) {
 	r.records[0] = n
 	r.count = 1
-	r.isUpdated = true
+	r.result = n
 }
 
 // GetInstantaneous returns the value just added.
@@ -87,10 +77,9 @@ func (r *MedianFilter) Clone() *MedianFilter {
 	records := make([]float64, len(r.records))
 	copy(records, r.records)
 	return &MedianFilter{
-		records:   records,
-		size:      r.size,
-		count:     r.count,
-		isUpdated: r.isUpdated,
-		result:    r.result,
+		records: records,
+		size:    r.size,
+		count:   r.count,
+		result:  r.result,
 	}
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6069

### What is changed and how does it work?

after #5798 we use cache result in `median.Get` to reduce memory, but it introduces a write operation in `get`, so we remove write op in `get` function to avoid data race. And considering there is more `get` than `add`, it still is valid to reduce memory and CPU time.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
