### PR TITLE
Fix deadloop in discovery.Deregister

### DIFF
--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -111,7 +111,7 @@ func (sr *ServiceRegister) Register() error {
 // Deregister deregisters the service from etcd.
 func (sr *ServiceRegister) Deregister() error {
 	sr.cancel()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(sr.ttl) * time.Second)
 	defer cancel()
 	_, err := sr.cli.Delete(ctx, sr.key)
 	return err

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -111,7 +111,7 @@ func (sr *ServiceRegister) Register() error {
 // Deregister deregisters the service from etcd.
 func (sr *ServiceRegister) Deregister() error {
 	sr.cancel()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(sr.ttl) * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(sr.ttl)*time.Second)
 	defer cancel()
 	_, err := sr.cli.Delete(ctx, sr.key)
 	return err


### PR DESCRIPTION
Fix deadloop in discovery.Deregister when the etcd backend isn't available and the server received exit-signal.

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5836 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix deadloop in discovery.Deregister when the etcd backend isn't available and the server received exit-signal.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)

With the repro steps below:
1. start etcd with `./pd-server`
2.start one tso server `./pd-server services tso --listen-addr="127.0.0.1:3379" --backend-endpoints="http://127.0.0.1:2379"`
3. kill pd(etcd)
4. ctl-c to terminate tso server. 

**Before:**
[2023/03/07 16:29:57.374 -08:00] [INFO] [server.go:281] ["closing tso server ..."]
[2023/03/07 16:29:57.374 -08:00] [ERROR] [register.go:94] ["grant lease failed"] [key=/pd/microservice/tso/registry/127.0.0.1:3379] [error="context canceled"]
[2023/03/07 16:29:57.374 -08:00] [INFO] [register.go:86] ["exit register process"] [key=/pd/microservice/tso/registry/127.0.0.1:3379]
**[2023/03/07 16:29:57.374 -08:00] [INFO] [register.go:116] ["in Deregister. before final Delete !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"]**
[2023/03/07 16:30:00.995 -08:00] [WARN] [retry_interceptor.go:62] ["retrying of unary invoker failed"] [target=endpoint://client-0c9cc686-6da3-4a26-b2f4-676fad2db807/127.0.0.1:2379] [attempt=0] [error="rpc error: code = DeadlineExceeded desc = latest balancer error: all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:2379: connect: connection refused\""]
**(Repeat the last line endlessly)**

**After:**
[2023/03/07 16:36:25.914 -08:00] [INFO] [server.go:281] ["closing tso server ..."]
**[2023/03/07 16:36:25.914 -08:00] [INFO] [register.go:116] ["in Deregister. before final Delete !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"]**
[2023/03/07 16:36:25.913 -08:00] [INFO] [register.go:76] ["exit register process"] [key=/pd/microservice/tso/registry/127.0.0.1:3379]
[2023/03/07 16:36:25.913 -08:00] [INFO] [server.go:196] ["the tso primary/leader has changed, try to re-campaign a primary/leader"]
[2023/03/07 16:36:25.914 -08:00] [INFO] [server.go:204] ["start to campaign the primary/leader"] [campaign-tso-primary-name=127.0.0.1:3379]
[2023/03/07 16:36:25.913 -08:00] [INFO] [server.go:172] ["tso server is closed, exit allocator loop"]
[2023/03/07 16:36:28.914 -08:00] [WARN] [retry_interceptor.go:62] ["retrying of unary invoker failed"] [target=endpoint://client-4ac63d3c-154b-4271-9688-d852be5f94e2/127.0.0.1:2379] [attempt=0] [error="rpc error: code = DeadlineExceeded desc = latest balancer error: all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:2379: connect: connection refused\""]
**[2023/03/07 16:36:28.914 -08:00] [INFO] [register.go:118] ["in Deregister. after final Delete !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"]**
[2023/03/07 16:36:28.914 -08:00] [INFO] [server.go:283] ["after s.serviceRegister.Deregister() !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"]
[2023/03/07 16:36:28.914 -08:00] [INFO] [server.go:539] ["mux stop serving"] [error="accept tcp 127.0.0.1:3379: use of closed network connection"]
[2023/03/07 16:36:28.914 -08:00] [INFO] [server.go:510] ["http server stopped serving"]
[2023/03/07 16:36:28.914 -08:00] [INFO] [server.go:517] ["all http(s) requests finished"]
[2023/03/07 16:36:28.916 -08:00] [INFO] [server.go:520] ["http server stopped"]
[2023/03/07 16:36:28.916 -08:00] [INFO] [server.go:476] ["grpc server stopped serving"]
[2023/03/07 16:36:28.916 -08:00] [INFO] [server.go:482] ["try to gracefully stop the server now"]
[2023/03/07 16:36:28.916 -08:00] [INFO] [server.go:494] ["grpc server stopped"]


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
