### PR TITLE
tests/api: replace init cluster 3 to 1 to reduce cost time

### DIFF
--- a/server/api/status_test.go
+++ b/server/api/status_test.go
@@ -33,7 +33,7 @@ func checkStatusResponse(re *require.Assertions, body []byte) {
 
 func TestStatus(t *testing.T) {
 	re := require.New(t)
-	cfgs, _, clean := mustNewCluster(re, 3)
+	cfgs, _, clean := mustNewCluster(re, 1)
 	defer clean()
 
 	for _, cfg := range cfgs {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7930

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

reduce

- init 3 member cluster need to cost  18s while init 1 just below 1s.
- status no need to check in 3 member cluster

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
