### PR TITLE
all, pd client: clean fix resource manager client random panic on exit issue.

### DIFF
--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -89,8 +89,10 @@ func (c *client) WatchKeyspaces(ctx context.Context) (chan []*keyspacepb.Keyspac
 		close(keyspaceWatcherChan)
 		return nil, err
 	}
+	c.wg.Add(1)
 	go func() {
 		defer func() {
+			defer c.wg.Done()
 			close(keyspaceWatcherChan)
 			if r := recover(); r != nil {
 				log.Error("[pd] panic in keyspace client `WatchKeyspaces`", zap.Any("error", r))

--- a/client/resource_manager_client.go
+++ b/client/resource_manager_client.go
@@ -302,11 +302,13 @@ func (c *client) createTokenDispatcher() {
 		tokenBatchController: newTokenBatchController(
 			make(chan *tokenRequest, 1)),
 	}
+	c.wg.Add(1)
 	go c.handleResourceTokenDispatcher(dispatcherCtx, dispatcher.tokenBatchController)
 	c.tokenDispatcher = dispatcher
 }
 
 func (c *client) handleResourceTokenDispatcher(dispatcherCtx context.Context, tbc *tokenBatchController) {
+	defer c.wg.Done()
 	var (
 		connection   resourceManagerConnectionContext
 		firstRequest *tokenRequest


### PR DESCRIPTION
resource manager client got random 'null pointer dereference' panic on exit. The pd client (resource manager client) exited without waiting for handleResourceTokenDispatcher() go routine to exit.

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6613 
Issue Number: Close #6631 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
resource manager client got random 'null pointer dereference' panic on exit.
The pd client (resource manager client) exited without waiting for handleResourceTokenDispatcher() go routine to exit.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
covered by the exiting unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
