### PR TITLE
*: make coordinator run

### DIFF
--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -129,7 +129,7 @@ func (s *Server) primaryElectionLoop() {
 
 	for {
 		select {
-		case <-s.ctx.Done():
+		case <-s.serverLoopCtx.Done():
 			log.Info("server is closed, exit resource manager primary election loop")
 			return
 		default:

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -128,9 +128,11 @@ func (s *Server) primaryElectionLoop() {
 	defer s.serverLoopWg.Done()
 
 	for {
-		if s.IsClosed() {
+		select {
+		case <-s.ctx.Done():
 			log.Info("server is closed, exit resource manager primary election loop")
 			return
+		default:
 		}
 
 		primary, checkAgain := s.participant.CheckLeader()

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tikv/pd/pkg/statistics/buckets"
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/storage"
-	"github.com/tikv/pd/pkg/storage/endpoint"
 )
 
 // Cluster is used to manage all information for scheduling purpose.
@@ -23,12 +22,13 @@ type Cluster struct {
 	labelerManager *labeler.RegionLabeler
 	persistConfig  *config.PersistConfig
 	hotStat        *statistics.HotStat
+	storage        storage.Storage
 }
 
 const regionLabelGCInterval = time.Hour
 
 // NewCluster creates a new cluster.
-func NewCluster(ctx context.Context, storage endpoint.RuleStorage, cfg *config.Config) (*Cluster, error) {
+func NewCluster(ctx context.Context, storage storage.Storage, cfg *config.Config) (*Cluster, error) {
 	basicCluster := core.NewBasicCluster()
 	persistConfig := config.NewPersistConfig(cfg)
 	labelerManager, err := labeler.NewRegionLabeler(ctx, storage, regionLabelGCInterval)
@@ -102,22 +102,33 @@ func (c *Cluster) BucketsStats(degree int, regionIDs ...uint64) map[uint64][]*bu
 	return c.hotStat.BucketsStats(degree, regionIDs...)
 }
 
+<<<<<<< HEAD
 // TODO: implement the following methods
+=======
+// GetPersistOptions returns the persist options.
+func (c *Cluster) GetPersistOptions() sc.ConfProvider {
+	return c.persistConfig
+}
+>>>>>>> remove some store config
 
 // GetStorage returns the storage.
-func (c *Cluster) GetStorage() storage.Storage { return nil }
+func (c *Cluster) GetStorage() storage.Storage {
+	return c.storage
+}
+
+// GetCheckerConfig returns the checker config.
+func (c *Cluster) GetCheckerConfig() sc.CheckerConfigProvider { return c.persistConfig }
+
+// GetSchedulerConfig returns the scheduler config.
+func (c *Cluster) GetSchedulerConfig() sc.SchedulerConfigProvider { return c.persistConfig }
+
+// TODO: implement the following methods
 
 // UpdateRegionsLabelLevelStats updates the region label level stats.
 func (c *Cluster) UpdateRegionsLabelLevelStats(regions []*core.RegionInfo) {}
 
-// GetStoreConfig returns the store config.
-func (c *Cluster) GetStoreConfig() sc.StoreConfigProvider { return nil }
-
 // AllocID allocates a new ID.
 func (c *Cluster) AllocID() (uint64, error) { return 0, nil }
 
-// GetCheckerConfig returns the checker config.
-func (c *Cluster) GetCheckerConfig() sc.CheckerConfigProvider { return nil }
-
-// GetSchedulerConfig returns the scheduler config.
-func (c *Cluster) GetSchedulerConfig() sc.SchedulerConfigProvider { return nil }
+// GetStoreConfig returns the store config.
+func (c *Cluster) GetStoreConfig() sc.StoreConfigProvider { return nil }

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -103,15 +103,6 @@ func (c *Cluster) BucketsStats(degree int, regionIDs ...uint64) map[uint64][]*bu
 	return c.hotStat.BucketsStats(degree, regionIDs...)
 }
 
-<<<<<<< HEAD
-// TODO: implement the following methods
-=======
-// GetPersistOptions returns the persist options.
-func (c *Cluster) GetPersistOptions() sc.ConfProvider {
-	return c.persistConfig
-}
->>>>>>> remove some store config
-
 // GetStorage returns the storage.
 func (c *Cluster) GetStorage() storage.Storage {
 	return c.storage
@@ -123,6 +114,9 @@ func (c *Cluster) GetCheckerConfig() sc.CheckerConfigProvider { return c.persist
 // GetSchedulerConfig returns the scheduler config.
 func (c *Cluster) GetSchedulerConfig() sc.SchedulerConfigProvider { return c.persistConfig }
 
+// GetStoreConfig returns the store config.
+func (c *Cluster) GetStoreConfig() sc.StoreConfigProvider { return c.persistConfig }
+
 // TODO: implement the following methods
 
 // UpdateRegionsLabelLevelStats updates the region label level stats.
@@ -130,6 +124,3 @@ func (c *Cluster) UpdateRegionsLabelLevelStats(regions []*core.RegionInfo) {}
 
 // AllocID allocates a new ID.
 func (c *Cluster) AllocID() (uint64, error) { return 0, nil }
-
-// GetStoreConfig returns the store config.
-func (c *Cluster) GetStoreConfig() sc.StoreConfigProvider { return nil }

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -42,6 +42,7 @@ func NewCluster(ctx context.Context, storage storage.Storage, cfg *config.Config
 		labelerManager: labelerManager,
 		persistConfig:  persistConfig,
 		hotStat:        statistics.NewHotStat(ctx),
+		storage:        storage,
 	}, nil
 }
 

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -564,6 +564,31 @@ func (o *PersistConfig) SetHaltScheduling(halt bool, source string) {
 	o.SetScheduleConfig(v)
 }
 
+// CheckRegionKeys return error if the smallest region's keys is less than mergeKeys
+func (o *PersistConfig) CheckRegionKeys(keys, mergeKeys uint64) error {
+	return o.GetStoreConfig().CheckRegionKeys(keys, mergeKeys)
+}
+
+// CheckRegionSize return error if the smallest region's size is less than mergeSize
+func (o *PersistConfig) CheckRegionSize(size, mergeSize uint64) error {
+	return o.GetStoreConfig().CheckRegionSize(size, mergeSize)
+}
+
+// GetRegionMaxSize returns the max region size in MB
+func (o *PersistConfig) GetRegionMaxSize() uint64 {
+	return o.GetStoreConfig().GetRegionMaxSize()
+}
+
+// GetRegionMaxKeys returns the region split keys
+func (o *PersistConfig) GetRegionMaxKeys() uint64 {
+	return o.GetStoreConfig().GetRegionMaxKeys()
+}
+
+// IsEnableRegionBucket return true if the region bucket is enabled.
+func (o *PersistConfig) IsEnableRegionBucket() bool {
+	return o.GetStoreConfig().IsEnableRegionBucket()
+}
+
 // TODO: implement the following methods
 
 // AddSchedulerCfg adds the scheduler configurations.

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -587,6 +587,3 @@ func (o *PersistConfig) Persist(storage endpoint.ConfigStorage) error {
 
 // RemoveSchedulerCfg removes the scheduler configurations.
 func (o *PersistConfig) RemoveSchedulerCfg(tp string) {}
-
-// UseRaftV2 set some config for raft store v2 by default temporary.
-func (o *PersistConfig) UseRaftV2() {}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -175,7 +175,7 @@ func (s *Server) primaryElectionLoop() {
 
 	for {
 		select {
-		case <-s.ctx.Done():
+		case <-s.serverLoopCtx.Done():
 			log.Info("server is closed, exit resource manager primary election loop")
 			return
 		default:

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -174,9 +174,11 @@ func (s *Server) primaryElectionLoop() {
 	defer s.serverLoopWg.Done()
 
 	for {
-		if s.IsClosed() {
-			log.Info("server is closed, exit scheduling primary election loop")
+		select {
+		case <-s.ctx.Done():
+			log.Info("server is closed, exit resource manager primary election loop")
 			return
+		default:
 		}
 
 		primary, checkAgain := s.participant.CheckLeader()
@@ -487,13 +489,18 @@ func (s *Server) startServer() (err error) {
 	s.participant.InitInfo(uniqueName, uniqueID, path.Join(schedulingPrimaryPrefix, fmt.Sprintf("%05d", 0)),
 		utils.PrimaryKey, "primary election", s.cfg.AdvertiseListenAddr)
 	s.storage = endpoint.NewStorageEndpoint(
-		kv.NewEtcdKVBase(s.etcdClient, endpoint.SchedulingSvcRootPath(s.clusterID)), nil)
+		kv.NewEtcdKVBase(s.etcdClient, endpoint.PDRootPath(s.clusterID)), nil)
 	s.cluster, err = NewCluster(s.ctx, s.storage, s.cfg)
 	if err != nil {
 		return err
 	}
 	s.hbStreams = hbstream.NewHeartbeatStreams(s.ctx, s.clusterID, s.cluster.GetBasicCluster())
 	s.coordinator = schedule.NewCoordinator(s.ctx, s.cluster, s.hbStreams)
+
+	s.listenURL, err = url.Parse(s.cfg.ListenAddr)
+	if err != nil {
+		return err
+	}
 	tlsConfig, err := s.cfg.Security.ToTLSConfig()
 	if err != nil {
 		return err
@@ -511,7 +518,7 @@ func (s *Server) startServer() (err error) {
 	if err != nil {
 		return err
 	}
-
+	go s.coordinator.RunUntilStop()
 	serverReadyChan := make(chan struct{})
 	defer close(serverReadyChan)
 	s.serverLoopWg.Add(1)

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -84,12 +84,12 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 
 // GetStoreConfig returns the store config.
 func (mc *Cluster) GetStoreConfig() sc.StoreConfigProvider {
-	return mc
+	return mc.PersistOptions.GetStoreConfig()
 }
 
 // SetRegionBucketEnabled sets the region bucket enabled.
 func (mc *Cluster) SetRegionBucketEnabled(enabled bool) {
-	cfg, ok := mc.GetStoreConfig().(*config.StoreConfig)
+	cfg, ok := mc.GetStoreConfig().(*sc.StoreConfig)
 	if !ok || cfg == nil {
 		return
 	}
@@ -99,17 +99,17 @@ func (mc *Cluster) SetRegionBucketEnabled(enabled bool) {
 
 // GetCheckerConfig returns the checker config.
 func (mc *Cluster) GetCheckerConfig() sc.CheckerConfigProvider {
-	return mc
+	return mc.PersistOptions
 }
 
 // GetSchedulerConfig returns the scheduler config.
 func (mc *Cluster) GetSchedulerConfig() sc.SchedulerConfigProvider {
-	return mc
+	return mc.PersistOptions
 }
 
 // GetSharedConfig returns the shared config.
 func (mc *Cluster) GetSharedConfig() sc.SharedConfigProvider {
-	return mc
+	return mc.PersistOptions
 }
 
 // GetStorage returns the storage.

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -87,6 +87,16 @@ func (mc *Cluster) GetStoreConfig() sc.StoreConfigProvider {
 	return mc
 }
 
+// SetRegionBucketEnabled sets the region bucket enabled.
+func (mc *Cluster) SetRegionBucketEnabled(enabled bool) {
+	cfg, ok := mc.GetStoreConfig().(*config.StoreConfig)
+	if !ok || cfg == nil {
+		return
+	}
+	cfg.Coprocessor.EnableRegionBucket = enabled
+	mc.SetStoreConfig(cfg)
+}
+
 // GetCheckerConfig returns the checker config.
 func (mc *Cluster) GetCheckerConfig() sc.CheckerConfigProvider {
 	return mc

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -131,8 +131,6 @@ type ConfProvider interface {
 	SetSplitMergeInterval(time.Duration)
 	SetMaxReplicas(int)
 	SetAllStoresLimit(storelimit.Type, float64)
-	// only for store configuration
-	UseRaftV2()
 }
 
 // StoreConfigProvider is the interface that wraps the StoreConfigProvider related methods.
@@ -142,6 +140,4 @@ type StoreConfigProvider interface {
 	CheckRegionSize(uint64, uint64) error
 	CheckRegionKeys(uint64, uint64) error
 	IsEnableRegionBucket() bool
-	// for test purpose
-	SetRegionBucketEnabled(bool)
 }

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -247,7 +247,7 @@ func TestSplitIfRegionTooHot(t *testing.T) {
 	addRegionInfo(tc, utils.Read, []testRegionInfo{
 		{1, []uint64{1, 2, 3}, 4 * units.MiB, 0, 0},
 	})
-	tc.GetStoreConfig().SetRegionBucketEnabled(true)
+	tc.SetRegionBucketEnabled(true)
 	ops, _ := hb.Schedule(tc, false)
 	re.Len(ops, 1)
 	expectOp, _ := operator.CreateSplitRegionOperator(splitHotReadBuckets, tc.GetRegion(1), operator.OpSplit,
@@ -283,7 +283,7 @@ func TestSplitBucketsBySize(t *testing.T) {
 	statistics.Denoising = false
 	cancel, _, tc, oc := prepareSchedulersTest()
 	tc.SetHotRegionCacheHitsThreshold(1)
-	tc.GetStoreConfig().SetRegionBucketEnabled(true)
+	tc.SetRegionBucketEnabled(true)
 	defer cancel()
 	hb, err := CreateScheduler(utils.Read.String(), oc, storage.NewStorageWithMemoryBackend(), nil)
 	re.NoError(err)
@@ -336,7 +336,7 @@ func TestSplitBucketsByLoad(t *testing.T) {
 	statistics.Denoising = false
 	cancel, _, tc, oc := prepareSchedulersTest()
 	tc.SetHotRegionCacheHitsThreshold(1)
-	tc.GetStoreConfig().SetRegionBucketEnabled(true)
+	tc.SetRegionBucketEnabled(true)
 	defer cancel()
 	hb, err := CreateScheduler(utils.Read.String(), oc, storage.NewStorageWithMemoryBackend(), nil)
 	re.NoError(err)

--- a/pkg/statistics/utils/kind.go
+++ b/pkg/statistics/utils/kind.go
@@ -226,7 +226,7 @@ func (rw RWType) DefaultAntiCount() int {
 	case Write:
 		return HotRegionAntiCount
 	default: // Case Read
-		return HotRegionAntiCount * (WriteReportInterval / ReadReportInterval)
+		return HotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
 	}
 }
 

--- a/pkg/statistics/utils/kind.go
+++ b/pkg/statistics/utils/kind.go
@@ -226,7 +226,7 @@ func (rw RWType) DefaultAntiCount() int {
 	case Write:
 		return HotRegionAntiCount
 	default: // Case Read
-		return HotRegionAntiCount * (RegionHeartBeatReportInterval / StoreHeartBeatReportInterval)
+		return HotRegionAntiCount * (WriteReportInterval / ReadReportInterval)
 	}
 }
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -426,7 +426,6 @@ func (c *RaftCluster) runStoreConfigSync() {
 	for {
 		synced, switchRaftV2Config = c.syncStoreConfig(stores)
 		if switchRaftV2Config {
-			c.GetOpts().UseRaftV2()
 			if err := c.opt.Persist(c.GetStorage()); err != nil {
 				log.Warn("store config persisted failed", zap.Error(err))
 			}

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -216,9 +216,6 @@ func (o *PersistOptions) SetMaxReplicas(replicas int) {
 	o.SetReplicationConfig(v)
 }
 
-// UseRaftV2 set some config for raft store v2 by default temporary.
-func (o *PersistOptions) UseRaftV2() {}
-
 const (
 	maxSnapshotCountKey            = "schedule.max-snapshot-count"
 	maxMergeRegionSizeKey          = "schedule.max-merge-region-size"

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -804,7 +804,7 @@ func (suite *clientTestSuite) SetupSuite() {
 		}))
 		suite.grpcSvr.GetRaftCluster().GetBasicCluster().PutStore(newStore)
 	}
-	cluster.GetStoreConfig().SetRegionBucketEnabled(true)
+	cluster.GetStoreConfig().(*config.StoreConfig).SetRegionBucketEnabled(true)
 }
 
 func (suite *clientTestSuite) TearDownSuite() {
@@ -893,7 +893,7 @@ func (suite *clientTestSuite) TestGetRegion() {
 		}
 		return r.Buckets != nil
 	})
-	suite.srv.GetRaftCluster().GetStoreConfig().SetRegionBucketEnabled(false)
+	suite.srv.GetRaftCluster().GetStoreConfig().(*config.StoreConfig).SetRegionBucketEnabled(false)
 
 	testutil.Eventually(re, func() bool {
 		r, err := suite.client.GetRegion(context.Background(), []byte("a"), pd.WithBuckets())
@@ -903,7 +903,7 @@ func (suite *clientTestSuite) TestGetRegion() {
 		}
 		return r.Buckets == nil
 	})
-	suite.srv.GetRaftCluster().GetStoreConfig().SetRegionBucketEnabled(true)
+	suite.srv.GetRaftCluster().GetStoreConfig().(*config.StoreConfig).SetRegionBucketEnabled(true)
 
 	suite.NoError(failpoint.Enable("github.com/tikv/pd/server/grpcClientClosed", `return(true)`))
 	suite.NoError(failpoint.Enable("github.com/tikv/pd/server/useForwardRequest", `return(true)`))

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mock/mockid"
-	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/tso"
 	"github.com/tikv/pd/pkg/utils/assertutil"
@@ -805,7 +804,7 @@ func (suite *clientTestSuite) SetupSuite() {
 		}))
 		suite.grpcSvr.GetRaftCluster().GetBasicCluster().PutStore(newStore)
 	}
-	cluster.GetStoreConfig().(*sc.StoreConfig).SetRegionBucketEnabled(true)
+	cluster.GetOpts().(*config.PersistOptions).SetRegionBucketEnabled(true)
 }
 
 func (suite *clientTestSuite) TearDownSuite() {
@@ -894,7 +893,7 @@ func (suite *clientTestSuite) TestGetRegion() {
 		}
 		return r.Buckets != nil
 	})
-	suite.srv.GetRaftCluster().GetStoreConfig().(*sc.StoreConfig).SetRegionBucketEnabled(false)
+	suite.srv.GetRaftCluster().GetOpts().(*config.PersistOptions).SetRegionBucketEnabled(false)
 
 	testutil.Eventually(re, func() bool {
 		r, err := suite.client.GetRegion(context.Background(), []byte("a"), pd.WithBuckets())
@@ -904,7 +903,7 @@ func (suite *clientTestSuite) TestGetRegion() {
 		}
 		return r.Buckets == nil
 	})
-	suite.srv.GetRaftCluster().GetStoreConfig().(*sc.StoreConfig).SetRegionBucketEnabled(true)
+	suite.srv.GetRaftCluster().GetOpts().(*config.PersistOptions).SetRegionBucketEnabled(true)
 
 	suite.NoError(failpoint.Enable("github.com/tikv/pd/server/grpcClientClosed", `return(true)`))
 	suite.NoError(failpoint.Enable("github.com/tikv/pd/server/useForwardRequest", `return(true)`))

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mock/mockid"
+	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/tso"
 	"github.com/tikv/pd/pkg/utils/assertutil"
@@ -804,7 +805,7 @@ func (suite *clientTestSuite) SetupSuite() {
 		}))
 		suite.grpcSvr.GetRaftCluster().GetBasicCluster().PutStore(newStore)
 	}
-	cluster.GetStoreConfig().(*config.StoreConfig).SetRegionBucketEnabled(true)
+	cluster.GetStoreConfig().(*sc.StoreConfig).SetRegionBucketEnabled(true)
 }
 
 func (suite *clientTestSuite) TearDownSuite() {
@@ -893,7 +894,7 @@ func (suite *clientTestSuite) TestGetRegion() {
 		}
 		return r.Buckets != nil
 	})
-	suite.srv.GetRaftCluster().GetStoreConfig().(*config.StoreConfig).SetRegionBucketEnabled(false)
+	suite.srv.GetRaftCluster().GetStoreConfig().(*sc.StoreConfig).SetRegionBucketEnabled(false)
 
 	testutil.Eventually(re, func() bool {
 		r, err := suite.client.GetRegion(context.Background(), []byte("a"), pd.WithBuckets())
@@ -903,7 +904,7 @@ func (suite *clientTestSuite) TestGetRegion() {
 		}
 		return r.Buckets == nil
 	})
-	suite.srv.GetRaftCluster().GetStoreConfig().(*config.StoreConfig).SetRegionBucketEnabled(true)
+	suite.srv.GetRaftCluster().GetStoreConfig().(*sc.StoreConfig).SetRegionBucketEnabled(true)
 
 	suite.NoError(failpoint.Enable("github.com/tikv/pd/server/grpcClientClosed", `return(true)`))
 	suite.NoError(failpoint.Enable("github.com/tikv/pd/server/useForwardRequest", `return(true)`))


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5839. 

### What is changed and how does it work?

```
[2023/08/04 16:48:08.944 +08:00] [INFO] [versioninfo.go:89] ["Welcome to Placement Driver (SCHEDULING)"]
[2023/08/04 16:48:08.944 +08:00] [INFO] [versioninfo.go:90] [SCHEDULING] [release-version=v7.4.0-alpha-3-g09921f5e5-dirty]
[2023/08/04 16:48:08.944 +08:00] [INFO] [versioninfo.go:91] [SCHEDULING] [edition=Community]
[2023/08/04 16:48:08.944 +08:00] [INFO] [versioninfo.go:92] [SCHEDULING] [git-hash=09921f5e513d7b38be9d1fe33943a9e70309a442]
[2023/08/04 16:48:08.944 +08:00] [INFO] [versioninfo.go:93] [SCHEDULING] [git-branch=remove-some-store-config]
[2023/08/04 16:48:08.944 +08:00] [INFO] [versioninfo.go:94] [SCHEDULING] [utc-build-time="2023-08-04 08:46:21"]
[2023/08/04 16:48:08.944 +08:00] [INFO] [server.go:613] ["Scheduling config"] [config="{\"backend-endpoints\":\"http://127.0.0.1:2379\",\"listen-addr\":\"http://127.0.0.1:3379\",\"advertise-listen-addr\":\"http://127.0.0.1:3379\",\"name\":\"Scheduling-cloud-ecosystem-00\",\"data-dir\":\"/data/nvme0n1/ryan/workspace/pd/default.Scheduling-cloud-ecosystem-00\",\"enable-grpc-gateway\":true,\"metric\":{\"job\":\"\",\"address\":\"\",\"interval\":\"0s\"},\"log\":{\"level\":\"info\",\"format\":\"text\",\"disable-timestamp\":false,\"file\":{\"filename\":\"\",\"max-size\":0,\"max-days\":0,\"max-backups\":0},\"development\":false,\"disable-caller\":false,\"disable-stacktrace\":false,\"disable-error-verbose\":true,\"sampling\":null,\"error-output-path\":\"\"},\"Logger\":{},\"LogProps\":{\"Core\":{\"LevelEnabler\":\"info\"},\"Syncer\":{},\"Level\":\"info\"},\"security\":{\"cacert-path\":\"\",\"cert-path\":\"\",\"key-path\":\"\",\"cert-allowed-cn\":null,\"SSLCABytes\":null,\"SSLCertBytes\":null,\"SSLKEYBytes\":null,\"redact-info-log\":false,\"encryption\":{\"data-encryption-method\":\"plaintext\",\"data-key-rotation-period\":\"168h0m0s\",\"master-key\":{\"type\":\"plaintext\",\"key-id\":\"\",\"region\":\"\",\"endpoint\":\"\",\"path\":\"\"}}},\"WarningMsgs\":null,\"lease\":3,\"cluster-version\":\"0.0.0\",\"schedule\":{\"max-snapshot-count\":64,\"max-pending-peer-count\":64,\"max-merge-region-size\":20,\"max-merge-region-keys\":0,\"split-merge-interval\":\"1h0m0s\",\"switch-witness-interval\":\"1h0m0s\",\"enable-one-way-merge\":\"false\",\"enable-cross-table-merge\":\"true\",\"patrol-region-interval\":\"10ms\",\"max-store-down-time\":\"30m0s\",\"max-store-preparing-time\":\"48h0m0s\",\"leader-schedule-limit\":4,\"leader-schedule-policy\":\"count\",\"region-schedule-limit\":2048,\"witness-schedule-limit\":4,\"replica-schedule-limit\":64,\"merge-schedule-limit\":8,\"hot-region-schedule-limit\":4,\"hot-region-cache-hits-threshold\":3,\"store-limit\":{},\"tolerant-size-ratio\":0,\"low-space-ratio\":0.8,\"high-space-ratio\":0.7,\"region-score-formula-version\":\"v2\",\"scheduler-max-waiting-operator\":5,\"enable-remove-down-replica\":\"true\",\"enable-replace-offline-replica\":\"true\",\"enable-make-up-replica\":\"true\",\"enable-remove-extra-replica\":\"true\",\"enable-location-replacement\":\"true\",\"enable-debug-metrics\":\"false\",\"enable-joint-consensus\":\"true\",\"enable-tikv-split-region\":\"true\",\"schedulers-v2\":[{\"type\":\"balance-region\",\"args\":null,\"disable\":false,\"args-payload\":\"\"},{\"type\":\"balance-leader\",\"args\":null,\"disable\":false,\"args-payload\":\"\"},{\"type\":\"balance-witness\",\"args\":null,\"disable\":false,\"args-payload\":\"\"},{\"type\":\"hot-region\",\"args\":null,\"disable\":false,\"args-payload\":\"\"},{\"type\":\"transfer-witness-leader\",\"args\":null,\"disable\":false,\"args-payload\":\"\"}],\"schedulers-payload\":null,\"hot-regions-write-interval\":\"10m0s\",\"hot-regions-reserved-days\":7,\"max-movable-hot-peer-size\":512,\"enable-diagnostic\":\"true\",\"enable-witness\":\"false\",\"slow-store-evicting-affected-store-ratio-threshold\":0.3,\"store-limit-version\":\"v1\"},\"replication\":{\"max-replicas\":3,\"location-labels\":\"\",\"strictly-match-label\":\"false\",\"enable-placement-rules\":\"true\",\"enable-placement-rules-cache\":\"false\",\"isolation-level\":\"\"}}"]
[2023/08/04 16:48:08.945 +08:00] [INFO] [metricutil.go:86] ["disable Prometheus push client"]
[2023/08/04 16:48:08.947 +08:00] [INFO] [server.go:479] ["init cluster id"] [cluster-id=7263376508257569687]
[2023/08/04 16:48:08.947 +08:00] [INFO] [server.go:486] ["joining primary election"] [participant-name=http://127.0.0.1:3379] [participant-id=2055417977794868804]
[2023/08/04 16:48:08.947 +08:00] [INFO] [participant.go:84] ["participant joining election"] [participant-info="name:\"http://127.0.0.1:3379\" id:2055417977794868804 listen_urls:\"http://127.0.0.1:3379\" "] [leader-path=/ms/7263376508257569687/scheduling/00000/primary]
[2023/08/04 16:48:08.949 +08:00] [INFO] [etcdutil.go:670] ["load finished in watch loop"] [name=scheduling-config-watcher] [key=/pd/7263376508257569687/config]
[2023/08/04 16:48:08.949 +08:00] [INFO] [etcdutil.go:608] ["start to watch loop"] [name=scheduling-config-watcher] [key=/pd/7263376508257569687/config]
[2023/08/04 16:48:08.950 +08:00] [INFO] [etcdutil.go:670] ["load finished in watch loop"] [name=scheduling-rule-watcher] [key=/pd/7263376508257569687/rules]
[2023/08/04 16:48:08.950 +08:00] [INFO] [etcdutil.go:608] ["start to watch loop"] [name=scheduling-rule-watcher] [key=/pd/7263376508257569687/rules]
[2023/08/04 16:48:08.950 +08:00] [INFO] [etcdutil.go:670] ["load finished in watch loop"] [name=scheduling-rule-group-watcher] [key=/pd/7263376508257569687/rule_group]
[2023/08/04 16:48:08.950 +08:00] [INFO] [etcdutil.go:608] ["start to watch loop"] [name=scheduling-rule-group-watcher] [key=/pd/7263376508257569687/rule_group]
[2023/08/04 16:48:08.951 +08:00] [INFO] [etcdutil.go:670] ["load finished in watch loop"] [name=scheduling-region-label-watcher] [key=/pd/7263376508257569687/region_label]
[2023/08/04 16:48:08.951 +08:00] [INFO] [etcdutil.go:608] ["start to watch loop"] [name=scheduling-region-label-watcher] [key=/pd/7263376508257569687/region_label]
[2023/08/04 16:48:08.951 +08:00] [INFO] [coordinator.go:332] ["Coordinator starts to collect cluster information"]
[2023/08/04 16:48:08.951 +08:00] [INFO] [coordinator.go:335] ["Coordinator has finished cluster information preparation"]
[2023/08/04 16:48:08.951 +08:00] [INFO] [coordinator.go:345] ["Coordinator starts to run schedulers"]
[2023/08/04 16:48:08.951 +08:00] [INFO] [server.go:348] ["grpc server starts serving"] [address=127.0.0.1:3379]
[2023/08/04 16:48:08.951 +08:00] [INFO] [server.go:361] ["http server starts serving"] [address=127.0.0.1:3379]
[2023/08/04 16:48:08.951 +08:00] [INFO] [server.go:530] ["triggering the start callback functions"]
[2023/08/04 16:48:08.952 +08:00] [INFO] [server.go:200] ["start to campaign the primary/leader"] [campaign-scheduling-primary-name=http://127.0.0.1:3379]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:392] ["the scheduler type not found"] [scheduler-name=balance-hot-region-scheduler] [error="[PD:scheduler:ErrSchedulerNotFound]scheduler not found"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:392] ["the scheduler type not found"] [scheduler-name=balance-leader-scheduler] [error="[PD:scheduler:ErrSchedulerNotFound]scheduler not found"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:392] ["the scheduler type not found"] [scheduler-name=balance-region-scheduler] [error="[PD:scheduler:ErrSchedulerNotFound]scheduler not found"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:392] ["the scheduler type not found"] [scheduler-name=balance-witness-scheduler] [error="[PD:scheduler:ErrSchedulerNotFound]scheduler not found"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:392] ["the scheduler type not found"] [scheduler-name=transfer-witness-leader-scheduler] [error="[PD:scheduler:ErrSchedulerNotFound]scheduler not found"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:422] ["can not create scheduler"] [scheduler-type=balance-region] [scheduler-args="[]"] [error="[PD:scheduler:ErrSchedulerCreateFuncNotRegistered]create func of balance-region is not registered"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:422] ["can not create scheduler"] [scheduler-type=balance-leader] [scheduler-args="[]"] [error="[PD:scheduler:ErrSchedulerCreateFuncNotRegistered]create func of balance-leader is not registered"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:422] ["can not create scheduler"] [scheduler-type=balance-witness] [scheduler-args="[]"] [error="[PD:scheduler:ErrSchedulerCreateFuncNotRegistered]create func of balance-witness is not registered"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:422] ["can not create scheduler"] [scheduler-type=hot-region] [scheduler-args="[]"] [error="[PD:scheduler:ErrSchedulerCreateFuncNotRegistered]create func of hot-region is not registered"]
[2023/08/04 16:48:08.952 +08:00] [ERROR] [coordinator.go:422] ["can not create scheduler"] [scheduler-type=transfer-witness-leader] [scheduler-args="[]"] [error="[PD:scheduler:ErrSchedulerCreateFuncNotRegistered]create func of transfer-witness-leader is not registered"]
[2023/08/04 16:48:08.952 +08:00] [INFO] [coordinator.go:301] ["Coordinator begins to actively drive push operator"]
[2023/08/04 16:48:08.952 +08:00] [INFO] [coordinator.go:129] ["Coordinator starts patrol regions"]
[2023/08/04 16:48:08.952 +08:00] [INFO] [coordinator.go:237] ["Coordinator begins to check suspect key ranges"]
[2023/08/04 16:48:08.952 +08:00] [INFO] [lease.go:66] ["lease granted"] [lease-id=2463901927147700502] [lease-timeout=3] [purpose="primary election"]
[2023/08/04 16:48:08.953 +08:00] [INFO] [leadership.go:130] ["check campaign resp"] [resp="{\"header\":{\"cluster_id\":15674009460217235928,\"member_id\":3474484975246189105,\"revision\":1539,\"raft_term\":2},\"succeeded\":true,\"responses\":[{\"Response\":{\"ResponsePut\":{\"header\":{\"revision\":1539}}}}]}"]
[2023/08/04 16:48:08.953 +08:00] [INFO] [leadership.go:139] ["write leaderData to leaderPath ok"] [leaderPath=/ms/7263376508257569687/scheduling/00000/primary] [purpose="primary election"]
[2023/08/04 16:48:08.953 +08:00] [INFO] [server.go:223] ["campaign scheduling primary ok"] [campaign-scheduling-primary-name=http://127.0.0.1:3379]
[2023/08/04 16:48:08.953 +08:00] [INFO] [server.go:225] ["triggering the primary callback functions"]
[2023/08/04 16:48:08.953 +08:00] [INFO] [server.go:231] ["scheduling primary is ready to serve"] [scheduling-primary-name=http://127.0.0.1:3379]
[2023/08/04 16:48:08.953 +08:00] [INFO] [lease.go:155] ["start lease keep alive worker"] [interval=1s] [purpose="primary election"]
^C[2023/08/04 16:48:25.656 +08:00] [INFO] [coordinator.go:319] ["Coordinator is stopping"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [labeler.go:69] ["region labeler GC stopped"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [etcdutil.go:612] ["server is closed, exit watch loop"] [name=scheduling-region-label-watcher] [key=/pd/7263376508257569687/region_label]
[2023/08/04 16:48:25.656 +08:00] [INFO] [server.go:639] ["got signal to exit"] [signal=interrupt]
[2023/08/04 16:48:25.656 +08:00] [INFO] [coordinator.go:141] ["patrol regions has been stopped"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [register.go:73] ["exit register process"] [key=/ms/7263376508257569687/scheduling/registry/http://127.0.0.1:3379]
[2023/08/04 16:48:25.656 +08:00] [INFO] [server.go:258] ["closing scheduling server ..."]
[2023/08/04 16:48:25.656 +08:00] [INFO] [etcdutil.go:612] ["server is closed, exit watch loop"] [name=scheduling-rule-watcher] [key=/pd/7263376508257569687/rules]
[2023/08/04 16:48:25.656 +08:00] [INFO] [lease.go:184] ["stop lease keep alive worker"] [purpose="primary election"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [etcdutil.go:612] ["server is closed, exit watch loop"] [name=scheduling-config-watcher] [key=/pd/7263376508257569687/config]
[2023/08/04 16:48:25.656 +08:00] [INFO] [coordinator.go:243] ["check suspect key ranges has been stopped"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [coordinator.go:307] ["drive push operator has been stopped"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [coordinator.go:322] ["Coordinator has been stopped"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [server.go:245] ["server is closed"]
[2023/08/04 16:48:25.656 +08:00] [INFO] [etcdutil.go:612] ["server is closed, exit watch loop"] [name=scheduling-rule-group-watcher] [key=/pd/7263376508257569687/rule_group]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:179] ["server is closed, exit resource manager primary election loop"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:414] ["stopping http server"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:401] ["mux stopped serving"] [error="accept tcp 127.0.0.1:3379: use of closed network connection"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:364] ["http server stopped"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:436] ["http server stopped"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:439] ["stopping grpc server"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:351] ["grpc server stopped"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:473] ["grpc server stopped"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [etcdutil.go:273] ["[etcd client] etcd client is closed, exit health check goroutine"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [etcdutil.go:316] ["[etcd client] etcd client is closed, exit update endpoint goroutine"]
[2023/08/04 16:48:25.657 +08:00] [INFO] [server.go:275] ["scheduling server is closed"]
```

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (see above logs)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
