### PR TITLE
tso: log tso service discovery info on the client side only when the primary is changed

### DIFF
--- a/client/tso_service_discovery.go
+++ b/client/tso_service_discovery.go
@@ -488,16 +488,14 @@ func (c *tsoServiceDiscovery) updateMember() error {
 		}
 	}
 
-	oldPrimary, primarySwitched, secondaryChanged :=
+	oldPrimary, primarySwitched, _ :=
 		c.keyspaceGroupSD.update(keyspaceGroup, primaryAddr, secondaryAddrs, addrs)
 	if primarySwitched {
+		log.Info("[tso] updated keyspace group service discovery info",
+			zap.String("keyspace-group-service", keyspaceGroup.String()))
 		if err := c.afterPrimarySwitched(oldPrimary, primaryAddr); err != nil {
 			return err
 		}
-	}
-	if primarySwitched || secondaryChanged {
-		log.Info("[tso] updated keyspace group service discovery info",
-			zap.String("keyspace-group-service", keyspaceGroup.String()))
 	}
 
 	// Even if the primary address is empty, we still updated other returned info above, including the


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6508 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Skip logging of the tso service discovery info when the secondar list is changed,
because tso servers currently don't have consistent view of the member list due to
remote etcd being used by tso service, which results in changing member list when
the client queries the tso servers in round-robin. We need to improve the server side
so that all tso servers can return the global consistent view of the keyspace groups'
serving or membership info.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- No code

```release-note
None.
```
