### PR TITLE
tests: unify the store address format in tests

### DIFF
--- a/pkg/core/store_test.go
+++ b/pkg/core/store_test.go
@@ -65,7 +65,7 @@ func TestDistinctScore(t *testing.T) {
 }
 
 func TestCloneStore(_ *testing.T) {
-	meta := &metapb.Store{Id: 1, Address: "mock://tikv-1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}}
+	meta := &metapb.Store{Id: 1, Address: "mock://tikv-1:1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}}
 	store := NewStoreInfo(meta)
 	start := time.Now()
 	wg := sync.WaitGroup{}
@@ -90,7 +90,7 @@ func TestCloneStore(_ *testing.T) {
 
 func TestCloneMetaStore(t *testing.T) {
 	re := require.New(t)
-	store := &metapb.Store{Id: 1, Address: "mock://tikv-1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}}
+	store := &metapb.Store{Id: 1, Address: "mock://tikv-1:1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}}
 	store2 := typeutil.DeepClone(NewStoreInfo(store).meta, StoreFactory)
 	re.Equal(store2.Labels, store.Labels)
 	store2.Labels[0].Value = "changed value"
@@ -99,7 +99,7 @@ func TestCloneMetaStore(t *testing.T) {
 
 func BenchmarkStoreClone(b *testing.B) {
 	meta := &metapb.Store{Id: 1,
-		Address: "mock://tikv-1",
+		Address: "mock://tikv-1:1",
 		Labels:  []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}}
 	store := NewStoreInfo(meta)
 	b.ResetTimer()

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -45,10 +45,10 @@ func TestRegionStatistics(t *testing.T) {
 	}
 
 	metaStores := []*metapb.Store{
-		{Id: 1, Address: "mock://tikv-1"},
-		{Id: 2, Address: "mock://tikv-2"},
-		{Id: 3, Address: "mock://tikv-3"},
-		{Id: 7, Address: "mock://tikv-7"},
+		{Id: 1, Address: "mock://tikv-1:1"},
+		{Id: 2, Address: "mock://tikv-2:2"},
+		{Id: 3, Address: "mock://tikv-3:3"},
+		{Id: 7, Address: "mock://tikv-7:7"},
 	}
 
 	stores := make([]*core.StoreInfo, 0, len(metaStores))
@@ -134,10 +134,10 @@ func TestRegionStatisticsWithPlacementRule(t *testing.T) {
 		{Id: 9, StoreId: 8, IsWitness: true},
 	}
 	metaStores := []*metapb.Store{
-		{Id: 1, Address: "mock://tikv-1"},
-		{Id: 2, Address: "mock://tikv-2"},
-		{Id: 3, Address: "mock://tikv-3"},
-		{Id: 7, Address: "mock://tikv-7"},
+		{Id: 1, Address: "mock://tikv-1:1"},
+		{Id: 2, Address: "mock://tikv-2:2"},
+		{Id: 3, Address: "mock://tikv-3:3"},
+		{Id: 7, Address: "mock://tikv-7:7"},
 	}
 
 	stores := make([]*core.StoreInfo, 0, len(metaStores))
@@ -223,9 +223,9 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 	regionID := 1
 	f := func(labels []map[string]string, res string, locationLabels []string) {
 		metaStores := []*metapb.Store{
-			{Id: 1, Address: "mock://tikv-1"},
-			{Id: 2, Address: "mock://tikv-2"},
-			{Id: 3, Address: "mock://tikv-3"},
+			{Id: 1, Address: "mock://tikv-1:1"},
+			{Id: 2, Address: "mock://tikv-2:2"},
+			{Id: 3, Address: "mock://tikv-3:3"},
 		}
 		stores := make([]*core.StoreInfo, 0, len(labels))
 		for i, m := range metaStores {
@@ -255,7 +255,7 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 	re.Equal(nonIsolation, label)
 	label = GetRegionLabelIsolation(nil, nil)
 	re.Equal(nonIsolation, label)
-	store := core.NewStoreInfo(&metapb.Store{Id: 1, Address: "mock://tikv-1"}, core.SetStoreLabels([]*metapb.StoreLabel{{Key: "foo", Value: "bar"}}))
+	store := core.NewStoreInfo(&metapb.Store{Id: 1, Address: "mock://tikv-1:1"}, core.SetStoreLabels([]*metapb.StoreLabel{{Key: "foo", Value: "bar"}}))
 	label = GetRegionLabelIsolation([]*core.StoreInfo{store}, locationLabels)
 	re.Equal("zone", label)
 
@@ -286,9 +286,9 @@ func BenchmarkObserve(b *testing.B) {
 	}
 
 	metaStores := []*metapb.Store{
-		{Id: 1, Address: "mock://tikv-1"},
-		{Id: 2, Address: "mock://tikv-2"},
-		{Id: 3, Address: "mock://tikv-3"},
+		{Id: 1, Address: "mock://tikv-1:1"},
+		{Id: 2, Address: "mock://tikv-2:2"},
+		{Id: 3, Address: "mock://tikv-3:3"},
 	}
 
 	stores := make([]*core.StoreInfo, 0, len(metaStores))

--- a/pkg/statistics/store_collection_test.go
+++ b/pkg/statistics/store_collection_test.go
@@ -15,7 +15,7 @@
 package statistics
 
 import (
-	"strconv"
+	"fmt"
 	"testing"
 	"time"
 
@@ -39,15 +39,15 @@ func TestStoreStatistics(t *testing.T) {
 	opt.SetReplicationConfig(rep)
 
 	metaStores := []*metapb.Store{
-		{Id: 1, Address: "mock://tikv-1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}},
-		{Id: 2, Address: "mock://tikv-2", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h2"}}},
-		{Id: 3, Address: "mock://tikv-3", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z2"}, {Key: "host", Value: "h1"}}},
-		{Id: 4, Address: "mock://tikv-4", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z2"}, {Key: "host", Value: "h2"}}},
-		{Id: 5, Address: "mock://tikv-5", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z3"}, {Key: "host", Value: "h1"}}},
-		{Id: 6, Address: "mock://tikv-6", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z3"}, {Key: "host", Value: "h2"}}},
-		{Id: 7, Address: "mock://tikv-7", Labels: []*metapb.StoreLabel{{Key: "host", Value: "h1"}}},
-		{Id: 8, Address: "mock://tikv-8", Labels: []*metapb.StoreLabel{{Key: "host", Value: "h2"}}},
-		{Id: 8, Address: "mock://tikv-9", Labels: []*metapb.StoreLabel{{Key: "host", Value: "h3"}}, State: metapb.StoreState_Tombstone, NodeState: metapb.NodeState_Removed},
+		{Id: 1, Address: "mock://tikv-1:1", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h1"}}},
+		{Id: 2, Address: "mock://tikv-2:2", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}, {Key: "host", Value: "h2"}}},
+		{Id: 3, Address: "mock://tikv-3:3", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z2"}, {Key: "host", Value: "h1"}}},
+		{Id: 4, Address: "mock://tikv-4:4", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z2"}, {Key: "host", Value: "h2"}}},
+		{Id: 5, Address: "mock://tikv-5:5", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z3"}, {Key: "host", Value: "h1"}}},
+		{Id: 6, Address: "mock://tikv-6:6", Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z3"}, {Key: "host", Value: "h2"}}},
+		{Id: 7, Address: "mock://tikv-7:7", Labels: []*metapb.StoreLabel{{Key: "host", Value: "h1"}}},
+		{Id: 8, Address: "mock://tikv-8:8", Labels: []*metapb.StoreLabel{{Key: "host", Value: "h2"}}},
+		{Id: 8, Address: "mock://tikv-9:9", Labels: []*metapb.StoreLabel{{Key: "host", Value: "h3"}}, State: metapb.StoreState_Tombstone, NodeState: metapb.NodeState_Removed},
 	}
 	storesStats := NewStoresStats()
 	stores := make([]*core.StoreInfo, 0, len(metaStores))
@@ -108,7 +108,7 @@ func TestSummaryStoreInfos(t *testing.T) {
 	for _, storeID := range []int{1, 3} {
 		storeInfos[uint64(storeID)] = &StoreSummaryInfo{
 			isTiFlash: false,
-			StoreInfo: core.NewStoreInfo(&metapb.Store{Id: uint64(storeID), Address: "mock://tikv" + strconv.Itoa(storeID)}, core.SetLastHeartbeatTS(time.Now())),
+			StoreInfo: core.NewStoreInfo(&metapb.Store{Id: uint64(storeID), Address: fmt.Sprintf("mock://tikv-%d:%d", storeID, storeID)}, core.SetLastHeartbeatTS(time.Now())),
 		}
 		storeLoads[uint64(storeID)] = []float64{1, 2, 0, 0, 5}
 		for i, v := range storeLoads[uint64(storeID)] {

--- a/pkg/unsaferecovery/unsafe_recovery_controller_test.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller_test.go
@@ -1845,8 +1845,8 @@ func newTestStores(n uint64, version string) []*core.StoreInfo {
 	for i := uint64(1); i <= n; i++ {
 		store := &metapb.Store{
 			Id:            i,
-			Address:       fmt.Sprintf("127.0.0.1:%d", i),
-			StatusAddress: fmt.Sprintf("127.0.0.1:%d", i),
+			Address:       fmt.Sprintf("mock://tikv-%d:%d", i, i),
+			StatusAddress: fmt.Sprintf("mock://tikv-%d:%d", i, i+1),
 			State:         metapb.StoreState_Up,
 			Version:       version,
 			DeployPath:    getTestDeployPath(i),

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1143,7 +1143,7 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 		}
 		store := &metapb.Store{
 			Id:      i,
-			Address: fmt.Sprintf("127.0.0.1:%d", i),
+			Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 			State:   metapb.StoreState_Up,
 			Labels:  labels,
 		}
@@ -2205,8 +2205,8 @@ func newTestStores(n uint64, version string) []*core.StoreInfo {
 	for i := uint64(1); i <= n; i++ {
 		store := &metapb.Store{
 			Id:            i,
-			Address:       fmt.Sprintf("127.0.0.1:%d", i),
-			StatusAddress: fmt.Sprintf("127.0.0.1:%d", i),
+			Address:       fmt.Sprintf("mock://tikv-%d:%d", i, i),
+			StatusAddress: fmt.Sprintf("mock://tikv-%d:%d", i, i+1),
 			State:         metapb.StoreState_Up,
 			Version:       version,
 			DeployPath:    getTestDeployPath(i),

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -373,7 +373,7 @@ func (s *TestServer) GetStoreRegions(storeID uint64) []*core.RegionInfo {
 func (s *TestServer) BootstrapCluster() error {
 	bootstrapReq := &pdpb.BootstrapRequest{
 		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
-		Store:  &metapb.Store{Id: 1, Address: "mock://1", LastHeartbeat: time.Now().UnixNano()},
+		Store:  &metapb.Store{Id: 1, Address: "mock://tikv-1:1", LastHeartbeat: time.Now().UnixNano()},
 		Region: &metapb.Region{Id: 2, Peers: []*metapb.Peer{{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter}}},
 	}
 	resp, err := s.grpcServer.Bootstrap(context.Background(), bootstrapReq)

--- a/tests/compatibility/version_upgrade_test.go
+++ b/tests/compatibility/version_upgrade_test.go
@@ -47,7 +47,7 @@ func TestStoreRegister(t *testing.T) {
 		Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 		Store: &metapb.Store{
 			Id:      1,
-			Address: "mock-1",
+			Address: "mock://tikv-1:1",
 			Version: "2.0.1",
 		},
 	}
@@ -75,7 +75,7 @@ func TestStoreRegister(t *testing.T) {
 		Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 		Store: &metapb.Store{
 			Id:      4,
-			Address: "mock-4",
+			Address: "mock://tikv-4:4",
 			Version: "1.0.1",
 		},
 	}
@@ -102,7 +102,7 @@ func TestRollingUpgrade(t *testing.T) {
 			Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      1,
-				Address: "mock-1",
+				Address: "mock://tikv-1:1",
 				Version: "2.0.1",
 			},
 		},
@@ -110,7 +110,7 @@ func TestRollingUpgrade(t *testing.T) {
 			Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      4,
-				Address: "mock-4",
+				Address: "mock://tikv-4:4",
 				Version: "2.0.1",
 			},
 		},
@@ -118,7 +118,7 @@ func TestRollingUpgrade(t *testing.T) {
 			Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      6,
-				Address: "mock-6",
+				Address: "mock://tikv-6:6",
 				Version: "2.0.1",
 			},
 		},
@@ -126,7 +126,7 @@ func TestRollingUpgrade(t *testing.T) {
 			Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      7,
-				Address: "mock-7",
+				Address: "mock://tikv-7:7",
 				Version: "2.0.1",
 			},
 		},

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -986,16 +986,16 @@ var (
 	// If we alloc ID in client in the future, these IDs must be updated.
 	stores = []*metapb.Store{
 		{Id: 1,
-			Address: "localhost:1",
+			Address: "mock://tikv-1:1",
 		},
 		{Id: 2,
-			Address: "localhost:2",
+			Address: "mock://tikv-2:2",
 		},
 		{Id: 3,
-			Address: "localhost:3",
+			Address: "mock://tikv-3:3",
 		},
 		{Id: 4,
-			Address: "localhost:4",
+			Address: "mock://tikv-4:4",
 		},
 	}
 

--- a/tests/integrations/mcs/scheduling/api_test.go
+++ b/tests/integrations/mcs/scheduling/api_test.go
@@ -622,14 +622,14 @@ func (suite *apiTestSuite) checkStores(cluster *tests.TestCluster) {
 		{
 			// metapb.StoreState_Up == 0
 			Id:        1,
-			Address:   "tikv1",
+			Address:   "mock://tikv-1:1",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "2.0.0",
 		},
 		{
 			Id:        4,
-			Address:   "tikv4",
+			Address:   "mock://tikv-4:4",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "2.0.0",
@@ -637,7 +637,7 @@ func (suite *apiTestSuite) checkStores(cluster *tests.TestCluster) {
 		{
 			// metapb.StoreState_Offline == 1
 			Id:        6,
-			Address:   "tikv6",
+			Address:   "mock://tikv-6:6",
 			State:     metapb.StoreState_Offline,
 			NodeState: metapb.NodeState_Removing,
 			Version:   "2.0.0",
@@ -645,7 +645,7 @@ func (suite *apiTestSuite) checkStores(cluster *tests.TestCluster) {
 		{
 			// metapb.StoreState_Tombstone == 2
 			Id:        7,
-			Address:   "tikv7",
+			Address:   "mock://tikv-7:7",
 			State:     metapb.StoreState_Tombstone,
 			NodeState: metapb.NodeState_Removed,
 			Version:   "2.0.0",
@@ -677,17 +677,17 @@ func (suite *apiTestSuite) checkStores(cluster *tests.TestCluster) {
 	urlPrefix = fmt.Sprintf("%s/scheduling/api/v1/stores/1", scheServerAddr)
 	err = testutil.ReadGetJSON(re, tests.TestDialClient, urlPrefix, &resp)
 	re.NoError(err)
-	re.Equal("tikv1", resp["store"].(map[string]any)["address"])
+	re.Equal("mock://tikv-1:1", resp["store"].(map[string]any)["address"])
 	re.Equal("Up", resp["store"].(map[string]any)["state_name"])
 	urlPrefix = fmt.Sprintf("%s/scheduling/api/v1/stores/6", scheServerAddr)
 	err = testutil.ReadGetJSON(re, tests.TestDialClient, urlPrefix, &resp)
 	re.NoError(err)
-	re.Equal("tikv6", resp["store"].(map[string]any)["address"])
+	re.Equal("mock://tikv-6:6", resp["store"].(map[string]any)["address"])
 	re.Equal("Offline", resp["store"].(map[string]any)["state_name"])
 	urlPrefix = fmt.Sprintf("%s/scheduling/api/v1/stores/7", scheServerAddr)
 	err = testutil.ReadGetJSON(re, tests.TestDialClient, urlPrefix, &resp)
 	re.NoError(err)
-	re.Equal("tikv7", resp["store"].(map[string]any)["address"])
+	re.Equal("mock://tikv-7:7", resp["store"].(map[string]any)["address"])
 	re.Equal("Tombstone", resp["store"].(map[string]any)["state_name"])
 	urlPrefix = fmt.Sprintf("%s/scheduling/api/v1/stores/233", scheServerAddr)
 	testutil.CheckGetJSON(tests.TestDialClient, urlPrefix, nil,

--- a/tests/integrations/mcs/scheduling/config_test.go
+++ b/tests/integrations/mcs/scheduling/config_test.go
@@ -180,7 +180,7 @@ func (suite *configTestSuite) TestSchedulerConfigWatch() {
 	err = suite.pdLeaderServer.GetServer().GetRaftCluster().PutMetaStore(
 		&metapb.Store{
 			Id:            2,
-			Address:       "mock://2",
+			Address:       "mock://tikv-2:2",
 			State:         metapb.StoreState_Up,
 			NodeState:     metapb.NodeState_Serving,
 			LastHeartbeat: time.Now().UnixNano(),

--- a/tests/integrations/mcs/scheduling/meta_test.go
+++ b/tests/integrations/mcs/scheduling/meta_test.go
@@ -83,7 +83,7 @@ func (suite *metaTestSuite) TestStoreWatch() {
 	re.NoError(err)
 	for i := uint64(1); i <= 4; i++ {
 		suite.getRaftCluster().PutMetaStore(
-			&metapb.Store{Id: i, Address: fmt.Sprintf("mock-%d", i), State: metapb.StoreState_Up, NodeState: metapb.NodeState_Serving, LastHeartbeat: time.Now().UnixNano()},
+			&metapb.Store{Id: i, Address: fmt.Sprintf("mock://tikv-%d:%d", i, i), State: metapb.StoreState_Up, NodeState: metapb.NodeState_Serving, LastHeartbeat: time.Now().UnixNano()},
 		)
 	}
 
@@ -108,7 +108,7 @@ func (suite *metaTestSuite) TestStoreWatch() {
 
 	// test synchronized store labels
 	suite.getRaftCluster().PutMetaStore(
-		&metapb.Store{Id: 5, Address: "mock-5", State: metapb.StoreState_Up, NodeState: metapb.NodeState_Serving, LastHeartbeat: time.Now().UnixNano(), Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}}},
+		&metapb.Store{Id: 5, Address: "mock://tikv-5:5", State: metapb.StoreState_Up, NodeState: metapb.NodeState_Serving, LastHeartbeat: time.Now().UnixNano(), Labels: []*metapb.StoreLabel{{Key: "zone", Value: "z1"}}},
 	)
 	testutil.Eventually(re, func() bool {
 		if len(cluster.GetStore(5).GetLabels()) == 0 {

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -176,7 +176,7 @@ func (suite *serverTestSuite) TestForwardStoreHeartbeat() {
 			Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      1,
-				Address: "tikv1",
+				Address: "mock://tikv-1:1",
 				State:   metapb.StoreState_Up,
 				Version: "7.0.0",
 			},
@@ -322,7 +322,7 @@ func (suite *serverTestSuite) TestSchedulerSync() {
 	err = suite.pdLeader.GetServer().GetRaftCluster().PutMetaStore(
 		&metapb.Store{
 			Id:            2,
-			Address:       "mock://2",
+			Address:       "mock://tikv-2:2",
 			State:         metapb.StoreState_Up,
 			NodeState:     metapb.NodeState_Serving,
 			LastHeartbeat: time.Now().UnixNano(),
@@ -437,7 +437,7 @@ func (suite *serverTestSuite) TestForwardRegionHeartbeat() {
 				Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 				Store: &metapb.Store{
 					Id:      i,
-					Address: fmt.Sprintf("mock://%d", i),
+					Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 					State:   metapb.StoreState_Up,
 					Version: "7.0.0",
 				},
@@ -519,7 +519,7 @@ func (suite *serverTestSuite) TestStoreLimit() {
 				Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 				Store: &metapb.Store{
 					Id:      i,
-					Address: fmt.Sprintf("mock://%d", i),
+					Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 					State:   metapb.StoreState_Up,
 					Version: "7.0.0",
 				},
@@ -709,7 +709,7 @@ func (suite *serverTestSuite) TestOnlineProgress() {
 				Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 				Store: &metapb.Store{
 					Id:      i,
-					Address: fmt.Sprintf("mock://%d", i),
+					Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 					State:   metapb.StoreState_Up,
 					Version: "7.0.0",
 				},
@@ -732,7 +732,7 @@ func (suite *serverTestSuite) TestOnlineProgress() {
 			Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      4,
-				Address: fmt.Sprintf("mock://%d", 4),
+				Address: "mock://tikv-4:4",
 				State:   metapb.StoreState_Up,
 				Version: "7.0.0",
 			},
@@ -779,7 +779,7 @@ func (suite *serverTestSuite) TestBatchSplit() {
 				Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 				Store: &metapb.Store{
 					Id:      i,
-					Address: fmt.Sprintf("mock://%d", i),
+					Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 					State:   metapb.StoreState_Up,
 					Version: "7.0.0",
 				},
@@ -852,7 +852,7 @@ func (suite *serverTestSuite) TestBatchSplitCompatibility() {
 				Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 				Store: &metapb.Store{
 					Id:      i,
-					Address: fmt.Sprintf("mock://%d", i),
+					Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 					State:   metapb.StoreState_Up,
 					Version: "7.0.0",
 				},
@@ -995,7 +995,7 @@ func (suite *serverTestSuite) TestConcurrentBatchSplit() {
 				Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
 				Store: &metapb.Store{
 					Id:      i,
-					Address: fmt.Sprintf("mock://%d", i),
+					Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 					State:   metapb.StoreState_Up,
 					Version: "7.0.0",
 				},

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -794,7 +794,7 @@ func TestRemovingProgress(t *testing.T) {
 	clusterID := leader.GetClusterID()
 	req := &pdpb.BootstrapRequest{
 		Header: testutil.NewRequestHeader(clusterID),
-		Store:  &metapb.Store{Id: 1, Address: "127.0.0.1:0"},
+		Store:  &metapb.Store{Id: 1, Address: "mock://tikv-1:1"},
 		Region: &metapb.Region{Id: 2, Peers: []*metapb.Peer{{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter}}},
 	}
 	resp, err := grpcPDClient.Bootstrap(context.Background(), req)
@@ -971,7 +971,7 @@ func TestSendApiWhenRestartRaftCluster(t *testing.T) {
 	clusterID := leader.GetClusterID()
 	req := &pdpb.BootstrapRequest{
 		Header: testutil.NewRequestHeader(clusterID),
-		Store:  &metapb.Store{Id: 1, Address: "127.0.0.1:0"},
+		Store:  &metapb.Store{Id: 1, Address: "mock://tikv-1:1"},
 		Region: &metapb.Region{Id: 2, Peers: []*metapb.Peer{{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter}}},
 	}
 	resp, err := grpcPDClient.Bootstrap(context.Background(), req)
@@ -1015,7 +1015,7 @@ func TestPreparingProgress(t *testing.T) {
 	clusterID := leader.GetClusterID()
 	req := &pdpb.BootstrapRequest{
 		Header: testutil.NewRequestHeader(clusterID),
-		Store:  &metapb.Store{Id: 1, Address: "127.0.0.1:0"},
+		Store:  &metapb.Store{Id: 1, Address: "mock://tikv-1:1"},
 		Region: &metapb.Region{Id: 2, Peers: []*metapb.Peer{{Id: 3, StoreId: 1, Role: metapb.PeerRole_Voter}}},
 	}
 	resp, err := grpcPDClient.Bootstrap(context.Background(), req)

--- a/tests/server/api/label_test.go
+++ b/tests/server/api/label_test.go
@@ -50,7 +50,7 @@ func (suite *labelsStoreTestSuite) SetupSuite() {
 	suite.stores = []*metapb.Store{
 		{
 			Id:        1,
-			Address:   "tikv1",
+			Address:   "mock://tikv-1:1",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Labels: []*metapb.StoreLabel{
@@ -67,7 +67,7 @@ func (suite *labelsStoreTestSuite) SetupSuite() {
 		},
 		{
 			Id:        4,
-			Address:   "tikv4",
+			Address:   "mock://tikv-4:4",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Labels: []*metapb.StoreLabel{
@@ -84,7 +84,7 @@ func (suite *labelsStoreTestSuite) SetupSuite() {
 		},
 		{
 			Id:        6,
-			Address:   "tikv6",
+			Address:   "mock://tikv-6:6",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Labels: []*metapb.StoreLabel{
@@ -101,7 +101,7 @@ func (suite *labelsStoreTestSuite) SetupSuite() {
 		},
 		{
 			Id:        7,
-			Address:   "tikv7",
+			Address:   "mock://tikv-7:7",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Labels: []*metapb.StoreLabel{
@@ -232,7 +232,7 @@ func (suite *strictlyLabelsStoreTestSuite) TestStoreMatch() {
 		{
 			store: &metapb.Store{
 				Id:      1,
-				Address: "tikv1",
+				Address: "mock://tikv-1:1",
 				State:   metapb.StoreState_Up,
 				Labels: []*metapb.StoreLabel{
 					{
@@ -251,7 +251,7 @@ func (suite *strictlyLabelsStoreTestSuite) TestStoreMatch() {
 		{
 			store: &metapb.Store{
 				Id:      2,
-				Address: "tikv2",
+				Address: "mock://tikv-2:2",
 				State:   metapb.StoreState_Up,
 				Labels:  []*metapb.StoreLabel{},
 				Version: "3.0.0",
@@ -262,7 +262,7 @@ func (suite *strictlyLabelsStoreTestSuite) TestStoreMatch() {
 		{
 			store: &metapb.Store{
 				Id:      2,
-				Address: "tikv2",
+				Address: "mock://tikv-2:2",
 				State:   metapb.StoreState_Up,
 				Labels: []*metapb.StoreLabel{
 					{
@@ -286,7 +286,7 @@ func (suite *strictlyLabelsStoreTestSuite) TestStoreMatch() {
 		{
 			store: &metapb.Store{
 				Id:      3,
-				Address: "tiflash1",
+				Address: "mock://tiflash-3:3",
 				State:   metapb.StoreState_Up,
 				Labels: []*metapb.StoreLabel{
 					{
@@ -320,7 +320,7 @@ func (suite *strictlyLabelsStoreTestSuite) TestStoreMatch() {
 				Version: testCase.store.Version,
 			},
 		})
-		if testCase.store.Address == "tiflash1" {
+		if testCase.store.Address == "mock://tiflash-3:3" {
 			re.Contains(resp.GetHeader().GetError().String(), testCase.expectError)
 			continue
 		}

--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -914,7 +914,7 @@ func (suite *ruleTestSuite) checkLeaderAndVoter(cluster *tests.TestCluster) {
 	stores := []*metapb.Store{
 		{
 			Id:        1,
-			Address:   "tikv1",
+			Address:   "mock://tikv-1:1",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "7.5.0",
@@ -922,7 +922,7 @@ func (suite *ruleTestSuite) checkLeaderAndVoter(cluster *tests.TestCluster) {
 		},
 		{
 			Id:        2,
-			Address:   "tikv2",
+			Address:   "mock://tikv-2:2",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "7.5.0",
@@ -1304,14 +1304,14 @@ func (suite *regionRuleTestSuite) checkRegionPlacementRule(cluster *tests.TestCl
 	stores := []*metapb.Store{
 		{
 			Id:        1,
-			Address:   "tikv1",
+			Address:   "mock://tikv-1:1",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "2.0.0",
 		},
 		{
 			Id:        2,
-			Address:   "tikv2",
+			Address:   "mock://tikv-2:2",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "2.0.0",

--- a/tests/server/api/store_test.go
+++ b/tests/server/api/store_test.go
@@ -72,14 +72,14 @@ func (suite *storeTestSuite) SetupSuite() {
 		{
 			// metapb.StoreState_Up == 0
 			Id:        1,
-			Address:   "tikv1",
+			Address:   "mock://tikv-1:1",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "2.0.0",
 		},
 		{
 			Id:        4,
-			Address:   "tikv4",
+			Address:   "mock://tikv-4:4",
 			State:     metapb.StoreState_Up,
 			NodeState: metapb.NodeState_Serving,
 			Version:   "2.0.0",
@@ -87,7 +87,7 @@ func (suite *storeTestSuite) SetupSuite() {
 		{
 			// metapb.StoreState_Offline == 1
 			Id:        6,
-			Address:   "tikv6",
+			Address:   "mock://tikv-6:6",
 			State:     metapb.StoreState_Offline,
 			NodeState: metapb.NodeState_Removing,
 			Version:   "2.0.0",
@@ -95,7 +95,7 @@ func (suite *storeTestSuite) SetupSuite() {
 		{
 			// metapb.StoreState_Tombstone == 2
 			Id:        7,
-			Address:   "tikv7",
+			Address:   "mock://tikv-7:7",
 			State:     metapb.StoreState_Tombstone,
 			NodeState: metapb.NodeState_Removed,
 			Version:   "2.0.0",
@@ -173,7 +173,7 @@ func (suite *storeTestSuite) TestStoresList() {
 	s := &server.GrpcServer{Server: suite.svr}
 	store := &metapb.Store{
 		Id:            100,
-		Address:       fmt.Sprintf("tikv%d", 100),
+		Address:       "mock://tikv-100:100",
 		State:         metapb.StoreState_Up,
 		Version:       versioninfo.MinSupportedVersion(versioninfo.Version2_0).String(),
 		LastHeartbeat: time.Now().UnixNano() - int64(1*time.Hour),

--- a/tests/server/api/testutil.go
+++ b/tests/server/api/testutil.go
@@ -112,7 +112,7 @@ var (
 
 	store = &metapb.Store{
 		Id:        1,
-		Address:   "localhost",
+		Address:   "mock://tikv-1:1",
 		NodeState: metapb.NodeState_Serving,
 	}
 	peers = []*metapb.Peer{
@@ -220,7 +220,7 @@ func mustPutStore(re *require.Assertions, svr *server.Server, id uint64, state m
 		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
 		Store: &metapb.Store{
 			Id:        id,
-			Address:   fmt.Sprintf("tikv%d", id),
+			Address:   fmt.Sprintf("mock://tikv-%d:%d", id, id),
 			State:     state,
 			NodeState: nodeState,
 			Labels:    labels,

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -66,8 +66,8 @@ const (
 	initEpochVersion uint64 = 1
 	initEpochConfVer uint64 = 1
 
-	testMetaStoreAddr = "127.0.0.1:12345"
-	testStoreAddr     = "127.0.0.1:0"
+	testMetaStoreAddr = "mock://tikv-1:12345"
+	testStoreAddr     = "mock://tikv-1:1"
 )
 
 func TestBootstrap(t *testing.T) {
@@ -149,7 +149,7 @@ func TestDamagedRegion(t *testing.T) {
 			Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      1,
-				Address: "mock-1",
+				Address: "mock://tikv-1:1",
 				Version: "2.0.1",
 			},
 		},
@@ -157,7 +157,7 @@ func TestDamagedRegion(t *testing.T) {
 			Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      2,
-				Address: "mock-4",
+				Address: "mock://tikv-2:2",
 				Version: "2.0.1",
 			},
 		},
@@ -165,7 +165,7 @@ func TestDamagedRegion(t *testing.T) {
 			Header: &pdpb.RequestHeader{ClusterId: leaderServer.GetClusterID()},
 			Store: &metapb.Store{
 				Id:      3,
-				Address: "mock-6",
+				Address: "mock://tikv-3:3",
 				Version: "2.0.1",
 			},
 		},
@@ -364,7 +364,7 @@ func TestConcurrencyGetPutConfig(t *testing.T) {
 				storeID := peer.GetStoreId()
 				client := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
 				store := getStore(re, clusterID, client, storeID)
-				store.Address = "127.0.0.1:1"
+				store.Address = "mock://tikv-1:1"
 				store.Labels = []*metapb.StoreLabel{
 					{
 						Key:   "testKey",
@@ -414,7 +414,7 @@ func TestGetPutConfig(t *testing.T) {
 	store := getStore(re, clusterID, grpcPDClient, storeID)
 
 	// Update store.
-	store.Address = "127.0.0.1:1"
+	store.Address = "mock://tikv-1:1"
 	testPutStore(re, clusterID, rc, grpcPDClient, store)
 
 	// Remove store.
@@ -664,7 +664,7 @@ func TestRaftClusterMultipleRestart(t *testing.T) {
 	// add an offline store
 	storeID, _, err := leaderServer.GetAllocator().Alloc(1)
 	re.NoError(err)
-	store := newMetaStore(storeID, "127.0.0.1:4", "2.1.0", metapb.StoreState_Offline, getTestDeployPath(storeID))
+	store := newMetaStore(storeID, "mock://tikv-1:1", "2.1.0", metapb.StoreState_Offline, getTestDeployPath(storeID))
 	rc := leaderServer.GetRaftCluster()
 	re.NotNil(rc)
 	err = rc.PutMetaStore(store)
@@ -846,7 +846,7 @@ func TestStoreVersionChange(t *testing.T) {
 	svr.SetClusterVersion("2.0.0")
 	storeID, _, err := leaderServer.GetAllocator().Alloc(1)
 	re.NoError(err)
-	store := newMetaStore(storeID, "127.0.0.1:4", "2.1.0", metapb.StoreState_Up, getTestDeployPath(storeID))
+	store := newMetaStore(storeID, "mock://tikv-1:1", "2.1.0", metapb.StoreState_Up, getTestDeployPath(storeID))
 	var wg sync.WaitGroup
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/versionChangeConcurrency", `return(true)`))
 	wg.Add(1)
@@ -880,7 +880,7 @@ func TestConcurrentHandleRegion(t *testing.T) {
 	grpcPDClient := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
 	clusterID := leaderServer.GetClusterID()
 	bootstrapCluster(re, clusterID, grpcPDClient)
-	storeAddrs := []string{"127.0.1.1:0", "127.0.1.1:1", "127.0.1.1:2"}
+	storeAddrs := []string{"mock://tikv-1:0", "mock://tikv-1:1", "mock://tikv-1:2"}
 	rc := leaderServer.GetRaftCluster()
 	re.NotNil(rc)
 	stores := make([]*metapb.Store, 0, len(storeAddrs))
@@ -1160,7 +1160,7 @@ func TestTiFlashWithPlacementRules(t *testing.T) {
 
 	tiflashStore := &metapb.Store{
 		Id:      11,
-		Address: "127.0.0.1:1",
+		Address: "mock://tiflash-1:1",
 		Labels:  []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}},
 		Version: "v4.1.0",
 	}
@@ -1213,7 +1213,7 @@ func TestReplicationModeStatus(t *testing.T) {
 	res, err := grpcPDClient.Bootstrap(context.Background(), req)
 	re.NoError(err)
 	re.Equal(replication_modepb.ReplicationMode_DR_AUTO_SYNC, res.GetReplicationStatus().GetMode()) // check status in bootstrap response
-	store := &metapb.Store{Id: 11, Address: "127.0.0.1:1", Version: "v4.1.0"}
+	store := &metapb.Store{Id: 11, Address: "mock://tikv-1:1", Version: "v4.1.0"}
 	putRes, err := putStore(grpcPDClient, clusterID, store)
 	re.NoError(err)
 	re.Equal(replication_modepb.ReplicationMode_DR_AUTO_SYNC, putRes.GetReplicationStatus().GetMode()) // check status in putStore response
@@ -1554,7 +1554,7 @@ func TestTransferLeaderForScheduler(t *testing.T) {
 	for i := 1; i <= storesNum; i++ {
 		store := &metapb.Store{
 			Id:      uint64(i),
-			Address: "127.0.0.1:" + strconv.Itoa(i),
+			Address: "mock://tikv-1:" + strconv.Itoa(i),
 		}
 		resp, err := putStore(grpcPDClient, leaderServer.GetClusterID(), store)
 		re.NoError(err)
@@ -1720,7 +1720,7 @@ func TestMinResolvedTS(t *testing.T) {
 		store := &metapb.Store{
 			Id:      storeID,
 			Version: "v6.0.0",
-			Address: "127.0.0.1:" + strconv.Itoa(int(storeID)),
+			Address: "mock://tikv-1:" + strconv.Itoa(int(storeID)),
 		}
 		if isTiflash {
 			store.Labels = []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}}
@@ -1889,7 +1889,7 @@ func TestExternalTimestamp(t *testing.T) {
 	store := &metapb.Store{
 		Id:      1,
 		Version: "v6.0.0",
-		Address: "127.0.0.1:" + strconv.Itoa(int(1)),
+		Address: "mock://tikv-1:" + strconv.Itoa(int(1)),
 	}
 	resp, err := putStore(grpcPDClient, clusterID, store)
 	re.NoError(err)

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -1213,7 +1213,7 @@ func TestReplicationModeStatus(t *testing.T) {
 	res, err := grpcPDClient.Bootstrap(context.Background(), req)
 	re.NoError(err)
 	re.Equal(replication_modepb.ReplicationMode_DR_AUTO_SYNC, res.GetReplicationStatus().GetMode()) // check status in bootstrap response
-	store := &metapb.Store{Id: 11, Address: "mock://tikv-1:1", Version: "v4.1.0"}
+	store := &metapb.Store{Id: 11, Address: "mock://tikv-11:11", Version: "v4.1.0"}
 	putRes, err := putStore(grpcPDClient, clusterID, store)
 	re.NoError(err)
 	re.Equal(replication_modepb.ReplicationMode_DR_AUTO_SYNC, putRes.GetReplicationStatus().GetMode()) // check status in putStore response
@@ -1554,7 +1554,7 @@ func TestTransferLeaderForScheduler(t *testing.T) {
 	for i := 1; i <= storesNum; i++ {
 		store := &metapb.Store{
 			Id:      uint64(i),
-			Address: "mock://tikv-1:" + strconv.Itoa(i),
+			Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 		}
 		resp, err := putStore(grpcPDClient, leaderServer.GetClusterID(), store)
 		re.NoError(err)

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -200,7 +200,7 @@ func WaitForPrimaryServing(re *require.Assertions, serverMap map[string]bs.Serve
 
 // MustPutStore is used for test purpose.
 func MustPutStore(re *require.Assertions, tc *TestCluster, store *metapb.Store) {
-	store.Address = fmt.Sprintf("tikv%d", store.GetId())
+	store.Address = fmt.Sprintf("mock://tikv-%d:%d", store.GetId(), store.GetId())
 	if len(store.Version) == 0 {
 		store.Version = versioninfo.MinSupportedVersion(versioninfo.Version2_0).String()
 	}

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -414,7 +414,7 @@ func TestStore(t *testing.T) {
 	re.Equal(20.0, limit)
 
 	// store delete addr <address>
-	args = []string{"-u", pdAddr, "store", "delete", "addr", "tikv3"}
+	args = []string{"-u", pdAddr, "store", "delete", "addr", "mock://tikv-3:3"}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.Equal("Success!\n", string(output))
 	re.NoError(err)
@@ -431,7 +431,7 @@ func TestStore(t *testing.T) {
 	// store cancel-delete addr <address>
 	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(3, storelimit.RemovePeer)
 	re.Equal(storelimit.Unlimited, limit)
-	args = []string{"-u", pdAddr, "store", "cancel-delete", "addr", "tikv3"}
+	args = []string{"-u", pdAddr, "store", "cancel-delete", "addr", "mock://tikv-3:3"}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.Equal("Success!\n", string(output))
 	re.NoError(err)

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -120,7 +120,7 @@ func bootstrap(ctx context.Context, cli pdpb.PDClient) {
 
 	store := &metapb.Store{
 		Id:      1,
-		Address: fmt.Sprintf("localhost:%d", 2),
+		Address: fmt.Sprintf("mock://tikv-1:%d", 2),
 		Version: "6.4.0-alpha",
 	}
 	region := &metapb.Region{
@@ -149,7 +149,7 @@ func putStores(ctx context.Context, cfg *config.Config, cli pdpb.PDClient, store
 	for i := uint64(1); i <= uint64(cfg.StoreCount); i++ {
 		store := &metapb.Store{
 			Id:      i,
-			Address: fmt.Sprintf("localhost:%d", i),
+			Address: fmt.Sprintf("mock://tikv-%d:%d", i, i),
 			Version: "6.4.0-alpha",
 		}
 		cctx, cancel := context.WithCancel(ctx)

--- a/tools/pd-region-bench/main.go
+++ b/tools/pd-region-bench/main.go
@@ -196,7 +196,7 @@ func (s *benchmarkSuite) prepareStores(ctx context.Context, cli pdpb.PDClient) {
 		storeID := uint64(i)
 		stores = append(stores, &metapb.Store{
 			Id:      storeID,
-			Address: fmt.Sprintf("localhost:%d", storeID),
+			Address: fmt.Sprintf("mock://tikv-%d:%d", storeID, storeID),
 			Version: version(),
 		})
 	}

--- a/tools/pd-simulator/simulator/node.go
+++ b/tools/pd-simulator/simulator/node.go
@@ -67,7 +67,7 @@ func NewNode(s *cases.Store, config *sc.SimConfig) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	store := &metapb.Store{
 		Id:      s.ID,
-		Address: fmt.Sprintf("mock:://tikv-%d", s.ID),
+		Address: fmt.Sprintf("mock:://tikv-%d:%d", s.ID, s.ID),
 		Version: config.StoreVersion,
 		Labels:  s.Labels,
 		State:   s.Status,

--- a/tools/utils/meta.go
+++ b/tools/utils/meta.go
@@ -50,7 +50,7 @@ func BootstrapCluster(ctx context.Context, cli pdpb.PDClient, header *pdpb.Reque
 
 	store := &metapb.Store{
 		Id:      1,
-		Address: fmt.Sprintf("localhost:%d", 2),
+		Address: fmt.Sprintf("mock://tikv-1:%d", 2),
 		Version: version,
 	}
 	region := &metapb.Region{


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7969.

### What is changed and how does it work?

After this PR, the store address can be unified as `mock://tikv-id:port` or `mock://tiflash-id:port` so that the bootstrap and test case won't have different store addresses for the same ID.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
