### PR TITLE
checker: avoid unnecessary remove disconnected peer with multi orphan peers

### DIFF
--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -551,9 +551,6 @@ var (
 // tikv's store heartbeat for a short time, maybe caused by process restart or
 // temporary network failure.
 func (s *StoreInfo) IsDisconnected() bool {
-	if s == nil {
-		return true
-	}
 	return s.DownTime() > storeDisconnectDuration
 }
 

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -78,6 +78,7 @@ var (
 	ruleCheckerSkipRemoveOrphanPeerCounter        = checkerCounter.WithLabelValues(ruleChecker, "skip-remove-orphan-peer")
 	ruleCheckerRemoveOrphanPeerCounter            = checkerCounter.WithLabelValues(ruleChecker, "remove-orphan-peer")
 	ruleCheckerReplaceOrphanPeerCounter           = checkerCounter.WithLabelValues(ruleChecker, "replace-orphan-peer")
+	ruleCheckerReplaceOrphanPeerNoFitCounter      = checkerCounter.WithLabelValues(ruleChecker, "replace-orphan-peer-no-fit")
 )
 
 // RuleChecker fix/improve region by placement rules.
@@ -544,6 +545,8 @@ func (c *RuleChecker) fixOrphanPeers(region *core.RegionInfo, fit *placement.Reg
 					// destRole should not same with orphanPeerRole. if role is same, it fit with orphanPeer should be better than now.
 					// destRole never be leader, so we not consider it.
 				}
+			} else {
+				ruleCheckerReplaceOrphanPeerNoFitCounter.Inc()
 			}
 		}
 	}

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -465,7 +465,11 @@ func (c *RuleChecker) fixOrphanPeers(region *core.RegionInfo, fit *placement.Reg
 	isDisconnectedPeer := func(p *metapb.Peer) bool {
 		// avoid to meet down store when fix orphan peers,
 		// Isdisconnected is more strictly than IsUnhealthy.
-		return c.cluster.GetStore(p.GetStoreId()).IsDisconnected()
+		store := c.cluster.GetStore(p.GetStoreId())
+		if store == nil {
+			return true
+		}
+		return store.IsDisconnected()
 	}
 
 	checkDownPeer := func(peers []*metapb.Peer) (*metapb.Peer, bool) {

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -554,14 +554,15 @@ func (c *RuleChecker) fixOrphanPeers(region *core.RegionInfo, fit *placement.Reg
 		hasHealthPeer := false
 		var disconnectedPeer *metapb.Peer
 		for _, orphanPeer := range fit.OrphanPeers {
+			if isDisconnectedPeer(orphanPeer) {
+				disconnectedPeer = orphanPeer
+				break
+			}
+		}
+		for _, orphanPeer := range fit.OrphanPeers {
 			if isUnhealthyPeer(orphanPeer.GetId()) {
 				ruleCheckerRemoveOrphanPeerCounter.Inc()
 				return operator.CreateRemovePeerOperator("remove-unhealthy-orphan-peer", c.cluster, 0, region, orphanPeer.StoreId)
-			}
-			if isDisconnectedPeer(orphanPeer) {
-				// we need to be careful to remove peer, so we will not think disconnected peer is healthy.
-				disconnectedPeer = orphanPeer
-				continue
 			}
 			if hasHealthPeer {
 				// there already exists a healthy orphan peer, so we can remove other orphan Peers.

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -818,8 +818,8 @@ func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRule
 
 			r1 := suite.cluster.GetRegion(1)
 			for _, p := range r1.GetPeers() {
-				suite.NotEqual(p.GetStoreId(), uint64(testCase[0]))
-				suite.NotEqual(p.GetStoreId(), uint64(testCase[1]))
+				suite.NotEqual(p.GetStoreId(), testCase[0])
+				suite.NotEqual(p.GetStoreId(), testCase[1])
 			}
 			suite.TearDownTest()
 			suite.SetupTest()
@@ -941,9 +941,9 @@ func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRule
 
 				r1 = suite.cluster.GetRegion(1)
 				for _, p := range r1.GetPeers() {
-					suite.NotEqual(p.GetStoreId(), uint64(testCase[0]))
-					suite.NotEqual(p.GetStoreId(), uint64(testCase[1]))
-					suite.NotEqual(p.GetStoreId(), uint64(testCase[2]))
+					suite.NotEqual(p.GetStoreId(), testCase[0])
+					suite.NotEqual(p.GetStoreId(), testCase[1])
+					suite.NotEqual(p.GetStoreId(), testCase[2])
 				}
 				suite.TearDownTest()
 				suite.SetupTest()

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -225,7 +225,6 @@ func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers() {
 	suite.NotNil(op)
 	suite.Equal("remove-orphan-peer", op.Desc())
 	suite.Equal(uint64(5), op.Step(0).(operator.RemovePeer).FromStore)
-
 	// Case2:
 	// store 4, 5, 6 are orphan peers, and peer on store 3 is down peer. and peer on store 4, 5 are pending.
 	region = suite.cluster.GetRegion(1)
@@ -237,6 +236,20 @@ func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers() {
 	suite.NotNil(op)
 	suite.Equal("remove-unhealthy-orphan-peer", op.Desc())
 	suite.Equal(uint64(4), op.Step(0).(operator.RemovePeer).FromStore)
+	// Case3:
+	// store 4, 5, 6 are orphan peers, and peer on store 5 is disconnect peer
+	// we should remove disconnect peer first.
+	region = suite.cluster.GetRegion(1)
+	suite.cluster.SetStoreDisconnect(5)
+	region = region.Clone(
+		core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(3), DownSeconds: 60000}}),
+		core.WithPendingPeers([]*metapb.Peer{region.GetStorePeer(3)}))
+	fmt.Println(len(region.GetPeers()))
+	suite.cluster.PutRegion(region)
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.NotNil(op)
+	suite.Equal("remove-orphan-peer", op.Desc())
+	suite.Equal(uint64(5), op.Step(0).(operator.RemovePeer).FromStore)
 }
 
 func (suite *ruleCheckerTestSuite) TestFixOrphanPeers2() {
@@ -725,173 +738,217 @@ func (suite *ruleCheckerTestSuite) TestPriorityFixOrphanPeer() {
 
 // Ref https://github.com/tikv/pd/issues/7249 https://github.com/tikv/tikv/issues/15799
 func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChanged() {
-	// init cluster with 5 replicas
-	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
-	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
-	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
-	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
-	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
-	storeIDs := []uint64{1, 2, 3, 4, 5}
-	suite.cluster.AddLeaderRegionWithRange(1, "", "", storeIDs[0], storeIDs[1:]...)
-	rule := &placement.Rule{
-		GroupID:  "pd",
-		ID:       "default",
-		Role:     placement.Voter,
-		Count:    5,
-		StartKey: []byte{},
-		EndKey:   []byte{},
+	// disconnect any two stores and change rule to 3 replicas
+	stores := []uint64{1, 2, 3, 4, 5}
+	testCases := [][]uint64{}
+	for i := 0; i < len(stores); i++ {
+		for j := i + 1; j < len(stores); j++ {
+			testCases = append(testCases, []uint64{stores[i], stores[j]})
+		}
 	}
-	suite.ruleManager.SetRule(rule)
-	op := suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.Nil(op)
+	for _, leader := range stores {
+		var followers []uint64
+		for i := 0; i < len(stores); i++ {
+			if stores[i] != leader {
+				followers = append(followers, stores[i])
+			}
+		}
 
-	// set store 1, 2 to disconnected
-	suite.cluster.SetStoreDisconnect(1)
-	suite.cluster.SetStoreDisconnect(2)
+		for _, testCase := range testCases {
+			// init cluster with 5 replicas
+			suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+			suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+			suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+			suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
+			suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+			suite.cluster.AddLeaderRegionWithRange(1, "", "", leader, followers...)
+			rule := &placement.Rule{
+				GroupID:  "pd",
+				ID:       "default",
+				Role:     placement.Voter,
+				Count:    5,
+				StartKey: []byte{},
+				EndKey:   []byte{},
+			}
+			err := suite.ruleManager.SetRule(rule)
+			suite.NoError(err)
+			op := suite.rc.Check(suite.cluster.GetRegion(1))
+			suite.Nil(op)
 
-	// change rule to 3 replicas
-	rule = &placement.Rule{
-		GroupID:  "pd",
-		ID:       "default",
-		Role:     placement.Voter,
-		Count:    3,
-		StartKey: []byte{},
-		EndKey:   []byte{},
-		Override: true,
-	}
-	suite.ruleManager.SetRule(rule)
+			// set two stores to disconnected
+			suite.cluster.SetStoreDisconnect(testCase[0])
+			suite.cluster.SetStoreDisconnect(testCase[1])
 
-	// remove store 1 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 2)
-	newLeaderID := op.Step(0).(operator.TransferLeader).ToStore
-	removedPeerID := op.Step(1).(operator.RemovePeer).FromStore
-	r1 := suite.cluster.GetRegion(1)
-	r1 = r1.Clone(
-		core.WithLeader(r1.GetPeer(newLeaderID)),
-		core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 4)
+			// change rule to 3 replicas
+			rule = &placement.Rule{
+				GroupID:  "pd",
+				ID:       "default",
+				Role:     placement.Voter,
+				Count:    3,
+				StartKey: []byte{},
+				EndKey:   []byte{},
+				Override: true,
+			}
+			suite.ruleManager.SetRule(rule)
 
-	// remove store 2 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 1)
-	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
-	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 3)
-	for _, p := range r1.GetPeers() {
-		suite.NotEqual(p.GetStoreId(), 1)
-		suite.NotEqual(p.GetStoreId(), 2)
+			// remove peer from region 1
+			for j := 1; j <= 2; j++ {
+				r1 := suite.cluster.GetRegion(1)
+				op = suite.rc.Check(suite.cluster.GetRegion(1))
+				suite.NotNil(op)
+				suite.Contains(op.Desc(), "orphan")
+				var removedPeerStoreID uint64
+				newLeaderStoreID := r1.GetLeader().GetStoreId()
+				for i := 0; i < op.Len(); i++ {
+					if s, ok := op.Step(i).(operator.RemovePeer); ok {
+						removedPeerStoreID = s.FromStore
+					}
+					if s, ok := op.Step(i).(operator.TransferLeader); ok {
+						newLeaderStoreID = s.ToStore
+					}
+				}
+				suite.NotZero(removedPeerStoreID)
+				r1 = r1.Clone(
+					core.WithLeader(r1.GetStorePeer(newLeaderStoreID)),
+					core.WithRemoveStorePeer(removedPeerStoreID))
+				suite.cluster.PutRegion(r1)
+				r1 = suite.cluster.GetRegion(1)
+				suite.Len(r1.GetPeers(), 5-j)
+			}
+
+			r1 := suite.cluster.GetRegion(1)
+			for _, p := range r1.GetPeers() {
+				suite.NotEqual(p.GetStoreId(), uint64(testCase[0]))
+				suite.NotEqual(p.GetStoreId(), uint64(testCase[1]))
+			}
+			suite.TearDownTest()
+			suite.SetupTest()
+		}
 	}
 }
 
 // Ref https://github.com/tikv/pd/issues/7249 https://github.com/tikv/tikv/issues/15799
-func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChanged2() {
-	// init cluster with 5 voters and 1 learner
-	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
-	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
-	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
-	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
-	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
-	suite.cluster.AddLabelsStore(6, 1, map[string]string{"host": "host6"})
-	storeIDs := []uint64{1, 2, 3, 4, 5}
-	suite.cluster.AddLeaderRegionWithRange(1, "", "", storeIDs[0], storeIDs[1:]...)
-	r1 := suite.cluster.GetRegion(1)
-	r1 = r1.Clone(core.WithAddPeer(&metapb.Peer{Id: 6, StoreId: 6, Role: metapb.PeerRole_Learner}))
-	suite.cluster.PutRegion(r1)
-	err := suite.ruleManager.SetRules([]*placement.Rule{
-		{
-			GroupID:   "pd",
-			ID:        "default",
-			Index:     100,
-			Override:  true,
-			Role:      placement.Voter,
-			Count:     5,
-			IsWitness: false,
-		},
-		{
-			GroupID:   "pd",
-			ID:        "r1",
-			Index:     100,
-			Override:  false,
-			Role:      placement.Learner,
-			Count:     1,
-			IsWitness: false,
-		},
-	})
-	suite.NoError(err)
-
-	op := suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.Nil(op)
-
-	// set store 1, 2 to disconnected
-	suite.cluster.SetStoreDisconnect(1)
-	suite.cluster.SetStoreDisconnect(2)
-	suite.cluster.SetStoreDisconnect(3)
-
-	// change rule to 3 replicas
-	suite.ruleManager.DeleteRuleGroup("pd")
-	suite.ruleManager.SetRule(&placement.Rule{
-		GroupID:  "pd",
-		ID:       "default",
-		Role:     placement.Voter,
-		Count:    2,
-		StartKey: []byte{},
-		EndKey:   []byte{},
-		Override: true,
-	})
-
-	// remove store 1 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 2)
-	newLeaderID := op.Step(0).(operator.TransferLeader).ToStore
-	removedPeerID := op.Step(1).(operator.RemovePeer).FromStore
-	r1 = suite.cluster.GetRegion(1)
-	r1 = r1.Clone(
-		core.WithLeader(r1.GetPeer(newLeaderID)),
-		core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 5)
-
-	// remove store 2 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 1)
-	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
-	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 4)
-	for _, p := range r1.GetPeers() {
-		fmt.Println(p.GetStoreId(), p.Role.String())
+func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChangedWithLearner() {
+	// disconnect any three stores and change rule to 3 replicas
+	// and there is a learner in the disconnected store.
+	stores := []uint64{1, 2, 3, 4, 5, 6}
+	testCases := [][]uint64{}
+	for i := 0; i < len(stores); i++ {
+		for j := i + 1; j < len(stores); j++ {
+			for k := j + 1; k < len(stores); k++ {
+				testCases = append(testCases, []uint64{stores[i], stores[j], stores[k]})
+			}
+		}
 	}
+	for _, leader := range stores {
+		var followers []uint64
+		for i := 0; i < len(stores); i++ {
+			if stores[i] != leader {
+				followers = append(followers, stores[i])
+			}
+		}
 
-	// remove store 3 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 1)
-	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
-	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 3)
+		for _, testCase := range testCases {
+			for _, learnerStore := range testCase {
+				if learnerStore == leader {
+					continue
+				}
+				voterFollowers := []uint64{}
+				for _, follower := range followers {
+					if follower != learnerStore {
+						voterFollowers = append(voterFollowers, follower)
+					}
+				}
+				// init cluster with 5 voters and 1 learner
+				suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+				suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+				suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+				suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
+				suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+				suite.cluster.AddLabelsStore(6, 1, map[string]string{"host": "host6"})
+				suite.cluster.AddLeaderRegionWithRange(1, "", "", leader, voterFollowers...)
+				err := suite.ruleManager.SetRules([]*placement.Rule{
+					{
+						GroupID:   "pd",
+						ID:        "default",
+						Index:     100,
+						Override:  true,
+						Role:      placement.Voter,
+						Count:     5,
+						IsWitness: false,
+					},
+					{
+						GroupID:   "pd",
+						ID:        "r1",
+						Index:     100,
+						Override:  false,
+						Role:      placement.Learner,
+						Count:     1,
+						IsWitness: false,
+						LabelConstraints: []placement.LabelConstraint{
+							{Key: "host", Op: "in", Values: []string{"host" + strconv.FormatUint(learnerStore, 10)}},
+						},
+					},
+				})
+				suite.NoError(err)
+				r1 := suite.cluster.GetRegion(1)
+				r1 = r1.Clone(core.WithAddPeer(&metapb.Peer{Id: 12, StoreId: learnerStore, Role: metapb.PeerRole_Learner}))
+				suite.cluster.PutRegion(r1)
+				op := suite.rc.Check(suite.cluster.GetRegion(1))
+				suite.Nil(op)
 
-	for _, p := range r1.GetPeers() {
-		suite.NotEqual(p.GetStoreId(), 1)
-		suite.NotEqual(p.GetStoreId(), 2)
-		suite.NotEqual(p.GetStoreId(), 3)
+				// set three stores to disconnected
+				suite.cluster.SetStoreDisconnect(testCase[0])
+				suite.cluster.SetStoreDisconnect(testCase[1])
+				suite.cluster.SetStoreDisconnect(testCase[2])
+
+				// change rule to 3 replicas
+				suite.ruleManager.DeleteRule("pd", "r1")
+				suite.ruleManager.SetRule(&placement.Rule{
+					GroupID:  "pd",
+					ID:       "default",
+					Role:     placement.Voter,
+					Count:    3,
+					StartKey: []byte{},
+					EndKey:   []byte{},
+					Override: true,
+				})
+
+				// remove peer from region 1
+				for j := 1; j <= 3; j++ {
+					r1 := suite.cluster.GetRegion(1)
+					op = suite.rc.Check(suite.cluster.GetRegion(1))
+					suite.NotNil(op)
+					suite.Contains(op.Desc(), "orphan")
+					var removedPeerStroeID uint64
+					newLeaderStoreID := r1.GetLeader().GetStoreId()
+					for i := 0; i < op.Len(); i++ {
+						if s, ok := op.Step(i).(operator.RemovePeer); ok {
+							removedPeerStroeID = s.FromStore
+						}
+						if s, ok := op.Step(i).(operator.TransferLeader); ok {
+							newLeaderStoreID = s.ToStore
+						}
+					}
+					suite.NotZero(removedPeerStroeID)
+					r1 = r1.Clone(
+						core.WithLeader(r1.GetStorePeer(newLeaderStoreID)),
+						core.WithRemoveStorePeer(removedPeerStroeID))
+					suite.cluster.PutRegion(r1)
+					r1 = suite.cluster.GetRegion(1)
+					suite.Len(r1.GetPeers(), 6-j)
+				}
+
+				r1 = suite.cluster.GetRegion(1)
+				for _, p := range r1.GetPeers() {
+					suite.NotEqual(p.GetStoreId(), uint64(testCase[0]))
+					suite.NotEqual(p.GetStoreId(), uint64(testCase[1]))
+					suite.NotEqual(p.GetStoreId(), uint64(testCase[2]))
+				}
+				suite.TearDownTest()
+				suite.SetupTest()
+			}
+		}
 	}
 }
 

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -269,7 +269,17 @@ func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers() {
 		op = suite.rc.Check(suite.cluster.GetRegion(1))
 		suite.NotNil(op)
 		suite.Equal("remove-orphan-peer", op.Desc())
-		suite.NotEqual(i, op.Step(0).(operator.RemovePeer).FromStore)
+		removedPeerStoreID := op.Step(0).(operator.RemovePeer).FromStore
+		suite.NotEqual(i, removedPeerStoreID)
+		region = suite.cluster.GetRegion(1)
+		newRegion := region.Clone(core.WithRemoveStorePeer(removedPeerStoreID))
+		suite.cluster.PutRegion(newRegion)
+		op = suite.rc.Check(suite.cluster.GetRegion(1))
+		suite.NotNil(op)
+		suite.Equal("remove-orphan-peer", op.Desc())
+		removedPeerStoreID = op.Step(0).(operator.RemovePeer).FromStore
+		suite.NotEqual(i, removedPeerStoreID)
+		suite.cluster.PutRegion(region)
 	}
 }
 

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -17,6 +17,7 @@ package checker
 import (
 	"context"
 	"fmt"
+
 	"strconv"
 	"strings"
 	"testing"
@@ -244,7 +245,6 @@ func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers() {
 	region = region.Clone(
 		core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(3), DownSeconds: 60000}}),
 		core.WithPendingPeers([]*metapb.Peer{region.GetStorePeer(3)}))
-	fmt.Println(len(region.GetPeers()))
 	suite.cluster.PutRegion(region)
 	op = suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.NotNil(op)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7249

When there are many orphan peers, we don't think disconnected peer are healthy
And when we decide to remove peer, we will pick disconnected peer firstly.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
![image](https://github.com/tikv/pd/assets/19542290/e29cb816-8cb3-4594-b599-ed663fdc470e)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
