### PR TITLE
*: update tidb-dashboard dependence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20250521074834-db74bf0e3ac1
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2
+	github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sasha-s/go-deadlock v0.3.5
 	github.com/shirou/gopsutil/v3 v3.23.3

--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2 h1:XYKnwxMFz3tOTdNP1ZUoMIS951Ol8MTbq6sKVsg8lFE=
-github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2/go.mod h1:1FZhe+luYtDAevex4G6OGCbLLiJM3E/IN6Plrmh1zo0=
+github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d h1:BUV7g/bRRgN3xbFh13XRikj7pGTTpkLLtLVZBjm42M8=
+github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d/go.mod h1:1FZhe+luYtDAevex4G6OGCbLLiJM3E/IN6Plrmh1zo0=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -392,8 +392,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2 h1:XYKnwxMFz3tOTdNP1ZUoMIS951Ol8MTbq6sKVsg8lFE=
-github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2/go.mod h1:1FZhe+luYtDAevex4G6OGCbLLiJM3E/IN6Plrmh1zo0=
+github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d h1:BUV7g/bRRgN3xbFh13XRikj7pGTTpkLLtLVZBjm42M8=
+github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d/go.mod h1:1FZhe+luYtDAevex4G6OGCbLLiJM3E/IN6Plrmh1zo0=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -397,8 +397,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2 h1:XYKnwxMFz3tOTdNP1ZUoMIS951Ol8MTbq6sKVsg8lFE=
-github.com/pingcap/tidb-dashboard v0.0.0-20250219061340-d62018124ae2/go.mod h1:1FZhe+luYtDAevex4G6OGCbLLiJM3E/IN6Plrmh1zo0=
+github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d h1:BUV7g/bRRgN3xbFh13XRikj7pGTTpkLLtLVZBjm42M8=
+github.com/pingcap/tidb-dashboard v0.0.0-20250612034343-251c34dd9f3d/go.mod h1:1FZhe+luYtDAevex4G6OGCbLLiJM3E/IN6Plrmh1zo0=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Update tidb-dashboard.
The main functions that are hoped to be added:
When we get the normal TiDB instance count of 0(fetch from tidbTopologyKeyPrefix), then let's check if there are any alive instances obtained from the path prefixed with keyspaceNameKeyPrefix.

In addition, we try our best not to affect the clusters without keyspace information

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/9405

### What is changed and how does it work?

<!--
Update tidb-dashboard.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
E2E manual test (we still need to update the pd dependency):

  - Log in to Dashboard successfully

  - In addition, the following are the situations where additional logs are added:

    <img width="1624" alt="截屏2025-06-11 14 09 14" src="https://github.com/user-attachments/assets/b150935a-bdd0-4250-bd99-ad80e05fc212" />
        KeyspaceID 1: tidb 4000 (normal)

        KeyspaceID 101: tidb 4001 (normal)

        KeyspaceID 2: tidb 4000 (only set kv to etcd:`ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:2379 put /keyspaces/tidb/2/topology/tidb/127.0.0.1:4000/ttl 1749619996349209123` )
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
