### PR TITLE
mcs: register tso allocator

### DIFF
--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -318,7 +318,7 @@ func (*Server) SetExternalTS(uint64) error {
 
 // ResetTS resets the TSO with the specified one.
 func (s *Server) ResetTS(ts uint64, ignoreSmaller, skipUpperBoundCheck bool, keyspaceGroupID uint32) error {
-	log.Info("reset-ts",
+	log.Info("reset ts",
 		zap.Uint64("new-ts", ts),
 		zap.Bool("ignore-smaller", ignoreSmaller),
 		zap.Bool("skip-upper-bound-check", skipUpperBoundCheck),

--- a/pkg/tso/allocator_manager.go
+++ b/pkg/tso/allocator_manager.go
@@ -171,6 +171,8 @@ type AllocatorManager struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	etcdClient *clientv3.Client
 	// kgID is the keyspace group ID
 	kgID uint32
 	// member is for election use
@@ -184,9 +186,11 @@ type AllocatorManager struct {
 	// leaderLease defines the time within which a TSO primary/leader must update its TTL
 	// in etcd, otherwise etcd will expire the leader key and other servers can campaign
 	// the primary/leader again. Etcd only supports seconds TTL, so here is second too.
-	leaderLease    int64
-	maxResetTSGap  func() time.Duration
-	securityConfig *grpcutil.TLSConfig
+	leaderLease        int64
+	maxResetTSGap      func() time.Duration
+	securityConfig     *grpcutil.TLSConfig
+	allocatorKeyPrefix string
+	allocatorKey       string
 	// for gRPC use
 	localAllocatorConn struct {
 		syncutil.RWMutex
@@ -197,16 +201,19 @@ type AllocatorManager struct {
 // NewAllocatorManager creates a new TSO Allocator Manager.
 func NewAllocatorManager(
 	ctx context.Context,
+	etcdClient *clientv3.Client,
 	keyspaceGroupID uint32,
 	member ElectionMember,
 	rootPath string,
 	storage endpoint.TSOStorage,
 	cfg Config,
+	allocatorKeyPrefix string,
 ) *AllocatorManager {
 	ctx, cancel := context.WithCancel(ctx)
 	am := &AllocatorManager{
 		ctx:                    ctx,
 		cancel:                 cancel,
+		etcdClient:             etcdClient,
 		kgID:                   keyspaceGroupID,
 		member:                 member,
 		rootPath:               rootPath,
@@ -217,6 +224,8 @@ func NewAllocatorManager(
 		leaderLease:            cfg.GetLeaderLease(),
 		maxResetTSGap:          cfg.GetMaxResetTSGap,
 		securityConfig:         cfg.GetTLSConfig(),
+		allocatorKey:           path.Join(allocatorKeyPrefix, fmt.Sprintf("keyspace_group_%d", keyspaceGroupID)),
+		allocatorKeyPrefix:     allocatorKeyPrefix,
 	}
 	am.mu.allocatorGroups = make(map[string]*allocatorGroup)
 	am.mu.clusterDCLocations = make(map[string]*DCLocationInfo)

--- a/pkg/tso/allocator_manager.go
+++ b/pkg/tso/allocator_manager.go
@@ -208,6 +208,7 @@ func NewAllocatorManager(
 	storage endpoint.TSOStorage,
 	cfg Config,
 	allocatorKeyPrefix string,
+	allocatorKey string,
 ) *AllocatorManager {
 	ctx, cancel := context.WithCancel(ctx)
 	am := &AllocatorManager{
@@ -224,8 +225,8 @@ func NewAllocatorManager(
 		leaderLease:            cfg.GetLeaderLease(),
 		maxResetTSGap:          cfg.GetMaxResetTSGap,
 		securityConfig:         cfg.GetTLSConfig(),
-		allocatorKey:           path.Join(allocatorKeyPrefix, fmt.Sprintf("keyspace_group_%d", keyspaceGroupID)),
 		allocatorKeyPrefix:     allocatorKeyPrefix,
+		allocatorKey:           allocatorKey,
 	}
 	am.mu.allocatorGroups = make(map[string]*allocatorGroup)
 	am.mu.clusterDCLocations = make(map[string]*DCLocationInfo)

--- a/pkg/tso/global_allocator.go
+++ b/pkg/tso/global_allocator.go
@@ -45,6 +45,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const ttlSeconds = 3
+
 // Allocator is a Timestamp Oracle allocator.
 type Allocator interface {
 	// Initialize is used to initialize a TSO allocator.
@@ -732,7 +734,7 @@ func (gta *GlobalTSOAllocator) registerAllocator() error {
 }
 
 func (gta *GlobalTSOAllocator) renewKeepalive() <-chan *clientv3.LeaseKeepAliveResponse {
-	t := time.NewTicker(time.Duration(3) * time.Second / 2)
+	t := time.NewTicker(time.Duration(ttlSeconds) * time.Second / 2)
 	defer t.Stop()
 	for {
 		select {
@@ -748,7 +750,7 @@ func (gta *GlobalTSOAllocator) renewKeepalive() <-chan *clientv3.LeaseKeepAliveR
 func (gta *GlobalTSOAllocator) txnWithTTL(key, value string) (clientv3.LeaseID, error) {
 	ctx, cancel := context.WithTimeout(gta.ctx, etcdutil.DefaultRequestTimeout)
 	defer cancel()
-	grantResp, err := gta.am.etcdClient.Grant(ctx, 3)
+	grantResp, err := gta.am.etcdClient.Grant(ctx, ttlSeconds)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/tso/global_allocator.go
+++ b/pkg/tso/global_allocator.go
@@ -775,38 +775,48 @@ func (gta *GlobalTSOAllocator) deregisterAllocator() error {
 }
 
 func (gta *GlobalTSOAllocator) tryRegister() <-chan *clientv3.LeaseKeepAliveResponse {
+	// register immediately
+	kresp, needRetry := gta.register()
+	if !needRetry {
+		return kresp
+	}
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
-outerLoop:
 	for {
 		select {
 		case <-gta.ctx.Done():
 			return nil
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(gta.ctx, time.Duration(3)*time.Second)
-			resp, err := gta.am.etcdClient.Get(ctx, gta.am.allocatorKeyPrefix, clientv3.WithPrefix())
-			cancel()
-			if err != nil {
-				continue
+			if kresp, needRetry := gta.register(); !needRetry {
+				return kresp
 			}
-			// wait for the previous allocator with different mode to be deregistered
-			if len(resp.Kvs) > 0 {
-				for _, kv := range resp.Kvs {
-					key := string(kv.Key)
-					if !strings.Contains(key, gta.am.allocatorKeyPrefix) {
-						continue outerLoop
-					}
-				}
-			}
-			id, err := gta.txnWithTTL(gta.am.allocatorKey, "")
-			if err != nil {
-				continue
-			}
-			kresp, err := gta.am.etcdClient.KeepAlive(gta.ctx, id)
-			if err != nil {
-				continue
-			}
-			return kresp
 		}
 	}
+}
+
+func (gta *GlobalTSOAllocator) register() (<-chan *clientv3.LeaseKeepAliveResponse, bool) {
+	ctx, cancel := context.WithTimeout(gta.ctx, time.Duration(3)*time.Second)
+	resp, err := gta.am.etcdClient.Get(ctx, gta.am.allocatorKeyPrefix, clientv3.WithPrefix())
+	cancel()
+	if err != nil {
+		return nil, true
+	}
+	// wait for the previous allocator with different mode to be deregistered
+	if len(resp.Kvs) > 0 {
+		for _, kv := range resp.Kvs {
+			key := string(kv.Key)
+			if !strings.Contains(key, gta.am.allocatorKeyPrefix) {
+				return nil, true
+			}
+		}
+	}
+	id, err := gta.txnWithTTL(gta.am.allocatorKey, "")
+	if err != nil {
+		return nil, true
+	}
+	kresp, err := gta.am.etcdClient.KeepAlive(gta.ctx, id)
+	if err != nil {
+		return nil, true
+	}
+	return kresp, false
 }

--- a/pkg/tso/global_allocator.go
+++ b/pkg/tso/global_allocator.go
@@ -40,7 +40,7 @@ import (
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
-	"go.etcd.io/etcd/clientv3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )

--- a/pkg/tso/global_allocator.go
+++ b/pkg/tso/global_allocator.go
@@ -775,7 +775,7 @@ func (gta *GlobalTSOAllocator) deregisterAllocator() error {
 }
 
 func (gta *GlobalTSOAllocator) tryRegister() <-chan *clientv3.LeaseKeepAliveResponse {
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 outerLoop:
 	for {

--- a/pkg/tso/global_allocator.go
+++ b/pkg/tso/global_allocator.go
@@ -34,10 +34,13 @@ import (
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/member"
 	"github.com/tikv/pd/pkg/slice"
+	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
+	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -130,6 +133,9 @@ func newGlobalTimestampOracle(am *AllocatorManager) *timestampOracle {
 // close is used to shutdown the primary election loop.
 // tso service call this function to shutdown the loop here, but pd manages its own loop.
 func (gta *GlobalTSOAllocator) close() {
+	if err := gta.deregisterAllocator(); err != nil {
+		log.Warn("deregister tso allocator failed", zap.String("key", gta.am.allocatorKey), errs.ZapError(err))
+	}
 	gta.cancel()
 	gta.wg.Wait()
 }
@@ -183,6 +189,9 @@ func (gta *GlobalTSOAllocator) estimateMaxTS(ctx context.Context, count uint32, 
 
 // Initialize will initialize the created global TSO allocator.
 func (gta *GlobalTSOAllocator) Initialize(int) error {
+	if err := gta.registerAllocator(); err != nil {
+		return err
+	}
 	gta.tsoAllocatorRoleGauge.Set(1)
 	// The suffix of a Global TSO should always be 0.
 	gta.timestampOracle.suffix = 0
@@ -694,4 +703,110 @@ func (gta *GlobalTSOAllocator) GetExpectedPrimaryLease() *election.Lease {
 
 func (gta *GlobalTSOAllocator) getMetrics() *tsoMetrics {
 	return gta.timestampOracle.metrics
+}
+
+// registerAllocator registers the tso allocator to etcd.
+// It is used when switching mode between pd and ms. We need to make sure only one TSO allocator is working at the same time.
+func (gta *GlobalTSOAllocator) registerAllocator() error {
+	log.Info("register tso allocator", zap.String("key", gta.am.allocatorKey))
+	kresp := gta.tryRegister()
+	if kresp == nil {
+		return errors.New("context canceled")
+	}
+	go func() {
+		defer logutil.LogPanic()
+		for {
+			select {
+			case <-gta.ctx.Done():
+				log.Info("exit register tso allocator", zap.String("key", gta.am.allocatorKey))
+				return
+			case _, ok := <-kresp:
+				if !ok {
+					log.Error("keep alive tso allocator failed", zap.String("key", gta.am.allocatorKey))
+					kresp = gta.renewKeepalive()
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (gta *GlobalTSOAllocator) renewKeepalive() <-chan *clientv3.LeaseKeepAliveResponse {
+	t := time.NewTicker(time.Duration(3) * time.Second / 2)
+	defer t.Stop()
+	for {
+		select {
+		case <-gta.ctx.Done():
+			log.Info("exit register tso allocator", zap.String("key", gta.am.allocatorKey))
+			return nil
+		case <-t.C:
+			return gta.tryRegister()
+		}
+	}
+}
+
+func (gta *GlobalTSOAllocator) txnWithTTL(key, value string) (clientv3.LeaseID, error) {
+	ctx, cancel := context.WithTimeout(gta.ctx, etcdutil.DefaultRequestTimeout)
+	defer cancel()
+	grantResp, err := gta.am.etcdClient.Grant(ctx, 3)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := kv.NewSlowLogTxn(gta.am.etcdClient).
+		Then(clientv3.OpPut(key, value, clientv3.WithLease(grantResp.ID))).
+		Commit()
+	if err != nil {
+		return 0, errs.ErrEtcdTxnInternal.Wrap(err).GenWithStackByArgs()
+	}
+	if !resp.Succeeded {
+		return 0, errs.ErrEtcdTxnConflict.FastGenByArgs()
+	}
+
+	return grantResp.ID, nil
+}
+
+// deregisterAllocator deregisters the tso allocator from etcd.
+func (gta *GlobalTSOAllocator) deregisterAllocator() error {
+	log.Info("deregister tso allocator", zap.String("key", gta.am.allocatorKey))
+	ctx, cancel := context.WithTimeout(gta.ctx, time.Duration(3)*time.Second)
+	defer cancel()
+	_, err := gta.am.etcdClient.Delete(ctx, gta.am.allocatorKey)
+	return err
+}
+
+func (gta *GlobalTSOAllocator) tryRegister() <-chan *clientv3.LeaseKeepAliveResponse {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+outerLoop:
+	for {
+		select {
+		case <-gta.ctx.Done():
+			return nil
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(gta.ctx, time.Duration(3)*time.Second)
+			resp, err := gta.am.etcdClient.Get(ctx, gta.am.allocatorKeyPrefix, clientv3.WithPrefix())
+			cancel()
+			if err != nil {
+				continue
+			}
+			// wait for the previous allocator with different mode to be deregistered
+			if len(resp.Kvs) > 0 {
+				for _, kv := range resp.Kvs {
+					key := string(kv.Key)
+					if !strings.Contains(key, gta.am.allocatorKeyPrefix) {
+						continue outerLoop
+					}
+				}
+			}
+			id, err := gta.txnWithTTL(gta.am.allocatorKey, "")
+			if err != nil {
+				continue
+			}
+			kresp, err := gta.am.etcdClient.KeepAlive(gta.ctx, id)
+			if err != nil {
+				continue
+			}
+			return kresp
+		}
+	}
 }

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -322,7 +322,6 @@ type KeyspaceGroupManager struct {
 
 	// tsoServiceID is the service ID of the TSO service, registered in the service discovery
 	tsoServiceID *discovery.ServiceRegistryEntry
-	clusterID    uint64
 	etcdClient   *clientv3.Client
 	httpClient   *http.Client
 	// electionNamePrefix is the name prefix to generate the unique name of a participant,
@@ -417,7 +416,6 @@ func NewKeyspaceGroupManager(
 		ctx:                          ctx,
 		cancel:                       cancel,
 		tsoServiceID:                 tsoServiceID,
-		clusterID:                    clusterID,
 		etcdClient:                   etcdClient,
 		httpClient:                   httpClient,
 		electionNamePrefix:           electionNamePrefix,

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -1102,6 +1102,9 @@ func (kgm *KeyspaceGroupManager) HandleTSORequest(
 		if err != nil {
 			return err
 		}
+		if allocator.IsInitialize() {
+			return nil
+		}
 		// TODO: support the Local TSO Allocator.
 		return allocator.Initialize(0)
 	})

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -1102,9 +1102,6 @@ func (kgm *KeyspaceGroupManager) HandleTSORequest(
 		if err != nil {
 			return err
 		}
-		if allocator.IsInitialize() {
-			return nil
-		}
 		// TODO: support the Local TSO Allocator.
 		return allocator.Initialize(0)
 	})

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"path"
 	"regexp"
 	"sort"
 	"sync"
@@ -321,6 +322,7 @@ type KeyspaceGroupManager struct {
 
 	// tsoServiceID is the service ID of the TSO service, registered in the service discovery
 	tsoServiceID *discovery.ServiceRegistryEntry
+	clusterID    uint64
 	etcdClient   *clientv3.Client
 	httpClient   *http.Client
 	// electionNamePrefix is the name prefix to generate the unique name of a participant,
@@ -415,6 +417,7 @@ func NewKeyspaceGroupManager(
 		ctx:                          ctx,
 		cancel:                       cancel,
 		tsoServiceID:                 tsoServiceID,
+		clusterID:                    clusterID,
 		etcdClient:                   etcdClient,
 		httpClient:                   httpClient,
 		electionNamePrefix:           electionNamePrefix,
@@ -789,7 +792,7 @@ func (kgm *KeyspaceGroupManager) updateKeyspaceGroup(group *endpoint.KeyspaceGro
 		storage = kgm.tsoSvcStorage
 	}
 	// Initialize all kinds of maps.
-	am := NewAllocatorManager(kgm.ctx, group.ID, participant, tsRootPath, storage, kgm.cfg)
+	am := NewAllocatorManager(kgm.ctx, kgm.etcdClient, group.ID, participant, tsRootPath, storage, kgm.cfg, path.Join(keypath.GlobalTSOAllocatorsPrefix(), "tso"))
 	am.startGlobalAllocatorLoop()
 	log.Info("created allocator manager",
 		zap.Uint32("keyspace-group-id", group.ID),

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -792,7 +792,8 @@ func (kgm *KeyspaceGroupManager) updateKeyspaceGroup(group *endpoint.KeyspaceGro
 		storage = kgm.tsoSvcStorage
 	}
 	// Initialize all kinds of maps.
-	am := NewAllocatorManager(kgm.ctx, kgm.etcdClient, group.ID, participant, tsRootPath, storage, kgm.cfg, path.Join(keypath.GlobalTSOAllocatorsPrefix(), "tso"))
+	allocatorKeyPrefix := keypath.GlobalTSOAllocatorsPrefix()
+	am := NewAllocatorManager(kgm.ctx, kgm.etcdClient, group.ID, participant, tsRootPath, storage, kgm.cfg, allocatorKeyPrefix, path.Join(allocatorKeyPrefix, "tso", fmt.Sprintf("keyspace_group_%d", group.ID)))
 	am.startGlobalAllocatorLoop()
 	log.Info("created allocator manager",
 		zap.Uint32("keyspace-group-id", group.ID),

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -33,7 +33,9 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
+	"github.com/tikv/pd/pkg/member"
 	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/syncutil"
@@ -43,6 +45,7 @@ import (
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/goleak"
 )
 
@@ -59,6 +62,7 @@ type keyspaceGroupManagerTestSuite struct {
 	etcdClient       *clientv3.Client
 	clean            func()
 	cfg              *TestServiceConfig
+	servers          []*embed.Etcd
 }
 
 func TestKeyspaceGroupManagerTestSuite(t *testing.T) {
@@ -69,8 +73,8 @@ func (suite *keyspaceGroupManagerTestSuite) SetupSuite() {
 	t := suite.T()
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	suite.ClusterID = rand.Uint64()
-	servers, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
-	suite.backendEndpoints, suite.etcdClient, suite.clean = servers[0].Config().ListenClientUrls[0].String(), client, clean
+	suite.servers, suite.etcdClient, suite.clean = etcdutil.NewTestEtcdCluster(t, 1)
+	suite.backendEndpoints = suite.servers[0].Config().ListenClientUrls[0].String()
 	suite.cfg = suite.createConfig()
 }
 
@@ -1216,4 +1220,47 @@ func waitForPrimariesServing(
 		}
 		return true
 	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+}
+
+func (suite *keyspaceGroupManagerTestSuite) TestRegisterAllocatorConflict() {
+	re := suite.Require()
+
+	kgm := suite.newKeyspaceGroupManager(0, suite.ClusterID, suite.cfg)
+	re.NotNil(kgm)
+	defer kgm.Close()
+	kgm.Initialize()
+	participant, err := kgm.GetElectionMember(0, 0)
+	re.NoError(err)
+
+	legacySvcRootPath := keypath.LegacyRootPath(suite.ClusterID)
+	allocatorKeyPrefix := keypath.GlobalTSOAllocatorsPrefix(suite.ClusterID)
+	legacySvcStorage := endpoint.NewStorageEndpoint(kv.NewEtcdKVBase(suite.etcdClient, legacySvcRootPath), nil)
+	member := member.NewMember(suite.servers[0], suite.etcdClient, uint64(suite.servers[0].Server.ID()))
+	am := NewAllocatorManager(suite.ctx, suite.etcdClient, constant.DefaultKeyspaceGroupID, member, legacySvcRootPath, legacySvcStorage, kgm.cfg, allocatorKeyPrefix, path.Join(allocatorKeyPrefix, "pd"))
+	gta := NewGlobalTSOAllocator(suite.ctx, am)
+	err = gta.Initialize(0)
+	re.NoError(err)
+
+	kam := NewAllocatorManager(kgm.ctx, kgm.etcdClient, constant.DefaultKeyspaceGroupID, participant, kgm.legacySvcRootPath, kgm.legacySvcStorage, kgm.cfg, allocatorKeyPrefix, path.Join(allocatorKeyPrefix, "tso", fmt.Sprintf("keyspace_group_%d", constant.DefaultKeyspaceGroupID)))
+	kgta := NewGlobalTSOAllocator(suite.ctx, kam)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err = kgta.Initialize(0)
+		re.NoError(err)
+	}()
+
+	gta.Reset()
+	wg.Wait()
+
+	var wg1 sync.WaitGroup
+	wg1.Add(1)
+	go func() {
+		defer wg1.Done()
+		err = gta.Initialize(0)
+		re.NoError(err)
+	}()
+	kgta.Reset()
+	wg1.Wait()
 }

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1225,8 +1225,8 @@ func waitForPrimariesServing(
 func (suite *keyspaceGroupManagerTestSuite) TestRegisterAllocatorConflict() {
 	re := suite.Require()
 
-	legacySvcRootPath := keypath.LegacyRootPath(suite.ClusterID)
-	allocatorKeyPrefix := keypath.GlobalTSOAllocatorsPrefix(suite.ClusterID)
+	legacySvcRootPath := keypath.LegacyRootPath()
+	allocatorKeyPrefix := keypath.GlobalTSOAllocatorsPrefix()
 	legacySvcStorage := endpoint.NewStorageEndpoint(kv.NewEtcdKVBase(suite.etcdClient, legacySvcRootPath), nil)
 	m := member.NewMember(suite.servers[0], suite.etcdClient, uint64(suite.servers[0].Server.ID()))
 	am := NewAllocatorManager(suite.ctx, suite.etcdClient, constant.DefaultKeyspaceGroupID, m, legacySvcRootPath, legacySvcStorage, suite.cfg, allocatorKeyPrefix, path.Join(allocatorKeyPrefix, "pd"))
@@ -1271,8 +1271,8 @@ func (suite *keyspaceGroupManagerTestSuite) TestRegisterAllocatorConflict() {
 	go func() {
 		defer wg1.Done()
 
-		legacySvcRootPath := keypath.LegacyRootPath(suite.ClusterID)
-		allocatorKeyPrefix := keypath.GlobalTSOAllocatorsPrefix(suite.ClusterID)
+		legacySvcRootPath := keypath.LegacyRootPath()
+		allocatorKeyPrefix := keypath.GlobalTSOAllocatorsPrefix()
 		legacySvcStorage := endpoint.NewStorageEndpoint(kv.NewEtcdKVBase(suite.etcdClient, legacySvcRootPath), nil)
 		m := member.NewMember(suite.servers[0], suite.etcdClient, uint64(suite.servers[0].Server.ID()))
 		am := NewAllocatorManager(suite.ctx, suite.etcdClient, constant.DefaultKeyspaceGroupID, m, legacySvcRootPath, legacySvcStorage, suite.cfg, allocatorKeyPrefix, path.Join(allocatorKeyPrefix, "pd"))

--- a/pkg/utils/keypath/key_path.go
+++ b/pkg/utils/keypath/key_path.go
@@ -74,6 +74,8 @@ const (
 	keyspaceGroupsMembershipKey = "membership"
 	keyspaceGroupsElectionKey   = "election"
 
+	tsoAllocatorsPrefix = "tso_allocators"
+
 	// we use uint64 to represent ID, the max length of uint64 is 20.
 	keyLen = 20
 
@@ -458,4 +460,9 @@ func ServicePath(serviceName string) string {
 // TSOPath returns the path to store TSO addresses.
 func TSOPath() string {
 	return ServicePath("tso")
+}
+
+// GlobalTSOAllocatorsPrefix returns the global TSO allocators prefix.
+func GlobalTSOAllocatorsPrefix() string {
+	return path.Join(PDRootPath(), tsoAllocatorsPrefix)
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -319,7 +319,7 @@ func (h *Handler) GetSchedulerConfigHandler() (http.Handler, error) {
 
 // ResetTS resets the ts with specified tso.
 func (h *Handler) ResetTS(ts uint64, ignoreSmaller, skipUpperBoundCheck bool, _ uint32) error {
-	log.Info("reset-ts",
+	log.Info("reset ts",
 		zap.Uint64("new-ts", ts),
 		zap.Bool("ignore-smaller", ignoreSmaller),
 		zap.Bool("skip-upper-bound-check", skipUpperBoundCheck))

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -470,7 +471,7 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.tsoDispatcher = tsoutil.NewTSODispatcher(tsoProxyHandleDuration, tsoProxyBatchSize)
 	s.tsoProtoFactory = &tsoutil.TSOProtoFactory{}
 	s.pdProtoFactory = &tsoutil.PDProtoFactory{}
-	s.tsoAllocatorManager = tso.NewAllocatorManager(s.ctx, constant.DefaultKeyspaceGroupID, s.member, s.rootPath, s.storage, s)
+	s.tsoAllocatorManager = tso.NewAllocatorManager(s.ctx, s.client, constant.DefaultKeyspaceGroupID, s.member, s.rootPath, s.storage, s, path.Join(keypath.GlobalTSOAllocatorsPrefix(), "pd"))
 	// When disabled the Local TSO, we should clean up the Local TSO Allocator's meta info written in etcd if it exists.
 	if !s.cfg.EnableLocalTSO {
 		if err = s.tsoAllocatorManager.CleanUpDCLocation(); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -471,7 +471,8 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.tsoDispatcher = tsoutil.NewTSODispatcher(tsoProxyHandleDuration, tsoProxyBatchSize)
 	s.tsoProtoFactory = &tsoutil.TSOProtoFactory{}
 	s.pdProtoFactory = &tsoutil.PDProtoFactory{}
-	s.tsoAllocatorManager = tso.NewAllocatorManager(s.ctx, s.client, constant.DefaultKeyspaceGroupID, s.member, s.rootPath, s.storage, s, path.Join(keypath.GlobalTSOAllocatorsPrefix(), "pd"))
+	allocatorKeyPrefix := keypath.GlobalTSOAllocatorsPrefix()
+	s.tsoAllocatorManager = tso.NewAllocatorManager(s.ctx, s.client, constant.DefaultKeyspaceGroupID, s.member, s.rootPath, s.storage, s, allocatorKeyPrefix, path.Join(allocatorKeyPrefix, "pd"))
 	// When disabled the Local TSO, we should clean up the Local TSO Allocator's meta info written in etcd if it exists.
 	if !s.cfg.EnableLocalTSO {
 		if err = s.tsoAllocatorManager.CleanUpDCLocation(); err != nil {

--- a/tests/integrations/mcs/tso/api_test.go
+++ b/tests/integrations/mcs/tso/api_test.go
@@ -209,6 +209,7 @@ func TestForwardOnlyTSONoScheduling(t *testing.T) {
 	tc.WaitLeader()
 	leaderServer := tc.GetLeaderServer()
 	re.NoError(leaderServer.BootstrapCluster())
+	ttc.WaitForDefaultPrimaryServing(re)
 
 	urlPrefix := fmt.Sprintf("%s/pd/api/v1", pdAddr)
 

--- a/tests/integrations/tso/server_test.go
+++ b/tests/integrations/tso/server_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/client/testutil"
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
-	"github.com/tikv/pd/pkg/mcs/utils"
+	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	tsopkg "github.com/tikv/pd/pkg/tso"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/tempurl"
@@ -90,7 +90,7 @@ func (suite *tsoServerTestSuite) SetupSuite() {
 		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
 		suite.tsoClientConn, suite.tsoClient = tso.MustNewGrpcClient(re, suite.tsoServer.GetAddr())
 		testutil.Eventually(re, func() bool {
-			am, err := suite.tsoServer.GetKeyspaceGroupManager().GetAllocatorManager(utils.DefaultKeyspaceGroupID)
+			am, err := suite.tsoServer.GetKeyspaceGroupManager().GetAllocatorManager(constant.DefaultKeyspaceGroupID)
 			if err != nil {
 				return false
 			}

--- a/tests/integrations/tso/server_test.go
+++ b/tests/integrations/tso/server_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/tsopb"
 	"github.com/stretchr/testify/suite"
+	"github.com/tikv/pd/client/testutil"
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
+	"github.com/tikv/pd/pkg/mcs/utils"
 	tsopkg "github.com/tikv/pd/pkg/tso"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/tempurl"
@@ -87,6 +89,13 @@ func (suite *tsoServerTestSuite) SetupSuite() {
 	} else {
 		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
 		suite.tsoClientConn, suite.tsoClient = tso.MustNewGrpcClient(re, suite.tsoServer.GetAddr())
+		testutil.Eventually(re, func() bool {
+			am, err := suite.tsoServer.GetKeyspaceGroupManager().GetAllocatorManager(utils.DefaultKeyspaceGroupID)
+			if err != nil {
+				return false
+			}
+			return am.GetMember().IsLeaderElected()
+		})
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #8477.

### What is changed and how does it work?

This PR tries to avoid there are two allocators at the same time. If the TSO service has an allocator that might finish the sync timestamp. Then PD still allocates TSO, after enabling the dynamic switch, it might have a TSO fallback issue.

TSO service sync t1, PD is allocating from t2, t2 is less than t1 at the moment. But if PD syncs again and starts from t2 which is larger than t1, meanwhile TSO is not discovered immediately. The TSO might fall back.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
