### PR TITLE
coordinator: make patrolRegions's subtask concurrently

### DIFF
--- a/pkg/cache/priority_queue.go
+++ b/pkg/cache/priority_queue.go
@@ -16,19 +16,21 @@ package cache
 
 import (
 	"github.com/tikv/pd/pkg/btree"
+	"github.com/tikv/pd/pkg/utils/syncutil"
 )
 
 // defaultDegree default btree degree, the depth is h<log(degree)(capacity+1)/2
 const defaultDegree = 4
 
-// PriorityQueue queue has priority  and preempt
+// PriorityQueue is a queue that supports priorities and preemption, and is thread-safe.
 type PriorityQueue struct {
 	items    map[uint64]*Entry
 	btree    *btree.BTreeG[*Entry]
 	capacity int
+	syncutil.RWMutex
 }
 
-// NewPriorityQueue construct of priority queue
+// NewPriorityQueue constructs a new instance of a thread-safe priority queue.
 func NewPriorityQueue(capacity int) *PriorityQueue {
 	return &PriorityQueue{
 		items:    make(map[uint64]*Entry),
@@ -42,8 +44,10 @@ type PriorityQueueItem interface {
 	ID() uint64
 }
 
-// Put put value with priority into queue
+// Put inserts a value with a given priority into the queue.
 func (pq *PriorityQueue) Put(priority int, value PriorityQueueItem) bool {
+	pq.Lock()
+	defer pq.Unlock()
 	id := value.ID()
 	entry, ok := pq.items[id]
 	if !ok {
@@ -54,7 +58,9 @@ func (pq *PriorityQueue) Put(priority int, value PriorityQueueItem) bool {
 			if !found || !min.Less(entry) {
 				return false
 			}
+			pq.Unlock()
 			pq.Remove(min.Value.ID())
+			pq.Lock()
 		}
 	} else if entry.Priority != priority { // delete before update
 		pq.btree.Delete(entry)
@@ -66,29 +72,37 @@ func (pq *PriorityQueue) Put(priority int, value PriorityQueueItem) bool {
 	return true
 }
 
-// Get find entry by id from queue
+// Get retrieves an entry by ID from the queue.
 func (pq *PriorityQueue) Get(id uint64) *Entry {
+	pq.RLock()
+	defer pq.RUnlock()
 	return pq.items[id]
 }
 
-// Peek return the highest priority entry
+// Peek returns the highest priority entry without removing it.
 func (pq *PriorityQueue) Peek() *Entry {
+	pq.RLock()
+	defer pq.RUnlock()
 	if max, ok := pq.btree.Max(); ok {
 		return max
 	}
 	return nil
 }
 
-// Tail return the lowest priority entry
+// Tail returns the lowest priority entry without removing it.
 func (pq *PriorityQueue) Tail() *Entry {
+	pq.RLock()
+	defer pq.RUnlock()
 	if min, ok := pq.btree.Min(); ok {
 		return min
 	}
 	return nil
 }
 
-// Elems return all elements in queue
+// Elems returns all elements in the queue.
 func (pq *PriorityQueue) Elems() []*Entry {
+	pq.RLock()
+	defer pq.RUnlock()
 	rs := make([]*Entry, pq.Len())
 	count := 0
 	pq.btree.Descend(func(i *Entry) bool {
@@ -99,20 +113,23 @@ func (pq *PriorityQueue) Elems() []*Entry {
 	return rs
 }
 
-// Remove remove value from queue
+// Remove deletes an entry from the queue.
 func (pq *PriorityQueue) Remove(id uint64) {
+	pq.Lock()
+	defer pq.Unlock()
 	if v, ok := pq.items[id]; ok {
 		pq.btree.Delete(v)
 		delete(pq.items, id)
 	}
 }
 
-// Len return queue size
+// Len returns the number of elements in the queue.
 func (pq *PriorityQueue) Len() int {
+	// Lock is not necessary for calling Len() on pq.btree as it is assumed to be thread-safe.
 	return pq.btree.Len()
 }
 
-// Entry a pair of region and it's priority
+// Entry represents a pair of region and it's priority.
 type Entry struct {
 	Priority int
 	Value    PriorityQueueItem
@@ -120,7 +137,5 @@ type Entry struct {
 
 // Less return true if the entry has smaller priority
 func (r *Entry) Less(other *Entry) bool {
-	left := r.Priority
-	right := other.Priority
-	return left > right
+	return r.Priority > other.Priority
 }

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -398,6 +398,11 @@ func (o *PersistConfig) GetHotRegionCacheHitsThreshold() int {
 	return int(o.GetScheduleConfig().HotRegionCacheHitsThreshold)
 }
 
+// GetPatrolRegionConcurrency returns the worker count of the patrol.
+func (o *PersistConfig) GetPatrolRegionConcurrency() int {
+	return int(o.GetScheduleConfig().PatrolRegionConcurrency)
+}
+
 // GetMaxMovableHotPeerSize returns the max movable hot peer size.
 func (o *PersistConfig) GetMaxMovableHotPeerSize() int64 {
 	return o.GetScheduleConfig().MaxMovableHotPeerSize

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -63,6 +63,7 @@ const (
 	defaultRegionScoreFormulaVersion = "v2"
 	defaultLeaderSchedulePolicy      = "count"
 	defaultStoreLimitVersion         = "v1"
+	defaultPatrolRegionConcurrency   = 8
 	// DefaultSplitMergeInterval is the default value of config split merge interval.
 	DefaultSplitMergeInterval      = time.Hour
 	defaultSwitchWitnessInterval   = time.Hour
@@ -305,6 +306,9 @@ type ScheduleConfig struct {
 	// HaltScheduling is the option to halt the scheduling. Once it's on, PD will halt the scheduling,
 	// and any other scheduling configs will be ignored.
 	HaltScheduling bool `toml:"halt-scheduling" json:"halt-scheduling,string,omitempty"`
+
+	// PatrolRegionConcurrency  is the number of workers to patrol region.
+	PatrolRegionConcurrency uint64 `toml:"patrol-worker-count" json:"patrol-worker-count"`
 }
 
 // Clone returns a cloned scheduling configuration.
@@ -373,6 +377,9 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	}
 	if !meta.IsDefined("store-limit-version") {
 		configutil.AdjustString(&c.StoreLimitVersion, defaultStoreLimitVersion)
+	}
+	if !meta.IsDefined("patrol-worker-count") {
+		configutil.AdjustUint64(&c.PatrolRegionConcurrency, defaultPatrolRegionConcurrency)
 	}
 
 	if !meta.IsDefined("enable-joint-consensus") {

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -62,6 +62,7 @@ type SchedulerConfigProvider interface {
 	GetHotRegionCacheHitsThreshold() int
 	GetMaxMovableHotPeerSize() int64
 	IsTraceRegionFlow() bool
+	GetPatrolRegionConcurrency() int
 
 	GetTolerantSizeRatio() float64
 	GetLeaderSchedulePolicy() constant.SchedulePolicy
@@ -117,6 +118,7 @@ type SharedConfigProvider interface {
 	IsPlacementRulesCacheEnabled() bool
 	SetHaltScheduling(bool, string)
 	GetHotRegionCacheHitsThreshold() int
+	GetPatrolRegionConcurrency() int
 
 	// for test purpose
 	SetPlacementRuleEnabled(bool)

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -228,6 +228,11 @@ func (o *PersistOptions) SetMaxReplicas(replicas int) {
 	o.SetReplicationConfig(v)
 }
 
+// GetPatrolRegionConcurrency  returns the worker count of the patrol.
+func (o *PersistOptions) GetPatrolRegionConcurrency() int {
+	return int(o.GetScheduleConfig().PatrolRegionConcurrency)
+}
+
 var supportedTTLConfigs = []string{
 	sc.MaxSnapshotCountKey,
 	sc.MaxMergeRegionSizeKey,


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7706

### What is changed and how does it work?

before

<img width="634" alt="image" src="https://github.com/tikv/pd/assets/53859786/df030a37-03e6-43af-8e12-9a712f26f9c9">

after

<img width="730" alt="image" src="https://github.com/tikv/pd/assets/53859786/b6b5fe2c-cf93-4d28-95e7-2b54cfdead91">



<img width="1032" alt="image" src="https://github.com/tikv/pd/assets/53859786/204f5e42-4efa-4dae-9865-b9ab4323a98c">

### patrol regions
8 concurrent threads, reducing patrol area time by a factor of 8

before
10w regions
<img width="1370" alt="image" src="https://github.com/tikv/pd/assets/53859786/85f7ee56-02ed-46c3-bb2b-4413283bfd06">
after
20w regions
<img width="1332" alt="image" src="https://github.com/tikv/pd/assets/53859786/925d48f6-c678-4719-bf0b-5ae30cf56c8c">


<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
