### PR TITLE
Print keyspace-group-id zap field in the tso log conditionally

### DIFF
--- a/pkg/utils/logutil/log.go
+++ b/pkg/utils/logutil/log.go
@@ -152,3 +152,13 @@ type stringer struct {
 func (s stringer) String() string {
 	return "?"
 }
+
+// CondUint32 constructs a field with the given key and value conditionally.
+// If the condition is true, it constructs a field with uint32 type; otherwise,
+// skip the field.
+func CondUint32(key string, val uint32, condition bool) zap.Field {
+	if condition {
+		return zap.Uint32(key, val)
+	}
+	return zap.Skip()
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5895 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
To keep the logging info in on-premises clean, we only print keyspace-group-id zap field
for the non-default keyspace group id.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

-- No code (change log only)

printed log expectedly:

For default keyspace group:
[2023/05/24 17:48:03.942 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] []
[2023/05/24 17:48:04.005 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] []
[2023/05/24 17:48:04.037 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] []
...

For non-default keyspace groups:
[2023/05/24 17:48:04.065 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] [keyspace-group-id=1]
[2023/05/24 17:48:04.065 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] [keyspace-group-id=1]
[2023/05/24 17:48:04.065 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] [keyspace-group-id=1]
[2023/05/24 17:48:04.127 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] [keyspace-group-id=2]
[2023/05/24 17:48:04.128 -07:00] [INFO] [allocator_manager.go:727] ["entering into allocator daemon"] [keyspace-group-id=2]
...


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
