### PR TITLE
*: put gRPC unknown error into the header. (#5310)

### DIFF
--- a/client/base_client.go
+++ b/client/base_client.go
@@ -309,6 +309,10 @@ func (c *baseClient) getMembers(ctx context.Context, url string, timeout time.Du
 		attachErr := errors.Errorf("error:%s target:%s status:%s", err, cc.Target(), cc.GetState().String())
 		return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
 	}
+	if members.GetHeader().GetError() != nil {
+		attachErr := errors.Errorf("error:%s target:%s status:%s", members.GetHeader().GetError().String(), cc.Target(), cc.GetState().String())
+		return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
+	}
 	return members, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/grpcutil"
 	"go.uber.org/zap"
@@ -583,10 +584,8 @@ func (c *client) GetAllMembers(ctx context.Context) ([]*pdpb.Member, error) {
 	ctx = grpcutil.BuildForwardContext(ctx, c.GetLeaderAddr())
 	resp, err := c.getClient().GetMembers(ctx, req)
 	cancel()
-	if err != nil {
-		cmdFailDurationGetAllMembers.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+	if err = c.respForErr(cmdFailDurationGetAllMembers, start, err, resp.GetHeader()); err != nil {
+		return nil, err
 	}
 	return resp.GetMembers(), nil
 }
@@ -1368,10 +1367,8 @@ func (c *client) GetRegion(ctx context.Context, key []byte, opts ...GetRegionOpt
 	resp, err := c.getClient().GetRegion(ctx, req)
 	cancel()
 
-	if err != nil {
-		cmdFailDurationGetRegion.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+	if err = c.respForErr(cmdFailDurationGetRegion, start, err, resp.GetHeader()); err != nil {
+		return nil, err
 	}
 	return handleRegionResponse(resp), nil
 }
@@ -1400,7 +1397,7 @@ func (c *client) GetRegionFromMember(ctx context.Context, key []byte, memberURLs
 			Header:    c.requestHeader(),
 			RegionKey: key,
 		})
-		if err != nil {
+		if err != nil || resp.GetHeader().GetError() != nil {
 			log.Error("[pd] can't get region info", zap.String("member-URL", url), errs.ZapError(err))
 			continue
 		}
@@ -1440,10 +1437,8 @@ func (c *client) GetPrevRegion(ctx context.Context, key []byte, opts ...GetRegio
 	resp, err := c.getClient().GetPrevRegion(ctx, req)
 	cancel()
 
-	if err != nil {
-		cmdFailDurationGetPrevRegion.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+	if err = c.respForErr(cmdFailDurationGetPrevRegion, start, err, resp.GetHeader()); err != nil {
+		return nil, err
 	}
 	return handleRegionResponse(resp), nil
 }
@@ -1470,10 +1465,8 @@ func (c *client) GetRegionByID(ctx context.Context, regionID uint64, opts ...Get
 	resp, err := c.getClient().GetRegionByID(ctx, req)
 	cancel()
 
-	if err != nil {
-		cmdFailedDurationGetRegionByID.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+	if err = c.respForErr(cmdFailedDurationGetRegionByID, start, err, resp.GetHeader()); err != nil {
+		return nil, err
 	}
 	return handleRegionResponse(resp), nil
 }
@@ -1501,10 +1494,8 @@ func (c *client) ScanRegions(ctx context.Context, key, endKey []byte, limit int)
 	scanCtx = grpcutil.BuildForwardContext(scanCtx, c.GetLeaderAddr())
 	resp, err := c.getClient().ScanRegions(scanCtx, req)
 
-	if err != nil {
-		cmdFailedDurationScanRegions.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+	if err = c.respForErr(cmdFailedDurationScanRegions, start, err, resp.GetHeader()); err != nil {
+		return nil, err
 	}
 
 	return handleRegionsResponse(resp), nil
@@ -1555,10 +1546,8 @@ func (c *client) GetStore(ctx context.Context, storeID uint64) (*metapb.Store, e
 	resp, err := c.getClient().GetStore(ctx, req)
 	cancel()
 
-	if err != nil {
-		cmdFailedDurationGetStore.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+	if err = c.respForErr(cmdFailedDurationGetStore, start, err, resp.GetHeader()); err != nil {
+		return nil, err
 	}
 	return handleStoreResponse(resp)
 }
@@ -1597,10 +1586,8 @@ func (c *client) GetAllStores(ctx context.Context, opts ...GetStoreOption) ([]*m
 	resp, err := c.getClient().GetAllStores(ctx, req)
 	cancel()
 
-	if err != nil {
-		cmdFailedDurationGetAllStores.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return nil, errors.WithStack(err)
+	if err = c.respForErr(cmdFailedDurationGetAllStores, start, err, resp.GetHeader()); err != nil {
+		return nil, err
 	}
 	return resp.GetStores(), nil
 }
@@ -1622,10 +1609,8 @@ func (c *client) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint6
 	resp, err := c.getClient().UpdateGCSafePoint(ctx, req)
 	cancel()
 
-	if err != nil {
-		cmdFailedDurationUpdateGCSafePoint.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return 0, errors.WithStack(err)
+	if err = c.respForErr(cmdFailedDurationUpdateGCSafePoint, start, err, resp.GetHeader()); err != nil {
+		return 0, err
 	}
 	return resp.GetNewSafePoint(), nil
 }
@@ -1654,10 +1639,8 @@ func (c *client) UpdateServiceGCSafePoint(ctx context.Context, serviceID string,
 	resp, err := c.getClient().UpdateServiceGCSafePoint(ctx, req)
 	cancel()
 
-	if err != nil {
-		cmdFailedDurationUpdateServiceGCSafePoint.Observe(time.Since(start).Seconds())
-		c.ScheduleCheckLeader()
-		return 0, errors.WithStack(err)
+	if err = c.respForErr(cmdFailedDurationUpdateServiceGCSafePoint, start, err, resp.GetHeader()); err != nil {
+		return 0, err
 	}
 	return resp.GetMinSafePoint(), nil
 }
@@ -1895,4 +1878,16 @@ func (c *client) WatchGlobalConfig(ctx context.Context) (chan []GlobalConfigItem
 		}
 	}()
 	return globalConfigWatcherCh, err
+}
+
+func (c *client) respForErr(observer prometheus.Observer, start time.Time, err error, header *pdpb.ResponseHeader) error {
+	if err != nil || header.GetError() != nil {
+		observer.Observe(time.Since(start).Seconds())
+		if err != nil {
+			c.ScheduleCheckLeader()
+			return errors.WithStack(err)
+		}
+		return errors.WithStack(errors.New(header.GetError().String()))
+	}
+	return nil
 }

--- a/server/api/label_test.go
+++ b/server/api/label_test.go
@@ -17,7 +17,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -268,7 +267,7 @@ func (s *testStrictlyLabelsStoreSuite) TestStoreMatch(c *C) {
 	}
 
 	for _, t := range cases {
-		_, err := s.grpcSvr.PutStore(context.Background(), &pdpb.PutStoreRequest{
+		resp, err := s.grpcSvr.PutStore(context.Background(), &pdpb.PutStoreRequest{
 			Header: &pdpb.RequestHeader{ClusterId: s.svr.ClusterID()},
 			Store: &metapb.Store{
 				Id:      t.store.Id,
@@ -281,14 +280,14 @@ func (s *testStrictlyLabelsStoreSuite) TestStoreMatch(c *C) {
 		if t.valid {
 			c.Assert(err, IsNil)
 		} else {
-			c.Assert(strings.Contains(err.Error(), t.expectError), IsTrue)
+			c.Assert(resp.GetHeader().GetError(), NotNil)
 		}
 	}
 
 	// enable placement rules. Report no error any more.
 	c.Assert(tu.CheckPostJSON(testDialClient, fmt.Sprintf("%s/config", s.urlPrefix), []byte(`{"enable-placement-rules":"true"}`), tu.StatusOK(c)), IsNil)
 	for _, t := range cases {
-		_, err := s.grpcSvr.PutStore(context.Background(), &pdpb.PutStoreRequest{
+		resp, err := s.grpcSvr.PutStore(context.Background(), &pdpb.PutStoreRequest{
 			Header: &pdpb.RequestHeader{ClusterId: s.svr.ClusterID()},
 			Store: &metapb.Store{
 				Id:      t.store.Id,
@@ -301,7 +300,7 @@ func (s *testStrictlyLabelsStoreSuite) TestStoreMatch(c *C) {
 		if t.valid {
 			c.Assert(err, IsNil)
 		} else {
-			c.Assert(strings.Contains(err.Error(), t.expectError), IsTrue)
+			c.Assert(resp.GetHeader().GetError(), NotNil)
 		}
 	}
 }

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -67,6 +67,9 @@ func getMembers(svr *server.Server) (*pdpb.GetMembersResponse, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if members.GetHeader().GetError() != nil {
+		return nil, errors.WithStack(errors.New(members.GetHeader().GetError().String()))
+	}
 	dclocationDistribution, err := svr.GetTSOAllocatorManager().GetClusterDCLocationsFromEtcd()
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -92,13 +92,22 @@ func (s *GrpcServer) unaryMiddleware(ctx context.Context, header *pdpb.RequestHe
 	return nil, nil
 }
 
+func (s *GrpcServer) wrapErrorToHeader(errorType pdpb.ErrorType, message string) *pdpb.ResponseHeader {
+	return s.errorHeader(&pdpb.Error{
+		Type:    errorType,
+		Message: message,
+	})
+}
+
 // GetMembers implements gRPC PDServer.
 func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb.GetMembersResponse, error) {
 	// Here we purposely do not check the cluster ID because the client does not know the correct cluster ID
 	// at startup and needs to get the cluster ID with the first request (i.e. GetMembers).
 	members, err := s.Server.GetMembers()
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.GetMembersResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 
 	var etcdLeader, pdLeader *pdpb.Member
@@ -113,7 +122,9 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	tsoAllocatorManager := s.GetTSOAllocatorManager()
 	tsoAllocatorLeaders, err := tsoAllocatorManager.GetLocalAllocatorLeaders()
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.GetMembersResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 
 	leader := s.member.GetLeader()
@@ -399,7 +410,9 @@ func (s *GrpcServer) Bootstrap(ctx context.Context, request *pdpb.BootstrapReque
 
 	res, err := s.bootstrapCluster(request)
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.BootstrapResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 
 	res.Header = s.header()
@@ -438,7 +451,9 @@ func (s *GrpcServer) AllocID(ctx context.Context, request *pdpb.AllocIDRequest) 
 	// We can use an allocator for all types ID allocation.
 	id, err := s.idAllocator.Alloc()
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.AllocIDResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 
 	return &pdpb.AllocIDResponse{
@@ -466,7 +481,10 @@ func (s *GrpcServer) GetStore(ctx context.Context, request *pdpb.GetStoreRequest
 	storeID := request.GetStoreId()
 	store := rc.GetStore(storeID)
 	if store == nil {
-		return nil, status.Errorf(codes.Unknown, "invalid store ID %d, not found", storeID)
+		return &pdpb.GetStoreResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+				fmt.Sprintf("invalid store ID %d, not found", storeID)),
+		}, nil
 	}
 	return &pdpb.GetStoreResponse{
 		Header: s.header(),
@@ -515,11 +533,16 @@ func (s *GrpcServer) PutStore(ctx context.Context, request *pdpb.PutStoreRequest
 
 	// NOTE: can be removed when placement rules feature is enabled by default.
 	if !s.GetConfig().Replication.EnablePlacementRules && core.IsStoreContainLabel(store, core.EngineKey, core.EngineTiFlash) {
-		return nil, status.Errorf(codes.FailedPrecondition, "placement rules is disabled")
+		return &pdpb.PutStoreResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+				"placement rules is disabled"),
+		}, nil
 	}
 
 	if err := rc.PutStore(store); err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.PutStoreResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 
 	log.Info("put store ok", zap.Stringer("store", store))
@@ -592,7 +615,10 @@ func (s *GrpcServer) StoreHeartbeat(ctx context.Context, request *pdpb.StoreHear
 	storeID := request.GetStats().GetStoreId()
 	store := rc.GetStore(storeID)
 	if store == nil {
-		return nil, errors.Errorf("store %v not found", storeID)
+		return &pdpb.StoreHeartbeatResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+				fmt.Sprintf("store %v not found", storeID)),
+		}, nil
 	}
 
 	// Bypass stats handling if the store report for unsafe recover is not empty.
@@ -603,7 +629,10 @@ func (s *GrpcServer) StoreHeartbeat(ctx context.Context, request *pdpb.StoreHear
 
 		err := rc.HandleStoreHeartbeat(request.GetStats())
 		if err != nil {
-			return nil, status.Errorf(codes.Unknown, err.Error())
+			return &pdpb.StoreHeartbeatResponse{
+				Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+					err.Error()),
+			}, nil
 		}
 
 		s.handleDamagedStore(request.GetStats())
@@ -1074,7 +1103,10 @@ func (s *GrpcServer) AskSplit(ctx context.Context, request *pdpb.AskSplitRequest
 		return &pdpb.AskSplitResponse{Header: s.notBootstrappedHeader()}, nil
 	}
 	if request.GetRegion() == nil {
-		return nil, errors.New("missing region for split")
+		return &pdpb.AskSplitResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_REGION_NOT_FOUND,
+				"missing region for split"),
+		}, nil
 	}
 	req := &pdpb.AskSplitRequest{
 		Region: request.Region,
@@ -1082,10 +1114,7 @@ func (s *GrpcServer) AskSplit(ctx context.Context, request *pdpb.AskSplitRequest
 	split, err := rc.HandleAskSplit(req)
 	if err != nil {
 		return &pdpb.AskSplitResponse{
-			Header: s.errorHeader(&pdpb.Error{
-				Type:    pdpb.ErrorType_UNKNOWN,
-				Message: err.Error(),
-			}),
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
 		}, nil
 	}
 
@@ -1116,7 +1145,10 @@ func (s *GrpcServer) AskBatchSplit(ctx context.Context, request *pdpb.AskBatchSp
 		return &pdpb.AskBatchSplitResponse{Header: s.incompatibleVersion("batch_split")}, nil
 	}
 	if request.GetRegion() == nil {
-		return nil, errors.New("missing region for split")
+		return &pdpb.AskBatchSplitResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_REGION_NOT_FOUND,
+				"missing region for split"),
+		}, nil
 	}
 	req := &pdpb.AskBatchSplitRequest{
 		Region:     request.Region,
@@ -1125,10 +1157,7 @@ func (s *GrpcServer) AskBatchSplit(ctx context.Context, request *pdpb.AskBatchSp
 	split, err := rc.HandleAskBatchSplit(req)
 	if err != nil {
 		return &pdpb.AskBatchSplitResponse{
-			Header: s.errorHeader(&pdpb.Error{
-				Type:    pdpb.ErrorType_UNKNOWN,
-				Message: err.Error(),
-			}),
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
 		}, nil
 	}
 
@@ -1155,7 +1184,9 @@ func (s *GrpcServer) ReportSplit(ctx context.Context, request *pdpb.ReportSplitR
 	}
 	_, err := rc.HandleReportSplit(request)
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.ReportSplitResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 
 	return &pdpb.ReportSplitResponse{
@@ -1181,7 +1212,10 @@ func (s *GrpcServer) ReportBatchSplit(ctx context.Context, request *pdpb.ReportB
 
 	_, err := rc.HandleBatchReportSplit(request)
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.ReportBatchSplitResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+				err.Error()),
+		}, nil
 	}
 
 	return &pdpb.ReportBatchSplitResponse{
@@ -1227,7 +1261,10 @@ func (s *GrpcServer) PutClusterConfig(ctx context.Context, request *pdpb.PutClus
 	}
 	conf := request.GetCluster()
 	if err := rc.PutMetaCluster(conf); err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.PutClusterConfigResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+				err.Error()),
+		}, nil
 	}
 
 	log.Info("put cluster config ok", zap.Reflect("config", conf))
@@ -1269,7 +1306,10 @@ func (s *GrpcServer) ScatterRegion(ctx context.Context, request *pdpb.ScatterReg
 	if region == nil {
 		if request.GetRegion() == nil {
 			//nolint
-			return nil, errors.Errorf("region %d not found", request.GetRegionId())
+			return &pdpb.ScatterRegionResponse{
+				Header: s.wrapErrorToHeader(pdpb.ErrorType_REGION_NOT_FOUND,
+					"region %d not found"),
+			}, nil
 		}
 		region = core.NewRegionInfo(request.GetRegion(), request.GetLeader())
 	}
@@ -1531,12 +1571,17 @@ func (s *GrpcServer) SyncMaxTS(_ context.Context, request *pdpb.SyncMaxTSRequest
 	tsoAllocatorManager := s.GetTSOAllocatorManager()
 	// There is no dc-location found in this server, return err.
 	if tsoAllocatorManager.GetClusterDCLocationsNumber() == 0 {
-		return nil, status.Errorf(codes.Unknown, "empty cluster dc-location found, checker may not work properly")
+		return &pdpb.SyncMaxTSResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+				"empty cluster dc-location found, checker may not work properly"),
+		}, nil
 	}
 	// Get all Local TSO Allocator leaders
 	allocatorLeaders, err := tsoAllocatorManager.GetHoldingLocalAllocatorLeaders()
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.SyncMaxTSResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 	if !request.GetSkipCheck() {
 		var maxLocalTS *pdpb.Timestamp
@@ -1549,7 +1594,9 @@ func (s *GrpcServer) SyncMaxTS(_ context.Context, request *pdpb.SyncMaxTSRequest
 			}
 			currentLocalTSO, err := allocator.GetCurrentTSO()
 			if err != nil {
-				return nil, status.Errorf(codes.Unknown, err.Error())
+				return &pdpb.SyncMaxTSResponse{
+					Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+				}, nil
 			}
 			if tsoutil.CompareTimestamp(currentLocalTSO, maxLocalTS) > 0 {
 				maxLocalTS = currentLocalTSO
@@ -1566,10 +1613,16 @@ func (s *GrpcServer) SyncMaxTS(_ context.Context, request *pdpb.SyncMaxTSRequest
 		})
 
 		if maxLocalTS == nil {
-			return nil, status.Errorf(codes.Unknown, "local tso allocator leaders have changed during the sync, should retry")
+			return &pdpb.SyncMaxTSResponse{
+				Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+					"local tso allocator leaders have changed during the sync, should retry"),
+			}, nil
 		}
 		if request.GetMaxTs() == nil {
-			return nil, status.Errorf(codes.Unknown, "empty maxTS in the request, should retry")
+			return &pdpb.SyncMaxTSResponse{
+				Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+					"empty maxTS in the request, should retry"),
+			}, nil
 		}
 		// Found a bigger or equal maxLocalTS, return it directly.
 		cmpResult := tsoutil.CompareTimestamp(maxLocalTS, request.GetMaxTs())
@@ -1595,7 +1648,9 @@ func (s *GrpcServer) SyncMaxTS(_ context.Context, request *pdpb.SyncMaxTSRequest
 			continue
 		}
 		if err := allocator.WriteTSO(request.GetMaxTs()); err != nil {
-			return nil, status.Errorf(codes.Unknown, err.Error())
+			return &pdpb.SyncMaxTSResponse{
+				Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+			}, nil
 		}
 		syncedDCs = append(syncedDCs, allocator.GetDCLocation())
 	}
@@ -1687,7 +1742,10 @@ func (s *GrpcServer) GetDCLocationInfo(ctx context.Context, request *pdpb.GetDCL
 	info, ok := am.GetDCLocationInfo(request.GetDcLocation())
 	if !ok {
 		am.ClusterDCLocationChecker()
-		return nil, status.Errorf(codes.Unknown, "dc-location %s is not found", request.GetDcLocation())
+		return &pdpb.GetDCLocationInfoResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN,
+				fmt.Sprintf("dc-location %s is not found", request.GetDcLocation())),
+		}, nil
 	}
 	resp := &pdpb.GetDCLocationInfoResponse{
 		Header: s.header(),
@@ -1702,7 +1760,9 @@ func (s *GrpcServer) GetDCLocationInfo(ctx context.Context, request *pdpb.GetDCL
 	// when it becomes the Local TSO Allocator leader.
 	// Please take a look at https://github.com/tikv/pd/issues/3260 for more details.
 	if resp.MaxTs, err = am.GetMaxLocalTSO(ctx); err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
+		return &pdpb.GetDCLocationInfoResponse{
+			Header: s.wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+		}, nil
 	}
 	return resp, nil
 }

--- a/server/tso/allocator_manager.go
+++ b/server/tso/allocator_manager.go
@@ -17,6 +17,7 @@ package tso
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/errors"
 	"math"
 	"path"
 	"strconv"
@@ -1077,6 +1078,9 @@ func (am *AllocatorManager) getDCLocationInfoFromLeader(ctx context.Context, dcL
 	})
 	if err != nil {
 		return false, &pdpb.GetDCLocationInfoResponse{}, err
+	}
+	if resp.GetHeader().GetError() != nil {
+		return false, &pdpb.GetDCLocationInfoResponse{}, errors.Errorf("get the dc-location info from leader failed: %s", resp.GetHeader().GetError().String())
 	}
 	return resp.GetSuffix() != 0, resp, nil
 }

--- a/server/tso/global_allocator.go
+++ b/server/tso/global_allocator.go
@@ -17,6 +17,7 @@ package tso
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -347,6 +348,11 @@ func (gta *GlobalTSOAllocator) SyncMaxTS(
 				respCh <- syncMaxTSResp
 				if syncMaxTSResp.err != nil {
 					log.Error("sync max ts rpc failed, got an error", zap.String("local-allocator-leader-url", leaderConn.Target()), errs.ZapError(err))
+					return
+				}
+				if syncMaxTSResp.rpcRes.GetHeader().GetError() != nil {
+					log.Error("sync max ts rpc failed, got an error", zap.String("local-allocator-leader-url", leaderConn.Target()),
+						errs.ZapError(errors.Errorf("%s", syncMaxTSResp.rpcRes.GetHeader().GetError().String())))
 					return
 				}
 			}(ctx, leaderConn, respCh)

--- a/tests/client/client_test.go
+++ b/tests/client/client_test.go
@@ -766,8 +766,9 @@ func bootstrapServer(c *C, header *pdpb.RequestHeader, client pdpb.PDClient) {
 		Store:  stores[0],
 		Region: region,
 	}
-	_, err := client.Bootstrap(context.Background(), req)
+	resp, err := client.Bootstrap(context.Background(), req)
 	c.Assert(err, IsNil)
+	c.Assert(pdpb.ErrorType_OK, Equals, resp.GetHeader().GetError().GetType())
 }
 
 func (s *testClientSuite) TestNormalTSO(c *C) {

--- a/tests/compatibility/version_upgrade_test.go
+++ b/tests/compatibility/version_upgrade_test.go
@@ -93,8 +93,9 @@ func (s *compatibilityTestSuite) TestStoreRegister(c *C) {
 			Version: "1.0.1",
 		},
 	}
-	_, err = svr.PutStore(context.Background(), putStoreRequest)
-	c.Assert(err, NotNil)
+	resp, err := svr.PutStore(context.Background(), putStoreRequest)
+	c.Assert(err, IsNil)
+	c.Assert(len(resp.GetHeader().GetError().String()) > 0, IsTrue)
 }
 
 func (s *compatibilityTestSuite) TestRollingUpgrade(c *C) {

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -524,8 +524,9 @@ func (s *testProgressSuite) TestRemovingProgress(c *C) {
 		Store:  &metapb.Store{Id: 1, Address: "127.0.0.1:0"},
 		Region: &metapb.Region{Id: 2, Peers: []*metapb.Peer{{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter}}},
 	}
-	_, err = grpcPDClient.Bootstrap(context.Background(), req)
+	resp, err := grpcPDClient.Bootstrap(context.Background(), req)
 	c.Assert(err, IsNil)
+	c.Assert(resp.GetHeader().GetError(), IsNil)
 	stores := []*metapb.Store{
 		{
 			Id:            1,
@@ -640,8 +641,9 @@ func (s *testProgressSuite) TestPreparingProgress(c *C) {
 		Store:  &metapb.Store{Id: 1, Address: "127.0.0.1:0"},
 		Region: &metapb.Region{Id: 2, Peers: []*metapb.Peer{{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter}}},
 	}
-	_, err = grpcPDClient.Bootstrap(context.Background(), req)
+	resp, err := grpcPDClient.Bootstrap(context.Background(), req)
 	c.Assert(err, IsNil)
+	c.Assert(resp.GetHeader().GetError(), IsNil)
 	stores := []*metapb.Store{
 		{
 			Id:             1,

--- a/tests/server/id/id_test.go
+++ b/tests/server/id/id_test.go
@@ -114,6 +114,7 @@ func (s *testAllocIDSuite) TestCommand(c *C) {
 		resp, err := grpcPDClient.AllocID(context.Background(), req)
 		c.Assert(err, IsNil)
 		c.Assert(resp.GetId(), Greater, last)
+		c.Assert(pdpb.ErrorType_OK, Equals, resp.GetHeader().GetError().GetType())
 		last = resp.GetId()
 	}
 }

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -61,6 +61,9 @@ func initClusterID(cli pdpb.PDClient) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if res.GetHeader().GetError() != nil {
+		log.Fatal(res.GetHeader().GetError())
+	}
 	clusterID = res.GetHeader().GetClusterId()
 	log.Println("ClusterID:", clusterID)
 }
@@ -95,9 +98,12 @@ func bootstrap(cli pdpb.PDClient) {
 		Store:  store,
 		Region: region,
 	}
-	_, err = cli.Bootstrap(context.TODO(), req)
+	resp, err := cli.Bootstrap(context.TODO(), req)
 	if err != nil {
 		log.Fatal(err)
+	}
+	if resp.GetHeader().GetError() != nil {
+		log.Fatalf("bootstrap failed: %s", resp.GetHeader().GetError().String())
 	}
 	log.Println("bootstrapped")
 }
@@ -108,9 +114,12 @@ func putStores(cli pdpb.PDClient) {
 			Id:      i,
 			Address: fmt.Sprintf("localhost:%d", i),
 		}
-		_, err := cli.PutStore(context.TODO(), &pdpb.PutStoreRequest{Header: header(), Store: store})
+		resp, err := cli.PutStore(context.TODO(), &pdpb.PutStoreRequest{Header: header(), Store: store})
 		if err != nil {
 			log.Fatal(err)
+		}
+		if resp.GetHeader().GetError() != nil {
+			log.Fatalf("put store failed: %s", resp.GetHeader().GetError().String())
 		}
 	}
 }

--- a/tools/pd-simulator/simulator/client.go
+++ b/tools/pd-simulator/simulator/client.go
@@ -117,6 +117,9 @@ func (c *client) getMembers(ctx context.Context) (*pdpb.GetMembersResponse, erro
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if members.GetHeader().GetError() != nil {
+		return nil, errors.WithStack(errors.New(members.GetHeader().GetError().String()))
+	}
 	return members, nil
 }
 
@@ -243,6 +246,9 @@ func (c *client) AllocID(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if resp.GetHeader().GetError() != nil {
+		return 0, errors.Errorf("alloc id failed: %s", resp.GetHeader().GetError().String())
+	}
 	return resp.GetId(), nil
 }
 
@@ -261,13 +267,16 @@ func (c *client) Bootstrap(ctx context.Context, store *metapb.Store, region *met
 	if err != nil {
 		return err
 	}
-	_, err = c.pdClient().Bootstrap(ctx, &pdpb.BootstrapRequest{
+	res, err := c.pdClient().Bootstrap(ctx, &pdpb.BootstrapRequest{
 		Header: c.requestHeader(),
 		Store:  store,
 		Region: region,
 	})
 	if err != nil {
 		return err
+	}
+	if res.GetHeader().GetError() != nil {
+		return errors.Errorf("bootstrap failed: %s", resp.GetHeader().GetError().String())
 	}
 	return nil
 }


### PR DESCRIPTION
Issue Number: Ref #5309. Close #5161  https://github.com/pingcap/tiflash/issues/7408
pick #5310 

### What is changed and how does it work?
<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
put the unknown error into the header instead of directly returning a gRPC error.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test



### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

```release-note
Put the unknown error into the header instead of directly returning a gRPC error.
And modify related uint tests and code.
```
