### PR TITLE
ci: adjust the task weight algorithm to make ci tasks more uniform

### DIFF
--- a/scripts/ci-subtask.sh
+++ b/scripts/ci-subtask.sh
@@ -43,8 +43,7 @@ else
     done
 
     # Sort tasks by weight in descending order.
-    IFS=$'\n' tasks=($(sort -rn <<<"${tasks[*]}"))
-    unset IFS
+    tasks=($(printf "%s\n" "${tasks[@]}" | sort -rn))
 
     scores=($(seq "$1" | xargs -I{} echo 0))
 

--- a/scripts/ci-subtask.sh
+++ b/scripts/ci-subtask.sh
@@ -29,10 +29,22 @@ else
     weight() {
         [[ $1 == "github.com/tikv/pd/server/api" ]] && return 30
         [[ $1 == "github.com/tikv/pd/pkg/schedule" ]] && return 30
-        [[ $1 == "pd/tests/server/api" ]] && return 30
+        [[ $1 == "github.com/tikv/pd/pkg/core" ]] && return 30
+        [[ $1 == "github.com/tikv/pd/tests/server/api" ]] && return 30
         [[ $1 =~ "pd/tests" ]] && return 5
         return 1
     }
+
+    # Create an associative array to store the weight of each task.
+    declare -A task_weights
+    for t in ${tasks[@]}; do
+        weight $t
+        task_weights[$t]=$?
+    done
+
+    # Sort tasks by weight in descending order.
+    IFS=$'\n' tasks=($(sort -rn <<<"${tasks[*]}"))
+    unset IFS
 
     scores=($(seq "$1" | xargs -I{} echo 0))
 
@@ -42,8 +54,7 @@ else
         for i in ${!scores[@]}; do
             [[ ${scores[i]} -lt ${scores[$min_i]} ]] && min_i=$i
         done
-        weight $t
-        scores[$min_i]=$((${scores[$min_i]} + $?))
+        scores[$min_i]=$((${scores[$min_i]} + ${task_weights[$t]}))
         [[ $(($min_i + 1)) -eq $2 ]] && res+=($t)
     done
     printf "%s " "${res[@]}"


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #4399

The tests that took the longest are as follows:
```
ok github.com/tikv/pd/tests/server/api 418.766s coverage: 39.2% of statements in ./...
ok github.com/tikv/pd/pkg/core 261.422s coverage: 26.1% of statements in ./...
ok github.com/tikv/pd/server/api 205.389s coverage: 30.5% of statements in ./...
ok github.com/tikv/pd/tests/server/member 175.151s coverage: 11.4% of statements in ./...
ok github.com/tikv/pd/tests/server/cluster 168.862s coverage: 26.9% of statements in ./...
ok github.com/tikv/pd/pkg/mcs/discovery 122.774s coverage: 20.9% of statements in ./...
ok github.com/tikv/pd/pkg/schedule/scatter 90.437s coverage: 20.5% of statements in ./...
ok github.com/tikv/pd/pkg/utils/etcdutil 81.330s coverage: 41.8% of statements in ./...
ok github.com/tikv/pd/tests/server/region_syncer 80.535s coverage: 21.1% of statements in ./...
ok github.com/tikv/pd/pkg/schedule/schedulers 79.579s coverage: 39.4% of statements in ./...
ok github.com/tikv/pd/tests/server/join 78.284s coverage: 9.6% of statements in ./...
ok github.com/tikv/pd/tests/server/join 77.112s coverage: 9.6% of statements in ./...
ok github.com/tikv/pd/tests/server/config 76.615s coverage: 22.5% of statements in ./...
ok github.com/tikv/pd/tests/pdctl/keyspace 73.011s coverage: 20.9% of statements in ./...
ok github.com/tikv/pd/pkg/election 71.484s coverage: 29.9% of statements in ./...
ok github.com/tikv/pd/tests/pdctl/config 70.265s coverage: 25.4% of statements in ./...
```

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

We will sort tasks by weight in descending order, and then calculate the sum of weight.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
