### PR TITLE
Revert "*: enlarge the default value of `max-merge-region-size`. (#8445)"

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -111,9 +111,9 @@
 
 [schedule]
 ## Controls the size limit of Region Merge.
-# max-merge-region-size = 54
+# max-merge-region-size = 20
 ## Specifies the upper limit of the Region Merge key.
-# max-merge-region-keys = 540000
+# max-merge-region-keys = 200000
 ## Controls the time interval between the split and merge operations on the same Region.
 # split-merge-interval = "1h"
 ## When PD fails to receive the heartbeat from a store after the specified period of time,

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -28,13 +28,10 @@ import (
 
 const (
 	// DefaultMaxReplicas is the default number of replicas for each region.
-	DefaultMaxReplicas         = 3
-	defaultMaxSnapshotCount    = 64
-	defaultMaxPendingPeerCount = 64
-	// defaultMaxMergeRegionSize is the default maximum size of region when regions can be merged.
-	// After https://github.com/tikv/tikv/issues/17309, the default value is enlarged from 20 to 54,
-	// to make it compatible with the default value of region size of tikv.
-	defaultMaxMergeRegionSize     = 54
+	DefaultMaxReplicas            = 3
+	defaultMaxSnapshotCount       = 64
+	defaultMaxPendingPeerCount    = 64
+	defaultMaxMergeRegionSize     = 20
 	defaultLeaderScheduleLimit    = 4
 	defaultRegionScheduleLimit    = 2048
 	defaultWitnessScheduleLimit   = 4

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -180,11 +180,9 @@ func (suite *configTestSuite) checkConfig(cluster *pdTests.TestCluster) {
 	scheduleConfig.MaxMergeRegionKeys = scheduleConfig.GetMaxMergeRegionKeys()
 	re.Equal(scheduleConfig, &scheduleCfg)
 
-	// After https://github.com/tikv/tikv/issues/17309, the default value is enlarged from 20 to 54,
-	// to make it compatible with the default value of region size of tikv.
-	re.Equal(54, int(svr.GetScheduleConfig().MaxMergeRegionSize))
+	re.Equal(20, int(svr.GetScheduleConfig().MaxMergeRegionSize))
 	re.Equal(0, int(svr.GetScheduleConfig().MaxMergeRegionKeys))
-	re.Equal(54*10000, int(svr.GetScheduleConfig().GetMaxMergeRegionKeys()))
+	re.Equal(20*10000, int(svr.GetScheduleConfig().GetMaxMergeRegionKeys()))
 
 	// set max-merge-region-size to 40MB
 	args = []string{"-u", pdAddr, "config", "set", "max-merge-region-size", "40"}

--- a/tools/pd-ctl/tests/region/region_test.go
+++ b/tools/pd-ctl/tests/region/region_test.go
@@ -142,7 +142,7 @@ func TestRegion(t *testing.T) {
 		// region check empty-region command
 		{[]string{"region", "check", "empty-region"}, []*core.RegionInfo{r1}},
 		// region check undersized-region command
-		{[]string{"region", "check", "undersized-region"}, []*core.RegionInfo{r1, r3, r4}},
+		{[]string{"region", "check", "undersized-region"}, []*core.RegionInfo{r1, r4}},
 		// region check oversized-region command
 		{[]string{"region", "check", "oversized-region"}, []*core.RegionInfo{r2}},
 		// region keys --format=raw <start_key> <end_key> <limit> command


### PR DESCRIPTION
This reverts commit aa85b6c0047b0f2af37c1bd271ee194af1c0dd56.

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/pingcap/tidb/issues/55374

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Revert the changes on the configuration of region-size. These changes will be delayed until v8.4.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
