### PR TITLE
scheduler: avoid to updateCounts frequently

### DIFF
--- a/pkg/schedule/operator/operator.go
+++ b/pkg/schedule/operator/operator.go
@@ -99,6 +99,10 @@ func NewOperator(desc, brief string, regionID uint64, regionEpoch *metapb.Region
 	for _, v := range steps {
 		maxDuration += v.Timeout(approximateSize).Seconds()
 	}
+	if desc == "scatter-region" {
+		// set an hour
+		maxDuration = 3600
+	}
 	return &Operator{
 		desc:            desc,
 		brief:           brief,

--- a/pkg/schedule/operator/operator.go
+++ b/pkg/schedule/operator/operator.go
@@ -99,10 +99,6 @@ func NewOperator(desc, brief string, regionID uint64, regionEpoch *metapb.Region
 	for _, v := range steps {
 		maxDuration += v.Timeout(approximateSize).Seconds()
 	}
-	if desc == "scatter-region" {
-		// set an hour
-		maxDuration = 3600
-	}
 	return &Operator{
 		desc:            desc,
 		brief:           brief,

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -560,6 +560,7 @@ func (oc *Controller) removeOperatorsLocked() []*Operator {
 	var removed []*Operator
 	for regionID, op := range oc.operators {
 		delete(oc.operators, regionID)
+		oc.counts[op.SchedulerKind()]--
 		operatorCounter.WithLabelValues(op.Desc(), "remove").Inc()
 		oc.ack(op)
 		if op.Kind()&OpMerge != 0 {
@@ -567,7 +568,6 @@ func (oc *Controller) removeOperatorsLocked() []*Operator {
 		}
 		removed = append(removed, op)
 	}
-	oc.updateCounts(oc.operators)
 	return removed
 }
 
@@ -781,16 +781,6 @@ func (oc *Controller) GetHistory(start time.Time) []OpHistory {
 		history = append(history, op.History()...)
 	}
 	return history
-}
-
-// updateCounts updates resource counts using current pending operators.
-func (oc *Controller) updateCounts(operators map[uint64]*Operator) {
-	for k := range oc.counts {
-		delete(oc.counts, k)
-	}
-	for _, op := range operators {
-		oc.counts[op.SchedulerKind()]++
-	}
 }
 
 // OperatorCount gets the count of operators filtered by kind.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7837

### What is changed and how does it work?
<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Use O(1) method to update `counts`.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

before PR, the speed of create operator decreased.
![image](https://github.com/tikv/pd/assets/36503113/63053ba7-7e94-46d2-88a2-e2b2205fd494)

after PR
![image](https://github.com/tikv/pd/assets/36503113/ae31ef7c-6804-4546-8a41-6eb4a427c2b4)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
