### PR TITLE
tools/pd-ut: accelarate build by `compile-without-link`

### DIFF
--- a/tools/pd-ut/go-compile-without-link.sh
+++ b/tools/pd-ut/go-compile-without-link.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# See https://gist.github.com/howardjohn/c0f5d0bc293ef7d7fada533a2c9ffaf4
+# Usage: go test -exec=true -toolexec=go-compile-without-link -vet=off ./...
+# Preferably as an alias like `alias go-test-compile='go test -exec=true -toolexec=go-compile-without-link -vet=off'`
+# This will compile all tests, but not link them (which is the least cacheable part)
+
+if [[ "${2}" == "-V=full" ]]; then
+  "$@"
+  exit 0
+fi
+case "$(basename ${1})" in
+  link)
+    # Output a dummy file
+    touch "${3}"
+    ;;
+  # We could skip vet as well, but it can be done with -vet=off if desired
+  *)
+    "$@"
+esac


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

Behind the scene, it's a technique called 'staged build'.

If we build all the test binaries parallelly, the go compiler will detect that much of the pacakge cache are not available, so it would build package cache several times. For example, building `pkg/server/api` and `pkg/server/apiv2` parallelly, they all depends on a lot of other small packages, since those packages do not exist at the time. The package is built repeatedly because of the parallel.

If we build all the packages first to make the cache available, and then built the test binaries, we can avoid repeated package building. This make the whole process a little bit faster.

And rely on this article, we can build without link. https://blog.howardjohn.info/posts/go-build-times/#linking-vs-compiling

run below command
```bash
function run-with-cores() {
  cores="$1"
  shift
  docker run --rm -v $PWD:$PWD -w $PWD \
    --cpus="$cores" -e GOMAXPROCS="$cores" \
    -e 'GOFLAGS=-buildvcs=false' \
    -v `go env GOMODCACHE`:/go/pkg/mod \
    -it --init golang:1.21 bash -c "$*"
}

run-with-cores 2 '
make pd-ut
go clean -modcache 
time ./bin/pd-ut build
'
```

before vs after
```
real		7m51.159s
user		9m8.612s
sys 		1m18.024s
---
real		5m51.492s
user		9m29.775s
sys 		1m18.955s
```

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
