### PR TITLE
mcs: fix datarace in keyspace group

### DIFF
--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -109,7 +109,12 @@ func (s *state) getKeyspaceGroupMeta(
 ) (*AllocatorManager, *endpoint.KeyspaceGroup) {
 	s.RLock()
 	defer s.RUnlock()
-	return s.ams[groupID], s.kgs[groupID]
+	am := s.ams[groupID]
+	if s.kgs[groupID] == nil {
+		return am, nil
+	}
+	kg := *s.kgs[groupID] // copy the keyspace group meta to avoid datarace
+	return am, &kg
 }
 
 // getKeyspaceGroupMetaWithCheck returns the keyspace group meta of the given keyspace.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6721



### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

`checkTSOMerge` and `checkTSOSplit` will read from `kgm.getKeyspaceGroupMeta`

`finishMergeKeyspaceGroup` and `finishSplitKeyspaceGroup` will update `kgm`

so just return a copy to avoid data race

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
