### PR TITLE
resourcemanager: return resource-group priority in OnRequestWait

### DIFF
--- a/client/resource_group/controller/controller_test.go
+++ b/client/resource_group/controller/controller_test.go
@@ -30,8 +30,9 @@ import (
 
 func createTestGroupCostController(re *require.Assertions) *groupCostController {
 	group := &rmpb.ResourceGroup{
-		Name: "test",
-		Mode: rmpb.GroupMode_RUMode,
+		Name:     "test",
+		Mode:     rmpb.GroupMode_RUMode,
+		Priority: 1,
 		RUSettings: &rmpb.GroupRequestUnitSettings{
 			RU: &rmpb.TokenBucket{
 				Settings: &rmpb.TokenLimitSettings{
@@ -100,8 +101,9 @@ func TestRequestAndResponseConsumption(t *testing.T) {
 	kvCalculator := gc.getKVCalculator()
 	for idx, testCase := range testCases {
 		caseNum := fmt.Sprintf("case %d", idx)
-		consumption, _, err := gc.onRequestWait(context.TODO(), testCase.req)
+		consumption, _, priority, err := gc.onRequestWait(context.TODO(), testCase.req)
 		re.NoError(err, caseNum)
+		re.Equal(priority, gc.meta.Priority)
 		expectedConsumption := &rmpb.Consumption{}
 		if testCase.req.IsWrite() {
 			kvCalculator.calculateWriteCost(expectedConsumption, testCase.req)

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -438,9 +438,9 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupController() {
 				rres := cas.tcs[i].makeReadResponse()
 				wres := cas.tcs[i].makeWriteResponse()
 				startTime := time.Now()
-				_, _, err := controller.OnRequestWait(suite.ctx, cas.resourceGroupName, rreq)
+				_, _, _, err := controller.OnRequestWait(suite.ctx, cas.resourceGroupName, rreq)
 				re.NoError(err)
-				_, _, err = controller.OnRequestWait(suite.ctx, cas.resourceGroupName, wreq)
+				_, _, _, err = controller.OnRequestWait(suite.ctx, cas.resourceGroupName, wreq)
 				re.NoError(err)
 				sum += time.Since(startTime)
 				controller.OnResponse(cas.resourceGroupName, rreq, rres)
@@ -457,7 +457,7 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupController() {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/resource_group/controller/triggerUpdate", "return(true)"))
 	tcs := tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 900000000, times: 1, waitDuration: 0}
 	wreq := tcs.makeWriteRequest()
-	_, _, err = controller.OnRequestWait(suite.ctx, rg.Name, wreq)
+	_, _, _, err = controller.OnRequestWait(suite.ctx, rg.Name, wreq)
 	re.Error(err)
 	time.Sleep(time.Millisecond * 200)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/triggerUpdate"))
@@ -512,9 +512,9 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 		wreq := tcs.makeWriteRequest()
 		rres := tcs.makeReadResponse()
 		wres := tcs.makeWriteResponse()
-		_, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName, rreq)
+		_, _, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName, rreq)
 		re.NoError(err)
-		_, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName, wreq)
+		_, _, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName, wreq)
 		re.NoError(err)
 		controller.OnResponse(resourceGroupName, rreq, rres)
 		controller.OnResponse(resourceGroupName, wreq, wres)
@@ -551,9 +551,9 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 				rres := cas.tcs[i].makeReadResponse()
 				wres := cas.tcs[i].makeWriteResponse()
 				startTime := time.Now()
-				_, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName, rreq)
+				_, _, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName, rreq)
 				re.NoError(err)
-				_, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName, wreq)
+				_, _, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName, wreq)
 				re.NoError(err)
 				sum += time.Since(startTime)
 				controller.OnResponse(resourceGroupName, rreq, rres)
@@ -571,14 +571,14 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 	resourceGroupName2 := suite.initGroups[2].Name
 	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 100000, times: 1, waitDuration: 0}
 	wreq := tcs.makeWriteRequest()
-	_, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName2, wreq)
+	_, _, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName2, wreq)
 	re.NoError(err)
 
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/resource_group/controller/acceleratedSpeedTrend", "return(true)"))
 	resourceGroupName3 := suite.initGroups[3].Name
 	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 1000, times: 1, waitDuration: 0}
 	wreq = tcs.makeWriteRequest()
-	_, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName3, wreq)
+	_, _, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName3, wreq)
 	re.NoError(err)
 	time.Sleep(110 * time.Millisecond)
 	tcs = tokenConsumptionPerSecond{rruTokensAtATime: 1, wruTokensAtATime: 10, times: 1010, waitDuration: 0}
@@ -586,7 +586,7 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 	for i := 0; i < tcs.times; i++ {
 		wreq = tcs.makeWriteRequest()
 		startTime := time.Now()
-		_, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName3, wreq)
+		_, _, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName3, wreq)
 		duration += time.Since(startTime)
 		re.NoError(err)
 	}
@@ -635,7 +635,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	// init
 	req := controller.NewTestRequestInfo(false, 0, 2 /* store2 */)
 	resp := controller.NewTestResponseInfo(0, time.Duration(30), true)
-	_, penalty, err := c.OnRequestWait(suite.ctx, resourceGroupName, req)
+	_, penalty, _, err := c.OnRequestWait(suite.ctx, resourceGroupName, req)
 	re.NoError(err)
 	re.Equal(penalty.WriteBytes, 0.0)
 	re.Equal(penalty.TotalCpuTimeMs, 0.0)
@@ -644,7 +644,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 
 	req = controller.NewTestRequestInfo(true, 60, 1 /* store1 */)
 	resp = controller.NewTestResponseInfo(0, time.Duration(10), true)
-	_, penalty, err = c.OnRequestWait(suite.ctx, resourceGroupName, req)
+	_, penalty, _, err = c.OnRequestWait(suite.ctx, resourceGroupName, req)
 	re.NoError(err)
 	re.Equal(penalty.WriteBytes, 0.0)
 	re.Equal(penalty.TotalCpuTimeMs, 0.0)
@@ -654,7 +654,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	// failed request, shouldn't be counted in penalty
 	req = controller.NewTestRequestInfo(true, 20, 1 /* store1 */)
 	resp = controller.NewTestResponseInfo(0, time.Duration(0), false)
-	_, penalty, err = c.OnRequestWait(suite.ctx, resourceGroupName, req)
+	_, penalty, _, err = c.OnRequestWait(suite.ctx, resourceGroupName, req)
 	re.NoError(err)
 	re.Equal(penalty.WriteBytes, 0.0)
 	re.Equal(penalty.TotalCpuTimeMs, 0.0)
@@ -664,7 +664,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	// from same store, should be zero
 	req1 := controller.NewTestRequestInfo(false, 0, 1 /* store1 */)
 	resp1 := controller.NewTestResponseInfo(0, time.Duration(10), true)
-	_, penalty, err = c.OnRequestWait(suite.ctx, resourceGroupName, req1)
+	_, penalty, _, err = c.OnRequestWait(suite.ctx, resourceGroupName, req1)
 	re.NoError(err)
 	re.Equal(penalty.WriteBytes, 0.0)
 	_, err = c.OnResponse(resourceGroupName, req1, resp1)
@@ -673,7 +673,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	// from different store, should be non-zero
 	req2 := controller.NewTestRequestInfo(true, 50, 2 /* store2 */)
 	resp2 := controller.NewTestResponseInfo(0, time.Duration(10), true)
-	_, penalty, err = c.OnRequestWait(suite.ctx, resourceGroupName, req2)
+	_, penalty, _, err = c.OnRequestWait(suite.ctx, resourceGroupName, req2)
 	re.NoError(err)
 	re.Equal(penalty.WriteBytes, 60.0)
 	re.InEpsilon(penalty.TotalCpuTimeMs, 10.0/1000.0/1000.0, 1e-6)
@@ -683,7 +683,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	// from new store, should be zero
 	req3 := controller.NewTestRequestInfo(true, 0, 3 /* store3 */)
 	resp3 := controller.NewTestResponseInfo(0, time.Duration(10), true)
-	_, penalty, err = c.OnRequestWait(suite.ctx, resourceGroupName, req3)
+	_, penalty, _, err = c.OnRequestWait(suite.ctx, resourceGroupName, req3)
 	re.NoError(err)
 	re.Equal(penalty.WriteBytes, 0.0)
 	_, err = c.OnResponse(resourceGroupName, req3, resp3)
@@ -693,7 +693,7 @@ func (suite *resourceManagerClientTestSuite) TestResourcePenalty() {
 	resourceGroupName = groupNames[1]
 	req4 := controller.NewTestRequestInfo(true, 50, 1 /* store2 */)
 	resp4 := controller.NewTestResponseInfo(0, time.Duration(10), true)
-	_, penalty, err = c.OnRequestWait(suite.ctx, resourceGroupName, req4)
+	_, penalty, _, err = c.OnRequestWait(suite.ctx, resourceGroupName, req4)
 	re.NoError(err)
 	re.Equal(penalty.WriteBytes, 0.0)
 	_, err = c.OnResponse(resourceGroupName, req4, resp4)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #7379, ref tikv/tikv#15994

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
return resource-group priority in OnRequestWait so client-go can set the resource-group priority to kv request.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes


Side effects


Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None
```
