### PR TITLE
ctl: clone tls config to avoid reusing connection

### DIFF
--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -69,7 +69,7 @@ func InitHTTPSClient(pdAddrs, caPath, certPath, keyPath string) error {
 			&http.Transport{TLSClientConfig: tlsConfig}, pdControlCallerID),
 	}
 
-	SetNewPDClient(strings.Split(pdAddrs, ","), pd.WithTLSConfig(tlsConfig))
+	SetNewPDClient(strings.Split(pdAddrs, ","), pd.WithTLSConfig(tlsConfig.Clone()))
 
 	return nil
 }

--- a/tools/pd-ctl/tests/cert_opt.sh
+++ b/tools/pd-ctl/tests/cert_opt.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+cert_dir="$2"
+
+function generate_certs() {
+    if [[ ! -z "$cert_dir" ]]; then
+        cd "$cert_dir" || exit 255  # Change to the specified directory
+    fi
+
+    if ! [[ "$0" =~ "cert_opt.sh" ]]; then
+        echo "must be run from 'cert'"
+        exit 255
+    fi
+
+    if ! which openssl; then
+        echo "openssl is not installed"
+        exit 255
+    fi
+
+    # Generate CA private key and self-signed certificate
+    openssl genpkey -algorithm RSA -out ca-key.pem
+    openssl req -new -x509 -key ca-key.pem -out ca.pem -days 1 -subj "/CN=ca"
+    # pd-server
+    openssl genpkey -algorithm RSA -out pd-server-key.pem
+    openssl req -new -key pd-server-key.pem -out pd-server.csr  -subj "/CN=pd-server"
+
+    # Add IP address as a SAN
+    echo "subjectAltName = IP:127.0.0.1" > extfile.cnf
+    openssl x509 -req -in pd-server.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out pd-server.pem -days 1 -extfile extfile.cnf
+
+    # Clean up the temporary extension file
+    rm extfile.cnf
+
+    # client
+    openssl genpkey -algorithm RSA -out client-key.pem
+    openssl req -new -key client-key.pem -out client.csr -subj "/CN=client"
+    openssl x509 -req -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out client.pem -days 1
+}
+
+function cleanup_certs() {
+    if [[ ! -z "$cert_dir" ]]; then
+        cd "$cert_dir" || exit 255  # Change to the specified directory
+    fi
+
+    rm -f ca.pem ca-key.pem ca.srl
+    rm -f pd-server.pem pd-server-key.pem pd-server.csr
+    rm -f client.pem client-key.pem client.csr
+}
+
+if [[ "$1" == "generate" ]]; then
+    generate_certs
+elif [[ "$1" == "cleanup" ]]; then
+    cleanup_certs
+else
+    echo "Usage: $0 [generate|cleanup] <cert_directory>"
+fi

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -17,6 +17,10 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,10 +29,13 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/statistics/utils"
+	"github.com/tikv/pd/pkg/utils/grpcutil"
 	"github.com/tikv/pd/server/api"
+	"github.com/tikv/pd/server/config"
 	pdTests "github.com/tikv/pd/tests"
 	ctl "github.com/tikv/pd/tools/pd-ctl/pdctl"
 	"github.com/tikv/pd/tools/pd-ctl/tests"
+	"go.etcd.io/etcd/pkg/transport"
 )
 
 func TestStore(t *testing.T) {
@@ -543,4 +550,97 @@ func TestTombstoneStore(t *testing.T) {
 	message := string(output)
 	re.Contains(message, "2")
 	re.Contains(message, "3")
+}
+
+func TestStoreTLS(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	certPath := "../cert"
+	certScript := "../cert_opt.sh"
+	// generate certs
+	if err := os.Mkdir(certPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command(certScript, "generate", certPath).Run(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := exec.Command(certScript, "cleanup", certPath).Run(); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.RemoveAll(certPath); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	tlsInfo := transport.TLSInfo{
+		KeyFile:       filepath.Join(certPath, "pd-server-key.pem"),
+		CertFile:      filepath.Join(certPath, "pd-server.pem"),
+		TrustedCAFile: filepath.Join(certPath, "ca.pem"),
+	}
+	cluster, err := pdTests.NewTestCluster(ctx, 1, func(conf *config.Config, serverName string) {
+		conf.Security.TLSConfig = grpcutil.TLSConfig{
+			KeyPath:  tlsInfo.KeyFile,
+			CertPath: tlsInfo.CertFile,
+			CAPath:   tlsInfo.TrustedCAFile,
+		}
+		conf.AdvertiseClientUrls = strings.ReplaceAll(conf.AdvertiseClientUrls, "http", "https")
+		conf.ClientUrls = strings.ReplaceAll(conf.ClientUrls, "http", "https")
+		conf.AdvertisePeerUrls = strings.ReplaceAll(conf.AdvertisePeerUrls, "http", "https")
+		conf.PeerUrls = strings.ReplaceAll(conf.PeerUrls, "http", "https")
+		conf.InitialCluster = strings.ReplaceAll(conf.InitialCluster, "http", "https")
+	})
+	re.NoError(err)
+	err = cluster.RunInitialServers()
+	re.NoError(err)
+	cluster.WaitLeader()
+	cmd := ctl.GetRootCmd()
+
+	stores := []*api.StoreInfo{
+		{
+			Store: &api.MetaStore{
+				Store: &metapb.Store{
+					Id:            1,
+					State:         metapb.StoreState_Up,
+					NodeState:     metapb.NodeState_Serving,
+					LastHeartbeat: time.Now().UnixNano(),
+				},
+				StateName: metapb.StoreState_Up.String(),
+			},
+		},
+		{
+			Store: &api.MetaStore{
+				Store: &metapb.Store{
+					Id:            2,
+					State:         metapb.StoreState_Up,
+					NodeState:     metapb.NodeState_Serving,
+					LastHeartbeat: time.Now().UnixNano(),
+				},
+				StateName: metapb.StoreState_Up.String(),
+			},
+		},
+	}
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NoError(leaderServer.BootstrapCluster())
+
+	for _, store := range stores {
+		pdTests.MustPutStore(re, cluster, store.Store.Store)
+	}
+	defer cluster.Destroy()
+
+	pdAddr := cluster.GetConfig().GetClientURL()
+	pdAddr = strings.ReplaceAll(pdAddr, "http", "https")
+	// store command
+	args := []string{"-u", pdAddr, "store",
+		"--cacert=../cert/ca.pem",
+		"--cert=../cert/client.pem",
+		"--key=../cert/client-key.pem"}
+	output, err := tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	storesInfo := new(api.StoresInfo)
+	re.NoError(json.Unmarshal(output, &storesInfo))
+
+	tests.CheckStoresInfo(re, storesInfo.Stores, stores)
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7739

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

- There is a read goroutine inside http transport that detects the closure of the socket. When another request is made before the readLoop actually detects the closure, the socket closes and an EOF is read.
- When they have the same tls they will shared connection
- release 7.6 does update member at startup. 
- Since get stores are slow, update member is done when the request is sent and not yet returned.
- Then the member returns faster and sends the request to readloop to read the return and then closes the socket, and stores encounters an eof.

![img_v3_0278_13250d7e-4d0e-4f82-847c-1e771ccf671g](https://github.com/tikv/pd/assets/53859786/5265ef0d-2368-4fdf-bcaf-a8ccbc8d2e3e)

can check error log
update member
![img_v3_0278_57ae34aa-87b1-42c5-bcde-37e5eb5f467g](https://github.com/tikv/pd/assets/53859786/78ad7c87-82c8-4443-acbe-564c9d0a7c86)
store url
![img_v3_0278_33deb940-1b00-4d3f-aa8d-ad580064d01g](https://github.com/tikv/pd/assets/53859786/e937d37d-a839-455f-b350-c0046332988e)
they are using URL in the same time
![img_v3_0278_95c0ef3f-a3ad-4291-9df9-dbce55d5f93g](https://github.com/tikv/pd/assets/53859786/aa50afc6-e360-403c-a364-a79975695e9a)
![img_v3_0278_b1d54304-3c6b-4b8b-bad6-640bf11e197g](https://github.com/tikv/pd/assets/53859786/4066b2d3-bca8-43a6-90dc-8be0b46c4f16)



### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
ctl: clone tls config to avoid reusing connection
```
