### PR TITLE
tests: fix waitFinishMerge to stablize the merge test

### DIFF
--- a/tests/integrations/mcs/tso/keyspace_group_manager_test.go
+++ b/tests/integrations/mcs/tso/keyspace_group_manager_test.go
@@ -648,14 +648,16 @@ func waitFinishMerge(
 	mergeTargetID uint32,
 	keyspaces []uint32,
 ) {
+	var kg *endpoint.KeyspaceGroup
 	testutil.Eventually(re, func() bool {
-		kg := handlersutil.MustLoadKeyspaceGroupByID(re, server, mergeTargetID)
-		re.Equal(mcsutils.DefaultKeyspaceGroupID, kg.ID)
-		for _, keyspaceID := range keyspaces {
-			re.Contains(kg.Keyspaces, keyspaceID)
-		}
+		kg = handlersutil.MustLoadKeyspaceGroupByID(re, server, mergeTargetID)
+		re.Equal(mergeTargetID, kg.ID)
 		return !kg.IsMergeTarget()
 	})
+	// If the merge is finished, the target keyspace group should contain all the keyspaces.
+	for _, keyspaceID := range keyspaces {
+		re.Contains(kg.Keyspaces, keyspaceID)
+	}
 }
 
 func (suite *tsoKeyspaceGroupManagerTestSuite) TestTSOKeyspaceGroupMergeBeforeInitTSO() {

--- a/tests/integrations/mcs/tso/proxy_test.go
+++ b/tests/integrations/mcs/tso/proxy_test.go
@@ -317,7 +317,6 @@ func (s *tsoProxyTestSuite) verifyTSOProxy(
 			for j := 0; j < requestsPerClient; j++ {
 				select {
 				case <-ctx.Done():
-					respErr.Store(ctx.Err())
 					s.cleanupGRPCStream(streams, cleanupFuncs, i)
 					return
 				default:


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7051.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Make `waitFinishMerge` assert the keyspace list after the merge is finished rather than every time.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
