### PR TITLE
tests/etcd: remove mod to make test stable

### DIFF
--- a/pkg/utils/etcdutil/testutil.go
+++ b/pkg/utils/etcdutil/testutil.go
@@ -51,7 +51,7 @@ func NewTestSingleConfig() *embed.Config {
 }
 
 func genRandName() string {
-	return "test_etcd_" + strconv.FormatInt(time.Now().UnixNano()%10000, 10)
+	return "test_etcd_" + strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
 // NewTestEtcdCluster is used to create a etcd cluster for the unit test purpose.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8091, Ref #7969

### What is changed and how does it work?

Because we create many etcd cluster concurrently when using `pd-ut` which makes etcd test unstable

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
