### PR TITLE
codecov: adjust the rules to prevent ci become meaningless

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,9 +21,9 @@ flag_management:
     carryforward: true
     statuses:
       - type: project
-        target: 85%
+        target: 74% # increase it if you want to enforce higher coverage for project, current setting as 74% is for do not let the error be reported and lose the meaning of warning.
       - type: patch
-        target: 85%
+        target: 74%  # increase it if you want to enforce higher coverage for project, current setting as 74% is for do not let the error be reported and lose the meaning of warning.
 
 ignore:
   - tests/** # integration test cases or tools.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #4399

### What is changed and how does it work?

Code coverage can serve as a valuable tool for self-reflection and as an indicator of testing effectiveness. During the development process, it can help to identify blind spots or remind us to consider corner cases in test design. In fact, our continuous CI has set up indicators, such as coverage reminders for each pull request (PR) patch.

But the unreasonable setting now makes it lose its relevant effect, and we should not blindly set the target value.

```commit-message
codecov: adjust the rules to prevent ci become meaningless
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
