### PR TITLE
mcs: use cluster ID for election

### DIFF
--- a/client/tso_service_discovery.go
+++ b/client/tso_service_discovery.go
@@ -33,13 +33,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	// tsoPrimaryPrefix defines the key prefix for keyspace group primary election.
-	// The entire key is in the format of "/ms/<cluster-id>/tso/<group-id>/primary" in which
-	// <group-id> is 5 digits integer with leading zeros. For now we use 0 as the default cluster id.
-	tsoPrimaryPrefix = "/ms/0/tso"
-)
-
 var _ ServiceDiscovery = (*tsoServiceDiscovery)(nil)
 var _ tsoAllocatorEventSource = (*tsoServiceDiscovery)(nil)
 
@@ -85,6 +78,7 @@ type tsoServiceDiscovery struct {
 // newTSOServiceDiscovery returns a new client-side service discovery for the independent TSO service.
 func newTSOServiceDiscovery(ctx context.Context, cancel context.CancelFunc, wg *sync.WaitGroup, metacli MetaStorageClient,
 	clusterID uint64, keyspaceID uint32, urls []string, tlsCfg *tlsutil.TLSConfig, option *option) ServiceDiscovery {
+	tsoPrimaryPrefix := fmt.Sprintf("/ms/%d/tso", clusterID)
 	bc := &tsoServiceDiscovery{
 		ctx:               ctx,
 		cancel:            cancel,

--- a/pkg/mcs/resource_manager/server/server.go
+++ b/pkg/mcs/resource_manager/server/server.go
@@ -50,13 +50,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	// resourceManagerPrimaryPrefix defines the key prefix for keyspace group primary election.
-	// The entire key is in the format of "/ms/<cluster-id>/resource_manager/<group-id>/primary"
-	// in which <group-id> is 5 digits integer with leading zeros. For now we use 0 as the default cluster id.
-	resourceManagerPrimaryPrefix = "/ms/0/resource_manager"
-)
-
 // Server is the resource manager server, and it implements bs.Server.
 type Server struct {
 	// Server state. 0 is not serving, 1 is serving.
@@ -371,6 +364,7 @@ func (s *Server) startServer() (err error) {
 	uniqueName := s.cfg.ListenAddr
 	uniqueID := memberutil.GenerateUniqueID(uniqueName)
 	log.Info("joining primary election", zap.String("participant-name", uniqueName), zap.Uint64("participant-id", uniqueID))
+	resourceManagerPrimaryPrefix := fmt.Sprintf("/ms/%d/resource_manager", s.clusterID)
 	s.participant = member.NewParticipant(s.etcdClient, uniqueID)
 	s.participant.InitInfo(uniqueName, path.Join(resourceManagerPrimaryPrefix, fmt.Sprintf("%05d", 0)), "primary", "keyspace group primary election", s.cfg.ListenAddr)
 	s.participant.SetMemberDeployPath(s.participant.ID())

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -66,10 +66,6 @@ import (
 const (
 	// pdRootPath is the old path for storing the tso related root path.
 	pdRootPath = "/pd"
-	// tsoPrimaryPrefix defines the key prefix for keyspace group primary election.
-	// The entire key is in the format of "/ms/<cluster-id>/tso/<group-id>/primary" in which
-	// <group-id> is 5 digits integer with leading zeros. For now we use 0 as the default cluster id.
-	tsoPrimaryPrefix = "/ms/0/tso"
 )
 
 var _ bs.Server = (*Server)(nil)
@@ -579,6 +575,7 @@ func (s *Server) startServer() (err error) {
 	uniqueID := memberutil.GenerateUniqueID(uniqueName)
 	log.Info("joining primary election", zap.String("participant-name", uniqueName), zap.Uint64("participant-id", uniqueID))
 
+	tsoPrimaryPrefix := fmt.Sprintf("/ms/%d/tso", s.clusterID)
 	s.participant = member.NewParticipant(s.etcdClient, uniqueID)
 	s.participant.InitInfo(uniqueName, path.Join(tsoPrimaryPrefix, fmt.Sprintf("%05d", 0)), "primary", "keyspace group primary election", s.cfg.ListenAddr)
 	s.participant.SetMemberDeployPath(s.participant.ID())

--- a/server/server.go
+++ b/server/server.go
@@ -1667,8 +1667,7 @@ func (s *Server) UnmarkSnapshotRecovering(ctx context.Context) error {
 
 // GetServicePrimaryAddr returns the primary address for a given service.
 func (s *Server) GetServicePrimaryAddr(ctx context.Context, serviceName string) (bool, string, error) {
-	// TODO: replace default group name after we make a decision.
-	key := path.Join("/ms/0", serviceName, fmt.Sprintf("%05d", 0), "primary")
+	key := fmt.Sprintf("/ms/%d/%s/%s/%s", s.clusterID, serviceName, fmt.Sprintf("%05d", 0), "primary")
 	leader := &pdpb.Member{}
 	ok, _, err := etcdutil.GetProtoMsgWithModRev(s.client, key, leader)
 	if err != nil || !ok {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5836.

### What is changed and how does it work?

This PR uses cluster id for the election instead of using 0.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
