### PR TITLE
client: retry load keyspace meta when creating a new client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -392,7 +392,7 @@ func NewClientWithKeyspaceName(ctx context.Context, keyspace string, svrAddrs []
 func (c *client) initRetry(f func(s string) error, str string) error {
 	var err error
 	for i := 0; i < c.option.maxRetryTimes; i++ {
-		if err = f(str); err == nil {
+		if err = f(str); err == nil || strings.Contains(err.Error(), "ENTRY_NOT_FOUND") {
 			return nil
 		}
 		select {

--- a/client/client.go
+++ b/client/client.go
@@ -383,13 +383,35 @@ func NewClientWithKeyspaceName(ctx context.Context, keyspace string, svrAddrs []
 		c.cancel()
 		return nil, err
 	}
+	if err := c.initRetry(c.loadKeyspaceMeta, keyspace); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *client) initRetry(f func(s string) error, str string) error {
+	var err error
+	for i := 0; i < c.option.maxRetryTimes; i++ {
+		if err = f(str); err == nil {
+			return nil
+		}
+		select {
+		case <-c.ctx.Done():
+			return err
+		case <-time.After(time.Second):
+		}
+	}
+	return errors.WithStack(err)
+}
+
+func (c *client) loadKeyspaceMeta(keyspace string) error {
 	keyspaceMeta, err := c.LoadKeyspace(context.TODO(), keyspace)
 	// Here we ignore ENTRY_NOT_FOUND error and it will set the keyspaceID to 0.
 	if err != nil && !strings.Contains(err.Error(), "ENTRY_NOT_FOUND") {
-		return nil, err
+		return err
 	}
 	c.keyspaceID = keyspaceMeta.GetId()
-	return c, nil
+	return nil
 }
 
 func (c *client) setup() error {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5895.

### What is changed and how does it work?

Adding retry for getting the keyspace meta in the client.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
