### PR TITLE
client/router: fix the incorrect deep copy method in QueryRegion

### DIFF
--- a/client/clients/router/client.go
+++ b/client/clients/router/client.go
@@ -240,11 +240,7 @@ func (c *Cli) newRequest(ctx context.Context) *Request {
 }
 
 func requestFinisher(resp *pdpb.QueryRegionResponse) batch.FinisherFunc[*Request] {
-	var (
-		keyIdx, prevKeyIdx int
-		// regionUsed is used to record whether the region has been used.
-		regionUsed = make(map[uint64]struct{})
-	)
+	var keyIdx, prevKeyIdx int
 	return func(_ int, req *Request, err error) {
 		requestCtx := req.requestCtx
 		defer trace.StartRegion(requestCtx, "pdclient.regionReqDone").End()
@@ -267,12 +263,7 @@ func requestFinisher(resp *pdpb.QueryRegionResponse) batch.FinisherFunc[*Request
 		if regionResp, ok := resp.RegionsById[id]; ok {
 			// Since the region results may be modified by the requester,
 			// we need to ensure each region result returned is unique.
-			if _, used := regionUsed[id]; used {
-				req.region = convertToRegionCopy(regionResp)
-			} else {
-				req.region = ConvertToRegion(regionResp)
-				regionUsed[id] = struct{}{}
-			}
+			req.region = convertToRegionCopy(regionResp)
 		}
 		req.tryDone(err)
 	}

--- a/client/clients/router/client_test.go
+++ b/client/clients/router/client_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+func newMockRegionResponse(id uint64) *pdpb.RegionResponse {
+	return &pdpb.RegionResponse{
+		Region:  &metapb.Region{Id: id, StartKey: make([]byte, 1)},
+		Leader:  &metapb.Peer{Id: id},
+		Buckets: &metapb.Buckets{},
+	}
+}
+
+func TestRequestFinisherNoDataRace(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+
+	// Create a mock QueryRegionResponse.
+	resp := &pdpb.QueryRegionResponse{
+		KeyIdMap:     []uint64{1, 2},
+		PrevKeyIdMap: []uint64{1, 2},
+		RegionsById: map[uint64]*pdpb.RegionResponse{
+			1: newMockRegionResponse(1),
+			2: newMockRegionResponse(2),
+		},
+	}
+
+	// Build a batch of mock requests:
+	// • Two requests with key set (will use KeyIdMap).
+	// • Two requests with prevKey set (will use PrevKeyIdMap).
+	// • Two requests with neither key nor prevKey (so the id branch is used).
+	var requests []*Request
+
+	// Requests that use `key`.
+	for range 2 {
+		req := &Request{
+			requestCtx: ctx,
+			key:        []byte("dummy-key"),
+			done:       make(chan error, 1),
+		}
+		requests = append(requests, req)
+	}
+
+	// Requests that use `prevKey`.
+	for range 2 {
+		req := &Request{
+			requestCtx: ctx,
+			prevKey:    []byte("dummy-prev-key"),
+			done:       make(chan error, 1),
+		}
+		requests = append(requests, req)
+	}
+
+	// Requests that use `id`.
+	for _, id := range []uint64{1, 2} {
+		req := &Request{
+			requestCtx: ctx,
+			id:         id,
+			done:       make(chan error, 1),
+		}
+		requests = append(requests, req)
+	}
+
+	// Get the finisher function.
+	finisher := requestFinisher(resp)
+
+	// Simulate finishing the batch – call the finisher for each request.
+	for idx, req := range requests {
+		finisher(idx, req, nil)
+		re.NoError(<-req.done)
+		// Modify the region key range in place.
+		req.region.Meta.StartKey[0] += byte(idx + 1)
+	}
+
+	// Verify that each request got the correct cloned region.
+	for idx, req := range requests {
+		re.Equal([]byte{byte(idx + 1)}, req.region.Meta.StartKey)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #8690.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Although #9055 identified the problem, the proposed fix is incorrect because the first request using the same region can still modify the data concurrently.
This PR resolves the issue by deep-copying the region from the response each time.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test

Before:

<img width="1771" src="https://github.com/user-attachments/assets/a725cf78-d9e8-40c8-85d9-8da0d9c85b1f" />

After:

<img width="996" src="https://github.com/user-attachments/assets/b0a1b9b4-664d-4c3f-8d1e-eb1e88612959" />


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
