### PR TITLE
etcdutil: check if the endpoint has been removed before evicting

### DIFF
--- a/pkg/utils/etcdutil/health_checker.go
+++ b/pkg/utils/etcdutil/health_checker.go
@@ -273,7 +273,7 @@ func (checker *healthChecker) updateEvictedEps(lastEps, pickedEps []string) {
 	for _, ep := range pickedEps {
 		pickedSet[ep] = true
 	}
-	// Reset the count to 0 if it's in evictedEps but not in the pickedEps.
+	// Reset the count to 0 if it's in `evictedEps` but not in `pickedEps`.
 	checker.evictedEps.Range(func(key, value any) bool {
 		ep := key.(string)
 		count := value.(int)
@@ -286,10 +286,13 @@ func (checker *healthChecker) updateEvictedEps(lastEps, pickedEps []string) {
 		}
 		return true
 	})
-	// Find all endpoints which are in the lastEps but not in the pickedEps,
-	// and add them to the evictedEps.
+	// Find all endpoints which are in `lastEps` and `healthyClients` but not in `pickedEps`,
+	// and add them to the `evictedEps`.
 	for _, ep := range lastEps {
 		if pickedSet[ep] {
+			continue
+		}
+		if hc := checker.loadClient(ep); hc == nil {
 			continue
 		}
 		checker.evictedEps.Store(ep, 0)
@@ -297,7 +300,7 @@ func (checker *healthChecker) updateEvictedEps(lastEps, pickedEps []string) {
 			zap.String("endpoint", ep),
 			zap.String("source", checker.source))
 	}
-	// Find all endpoints which are in both pickedEps and evictedEps to
+	// Find all endpoints which are in both `pickedEps` and `evictedEps` to
 	// increase their picked count.
 	for _, ep := range pickedEps {
 		if count, ok := checker.evictedEps.Load(ep); ok {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #8286.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Once a member is removed from the cluster, its endpoint should no longer exist in the health checker.
This PR adds a check to prevent the removed endpoint from being evicted again unexpectedly.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
