### PR TITLE
pd-ctl: add `region rule` to get the detail of region fit rule

### DIFF
--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -48,6 +48,7 @@ var (
 	regionsKeyspacePrefix   = "pd/api/v1/regions/keyspace"
 	regionIDPrefix          = "pd/api/v1/region/id"
 	regionKeyPrefix         = "pd/api/v1/region/key"
+	regionRulePrefix        = "pd/api/v1/config/rules/region"
 )
 
 // NewRegionCommand returns a region subcommand of rootCmd
@@ -129,6 +130,14 @@ func NewRegionCommand() *cobra.Command {
 	scanRegion.Flags().String("jq", "", "jq query")
 	r.AddCommand(scanRegion)
 
+	rulesDetail := &cobra.Command{
+		Use:   `rules <region_id>`,
+		Short: "show rules detail of this region",
+		Run:   showRulesDetailCommandFunc,
+	}
+	rulesDetail.Flags().Bool(flagFromAPIServer, false, "read data from api server rather than micor service")
+	r.AddCommand(rulesDetail)
+
 	r.Flags().String("jq", "", "jq query")
 
 	return r
@@ -153,6 +162,25 @@ func showRegionCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	cmd.Println(r)
+}
+
+func showRulesDetailCommandFunc(cmd *cobra.Command, args []string) {
+	if len(args) < 1 {
+		cmd.Usage()
+		return
+	}
+	if _, err := strconv.Atoi(args[0]); err != nil {
+		cmd.Println("region_id should be a number")
+		return
+	}
+	prefix := regionRulePrefix + "/" + args[0] + "/detail"
+	header := buildHeader(cmd)
+	r, err := doRequest(cmd, prefix, http.MethodGet, header)
+	if err != nil {
+		cmd.Printf("Failed to get region: %s\n", err)
+		return
+	}
 	cmd.Println(r)
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7690

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
```
./pd/bin/pd-ctl -u http://127.0.0.1:59935 region rules 54                         ~ 
{
  "rule-fits": [
    {
      "rule": {
        "group_id": "pd",
        "id": "default",
        "start_key": "",
        "end_key": "",
        "role": "voter",
        "is_witness": false,
        "count": 3
      },
      "peers": [
        {
          "id": 55,
          "store_id": 1
        },
        {
          "id": 147,
          "store_id": 3
        },
        {
          "id": 249,
          "store_id": 2
        }
      ],
      "peers-different-role": null,
      "isolation-score": 0,
      "witness-score": 0
    }
  ],
  "orphan-peers": null
}
```

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
