### PR TITLE
errs: remove redundant `FastGenWithCause` in `ZapError`

### DIFF
--- a/client/errs/errno.go
+++ b/client/errs/errno.go
@@ -54,7 +54,7 @@ var (
 	ErrClientGetMultiResponse         = errors.Normalize("get invalid value response %v, must only one", errors.RFCCodeText("PD:client:ErrClientGetMultiResponse"))
 	ErrClientGetServingEndpoint       = errors.Normalize("get serving endpoint failed", errors.RFCCodeText("PD:client:ErrClientGetServingEndpoint"))
 	ErrClientFindGroupByKeyspaceID    = errors.Normalize("can't find keyspace group by keyspace id", errors.RFCCodeText("PD:client:ErrClientFindGroupByKeyspaceID"))
-	ErrClientWatchGCSafePointV2Stream = errors.Normalize("watch gc safe point v2 stream failed, %s", errors.RFCCodeText("PD:client:ErrClientWatchGCSafePointV2Stream"))
+	ErrClientWatchGCSafePointV2Stream = errors.Normalize("watch gc safe point v2 stream failed", errors.RFCCodeText("PD:client:ErrClientWatchGCSafePointV2Stream"))
 )
 
 // grpcutil errors

--- a/client/errs/errs.go
+++ b/client/errs/errs.go
@@ -27,7 +27,7 @@ func ZapError(err error, causeError ...error) zap.Field {
 	}
 	if e, ok := err.(*errors.Error); ok {
 		if len(causeError) >= 1 {
-			err = e.FastGenWithCause(causeError[0])
+			err = e.Wrap(causeError[0])
 		} else {
 			err = e.FastGenByArgs()
 		}

--- a/client/errs/errs.go
+++ b/client/errs/errs.go
@@ -27,7 +27,7 @@ func ZapError(err error, causeError ...error) zap.Field {
 	}
 	if e, ok := err.(*errors.Error); ok {
 		if len(causeError) >= 1 {
-			err = e.Wrap(causeError[0]).FastGenWithCause()
+			err = e.FastGenWithCause(causeError[0])
 		} else {
 			err = e.FastGenByArgs()
 		}

--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -412,7 +412,7 @@ tsoBatchLoop:
 			} else {
 				log.Error("[tso] fetch pending tso requests error",
 					zap.String("dc-location", dc),
-					errs.ZapError(errs.ErrClientGetTSO.FastGenByArgs("when fetch pending tso requests"), err))
+					errs.ZapError(errs.ErrClientGetTSO, err))
 			}
 			return
 		}
@@ -495,10 +495,10 @@ tsoBatchLoop:
 			default:
 			}
 			c.svcDiscovery.ScheduleCheckMemberChanged()
-			log.Error("[tso] getTS error",
+			log.Error("[tso] getTS error after processing requests",
 				zap.String("dc-location", dc),
 				zap.String("stream-addr", streamAddr),
-				errs.ZapError(errs.ErrClientGetTSO.FastGenByArgs("after processing requests"), err))
+				errs.ZapError(errs.ErrClientGetTSO, err))
 			// Set `stream` to nil and remove this stream from the `connectionCtxs` due to error.
 			connectionCtxs.Delete(streamAddr)
 			cancel()

--- a/errors.toml
+++ b/errors.toml
@@ -83,7 +83,7 @@ get min TSO failed, %v
 
 ["PD:client:ErrClientGetTSO"]
 error = '''
-get TSO failed, %v
+get TSO failed
 '''
 
 ["PD:client:ErrClientGetTSOTimeout"]

--- a/pkg/autoscaling/prometheus.go
+++ b/pkg/autoscaling/prometheus.go
@@ -94,7 +94,7 @@ func (prom *PrometheusQuerier) queryMetricsFromPrometheus(query string, timestam
 	resp, warnings, err := prom.api.Query(ctx, query, timestamp)
 
 	if err != nil {
-		return nil, errs.ErrPrometheusQuery.Wrap(err).FastGenWithCause()
+		return nil, errs.ErrPrometheusQuery.Wrap(err)
 	}
 
 	if len(warnings) > 0 {

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -86,7 +86,7 @@ var (
 var (
 	ErrClientCreateTSOStream = errors.Normalize("create TSO stream failed, %s", errors.RFCCodeText("PD:client:ErrClientCreateTSOStream"))
 	ErrClientGetTSOTimeout   = errors.Normalize("get TSO timeout", errors.RFCCodeText("PD:client:ErrClientGetTSOTimeout"))
-	ErrClientGetTSO          = errors.Normalize("get TSO failed, %v", errors.RFCCodeText("PD:client:ErrClientGetTSO"))
+	ErrClientGetTSO          = errors.Normalize("get TSO failed", errors.RFCCodeText("PD:client:ErrClientGetTSO"))
 	ErrClientGetLeader       = errors.Normalize("get leader failed, %v", errors.RFCCodeText("PD:client:ErrClientGetLeader"))
 	ErrClientGetMember       = errors.Normalize("get member failed", errors.RFCCodeText("PD:client:ErrClientGetMember"))
 	ErrClientGetMinTSO       = errors.Normalize("get min TSO failed, %v", errors.RFCCodeText("PD:client:ErrClientGetMinTSO"))

--- a/pkg/errs/errs.go
+++ b/pkg/errs/errs.go
@@ -27,7 +27,7 @@ func ZapError(err error, causeError ...error) zap.Field {
 	}
 	if e, ok := err.(*errors.Error); ok {
 		if len(causeError) >= 1 {
-			err = e.FastGenWithCause(causeError[0])
+			err = e.Wrap(causeError[0])
 		} else {
 			err = e.FastGenByArgs()
 		}

--- a/pkg/errs/errs.go
+++ b/pkg/errs/errs.go
@@ -27,7 +27,7 @@ func ZapError(err error, causeError ...error) zap.Field {
 	}
 	if e, ok := err.(*errors.Error); ok {
 		if len(causeError) >= 1 {
-			err = e.Wrap(causeError[0]).FastGenWithCause()
+			err = e.FastGenWithCause(causeError[0])
 		} else {
 			err = e.FastGenByArgs()
 		}

--- a/pkg/errs/errs_test.go
+++ b/pkg/errs/errs_test.go
@@ -81,9 +81,19 @@ func TestError(t *testing.T) {
 	log.Error("test", zap.Error(ErrEtcdLeaderNotFound.FastGenByArgs()))
 	re.Contains(lg.Message(), rfc)
 	err := errors.New("test error")
-	log.Error("test", ZapError(ErrEtcdLeaderNotFound, err))
+	// use Info() because of no stack for comparing.
+	log.Info("test", ZapError(ErrEtcdLeaderNotFound, err))
 	rfc = `[error="[PD:member:ErrEtcdLeaderNotFound]etcd leader not found: test error`
-	re.Contains(lg.Message(), rfc)
+	m1 := lg.Message()
+	re.Contains(m1, rfc)
+	log.Info("test", zap.Error(ErrEtcdLeaderNotFound.Wrap(err)))
+	m2 := lg.Message()
+	idx1 := strings.Index(m1, "[error")
+	idx2 := strings.Index(m2, "[error")
+	re.Equal(m1[idx1:], m2[idx2:])
+	log.Info("test", zap.Error(ErrEtcdLeaderNotFound.Wrap(err).FastGenWithCause()))
+	m3 := lg.Message()
+	re.NotContains(m3, rfc)
 }
 
 func TestErrorEqual(t *testing.T) {
@@ -135,11 +145,16 @@ func TestErrorWithStack(t *testing.T) {
 	m1 := lg.Message()
 	log.Error("test", zap.Error(errors.WithStack(err)))
 	m2 := lg.Message()
+	log.Error("test", ZapError(ErrStrconvParseInt.GenWithStackByCause(), err))
+	m3 := lg.Message()
 	// This test is based on line number and the first log is in line 141, the second is in line 142.
 	// So they have the same length stack. Move this test to another place need to change the corresponding length.
 	idx1 := strings.Index(m1, "[stack=")
 	re.GreaterOrEqual(idx1, -1)
 	idx2 := strings.Index(m2, "[stack=")
 	re.GreaterOrEqual(idx2, -1)
+	idx3 := strings.Index(m3, "[stack=")
+	re.GreaterOrEqual(idx3, -1)
 	re.Len(m2[idx2:], len(m1[idx1:]))
+	re.Len(m3[idx3:], len(m1[idx1:]))
 }

--- a/pkg/errs/errs_test.go
+++ b/pkg/errs/errs_test.go
@@ -94,24 +94,24 @@ func TestErrorEqual(t *testing.T) {
 	re.True(errors.ErrorEqual(err1, err2))
 
 	err := errors.New("test")
-	err1 = ErrSchedulerNotFound.Wrap(err).FastGenWithCause()
-	err2 = ErrSchedulerNotFound.Wrap(err).FastGenWithCause()
+	err1 = ErrSchedulerNotFound.Wrap(err)
+	err2 = ErrSchedulerNotFound.Wrap(err)
 	re.True(errors.ErrorEqual(err1, err2))
 
 	err1 = ErrSchedulerNotFound.FastGenByArgs()
-	err2 = ErrSchedulerNotFound.Wrap(err).FastGenWithCause()
+	err2 = ErrSchedulerNotFound.Wrap(err)
 	re.False(errors.ErrorEqual(err1, err2))
 
 	err3 := errors.New("test")
 	err4 := errors.New("test")
-	err1 = ErrSchedulerNotFound.Wrap(err3).FastGenWithCause()
-	err2 = ErrSchedulerNotFound.Wrap(err4).FastGenWithCause()
+	err1 = ErrSchedulerNotFound.Wrap(err3)
+	err2 = ErrSchedulerNotFound.Wrap(err4)
 	re.True(errors.ErrorEqual(err1, err2))
 
 	err3 = errors.New("test1")
 	err4 = errors.New("test")
-	err1 = ErrSchedulerNotFound.Wrap(err3).FastGenWithCause()
-	err2 = ErrSchedulerNotFound.Wrap(err4).FastGenWithCause()
+	err1 = ErrSchedulerNotFound.Wrap(err3)
+	err2 = ErrSchedulerNotFound.Wrap(err4)
 	re.False(errors.ErrorEqual(err1, err2))
 }
 

--- a/pkg/errs/errs_test.go
+++ b/pkg/errs/errs_test.go
@@ -82,7 +82,7 @@ func TestError(t *testing.T) {
 	re.Contains(lg.Message(), rfc)
 	err := errors.New("test error")
 	log.Error("test", ZapError(ErrEtcdLeaderNotFound, err))
-	rfc = `[error="[PD:member:ErrEtcdLeaderNotFound]test error`
+	rfc = `[error="[PD:member:ErrEtcdLeaderNotFound]etcd leader not found: test error`
 	re.Contains(lg.Message(), rfc)
 }
 

--- a/pkg/schedule/hbstream/heartbeat_streams.go
+++ b/pkg/schedule/hbstream/heartbeat_streams.go
@@ -139,7 +139,7 @@ func (s *HeartbeatStreams) run() {
 			if stream, ok := s.streams[storeID]; ok {
 				if err := stream.Send(msg); err != nil {
 					log.Error("send heartbeat message fail",
-						zap.Uint64("region-id", msg.GetRegionId()), errs.ZapError(errs.ErrGRPCSend.Wrap(err).GenWithStackByArgs()))
+						zap.Uint64("region-id", msg.GetRegionId()), errs.ZapError(errs.ErrGRPCSend, err))
 					delete(s.streams, storeID)
 					heartbeatStreamCounter.WithLabelValues(storeAddress, storeLabel, "push", "err").Inc()
 				} else {

--- a/pkg/schedule/plugin_interface.go
+++ b/pkg/schedule/plugin_interface.go
@@ -46,19 +46,19 @@ func (p *PluginInterface) GetFunction(path string, funcName string) (plugin.Symb
 		// open plugin
 		filePath, err := filepath.Abs(path)
 		if err != nil {
-			return nil, errs.ErrFilePathAbs.Wrap(err).FastGenWithCause()
+			return nil, errs.ErrFilePathAbs.Wrap(err)
 		}
 		log.Info("open plugin file", zap.String("file-path", filePath))
 		plugin, err := plugin.Open(filePath)
 		if err != nil {
-			return nil, errs.ErrLoadPlugin.Wrap(err).FastGenWithCause()
+			return nil, errs.ErrLoadPlugin.Wrap(err)
 		}
 		p.pluginMap[path] = plugin
 	}
 	// get func from plugin
 	f, err := p.pluginMap[path].Lookup(funcName)
 	if err != nil {
-		return nil, errs.ErrLookupPluginFunc.Wrap(err).FastGenWithCause()
+		return nil, errs.ErrLookupPluginFunc.Wrap(err)
 	}
 	return f, nil
 }

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -80,7 +80,7 @@ func (conf *evictLeaderSchedulerConfig) BuildWithArgs(args []string) error {
 
 	id, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
-		return errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause()
+		return errs.ErrStrconvParseUint.Wrap(err)
 	}
 	ranges, err := getKeyRanges(args[1:])
 	if err != nil {

--- a/pkg/schedule/schedulers/grant_leader.go
+++ b/pkg/schedule/schedulers/grant_leader.go
@@ -63,7 +63,7 @@ func (conf *grantLeaderSchedulerConfig) BuildWithArgs(args []string) error {
 
 	id, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
-		return errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause()
+		return errs.ErrStrconvParseUint.Wrap(err)
 	}
 	ranges, err := getKeyRanges(args[1:])
 	if err != nil {

--- a/pkg/schedule/schedulers/init.go
+++ b/pkg/schedule/schedulers/init.go
@@ -129,7 +129,7 @@ func schedulersRegister() {
 
 			id, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
-				return errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause()
+				return errs.ErrStrconvParseUint.Wrap(err)
 			}
 
 			ranges, err := getKeyRanges(args[1:])
@@ -180,14 +180,14 @@ func schedulersRegister() {
 			}
 			leaderID, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
-				return errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause()
+				return errs.ErrStrconvParseUint.Wrap(err)
 			}
 
 			storeIDs := make([]uint64, 0)
 			for _, id := range strings.Split(args[1], ",") {
 				storeID, err := strconv.ParseUint(id, 10, 64)
 				if err != nil {
-					return errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause()
+					return errs.ErrStrconvParseUint.Wrap(err)
 				}
 				storeIDs = append(storeIDs, storeID)
 			}
@@ -248,7 +248,7 @@ func schedulersRegister() {
 
 			id, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
-				return errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause()
+				return errs.ErrStrconvParseUint.Wrap(err)
 			}
 			ranges, err := getKeyRanges(args[1:])
 			if err != nil {
@@ -365,7 +365,7 @@ func schedulersRegister() {
 			if len(args) == 1 {
 				limit, err := strconv.ParseUint(args[0], 10, 64)
 				if err != nil {
-					return errs.ErrStrconvParseUint.Wrap(err).FastGenWithCause()
+					return errs.ErrStrconvParseUint.Wrap(err)
 				}
 				conf.Limit = limit
 			}

--- a/pkg/schedule/schedulers/scheduler.go
+++ b/pkg/schedule/schedulers/scheduler.go
@@ -52,7 +52,7 @@ type Scheduler interface {
 func EncodeConfig(v interface{}) ([]byte, error) {
 	marshaled, err := json.Marshal(v)
 	if err != nil {
-		return nil, errs.ErrJSONMarshal.Wrap(err).FastGenWithCause()
+		return nil, errs.ErrJSONMarshal.Wrap(err)
 	}
 	return marshaled, nil
 }
@@ -61,7 +61,7 @@ func EncodeConfig(v interface{}) ([]byte, error) {
 func DecodeConfig(data []byte, v interface{}) error {
 	err := json.Unmarshal(data, v)
 	if err != nil {
-		return errs.ErrJSONUnmarshal.Wrap(err).FastGenWithCause()
+		return errs.ErrJSONUnmarshal.Wrap(err)
 	}
 	return nil
 }

--- a/pkg/schedule/schedulers/utils.go
+++ b/pkg/schedule/schedulers/utils.go
@@ -218,11 +218,11 @@ func getKeyRanges(args []string) ([]core.KeyRange, error) {
 	for len(args) > 1 {
 		startKey, err := url.QueryUnescape(args[0])
 		if err != nil {
-			return nil, errs.ErrQueryUnescape.Wrap(err).FastGenWithCause()
+			return nil, errs.ErrQueryUnescape.Wrap(err)
 		}
 		endKey, err := url.QueryUnescape(args[1])
 		if err != nil {
-			return nil, errs.ErrQueryUnescape.Wrap(err).FastGenWithCause()
+			return nil, errs.ErrQueryUnescape.Wrap(err)
 		}
 		args = args[2:]
 		ranges = append(ranges, core.NewKeyRange(startKey, endKey))

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -542,7 +542,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	putFn := func(kv *mvccpb.KeyValue) error {
 		group := &endpoint.KeyspaceGroup{}
 		if err := json.Unmarshal(kv.Value, group); err != nil {
-			return errs.ErrJSONUnmarshal.Wrap(err).FastGenWithCause()
+			return errs.ErrJSONUnmarshal.Wrap(err)
 		}
 		kgm.updateKeyspaceGroup(group)
 		if group.ID == mcsutils.DefaultKeyspaceGroupID {

--- a/pkg/utils/logutil/log.go
+++ b/pkg/utils/logutil/log.go
@@ -70,7 +70,7 @@ func StringToZapLogLevel(level string) zapcore.Level {
 func SetupLogger(logConfig log.Config, logger **zap.Logger, logProps **log.ZapProperties, enabled ...bool) error {
 	lg, p, err := log.InitLogger(&logConfig, zap.AddStacktrace(zapcore.FatalLevel))
 	if err != nil {
-		return errs.ErrInitLogger.Wrap(err).FastGenWithCause()
+		return errs.ErrInitLogger.Wrap(err)
 	}
 	*logger = lg
 	*logProps = p

--- a/pkg/utils/tempurl/check_env_linux.go
+++ b/pkg/utils/tempurl/check_env_linux.go
@@ -36,7 +36,7 @@ func checkAddr(addr string) (bool, error) {
 		return s.RemoteAddr.String() == addr || s.LocalAddr.String() == addr
 	})
 	if err != nil {
-		return false, errs.ErrNetstatTCPSocks.Wrap(err).FastGenWithCause()
+		return false, errs.ErrNetstatTCPSocks.Wrap(err)
 	}
 	return len(tabs) < 1, nil
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -470,7 +470,7 @@ func (h *Handler) PluginLoad(pluginPath string) error {
 	// make sure path is in data dir
 	filePath, err := filepath.Abs(pluginPath)
 	if err != nil || !isPathInDirectory(filePath, h.s.GetConfig().DataDir) {
-		return errs.ErrFilePathAbs.Wrap(err).FastGenWithCause()
+		return errs.ErrFilePathAbs.Wrap(err)
 	}
 
 	c.LoadPlugin(pluginPath, ch)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7496

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)
after  
```
[2023/12/06 10:43:25.636 +08:00] [ERROR] [tso_dispatcher.go:498] ["[tso] getTS error after processing requests"] [dc-location=global] [stream-addr=http://127.0.0.1:64317] [error="[PD:client:ErrClientGetTSO]get TSO failed, rpc error: code = Unknown desc = [PD:tso:ErrGenerateTimestamp]generate timestamp failed, requested pd is not leader of cluster"]
```

some example
```
[2023/12/06 11:16:43.550 +08:00] [ERROR] [client_test.go:506] ["[pd] failed to close grpc clientConn"] [error="[PD:grpc:ErrCloseGRPCConn]close gRPC connection failed: test"] [stack="github.com/tikv/pd/tests/integrations/client_test.TestCustomTimeout\n\t/Users/jiangyongbo/github/pd/tests/integrations/client/client_test.go:506\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"]
[2023/12/06 11:16:43.551 +08:00] [ERROR] [client_test.go:507] ["[tso] fetch pending tso requests error"] [error="[PD:client:ErrClientGetTSO]get TSO failed: test"] [stack="github.com/tikv/pd/tests/integrations/client_test.TestCustomTimeout\n\t/Users/jiangyongbo/github/pd/tests/integrations/client/client_test.go:507\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"]
[2023/12/06 11:16:43.551 +08:00] [ERROR] [client_test.go:508] ["send heartbeat message fail"] [error="[PD:grpc:ErrGRPCSend]send request error: test"] [stack="github.com/tikv/pd/tests/integrations/client_test.TestCustomTimeout\n\t/Users/jiangyongbo/github/pd/tests/integrations/client/client_test.go:508\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"]
[2023/12/06 11:16:43.551 +08:00] [ERROR] [client_test.go:509] ["watch gc safe point v2 error"] [error="[PD:client:ErrClientWatchGCSafePointV2Stream]watch gc safe point v2 stream failed: test"] [stack="github.com/tikv/pd/tests/integrations/client_test.TestCustomTimeout\n\t/Users/jiangyongbo/github/pd/tests/integrations/client/client_test.go:509\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1595"]
```

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
