### PR TITLE
server(gRPC): use the PD leader member in server if it's not in etcd members

### DIFF
--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -204,7 +204,7 @@ func (m *EmbeddedEtcdMember) KeepLeader(ctx context.Context) {
 
 // PreCheckLeader does some pre-check before checking whether it's the leader.
 func (m *EmbeddedEtcdMember) PreCheckLeader() error {
-	if m.GetEtcdLeader() == 0 {
+	if m.GetEtcdLeaderID() == 0 {
 		return errs.ErrEtcdLeaderNotFound
 	}
 	return nil
@@ -281,7 +281,7 @@ func (m *EmbeddedEtcdMember) ResetLeader() {
 
 // CheckPriority checks whether the etcd leader should be moved according to the priority.
 func (m *EmbeddedEtcdMember) CheckPriority(ctx context.Context) {
-	etcdLeader := m.GetEtcdLeader()
+	etcdLeader := m.GetEtcdLeaderID()
 	if etcdLeader == m.ID() || etcdLeader == 0 {
 		return
 	}
@@ -318,8 +318,8 @@ func (m *EmbeddedEtcdMember) MoveEtcdLeader(ctx context.Context, old, new uint64
 	return nil
 }
 
-// GetEtcdLeader returns the etcd leader ID.
-func (m *EmbeddedEtcdMember) GetEtcdLeader() uint64 {
+// GetEtcdLeaderID returns the etcd leader ID.
+func (m *EmbeddedEtcdMember) GetEtcdLeaderID() uint64 {
 	return m.etcd.Server.Lead()
 }
 

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -87,7 +87,7 @@ func getMembers(svr *server.Server) (*pdpb.GetMembersResponse, error) {
 		if e != nil {
 			log.Error("failed to load deploy path", zap.Uint64("member", m.GetMemberId()), errs.ZapError(e))
 		}
-		if svr.GetMember().GetEtcdLeader() == 0 {
+		if svr.GetMember().GetEtcdLeaderID() == 0 {
 			log.Warn("no etcd leader, skip get leader priority", zap.Uint64("member", m.GetMemberId()))
 			continue
 		}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -473,9 +473,9 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	}
 
 	var etcdLeader, pdLeader *pdpb.Member
-	leaderID := s.member.GetEtcdLeader()
+	etcdLeaderID := s.member.GetEtcdLeaderID()
 	for _, m := range members {
-		if m.MemberId == leaderID {
+		if m.MemberId == etcdLeaderID {
 			etcdLeader = m
 			break
 		}
@@ -502,9 +502,10 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	failpoint.Inject("noLeaderInMembers", func() {
 		pdLeader = nil
 	})
-	// If the leader is not in the member list, we should fallback
-	// to the `leader` set in the PD server to gain a chance to work.
-	if pdLeader == nil && leader.GetMemberId() == leaderID {
+	// If the leader is not in the member list, we should fallback to
+	// the `leader` set in the PD server to gain a better availability.
+	// See https://github.com/tikv/pd/issues/7752 for more details.
+	if pdLeader == nil && leader.GetMemberId() == etcdLeaderID {
 		pdLeader = leader
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1645,7 +1645,7 @@ func (s *Server) leaderLoop() {
 		}
 
 		// To make sure the etcd leader and PD leader are on the same server.
-		etcdLeader := s.member.GetEtcdLeader()
+		etcdLeader := s.member.GetEtcdLeaderID()
 		if etcdLeader != s.member.ID() {
 			if s.member.GetLeader() == nil {
 				lastUpdated := s.member.GetLastLeaderUpdatedTime()
@@ -1800,7 +1800,7 @@ func (s *Server) campaignLeader() {
 				}
 			})
 
-			etcdLeader := s.member.GetEtcdLeader()
+			etcdLeader := s.member.GetEtcdLeaderID()
 			if etcdLeader != s.member.ID() {
 				log.Info("etcd leader changed, resigns pd leadership", zap.String("old-pd-leader-name", s.Name()))
 				return


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #7752.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Use the PD leader member set in the server if it's not in the etcd member list to gain a better chance to work.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
