### PR TITLE
statistics: fix data race in `IsRegionHot`

### DIFF
--- a/pkg/statistics/hot_cache_test.go
+++ b/pkg/statistics/hot_cache_test.go
@@ -1,0 +1,36 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/pd/pkg/statistics/utils"
+)
+
+func TestIsHot(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewHotCache(ctx)
+	region := buildRegion(utils.Read, 3, 60)
+	stats := cache.CheckReadPeerSync(region, region.GetPeers(), []float64{100000000, 1000, 1000}, 60)
+	cache.Update(stats[0], utils.Read)
+	for i := 0; i < 100; i++ {
+		re.True(cache.IsRegionHot(region, 1))
+	}
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8335

Before #8164 it is 
```
// IsRegionHot checks if the region is hot.
func (w *HotCache) IsRegionHot(region *core.RegionInfo, minHotDegree int) bool {
	checkRegionHotWriteTask := newCheckRegionHotTask(region, minHotDegree)
	checkRegionHotReadTask := newCheckRegionHotTask(region, minHotDegree)
	succ1 := w.CheckWriteAsync(checkRegionHotWriteTask)
	succ2 := w.CheckReadAsync(checkRegionHotReadTask)
	if succ1 && succ2 {
		return checkRegionHotWriteTask.waitRet(w.ctx) || checkRegionHotReadTask.waitRet(w.ctx)
	}
	return false
}
```

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

- Test1: 
This test will meet data race in master and is normal in this PR.
```
for i in {1..50}; do
	go clean -testcache
	go test -timeout 120s -run ^TestSpecialUseHotRegion$ github.com/tikv/pd/pkg/schedule/schedulers -race
done

```


- Test2:
This test will be successful in this PR and be failed in master branches
```
--- FAIL: TestIsHot (0.00s)
    /home/lhy1024/pd/pkg/statistics/hot_cache_test.go:34: 
        	Error Trace:	/home/lhy1024/pd/pkg/statistics/hot_cache_test.go:34
        	Error:      	Should be true
        	Test:       	TestIsHot
FAIL
```
### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
