### PR TITLE
leadership: check leadership key before exit watch loop

### DIFF
--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -31,9 +31,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	watchLoopUnhealthyTimeout = 60 * time.Second
-)
+const watchLoopUnhealthyTimeout = 60 * time.Second
 
 // GetLeader gets the corresponding leader from etcd by given leaderPath (as the key).
 func GetLeader(c *clientv3.Client, leaderPath string) (*pdpb.Member, int64, error) {

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -318,7 +318,13 @@ func (ls *Leadership) Watch(serverCtx context.Context, revision int64) {
 						return
 					}
 					// The leader key is overwritten by another server, so we need to watch the new leader.
-					log.Info("current leadership is overwritten by another server, watch the new leader",
+					log.Info("current leadership is overwritten by another server, watch the new leader with delete event",
+						zap.Int64("revision", revision),
+						zap.String("leader-key", ls.leaderKey),
+						zap.String("purpose", ls.purpose))
+				}
+				if ev.Type == mvccpb.PUT {
+					log.Info("current leadership is updated by another server, watch the new leader with put event",
 						zap.Int64("revision", revision),
 						zap.String("leader-key", ls.leaderKey),
 						zap.String("purpose", ls.purpose))

--- a/pkg/election/leadership_test.go
+++ b/pkg/election/leadership_test.go
@@ -179,7 +179,11 @@ func TestExitWatch(t *testing.T) {
 		server.Server.HardStop()
 		client1.Delete(context.Background(), leaderKey)
 	})
-	// TODO: add test to simulate the case that pd leader is io hang.
+	// Case7: whether request progress is valid
+	checkExitWatch(t, leaderKey, func(server *embed.Etcd, client *clientv3.Client) {
+		re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/watchChanBlock", "return(true)"))
+	})
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/watchChanBlock"))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/fastTick"))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/fastTick"))
 }

--- a/pkg/schedule/schedulers/hot_region_v2_test.go
+++ b/pkg/schedule/schedulers/hot_region_v2_test.go
@@ -404,7 +404,7 @@ func TestHotReadRegionScheduleWithSmallHotRegion(t *testing.T) {
 	re.Len(ops, 1)
 	re.NotEqual(hotRegionID, ops[0].RegionID())
 
-	// Case5: If there are more than topnPosition hot regions, but them need to cool down,
+	// Case6: If there are more than topnPosition hot regions, but them need to cool down,
 	// we will schedule large hot region rather than small hot region, so there is no operator.
 	topnPosition = 2
 	ops = checkHotReadRegionScheduleWithSmallHotRegion(re, highLoad, lowLoad, func(tc *mockcluster.Cluster, _ *hotScheduler) {
@@ -418,7 +418,7 @@ func TestHotReadRegionScheduleWithSmallHotRegion(t *testing.T) {
 	re.Len(ops, 0)
 	topnPosition = origin
 
-	// Case6: If there are more than topnPosition hot regions, but them are pending,
+	// Case7: If there are more than topnPosition hot regions, but them are pending,
 	// we will schedule large hot region rather than small hot region, so there is no operator.
 	topnPosition = 2
 	ops = checkHotReadRegionScheduleWithSmallHotRegion(re, highLoad, lowLoad, func(tc *mockcluster.Cluster, hb *hotScheduler) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6977

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
