### PR TITLE
mcs: introduce getter and setter methods for RU settings

### DIFF
--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -52,7 +52,7 @@ func TestInitDefaultResourceGroup(t *testing.T) {
 	re.Equal(uint32(middlePriority), defaultGroup.Priority)
 
 	// Verify the default resource group has unlimited rate and burst limit.
-	re.Equal(uint64(unlimitedRate), defaultGroup.RUSettings.RU.getFillRateSetting())
+	re.Equal(float64(unlimitedRate), defaultGroup.RUSettings.RU.getFillRateSetting())
 	re.Equal(int64(unlimitedBurstLimit), defaultGroup.RUSettings.RU.getBurstLimitSetting())
 }
 
@@ -99,7 +99,10 @@ func TestAddResourceGroup(t *testing.T) {
 	re.Equal(group.GetName(), addedGroup.Name)
 	re.Equal(group.GetMode(), addedGroup.Mode)
 	re.Equal(group.GetPriority(), addedGroup.Priority)
-	re.Equal(group.GetRUSettings().GetRU().GetSettings().GetFillRate(), addedGroup.RUSettings.RU.getFillRateSetting())
+	re.Equal(
+		float64(group.GetRUSettings().GetRU().GetSettings().GetFillRate()),
+		addedGroup.RUSettings.RU.getFillRateSetting(),
+	)
 	re.Equal(group.GetRUSettings().GetRU().GetSettings().GetBurstLimit(), addedGroup.RUSettings.RU.getBurstLimitSetting())
 }
 
@@ -147,7 +150,10 @@ func TestModifyResourceGroup(t *testing.T) {
 	re.True(exists)
 	re.Equal(modifiedGroup.GetName(), updatedGroup.Name)
 	re.Equal(modifiedGroup.GetPriority(), updatedGroup.Priority)
-	re.Equal(modifiedGroup.GetRUSettings().GetRU().GetSettings().GetFillRate(), updatedGroup.RUSettings.RU.getFillRateSetting())
+	re.Equal(
+		float64(modifiedGroup.GetRUSettings().GetRU().GetSettings().GetFillRate()),
+		updatedGroup.RUSettings.RU.getFillRateSetting(),
+	)
 	re.Equal(modifiedGroup.GetRUSettings().GetRU().GetSettings().GetBurstLimit(), updatedGroup.RUSettings.RU.getBurstLimitSetting())
 
 	// Try to modify a non-existent group.

--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -52,8 +52,8 @@ func TestInitDefaultResourceGroup(t *testing.T) {
 	re.Equal(uint32(middlePriority), defaultGroup.Priority)
 
 	// Verify the default resource group has unlimited rate and burst limit.
-	re.Equal(uint64(unlimitedRate), defaultGroup.RUSettings.RU.Settings.FillRate)
-	re.Equal(int64(unlimitedBurstLimit), defaultGroup.RUSettings.RU.Settings.BurstLimit)
+	re.Equal(uint64(unlimitedRate), defaultGroup.RUSettings.RU.getFillRateSetting())
+	re.Equal(int64(unlimitedBurstLimit), defaultGroup.RUSettings.RU.getBurstLimitSetting())
 }
 
 func TestAddResourceGroup(t *testing.T) {
@@ -99,8 +99,8 @@ func TestAddResourceGroup(t *testing.T) {
 	re.Equal(group.GetName(), addedGroup.Name)
 	re.Equal(group.GetMode(), addedGroup.Mode)
 	re.Equal(group.GetPriority(), addedGroup.Priority)
-	re.Equal(group.GetRUSettings().GetRU().GetSettings().GetFillRate(), addedGroup.RUSettings.RU.Settings.FillRate)
-	re.Equal(group.GetRUSettings().GetRU().GetSettings().GetBurstLimit(), addedGroup.RUSettings.RU.Settings.BurstLimit)
+	re.Equal(group.GetRUSettings().GetRU().GetSettings().GetFillRate(), addedGroup.RUSettings.RU.getFillRateSetting())
+	re.Equal(group.GetRUSettings().GetRU().GetSettings().GetBurstLimit(), addedGroup.RUSettings.RU.getBurstLimitSetting())
 }
 
 func TestModifyResourceGroup(t *testing.T) {
@@ -147,8 +147,8 @@ func TestModifyResourceGroup(t *testing.T) {
 	re.True(exists)
 	re.Equal(modifiedGroup.GetName(), updatedGroup.Name)
 	re.Equal(modifiedGroup.GetPriority(), updatedGroup.Priority)
-	re.Equal(modifiedGroup.GetRUSettings().GetRU().GetSettings().GetFillRate(), updatedGroup.RUSettings.RU.Settings.FillRate)
-	re.Equal(modifiedGroup.GetRUSettings().GetRU().GetSettings().GetBurstLimit(), updatedGroup.RUSettings.RU.Settings.BurstLimit)
+	re.Equal(modifiedGroup.GetRUSettings().GetRU().GetSettings().GetFillRate(), updatedGroup.RUSettings.RU.getFillRateSetting())
+	re.Equal(modifiedGroup.GetRUSettings().GetRU().GetSettings().GetBurstLimit(), updatedGroup.RUSettings.RU.getBurstLimitSetting())
 
 	// Try to modify a non-existent group.
 	nonExistentGroup := &rmpb.ResourceGroup{

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -97,7 +97,7 @@ func TestInitManager(t *testing.T) {
 	re.NotNil(rg)
 	// Verify the default resource group settings are updated. This is to ensure the default resource group
 	// can be loaded from the storage correctly rather than created as a new one.
-	re.Equal(defaultGroup.RUSettings.RU.Settings.FillRate, rg.RUSettings.RU.Settings.FillRate)
+	re.Equal(defaultGroup.RUSettings.RU.getFillRateSetting(), rg.RUSettings.RU.getFillRateSetting())
 }
 
 func TestBackgroundMetricsFlush(t *testing.T) {
@@ -218,7 +218,7 @@ func checkAddAndModifyResourceGroup(re *require.Assertions, manager *Manager, ke
 		rg := manager.GetResourceGroup(keyspaceID, group.Name, true)
 		re.NotNil(rg)
 		return rg.Priority == group.Priority &&
-			rg.RUSettings.RU.Settings.BurstLimit == group.RUSettings.RU.Settings.BurstLimit
+			rg.RUSettings.RU.getBurstLimitSetting() == group.RUSettings.RU.Settings.BurstLimit
 	})
 }
 

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -56,7 +56,7 @@ func (rus *RequestUnitSettings) Clone() *RequestUnitSettings {
 	}
 	var ru *GroupTokenBucket
 	if rus.RU != nil {
-		ru = rus.RU.Clone()
+		ru = rus.RU.clone()
 	}
 	return &RequestUnitSettings{
 		RU: ru,
@@ -119,13 +119,13 @@ func (rg *ResourceGroup) getPriority() float64 {
 func (rg *ResourceGroup) getFillRate() float64 {
 	rg.RLock()
 	defer rg.RUnlock()
-	return float64(rg.RUSettings.RU.Settings.FillRate)
+	return rg.RUSettings.RU.getFillRateSetting()
 }
 
 func (rg *ResourceGroup) getBurstLimit() float64 {
 	rg.RLock()
 	defer rg.RUnlock()
-	return float64(rg.RUSettings.RU.Settings.BurstLimit)
+	return float64(rg.RUSettings.RU.getBurstLimitSetting())
 }
 
 // PatchSettings patches the resource group settings.
@@ -205,7 +205,7 @@ func (rg *ResourceGroup) RequestRU(
 	if limitedTokens < grantedTokens {
 		tb.Tokens = limitedTokens
 		// Retain the unused tokens for the later requests if it has a burst limit.
-		if rg.RUSettings.RU.Settings.BurstLimit > 0 {
+		if rg.RUSettings.RU.getBurstLimitSetting() > 0 {
 			rg.RUSettings.RU.lastLimitedTokens += grantedTokens - limitedTokens
 		}
 	}
@@ -269,7 +269,7 @@ func (rg *ResourceGroup) GetGroupStates() *GroupStates {
 	case rmpb.GroupMode_RUMode: // RU mode
 		consumption := *rg.RUConsumption
 		tokens := &GroupStates{
-			RU:            rg.RUSettings.RU.GroupTokenBucketState.Clone(),
+			RU:            rg.RUSettings.RU.GroupTokenBucketState.clone(),
 			RUConsumption: &consumption,
 		}
 		return tokens

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -79,8 +79,19 @@ type GroupTokenBucket struct {
 	GroupTokenBucketState `json:"state,omitempty"`
 }
 
-// Clone returns the deep copy of GroupTokenBucket
-func (gtb *GroupTokenBucket) Clone() *GroupTokenBucket {
+func (gtb *GroupTokenBucket) getFillRateSetting() float64 {
+	return float64(gtb.Settings.GetFillRate())
+}
+
+func (gtb *GroupTokenBucket) setFillRateSetting(fillRate uint64) {
+	gtb.Settings.FillRate = fillRate
+}
+
+func (gtb *GroupTokenBucket) getBurstLimitSetting() int64 {
+	return gtb.Settings.GetBurstLimit()
+}
+
+func (gtb *GroupTokenBucket) clone() *GroupTokenBucket {
 	if gtb == nil {
 		return nil
 	}
@@ -88,7 +99,7 @@ func (gtb *GroupTokenBucket) Clone() *GroupTokenBucket {
 	if gtb.Settings != nil {
 		settings = proto.Clone(gtb.Settings).(*rmpb.TokenLimitSettings)
 	}
-	stateClone := *gtb.GroupTokenBucketState.Clone()
+	stateClone := *gtb.GroupTokenBucketState.clone()
 	return &GroupTokenBucket{
 		Settings:              settings,
 		GroupTokenBucketState: stateClone,
@@ -101,11 +112,11 @@ func (gtb *GroupTokenBucket) setState(state *GroupTokenBucketState) {
 	gtb.Initialized = state.Initialized
 }
 
-// TokenSlot is used to split a token bucket into multiple slots to
+// tokenSlot is used to split a token bucket into multiple slots to
 // server different clients within the same resource group.
-type TokenSlot struct {
-	// settings is the token limit settings for the slot.
-	settings *rmpb.TokenLimitSettings
+type tokenSlot struct {
+	fillRate   uint64
+	burstLimit int64
 	// requireTokensSum is the number of tokens required.
 	requireTokensSum float64
 	// tokenCapacity is the number of tokens in the slot.
@@ -118,7 +129,7 @@ type TokenSlot struct {
 type GroupTokenBucketState struct {
 	Tokens float64 `json:"tokens,omitempty"`
 	// ClientUniqueID -> TokenSlot
-	tokenSlots                 map[uint64]*TokenSlot
+	tokenSlots                 map[uint64]*tokenSlot
 	clientConsumptionTokensSum float64
 	// Used to store tokens in the token slot that exceed burst limits,
 	// ensuring that these tokens are not lost but are reintroduced into
@@ -136,11 +147,10 @@ type GroupTokenBucketState struct {
 	lastCheckExpireSlot time.Time
 }
 
-// Clone returns the copy of GroupTokenBucketState
-func (gts *GroupTokenBucketState) Clone() *GroupTokenBucketState {
-	var tokenSlots map[uint64]*TokenSlot
+func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
+	var tokenSlots map[uint64]*tokenSlot
 	if gts.tokenSlots != nil {
-		tokenSlots = make(map[uint64]*TokenSlot)
+		tokenSlots = make(map[uint64]*tokenSlot)
 		for id, tokens := range gts.tokenSlots {
 			tokenSlots[id] = tokens
 		}
@@ -178,69 +188,66 @@ func (gts *GroupTokenBucketState) resetLoan() {
 	}
 }
 
-func (gts *GroupTokenBucketState) balanceSlotTokens(
+func (gtb *GroupTokenBucket) balanceSlotTokens(
 	clientUniqueID uint64,
-	settings *rmpb.TokenLimitSettings,
-	requiredToken, elapseTokens float64) {
+	requiredToken, elapseTokens float64,
+) {
 	now := time.Now()
-	slot, exist := gts.tokenSlots[clientUniqueID]
+	slot, exist := gtb.tokenSlots[clientUniqueID]
 	if !exist {
 		// Only slots that require a positive number will be considered alive,
 		// but still need to allocate the elapsed tokens as well.
 		if requiredToken != 0 {
-			slot = &TokenSlot{lastReqTime: now}
-			gts.tokenSlots[clientUniqueID] = slot
-			gts.clientConsumptionTokensSum = 0
+			slot = &tokenSlot{lastReqTime: now}
+			gtb.tokenSlots[clientUniqueID] = slot
+			gtb.clientConsumptionTokensSum = 0
 		}
 	} else {
 		slot.lastReqTime = now
-		if gts.clientConsumptionTokensSum >= maxAssignTokens {
-			gts.clientConsumptionTokensSum = 0
+		if gtb.clientConsumptionTokensSum >= maxAssignTokens {
+			gtb.clientConsumptionTokensSum = 0
 		}
 		// Clean up slot that required 0.
 		if requiredToken == 0 {
-			delete(gts.tokenSlots, clientUniqueID)
-			gts.clientConsumptionTokensSum = 0
+			delete(gtb.tokenSlots, clientUniqueID)
+			gtb.clientConsumptionTokensSum = 0
 		}
 	}
 
-	if time.Since(gts.lastCheckExpireSlot) >= slotExpireTimeout {
-		gts.lastCheckExpireSlot = now
-		for clientUniqueID, slot := range gts.tokenSlots {
+	if time.Since(gtb.lastCheckExpireSlot) >= slotExpireTimeout {
+		gtb.lastCheckExpireSlot = now
+		for clientUniqueID, slot := range gtb.tokenSlots {
 			if time.Since(slot.lastReqTime) >= slotExpireTimeout {
-				delete(gts.tokenSlots, clientUniqueID)
-				log.Info("delete resource group slot because expire", zap.Time("last-req-time", slot.lastReqTime),
-					zap.Duration("expire-timeout", slotExpireTimeout), zap.Uint64("del-client-id", clientUniqueID), zap.Int("len", len(gts.tokenSlots)))
+				delete(gtb.tokenSlots, clientUniqueID)
+				log.Info("delete resource group slot because expire",
+					zap.Time("last-req-time", slot.lastReqTime),
+					zap.Duration("expire-timeout", slotExpireTimeout),
+					zap.Uint64("del-client-id", clientUniqueID),
+					zap.Int("len", len(gtb.tokenSlots)))
 			}
 		}
 	}
-	if len(gts.tokenSlots) == 0 {
+	if len(gtb.tokenSlots) == 0 {
 		return
 	}
-	evenRatio := 1 / float64(len(gts.tokenSlots))
-	if mode := getBurstableMode(settings); mode == rateControlled || mode == unlimited {
-		for _, slot := range gts.tokenSlots {
-			slot.settings = &rmpb.TokenLimitSettings{
-				FillRate:   uint64(float64(settings.GetFillRate()) * evenRatio),
-				BurstLimit: settings.GetBurstLimit(),
-			}
+	evenRatio := 1 / float64(len(gtb.tokenSlots))
+	if mode := getBurstableMode(gtb.Settings); mode == rateControlled || mode == unlimited {
+		for _, slot := range gtb.tokenSlots {
+			slot.fillRate = uint64(gtb.getFillRateSetting() * evenRatio)
+			slot.burstLimit = gtb.getBurstLimitSetting()
 		}
 		return
 	}
 
-	for _, slot := range gts.tokenSlots {
-		if gts.clientConsumptionTokensSum == 0 || len(gts.tokenSlots) == 1 {
+	for _, slot := range gtb.tokenSlots {
+		if gtb.clientConsumptionTokensSum == 0 || len(gtb.tokenSlots) == 1 {
 			// Need to make each slot even.
-			slot.tokenCapacity = evenRatio * gts.Tokens
-			slot.lastTokenCapacity = evenRatio * gts.Tokens
+			slot.tokenCapacity = evenRatio * gtb.Tokens
+			slot.lastTokenCapacity = evenRatio * gtb.Tokens
 			slot.requireTokensSum = 0
-			gts.clientConsumptionTokensSum = 0
+			gtb.clientConsumptionTokensSum = 0
 
-			fillRate, burstLimit := calcRateAndBurstLimit(settings, evenRatio)
-			slot.settings = &rmpb.TokenLimitSettings{
-				FillRate:   uint64(fillRate),
-				BurstLimit: int64(burstLimit),
-			}
+			slot.fillRate, slot.burstLimit = gtb.calcRateAndBurstLimit(evenRatio)
 		} else {
 			// In order to have fewer tokens available to clients that are currently consuming more.
 			// We have the following formula:
@@ -250,42 +257,40 @@ func (gts *GroupTokenBucketState) balanceSlotTokens(
 			// 		clientN: (1 - n/N + 1/N) * 1/N
 			// Sum is:
 			// 		(N - (a+b+...+n)/N +1) * 1/N => (N - 1 + 1) * 1/N => 1
-			ratio := (1 - slot.requireTokensSum/gts.clientConsumptionTokensSum + evenRatio) * evenRatio
+			ratio := (1 - slot.requireTokensSum/gtb.clientConsumptionTokensSum + evenRatio) * evenRatio
 
 			assignToken := elapseTokens * ratio
-			fillRate, burstLimit := calcRateAndBurstLimit(settings, ratio)
+			fillRate, burstLimit := gtb.calcRateAndBurstLimit(ratio)
 
 			// Need to reserve burst limit to next balance.
-			if burstLimit > 0 && slot.tokenCapacity > burstLimit {
-				reservedTokens := slot.tokenCapacity - burstLimit
-				gts.lastBurstTokens += reservedTokens
-				gts.Tokens -= reservedTokens
+			if burstLimit > 0 && slot.tokenCapacity > float64(burstLimit) {
+				reservedTokens := slot.tokenCapacity - float64(burstLimit)
+				gtb.lastBurstTokens += reservedTokens
+				gtb.Tokens -= reservedTokens
 				assignToken -= reservedTokens
 			}
 
 			slot.tokenCapacity += assignToken
 			slot.lastTokenCapacity += assignToken
-			slot.settings = &rmpb.TokenLimitSettings{
-				FillRate:   uint64(fillRate),
-				BurstLimit: int64(burstLimit),
-			}
+			slot.fillRate = fillRate
+			slot.burstLimit = burstLimit
 		}
 	}
 	if requiredToken != 0 {
 		// Only slots that require a positive number will be considered alive.
 		slot.requireTokensSum += requiredToken
-		gts.clientConsumptionTokensSum += requiredToken
+		gtb.clientConsumptionTokensSum += requiredToken
 	}
 }
 
-func calcRateAndBurstLimit(settings *rmpb.TokenLimitSettings, ratio float64) (fillRate, burstLimit float64) {
-	if getBurstableMode(settings) == moderated {
-		fillRate = math.Min(float64(settings.GetFillRate())+defaultModeratedBurstRate, unlimitedRate) * ratio
-		burstLimit = fillRate
+func (gtb *GroupTokenBucket) calcRateAndBurstLimit(ratio float64) (fillRate uint64, burstLimit int64) {
+	if getBurstableMode(gtb.Settings) == moderated {
+		fillRate = uint64(math.Min(gtb.getFillRateSetting()+defaultModeratedBurstRate, unlimitedRate) * ratio)
+		burstLimit = int64(fillRate)
 		return
 	}
-	fillRate = float64(settings.GetFillRate()) * ratio
-	burstLimit = float64(settings.GetBurstLimit()) * ratio
+	fillRate = uint64(gtb.getFillRateSetting() * ratio)
+	burstLimit = int64(float64(gtb.getBurstLimitSetting()) * ratio)
 	return
 }
 
@@ -298,7 +303,7 @@ func NewGroupTokenBucket(tokenBucket *rmpb.TokenBucket) *GroupTokenBucket {
 		Settings: tokenBucket.GetSettings(),
 		GroupTokenBucketState: GroupTokenBucketState{
 			Tokens:     tokenBucket.GetTokens(),
-			tokenSlots: make(map[uint64]*TokenSlot),
+			tokenSlots: make(map[uint64]*tokenSlot),
 		},
 	}
 }
@@ -330,15 +335,17 @@ func (gtb *GroupTokenBucket) patch(tb *rmpb.TokenBucket) {
 
 // init initializes the group token bucket.
 func (gtb *GroupTokenBucket) init(now time.Time, clientID uint64) {
-	if gtb.Settings.FillRate == 0 {
-		gtb.Settings.FillRate = defaultRefillRate
+	if gtb.getFillRateSetting() == 0 {
+		gtb.setFillRateSetting(defaultRefillRate)
 	}
-	if gtb.Tokens < defaultInitialTokens && gtb.Settings.BurstLimit > 0 {
+	if gtb.Tokens < defaultInitialTokens && gtb.getBurstLimitSetting() > 0 {
 		gtb.Tokens = defaultInitialTokens
 	}
 	// init slot
-	gtb.tokenSlots[clientID] = &TokenSlot{
-		settings:          gtb.Settings,
+	gtb.tokenSlots[clientID] = &tokenSlot{
+		// Copy settings to avoid modifying the original settings.
+		fillRate:          uint64(gtb.getFillRateSetting()),
+		burstLimit:        gtb.getBurstLimitSetting(),
 		tokenCapacity:     gtb.Tokens,
 		lastTokenCapacity: gtb.Tokens,
 	}
@@ -354,7 +361,7 @@ func (gtb *GroupTokenBucket) updateTokens(now time.Time, burstLimit int64, clien
 		gtb.init(now, clientUniqueID)
 	} else if burst := float64(burstLimit); burst > 0 {
 		if delta := now.Sub(*gtb.LastUpdate); delta > 0 {
-			elapseTokens = float64(gtb.Settings.GetFillRate())*delta.Seconds() + gtb.lastBurstTokens + gtb.lastLimitedTokens
+			elapseTokens = gtb.getFillRateSetting()*delta.Seconds() + gtb.lastBurstTokens + gtb.lastLimitedTokens
 			gtb.lastBurstTokens = 0
 			gtb.lastLimitedTokens = 0
 			gtb.Tokens += elapseTokens
@@ -371,7 +378,7 @@ func (gtb *GroupTokenBucket) updateTokens(now time.Time, burstLimit int64, clien
 		gtb.resetLoan()
 	}
 	// Balance each slots.
-	gtb.balanceSlotTokens(clientUniqueID, gtb.Settings, requiredToken, elapseTokens)
+	gtb.balanceSlotTokens(clientUniqueID, requiredToken, elapseTokens)
 }
 
 // request requests tokens from the corresponding slot.
@@ -379,7 +386,7 @@ func (gtb *GroupTokenBucket) request(now time.Time,
 	requiredToken float64,
 	targetPeriodMs, clientUniqueID uint64,
 ) (*rmpb.TokenBucket, int64) {
-	burstLimit := gtb.Settings.GetBurstLimit()
+	burstLimit := gtb.getBurstLimitSetting()
 	gtb.updateTokens(now, burstLimit, clientUniqueID, requiredToken)
 	slot, ok := gtb.tokenSlots[clientUniqueID]
 	if !ok {
@@ -393,9 +400,9 @@ func (gtb *GroupTokenBucket) request(now time.Time,
 	return res, trickleDuration
 }
 
-func (ts *TokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint64) (*rmpb.TokenBucket, int64) {
+func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint64) (*rmpb.TokenBucket, int64) {
 	var res rmpb.TokenBucket
-	burstLimit := ts.settings.GetBurstLimit()
+	burstLimit := ts.burstLimit
 	res.Settings = &rmpb.TokenLimitSettings{BurstLimit: burstLimit}
 	if getBurstableMode(res.Settings) == unlimited {
 		res.Tokens = requiredToken
@@ -427,7 +434,7 @@ func (ts *TokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint
 		targetPeriodTime    = time.Duration(targetPeriodMs) * time.Millisecond
 		targetPeriodTimeSec = targetPeriodTime.Seconds()
 		trickleTime         = 0.
-		fillRate            = ts.settings.GetFillRate()
+		fillRate            = ts.fillRate
 	)
 
 	loanCoefficient := defaultLoanCoefficient

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -39,7 +39,7 @@ func TestGroupTokenBucketUpdateAndPatch(t *testing.T) {
 	time1 := time.Now()
 	tb.request(time1, 0, 0, clientUniqueID)
 	re.LessOrEqual(math.Abs(tbSetting.Tokens-tb.Tokens), 1e-7)
-	re.Equal(tbSetting.Settings.FillRate, tb.Settings.FillRate)
+	re.Equal(tbSetting.Settings.FillRate, tb.getFillRateSetting())
 
 	tbSetting = &rmpb.TokenBucket{
 		Tokens: -100000,
@@ -53,7 +53,7 @@ func TestGroupTokenBucketUpdateAndPatch(t *testing.T) {
 	time2 := time.Now()
 	tb.request(time2, 0, 0, clientUniqueID)
 	re.LessOrEqual(math.Abs(100000-tb.Tokens), time2.Sub(time1).Seconds()*float64(tbSetting.Settings.FillRate)+1e7)
-	re.Equal(tbSetting.Settings.FillRate, tb.Settings.FillRate)
+	re.Equal(tbSetting.Settings.FillRate, tb.getFillRateSetting())
 
 	tbSetting = &rmpb.TokenBucket{
 		Tokens: 0,
@@ -135,11 +135,11 @@ func TestGroupTokenBucketRequestBurstLimit(t *testing.T) {
 		re.Contains(gtb.tokenSlots, clientUniqueID)
 		// it should not be able to change group settings
 		groupSetting := gtb.tokenSlots[clientUniqueID]
-		re.Equal(expectedBurstLimit, groupSetting.settings.BurstLimit)
-		re.Equal(uint64(expectedFillRate), groupSetting.settings.FillRate)
+		re.Equal(expectedBurstLimit, groupSetting.burstLimit)
+		re.Equal(uint64(expectedFillRate), groupSetting.fillRate)
 		// it should not be able to change gtb settings
-		re.Equal(tbSetting.GetSettings().BurstLimit, gtb.Settings.BurstLimit)
-		re.Equal(tbSetting.GetSettings().FillRate, gtb.Settings.FillRate)
+		re.Equal(tbSetting.GetSettings().BurstLimit, gtb.getBurstLimitSetting())
+		re.Equal(tbSetting.GetSettings().FillRate, gtb.getFillRateSetting())
 	}
 
 	// case 1: fillrate = 2000, burstLimit = 2000,0,-1,-2

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -39,7 +39,7 @@ func TestGroupTokenBucketUpdateAndPatch(t *testing.T) {
 	time1 := time.Now()
 	tb.request(time1, 0, 0, clientUniqueID)
 	re.LessOrEqual(math.Abs(tbSetting.Tokens-tb.Tokens), 1e-7)
-	re.Equal(tbSetting.Settings.FillRate, tb.getFillRateSetting())
+	re.Equal(float64(tbSetting.Settings.FillRate), tb.getFillRateSetting())
 
 	tbSetting = &rmpb.TokenBucket{
 		Tokens: -100000,
@@ -53,7 +53,7 @@ func TestGroupTokenBucketUpdateAndPatch(t *testing.T) {
 	time2 := time.Now()
 	tb.request(time2, 0, 0, clientUniqueID)
 	re.LessOrEqual(math.Abs(100000-tb.Tokens), time2.Sub(time1).Seconds()*float64(tbSetting.Settings.FillRate)+1e7)
-	re.Equal(tbSetting.Settings.FillRate, tb.getFillRateSetting())
+	re.Equal(float64(tbSetting.Settings.FillRate), tb.getFillRateSetting())
 
 	tbSetting = &rmpb.TokenBucket{
 		Tokens: 0,
@@ -138,8 +138,8 @@ func TestGroupTokenBucketRequestBurstLimit(t *testing.T) {
 		re.Equal(expectedBurstLimit, groupSetting.burstLimit)
 		re.Equal(uint64(expectedFillRate), groupSetting.fillRate)
 		// it should not be able to change gtb settings
+		re.Equal(float64(tbSetting.GetSettings().FillRate), gtb.getFillRateSetting())
 		re.Equal(tbSetting.GetSettings().BurstLimit, gtb.getBurstLimitSetting())
-		re.Equal(tbSetting.GetSettings().FillRate, gtb.getFillRateSetting())
 	}
 
 	// case 1: fillrate = 2000, burstLimit = 2000,0,-1,-2


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
The current code has too many nested structures, causing the same RU settings to be passed around in different structures and functions.
This PR simplifies that part of the code by consolidating access and usage as much as possible into unified getters and setters.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
