### PR TITLE
mcs, tso: fix split and split-range command bugs.

### DIFF
--- a/pkg/keyspace/tso_keyspace_group_test.go
+++ b/pkg/keyspace/tso_keyspace_group_test.go
@@ -484,8 +484,8 @@ func TestBuildSplitKeyspaces(t *testing.T) {
 			err: ErrKeyspaceNotInKeyspaceGroup,
 		},
 		{
-			old: []uint32{1, 2},
-			new: []uint32{2, 2},
+			old:         []uint32{1, 2},
+			new:         []uint32{2, 2},
 			expectedOld: []uint32{1},
 			expectedNew: []uint32{2},
 		},
@@ -512,6 +512,13 @@ func TestBuildSplitKeyspaces(t *testing.T) {
 		},
 		{
 			old:             []uint32{1, 2, 3, 4, 5},
+			startKeyspaceID: 5,
+			endKeyspaceID:   6,
+			expectedOld:     []uint32{1, 2, 3, 4},
+			expectedNew:     []uint32{5},
+		},
+		{
+			old:             []uint32{1, 2, 3, 4, 5},
 			startKeyspaceID: 2,
 			endKeyspaceID:   6,
 			expectedOld:     []uint32{1},
@@ -519,10 +526,24 @@ func TestBuildSplitKeyspaces(t *testing.T) {
 		},
 		{
 			old:             []uint32{1, 2, 3, 4, 5},
+			startKeyspaceID: 1,
+			endKeyspaceID:   1,
+			expectedOld:     []uint32{2, 3, 4, 5},
+			expectedNew:     []uint32{1},
+		},
+		{
+			old:             []uint32{1, 2, 3, 4, 5},
 			startKeyspaceID: 0,
 			endKeyspaceID:   6,
 			expectedOld:     []uint32{},
 			expectedNew:     []uint32{1, 2, 3, 4, 5},
+		},
+		{
+			old:             []uint32{1, 2, 3, 4, 5},
+			startKeyspaceID: 7,
+			endKeyspaceID:   10,
+			expectedOld:     []uint32{1, 2, 3, 4, 5},
+			expectedNew:     []uint32{},
 		},
 		{
 			old: []uint32{1, 2, 3, 4, 5},

--- a/pkg/keyspace/tso_keyspace_group_test.go
+++ b/pkg/keyspace/tso_keyspace_group_test.go
@@ -484,6 +484,26 @@ func TestBuildSplitKeyspaces(t *testing.T) {
 			err: ErrKeyspaceNotInKeyspaceGroup,
 		},
 		{
+			old: []uint32{1, 2},
+			new: []uint32{2, 2},
+			expectedOld: []uint32{1},
+			expectedNew: []uint32{2},
+		},
+		{
+			old:             []uint32{0, 1, 2, 3, 4, 5},
+			startKeyspaceID: 2,
+			endKeyspaceID:   4,
+			expectedOld:     []uint32{0, 1, 5},
+			expectedNew:     []uint32{2, 3, 4},
+		},
+		{
+			old:             []uint32{0, 1, 2, 3, 4, 5},
+			startKeyspaceID: 0,
+			endKeyspaceID:   4,
+			expectedOld:     []uint32{0, 5},
+			expectedNew:     []uint32{1, 2, 3, 4},
+		},
+		{
 			old:             []uint32{1, 2, 3, 4, 5},
 			startKeyspaceID: 2,
 			endKeyspaceID:   4,


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6687
Issue Number: Close #6731

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix split and split-range command bugs.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
