### PR TITLE
bootstrap default keyspace group in the tso service

### DIFF
--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -58,6 +58,10 @@ func NewKeyspaceGroupManager(ctx context.Context, store endpoint.KeyspaceGroupSt
 
 // Bootstrap saves default keyspace group info and init group mapping in the memory.
 func (m *GroupManager) Bootstrap() error {
+	// Force the membership restriction that the default keyspace must belong to default keyspace group.
+	// Have no information to specify the distribution of the default keyspace group replicas, so just
+	// leave the replica/member list empty. The TSO service will assign the default keyspace group replica
+	// to every tso node/pod by default.
 	defaultKeyspaceGroup := &endpoint.KeyspaceGroup{
 		ID:        utils.DefaultKeyspaceGroupID,
 		UserKind:  endpoint.Basic.String(),
@@ -71,9 +75,6 @@ func (m *GroupManager) Bootstrap() error {
 	if err != nil && err != ErrKeyspaceGroupExists {
 		return err
 	}
-
-	userKind := endpoint.StringUserKind(defaultKeyspaceGroup.UserKind)
-	m.groups[userKind].Put(defaultKeyspaceGroup)
 
 	// Load all the keyspace groups from the storage and add to the respective userKind groups.
 	groups, err := m.store.LoadKeyspaceGroups(utils.DefaultKeyspaceGroupID, 0)

--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -59,8 +59,9 @@ func NewKeyspaceGroupManager(ctx context.Context, store endpoint.KeyspaceGroupSt
 // Bootstrap saves default keyspace group info and init group mapping in the memory.
 func (m *GroupManager) Bootstrap() error {
 	defaultKeyspaceGroup := &endpoint.KeyspaceGroup{
-		ID:       utils.DefaultKeyspaceGroupID,
-		UserKind: endpoint.Basic.String(),
+		ID:        utils.DefaultKeyspaceGroupID,
+		UserKind:  endpoint.Basic.String(),
+		Keyspaces: []uint32{utils.DefaultKeyspaceID},
 	}
 
 	m.Lock()

--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -59,7 +59,7 @@ func NewKeyspaceGroupManager(ctx context.Context, store endpoint.KeyspaceGroupSt
 // Bootstrap saves default keyspace group info and init group mapping in the memory.
 func (m *GroupManager) Bootstrap() error {
 	defaultKeyspaceGroup := &endpoint.KeyspaceGroup{
-		ID:       utils.DefaultKeySpaceGroupID,
+		ID:       utils.DefaultKeyspaceGroupID,
 		UserKind: endpoint.Basic.String(),
 	}
 
@@ -75,7 +75,7 @@ func (m *GroupManager) Bootstrap() error {
 	m.groups[userKind].Put(defaultKeyspaceGroup)
 
 	// Load all the keyspace groups from the storage and add to the respective userKind groups.
-	groups, err := m.store.LoadKeyspaceGroups(utils.DefaultKeySpaceGroupID, 0)
+	groups, err := m.store.LoadKeyspaceGroups(utils.DefaultKeyspaceGroupID, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/mcs/tso/server/handler.go
+++ b/pkg/mcs/tso/server/handler.go
@@ -38,7 +38,7 @@ func (h *Handler) ResetTS(ts uint64, ignoreSmaller, skipUpperBoundCheck bool) er
 		zap.Uint64("new-ts", ts),
 		zap.Bool("ignore-smaller", ignoreSmaller),
 		zap.Bool("skip-upper-bound-check", skipUpperBoundCheck))
-	tsoAllocatorManager, err := h.s.GetTSOAllocatorManager(mcsutils.DefaultKeySpaceGroupID)
+	tsoAllocatorManager, err := h.s.GetTSOAllocatorManager(mcsutils.DefaultKeyspaceGroupID)
 	if err != nil {
 		log.Error("failed to get allocator manager", errs.ZapError(err))
 		return err

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -209,7 +209,7 @@ func (s *Server) IsServing() bool {
 	}
 
 	member, err := s.keyspaceGroupManager.GetElectionMember(
-		mcsutils.DefaultKeyspaceID, mcsutils.DefaultKeySpaceGroupID)
+		mcsutils.DefaultKeyspaceID, mcsutils.DefaultKeyspaceGroupID)
 	if err != nil {
 		log.Error("failed to get election member", errs.ZapError(err))
 		return false
@@ -221,7 +221,7 @@ func (s *Server) IsServing() bool {
 // The entry at the index 0 is the primary's service endpoint.
 func (s *Server) GetLeaderListenUrls() []string {
 	member, err := s.keyspaceGroupManager.GetElectionMember(
-		mcsutils.DefaultKeyspaceID, mcsutils.DefaultKeySpaceGroupID)
+		mcsutils.DefaultKeyspaceID, mcsutils.DefaultKeyspaceGroupID)
 	if err != nil {
 		log.Error("failed to get election member", errs.ZapError(err))
 		return nil
@@ -436,15 +436,14 @@ func (s *Server) startServer() (err error) {
 		return err
 	}
 
+	// Initialize the TSO service.
 	s.serverLoopCtx, s.serverLoopCancel = context.WithCancel(s.ctx)
 	legacySvcRootPath := path.Join(pdRootPath, strconv.FormatUint(s.clusterID, 10))
 	tsoSvcRootPath := fmt.Sprintf(tsoSvcRootPathFormat, s.clusterID)
 	s.serviceID = &discovery.ServiceRegistryEntry{ServiceAddr: s.cfg.AdvertiseListenAddr}
 	s.keyspaceGroupManager = tso.NewKeyspaceGroupManager(
 		s.serverLoopCtx, s.serviceID, s.etcdClient, s.listenURL.Host, legacySvcRootPath, tsoSvcRootPath, s.cfg)
-	// The param `false` means that we don't initialize the keyspace group manager
-	// by loading the keyspace group meta from etcd.
-	if err := s.keyspaceGroupManager.Initialize(false); err != nil {
+	if err := s.keyspaceGroupManager.Initialize(); err != nil {
 		return err
 	}
 

--- a/pkg/mcs/utils/constant.go
+++ b/pkg/mcs/utils/constant.go
@@ -37,12 +37,13 @@ const (
 
 	// DefaultKeyspaceID is the default key space id.
 	// Valid keyspace id range is [0, 0xFFFFFF](uint24max, or 16777215)
-	// ​0 is reserved for default keyspace with the name "DEFAULT", It's initialized when PD bootstrap and reserved for users who haven't been assigned keyspace.
+	// ​0 is reserved for default keyspace with the name "DEFAULT", It's initialized when PD bootstrap
+	// and reserved for users who haven't been assigned keyspace.
 	DefaultKeyspaceID = uint32(0)
 
-	// DefaultKeySpaceGroupID is the default key space group id.
+	// DefaultKeyspaceGroupID is the default key space group id.
 	// We also reserved 0 for the keyspace group for the same purpose.
-	DefaultKeySpaceGroupID = uint32(0)
+	DefaultKeyspaceGroupID = uint32(0)
 
 	// APIServiceName is the name of api server.
 	APIServiceName = "api"

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -280,7 +280,8 @@ func (kgm *KeyspaceGroupManager) checkInitProgress(ctx context.Context, cancel c
 }
 
 func (kgm *KeyspaceGroupManager) initDefaultKeysapceGroup(keyspaces []uint32) {
-	log.Info("initializing default keyspace group", zap.Any("keyspaces", keyspaces))
+	log.Info("initializing default keyspace group",
+		zap.Int("keyspaces-length", len(keyspaces)))
 
 	group := &endpoint.KeyspaceGroup{
 		ID:        mcsutils.DefaultKeyspaceGroupID,

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -227,7 +227,7 @@ func (kgm *KeyspaceGroupManager) Initialize() error {
 	done := make(chan struct{}, 1)
 	ctx, cancel := context.WithCancel(kgm.ctx)
 	go kgm.checkInitProgress(ctx, cancel, done)
-	watchStartRevision, sawDefaultKeyspaceGroup, err := kgm.initAssignment(ctx)
+	watchStartRevision, defaultKGConfigured, err := kgm.initAssignment(ctx)
 	done <- struct{}{}
 	if err != nil {
 		log.Error("failed to initialize keyspace group manager", errs.ZapError(err))
@@ -237,7 +237,7 @@ func (kgm *KeyspaceGroupManager) Initialize() error {
 	}
 
 	// Initialize the default keyspace group if it isn't configured in the storage.
-	if !sawDefaultKeyspaceGroup {
+	if !defaultKGConfigured {
 		keyspaces := []uint32{mcsutils.DefaultKeyspaceID}
 		kgm.initDefaultKeysapceGroup(keyspaces)
 	}
@@ -292,7 +292,7 @@ func (kgm *KeyspaceGroupManager) initDefaultKeysapceGroup(keyspaces []uint32) {
 // Return watchStartRevision, the start revision for watching keyspace group membership/distribution change.
 func (kgm *KeyspaceGroupManager) initAssignment(
 	ctx context.Context,
-) (watchStartRevision int64, sawDefaultKeyspaceGroup bool, err error) {
+) (watchStartRevision int64, defaultKGConfigured bool, err error) {
 	var (
 		groups               []*endpoint.KeyspaceGroup
 		more                 bool
@@ -323,7 +323,7 @@ func (kgm *KeyspaceGroupManager) initAssignment(
 			}
 
 			if group.ID == mcsutils.DefaultKeyspaceGroupID {
-				sawDefaultKeyspaceGroup = true
+				defaultKGConfigured = true
 			}
 
 			kgm.updateKeyspaceGroup(group)

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -124,7 +124,15 @@ func (s *state) getAMWithMembershipCheck(
 	if kgid, ok := s.keyspaceLookupTable[keyspaceID]; ok {
 		return nil, kgid, genNotServedErr(errs.ErrGetAllocatorManager, keyspaceGroupID)
 	}
-	return nil, keyspaceGroupID, errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
+
+	if keyspaceGroupID != mcsutils.DefaultKeyspaceGroupID {
+		return nil, keyspaceGroupID, errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
+	}
+
+	// The keyspace doesn't belong to any keyspace group, so return the default keyspace group.
+	// It's for migrating the existing keyspaces which have no keyspace group assigned, so the
+	// the default keyspace group is used to serve the keyspaces.
+	return s.ams[mcsutils.DefaultKeyspaceGroupID], mcsutils.DefaultKeyspaceGroupID, nil
 }
 
 // KeyspaceGroupManager manages the members of the keyspace groups assigned to this host.

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -96,30 +96,30 @@ func (suite *keyspaceGroupManagerTestSuite) TestNewKeyspaceGroupManager() {
 	tsoSvcRootPath := path.Join("/ms", guid, "tso")
 	electionNamePrefix := "tso-server-" + guid
 
-	ksgMgr := suite.newKeyspaceGroupManager(tsoServiceID, electionNamePrefix, legacySvcRootPath, tsoSvcRootPath)
-	err := ksgMgr.Initialize(false)
+	kgm := suite.newKeyspaceGroupManager(tsoServiceID, electionNamePrefix, legacySvcRootPath, tsoSvcRootPath)
+	err := kgm.Initialize()
 	re.NoError(err)
 
-	re.Equal(tsoServiceID, ksgMgr.tsoServiceID)
-	re.Equal(suite.etcdClient, ksgMgr.etcdClient)
-	re.Equal(electionNamePrefix, ksgMgr.electionNamePrefix)
-	re.Equal(legacySvcRootPath, ksgMgr.legacySvcRootPath)
-	re.Equal(tsoSvcRootPath, ksgMgr.tsoSvcRootPath)
-	re.Equal(suite.cfg, ksgMgr.cfg)
-	re.Equal(defaultLoadKeyspaceGroupsBatchSize, ksgMgr.loadKeyspaceGroupsBatchSize)
-	re.Equal(defaultLoadKeyspaceGroupsTimeout, ksgMgr.loadKeyspaceGroupsTimeout)
+	re.Equal(tsoServiceID, kgm.tsoServiceID)
+	re.Equal(suite.etcdClient, kgm.etcdClient)
+	re.Equal(electionNamePrefix, kgm.electionNamePrefix)
+	re.Equal(legacySvcRootPath, kgm.legacySvcRootPath)
+	re.Equal(tsoSvcRootPath, kgm.tsoSvcRootPath)
+	re.Equal(suite.cfg, kgm.cfg)
+	re.Equal(defaultLoadKeyspaceGroupsBatchSize, kgm.loadKeyspaceGroupsBatchSize)
+	re.Equal(defaultLoadKeyspaceGroupsTimeout, kgm.loadKeyspaceGroupsTimeout)
 
-	am, err := ksgMgr.GetAllocatorManager(mcsutils.DefaultKeySpaceGroupID)
+	am, err := kgm.GetAllocatorManager(mcsutils.DefaultKeyspaceGroupID)
 	re.NoError(err)
 	re.False(am.enableLocalTSO)
-	re.Equal(mcsutils.DefaultKeySpaceGroupID, am.kgID)
+	re.Equal(mcsutils.DefaultKeyspaceGroupID, am.kgID)
 	re.Equal(mcsutils.DefaultLeaderLease, am.leaderLease)
 	re.Equal(time.Hour*24, am.maxResetTSGap())
 	re.Equal(legacySvcRootPath, am.rootPath)
 	re.Equal(time.Duration(mcsutils.DefaultLeaderLease)*time.Second, am.saveInterval)
 	re.Equal(time.Duration(50)*time.Millisecond, am.updatePhysicalInterval)
 
-	ksgMgr.Close()
+	kgm.Close()
 }
 
 // TestLoadKeyspaceGroupsAssignment tests the loading of the keyspace group assignment.
@@ -183,7 +183,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestLoadKeyspaceGroupsTimeout() {
 	// the loading sleep 3 seconds.
 	mgr.loadKeyspaceGroupsTimeout = time.Second
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/delayLoadKeyspaceGroups", "return(3)"))
-	err := mgr.Initialize(true)
+	err := mgr.Initialize()
 	// If loading keyspace groups timeout, the initialization should fail with ErrLoadKeyspaceGroupsTerminated.
 	re.Equal(errs.ErrLoadKeyspaceGroupsTerminated, err)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/delayLoadKeyspaceGroups"))
@@ -206,7 +206,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestLoadKeyspaceGroupsSucceedWithTem
 	// loading from etcd fail 2 times but the whole initialization still succeeds.
 	mgr.loadFromEtcdMaxRetryTimes = 3
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/loadKeyspaceGroupsTemporaryFail", "return(2)"))
-	err := mgr.Initialize(true)
+	err := mgr.Initialize()
 	re.NoError(err)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/loadKeyspaceGroupsTemporaryFail"))
 }
@@ -228,7 +228,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestLoadKeyspaceGroupsFailed() {
 	// loading from etcd fail 3 times which should cause the whole initialization to fail.
 	mgr.loadFromEtcdMaxRetryTimes = 3
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/loadKeyspaceGroupsTemporaryFail", "return(3)"))
-	err := mgr.Initialize(true)
+	err := mgr.Initialize()
 	re.Error(err)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/loadKeyspaceGroupsTemporaryFail"))
 }
@@ -242,7 +242,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestWatchAndDynamicallyApplyChanges(
 	mgr := suite.newUniqueKeyspaceGroupManager(0)
 	re.NotNil(mgr)
 	defer mgr.Close()
-	err := mgr.Initialize(true)
+	err := mgr.Initialize()
 	re.NoError(err)
 
 	rootPath := mgr.legacySvcRootPath
@@ -252,37 +252,37 @@ func (suite *keyspaceGroupManagerTestSuite) TestWatchAndDynamicallyApplyChanges(
 	events := []*etcdEvent{}
 	// Assign keyspace group 0 to this host/pod/keyspace-group-manager.
 	// final result: [0]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 0, []string{svcAddr})
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 0, []uint32{0}, []string{svcAddr}))
 	// Assign keyspace group 1 to this host/pod/keyspace-group-manager.
 	// final result: [0,1]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 1, []string{"unknown", svcAddr})
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 1, []uint32{1}, []string{"unknown", svcAddr}))
 	// Assign keyspace group 2 to other host/pod/keyspace-group-manager.
 	// final result: [0,1]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 2, []string{"unknown"})
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 2, []uint32{2}, []string{"unknown"}))
 	// Assign keyspace group 3 to this host/pod/keyspace-group-manager.
 	// final result: [0,1,3]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 3, []string{svcAddr})
-	// Delete keyspace group 0
-	// final result: [1,3]
-	events = generateKeyspaceGroupEvent(events, mvccpb.DELETE, 0, []string{})
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 3, []uint32{3}, []string{svcAddr}))
+	// Delete keyspace group 0. Every tso node/pod now should initialize keyspace group 0.
+	// final result: [0,1,3]
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.DELETE, 0, []uint32{0}, []string{}))
 	// Put keyspace group 4 which doesn't belong to anyone.
-	// final result: [1,3]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 4, []string{})
+	// final result: [0,1,3]
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 4, []uint32{4}, []string{}))
 	// Put keyspace group 5 which doesn't belong to anyone.
-	// final result: [1,3]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 5, []string{})
+	// final result: [0,1,3]
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 5, []uint32{5}, []string{}))
 	// Assign keyspace group 2 to this host/pod/keyspace-group-manager.
-	// final result: [1,2,3]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 2, []string{svcAddr})
+	// final result: [0,1,2,3]
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 2, []uint32{2}, []string{svcAddr}))
 	// Reassign keyspace group 3 to no one.
-	// final result: [1,2]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 3, []string{})
+	// final result: [0,1,2]
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 3, []uint32{3}, []string{}))
 	// Reassign keyspace group 4 to this host/pod/keyspace-group-manager.
-	// final result: [1,2,4]
-	events = generateKeyspaceGroupEvent(events, mvccpb.PUT, 4, []string{svcAddr})
+	// final result: [0,1,2,4]
+	events = append(events, generateKeyspaceGroupEvent(mvccpb.PUT, 4, []uint32{4}, []string{svcAddr}))
 
 	// Eventually, this keyspace groups manager is expected to serve the following keyspace groups.
-	idsExpected := []int{1, 2, 4}
+	expectedGroupIDs := []uint32{0, 1, 2, 4}
 
 	// Apply the keyspace group assignment change events to etcd.
 	for _, event := range events {
@@ -298,8 +298,76 @@ func (suite *keyspaceGroupManagerTestSuite) TestWatchAndDynamicallyApplyChanges(
 
 	// Verify the keyspace group assignment.
 	testutil.Eventually(re, func() bool {
-		idsAssigned := collectAssignedKeyspaceGroupIDs(re, mgr)
-		return reflect.DeepEqual(idsExpected, idsAssigned)
+		assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
+		return reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs)
+	})
+}
+
+// TestDefaultKeyspaceGroup tests the initialization logic of the default keyspace group.
+// If the default keyspace group isn't configured in the etcd, every tso node/pod should initialize
+// it and join the election for the primary of this group.
+// If the default keyspace group is configured in the etcd, the tso nodes/pods which are assigned with
+// this group will initialize it and join the election for the primary of this group.
+func (suite *keyspaceGroupManagerTestSuite) TestInitDefaultKeyspaceGroup() {
+	re := suite.Require()
+
+	var (
+		expectedGroupIDs []uint32
+		event            *etcdEvent
+	)
+
+	// Start with the empty keyspace group assignment.
+	mgr := suite.newUniqueKeyspaceGroupManager(0)
+	defer mgr.Close()
+	err := mgr.Initialize()
+	re.NoError(err)
+
+	rootPath := mgr.legacySvcRootPath
+	svcAddr := mgr.tsoServiceID.ServiceAddr
+
+	expectedGroupIDs = []uint32{0}
+	assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
+	re.True(reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs))
+
+	// Config keyspace group 0 in the storage but assigned to no one.
+	// final result: []
+	expectedGroupIDs = []uint32{}
+	event = generateKeyspaceGroupEvent(mvccpb.PUT, 0, []uint32{0}, []string{"unknown"})
+	err = putKeyspaceGroupToEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg)
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
+		return reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs)
+	})
+	// Config keyspace group 0 in the storage and assigned to this host/pod/keyspace-group-manager.
+	// final result: [0]
+	expectedGroupIDs = []uint32{0}
+	event = generateKeyspaceGroupEvent(mvccpb.PUT, 0, []uint32{0}, []string{svcAddr})
+	err = putKeyspaceGroupToEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg)
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
+		return reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs)
+	})
+	// Delete keyspace group 0. Every tso node/pod now should initialize keyspace group 0.
+	// final result: [0]
+	expectedGroupIDs = []uint32{0}
+	event = generateKeyspaceGroupEvent(mvccpb.DELETE, 0, []uint32{0}, []string{})
+	err = deleteKeyspaceGroupInEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg.ID)
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
+		return reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs)
+	})
+	// Config keyspace group 0 in the storage and assigned to this host/pod/keyspace-group-manager.
+	// final result: [0]
+	expectedGroupIDs = []uint32{0}
+	event = generateKeyspaceGroupEvent(mvccpb.PUT, 0, []uint32{0}, []string{svcAddr})
+	err = putKeyspaceGroupToEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg)
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
+		return reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs)
 	})
 }
 
@@ -323,31 +391,90 @@ func (suite *keyspaceGroupManagerTestSuite) TestGetAMWithMembershipCheck() {
 		mgr.legacySvcRootPath, mgr.tsoServiceID.ServiceAddr,
 		uint32(0), []uint32{0, 1, 2})
 
-	err = mgr.Initialize(true)
+	err = mgr.Initialize()
 	re.NoError(err)
 
 	// Should be able to get AM for keyspace 0, 1, 2 in keyspace group 0.
-	am, kgid, err = mgr.state.getAMWithMembershipCheck(0, 0)
+	am, kgid, err = mgr.getAMWithMembershipCheck(0, 0)
 	re.NoError(err)
 	re.Equal(uint32(0), kgid)
 	re.NotNil(am)
-	am, kgid, err = mgr.state.getAMWithMembershipCheck(1, 0)
+	am, kgid, err = mgr.getAMWithMembershipCheck(1, 0)
 	re.NoError(err)
 	re.Equal(uint32(0), kgid)
 	re.NotNil(am)
-	am, kgid, err = mgr.state.getAMWithMembershipCheck(2, 0)
+	am, kgid, err = mgr.getAMWithMembershipCheck(2, 0)
 	re.NoError(err)
 	re.Equal(uint32(0), kgid)
 	re.NotNil(am)
 	// Should fail because keyspace 3 is not in keyspace group 0.
-	am, kgid, err = mgr.state.getAMWithMembershipCheck(3, 0)
+	am, kgid, err = mgr.getAMWithMembershipCheck(3, 0)
 	re.Error(err)
 	re.Equal(uint32(0), kgid)
 	re.Nil(am)
 	// Should fail because keyspace group 1 doesn't exist.
-	am, kgid, err = mgr.state.getAMWithMembershipCheck(0, 1)
+	am, kgid, err = mgr.getAMWithMembershipCheck(0, 1)
 	re.Error(err)
 	re.Equal(uint32(0), kgid)
+	re.Nil(am)
+}
+
+// TestDefaultMembershipRestriction tests the restriction of default keyspace always
+// belongs to default keyspace group.
+func (suite *keyspaceGroupManagerTestSuite) TestDefaultMembershipRestriction() {
+	re := suite.Require()
+
+	mgr := suite.newUniqueKeyspaceGroupManager(1)
+	re.NotNil(mgr)
+	defer mgr.Close()
+
+	rootPath := mgr.legacySvcRootPath
+	svcAddr := mgr.tsoServiceID.ServiceAddr
+
+	var (
+		am    *AllocatorManager
+		kgid  uint32
+		err   error
+		event *etcdEvent
+	)
+
+	// Create keyspace group 0 which contains keyspace 0, 1, 2.
+	addKeyspaceGroupAssignment(
+		suite.ctx, suite.etcdClient, true,
+		mgr.legacySvcRootPath, mgr.tsoServiceID.ServiceAddr,
+		mcsutils.DefaultKeyspaceGroupID, []uint32{mcsutils.DefaultKeyspaceID, 1, 2})
+	// Create keyspace group 3 which contains keyspace 3, 4.
+	addKeyspaceGroupAssignment(
+		suite.ctx, suite.etcdClient, true,
+		mgr.legacySvcRootPath, mgr.tsoServiceID.ServiceAddr,
+		uint32(3), []uint32{3, 4})
+
+	err = mgr.Initialize()
+	re.NoError(err)
+
+	event = generateKeyspaceGroupEvent(
+		mvccpb.PUT, mcsutils.DefaultKeyspaceGroupID, []uint32{1, 2}, []string{svcAddr})
+	err = putKeyspaceGroupToEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg)
+	re.NoError(err)
+	event = generateKeyspaceGroupEvent(
+		mvccpb.PUT, 3, []uint32{mcsutils.DefaultKeyspaceID, 3, 4}, []string{svcAddr})
+	err = putKeyspaceGroupToEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg)
+	re.NoError(err)
+
+	// Should be able to still get AM for keyspace 0 in keyspace group 0.
+	// Sleep for a while to wait for the events to propagate. If the restriction is not working,
+	// it will cause random failure.
+	time.Sleep(1 * time.Second)
+	// Should be able to get AM for keyspace 0 in keyspace group 0.
+	am, kgid, err = mgr.getAMWithMembershipCheck(
+		mcsutils.DefaultKeyspaceID, mcsutils.DefaultKeyspaceGroupID)
+	re.NoError(err)
+	re.Equal(mcsutils.DefaultKeyspaceGroupID, kgid)
+	re.NotNil(am)
+	// Can't get the default keyspace from the keyspace group 3
+	am, kgid, err = mgr.getAMWithMembershipCheck(mcsutils.DefaultKeyspaceID, 3)
+	re.Error(err)
+	re.Equal(mcsutils.DefaultKeyspaceGroupID, kgid)
 	re.Nil(am)
 }
 
@@ -366,7 +493,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestHandleTSORequestWithWrongMembers
 		mgr.legacySvcRootPath, mgr.tsoServiceID.ServiceAddr,
 		uint32(0), []uint32{0, 1, 2})
 
-	err := mgr.Initialize(true)
+	err := mgr.Initialize()
 	re.NoError(err)
 
 	// Should fail because keyspace 0 is not in keyspace group 1 and the API returns
@@ -382,23 +509,21 @@ type etcdEvent struct {
 }
 
 func generateKeyspaceGroupEvent(
-	events []*etcdEvent, eventType mvccpb.Event_EventType, id uint32, addrs []string,
-) []*etcdEvent {
+	eventType mvccpb.Event_EventType, groupID uint32, keyspaces []uint32, addrs []string,
+) *etcdEvent {
 	members := []endpoint.KeyspaceGroupMember{}
 	for _, addr := range addrs {
 		members = append(members, endpoint.KeyspaceGroupMember{Address: addr})
 	}
 
-	return append(events,
-		&etcdEvent{
-			eventType: eventType,
-			ksg: &endpoint.KeyspaceGroup{
-				ID:        id,
-				Members:   members,
-				Keyspaces: []uint32{id},
-			},
+	return &etcdEvent{
+		eventType: eventType,
+		ksg: &endpoint.KeyspaceGroup{
+			ID:        groupID,
+			Members:   members,
+			Keyspaces: keyspaces,
 		},
-	)
+	}
 }
 
 func (suite *keyspaceGroupManagerTestSuite) newKeyspaceGroupManager(
@@ -418,7 +543,7 @@ func (suite *keyspaceGroupManagerTestSuite) runTestLoadKeyspaceGroupsAssignment(
 	loadKeyspaceGroupsBatchSize int64, // set to 0 to use the default value
 	probabilityAssignToMe int, // percentage of assigning keyspace groups to this host/pod
 ) {
-	idsExpected := []int{}
+	expectedGroupIDs := []uint32{}
 	mgr := suite.newUniqueKeyspaceGroupManager(loadKeyspaceGroupsBatchSize)
 	re.NotNil(mgr)
 	defer mgr.Close()
@@ -445,7 +570,7 @@ func (suite *keyspaceGroupManagerTestSuite) runTestLoadKeyspaceGroupsAssignment(
 				if j < len(mgr.ams) && randomGen.Intn(100) < probabilityAssignToMe {
 					assignToMe = true
 					mux.Lock()
-					idsExpected = append(idsExpected, j)
+					expectedGroupIDs = append(expectedGroupIDs, uint32(j))
 					mux.Unlock()
 				}
 				addKeyspaceGroupAssignment(
@@ -457,13 +582,21 @@ func (suite *keyspaceGroupManagerTestSuite) runTestLoadKeyspaceGroupsAssignment(
 	}
 	wg.Wait()
 
-	err := mgr.Initialize(true)
+	err := mgr.Initialize()
 	re.NoError(err)
 
+	// If no keyspace group is assigned to this host/pod, the default keyspace group should be initialized.
+	if numberOfKeypaceGroupsToAdd <= 0 {
+		expectedGroupIDs = append(expectedGroupIDs, mcsutils.DefaultKeyspaceGroupID)
+	}
+
 	// Verify the keyspace group assignment.
-	sort.Ints(idsExpected)
-	idsAssigned := collectAssignedKeyspaceGroupIDs(re, mgr)
-	re.Equal(idsExpected, idsAssigned)
+	// Sort the keyspaces in ascending order
+	sort.Slice(expectedGroupIDs, func(i, j int) bool {
+		return expectedGroupIDs[i] < expectedGroupIDs[j]
+	})
+	assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
+	re.Equal(expectedGroupIDs, assignedGroupIDs)
 }
 
 func (suite *keyspaceGroupManagerTestSuite) newUniqueKeyspaceGroupManager(
@@ -547,23 +680,23 @@ func addKeyspaceGroupAssignment(
 	return nil
 }
 
-func collectAssignedKeyspaceGroupIDs(re *require.Assertions, ksgMgr *KeyspaceGroupManager) []int {
-	ksgMgr.RLock()
-	defer ksgMgr.RUnlock()
+func collectAssignedKeyspaceGroupIDs(re *require.Assertions, kgm *KeyspaceGroupManager) []uint32 {
+	kgm.RLock()
+	defer kgm.RUnlock()
 
-	ids := []int{}
-	for i := 0; i < len(ksgMgr.kgs); i++ {
-		ksg := ksgMgr.kgs[i]
-		if ksg == nil {
-			re.Nil(ksgMgr.ams[i], fmt.Sprintf("ksg is nil but am is not nil for id %d", i))
+	ids := []uint32{}
+	for i := 0; i < len(kgm.kgs); i++ {
+		kg := kgm.kgs[i]
+		if kg == nil {
+			re.Nil(kgm.ams[i], fmt.Sprintf("ksg is nil but am is not nil for id %d", i))
 		} else {
-			am := ksgMgr.ams[i]
+			am := kgm.ams[i]
 			re.NotNil(am, fmt.Sprintf("ksg is not nil but am is nil for id %d", i))
 			re.Equal(i, int(am.kgID))
-			re.Equal(i, int(ksg.ID))
-			for _, m := range ksg.Members {
-				if m.Address == ksgMgr.tsoServiceID.ServiceAddr {
-					ids = append(ids, i)
+			re.Equal(i, int(kg.ID))
+			for _, m := range kg.Members {
+				if m.Address == kgm.tsoServiceID.ServiceAddr {
+					ids = append(ids, uint32(i))
 					break
 				}
 			}
@@ -577,9 +710,16 @@ func (suite *keyspaceGroupManagerTestSuite) TestUpdateKeyspaceGroupMembership() 
 	re := suite.Require()
 
 	// Start from an empty keyspace group.
-	oldGroup := &endpoint.KeyspaceGroup{ID: 0, Keyspaces: []uint32{}}
-	newGroup := &endpoint.KeyspaceGroup{ID: 0, Keyspaces: []uint32{}}
-	kgm := &KeyspaceGroupManager{state: state{keyspaceLookupTable: make(map[uint32]uint32)}}
+	// Use non-default keyspace group ID.
+	// The default keyspace group always contains the default keyspace.
+	// We have dedicated tests for the default keyspace group.
+	groupID := uint32(1)
+	oldGroup := &endpoint.KeyspaceGroup{ID: groupID, Keyspaces: []uint32{}}
+	newGroup := &endpoint.KeyspaceGroup{ID: groupID, Keyspaces: []uint32{}}
+	kgm := &KeyspaceGroupManager{
+		state: state{
+			keyspaceLookupTable: make(map[uint32]uint32),
+		}}
 
 	kgm.updateKeyspaceGroupMembership(oldGroup, newGroup)
 	verifyLocalKeyspaceLookupTable(re, newGroup.KeyspaceLookupTable, newGroup.Keyspaces)

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -327,7 +327,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestInitDefaultKeyspaceGroup() {
 
 	expectedGroupIDs = []uint32{0}
 	assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
-	re.True(reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs))
+	re.Equal(expectedGroupIDs, assignedGroupIDs)
 
 	// Config keyspace group 0 in the storage but assigned to no one.
 	// final result: []
@@ -750,7 +750,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestUpdateKeyspaceGroupMembership() 
 		oldGroup = newGroup
 		keyspacesCopy := make([]uint32, len(keyspaces))
 		copy(keyspacesCopy, keyspaces)
-		newGroup = &endpoint.KeyspaceGroup{ID: 0, Keyspaces: keyspacesCopy}
+		newGroup = &endpoint.KeyspaceGroup{ID: groupID, Keyspaces: keyspacesCopy}
 		kgm.updateKeyspaceGroupMembership(oldGroup, newGroup)
 		verifyLocalKeyspaceLookupTable(re, newGroup.KeyspaceLookupTable, newGroup.Keyspaces)
 		verifyGlobalKeyspaceLookupTable(re, kgm.keyspaceLookupTable, newGroup.KeyspaceLookupTable)

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -452,6 +452,13 @@ func (suite *keyspaceGroupManagerTestSuite) TestDefaultMembershipRestriction() {
 	err = mgr.Initialize()
 	re.NoError(err)
 
+	// Should be able to get AM for keyspace 0 in keyspace group 0.
+	am, kgid, err = mgr.getAMWithMembershipCheck(
+		mcsutils.DefaultKeyspaceID, mcsutils.DefaultKeyspaceGroupID)
+	re.NoError(err)
+	re.Equal(mcsutils.DefaultKeyspaceGroupID, kgid)
+	re.NotNil(am)
+
 	event = generateKeyspaceGroupEvent(
 		mvccpb.PUT, mcsutils.DefaultKeyspaceGroupID, []uint32{1, 2}, []string{svcAddr})
 	err = putKeyspaceGroupToEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg)
@@ -461,11 +468,10 @@ func (suite *keyspaceGroupManagerTestSuite) TestDefaultMembershipRestriction() {
 	err = putKeyspaceGroupToEtcd(suite.ctx, suite.etcdClient, rootPath, event.ksg)
 	re.NoError(err)
 
-	// Should be able to still get AM for keyspace 0 in keyspace group 0.
 	// Sleep for a while to wait for the events to propagate. If the restriction is not working,
 	// it will cause random failure.
 	time.Sleep(1 * time.Second)
-	// Should be able to get AM for keyspace 0 in keyspace group 0.
+	// Should still be able to get AM for keyspace 0 in keyspace group 0.
 	am, kgid, err = mgr.getAMWithMembershipCheck(
 		mcsutils.DefaultKeyspaceID, mcsutils.DefaultKeyspaceGroupID)
 	re.NoError(err)

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -407,11 +407,12 @@ func (suite *keyspaceGroupManagerTestSuite) TestGetAMWithMembershipCheck() {
 	re.NoError(err)
 	re.Equal(uint32(0), kgid)
 	re.NotNil(am)
-	// Should fail because keyspace 3 is not in keyspace group 0.
+	// Should still succeed even keyspace 3 isn't explicitly assigned to any
+	// keyspace group. It will be assigned to the default keyspace group.
 	am, kgid, err = mgr.getAMWithMembershipCheck(3, 0)
-	re.Error(err)
+	re.NoError(err)
 	re.Equal(uint32(0), kgid)
-	re.Nil(am)
+	re.NotNil(am)
 	// Should fail because keyspace group 1 doesn't exist.
 	am, kgid, err = mgr.getAMWithMembershipCheck(0, 1)
 	re.Error(err)

--- a/pkg/utils/tsoutil/tso_request.go
+++ b/pkg/utils/tsoutil/tso_request.go
@@ -141,7 +141,7 @@ func (r *PDProtoRequest) getCount() uint32 {
 // count defins the count of timestamps to retrieve.
 func (r *PDProtoRequest) process(forwardStream stream, count uint32, tsoProtoFactory ProtoFactory) (tsoResp, error) {
 	return forwardStream.process(r.request.GetHeader().GetClusterId(), count,
-		utils.DefaultKeyspaceID, utils.DefaultKeySpaceGroupID, r.request.GetDcLocation())
+		utils.DefaultKeyspaceID, utils.DefaultKeyspaceGroupID, r.request.GetDcLocation())
 }
 
 // postProcess sends the response back to the sender of the request

--- a/server/apiv2/handlers/tso_keyspace_group.go
+++ b/server/apiv2/handlers/tso_keyspace_group.go
@@ -195,5 +195,5 @@ func validateKeyspaceGroupID(c *gin.Context) (uint32, error) {
 }
 
 func isValid(id uint32) bool {
-	return id >= utils.DefaultKeySpaceGroupID && id <= utils.MaxKeyspaceGroupCountInUse
+	return id >= utils.DefaultKeyspaceGroupID && id <= utils.MaxKeyspaceGroupCountInUse
 }

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1774,7 +1774,7 @@ func (s *GrpcServer) getGlobalTSOFromTSOServer(ctx context.Context) (pdpb.Timest
 		Header: &tsopb.RequestHeader{
 			ClusterId:       s.clusterID,
 			KeyspaceId:      utils.DefaultKeyspaceID,
-			KeyspaceGroupId: utils.DefaultKeySpaceGroupID,
+			KeyspaceGroupId: utils.DefaultKeyspaceGroupID,
 		},
 		Count: 1,
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -405,7 +405,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.tsoProtoFactory = &tsoutil.TSOProtoFactory{}
 	s.pdProtoFactory = &tsoutil.PDProtoFactory{}
 	if !s.IsAPIServiceMode() {
-		s.tsoAllocatorManager = tso.NewAllocatorManager(s.ctx, mcs.DefaultKeySpaceGroupID, s.member, s.rootPath, s.storage, s, false)
+		s.tsoAllocatorManager = tso.NewAllocatorManager(s.ctx, mcs.DefaultKeyspaceGroupID, s.member, s.rootPath, s.storage, s, false)
 		// When disabled the Local TSO, we should clean up the Local TSO Allocator's meta info written in etcd if it exists.
 		if !s.cfg.EnableLocalTSO {
 			if err = s.tsoAllocatorManager.CleanUpDCLocation(); err != nil {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #6232

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Changes:

1. Introduce the initialization logic of the default keyspace group.
- If the default keyspace group isn't configured in the etcd, every tso node/pod should initialize it and join the election for the primary of this group.
- If the default keyspace group is configured in the etcd, the tso nodes/pods which are assigned with this group will initialize it and join the election for the primary of this group.

2. Introduce the keyspace group membership restriction -- default keyspace always belongs to default keyspace group.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
