### PR TITLE
tests: fix the race in TestMemberUpdateBackOff

### DIFF
--- a/client/pkg/retry/backoff.go
+++ b/client/pkg/retry/backoff.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -95,7 +96,7 @@ func (bo *Backoffer) Exec(
 			return errors.Trace(ctx.Err())
 		case <-after.C:
 			failpoint.Inject("backOffExecute", func() {
-				testBackOffExecuteFlag = true
+				testBackOffExecuteFlag.Store(true)
 			})
 		}
 		after.Stop()
@@ -181,11 +182,11 @@ func (bo *Backoffer) resetBackoff() {
 }
 
 // Only used for test.
-var testBackOffExecuteFlag = false
+var testBackOffExecuteFlag atomic.Bool
 
 // TestBackOffExecute Only used for test.
 func TestBackOffExecute() bool {
-	return testBackOffExecuteFlag
+	return testBackOffExecuteFlag.Load()
 }
 
 func getFunctionName(f any) string {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9098

### What is changed and how does it work?

The internal update member loop may be executed at the same time to change the value.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
