### PR TITLE
*: decouple the scheduler and checker interfaces

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -88,9 +88,19 @@ func (mc *Cluster) GetStoreConfig() sc.StoreConfig {
 	return mc.StoreConfigManager.GetStoreConfig()
 }
 
-// GetOpts returns the cluster configuration.
-func (mc *Cluster) GetOpts() sc.Config {
-	return mc.PersistOptions
+// GetCheckerConfig returns the checker config.
+func (mc *Cluster) GetCheckerConfig() sc.CheckerConfig {
+	return mc
+}
+
+// GetSchedulerConfig returns the scheduler config.
+func (mc *Cluster) GetSchedulerConfig() sc.SchedulerConfig {
+	return mc
+}
+
+// GetSharedConfig returns the shared config.
+func (mc *Cluster) GetSharedConfig() sc.SharedConfig {
+	return mc
 }
 
 // GetStorage returns the storage.
@@ -198,7 +208,7 @@ func (mc *Cluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
 
 func (mc *Cluster) initRuleManager() {
 	if mc.RuleManager == nil {
-		mc.RuleManager = placement.NewRuleManager(mc.GetStorage(), mc, mc.GetOpts())
+		mc.RuleManager = placement.NewRuleManager(mc.GetStorage(), mc, mc.GetSharedConfig())
 		mc.RuleManager.Initialize(int(mc.GetReplicationConfig().MaxReplicas), mc.GetReplicationConfig().LocationLabels)
 	}
 }

--- a/pkg/schedule/checker/checker_controller.go
+++ b/pkg/schedule/checker/checker_controller.go
@@ -37,8 +37,8 @@ var denyCheckersByLabelerCounter = labeler.LabelerEventCounter.WithLabelValues("
 
 // Controller is used to manage all checkers.
 type Controller struct {
-	cluster           sche.ClusterInformer
-	conf              config.Config
+	cluster           sche.CheckerCluster
+	conf              config.CheckerConfig
 	opController      *operator.Controller
 	learnerChecker    *LearnerChecker
 	replicaChecker    *ReplicaChecker
@@ -53,7 +53,7 @@ type Controller struct {
 }
 
 // NewController create a new Controller.
-func NewController(ctx context.Context, cluster sche.ClusterInformer, conf config.Config, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler, opController *operator.Controller) *Controller {
+func NewController(ctx context.Context, cluster sche.CheckerCluster, conf config.CheckerConfig, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler, opController *operator.Controller) *Controller {
 	regionWaitingList := cache.NewDefaultCache(DefaultCacheSize)
 	return &Controller{
 		cluster:           cluster,
@@ -87,7 +87,7 @@ func (c *Controller) CheckRegion(region *core.RegionInfo) []*operator.Operator {
 	}
 
 	if c.conf.IsPlacementRulesEnabled() {
-		skipRuleCheck := c.cluster.GetOpts().IsPlacementRulesCacheEnabled() &&
+		skipRuleCheck := c.cluster.GetCheckerConfig().IsPlacementRulesCacheEnabled() &&
 			c.cluster.GetRuleManager().IsRegionFitCached(c.cluster, region)
 		if skipRuleCheck {
 			// If the fit is fetched from cache, it seems that the region doesn't need check

--- a/pkg/schedule/checker/joint_state_checker.go
+++ b/pkg/schedule/checker/joint_state_checker.go
@@ -26,7 +26,7 @@ import (
 // JointStateChecker ensures region is in joint state will leave.
 type JointStateChecker struct {
 	PauseController
-	cluster sche.ClusterInformer
+	cluster sche.CheckerCluster
 }
 
 const jointStateCheckerName = "joint_state_checker"
@@ -41,7 +41,7 @@ var (
 )
 
 // NewJointStateChecker creates a joint state checker.
-func NewJointStateChecker(cluster sche.ClusterInformer) *JointStateChecker {
+func NewJointStateChecker(cluster sche.CheckerCluster) *JointStateChecker {
 	return &JointStateChecker{
 		cluster: cluster,
 	}

--- a/pkg/schedule/checker/learner_checker.go
+++ b/pkg/schedule/checker/learner_checker.go
@@ -25,7 +25,7 @@ import (
 // LearnerChecker ensures region has a learner will be promoted.
 type LearnerChecker struct {
 	PauseController
-	cluster sche.ClusterInformer
+	cluster sche.CheckerCluster
 }
 
 var (
@@ -34,7 +34,7 @@ var (
 )
 
 // NewLearnerChecker creates a learner checker.
-func NewLearnerChecker(cluster sche.ClusterInformer) *LearnerChecker {
+func NewLearnerChecker(cluster sche.CheckerCluster) *LearnerChecker {
 	return &LearnerChecker{
 		cluster: cluster,
 	}

--- a/pkg/schedule/checker/merge_checker.go
+++ b/pkg/schedule/checker/merge_checker.go
@@ -76,14 +76,14 @@ var (
 // MergeChecker ensures region to merge with adjacent region when size is small
 type MergeChecker struct {
 	PauseController
-	cluster    sche.ScheduleCluster
-	conf       config.Config
+	cluster    sche.CheckerCluster
+	conf       config.CheckerConfig
 	splitCache *cache.TTLUint64
 	startTime  time.Time // it's used to judge whether server recently start.
 }
 
 // NewMergeChecker creates a merge checker.
-func NewMergeChecker(ctx context.Context, cluster sche.ScheduleCluster, conf config.Config) *MergeChecker {
+func NewMergeChecker(ctx context.Context, cluster sche.CheckerCluster, conf config.CheckerConfig) *MergeChecker {
 	splitCache := cache.NewIDTTL(ctx, time.Minute, conf.GetSplitMergeInterval())
 	return &MergeChecker{
 		cluster:    cluster,
@@ -250,7 +250,7 @@ func (m *MergeChecker) checkTarget(region, adjacent *core.RegionInfo) bool {
 }
 
 // AllowMerge returns true if two regions can be merged according to the key type.
-func AllowMerge(cluster sche.ScheduleCluster, region, adjacent *core.RegionInfo) bool {
+func AllowMerge(cluster sche.SharedCluster, region, adjacent *core.RegionInfo) bool {
 	var start, end []byte
 	if bytes.Equal(region.GetEndKey(), adjacent.GetStartKey()) && len(region.GetEndKey()) != 0 {
 		start, end = region.GetStartKey(), adjacent.GetEndKey()
@@ -266,7 +266,7 @@ func AllowMerge(cluster sche.ScheduleCluster, region, adjacent *core.RegionInfo)
 	// We can consider using dependency injection techniques to optimize in
 	// the future.
 
-	if cluster.GetOpts().IsPlacementRulesEnabled() {
+	if cluster.GetSharedConfig().IsPlacementRulesEnabled() {
 		cl, ok := cluster.(interface{ GetRuleManager() *placement.RuleManager })
 		if !ok || len(cl.GetRuleManager().GetSplitKeys(start, end)) > 0 {
 			return false
@@ -283,10 +283,10 @@ func AllowMerge(cluster sche.ScheduleCluster, region, adjacent *core.RegionInfo)
 		}
 	}
 
-	policy := cluster.GetOpts().GetKeyType()
+	policy := cluster.GetSharedConfig().GetKeyType()
 	switch policy {
 	case constant.Table:
-		if cluster.GetOpts().IsCrossTableMergeEnabled() {
+		if cluster.GetSharedConfig().IsCrossTableMergeEnabled() {
 			return true
 		}
 		return isTableIDSame(region, adjacent)
@@ -306,7 +306,7 @@ func isTableIDSame(region, adjacent *core.RegionInfo) bool {
 // Check whether there is a peer of the adjacent region on an offline store,
 // while the source region has no peer on it. This is to prevent from bringing
 // any other peer into an offline store to slow down the offline process.
-func checkPeerStore(cluster sche.ScheduleCluster, region, adjacent *core.RegionInfo) bool {
+func checkPeerStore(cluster sche.SharedCluster, region, adjacent *core.RegionInfo) bool {
 	regionStoreIDs := region.GetStoreIDs()
 	for _, peer := range adjacent.GetPeers() {
 		storeID := peer.GetStoreId()

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -80,7 +80,7 @@ func (suite *mergeCheckerTestSuite) SetupTest() {
 	for _, region := range suite.regions {
 		suite.cluster.PutRegion(region)
 	}
-	suite.mc = NewMergeChecker(suite.ctx, suite.cluster, suite.cluster.GetOpts())
+	suite.mc = NewMergeChecker(suite.ctx, suite.cluster, suite.cluster.GetCheckerConfig())
 }
 
 func (suite *mergeCheckerTestSuite) TearDownTest() {
@@ -461,9 +461,9 @@ func (suite *mergeCheckerTestSuite) TestStoreLimitWithMerge() {
 		tc.PutRegion(region)
 	}
 
-	mc := NewMergeChecker(suite.ctx, tc, tc.GetOpts())
+	mc := NewMergeChecker(suite.ctx, tc, tc.GetCheckerConfig())
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := operator.NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 
 	regions[2] = regions[2].Clone(
 		core.SetPeers([]*metapb.Peer{
@@ -530,7 +530,7 @@ func (suite *mergeCheckerTestSuite) TestCache() {
 		suite.cluster.PutRegion(region)
 	}
 
-	suite.mc = NewMergeChecker(suite.ctx, suite.cluster, suite.cluster.GetOpts())
+	suite.mc = NewMergeChecker(suite.ctx, suite.cluster, suite.cluster.GetCheckerConfig())
 
 	ops := suite.mc.Check(suite.regions[1])
 	suite.Nil(ops)

--- a/pkg/schedule/checker/priority_inspector.go
+++ b/pkg/schedule/checker/priority_inspector.go
@@ -29,13 +29,13 @@ const defaultPriorityQueueSize = 1280
 
 // PriorityInspector ensures high priority region should run first
 type PriorityInspector struct {
-	cluster sche.ClusterInformer
-	conf    config.Config
+	cluster sche.CheckerCluster
+	conf    config.CheckerConfig
 	queue   *cache.PriorityQueue
 }
 
 // NewPriorityInspector creates a priority inspector.
-func NewPriorityInspector(cluster sche.ClusterInformer, conf config.Config) *PriorityInspector {
+func NewPriorityInspector(cluster sche.CheckerCluster, conf config.CheckerConfig) *PriorityInspector {
 	return &PriorityInspector{
 		cluster: cluster,
 		conf:    conf,

--- a/pkg/schedule/checker/priority_inspector_test.go
+++ b/pkg/schedule/checker/priority_inspector_test.go
@@ -37,7 +37,7 @@ func TestCheckPriorityRegions(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3)
 	tc.AddLeaderRegion(3, 2)
 
-	pc := NewPriorityInspector(tc, tc.GetOpts())
+	pc := NewPriorityInspector(tc, tc.GetCheckerConfig())
 	checkPriorityRegionTest(re, pc, tc)
 	opt.SetPlacementRuleEnabled(true)
 	re.True(opt.IsPlacementRulesEnabled())
@@ -47,7 +47,7 @@ func TestCheckPriorityRegions(t *testing.T) {
 func checkPriorityRegionTest(re *require.Assertions, pc *PriorityInspector, tc *mockcluster.Cluster) {
 	// case1: inspect region 1, it doesn't lack replica
 	region := tc.GetRegion(1)
-	opt := tc.GetOpts()
+	opt := tc.GetCheckerConfig()
 	pc.Inspect(region)
 	re.Equal(0, pc.queue.Len())
 

--- a/pkg/schedule/checker/replica_checker.go
+++ b/pkg/schedule/checker/replica_checker.go
@@ -61,13 +61,13 @@ var (
 // Location management, mainly used for cross data center deployment.
 type ReplicaChecker struct {
 	PauseController
-	cluster           sche.ClusterInformer
-	conf              config.Config
+	cluster           sche.CheckerCluster
+	conf              config.CheckerConfig
 	regionWaitingList cache.Cache
 }
 
 // NewReplicaChecker creates a replica checker.
-func NewReplicaChecker(cluster sche.ClusterInformer, conf config.Config, regionWaitingList cache.Cache) *ReplicaChecker {
+func NewReplicaChecker(cluster sche.CheckerCluster, conf config.CheckerConfig, regionWaitingList cache.Cache) *ReplicaChecker {
 	return &ReplicaChecker{
 		cluster:           cluster,
 		conf:              conf,

--- a/pkg/schedule/checker/replica_checker_test.go
+++ b/pkg/schedule/checker/replica_checker_test.go
@@ -50,7 +50,7 @@ func (suite *replicaCheckerTestSuite) SetupTest() {
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	suite.cluster = mockcluster.NewCluster(suite.ctx, cfg)
 	suite.cluster.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
-	suite.rc = NewReplicaChecker(suite.cluster, suite.cluster.GetOpts(), cache.NewDefaultCache(10))
+	suite.rc = NewReplicaChecker(suite.cluster, suite.cluster.GetCheckerConfig(), cache.NewDefaultCache(10))
 	stats := &pdpb.StoreStats{
 		Capacity:  100,
 		Available: 100,
@@ -207,7 +207,7 @@ func (suite *replicaCheckerTestSuite) TestBasic() {
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	tc.SetMaxSnapshotCount(2)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	// Add stores 1,2,3,4.
 	tc.AddRegionStore(1, 4)
@@ -283,7 +283,7 @@ func (suite *replicaCheckerTestSuite) TestLostStore() {
 	tc.AddRegionStore(1, 1)
 	tc.AddRegionStore(2, 1)
 
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	// now region peer in store 1,2,3.but we just have store 1,2
 	// This happens only in recovering the PD tc
@@ -301,7 +301,7 @@ func (suite *replicaCheckerTestSuite) TestOffline() {
 	tc.SetMaxReplicas(3)
 	tc.SetLocationLabels([]string{"zone", "rack", "host"})
 
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 	tc.AddLabelsStore(1, 1, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	tc.AddLabelsStore(2, 2, map[string]string{"zone": "z2", "rack": "r1", "host": "h1"})
 	tc.AddLabelsStore(3, 3, map[string]string{"zone": "z3", "rack": "r1", "host": "h1"})
@@ -352,7 +352,7 @@ func (suite *replicaCheckerTestSuite) TestDistinctScore() {
 	tc.SetMaxReplicas(3)
 	tc.SetLocationLabels([]string{"zone", "rack", "host"})
 
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	tc.AddLabelsStore(1, 9, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
 	tc.AddLabelsStore(2, 8, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
@@ -431,7 +431,7 @@ func (suite *replicaCheckerTestSuite) TestDistinctScore2() {
 	tc.SetMaxReplicas(5)
 	tc.SetLocationLabels([]string{"zone", "host"})
 
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	tc.AddLabelsStore(1, 1, map[string]string{"zone": "z1", "host": "h1"})
 	tc.AddLabelsStore(2, 1, map[string]string{"zone": "z1", "host": "h2"})
@@ -459,7 +459,7 @@ func (suite *replicaCheckerTestSuite) TestStorageThreshold() {
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	tc.SetLocationLabels([]string{"zone"})
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	tc.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
 	tc.UpdateStorageRatio(1, 0.5, 0.5)
@@ -494,7 +494,7 @@ func (suite *replicaCheckerTestSuite) TestOpts() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	tc.AddRegionStore(1, 100)
 	tc.AddRegionStore(2, 100)
@@ -526,7 +526,7 @@ func (suite *replicaCheckerTestSuite) TestFixDownPeer() {
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 	tc.SetLocationLabels([]string{"zone"})
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	tc.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
 	tc.AddLabelsStore(2, 1, map[string]string{"zone": "z1"})
@@ -557,7 +557,7 @@ func (suite *replicaCheckerTestSuite) TestFixOfflinePeer() {
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 	tc.SetLocationLabels([]string{"zone"})
-	rc := NewReplicaChecker(tc, tc.GetOpts(), cache.NewDefaultCache(10))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewDefaultCache(10))
 
 	tc.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
 	tc.AddLabelsStore(2, 1, map[string]string{"zone": "z1"})

--- a/pkg/schedule/checker/split_checker.go
+++ b/pkg/schedule/checker/split_checker.go
@@ -28,7 +28,7 @@ import (
 // SplitChecker splits regions when the key range spans across rule/label boundary.
 type SplitChecker struct {
 	PauseController
-	cluster     sche.ClusterInformer
+	cluster     sche.CheckerCluster
 	ruleManager *placement.RuleManager
 	labeler     *labeler.RegionLabeler
 }
@@ -42,7 +42,7 @@ var (
 )
 
 // NewSplitChecker creates a new SplitChecker.
-func NewSplitChecker(cluster sche.ClusterInformer, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler) *SplitChecker {
+func NewSplitChecker(cluster sche.CheckerCluster, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler) *SplitChecker {
 	return &SplitChecker{
 		cluster:     cluster,
 		ruleManager: ruleManager,
@@ -71,7 +71,7 @@ func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 	desc := "labeler-split-region"
 	keys := c.labeler.GetSplitKeys(start, end)
 
-	if len(keys) == 0 && c.cluster.GetOpts().IsPlacementRulesEnabled() {
+	if len(keys) == 0 && c.cluster.GetCheckerConfig().IsPlacementRulesEnabled() {
 		desc = "rule-split-region"
 		keys = c.ruleManager.GetSplitKeys(start, end)
 	}

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -28,17 +28,18 @@ func IsSchedulerRegistered(name string) bool {
 	return ok
 }
 
-// Config is the interface that wraps the Config related methods.
-type Config interface {
+// SchedulerConfig is the interface for scheduler configurations.
+type SchedulerConfig interface {
+	SharedConfig
+
 	IsSchedulingHalted() bool
+
 	IsSchedulerDisabled(string) bool
 	AddSchedulerCfg(string, []string)
 	RemoveSchedulerCfg(string)
 	Persist(endpoint.ConfigStorage) error
 
-	GetReplicaScheduleLimit() uint64
 	GetRegionScheduleLimit() uint64
-	GetMergeScheduleLimit() uint64
 	GetLeaderScheduleLimit() uint64
 	GetHotRegionScheduleLimit() uint64
 	GetWitnessScheduleLimit() uint64
@@ -47,54 +48,69 @@ type Config interface {
 	GetMaxMovableHotPeerSize() int64
 	IsTraceRegionFlow() bool
 
-	GetSplitMergeInterval() time.Duration
-	GetMaxMergeRegionSize() uint64
-	GetMaxMergeRegionKeys() uint64
-	GetKeyType() constant.KeyType
-	IsOneWayMergeEnabled() bool
-	IsCrossTableMergeEnabled() bool
-
-	IsPlacementRulesEnabled() bool
-	IsPlacementRulesCacheEnabled() bool
-
-	GetMaxReplicas() int
-	GetPatrolRegionInterval() time.Duration
-	GetMaxStoreDownTime() time.Duration
-	GetLocationLabels() []string
-	GetIsolationLevel() string
-	IsReplaceOfflineReplicaEnabled() bool
-	IsMakeUpReplicaEnabled() bool
-	IsRemoveExtraReplicaEnabled() bool
-	IsLocationReplacementEnabled() bool
-	IsRemoveDownReplicaEnabled() bool
-
-	GetSwitchWitnessInterval() time.Duration
-	IsWitnessAllowed() bool
-
-	GetLowSpaceRatio() float64
-	GetHighSpaceRatio() float64
 	GetTolerantSizeRatio() float64
 	GetLeaderSchedulePolicy() constant.SchedulePolicy
-	GetRegionScoreFormulaVersion() string
 
+	IsDebugMetricsEnabled() bool
+	IsDiagnosticAllowed() bool
+	GetSlowStoreEvictingAffectedStoreRatioThreshold() float64
+}
+
+// CheckerConfig is the interface for checker configurations.
+type CheckerConfig interface {
+	SharedConfig
+
+	GetSwitchWitnessInterval() time.Duration
+	IsRemoveExtraReplicaEnabled() bool
+	IsRemoveDownReplicaEnabled() bool
+	IsReplaceOfflineReplicaEnabled() bool
+	IsMakeUpReplicaEnabled() bool
+	IsLocationReplacementEnabled() bool
+	GetIsolationLevel() string
+	GetSplitMergeInterval() time.Duration
+	GetPatrolRegionInterval() time.Duration
+	GetMaxMergeRegionSize() uint64
+	GetMaxMergeRegionKeys() uint64
+	GetReplicaScheduleLimit() uint64
+}
+
+// SharedConfig is the interface for shared configurations.
+type SharedConfig interface {
+	GetMaxReplicas() int
+	IsPlacementRulesEnabled() bool
 	GetMaxSnapshotCount() uint64
 	GetMaxPendingPeerCount() uint64
+	GetLowSpaceRatio() float64
+	GetHighSpaceRatio() float64
+	GetMaxStoreDownTime() time.Duration
+	GetLocationLabels() []string
+	CheckLabelProperty(string, []*metapb.StoreLabel) bool
+	GetClusterVersion() *semver.Version
+	IsUseJointConsensus() bool
+	GetKeyType() constant.KeyType
+	IsCrossTableMergeEnabled() bool
+	IsOneWayMergeEnabled() bool
+	GetMergeScheduleLimit() uint64
+	GetRegionScoreFormulaVersion() string
 	GetSchedulerMaxWaitingOperator() uint64
 	GetStoreLimitByType(uint64, storelimit.Type) float64
-	SetAllStoresLimit(storelimit.Type, float64)
-	GetSlowStoreEvictingAffectedStoreRatioThreshold() float64
-	IsUseJointConsensus() bool
-	CheckLabelProperty(string, []*metapb.StoreLabel) bool
-	IsDebugMetricsEnabled() bool
-	GetClusterVersion() *semver.Version
-	GetStoreLimitVersion() string
-	IsDiagnosticAllowed() bool
+	IsWitnessAllowed() bool
+	IsPlacementRulesCacheEnabled() bool
+
+	// for test purpose
+	SetPlacementRulesCacheEnabled(bool)
+	SetEnableWitness(bool)
+}
+
+// Config is the interface that wraps the Config related methods.
+type Config interface {
+	SchedulerConfig
+	CheckerConfig
 	// for test purpose
 	SetPlacementRuleEnabled(bool)
 	SetSplitMergeInterval(time.Duration)
 	SetMaxReplicas(int)
-	SetPlacementRulesCacheEnabled(bool)
-	SetEnableWitness(bool)
+	SetAllStoresLimit(typ storelimit.Type, ratePerMin float64)
 	// only for store configuration
 	UseRaftV2()
 }

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -86,23 +86,22 @@ type Coordinator struct {
 // NewCoordinator creates a new Coordinator.
 func NewCoordinator(ctx context.Context, cluster sche.ClusterInformer, hbStreams *hbstream.HeartbeatStreams) *Coordinator {
 	ctx, cancel := context.WithCancel(ctx)
-	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetOpts(), hbStreams)
+	opController := operator.NewController(ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), hbStreams)
 	schedulers := schedulers.NewController(ctx, cluster, cluster.GetStorage(), opController)
-	c := &Coordinator{
-		ctx:             ctx,
-		cancel:          cancel,
-		cluster:         cluster,
-		prepareChecker:  newPrepareChecker(),
-		checkers:        checker.NewController(ctx, cluster, cluster.GetOpts(), cluster.GetRuleManager(), cluster.GetRegionLabeler(), opController),
-		regionScatterer: scatter.NewRegionScatterer(ctx, cluster, opController),
-		regionSplitter:  splitter.NewRegionSplitter(cluster, splitter.NewSplitRegionsHandler(cluster, opController)),
-		schedulers:      schedulers,
-		opController:    opController,
-		hbStreams:       hbStreams,
-		pluginInterface: NewPluginInterface(),
+	return &Coordinator{
+		ctx:               ctx,
+		cancel:            cancel,
+		cluster:           cluster,
+		prepareChecker:    newPrepareChecker(),
+		checkers:          checker.NewController(ctx, cluster, cluster.GetCheckerConfig(), cluster.GetRuleManager(), cluster.GetRegionLabeler(), opController),
+		regionScatterer:   scatter.NewRegionScatterer(ctx, cluster, opController),
+		regionSplitter:    splitter.NewRegionSplitter(cluster, splitter.NewSplitRegionsHandler(cluster, opController)),
+		schedulers:        schedulers,
+		opController:      opController,
+		hbStreams:         hbStreams,
+		pluginInterface:   NewPluginInterface(),
+		diagnosticManager: diagnostic.NewManager(schedulers, cluster.GetSchedulerConfig()),
 	}
-	c.diagnosticManager = diagnostic.NewManager(schedulers, cluster.GetOpts())
-	return c
 }
 
 // GetWaitingRegions returns the regions in the waiting list.
@@ -122,7 +121,7 @@ func (c *Coordinator) PatrolRegions() {
 	defer logutil.LogPanic()
 
 	defer c.wg.Done()
-	ticker := time.NewTicker(c.cluster.GetOpts().GetPatrolRegionInterval())
+	ticker := time.NewTicker(c.cluster.GetCheckerConfig().GetPatrolRegionInterval())
 	defer ticker.Stop()
 
 	log.Info("Coordinator starts patrol regions")
@@ -135,7 +134,7 @@ func (c *Coordinator) PatrolRegions() {
 		select {
 		case <-ticker.C:
 			// Note: we reset the ticker here to support updating configuration dynamically.
-			ticker.Reset(c.cluster.GetOpts().GetPatrolRegionInterval())
+			ticker.Reset(c.cluster.GetCheckerConfig().GetPatrolRegionInterval())
 		case <-c.ctx.Done():
 			log.Info("patrol regions has been stopped")
 			return
@@ -505,7 +504,7 @@ func (c *Coordinator) Stop() {
 
 // GetHotRegionsByType gets hot regions' statistics by RWType.
 func (c *Coordinator) GetHotRegionsByType(typ statistics.RWType) *statistics.StoreHotPeersInfos {
-	isTraceFlow := c.cluster.GetOpts().IsTraceRegionFlow()
+	isTraceFlow := c.cluster.GetSchedulerConfig().IsTraceRegionFlow()
 	storeLoads := c.cluster.GetStoresLoads()
 	stores := c.cluster.GetStores()
 	var infos *statistics.StoreHotPeersInfos

--- a/pkg/schedule/core/cluster_informer.go
+++ b/pkg/schedule/core/cluster_informer.go
@@ -27,27 +27,50 @@ import (
 
 // ClusterInformer provides the necessary information of a cluster.
 type ClusterInformer interface {
-	ScheduleCluster
+	SchedulerCluster
+	CheckerCluster
+	ScatterCluster
 
 	GetStorage() storage.Storage
 	UpdateRegionsLabelLevelStats(regions []*core.RegionInfo)
-	AddSuspectRegions(ids ...uint64)
 	GetPersistOptions() *config.PersistOptions
 }
 
-// ScheduleCluster is an aggregate interface that wraps multiple interfaces for schedulers use
-type ScheduleCluster interface {
-	BasicCluster
+// SchedulerCluster is an aggregate interface that wraps multiple interfaces
+type SchedulerCluster interface {
+	SharedCluster
 
 	statistics.StoreStatInformer
-	statistics.RegionStatInformer
 	buckets.BucketStatInformer
 
-	GetOpts() sc.Config
-	GetRuleManager() *placement.RuleManager
+	GetSchedulerConfig() sc.SchedulerConfig
 	GetRegionLabeler() *labeler.RegionLabeler
-	GetBasicCluster() *core.BasicCluster
 	GetStoreConfig() sc.StoreConfig
+}
+
+// CheckerCluster is an aggregate interface that wraps multiple interfaces
+type CheckerCluster interface {
+	SharedCluster
+
+	GetCheckerConfig() sc.CheckerConfig
+	GetStoreConfig() sc.StoreConfig
+}
+
+// ScatterCluster is an aggregate interface that wraps multiple interfaces
+type ScatterCluster interface {
+	SharedCluster
+
+	AddSuspectRegions(ids ...uint64)
+}
+
+// SharedCluster is an aggregate interface that wraps multiple interfaces
+type SharedCluster interface {
+	BasicCluster
+	statistics.RegionStatInformer
+
+	GetBasicCluster() *core.BasicCluster
+	GetSharedConfig() sc.SharedConfig
+	GetRuleManager() *placement.RuleManager
 	AllocID() (uint64, error)
 }
 

--- a/pkg/schedule/diagnostic/diagnostic_manager.go
+++ b/pkg/schedule/diagnostic/diagnostic_manager.go
@@ -24,12 +24,12 @@ import (
 
 // Manager is used to manage the diagnostic result of schedulers for now.
 type Manager struct {
-	config              config.Config
+	config              config.SchedulerConfig
 	schedulerController *schedulers.Controller
 }
 
 // NewManager creates a new Manager.
-func NewManager(schedulerController *schedulers.Controller, config config.Config) *Manager {
+func NewManager(schedulerController *schedulers.Controller, config config.SchedulerConfig) *Manager {
 	return &Manager{
 		config:              config,
 		schedulerController: schedulerController,

--- a/pkg/schedule/filter/candidates.go
+++ b/pkg/schedule/filter/candidates.go
@@ -37,13 +37,13 @@ func NewCandidates(stores []*core.StoreInfo) *StoreCandidates {
 }
 
 // FilterSource keeps stores that can pass all source filters.
-func (c *StoreCandidates) FilterSource(conf config.Config, collector *plan.Collector, counter *Counter, filters ...Filter) *StoreCandidates {
+func (c *StoreCandidates) FilterSource(conf config.SharedConfig, collector *plan.Collector, counter *Counter, filters ...Filter) *StoreCandidates {
 	c.Stores = SelectSourceStores(c.Stores, filters, conf, collector, counter)
 	return c
 }
 
 // FilterTarget keeps stores that can pass all target filters.
-func (c *StoreCandidates) FilterTarget(conf config.Config, collector *plan.Collector, counter *Counter, filters ...Filter) *StoreCandidates {
+func (c *StoreCandidates) FilterTarget(conf config.SharedConfig, collector *plan.Collector, counter *Counter, filters ...Filter) *StoreCandidates {
 	c.Stores = SelectTargetStores(c.Stores, filters, conf, collector, counter)
 	return c
 }

--- a/pkg/schedule/filter/candidates_test.go
+++ b/pkg/schedule/filter/candidates_test.go
@@ -50,7 +50,7 @@ type idFilter func(uint64) bool
 
 func (f idFilter) Scope() string    { return "idFilter" }
 func (f idFilter) Type() filterType { return filterType(0) }
-func (f idFilter) Source(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f idFilter) Source(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if f(store.GetID()) {
 		return statusOK
 	}
@@ -58,7 +58,7 @@ func (f idFilter) Source(conf config.Config, store *core.StoreInfo) *plan.Status
 	return statusStoreScoreDisallowed
 }
 
-func (f idFilter) Target(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f idFilter) Target(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if f(store.GetID()) {
 		return statusOK
 	}

--- a/pkg/schedule/filter/comparer.go
+++ b/pkg/schedule/filter/comparer.go
@@ -25,7 +25,7 @@ type StoreComparer func(a, b *core.StoreInfo) int
 
 // RegionScoreComparer creates a StoreComparer to sort store by region
 // score.
-func RegionScoreComparer(conf config.Config) StoreComparer {
+func RegionScoreComparer(conf config.SharedConfig) StoreComparer {
 	return func(a, b *core.StoreInfo) int {
 		sa := a.RegionScore(conf.GetRegionScoreFormulaVersion(), conf.GetHighSpaceRatio(), conf.GetLowSpaceRatio(), 0)
 		sb := b.RegionScore(conf.GetRegionScoreFormulaVersion(), conf.GetHighSpaceRatio(), conf.GetLowSpaceRatio(), 0)

--- a/pkg/schedule/filter/filters.go
+++ b/pkg/schedule/filter/filters.go
@@ -31,7 +31,7 @@ import (
 )
 
 // SelectSourceStores selects stores that be selected as source store from the list.
-func SelectSourceStores(stores []*core.StoreInfo, filters []Filter, conf config.Config, collector *plan.Collector,
+func SelectSourceStores(stores []*core.StoreInfo, filters []Filter, conf config.SharedConfig, collector *plan.Collector,
 	counter *Counter) []*core.StoreInfo {
 	return filterStoresBy(stores, func(s *core.StoreInfo) bool {
 		return slice.AllOf(filters, func(i int) bool {
@@ -55,7 +55,7 @@ func SelectSourceStores(stores []*core.StoreInfo, filters []Filter, conf config.
 }
 
 // SelectUnavailableTargetStores selects unavailable stores that can't be selected as target store from the list.
-func SelectUnavailableTargetStores(stores []*core.StoreInfo, filters []Filter, conf config.Config,
+func SelectUnavailableTargetStores(stores []*core.StoreInfo, filters []Filter, conf config.SharedConfig,
 	collector *plan.Collector, counter *Counter) []*core.StoreInfo {
 	return filterStoresBy(stores, func(s *core.StoreInfo) bool {
 		targetID := strconv.FormatUint(s.GetID(), 10)
@@ -85,7 +85,7 @@ func SelectUnavailableTargetStores(stores []*core.StoreInfo, filters []Filter, c
 }
 
 // SelectTargetStores selects stores that be selected as target store from the list.
-func SelectTargetStores(stores []*core.StoreInfo, filters []Filter, conf config.Config, collector *plan.Collector,
+func SelectTargetStores(stores []*core.StoreInfo, filters []Filter, conf config.SharedConfig, collector *plan.Collector,
 	counter *Counter) []*core.StoreInfo {
 	if len(filters) == 0 {
 		return stores
@@ -133,9 +133,9 @@ type Filter interface {
 	Scope() string
 	Type() filterType
 	// Source Return plan.Status to show whether be filtered as source
-	Source(conf config.Config, store *core.StoreInfo) *plan.Status
+	Source(conf config.SharedConfig, store *core.StoreInfo) *plan.Status
 	// Target Return plan.Status to show whether be filtered as target
-	Target(conf config.Config, store *core.StoreInfo) *plan.Status
+	Target(conf config.SharedConfig, store *core.StoreInfo) *plan.Status
 }
 
 // comparingFilter is an interface to filter target store by comparing source and target stores
@@ -146,7 +146,7 @@ type comparingFilter interface {
 }
 
 // Target checks if store can pass all Filters as target store.
-func Target(conf config.Config, store *core.StoreInfo, filters []Filter) bool {
+func Target(conf config.SharedConfig, store *core.StoreInfo, filters []Filter) bool {
 	storeID := strconv.FormatUint(store.GetID(), 10)
 	for _, filter := range filters {
 		status := filter.Target(conf, store)
@@ -189,14 +189,14 @@ func (f *excludedFilter) Type() filterType {
 	return excluded
 }
 
-func (f *excludedFilter) Source(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *excludedFilter) Source(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if _, ok := f.sources[store.GetID()]; ok {
 		return statusStoreAlreadyHasPeer
 	}
 	return statusOK
 }
 
-func (f *excludedFilter) Target(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *excludedFilter) Target(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if _, ok := f.targets[store.GetID()]; ok {
 		return statusStoreAlreadyHasPeer
 	}
@@ -219,11 +219,11 @@ func (f *storageThresholdFilter) Type() filterType {
 	return storageThreshold
 }
 
-func (f *storageThresholdFilter) Source(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *storageThresholdFilter) Source(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	return statusOK
 }
 
-func (f *storageThresholdFilter) Target(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *storageThresholdFilter) Target(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !store.IsLowSpace(conf.GetLowSpaceRatio()) {
 		return statusOK
 	}
@@ -287,11 +287,11 @@ func (f *distinctScoreFilter) Type() filterType {
 	return distinctScore
 }
 
-func (f *distinctScoreFilter) Source(_ config.Config, _ *core.StoreInfo) *plan.Status {
+func (f *distinctScoreFilter) Source(_ config.SharedConfig, _ *core.StoreInfo) *plan.Status {
 	return statusOK
 }
 
-func (f *distinctScoreFilter) Target(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *distinctScoreFilter) Target(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	score := core.DistinctScore(f.labels, f.stores, store)
 	switch f.policy {
 	case locationSafeguard:
@@ -348,9 +348,9 @@ func (f *StoreStateFilter) Type() filterType {
 
 // conditionFunc defines condition to determine a store should be selected.
 // It should consider if the filter allows temporary states.
-type conditionFunc func(config.Config, *core.StoreInfo) *plan.Status
+type conditionFunc func(config.SharedConfig, *core.StoreInfo) *plan.Status
 
-func (f *StoreStateFilter) isRemoved(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) isRemoved(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if store.IsRemoved() {
 		f.Reason = storeStateTombstone
 		return statusStoreRemoved
@@ -359,7 +359,7 @@ func (f *StoreStateFilter) isRemoved(_ config.Config, store *core.StoreInfo) *pl
 	return statusOK
 }
 
-func (f *StoreStateFilter) isDown(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) isDown(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if store.DownTime() > conf.GetMaxStoreDownTime() {
 		f.Reason = storeStateDown
 		return statusStoreDown
@@ -369,7 +369,7 @@ func (f *StoreStateFilter) isDown(conf config.Config, store *core.StoreInfo) *pl
 	return statusOK
 }
 
-func (f *StoreStateFilter) isRemoving(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) isRemoving(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if store.IsRemoving() {
 		f.Reason = storeStateOffline
 		return statusStoresRemoving
@@ -378,7 +378,7 @@ func (f *StoreStateFilter) isRemoving(_ config.Config, store *core.StoreInfo) *p
 	return statusOK
 }
 
-func (f *StoreStateFilter) pauseLeaderTransfer(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) pauseLeaderTransfer(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !store.AllowLeaderTransfer() {
 		f.Reason = storeStatePauseLeader
 		return statusStoreRejectLeader
@@ -387,7 +387,7 @@ func (f *StoreStateFilter) pauseLeaderTransfer(_ config.Config, store *core.Stor
 	return statusOK
 }
 
-func (f *StoreStateFilter) slowStoreEvicted(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) slowStoreEvicted(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if store.EvictedAsSlowStore() {
 		f.Reason = storeStateSlow
 		return statusStoreRejectLeader
@@ -396,7 +396,7 @@ func (f *StoreStateFilter) slowStoreEvicted(conf config.Config, store *core.Stor
 	return statusOK
 }
 
-func (f *StoreStateFilter) slowTrendEvicted(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) slowTrendEvicted(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if store.IsEvictedAsSlowTrend() {
 		f.Reason = storeStateSlowTrend
 		return statusStoreRejectLeader
@@ -405,7 +405,7 @@ func (f *StoreStateFilter) slowTrendEvicted(_ config.Config, store *core.StoreIn
 	return statusOK
 }
 
-func (f *StoreStateFilter) isDisconnected(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) isDisconnected(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !f.AllowTemporaryStates && store.IsDisconnected() {
 		f.Reason = storeStateDisconnected
 		return statusStoreDisconnected
@@ -414,7 +414,7 @@ func (f *StoreStateFilter) isDisconnected(_ config.Config, store *core.StoreInfo
 	return statusOK
 }
 
-func (f *StoreStateFilter) isBusy(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) isBusy(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !f.AllowTemporaryStates && store.IsBusy() {
 		f.Reason = storeStateBusy
 		return statusStoreBusy
@@ -423,7 +423,7 @@ func (f *StoreStateFilter) isBusy(_ config.Config, store *core.StoreInfo) *plan.
 	return statusOK
 }
 
-func (f *StoreStateFilter) exceedRemoveLimit(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) exceedRemoveLimit(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !f.AllowTemporaryStates && !store.IsAvailable(storelimit.RemovePeer, f.OperatorLevel) {
 		f.Reason = storeStateExceedRemoveLimit
 		return statusStoreRemoveLimit
@@ -432,7 +432,7 @@ func (f *StoreStateFilter) exceedRemoveLimit(_ config.Config, store *core.StoreI
 	return statusOK
 }
 
-func (f *StoreStateFilter) exceedAddLimit(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) exceedAddLimit(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !f.AllowTemporaryStates && !store.IsAvailable(storelimit.AddPeer, f.OperatorLevel) {
 		f.Reason = storeStateExceedAddLimit
 		return statusStoreAddLimit
@@ -441,7 +441,7 @@ func (f *StoreStateFilter) exceedAddLimit(_ config.Config, store *core.StoreInfo
 	return statusOK
 }
 
-func (f *StoreStateFilter) tooManySnapshots(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) tooManySnapshots(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !f.AllowTemporaryStates && (uint64(store.GetSendingSnapCount()) > conf.GetMaxSnapshotCount() ||
 		uint64(store.GetReceivingSnapCount()) > conf.GetMaxSnapshotCount()) {
 		f.Reason = storeStateTooManySnapshot
@@ -451,7 +451,7 @@ func (f *StoreStateFilter) tooManySnapshots(conf config.Config, store *core.Stor
 	return statusOK
 }
 
-func (f *StoreStateFilter) tooManyPendingPeers(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) tooManyPendingPeers(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !f.AllowTemporaryStates &&
 		conf.GetMaxPendingPeerCount() > 0 &&
 		store.GetPendingPeerCount() > int(conf.GetMaxPendingPeerCount()) {
@@ -462,7 +462,7 @@ func (f *StoreStateFilter) tooManyPendingPeers(conf config.Config, store *core.S
 	return statusOK
 }
 
-func (f *StoreStateFilter) hasRejectLeaderProperty(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) hasRejectLeaderProperty(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if conf.CheckLabelProperty(config.RejectLeader, store.GetLabels()) {
 		f.Reason = storeStateRejectLeader
 		return statusStoreRejectLeader
@@ -495,7 +495,7 @@ const (
 	fastFailoverTarget
 )
 
-func (f *StoreStateFilter) anyConditionMatch(typ int, conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *StoreStateFilter) anyConditionMatch(typ int, conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	var funcs []conditionFunc
 	switch typ {
 	case leaderSource:
@@ -527,7 +527,7 @@ func (f *StoreStateFilter) anyConditionMatch(typ int, conf config.Config, store 
 
 // Source returns true when the store can be selected as the schedule
 // source.
-func (f *StoreStateFilter) Source(conf config.Config, store *core.StoreInfo) (status *plan.Status) {
+func (f *StoreStateFilter) Source(conf config.SharedConfig, store *core.StoreInfo) (status *plan.Status) {
 	if f.TransferLeader {
 		if status = f.anyConditionMatch(leaderSource, conf, store); !status.IsOK() {
 			return
@@ -544,7 +544,7 @@ func (f *StoreStateFilter) Source(conf config.Config, store *core.StoreInfo) (st
 
 // Target returns true when the store can be selected as the schedule
 // target.
-func (f *StoreStateFilter) Target(conf config.Config, store *core.StoreInfo) (status *plan.Status) {
+func (f *StoreStateFilter) Target(conf config.SharedConfig, store *core.StoreInfo) (status *plan.Status) {
 	if f.TransferLeader {
 		if status = f.anyConditionMatch(leaderTarget, conf, store); !status.IsOK() {
 			return
@@ -588,7 +588,7 @@ func (f labelConstraintFilter) Type() filterType {
 }
 
 // Source filters stores when select them as schedule source.
-func (f labelConstraintFilter) Source(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f labelConstraintFilter) Source(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if placement.MatchLabelConstraints(store, f.constraints) {
 		return statusOK
 	}
@@ -596,7 +596,7 @@ func (f labelConstraintFilter) Source(conf config.Config, store *core.StoreInfo)
 }
 
 // Target filters stores when select them as schedule target.
-func (f labelConstraintFilter) Target(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f labelConstraintFilter) Target(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if placement.MatchLabelConstraints(store, f.constraints) {
 		return statusOK
 	}
@@ -638,7 +638,7 @@ func (f *ruleFitFilter) Type() filterType {
 	return ruleFit
 }
 
-func (f *ruleFitFilter) Source(_ config.Config, _ *core.StoreInfo) *plan.Status {
+func (f *ruleFitFilter) Source(_ config.SharedConfig, _ *core.StoreInfo) *plan.Status {
 	return statusOK
 }
 
@@ -647,7 +647,7 @@ func (f *ruleFitFilter) Source(_ config.Config, _ *core.StoreInfo) *plan.Status 
 // the replaced store can match the source rule.
 // RegionA:[1,2,3], move peer1 --> peer2 will not allow, because it's count not match the rule.
 // but transfer role peer1 --> peer2, it will support.
-func (f *ruleFitFilter) Target(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *ruleFitFilter) Target(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if f.oldFit.Replace(f.srcStore, store) {
 		return statusOK
 	}
@@ -691,11 +691,11 @@ func (f *ruleLeaderFitFilter) Type() filterType {
 	return ruleLeader
 }
 
-func (f *ruleLeaderFitFilter) Source(_ config.Config, _ *core.StoreInfo) *plan.Status {
+func (f *ruleLeaderFitFilter) Source(_ config.SharedConfig, _ *core.StoreInfo) *plan.Status {
 	return statusOK
 }
 
-func (f *ruleLeaderFitFilter) Target(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *ruleLeaderFitFilter) Target(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	targetStoreID := store.GetID()
 	targetPeer := f.region.GetStorePeer(targetStoreID)
 	if targetPeer == nil && !f.allowMoveLeader {
@@ -747,11 +747,11 @@ func (f *ruleWitnessFitFilter) Type() filterType {
 	return ruleFit
 }
 
-func (f *ruleWitnessFitFilter) Source(_ config.Config, _ *core.StoreInfo) *plan.Status {
+func (f *ruleWitnessFitFilter) Source(_ config.SharedConfig, _ *core.StoreInfo) *plan.Status {
 	return statusOK
 }
 
-func (f *ruleWitnessFitFilter) Target(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *ruleWitnessFitFilter) Target(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	targetStoreID := store.GetID()
 	targetPeer := f.region.GetStorePeer(targetStoreID)
 	if targetPeer == nil {
@@ -769,7 +769,7 @@ func (f *ruleWitnessFitFilter) Target(_ config.Config, store *core.StoreInfo) *p
 
 // NewPlacementSafeguard creates a filter that ensures after replace a peer with new
 // peer, the placement restriction will not become worse.
-func NewPlacementSafeguard(scope string, conf config.Config, cluster *core.BasicCluster, ruleManager *placement.RuleManager,
+func NewPlacementSafeguard(scope string, conf config.SharedConfig, cluster *core.BasicCluster, ruleManager *placement.RuleManager,
 	region *core.RegionInfo, sourceStore *core.StoreInfo, oldFit *placement.RegionFit) Filter {
 	if conf.IsPlacementRulesEnabled() {
 		return newRuleFitFilter(scope, cluster, ruleManager, region, oldFit, sourceStore.GetID())
@@ -780,7 +780,7 @@ func NewPlacementSafeguard(scope string, conf config.Config, cluster *core.Basic
 // NewPlacementLeaderSafeguard creates a filter that ensures after transfer a leader with
 // existed peer, the placement restriction will not become worse.
 // Note that it only worked when PlacementRules enabled otherwise it will always permit the sourceStore.
-func NewPlacementLeaderSafeguard(scope string, conf config.Config, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, sourceStore *core.StoreInfo, allowMoveLeader bool) Filter {
+func NewPlacementLeaderSafeguard(scope string, conf config.SharedConfig, cluster *core.BasicCluster, ruleManager *placement.RuleManager, region *core.RegionInfo, sourceStore *core.StoreInfo, allowMoveLeader bool) Filter {
 	if conf.IsPlacementRulesEnabled() {
 		return newRuleLeaderFitFilter(scope, cluster, ruleManager, region, sourceStore.GetID(), allowMoveLeader)
 	}
@@ -790,7 +790,7 @@ func NewPlacementLeaderSafeguard(scope string, conf config.Config, cluster *core
 // NewPlacementWitnessSafeguard creates a filter that ensures after transfer a witness with
 // existed peer, the placement restriction will not become worse.
 // Note that it only worked when PlacementRules enabled otherwise it will always permit the sourceStore.
-func NewPlacementWitnessSafeguard(scope string, conf config.Config, cluster *core.BasicCluster, ruleManager *placement.RuleManager,
+func NewPlacementWitnessSafeguard(scope string, conf config.SharedConfig, cluster *core.BasicCluster, ruleManager *placement.RuleManager,
 	region *core.RegionInfo, sourceStore *core.StoreInfo, oldFit *placement.RegionFit) Filter {
 	if conf.IsPlacementRulesEnabled() {
 		return newRuleWitnessFitFilter(scope, cluster, ruleManager, region, oldFit, sourceStore.GetID())
@@ -819,14 +819,14 @@ func (f *engineFilter) Type() filterType {
 	return engine
 }
 
-func (f *engineFilter) Source(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *engineFilter) Source(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if f.constraint.MatchStore(store) {
 		return statusOK
 	}
 	return statusStoreNotMatchRule
 }
 
-func (f *engineFilter) Target(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *engineFilter) Target(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if f.constraint.MatchStore(store) {
 		return statusOK
 	}
@@ -862,14 +862,14 @@ func (f *specialUseFilter) Type() filterType {
 	return specialUse
 }
 
-func (f *specialUseFilter) Source(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *specialUseFilter) Source(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if store.IsLowSpace(conf.GetLowSpaceRatio()) || !f.constraint.MatchStore(store) {
 		return statusOK
 	}
 	return statusStoreNotMatchRule
 }
 
-func (f *specialUseFilter) Target(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *specialUseFilter) Target(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	if !f.constraint.MatchStore(store) {
 		return statusOK
 	}
@@ -936,11 +936,11 @@ func (f *isolationFilter) Type() filterType {
 	return isolation
 }
 
-func (f *isolationFilter) Source(conf config.Config, store *core.StoreInfo) *plan.Status {
+func (f *isolationFilter) Source(conf config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	return statusOK
 }
 
-func (f *isolationFilter) Target(_ config.Config, store *core.StoreInfo) *plan.Status {
+func (f *isolationFilter) Target(_ config.SharedConfig, store *core.StoreInfo) *plan.Status {
 	// No isolation constraint to fit
 	if len(f.constraintSet) == 0 {
 		return statusStoreNotMatchIsolation

--- a/pkg/schedule/filter/filters_test.go
+++ b/pkg/schedule/filter/filters_test.go
@@ -93,7 +93,7 @@ func TestLabelConstraintsFilter(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		filter := NewLabelConstraintFilter("", []placement.LabelConstraint{{Key: testCase.key, Op: placement.LabelConstraintOp(testCase.op), Values: testCase.values}})
-		re.Equal(testCase.res, filter.Source(testCluster.GetOpts(), store).StatusCode)
+		re.Equal(testCase.res, filter.Source(testCluster.GetSharedConfig(), store).StatusCode)
 	}
 }
 
@@ -139,15 +139,15 @@ func TestRuleFitFilter(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		filter := newRuleFitFilter("", testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, nil, 1)
-		re.Equal(testCase.sourceRes, filter.Source(testCluster.GetOpts(), testCluster.GetStore(testCase.storeID)).StatusCode)
-		re.Equal(testCase.targetRes, filter.Target(testCluster.GetOpts(), testCluster.GetStore(testCase.storeID)).StatusCode)
+		re.Equal(testCase.sourceRes, filter.Source(testCluster.GetSharedConfig(), testCluster.GetStore(testCase.storeID)).StatusCode)
+		re.Equal(testCase.targetRes, filter.Target(testCluster.GetSharedConfig(), testCluster.GetStore(testCase.storeID)).StatusCode)
 		leaderFilter := newRuleLeaderFitFilter("", testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, 1, true)
-		re.Equal(testCase.targetRes, leaderFilter.Target(testCluster.GetOpts(), testCluster.GetStore(testCase.storeID)).StatusCode)
+		re.Equal(testCase.targetRes, leaderFilter.Target(testCluster.GetSharedConfig(), testCluster.GetStore(testCase.storeID)).StatusCode)
 	}
 
 	// store-6 is not exist in the peers, so it will not allow transferring leader to store 6.
 	leaderFilter := newRuleLeaderFitFilter("", testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, 1, false)
-	re.False(leaderFilter.Target(testCluster.GetOpts(), testCluster.GetStore(6)).IsOK())
+	re.False(leaderFilter.Target(testCluster.GetSharedConfig(), testCluster.GetStore(6)).IsOK())
 }
 
 func TestSendStateFilter(t *testing.T) {
@@ -334,8 +334,8 @@ func TestIsolationFilter(t *testing.T) {
 	for _, testCase := range testCases {
 		filter := NewIsolationFilter("", testCase.isolationLevel, testCluster.GetLocationLabels(), testCluster.GetRegionStores(testCase.region))
 		for idx, store := range allStores {
-			re.Equal(testCase.sourceRes[idx], filter.Source(testCluster.GetOpts(), testCluster.GetStore(store.storeID)).StatusCode)
-			re.Equal(testCase.targetRes[idx], filter.Target(testCluster.GetOpts(), testCluster.GetStore(store.storeID)).StatusCode)
+			re.Equal(testCase.sourceRes[idx], filter.Source(testCluster.GetSharedConfig(), testCluster.GetStore(store.storeID)).StatusCode)
+			re.Equal(testCase.targetRes[idx], filter.Target(testCluster.GetSharedConfig(), testCluster.GetStore(store.storeID)).StatusCode)
 		}
 	}
 }
@@ -362,10 +362,10 @@ func TestPlacementGuard(t *testing.T) {
 	store := testCluster.GetStore(1)
 
 	re.IsType(NewLocationSafeguard("", []string{"zone"}, testCluster.GetRegionStores(region), store),
-		NewPlacementSafeguard("", testCluster.GetOpts(), testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, store, nil))
+		NewPlacementSafeguard("", testCluster.GetSharedConfig(), testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, store, nil))
 	testCluster.SetEnablePlacementRules(true)
 	re.IsType(newRuleFitFilter("", testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, nil, 1),
-		NewPlacementSafeguard("", testCluster.GetOpts(), testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, store, nil))
+		NewPlacementSafeguard("", testCluster.GetSharedConfig(), testCluster.GetBasicCluster(), testCluster.GetRuleManager(), region, store, nil))
 }
 
 func TestSpecialUseFilter(t *testing.T) {
@@ -393,8 +393,8 @@ func TestSpecialUseFilter(t *testing.T) {
 		store := core.NewStoreInfoWithLabel(1, testCase.label)
 		store = store.Clone(core.SetStoreStats(&pdpb.StoreStats{StoreId: 1, Capacity: 100 * units.GiB, Available: 100 * units.GiB}))
 		filter := NewSpecialUseFilter("", testCase.allowUse...)
-		re.Equal(testCase.sourceRes, filter.Source(testCluster.GetOpts(), store).StatusCode)
-		re.Equal(testCase.targetRes, filter.Target(testCluster.GetOpts(), store).StatusCode)
+		re.Equal(testCase.sourceRes, filter.Source(testCluster.GetSharedConfig(), store).StatusCode)
+		re.Equal(testCase.targetRes, filter.Target(testCluster.GetSharedConfig(), store).StatusCode)
 	}
 }
 

--- a/pkg/schedule/filter/healthy.go
+++ b/pkg/schedule/filter/healthy.go
@@ -42,17 +42,17 @@ func hasDownPeers(region *core.RegionInfo) bool {
 // IsRegionReplicated checks if a region is fully replicated. When placement
 // rules is enabled, its peers should fit corresponding rules. When placement
 // rules is disabled, it should have enough replicas and no any learner peer.
-func IsRegionReplicated(cluster sche.ScheduleCluster, region *core.RegionInfo) bool {
-	if cluster.GetOpts().IsPlacementRulesEnabled() {
+func IsRegionReplicated(cluster sche.SharedCluster, region *core.RegionInfo) bool {
+	if cluster.GetSharedConfig().IsPlacementRulesEnabled() {
 		return isRegionPlacementRuleSatisfied(cluster, region)
 	}
 	return isRegionReplicasSatisfied(cluster, region)
 }
 
-func isRegionPlacementRuleSatisfied(cluster sche.ScheduleCluster, region *core.RegionInfo) bool {
+func isRegionPlacementRuleSatisfied(cluster sche.SharedCluster, region *core.RegionInfo) bool {
 	return cluster.GetRuleManager().FitRegion(cluster, region).IsSatisfied()
 }
 
-func isRegionReplicasSatisfied(cluster sche.ScheduleCluster, region *core.RegionInfo) bool {
-	return len(region.GetLearners()) == 0 && len(region.GetPeers()) == cluster.GetOpts().GetMaxReplicas()
+func isRegionReplicasSatisfied(cluster sche.SharedCluster, region *core.RegionInfo) bool {
+	return len(region.GetLearners()) == 0 && len(region.GetPeers()) == cluster.GetSharedConfig().GetMaxReplicas()
 }

--- a/pkg/schedule/filter/region_filters.go
+++ b/pkg/schedule/filter/region_filters.go
@@ -100,12 +100,12 @@ func (f *regionDownFilter) Select(region *core.RegionInfo) *plan.Status {
 
 // RegionReplicatedFilter filters all unreplicated regions.
 type RegionReplicatedFilter struct {
-	cluster sche.ScheduleCluster
+	cluster sche.SharedCluster
 	fit     *placement.RegionFit
 }
 
 // NewRegionReplicatedFilter creates a RegionFilter that filters all unreplicated regions.
-func NewRegionReplicatedFilter(cluster sche.ScheduleCluster) RegionFilter {
+func NewRegionReplicatedFilter(cluster sche.SharedCluster) RegionFilter {
 	return &RegionReplicatedFilter{cluster: cluster}
 }
 
@@ -117,7 +117,7 @@ func (f *RegionReplicatedFilter) GetFit() *placement.RegionFit {
 // Select returns Ok if the given region satisfy the replication.
 // it will cache the lasted region fit if the region satisfy the replication.
 func (f *RegionReplicatedFilter) Select(region *core.RegionInfo) *plan.Status {
-	if f.cluster.GetOpts().IsPlacementRulesEnabled() {
+	if f.cluster.GetSharedConfig().IsPlacementRulesEnabled() {
 		fit := f.cluster.GetRuleManager().FitRegion(f.cluster, region)
 		if !fit.IsSatisfied() {
 			return statusRegionNotMatchRule
@@ -132,11 +132,11 @@ func (f *RegionReplicatedFilter) Select(region *core.RegionInfo) *plan.Status {
 }
 
 type regionEmptyFilter struct {
-	cluster sche.ScheduleCluster
+	cluster sche.SharedCluster
 }
 
 // NewRegionEmptyFilter returns creates a RegionFilter that filters all empty regions.
-func NewRegionEmptyFilter(cluster sche.ScheduleCluster) RegionFilter {
+func NewRegionEmptyFilter(cluster sche.SharedCluster) RegionFilter {
 	return &regionEmptyFilter{cluster: cluster}
 }
 
@@ -148,7 +148,7 @@ func (f *regionEmptyFilter) Select(region *core.RegionInfo) *plan.Status {
 }
 
 // isEmptyRegionAllowBalance returns true if the region is not empty or the number of regions is too small.
-func isEmptyRegionAllowBalance(cluster sche.ScheduleCluster, region *core.RegionInfo) bool {
+func isEmptyRegionAllowBalance(cluster sche.SharedCluster, region *core.RegionInfo) bool {
 	return region.GetApproximateSize() > core.EmptyRegionApproximateSize || cluster.GetTotalRegionCount() < core.InitClusterRegionThreshold
 }
 

--- a/pkg/schedule/operator/create_operator.go
+++ b/pkg/schedule/operator/create_operator.go
@@ -31,35 +31,35 @@ import (
 )
 
 // CreateAddPeerOperator creates an operator that adds a new peer.
-func CreateAddPeerOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, peer *metapb.Peer, kind OpKind) (*Operator, error) {
+func CreateAddPeerOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, peer *metapb.Peer, kind OpKind) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		AddPeer(peer).
 		Build(kind)
 }
 
 // CreateDemoteVoterOperator creates an operator that demotes a voter
-func CreateDemoteVoterOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+func CreateDemoteVoterOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		DemoteVoter(peer.GetStoreId()).
 		Build(0)
 }
 
 // CreatePromoteLearnerOperator creates an operator that promotes a learner.
-func CreatePromoteLearnerOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+func CreatePromoteLearnerOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		PromoteLearner(peer.GetStoreId()).
 		Build(0)
 }
 
 // CreateRemovePeerOperator creates an operator that removes a peer from region.
-func CreateRemovePeerOperator(desc string, ci sche.ScheduleCluster, kind OpKind, region *core.RegionInfo, storeID uint64) (*Operator, error) {
+func CreateRemovePeerOperator(desc string, ci sche.SharedCluster, kind OpKind, region *core.RegionInfo, storeID uint64) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		RemovePeer(storeID).
 		Build(kind)
 }
 
 // CreateTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store.
-func CreateTransferLeaderOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, targetStoreIDs []uint64, kind OpKind) (*Operator, error) {
+func CreateTransferLeaderOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, targetStoreIDs []uint64, kind OpKind) (*Operator, error) {
 	return NewBuilder(desc, ci, region, SkipOriginJointStateCheck).
 		SetLeader(targetStoreID).
 		SetLeaders(targetStoreIDs).
@@ -67,7 +67,7 @@ func CreateTransferLeaderOperator(desc string, ci sche.ScheduleCluster, region *
 }
 
 // CreateForceTransferLeaderOperator creates an operator that transfers the leader from a source store to a target store forcible.
-func CreateForceTransferLeaderOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
+func CreateForceTransferLeaderOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64, kind OpKind) (*Operator, error) {
 	return NewBuilder(desc, ci, region, SkipOriginJointStateCheck, SkipPlacementRulesCheck).
 		SetLeader(targetStoreID).
 		EnableForceTargetLeader().
@@ -75,7 +75,7 @@ func CreateForceTransferLeaderOperator(desc string, ci sche.ScheduleCluster, reg
 }
 
 // CreateMoveRegionOperator creates an operator that moves a region to specified stores.
-func CreateMoveRegionOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, kind OpKind, roles map[uint64]placement.PeerRoleType) (*Operator, error) {
+func CreateMoveRegionOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, kind OpKind, roles map[uint64]placement.PeerRoleType) (*Operator, error) {
 	// construct the peers from roles
 	oldPeers := region.GetPeers()
 	peers := make(map[uint64]*metapb.Peer)
@@ -97,7 +97,7 @@ func CreateMoveRegionOperator(desc string, ci sche.ScheduleCluster, region *core
 }
 
 // CreateMovePeerOperator creates an operator that replaces an old peer with a new peer.
-func CreateMovePeerOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
+func CreateMovePeerOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
@@ -105,7 +105,7 @@ func CreateMovePeerOperator(desc string, ci sche.ScheduleCluster, region *core.R
 }
 
 // CreateMoveWitnessOperator creates an operator that replaces an old witness with a new witness.
-func CreateMoveWitnessOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64) (*Operator, error) {
+func CreateMoveWitnessOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, sourceStoreID uint64, targetStoreID uint64) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		BecomeNonWitness(sourceStoreID).
 		BecomeWitness(targetStoreID).
@@ -113,7 +113,7 @@ func CreateMoveWitnessOperator(desc string, ci sche.ScheduleCluster, region *cor
 }
 
 // CreateReplaceLeaderPeerOperator creates an operator that replaces an old peer with a new peer, and move leader from old store firstly.
-func CreateReplaceLeaderPeerOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer, leader *metapb.Peer) (*Operator, error) {
+func CreateReplaceLeaderPeerOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer, leader *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
@@ -122,7 +122,7 @@ func CreateReplaceLeaderPeerOperator(desc string, ci sche.ScheduleCluster, regio
 }
 
 // CreateMoveLeaderOperator creates an operator that replaces an old leader with a new leader.
-func CreateMoveLeaderOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
+func CreateMoveLeaderOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, kind OpKind, oldStore uint64, peer *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		RemovePeer(oldStore).
 		AddPeer(peer).
@@ -157,7 +157,7 @@ func CreateSplitRegionOperator(desc string, region *core.RegionInfo, kind OpKind
 }
 
 // CreateMergeRegionOperator creates an operator that merge two region into one.
-func CreateMergeRegionOperator(desc string, ci sche.ScheduleCluster, source *core.RegionInfo, target *core.RegionInfo, kind OpKind) ([]*Operator, error) {
+func CreateMergeRegionOperator(desc string, ci sche.SharedCluster, source *core.RegionInfo, target *core.RegionInfo, kind OpKind) ([]*Operator, error) {
 	if core.IsInJointState(source.GetPeers()...) || core.IsInJointState(target.GetPeers()...) {
 		return nil, errors.Errorf("cannot merge regions which are in joint state")
 	}
@@ -215,7 +215,7 @@ func isRegionMatch(a, b *core.RegionInfo) bool {
 }
 
 // CreateScatterRegionOperator creates an operator that scatters the specified region.
-func CreateScatterRegionOperator(desc string, ci sche.ScheduleCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64) (*Operator, error) {
+func CreateScatterRegionOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64) (*Operator, error) {
 	// randomly pick a leader.
 	var ids []uint64
 	for id, peer := range targetPeers {
@@ -243,7 +243,7 @@ func CreateScatterRegionOperator(desc string, ci sche.ScheduleCluster, origin *c
 const OpDescLeaveJointState = "leave-joint-state"
 
 // CreateLeaveJointStateOperator creates an operator that let region leave joint state.
-func CreateLeaveJointStateOperator(desc string, ci sche.ScheduleCluster, origin *core.RegionInfo) (*Operator, error) {
+func CreateLeaveJointStateOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo) (*Operator, error) {
 	b := NewBuilder(desc, ci, origin, SkipOriginJointStateCheck, SkipPlacementRulesCheck)
 
 	if b.err == nil && !core.IsInJointState(origin.GetPeers()...) {
@@ -303,14 +303,14 @@ func CreateLeaveJointStateOperator(desc string, ci sche.ScheduleCluster, origin 
 }
 
 // CreateWitnessPeerOperator creates an operator that set a follower or learner peer with witness
-func CreateWitnessPeerOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+func CreateWitnessPeerOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		BecomeWitness(peer.GetStoreId()).
 		Build(OpWitness)
 }
 
 // CreateNonWitnessPeerOperator creates an operator that set a peer with non-witness
-func CreateNonWitnessPeerOperator(desc string, ci sche.ScheduleCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
+func CreateNonWitnessPeerOperator(desc string, ci sche.SharedCluster, region *core.RegionInfo, peer *metapb.Peer) (*Operator, error) {
 	return NewBuilder(desc, ci, region).
 		BecomeNonWitness(peer.GetStoreId()).
 		Build(OpWitness)

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -56,7 +56,7 @@ var (
 type Controller struct {
 	syncutil.RWMutex
 	ctx             context.Context
-	config          config.Config
+	config          config.SharedConfig
 	cluster         *core.BasicCluster
 	operators       map[uint64]*Operator
 	hbStreams       *hbstream.HeartbeatStreams
@@ -69,7 +69,7 @@ type Controller struct {
 }
 
 // NewController creates a Controller.
-func NewController(ctx context.Context, cluster *core.BasicCluster, config config.Config, hbStreams *hbstream.HeartbeatStreams) *Controller {
+func NewController(ctx context.Context, cluster *core.BasicCluster, config config.SharedConfig, hbStreams *hbstream.HeartbeatStreams) *Controller {
 	return &Controller{
 		ctx:             ctx,
 		cluster:         cluster,

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -59,7 +59,7 @@ func (suite *operatorControllerTestSuite) TestCacheInfluence() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	bc := tc.GetBasicCluster()
-	oc := NewController(suite.ctx, bc, tc.GetOpts(), nil)
+	oc := NewController(suite.ctx, bc, tc.GetSharedConfig(), nil)
 	tc.AddLeaderStore(2, 1)
 	region := tc.AddLeaderRegion(1, 1, 2)
 
@@ -91,7 +91,7 @@ func (suite *operatorControllerTestSuite) TestCacheInfluence() {
 func (suite *operatorControllerTestSuite) TestGetOpInfluence() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), nil)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), nil)
 	tc.AddLeaderStore(2, 1)
 	tc.AddLeaderRegion(1, 1, 2)
 	tc.AddLeaderRegion(2, 1, 2)
@@ -134,7 +134,7 @@ func (suite *operatorControllerTestSuite) TestOperatorStatus() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.AddLeaderStore(1, 2)
 	tc.AddLeaderStore(2, 0)
 	tc.AddLeaderRegion(1, 1, 2)
@@ -169,7 +169,7 @@ func (suite *operatorControllerTestSuite) TestFastFailOperator() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.AddLeaderStore(1, 2)
 	tc.AddLeaderStore(2, 0)
 	tc.AddLeaderStore(3, 0)
@@ -203,7 +203,7 @@ func (suite *operatorControllerTestSuite) TestFastFailWithUnhealthyStore() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.AddLeaderStore(1, 2)
 	tc.AddLeaderStore(2, 0)
 	tc.AddLeaderStore(3, 0)
@@ -223,7 +223,7 @@ func (suite *operatorControllerTestSuite) TestCheckAddUnexpectedStatus() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.AddLeaderStore(1, 0)
 	tc.AddLeaderStore(2, 1)
 	tc.AddLeaderRegion(1, 2, 1)
@@ -288,7 +288,7 @@ func (suite *operatorControllerTestSuite) TestConcurrentRemoveOperator() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.AddLeaderStore(1, 0)
 	tc.AddLeaderStore(2, 1)
 	tc.AddLeaderRegion(1, 2, 1)
@@ -329,7 +329,7 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegion() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.AddLeaderStore(1, 2)
 	tc.AddLeaderStore(2, 1)
 	tc.AddLeaderRegion(1, 1, 2)
@@ -402,7 +402,7 @@ func (suite *operatorControllerTestSuite) TestStoreLimit() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.AddLeaderStore(1, 0)
 	tc.UpdateLeaderCount(1, 1000)
 	tc.AddLeaderStore(2, 0)
@@ -469,7 +469,7 @@ func (suite *operatorControllerTestSuite) TestStoreLimit() {
 func (suite *operatorControllerTestSuite) TestDispatchOutdatedRegion() {
 	cluster := mockcluster.NewCluster(suite.ctx, mockconfig.NewTestOptions())
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster.ID, cluster, false /* no need to run */)
-	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetOpts(), stream)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
 
 	cluster.AddLeaderStore(1, 2)
 	cluster.AddLeaderStore(2, 0)
@@ -519,7 +519,7 @@ func (suite *operatorControllerTestSuite) TestDispatchOutdatedRegion() {
 func (suite *operatorControllerTestSuite) TestCalcInfluence() {
 	cluster := mockcluster.NewCluster(suite.ctx, mockconfig.NewTestOptions())
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster.ID, cluster, false /* no need to run */)
-	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetOpts(), stream)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
 
 	epoch := &metapb.RegionEpoch{ConfVer: 0, Version: 0}
 	region := cluster.MockRegionInfo(1, 1, []uint64{2}, []uint64{}, epoch)
@@ -596,7 +596,7 @@ func (suite *operatorControllerTestSuite) TestCalcInfluence() {
 func (suite *operatorControllerTestSuite) TestDispatchUnfinishedStep() {
 	cluster := mockcluster.NewCluster(suite.ctx, mockconfig.NewTestOptions())
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster.ID, cluster, false /* no need to run */)
-	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetOpts(), stream)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
 
 	// Create a new region with epoch(0, 0)
 	// the region has two peers with its peer id allocated incrementally.
@@ -733,7 +733,7 @@ func (suite *operatorControllerTestSuite) TestAddWaitingOperator() {
 	opts := mockconfig.NewTestOptions()
 	cluster := mockcluster.NewCluster(suite.ctx, opts)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster.ID, cluster, false /* no need to run */)
-	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetOpts(), stream)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
 	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
 	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
 	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
@@ -802,7 +802,7 @@ func (suite *operatorControllerTestSuite) TestInvalidStoreId() {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, tc.ID, tc, false /* no need to run */)
-	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := NewController(suite.ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// If PD and store 3 are gone, PD will not have info of store 3 after recreating it.
 	tc.AddRegionStore(1, 1)
 	tc.AddRegionStore(2, 1)

--- a/pkg/schedule/operator/step.go
+++ b/pkg/schedule/operator/step.go
@@ -54,7 +54,7 @@ type OpStep interface {
 	fmt.Stringer
 	ConfVerChanged(region *core.RegionInfo) uint64
 	IsFinish(region *core.RegionInfo) bool
-	CheckInProgress(ci *core.BasicCluster, config config.Config, region *core.RegionInfo) error
+	CheckInProgress(ci *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error
 	Influence(opInfluence OpInfluence, region *core.RegionInfo)
 	Timeout(regionSize int64) time.Duration
 	GetCmd(region *core.RegionInfo, useConfChangeV2 bool) *pdpb.RegionHeartbeatResponse
@@ -88,7 +88,7 @@ func (tl TransferLeader) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (tl TransferLeader) CheckInProgress(ci *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (tl TransferLeader) CheckInProgress(ci *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	errList := make([]error, 0, len(tl.ToStores)+1)
 	for _, storeID := range append(tl.ToStores, tl.ToStore) {
 		peer := region.GetStorePeer(tl.ToStore)
@@ -193,7 +193,7 @@ func (ap AddPeer) Influence(opInfluence OpInfluence, region *core.RegionInfo) {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (ap AddPeer) CheckInProgress(ci *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (ap AddPeer) CheckInProgress(ci *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	if err := validateStore(ci, config, ap.ToStore); err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func (bw BecomeWitness) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (bw BecomeWitness) CheckInProgress(ci *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (bw BecomeWitness) CheckInProgress(ci *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	if err := validateStore(ci, config, bw.StoreID); err != nil {
 		return err
 	}
@@ -309,7 +309,7 @@ func (bn BecomeNonWitness) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (bn BecomeNonWitness) CheckInProgress(ci *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (bn BecomeNonWitness) CheckInProgress(ci *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	if err := validateStore(ci, config, bn.StoreID); err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func (bsw BatchSwitchWitness) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (bsw BatchSwitchWitness) CheckInProgress(ci *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (bsw BatchSwitchWitness) CheckInProgress(ci *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	for _, w := range bsw.ToWitnesses {
 		if err := w.CheckInProgress(ci, config, region); err != nil {
 			return err
@@ -478,7 +478,7 @@ func (al AddLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (al AddLearner) CheckInProgress(ci *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (al AddLearner) CheckInProgress(ci *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	if err := validateStore(ci, config, al.ToStore); err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func (pl PromoteLearner) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (pl PromoteLearner) CheckInProgress(_ *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (pl PromoteLearner) CheckInProgress(_ *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	peer := region.GetStorePeer(pl.ToStore)
 	if peer.GetId() != pl.PeerID {
 		return errors.New("peer does not exist")
@@ -615,7 +615,7 @@ func (rp RemovePeer) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (rp RemovePeer) CheckInProgress(_ *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (rp RemovePeer) CheckInProgress(_ *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	if rp.FromStore == region.GetLeader().GetStoreId() {
 		return errors.New("cannot remove leader peer")
 	}
@@ -685,7 +685,7 @@ func (mr MergeRegion) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (mr MergeRegion) CheckInProgress(_ *core.BasicCluster, config config.Config, _ *core.RegionInfo) error {
+func (mr MergeRegion) CheckInProgress(_ *core.BasicCluster, config config.SharedConfig, _ *core.RegionInfo) error {
 	return nil
 }
 
@@ -753,7 +753,7 @@ func (sr SplitRegion) Influence(opInfluence OpInfluence, region *core.RegionInfo
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (sr SplitRegion) CheckInProgress(_ *core.BasicCluster, config config.Config, _ *core.RegionInfo) error {
+func (sr SplitRegion) CheckInProgress(_ *core.BasicCluster, config config.SharedConfig, _ *core.RegionInfo) error {
 	return nil
 }
 
@@ -878,7 +878,7 @@ func (cpe ChangePeerV2Enter) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpe ChangePeerV2Enter) CheckInProgress(_ *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (cpe ChangePeerV2Enter) CheckInProgress(_ *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	inJointState, notInJointState := false, false
 	for _, pl := range cpe.PromoteLearners {
 		peer := region.GetStorePeer(pl.ToStore)
@@ -1007,7 +1007,7 @@ func (cpl ChangePeerV2Leave) IsFinish(region *core.RegionInfo) bool {
 }
 
 // CheckInProgress checks if the step is in the progress of advancing.
-func (cpl ChangePeerV2Leave) CheckInProgress(_ *core.BasicCluster, config config.Config, region *core.RegionInfo) error {
+func (cpl ChangePeerV2Leave) CheckInProgress(_ *core.BasicCluster, config config.SharedConfig, region *core.RegionInfo) error {
 	inJointState, notInJointState, demoteLeader := false, false, false
 	leaderStoreID := region.GetLeader().GetStoreId()
 
@@ -1085,7 +1085,7 @@ func (cpl ChangePeerV2Leave) GetCmd(region *core.RegionInfo, useConfChangeV2 boo
 	}
 }
 
-func validateStore(ci *core.BasicCluster, config config.Config, id uint64) error {
+func validateStore(ci *core.BasicCluster, config config.SharedConfig, id uint64) error {
 	store := ci.GetStore(id)
 	if store == nil {
 		return errors.New("target store does not exist")

--- a/pkg/schedule/operator/step_test.go
+++ b/pkg/schedule/operator/step_test.go
@@ -566,7 +566,7 @@ func (suite *operatorStepTestSuite) check(step OpStep, desc string, testCases []
 		region := core.NewRegionInfo(&metapb.Region{Id: 1, Peers: testCase.Peers}, testCase.Peers[0])
 		suite.Equal(testCase.ConfVerChanged, step.ConfVerChanged(region))
 		suite.Equal(testCase.IsFinish, step.IsFinish(region))
-		err := step.CheckInProgress(suite.cluster.GetBasicCluster(), suite.cluster.GetOpts(), region)
+		err := step.CheckInProgress(suite.cluster.GetBasicCluster(), suite.cluster.GetSharedConfig(), region)
 		testCase.CheckInProgress(err)
 		_ = step.GetCmd(region, true)
 

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -50,11 +50,11 @@ type RuleManager struct {
 	keyType          string
 	storeSetInformer core.StoreSetInformer
 	cache            *RegionRuleFitCacheManager
-	conf             config.Config
+	conf             config.SharedConfig
 }
 
 // NewRuleManager creates a RuleManager instance.
-func NewRuleManager(storage endpoint.RuleStorage, storeSetInformer core.StoreSetInformer, conf config.Config) *RuleManager {
+func NewRuleManager(storage endpoint.RuleStorage, storeSetInformer core.StoreSetInformer, conf config.SharedConfig) *RuleManager {
 	return &RuleManager{
 		storage:          storage,
 		storeSetInformer: storeSetInformer,

--- a/pkg/schedule/scatter/region_scatterer_test.go
+++ b/pkg/schedule/scatter/region_scatterer_test.go
@@ -91,7 +91,7 @@ func scatter(re *require.Assertions, numStores, numRegions uint64, useRules bool
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 
 	// Add ordinary stores.
@@ -148,7 +148,7 @@ func scatterSpecial(re *require.Assertions, numOrdinaryStores, numSpecialStores,
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 
 	// Add ordinary stores.
@@ -226,7 +226,7 @@ func TestStoreLimit(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 
 	// Add stores 1~6.
 	for i := uint64(1); i <= 5; i++ {
@@ -258,7 +258,7 @@ func TestScatterCheck(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 5 stores.
 	for i := uint64(1); i <= 5; i++ {
 		tc.AddRegionStore(i, 0)
@@ -307,7 +307,7 @@ func TestSomeStoresFilteredScatterGroupInConcurrency(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 5 connected stores.
 	for i := uint64(1); i <= 5; i++ {
 		tc.AddRegionStore(i, 0)
@@ -352,7 +352,7 @@ func TestScatterGroupInConcurrency(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 5 stores.
 	for i := uint64(1); i <= 5; i++ {
 		tc.AddRegionStore(i, 0)
@@ -424,7 +424,7 @@ func TestScatterForManyRegion(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 60 stores.
 	for i := uint64(1); i <= 60; i++ {
 		tc.AddRegionStore(i, 0)
@@ -452,7 +452,7 @@ func TestScattersGroup(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 5 stores.
 	for i := uint64(1); i <= 5; i++ {
 		tc.AddRegionStore(i, 0)
@@ -541,7 +541,7 @@ func TestRegionFromDifferentGroups(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 6 stores.
 	storeCount := 6
 	for i := uint64(1); i <= uint64(storeCount); i++ {
@@ -577,7 +577,7 @@ func TestRegionHasLearner(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 8 stores.
 	voterCount := uint64(6)
 	storeCount := uint64(8)
@@ -665,7 +665,7 @@ func TestSelectedStoresTooFewPeers(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 4 stores.
 	for i := uint64(1); i <= 4; i++ {
 		tc.AddRegionStore(i, 0)
@@ -702,7 +702,7 @@ func TestSelectedStoresTooManyPeers(t *testing.T) {
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 4 stores.
 	for i := uint64(1); i <= 5; i++ {
 		tc.AddRegionStore(i, 0)
@@ -740,7 +740,7 @@ func TestBalanceRegion(t *testing.T) {
 	opt.SetLocationLabels([]string{"host"})
 	tc := mockcluster.NewCluster(ctx, opt)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	// Add 6 stores in 3 hosts.
 	for i := uint64(2); i <= 7; i++ {
 		tc.AddLabelsStore(i, 0, map[string]string{"host": strconv.FormatUint(i/2, 10)})

--- a/pkg/schedule/schedulers/balance_benchmark_test.go
+++ b/pkg/schedule/schedulers/balance_benchmark_test.go
@@ -46,7 +46,7 @@ func newBenchCluster(ruleEnable, labelEnable bool, tombstoneEnable bool) (contex
 	ctx, cancel := context.WithCancel(context.Background())
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), nil)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), nil)
 	opt.GetScheduleConfig().TolerantSizeRatio = float64(storeCount)
 	opt.SetPlacementRuleEnabled(ruleEnable)
 
@@ -95,7 +95,7 @@ func newBenchBigCluster(storeNumInOneRack, regionNum int) (context.CancelFunc, *
 	ctx, cancel := context.WithCancel(context.Background())
 	opt := mockconfig.NewTestOptions()
 	tc := mockcluster.NewCluster(ctx, opt)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), nil)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), nil)
 	opt.GetScheduleConfig().TolerantSizeRatio = float64(storeCount)
 	opt.SetPlacementRuleEnabled(true)
 

--- a/pkg/schedule/schedulers/balance_test.go
+++ b/pkg/schedule/schedulers/balance_test.go
@@ -229,7 +229,7 @@ type balanceLeaderSchedulerTestSuite struct {
 	tc     *mockcluster.Cluster
 	lb     Scheduler
 	oc     *operator.Controller
-	conf   config.Config
+	conf   config.SchedulerConfig
 }
 
 func TestBalanceLeaderSchedulerTestSuite(t *testing.T) {

--- a/pkg/schedule/schedulers/balance_witness_test.go
+++ b/pkg/schedule/schedulers/balance_witness_test.go
@@ -36,7 +36,7 @@ type balanceWitnessSchedulerTestSuite struct {
 	tc     *mockcluster.Cluster
 	lb     Scheduler
 	oc     *operator.Controller
-	conf   config.Config
+	conf   config.SchedulerConfig
 }
 
 func (suite *balanceWitnessSchedulerTestSuite) SetupTest() {

--- a/pkg/schedule/schedulers/base_scheduler.go
+++ b/pkg/schedule/schedulers/base_scheduler.go
@@ -88,7 +88,7 @@ func (s *BaseScheduler) GetNextInterval(interval time.Duration) time.Duration {
 }
 
 // Prepare does some prepare work
-func (s *BaseScheduler) Prepare(cluster sche.ScheduleCluster) error { return nil }
+func (s *BaseScheduler) Prepare(cluster sche.SchedulerCluster) error { return nil }
 
 // Cleanup does some cleanup work
-func (s *BaseScheduler) Cleanup(cluster sche.ScheduleCluster) {}
+func (s *BaseScheduler) Cleanup(cluster sche.SchedulerCluster) {}

--- a/pkg/schedule/schedulers/diagnostic_recorder.go
+++ b/pkg/schedule/schedulers/diagnostic_recorder.go
@@ -54,13 +54,13 @@ var DiagnosableSummaryFunc = map[string]plan.Summary{
 // DiagnosticRecorder is used to manage diagnostic for one scheduler.
 type DiagnosticRecorder struct {
 	schedulerName string
-	config        sc.Config
+	config        sc.SchedulerConfig
 	summaryFunc   plan.Summary
 	results       *cache.FIFO
 }
 
 // NewDiagnosticRecorder creates a new DiagnosticRecorder.
-func NewDiagnosticRecorder(name string, config sc.Config) *DiagnosticRecorder {
+func NewDiagnosticRecorder(name string, config sc.SchedulerConfig) *DiagnosticRecorder {
 	summaryFunc, ok := DiagnosableSummaryFunc[name]
 	if !ok {
 		return nil

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -109,7 +109,7 @@ func (s *evictSlowStoreScheduler) EncodeConfig() ([]byte, error) {
 	return EncodeConfig(s.conf)
 }
 
-func (s *evictSlowStoreScheduler) Prepare(cluster sche.ScheduleCluster) error {
+func (s *evictSlowStoreScheduler) Prepare(cluster sche.SchedulerCluster) error {
 	evictStore := s.conf.evictStore()
 	if evictStore != 0 {
 		return cluster.SlowStoreEvicted(evictStore)
@@ -117,11 +117,11 @@ func (s *evictSlowStoreScheduler) Prepare(cluster sche.ScheduleCluster) error {
 	return nil
 }
 
-func (s *evictSlowStoreScheduler) Cleanup(cluster sche.ScheduleCluster) {
+func (s *evictSlowStoreScheduler) Cleanup(cluster sche.SchedulerCluster) {
 	s.cleanupEvictLeader(cluster)
 }
 
-func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster sche.ScheduleCluster, storeID uint64) error {
+func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster sche.SchedulerCluster, storeID uint64) error {
 	err := s.conf.setStoreAndPersist(storeID)
 	if err != nil {
 		log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64("store-id", storeID))
@@ -131,7 +131,7 @@ func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster sche.ScheduleCluste
 	return cluster.SlowStoreEvicted(storeID)
 }
 
-func (s *evictSlowStoreScheduler) cleanupEvictLeader(cluster sche.ScheduleCluster) {
+func (s *evictSlowStoreScheduler) cleanupEvictLeader(cluster sche.SchedulerCluster) {
 	evictSlowStore, err := s.conf.clearAndPersist()
 	if err != nil {
 		log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64("store-id", evictSlowStore))
@@ -142,13 +142,13 @@ func (s *evictSlowStoreScheduler) cleanupEvictLeader(cluster sche.ScheduleCluste
 	cluster.SlowStoreRecovered(evictSlowStore)
 }
 
-func (s *evictSlowStoreScheduler) schedulerEvictLeader(cluster sche.ScheduleCluster) []*operator.Operator {
+func (s *evictSlowStoreScheduler) schedulerEvictLeader(cluster sche.SchedulerCluster) []*operator.Operator {
 	return scheduleEvictLeaderBatch(s.GetName(), s.GetType(), cluster, s.conf, EvictLeaderBatchSize)
 }
 
-func (s *evictSlowStoreScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
+func (s *evictSlowStoreScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
 	if s.conf.evictStore() != 0 {
-		allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
+		allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetSchedulerConfig().GetLeaderScheduleLimit()
 		if !allowed {
 			operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
 		}
@@ -157,7 +157,7 @@ func (s *evictSlowStoreScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster
 	return true
 }
 
-func (s *evictSlowStoreScheduler) Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (s *evictSlowStoreScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	evictSlowStoreCounter.Inc()
 	var ops []*operator.Operator
 

--- a/pkg/schedule/schedulers/grant_hot_region.go
+++ b/pkg/schedule/schedulers/grant_hot_region.go
@@ -152,9 +152,10 @@ func (s *grantHotRegionScheduler) EncodeConfig() ([]byte, error) {
 
 // IsScheduleAllowed returns whether the scheduler is allowed to schedule.
 // TODO it should check if there is any scheduler such as evict or hot region scheduler
-func (s *grantHotRegionScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
-	regionAllowed := s.OpController.OperatorCount(operator.OpRegion) < cluster.GetOpts().GetRegionScheduleLimit()
-	leaderAllowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
+func (s *grantHotRegionScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
+	conf := cluster.GetSchedulerConfig()
+	regionAllowed := s.OpController.OperatorCount(operator.OpRegion) < conf.GetRegionScheduleLimit()
+	leaderAllowed := s.OpController.OperatorCount(operator.OpLeader) < conf.GetLeaderScheduleLimit()
 	if !regionAllowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpRegion.String()).Inc()
 	}
@@ -226,14 +227,14 @@ func newGrantHotRegionHandler(config *grantHotRegionSchedulerConfig) http.Handle
 	return router
 }
 
-func (s *grantHotRegionScheduler) Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (s *grantHotRegionScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	grantHotRegionCounter.Inc()
 	rw := s.randomRWType()
 	s.prepareForBalance(rw, cluster)
 	return s.dispatch(rw, cluster), nil
 }
 
-func (s *grantHotRegionScheduler) dispatch(typ statistics.RWType, cluster sche.ScheduleCluster) []*operator.Operator {
+func (s *grantHotRegionScheduler) dispatch(typ statistics.RWType, cluster sche.SchedulerCluster) []*operator.Operator {
 	stLoadInfos := s.stLoadInfos[buildResourceType(typ, constant.RegionKind)]
 	infos := make([]*statistics.StoreLoadDetail, len(stLoadInfos))
 	index := 0
@@ -247,7 +248,7 @@ func (s *grantHotRegionScheduler) dispatch(typ statistics.RWType, cluster sche.S
 	return s.randomSchedule(cluster, infos)
 }
 
-func (s *grantHotRegionScheduler) randomSchedule(cluster sche.ScheduleCluster, srcStores []*statistics.StoreLoadDetail) (ops []*operator.Operator) {
+func (s *grantHotRegionScheduler) randomSchedule(cluster sche.SchedulerCluster, srcStores []*statistics.StoreLoadDetail) (ops []*operator.Operator) {
 	isLeader := s.r.Int()%2 == 1
 	for _, srcStore := range srcStores {
 		srcStoreID := srcStore.GetID()
@@ -278,7 +279,7 @@ func (s *grantHotRegionScheduler) randomSchedule(cluster sche.ScheduleCluster, s
 	return nil
 }
 
-func (s *grantHotRegionScheduler) transfer(cluster sche.ScheduleCluster, regionID uint64, srcStoreID uint64, isLeader bool) (op *operator.Operator, err error) {
+func (s *grantHotRegionScheduler) transfer(cluster sche.SchedulerCluster, regionID uint64, srcStoreID uint64, isLeader bool) (op *operator.Operator, err error) {
 	srcRegion := cluster.GetRegion(regionID)
 	if srcRegion == nil || len(srcRegion.GetDownPeers()) != 0 || len(srcRegion.GetPendingPeers()) != 0 {
 		return nil, errs.ErrRegionRuleNotFound
@@ -289,7 +290,7 @@ func (s *grantHotRegionScheduler) transfer(cluster sche.ScheduleCluster, regionI
 		return nil, errs.ErrStoreNotFound
 	}
 	filters := []filter.Filter{
-		filter.NewPlacementSafeguard(s.GetName(), cluster.GetOpts(), cluster.GetBasicCluster(), cluster.GetRuleManager(), srcRegion, srcStore, nil),
+		filter.NewPlacementSafeguard(s.GetName(), cluster.GetSchedulerConfig(), cluster.GetBasicCluster(), cluster.GetRuleManager(), srcRegion, srcStore, nil),
 	}
 
 	destStoreIDs := make([]uint64, 0, len(s.conf.StoreIDs))
@@ -304,7 +305,7 @@ func (s *grantHotRegionScheduler) transfer(cluster sche.ScheduleCluster, regionI
 	}
 	for _, storeID := range candidate {
 		store := cluster.GetStore(storeID)
-		if !filter.Target(cluster.GetOpts(), store, filters) {
+		if !filter.Target(cluster.GetSchedulerConfig(), store, filters) {
 			continue
 		}
 		destStoreIDs = append(destStoreIDs, storeID)

--- a/pkg/schedule/schedulers/grant_leader.go
+++ b/pkg/schedule/schedulers/grant_leader.go
@@ -178,7 +178,7 @@ func (s *grantLeaderScheduler) EncodeConfig() ([]byte, error) {
 	return EncodeConfig(s.conf)
 }
 
-func (s *grantLeaderScheduler) Prepare(cluster sche.ScheduleCluster) error {
+func (s *grantLeaderScheduler) Prepare(cluster sche.SchedulerCluster) error {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	var res error
@@ -190,7 +190,7 @@ func (s *grantLeaderScheduler) Prepare(cluster sche.ScheduleCluster) error {
 	return res
 }
 
-func (s *grantLeaderScheduler) Cleanup(cluster sche.ScheduleCluster) {
+func (s *grantLeaderScheduler) Cleanup(cluster sche.SchedulerCluster) {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	for id := range s.conf.StoreIDWithRanges {
@@ -198,15 +198,15 @@ func (s *grantLeaderScheduler) Cleanup(cluster sche.ScheduleCluster) {
 	}
 }
 
-func (s *grantLeaderScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
-	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
+func (s *grantLeaderScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
+	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetSchedulerConfig().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
 	}
 	return allowed
 }
 
-func (s *grantLeaderScheduler) Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (s *grantLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	grantLeaderCounter.Inc()
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()

--- a/pkg/schedule/schedulers/hot_region_config.go
+++ b/pkg/schedule/schedulers/hot_region_config.go
@@ -446,14 +446,15 @@ func (conf *hotRegionSchedulerConfig) persistLocked() error {
 	return conf.storage.SaveScheduleConfig(HotRegionName, data)
 }
 
-func (conf *hotRegionSchedulerConfig) checkQuerySupport(cluster sche.ScheduleCluster) bool {
-	querySupport := versioninfo.IsFeatureSupported(cluster.GetOpts().GetClusterVersion(), versioninfo.HotScheduleWithQuery)
+func (conf *hotRegionSchedulerConfig) checkQuerySupport(cluster sche.SchedulerCluster) bool {
+	version := cluster.GetSchedulerConfig().GetClusterVersion()
+	querySupport := versioninfo.IsFeatureSupported(version, versioninfo.HotScheduleWithQuery)
 	conf.Lock()
 	defer conf.Unlock()
 	if querySupport != conf.lastQuerySupported {
 		log.Info("query supported changed",
 			zap.Bool("last-query-support", conf.lastQuerySupported),
-			zap.String("cluster-version", cluster.GetOpts().GetClusterVersion().String()),
+			zap.String("cluster-version", version.String()),
 			zap.Reflect("config", conf),
 			zap.Reflect("valid-config", conf.getValidConf()))
 		conf.lastQuerySupported = querySupport

--- a/pkg/schedule/schedulers/range_cluster.go
+++ b/pkg/schedule/schedulers/range_cluster.go
@@ -22,22 +22,22 @@ import (
 
 // rangeCluster isolates the cluster by range.
 type rangeCluster struct {
-	sche.ScheduleCluster
+	sche.SchedulerCluster
 	subCluster        *core.BasicCluster // Collect all regions belong to the range.
 	tolerantSizeRatio float64
 }
 
 // genRangeCluster gets a range cluster by specifying start key and end key.
 // The cluster can only know the regions within [startKey, endKey).
-func genRangeCluster(cluster sche.ScheduleCluster, startKey, endKey []byte) *rangeCluster {
+func genRangeCluster(cluster sche.SchedulerCluster, startKey, endKey []byte) *rangeCluster {
 	subCluster := core.NewBasicCluster()
 	for _, r := range cluster.ScanRegions(startKey, endKey, -1) {
 		origin, overlaps, rangeChanged := subCluster.SetRegion(r)
 		subCluster.UpdateSubTree(r, origin, overlaps, rangeChanged)
 	}
 	return &rangeCluster{
-		ScheduleCluster: cluster,
-		subCluster:      subCluster,
+		SchedulerCluster: cluster,
+		subCluster:       subCluster,
 	}
 }
 
@@ -70,7 +70,7 @@ func (r *rangeCluster) updateStoreInfo(s *core.StoreInfo) *core.StoreInfo {
 
 // GetStore searches for a store by ID.
 func (r *rangeCluster) GetStore(id uint64) *core.StoreInfo {
-	s := r.ScheduleCluster.GetStore(id)
+	s := r.SchedulerCluster.GetStore(id)
 	if s == nil {
 		return nil
 	}
@@ -79,7 +79,7 @@ func (r *rangeCluster) GetStore(id uint64) *core.StoreInfo {
 
 // GetStores returns all Stores in the cluster.
 func (r *rangeCluster) GetStores() []*core.StoreInfo {
-	stores := r.ScheduleCluster.GetStores()
+	stores := r.SchedulerCluster.GetStores()
 	newStores := make([]*core.StoreInfo, 0, len(stores))
 	for _, s := range stores {
 		newStores = append(newStores, r.updateStoreInfo(s))
@@ -97,7 +97,7 @@ func (r *rangeCluster) GetTolerantSizeRatio() float64 {
 	if r.tolerantSizeRatio != 0 {
 		return r.tolerantSizeRatio
 	}
-	return r.ScheduleCluster.GetOpts().GetTolerantSizeRatio()
+	return r.SchedulerCluster.GetSchedulerConfig().GetTolerantSizeRatio()
 }
 
 // RandFollowerRegions returns a random region that has a follower on the store.
@@ -117,7 +117,7 @@ func (r *rangeCluster) GetAverageRegionSize() int64 {
 
 // GetRegionStores returns all stores that contains the region's peer.
 func (r *rangeCluster) GetRegionStores(region *core.RegionInfo) []*core.StoreInfo {
-	stores := r.ScheduleCluster.GetRegionStores(region)
+	stores := r.SchedulerCluster.GetRegionStores(region)
 	newStores := make([]*core.StoreInfo, 0, len(stores))
 	for _, s := range stores {
 		newStores = append(newStores, r.updateStoreInfo(s))
@@ -127,7 +127,7 @@ func (r *rangeCluster) GetRegionStores(region *core.RegionInfo) []*core.StoreInf
 
 // GetFollowerStores returns all stores that contains the region's follower peer.
 func (r *rangeCluster) GetFollowerStores(region *core.RegionInfo) []*core.StoreInfo {
-	stores := r.ScheduleCluster.GetFollowerStores(region)
+	stores := r.SchedulerCluster.GetFollowerStores(region)
 	newStores := make([]*core.StoreInfo, 0, len(stores))
 	for _, s := range stores {
 		newStores = append(newStores, r.updateStoreInfo(s))
@@ -137,7 +137,7 @@ func (r *rangeCluster) GetFollowerStores(region *core.RegionInfo) []*core.StoreI
 
 // GetLeaderStore returns all stores that contains the region's leader peer.
 func (r *rangeCluster) GetLeaderStore(region *core.RegionInfo) *core.StoreInfo {
-	s := r.ScheduleCluster.GetLeaderStore(region)
+	s := r.SchedulerCluster.GetLeaderStore(region)
 	if s != nil {
 		return r.updateStoreInfo(s)
 	}

--- a/pkg/schedule/schedulers/scatter_range.go
+++ b/pkg/schedule/schedulers/scatter_range.go
@@ -168,27 +168,27 @@ func (l *scatterRangeScheduler) EncodeConfig() ([]byte, error) {
 	return EncodeConfig(l.config)
 }
 
-func (l *scatterRangeScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
+func (l *scatterRangeScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
 	return l.allowBalanceLeader(cluster) || l.allowBalanceRegion(cluster)
 }
 
-func (l *scatterRangeScheduler) allowBalanceLeader(cluster sche.ScheduleCluster) bool {
-	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetLeaderScheduleLimit()
+func (l *scatterRangeScheduler) allowBalanceLeader(cluster sche.SchedulerCluster) bool {
+	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetSchedulerConfig().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(l.GetType(), operator.OpLeader.String()).Inc()
 	}
 	return allowed
 }
 
-func (l *scatterRangeScheduler) allowBalanceRegion(cluster sche.ScheduleCluster) bool {
-	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetOpts().GetRegionScheduleLimit()
+func (l *scatterRangeScheduler) allowBalanceRegion(cluster sche.SchedulerCluster) bool {
+	allowed := l.OpController.OperatorCount(operator.OpRange) < cluster.GetSchedulerConfig().GetRegionScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(l.GetType(), operator.OpRegion.String()).Inc()
 	}
 	return allowed
 }
 
-func (l *scatterRangeScheduler) Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (l *scatterRangeScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	scatterRangeCounter.Inc()
 	// isolate a new cluster according to the key range
 	c := genRangeCluster(cluster, l.config.GetStartKey(), l.config.GetEndKey())

--- a/pkg/schedule/schedulers/scheduler.go
+++ b/pkg/schedule/schedulers/scheduler.go
@@ -40,10 +40,10 @@ type Scheduler interface {
 	EncodeConfig() ([]byte, error)
 	GetMinInterval() time.Duration
 	GetNextInterval(interval time.Duration) time.Duration
-	Prepare(cluster sche.ScheduleCluster) error
-	Cleanup(cluster sche.ScheduleCluster)
-	Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan)
-	IsScheduleAllowed(cluster sche.ScheduleCluster) bool
+	Prepare(cluster sche.SchedulerCluster) error
+	Cleanup(cluster sche.SchedulerCluster)
+	Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan)
+	IsScheduleAllowed(cluster sche.SchedulerCluster) bool
 }
 
 // EncodeConfig encode the custom config for each scheduler.

--- a/pkg/schedule/schedulers/scheduler_test.go
+++ b/pkg/schedule/schedulers/scheduler_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/tikv/pd/pkg/versioninfo"
 )
 
-func prepareSchedulersTest(needToRunStream ...bool) (context.CancelFunc, config.Config, *mockcluster.Cluster, *operator.Controller) {
+func prepareSchedulersTest(needToRunStream ...bool) (context.CancelFunc, config.SchedulerConfig, *mockcluster.Cluster, *operator.Controller) {
 	Register()
 	ctx, cancel := context.WithCancel(context.Background())
 	opt := mockconfig.NewTestOptions()
@@ -45,7 +45,7 @@ func prepareSchedulersTest(needToRunStream ...bool) (context.CancelFunc, config.
 	} else {
 		stream = hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, needToRunStream[0])
 	}
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetOpts(), stream)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSchedulerConfig(), stream)
 	return cancel, opt, tc, oc
 }
 

--- a/pkg/schedule/schedulers/shuffle_leader.go
+++ b/pkg/schedule/schedulers/shuffle_leader.go
@@ -78,21 +78,21 @@ func (s *shuffleLeaderScheduler) EncodeConfig() ([]byte, error) {
 	return EncodeConfig(s.conf)
 }
 
-func (s *shuffleLeaderScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
-	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
+func (s *shuffleLeaderScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
+	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetSchedulerConfig().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
 	}
 	return allowed
 }
 
-func (s *shuffleLeaderScheduler) Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (s *shuffleLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	// We shuffle leaders between stores by:
 	// 1. random select a valid store.
 	// 2. transfer a leader to the store.
 	shuffleLeaderCounter.Inc()
 	targetStore := filter.NewCandidates(cluster.GetStores()).
-		FilterTarget(cluster.GetOpts(), nil, nil, s.filters...).
+		FilterTarget(cluster.GetSchedulerConfig(), nil, nil, s.filters...).
 		RandomPick()
 	if targetStore == nil {
 		shuffleLeaderNoTargetStoreCounter.Inc()

--- a/pkg/schedule/schedulers/split_bucket.go
+++ b/pkg/schedule/schedulers/split_bucket.go
@@ -165,7 +165,7 @@ func (s *splitBucketScheduler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 }
 
 // IsScheduleAllowed return true if the sum of executing opSplit operator is less  .
-func (s *splitBucketScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
+func (s *splitBucketScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
 	if !cluster.GetStoreConfig().IsEnableRegionBucket() {
 		splitBucketDisableCounter.Inc()
 		return false
@@ -180,20 +180,20 @@ func (s *splitBucketScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) b
 
 type splitBucketPlan struct {
 	hotBuckets         map[uint64][]*buckets.BucketStat
-	cluster            sche.ScheduleCluster
+	cluster            sche.SchedulerCluster
 	conf               *splitBucketSchedulerConfig
 	hotRegionSplitSize int64
 }
 
 // Schedule return operators if some bucket is too hot.
-func (s *splitBucketScheduler) Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (s *splitBucketScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	splitBucketScheduleCounter.Inc()
 	conf := s.conf.Clone()
 	plan := &splitBucketPlan{
 		conf:               conf,
 		cluster:            cluster,
 		hotBuckets:         cluster.BucketsStats(conf.Degree),
-		hotRegionSplitSize: cluster.GetOpts().GetMaxMovableHotPeerSize(),
+		hotRegionSplitSize: cluster.GetSchedulerConfig().GetMaxMovableHotPeerSize(),
 	}
 	return s.splitBucket(plan), nil
 }

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -74,7 +74,7 @@ type RegionInfo struct {
 // RegionStatistics is used to record the status of regions.
 type RegionStatistics struct {
 	sync.RWMutex
-	conf               sc.Config
+	conf               sc.CheckerConfig
 	stats              map[RegionStatisticType]map[uint64]*RegionInfo
 	offlineStats       map[RegionStatisticType]map[uint64]*core.RegionInfo
 	index              map[uint64]RegionStatisticType
@@ -84,7 +84,7 @@ type RegionStatistics struct {
 }
 
 // NewRegionStatistics creates a new RegionStatistics.
-func NewRegionStatistics(conf sc.Config, ruleManager *placement.RuleManager, storeConfigManager *config.StoreConfigManager) *RegionStatistics {
+func NewRegionStatistics(conf sc.CheckerConfig, ruleManager *placement.RuleManager, storeConfigManager *config.StoreConfigManager) *RegionStatistics {
 	r := &RegionStatistics{
 		conf:               conf,
 		ruleManager:        ruleManager,

--- a/plugin/scheduler_example/evict_leader.go
+++ b/plugin/scheduler_example/evict_leader.go
@@ -186,7 +186,7 @@ func (s *evictLeaderScheduler) EncodeConfig() ([]byte, error) {
 	return schedulers.EncodeConfig(s.conf)
 }
 
-func (s *evictLeaderScheduler) Prepare(cluster sche.ScheduleCluster) error {
+func (s *evictLeaderScheduler) Prepare(cluster sche.SchedulerCluster) error {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	var res error
@@ -198,7 +198,7 @@ func (s *evictLeaderScheduler) Prepare(cluster sche.ScheduleCluster) error {
 	return res
 }
 
-func (s *evictLeaderScheduler) Cleanup(cluster sche.ScheduleCluster) {
+func (s *evictLeaderScheduler) Cleanup(cluster sche.SchedulerCluster) {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 	for id := range s.conf.StoreIDWitRanges {
@@ -206,15 +206,15 @@ func (s *evictLeaderScheduler) Cleanup(cluster sche.ScheduleCluster) {
 	}
 }
 
-func (s *evictLeaderScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
-	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetOpts().GetLeaderScheduleLimit()
+func (s *evictLeaderScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
+	allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetSchedulerConfig().GetLeaderScheduleLimit()
 	if !allowed {
 		operator.OperatorLimitCounter.WithLabelValues(s.GetType(), operator.OpLeader.String()).Inc()
 	}
 	return allowed
 }
 
-func (s *evictLeaderScheduler) Schedule(cluster sche.ScheduleCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
+func (s *evictLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	ops := make([]*operator.Operator, 0, len(s.conf.StoreIDWitRanges))
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
@@ -226,7 +226,7 @@ func (s *evictLeaderScheduler) Schedule(cluster sche.ScheduleCluster, dryRun boo
 			continue
 		}
 		target := filter.NewCandidates(cluster.GetFollowerStores(region)).
-			FilterTarget(cluster.GetOpts(), nil, nil, &filter.StoreStateFilter{ActionScope: EvictLeaderName, TransferLeader: true, OperatorLevel: constant.Urgent}).
+			FilterTarget(cluster.GetSchedulerConfig(), nil, nil, &filter.StoreStateFilter{ActionScope: EvictLeaderName, TransferLeader: true, OperatorLevel: constant.Urgent}).
 			RandomPick()
 		if target == nil {
 			continue

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -196,6 +196,21 @@ func (c *RaftCluster) GetStoreConfig() sc.StoreConfig {
 	return c.storeConfigManager.GetStoreConfig()
 }
 
+// GetCheckerConfig returns the checker config.
+func (c *RaftCluster) GetCheckerConfig() sc.CheckerConfig {
+	return c.GetOpts()
+}
+
+// GetSchedulerConfig returns the scheduler config.
+func (c *RaftCluster) GetSchedulerConfig() sc.SchedulerConfig {
+	return c.GetOpts()
+}
+
+// GetSharedConfig returns the shared config.
+func (c *RaftCluster) GetSharedConfig() sc.SharedConfig {
+	return c.GetOpts()
+}
+
 // LoadClusterStatus loads the cluster status.
 func (c *RaftCluster) LoadClusterStatus() (*Status, error) {
 	bootstrapTime, err := c.loadBootstrapTime()

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -2409,7 +2409,7 @@ func TestCollectMetrics(t *testing.T) {
 	stores := co.GetCluster().GetStores()
 	regionStats := co.GetCluster().RegionWriteStats()
 	status1 := statistics.CollectHotPeerInfos(stores, regionStats)
-	status2 := statistics.GetHotStatus(stores, co.GetCluster().GetStoresLoads(), regionStats, statistics.Write, co.GetCluster().GetOpts().IsTraceRegionFlow())
+	status2 := statistics.GetHotStatus(stores, co.GetCluster().GetStoresLoads(), regionStats, statistics.Write, co.GetCluster().GetSchedulerConfig().IsTraceRegionFlow())
 	for _, s := range status2.AsLeader {
 		s.Stats = nil
 	}
@@ -3391,7 +3391,7 @@ type mockLimitScheduler struct {
 	kind    operator.OpKind
 }
 
-func (s *mockLimitScheduler) IsScheduleAllowed(cluster sche.ScheduleCluster) bool {
+func (s *mockLimitScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
 	return s.counter.OperatorCount(s.kind) < s.limit
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5839.

### What is changed and how does it work?

The PR makes the interface usage more clear. `SchedulerCluster` represents the methods that the schedulers need. `CheckerCluster` represents the methods that the checkers need. `SharedCluster` represents the methods that both schedulers and checkers need. The definitions are the same as config.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
