### PR TITLE
feat(resourcemanager): automatically initialize default resource group for each keyspace

### DIFF
--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -59,11 +59,12 @@ type keyspaceResourceGroupManager struct {
 }
 
 func newKeyspaceResourceGroupManager(keyspaceID uint32, storage endpoint.ResourceGroupStorage) *keyspaceResourceGroupManager {
-	return &keyspaceResourceGroupManager{
+	krgm := &keyspaceResourceGroupManager{
 		groups:     make(map[string]*ResourceGroup),
 		keyspaceID: keyspaceID,
 		storage:    storage,
 	}
+	return krgm
 }
 
 func (krgm *keyspaceResourceGroupManager) addResourceGroupFromRaw(name string, rawValue string) error {
@@ -96,11 +97,11 @@ func (krgm *keyspaceResourceGroupManager) setRawStatesIntoResourceGroup(name str
 
 func (krgm *keyspaceResourceGroupManager) initDefaultResourceGroup() {
 	krgm.RLock()
-	if _, ok := krgm.groups[DefaultResourceGroupName]; ok {
-		krgm.RUnlock()
+	_, ok := krgm.groups[DefaultResourceGroupName]
+	krgm.RUnlock()
+	if ok {
 		return
 	}
-	krgm.RUnlock()
 	defaultGroup := &ResourceGroup{
 		Name: DefaultResourceGroupName,
 		Mode: rmpb.GroupMode_RUMode,

--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -59,12 +59,11 @@ type keyspaceResourceGroupManager struct {
 }
 
 func newKeyspaceResourceGroupManager(keyspaceID uint32, storage endpoint.ResourceGroupStorage) *keyspaceResourceGroupManager {
-	krgm := &keyspaceResourceGroupManager{
+	return &keyspaceResourceGroupManager{
 		groups:     make(map[string]*ResourceGroup),
 		keyspaceID: keyspaceID,
 		storage:    storage,
 	}
-	return krgm
 }
 
 func (krgm *keyspaceResourceGroupManager) addResourceGroupFromRaw(name string, rawValue string) error {

--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -242,7 +242,7 @@ func TestGetResourceGroupList(t *testing.T) {
 	}
 
 	// Get all resource groups.
-	groups := krgm.getResourceGroupList(false, true)
+	groups := krgm.getResourceGroupList(false, false)
 	re.Len(groups, 3)
 
 	// Verify groups are sorted by name.

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -1633,8 +1633,8 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupCURDWithKeyspace()
 	re.NotNil(rg)
 	rgs, err = clientKeyspace.ListResourceGroups(suite.ctx, pd.WithRUStats)
 	re.NoError(err)
-	re.Len(rgs, 1)
-	re.Equal(rgs[0].Name, group.Name)
+	re.Len(rgs, 2) // Including the default resource group.
+	re.Contains(rgs, rg)
 
 	// Modify resource group with keyspace id
 	group.RUSettings.RU.Settings.FillRate = 1000

--- a/tools/pd-ut/testdata/group.9.etcdkey
+++ b/tools/pd-ut/testdata/group.9.etcdkey
@@ -80,11 +80,13 @@ resource_group/controller save
 resource_group/controller watch
 resource_group/keyspace/settings/ get
 resource_group/keyspace/settings/ watch
+resource_group/keyspace/settings//default save
 resource_group/keyspace/settings//keyspace_test remove
 resource_group/keyspace/settings//keyspace_test save
 resource_group/keyspace/settings//keyspace_test_ remove
 resource_group/keyspace/settings//keyspace_test_ save
 resource_group/keyspace/states/ get
+resource_group/keyspace/states//default save
 resource_group/keyspace/states//keyspace_test save
 resource_group/keyspace/states//keyspace_test_ save
 resource_group/settings watch


### PR DESCRIPTION
### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Initialize the default resource group during keyspace resource group manager creation rather than separately.
This change simplifies the initialization process by ensuring each new keyspace manager automatically has a default resource group.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
