### PR TITLE
config: raftv2 use enable bucket split by default

### DIFF
--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1336,8 +1336,8 @@ func TestSyncConfig(t *testing.T) {
 		if v.updated {
 			re.True(switchRaftV2)
 			tc.opt.UseRaftV2()
-			re.EqualValues(0, tc.opt.GetScheduleConfig().MaxMergeRegionSize)
-			re.EqualValues(math.MaxInt64, tc.opt.GetScheduleConfig().MaxMovableHotPeerSize)
+			re.EqualValues(0, tc.opt.GetMaxMergeRegionSize())
+			re.EqualValues(512, tc.opt.GetMaxMovableHotPeerSize())
 			success, switchRaftV2 = syncConfig(tc.storeConfigManager, tc.GetStores())
 			re.True(success)
 			re.False(switchRaftV2)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -17,7 +17,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -212,11 +211,9 @@ func (o *PersistOptions) SetMaxReplicas(replicas int) {
 // UseRaftV2 set some config for raft store v2 by default temporary.
 // todo: remove this after raft store support this.
 // disable merge check
-// disable split buckets
 func (o *PersistOptions) UseRaftV2() {
 	v := o.GetScheduleConfig().Clone()
 	v.MaxMergeRegionSize = 0
-	v.MaxMovableHotPeerSize = math.MaxInt64
 	o.SetScheduleConfig(v)
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6433

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
 MaxMovableHotPeerSize is enable in raftkv2.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


Code changes



Side effects


Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
 MaxMovableHotPeerSize is enable in raftkv2.
```
