### PR TITLE
tools/ut: add -v to help diagnose

### DIFF
--- a/tools/pd-ut/ut.go
+++ b/tools/pd-ut/ut.go
@@ -679,6 +679,8 @@ func (*numa) testCommand(pkg string, fn string) *exec.Cmd {
 		tmpFile := path.Join(coverFileTempDir, fileName)
 		args = append(args, "-test.coverprofile", tmpFile)
 	}
+	// let the test run in the verbose mode.
+	args = append(args, "-test.v")
 	if strings.Contains(fn, "Suite") {
 		args = append(args, "-test.cpu", fmt.Sprint(parallel/2))
 	} else {

--- a/tools/pd-ut/ut.go
+++ b/tools/pd-ut/ut.go
@@ -673,14 +673,14 @@ func failureCases(input []JUnitTestCase) int {
 
 func (*numa) testCommand(pkg string, fn string) *exec.Cmd {
 	args := make([]string, 0, 10)
+	// let the test run in the verbose mode.
+	args = append(args, "-test.v")
 	exe := "./" + testFileName(pkg)
 	if coverProfile != "" {
 		fileName := strings.ReplaceAll(pkg, "/", "_") + "." + fn
 		tmpFile := path.Join(coverFileTempDir, fileName)
 		args = append(args, "-test.coverprofile", tmpFile)
 	}
-	// let the test run in the verbose mode.
-	args = append(args, "-test.v")
 	if strings.Contains(fn, "Suite") {
 		args = append(args, "-test.cpu", fmt.Sprint(parallel/2))
 	} else {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

before, The error message will appear at the very end
<img width="752" alt="image" src="https://github.com/user-attachments/assets/7c94cb50-62ae-47b9-9f64-af411a5c1a11">
We'd prefer to have the error message appear immediately so that it's easy to know the event clearly.

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #7969

### What is changed and how does it work?

When meet error in the test, let the error message appear immediately so that it's easy to know the event clearly.
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/7dd8b1a4-a3d3-4fa2-8e46-cec54972ea28">



<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
