### PR TITLE
tools/ut: accelerate the build process and scatter test

### DIFF
--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -27,19 +27,27 @@ jobs:
       matrix:
         include:
           - worker_id: 1
-            name: 'Unit Test(1)'
+            name: 'Unit Test(core)'
           - worker_id: 2
-            name: 'Unit Test(2)'
+            name: 'Unit Test(schedule)'
           - worker_id: 3
-            name: 'Tools Test'
+            name: 'Unit Test(others)'
           - worker_id: 4
-            name: 'Client Integration Test'
+            name: 'Tests(core)'
           - worker_id: 5
-            name: 'TSO Integration Test'
+            name: 'Tests(others)'
           - worker_id: 6
-            name: 'MicroService Integration Test'
+            name: 'Tools Test'
+          - worker_id: 7
+            name: 'Client Integration Test'
+          - worker_id: 8
+            name: 'TSO Integration Test'
+          - worker_id: 9
+            name: 'MicroService Integration(Core)'
+          - worker_id: 10
+            name: 'MicroService Integration(TSO)'
     outputs:
-      job-total: 6
+      job-total: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,6 +60,9 @@ jobs:
         run: |
           make ci-test-job JOB_INDEX=$WORKER_ID
           mv covprofile covprofile_$WORKER_ID
+          if [ -f junitfile ]; then
+            cat junitfile
+          fi
       - name: Upload coverage result ${{ matrix.worker_id }}
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -88,7 +88,7 @@ jobs:
           # only keep the first line(`mode: aomic`) of the coverage profile
           sed -i '2,${/mode: atomic/d;}' covprofile
       - name: Send coverage
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV }}
           file: ./covprofile

--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -27,15 +27,15 @@ jobs:
       matrix:
         include:
           - worker_id: 1
-            name: 'Unit Test(core)'
+            name: 'Unit Test(1)'
           - worker_id: 2
-            name: 'Unit Test(schedule)'
+            name: 'Unit Test(2)'
           - worker_id: 3
-            name: 'Unit Test(others)'
+            name: 'Unit Test(3)'
           - worker_id: 4
-            name: 'Tests(core)'
+            name: 'Tests(1)'
           - worker_id: 5
-            name: 'Tests(others)'
+            name: 'Tests(2)'
           - worker_id: 6
             name: 'Tools Test'
           - worker_id: 7
@@ -43,7 +43,7 @@ jobs:
           - worker_id: 8
             name: 'TSO Integration Test'
           - worker_id: 9
-            name: 'MicroService Integration(Core)'
+            name: 'MicroService Integration(!TSO)'
           - worker_id: 10
             name: 'MicroService Integration(TSO)'
     outputs:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ docs/swagger/*
 *.before
 covprofile
 coverage.tmp
+junitfile
 package.list
 report.xml
 coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ failpoint-disable: install-tools
 ut: pd-ut
 	@$(FAILPOINT_ENABLE)
 	# only run unit tests
-	./bin/pd-ut run --ignore tests --race
+	./bin/pd-ut run --ignore tests --race --junitfile ./junitfile
 	@$(CLEAN_UT_BINARY)
 	@$(FAILPOINT_DISABLE)
 

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -731,7 +731,7 @@ func BenchmarkRandomSetRegion(b *testing.B) {
 
 func TestGetRegionSizeByRange(t *testing.T) {
 	regions := NewRegionsInfo()
-	nums := 1000010
+	nums := 100001
 	for i := 0; i < nums; i++ {
 		peer := &metapb.Peer{StoreId: 1, Id: uint64(i + 1)}
 		endKey := []byte(fmt.Sprintf("%20d", i+1))

--- a/scripts/ci-subtask.sh
+++ b/scripts/ci-subtask.sh
@@ -3,34 +3,51 @@
 # ./ci-subtask.sh <TOTAL_TASK_N> <TASK_INDEX>
 
 ROOT_PATH_COV=$(pwd)/covprofile
+ROOT_PATH_JUNITFILE=$(pwd)/junitfile
 # Currently, we only have 3 integration tests, so we can hardcode the task index.
 integrations_dir=$(pwd)/tests/integrations
 
 case $1 in
     1)
-        # unit tests ignore `tests`
-        ./bin/pd-ut run --race --ignore tests --coverprofile $ROOT_PATH_COV || exit 1
+        # unit tests ignore `tests`, `server`, `schedule`,`utils` and `encryption`
+        ./bin/pd-ut run --ignore tests,server,pkg/schedule,pkg/utils,pkg/encryption --race --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
         ;;
     2)
-        # unit tests only in `tests`
-        ./bin/pd-ut run tests --race --coverprofile $ROOT_PATH_COV || exit 1
+        # unit tests only in `schedule` and `encryption` without `tests`
+        ./bin/pd-ut run schedule,encryption --ignore tests --race --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
         ;;
     3)
+        # unit tests only in `server` and `utils` without `tests`
+        ./bin/pd-ut run server,utils --ignore tests --race --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
+        ;;
+    4)
+        # tests only in `tests` without `server/api, server/cluster and `server/config`
+        ./bin/pd-ut run tests --ignore tests/server/api,tests/server/cluster,tests/server/config --race --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
+        ;;
+    5)
+        # tests only in `server/api, server/cluster and `server/config` in `tests`
+        ./bin/pd-ut run tests/server/api,tests/server/cluster,tests/server/config --race --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
+        ;;
+    6)
         # tools tests
         cd ./tools && make ci-test-job && cat covprofile >> $ROOT_PATH_COV || exit 1
         ;;
-    4)
+    7)
         # integration test client
-        ./bin/pd-ut it run client --race --coverprofile $ROOT_PATH_COV || exit 1
+        ./bin/pd-ut it run client --race --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
         # client tests
         cd ./client && make ci-test-job && cat covprofile >> $ROOT_PATH_COV || exit 1
         ;;
-    5)
+    8)
         # integration test tso
-        ./bin/pd-ut it run tso --race --coverprofile $ROOT_PATH_COV || exit 1
+        ./bin/pd-ut it run tso --race --ignore mcs/tso --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
         ;;
-    6)
-        # integration test mcs
-        ./bin/pd-ut it run mcs --race --coverprofile $ROOT_PATH_COV || exit 1
+    9)
+        # integration test mcs without mcs/tso
+        ./bin/pd-ut it run mcs --race --ignore mcs/tso --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
+        ;;
+    10)
+        # integration test mcs/tso
+        ./bin/pd-ut it run mcs/tso --race --coverprofile $ROOT_PATH_COV --junitfile $ROOT_PATH_JUNITFILE || exit 1
         ;;
 esac

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -333,7 +333,7 @@ func TestRegionsWithKillRequest(t *testing.T) {
 	url := fmt.Sprintf("%s%s/api/v1/regions", addr, apiPrefix)
 	mustBootstrapCluster(re, svr)
 
-	regionCount := 100000
+	regionCount := 10000
 	tu.GenerateTestDataConcurrently(regionCount, func(i int) {
 		r := core.NewTestRegionInfo(uint64(i+2), 1,
 			[]byte(fmt.Sprintf("%09d", i)),

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -217,7 +217,7 @@ func TestLeaderTransferAndMoveCluster(t *testing.T) {
 	}()
 
 	// Transfer leader.
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 3; i++ {
 		oldLeaderName := cluster.WaitLeader()
 		err := cluster.GetServer(oldLeaderName).ResignLeader()
 		re.NoError(err)

--- a/tests/integrations/mcs/scheduling/api_test.go
+++ b/tests/integrations/mcs/scheduling/api_test.go
@@ -514,7 +514,7 @@ func (suite *apiTestSuite) checkAdminRegionCacheForward(cluster *tests.TestClust
 }
 
 func (suite *apiTestSuite) TestFollowerForward() {
-	suite.env.RunTestInTwoModes(suite.checkFollowerForward)
+	suite.env.RunTestBasedOnMode(suite.checkFollowerForward)
 }
 
 func (suite *apiTestSuite) checkFollowerForward(cluster *tests.TestCluster) {

--- a/tests/integrations/mcs/tso/keyspace_group_manager_test.go
+++ b/tests/integrations/mcs/tso/keyspace_group_manager_test.go
@@ -67,7 +67,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) allocID() uint32 {
 	return uint32(id)
 }
 
-func TestTSOKeyspaceGroupManager(t *testing.T) {
+func TestTSOKeyspaceGroupManagerSuite(t *testing.T) {
 	suite.Run(t, &tsoKeyspaceGroupManagerTestSuite{})
 }
 

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -71,13 +71,13 @@ func (suite *tsoClientTestSuite) getBackendEndpoints() []string {
 	return strings.Split(suite.backendEndpoints, ",")
 }
 
-func TestLegacyTSOClient(t *testing.T) {
+func TestLegacyTSOClientSuite(t *testing.T) {
 	suite.Run(t, &tsoClientTestSuite{
 		legacy: true,
 	})
 }
 
-func TestMicroserviceTSOClient(t *testing.T) {
+func TestMicroserviceTSOClientSuite(t *testing.T) {
 	suite.Run(t, &tsoClientTestSuite{
 		legacy: false,
 	})

--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -53,13 +53,13 @@ type tsoConsistencyTestSuite struct {
 	tsoClient tsopb.TSOClient
 }
 
-func TestLegacyTSOConsistency(t *testing.T) {
+func TestLegacyTSOConsistencySuite(t *testing.T) {
 	suite.Run(t, &tsoConsistencyTestSuite{
 		legacy: true,
 	})
 }
 
-func TestMicroserviceTSOConsistency(t *testing.T) {
+func TestMicroserviceTSOConsistencySuite(t *testing.T) {
 	suite.Run(t, &tsoConsistencyTestSuite{
 		legacy: false,
 	})

--- a/tests/server/api/checker_test.go
+++ b/tests/server/api/checker_test.go
@@ -44,7 +44,7 @@ func (suite *checkerTestSuite) TearDownSuite() {
 }
 
 func (suite *checkerTestSuite) TestAPI() {
-	suite.env.RunTestInTwoModes(suite.checkAPI)
+	suite.env.RunTestBasedOnMode(suite.checkAPI)
 }
 
 func (suite *checkerTestSuite) checkAPI(cluster *tests.TestCluster) {

--- a/tests/server/api/operator_test.go
+++ b/tests/server/api/operator_test.go
@@ -55,7 +55,7 @@ func (suite *operatorTestSuite) TearDownSuite() {
 }
 
 func (suite *operatorTestSuite) TestAddRemovePeer() {
-	suite.env.RunTestInTwoModes(suite.checkAddRemovePeer)
+	suite.env.RunTestBasedOnMode(suite.checkAddRemovePeer)
 }
 
 func (suite *operatorTestSuite) checkAddRemovePeer(cluster *tests.TestCluster) {
@@ -165,7 +165,7 @@ func (suite *operatorTestSuite) checkAddRemovePeer(cluster *tests.TestCluster) {
 }
 
 func (suite *operatorTestSuite) TestMergeRegionOperator() {
-	suite.env.RunTestInTwoModes(suite.checkMergeRegionOperator)
+	suite.env.RunTestBasedOnMode(suite.checkMergeRegionOperator)
 }
 
 func (suite *operatorTestSuite) checkMergeRegionOperator(cluster *tests.TestCluster) {
@@ -225,7 +225,7 @@ func (suite *operatorTestSuite) TestTransferRegionWithPlacementRule() {
 		func(conf *config.Config, _ string) {
 			conf.Replication.MaxReplicas = 3
 		})
-	env.RunTestInTwoModes(suite.checkTransferRegionWithPlacementRule)
+	env.RunTestBasedOnMode(suite.checkTransferRegionWithPlacementRule)
 	env.Cleanup()
 }
 
@@ -505,7 +505,7 @@ func (suite *operatorTestSuite) TestGetOperatorsAsObject() {
 		func(conf *config.Config, _ string) {
 			conf.Replication.MaxReplicas = 1
 		})
-	env.RunTestInTwoModes(suite.checkGetOperatorsAsObject)
+	env.RunTestBasedOnMode(suite.checkGetOperatorsAsObject)
 	env.Cleanup()
 }
 
@@ -602,7 +602,7 @@ func (suite *operatorTestSuite) checkGetOperatorsAsObject(cluster *tests.TestClu
 }
 
 func (suite *operatorTestSuite) TestRemoveOperators() {
-	suite.env.RunTestInTwoModes(suite.checkRemoveOperators)
+	suite.env.RunTestBasedOnMode(suite.checkRemoveOperators)
 }
 
 func (suite *operatorTestSuite) checkRemoveOperators(cluster *tests.TestCluster) {

--- a/tests/server/api/region_test.go
+++ b/tests/server/api/region_test.go
@@ -97,7 +97,7 @@ func (suite *regionTestSuite) TearDownTest() {
 func (suite *regionTestSuite) TestSplitRegions() {
 	// use a new environment to avoid affecting other tests
 	env := tests.NewSchedulingTestEnvironment(suite.T())
-	env.RunTestInTwoModes(suite.checkSplitRegions)
+	env.RunTestBasedOnMode(suite.checkSplitRegions)
 	env.Cleanup()
 }
 
@@ -138,7 +138,7 @@ func (suite *regionTestSuite) checkSplitRegions(cluster *tests.TestCluster) {
 }
 
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRange() {
-	suite.env.RunTestInTwoModes(suite.checkAccelerateRegionsScheduleInRange)
+	suite.env.RunTestBasedOnMode(suite.checkAccelerateRegionsScheduleInRange)
 }
 
 func (suite *regionTestSuite) checkAccelerateRegionsScheduleInRange(cluster *tests.TestCluster) {
@@ -173,7 +173,7 @@ func (suite *regionTestSuite) checkAccelerateRegionsScheduleInRange(cluster *tes
 }
 
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRanges() {
-	suite.env.RunTestInTwoModes(suite.checkAccelerateRegionsScheduleInRanges)
+	suite.env.RunTestBasedOnMode(suite.checkAccelerateRegionsScheduleInRanges)
 }
 
 func (suite *regionTestSuite) checkAccelerateRegionsScheduleInRanges(cluster *tests.TestCluster) {
@@ -211,7 +211,7 @@ func (suite *regionTestSuite) checkAccelerateRegionsScheduleInRanges(cluster *te
 func (suite *regionTestSuite) TestScatterRegions() {
 	// use a new environment to avoid affecting other tests
 	env := tests.NewSchedulingTestEnvironment(suite.T())
-	env.RunTestInTwoModes(suite.checkScatterRegions)
+	env.RunTestBasedOnMode(suite.checkScatterRegions)
 	env.Cleanup()
 }
 
@@ -258,7 +258,7 @@ func (suite *regionTestSuite) checkScatterRegions(cluster *tests.TestCluster) {
 }
 
 func (suite *regionTestSuite) TestCheckRegionsReplicated() {
-	suite.env.RunTestInTwoModes(suite.checkRegionsReplicated)
+	suite.env.RunTestBasedOnMode(suite.checkRegionsReplicated)
 }
 
 func (suite *regionTestSuite) checkRegionsReplicated(cluster *tests.TestCluster) {

--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -78,7 +78,7 @@ func (suite *ruleTestSuite) TearDownTest() {
 }
 
 func (suite *ruleTestSuite) TestSet() {
-	suite.env.RunTestInTwoModes(suite.checkSet)
+	suite.env.RunTestBasedOnMode(suite.checkSet)
 }
 
 func (suite *ruleTestSuite) checkSet(cluster *tests.TestCluster) {
@@ -194,7 +194,7 @@ func (suite *ruleTestSuite) checkSet(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestGet() {
-	suite.env.RunTestInTwoModes(suite.checkGet)
+	suite.env.RunTestBasedOnMode(suite.checkGet)
 }
 
 func (suite *ruleTestSuite) checkGet(cluster *tests.TestCluster) {
@@ -245,7 +245,7 @@ func (suite *ruleTestSuite) checkGet(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestGetAll() {
-	suite.env.RunTestInTwoModes(suite.checkGetAll)
+	suite.env.RunTestBasedOnMode(suite.checkGetAll)
 }
 
 func (suite *ruleTestSuite) checkGetAll(cluster *tests.TestCluster) {
@@ -267,7 +267,7 @@ func (suite *ruleTestSuite) checkGetAll(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestSetAll() {
-	suite.env.RunTestInTwoModes(suite.checkSetAll)
+	suite.env.RunTestBasedOnMode(suite.checkSetAll)
 }
 
 func (suite *ruleTestSuite) checkSetAll(cluster *tests.TestCluster) {
@@ -383,7 +383,7 @@ func (suite *ruleTestSuite) checkSetAll(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestGetAllByGroup() {
-	suite.env.RunTestInTwoModes(suite.checkGetAllByGroup)
+	suite.env.RunTestBasedOnMode(suite.checkGetAllByGroup)
 }
 
 func (suite *ruleTestSuite) checkGetAllByGroup(cluster *tests.TestCluster) {
@@ -440,7 +440,7 @@ func (suite *ruleTestSuite) checkGetAllByGroup(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestGetAllByRegion() {
-	suite.env.RunTestInTwoModes(suite.checkGetAllByRegion)
+	suite.env.RunTestBasedOnMode(suite.checkGetAllByRegion)
 }
 
 func (suite *ruleTestSuite) checkGetAllByRegion(cluster *tests.TestCluster) {
@@ -505,7 +505,7 @@ func (suite *ruleTestSuite) checkGetAllByRegion(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestGetAllByKey() {
-	suite.env.RunTestInTwoModes(suite.checkGetAllByKey)
+	suite.env.RunTestBasedOnMode(suite.checkGetAllByKey)
 }
 
 func (suite *ruleTestSuite) checkGetAllByKey(cluster *tests.TestCluster) {
@@ -564,7 +564,7 @@ func (suite *ruleTestSuite) checkGetAllByKey(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestDelete() {
-	suite.env.RunTestInTwoModes(suite.checkDelete)
+	suite.env.RunTestBasedOnMode(suite.checkDelete)
 }
 
 func (suite *ruleTestSuite) checkDelete(cluster *tests.TestCluster) {
@@ -630,7 +630,7 @@ func (suite *ruleTestSuite) checkDelete(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestBatch() {
-	suite.env.RunTestInTwoModes(suite.checkBatch)
+	suite.env.RunTestBasedOnMode(suite.checkBatch)
 }
 
 func (suite *ruleTestSuite) checkBatch(cluster *tests.TestCluster) {
@@ -759,7 +759,7 @@ func (suite *ruleTestSuite) checkBatch(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestBundle() {
-	suite.env.RunTestInTwoModes(suite.checkBundle)
+	suite.env.RunTestBasedOnMode(suite.checkBundle)
 }
 
 func (suite *ruleTestSuite) checkBundle(cluster *tests.TestCluster) {
@@ -869,7 +869,7 @@ func (suite *ruleTestSuite) checkBundle(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestBundleBadRequest() {
-	suite.env.RunTestInTwoModes(suite.checkBundleBadRequest)
+	suite.env.RunTestBasedOnMode(suite.checkBundleBadRequest)
 }
 
 func (suite *ruleTestSuite) checkBundleBadRequest(cluster *tests.TestCluster) {
@@ -900,7 +900,7 @@ func (suite *ruleTestSuite) checkBundleBadRequest(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestLeaderAndVoter() {
-	suite.env.RunTestInTwoModes(suite.checkLeaderAndVoter)
+	suite.env.RunTestBasedOnMode(suite.checkLeaderAndVoter)
 }
 
 func (suite *ruleTestSuite) checkLeaderAndVoter(cluster *tests.TestCluster) {
@@ -997,7 +997,7 @@ func (suite *ruleTestSuite) checkLeaderAndVoter(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestDeleteAndUpdate() {
-	suite.env.RunTestInTwoModes(suite.checkDeleteAndUpdate)
+	suite.env.RunTestBasedOnMode(suite.checkDeleteAndUpdate)
 }
 
 func (suite *ruleTestSuite) checkDeleteAndUpdate(cluster *tests.TestCluster) {
@@ -1078,7 +1078,7 @@ func (suite *ruleTestSuite) checkDeleteAndUpdate(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestConcurrency() {
-	suite.env.RunTestInTwoModes(suite.checkConcurrency)
+	suite.env.RunTestBasedOnMode(suite.checkConcurrency)
 }
 
 func (suite *ruleTestSuite) checkConcurrency(cluster *tests.TestCluster) {
@@ -1167,7 +1167,7 @@ func (suite *ruleTestSuite) checkConcurrencyWith(cluster *tests.TestCluster,
 }
 
 func (suite *ruleTestSuite) TestLargeRules() {
-	suite.env.RunTestInTwoModes(suite.checkLargeRules)
+	suite.env.RunTestBasedOnMode(suite.checkLargeRules)
 }
 
 func (suite *ruleTestSuite) checkLargeRules(cluster *tests.TestCluster) {
@@ -1296,7 +1296,7 @@ func (suite *regionRuleTestSuite) TearDownSuite() {
 }
 
 func (suite *regionRuleTestSuite) TestRegionPlacementRule() {
-	suite.env.RunTestInTwoModes(suite.checkRegionPlacementRule)
+	suite.env.RunTestBasedOnMode(suite.checkRegionPlacementRule)
 }
 
 func (suite *regionRuleTestSuite) checkRegionPlacementRule(cluster *tests.TestCluster) {

--- a/tests/server/api/scheduler_test.go
+++ b/tests/server/api/scheduler_test.go
@@ -72,7 +72,7 @@ func (suite *scheduleTestSuite) TearDownSuite() {
 }
 
 func (suite *scheduleTestSuite) TestOriginAPI() {
-	suite.env.RunTestInTwoModes(suite.checkOriginAPI)
+	suite.env.RunTestBasedOnMode(suite.checkOriginAPI)
 }
 
 func (suite *scheduleTestSuite) checkOriginAPI(cluster *tests.TestCluster) {
@@ -140,7 +140,7 @@ func (suite *scheduleTestSuite) checkOriginAPI(cluster *tests.TestCluster) {
 }
 
 func (suite *scheduleTestSuite) TestAPI() {
-	suite.env.RunTestInTwoModes(suite.checkAPI)
+	suite.env.RunTestBasedOnMode(suite.checkAPI)
 }
 
 func (suite *scheduleTestSuite) checkAPI(cluster *tests.TestCluster) {
@@ -626,7 +626,7 @@ func (suite *scheduleTestSuite) checkAPI(cluster *tests.TestCluster) {
 }
 
 func (suite *scheduleTestSuite) TestDisable() {
-	suite.env.RunTestInTwoModes(suite.checkDisable)
+	suite.env.RunTestBasedOnMode(suite.checkDisable)
 }
 
 func (suite *scheduleTestSuite) checkDisable(cluster *tests.TestCluster) {
@@ -734,7 +734,7 @@ func (suite *scheduleTestSuite) testPauseOrResume(re *require.Assertions, urlPre
 }
 
 func (suite *scheduleTestSuite) TestEmptySchedulers() {
-	suite.env.RunTestInTwoModes(suite.checkEmptySchedulers)
+	suite.env.RunTestBasedOnMode(suite.checkEmptySchedulers)
 }
 
 func (suite *scheduleTestSuite) checkEmptySchedulers(cluster *tests.TestCluster) {

--- a/tests/server/api/scheduler_test.go
+++ b/tests/server/api/scheduler_test.go
@@ -40,11 +40,20 @@ const apiPrefix = "/pd"
 
 type scheduleTestSuite struct {
 	suite.Suite
-	env *tests.SchedulingTestEnvironment
+	env     *tests.SchedulingTestEnvironment
+	runMode tests.SchedulerMode
 }
 
-func TestScheduleTestSuite(t *testing.T) {
-	suite.Run(t, new(scheduleTestSuite))
+func TestPDSchedulingTestSuite(t *testing.T) {
+	suite.Run(t, &scheduleTestSuite{
+		runMode: tests.PDMode,
+	})
+}
+
+func TestAPISchedulingTestSuite(t *testing.T) {
+	suite.Run(t, &scheduleTestSuite{
+		runMode: tests.APIMode,
+	})
 }
 
 func (suite *scheduleTestSuite) SetupSuite() {
@@ -52,6 +61,7 @@ func (suite *scheduleTestSuite) SetupSuite() {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/changeCoordinatorTicker", `return(true)`))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/skipStoreConfigSync", `return(true)`))
 	suite.env = tests.NewSchedulingTestEnvironment(suite.T())
+	suite.env.RunMode = suite.runMode
 }
 
 func (suite *scheduleTestSuite) TearDownSuite() {

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -91,7 +91,7 @@ func (suite *configTestSuite) TearDownSuite() {
 }
 
 func (suite *configTestSuite) TestConfigAll() {
-	suite.env.RunTestInTwoModes(suite.checkConfigAll)
+	suite.env.RunTestBasedOnMode(suite.checkConfigAll)
 }
 
 func (suite *configTestSuite) checkConfigAll(cluster *tests.TestCluster) {
@@ -212,7 +212,7 @@ func (suite *configTestSuite) checkConfigAll(cluster *tests.TestCluster) {
 }
 
 func (suite *configTestSuite) TestConfigSchedule() {
-	suite.env.RunTestInTwoModes(suite.checkConfigSchedule)
+	suite.env.RunTestBasedOnMode(suite.checkConfigSchedule)
 }
 
 func (suite *configTestSuite) checkConfigSchedule(cluster *tests.TestCluster) {
@@ -238,7 +238,7 @@ func (suite *configTestSuite) checkConfigSchedule(cluster *tests.TestCluster) {
 }
 
 func (suite *configTestSuite) TestConfigReplication() {
-	suite.env.RunTestInTwoModes(suite.checkConfigReplication)
+	suite.env.RunTestBasedOnMode(suite.checkConfigReplication)
 }
 
 func (suite *configTestSuite) checkConfigReplication(cluster *tests.TestCluster) {
@@ -281,7 +281,7 @@ func (suite *configTestSuite) checkConfigReplication(cluster *tests.TestCluster)
 }
 
 func (suite *configTestSuite) TestConfigLabelProperty() {
-	suite.env.RunTestInTwoModes(suite.checkConfigLabelProperty)
+	suite.env.RunTestBasedOnMode(suite.checkConfigLabelProperty)
 }
 
 func (suite *configTestSuite) checkConfigLabelProperty(cluster *tests.TestCluster) {
@@ -333,7 +333,7 @@ func (suite *configTestSuite) checkConfigLabelProperty(cluster *tests.TestCluste
 }
 
 func (suite *configTestSuite) TestConfigDefault() {
-	suite.env.RunTestInTwoModes(suite.checkConfigDefault)
+	suite.env.RunTestBasedOnMode(suite.checkConfigDefault)
 }
 
 func (suite *configTestSuite) checkConfigDefault(cluster *tests.TestCluster) {
@@ -377,7 +377,7 @@ func (suite *configTestSuite) checkConfigDefault(cluster *tests.TestCluster) {
 }
 
 func (suite *configTestSuite) TestConfigPDServer() {
-	suite.env.RunTestInTwoModes(suite.checkConfigPDServer)
+	suite.env.RunTestBasedOnMode(suite.checkConfigPDServer)
 }
 
 func (suite *configTestSuite) checkConfigPDServer(cluster *tests.TestCluster) {
@@ -507,7 +507,7 @@ func createTTLUrl(url string, ttl int) string {
 }
 
 func (suite *configTestSuite) TestConfigTTL() {
-	suite.env.RunTestInTwoModes(suite.checkConfigTTL)
+	suite.env.RunTestBasedOnMode(suite.checkConfigTTL)
 }
 
 func (suite *configTestSuite) checkConfigTTL(cluster *tests.TestCluster) {
@@ -568,7 +568,7 @@ func (suite *configTestSuite) checkConfigTTL(cluster *tests.TestCluster) {
 }
 
 func (suite *configTestSuite) TestTTLConflict() {
-	suite.env.RunTestInTwoModes(suite.checkTTLConflict)
+	suite.env.RunTestBasedOnMode(suite.checkTTLConflict)
 }
 
 func (suite *configTestSuite) checkTTLConflict(cluster *tests.TestCluster) {

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -283,19 +283,21 @@ func MustReportBuckets(re *require.Assertions, cluster *TestCluster, regionID ui
 	return buckets
 }
 
-type mode int
+type SchedulerMode int
 
 const (
-	pdMode mode = iota
-	apiMode
+	Both SchedulerMode = iota
+	PDMode
+	APIMode
 )
 
 // SchedulingTestEnvironment is used for test purpose.
 type SchedulingTestEnvironment struct {
 	t        *testing.T
 	opts     []ConfigOption
-	clusters map[mode]*TestCluster
+	clusters map[SchedulerMode]*TestCluster
 	cancels  []context.CancelFunc
+	RunMode  SchedulerMode
 }
 
 // NewSchedulingTestEnvironment is to create a new SchedulingTestEnvironment.
@@ -303,24 +305,30 @@ func NewSchedulingTestEnvironment(t *testing.T, opts ...ConfigOption) *Schedulin
 	return &SchedulingTestEnvironment{
 		t:        t,
 		opts:     opts,
-		clusters: make(map[mode]*TestCluster),
+		clusters: make(map[SchedulerMode]*TestCluster),
 		cancels:  make([]context.CancelFunc, 0),
 	}
 }
 
-// RunTestInTwoModes is to run test in two modes.
 func (s *SchedulingTestEnvironment) RunTestInTwoModes(test func(*TestCluster)) {
-	s.RunTestInPDMode(test)
-	s.RunTestInAPIMode(test)
+	switch s.RunMode {
+	case PDMode:
+		s.RunTestInPDMode(test)
+	case APIMode:
+		s.RunTestInAPIMode(test)
+	default:
+		s.RunTestInPDMode(test)
+		s.RunTestInAPIMode(test)
+	}
 }
 
 // RunTestInPDMode is to run test in pd mode.
 func (s *SchedulingTestEnvironment) RunTestInPDMode(test func(*TestCluster)) {
 	s.t.Logf("start test %s in pd mode", getTestName())
-	if _, ok := s.clusters[pdMode]; !ok {
-		s.startCluster(pdMode)
+	if _, ok := s.clusters[PDMode]; !ok {
+		s.startCluster(PDMode)
 	}
-	test(s.clusters[pdMode])
+	test(s.clusters[PDMode])
 }
 
 func getTestName() string {
@@ -347,18 +355,18 @@ func (s *SchedulingTestEnvironment) RunTestInAPIMode(test func(*TestCluster)) {
 		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/highFrequencyClusterJobs"))
 	}()
 	s.t.Logf("start test %s in api mode", getTestName())
-	if _, ok := s.clusters[apiMode]; !ok {
-		s.startCluster(apiMode)
+	if _, ok := s.clusters[APIMode]; !ok {
+		s.startCluster(APIMode)
 	}
-	test(s.clusters[apiMode])
+	test(s.clusters[APIMode])
 }
 
 // RunFuncInTwoModes is to run func in two modes.
 func (s *SchedulingTestEnvironment) RunFuncInTwoModes(f func(*TestCluster)) {
-	if c, ok := s.clusters[pdMode]; ok {
+	if c, ok := s.clusters[PDMode]; ok {
 		f(c)
 	}
-	if c, ok := s.clusters[apiMode]; ok {
+	if c, ok := s.clusters[APIMode]; ok {
 		f(c)
 	}
 }
@@ -373,12 +381,12 @@ func (s *SchedulingTestEnvironment) Cleanup() {
 	}
 }
 
-func (s *SchedulingTestEnvironment) startCluster(m mode) {
+func (s *SchedulingTestEnvironment) startCluster(m SchedulerMode) {
 	re := require.New(s.t)
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancels = append(s.cancels, cancel)
 	switch m {
-	case pdMode:
+	case PDMode:
 		cluster, err := NewTestCluster(ctx, 1, s.opts...)
 		re.NoError(err)
 		err = cluster.RunInitialServers()
@@ -386,8 +394,8 @@ func (s *SchedulingTestEnvironment) startCluster(m mode) {
 		re.NotEmpty(cluster.WaitLeader())
 		leaderServer := cluster.GetServer(cluster.GetLeader())
 		re.NoError(leaderServer.BootstrapCluster())
-		s.clusters[pdMode] = cluster
-	case apiMode:
+		s.clusters[PDMode] = cluster
+	case APIMode:
 		cluster, err := NewTestAPICluster(ctx, 1, s.opts...)
 		re.NoError(err)
 		err = cluster.RunInitialServers()
@@ -406,7 +414,7 @@ func (s *SchedulingTestEnvironment) startCluster(m mode) {
 		testutil.Eventually(re, func() bool {
 			return cluster.GetLeaderServer().GetServer().GetRaftCluster().IsServiceIndependent(utils.SchedulingServiceName)
 		})
-		s.clusters[apiMode] = cluster
+		s.clusters[APIMode] = cluster
 	}
 }
 

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -310,7 +310,9 @@ func NewSchedulingTestEnvironment(t *testing.T, opts ...ConfigOption) *Schedulin
 	}
 }
 
-func (s *SchedulingTestEnvironment) RunTestInTwoModes(test func(*TestCluster)) {
+// RunTestBasedOnMode runs test based on mode.
+// If mode not set, it will run test in both PD mode and API mode.
+func (s *SchedulingTestEnvironment) RunTestBasedOnMode(test func(*TestCluster)) {
 	switch s.RunMode {
 	case PDMode:
 		s.RunTestInPDMode(test)
@@ -334,7 +336,7 @@ func (s *SchedulingTestEnvironment) RunTestInPDMode(test func(*TestCluster)) {
 func getTestName() string {
 	pc, _, _, _ := runtime.Caller(2)
 	caller := runtime.FuncForPC(pc)
-	if caller == nil || strings.Contains(caller.Name(), "RunTestInTwoModes") {
+	if caller == nil || strings.Contains(caller.Name(), "RunTestBasedOnMode") {
 		pc, _, _, _ = runtime.Caller(3)
 		caller = runtime.FuncForPC(pc)
 	}

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -103,7 +103,7 @@ func (suite *configTestSuite) TearDownTest() {
 func (suite *configTestSuite) TestConfig() {
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/dashboard/adapter/skipDashboardLoop", `return(true)`))
-	suite.env.RunTestInTwoModes(suite.checkConfig)
+	suite.env.RunTestBasedOnMode(suite.checkConfig)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/dashboard/adapter/skipDashboardLoop"))
 }
 
@@ -348,7 +348,7 @@ func (suite *configTestSuite) checkConfig(cluster *pdTests.TestCluster) {
 func (suite *configTestSuite) TestConfigForwardControl() {
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/dashboard/adapter/skipDashboardLoop", `return(true)`))
-	suite.env.RunTestInTwoModes(suite.checkConfigForwardControl)
+	suite.env.RunTestBasedOnMode(suite.checkConfigForwardControl)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/dashboard/adapter/skipDashboardLoop"))
 }
 
@@ -547,7 +547,7 @@ func (suite *configTestSuite) checkConfigForwardControl(cluster *pdTests.TestClu
 }
 
 func (suite *configTestSuite) TestPlacementRules() {
-	suite.env.RunTestInTwoModes(suite.checkPlacementRules)
+	suite.env.RunTestBasedOnMode(suite.checkPlacementRules)
 }
 
 func (suite *configTestSuite) checkPlacementRules(cluster *pdTests.TestCluster) {
@@ -613,7 +613,7 @@ func (suite *configTestSuite) checkPlacementRules(cluster *pdTests.TestCluster) 
 }
 
 func (suite *configTestSuite) TestPlacementRuleGroups() {
-	suite.env.RunTestInTwoModes(suite.checkPlacementRuleGroups)
+	suite.env.RunTestBasedOnMode(suite.checkPlacementRuleGroups)
 }
 
 func (suite *configTestSuite) checkPlacementRuleGroups(cluster *pdTests.TestCluster) {
@@ -690,7 +690,7 @@ func (suite *configTestSuite) checkPlacementRuleGroups(cluster *pdTests.TestClus
 }
 
 func (suite *configTestSuite) TestPlacementRuleBundle() {
-	suite.env.RunTestInTwoModes(suite.checkPlacementRuleBundle)
+	suite.env.RunTestBasedOnMode(suite.checkPlacementRuleBundle)
 }
 
 func (suite *configTestSuite) checkPlacementRuleBundle(cluster *pdTests.TestCluster) {
@@ -933,7 +933,7 @@ func TestReplicationMode(t *testing.T) {
 }
 
 func (suite *configTestSuite) TestUpdateDefaultReplicaConfig() {
-	suite.env.RunTestInTwoModes(suite.checkUpdateDefaultReplicaConfig)
+	suite.env.RunTestBasedOnMode(suite.checkUpdateDefaultReplicaConfig)
 }
 
 func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.TestCluster) {
@@ -1082,7 +1082,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 }
 
 func (suite *configTestSuite) TestPDServerConfig() {
-	suite.env.RunTestInTwoModes(suite.checkPDServerConfig)
+	suite.env.RunTestBasedOnMode(suite.checkPDServerConfig)
 }
 
 func (suite *configTestSuite) checkPDServerConfig(cluster *pdTests.TestCluster) {
@@ -1115,7 +1115,7 @@ func (suite *configTestSuite) checkPDServerConfig(cluster *pdTests.TestCluster) 
 }
 
 func (suite *configTestSuite) TestMicroServiceConfig() {
-	suite.env.RunTestInTwoModes(suite.checkMicroServiceConfig)
+	suite.env.RunTestBasedOnMode(suite.checkMicroServiceConfig)
 }
 
 func (suite *configTestSuite) checkMicroServiceConfig(cluster *pdTests.TestCluster) {
@@ -1145,7 +1145,7 @@ func (suite *configTestSuite) checkMicroServiceConfig(cluster *pdTests.TestClust
 }
 
 func (suite *configTestSuite) TestRegionRules() {
-	suite.env.RunTestInTwoModes(suite.checkRegionRules)
+	suite.env.RunTestBasedOnMode(suite.checkRegionRules)
 }
 
 func (suite *configTestSuite) checkRegionRules(cluster *pdTests.TestCluster) {

--- a/tools/pd-ctl/tests/hot/hot_test.go
+++ b/tools/pd-ctl/tests/hot/hot_test.go
@@ -75,7 +75,7 @@ func (suite *hotTestSuite) TearDownTest() {
 }
 
 func (suite *hotTestSuite) TestHot() {
-	suite.env.RunTestInTwoModes(suite.checkHot)
+	suite.env.RunTestBasedOnMode(suite.checkHot)
 }
 
 func (suite *hotTestSuite) checkHot(cluster *pdTests.TestCluster) {
@@ -245,7 +245,7 @@ func (suite *hotTestSuite) checkHot(cluster *pdTests.TestCluster) {
 }
 
 func (suite *hotTestSuite) TestHotWithStoreID() {
-	suite.env.RunTestInTwoModes(suite.checkHotWithStoreID)
+	suite.env.RunTestBasedOnMode(suite.checkHotWithStoreID)
 }
 
 func (suite *hotTestSuite) checkHotWithStoreID(cluster *pdTests.TestCluster) {
@@ -312,7 +312,7 @@ func (suite *hotTestSuite) checkHotWithStoreID(cluster *pdTests.TestCluster) {
 }
 
 func (suite *hotTestSuite) TestHotWithoutHotPeer() {
-	suite.env.RunTestInTwoModes(suite.checkHotWithoutHotPeer)
+	suite.env.RunTestBasedOnMode(suite.checkHotWithoutHotPeer)
 }
 
 func (suite *hotTestSuite) checkHotWithoutHotPeer(cluster *pdTests.TestCluster) {

--- a/tools/pd-ctl/tests/operator/operator_test.go
+++ b/tools/pd-ctl/tests/operator/operator_test.go
@@ -57,7 +57,7 @@ func (suite *operatorTestSuite) TearDownSuite() {
 }
 
 func (suite *operatorTestSuite) TestOperator() {
-	suite.env.RunTestInTwoModes(suite.checkOperator)
+	suite.env.RunTestBasedOnMode(suite.checkOperator)
 }
 
 func (suite *operatorTestSuite) checkOperator(cluster *pdTests.TestCluster) {

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -99,7 +99,7 @@ func (suite *schedulerTestSuite) TearDownTest() {
 }
 
 func (suite *schedulerTestSuite) TestScheduler() {
-	suite.env.RunTestInTwoModes(suite.checkScheduler)
+	suite.env.RunTestBasedOnMode(suite.checkScheduler)
 }
 
 func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
@@ -392,7 +392,7 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 }
 
 func (suite *schedulerTestSuite) TestSchedulerConfig() {
-	suite.env.RunTestInTwoModes(suite.checkSchedulerConfig)
+	suite.env.RunTestBasedOnMode(suite.checkSchedulerConfig)
 }
 
 func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestCluster) {
@@ -558,7 +558,7 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 }
 
 func (suite *schedulerTestSuite) TestHotRegionSchedulerConfig() {
-	suite.env.RunTestInTwoModes(suite.checkHotRegionSchedulerConfig)
+	suite.env.RunTestBasedOnMode(suite.checkHotRegionSchedulerConfig)
 }
 
 func (suite *schedulerTestSuite) checkHotRegionSchedulerConfig(cluster *pdTests.TestCluster) {
@@ -725,7 +725,7 @@ func (suite *schedulerTestSuite) checkHotRegionSchedulerConfig(cluster *pdTests.
 }
 
 func (suite *schedulerTestSuite) TestSchedulerDiagnostic() {
-	suite.env.RunTestInTwoModes(suite.checkSchedulerDiagnostic)
+	suite.env.RunTestBasedOnMode(suite.checkSchedulerDiagnostic)
 }
 
 func (suite *schedulerTestSuite) checkSchedulerDiagnostic(cluster *pdTests.TestCluster) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

accelerate pd-ut, for now all tests can be executed in 5min

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

### What is changed and how does it work?

- enable `race`
- divide unit test/tests/tso integration test into 2 parts respectively
- accelerate the build process by concurrency
- add `junitfile` in ci to indicate test time

<img width="1494" alt="image" src="https://github.com/tikv/pd/assets/53859786/cf78b353-60d4-4f9c-9059-d5a1e0963038">

check junitfile

<img width="649" alt="image" src="https://github.com/tikv/pd/assets/53859786/44fd654f-b3ee-4c97-a57b-d1e68069c545">


<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
