### PR TITLE
pd-api-bench: fix the gosec check

### DIFF
--- a/tools/pd-api-bench/main.go
+++ b/tools/pd-api-bench/main.go
@@ -154,13 +154,13 @@ func main() {
 		log.Println("concurrency == 0, exit")
 		return
 	}
-	pdClis := make([]pd.Client, 0)
+	pdClis := make([]pd.Client, *client)
 	for i := 0; i < *client; i++ {
-		pdClis = append(pdClis, newPDClient(ctx))
+		pdClis[i] = newPDClient(ctx)
 	}
-	httpClis := make([]*http.Client, 0)
+	httpClis := make([]*http.Client, *client)
 	for i := 0; i < *client; i++ {
-		httpClis = append(httpClis, newHTTPClient())
+		httpClis[i] = newHTTPClient()
 	}
 	err = cases.InitCluster(ctx, pdClis[0], httpClis[0])
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #4399.

```shell
main.go:165:31: G602: Potentially accessing slice out of bounds (gosec)
	err = cases.InitCluster(ctx, pdClis[0], httpClis[0])
	                             ^
```

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix the gosec check warning.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
