### PR TITLE
command: check for too many arguments in pd-ctl unsafe remove-failed-stores

### DIFF
--- a/tools/pd-ctl/pdctl/command/unsafe_command.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command.go
@@ -98,6 +98,13 @@ func removeFailedStoresCommandFunc(cmd *cobra.Command, args []string) {
 			return
 		}
 
+		// This is to detect "<storeid> <storeid>" instead of "<storeid>,<storeid>"
+		if len(args) > 1 {
+			cmd.Println("More arguments than expected")
+			cmd.Usage()
+			return
+		}
+
 		strStores := strings.Split(args[0], ",")
 		var stores []uint64
 		for _, strStore := range strStores {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9033

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Check for too many arguments in pd-ctl unsafe remove-failed-stores
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->


- Manual test (add detailed scripts or steps below)




### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
A check for too many arguments in pd-ctl unsafe remove-failed-stores has been added
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced argument validation to detect and properly handle incorrectly formatted inputs, providing clearer error messages and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->