### PR TITLE
fix(syncer): prevent waiting on retry interval when leader steps down

### DIFF
--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -173,6 +173,11 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					if err = stream.CloseSend(); err != nil {
 						log.Error("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
 					}
+					// Check if the leader is still there to avoid waiting for a `retryInterval`.
+					if s.server.GetLeader() == nil {
+						log.Info("stop synchronizing with leader due to leader stepped down")
+						return
+					}
 					select {
 					case <-ctx.Done():
 						log.Info("stop synchronizing with leader due to context canceled")

--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -175,12 +175,14 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					}
 					// Check if the leader is still there to avoid waiting for a `retryInterval`.
 					if s.server.GetLeader() == nil {
-						log.Info("stop synchronizing with leader due to leader stepped down")
+						log.Info("stop synchronizing with leader due to leader stepped down",
+							zap.String("server", s.server.Name()), zap.Uint64("next-index", s.history.getNextIndex()))
 						return
 					}
 					select {
 					case <-ctx.Done():
-						log.Info("stop synchronizing with leader due to context canceled")
+						log.Info("stop synchronizing with leader due to context canceled",
+							zap.String("server", s.server.Name()), zap.Uint64("next-index", s.history.getNextIndex()))
 						return
 					case <-time.After(retryInterval):
 					}

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -174,7 +174,7 @@ func TestRegionSyncer(t *testing.T) {
 		return !leaderServer.GetServer().GetRaftCluster().GetRegionSyncer().IsRunning()
 	})
 	re.NotNil(leaderServer)
-	loadRegions := leaderServer.GetServer().GetRaftCluster().GetRegions()
+	loadRegions := leaderServer.GetServer().GetRegions()
 	re.Len(loadRegions, regionLen)
 	for _, region := range regions {
 		r := leaderServer.GetRegionInfoByID(region.GetID())
@@ -227,12 +227,12 @@ func TestFullSyncWithAddMember(t *testing.T) {
 	// waiting for synchronization to complete
 	var loadRegionLen int
 	testutil.Eventually(re, func() bool {
-		loadRegionLen = len(pd2.GetServer().GetRaftCluster().GetRegions())
+		loadRegionLen = len(pd2.GetServer().GetBasicCluster().GetRegions())
 		return loadRegionLen == regionLen
 	})
 	re.NoError(cluster.ResignLeader())
 	re.Equal("pd2", cluster.WaitLeader())
-	loadRegionLen = len(pd2.GetServer().GetRaftCluster().GetRegions())
+	loadRegionLen = len(pd2.GetServer().GetRegions())
 	re.Equal(regionLen, loadRegionLen)
 }
 
@@ -271,7 +271,7 @@ func TestPrepareChecker(t *testing.T) {
 	re.NotEmpty(cluster.WaitLeader())
 	// waiting for synchronization to complete
 	testutil.Eventually(re, func() bool {
-		return len(pd2.GetServer().GetRaftCluster().GetRegions()) == regionLen
+		return len(pd2.GetServer().GetBasicCluster().GetRegions()) == regionLen
 	})
 	leaderServer = cluster.GetLeaderServer()
 	err = cluster.ResignLeader()
@@ -328,7 +328,7 @@ func TestPrepareCheckerWithTransferLeader(t *testing.T) {
 	re.NotEmpty(cluster.WaitLeader())
 	// waiting for synchronization to complete
 	testutil.Eventually(re, func() bool {
-		return len(pd2.GetServer().GetRaftCluster().GetRegions()) == regionLen
+		return len(pd2.GetServer().GetBasicCluster().GetRegions()) == regionLen
 	})
 	leaderServer = cluster.GetLeaderServer()
 	err = cluster.ResignLeader()

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -80,7 +80,9 @@ func TestRegionSyncer(t *testing.T) {
 		err = rc.HandleRegionHeartbeat(region)
 		re.NoError(err)
 	}
-	time.Sleep(time.Second)
+	testutil.Eventually(re, func() bool {
+		return len(rc.GetRegions()) == regionLen
+	})
 	close(mockSyncFull)
 
 	checkRegions := func() {
@@ -223,11 +225,15 @@ func TestFullSyncWithAddMember(t *testing.T) {
 	re.NoError(pd2.Run())
 	re.Equal("pd1", cluster.WaitLeader())
 	// waiting for synchronization to complete
-	time.Sleep(3 * time.Second)
+	var loadRegionLen int
+	testutil.Eventually(re, func() bool {
+		loadRegionLen = len(pd2.GetServer().GetRaftCluster().GetRegions())
+		return loadRegionLen == regionLen
+	})
 	re.NoError(cluster.ResignLeader())
 	re.Equal("pd2", cluster.WaitLeader())
-	loadRegions := pd2.GetServer().GetRaftCluster().GetRegions()
-	re.Len(loadRegions, regionLen)
+	loadRegionLen = len(pd2.GetServer().GetRaftCluster().GetRegions())
+	re.Equal(regionLen, loadRegionLen)
 }
 
 func TestPrepareChecker(t *testing.T) {
@@ -264,7 +270,9 @@ func TestPrepareChecker(t *testing.T) {
 	re.NoError(err)
 	re.NotEmpty(cluster.WaitLeader())
 	// waiting for synchronization to complete
-	time.Sleep(3 * time.Second)
+	testutil.Eventually(re, func() bool {
+		return len(pd2.GetServer().GetRaftCluster().GetRegions()) == regionLen
+	})
 	leaderServer = cluster.GetLeaderServer()
 	err = cluster.ResignLeader()
 	re.NoError(err)
@@ -275,8 +283,9 @@ func TestPrepareChecker(t *testing.T) {
 		err = rc.HandleRegionHeartbeat(region)
 		re.NoError(err)
 	}
-	time.Sleep(time.Second)
-	re.True(rc.IsPrepared())
+	testutil.Eventually(re, func() bool {
+		return rc.IsPrepared()
+	})
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/changeCoordinatorTicker"))
 }
 
@@ -318,7 +327,9 @@ func TestPrepareCheckerWithTransferLeader(t *testing.T) {
 	re.NoError(err)
 	re.NotEmpty(cluster.WaitLeader())
 	// waiting for synchronization to complete
-	time.Sleep(3 * time.Second)
+	testutil.Eventually(re, func() bool {
+		return len(pd2.GetServer().GetRaftCluster().GetRegions()) == regionLen
+	})
 	leaderServer = cluster.GetLeaderServer()
 	err = cluster.ResignLeader()
 	re.NoError(err)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #9230.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
When the leader steps down, we should exit the region syncer on the followers ASAP.
This PR fixes this problem by checking whether the leader is still there before retrying.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Mannual test

```bash
[2025/04/22 13:49:20.418 +08:00] [INFO] [leadership.go:404] ["current leadership is deleted"] [revision=507] [leader-key=/pd/7496010051441429963/leader] [purpose="leader election"]
[2025/04/22 13:49:20.421 +08:00] [ERROR] [client.go:172] ["region sync with leader meet error"] [error="[PD:grpc:ErrGRPCRecv]receive response error: rpc error: code = Canceled desc = context canceled"]
[2025/04/22 13:49:20.425 +08:00] [INFO] [client.go:178] ["stop synchronizing with leader due to leader stepped down"] [server=pd-1] [next-index=305]
[2025/04/22 13:49:20.426 +08:00] [INFO] [server.go:1625] ["pd leader has changed, try to re-campaign a pd leader"]
[2025/04/22 13:49:20.429 +08:00] [INFO] [server.go:1664] ["start to campaign PD leader"] [campaign-leader-name=pd-1]
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
