### PR TITLE
keyspace: return error if the split keyspace list is empty

### DIFF
--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -675,6 +675,10 @@ func buildSplitKeyspaces(
 			newKeyspaceMap[keyspace] = struct{}{}
 		}
 	}
+	// Check if the new keyspace list is empty.
+	if len(newSplit) == 0 {
+		return nil, nil, ErrKeyspaceGroupWithEmptyKeyspace
+	}
 	// Get the split keyspace list for the old keyspace group.
 	oldSplit := make([]uint32, 0, oldNum-len(newSplit))
 	for _, keyspace := range old {

--- a/pkg/keyspace/tso_keyspace_group_test.go
+++ b/pkg/keyspace/tso_keyspace_group_test.go
@@ -542,8 +542,7 @@ func TestBuildSplitKeyspaces(t *testing.T) {
 			old:             []uint32{1, 2, 3, 4, 5},
 			startKeyspaceID: 7,
 			endKeyspaceID:   10,
-			expectedOld:     []uint32{1, 2, 3, 4, 5},
-			expectedNew:     []uint32{},
+			err:             ErrKeyspaceGroupWithEmptyKeyspace,
 		},
 		{
 			old: []uint32{1, 2, 3, 4, 5},

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -76,6 +76,8 @@ var (
 	ErrNodeNotInKeyspaceGroup = errors.New("the tso node is not in this keyspace group")
 	// ErrKeyspaceGroupNotEnoughReplicas is used to indicate not enough replicas in the keyspace group.
 	ErrKeyspaceGroupNotEnoughReplicas = errors.New("not enough replicas in the keyspace group")
+	// ErrKeyspaceGroupWithEmptyKeyspace is used to indicate keyspace group with empty keyspace.
+	ErrKeyspaceGroupWithEmptyKeyspace = errors.New("keyspace group with empty keyspace")
 	// ErrModifyDefaultKeyspaceGroup is used to indicate that default keyspace group cannot be modified.
 	ErrModifyDefaultKeyspaceGroup = errors.New("default keyspace group cannot be modified")
 	// ErrNoAvailableNode is used to indicate no available node in the keyspace group.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7101.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
