### PR TITLE
client: Support both sync and async interface for tsoStream, to avoid potential performane regression when concurrent RPC is not enabled

### DIFF
--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -521,9 +521,8 @@ func (td *tsoDispatcher) processRequests(
 
 			td.cancelCollectedRequests(tbc, stream.streamID, err)
 			return false, err
-		} else {
-			return true, nil
 		}
+		return true, nil
 	} else {
 		result, err := stream.ProcessRequests(
 			clusterID, keyspaceID, reqKeyspaceGroupID, dcLocation, count, tbc.extraBatchingStartTime)


### PR DESCRIPTION


<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: 
 * Ref #8432 
 * Ref https://github.com/pingcap/tidb/issues/56103

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
client: Support both sync and async interface for tsoStream, to avoid potential performane regression when concurrent RPC is not enabled
```

The issue https://github.com/pingcap/tidb/issues/56103 reports a performance regression introduced by PR https://github.com/pingcap/tidb/pull/56093 , which introduces #8483 to TiDB.

It's reasonable that this PR does have risk to introduce performance regression in non-current mode (which would be default after finishing #8432). However:

* After I rerun the failed bisect task twice, both of these reruns failed to reproduce the regression.
* According to the previously done microbench (mentioned [here](https://github.com/tikv/pd/pull/8483#issuecomment-2345496796)), the additional overhead introduced by that PR should not be that much.

So I think the performance regression report looks quite doubtful.

Anyway, I still prepared this PR: the `tsoStream` provides both sync and async interface. When concurrent RPC is not enabled, the sync interface will be used, making the logic the same as that before merging #8483 .

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
