### PR TITLE
tools/ut: add alloc server for `pd-ut`

### DIFF
--- a/pkg/utils/tempurl/tempurl.go
+++ b/pkg/utils/tempurl/tempurl.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/pingcap/log"
@@ -32,7 +33,7 @@ var (
 )
 
 // reference: /pd/tools/pd-ut/alloc/server.go
-const utAllocURL = "http://0.0.0.0:20180/alloc"
+const AllocURLFromUT = "allocURLFromUT"
 
 // Alloc allocates a local URL for testing.
 func Alloc() string {
@@ -73,7 +74,12 @@ func tryAllocTestURL() string {
 }
 
 func getFromUT() string {
-	resp, err := http.Get(utAllocURL)
+	addr := os.Getenv(AllocURLFromUT)
+	if addr == "" {
+		return ""
+	}
+
+	resp, err := http.Get(addr)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return ""
 	}

--- a/pkg/utils/tempurl/tempurl.go
+++ b/pkg/utils/tempurl/tempurl.go
@@ -79,11 +79,14 @@ func getFromUT() string {
 		return ""
 	}
 
-	resp, err := http.Get(addr)
+	req, err := http.NewRequest(http.MethodGet, addr, nil)
+	if err != nil {
+		return ""
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return ""
 	}
-
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -289,7 +289,7 @@ func TestMoveLeader(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cluster, err := tests.NewTestCluster(ctx, 3)
+	cluster, err := tests.NewTestCluster(ctx, 5)
 	defer cluster.Destroy()
 	re.NoError(err)
 
@@ -298,7 +298,7 @@ func TestMoveLeader(t *testing.T) {
 	cluster.WaitLeader()
 
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(5)
 	for _, s := range cluster.GetServers() {
 		go func(s *tests.TestServer) {
 			defer wg.Done()

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -289,7 +289,7 @@ func TestMoveLeader(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cluster, err := tests.NewTestCluster(ctx, 5)
+	cluster, err := tests.NewTestCluster(ctx, 3)
 	defer cluster.Destroy()
 	re.NoError(err)
 
@@ -298,7 +298,7 @@ func TestMoveLeader(t *testing.T) {
 	cluster.WaitLeader()
 
 	var wg sync.WaitGroup
-	wg.Add(5)
+	wg.Add(3)
 	for _, s := range cluster.GetServers() {
 		go func(s *tests.TestServer) {
 			defer wg.Done()

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -9,6 +9,7 @@ replace (
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-semver v0.3.1
 	github.com/docker/go-units v0.4.0
@@ -64,7 +65,6 @@ require (
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/breeswish/gin-jwt/v2 v2.6.4-jwt-patch // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
-	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 // indirect
 	github.com/cenkalti/backoff/v4 v4.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect

--- a/tools/pd-ut/alloc/check_env_dummy.go
+++ b/tools/pd-ut/alloc/check_env_dummy.go
@@ -1,0 +1,21 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !linux
+// +build !linux
+
+package alloc
+
+func environmentCheck(_ string) bool {
+	return true
+}

--- a/tools/pd-ut/alloc/check_env_linux.go
+++ b/tools/pd-ut/alloc/check_env_linux.go
@@ -1,0 +1,42 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build linux
+// +build linux
+
+package alloc
+
+import (
+	"github.com/cakturk/go-netstat/netstat"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+)
+
+func environmentCheck(addr string) bool {
+	valid, err := checkAddr(addr[len("http://"):])
+	if err != nil {
+		log.Error("check port status failed", zap.Error(err))
+		return false
+	}
+	return valid
+}
+
+func checkAddr(addr string) (bool, error) {
+	tabs, err := netstat.TCPSocks(func(s *netstat.SockTabEntry) bool {
+		return s.RemoteAddr.String() == addr || s.LocalAddr.String() == addr
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(tabs) < 1, nil
+}

--- a/tools/pd-ut/alloc/server.go
+++ b/tools/pd-ut/alloc/server.go
@@ -16,18 +16,26 @@ package alloc
 
 import (
 	"errors"
+	"flag"
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pingcap/log"
-	flag "github.com/spf13/pflag"
+	"github.com/tikv/pd/pkg/utils/tempurl"
 	"go.uber.org/zap"
 )
 
 var statusAddress = flag.String("status-addr", "0.0.0.0:20180", "status address")
 
 func RunHTTPServer() *http.Server {
+	err := os.Setenv(tempurl.AllocURLFromUT, fmt.Sprintf("http://%s/alloc", *statusAddress))
+	if err != nil {
+		fmt.Println(err)
+	}
+
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
 	engine.Use(gin.Recovery())

--- a/tools/pd-ut/alloc/server.go
+++ b/tools/pd-ut/alloc/server.go
@@ -1,0 +1,48 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alloc
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap/log"
+	flag "github.com/spf13/pflag"
+	"go.uber.org/zap"
+)
+
+var statusAddress = flag.String("status-addr", "0.0.0.0:20180", "status address")
+
+func RunHTTPServer() *http.Server {
+	gin.SetMode(gin.ReleaseMode)
+	engine := gin.New()
+	engine.Use(gin.Recovery())
+
+	engine.GET("alloc", func(c *gin.Context) {
+		addr := Alloc()
+		c.String(http.StatusOK, addr)
+	})
+
+	srv := &http.Server{Addr: *statusAddress, Handler: engine.Handler(), ReadHeaderTimeout: 3 * time.Second}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal("server listen error", zap.Error(err))
+		}
+	}()
+
+	return srv
+}

--- a/tools/pd-ut/alloc/tempurl.go
+++ b/tools/pd-ut/alloc/tempurl.go
@@ -1,4 +1,4 @@
-// Copyright 2018 TiKV Project Authors.
+// Copyright 2024 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,47 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tempurl
+package alloc
 
 import (
 	"fmt"
-	"io"
 	"net"
-	"net/http"
+	"sync"
 	"time"
 
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
-	"github.com/tikv/pd/pkg/utils/syncutil"
 )
 
 var (
-	testAddrMutex syncutil.Mutex
+	testAddrMutex sync.Mutex
 	testAddrMap   = make(map[string]struct{})
 )
 
-// reference: /pd/tools/pd-ut/alloc/server.go
-const utAllocURL = "http://0.0.0.0:20180/alloc"
-
 // Alloc allocates a local URL for testing.
 func Alloc() string {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 50; i++ {
 		if u := tryAllocTestURL(); u != "" {
 			return u
 		}
-		time.Sleep(time.Second)
+		time.Sleep(200 * time.Millisecond)
 	}
 	log.Fatal("failed to alloc test URL")
 	return ""
 }
 
 func tryAllocTestURL() string {
-	if url := getFromUT(); url != "" {
-		return url
-	}
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
-		log.Fatal("listen failed", errs.ZapError(err))
+		return ""
 	}
 	addr := fmt.Sprintf("http://%s", l.Addr())
 	err = l.Close()
@@ -70,19 +62,4 @@ func tryAllocTestURL() string {
 	}
 	testAddrMap[addr] = struct{}{}
 	return addr
-}
-
-func getFromUT() string {
-	resp, err := http.Get(utAllocURL)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return ""
-	}
-
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return ""
-	}
-	url := string(body)
-	return url
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

### What is changed and how does it work?

When using larger concurrency for `pd-ut`, there are problems with `address already in use`

```bash
[PD:etcd:ErrStartEtcd]listen tcp [127.0.0.1:37561](http://127.0.0.1:37561/): bind: address already in use: listen tcp [127.0.0.1:37561](http://127.0.0.1:37561/): bind: address already in use
```

because there is a `URL alloc` for init etcd cluster config that assigns a local port number.

https://github.com/tikv/pd/blob/8e844d8483655ca3cd902220c372621c6c14cb43/pkg/utils/tempurl/tempurl.go#L32-L42

After changing to pd-ut, our tests run concurrently and are unaware of the URL used by the other tests, so there may be a conflict if there are many concurrent tests.

You can check by script below

```bash
for i in {1..200}
do
netstat -n | awk '/^tcp/ {++S[$NF]} END {for(a in S) print a, S[a]}'
sleep 1
done
```

```output
...
ESTABLISHED 205
TIME_WAIT 5905
ESTABLISHED 205
TIME_WAIT 5922
ESTABLISHED 205
TIME_WAIT 5929
...
```
So we can support a alloc server for `pd-ut` to ensure the URL is unique.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
