### PR TITLE
*: support generate the test coverage file and using it in ci

### DIFF
--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -25,24 +25,33 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        worker_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        include:
+          - worker_id: 1
+            name: 'Unit Test(1)'
+          - worker_id: 2
+            name: 'Unit Test(2)'
+          - worker_id: 3
+            name: 'Tools Test'
+          - worker_id: 4
+            name: 'Client Integration Test'
+          - worker_id: 5
+            name: 'TSO Integration Test'
+          - worker_id: 6
+            name: 'MicroService Integration Test'
     outputs:
-      job-total: 13
+      job-total: 6
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-      - name: Make Test
+      - name: ${{ matrix.name }}
         env:
           WORKER_ID: ${{ matrix.worker_id }}
-          WORKER_COUNT: 13
-          JOB_COUNT: 9 # 10 is tools test, 11, 12, 13 are for other integrations jobs
         run: |
-          make ci-test-job JOB_COUNT=$(($JOB_COUNT)) JOB_INDEX=$WORKER_ID
+          make ci-test-job JOB_INDEX=$WORKER_ID
           mv covprofile covprofile_$WORKER_ID
-          sed -i "/failpoint_binding/d" covprofile_$WORKER_ID
       - name: Upload coverage result ${{ matrix.worker_id }}
         uses: actions/upload-artifact@v4
         with:
@@ -62,7 +71,11 @@ jobs:
       - name: Merge
         env:
           TOTAL_JOBS: ${{needs.chunks.outputs.job-total}}
-        run: for i in $(seq 1 $TOTAL_JOBS); do cat covprofile_$i >> covprofile; done
+        run: |
+          for i in $(seq 1 $TOTAL_JOBS); do cat covprofile_$i >> covprofile; done
+          sed -i "/failpoint_binding/d" covprofile
+          # only keep the first line(`mode: aomic`) of the coverage profile
+          sed -i '2,${/mode: atomic/d;}' covprofile
       - name: Send coverage
         uses: codecov/codecov-action@v4.2.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ regions-dump:
 stores-dump:
 	cd tools && CGO_ENABLED=0 go build -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o $(BUILD_BIN_PATH)/stores-dump stores-dump/main.go
 pd-ut: pd-xprog
-	cd tools && GOEXPERIMENT=$(BUILD_GOEXPERIMENT) CGO_ENABLED=$(BUILD_TOOL_CGO_ENABLED) go build -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o $(BUILD_BIN_PATH)/pd-ut pd-ut/ut.go
+	cd tools && GOEXPERIMENT=$(BUILD_GOEXPERIMENT) CGO_ENABLED=$(BUILD_TOOL_CGO_ENABLED) go build -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o $(BUILD_BIN_PATH)/pd-ut pd-ut/ut.go pd-ut/coverProfile.go
 pd-xprog:
 	cd tools && GOEXPERIMENT=$(BUILD_GOEXPERIMENT) CGO_ENABLED=$(BUILD_TOOL_CGO_ENABLED) go build -tags xprog -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -o $(BUILD_BIN_PATH)/xprog pd-ut/xprog.go
 
@@ -251,7 +251,7 @@ basic-test: install-tools
 	go test $(BASIC_TEST_PKGS) || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
 
-ci-test-job: install-tools dashboard-ui
+ci-test-job: install-tools dashboard-ui pd-ut
 	@$(FAILPOINT_ENABLE)
 	./scripts/ci-subtask.sh $(JOB_COUNT) $(JOB_INDEX) || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,9 +24,3 @@ flag_management:
         target: 74% # increase it if you want to enforce higher coverage for project, current setting as 74% is for do not let the error be reported and lose the meaning of warning.
       - type: patch
         target: 74% # increase it if you want to enforce higher coverage for project, current setting as 74% is for do not let the error be reported and lose the meaning of warning.
-
-ignore:
-  # Ignore the tool tests
-  - tests/dashboard
-  - tests/pdbackup
-  - tests/pdctl

--- a/scripts/ci-subtask.sh
+++ b/scripts/ci-subtask.sh
@@ -3,63 +3,33 @@
 # ./ci-subtask.sh <TOTAL_TASK_N> <TASK_INDEX>
 
 ROOT_PATH_COV=$(pwd)/covprofile
+# Currently, we only have 3 integration tests, so we can hardcode the task index.
+integrations_dir=$(pwd)/tests/integrations
 
-if [[ $2 -gt 9 ]]; then
-    # run tools tests
-    if [[ $2 -eq 10 ]]; then
+case $1 in
+    1)
+        # unit tests ignore `tests`
+        ./bin/pd-ut run --race --ignore tests --coverprofile $ROOT_PATH_COV  || exit 1
+        ;;
+    2)
+        # unit tests only in `tests`
+        ./bin/pd-ut run tests --race --coverprofile $ROOT_PATH_COV  || exit 1
+        ;;
+    3)
+        # tools tests
         cd ./tools && make ci-test-job && cat covprofile >> $ROOT_PATH_COV || exit 1
-        exit
-    fi
-
-    # Currently, we only have 3 integration tests, so we can hardcode the task index.
-    integrations_dir=$(pwd)/tests/integrations
-    integrations_tasks=($(find "$integrations_dir" -mindepth 1 -maxdepth 1 -type d))
-    for t in "${integrations_tasks[@]}"; do
-        if [[ "$t" = "$integrations_dir/client" && $2 -eq 11 ]]; then
-            cd ./client && make ci-test-job && cat covprofile >> $ROOT_PATH_COV || exit 1
-            cd $integrations_dir && make ci-test-job test_name=client && cat ./client/covprofile >> $ROOT_PATH_COV || exit 1
-        elif [[ "$t" = "$integrations_dir/tso" && $2 -eq 12 ]]; then
-            cd $integrations_dir && make ci-test-job test_name=tso && cat ./tso/covprofile >> $ROOT_PATH_COV || exit 1
-        elif [[ "$t" = "$integrations_dir/mcs" && $2 -eq 13 ]]; then
-            cd $integrations_dir && make ci-test-job test_name=mcs && cat ./mcs/covprofile >> $ROOT_PATH_COV || exit 1
-        fi
-    done
-else
-    # Get package test list.
-    packages=($(go list ./...))
-    dirs=($(find . -iname "*_test.go" -exec dirname {} \; | sort -u | sed -e "s/^\./github.com\/tikv\/pd/"))
-    tasks=($(comm -12 <(printf "%s\n" "${packages[@]}") <(printf "%s\n" "${dirs[@]}")))
-
-    weight() {
-        [[ $1 == "github.com/tikv/pd/server/api" ]] && return 30
-        [[ $1 == "github.com/tikv/pd/pkg/schedule" ]] && return 30
-        [[ $1 == "github.com/tikv/pd/pkg/core" ]] && return 30
-        [[ $1 == "github.com/tikv/pd/tests/server/api" ]] && return 30
-        [[ $1 =~ "pd/tests" ]] && return 5
-        return 1
-    }
-
-    # Create an associative array to store the weight of each task.
-    declare -A task_weights
-    for t in ${tasks[@]}; do
-        weight $t
-        task_weights[$t]=$?
-    done
-
-    # Sort tasks by weight in descending order.
-    tasks=($(printf "%s\n" "${tasks[@]}" | sort -rn))
-
-    scores=($(seq "$1" | xargs -I{} echo 0))
-
-    res=()
-    for t in ${tasks[@]}; do
-        min_i=0
-        for i in ${!scores[@]}; do
-            [[ ${scores[i]} -lt ${scores[$min_i]} ]] && min_i=$i
-        done
-        scores[$min_i]=$((${scores[$min_i]} + ${task_weights[$t]}))
-        [[ $(($min_i + 1)) -eq $2 ]] && res+=($t)
-    done
-
-    CGO_ENABLED=1 go test -timeout=15m -tags deadlock -race -cover -covermode=atomic -coverprofile=$ROOT_PATH_COV -coverpkg=./... ${res[@]}
-fi
+        ;;
+    4)
+        # integration test client
+        cd ./client && make ci-test-job && cat covprofile >> $ROOT_PATH_COV  || exit 1
+        cd $integrations_dir && make ci-test-job test_name=client && cat ./client/covprofile >> $ROOT_PATH_COV || exit 1
+        ;;
+    5)
+        # integration test tso
+        cd $integrations_dir && make ci-test-job test_name=tso && cat ./tso/covprofile >> $ROOT_PATH_COV || exit 1
+        ;;
+    6)
+        # integration test mcs
+        cd $integrations_dir && make ci-test-job test_name=mcs && cat ./mcs/covprofile >> $ROOT_PATH_COV || exit 1
+        ;;
+esac

--- a/tests/scheduling_cluster.go
+++ b/tests/scheduling_cluster.go
@@ -113,7 +113,7 @@ func (tc *TestSchedulingCluster) WaitForPrimaryServing(re *require.Assertions) *
 			}
 		}
 		return false
-	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 
 	return primary
 }

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -753,20 +753,19 @@ func TestConcurrentHandleRegion(t *testing.T) {
 		re.NoError(err)
 		peerID, err := id.Alloc()
 		re.NoError(err)
-		regionID, err := id.Alloc()
-		re.NoError(err)
 		peer := &metapb.Peer{Id: peerID, StoreId: store.GetId()}
 		regionReq := &pdpb.RegionHeartbeatRequest{
 			Header: testutil.NewRequestHeader(clusterID),
 			Region: &metapb.Region{
-				Id:    regionID,
+				// mock error msg to trigger stream.Recv()
+				Id:    0,
 				Peers: []*metapb.Peer{peer},
 			},
 			Leader: peer,
 		}
 		err = stream.Send(regionReq)
 		re.NoError(err)
-		// make sure the first store can receive one response
+		// make sure the first store can receive one response(error msg)
 		if i == 0 {
 			wg.Add(1)
 		}

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -157,7 +157,7 @@ func WaitForPrimaryServing(re *require.Assertions, serverMap map[string]bs.Serve
 			}
 		}
 		return false
-	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 
 	return primary
 }

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -35,6 +35,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/text v0.14.0
+	golang.org/x/tools v0.14.0
 	google.golang.org/grpc v1.62.1
 )
 
@@ -172,7 +173,6 @@ require (
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240401170217-c3f982113cda // indirect

--- a/tools/pd-ut/README.md
+++ b/tools/pd-ut/README.md
@@ -63,4 +63,8 @@ pd-ut run --junitfile xxx
 
 // test with race flag
 pd-ut run --race
+
+// test with coverprofile
+pd-ut run --coverprofile xxx
+go tool cover --func=xxx
 ```

--- a/tools/pd-ut/coverProfile.go
+++ b/tools/pd-ut/coverProfile.go
@@ -1,0 +1,176 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+
+	"golang.org/x/tools/cover"
+)
+
+func collectCoverProfileFile() {
+	// Combine all the cover file of single test function into a whole.
+	files, err := os.ReadDir(coverFileTempDir)
+	if err != nil {
+		fmt.Println("collect cover file error:", err)
+		os.Exit(-1)
+	}
+
+	w, err := os.Create(coverProfile)
+	if err != nil {
+		fmt.Println("create cover file error:", err)
+		os.Exit(-1)
+	}
+	//nolint: errcheck
+	defer w.Close()
+	w.WriteString("mode: atomic\n")
+
+	result := make(map[string]*cover.Profile)
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		collectOneCoverProfileFile(result, file)
+	}
+
+	w1 := bufio.NewWriter(w)
+	for _, prof := range result {
+		for _, block := range prof.Blocks {
+			fmt.Fprintf(w1, "%s:%d.%d,%d.%d %d %d\n",
+				prof.FileName,
+				block.StartLine,
+				block.StartCol,
+				block.EndLine,
+				block.EndCol,
+				block.NumStmt,
+				block.Count,
+			)
+		}
+		if err := w1.Flush(); err != nil {
+			fmt.Println("flush data to cover profile file error:", err)
+			os.Exit(-1)
+		}
+	}
+}
+
+func collectOneCoverProfileFile(result map[string]*cover.Profile, file os.DirEntry) {
+	f, err := os.Open(path.Join(coverFileTempDir, file.Name()))
+	if err != nil {
+		fmt.Println("open temp cover file error:", err)
+		os.Exit(-1)
+	}
+	//nolint: errcheck
+	defer f.Close()
+
+	profs, err := cover.ParseProfilesFromReader(f)
+	if err != nil {
+		fmt.Println("parse cover profile file error:", err)
+		os.Exit(-1)
+	}
+	mergeProfile(result, profs)
+}
+
+func mergeProfile(m map[string]*cover.Profile, profs []*cover.Profile) {
+	for _, prof := range profs {
+		sort.Sort(blocksByStart(prof.Blocks))
+		old, ok := m[prof.FileName]
+		if !ok {
+			m[prof.FileName] = prof
+			continue
+		}
+
+		// Merge samples from the same location.
+		// The data has already been sorted.
+		tmp := old.Blocks[:0]
+		var i, j int
+		for i < len(old.Blocks) && j < len(prof.Blocks) {
+			v1 := old.Blocks[i]
+			v2 := prof.Blocks[j]
+
+			switch compareProfileBlock(v1, v2) {
+			case -1:
+				tmp = appendWithReduce(tmp, v1)
+				i++
+			case 1:
+				tmp = appendWithReduce(tmp, v2)
+				j++
+			default:
+				tmp = appendWithReduce(tmp, v1)
+				tmp = appendWithReduce(tmp, v2)
+				i++
+				j++
+			}
+		}
+		for ; i < len(old.Blocks); i++ {
+			tmp = appendWithReduce(tmp, old.Blocks[i])
+		}
+		for ; j < len(prof.Blocks); j++ {
+			tmp = appendWithReduce(tmp, prof.Blocks[j])
+		}
+
+		m[prof.FileName] = old
+	}
+}
+
+// appendWithReduce works like append(), but it merge the duplicated values.
+func appendWithReduce(input []cover.ProfileBlock, b cover.ProfileBlock) []cover.ProfileBlock {
+	if len(input) >= 1 {
+		last := &input[len(input)-1]
+		if b.StartLine == last.StartLine &&
+			b.StartCol == last.StartCol &&
+			b.EndLine == last.EndLine &&
+			b.EndCol == last.EndCol {
+			if b.NumStmt != last.NumStmt {
+				panic(fmt.Errorf("inconsistent NumStmt: changed from %d to %d", last.NumStmt, b.NumStmt))
+			}
+			// Merge the data with the last one of the slice.
+			last.Count |= b.Count
+			return input
+		}
+	}
+	return append(input, b)
+}
+
+type blocksByStart []cover.ProfileBlock
+
+func compareProfileBlock(x, y cover.ProfileBlock) int {
+	if x.StartLine < y.StartLine {
+		return -1
+	}
+	if x.StartLine > y.StartLine {
+		return 1
+	}
+
+	// Now x.StartLine == y.StartLine
+	if x.StartCol < y.StartCol {
+		return -1
+	}
+	if x.StartCol > y.StartCol {
+		return 1
+	}
+
+	return 0
+}
+
+func (b blocksByStart) Len() int      { return len(b) }
+func (b blocksByStart) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+func (b blocksByStart) Less(i, j int) bool {
+	bi, bj := b[i], b[j]
+	return bi.StartLine < bj.StartLine || bi.StartLine == bj.StartLine && bi.StartCol < bj.StartCol
+}


### PR DESCRIPTION
<!--
Signed-off-by: husharp <jinhao.hu@pingcap.com><!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

need merge https://github.com/ti-community-infra/configs/pull/1048/files firstly

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

### add coverprofile for pd-ut
```bash
$ ./bin/pd-ut run pkg/audit --coverprofile xxx
2024/03/27 17:37:18 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
building task finish, parallelism=16, count=3, takes=2.976902167s
run all tasks takes 1.032669083s
```

```bash
support_coverprofile* $ cat xxx
mode: set
github.com/tikv/pd/pkg/audit/audit.go:44.58,45.37 1 1
github.com/tikv/pd/pkg/audit/audit.go:45.37,46.29 1 1
github.com/tikv/pd/pkg/audit/audit.go:46.29,48.4 1 1
github.com/tikv/pd/pkg/audit/audit.go:50.2,50.14 1 1
github.com/tikv/pd/pkg/audit/audit.go:59.48,61.2 1 0
github.com/tikv/pd/pkg/audit/audit.go:83.96,89.2 1 1
github.com/tikv/pd/pkg/audit/audit.go:92.81,94.9 2 1
github.com/tikv/pd/pkg/audit/audit.go:94.9,96.3 1 0
github.com/tikv/pd/pkg/audit/audit.go:97.2,98.9 2 1
github.com/tikv/pd/pkg/audit/audit.go:98.9,100.3 1 1
github.com/tikv/pd/pkg/audit/audit.go:101.2,102.13 2 1
github.com/tikv/pd/pkg/audit/audit.go:113.46,118.2 1 1
github.com/tikv/pd/pkg/audit/audit.go:121.68,123.9 2 1
github.com/tikv/pd/pkg/audit/audit.go:123.9,125.3 1 1
github.com/tikv/pd/pkg/audit/audit.go:126.2,127.13 2 1
```

```bash
support_coverprofile* $ go tool cover --func=xxx
github.com/tikv/pd/pkg/audit/audit.go:44:       Match                           100.0%
github.com/tikv/pd/pkg/audit/audit.go:59:       ProcessBeforeHandler            0.0%
github.com/tikv/pd/pkg/audit/audit.go:83:       NewPrometheusHistogramBackend   100.0%
github.com/tikv/pd/pkg/audit/audit.go:92:       ProcessHTTPRequest              87.5%
github.com/tikv/pd/pkg/audit/audit.go:113:      NewLocalLogBackend              100.0%
github.com/tikv/pd/pkg/audit/audit.go:121:      ProcessHTTPRequest              100.0%
total:                                          (statements)                    90.0%
```

### integrate ci unit tests job

advantage:
- now: run 2 chunks each 5min
- before: run 10 chunks each 5min

now
<img width="60%" alt="image" src="https://github.com/tikv/pd/assets/53859786/8e28be45-ed9f-4d48-807a-519c89a77ef3">

before 
<img width="60%" alt="image" src="https://github.com/tikv/pd/assets/53859786/3fee3e90-ddc1-475c-8267-4609119df881">



```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
