### PR TITLE
tests/operators: pause all checkers to make test stable

### DIFF
--- a/tests/server/api/operator_test.go
+++ b/tests/server/api/operator_test.go
@@ -70,7 +70,7 @@ func (suite *operatorTestSuite) TestAddRemovePeer() {
 
 func (suite *operatorTestSuite) checkAddRemovePeer(cluster *tests.TestCluster) {
 	re := suite.Require()
-	pauseRuleChecker(re, cluster)
+	pauseAllCheckers(re, cluster)
 	stores := []*metapb.Store{
 		{
 			Id:            1,
@@ -205,7 +205,7 @@ func (suite *operatorTestSuite) checkMergeRegionOperator(cluster *tests.TestClus
 		tests.MustPutStore(re, cluster, store)
 	}
 
-	pauseRuleChecker(re, cluster)
+	pauseAllCheckers(re, cluster)
 	r1 := core.NewTestRegionInfo(10, 1, []byte(""), []byte("b"), core.SetWrittenBytes(1000), core.SetReadBytes(1000), core.SetRegionConfVer(1), core.SetRegionVersion(1))
 	tests.MustPutRegionInfo(re, cluster, r1)
 	r2 := core.NewTestRegionInfo(20, 1, []byte("b"), []byte("c"), core.SetWrittenBytes(2000), core.SetReadBytes(0), core.SetRegionConfVer(2), core.SetRegionVersion(3))
@@ -241,7 +241,7 @@ func (suite *operatorTestSuite) TestTransferRegionWithPlacementRule() {
 
 func (suite *operatorTestSuite) checkTransferRegionWithPlacementRule(cluster *tests.TestCluster) {
 	re := suite.Require()
-	pauseRuleChecker(re, cluster)
+	pauseAllCheckers(re, cluster)
 	stores := []*metapb.Store{
 		{
 			Id:            1,
@@ -521,7 +521,7 @@ func (suite *operatorTestSuite) TestGetOperatorsAsObject() {
 
 func (suite *operatorTestSuite) checkGetOperatorsAsObject(cluster *tests.TestCluster) {
 	re := suite.Require()
-	pauseRuleChecker(re, cluster)
+	pauseAllCheckers(re, cluster)
 	stores := []*metapb.Store{
 		{
 			Id:            1,
@@ -642,7 +642,7 @@ func (suite *operatorTestSuite) checkRemoveOperators(cluster *tests.TestCluster)
 		tests.MustPutStore(re, cluster, store)
 	}
 
-	pauseRuleChecker(re, cluster)
+	pauseAllCheckers(re, cluster)
 	r1 := core.NewTestRegionInfo(10, 1, []byte(""), []byte("b"), core.SetWrittenBytes(1000), core.SetReadBytes(1000), core.SetRegionConfVer(1), core.SetRegionVersion(1))
 	tests.MustPutRegionInfo(re, cluster, r1)
 	r2 := core.NewTestRegionInfo(20, 1, []byte("b"), []byte("c"), core.SetWrittenBytes(2000), core.SetReadBytes(0), core.SetRegionConfVer(2), core.SetRegionVersion(3))


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

### What is changed and how does it work?


https://github.com/tikv/pd/blob/86e3033fc67c3e33423f97c9b3df0a6dfa15fea7/tests/server/api/operator_test.go#L654-L657

For example, when operators are to be tested in `TestRemoveOperators`  will meet `replace the old operators` which is triggered by `labeler-split-region` and make test failed in 

https://github.com/tikv/pd/blob/86e3033fc67c3e33423f97c9b3df0a6dfa15fea7/tests/server/api/operator_test.go#L658-L659

```
[2024/05/11 15:58:38.823 +08:00] [INFO] [operator_controller.go:786] ["send schedule command"] [region-id=20] [step="merge region 10 into region 20"] [source=create]
[2024/05/11 15:58:38.829 +08:00] [INFO] [operator_controller.go:510] ["add operator"] [region-id=30] [operator="\"admin-add-peer {add peer: store [4]} (kind:admin,region, region:30(2, 3), createAt:2024-05-11 15:58:38.828966736 +0800 CST m=+20.568753104, startAt:0001-01-01 00:00:00 +0000 UTC, currentStep:0, size:1, steps:[0:{add learner peer 5 on store 4}, 1:{promote learner peer 5 on store 4 to voter}], timeout:[11m0s])\""] [additional-info=]
[2024/05/11 15:58:38.830 +08:00] [INFO] [operator_controller.go:705] ["replace old operator"] [region-id=30] [takes=129.326768ms] [operator="\"labeler-split-region {split: region 30 use policy USEKEY and keys [7200000000000000FB 7200000100000000FB 7800000000000000FB 7800000100000000FB]} (kind:split, region:30(2, 3), createAt:2024-05-11 15:58:38.699935018 +0800 CST m=+20.439721392, startAt:2024-05-11 15:58:38.701135093 +0800 CST m=+20.440921467, currentStep:0, size:1, steps:[0:{split region with policy USEKEY}], timeout:[1m0s])\""] [additional-info="{\"region-end-key\":\"\",\"region-start-key\":\"63\"}"]
[2024/05/11 15:58:38.830 +08:00] [INFO] [operator_controller.go:510] ["add operator"] [region-id=30] [operator="\"labeler-split-region {split: region 30 use policy USEKEY and keys [7200000000000000FB 7200000100000000FB 7800000000000000FB 7800000100000000FB]} (kind:split, region:30(2, 3), createAt:2024-05-11 15:58:38.830271352 +0800 CST m=+20.570057726, startAt:0001-01-01 00:00:00 +0000 UTC, currentStep:0, size:1, steps:[0:{split region with policy USEKEY}], timeout:[1m0s])\""] [additional-info="{\"region-end-key\":\"\",\"region-start-key\":\"63\"}"]
[2024/05/11 15:58:38.831 +08:00] [INFO] [operator_controller.go:786] ["send schedule command"] [region-id=30] [step="add learner peer 5 on store 4"] [source=create]
[2024/05/11 15:58:38.832 +08:00] [INFO] [operator_controller.go:705] ["replace old operator"] [region-id=30] [takes=1.313443ms] [operator="\"admin-add-peer {add peer: store [4]} (kind:admin,region, region:30(2, 3), createAt:2024-05-11 15:58:38.828966736 +0800 CST m=+20.568753104, startAt:2024-05-11 15:58:38.831088504 +0800 CST m=+20.570874872, currentStep:0, size:1, steps:[0:{add learner peer 5 on store 4}, 1:{promote learner peer 5 on store 4 to voter}], timeout:[11m0s])\""] [additional-info=]
```

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
