### PR TITLE
*: not use a fixed port number

### DIFF
--- a/tools/pd-ut/alloc/server.go
+++ b/tools/pd-ut/alloc/server.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var statusAddress = flag.String("status-addr", "0.0.0.0:20180", "status address")
+var statusAddress = flag.String("status-addr", "0.0.0.0:0", "status address")
 
 func RunHTTPServer() *http.Server {
 	err := os.Setenv(tempurl.AllocURLFromUT, fmt.Sprintf("http://%s/alloc", *statusAddress))


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7969 

### What is changed and how does it work?

To fix the following error:
```
$ make ut
cd tools && GOEXPERIMENT= CGO_ENABLED=0 go build -tags xprog -gcflags '' -ldflags '-X "github.com/tikv/pd/pkg/versioninfo.PDReleaseVersion=v8.3.0-alpha-26-g80f74bfc3" -X "github.com/tikv/pd/pkg/versioninfo.PDBuildTS=2024-08-08 07:31:05" -X "github.com/tikv/pd/pkg/versioninfo.PDGitHash=80f74bfc3af5e18b368134d8ed96f2a7c13ca33c" -X "github.com/tikv/pd/pkg/versioninfo.PDGitBranch=leak" -X "github.com/tikv/pd/pkg/versioninfo.PDEdition=Community" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.InternalVersion=8.3.0-e6e78c7c" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.Standalone=No" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.PDVersion=v8.3.0-alpha-26-g80f74bfc3" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildTime=2024-08-08 07:31:05" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildGitHash=e6e78c7c120b"' -o /data/nvme0n1/ryan/workspace/pd/bin/xprog pd-ut/xprog.go
cd tools && GOEXPERIMENT= CGO_ENABLED=0 go build -gcflags '' -ldflags '-X "github.com/tikv/pd/pkg/versioninfo.PDReleaseVersion=v8.3.0-alpha-26-g80f74bfc3" -X "github.com/tikv/pd/pkg/versioninfo.PDBuildTS=2024-08-08 07:31:06" -X "github.com/tikv/pd/pkg/versioninfo.PDGitHash=80f74bfc3af5e18b368134d8ed96f2a7c13ca33c" -X "github.com/tikv/pd/pkg/versioninfo.PDGitBranch=leak" -X "github.com/tikv/pd/pkg/versioninfo.PDEdition=Community" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.InternalVersion=8.3.0-e6e78c7c" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.Standalone=No" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.PDVersion=v8.3.0-alpha-26-g80f74bfc3" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildTime=2024-08-08 07:31:06" -X "github.com/pingcap/tidb-dashboard/pkg/utils/version.BuildGitHash=e6e78c7c120b"' -o /data/nvme0n1/ryan/workspace/pd/bin/pd-ut pd-ut/ut.go pd-ut/coverProfile.go
# only run unit tests
./bin/pd-ut run --ignore tests --race --junitfile ./junitfile
2024/08/08 15:31:10 maxprocs: Leaving GOMAXPROCS=72: CPU quota undefined
[2024/08/08 15:31:10.938 +08:00] [FATAL] [server.go:51] ["server listen error"] [error="listen tcp 0.0.0.0:20180: bind: address already in use"] [stack="github.com/tikv/pd/tools/pd-ut/alloc.RunHTTPServer.func2\n\t/data/nvme0n1/ryan/workspace/pd/tools/pd-ut/alloc/server.go:51"]
make: *** [Makefile:231: ut] Error 1
```

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- No code

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
