### PR TITLE
region: check if the query startkey and endkey specify an uncovered region

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1791,22 +1791,22 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 	end := &regionItem{&RegionInfo{meta: &metapb.Region{StartKey: endKey}}}
 
 	// check if both keys are in the uncovered ranges.
-	startItemt, startIndex := r.tree.tree.GetWithIndex(start)
-	endItemt, eit := r.tree.tree.GetWithIndex(end)
-	if startItemt == nil {
-		startItemt = r.tree.tree.GetAt(startIndex - 1)
+	startItem, startIndex := r.tree.tree.GetWithIndex(start)
+	endItem, eit := r.tree.tree.GetWithIndex(end)
+	if startItem == nil {
+		startItem = r.tree.tree.GetAt(startIndex - 1)
 	}
-	if endItemt == nil {
-		endItemt = r.tree.tree.GetAt(eit - 1)
+	if endItem == nil {
+		endItem = r.tree.tree.GetAt(eit - 1)
 	}
 
 	startInAnInterval := false
-	if startItemt != nil {
-		startInAnInterval = (bytes.Compare(startItemt.GetStartKey(), startKey) <= 0) && (bytes.Compare(startKey, startItemt.GetEndKey()) <= 0)
+	if startItem != nil {
+		startInAnInterval = (bytes.Compare(startItem.GetStartKey(), startKey) <= 0) && (bytes.Compare(startKey, startItem.GetEndKey()) <= 0)
 	}
 	endInAnInterval := false
-	if endItemt != nil {
-		endInAnInterval = (bytes.Compare(endItemt.GetStartKey(), endKey) <= 0) && (bytes.Compare(endKey, endItemt.GetEndKey()) <= 0)
+	if endItem != nil {
+		endInAnInterval = (bytes.Compare(endItem.GetStartKey(), endKey) <= 0) && (bytes.Compare(endKey, endItem.GetEndKey()) <= 0)
 	}
 	if startIndex == eit && (!startInAnInterval) && (!endInAnInterval) {
 		return 0

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1791,10 +1791,10 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 	end := &regionItem{&RegionInfo{meta: &metapb.Region{StartKey: endKey}}}
 
 	// check if both keys are in the uncovered ranges.
-	startItemt, sit := r.tree.tree.GetWithIndex(start)
+	startItemt, startIndex := r.tree.tree.GetWithIndex(start)
 	endItemt, eit := r.tree.tree.GetWithIndex(end)
 	if startItemt == nil {
-		startItemt = r.tree.tree.GetAt(sit - 1)
+		startItemt = r.tree.tree.GetAt(startIndex - 1)
 	}
 	if endItemt == nil {
 		endItemt = r.tree.tree.GetAt(eit - 1)
@@ -1808,12 +1808,10 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 	if endItemt != nil {
 		endInAnInterval = (bytes.Compare(endItemt.GetStartKey(), endKey) <= 0) && (bytes.Compare(endKey, endItemt.GetEndKey()) <= 0)
 	}
-	if sit == eit && (!startInAnInterval) && (!endInAnInterval) {
+	if startIndex == eit && (!startInAnInterval) && (!endInAnInterval) {
 		return 0
 	}
 
-	// it returns 0 if startKey is nil.
-	_, startIndex := r.tree.tree.GetWithIndex(start)
 	var endIndex int
 	var item *regionItem
 	// it should return the length of the tree if endKey is nil.

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1249,11 +1249,11 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol 
 
 // UpdateSubTree updates the subtree.
 func (r *RegionsInfo) UpdateSubTree(region, origin *RegionInfo, overlaps []*RegionInfo, rangeChanged bool) {
-	if _, _err_ := failpoint.Eval(_curpkg_("UpdateSubTree")); _err_ == nil {
+	failpoint.Inject("UpdateSubTree", func() {
 		if origin == nil {
 			time.Sleep(time.Second)
 		}
-	}
+	})
 	r.st.Lock()
 	defer r.st.Unlock()
 	if origin != nil {

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1791,12 +1791,12 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 	end := &regionItem{&RegionInfo{meta: &metapb.Region{StartKey: endKey}}}
 
 	// check if both keys are in the uncovered ranges.
-	startItem, startIndex := r.tree.tree.GetWithIndex(start)
+	startItem, sit := r.tree.tree.GetWithIndex(start)
 	endItem, eit := r.tree.tree.GetWithIndex(end)
 	if startItem == nil {
-		startItem = r.tree.tree.GetAt(startIndex - 1)
+		startItem = r.tree.tree.GetAt(sit - 1)
 	} else {
-		startIndex += 1
+		sit += 1
 	}
 	if endItem == nil {
 		endItem = r.tree.tree.GetAt(eit - 1)
@@ -1818,11 +1818,11 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 		eit = r.tree.tree.Len()
 		endInAnInterval = (bytes.Compare(endItem.GetEndKey(), endKey) <= 0) && (bytes.Compare(endKey, endItem.GetEndKey()) <= 0)
 	}
-
-	if startIndex == eit && (!startInAnInterval) && (!endInAnInterval) {
+	if sit == eit && (!startInAnInterval) && (!endInAnInterval) {
 		return 0
 	}
 
+	_, startIndex := r.tree.tree.GetWithIndex(start)
 	var endIndex int
 	var item *regionItem
 	// it should return the length of the tree if endKey is nil.
@@ -1835,7 +1835,6 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 			endIndex--
 		}
 	}
-
 	return endIndex - startIndex + 1
 }
 

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1816,7 +1816,10 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 	if len(endKey) == 0 {
 		endItem = r.tree.tree.GetAt(r.tree.tree.Len() - 1)
 		eit = r.tree.tree.Len()
-		endInAnInterval = (bytes.Compare(endItem.GetEndKey(), endKey) <= 0) && (bytes.Compare(endKey, endItem.GetEndKey()) <= 0)
+		endInAnInterval = false
+		if endItem != nil {
+			endInAnInterval = (bytes.Compare(endItem.GetEndKey(), endKey) <= 0) && (bytes.Compare(endKey, endItem.GetEndKey()) <= 0)
+		}
 	}
 	if sit == eit && (!startInAnInterval) && (!endInAnInterval) {
 		return 0

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -288,7 +288,7 @@ func TestRegionStatsHoles(t *testing.T) {
 	endKeys := [6]string{"e", "e", "i", "j", "", ""}
 	ans := [6]int{0, 1, 2, 1, 3, 0}
 
-	for i := 0; i < len(startKeys); i++ {
+	for i := range startKeys {
 		startKey := url.QueryEscape(startKeys[i])
 		endKey := url.QueryEscape(endKeys[i])
 		argsWithHoles := fmt.Sprintf("?start_key=%s&end_key=%s&count", startKey, endKey)

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -228,7 +228,7 @@ func TestRegionStatsHoles(t *testing.T) {
 		core.NewRegionInfo(
 			&metapb.Region{
 				Id:       1,
-				StartKey: []byte(""),
+				StartKey: []byte("-"),
 				EndKey:   []byte("c"),
 				Peers: []*metapb.Peer{
 					{Id: 101, StoreId: 1},
@@ -245,8 +245,8 @@ func TestRegionStatsHoles(t *testing.T) {
 		core.NewRegionInfo(
 			&metapb.Region{
 				Id:       2,
-				StartKey: []byte("h"),
-				EndKey:   []byte("x"),
+				StartKey: []byte("g"),
+				EndKey:   []byte("l"),
 				Peers: []*metapb.Peer{
 					{Id: 104, StoreId: 1},
 					{Id: 105, StoreId: 4},
@@ -262,8 +262,8 @@ func TestRegionStatsHoles(t *testing.T) {
 		core.NewRegionInfo(
 			&metapb.Region{
 				Id:       3,
-				StartKey: []byte("z"),
-				EndKey:   []byte(""),
+				StartKey: []byte("o"),
+				EndKey:   []byte("u"),
 				Peers: []*metapb.Peer{
 					{Id: 106, StoreId: 1},
 					{Id: 107, StoreId: 5},
@@ -282,13 +282,13 @@ func TestRegionStatsHoles(t *testing.T) {
 	}
 
 	// holes in between :
-	// | - c| ... |h - x| ... |z - |
+	// | - c| ... |g - l| ... |o - u| ...
 
-	startKeys := [4]string{"d", "b", "b", "i"}
-	endKeys := [4]string{"e", "e", "i", "j"}
-	ans := [4]int{0, 1, 2, 1}
+	startKeys := [6]string{"d", "b", "b", "i", "", "v"}
+	endKeys := [6]string{"e", "e", "i", "j", "", ""}
+	ans := [6]int{0, 1, 2, 1, 3, 0}
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < len(startKeys); i++ {
 		startKey := url.QueryEscape(startKeys[i])
 		endKey := url.QueryEscape(endKeys[i])
 		argsWithHoles := fmt.Sprintf("?start_key=%s&end_key=%s&count", startKey, endKey)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
when the query region [startKey, endKey] is an uncovered region, the function GetRegionCount now returns 0.

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #6711

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
