### PR TITLE
config: completely remove the deprecated field from the PD server config

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -577,7 +577,7 @@ func (c *PDServerConfig) adjust(meta *configutil.ConfigMetaData) error {
 
 func migrateConfigurationFromFile(meta *configutil.ConfigMetaData) error {
 	oldName, newName := "trace-region-flow", "flow-round-by-digit"
-	defineOld, _ := meta.IsDefined(oldName), meta.IsDefined(newName)
+	defineOld := meta.IsDefined(oldName)
 	switch {
 	case defineOld:
 		return errors.Errorf("config item %s and %s(deprecated) are conflict", newName, oldName)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -507,9 +506,6 @@ type PDServerConfig struct {
 	MetricStorage string `toml:"metric-storage" json:"metric-storage"`
 	// There are some values supported: "auto", "none", or a specific address, default: "auto"
 	DashboardAddress string `toml:"dashboard-address" json:"dashboard-address"`
-	// TraceRegionFlow the option to update flow information of regions.
-	// WARN: TraceRegionFlow is deprecated.
-	TraceRegionFlow bool `toml:"trace-region-flow" json:"trace-region-flow,string,omitempty"`
 	// FlowRoundByDigit used to discretization processing flow information.
 	FlowRoundByDigit int `toml:"flow-round-by-digit" json:"flow-round-by-digit"`
 	// MinResolvedTSPersistenceInterval is the interval to save the min resolved ts.
@@ -573,35 +569,21 @@ func (c *PDServerConfig) adjust(meta *configutil.ConfigMetaData) error {
 	} else if c.GCTunerThreshold > maxGCTunerThreshold {
 		c.GCTunerThreshold = maxGCTunerThreshold
 	}
-	if err := c.migrateConfigurationFromFile(meta); err != nil {
+	if err := migrateConfigurationFromFile(meta); err != nil {
 		return err
 	}
 	return c.Validate()
 }
 
-func (c *PDServerConfig) migrateConfigurationFromFile(meta *configutil.ConfigMetaData) error {
+func migrateConfigurationFromFile(meta *configutil.ConfigMetaData) error {
 	oldName, newName := "trace-region-flow", "flow-round-by-digit"
-	defineOld, defineNew := meta.IsDefined(oldName), meta.IsDefined(newName)
+	defineOld, _ := meta.IsDefined(oldName), meta.IsDefined(newName)
 	switch {
-	case defineOld && defineNew:
-		if c.TraceRegionFlow && (c.FlowRoundByDigit == defaultFlowRoundByDigit) {
-			return errors.Errorf("config item %s and %s(deprecated) are conflict", newName, oldName)
-		}
-	case defineOld && !defineNew:
-		if !c.TraceRegionFlow {
-			c.FlowRoundByDigit = math.MaxInt8
-		}
+	case defineOld:
+		return errors.Errorf("config item %s and %s(deprecated) are conflict", newName, oldName)
+	default:
 	}
 	return nil
-}
-
-// MigrateDeprecatedFlags updates new flags according to deprecated flags.
-func (c *PDServerConfig) MigrateDeprecatedFlags() {
-	if !c.TraceRegionFlow {
-		c.FlowRoundByDigit = math.MaxInt8
-	}
-	// json omity the false. next time will not persist to the kv.
-	c.TraceRegionFlow = false
 }
 
 // Clone returns a cloned PD server config.

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -277,7 +277,7 @@ func TestMigrateFlags(t *testing.T) {
 	}
 	cfg, err := load(`
 [pd-server]
-trace-region-flow = false
+flow-round-by-digit = 127
 [schedule]
 disable-remove-down-replica = true
 enable-make-up-replica = false

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -817,7 +817,6 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 	adjustScheduleCfg(&cfg.Schedule)
 	// Some fields may not be stored in the storage, we need to calculate them manually.
 	cfg.StoreConfig.Adjust()
-	cfg.PDServerCfg.MigrateDeprecatedFlags()
 	if isExist {
 		o.schedule.Store(&cfg.Schedule)
 		o.replication.Store(&cfg.Replication)

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -150,7 +150,6 @@ func (suite *configTestSuite) checkConfig(cluster *pdTests.TestCluster) {
 	args = []string{"-u", pdAddr, "config", "set", "trace-region-flow", "false"}
 	_, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
-	re.False(svr.GetPDServerConfig().TraceRegionFlow)
 
 	origin := svr.GetPDServerConfig().FlowRoundByDigit
 	args = []string{"-u", pdAddr, "config", "set", "flow-round-by-digit", "10"}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close  https://github.com/tikv/pd/issues/8980

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
server/config: completely remove the deprecated field from the PD server config
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

From 7.1.1 to master:
![image](https://github.com/user-attachments/assets/7f77a582-0fc8-4375-a8a1-bf950c14da17)

master restart twice:
![image](https://github.com/user-attachments/assets/87d32a04-0f25-48d6-9417-4de615d3e4d4)


Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
