### PR TITLE
schedule: add check action when poll the opeators from opNotifierQueue

### DIFF
--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -459,7 +459,7 @@ func (oc *Controller) checkAddOperator(isPromoting bool, ops ...*Operator) (bool
 }
 
 // checkOperatorLightly checks whether the ops can be dispatched in Controller::pollNeedDispatchRegion.
-// The operators can't be dispatched for some scenarios, such as region disapeared, region changed ...
+// The operators can't be dispatched for some scenarios, such as region disappeared, region changed ...
 // `region` is the target region of `op`.
 func (oc *Controller) checkOperatorLightly(op *Operator) (*core.RegionInfo, CancelReasonType) {
 	region := oc.cluster.GetRegion(op.RegionID())

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -471,7 +471,7 @@ func (oc *Controller) checkOperatorLightly(op *Operator) (*core.RegionInfo, Canc
 	// It may be suitable for all kinds of operator but not merge-region.
 	// But to be cautions, it only takes effect on merge-region currently.
 	// If the version of epoch is changed, the region has been splitted or merged, and the key range has been changed.
-	// The changing for conf_version of epoch doesn't modify the region key range, skipt it.
+	// The changing for conf_version of epoch doesn't modify the region key range, skip it.
 	if (op.Kind()&OpMerge != 0) && region.GetRegionEpoch().GetVersion() != op.RegionEpoch().GetVersion() {
 		operatorCounter.WithLabelValues(op.Desc(), "epoch-not-match").Inc()
 		return nil, EpochNotMatch

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -472,7 +472,7 @@ func (oc *Controller) checkOperatorLightly(op *Operator) (*core.RegionInfo, Canc
 	// But to be cautions, it only takes effect on merge-region currently.
 	// If the version of epoch is changed, the region has been splitted or merged, and the key range has been changed.
 	// The changing for conf_version of epoch doesn't modify the region key range, skip it.
-	if (op.Kind()&OpMerge != 0) && region.GetRegionEpoch().GetVersion() != op.RegionEpoch().GetVersion() {
+	if (op.Kind()&OpMerge != 0) && region.GetRegionEpoch().GetVersion() > op.RegionEpoch().GetVersion() {
 		operatorCounter.WithLabelValues(op.Desc(), "epoch-not-match").Inc()
 		return nil, EpochNotMatch
 	}

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -217,10 +217,12 @@ func (oc *Controller) pollNeedDispatchRegion() (r *core.RegionInfo, next bool) {
 	if !ok || op == nil {
 		return nil, true
 	}
-	r = oc.cluster.GetRegion(regionID)
-	if r == nil {
+	// Check the operator lightly. It cant't dispatch the op for some scenario.
+	var reason CancelReasonType
+	r, reason = oc.checkOperatorLightly(op)
+	if len(reason) != 0 {
 		_ = oc.removeOperatorLocked(op)
-		if op.Cancel(RegionNotFound) {
+		if op.Cancel(reason) {
 			log.Warn("remove operator because region disappeared",
 				zap.Uint64("region-id", op.RegionID()),
 				zap.Stringer("operator", op))
@@ -301,6 +303,7 @@ func (oc *Controller) AddWaitingOperator(ops ...*Operator) int {
 		if isMerge {
 			// count two merge operators as one, so wopStatus.ops[desc] should
 			// not be updated here
+			// TODO: call checkAddOperator ...
 			i++
 			added++
 			oc.wop.PutOperator(ops[i])
@@ -453,6 +456,27 @@ func (oc *Controller) checkAddOperator(isPromoting bool, ops ...*Operator) (bool
 		}
 	}
 	return reason != Expired, reason
+}
+
+// checkOperatorLightly checks whether the ops can be dispatched in Controller::pollNeedDispatchRegion.
+// The operators can't be dispatched for some scenarios, such as region disapeared, region changed ...
+// `region` is the target region of `op`.
+func (oc *Controller) checkOperatorLightly(op *Operator) (*core.RegionInfo, CancelReasonType) {
+	region := oc.cluster.GetRegion(op.RegionID())
+	if region == nil {
+		operatorCounter.WithLabelValues(op.Desc(), "not-found").Inc()
+		return nil, RegionNotFound
+	}
+
+	// It may be suitable for all kinds of operator but not merge-region.
+	// But to be cautions, it only takes effect on merge-region currently.
+	// If the version of epoch is changed, the region has been splitted or merged, and the key range has been changed.
+	// The changing for conf_version of epoch doesn't modify the region key range, skipt it.
+	if (op.Kind()&OpMerge != 0) && region.GetRegionEpoch().GetVersion() != op.RegionEpoch().GetVersion() {
+		operatorCounter.WithLabelValues(op.Desc(), "epoch-not-match").Inc()
+		return nil, EpochNotMatch
+	}
+	return region, ""
 }
 
 func isHigherPriorityOperator(new, old *Operator) bool {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -418,10 +418,10 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
 	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
 
-	source := newRegionInfo(101, "1a", "1b", 1, 1, []uint64{101, 1}, []uint64{101, 1})
+	source := newRegionInfo(101, "1a", "1b", 10, 10, []uint64{101, 1}, []uint64{101, 1})
 	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
 	cluster.PutRegion(source)
-	target := newRegionInfo(102, "1b", "1c", 1, 1, []uint64{101, 1}, []uint64{101, 1})
+	target := newRegionInfo(102, "1b", "1c", 10, 10, []uint64{101, 1}, []uint64{101, 1})
 	target.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
 	cluster.PutRegion(target)
 
@@ -448,9 +448,9 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 	r, next = controller.pollNeedDispatchRegion()
 	re.True(next)
 	re.Nil(r)
-	re.Equal(len(controller.opNotifierQueue), 1)
-	re.Equal(len(controller.operators), 0)
-	re.Equal(len(controller.wop.ListOperator()), 0)
+	re.Len(controller.opNotifierQueue, 1)
+	re.Empty(controller.operators)
+	re.Empty(controller.wop.ListOperator())
 	re.NotNil(controller.records.Get(101))
 	re.NotNil(controller.records.Get(102))
 
@@ -459,14 +459,14 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 	r, next = controller.pollNeedDispatchRegion()
 	re.True(next)
 	re.Nil(r)
-	re.Equal(len(controller.opNotifierQueue), 0)
+	re.Empty(controller.opNotifierQueue)
 
 	// Add the two ops to waiting operators again.
 	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{ConfVer: 0, Version: 0}
 	controller.records.ttl.Remove(101)
 	controller.records.ttl.Remove(102)
 	ops, err = CreateMergeRegionOperator("merge-region", cluster, source, target, OpMerge)
-	re.Nil(err)
+	re.NoError(err)
 	re.Equal(2, controller.AddWaitingOperator(ops...))
 	// change the target RegionEpoch
 	// first poll gets source region from opNotifierQueue
@@ -479,9 +479,9 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 	r, next = controller.pollNeedDispatchRegion()
 	re.True(next)
 	re.Nil(r)
-	re.Equal(len(controller.opNotifierQueue), 1)
-	re.Equal(len(controller.operators), 0)
-	re.Equal(len(controller.wop.ListOperator()), 0)
+	re.Len(controller.opNotifierQueue, 1)
+	re.Empty(controller.operators)
+	re.Empty(controller.wop.ListOperator())
 	re.NotNil(controller.records.Get(101))
 	re.NotNil(controller.records.Get(102))
 
@@ -489,7 +489,7 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 	r, next = controller.pollNeedDispatchRegion()
 	re.True(next)
 	re.Nil(r)
-	re.Equal(len(controller.opNotifierQueue), 0)
+	re.Empty(controller.opNotifierQueue)
 }
 
 func (suite *operatorControllerTestSuite) TestStoreLimit() {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -407,6 +407,91 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegion() {
 	re.False(next)
 }
 
+// issue #7992
+func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster.ID, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+
+	source := newRegionInfo(101, "1a", "1b", 1, 1, []uint64{101, 1}, []uint64{101, 1})
+	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+	cluster.PutRegion(source)
+	target := newRegionInfo(102, "1b", "1c", 1, 1, []uint64{101, 1}, []uint64{101, 1})
+	target.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+	cluster.PutRegion(target)
+
+	ops, err := CreateMergeRegionOperator("merge-region", cluster, source, target, OpMerge)
+	re.NoError(err)
+	re.Len(ops, 2)
+	re.Equal(2, controller.AddWaitingOperator(ops...))
+	// Change next push time to now, it's used to make test case faster.
+	controller.opNotifierQueue[0].time = time.Now()
+
+	// first poll gets source region op.
+	r, next := controller.pollNeedDispatchRegion()
+	re.True(next)
+	re.Equal(r, source)
+
+	// second poll gets target region op.
+	controller.opNotifierQueue[0].time = time.Now()
+	r, next = controller.pollNeedDispatchRegion()
+	re.True(next)
+	re.Equal(r, target)
+
+	// third poll removes the two merge-region ops.
+	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{ConfVer: 0, Version: 1}
+	r, next = controller.pollNeedDispatchRegion()
+	re.True(next)
+	re.Nil(r)
+	re.Equal(len(controller.opNotifierQueue), 1)
+	re.Equal(len(controller.operators), 0)
+	re.Equal(len(controller.wop.ListOperator()), 0)
+	re.NotNil(controller.records.Get(101))
+	re.NotNil(controller.records.Get(102))
+
+	// fourth poll removes target region op from opNotifierQueue
+	controller.opNotifierQueue[0].time = time.Now()
+	r, next = controller.pollNeedDispatchRegion()
+	re.True(next)
+	re.Nil(r)
+	re.Equal(len(controller.opNotifierQueue), 0)
+
+	// Add the two ops to waiting operators again.
+	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{ConfVer: 0, Version: 0}
+	controller.records.ttl.Remove(101)
+	controller.records.ttl.Remove(102)
+	ops, err = CreateMergeRegionOperator("merge-region", cluster, source, target, OpMerge)
+	re.Nil(err)
+	re.Equal(2, controller.AddWaitingOperator(ops...))
+	// change the target RegionEpoch
+	// first poll gets source region from opNotifierQueue
+	target.GetMeta().RegionEpoch = &metapb.RegionEpoch{ConfVer: 0, Version: 1}
+	controller.opNotifierQueue[0].time = time.Now()
+	r, next = controller.pollNeedDispatchRegion()
+	re.True(next)
+	re.Equal(r, source)
+
+	r, next = controller.pollNeedDispatchRegion()
+	re.True(next)
+	re.Nil(r)
+	re.Equal(len(controller.opNotifierQueue), 1)
+	re.Equal(len(controller.operators), 0)
+	re.Equal(len(controller.wop.ListOperator()), 0)
+	re.NotNil(controller.records.Get(101))
+	re.NotNil(controller.records.Get(102))
+
+	controller.opNotifierQueue[0].time = time.Now()
+	r, next = controller.pollNeedDispatchRegion()
+	re.True(next)
+	re.Nil(r)
+	re.Equal(len(controller.opNotifierQueue), 0)
+}
+
 func (suite *operatorControllerTestSuite) TestStoreLimit() {
 	re := suite.Require()
 	opt := mockconfig.NewTestOptions()

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -492,6 +492,46 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 	re.Empty(controller.opNotifierQueue)
 }
 
+func (suite *operatorControllerTestSuite) TestCheckOperatorLightly() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster.ID, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+
+	source := newRegionInfo(101, "1a", "1b", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+	cluster.PutRegion(source)
+	target := newRegionInfo(102, "1b", "1c", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+	target.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+	cluster.PutRegion(target)
+
+	ops, err := CreateMergeRegionOperator("merge-region", cluster, source, target, OpMerge)
+	re.NoError(err)
+	re.Len(ops, 2)
+
+	// check successfully
+	r, reason := controller.checkOperatorLightly(ops[0])
+	re.Empty(reason)
+	re.Equal(r, source)
+
+	// check failed because of region disappeared
+	cluster.RemoveRegion(target)
+	r, reason = controller.checkOperatorLightly(ops[1])
+	re.Nil(r)
+	re.Equal(reason, RegionNotFound)
+
+	// check failed because of verions of region epoch changed
+	cluster.PutRegion(target)
+	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{ConfVer: 0, Version: 1}
+	r, reason = controller.checkOperatorLightly(ops[0])
+	re.Nil(r)
+	re.Equal(reason, EpochNotMatch)
+}
+
 func (suite *operatorControllerTestSuite) TestStoreLimit() {
 	re := suite.Require()
 	opt := mockconfig.NewTestOptions()


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #7992 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
It add light check for polling the opeators from Controller::opNotifierQueue. 
For example, check whether the region has disappeared，check whether the version of region epoch has changed for merge-region operator.
It has the chance to cancel the operators from Controller::opNotifierQueue execept timeout. We can only cancel the operator by timeout mechanism before.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
