### PR TITLE
mcs/scheduling: register the scheduler handler in API service mode

### DIFF
--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -204,8 +203,6 @@ type PersistConfig struct {
 	schedule       atomic.Value
 	replication    atomic.Value
 	storeConfig    atomic.Value
-	// Store the respective configurations for different schedulers.
-	schedulerConfig sync.Map
 }
 
 // NewPersistConfig creates a new PersistConfig instance.
@@ -273,24 +270,6 @@ func (o *PersistConfig) SetStoreConfig(cfg *sc.StoreConfig) {
 // GetStoreConfig returns the TiKV store configuration.
 func (o *PersistConfig) GetStoreConfig() *sc.StoreConfig {
 	return o.storeConfig.Load().(*sc.StoreConfig)
-}
-
-// SetSchedulerConfig sets the scheduler configuration with the given name.
-func (o *PersistConfig) SetSchedulerConfig(name, data string) {
-	o.schedulerConfig.Store(name, data)
-}
-
-// RemoveSchedulerConfig removes the scheduler configuration with the given name.
-func (o *PersistConfig) RemoveSchedulerConfig(name string) {
-	o.schedulerConfig.Delete(name)
-}
-
-// GetSchedulerConfig returns the scheduler configuration with the given name.
-func (o *PersistConfig) GetSchedulerConfig(name string) string {
-	if v, ok := o.schedulerConfig.Load(name); ok {
-		return v.(string)
-	}
-	return ""
 }
 
 // GetMaxReplicas returns the max replicas.

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -47,7 +47,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
-	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/apiutil"
@@ -433,7 +432,7 @@ func (s *Server) startServer() (err error) {
 
 func (s *Server) startCluster(context.Context) error {
 	s.basicCluster = core.NewBasicCluster()
-	err := s.startWatcher(s.storage)
+	err := s.startWatcher()
 	if err != nil {
 		return err
 	}
@@ -454,12 +453,12 @@ func (s *Server) stopCluster() {
 	s.metaWatcher.Close()
 }
 
-func (s *Server) startWatcher(storage storage.Storage) (err error) {
+func (s *Server) startWatcher() (err error) {
 	s.metaWatcher, err = meta.NewWatcher(s.Context(), s.GetClient(), s.clusterID, s.basicCluster)
 	if err != nil {
 		return err
 	}
-	s.configWatcher, err = config.NewWatcher(s.Context(), s.GetClient(), s.clusterID, s.persistConfig, storage)
+	s.configWatcher, err = config.NewWatcher(s.Context(), s.GetClient(), s.clusterID, s.persistConfig, s.storage)
 	if err != nil {
 		return err
 	}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
+	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/apiutil"
@@ -432,7 +433,7 @@ func (s *Server) startServer() (err error) {
 
 func (s *Server) startCluster(context.Context) error {
 	s.basicCluster = core.NewBasicCluster()
-	err := s.startWatcher()
+	err := s.startWatcher(s.storage)
 	if err != nil {
 		return err
 	}
@@ -453,12 +454,12 @@ func (s *Server) stopCluster() {
 	s.metaWatcher.Close()
 }
 
-func (s *Server) startWatcher() (err error) {
+func (s *Server) startWatcher(storage storage.Storage) (err error) {
 	s.metaWatcher, err = meta.NewWatcher(s.Context(), s.GetClient(), s.clusterID, s.basicCluster)
 	if err != nil {
 		return err
 	}
-	s.configWatcher, err = config.NewWatcher(s.Context(), s.GetClient(), s.clusterID, s.persistConfig)
+	s.configWatcher, err = config.NewWatcher(s.Context(), s.GetClient(), s.clusterID, s.persistConfig, storage)
 	if err != nil {
 		return err
 	}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -432,11 +432,11 @@ func (s *Server) startServer() (err error) {
 
 func (s *Server) startCluster(context.Context) error {
 	s.basicCluster = core.NewBasicCluster()
+	s.storage = endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	err := s.startWatcher()
 	if err != nil {
 		return err
 	}
-	s.storage = endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	s.hbStreams = hbstream.NewHeartbeatStreams(s.Context(), s.clusterID, s.basicCluster)
 	s.cluster, err = NewCluster(s.Context(), s.persistConfig, s.storage, s.basicCluster, s.hbStreams, s.clusterID, s.checkMembershipCh)
 	if err != nil {

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -444,6 +444,8 @@ func (c *Coordinator) InitSchedulers(needRun bool) {
 			if err = c.schedulers.AddScheduler(s); err != nil {
 				log.Error("can not add scheduler with independent configuration", zap.String("scheduler-name", s.GetName()), zap.Strings("scheduler-args", cfg.Args), errs.ZapError(err))
 			}
+		} else if err = c.schedulers.AddSchedulerHandler(s); err != nil {
+			log.Error("can not add scheduler handler with independent configuration", zap.String("scheduler-name", s.GetName()), zap.Strings("scheduler-args", cfg.Args), errs.ZapError(err))
 		}
 	}
 
@@ -472,6 +474,8 @@ func (c *Coordinator) InitSchedulers(needRun bool) {
 				scheduleCfg.Schedulers[k] = schedulerCfg
 				k++
 			}
+		} else if err = c.schedulers.AddSchedulerHandler(s, schedulerCfg.Args...); err != nil && !errors.ErrorEqual(err, errs.ErrSchedulerExisted.FastGenByArgs()) {
+			log.Error("can not add scheduler handler", zap.String("scheduler-name", s.GetName()), zap.Strings("scheduler-args", schedulerCfg.Args), errs.ZapError(err))
 		}
 	}
 
@@ -507,6 +511,7 @@ func (c *Coordinator) LoadPlugin(pluginPath string, ch chan string) {
 		return
 	}
 	log.Info("create scheduler", zap.String("scheduler-name", s.GetName()))
+	// TODO: handle the plugin in API service mode.
 	if err = c.schedulers.AddScheduler(s); err != nil {
 		log.Error("can't add scheduler", zap.String("scheduler-name", s.GetName()), errs.ZapError(err))
 		return

--- a/pkg/schedule/schedulers/scheduler.go
+++ b/pkg/schedule/schedulers/scheduler.go
@@ -91,8 +91,10 @@ func ConfigSliceDecoder(name string, args []string) ConfigDecoder {
 // CreateSchedulerFunc is for creating scheduler.
 type CreateSchedulerFunc func(opController *operator.Controller, storage endpoint.ConfigStorage, dec ConfigDecoder, removeSchedulerCb ...func(string) error) (Scheduler, error)
 
-var schedulerMap = make(map[string]CreateSchedulerFunc)
-var schedulerArgsToDecoder = make(map[string]ConfigSliceDecoderBuilder)
+var (
+	schedulerMap           = make(map[string]CreateSchedulerFunc)
+	schedulerArgsToDecoder = make(map[string]ConfigSliceDecoderBuilder)
+)
 
 // RegisterScheduler binds a scheduler creator. It should be called in init()
 // func of a package.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -795,6 +795,16 @@ func (c *RaftCluster) GetSchedulerHandlers() map[string]http.Handler {
 	return c.coordinator.GetSchedulersController().GetSchedulerHandlers()
 }
 
+// AddSchedulerHandler adds a scheduler handler.
+func (c *RaftCluster) AddSchedulerHandler(scheduler schedulers.Scheduler, args ...string) error {
+	return c.coordinator.GetSchedulersController().AddSchedulerHandler(scheduler, args...)
+}
+
+// RemoveSchedulerHandler removes a scheduler handler.
+func (c *RaftCluster) RemoveSchedulerHandler(name string) error {
+	return c.coordinator.GetSchedulersController().RemoveSchedulerHandler(name)
+}
+
 // AddScheduler adds a scheduler.
 func (c *RaftCluster) AddScheduler(scheduler schedulers.Scheduler, args ...string) error {
 	return c.coordinator.GetSchedulersController().AddScheduler(scheduler, args...)

--- a/tests/integrations/mcs/scheduling/config_test.go
+++ b/tests/integrations/mcs/scheduling/config_test.go
@@ -17,12 +17,18 @@ package scheduling
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
+	"github.com/tikv/pd/pkg/slice"
+	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/versioninfo"
 	"github.com/tikv/pd/tests"
@@ -77,6 +83,7 @@ func (suite *configTestSuite) TestConfigWatch() {
 		suite.pdLeaderServer.GetEtcdClient(),
 		suite.cluster.GetCluster().GetId(),
 		config.NewPersistConfig(config.NewConfig()),
+		endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
 	)
 	re.NoError(err)
 	// Check the initial config value.
@@ -128,39 +135,75 @@ func (suite *configTestSuite) TestSchedulerConfigWatch() {
 	// Make sure the config is persisted before the watcher is created.
 	persistConfig(re, suite.pdLeaderServer)
 	// Create a config watcher.
+	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	watcher, err := config.NewWatcher(
 		suite.ctx,
 		suite.pdLeaderServer.GetEtcdClient(),
 		suite.cluster.GetCluster().GetId(),
 		config.NewPersistConfig(config.NewConfig()),
+		storage,
 	)
 	re.NoError(err)
 	// Get all default scheduler names.
-	var schedulerNames, _, _ = suite.pdLeaderServer.GetRaftCluster().GetStorage().LoadAllScheduleConfig()
-
+	var namesFromAPIServer, _, _ = suite.pdLeaderServer.GetRaftCluster().GetStorage().LoadAllScheduleConfig()
 	testutil.Eventually(re, func() bool {
-		targetCount := len(sc.DefaultSchedulers)
-		return len(schedulerNames) == targetCount
+		return len(namesFromAPIServer) == len(sc.DefaultSchedulers)
 	})
 	// Check all default schedulers' configs.
-	for _, schedulerName := range schedulerNames {
-		testutil.Eventually(re, func() bool {
-			return len(watcher.GetSchedulerConfig(schedulerName)) > 0
-		})
-	}
+	var namesFromSchedulingServer []string
+	testutil.Eventually(re, func() bool {
+		namesFromSchedulingServer, _, err = storage.LoadAllScheduleConfig()
+		re.NoError(err)
+		return len(namesFromSchedulingServer) == len(namesFromAPIServer)
+	})
+	re.Equal(namesFromAPIServer, namesFromSchedulingServer)
 	// Add a new scheduler.
 	err = suite.pdLeaderServer.GetServer().GetHandler().AddEvictLeaderScheduler(1)
 	re.NoError(err)
 	// Check the new scheduler's config.
 	testutil.Eventually(re, func() bool {
-		return len(watcher.GetSchedulerConfig(schedulers.EvictLeaderName)) > 0
+		namesFromSchedulingServer, _, err = storage.LoadAllScheduleConfig()
+		re.NoError(err)
+		return slice.Contains(namesFromSchedulingServer, schedulers.EvictLeaderName)
 	})
+	// Update the scheduler.
+	suite.pdLeaderServer.GetServer().GetRaftCluster().PutStore(&metapb.Store{
+		Id:            2,
+		Address:       "mock://2",
+		LastHeartbeat: time.Now().UnixNano(),
+	})
+	err = suite.pdLeaderServer.GetServer().GetHandler().AddEvictOrGrant(2, schedulers.EvictLeaderName)
+	re.NoError(err)
+	// Check the updated scheduler's config.
+	var (
+		configs        []string
+		evictLeaderCfg struct {
+			StoreIDWithRanges map[uint64][]core.KeyRange `json:"store-id-ranges"`
+		}
+	)
+	testutil.Eventually(re, func() bool {
+		namesFromSchedulingServer, configs, err = storage.LoadAllScheduleConfig()
+		re.NoError(err)
+		for idx, name := range namesFromSchedulingServer {
+			if name == schedulers.EvictLeaderName {
+				err = schedulers.DecodeConfig([]byte(configs[idx]), &evictLeaderCfg)
+				re.NoError(err)
+				return len(evictLeaderCfg.StoreIDWithRanges) == 2
+			}
+		}
+		return false
+	})
+	// Validate the updated scheduler's config.
+	re.Contains(evictLeaderCfg.StoreIDWithRanges, uint64(1))
+	re.Contains(evictLeaderCfg.StoreIDWithRanges, uint64(2))
 	// Remove the scheduler.
 	err = suite.pdLeaderServer.GetServer().GetHandler().RemoveScheduler(schedulers.EvictLeaderName)
 	re.NoError(err)
 	// Check the removed scheduler's config.
 	testutil.Eventually(re, func() bool {
-		return len(watcher.GetSchedulerConfig(schedulers.EvictLeaderName)) == 0
+		namesFromSchedulingServer, _, err = storage.LoadAllScheduleConfig()
+		re.NoError(err)
+		return !slice.Contains(namesFromSchedulingServer, schedulers.EvictLeaderName)
 	})
 	watcher.Close()
 }

--- a/tests/integrations/mcs/scheduling/config_test.go
+++ b/tests/integrations/mcs/scheduling/config_test.go
@@ -167,11 +167,17 @@ func (suite *configTestSuite) TestSchedulerConfigWatch() {
 		return slice.Contains(namesFromSchedulingServer, schedulers.EvictLeaderName)
 	})
 	// Update the scheduler.
-	suite.pdLeaderServer.GetServer().GetRaftCluster().PutStore(&metapb.Store{
-		Id:            2,
-		Address:       "mock://2",
-		LastHeartbeat: time.Now().UnixNano(),
-	})
+	err = suite.pdLeaderServer.GetServer().GetRaftCluster().PutStore(
+		&metapb.Store{
+			Id:            2,
+			Address:       "mock://2",
+			State:         metapb.StoreState_Up,
+			NodeState:     metapb.NodeState_Serving,
+			LastHeartbeat: time.Now().UnixNano(),
+			Version:       "4.0.0",
+		},
+	)
+	re.NoError(err)
 	err = suite.pdLeaderServer.GetServer().GetHandler().AddEvictOrGrant(2, schedulers.EvictLeaderName)
 	re.NoError(err)
 	// Check the updated scheduler's config.

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api_test
+package api
 
 import (
 	"bytes"
@@ -43,13 +43,6 @@ import (
 	"github.com/tikv/pd/tests/pdctl"
 	"go.uber.org/goleak"
 )
-
-// dialClient used to dial http request.
-var dialClient = &http.Client{
-	Transport: &http.Transport{
-		DisableKeepAlives: true,
-	},
-}
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)

--- a/tests/server/api/testutil.go
+++ b/tests/server/api/testutil.go
@@ -1,0 +1,70 @@
+// Copyright 2023 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/stretchr/testify/require"
+)
+
+const schedulersPrefix = "/pd/api/v1/schedulers"
+
+// dialClient used to dial http request.
+var dialClient = &http.Client{
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+	},
+}
+
+// MustAddScheduler adds a scheduler with HTTP API.
+func MustAddScheduler(
+	re *require.Assertions, serverAddr string,
+	schedulerName string, args map[string]interface{},
+) {
+	request := map[string]interface{}{
+		"name": schedulerName,
+	}
+	for arg, val := range args {
+		request[arg] = val
+	}
+	data, err := json.Marshal(request)
+	re.NoError(err)
+	httpReq, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s%s", serverAddr, schedulersPrefix), bytes.NewBuffer(data))
+	re.NoError(err)
+	// Send request.
+	resp, err := dialClient.Do(httpReq)
+	re.NoError(err)
+	defer resp.Body.Close()
+	data, err = io.ReadAll(resp.Body)
+	re.NoError(err)
+	re.Equal(http.StatusOK, resp.StatusCode, string(data))
+}
+
+// MustDeleteScheduler deletes a scheduler with HTTP API.
+func MustDeleteScheduler(re *require.Assertions, serverAddr, schedulerName string) {
+	httpReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s%s/%s", serverAddr, schedulersPrefix, schedulerName), nil)
+	re.NoError(err)
+	resp, err := dialClient.Do(httpReq)
+	re.NoError(err)
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	re.NoError(err)
+	re.Equal(http.StatusOK, resp.StatusCode, string(data))
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5839.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
To ensure that the HTTP API handler could be initialized properly for each scheduler in the API service mode,
this PR updates the scheduler controller and PD server handler to support initialize the HTTP handler only.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
