### PR TITLE
scatter: fix incorrect judgment condition

### DIFF
--- a/pkg/schedule/scatter/region_scatterer.go
+++ b/pkg/schedule/scatter/region_scatterer.go
@@ -451,7 +451,7 @@ func (r *RegionScatterer) selectNewPeer(context engineContext, group string, pee
 	originStorePickedCount := uint64(math.MaxUint64)
 	for _, store := range stores {
 		storeCount := context.selectedPeer.Get(store.GetID(), group)
-		if store.GetID() == peer.GetId() {
+		if store.GetID() == peer.GetStoreId() {
 			originStorePickedCount = storeCount
 		}
 		// If storeCount is equal to the maxStoreTotalCount, we should skip this store as candidate.

--- a/pkg/schedule/scatter/region_scatterer_test.go
+++ b/pkg/schedule/scatter/region_scatterer_test.go
@@ -67,6 +67,7 @@ func TestScatterRegions(t *testing.T) {
 	scatter(re, 5, 50, true)
 	scatter(re, 5, 500, true)
 	scatter(re, 6, 50, true)
+	scatter(re, 7, 71, true)
 	scatter(re, 5, 50, false)
 	scatterSpecial(re, 3, 6, 50)
 	scatterSpecial(re, 5, 5, 50)
@@ -132,20 +133,36 @@ func scatter(re *require.Assertions, numStores, numRegions uint64, useRules bool
 			}
 		}
 	}
+	maxStorePeerTotalCount := uint64(0)
+	minStorePeerTotalCount := uint64(math.MaxUint64)
 
 	// Each store should have the same number of peers.
 	for _, count := range countPeers {
-		re.LessOrEqual(float64(count), 1.1*float64(numRegions*3)/float64(numStores))
-		re.GreaterOrEqual(float64(count), 0.9*float64(numRegions*3)/float64(numStores))
+		if count > maxStorePeerTotalCount {
+			maxStorePeerTotalCount = count
+		}
+		if count < minStorePeerTotalCount {
+			minStorePeerTotalCount = count
+		}
 	}
+	re.LessOrEqual(maxStorePeerTotalCount-minStorePeerTotalCount, uint64(1))
 
 	// Each store should have the same number of leaders.
 	re.Len(countPeers, int(numStores))
 	re.Len(countLeader, int(numStores))
+
+	maxStoreLeaderTotalCount := uint64(0)
+	minStoreLeaderTotalCount := uint64(math.MaxUint64)
 	for _, count := range countLeader {
-		re.LessOrEqual(float64(count), 1.1*float64(numRegions)/float64(numStores))
-		re.GreaterOrEqual(float64(count), 0.9*float64(numRegions)/float64(numStores))
+		if count > maxStoreLeaderTotalCount {
+			maxStoreLeaderTotalCount = count
+		}
+		if count < minStoreLeaderTotalCount {
+			minStoreLeaderTotalCount = count
+		}
 	}
+	// Since the scatter leader depends on the scatter result of the peer, the maximum difference is 2.
+	re.LessOrEqual(maxStoreLeaderTotalCount-minStoreLeaderTotalCount, uint64(2))
 	re.GreaterOrEqual(noNeedMoveNum, 0)
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7109

### What is changed and how does it work?
Modified the judgment criteria.
Replaced with a more rigorous test judgment.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
