### PR TITLE
feat(resourcemanager): load resource groups in the background

### DIFF
--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -40,10 +40,10 @@ import (
 )
 
 const (
-	persistLoopInterval        = 1 * time.Minute
+	persistLoopInterval        = time.Minute
 	metricsCleanupInterval     = time.Minute
 	metricsCleanupTimeout      = 20 * time.Minute
-	metricsAvailableRUInterval = 1 * time.Second
+	metricsAvailableRUInterval = time.Second
 	defaultCollectIntervalSec  = 20
 	tickPerSecond              = time.Second
 )
@@ -141,9 +141,17 @@ func (m *Manager) Init(ctx context.Context) error {
 	}
 
 	// Load keyspace resource groups from the storage.
-	if err := m.loadKeyspaceResourceGroups(); err != nil {
-		return err
-	}
+	// This operation is potentially time-consuming when there are many keyspaces and resource groups.
+	// So we run it in a new goroutine to prevent it from blocking the leader startup.
+	go func() {
+		start := time.Now()
+		log.Info("start to load keyspace resource groups in the background")
+		if err := m.loadKeyspaceResourceGroups(start); err != nil {
+			log.Error("failed to load keyspace resource groups", zap.Duration("time-cost", time.Since(start)), zap.Error(err))
+		} else {
+			log.Info("load keyspace resource groups finished", zap.Duration("time-cost", time.Since(start)))
+		}
+	}()
 
 	// Start the background metrics flusher.
 	go m.backgroundMetricsFlush(ctx)
@@ -155,7 +163,7 @@ func (m *Manager) Init(ctx context.Context) error {
 	return nil
 }
 
-func (m *Manager) loadKeyspaceResourceGroups() error {
+func (m *Manager) loadKeyspaceResourceGroups(start time.Time) error {
 	// Empty the keyspace resource group manager map before the loading.
 	m.Lock()
 	m.krgms = make(map[uint32]*keyspaceResourceGroupManager)
@@ -170,6 +178,7 @@ func (m *Manager) loadKeyspaceResourceGroups() error {
 	}); err != nil {
 		return err
 	}
+	log.Info("load keyspace resource groups meta info finished", zap.Duration("time-cost", time.Since(start)))
 	// Load keyspace resource group states from the storage.
 	if err := m.storage.LoadResourceGroupStates(func(keyspaceID uint32, name string, rawValue string) {
 		krgm := m.getKeyspaceResourceGroupManager(keyspaceID)
@@ -186,6 +195,7 @@ func (m *Manager) loadKeyspaceResourceGroups() error {
 	}); err != nil {
 		return err
 	}
+	log.Info("load keyspace resource groups states finished", zap.Duration("time-cost", time.Since(start)))
 	// Initialize the reserved keyspace resource group manager and default resource groups.
 	m.initReserved()
 	return nil


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #9335, ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Improves resource manager initialization by loading keyspace resource groups asynchronously in a background goroutine instead of blocking the leader startup process.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
