### PR TITLE
checker: reduces the probability of deleting normal peers when the store becomes unavailable (#7249)

### DIFF
--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -551,6 +551,9 @@ var (
 // tikv's store heartbeat for a short time, maybe caused by process restart or
 // temporary network failure.
 func (s *StoreInfo) IsDisconnected() bool {
+	if s == nil {
+		return true
+	}
 	return s.DownTime() > storeDisconnectDuration
 }
 

--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -551,9 +551,6 @@ var (
 // tikv's store heartbeat for a short time, maybe caused by process restart or
 // temporary network failure.
 func (s *StoreInfo) IsDisconnected() bool {
-	if s == nil {
-		return true
-	}
 	return s.DownTime() > storeDisconnectDuration
 }
 

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -479,6 +479,13 @@ loopFits:
 				hasUnhealthyFit = true
 				break loopFits
 			}
+			// avoid to meet down store when fix orpahn peers,
+			// Isdisconnected is more strictly than IsUnhealthy.
+			if c.cluster.GetStore(p.GetStoreId()).IsDisconnected() {
+				hasUnhealthyFit = true
+				pinDownPeer = p
+				break loopFits
+			}
 		}
 	}
 
@@ -491,6 +498,9 @@ loopFits:
 	// try to use orphan peers to replace unhealthy down peers.
 	for _, orphanPeer := range fit.OrphanPeers {
 		if pinDownPeer != nil {
+			if pinDownPeer.GetId() == orphanPeer.GetId() {
+				continue
+			}
 			// make sure the orphan peer is healthy.
 			if isUnhealthyPeer(orphanPeer.GetId()) {
 				continue
@@ -514,6 +524,9 @@ loopFits:
 					return operator.CreatePromoteLearnerOperatorAndRemovePeer("replace-down-peer-with-orphan-peer", c.cluster, region, orphanPeer, pinDownPeer)
 				case orphanPeerRole == metapb.PeerRole_Voter && destRole == metapb.PeerRole_Learner:
 					return operator.CreateDemoteLearnerOperatorAndRemovePeer("replace-down-peer-with-orphan-peer", c.cluster, region, orphanPeer, pinDownPeer)
+				case orphanPeerRole == metapb.PeerRole_Voter && destRole == metapb.PeerRole_Voter &&
+					c.cluster.GetStore(pinDownPeer.GetStoreId()).IsDisconnected() && !dstStore.IsDisconnected():
+					return operator.CreateRemovePeerOperator("remove-replaced-orphan-peer", c.cluster, 0, region, pinDownPeer.GetStoreId())
 				default:
 					// destRole should not same with orphanPeerRole. if role is same, it fit with orphanPeer should be better than now.
 					// destRole never be leader, so we not consider it.

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -78,6 +78,7 @@ var (
 	ruleCheckerSkipRemoveOrphanPeerCounter        = checkerCounter.WithLabelValues(ruleChecker, "skip-remove-orphan-peer")
 	ruleCheckerRemoveOrphanPeerCounter            = checkerCounter.WithLabelValues(ruleChecker, "remove-orphan-peer")
 	ruleCheckerReplaceOrphanPeerCounter           = checkerCounter.WithLabelValues(ruleChecker, "replace-orphan-peer")
+	ruleCheckerReplaceOrphanPeerNoFitCounter      = checkerCounter.WithLabelValues(ruleChecker, "replace-orphan-peer-no-fit")
 )
 
 // RuleChecker fix/improve region by placement rules.
@@ -465,7 +466,11 @@ func (c *RuleChecker) fixOrphanPeers(region *core.RegionInfo, fit *placement.Reg
 	isDisconnectedPeer := func(p *metapb.Peer) bool {
 		// avoid to meet down store when fix orphan peers,
 		// Isdisconnected is more strictly than IsUnhealthy.
-		return c.cluster.GetStore(p.GetStoreId()).IsDisconnected()
+		store := c.cluster.GetStore(p.GetStoreId())
+		if store == nil {
+			return true
+		}
+		return store.IsDisconnected()
 	}
 
 	checkDownPeer := func(peers []*metapb.Peer) (*metapb.Peer, bool) {
@@ -519,7 +524,7 @@ func (c *RuleChecker) fixOrphanPeers(region *core.RegionInfo, fit *placement.Reg
 			if pinDownPeer.GetIsWitness() || orphanPeer.GetIsWitness() {
 				continue
 			}
-			// down peer's store should be disconnected
+			// pinDownPeer's store should be disconnected, because we use more strict judge before.
 			if !isDisconnectedPeer(pinDownPeer) {
 				continue
 			}
@@ -534,13 +539,14 @@ func (c *RuleChecker) fixOrphanPeers(region *core.RegionInfo, fit *placement.Reg
 					return operator.CreatePromoteLearnerOperatorAndRemovePeer("replace-down-peer-with-orphan-peer", c.cluster, region, orphanPeer, pinDownPeer)
 				case orphanPeerRole == metapb.PeerRole_Voter && destRole == metapb.PeerRole_Learner:
 					return operator.CreateDemoteLearnerOperatorAndRemovePeer("replace-down-peer-with-orphan-peer", c.cluster, region, orphanPeer, pinDownPeer)
-				case orphanPeerRole == metapb.PeerRole_Voter && destRole == metapb.PeerRole_Voter &&
-					isDisconnectedPeer(pinDownPeer) && !dstStore.IsDisconnected():
+				case orphanPeerRole == destRole && isDisconnectedPeer(pinDownPeer) && !dstStore.IsDisconnected():
 					return operator.CreateRemovePeerOperator("remove-replaced-orphan-peer", c.cluster, 0, region, pinDownPeer.GetStoreId())
 				default:
 					// destRole should not same with orphanPeerRole. if role is same, it fit with orphanPeer should be better than now.
 					// destRole never be leader, so we not consider it.
 				}
+			} else {
+				ruleCheckerReplaceOrphanPeerNoFitCounter.Inc()
 			}
 		}
 	}
@@ -549,18 +555,25 @@ func (c *RuleChecker) fixOrphanPeers(region *core.RegionInfo, fit *placement.Reg
 	// Ref https://github.com/tikv/pd/issues/4045
 	if len(fit.OrphanPeers) >= 2 {
 		hasHealthPeer := false
+		var disconnectedPeer *metapb.Peer
+		for _, orphanPeer := range fit.OrphanPeers {
+			if isDisconnectedPeer(orphanPeer) {
+				disconnectedPeer = orphanPeer
+				break
+			}
+		}
 		for _, orphanPeer := range fit.OrphanPeers {
 			if isUnhealthyPeer(orphanPeer.GetId()) {
 				ruleCheckerRemoveOrphanPeerCounter.Inc()
 				return operator.CreateRemovePeerOperator("remove-unhealthy-orphan-peer", c.cluster, 0, region, orphanPeer.StoreId)
 			}
-			if isDisconnectedPeer(orphanPeer) {
-				ruleCheckerRemoveOrphanPeerCounter.Inc()
-				return operator.CreateRemovePeerOperator("remove-disconnected-orphan-peer", c.cluster, 0, region, orphanPeer.StoreId)
-			}
 			if hasHealthPeer {
 				// there already exists a healthy orphan peer, so we can remove other orphan Peers.
 				ruleCheckerRemoveOrphanPeerCounter.Inc()
+				// if there exists a disconnected orphan peer, we will pick it to remove firstly.
+				if disconnectedPeer != nil {
+					return operator.CreateRemovePeerOperator("remove-orphan-peer", c.cluster, 0, region, disconnectedPeer.StoreId)
+				}
 				return operator.CreateRemovePeerOperator("remove-orphan-peer", c.cluster, 0, region, orphanPeer.StoreId)
 			}
 			hasHealthPeer = true

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -17,6 +17,7 @@ package checker
 import (
 	"context"
 	"fmt"
+
 	"strconv"
 	"strings"
 	"testing"
@@ -225,7 +226,6 @@ func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers() {
 	suite.NotNil(op)
 	suite.Equal("remove-orphan-peer", op.Desc())
 	suite.Equal(uint64(5), op.Step(0).(operator.RemovePeer).FromStore)
-
 	// Case2:
 	// store 4, 5, 6 are orphan peers, and peer on store 3 is down peer. and peer on store 4, 5 are pending.
 	region = suite.cluster.GetRegion(1)
@@ -236,6 +236,91 @@ func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers() {
 	op = suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.NotNil(op)
 	suite.Equal("remove-unhealthy-orphan-peer", op.Desc())
+	suite.Equal(uint64(4), op.Step(0).(operator.RemovePeer).FromStore)
+	// Case3:
+	// store 4, 5, 6 are orphan peers, and peer on one of stores is disconnect peer
+	// we should remove disconnect peer first.
+	for i := uint64(4); i <= 6; i++ {
+		region = suite.cluster.GetRegion(1)
+		suite.cluster.SetStoreDisconnect(i)
+		region = region.Clone(
+			core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(3), DownSeconds: 60000}}),
+			core.WithPendingPeers([]*metapb.Peer{region.GetStorePeer(3)}))
+		suite.cluster.PutRegion(region)
+		op = suite.rc.Check(suite.cluster.GetRegion(1))
+		suite.NotNil(op)
+		suite.Equal("remove-orphan-peer", op.Desc())
+		suite.Equal(i, op.Step(0).(operator.RemovePeer).FromStore)
+		suite.cluster.SetStoreUp(i)
+	}
+	// Case4:
+	// store 4, 5, 6 are orphan peers, and peer on two of stores is disconnect peer
+	// we should remove disconnect peer first.
+	for i := uint64(4); i <= 6; i++ {
+		region = suite.cluster.GetRegion(1)
+		suite.cluster.SetStoreDisconnect(4)
+		suite.cluster.SetStoreDisconnect(5)
+		suite.cluster.SetStoreDisconnect(6)
+		suite.cluster.SetStoreUp(i)
+		region = region.Clone(
+			core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(3), DownSeconds: 60000}}),
+			core.WithPendingPeers([]*metapb.Peer{region.GetStorePeer(3)}))
+		suite.cluster.PutRegion(region)
+		op = suite.rc.Check(suite.cluster.GetRegion(1))
+		suite.NotNil(op)
+		suite.Equal("remove-orphan-peer", op.Desc())
+		removedPeerStoreID := op.Step(0).(operator.RemovePeer).FromStore
+		suite.NotEqual(i, removedPeerStoreID)
+		region = suite.cluster.GetRegion(1)
+		newRegion := region.Clone(core.WithRemoveStorePeer(removedPeerStoreID))
+		suite.cluster.PutRegion(newRegion)
+		op = suite.rc.Check(suite.cluster.GetRegion(1))
+		suite.NotNil(op)
+		suite.Equal("remove-orphan-peer", op.Desc())
+		removedPeerStoreID = op.Step(0).(operator.RemovePeer).FromStore
+		suite.NotEqual(i, removedPeerStoreID)
+		suite.cluster.PutRegion(region)
+	}
+}
+
+func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers2() {
+	suite.cluster.AddLeaderStore(1, 1)
+	suite.cluster.AddLeaderStore(2, 1)
+	suite.cluster.AddLeaderStore(3, 1)
+	suite.cluster.AddLeaderStore(4, 1)
+	suite.cluster.AddLeaderStore(5, 1)
+	suite.cluster.AddRegionWithLearner(1, 1, []uint64{2, 3}, []uint64{4, 5})
+
+	// Case1:
+	// store 4, 5 are orphan peers, and peer on one of stores is disconnect peer
+	// we should remove disconnect peer first.
+	for i := uint64(4); i <= 5; i++ {
+		region := suite.cluster.GetRegion(1)
+		suite.cluster.SetStoreDisconnect(i)
+		region = region.Clone(
+			core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(3), DownSeconds: 60000}}),
+			core.WithPendingPeers([]*metapb.Peer{region.GetStorePeer(3)}))
+		suite.cluster.PutRegion(region)
+		op := suite.rc.Check(suite.cluster.GetRegion(1))
+		suite.NotNil(op)
+		suite.Equal("remove-orphan-peer", op.Desc())
+		suite.Equal(i, op.Step(0).(operator.RemovePeer).FromStore)
+		suite.cluster.SetStoreUp(i)
+	}
+
+	// Case2:
+	// store 4, 5 are orphan peers, and they are disconnect peers
+	// we should remove the peer on disconnect stores at least.
+	region := suite.cluster.GetRegion(1)
+	suite.cluster.SetStoreDisconnect(4)
+	suite.cluster.SetStoreDisconnect(5)
+	region = region.Clone(
+		core.WithDownPeers([]*pdpb.PeerStats{{Peer: region.GetStorePeer(3), DownSeconds: 60000}}),
+		core.WithPendingPeers([]*metapb.Peer{region.GetStorePeer(3)}))
+	suite.cluster.PutRegion(region)
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.NotNil(op)
+	suite.Equal("remove-orphan-peer", op.Desc())
 	suite.Equal(uint64(4), op.Step(0).(operator.RemovePeer).FromStore)
 }
 
@@ -725,173 +810,217 @@ func (suite *ruleCheckerTestSuite) TestPriorityFixOrphanPeer() {
 
 // Ref https://github.com/tikv/pd/issues/7249 https://github.com/tikv/tikv/issues/15799
 func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChanged() {
-	// init cluster with 5 replicas
-	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
-	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
-	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
-	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
-	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
-	storeIDs := []uint64{1, 2, 3, 4, 5}
-	suite.cluster.AddLeaderRegionWithRange(1, "", "", storeIDs[0], storeIDs[1:]...)
-	rule := &placement.Rule{
-		GroupID:  "pd",
-		ID:       "default",
-		Role:     placement.Voter,
-		Count:    5,
-		StartKey: []byte{},
-		EndKey:   []byte{},
+	// disconnect any two stores and change rule to 3 replicas
+	stores := []uint64{1, 2, 3, 4, 5}
+	testCases := [][]uint64{}
+	for i := 0; i < len(stores); i++ {
+		for j := i + 1; j < len(stores); j++ {
+			testCases = append(testCases, []uint64{stores[i], stores[j]})
+		}
 	}
-	suite.ruleManager.SetRule(rule)
-	op := suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.Nil(op)
+	for _, leader := range stores {
+		var followers []uint64
+		for i := 0; i < len(stores); i++ {
+			if stores[i] != leader {
+				followers = append(followers, stores[i])
+			}
+		}
 
-	// set store 1, 2 to disconnected
-	suite.cluster.SetStoreDisconnect(1)
-	suite.cluster.SetStoreDisconnect(2)
+		for _, testCase := range testCases {
+			// init cluster with 5 replicas
+			suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+			suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+			suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+			suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
+			suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+			suite.cluster.AddLeaderRegionWithRange(1, "", "", leader, followers...)
+			rule := &placement.Rule{
+				GroupID:  "pd",
+				ID:       "default",
+				Role:     placement.Voter,
+				Count:    5,
+				StartKey: []byte{},
+				EndKey:   []byte{},
+			}
+			err := suite.ruleManager.SetRule(rule)
+			suite.NoError(err)
+			op := suite.rc.Check(suite.cluster.GetRegion(1))
+			suite.Nil(op)
 
-	// change rule to 3 replicas
-	rule = &placement.Rule{
-		GroupID:  "pd",
-		ID:       "default",
-		Role:     placement.Voter,
-		Count:    3,
-		StartKey: []byte{},
-		EndKey:   []byte{},
-		Override: true,
-	}
-	suite.ruleManager.SetRule(rule)
+			// set two stores to disconnected
+			suite.cluster.SetStoreDisconnect(testCase[0])
+			suite.cluster.SetStoreDisconnect(testCase[1])
 
-	// remove store 1 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 2)
-	newLeaderID := op.Step(0).(operator.TransferLeader).ToStore
-	removedPeerID := op.Step(1).(operator.RemovePeer).FromStore
-	r1 := suite.cluster.GetRegion(1)
-	r1 = r1.Clone(
-		core.WithLeader(r1.GetPeer(newLeaderID)),
-		core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 4)
+			// change rule to 3 replicas
+			rule = &placement.Rule{
+				GroupID:  "pd",
+				ID:       "default",
+				Role:     placement.Voter,
+				Count:    3,
+				StartKey: []byte{},
+				EndKey:   []byte{},
+				Override: true,
+			}
+			suite.ruleManager.SetRule(rule)
 
-	// remove store 2 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 1)
-	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
-	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 3)
-	for _, p := range r1.GetPeers() {
-		suite.NotEqual(p.GetStoreId(), 1)
-		suite.NotEqual(p.GetStoreId(), 2)
+			// remove peer from region 1
+			for j := 1; j <= 2; j++ {
+				r1 := suite.cluster.GetRegion(1)
+				op = suite.rc.Check(suite.cluster.GetRegion(1))
+				suite.NotNil(op)
+				suite.Contains(op.Desc(), "orphan")
+				var removedPeerStoreID uint64
+				newLeaderStoreID := r1.GetLeader().GetStoreId()
+				for i := 0; i < op.Len(); i++ {
+					if s, ok := op.Step(i).(operator.RemovePeer); ok {
+						removedPeerStoreID = s.FromStore
+					}
+					if s, ok := op.Step(i).(operator.TransferLeader); ok {
+						newLeaderStoreID = s.ToStore
+					}
+				}
+				suite.NotZero(removedPeerStoreID)
+				r1 = r1.Clone(
+					core.WithLeader(r1.GetStorePeer(newLeaderStoreID)),
+					core.WithRemoveStorePeer(removedPeerStoreID))
+				suite.cluster.PutRegion(r1)
+				r1 = suite.cluster.GetRegion(1)
+				suite.Len(r1.GetPeers(), 5-j)
+			}
+
+			r1 := suite.cluster.GetRegion(1)
+			for _, p := range r1.GetPeers() {
+				suite.NotEqual(p.GetStoreId(), testCase[0])
+				suite.NotEqual(p.GetStoreId(), testCase[1])
+			}
+			suite.TearDownTest()
+			suite.SetupTest()
+		}
 	}
 }
 
 // Ref https://github.com/tikv/pd/issues/7249 https://github.com/tikv/tikv/issues/15799
-func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChanged2() {
-	// init cluster with 5 voters and 1 learner
-	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
-	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
-	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
-	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
-	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
-	suite.cluster.AddLabelsStore(6, 1, map[string]string{"host": "host6"})
-	storeIDs := []uint64{1, 2, 3, 4, 5}
-	suite.cluster.AddLeaderRegionWithRange(1, "", "", storeIDs[0], storeIDs[1:]...)
-	r1 := suite.cluster.GetRegion(1)
-	r1 = r1.Clone(core.WithAddPeer(&metapb.Peer{Id: 6, StoreId: 6, Role: metapb.PeerRole_Learner}))
-	suite.cluster.PutRegion(r1)
-	err := suite.ruleManager.SetRules([]*placement.Rule{
-		{
-			GroupID:   "pd",
-			ID:        "default",
-			Index:     100,
-			Override:  true,
-			Role:      placement.Voter,
-			Count:     5,
-			IsWitness: false,
-		},
-		{
-			GroupID:   "pd",
-			ID:        "r1",
-			Index:     100,
-			Override:  false,
-			Role:      placement.Learner,
-			Count:     1,
-			IsWitness: false,
-		},
-	})
-	suite.NoError(err)
-
-	op := suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.Nil(op)
-
-	// set store 1, 2 to disconnected
-	suite.cluster.SetStoreDisconnect(1)
-	suite.cluster.SetStoreDisconnect(2)
-	suite.cluster.SetStoreDisconnect(3)
-
-	// change rule to 3 replicas
-	suite.ruleManager.DeleteRuleGroup("pd")
-	suite.ruleManager.SetRule(&placement.Rule{
-		GroupID:  "pd",
-		ID:       "default",
-		Role:     placement.Voter,
-		Count:    2,
-		StartKey: []byte{},
-		EndKey:   []byte{},
-		Override: true,
-	})
-
-	// remove store 1 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 2)
-	newLeaderID := op.Step(0).(operator.TransferLeader).ToStore
-	removedPeerID := op.Step(1).(operator.RemovePeer).FromStore
-	r1 = suite.cluster.GetRegion(1)
-	r1 = r1.Clone(
-		core.WithLeader(r1.GetPeer(newLeaderID)),
-		core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 5)
-
-	// remove store 2 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 1)
-	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
-	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 4)
-	for _, p := range r1.GetPeers() {
-		fmt.Println(p.GetStoreId(), p.Role.String())
+func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChangedWithLearner() {
+	// disconnect any three stores and change rule to 3 replicas
+	// and there is a learner in the disconnected store.
+	stores := []uint64{1, 2, 3, 4, 5, 6}
+	testCases := [][]uint64{}
+	for i := 0; i < len(stores); i++ {
+		for j := i + 1; j < len(stores); j++ {
+			for k := j + 1; k < len(stores); k++ {
+				testCases = append(testCases, []uint64{stores[i], stores[j], stores[k]})
+			}
+		}
 	}
+	for _, leader := range stores {
+		var followers []uint64
+		for i := 0; i < len(stores); i++ {
+			if stores[i] != leader {
+				followers = append(followers, stores[i])
+			}
+		}
 
-	// remove store 3 from region 1
-	op = suite.rc.Check(suite.cluster.GetRegion(1))
-	suite.NotNil(op)
-	suite.Equal("remove-replaced-orphan-peer", op.Desc())
-	suite.Equal(op.Len(), 1)
-	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
-	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
-	suite.cluster.PutRegion(r1)
-	r1 = suite.cluster.GetRegion(1)
-	suite.Len(r1.GetPeers(), 3)
+		for _, testCase := range testCases {
+			for _, learnerStore := range testCase {
+				if learnerStore == leader {
+					continue
+				}
+				voterFollowers := []uint64{}
+				for _, follower := range followers {
+					if follower != learnerStore {
+						voterFollowers = append(voterFollowers, follower)
+					}
+				}
+				// init cluster with 5 voters and 1 learner
+				suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+				suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+				suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+				suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
+				suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+				suite.cluster.AddLabelsStore(6, 1, map[string]string{"host": "host6"})
+				suite.cluster.AddLeaderRegionWithRange(1, "", "", leader, voterFollowers...)
+				err := suite.ruleManager.SetRules([]*placement.Rule{
+					{
+						GroupID:   "pd",
+						ID:        "default",
+						Index:     100,
+						Override:  true,
+						Role:      placement.Voter,
+						Count:     5,
+						IsWitness: false,
+					},
+					{
+						GroupID:   "pd",
+						ID:        "r1",
+						Index:     100,
+						Override:  false,
+						Role:      placement.Learner,
+						Count:     1,
+						IsWitness: false,
+						LabelConstraints: []placement.LabelConstraint{
+							{Key: "host", Op: "in", Values: []string{"host" + strconv.FormatUint(learnerStore, 10)}},
+						},
+					},
+				})
+				suite.NoError(err)
+				r1 := suite.cluster.GetRegion(1)
+				r1 = r1.Clone(core.WithAddPeer(&metapb.Peer{Id: 12, StoreId: learnerStore, Role: metapb.PeerRole_Learner}))
+				suite.cluster.PutRegion(r1)
+				op := suite.rc.Check(suite.cluster.GetRegion(1))
+				suite.Nil(op)
 
-	for _, p := range r1.GetPeers() {
-		suite.NotEqual(p.GetStoreId(), 1)
-		suite.NotEqual(p.GetStoreId(), 2)
-		suite.NotEqual(p.GetStoreId(), 3)
+				// set three stores to disconnected
+				suite.cluster.SetStoreDisconnect(testCase[0])
+				suite.cluster.SetStoreDisconnect(testCase[1])
+				suite.cluster.SetStoreDisconnect(testCase[2])
+
+				// change rule to 3 replicas
+				suite.ruleManager.DeleteRule("pd", "r1")
+				suite.ruleManager.SetRule(&placement.Rule{
+					GroupID:  "pd",
+					ID:       "default",
+					Role:     placement.Voter,
+					Count:    3,
+					StartKey: []byte{},
+					EndKey:   []byte{},
+					Override: true,
+				})
+
+				// remove peer from region 1
+				for j := 1; j <= 3; j++ {
+					r1 := suite.cluster.GetRegion(1)
+					op = suite.rc.Check(suite.cluster.GetRegion(1))
+					suite.NotNil(op)
+					suite.Contains(op.Desc(), "orphan")
+					var removedPeerStroeID uint64
+					newLeaderStoreID := r1.GetLeader().GetStoreId()
+					for i := 0; i < op.Len(); i++ {
+						if s, ok := op.Step(i).(operator.RemovePeer); ok {
+							removedPeerStroeID = s.FromStore
+						}
+						if s, ok := op.Step(i).(operator.TransferLeader); ok {
+							newLeaderStoreID = s.ToStore
+						}
+					}
+					suite.NotZero(removedPeerStroeID)
+					r1 = r1.Clone(
+						core.WithLeader(r1.GetStorePeer(newLeaderStoreID)),
+						core.WithRemoveStorePeer(removedPeerStroeID))
+					suite.cluster.PutRegion(r1)
+					r1 = suite.cluster.GetRegion(1)
+					suite.Len(r1.GetPeers(), 6-j)
+				}
+
+				r1 = suite.cluster.GetRegion(1)
+				for _, p := range r1.GetPeers() {
+					suite.NotEqual(p.GetStoreId(), testCase[0])
+					suite.NotEqual(p.GetStoreId(), testCase[1])
+					suite.NotEqual(p.GetStoreId(), testCase[2])
+				}
+				suite.TearDownTest()
+				suite.SetupTest()
+			}
+		}
 	}
 }
 

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -17,7 +17,6 @@ package checker
 import (
 	"context"
 	"fmt"
-
 	"strconv"
 	"strings"
 	"testing"

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -235,7 +235,7 @@ func (suite *ruleCheckerTestSuite) TestFixToManyOrphanPeers() {
 	suite.cluster.PutRegion(region)
 	op = suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.NotNil(op)
-	suite.Equal("remove-orphan-peer", op.Desc())
+	suite.Equal("remove-unhealthy-orphan-peer", op.Desc())
 	suite.Equal(uint64(4), op.Step(0).(operator.RemovePeer).FromStore)
 }
 
@@ -702,7 +702,7 @@ func (suite *ruleCheckerTestSuite) TestPriorityFixOrphanPeer() {
 	suite.cluster.PutRegion(testRegion)
 	op = suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.NotNil(op)
-	suite.Equal("remove-orphan-peer", op.Desc())
+	suite.Equal("remove-unhealthy-orphan-peer", op.Desc())
 	suite.IsType(remove, op.Step(0))
 	// Ref #3521
 	suite.cluster.SetStoreOffline(2)
@@ -721,6 +721,178 @@ func (suite *ruleCheckerTestSuite) TestPriorityFixOrphanPeer() {
 	op = suite.rc.Check(suite.cluster.GetRegion(1))
 	suite.IsType(remove, op.Step(0))
 	suite.Equal("remove-orphan-peer", op.Desc())
+}
+
+// Ref https://github.com/tikv/pd/issues/7249 https://github.com/tikv/tikv/issues/15799
+func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChanged() {
+	// init cluster with 5 replicas
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
+	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+	storeIDs := []uint64{1, 2, 3, 4, 5}
+	suite.cluster.AddLeaderRegionWithRange(1, "", "", storeIDs[0], storeIDs[1:]...)
+	rule := &placement.Rule{
+		GroupID:  "pd",
+		ID:       "default",
+		Role:     placement.Voter,
+		Count:    5,
+		StartKey: []byte{},
+		EndKey:   []byte{},
+	}
+	suite.ruleManager.SetRule(rule)
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.Nil(op)
+
+	// set store 1, 2 to disconnected
+	suite.cluster.SetStoreDisconnect(1)
+	suite.cluster.SetStoreDisconnect(2)
+
+	// change rule to 3 replicas
+	rule = &placement.Rule{
+		GroupID:  "pd",
+		ID:       "default",
+		Role:     placement.Voter,
+		Count:    3,
+		StartKey: []byte{},
+		EndKey:   []byte{},
+		Override: true,
+	}
+	suite.ruleManager.SetRule(rule)
+
+	// remove store 1 from region 1
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.NotNil(op)
+	suite.Equal("remove-replaced-orphan-peer", op.Desc())
+	suite.Equal(op.Len(), 2)
+	newLeaderID := op.Step(0).(operator.TransferLeader).ToStore
+	removedPeerID := op.Step(1).(operator.RemovePeer).FromStore
+	r1 := suite.cluster.GetRegion(1)
+	r1 = r1.Clone(
+		core.WithLeader(r1.GetPeer(newLeaderID)),
+		core.WithRemoveStorePeer(removedPeerID))
+	suite.cluster.PutRegion(r1)
+	r1 = suite.cluster.GetRegion(1)
+	suite.Len(r1.GetPeers(), 4)
+
+	// remove store 2 from region 1
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.NotNil(op)
+	suite.Equal("remove-replaced-orphan-peer", op.Desc())
+	suite.Equal(op.Len(), 1)
+	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
+	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
+	suite.cluster.PutRegion(r1)
+	r1 = suite.cluster.GetRegion(1)
+	suite.Len(r1.GetPeers(), 3)
+	for _, p := range r1.GetPeers() {
+		suite.NotEqual(p.GetStoreId(), 1)
+		suite.NotEqual(p.GetStoreId(), 2)
+	}
+}
+
+// Ref https://github.com/tikv/pd/issues/7249 https://github.com/tikv/tikv/issues/15799
+func (suite *ruleCheckerTestSuite) TestFixOrphanPeerWithDisconnectedStoreAndRuleChanged2() {
+	// init cluster with 5 voters and 1 learner
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4"})
+	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+	suite.cluster.AddLabelsStore(6, 1, map[string]string{"host": "host6"})
+	storeIDs := []uint64{1, 2, 3, 4, 5}
+	suite.cluster.AddLeaderRegionWithRange(1, "", "", storeIDs[0], storeIDs[1:]...)
+	r1 := suite.cluster.GetRegion(1)
+	r1 = r1.Clone(core.WithAddPeer(&metapb.Peer{Id: 6, StoreId: 6, Role: metapb.PeerRole_Learner}))
+	suite.cluster.PutRegion(r1)
+	err := suite.ruleManager.SetRules([]*placement.Rule{
+		{
+			GroupID:   "pd",
+			ID:        "default",
+			Index:     100,
+			Override:  true,
+			Role:      placement.Voter,
+			Count:     5,
+			IsWitness: false,
+		},
+		{
+			GroupID:   "pd",
+			ID:        "r1",
+			Index:     100,
+			Override:  false,
+			Role:      placement.Learner,
+			Count:     1,
+			IsWitness: false,
+		},
+	})
+	suite.NoError(err)
+
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.Nil(op)
+
+	// set store 1, 2 to disconnected
+	suite.cluster.SetStoreDisconnect(1)
+	suite.cluster.SetStoreDisconnect(2)
+	suite.cluster.SetStoreDisconnect(3)
+
+	// change rule to 3 replicas
+	suite.ruleManager.DeleteRuleGroup("pd")
+	suite.ruleManager.SetRule(&placement.Rule{
+		GroupID:  "pd",
+		ID:       "default",
+		Role:     placement.Voter,
+		Count:    2,
+		StartKey: []byte{},
+		EndKey:   []byte{},
+		Override: true,
+	})
+
+	// remove store 1 from region 1
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.NotNil(op)
+	suite.Equal("remove-replaced-orphan-peer", op.Desc())
+	suite.Equal(op.Len(), 2)
+	newLeaderID := op.Step(0).(operator.TransferLeader).ToStore
+	removedPeerID := op.Step(1).(operator.RemovePeer).FromStore
+	r1 = suite.cluster.GetRegion(1)
+	r1 = r1.Clone(
+		core.WithLeader(r1.GetPeer(newLeaderID)),
+		core.WithRemoveStorePeer(removedPeerID))
+	suite.cluster.PutRegion(r1)
+	r1 = suite.cluster.GetRegion(1)
+	suite.Len(r1.GetPeers(), 5)
+
+	// remove store 2 from region 1
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.NotNil(op)
+	suite.Equal("remove-replaced-orphan-peer", op.Desc())
+	suite.Equal(op.Len(), 1)
+	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
+	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
+	suite.cluster.PutRegion(r1)
+	r1 = suite.cluster.GetRegion(1)
+	suite.Len(r1.GetPeers(), 4)
+	for _, p := range r1.GetPeers() {
+		fmt.Println(p.GetStoreId(), p.Role.String())
+	}
+
+	// remove store 3 from region 1
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	suite.NotNil(op)
+	suite.Equal("remove-replaced-orphan-peer", op.Desc())
+	suite.Equal(op.Len(), 1)
+	removedPeerID = op.Step(0).(operator.RemovePeer).FromStore
+	r1 = r1.Clone(core.WithRemoveStorePeer(removedPeerID))
+	suite.cluster.PutRegion(r1)
+	r1 = suite.cluster.GetRegion(1)
+	suite.Len(r1.GetPeers(), 3)
+
+	for _, p := range r1.GetPeers() {
+		suite.NotEqual(p.GetStoreId(), 1)
+		suite.NotEqual(p.GetStoreId(), 2)
+		suite.NotEqual(p.GetStoreId(), 3)
+	}
 }
 
 func (suite *ruleCheckerTestSuite) TestPriorityFitHealthWithDifferentRole1() {

--- a/server/cluster/coordinator_test.go
+++ b/server/cluster/coordinator_test.go
@@ -510,11 +510,11 @@ func TestReplica(t *testing.T) {
 	re.NoError(dispatchHeartbeat(co, region, stream))
 	waitNoResponse(re, stream)
 
-	// Remove peer from store 4.
+	// Remove peer from store 3.
 	re.NoError(tc.addLeaderRegion(2, 1, 2, 3, 4))
 	region = tc.GetRegion(2)
 	re.NoError(dispatchHeartbeat(co, region, stream))
-	region = waitRemovePeer(re, stream, region, 4)
+	region = waitRemovePeer(re, stream, region, 3) // store3 is down, we should remove it firstly.
 	re.NoError(dispatchHeartbeat(co, region, stream))
 	waitNoResponse(re, stream)
 


### PR DESCRIPTION
It is a pick for https://github.com/tikv/pd/pull/7240, https://github.com/tikv/pd/pull/7294 and https://github.com/tikv/pd/pull/7315
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7249

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
