### PR TITLE
operator: fix operator count conflict 

### DIFF
--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -538,6 +538,7 @@ func (oc *Controller) addOperatorInner(op *Operator) bool {
 			zap.Uint64("region-id", regionID),
 			zap.Reflect("old", old.(*Operator)),
 			zap.Reflect("new", op))
+		operatorCounter.WithLabelValues(op.Desc(), "redundant").Inc()
 		return false
 	}
 

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -531,21 +531,21 @@ func (oc *Controller) addOperatorInner(op *Operator) bool {
 		operatorCounter.WithLabelValues(op.Desc(), "unexpected").Inc()
 		return false
 	}
-	oc.counts.inc(op.SchedulerKind())
+
 	old, loaded := oc.operators.LoadOrStore(regionID, op)
 	if loaded {
-		oc.counts.dec(op.SchedulerKind())
-		log.Info("operator already exists",
+		log.Debug("operator already exists",
 			zap.Uint64("region-id", regionID),
 			zap.Reflect("old", old.(*Operator)),
 			zap.Reflect("new", op))
 		return false
 	}
+
+	oc.counts.inc(op.SchedulerKind())
 	log.Info("add operator",
 		zap.Uint64("region-id", regionID),
 		zap.Reflect("operator", op),
 		zap.String("additional-info", op.LogAdditionalInfo()))
-
 	operatorCounter.WithLabelValues(op.Desc(), "start").Inc()
 	operatorSizeHist.WithLabelValues(op.Desc()).Observe(float64(op.ApproximateSize))
 	opInfluence := NewTotalOpInfluence([]*Operator{op}, oc.cluster)

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -496,46 +496,48 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 func (suite *operatorControllerTestSuite) TestConcurrentMergeConflict() {
 	re := suite.Require()
 
-	opts := mockconfig.NewTestOptions()
-	cluster := mockcluster.NewCluster(suite.ctx, opts)
-	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
-	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
-	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
-	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
-	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
-	left := newRegionInfo(101, "1a", "1b", 10, 10, []uint64{101, 1}, []uint64{101, 1})
-	left.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
-	cluster.PutRegion(left)
-	middle := newRegionInfo(102, "1b", "1c", 10, 10, []uint64{101, 1}, []uint64{101, 1})
-	middle.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
-	cluster.PutRegion(middle)
-	right := newRegionInfo(103, "1c", "1d", 10, 10, []uint64{101, 1}, []uint64{101, 1})
-	right.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
-	cluster.PutRegion(right)
-	wg := &sync.WaitGroup{}
-	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			ops1, err := CreateMergeRegionOperator("merge-region", cluster, left, middle, OpMerge)
-			re.NoError(err)
-			re.Len(ops1, 2)
-			controller.AddWaitingOperator(ops1...)
-			ops2, err := CreateMergeRegionOperator("merge-region", cluster, middle, right, OpMerge)
-			re.NoError(err)
-			re.Len(ops2, 2)
-			controller.AddWaitingOperator(ops2...)
-		}()
-	}
-	wg.Wait()
-	var count int
-	controller.operators.Range(func(_ any, op any) bool {
-		if op.(*Operator).Kind() == OpMerge {
-			count++
+	for range 10 {
+		opts := mockconfig.NewTestOptions()
+		cluster := mockcluster.NewCluster(suite.ctx, opts)
+		stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+		controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+		cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+		cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+		cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+		left := newRegionInfo(101, "1a", "1b", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+		left.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+		cluster.PutRegion(left)
+		middle := newRegionInfo(102, "1b", "1c", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+		middle.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+		cluster.PutRegion(middle)
+		right := newRegionInfo(103, "1c", "1d", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+		right.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+		cluster.PutRegion(right)
+		wg := &sync.WaitGroup{}
+		for range 5 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ops1, err := CreateMergeRegionOperator("merge-region", cluster, left, middle, OpMerge)
+				re.NoError(err)
+				re.Len(ops1, 2)
+				controller.AddWaitingOperator(ops1...)
+				ops2, err := CreateMergeRegionOperator("merge-region", cluster, middle, right, OpMerge)
+				re.NoError(err)
+				re.Len(ops2, 2)
+				controller.AddWaitingOperator(ops2...)
+			}()
 		}
-		return true
-	})
-	re.Equal(count, int(controller.counts.getCountByKind(OpMerge)))
+		wg.Wait()
+		var count int
+		controller.operators.Range(func(_ any, op any) bool {
+			if op.(*Operator).Kind() == OpMerge {
+				count++
+			}
+			return true
+		})
+		re.Equal(count, int(controller.counts.getCountByKind(OpMerge)))
+	}
 }
 
 func (suite *operatorControllerTestSuite) TestCheckOperatorLightly() {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -495,6 +495,7 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 
 func (suite *operatorControllerTestSuite) TestConcurrentMergeConflict() {
 	re := suite.Require()
+
 	opts := mockconfig.NewTestOptions()
 	cluster := mockcluster.NewCluster(suite.ctx, opts)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
@@ -502,31 +503,31 @@ func (suite *operatorControllerTestSuite) TestConcurrentMergeConflict() {
 	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
 	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
 	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
-
-	source := newRegionInfo(101, "1a", "1b", 10, 10, []uint64{101, 1}, []uint64{101, 1})
-	source.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
-	cluster.PutRegion(source)
-	target := newRegionInfo(102, "1b", "1c", 10, 10, []uint64{101, 1}, []uint64{101, 1})
-	target.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
-	cluster.PutRegion(target)
-
+	left := newRegionInfo(101, "1a", "1b", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+	left.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+	cluster.PutRegion(left)
+	middle := newRegionInfo(102, "1b", "1c", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+	middle.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+	cluster.PutRegion(middle)
+	right := newRegionInfo(103, "1c", "1d", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+	right.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
+	cluster.PutRegion(right)
 	wg := &sync.WaitGroup{}
 	for range 5 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for range 10 {
-				ops, err := CreateMergeRegionOperator("merge-region", cluster, source, target, OpMerge)
-				re.NoError(err)
-				re.NotEmpty(ops)
-				for i := range ops {
-					controller.addOperatorInner(ops[i])
-				}
-			}
+			ops1, err := CreateMergeRegionOperator("merge-region", cluster, left, middle, OpMerge)
+			re.NoError(err)
+			re.Len(ops1, 2)
+			controller.AddWaitingOperator(ops1...)
+			ops2, err := CreateMergeRegionOperator("merge-region", cluster, middle, right, OpMerge)
+			re.NoError(err)
+			re.Len(ops2, 2)
+			controller.AddWaitingOperator(ops2...)
 		}()
 	}
 	wg.Wait()
-
 	var count int
 	controller.operators.Range(func(key any, op any) bool {
 		if op.(*Operator).Kind() == OpMerge {
@@ -534,7 +535,6 @@ func (suite *operatorControllerTestSuite) TestConcurrentMergeConflict() {
 		}
 		return true
 	})
-	re.NotZero(count)
 	re.Equal(count, int(controller.counts.getCountByKind(OpMerge)))
 }
 

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -529,7 +529,7 @@ func (suite *operatorControllerTestSuite) TestConcurrentMergeConflict() {
 	}
 	wg.Wait()
 	var count int
-	controller.operators.Range(func(key any, op any) bool {
+	controller.operators.Range(func(_ any, op any) bool {
 		if op.(*Operator).Kind() == OpMerge {
 			count++
 		}

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -496,21 +496,22 @@ func (suite *operatorControllerTestSuite) TestPollDispatchRegionForMergeRegion()
 func (suite *operatorControllerTestSuite) TestConcurrentMergeConflict() {
 	re := suite.Require()
 
-	for range 10 {
-		opts := mockconfig.NewTestOptions()
-		cluster := mockcluster.NewCluster(suite.ctx, opts)
-		stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
-		controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
-		cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
-		cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
-		cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
-		left := newRegionInfo(101, "1a", "1b", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+
+	for i := range 10 {
+		left := newRegionInfo(uint64(100+i), fmt.Sprintf("%da", i), fmt.Sprintf("%db", i), 10, 10, []uint64{101, 1}, []uint64{101, 1})
 		left.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
 		cluster.PutRegion(left)
-		middle := newRegionInfo(102, "1b", "1c", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+		middle := newRegionInfo(uint64(101+i), fmt.Sprintf("%db", i), fmt.Sprintf("%dc", i), 10, 10, []uint64{101, 1}, []uint64{101, 1})
 		middle.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
 		cluster.PutRegion(middle)
-		right := newRegionInfo(103, "1c", "1d", 10, 10, []uint64{101, 1}, []uint64{101, 1})
+		right := newRegionInfo(uint64(102+i), fmt.Sprintf("%dc", i), fmt.Sprintf("%dd", i), 10, 10, []uint64{101, 1}, []uint64{101, 1})
 		right.GetMeta().RegionEpoch = &metapb.RegionEpoch{}
 		cluster.PutRegion(right)
 		wg := &sync.WaitGroup{}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8452

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
it will failed in master branch
```
--- FAIL: TestOperatorControllerTestSuite (0.01s)
    --- FAIL: TestOperatorControllerTestSuite/TestConcurrentMergeConflict (0.01s)
        /home/lhy1024/pd/pkg/schedule/operator/operator_controller_test.go:538: 
            	Error Trace:	/home/lhy1024/pd/pkg/schedule/operator/operator_controller_test.go:538
            	Error:      	Not equal: 
            	            	expected: 2
            	            	actual  : 3
            	Test:       	TestOperatorControllerTestSuite/TestConcurrentMergeConflict
FAIL
exit status 1
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
