### PR TITLE
client: use debug level

### DIFF
--- a/client/pkg/circuitbreaker/circuit_breaker.go
+++ b/client/pkg/circuitbreaker/circuit_breaker.go
@@ -138,7 +138,7 @@ func (cb *CircuitBreaker) ChangeSettings(apply func(config *Settings)) {
 	defer cb.Unlock()
 
 	apply(cb.config)
-	log.Info("circuit breaker settings changed", zap.Any("config", cb.config))
+	log.Debug("circuit breaker settings changed", zap.Any("config", cb.config))
 }
 
 // Execute calls the given function if the CircuitBreaker is closed and returns the result of execution.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #8678.

### What is changed and how does it work?

I think there is no need to print it frequently.

```
[2025/03/06 17:46:07.066 +08:00] [INFO] [circuit_breaker.go:141] ["circuit breaker settings changed"] [config="{\"ErrorRateThresholdPct\":0,\"MinQPSForOpen\":10,\"ErrorRateWindow\":30000000000,\"CoolDownInterval\":10000000000,\"HalfOpenSuccessCount\":1}"]
[2025/03/06 17:46:10.071 +08:00] [INFO] [queue.go:320] ["Start to fetch DML changes of tables"] [category=stats] [sampled=]
[2025/03/06 17:46:10.078 +08:00] [INFO] [queue.go:377] ["Updating last fetch timestamp"] [category=stats] [sampled=] [new_max_version=456459380444889093]
[2025/03/06 17:46:19.038 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:46:31.039 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:46:37.069 +08:00] [INFO] [circuit_breaker.go:141] ["circuit breaker settings changed"] [config="{\"ErrorRateThresholdPct\":0,\"MinQPSForOpen\":10,\"ErrorRateWindow\":30000000000,\"CoolDownInterval\":10000000000,\"HalfOpenSuccessCount\":1}"]
[2025/03/06 17:46:43.039 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:46:55.039 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:47:07.043 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:47:07.076 +08:00] [INFO] [circuit_breaker.go:141] ["circuit breaker settings changed"] [config="{\"ErrorRateThresholdPct\":0,\"MinQPSForOpen\":10,\"ErrorRateWindow\":30000000000,\"CoolDownInterval\":10000000000,\"HalfOpenSuccessCount\":1}"]
[2025/03/06 17:47:19.038 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:47:31.038 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:47:37.081 +08:00] [INFO] [circuit_breaker.go:141] ["circuit breaker settings changed"] [config="{\"ErrorRateThresholdPct\":0,\"MinQPSForOpen\":10,\"ErrorRateWindow\":30000000000,\"CoolDownInterval\":10000000000,\"HalfOpenSuccessCount\":1}"]
[2025/03/06 17:47:43.038 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:47:55.039 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:48:07.038 +08:00] [INFO] [advancer.go:669] ["No tasks yet, skipping advancing."]
[2025/03/06 17:48:07.097 +08:00] [INFO] [circuit_breaker.go:141] ["circuit breaker settings changed"] [config="{\"ErrorRateThresholdPct\":0,\"MinQPSForOpen\":10,\"ErrorRateWindow\":30000000000,\"CoolDownInterval\":10000000000,\"HalfOpenSuccessCount\":1}"]
```

We can use `show global variables like 'tidb_cb_pd_metadata_error_rate_threshold_pct';` to get the value.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
