### PR TITLE
tso: enhance timestamp persistency with strong leader consistency

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -1046,6 +1046,11 @@ error = '''
 reset user timestamp failed, %s
 '''
 
+["PD:tso:ErrSaveTimestamp"]
+error = '''
+save timestamp failed, %s
+'''
+
 ["PD:tso:ErrUpdateTimestamp"]
 error = '''
 update timestamp failed, %s

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -65,7 +65,7 @@ type Leadership struct {
 	client *clientv3.Client
 	// leaderKey and leaderValue are key-value pair in etcd
 	leaderKey   string
-	leaderValue string
+	leaderValue atomic.Value // Stored as string
 
 	keepAliveCtx            context.Context
 	keepAliveCancelFunc     context.CancelFunc
@@ -125,7 +125,11 @@ func (ls *Leadership) GetLeaderValue() string {
 	if ls == nil {
 		return ""
 	}
-	return ls.leaderValue
+	leaderValue := ls.leaderValue.Load()
+	if leaderValue == nil {
+		return ""
+	}
+	return leaderValue.(string)
 }
 
 // SetPrimaryWatch sets the primary watch flag.
@@ -174,7 +178,7 @@ func (ls *Leadership) AddCampaignTimes() {
 
 // Campaign is used to campaign the leader with given lease and returns a leadership
 func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...clientv3.Cmp) error {
-	ls.leaderValue = leaderData
+	ls.leaderValue.Store(leaderData)
 	// Create a new lease to campaign
 	newLease := NewLease(ls.client, ls.purpose)
 	ls.SetLease(newLease)
@@ -241,7 +245,7 @@ func (ls *Leadership) LeaderTxn(cs ...clientv3.Cmp) clientv3.Txn {
 }
 
 func (ls *Leadership) leaderCmp() clientv3.Cmp {
-	return clientv3.Compare(clientv3.Value(ls.leaderKey), "=", ls.leaderValue)
+	return clientv3.Compare(clientv3.Value(ls.leaderKey), "=", ls.GetLeaderValue())
 }
 
 // DeleteLeaderKey deletes the corresponding leader from etcd by the leaderPath as the key.
@@ -427,4 +431,5 @@ func (ls *Leadership) Reset() {
 	ls.keepAliveCancelFuncLock.Unlock()
 	ls.GetLease().Close()
 	ls.SetPrimaryWatch(false)
+	ls.leaderValue.Store("")
 }

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -120,6 +120,14 @@ func (ls *Leadership) GetLeaderKey() string {
 	return ls.leaderKey
 }
 
+// GetLeaderValue is used to get the leader value saved in etcd.
+func (ls *Leadership) GetLeaderValue() string {
+	if ls == nil {
+		return ""
+	}
+	return ls.leaderValue
+}
+
 // SetPrimaryWatch sets the primary watch flag.
 func (ls *Leadership) SetPrimaryWatch(val bool) {
 	ls.primaryWatch.Store(val)

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -105,6 +105,7 @@ var (
 	ErrResetUserTimestamp               = errors.Normalize("reset user timestamp failed, %s", errors.RFCCodeText("PD:tso:ErrResetUserTimestamp"))
 	ErrGenerateTimestamp                = errors.Normalize("generate timestamp failed, %s", errors.RFCCodeText("PD:tso:ErrGenerateTimestamp"))
 	ErrUpdateTimestamp                  = errors.Normalize("update timestamp failed, %s", errors.RFCCodeText("PD:tso:ErrUpdateTimestamp"))
+	ErrSaveTimestamp                    = errors.Normalize("save timestamp failed, %s", errors.RFCCodeText("PD:tso:ErrSaveTimestamp"))
 	ErrLogicOverflow                    = errors.Normalize("logic part overflow", errors.RFCCodeText("PD:tso:ErrLogicOverflow"))
 	ErrProxyTSOTimeout                  = errors.Normalize("proxy tso timeout", errors.RFCCodeText("PD:tso:ErrProxyTSOTimeout"))
 	ErrKeyspaceGroupIDInvalid           = errors.Normalize("the keyspace group id is invalid, %s", errors.RFCCodeText("PD:tso:ErrKeyspaceGroupIDInvalid"))

--- a/pkg/errs/errs.go
+++ b/pkg/errs/errs.go
@@ -15,6 +15,8 @@
 package errs
 
 import (
+	"strings"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -34,4 +36,12 @@ func ZapError(err error, causeError ...error) zap.Field {
 		}
 	}
 	return zap.Field{Key: "error", Type: zapcore.ErrorType, Interface: err}
+}
+
+// IsLeaderChanged returns true if the error is due to leader changed.
+func IsLeaderChanged(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), NotLeaderErr)
 }

--- a/pkg/storage/endpoint/tso.go
+++ b/pkg/storage/endpoint/tso.go
@@ -76,7 +76,8 @@ func (se *StorageEndpoint) SaveTimestamp(groupID uint32, ts time.Time, leadershi
 		zap.String("expected-leader-value", leadership.GetLeaderValue()),
 	}
 	log.Info("saving timestamp to the storage", logFilds...)
-	// Fast path to return error if the leadership has not been granted yet.
+	// The PD leadership or TSO primary will always be granted first before the TSO timestamp window is saved.
+	// So we here check whether the leader value is filled to see if the requirement is met.
 	if len(leadership.GetLeaderValue()) == 0 {
 		return errors.Errorf("%s due to leadership has not been granted yet", errs.NotLeaderErr)
 	}

--- a/pkg/storage/storage_tso_test.go
+++ b/pkg/storage/storage_tso_test.go
@@ -82,7 +82,7 @@ func TestSaveTimestampWithLeaderCheck(t *testing.T) {
 	re.Equal(globalTS, ts)
 
 	err = storage.SaveTimestamp(testGroupID, globalTS.Add(time.Second), &election.Leadership{})
-	re.ErrorContains(err, "leadership is not valid, leader value is empty")
+	re.ErrorContains(err, "leadership has not been granted yet, leader value is empty")
 	ts, err = storage.LoadTimestamp(testGroupID)
 	re.NoError(err)
 	re.Equal(globalTS, ts)

--- a/pkg/storage/storage_tso_test.go
+++ b/pkg/storage/storage_tso_test.go
@@ -20,17 +20,31 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 )
 
-const testGroupID = uint32(1)
+const (
+	testGroupID     = uint32(1)
+	testLeaderKey   = "test-leader-key"
+	testLeaderValue = "test-leader-value"
+)
+
+func prepare(t *testing.T) (storage Storage, clean func(), leadership *election.Leadership) {
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
+	storage = NewStorageWithEtcdBackend(client)
+	leadership = election.NewLeadership(client, testLeaderKey, "storage_tso_test")
+	err := leadership.Campaign(60, testLeaderValue)
+	require.NoError(t, err)
+	return storage, clean, leadership
+}
 
 func TestSaveLoadTimestamp(t *testing.T) {
 	re := require.New(t)
-	storage, clean := newTestStorage(t)
+	storage, clean, leadership := prepare(t)
 	defer clean()
 	expectedTS := time.Now().Round(0)
-	err := storage.SaveTimestamp(testGroupID, expectedTS)
+	err := storage.SaveTimestamp(testGroupID, expectedTS, leadership)
 	re.NoError(err)
 	ts, err := storage.LoadTimestamp(testGroupID)
 	re.NoError(err)
@@ -39,14 +53,14 @@ func TestSaveLoadTimestamp(t *testing.T) {
 
 func TestTimestampTxn(t *testing.T) {
 	re := require.New(t)
-	storage, clean := newTestStorage(t)
+	storage, clean, leadership := prepare(t)
 	defer clean()
 	globalTS1 := time.Now().Round(0)
-	err := storage.SaveTimestamp(testGroupID, globalTS1)
+	err := storage.SaveTimestamp(testGroupID, globalTS1, leadership)
 	re.NoError(err)
 
 	globalTS2 := globalTS1.Add(-time.Millisecond).Round(0)
-	err = storage.SaveTimestamp(testGroupID, globalTS2)
+	err = storage.SaveTimestamp(testGroupID, globalTS2, leadership)
 	re.Error(err)
 
 	ts, err := storage.LoadTimestamp(testGroupID)
@@ -54,7 +68,47 @@ func TestTimestampTxn(t *testing.T) {
 	re.Equal(globalTS1, ts)
 }
 
-func newTestStorage(t *testing.T) (Storage, func()) {
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1)
-	return NewStorageWithEtcdBackend(client), clean
+func TestSaveTimestampWithLeaderCheck(t *testing.T) {
+	re := require.New(t)
+	storage, clean, leadership := prepare(t)
+	defer clean()
+
+	// testLeaderKey -> testLeaderValue
+	globalTS := time.Now().Round(0)
+	err := storage.SaveTimestamp(testGroupID, globalTS, leadership)
+	re.NoError(err)
+	ts, err := storage.LoadTimestamp(testGroupID)
+	re.NoError(err)
+	re.Equal(globalTS, ts)
+
+	err = storage.SaveTimestamp(testGroupID, globalTS.Add(time.Second), &election.Leadership{})
+	re.ErrorContains(err, "leadership is not valid, leader value is empty")
+	ts, err = storage.LoadTimestamp(testGroupID)
+	re.NoError(err)
+	re.Equal(globalTS, ts)
+
+	// testLeaderKey -> ""
+	storage.Save(leadership.GetLeaderKey(), "")
+	err = storage.SaveTimestamp(testGroupID, globalTS.Add(time.Second), leadership)
+	re.ErrorContains(err, "leader value does not match")
+	ts, err = storage.LoadTimestamp(testGroupID)
+	re.NoError(err)
+	re.Equal(globalTS, ts)
+
+	// testLeaderKey -> non-existent
+	storage.Remove(leadership.GetLeaderKey())
+	err = storage.SaveTimestamp(testGroupID, globalTS.Add(time.Second), leadership)
+	re.ErrorContains(err, "leader value does not match")
+	ts, err = storage.LoadTimestamp(testGroupID)
+	re.NoError(err)
+	re.Equal(globalTS, ts)
+
+	// testLeaderKey -> testLeaderValue
+	storage.Save(leadership.GetLeaderKey(), testLeaderValue)
+	globalTS = globalTS.Add(time.Second)
+	err = storage.SaveTimestamp(testGroupID, globalTS, leadership)
+	re.NoError(err)
+	ts, err = storage.LoadTimestamp(testGroupID)
+	re.NoError(err)
+	re.Equal(globalTS, ts)
 }

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -131,6 +131,7 @@ func NewAllocator(
 		member:          member,
 		timestampOracle: &timestampOracle{
 			keyspaceGroupID:        keyspaceGroupID,
+			member:                 member,
 			storage:                storage,
 			saveInterval:           cfg.GetTSOSaveInterval(),
 			updatePhysicalInterval: cfg.GetTSOUpdatePhysicalInterval(),
@@ -224,7 +225,7 @@ func (a *Allocator) UpdateTSO() (err error) {
 
 // SetTSO sets the physical part with given TSO.
 func (a *Allocator) SetTSO(tso uint64, ignoreSmaller, skipUpperBoundCheck bool) error {
-	return a.timestampOracle.resetUserTimestamp(a.member.GetLeadership(), tso, ignoreSmaller, skipUpperBoundCheck)
+	return a.timestampOracle.resetUserTimestamp(tso, ignoreSmaller, skipUpperBoundCheck)
 }
 
 // GenerateTSO is used to generate the given number of TSOs. Make sure you have initialized the TSO allocator before calling this method.
@@ -235,7 +236,7 @@ func (a *Allocator) GenerateTSO(ctx context.Context, count uint32) (pdpb.Timesta
 		return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs(fmt.Sprintf("requested pd %s of cluster", errs.NotLeaderErr))
 	}
 
-	return a.timestampOracle.getTS(ctx, a.member, count)
+	return a.timestampOracle.getTS(ctx, count)
 }
 
 // Reset is used to reset the TSO allocator, it will also reset the leadership if the `resetLeader` flag is true.

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 
-	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/logutil"
@@ -60,6 +59,7 @@ type tsoObject struct {
 // timestampOracle is used to maintain the logic of TSO.
 type timestampOracle struct {
 	keyspaceGroupID uint32
+	member          ElectionMember
 	storage         endpoint.TSOStorage
 	// TODO: remove saveInterval
 	saveInterval           time.Duration
@@ -72,6 +72,13 @@ type timestampOracle struct {
 
 	// pre-initialized metrics
 	metrics *tsoMetrics
+}
+
+func (t *timestampOracle) saveTimestamp(ts time.Time) error {
+	if !t.member.IsLeader() {
+		return errs.ErrSaveTimestamp.FastGenByArgs("not leader anymore")
+	}
+	return t.storage.SaveTimestamp(t.keyspaceGroupID, ts, t.member.GetLeadership())
 }
 
 func (t *timestampOracle) setTSOPhysical(next time.Time, force bool) {
@@ -172,7 +179,7 @@ func (t *timestampOracle) syncTimestamp() error {
 	})
 	save := next.Add(t.saveInterval)
 	start := time.Now()
-	if err = t.storage.SaveTimestamp(t.keyspaceGroupID, save); err != nil {
+	if err = t.saveTimestamp(save); err != nil {
 		t.metrics.errSaveSyncTSEvent.Inc()
 		return err
 	}
@@ -202,12 +209,12 @@ func (t *timestampOracle) isInitialized() bool {
 // resetUserTimestamp update the TSO in memory with specified TSO by an atomically way.
 // When ignoreSmaller is true, a smaller tso resetting error will be ignored and do nothing.
 // The TSO in memory can only be set to one which is smaller than current TSO + `maxResetTSGap`.
-func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, tso uint64, ignoreSmaller, skipUpperBoundCheck bool) error {
+func (t *timestampOracle) resetUserTimestamp(tso uint64, ignoreSmaller, skipUpperBoundCheck bool) error {
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
-	if !leadership.Check() {
+	if !t.member.IsLeader() {
 		t.metrics.errLeaseResetTSEvent.Inc()
-		return errs.ErrResetUserTimestamp.FastGenByArgs("lease expired")
+		return errs.ErrResetUserTimestamp.FastGenByArgs(errs.NotLeaderErr)
 	}
 	var (
 		nextPhysical, nextLogical = tsoutil.ParseTS(tso)
@@ -243,7 +250,7 @@ func (t *timestampOracle) resetUserTimestamp(leadership *election.Leadership, ts
 	if typeutil.SubRealTimeByWallClock(t.getLastSavedTime(), nextPhysical) <= updateTimestampGuard {
 		save := nextPhysical.Add(t.saveInterval)
 		start := time.Now()
-		if err := t.storage.SaveTimestamp(t.keyspaceGroupID, save); err != nil {
+		if err := t.saveTimestamp(save); err != nil {
 			t.metrics.errSaveResetTSEvent.Inc()
 			return err
 		}
@@ -326,7 +333,7 @@ func (t *timestampOracle) updateTimestamp() error {
 	if typeutil.SubRealTimeByWallClock(t.getLastSavedTime(), next) <= updateTimestampGuard {
 		save := next.Add(t.saveInterval)
 		start := time.Now()
-		if err := t.storage.SaveTimestamp(t.keyspaceGroupID, save); err != nil {
+		if err := t.saveTimestamp(save); err != nil {
 			log.Warn("save timestamp failed",
 				logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
 				zap.Error(err))
@@ -344,7 +351,7 @@ func (t *timestampOracle) updateTimestamp() error {
 
 var maxRetryCount = 10
 
-func (t *timestampOracle) getTS(ctx context.Context, member ElectionMember, count uint32) (pdpb.Timestamp, error) {
+func (t *timestampOracle) getTS(ctx context.Context, count uint32) (pdpb.Timestamp, error) {
 	defer trace.StartRegion(ctx, "timestampOracle.getTS").End()
 	var resp pdpb.Timestamp
 	if count == 0 {
@@ -354,7 +361,7 @@ func (t *timestampOracle) getTS(ctx context.Context, member ElectionMember, coun
 		currentPhysical, _ := t.getTSO()
 		if currentPhysical == typeutil.ZeroTime {
 			// If it's leader, maybe SyncTimestamp hasn't completed yet
-			if member.IsLeader() {
+			if t.member.IsLeader() {
 				time.Sleep(200 * time.Millisecond)
 				continue
 			}
@@ -376,7 +383,7 @@ func (t *timestampOracle) getTS(ctx context.Context, member ElectionMember, coun
 			continue
 		}
 		// In case lease expired after the first check.
-		if !member.IsLeader() {
+		if !t.member.IsLeader() {
 			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs(fmt.Sprintf("requested %s anymore", errs.NotLeaderErr))
 		}
 		return resp, nil

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -75,9 +75,6 @@ type timestampOracle struct {
 }
 
 func (t *timestampOracle) saveTimestamp(ts time.Time) error {
-	if !t.member.IsLeader() {
-		return errs.ErrSaveTimestamp.FastGenByArgs("not leader anymore")
-	}
 	return t.storage.SaveTimestamp(t.keyspaceGroupID, ts, t.member.GetLeadership())
 }
 

--- a/pkg/utils/tsoutil/tso_dispatcher.go
+++ b/pkg/utils/tsoutil/tso_dispatcher.go
@@ -16,7 +16,6 @@ package tsoutil
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -141,7 +140,7 @@ func (s *TSODispatcher) dispatch(
 				log.Error("proxy forward tso error",
 					zap.String("forwarded-host", forwardedHost),
 					errs.ZapError(errs.ErrGRPCSend, err))
-				if needUpdateServicePrimaryAddr && strings.Contains(err.Error(), errs.NotLeaderErr) {
+				if needUpdateServicePrimaryAddr && errs.IsLeaderChanged(err) {
 					tsoPrimaryWatchers[0].ForceLoad()
 				}
 				select {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -226,8 +226,9 @@ const (
 	defaultTSOSaveInterval = time.Duration(defaultLeaderLease) * time.Second
 	// defaultTSOUpdatePhysicalInterval is the default value of the config `TSOUpdatePhysicalInterval`.
 	defaultTSOUpdatePhysicalInterval = 50 * time.Millisecond
-	maxTSOUpdatePhysicalInterval     = 10 * time.Second
-	minTSOUpdatePhysicalInterval     = 1 * time.Millisecond
+	// MaxTSOUpdatePhysicalInterval is the max value of the config `TSOUpdatePhysicalInterval`.
+	MaxTSOUpdatePhysicalInterval = 10 * time.Second
+	minTSOUpdatePhysicalInterval = 1 * time.Millisecond
 
 	defaultLogFormat = "text"
 	defaultLogLevel  = "info"
@@ -400,8 +401,8 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	configutil.AdjustDuration(&c.TSOSaveInterval, defaultTSOSaveInterval)
 	configutil.AdjustDuration(&c.TSOUpdatePhysicalInterval, defaultTSOUpdatePhysicalInterval)
 
-	if c.TSOUpdatePhysicalInterval.Duration > maxTSOUpdatePhysicalInterval {
-		c.TSOUpdatePhysicalInterval.Duration = maxTSOUpdatePhysicalInterval
+	if c.TSOUpdatePhysicalInterval.Duration > MaxTSOUpdatePhysicalInterval {
+		c.TSOUpdatePhysicalInterval.Duration = MaxTSOUpdatePhysicalInterval
 	} else if c.TSOUpdatePhysicalInterval.Duration < minTSOUpdatePhysicalInterval {
 		c.TSOUpdatePhysicalInterval.Duration = minTSOUpdatePhysicalInterval
 	}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -253,7 +253,7 @@ tso-update-physical-interval = "15s"
 	err = cfg.Adjust(&meta, false)
 	re.NoError(err)
 
-	re.Equal(maxTSOUpdatePhysicalInterval, cfg.TSOUpdatePhysicalInterval.Duration)
+	re.Equal(MaxTSOUpdatePhysicalInterval, cfg.TSOUpdatePhysicalInterval.Duration)
 
 	cfgData = `
 [log]

--- a/server/forward.go
+++ b/server/forward.go
@@ -17,7 +17,6 @@ package server
 import (
 	"context"
 	"io"
-	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -246,7 +245,7 @@ func (s *GrpcServer) forwardTSORequestWithDeadLine(
 	resp, err := forwarder.forwardTSORequest(request)
 	close(done)
 	if err != nil {
-		if strings.Contains(err.Error(), errs.NotLeaderErr) {
+		if errs.IsLeaderChanged(err) {
 			s.tsoPrimaryWatcher.ForceLoad()
 		}
 		return nil, err
@@ -454,7 +453,7 @@ func (s *GrpcServer) getGlobalTSO(ctx context.Context) (pdpb.Timestamp, error) {
 		ok            bool
 	)
 	handleStreamError := func(err error) (needRetry bool) {
-		if strings.Contains(err.Error(), errs.NotLeaderErr) {
+		if errs.IsLeaderChanged(err) {
 			s.tsoPrimaryWatcher.ForceLoad()
 			log.Warn("force to load tso primary address due to error", zap.Error(err), zap.String("tso-addr", forwardedHost))
 			return true

--- a/tools/pd-ut/testdata/group.1.etcdkey
+++ b/tools/pd-ut/testdata/group.1.etcdkey
@@ -61,6 +61,9 @@ test-a save
 test-a/ get
 test-a/a save
 test-a/ab save
+test-leader-key get
+test-leader-key remove
+test-leader-key save
 test/ get
 test/a save
 test/ab save


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #9157.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
This commit enhances the timestamp storage mechanism by adding a leadership validation check when saving TSO timestamps to etcd.
This prevents a former leader from incorrectly persisting timestamps after losing leadership.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
Fix a bug that could cause the former PD leader to incorrectly persist timestamps after losing its leadership.
```
