### PR TITLE
fix `TestDisableSchedulingServiceFallback` flaky test 

### DIFF
--- a/client/circuitbreaker/circuit_breaker.go
+++ b/client/circuitbreaker/circuit_breaker.go
@@ -238,10 +238,10 @@ func (s *State[T]) onRequest(cb *CircuitBreaker[T]) (*State[T], error) {
 					observedErrorRatePct := s.failureCount * 100 / total
 					if total >= uint32(s.cb.config.ErrorRateWindow.Seconds())*s.cb.config.MinQPSForOpen && observedErrorRatePct >= s.cb.config.ErrorRateThresholdPct {
 						// the error threshold is breached, let's move to open state and start failing all requests
-						log.Error("Circuit breaker tripped. Starting to fail all requests",
+						log.Error("circuit breaker tripped and starting to fail all requests",
 							zap.String("name", cb.name),
-							zap.Uint32("observedErrorRatePct", observedErrorRatePct),
-							zap.String("config", fmt.Sprintf("%+v", cb.config)))
+							zap.Uint32("observed-err-rate-pct", observedErrorRatePct),
+							zap.Any("config", cb.config))
 						return cb.newState(now, StateOpen), errs.ErrCircuitBreakerOpen
 					}
 				}
@@ -255,27 +255,28 @@ func (s *State[T]) onRequest(cb *CircuitBreaker[T]) (*State[T], error) {
 	case StateOpen:
 		if now.After(s.end) {
 			// CoolDownInterval is over, it is time to transition to half-open state
-			log.Info("Circuit breaker cooldown period is over. Transitioning to half-open state to test the service",
+			log.Info("circuit breaker cooldown period is over. Transitioning to half-open state to test the service",
 				zap.String("name", cb.name),
-				zap.String("config", fmt.Sprintf("%+v", cb.config)))
+				zap.Any("config", cb.config))
 			return cb.newState(now, StateHalfOpen), nil
 		} else {
 			// continue in the open state till CoolDownInterval is over
 			return s, errs.ErrCircuitBreakerOpen
 		}
 	case StateHalfOpen:
+		fmt.Println("StateHalfOpen", s.failureCount, s.successCount, s.pendingCount, s.cb.config.HalfOpenSuccessCount)
 		// do we need some expire time here in case of one of pending requests is stuck forever?
 		if s.failureCount > 0 {
 			// there were some failures during half-open state, let's go back to open state to wait a bit longer
-			log.Error("Circuit breaker goes from half-open to open again as errors persist and continue to fail all requests",
+			log.Error("circuit breaker goes from half-open to open again as errors persist and continue to fail all requests",
 				zap.String("name", cb.name),
-				zap.String("config", fmt.Sprintf("%+v", cb.config)))
+				zap.Any("config", cb.config))
 			return cb.newState(now, StateOpen), errs.ErrCircuitBreakerOpen
 		} else if s.successCount == s.cb.config.HalfOpenSuccessCount {
 			// all probe requests are succeeded, we can move to closed state and allow all requests
-			log.Info("Circuit breaker is closed. Start allowing all requests",
+			log.Info("circuit breaker is closed and start allowing all requests",
 				zap.String("name", cb.name),
-				zap.String("config", fmt.Sprintf("%+v", cb.config)))
+				zap.Any("config", cb.config))
 			return cb.newState(now, StateClosed), nil
 		} else if s.pendingCount < s.cb.config.HalfOpenSuccessCount {
 			// allow more probe requests and continue in half-open state

--- a/client/circuitbreaker/circuit_breaker_test.go
+++ b/client/circuitbreaker/circuit_breaker_test.go
@@ -38,7 +38,7 @@ var settings = Settings{
 
 var minCountToOpen = int(settings.MinQPSForOpen * uint32(settings.ErrorRateWindow.Seconds()))
 
-func TestCircuitBreaker_Execute_Wrapper_Return_Values(t *testing.T) {
+func TestCircuitBreakerExecuteWrapperReturnValues(t *testing.T) {
 	re := require.New(t)
 	cb := NewCircuitBreaker[int]("test_cb", settings)
 	originalError := errors.New("circuit breaker is open")
@@ -57,7 +57,7 @@ func TestCircuitBreaker_Execute_Wrapper_Return_Values(t *testing.T) {
 	re.Equal(42, result)
 }
 
-func TestCircuitBreaker_OpenState(t *testing.T) {
+func TestCircuitBreakerOpenState(t *testing.T) {
 	re := require.New(t)
 	cb := NewCircuitBreaker[int]("test_cb", settings)
 	driveQPS(cb, minCountToOpen, Yes, re)
@@ -68,7 +68,7 @@ func TestCircuitBreaker_OpenState(t *testing.T) {
 	re.Equal(StateOpen, cb.state.stateType)
 }
 
-func TestCircuitBreaker_CloseState_Not_Enough_QPS(t *testing.T) {
+func TestCircuitBreakerCloseStateNotEnoughQPS(t *testing.T) {
 	re := require.New(t)
 	cb := NewCircuitBreaker[int]("test_cb", settings)
 	re.Equal(StateClosed, cb.state.stateType)
@@ -78,7 +78,7 @@ func TestCircuitBreaker_CloseState_Not_Enough_QPS(t *testing.T) {
 	re.Equal(StateClosed, cb.state.stateType)
 }
 
-func TestCircuitBreaker_CloseState_Not_Enough_Error_Rate(t *testing.T) {
+func TestCircuitBreakerCloseStateNotEnoughErrorRate(t *testing.T) {
 	re := require.New(t)
 	cb := NewCircuitBreaker[int]("test_cb", settings)
 	re.Equal(StateClosed, cb.state.stateType)
@@ -89,7 +89,7 @@ func TestCircuitBreaker_CloseState_Not_Enough_Error_Rate(t *testing.T) {
 	re.Equal(StateClosed, cb.state.stateType)
 }
 
-func TestCircuitBreaker_Half_Open_To_Closed(t *testing.T) {
+func TestCircuitBreakerHalfOpenToClosed(t *testing.T) {
 	re := require.New(t)
 	cb := NewCircuitBreaker[int]("test_cb", settings)
 	re.Equal(StateClosed, cb.state.stateType)
@@ -107,7 +107,7 @@ func TestCircuitBreaker_Half_Open_To_Closed(t *testing.T) {
 	re.Equal(StateClosed, cb.state.stateType)
 }
 
-func TestCircuitBreaker_Half_Open_To_Open(t *testing.T) {
+func TestCircuitBreakerHalfOpenToOpen(t *testing.T) {
 	re := require.New(t)
 	cb := NewCircuitBreaker[int]("test_cb", settings)
 	re.Equal(StateClosed, cb.state.stateType)
@@ -130,7 +130,7 @@ func TestCircuitBreaker_Half_Open_To_Open(t *testing.T) {
 
 // in half open state, circuit breaker will allow only HalfOpenSuccessCount pending and should fast fail all other request till HalfOpenSuccessCount requests is completed
 // this test moves circuit breaker to the half open state and verifies that requests above HalfOpenSuccessCount are failing
-func TestCircuitBreaker_Half_Open_Fail_Over_Pending_Count(t *testing.T) {
+func TestCircuitBreakerHalfOpenFailOverPendingCount(t *testing.T) {
 	re := require.New(t)
 	cb := newCircuitBreakerMovedToHalfOpenState(re)
 
@@ -176,7 +176,7 @@ func TestCircuitBreaker_Half_Open_Fail_Over_Pending_Count(t *testing.T) {
 	re.Equal(uint32(1), cb.state.successCount)
 }
 
-func TestCircuitBreaker_Count_Only_Requests_In_Same_Window(t *testing.T) {
+func TestCircuitBreakerCountOnlyRequestsInSameWindow(t *testing.T) {
 	re := require.New(t)
 	cb := NewCircuitBreaker[int]("test_cb", settings)
 	re.Equal(StateClosed, cb.state.stateType)
@@ -211,7 +211,7 @@ func TestCircuitBreaker_Count_Only_Requests_In_Same_Window(t *testing.T) {
 	re.Equal(uint32(1), cb.state.successCount)
 }
 
-func TestCircuitBreaker_ChangeSettings(t *testing.T) {
+func TestCircuitBreakerChangeSettings(t *testing.T) {
 	re := require.New(t)
 
 	cb := NewCircuitBreaker[int]("test_cb", AlwaysClosedSettings)

--- a/client/metrics/metrics.go
+++ b/client/metrics/metrics.go
@@ -152,7 +152,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   "pd_client",
 			Subsystem:   "request",
 			Name:        "circuit_breaker_count",
-			Help:        "Circuit Breaker counters",
+			Help:        "Circuit breaker counters",
 			ConstLabels: constLabels,
 		}, []string{"name", "success"})
 }

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -2072,7 +2072,7 @@ func TestCircuitBreaker(t *testing.T) {
 	cli := setupCli(ctx, re, endpoints, opt.WithRegionMetaCircuitBreaker(circuitBreakerSettings))
 	defer cli.Close()
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		region, err := cli.GetRegion(context.TODO(), []byte("a"))
 		re.NoError(err)
 		re.NotNil(region)
@@ -2080,7 +2080,7 @@ func TestCircuitBreaker(t *testing.T) {
 
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/triggerCircuitBreaker", "return(true)"))
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		_, err := cli.GetRegion(context.TODO(), []byte("a"))
 		re.Error(err)
 	}
@@ -2097,7 +2097,7 @@ func TestCircuitBreaker(t *testing.T) {
 	// wait cooldown
 	time.Sleep(time.Second)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		region, err := cli.GetRegion(context.TODO(), []byte("a"))
 		re.NoError(err)
 		re.NotNil(region)
@@ -2125,7 +2125,7 @@ func TestCircuitBreakerChangeSettings(t *testing.T) {
 	cli := setupCli(ctx, re, endpoints, opt.WithRegionMetaCircuitBreaker(circuitBreakerSettings))
 	defer cli.Close()
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		region, err := cli.GetRegion(context.TODO(), []byte("a"))
 		re.NoError(err)
 		re.NotNil(region)
@@ -2133,7 +2133,7 @@ func TestCircuitBreakerChangeSettings(t *testing.T) {
 
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/triggerCircuitBreaker", "return(true)"))
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		_, err := cli.GetRegion(context.TODO(), []byte("a"))
 		re.Error(err)
 	}

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"path"
 	"reflect"
 	"sort"
@@ -2104,7 +2105,7 @@ func TestCircuitBreaker(t *testing.T) {
 	}
 }
 
-func TestCircuitBreakerChangeSettings(t *testing.T) {
+func TestCircuitBreakerOpenAndChangeSettings(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2149,5 +2150,74 @@ func TestCircuitBreakerChangeSettings(t *testing.T) {
 	_, err = cli.GetRegion(context.TODO(), []byte("a"))
 	re.Error(err)
 	re.Contains(err.Error(), "ResourceExhausted")
+	re.NoError(failpoint.Disable("github.com/tikv/pd/client/triggerCircuitBreaker"))
+}
+
+func TestCircuitBreakerHalfOpenAndChangeSettings(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+
+	circuitBreakerSettings := cb.Settings{
+		ErrorRateThresholdPct: 60,
+		MinQPSForOpen:         10,
+		ErrorRateWindow:       time.Millisecond,
+		CoolDownInterval:      time.Second,
+		HalfOpenSuccessCount:  20,
+	}
+
+	endpoints := runServer(re, cluster)
+	cli := setupCli(ctx, re, endpoints, opt.WithRegionMetaCircuitBreaker(circuitBreakerSettings))
+	defer cli.Close()
+
+	for range 10 {
+		region, err := cli.GetRegion(context.TODO(), []byte("a"))
+		re.NoError(err)
+		re.NotNil(region)
+	}
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/client/triggerCircuitBreaker", "return(true)"))
+
+	for range 100 {
+		_, err := cli.GetRegion(context.TODO(), []byte("a"))
+		re.Error(err)
+	}
+
+	_, err = cli.GetRegion(context.TODO(), []byte("a"))
+	re.Error(err)
+	re.Contains(err.Error(), "circuit breaker is open")
+
+	fname := testutil.InitTempFileLogger("info")
+	defer os.RemoveAll(fname)
+	// wait for cooldown
+	time.Sleep(time.Second)
+	re.NoError(failpoint.Disable("github.com/tikv/pd/client/triggerCircuitBreaker"))
+	// trigger circuit breaker state to be half open
+	_, err = cli.GetRegion(context.TODO(), []byte("a"))
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		b, _ := os.ReadFile(fname)
+		l := string(b)
+		// We need to check the log to see if the circuit breaker is half open
+		return strings.Contains(l, "Transitioning to half-open state to test the service")
+	})
+
+	// The state is half open
+	re.NoError(failpoint.Enable("github.com/tikv/pd/client/triggerCircuitBreaker", "return(true)"))
+	// change settings to always closed
+	cli.UpdateOption(opt.RegionMetadataCircuitBreakerSettings, func(config *cb.Settings) {
+		*config = cb.AlwaysClosedSettings
+	})
+
+	// It won't be changed to open state.
+	for range 100 {
+		_, err := cli.GetRegion(context.TODO(), []byte("a"))
+		re.Error(err)
+		re.NotContains(err.Error(), "circuit breaker is open")
+	}
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/triggerCircuitBreaker"))
 }

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -106,7 +106,7 @@ func (suite *serverTestSuite) TestAllocIDAfterLeaderChange() {
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/mcs/scheduling/server/fastUpdateMember", `return(true)`))
 	pd2, err := suite.cluster.Join(suite.ctx)
-	re.NoError(err)
+	re.NoError(err, "error:%v", err)
 	err = pd2.Run()
 	re.NotEmpty(suite.cluster.WaitLeader())
 	re.NoError(err)
@@ -261,6 +261,12 @@ func (suite *serverTestSuite) TestDisableSchedulingServiceFallback() {
 
 	// API server will execute scheduling jobs since there is no scheduling server.
 	testutil.Eventually(re, func() bool {
+		if suite.pdLeader.GetServer() == nil {
+			println("pd server is nil")
+		}
+		if suite.pdLeader.GetServer().GetRaftCluster() == nil {
+			println("raft cluster is nil")
+		}
 		return suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})
 	leaderServer := suite.pdLeader.GetServer()


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8926 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
