### PR TITLE
http: add Admin API and Config with TTL API

### DIFF
--- a/client/http/request_info.go
+++ b/client/http/request_info.go
@@ -39,6 +39,8 @@ const (
 	getStoresName                           = "GetStores"
 	getStoreName                            = "GetStore"
 	setStoreLabelsName                      = "SetStoreLabels"
+	getConfigName                           = "GetConfig"
+	setConfigName                           = "SetConfig"
 	getScheduleConfigName                   = "GetScheduleConfig"
 	setScheduleConfigName                   = "SetScheduleConfig"
 	getClusterVersionName                   = "GetClusterVersion"
@@ -69,6 +71,10 @@ const (
 	getMinResolvedTSByStoresIDsName         = "GetMinResolvedTSByStoresIDs"
 	getMicroServiceMembersName              = "GetMicroServiceMembers"
 	getPDVersionName                        = "GetPDVersion"
+	resetTSName                             = "ResetTS"
+	resetBaseAllocIDName                    = "ResetBaseAllocID"
+	setSnapshotRecoveringMarkName           = "SetSnapshotRecoveringMark"
+	deleteSnapshotRecoveringMarkName        = "DeleteSnapshotRecoveringMark"
 )
 
 type requestInfo struct {

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -27,7 +27,7 @@ import (
 	pd "github.com/tikv/pd/client/http"
 	"github.com/tikv/pd/client/retry"
 	"github.com/tikv/pd/pkg/core"
-	config2 "github.com/tikv/pd/pkg/schedule/config"
+	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -420,7 +420,7 @@ func (suite *httpClientTestSuite) TestConfig() {
 	}
 	err = suite.client.SetConfig(suite.ctx, newConfig, 5)
 	re.NoError(err)
-	resp, err := suite.cluster.GetEtcdClient().Get(suite.ctx, config2.TTLConfigPrefix+"/schedule.leader-schedule-limit")
+	resp, err := suite.cluster.GetEtcdClient().Get(suite.ctx, sc.TTLConfigPrefix+"/schedule.leader-schedule-limit")
 	re.NoError(err)
 	re.Equal([]byte("16"), resp.Kvs[0].Value)
 }

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -397,6 +397,30 @@ func (suite *httpClientTestSuite) TestAccelerateSchedule() {
 	re.Len(suspectRegions, 2)
 }
 
+func (suite *httpClientTestSuite) TestConfig() {
+	re := suite.Require()
+	config, err := suite.client.GetConfig(suite.ctx)
+	re.NoError(err)
+	re.Equal(float64(4), config["schedule"].(map[string]interface{})["leader-schedule-limit"])
+
+	newConfig := map[string]interface{}{
+		"schedule.leader-schedule-limit": float64(8),
+	}
+	err = suite.client.SetConfig(suite.ctx, newConfig)
+	re.NoError(err)
+
+	config, err = suite.client.GetConfig(suite.ctx)
+	re.NoError(err)
+	re.Equal(float64(8), config["schedule"].(map[string]interface{})["leader-schedule-limit"])
+
+	// Test the config with TTL.
+	newConfig = map[string]interface{}{
+		"schedule.leader-schedule-limit": float64(16),
+	}
+	err = suite.client.SetConfig(suite.ctx, newConfig, 1)
+	re.NoError(err)
+}
+
 func (suite *httpClientTestSuite) TestScheduleConfig() {
 	re := suite.Require()
 	config, err := suite.client.GetScheduleConfig(suite.ctx)
@@ -490,6 +514,18 @@ func (suite *httpClientTestSuite) TestVersion() {
 	ver, err := suite.client.GetPDVersion(suite.ctx)
 	re.NoError(err)
 	re.Equal(versioninfo.PDReleaseVersion, ver)
+}
+
+func (suite *httpClientTestSuite) TestAdmin() {
+	re := suite.Require()
+	err := suite.client.SetSnapshotRecoveringMark(suite.ctx)
+	re.NoError(err)
+	err = suite.client.ResetTS(suite.ctx, 123, true)
+	re.NoError(err)
+	err = suite.client.ResetBaseAllocID(suite.ctx, 456)
+	re.NoError(err)
+	err = suite.client.DeleteSnapshotRecoveringMark(suite.ctx)
+	re.NoError(err)
 }
 
 func (suite *httpClientTestSuite) TestWithBackoffer() {

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -27,6 +27,7 @@ import (
 	pd "github.com/tikv/pd/client/http"
 	"github.com/tikv/pd/client/retry"
 	"github.com/tikv/pd/pkg/core"
+	config2 "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -417,8 +418,11 @@ func (suite *httpClientTestSuite) TestConfig() {
 	newConfig = map[string]interface{}{
 		"schedule.leader-schedule-limit": float64(16),
 	}
-	err = suite.client.SetConfig(suite.ctx, newConfig, 1)
+	err = suite.client.SetConfig(suite.ctx, newConfig, 5)
 	re.NoError(err)
+	resp, err := suite.cluster.GetEtcdClient().Get(suite.ctx, config2.TTLConfigPrefix+"/schedule.leader-schedule-limit")
+	re.NoError(err)
+	re.Equal([]byte("16"), resp.Kvs[0].Value)
 }
 
 func (suite *httpClientTestSuite) TestScheduleConfig() {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7300 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
