### PR TITLE
utils: use `keyutil` pkg to simply the code 

### DIFF
--- a/pkg/statistics/buckets/bucket_stat_informer.go
+++ b/pkg/statistics/buckets/bucket_stat_informer.go
@@ -96,7 +96,7 @@ func (b *BucketTreeItem) String() string {
 
 // Less returns true if the start key is less than the other.
 func (b *BucketTreeItem) Less(than rangetree.RangeItem) bool {
-	return bytes.Compare(b.startKey, than.(*BucketTreeItem).startKey) < 0
+	return keyutil.Less(b.startKey, than.(*BucketTreeItem).startKey, keyutil.Left)
 }
 
 // equals returns whether the key range is overlaps with the item.
@@ -127,7 +127,7 @@ func (b *BucketTreeItem) cloneBucketItemByRange(startKey, endKey []byte) *Bucket
 		if len(endKey) == 0 {
 			right = stat.EndKey
 		}
-		if bytes.Compare(left, right) < 0 {
+		if keyutil.Less(left, right, keyutil.Mix) {
 			copy := stat.clone()
 			copy.StartKey = left
 			copy.EndKey = right
@@ -142,7 +142,7 @@ func (b *BucketTreeItem) cloneBucketItemByRange(startKey, endKey []byte) *Bucket
 // rule2: if the cross buckets are not hot, it will inherit the coldest one.
 // rule3: if some cross buckets are hot and the others are cold, it will inherit the hottest one.
 func (b *BucketTreeItem) inherit(origins []*BucketTreeItem) {
-	if len(origins) == 0 || len(b.stats) == 0 || bytes.Compare(b.endKey, origins[0].startKey) < 0 {
+	if len(origins) == 0 || len(b.stats) == 0 || !keyutil.Less(origins[0].startKey, b.endKey, keyutil.Mix) {
 		return
 	}
 

--- a/pkg/statistics/buckets/hot_bucket_cache.go
+++ b/pkg/statistics/buckets/hot_bucket_cache.go
@@ -100,7 +100,7 @@ func bucketDebrisFactory(startKey, endKey []byte, old rangetree.RangeItem) []ran
 	// key range:   |001--------------80|
 	// bucket tree:                      |100-----------200|
 	// [left,right]: [100,80]
-	if keyutil.Less(right, left, keyutil.Left) && len(right) != 0 {
+	if !keyutil.Less(left, right, keyutil.Mix) {
 		return nil
 	}
 

--- a/pkg/statistics/buckets/hot_bucket_task.go
+++ b/pkg/statistics/buckets/hot_bucket_task.go
@@ -45,13 +45,14 @@ type flowBucketsItemTask interface {
 
 // checkBucketsTask indicates the task in checkBuckets queue
 type checkBucketsTask struct {
-	Buckets *metapb.Buckets
+	item *BucketTreeItem
 }
 
 // NewCheckPeerTask creates task to update peerInfo
 func NewCheckPeerTask(buckets *metapb.Buckets) flowBucketsItemTask {
+	item := convertToBucketTreeItem(buckets)
 	return &checkBucketsTask{
-		Buckets: buckets,
+		item: item,
 	}
 }
 
@@ -60,8 +61,8 @@ func (t *checkBucketsTask) taskType() flowItemTaskKind {
 }
 
 func (t *checkBucketsTask) runTask(cache *HotBucketCache) {
-	newItems, overlaps := cache.checkBucketsFlow(t.Buckets)
-	cache.putItem(newItems, overlaps)
+	overlaps := cache.checkBucketsFlow(t.item)
+	cache.putItem(t.item, overlaps)
 }
 
 type collectBucketStatsTask struct {

--- a/pkg/utils/keyutil/util.go
+++ b/pkg/utils/keyutil/util.go
@@ -44,14 +44,22 @@ func MinKey(a, b []byte, boundary boundary) []byte {
 type boundary int
 
 const (
+	// Left means that the empty key is the smallest key.
 	Left boundary = iota
+	// Right means that the empty key is the biggest key.
 	Right
+	// Mix means that the first empty key is the smallest key and the second empty key is biggest key.
+	Mix
 )
 
 // Less returns true only if a < b.
-// If the key is empty and the boundary is Right, the keys is infinite.
 func Less(a, b []byte, boundary boundary) bool {
-	if boundary == Right {
+	switch boundary {
+	case Left:
+		return bytes.Compare(a, b) < 0
+	case Mix:
+		return bytes.Compare(a, b) < 0 || len(b) == 0
+	case Right:
 		if len(a) == 0 {
 			return false
 		}
@@ -59,14 +67,16 @@ func Less(a, b []byte, boundary boundary) bool {
 			return true
 		}
 		return bytes.Compare(a, b) < 0
-	} else {
-		return bytes.Compare(a, b) < 0
 	}
-	return false
+	return true
 }
 
 // Between returns true if startKey < key < endKey.
-// If the key is empty and the boundary is Right, the keys is infinite.
 func Between(startKey, endKey, key []byte) bool {
 	return Less(startKey, key, Left) && Less(key, endKey, Right)
+}
+
+// Contains returns true if startKey <= key < endKey.
+func Contains(startKey, endKey, key []byte) bool {
+	return Between(startKey, endKey, key) || bytes.Equal(startKey, key)
 }

--- a/pkg/utils/keyutil/util.go
+++ b/pkg/utils/keyutil/util.go
@@ -26,16 +26,16 @@ func BuildKeyRangeKey(startKey, endKey []byte) string {
 }
 
 // MaxKey return the bigger key for the given keys.
-func MaxKey(a, b []byte) []byte {
-	if bytes.Compare(a, b) > 0 {
+func MaxKey(a, b []byte, boundary boundary) []byte {
+	if Less(b, a, boundary) {
 		return a
 	}
 	return b
 }
 
 // MinKey returns the smaller key for the given keys.
-func MinKey(a, b []byte) []byte {
-	if bytes.Compare(a, b) > 0 {
+func MinKey(a, b []byte, boundary boundary) []byte {
+	if Less(b, a, boundary) {
 		return b
 	}
 	return a
@@ -44,25 +44,29 @@ func MinKey(a, b []byte) []byte {
 type boundary int
 
 const (
-	left boundary = iota
-	right
+	Left boundary = iota
+	Right
 )
 
-// less returns true if a < b.
-// If the key is empty and the boundary is right, the keys is infinite.
-func less(a, b []byte, boundary boundary) bool {
-	ret := bytes.Compare(a, b)
-	if ret < 0 {
-		return true
-	}
-	if boundary == right && len(b) == 0 && len(a) > 0 {
-		return true
+// Less returns true only if a < b.
+// If the key is empty and the boundary is Right, the keys is infinite.
+func Less(a, b []byte, boundary boundary) bool {
+	if boundary == Right {
+		if len(a) == 0 {
+			return false
+		}
+		if len(b) == 0 {
+			return true
+		}
+		return bytes.Compare(a, b) < 0
+	} else {
+		return bytes.Compare(a, b) < 0
 	}
 	return false
 }
 
 // Between returns true if startKey < key < endKey.
-// If the key is empty and the boundary is right, the keys is infinite.
+// If the key is empty and the boundary is Right, the keys is infinite.
 func Between(startKey, endKey, key []byte) bool {
-	return less(startKey, key, left) && less(key, endKey, right)
+	return Less(startKey, key, Left) && Less(key, endKey, Right)
 }

--- a/pkg/utils/keyutil/util_test.go
+++ b/pkg/utils/keyutil/util_test.go
@@ -29,6 +29,50 @@ func TestKeyUtil(t *testing.T) {
 	re.Equal("61-62", key)
 }
 
+func TestCompare(t *testing.T) {
+	re := require.New(t)
+	testdata := []struct {
+		a        []byte
+		b        []byte
+		min      []byte
+		max      []byte
+		boundary boundary
+	}{
+		{
+			[]byte("a"),
+			[]byte("b"),
+			[]byte("a"),
+			[]byte("b"),
+			Left,
+		}, {
+			[]byte("a"),
+			[]byte("b"),
+			[]byte("a"),
+			[]byte("b"),
+			Right,
+		},
+		{
+			[]byte("a"),
+			[]byte(""),
+			[]byte(""),
+			[]byte("a"),
+			Left,
+		},
+		{
+			[]byte("a"),
+			[]byte(""),
+			[]byte("a"),
+			[]byte(""),
+			Right,
+		},
+	}
+
+	for _, data := range testdata {
+		re.Equal(data.min, MinKey(data.a, data.b, data.boundary))
+		re.Equal(data.max, MaxKey(data.a, data.b, data.boundary))
+	}
+}
+
 func TestLess(t *testing.T) {
 	re := require.New(t)
 	TestData := []struct {
@@ -40,48 +84,54 @@ func TestLess(t *testing.T) {
 		{
 			[]byte("a"),
 			[]byte("b"),
-			left,
+			Left,
 			true,
 		},
 		{
 			[]byte("a"),
 			[]byte("b"),
-			right,
+			Right,
 			true,
 		},
 		{
 			[]byte("a"),
 			[]byte(""),
-			left,
+			Left,
 			false,
 		},
 		{
 			[]byte("a"),
 			[]byte(""),
-			right,
+			Right,
 			true,
 		},
 		{
+			[]byte(""),
+			[]byte("a"),
+			Right,
+			false,
+		},
+		{
 			[]byte("a"),
 			[]byte("a"),
-			right,
+			Right,
 			false,
 		},
 		{
 			[]byte(""),
 			[]byte(""),
-			right,
+			Right,
 			false,
 		},
 		{
 			[]byte(""),
 			[]byte(""),
-			left,
+			Left,
 			false,
 		},
 	}
 	for _, data := range TestData {
-		re.Equal(data.expect, less(data.a, data.b, data.boundary))
+		re.Equal(data.expect, Less(data.a, data.b, data.boundary))
 	}
 }
 

--- a/pkg/utils/keyutil/util_test.go
+++ b/pkg/utils/keyutil/util_test.go
@@ -129,6 +129,24 @@ func TestLess(t *testing.T) {
 			Left,
 			false,
 		},
+		{
+			[]byte(""),
+			[]byte(""),
+			Mix,
+			true,
+		},
+		{
+			[]byte("a"),
+			[]byte(""),
+			Mix,
+			true,
+		},
+		{
+			[]byte(""),
+			[]byte("a"),
+			Mix,
+			true,
+		},
 	}
 	for _, data := range TestData {
 		re.Equal(data.expect, Less(data.a, data.b, data.boundary))


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
