### PR TITLE
Add and initialize cluster id in the TSO service

### DIFF
--- a/client/pd_service_discovery.go
+++ b/client/pd_service_discovery.go
@@ -46,7 +46,7 @@ type ServiceDiscovery interface {
 	// Close releases all resources
 	Close()
 	// GetClusterID returns the ID of the cluster
-	GetClusterID(context.Context) uint64
+	GetClusterID() uint64
 	// GetURLs returns the URLs of the servers.
 	GetURLs() []string
 	// GetServingEndpointClientConn returns the grpc client connection of the serving endpoint
@@ -222,7 +222,7 @@ func (c *pdServiceDiscovery) Close() {
 }
 
 // GetClusterID returns the ClusterID.
-func (c *pdServiceDiscovery) GetClusterID(context.Context) uint64 {
+func (c *pdServiceDiscovery) GetClusterID() uint64 {
 	return c.clusterID
 }
 

--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -700,7 +700,7 @@ func (c *tsoClient) processTSORequests(stream tsoStream, dcLocation string, tbc 
 
 	requests := tbc.getCollectedRequests()
 	count := int64(len(requests))
-	physical, logical, suffixBits, err := stream.processRequests(c.svcDiscovery.GetClusterID(c.ctx), dcLocation, requests, tbc.batchStartTime)
+	physical, logical, suffixBits, err := stream.processRequests(c.svcDiscovery.GetClusterID(), dcLocation, requests, tbc.batchStartTime)
 	if err != nil {
 		c.finishTSORequest(requests, 0, 0, 0, err)
 		return err

--- a/client/tso_service_discovery.go
+++ b/client/tso_service_discovery.go
@@ -45,6 +45,7 @@ var _ tsoAllocatorEventSource = (*tsoServiceDiscovery)(nil)
 
 // tsoServiceDiscovery is the service discovery client of the independent TSO service
 type tsoServiceDiscovery struct {
+	clusterID  uint64
 	keyspaceID uint32
 	urls       atomic.Value // Store as []string
 	// primary key is the etcd path used for discoverying the serving endpoint of this keyspace
@@ -83,13 +84,14 @@ type tsoServiceDiscovery struct {
 
 // newTSOServiceDiscovery returns a new client-side service discovery for the independent TSO service.
 func newTSOServiceDiscovery(ctx context.Context, cancel context.CancelFunc, wg *sync.WaitGroup, metacli MetaStorageClient,
-	keyspaceID uint32, urls []string, tlsCfg *tlsutil.TLSConfig, option *option) ServiceDiscovery {
+	clusterID uint64, keyspaceID uint32, urls []string, tlsCfg *tlsutil.TLSConfig, option *option) ServiceDiscovery {
 	bc := &tsoServiceDiscovery{
 		ctx:               ctx,
 		cancel:            cancel,
 		wg:                wg,
 		metacli:           metacli,
 		keyspaceID:        keyspaceID,
+		clusterID:         clusterID,
 		primaryKey:        path.Join(tsoPrimaryPrefix, fmt.Sprintf("%05d", 0), "primary"),
 		tlsCfg:            tlsCfg,
 		option:            option,
@@ -158,8 +160,8 @@ func (c *tsoServiceDiscovery) Close() {
 }
 
 // GetClusterID returns the ID of the cluster
-func (c *tsoServiceDiscovery) GetClusterID(context.Context) uint64 {
-	return 0
+func (c *tsoServiceDiscovery) GetClusterID() uint64 {
+	return c.clusterID
 }
 
 // GetURLs returns the URLs of the servers.

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -557,12 +557,9 @@ func (s *Server) startGRPCAndHTTPServers(l net.Listener) {
 }
 
 func (s *Server) startServer() (err error) {
-	// TODO: uncomment the following code to generate a unique cluster id from the given ClusterIDPath
-	// after we add rpc for the client to retrieve the cluster id from the server then use it in every
-	// request for verification.
-	// if s.clusterID, err = etcdutil.GetClusterID(s.etcdClient, utils.ClusterIDPath); err != nil {
-	// 	return err
-	// }
+	if s.clusterID, err = etcdutil.GetClusterID(s.etcdClient, utils.ClusterIDPath); err != nil {
+		return err
+	}
 	log.Info("init cluster id", zap.Uint64("cluster-id", s.clusterID))
 
 	// It may lose accuracy if use float64 to store uint64. So we store the cluster id in label.

--- a/tests/mcs/tso/testutil.go
+++ b/tests/mcs/tso/testutil.go
@@ -82,6 +82,7 @@ func startSingleTSOTestServer(ctx context.Context, re *require.Assertions, backe
 }
 
 func setupCli(re *require.Assertions, ctx context.Context, endpoints []string, opts ...pd.ClientOption) pd.Client {
+	// TODO: we use keyspace 0 as the default keyspace for now, which mightn't need change in the future
 	cli, err := pd.NewTSOClientWithContext(ctx, 0, endpoints, pd.SecurityOption{}, opts...)
 	re.NoError(err)
 	return cli

--- a/tests/mcs/tso/testutil.go
+++ b/tests/mcs/tso/testutil.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/client/testutil"
 	tsosvr "github.com/tikv/pd/pkg/mcs/tso/server"
 	"github.com/tikv/pd/pkg/utils/logutil"
@@ -78,4 +79,10 @@ func startSingleTSOTestServer(ctx context.Context, re *require.Assertions, backe
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 
 	return s, cleanup, err
+}
+
+func setupCli(re *require.Assertions, ctx context.Context, endpoints []string, opts ...pd.ClientOption) pd.Client {
+	cli, err := pd.NewTSOClientWithContext(ctx, 0, endpoints, pd.SecurityOption{}, opts...)
+	re.NoError(err)
+	return cli
 }

--- a/tests/mcs/tso/tso_service_test.go
+++ b/tests/mcs/tso/tso_service_test.go
@@ -1,0 +1,102 @@
+// Copyright 2023 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tso
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	tsosvr "github.com/tikv/pd/pkg/mcs/tso/server"
+	"github.com/tikv/pd/pkg/utils/tsoutil"
+	"github.com/tikv/pd/tests"
+)
+
+const (
+	tsoRequestConcurrencyNumber = 1
+	tsoRequestRound             = 30
+)
+
+type tsoServiceTestSuite struct {
+	suite.Suite
+	ctx              context.Context
+	cancel           context.CancelFunc
+	cluster          *tests.TestCluster
+	pdLeader         *tests.TestServer
+	backendEndpoints string
+	tsoSvr1          *tsosvr.Server
+	tsoSvrCleanup1   CleanupFunc
+}
+
+func TestTSOServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(tsoServiceTestSuite))
+}
+
+func (suite *tsoServiceTestSuite) SetupSuite() {
+	var err error
+	re := suite.Require()
+
+	suite.ctx, suite.cancel = context.WithCancel(context.Background())
+	suite.cluster, err = tests.NewTestCluster(suite.ctx, 1)
+	re.NoError(err)
+
+	err = suite.cluster.RunInitialServers()
+	re.NoError(err)
+
+	leaderName := suite.cluster.WaitLeader()
+	suite.pdLeader = suite.cluster.GetServer(leaderName)
+	suite.backendEndpoints = suite.pdLeader.GetAddr()
+
+	suite.tsoSvr1, suite.tsoSvrCleanup1, err = startSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints)
+	re.NoError(err)
+}
+
+func (suite *tsoServiceTestSuite) TearDownSuite() {
+	suite.tsoSvrCleanup1()
+	suite.cluster.Destroy()
+	suite.cancel()
+}
+
+func (suite *tsoServiceTestSuite) TestTSOServerRegister() {
+	re := suite.Require()
+
+	endpoints := strings.Split(suite.backendEndpoints, ",")
+	cli1 := setupCli(re, suite.ctx, endpoints)
+	cli2 := setupCli(re, suite.ctx, endpoints)
+
+	var wg sync.WaitGroup
+	wg.Add(tsoRequestConcurrencyNumber)
+	for i := 0; i < tsoRequestConcurrencyNumber; i++ {
+		go func() {
+			defer wg.Done()
+			var lastTS uint64
+			for i := 0; i < tsoRequestRound; i++ {
+				physical, logical, err := cli1.GetTS(context.Background())
+				re.NoError(err)
+				ts := tsoutil.ComposeTS(physical, logical)
+				re.Less(lastTS, ts)
+				lastTS = ts
+				physical, logical, err = cli2.GetTS(context.Background())
+				re.NoError(err)
+				ts = tsoutil.ComposeTS(physical, logical)
+				re.Less(lastTS, ts)
+				lastTS = ts
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5836 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Add and initialize cluster id in the TSO service.
PD/API service discovery gets cluster id from the API service.
It then passes the cluster id to the TSO service because both share the same cluster id.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
