### PR TITLE
cmd, server: check the release version before starting the pd-server

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -221,6 +221,8 @@ func start(cmd *cobra.Command, args []string, services ...string) {
 		exit(0)
 	}
 
+	// Check the PD version first before running.
+	server.CheckAndGetPDVersion()
 	// New zap logger
 	err = logutil.SetupLogger(cfg.Log, &cfg.Logger, &cfg.LogProps, cfg.Security.RedactInfoLog)
 	if err == nil {

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -833,7 +833,7 @@ func (s *GrpcServer) PutStore(ctx context.Context, request *pdpb.PutStoreRequest
 	}
 
 	log.Info("put store ok", zap.Stringer("store", store))
-	CheckPDVersion(s.persistOptions)
+	CheckPDVersionWithClusterVersion(s.persistOptions)
 
 	return &pdpb.PutStoreResponse{
 		Header:            s.header(),

--- a/server/server.go
+++ b/server/server.go
@@ -1800,7 +1800,7 @@ func (s *Server) campaignLeader() {
 		member.ServiceMemberGauge.WithLabelValues(s.mode).Set(0)
 	})
 
-	CheckPDVersion(s.persistOptions)
+	CheckPDVersionWithClusterVersion(s.persistOptions)
 	log.Info(fmt.Sprintf("%s leader is ready to serve", s.mode), zap.String("leader-name", s.Name()))
 
 	leaderTicker := time.NewTicker(mcs.LeaderTickInterval)

--- a/server/util.go
+++ b/server/util.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gorilla/mux"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -33,14 +34,21 @@ import (
 	"go.uber.org/zap"
 )
 
-// CheckPDVersion checks if PD needs to be upgraded.
-func CheckPDVersion(opt *config.PersistOptions) {
+// CheckAndGetPDVersion checks and returns the PD version.
+func CheckAndGetPDVersion() *semver.Version {
 	pdVersion := versioninfo.MinSupportedVersion(versioninfo.Base)
 	if versioninfo.PDReleaseVersion != "None" {
 		pdVersion = versioninfo.MustParseVersion(versioninfo.PDReleaseVersion)
 	}
+	return pdVersion
+}
+
+// CheckPDVersionWithClusterVersion checks if PD needs to be upgraded by comparing the PD version with the cluster version.
+func CheckPDVersionWithClusterVersion(opt *config.PersistOptions) {
+	pdVersion := CheckAndGetPDVersion()
 	clusterVersion := *opt.GetClusterVersion()
-	log.Info("load cluster version", zap.Stringer("cluster-version", clusterVersion))
+	log.Info("load pd and cluster version",
+		zap.Stringer("pd-version", pdVersion), zap.Stringer("cluster-version", clusterVersion))
 	if pdVersion.LessThan(clusterVersion) {
 		log.Warn(
 			"PD version less than cluster version, please upgrade PD",


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7978.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Move the release version check before the startup to ensure we can know it as soon as possible.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```shell
> GOEXPERIMENT= CGO_ENABLED=1 go build  -gcflags '' -ldflags '-X "github.com/tikv/pd/pkg/versioninfo.PDReleaseVersion=g39108f7be" -X "github.com/tikv/pd/pkg/versioninfo.PDBuildTS=2024-03-26 06:12:55" -X "github.com/tikv/pd/pkg/versioninfo.PDGitHash=39108f7be343368ed7487848d81d4528734dc02a" -X "github.com/tikv/pd/pkg/versioninfo.PDGitBranch=fix_release_version_check" -X "github.com/tikv/pd/pkg/versioninfo.PDEdition=Community" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.InternalVersion=8.0.0-ab48e09f" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.Standalone=No" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.PDVersion=v8.0.0-alpha-114-g39108f7be-dirty" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildTime=2024-03-26 06:12:56" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildGitHash=ab48e09f7762"' -tags "" -o /Users/jmpotato/go/src/github.com/JmPotato/pd/bin/pd-server cmd/pd-server/main.go
> ./bin/pd-server
[2024/03/26 14:13:47.423 +08:00] [FATAL] [versioninfo.go:70] ["version string is illegal"] [error="[PD:semver:ErrSemverNewVersion]g39108f7be is not in dotted-tri format: g39108f7be is not in dotted-tri format"] [errorVerbose="[PD:semver:ErrSemverNewVersion]g39108f7be is not in dotted-tri format: g39108f7be is not in dotted-tri format\ngithub.com/pingcap/errors.AddStack\n\t/Users/jmpotato/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20211224045212-9687c2b0f87c/errors.go:174\ngithub.com/pingcap/errors.(*Error).GenWithStackByCause\n\t/Users/jmpotato/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20211224045212-9687c2b0f87c/normalize.go:307\ngithub.com/tikv/pd/pkg/versioninfo.ParseVersion\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/pkg/versioninfo/versioninfo.go:61\ngithub.com/tikv/pd/pkg/versioninfo.MustParseVersion\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/pkg/versioninfo/versioninfo.go:68\ngithub.com/tikv/pd/server.CheckAndGetPDVersion\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/server/util.go:41\nmain.start\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/cmd/pd-server/main.go:225\nmain.createServerWrapper\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/cmd/pd-server/main.go:191\ngithub.com/spf13/cobra.(*Command).execute\n\t/Users/jmpotato/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/Users/jmpotato/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\t/Users/jmpotato/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887\nmain.main\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/cmd/pd-server/main.go:71\nruntime.main\n\t/opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/proc.go:271\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/asm_arm64.s:1222"] [stack="github.com/tikv/pd/pkg/versioninfo.MustParseVersion\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/pkg/versioninfo/versioninfo.go:70\ngithub.com/tikv/pd/server.CheckAndGetPDVersion\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/server/util.go:41\nmain.start\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/cmd/pd-server/main.go:225\nmain.createServerWrapper\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/cmd/pd-server/main.go:191\ngithub.com/spf13/cobra.(*Command).execute\n\t/Users/jmpotato/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/Users/jmpotato/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\t/Users/jmpotato/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887\nmain.main\n\t/Users/jmpotato/go/src/github.com/JmPotato/pd/cmd/pd-server/main.go:71\nruntime.main\n\t/opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/proc.go:271"]
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
