### PR TITLE
tests/rule: make TestLargeRules more stable

### DIFF
--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -1261,6 +1261,13 @@ func (suite *ruleTestSuite) postAndCheckRuleBundle(urlPrefix string, bundle []pl
 		err = tu.CheckGetJSON(testDialClient, urlPrefix+"/config/placement-rule", nil,
 			tu.StatusOK(re), tu.ExtractJSON(re, &respBundle))
 		re.NoError(err)
+		// skip default rule check
+		for i := range respBundle {
+			if respBundle[i].ID == placement.DefaultGroupID {
+				respBundle = append(respBundle[:i], respBundle[i+1:]...)
+				break
+			}
+		}
 		if len(respBundle) != len(bundle) {
 			return false
 		}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

### What is changed and how does it work?

tested by #7969
Because below code will add default rule after the previous test finished, we need to skip default rule for large rule test to make it stable
https://github.com/tikv/pd/blob/7e95abff62564dbe683ee2359aa69769cab4dc0d/tests/server/api/rule_test.go#L62-L78 will 

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
