### PR TITLE
chore(dashboard): update TiDB Dashboard to v8.4.0-6a0d342d [master]

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -204,6 +204,9 @@
 ## When enabled, usage data will be sent to PingCAP for improving user experience.
 # enable-telemetry = false
 
+## When enabled, configuring a custom prometheus address through Dashboard will not be allowed.
+# disable-custom-prom-addr = false
+
 [keyspace]
 ## pre-alloc is used to pre-allocate keyspaces during pd bootstrap.
 ## Its value should be a list of strings, denoting the name of the keyspaces.

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20240716095229-5f7ffec83ea7
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c
+	github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.51.1
 	github.com/sasha-s/go-deadlock v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20240716095229-5f7ffec83ea7
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6
+	github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.51.1
 	github.com/sasha-s/go-deadlock v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c h1:iiVpATdlLLr0NEgKZu+ZnBuYR4J8IgjNE1hNMjMOkYY=
-github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
+github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 h1:cdSpHzMC2gwz26I2svwKLATJuuW7ynW9F2qC12wce1g=
+github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 h1:cdSpHzMC2gwz26I2svwKLATJuuW7ynW9F2qC12wce1g=
-github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
+github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c h1:+0Tl9izTX2X5cy4wO4cbvjjsg8LqKpHdH5bEMv7pTb4=
+github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/pkg/dashboard/adapter/config.go
+++ b/pkg/dashboard/adapter/config.go
@@ -35,6 +35,7 @@ func GenDashboardConfig(srv *server.Server) (*config.Config, error) {
 	dashboardCfg.PublicPathPrefix = cfg.Dashboard.PublicPathPrefix
 	dashboardCfg.EnableTelemetry = cfg.Dashboard.EnableTelemetry
 	dashboardCfg.EnableExperimental = cfg.Dashboard.EnableExperimental
+	dashboardCfg.DisableCustomPromAddr = cfg.Dashboard.DisableCustomPromAddr
 	if dashboardCfg.ClusterTLSConfig, err = cfg.Security.ToTLSConfig(); err != nil {
 		return nil, err
 	}

--- a/scripts/dashboard-version
+++ b/scripts/dashboard-version
@@ -1,3 +1,3 @@
 # This file is updated by running scripts/update-dashboard.sh
 # Don't edit it manually
-8.4.0-6a0d342d
+8.4.0-3d0c3db0

--- a/scripts/dashboard-version
+++ b/scripts/dashboard-version
@@ -1,3 +1,3 @@
 # This file is updated by running scripts/update-dashboard.sh
 # Don't edit it manually
-8.3.0-e6e78c7c
+8.4.0-6a0d342d

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -774,13 +774,14 @@ func (c *Config) GenEmbedEtcdConfig() (*embed.Config, error) {
 
 // DashboardConfig is the configuration for tidb-dashboard.
 type DashboardConfig struct {
-	TiDBCAPath         string `toml:"tidb-cacert-path" json:"tidb-cacert-path"`
-	TiDBCertPath       string `toml:"tidb-cert-path" json:"tidb-cert-path"`
-	TiDBKeyPath        string `toml:"tidb-key-path" json:"tidb-key-path"`
-	PublicPathPrefix   string `toml:"public-path-prefix" json:"public-path-prefix"`
-	InternalProxy      bool   `toml:"internal-proxy" json:"internal-proxy"`
-	EnableTelemetry    bool   `toml:"enable-telemetry" json:"enable-telemetry"`
-	EnableExperimental bool   `toml:"enable-experimental" json:"enable-experimental"`
+	TiDBCAPath            string `toml:"tidb-cacert-path" json:"tidb-cacert-path"`
+	TiDBCertPath          string `toml:"tidb-cert-path" json:"tidb-cert-path"`
+	TiDBKeyPath           string `toml:"tidb-key-path" json:"tidb-key-path"`
+	PublicPathPrefix      string `toml:"public-path-prefix" json:"public-path-prefix"`
+	InternalProxy         bool   `toml:"internal-proxy" json:"internal-proxy"`
+	EnableTelemetry       bool   `toml:"enable-telemetry" json:"enable-telemetry"`
+	EnableExperimental    bool   `toml:"enable-experimental" json:"enable-experimental"`
+	DisableCustomPromAddr bool   `toml:"disable-custom-prom-addr" json:"disable-custom-prom-addr"`
 }
 
 // ToTiDBTLSConfig generates tls config for connecting to TiDB, used by tidb-dashboard.

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -391,8 +391,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 h1:cdSpHzMC2gwz26I2svwKLATJuuW7ynW9F2qC12wce1g=
-github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
+github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c h1:+0Tl9izTX2X5cy4wO4cbvjjsg8LqKpHdH5bEMv7pTb4=
+github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -391,8 +391,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c h1:iiVpATdlLLr0NEgKZu+ZnBuYR4J8IgjNE1hNMjMOkYY=
-github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
+github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 h1:cdSpHzMC2gwz26I2svwKLATJuuW7ynW9F2qC12wce1g=
+github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -388,8 +388,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 h1:cdSpHzMC2gwz26I2svwKLATJuuW7ynW9F2qC12wce1g=
-github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
+github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c h1:+0Tl9izTX2X5cy4wO4cbvjjsg8LqKpHdH5bEMv7pTb4=
+github.com/pingcap/tidb-dashboard v0.0.0-20240830080600-3d0c3db0d55c/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -388,8 +388,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c h1:iiVpATdlLLr0NEgKZu+ZnBuYR4J8IgjNE1hNMjMOkYY=
-github.com/pingcap/tidb-dashboard v0.0.0-20240815045040-4d89bc193a0c/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
+github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6 h1:cdSpHzMC2gwz26I2svwKLATJuuW7ynW9F2qC12wce1g=
+github.com/pingcap/tidb-dashboard v0.0.0-20240828033147-6a0d342d71e6/go.mod h1:AT9vfeojwr/GGCHTURXtA8yZBE9AW8LdIo02/eYdfHU=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4257

Update TiDB Dashboard to [v8.4.0-6a0d342d](https://github.com/pingcap/tidb-dashboard/releases/tag/v8.4.0-6a0d342d).

### Release note

```release-note
None
```