### PR TITLE
client/http: use copied pdAddrs to prevent panic

### DIFF
--- a/client/http/client.go
+++ b/client/http/client.go
@@ -183,11 +183,13 @@ func (ci *clientInner) requestWithRetry(
 	if reqInfo.bo == nil {
 		return execFunc()
 	}
+	// Copy a new backoffer for each request.
+	bo := *reqInfo.bo
 	// Backoffer also needs to check the status code to determine whether to retry.
-	reqInfo.bo.SetRetryableChecker(func(err error) bool {
+	bo.SetRetryableChecker(func(err error) bool {
 		return err != nil && !noNeedRetry(statusCode)
 	})
-	return reqInfo.bo.Exec(ctx, execFunc)
+	return bo.Exec(ctx, execFunc)
 }
 
 func noNeedRetry(statusCode int) bool {

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -170,7 +170,7 @@ func (ci *clientInner) requestWithRetry(
 			if idx == leaderAddrIdx {
 				continue
 			}
-			addr = ci.pdAddrs[idx]
+			addr = pdAddrs[idx]
 			statusCode, err = ci.doRequest(ctx, addr, reqInfo, headerOpts...)
 			if err == nil || noNeedRetry(statusCode) {
 				break

--- a/client/http/client_test.go
+++ b/client/http/client_test.go
@@ -20,11 +20,13 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/pd/client/retry"
 	"go.uber.org/atomic"
 )
 
@@ -167,5 +169,31 @@ func TestRedirectWithMetrics(t *testing.T) {
 	failureCnt.Write(&out)
 	// leader failure
 	re.Equal(float64(4), out.Counter.GetValue())
+	c.Close()
+}
+
+func TestWithBackoffer(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := NewClient("test-with-backoffer", []string{"http://127.0.0.1"})
+
+	base := 100 * time.Millisecond
+	max := 500 * time.Millisecond
+	total := time.Second
+	bo := retry.InitialBackoffer(base, max, total)
+	// Test the time cost of the backoff.
+	start := time.Now()
+	_, err := c.WithBackoffer(bo).GetPDVersion(ctx)
+	re.InDelta(total, time.Since(start), float64(250*time.Millisecond))
+	re.Error(err)
+	// Test if the infinite retry works.
+	bo = retry.InitialBackoffer(base, max, 0)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	start = time.Now()
+	_, err = c.WithBackoffer(bo).GetPDVersion(timeoutCtx)
+	re.InDelta(3*time.Second, time.Since(start), float64(250*time.Millisecond))
+	re.ErrorIs(err, context.DeadlineExceeded)
 	c.Close()
 }

--- a/client/http/interface.go
+++ b/client/http/interface.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/tikv/pd/client/retry"
 )
 
 // Client is a PD (Placement Driver) HTTP client.
@@ -92,6 +93,8 @@ type Client interface {
 	// Additionally, it is important for the caller to handle the content of the response body properly
 	// in order to ensure that it can be read and marshaled correctly into `res`.
 	WithRespHandler(func(resp *http.Response, res interface{}) error) Client
+	// WithBackoffer sets and returns a new client with the given backoffer.
+	WithBackoffer(*retry.Backoffer) Client
 	// Close gracefully closes the HTTP client.
 	Close()
 }

--- a/client/http/request_info.go
+++ b/client/http/request_info.go
@@ -14,7 +14,11 @@
 
 package http
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/tikv/pd/client/retry"
+)
 
 // The following constants are the names of the requests.
 const (
@@ -75,6 +79,7 @@ type requestInfo struct {
 	body        []byte
 	res         interface{}
 	respHandler respHandleFunc
+	bo          *retry.Backoffer
 }
 
 // newRequestInfo creates a new request info.
@@ -121,6 +126,12 @@ func (ri *requestInfo) WithResp(res interface{}) *requestInfo {
 // WithRespHandler sets the response handle function of the request.
 func (ri *requestInfo) WithRespHandler(respHandler respHandleFunc) *requestInfo {
 	ri.respHandler = respHandler
+	return ri
+}
+
+// WithBackoffer sets the backoffer of the request.
+func (ri *requestInfo) WithBackoffer(bo *retry.Backoffer) *requestInfo {
+	ri.bo = bo
 	return ri
 }
 

--- a/client/pd_service_discovery.go
+++ b/client/pd_service_discovery.go
@@ -518,7 +518,7 @@ func (c *pdServiceDiscovery) updateMemberLoop() {
 	ticker := time.NewTicker(memberUpdateInterval)
 	defer ticker.Stop()
 
-	bo := retry.InitialBackOffer(updateMemberBackOffBaseTime, updateMemberTimeout)
+	bo := retry.InitialBackoffer(updateMemberBackOffBaseTime, updateMemberTimeout, updateMemberBackOffBaseTime)
 	for {
 		select {
 		case <-ctx.Done():

--- a/client/retry/backoff.go
+++ b/client/retry/backoff.go
@@ -18,56 +18,119 @@ import (
 	"context"
 	"time"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 )
 
-// BackOffer is a backoff policy for retrying operations.
-type BackOffer struct {
-	max  time.Duration
-	next time.Duration
+// Backoffer is a backoff policy for retrying operations.
+type Backoffer struct {
+	// base defines the initial time interval to wait before each retry.
 	base time.Duration
+	// max defines the max time interval to wait before each retry.
+	max time.Duration
+	// total defines the max total time duration cost in retrying. If it's 0, it means infinite retry until success.
+	total time.Duration
+	// retryableChecker is used to check if the error is retryable.
+	// By default, all errors are retryable.
+	retryableChecker func(err error) bool
+
+	next         time.Duration
+	currentTotal time.Duration
 }
 
 // Exec is a helper function to exec backoff.
-func (bo *BackOffer) Exec(
+func (bo *Backoffer) Exec(
 	ctx context.Context,
 	fn func() error,
 ) error {
-	if err := fn(); err != nil {
-		after := time.NewTimer(bo.nextInterval())
-		defer after.Stop()
+	defer bo.resetBackoff()
+	var (
+		err   error
+		after *time.Timer
+	)
+	for {
+		err = fn()
+		if !bo.isRetryable(err) {
+			break
+		}
+		currentInterval := bo.nextInterval()
+		if after == nil {
+			after = time.NewTimer(currentInterval)
+		} else {
+			after.Reset(currentInterval)
+		}
 		select {
 		case <-ctx.Done():
+			after.Stop()
+			return errors.Trace(ctx.Err())
 		case <-after.C:
 			failpoint.Inject("backOffExecute", func() {
 				testBackOffExecuteFlag = true
 			})
 		}
-		return err
+		after.Stop()
+		// If the current total time exceeds the maximum total time, return the last error.
+		if bo.total > 0 {
+			bo.currentTotal += currentInterval
+			if bo.currentTotal >= bo.total {
+				break
+			}
+		}
 	}
-	// reset backoff when fn() succeed.
-	bo.resetBackoff()
-	return nil
+	return err
 }
 
-// InitialBackOffer make the initial state for retrying.
-func InitialBackOffer(base, max time.Duration) BackOffer {
-	return BackOffer{
-		max:  max,
-		base: base,
-		next: base,
+// InitialBackoffer make the initial state for retrying.
+//   - `base` defines the initial time interval to wait before each retry.
+//   - `max` defines the max time interval to wait before each retry.
+//   - `total` defines the max total time duration cost in retrying. If it's 0, it means infinite retry until success.
+func InitialBackoffer(base, max, total time.Duration) *Backoffer {
+	// Make sure the base is less than or equal to the max.
+	if base > max {
+		base = max
 	}
+	// Make sure the total is not less than the base.
+	if total > 0 && total < base {
+		total = base
+	}
+	return &Backoffer{
+		base:  base,
+		max:   max,
+		total: total,
+		retryableChecker: func(err error) bool {
+			return err != nil
+		},
+		next:         base,
+		currentTotal: 0,
+	}
+}
+
+// SetRetryableChecker sets the retryable checker.
+func (bo *Backoffer) SetRetryableChecker(checker func(err error) bool) {
+	bo.retryableChecker = checker
+}
+
+func (bo *Backoffer) isRetryable(err error) bool {
+	if bo.retryableChecker == nil {
+		return true
+	}
+	return bo.retryableChecker(err)
 }
 
 // nextInterval for now use the `exponentialInterval`.
-func (bo *BackOffer) nextInterval() time.Duration {
+func (bo *Backoffer) nextInterval() time.Duration {
 	return bo.exponentialInterval()
 }
 
 // exponentialInterval returns the exponential backoff duration.
-func (bo *BackOffer) exponentialInterval() time.Duration {
+func (bo *Backoffer) exponentialInterval() time.Duration {
 	backoffInterval := bo.next
+	// Make sure the total backoff time is less than the total.
+	if bo.total > 0 && bo.currentTotal+backoffInterval > bo.total {
+		backoffInterval = bo.total - bo.currentTotal
+	}
 	bo.next *= 2
+	// Make sure the next backoff time is less than the max.
 	if bo.next > bo.max {
 		bo.next = bo.max
 	}
@@ -75,8 +138,9 @@ func (bo *BackOffer) exponentialInterval() time.Duration {
 }
 
 // resetBackoff resets the backoff to initial state.
-func (bo *BackOffer) resetBackoff() {
+func (bo *Backoffer) resetBackoff() {
 	bo.next = bo.base
+	bo.currentTotal = 0
 }
 
 // Only used for test.

--- a/client/retry/backoff_test.go
+++ b/client/retry/backoff_test.go
@@ -16,32 +16,93 @@ package retry
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/stretchr/testify/require"
 )
 
-func TestExponentialBackoff(t *testing.T) {
+func TestBackoffer(t *testing.T) {
 	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	baseBackoff := 100 * time.Millisecond
-	maxBackoff := 1 * time.Second
+	base := time.Second
+	max := 100 * time.Millisecond
+	total := time.Millisecond
+	// Test initial backoffer.
+	bo := InitialBackoffer(base, max, total)
+	// `bo.base` will be set to `bo.max` if `bo.base` is greater than `bo.max`.
+	re.Equal(max, bo.base)
+	re.Equal(max, bo.max)
+	// `bo.total` will be set to `bo.base` if `bo.total` is greater than `bo.base`.
+	re.Equal(bo.base, bo.total)
 
-	backoff := InitialBackOffer(baseBackoff, maxBackoff)
-	re.Equal(backoff.nextInterval(), baseBackoff)
-	re.Equal(backoff.nextInterval(), 2*baseBackoff)
-
-	for i := 0; i < 10; i++ {
-		re.LessOrEqual(backoff.nextInterval(), maxBackoff)
-	}
-	re.Equal(backoff.nextInterval(), maxBackoff)
-
-	// Reset backoff
-	backoff.resetBackoff()
-	err := backoff.Exec(context.Background(), func() error {
-		return errors.New("test")
+	base = 100 * time.Millisecond
+	max = time.Second
+	total = base
+	// Test the same value of `bo.base` and `bo.total`.
+	bo = InitialBackoffer(base, max, total)
+	re.Equal(base, bo.base)
+	re.Equal(total, bo.total)
+	re.Equal(base, total)
+	var (
+		execCount   int
+		expectedErr = errors.New("test")
+	)
+	err := bo.Exec(ctx, func() error {
+		execCount++
+		return expectedErr
 	})
-	re.Error(err)
+	re.ErrorIs(err, expectedErr)
+	re.Equal(1, execCount)
+	re.True(isBackofferReset(bo))
+
+	base = 100 * time.Millisecond
+	max = time.Second
+	total = time.Second
+	// Test the nextInterval function.
+	bo = InitialBackoffer(base, max, total)
+	re.Equal(bo.nextInterval(), base)
+	re.Equal(bo.nextInterval(), 2*base)
+	for i := 0; i < 10; i++ {
+		re.LessOrEqual(bo.nextInterval(), max)
+	}
+	re.Equal(bo.nextInterval(), max)
+	bo.resetBackoff()
+	re.True(isBackofferReset(bo))
+
+	// Test the total time cost.
+	execCount = 0
+	var start time.Time
+	err = bo.Exec(ctx, func() error {
+		execCount++
+		if start.IsZero() {
+			start = time.Now()
+		}
+		return expectedErr
+	})
+	re.InDelta(total, time.Since(start), float64(250*time.Millisecond))
+	re.ErrorIs(err, expectedErr)
+	re.Equal(4, execCount)
+	re.True(isBackofferReset(bo))
+
+	// Test the retryable checker.
+	execCount = 0
+	bo = InitialBackoffer(base, max, total)
+	bo.SetRetryableChecker(func(err error) bool {
+		return execCount < 2
+	})
+	err = bo.Exec(ctx, func() error {
+		execCount++
+		return nil
+	})
+	re.NoError(err)
+	re.Equal(2, execCount)
+	re.True(isBackofferReset(bo))
+}
+
+func isBackofferReset(bo *Backoffer) bool {
+	return bo.next == bo.base && bo.currentTotal == 0
 }

--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -395,7 +395,7 @@ func (c *tsoClient) handleDispatcher(
 	// Loop through each batch of TSO requests and send them for processing.
 	streamLoopTimer := time.NewTimer(c.option.timeout)
 	defer streamLoopTimer.Stop()
-	bo := retry.InitialBackOffer(updateMemberBackOffBaseTime, updateMemberTimeout)
+	bo := retry.InitialBackoffer(updateMemberBackOffBaseTime, updateMemberTimeout, updateMemberBackOffBaseTime)
 tsoBatchLoop:
 	for {
 		select {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #7760.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Cherry-pick #7680 and #7684 and use copied pdAddrs to prevent panic.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
