### PR TITLE
mcs: fix ticker stop in register

### DIFF
--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -82,11 +82,11 @@ func (sr *ServiceRegister) Register() error {
 					log.Error("keep alive failed", zap.String("key", sr.key))
 					// retry
 					t := time.NewTicker(time.Duration(sr.ttl) * time.Second / 2)
+					defer t.Stop()
 					for {
 						select {
 						case <-sr.ctx.Done():
 							log.Info("exit register process", zap.String("key", sr.key))
-							t.Stop()
 							return
 						default:
 						}
@@ -95,13 +95,11 @@ func (sr *ServiceRegister) Register() error {
 						resp, err := sr.cli.Grant(sr.ctx, sr.ttl)
 						if err != nil {
 							log.Error("grant lease failed", zap.String("key", sr.key), zap.Error(err))
-							t.Stop()
 							continue
 						}
 
 						if _, err := sr.cli.Put(sr.ctx, sr.key, sr.value, clientv3.WithLease(resp.ID)); err != nil {
 							log.Error("put the key failed", zap.String("key", sr.key), zap.Error(err))
-							t.Stop()
 							continue
 						}
 					}

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/log"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
@@ -54,18 +55,14 @@ func NewServiceRegister(ctx context.Context, cli *clientv3.Client, clusterID, se
 
 // Register registers the service to etcd.
 func (sr *ServiceRegister) Register() error {
-	resp, err := sr.cli.Grant(sr.ctx, sr.ttl)
+	ctx, cancel := context.WithTimeout(sr.ctx, etcdutil.DefaultRequestTimeout)
+	defer cancel()
+	id, err := etcdutil.EtcdKVPutWithTTL(ctx, sr.cli, sr.key, sr.value, sr.ttl)
 	if err != nil {
 		sr.cancel()
-		return fmt.Errorf("grant lease failed: %v", err)
+		return fmt.Errorf("put the key with lease %s failed: %v", sr.key, err)
 	}
-
-	if _, err := sr.cli.Put(sr.ctx, sr.key, sr.value, clientv3.WithLease(resp.ID)); err != nil {
-		sr.cancel()
-		return fmt.Errorf("put the key %s failed: %v", sr.key, err)
-	}
-
-	kresp, err := sr.cli.KeepAlive(sr.ctx, resp.ID)
+	kresp, err := sr.cli.KeepAlive(sr.ctx, id)
 	if err != nil {
 		sr.cancel()
 		return fmt.Errorf("keepalive failed: %v", err)
@@ -98,18 +95,14 @@ func (sr *ServiceRegister) renewKeepalive() <-chan *clientv3.LeaseKeepAliveRespo
 			log.Info("exit register process", zap.String("key", sr.key))
 			return nil
 		case <-t.C:
-			resp, err := sr.cli.Grant(sr.ctx, sr.ttl)
+			ctx, cancel := context.WithTimeout(sr.ctx, etcdutil.DefaultRequestTimeout)
+			defer cancel()
+			id, err := etcdutil.EtcdKVPutWithTTL(ctx, sr.cli, sr.key, sr.value, sr.ttl)
 			if err != nil {
-				log.Error("grant lease failed", zap.String("key", sr.key), zap.Error(err))
+				log.Error("put the key with lease failed", zap.String("key", sr.key), zap.Error(err))
 				continue
 			}
-
-			if _, err := sr.cli.Put(sr.ctx, sr.key, sr.value, clientv3.WithLease(resp.ID)); err != nil {
-				log.Error("put the key failed", zap.String("key", sr.key), zap.Error(err))
-				continue
-			}
-
-			kresp, err := sr.cli.KeepAlive(sr.ctx, resp.ID)
+			kresp, err := sr.cli.KeepAlive(sr.ctx, id)
 			if err != nil {
 				log.Error("client keep alive failed", zap.String("key", sr.key), zap.Error(err))
 				continue

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -78,11 +78,10 @@ func (sr *ServiceRegister) Register() error {
 				log.Info("exit register process", zap.String("key", sr.key))
 				return
 			case _, ok := <-kresp:
-				if ok {
-					continue
+				if !ok {
+					log.Error("keep alive failed", zap.String("key", sr.key))
+					kresp = sr.renewKeepalive()
 				}
-				log.Error("keep alive failed", zap.String("key", sr.key))
-				kresp = sr.renew()
 			}
 		}
 	}()
@@ -90,7 +89,7 @@ func (sr *ServiceRegister) Register() error {
 	return nil
 }
 
-func (sr *ServiceRegister) renew() <-chan *clientv3.LeaseKeepAliveResponse {
+func (sr *ServiceRegister) renewKeepalive() <-chan *clientv3.LeaseKeepAliveResponse {
 	t := time.NewTicker(time.Duration(sr.ttl) * time.Second / 2)
 	defer t.Stop()
 	for {

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -102,6 +102,12 @@ func (sr *ServiceRegister) Register() error {
 							log.Error("put the key failed", zap.String("key", sr.key), zap.Error(err))
 							continue
 						}
+
+						kresp, err = sr.cli.KeepAlive(sr.ctx, resp.ID)
+						if err != nil {
+							log.Error("client keep alive failed", zap.String("key", sr.key), zap.Error(err))
+							continue
+						}
 						t.Stop()
 						goto KeepaliveLoop
 					}

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -29,17 +29,13 @@ func TestRegister(t *testing.T) {
 	re := require.New(t)
 	cfg := etcdutil.NewTestSingleConfig(t)
 	etcd, err := embed.StartEtcd(cfg)
-	defer func() {
-		etcd.Close()
-	}()
 	re.NoError(err)
-
 	ep := cfg.LCUrls[0].String()
 	client, err := clientv3.NewFromURL(ep)
 	re.NoError(err)
-
 	<-etcd.Server.ReadyNotify()
-	// with http prefix
+
+	// Test register with http prefix.
 	sr := NewServiceRegister(context.Background(), client, "12345", "test_service", "http://127.0.0.1:1", "http://127.0.0.1:1", 10)
 	re.NoError(err)
 	err = sr.Register()
@@ -49,20 +45,40 @@ func TestRegister(t *testing.T) {
 	re.NoError(err)
 	re.Equal("http://127.0.0.1:1", string(resp.Kvs[0].Value))
 
+	// Test deregister.
 	err = sr.Deregister()
 	re.NoError(err)
 	resp, err = client.Get(context.Background(), sr.key)
 	re.NoError(err)
 	re.Empty(resp.Kvs)
 
+	// Test the case that ctx is canceled.
 	sr = NewServiceRegister(context.Background(), client, "12345", "test_service", "127.0.0.1:2", "127.0.0.1:2", 1)
-	re.NoError(err)
 	err = sr.Register()
 	re.NoError(err)
 	sr.cancel()
-	// ensure that the lease is expired
-	time.Sleep(3 * time.Second)
-	resp, err = client.Get(context.Background(), sr.key)
+	re.Empty(getKeyAfterLeaseExpired(re, client, sr.key))
+
+	// Test the case that keepalive is failed when the etcd is restarted.
+	sr = NewServiceRegister(context.Background(), client, "12345", "test_service", "127.0.0.1:2", "127.0.0.1:2", 1)
+	err = sr.Register()
 	re.NoError(err)
-	re.Empty(resp.Kvs)
+	re.Equal("127.0.0.1:2", getKeyAfterLeaseExpired(re, client, sr.key))
+	etcd.Close()                // close the etcd to make the keepalive failed
+	time.Sleep(3 * time.Second) // ensure that the lease is expired
+	etcd, err = embed.StartEtcd(cfg)
+	re.NoError(err)
+	<-etcd.Server.ReadyNotify()
+	defer etcd.Close()
+	re.Equal("127.0.0.1:2", getKeyAfterLeaseExpired(re, client, sr.key))
+}
+
+func getKeyAfterLeaseExpired(re *require.Assertions, client *clientv3.Client, key string) string {
+	time.Sleep(3 * time.Second) // ensure that the lease is expired
+	resp, err := client.Get(context.Background(), key)
+	re.NoError(err)
+	if len(resp.Kvs) == 0 {
+		return ""
+	}
+	return string(resp.Kvs[0].Value)
 }

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -202,13 +202,14 @@ func GetProtoMsgWithModRev(c *clientv3.Client, key string, msg proto.Message, op
 }
 
 // EtcdKVPutWithTTL put (key, value) into etcd with a ttl of ttlSeconds
-func EtcdKVPutWithTTL(ctx context.Context, c *clientv3.Client, key string, value string, ttlSeconds int64) (*clientv3.PutResponse, error) {
+func EtcdKVPutWithTTL(ctx context.Context, c *clientv3.Client, key string, value string, ttlSeconds int64) (clientv3.LeaseID, error) {
 	kv := clientv3.NewKV(c)
 	grantResp, err := c.Grant(ctx, ttlSeconds)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	return kv.Put(ctx, key, value, clientv3.WithLease(grantResp.ID))
+	_, err = kv.Put(ctx, key, value, clientv3.WithLease(grantResp.ID))
+	return grantResp.ID, err
 }
 
 const (

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -718,6 +718,12 @@ func (suite *loopWatcherTestSuite) TestWatcherBreak() {
 	// Case1: restart the etcd server
 	suite.etcd.Close()
 	suite.startEtcd()
+	suite.put("TestWatcherBreak", "0")
+	checkCache("0")
+	suite.etcd.Server.Stop()
+	time.Sleep(DefaultRequestTimeout)
+	suite.etcd.Close()
+	suite.startEtcd()
 	suite.put("TestWatcherBreak", "1")
 	checkCache("1")
 

--- a/server/server.go
+++ b/server/server.go
@@ -1861,6 +1861,12 @@ func (s *Server) initTSOPrimaryWatcher() {
 		return nil
 	}
 	deleteFn := func(kv *mvccpb.KeyValue) error {
+		var oldPrimary string
+		v, ok := s.servicePrimaryMap.Load(serviceName)
+		if ok {
+			oldPrimary = v.(string)
+		}
+		log.Info("delete tso primary", zap.String("old-primary", oldPrimary))
 		s.servicePrimaryMap.Delete(serviceName)
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6875

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
pd0: `./pd-server services api`
tso1: `./pd-server services tso --listen-addr="http://127.0.0.1:3380" --backend-endpoints="http://127.0.0.1:2379"`
tso2: `./pd-server services tso --listen-addr="http://127.0.0.1:3379" --backend-endpoints="http://127.0.0.1:2379"`

can find register key
![image](https://github.com/tikv/pd/assets/19542290/19129f88-9644-4a5b-89d9-659c8a8d892e)


then close pd0 and wait a minutes and can see  keepalive failed log
![image](https://github.com/tikv/pd/assets/19542290/22eff826-c54c-4c2d-81fa-97a665f2cb68)


and restart pd0 and can see normal and no keepalive failed log anymore
![image](https://github.com/tikv/pd/assets/19542290/078454b2-2a8a-47e7-81e8-8a06cbbb7fa5)
![image](https://github.com/tikv/pd/assets/19542290/5d4c3211-45bb-413d-98dd-df0b4f40caca)




### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
