### PR TITLE
fix: fix update-dashboard script not work when target is semver style

### DIFF
--- a/scripts/dashboard-version
+++ b/scripts/dashboard-version
@@ -1,3 +1,4 @@
 # This file is updated by running scripts/update-dashboard.sh
 # Don't edit it manullay
+# the version will become X.Y.Z-<commit-short-hash> format later
 2023.12.18.1

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -5,21 +5,40 @@ CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 BASE_DIR="$(dirname "$CUR_DIR")"
 DASHBOARD_VERSION_FILE="$BASE_DIR/scripts/dashboard-version"
 # old version
-DASHBOARD_VERSION=$(grep -v '^#' "$DASHBOARD_VERSION_FILE")
+DASHBOARD_VERSION=v$(grep -v '^#' "$DASHBOARD_VERSION_FILE")
 
 # new version
 # Usage: ./scripts/update-dashboard.sh <version>
-# Example: ./scripts/update-dashboard.sh 2023.12.18.1
+# Example: ./scripts/update-dashboard.sh v7.6.0-f7bbcdcf
 if [ "$#" -ge 1 ]; then
   DASHBOARD_VERSION=$1
-  echo $1 > $DASHBOARD_VERSION_FILE
+
+  # if DASHBOARD_VERSION not start with `v`, then exit
+  if [[ ! $DASHBOARD_VERSION =~ ^v[0-9]+\. ]]; then
+    echo "Invalid dashboard version: $DASHBOARD_VERSION, it should start with \"v\""
+    exit 1
+  fi
+
+  # when writing to DASHBOARD_VERSION_FILE, remove the leading `v`,
+  # so that we don't need to modify the embed-dashboard-ui.sh logic
+  TO_FILE_VERSION=${DASHBOARD_VERSION#v}
+
+  echo "# This file is updated by running scripts/update-dashboard.sh" > $DASHBOARD_VERSION_FILE
+  echo "# Don't edit it manullay" >> $DASHBOARD_VERSION_FILE
+  echo $TO_FILE_VERSION >> $DASHBOARD_VERSION_FILE
 fi
 
-echo "+ Update dashboard version to v$DASHBOARD_VERSION"
+echo "+ Update dashboard version to $DASHBOARD_VERSION"
 
 cd $BASE_DIR
 
-go get -d github.com/pingcap/tidb-dashboard@v$DASHBOARD_VERSION
+# if DASHBOARD_VERSION match "vX.Y.Z-<commit-short-hash>" format,
+# then extract the commit hash as tidb-dashboard target
+if [[ $DASHBOARD_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]{7,8} ]]; then
+  DASHBOARD_VERSION=$(echo $DASHBOARD_VERSION | cut -d'-' -f2)
+fi
+
+go get -d github.com/pingcap/tidb-dashboard@$DASHBOARD_VERSION
 go mod tidy
 make pd-server
 go mod tidy


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7637 

### What is changed and how does it work?

This PR fix the `scripts/update-dashboard` script can't work with dashboard semver style version format.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
none
```

### Test

```
❯ scripts/update-dashboard.sh v7.6.0-f7bbcdcf-test
+ Update dashboard version to v7.6.0-f7bbcdcf-test
go: upgraded github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c => v0.0.0-20231228101154-f7bbcdcf902c
./scripts/embed-dashboard-ui.sh
+ Clean up existing asset file
+ Fetch TiDB Dashboard Go module
  - TiDB Dashboard directory: /home/bao/go/pkg/mod/github.com/pingcap/tidb-dashboard@v0.0.0-20231228101154-f7bbcdcf902c
+ Create download cache directory: /mnt/bao/codes/work/pd/.dashboard_download_cache
+ Discover TiDB Dashboard release version
  - TiDB Dashboard release version: 7.6.0-f7bbcdcf-test
+ Check whether pre-built assets are available
  - Cached archive does not exist
  - Download pre-built embedded assets from GitHub release
  - Download https://github.com/pingcap/tidb-dashboard/releases/download/v7.6.0-f7bbcdcf-test/embedded-assets-golang.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 12.1M  100 12.1M    0     0  2419k      0  0:00:05  0:00:05 --:--:-- 2878k
  - Save archive to cache: /mnt/bao/codes/work/pd/.dashboard_download_cache/embedded-assets-golang-7.6.0-f7bbcdcf-test.zip
+ Unpack embedded asset from archive
Archive:  /mnt/bao/codes/work/pd/.dashboard_download_cache/embedded-assets-golang-7.6.0-f7bbcdcf-test.zip
  inflating: embedded_assets_handler.go  
  - Unpacked /mnt/bao/codes/work/pd/pkg/dashboard/uiserver/embedded_assets_handler.go
GOEXPERIMENT= CGO_ENABLED=1 go build  -gcflags '' -ldflags '-X "github.com/tikv/pd/pkg/versioninfo.PDReleaseVersion=v7.6.0-alpha-157-gc7644be0e-dirty" -X "github.com/tikv/pd/pkg/versioninfo.PDBuildTS=2023-12-29 03:20:07" -X "github.com/tikv/pd/pkg/versioninfo.PDGitHash=c7644be0e86d28719b428f22ceec778ee143696a" -X "github.com/tikv/pd/pkg/versioninfo.PDGitBranch=master" -X "github.com/tikv/pd/pkg/versioninfo.PDEdition=Community" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.InternalVersion=7.6.0-f7bbcdcf-test" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.Standalone=No" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.PDVersion=v7.6.0-alpha-157-gc7644be0e-dirty" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildTime=2023-12-29 03:20:07" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildGitHash=f7bbcdcf902c"' -tags "" -o /mnt/bao/codes/work/pd/bin/pd-server cmd/pd-server/main.go
```

```
❯ scripts/update-dashboard.sh v2023.12.18.1                   
+ Update dashboard version to v2023.12.18.1
go: downgraded github.com/pingcap/tidb-dashboard v0.0.0-20231228101154-f7bbcdcf902c => v0.0.0-20231218095437-aa621ed4de2c
./scripts/embed-dashboard-ui.sh
+ Clean up existing asset file
+ Fetch TiDB Dashboard Go module
  - TiDB Dashboard directory: /home/bao/go/pkg/mod/github.com/pingcap/tidb-dashboard@v0.0.0-20231218095437-aa621ed4de2c
+ Create download cache directory: /mnt/bao/codes/work/pd/.dashboard_download_cache
+ Discover TiDB Dashboard release version
  - TiDB Dashboard release version: 2023.12.18.1
+ Check whether pre-built assets are available
  - Cached archive exists: /mnt/bao/codes/work/pd/.dashboard_download_cache/embedded-assets-golang-2023.12.18.1.zip
+ Unpack embedded asset from archive
Archive:  /mnt/bao/codes/work/pd/.dashboard_download_cache/embedded-assets-golang-2023.12.18.1.zip
  inflating: embedded_assets_handler.go  
  - Unpacked /mnt/bao/codes/work/pd/pkg/dashboard/uiserver/embedded_assets_handler.go
GOEXPERIMENT= CGO_ENABLED=1 go build  -gcflags '' -ldflags '-X "github.com/tikv/pd/pkg/versioninfo.PDReleaseVersion=v7.6.0-alpha-157-gc7644be0e-dirty" -X "github.com/tikv/pd/pkg/versioninfo.PDBuildTS=2023-12-29 03:21:38" -X "github.com/tikv/pd/pkg/versioninfo.PDGitHash=c7644be0e86d28719b428f22ceec778ee143696a" -X "github.com/tikv/pd/pkg/versioninfo.PDGitBranch=master" -X "github.com/tikv/pd/pkg/versioninfo.PDEdition=Community" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.InternalVersion=2023.12.18.1" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.Standalone=No" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.PDVersion=v7.6.0-alpha-157-gc7644be0e-dirty" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildTime=2023-12-29 03:21:38" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildGitHash=aa621ed4de2c"' -tags "" -o /mnt/bao/codes/work/pd/bin/pd-server cmd/pd-server/main.go
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
