### PR TITLE
Add split-range cmd and fix duplicate keyspaces

### DIFF
--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -615,7 +615,15 @@ func buildSplitKeyspaces(
 				oldSplit = append(oldSplit, keyspace)
 			}
 		}
-		return oldSplit, new, nil
+		// Dedup new keyspaces if it's necessary.
+		if newNum == len(newKeyspaceMap) {
+			return oldSplit, new, nil
+		}
+		newSplit := make([]uint32, 0, len(newKeyspaceMap))
+		for keyspace := range newKeyspaceMap {
+			newSplit = append(newSplit, keyspace)
+		}
+		return oldSplit, newSplit, nil
 	}
 	// Split according to the start and end keyspace ID.
 	if startKeyspaceID == 0 && endKeyspaceID == 0 {

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -192,7 +192,7 @@ func postJSON(cmd *cobra.Command, prefix string, input map[string]interface{}) {
 		return nil
 	})
 	if err != nil {
-		cmd.Printf("Failed! %s", err)
+		cmd.Printf("Failed! %s\n", err)
 		return
 	}
 	cmd.Println("Success!")

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command.go
@@ -33,6 +33,7 @@ func NewKeyspaceGroupCommand() *cobra.Command {
 		Run:   showKeyspaceGroupCommandFunc,
 	}
 	cmd.AddCommand(newSplitKeyspaceGroupCommand())
+	cmd.AddCommand(newSplitRangeKeyspaceGroupCommand())
 	cmd.AddCommand(newFinishSplitKeyspaceGroupCommand())
 	cmd.AddCommand(newMergeKeyspaceGroupCommand())
 	cmd.AddCommand(newFinishMergeKeyspaceGroupCommand())
@@ -46,6 +47,15 @@ func newSplitKeyspaceGroupCommand() *cobra.Command {
 		Use:   "split <keyspace_group_id> <new_keyspace_group_id> [<keyspace_id>]",
 		Short: "split the keyspace group with the given ID and transfer the keyspaces into the newly split one",
 		Run:   splitKeyspaceGroupCommandFunc,
+	}
+	return r
+}
+
+func newSplitRangeKeyspaceGroupCommand() *cobra.Command {
+	r := &cobra.Command{
+		Use:   "split-range <keyspace_group_id> <new_keyspace_group_id> <start_keyspace_id> <end_keyspace_id>",
+		Short: "split the keyspace group with the given ID and transfer the keyspaces in the given range (both ends inclusive) into the newly split one",
+		Run:   splitRangeKeyspaceGroupCommandFunc,
 	}
 	return r
 }
@@ -137,6 +147,38 @@ func splitKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	postJSON(cmd, fmt.Sprintf("%s/%s/split", keyspaceGroupsPrefix, args[0]), map[string]interface{}{
 		"new-id":    uint32(newID),
 		"keyspaces": keyspaces,
+	})
+}
+
+func splitRangeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
+	if len(args) < 4 {
+		cmd.Usage()
+		return
+	}
+	_, err := strconv.ParseUint(args[0], 10, 32)
+	if err != nil {
+		cmd.Printf("Failed to parse the old keyspace group ID: %s\n", err)
+		return
+	}
+	newID, err := strconv.ParseUint(args[1], 10, 32)
+	if err != nil {
+		cmd.Printf("Failed to parse the new keyspace group ID: %s\n", err)
+		return
+	}
+	startKeyspaceID, err := strconv.ParseUint(args[2], 10, 32)
+	if err != nil {
+		cmd.Printf("Failed to parse the start keyspace ID: %s\n", err)
+		return
+	}
+	endKeyspaceID, err := strconv.ParseUint(args[3], 10, 32)
+	if err != nil {
+		cmd.Printf("Failed to parse the end keyspace ID: %s\n", err)
+		return
+	}
+	postJSON(cmd, fmt.Sprintf("%s/%s/split", keyspaceGroupsPrefix, args[0]), map[string]interface{}{
+		"new-id":            uint32(newID),
+		"start-keyspace-id": uint32(startKeyspaceID),
+		"end-keyspace-id":   uint32(endKeyspaceID),
 	})
 }
 


### PR DESCRIPTION
1. Add split-range cmd to support StartKeyspaceID and EndKeyspaceID parameters.
2. Fix "split 0 2 2 2" generate duplicate keyspaces in the keyspace list of the group"

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6687
Issue Number: Close #6688

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
    Add split-range cmd and fix duplicate keyspaces
    
    1. Add split-range cmd to support StartKeyspaceID and EndKeyspaceID parameters.
    2. Fix "split 0 2 2 2" generate duplicate keyspaces in the keyspace list of the group"
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)

**split-range works.**

root@serverless-cluster-pd-0:/# ./pd-ctl keyspace-group split-range 0 2 11 12
Success!
root@serverless-cluster-pd-0:/# ./pd-ctl keyspace-group split-range 0 3 12 13
Success!
root@serverless-cluster-pd-0:/# ./pd-ctl keyspace-group split-range 0 3 15 200
Failed! [500] "keyspace group is in split state"
root@serverless-cluster-pd-0:/# ./pd-ctl keyspace-group split-range 0 4 15 200
Success!

{"id":1,"user-kind":"basic","members":[{"address":"http://pd-tso-server-0.tso-service.tidb-serverless.svc:2379/","priority":200},{"address":"http://pd-tso-server-1.tso-service.tidb-serverless.svc:2379/","priority":300}],"keyspaces":[0,1,2,3,4,5,6,7,8,9,10]}
/pd/7187976276065784319/tso/keyspace_groups/membership/00002
{"id":2,"user-kind":"basic","members":[{"address":"http://pd-tso-server-0.tso-service.tidb-serverless.svc:2379/","priority":200},{"address":"http://pd-tso-server-1.tso-service.tidb-serverless.svc:2379/","priority":300}],"keyspaces":[11,12]}
/pd/7187976276065784319/tso/keyspace_groups/membership/00003
{"id":3,"user-kind":"basic","members":[{"address":"http://pd-tso-server-0.tso-service.tidb-serverless.svc:2379/","priority":200},{"address":"http://pd-tso-server-1.tso-service.tidb-serverless.svc:2379/","priority":300}],"keyspaces":[13]}
/pd/7187976276065784319/tso/keyspace_groups/membership/00004
{"id":4,"user-kind":"basic","split-state":{"split-source":0},"members":[{"address":"http://pd-tso-server-0.tso-service.tidb-serverless.svc:2379/","priority":200},{"address":"http://pd-tso-server-1.tso-service.tidb-serverless.svc:2379/","priority":300}],"keyspaces":[15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200]}

**duplicate keyspaces bug fixed.**
root@serverless-cluster-pd-0:/# ./pd-ctl keyspace-group split 0 5 1000 1000
Success!

{"id":5,"user-kind":"basic","split-state":{"split-source":0},"members":[{"address":"http://pd-tso-server-0.tso-service.tidb-serverless.svc:2379","priority":200},{"address":"http://pd-tso-server-1.tso-service.tidb-serverless.svc:2379","priority":300}],"keyspaces":[1000]}

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
