### PR TITLE
ctl: support new interface to acquire stores by state

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -226,6 +226,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(clusterRouter, "/stores/limit/scene", storesHandler.SetStoreLimitScene, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/stores/limit/scene", storesHandler.GetStoreLimitScene, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/stores/progress", storesHandler.GetStoresProgress, setMethods(http.MethodGet), setAuditBackend(prometheus))
+	registerFunc(clusterRouter, "/stores/check", storesHandler.GetStoresByState, setMethods(http.MethodGet), setAuditBackend(prometheus))
 
 	labelsHandler := newLabelsHandler(svr, rd)
 	registerFunc(clusterRouter, "/labels", labelsHandler.GetLabels, setMethods(http.MethodGet), setAuditBackend(prometheus))

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -143,7 +143,7 @@ func NewStoreLimitCommand() *cobra.Command {
 // NewStoreCheckCommand return a check subcommand of storeCmd
 func NewStoreCheckCommand() *cobra.Command {
 	d := &cobra.Command{
-		Use:   "check [up|offline|tombstone]",
+		Use:   "check [up|offline|tombstone|disconnected|down]",
 		Short: "Check all the stores with specified status",
 		Run:   storeCheckCommandFunc,
 	}
@@ -666,13 +666,7 @@ func storeCheckCommandFunc(cmd *cobra.Command, args []string) {
 
 	caser := cases.Title(language.Und)
 	state := caser.String(strings.ToLower(args[0]))
-	stateValue, ok := metapb.StoreState_value[state]
-	if !ok {
-		cmd.Println("Unknown state: " + state)
-		return
-	}
-
-	prefix := fmt.Sprintf("%s?state=%d", storesPrefix, stateValue)
+	prefix := fmt.Sprintf("%s/check?state=%s", storesPrefix, state)
 	r, err := doRequest(cmd, prefix, http.MethodGet, http.Header{})
 	if err != nil {
 		cmd.Printf("Failed to get store: %s\n", err)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7188

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```
- deprecated `/stores` interface instead of `/stores/check`
- instead `pd ctl store check` relying on `/stores` of `/stores/check`
- usage
```bash
$ ./pd-ctl store check up
{
  "count": 3,
  "stores": [
    {
      "store": {
        "id": 3,
	...

$ ./pd-ctl store check down
{
  "count": 0,
  "stores": []
}

$ ./pd-ctl store check hu
Failed to get store: [400] "unknown StoreState: hu"
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Code changes

- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
deprecated /stores interface instead of /check/stores
```
