### PR TITLE
keyspace: add split-from field for endpoint.KeyspaceGroup

### DIFF
--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -184,6 +184,7 @@ func (m *GroupManager) saveKeyspaceGroups(keyspaceGroups []*endpoint.KeyspaceGro
 				Members:   keyspaceGroup.Members,
 				Keyspaces: keyspaceGroup.Keyspaces,
 				InSplit:   keyspaceGroup.InSplit,
+				SplitFrom: keyspaceGroup.SplitFrom,
 			})
 		}
 		return nil
@@ -339,7 +340,8 @@ func (m *GroupManager) SplitKeyspaceGroupByID(id, newID uint32, keyspaces []uint
 			Members:   oldKg.Members,
 			Keyspaces: keyspaces,
 			// Only set the new keyspace group in split state.
-			InSplit: true,
+			InSplit:   true,
+			SplitFrom: oldKg.ID,
 		})
 	})
 }

--- a/pkg/keyspace/tso_keyspace_group_test.go
+++ b/pkg/keyspace/tso_keyspace_group_test.go
@@ -254,11 +254,13 @@ func (suite *keyspaceGroupTestSuite) TestKeyspaceGroupSplit() {
 	re.Equal(uint32(2), kg2.ID)
 	re.Equal([]uint32{111, 222}, kg2.Keyspaces)
 	re.False(kg2.InSplit)
+	re.Empty(kg2.SplitFrom)
 	kg4, err := suite.kgm.GetKeyspaceGroupByID(4)
 	re.NoError(err)
 	re.Equal(uint32(4), kg4.ID)
 	re.Equal([]uint32{333}, kg4.Keyspaces)
 	re.True(kg4.InSplit)
+	re.Equal(kg2.ID, kg4.SplitFrom)
 	re.Equal(kg2.UserKind, kg4.UserKind)
 	re.Equal(kg2.Members, kg4.Members)
 	// finish the split of keyspace group 4
@@ -268,6 +270,7 @@ func (suite *keyspaceGroupTestSuite) TestKeyspaceGroupSplit() {
 	re.NoError(err)
 	re.Equal(uint32(4), kg4.ID)
 	re.False(kg4.InSplit)
+	re.Equal(kg2.ID, kg4.SplitFrom)
 	// split a non-existing keyspace group
 	err = suite.kgm.SplitKeyspaceGroupByID(3, 5, nil)
 	re.ErrorIs(err, ErrKeyspaceGroupNotFound)

--- a/pkg/storage/endpoint/tso_keyspace_group.go
+++ b/pkg/storage/endpoint/tso_keyspace_group.go
@@ -71,6 +71,8 @@ type KeyspaceGroup struct {
 	UserKind string `json:"user-kind"`
 	// InSplit indicates whether the keyspace group is in split.
 	InSplit bool `json:"in-split"`
+	// SplitFrom is the keyspace group ID which the keyspace group is split from.
+	SplitFrom uint32 `json:"split-from"`
 	// Members are the election members which campaign for the primary of the keyspace group.
 	Members []KeyspaceGroupMember `json:"members"`
 	// Keyspaces are the keyspace IDs which belong to the keyspace group.

--- a/pkg/storage/endpoint/tso_keyspace_group.go
+++ b/pkg/storage/endpoint/tso_keyspace_group.go
@@ -71,7 +71,7 @@ type KeyspaceGroup struct {
 	UserKind string `json:"user-kind"`
 	// InSplit indicates whether the keyspace group is in split.
 	InSplit bool `json:"in-split"`
-	// SplitFrom is the keyspace group ID which the keyspace group is split from.
+	// SplitFrom is the keyspace group ID from which the keyspace group is split.
 	SplitFrom uint32 `json:"split-from"`
 	// Members are the election members which campaign for the primary of the keyspace group.
 	Members []KeyspaceGroupMember `json:"members"`

--- a/tests/server/apiv2/handlers/tso_keyspace_group_test.go
+++ b/tests/server/apiv2/handlers/tso_keyspace_group_test.go
@@ -118,11 +118,13 @@ func (suite *keyspaceGroupTestSuite) TestSplitKeyspaceGroup() {
 	re.Equal(uint32(1), kg1.ID)
 	re.Equal([]uint32{333}, kg1.Keyspaces)
 	re.False(kg1.InSplit)
+	re.Empty(kg1.SplitFrom)
 	// Check keyspace group 2.
 	kg2 := mustLoadKeyspaceGroupByID(re, suite.server, 2)
 	re.Equal(uint32(2), kg2.ID)
 	re.Equal([]uint32{111, 222}, kg2.Keyspaces)
 	re.True(kg2.InSplit)
+	re.Equal(kg1.ID, kg2.SplitFrom)
 	// They should have the same user kind and members.
 	re.Equal(kg1.UserKind, kg2.UserKind)
 	re.Equal(kg1.Members, kg2.Members)
@@ -130,6 +132,7 @@ func (suite *keyspaceGroupTestSuite) TestSplitKeyspaceGroup() {
 	mustFinishSplitKeyspaceGroup(re, suite.server, 2)
 	kg2 = mustLoadKeyspaceGroupByID(re, suite.server, 2)
 	re.False(kg2.InSplit)
+	re.Equal(kg1.ID, kg2.SplitFrom)
 }
 
 func sendLoadKeyspaceGroupRequest(re *require.Assertions, server *tests.TestServer, token, limit string) []*endpoint.KeyspaceGroup {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #6232. This field is necessary since we have to know which keyspace group this new one comes from, so we can get the corresponding member info to implement the election constraint during the TSO split.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Add `split-from` field for `endpoint.KeyspaceGroup`.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
