### PR TITLE
mcs, tso: fix ts fallback caused by multi-primary of the same keyspace group 

### DIFF
--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -467,7 +467,7 @@ func (s *Server) startServer() (err error) {
 	tsoSvcRootPath := fmt.Sprintf(tsoSvcRootPathFormat, s.clusterID)
 	s.serviceID = &discovery.ServiceRegistryEntry{ServiceAddr: s.cfg.AdvertiseListenAddr}
 	s.keyspaceGroupManager = tso.NewKeyspaceGroupManager(
-		s.serverLoopCtx, s.serviceID, s.etcdClient, s.httpClient, s.listenURL.Host, legacySvcRootPath, tsoSvcRootPath, s.cfg)
+		s.serverLoopCtx, s.serviceID, s.etcdClient, s.httpClient, s.cfg.AdvertiseListenAddr, legacySvcRootPath, tsoSvcRootPath, s.cfg)
 	if err := s.keyspaceGroupManager.Initialize(); err != nil {
 		return err
 	}

--- a/tests/integrations/mcs/cluster.go
+++ b/tests/integrations/mcs/cluster.go
@@ -62,11 +62,11 @@ func (tc *TestTSOCluster) AddServer(addr string) error {
 	if err != nil {
 		return err
 	}
-	err = initLogger(generatedCfg)
+	err = InitLogger(generatedCfg)
 	if err != nil {
 		return err
 	}
-	server, cleanup, err := newTSOTestServer(tc.ctx, generatedCfg)
+	server, cleanup, err := NewTSOTestServer(tc.ctx, generatedCfg)
 	if err != nil {
 		return err
 	}

--- a/tests/integrations/mcs/testutil.go
+++ b/tests/integrations/mcs/testutil.go
@@ -34,7 +34,7 @@ import (
 
 var once sync.Once
 
-func initLogger(cfg *tso.Config) (err error) {
+func InitLogger(cfg *tso.Config) (err error) {
 	once.Do(func() {
 		// Setup the logger.
 		err = logutil.SetupLogger(cfg.Log, &cfg.Logger, &cfg.LogProps, cfg.Security.RedactInfoLog)
@@ -88,10 +88,10 @@ func StartSingleTSOTestServer(ctx context.Context, re *require.Assertions, backe
 	re.NoError(err)
 
 	// Setup the logger.
-	err = initLogger(cfg)
+	err = InitLogger(cfg)
 	re.NoError(err)
 
-	s, cleanup, err := newTSOTestServer(ctx, cfg)
+	s, cleanup, err := NewTSOTestServer(ctx, cfg)
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		return !s.IsClosed()
@@ -100,7 +100,7 @@ func StartSingleTSOTestServer(ctx context.Context, re *require.Assertions, backe
 	return s, cleanup
 }
 
-func newTSOTestServer(ctx context.Context, cfg *tso.Config) (*tso.Server, testutil.CleanupFunc, error) {
+func NewTSOTestServer(ctx context.Context, cfg *tso.Config) (*tso.Server, testutil.CleanupFunc, error) {
 	s := tso.CreateServer(ctx, cfg)
 	if err := s.Run(); err != nil {
 		return nil, nil, err

--- a/tests/integrations/mcs/testutil.go
+++ b/tests/integrations/mcs/testutil.go
@@ -34,6 +34,7 @@ import (
 
 var once sync.Once
 
+// InitLogger initializes the logger for test.
 func InitLogger(cfg *tso.Config) (err error) {
 	once.Do(func() {
 		// Setup the logger.
@@ -100,6 +101,7 @@ func StartSingleTSOTestServer(ctx context.Context, re *require.Assertions, backe
 	return s, cleanup
 }
 
+// NewTSOTestServer creates a tso server with given config for testing.
 func NewTSOTestServer(ctx context.Context, cfg *tso.Config) (*tso.Server, testutil.CleanupFunc, error) {
 	s := tso.CreateServer(ctx, cfg)
 	if err := s.Run(); err != nil {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #6355 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Change participant election-prifix from listen-addr to advertise-listen-addr to guarantee uniqueness.
If multiple participants have the same unique name/id, they all could become the primary and cause ts fallback seen by the client.

```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
