### PR TITLE
tests: make `TestRemovingProgress` stable

### DIFF
--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -917,21 +917,23 @@ func TestRemovingProgress(t *testing.T) {
 			return false
 		}
 		// store 1: (60-20)/(60+50) ~= 0.36
-		// store 2: (30-10)/(30+40) ~= 0.28
+		// store 2: (30-10)/(30+40) ~= 0.28 110-40 70-20
 		// average progress ~= (0.36+0.28)/2 = 0.32
 		if fmt.Sprintf("%.2f", p.Progress) != "0.32" {
 			return false
 		}
-		// store 1: 40/10s = 4
-		// store 2: 20/10s = 2
+		// store 1: 40/20s = 4
+		// store 2: 20/20s = 2
 		// average speed = (2+4)/2 = 3.0
-		if p.CurrentSpeed != 3.0 {
+		// If checkStore is executed multiple times, the time windows will increase
+		// which is 20s, 30s, 40s ..., the corresponding speed will be 3.0, 1.5, 1 ...
+		if p.CurrentSpeed > 3.0 {
 			return false
 		}
 		// store 1: (20+50)/4 = 17.5s
 		// store 2: (10+40)/2 = 25s
 		// average time = (17.5+25)/2 = 21.25s
-		if p.LeftSeconds != 21.25 {
+		if p.LeftSeconds < 21.25 {
 			return false
 		}
 		return true

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -917,7 +917,7 @@ func TestRemovingProgress(t *testing.T) {
 			return false
 		}
 		// store 1: (60-20)/(60+50) ~= 0.36
-		// store 2: (30-10)/(30+40) ~= 0.28 110-40 70-20
+		// store 2: (30-10)/(30+40) ~= 0.28
 		// average progress ~= (0.36+0.28)/2 = 0.32
 		if fmt.Sprintf("%.2f", p.Progress) != "0.32" {
 			return false

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -922,11 +922,11 @@ func TestRemovingProgress(t *testing.T) {
 		if fmt.Sprintf("%.2f", p.Progress) != "0.32" {
 			return false
 		}
-		// store 1: 40/20s = 4
-		// store 2: 20/20s = 2
+		// store 1: 40/10s = 4
+		// store 2: 20/10s = 2
 		// average speed = (2+4)/2 = 3.0
 		// If checkStore is executed multiple times, the time windows will increase
-		// which is 20s, 30s, 40s ..., the corresponding speed will be 3.0, 1.5, 1 ...
+		// which is 10s, 20s, 30s ..., the corresponding speed will be 3.0, 1.5, 1 ...
 		if p.CurrentSpeed > 3.0 {
 			return false
 		}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8992.

### What is changed and how does it work?

The test failed because we enabled `highFrequencyClusterJobs` failpoint to make `checkStores` execute ASAP. However, it could cause running `checkStores` multiple times if the environment is in a high load state. In this case, the data point in the progress window will increase which results in speed inaccuracy.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
