### PR TITLE
resourcemanager: make TestResourceManagerServer more stable

### DIFF
--- a/tests/integrations/mcs/resourcemanager/server_test.go
+++ b/tests/integrations/mcs/resourcemanager/server_test.go
@@ -25,6 +25,7 @@ import (
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/client/grpcutil"
+	bs "github.com/tikv/pd/pkg/basicserver"
 	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/versioninfo"
 	"github.com/tikv/pd/tests"
@@ -49,6 +50,7 @@ func TestResourceManagerServer(t *testing.T) {
 	s, cleanup := tests.StartSingleResourceManagerTestServer(ctx, re, leader.GetAddr(), tempurl.Alloc())
 	addr := s.GetAddr()
 	defer cleanup()
+	tests.WaitForPrimaryServing(re, map[string]bs.Server{addr: s})
 
 	// Test registered GRPC Service
 	cc, err := grpcutil.GetClientConn(ctx, addr, nil)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8417

### What is changed and how does it work?

```bash
2024-07-18T08:30:29.5157887Z --- FAIL: TestResourceManagerServer (2.97s)
2024-07-18T08:30:29.5158616Z     server_test.go:62: 
2024-07-18T08:30:29.5160011Z         	Error Trace:	/home/runner/work/pd/pd/tests/integrations/mcs/resourcemanager/server_test.go:62
2024-07-18T08:30:29.5162038Z         	Error:      	Error "rpc error: code = Unavailable desc = not leader" does not contain "resource group not found"
2024-07-18T08:30:29.5163328Z         	Test:       	TestResourceManagerServer
2024-07-18T08:30:29.5163912Z FAIL
```
checked by https://github.com/tikv/pd/blob/e7c9d1514bd385d045b14aae4b51c1aec51be3aa/pkg/mcs/resourcemanager/server/grpc_service.go#L89-L94

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
