### PR TITLE
core/region: use a separate tree to check for overlaps in the subtree

### DIFF
--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -778,27 +778,24 @@ func BenchmarkRandomSetRegionWithGetRegionSizeByRangeParallel(b *testing.B) {
 	)
 }
 
-const keyLength = 100
-
-func randomBytes(n int) []byte {
-	bytes := make([]byte, n)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		panic(err)
-	}
-	return bytes
-}
+const (
+	peerNum   = 3
+	storeNum  = 10
+	keyLength = 100
+)
 
 func newRegionInfoIDRandom(idAllocator id.Allocator) *RegionInfo {
 	var (
 		peers  []*metapb.Peer
 		leader *metapb.Peer
 	)
-	storeNum := 10
-	for i := 0; i < 3; i++ {
+	// Randomly select a peer as the leader.
+	leaderIdx := mrand.Intn(peerNum)
+	for i := 0; i < peerNum; i++ {
 		id, _ := idAllocator.Alloc()
-		p := &metapb.Peer{Id: id, StoreId: uint64(i%storeNum + 1)}
-		if i == 0 {
+		// Randomly distribute the peers to different stores.
+		p := &metapb.Peer{Id: id, StoreId: uint64(mrand.Intn(storeNum) + 1)}
+		if i == leaderIdx {
 			leader = p
 		}
 		peers = append(peers, p)
@@ -817,6 +814,15 @@ func newRegionInfoIDRandom(idAllocator id.Allocator) *RegionInfo {
 	)
 }
 
+func randomBytes(n int) []byte {
+	bytes := make([]byte, n)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
+}
+
 func BenchmarkAddRegion(b *testing.B) {
 	regions := NewRegionsInfo()
 	idAllocator := mockid.NewIDAllocator()
@@ -829,6 +835,54 @@ func BenchmarkAddRegion(b *testing.B) {
 		origin, overlaps, rangeChanged := regions.SetRegion(items[i])
 		regions.UpdateSubTree(items[i], origin, overlaps, rangeChanged)
 	}
+}
+
+func BenchmarkUpdateSubTreeOrderInsensitive(b *testing.B) {
+	idAllocator := mockid.NewIDAllocator()
+	for _, size := range []int{10, 100, 1000, 10000, 100000, 1000000, 10000000} {
+		regions := NewRegionsInfo()
+		items := generateRegionItems(idAllocator, size)
+		// Update the subtrees from an empty `*RegionsInfo`.
+		b.Run(fmt.Sprintf("from empty with size %d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for idx := range items {
+					regions.UpdateSubTreeOrderInsensitive(items[idx])
+				}
+			}
+		})
+
+		// Update the subtrees from a non-empty `*RegionsInfo` with the same regions,
+		// which means the regions are completely non-overlapped.
+		b.Run(fmt.Sprintf("from non-overlapped regions with size %d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for idx := range items {
+					regions.UpdateSubTreeOrderInsensitive(items[idx])
+				}
+			}
+		})
+
+		// Update the subtrees from a non-empty `*RegionsInfo` with different regions,
+		// which means the regions are most likely overlapped.
+		b.Run(fmt.Sprintf("from overlapped regions with size %d", size), func(b *testing.B) {
+			items = generateRegionItems(idAllocator, size)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for idx := range items {
+					regions.UpdateSubTreeOrderInsensitive(items[idx])
+				}
+			}
+		})
+	}
+}
+
+func generateRegionItems(idAllocator *mockid.IDAllocator, size int) []*RegionInfo {
+	items := make([]*RegionInfo, size)
+	for i := 0; i < size; i++ {
+		items[i] = newRegionInfoIDRandom(idAllocator)
+	}
+	return items
 }
 
 func BenchmarkRegionFromHeartbeat(b *testing.B) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7897.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Previously, removing overlapped regions in subtrees required finding overlaps for each subtree individually.
This PR introduces a separate tree specifically for checking overlaps in the subtrees, thereby reducing lookup times and improving performance.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```shell
> go test -timeout=30m -count=3 -benchmem -bench=BenchmarkUpdateSubTreeOrderInsensitive . > new.txt
> git checkout master
> go test -timeout=30m -count=3 -benchmem -bench=BenchmarkUpdateSubTreeOrderInsensitive . > old.txt
> benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/tikv/pd/pkg/core
                                                                               │   old.txt    │                new.txt                │
                                                                               │    sec/op    │    sec/op     vs base                 │
UpdateSubTreeOrderInsensitive/from_empty_with_size_10-8                          8.534µ ± ∞ ¹   9.837µ ± ∞ ¹        ~ (p=0.700 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10-8         8.627µ ± ∞ ¹   9.821µ ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10-8             21.70µ ± ∞ ¹   12.28µ ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_100-8                         294.0µ ± ∞ ¹   167.3µ ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_100-8        294.7µ ± ∞ ¹   166.8µ ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_100-8            306.5µ ± ∞ ¹   182.1µ ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_1000-8                        3.489m ± ∞ ¹   1.907m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_1000-8       3.509m ± ∞ ¹   1.912m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_1000-8           3.755m ± ∞ ¹   2.049m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_10000-8                       38.43m ± ∞ ¹   20.81m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10000-8      38.22m ± ∞ ¹   20.86m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10000-8          38.34m ± ∞ ¹   21.54m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_100000-8                      376.4m ± ∞ ¹   212.5m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_100000-8     377.7m ± ∞ ¹   212.7m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_100000-8         391.3m ± ∞ ¹   220.4m ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_1000000-8                      3.836 ± ∞ ¹    2.140 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_1000000-8     3.847 ± ∞ ¹    2.120 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_1000000-8         3.918 ± ∞ ¹    2.192 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_10000000-8                     45.93 ± ∞ ¹    27.08 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10000000-8    47.92 ± ∞ ¹    27.48 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10000000-8        56.14 ± ∞ ¹    35.17 ± ∞ ¹        ~ (p=0.100 n=3) ²
geomean                                                                          32.11m         19.39m        -39.62%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                                               │    old.txt    │                new.txt                 │
                                                                               │     B/op      │     B/op       vs base                 │
UpdateSubTreeOrderInsensitive/from_empty_with_size_10-8                          1.031Ki ± ∞ ¹   2.266Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10-8         1.031Ki ± ∞ ¹   2.266Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10-8             2.680Ki ± ∞ ¹   2.242Ki ± ∞ ¹        ~ (p=0.400 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_100-8                         56.54Ki ± ∞ ¹   39.53Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_100-8        56.53Ki ± ∞ ¹   39.53Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_100-8            51.51Ki ± ∞ ¹   46.38Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_1000-8                        597.1Ki ± ∞ ¹   483.0Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_1000-8       597.1Ki ± ∞ ¹   483.0Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_1000-8           601.8Ki ± ∞ ¹   488.8Ki ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_10000-8                       6.197Mi ± ∞ ¹   4.944Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10000-8      6.197Mi ± ∞ ¹   4.944Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10000-8          6.061Mi ± ∞ ¹   4.964Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_100000-8                      59.93Mi ± ∞ ¹   49.54Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_100000-8     59.93Mi ± ∞ ¹   49.54Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_100000-8         59.91Mi ± ∞ ¹   49.41Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_1000000-8                     601.9Mi ± ∞ ¹   496.3Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_1000000-8    601.9Mi ± ∞ ¹   496.3Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_1000000-8        601.7Mi ± ∞ ¹   495.8Mi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_10000000-8                    5.878Gi ± ∞ ¹   4.841Gi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10000000-8   5.878Gi ± ∞ ¹   4.841Gi ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10000000-8       5.878Gi ± ∞ ¹   4.842Gi ± ∞ ¹        ~ (p=0.100 n=3) ²
geomean                                                                          4.790Mi         4.264Mi        -10.98%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                                               │   old.txt    │                new.txt                │
                                                                               │  allocs/op   │  allocs/op    vs base                 │
UpdateSubTreeOrderInsensitive/from_empty_with_size_10-8                           71.00 ± ∞ ¹   104.00 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10-8          71.00 ± ∞ ¹   104.00 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10-8              207.0 ± ∞ ¹    116.0 ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_100-8                         2.559k ± ∞ ¹   1.334k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_100-8        2.559k ± ∞ ¹   1.334k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_100-8            2.475k ± ∞ ¹   1.390k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_1000-8                        26.92k ± ∞ ¹   14.27k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_1000-8       26.92k ± ∞ ¹   14.27k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_1000-8           27.46k ± ∞ ¹   14.33k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_10000-8                       284.7k ± ∞ ¹   144.5k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10000-8      284.7k ± ∞ ¹   144.5k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10000-8          280.4k ± ∞ ¹   145.0k ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_100000-8                      2.777M ± ∞ ¹   1.448M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_100000-8     2.777M ± ∞ ¹   1.448M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_100000-8         2.781M ± ∞ ¹   1.449M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_1000000-8                     27.87M ± ∞ ¹   14.50M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_1000000-8    27.87M ± ∞ ¹   14.50M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_1000000-8        27.88M ± ∞ ¹   14.50M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_empty_with_size_10000000-8                    278.9M ± ∞ ¹   145.0M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_non-overlapped_regions_with_size_10000000-8   278.9M ± ∞ ¹   145.0M ± ∞ ¹        ~ (p=0.100 n=3) ²
UpdateSubTreeOrderInsensitive/from_overlapped_regions_with_size_10000000-8       278.9M ± ∞ ¹   145.0M ± ∞ ¹        ~ (p=0.100 n=3) ²
geomean                                                                          237.5k         137.3k        -42.19%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
