### PR TITLE
schedulers, handler: fix the evict-leader-scheduler sync

### DIFF
--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -204,6 +204,7 @@ func (c *Cluster) updateScheduler() {
 			log.Info("cluster is closing, stop listening the schedulers updating notifier")
 			return
 		case <-notifier:
+			// This is triggered by the watcher when the schedulers are updated.
 		}
 
 		log.Info("schedulers updating notifier is triggered, try to update the scheduler")

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -218,6 +218,19 @@ func (s *evictLeaderScheduler) ReloadConfig() error {
 	if err = DecodeConfig([]byte(cfgData), newCfg); err != nil {
 		return err
 	}
+	// Resume and pause the leader transfer for each store.
+	for id := range s.conf.StoreIDWithRanges {
+		if _, ok := newCfg.StoreIDWithRanges[id]; ok {
+			continue
+		}
+		s.conf.cluster.ResumeLeaderTransfer(id)
+	}
+	for id := range newCfg.StoreIDWithRanges {
+		if _, ok := s.conf.StoreIDWithRanges[id]; ok {
+			continue
+		}
+		s.conf.cluster.PauseLeaderTransfer(id)
+	}
 	s.conf.StoreIDWithRanges = newCfg.StoreIDWithRanges
 	return nil
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -231,7 +231,13 @@ func (h *Handler) AddScheduler(name string, args ...string) error {
 		return err
 	}
 
-	s, err := schedulers.CreateScheduler(name, c.GetOperatorController(), h.s.storage, schedulers.ConfigSliceDecoder(name, args), c.GetCoordinator().GetSchedulersController().RemoveScheduler)
+	var removeSchedulerCb func(string) error
+	if h.s.IsAPIServiceMode() {
+		removeSchedulerCb = c.GetCoordinator().GetSchedulersController().RemoveSchedulerHandler
+	} else {
+		removeSchedulerCb = c.GetCoordinator().GetSchedulersController().RemoveScheduler
+	}
+	s, err := schedulers.CreateScheduler(name, c.GetOperatorController(), h.s.storage, schedulers.ConfigSliceDecoder(name, args), removeSchedulerCb)
 	if err != nil {
 		return err
 	}

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -17,12 +17,14 @@ package scheduling
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	mcs "github.com/tikv/pd/pkg/mcs/utils"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
@@ -196,25 +198,15 @@ func (suite *serverTestSuite) TestSchedulerSync() {
 	defer tc.Destroy()
 	tc.WaitForPrimaryServing(re)
 	schedulersController := tc.GetPrimaryServer().GetCluster().GetCoordinator().GetSchedulersController()
-	re.Len(schedulersController.GetSchedulerNames(), 5)
-	re.Nil(schedulersController.GetScheduler(schedulers.EvictLeaderName))
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, false)
 	// Add a new evict-leader-scheduler through the API server.
 	api.MustAddScheduler(re, suite.backendEndpoints, schedulers.EvictLeaderName, map[string]interface{}{
 		"store_id": 1,
 	})
 	// Check if the evict-leader-scheduler is added.
-	testutil.Eventually(re, func() bool {
-		return len(schedulersController.GetSchedulerNames()) == 6 &&
-			schedulersController.GetScheduler(schedulers.EvictLeaderName) != nil
-	})
-	handler, ok := schedulersController.GetSchedulerHandlers()[schedulers.EvictLeaderName]
-	re.True(ok)
-	h, ok := handler.(interface {
-		EvictStoreIDs() []uint64
-	})
-	re.True(ok)
-	re.ElementsMatch(h.EvictStoreIDs(), []uint64{1})
-	// Update the evict-leader-scheduler through the API server.
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, true)
+	checkEvictLeaderStoreIDs(re, schedulersController, []uint64{1})
+	// Add a store_id to the evict-leader-scheduler through the API server.
 	err = suite.pdLeader.GetServer().GetRaftCluster().PutStore(
 		&metapb.Store{
 			Id:            2,
@@ -229,25 +221,70 @@ func (suite *serverTestSuite) TestSchedulerSync() {
 	api.MustAddScheduler(re, suite.backendEndpoints, schedulers.EvictLeaderName, map[string]interface{}{
 		"store_id": 2,
 	})
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, true)
+	checkEvictLeaderStoreIDs(re, schedulersController, []uint64{1, 2})
+	// Delete a store_id from the evict-leader-scheduler through the API server.
+	api.MustDeleteScheduler(re, suite.backendEndpoints, fmt.Sprintf("%s-%d", schedulers.EvictLeaderName, 1))
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, true)
+	checkEvictLeaderStoreIDs(re, schedulersController, []uint64{2})
+	// Add a store_id to the evict-leader-scheduler through the API server by the scheduler handler.
+	api.MustCallSchedulerConfigAPI(re, http.MethodPost, suite.backendEndpoints, schedulers.EvictLeaderName, []string{"config"}, map[string]interface{}{
+		"name":     schedulers.EvictLeaderName,
+		"store_id": 1,
+	})
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, true)
+	checkEvictLeaderStoreIDs(re, schedulersController, []uint64{1, 2})
+	// Delete a store_id from the evict-leader-scheduler through the API server by the scheduler handler.
+	api.MustCallSchedulerConfigAPI(re, http.MethodDelete, suite.backendEndpoints, schedulers.EvictLeaderName, []string{"delete", "2"}, nil)
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, true)
+	checkEvictLeaderStoreIDs(re, schedulersController, []uint64{1})
+	// If the last store is deleted, the scheduler should be removed.
+	api.MustCallSchedulerConfigAPI(re, http.MethodDelete, suite.backendEndpoints, schedulers.EvictLeaderName, []string{"delete", "1"}, nil)
+	// Check if the scheduler is removed.
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, false)
+
+	// Delete the evict-leader-scheduler through the API server by removing the last store_id.
+	api.MustAddScheduler(re, suite.backendEndpoints, schedulers.EvictLeaderName, map[string]interface{}{
+		"store_id": 1,
+	})
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, true)
+	checkEvictLeaderStoreIDs(re, schedulersController, []uint64{1})
+	api.MustDeleteScheduler(re, suite.backendEndpoints, fmt.Sprintf("%s-%d", schedulers.EvictLeaderName, 1))
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, false)
+
+	// Delete the evict-leader-scheduler through the API server.
+	api.MustAddScheduler(re, suite.backendEndpoints, schedulers.EvictLeaderName, map[string]interface{}{
+		"store_id": 1,
+	})
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, true)
+	checkEvictLeaderStoreIDs(re, schedulersController, []uint64{1})
+	api.MustDeleteScheduler(re, suite.backendEndpoints, schedulers.EvictLeaderName)
+	checkSchedulerExist(re, schedulersController, schedulers.EvictLeaderName, false)
+
+	// TODO: test more schedulers.
+}
+
+func checkSchedulerExist(re *require.Assertions, sc *schedulers.Controller, schedulerName string, exist bool) {
+	re.NotEmpty(schedulerName)
+	testutil.Eventually(re, func() bool {
+		if !exist {
+			return sc.GetScheduler(schedulerName) == nil
+		}
+		return sc.GetScheduler(schedulerName) != nil
+	})
+}
+
+func checkEvictLeaderStoreIDs(re *require.Assertions, sc *schedulers.Controller, expected []uint64) {
+	handler, ok := sc.GetSchedulerHandlers()[schedulers.EvictLeaderName]
+	re.True(ok)
+	h, ok := handler.(interface {
+		EvictStoreIDs() []uint64
+	})
+	re.True(ok)
 	var evictStoreIDs []uint64
 	testutil.Eventually(re, func() bool {
 		evictStoreIDs = h.EvictStoreIDs()
-		return len(evictStoreIDs) == 2
+		return len(evictStoreIDs) == len(expected)
 	})
-	re.ElementsMatch(evictStoreIDs, []uint64{1, 2})
-	api.MustDeleteScheduler(re, suite.backendEndpoints, fmt.Sprintf("%s-%d", schedulers.EvictLeaderName, 1))
-	testutil.Eventually(re, func() bool {
-		evictStoreIDs = h.EvictStoreIDs()
-		return len(evictStoreIDs) == 1
-	})
-	re.ElementsMatch(evictStoreIDs, []uint64{2})
-	// Remove the evict-leader-scheduler through the API server.
-	api.MustDeleteScheduler(re, suite.backendEndpoints, schedulers.EvictLeaderName)
-	// Check if the scheduler is removed.
-	testutil.Eventually(re, func() bool {
-		return len(schedulersController.GetSchedulerNames()) == 5 &&
-			schedulersController.GetScheduler(schedulers.EvictLeaderName) == nil
-	})
-
-	// TODO: test more schedulers.
+	re.ElementsMatch(evictStoreIDs, expected)
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5839.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- Pass the correct `removeSchedulerCb` when the server is in API mode.
- Pause and resume the store leader transfer when reloading the cfg.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
