### PR TITLE
mcs: wait until API server is ready

### DIFF
--- a/pkg/mcs/utils/constant.go
+++ b/pkg/mcs/utils/constant.go
@@ -17,8 +17,6 @@ package utils
 import "time"
 
 const (
-	// MaxRetryTimesWaitAPIService is the max retry times for initializing the cluster ID.
-	MaxRetryTimesWaitAPIService = 360
 	// RetryIntervalWaitAPIService is the interval to retry.
 	// Note: the interval must be less than the timeout of tidb and tikv, which is 2s by default in tikv.
 	RetryIntervalWaitAPIService = 500 * time.Millisecond

--- a/pkg/mcs/utils/util.go
+++ b/pkg/mcs/utils/util.go
@@ -123,7 +123,7 @@ func WaitAPIServiceReady(s server) error {
 	)
 	ticker := time.NewTicker(RetryIntervalWaitAPIService)
 	defer ticker.Stop()
-	for i := 0; i < MaxRetryTimesWaitAPIService; i++ {
+	for {
 		ready, err = isAPIServiceReady(s)
 		if err == nil && ready {
 			return nil
@@ -135,10 +135,6 @@ func WaitAPIServiceReady(s server) error {
 		case <-ticker.C:
 		}
 	}
-	if err != nil {
-		log.Warn("failed to check api server ready", errs.ZapError(err))
-	}
-	return errors.Errorf("failed to wait api server ready after retrying %d times", MaxRetryTimesWaitAPIService)
 }
 
 func isAPIServiceReady(s server) (bool, error) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #5839.

### What is changed and how does it work?
TSO and scheduling server should keep waiting until the API server is ready.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
