### PR TITLE
tools/simulator: replace GenerateSplitKey with GenerateTableKeys

### DIFF
--- a/tests/integrations/realcluster/scheduler_test.go
+++ b/tests/integrations/realcluster/scheduler_test.go
@@ -86,7 +86,7 @@ func TestRegionLabelDenyScheduler(t *testing.T) {
 
 	regions, err := pdHTTPCli.GetRegions(ctx)
 	re.NoError(err)
-	re.GreaterOrEqual(len(regions.Regions), 1)
+	re.NotEmpty(regions.Regions)
 	region1 := regions.Regions[0]
 
 	err = pdHTTPCli.DeleteScheduler(ctx, schedulers.BalanceLeaderName)

--- a/tools/pd-simulator/simulator/cases/region_split.go
+++ b/tools/pd-simulator/simulator/cases/region_split.go
@@ -38,7 +38,7 @@ func newRegionSplit(config *sc.SimConfig) *Case {
 	}
 	replica := int(config.ServerConfig.Replication.MaxReplicas)
 	peers := make([]*metapb.Peer, 0, replica)
-	for j := 1; j < replica; j++ {
+	for j := 0; j < replica; j++ {
 		peers = append(peers, &metapb.Peer{
 			Id:      simutil.IDAllocator.NextID(),
 			StoreId: uint64((j)%(totalStore-1) + 1),
@@ -63,7 +63,7 @@ func newRegionSplit(config *sc.SimConfig) *Case {
 	e := &WriteFlowOnSpotDescriptor{}
 	e.Step = func(int64) map[string]int64 {
 		return map[string]int64{
-			"a": 8 * units.MiB,
+			"foobar": 8 * units.MiB,
 		}
 	}
 	simCase.Events = []EventDescriptor{e}

--- a/tools/pd-simulator/simulator/cases/region_split.go
+++ b/tools/pd-simulator/simulator/cases/region_split.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	sc "github.com/tikv/pd/tools/pd-simulator/simulator/config"
 	"github.com/tikv/pd/tools/pd-simulator/simulator/info"
+	"github.com/tikv/pd/tools/pd-simulator/simulator/simutil"
 )
 
 func newRegionSplit(config *sc.SimConfig) *Case {
@@ -28,23 +29,33 @@ func newRegionSplit(config *sc.SimConfig) *Case {
 	allStores := make(map[uint64]struct{}, totalStore)
 
 	for i := 0; i < totalStore; i++ {
-		id := uint64(i)
+		storeID := simutil.IDAllocator.NextID()
 		simCase.Stores = append(simCase.Stores, &Store{
-			ID:     id,
+			ID:     storeID,
 			Status: metapb.StoreState_Up,
 		})
-		allStores[id] = struct{}{}
+		allStores[storeID] = struct{}{}
 	}
-	peers := []*metapb.Peer{
-		{Id: 4, StoreId: 1},
+	replica := int(config.ServerConfig.Replication.MaxReplicas)
+	peers := make([]*metapb.Peer, 0, replica)
+	for j := 1; j < replica; j++ {
+		peers = append(peers, &metapb.Peer{
+			Id:      simutil.IDAllocator.NextID(),
+			StoreId: uint64((j)%(totalStore-1) + 1),
+		})
 	}
-	simCase.Regions = append(simCase.Regions, Region{
-		ID:     5,
-		Peers:  peers,
-		Leader: peers[0],
-		Size:   1 * units.MiB,
-		Keys:   10000,
-	})
+	regionID := simutil.IDAllocator.NextID()
+	simCase.Regions = []Region{
+		{
+			ID:     regionID,
+			Peers:  peers,
+			Leader: peers[0],
+			Size:   1 * units.MiB,
+			Keys:   10000,
+		},
+	}
+	// update total region
+	config.TotalRegion = 1
 
 	simCase.RegionSplitSize = 128 * units.MiB
 	simCase.RegionSplitKeys = 10000
@@ -52,7 +63,7 @@ func newRegionSplit(config *sc.SimConfig) *Case {
 	e := &WriteFlowOnSpotDescriptor{}
 	e.Step = func(int64) map[string]int64 {
 		return map[string]int64{
-			"foobar": 8 * units.MiB,
+			"a": 8 * units.MiB,
 		}
 	}
 	simCase.Events = []EventDescriptor{e}

--- a/tools/pd-simulator/simulator/client.go
+++ b/tools/pd-simulator/simulator/client.go
@@ -206,6 +206,10 @@ func (c *client) reportRegionHeartbeat(ctx context.Context, stream pdpb.PD_Regio
 	for {
 		select {
 		case r := <-c.reportRegionHeartbeatCh:
+			if r == nil {
+				simutil.Logger.Error("report nil regionHeartbeat error",
+					zap.String("tag", c.tag), zap.Error(errors.New("nil region")))
+			}
 			region := r.Clone()
 			request := &pdpb.RegionHeartbeatRequest{
 				Header:          requestHeader(),
@@ -539,6 +543,7 @@ func PutPDConfig(config *sc.PDConfig) error {
 }
 
 func ChooseToHaltPDSchedule(halt bool) {
+	HaltSchedule = halt
 	PDHTTPClient.SetConfig(context.Background(), map[string]any{
 		"schedule.halt-scheduling": strconv.FormatBool(halt),
 	})

--- a/tools/pd-simulator/simulator/drive.go
+++ b/tools/pd-simulator/simulator/drive.go
@@ -176,8 +176,13 @@ func (d *Driver) Tick() {
 	d.wg.Wait()
 }
 
+var HaltSchedule = false
+
 // Check checks if the simulation is completed.
 func (d *Driver) Check() bool {
+	if !HaltSchedule {
+		return false
+	}
 	length := uint64(len(d.conn.Nodes) + 1)
 	var stores []*metapb.Store
 	for index, s := range d.conn.Nodes {

--- a/tools/pd-simulator/simulator/event.go
+++ b/tools/pd-simulator/simulator/event.go
@@ -131,7 +131,7 @@ func (e *WriteFlowOnSpot) Run(raft *RaftEngine, tickCount int64) bool {
 		region := raft.GetRegionByKey([]byte(key))
 		simutil.Logger.Debug("search the region", zap.Reflect("region", region.GetMeta()))
 		if region == nil {
-			simutil.Logger.Error("region not found for key", zap.String("key", key))
+			simutil.Logger.Error("region not found for key", zap.String("key", key), zap.Any("byte(key)", []byte(key)))
 			continue
 		}
 		raft.updateRegionStore(region, size)

--- a/tools/pd-simulator/simulator/node.go
+++ b/tools/pd-simulator/simulator/node.go
@@ -208,6 +208,9 @@ func (n *Node) regionHeartBeat() {
 	n.raftEngine.TraverseRegions(func(region *core.RegionInfo) {
 		if region.GetLeader() != nil && region.GetLeader().GetStoreId() == n.Id {
 			ctx, cancel := context.WithTimeout(n.ctx, pdTimeout)
+			if region == nil {
+				simutil.Logger.Fatal("region not found")
+			}
 			err := n.client.RegionHeartbeat(ctx, region)
 			if err != nil {
 				simutil.Logger.Info("report region heartbeat error",
@@ -225,6 +228,10 @@ func (n *Node) reportRegionChange() {
 	for _, regionID := range regionIDs {
 		region := n.raftEngine.GetRegion(regionID)
 		ctx, cancel := context.WithTimeout(n.ctx, pdTimeout)
+		if region == nil {
+			simutil.Logger.Info("region not found",
+				zap.Uint64("region-id", regionID), zap.Uint64("node-id", n.Id))
+		}
 		err := n.client.RegionHeartbeat(ctx, region)
 		if err != nil {
 			simutil.Logger.Info("report region change heartbeat error",

--- a/tools/pd-simulator/simulator/raft.go
+++ b/tools/pd-simulator/simulator/raft.go
@@ -30,13 +30,12 @@ import (
 // RaftEngine records all raft information.
 type RaftEngine struct {
 	syncutil.RWMutex
-	regionsInfo       *core.RegionsInfo
-	conn              *Connection
-	regionChange      map[uint64][]uint64
-	regionSplitSize   int64
-	regionSplitKeys   int64
-	storeConfig       *config.SimConfig
-	useTiDBEncodedKey bool
+	regionsInfo     *core.RegionsInfo
+	conn            *Connection
+	regionChange    map[uint64][]uint64
+	regionSplitSize int64
+	regionSplitKeys int64
+	storeConfig     *config.SimConfig
 }
 
 // NewRaftEngine creates the initialized raft with the configuration.
@@ -49,14 +48,7 @@ func NewRaftEngine(conf *cases.Case, conn *Connection, storeConfig *config.SimCo
 		regionSplitKeys: conf.RegionSplitKeys,
 		storeConfig:     storeConfig,
 	}
-	var splitKeys []string
-	if conf.TableNumber > 0 {
-		splitKeys = simutil.GenerateTableKeys(conf.TableNumber, len(conf.Regions)-1)
-		r.useTiDBEncodedKey = true
-	} else {
-		splitKeys = simutil.GenerateKeys(len(conf.Regions) - 1)
-	}
-
+	splitKeys := simutil.GenerateTableKeys(conf.TableNumber, len(conf.Regions)-1)
 	for i, region := range conf.Regions {
 		meta := &metapb.Region{
 			Id:          region.ID,
@@ -133,14 +125,9 @@ func (r *RaftEngine) stepSplit(region *core.RegionInfo) {
 		}
 	}
 
-	var splitKey []byte
-	if r.useTiDBEncodedKey {
-		splitKey, err = simutil.GenerateTiDBEncodedSplitKey(region.GetStartKey(), region.GetEndKey())
-		if err != nil {
-			simutil.Logger.Fatal("Generate TiDB encoded split key failed", zap.Error(err))
-		}
-	} else {
-		splitKey = simutil.GenerateSplitKey(region.GetStartKey(), region.GetEndKey())
+	splitKey, err := simutil.GenerateTiDBEncodedSplitKey(region.GetStartKey(), region.GetEndKey())
+	if err != nil {
+		simutil.Logger.Fatal("Generate TiDB encoded split key failed", zap.Error(err))
 	}
 	left := region.Clone(
 		core.WithNewRegionID(ids[len(ids)-1]),

--- a/tools/pd-simulator/simulator/raft.go
+++ b/tools/pd-simulator/simulator/raft.go
@@ -162,6 +162,7 @@ func (r *RaftEngine) stepSplit(region *core.RegionInfo) {
 	r.SetRegion(right)
 	r.SetRegion(left)
 	simutil.Logger.Debug("region split",
+		zap.Uint64("node-id", region.GetLeader().GetStoreId()),
 		zap.Uint64("region-id", region.GetID()),
 		zap.Reflect("origin", region.GetMeta()),
 		zap.Reflect("left", left.GetMeta()),


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

`GenerateSplitKey` is less efficient and has some problems, such as wrong generate when start_key and end_key are same, and wrong generate when start_key is ""... Actually, we can replace GenerateSplitKey with GenerateTableKeys which is more line with test requirement

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #8135

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
