### PR TITLE
storelimit: fix datarace from `getOrCreateStoreLimit`

### DIFF
--- a/pkg/core/storelimit/store_limit.go
+++ b/pkg/core/storelimit/store_limit.go
@@ -17,6 +17,7 @@ package storelimit
 import (
 	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/ratelimit"
+	"github.com/tikv/pd/pkg/utils/syncutil"
 )
 
 const (
@@ -106,7 +107,7 @@ func (l *StoreRateLimit) Rate(typ Type) float64 {
 	if l.limits[typ] == nil {
 		return 0.0
 	}
-	return l.limits[typ].ratePerSec
+	return l.limits[typ].GetRatePerSec()
 }
 
 // Take takes count tokens from the bucket without blocking.
@@ -128,12 +129,15 @@ func (l *StoreRateLimit) Reset(rate float64, typ Type) {
 
 // limit the operators of a store
 type limit struct {
+	syncutil.RWMutex
 	limiter    *ratelimit.RateLimiter
 	ratePerSec float64
 }
 
 // Reset resets the rate limit.
 func (l *limit) Reset(ratePerSec float64) {
+	l.Lock()
+	defer l.Unlock()
 	if l.ratePerSec == ratePerSec {
 		return
 	}
@@ -155,6 +159,8 @@ func (l *limit) Reset(ratePerSec float64) {
 // Available returns the number of available tokens
 // It returns true if the rate per second is zero.
 func (l *limit) Available(n int64) bool {
+	l.RLock()
+	defer l.RUnlock()
 	if l.ratePerSec == 0 {
 		return true
 	}
@@ -164,8 +170,16 @@ func (l *limit) Available(n int64) bool {
 
 // Take takes count tokens from the bucket without blocking.
 func (l *limit) Take(count int64) bool {
+	l.RLock()
+	defer l.RUnlock()
 	if l.ratePerSec == 0 {
 		return true
 	}
 	return l.limiter.AllowN(int(count))
+}
+
+func (l *limit) GetRatePerSec() float64 {
+	l.RLock()
+	defer l.RUnlock()
+	return l.ratePerSec
 }

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -955,3 +955,43 @@ func (suite *operatorControllerTestSuite) TestInvalidStoreId() {
 	// Although store 3 does not exist in PD, PD can also send op to TiKV.
 	re.Equal(pdpb.OperatorStatus_RUNNING, oc.GetOperatorStatus(1).Status)
 }
+
+func TestConcurrentAddOperatorAndSetStoreLimit(t *testing.T) {
+	re := require.New(t)
+	opt := mockconfig.NewTestOptions()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc.ID, tc, false /* no need to run */)
+	oc := NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+
+	regionNum := 10000
+	limit := 16000000.0
+	storeID := uint64(2)
+	for i := 1; i < 4; i++ {
+		tc.AddRegionStore(uint64(i), 100)
+		tc.SetStoreLimit(uint64(i), storelimit.AddPeer, limit)
+	}
+	for i := 1; i < regionNum; i++ {
+		tc.AddLeaderRegion(uint64(i), 1, 2, 3)
+	}
+
+	var wg sync.WaitGroup
+	for i := 1; i < 10; i++ {
+		wg.Add(1)
+		go func(i uint64) {
+			defer wg.Done()
+			for j := 1; j < 10; j++ {
+				regionID := uint64(j) + i*100
+				op := NewTestOperator(regionID, tc.GetRegion(regionID).GetRegionEpoch(), OpRegion, AddPeer{ToStore: storeID, PeerID: regionID})
+				re.True(oc.AddOperator(op))
+				if i%2 == 0 {
+					tc.SetStoreLimit(storeID, storelimit.AddPeer, limit)
+				} else {
+					tc.SetStoreLimit(storeID, storelimit.AddPeer, limit-float64(j))
+				}
+			}
+		}(uint64(i))
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8253

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

`go test -timeout 120s -run ^TestConcurrentAddOperatorAndSetStoreLimit$ github.com/tikv/pd/pkg/schedule/operator -race`
- run test `TestConcurrentAddOperatorAndSetStoreLimit` on master
```
WARNING: DATA RACE
Write at 0x00c0005ae480 by goroutine 220:
  github.com/tikv/pd/pkg/core/storelimit.(*limit).Reset()
      /home/lhy1024/pd/pkg/core/storelimit/store_limit.go:151 +0x227
  github.com/tikv/pd/pkg/core/storelimit.(*StoreRateLimit).Reset()
      /home/lhy1024/pd/pkg/core/storelimit/store_limit.go:126 +0x3b
  github.com/tikv/pd/pkg/core.(*StoresInfo).ResetStoreLimit.ResetStoreLimit.func1()
      /home/lhy1024/pd/pkg/core/store_option.go:258 +0x14b
  github.com/tikv/pd/pkg/core.(*StoreInfo).Clone()
      /home/lhy1024/pd/pkg/core/store.go:112 +0x17a
  github.com/tikv/pd/pkg/core.(*StoresInfo).ResetStoreLimit()
      /home/lhy1024/pd/pkg/core/store.go:870 +0x208
  github.com/tikv/pd/pkg/schedule/operator.(*Controller).getOrCreateStoreLimit()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller.go:989 +0x2b7
  github.com/tikv/pd/pkg/schedule/operator.(*Controller).ExceedStoreLimit()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller.go:966 +0x464
  github.com/tikv/pd/pkg/schedule/operator.(*Controller).AddOperator()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller.go:355 +0x6b
  github.com/tikv/pd/pkg/schedule/operator.TestConcurrentAddOperatorAndSetStoreLimit.func1()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller_test.go:987 +0x2fb
  github.com/tikv/pd/pkg/schedule/operator.TestConcurrentAddOperatorAndSetStoreLimit.gowrap1()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller_test.go:994 +0x41

Previous read at 0x00c0005ae480 by goroutine 221:
  github.com/tikv/pd/pkg/core/storelimit.(*limit).Available()
      /home/lhy1024/pd/pkg/core/storelimit/store_limit.go:162 +0xb2
  github.com/tikv/pd/pkg/core/storelimit.(*StoreRateLimit).Available()
      /home/lhy1024/pd/pkg/core/storelimit/store_limit.go:101 +0x3a
  github.com/tikv/pd/pkg/schedule/operator.(*Controller).ExceedStoreLimit()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller.go:970 +0x4e5
  github.com/tikv/pd/pkg/schedule/operator.(*Controller).AddOperator()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller.go:355 +0x6b
  github.com/tikv/pd/pkg/schedule/operator.TestConcurrentAddOperatorAndSetStoreLimit.func1()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller_test.go:987 +0x2fb
  github.com/tikv/pd/pkg/schedule/operator.TestConcurrentAddOperatorAndSetStoreLimit.gowrap1()
      /home/lhy1024/pd/pkg/schedule/operator/operator_controller_test.go:994 +0x41
```
- run test `TestConcurrentAddOperatorAndSetStoreLimit` with this PR
```
ok  	github.com/tikv/pd/pkg/schedule/operator	1.473s
```
### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
