### PR TITLE
etcdutil: consider the latency while patrolling the healthy endpoints

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -10220,7 +10220,7 @@
           ],
           "thresholds": [],
           "timeRegions": [],
-          "title": "Endpoint Health State",
+          "title": "Endpoint health state",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -10072,13 +10072,195 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The time consumed of etcd endpoint health check in .99",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 53
+          },
+          "hiddenSeries": false,
+          "id": 1607,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": false,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pluginVersion": "8.5.27",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(pd_server_etcd_endpoint_latency_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=~\"$tidb_cluster.*\", source=\"server-etcd-client\"}[30s])) by (instance, endpoint, le))",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} -> {{endpoint}}",
+              "range": true,
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "99% Endpoint health check latency",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The state of the endpoint health.",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 61
+          },
+          "hiddenSeries": false,
+          "id": 1110,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "percentage": false,
+          "pluginVersion": "8.5.27",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "pd_server_etcd_client{k8s_cluster=\"$k8s_cluster\", tidb_cluster=~\"$tidb_cluster.*\", source=\"server-etcd-client\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} - {{type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Endpoint Health State",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The current term of Raft",
           "fill": 1,
           "gridPos": {
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 53
+            "y": 69
           },
           "id": 1109,
           "legend": {
@@ -10169,7 +10351,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 53
+            "y": 69
           },
           "id": 1110,
           "legend": {
@@ -10261,7 +10443,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 53
+            "y": 69
           },
           "id": 1111,
           "legend": {

--- a/pkg/mcs/utils/util.go
+++ b/pkg/mcs/utils/util.go
@@ -177,7 +177,7 @@ func InitClient(s server) error {
 	if err != nil {
 		return err
 	}
-	etcdClient, err := etcdutil.CreateEtcdClient(tlsConfig, backendUrls)
+	etcdClient, err := etcdutil.CreateEtcdClient(tlsConfig, backendUrls, "mcs-etcd-client")
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -253,7 +253,7 @@ func newClient(tlsConfig *tls.Config, endpoints ...string) (*clientv3.Client, er
 }
 
 // CreateEtcdClient creates etcd v3 client with detecting endpoints.
-func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL) (*clientv3.Client, error) {
+func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL, sourceOpt ...string) (*clientv3.Client, error) {
 	urls := make([]string, 0, len(acURLs))
 	for _, u := range acURLs {
 		urls = append(urls, u.String())
@@ -270,7 +270,11 @@ func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL) (*clientv3.Client
 	failpoint.Inject("closeTick", func() {
 		failpoint.Return(client, err)
 	})
-	initHealthChecker(tickerInterval, tlsConfig, client)
+	source := "default-etcd-client"
+	if len(sourceOpt) > 0 {
+		source = sourceOpt[0]
+	}
+	initHealthChecker(tickerInterval, tlsConfig, client, source)
 
 	return client, err
 }

--- a/pkg/utils/etcdutil/health_checker_test.go
+++ b/pkg/utils/etcdutil/health_checker_test.go
@@ -1,0 +1,214 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPickEps(t *testing.T) {
+	re := require.New(t)
+	testCases := []struct {
+		healthProbes       []healthProbe
+		expectedEvictedEps map[string]int
+		expectedPickedEps  []string
+	}{
+		// {} -> {A, B}
+		{
+			[]healthProbe{
+				{
+					ep:      "A",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "B",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{},
+			[]string{"A", "B"},
+		},
+		// {A, B} -> {A, B, C}
+		{
+			[]healthProbe{
+				{
+					ep:      "A",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "B",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "C",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{},
+			[]string{"A", "B", "C"},
+		},
+		// {A, B, C} -> {A, B, C}
+		{
+			[]healthProbe{
+				{
+					ep:      "A",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "B",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "C",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{},
+			[]string{"A", "B", "C"},
+		},
+		// {A, B, C} -> {C}
+		{
+			[]healthProbe{
+				{
+					ep:      "C",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{"A": 0, "B": 0},
+			[]string{"C"},
+		},
+		// {C} -> {A, B, C}
+		{
+			[]healthProbe{
+				{
+					ep:      "A",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "B",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "C",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{"A": 1, "B": 1},
+			[]string{"C"},
+		},
+		// {C} -> {B, C}
+		{
+			[]healthProbe{
+				{
+					ep:      "B",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "C",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{"A": 0, "B": 2},
+			[]string{"C"},
+		},
+		// {C} -> {A, B, C}
+		{
+			[]healthProbe{
+				{
+					ep:      "A",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "B",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "C",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{"A": 1},
+			[]string{"B", "C"},
+		},
+		// {B, C} -> {D}
+		{
+			[]healthProbe{
+				{
+					ep:      "D",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{"A": 0, "B": 0, "C": 0},
+			[]string{"D"},
+		},
+		// {D} -> {B, C}
+		{
+			[]healthProbe{
+				{
+					ep:      "B",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+				{
+					ep:      "C",
+					healthy: true,
+					took:    time.Millisecond,
+				},
+			},
+			map[string]int{"A": 0, "B": 1, "C": 1, "D": 0},
+			[]string{},
+		},
+	}
+	checker := &healthChecker{}
+	lastEps := []string{}
+	for idx, tc := range testCases {
+		pickedEps := checker.pickEps(tc.healthProbes)
+		checker.updateEvictedEps(lastEps, pickedEps)
+		pickedEps = checker.filterEps(pickedEps)
+		// Check the states after finishing picking.
+		count := 0
+		checker.evictedEps.Range(func(key, value interface{}) bool {
+			count++
+			ep := key.(string)
+			times := value.(int)
+			re.Equal(tc.expectedEvictedEps[ep], times, "case %d ep %s", idx, ep)
+			return true
+		})
+		re.Len(tc.expectedEvictedEps, count, "case %d", idx)
+		re.Equal(tc.expectedPickedEps, pickedEps, "case %d", idx)
+		lastEps = pickedEps
+	}
+}

--- a/pkg/utils/etcdutil/health_checker_test.go
+++ b/pkg/utils/etcdutil/health_checker_test.go
@@ -33,14 +33,12 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "A",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "A",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "B",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "B",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{},
@@ -50,19 +48,16 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "A",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "A",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "B",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "B",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "C",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "C",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{},
@@ -72,19 +67,16 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "A",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "A",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "B",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "B",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "C",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "C",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{},
@@ -94,9 +86,8 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "C",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "C",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{"A": 0, "B": 0},
@@ -106,19 +97,16 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "A",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "A",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "B",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "B",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "C",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "C",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{"A": 1, "B": 1},
@@ -128,14 +116,12 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "B",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "B",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "C",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "C",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{"A": 0, "B": 2},
@@ -145,19 +131,16 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "A",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "A",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "B",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "B",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "C",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "C",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{"A": 1},
@@ -167,9 +150,8 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "D",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "D",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{"A": 0, "B": 0, "C": 0},
@@ -179,14 +161,12 @@ func TestPickEps(t *testing.T) {
 		{
 			[]healthProbe{
 				{
-					ep:      "B",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "B",
+					took: time.Millisecond,
 				},
 				{
-					ep:      "C",
-					healthy: true,
-					took:    time.Millisecond,
+					ep:   "C",
+					took: time.Millisecond,
 				},
 			},
 			map[string]int{"A": 0, "B": 1, "C": 1, "D": 0},
@@ -196,7 +176,14 @@ func TestPickEps(t *testing.T) {
 	checker := &healthChecker{}
 	lastEps := []string{}
 	for idx, tc := range testCases {
-		pickedEps := checker.pickEps(tc.healthProbes)
+		// Send the health probes to the channel.
+		probeCh := make(chan healthProbe, len(tc.healthProbes))
+		for _, probe := range tc.healthProbes {
+			probeCh <- probe
+		}
+		close(probeCh)
+		// Pick and filter the endpoints.
+		pickedEps := checker.pickEps(probeCh)
 		checker.updateEvictedEps(lastEps, pickedEps)
 		pickedEps = checker.filterEps(pickedEps)
 		// Check the states after finishing picking.

--- a/pkg/utils/etcdutil/health_checker_test.go
+++ b/pkg/utils/etcdutil/health_checker_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test the endpoint picking and evicting logic.
 func TestPickEps(t *testing.T) {
 	re := require.New(t)
 	testCases := []struct {

--- a/pkg/utils/etcdutil/metrics.go
+++ b/pkg/utils/etcdutil/metrics.go
@@ -16,14 +16,26 @@ package etcdutil
 
 import "github.com/prometheus/client_golang/prometheus"
 
-var etcdStateGauge = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Namespace: "pd",
-		Subsystem: "server",
-		Name:      "etcd_client",
-		Help:      "Etcd client states.",
-	}, []string{"type"})
+var (
+	etcdStateGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "etcd_client",
+			Help:      "Etcd client states.",
+		}, []string{"type"})
+
+	etcdEndpointLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "etcd_endpoint_latency_seconds",
+			Help:      "Bucketed histogram of latency of health check.",
+			Buckets:   []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		}, []string{"endpoint"})
+)
 
 func init() {
 	prometheus.MustRegister(etcdStateGauge)
+	prometheus.MustRegister(etcdEndpointLatency)
 }

--- a/pkg/utils/etcdutil/metrics.go
+++ b/pkg/utils/etcdutil/metrics.go
@@ -17,13 +17,19 @@ package etcdutil
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
+	sourceLabel   = "source"
+	typeLabel     = "type"
+	endpointLabel = "endpoint"
+)
+
+var (
 	etcdStateGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
 			Subsystem: "server",
 			Name:      "etcd_client",
 			Help:      "Etcd client states.",
-		}, []string{"type"})
+		}, []string{sourceLabel, typeLabel})
 
 	etcdEndpointLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -32,7 +38,7 @@ var (
 			Name:      "etcd_endpoint_latency_seconds",
 			Help:      "Bucketed histogram of latency of health check.",
 			Buckets:   []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		}, []string{"endpoint"})
+		}, []string{sourceLabel, endpointLabel})
 )
 
 func init() {

--- a/pkg/utils/typeutil/comparison_test.go
+++ b/pkg/utils/typeutil/comparison_test.go
@@ -53,3 +53,21 @@ func TestEqualFloat(t *testing.T) {
 	re.True(Float64Equal(f1, f1*1.000))
 	re.True(Float64Equal(f1, f1/1.000))
 }
+
+func TestAreStringSlicesEquivalent(t *testing.T) {
+	t.Parallel()
+	re := require.New(t)
+	re.True(AreStringSlicesEquivalent(nil, nil))
+	re.True(AreStringSlicesEquivalent([]string{}, nil))
+	re.True(AreStringSlicesEquivalent(nil, []string{}))
+	re.True(AreStringSlicesEquivalent([]string{}, []string{}))
+	re.True(AreStringSlicesEquivalent([]string{"a", "b"}, []string{"b", "a"}))
+	re.False(AreStringSlicesEquivalent([]string{"a", "b"}, []string{"a", "b", "c"}))
+	re.False(AreStringSlicesEquivalent([]string{"a", "b", "c"}, []string{"a", "b"}))
+	re.False(AreStringSlicesEquivalent([]string{"a", "b"}, []string{"a", "c"}))
+	re.False(AreStringSlicesEquivalent([]string{"a", "b"}, []string{"c", "d"}))
+	re.False(AreStringSlicesEquivalent(nil, []string{"a", "b"}))
+	re.False(AreStringSlicesEquivalent([]string{"a", "b"}, nil))
+	re.False(AreStringSlicesEquivalent([]string{}, []string{"a", "b"}))
+	re.False(AreStringSlicesEquivalent([]string{"a", "b"}, []string{}))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -384,12 +384,12 @@ func (s *Server) startClient() error {
 	}
 	/* Starting two different etcd clients here is to avoid the throttling. */
 	// This etcd client will be used to access the etcd cluster to read and write all kinds of meta data.
-	s.client, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.ACUrls)
+	s.client, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.ACUrls, "server-etcd-client")
 	if err != nil {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()
 	}
 	// This etcd client will only be used to read and write the election-related data, such as leader key.
-	s.electionClient, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.ACUrls)
+	s.electionClient, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.ACUrls, "election-etcd-client")
 	if err != nil {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()
 	}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7730, #7499.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Consider the latency while patrolling the healthy endpoints to reduce the effect of slow nodes.
Now, there are the following strategies to select and remove unhealthy endpoints:

- Choose only the healthy endpoint within the lowest acceptable latency range.
- The evicted endpoint can only rejoin if it is selected again for three consecutive times.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Inject the etcd leader IO latency like:

<img width="1008" alt="image" src="https://github.com/tikv/pd/assets/1446531/a062e522-f5dd-4d60-849a-3125fcdfa2dc">

<img width="1050" alt="image" src="https://github.com/tikv/pd/assets/1446531/57d6c265-f0ec-4c83-9eeb-2a95a449de12">

The duration of QPS being affected is reduced, and it may not necessarily hit rock bottom completely. It will only be impacted by the switch of the etcd leader.

<img width="885" alt="image" src="https://github.com/tikv/pd/assets/1446531/772adb6b-a396-4b4c-a0a5-de6ed501a833">

Before:

<img width="926" alt="image" src="https://github.com/tikv/pd/assets/1446531/f092cd09-0cc0-4308-a2fa-941bae646993">

Etcd leader changing will be finished in just one term.

<img width="988" alt="image" src="https://github.com/tikv/pd/assets/1446531/44c8f8db-4c69-4e39-94b3-00c2256c7788">

Before:

<img width="988" alt="image" src="https://github.com/tikv/pd/assets/1446531/7aec7684-03ad-43ed-a3a3-f4c6e0ea663c">

Endpoint updating will be stabilized and only occur during IO hang injection and recovery points.

<img width="2078" alt="image" src="https://github.com/tikv/pd/assets/1446531/feb2c3b7-63a8-4774-8a3f-657a201c0e4e">

![image](https://github.com/tikv/pd/assets/1446531/7bf8cc0a-6f77-448c-9c4d-09b4703f72ec)

Before:

![img_v3_0276_d4aef8d7-fb9e-4ae5-a0de-638c0905dccg](https://github.com/tikv/pd/assets/1446531/fb0f6560-ce34-48f5-939b-d5987dca77fc)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
Enhance PD availability in the event of IO hang causing node unavailability.
```
