### PR TITLE
client/resource_group: make maxWaitDuration configurable

### DIFF
--- a/client/resource_group/controller/config.go
+++ b/client/resource_group/controller/config.go
@@ -51,6 +51,8 @@ const (
 	// targetPeriod indicate how long it is expected to cost token when acquiring token.
 	// According to the resource control Grafana panel and Prometheus sampling period, the period should be the factor of 15.
 	defaultTargetPeriod = 5 * time.Second
+	// defaultMaxWaitDuration is the max duration to wait for the token before throwing error.
+	defaultMaxWaitDuration = time.Second
 )
 
 const (
@@ -105,6 +107,7 @@ type Config struct {
 	CPUMsCost      RequestUnit
 	// The CPU statistics need to distinguish between different environments.
 	isSingleGroupByKeyspace bool
+	maxWaitDuration         time.Duration
 }
 
 // DefaultConfig returns the default configuration.
@@ -117,11 +120,12 @@ func DefaultConfig() *Config {
 // GenerateConfig generates the configuration by the given request unit configuration.
 func GenerateConfig(ruConfig *RequestUnitConfig) *Config {
 	cfg := &Config{
-		ReadBaseCost:   RequestUnit(ruConfig.ReadBaseCost),
-		ReadBytesCost:  RequestUnit(ruConfig.ReadCostPerByte),
-		WriteBaseCost:  RequestUnit(ruConfig.WriteBaseCost),
-		WriteBytesCost: RequestUnit(ruConfig.WriteCostPerByte),
-		CPUMsCost:      RequestUnit(ruConfig.CPUMsCost),
+		ReadBaseCost:    RequestUnit(ruConfig.ReadBaseCost),
+		ReadBytesCost:   RequestUnit(ruConfig.ReadCostPerByte),
+		WriteBaseCost:   RequestUnit(ruConfig.WriteBaseCost),
+		WriteBytesCost:  RequestUnit(ruConfig.WriteCostPerByte),
+		CPUMsCost:       RequestUnit(ruConfig.CPUMsCost),
+		maxWaitDuration: defaultMaxWaitDuration,
 	}
 	return cfg
 }


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: Ref #4399 

The default value (1s) of maxWaitDuration may not suitable for some cases.

### What is changed and how does it work?
make configurable.

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

- Has the configuration change

### Release note


```release-note
None.
```
