### PR TITLE
mcs: support alloc ID for scheduling server

### DIFF
--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -22,6 +22,7 @@ import (
 
 // Cluster is used to manage all information for scheduling purpose.
 type Cluster struct {
+	ctx context.Context
 	*core.BasicCluster
 	persistConfig     *config.PersistConfig
 	ruleManager       *placement.RuleManager
@@ -45,6 +46,7 @@ func NewCluster(ctx context.Context, persistConfig *config.PersistConfig, storag
 	}
 	ruleManager := placement.NewRuleManager(storage, basicCluster, persistConfig)
 	c := &Cluster{
+		ctx:               ctx,
 		BasicCluster:      basicCluster,
 		ruleManager:       ruleManager,
 		labelerManager:    labelerManager,
@@ -146,7 +148,7 @@ func (c *Cluster) AllocID() (uint64, error) {
 		c.checkMembershipCh <- struct{}{}
 		return 0, errors.New("API server leader is not found")
 	}
-	resp, err := cli.AllocID(context.Background(), &pdpb.AllocIDRequest{Header: &pdpb.RequestHeader{ClusterId: c.clusterID}})
+	resp, err := cli.AllocID(c.ctx, &pdpb.AllocIDRequest{Header: &pdpb.RequestHeader{ClusterId: c.clusterID}})
 	if err != nil {
 		c.checkMembershipCh <- struct{}{}
 		return 0, err

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
 	"github.com/tikv/pd/pkg/schedule"
@@ -20,32 +23,37 @@ import (
 // Cluster is used to manage all information for scheduling purpose.
 type Cluster struct {
 	*core.BasicCluster
-	persistConfig  *config.PersistConfig
-	ruleManager    *placement.RuleManager
-	labelerManager *labeler.RegionLabeler
-	regionStats    *statistics.RegionStatistics
-	hotStat        *statistics.HotStat
-	storage        storage.Storage
-	coordinator    *schedule.Coordinator
+	persistConfig     *config.PersistConfig
+	ruleManager       *placement.RuleManager
+	labelerManager    *labeler.RegionLabeler
+	regionStats       *statistics.RegionStatistics
+	hotStat           *statistics.HotStat
+	storage           storage.Storage
+	coordinator       *schedule.Coordinator
+	checkMembershipCh chan struct{}
+	apiServerLeader   atomic.Value
+	clusterID         uint64
 }
 
 const regionLabelGCInterval = time.Hour
 
 // NewCluster creates a new cluster.
-func NewCluster(ctx context.Context, persistConfig *config.PersistConfig, storage storage.Storage, basicCluster *core.BasicCluster, hbStreams *hbstream.HeartbeatStreams) (*Cluster, error) {
+func NewCluster(ctx context.Context, persistConfig *config.PersistConfig, storage storage.Storage, basicCluster *core.BasicCluster, hbStreams *hbstream.HeartbeatStreams, clusterID uint64, checkMembershipCh chan struct{}) (*Cluster, error) {
 	labelerManager, err := labeler.NewRegionLabeler(ctx, storage, regionLabelGCInterval)
 	if err != nil {
 		return nil, err
 	}
 	ruleManager := placement.NewRuleManager(storage, basicCluster, persistConfig)
 	c := &Cluster{
-		BasicCluster:   basicCluster,
-		ruleManager:    ruleManager,
-		labelerManager: labelerManager,
-		persistConfig:  persistConfig,
-		hotStat:        statistics.NewHotStat(ctx),
-		regionStats:    statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
-		storage:        storage,
+		BasicCluster:      basicCluster,
+		ruleManager:       ruleManager,
+		labelerManager:    labelerManager,
+		persistConfig:     persistConfig,
+		hotStat:           statistics.NewHotStat(ctx),
+		regionStats:       statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
+		storage:           storage,
+		clusterID:         clusterID,
+		checkMembershipCh: checkMembershipCh,
 	}
 	c.coordinator = schedule.NewCoordinator(ctx, c, hbStreams)
 	err = c.ruleManager.Initialize(persistConfig.GetMaxReplicas(), persistConfig.GetLocationLabels())
@@ -131,11 +139,29 @@ func (c *Cluster) GetSchedulerConfig() sc.SchedulerConfigProvider { return c.per
 // GetStoreConfig returns the store config.
 func (c *Cluster) GetStoreConfig() sc.StoreConfigProvider { return c.persistConfig }
 
+// AllocID allocates a new ID.
+func (c *Cluster) AllocID() (uint64, error) {
+	cli := c.apiServerLeader.Load().(pdpb.PDClient)
+	if cli == nil {
+		c.checkMembershipCh <- struct{}{}
+		return 0, errors.New("API server leader is not found")
+	}
+	resp, err := cli.AllocID(context.Background(), &pdpb.AllocIDRequest{Header: &pdpb.RequestHeader{ClusterId: c.clusterID}})
+	if err != nil {
+		c.checkMembershipCh <- struct{}{}
+		return 0, err
+	}
+	return resp.GetId(), nil
+}
+
+// SwitchAPIServerLeader switches the API server leader.
+func (c *Cluster) SwitchAPIServerLeader(new pdpb.PDClient) bool {
+	old := c.apiServerLeader.Load()
+	return c.apiServerLeader.CompareAndSwap(old, new)
+}
+
 // TODO: implement the following methods
 
 // UpdateRegionsLabelLevelStats updates the status of the region label level by types.
 func (c *Cluster) UpdateRegionsLabelLevelStats(regions []*core.RegionInfo) {
 }
-
-// AllocID allocates a new ID.
-func (c *Cluster) AllocID() (uint64, error) { return 0, nil }

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -164,6 +164,11 @@ func (c *Config) adjustLog(meta *configutil.ConfigMetaData) {
 	}
 }
 
+// GetListenAddr returns the ListenAddr
+func (c *Config) GetListenAddr() string {
+	return c.ListenAddr
+}
+
 // GetTLSConfig returns the TLS config.
 func (c *Config) GetTLSConfig() *grpcutil.TLSConfig {
 	return &c.Security.TLSConfig

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -388,7 +388,6 @@ func (s *Server) startServer() (err error) {
 	go utils.StartGRPCAndHTTPServers(s, serverReadyChan, s.GetListener())
 	s.checkMembershipCh <- struct{}{}
 	<-serverReadyChan
-	s.startServerLoop()
 	go s.GetCoordinator().RunUntilStop()
 
 	// Run callbacks

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -30,6 +30,7 @@ import (
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/diagnosticspb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/sysutil"
 	"github.com/spf13/cobra"
@@ -58,6 +59,8 @@ import (
 
 var _ bs.Server = (*Server)(nil)
 
+const memberUpdateInterval = time.Minute
+
 // Server is the scheduling server, and it implements bs.Server.
 type Server struct {
 	*server.BaseServer
@@ -77,7 +80,8 @@ type Server struct {
 	// for the primary election of scheduling
 	participant *member.Participant
 
-	service *Service
+	service           *Service
+	checkMembershipCh chan struct{}
 
 	// primaryCallbacks will be called after the server becomes leader.
 	primaryCallbacks []func(context.Context)
@@ -130,8 +134,53 @@ func (s *Server) Run() error {
 
 func (s *Server) startServerLoop() {
 	s.serverLoopCtx, s.serverLoopCancel = context.WithCancel(s.Context())
-	s.serverLoopWg.Add(1)
+	s.serverLoopWg.Add(2)
 	go s.primaryElectionLoop()
+	go s.updateMemberLoop()
+}
+
+func (s *Server) updateMemberLoop() {
+	defer logutil.LogPanic()
+	defer s.serverLoopWg.Done()
+
+	ctx, cancel := context.WithCancel(s.serverLoopCtx)
+	defer cancel()
+	ticker := time.NewTicker(memberUpdateInterval)
+	failpoint.Inject("fastUpdateMember", func() {
+		ticker.Stop()
+		ticker = time.NewTicker(100 * time.Millisecond)
+	})
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("server is closed, exit update member loop")
+			return
+		case <-ticker.C:
+		case <-s.checkMembershipCh:
+		}
+		members, err := s.GetClient().MemberList(ctx)
+		if err != nil {
+			log.Warn("failed to list members", errs.ZapError(err))
+		}
+		for _, ep := range members.Members {
+			status, err := s.GetClient().Status(ctx, ep.ClientURLs[0])
+			if err != nil {
+				log.Info("failed to get status of member", zap.String("member-id", fmt.Sprintf("%x", ep.ID)), zap.String("endpoint", ep.ClientURLs[0]), errs.ZapError(err))
+				continue
+			}
+			if status.Leader == ep.ID {
+				cc, err := s.GetDelegateClient(ctx, s.GetTLSConfig(), ep.ClientURLs[0])
+				if err != nil {
+					log.Info("failed to get delegate client", errs.ZapError(err))
+				}
+				if s.cluster.SwitchAPIServerLeader(pdpb.NewPDClient(cc)) {
+					log.Info("switch leader", zap.String("leader-id", fmt.Sprintf("%x", ep.ID)), zap.String("endpoint", ep.ClientURLs[0]))
+					break
+				}
+			}
+		}
+	}
 }
 
 func (s *Server) primaryElectionLoop() {
@@ -141,7 +190,7 @@ func (s *Server) primaryElectionLoop() {
 	for {
 		select {
 		case <-s.serverLoopCtx.Done():
-			log.Info("server is closed, exit resource manager primary election loop")
+			log.Info("server is closed, exit primary election loop")
 			return
 		default:
 		}
@@ -226,6 +275,8 @@ func (s *Server) Close() {
 	utils.StopGRPCServer(s)
 	s.GetListener().Close()
 	s.GetCoordinator().Stop()
+	s.ruleWatcher.Close()
+	s.configWatcher.Close()
 	s.serverLoopCancel()
 	s.serverLoopWg.Wait()
 
@@ -320,7 +371,7 @@ func (s *Server) startServer() (err error) {
 		kv.NewEtcdKVBase(s.GetClient(), endpoint.PDRootPath(s.clusterID)), nil)
 	basicCluster := core.NewBasicCluster()
 	s.hbStreams = hbstream.NewHeartbeatStreams(s.Context(), s.clusterID, basicCluster)
-	s.cluster, err = NewCluster(s.Context(), s.persistConfig, s.storage, basicCluster, s.hbStreams)
+	s.cluster, err = NewCluster(s.Context(), s.persistConfig, s.storage, basicCluster, s.hbStreams, s.clusterID, s.checkMembershipCh)
 	if err != nil {
 		return err
 	}
@@ -330,13 +381,14 @@ func (s *Server) startServer() (err error) {
 		return err
 	}
 
-	go s.GetCoordinator().RunUntilStop()
 	serverReadyChan := make(chan struct{})
 	defer close(serverReadyChan)
 	s.serverLoopWg.Add(1)
 	go utils.StartGRPCAndHTTPServers(s, serverReadyChan, s.GetListener())
+	s.checkMembershipCh <- struct{}{}
 	<-serverReadyChan
 	s.startServerLoop()
+	go s.GetCoordinator().RunUntilStop()
 
 	// Run callbacks
 	log.Info("triggering the start callback functions")
@@ -379,6 +431,7 @@ func CreateServer(ctx context.Context, cfg *config.Config) *Server {
 		DiagnosticsServer: sysutil.NewDiagnosticsServer(cfg.Log.File.Filename),
 		cfg:               cfg,
 		persistConfig:     config.NewPersistConfig(cfg),
+		checkMembershipCh: make(chan struct{}, 1),
 	}
 	return svr
 }

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -136,10 +136,10 @@ func (s *Server) startServerLoop() {
 	s.serverLoopCtx, s.serverLoopCancel = context.WithCancel(s.Context())
 	s.serverLoopWg.Add(2)
 	go s.primaryElectionLoop()
-	go s.updateMemberLoop()
+	go s.updateAPIServerMemberLoop()
 }
 
-func (s *Server) updateMemberLoop() {
+func (s *Server) updateAPIServerMemberLoop() {
 	defer logutil.LogPanic()
 	defer s.serverLoopWg.Done()
 

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -383,6 +383,7 @@ func (s *Server) startServer() (err error) {
 
 	serverReadyChan := make(chan struct{})
 	defer close(serverReadyChan)
+	s.startServerLoop()
 	s.serverLoopWg.Add(1)
 	go utils.StartGRPCAndHTTPServers(s, serverReadyChan, s.GetListener())
 	s.checkMembershipCh <- struct{}{}

--- a/pkg/mcs/server/server.go
+++ b/pkg/mcs/server/server.go
@@ -61,7 +61,7 @@ func (bs *BaseServer) Context() context.Context {
 	return bs.ctx
 }
 
-// GetDelegateClient returns grpc client connection talking to the forwarded host
+// GetDelegateClient returns grpc client connection talking to the forwarded host.
 func (bs *BaseServer) GetDelegateClient(ctx context.Context, tlsCfg *grpcutil.TLSConfig, forwardedHost string) (*grpc.ClientConn, error) {
 	client, ok := bs.clientConns.Load(forwardedHost)
 	if !ok {

--- a/tests/integrations/mcs/scheduling/api_test.go
+++ b/tests/integrations/mcs/scheduling/api_test.go
@@ -55,6 +55,11 @@ func (suite *apiTestSuite) SetupSuite() {
 	}
 }
 
+func (suite *apiTestSuite) TearDownSuite() {
+	suite.cluster.Destroy()
+	suite.cleanupFunc()
+}
+
 func (suite *apiTestSuite) TestGetCheckerByName() {
 	testCases := []struct {
 		name string

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -1,0 +1,97 @@
+// Copyright 2023 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/stretchr/testify/suite"
+	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/tests"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+type serverTestSuite struct {
+	suite.Suite
+	ctx              context.Context
+	cancel           context.CancelFunc
+	cluster          *tests.TestCluster
+	pdLeader         *tests.TestServer
+	backendEndpoints string
+}
+
+func TestServerTestSuite(t *testing.T) {
+	suite.Run(t, new(serverTestSuite))
+}
+
+func (suite *serverTestSuite) SetupSuite() {
+	var err error
+	re := suite.Require()
+
+	suite.ctx, suite.cancel = context.WithCancel(context.Background())
+	suite.cluster, err = tests.NewTestAPICluster(suite.ctx, 3)
+	re.NoError(err)
+
+	err = suite.cluster.RunInitialServers()
+	re.NoError(err)
+
+	leaderName := suite.cluster.WaitLeader()
+	suite.pdLeader = suite.cluster.GetServer(leaderName)
+	suite.backendEndpoints = suite.pdLeader.GetAddr()
+	suite.NoError(suite.pdLeader.BootstrapCluster())
+}
+
+func (suite *serverTestSuite) TearDownSuite() {
+	suite.cluster.Destroy()
+	suite.cancel()
+}
+
+func (suite *serverTestSuite) TestAllocID() {
+	re := suite.Require()
+	tc, err := tests.NewTestSchedulingCluster(suite.ctx, 1, suite.backendEndpoints)
+	re.NoError(err)
+	defer tc.Destroy()
+	tc.WaitForPrimaryServing(re)
+	id, err := tc.GetPrimaryServer().GetCluster().AllocID()
+	re.NoError(err)
+	re.NotEqual(uint64(0), id)
+}
+
+func (suite *serverTestSuite) TestAllocIDAfterLeaderChange() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/mcs/scheduling/server/fastUpdateMember", `return(true)`))
+	tc, err := tests.NewTestSchedulingCluster(suite.ctx, 1, suite.backendEndpoints)
+	re.NoError(err)
+	defer tc.Destroy()
+	tc.WaitForPrimaryServing(re)
+	cluster := tc.GetPrimaryServer().GetCluster()
+	id, err := cluster.AllocID()
+	re.NoError(err)
+	re.NotEqual(uint64(0), id)
+	suite.cluster.ResignLeader()
+	suite.cluster.WaitLeader()
+	time.Sleep(time.Second)
+	id1, err := cluster.AllocID()
+	re.NoError(err)
+	re.Greater(id1, id)
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/mcs/scheduling/server/fastUpdateMember"))
+}

--- a/tests/integrations/mcs/tso/server_test.go
+++ b/tests/integrations/mcs/tso/server_test.go
@@ -136,7 +136,7 @@ func (suite *tsoServerTestSuite) TestParticipantStartWithAdvertiseListenAddr() {
 	re.NoError(err)
 
 	// Setup the logger.
-	err = tests.InitLogger(cfg)
+	err = tests.InitTSOLogger(cfg)
 	re.NoError(err)
 
 	s, cleanup, err := tests.NewTSOTestServer(suite.ctx, cfg)

--- a/tests/scheduling_cluster.go
+++ b/tests/scheduling_cluster.go
@@ -1,0 +1,141 @@
+// Copyright 2023 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	scheduling "github.com/tikv/pd/pkg/mcs/scheduling/server"
+	sc "github.com/tikv/pd/pkg/mcs/scheduling/server/config"
+	"github.com/tikv/pd/pkg/utils/tempurl"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+// TestSchedulingCluster is a test cluster for scheduling.
+type TestSchedulingCluster struct {
+	ctx context.Context
+
+	backendEndpoints string
+	servers          map[string]*scheduling.Server
+	cleanupFuncs     map[string]testutil.CleanupFunc
+}
+
+// NewTestSchedulingCluster creates a new scheduling test cluster.
+func NewTestSchedulingCluster(ctx context.Context, initialServerCount int, backendEndpoints string) (tc *TestSchedulingCluster, err error) {
+	tc = &TestSchedulingCluster{
+		ctx:              ctx,
+		backendEndpoints: backendEndpoints,
+		servers:          make(map[string]*scheduling.Server, initialServerCount),
+		cleanupFuncs:     make(map[string]testutil.CleanupFunc, initialServerCount),
+	}
+	for i := 0; i < initialServerCount; i++ {
+		err = tc.AddServer(tempurl.Alloc())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return tc, nil
+}
+
+// AddServer adds a new scheduling server to the test cluster.
+func (tc *TestSchedulingCluster) AddServer(addr string) error {
+	cfg := sc.NewConfig()
+	cfg.BackendEndpoints = tc.backendEndpoints
+	cfg.ListenAddr = addr
+	cfg.Name = cfg.ListenAddr
+	generatedCfg, err := scheduling.GenerateConfig(cfg)
+	if err != nil {
+		return err
+	}
+	err = InitSchedulingLogger(generatedCfg)
+	if err != nil {
+		return err
+	}
+	server, cleanup, err := NewSchedulingTestServer(tc.ctx, generatedCfg)
+	if err != nil {
+		return err
+	}
+	tc.servers[generatedCfg.GetListenAddr()] = server
+	tc.cleanupFuncs[generatedCfg.GetListenAddr()] = cleanup
+	return nil
+}
+
+// Destroy stops and destroy the test cluster.
+func (tc *TestSchedulingCluster) Destroy() {
+	for _, cleanup := range tc.cleanupFuncs {
+		cleanup()
+	}
+	tc.cleanupFuncs = nil
+	tc.servers = nil
+}
+
+// DestroyServer stops and destroy the test server by the given address.
+func (tc *TestSchedulingCluster) DestroyServer(addr string) {
+	tc.cleanupFuncs[addr]()
+	delete(tc.cleanupFuncs, addr)
+	delete(tc.servers, addr)
+}
+
+// GetPrimaryServer returns the primary scheduling server.
+func (tc *TestSchedulingCluster) GetPrimaryServer() *scheduling.Server {
+	for _, server := range tc.servers {
+		if server.IsServing() {
+			return server
+		}
+	}
+	return nil
+}
+
+// WaitForPrimaryServing waits for one of servers being elected to be the primary/leader of the given keyspace.
+func (tc *TestSchedulingCluster) WaitForPrimaryServing(re *require.Assertions) *scheduling.Server {
+	var primary *scheduling.Server
+	testutil.Eventually(re, func() bool {
+		for _, server := range tc.servers {
+			if server.IsServing() {
+				primary = server
+				return true
+			}
+		}
+		return false
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+
+	return primary
+}
+
+// GetServer returns the scheduling server by the given address.
+func (tc *TestSchedulingCluster) GetServer(addr string) *scheduling.Server {
+	for srvAddr, server := range tc.servers {
+		if srvAddr == addr {
+			return server
+		}
+	}
+	return nil
+}
+
+// GetServers returns all scheduling servers.
+func (tc *TestSchedulingCluster) GetServers() map[string]*scheduling.Server {
+	return tc.servers
+}
+
+// GetAddrs returns all scheduling server addresses.
+func (tc *TestSchedulingCluster) GetAddrs() []string {
+	addrs := make([]string, 0, len(tc.servers))
+	for _, server := range tc.servers {
+		addrs = append(addrs, server.GetAddr())
+	}
+	return addrs
+}

--- a/tests/tso_cluster.go
+++ b/tests/tso_cluster.go
@@ -114,7 +114,7 @@ func (tc *TestTSOCluster) AddServer(addr string) error {
 	if err != nil {
 		return err
 	}
-	err = InitLogger(generatedCfg)
+	err = InitTSOLogger(generatedCfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5839.

### What is changed and how does it work?

We need to allocate ID for building the operator in the scheduling server. But the ID is maintained by the API server, so we have to call RPC to get the ID.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
