### PR TITLE
Add force option to "pd-ctl store delete" command

### DIFF
--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -60,20 +60,22 @@ func NewStoreCommand() *cobra.Command {
 // NewDeleteStoreByAddrCommand returns a subcommand of delete
 func NewDeleteStoreByAddrCommand() *cobra.Command {
 	d := &cobra.Command{
-		Use:   "addr <address>",
+		Use:   "addr <address> [flag]",
 		Short: "delete store by its address",
 		RunE:  deleteStoreCommandByAddrFunc,
 	}
+	d.Flags().BoolP("force", "f", false, "Set status to Tombstone directly")
 	return d
 }
 
 // NewDeleteStoreCommand return a delete subcommand of storeCmd
 func NewDeleteStoreCommand() *cobra.Command {
 	d := &cobra.Command{
-		Use:   "delete <store_id>",
+		Use:   "delete <store_id> [flag]",
 		Short: "delete the store",
 		Run:   deleteStoreCommandFunc,
 	}
+	d.Flags().BoolP("force", "f", false, "Set status to Tombstone directly")
 	d.AddCommand(NewDeleteStoreByAddrCommand())
 	return d
 }
@@ -319,6 +321,9 @@ func deleteStoreCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 	prefix := fmt.Sprintf(storePrefix, args[0])
+	if force, _ := cmd.Flags().GetBool("force"); force {
+		prefix += "?force=true"
+	}
 	_, err := doRequest(cmd, prefix, http.MethodDelete, http.Header{})
 	if err != nil {
 		cmd.Printf("Failed to delete store %s: %s\n", args[0], err)
@@ -334,6 +339,9 @@ func deleteStoreCommandByAddrFunc(cmd *cobra.Command, args []string) error {
 	}
 	// delete store by its ID
 	prefix := fmt.Sprintf(storePrefix, id)
+	if force, _ := cmd.Flags().GetBool("force"); force {
+		prefix += "?force=true"
+	}
 	_, err := doRequest(cmd, prefix, http.MethodDelete, http.Header{})
 	if err != nil {
 		return fmt.Errorf("failed to delete store %s: %s", args[0], err)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8878

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

Add `--force` option to `pd-ctl store delete` command.
Set status to Tombstone directly.
https://download.pingcap.com/pd-api-doc.html#store__storeid__delete

```commit-message
$ ./bin/pd-ctl store delete --help
delete the store

Usage:
  pd-ctl store delete <store_id> [flags]
  pd-ctl store delete [command]

Available Commands:
  addr        delete store by its address

Flags:
  -f, --force   Set status to Tombstone directly
  -h, --help    help for delete

Global Flags:
      --cacert string   path of file that contains list of trusted SSL CAs
      --cert string     path of file that contains X509 certificate in PEM format
      --key string      path of file that contains X509 key in PEM format
  -u, --pd string       address of PD (default "http://127.0.0.1:2379")

Use "pd-ctl store delete [command] --help" for more information about a command.
$
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
