### PR TITLE
client/http: change the keyspace config name for the GC management type

### DIFF
--- a/client/http/interface.go
+++ b/client/http/interface.go
@@ -98,6 +98,11 @@ type Client interface {
 	DeleteOperators(context.Context) error
 
 	/* Keyspace interface */
+
+	// UpdateKeyspaceGCManagementType update the `gc_management_type` in keyspace meta config.
+	// If `gc_management_type` is `global_gc`, it means the current keyspace requires a tidb without 'keyspace-name'
+	// configured to run a global gc worker to compute a global gc safe point.
+	// If `gc_management_type` is `keyspace_level_gc` it means the current keyspace can compute gc safe point by its own.
 	UpdateKeyspaceGCManagementType(ctx context.Context, keyspaceName string, keyspaceGCManagementType *KeyspaceGCManagementTypeConfig) error
 	GetKeyspaceMetaByName(ctx context.Context, keyspaceName string) (*keyspacepb.KeyspaceMeta, error)
 

--- a/client/http/interface.go
+++ b/client/http/interface.go
@@ -98,7 +98,7 @@ type Client interface {
 	DeleteOperators(context.Context) error
 
 	/* Keyspace interface */
-	UpdateKeyspaceSafePointVersion(ctx context.Context, keyspaceName string, keyspaceSafePointVersion *KeyspaceSafePointVersionConfig) error
+	UpdateKeyspaceGCManagementType(ctx context.Context, keyspaceName string, keyspaceGCManagementType *KeyspaceGCManagementTypeConfig) error
 	GetKeyspaceMetaByName(ctx context.Context, keyspaceName string) (*keyspacepb.KeyspaceMeta, error)
 
 	/* Client-related methods */
@@ -921,14 +921,14 @@ func (c *client) DeleteOperators(ctx context.Context) error {
 		WithMethod(http.MethodDelete))
 }
 
-// UpdateKeyspaceSafePointVersion patches the keyspace config.
-func (c *client) UpdateKeyspaceSafePointVersion(ctx context.Context, keyspaceName string, keyspaceSafePointVersion *KeyspaceSafePointVersionConfig) error {
-	keyspaceConfigPatchJSON, err := json.Marshal(keyspaceSafePointVersion)
+// UpdateKeyspaceGCManagementType patches the keyspace config.
+func (c *client) UpdateKeyspaceGCManagementType(ctx context.Context, keyspaceName string, keyspaceGCmanagementType *KeyspaceGCManagementTypeConfig) error {
+	keyspaceConfigPatchJSON, err := json.Marshal(keyspaceGCmanagementType)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	return c.request(ctx, newRequestInfo().
-		WithName(UpdateKeyspaceSafePointVersionName).
+		WithName(UpdateKeyspaceGCManagementTypeName).
 		WithURI(GetUpdateKeyspaceConfigURL(keyspaceName)).
 		WithMethod(http.MethodPatch).
 		WithBody(keyspaceConfigPatchJSON))

--- a/client/http/interface.go
+++ b/client/http/interface.go
@@ -101,8 +101,8 @@ type Client interface {
 
 	// UpdateKeyspaceGCManagementType update the `gc_management_type` in keyspace meta config.
 	// If `gc_management_type` is `global_gc`, it means the current keyspace requires a tidb without 'keyspace-name'
-	// configured to run a global gc worker to compute a global gc safe point.
-	// If `gc_management_type` is `keyspace_level_gc` it means the current keyspace can compute gc safe point by its own.
+	// configured to run a global gc worker to calculate a global gc safe point.
+	// If `gc_management_type` is `keyspace_level_gc` it means the current keyspace can calculate gc safe point by its own.
 	UpdateKeyspaceGCManagementType(ctx context.Context, keyspaceName string, keyspaceGCManagementType *KeyspaceGCManagementTypeConfig) error
 	GetKeyspaceMetaByName(ctx context.Context, keyspaceName string) (*keyspacepb.KeyspaceMeta, error)
 

--- a/client/http/request_info.go
+++ b/client/http/request_info.go
@@ -78,7 +78,7 @@ const (
 	setSnapshotRecoveringMarkName           = "SetSnapshotRecoveringMark"
 	deleteSnapshotRecoveringMarkName        = "DeleteSnapshotRecoveringMark"
 	deleteOperators                         = "DeleteOperators"
-	UpdateKeyspaceSafePointVersionName      = "UpdateKeyspaceSafePointVersion"
+	UpdateKeyspaceGCManagementTypeName      = "UpdateKeyspaceGCManagementType"
 	GetKeyspaceMetaByNameName               = "GetKeyspaceMetaByName"
 )
 

--- a/client/http/types.go
+++ b/client/http/types.go
@@ -624,14 +624,14 @@ type MicroServiceMember struct {
 	StartTimestamp int64  `json:"start-timestamp"`
 }
 
-// KeyspaceSafePointVersion represents parameters needed to modify the safe point version.
-type KeyspaceSafePointVersion struct {
-	SafePointVersion string `json:"safe_point_version,omitempty"`
+// KeyspaceGCManagementType represents parameters needed to modify the safe point version.
+type KeyspaceGCManagementType struct {
+	gc_management_type string `json:"gc_management_type,omitempty"`
 }
 
-// KeyspaceSafePointVersionConfig represents parameters needed to modify target keyspace's configs.
-type KeyspaceSafePointVersionConfig struct {
-	Config KeyspaceSafePointVersion `json:"config"`
+// KeyspaceGCManagementTypeConfig represents parameters needed to modify target keyspace's configs.
+type KeyspaceGCManagementTypeConfig struct {
+	Config KeyspaceGCManagementType `json:"config"`
 }
 
 // tempKeyspaceMeta is the keyspace meta struct that returned from the http interface.

--- a/client/http/types.go
+++ b/client/http/types.go
@@ -624,7 +624,10 @@ type MicroServiceMember struct {
 	StartTimestamp int64  `json:"start-timestamp"`
 }
 
-// KeyspaceGCManagementType represents parameters needed to modify the safe point version.
+// KeyspaceGCManagementType represents parameters needed to modify the gc management type.
+// If `gc_management_type` is `global_gc`, it means the current keyspace requires a tidb without 'keyspace-name'
+// configured to run a global gc worker to compute a global gc safe point.
+// If `gc_management_type` is `keyspace_level_gc` it means the current keyspace can compute gc safe point by its own.
 type KeyspaceGCManagementType struct {
 	GCManagementType string `json:"gc_management_type,omitempty"`
 }

--- a/client/http/types.go
+++ b/client/http/types.go
@@ -626,7 +626,7 @@ type MicroServiceMember struct {
 
 // KeyspaceGCManagementType represents parameters needed to modify the safe point version.
 type KeyspaceGCManagementType struct {
-	gc_management_type string `json:"gc_management_type,omitempty"`
+	GCManagementType string `json:"gc_management_type,omitempty"`
 }
 
 // KeyspaceGCManagementTypeConfig represents parameters needed to modify target keyspace's configs.

--- a/client/http/types.go
+++ b/client/http/types.go
@@ -626,8 +626,8 @@ type MicroServiceMember struct {
 
 // KeyspaceGCManagementType represents parameters needed to modify the gc management type.
 // If `gc_management_type` is `global_gc`, it means the current keyspace requires a tidb without 'keyspace-name'
-// configured to run a global gc worker to compute a global gc safe point.
-// If `gc_management_type` is `keyspace_level_gc` it means the current keyspace can compute gc safe point by its own.
+// configured to run a global gc worker to calculate a global gc safe point.
+// If `gc_management_type` is `keyspace_level_gc` it means the current keyspace can calculate gc safe point by its own.
 type KeyspaceGCManagementType struct {
 	GCManagementType string `json:"gc_management_type,omitempty"`
 }

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -797,7 +797,7 @@ func (suite *httpClientTestSuite) checkUpdateKeyspaceSafePointVersion(mode mode,
 
 	keyspaceSafePointVersionConfig := pd.KeyspaceGCManagementTypeConfig{
 		Config: pd.KeyspaceGCManagementType{
-			SafePointVersion: gcManagementType,
+			GCManagementType: gcManagementType,
 		},
 	}
 	err := client.UpdateKeyspaceGCManagementType(env.ctx, keyspaceName, &keyspaceSafePointVersionConfig)

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -784,20 +784,20 @@ func (suite *httpClientTestSuite) TestRedirectWithMetrics() {
 	c.Close()
 }
 
-func (suite *httpClientTestSuite) TestUpdateKeyspaceSafePointVersion() {
-	suite.RunTestInTwoModes(suite.checkUpdateKeyspaceSafePointVersion)
+func (suite *httpClientTestSuite) TestUpdateKeyspaceGCManagementType() {
+	suite.RunTestInTwoModes(suite.checkUpdateKeyspaceGCManagementType)
 }
 
-func (suite *httpClientTestSuite) checkUpdateKeyspaceSafePointVersion(mode mode, client pd.Client) {
+func (suite *httpClientTestSuite) checkUpdateKeyspaceGCManagementType(mode mode, client pd.Client) {
 	re := suite.Require()
 	env := suite.env[mode]
 
 	keyspaceName := "DEFAULT"
-	gcManagementType := "keysapce_level_gc"
+	expectGCManagementType := "keysapce_level_gc"
 
 	keyspaceSafePointVersionConfig := pd.KeyspaceGCManagementTypeConfig{
 		Config: pd.KeyspaceGCManagementType{
-			GCManagementType: gcManagementType,
+			GCManagementType: expectGCManagementType,
 		},
 	}
 	err := client.UpdateKeyspaceGCManagementType(env.ctx, keyspaceName, &keyspaceSafePointVersionConfig)
@@ -806,6 +806,8 @@ func (suite *httpClientTestSuite) checkUpdateKeyspaceSafePointVersion(mode mode,
 	keyspaceMetaRes, err := client.GetKeyspaceMetaByName(env.ctx, keyspaceName)
 	re.NoError(err)
 	val, ok := keyspaceMetaRes.Config["gc_management_type"]
+
+	// Check it can get expect key and value in keyspace meta config.
 	re.True(ok)
-	re.Equal(gcManagementType, val)
+	re.Equal(expectGCManagementType, val)
 }

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -793,19 +793,19 @@ func (suite *httpClientTestSuite) checkUpdateKeyspaceSafePointVersion(mode mode,
 	env := suite.env[mode]
 
 	keyspaceName := "DEFAULT"
-	safePointVersion := "v2"
+	gcManagementType := "keysapce_level_gc"
 
-	keyspaceSafePointVersionConfig := pd.KeyspaceSafePointVersionConfig{
-		Config: pd.KeyspaceSafePointVersion{
-			SafePointVersion: safePointVersion,
+	keyspaceSafePointVersionConfig := pd.KeyspaceGCManagementTypeConfig{
+		Config: pd.KeyspaceGCManagementType{
+			SafePointVersion: gcManagementType,
 		},
 	}
-	err := client.UpdateKeyspaceSafePointVersion(env.ctx, keyspaceName, &keyspaceSafePointVersionConfig)
+	err := client.UpdateKeyspaceGCManagementType(env.ctx, keyspaceName, &keyspaceSafePointVersionConfig)
 	re.NoError(err)
 
 	keyspaceMetaRes, err := client.GetKeyspaceMetaByName(env.ctx, keyspaceName)
 	re.NoError(err)
-	val, ok := keyspaceMetaRes.Config["safe_point_version"]
+	val, ok := keyspaceMetaRes.Config["gc_management_type"]
 	re.True(ok)
-	re.Equal(safePointVersion, val)
+	re.Equal(gcManagementType, val)
 }

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -793,7 +793,7 @@ func (suite *httpClientTestSuite) checkUpdateKeyspaceGCManagementType(mode mode,
 	env := suite.env[mode]
 
 	keyspaceName := "DEFAULT"
-	expectGCManagementType := "keysapce_level_gc"
+	expectGCManagementType := "keyspace_level_gc"
 
 	keyspaceSafePointVersionConfig := pd.KeyspaceGCManagementTypeConfig{
 		Config: pd.KeyspaceGCManagementType{


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

`safe_point_version` Config name in keyspace meta config make some confuse.
It need be changed to `gc_management_type`.

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref https://github.com/tikv/pd/issues/8002

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Change `safe_point_version` to 'gc_management_type' in keyspace meta config 
```
If `gc_management_type` is `global_gc`, it means the current keyspace requires a tidb without 'keyspace-name'
configured to run a global gc worker to calculate a global gc safe point.
If `gc_management_type` is `keyspace_level_gc` it means the current keyspace can calculate gc safe point by its own.


After update Keyspace GC management type, query keyspace meta from PD, we can get as follows:
```
{
    "id": 1,
    "name": "ks1",
    "state": "ENABLED",
    "created_at": 1711703870,
    "state_changed_at": 1711703870,
    "config": {
        "gc_management_type": "keyspace_level_gc",    // It's in effect in this PR
        "tso_keyspace_group_id": "0",
        "user_kind": "basic"
    }
}
```


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
   - TestUpdateKeyspaceGCManagementType

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
Change `safe_point_version` to 'gc_management_type' in keyspace meta config 
```
