### PR TITLE
fix data race issue in the store limit test

### DIFF
--- a/pkg/core/storelimit/limit_test.go
+++ b/pkg/core/storelimit/limit_test.go
@@ -18,6 +18,7 @@ import (
 	"container/list"
 	"context"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -125,21 +126,22 @@ func TestFeedback(t *testing.T) {
 	}
 	// region size is 10GB, snapshot write limit is 100MB/s and the snapshot concurrency is 3.
 	// the best strategy is that the tikv executing queue equals the wait.
-	regionSize, limit, wait := int64(10000), int64(100), int64(4)
-	iter := 100
+	const regionSize, limit, wait = int64(10000), int64(100), int64(4)
+	var iter atomic.Int32 
+	iter.Store(100)
 	ops := make(chan int64, 10)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// generate the operator
 	go func() {
 		for {
-			if s.Available(regionSize, SendSnapshot, constant.Low) && iter > 0 {
-				iter--
+			if s.Available(regionSize, SendSnapshot, constant.Low) && iter.Load() > 0 {
+				iter.Add(-1)
 				size := regionSize - rand.Int63n(regionSize/10)
 				s.Take(size, SendSnapshot, constant.Low)
 				ops <- size
 			}
-			if iter == 0 {
+			if iter.Load() == 0 {
 				cancel()
 				return
 			}
@@ -185,7 +187,7 @@ func TestFeedback(t *testing.T) {
 			err := exec*wait - cost
 			queue.Remove(first)
 			s.Feedback(float64(err))
-			if iter < 5 {
+			if iter.Load() < 5 {
 				re.Greater(float64(s.GetCap()), float64(regionSize*(wait-2)))
 				re.Less(float64(s.GetCap()), float64(regionSize*wait))
 			}

--- a/pkg/core/storelimit/limit_test.go
+++ b/pkg/core/storelimit/limit_test.go
@@ -127,7 +127,7 @@ func TestFeedback(t *testing.T) {
 	// region size is 10GB, snapshot write limit is 100MB/s and the snapshot concurrency is 3.
 	// the best strategy is that the tikv executing queue equals the wait.
 	const regionSize, limit, wait = int64(10000), int64(100), int64(4)
-	var iter atomic.Int32 
+	var iter atomic.Int32
 	iter.Store(100)
 	ops := make(chan int64, 10)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6369

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
