### PR TITLE
ci-subtask: exit ci-subtask.sh when execute ci failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ basic-test: install-tools
 
 ci-test-job: install-tools dashboard-ui
 	@$(FAILPOINT_ENABLE)
-	./scripts/ci-subtask.sh $(JOB_COUNT) $(JOB_INDEX)
+	./scripts/ci-subtask.sh $(JOB_COUNT) $(JOB_INDEX) || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
 
 TSO_INTEGRATION_TEST_PKGS := $(PD_PKG)/tests/server/tso

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -557,7 +557,7 @@ var DefaultSchedulers = SchedulerConfigs{
 	{Type: "evict-slow-store"},
 }
 
-// IsDefaultScheduler checks whether the scheduler is enable by default.
+// IsDefaultScheduler checks whether the scheduler is enabled by default.
 func IsDefaultScheduler(typ string) bool {
 	for _, c := range DefaultSchedulers {
 		if typ == c.Type {

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -48,7 +48,7 @@ type Controller struct {
 	ctx     context.Context
 	cluster sche.SchedulerCluster
 	storage endpoint.ConfigStorage
-	// schedulers is used to manage all schedulers, which will only be initialized
+	// schedulers are used to manage all schedulers, which will only be initialized
 	// and used in the PD leader service mode now.
 	schedulers map[string]*ScheduleController
 	// schedulerHandlers is used to manage the HTTP handlers of schedulers,

--- a/scripts/ci-subtask.sh
+++ b/scripts/ci-subtask.sh
@@ -10,7 +10,7 @@ if [[ $2 -gt 10 ]]; then
     # Currently, we only have 3 integration tests, so we can hardcode the task index.
     for t in "${integrations_tasks[@]}"; do
         if [[ "$t" = "$integrations_dir/client" && $2 -eq 11 ]]; then
-            cd ./client && make ci-test-job && cd .. && cat ./client/covprofile >> covprofile
+            cd ./client && make ci-test-job && cd .. && cat ./covprofile >> covprofile || exit 1
             cd $integrations_dir && make ci-test-job test_name=client && cat ./client/covprofile >> "$ROOT_PATH/covprofile" || exit 1
         elif [[ "$t" = "$integrations_dir/tso" && $2 -eq 12 ]]; then
             cd $integrations_dir && make ci-test-job test_name=tso && cat ./tso/covprofile >> "$ROOT_PATH/covprofile" || exit 1

--- a/scripts/ci-subtask.sh
+++ b/scripts/ci-subtask.sh
@@ -8,20 +8,14 @@ if [[ $2 -gt 10 ]]; then
     integrations_dir=./tests/integrations
     integrations_tasks=($(find "$integrations_dir" -mindepth 1 -maxdepth 1 -type d))
     # Currently, we only have 3 integration tests, so we can hardcode the task index.
-    for t in ${integrations_tasks[@]}; do
-        if [[ "$t" = "$integrations_dir/client" && "$2" = 11 ]]; then
+    for t in "${integrations_tasks[@]}"; do
+        if [[ "$t" = "$integrations_dir/client" && $2 -eq 11 ]]; then
             cd ./client && make ci-test-job && cd .. && cat ./client/covprofile >> covprofile
-            cd $integrations_dir && make ci-test-job test_name=client
-            cd $ROOT_PATH && cat $integrations_dir/client/covprofile >> covprofile
-            break
-        elif [[ "$t" = "$integrations_dir/tso" && "$2" = 12 ]]; then
-            cd $integrations_dir && make ci-test-job test_name=tso
-            cd $ROOT_PATH && cat $integrations_dir/tso/covprofile >> covprofile
-            break
-        elif [[ "$t" = "$integrations_dir/mcs" && "$2" = 13 ]]; then
-            cd $integrations_dir && make ci-test-job test_name=mcs
-            cd $ROOT_PATH && cat $integrations_dir/mcs/covprofile >> covprofile
-            break
+            cd $integrations_dir && make ci-test-job test_name=client && cat ./client/covprofile >> "$ROOT_PATH/covprofile" || exit 1
+        elif [[ "$t" = "$integrations_dir/tso" && $2 -eq 12 ]]; then
+            cd $integrations_dir && make ci-test-job test_name=tso && cat ./tso/covprofile >> "$ROOT_PATH/covprofile" || exit 1
+        elif [[ "$t" = "$integrations_dir/mcs" && $2 -eq 13 ]]; then
+            cd $integrations_dir && make ci-test-job test_name=mcs && cat ./mcs/covprofile >> "$ROOT_PATH/covprofile" || exit 1
         fi
     done
 else

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -77,21 +77,19 @@ func TestClientClusterIDCheck(t *testing.T) {
 	defer cluster2.Destroy()
 	endpoints2 := runServer(re, cluster2)
 	// Try to create a client with the mixed endpoints.
-	cli, err := pd.NewClientWithContext(
+	_, err = pd.NewClientWithContext(
 		ctx, append(endpoints1, endpoints2...),
 		pd.SecurityOption{}, pd.WithMaxErrorRetry(1),
 	)
 	re.Error(err)
-	defer cli.Close()
 	re.Contains(err.Error(), "unmatched cluster id")
 	// updateMember should fail due to unmatched cluster ID found.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/skipClusterIDCheck", `return(true)`))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/skipFirstUpdateMember", `return(true)`))
-	cli, err = pd.NewClientWithContext(ctx, []string{endpoints1[0], endpoints2[0]},
+	_, err = pd.NewClientWithContext(ctx, []string{endpoints1[0], endpoints2[0]},
 		pd.SecurityOption{}, pd.WithMaxErrorRetry(1),
 	)
 	re.Error(err)
-	defer cli.Close()
 	re.Contains(err.Error(), "ErrClientGetMember")
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/skipFirstUpdateMember"))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/skipClusterIDCheck"))

--- a/tests/integrations/client/client_tls_test.go
+++ b/tests/integrations/client/client_tls_test.go
@@ -173,12 +173,12 @@ func testTLSReload(
 				CertPath: testClientTLSInfo.CertFile,
 				KeyPath:  testClientTLSInfo.KeyFile,
 			}, pd.WithGRPCDialOptions(grpc.WithBlock()))
-			cli.Close()
 			if err != nil {
 				errc <- err
 				dcancel()
 				return
 			}
+			cli.Close()
 			dcancel()
 		}
 	}()

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -520,14 +520,14 @@ func (suite *httpClientTestSuite) checkScheduleConfig(mode mode, client pd.Clien
 
 	config, err := client.GetScheduleConfig(env.ctx)
 	re.NoError(err)
-	re.Equal(float64(4), config["leader-schedule-limit"])
+	re.Equal(float64(4), config["hot-region-schedule-limit"])
 	re.Equal(float64(2048), config["region-schedule-limit"])
-	config["leader-schedule-limit"] = float64(8)
+	config["hot-region-schedule-limit"] = float64(8)
 	err = client.SetScheduleConfig(env.ctx, config)
 	re.NoError(err)
 	config, err = client.GetScheduleConfig(env.ctx)
 	re.NoError(err)
-	re.Equal(float64(8), config["leader-schedule-limit"])
+	re.Equal(float64(8), config["hot-region-schedule-limit"])
 	re.Equal(float64(2048), config["region-schedule-limit"])
 }
 

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -508,6 +508,12 @@ func (suite *httpClientTestSuite) checkConfig(mode mode, client pd.Client) {
 	resp, err := env.cluster.GetEtcdClient().Get(env.ctx, sc.TTLConfigPrefix+"/schedule.leader-schedule-limit")
 	re.NoError(err)
 	re.Equal([]byte("16"), resp.Kvs[0].Value)
+	// delete the config with TTL.
+	err = client.SetConfig(env.ctx, newConfig, 0)
+	re.NoError(err)
+	resp, err = env.cluster.GetEtcdClient().Get(env.ctx, sc.TTLConfigPrefix+"/schedule.leader-schedule-limit")
+	re.NoError(err)
+	re.Empty(resp.Kvs)
 }
 
 func (suite *httpClientTestSuite) TestScheduleConfig() {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7770

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
need to exit when execute failed
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
