### PR TITLE
tests/discovery: reduce TestRegister cost time

### DIFF
--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -69,6 +69,8 @@ func TestRegister(t *testing.T) {
 		testutil.Eventually(re, func() bool {
 			b, _ := os.ReadFile(fname)
 			l := string(b)
+			// check log in function `ServiceRegister.Register`
+			// ref https://github.com/tikv/pd/blob/6377b26e4e879e7623fbc1d0b7f1be863dea88ad/pkg/mcs/discovery/register.go#L77
 			count := strings.Count(l, "keep alive failed")
 			return count >= i+1
 		})

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -17,7 +17,7 @@ package discovery
 import (
 	"context"
 	"os"
-	"strings"
+	"regexp"
 	"testing"
 	"time"
 
@@ -62,17 +62,19 @@ func TestRegister(t *testing.T) {
 	err = sr.Register()
 	re.NoError(err)
 	fname := testutil.InitTempFileLogger("info")
+	defer os.Remove(fname)
 	for i := 0; i < 3; i++ {
 		re.Equal("127.0.0.1:2", getKeyAfterLeaseExpired(re, client, sr.key))
 		etcd.Server.HardStop() // close the etcd to make the keepalive failed
 		// ensure that the request is timeout
 		testutil.Eventually(re, func() bool {
-			b, _ := os.ReadFile(fname)
-			l := string(b)
+			content, _ := os.ReadFile(fname)
 			// check log in function `ServiceRegister.Register`
 			// ref https://github.com/tikv/pd/blob/6377b26e4e879e7623fbc1d0b7f1be863dea88ad/pkg/mcs/discovery/register.go#L77
-			count := strings.Count(l, "keep alive failed")
-			return count >= i+1
+			// need to both contain `register.go` and `keep alive failed`
+			pattern := regexp.MustCompile(`register.go.*keep alive failed`)
+			matches := pattern.FindAll(content, -1)
+			return len(matches) >= i+1
 		})
 		etcd.Close()
 		etcd, err = embed.StartEtcd(&cfg)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7930

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

can reduce from 2min to 60s
check on log
```bash
[2024/03/19 18:21:40.148 +08:00] [INFO] [register.go:73] ["exit register process"] [key=/ms/12345/test_service/registry/http://127.0.0.1:1]
[2024/03/19 18:21:40.159 +08:00] [INFO] [register.go:73] ["exit register process"] [key=/ms/12345/test_service/registry/127.0.0.1:2]
[2024/03/19 18:21:48.157 +08:00] [ERROR] [register.go:77] ["keep alive failed"] 
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
