### PR TITLE
resource_manager: change the default group fillrate to MaxInt32

### DIFF
--- a/pkg/mcs/resource_manager/server/manager.go
+++ b/pkg/mcs/resource_manager/server/manager.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -132,7 +133,7 @@ func (m *Manager) Init(ctx context.Context) {
 		RUSettings: &RequestUnitSettings{
 			RU: &GroupTokenBucket{
 				Settings: &rmpb.TokenLimitSettings{
-					FillRate:   1000000,
+					FillRate:   math.MaxInt32,
 					BurstLimit: -1,
 				},
 			},

--- a/tests/integrations/mcs/resource_manager/server_test.go
+++ b/tests/integrations/mcs/resource_manager/server_test.go
@@ -69,7 +69,7 @@ func TestResourceManagerServer(t *testing.T) {
 		re.Equal(http.StatusOK, resp.StatusCode)
 		respString, err := io.ReadAll(resp.Body)
 		re.NoError(err)
-		re.Equal(`[{"name":"default","mode":1,"r_u_settings":{"r_u":{"settings":{"fill_rate":1000000,"burst_limit":-1},"state":{"initialized":false}}},"priority":8}]`, string(respString))
+		re.Equal(`[{"name":"default","mode":1,"r_u_settings":{"r_u":{"settings":{"fill_rate":2147483647,"burst_limit":-1},"state":{"initialized":false}}},"priority":8}]`, string(respString))
 	}
 	{
 		group := &rmpb.ResourceGroup{


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #4399 Ref https://github.com/pingcap/tidb/issues/42595

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
resource_manager: change the default group fillrate to MaxInt32
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
