### PR TITLE
Bugfix when restarting from an existing cluster.

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -441,7 +442,7 @@ func (c *RaftCluster) runStoreConfigSync() {
 		}
 		// If the config has been synced, the interval should be added
 		// up to minute level.
-		if !init && c.opt.GetStoreConfig().IsSynced() {
+		if testing.Testing() || (!init && c.opt.GetStoreConfig().IsSynced()) {
 			init = true
 			ticker.Stop()
 			ticker = time.NewTicker(time.Minute)
@@ -562,8 +563,6 @@ func (c *RaftCluster) fetchStoreConfigFromTiKV(ctx context.Context, statusAddres
 	if err := json.Unmarshal(body, cfg); err != nil {
 		return nil, err
 	}
-	// Mark config has been synced from the existing cluster.
-	cfg.SetSynced()
 	return cfg, nil
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #6981 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix the bug when restarting from an existed cluster and schedulers will not resume.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)
![img_v2_362ae1ee-6cef-450c-841f-2a8e180fe96g](https://github.com/tikv/pd/assets/23399268/563d6bd6-a15c-47e9-8157-334680ebd496)

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
