### PR TITLE
test: add test for clone unmarshal

### DIFF
--- a/client/http/types_test.go
+++ b/client/http/types_test.go
@@ -308,3 +308,30 @@ func mustMarshalAndUnmarshalRuleOp(re *require.Assertions, ruleOp *RuleOp) *Rule
 	re.NoError(err)
 	return newRuleOp
 }
+
+// startKey and endKey are json:"-" which means cannot be Unmarshal from json
+// We need to take care of `Clone` method.
+func TestRuleKeyClone(t *testing.T) {
+	re := require.New(t)
+	r := &Rule{
+		StartKey: []byte{1, 2, 3},
+		EndKey:   []byte{4, 5, 6},
+	}
+
+	clone := r.Clone()
+	// Modify the original rule
+	r.StartKey[0] = 9
+	r.EndKey[0] = 9
+
+	// The clone should not be affected
+	re.Equal([]byte{1, 2, 3}, clone.StartKey)
+	re.Equal([]byte{4, 5, 6}, clone.EndKey)
+
+	// Modify the clone
+	clone.StartKey[0] = 8
+	clone.EndKey[0] = 8
+
+	// The original rule should not be affected
+	re.Equal([]byte{9, 2, 3}, r.StartKey)
+	re.Equal([]byte{9, 5, 6}, r.EndKey)
+}

--- a/pkg/schedule/placement/rule_test.go
+++ b/pkg/schedule/placement/rule_test.go
@@ -186,3 +186,30 @@ func TestBuildRuleList(t *testing.T) {
 		re.Equal(testCase.expect.ranges, result.ranges)
 	}
 }
+
+// startKey and endKey are json:"-" which means cannot be Unmarshal from json
+// We need to take care of `Clone` method.
+func TestRuleKeyClone(t *testing.T) {
+	re := require.New(t)
+	r := &Rule{
+		StartKey: []byte{1, 2, 3},
+		EndKey:   []byte{4, 5, 6},
+	}
+
+	clone := r.Clone()
+	// Modify the original rule
+	r.StartKey[0] = 9
+	r.EndKey[0] = 9
+
+	// The clone should not be affected
+	re.Equal([]byte{1, 2, 3}, clone.StartKey)
+	re.Equal([]byte{4, 5, 6}, clone.EndKey)
+
+	// Modify the clone
+	clone.StartKey[0] = 8
+	clone.EndKey[0] = 8
+
+	// The original rule should not be affected
+	re.Equal([]byte{9, 2, 3}, r.StartKey)
+	re.Equal([]byte{9, 5, 6}, r.EndKey)
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #4399

### What is changed and how does it work?

issue relies on 
https://github.com/tikv/pd/pull/8301/commits/76b49327ff7842027631642ad1d3746c5b14a02a#diff-5cf563058fdae91ee59093d5721fde21b45888669570a5fdfd54bbe502ce3e03L93-L95

We have this logic for `clone`
https://github.com/tikv/pd/blob/13174b5d4cab4d958f0b4ea2718ea7bb74992bc7/client/http/types.go#L366-L373

This is because startKey is json:"-" which means cannot be Unmarshal from json, We need to take care of `Clone` method.
https://github.com/tikv/pd/blob/13174b5d4cab4d958f0b4ea2718ea7bb74992bc7/client/http/types.go#L346-L349


<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
