### PR TITLE
mcs, tso: delete the tso ms discovery when switching away from API mode.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -621,13 +621,13 @@ func (c *client) setServiceMode(newMode pdpb.ServiceMode) {
 	oldTSOClient.Close()
 	// Replace the old TSO service discovery if needed.
 	oldTSOSvcDiscovery := c.tsoSvcDiscovery
-	if newTSOSvcDiscovery != nil {
-		c.tsoSvcDiscovery = newTSOSvcDiscovery
-		// Close the old TSO service discovery safely after both the old client
-		// and service discovery are replaced.
-		if oldTSOSvcDiscovery != nil {
-			oldTSOSvcDiscovery.Close()
-		}
+	// If newTSOSvcDiscovery is nil, that's expected, as it means we are switching to PD service mode and
+	// no tso microservice discovery is needed.
+	c.tsoSvcDiscovery = newTSOSvcDiscovery
+	// Close the old TSO service discovery safely after both the old client and service discovery are replaced.
+	if oldTSOSvcDiscovery != nil {
+		// We are switching from API service mode to PD service mode, so delete the old tso microservice discovery.
+		oldTSOSvcDiscovery.Close()
 	}
 	oldMode := c.serviceMode
 	c.serviceMode = newMode


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6543 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
When switching from the PD mode to the API mode, the old tso microservice discovery isn't needed anymore,
and all resources can be released to avoid noisy error logs when the component trying to discover
the non-existent tso microservice.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
Covered by the existing test cases.


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
