### PR TITLE
Test: add follower proxy when pd leader changed

### DIFF
--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -509,12 +509,27 @@ func TestTSOFollowerProxyWhenLeaderChanged(t *testing.T) {
 		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		_, _, err = pdClient.GetTS(reqCtx)
-		re.ErrorContains(err, errMsg)
+		if errMsg != "" {
+			re.ErrorContains(err, errMsg)
+		} else {
+			re.NoError(err)
+		}
 	}
 	checkErrFn("rpc error")
-	// try again
 	pdCluster.WaitLeader()
+	// try again, the error is same
 	checkErrFn("rpc error")
+	// it will work when pull/9219 is merged
+	//testutil.Eventually(re, func() bool {
+	//	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	//	defer cancel()
+	//	_, _, err = pdClient.GetTS(reqCtx)
+	//	if err != nil {
+	//		re.Contains(err.Error(), "pd is not leader of cluster")
+	//		return false
+	//	}
+	//	return err == nil
+	//}, testutil.WithWaitFor(time.Second))
 }
 
 func TestTSONotLeader(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
