### PR TITLE
Fix test issue in TestRandomResignLeader.

### DIFF
--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -53,6 +53,11 @@ type tsoClientTestSuite struct {
 	// The TSO service in microservice mode.
 	tsoCluster *mcs.TestTSOCluster
 
+	keyspaceGroups []struct {
+		keyspaceGroupID uint32
+		keyspaceIDs     []uint32
+	}
+
 	backendEndpoints string
 	keyspaceIDs      []uint32
 	clients          []pd.Client
@@ -99,7 +104,7 @@ func (suite *tsoClientTestSuite) SetupSuite() {
 		suite.tsoCluster, err = mcs.NewTestTSOCluster(suite.ctx, 3, suite.backendEndpoints)
 		re.NoError(err)
 
-		params := []struct {
+		suite.keyspaceGroups = []struct {
 			keyspaceGroupID uint32
 			keyspaceIDs     []uint32
 		}{
@@ -108,7 +113,7 @@ func (suite *tsoClientTestSuite) SetupSuite() {
 			{2, []uint32{2}},
 		}
 
-		for _, param := range params {
+		for _, param := range suite.keyspaceGroups {
 			if param.keyspaceGroupID == 0 {
 				// we have already created default keyspace group, so we can skip it.
 				// keyspace 10 isn't assigned to any keyspace group, so they will be
@@ -127,8 +132,8 @@ func (suite *tsoClientTestSuite) SetupSuite() {
 			})
 		}
 
-		for _, param := range params {
-			suite.keyspaceIDs = append(suite.keyspaceIDs, param.keyspaceIDs...)
+		for _, keyspaceGroup := range suite.keyspaceGroups {
+			suite.keyspaceIDs = append(suite.keyspaceIDs, keyspaceGroup.keyspaceIDs...)
 		}
 
 		suite.clients = mcs.WaitForMultiKeyspacesTSOAvailable(
@@ -242,10 +247,15 @@ func (suite *tsoClientTestSuite) TestRandomResignLeader() {
 		time.Sleep(time.Duration(n) * time.Second)
 		if !suite.legacy {
 			wg := sync.WaitGroup{}
-			// Select the default keyspace and a randomly picked keyspace to test
-			keyspaceIDs := []uint32{mcsutils.DefaultKeyspaceID}
-			selectIdx := uint32(r.Intn(len(suite.keyspaceIDs)-1) + 1)
-			keyspaceIDs = append(keyspaceIDs, suite.keyspaceIDs[selectIdx])
+			// Select the first keyspace from all keyspace groups. We need to make sure the selected
+			// keyspaces are from different keyspace groups, otherwise multiple goroutines below could
+			// try to resign the primary of the same keyspace group and cause race condition.
+			keyspaceIDs := make([]uint32, 0)
+			for _, keyspaceGroup := range suite.keyspaceGroups {
+				if len(keyspaceGroup.keyspaceIDs) > 0 {
+					keyspaceIDs = append(keyspaceIDs, keyspaceGroup.keyspaceIDs[0])
+				}
+			}
 			wg.Add(len(keyspaceIDs))
 			for _, keyspaceID := range keyspaceIDs {
 				go func(keyspaceID uint32) {


### PR DESCRIPTION

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6404 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
We need to make sure the selected keyspaces are from different keyspace groups, otherwise multiple goroutines below could try to resign the primary of the same keyspace group and cause race condition.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
