### PR TITLE
feat(resourcemanager): implement fill rate conciliation based on priority

### DIFF
--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -252,10 +252,9 @@ func (krgm *keyspaceResourceGroupManager) setServiceLimit(serviceLimit float64) 
 	// Set the new service limit to the limiter.
 	sl.setServiceLimit(serviceLimit)
 	// Cleanup the overrides if the service limit is set to 0.
-	if serviceLimit > 0 {
-		return
+	if serviceLimit <= 0 {
+		krgm.cleanupOverrides()
 	}
-	krgm.cleanupOverrides()
 }
 
 func (krgm *keyspaceResourceGroupManager) getServiceLimiter() *serviceLimiter {
@@ -364,8 +363,9 @@ func (rt *ruTracker) getRUPerSec() float64 {
 //     a. Skip groups without RU tracker (inactive groups).
 //     b. Calculate demands for all active groups in this priority level:
 //     - Basic RU demand: min(realtime_RU_per_sec, fill_rate_setting)
-//     - Burst RU demand: max(0, realtime_RU_per_sec - fill_rate_setting)
-//     * If burst_limit_setting >= 0: burst_demand = min(burst_demand, burst_limit_setting)
+//     - Burst RU demand:
+//     * If burst_limit_setting is in [0, fill_rate_setting]: burst_demand = 0 (no extra tokens allowed)
+//     * Otherwise: burst_demand = max(0, realtime_RU_per_sec - fill_rate_setting)
 //     c. Determine allocation strategy based on remaining service limit:
 //     - Case 1: If total RU demand (basic + burst) < remaining service limit:
 //     * Grant all groups their full demanded resources (overrideFillRate = -1, overrideBurstLimit = -1)
@@ -378,19 +378,20 @@ func (rt *ruTracker) getRUPerSec() float64 {
 //     - Set overrideBurstLimit = overrideFillRate (no extra burst allowed)
 //     - Deduct allocated amount from remaining service limit and totalFillRate
 //     * Sub-case 2.2: If basic RU demand < remaining service limit:
-//     - Fully satisfy all basic demands first (overrideFillRate = -1)
-//     - Calculate burst capacity: remainingLimit - totalBasicDemand
-//     - Distribute burst capacity proportionally among burst demands:
+//     - First deduct totalBasicDemand from remaining service limit
+//     - The remaining capacity becomes burst capacity
+//     - Fully satisfy all basic demand first (overrideFillRate = -1)
+//     - Distribute burst capacity proportionally among burst demand:
 //     overrideBurstLimit = fillRateSetting + burstCapacity * (burstDemand / totalBurstDemand)
 //     - Respect original burst_limit_setting if > 0
-//     - Deduct burst capacity from remaining service limit
+//     - Deduct actual burst supply (overrideBurstLimit - fillRateSetting) from remaining service limit
 //  3. Continue to next priority level until all groups are processed or service limit is exhausted.
 //  4. If service limit is exhausted (remainingServiceLimit == 0), set overrideFillRate = 0 and
 //     overrideBurstLimit = 0 for all remaining lower priority groups (only for active groups).
 //
 // This ensures:
 // - Higher priority groups get resources first
-// - Within same priority, resources are allocated proportionally based on actual demand
+// - Within same priority, resources are allocated proportionally based on actual demand as much as possible
 // - Basic needs are prioritized over burst needs
 // - No group exceeds its configured limits
 // - Inactive groups (no RU consumption) are skipped to avoid unnecessary computation
@@ -412,112 +413,26 @@ func (krgm *keyspaceResourceGroupManager) conciliateFillRates() {
 		// If the remaining service limit is 0, set the fill rate of all the remaining resource groups to 0 directly.
 		// Only apply this to active resource groups (those with RU tracker and actual RU consumption).
 		if remainingServiceLimit == 0 {
-			for _, group := range queue {
-				ruTracker := krgm.getRUTracker(group.Name)
-				if ruTracker == nil || ruTracker.getRUPerSec() == 0 {
-					continue
-				}
-				// Only set the active resource groups to avoid unnecessary overrides.
-				group.overrideFillRateAndBurstLimit(0, 0)
-			}
+			krgm.setZeroFillRateForAllGroups(queue)
 			continue
 		}
 
-		var (
-			totalFillRate      = 0.0
-			totalBasicRUDemand = 0.0
-			totalBurstRUDemand = 0.0
-			basicRUDemandMap   = make(map[string]float64, len(queue))
-			burstRUDemandMap   = make(map[string]float64, len(queue))
-		)
 		// Calculate the basic and burst RU demands for all groups in this priority level.
-		for _, group := range queue {
-			ruTracker := krgm.getRUTracker(group.Name)
-			// Not found the RU tracker, skip this group.
-			if ruTracker == nil {
-				continue
-			}
-			ruPerSec := ruTracker.getRUPerSec()
-			fillRateSetting := group.getFillRateSetting()
-			burstLimitSetting := group.getBurstLimitSetting()
-			// Calculate the basic RU demand of the resource group.
-			// Basic demand is the minimum of real-time RU consumption and configured fill rate.
-			basicRUDemand := math.Min(ruPerSec, fillRateSetting)
-			totalBasicRUDemand += basicRUDemand
-			basicRUDemandMap[group.Name] = basicRUDemand
-			// Calculate the burst RU demand of the resource group.
-			// Burst demand is the excess consumption beyond the fill rate setting.
-			burstRUDemand := math.Max(0, ruPerSec-fillRateSetting)
-			// If the burst limit setting is greater than 0, the burst RU demand should not exceed the burst limit setting.
-			if burstLimitSetting >= 0 {
-				burstRUDemand = math.Min(burstRUDemand, burstLimitSetting)
-			}
-			totalBurstRUDemand += burstRUDemand
-			burstRUDemandMap[group.Name] = burstRUDemand
-			// Calculate the total fill rate of all the resource groups in this priority level.
-			totalFillRate += fillRateSetting
+		di := krgm.calculateDemandInfo(queue)
+		totalRUDemand := di.totalRUDemand()
+		if totalRUDemand == 0 {
+			continue
 		}
-
-		totalRUDemand := totalBasicRUDemand + totalBurstRUDemand
 		// If the total real-time RU demand is greater than or equal to the remaining service limit,
 		// we need to divide the remaining service limit proportionally within the same priority level.
 		if totalRUDemand >= remainingServiceLimit {
-			type groupInfo struct {
-				group              *ResourceGroup
-				basicRUDemand      float64
-				normalizedRUDemand float64
-			}
-			groupInfos := make([]*groupInfo, 0, len(queue))
-			for _, group := range queue {
-				basicRUDemand := basicRUDemandMap[group.Name]
-				groupInfos = append(groupInfos, &groupInfo{
-					group:         group,
-					basicRUDemand: basicRUDemand,
-					// The normalized RU demand is the basic RU demand divided by the fill rate setting.
-					// This can represent its demand level under the fill rate setting.
-					normalizedRUDemand: basicRUDemand / group.getFillRateSetting(),
-				})
-			}
-			// Sort the group infos by the normalized RU demand in ascending order, low demand first.
-			sort.Slice(groupInfos, func(i, j int) bool {
-				return groupInfos[i].normalizedRUDemand < groupInfos[j].normalizedRUDemand
-			})
-			// If the basic RU demand already exceeds the remaining service limit, then we can only try to meet the basic needs of
-			// the resource groups through proportional allocation of the fill rate setting.
-			if totalBasicRUDemand >= remainingServiceLimit {
-				for _, gi := range groupInfos {
-					fillRateSetting := gi.group.getFillRateSetting()
-					proportionalFillRate := remainingServiceLimit * fillRateSetting / totalFillRate
-					// Allocate the remaining service limit proportionally based on basic demand.
-					overrideFillRate := math.Min(
-						gi.basicRUDemand,
-						proportionalFillRate,
-					)
-					// Do not allow the resource group to consume extra tokens in this case,
-					// so the override burst limit is set to the same as the override fill rate.
-					gi.group.overrideFillRateAndBurstLimit(overrideFillRate, int64(overrideFillRate))
-					// Deduct the basic RU demand from the remaining service limit.
-					remainingServiceLimit -= overrideFillRate
-					totalFillRate -= fillRateSetting
-				}
+			if di.totalBasicRUDemand >= remainingServiceLimit {
+				// If the basic RU demand already exceeds the remaining service limit, then we can only try to meet the basic needs of
+				// the resource groups through proportional allocation of the fill rate setting.
+				remainingServiceLimit = di.allocateBasicRUDemand(queue, remainingServiceLimit)
 			} else {
-				// If the basic RU demand can be fully met, we can further satisfy burst RU demands.
-				burstCapacity := remainingServiceLimit - totalBasicRUDemand
-				for _, group := range queue {
-					burstRUDemand := burstRUDemandMap[group.Name]
-					// Allocate the remaining service limit proportionally based on burst demand.
-					overrideBurstLimit := group.getFillRateSetting() + burstCapacity*burstRUDemand/totalBurstRUDemand
-					// Should not exceed the original burst limit setting if it's greater than 0.
-					if burstLimit := group.getBurstLimitSetting(); burstLimit > 0 {
-						overrideBurstLimit = math.Min(overrideBurstLimit, burstLimit)
-					}
-					// The basic RU demand is already met, so the override fill rate is set to -1
-					// to allow the resource group to consume as many RUs as they originally need
-					// according to its fill rate setting.
-					group.overrideFillRateAndBurstLimit(-1, int64(overrideBurstLimit))
-					// Deduct the burst capacity from the remaining service limit.
-					remainingServiceLimit -= overrideBurstLimit
-				}
+				// If the basic RU demand can be fully met, we can further satisfy the extra burst RU demand.
+				remainingServiceLimit = di.allocateBurstRUDemand(queue, remainingServiceLimit)
 			}
 		} else {
 			// If the total real-time RU demand is less than the remaining service limit, no need to divide the service limit,
@@ -563,6 +478,135 @@ func (krgm *keyspaceResourceGroupManager) getPriorityQueues() [][]*ResourceGroup
 		n++
 	}
 	return priorityQueues[:n]
+}
+
+func (krgm *keyspaceResourceGroupManager) setZeroFillRateForAllGroups(queue []*ResourceGroup) {
+	for _, group := range queue {
+		ruTracker := krgm.getRUTracker(group.Name)
+		if ruTracker == nil || ruTracker.getRUPerSec() == 0 {
+			continue
+		}
+		// Only set the active resource groups to avoid unnecessary overrides.
+		group.overrideFillRateAndBurstLimit(0, 0)
+	}
+}
+
+func (krgm *keyspaceResourceGroupManager) calculateDemandInfo(queue []*ResourceGroup) *demandInfo {
+	di := &demandInfo{
+		basicRUDemandMap: make(map[string]float64, len(queue)),
+		burstRUDemandMap: make(map[string]float64, len(queue)),
+	}
+	for _, group := range queue {
+		ruTracker := krgm.getRUTracker(group.Name)
+		// Not found the RU tracker, skip this group.
+		if ruTracker == nil {
+			continue
+		}
+		ruPerSec := ruTracker.getRUPerSec()
+		fillRateSetting := group.getFillRate(true)
+		burstLimitSetting := float64(group.getBurstLimit(true))
+		// Calculate the basic RU demand of the resource group.
+		// Basic demand is the minimum of real-time RU consumption and configured fill rate.
+		basicRUDemand := math.Min(ruPerSec, fillRateSetting)
+		di.totalBasicRUDemand += basicRUDemand
+		di.basicRUDemandMap[group.Name] = basicRUDemand
+		// Calculate the burst RU demand of the resource group.
+		burstRUDemand := 0.0
+		// If the burst limit setting is within the range of [0, fillRateSetting],
+		// it means the resource group is not allowed to consume extra tokens,
+		// so the burst RU demand should always be 0.
+		if 0 <= burstLimitSetting && burstLimitSetting <= fillRateSetting {
+			burstRUDemand = 0
+		} else {
+			burstRUDemand = math.Max(0, ruPerSec-fillRateSetting)
+		}
+		di.totalBurstRUDemand += burstRUDemand
+		di.burstRUDemandMap[group.Name] = burstRUDemand
+		// Calculate the total fill rate of all the resource groups in this priority level.
+		di.totalFillRate += fillRateSetting
+	}
+	return di
+}
+
+type demandInfo struct {
+	totalFillRate      float64
+	totalBasicRUDemand float64
+	totalBurstRUDemand float64
+	basicRUDemandMap   map[string]float64
+	burstRUDemandMap   map[string]float64
+}
+
+func (di *demandInfo) totalRUDemand() float64 {
+	return di.totalBasicRUDemand + di.totalBurstRUDemand
+}
+
+func (di *demandInfo) allocateBasicRUDemand(
+	queue []*ResourceGroup,
+	remainingServiceLimit float64,
+) float64 {
+	type groupInfo struct {
+		group              *ResourceGroup
+		basicRUDemand      float64
+		normalizedRUDemand float64
+	}
+	groupInfos := make([]*groupInfo, 0, len(queue))
+	for _, group := range queue {
+		basicRUDemand := di.basicRUDemandMap[group.Name]
+		groupInfos = append(groupInfos, &groupInfo{
+			group:         group,
+			basicRUDemand: basicRUDemand,
+			// The normalized RU demand is the basic RU demand divided by the fill rate setting.
+			// This can represent its demand level under the fill rate setting.
+			normalizedRUDemand: basicRUDemand / group.getFillRate(true),
+		})
+	}
+	// Sort the group infos by the normalized RU demand in ascending order, low demand first.
+	sort.Slice(groupInfos, func(i, j int) bool {
+		return groupInfos[i].normalizedRUDemand < groupInfos[j].normalizedRUDemand
+	})
+	for _, gi := range groupInfos {
+		fillRateSetting := gi.group.getFillRate(true)
+		proportionalFillRate := remainingServiceLimit * fillRateSetting / di.totalFillRate
+		// Allocate the remaining service limit proportionally based on basic demand.
+		overrideFillRate := math.Min(
+			gi.basicRUDemand,
+			proportionalFillRate,
+		)
+		// Do not allow the resource group to consume extra tokens in this case,
+		// so the override burst limit is set to the same as the override fill rate.
+		gi.group.overrideFillRateAndBurstLimit(overrideFillRate, int64(overrideFillRate))
+		// Deduct the basic RU demand from the remaining service limit.
+		remainingServiceLimit -= overrideFillRate
+		di.totalFillRate -= fillRateSetting
+	}
+	return remainingServiceLimit
+}
+
+func (di *demandInfo) allocateBurstRUDemand(
+	queue []*ResourceGroup,
+	remainingServiceLimit float64,
+) float64 {
+	remainingServiceLimit -= di.totalBasicRUDemand
+	// The remaining service limit is the burst capacity.
+	burstCapacity := remainingServiceLimit
+	for _, group := range queue {
+		burstRUDemand := di.burstRUDemandMap[group.Name]
+		fillRateSetting := group.getFillRate(true)
+		// Allocate the remaining service limit proportionally based on burst demand.
+		overrideBurstLimit := fillRateSetting + burstCapacity*burstRUDemand/di.totalBurstRUDemand
+		// Should not exceed the original burst limit setting if it's greater than 0.
+		burstLimitSetting := float64(group.getBurstLimit(true))
+		if burstLimitSetting > 0 {
+			overrideBurstLimit = math.Min(overrideBurstLimit, burstLimitSetting)
+		}
+		// The basic RU demand is already met, so the override fill rate is set to -1
+		// to allow the resource group to consume as many RUs as they originally need
+		// according to its fill rate setting.
+		group.overrideFillRateAndBurstLimit(-1, int64(overrideBurstLimit))
+		// Deduct the burst supply from the remaining service limit.
+		remainingServiceLimit -= math.Max(0, overrideBurstLimit-fillRateSetting)
+	}
+	return remainingServiceLimit
 }
 
 func (krgm *keyspaceResourceGroupManager) cleanupOverrides() {

--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -811,8 +811,8 @@ func TestConciliateFillRate(t *testing.T) {
 			ruDemandList:          []float64{35, 45, 22, 20}, // Basic: 30,40,20,30=120; Burst: 5,5,2,0=12; Total: 132
 			// Priority 2: demand 80, gets full allocation (remaining: 20)
 			// Priority 1: demand 42 > remaining 20, basic demand 50 > remaining 20, proportional allocation: 20*(20/40)=10, 20*(20/40)=10
-			expectedOverrideFillRateList:   []float64{-1, -1, 10, 10}, // Priority 2 gets full, priority 1 gets basic demand proportionally
-			expectedOverrideBurstLimitList: []int64{-1, -1, 10, 10},
+			expectedOverrideFillRateList:   []float64{-1, -1, 8, 12}, // Priority 2 gets full, priority 1 gets basic demand proportionally
+			expectedOverrideBurstLimitList: []int64{-1, -1, 8, 12},
 		},
 		{
 			name:                  "Unlimited burst limit with service limit constraint",
@@ -864,6 +864,24 @@ func TestConciliateFillRate(t *testing.T) {
 			// Basic demand 1000 > service limit 100, so gets proportional allocation: 100*(1000/1000)=100
 			expectedOverrideFillRateList:   []float64{100},
 			expectedOverrideBurstLimitList: []int64{100},
+		},
+		{
+			name:                           "Proportional allocation with normalization check - case 1",
+			serviceLimit:                   100,
+			priorityList:                   []uint32{1, 1, 1},
+			fillRateSettingList:            []uint64{100, 100, 100},
+			ruDemandList:                   []float64{40, 80, 10},
+			expectedOverrideFillRateList:   []float64{40, 50, 10},
+			expectedOverrideBurstLimitList: []int64{40, 50, 10},
+		},
+		{
+			name:                           "Proportional allocation with normalization check - case 2",
+			serviceLimit:                   90,
+			priorityList:                   []uint32{1, 1, 1},
+			fillRateSettingList:            []uint64{100, 100, 100},
+			ruDemandList:                   []float64{50, 60, 70},
+			expectedOverrideFillRateList:   []float64{30, 30, 30},
+			expectedOverrideBurstLimitList: []int64{30, 30, 30},
 		},
 	}
 	genGroupName := func(caseIdx, i int) string {

--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -54,7 +54,7 @@ func TestInitDefaultResourceGroup(t *testing.T) {
 
 	// Verify the default resource group has unlimited rate and burst limit.
 	re.Equal(float64(unlimitedRate), defaultGroup.getFillRate())
-	re.Equal(int64(unlimitedBurstLimit), defaultGroup.getBurstLimitSetting())
+	re.Equal(float64(unlimitedBurstLimit), defaultGroup.getBurstLimitSetting())
 }
 
 func TestAddResourceGroup(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -831,13 +831,14 @@ func TestConciliateFillRate(t *testing.T) {
 			serviceLimit:          60,
 			priorityList:          []uint32{2, 2, 1},
 			fillRateSettingList:   []uint64{20, 30, 40},
-			burstLimitSettingList: []int64{10, 15, 20},
+			burstLimitSettingList: []int64{20, 30, 40},
 			ruDemandList:          []float64{25, 40, 50}, // Basic: 20,30,40=90; Burst: 5,10,10=25; Total: 115
 			// Priority 2: demand 65 > service limit 60, basic demand 50 < service limit 60, basic satisfied, burst gets: 60-50=10
-			// Burst allocation: 10*(5/15)=3.33, 10*(10/15)=6.67, so burst limits: min(20+3.33, 10), min(30+6.67, 15)
-			// Priority 1: gets 0 (no remaining service limit)
-			expectedOverrideFillRateList:   []float64{-1, -1, 0},
-			expectedOverrideBurstLimitList: []int64{10, 15, 0},
+			// Burst allocation: 10*(5/15)=3.33, 10*(10/15)=6.67, so burst limits: min(20+3.33, 20)=20, min(30+6.67, 30)=30
+			// After allocation, remaining service limit is still 10.
+			// Priority 1: gets 10
+			expectedOverrideFillRateList:   []float64{-1, -1, 10},
+			expectedOverrideBurstLimitList: []int64{20, 30, 10},
 		},
 		{
 			name:                  "Partial burst demand satisfied with unlimited burst limit",

--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -927,5 +927,12 @@ func TestConciliateFillRate(t *testing.T) {
 				"check burst limit of case %s, group %d", tc.name, i,
 			)
 		}
+		// Test the cleanup overrides.
+		krgm.setServiceLimit(0)
+		for i := range tc.priorityList {
+			group := krgm.getMutableResourceGroup(genGroupName(idx, i))
+			re.Equal(float64(-1), group.getOverrideFillRate(), "check fill rate of case %s, group %d", tc.name, i)
+			re.Equal(int64(-1), group.getOverrideBurstLimit(), "check burst limit of case %s, group %d", tc.name, i)
+		}
 	}
 }

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -542,7 +542,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 						continue
 					}
 					metrics := m.metrics.getGaugeMetrics(krgm.keyspaceID, keyspaceName, groupName)
-					metrics.setGroup(group)
+					metrics.setGroup(group, keyspaceName)
 					// Record the tracked RU per second.
 					if rt := krgm.getRUTracker(groupName); rt != nil {
 						metrics.setSampledRUPerSec(rt.getRUPerSec())

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -520,7 +520,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 					consumptionInfo.RRU+consumptionInfo.WRU,
 					sinceLastRecord,
 				)
-				// Consiliate the fill rate of the resource group.
+				// Conciliate the fill rate of the resource group.
 				krgm.conciliateFillRates()
 			}
 		case <-cleanUpTicker.C:

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -102,7 +102,7 @@ func TestInitManager(t *testing.T) {
 	re.NotNil(rg)
 	// Verify the default resource group settings are updated. This is to ensure the default resource group
 	// can be loaded from the storage correctly rather than created as a new one.
-	re.Equal(defaultGroup.RUSettings.RU.getFillRate(), rg.RUSettings.RU.getFillRate())
+	re.Equal(defaultGroup.getFillRate(), rg.getFillRate())
 }
 
 func TestBackgroundMetricsFlush(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -102,7 +102,7 @@ func TestInitManager(t *testing.T) {
 	re.NotNil(rg)
 	// Verify the default resource group settings are updated. This is to ensure the default resource group
 	// can be loaded from the storage correctly rather than created as a new one.
-	re.Equal(defaultGroup.RUSettings.RU.getFillRateSetting(), rg.RUSettings.RU.getFillRateSetting())
+	re.Equal(defaultGroup.RUSettings.RU.getFillRate(), rg.RUSettings.RU.getFillRate())
 }
 
 func TestBackgroundMetricsFlush(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -217,20 +217,14 @@ func newMetrics() *metrics {
 	}
 }
 
-// insertConsumptionRecord inserts the consumption record and returns the duration since the last record.
-// If the record is not found, it returns 0 as the duration.
-func (m *metrics) insertConsumptionRecord(keyspaceID uint32, groupName string, ruType string, now time.Time) time.Duration {
+// insertConsumptionRecord inserts the consumption record.
+func (m *metrics) insertConsumptionRecord(keyspaceID uint32, groupName string, ruType string, now time.Time) {
 	key := consumptionRecordKey{
 		keyspaceID: keyspaceID,
 		groupName:  groupName,
 		ruType:     ruType,
 	}
-	last, ok := m.consumptionRecordMap[key]
 	m.consumptionRecordMap[key] = now
-	if !ok {
-		return 0
-	}
-	return now.Sub(last)
 }
 
 func (m *metrics) deleteConsumptionRecord(record consumptionRecordKey) {
@@ -277,7 +271,7 @@ func (m *metrics) recordConsumption(
 	keyspaceName string,
 	controllerConfig *ControllerConfig,
 	now time.Time,
-) time.Duration {
+) {
 	keyspaceID := consumptionInfo.keyspaceID
 	groupName := consumptionInfo.resourceGroupName
 	ruLabelType := defaultTypeLabel
@@ -290,7 +284,7 @@ func (m *metrics) recordConsumption(
 	consumption := consumptionInfo.Consumption
 	m.getMaxPerSecTracker(keyspaceID, keyspaceName, groupName).collect(consumption)
 	m.getCounterMetrics(keyspaceID, keyspaceName, groupName, ruLabelType).add(consumption, controllerConfig)
-	return m.insertConsumptionRecord(keyspaceID, groupName, ruLabelType, now)
+	m.insertConsumptionRecord(keyspaceID, groupName, ruLabelType, now)
 }
 
 func (m *metrics) cleanupAllMetrics(r consumptionRecordKey, keyspaceName string) {

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -147,6 +147,10 @@ func (rg *ResourceGroup) getOverrideFillRate() float64 {
 func (rg *ResourceGroup) overrideFillRate(new float64) {
 	rg.Lock()
 	defer rg.Unlock()
+	rg.overrideFillRateLocked(new)
+}
+
+func (rg *ResourceGroup) overrideFillRateLocked(new float64) {
 	original := rg.RUSettings.RU.overrideFillRate
 	// If the fill rate has not been set before or the new value is negative,
 	// set it to the new fill rate directly without checking the tolerance.
@@ -180,15 +184,15 @@ func (rg *ResourceGroup) getOverrideBurstLimit() int64 {
 	return rg.RUSettings.RU.overrideBurstLimit
 }
 
-func (rg *ResourceGroup) overrideBurstLimit(new int64) {
-	rg.Lock()
-	defer rg.Unlock()
+func (rg *ResourceGroup) overrideBurstLimitLocked(new int64) {
 	rg.RUSettings.RU.overrideBurstLimit = new
 }
 
 func (rg *ResourceGroup) overrideFillRateAndBurstLimit(fillRate float64, burstLimit int64) {
-	rg.overrideFillRate(fillRate)
-	rg.overrideBurstLimit(burstLimit)
+	rg.Lock()
+	defer rg.Unlock()
+	rg.overrideFillRateLocked(fillRate)
+	rg.overrideBurstLimitLocked(burstLimit)
 }
 
 // PatchSettings patches the resource group settings.

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -121,23 +121,17 @@ func (rg *ResourceGroup) getPriority() float64 {
 	return float64(rg.Priority)
 }
 
-// getFillRateSetting returns the fill rate setting of the resource group.
-// It is the fill rate setting in the resource group settings without considering the override.
-func (rg *ResourceGroup) getFillRateSetting() float64 {
-	rg.RLock()
-	defer rg.RUnlock()
-	return rg.RUSettings.RU.getFillRateSetting()
-}
-
 // getFillRate returns the fill rate of the resource group.
-// It is the fill rate setting in the resource group settings that takes into account the override.
-func (rg *ResourceGroup) getFillRate() float64 {
+// It will ignore the override fill rate and return the fill rate setting if the `ignoreOverride` is true.
+func (rg *ResourceGroup) getFillRate(ignoreOverride ...bool) float64 {
 	rg.RLock()
 	defer rg.RUnlock()
+	if len(ignoreOverride) > 0 && ignoreOverride[0] {
+		return rg.RUSettings.RU.getFillRateSetting()
+	}
 	return rg.RUSettings.RU.getFillRate()
 }
 
-// getOverrideFillRate returns the override fill rate of the resource group.
 func (rg *ResourceGroup) getOverrideFillRate() float64 {
 	rg.RLock()
 	defer rg.RUnlock()
@@ -166,15 +160,14 @@ func (rg *ResourceGroup) overrideFillRateLocked(new float64) {
 	}
 }
 
-func (rg *ResourceGroup) getBurstLimitSetting() float64 {
+// getBurstLimit returns the burst limit of the resource group.
+// It will ignore the override burst limit and return the burst limit setting if the `ignoreOverride` is true.
+func (rg *ResourceGroup) getBurstLimit(ignoreOverride ...bool) int64 {
 	rg.RLock()
 	defer rg.RUnlock()
-	return float64(rg.RUSettings.RU.getBurstLimitSetting())
-}
-
-func (rg *ResourceGroup) getBurstLimit() int64 {
-	rg.RLock()
-	defer rg.RUnlock()
+	if len(ignoreOverride) > 0 && ignoreOverride[0] {
+		return rg.RUSettings.RU.getBurstLimitSetting()
+	}
 	return rg.RUSettings.RU.getBurstLimit()
 }
 

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -121,14 +121,6 @@ func (rg *ResourceGroup) getPriority() float64 {
 	return float64(rg.Priority)
 }
 
-// getFillRate returns the fill rate of the resource group.
-// It may be overridden by the override fill rate of the runtime state.
-func (rg *ResourceGroup) getFillRate() float64 {
-	rg.RLock()
-	defer rg.RUnlock()
-	return rg.RUSettings.RU.getFillRate()
-}
-
 // getFillRateSetting returns the fill rate setting of the resource group.
 // It is the fill rate setting in the resource group settings.
 func (rg *ResourceGroup) getFillRateSetting() float64 {
@@ -245,7 +237,7 @@ func (rg *ResourceGroup) RequestRU(
 	if limitedTokens < grantedTokens {
 		tb.Tokens = limitedTokens
 		// Retain the unused tokens for the later requests if it has a burst limit.
-		if rg.RUSettings.RU.getBurstLimitSetting() > 0 {
+		if rg.RUSettings.RU.getBurstLimit() > 0 {
 			rg.RUSettings.RU.lastLimitedTokens += grantedTokens - limitedTokens
 		}
 	}

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -39,7 +39,7 @@ func TestGroupTokenBucketUpdateAndPatch(t *testing.T) {
 	time1 := time.Now()
 	tb.request(time1, 0, 0, clientUniqueID)
 	re.LessOrEqual(math.Abs(tbSetting.Tokens-tb.Tokens), 1e-7)
-	re.Equal(float64(tbSetting.Settings.FillRate), tb.getFillRateSetting())
+	re.Equal(float64(tbSetting.Settings.FillRate), tb.getFillRate())
 
 	tbSetting = &rmpb.TokenBucket{
 		Tokens: -100000,
@@ -53,7 +53,7 @@ func TestGroupTokenBucketUpdateAndPatch(t *testing.T) {
 	time2 := time.Now()
 	tb.request(time2, 0, 0, clientUniqueID)
 	re.LessOrEqual(math.Abs(100000-tb.Tokens), time2.Sub(time1).Seconds()*float64(tbSetting.Settings.FillRate)+1e7)
-	re.Equal(float64(tbSetting.Settings.FillRate), tb.getFillRateSetting())
+	re.Equal(float64(tbSetting.Settings.FillRate), tb.getFillRate())
 
 	tbSetting = &rmpb.TokenBucket{
 		Tokens: 0,
@@ -138,7 +138,7 @@ func TestGroupTokenBucketRequestBurstLimit(t *testing.T) {
 		re.Equal(expectedBurstLimit, groupSetting.burstLimit)
 		re.Equal(uint64(expectedFillRate), groupSetting.fillRate)
 		// it should not be able to change gtb settings
-		re.Equal(float64(tbSetting.GetSettings().FillRate), gtb.getFillRateSetting())
+		re.Equal(float64(tbSetting.GetSettings().FillRate), gtb.getFillRate())
 		re.Equal(tbSetting.GetSettings().BurstLimit, gtb.getBurstLimitSetting())
 	}
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Implement the fill rate conciliation based on resource group's priority. This ensure the RU priority scheduling within the service limit.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Case 1: Two Resource Groups With the Same Priority

- rg1 RU_PER_SEC=2500 PRIORITY=MEDIUM BURSTABLE=ON
- rg2 RU_PER_SEC=5000 PRIORITY=MEDIUM BURSTABLE=OFF

![](https://github.com/user-attachments/assets/35ddf61b-8b10-4b31-95c2-de34314be5f8)

Case 2: Two Resource Groups With Different Priorities

- rg1 RU_PER_SEC=2500 PRIORITY=MEDIUM BURSTABLE=ON
- rg2 RU_PER_SEC=5000 PRIORITY=HIGH BURSTABLE=OFF

![](https://github.com/user-attachments/assets/7ae6c35e-2a11-4fff-9dc7-ce80cbf4cb91)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
