### PR TITLE
Fix a deadloop in ServiceRegister

### DIFF
--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -81,6 +81,13 @@ func (sr *ServiceRegister) Register() error {
 					// retry
 					t := time.NewTicker(time.Duration(sr.ttl) * time.Second / 2)
 					for {
+						select {
+						case <-sr.ctx.Done():
+							log.Info("exit register process", zap.String("key", sr.key))
+							return
+						default:
+						}
+
 						<-t.C
 						resp, err := sr.cli.Grant(sr.ctx, sr.ttl)
 						if err != nil {


### PR DESCRIPTION
Fix a deadloop in ServiceRegister which happens after etcd exits then the server receives the exit-signal

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5836

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)

Before:

1. start etcd with `./pd-server`
2.start one tso server `./pd-server services tso --listen-addr="127.0.0.1:3379" --backend-endpoints="http://127.0.0.1:2379"`
3. kill pd(etcd)
4. ctl-c to terminate tso server. tso server will in the deadloop of renew lease in the service registry.

_[2023/03/06 21:34:15.076 -08:00] [ERROR] [register.go:87] ["grant lease failed"] [key=/pd/microservice/tso/registry/127.0.0.1:3380] [error="context canceled"]
[2023/03/06 21:34:16.576 -08:00] [WARN] [retry_interceptor.go:62] ["retrying of unary invoker failed"] [target=endpoint://client-4482f527-3680-44fb-bac6-fa25cb48bb25/127.0.0.1:2379] [attempt=0] [error="rpc error: code = Canceled desc = context canceled"]
[2023/03/06 21:34:16.577 -08:00] [ERROR] [register.go:87] ["grant lease failed"] [key=/pd/microservice/tso/registry/127.0.0.1:3380] [error="context canceled"]
[2023/03/06 21:34:18.076 -08:00] [WARN] [retry_interceptor.go:62] ["retrying of unary invoker failed"] [target=endpoint://client-4482f527-3680-44fb-bac6-fa25cb48bb25/127.0.0.1:2379] [attempt=0] [error="rpc error: code = Canceled desc = context canceled"]_
...

After:
After the above steps 1 ~ 4:
[2023/03/06 22:42:20.682 -08:00] [ERROR] [register.go:94] ["grant lease failed"] [key=/pd/microservice/tso/registry/127.0.0.1:3380] [error="context canceled"]
[2023/03/06 22:42:20.682 -08:00] [INFO] [register.go:86] ["exit register process"] [key=/pd/microservice/tso/registry/127.0.0.1:3380]



### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
