### PR TITLE
pd-ctl: fix keyspace group split hang when pd is in pd-mode

### DIFF
--- a/server/apiv2/handlers/tso_keyspace_group.go
+++ b/server/apiv2/handlers/tso_keyspace_group.go
@@ -289,6 +289,10 @@ func FinishSplitKeyspaceByID(c *gin.Context) {
 
 	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
 	manager := svr.GetKeyspaceGroupManager()
+	if manager == nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, groupManagerUninitializedErr)
+		return
+	}
 	err = manager.FinishSplitKeyspaceByID(id)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
@@ -360,6 +364,10 @@ func FinishMergeKeyspaceByID(c *gin.Context) {
 
 	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
 	manager := svr.GetKeyspaceGroupManager()
+	if manager == nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, groupManagerUninitializedErr)
+		return
+	}
 	err = manager.FinishMergeKeyspaceByID(id)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())

--- a/server/server.go
+++ b/server/server.go
@@ -1718,6 +1718,9 @@ func (s *Server) reloadConfigFromKV() error {
 }
 
 func (s *Server) loadKeyspaceConfig() {
+	if s.keyspaceManager == nil {
+		return
+	}
 	cfg := s.persistOptions.GetKeyspaceConfig()
 	s.keyspaceManager.UpdateConfig(cfg)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -855,6 +855,12 @@ func (s *Server) GetKeyspaceManager() *keyspace.Manager {
 	return s.keyspaceManager
 }
 
+// SetKeyspaceManager sets the keyspace manager of server.
+// Note: it is only used for test.
+func (s *Server) SetKeyspaceManager(keyspaceManager *keyspace.Manager) {
+	s.keyspaceManager = keyspaceManager
+}
+
 // GetSafePointV2Manager returns the safe point v2 manager of server.
 func (s *Server) GetSafePointV2Manager() *gc.SafePointV2Manager {
 	return s.safePointV2Manager

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -244,6 +244,13 @@ func (s *TestServer) GetKeyspaceManager() *keyspace.Manager {
 	return s.server.GetKeyspaceManager()
 }
 
+// SetKeyspaceManager sets the current TestServer's Keyspace Manager.
+func (s *TestServer) SetKeyspaceManager(km *keyspace.Manager) {
+	s.RLock()
+	defer s.RUnlock()
+	s.server.SetKeyspaceManager(km)
+}
+
 // GetCluster returns PD cluster.
 func (s *TestServer) GetCluster() *metapb.Cluster {
 	s.RLock()

--- a/tests/pdctl/keyspace/keyspace_group_test.go
+++ b/tests/pdctl/keyspace/keyspace_group_test.go
@@ -583,3 +583,42 @@ func TestShowKeyspaceGroupPrimary(t *testing.T) {
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/fastGroupSplitPatroller"))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayStartServerLoop"))
 }
+
+func TestInPDMode(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	err = tc.RunInitialServers()
+	re.NoError(err)
+	pdAddr := tc.GetConfig().GetClientURL()
+	cmd := pdctlCmd.GetRootCmd()
+	tc.WaitLeader()
+	leaderServer := tc.GetServer(tc.GetLeader())
+	re.NoError(leaderServer.BootstrapCluster())
+
+	argsList := [][]string{
+		{"-u", pdAddr, "keyspace-group"},
+		{"-u", pdAddr, "keyspace-group", "0"},
+		{"-u", pdAddr, "keyspace-group", "split", "0", "1", "2"},
+		{"-u", pdAddr, "keyspace-group", "split-range", "1", "2", "3", "4"},
+		{"-u", pdAddr, "keyspace-group", "finish-split", "1"},
+		{"-u", pdAddr, "keyspace-group", "merge", "1", "2"},
+		{"-u", pdAddr, "keyspace-group", "merge", "0", "--all"},
+		{"-u", pdAddr, "keyspace-group", "finish-merge", "1"},
+		{"-u", pdAddr, "keyspace-group", "set-node", "0", "http://127.0.0.1:2379"},
+		{"-u", pdAddr, "keyspace-group", "set-priority", "0", "http://127.0.0.1:2379", "200"},
+		{"-u", pdAddr, "keyspace-group", "primary", "0"},
+	}
+	for _, args := range argsList {
+		output, err := pdctl.ExecuteCommand(cmd, args...)
+		re.NoError(err)
+		re.Contains(string(output), "Failed",
+			"args: %v, output: %v", args, string(output))
+		re.Contains(string(output), "keyspace group manager is not initialized",
+			"args: %v, output: %v", args, string(output))
+	}
+
+	leaderServer.GetKeyspaceManager()
+}

--- a/tests/pdctl/keyspace/keyspace_group_test.go
+++ b/tests/pdctl/keyspace/keyspace_group_test.go
@@ -620,5 +620,12 @@ func TestInPDMode(t *testing.T) {
 			"args: %v, output: %v", args, string(output))
 	}
 
-	leaderServer.GetKeyspaceManager()
+	leaderServer.SetKeyspaceManager(nil)
+	args := []string{"-u", pdAddr, "keyspace-group", "split", "0", "1", "2"}
+	output, err := pdctl.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.Contains(string(output), "Failed",
+		"args: %v, output: %v", args, string(output))
+	re.Contains(string(output), "keyspace manager is not initialized",
+		"args: %v, output: %v", args, string(output))
 }

--- a/tools/pd-ctl/pdctl/command/keyspace_group_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_group_command.go
@@ -242,7 +242,7 @@ func finishSplitKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	}
 	_, err = doRequest(cmd, fmt.Sprintf("%s/%s/split", keyspaceGroupsPrefix, args[0]), http.MethodDelete, http.Header{})
 	if err != nil {
-		cmd.Println(err)
+		cmd.Printf("Failed to finish split-keyspace-group: %s\n", err)
 		return
 	}
 	cmd.Println("Success!")
@@ -309,7 +309,7 @@ func finishMergeKeyspaceGroupCommandFunc(cmd *cobra.Command, args []string) {
 	}
 	_, err = doRequest(cmd, fmt.Sprintf("%s/%s/merge", keyspaceGroupsPrefix, args[0]), http.MethodDelete, http.Header{})
 	if err != nil {
-		cmd.Println(err)
+		cmd.Printf("Failed to finish merge-keyspace-group: %s\n", err)
 		return
 	}
 	cmd.Println("Success!")


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6906

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test
![image](https://github.com/tikv/pd/assets/19542290/04fd3dda-b69a-4c97-bbfc-97aa9387764e)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
