### PR TITLE
resource_control: introduce some functions to get more resource group info in client

### DIFF
--- a/client/resource_group/controller/controller.go
+++ b/client/resource_group/controller/controller.go
@@ -46,7 +46,7 @@ type ResourceGroupKVInterceptor interface {
 	// IsInsufficientResource indicates whether resource group's resource is insufficient which decides whether request needs wait.
 	// Note: The semantic of IsInsufficientResource is different from `isLowTokens` in limiter.
 	IsInsufficientResource(resourceGroupName string) ([]bool, error)
-	// GetConsumption
+	// GetConsumption is used to get resource consumption
 	GetConsumption(resourceGroupName string) ([]float64, error)
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5851 ref https://github.com/pingcap/tidb/issues/41690

### What is changed and how does it work?
Introduce some function in `ResourceGroupKVInterceptor`
1. `IsInsufficientResource` indicates whether resource group's resource is insufficient which decides whether request needs wait.
2. `GetConsumption` is used to get resource consumption

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
