### PR TITLE
statistics: fix empty region count when resuming

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -194,6 +194,13 @@ func RegionFromHeartbeat(heartbeat *pdpb.RegionHeartbeatRequest, opts ...RegionC
 	return region
 }
 
+// InheritBuckets inherits the buckets from the parent region if bucket enabled.
+func (r *RegionInfo) InheritBuckets(origin *RegionInfo) {
+	if origin != nil && r.buckets == nil {
+		r.buckets = origin.buckets
+	}
+}
+
 // Clone returns a copy of current regionInfo.
 func (r *RegionInfo) Clone(opts ...RegionCreateOption) *RegionInfo {
 	downPeers := make([]*pdpb.PeerStats, 0, len(r.downPeers))

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -506,6 +506,13 @@ func (r *RegionInfo) GetApproximateSize() int64 {
 	return r.approximateSize
 }
 
+// IsEmptyRegion returns whether the region is empty.
+func (r *RegionInfo) IsEmptyRegion() bool {
+	// When cluster resumes, the region size may be not initialized, but region heartbeat is send.
+	// So use `==` here.
+	return r.approximateSize == EmptyRegionApproximateSize
+}
+
 // GetStorePeerApproximateKeys returns the approximate keys of the peer on the specified store.
 func (r *RegionInfo) GetStorePeerApproximateKeys(storeID uint64) int64 {
 	peer := r.GetStorePeer(storeID)

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -186,6 +186,31 @@ func TestSortedEqual(t *testing.T) {
 	}
 }
 
+func TestInheritBuckets(t *testing.T) {
+	re := require.New(t)
+
+	data := []struct {
+		originBuckets *metapb.Buckets
+		buckets       *metapb.Buckets
+	}{
+		{nil, nil},
+		{nil, &metapb.Buckets{RegionId: 100, Version: 2}},
+		{&metapb.Buckets{RegionId: 100, Version: 2}, &metapb.Buckets{RegionId: 100, Version: 3}},
+		{&metapb.Buckets{RegionId: 100, Version: 2}, nil},
+	}
+	for _, d := range data {
+		origin := NewRegionInfo(&metapb.Region{Id: 100}, nil, SetBuckets(d.originBuckets))
+		r := NewRegionInfo(&metapb.Region{Id: 100}, nil)
+		r.InheritBuckets(origin)
+		re.Equal(d.originBuckets, r.GetBuckets())
+		// region will not inherit bucket keys.
+		if origin.GetBuckets() != nil {
+			newRegion := NewRegionInfo(&metapb.Region{Id: 100}, nil)
+			re.NotEqual(d.originBuckets, newRegion.GetBuckets())
+		}
+	}
+}
+
 func TestRegionRoundingFlow(t *testing.T) {
 	re := require.New(t)
 	testCases := []struct {

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -186,58 +186,6 @@ func TestSortedEqual(t *testing.T) {
 	}
 }
 
-func TestInherit(t *testing.T) {
-	re := require.New(t)
-	// size in MB
-	// case for approximateSize
-	testCases := []struct {
-		originExists bool
-		originSize   uint64
-		size         uint64
-		expect       uint64
-	}{
-		{false, 0, 0, 1},
-		{false, 0, 2, 2},
-		{true, 0, 2, 2},
-		{true, 1, 2, 2},
-		{true, 2, 0, 2},
-	}
-	for _, testCase := range testCases {
-		var origin *RegionInfo
-		if testCase.originExists {
-			origin = NewRegionInfo(&metapb.Region{Id: 100}, nil)
-			origin.approximateSize = int64(testCase.originSize)
-		}
-		r := NewRegionInfo(&metapb.Region{Id: 100}, nil)
-		r.approximateSize = int64(testCase.size)
-		r.Inherit(origin, false)
-		re.Equal(int64(testCase.expect), r.approximateSize)
-	}
-
-	// bucket
-	data := []struct {
-		originBuckets *metapb.Buckets
-		buckets       *metapb.Buckets
-	}{
-		{nil, nil},
-		{nil, &metapb.Buckets{RegionId: 100, Version: 2}},
-		{&metapb.Buckets{RegionId: 100, Version: 2}, &metapb.Buckets{RegionId: 100, Version: 3}},
-		{&metapb.Buckets{RegionId: 100, Version: 2}, nil},
-	}
-	for _, d := range data {
-		origin := NewRegionInfo(&metapb.Region{Id: 100}, nil, SetBuckets(d.originBuckets))
-		r := NewRegionInfo(&metapb.Region{Id: 100}, nil)
-		r.Inherit(origin, true)
-		re.Equal(d.originBuckets, r.GetBuckets())
-		// region will not inherit bucket keys.
-		if origin.GetBuckets() != nil {
-			newRegion := NewRegionInfo(&metapb.Region{Id: 100}, nil)
-			newRegion.Inherit(origin, false)
-			re.NotEqual(d.originBuckets, newRegion.GetBuckets())
-		}
-	}
-}
-
 func TestRegionRoundingFlow(t *testing.T) {
 	re := require.New(t)
 	testCases := []struct {

--- a/pkg/statistics/region.go
+++ b/pkg/statistics/region.go
@@ -59,7 +59,7 @@ func (s *RegionStats) Observe(r *core.RegionInfo) {
 	approximateKeys := r.GetApproximateKeys()
 	approximateSize := r.GetApproximateSize()
 	approximateKvSize := r.GetApproximateKvSize()
-	if approximateSize <= core.EmptyRegionApproximateSize {
+	if approximateSize == core.EmptyRegionApproximateSize {
 		s.EmptyCount++
 	}
 	s.StorageSize += approximateSize

--- a/pkg/statistics/region.go
+++ b/pkg/statistics/region.go
@@ -62,7 +62,9 @@ func (s *RegionStats) Observe(r *core.RegionInfo) {
 	if approximateSize == core.EmptyRegionApproximateSize {
 		s.EmptyCount++
 	}
-	s.StorageSize += approximateSize
+	if !r.IsEmptyRegion() {
+		s.StorageSize += approximateSize
+	}
 	s.UserStorageSize += approximateKvSize
 	s.StorageKeys += approximateKeys
 	leader := r.GetLeader()

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -208,7 +208,7 @@ func (r *RegionStatistics) Observe(region *core.RegionInfo, stores []*core.Store
 		UndersizedRegion: region.NeedMerge(
 			int64(r.conf.GetMaxMergeRegionSize()),
 			int64(r.conf.GetMaxMergeRegionKeys()),
-		),
+		) && region.GetApproximateSize() >= core.EmptyRegionApproximateSize,
 		WitnessLeader: region.GetLeader().GetIsWitness(),
 	}
 	// Check if the region meets any of the conditions and update the corresponding info.

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -198,7 +198,9 @@ func (r *RegionStatistics) Observe(region *core.RegionInfo, stores []*core.Store
 			return false
 		}(),
 		LearnerPeer: len(region.GetLearners()) > 0,
-		EmptyRegion: region.GetApproximateSize() <= core.EmptyRegionApproximateSize,
+		// When cluster resumes, the region size may be not initialized, but region heartbeat is send.
+		// So use `==` here.
+		EmptyRegion: region.GetApproximateSize() == core.EmptyRegionApproximateSize,
 		OversizedRegion: region.IsOversized(
 			int64(r.conf.GetRegionMaxSize()),
 			int64(r.conf.GetRegionMaxKeys()),

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -198,9 +198,7 @@ func (r *RegionStatistics) Observe(region *core.RegionInfo, stores []*core.Store
 			return false
 		}(),
 		LearnerPeer: len(region.GetLearners()) > 0,
-		// When cluster resumes, the region size may be not initialized, but region heartbeat is send.
-		// So use `==` here.
-		EmptyRegion: region.GetApproximateSize() == core.EmptyRegionApproximateSize,
+		EmptyRegion: region.IsEmptyRegion(),
 		OversizedRegion: region.IsOversized(
 			int64(r.conf.GetRegionMaxSize()),
 			int64(r.conf.GetRegionMaxKeys()),

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -63,7 +63,7 @@ func TestRegionStatistics(t *testing.T) {
 	stores[3] = store3
 	r1 := &metapb.Region{Id: 1, Peers: peers, StartKey: []byte("aa"), EndKey: []byte("bb")}
 	r2 := &metapb.Region{Id: 2, Peers: peers[0:2], StartKey: []byte("cc"), EndKey: []byte("dd")}
-	region1 := core.NewRegionInfo(r1, peers[0])
+	region1 := core.NewRegionInfo(r1, peers[0], core.SetApproximateSize(1))
 	region2 := core.NewRegionInfo(r2, peers[0])
 	regionStats := NewRegionStatistics(nil, opt, manager)
 	regionStats.Observe(region1, stores)

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -97,7 +97,8 @@ func TestRegionStatistics(t *testing.T) {
 	re.Len(regionStats.stats[PendingPeer], 1)
 	re.Len(regionStats.stats[LearnerPeer], 1)
 	re.Len(regionStats.stats[OversizedRegion], 1)
-	re.Len(regionStats.stats[UndersizedRegion], 1)
+	re.Len(regionStats.stats[UndersizedRegion], 0)
+	re.Len(regionStats.stats[EmptyRegion], 0)
 	re.Len(regionStats.stats[OfflinePeer], 1)
 
 	region1 = region1.Clone(core.WithRemoveStorePeer(7))

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -142,7 +142,7 @@ func (suite *statsTestSuite) TestRegionStats() {
 	statsAll := &statistics.RegionStats{
 		Count:            4,
 		EmptyCount:       1,
-		StorageSize:      351,
+		StorageSize:      350,
 		UserStorageSize:  291,
 		StorageKeys:      221,
 		StoreLeaderCount: map[uint64]int{1: 1, 4: 2, 5: 1},
@@ -156,7 +156,7 @@ func (suite *statsTestSuite) TestRegionStats() {
 	stats23 := &statistics.RegionStats{
 		Count:            2,
 		EmptyCount:       1,
-		StorageSize:      201,
+		StorageSize:      200,
 		UserStorageSize:  181,
 		StorageKeys:      151,
 		StoreLeaderCount: map[uint64]int{4: 1, 5: 1},

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1060,7 +1060,6 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	if err != nil {
 		return err
 	}
-	region.Inherit(origin, c.GetStoreConfig().IsEnableRegionBucket())
 
 	c.hotStat.CheckWriteAsync(statistics.NewCheckExpiredItemTask(region))
 	c.hotStat.CheckReadAsync(statistics.NewCheckExpiredItemTask(region))

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1060,6 +1060,9 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	if err != nil {
 		return err
 	}
+	if c.GetStoreConfig().IsEnableRegionBucket() {
+		region.InheritBuckets(origin)
+	}
 
 	c.hotStat.CheckWriteAsync(statistics.NewCheckExpiredItemTask(region))
 	c.hotStat.CheckReadAsync(statistics.NewCheckExpiredItemTask(region))


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7008 #5273

### What is changed and how does it work?
We only save `meta` when save regions, so the approximate size of the original region is zero when restarting and `Inherit` is useless.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)
![image](https://github.com/tikv/pd/assets/23399268/618371a9-75ae-4f44-9c3f-14b584bc9586)


Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
