### PR TITLE
pd-ctl: print warn information when set max-replica to less than current

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pingcap/errcode"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/errs"
@@ -411,6 +412,10 @@ func (h *confHandler) SetScheduleConfig(w http.ResponseWriter, r *http.Request) 
 // @Success  200  {object}  sc.ReplicationConfig
 // @Router   /config/replicate [get]
 func (h *confHandler) GetReplicationConfig(w http.ResponseWriter, r *http.Request) {
+	failpoint.Inject("getReplicationConfigFailed", func(v failpoint.Value) {
+		code := v.(int)
+		h.rd.JSON(w, code, "get config failed")
+	})
 	if h.svr.IsServiceIndependent(constant.SchedulingServiceName) &&
 		r.Header.Get(apiutil.XForbiddenForwardToMicroserviceHeader) != "true" {
 		cfg, err := h.getSchedulingServerConfig()

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -372,9 +372,8 @@ func postConfigDataWithPath(cmd *cobra.Command, key, value, path string) error {
 	val, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		val = value
-	}
-	if key == "max-replicas" {
-		checkMaxReplicas(cmd, val)
+	} else if key == "max-replicas" {
+		checkMaxReplicas(cmd, val.(float64))
 	}
 	data[key] = val
 	reqData, err := json.Marshal(data)
@@ -389,12 +388,7 @@ func postConfigDataWithPath(cmd *cobra.Command, key, value, path string) error {
 	return nil
 }
 
-func checkMaxReplicas(cmd *cobra.Command, value any) {
-	newReplica, ok := value.(float64)
-	if !ok {
-		// If the type is not float64, it will be handled elsewhere
-		return
-	}
+func checkMaxReplicas(cmd *cobra.Command, newReplica float64) {
 	header := buildHeader(cmd)
 	r, err := doRequest(cmd, replicatePrefix, http.MethodGet, header)
 	if err != nil {

--- a/tools/pd-ctl/pdctl/command/config_command.go
+++ b/tools/pd-ctl/pdctl/command/config_command.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/reflectutil"
@@ -374,6 +375,12 @@ func postConfigDataWithPath(cmd *cobra.Command, key, value, path string) error {
 		val = value
 	}
 	data[key] = val
+	if key == "max-replicas" {
+		replica, err := strconv.ParseInt(value, 10, 64)
+		if err == nil && replica < sc.DefaultMaxReplicas {
+			cmd.Println("Setting max-replica to less than 3 may be a mistake and carries high risk. Please confirm the setting.")
+		}
+	}
 	reqData, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -1136,6 +1136,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 	output, err := tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "2")
 	re.NoError(err)
 	re.Contains(string(output), "Success!")
+	re.Contains(string(output), "Setting max-replica to less than 3 may be a mistake and carries high risk. Please confirm the setting.")
 	checkMaxReplicas(2)
 	output, err = tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "location-labels", "zone,host")
 	re.NoError(err)
@@ -1156,6 +1157,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 	output, err = tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "3")
 	re.NoError(err)
 	re.Contains(string(output), "Success!")
+	re.NotContains(string(output), "Setting max-replica to less than 3 may be a mistake and carries high risk. Please confirm the setting.")
 	checkMaxReplicas(3)
 	checkRuleCount(3)
 

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -1200,7 +1200,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 }
 
 func (suite *configTestSuite) TestMaxReplicaChanged() {
-	suite.env.RunTestInPDMode(suite.checkMaxReplicaChanged)
+	suite.env.RunTest(suite.checkMaxReplicaChanged)
 }
 
 func (suite *configTestSuite) checkMaxReplicaChanged(cluster *pdTests.TestCluster) {

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -1136,7 +1136,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 	output, err := tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "2")
 	re.NoError(err)
 	re.Contains(string(output), "Success!")
-	re.Contains(string(output), "Setting max-replica to less than 3 may be a mistake and carries high risk. Please confirm the setting.")
+	re.Contains(string(output), "which is less than the current replicas")
 	checkMaxReplicas(2)
 	output, err = tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "location-labels", "zone,host")
 	re.NoError(err)
@@ -1157,7 +1157,7 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 	output, err = tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "set", "max-replicas", "3")
 	re.NoError(err)
 	re.Contains(string(output), "Success!")
-	re.NotContains(string(output), "Setting max-replica to less than 3 may be a mistake and carries high risk. Please confirm the setting.")
+	re.NotContains(string(output), "which is less than the current replicas")
 	checkMaxReplicas(3)
 	checkRuleCount(3)
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8959

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
