### PR TITLE
mcs, tso: fix stream Send() and CloseSend() data race issue in TSO proxy

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -411,9 +411,6 @@ func (s *GrpcServer) forwardTSO(stream pdpb.PD_TsoServer) error {
 	)
 	defer func() {
 		s.concurrentTSOProxyStreamings.Add(-1)
-		if forwardStream != nil {
-			forwardStream.CloseSend()
-		}
 		// cancel the forward stream
 		if cancel != nil {
 			cancel()
@@ -452,9 +449,6 @@ func (s *GrpcServer) forwardTSO(stream pdpb.PD_TsoServer) error {
 			return errors.WithStack(ErrNotFoundTSOAddr)
 		}
 		if forwardStream == nil || lastForwardedHost != forwardedHost {
-			if forwardStream != nil {
-				forwardStream.CloseSend()
-			}
 			if cancel != nil {
 				cancel()
 			}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6590

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
No need to call SendClose(), because TSO proxy will cancel the stream context which will cause the corresponding grpc stream on the server side to exit.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
Covered by the existing test cases, and it fixes the flaky test.

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
