### PR TITLE
support block update gc v1 safe point 

### DIFF
--- a/pkg/gc/safepoint.go
+++ b/pkg/gc/safepoint.go
@@ -45,11 +45,6 @@ func (manager *SafePointManager) LoadGCSafePoint() (uint64, error) {
 // UpdateGCSafePoint updates the safepoint if it is greater than the previous one
 // it returns the old safepoint in the storage.
 func (manager *SafePointManager) UpdateGCSafePoint(newSafePoint uint64) (oldSafePoint uint64, err error) {
-	if manager.cfg.BlockSafePointV1 {
-		oldSafePoint = 0
-		err = errors.Errorf("Don't allow update gc safe point v1.")
-		return
-	}
 	manager.gcLock.Lock()
 	defer manager.gcLock.Unlock()
 	// TODO: cache the safepoint in the storage.
@@ -57,6 +52,11 @@ func (manager *SafePointManager) UpdateGCSafePoint(newSafePoint uint64) (oldSafe
 	if err != nil {
 		return
 	}
+	if manager.cfg.BlockSafePointV1 {
+		err = errors.Errorf("Don't allow update gc safe point v1.")
+		return
+	}
+
 	if oldSafePoint >= newSafePoint {
 		return
 	}

--- a/pkg/gc/safepoint.go
+++ b/pkg/gc/safepoint.go
@@ -24,6 +24,9 @@ import (
 	"github.com/tikv/pd/server/config"
 )
 
+var blockGCSafePointErrmsg = "don't allow update gc safe point v1."
+var blockServiceSafepointErrmsg = "don't allow update service safe point v1."
+
 // SafePointManager is the manager for safePoint of GC and services.
 type SafePointManager struct {
 	gcLock        syncutil.Mutex
@@ -53,7 +56,7 @@ func (manager *SafePointManager) UpdateGCSafePoint(newSafePoint uint64) (oldSafe
 		return
 	}
 	if manager.cfg.BlockSafePointV1 {
-		err = errors.Errorf("Don't allow update gc safe point v1.")
+		err = errors.Errorf(blockGCSafePointErrmsg)
 		return
 	}
 
@@ -67,7 +70,7 @@ func (manager *SafePointManager) UpdateGCSafePoint(newSafePoint uint64) (oldSafe
 // UpdateServiceGCSafePoint update the safepoint for a specific service.
 func (manager *SafePointManager) UpdateServiceGCSafePoint(serviceID string, newSafePoint uint64, ttl int64, now time.Time) (minServiceSafePoint *endpoint.ServiceSafePoint, updated bool, err error) {
 	if manager.cfg.BlockSafePointV1 {
-		return nil, false, errors.Errorf("Don't allow update service safe point v1.")
+		return nil, false, errors.Errorf(blockServiceSafepointErrmsg)
 	}
 	manager.serviceGCLock.Lock()
 	defer manager.serviceGCLock.Unlock()

--- a/pkg/gc/safepoint_test.go
+++ b/pkg/gc/safepoint_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/server/config"
 )
 
 func newGCStorage() endpoint.GCSafePointStorage {
@@ -30,7 +31,7 @@ func newGCStorage() endpoint.GCSafePointStorage {
 }
 
 func TestGCSafePointUpdateSequentially(t *testing.T) {
-	gcSafePointManager := NewSafePointManager(newGCStorage())
+	gcSafePointManager := NewSafePointManager(newGCStorage(), config.PDServerConfig{})
 	re := require.New(t)
 	curSafePoint := uint64(0)
 	// update gc safePoint with asc value.
@@ -59,7 +60,7 @@ func TestGCSafePointUpdateSequentially(t *testing.T) {
 }
 
 func TestGCSafePointUpdateCurrently(t *testing.T) {
-	gcSafePointManager := NewSafePointManager(newGCStorage())
+	gcSafePointManager := NewSafePointManager(newGCStorage(), config.PDServerConfig{})
 	maxSafePoint := uint64(1000)
 	wg := sync.WaitGroup{}
 	re := require.New(t)
@@ -83,7 +84,7 @@ func TestGCSafePointUpdateCurrently(t *testing.T) {
 
 func TestServiceGCSafePointUpdate(t *testing.T) {
 	re := require.New(t)
-	manager := NewSafePointManager(newGCStorage())
+	manager := NewSafePointManager(newGCStorage(), config.PDServerConfig{})
 	gcworkerServiceID := "gc_worker"
 	cdcServiceID := "cdc"
 	brServiceID := "br"

--- a/pkg/gc/safepoint_test.go
+++ b/pkg/gc/safepoint_test.go
@@ -170,8 +170,6 @@ func TestBlockUpdateSafePointV1(t *testing.T) {
 	gcworkerServiceID := "gc_worker"
 	gcWorkerSafePoint := uint64(8)
 
-	// update safepoint to 15(>10 for cdc) for gc_worker
-	gcWorkerSafePoint = uint64(15)
 	min, updated, err := manager.UpdateServiceGCSafePoint(gcworkerServiceID, gcWorkerSafePoint, math.MaxInt64, time.Now())
 	re.Error(err, "Don't allow update service safe point v1.")
 	re.False(updated)
@@ -180,6 +178,4 @@ func TestBlockUpdateSafePointV1(t *testing.T) {
 	oldSafePoint, err := manager.UpdateGCSafePoint(gcWorkerSafePoint)
 	re.Error(err, "Don't allow update service safe point v1.")
 	re.Equal(uint64(0), oldSafePoint)
-	re.Nil(min)
-
 }

--- a/pkg/gc/safepoint_test.go
+++ b/pkg/gc/safepoint_test.go
@@ -171,11 +171,14 @@ func TestBlockUpdateSafePointV1(t *testing.T) {
 	gcWorkerSafePoint := uint64(8)
 
 	min, updated, err := manager.UpdateServiceGCSafePoint(gcworkerServiceID, gcWorkerSafePoint, math.MaxInt64, time.Now())
-	re.Error(err, "Don't allow update service safe point v1.")
+	re.Error(err, blockServiceSafepointErrmsg)
+	re.Equal(err.Error(), blockServiceSafepointErrmsg)
 	re.False(updated)
 	re.Nil(min)
 
 	oldSafePoint, err := manager.UpdateGCSafePoint(gcWorkerSafePoint)
-	re.Error(err, "Don't allow update service safe point v1.")
+	re.Error(err)
+	re.Equal(err.Error(), blockGCSafePointErrmsg)
+
 	re.Equal(uint64(0), oldSafePoint)
 }

--- a/pkg/gc/safepoint_test.go
+++ b/pkg/gc/safepoint_test.go
@@ -163,3 +163,23 @@ func TestServiceGCSafePointUpdate(t *testing.T) {
 	re.NoError(err)
 	re.True(updated)
 }
+
+func TestBlockUpdateSafePointV1(t *testing.T) {
+	re := require.New(t)
+	manager := NewSafePointManager(newGCStorage(), config.PDServerConfig{BlockSafePointV1: true})
+	gcworkerServiceID := "gc_worker"
+	gcWorkerSafePoint := uint64(8)
+
+	// update safepoint to 15(>10 for cdc) for gc_worker
+	gcWorkerSafePoint = uint64(15)
+	min, updated, err := manager.UpdateServiceGCSafePoint(gcworkerServiceID, gcWorkerSafePoint, math.MaxInt64, time.Now())
+	re.Error(err, "Don't allow update service safe point v1.")
+	re.False(updated)
+	re.Nil(min)
+
+	oldSafePoint, err := manager.UpdateGCSafePoint(gcWorkerSafePoint)
+	re.Error(err, "Don't allow update service safe point v1.")
+	re.Equal(uint64(0), oldSafePoint)
+	re.Nil(min)
+
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1106,6 +1106,8 @@ type PDServerConfig struct {
 	EnableGOGCTuner bool `toml:"enable-gogc-tuner" json:"enable-gogc-tuner,string"`
 	// GCTunerThreshold is the threshold of GC tuner.
 	GCTunerThreshold float64 `toml:"gc-tuner-threshold" json:"gc-tuner-threshold"`
+	// BlockSafePointV1 is used to control gc safe point v1 and service safe point v1 can not be updated.
+	BlockSafePointV1 bool `toml:"block-safe-point-v1" json:"block-safe-point-v1"`
 }
 
 func (c *PDServerConfig) adjust(meta *configutil.ConfigMetaData) error {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1107,7 +1107,7 @@ type PDServerConfig struct {
 	// GCTunerThreshold is the threshold of GC tuner.
 	GCTunerThreshold float64 `toml:"gc-tuner-threshold" json:"gc-tuner-threshold"`
 	// BlockSafePointV1 is used to control gc safe point v1 and service safe point v1 can not be updated.
-	BlockSafePointV1 bool `toml:"block-safe-point-v1" json:"block-safe-point-v1"`
+	BlockSafePointV1 bool `toml:"block-safe-point-v1" json:"block-safe-point-v1,string"`
 }
 
 func (c *PDServerConfig) adjust(meta *configutil.ConfigMetaData) error {

--- a/server/server.go
+++ b/server/server.go
@@ -452,7 +452,7 @@ func (s *Server) startServer(ctx context.Context) error {
 		return err
 	}
 
-	s.gcSafePointManager = gc.NewSafePointManager(s.storage)
+	s.gcSafePointManager = gc.NewSafePointManager(s.storage, s.cfg.PDServerCfg)
 	s.basicCluster = core.NewBasicCluster()
 	s.cluster = cluster.NewRaftCluster(ctx, s.clusterID, syncer.NewRegionSyncer(s), s.client, s.httpClient)
 	keyspaceIDAllocator := id.NewAllocator(&id.AllocatorParams{


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref https://github.com/tikv/pd/issues/6849

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
If set block-safe-point-v1 = true, it will block update safe point v1. It's used when upgrade safe point v1 to safe point v2.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
If set block-safe-point-v1 = true, it will block update safe point v1. It's used when upgrade safe point v1 to safe point v2.
```
