### PR TITLE
scheduler: add leader verify in balance-region scheduler (#2966)

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -595,6 +595,7 @@ func (mc *Cluster) RemoveScheduler(name string) error {
 }
 
 // MockRegionInfo returns a mock region
+// If leaderStoreID is zero, the regions would have no leader
 func (mc *Cluster) MockRegionInfo(regionID uint64, leaderStoreID uint64,
 	followerStoreIDs, learnerStoreIDs []uint64, epoch *metapb.RegionEpoch) *core.RegionInfo {
 
@@ -604,8 +605,11 @@ func (mc *Cluster) MockRegionInfo(regionID uint64, leaderStoreID uint64,
 		EndKey:      []byte(fmt.Sprintf("%20d", regionID+1)),
 		RegionEpoch: epoch,
 	}
-	leader, _ := mc.AllocPeer(leaderStoreID)
-	region.Peers = []*metapb.Peer{leader}
+	var leader *metapb.Peer
+	if leaderStoreID != 0 {
+		leader, _ = mc.AllocPeer(leaderStoreID)
+		region.Peers = append(region.Peers, leader)
+	}
 	for _, storeID := range followerStoreIDs {
 		peer, _ := mc.AllocPeer(storeID)
 		region.Peers = append(region.Peers, peer)

--- a/server/schedule/filter/filters.go
+++ b/server/schedule/filter/filters.go
@@ -16,6 +16,7 @@ package filter
 import (
 	"fmt"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/slice"
@@ -722,11 +723,7 @@ var allSpeicalEngines = []string{EngineTiFlash}
 // FitRegion in filter
 func createRegionForRuleFit(startKey, endKey []byte,
 	peers []*metapb.Peer, leader *metapb.Peer, opts ...core.RegionCreateOption) *core.RegionInfo {
-	copyLeader := &metapb.Peer{
-		Id:        leader.Id,
-		StoreId:   leader.StoreId,
-		IsLearner: leader.IsLearner,
-	}
+	copyLeader := proto.Clone(leader).(*metapb.Peer)
 	copyPeers := make([]*metapb.Peer, 0, len(peers))
 	for _, p := range peers {
 		peer := &metapb.Peer{

--- a/server/schedulers/balance_region.go
+++ b/server/schedulers/balance_region.go
@@ -173,6 +173,12 @@ func (s *balanceRegionScheduler) Schedule(cluster opt.Cluster) []*operator.Opera
 				schedulerCounter.WithLabelValues(s.GetName(), "region-hot").Inc()
 				continue
 			}
+			// Check region whether have leader
+			if region.GetLeader() == nil {
+				log.Warn("region have no leader", zap.String("scheduler", s.GetName()), zap.Uint64("region-id", region.GetID()))
+				schedulerCounter.WithLabelValues(s.GetName(), "no-leader").Inc()
+				continue
+			}
 
 			oldPeer := region.GetStorePeer(sourceID)
 			if op := s.transferPeer(cluster, region, oldPeer); op != nil {

--- a/server/schedulers/balance_test.go
+++ b/server/schedulers/balance_test.go
@@ -1124,6 +1124,23 @@ func (s *testReplicaCheckerSuite) TestOpts(c *C) {
 	c.Assert(rc.Check(region), IsNil)
 }
 
+func (s *testBalanceRegionSchedulerSuite) TestShouldNotBalance(c *C) {
+	opt := config.NewTestOptions()
+	tc := mockcluster.NewCluster(opt)
+	tc.DisableFeature(versioninfo.JointConsensus)
+	oc := schedule.NewOperatorController(s.ctx, nil, nil)
+	sb, err := schedule.CreateScheduler(BalanceRegionType, oc, core.NewStorage(kv.NewMemoryKV()), schedule.ConfigSliceDecoder(BalanceRegionType, []string{"", ""}))
+	c.Assert(err, IsNil)
+	region := tc.MockRegionInfo(1, 0, []uint64{2, 3, 4}, nil, nil)
+	tc.PutRegion(region)
+	operators := sb.Schedule(tc)
+	if operators != nil {
+		c.Assert(len(operators), Equals, 0)
+	} else {
+		c.Assert(operators, IsNil)
+	}
+}
+
 var _ = Suite(&testRandomMergeSchedulerSuite{})
 
 type testRandomMergeSchedulerSuite struct{}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #2966.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Check region leader before balance region. If it has no leader, the balance for this region would be skipped.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
