### PR TITLE
Revert the initialization of evict-slow-trend scheduler in `init_schedulers`.

### DIFF
--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -606,11 +606,6 @@ func (o *PersistConfig) GetRegionMaxKeys() uint64 {
 	return o.GetStoreConfig().GetRegionMaxKeys()
 }
 
-// IsSynced returns true if the cluster config is synced.
-func (o *PersistConfig) IsSynced() bool {
-	return o.GetStoreConfig().IsSynced()
-}
-
 // IsEnableRegionBucket return true if the region bucket is enabled.
 func (o *PersistConfig) IsEnableRegionBucket() bool {
 	return o.GetStoreConfig().IsEnableRegionBucket()

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -139,7 +139,6 @@ type StoreConfigProvider interface {
 	GetRegionMaxKeys() uint64
 	CheckRegionSize(uint64, uint64) error
 	CheckRegionKeys(uint64, uint64) error
-	IsSynced() bool
 	IsEnableRegionBucket() bool
 	IsRaftKV2() bool
 }

--- a/pkg/schedule/config/store_config.go
+++ b/pkg/schedule/config/store_config.go
@@ -48,8 +48,6 @@ type StoreConfig struct {
 	RegionMaxSizeMB    uint64 `json:"-"`
 	RegionSplitSizeMB  uint64 `json:"-"`
 	RegionBucketSizeMB uint64 `json:"-"`
-
-	Sync bool `json:"sync"`
 }
 
 // Storage is the config for the tikv storage.
@@ -125,21 +123,6 @@ func (c *StoreConfig) GetRegionMaxKeys() uint64 {
 		return defaultRegionMaxKey
 	}
 	return uint64(c.RegionMaxKeys)
-}
-
-// SetSynced marks StoreConfig has been synced.
-func (c *StoreConfig) SetSynced() {
-	if c != nil {
-		c.Sync = true
-	}
-}
-
-// IsSynced returns whether the StoreConfig is synced or not.
-func (c *StoreConfig) IsSynced() bool {
-	if c == nil {
-		return false
-	}
-	return c.Sync
 }
 
 // IsEnableRegionBucket return true if the region bucket is enabled.

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"strconv"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -313,6 +312,42 @@ func (c *Coordinator) drivePushOperator() {
 	}
 }
 
+// driveSlowNodeScheduler is used to enable slow node scheduler when using `raft-kv2`.
+func (c *Coordinator) driveSlowNodeScheduler() {
+	defer logutil.LogPanic()
+	defer c.wg.Done()
+
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.ctx.Done():
+			log.Info("drive slow node scheduler is stopped")
+			return
+		case <-ticker.C:
+			{
+				// If the cluster was set up with `raft-kv2` engine, this cluster should
+				// enable `evict-slow-trend` scheduler as default.
+				if c.GetCluster().GetStoreConfig().IsRaftKV2() {
+					typ := schedulers.EvictSlowTrendType
+					args := []string{}
+
+					s, err := schedulers.CreateScheduler(typ, c.opController, c.cluster.GetStorage(), schedulers.ConfigSliceDecoder(typ, args), c.schedulers.RemoveScheduler)
+					if err != nil {
+						log.Warn("initializing evict-slow-trend scheduler failed", errs.ZapError(err))
+					} else if err = c.schedulers.AddScheduler(s, args...); err != nil {
+						log.Error("can not add scheduler", zap.String("scheduler-name", s.GetName()), zap.Strings("scheduler-args", args), errs.ZapError(err))
+					}
+					// If enabled, exit.
+					if exists, _ := c.schedulers.IsSchedulerExisted(schedulers.EvictSlowTrendName); exists {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
 // RunUntilStop runs the coordinator until receiving the stop signal.
 func (c *Coordinator) RunUntilStop() {
 	c.Run()
@@ -346,12 +381,14 @@ func (c *Coordinator) Run() {
 	log.Info("Coordinator starts to run schedulers")
 	c.initSchedulers()
 
-	c.wg.Add(3)
+	c.wg.Add(4)
 	// Starts to patrol regions.
 	go c.PatrolRegions()
 	// Checks suspect key ranges
 	go c.checkSuspectRanges()
 	go c.drivePushOperator()
+	// // Checks whether to create evict-slow-trend scheduler.
+	go c.driveSlowNodeScheduler()
 }
 
 func (c *Coordinator) initSchedulers() {
@@ -438,20 +475,6 @@ func (c *Coordinator) initSchedulers() {
 	c.cluster.GetSchedulerConfig().SetScheduleConfig(scheduleCfg)
 	if err := c.cluster.GetSchedulerConfig().Persist(c.cluster.GetStorage()); err != nil {
 		log.Error("cannot persist schedule config", errs.ZapError(err))
-	}
-
-	// If the cluster was set up with `raft-kv2` engine, this cluster should
-	// enable `evict-slow-trend` scheduler as default.
-	if c.GetCluster().GetStoreConfig().IsRaftKV2() {
-		name := schedulers.EvictSlowTrendType
-		args := []string{}
-
-		s, err := schedulers.CreateScheduler(name, c.opController, c.cluster.GetStorage(), schedulers.ConfigSliceDecoder(name, args), c.schedulers.RemoveScheduler)
-		if err != nil {
-			log.Warn("initializing evict-slow-trend scheduler failed", errs.ZapError(err))
-		} else if err = c.schedulers.AddScheduler(s, args...); err != nil {
-			log.Error("can not add scheduler", zap.String("scheduler-name", s.GetName()), zap.Strings("scheduler-args", args), errs.ZapError(err))
-		}
 	}
 }
 
@@ -639,11 +662,7 @@ func (c *Coordinator) ResetHotSpotMetrics() {
 
 // ShouldRun returns true if the coordinator should run.
 func (c *Coordinator) ShouldRun() bool {
-	isSynced := c.cluster.GetStoreConfig().IsSynced()
-	if testing.Testing() {
-		isSynced = true
-	}
-	return c.prepareChecker.check(c.cluster.GetBasicCluster()) && isSynced
+	return c.prepareChecker.check(c.cluster.GetBasicCluster())
 }
 
 // GetSchedulersController returns the schedulers controller.

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -326,6 +326,10 @@ func (c *Coordinator) driveSlowNodeScheduler() {
 			return
 		case <-ticker.C:
 			{
+				// If enabled, exit.
+				if exists, _ := c.schedulers.IsSchedulerExisted(schedulers.EvictSlowTrendName); exists {
+					return
+				}
 				// If the cluster was set up with `raft-kv2` engine, this cluster should
 				// enable `evict-slow-trend` scheduler as default.
 				if c.GetCluster().GetStoreConfig().IsRaftKV2() {
@@ -337,10 +341,6 @@ func (c *Coordinator) driveSlowNodeScheduler() {
 						log.Warn("initializing evict-slow-trend scheduler failed", errs.ZapError(err))
 					} else if err = c.schedulers.AddScheduler(s, args...); err != nil {
 						log.Error("can not add scheduler", zap.String("scheduler-name", s.GetName()), zap.Strings("scheduler-args", args), errs.ZapError(err))
-					}
-					// If enabled, exit.
-					if exists, _ := c.schedulers.IsSchedulerExisted(schedulers.EvictSlowTrendName); exists {
-						return
 					}
 				}
 			}

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -387,7 +387,7 @@ func (c *Coordinator) Run() {
 	// Checks suspect key ranges
 	go c.checkSuspectRanges()
 	go c.drivePushOperator()
-	// // Checks whether to create evict-slow-trend scheduler.
+	// Checks whether to create evict-slow-trend scheduler.
 	go c.driveSlowNodeScheduler()
 }
 

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -123,7 +123,7 @@ var (
 			Namespace: "pd",
 			Subsystem: "scheduler",
 			Name:      "store_slow_trend_misc",
-			Help:      "Store trend internal uncatelogued values",
+			Help:      "Store trend internal uncatalogued values",
 		}, []string{"type", "dim"})
 
 	// HotPendingSum is the sum of pending influence in hot region scheduler.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1354,14 +1354,12 @@ func TestStoreConfigUpdate(t *testing.T) {
         "perf-level": 2
     	}}`
 		var config sc.StoreConfig
-		re.False(config.IsSynced())
 		re.NoError(json.Unmarshal([]byte(body), &config))
 		tc.updateStoreConfig(opt.GetStoreConfig(), &config)
 		re.Equal(uint64(144000000), opt.GetRegionMaxKeys())
 		re.Equal(uint64(96000000), opt.GetRegionSplitKeys())
 		re.Equal(uint64(15*units.GiB/units.MiB), opt.GetRegionMaxSize())
 		re.Equal(uint64(10*units.GiB/units.MiB), opt.GetRegionSplitSize())
-		re.True(opt.IsSynced())
 	}
 	// Case2: empty config.
 	{
@@ -1373,7 +1371,6 @@ func TestStoreConfigUpdate(t *testing.T) {
 		re.Equal(uint64(960000), opt.GetRegionSplitKeys())
 		re.Equal(uint64(144), opt.GetRegionMaxSize())
 		re.Equal(uint64(96), opt.GetRegionSplitSize())
-		re.True(opt.IsSynced())
 	}
 	// Case3: raft-kv2 config.
 	{

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -1012,11 +1012,6 @@ func (o *PersistOptions) CheckRegionKeys(keys, mergeKeys uint64) error {
 	return o.GetStoreConfig().CheckRegionKeys(keys, mergeKeys)
 }
 
-// IsSynced returns true if the store config is synced.
-func (o *PersistOptions) IsSynced() bool {
-	return o.GetStoreConfig().IsSynced()
-}
-
 // IsEnableRegionBucket return true if the region bucket is enabled.
 func (o *PersistOptions) IsEnableRegionBucket() bool {
 	return o.GetStoreConfig().IsEnableRegionBucket()


### PR DESCRIPTION

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #6981 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
In this pr:
+ Revert and re-factor the initialization of `evict-slow-trend` scheduler when starting with `raft-kv2`.
+ Fix typo errors.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
