### PR TITLE
pd-ctl: avoid initializing a new PD client for each cmd execution

### DIFF
--- a/tools/pd-ctl/pdctl/command/cluster_command.go
+++ b/tools/pd-ctl/pdctl/command/cluster_command.go
@@ -14,11 +14,7 @@
 
 package command
 
-import (
-	"context"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 // NewClusterCommand return a cluster subcommand of rootCmd
 func NewClusterCommand() *cobra.Command {
@@ -42,7 +38,7 @@ func NewClusterStatusCommand() *cobra.Command {
 }
 
 func showClusterCommandFunc(cmd *cobra.Command, _ []string) {
-	info, err := PDCli.GetCluster(context.Background())
+	info, err := PDCli.GetCluster(cmd.Context())
 	if err != nil {
 		cmd.Printf("Failed to get the cluster information: %s\n", err)
 		return
@@ -51,7 +47,7 @@ func showClusterCommandFunc(cmd *cobra.Command, _ []string) {
 }
 
 func showClusterStatusCommandFunc(cmd *cobra.Command, _ []string) {
-	status, err := PDCli.GetClusterStatus(context.Background())
+	status, err := PDCli.GetClusterStatus(cmd.Context())
 	if err != nil {
 		cmd.Printf("Failed to get the cluster status: %s\n", err)
 		return

--- a/tools/pd-ctl/pdctl/command/cluster_command.go
+++ b/tools/pd-ctl/pdctl/command/cluster_command.go
@@ -21,8 +21,8 @@ func NewClusterCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "cluster",
 		Short:             "show the cluster information",
-		Run:               showClusterCommandFunc,
 		PersistentPreRunE: requirePDClient,
+		Run:               showClusterCommandFunc,
 	}
 	cmd.AddCommand(NewClusterStatusCommand())
 	return cmd

--- a/tools/pd-ctl/pdctl/command/cluster_command.go
+++ b/tools/pd-ctl/pdctl/command/cluster_command.go
@@ -19,9 +19,10 @@ import "github.com/spf13/cobra"
 // NewClusterCommand return a cluster subcommand of rootCmd
 func NewClusterCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cluster",
-		Short: "show the cluster information",
-		Run:   showClusterCommandFunc,
+		Use:               "cluster",
+		Short:             "show the cluster information",
+		Run:               showClusterCommandFunc,
+		PersistentPreRunE: requirePDClient,
 	}
 	cmd.AddCommand(NewClusterStatusCommand())
 	return cmd

--- a/tools/pd-ctl/pdctl/command/ping_command.go
+++ b/tools/pd-ctl/pdctl/command/ping_command.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const pingPrefix = "pd/api/v1/ping"
+
 // NewPingCommand return a ping subcommand of rootCmd
 func NewPingCommand() *cobra.Command {
 	m := &cobra.Command{

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -35,14 +35,18 @@ func init() {
 // GetRootCmd is exposed for integration tests. But it can be embedded into another suite, too.
 func GetRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "pd-ctl",
-		Short: "Placement Driver control",
+		Use:               "pd-ctl",
+		Short:             "Placement Driver control",
+		PersistentPreRunE: command.RequireHTTPSClient,
+		SilenceErrors:     true,
 	}
 
 	rootCmd.PersistentFlags().StringP("pd", "u", "http://127.0.0.1:2379", "address of PD")
 	rootCmd.PersistentFlags().String("cacert", "", "path of file that contains list of trusted SSL CAs")
 	rootCmd.PersistentFlags().String("cert", "", "path of file that contains X509 certificate in PEM format")
 	rootCmd.PersistentFlags().String("key", "", "path of file that contains X509 key in PEM format")
+
+	rootCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
 
 	rootCmd.AddCommand(
 		command.NewConfigCommand(),
@@ -69,29 +73,6 @@ func GetRootCmd() *cobra.Command {
 		command.NewKeyspaceCommand(),
 		command.NewResourceManagerCommand(),
 	)
-
-	rootCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
-	rootCmd.SilenceErrors = true
-
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		caPath, err := cmd.Flags().GetString("cacert")
-		if err == nil && len(caPath) != 0 {
-			certPath, err := cmd.Flags().GetString("cert")
-			if err != nil {
-				return err
-			}
-			keyPath, err := cmd.Flags().GetString("key")
-			if err != nil {
-				return err
-			}
-			err = command.InitHTTPSClient(caPath, certPath, keyPath)
-			if err != nil {
-				rootCmd.Println(err)
-				return err
-			}
-		}
-		return nil
-	}
 
 	return rootCmd
 }

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -89,17 +89,6 @@ func GetRootCmd() *cobra.Command {
 				rootCmd.Println(err)
 				return err
 			}
-			err = command.InitNewPDClientWithTLS(cmd, caPath, certPath, keyPath)
-			if err != nil {
-				rootCmd.Println(err)
-				return err
-			}
-		} else {
-			err = command.InitNewPDClient(cmd)
-			if err != nil {
-				rootCmd.Println(err)
-				return err
-			}
 		}
 		return nil
 	}

--- a/tools/pd-ctl/tests/helper.go
+++ b/tools/pd-ctl/tests/helper.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/response"
 	"github.com/tikv/pd/pkg/utils/typeutil"
-	"github.com/tikv/pd/tools/pd-ctl/pdctl/command"
 )
 
 // ExecuteCommand is used for test purpose.
@@ -31,8 +30,6 @@ func ExecuteCommand(root *cobra.Command, args ...string) (output []byte, err err
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
 	root.SetArgs(args)
-	command.SetNewPDClient([]string{args[1]})
-	defer command.PDCli.Close()
 	err = root.Execute()
 	return buf.Bytes(), err
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7300.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Avoid initializing a new PD client for each cmd execution. Now we will only initialize a new one when the cluster changes.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```shell
./bin/pd-ctl -i
» tso 123
system:  1970-01-01 08:00:00 +0800 CST
logic:   123
» cluster
Usage:
  pd-ctl cluster [flags]
  pd-ctl cluster [command]

Available Commands:
  status      show the cluster status

Flags:
  -h, --help   help for cluster

Use "pd-ctl cluster [command] --help" for more information about a command.

Get "http://127.0.0.1:2379/pd/api/v1/cluster": dial tcp 127.0.0.1:2379: connect: connection refused
// Start the cluster
» cluster
{
  "id": 7332031263979491699,
  "max_peer_count": 3
}
// Start another cluster
» -u http://127.0.0.1:63039 cluster
{
  "id": 7332031352003469768,
  "max_peer_count": 3
}
» -u http://127.0.0.1:63 cluster
Usage:
  pd-ctl cluster [flags]
  pd-ctl cluster [command]

Available Commands:
  status      show the cluster status

Flags:
  -h, --help   help for cluster

Use "pd-ctl cluster [command] --help" for more information about a command.

Get "http://127.0.0.1:63/pd/api/v1/cluster": dial tcp 127.0.0.1:63: connect: connection refused
» store 1
{
  "store": {
    "id": 1,
    "address": "127.0.0.1:20160",
    "version": "8.0.0-alpha",
    "peer_address": "127.0.0.1:20160",
    "status_address": "127.0.0.1:20180",
    "git_hash": "04370e9ef47c2768d368cb62309631018be3eaa8",
    "start_timestamp": 1707121719,
    "deploy_path": "/Users/jmpotato/.tiup/components/tikv/v8.0.0-alpha-nightly",
    "last_heartbeat": 1707121729917357000,
    "node_state": 1,
    "state_name": "Up"
  },
  "status": {
    "capacity": "460.4GiB",
    "available": "145.2GiB",
    "used_size": "290.8MiB",
    "leader_count": 61,
    "leader_weight": 1,
    "leader_score": 61,
    "leader_size": 60,
    "region_count": 61,
    "region_weight": 1,
    "region_score": 140.93049047606394,
    "region_size": 60,
    "slow_score": 1,
    "slow_trend": {
      "cause_value": 250010.35204081633,
      "cause_rate": 0,
      "result_value": 0,
      "result_rate": 0
    },
    "is_busy": true,
    "start_ts": "2024-02-05T16:28:39+08:00",
    "last_heartbeat_ts": "2024-02-05T16:28:49.917357+08:00",
    "uptime": "10.917357s"
  }
}
» -u http://127.0.0.1:63693 store 1
{
  "store": {
    "id": 1,
    "address": "127.0.0.1:63694",
    "version": "8.0.0-alpha",
    "peer_address": "127.0.0.1:63694",
    "status_address": "127.0.0.1:63695",
    "git_hash": "04370e9ef47c2768d368cb62309631018be3eaa8",
    "start_timestamp": 1707121730,
    "deploy_path": "/Users/jmpotato/.tiup/components/tikv/v8.0.0-alpha-nightly",
    "last_heartbeat": 1707121760528419000,
    "node_state": 1,
    "state_name": "Up"
  },
  "status": {
    "capacity": "460.4GiB",
    "available": "145GiB",
    "used_size": "290.8MiB",
    "leader_count": 61,
    "leader_weight": 1,
    "leader_score": 61,
    "leader_size": 60,
    "region_count": 61,
    "region_weight": 1,
    "region_score": 141.0322261693217,
    "region_size": 60,
    "slow_score": 1,
    "slow_trend": {
      "cause_value": 250007.81016949154,
      "cause_rate": 0,
      "result_value": 19.5,
      "result_rate": 0
    },
    "is_busy": true,
    "start_ts": "2024-02-05T16:28:50+08:00",
    "last_heartbeat_ts": "2024-02-05T16:29:20.528419+08:00",
    "uptime": "30.528419s"
  }
}
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
