### PR TITLE
gc: Add a temporary solution to make service safe point compatible with the new txn safe point mechanism

### DIFF
--- a/pkg/storage/endpoint/gc_safe_point.go
+++ b/pkg/storage/endpoint/gc_safe_point.go
@@ -75,7 +75,7 @@ func (se *StorageEndpoint) LoadMinServiceGCSafePoint(now time.Time) (*ServiceSaf
 		// There's no service safepoint. It may be a new cluster, or upgraded from an older version where all service
 		// safepoints are missing. For the second case, we have no way to recover it. Store an initial value 0 for
 		// gc_worker.
-		return se.initServiceGCSafePointForGCWorker(0)
+		return se.initServiceGCSafePointForGCWorker()
 	}
 
 	hasGCWorker := false
@@ -111,22 +111,28 @@ func (se *StorageEndpoint) LoadMinServiceGCSafePoint(now time.Time) (*ServiceSaf
 	if min.SafePoint == math.MaxUint64 {
 		// There's no valid safepoints and we have no way to recover it. Just set gc_worker to 0.
 		log.Info("there are no valid service safepoints. init gc_worker's service safepoint to 0")
-		return se.initServiceGCSafePointForGCWorker(0)
+		return se.initServiceGCSafePointForGCWorker()
 	}
 
 	if !hasGCWorker {
 		// If there exists some service safepoints but gc_worker is missing, init it with the min value among all
 		// safepoints (including expired ones)
-		return se.initServiceGCSafePointForGCWorker(min.SafePoint)
+		return se.initServiceGCSafePointForGCWorker()
 	}
 
 	return min, nil
 }
 
-func (se *StorageEndpoint) initServiceGCSafePointForGCWorker(initialValue uint64) (*ServiceSafePoint, error) {
+func (se *StorageEndpoint) initServiceGCSafePointForGCWorker() (*ServiceSafePoint, error) {
+	// Temporary solution:
+	// Use the txn safe point as the initial value of gc_worker.
+	txnSafePoint, err := newGCStateProvider(se).LoadTxnSafePoint(constant.NullKeyspaceID)
+	if err != nil {
+		return nil, err
+	}
 	ssp := &ServiceSafePoint{
 		ServiceID: keypath.GCWorkerServiceSafePointID,
-		SafePoint: initialValue,
+		SafePoint: txnSafePoint,
 		ExpiredAt: math.MaxInt64,
 	}
 	if err := se.SaveServiceGCSafePoint(ssp); err != nil {

--- a/pkg/storage/endpoint/safepoint_v2.go
+++ b/pkg/storage/endpoint/safepoint_v2.go
@@ -115,7 +115,7 @@ func (se *StorageEndpoint) LoadMinServiceSafePointV2(keyspaceID uint32, now time
 		return nil, err
 	}
 	if len(keys) == 0 {
-		return se.initServiceSafePointV2ForGCWorker(keyspaceID, 0)
+		return se.initServiceSafePointV2ForGCWorker(keyspaceID)
 	}
 
 	hasGCWorker := false
@@ -149,12 +149,12 @@ func (se *StorageEndpoint) LoadMinServiceSafePointV2(keyspaceID uint32, now time
 	if min.SafePoint == math.MaxUint64 {
 		// No service safe point or all of them are expired, set min service safe point to 0 to allow any update
 		log.Info("there are no valid service safepoints. init gc_worker's service safepoint to 0")
-		return se.initServiceSafePointV2ForGCWorker(keyspaceID, 0)
+		return se.initServiceSafePointV2ForGCWorker(keyspaceID)
 	}
 	if !hasGCWorker {
 		// If there exists some service safepoints but gc_worker is missing, init it with the min value among all
 		// safepoints (including expired ones)
-		return se.initServiceSafePointV2ForGCWorker(keyspaceID, min.SafePoint)
+		return se.initServiceSafePointV2ForGCWorker(keyspaceID)
 	}
 	return min, nil
 }
@@ -177,11 +177,17 @@ func (se *StorageEndpoint) LoadServiceSafePointV2(keyspaceID uint32, serviceID s
 	return serviceSafePoint, nil
 }
 
-func (se *StorageEndpoint) initServiceSafePointV2ForGCWorker(keyspaceID uint32, initialValue uint64) (*ServiceSafePointV2, error) {
+func (se *StorageEndpoint) initServiceSafePointV2ForGCWorker(keyspaceID uint32) (*ServiceSafePointV2, error) {
+	// Temporary solution:
+	// Use the txn safe point as the initial value of gc_worker.
+	txnSafePoint, err := newGCStateProvider(se).LoadTxnSafePoint(keyspaceID)
+	if err != nil {
+		return nil, err
+	}
 	ssp := &ServiceSafePointV2{
 		KeyspaceID: keyspaceID,
 		ServiceID:  keypath.GCWorkerServiceSafePointID,
-		SafePoint:  initialValue,
+		SafePoint:  txnSafePoint,
 		ExpiredAt:  math.MaxInt64,
 	}
 	if err := se.SaveServiceSafePointV2(ssp); err != nil {


### PR DESCRIPTION
…th the new txn safe point mechanism

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #8978


The `UpdateServiceGCSafePoint(V2)` methods are going to be deprecated and replaced by a compatibility layer over the `GCStatesManager`, which is expected to be done in #9292. However it's not sure when #9292 can be merged. Now, there still exist usages of `UpdateServiceGCSafePoint(V2)`, but TiDB won't register the service safe point of `"gc_worker"` anymore. This causes that when other components tries to register their service safe points, the `"gc_worker"`'s service safe point may be automatically initialized as 0, allowing data access that breaks the constraint of txn safe point.

This PR is a temporary solution to this problem, and should be finally cleaned up in #9292. This PR makes the service safe point of `"gc_worker"` always be initalized to the same value as the current txn safe point.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->


```commit-message
This PR makes the initialization of the service safe point of gc_worker to consider the txn safe point.
```


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
