### PR TITLE
scheduling: watch the respective scheduler config and trim the prefix

### DIFF
--- a/pkg/mcs/scheduling/server/config/watcher.go
+++ b/pkg/mcs/scheduling/server/config/watcher.go
@@ -17,11 +17,13 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/pingcap/log"
 	sc "github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/mvcc/mvccpb"
@@ -34,11 +36,20 @@ type Watcher struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	etcdClient *clientv3.Client
-	watcher    *etcdutil.LoopWatcher
+	// configPath is the path of the configuration in etcd:
+	//  - Key: /pd/{cluster_id}/config
+	//  - Value: configuration JSON.
+	configPath string
+	// schedulerConfigPath is the path of the scheduler configuration in etcd:
+	//  - Key: /pd/{cluster_id}/scheduler_config/{scheduler_name}
+	//  - Value: configuration JSON.
+	schedulerConfigPath string
+
+	etcdClient             *clientv3.Client
+	configWatcher          *etcdutil.LoopWatcher
+	schedulerConfigWatcher *etcdutil.LoopWatcher
 
 	*PersistConfig
-	// TODO: watch the scheduler config change.
 }
 
 type persistedConfig struct {
@@ -52,19 +63,30 @@ type persistedConfig struct {
 func NewWatcher(
 	ctx context.Context,
 	etcdClient *clientv3.Client,
-	// configPath is the path of the configuration in etcd:
-	//  - Key: /pd/{cluster_id}/config
-	//  - Value: configuration JSON.
-	configPath string,
+	clusterID uint64,
 	persistConfig *PersistConfig,
 ) (*Watcher, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	cw := &Watcher{
-		ctx:           ctx,
-		cancel:        cancel,
-		etcdClient:    etcdClient,
-		PersistConfig: persistConfig,
+		ctx:                 ctx,
+		cancel:              cancel,
+		configPath:          endpoint.ConfigPath(clusterID),
+		schedulerConfigPath: endpoint.SchedulerConfigPath(clusterID) + "/",
+		etcdClient:          etcdClient,
+		PersistConfig:       persistConfig,
 	}
+	err := cw.initializeConfigWatcher()
+	if err != nil {
+		return nil, err
+	}
+	err = cw.initializeSchedulerConfigWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return cw, nil
+}
+
+func (cw *Watcher) initializeConfigWatcher() error {
 	putFn := func(kv *mvccpb.KeyValue) error {
 		cfg := &persistedConfig{}
 		if err := json.Unmarshal(kv.Value, cfg); err != nil {
@@ -84,21 +106,40 @@ func NewWatcher(
 	postEventFn := func() error {
 		return nil
 	}
-	cw.watcher = etcdutil.NewLoopWatcher(
-		ctx,
-		&cw.wg,
-		etcdClient,
-		"scheduling-config-watcher",
-		configPath,
-		putFn,
-		deleteFn,
-		postEventFn,
+	cw.configWatcher = etcdutil.NewLoopWatcher(
+		cw.ctx, &cw.wg,
+		cw.etcdClient,
+		"scheduling-config-watcher", cw.configPath,
+		putFn, deleteFn, postEventFn,
 	)
-	cw.watcher.StartWatchLoop()
-	if err := cw.watcher.WaitLoad(); err != nil {
-		return nil, err
+	cw.configWatcher.StartWatchLoop()
+	return cw.configWatcher.WaitLoad()
+}
+
+func (cw *Watcher) initializeSchedulerConfigWatcher() error {
+	putFn := func(kv *mvccpb.KeyValue) error {
+		cw.SetSchedulerConfig(
+			strings.TrimPrefix(string(kv.Key), cw.schedulerConfigPath),
+			string(kv.Value),
+		)
+		return nil
 	}
-	return cw, nil
+	deleteFn := func(kv *mvccpb.KeyValue) error {
+		cw.RemoveSchedulerConfig(strings.TrimPrefix(string(kv.Key), cw.schedulerConfigPath))
+		return nil
+	}
+	postEventFn := func() error {
+		return nil
+	}
+	cw.schedulerConfigWatcher = etcdutil.NewLoopWatcher(
+		cw.ctx, &cw.wg,
+		cw.etcdClient,
+		"scheduling-scheduler-config-watcher", cw.schedulerConfigPath,
+		putFn, deleteFn, postEventFn,
+		clientv3.WithPrefix(),
+	)
+	cw.schedulerConfigWatcher.StartWatchLoop()
+	return cw.schedulerConfigWatcher.WaitLoad()
 }
 
 // Close closes the watcher.

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -550,18 +550,13 @@ func (s *Server) startServer() (err error) {
 
 func (s *Server) startWatcher() (err error) {
 	s.configWatcher, err = config.NewWatcher(
-		s.ctx, s.etcdClient,
-		endpoint.ConfigPath(s.clusterID),
-		s.persistConfig,
+		s.ctx, s.etcdClient, s.clusterID, s.persistConfig,
 	)
 	if err != nil {
 		return err
 	}
 	s.ruleWatcher, err = rule.NewWatcher(
-		s.ctx, s.etcdClient,
-		endpoint.RulesPath(s.clusterID),
-		endpoint.RuleGroupPath(s.clusterID),
-		endpoint.RegionLabelPath(s.clusterID),
+		s.ctx, s.etcdClient, s.clusterID,
 	)
 	return err
 }

--- a/pkg/storage/endpoint/key_path.go
+++ b/pkg/storage/endpoint/key_path.go
@@ -92,6 +92,11 @@ func ConfigPath(clusterID uint64) string {
 	return path.Join(PDRootPath(clusterID), configPath)
 }
 
+// SchedulerConfigPath returns the path to save the scheduler config.
+func SchedulerConfigPath(clusterID uint64) string {
+	return path.Join(PDRootPath(clusterID), customScheduleConfigPath)
+}
+
 // RulesPath returns the path to save the placement rules.
 func RulesPath(clusterID uint64) string {
 	return path.Join(PDRootPath(clusterID), rulesPath)

--- a/pkg/storage/endpoint/key_path.go
+++ b/pkg/storage/endpoint/key_path.go
@@ -92,23 +92,23 @@ func ConfigPath(clusterID uint64) string {
 	return path.Join(PDRootPath(clusterID), configPath)
 }
 
-// SchedulerConfigPath returns the path to save the scheduler config.
-func SchedulerConfigPath(clusterID uint64) string {
+// SchedulerConfigPathPrefix returns the path prefix to save the scheduler config.
+func SchedulerConfigPathPrefix(clusterID uint64) string {
 	return path.Join(PDRootPath(clusterID), customScheduleConfigPath)
 }
 
-// RulesPath returns the path to save the placement rules.
-func RulesPath(clusterID uint64) string {
+// RulesPathPrefix returns the path prefix to save the placement rules.
+func RulesPathPrefix(clusterID uint64) string {
 	return path.Join(PDRootPath(clusterID), rulesPath)
 }
 
-// RuleGroupPath returns the path to save the placement rule groups.
-func RuleGroupPath(clusterID uint64) string {
+// RuleGroupPathPrefix returns the path prefix to save the placement rule groups.
+func RuleGroupPathPrefix(clusterID uint64) string {
 	return path.Join(PDRootPath(clusterID), ruleGroupPath)
 }
 
-// RegionLabelPath returns the path to save the region label.
-func RegionLabelPath(clusterID uint64) string {
+// RegionLabelPathPrefix returns the path prefix to save the region label.
+func RegionLabelPathPrefix(clusterID uint64) string {
 	return path.Join(PDRootPath(clusterID), regionLabelPath)
 }
 

--- a/tests/integrations/mcs/scheduling/rule_test.go
+++ b/tests/integrations/mcs/scheduling/rule_test.go
@@ -100,13 +100,10 @@ func (suite *ruleTestSuite) TestRuleWatch() {
 	re := suite.Require()
 
 	// Create a rule watcher.
-	clusterID := suite.cluster.GetCluster().GetId()
 	watcher, err := rule.NewWatcher(
 		suite.ctx,
 		suite.pdLeaderServer.GetEtcdClient(),
-		endpoint.RulesPath(clusterID),
-		endpoint.RuleGroupPath(clusterID),
-		endpoint.RegionLabelPath(clusterID),
+		suite.cluster.GetCluster().GetId(),
 	)
 	re.NoError(err)
 	ruleStorage := watcher.GetRuleStorage()


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5839.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- Make scheduling service watch the respective scheduler config.
- Trim the key prefix inside the watcher.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
