### PR TITLE
resource_manager/client: fix exceed error when ru consump of query is greater than ru fill rate

### DIFF
--- a/client/resource_group/controller/controller.go
+++ b/client/resource_group/controller/controller.go
@@ -674,11 +674,11 @@ func (gc *groupCostController) resetEmergencyTokenAcquisition() {
 	switch gc.mode {
 	case rmpb.GroupMode_RawMode:
 		for _, counter := range gc.run.resourceTokens {
-			counter.limiter.ResetNotifytime()
+			counter.limiter.ResetRemainingNotifyTimes()
 		}
 	case rmpb.GroupMode_RUMode:
 		for _, counter := range gc.run.requestUnitTokens {
-			counter.limiter.ResetNotifytime()
+			counter.limiter.ResetRemainingNotifyTimes()
 		}
 	}
 }

--- a/client/resource_group/controller/controller_test.go
+++ b/client/resource_group/controller/controller_test.go
@@ -42,7 +42,7 @@ func createTestGroupCostController(re *require.Assertions) *groupCostController 
 	}
 	ch1 := make(chan struct{})
 	ch2 := make(chan *groupCostController)
-	gc, err := newGroupCostController(group, DefaultConfig(), ch1, ch2, successfulRequestDuration.WithLabelValues(group.Name), failedRequestCounter.WithLabelValues(group.Name), requestRetryCounter.WithLabelValues(group.Name), resourceGroupTokenRequestCounter.WithLabelValues(group.Name))
+	gc, err := newGroupCostController(group, DefaultConfig(), ch1, ch2)
 	re.NoError(err)
 	return gc
 }

--- a/client/resource_group/controller/controller_test.go
+++ b/client/resource_group/controller/controller_test.go
@@ -42,7 +42,7 @@ func createTestGroupCostController(re *require.Assertions) *groupCostController 
 	}
 	ch1 := make(chan struct{})
 	ch2 := make(chan *groupCostController)
-	gc, err := newGroupCostController(group, DefaultConfig(), ch1, ch2, successfulRequestDuration.WithLabelValues(group.Name), failedRequestCounter.WithLabelValues(group.Name), resourceGroupTokenRequestCounter.WithLabelValues(group.Name))
+	gc, err := newGroupCostController(group, DefaultConfig(), ch1, ch2, successfulRequestDuration.WithLabelValues(group.Name), failedRequestCounter.WithLabelValues(group.Name), requestRetryCounter.WithLabelValues(group.Name), resourceGroupTokenRequestCounter.WithLabelValues(group.Name))
 	re.NoError(err)
 	return gc
 }

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -79,8 +79,8 @@ type Limiter struct {
 	// So the notifyThreshold cannot show whether the limiter is in the low token state,
 	// isLowProcess is used to check it.
 	isLowProcess bool
-	// notifyTime is used to limit notify when the speed limit is already set.
-	notifyTime int
+	// remainingNotifyTimes is used to limit notify when the speed limit is already set.
+	remainingNotifyTimes int
 }
 
 // Limit returns the maximum overall event rate.
@@ -300,7 +300,7 @@ func (lim *Limiter) Reconfigure(now time.Time,
 ) {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()
-	log.Debug("[resource group controller] before reconfigure", zap.Float64("NewTokens", lim.tokens), zap.Float64("NewRate", float64(lim.limit)), zap.Float64("NotifyThreshold", args.NotifyThreshold), zap.Int64("burst", lim.burst))
+	log.Debug("[resource group controller] before reconfigure", zap.Float64("OldTokens", lim.tokens), zap.Float64("OldRate", float64(lim.limit)), zap.Float64("OldNotifyThreshold", args.NotifyThreshold), zap.Int64("OldBurst", lim.burst))
 	if args.NewBurst < 0 {
 		lim.last = now
 		lim.tokens = args.NewTokens
@@ -316,7 +316,7 @@ func (lim *Limiter) Reconfigure(now time.Time,
 		opt(lim)
 	}
 	lim.maybeNotify()
-	log.Debug("[resource group controller] after reconfigure", zap.Float64("NewTokens", lim.tokens), zap.Float64("NewRate", float64(lim.limit)), zap.Float64("NotifyThreshold", args.NotifyThreshold), zap.Int64("burst", lim.burst))
+	log.Debug("[resource group controller] after reconfigure", zap.Float64("Tokens", lim.tokens), zap.Float64("Rate", float64(lim.limit)), zap.Float64("NotifyThreshold", args.NotifyThreshold), zap.Int64("Burst", lim.burst))
 }
 
 // AvailableTokens decreases the amount of tokens currently available.
@@ -371,26 +371,25 @@ func (lim *Limiter) reserveN(now time.Time, n float64, maxFutureReserve time.Dur
 		lim.tokens = tokens
 		lim.maybeNotify()
 	} else {
+		log.Warn("[resource group controller]", zap.Float64("NewTokens", lim.tokens), zap.Float64("current rate", float64(lim.limit)), zap.Float64("request tokens", n), zap.Int64("burst", lim.burst), zap.Int("remaining notify times", lim.remainingNotifyTimes))
 		lim.last = last
 		if lim.limit == 0 {
 			lim.notify()
-		} else {
+		} else if lim.remainingNotifyTimes > 0 {
 			// When fillrate is greater than 0, the speed limit is already set.
 			// If limiter are in limit state, the server has allocated tokens as much as possible. Don't need to request tokens.
-			if lim.notifyTime > 0 {
-				lim.notifyTime--
-				lim.notify()
-			}
+			// But there is a special case, see issue https://github.com/tikv/pd/issues/6300.
+			lim.remainingNotifyTimes--
+			lim.notify()
 		}
-		log.Warn("[resource group controller]", zap.Float64("NewTokens", lim.tokens), zap.Float64("NewRate", float64(lim.limit)), zap.Float64("n", n), zap.Int64("burst", lim.burst))
 	}
 	return r
 }
 
-func (lim *Limiter) ResetNotifytime() {
+func (lim *Limiter) ResetRemainingNotifyTimes() {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()
-	lim.notifyTime = 1
+	lim.remainingNotifyTimes = 3
 }
 
 // advance calculates and returns an updated state for lim resulting from the passage of time.

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -370,7 +370,10 @@ func (lim *Limiter) reserveN(now time.Time, n float64, maxFutureReserve time.Dur
 		lim.maybeNotify()
 	} else {
 		lim.last = last
-		lim.notify()
+		if lim.limit == 0 {
+			lim.notify()
+		}
+		log.Warn("[resource group controller]", zap.Float64("NewTokens", lim.tokens), zap.Float64("NewRate", float64(lim.limit)), zap.Float64("n", n), zap.Int64("burst", lim.burst))
 	}
 	return r
 }

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -370,6 +370,7 @@ func (lim *Limiter) reserveN(now time.Time, n float64, maxFutureReserve time.Dur
 		lim.maybeNotify()
 	} else {
 		lim.last = last
+		lim.notify()
 	}
 	return r
 }

--- a/client/resource_group/controller/metrics.go
+++ b/client/resource_group/controller/metrics.go
@@ -50,6 +50,14 @@ var (
 			Help:      "Counter of failed request.",
 		}, []string{resourceGroupNameLabel})
 
+	requestRetryCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: requestSubsystem,
+			Name:      "retry",
+			Help:      "Counter of retry time for request.",
+		}, []string{resourceGroupNameLabel})
+
 	tokenRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -77,6 +85,7 @@ func init() {
 	prometheus.MustRegister(resourceGroupStatusGauge)
 	prometheus.MustRegister(successfulRequestDuration)
 	prometheus.MustRegister(failedRequestCounter)
+	prometheus.MustRegister(requestRetryCounter)
 	prometheus.MustRegister(tokenRequestDuration)
 	prometheus.MustRegister(resourceGroupTokenRequestCounter)
 }

--- a/tests/integrations/mcs/resource_manager/resource_manager_test.go
+++ b/tests/integrations/mcs/resource_manager/resource_manager_test.go
@@ -115,6 +115,19 @@ func (suite *resourceManagerClientTestSuite) SetupSuite() {
 				},
 			},
 		},
+		{
+			Name: "test4",
+			Mode: rmpb.GroupMode_RUMode,
+			RUSettings: &rmpb.GroupRequestUnitSettings{
+				RU: &rmpb.TokenBucket{
+					Settings: &rmpb.TokenLimitSettings{
+						FillRate:   1000,
+						BurstLimit: 5000000,
+					},
+					Tokens: 5000000,
+				},
+			},
+		},
 	}
 }
 
@@ -450,13 +463,32 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 			break
 		}
 	}
-	re.NoError(failpoint.Enable("github.com/tikv/pd/client/resource_group/controller/acceleratedReportingPeriod", "return(true)"))
 
 	resourceGroupName2 := suite.initGroups[2].Name
-	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 100000, times: 100, waitDuration: 0}
+	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 100000, times: 1, waitDuration: 0}
 	wreq := tcs.makeWriteRequest()
 	_, err := controller.OnRequestWait(suite.ctx, resourceGroupName2, wreq)
 	re.NoError(err)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/client/resource_group/controller/acceleratedSpeedTrend", "return(true)"))
+	resourceGroupName3 := suite.initGroups[3].Name
+	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 1000, times: 1, waitDuration: 0}
+	wreq = tcs.makeWriteRequest()
+	_, err = controller.OnRequestWait(suite.ctx, resourceGroupName3, wreq)
+	re.NoError(err)
+	time.Sleep(110 * time.Millisecond)
+	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 10, times: 1010, waitDuration: 0}
+	duration := time.Duration(0)
+	for i := 0; i < tcs.times; i++ {
+		wreq = tcs.makeWriteRequest()
+		startTime := time.Now()
+		_, err = controller.OnRequestWait(suite.ctx, resourceGroupName3, wreq)
+		duration += time.Since(startTime)
+		re.NoError(err)
+	}
+	re.Less(duration, 100*time.Millisecond)
+	re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/acceleratedReportingPeriod"))
+	re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/acceleratedSpeedTrend"))
 	suite.cleanupResourceGroups()
 	controller.Stop()
 }

--- a/tests/integrations/mcs/resource_manager/resource_manager_test.go
+++ b/tests/integrations/mcs/resource_manager/resource_manager_test.go
@@ -102,6 +102,19 @@ func (suite *resourceManagerClientTestSuite) SetupSuite() {
 				},
 			},
 		},
+		{
+			Name: "test3",
+			Mode: rmpb.GroupMode_RUMode,
+			RUSettings: &rmpb.GroupRequestUnitSettings{
+				RU: &rmpb.TokenBucket{
+					Settings: &rmpb.TokenLimitSettings{
+						FillRate:   100,
+						BurstLimit: 5000000,
+					},
+					Tokens: 5000000,
+				},
+			},
+		},
 	}
 }
 
@@ -438,6 +451,12 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 		}
 	}
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/resource_group/controller/acceleratedReportingPeriod", "return(true)"))
+
+	resourceGroupName2 := suite.initGroups[2].Name
+	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 100000, times: 100, waitDuration: 0}
+	wreq := tcs.makeWriteRequest()
+	_, err := controller.OnRequestWait(suite.ctx, resourceGroupName2, wreq)
+	re.NoError(err)
 	suite.cleanupResourceGroups()
 	controller.Stop()
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6298 close #6300

### What is changed and how does it work?
1. notify when the limiter reserve token fails. In addition, the limit of notify times is set when the limiter is limit state.
2. Update the logic of RU consumption statistics. This ensures that speed includes the application in progress when notifying

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
