### PR TITLE
Revert "cluster: don't collect region stats in API mode (#7817)"

### DIFF
--- a/server/api/server.go
+++ b/server/api/server.go
@@ -41,6 +41,8 @@ func NewHandler(_ context.Context, svr *server.Server) (http.Handler, apiutil.AP
 	r := createRouter(apiPrefix, svr)
 	router := mux.NewRouter()
 
+	// TODO: we should support forward "regions/check/xxx" to scheduling server.
+
 	// Following requests are redirected:
 	// 	"/admin/reset-ts", http.MethodPost
 	//	"/operators", http.MethodGet

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -41,8 +41,6 @@ func NewHandler(_ context.Context, svr *server.Server) (http.Handler, apiutil.AP
 	r := createRouter(apiPrefix, svr)
 	router := mux.NewRouter()
 
-	// TODO: we should support forward "regions/check/xxx" to scheduling server.
-
 	// Following requests are redirected:
 	// 	"/admin/reset-ts", http.MethodPost
 	//	"/operators", http.MethodGet

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1008,6 +1008,9 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	if !saveKV && !saveCache {
 		// Due to some config changes need to update the region stats as well,
 		// so we do some extra checks here.
+		// TODO: Due to the accuracy requirements of the API "/regions/check/xxx",
+		// region stats needs to be collected in API mode.
+		// We need to think of a better way to reduce this part of the cost in the future.
 		if hasRegionStats && c.regionStats.RegionStatsNeedUpdate(region) {
 			c.regionStats.Observe(region, c.getRegionStoresLocked(region))
 		}
@@ -1036,6 +1039,9 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		regionUpdateCacheEventCounter.Inc()
 	}
 
+	// TODO: Due to the accuracy requirements of the API "/regions/check/xxx",
+	// region stats needs to be collected in API mode.
+	// We need to think of a better way to reduce this part of the cost in the future.
 	cluster.Collect(c, region, c.GetRegionStores(region), hasRegionStats)
 
 	if c.storage != nil {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1005,7 +1005,7 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 	// Save to storage if meta is updated, except for flashback.
 	// Save to cache if meta or leader is updated, or contains any down/pending peer.
 	saveKV, saveCache, needSync := regionGuide(region, origin)
-	if !c.IsServiceIndependent(mcsutils.SchedulingServiceName) && !saveKV && !saveCache {
+	if !saveKV && !saveCache {
 		// Due to some config changes need to update the region stats as well,
 		// so we do some extra checks here.
 		if hasRegionStats && c.regionStats.RegionStatsNeedUpdate(region) {
@@ -1035,9 +1035,8 @@ func (c *RaftCluster) processRegionHeartbeat(region *core.RegionInfo) error {
 		}
 		regionUpdateCacheEventCounter.Inc()
 	}
-	if !c.IsServiceIndependent(mcsutils.SchedulingServiceName) {
-		cluster.Collect(c, region, c.GetRegionStores(region), hasRegionStats)
-	}
+
+	cluster.Collect(c, region, c.GetRegionStores(region), hasRegionStats)
 
 	if c.storage != nil {
 		// If there are concurrent heartbeats from the same region, the last write will win even if

--- a/tests/server/api/region_test.go
+++ b/tests/server/api/region_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/schedule/placement"
-	"github.com/tikv/pd/pkg/statistics"
 	tu "github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/tests"
 )
@@ -171,32 +170,6 @@ func (suite *regionTestSuite) checkAccelerateRegionsScheduleInRange(cluster *tes
 		idList = sche.GetCluster().GetCoordinator().GetCheckerController().GetSuspectRegions()
 	}
 	re.Len(idList, 2, len(idList))
-}
-
-func (suite *regionTestSuite) TestRegionStats() {
-	env := tests.NewSchedulingTestEnvironment(suite.T())
-	env.RunTestInAPIMode(suite.checkRegionStats)
-	env.Cleanup()
-}
-
-func (suite *regionTestSuite) checkRegionStats(cluster *tests.TestCluster) {
-	re := suite.Require()
-	leader := cluster.GetLeaderServer()
-	rc := leader.GetRaftCluster()
-	re.NotNil(rc)
-	for i := 13; i <= 16; i++ {
-		s1 := &metapb.Store{
-			Id:        uint64(i),
-			State:     metapb.StoreState_Up,
-			NodeState: metapb.NodeState_Serving,
-		}
-		tests.MustPutStore(re, cluster, s1)
-	}
-	r := core.NewTestRegionInfo(1001, 13, []byte("b1"), []byte("b2"), core.SetApproximateSize(0))
-	r.GetMeta().Peers = append(r.GetMeta().Peers, &metapb.Peer{Id: 5, StoreId: 14}, &metapb.Peer{Id: 6, StoreId: 15})
-	tests.MustPutRegionInfo(re, cluster, r)
-	suite.checkRegionCount(re, cluster, 1)
-	re.False(rc.GetRegionStats().IsRegionStatsType(1001, statistics.EmptyRegion))
 }
 
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRanges() {


### PR DESCRIPTION
This reverts commit e264a6143f6d8badde7783577c5fced5dcb2c39f.

now we don't support forward `regions/check` request to scheduling server, so revert it.

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5839

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
