### PR TITLE
fix watch keyspace

### DIFF
--- a/server/keyspace_service.go
+++ b/server/keyspace_service.go
@@ -74,7 +74,7 @@ func (s *KeyspaceServer) WatchKeyspaces(request *keyspacepb.WatchKeyspacesReques
 	}
 	ctx, cancel := context.WithCancel(s.Context())
 	defer cancel()
-	startKey := path.Join(s.rootPath, endpoint.KeyspaceMetaPrefix())
+	startKey := path.Join(s.rootPath, endpoint.KeyspaceMetaPrefix()) + "/"
 
 	keyspaces := make([]*keyspacepb.KeyspaceMeta, 0)
 	putFn := func(kv *mvccpb.KeyValue) error {
@@ -106,7 +106,7 @@ func (s *KeyspaceServer) WatchKeyspaces(request *keyspacepb.WatchKeyspacesReques
 		putFn,
 		deleteFn,
 		postEventFn,
-		clientv3.WithPrefix(),
+		clientv3.WithRange(clientv3.GetPrefixRangeEnd(startKey)),
 	)
 	s.serverLoopWg.Add(1)
 	go watcher.StartWatchLoop()


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6527 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
The problem is caused by using `clientv3.WithPrefix`, which start watching from `startKey` with prefix.
'pd/xxx/keyspaces/meta`

But within the inital load, the startKey got reassigned after first batch of load to
`pd/xxx/keyspaces/meta/000400`
which, when load again, indicates that no more key exists with that prefix.

This PR fix this by changing the `clientv3.WithPrefix` to `clientv3.WithRange()` with proper endkey, thus the subsequent load batch fron initLoad no can succeed.

### Release note

```release-note
None.
```
