### PR TITLE
tests: fix `TestTSONotLeader`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -532,6 +532,10 @@ func (c *client) GetTS(ctx context.Context) (physical int64, logical int64, err 
 	for retryCount = range maxTSORetryTimes {
 		resp := c.GetTSAsync(ctx)
 		if physical, logical, err = resp.Wait(); err != nil {
+			failpoint.Inject("skipRetry", func() {
+				failpoint.Return(physical, logical, err)
+			})
+
 			if !errs.IsLeaderChange(err) {
 				break
 			}

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -504,6 +504,7 @@ func TestTSONotLeader(t *testing.T) {
 	re.NoError(err)
 	defer pdClient.Close()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/rebaseErr", "return(true)"))
+	re.NoError(failpoint.Enable("github.com/tikv/pd/client/skipRetry", "return(true)"))
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func(client pd.Client) {
@@ -514,6 +515,7 @@ func TestTSONotLeader(t *testing.T) {
 	}(pdClient)
 
 	wg.Wait()
+	re.NoError(failpoint.Disable("github.com/tikv/pd/client/skipRetry"))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/rebaseErr"))
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9412.

### What is changed and how does it work?

The test won't return `not leader` because of the retry. So we add a failpoint to skip the retry.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
