### PR TITLE
Cgroup monitoring and alerting

### DIFF
--- a/metrics/alertmanager/pd.rules.yml
+++ b/metrics/alertmanager/pd.rules.yml
@@ -197,12 +197,12 @@ groups:
       summary: PD_cluster_slow_tikv_nums
 
   - alert: PD_cpu_quota
-    expr:  irate(process_cpu_seconds_total{job="pd"}[30s]) / pd_server_maxprocs > 0.8
+    expr:  irate(process_cpu_seconds_total{job="pd"}[30s]) / pd_service_maxprocs > 0.8
     for: 45s
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: irate(process_cpu_seconds_total{job="pd"}[30s]) / pd_server_maxprocs > 0.8
+      expr: irate(process_cpu_seconds_total{job="pd"}[30s]) / pd_service_maxprocs > 0.8
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'

--- a/metrics/alertmanager/pd.rules.yml
+++ b/metrics/alertmanager/pd.rules.yml
@@ -209,12 +209,12 @@ groups:
       summary: PD CPU usage is over 80% of CPU quota
 
   - alert: PD_memory_quota
-    expr:  process_resident_memory_bytes{job="pd"} / pd_server_memory_quota_bytes > 0.8
+    expr:  process_resident_memory_bytes{job="pd"} / pd_service_memory_quota_bytes > 0.8
     for: 15s
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: process_resident_memory_bytes{job="pd"} / pd_server_memory_quota_bytes > 0.8
+      expr: process_resident_memory_bytes{job="pd"} / pd_service_memory_quota_bytes > 0.8
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'

--- a/metrics/alertmanager/pd.rules.yml
+++ b/metrics/alertmanager/pd.rules.yml
@@ -195,3 +195,27 @@ groups:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'
       summary: PD_cluster_slow_tikv_nums
+
+  - alert: PD_cpu_quota
+    expr:  irate(process_cpu_seconds_total{job="pd"}[30s]) / pd_server_maxprocs > 0.8
+    for: 45s
+    labels:
+      env: ENV_LABELS_ENV
+      level: warning
+      expr: irate(process_cpu_seconds_total{job="pd"}[30s]) / pd_server_maxprocs > 0.8
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
+      value: '{{ $value }}'
+      summary: PD CPU usage is over 80% of CPU quota
+
+  - alert: PD_memory_quota
+    expr:  process_resident_memory_bytes{job="pd"} / pd_server_memory_quota_bytes > 0.8
+    for: 15s
+    labels:
+      env: ENV_LABELS_ENV
+      level: warning
+      expr: process_resident_memory_bytes{job="pd"} / pd_server_memory_quota_bytes > 0.8
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
+      value: '{{ $value }}'
+      summary: PD memory usage is over 80% of memory quota

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -1819,10 +1819,10 @@
             },
             {
               "exemplar": true,
-              "expr": "pd_service_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",job=~\".*(pd|tso|scheduling).*\"}",
+              "expr": "pd_server_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",job=~\".*(pd|tso|scheduling).*\"}",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{job}}-{{instance}}-limit",
+              "legendFormat": "quota-{{job}}-{{instance}}",
               "refId": "B"
             }
           ],
@@ -1967,6 +1967,13 @@
               "interval": "",
               "legendFormat": "GCTrigger-{{job}}-{{instance}}",
               "refId": "G"
+            },
+            {
+              "expr": "pd_server_memory_quota_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",job=~\".*pd.*\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "quota-{{job}}-{{instance}}",
+              "refId": "H"
             }
           ],
           "thresholds": [],

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -1819,7 +1819,7 @@
             },
             {
               "exemplar": true,
-              "expr": "pd_server_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",job=~\".*(pd|tso|scheduling).*\"}",
+              "expr": "pd_service_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",job=~\".*(pd|tso|scheduling).*\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "quota-{{job}}-{{instance}}",

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -1969,7 +1969,7 @@
               "refId": "G"
             },
             {
-              "expr": "pd_server_memory_quota_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",job=~\".*pd.*\"}",
+              "expr": "pd_service_memory_quota_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",job=~\".*pd.*\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "quota-{{job}}-{{instance}}",

--- a/pkg/basicserver/metrics.go
+++ b/pkg/basicserver/metrics.go
@@ -47,5 +47,6 @@ var (
 
 func init() {
 	prometheus.MustRegister(ServerMaxProcsGauge)
+	prometheus.MustRegister(ServerMemoryLimit)
 	prometheus.MustRegister(ServerInfoGauge)
 }

--- a/pkg/basicserver/metrics.go
+++ b/pkg/basicserver/metrics.go
@@ -30,7 +30,7 @@ var (
 	ServerMemoryLimit = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
-			Subsystem: "server",
+			Subsystem: "service",
 			Name:      "memory_quota_bytes",
 			Help:      "The value of memory quota bytes.",
 		})

--- a/pkg/basicserver/metrics.go
+++ b/pkg/basicserver/metrics.go
@@ -21,7 +21,7 @@ var (
 	ServerMaxProcsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
-			Subsystem: "server",
+			Subsystem: "service",
 			Name:      "maxprocs",
 			Help:      "The value of GOMAXPROCS.",
 		})

--- a/pkg/basicserver/metrics.go
+++ b/pkg/basicserver/metrics.go
@@ -17,13 +17,22 @@ package server
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	// ServerMaxProcsGauge record the maxprocs.
+	// ServerMaxProcsGauge records the maxprocs.
 	ServerMaxProcsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
-			Subsystem: "service",
+			Subsystem: "server",
 			Name:      "maxprocs",
 			Help:      "The value of GOMAXPROCS.",
+		})
+
+	// ServerMemoryLimit records the cgroup memory limit.
+	ServerMemoryLimit = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "memory_quota_bytes",
+			Help:      "The value of memory quota bytes.",
 		})
 
 	// ServerInfoGauge indicates the pd server info including version and git hash.

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -155,6 +155,33 @@ func readFile(filepath string) (res []byte, err error) {
 	return res, err
 }
 
+// The field in /proc/self/cgroup and /proc/self/mountinfo may appear as "cpuacct,cpu" or "rw,cpuacct,cpu"
+// while the input controller is "cpu,cpuacct"
+func controllerMatch(field string, controller string) bool {
+	if field == controller {
+		return true
+	}
+
+	fs := strings.Split(field, ",")
+	if len(fs) < 2 {
+		return false
+	}
+	cs := strings.Split(controller, ",")
+	if len(fs) < len(cs) {
+		return false
+	}
+	fmap := make(map[string]struct{}, len(fs))
+	for _, f := range fs {
+		fmap[f] = struct{}{}
+	}
+	for _, c := range cs {
+		if _, ok := fmap[c]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // The controller is defined via either type `memory` for cgroup v1 or via empty type for cgroup v2,
 // where the type is the second field in /proc/[pid]/cgroup file
 func detectControlPath(cgroupFilePath string, controller string) (string, error) {
@@ -185,7 +212,7 @@ func detectControlPath(cgroupFilePath string, controller string) (string, error)
 		// but no known container solutions support it.
 		if f0 == "0" && f1 == "" {
 			unifiedPathIfFound = string(fields[2])
-		} else if f1 == controller {
+		} else if controllerMatch(f1, controller) {
 			var result []byte
 			// In some case, the cgroup path contains `:`. We need to join them back.
 			if len(fields) > 3 {
@@ -314,7 +341,7 @@ func detectCgroupVersion(fields [][]byte, controller string) (_ int, found bool)
 
 	// Check for controller specifically in cgroup v1 (it is listed in super
 	// options field), as the value can't be found if it is not enforced.
-	if bytes.Equal(fields[pos], []byte("cgroup")) && bytes.Contains(fields[pos+2], []byte(controller)) {
+	if bytes.Equal(fields[pos], []byte("cgroup")) && controllerMatch(string(fields[pos+2]), controller) {
 		return 1, true
 	} else if bytes.Equal(fields[pos], []byte("cgroup2")) {
 		return 2, true

--- a/pkg/cgroup/cgroup_cpu.go
+++ b/pkg/cgroup/cgroup_cpu.go
@@ -88,6 +88,49 @@ func getCgroupCPUHelper(root string) (CPUUsage, error) {
 	return res, nil
 }
 
+// Helper function for getCgroupCPUPeriodAndQuota. Root is always "/", except in tests.
+func getCgroupCPUPeriodAndQuota(root string) (period int64, quota int64, err error) {
+	path, err := detectControlPath(filepath.Join(root, procPathCGroup), "cpu")
+	if err != nil {
+		return
+	}
+
+	// No CPU controller detected
+	if path == "" {
+		err = errors.New("no cpu controller detected")
+		return
+	}
+
+	mount, ver, err := getCgroupDetails(filepath.Join(root, procPathMountInfo), path, "cpu")
+	if err != nil {
+		return
+	}
+
+	if len(mount) == 2 {
+		cgroupRootV1 := filepath.Join(root, mount[0])
+		cgroupRootV2 := filepath.Join(root, mount[1], path)
+		period, quota, err = detectCPUQuotaInV2(cgroupRootV2)
+		if err != nil {
+			period, quota, err = detectCPUQuotaInV1(cgroupRootV1)
+		}
+		if err != nil {
+			return
+		}
+	} else {
+		switch ver[0] {
+		case 1:
+			cgroupRoot := filepath.Join(root, mount[0])
+			period, quota, err = detectCPUQuotaInV1(cgroupRoot)
+		case 2:
+			cgroupRoot := filepath.Join(root, mount[0], path)
+			period, quota, err = detectCPUQuotaInV2(cgroupRoot)
+		default:
+			err = fmt.Errorf("detected unknown cgroup version index: %d", ver[0])
+		}
+	}
+	return
+}
+
 // CPUShares returns the number of CPUs this cgroup can be expected to
 // max out. If there's no limit, NumCPU is returned.
 func (c CPUUsage) CPUShares() float64 {

--- a/pkg/cgroup/cgroup_cpu_linux.go
+++ b/pkg/cgroup/cgroup_cpu_linux.go
@@ -44,6 +44,11 @@ func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
 	return maxProcs, CPUQuotaUsed, nil
 }
 
+// GetCPUPeriodAndQuota returns CPU period and quota time of cgroup.
+func GetCPUPeriodAndQuota() (int64, int64, error) {
+	return getCgroupCPUPeriodAndQuota("/")
+}
+
 // InContainer returns true if the process is running in a container.
 func InContainer() bool {
 	v, err := os.ReadFile(procPathCGroup)

--- a/pkg/cgroup/cgroup_cpu_linux.go
+++ b/pkg/cgroup/cgroup_cpu_linux.go
@@ -45,7 +45,7 @@ func CPUQuotaToGOMAXPROCS(minValue int) (int, CPUQuotaStatus, error) {
 }
 
 // GetCPUPeriodAndQuota returns CPU period and quota time of cgroup.
-func GetCPUPeriodAndQuota() (int64, int64, error) {
+func GetCPUPeriodAndQuota() (period int64, quota int64, err error) {
 	return getCgroupCPUPeriodAndQuota("/")
 }
 

--- a/pkg/cgroup/cgroup_cpu_unsupport.go
+++ b/pkg/cgroup/cgroup_cpu_unsupport.go
@@ -27,6 +27,12 @@ func GetCgroupCPU() (CPUUsage, error) {
 	return cpuUsage, nil
 }
 
+// GetCPUPeriodAndQuota returns CPU period and quota time of cgroup.
+// This is Linux-specific and not supported in the current OS.
+func GetCPUPeriodAndQuota() (period int64, quota int64, err error) {
+	return -1, -1, nil
+}
+
 // CPUQuotaToGOMAXPROCS converts the CPU quota applied to the calling process
 // to a valid GOMAXPROCS value. This is Linux-specific and not supported in the
 // current OS.

--- a/pkg/cgroup/cgroup_mock_test.go
+++ b/pkg/cgroup/cgroup_mock_test.go
@@ -387,12 +387,12 @@ func TestCgroupsGetCPU(t *testing.T) {
 			v1MountsWithCPUControllerNSMountRelRemount = strings.ReplaceAll(v1MountsWithCPUControllerNSMountRelRemount, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
 			v1MountsWithCPUControllerNS2 = strings.ReplaceAll(v1MountsWithCPUControllerNS2, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
 		}
-		testCgroupsGetCPU(t)
+		testCgroupGetCPUHelper(t)
 		testCgroupsGetCPUPeriodAndQuota(t)
 	}
 }
 
-func testCgroupsGetCPU(t *testing.T) {
+func testCgroupGetCPUHelper(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		paths  map[string]string

--- a/pkg/cgroup/cgroup_mock_test.go
+++ b/pkg/cgroup/cgroup_mock_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -370,6 +371,28 @@ const (
 )
 
 func TestCgroupsGetCPU(t *testing.T) {
+	for i := 0; i < 2; i++ {
+		if i == 1 {
+			// The field in /proc/self/cgroup and /proc/self/mountinfo may appear as "cpuacct,cpu" or "rw,cpuacct,cpu"
+			// while the input controller is "cpu,cpuacct"
+			v1CgroupWithCPUController = strings.ReplaceAll(v1CgroupWithCPUController, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNS = strings.ReplaceAll(v1CgroupWithCPUControllerNS, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNSMountRel = strings.ReplaceAll(v1CgroupWithCPUControllerNSMountRel, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNSMountRelRemount = strings.ReplaceAll(v1CgroupWithCPUControllerNSMountRelRemount, "cpu,cpuacct", "cpuacct,cpu")
+			v1CgroupWithCPUControllerNS2 = strings.ReplaceAll(v1CgroupWithCPUControllerNS2, "cpu,cpuacct", "cpuacct,cpu")
+
+			v1MountsWithCPUController = strings.ReplaceAll(v1MountsWithCPUController, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNS = strings.ReplaceAll(v1MountsWithCPUControllerNS, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNSMountRel = strings.ReplaceAll(v1MountsWithCPUControllerNSMountRel, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNSMountRelRemount = strings.ReplaceAll(v1MountsWithCPUControllerNSMountRelRemount, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+			v1MountsWithCPUControllerNS2 = strings.ReplaceAll(v1MountsWithCPUControllerNS2, "rw,cpu,cpuacct", "rw,cpuacct,cpu")
+		}
+		testCgroupsGetCPU(t)
+		testCgroupsGetCPUPeriodAndQuota(t)
+	}
+}
+
+func testCgroupsGetCPU(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		paths  map[string]string
@@ -552,6 +575,147 @@ func TestCgroupsGetCPU(t *testing.T) {
 	}
 }
 
+func testCgroupsGetCPUPeriodAndQuota(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		paths  map[string]string
+		errMsg string
+		period int64
+		quota  int64
+	}{
+		{
+			errMsg: "failed to read cpu cgroup from cgroups file:",
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithoutCPUController,
+				"/proc/self/mountinfo": v1MountsWithoutCPUController,
+			},
+			errMsg: "no cpu controller detected",
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup": v1CgroupWithCPUController,
+			},
+			errMsg: "failed to read mounts info from file:",
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUController,
+				"/proc/self/mountinfo": v1MountsWithoutCPUController,
+			},
+			errMsg: "failed to detect cgroup root mount and version",
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":                            v1CgroupWithCPUController,
+				"/proc/self/mountinfo":                         v1MountsWithCPUController,
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us":  "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us": "67890",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNS,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNS,
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":  "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us": "67890",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNSMountRel,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNSMountRel,
+			},
+			errMsg: "failed to detect cgroup root mount and version",
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNSMountRelRemount,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNSMountRelRemount,
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":  "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us": "67890",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v1CgroupWithCPUControllerNS2,
+				"/proc/self/mountinfo": v1MountsWithCPUControllerNS2,
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_quota_us":  "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/crdb_test/cpu.cfs_period_us": "67890",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":                            v1CgroupWithCPUController,
+				"/proc/self/mountinfo":                         v1MountsWithCPUController,
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us":  "-1",
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us": "67890",
+			},
+			quota:  int64(-1),
+			period: int64(67890),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+			},
+			errMsg: "error when read cpu quota from cgroup v2",
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max": "foo bar\n",
+			},
+			errMsg: "error when reading cpu quota from cgroup v2 at",
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max": "100 1000\n",
+			},
+			quota:  int64(100),
+			period: int64(1000),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max": "max 1000\n",
+			},
+			quota:  int64(-1),
+			period: int64(1000),
+		},
+		{
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max": "100 1000\n",
+			},
+			quota:  int64(100),
+			period: int64(1000),
+		},
+	} {
+		dir := createFiles(t, tc.paths)
+
+		period, quota, err := getCgroupCPUPeriodAndQuota(dir)
+		require.True(t, isError(err, tc.errMsg),
+			"%v %v", err, tc.errMsg)
+		require.Equal(t, tc.quota, quota)
+		require.Equal(t, tc.period, period)
+	}
+}
+
 func createFiles(t *testing.T, paths map[string]string) (dir string) {
 	dir = t.TempDir()
 
@@ -564,7 +728,7 @@ func createFiles(t *testing.T, paths map[string]string) (dir string) {
 	return dir
 }
 
-const (
+var (
 	//#nosec G101
 	v1CgroupWithMemoryController = `11:blkio:/kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3
 10:devices:/kubepods/besteffort/podcbfx2j5d-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3

--- a/server/cgmon.go
+++ b/server/cgmon.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/shirou/gopsutil/v3/mem"
+	bs "github.com/tikv/pd/pkg/basicserver"
+	"github.com/tikv/pd/pkg/cgroup"
+	"go.uber.org/zap"
+)
+
+const (
+	refreshInterval = 10 * time.Second
+)
+
+type cgroupMonitor struct {
+	started         bool
+	ctx             context.Context
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
+	cfgMaxProcs     int
+	lastMaxProcs    int
+	lastMemoryLimit uint64
+}
+
+// StartCgroupMonitor uses to start the cgroup monitoring.
+// WARN: this function is not thread-safe.
+func (cgmon *cgroupMonitor) startCgroupMonitor() {
+	if cgmon.started {
+		return
+	}
+	cgmon.started = true
+	// Get configured maxprocs.
+	cgmon.cfgMaxProcs = runtime.GOMAXPROCS(0)
+	cgmon.ctx, cgmon.cancel = context.WithCancel(context.Background())
+	cgmon.wg.Add(1)
+	go cgmon.refreshCgroupLoop()
+	log.Info("cgroup monitor started")
+}
+
+// StopCgroupMonitor uses to stop the cgroup monitoring.
+// WARN: this function is not thread-safe.
+func (cgmon *cgroupMonitor) stopCgroupMonitor() {
+	if !cgmon.started {
+		return
+	}
+	cgmon.started = false
+	if cgmon.cancel != nil {
+		cgmon.cancel()
+	}
+	cgmon.wg.Wait()
+	log.Info("cgroup monitor stopped")
+}
+
+func (cgmon *cgroupMonitor) refreshCgroupLoop() {
+	ticker := time.NewTicker(refreshInterval)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("[pd] panic in the recoverable goroutine",
+				zap.String("funcInfo", "refreshCgroupLoop"),
+				zap.Reflect("r", r),
+				zap.Stack("stack"))
+		}
+		cgmon.wg.Done()
+		ticker.Stop()
+	}()
+
+	cgmon.refreshCgroupCPU()
+	cgmon.refreshCgroupMemory()
+	for {
+		select {
+		case <-cgmon.ctx.Done():
+			return
+		case <-ticker.C:
+			cgmon.refreshCgroupCPU()
+			cgmon.refreshCgroupMemory()
+		}
+	}
+}
+
+func (cgmon *cgroupMonitor) refreshCgroupCPU() {
+	// Get the number of CPUs.
+	quota := runtime.NumCPU()
+
+	// Get CPU quota from cgroup.
+	cpuPeriod, cpuQuota, err := cgroup.GetCPUPeriodAndQuota()
+	if err != nil {
+		log.Warn("failed to get cgroup cpu quota", zap.Error(err))
+		return
+	}
+	if cpuPeriod > 0 && cpuQuota > 0 {
+		ratio := float64(cpuQuota) / float64(cpuPeriod)
+		if ratio < float64(quota) {
+			quota = int(math.Ceil(ratio))
+		}
+	}
+
+	if quota != cgmon.lastMaxProcs && quota < cgmon.cfgMaxProcs {
+		runtime.GOMAXPROCS(quota)
+		log.Info(fmt.Sprintf("maxprocs set to %v", quota))
+		bs.ServerMaxProcsGauge.Set(float64(quota))
+		cgmon.lastMaxProcs = quota
+	} else if cgmon.lastMaxProcs == 0 {
+		log.Info(fmt.Sprintf("maxprocs set to %v", cgmon.cfgMaxProcs))
+		bs.ServerMaxProcsGauge.Set(float64(cgmon.cfgMaxProcs))
+		cgmon.lastMaxProcs = cgmon.cfgMaxProcs
+	}
+}
+
+func (cgmon *cgroupMonitor) refreshCgroupMemory() {
+	memLimit, err := cgroup.GetMemoryLimit()
+	if err != nil {
+		log.Warn("failed to get cgroup memory limit", zap.Error(err))
+		return
+	}
+	vmem, err := mem.VirtualMemory()
+	if err != nil {
+		log.Warn("failed to get system memory size", zap.Error(err))
+		return
+	}
+	if memLimit > vmem.Total {
+		memLimit = vmem.Total
+	}
+	if memLimit != cgmon.lastMemoryLimit {
+		log.Info(fmt.Sprintf("memory limit set to %v", memLimit))
+		bs.ServerMemoryLimit.Set(float64(memLimit))
+		cgmon.lastMemoryLimit = memLimit
+	}
+}

--- a/server/cgmon.go
+++ b/server/cgmon.go
@@ -44,14 +44,14 @@ type cgroupMonitor struct {
 
 // StartCgroupMonitor uses to start the cgroup monitoring.
 // WARN: this function is not thread-safe.
-func (cgmon *cgroupMonitor) startCgroupMonitor() {
+func (cgmon *cgroupMonitor) startCgroupMonitor(ctx context.Context) {
 	if cgmon.started {
 		return
 	}
 	cgmon.started = true
 	// Get configured maxprocs.
 	cgmon.cfgMaxProcs = runtime.GOMAXPROCS(0)
-	cgmon.ctx, cgmon.cancel = context.WithCancel(context.Background())
+	cgmon.ctx, cgmon.cancel = context.WithCancel(ctx)
 	cgmon.wg.Add(1)
 	go cgmon.refreshCgroupLoop()
 	log.Info("cgroup monitor started")

--- a/server/cgmon.go
+++ b/server/cgmon.go
@@ -1,4 +1,4 @@
-// Copyright 2016 TiKV Project Authors.
+// Copyright 2024 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/cgmon.go
+++ b/server/cgmon.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"runtime"
 	"sync"
@@ -117,11 +116,11 @@ func (cgmon *cgroupMonitor) refreshCgroupCPU() {
 
 	if quota != cgmon.lastMaxProcs && quota < cgmon.cfgMaxProcs {
 		runtime.GOMAXPROCS(quota)
-		log.Info(fmt.Sprintf("maxprocs set to %v", quota))
+		log.Info("set the maxprocs", zap.Int("quota", quota))
 		bs.ServerMaxProcsGauge.Set(float64(quota))
 		cgmon.lastMaxProcs = quota
 	} else if cgmon.lastMaxProcs == 0 {
-		log.Info(fmt.Sprintf("maxprocs set to %v", cgmon.cfgMaxProcs))
+		log.Info("set the maxprocs", zap.Int("cfgMaxProcs", cgmon.cfgMaxProcs))
 		bs.ServerMaxProcsGauge.Set(float64(cgmon.cfgMaxProcs))
 		cgmon.lastMaxProcs = cgmon.cfgMaxProcs
 	}
@@ -142,7 +141,7 @@ func (cgmon *cgroupMonitor) refreshCgroupMemory() {
 		memLimit = vmem.Total
 	}
 	if memLimit != cgmon.lastMemoryLimit {
-		log.Info(fmt.Sprintf("memory limit set to %v", memLimit))
+		log.Info("set the memory limit", zap.Uint64("memLimit", memLimit))
 		bs.ServerMemoryLimit.Set(float64(memLimit))
 		cgmon.lastMemoryLimit = memLimit
 	}

--- a/server/cgmon.go
+++ b/server/cgmon.go
@@ -1,3 +1,17 @@
+// Copyright 2016 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/server.go
+++ b/server/server.go
@@ -622,7 +622,7 @@ func (s *Server) Run() error {
 		return err
 	}
 
-	s.cgmon.startCgroupMonitor()
+	s.cgmon.startCgroupMonitor(s.ctx)
 
 	failpoint.Inject("delayStartServerLoop", func() {
 		time.Sleep(2 * time.Second)

--- a/server/server.go
+++ b/server/server.go
@@ -235,6 +235,9 @@ type Server struct {
 	servicePrimaryMap        sync.Map /* Store as map[string]string */
 	tsoPrimaryWatcher        *etcdutil.LoopWatcher
 	schedulingPrimaryWatcher *etcdutil.LoopWatcher
+
+	// Cgroup Monitor
+	cgmon cgroupMonitor
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -542,6 +545,8 @@ func (s *Server) Close() {
 
 	log.Info("closing server")
 
+	s.cgmon.stopCgroupMonitor()
+
 	s.stopServerLoop()
 	if s.IsAPIServiceMode() {
 		s.keyspaceGroupManager.Close()
@@ -616,6 +621,8 @@ func (s *Server) Run() error {
 	if err := s.startServer(s.ctx); err != nil {
 		return err
 	}
+
+	s.cgmon.startCgroupMonitor()
 
 	failpoint.Inject("delayStartServerLoop", func() {
 		time.Sleep(2 * time.Second)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
There isn't yet a mechanism to monitor the cgroup cpu/memory limit and do corresponding alerting.
<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7716

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->
Cgmon pkg was added to periodically watch the cgroup cpu/memory limit setting changes. GOMAXPROCS will be set to the minor one between cgroup limit and maxprocs. Metrics will be set accordingly and displayed on Grafana. New alerting rules were also added for the cpu/memory usage ratio relative to the limits.
```Cgmon pkg was added to periodically watch the cgroup cpu/memory limit setting changes. GOMAXPROCS will be set to the minor one between cgroup limit and maxprocs. Metrics will be set accordingly and displayed on Grafana. New alerting rules were also added for the cpu/memory usage ratio relative to the limits.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
   Grafana display and alerting trigger

Code changes

- cgmon pkg added
- New metrics added
- Grafana dashboard json modified
- New alerting rules

Side effects

None

Related changes

None

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
