### PR TITLE
api: optional return operators as JSON object

### DIFF
--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -324,7 +324,8 @@ func getOperatorByRegion(c *gin.Context) {
 
 // @Tags     operators
 // @Summary  List operators.
-// @Param    kind  query  string  false  "Specify the operator kind."  Enums(admin, leader, region, waiting)
+// @Param    kind   query  string  false  "Specify the operator kind."  Enums(admin, leader, region, waiting)
+// @Param    object query  bool    false  "Whether to return as JSON object."
 // @Produce  json
 // @Success  200  {array}   operator.Operator
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
@@ -337,6 +338,7 @@ func getOperators(c *gin.Context) {
 	)
 
 	kinds := c.QueryArray("kind")
+	_, objectFlag := c.GetQuery("object")
 	if len(kinds) == 0 {
 		results, err = handler.GetOperators()
 	} else {
@@ -347,7 +349,15 @@ func getOperators(c *gin.Context) {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}
-	c.IndentedJSON(http.StatusOK, results)
+	if objectFlag {
+		objResults := make([]*operator.OpObject, len(results))
+		for i, op := range results {
+			objResults[i] = op.ToJSONObject()
+		}
+		c.IndentedJSON(http.StatusOK, objResults)
+	} else {
+		c.IndentedJSON(http.StatusOK, results)
+	}
 }
 
 // @Tags     operator

--- a/pkg/schedule/operator/operator.go
+++ b/pkg/schedule/operator/operator.go
@@ -149,6 +149,39 @@ func (o *Operator) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + o.String() + `"`), nil
 }
 
+// OpObject is used to return Operator as a json object for API.
+type OpObject struct {
+	Desc        string              `json:"desc"`
+	Brief       string              `json:"brief"`
+	RegionID    uint64              `json:"region_id"`
+	RegionEpoch *metapb.RegionEpoch `json:"region_epoch"`
+	Kind        OpKind              `json:"kind"`
+	Timeout     string              `json:"timeout"`
+	Status      OpStatus            `json:"status"`
+}
+
+// ToJSONObject serializes Operator as JSON object.
+func (o *Operator) ToJSONObject() *OpObject {
+	var status OpStatus
+	if o.CheckSuccess() {
+		status = SUCCESS
+	} else if o.CheckTimeout() {
+		status = TIMEOUT
+	} else {
+		status = o.Status()
+	}
+
+	return &OpObject{
+		Desc:        o.desc,
+		Brief:       o.brief,
+		RegionID:    o.regionID,
+		RegionEpoch: o.regionEpoch,
+		Kind:        o.kind,
+		Timeout:     o.timeout.String(),
+		Status:      status,
+	}
+}
+
 // Desc returns the operator's short description.
 func (o *Operator) Desc() string {
 	return o.desc

--- a/pkg/schedule/operator/operator_test.go
+++ b/pkg/schedule/operator/operator_test.go
@@ -545,8 +545,8 @@ func (suite *operatorTestSuite) TestRecord() {
 func (suite *operatorTestSuite) TestToJSONObject() {
 	steps := []OpStep{
 		AddPeer{ToStore: 1, PeerID: 1},
-		TransferLeader{FromStore: 2, ToStore: 1},
-		RemovePeer{FromStore: 2},
+		TransferLeader{FromStore: 3, ToStore: 1},
+		RemovePeer{FromStore: 3},
 	}
 	op := suite.newTestOperator(101, OpLeader|OpRegion, steps...)
 	op.Start()
@@ -557,4 +557,20 @@ func (suite *operatorTestSuite) TestToJSONObject() {
 	suite.Equal(OpLeader|OpRegion, obj.Kind)
 	suite.Equal("12m0s", obj.Timeout)
 	suite.Equal(STARTED, obj.Status)
+
+	// Test SUCCESS status.
+	region := suite.newTestRegion(1, 1, [2]uint64{1, 1}, [2]uint64{2, 2})
+	suite.Nil(op.Check(region))
+	suite.Equal(SUCCESS, op.Status())
+	obj = op.ToJSONObject()
+	suite.Equal(SUCCESS, obj.Status)
+
+	// Test TIMEOUT status.
+	steps = []OpStep{TransferLeader{FromStore: 2, ToStore: 1}}
+	op = suite.newTestOperator(1, OpLeader, steps...)
+	op.Start()
+	op.SetStatusReachTime(STARTED, op.GetStartTime().Add(-FastStepWaitTime-time.Second))
+	suite.True(op.CheckTimeout())
+	obj = op.ToJSONObject()
+	suite.Equal(TIMEOUT, obj.Status)
 }

--- a/pkg/schedule/operator/operator_test.go
+++ b/pkg/schedule/operator/operator_test.go
@@ -541,3 +541,20 @@ func (suite *operatorTestSuite) TestRecord() {
 	re.Equal(now, ob.FinishTime)
 	re.Greater(ob.duration.Seconds(), time.Second.Seconds())
 }
+
+func (suite *operatorTestSuite) TestToJSONObject() {
+	steps := []OpStep{
+		AddPeer{ToStore: 1, PeerID: 1},
+		TransferLeader{FromStore: 2, ToStore: 1},
+		RemovePeer{FromStore: 2},
+	}
+	op := suite.newTestOperator(101, OpLeader|OpRegion, steps...)
+	op.Start()
+	obj := op.ToJSONObject()
+	suite.Equal("test", obj.Desc)
+	suite.Equal("test", obj.Brief)
+	suite.Equal(uint64(101), obj.RegionID)
+	suite.Equal(OpLeader|OpRegion, obj.Kind)
+	suite.Equal("12m0s", obj.Timeout)
+	suite.Equal(STARTED, obj.Status)
+}

--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -66,7 +66,8 @@ func (h *operatorHandler) GetOperatorsByRegion(w http.ResponseWriter, r *http.Re
 
 // @Tags     operator
 // @Summary  List pending operators.
-// @Param    kind  query  string  false  "Specify the operator kind."  Enums(admin, leader, region)
+// @Param    kind   query  string  false  "Specify the operator kind."  Enums(admin, leader, region)
+// @Param    object query  bool    false  "Whether to return as JSON object."
 // @Produce  json
 // @Success  200  {array}   operator.Operator
 // @Failure  500  {string}  string  "PD server failed to proceed the request."

--- a/server/api/operator.go
+++ b/server/api/operator.go
@@ -78,6 +78,7 @@ func (h *operatorHandler) GetOperators(w http.ResponseWriter, r *http.Request) {
 	)
 
 	kinds, ok := r.URL.Query()["kind"]
+	_, objectFlag := r.URL.Query()["object"]
 	if !ok {
 		results, err = h.Handler.GetOperators()
 	} else {
@@ -88,7 +89,15 @@ func (h *operatorHandler) GetOperators(w http.ResponseWriter, r *http.Request) {
 		h.r.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.r.JSON(w, http.StatusOK, results)
+	if objectFlag {
+		objResults := make([]*operator.OpObject, len(results))
+		for i, op := range results {
+			objResults[i] = op.ToJSONObject()
+		}
+		h.r.JSON(w, http.StatusOK, objResults)
+	} else {
+		h.r.JSON(w, http.StatusOK, results)
+	}
 }
 
 // FIXME: details of input json body params


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7704 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
api: optional return operators as JSON object
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

```
❯ curl "http://127.0.0.1:4379/pd/api/v1/operators"
[
  "shuffle-leader {transfer leader: store 1 to 4} (kind:admin,leader, region:16(7, 5), createAt:2024-01-12 22:38:17.517275979 +0800 CST m=+52.853398165, startAt:2024-01-12 22:38:17.517387568 +0800 CST m=+52.853509755, currentStep:0, size:1, steps:[0:{transfer leader from store 1 to store 4}], timeout:[1m0s])",
  "shuffle-leader {transfer leader: store 4 to 1} (kind:admin,leader, region:8(7, 5), createAt:2024-01-12 22:38:17.452175149 +0800 CST m=+52.788297323, startAt:2024-01-12 22:38:17.456446852 +0800 CST m=+52.792569049, currentStep:0, size:1, steps:[0:{transfer leader from store 4 to store 1}], timeout:[1m0s])",
  "shuffle-leader {transfer leader: store 1 to 4} (kind:admin,leader, region:2(7, 5), createAt:2024-01-12 22:38:17.466611818 +0800 CST m=+52.802733993, startAt:2024-01-12 22:38:17.506606672 +0800 CST m=+52.842728857, currentStep:0, size:1, steps:[0:{transfer leader from store 1 to store 4}], timeout:[1m0s])"
]
❯ curl "http://127.0.0.1:4379/pd/api/v1/operators?object=1"
[
  {
    "desc": "shuffle-leader",
    "brief": "transfer leader: store 5 to 1",
    "region_id": 16,
    "region_epoch": {
      "conf_ver": 5,
      "version": 7
    },
    "kind": 129,
    "timeout": "1m0s",
    "status": 1
  },
  {
    "desc": "shuffle-leader",
    "brief": "transfer leader: store 5 to 1",
    "region_id": 10,
    "region_epoch": {
      "conf_ver": 5,
      "version": 7
    },
    "kind": 129,
    "timeout": "1m0s",
    "status": 1
  },
  {
    "desc": "shuffle-leader",
    "brief": "transfer leader: store 1 to 5",
    "region_id": 8,
    "region_epoch": {
      "conf_ver": 5,
      "version": 7
    },
    "kind": 129,
    "timeout": "1m0s",
    "status": 1
  }
]
```


Code changes

- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

Side effects

- No.

Related changes

- No.

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
api: optional return operators as JSON object
```
