### PR TITLE
tests: reduce etcdutil test time

### DIFF
--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -418,6 +418,8 @@ type LoopWatcher struct {
 	// updateClientCh is used to update the etcd client.
 	// It's only used for testing.
 	updateClientCh chan *clientv3.Client
+	// watchChTimeoutDuration is the timeout duration for a watchChan.
+	watchChTimeoutDuration time.Duration
 }
 
 // NewLoopWatcher creates a new LoopWatcher.
@@ -597,7 +599,7 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 			cancel()
 			// If no message comes from an etcd watchChan for WatchChTimeoutDuration,
 			// create a new one and need not to reset lastReceivedResponseTime.
-			if time.Since(lastReceivedResponseTime) >= WatchChTimeoutDuration {
+			if time.Since(lastReceivedResponseTime) >= lw.watchChTimeoutDuration {
 				log.Warn("watch channel is blocked for a long time, recreating a new one in watch loop",
 					zap.Duration("timeout", time.Since(lastReceivedResponseTime)),
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
@@ -793,4 +795,8 @@ func (lw *LoopWatcher) SetLoadRetryTimes(times int) {
 // SetLoadBatchSize sets the batch size when loading data from etcd.
 func (lw *LoopWatcher) SetLoadBatchSize(size int64) {
 	lw.loadBatchSize = size
+}
+
+func (lw *LoopWatcher) SetWatchChTimeoutDuration(v time.Duration) {
+	lw.watchChTimeoutDuration = v
 }

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -796,7 +796,3 @@ func (lw *LoopWatcher) SetLoadRetryTimes(times int) {
 func (lw *LoopWatcher) SetLoadBatchSize(size int64) {
 	lw.loadBatchSize = size
 }
-
-func (lw *LoopWatcher) SetWatchChTimeoutDuration(v time.Duration) {
-	lw.watchChTimeoutDuration = v
-}

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -450,6 +450,7 @@ func NewLoopWatcher(
 		loadRetryTimes:           defaultLoadFromEtcdRetryTimes,
 		loadBatchSize:            maxLoadBatchSize,
 		watchChangeRetryInterval: defaultEtcdRetryInterval,
+		watchChTimeoutDuration:   WatchChTimeoutDuration,
 	}
 }
 

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -583,9 +583,25 @@ func (suite *loopWatcherTestSuite) TestWatcherLoadLargeKey() {
 	count := 65536
 	ctx, cancel := context.WithCancel(suite.ctx)
 	defer cancel()
-	for i := 0; i < count; i++ {
-		suite.put(re, fmt.Sprintf("TestWatcherLoadLargeKey/test-%d", i), "")
+
+	// crate data
+	var wg sync.WaitGroup
+	tasks := make(chan int, count)
+	for w := 0; w < 16; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range tasks {
+				suite.put(re, fmt.Sprintf("TestWatcherLoadLargeKey/test-%d", i), "")
+			}
+		}()
 	}
+	for i := 0; i < count; i++ {
+		tasks <- i
+	}
+	close(tasks)
+	wg.Wait()
+
 	cache := make([]string, 0)
 	watcher := NewLoopWatcher(
 		ctx,
@@ -724,6 +740,7 @@ func (suite *loopWatcherTestSuite) TestWatcherRequestProgress() {
 			func([]*clientv3.Event) error { return nil },
 			false, /* withPrefix */
 		)
+		watcher.watchChTimeoutDuration = 2 * RequestProgressInterval
 
 		suite.wg.Add(1)
 		go func() {

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -584,7 +584,7 @@ func (suite *loopWatcherTestSuite) TestWatcherLoadLargeKey() {
 	ctx, cancel := context.WithCancel(suite.ctx)
 	defer cancel()
 
-	// crate data
+	// create data
 	var wg sync.WaitGroup
 	tasks := make(chan int, count)
 	for w := 0; w < 16; w++ {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7930

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

local
```
Before 
go test -timeout 120s -run ^TestLoopWatcherTestSuite$ -testify.m ^(TestWatcherLoadLargeKey)$ github.com/tikv/pd/pkg/utils/etcdutil
ok      github.com/tikv/pd/pkg/utils/etcdutil   51.058s
After
go test -timeout 120s -run ^TestLoopWatcherTestSuite$ -testify.m ^(TestWatcherLoadLargeKey)$ github.com/tikv/pd/pkg/utils/etcdutil
ok      github.com/tikv/pd/pkg/utils/etcdutil   28.717s
```
ci
```
Before 
https://github.com/tikv/pd/actions/runs/8339040119/job/22820335714
ok  	http://github.com/tikv/pd/pkg/utils/etcdutil	208.548s 
After
https://github.com/tikv/pd/actions/runs/8339647034/job/22822028949?pr=7945
ok  	http://github.com/tikv/pd/pkg/utils/etcdutil	125.064s
```
### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
