### PR TITLE
client: fix panic when checking resp error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
@@ -1042,6 +1043,9 @@ func (c *client) ScanRegions(ctx context.Context, key, endKey []byte, limit int,
 		return nil, errs.ErrClientGetProtoClient
 	}
 	resp, err := pdpb.NewPDClient(serviceClient.GetClientConn()).ScanRegions(cctx, req)
+	failpoint.Inject("responseNil", func() {
+		resp = nil
+	})
 	if serviceClient.NeedRetry(resp.GetHeader().GetError(), err) {
 		protoClient, cctx := c.getClientAndContext(scanCtx)
 		if protoClient == nil {

--- a/client/client.go
+++ b/client/client.go
@@ -1042,7 +1042,7 @@ func (c *client) ScanRegions(ctx context.Context, key, endKey []byte, limit int,
 		return nil, errs.ErrClientGetProtoClient
 	}
 	resp, err := pdpb.NewPDClient(serviceClient.GetClientConn()).ScanRegions(cctx, req)
-	if !serviceClient.IsConnectedToLeader() && err != nil || resp.Header.GetError() != nil {
+	if serviceClient.NeedRetry(resp.GetHeader().GetError(), err) {
 		protoClient, cctx := c.getClientAndContext(scanCtx)
 		if protoClient == nil {
 			return nil, errs.ErrClientGetProtoClient
@@ -1245,8 +1245,8 @@ func (c *client) scatterRegionsWithGroup(ctx context.Context, regionID uint64, g
 	if err != nil {
 		return err
 	}
-	if resp.Header.GetError() != nil {
-		return errors.Errorf("scatter region %d failed: %s", regionID, resp.Header.GetError().String())
+	if resp.GetHeader().GetError() != nil {
+		return errors.Errorf("scatter region %d failed: %s", regionID, resp.GetHeader().GetError().String())
 	}
 	return nil
 }
@@ -1369,8 +1369,8 @@ func (c *client) scatterRegionsWithOptions(ctx context.Context, regionsID []uint
 	if err != nil {
 		return nil, err
 	}
-	if resp.Header.GetError() != nil {
-		return nil, errors.Errorf("scatter regions %v failed: %s", regionsID, resp.Header.GetError().String())
+	if resp.GetHeader().GetError() != nil {
+		return nil, errors.Errorf("scatter regions %v failed: %s", regionsID, resp.GetHeader().GetError().String())
 	}
 	return resp, nil
 }

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -617,6 +617,15 @@ func (suite *followerForwardAndHandleTestSuite) TestGetTsoByFollowerForwarding1(
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/unreachableNetwork"))
 	time.Sleep(2 * time.Second)
 	checkTS(re, cli, lastTS)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/client/responseNil", "return(true)"))
+	regions, err := cli.ScanRegions(ctx, []byte(""), []byte(""), 100)
+	re.NoError(err)
+	re.Len(regions, 0)
+	re.NoError(failpoint.Disable("github.com/tikv/pd/client/responseNil"))
+	regions, err = cli.ScanRegions(ctx, []byte(""), []byte(""), 100)
+	re.NoError(err)
+	re.Len(regions, 1)
 }
 
 // case 2: unreachable -> leader transfer -> normal

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -621,7 +621,7 @@ func (suite *followerForwardAndHandleTestSuite) TestGetTsoByFollowerForwarding1(
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/responseNil", "return(true)"))
 	regions, err := cli.ScanRegions(ctx, []byte(""), []byte(""), 100)
 	re.NoError(err)
-	re.Len(regions, 0)
+	re.Empty(regions)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/responseNil"))
 	regions, err = cli.ScanRegions(ctx, []byte(""), []byte(""), 100)
 	re.NoError(err)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7676

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Integration test

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
