### PR TITLE
member: fix useless unicode in log

### DIFF
--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -264,7 +264,7 @@ func (s *Server) primaryElectionLoop() {
 				zap.String("server-name", s.Name()),
 				zap.String("expected-primary-id", expectedPrimary),
 				zap.Uint64("member-id", s.participant.ID()),
-				zap.String("cur-member-value", s.participant.MemberValue()))
+				zap.String("cur-member-value", s.participant.MemberString()))
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
@@ -317,7 +317,7 @@ func (s *Server) campaignLeader() {
 	lease, err := utils.KeepExpectedPrimaryAlive(ctx, s.GetClient(), exitPrimary,
 		s.cfg.LeaderLease, &keypath.MsParam{
 			ServiceName: constant.SchedulingServiceName,
-		}, s.participant.MemberValue())
+		}, s.participant)
 	if err != nil {
 		log.Error("prepare scheduling primary watch error", errs.ZapError(err))
 		return

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -56,7 +56,7 @@ import (
 )
 
 var _ bs.Server = (*Server)(nil)
-var _ tso.ElectionMember = (*member.Participant)(nil)
+var _ member.ElectionMember = (*member.Participant)(nil)
 
 const serviceName = "TSO Service"
 
@@ -230,7 +230,7 @@ func (s *Server) GetLeaderListenUrls() []string {
 }
 
 // GetMember returns the election member of the given keyspace and keyspace group.
-func (s *Server) GetMember(keyspaceID, keyspaceGroupID uint32) (tso.ElectionMember, error) {
+func (s *Server) GetMember(keyspaceID, keyspaceGroupID uint32) (member.ElectionMember, error) {
 	member, err := s.keyspaceGroupManager.GetElectionMember(keyspaceID, keyspaceGroupID)
 	if err != nil {
 		return nil, err

--- a/pkg/member/election_member.go
+++ b/pkg/member/election_member.go
@@ -1,0 +1,72 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"context"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/tikv/pd/pkg/election"
+)
+
+// ElectionMember defines the interface for the election related logic.
+type ElectionMember interface {
+	// ID returns the unique ID in the election group. For example, it can be unique
+	// server id of a cluster or the unique keyspace group replica id of the election
+	// group composed of the replicas of a keyspace group.
+	ID() uint64
+	// Name returns the unique name in the election group.
+	Name() string
+	// MemberValue returns the member value.
+	MemberValue() string
+	// MemberString returns the member value as a string.
+	MemberString() string
+	// GetMember returns the current member
+	GetMember() any
+	// Client returns the etcd client.
+	Client() *clientv3.Client
+	// IsLeader returns whether the participant is the leader or not by checking its
+	// leadership's lease and leader info.
+	IsLeader() bool
+	// IsLeaderElected returns true if the leader exists; otherwise false.
+	IsLeaderElected() bool
+	// CheckLeader checks if someone else is taking the leadership. If yes, returns the leader;
+	// otherwise returns a bool which indicates if it is needed to check later.
+	CheckLeader() (leader ElectionLeader, checkAgain bool)
+	// EnableLeader declares the member itself to be the leader.
+	EnableLeader()
+	// KeepLeader is used to keep the leader's leadership.
+	KeepLeader(ctx context.Context)
+	// CampaignLeader is used to campaign the leadership and make it become a leader in an election group.
+	CampaignLeader(ctx context.Context, leaseTimeout int64) error
+	// ResetLeader is used to reset the member's current leadership.
+	// Basically it will reset the leader lease and unset leader info.
+	ResetLeader()
+	// GetLeaderListenUrls returns current leader's listen urls
+	// The first element is the leader/primary url
+	GetLeaderListenUrls() []string
+	// GetLeaderID returns current leader's member ID.
+	GetLeaderID() uint64
+	// GetLeaderPath returns the path of the leader.
+	GetLeaderPath() string
+	// GetLeadership returns the leadership of the election member.
+	GetLeadership() *election.Leadership
+	// GetLastLeaderUpdatedTime returns the last time when the leader is updated.
+	GetLastLeaderUpdatedTime() time.Time
+	// PreCheckLeader does some pre-check before checking whether it's the leader.
+	PreCheckLeader() error
+}

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -93,6 +93,14 @@ func (m *EmbeddedEtcdMember) MemberValue() string {
 	return m.memberValue
 }
 
+// MemberString returns the member string.
+func (m *EmbeddedEtcdMember) MemberString() string {
+	if m.member == nil {
+		return ""
+	}
+	return m.member.String()
+}
+
 // Member returns the member.
 func (m *EmbeddedEtcdMember) Member() *pdpb.Member {
 	return m.member

--- a/pkg/member/participant.go
+++ b/pkg/member/participant.go
@@ -110,6 +110,14 @@ func (m *Participant) MemberValue() string {
 	return m.memberValue
 }
 
+// MemberString returns the member string.
+func (m *Participant) MemberString() string {
+	if m.member == nil {
+		return ""
+	}
+	return m.member.String()
+}
+
 // Client returns the etcd client.
 func (m *Participant) Client() *clientv3.Client {
 	return m.client

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/failpoint"
@@ -55,52 +54,6 @@ const (
 	updateTSORetryInterval = 50 * time.Millisecond
 )
 
-// ElectionMember defines the interface for the election related logic.
-type ElectionMember interface {
-	// ID returns the unique ID in the election group. For example, it can be unique
-	// server id of a cluster or the unique keyspace group replica id of the election
-	// group composed of the replicas of a keyspace group.
-	ID() uint64
-	// Name returns the unique name in the election group.
-	Name() string
-	// MemberValue returns the member value.
-	MemberValue() string
-	// GetMember returns the current member
-	GetMember() any
-	// Client returns the etcd client.
-	Client() *clientv3.Client
-	// IsLeader returns whether the participant is the leader or not by checking its
-	// leadership's lease and leader info.
-	IsLeader() bool
-	// IsLeaderElected returns true if the leader exists; otherwise false.
-	IsLeaderElected() bool
-	// CheckLeader checks if someone else is taking the leadership. If yes, returns the leader;
-	// otherwise returns a bool which indicates if it is needed to check later.
-	CheckLeader() (leader member.ElectionLeader, checkAgain bool)
-	// EnableLeader declares the member itself to be the leader.
-	EnableLeader()
-	// KeepLeader is used to keep the leader's leadership.
-	KeepLeader(ctx context.Context)
-	// CampaignLeader is used to campaign the leadership and make it become a leader in an election group.
-	CampaignLeader(ctx context.Context, leaseTimeout int64) error
-	// ResetLeader is used to reset the member's current leadership.
-	// Basically it will reset the leader lease and unset leader info.
-	ResetLeader()
-	// GetLeaderListenUrls returns current leader's listen urls
-	// The first element is the leader/primary url
-	GetLeaderListenUrls() []string
-	// GetLeaderID returns current leader's member ID.
-	GetLeaderID() uint64
-	// GetLeaderPath returns the path of the leader.
-	GetLeaderPath() string
-	// GetLeadership returns the leadership of the election member.
-	GetLeadership() *election.Leadership
-	// GetLastLeaderUpdatedTime returns the last time when the leader is updated.
-	GetLastLeaderUpdatedTime() time.Time
-	// PreCheckLeader does some pre-check before checking whether it's the leader.
-	PreCheckLeader() error
-}
-
 // Allocator is the global single point TSO allocator.
 type Allocator struct {
 	ctx    context.Context
@@ -111,7 +64,7 @@ type Allocator struct {
 	// keyspaceGroupID is the keyspace group ID of the allocator.
 	keyspaceGroupID uint32
 	// for election use
-	member ElectionMember
+	member member.ElectionMember
 	// expectedPrimaryLease is used to store the expected primary lease.
 	expectedPrimaryLease atomic.Value // store as *election.LeaderLease
 	timestampOracle      *timestampOracle
@@ -125,7 +78,7 @@ type Allocator struct {
 func NewAllocator(
 	ctx context.Context,
 	keyspaceGroupID uint32,
-	member ElectionMember,
+	member member.ElectionMember,
 	storage endpoint.TSOStorage,
 	cfg Config,
 ) *Allocator {
@@ -299,7 +252,7 @@ func (a *Allocator) primaryElectionLoop() {
 		if len(expectedPrimary) > 0 && !strings.Contains(a.member.MemberValue(), expectedPrimary) {
 			log.Info("skip campaigning of tso primary and check later", append(a.logFields,
 				zap.String("expected-primary-id", expectedPrimary),
-				zap.String("cur-member-value", a.member.MemberValue()))...)
+				zap.String("cur-member-value", a.member.MemberString()))...)
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
@@ -355,7 +308,7 @@ func (a *Allocator) campaignLeader() {
 		leaderLease, &keypath.MsParam{
 			ServiceName: constant.TSOServiceName,
 			GroupID:     a.keyspaceGroupID,
-		}, a.member.MemberValue())
+		}, a.member)
 	if err != nil {
 		log.Error("prepare tso primary watch error", append(a.logFields, errs.ZapError(err))...)
 		return
@@ -407,7 +360,7 @@ func (a *Allocator) GetPrimaryAddr() string {
 }
 
 // GetMember returns the member of the allocator.
-func (a *Allocator) GetMember() ElectionMember {
+func (a *Allocator) GetMember() member.ElectionMember {
 	return a.member
 }
 

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -280,7 +280,7 @@ func (s *state) getKeyspaceGroupMetaWithCheck(
 
 func (s *state) getNextPrimaryToReset(
 	groupID int, localAddress string,
-) (member ElectionMember, kg *endpoint.KeyspaceGroup, localPriority, nextGroupID int) {
+) (member member.ElectionMember, kg *endpoint.KeyspaceGroup, localPriority, nextGroupID int) {
 	s.RLock()
 	defer s.RUnlock()
 
@@ -998,7 +998,7 @@ func (kgm *KeyspaceGroupManager) FindGroupByKeyspaceID(
 // GetElectionMember returns the election member of the keyspace group serving the given keyspace.
 func (kgm *KeyspaceGroupManager) GetElectionMember(
 	keyspaceID, keyspaceGroupID uint32,
-) (ElectionMember, error) {
+) (member.ElectionMember, error) {
 	if err := checkKeySpaceGroupID(keyspaceGroupID); err != nil {
 		return nil, err
 	}

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/member"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
@@ -59,7 +60,7 @@ type tsoObject struct {
 // timestampOracle is used to maintain the logic of TSO.
 type timestampOracle struct {
 	keyspaceGroupID uint32
-	member          ElectionMember
+	member          member.ElectionMember
 	storage         endpoint.TSOStorage
 	// TODO: remove saveInterval
 	saveInterval           time.Duration


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8561

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
```
[2025/06/25 16:55:36.726 +08:00] [INFO] [expected_primary.go:86] ["primary start to watch the expected primary"] [service=scheduling] [primary-value="name:\"http://192.168.8.88:2386\" id:2098730525054592624 listen_urls:\"http://192.168.8.88:2386\" "]
[2025/06/25 16:55:36.729 +08:00] [INFO] [lease.go:77] ["lease granted"] [lease-id=2369623094457411927] [lease-timeout=5] [purpose="scheduling expected primary"]
[2025/06/25 16:55:36.729 +08:00] [INFO] [expected_primary.go:61] ["set expected primary flag"] [primary-path=/ms/7519807998145716660/scheduling/primary/expected_primary] [leader-raw="name:\"http://192.168.8.88:2386\" id:2098730525054592624 listen_urls:\"http://192.168.8.88:2386\" "]
[2025/06/25 16:55:36.731 +08:00] [INFO] [lease.go:160] ["start lease keep alive worker"] [interval=1.666666666s] [purpose="scheduling expected primary"]
[2025/06/25 16:55:36.733 +08:00] [INFO] [leadership.go:347] ["watch channel is created"] [revision=18] [leader-key=/ms/7519807998145716660/scheduling/primary/expected_primary] [purpose="scheduling expected primary"]
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
