### PR TITLE
mcs, test: fix `IsKeyspaceServing` and `TestKeyspacesServedByDefaultKeyspaceGroup` 

### DIFF
--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -213,7 +213,7 @@ func (s *Server) IsKeyspaceServingByGroup(keyspaceID, keyspaceGroupID uint32) bo
 	if keyspaceGroupID != expected || err != nil {
 		return false
 	}
-	return s.isKeyspacePrimary(keyspaceID, keyspaceGroupID)
+	return s.checkKeyspaceGroupLeadership(keyspaceID, keyspaceGroupID)
 }
 
 // IsKeyspaceServing returns whether the keyspace is serving.
@@ -224,9 +224,9 @@ func (s *Server) IsKeyspaceServing(keyspaceID uint32) bool {
 	// We only need to pass the keyspace ID and the default keyspace group ID.
 	// Because GetElectionMember will call getKeyspaceGroupMetaWithCheck,
 	// getKeyspaceGroupMetaWithCheck will correct the keyspace group ID automatically if keyspace serves.
-	return s.isKeyspacePrimary(keyspaceID, constant.DefaultKeyspaceGroupID)
+	return s.checkKeyspaceGroupLeadership(keyspaceID, constant.DefaultKeyspaceGroupID)
 }
-func (s *Server) isKeyspacePrimary(keyspaceID, keyspaceGroupID uint32) bool {
+func (s *Server) checkKeyspaceGroupLeadership(keyspaceID, keyspaceGroupID uint32) bool {
 	member, err := s.keyspaceGroupManager.GetElectionMember(
 		keyspaceID, keyspaceGroupID)
 	if err != nil {

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -216,7 +216,7 @@ func (s *Server) IsKeyspaceServingByGroup(keyspaceID, keyspaceGroupID uint32) bo
 	return s.isKeyspacePrimary(keyspaceID, keyspaceGroupID)
 }
 
-// IsKeyspaceServing returns whether the server is the primary of the given keyspace.
+// IsKeyspaceServing returns whether the keyspace is serving.
 func (s *Server) IsKeyspaceServing(keyspaceID uint32) bool {
 	if atomic.LoadInt64(&s.isRunning) == 0 {
 		return false

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -208,7 +208,7 @@ func (s *Server) IsKeyspaceServingByGroup(keyspaceID, keyspaceGroupID uint32) bo
 		return false
 	}
 	// We need to check if the keyspace group ID is expected for the given keyspace ID.
-	// It is necessary because isKeyspacePrimary will correct the keyspace group ID automatically if keyspace serves.
+	// It is necessary because checkKeyspaceGroupLeadership will correct the keyspace group ID automatically if keyspace serves.
 	_, _, expected, err := s.keyspaceGroupManager.FindGroupByKeyspaceID(keyspaceID)
 	if keyspaceGroupID != expected || err != nil {
 		return false

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -198,16 +198,35 @@ func (s *Server) Close() {
 // IsServing implements basicserver. It returns whether the server is the leader
 // if there is embedded etcd, or the primary otherwise.
 func (s *Server) IsServing() bool {
-	return s.IsKeyspaceServing(constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID)
+	return s.IsKeyspaceServing(constant.DefaultKeyspaceID)
 }
 
-// IsKeyspaceServing returns whether the server is the primary of the given keyspace.
-// TODO: update basicserver interface to support keyspace.
-func (s *Server) IsKeyspaceServing(keyspaceID, keyspaceGroupID uint32) bool {
+// IsKeyspaceServingByGroup returns whether the server is the primary of the given keyspace.
+// It only returns true when the keyspace ID matches the keyspace group ID.
+func (s *Server) IsKeyspaceServingByGroup(keyspaceID, keyspaceGroupID uint32) bool {
 	if atomic.LoadInt64(&s.isRunning) == 0 {
 		return false
 	}
+	// We need to check if the keyspace group ID is expected for the given keyspace ID.
+	// It is necessary because isKeyspacePrimary will correct the keyspace group ID automatically if keyspace serves.
+	_, _, expected, err := s.keyspaceGroupManager.FindGroupByKeyspaceID(keyspaceID)
+	if keyspaceGroupID != expected || err != nil {
+		return false
+	}
+	return s.isKeyspacePrimary(keyspaceID, keyspaceGroupID)
+}
 
+// IsKeyspaceServing returns whether the server is the primary of the given keyspace.
+func (s *Server) IsKeyspaceServing(keyspaceID uint32) bool {
+	if atomic.LoadInt64(&s.isRunning) == 0 {
+		return false
+	}
+	// We only need to pass the keyspace ID and the default keyspace group ID.
+	// Because GetElectionMember will call getKeyspaceGroupMetaWithCheck,
+	// getKeyspaceGroupMetaWithCheck will correct the keyspace group ID automatically if keyspace serves.
+	return s.isKeyspacePrimary(keyspaceID, constant.DefaultKeyspaceGroupID)
+}
+func (s *Server) isKeyspacePrimary(keyspaceID, keyspaceGroupID uint32) bool {
 	member, err := s.keyspaceGroupManager.GetElectionMember(
 		keyspaceID, keyspaceGroupID)
 	if err != nil {

--- a/tests/integrations/mcs/tso/server_test.go
+++ b/tests/integrations/mcs/tso/server_test.go
@@ -424,7 +424,7 @@ func (suite *PDServiceForward) checkForwardTSOUnexpectedToFollower(checkTSO func
 
 	// get follower's address
 	servers := tc.GetServers()
-	oldPrimary := tc.GetPrimaryServer(constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID).GetAddr()
+	oldPrimary := tc.GetPrimaryServer(constant.DefaultKeyspaceID).GetAddr()
 	var follower string
 	for addr := range servers {
 		if addr != oldPrimary {
@@ -612,7 +612,7 @@ func (suite *CommonTestSuite) SetupSuite() {
 	suite.tsoCluster, err = tests.NewTestTSOCluster(suite.ctx, 1, suite.backendEndpoints)
 	re.NoError(err)
 	suite.tsoCluster.WaitForDefaultPrimaryServing(re)
-	suite.tsoDefaultPrimaryServer = suite.tsoCluster.GetPrimaryServer(constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID)
+	suite.tsoDefaultPrimaryServer = suite.tsoCluster.GetPrimaryServer(constant.DefaultKeyspaceID)
 }
 
 func (suite *CommonTestSuite) TearDownSuite() {

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -182,7 +182,7 @@ func (suite *tsoClientTestSuite) waitForAllKeyspaceGroupsInServing(re *require.A
 			for _, keyspaceID := range keyspaceGroup.keyspaceIDs {
 				served := false
 				for _, server := range suite.tsoCluster.GetServers() {
-					if server.IsKeyspaceServing(keyspaceID, keyspaceGroup.keyspaceGroupID) {
+					if server.IsKeyspaceServingByGroup(keyspaceID, keyspaceGroup.keyspaceGroupID) {
 						served = true
 						break
 					}
@@ -407,9 +407,10 @@ func (suite *tsoClientTestSuite) TestRandomResignLeader() {
 			for _, keyspaceID := range keyspaceIDs {
 				go func(keyspaceID uint32) {
 					defer wg.Done()
+					suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID)
 					err := suite.tsoCluster.ResignPrimary(keyspaceID, constant.DefaultKeyspaceGroupID)
 					re.NoError(err)
-					suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID, 0)
+					suite.tsoCluster.WaitForPrimaryServing(re, keyspaceID)
 				}(keyspaceID)
 			}
 			wg.Wait()

--- a/tests/tso_cluster.go
+++ b/tests/tso_cluster.go
@@ -149,7 +149,7 @@ func (tc *TestTSOCluster) DestroyServer(addr string) {
 
 // ResignPrimary resigns the primary TSO server.
 func (tc *TestTSOCluster) ResignPrimary(keyspaceID, keyspaceGroupID uint32) error {
-	primaryServer := tc.GetPrimaryServer(keyspaceID, keyspaceGroupID)
+	primaryServer := tc.GetPrimaryServer(keyspaceID)
 	if primaryServer == nil {
 		return fmt.Errorf("no tso server serves this keyspace %d", keyspaceID)
 	}
@@ -157,9 +157,9 @@ func (tc *TestTSOCluster) ResignPrimary(keyspaceID, keyspaceGroupID uint32) erro
 }
 
 // GetPrimaryServer returns the primary TSO server of the given keyspace
-func (tc *TestTSOCluster) GetPrimaryServer(keyspaceID, keyspaceGroupID uint32) *tso.Server {
+func (tc *TestTSOCluster) GetPrimaryServer(keyspaceID uint32) *tso.Server {
 	for _, server := range tc.servers {
-		if server.IsKeyspaceServing(keyspaceID, keyspaceGroupID) {
+		if server.IsKeyspaceServing(keyspaceID) {
 			return server
 		}
 	}
@@ -167,11 +167,11 @@ func (tc *TestTSOCluster) GetPrimaryServer(keyspaceID, keyspaceGroupID uint32) *
 }
 
 // WaitForPrimaryServing waits for one of servers being elected to be the primary/leader of the given keyspace.
-func (tc *TestTSOCluster) WaitForPrimaryServing(re *require.Assertions, keyspaceID, keyspaceGroupID uint32) *tso.Server {
+func (tc *TestTSOCluster) WaitForPrimaryServing(re *require.Assertions, keyspaceID uint32) *tso.Server {
 	var primary *tso.Server
 	testutil.Eventually(re, func() bool {
 		for _, server := range tc.servers {
-			if server.IsKeyspaceServing(keyspaceID, keyspaceGroupID) {
+			if server.IsKeyspaceServing(keyspaceID) {
 				primary = server
 				return true
 			}
@@ -184,7 +184,7 @@ func (tc *TestTSOCluster) WaitForPrimaryServing(re *require.Assertions, keyspace
 
 // WaitForDefaultPrimaryServing waits for one of servers being elected to be the primary/leader of the default keyspace.
 func (tc *TestTSOCluster) WaitForDefaultPrimaryServing(re *require.Assertions) *tso.Server {
-	return tc.WaitForPrimaryServing(re, constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID)
+	return tc.WaitForPrimaryServing(re, constant.DefaultKeyspaceID)
 }
 
 // GetServer returns the TSO server by the given address.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #4399 

1. `IsKeyspaceServing` will call `GetElectionMember`, `GetElectionMember` will call `getKeyspaceGroupMetaWithCheck`, `getKeyspaceGroupMetaWithCheck` will correct the keyspace group ID automatically if keyspace serves. So it doesn't care keyspace group. We should use two functions to solve it.
2. `TestKeyspacesServedByDefaultKeyspaceGroup` don't use the result of `IsKeyspaceServing`

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
