### PR TITLE
apiutil, middleware: strengthen the robustness of GetIPPortFromHTTPRequest function

### DIFF
--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -103,7 +103,7 @@ func TestLocalLogBackendUsingFile(t *testing.T) {
 	b, _ := os.ReadFile(fname)
 	output := strings.SplitN(string(b), "]", 4)
 	re.Equal(
-		fmt.Sprintf(" [\"audit log\"] [service-info=\"{ServiceLabel:, Method:HTTP/1.1/GET:/test, Component:anonymous, IP:, "+
+		fmt.Sprintf(" [\"audit log\"] [service-info=\"{ServiceLabel:, Method:HTTP/1.1/GET:/test, Component:anonymous, IP:, Port:, "+
 			"StartTime:%s, URLParam:{\\\"test\\\":[\\\"test\\\"]}, BodyParam:testBody}\"]\n",
 			time.Unix(info.StartTimeStamp, 0).String()),
 		output[3],

--- a/pkg/utils/apiutil/apiutil.go
+++ b/pkg/utils/apiutil/apiutil.go
@@ -47,6 +47,17 @@ var (
 )
 
 const (
+	// PDRedirectorHeader is used to mark which PD redirected this request.
+	PDRedirectorHeader = "PD-Redirector"
+	// PDAllowFollowerHandle is used to mark whether this request is allowed to be handled by the follower PD.
+	PDAllowFollowerHandle = "PD-Allow-follower-handle"
+	// XForwardedForHeader is used to mark the client IP.
+	XForwardedForHeader = "X-Forwarded-For"
+	// XForwardedPortHeader is used to mark the client port.
+	XForwardedPortHeader = "X-Forwarded-Port"
+	// XRealIP is used to mark the real client IP.
+	XRealIP = "X-Real-Ip"
+
 	// ErrRedirectFailed is the error message for redirect failed.
 	ErrRedirectFailed = "redirect failed"
 	// ErrRedirectToNotLeader is the error message for redirect to not leader.
@@ -101,26 +112,30 @@ func ErrorResp(rd *render.Render, w http.ResponseWriter, err error) {
 	}
 }
 
-// GetIPAddrFromHTTPRequest returns http client IP from context.
+// GetIPPortFromHTTPRequest returns http client host IP and port from context.
 // Because `X-Forwarded-For ` header has been written into RFC 7239(Forwarded HTTP Extension),
 // so `X-Forwarded-For` has the higher priority than `X-Real-IP`.
 // And both of them have the higher priority than `RemoteAddr`
-func GetIPAddrFromHTTPRequest(r *http.Request) string {
-	ips := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
-	if len(strings.Trim(ips[0], " ")) > 0 {
-		return ips[0]
+func GetIPPortFromHTTPRequest(r *http.Request) (ip, port string) {
+	forwardedIPs := strings.Split(r.Header.Get(XForwardedForHeader), ",")
+	if forwardedIP := strings.Trim(forwardedIPs[0], " "); len(forwardedIP) > 0 {
+		ip = forwardedIP
+		// Try to get the port from "X-Forwarded-Port" header.
+		forwardedPorts := strings.Split(r.Header.Get(XForwardedPortHeader), ",")
+		if forwardedPort := strings.Trim(forwardedPorts[0], " "); len(forwardedPort) > 0 {
+			port = forwardedPort
+		}
+	} else if realIP := r.Header.Get(XRealIP); len(realIP) > 0 {
+		ip = realIP
+	} else {
+		ip = r.RemoteAddr
 	}
-
-	ip := r.Header.Get("X-Real-Ip")
-	if ip != "" {
-		return ip
-	}
-
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	splitIP, splitPort, err := net.SplitHostPort(ip)
 	if err != nil {
-		return ""
+		// Ensure that we could get a valid IP address at least.
+		return ip, port
 	}
-	return ip
+	return splitIP, splitPort
 }
 
 // GetComponentNameOnHTTP returns component name from Request Header

--- a/pkg/utils/apiutil/apiutil.go
+++ b/pkg/utils/apiutil/apiutil.go
@@ -49,14 +49,14 @@ var (
 const (
 	// PDRedirectorHeader is used to mark which PD redirected this request.
 	PDRedirectorHeader = "PD-Redirector"
-	// PDAllowFollowerHandle is used to mark whether this request is allowed to be handled by the follower PD.
-	PDAllowFollowerHandle = "PD-Allow-follower-handle"
+	// PDAllowFollowerHandleHeader is used to mark whether this request is allowed to be handled by the follower PD.
+	PDAllowFollowerHandleHeader = "PD-Allow-follower-handle"
 	// XForwardedForHeader is used to mark the client IP.
 	XForwardedForHeader = "X-Forwarded-For"
 	// XForwardedPortHeader is used to mark the client port.
 	XForwardedPortHeader = "X-Forwarded-Port"
-	// XRealIP is used to mark the real client IP.
-	XRealIP = "X-Real-Ip"
+	// XRealIPHeader is used to mark the real client IP.
+	XRealIPHeader = "X-Real-Ip"
 
 	// ErrRedirectFailed is the error message for redirect failed.
 	ErrRedirectFailed = "redirect failed"
@@ -125,7 +125,7 @@ func GetIPPortFromHTTPRequest(r *http.Request) (ip, port string) {
 		if forwardedPort := strings.Trim(forwardedPorts[0], " "); len(forwardedPort) > 0 {
 			port = forwardedPort
 		}
-	} else if realIP := r.Header.Get(XRealIP); len(realIP) > 0 {
+	} else if realIP := r.Header.Get(XRealIPHeader); len(realIP) > 0 {
 		ip = realIP
 	} else {
 		ip = r.RemoteAddr

--- a/pkg/utils/apiutil/apiutil.go
+++ b/pkg/utils/apiutil/apiutil.go
@@ -132,7 +132,7 @@ func GetIPPortFromHTTPRequest(r *http.Request) (ip, port string) {
 	}
 	splitIP, splitPort, err := net.SplitHostPort(ip)
 	if err != nil {
-		// Ensure that we could get a valid IP address at least.
+		// Ensure we could get an IP address at least.
 		return ip, port
 	}
 	return splitIP, splitPort

--- a/pkg/utils/apiutil/apiutil_test.go
+++ b/pkg/utils/apiutil/apiutil_test.go
@@ -17,6 +17,7 @@ package apiutil
 import (
 	"bytes"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -66,5 +67,137 @@ func TestJsonRespondErrorBadInput(t *testing.T) {
 		result := response.Result()
 		defer result.Body.Close()
 		re.Equal(400, result.StatusCode)
+	}
+}
+
+func TestGetIPPortFromHTTPRequest(t *testing.T) {
+	t.Parallel()
+	re := require.New(t)
+
+	testCases := []struct {
+		r    *http.Request
+		ip   string
+		port string
+		err  error
+	}{
+		// IPv4 "X-Forwarded-For" with port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XForwardedForHeader: {"127.0.0.1:5299"},
+				},
+			},
+			ip:   "127.0.0.1",
+			port: "5299",
+		},
+		// IPv4 "X-Forwarded-For" without port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XForwardedForHeader:  {"127.0.0.1"},
+					XForwardedPortHeader: {"5299"},
+				},
+			},
+			ip:   "127.0.0.1",
+			port: "5299",
+		},
+		// IPv4 "X-Real-IP" with port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XRealIP: {"127.0.0.1:5299"},
+				},
+			},
+			ip:   "127.0.0.1",
+			port: "5299",
+		},
+		// IPv4 "X-Real-IP" without port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XForwardedForHeader:  {"127.0.0.1"},
+					XForwardedPortHeader: {"5299"},
+				},
+			},
+			ip:   "127.0.0.1",
+			port: "5299",
+		},
+		// IPv4 RemoteAddr with port
+		{
+			r: &http.Request{
+				RemoteAddr: "127.0.0.1:5299",
+			},
+			ip:   "127.0.0.1",
+			port: "5299",
+		},
+		// IPv4 RemoteAddr without port
+		{
+			r: &http.Request{
+				RemoteAddr: "127.0.0.1",
+			},
+			ip:   "127.0.0.1",
+			port: "",
+		},
+		// IPv6 "X-Forwarded-For" with port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XForwardedForHeader: {"[::1]:5299"},
+				},
+			},
+			ip:   "::1",
+			port: "5299",
+		},
+		// IPv6 "X-Forwarded-For" without port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XForwardedForHeader: {"::1"},
+				},
+			},
+			ip:   "::1",
+			port: "",
+		},
+		// IPv6 "X-Real-IP" with port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XRealIP: {"[::1]:5299"},
+				},
+			},
+			ip:   "::1",
+			port: "5299",
+		},
+		// IPv6 "X-Real-IP" without port
+		{
+			r: &http.Request{
+				Header: map[string][]string{
+					XForwardedForHeader: {"::1"},
+				},
+			},
+			ip:   "::1",
+			port: "",
+		},
+		// IPv6 RemoteAddr with port
+		{
+			r: &http.Request{
+				RemoteAddr: "[::1]:5299",
+			},
+			ip:   "::1",
+			port: "5299",
+		},
+		// IPv6 RemoteAddr without port
+		{
+			r: &http.Request{
+				RemoteAddr: "::1",
+			},
+			ip:   "::1",
+			port: "",
+		},
+	}
+	for idx, testCase := range testCases {
+		ip, port := GetIPPortFromHTTPRequest(testCase.r)
+		re.Equal(testCase.ip, ip, "case %d", idx)
+		re.Equal(testCase.port, port, "case %d", idx)
 	}
 }

--- a/pkg/utils/apiutil/apiutil_test.go
+++ b/pkg/utils/apiutil/apiutil_test.go
@@ -105,7 +105,7 @@ func TestGetIPPortFromHTTPRequest(t *testing.T) {
 		{
 			r: &http.Request{
 				Header: map[string][]string{
-					XRealIP: {"127.0.0.1:5299"},
+					XRealIPHeader: {"127.0.0.1:5299"},
 				},
 			},
 			ip:   "127.0.0.1",
@@ -162,7 +162,7 @@ func TestGetIPPortFromHTTPRequest(t *testing.T) {
 		{
 			r: &http.Request{
 				Header: map[string][]string{
-					XRealIP: {"[::1]:5299"},
+					XRealIPHeader: {"[::1]:5299"},
 				},
 			},
 			ip:   "::1",

--- a/pkg/utils/apiutil/apiutil_test.go
+++ b/pkg/utils/apiutil/apiutil_test.go
@@ -194,6 +194,12 @@ func TestGetIPPortFromHTTPRequest(t *testing.T) {
 			ip:   "::1",
 			port: "",
 		},
+		// Abnormal case
+		{
+			r:    &http.Request{},
+			ip:   "",
+			port: "",
+		},
 	}
 	for idx, testCase := range testCases {
 		ip, port := GetIPPortFromHTTPRequest(testCase.r)

--- a/pkg/utils/apiutil/serverapi/middleware.go
+++ b/pkg/utils/apiutil/serverapi/middleware.go
@@ -15,7 +15,6 @@
 package serverapi
 
 import (
-	"net"
 	"net/http"
 	"net/url"
 
@@ -139,11 +138,15 @@ func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http
 	}
 
 	r.Header.Set(apiutil.PDRedirectorHeader, h.s.Name())
-	if forwardedIP, forwardedPort, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+	forwardedIP, forwardedPort := apiutil.GetIPPortFromHTTPRequest(r)
+	if len(forwardedIP) > 0 {
 		r.Header.Add(apiutil.XForwardedForHeader, forwardedIP)
-		r.Header.Add(apiutil.XForwardedPortHeader, forwardedPort)
 	} else {
+		// Fallback if GetIPPortFromHTTPRequest failed to get the IP.
 		r.Header.Add(apiutil.XForwardedForHeader, r.RemoteAddr)
+	}
+	if len(forwardedPort) > 0 {
+		r.Header.Add(apiutil.XForwardedPortHeader, forwardedPort)
 	}
 
 	var clientUrls []string

--- a/pkg/utils/apiutil/serverapi/middleware.go
+++ b/pkg/utils/apiutil/serverapi/middleware.go
@@ -123,7 +123,7 @@ func (h *redirector) matchMicroServiceRedirectRules(r *http.Request) (bool, stri
 
 func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	matchedFlag, targetAddr := h.matchMicroServiceRedirectRules(r)
-	allowFollowerHandle := len(r.Header.Get(apiutil.PDAllowFollowerHandle)) > 0
+	allowFollowerHandle := len(r.Header.Get(apiutil.PDAllowFollowerHandleHeader)) > 0
 	isLeader := h.s.GetMember().IsLeader()
 	if !h.s.IsClosed() && (allowFollowerHandle || isLeader) && !matchedFlag {
 		next(w, r)

--- a/pkg/utils/apiutil/serverapi/middleware.go
+++ b/pkg/utils/apiutil/serverapi/middleware.go
@@ -15,6 +15,7 @@
 package serverapi
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 
@@ -24,13 +25,6 @@ import (
 	"github.com/tikv/pd/server"
 	"github.com/urfave/negroni"
 	"go.uber.org/zap"
-)
-
-// HTTP headers.
-const (
-	PDRedirectorHeader    = "PD-Redirector"
-	PDAllowFollowerHandle = "PD-Allow-follower-handle"
-	ForwardedForHeader    = "X-Forwarded-For"
 )
 
 type runtimeServiceValidator struct {
@@ -130,7 +124,7 @@ func (h *redirector) matchMicroServiceRedirectRules(r *http.Request) (bool, stri
 
 func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	matchedFlag, targetAddr := h.matchMicroServiceRedirectRules(r)
-	allowFollowerHandle := len(r.Header.Get(PDAllowFollowerHandle)) > 0
+	allowFollowerHandle := len(r.Header.Get(apiutil.PDAllowFollowerHandle)) > 0
 	isLeader := h.s.GetMember().IsLeader()
 	if !h.s.IsClosed() && (allowFollowerHandle || isLeader) && !matchedFlag {
 		next(w, r)
@@ -138,14 +132,19 @@ func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http
 	}
 
 	// Prevent more than one redirection.
-	if name := r.Header.Get(PDRedirectorHeader); len(name) != 0 {
+	if name := r.Header.Get(apiutil.PDRedirectorHeader); len(name) != 0 {
 		log.Error("redirect but server is not leader", zap.String("from", name), zap.String("server", h.s.Name()), errs.ZapError(errs.ErrRedirect))
 		http.Error(w, apiutil.ErrRedirectToNotLeader, http.StatusInternalServerError)
 		return
 	}
 
-	r.Header.Set(PDRedirectorHeader, h.s.Name())
-	r.Header.Add(ForwardedForHeader, r.RemoteAddr)
+	r.Header.Set(apiutil.PDRedirectorHeader, h.s.Name())
+	if forwardedIP, forwardedPort, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		r.Header.Add(apiutil.XForwardedForHeader, forwardedIP)
+		r.Header.Add(apiutil.XForwardedPortHeader, forwardedPort)
+	} else {
+		r.Header.Add(apiutil.XForwardedForHeader, r.RemoteAddr)
+	}
 
 	var clientUrls []string
 	if matchedFlag {

--- a/pkg/utils/requestutil/request_info.go
+++ b/pkg/utils/requestutil/request_info.go
@@ -31,24 +31,27 @@ type RequestInfo struct {
 	Method         string
 	Component      string
 	IP             string
+	Port           string
 	URLParam       string
 	BodyParam      string
 	StartTimeStamp int64
 }
 
 func (info *RequestInfo) String() string {
-	s := fmt.Sprintf("{ServiceLabel:%s, Method:%s, Component:%s, IP:%s, StartTime:%s, URLParam:%s, BodyParam:%s}",
-		info.ServiceLabel, info.Method, info.Component, info.IP, time.Unix(info.StartTimeStamp, 0), info.URLParam, info.BodyParam)
+	s := fmt.Sprintf("{ServiceLabel:%s, Method:%s, Component:%s, IP:%s, Port:%s, StartTime:%s, URLParam:%s, BodyParam:%s}",
+		info.ServiceLabel, info.Method, info.Component, info.IP, info.Port, time.Unix(info.StartTimeStamp, 0), info.URLParam, info.BodyParam)
 	return s
 }
 
 // GetRequestInfo returns request info needed from http.Request
 func GetRequestInfo(r *http.Request) RequestInfo {
+	ip, port := apiutil.GetIPPortFromHTTPRequest(r)
 	return RequestInfo{
 		ServiceLabel:   apiutil.GetRouteName(r),
 		Method:         fmt.Sprintf("%s/%s:%s", r.Proto, r.Method, r.URL.Path),
 		Component:      apiutil.GetComponentNameOnHTTP(r),
-		IP:             apiutil.GetIPAddrFromHTTPRequest(r),
+		IP:             ip,
+		Port:           port,
 		URLParam:       getURLParam(r),
 		BodyParam:      getBodyParam(r),
 		StartTimeStamp: time.Now().Unix(),

--- a/server/apiv2/middlewares/redirector.go
+++ b/server/apiv2/middlewares/redirector.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/utils/apiutil"
-	"github.com/tikv/pd/pkg/utils/apiutil/serverapi"
 	"github.com/tikv/pd/server"
 	"go.uber.org/zap"
 )
@@ -31,7 +30,7 @@ import (
 func Redirector() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		svr := c.MustGet(ServerContextKey).(*server.Server)
-		allowFollowerHandle := len(c.Request.Header.Get(serverapi.PDAllowFollowerHandle)) > 0
+		allowFollowerHandle := len(c.Request.Header.Get(apiutil.PDAllowFollowerHandle)) > 0
 		isLeader := svr.GetMember().IsLeader()
 		if !svr.IsClosed() && (allowFollowerHandle || isLeader) {
 			c.Next()
@@ -39,13 +38,13 @@ func Redirector() gin.HandlerFunc {
 		}
 
 		// Prevent more than one redirection.
-		if name := c.Request.Header.Get(serverapi.PDRedirectorHeader); len(name) != 0 {
+		if name := c.Request.Header.Get(apiutil.PDRedirectorHeader); len(name) != 0 {
 			log.Error("redirect but server is not leader", zap.String("from", name), zap.String("server", svr.Name()), errs.ZapError(errs.ErrRedirect))
 			c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrRedirect.FastGenByArgs().Error())
 			return
 		}
 
-		c.Request.Header.Set(serverapi.PDRedirectorHeader, svr.Name())
+		c.Request.Header.Set(apiutil.PDRedirectorHeader, svr.Name())
 
 		leader := svr.GetMember().GetLeader()
 		if leader == nil {

--- a/server/apiv2/middlewares/redirector.go
+++ b/server/apiv2/middlewares/redirector.go
@@ -30,7 +30,7 @@ import (
 func Redirector() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		svr := c.MustGet(ServerContextKey).(*server.Server)
-		allowFollowerHandle := len(c.Request.Header.Get(apiutil.PDAllowFollowerHandle)) > 0
+		allowFollowerHandle := len(c.Request.Header.Get(apiutil.PDAllowFollowerHandleHeader)) > 0
 		isLeader := svr.GetMember().IsLeader()
 		if !svr.IsClosed() && (allowFollowerHandle || isLeader) {
 			c.Next()

--- a/server/server.go
+++ b/server/server.go
@@ -1744,7 +1744,7 @@ func (s *Server) ReplicateFileToMember(ctx context.Context, member *pdpb.Member,
 	}
 	url := clientUrls[0] + filepath.Join("/pd/api/v1/admin/persist-file", name)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(data))
-	req.Header.Set("PD-Allow-follower-handle", "true")
+	req.Header.Set(apiutil.PDAllowFollowerHandleHeader, "true")
 	res, err := s.httpClient.Do(req)
 	if err != nil {
 		log.Warn("failed to replicate file", zap.String("name", name), zap.String("member", member.GetName()), errs.ZapError(err))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/pkg/mcs/utils"
+	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/assertutil"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -218,7 +219,7 @@ func (suite *leaderServerTestSuite) TestSourceIpForHeaderForwarded() {
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/pd/apis/mock/v1/hello", svr.GetAddr()), nil)
 	suite.NoError(err)
-	req.Header.Add("X-Forwarded-For", "127.0.0.2")
+	req.Header.Add(apiutil.XForwardedForHeader, "127.0.0.2")
 	resp, err := http.DefaultClient.Do(req)
 	suite.NoError(err)
 	suite.Equal(http.StatusOK, resp.StatusCode)
@@ -248,7 +249,7 @@ func (suite *leaderServerTestSuite) TestSourceIpForHeaderXReal() {
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/pd/apis/mock/v1/hello", svr.GetAddr()), nil)
 	suite.NoError(err)
-	req.Header.Add("X-Real-Ip", "127.0.0.2")
+	req.Header.Add(apiutil.XRealIPHeader, "127.0.0.2")
 	resp, err := http.DefaultClient.Do(req)
 	suite.NoError(err)
 	suite.Equal(http.StatusOK, resp.StatusCode)
@@ -278,8 +279,8 @@ func (suite *leaderServerTestSuite) TestSourceIpForHeaderBoth() {
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/pd/apis/mock/v1/hello", svr.GetAddr()), nil)
 	suite.NoError(err)
-	req.Header.Add("X-Forwarded-For", "127.0.0.2")
-	req.Header.Add("X-Real-Ip", "127.0.0.3")
+	req.Header.Add(apiutil.XForwardedForHeader, "127.0.0.2")
+	req.Header.Add(apiutil.XRealIPHeader, "127.0.0.3")
 	resp, err := http.DefaultClient.Do(req)
 	suite.NoError(err)
 	suite.Equal(http.StatusOK, resp.StatusCode)

--- a/server/testutil.go
+++ b/server/testutil.go
@@ -143,7 +143,7 @@ func CreateMockHandler(re *require.Assertions, ip string) HandlerBuilder {
 		mux.HandleFunc("/pd/apis/mock/v1/hello", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "Hello World")
 			// test getting ip
-			clientIP := apiutil.GetIPAddrFromHTTPRequest(r)
+			clientIP, _ := apiutil.GetIPPortFromHTTPRequest(r)
 			re.Equal(ip, clientIP)
 		})
 		info := apiutil.APIServiceGroup{

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -621,7 +621,7 @@ func (suite *redirectorTestSuite) TestAllowFollowerHandle() {
 	addr := follower.GetAddr() + "/pd/api/v1/version"
 	request, err := http.NewRequest(http.MethodGet, addr, nil)
 	suite.NoError(err)
-	request.Header.Add(apiutil.PDAllowFollowerHandle, "true")
+	request.Header.Add(apiutil.PDAllowFollowerHandleHeader, "true")
 	resp, err := dialClient.Do(request)
 	suite.NoError(err)
 	suite.Equal("", resp.Header.Get(apiutil.PDRedirectorHeader))

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/pkg/core"
-	"github.com/tikv/pd/pkg/utils/apiutil/serverapi"
+	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server"
@@ -621,10 +621,10 @@ func (suite *redirectorTestSuite) TestAllowFollowerHandle() {
 	addr := follower.GetAddr() + "/pd/api/v1/version"
 	request, err := http.NewRequest(http.MethodGet, addr, nil)
 	suite.NoError(err)
-	request.Header.Add(serverapi.PDAllowFollowerHandle, "true")
+	request.Header.Add(apiutil.PDAllowFollowerHandle, "true")
 	resp, err := dialClient.Do(request)
 	suite.NoError(err)
-	suite.Equal("", resp.Header.Get(serverapi.PDRedirectorHeader))
+	suite.Equal("", resp.Header.Get(apiutil.PDRedirectorHeader))
 	defer resp.Body.Close()
 	suite.Equal(http.StatusOK, resp.StatusCode)
 	_, err = io.ReadAll(resp.Body)
@@ -655,7 +655,7 @@ func (suite *redirectorTestSuite) TestNotLeader() {
 
 	// Request to follower with redirectorHeader will fail.
 	request.RequestURI = ""
-	request.Header.Set(serverapi.PDRedirectorHeader, "pd")
+	request.Header.Set(apiutil.PDRedirectorHeader, "pd")
 	resp1, err := dialClient.Do(request)
 	suite.NoError(err)
 	defer resp1.Body.Close()

--- a/tools/pd-ctl/pdctl/command/log_command.go
+++ b/tools/pd-ctl/pdctl/command/log_command.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
+	"github.com/tikv/pd/pkg/utils/apiutil"
 )
 
 var (
@@ -55,7 +56,7 @@ func logCommandFunc(cmd *cobra.Command, args []string) {
 			cmd.Printf("Failed to parse address %v: %s\n", args[1], err)
 			return
 		}
-		_, err = doRequestSingleEndpoint(cmd, url, logPrefix, http.MethodPost, http.Header{"Content-Type": {"application/json"}, "PD-Allow-follower-handle": {"true"}},
+		_, err = doRequestSingleEndpoint(cmd, url, logPrefix, http.MethodPost, http.Header{"Content-Type": {"application/json"}, apiutil.PDAllowFollowerHandleHeader: {"true"}},
 			WithBody(bytes.NewBuffer(data)))
 		if err != nil {
 			cmd.Printf("Failed to set %v log level: %s\n", args[1], err)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6957.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- Improve `GetIPPortFromHTTPRequest` to ensure it could handle different host addresses.
- Make middleware set the forwarded header correctly.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
Ensure the HTTP middleware set the forwarded header correctly.
```
