### PR TITLE
client/http: fix the panic when merging empty RegionsInfo

### DIFF
--- a/client/http/types.go
+++ b/client/http/types.go
@@ -133,11 +133,22 @@ type RegionsInfo struct {
 	Regions []RegionInfo `json:"regions"`
 }
 
+func newRegionsInfo(count int64) *RegionsInfo {
+	return &RegionsInfo{
+		Count:   count,
+		Regions: make([]RegionInfo, 0, count),
+	}
+}
+
 // Merge merges two RegionsInfo together and returns a new one.
 func (ri *RegionsInfo) Merge(other *RegionsInfo) *RegionsInfo {
-	newRegionsInfo := &RegionsInfo{
-		Regions: make([]RegionInfo, 0, ri.Count+other.Count),
+	if ri == nil {
+		ri = newRegionsInfo(0)
 	}
+	if other == nil {
+		other = newRegionsInfo(0)
+	}
+	newRegionsInfo := newRegionsInfo(ri.Count + other.Count)
 	m := make(map[int64]RegionInfo, ri.Count+other.Count)
 	for _, region := range ri.Regions {
 		m[region.ID] = region

--- a/client/http/types_test.go
+++ b/client/http/types_test.go
@@ -23,30 +23,140 @@ import (
 
 func TestMergeRegionsInfo(t *testing.T) {
 	re := require.New(t)
-	regionsInfo1 := &RegionsInfo{
-		Count: 1,
-		Regions: []RegionInfo{
-			{
-				ID:       1,
-				StartKey: "",
-				EndKey:   "a",
+	testCases := []struct {
+		source *RegionsInfo
+		target *RegionsInfo
+	}{
+		// Different regions.
+		{
+			source: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       1,
+						StartKey: "",
+						EndKey:   "a",
+					},
+				},
+			},
+			target: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       2,
+						StartKey: "a",
+						EndKey:   "",
+					},
+				},
 			},
 		},
-	}
-	regionsInfo2 := &RegionsInfo{
-		Count: 1,
-		Regions: []RegionInfo{
-			{
-				ID:       2,
-				StartKey: "a",
-				EndKey:   "",
+		// Same region.
+		{
+			source: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       1,
+						StartKey: "",
+						EndKey:   "a",
+					},
+				},
+			},
+			target: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       1,
+						StartKey: "",
+						EndKey:   "a",
+					},
+				},
 			},
 		},
+		{
+			source: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       1,
+						StartKey: "",
+						EndKey:   "a",
+					},
+				},
+			},
+			target: nil,
+		},
+		{
+			source: nil,
+			target: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       2,
+						StartKey: "a",
+						EndKey:   "",
+					},
+				},
+			},
+		},
+		{
+			source: nil,
+			target: nil,
+		},
+		{
+			source: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       1,
+						StartKey: "",
+						EndKey:   "a",
+					},
+				},
+			},
+			target: newRegionsInfo(0),
+		},
+		{
+			source: newRegionsInfo(0),
+			target: &RegionsInfo{
+				Count: 1,
+				Regions: []RegionInfo{
+					{
+						ID:       2,
+						StartKey: "a",
+						EndKey:   "",
+					},
+				},
+			},
+		},
+		{
+			source: newRegionsInfo(0),
+			target: newRegionsInfo(0),
+		},
 	}
-	regionsInfo := regionsInfo1.Merge(regionsInfo2)
-	re.Equal(int64(2), regionsInfo.Count)
-	re.Len(regionsInfo.Regions, 2)
-	re.Subset(regionsInfo.Regions, append(regionsInfo1.Regions, regionsInfo2.Regions...))
+	for idx, tc := range testCases {
+		regionsInfo := tc.source.Merge(tc.target)
+		if tc.source == nil {
+			tc.source = newRegionsInfo(0)
+		}
+		if tc.target == nil {
+			tc.target = newRegionsInfo(0)
+		}
+		m := make(map[int64]RegionInfo, tc.source.Count+tc.target.Count)
+		for _, region := range tc.source.Regions {
+			m[region.ID] = region
+		}
+		for _, region := range tc.target.Regions {
+			m[region.ID] = region
+		}
+		mergedCount := len(m)
+		re.Equal(int64(mergedCount), regionsInfo.Count, "case %d", idx)
+		re.Len(regionsInfo.Regions, mergedCount, "case %d", idx)
+		// All regions in source and target should be in the merged result.
+		for _, region := range append(tc.source.Regions, tc.target.Regions...) {
+			re.Contains(regionsInfo.Regions, region, "case %d", idx)
+		}
+	}
 }
 
 func TestRuleStartEndKey(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7300, https://github.com/pingcap/tidb/issues/52013.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Check if the source and target `*RegionsInfo` are nil before merging.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
