### PR TITLE
tools: support querying keyspace group by state

### DIFF
--- a/server/apiv2/handlers/tso_keyspace_group.go
+++ b/server/apiv2/handlers/tso_keyspace_group.go
@@ -108,8 +108,29 @@ func GetKeyspaceGroups(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
 	}
+	var kgs []*endpoint.KeyspaceGroup
+	state, set := c.GetQuery("state")
+	if set {
+		switch state {
+		case "merge":
+			for _, keyspaceGroup := range keyspaceGroups {
+				if keyspaceGroup.MergeState != nil {
+					kgs = append(kgs, keyspaceGroup)
+				}
+			}
+		case "split":
+			for _, keyspaceGroup := range keyspaceGroups {
+				if keyspaceGroup.SplitState != nil {
+					kgs = append(kgs, keyspaceGroup)
+				}
+			}
+		default:
+		}
+	} else {
+		kgs = keyspaceGroups
+	}
 
-	c.IndentedJSON(http.StatusOK, keyspaceGroups)
+	c.IndentedJSON(http.StatusOK, kgs)
 }
 
 // GetKeyspaceGroupByID gets keyspace group by ID.

--- a/tests/pdctl/keyspace/keyspace_group_test.go
+++ b/tests/pdctl/keyspace/keyspace_group_test.go
@@ -289,7 +289,7 @@ func TestMergeKeyspaceGroup(t *testing.T) {
 	for i := 0; i < 129; i++ {
 		keyspaces = append(keyspaces, fmt.Sprintf("keyspace_%d", i))
 	}
-	tc, err := tests.NewTestAPICluster(ctx, 3, func(conf *config.Config, serverName string) {
+	tc, err := tests.NewTestAPICluster(ctx, 1, func(conf *config.Config, serverName string) {
 		conf.Keyspace.PreAlloc = keyspaces
 	})
 	re.NoError(err)
@@ -317,12 +317,8 @@ func TestMergeKeyspaceGroup(t *testing.T) {
 		return strings.Contains(string(output), "Success")
 	})
 
-	args := []string{"-u", pdAddr, "keyspace-group", "finish-split", "0"}
+	args := []string{"-u", pdAddr, "keyspace-group", "finish-split", "1"}
 	output, err := pdctl.ExecuteCommand(cmd, args...)
-	re.NoError(err)
-	strings.Contains(string(output), "Success")
-	args = []string{"-u", pdAddr, "keyspace-group", "finish-split", "1"}
-	output, err = pdctl.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	strings.Contains(string(output), "Success")
 
@@ -346,6 +342,99 @@ func TestMergeKeyspaceGroup(t *testing.T) {
 	re.NoError(err)
 	re.Len(keyspaceGroup.Keyspaces, 130)
 	re.Nil(keyspaceGroup.MergeState)
+
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes"))
+	re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayStartServerLoop"))
+}
+
+func TestKeyspaceGroupState(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes", `return(true)`))
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
+	keyspaces := make([]string, 0)
+	// we test the case which exceed the default max txn ops limit in etcd, which is 128.
+	for i := 0; i < 10; i++ {
+		keyspaces = append(keyspaces, fmt.Sprintf("keyspace_%d", i))
+	}
+	tc, err := tests.NewTestAPICluster(ctx, 1, func(conf *config.Config, serverName string) {
+		conf.Keyspace.PreAlloc = keyspaces
+	})
+	re.NoError(err)
+	err = tc.RunInitialServers()
+	re.NoError(err)
+	pdAddr := tc.GetConfig().GetClientURL()
+
+	_, tsoServerCleanup1, err := tests.StartSingleTSOTestServer(ctx, re, pdAddr, tempurl.Alloc())
+	defer tsoServerCleanup1()
+	re.NoError(err)
+	_, tsoServerCleanup2, err := tests.StartSingleTSOTestServer(ctx, re, pdAddr, tempurl.Alloc())
+	defer tsoServerCleanup2()
+	re.NoError(err)
+	cmd := pdctlCmd.GetRootCmd()
+
+	tc.WaitLeader()
+	leaderServer := tc.GetServer(tc.GetLeader())
+	re.NoError(leaderServer.BootstrapCluster())
+
+	// split keyspace group.
+	testutil.Eventually(re, func() bool {
+		args := []string{"-u", pdAddr, "keyspace-group", "split", "0", "1", "2"}
+		output, err := pdctl.ExecuteCommand(cmd, args...)
+		re.NoError(err)
+		return strings.Contains(string(output), "Success")
+	})
+	args := []string{"-u", pdAddr, "keyspace-group", "finish-split", "1"}
+	output, err := pdctl.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	strings.Contains(string(output), "Success")
+	args = []string{"-u", pdAddr, "keyspace-group", "--state", "split"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	strings.Contains(string(output), "Success")
+	var keyspaceGroups []*endpoint.KeyspaceGroup
+	err = json.Unmarshal(output, &keyspaceGroups)
+	re.NoError(err)
+	re.Len(keyspaceGroups, 0)
+	testutil.Eventually(re, func() bool {
+		args := []string{"-u", pdAddr, "keyspace-group", "split", "0", "2", "3"}
+		output, err := pdctl.ExecuteCommand(cmd, args...)
+		re.NoError(err)
+		return strings.Contains(string(output), "Success")
+	})
+	args = []string{"-u", pdAddr, "keyspace-group", "--state", "split"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	strings.Contains(string(output), "Success")
+	err = json.Unmarshal(output, &keyspaceGroups)
+	re.NoError(err)
+	re.Len(keyspaceGroups, 2)
+	re.Equal(keyspaceGroups[0].ID, uint32(0))
+	re.Equal(keyspaceGroups[1].ID, uint32(2))
+
+	args = []string{"-u", pdAddr, "keyspace-group", "finish-split", "2"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	strings.Contains(string(output), "Success")
+	// merge keyspace group.
+	testutil.Eventually(re, func() bool {
+		args := []string{"-u", pdAddr, "keyspace-group", "merge", "0", "1"}
+		output, err := pdctl.ExecuteCommand(cmd, args...)
+		re.NoError(err)
+		return strings.Contains(string(output), "Success")
+	})
+
+	args = []string{"-u", pdAddr, "keyspace-group", "--state", "merge"}
+	output, err = pdctl.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	strings.Contains(string(output), "Success")
+	err = json.Unmarshal(output, &keyspaceGroups)
+	re.NoError(err)
+	err = json.Unmarshal(output, &keyspaceGroups)
+	re.NoError(err)
+	re.Len(keyspaceGroups, 1)
+	re.Equal(keyspaceGroups[0].ID, uint32(0))
 
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes"))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayStartServerLoop"))

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command.go
@@ -15,12 +15,14 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/spf13/cobra"
+	"github.com/tikv/pd/pkg/storage/endpoint"
 )
 
 const keyspaceGroupsPrefix = "pd/api/v2/tso/keyspace-groups"
@@ -28,9 +30,9 @@ const keyspaceGroupsPrefix = "pd/api/v2/tso/keyspace-groups"
 // NewKeyspaceGroupCommand return a keyspace group subcommand of rootCmd
 func NewKeyspaceGroupCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "keyspace-group <keyspace_group_id>",
-		Short: "show keyspace group information with the given ID",
-		Run:   showKeyspaceGroupCommandFunc,
+		Use:   "keyspace-group [command] [flags]",
+		Short: "show keyspace group information",
+		Run:   showKeyspaceGroupsCommandFunc,
 	}
 	cmd.AddCommand(newSplitKeyspaceGroupCommand())
 	cmd.AddCommand(newSplitRangeKeyspaceGroupCommand())
@@ -39,6 +41,7 @@ func NewKeyspaceGroupCommand() *cobra.Command {
 	cmd.AddCommand(newFinishMergeKeyspaceGroupCommand())
 	cmd.AddCommand(newSetNodesKeyspaceGroupCommand())
 	cmd.AddCommand(newSetPriorityKeyspaceGroupCommand())
+	cmd.Flags().String("state", "", "state filter")
 	return cmd
 }
 
@@ -107,16 +110,45 @@ func newSetPriorityKeyspaceGroupCommand() *cobra.Command {
 	return r
 }
 
-func showKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) < 1 {
+func showKeyspaceGroupsCommandFunc(cmd *cobra.Command, args []string) {
+	prefix := keyspaceGroupsPrefix
+	if len(args) > 1 {
 		cmd.Usage()
 		return
 	}
-	r, err := doRequest(cmd, fmt.Sprintf("%s/%s", keyspaceGroupsPrefix, args[0]), http.MethodGet, http.Header{})
+	cFunc := convertToKeyspaceGroups
+	if len(args) == 1 {
+		if _, err := strconv.Atoi(args[0]); err != nil {
+			cmd.Println("keyspace_group_id should be a number")
+			return
+		}
+		prefix = fmt.Sprintf("%s/%s", keyspaceGroupsPrefix, args[0])
+		cFunc = convertToKeyspaceGroup
+	} else {
+		flags := cmd.Flags()
+		state, err := flags.GetString("state")
+		if err != nil {
+			cmd.Printf("Failed to get state: %s\n", err)
+		}
+		stateValue := ""
+		switch state {
+		case "merge", "split":
+			stateValue = fmt.Sprintf("state=%v", state)
+		default:
+			cmd.Println("Unknown state: " + state)
+			return
+		}
+
+		if len(stateValue) != 0 {
+			prefix = fmt.Sprintf("%v?%v", keyspaceGroupsPrefix, stateValue)
+		}
+	}
+	r, err := doRequest(cmd, prefix, http.MethodGet, http.Header{})
 	if err != nil {
 		cmd.Printf("Failed to get the keyspace groups information: %s\n", err)
 		return
 	}
+	r = cFunc(r)
 	cmd.Println(r)
 }
 
@@ -294,4 +326,30 @@ func setPriorityKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 		"Node":     address,
 		"Priority": priority,
 	})
+}
+
+func convertToKeyspaceGroup(content string) string {
+	kg := endpoint.KeyspaceGroup{}
+	err := json.Unmarshal([]byte(content), &kg)
+	if err != nil {
+		return content
+	}
+	byteArr, err := json.MarshalIndent(kg, "", "  ")
+	if err != nil {
+		return content
+	}
+	return string(byteArr)
+}
+
+func convertToKeyspaceGroups(content string) string {
+	kgs := []*endpoint.KeyspaceGroup{}
+	err := json.Unmarshal([]byte(content), &kgs)
+	if err != nil {
+		return content
+	}
+	byteArr, err := json.MarshalIndent(kgs, "", "  ")
+	if err != nil {
+		return content
+	}
+	return string(byteArr)
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5895.

### What is changed and how does it work?

This PR adds a state flag to help query the keyspace group by state, which is useful for debugging the problem.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
