### PR TITLE
schedule: fix panic when switching placement rules

### DIFF
--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -132,6 +132,11 @@ func (c *RuleChecker) CheckWithFit(region *core.RegionInfo, fit *placement.Regio
 		return
 	}
 
+	// the placement rule is disabled
+	if fit == nil {
+		return
+	}
+
 	// If the fit is calculated by FitRegion, which means we get a new fit result, thus we should
 	// invalid the cache if it exists
 	c.ruleManager.InvalidCache(region.GetID())


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7414.

### What is changed and how does it work?

When we going to disable the placement rule, we might first check:

https://github.com/tikv/pd/blob/8e6dcfbad0392bbacfc6fa1611457f75a8f0f2b4/pkg/schedule/checker/checker_controller.go#L89

Before we change it, the value is true. But when we call:
https://github.com/tikv/pd/blob/8e6dcfbad0392bbacfc6fa1611457f75a8f0f2b4/pkg/schedule/checker/checker_controller.go#L102
https://github.com/tikv/pd/blob/8e6dcfbad0392bbacfc6fa1611457f75a8f0f2b4/pkg/schedule/checker/priority_inspector.go#L64-L74
The value can be changed to false. So the fit will be nil in this case.



<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
