### PR TITLE
tso: sync timestamp once before the first serving

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -272,14 +272,6 @@ func WithInitMetricsOption(initMetrics bool) ClientOption {
 	}
 }
 
-// WithAllowTSOFallback configures the client with `allowTSOFallback` option.
-// NOTICE: This should only be used for testing.
-func WithAllowTSOFallback() ClientOption {
-	return func(c *client) {
-		c.option.allowTSOFallback = true
-	}
-}
-
 var _ Client = (*client)(nil)
 
 // serviceModeKeeper is for service mode switching.

--- a/client/option.go
+++ b/client/option.go
@@ -54,7 +54,6 @@ type option struct {
 	enableForwarding bool
 	metricsLabels    prometheus.Labels
 	initMetrics      bool
-	allowTSOFallback bool
 
 	// Dynamic options.
 	dynamicOptions [dynamicOptionCount]atomic.Value

--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -796,22 +796,7 @@ func (c *tsoClient) compareAndSwapTS(
 	// all TSOs we get will be [6, 7, 8, 9, 10]. lastTSOInfo.logical stores the logical part of the largest ts returned
 	// last time.
 	if tsoutil.TSLessEqual(physical, firstLogical, lastTSOInfo.physical, lastTSOInfo.logical) {
-		if !c.option.allowTSOFallback {
-			log.Panic("[tso] timestamp fallback",
-				zap.String("dc-location", dcLocation),
-				zap.Uint32("keyspace", c.svcDiscovery.GetKeyspaceID()),
-				zap.String("last-ts", fmt.Sprintf("(%d, %d)", lastTSOInfo.physical, lastTSOInfo.logical)),
-				zap.String("cur-ts", fmt.Sprintf("(%d, %d)", physical, firstLogical)),
-				zap.String("last-tso-server", lastTSOInfo.tsoServer),
-				zap.String("cur-tso-server", curTSOInfo.tsoServer),
-				zap.Uint32("last-keyspace-group-in-request", lastTSOInfo.reqKeyspaceGroupID),
-				zap.Uint32("cur-keyspace-group-in-request", curTSOInfo.reqKeyspaceGroupID),
-				zap.Uint32("last-keyspace-group-in-response", lastTSOInfo.respKeyspaceGroupID),
-				zap.Uint32("cur-keyspace-group-in-response", curTSOInfo.respKeyspaceGroupID),
-				zap.Time("last-response-received-at", lastTSOInfo.respReceivedAt),
-				zap.Time("cur-response-received-at", curTSOInfo.respReceivedAt))
-		}
-		log.Error("[tso] timestamp fallback",
+		log.Panic("[tso] timestamp fallback",
 			zap.String("dc-location", dcLocation),
 			zap.Uint32("keyspace", c.svcDiscovery.GetKeyspaceID()),
 			zap.String("last-ts", fmt.Sprintf("(%d, %d)", lastTSOInfo.physical, lastTSOInfo.logical)),

--- a/pkg/mcs/tso/server/grpc_service.go
+++ b/pkg/mcs/tso/server/grpc_service.go
@@ -142,7 +142,9 @@ func (s *Service) Tso(stream tsopb.TSO_TsoServer) error {
 		}
 		count := request.GetCount()
 		ts, keyspaceGroupBelongTo, err := s.keyspaceGroupManager.HandleTSORequest(
-			request.Header.KeyspaceId, request.Header.KeyspaceGroupId, request.GetDcLocation(), count)
+			ctx,
+			request.Header.KeyspaceId, request.Header.KeyspaceGroupId,
+			request.GetDcLocation(), count)
 		if err != nil {
 			return status.Errorf(codes.Unknown, err.Error())
 		}

--- a/pkg/tso/allocator_manager.go
+++ b/pkg/tso/allocator_manager.go
@@ -1198,6 +1198,9 @@ func (am *AllocatorManager) getAllocatorGroup(dcLocation string) (*allocatorGrou
 func (am *AllocatorManager) GetAllocator(dcLocation string) (Allocator, error) {
 	am.mu.RLock()
 	defer am.mu.RUnlock()
+	if len(dcLocation) == 0 {
+		dcLocation = GlobalDCLocation
+	}
 	allocatorGroup, exist := am.mu.allocatorGroups[dcLocation]
 	if !exist {
 		return nil, errs.ErrGetAllocator.FastGenByArgs(fmt.Sprintf("%s allocator not found", dcLocation))

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -665,19 +665,19 @@ func (suite *keyspaceGroupManagerTestSuite) TestHandleTSORequestWithWrongMembers
 	// Should succeed because keyspace 0 is actually in keyspace group 0, which is served
 	// by the current keyspace group manager, instead of keyspace group 1 in ask, and
 	// keyspace group 0 is returned in the response.
-	_, keyspaceGroupBelongTo, err := mgr.HandleTSORequest(0, 1, GlobalDCLocation, 1)
+	_, keyspaceGroupBelongTo, err := mgr.HandleTSORequest(suite.ctx, 0, 1, GlobalDCLocation, 1)
 	re.NoError(err)
 	re.Equal(uint32(0), keyspaceGroupBelongTo)
 
 	// Should succeed because keyspace 100 doesn't belong to any keyspace group, so it will
 	// be served by the default keyspace group 0, and keyspace group 0 is returned in the response.
-	_, keyspaceGroupBelongTo, err = mgr.HandleTSORequest(100, 0, GlobalDCLocation, 1)
+	_, keyspaceGroupBelongTo, err = mgr.HandleTSORequest(suite.ctx, 100, 0, GlobalDCLocation, 1)
 	re.NoError(err)
 	re.Equal(uint32(0), keyspaceGroupBelongTo)
 
 	// Should fail because keyspace 100 doesn't belong to any keyspace group, and the keyspace group
 	// 1 in ask doesn't exist.
-	_, keyspaceGroupBelongTo, err = mgr.HandleTSORequest(100, 1, GlobalDCLocation, 1)
+	_, keyspaceGroupBelongTo, err = mgr.HandleTSORequest(suite.ctx, 100, 1, GlobalDCLocation, 1)
 	re.Error(err)
 	re.Equal(uint32(1), keyspaceGroupBelongTo)
 }
@@ -1107,7 +1107,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestPrimaryPriorityChange() {
 	// And the primaries on TSO Server 1 should continue to serve TSO requests without any failures.
 	for i := 0; i < 100; i++ {
 		for _, id := range ids {
-			_, keyspaceGroupBelongTo, err := mgr1.HandleTSORequest(id, id, GlobalDCLocation, 1)
+			_, keyspaceGroupBelongTo, err := mgr1.HandleTSORequest(suite.ctx, id, id, GlobalDCLocation, 1)
 			re.NoError(err)
 			re.Equal(id, keyspaceGroupBelongTo)
 		}
@@ -1203,7 +1203,7 @@ func checkTSO(
 					return
 				default:
 				}
-				respTS, respGroupID, err := mgr.HandleTSORequest(id, id, GlobalDCLocation, 1)
+				respTS, respGroupID, err := mgr.HandleTSORequest(ctx, id, id, GlobalDCLocation, 1)
 				// omit the error check since there are many kinds of errors during primaries movement
 				if err != nil {
 					continue
@@ -1226,7 +1226,7 @@ func waitForPrimariesServing(
 				if member, err := mgrs[j].GetElectionMember(id, id); err != nil || !member.IsLeader() {
 					return false
 				}
-				if _, _, err := mgrs[j].HandleTSORequest(id, id, GlobalDCLocation, 1); err != nil {
+				if _, _, err := mgrs[j].HandleTSORequest(mgrs[j].ctx, id, id, GlobalDCLocation, 1); err != nil {
 					return false
 				}
 			}

--- a/pkg/tso/metrics.go
+++ b/pkg/tso/metrics.go
@@ -87,6 +87,7 @@ func init() {
 type tsoMetrics struct {
 	// timestampOracle event counter
 	syncEvent                    prometheus.Counter
+	skipSyncEvent                prometheus.Counter
 	syncOKEvent                  prometheus.Counter
 	errSaveSyncTSEvent           prometheus.Counter
 	errLeaseResetTSEvent         prometheus.Counter
@@ -119,6 +120,7 @@ type tsoMetrics struct {
 func newTSOMetrics(groupID, dcLocation string) *tsoMetrics {
 	return &tsoMetrics{
 		syncEvent:                    tsoCounter.WithLabelValues("sync", groupID, dcLocation),
+		skipSyncEvent:                tsoCounter.WithLabelValues("skip_sync", groupID, dcLocation),
 		syncOKEvent:                  tsoCounter.WithLabelValues("sync_ok", groupID, dcLocation),
 		errSaveSyncTSEvent:           tsoCounter.WithLabelValues("err_save_sync_ts", groupID, dcLocation),
 		errLeaseResetTSEvent:         tsoCounter.WithLabelValues("err_lease_reset_ts", groupID, dcLocation),

--- a/tests/integrations/mcs/tso/keyspace_group_manager_test.go
+++ b/tests/integrations/mcs/tso/keyspace_group_manager_test.go
@@ -289,7 +289,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) requestTSO(
 	primary := suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID, keyspaceGroupID)
 	kgm := primary.GetKeyspaceGroupManager()
 	re.NotNil(kgm)
-	ts, _, err := kgm.HandleTSORequest(keyspaceID, keyspaceGroupID, tsopkg.GlobalDCLocation, 1)
+	ts, _, err := kgm.HandleTSORequest(suite.ctx, keyspaceID, keyspaceGroupID, tsopkg.GlobalDCLocation, 1)
 	return ts, err
 }
 

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -436,7 +436,7 @@ func TestMixedTSODeployment(t *testing.T) {
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
-	checkTSO(ctx1, re, &wg, backendEndpoints, pd.WithAllowTSOFallback() /* It's expected that the timestamp fallback happens here */)
+	checkTSO(ctx1, re, &wg, backendEndpoints)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -498,14 +498,13 @@ func TestUpgradingAPIandTSOClusters(t *testing.T) {
 }
 
 func checkTSO(
-	ctx context.Context, re *require.Assertions, wg *sync.WaitGroup,
-	backendEndpoints string, opts ...pd.ClientOption,
+	ctx context.Context, re *require.Assertions, wg *sync.WaitGroup, backendEndpoints string,
 ) {
 	wg.Add(tsoRequestConcurrencyNumber)
 	for i := 0; i < tsoRequestConcurrencyNumber; i++ {
 		go func() {
 			defer wg.Done()
-			cli := mcs.SetupClientWithAPIContext(ctx, re, pd.NewAPIContextV1(), strings.Split(backendEndpoints, ","), opts...)
+			cli := mcs.SetupClientWithAPIContext(ctx, re, pd.NewAPIContextV1(), strings.Split(backendEndpoints, ","))
 			defer cli.Close()
 			var ts, lastTS uint64
 			for {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7015.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Sync the timestamp once before the first serving to make sure that the TSO is the latest one from the storage,
which could prevent the potential fallback caused by the rolling update of the mixed PD and TSO service.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
