### PR TITLE
client/tso: fix the bug that TSO may hang when switching mode

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -802,7 +802,11 @@ func (c *client) dispatchTSORequestWithRetry(req *tsoRequest) error {
 		err       error
 	)
 	for i := 0; i < dispatchRetryCount; i++ {
-		// Get the tsoClient for each retry, as it may be initialized or switched during the process.
+		// Do not delay for the first time.
+		if i > 0 {
+			time.Sleep(dispatchRetryDelay)
+		}
+		// Get the tsoClient each time, as it may be initialized or switched during the process.
 		tsoClient := c.getTSOClient()
 		if tsoClient == nil {
 			err = errs.ErrClientGetTSO.FastGenByArgs("tso client is nil")
@@ -812,7 +816,6 @@ func (c *client) dispatchTSORequestWithRetry(req *tsoRequest) error {
 		if !retryable {
 			break
 		}
-		time.Sleep(dispatchRetryDelay)
 	}
 	return err
 }

--- a/client/client.go
+++ b/client/client.go
@@ -782,23 +782,39 @@ func (c *client) GetLocalTSAsync(ctx context.Context, dcLocation string) TSFutur
 	req := tsoReqPool.Get().(*tsoRequest)
 	req.requestCtx = ctx
 	req.clientCtx = c.ctx
-	tsoClient := c.getTSOClient()
 	req.start = time.Now()
 	req.dcLocation = dcLocation
 
-	if tsoClient == nil {
-		req.done <- errs.ErrClientGetTSO.FastGenByArgs("tso client is nil")
-		return req
-	}
-
-	if err := tsoClient.dispatchRequest(ctx, dcLocation, req); err != nil {
-		// Wait for a while and try again
-		time.Sleep(50 * time.Millisecond)
-		if err = tsoClient.dispatchRequest(ctx, dcLocation, req); err != nil {
-			req.done <- err
-		}
+	if err := c.dispatchTSORequestWithRetry(req); err != nil {
+		req.done <- err
 	}
 	return req
+}
+
+const (
+	dispatchRetryDelay = 50 * time.Millisecond
+	dispatchRetryCount = 2
+)
+
+func (c *client) dispatchTSORequestWithRetry(req *tsoRequest) error {
+	var (
+		retryable bool
+		err       error
+	)
+	for i := 0; i < dispatchRetryCount; i++ {
+		// Get the tsoClient for each retry, as it may be initialized or switched during the process.
+		tsoClient := c.getTSOClient()
+		if tsoClient == nil {
+			err = errs.ErrClientGetTSO.FastGenByArgs("tso client is nil")
+			continue
+		}
+		retryable, err = tsoClient.dispatchRequest(req)
+		if !retryable {
+			return nil
+		}
+		time.Sleep(dispatchRetryDelay)
+	}
+	return err
 }
 
 func (c *client) GetTS(ctx context.Context) (physical int64, logical int64, err error) {

--- a/client/client.go
+++ b/client/client.go
@@ -810,7 +810,7 @@ func (c *client) dispatchTSORequestWithRetry(req *tsoRequest) error {
 		}
 		retryable, err = tsoClient.dispatchRequest(req)
 		if !retryable {
-			return nil
+			break
 		}
 		time.Sleep(dispatchRetryDelay)
 	}

--- a/client/tso_client.go
+++ b/client/tso_client.go
@@ -80,7 +80,7 @@ type tsoClient struct {
 
 	// tsoDispatcher is used to dispatch different TSO requests to
 	// the corresponding dc-location TSO channel.
-	tsoDispatcher sync.Map // Same as map[string]chan *tsoDispatcher
+	tsoDispatcher sync.Map // Same as map[string]*tsoDispatcher
 	// dc-location -> deadline
 	tsDeadline sync.Map // Same as map[string]chan deadline
 	// dc-location -> *tsoInfo while the tsoInfo is the last TSO info

--- a/client/tso_client.go
+++ b/client/tso_client.go
@@ -80,7 +80,7 @@ type tsoClient struct {
 
 	// tsoDispatcher is used to dispatch different TSO requests to
 	// the corresponding dc-location TSO channel.
-	tsoDispatcher sync.Map // Same as map[string]chan *tsoRequest
+	tsoDispatcher sync.Map // Same as map[string]chan *tsoDispatcher
 	// dc-location -> deadline
 	tsDeadline sync.Map // Same as map[string]chan deadline
 	// dc-location -> *tsoInfo while the tsoInfo is the last TSO info


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7849.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Because the old `(*tsoClient).dispatchRequest` only checked the request's context,
this could potentially cause a `tsoRequest` to be sent to a batch channel that has already
finished `revokePendingTokenRequest`, thus being left there forever without returning.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
