### PR TITLE
fix(client): call scheduleUpdateConnectionCtxs after leader switch

### DIFF
--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -6,12 +6,14 @@ on:
       - release-4.0
       - release-5.*
       - release-6.*
+      - cherry-pick-8123
   pull_request:
     branches:
       - master
       - release-4.0
       - release-5.*
       - release-6.*
+      - cherry-pick-8123
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -48,29 +50,3 @@ jobs:
           [ $WORKER_ID -eq $WORKER_COUNT ] && make ci-test-job-submod
           mv covprofile covprofile_$WORKER_ID
           sed -i "/failpoint_binding/d" covprofile_$WORKER_ID
-      - name: Upload coverage result ${{ matrix.worker_id }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: cover-reports
-          path: covprofile_${{ matrix.worker_id }}
-  report-coverage:
-    needs: chunks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Download chunk report
-        uses: actions/download-artifact@v2
-        with:
-          name: cover-reports
-      - name: Merge
-        env:
-          TOTAL_JOBS: ${{needs.chunks.outputs.job-total}}
-        run: for i in $(seq 1 $TOTAL_JOBS); do cat covprofile_$i >> covprofile; done
-      - name: Send coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV }}
-          file: ./covprofile
-          flags: unittests
-          name: codecov-umbrella

--- a/client/base_client.go
+++ b/client/base_client.go
@@ -381,6 +381,7 @@ func (c *baseClient) switchLeader(addrs []string) error {
 	// Set PD leader and Global TSO Allocator (which is also the PD leader)
 	c.leader.Store(addr)
 	c.allocators.Store(globalDCLocation, addr)
+	c.scheduleUpdateConnectionCtxs()
 	log.Info("[pd] switch leader", zap.String("new-leader", addr), zap.String("old-leader", oldLeader))
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7997, cherry-pick for #8123.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Call ``scheduleUpdateConnectionCtxs`` after leader switch to update connection contexts.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
