### PR TITLE
schedulers,test: avoid some test branches not being reached and remove schedulePeerPr 

### DIFF
--- a/pkg/schedule/schedulers/grant_hot_region.go
+++ b/pkg/schedule/schedulers/grant_hot_region.go
@@ -258,13 +258,13 @@ func newGrantHotRegionHandler(config *grantHotRegionSchedulerConfig) http.Handle
 
 func (s *grantHotRegionScheduler) Schedule(cluster sche.SchedulerCluster, _ bool) ([]*operator.Operator, []plan.Plan) {
 	grantHotRegionCounter.Inc()
-	rw := s.randomRWType()
-	s.prepareForBalance(rw, cluster)
-	return s.dispatch(rw, cluster), nil
+	typ := s.randomType()
+	s.prepareForBalance(typ, cluster)
+	return s.dispatch(typ, cluster), nil
 }
 
-func (s *grantHotRegionScheduler) dispatch(typ utils.RWType, cluster sche.SchedulerCluster) []*operator.Operator {
-	stLoadInfos := s.stLoadInfos[buildResourceType(typ, constant.RegionKind)]
+func (s *grantHotRegionScheduler) dispatch(typ resourceType, cluster sche.SchedulerCluster) []*operator.Operator {
+	stLoadInfos := s.stLoadInfos[typ]
 	infos := make([]*statistics.StoreLoadDetail, len(stLoadInfos))
 	index := 0
 	for _, info := range stLoadInfos {

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -47,25 +47,29 @@ const (
 	// HotRegionName is balance hot region scheduler name.
 	HotRegionName = "balance-hot-region-scheduler"
 	// HotRegionType is balance hot region scheduler type.
-	HotRegionType          = "hot-region"
-	splitHotReadBuckets    = "split-hot-read-region"
-	splitHotWriteBuckets   = "split-hot-write-region"
-	splitProgressiveRank   = int64(-5)
-	minHotScheduleInterval = time.Second
-	maxHotScheduleInterval = 20 * time.Second
+	HotRegionType           = "hot-region"
+	splitHotReadBuckets     = "split-hot-read-region"
+	splitHotWriteBuckets    = "split-hot-write-region"
+	splitProgressiveRank    = int64(-5)
+	minHotScheduleInterval  = time.Second
+	maxHotScheduleInterval  = 20 * time.Second
+	defaultSchedulePeerPr   = 0.66
+	defaultPendingAmpFactor = 2.0
+	defaultStddevThreshold  = 0.1
+	defaultTopnPosition     = 10
 )
 
 var (
 	// schedulePeerPr the probability of schedule the hot peer.
-	schedulePeerPr = 0.66
+	schedulePeerPr = defaultSchedulePeerPr
 	// pendingAmpFactor will amplify the impact of pending influence, making scheduling slower or even serial when two stores are close together
-	pendingAmpFactor = 2.0
+	pendingAmpFactor = defaultPendingAmpFactor
 	// If the distribution of a dimension is below the corresponding stddev threshold, then scheduling will no longer be based on this dimension,
 	// as it implies that this dimension is sufficiently uniform.
-	stddevThreshold = 0.1
+	stddevThreshold = defaultStddevThreshold
 	// topnPosition is the position of the topn peer in the hot peer list.
 	// We use it to judge whether to schedule the hot peer in some cases.
-	topnPosition = 10
+	topnPosition = defaultTopnPosition
 	// statisticsInterval is the interval to update statistics information.
 	statisticsInterval = time.Second
 )

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -121,7 +121,8 @@ type baseHotScheduler struct {
 	// regionPendings stores regionID -> pendingInfluence,
 	// this records regionID which have pending Operator by operation type. During filterHotPeers, the hot peers won't
 	// be selected if its owner region is tracked in this attribute.
-	regionPendings  map[uint64]*pendingInfluence
+	regionPendings map[uint64]*pendingInfluence
+	// types is the resource types that the scheduler considers.
 	types           []resourceType
 	r               *rand.Rand
 	updateReadTime  time.Time

--- a/pkg/schedule/schedulers/hot_region.go
+++ b/pkg/schedule/schedulers/hot_region.go
@@ -53,15 +53,12 @@ const (
 	splitProgressiveRank    = int64(-5)
 	minHotScheduleInterval  = time.Second
 	maxHotScheduleInterval  = 20 * time.Second
-	defaultSchedulePeerPr   = 0.66
 	defaultPendingAmpFactor = 2.0
 	defaultStddevThreshold  = 0.1
 	defaultTopnPosition     = 10
 )
 
 var (
-	// schedulePeerPr the probability of schedule the hot peer.
-	schedulePeerPr = defaultSchedulePeerPr
 	// pendingAmpFactor will amplify the impact of pending influence, making scheduling slower or even serial when two stores are close together
 	pendingAmpFactor = defaultPendingAmpFactor
 	// If the distribution of a dimension is below the corresponding stddev threshold, then scheduling will no longer be based on this dimension,
@@ -125,7 +122,7 @@ type baseHotScheduler struct {
 	// this records regionID which have pending Operator by operation type. During filterHotPeers, the hot peers won't
 	// be selected if its owner region is tracked in this attribute.
 	regionPendings  map[uint64]*pendingInfluence
-	types           []utils.RWType
+	types           []resourceType
 	r               *rand.Rand
 	updateReadTime  time.Time
 	updateWriteTime time.Time
@@ -135,12 +132,12 @@ func newBaseHotScheduler(opController *operator.Controller, sampleDuration time.
 	base := NewBaseScheduler(opController)
 	ret := &baseHotScheduler{
 		BaseScheduler:  base,
-		types:          []utils.RWType{utils.Write, utils.Read},
 		regionPendings: make(map[uint64]*pendingInfluence),
 		stHistoryLoads: statistics.NewStoreHistoryLoads(utils.DimLen, sampleDuration, sampleInterval),
 		r:              rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	for ty := resourceType(0); ty < resourceTypeLen; ty++ {
+		ret.types = append(ret.types, ty)
 		ret.stLoadInfos[ty] = map[uint64]*statistics.StoreLoadDetail{}
 	}
 	return ret
@@ -148,13 +145,13 @@ func newBaseHotScheduler(opController *operator.Controller, sampleDuration time.
 
 // prepareForBalance calculate the summary of pending Influence for each store and prepare the load detail for
 // each store, only update read or write load detail
-func (h *baseHotScheduler) prepareForBalance(rw utils.RWType, cluster sche.SchedulerCluster) {
+func (h *baseHotScheduler) prepareForBalance(typ resourceType, cluster sche.SchedulerCluster) {
 	storeInfos := statistics.SummaryStoreInfos(cluster.GetStores())
 	h.summaryPendingInfluence(storeInfos)
 	storesLoads := cluster.GetStoresLoads()
 	isTraceRegionFlow := cluster.GetSchedulerConfig().IsTraceRegionFlow()
 
-	prepare := func(regionStats map[uint64][]*statistics.HotPeerStat, resource constant.ResourceKind) {
+	prepare := func(regionStats map[uint64][]*statistics.HotPeerStat, rw utils.RWType, resource constant.ResourceKind) {
 		ty := buildResourceType(rw, resource)
 		h.stLoadInfos[ty] = statistics.SummaryStoresLoad(
 			storeInfos,
@@ -164,23 +161,25 @@ func (h *baseHotScheduler) prepareForBalance(rw utils.RWType, cluster sche.Sched
 			isTraceRegionFlow,
 			rw, resource)
 	}
-	switch rw {
-	case utils.Read:
+	switch typ {
+	case readLeader, readPeer:
 		// update read statistics
 		if time.Since(h.updateReadTime) >= statisticsInterval {
 			regionRead := cluster.RegionReadStats()
-			prepare(regionRead, constant.LeaderKind)
-			prepare(regionRead, constant.RegionKind)
+			prepare(regionRead, utils.Read, constant.LeaderKind)
+			prepare(regionRead, utils.Read, constant.RegionKind)
 			h.updateReadTime = time.Now()
 		}
-	case utils.Write:
+	case writeLeader, writePeer:
 		// update write statistics
 		if time.Since(h.updateWriteTime) >= statisticsInterval {
 			regionWrite := cluster.RegionWriteStats()
-			prepare(regionWrite, constant.LeaderKind)
-			prepare(regionWrite, constant.RegionKind)
+			prepare(regionWrite, utils.Write, constant.LeaderKind)
+			prepare(regionWrite, utils.Write, constant.RegionKind)
 			h.updateWriteTime = time.Now()
 		}
+	default:
+		log.Error("invalid resource type", zap.String("type", typ.String()))
 	}
 }
 
@@ -227,7 +226,7 @@ func setHotPendingInfluenceMetrics(storeLabel, rwTy, dim string, load float64) {
 	HotPendingSum.WithLabelValues(storeLabel, rwTy, dim).Set(load)
 }
 
-func (h *baseHotScheduler) randomRWType() utils.RWType {
+func (h *baseHotScheduler) randomType() resourceType {
 	return h.types[h.r.Int()%len(h.types)]
 }
 
@@ -328,24 +327,32 @@ func (h *hotScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
 
 func (h *hotScheduler) Schedule(cluster sche.SchedulerCluster, _ bool) ([]*operator.Operator, []plan.Plan) {
 	hotSchedulerCounter.Inc()
-	rw := h.randomRWType()
-	return h.dispatch(rw, cluster), nil
+	typ := h.randomType()
+	return h.dispatch(typ, cluster), nil
 }
 
-func (h *hotScheduler) dispatch(typ utils.RWType, cluster sche.SchedulerCluster) []*operator.Operator {
+func (h *hotScheduler) dispatch(typ resourceType, cluster sche.SchedulerCluster) []*operator.Operator {
 	h.Lock()
 	defer h.Unlock()
 	h.updateHistoryLoadConfig(h.conf.GetHistorySampleDuration(), h.conf.GetHistorySampleInterval())
 	h.prepareForBalance(typ, cluster)
-	// it can not move earlier to support to use api and metrics.
-	if h.conf.IsForbidRWType(typ) {
-		return nil
-	}
+	// IsForbidRWType can not be move earlier to support to use api and metrics.
 	switch typ {
-	case utils.Read:
+	case readLeader, readPeer:
+		if h.conf.IsForbidRWType(utils.Read) {
+			return nil
+		}
 		return h.balanceHotReadRegions(cluster)
-	case utils.Write:
-		return h.balanceHotWriteRegions(cluster)
+	case writePeer:
+		if h.conf.IsForbidRWType(utils.Write) {
+			return nil
+		}
+		return h.balanceHotWritePeers(cluster)
+	case writeLeader:
+		if h.conf.IsForbidRWType(utils.Write) {
+			return nil
+		}
+		return h.balanceHotWriteLeaders(cluster)
 	}
 	return nil
 }
@@ -410,19 +417,16 @@ func (h *hotScheduler) balanceHotReadRegions(cluster sche.SchedulerCluster) []*o
 	return nil
 }
 
-func (h *hotScheduler) balanceHotWriteRegions(cluster sche.SchedulerCluster) []*operator.Operator {
-	// prefer to balance by peer
-	s := h.r.Intn(100)
-	switch {
-	case s < int(schedulePeerPr*100):
-		peerSolver := newBalanceSolver(h, cluster, utils.Write, movePeer)
-		ops := peerSolver.solve()
-		if len(ops) > 0 && peerSolver.tryAddPendingInfluence() {
-			return ops
-		}
-	default:
+func (h *hotScheduler) balanceHotWritePeers(cluster sche.SchedulerCluster) []*operator.Operator {
+	peerSolver := newBalanceSolver(h, cluster, utils.Write, movePeer)
+	ops := peerSolver.solve()
+	if len(ops) > 0 && peerSolver.tryAddPendingInfluence() {
+		return ops
 	}
+	return nil
+}
 
+func (h *hotScheduler) balanceHotWriteLeaders(cluster sche.SchedulerCluster) []*operator.Operator {
 	leaderSolver := newBalanceSolver(h, cluster, utils.Write, transferLeader)
 	ops := leaderSolver.solve()
 	if len(ops) > 0 && leaderSolver.tryAddPendingInfluence() {

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -390,7 +390,6 @@ func TestHotWriteRegionScheduleByteRateOnly(t *testing.T) {
 }
 
 func checkHotWriteRegionPlacement(re *require.Assertions, enablePlacementRules bool) {
-	// This test is used to test move leader and move peer.
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	tc.SetEnableUseJointConsensus(true)

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -781,8 +781,10 @@ func TestHotWriteRegionScheduleByteRateOnlyWithTiFlash(t *testing.T) {
 		allowLeaderTiKVCount := aliveTiKVCount - 1 // store 5 with evict leader
 		aliveTiFlashCount := float64(aliveTiFlashLastID - aliveTiFlashStartID + 1)
 		tc.ObserveRegionsStats()
-		ops, _ := hb.Schedule(tc, false)
-		re.NotEmpty(ops)
+		testutil.Eventually(re, func() bool {
+			ops, _ := hb.Schedule(tc, false)
+			return len(ops) != 0
+		})
 		re.True(
 			loadsEqual(
 				hb.stLoadInfos[writeLeader][1].LoadPred.Expect.Loads,
@@ -801,8 +803,10 @@ func TestHotWriteRegionScheduleByteRateOnlyWithTiFlash(t *testing.T) {
 		pdServerCfg.FlowRoundByDigit = 8
 		tc.SetPDServerConfig(pdServerCfg)
 		clearPendingInfluence(hb)
-		ops, _ = hb.Schedule(tc, false)
-		re.NotEmpty(ops)
+		testutil.Eventually(re, func() bool {
+			ops, _ := hb.Schedule(tc, false)
+			return len(ops) != 0
+		})
 		re.True(
 			loadsEqual(
 				hb.stLoadInfos[writePeer][8].LoadPred.Expect.Loads,

--- a/pkg/schedule/schedulers/hot_region_v2_test.go
+++ b/pkg/schedule/schedulers/hot_region_v2_test.go
@@ -30,6 +30,7 @@ import (
 func TestHotWriteRegionScheduleWithRevertRegionsDimSecond(t *testing.T) {
 	// This is a test that searchRevertRegions finds a solution of rank -1.
 	re := require.New(t)
+	schedulePeerPr = 1.0
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	sche, err := CreateScheduler(utils.Write.String(), oc, storage.NewStorageWithMemoryBackend(), nil, nil)
@@ -90,6 +91,7 @@ func TestHotWriteRegionScheduleWithRevertRegionsDimSecond(t *testing.T) {
 func TestHotWriteRegionScheduleWithRevertRegionsDimFirst(t *testing.T) {
 	// This is a test that searchRevertRegions finds a solution of rank -3.
 	re := require.New(t)
+	schedulePeerPr = 1.0
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	sche, err := CreateScheduler(utils.Write.String(), oc, storage.NewStorageWithMemoryBackend(), nil, nil)
@@ -141,6 +143,7 @@ func TestHotWriteRegionScheduleWithRevertRegionsDimFirst(t *testing.T) {
 func TestHotWriteRegionScheduleWithRevertRegionsDimFirstOnly(t *testing.T) {
 	// This is a test that searchRevertRegions finds a solution of rank -2.
 	re := require.New(t)
+	schedulePeerPr = 1.0
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	sche, err := CreateScheduler(utils.Write.String(), oc, storage.NewStorageWithMemoryBackend(), nil, nil)
@@ -352,11 +355,9 @@ func TestHotReadRegionScheduleWithSmallHotRegion(t *testing.T) {
 
 	// Case1: Before #6827, we only use minHotRatio, so cannot schedule small hot region in this case.
 	// Because 10000 is larger than the length of hotRegions, so `filterHotPeers` will skip the topn calculation.
-	origin := topnPosition
 	topnPosition = 10000
 	ops := checkHotReadRegionScheduleWithSmallHotRegion(re, highLoad, lowLoad, emptyFunc)
 	re.Empty(ops)
-	topnPosition = origin
 
 	// Case2: After #6827, we use top10 as the threshold of minHotPeer.
 	ops = checkHotReadRegionScheduleWithSmallHotRegion(re, highLoad, lowLoad, emptyFunc)
@@ -401,7 +402,6 @@ func TestHotReadRegionScheduleWithSmallHotRegion(t *testing.T) {
 		tc.AddRegionWithReadInfo(hotRegionID+1, 1, bigHotRegionByte, 0, bigHotRegionQuery, utils.StoreHeartBeatReportInterval, []uint64{2, 3})
 	})
 	re.Empty(ops)
-	topnPosition = origin
 
 	// Case7: If there are more than topnPosition hot regions, but them are pending,
 	// we will schedule large hot region rather than small hot region, so there is no operator.
@@ -413,7 +413,6 @@ func TestHotReadRegionScheduleWithSmallHotRegion(t *testing.T) {
 		hb.regionPendings[hotRegionID+1] = &pendingInfluence{}
 	})
 	re.Empty(ops)
-	topnPosition = origin
 }
 
 func checkHotReadRegionScheduleWithSmallHotRegion(re *require.Assertions, highLoad, lowLoad uint64,

--- a/pkg/schedule/schedulers/hot_region_v2_test.go
+++ b/pkg/schedule/schedulers/hot_region_v2_test.go
@@ -30,12 +30,12 @@ import (
 func TestHotWriteRegionScheduleWithRevertRegionsDimSecond(t *testing.T) {
 	// This is a test that searchRevertRegions finds a solution of rank -1.
 	re := require.New(t)
-	schedulePeerPr = 1.0
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	sche, err := CreateScheduler(utils.Write.String(), oc, storage.NewStorageWithMemoryBackend(), nil, nil)
 	re.NoError(err)
 	hb := sche.(*hotScheduler)
+	hb.types = []resourceType{writePeer}
 	hb.conf.SetDstToleranceRatio(0.0)
 	hb.conf.SetSrcToleranceRatio(0.0)
 	hb.conf.SetRankFormulaVersion("v1")
@@ -91,12 +91,12 @@ func TestHotWriteRegionScheduleWithRevertRegionsDimSecond(t *testing.T) {
 func TestHotWriteRegionScheduleWithRevertRegionsDimFirst(t *testing.T) {
 	// This is a test that searchRevertRegions finds a solution of rank -3.
 	re := require.New(t)
-	schedulePeerPr = 1.0
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	sche, err := CreateScheduler(utils.Write.String(), oc, storage.NewStorageWithMemoryBackend(), nil, nil)
 	re.NoError(err)
 	hb := sche.(*hotScheduler)
+	hb.types = []resourceType{writePeer}
 	hb.conf.SetDstToleranceRatio(0.0)
 	hb.conf.SetSrcToleranceRatio(0.0)
 	hb.conf.SetRankFormulaVersion("v1")
@@ -143,12 +143,12 @@ func TestHotWriteRegionScheduleWithRevertRegionsDimFirst(t *testing.T) {
 func TestHotWriteRegionScheduleWithRevertRegionsDimFirstOnly(t *testing.T) {
 	// This is a test that searchRevertRegions finds a solution of rank -2.
 	re := require.New(t)
-	schedulePeerPr = 1.0
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
 	sche, err := CreateScheduler(utils.Write.String(), oc, storage.NewStorageWithMemoryBackend(), nil, nil)
 	re.NoError(err)
 	hb := sche.(*hotScheduler)
+	hb.types = []resourceType{writePeer}
 	hb.conf.SetDstToleranceRatio(0.0)
 	hb.conf.SetSrcToleranceRatio(0.0)
 	hb.conf.SetRankFormulaVersion("v1")

--- a/pkg/schedule/schedulers/scheduler_test.go
+++ b/pkg/schedule/schedulers/scheduler_test.go
@@ -317,6 +317,7 @@ func TestShuffleRegionRole(t *testing.T) {
 }
 
 func TestSpecialUseHotRegion(t *testing.T) {
+	schedulePeerPr = 1.0
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()

--- a/pkg/schedule/schedulers/shuffle_hot_region.go
+++ b/pkg/schedule/schedulers/shuffle_hot_region.go
@@ -159,9 +159,9 @@ func (s *shuffleHotRegionScheduler) IsScheduleAllowed(cluster sche.SchedulerClus
 
 func (s *shuffleHotRegionScheduler) Schedule(cluster sche.SchedulerCluster, _ bool) ([]*operator.Operator, []plan.Plan) {
 	shuffleHotRegionCounter.Inc()
-	rw := s.randomRWType()
-	s.prepareForBalance(rw, cluster)
-	operators := s.randomSchedule(cluster, s.stLoadInfos[buildResourceType(rw, constant.LeaderKind)])
+	typ := s.randomType()
+	s.prepareForBalance(typ, cluster)
+	operators := s.randomSchedule(cluster, s.stLoadInfos[typ])
 	return operators, nil
 }
 

--- a/pkg/schedule/schedulers/shuffle_hot_region.go
+++ b/pkg/schedule/schedulers/shuffle_hot_region.go
@@ -161,8 +161,12 @@ func (s *shuffleHotRegionScheduler) Schedule(cluster sche.SchedulerCluster, _ bo
 	shuffleHotRegionCounter.Inc()
 	typ := s.randomType()
 	s.prepareForBalance(typ, cluster)
-	operators := s.randomSchedule(cluster, s.stLoadInfos[typ])
-	return operators, nil
+	switch typ {
+	case readLeader, writeLeader:
+		return s.randomSchedule(cluster, s.stLoadInfos[typ]), nil
+	default:
+	}
+	return nil, nil
 }
 
 func (s *shuffleHotRegionScheduler) randomSchedule(cluster sche.SchedulerCluster, loadDetail map[uint64]*statistics.StoreLoadDetail) []*operator.Operator {

--- a/pkg/statistics/hot_cache_test.go
+++ b/pkg/statistics/hot_cache_test.go
@@ -26,11 +26,13 @@ func TestIsHot(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cache := NewHotCache(ctx)
-	region := buildRegion(utils.Read, 3, 60)
-	stats := cache.CheckReadPeerSync(region, region.GetPeers(), []float64{100000000, 1000, 1000}, 60)
-	cache.Update(stats[0], utils.Read)
-	for i := 0; i < 100; i++ {
-		re.True(cache.IsRegionHot(region, 1))
+	for i := utils.RWType(0); i < utils.RWTypeLen; i++ {
+		cache := NewHotCache(ctx)
+		region := buildRegion(i, 3, 60)
+		stats := cache.CheckReadPeerSync(region, region.GetPeers(), []float64{100000000, 1000, 1000}, 60)
+		cache.Update(stats[0], i)
+		for i := 0; i < 100; i++ {
+			re.True(cache.IsRegionHot(region, 1))
+		}
 	}
 }

--- a/pkg/statistics/store_hot_peers_infos.go
+++ b/pkg/statistics/store_hot_peers_infos.go
@@ -288,9 +288,10 @@ func summaryStoresLoadByEngine(
 func filterHotPeers(kind constant.ResourceKind, peers []*HotPeerStat) []*HotPeerStat {
 	ret := make([]*HotPeerStat, 0, len(peers))
 	for _, peer := range peers {
-		if kind != constant.LeaderKind || peer.IsLeader() {
-			ret = append(ret, peer)
+		if kind == constant.LeaderKind && !peer.IsLeader() {
+			continue
 		}
+		ret = append(ret, peer)
 	}
 	return ret
 }

--- a/pkg/utils/operatorutil/operator_check.go
+++ b/pkg/utils/operatorutil/operator_check.go
@@ -82,7 +82,7 @@ func CheckTransferPeer(re *require.Assertions, op *operator.Operator, kind opera
 		addLearnerTo = steps[0].(operator.AddLearner).ToStore
 		removePeerFrom = steps[3].(operator.RemovePeer).FromStore
 	default:
-		re.FailNow("unexpected operator steps")
+		re.FailNow("unexpected operator steps: " + op.String())
 	}
 	re.Equal(sourceID, removePeerFrom)
 	re.Equal(targetID, addLearnerTo)
@@ -95,7 +95,9 @@ func CheckTransferLearner(re *require.Assertions, op *operator.Operator, kind op
 	re.NotNil(op)
 	steps, _ := trimTransferLeaders(op)
 	re.Len(steps, 2)
-	re.Equal(targetID, steps[0].(operator.AddLearner).ToStore)
+	if targetID != 0 {
+		re.Equal(targetID, steps[0].(operator.AddLearner).ToStore)
+	}
 	re.Equal(sourceID, steps[1].(operator.RemovePeer).FromStore)
 	kind |= operator.OpRegion
 	re.Equal(kind, op.Kind()&kind)
@@ -124,7 +126,7 @@ func CheckTransferPeerWithLeaderTransfer(re *require.Assertions, op *operator.Op
 		addLearnerTo = steps[0].(operator.AddLearner).ToStore
 		removePeerFrom = steps[3].(operator.RemovePeer).FromStore
 	default:
-		re.FailNow("unexpected operator steps")
+		re.FailNow("unexpected operator steps: " + op.String())
 	}
 	re.NotZero(lastLeader)
 	re.NotEqual(sourceID, lastLeader)
@@ -177,7 +179,7 @@ func CheckSteps(re *require.Assertions, op *operator.Operator, steps []operator.
 		case operator.MergeRegion:
 			re.Equal(steps[i].(operator.MergeRegion).IsPassive, op.Step(i).(operator.MergeRegion).IsPassive)
 		default:
-			re.FailNow("unknown operator step type")
+			re.FailNow("unexpected operator steps: " + op.String())
 		}
 	}
 }

--- a/pkg/utils/operatorutil/operator_check.go
+++ b/pkg/utils/operatorutil/operator_check.go
@@ -95,9 +95,7 @@ func CheckTransferLearner(re *require.Assertions, op *operator.Operator, kind op
 	re.NotNil(op)
 	steps, _ := trimTransferLeaders(op)
 	re.Len(steps, 2)
-	if targetID != 0 {
-		re.Equal(targetID, steps[0].(operator.AddLearner).ToStore)
-	}
+	re.Equal(targetID, steps[0].(operator.AddLearner).ToStore)
 	re.Equal(sourceID, steps[1].(operator.RemovePeer).FromStore)
 	kind |= operator.OpRegion
 	re.Equal(kind, op.Kind()&kind)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8073

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

schedulePeerPr always be 1.0, which makes some test cannot reach transfer-leader branch

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
