### PR TITLE
feat(resourcemanager): add ruTracker for monitoring keyspace RU/s

### DIFF
--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -254,8 +254,12 @@ func (krgm *keyspaceResourceGroupManager) getOrCreateRUTracker(name string) *ruT
 	rt := krgm.getRUTracker(name)
 	if rt == nil {
 		krgm.Lock()
-		rt = newRUTracker(defaultRUTrackerTimeConstant)
-		krgm.ruTrackers[name] = rt
+		// Double check the RU tracker is not created by other goroutine.
+		rt = krgm.ruTrackers[name]
+		if rt == nil {
+			rt = newRUTracker(defaultRUTrackerTimeConstant)
+			krgm.ruTrackers[name] = rt
+		}
 		krgm.Unlock()
 	}
 	return rt

--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/zap"
@@ -39,6 +40,12 @@ const (
 	unlimitedBurstLimit        = -1
 	// DefaultResourceGroupName is the reserved default resource group name within each keyspace.
 	DefaultResourceGroupName = "default"
+	// defaultRUTrackerTimeConstant is the default time-aware EMA time constant for the RU tracker.
+	// The following values are reasonable for the RU tracker:
+	//   - ~5s, which captures the RU/s spike quickly but may be too sensitive to the short-term fluctuations.
+	//   - ~10s, which smooths the RU/s fluctuations but may not track the spike that quickly.
+	//   - ~20s, which smooths the RU/s fluctuations but can only be used to observe the long-term trend.
+	defaultRUTrackerTimeConstant = 5 * time.Second
 )
 
 // consumptionItem is used to send the consumption info to the background metrics flusher.
@@ -52,16 +59,18 @@ type consumptionItem struct {
 
 type keyspaceResourceGroupManager struct {
 	syncutil.RWMutex
-	groups map[string]*ResourceGroup
+	groups     map[string]*ResourceGroup
+	ruTrackers map[string]*ruTracker
+	sl         *serviceLimiter
 
 	keyspaceID uint32
 	storage    endpoint.ResourceGroupStorage
-	sl         *serviceLimiter
 }
 
 func newKeyspaceResourceGroupManager(keyspaceID uint32, storage endpoint.ResourceGroupStorage) *keyspaceResourceGroupManager {
 	return &keyspaceResourceGroupManager{
 		groups:     make(map[string]*ResourceGroup),
+		ruTrackers: make(map[string]*ruTracker),
 		keyspaceID: keyspaceID,
 		storage:    storage,
 		sl:         newServiceLimiter(keyspaceID, 0),
@@ -239,4 +248,84 @@ func (krgm *keyspaceResourceGroupManager) getServiceLimiter() *serviceLimiter {
 	krgm.RLock()
 	defer krgm.RUnlock()
 	return krgm.sl
+}
+
+func (krgm *keyspaceResourceGroupManager) getOrCreateRUTracker(name string) *ruTracker {
+	rt := krgm.getRUTracker(name)
+	if rt == nil {
+		krgm.Lock()
+		rt = newRUTracker(defaultRUTrackerTimeConstant)
+		krgm.ruTrackers[name] = rt
+		krgm.Unlock()
+	}
+	return rt
+}
+
+func (krgm *keyspaceResourceGroupManager) getRUTracker(name string) *ruTracker {
+	krgm.RLock()
+	defer krgm.RUnlock()
+	return krgm.ruTrackers[name]
+}
+
+// ruTracker is used to track the RU consumption within a keyspace.
+// It uses the algorithm of time-aware exponential moving average (EMA) to
+// sample and calculate the real-time RU/s of each resource group. The main
+// reason for choosing this EMA algorithm is that conventional EMA algorithms or
+// moving average algorithms over a time window cannot handle non-fixed frequency
+// data sampling well. Since the reporting interval of RU consumption depends on
+// the RU consumption rate of the workload, it is necessary to introduce a time
+// dimension to calculate real-time RU/s more accurately.
+type ruTracker struct {
+	syncutil.RWMutex
+	// beta = ln(2) / τ, τ is the time constant which can be thought of as the half-life of the EMA.
+	// For example, if τ = 5s, then the decay factor calculated by e^{-β·Δt} will be 0.5 when Δt = 5s,
+	// which means the weight of the "old data" is 0.5 when the elapsed time is 5s.
+	beta           float64
+	lastSampleTime time.Time
+	lastEMA        float64
+}
+
+func newRUTracker(timeConstant time.Duration) *ruTracker {
+	return &ruTracker{
+		beta: math.Log(2) / timeConstant.Seconds(),
+	}
+}
+
+// Sample the RU consumption and calculate the real-time RU/s as `lastEMA`.
+// - `now` is the current time point to sample the RU consumption.
+// - `totalRU` is the total RU consumption within the `dur`.
+// - `dur` is the time cost to run out of the `totalRU`.
+func (rt *ruTracker) sample(now time.Time, totalRU float64, dur time.Duration) {
+	rt.Lock()
+	defer rt.Unlock()
+	// If `dur` is not greater than 0, skip this record.
+	if dur <= 0 {
+		return
+	}
+	// Calculate the average RU/s within the `dur`.
+	ruPerSec := totalRU / dur.Seconds()
+	// If the last sample time is not set, set the last EMA directly.
+	if rt.lastSampleTime.IsZero() {
+		rt.lastEMA = ruPerSec
+		rt.lastSampleTime = now
+		return
+	}
+	// Calculate the time delta between the last sample time and the current time.
+	dt := now.Sub(rt.lastSampleTime).Seconds()
+	if dt <= 0 {
+		dt = 1e-3 // Avoid division by zero or negative value, use 1 millisecond as the minimum time delta.
+	}
+	// By using e^{-β·Δt} to calculate the decay factor, we can have the following behavior:
+	//   1. The decay factor is always between 0 and 1.
+	//   2. The decay factor is time-aware, the larger the time delta, the lower the weight of the "old data".
+	decay := math.Exp(-rt.beta * dt)
+	rt.lastEMA = decay*rt.lastEMA + (1-decay)*ruPerSec
+	rt.lastSampleTime = now
+}
+
+// Get the real-time RU/s calculated by the EMA algorithm.
+func (rt *ruTracker) getRUPerSec() float64 {
+	rt.RLock()
+	defer rt.RUnlock()
+	return rt.lastEMA
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
This PR introduces a `ruTracker` to use a time-aware EMA algorithm to sample and calculate the real-time RU/s for each resource group.
It it critical to provide an accurate sampled RU/s for the priority scheduling under service limit, so this is a prerequisite work.
```

An illustration for the formual `e^{-β·Δt}`, which desribe the relation between decay factor and time delta:

![](https://github.com/user-attachments/assets/74d81499-fdec-49c8-b233-cf13782a065a)

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Test with:

- rg1: burstable 5000 RU/s
- rg2: non-burstable 2500 RU/s

![](https://github.com/user-attachments/assets/1cd75278-f37f-4d0f-a31d-56f9a58135d8)

<img width="829" alt="截屏2025-06-05 17 42 25" src="https://github.com/user-attachments/assets/41e205b5-4e62-4cb2-9df2-2482b927bd77" />

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
