### PR TITLE
chore(dashboard): update TiDB Dashboard to v7.6.0-473bf80a [master]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20231222062942-c0c73f41d0b2
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c
+	github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/common v0.26.0
 	github.com/sasha-s/go-deadlock v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -462,8 +462,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c h1:iEZwsxxOxXaH0zEfzVAn6fjveOlPh3v3DsYlhWJAVi0=
-github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
+github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2 h1:5GB9XSo9tDdjxEzoiibA9rPgrE0YUSKrPmPYZym8dY0=
+github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/scripts/dashboard-version
+++ b/scripts/dashboard-version
@@ -1,4 +1,3 @@
 # This file is updated by running scripts/update-dashboard.sh
 # Don't edit it manullay
-# the version will become X.Y.Z-<commit-short-hash> format later
-2023.12.18.1
+7.6.0-473bf80a

--- a/scripts/update-dashboard.sh
+++ b/scripts/update-dashboard.sh
@@ -45,3 +45,6 @@ go mod tidy
 
 cd ./tests/integrations
 go mod tidy
+
+cd ../../tools
+go mod tidy

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -439,8 +439,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c h1:iEZwsxxOxXaH0zEfzVAn6fjveOlPh3v3DsYlhWJAVi0=
-github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
+github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2 h1:5GB9XSo9tDdjxEzoiibA9rPgrE0YUSKrPmPYZym8dY0=
+github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -438,8 +438,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c h1:iEZwsxxOxXaH0zEfzVAn6fjveOlPh3v3DsYlhWJAVi0=
-github.com/pingcap/tidb-dashboard v0.0.0-20231218095437-aa621ed4de2c/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
+github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2 h1:5GB9XSo9tDdjxEzoiibA9rPgrE0YUSKrPmPYZym8dY0=
+github.com/pingcap/tidb-dashboard v0.0.0-20231229113139-473bf80ad4f2/go.mod h1:ucZBRz52icb23T/5Z4CsuUHmarYiin7p2MeiVBe+o8c=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
### What problem does this PR solve?

Close #7646  , fix instance profiling white screen page issue

Issue Number: ref #4257

Update TiDB Dashboard to [v7.6.0-473bf80a](https://github.com/pingcap/tidb-dashboard/releases/tag/v7.6.0-473bf80a).

This PR also support TiProxy & TiCDC components in tidb-dashboard.

### Release note

```release-note
1. Support showing TiProxy & TiCDC components
```

### Test

```
$ make pd-server
$ tiup playground nightly --pd.binpath ./bin/pd-server --tiflash 0 --tiproxy 1   --ticdc 1
```


![image](https://github.com/tikv/pd/assets/1284531/a4758c71-dacb-4313-97ea-b4d070bf3f26)

![image](https://github.com/tikv/pd/assets/1284531/2acfc4c9-bd44-4285-acfa-9ba9af51ca6c)
