### PR TITLE
client/http: do not retry the 4XX code returned by leader

### DIFF
--- a/client/http/client.go
+++ b/client/http/client.go
@@ -147,6 +147,7 @@ func (ci *clientInner) requestWithRetry(
 	headerOpts ...HeaderOption,
 ) error {
 	var (
+		statusCode             int
 		err                    error
 		addr                   string
 		pdAddrs, leaderAddrIdx = ci.getPDAddrs()
@@ -154,9 +155,10 @@ func (ci *clientInner) requestWithRetry(
 	// Try to send the request to the PD leader first.
 	if leaderAddrIdx != -1 {
 		addr = pdAddrs[leaderAddrIdx]
-		err = ci.doRequest(ctx, addr, reqInfo, headerOpts...)
-		if err == nil {
-			return nil
+		statusCode, err = ci.doRequest(ctx, addr, reqInfo, headerOpts...)
+		// No need to retry if there is no error or the status code is 404 returned by the PD leader.
+		if err == nil || statusCode == http.StatusNotFound {
+			return err
 		}
 		log.Debug("[pd] request leader addr failed",
 			zap.String("source", ci.source), zap.Int("leader-idx", leaderAddrIdx), zap.String("addr", addr), zap.Error(err))
@@ -167,7 +169,9 @@ func (ci *clientInner) requestWithRetry(
 			continue
 		}
 		addr = ci.pdAddrs[idx]
-		err = ci.doRequest(ctx, addr, reqInfo, headerOpts...)
+		_, err = ci.doRequest(ctx, addr, reqInfo, headerOpts...)
+		// Since some requests are allowed to be processed by the PD followers, retry should be performed
+		// even though the status code is 404 to take a chance that other PD followers could handle it.
 		if err == nil {
 			break
 		}
@@ -181,7 +185,7 @@ func (ci *clientInner) doRequest(
 	ctx context.Context,
 	addr string, reqInfo *requestInfo,
 	headerOpts ...HeaderOption,
-) error {
+) (int, error) {
 	var (
 		source      = ci.source
 		callerID    = reqInfo.callerID
@@ -203,7 +207,7 @@ func (ci *clientInner) doRequest(
 	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
 	if err != nil {
 		log.Error("[pd] create http request failed", append(logFields, zap.Error(err))...)
-		return errors.Trace(err)
+		return -1, errors.Trace(err)
 	}
 	for _, opt := range headerOpts {
 		opt(req.Header)
@@ -215,14 +219,14 @@ func (ci *clientInner) doRequest(
 	if err != nil {
 		ci.reqCounter(name, networkErrorStatus)
 		log.Error("[pd] do http request failed", append(logFields, zap.Error(err))...)
-		return errors.Trace(err)
+		return -1, errors.Trace(err)
 	}
 	ci.execDuration(name, time.Since(start))
 	ci.reqCounter(name, resp.Status)
 
 	// Give away the response handling to the caller if the handler is set.
 	if respHandler != nil {
-		return respHandler(resp, res)
+		return resp.StatusCode, respHandler(resp, res)
 	}
 
 	defer func() {
@@ -243,18 +247,18 @@ func (ci *clientInner) doRequest(
 		}
 
 		log.Error("[pd] request failed with a non-200 status", logFields...)
-		return errors.Errorf("request pd http api failed with status: '%s'", resp.Status)
+		return resp.StatusCode, errors.Errorf("request pd http api failed with status: '%s'", resp.Status)
 	}
 
 	if res == nil {
-		return nil
+		return resp.StatusCode, nil
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(res)
 	if err != nil {
-		return errors.Trace(err)
+		return resp.StatusCode, errors.Trace(err)
 	}
-	return nil
+	return resp.StatusCode, nil
 }
 
 func (ci *clientInner) membersInfoUpdater(ctx context.Context) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7300.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
When the PD leader returns a 404 status code, it no longer continues to retry but returns directly.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
