### PR TITLE
pkg/ratelimit: make TestConcurrencyLimiterAcquire stable

### DIFF
--- a/pkg/ratelimit/concurrency_limiter_test.go
+++ b/pkg/ratelimit/concurrency_limiter_test.go
@@ -122,6 +122,6 @@ func TestConcurrencyLimiterAcquire(t *testing.T) {
 	}
 	wg.Wait()
 	// We should have 20 tasks running concurrently, so it should take at least 50ms to complete
-	require.Greater(t, time.Since(start).Milliseconds(), int64(50))
+	require.GreaterOrEqual(t, time.Since(start).Milliseconds(), int64(50))
 	require.Equal(t, int64(100), sum)
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

### What is changed and how does it work?

```bash
[FAIL]  pkg/ratelimit TestConcurrencyLimiterAcquire
err=exit status 1
--- FAIL: TestConcurrencyLimiterAcquire (0.05s)
    concurrency_limiter_test.go:125:
        	Error Trace:	/Users/pingcap/CS/PingCAP/pd/pkg/ratelimit/concurrency_limiter_test.go:125
        	Error:      	"50" is not greater than "50"
        	Test:       	TestConcurrencyLimiterAcquire
FAIL
^Cmake: *** [ut] Interrupt: 2
```

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
