### PR TITLE
client/tso: improve the switching of TSO stream

### DIFF
--- a/client/tso_client.go
+++ b/client/tso_client.go
@@ -353,9 +353,9 @@ func (c *tsoClient) tryConnectToTSO(
 		url            string
 		cc             *grpc.ClientConn
 		updateAndClear = func(newURL string, connectionCtx *tsoConnectionContext) {
-			// Only store the connectionCtx if it does not exist before.
+			// Only store the `connectionCtx` if it does not exist before.
 			connectionCtxs.LoadOrStore(newURL, connectionCtx)
-			// Remove all other connection contexts.
+			// Remove all other `connectionCtx`s.
 			connectionCtxs.Range(func(url, cc any) bool {
 				if url.(string) != newURL {
 					cc.(*tsoConnectionContext).cancel()

--- a/client/tso_client.go
+++ b/client/tso_client.go
@@ -180,7 +180,7 @@ func (c *tsoClient) getTSORequest(ctx context.Context, dcLocation string) *tsoRe
 
 func (c *tsoClient) getTSODispatcher(dcLocation string) (*tsoDispatcher, bool) {
 	dispatcher, ok := c.tsoDispatcher.Load(dcLocation)
-	if !ok {
+	if !ok || dispatcher == nil {
 		return nil, false
 	}
 	return dispatcher.(*tsoDispatcher), true

--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -519,7 +519,6 @@ func (c *tsoClient) connectionCtxsUpdater(
 				// the periodic check needs to be turned off.
 				setNewUpdateTicker(&time.Ticker{})
 			} else {
-				// The status of TSO Follower Proxy does not change, and updateTSOConnectionCtxs is not triggered
 				continue
 			}
 		case <-updateTicker.C:

--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -122,8 +122,8 @@ func (c *tsoClient) updateTSODispatcher() {
 		}
 		if _, exist := c.GetTSOAllocators().Load(dcLocation); !exist {
 			log.Info("[tso] delete unused tso dispatcher", zap.String("dc-location", dcLocation))
-			dispatcher.(*tsoDispatcher).close()
 			c.tsoDispatcher.Delete(dcLocation)
+			dispatcher.(*tsoDispatcher).close()
 		}
 		return true
 	})
@@ -335,7 +335,7 @@ func (c *tsoClient) handleDispatcher(
 		tbc.clear()
 		c.wg.Done()
 	}()
-	// Daemon goroutine to update the connectionCtxs periodically and handle the TSO Follower Proxy switch event.
+	// Daemon goroutine to update the connectionCtxs periodically and handle the `connectionCtxs` update event.
 	go func() {
 		var updateTicker = &time.Ticker{}
 		setNewUpdateTicker := func(ticker *time.Ticker) {

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -246,6 +247,40 @@ func TestLeaderTransferAndMoveCluster(t *testing.T) {
 
 	close(quit)
 	wg.Wait()
+}
+
+func TestGetTSAfterTransferLeader(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 2)
+	re.NoError(err)
+	endpoints := runServer(re, cluster)
+	leader := cluster.WaitLeader()
+	re.NotEmpty(leader)
+	defer cluster.Destroy()
+
+	cli := setupCli(ctx, re, endpoints, pd.WithCustomTimeoutOption(10*time.Second))
+	defer cli.Close()
+
+	var leaderSwitched atomic.Bool
+	cli.GetServiceDiscovery().AddServingURLSwitchedCallback(func() {
+		leaderSwitched.Store(true)
+	})
+	err = cluster.GetServer(leader).ResignLeader()
+	re.NoError(err)
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(leader, newLeader)
+	leader = cluster.WaitLeader()
+	re.NotEmpty(leader)
+	err = cli.GetServiceDiscovery().CheckMemberChanged()
+	re.NoError(err)
+
+	testutil.Eventually(re, leaderSwitched.Load)
+	// The leader stream must be updated after the leader switch is sensed by the client.
+	_, _, err = cli.GetTS(context.TODO())
+	re.NoError(err)
 }
 
 func TestTSOAllocatorLeader(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #7997, ref #8047.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Previously, without enabling the TSO Follower Proxy, we only passively update its stream when a TSO request fails.
This means that we cannot automatically and gradually complete the TSO stream update after a service switch.
This PR strengthens this logic, which can improve the success rate of TSO requests during service switching.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
