### PR TITLE
apiutil/middleware: add retry logic for obtaining PD leader in redirector

### DIFF
--- a/pkg/utils/apiutil/serverapi/middleware.go
+++ b/pkg/utils/apiutil/serverapi/middleware.go
@@ -18,7 +18,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
 	mcsutils "github.com/tikv/pd/pkg/mcs/utils"
@@ -204,20 +206,19 @@ func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http
 		clientUrls = append(clientUrls, targetAddr)
 		// Add a header to the response, it is used to mark whether the request has been forwarded to the micro service.
 		w.Header().Add(apiutil.XForwardedToMicroServiceHeader, "true")
-	} else {
-		leader := h.s.GetMember().GetLeader()
+	} else if name := r.Header.Get(apiutil.PDRedirectorHeader); len(name) == 0 {
+		leader := h.waitForLeader(r)
 		if leader == nil {
 			http.Error(w, "no leader", http.StatusServiceUnavailable)
 			return
 		}
 		clientUrls = leader.GetClientUrls()
-		// Prevent more than one redirection among PD/API servers.
-		if name := r.Header.Get(apiutil.PDRedirectorHeader); len(name) != 0 {
-			log.Error("redirect but server is not leader", zap.String("from", name), zap.String("server", h.s.Name()), errs.ZapError(errs.ErrRedirect))
-			http.Error(w, errs.ErrRedirectToNotLeader.FastGenByArgs().Error(), http.StatusInternalServerError)
-			return
-		}
 		r.Header.Set(apiutil.PDRedirectorHeader, h.s.Name())
+	} else {
+		// Prevent more than one redirection among PD/API servers.
+		log.Error("redirect but server is not leader", zap.String("from", name), zap.String("server", h.s.Name()), errs.ZapError(errs.ErrRedirect))
+		http.Error(w, errs.ErrRedirectToNotLeader.FastGenByArgs().Error(), http.StatusInternalServerError)
+		return
 	}
 
 	urls := make([]url.URL, 0, len(clientUrls))
@@ -232,4 +233,39 @@ func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http
 	}
 	client := h.s.GetHTTPClient()
 	apiutil.NewCustomReverseProxies(client, urls).ServeHTTP(w, r)
+}
+
+const (
+	backoffMaxDelay = 3 * time.Second
+	backoffInterval = 100 * time.Millisecond
+)
+
+// If current server does not have a leader, backoff to increase the chance of success.
+func (h *redirector) waitForLeader(r *http.Request) (leader *pdpb.Member) {
+	var (
+		interval = backoffInterval
+		maxDelay = backoffMaxDelay
+		curDelay = time.Duration(0)
+	)
+	for {
+		leader = h.s.GetMember().GetLeader()
+		if leader != nil {
+			return
+		}
+		select {
+		case <-time.After(interval):
+			curDelay += interval
+			if curDelay >= maxDelay {
+				return
+			}
+			interval *= 2
+			if curDelay+interval > maxDelay {
+				interval = maxDelay - curDelay
+			}
+		case <-r.Context().Done():
+			return
+		case <-h.s.LoopContext().Done():
+			return
+		}
+	}
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #8142.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Add retry logic to improve PD HTTP request forwarding success rate during PD leader switch.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
