### PR TITLE
mcs, tso: fix Nil pointer deference when (*AllocatorManager).GetMember

### DIFF
--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -130,13 +130,14 @@ func (s *state) getAMWithMembershipCheck(
 		return nil, kgid, genNotServedErr(errs.ErrGetAllocatorManager, keyspaceGroupID)
 	}
 
+	// The keyspace doesn't belong to any keyspace group but the keyspace has been assigned to a
+	// keyspace group before, which means the keyspace group hasn't initialized yet.
 	if keyspaceGroupID != mcsutils.DefaultKeyspaceGroupID {
 		return nil, keyspaceGroupID, errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
 	}
 
-	// The keyspace doesn't belong to any keyspace group, so return the default keyspace group.
-	// It's for migrating the existing keyspaces which have no keyspace group assigned, so the
-	// the default keyspace group is used to serve the keyspaces.
+	// For migrating the existing keyspaces which have no keyspace group assigned as configured in the
+	// keyspace meta. All these keyspaces will be served by the default keyspace group.
 	if s.ams[mcsutils.DefaultKeyspaceGroupID] == nil {
 		return nil, mcsutils.DefaultKeyspaceGroupID, errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
 	}

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -137,6 +137,9 @@ func (s *state) getAMWithMembershipCheck(
 	// The keyspace doesn't belong to any keyspace group, so return the default keyspace group.
 	// It's for migrating the existing keyspaces which have no keyspace group assigned, so the
 	// the default keyspace group is used to serve the keyspaces.
+	if s.ams[mcsutils.DefaultKeyspaceGroupID] == nil {
+		return nil, mcsutils.DefaultKeyspaceGroupID, errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
+	}
 	return s.ams[mcsutils.DefaultKeyspaceGroupID], mcsutils.DefaultKeyspaceGroupID, nil
 }
 


### PR DESCRIPTION
If the desired keyspace group fall back to the default keyspace group and the AM isn't initialized, return not served error.

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6381 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
If the desired keyspace group fall back to the default keyspace group and the AM isn't initialized, return not served error.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

```release-note
None.
```
