### PR TITLE
placement: add peer healthy factor when comparing region fit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ static: install-tools
 	@ echo "gofmt ..."
 	@ gofmt -s -l -d $(PACKAGE_DIRECTORIES) 2>&1 | awk '{ print } END { if (NR > 0) { exit 1 } }'
 	@ echo "golangci-lint ..."
-	@ golangci-lint run --verbose $(PACKAGE_DIRECTORIES)
+	@ golangci-lint run --verbose $(PACKAGE_DIRECTORIES) --allow-parallel-runners
 	@ echo "revive ..."
 	@ revive -formatter friendly -config revive.toml $(PACKAGES)
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -34,7 +34,7 @@ static: install-tools
 	@ echo "gofmt ..."
 	@ gofmt -s -l -d . 2>&1 | awk '{ print } END { if (NR > 0) { exit 1 } }'
 	@ echo "golangci-lint ..."
-	@ golangci-lint run -c ../.golangci.yml --verbose ./...
+	@ golangci-lint run -c ../.golangci.yml --verbose ./... --allow-parallel-runners
 	@ echo "revive ..."
 	@ revive -formatter friendly -config ../revive.toml ./...
 

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/docker/go-units"
@@ -294,11 +295,11 @@ func (r *RegionInfo) GetDownPeer(peerID uint64) *metapb.Peer {
 	return nil
 }
 
-// PeerDownTooLong returns if a peer is down for too long.
-func (r *RegionInfo) PeerDownTooLong(peerID uint64) bool {
+// IsPeerDownTooLong returns if a peer is down for too long.
+func (r *RegionInfo) IsPeerDownTooLong(peerID uint64, duration time.Duration) bool {
 	for _, down := range r.downPeers {
 		if down.GetPeer().GetId() == peerID {
-			return down.GetDownSeconds() > uint64(storeUnhealthyDuration.Seconds())
+			return down.GetDownSeconds() > uint64(duration.Seconds())
 		}
 	}
 	return false

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -294,6 +294,16 @@ func (r *RegionInfo) GetDownPeer(peerID uint64) *metapb.Peer {
 	return nil
 }
 
+// PeerDownTooLong returns if a peer is down for too long.
+func (r *RegionInfo) PeerDownTooLong(peerID uint64) bool {
+	for _, down := range r.downPeers {
+		if down.GetPeer().GetId() == peerID {
+			return down.GetDownSeconds() > uint64(storeUnhealthyDuration.Seconds())
+		}
+	}
+	return false
+}
+
 // GetDownVoter returns the down voter with specified peer id.
 func (r *RegionInfo) GetDownVoter(peerID uint64) *metapb.Peer {
 	for _, down := range r.downPeers {

--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -544,8 +544,8 @@ var (
 	// be marked as disconnected state. The value should be greater than tikv's
 	// store heartbeat interval (default 10s).
 	storeDisconnectDuration = 20 * time.Second
-	// If a store is disconnected for StoreUnhealthyDuration, the store will be
-	// seen as unhealthy.
+	// StoreUnhealthyDuration is the duration that the store will be marked as
+	// unhealthy if the store is disconnected.
 	StoreUnhealthyDuration = 10 * time.Minute
 )
 

--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -544,7 +544,9 @@ var (
 	// be marked as disconnected state. The value should be greater than tikv's
 	// store heartbeat interval (default 10s).
 	storeDisconnectDuration = 20 * time.Second
-	storeUnhealthyDuration  = 10 * time.Minute
+	// If a store is disconnected for StoreUnhealthyDuration, the store will be
+	// seen as unhealthy.
+	StoreUnhealthyDuration = 10 * time.Minute
 )
 
 // IsDisconnected checks if a store is disconnected, which means PD misses
@@ -556,7 +558,7 @@ func (s *StoreInfo) IsDisconnected() bool {
 
 // IsUnhealthy checks if a store is unhealthy.
 func (s *StoreInfo) IsUnhealthy() bool {
-	return s.DownTime() > storeUnhealthyDuration
+	return s.DownTime() > StoreUnhealthyDuration
 }
 
 // GetLabelValue returns a label's value (if exists).

--- a/pkg/schedule/placement/fit_region_test.go
+++ b/pkg/schedule/placement/fit_region_test.go
@@ -121,7 +121,7 @@ func BenchmarkFitRegion(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -140,7 +140,7 @@ func BenchmarkFitRegionMoreStores(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -159,7 +159,7 @@ func BenchmarkFitRegionMorePeers(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -185,7 +185,7 @@ func BenchmarkFitRegionMorePeersEquals(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -213,7 +213,7 @@ func BenchmarkFitRegionMorePeersSplitRules(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -241,7 +241,7 @@ func BenchmarkFitRegionMoreVotersSplitRules(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -252,7 +252,7 @@ func BenchmarkFitRegionTiflash(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -279,7 +279,7 @@ func BenchmarkFitRegionCrossRegion(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -343,7 +343,7 @@ func BenchmarkFitRegionWithMoreRulesAndStoreLabels(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }
 
@@ -401,6 +401,6 @@ func BenchmarkFitRegionWithLocationLabels(b *testing.B) {
 	stores := getStoresByRegion(storesSet, region)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		fitRegion(stores, region, rules, false)
+		fitRegion(stores, region, rules, false, core.StoreUnhealthyDuration)
 	}
 }

--- a/pkg/schedule/placement/fit_test.go
+++ b/pkg/schedule/placement/fit_test.go
@@ -152,7 +152,7 @@ func TestReplace(t *testing.T) {
 		for _, r := range tc.rules {
 			rules = append(rules, makeRule(r))
 		}
-		rf := fitRegion(stores.GetStores(), region, rules, false)
+		rf := fitRegion(stores.GetStores(), region, rules, false, core.StoreUnhealthyDuration)
 		re.True(rf.IsSatisfied())
 		rf.regionStores = stores.GetStores()
 		re.Equal(rf.Replace(tc.srcStoreID, stores.GetStore(tc.dstStoreID)), tc.ok)
@@ -194,7 +194,7 @@ func TestFitRegion(t *testing.T) {
 		for _, r := range testCase.rules {
 			rules = append(rules, makeRule(r))
 		}
-		rf := fitRegion(stores.GetStores(), region, rules, false)
+		rf := fitRegion(stores.GetStores(), region, rules, false, core.StoreUnhealthyDuration)
 		expects := strings.Split(testCase.fitPeers, "/")
 		for i, f := range rf.RuleFits {
 			re.True(checkPeerMatch(f.Peers, expects[i]))

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -372,7 +372,7 @@ func (m *RuleManager) FitRegion(storeSet StoreSet, region *core.RegionInfo) (fit
 			return fit
 		}
 	}
-	fit = fitRegion(regionStores, region, rules, m.conf.IsWitnessAllowed())
+	fit = fitRegion(regionStores, region, rules, m.conf.IsWitnessAllowed(), m.conf.GetMaxStoreDownTime())
 	fit.regionStores = regionStores
 	fit.rules = rules
 	if isCached {

--- a/tests/integrations/client/Makefile
+++ b/tests/integrations/client/Makefile
@@ -21,7 +21,7 @@ static: install-tools
 	@ echo "gofmt ..."
 	@ gofmt -s -l -d . 2>&1 | awk '{ print } END { if (NR > 0) { exit 1 } }'
 	@ echo "golangci-lint ..."
-	@ golangci-lint run -c $(ROOT_PATH)/.golangci.yml --verbose ./...
+	@ golangci-lint run -c $(ROOT_PATH)/.golangci.yml --verbose ./... --allow-parallel-runners
 	@ echo "revive ..."
 	@ revive -formatter friendly -config $(ROOT_PATH)/revive.toml ./...
 

--- a/tests/integrations/mcs/Makefile
+++ b/tests/integrations/mcs/Makefile
@@ -21,7 +21,7 @@ static: install-tools
 	@ echo "gofmt ..."
 	@ gofmt -s -l -d . 2>&1 | awk '{ print } END { if (NR > 0) { exit 1 } }'
 	@ echo "golangci-lint ..."
-	@ golangci-lint run -c $(ROOT_PATH)/.golangci.yml --verbose ./...
+	@ golangci-lint run -c $(ROOT_PATH)/.golangci.yml --verbose ./... --allow-parallel-runners
 	@ echo "revive ..."
 	@ revive -formatter friendly -config $(ROOT_PATH)/revive.toml ./...
 

--- a/tests/integrations/tso/Makefile
+++ b/tests/integrations/tso/Makefile
@@ -21,7 +21,7 @@ static: install-tools
 	@ echo "gofmt ..."
 	@ gofmt -s -l -d . 2>&1 | awk '{ print } END { if (NR > 0) { exit 1 } }'
 	@ echo "golangci-lint ..."
-	@ golangci-lint run -c $(ROOT_PATH)/.golangci.yml --verbose ./...
+	@ golangci-lint run -c $(ROOT_PATH)/.golangci.yml --verbose ./... --allow-parallel-runners
 	@ echo "revive ..."
 	@ revive -formatter friendly -config $(ROOT_PATH)/revive.toml ./...
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?



<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/6559

When Region looks like:

```
{
  "id": 55929554,
  "start_key": "748000000000000BFF065F728000000042FFEF8B7A0000000000FA",
  "end_key": "748000000000000BFF065F728000000042FFF07AFD0000000000FA",
  "epoch": {
    "conf_ver": 6,
    "version": 109399
  },
  "peers": [
    {
      "id": 55929555,
      "store_id": 1,
      "role_name": "Voter"
    },
    {
      "id": 55929556,
      "store_id": 4,
      "role_name": "Voter"
    },
    {
      "id": 55929557,
      "store_id": 5,
      "role_name": "Voter"
    },
    {
      "id": 55929558,
      "store_id": 2751139,
      "role": 1,
      "role_name": "Learner",
      "is_learner": true
    }
  ],
  "leader": {
    "id": 55929555,
    "store_id": 1,
    "role_name": "Voter"
  },
  "down_peers": [
    {
      "down_seconds": 40307,
      "peer": {
        "id": 55929556,
        "store_id": 4,
        "role_name": "Voter"
      }
    }
  ],
  "pending_peers": [
    {
      "id": 55929556,
      "store_id": 4,
      "role_name": "Voter"
    }
  ],
  "cpu_usage": 0,
  "written_bytes": 0,
  "read_bytes": 0,
  "written_keys": 0,
  "read_keys": 0,
  "approximate_size": 1,
  "approximate_keys": 40960
}
```
and the region fit likes:

```
{
  "rule-fits": [
    {
      "rule": {
        "group_id": "pd",
        "id": "default",
        "start_key": "",
        "end_key": "",
        "role": "voter",
        "is_witness": false,
        "count": 3,
        "location_labels": [
          "region",
          "zone",
          "host"
        ]
      },
      "peers": [
        {
          "id": 55929555,
          "store_id": 1
        },
        {
          "id": 55929557,
          "store_id": 5
        },
        {
          "id": 55929556,
          "store_id": 4
        }
      ],
      "peers-different-role": null,
      "isolation-score": 300
    }
  ],
  "orphan-peers": [
    {
      "id": 55929558,
      "store_id": 2751139,
      "role": 1
    }
  ]
}
```
cannot fix the region, always report as an unhealthy region. and store 4 is gone.


### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
 add peer healthy factor when comparing region fit
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
