### PR TITLE
statistics: get region info via core cluster inside RegionStatistics

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -796,13 +796,6 @@
           "intervalFactor": 2,
           "legendFormat": "{{type}}",
           "refId": "B"
-        },
-        {
-          "expr": "pd_regions_offline_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"offline-peer-region-count\", instance=\"$instance\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{type}}",
-          "refId": "C"
         }
       ],
       "thresholds": [

--- a/pkg/statistics/metrics.go
+++ b/pkg/statistics/metrics.go
@@ -41,14 +41,6 @@ var (
 			Help:      "Status of the regions.",
 		}, []string{"type"})
 
-	offlineRegionStatusGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "pd",
-			Subsystem: "regions",
-			Name:      "offline_status",
-			Help:      "Status of the offline regions.",
-		}, []string{"type"})
-
 	clusterStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
@@ -190,7 +182,6 @@ func init() {
 	prometheus.MustRegister(hotCacheStatusGauge)
 	prometheus.MustRegister(storeStatusGauge)
 	prometheus.MustRegister(regionStatusGauge)
-	prometheus.MustRegister(offlineRegionStatusGauge)
 	prometheus.MustRegister(clusterStatusGauge)
 	prometheus.MustRegister(placementStatusGauge)
 	prometheus.MustRegister(configStatusGauge)

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -67,7 +67,7 @@ var (
 	regionOversizedRegionCounter     = regionStatusGauge.WithLabelValues("oversized-region-count")
 	regionUndersizedRegionCounter    = regionStatusGauge.WithLabelValues("undersized-region-count")
 	regionWitnessLeaderRegionCounter = regionStatusGauge.WithLabelValues("witness-leader-region-count")
-	offlineOfflinePeerRegionCounter  = offlineRegionStatusGauge.WithLabelValues("offline-peer-region-count")
+	regionOfflinePeerRegionCounter   = offlineRegionStatusGauge.WithLabelValues("offline-peer-region-count")
 )
 
 // RegionInfoWithTS is used to record the extra timestamp status of a region.
@@ -287,7 +287,7 @@ func (r *RegionStatistics) Collect() {
 	regionOversizedRegionCounter.Set(float64(len(r.stats[OversizedRegion])))
 	regionUndersizedRegionCounter.Set(float64(len(r.stats[UndersizedRegion])))
 	regionWitnessLeaderRegionCounter.Set(float64(len(r.stats[WitnessLeader])))
-	offlineOfflinePeerRegionCounter.Set(float64(len(r.offlineStats)))
+	regionOfflinePeerRegionCounter.Set(float64(len(r.offlineStats)))
 }
 
 // Reset resets the metrics of the regions' status.
@@ -301,7 +301,7 @@ func (r *RegionStatistics) Reset() {
 	regionOversizedRegionCounter.Set(0)
 	regionUndersizedRegionCounter.Set(0)
 	regionWitnessLeaderRegionCounter.Set(0)
-	offlineOfflinePeerRegionCounter.Set(0)
+	regionOfflinePeerRegionCounter.Set(0)
 }
 
 // LabelStatistics is the statistics of the level of labels.

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -69,14 +69,12 @@ var (
 	regionExtraPeerRegionCounter     = regionStatusGauge.WithLabelValues("extra-peer-region-count")
 	regionDownPeerRegionCounter      = regionStatusGauge.WithLabelValues("down-peer-region-count")
 	regionPendingPeerRegionCounter   = regionStatusGauge.WithLabelValues("pending-peer-region-count")
+	regionOfflinePeerRegionCounter   = regionStatusGauge.WithLabelValues("offline-peer-region-count")
 	regionLearnerPeerRegionCounter   = regionStatusGauge.WithLabelValues("learner-peer-region-count")
 	regionEmptyRegionCounter         = regionStatusGauge.WithLabelValues("empty-region-count")
 	regionOversizedRegionCounter     = regionStatusGauge.WithLabelValues("oversized-region-count")
 	regionUndersizedRegionCounter    = regionStatusGauge.WithLabelValues("undersized-region-count")
 	regionWitnessLeaderRegionCounter = regionStatusGauge.WithLabelValues("witness-leader-region-count")
-	// In order to maintain historical compatibility, we did not replace it with a unified `regionStatusGauge` metrics,
-	// but kept it so that we don't have to modify the Prometheus query on the Grafana dashboard.
-	regionOfflinePeerRegionCounter = offlineRegionStatusGauge.WithLabelValues("offline-peer-region-count")
 )
 
 // RegionInfoWithTS is used to record the extra timestamp status of a region.
@@ -266,12 +264,12 @@ func (r *RegionStatistics) Collect() {
 	regionExtraPeerRegionCounter.Set(float64(len(r.stats[ExtraPeer])))
 	regionDownPeerRegionCounter.Set(float64(len(r.stats[DownPeer])))
 	regionPendingPeerRegionCounter.Set(float64(len(r.stats[PendingPeer])))
+	regionOfflinePeerRegionCounter.Set(float64(len(r.stats[OfflinePeer])))
 	regionLearnerPeerRegionCounter.Set(float64(len(r.stats[LearnerPeer])))
 	regionEmptyRegionCounter.Set(float64(len(r.stats[EmptyRegion])))
 	regionOversizedRegionCounter.Set(float64(len(r.stats[OversizedRegion])))
 	regionUndersizedRegionCounter.Set(float64(len(r.stats[UndersizedRegion])))
 	regionWitnessLeaderRegionCounter.Set(float64(len(r.stats[WitnessLeader])))
-	regionOfflinePeerRegionCounter.Set(float64(len(r.stats[OfflinePeer])))
 }
 
 // Reset resets the metrics of the regions' status.
@@ -280,12 +278,12 @@ func (r *RegionStatistics) Reset() {
 	regionExtraPeerRegionCounter.Set(0)
 	regionDownPeerRegionCounter.Set(0)
 	regionPendingPeerRegionCounter.Set(0)
+	regionOfflinePeerRegionCounter.Set(0)
 	regionLearnerPeerRegionCounter.Set(0)
 	regionEmptyRegionCounter.Set(0)
 	regionOversizedRegionCounter.Set(0)
 	regionUndersizedRegionCounter.Set(0)
 	regionWitnessLeaderRegionCounter.Set(0)
-	regionOfflinePeerRegionCounter.Set(0)
 }
 
 // LabelStatistics is the statistics of the level of labels.

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -68,15 +68,15 @@ const nonIsolation = "none"
 
 var (
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
-	regionMissPeerRegionCounter       = regionStatusGauge.WithLabelValues("miss-peer-region-count")
-	regionExtraPeerRegionCounter      = regionStatusGauge.WithLabelValues("extra-peer-region-count")
-	regionDownPeerRegionCounter       = regionStatusGauge.WithLabelValues("down-peer-region-count")
-	regionPendingPeerRegionCounter    = regionStatusGauge.WithLabelValues("pending-peer-region-count")
-	regionLearnerPeerRegionCounter    = regionStatusGauge.WithLabelValues("learner-peer-region-count")
-	regionEmptyRegionCounter          = regionStatusGauge.WithLabelValues("empty-region-count")
-	regionOversizedRegionCounter      = regionStatusGauge.WithLabelValues("oversized-region-count")
-	regionUndersizedRegionCounter     = regionStatusGauge.WithLabelValues("undersized-region-count")
-	regionWitnesssLeaderRegionCounter = regionStatusGauge.WithLabelValues("witness-leader-region-count")
+	regionMissPeerRegionCounter      = regionStatusGauge.WithLabelValues("miss-peer-region-count")
+	regionExtraPeerRegionCounter     = regionStatusGauge.WithLabelValues("extra-peer-region-count")
+	regionDownPeerRegionCounter      = regionStatusGauge.WithLabelValues("down-peer-region-count")
+	regionPendingPeerRegionCounter   = regionStatusGauge.WithLabelValues("pending-peer-region-count")
+	regionLearnerPeerRegionCounter   = regionStatusGauge.WithLabelValues("learner-peer-region-count")
+	regionEmptyRegionCounter         = regionStatusGauge.WithLabelValues("empty-region-count")
+	regionOversizedRegionCounter     = regionStatusGauge.WithLabelValues("oversized-region-count")
+	regionUndersizedRegionCounter    = regionStatusGauge.WithLabelValues("undersized-region-count")
+	regionWitnessLeaderRegionCounter = regionStatusGauge.WithLabelValues("witness-leader-region-count")
 
 	offlineMissPeerRegionCounter    = offlineRegionStatusGauge.WithLabelValues("miss-peer-region-count")
 	offlineExtraPeerRegionCounter   = offlineRegionStatusGauge.WithLabelValues("extra-peer-region-count")
@@ -324,7 +324,7 @@ func (r *RegionStatistics) Collect() {
 	regionEmptyRegionCounter.Set(float64(len(r.stats[EmptyRegion])))
 	regionOversizedRegionCounter.Set(float64(len(r.stats[OversizedRegion])))
 	regionUndersizedRegionCounter.Set(float64(len(r.stats[UndersizedRegion])))
-	regionWitnesssLeaderRegionCounter.Set(float64(len(r.stats[WitnessLeader])))
+	regionWitnessLeaderRegionCounter.Set(float64(len(r.stats[WitnessLeader])))
 
 	offlineMissPeerRegionCounter.Set(float64(len(r.offlineStats[MissPeer])))
 	offlineExtraPeerRegionCounter.Set(float64(len(r.offlineStats[ExtraPeer])))
@@ -344,7 +344,7 @@ func (r *RegionStatistics) Reset() {
 	regionEmptyRegionCounter.Set(0)
 	regionOversizedRegionCounter.Set(0)
 	regionUndersizedRegionCounter.Set(0)
-	regionWitnesssLeaderRegionCounter.Set(0)
+	regionWitnessLeaderRegionCounter.Set(0)
 
 	offlineMissPeerRegionCounter.Set(0)
 	offlineExtraPeerRegionCounter.Set(0)

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -65,7 +65,7 @@ func TestRegionStatistics(t *testing.T) {
 	r2 := &metapb.Region{Id: 2, Peers: peers[0:2], StartKey: []byte("cc"), EndKey: []byte("dd")}
 	region1 := core.NewRegionInfo(r1, peers[0])
 	region2 := core.NewRegionInfo(r2, peers[0])
-	regionStats := NewRegionStatistics(opt, manager, nil)
+	regionStats := NewRegionStatistics(nil, opt, manager, nil)
 	regionStats.Observe(region1, stores)
 	re.Len(regionStats.stats[ExtraPeer], 1)
 	re.Len(regionStats.stats[LearnerPeer], 1)
@@ -166,7 +166,7 @@ func TestRegionStatisticsWithPlacementRule(t *testing.T) {
 	region3 := core.NewRegionInfo(r3, peers[0])
 	region4 := core.NewRegionInfo(r4, peers[0])
 	region5 := core.NewRegionInfo(r5, peers[4])
-	regionStats := NewRegionStatistics(opt, manager, nil)
+	regionStats := NewRegionStatistics(nil, opt, manager, nil)
 	// r2 didn't match the rules
 	regionStats.Observe(region2, stores)
 	re.Len(regionStats.stats[MissPeer], 1)

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -71,8 +71,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Len(regionStats.stats[LearnerPeer], 1)
 	re.Len(regionStats.stats[EmptyRegion], 1)
 	re.Len(regionStats.stats[UndersizedRegion], 1)
-	re.Len(regionStats.offlineStats[ExtraPeer], 1)
-	re.Len(regionStats.offlineStats[LearnerPeer], 1)
+	re.Len(regionStats.offlineStats, 1)
 
 	region1 = region1.Clone(
 		core.WithDownPeers(downPeers),
@@ -88,12 +87,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Empty(regionStats.stats[EmptyRegion])
 	re.Len(regionStats.stats[OversizedRegion], 1)
 	re.Empty(regionStats.stats[UndersizedRegion])
-	re.Len(regionStats.offlineStats[ExtraPeer], 1)
-	re.Empty(regionStats.offlineStats[MissPeer])
-	re.Len(regionStats.offlineStats[DownPeer], 1)
-	re.Len(regionStats.offlineStats[PendingPeer], 1)
-	re.Len(regionStats.offlineStats[LearnerPeer], 1)
-	re.Len(regionStats.offlineStats[OfflinePeer], 1)
+	re.Len(regionStats.offlineStats, 1)
 
 	region2 = region2.Clone(core.WithDownPeers(downPeers[0:1]))
 	regionStats.Observe(region2, stores[0:2])
@@ -104,12 +98,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Len(regionStats.stats[LearnerPeer], 1)
 	re.Len(regionStats.stats[OversizedRegion], 1)
 	re.Len(regionStats.stats[UndersizedRegion], 1)
-	re.Len(regionStats.offlineStats[ExtraPeer], 1)
-	re.Empty(regionStats.offlineStats[MissPeer])
-	re.Len(regionStats.offlineStats[DownPeer], 1)
-	re.Len(regionStats.offlineStats[PendingPeer], 1)
-	re.Len(regionStats.offlineStats[LearnerPeer], 1)
-	re.Len(regionStats.offlineStats[OfflinePeer], 1)
+	re.Len(regionStats.offlineStats, 1)
 
 	region1 = region1.Clone(core.WithRemoveStorePeer(7))
 	regionStats.Observe(region1, stores[0:3])
@@ -118,12 +107,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Len(regionStats.stats[DownPeer], 2)
 	re.Len(regionStats.stats[PendingPeer], 1)
 	re.Empty(regionStats.stats[LearnerPeer])
-	re.Empty(regionStats.offlineStats[ExtraPeer])
-	re.Empty(regionStats.offlineStats[MissPeer])
-	re.Empty(regionStats.offlineStats[DownPeer])
-	re.Empty(regionStats.offlineStats[PendingPeer])
-	re.Empty(regionStats.offlineStats[LearnerPeer])
-	re.Empty(regionStats.offlineStats[OfflinePeer])
+	re.Empty(regionStats.offlineStats)
 
 	store3 = stores[3].Clone(core.UpStore())
 	stores[3] = store3

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -71,7 +71,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Len(regionStats.stats[LearnerPeer], 1)
 	re.Len(regionStats.stats[EmptyRegion], 1)
 	re.Len(regionStats.stats[UndersizedRegion], 1)
-	re.Len(regionStats.offlineStats, 1)
+	re.Len(regionStats.stats[OfflinePeer], 1)
 
 	region1 = region1.Clone(
 		core.WithDownPeers(downPeers),
@@ -87,7 +87,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Empty(regionStats.stats[EmptyRegion])
 	re.Len(regionStats.stats[OversizedRegion], 1)
 	re.Empty(regionStats.stats[UndersizedRegion])
-	re.Len(regionStats.offlineStats, 1)
+	re.Len(regionStats.stats[OfflinePeer], 1)
 
 	region2 = region2.Clone(core.WithDownPeers(downPeers[0:1]))
 	regionStats.Observe(region2, stores[0:2])
@@ -98,7 +98,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Len(regionStats.stats[LearnerPeer], 1)
 	re.Len(regionStats.stats[OversizedRegion], 1)
 	re.Len(regionStats.stats[UndersizedRegion], 1)
-	re.Len(regionStats.offlineStats, 1)
+	re.Len(regionStats.stats[OfflinePeer], 1)
 
 	region1 = region1.Clone(core.WithRemoveStorePeer(7))
 	regionStats.Observe(region1, stores[0:3])
@@ -107,7 +107,7 @@ func TestRegionStatistics(t *testing.T) {
 	re.Len(regionStats.stats[DownPeer], 2)
 	re.Len(regionStats.stats[PendingPeer], 1)
 	re.Empty(regionStats.stats[LearnerPeer])
-	re.Empty(regionStats.offlineStats)
+	re.Empty(regionStats.stats[OfflinePeer])
 
 	store3 = stores[3].Clone(core.UpStore())
 	stores[3] = store3

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -455,9 +455,16 @@ func (h *regionsHandler) GetKeyspaceRegions(w http.ResponseWriter, r *http.Reque
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/miss-peer [get]
-func (h *regionsHandler) GetMissPeerRegions(w http.ResponseWriter, r *http.Request) {
+func (h *regionsHandler) GetMissPeerRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.MissPeer)
+}
+
+func (h *regionsHandler) getRegionsByType(
+	w http.ResponseWriter,
+	typ statistics.RegionStatisticType,
+) {
 	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.MissPeer)
+	regions, err := handler.GetRegionsByType(typ)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -472,15 +479,8 @@ func (h *regionsHandler) GetMissPeerRegions(w http.ResponseWriter, r *http.Reque
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/extra-peer [get]
-func (h *regionsHandler) GetExtraPeerRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.ExtraPeer)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetExtraPeerRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.ExtraPeer)
 }
 
 // @Tags     region
@@ -489,15 +489,8 @@ func (h *regionsHandler) GetExtraPeerRegions(w http.ResponseWriter, r *http.Requ
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/pending-peer [get]
-func (h *regionsHandler) GetPendingPeerRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.PendingPeer)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetPendingPeerRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.PendingPeer)
 }
 
 // @Tags     region
@@ -506,15 +499,8 @@ func (h *regionsHandler) GetPendingPeerRegions(w http.ResponseWriter, r *http.Re
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/down-peer [get]
-func (h *regionsHandler) GetDownPeerRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.DownPeer)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetDownPeerRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.DownPeer)
 }
 
 // @Tags     region
@@ -523,15 +509,8 @@ func (h *regionsHandler) GetDownPeerRegions(w http.ResponseWriter, r *http.Reque
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/learner-peer [get]
-func (h *regionsHandler) GetLearnerPeerRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.LearnerPeer)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetLearnerPeerRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.LearnerPeer)
 }
 
 // @Tags     region
@@ -540,15 +519,8 @@ func (h *regionsHandler) GetLearnerPeerRegions(w http.ResponseWriter, r *http.Re
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/offline-peer [get]
-func (h *regionsHandler) GetOfflinePeerRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.OfflinePeer)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetOfflinePeerRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.OfflinePeer)
 }
 
 // @Tags     region
@@ -557,15 +529,8 @@ func (h *regionsHandler) GetOfflinePeerRegions(w http.ResponseWriter, r *http.Re
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/oversized-region [get]
-func (h *regionsHandler) GetOverSizedRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.OversizedRegion)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetOverSizedRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.OversizedRegion)
 }
 
 // @Tags     region
@@ -574,15 +539,8 @@ func (h *regionsHandler) GetOverSizedRegions(w http.ResponseWriter, r *http.Requ
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/undersized-region [get]
-func (h *regionsHandler) GetUndersizedRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.UndersizedRegion)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetUndersizedRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.UndersizedRegion)
 }
 
 // @Tags     region
@@ -591,15 +549,8 @@ func (h *regionsHandler) GetUndersizedRegions(w http.ResponseWriter, r *http.Req
 // @Success  200  {object}  RegionsInfo
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /regions/check/empty-region [get]
-func (h *regionsHandler) GetEmptyRegions(w http.ResponseWriter, r *http.Request) {
-	handler := h.svr.GetHandler()
-	regions, err := handler.GetRegionsByType(statistics.EmptyRegion)
-	if err != nil {
-		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	regionsInfo := convertToAPIRegions(regions)
-	h.rd.JSON(w, http.StatusOK, regionsInfo)
+func (h *regionsHandler) GetEmptyRegions(w http.ResponseWriter, _ *http.Request) {
+	h.getRegionsByType(w, statistics.EmptyRegion)
 }
 
 type histItem struct {

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -542,7 +542,7 @@ func (h *regionsHandler) GetLearnerPeerRegions(w http.ResponseWriter, r *http.Re
 // @Router   /regions/check/offline-peer [get]
 func (h *regionsHandler) GetOfflinePeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	regions, err := handler.GetOfflinePeer(statistics.OfflinePeer)
+	regions, err := handler.GetOfflinePeer()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -542,7 +542,7 @@ func (h *regionsHandler) GetLearnerPeerRegions(w http.ResponseWriter, r *http.Re
 // @Router   /regions/check/offline-peer [get]
 func (h *regionsHandler) GetOfflinePeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	regions, err := handler.GetOfflinePeerRegions()
+	regions, err := handler.GetRegionsByType(statistics.OfflinePeer)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -542,7 +542,7 @@ func (h *regionsHandler) GetLearnerPeerRegions(w http.ResponseWriter, r *http.Re
 // @Router   /regions/check/offline-peer [get]
 func (h *regionsHandler) GetOfflinePeerRegions(w http.ResponseWriter, r *http.Request) {
 	handler := h.svr.GetHandler()
-	regions, err := handler.GetOfflinePeer()
+	regions, err := handler.GetOfflinePeerRegions()
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -320,7 +320,7 @@ func (c *RaftCluster) Start(s Server) error {
 	}
 	c.storeConfigManager = config.NewStoreConfigManager(c.httpClient)
 	c.coordinator = schedule.NewCoordinator(c.ctx, cluster, s.GetHBStreams())
-	c.regionStats = statistics.NewRegionStatistics(c.opt, c.ruleManager, c.storeConfigManager)
+	c.regionStats = statistics.NewRegionStatistics(c.core, c.opt, c.ruleManager, c.storeConfigManager)
 	c.limiter = NewStoreLimiter(s.GetPersistOptions())
 	c.externalTS, err = c.storage.LoadExternalTS()
 	if err != nil {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2129,12 +2129,12 @@ func (c *RaftCluster) GetRegionStatsByType(typ statistics.RegionStatisticType) [
 	return c.regionStats.GetRegionStatsByType(typ)
 }
 
-// GetOfflineRegionStatsByType gets the status of the offline region by types.
-func (c *RaftCluster) GetOfflineRegionStatsByType(typ statistics.RegionStatisticType) []*core.RegionInfo {
+// GetOfflineRegionStats gets the status of the offline region.
+func (c *RaftCluster) GetOfflineRegionStats() []*core.RegionInfo {
 	if c.regionStats == nil {
 		return nil
 	}
-	return c.regionStats.GetOfflineRegionStatsByType(typ)
+	return c.regionStats.GetOfflineRegionStats()
 }
 
 // UpdateRegionsLabelLevelStats updates the status of the region label level by types.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2129,14 +2129,6 @@ func (c *RaftCluster) GetRegionStatsByType(typ statistics.RegionStatisticType) [
 	return c.regionStats.GetRegionStatsByType(typ)
 }
 
-// GetOfflineRegionStats gets the status of the offline region.
-func (c *RaftCluster) GetOfflineRegionStats() []*core.RegionInfo {
-	if c.regionStats == nil {
-		return nil
-	}
-	return c.regionStats.GetOfflineRegionStats()
-}
-
 // UpdateRegionsLabelLevelStats updates the status of the region label level by types.
 func (c *RaftCluster) UpdateRegionsLabelLevelStats(regions []*core.RegionInfo) {
 	for _, region := range regions {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -978,7 +978,11 @@ func TestRegionSizeChanged(t *testing.T) {
 	re.NoError(err)
 	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
 	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
-	cluster.regionStats = statistics.NewRegionStatistics(cluster.GetOpts(), cluster.ruleManager, cluster.storeConfigManager)
+	cluster.regionStats = statistics.NewRegionStatistics(
+		cluster.GetBasicCluster(),
+		cluster.GetOpts(),
+		cluster.ruleManager,
+		cluster.storeConfigManager)
 	region := newTestRegions(1, 3, 3)[0]
 	cluster.opt.GetMaxMergeRegionKeys()
 	curMaxMergeSize := int64(cluster.opt.GetMaxMergeRegionSize())
@@ -1260,7 +1264,11 @@ func TestOfflineAndMerge(t *testing.T) {
 			panic(err)
 		}
 	}
-	cluster.regionStats = statistics.NewRegionStatistics(cluster.GetOpts(), cluster.ruleManager, cluster.storeConfigManager)
+	cluster.regionStats = statistics.NewRegionStatistics(
+		cluster.GetBasicCluster(),
+		cluster.GetOpts(),
+		cluster.ruleManager,
+		cluster.storeConfigManager)
 	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
 
 	// Put 4 stores.
@@ -1514,7 +1522,11 @@ func TestCalculateStoreSize1(t *testing.T) {
 	opt.SetReplicationConfig(cfg)
 	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
 	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
-	cluster.regionStats = statistics.NewRegionStatistics(cluster.GetOpts(), cluster.ruleManager, cluster.storeConfigManager)
+	cluster.regionStats = statistics.NewRegionStatistics(
+		cluster.GetBasicCluster(),
+		cluster.GetOpts(),
+		cluster.ruleManager,
+		cluster.storeConfigManager)
 
 	// Put 10 stores.
 	for i, store := range newTestStores(10, "6.0.0") {
@@ -1597,7 +1609,11 @@ func TestCalculateStoreSize2(t *testing.T) {
 	opt.SetMaxReplicas(3)
 	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
 	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
-	cluster.regionStats = statistics.NewRegionStatistics(cluster.GetOpts(), cluster.ruleManager, cluster.storeConfigManager)
+	cluster.regionStats = statistics.NewRegionStatistics(
+		cluster.GetBasicCluster(),
+		cluster.GetOpts(),
+		cluster.ruleManager,
+		cluster.storeConfigManager)
 
 	// Put 10 stores.
 	for i, store := range newTestStores(10, "6.0.0") {
@@ -2351,7 +2367,11 @@ func TestCollectMetricsConcurrent(t *testing.T) {
 	re := require.New(t)
 
 	tc, co, cleanup := prepare(nil, func(tc *testCluster) {
-		tc.regionStats = statistics.NewRegionStatistics(tc.GetOpts(), nil, tc.storeConfigManager)
+		tc.regionStats = statistics.NewRegionStatistics(
+			tc.GetBasicCluster(),
+			tc.GetOpts(),
+			nil,
+			tc.storeConfigManager)
 	}, func(co *schedule.Coordinator) { co.Run() }, re)
 	defer cleanup()
 
@@ -2383,7 +2403,11 @@ func TestCollectMetrics(t *testing.T) {
 	re := require.New(t)
 
 	tc, co, cleanup := prepare(nil, func(tc *testCluster) {
-		tc.regionStats = statistics.NewRegionStatistics(tc.GetOpts(), nil, tc.storeConfigManager)
+		tc.regionStats = statistics.NewRegionStatistics(
+			tc.GetBasicCluster(),
+			tc.GetOpts(),
+			nil,
+			tc.storeConfigManager)
 	}, func(co *schedule.Coordinator) { co.Run() }, re)
 	defer cleanup()
 	count := 10

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1308,13 +1308,13 @@ func TestOfflineAndMerge(t *testing.T) {
 		regions = core.SplitRegions(regions)
 	}
 	heartbeatRegions(re, cluster, regions)
-	re.Len(cluster.GetOfflineRegionStats(), len(regions))
+	re.Len(cluster.GetRegionStatsByType(statistics.OfflinePeer), len(regions))
 
 	// Merge.
 	for i := 0; i < n; i++ {
 		regions = core.MergeRegions(regions)
 		heartbeatRegions(re, cluster, regions)
-		re.Len(cluster.GetOfflineRegionStats(), len(regions))
+		re.Len(cluster.GetRegionStatsByType(statistics.OfflinePeer), len(regions))
 	}
 }
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1308,13 +1308,13 @@ func TestOfflineAndMerge(t *testing.T) {
 		regions = core.SplitRegions(regions)
 	}
 	heartbeatRegions(re, cluster, regions)
-	re.Len(cluster.GetOfflineRegionStatsByType(statistics.OfflinePeer), len(regions))
+	re.Len(cluster.GetOfflineRegionStats(), len(regions))
 
 	// Merge.
 	for i := 0; i < n; i++ {
 		regions = core.MergeRegions(regions)
 		heartbeatRegions(re, cluster, regions)
-		re.Len(cluster.GetOfflineRegionStatsByType(statistics.OfflinePeer), len(regions))
+		re.Len(cluster.GetOfflineRegionStats(), len(regions))
 	}
 }
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -928,12 +928,12 @@ func (h *Handler) GetSchedulerConfigHandler() (http.Handler, error) {
 }
 
 // GetOfflinePeer gets the region with offline peer.
-func (h *Handler) GetOfflinePeer(typ statistics.RegionStatisticType) ([]*core.RegionInfo, error) {
+func (h *Handler) GetOfflinePeer() ([]*core.RegionInfo, error) {
 	c := h.s.GetRaftCluster()
 	if c == nil {
 		return nil, errs.ErrNotBootstrapped.FastGenByArgs()
 	}
-	return c.GetOfflineRegionStatsByType(typ), nil
+	return c.GetOfflineRegionStats(), nil
 }
 
 // ResetTS resets the ts with specified tso.

--- a/server/handler.go
+++ b/server/handler.go
@@ -927,8 +927,8 @@ func (h *Handler) GetSchedulerConfigHandler() (http.Handler, error) {
 	return mux, nil
 }
 
-// GetOfflinePeer gets the region with offline peer.
-func (h *Handler) GetOfflinePeer() ([]*core.RegionInfo, error) {
+// GetOfflinePeerRegions gets the regions with offline peers.
+func (h *Handler) GetOfflinePeerRegions() ([]*core.RegionInfo, error) {
 	c := h.s.GetRaftCluster()
 	if c == nil {
 		return nil, errs.ErrNotBootstrapped.FastGenByArgs()

--- a/server/handler.go
+++ b/server/handler.go
@@ -927,15 +927,6 @@ func (h *Handler) GetSchedulerConfigHandler() (http.Handler, error) {
 	return mux, nil
 }
 
-// GetOfflinePeerRegions gets the regions with offline peers.
-func (h *Handler) GetOfflinePeerRegions() ([]*core.RegionInfo, error) {
-	c := h.s.GetRaftCluster()
-	if c == nil {
-		return nil, errs.ErrNotBootstrapped.FastGenByArgs()
-	}
-	return c.GetOfflineRegionStats(), nil
-}
-
 // ResetTS resets the ts with specified tso.
 func (h *Handler) ResetTS(ts uint64, ignoreSmaller, skipUpperBoundCheck bool, _ uint32) error {
 	log.Info("reset-ts",


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6560.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Instead of maintaining its own region info cache, use the core cluster to
fetch the region info inside `RegionStatistics` to make sure consistency.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test

Run `pd-ctl region check miss-peer`:

```json
[
  {
      "id": 22,
      "start_key": "7480000000000000FF5C00000000000000F8",
      "end_key": "748000FFFFFFFFFFFFF900000000000000F8",
      "epoch": {
        "conf_ver": 1,
        "version": 56
      },
      "peers": [
        {
          "id": 23,
          "store_id": 1,
          "role_name": "Voter"
        }
      ],
      "leader": {
        "id": 23,
        "store_id": 1,
        "role_name": "Voter"
      },
      "cpu_usage": 0,
      "written_bytes": 204,
      "read_bytes": 0,
      "written_keys": 4,
      "read_keys": 0,
      "approximate_size": 1,
      "approximate_keys": 0
  }
]
```

Run `pd-ctl region 22`:

```json
{
  "id": 22,
  "start_key": "7480000000000000FF5C00000000000000F8",
  "end_key": "748000FFFFFFFFFFFFF900000000000000F8",
  "epoch": {
    "conf_ver": 1,
    "version": 56
  },
  "peers": [
    {
      "id": 23,
      "store_id": 1,
      "role_name": "Voter"
    }
  ],
  "leader": {
    "id": 23,
    "store_id": 1,
    "role_name": "Voter"
  },
  "cpu_usage": 0,
  "written_bytes": 204,
  "read_bytes": 0,
  "written_keys": 4,
  "read_keys": 0,
  "approximate_size": 1,
  "approximate_keys": 0
}
``` 

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
