### PR TITLE
scheduling/config: watch StoreConfig in scheduling config watcher

### DIFF
--- a/pkg/mcs/scheduling/server/config/watcher.go
+++ b/pkg/mcs/scheduling/server/config/watcher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/log"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
+	"github.com/tikv/pd/server/config"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/mvcc/mvccpb"
 	"go.uber.org/zap"
@@ -42,9 +43,10 @@ type Watcher struct {
 }
 
 type persistedConfig struct {
+	ClusterVersion semver.Version       `json:"cluster-version"`
 	Schedule       sc.ScheduleConfig    `json:"schedule"`
 	Replication    sc.ReplicationConfig `json:"replication"`
-	ClusterVersion semver.Version       `json:"cluster-version"`
+	Store          config.StoreConfig   `json:"store"`
 }
 
 // NewWatcher creates a new watcher to watch the config meta change from PD API server.
@@ -71,9 +73,10 @@ func NewWatcher(
 				zap.String("event-kv-key", string(kv.Key)), zap.Error(err))
 			return err
 		}
+		cw.SetClusterVersion(&cfg.ClusterVersion)
 		cw.SetScheduleConfig(&cfg.Schedule)
 		cw.SetReplicationConfig(&cfg.Replication)
-		cw.SetClusterVersion(&cfg.ClusterVersion)
+		cw.SetStoreConfig(&cfg.Store)
 		return nil
 	}
 	deleteFn := func(kv *mvccpb.KeyValue) error {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5839

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Watch `StoreConfig` in scheduling config watcher.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
