### PR TITLE
core/region: optimize the logic of randomly selecting regions within a single range

### DIFF
--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -668,18 +668,33 @@ func BenchmarkRandomRegion(b *testing.B) {
 			}
 		})
 		ranges := []KeyRange{
-			NewKeyRange(fmt.Sprintf("%20d", 0), fmt.Sprintf("%20d", size/4)),
-			NewKeyRange(fmt.Sprintf("%20d", size/4), fmt.Sprintf("%20d", size/2)),
-			NewKeyRange(fmt.Sprintf("%20d", size/2), fmt.Sprintf("%20d", size*3/4)),
-			NewKeyRange(fmt.Sprintf("%20d", size*3/4), fmt.Sprintf("%20d", size)),
+			NewKeyRange(fmt.Sprintf("%20d", size/4), fmt.Sprintf("%20d", size*3/4)),
 		}
-		b.Run(fmt.Sprintf("random region given ranges with size %d", size), func(b *testing.B) {
+		b.Run(fmt.Sprintf("random region single range with size %d", size), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				regions.randLeaderRegion(1, ranges)
 			}
 		})
-		b.Run(fmt.Sprintf("random regions given ranges with size %d", size), func(b *testing.B) {
+		b.Run(fmt.Sprintf("random regions single range with size %d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				regions.RandLeaderRegions(1, ranges)
+			}
+		})
+		ranges = []KeyRange{
+			NewKeyRange(fmt.Sprintf("%20d", 0), fmt.Sprintf("%20d", size/4)),
+			NewKeyRange(fmt.Sprintf("%20d", size/4), fmt.Sprintf("%20d", size/2)),
+			NewKeyRange(fmt.Sprintf("%20d", size/2), fmt.Sprintf("%20d", size*3/4)),
+			NewKeyRange(fmt.Sprintf("%20d", size*3/4), fmt.Sprintf("%20d", size)),
+		}
+		b.Run(fmt.Sprintf("random region multiple ranges with size %d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				regions.randLeaderRegion(1, ranges)
+			}
+		})
+		b.Run(fmt.Sprintf("random regions multiple ranges with size %d", size), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				regions.RandLeaderRegions(1, ranges)

--- a/pkg/core/region_tree.go
+++ b/pkg/core/region_tree.go
@@ -339,24 +339,32 @@ func (t *regionTree) RandomRegions(n int, ranges []KeyRange) []*RegionInfo {
 	}
 	// Pre-allocate the variables to reduce the temporary memory allocations.
 	var (
-		startKey, endKey                []byte
-		startIndex, endIndex, randIndex int
-		startItem                       *regionItem
-		pivotItem                       = &regionItem{&RegionInfo{meta: &metapb.Region{}}}
-		region                          *RegionInfo
-		regions                         = make([]*RegionInfo, 0, n)
-		rangeLen, curLen                = len(ranges), len(regions)
+		startKey, endKey []byte
+		// By default, we set the `startIndex` and `endIndex` to the whole tree range.
+		startIndex, endIndex = 0, treeLen
+		randIndex            int
+		startItem            *regionItem
+		pivotItem            = &regionItem{&RegionInfo{meta: &metapb.Region{}}}
+		region               *RegionInfo
+		regions              = make([]*RegionInfo, 0, n)
+		rangeLen, curLen     = len(ranges), len(regions)
 		// setStartEndIndices is a helper function to set `startIndex` and `endIndex`
-		// according to the `startKey` and `endKey`.
+		// according to the `startKey` and `endKey` and check if the range is invalid
+		// to skip the iteration.
 		// TODO: maybe we could cache the `startIndex` and `endIndex` for each range.
-		setStartEndIndices = func() {
-			pivotItem.meta.StartKey = startKey
-			startItem, startIndex = t.tree.GetWithIndex(pivotItem)
-			if len(endKey) != 0 {
+		setAndCheckStartEndIndices = func() bool {
+			startKeyLen, endKeyLen := len(startKey), len(endKey)
+			if startKeyLen == 0 && endKeyLen == 0 {
+				startIndex, endIndex = 0, treeLen
+				return false
+			}
+			if startKeyLen > 0 {
+				pivotItem.meta.StartKey = startKey
+				startItem, startIndex = t.tree.GetWithIndex(pivotItem)
+			}
+			if endKeyLen > 0 {
 				pivotItem.meta.StartKey = endKey
 				_, endIndex = t.tree.GetWithIndex(pivotItem)
-			} else {
-				endIndex = treeLen
 			}
 			// Consider that the item in the tree may not be continuous,
 			// we need to check if the previous item contains the key.
@@ -366,13 +374,27 @@ func (t *regionTree) RandomRegions(n int, ranges []KeyRange) []*RegionInfo {
 					startIndex--
 				}
 			}
+			// Check whether the `startIndex` and `endIndex` are valid.
+			if endIndex <= startIndex {
+				if endKeyLen > 0 && bytes.Compare(startKey, endKey) > 0 {
+					log.Error("wrong range keys",
+						logutil.ZapRedactString("start-key", string(HexRegionKey(startKey))),
+						logutil.ZapRedactString("end-key", string(HexRegionKey(endKey))),
+						errs.ZapError(errs.ErrWrongRangeKeys))
+				}
+				return true
+			}
+			return false
 		}
 	)
-	// If no ranges specified, select randomly from the whole tree.
-	// This is a fast path to reduce the unnecessary iterations.
-	if rangeLen == 0 {
-		startKey, endKey = []byte(""), []byte("")
-		setStartEndIndices()
+	// This is a fast path to reduce the unnecessary iterations when we only have one range.
+	if rangeLen <= 1 {
+		if rangeLen == 1 {
+			startKey, endKey = ranges[0].StartKey, ranges[0].EndKey
+			if setAndCheckStartEndIndices() {
+				return regions
+			}
+		}
 		for curLen < n {
 			randIndex = rand.Intn(endIndex-startIndex) + startIndex
 			region = t.tree.GetAt(randIndex).RegionInfo
@@ -393,14 +415,7 @@ func (t *regionTree) RandomRegions(n int, ranges []KeyRange) []*RegionInfo {
 		// Shuffle the ranges to increase the randomness.
 		for _, i := range rand.Perm(rangeLen) {
 			startKey, endKey = ranges[i].StartKey, ranges[i].EndKey
-			setStartEndIndices()
-			if endIndex <= startIndex {
-				if len(endKey) > 0 && bytes.Compare(startKey, endKey) > 0 {
-					log.Error("wrong range keys",
-						logutil.ZapRedactString("start-key", string(HexRegionKey(startKey))),
-						logutil.ZapRedactString("end-key", string(HexRegionKey(endKey))),
-						errs.ZapError(errs.ErrWrongRangeKeys))
-				}
+			if setAndCheckStartEndIndices() {
 				continue
 			}
 

--- a/pkg/core/region_tree.go
+++ b/pkg/core/region_tree.go
@@ -352,7 +352,7 @@ func (t *regionTree) RandomRegions(n int, ranges []KeyRange) []*RegionInfo {
 		// according to the `startKey` and `endKey` and check if the range is invalid
 		// to skip the iteration.
 		// TODO: maybe we could cache the `startIndex` and `endIndex` for each range.
-		setAndCheckStartEndIndices = func() bool {
+		setAndCheckStartEndIndices = func() (skip bool) {
 			startKeyLen, endKeyLen := len(startKey), len(endKey)
 			if startKeyLen == 0 && endKeyLen == 0 {
 				startIndex, endIndex = 0, treeLen

--- a/pkg/core/region_tree.go
+++ b/pkg/core/region_tree.go
@@ -358,13 +358,13 @@ func (t *regionTree) RandomRegions(n int, ranges []KeyRange) []*RegionInfo {
 				startIndex, endIndex = 0, treeLen
 				return false
 			}
-			if startKeyLen > 0 {
-				pivotItem.meta.StartKey = startKey
-				startItem, startIndex = t.tree.GetWithIndex(pivotItem)
-			}
+			pivotItem.meta.StartKey = startKey
+			startItem, startIndex = t.tree.GetWithIndex(pivotItem)
 			if endKeyLen > 0 {
 				pivotItem.meta.StartKey = endKey
 				_, endIndex = t.tree.GetWithIndex(pivotItem)
+			} else {
+				endIndex = treeLen
 			}
 			// Consider that the item in the tree may not be continuous,
 			// we need to check if the previous item contains the key.

--- a/pkg/core/region_tree_test.go
+++ b/pkg/core/region_tree_test.go
@@ -281,7 +281,11 @@ func TestRandomRegion(t *testing.T) {
 	updateNewItem(tree, regionA)
 	ra := tree.randomRegion([]KeyRange{NewKeyRange("", "")})
 	re.Equal(regionA, ra)
+	ra = tree.randomRegion(nil)
+	re.Equal(regionA, ra)
 	ra2 := tree.RandomRegions(2, []KeyRange{NewKeyRange("", "")})
+	re.Equal([]*RegionInfo{regionA, regionA}, ra2)
+	ra2 = tree.RandomRegions(2, nil)
 	re.Equal([]*RegionInfo{regionA, regionA}, ra2)
 
 	regionB := NewTestRegionInfo(2, 2, []byte("g"), []byte("n"))
@@ -307,6 +311,7 @@ func TestRandomRegion(t *testing.T) {
 	rf = tree.randomRegion([]KeyRange{NewKeyRange("z", "")})
 	re.Nil(rf)
 
+	checkRandomRegion(re, tree, []*RegionInfo{regionA, regionB, regionC, regionD}, nil)
 	checkRandomRegion(re, tree, []*RegionInfo{regionA, regionB, regionC, regionD}, []KeyRange{NewKeyRange("", "")})
 	checkRandomRegion(re, tree, []*RegionInfo{regionA, regionB}, []KeyRange{NewKeyRange("", "n")})
 	checkRandomRegion(re, tree, []*RegionInfo{regionC, regionD}, []KeyRange{NewKeyRange("n", "")})
@@ -356,6 +361,7 @@ func TestRandomRegionDiscontinuous(t *testing.T) {
 	rd := tree.randomRegion([]KeyRange{NewKeyRange("", "b")})
 	re.Equal(regionD, rd)
 
+	checkRandomRegion(re, tree, []*RegionInfo{regionA, regionB, regionC, regionD}, nil)
 	checkRandomRegion(re, tree, []*RegionInfo{regionA, regionB, regionC, regionD}, []KeyRange{NewKeyRange("", "")})
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7897.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
In the case of only one key range, follow the fast path logic to avoid unnecessary random and loop operations.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```shell
> benchstat master-6b8d22779.txt new-7c6603926.txt
goos: darwin
goarch: arm64
pkg: github.com/tikv/pd/pkg/core
                                                              │ master-6b8d22779.txt │           new-7c6603926.txt           │
                                                              │        sec/op        │     sec/op      vs base               │
RandomRegion/random_region_whole_range_with_size_10-8                   283.2n ±  2%    244.4n ±   4%  -13.73% (p=0.002 n=6)
RandomRegion/random_regions_whole_range_with_size_10-8                  460.8n ±  5%    404.5n ±   0%  -12.22% (p=0.002 n=6)
RandomRegion/random_region_single_range_with_size_10-8                  364.5n ±  2%    329.6n ±   2%   -9.55% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10-8                1532.0n ±  1%    560.4n ±   4%  -63.42% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_100-8                  319.5n ±  5%    238.8n ±   4%  -25.27% (p=0.002 n=6)
RandomRegion/random_regions_whole_range_with_size_100-8                 490.0n ±  0%    407.5n ±   2%  -16.83% (p=0.002 n=6)
RandomRegion/random_region_single_range_with_size_100-8                 447.2n ±  1%    404.6n ±   1%   -9.54% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_100-8               2241.5n ±  2%    578.3n ±   0%  -74.20% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_1000-8                 385.2n ±  1%    274.5n ±   3%  -28.72% (p=0.002 n=6)
RandomRegion/random_regions_whole_range_with_size_1000-8                732.0n ±  0%    592.4n ±   1%  -19.08% (p=0.002 n=6)
RandomRegion/random_region_single_range_with_size_1000-8                564.7n ±  2%    516.6n ±   0%   -8.53% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_1000-8              3371.0n ±  0%    892.4n ±   1%  -73.53% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_10000-8                514.0n ±  5%    364.0n ±   5%  -29.19% (p=0.002 n=6)
RandomRegion/random_regions_whole_range_with_size_10000-8               1.250µ ±  3%    1.005µ ±   0%  -19.60% (p=0.002 n=6)
RandomRegion/random_region_single_range_with_size_10000-8               750.0n ±  0%    692.2n ±   1%   -7.71% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10000-8              4.884µ ±  1%    1.495µ ±   0%  -69.39% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_100000-8               801.8n ±  0%    609.5n ±   2%  -23.99% (p=0.002 n=6)
RandomRegion/random_regions_whole_range_with_size_100000-8              3.711µ ±  1%    3.185µ ±   5%  -14.18% (p=0.002 n=6)
RandomRegion/random_region_single_range_with_size_100000-8              1.130µ ±  5%    1.067µ ±   2%   -5.58% (p=0.030 n=6)
RandomRegion/random_regions_single_range_with_size_100000-8             7.902µ ±  6%    3.614µ ±   5%  -54.26% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_1000000-8             1032.5n ±  4%    821.7n ±   3%  -20.42% (p=0.002 n=6)
RandomRegion/random_regions_whole_range_with_size_1000000-8             6.144µ ±  3%    5.815µ ±   2%   -5.36% (p=0.002 n=6)
RandomRegion/random_region_single_range_with_size_1000000-8             1.518µ ±  1%    1.433µ ±   2%   -5.57% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_1000000-8           12.495µ ±  3%    7.188µ ±   2%  -42.47% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_10000000-8             9.834µ ± 31%   11.163µ ±   7%        ~ (p=0.093 n=6)
RandomRegion/random_regions_whole_range_with_size_10000000-8            92.83µ ± 13%   102.33µ ±   6%  +10.23% (p=0.004 n=6)
RandomRegion/random_region_single_range_with_size_10000000-8            7.853µ ± 22%   10.106µ ± 114%        ~ (p=0.132 n=6)
RandomRegion/random_regions_single_range_with_size_10000000-8           65.62µ ±  7%    48.39µ ±  46%        ~ (p=0.065 n=6)
geomean                                                                 1.828µ          1.321µ         -27.75%

                                                              │ master-6b8d22779.txt │          new-7c6603926.txt          │
                                                              │         B/op         │    B/op     vs base                 │
RandomRegion/random_region_whole_range_with_size_10-8                     416.0 ± 0%   416.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_10-8                    488.0 ± 0%   488.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_10-8                    424.0 ± 0%   416.0 ± 0%   -1.89% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10-8                   568.0 ± 0%   488.0 ± 0%  -14.08% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_100-8                    416.0 ± 0%   416.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_100-8                   488.0 ± 0%   488.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_100-8                   424.0 ± 0%   416.0 ± 0%   -1.89% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_100-8                  568.0 ± 0%   488.0 ± 0%  -14.08% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_1000-8                   416.0 ± 0%   416.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_1000-8                  488.0 ± 0%   488.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_1000-8                  424.0 ± 0%   416.0 ± 0%   -1.89% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_1000-8                 568.0 ± 0%   488.0 ± 0%  -14.08% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_10000-8                  416.0 ± 0%   416.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_10000-8                 488.0 ± 0%   488.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_10000-8                 424.0 ± 0%   416.0 ± 0%   -1.89% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10000-8                568.0 ± 0%   488.0 ± 0%  -14.08% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_100000-8                 416.0 ± 0%   416.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_100000-8                488.0 ± 0%   488.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_100000-8                424.0 ± 0%   416.0 ± 0%   -1.89% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_100000-8               568.0 ± 0%   488.0 ± 0%  -14.08% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_1000000-8                416.0 ± 0%   416.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_1000000-8               488.0 ± 0%   488.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_1000000-8               424.0 ± 0%   416.0 ± 0%   -1.89% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_1000000-8              568.0 ± 0%   488.0 ± 0%  -14.08% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_10000000-8               416.0 ± 0%   416.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_10000000-8              488.0 ± 0%   488.0 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_10000000-8              424.0 ± 0%   416.0 ± 0%   -1.89% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10000000-8             568.0 ± 0%   488.0 ± 0%  -14.08% (p=0.002 n=6)
geomean                                                                   470.2        450.6        -4.18%
¹ all samples are equal

                                                              │ master-6b8d22779.txt │          new-7c6603926.txt          │
                                                              │      allocs/op       │ allocs/op   vs base                 │
RandomRegion/random_region_whole_range_with_size_10-8                     4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_10-8                    4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_10-8                    5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10-8                  14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_100-8                    4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_100-8                   4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_100-8                   5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_100-8                 14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_1000-8                   4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_1000-8                  4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_1000-8                  5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_1000-8                14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_10000-8                  4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_10000-8                 4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_10000-8                 5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10000-8               14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_100000-8                 4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_100000-8                4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_100000-8                5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_100000-8              14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_1000000-8                4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_1000000-8               4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_1000000-8               5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_1000000-8             14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.002 n=6)
RandomRegion/random_region_whole_range_with_size_10000000-8               4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_regions_whole_range_with_size_10000000-8              4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
RandomRegion/random_region_single_range_with_size_10000000-8              5.000 ± 0%   4.000 ± 0%  -20.00% (p=0.002 n=6)
RandomRegion/random_regions_single_range_with_size_10000000-8            14.000 ± 0%   4.000 ± 0%  -71.43% (p=0.002 n=6)
geomean                                                                   5.785        4.000       -30.86%
¹ all samples are equal
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```