### PR TITLE
simulator: scale-in and scale out test for `store-limit-version=v2`

### DIFF
--- a/server/api/store.go
+++ b/server/api/store.go
@@ -429,6 +429,10 @@ func (h *storeHandler) SetStoreWeight(w http.ResponseWriter, r *http.Request) {
 // @Router   /store/{id}/limit [post]
 func (h *storeHandler) SetStoreLimit(w http.ResponseWriter, r *http.Request) {
 	rc := getCluster(r)
+	if version := rc.GetScheduleConfig().StoreLimitVersion; version != storelimit.VersionV1 {
+		h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("current store limit version:%s not support set limit", version))
+		return
+	}
 	vars := mux.Vars(r)
 	storeID, errParse := apiutil.ParseUint64VarsField(vars, "id")
 	if errParse != nil {
@@ -529,6 +533,11 @@ func (h *storesHandler) RemoveTombStone(w http.ResponseWriter, r *http.Request) 
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /stores/limit [post]
 func (h *storesHandler) SetAllStoresLimit(w http.ResponseWriter, r *http.Request) {
+	cfg := h.GetScheduleConfig()
+	if version := cfg.StoreLimitVersion; version != storelimit.VersionV1 {
+		h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("current store limit version:%s not support get limit", version))
+		return
+	}
 	var input map[string]interface{}
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
@@ -609,7 +618,12 @@ func (h *storesHandler) SetAllStoresLimit(w http.ResponseWriter, r *http.Request
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /stores/limit [get]
 func (h *storesHandler) GetAllStoresLimit(w http.ResponseWriter, r *http.Request) {
-	limits := h.GetScheduleConfig().StoreLimit
+	cfg := h.GetScheduleConfig()
+	if version := cfg.StoreLimitVersion; version != storelimit.VersionV1 {
+		h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("current store limit version:%s not support get limit", version))
+		return
+	}
+	limits := cfg.StoreLimit
 	includeTombstone := false
 	var err error
 	if includeStr := r.URL.Query().Get("include_tombstone"); includeStr != "" {

--- a/tools/pd-simulator/README.md
+++ b/tools/pd-simulator/README.md
@@ -43,3 +43,14 @@ Run a specific case with an external PD:
 ```shell
 ./pd-simulator -pd="http://127.0.0.1:2379" -case="casename"
 ```
+
+Run with tiup playgroudn :
+```shell
+tiup playground nightly --host 127.0.0.1 --kv.binpath ./pd-simulator --kv=1 --db=0 --kv.config=./tikv.conf
+```
+tikv conf
+```
+case-name="redundant-balance-region"
+sim-tick-interval="1s"
+store-io-per-second=100
+```

--- a/tools/pd-simulator/simulator/cases/cases.go
+++ b/tools/pd-simulator/simulator/cases/cases.go
@@ -91,6 +91,7 @@ var CaseMap = map[string]func() *Case{
 	"redundant-balance-region":  newRedundantBalanceRegion,
 	"add-nodes":                 newAddNodes,
 	"add-nodes-dynamic":         newAddNodesDynamic,
+	"scale-in-out":              newScaleInOut,
 	"delete-nodes":              newDeleteNodes,
 	"region-split":              newRegionSplit,
 	"region-merge":              newRegionMerge,

--- a/tools/pd-simulator/simulator/cases/scale_tikv.go
+++ b/tools/pd-simulator/simulator/cases/scale_tikv.go
@@ -1,0 +1,89 @@
+// Copyright 2018 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cases
+
+import (
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/tools/pd-simulator/simulator/info"
+	"github.com/tikv/pd/tools/pd-simulator/simulator/simutil"
+	"go.uber.org/zap"
+)
+
+func newScaleInOut() *Case {
+	var simCase Case
+
+	storeNum := simutil.CaseConfigure.StoreNum
+	regionNum := simutil.CaseConfigure.RegionNum
+	if storeNum == 0 || regionNum == 0 {
+		storeNum, regionNum = 6, 4000
+	}
+
+	for i := 0; i < storeNum; i++ {
+		s := &Store{
+			ID:     IDAllocator.nextID(),
+			Status: metapb.StoreState_Up,
+		}
+		if i%2 == 1 {
+			s.HasExtraUsedSpace = true
+		}
+		simCase.Stores = append(simCase.Stores, s)
+	}
+
+	for i := 0; i < regionNum; i++ {
+		peers := []*metapb.Peer{
+			{Id: IDAllocator.nextID(), StoreId: uint64(i%storeNum + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64((i+1)%storeNum + 1)},
+			{Id: IDAllocator.nextID(), StoreId: uint64((i+2)%storeNum + 1)},
+		}
+		simCase.Regions = append(simCase.Regions, Region{
+			ID:     IDAllocator.nextID(),
+			Peers:  peers,
+			Leader: peers[0],
+		})
+	}
+
+	scaleInTick := int64(regionNum * 3 / storeNum)
+	addEvent := &AddNodesDescriptor{}
+	addEvent.Step = func(tick int64) uint64 {
+		if tick > scaleInTick {
+			storeNum++
+			return uint64(storeNum)
+		}
+		return 0
+	}
+
+	removeEvent := &DeleteNodesDescriptor{}
+	removeEvent.Step = func(tick int64) uint64 {
+		if tick > scaleInTick*2 {
+			return uint64(storeNum)
+		}
+		return 0
+	}
+
+	simCase.Events = []EventDescriptor{addEvent, removeEvent}
+
+	// storesLastUpdateTime := make([]int64, storeNum+1)
+	// storeLastAvailable := make([]uint64, storeNum+1)
+
+	simCase.Checker = func(regions *core.RegionsInfo, stats []info.StoreStats) bool {
+		newStore := stats[storeNum-1]
+		simutil.Logger.Info("current counts",
+			zap.Uint32("peer-count", newStore.GetRegionCount()),
+		)
+		return false
+	}
+	return &simCase
+}

--- a/tools/pd-simulator/simulator/node.go
+++ b/tools/pd-simulator/simulator/node.go
@@ -70,6 +70,7 @@ func NewNode(s *cases.Store, pdAddr string, config *SimConfig) (*Node, error) {
 		StoreStats: pdpb.StoreStats{
 			StoreId:   s.ID,
 			Capacity:  uint64(config.RaftStore.Capacity),
+			Available: uint64(config.RaftStore.Capacity),
 			StartTime: uint32(time.Now().Unix()),
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
run 
tiup playground nightly --host localhost --kv.binpath ./bin/pd-simulator --kv=1 --db=0 --kv.config=./tikv.conf  --pd.config ./pd.conf

tikv.conf

case-name="scale-in-out"
sim-tick-interval="100ms"
store-io-per-second=100

pd.toml
[schedule]
max-store-down-time = "5m"
store-limit-version = "v2"
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->


- Manual test (add detailed scripts or steps below)
<img width="501" alt="image" src="https://github.com/tikv/pd/assets/23159587/0b6e3d6b-171f-4af2-a8ea-042d8bc11e3d">

- No code

Code changes


Side effects

Related changes


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
