### PR TITLE
etcdutil: return original enpoints when all are evicted

### DIFF
--- a/pkg/utils/etcdutil/health_checker.go
+++ b/pkg/utils/etcdutil/health_checker.go
@@ -93,7 +93,7 @@ func (checker *healthChecker) syncer(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info("etcd client is closed, exit update endpoint goroutine",
+			log.Info("etcd client is closed, exit the endpoint syncer goroutine",
 				zap.String("source", checker.source))
 			return
 		case <-ticker.C:
@@ -110,7 +110,7 @@ func (checker *healthChecker) inspector(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info("etcd client is closed, exit health check goroutine",
+			log.Info("etcd client is closed, exit the health inspector goroutine",
 				zap.String("source", checker.source))
 			checker.close()
 			return

--- a/pkg/utils/etcdutil/health_checker.go
+++ b/pkg/utils/etcdutil/health_checker.go
@@ -329,6 +329,14 @@ func (checker *healthChecker) filterEps(eps []string) []string {
 		}
 		pickedEps = append(pickedEps, ep)
 	}
+	// If the pickedEps is empty, it means all endpoints are evicted,
+	// to gain better availability, just use the original picked endpoints.
+	if len(pickedEps) == 0 {
+		log.Warn("all etcd endpoints are evicted, use the picked endpoints directly",
+			zap.Strings("endpoints", eps),
+			zap.String("source", checker.source))
+		return eps
+	}
 	return pickedEps
 }
 

--- a/pkg/utils/etcdutil/health_checker_test.go
+++ b/pkg/utils/etcdutil/health_checker_test.go
@@ -201,7 +201,45 @@ func TestPickEps(t *testing.T) {
 				},
 			},
 			map[string]int{"A": 0, "B": 1, "C": 1, "D": 0},
-			[]string{},
+			[]string{"B", "C"},
+		},
+		// {B, C} -> {A, B, C}
+		{
+			[]healthProbe{
+				{
+					ep:   "A",
+					took: time.Millisecond,
+				},
+				{
+					ep:   "B",
+					took: time.Millisecond,
+				},
+				{
+					ep:   "C",
+					took: time.Millisecond,
+				},
+			},
+			map[string]int{"A": 1, "B": 2, "C": 2, "D": 0},
+			[]string{"A", "B", "C"},
+		},
+		// {A, B, C} -> {A, C, E}
+		{
+			[]healthProbe{
+				{
+					ep:   "A",
+					took: time.Millisecond,
+				},
+				{
+					ep:   "C",
+					took: time.Millisecond,
+				},
+				{
+					ep:   "E",
+					took: time.Millisecond,
+				},
+			},
+			map[string]int{"A": 2, "B": 0, "D": 0},
+			[]string{"C", "E"},
 		},
 	}
 	check(re, testCases)
@@ -318,7 +356,7 @@ func TestLatencyPick(t *testing.T) {
 				},
 			},
 			map[string]int{"A": 1, "B": 1, "C": 0},
-			[]string{},
+			[]string{"A", "B"},
 		},
 	}
 	check(re, testCases)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7730, ref #7499.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Return the originally picked endpoints directly if all are evicted to gain better availability.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
