### PR TITLE
hot_region_storage: Fix a typo in comment

### DIFF
--- a/pkg/storage/hot_region_storage.go
+++ b/pkg/storage/hot_region_storage.go
@@ -90,7 +90,7 @@ type HistoryHotRegion struct {
 
 // HotRegionStorageHandler help hot region storage get hot region info.
 type HotRegionStorageHandler interface {
-	// PackHistoryHotWriteRegions get read hot region info in HistoryHotRegion form.
+	// PackHistoryHotReadRegions get read hot region info in HistoryHotRegion form.
 	PackHistoryHotReadRegions() ([]HistoryHotRegion, error)
 	// PackHistoryHotWriteRegions get write hot region info in HistoryHotRegion form.
 	PackHistoryHotWriteRegions() ([]HistoryHotRegion, error)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #6989 

### What is changed and how does it work?

```commit-message

https://github.com/tikv/pd/blob/50368e57bde37a4e4994ffe4da4394433799ac71/pkg/storage/hot_region_storage.go#L93

* fix a typo by changing "PackHistoryHotWriteRegions" to "PackHistoryHotReadRegions"

```

### Check List

None

### Release note

```release-note
None.
```
