### PR TITLE
api: supports GetRegion by hex key

### DIFF
--- a/server/api/region.go
+++ b/server/api/region.go
@@ -280,7 +280,7 @@ func (h *regionHandler) GetRegion(w http.ResponseWriter, r *http.Request) {
 	// decode hex if query has params with hex format
 	formatStr := r.URL.Query().Get("format")
 	if formatStr == "hex" {
-		keyBytes, err := hex.DecodeString(string(key))
+		keyBytes, err := hex.DecodeString(key)
 		if err != nil {
 			h.rd.JSON(w, http.StatusBadRequest, err.Error())
 			return

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -277,6 +277,17 @@ func (h *regionHandler) GetRegion(w http.ResponseWriter, r *http.Request) {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// decode hex if query has params with hex format
+	formatStr := r.URL.Query().Get("format")
+	if formatStr == "hex" {
+		keyBytes, err := hex.DecodeString(string(key))
+		if err != nil {
+			h.rd.JSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		key = string(keyBytes)
+	}
+
 	regionInfo := rc.GetRegionByKey([]byte(key))
 	h.rd.JSON(w, http.StatusOK, NewAPIRegionInfo(regionInfo))
 }

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -147,6 +147,13 @@ func (suite *regionTestSuite) TestRegion() {
 	suite.NoError(tu.ReadGetJSON(re, testDialClient, url, r2))
 	r2.Adjust()
 	suite.Equal(NewAPIRegionInfo(r), r2)
+
+	url = fmt.Sprintf("%s/region/key/%s?format=hex", suite.urlPrefix, hex.EncodeToString([]byte("a")))
+	r2 = &RegionInfo{}
+	suite.NoError(tu.ReadGetJSON(re, testDialClient, url, r2))
+	r2.Adjust()
+	suite.Equal(NewAPIRegionInfo(r), r2)
+
 }
 
 func (suite *regionTestSuite) TestRegionCheck() {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -153,7 +153,6 @@ func (suite *regionTestSuite) TestRegion() {
 	suite.NoError(tu.ReadGetJSON(re, testDialClient, url, r2))
 	r2.Adjust()
 	suite.Equal(NewAPIRegionInfo(r), r2)
-
 }
 
 func (suite *regionTestSuite) TestRegionCheck() {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/7159

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

sometimes, the user uses the API /region/key/{key} without `pd-ctl`. it's not useful because the key should specified with the raw key.

```commit-message
api: supports GetRegion by hex key
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
