### PR TITLE
tests: fix race of TestWatcherCompacted

### DIFF
--- a/tests/server/watch/leader_watch_test.go
+++ b/tests/server/watch/leader_watch_test.go
@@ -95,6 +95,6 @@ func TestWatcherCompacted(t *testing.T) {
 	err = pd2.Run()
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
-		return pd2.GetLeader().GetName() == pd1.GetConfig().Name
+		return cluster.WaitLeader() != "" && pd2.GetLeader().GetName() == pd1.GetConfig().Name
 	})
 }

--- a/tests/server/watch/leader_watch_test.go
+++ b/tests/server/watch/leader_watch_test.go
@@ -95,6 +95,6 @@ func TestWatcherCompacted(t *testing.T) {
 	err = pd2.Run()
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
-		return cluster.WaitLeader() != "" && pd2.GetLeader().GetName() == pd1.GetConfig().Name
+		return len(cluster.WaitLeader()) > 0 && pd2.GetLeader().GetName() == pd1.GetConfig().Name
 	})
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9194

### What is changed and how does it work?

If there is an election, the resource control initialization might race with `GetConfig`.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
