### PR TITLE
resource_manager: only init the default resource group once

### DIFF
--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -946,10 +946,11 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 	re.NoError(err)
 	servers := suite.cluster.GetServers()
 	re.NoError(suite.cluster.StopAll())
+	serverList := make([]*tests.TestServer, 0, len(servers))
 	for _, s := range servers {
-		err := <-suite.cluster.RunServer(s)
-		re.NoError(err)
+		serverList = append(serverList, s)
 	}
+	re.NoError(suite.cluster.RunServers(serverList))
 	suite.cluster.WaitLeader()
 	newGroups, err := cli.ListResourceGroups(suite.ctx)
 	re.NoError(err)

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -776,6 +776,22 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 				}
 			},
 		},
+		{"default", rmpb.GroupMode_RUMode, false, true,
+			`{"name":"default","mode":1,"r_u_settings":{"r_u":{"settings":{"fill_rate":10000,"burst_limit":-1},"state":{"initialized":false}}},"priority":0,"background_settings":{"job_types":["br"]}}`,
+			func(gs *rmpb.ResourceGroup) {
+				gs.RUSettings = &rmpb.GroupRequestUnitSettings{
+					RU: &rmpb.TokenBucket{
+						Settings: &rmpb.TokenLimitSettings{
+							FillRate:   10000,
+							BurstLimit: -1,
+						},
+					},
+				}
+				gs.BackgroundSettings = &rmpb.BackgroundSettings{
+					JobTypes: []string{"br"},
+				}
+			},
+		},
 	}
 
 	checkErr := func(err error, success bool) {

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -940,6 +940,20 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 			re.Equal(1, len(groups1))
 		}
 	}
+
+	// test restart cluster
+	groups, err := cli.ListResourceGroups(suite.ctx)
+	re.NoError(err)
+	servers := suite.cluster.GetServers()
+	re.NoError(suite.cluster.StopAll())
+	for _, s := range servers {
+		err := <-suite.cluster.RunServer(s)
+		re.NoError(err)
+	}
+	suite.cluster.WaitLeader()
+	newGroups, err := cli.ListResourceGroups(suite.ctx)
+	re.NoError(err)
+	re.Equal(groups, newGroups)
 }
 
 func (suite *resourceManagerClientTestSuite) TestResourceManagerClientFailover() {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6787

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
Only init the default resource group once if it is not exist to avoid reset the existing default group's config.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
