### PR TITLE
feat(resourcemanager): add service limit for keyspace

### DIFF
--- a/pkg/mcs/resourcemanager/server/apis/v1/api.go
+++ b/pkg/mcs/resourcemanager/server/apis/v1/api.go
@@ -267,10 +267,6 @@ func (s *Service) setKeyspaceServiceLimit(c *gin.Context) {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
-	if keyspaceIDValue == nil {
-		c.String(http.StatusNotFound, fmt.Sprintf("keyspace not found with name: %s", keyspaceName))
-		return
-	}
 	var req KeyspaceServiceLimitRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.String(http.StatusBadRequest, err.Error())
@@ -291,16 +287,13 @@ func (s *Service) setKeyspaceServiceLimit(c *gin.Context) {
 //	@Param		keyspace_name	path		string	true	"Keyspace name"
 //	@Success	200				{string}	json	format	of	rmserver.serviceLimiter
 //	@Failure	400				{string}	error
+//	@Failure	404				{string}	error
 //	@Router		/config/keyspace/service-limit/{keyspace_name} [get]
 func (s *Service) getKeyspaceServiceLimit(c *gin.Context) {
 	keyspaceName := c.Param("keyspace_name")
 	keyspaceIDValue, err := s.manager.GetKeyspaceIDByName(c, keyspaceName)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
-		return
-	}
-	if keyspaceIDValue == nil {
-		c.String(http.StatusNotFound, fmt.Sprintf("keyspace not found with name: %s", keyspaceName))
 		return
 	}
 	keyspaceID := keyspaceIDValue.GetValue()

--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -56,6 +56,7 @@ type keyspaceResourceGroupManager struct {
 
 	keyspaceID uint32
 	storage    endpoint.ResourceGroupStorage
+	sl         *serviceLimiter
 }
 
 func newKeyspaceResourceGroupManager(keyspaceID uint32, storage endpoint.ResourceGroupStorage) *keyspaceResourceGroupManager {
@@ -63,6 +64,7 @@ func newKeyspaceResourceGroupManager(keyspaceID uint32, storage endpoint.Resourc
 		groups:     make(map[string]*ResourceGroup),
 		keyspaceID: keyspaceID,
 		storage:    storage,
+		sl:         newServiceLimiter(0),
 	}
 }
 
@@ -236,4 +238,18 @@ func (krgm *keyspaceResourceGroupManager) persistResourceGroupRunningState() {
 		}
 		krgm.RUnlock()
 	}
+}
+
+func (krgm *keyspaceResourceGroupManager) setServiceLimiter(serviceLimit float64) {
+	krgm.RLock()
+	sl := krgm.sl
+	krgm.RUnlock()
+	// Set the new service limit to the limiter.
+	sl.setServiceLimit(serviceLimit)
+}
+
+func (krgm *keyspaceResourceGroupManager) getServiceLimiter() *serviceLimiter {
+	krgm.RLock()
+	defer krgm.RUnlock()
+	return krgm.sl
 }

--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -64,7 +64,7 @@ func newKeyspaceResourceGroupManager(keyspaceID uint32, storage endpoint.Resourc
 		groups:     make(map[string]*ResourceGroup),
 		keyspaceID: keyspaceID,
 		storage:    storage,
-		sl:         newServiceLimiter(0),
+		sl:         newServiceLimiter(keyspaceID, 0),
 	}
 }
 

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -131,11 +131,7 @@ func (m *Manager) GetKeyspaceServiceLimiter(keyspaceID uint32) *serviceLimiter {
 // SetKeyspaceServiceLimit sets the service limit of the keyspace.
 func (m *Manager) SetKeyspaceServiceLimit(keyspaceID uint32, serviceLimit float64) {
 	// If the keyspace is not found, create a new keyspace resource group manager.
-	krgm := m.getOrCreateKeyspaceResourceGroupManager(keyspaceID)
-	if krgm == nil {
-		return
-	}
-	krgm.setServiceLimiter(serviceLimit)
+	m.getOrCreateKeyspaceResourceGroupManager(keyspaceID).setServiceLimiter(serviceLimit)
 }
 
 func (m *Manager) getOrCreateKeyspaceResourceGroupManager(keyspaceID uint32, initDefault bool) *keyspaceResourceGroupManager {

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -67,6 +67,8 @@ type Manager struct {
 	consumptionDispatcher chan *consumptionItem
 	// cached keyspace name for each keyspace ID.
 	keyspaceNameLookup map[uint32]string
+	// used to get the keyspace ID by name.
+	keyspaceIDLookup map[string]uint32
 }
 
 // ConfigProvider is used to get resource manager config from the given
@@ -83,6 +85,7 @@ func NewManager[T ConfigProvider](srv bs.Server) *Manager {
 		krgms:                 make(map[uint32]*keyspaceResourceGroupManager),
 		consumptionDispatcher: make(chan *consumptionItem, defaultConsumptionChanSize),
 		keyspaceNameLookup:    make(map[uint32]string),
+		keyspaceIDLookup:      make(map[string]uint32),
 	}
 	// The first initialization after the server is started.
 	srv.AddStartCallback(func() {
@@ -127,7 +130,8 @@ func (m *Manager) GetKeyspaceServiceLimiter(keyspaceID uint32) *serviceLimiter {
 
 // SetKeyspaceServiceLimit sets the service limit of the keyspace.
 func (m *Manager) SetKeyspaceServiceLimit(keyspaceID uint32, serviceLimit float64) {
-	krgm := m.getKeyspaceResourceGroupManager(keyspaceID)
+	// If the keyspace is not found, create a new keyspace resource group manager.
+	krgm := m.getOrCreateKeyspaceResourceGroupManager(keyspaceID)
 	if krgm == nil {
 		return
 	}
@@ -387,7 +391,9 @@ func (m *Manager) getKeyspaceNameByID(ctx context.Context, id uint32) (string, e
 		return "", nil
 	}
 	// Try to get the keyspace name from the cache first.
+	m.RLock()
 	name, ok := m.keyspaceNameLookup[id]
+	m.RUnlock()
 	if ok {
 		return name, nil
 	}
@@ -409,8 +415,48 @@ func (m *Manager) getKeyspaceNameByID(ctx context.Context, id uint32) (string, e
 		return "", fmt.Errorf("got an empty keyspace name by id %d", id)
 	}
 	// Update the cache.
+	m.Lock()
 	m.keyspaceNameLookup[id] = loadedName
+	m.keyspaceIDLookup[loadedName] = id
+	m.Unlock()
 	return loadedName, nil
+}
+
+// GetKeyspaceIDByName gets the keyspace ID by name.
+func (m *Manager) GetKeyspaceIDByName(ctx context.Context, name string) (*rmpb.KeyspaceIDValue, error) {
+	if len(name) == 0 {
+		return &rmpb.KeyspaceIDValue{Value: constant.NullKeyspaceID}, nil
+	}
+	m.RLock()
+	id, ok := m.keyspaceIDLookup[name]
+	m.RUnlock()
+	if ok {
+		return &rmpb.KeyspaceIDValue{Value: id}, nil
+	}
+	var (
+		loadedID uint32
+		err      error
+	)
+	err = m.storage.RunInTxn(ctx, func(txn kv.Txn) error {
+		ok, loadedID, err = m.storage.LoadKeyspaceID(txn, name)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		log.Error("failed to get the keyspace id", zap.String("keyspace-name", name), zap.Error(err))
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("keyspace not found with name: %s", name)
+	}
+	// Update the cache.
+	m.Lock()
+	m.keyspaceNameLookup[loadedID] = name
+	m.keyspaceIDLookup[name] = loadedID
+	m.Unlock()
+	return &rmpb.KeyspaceIDValue{Value: loadedID}, nil
 }
 
 func (m *Manager) backgroundMetricsFlush(ctx context.Context) {

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -116,6 +116,24 @@ func (m *Manager) GetStorage() endpoint.ResourceGroupStorage {
 	return m.storage
 }
 
+// GetKeyspaceServiceLimiter returns the service limit of the keyspace.
+func (m *Manager) GetKeyspaceServiceLimiter(keyspaceID uint32) *serviceLimiter {
+	krgm := m.getKeyspaceResourceGroupManager(keyspaceID)
+	if krgm == nil {
+		return nil
+	}
+	return krgm.getServiceLimiter().Clone()
+}
+
+// SetKeyspaceServiceLimit sets the service limit of the keyspace.
+func (m *Manager) SetKeyspaceServiceLimit(keyspaceID uint32, serviceLimit float64) {
+	krgm := m.getKeyspaceResourceGroupManager(keyspaceID)
+	if krgm == nil {
+		return
+	}
+	krgm.setServiceLimiter(serviceLimit)
+}
+
 func (m *Manager) getOrCreateKeyspaceResourceGroupManager(keyspaceID uint32, initDefault bool) *keyspaceResourceGroupManager {
 	m.Lock()
 	krgm, ok := m.krgms[keyspaceID]

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -411,11 +411,15 @@ func (m *Manager) getKeyspaceNameByID(ctx context.Context, id uint32) (string, e
 		return "", fmt.Errorf("got an empty keyspace name by id %d", id)
 	}
 	// Update the cache.
-	m.Lock()
-	m.keyspaceNameLookup[id] = loadedName
-	m.keyspaceIDLookup[loadedName] = id
-	m.Unlock()
+	m.updateKeyspaceNameLookup(id, loadedName)
 	return loadedName, nil
+}
+
+func (m *Manager) updateKeyspaceNameLookup(id uint32, name string) {
+	m.Lock()
+	defer m.Unlock()
+	m.keyspaceNameLookup[id] = name
+	m.keyspaceIDLookup[name] = id
 }
 
 // GetKeyspaceIDByName gets the keyspace ID by name.
@@ -448,10 +452,7 @@ func (m *Manager) GetKeyspaceIDByName(ctx context.Context, name string) (*rmpb.K
 		return nil, fmt.Errorf("keyspace not found with name: %s", name)
 	}
 	// Update the cache.
-	m.Lock()
-	m.keyspaceNameLookup[loadedID] = name
-	m.keyspaceIDLookup[name] = loadedID
-	m.Unlock()
+	m.updateKeyspaceNameLookup(loadedID, name)
 	return &rmpb.KeyspaceIDValue{Value: loadedID}, nil
 }
 

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -131,7 +131,7 @@ func (m *Manager) GetKeyspaceServiceLimiter(keyspaceID uint32) *serviceLimiter {
 // SetKeyspaceServiceLimit sets the service limit of the keyspace.
 func (m *Manager) SetKeyspaceServiceLimit(keyspaceID uint32, serviceLimit float64) {
 	// If the keyspace is not found, create a new keyspace resource group manager.
-	m.getOrCreateKeyspaceResourceGroupManager(keyspaceID).setServiceLimiter(serviceLimit)
+	m.getOrCreateKeyspaceResourceGroupManager(keyspaceID, true).setServiceLimiter(serviceLimit)
 }
 
 func (m *Manager) getOrCreateKeyspaceResourceGroupManager(keyspaceID uint32, initDefault bool) *keyspaceResourceGroupManager {

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -317,6 +317,11 @@ func TestKeyspaceServiceLimit(t *testing.T) {
 	limiter = m.GetKeyspaceServiceLimiter(2)
 	re.Equal(100.0, limiter.ServiceLimit)
 	re.Equal(0.0, limiter.AvailableTokens)
+	// Ensure the keyspace resource group manager is initialized correctly.
+	krgm := m.getKeyspaceResourceGroupManager(2)
+	re.NotNil(krgm)
+	re.Equal(uint32(2), krgm.keyspaceID)
+	re.Equal(DefaultResourceGroupName, krgm.getMutableResourceGroup(DefaultResourceGroupName).Name)
 }
 
 func TestKeyspaceNameLookup(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -164,7 +164,10 @@ func prepareKeyspaceName(ctx context.Context, re *require.Assertions, manager *M
 	}
 	err := manager.storage.RunInTxn(ctx, func(txn kv.Txn) error {
 		err := manager.storage.SaveKeyspaceMeta(txn, keyspaceMeta)
-		return err
+		if err != nil {
+			return err
+		}
+		return manager.storage.SaveKeyspaceID(txn, keyspaceMeta.Id, keyspaceMeta.Name)
 	})
 	re.NoError(err)
 }
@@ -308,7 +311,55 @@ func TestKeyspaceServiceLimit(t *testing.T) {
 	re.Equal(100.0, limiter.ServiceLimit)
 	re.Equal(0.0, limiter.AvailableTokens) // When setting from 0 to positive, available tokens remain 0
 	// Test set the service limit of the non-existing keyspace.
-	m.SetKeyspaceServiceLimit(2, 100.0)
 	limiter = m.GetKeyspaceServiceLimiter(2)
 	re.Nil(limiter)
+	m.SetKeyspaceServiceLimit(2, 100.0)
+	limiter = m.GetKeyspaceServiceLimiter(2)
+	re.Equal(100.0, limiter.ServiceLimit)
+	re.Equal(0.0, limiter.AvailableTokens)
+}
+
+func TestKeyspaceNameLookup(t *testing.T) {
+	re := require.New(t)
+	m := prepareManager()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := m.Init(ctx)
+	re.NoError(err)
+	// Get the null keyspace ID by an empty name.
+	idValue, err := m.GetKeyspaceIDByName(ctx, "")
+	re.NoError(err)
+	re.NotNil(idValue)
+	re.Equal(constant.NullKeyspaceID, idValue.Value)
+	// Get the non-existing keyspace ID by name.
+	idValue, err = m.GetKeyspaceIDByName(ctx, "non-existing-keyspace")
+	re.Error(err)
+	re.Nil(idValue)
+	// Get the null keyspace name.
+	name, err := m.getKeyspaceNameByID(ctx, constant.NullKeyspaceID)
+	re.NoError(err)
+	re.Empty(name)
+	// Get the non-existing keyspace name.
+	name, err = m.getKeyspaceNameByID(ctx, 1)
+	re.Error(err)
+	re.Empty(name)
+	// Get the keyspace ID by name first, then get the keyspace name by ID.
+	prepareKeyspaceName(ctx, re, m, &rmpb.KeyspaceIDValue{Value: 1}, "test_keyspace")
+	idValue, err = m.GetKeyspaceIDByName(ctx, "test_keyspace")
+	re.NoError(err)
+	re.NotNil(idValue)
+	re.Equal(uint32(1), idValue.Value)
+	name, err = m.getKeyspaceNameByID(ctx, 1)
+	re.NoError(err)
+	re.Equal("test_keyspace", name)
+	// Get the keyspace name by ID first, then get the keyspace ID by name.
+	prepareKeyspaceName(ctx, re, m, &rmpb.KeyspaceIDValue{Value: 2}, "test_keyspace_2")
+	name, err = m.getKeyspaceNameByID(ctx, 2)
+	re.NoError(err)
+	re.Equal("test_keyspace_2", name)
+	idValue, err = m.GetKeyspaceIDByName(ctx, "test_keyspace_2")
+	re.NoError(err)
+	re.NotNil(idValue)
+	re.Equal(uint32(2), idValue.Value)
 }

--- a/pkg/mcs/resourcemanager/server/service_limit.go
+++ b/pkg/mcs/resourcemanager/server/service_limit.go
@@ -1,0 +1,137 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"math"
+	"time"
+
+	"github.com/tikv/pd/pkg/utils/syncutil"
+)
+
+// serviceLimiterBurstFactor defines how many seconds worth of tokens can be accumulated.
+// This allows the limiter to handle batch requests from clients that request tokens periodically.
+// Since the client will request tokens with a 5-second period by default, the burst factor is 5.0 here.
+const serviceLimiterBurstFactor = 5.0
+
+// TODO: persist the service limit to the storage and reload it when the service starts.
+type serviceLimiter struct {
+	syncutil.RWMutex
+	// ServiceLimit is the configured service limit for this limiter.
+	// It's an unburstable RU per second rate limit.
+	ServiceLimit float64 `json:"service_limit"`
+	// AvailableTokens tracks the available RU tokens for this limiter.
+	AvailableTokens float64 `json:"available_tokens"`
+	// LastUpdate records the last time the limiter was updated.
+	LastUpdate time.Time `json:"last_update"`
+}
+
+func newServiceLimiter(serviceLimit float64) *serviceLimiter {
+	// The service limit should be non-negative.
+	serviceLimit = math.Max(0, serviceLimit)
+	return &serviceLimiter{
+		ServiceLimit: serviceLimit,
+		LastUpdate:   time.Now(),
+	}
+}
+
+func (krl *serviceLimiter) setServiceLimit(newServiceLimit float64) {
+	// The service limit should be non-negative.
+	newServiceLimit = math.Max(0, newServiceLimit)
+	krl.Lock()
+	defer krl.Unlock()
+	if newServiceLimit == krl.ServiceLimit {
+		return
+	}
+	oldServiceLimit := krl.ServiceLimit
+	krl.ServiceLimit = newServiceLimit
+	now := time.Now()
+	// If the old service limit was 0 (no limit) or the new service limit is 0,
+	// initialize the available tokens or clear the available tokens.
+	if oldServiceLimit == 0 || newServiceLimit == 0 {
+		krl.AvailableTokens = 0
+		krl.LastUpdate = now
+	} else {
+		// Trigger the refill of the available tokens to ensure that the previous
+		// service limit setting was not too high, so that many available tokens
+		// are not left unused, causing the new service limit to become invalid.
+		krl.refillTokensLocked(now)
+	}
+}
+
+func (krl *serviceLimiter) refillTokensLocked(now time.Time) {
+	// No limit configured, do nothing.
+	if krl.ServiceLimit <= 0 {
+		return
+	}
+	// Calculate the elapsed time since the last update.
+	elapsed := now.Sub(krl.LastUpdate).Seconds()
+	if elapsed < 0 {
+		return
+	}
+	// Add tokens based on the configured rate and the burst limit.
+	krl.AvailableTokens = math.Min(
+		krl.AvailableTokens+krl.ServiceLimit*elapsed,
+		krl.ServiceLimit*serviceLimiterBurstFactor,
+	)
+	// Update the last update time.
+	krl.LastUpdate = now
+}
+
+// applyServiceLimit applies the service limit to the requested tokens and returns the limited tokens.
+func (krl *serviceLimiter) applyServiceLimit(
+	now time.Time,
+	requestedTokens float64,
+) (limitedTokens float64) {
+	if krl == nil {
+		return requestedTokens
+	}
+	krl.Lock()
+	defer krl.Unlock()
+
+	// No limit configured, allow all tokens.
+	if krl.ServiceLimit <= 0 {
+		return requestedTokens
+	}
+
+	// Refill first to ensure the available tokens is up to date.
+	krl.refillTokensLocked(now)
+
+	// If the requested tokens is less than the available tokens, grant all tokens.
+	if requestedTokens <= krl.AvailableTokens {
+		krl.AvailableTokens -= requestedTokens
+		return requestedTokens
+	}
+
+	// If the requested tokens is greater than the available tokens, grant all available tokens.
+	if krl.AvailableTokens > 0 && requestedTokens > krl.AvailableTokens {
+		limitedTokens = krl.AvailableTokens
+		// TODO: allow the loan to decrease the allocation at a smooth rate.
+		krl.AvailableTokens = 0
+	}
+
+	return limitedTokens
+}
+
+// Clone returns a copy of the service limiter.
+func (krl *serviceLimiter) Clone() *serviceLimiter {
+	krl.RLock()
+	defer krl.RUnlock()
+	return &serviceLimiter{
+		ServiceLimit:    krl.ServiceLimit,
+		AvailableTokens: krl.AvailableTokens,
+		LastUpdate:      krl.LastUpdate,
+	}
+}

--- a/pkg/mcs/resourcemanager/server/service_limit_test.go
+++ b/pkg/mcs/resourcemanager/server/service_limit_test.go
@@ -1,0 +1,312 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServiceLimiter(t *testing.T) {
+	re := require.New(t)
+
+	// Test creating a service limiter with positive limit
+	limiter := newServiceLimiter(100.0)
+	re.NotNil(limiter)
+	re.Equal(100.0, limiter.ServiceLimit)
+	re.Equal(0.0, limiter.AvailableTokens)
+
+	// Test creating a service limiter with zero limit
+	limiter = newServiceLimiter(0.0)
+	re.NotNil(limiter)
+	re.Equal(0.0, limiter.ServiceLimit)
+	re.Equal(0.0, limiter.AvailableTokens)
+
+	// Test creating a service limiter with negative limit
+	limiter = newServiceLimiter(-10.0)
+	re.NotNil(limiter)
+	re.Equal(0.0, limiter.ServiceLimit)
+	re.Equal(0.0, limiter.AvailableTokens)
+}
+
+func TestRefillTokensLocked(t *testing.T) {
+	re := require.New(t)
+
+	// Test refill with positive service limit
+	limiter := newServiceLimiter(100.0)
+	baseTime := time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 50.0
+
+	// Refill after 1 second should add 100 tokens, but cap at burst limit (100 * serviceLimiterBurstFactor)
+	futureTime := baseTime.Add(time.Second)
+	limiter.refillTokensLocked(futureTime)
+	re.Equal(150.0, limiter.AvailableTokens) // 50 + 100 = 150 (within burst limit)
+	re.Equal(futureTime, limiter.LastUpdate)
+
+	// Test refill when reach the burst limit
+	limiter.AvailableTokens = 475.0
+	limiter.LastUpdate = baseTime
+	limiter.refillTokensLocked(futureTime)
+	re.Equal(100*serviceLimiterBurstFactor, limiter.AvailableTokens) // Should remain at burst limit
+	re.Equal(futureTime, limiter.LastUpdate)                         // Should update time even when no tokens added
+
+	// Test partial refill
+	limiter.AvailableTokens = 20.0
+	limiter.LastUpdate = baseTime
+	halfSecondLater := baseTime.Add(500 * time.Millisecond)
+	limiter.refillTokensLocked(halfSecondLater)
+	re.InDelta(70.0, limiter.AvailableTokens, 0.1) // 20 + 100*0.5 = 70
+	re.Equal(halfSecondLater, limiter.LastUpdate)
+
+	// Test with zero service limit
+	limiter.ServiceLimit = 0.0
+	limiter.AvailableTokens = 0.0
+	limiter.LastUpdate = baseTime
+	limiter.refillTokensLocked(futureTime)
+	re.Equal(0.0, limiter.AvailableTokens) // Should remain 0
+	re.Equal(baseTime, limiter.LastUpdate) // Should not update time
+
+	// Test with elapsed time <= 0 (time going backwards)
+	limiter.ServiceLimit = 100.0
+	limiter.AvailableTokens = 50.0
+	limiter.LastUpdate = futureTime
+	limiter.refillTokensLocked(baseTime)     // Earlier time
+	re.Equal(50.0, limiter.AvailableTokens)  // Should remain unchanged
+	re.Equal(futureTime, limiter.LastUpdate) // Should not update time
+}
+
+func TestApplyServiceLimit(t *testing.T) {
+	re := require.New(t)
+
+	// Test with nil limiter
+	var limiter *serviceLimiter
+	tokens := limiter.applyServiceLimit(time.Now(), 50.0)
+	re.Equal(50.0, tokens)
+
+	// Test with zero service limit (no limit)
+	limiter = newServiceLimiter(0.0)
+	now := time.Now()
+	tokens = limiter.applyServiceLimit(now, 50.0)
+	re.Equal(50.0, tokens)
+
+	// Test request within available tokens (need to set available tokens first)
+	limiter = newServiceLimiter(100.0)
+	limiter.AvailableTokens = 100.0 // Manually set available tokens
+	limiter.LastUpdate = now
+	tokens = limiter.applyServiceLimit(now, 50.0)
+	re.Equal(50.0, tokens)
+	re.Equal(50.0, limiter.AvailableTokens) // 100 - 50 = 50
+
+	// Test request exactly equal to available tokens
+	limiter = newServiceLimiter(100.0)
+	limiter.AvailableTokens = 100.0 // Manually set available tokens
+	limiter.LastUpdate = now
+	tokens = limiter.applyServiceLimit(now, 100.0)
+	re.Equal(100.0, tokens)
+	re.Equal(0.0, limiter.AvailableTokens)
+
+	// Test request exceeding available tokens
+	limiter = newServiceLimiter(100.0)
+	limiter.LastUpdate = now
+	limiter.AvailableTokens = 30.0
+	tokens = limiter.applyServiceLimit(now, 80.0)
+	re.Equal(30.0, tokens) // Only available tokens granted
+	re.Equal(0.0, limiter.AvailableTokens)
+}
+
+func TestApplyServiceLimitWithRefill(t *testing.T) {
+	re := require.New(t)
+
+	// Test that refill happens before applying limit
+	limiter := newServiceLimiter(100.0)
+	baseTime := time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 20.0
+
+	// Request after 1 second should trigger refill first
+	futureTime := baseTime.Add(time.Second)
+	tokens := limiter.applyServiceLimit(futureTime, 50.0)
+	re.Equal(50.0, tokens)
+	re.Equal(70.0, limiter.AvailableTokens) // 20 + 100 - 50 = 70
+	re.Equal(futureTime, limiter.LastUpdate)
+
+	// Test partial refill scenario
+	limiter = newServiceLimiter(100.0)
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 10.0
+
+	halfSecondLater := baseTime.Add(500 * time.Millisecond)
+	tokens = limiter.applyServiceLimit(halfSecondLater, 80.0)
+	// After refill: 10 + 100*0.5 = 60 tokens available
+	re.Equal(60.0, tokens)
+	re.Equal(0.0, limiter.AvailableTokens)
+}
+
+func TestServiceLimiterEdgeCases(t *testing.T) {
+	re := require.New(t)
+
+	// Test with very small service limit
+	limiter := newServiceLimiter(0.1)
+	limiter.AvailableTokens = 0.1   // Manually set available tokens
+	limiter.LastUpdate = time.Now() // Set LastUpdate to current time to avoid refill
+	now := time.Now()
+	tokens := limiter.applyServiceLimit(now, 1.0)
+	re.InDelta(0.1, tokens, 0.001) // Use InDelta to handle floating point precision
+
+	// Test with very large service limit
+	limiter = newServiceLimiter(1000000.0)
+	limiter.AvailableTokens = 1000000.0 // Manually set available tokens
+	tokens = limiter.applyServiceLimit(now, 500000.0)
+	re.Equal(500000.0, tokens)
+
+	// Test with zero requested tokens
+	limiter = newServiceLimiter(100.0)
+	limiter.AvailableTokens = 100.0 // Manually set available tokens
+	tokens = limiter.applyServiceLimit(now, 0.0)
+	re.Equal(0.0, tokens)
+	re.Equal(100.0, limiter.AvailableTokens) // Should remain unchanged
+
+	// Test with fractional tokens
+	limiter = newServiceLimiter(10.5)
+	limiter.LastUpdate = now
+	limiter.AvailableTokens = 5.25
+	tokens = limiter.applyServiceLimit(now, 7.75)
+	re.Equal(5.25, tokens)
+}
+
+func TestSetServiceLimit(t *testing.T) {
+	re := require.New(t)
+
+	// Test setting the same service limit (should be no-op)
+	limiter := newServiceLimiter(100.0)
+	originalTokens := limiter.AvailableTokens
+	originalUpdate := limiter.LastUpdate
+
+	limiter.setServiceLimit(100.0) // Same limit
+	re.Equal(100.0, limiter.ServiceLimit)
+	re.Equal(originalTokens, limiter.AvailableTokens) // Should remain unchanged
+	re.Equal(originalUpdate, limiter.LastUpdate)      // Should remain unchanged
+
+	// Test increasing service limit
+	limiter = newServiceLimiter(50.0)
+	baseTime := time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 30.0
+
+	limiter.setServiceLimit(100.0)
+	re.Equal(100.0, limiter.ServiceLimit)
+	re.InDelta(30.0, limiter.AvailableTokens, 0.1) // Should remain the same since no time elapsed (allow for floating point precision)
+	re.True(limiter.LastUpdate.After(baseTime))    // Should update time
+
+	// Test decreasing service limit with available tokens exceeding new limit
+	limiter = newServiceLimiter(100.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 80.0
+
+	// Sleep a bit to ensure some time passes
+	time.Sleep(1 * time.Millisecond)
+	limiter.setServiceLimit(50.0)
+	re.Equal(50.0, limiter.ServiceLimit)
+	// After refill, tokens might exceed 80, but should be capped at burst limit (50 * serviceLimiterBurstFactor)
+	re.Greater(limiter.AvailableTokens, 80.0)                               // Should increase the available tokens
+	re.LessOrEqual(limiter.AvailableTokens, 50.0*serviceLimiterBurstFactor) // Should not exceed burst limit
+	re.True(limiter.LastUpdate.After(baseTime))                             // Should update time
+
+	// Test decreasing service limit with available tokens below new limit
+	limiter = newServiceLimiter(100.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 30.0
+
+	limiter.setServiceLimit(50.0)
+	re.Equal(50.0, limiter.ServiceLimit)
+	re.InDelta(30.0, limiter.AvailableTokens, 0.1) // Should remain unchanged since below new limit (allow for floating point precision)
+	re.True(limiter.LastUpdate.After(baseTime))    // Should update time
+
+	// Test setting service limit to zero
+	limiter = newServiceLimiter(100.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 50.0
+
+	limiter.setServiceLimit(0.0)
+	re.Equal(0.0, limiter.ServiceLimit)
+	re.Equal(0.0, limiter.AvailableTokens)      // Should be cleared
+	re.True(limiter.LastUpdate.After(baseTime)) // Should update time
+
+	// Test setting service limit from zero to positive (should NOT initialize available tokens)
+	limiter = newServiceLimiter(0.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 0.0
+
+	limiter.setServiceLimit(50.0)
+	re.Equal(50.0, limiter.ServiceLimit)
+	re.Equal(0.0, limiter.AvailableTokens)      // Should remain 0 (not initialized to service limit)
+	re.True(limiter.LastUpdate.After(baseTime)) // Should update time
+
+	// Test setting negative service limit (should be treated as zero)
+	limiter = newServiceLimiter(100.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 50.0
+
+	limiter.setServiceLimit(-10.0)
+	re.Equal(0.0, limiter.ServiceLimit)         // Should be treated as zero
+	re.Equal(0.0, limiter.AvailableTokens)      // Should be cleared
+	re.True(limiter.LastUpdate.After(baseTime)) // Should update time
+
+	// Test setting service limit with time elapsed (should trigger refill)
+	limiter = newServiceLimiter(50.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 20.0
+
+	// Simulate time passing before setting new limit
+	time.Sleep(10 * time.Millisecond)
+	limiter.setServiceLimit(100.0)
+	re.Equal(100.0, limiter.ServiceLimit)
+	// Available tokens should be refilled based on elapsed time, but capped at new service limit
+	re.GreaterOrEqual(limiter.AvailableTokens, 20.0) // Should be at least the original amount
+	re.LessOrEqual(limiter.AvailableTokens, 100.0)   // Should not exceed new service limit
+	re.True(limiter.LastUpdate.After(baseTime))      // Should update time
+
+	// Test setting a smaller service limit
+	limiter = newServiceLimiter(1000.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 500.0
+
+	limiter.setServiceLimit(10.0)
+	re.Equal(10.0, limiter.ServiceLimit)
+	// After refill with new limit, tokens should be capped at burst limit (10 * serviceLimiterBurstFactor)
+	re.Equal(10.0*serviceLimiterBurstFactor, limiter.AvailableTokens) // Should be capped at burst limit, not service limit
+	re.True(limiter.LastUpdate.After(baseTime))                       // Should update time
+
+	// Test setting a larger service limit
+	limiter = newServiceLimiter(10.0)
+	baseTime = time.Now()
+	limiter.LastUpdate = baseTime
+	limiter.AvailableTokens = 5.0
+
+	limiter.setServiceLimit(1000000.0)
+	re.Equal(1000000.0, limiter.ServiceLimit)
+	re.Greater(limiter.AvailableTokens, 5.0)
+	re.True(limiter.LastUpdate.After(baseTime))
+}

--- a/server/api/min_resolved_ts.go
+++ b/server/api/min_resolved_ts.go
@@ -50,10 +50,10 @@ type MinResolvedTS struct {
 // GetStoreMinResolvedTS gets the store-level min resolved ts.
 // @Tags     min_store_resolved_ts
 // @Summary  Get store-level min resolved ts.
-// @Produce      json
-// @Success      200    {array}   MinResolvedTS
+// @Produce  json
+// @Success  200  {array}   MinResolvedTS
 // @Failure  400  {string}  string  "The input is invalid."
-// @Failure      500    {string}  string  "PD server failed to proceed the request."
+// @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /min-resolved-ts/{store_id} [get]
 func (h *minResolvedTSHandler) GetStoreMinResolvedTS(w http.ResponseWriter, r *http.Request) {
 	c := getCluster(r)

--- a/server/api/min_resolved_ts.go
+++ b/server/api/min_resolved_ts.go
@@ -50,10 +50,10 @@ type MinResolvedTS struct {
 // GetStoreMinResolvedTS gets the store-level min resolved ts.
 // @Tags     min_store_resolved_ts
 // @Summary  Get store-level min resolved ts.
-// @Produce  json
-// @Success  200  {array}   MinResolvedTS
+// @Produce      json
+// @Success      200    {array}   MinResolvedTS
 // @Failure  400  {string}  string  "The input is invalid."
-// @Failure  500  {string}  string  "PD server failed to proceed the request."
+// @Failure      500    {string}  string  "PD server failed to proceed the request."
 // @Router   /min-resolved-ts/{store_id} [get]
 func (h *minResolvedTSHandler) GetStoreMinResolvedTS(w http.ResponseWriter, r *http.Request) {
 	c := getCluster(r)

--- a/tools/pd-ut/testdata/group.9.etcdkey
+++ b/tools/pd-ut/testdata/group.9.etcdkey
@@ -21,8 +21,12 @@
 /pd//config get
 /pd//config save
 /pd//config watch
+/pd//keyspaces/alloc_id get
 /pd//keyspaces/id/DEFAULT get
 /pd//keyspaces/id/DEFAULT save
+/pd//keyspaces/id/non_existing_keyspace get
+/pd//keyspaces/id/test_keyspace get
+/pd//keyspaces/id/test_keyspace save
 /pd//keyspaces/meta/ get
 /pd//keyspaces/meta/ save
 /pd//leader get


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Add a keyspace-level service limiter to control the maximum request rate for each keyspace.
The service limit is an unburstable RU per second rate limit that applies across all resource groups within a keyspace.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

With a resource group rg1 whose RU is 5000 and is non-burstable, set the service limit to 10000 RU > 5000 RU:

<img width="2354" alt="image" src="https://github.com/user-attachments/assets/88f849d2-9d6c-42db-988b-c7bd7bd4ba1b" />

<img width="650" alt="image" src="https://github.com/user-attachments/assets/8dda5d40-9bc3-40f8-92ee-9b978333f3f6" />

Set the service limit to 2500 RU:

<img width="2360" alt="image" src="https://github.com/user-attachments/assets/aefc41cc-47e3-498a-8764-9d52fedef93b" />

<img width="675" alt="image" src="https://github.com/user-attachments/assets/d6168eac-0d0c-45ab-9db1-4b19e0531de2" />

rg1 5000 RU + rg2 2500 RU with 2500 RU service limit.

![image](https://github.com/user-attachments/assets/da6eae22-3cfd-485c-949f-a0cda9dc0af9)

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
