### PR TITLE
etcdutil, mcs: fix the issue loading label rules is too slow

### DIFF
--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -175,8 +175,8 @@ func MakeRegionBound(id uint32) *RegionBound {
 	}
 }
 
-// makeKeyRanges encodes keyspace ID to correct LabelRule data.
-func makeKeyRanges(id uint32) []interface{} {
+// MakeKeyRanges encodes keyspace ID to correct LabelRule data.
+func MakeKeyRanges(id uint32) []interface{} {
 	regionBound := MakeRegionBound(id)
 	return []interface{}{
 		map[string]interface{}{
@@ -207,7 +207,7 @@ func MakeLabelRule(id uint32) *labeler.LabelRule {
 			},
 		},
 		RuleType: labeler.KeyRange,
-		Data:     makeKeyRanges(id),
+		Data:     MakeKeyRanges(id),
 	}
 }
 

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -233,7 +233,7 @@ func (rw *Watcher) initializeRegionLabelWatcher() error {
 	}
 	postEventsFn := func(events []*clientv3.Event) error {
 		defer rw.regionLabeler.Unlock()
-		rw.regionLabeler.BuildRangeList()
+		rw.regionLabeler.BuildRangeListLocked()
 		return nil
 	}
 	rw.labelWatcher = etcdutil.NewLoopWatcher(

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -110,7 +110,7 @@ func (rw *Watcher) initializeRuleWatcher() error {
 	var suspectKeyRanges *core.KeyRanges
 
 	preEventsFn := func(events []*clientv3.Event) error {
-		// It will be locked until the postFn is finished.
+		// It will be locked until the postEventsFn is finished.
 		rw.ruleManager.Lock()
 		rw.patch = rw.ruleManager.BeginPatch()
 		suspectKeyRanges = &core.KeyRanges{}
@@ -212,26 +212,37 @@ func (rw *Watcher) initializeRuleWatcher() error {
 
 func (rw *Watcher) initializeRegionLabelWatcher() error {
 	prefixToTrim := rw.regionLabelPathPrefix + "/"
+	// TODO: use txn in region labeler.
+	preEventsFn := func(events []*clientv3.Event) error {
+		// It will be locked until the postEventsFn is finished.
+		rw.regionLabeler.Lock()
+		return nil
+	}
 	putFn := func(kv *mvccpb.KeyValue) error {
-		log.Info("update region label rule", zap.String("key", string(kv.Key)), zap.String("value", string(kv.Value)))
+		log.Debug("update region label rule", zap.String("key", string(kv.Key)), zap.String("value", string(kv.Value)))
 		rule, err := labeler.NewLabelRuleFromJSON(kv.Value)
 		if err != nil {
 			return err
 		}
-		return rw.regionLabeler.SetLabelRule(rule)
+		return rw.regionLabeler.SetLabelRuleLocked(rule)
 	}
 	deleteFn := func(kv *mvccpb.KeyValue) error {
 		key := string(kv.Key)
 		log.Info("delete region label rule", zap.String("key", key))
-		return rw.regionLabeler.DeleteLabelRule(strings.TrimPrefix(key, prefixToTrim))
+		return rw.regionLabeler.DeleteLabelRuleLocked(strings.TrimPrefix(key, prefixToTrim))
+	}
+	postEventsFn := func(events []*clientv3.Event) error {
+		defer rw.regionLabeler.Unlock()
+		rw.regionLabeler.BuildRangeList()
+		return nil
 	}
 	rw.labelWatcher = etcdutil.NewLoopWatcher(
 		rw.ctx, &rw.wg,
 		rw.etcdClient,
 		"scheduling-region-label-watcher", rw.regionLabelPathPrefix,
-		func([]*clientv3.Event) error { return nil },
+		preEventsFn,
 		putFn, deleteFn,
-		func([]*clientv3.Event) error { return nil },
+		postEventsFn,
 		true, /* withPrefix */
 	)
 	rw.labelWatcher.StartWatchLoop()

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -188,7 +188,7 @@ func (rw *Watcher) initializeRuleWatcher() error {
 	}
 	postEventsFn := func(events []*clientv3.Event) error {
 		defer rw.ruleManager.Unlock()
-		if err := rw.ruleManager.TryCommitPatch(rw.patch); err != nil {
+		if err := rw.ruleManager.TryCommitPatchLocked(rw.patch); err != nil {
 			log.Error("failed to commit patch", zap.Error(err))
 			return err
 		}

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -107,10 +107,6 @@ func NewWatcher(
 }
 
 func (rw *Watcher) initializeRuleWatcher() error {
-	if rw.ruleManager == nil {
-		return nil
-	}
-
 	var suspectKeyRanges *core.KeyRanges
 
 	preEventsFn := func(events []*clientv3.Event) error {
@@ -215,10 +211,6 @@ func (rw *Watcher) initializeRuleWatcher() error {
 }
 
 func (rw *Watcher) initializeRegionLabelWatcher() error {
-	if rw.regionLabeler == nil {
-		return nil
-	}
-
 	prefixToTrim := rw.regionLabelPathPrefix + "/"
 	// TODO: use txn in region labeler.
 	preEventsFn := func(events []*clientv3.Event) error {

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -107,6 +107,10 @@ func NewWatcher(
 }
 
 func (rw *Watcher) initializeRuleWatcher() error {
+	if rw.ruleManager == nil {
+		return nil
+	}
+
 	var suspectKeyRanges *core.KeyRanges
 
 	preEventsFn := func(events []*clientv3.Event) error {
@@ -211,6 +215,10 @@ func (rw *Watcher) initializeRuleWatcher() error {
 }
 
 func (rw *Watcher) initializeRegionLabelWatcher() error {
+	if rw.regionLabeler == nil {
+		return nil
+	}
+
 	prefixToTrim := rw.regionLabelPathPrefix + "/"
 	// TODO: use txn in region labeler.
 	preEventsFn := func(events []*clientv3.Event) error {

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/embed"
+)
+
+func TestLoadLargeRules(t *testing.T) {
+	re := require.New(t)
+	ctx, client, clusterID, storage, labelerManager, clean := prepare(t)
+	defer clean()
+
+	watcher, err := NewWatcher(ctx, client, clusterID, storage, nil, nil, labelerManager)
+	re.NoError(err)
+	re.NotNil(watcher)
+}
+
+func BenchmarkLoadLargeRules(b *testing.B) {
+	re := require.New(b)
+	ctx, client, clusterID, storage, labelerManager, clean := prepare(b)
+	defer clean()
+
+	b.ResetTimer() // Resets the timer to ignore initialization time in the benchmark
+
+	for n := 0; n < b.N; n++ {
+		watcher, err := NewWatcher(ctx, client, clusterID, storage, nil, nil, labelerManager)
+		re.NoError(err)
+		re.NotNil(watcher)
+	}
+}
+
+func prepare(t require.TestingT) (context.Context, *clientv3.Client, uint64, *endpoint.StorageEndpoint,
+	*labeler.RegionLabeler, func()) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := etcdutil.NewTestSingleConfig()
+	cfg.Dir = os.TempDir() + "/test_etcd"
+	etcd, err := embed.StartEtcd(cfg)
+	re.NoError(err)
+	client, err := etcdutil.CreateEtcdClient(nil, cfg.LCUrls)
+	re.NoError(err)
+	<-etcd.Server.ReadyNotify()
+
+	clusterID := uint64(20240117)
+	key := endpoint.RegionLabelPathPrefix(clusterID)
+	for i := 1; i < 65536; i++ {
+		rule := &labeler.LabelRule{
+			ID:       "test",
+			Labels:   []labeler.RegionLabel{{Key: "test", Value: "test"}},
+			RuleType: labeler.KeyRange,
+			Data:     keyspace.MakeKeyRanges(uint32(i)),
+		}
+		value, err := json.Marshal(rule)
+		re.NoError(err)
+		_, err = clientv3.NewKV(client).Put(ctx, key, string(value))
+		re.NoError(err)
+	}
+
+	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	labelerManager, err := labeler.NewRegionLabeler(ctx, storage, time.Hour)
+	re.NoError(err)
+	return ctx, client, clusterID, storage, labelerManager, func() {
+		cancel()
+		client.Close()
+		etcd.Close()
+		os.Remove(cfg.Dir)
+	}
+}

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -99,7 +99,7 @@ func (l *RegionLabeler) checkAndClearExpiredLabels() {
 		}
 	}
 	if deleted {
-		l.BuildRangeList()
+		l.BuildRangeListLocked()
 	}
 }
 
@@ -128,12 +128,12 @@ func (l *RegionLabeler) loadRules() error {
 			return err
 		}
 	}
-	l.BuildRangeList()
+	l.BuildRangeListLocked()
 	return nil
 }
 
-// BuildRangeList builds the range list.
-func (l *RegionLabeler) BuildRangeList() {
+// BuildRangeListLocked builds the range list.
+func (l *RegionLabeler) BuildRangeListLocked() {
 	builder := rangelist.NewBuilder()
 	l.minExpire = nil
 	for _, rule := range l.labelRules {
@@ -212,7 +212,7 @@ func (l *RegionLabeler) SetLabelRule(rule *LabelRule) error {
 	if err := l.SetLabelRuleLocked(rule); err != nil {
 		return err
 	}
-	l.BuildRangeList()
+	l.BuildRangeListLocked()
 	return nil
 }
 
@@ -235,7 +235,7 @@ func (l *RegionLabeler) DeleteLabelRule(id string) error {
 	if err := l.DeleteLabelRuleLocked(id); err != nil {
 		return err
 	}
-	l.BuildRangeList()
+	l.BuildRangeListLocked()
 	return nil
 }
 
@@ -281,7 +281,7 @@ func (l *RegionLabeler) Patch(patch LabelRulePatch) error {
 	for _, rule := range patch.SetRules {
 		l.labelRules[rule.ID] = rule
 	}
-	l.BuildRangeList()
+	l.BuildRangeListLocked()
 	return nil
 }
 

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -99,7 +99,7 @@ func (l *RegionLabeler) checkAndClearExpiredLabels() {
 		}
 	}
 	if deleted {
-		l.buildRangeList()
+		l.BuildRangeList()
 	}
 }
 
@@ -128,11 +128,12 @@ func (l *RegionLabeler) loadRules() error {
 			return err
 		}
 	}
-	l.buildRangeList()
+	l.BuildRangeList()
 	return nil
 }
 
-func (l *RegionLabeler) buildRangeList() {
+// BuildRangeList builds the range list.
+func (l *RegionLabeler) BuildRangeList() {
 	builder := rangelist.NewBuilder()
 	l.minExpire = nil
 	for _, rule := range l.labelRules {
@@ -206,16 +207,24 @@ func (l *RegionLabeler) getAndCheckRule(id string, now time.Time) *LabelRule {
 
 // SetLabelRule inserts or updates a LabelRule.
 func (l *RegionLabeler) SetLabelRule(rule *LabelRule) error {
+	l.Lock()
+	defer l.Unlock()
+	if err := l.SetLabelRuleLocked(rule); err != nil {
+		return err
+	}
+	l.BuildRangeList()
+	return nil
+}
+
+// SetLabelRuleLocked inserts or updates a LabelRule but not buildRangeList.
+func (l *RegionLabeler) SetLabelRuleLocked(rule *LabelRule) error {
 	if err := rule.checkAndAdjust(); err != nil {
 		return err
 	}
-	l.Lock()
-	defer l.Unlock()
 	if err := l.storage.SaveRegionRule(rule.ID, rule); err != nil {
 		return err
 	}
 	l.labelRules[rule.ID] = rule
-	l.buildRangeList()
 	return nil
 }
 
@@ -223,6 +232,15 @@ func (l *RegionLabeler) SetLabelRule(rule *LabelRule) error {
 func (l *RegionLabeler) DeleteLabelRule(id string) error {
 	l.Lock()
 	defer l.Unlock()
+	if err := l.DeleteLabelRuleLocked(id); err != nil {
+		return err
+	}
+	l.BuildRangeList()
+	return nil
+}
+
+// DeleteLabelRuleLocked removes a LabelRule but not buildRangeList.
+func (l *RegionLabeler) DeleteLabelRuleLocked(id string) error {
 	if _, ok := l.labelRules[id]; !ok {
 		return errs.ErrRegionRuleNotFound.FastGenByArgs(id)
 	}
@@ -230,7 +248,6 @@ func (l *RegionLabeler) DeleteLabelRule(id string) error {
 		return err
 	}
 	delete(l.labelRules, id)
-	l.buildRangeList()
 	return nil
 }
 
@@ -264,7 +281,7 @@ func (l *RegionLabeler) Patch(patch LabelRulePatch) error {
 	for _, rule := range patch.SetRules {
 		l.labelRules[rule.ID] = rule
 	}
-	l.buildRangeList()
+	l.BuildRangeList()
 	return nil
 }
 

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -311,7 +311,7 @@ func (m *RuleManager) SetRule(rule *Rule) error {
 	defer m.Unlock()
 	p := m.BeginPatch()
 	p.SetRule(rule)
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 	log.Info("placement rule updated", zap.String("rule", fmt.Sprint(rule)))
@@ -324,7 +324,7 @@ func (m *RuleManager) DeleteRule(group, id string) error {
 	defer m.Unlock()
 	p := m.BeginPatch()
 	p.DeleteRule(group, id)
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 	log.Info("placement rule is removed", zap.String("group", group), zap.String("id", id))
@@ -469,8 +469,8 @@ func (m *RuleManager) BeginPatch() *RuleConfigPatch {
 	return m.ruleConfig.beginPatch()
 }
 
-// TryCommitPatch tries to commit a patch.
-func (m *RuleManager) TryCommitPatch(patch *RuleConfigPatch) error {
+// TryCommitPatchLocked tries to commit a patch.
+func (m *RuleManager) TryCommitPatchLocked(patch *RuleConfigPatch) error {
 	patch.adjust()
 
 	ruleList, err := buildRuleList(patch)
@@ -535,7 +535,7 @@ func (m *RuleManager) SetRules(rules []*Rule) error {
 		}
 		p.SetRule(r)
 	}
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 
@@ -598,7 +598,7 @@ func (m *RuleManager) Batch(todo []RuleOp) error {
 		}
 	}
 
-	if err := m.TryCommitPatch(patch); err != nil {
+	if err := m.TryCommitPatchLocked(patch); err != nil {
 		return err
 	}
 
@@ -634,7 +634,7 @@ func (m *RuleManager) SetRuleGroup(group *RuleGroup) error {
 	defer m.Unlock()
 	p := m.BeginPatch()
 	p.SetGroup(group)
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 	log.Info("group config updated", zap.String("group", fmt.Sprint(group)))
@@ -647,7 +647,7 @@ func (m *RuleManager) DeleteRuleGroup(id string) error {
 	defer m.Unlock()
 	p := m.BeginPatch()
 	p.DeleteGroup(id)
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 	log.Info("group config reset", zap.String("group", id))
@@ -737,7 +737,7 @@ func (m *RuleManager) SetAllGroupBundles(groups []GroupBundle, override bool) er
 			p.SetRule(r)
 		}
 	}
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 	log.Info("full config reset", zap.String("config", fmt.Sprint(groups)))
@@ -768,7 +768,7 @@ func (m *RuleManager) SetGroupBundle(group GroupBundle) error {
 		}
 		p.SetRule(r)
 	}
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 	log.Info("group is reset", zap.String("group", fmt.Sprint(group)))
@@ -800,7 +800,7 @@ func (m *RuleManager) DeleteGroupBundle(id string, regex bool) error {
 			p.DeleteGroup(g.ID)
 		}
 	}
-	if err := m.TryCommitPatch(p); err != nil {
+	if err := m.TryCommitPatchLocked(p); err != nil {
 		return err
 	}
 	log.Info("groups are removed", zap.String("id", id), zap.Bool("regexp", regex))

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -364,8 +364,6 @@ type KeyspaceGroupManager struct {
 	// cfg is the TSO config
 	cfg ServiceConfig
 
-	// loadKeyspaceGroupsTimeout is the timeout for loading the initial keyspace group assignment.
-	loadKeyspaceGroupsTimeout   time.Duration
 	loadKeyspaceGroupsBatchSize int64
 	loadFromEtcdMaxRetryTimes   int
 
@@ -574,9 +572,6 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		postEventsFn,
 		true, /* withPrefix */
 	)
-	if kgm.loadKeyspaceGroupsTimeout > 0 {
-		kgm.groupWatcher.SetLoadTimeout(kgm.loadKeyspaceGroupsTimeout)
-	}
 	if kgm.loadFromEtcdMaxRetryTimes > 0 {
 		kgm.groupWatcher.SetLoadRetryTimes(kgm.loadFromEtcdMaxRetryTimes)
 	}

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	mcsutils "github.com/tikv/pd/pkg/mcs/utils"
 	"github.com/tikv/pd/pkg/storage/endpoint"
@@ -226,29 +225,6 @@ func (suite *keyspaceGroupManagerTestSuite) TestLoadWithDifferentBatchSize() {
 		suite.runTestLoadKeyspaceGroupsAssignment(re, param.count, param.batchSize, param.probabilityAssignToMe)
 		suite.runTestLoadKeyspaceGroupsAssignment(re, param.count+1, param.batchSize, param.probabilityAssignToMe)
 	}
-}
-
-// TestLoadKeyspaceGroupsTimeout tests there is timeout when loading the initial keyspace group assignment
-// from etcd. The initialization of the keyspace group manager should fail.
-func (suite *keyspaceGroupManagerTestSuite) TestLoadKeyspaceGroupsTimeout() {
-	re := suite.Require()
-
-	mgr := suite.newUniqueKeyspaceGroupManager(1)
-	re.NotNil(mgr)
-	defer mgr.Close()
-
-	addKeyspaceGroupAssignment(
-		suite.ctx, suite.etcdClient, uint32(0), mgr.legacySvcRootPath,
-		[]string{mgr.tsoServiceID.ServiceAddr}, []int{0}, []uint32{0})
-
-	// Set the timeout to 1 second and inject the delayLoad to return 3 seconds to let
-	// the loading sleep 3 seconds.
-	mgr.loadKeyspaceGroupsTimeout = time.Second
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/utils/etcdutil/delayLoad", "return(3)"))
-	err := mgr.Initialize()
-	// If loading keyspace groups timeout, the initialization should fail with ErrLoadKeyspaceGroupsTerminated.
-	re.Contains(err.Error(), errs.ErrLoadKeyspaceGroupsTerminated.Error())
-	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/delayLoad"))
 }
 
 // TestLoadKeyspaceGroupsSucceedWithTempFailures tests the initialization should succeed when there are temporary

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -447,7 +447,7 @@ func (suite *loopWatcherTestSuite) TestLoadWithLimitChange() {
 	watcher.StartWatchLoop()
 	err := watcher.WaitLoad()
 	re.NoError(err)
-	re.Equal(int(maxLoadBatchSize)*2, len(cache))
+	re.Len(cache, int(maxLoadBatchSize)*2)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/meetEtcdError"))
 }
 

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -523,8 +523,8 @@ func (suite *loopWatcherTestSuite) TestWatcherLoadLimit() {
 
 func (suite *loopWatcherTestSuite) TestWatcherLoadLargeKey() {
 	re := suite.Require()
-	// use default limit to test 16384 key in etcd
-	count := 16384
+	// use default limit to test 65536 key in etcd
+	count := 65536
 	ctx, cancel := context.WithCancel(suite.ctx)
 	defer cancel()
 	for i := 0; i < count; i++ {

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -380,7 +380,8 @@ func (suite *loopWatcherTestSuite) SetupSuite() {
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	suite.cleans = make([]func(), 0)
 	// Start a etcd server and create a client with etcd1 as endpoint.
-	suite.config = newTestSingleConfig(suite.T())
+	suite.config = NewTestSingleConfig()
+	suite.config.Dir = suite.T().TempDir()
 	suite.startEtcd(re)
 	suite.client, err = CreateEtcdClient(nil, suite.config.LCUrls)
 	re.NoError(err)

--- a/pkg/utils/etcdutil/testutil.go
+++ b/pkg/utils/etcdutil/testutil.go
@@ -29,11 +29,10 @@ import (
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 )
 
-// newTestSingleConfig is used to create a etcd config for the unit test purpose.
-func newTestSingleConfig(t *testing.T) *embed.Config {
+// NewTestSingleConfig is used to create a etcd config for the unit test purpose.
+func NewTestSingleConfig() *embed.Config {
 	cfg := embed.NewConfig()
 	cfg.Name = genRandName()
-	cfg.Dir = t.TempDir()
 	cfg.WalDir = ""
 	cfg.Logger = "zap"
 	cfg.LogOutputs = []string{"stdout"}
@@ -60,7 +59,8 @@ func NewTestEtcdCluster(t *testing.T, count int) (servers []*embed.Etcd, etcdCli
 	re := require.New(t)
 	servers = make([]*embed.Etcd, 0, count)
 
-	cfg := newTestSingleConfig(t)
+	cfg := NewTestSingleConfig()
+	cfg.Dir = t.TempDir()
 	etcd, err := embed.StartEtcd(cfg)
 	re.NoError(err)
 	etcdClient, err = CreateEtcdClient(nil, cfg.LCUrls)
@@ -98,7 +98,8 @@ func NewTestEtcdCluster(t *testing.T, count int) (servers []*embed.Etcd, etcdCli
 // MustAddEtcdMember is used to add a new etcd member to the cluster for test.
 func MustAddEtcdMember(t *testing.T, cfg1 *embed.Config, client *clientv3.Client) *embed.Etcd {
 	re := require.New(t)
-	cfg2 := newTestSingleConfig(t)
+	cfg2 := NewTestSingleConfig()
+	cfg2.Dir = t.TempDir()
 	cfg2.Name = genRandName()
 	cfg2.InitialCluster = cfg1.InitialCluster + fmt.Sprintf(",%s=%s", cfg2.Name, &cfg2.LPUrls[0])
 	cfg2.ClusterState = embed.ClusterStateFlagExisting


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7724

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```
1. cancel timeout in loading function
2. use larger batch when loading from etcd
3. reduce times that call `buildRangeList` in label watcher

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
```
goos: linux
goarch: amd64
pkg: github.com/tikv/pd/pkg/mcs/scheduling/server/rule
cpu: AMD Ryzen 7 7840S with Radeon 780M Graphics         
```
| BenchmarkLoadLargeRules-16      |  | ||
| :---        |    ----: |        ----:  | ----: | 
| Master(timeout1h)     |  270616573162 ns/op        | 199973994432 B/op     |270541132 allocs/op|
| batch | 303262574 ns/op|	135643794 B/op	| 1146309 allocs/op|
| batch with larger limit (This PR) |208206918 ns/op |       128028446 B/op       |  1197805 allocs/op|
| This PR with easyjson | 201611560 ns/op       | 124696554 B/op    |     1132302 allocs/op|

#### cpu time

Master:
![image](https://github.com/tikv/pd/assets/19542290/463a11ce-4b9d-46ed-bd0a-445ff4f52b59)

This PR:
![image](https://github.com/tikv/pd/assets/19542290/2e3ce742-9236-4f95-b18c-46f510e2e85b)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
