### PR TITLE
dashboard_test: extend wait time for dashboard service

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -505,7 +505,7 @@ type PDServerConfig struct {
 	// RuntimeServices is the running extension services.
 	RuntimeServices typeutil.StringSlice `toml:"runtime-services" json:"runtime-services"`
 	// MetricStorage is the cluster metric storage.
-	// Currently we use prometheus as metric storage, we may use PD/TiKV as metric storage later.
+	// Currently, we use prometheus as metric storage, we may use PD/TiKV as metric storage later.
 	MetricStorage string `toml:"metric-storage" json:"metric-storage"`
 	// There are some values supported: "auto", "none", or a specific address, default: "auto"
 	DashboardAddress string `toml:"dashboard-address" json:"dashboard-address"`

--- a/tests/dashboard/service_test.go
+++ b/tests/dashboard/service_test.go
@@ -86,7 +86,8 @@ func (suite *dashboardTestSuite) checkRespCode(url string, code int) {
 }
 
 func waitForConfigSync() {
-	time.Sleep(time.Second)
+	// Need to wait dashboard service start.
+	time.Sleep(3 * time.Second)
 }
 
 func (suite *dashboardTestSuite) checkServiceIsStarted(internalProxy bool, servers map[string]*tests.TestServer, leader *tests.TestServer) string {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #3182

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```
Add some logs to indicate the cause is dashboard has not been start quickly in ci machine
```
[2023/09/28 04:24:46.275 +00:00] [INFO] [manager.go:205] ["start dashboard server"] [svr-name=pd1]
[2023/09/28 04:24:47.7059358Z                 Error Trace:        /home/runner/work/pd/pd/tests/dashboard/service_test.go:89
														                Error:              Not equal: 
														                                     expected: 200
														                                     actual  : 307
														                 Test:               TestDashboardTestSuite/TestDashboardRedirect
[2023/09/28 04:24:47.832 +00:00] [INFO] [manager.go:213] ["dashboard server is started"] [svr-name=pd1]
```
Tested about 100 times after adding sleep time and no errors were found
https://github.com/HuSharp/pd/pull/1

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
