### PR TITLE
etcdutil: only output the log when picked count > 0

### DIFF
--- a/pkg/utils/etcdutil/health_checker.go
+++ b/pkg/utils/etcdutil/health_checker.go
@@ -274,12 +274,14 @@ func (checker *healthChecker) updateEvictedEps(lastEps, pickedEps []string) {
 		pickedSet[ep] = true
 	}
 	// Reset the count to 0 if it's in evictedEps but not in the pickedEps.
-	checker.evictedEps.Range(func(key, _ any) bool {
+	checker.evictedEps.Range(func(key, value any) bool {
 		ep := key.(string)
-		if !pickedSet[ep] {
+		count := value.(int)
+		if count > 0 && !pickedSet[ep] {
 			checker.evictedEps.Store(ep, 0)
 			log.Info("reset evicted etcd endpoint picked count",
 				zap.String("endpoint", ep),
+				zap.Int("previous-count", count),
 				zap.String("source", checker.source))
 		}
 		return true


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #7844.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Only output the log when picked count > 0 in `updateEvictedEps`.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
