### PR TITLE
client: fix tso service discovery at the first time for NewClientWithAPIContext

### DIFF
--- a/client/tso_service_discovery.go
+++ b/client/tso_service_discovery.go
@@ -277,11 +277,6 @@ func (c *tsoServiceDiscovery) GetKeyspaceID() uint32 {
 	return c.keyspaceID.Load()
 }
 
-// SetKeyspaceID sets the ID of the keyspace
-func (c *tsoServiceDiscovery) SetKeyspaceID(keyspaceID uint32) {
-	c.keyspaceID.Store(keyspaceID)
-}
-
 // GetKeyspaceGroupID returns the ID of the keyspace group. If the keyspace group is unknown,
 // it returns the default keyspace group ID.
 func (c *tsoServiceDiscovery) GetKeyspaceGroupID() uint32 {
@@ -429,12 +424,16 @@ func (c *tsoServiceDiscovery) updateMember() error {
 		return err
 	}
 
+	keyspaceID := c.GetKeyspaceID()
 	var keyspaceGroup *tsopb.KeyspaceGroup
 	if len(tsoServerAddr) > 0 {
-		keyspaceGroup, err = c.findGroupByKeyspaceID(c.GetKeyspaceID(), tsoServerAddr, updateMemberTimeout)
+		keyspaceGroup, err = c.findGroupByKeyspaceID(keyspaceID, tsoServerAddr, updateMemberTimeout)
 		if err != nil {
 			if c.tsoServerDiscovery.countFailure() {
-				log.Error("[tso] failed to find the keyspace group", errs.ZapError(err))
+				log.Error("[tso] failed to find the keyspace group",
+					zap.Uint32("keyspace-id-in-request", keyspaceID),
+					zap.String("tso-server-addr", tsoServerAddr),
+					errs.ZapError(err))
 			}
 			return err
 		}
@@ -448,6 +447,8 @@ func (c *tsoServiceDiscovery) updateMember() error {
 		c.printFallbackLogOnce.Do(func() {
 			log.Warn("[tso] no tso server address found,"+
 				" fallback to the legacy path to discover from etcd directly",
+				zap.Uint32("keyspace-id-in-request", keyspaceID),
+				zap.String("tso-server-addr", tsoServerAddr),
 				zap.String("discovery-key", c.defaultDiscoveryKey))
 		})
 		addrs, err := c.discoverWithLegacyPath()
@@ -487,6 +488,8 @@ func (c *tsoServiceDiscovery) updateMember() error {
 		if primarySwitched := !strings.EqualFold(primaryAddr, c.getPrimaryAddr()); primarySwitched {
 			if _, err := c.GetOrCreateGRPCConn(primaryAddr); err != nil {
 				log.Warn("[tso] failed to connect the next primary",
+					zap.Uint32("keyspace-id-in-request", keyspaceID),
+					zap.String("tso-server-addr", tsoServerAddr),
 					zap.String("next-primary", primaryAddr), errs.ZapError(err))
 				return err
 			}
@@ -497,6 +500,8 @@ func (c *tsoServiceDiscovery) updateMember() error {
 		c.keyspaceGroupSD.update(keyspaceGroup, primaryAddr, secondaryAddrs, addrs)
 	if primarySwitched {
 		log.Info("[tso] updated keyspace group service discovery info",
+			zap.Uint32("keyspace-id-in-request", keyspaceID),
+			zap.String("tso-server-addr", tsoServerAddr),
 			zap.String("keyspace-group-service", keyspaceGroup.String()))
 		if err := c.afterPrimarySwitched(oldPrimary, primaryAddr); err != nil {
 			return err


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6748 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
After NewClientWithAPIContextV2 returns, the keyspace group should be discovered by the passed keyspace name immediately
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- 
### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
