### PR TITLE
unsafe recovery: Add log for overlapping regions in unsafe recovery

### DIFF
--- a/pkg/unsaferecovery/unsafe_recovery_controller.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller.go
@@ -890,10 +890,11 @@ func (t *regionTree) insert(item *regionItem) (bool, error) {
 		return false, errors.Errorf("region %v shouldn't be updated twice", item.Region().GetId())
 	}
 
-	for _, old := range overlaps {
+	for _, newer := range overlaps {
+		log.Info("Unsafe recovery found overlap regions", logutil.ZapRedactStringer("newer-region-meta", core.RegionToHexMeta(newer.Region())), logutil.ZapRedactStringer("older-region-meta", core.RegionToHexMeta(item.Region())))
 		// it's ensured by the `buildUpFromReports` that peers are inserted in epoch descending order.
-		if old.IsEpochStale(item) {
-			return false, errors.Errorf("region %v's epoch shouldn't be staler than old ones %v", item, old)
+		if newer.IsEpochStale(item) {
+			return false, errors.Errorf("region %v's epoch shouldn't be staler than old ones %v", item, newer)
 		}
 	}
 	if len(overlaps) != 0 {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #6859

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Add log for overlapping regions in unsafe recovery.

We were unable to find the root cause of #6859, adding this log may help us better identify the issue, by printing out the regions that overlap with each other, that causes some of them to be marked as tombstone. 
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->


- No code

Code changes

N/A

Side effects

N/A

Related changes

N/A

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
