### PR TITLE
client/http: fix the URI of GetRegionLabelRulesByIDs

### DIFF
--- a/client/http/interface.go
+++ b/client/http/interface.go
@@ -715,7 +715,7 @@ func (c *client) GetRegionLabelRulesByIDs(ctx context.Context, ruleIDs []string)
 	var labelRules []*LabelRule
 	err = c.request(ctx, newRequestInfo().
 		WithName(getRegionLabelRulesByIDsName).
-		WithURI(RegionLabelRules).
+		WithURI(RegionLabelRulesByIDs).
 		WithMethod(http.MethodGet).
 		WithBody(idsJSON).
 		WithResp(&labelRules))

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -440,6 +440,10 @@ func (suite *httpClientTestSuite) TestRegionLabel() {
 	re.Equal(labelRule.ID, allLabelRules[1].ID)
 	re.Equal(labelRule.Labels, allLabelRules[1].Labels)
 	re.Equal(labelRule.RuleType, allLabelRules[1].RuleType)
+	labelRules, err = client.GetRegionLabelRulesByIDs(ctx, []string{"rule2"})
+	re.NoError(err)
+	re.Len(labelRules, 1)
+	re.Equal(labelRule, labelRules[0])
 	labelRules, err = client.GetRegionLabelRulesByIDs(ctx, []string{"keyspaces/0", "rule2"})
 	re.NoError(err)
 	sort.Slice(labelRules, func(i, j int) bool {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #8491, ref https://github.com/pingcap/tidb/issues/55188.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Fix the URI of `GetRegionLabelRulesByIDs` to correct the call.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
