### PR TITLE
api: return `[]` rather than `null` for empty scheduler results

### DIFF
--- a/pkg/schedule/handler/handler.go
+++ b/pkg/schedule/handler/handler.go
@@ -807,7 +807,7 @@ func (h *Handler) GetSchedulerByStatus(status string, needTS bool) (interface{},
 	schedulers := sc.GetSchedulerNames()
 	switch status {
 	case "paused":
-		var pausedSchedulers []string
+		pausedSchedulers := make([]string, 0, len(schedulers))
 		pausedPeriods := []schedulerPausedPeriod{}
 		for _, scheduler := range schedulers {
 			paused, err := sc.IsSchedulerPaused(scheduler)
@@ -842,7 +842,7 @@ func (h *Handler) GetSchedulerByStatus(status string, needTS bool) (interface{},
 		}
 		return pausedSchedulers, nil
 	case "disabled":
-		var disabledSchedulers []string
+		disabledSchedulers := make([]string, 0, len(schedulers))
 		for _, scheduler := range schedulers {
 			disabled, err := sc.IsSchedulerDisabled(scheduler)
 			if err != nil {
@@ -857,7 +857,7 @@ func (h *Handler) GetSchedulerByStatus(status string, needTS bool) (interface{},
 		// The default scheduler could not be deleted in scheduling server,
 		// so schedulers could only be disabled.
 		// We should not return the disabled schedulers here.
-		var enabledSchedulers []string
+		enabledSchedulers := make([]string, 0, len(schedulers))
 		for _, scheduler := range schedulers {
 			disabled, err := sc.IsSchedulerDisabled(scheduler)
 			if err != nil {

--- a/tests/pdctl/scheduler/scheduler_test.go
+++ b/tests/pdctl/scheduler/scheduler_test.go
@@ -545,7 +545,7 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *tests.TestCluster) {
 	mustUsage([]string{"-u", pdAddr, "scheduler", "resume", "balance-leader-scheduler", "60"})
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "resume", "balance-leader-scheduler"}, nil)
 	re.Contains(echo, "Success!")
-	checkSchedulerWithStatusCommand("paused", nil)
+	checkSchedulerWithStatusCommand("paused", []string{})
 
 	// set label scheduler to disabled manually.
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "label-scheduler"}, nil)
@@ -560,7 +560,7 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *tests.TestCluster) {
 	cfg.Schedulers = origin
 	err = leaderServer.GetServer().SetScheduleConfig(*cfg)
 	re.NoError(err)
-	checkSchedulerWithStatusCommand("disabled", nil)
+	checkSchedulerWithStatusCommand("disabled", []string{})
 }
 
 func (suite *schedulerTestSuite) TestSchedulerDiagnostic() {

--- a/tests/server/api/scheduler_test.go
+++ b/tests/server/api/scheduler_test.go
@@ -17,6 +17,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/slice"
+	"github.com/tikv/pd/pkg/utils/apiutil"
 	tu "github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/tests"
@@ -673,6 +675,40 @@ func (suite *scheduleTestSuite) testPauseOrResume(urlPrefix string, name, create
 	suite.False(isPaused)
 }
 
+func (suite *scheduleTestSuite) TestEmptySchedulers() {
+	env := tests.NewSchedulingTestEnvironment(suite.T())
+	env.RunTestInTwoModes(suite.checkEmptySchedulers)
+}
+
+func (suite *scheduleTestSuite) checkEmptySchedulers(cluster *tests.TestCluster) {
+	re := suite.Require()
+	leaderAddr := cluster.GetLeaderServer().GetAddr()
+	urlPrefix := fmt.Sprintf("%s/pd/api/v1/schedulers", leaderAddr)
+	for i := 1; i <= 4; i++ {
+		store := &metapb.Store{
+			Id:            uint64(i),
+			State:         metapb.StoreState_Up,
+			NodeState:     metapb.NodeState_Serving,
+			LastHeartbeat: time.Now().UnixNano(),
+		}
+		tests.MustPutStore(suite.Require(), cluster, store)
+	}
+
+	// test disabled and paused schedulers
+	suite.checkEmptySchedulersResp(urlPrefix + "?status=disabled")
+	suite.checkEmptySchedulersResp(urlPrefix + "?status=paused")
+
+	// test enabled schedulers
+	schedulers := make([]string, 0)
+	suite.NoError(tu.ReadGetJSON(re, testDialClient, urlPrefix, &schedulers))
+	for _, scheduler := range schedulers {
+		suite.deleteScheduler(urlPrefix, scheduler)
+	}
+	suite.NoError(tu.ReadGetJSON(re, testDialClient, urlPrefix, &schedulers))
+	suite.Len(schedulers, 0)
+	suite.checkEmptySchedulersResp(urlPrefix)
+}
+
 func (suite *scheduleTestSuite) assertSchedulerExists(re *require.Assertions, urlPrefix string, scheduler string) {
 	var schedulers []string
 	tu.Eventually(re, func() bool {
@@ -699,4 +735,15 @@ func (suite *scheduleTestSuite) isSchedulerPaused(urlPrefix, name string) bool {
 		}
 	}
 	return false
+}
+
+func (suite *scheduleTestSuite) checkEmptySchedulersResp(url string) {
+	resp, err := apiutil.GetJSON(testDialClient, url, nil)
+	suite.NoError(err)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+	b, err := io.ReadAll(resp.Body)
+	suite.NoError(err)
+	suite.Contains(string(b), "[]")
+	suite.NotContains(string(b), "null")
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7452

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
