### PR TITLE
client: Add benchmark for tsoStream and tsoDispatcher

### DIFF
--- a/client/tso_dispatcher_test.go
+++ b/client/tso_dispatcher_test.go
@@ -39,11 +39,11 @@ func (m *mockTSOServiceProvider) getOption() *option {
 	return m.option
 }
 
-func (m *mockTSOServiceProvider) getServiceDiscovery() ServiceDiscovery {
+func (*mockTSOServiceProvider) getServiceDiscovery() ServiceDiscovery {
 	return NewMockPDServiceDiscovery([]string{mockStreamURL}, nil)
 }
 
-func (m *mockTSOServiceProvider) updateConnectionCtxs(ctx context.Context, _dc string, connectionCtxs *sync.Map) bool {
+func (*mockTSOServiceProvider) updateConnectionCtxs(ctx context.Context, _dc string, connectionCtxs *sync.Map) bool {
 	_, ok := connectionCtxs.Load(mockStreamURL)
 	if ok {
 		return true

--- a/client/tso_dispatcher_test.go
+++ b/client/tso_dispatcher_test.go
@@ -1,0 +1,107 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pingcap/log"
+	"go.uber.org/zap/zapcore"
+)
+
+type mockTSOServiceProvider struct {
+	option *option
+}
+
+func newMockTSOServiceProvider(option *option) *mockTSOServiceProvider {
+	return &mockTSOServiceProvider{
+		option: option,
+	}
+}
+
+func (m *mockTSOServiceProvider) getOption() *option {
+	return m.option
+}
+
+func (m *mockTSOServiceProvider) getServiceDiscovery() ServiceDiscovery {
+	return NewMockPDServiceDiscovery([]string{mockStreamURL}, nil)
+}
+
+func (m *mockTSOServiceProvider) updateConnectionCtxs(ctx context.Context, _dc string, connectionCtxs *sync.Map) bool {
+	_, ok := connectionCtxs.Load(mockStreamURL)
+	if ok {
+		return true
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	stream := &tsoStream{
+		serverURL: mockStreamURL,
+		stream:    newMockTSOStreamImpl(ctx, true),
+	}
+	connectionCtxs.LoadOrStore(mockStreamURL, &tsoConnectionContext{ctx, cancel, mockStreamURL, stream})
+	return true
+}
+
+func BenchmarkTSODispatcherHandleRequests(b *testing.B) {
+	log.SetLevel(zapcore.FatalLevel)
+
+	ctx := context.Background()
+
+	reqPool := &sync.Pool{
+		New: func() any {
+			return &tsoRequest{
+				done:       make(chan error, 1),
+				physical:   0,
+				logical:    0,
+				dcLocation: globalDCLocation,
+			}
+		},
+	}
+	getReq := func() *tsoRequest {
+		req := reqPool.Get().(*tsoRequest)
+		req.clientCtx = ctx
+		req.requestCtx = ctx
+		req.physical = 0
+		req.logical = 0
+		req.start = time.Now()
+		req.pool = reqPool
+		return req
+	}
+
+	dispatcher := newTSODispatcher(ctx, globalDCLocation, defaultMaxTSOBatchSize, newMockTSOServiceProvider(newOption()))
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go dispatcher.handleDispatcher(&wg)
+	defer func() {
+		dispatcher.close()
+		wg.Wait()
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := getReq()
+		dispatcher.push(req)
+		_, _, err := req.Wait()
+		if err != nil {
+			panic(fmt.Sprintf("unexpected error from tsoReq: %+v", err))
+		}
+	}
+	// Don't count the time cost in `defer`
+	b.StopTimer()
+}

--- a/client/tso_stream_test.go
+++ b/client/tso_stream_test.go
@@ -118,7 +118,10 @@ func (s *mockTSOStreamImpl) Recv() (tsoRequestResult, error) {
 
 	if hasRes {
 		if res.breakStream {
-			s.errorState = s.ctx.Err()
+			if res.err == nil {
+				panic("breaking mockTSOStreamImpl without error")
+			}
+			s.errorState = res.err
 			return tsoRequestResult{}, s.errorState
 		} else {
 			// Do not allow manually assigning result.

--- a/client/tso_stream_test.go
+++ b/client/tso_stream_test.go
@@ -1,0 +1,188 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pd
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+const mockStreamURL = "mock:///"
+
+type requestMsg struct {
+	clusterID       uint64
+	keyspaceGroupID uint32
+	count           int64
+}
+
+type resultMsg struct {
+	r           tsoRequestResult
+	err         error
+	breakStream bool
+}
+
+type mockTSOStreamImpl struct {
+	ctx        context.Context
+	requestCh  chan requestMsg
+	resultCh   chan resultMsg
+	keyspaceID uint32
+	errorState error
+
+	autoGenerateResult bool
+	// Current progress of generating TSO results
+	resGenPhysical, resGenLogical int64
+}
+
+func newMockTSOStreamImpl(ctx context.Context, autoGenerateResult bool) *mockTSOStreamImpl {
+	return &mockTSOStreamImpl{
+		ctx:        ctx,
+		requestCh:  make(chan requestMsg, 64),
+		resultCh:   make(chan resultMsg, 64),
+		keyspaceID: 0,
+
+		autoGenerateResult: autoGenerateResult,
+		resGenPhysical:     10000,
+		resGenLogical:      0,
+	}
+}
+
+func (s *mockTSOStreamImpl) Send(clusterID uint64, _keyspaceID, keyspaceGroupID uint32, _dcLocation string, count int64) error {
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+	}
+	s.requestCh <- requestMsg{
+		clusterID:       clusterID,
+		keyspaceGroupID: keyspaceGroupID,
+		count:           count,
+	}
+	return nil
+}
+
+func (s *mockTSOStreamImpl) Recv() (ret tsoRequestResult, retErr error) {
+	// This stream have ever receive an error, it returns the error forever.
+	if s.errorState != nil {
+		return tsoRequestResult{}, s.errorState
+	}
+
+	select {
+	case <-s.ctx.Done():
+		s.errorState = s.ctx.Err()
+		return tsoRequestResult{}, s.errorState
+	default:
+	}
+
+	var res resultMsg
+	needGenRes := false
+	if s.autoGenerateResult {
+		select {
+		case res = <-s.resultCh:
+		default:
+			needGenRes = true
+		}
+	} else {
+		select {
+		case res = <-s.resultCh:
+		case <-s.ctx.Done():
+			s.errorState = s.ctx.Err()
+			return tsoRequestResult{}, s.errorState
+		}
+	}
+
+	if !res.breakStream {
+		var req requestMsg
+		select {
+		case req = <-s.requestCh:
+		case <-s.ctx.Done():
+			s.errorState = s.ctx.Err()
+			return tsoRequestResult{}, s.errorState
+		}
+		if needGenRes {
+
+			physical := s.resGenPhysical
+			logical := s.resGenLogical + req.count
+			if logical >= (1 << 18) {
+				physical += logical >> 18
+				logical &= (1 << 18) - 1
+			}
+
+			s.resGenPhysical = physical
+			s.resGenLogical = logical
+
+			res = resultMsg{
+				r: tsoRequestResult{
+					physical:            s.resGenPhysical,
+					logical:             s.resGenLogical,
+					count:               uint32(req.count),
+					suffixBits:          0,
+					respKeyspaceGroupID: 0,
+				},
+			}
+		}
+	}
+	if res.err != nil {
+		s.errorState = res.err
+	}
+	return res.r, res.err
+}
+
+func (s *mockTSOStreamImpl) returnResult(physical int64, logical int64, count uint32) {
+	s.resultCh <- resultMsg{
+		r: tsoRequestResult{
+			physical:            physical,
+			logical:             logical,
+			count:               count,
+			suffixBits:          0,
+			respKeyspaceGroupID: s.keyspaceID,
+		},
+	}
+}
+
+func (s *mockTSOStreamImpl) returnError(err error) {
+	s.resultCh <- resultMsg{
+		err: err,
+	}
+}
+
+func (s *mockTSOStreamImpl) breakStream(err error) {
+	s.resultCh <- resultMsg{
+		err:         err,
+		breakStream: true,
+	}
+}
+
+func (s *mockTSOStreamImpl) stop() {
+	s.breakStream(io.EOF)
+}
+
+func BenchmarkTSOStreamSendRecv(b *testing.B) {
+	streamInner := newMockTSOStreamImpl(context.Background(), true)
+	stream := tsoStream{
+		serverURL: mockStreamURL,
+		stream:    streamInner,
+	}
+	defer streamInner.stop()
+
+	now := time.Now()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _, _, _ = stream.processRequests(1, 1, 1, globalDCLocation, 1, now)
+	}
+	b.StopTimer()
+}

--- a/client/tso_stream_test.go
+++ b/client/tso_stream_test.go
@@ -123,11 +123,9 @@ func (s *mockTSOStreamImpl) Recv() (tsoRequestResult, error) {
 			}
 			s.errorState = res.err
 			return tsoRequestResult{}, s.errorState
-		} else {
+		} else if s.autoGenerateResult {
 			// Do not allow manually assigning result.
-			if s.autoGenerateResult {
-				panic("trying manually specifying result for mockTSOStreamImpl when it's auto-generating mode")
-			}
+			panic("trying manually specifying result for mockTSOStreamImpl when it's auto-generating mode")
 		}
 	} else if s.autoGenerateResult {
 		res = s.autoGenResult(req.count)
@@ -141,7 +139,8 @@ func (s *mockTSOStreamImpl) Recv() (tsoRequestResult, error) {
 			s.errorState = s.ctx.Err()
 			return tsoRequestResult{}, s.errorState
 		case req = <-s.requestCh:
-			hasReq = true
+			// Skip the assignment to make linter happy.
+			// hasReq = true
 		}
 	} else if !hasRes {
 		select {
@@ -149,7 +148,8 @@ func (s *mockTSOStreamImpl) Recv() (tsoRequestResult, error) {
 			s.errorState = s.ctx.Err()
 			return tsoRequestResult{}, s.errorState
 		case res = <-s.resultCh:
-			hasRes = true
+			// Skip the assignment to make linter happy.
+			// hasRes = true
 		}
 	}
 
@@ -182,6 +182,7 @@ func (s *mockTSOStreamImpl) autoGenResult(count int64) resultMsg {
 	}
 }
 
+// nolint:unused
 func (s *mockTSOStreamImpl) returnResult(physical int64, logical int64, count uint32) {
 	s.resultCh <- resultMsg{
 		r: tsoRequestResult{
@@ -194,12 +195,14 @@ func (s *mockTSOStreamImpl) returnResult(physical int64, logical int64, count ui
 	}
 }
 
+// nolint:unused
 func (s *mockTSOStreamImpl) returnError(err error) {
 	s.resultCh <- resultMsg{
 		err: err,
 	}
 }
 
+// nolint:unused
 func (s *mockTSOStreamImpl) breakStream(err error) {
 	s.resultCh <- resultMsg{
 		err:         err,


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #8432

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->


```commit-message
client: Add benchmark for tsoStream and tsoDispatcher
```


This PR adds some benchmarks that might be helpful for checking if there's any regression when working on #8432 .

### Current result:

```text
goos: linux
goarch: amd64
pkg: github.com/tikv/pd/client
cpu: Intel(R) Xeon(R) Silver 4214R CPU @ 2.40GHz
BenchmarkTSODispatcherHandleRequests-28           140149              7508 ns/op
BenchmarkTSOStreamSendRecv-28                    2788069               425.8 ns/op
PASS
ok      github.com/tikv/pd/client       2.796s
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
