### PR TITLE
mcs: use getClusterInfo to check whether api service is ready

### DIFF
--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -32,10 +32,13 @@ import (
 	"time"
 
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/diagnosticspb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/tsopb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/sysutil"
+	"github.com/pkg/errors"
 	"github.com/soheilhy/cmux"
 	"github.com/spf13/cobra"
 	bs "github.com/tikv/pd/pkg/basicserver"
@@ -66,6 +69,11 @@ const (
 	// tsoSvcRootPathFormat defines the root path for all etcd paths used for different purposes.
 	// format: "/ms/{cluster_id}/tso".
 	tsoSvcRootPathFormat = msServiceRootPath + "/%d/" + mcsutils.TSOServiceName
+
+	// maxRetryTimesWaitAPIService is the max retry times for initializing the cluster ID.
+	maxRetryTimesWaitAPIService = 60
+	// retryIntervalWaitAPIService is the interval to retry.
+	retryIntervalWaitAPIService = 3 * time.Second
 )
 
 var _ bs.Server = (*Server)(nil)
@@ -147,6 +155,15 @@ func (s *Server) GetAddr() string {
 
 // Run runs the TSO server.
 func (s *Server) Run() error {
+	skipWaitAPIServiceReady := false
+	failpoint.Inject("skipWaitAPIServiceReady", func() {
+		skipWaitAPIServiceReady = true
+	})
+	if !skipWaitAPIServiceReady {
+		if err := s.waitAPIServiceReady(s.ctx); err != nil {
+			return err
+		}
+	}
 	go systimemon.StartMonitor(s.ctx, time.Now, func() {
 		log.Error("system time jumps backward", errs.ZapError(errs.ErrIncorrectSystemTime))
 		timeJumpBackCounter.Inc()
@@ -515,6 +532,51 @@ func (s *Server) startServer() (err error) {
 
 	atomic.StoreInt64(&s.isRunning, 1)
 	return nil
+}
+
+func (s *Server) waitAPIServiceReady(ctx context.Context) error {
+	for i := 0; i < maxRetryTimesWaitAPIService; i++ {
+		ready, err := s.isAPIServiceReady(ctx)
+		if err != nil {
+			log.Warn("failed to check api server ready", errs.ZapError(err))
+		}
+		if ready {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.New("context canceled while waiting api server ready")
+		case <-time.After(retryIntervalWaitAPIService):
+			log.Debug("api server is not ready, retrying")
+		}
+	}
+	return errors.Errorf("failed to wait api server ready after retrying %d times", maxRetryTimesWaitAPIService)
+}
+
+func (s *Server) isAPIServiceReady(ctx context.Context) (bool, error) {
+	urls := strings.Split(s.cfg.BackendEndpoints, ",")
+	if len(urls) == 0 {
+		return false, errors.New("no backend endpoints")
+	}
+	cc, err := s.GetDelegateClient(s.ctx, urls[0])
+	if err != nil {
+		return false, err
+	}
+	clusterInfo, err := pdpb.NewPDClient(cc).GetClusterInfo(s.ctx, &pdpb.GetClusterInfoRequest{})
+	if err != nil {
+		return false, err
+	}
+	if clusterInfo.GetHeader().GetError() != nil {
+		return false, errors.Errorf(clusterInfo.GetHeader().GetError().String())
+	}
+	modes := clusterInfo.ServiceModes
+	if len(modes) == 0 {
+		return false, errors.New("no service mode")
+	}
+	if modes[0] == pdpb.ServiceMode_API_SVC_MODE {
+		return true, nil
+	}
+	return false, nil
 }
 
 // CreateServer creates the Server

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -160,7 +160,7 @@ func (s *Server) Run() error {
 		skipWaitAPIServiceReady = true
 	})
 	if !skipWaitAPIServiceReady {
-		if err := s.waitAPIServiceReady(s.ctx); err != nil {
+		if err := s.waitAPIServiceReady(); err != nil {
 			return err
 		}
 	}
@@ -534,9 +534,9 @@ func (s *Server) startServer() (err error) {
 	return nil
 }
 
-func (s *Server) waitAPIServiceReady(ctx context.Context) error {
+func (s *Server) waitAPIServiceReady() error {
 	for i := 0; i < maxRetryTimesWaitAPIService; i++ {
-		ready, err := s.isAPIServiceReady(ctx)
+		ready, err := s.isAPIServiceReady()
 		if err != nil {
 			log.Warn("failed to check api server ready", errs.ZapError(err))
 		}
@@ -544,7 +544,7 @@ func (s *Server) waitAPIServiceReady(ctx context.Context) error {
 			return nil
 		}
 		select {
-		case <-ctx.Done():
+		case <-s.ctx.Done():
 			return errors.New("context canceled while waiting api server ready")
 		case <-time.After(retryIntervalWaitAPIService):
 			log.Debug("api server is not ready, retrying")
@@ -553,7 +553,7 @@ func (s *Server) waitAPIServiceReady(ctx context.Context) error {
 	return errors.Errorf("failed to wait api server ready after retrying %d times", maxRetryTimesWaitAPIService)
 }
 
-func (s *Server) isAPIServiceReady(ctx context.Context) (bool, error) {
+func (s *Server) isAPIServiceReady() (bool, error) {
 	urls := strings.Split(s.cfg.BackendEndpoints, ",")
 	if len(urls) == 0 {
 		return false, errors.New("no backend endpoints")

--- a/tests/integrations/mcs/testutil.go
+++ b/tests/integrations/mcs/testutil.go
@@ -85,19 +85,22 @@ func StartSingleResourceManagerTestServer(ctx context.Context, re *require.Asser
 	return s, cleanup
 }
 
-// StartSingleTSOTestServer creates and starts a tso server with default config for testing.
-func StartSingleTSOTestServer(ctx context.Context, re *require.Assertions, backendEndpoints, listenAddrs string) (*tso.Server, func()) {
+// StartSingleTSOTestServerWithoutCheck creates and starts a tso server with default config for testing.
+func StartSingleTSOTestServerWithoutCheck(ctx context.Context, re *require.Assertions, backendEndpoints, listenAddrs string) (*tso.Server, func(), error) {
 	cfg := tso.NewConfig()
 	cfg.BackendEndpoints = backendEndpoints
 	cfg.ListenAddr = listenAddrs
 	cfg, err := tso.GenerateConfig(cfg)
 	re.NoError(err)
-
 	// Setup the logger.
 	err = InitLogger(cfg)
 	re.NoError(err)
+	return NewTSOTestServer(ctx, cfg)
+}
 
-	s, cleanup, err := NewTSOTestServer(ctx, cfg)
+// StartSingleTSOTestServer creates and starts a tso server with default config for testing.
+func StartSingleTSOTestServer(ctx context.Context, re *require.Assertions, backendEndpoints, listenAddrs string) (*tso.Server, func()) {
+	s, cleanup, err := StartSingleTSOTestServerWithoutCheck(ctx, re, backendEndpoints, listenAddrs)
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		return !s.IsClosed()

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -307,9 +307,13 @@ func TestMixedTSODeployment(t *testing.T) {
 	re := require.New(t)
 
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/fastUpdatePhysicalInterval", "return(true)"))
-	defer re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/fastUpdatePhysicalInterval"))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/skipUpdateServiceMode", "return(true)"))
-	defer re.NoError(failpoint.Disable("github.com/tikv/pd/client/skipUpdateServiceMode"))
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/mcs/tso/server/skipWaitAPIServiceReady", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/fastUpdatePhysicalInterval"))
+		re.NoError(failpoint.Disable("github.com/tikv/pd/client/skipUpdateServiceMode"))
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/mcs/tso/server/skipWaitAPIServiceReady"))
+	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cluster, err := tests.NewTestCluster(ctx, 1)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Issue Number: Ref https://github.com/tikv/pd/issues/5836

It is a pick from pd-cse.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
