### PR TITLE
mcs: add a switch to dynamically enable scheduling service

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -181,6 +181,8 @@ func (h *confHandler) updateConfig(cfg *config.Config, key string, value interfa
 	case "label-property": // TODO: support changing label-property
 	case "keyspace":
 		return h.updateKeyspaceConfig(cfg, kp[len(kp)-1], value)
+	case "micro-service":
+		return h.updateMicroServiceConfig(cfg, kp[len(kp)-1], value)
 	}
 	return errors.Errorf("config prefix %s not found", kp[0])
 }
@@ -197,6 +199,22 @@ func (h *confHandler) updateKeyspaceConfig(config *config.Config, key string, va
 
 	if updated {
 		err = h.svr.SetKeyspaceConfig(config.Keyspace)
+	}
+	return err
+}
+
+func (h *confHandler) updateMicroServiceConfig(config *config.Config, key string, value interface{}) error {
+	updated, found, err := jsonutil.AddKeyValue(&config.MicroService, key, value)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return errors.Errorf("config item %s not found", key)
+	}
+
+	if updated {
+		err = h.svr.SetMicroServiceConfig(config.MicroService)
 	}
 	return err
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -355,7 +355,7 @@ var once sync.Once
 func (c *RaftCluster) checkServices() {
 	if c.isAPIServiceMode {
 		servers, err := discovery.Discover(c.etcdClient, strconv.FormatUint(c.clusterID, 10), mcsutils.SchedulingServiceName)
-		if err != nil || len(servers) == 0 {
+		if c.opt.GetMicroServiceConfig().IsDynamicSwitchEnabled() && (err != nil || len(servers) == 0) {
 			c.startSchedulingJobs(c, c.hbstreams)
 			c.independentServices.Delete(mcsutils.SchedulingServiceName)
 		} else {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -355,7 +355,7 @@ var once sync.Once
 func (c *RaftCluster) checkServices() {
 	if c.isAPIServiceMode {
 		servers, err := discovery.Discover(c.etcdClient, strconv.FormatUint(c.clusterID, 10), mcsutils.SchedulingServiceName)
-		if c.opt.GetMicroServiceConfig().IsDynamicSwitchEnabled() && (err != nil || len(servers) == 0) {
+		if c.opt.GetMicroServiceConfig().IsSchedulingFallbackEnabled() && (err != nil || len(servers) == 0) {
 			c.startSchedulingJobs(c, c.hbstreams)
 			c.independentServices.Delete(mcsutils.SchedulingServiceName)
 		} else {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -165,6 +165,8 @@ type Config struct {
 
 	Keyspace KeyspaceConfig `toml:"keyspace" json:"keyspace"`
 
+	MicroService MicroServiceConfig `toml:"micro-service" json:"micro-service"`
+
 	Controller rm.ControllerConfig `toml:"controller" json:"controller"`
 }
 
@@ -249,6 +251,8 @@ const (
 	defaultCheckRegionSplitInterval = 50 * time.Millisecond
 	minCheckRegionSplitInterval     = 1 * time.Millisecond
 	maxCheckRegionSplitInterval     = 100 * time.Millisecond
+
+	defaultEnableDynamicSwitch = true
 )
 
 // Special keys for Labels
@@ -460,6 +464,8 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	c.ReplicationMode.adjust(configMetaData.Child("replication-mode"))
 
 	c.Keyspace.adjust(configMetaData.Child("keyspace"))
+
+	c.MicroService.adjust(configMetaData.Child("micro-service"))
 
 	c.Security.Encryption.Adjust()
 
@@ -845,6 +851,28 @@ func (c *DRAutoSyncReplicationConfig) adjust(meta *configutil.ConfigMetaData) {
 	if !meta.IsDefined("wait-store-timeout") {
 		c.WaitStoreTimeout = typeutil.NewDuration(defaultDRWaitStoreTimeout)
 	}
+}
+
+// MicroServiceConfig is the configuration for micro service.
+type MicroServiceConfig struct {
+	EnableDynamicSwitch bool `toml:"enable-dynamic-switch" json:"enable-dynamic-switch,string"`
+}
+
+func (c *MicroServiceConfig) adjust(meta *configutil.ConfigMetaData) {
+	if !meta.IsDefined("enable-dynamic-switch") {
+		c.EnableDynamicSwitch = defaultEnableDynamicSwitch
+	}
+}
+
+// Clone returns a copy of micro service config.
+func (c *MicroServiceConfig) Clone() *MicroServiceConfig {
+	cfg := *c
+	return &cfg
+}
+
+// IsDynamicSwitchEnabled returns whether to enable dynamic switch.
+func (c *MicroServiceConfig) IsDynamicSwitchEnabled() bool {
+	return c.EnableDynamicSwitch
 }
 
 // KeyspaceConfig is the configuration for keyspace management.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -252,7 +252,7 @@ const (
 	minCheckRegionSplitInterval     = 1 * time.Millisecond
 	maxCheckRegionSplitInterval     = 100 * time.Millisecond
 
-	defaultEnableDynamicSwitch = true
+	defaultEnableSchedulingFallback = true
 )
 
 // Special keys for Labels
@@ -855,12 +855,12 @@ func (c *DRAutoSyncReplicationConfig) adjust(meta *configutil.ConfigMetaData) {
 
 // MicroServiceConfig is the configuration for micro service.
 type MicroServiceConfig struct {
-	EnableDynamicSwitch bool `toml:"enable-dynamic-switch" json:"enable-dynamic-switch,string"`
+	EnableSchedulingFallback bool `toml:"enable-scheduling-fallback" json:"enable-scheduling-fallback,string"`
 }
 
 func (c *MicroServiceConfig) adjust(meta *configutil.ConfigMetaData) {
-	if !meta.IsDefined("enable-dynamic-switch") {
-		c.EnableDynamicSwitch = defaultEnableDynamicSwitch
+	if !meta.IsDefined("enable-scheduling-fallback") {
+		c.EnableSchedulingFallback = defaultEnableSchedulingFallback
 	}
 }
 
@@ -870,9 +870,9 @@ func (c *MicroServiceConfig) Clone() *MicroServiceConfig {
 	return &cfg
 }
 
-// IsDynamicSwitchEnabled returns whether to enable dynamic switch.
-func (c *MicroServiceConfig) IsDynamicSwitchEnabled() bool {
-	return c.EnableDynamicSwitch
+// IsSchedulingFallbackEnabled returns whether to enable scheduling service fallback to api service.
+func (c *MicroServiceConfig) IsSchedulingFallbackEnabled() bool {
+	return c.EnableSchedulingFallback
 }
 
 // KeyspaceConfig is the configuration for keyspace management.

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -52,6 +52,7 @@ type PersistOptions struct {
 	replicationMode atomic.Value
 	labelProperty   atomic.Value
 	keyspace        atomic.Value
+	microService    atomic.Value
 	storeConfig     atomic.Value
 	clusterVersion  unsafe.Pointer
 }
@@ -65,6 +66,7 @@ func NewPersistOptions(cfg *Config) *PersistOptions {
 	o.replicationMode.Store(&cfg.ReplicationMode)
 	o.labelProperty.Store(cfg.LabelProperty)
 	o.keyspace.Store(&cfg.Keyspace)
+	o.microService.Store(&cfg.MicroService)
 	// storeConfig will be fetched from TiKV later,
 	// set it to an empty config here first.
 	o.storeConfig.Store(&sc.StoreConfig{})
@@ -131,6 +133,16 @@ func (o *PersistOptions) GetKeyspaceConfig() *KeyspaceConfig {
 // SetKeyspaceConfig sets the keyspace configuration.
 func (o *PersistOptions) SetKeyspaceConfig(cfg *KeyspaceConfig) {
 	o.keyspace.Store(cfg)
+}
+
+// GetMicroServiceConfig returns the micro service configuration.
+func (o *PersistOptions) GetMicroServiceConfig() *MicroServiceConfig {
+	return o.microService.Load().(*MicroServiceConfig)
+}
+
+// SetMicroServiceConfig sets the micro service configuration.
+func (o *PersistOptions) SetMicroServiceConfig(cfg *MicroServiceConfig) {
+	o.microService.Store(cfg)
 }
 
 // GetStoreConfig returns the store config.
@@ -768,6 +780,7 @@ func (o *PersistOptions) Persist(storage endpoint.ConfigStorage) error {
 			ReplicationMode: *o.GetReplicationModeConfig(),
 			LabelProperty:   o.GetLabelPropertyConfig(),
 			Keyspace:        *o.GetKeyspaceConfig(),
+			MicroService:    *o.GetMicroServiceConfig(),
 			ClusterVersion:  *o.GetClusterVersion(),
 		},
 		StoreConfig: *o.GetStoreConfig(),
@@ -799,6 +812,7 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 		o.replicationMode.Store(&cfg.ReplicationMode)
 		o.labelProperty.Store(cfg.LabelProperty)
 		o.keyspace.Store(&cfg.Keyspace)
+		o.microService.Store(&cfg.MicroService)
 		o.storeConfig.Store(&cfg.StoreConfig)
 		o.SetClusterVersion(&cfg.ClusterVersion)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -952,6 +952,7 @@ func (s *Server) GetConfig() *config.Config {
 	cfg.PDServerCfg = *s.persistOptions.GetPDServerConfig().Clone()
 	cfg.ReplicationMode = *s.persistOptions.GetReplicationModeConfig()
 	cfg.Keyspace = *s.persistOptions.GetKeyspaceConfig().Clone()
+	cfg.MicroService = *s.persistOptions.GetMicroServiceConfig().Clone()
 	cfg.LabelProperty = s.persistOptions.GetLabelPropertyConfig().Clone()
 	cfg.ClusterVersion = *s.persistOptions.GetClusterVersion()
 	if s.storage == nil {
@@ -987,6 +988,27 @@ func (s *Server) SetKeyspaceConfig(cfg config.KeyspaceConfig) error {
 	}
 	s.keyspaceManager.UpdateConfig(&cfg)
 	log.Info("keyspace config is updated", zap.Reflect("new", cfg), zap.Reflect("old", old))
+	return nil
+}
+
+// GetMicroServiceConfig gets the micro service config information.
+func (s *Server) GetMicroServiceConfig() *config.MicroServiceConfig {
+	return s.persistOptions.GetMicroServiceConfig().Clone()
+}
+
+// SetMicroServiceConfig sets the micro service config information.
+func (s *Server) SetMicroServiceConfig(cfg config.MicroServiceConfig) error {
+	old := s.persistOptions.GetMicroServiceConfig()
+	s.persistOptions.SetMicroServiceConfig(&cfg)
+	if err := s.persistOptions.Persist(s.storage); err != nil {
+		s.persistOptions.SetMicroServiceConfig(old)
+		log.Error("failed to update micro service config",
+			zap.Reflect("new", cfg),
+			zap.Reflect("old", old),
+			errs.ZapError(err))
+		return err
+	}
+	log.Info("micro service config is updated", zap.Reflect("new", cfg), zap.Reflect("old", old))
 	return nil
 }
 

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -210,7 +210,7 @@ func (suite *serverTestSuite) TestDynamicSwitch() {
 	// Change back to the default value.
 	conf.EnableDynamicSwitch = true
 	leaderServer.SetMicroServiceConfig(*conf)
-	// API server will execute scheduling jobs since there is no scheduler server.
+	// API server will execute scheduling jobs since there is no scheduling server.
 	testutil.Eventually(re, func() bool {
 		return suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})
@@ -249,7 +249,7 @@ func (suite *serverTestSuite) TestDynamicSwitch() {
 func (suite *serverTestSuite) TestDisableDynamicSwitch() {
 	re := suite.Require()
 
-	// API server will execute scheduling jobs since there is no scheduler server.
+	// API server will execute scheduling jobs since there is no scheduling server.
 	testutil.Eventually(re, func() bool {
 		return suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -203,12 +203,12 @@ func (suite *serverTestSuite) TestForwardStoreHeartbeat() {
 	})
 }
 
-func (suite *serverTestSuite) TestDynamicSwitch() {
+func (suite *serverTestSuite) TestSchedulingServiceFallback() {
 	re := suite.Require()
 	leaderServer := suite.pdLeader.GetServer()
 	conf := leaderServer.GetMicroServiceConfig().Clone()
 	// Change back to the default value.
-	conf.EnableDynamicSwitch = true
+	conf.EnableSchedulingFallback = true
 	leaderServer.SetMicroServiceConfig(*conf)
 	// API server will execute scheduling jobs since there is no scheduling server.
 	testutil.Eventually(re, func() bool {
@@ -246,7 +246,7 @@ func (suite *serverTestSuite) TestDynamicSwitch() {
 	})
 }
 
-func (suite *serverTestSuite) TestDisableDynamicSwitch() {
+func (suite *serverTestSuite) TestDisableSchedulingServiceFallback() {
 	re := suite.Require()
 
 	// API server will execute scheduling jobs since there is no scheduling server.
@@ -254,15 +254,15 @@ func (suite *serverTestSuite) TestDisableDynamicSwitch() {
 		return suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})
 	leaderServer := suite.pdLeader.GetServer()
-	// After Disabling dynamic switch, the API server will stop scheduling.
+	// After Disabling scheduling service fallback, the API server will stop scheduling.
 	conf := leaderServer.GetMicroServiceConfig().Clone()
-	conf.EnableDynamicSwitch = false
+	conf.EnableSchedulingFallback = false
 	leaderServer.SetMicroServiceConfig(*conf)
 	testutil.Eventually(re, func() bool {
 		return !suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})
-	// Enable dynamic switch again, the API server will restart scheduling.
-	conf.EnableDynamicSwitch = true
+	// Enable scheduling service fallback again, the API server will restart scheduling.
+	conf.EnableSchedulingFallback = true
 	leaderServer.SetMicroServiceConfig(*conf)
 	testutil.Eventually(re, func() bool {
 		return suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
@@ -280,8 +280,8 @@ func (suite *serverTestSuite) TestDisableDynamicSwitch() {
 	testutil.Eventually(re, func() bool {
 		return tc.GetPrimaryServer().GetCluster().IsBackgroundJobsRunning()
 	})
-	// Disable dynamic switch and stop scheduling server. API server won't execute scheduling jobs again.
-	conf.EnableDynamicSwitch = false
+	// Disable scheduling service fallback and stop scheduling server. API server won't execute scheduling jobs again.
+	conf.EnableSchedulingFallback = false
 	leaderServer.SetMicroServiceConfig(*conf)
 	tc.GetPrimaryServer().Close()
 	time.Sleep(time.Second)

--- a/tests/server/api/operator_test.go
+++ b/tests/server/api/operator_test.go
@@ -465,7 +465,7 @@ func (suite *operatorTestSuite) checkTransferRegionWithPlacementRule(cluster *te
 		err := tu.CheckPostJSON(testDialClient, url, reqData, tu.StatusOK(re))
 		re.NoError(err)
 		if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
-			// wait for the scheduler server to update the config
+			// wait for the scheduling server to update the config
 			tu.Eventually(re, func() bool {
 				return sche.GetCluster().GetCheckerConfig().IsPlacementRulesEnabled() == testCase.placementRuleEnable
 			})

--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -1437,7 +1437,7 @@ func (suite *regionRuleTestSuite) checkRegionPlacementRule(cluster *tests.TestCl
 	err = tu.CheckPostJSON(testDialClient, u, reqData, tu.StatusOK(re))
 	re.NoError(err)
 	if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
-		// wait for the scheduler server to update the config
+		// wait for the scheduling server to update the config
 		tu.Eventually(re, func() bool {
 			return !sche.GetCluster().GetCheckerConfig().IsPlacementRulesEnabled()
 		})

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -1115,30 +1115,30 @@ func (suite *configTestSuite) TestMicroServiceConfig() {
 	suite.env.RunTestInTwoModes(suite.checkMicroServiceConfig)
 }
 
-func (suite *configTestSuite) checkMicroServiceConfig(cluster *tests.TestCluster) {
+func (suite *configTestSuite) checkMicroServiceConfig(cluster *pdTests.TestCluster) {
 	re := suite.Require()
 	leaderServer := cluster.GetLeaderServer()
 	pdAddr := leaderServer.GetAddr()
-	cmd := pdctlCmd.GetRootCmd()
+	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
 		Id:            1,
 		State:         metapb.StoreState_Up,
 		LastHeartbeat: time.Now().UnixNano(),
 	}
-	tests.MustPutStore(re, cluster, store)
+	pdTests.MustPutStore(re, cluster, store)
 	svr := leaderServer.GetServer()
-	output, err := pdctl.ExecuteCommand(cmd, "-u", pdAddr, "config", "show", "all")
+	output, err := tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "show", "all")
 	re.NoError(err)
 	cfg := config.Config{}
 	re.NoError(json.Unmarshal(output, &cfg))
-	re.True(svr.GetMicroServiceConfig().EnableDynamicSwitch)
-	re.True(cfg.MicroService.EnableDynamicSwitch)
-	// config set enable-dynamic-switch <value>
-	args := []string{"-u", pdAddr, "config", "set", "enable-dynamic-switch", "false"}
-	_, err = pdctl.ExecuteCommand(cmd, args...)
+	re.True(svr.GetMicroServiceConfig().EnableSchedulingFallback)
+	re.True(cfg.MicroService.EnableSchedulingFallback)
+	// config set enable-scheduling-fallback <value>
+	args := []string{"-u", pdAddr, "config", "set", "enable-scheduling-fallback", "false"}
+	_, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
-	re.False(svr.GetMicroServiceConfig().EnableDynamicSwitch)
+	re.False(svr.GetMicroServiceConfig().EnableSchedulingFallback)
 }
 
 func assertBundles(re *require.Assertions, a, b []placement.GroupBundle) {

--- a/tools/pd-ctl/tests/operator/operator_test.go
+++ b/tools/pd-ctl/tests/operator/operator_test.go
@@ -226,7 +226,7 @@ func (suite *operatorTestSuite) checkOperator(cluster *pdTests.TestCluster) {
 	_, err = tests.ExecuteCommand(cmd, "config", "set", "enable-placement-rules", "true")
 	re.NoError(err)
 	if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
-		// wait for the scheduler server to update the config
+		// wait for the scheduling server to update the config
 		testutil.Eventually(re, func() bool {
 			return sche.GetCluster().GetCheckerConfig().IsPlacementRulesEnabled()
 		})


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5839.

### What is changed and how does it work?

This PR adds a switch to dynamically enable scheduling service. If we only upgrade the scheduling service, the logic could be different from the logic inside the api service. To avoid the changes of different logic bringing some troubles, we use a config to let the users control it by themselves.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
