### PR TITLE
pkg: improve region statistics observe

### DIFF
--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -269,3 +269,43 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 		re.Equal(res, labelLevelStats.labelCounter[i])
 	}
 }
+
+func BenchmarkObserve(b *testing.B) {
+	// Setup
+	store := storage.NewStorageWithMemoryBackend()
+	manager := placement.NewRuleManager(context.Background(), store, nil, nil)
+	manager.Initialize(3, []string{"zone", "rack", "host"}, "")
+	opt := mockconfig.NewTestOptions()
+	opt.SetPlacementRuleEnabled(false)
+	peers := []*metapb.Peer{
+		{Id: 4, StoreId: 1},
+		{Id: 5, StoreId: 2},
+		{Id: 6, StoreId: 3},
+	}
+
+	metaStores := []*metapb.Store{
+		{Id: 1, Address: "mock://tikv-1"},
+		{Id: 2, Address: "mock://tikv-2"},
+		{Id: 3, Address: "mock://tikv-3"},
+	}
+
+	stores := make([]*core.StoreInfo, 0, len(metaStores))
+	for _, m := range metaStores {
+		s := core.NewStoreInfo(m)
+		stores = append(stores, s)
+	}
+
+	regionNum := uint64(1000000)
+	regions := make([]*core.RegionInfo, 0, regionNum)
+	for i := uint64(1); i <= regionNum; i++ {
+		r := &metapb.Region{Id: i, Peers: peers, StartKey: []byte{byte(i)}, EndKey: []byte{byte(i + 1)}}
+		regions = append(regions, core.NewRegionInfo(r, peers[0]))
+	}
+	regionStats := NewRegionStatistics(nil, opt, manager)
+
+	b.ResetTimer()
+	// Run the Observe function b.N times
+	for i := 0; i < b.N; i++ {
+		regionStats.Observe(regions[i%int(regionNum)], stores)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7897.

### What is changed and how does it work?


<img width="1747" alt="Screenshot 2024-05-16 at 17 09 35" src="https://github.com/tikv/pd/assets/35896542/3f6e8e51-527e-49fc-8f38-27d1a77ab5b6">

```
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/tikv/pd/pkg/statistics
cpu: Intel(R) Xeon(R) Gold 6240 CPU @ 2.60GHz
           │   old.txt   │              new.txt               │
           │   sec/op    │   sec/op     vs base               │
Observe-72   2.134µ ± 4%   2.012µ ± 7%  -5.69% (p=0.015 n=10)

           │  old.txt   │               new.txt               │
           │    B/op    │    B/op      vs base                │
Observe-72   485.0 ± 1%   325.5 ± 49%  -32.89% (p=0.003 n=10)

           │  old.txt   │              new.txt               │
           │ allocs/op  │ allocs/op   vs base                │
Observe-72   5.000 ± 0%   3.000 ± 0%  -40.00% (p=0.000 n=10)
```

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
