### PR TITLE
mcs: fix duplicate start of RaftCluster.

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -134,7 +133,7 @@ type RaftCluster struct {
 	etcdClient *clientv3.Client
 	httpClient *http.Client
 
-	running            atomic.Bool
+	running            bool
 	meta               *metapb.Cluster
 	storeConfigManager *config.StoreConfigManager
 	storage            storage.Storage
@@ -261,7 +260,7 @@ func (c *RaftCluster) Start(s Server) error {
 	c.Lock()
 	defer c.Unlock()
 
-	if c.IsRunning() {
+	if c.running {
 		log.Warn("raft cluster has already been started")
 		return nil
 	}
@@ -317,7 +316,7 @@ func (c *RaftCluster) Start(s Server) error {
 	go c.runUpdateStoreStats()
 	go c.startGCTuner()
 
-	c.running.Store(true)
+	c.running = true
 	return nil
 }
 
@@ -605,26 +604,31 @@ func (c *RaftCluster) runReplicationMode() {
 // Stop stops the cluster.
 func (c *RaftCluster) Stop() {
 	c.Lock()
-	if !c.running.CompareAndSwap(true, false) {
+	if !c.running {
 		c.Unlock()
 		return
 	}
-
 	c.coordinator.stop()
 	c.cancel()
+	c.running = false
 	c.Unlock()
+
 	c.wg.Wait()
 	log.Info("raftcluster is stopped")
 }
 
 // IsRunning return if the cluster is running.
 func (c *RaftCluster) IsRunning() bool {
-	return c.running.Load()
+	c.RLock()
+	defer c.RUnlock()
+	return c.running
 }
 
 // Context returns the context of RaftCluster.
 func (c *RaftCluster) Context() context.Context {
-	if c.running.Load() {
+	c.RLock()
+	defer c.RUnlock()
+	if c.running {
 		return c.ctx
 	}
 	return nil

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -258,16 +258,9 @@ func (c *RaftCluster) InitCluster(
 
 // Start starts a cluster.
 func (c *RaftCluster) Start(s Server) error {
-	// This is the most common case, so we use a fast path to avoid the lock.
-	if c.IsRunning() {
-		log.Warn("raft cluster has already been started")
-		return nil
-	}
-
 	c.Lock()
 	defer c.Unlock()
 
-	// Double-check with lock to avoid duplicate start
 	if c.IsRunning() {
 		log.Warn("raft cluster has already been started")
 		return nil

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -608,9 +608,9 @@ func (c *RaftCluster) Stop() {
 		c.Unlock()
 		return
 	}
+	c.running = false
 	c.coordinator.stop()
 	c.cancel()
-	c.running = false
 	c.Unlock()
 
 	c.wg.Wait()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -258,6 +258,7 @@ func (c *RaftCluster) InitCluster(
 
 // Start starts a cluster.
 func (c *RaftCluster) Start(s Server) error {
+	// This is the most common case, so we use a fast path to avoid the lock.
 	if c.IsRunning() {
 		log.Warn("raft cluster has already been started")
 		return nil
@@ -265,6 +266,12 @@ func (c *RaftCluster) Start(s Server) error {
 
 	c.Lock()
 	defer c.Unlock()
+
+	// Double-check with lock to avoid duplicate start
+	if c.IsRunning() {
+		log.Warn("raft cluster has already been started")
+		return nil
+	}
 
 	c.InitCluster(s.GetAllocator(), s.GetPersistOptions(), s.GetStorage(), s.GetBasicCluster(), s.GetKeyspaceGroupManager())
 	cluster, err := c.LoadClusterInfo()


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Issue Number: Close #6351

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
The root cause is that the multi-thread locking issue in RaftCluster.Start. RaftCluster.Start can be invoked concurrently in different routines -- one is from becoming new leader; another is Server.BootStrap RPC called by test or other callers. Both routines check that RaftCluster isn't running, so both proceed to c.Lock and only one enters the critical section and complete all the start work including GroupManager.Bootstrap in which watchServiceAddrs could dynamically update the serverRegistryMap; after the first one exits the critical section, the second one enters and calls GroupManager.Bootstrap() again and it will concurrently update serverRegistryMap with the previously created loop. The fundermal issue is that the second one should check, inside of the critical section, if RaftCluster is running, if yes, then exit the critical section without doing anything.

// Start starts a cluster.
func (c *RaftCluster) Start(s Server) error {
    if c.IsRunning() {
        log.Warn("raft cluster has already been started")
        return nil
    }

    c.Lock()
    defer c.Unlock()

     // we should check if c. IsRunning() if it's running return here.
     ...
}

Because of serverRegistryMap we added, it reveals this bug existing for long time.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
