### PR TITLE
server: ensure proper parsing of large ttl value from persisted options

### DIFF
--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -547,6 +547,58 @@ func (suite *httpClientTestSuite) TestConfig() {
 	re.Empty(resp.Kvs)
 }
 
+func (suite *httpClientTestSuite) TestTTLConfigPersist() {
+	re := suite.Require()
+	client := suite.client
+	ctx, cancel := context.WithCancel(suite.ctx)
+	defer cancel()
+	configKey := "schedule.max-pending-peer-count"
+
+	testCases := []struct {
+		inputValue        any
+		expectedEtcdValue string
+	}{
+		{
+			inputValue:        uint64(10000000),
+			expectedEtcdValue: "10000000",
+		},
+		{
+			inputValue:        int(20000000),
+			expectedEtcdValue: "20000000",
+		},
+		{
+			inputValue:        float64(2147483647),
+			expectedEtcdValue: "2147483647",
+		},
+		{
+			inputValue:        float64(1234567890.0),
+			expectedEtcdValue: "1234567890",
+		},
+		{
+			inputValue:        float64(0.0),
+			expectedEtcdValue: "0",
+		},
+		{
+			inputValue:        float64(987.65),
+			expectedEtcdValue: "987.65",
+		},
+	}
+
+	for _, tc := range testCases {
+		newConfig := map[string]any{
+			configKey: tc.inputValue,
+		}
+		err := client.SetConfig(ctx, newConfig, 10000)
+		re.NoError(err)
+		resp, err := suite.cluster.GetEtcdClient().Get(ctx, sc.TTLConfigPrefix+"/"+configKey)
+		re.NoError(err)
+		re.Len(resp.Kvs, 1)
+		re.Equal([]byte(tc.expectedEtcdValue), resp.Kvs[0].Value)
+		err = client.SetConfig(ctx, newConfig, 0)
+		re.NoError(err)
+	}
+}
+
 func (suite *httpClientTestSuite) TestScheduleConfig() {
 	re := suite.Require()
 	client := suite.client

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -582,6 +582,14 @@ func (suite *httpClientTestSuite) TestTTLConfigPersist() {
 			inputValue:        float64(987.65),
 			expectedEtcdValue: "987.65",
 		},
+		{
+			inputValue:        int(-1),
+			expectedEtcdValue: "-1",
+		},
+		{
+			inputValue:        int32(-2147483647),
+			expectedEtcdValue: "-2147483647",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9343

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

In previous code, it will out log. So we need to ensure proper parsing of large ttl value from persisted options
```
log.Info("ttl firstly", zap.Any("data", data))
  for k, v := range data {
    log.Info("ttl secondly", zap.Any("k", k), zap.Any("fmt.Sprint(v)", fmt.Sprint(v)))
    if err := s.persistOptions.SetTTLData(s.ctx, s.client, k, fmt.Sprint(v), ttl); err != nil {
      return err
    }
  }
```
```
[2025/05/23 16:30:41.890 +08:00] [INFO] [server.go:1898] ["ttl firstly"] [data="{\"schedule.max-pending-peer-count\":2147483647}"]
[2025/05/23 16:30:41.890 +08:00] [INFO] [server.go:1900] ["ttl secondly"] [k=schedule.max-pending-peer-count] [fmt.Sprint(v)=2.147483647e+09]
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
