### PR TITLE
change rule-group delete func to rule-bundle delete func

### DIFF
--- a/tests/pdctl/config/config_test.go
+++ b/tests/pdctl/config/config_test.go
@@ -411,6 +411,9 @@ func TestPlacementRuleGroups(t *testing.T) {
 	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "set", "group2", "100", "false")
 	re.NoError(err)
 	re.Contains(string(output), "Success!")
+	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "set", "group3", "200", "false")
+	re.NoError(err)
+	re.Contains(string(output), "Success!")
 
 	// show all
 	var groups []placement.RuleGroup
@@ -420,15 +423,24 @@ func TestPlacementRuleGroups(t *testing.T) {
 	re.Equal([]placement.RuleGroup{
 		{ID: "pd", Index: 42, Override: true},
 		{ID: "group2", Index: 100, Override: false},
+		{ID: "group3", Index: 200, Override: false},
 	}, groups)
 
 	// delete
 	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "delete", "group2")
 	re.NoError(err)
-	re.Contains(string(output), "Success!")
+	re.Contains(string(output), "Delete group and rules successfully.")
 
 	// show again
 	output, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show", "group2")
+	re.NoError(err)
+	re.Contains(string(output), "404")
+
+	// delete using regex
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "delete", "--regexp", ".*3")
+	re.NoError(err)
+
+	_, err = pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "rule-group", "show", "group3")
 	re.NoError(err)
 	re.Contains(string(output), "404")
 }

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -468,9 +468,10 @@ func NewPlacementRulesCommand() *cobra.Command {
 	}
 	ruleGroupDelete := &cobra.Command{
 		Use:   "delete <id>",
-		Short: "delete rule group configuration",
-		Run:   deleteRuleGroupFunc,
+		Short: "delete rule group configuration. Note: this command will be deprecated soon, use <rule-bundle delete> instead",
+		Run:   delRuleBundle,
 	}
+	ruleGroupDelete.Flags().Bool("regexp", false, "match group id by regular expression")
 	ruleGroup.AddCommand(ruleGroupShow, ruleGroupSet, ruleGroupDelete)
 	ruleBundle := &cobra.Command{
 		Use:   "rule-bundle",
@@ -661,19 +662,6 @@ func updateRuleGroupFunc(cmd *cobra.Command, args []string) {
 		"index":    index,
 		"override": override,
 	})
-}
-
-func deleteRuleGroupFunc(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		cmd.Println(cmd.UsageString())
-		return
-	}
-	_, err := doRequest(cmd, path.Join(ruleGroupPrefix, args[0]), http.MethodDelete, http.Header{})
-	if err != nil {
-		cmd.Printf("Failed to remove rule group config: %s \n", err)
-		return
-	}
-	cmd.Println("Success!")
 }
 
 func getRuleBundle(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #5967 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
- Change `rule-group delete` func to `delRuleBundle`
- Add regex usage message in `rule-group delete` command desc
- Add deprecated message in `rule-group delete` command desc 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)
  - Compile & build pd-ctl
  - start a tiup playground, and added few placement rules
  - use `pd-ctl config placement-rules rule-group delete` command to delete one or some groups
  - check and validate the result

Code changes


Side effects

Related changes
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
