### PR TITLE
server/join: log detailed info when a join failure member is detected

### DIFF
--- a/server/join/join.go
+++ b/server/join/join.go
@@ -136,7 +136,11 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	existed := false
 	for _, m := range listResp.Members {
 		if len(m.Name) == 0 {
-			return errors.New("there is a member that has not joined successfully")
+			log.Error("there is an abnormal joined member in the current member list",
+				zap.Uint64("id", m.ID),
+				zap.Strings("peer-urls", m.PeerURLs),
+				zap.Strings("client-urls", m.ClientURLs))
+			return errors.Errorf("there is a member %d that has not joined successfully", m.ID)
 		}
 		if m.Name == cfg.Name {
 			existed = true
@@ -184,7 +188,11 @@ func PrepareJoinCluster(cfg *config.Config) error {
 				listSucc = true
 			}
 			if len(n) == 0 {
-				return errors.New("there is a member that has not joined successfully")
+				log.Error("there is an abnormal joined member in the current member list",
+					zap.Uint64("id", memb.ID),
+					zap.Strings("peer-urls", memb.PeerURLs),
+					zap.Strings("client-urls", memb.ClientURLs))
+				return errors.Errorf("there is a member %d that has not joined successfully", memb.ID)
 			}
 			for _, m := range memb.PeerURLs {
 				pds = append(pds, fmt.Sprintf("%s=%s", n, m))


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7983.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Log the detailed info when a join failure member is detected to help troubleshoot.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
