### PR TITLE
client: return error if the keyspace meta cannot be found

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -396,7 +396,7 @@ func NewClientWithKeyspaceName(
 	log.Info("[pd] create pd client with endpoints and keyspace",
 		zap.Strings("pd-address", svrAddrs), zap.String("keyspace-name", keyspaceName))
 
-	// if keyspace is empty, fall back to the legacy API
+	// if keyspace name is empty, fall back to the legacy API
 	if len(keyspaceName) == 0 {
 		return NewClientWithContext(ctx, svrAddrs, security, opts...)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -390,14 +390,14 @@ func createClientWithKeyspace(
 
 // NewClientWithKeyspaceName creates a client with context and the specified keyspace name.
 func NewClientWithKeyspaceName(
-	ctx context.Context, keyspace string, svrAddrs []string,
+	ctx context.Context, keyspaceName string, svrAddrs []string,
 	security SecurityOption, opts ...ClientOption,
 ) (Client, error) {
 	log.Info("[pd] create pd client with endpoints and keyspace",
-		zap.Strings("pd-address", svrAddrs), zap.String("keyspace", keyspace))
+		zap.Strings("pd-address", svrAddrs), zap.String("keyspace-name", keyspaceName))
 
 	// if keyspace is empty, fall back to the legacy API
-	if len(keyspace) == 0 {
+	if len(keyspaceName) == 0 {
 		return NewClientWithContext(ctx, svrAddrs, security, opts...)
 	}
 
@@ -434,7 +434,7 @@ func NewClientWithKeyspaceName(
 		c.cancel()
 		return nil, err
 	}
-	if err := c.initRetry(c.loadKeyspaceMeta, keyspace); err != nil {
+	if err := c.initRetry(c.loadKeyspaceMeta, keyspaceName); err != nil {
 		return nil, err
 	}
 	c.pdSvcDiscovery.SetKeyspaceID(c.keyspaceID)
@@ -445,7 +445,7 @@ func NewClientWithKeyspaceName(
 func (c *client) initRetry(f func(s string) error, str string) error {
 	var err error
 	for i := 0; i < c.option.maxRetryTimes; i++ {
-		if err = f(str); err == nil || strings.Contains(err.Error(), "ENTRY_NOT_FOUND") {
+		if err = f(str); err == nil {
 			return nil
 		}
 		select {
@@ -459,8 +459,7 @@ func (c *client) initRetry(f func(s string) error, str string) error {
 
 func (c *client) loadKeyspaceMeta(keyspace string) error {
 	keyspaceMeta, err := c.LoadKeyspace(context.TODO(), keyspace)
-	// Here we ignore ENTRY_NOT_FOUND error and it will set the keyspaceID to 0.
-	if err != nil && !strings.Contains(err.Error(), "ENTRY_NOT_FOUND") {
+	if err != nil {
 		return err
 	}
 	c.keyspaceID = keyspaceMeta.GetId()


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #6142.

### What is changed and how does it work?

Just as the title says. 0 is reserved for the "DEFAULT" keyspace.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
