### PR TITLE
*: fix the static checks from the latest tools

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,3 +32,4 @@ linters-settings:
     excludes:
       - G402
       - G404
+      - G601

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1660,15 +1660,11 @@ func DiffRegionKeyInfo(origin *RegionInfo, other *RegionInfo) string {
 }
 
 // String converts slice of bytes to string without copy.
-func String(b []byte) (s string) {
+func String(b []byte) string {
 	if len(b) == 0 {
 		return ""
 	}
-	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	pstring.Data = pbytes.Data
-	pstring.Len = pbytes.Len
-	return
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }
 
 // ToUpperASCIIInplace bytes.ToUpper but zero-cost

--- a/pkg/encryption/key_manager_test.go
+++ b/pkg/encryption/key_manager_test.go
@@ -37,6 +37,7 @@ import (
 	"go.etcd.io/etcd/embed"
 )
 
+// #nosec G101
 const (
 	testMasterKey     = "8fd7e3e917c170d92f3e51a981dd7bc8fba11f3df7d8df994842f6e86f69b530"
 	testMasterKey2    = "8fd7e3e917c170d92f3e51a981dd7bc8fba11f3df7d8df994842f6e86f69b531"

--- a/pkg/encryption/master_key_test.go
+++ b/pkg/encryption/master_key_test.go
@@ -52,7 +52,7 @@ func TestPlaintextMasterKey(t *testing.T) {
 func TestEncrypt(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	keyHex := "2f07ec61e5a50284f47f2b402a962ec672e500b26cb3aa568bb1531300c74806"
+	keyHex := "2f07ec61e5a50284f47f2b402a962ec672e500b26cb3aa568bb1531300c74806" // #nosec G101
 	key, err := hex.DecodeString(keyHex)
 	re.NoError(err)
 	masterKey := &MasterKey{key: key}
@@ -68,7 +68,7 @@ func TestEncrypt(t *testing.T) {
 func TestDecrypt(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	keyHex := "2f07ec61e5a50284f47f2b402a962ec672e500b26cb3aa568bb1531300c74806"
+	keyHex := "2f07ec61e5a50284f47f2b402a962ec672e500b26cb3aa568bb1531300c74806" // #nosec G101
 	key, err := hex.DecodeString(keyHex)
 	re.NoError(err)
 	plaintext := "this-is-a-plaintext"
@@ -149,7 +149,7 @@ func TestNewFileMasterKeyLengthMismatch(t *testing.T) {
 func TestNewFileMasterKey(t *testing.T) {
 	t.Parallel()
 	re := require.New(t)
-	key := "2f07ec61e5a50284f47f2b402a962ec672e500b26cb3aa568bb1531300c74806"
+	key := "2f07ec61e5a50284f47f2b402a962ec672e500b26cb3aa568bb1531300c74806" // #nosec G101
 	dir := t.TempDir()
 	path := dir + "/key"
 	os.WriteFile(path, []byte(key), 0600)

--- a/pkg/schedule/schedulers/transfer_witness_leader.go
+++ b/pkg/schedule/schedulers/transfer_witness_leader.go
@@ -78,6 +78,7 @@ func (s *trasferWitnessLeaderScheduler) Schedule(cluster sche.SchedulerCluster, 
 
 func (s *trasferWitnessLeaderScheduler) scheduleTransferWitnessLeaderBatch(name, typ string, cluster sche.SchedulerCluster, batchSize int) []*operator.Operator {
 	var ops []*operator.Operator
+batchLoop:
 	for i := 0; i < batchSize; i++ {
 		select {
 		case region := <-s.regions:
@@ -92,7 +93,7 @@ func (s *trasferWitnessLeaderScheduler) scheduleTransferWitnessLeaderBatch(name,
 				ops = append(ops, op)
 			}
 		default:
-			break
+			break batchLoop
 		}
 	}
 	return ops

--- a/pkg/utils/apiutil/apiutil.go
+++ b/pkg/utils/apiutil/apiutil.go
@@ -50,7 +50,7 @@ const (
 	// PDRedirectorHeader is used to mark which PD redirected this request.
 	PDRedirectorHeader = "PD-Redirector"
 	// PDAllowFollowerHandleHeader is used to mark whether this request is allowed to be handled by the follower PD.
-	PDAllowFollowerHandleHeader = "PD-Allow-follower-handle"
+	PDAllowFollowerHandleHeader = "PD-Allow-follower-handle" // #nosec G101
 	// XForwardedForHeader is used to mark the client IP.
 	XForwardedForHeader = "X-Forwarded-For"
 	// XForwardedPortHeader is used to mark the client port.

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -179,11 +179,11 @@ func (s *GrpcServer) GetMinTSFromTSOService(dcLocation string) (*pdpb.Timestamp,
 
 	// Get the minimal timestamp from the TSO servers/pods
 	var mutex sync.Mutex
-	resps := make([]*tsopb.GetMinTSResponse, 0)
+	resps := make([]*tsopb.GetMinTSResponse, len(addrs))
 	wg := sync.WaitGroup{}
 	wg.Add(len(addrs))
-	for _, addr := range addrs {
-		go func(addr string) {
+	for idx, addr := range addrs {
+		go func(idx int, addr string) {
 			defer wg.Done()
 			resp, err := s.getMinTSFromSingleServer(s.ctx, dcLocation, addr)
 			if err != nil || resp == nil {
@@ -193,8 +193,8 @@ func (s *GrpcServer) GetMinTSFromTSOService(dcLocation string) (*pdpb.Timestamp,
 			}
 			mutex.Lock()
 			defer mutex.Unlock()
-			resps = append(resps, resp)
-		}(addr)
+			resps[idx] = resp
+		}(idx, addr)
 	}
 	wg.Wait()
 

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -655,6 +655,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	c.Stop()
 }
 
+// nolint:gosec
 func (suite *resourceManagerClientTestSuite) TestAcquireTokenBucket() {
 	re := suite.Require()
 	cli := suite.client


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #4399.

```shell
pkg/utils/apiutil/apiutil.go:53:2: G101: Potential hardcoded credentials (gosec)
	PDAllowFollowerHandleHeader = "PD-Allow-follower-handle"
	^
pkg/core/region.go:1667:14: SA1019: reflect.SliceHeader has been deprecated since Go 1.21 and an alternative has been available since Go 1.17: Use unsafe.Slice or unsafe.SliceData instead. (staticcheck)
	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
	            ^
pkg/core/region.go:1668:15: SA1019: reflect.StringHeader has been deprecated since Go 1.21 and an alternative has been available since Go 1.20: Use unsafe.String or unsafe.StringData instead. (staticcheck)
	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
	             ^
pkg/encryption/key_manager_test.go:41:2: G101: Potential hardcoded credentials (gosec)
	testMasterKey     = "8fd7e3e917c170d92f3e51a981dd7bc8fba11f3df7d8df994842f6e86f69b530"
	^
pkg/encryption/key_manager_test.go:42:2: G101: Potential hardcoded credentials (gosec)
	testMasterKey2    = "8fd7e3e917c170d92f3e51a981dd7bc8fba11f3df7d8df994842f6e86f69b531"
	^
pkg/encryption/key_manager_test.go:43:2: G101: Potential hardcoded credentials (gosec)
	testCiphertextKey = "8fd7e3e917c170d92f3e51a981dd7bc8fba11f3df7d8df994842f6e86f69b532"
	^
pkg/schedule/schedulers/hot_region.go:178:23: G601: Implicit memory aliasing in for loop. (gosec)
				from.AddInfluence(&p.origin, -weight)
				                  ^
pkg/schedule/schedulers/hot_region.go:181:21: G601: Implicit memory aliasing in for loop. (gosec)
				to.AddInfluence(&p.origin, weight)
				                ^
pkg/schedule/schedulers/hot_region.go:529:39: G601: Implicit memory aliasing in for loop. (gosec)
		maxCur = statistics.MaxLoad(maxCur, &detail.LoadPred.Current)
		                                    ^
server/grpc_service.go:213:25: G602: Potentially accessing slice out of bounds (gosec)
	keyspaceGroupsTotal := resps[0].KeyspaceGroupsTotal
```

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix some static check errors from the latest version of tools.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
