### PR TITLE
*: fix deletion of region stats metrics after resign

### DIFF
--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -318,8 +318,22 @@ func (r *RegionStatistics) Collect() {
 
 // Reset resets the metrics of the regions' status.
 func (r *RegionStatistics) Reset() {
-	regionStatusGauge.Reset()
-	offlineRegionStatusGauge.Reset()
+	regionMissPeerRegionCounter.Set(0)
+	regionExtraPeerRegionCounter.Set(0)
+	regionDownPeerRegionCounter.Set(0)
+	regionPendingPeerRegionCounter.Set(0)
+	regionLearnerPeerRegionCounter.Set(0)
+	regionEmptyRegionCounter.Set(0)
+	regionOversizedRegionCounter.Set(0)
+	regionUndersizedRegionCounter.Set(0)
+	regionWitnesssLeaderRegionCounter.Set(0)
+
+	offlineMissPeerRegionCounter.Set(0)
+	offlineExtraPeerRegionCounter.Set(0)
+	offlineDownPeerRegionCounter.Set(0)
+	offlinePendingPeerRegionCounter.Set(0)
+	offlineLearnerPeerRegionCounter.Set(0)
+	offlineOfflinePeerRegionCounter.Set(0)
 }
 
 // LabelStatistics is the statistics of the level of labels.


### PR DESCRIPTION


### What problem does this PR solve?


Issue Number: Close #6366 

### What is changed and how does it work?
https://github.com/prometheus/client_golang/blob/d7896d4bd082b17e525c29055d79cc29484aa9cb/prometheus/vec.go#L125 doesn't reset the gauge in this metrics vec, instead, it deletes them all.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
*: fix deletion of region stats metrics after resign
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
