### PR TITLE
maintenance: implement PD maintenance endpoints to serialize TiKV maintenance operations

### DIFF
--- a/pkg/maintenance/metrics.go
+++ b/pkg/maintenance/metrics.go
@@ -1,0 +1,36 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maintenance
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	maintenanceTaskInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "maintenance",
+			Name:      "task_info",
+			Help:      "Current maintenance task info in PD",
+		}, []string{"task_type", "task_id"})
+)
+
+func init() {
+	prometheus.MustRegister(maintenanceTaskInfo)
+}
+
+// SetMaintenanceTaskInfo sets the maintenance task info metric.
+func SetMaintenanceTaskInfo(taskType, taskID string, value float64) {
+	maintenanceTaskInfo.WithLabelValues(taskType, taskID).Set(value)
+}

--- a/pkg/storage/endpoint/maintenance.go
+++ b/pkg/storage/endpoint/maintenance.go
@@ -1,0 +1,239 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package endpoint provides storage operations for maintenance tasks.
+// This implementation follows the design specified in RFC-0118:
+// https://github.com/tikv/rfcs/blob/master/text/0118-pd-maintenance-endpoints.md
+//
+// The storage layer provides atomic operations to ensure only one maintenance
+// task can be active at a time, preventing Raft quorum loss during TiKV maintenance.
+
+package endpoint
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/keypath"
+)
+
+// MaintenanceTask represents a maintenance task stored in etcd.
+// NOTE: This type is exported by HTTP API. Please pay more attention when modifying it.
+type MaintenanceTask struct {
+	Type           string `json:"type"`            // The type of maintenance task
+	ID             string `json:"id"`              // Unique identifier for the task
+	StartTimestamp int64  `json:"start_timestamp"` // Unix timestamp when the task started
+	Description    string `json:"description"`     // Optional description of the task
+}
+
+// MaintenanceStorage defines the interface for maintenance task storage operations.
+type MaintenanceStorage interface {
+	// LoadMaintenanceTask loads a maintenance task by type from storage.
+	LoadMaintenanceTask(taskType string) (*MaintenanceTask, error)
+	// LoadAllMaintenanceTasks loads all maintenance tasks from storage.
+	LoadAllMaintenanceTasks(f func(k, v string)) error
+	// TryStartMaintenanceTaskAtomic tries to start a maintenance task atomically.
+	TryStartMaintenanceTaskAtomic(ctx context.Context, task *MaintenanceTask) (bool, *MaintenanceTask, error)
+	// TryEndMaintenanceTaskAtomic tries to end a maintenance task atomically.
+	TryEndMaintenanceTaskAtomic(ctx context.Context, taskType, taskID string) (bool, *MaintenanceTask, error)
+}
+
+var _ MaintenanceStorage = (*StorageEndpoint)(nil)
+
+// LoadMaintenanceTask loads a maintenance task by type from storage.
+func (se *StorageEndpoint) LoadMaintenanceTask(taskType string) (*MaintenanceTask, error) {
+	key := keypath.MaintenanceTaskPath(taskType)
+	val, err := se.Load(key)
+	if err != nil {
+		return nil, err
+	}
+	if val == "" {
+		return nil, nil
+	}
+	var task MaintenanceTask
+	if err := json.Unmarshal([]byte(val), &task); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+// LoadAllMaintenanceTasks loads all maintenance tasks from storage.
+func (se *StorageEndpoint) LoadAllMaintenanceTasks(f func(k, v string)) error {
+	return se.loadRangeByPrefix(keypath.MaintenanceTaskPathPrefix(), f)
+}
+
+// TryStartMaintenanceTaskAtomic tries to start a maintenance task atomically.
+// Returns (true, nil) if success, (false, existingTask, nil) if conflict, (false, nil, err) if error.
+func (se *StorageEndpoint) TryStartMaintenanceTaskAtomic(_ context.Context, task *MaintenanceTask) (bool, *MaintenanceTask, error) {
+	// Use a single atomic transaction with proper etcd pattern
+	rawTxn := se.CreateRawTxn()
+
+	// Maintenance lock key to enforce single task type constraint
+	lockKey := keypath.MaintenanceTaskPath("__maintenance_lock__")
+	// Task key for storing the actual task data
+	taskKey := keypath.MaintenanceTaskPath(task.Type)
+
+	// Condition: check if no maintenance task is running (lock doesn't exist)
+	cond := kv.RawTxnCondition{
+		Key:     lockKey,
+		CmpType: kv.RawTxnCmpNotExists,
+	}
+
+	// Then: put both the lock and the task
+	val, err := json.Marshal(task)
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Put the maintenance lock with "task_type/task_id"
+	lockOp := kv.RawTxnOp{
+		Key:    lockKey,
+		OpType: kv.RawTxnOpPut,
+		Value:  task.Type + "/" + task.ID, // Store "task_type/task_id" as the lock value
+	}
+
+	// Put the actual task
+	taskOp := kv.RawTxnOp{
+		Key:    taskKey,
+		OpType: kv.RawTxnOpPut,
+		Value:  string(val),
+	}
+
+	// Else: get all tasks to see what's currently running
+	getAllOp := kv.RawTxnOp{
+		Key:    keypath.MaintenanceTaskPathPrefix(),          // Start key
+		OpType: kv.RawTxnOpGetRange,                          // Get range of keys
+		EndKey: keypath.MaintenanceTaskPathPrefix() + "\xff", // End key (prefix + max byte)
+		Limit:  100,                                          // Reasonable limit
+	}
+
+	// Execute the transaction: if no maintenance running, put lock and task; else get all tasks
+	resp, err := rawTxn.If(cond).Then(lockOp, taskOp).Else(getAllOp).Commit()
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Check if the transaction succeeded (lock and task were put)
+	if resp.Succeeded {
+		return true, nil, nil
+	}
+
+	// Transaction failed, meaning there was an existing lock
+	// Get all tasks and find the one that's currently running
+	if len(resp.Responses) > 0 && len(resp.Responses[0].KeyValuePairs) > 0 {
+		var existingTask *MaintenanceTask
+		taskCount := 0
+
+		for _, kv := range resp.Responses[0].KeyValuePairs {
+			// Skip the lock key itself
+			if kv.Key == lockKey {
+				continue
+			}
+
+			// Parse the task
+			var task MaintenanceTask
+			if err := json.Unmarshal([]byte(kv.Value), &task); err == nil {
+				existingTask = &task
+				taskCount++
+			}
+		}
+
+		// Assert that there should be only one task
+		if taskCount > 1 {
+			// This shouldn't happen - multiple tasks running simultaneously
+			return false, nil, fmt.Errorf("multiple maintenance tasks running simultaneously: found %d tasks", taskCount)
+		}
+
+		// Return the single task that's running
+		if existingTask != nil {
+			return false, existingTask, nil
+		}
+	}
+
+	return false, nil, nil
+}
+
+// TryEndMaintenanceTaskAtomic tries to end a maintenance task atomically.
+// Returns (true, nil) if success, (false, existingTask, nil) if conflict, (false, nil, err) if error.
+func (se *StorageEndpoint) TryEndMaintenanceTaskAtomic(_ context.Context, taskType, taskID string) (bool, *MaintenanceTask, error) {
+	// Use a single atomic transaction
+	rawTxn := se.CreateRawTxn()
+
+	lockKey := keypath.MaintenanceTaskPath("__maintenance_lock__")
+	taskKey := keypath.MaintenanceTaskPath(taskType)
+
+	// Condition: check if the lock value matches "task_type/task_id"
+	expectedLockValue := taskType + "/" + taskID
+	cond := kv.RawTxnCondition{
+		Key:     lockKey,
+		CmpType: kv.RawTxnCmpEqual,
+		Value:   expectedLockValue,
+	}
+
+	// Then: delete both the lock and the task
+	lockDeleteOp := kv.RawTxnOp{
+		Key:    lockKey,
+		OpType: kv.RawTxnOpDelete,
+	}
+
+	taskDeleteOp := kv.RawTxnOp{
+		Key:    taskKey,
+		OpType: kv.RawTxnOpDelete,
+	}
+
+	// Else: get all tasks to check what's currently running
+	getAllOp := kv.RawTxnOp{
+		Key:    keypath.MaintenanceTaskPathPrefix(),          // Start key
+		OpType: kv.RawTxnOpGetRange,                          // Get range of keys
+		EndKey: keypath.MaintenanceTaskPathPrefix() + "\xff", // End key (prefix + max byte)
+		Limit:  100,                                          // Reasonable limit
+	}
+
+	// Execute the transaction: if lock matches "task_type/task_id", delete both; else get all tasks
+	resp, err := rawTxn.If(cond).Then(lockDeleteOp, taskDeleteOp).Else(getAllOp).Commit()
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Check if the transaction succeeded (deletes were executed)
+	if resp.Succeeded {
+		return true, nil, nil
+	}
+
+	// Transaction failed, meaning we got all tasks
+	// Check if there's a task running for the requested type
+	if len(resp.Responses) > 0 && len(resp.Responses[0].KeyValuePairs) > 0 {
+		for _, kv := range resp.Responses[0].KeyValuePairs {
+			// Skip the lock key itself
+			if kv.Key == lockKey {
+				continue
+			}
+
+			// Parse the task
+			var existingTask MaintenanceTask
+			if err := json.Unmarshal([]byte(kv.Value), &existingTask); err == nil {
+				// Check if this is the task type we're looking for
+				if existingTask.Type == taskType {
+					// Found a task for this type, return it as conflict
+					return false, &existingTask, nil
+				}
+			}
+		}
+	}
+
+	// No task found for this type
+	return false, nil, nil
+}

--- a/pkg/storage/endpoint/maintenance.go
+++ b/pkg/storage/endpoint/maintenance.go
@@ -26,10 +26,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"github.com/pingcap/log"
+
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/keypath"
-	"go.uber.org/zap"
 )
 
 // MaintenanceLockName is the name used for the maintenance lock key.

--- a/pkg/storage/endpoint/maintenance.go
+++ b/pkg/storage/endpoint/maintenance.go
@@ -47,8 +47,8 @@ type MaintenanceStorage interface {
 	LoadAllMaintenanceTasks(f func(k, v string)) error
 	// TryStartMaintenanceTaskAtomic tries to start a maintenance task atomically.
 	TryStartMaintenanceTaskAtomic(ctx context.Context, task *MaintenanceTask) (bool, *MaintenanceTask, error)
-	// TryEndMaintenanceTaskAtomic tries to end a maintenance task atomically.
-	TryEndMaintenanceTaskAtomic(ctx context.Context, taskType, taskID string) (bool, *MaintenanceTask, error)
+	// TryDeleteMaintenanceTaskAtomic tries to delete a maintenance task atomically.
+	TryDeleteMaintenanceTaskAtomic(ctx context.Context, taskType, taskID string) (bool, *MaintenanceTask, error)
 }
 
 var _ MaintenanceStorage = (*StorageEndpoint)(nil)
@@ -166,9 +166,9 @@ func (se *StorageEndpoint) TryStartMaintenanceTaskAtomic(_ context.Context, task
 	return false, nil, nil
 }
 
-// TryEndMaintenanceTaskAtomic tries to end a maintenance task atomically.
+// TryDeleteMaintenanceTaskAtomic tries to delete a maintenance task atomically.
 // Returns (true, nil) if success, (false, existingTask, nil) if conflict, (false, nil, err) if error.
-func (se *StorageEndpoint) TryEndMaintenanceTaskAtomic(_ context.Context, taskType, taskID string) (bool, *MaintenanceTask, error) {
+func (se *StorageEndpoint) TryDeleteMaintenanceTaskAtomic(_ context.Context, taskType, taskID string) (bool, *MaintenanceTask, error) {
 	// Use a single atomic transaction
 	rawTxn := se.CreateRawTxn()
 

--- a/pkg/storage/endpoint/maintenance.go
+++ b/pkg/storage/endpoint/maintenance.go
@@ -26,7 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/tikv/pd/pkg/logutil"
+	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"go.uber.org/zap"
@@ -84,7 +84,7 @@ func (se *StorageEndpoint) LoadAllMaintenanceTasks(f func(k, v string)) error {
 // TryStartMaintenanceTaskAtomic tries to start a maintenance task atomically.
 // Returns (true, nil) if success, (false, existingTask, nil) if conflict, (false, nil, err) if error.
 func (se *StorageEndpoint) TryStartMaintenanceTaskAtomic(_ context.Context, task *MaintenanceTask) (bool, *MaintenanceTask, error) {
-	logger := logutil.BgLogger().With(zap.String("component", "maintenance"), zap.String("op", "TryStartMaintenanceTaskAtomic"))
+	logger := log.L().With(zap.String("component", "maintenance"), zap.String("op", "TryStartMaintenanceTaskAtomic"))
 	logger.Debug("Attempting to start maintenance task", zap.String("type", task.Type), zap.String("id", task.ID))
 	// Use a single atomic transaction with proper etcd pattern
 	rawTxn := se.CreateRawTxn()
@@ -183,7 +183,7 @@ func (se *StorageEndpoint) TryStartMaintenanceTaskAtomic(_ context.Context, task
 // TryDeleteMaintenanceTaskAtomic tries to delete a maintenance task atomically.
 // Returns (true, nil) if success, (false, existingTask, nil) if conflict, (false, nil, err) if error.
 func (se *StorageEndpoint) TryDeleteMaintenanceTaskAtomic(_ context.Context, taskType, taskID string) (bool, *MaintenanceTask, error) {
-	logger := logutil.BgLogger().With(zap.String("component", "maintenance"), zap.String("op", "TryDeleteMaintenanceTaskAtomic"))
+	logger := log.L().With(zap.String("component", "maintenance"), zap.String("op", "TryDeleteMaintenanceTaskAtomic"))
 	logger.Debug("Attempting to delete maintenance task", zap.String("type", taskType), zap.String("id", taskID))
 	// Use a single atomic transaction
 	rawTxn := se.CreateRawTxn()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -48,6 +48,7 @@ type Storage interface {
 	endpoint.ResourceGroupStorage
 	endpoint.TSOStorage
 	endpoint.KeyspaceGroupStorage
+	endpoint.MaintenanceStorage
 }
 
 // NewStorageWithMemoryBackend creates a new storage with memory backend.

--- a/pkg/utils/keypath/absolute_key_path.go
+++ b/pkg/utils/keypath/absolute_key_path.go
@@ -58,6 +58,9 @@ const (
 	regionLablePathFormat   = "/pd/%d/region_label/%s" // "/pd/{cluster_id}/region_label/{label_id}"
 	regionLabelPrefixFormat = "/pd/%d/region_label/"   // "/pd/{cluster_id}/region_label/"
 
+	// Maintenance task path format
+	maintenanceTaskPathFormat = "/pd/%d/maintenance/%s" // "/pd/{cluster_id}/maintenance/{task_type}"
+
 	// "%08d" adds extra padding to make encoded ID ordered.
 	// Encoded ID can be decoded directly with strconv.ParseUint. Width of the
 	// padded keyspaceID is 8 (decimal representation of uint24max is 16777215).

--- a/pkg/utils/keypath/maintenance.go
+++ b/pkg/utils/keypath/maintenance.go
@@ -1,0 +1,29 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keypath
+
+import (
+	"fmt"
+)
+
+// MaintenanceTaskPath returns the path to save the maintenance task with the given task type.
+func MaintenanceTaskPath(taskType string) string {
+	return fmt.Sprintf(maintenanceTaskPathFormat, ClusterID(), taskType)
+}
+
+// MaintenanceTaskPathPrefix returns the path prefix to save the maintenance tasks.
+func MaintenanceTaskPathPrefix() string {
+	return MaintenanceTaskPath("")
+}

--- a/server/apiv2/handlers/maintenance.go
+++ b/server/apiv2/handlers/maintenance.go
@@ -115,9 +115,9 @@ func GetMaintenanceTask(c *gin.Context) {
 		if k == keypath.MaintenanceTaskPath("__maintenance_lock__") {
 			return
 		}
-		var task endpoint.MaintenanceTask
-		if err := json.Unmarshal([]byte(v), &task); err == nil {
-			tasks = append(tasks, &task)
+		task := &endpoint.MaintenanceTask{} // Heap allocation
+		if err := json.Unmarshal([]byte(v), task); err == nil {
+			tasks = append(tasks, task)
 		}
 	})
 

--- a/server/apiv2/handlers/maintenance.go
+++ b/server/apiv2/handlers/maintenance.go
@@ -1,0 +1,203 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package handlers implements the maintenance endpoints for PD.
+// This implementation follows the design specified in RFC-0118:
+// https://github.com/tikv/rfcs/blob/master/text/0118-pd-maintenance-endpoints.md
+//
+// The maintenance endpoints provide a way to serialize TiKV maintenance operations
+// to prevent Raft quorum loss by ensuring only one maintenance task is active at a time.
+
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tikv/pd/pkg/maintenance"
+	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/utils/keypath"
+	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/apiv2/middlewares"
+)
+
+// RegisterMaintenance register maintenance related handlers to router paths.
+func RegisterMaintenance(r *gin.RouterGroup) {
+	router := r.Group("maintenance")
+	router.PUT("/:task_type/:task_id", StartMaintenanceTask)
+	router.GET("", GetMaintenanceTask)
+	router.GET("/:task_type", GetMaintenanceTaskByType)
+	router.DELETE("/:task_type/:task_id", EndMaintenanceTask)
+}
+
+// StartMaintenanceTask starts a maintenance task.
+// @Tags     maintenance
+// @Summary  Start a maintenance task.
+// @Param    task_type  path  string  true   "The type of maintenance task"
+// @Param    task_id    path  string  true   "Unique identifier for the task"
+// @Accept   plain
+// @Produce  json
+// @Success  200  {string}  string  "Maintenance task started successfully."
+// @Failure  409  {object}  map[string]interface{}  "Another maintenance task is already running."
+// @Failure  500  {string}  string  "PD server failed to proceed the request."
+// @Router   /maintenance/{task_type}/{task_id} [put]
+func StartMaintenanceTask(c *gin.Context) {
+	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
+	taskType := c.Param("task_type")
+	taskID := c.Param("task_id")
+
+	// Read optional description from request body
+	description := ""
+	if c.Request.Body != nil {
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+			return
+		}
+		description = string(body)
+	}
+
+	task := &endpoint.MaintenanceTask{
+		Type:           taskType,
+		ID:             taskID,
+		StartTimestamp: time.Now().Unix(),
+		Description:    description,
+	}
+
+	ok, existingTask, err := svr.GetStorage().TryStartMaintenanceTaskAtomic(c.Request.Context(), task)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{
+			"error":         "Another maintenance task is already running",
+			"existing_task": existingTask,
+		})
+		return
+	}
+
+	// Update metrics
+	maintenance.SetMaintenanceTaskInfo(taskType, taskID, 1)
+
+	c.JSON(http.StatusOK, "Maintenance task started successfully.")
+}
+
+// GetMaintenanceTask gets information about the ongoing maintenance task.
+// @Tags     maintenance
+// @Summary  Get information about the ongoing maintenance task.
+// @Produce  json
+// @Success  200  {array}  endpoint.MaintenanceTask
+// @Failure  404  {string}  string  "No maintenance task is running."
+// @Failure  500  {string}  string  "PD server failed to proceed the request."
+// @Router   /maintenance [get]
+func GetMaintenanceTask(c *gin.Context) {
+	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
+	var tasks []*endpoint.MaintenanceTask
+
+	err := svr.GetStorage().LoadAllMaintenanceTasks(func(k, v string) {
+		// Skip the lock key
+		if k == keypath.MaintenanceTaskPath("__maintenance_lock__") {
+			return
+		}
+		var task endpoint.MaintenanceTask
+		if err := json.Unmarshal([]byte(v), &task); err == nil {
+			tasks = append(tasks, &task)
+		}
+	})
+
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if len(tasks) == 0 {
+		c.AbortWithStatusJSON(http.StatusNotFound, "No maintenance task is running")
+		return
+	}
+
+	// Return all tasks to help with debugging
+	c.JSON(http.StatusOK, tasks)
+}
+
+// GetMaintenanceTaskByType gets information about the ongoing maintenance task for a specific type.
+// @Tags     maintenance
+// @Summary  Get information about the ongoing maintenance task for a specific type.
+// @Param    task_type  path  string  true  "The type of maintenance task"
+// @Produce  json
+// @Success  200  {object}  endpoint.MaintenanceTask
+// @Failure  404  {string}  string  "No maintenance task is running for this type."
+// @Failure  500  {string}  string  "PD server failed to proceed the request."
+// @Router   /maintenance/{task_type} [get]
+func GetMaintenanceTaskByType(c *gin.Context) {
+	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
+	taskType := c.Param("task_type")
+
+	task, err := svr.GetStorage().LoadMaintenanceTask(taskType)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// If no task found for this type, return 404
+	if task == nil {
+		c.AbortWithStatusJSON(http.StatusNotFound, "No maintenance task is running for this type")
+		return
+	}
+
+	c.JSON(http.StatusOK, task)
+}
+
+// EndMaintenanceTask ends a maintenance task.
+// @Tags     maintenance
+// @Summary  End a maintenance task.
+// @Param    task_type  path  string  true  "The type of maintenance task"
+// @Param    task_id    path  string  true  "Unique identifier for the task"
+// @Produce  json
+// @Success  200  {string}  string  "Maintenance task ended successfully."
+// @Failure  404  {string}  string  "No maintenance task is running for this type."
+// @Failure  409  {object}  map[string]interface{}  "Task ID does not match the current task."
+// @Failure  500  {string}  string  "PD server failed to proceed the request."
+// @Router   /maintenance/{task_type}/{task_id} [delete]
+func EndMaintenanceTask(c *gin.Context) {
+	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
+	taskType := c.Param("task_type")
+	taskID := c.Param("task_id")
+
+	ok, existingTask, err := svr.GetStorage().TryEndMaintenanceTaskAtomic(c.Request.Context(), taskType, taskID)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		if existingTask == nil {
+			c.AbortWithStatusJSON(http.StatusNotFound, "No maintenance task is running for this type")
+			return
+		}
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{
+			"error":         "Task ID does not match the current task",
+			"existing_task": existingTask,
+		})
+		return
+	}
+
+	// Update metrics
+	maintenance.SetMaintenanceTaskInfo(taskType, taskID, 0)
+
+	c.JSON(http.StatusOK, "Maintenance task ended successfully.")
+}

--- a/server/apiv2/handlers/maintenance.go
+++ b/server/apiv2/handlers/maintenance.go
@@ -112,7 +112,7 @@ func GetMaintenanceTask(c *gin.Context) {
 
 	err := svr.GetStorage().LoadAllMaintenanceTasks(func(k, v string) {
 		// Skip the lock key
-		if k == keypath.MaintenanceTaskPath("__maintenance_lock__") {
+		if k == keypath.MaintenanceTaskPath(endpoint.MaintenanceLockName) {
 			return
 		}
 		task := &endpoint.MaintenanceTask{} // Heap allocation

--- a/server/apiv2/handlers/maintenance.go
+++ b/server/apiv2/handlers/maintenance.go
@@ -42,7 +42,7 @@ func RegisterMaintenance(r *gin.RouterGroup) {
 	router.PUT("/:task_type/:task_id", StartMaintenanceTask)
 	router.GET("", GetMaintenanceTask)
 	router.GET("/:task_type", GetMaintenanceTaskByType)
-	router.DELETE("/:task_type/:task_id", EndMaintenanceTask)
+	router.DELETE("/:task_type/:task_id", DeleteMaintenanceTask)
 }
 
 // StartMaintenanceTask starts a maintenance task.
@@ -163,23 +163,23 @@ func GetMaintenanceTaskByType(c *gin.Context) {
 	c.JSON(http.StatusOK, task)
 }
 
-// EndMaintenanceTask ends a maintenance task.
+// DeleteMaintenanceTask deletes a maintenance task.
 // @Tags     maintenance
-// @Summary  End a maintenance task.
+// @Summary  Delete a maintenance task.
 // @Param    task_type  path  string  true  "The type of maintenance task"
 // @Param    task_id    path  string  true  "Unique identifier for the task"
 // @Produce  json
-// @Success  200  {string}  string  "Maintenance task ended successfully."
+// @Success  200  {string}  string  "Maintenance task deleted successfully."
 // @Failure  404  {string}  string  "No maintenance task is running for this type."
 // @Failure  409  {object}  map[string]interface{}  "Task ID does not match the current task."
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /maintenance/{task_type}/{task_id} [delete]
-func EndMaintenanceTask(c *gin.Context) {
+func DeleteMaintenanceTask(c *gin.Context) {
 	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
 	taskType := c.Param("task_type")
 	taskID := c.Param("task_id")
 
-	ok, existingTask, err := svr.GetStorage().TryEndMaintenanceTaskAtomic(c.Request.Context(), taskType, taskID)
+	ok, existingTask, err := svr.GetStorage().TryDeleteMaintenanceTaskAtomic(c.Request.Context(), taskType, taskID)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
@@ -199,5 +199,5 @@ func EndMaintenanceTask(c *gin.Context) {
 	// Update metrics
 	maintenance.SetMaintenanceTaskInfo(taskType, taskID, 0)
 
-	c.JSON(http.StatusOK, "Maintenance task ended successfully.")
+	c.JSON(http.StatusOK, "Maintenance task deleted successfully.")
 }

--- a/server/apiv2/handlers/maintenance.go
+++ b/server/apiv2/handlers/maintenance.go
@@ -40,7 +40,7 @@ import (
 func RegisterMaintenance(r *gin.RouterGroup) {
 	router := r.Group("maintenance")
 	router.PUT("/:task_type/:task_id", StartMaintenanceTask)
-	router.GET("", GetMaintenanceTask)
+	router.GET("", GetMaintenanceTasks)
 	router.GET("/:task_type", GetMaintenanceTaskByType)
 	router.DELETE("/:task_type/:task_id", DeleteMaintenanceTask)
 }
@@ -98,15 +98,15 @@ func StartMaintenanceTask(c *gin.Context) {
 	c.JSON(http.StatusOK, "Maintenance task started successfully.")
 }
 
-// GetMaintenanceTask gets information about the ongoing maintenance task.
+// GetMaintenanceTasks gets information about all ongoing maintenance tasks.
 // @Tags     maintenance
-// @Summary  Get information about the ongoing maintenance task.
+// @Summary  Get information about all ongoing maintenance tasks.
 // @Produce  json
 // @Success  200  {array}  endpoint.MaintenanceTask
 // @Failure  404  {string}  string  "No maintenance task is running."
 // @Failure  500  {string}  string  "PD server failed to proceed the request."
 // @Router   /maintenance [get]
-func GetMaintenanceTask(c *gin.Context) {
+func GetMaintenanceTasks(c *gin.Context) {
 	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
 	var tasks []*endpoint.MaintenanceTask
 

--- a/server/apiv2/router.go
+++ b/server/apiv2/router.go
@@ -58,5 +58,6 @@ func NewV2Handler(_ context.Context, svr *server.Server) (http.Handler, apiutil.
 	handlers.RegisterKeyspace(root)
 	handlers.RegisterTSOKeyspaceGroup(root)
 	handlers.RegisterMicroservice(root)
+	handlers.RegisterMaintenance(root)
 	return router, group, nil
 }

--- a/tests/server/apiv2/handlers/maintenance_test.go
+++ b/tests/server/apiv2/handlers/maintenance_test.go
@@ -88,8 +88,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPI() {
 		re.NoError(err)
 
 		type conflictErrorResp struct {
-			Error        string      `json:"error"`
-			ExistingTask interface{} `json:"existing_task"`
+			Error        string `json:"error"`
+			ExistingTask any    `json:"existing_task"`
 		}
 		var errorResp conflictErrorResp
 		err = json.Unmarshal(body, &errorResp)
@@ -122,7 +122,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPI() {
 				StartTimestamp int64  `json:"start_timestamp"`
 				Description    string `json:"description"`
 			}
-			json.NewDecoder(res.Body).Decode(&tasks)
+			err = json.NewDecoder(res.Body).Decode(&tasks)
+			re.NoError(err)
 			re.Len(tasks, 1) // Should only have one task
 			task := tasks[0]
 			re.Equal(taskType, task.Type)
@@ -145,7 +146,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPI() {
 			StartTimestamp int64  `json:"start_timestamp"`
 			Description    string `json:"description"`
 		}
-		json.NewDecoder(res.Body).Decode(&taskByType)
+		err = json.NewDecoder(res.Body).Decode(&taskByType)
+		re.NoError(err)
 		re.Equal(taskType, taskByType.Type)
 		re.Equal(taskID, taskByType.ID)
 		re.Equal(desc, taskByType.Description)
@@ -290,7 +292,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIAtomicOperations() {
 			StartTimestamp int64  `json:"start_timestamp"`
 			Description    string `json:"description"`
 		}
-		json.NewDecoder(res.Body).Decode(&tasks)
+		err = json.NewDecoder(res.Body).Decode(&tasks)
+		re.NoError(err)
 		re.Len(tasks, 1, "Should only have one task")
 		successfulTaskID := tasks[0].ID
 
@@ -434,7 +437,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIMultipleTaskTypes() {
 			StartTimestamp int64  `json:"start_timestamp"`
 			Description    string `json:"description"`
 		}
-		json.NewDecoder(res.Body).Decode(&tasks)
+		err = json.NewDecoder(res.Body).Decode(&tasks)
+		re.NoError(err)
 
 		// Verify that GetMaintenanceTasks returns both tasks in an array
 		re.Len(tasks, 2, "GetMaintenanceTasks should return both tasks in an array")
@@ -443,11 +447,12 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIMultipleTaskTypes() {
 		task1Found := false
 		task2Found := false
 		for _, task := range tasks {
-			if task.Type == taskType1 {
+			switch task.Type {
+			case taskType1:
 				re.Equal(taskID1, task.ID)
 				re.Equal(desc1, task.Description)
 				task1Found = true
-			} else if task.Type == taskType2 {
+			case taskType2:
 				re.Equal(taskID2, task.ID)
 				re.Equal(desc2, task.Description)
 				task2Found = true
@@ -469,7 +474,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIMultipleTaskTypes() {
 			StartTimestamp int64  `json:"start_timestamp"`
 			Description    string `json:"description"`
 		}
-		json.NewDecoder(res.Body).Decode(&taskByType1)
+		err = json.NewDecoder(res.Body).Decode(&taskByType1)
+		re.NoError(err)
 		re.Equal(taskType1, taskByType1.Type)
 		re.Equal(taskID1, taskByType1.ID)
 		re.Equal(desc1, taskByType1.Description)
@@ -486,7 +492,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIMultipleTaskTypes() {
 			StartTimestamp int64  `json:"start_timestamp"`
 			Description    string `json:"description"`
 		}
-		json.NewDecoder(res.Body).Decode(&taskByType2)
+		err = json.NewDecoder(res.Body).Decode(&taskByType2)
+		re.NoError(err)
 		re.Equal(taskType2, taskByType2.Type)
 		re.Equal(taskID2, taskByType2.ID)
 		re.Equal(desc2, taskByType2.Description)

--- a/tests/server/apiv2/handlers/maintenance_test.go
+++ b/tests/server/apiv2/handlers/maintenance_test.go
@@ -1,0 +1,377 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/tikv/pd/tests"
+)
+
+type maintenanceTestSuite struct {
+	suite.Suite
+	env *tests.SchedulingTestEnvironment
+}
+
+func TestMaintenanceTestSuite(t *testing.T) {
+	suite.Run(t, new(maintenanceTestSuite))
+}
+
+func (suite *maintenanceTestSuite) SetupSuite() {
+	suite.env = tests.NewSchedulingTestEnvironment(suite.T())
+}
+
+func (suite *maintenanceTestSuite) TearDownSuite() {
+	suite.env.Cleanup()
+}
+
+func (suite *maintenanceTestSuite) TestMaintenanceAPI() {
+	suite.env.RunTest(func(cluster *tests.TestCluster) {
+		re := suite.Require()
+		leader := cluster.GetLeaderServer()
+		client := tests.TestDialClient
+		baseURL := fmt.Sprintf("%s/pd/api/v2/maintenance", leader.GetAddr())
+
+		taskType := "task_tikv"
+		taskID := "task_123"
+		desc := "Upgrade rolling restart for TiKV store-1"
+
+		// 1. Start a maintenance task
+		putURL := fmt.Sprintf("%s/%s/%s", baseURL, taskType, taskID)
+		resp, err := http.NewRequest(http.MethodPut, putURL, bytes.NewBufferString(desc))
+		re.NoError(err)
+		resp.Header.Set("Content-Type", "text/plain")
+		res, err := client.Do(resp)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusOK, res.StatusCode)
+		body, _ := io.ReadAll(res.Body)
+		re.Contains(string(body), "started successfully")
+
+		// 2. Try to start another task of the same type (should fail)
+		sameTypeTaskID := "task_456"
+		sameTypeDesc := "Another TiKV upgrade task"
+		sameTypePutURL := fmt.Sprintf("%s/%s/%s", baseURL, taskType, sameTypeTaskID)
+		resp2, err := http.NewRequest(http.MethodPut, sameTypePutURL, bytes.NewBufferString(sameTypeDesc))
+		re.NoError(err)
+		resp2.Header.Set("Content-Type", "text/plain")
+		res2, err := client.Do(resp2)
+		re.NoError(err)
+		defer res2.Body.Close()
+		re.Equal(http.StatusConflict, res2.StatusCode)
+
+		// Verify the error response contains details about the existing task
+		body, err = io.ReadAll(res2.Body)
+		re.NoError(err)
+
+		type conflictErrorResp struct {
+			Error        string      `json:"error"`
+			ExistingTask interface{} `json:"existing_task"`
+		}
+		var errorResp conflictErrorResp
+		err = json.Unmarshal(body, &errorResp)
+		re.NoError(err)
+		re.Equal("Another maintenance task is already running", errorResp.Error)
+		re.NotNil(errorResp.ExistingTask)
+
+		// 3. Try to start another task of different type (should also fail due to constraint)
+		otherTaskType := "tidb_upgrade"
+		otherTaskID := "task_789"
+		otherDescription := "Upgrade TiDB server-1"
+
+		otherPutURL := fmt.Sprintf("%s/%s/%s", baseURL, otherTaskType, otherTaskID)
+		resp3, err := http.NewRequest(http.MethodPut, otherPutURL, bytes.NewBufferString(otherDescription))
+		re.NoError(err)
+		resp3.Header.Set("Content-Type", "text/plain")
+		res3, err := client.Do(resp3)
+		re.NoError(err)
+		defer res3.Body.Close()
+		re.Equal(http.StatusConflict, res3.StatusCode)
+
+		// 4. Get all maintenance tasks
+		res, err = client.Get(baseURL)
+		re.NoError(err)
+		defer res.Body.Close()
+		if res.StatusCode == http.StatusOK {
+			var tasks []struct {
+				Type           string `json:"type"`
+				ID             string `json:"id"`
+				StartTimestamp int64  `json:"start_timestamp"`
+				Description    string `json:"description"`
+			}
+			json.NewDecoder(res.Body).Decode(&tasks)
+			re.Len(tasks, 1) // Should only have one task
+			task := tasks[0]
+			re.Equal(taskType, task.Type)
+			re.Equal(taskID, task.ID)
+			re.Equal(desc, task.Description)
+			re.Less(time.Now().Unix()-task.StartTimestamp, int64(60))
+		} else {
+			suite.T().Fatalf("expected 200, got %d", res.StatusCode)
+		}
+
+		// 5. Get maintenance task by type
+		getTypeURL := fmt.Sprintf("%s/%s", baseURL, taskType)
+		res, err = client.Get(getTypeURL)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusOK, res.StatusCode)
+		var taskByType struct {
+			Type           string `json:"type"`
+			ID             string `json:"id"`
+			StartTimestamp int64  `json:"start_timestamp"`
+			Description    string `json:"description"`
+		}
+		json.NewDecoder(res.Body).Decode(&taskByType)
+		re.Equal(taskType, taskByType.Type)
+		re.Equal(taskID, taskByType.ID)
+		re.Equal(desc, taskByType.Description)
+
+		// 6. End maintenance task with wrong ID (should conflict)
+		wrongID := "wrong_id"
+		deleteURL := fmt.Sprintf("%s/%s/%s", baseURL, taskType, wrongID)
+		req, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+		re.NoError(err)
+		res, err = client.Do(req)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusConflict, res.StatusCode)
+
+		// Verify the error response contains details about the existing task
+		body, err = io.ReadAll(res.Body)
+		re.NoError(err)
+
+		var deleteErrorResp conflictErrorResp
+		err = json.Unmarshal(body, &deleteErrorResp)
+		re.NoError(err)
+		re.Equal("Task ID does not match the current task", deleteErrorResp.Error)
+		re.NotNil(deleteErrorResp.ExistingTask)
+
+		// 7. End maintenance task with correct ID
+		deleteURL = fmt.Sprintf("%s/%s/%s", baseURL, taskType, taskID)
+		req, err = http.NewRequest(http.MethodDelete, deleteURL, nil)
+		re.NoError(err)
+		res, err = client.Do(req)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusOK, res.StatusCode)
+		body, _ = io.ReadAll(res.Body)
+		re.Contains(string(body), "ended successfully")
+
+		// 8. Get maintenance task after deletion (should 404)
+		res, err = client.Get(baseURL)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusNotFound, res.StatusCode)
+
+		// 9. Now we should be able to start the same type task that was rejected before
+		resp4, err := http.NewRequest(http.MethodPut, sameTypePutURL, bytes.NewBufferString(sameTypeDesc))
+		re.NoError(err)
+		resp4.Header.Set("Content-Type", "text/plain")
+		res4, err := client.Do(resp4)
+		re.NoError(err)
+		defer res4.Body.Close()
+		re.Equal(http.StatusOK, res4.StatusCode)
+
+		// 10. Clean up the second task
+		req, err = http.NewRequest(http.MethodDelete, sameTypePutURL, nil)
+		re.NoError(err)
+		res, err = client.Do(req)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusOK, res.StatusCode)
+
+		// 11. Test GET /maintenance/{task_type} when no task exists for that type (should 404)
+		getTypeURL = fmt.Sprintf("%s/nonexistent_type", baseURL)
+		res, err = client.Get(getTypeURL)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusNotFound, res.StatusCode)
+
+		// 12. Test DELETE /maintenance/{task_type}/{task_id} when no task exists for that type (should 404)
+		deleteURL = fmt.Sprintf("%s/nonexistent_type/task_123", baseURL)
+		req, err = http.NewRequest(http.MethodDelete, deleteURL, nil)
+		re.NoError(err)
+		res, err = client.Do(req)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusNotFound, res.StatusCode)
+	})
+}
+
+func (suite *maintenanceTestSuite) TestMaintenanceAPIAtomicOperations() {
+	suite.env.RunTest(func(cluster *tests.TestCluster) {
+		re := suite.Require()
+		leader := cluster.GetLeaderServer()
+		client := tests.TestDialClient
+		baseURL := fmt.Sprintf("%s/pd/api/v2/maintenance", leader.GetAddr())
+
+		taskType := "concurrent_test"
+		numConcurrentRequests := 10
+		var wg sync.WaitGroup
+		successCount := 0
+		conflictCount := 0
+		var mu sync.Mutex
+
+		// Test concurrent start requests
+		suite.T().Log("Testing concurrent start requests...")
+		for i := range make([]struct{}, numConcurrentRequests) {
+			wg.Add(1)
+			go func(index int) {
+				defer wg.Done()
+				taskID := fmt.Sprintf("task_%d", index)
+				desc := fmt.Sprintf("Concurrent task %d", index)
+				putURL := fmt.Sprintf("%s/%s/%s", baseURL, taskType, taskID)
+
+				resp, err := http.NewRequest(http.MethodPut, putURL, bytes.NewBufferString(desc))
+				if err != nil {
+					suite.T().Logf("Failed to create request: %v", err)
+					return
+				}
+				resp.Header.Set("Content-Type", "text/plain")
+
+				res, err := client.Do(resp)
+				if err != nil {
+					suite.T().Logf("Failed to send request: %v", err)
+					return
+				}
+				defer res.Body.Close()
+
+				mu.Lock()
+				switch res.StatusCode {
+				case http.StatusOK:
+					successCount++
+					suite.T().Logf("Task %d started successfully", index)
+				case http.StatusConflict:
+					conflictCount++
+					suite.T().Logf("Task %d got conflict", index)
+				default:
+					suite.T().Logf("Task %d got unexpected status: %d", index, res.StatusCode)
+				}
+				mu.Unlock()
+			}(i)
+		}
+		wg.Wait()
+
+		// Verify atomic behavior: only one task should succeed
+		re.Equal(1, successCount, "Only one task should succeed")
+		re.Equal(numConcurrentRequests-1, conflictCount, "All other tasks should get conflict")
+
+		// Get the current task to find which one succeeded
+		res, err := client.Get(baseURL)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusOK, res.StatusCode)
+
+		var tasks []struct {
+			Type           string `json:"type"`
+			ID             string `json:"id"`
+			StartTimestamp int64  `json:"start_timestamp"`
+			Description    string `json:"description"`
+		}
+		json.NewDecoder(res.Body).Decode(&tasks)
+		re.Len(tasks, 1, "Should only have one task")
+		successfulTaskID := tasks[0].ID
+
+		// Test concurrent end requests with wrong IDs
+		suite.T().Log("Testing concurrent end requests with wrong IDs...")
+		wrongEndCount := 0
+		for i := range make([]struct{}, numConcurrentRequests) {
+			wg.Add(1)
+			go func(index int) {
+				defer wg.Done()
+				wrongTaskID := fmt.Sprintf("wrong_task_%d", index)
+				deleteURL := fmt.Sprintf("%s/%s/%s", baseURL, taskType, wrongTaskID)
+
+				req, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+				if err != nil {
+					suite.T().Logf("Failed to create delete request: %v", err)
+					return
+				}
+
+				res, err := client.Do(req)
+				if err != nil {
+					suite.T().Logf("Failed to send delete request: %v", err)
+					return
+				}
+				defer res.Body.Close()
+
+				mu.Lock()
+				if res.StatusCode == http.StatusConflict {
+					wrongEndCount++
+				}
+				mu.Unlock()
+			}(i)
+		}
+		wg.Wait()
+
+		re.Equal(numConcurrentRequests, wrongEndCount, "All wrong end requests should get conflict")
+
+		// Test concurrent end requests with correct ID
+		suite.T().Log("Testing concurrent end requests with correct ID...")
+		correctEndCount := 0
+		for i := range make([]struct{}, numConcurrentRequests) {
+			wg.Add(1)
+			go func(index int) {
+				defer wg.Done()
+				deleteURL := fmt.Sprintf("%s/%s/%s", baseURL, taskType, successfulTaskID)
+
+				req, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+				if err != nil {
+					suite.T().Logf("Failed to create delete request: %v", err)
+					return
+				}
+
+				res, err := client.Do(req)
+				if err != nil {
+					suite.T().Logf("Failed to send delete request: %v", err)
+					return
+				}
+				defer res.Body.Close()
+
+				mu.Lock()
+				switch res.StatusCode {
+				case http.StatusOK:
+					correctEndCount++
+					suite.T().Logf("Task ended successfully on attempt %d", index)
+				case http.StatusNotFound:
+					suite.T().Logf("Task already ended on attempt %d", index)
+				default:
+					suite.T().Logf("Unexpected status on attempt %d: %d", index, res.StatusCode)
+				}
+				mu.Unlock()
+			}(i)
+		}
+		wg.Wait()
+
+		// Verify that exactly one end request succeeded
+		re.Equal(1, correctEndCount, "Only one end request should succeed")
+
+		// Verify no tasks are running
+		res, err = client.Get(baseURL)
+		re.NoError(err)
+		defer res.Body.Close()
+		re.Equal(http.StatusNotFound, res.StatusCode, "No tasks should be running after deletion")
+	})
+}

--- a/tests/server/apiv2/handlers/maintenance_test.go
+++ b/tests/server/apiv2/handlers/maintenance_test.go
@@ -383,10 +383,10 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIMultipleTaskTypes() {
 		client := tests.TestDialClient
 		baseURL := fmt.Sprintf("%s/pd/api/v2/maintenance", leader.GetAddr())
 
-		// NOTE: This test verifies that GetMaintenanceTask can correctly return multiple task types
+		// NOTE: This test verifies that GetMaintenanceTasks can correctly return multiple task types
 		// in an array format. According to the design specification (RFC-0118), only one maintenance
 		// task should be active at a time globally due to the maintenance lock constraint. However,
-		// we test this scenario to ensure the GetMaintenanceTask endpoint can handle multiple tasks
+		// we test this scenario to ensure the GetMaintenanceTasks endpoint can handle multiple tasks
 		// correctly if they were to exist simultaneously (e.g., due to a bug or manual intervention).
 
 		// Directly create multiple maintenance tasks in storage to simulate the scenario
@@ -422,7 +422,7 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIMultipleTaskTypes() {
 		err = storage.Save(keypath.MaintenanceTaskPath(taskType2), string(task2Data))
 		re.NoError(err)
 
-		// Test GetMaintenanceTask - should return both tasks in an array
+		// Test GetMaintenanceTasks - should return both tasks in an array
 		res, err := client.Get(baseURL)
 		re.NoError(err)
 		defer res.Body.Close()
@@ -436,8 +436,8 @@ func (suite *maintenanceTestSuite) TestMaintenanceAPIMultipleTaskTypes() {
 		}
 		json.NewDecoder(res.Body).Decode(&tasks)
 
-		// Verify that GetMaintenanceTask returns both tasks in an array
-		re.Len(tasks, 2, "GetMaintenanceTask should return both tasks in an array")
+		// Verify that GetMaintenanceTasks returns both tasks in an array
+		re.Len(tasks, 2, "GetMaintenanceTasks should return both tasks in an array")
 
 		// Verify both tasks are present with correct data
 		task1Found := false

--- a/tools/pd-ctl/pdctl/command/maintenance_command.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command.go
@@ -129,7 +129,7 @@ func newMaintenanceShowCommand() *cobra.Command {
 func newMaintenanceDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <task_type> <task_id>",
-		Short: "End a maintenance task",
+		Short: "Delete a maintenance task",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			taskType := args[0]
@@ -139,15 +139,15 @@ func newMaintenanceDeleteCommand() *cobra.Command {
 			resp, err := doRequest(cmd, path, http.MethodDelete, http.Header{})
 			if err != nil {
 				if strings.Contains(err.Error(), "[404]") {
-					cmd.Printf("Failed to end maintenance task: No maintenance task is running for type %s\n", taskType)
+					cmd.Printf("Failed to delete maintenance task: No maintenance task is running for type %s\n", taskType)
 				} else if strings.Contains(err.Error(), "[409]") {
-					cmd.Printf("Failed to end maintenance task: Task ID does not match the current task.\n")
+					cmd.Printf("Failed to delete maintenance task: Task ID does not match the current task.\n")
 					// Try to parse the existing task from the error response
 					if strings.Contains(err.Error(), "existing_task") {
 						cmd.Printf("Current task details: %s\n", extractExistingTaskInfo(err.Error()))
 					}
 				} else {
-					cmd.Printf("Failed to end maintenance task: %s\n", err)
+					cmd.Printf("Failed to delete maintenance task: %s\n", err)
 				}
 				return
 			}

--- a/tools/pd-ctl/pdctl/command/maintenance_command.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command.go
@@ -29,6 +29,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const maintenancePrefixURI = "pd/api/v2/maintenance"
+
 // NewMaintenanceCommand returns the maintenance subcommand for pd-ctl
 func NewMaintenanceCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -51,7 +53,7 @@ func newMaintenanceSetCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			taskType := args[0]
 			taskID := args[1]
-			path := fmt.Sprintf("pd/api/v2/maintenance/%s/%s", taskType, taskID)
+			path := fmt.Sprintf(maintenancePrefixURI+"/%s/%s", taskType, taskID)
 
 			var resp string
 			var err error
@@ -83,9 +85,9 @@ func newMaintenanceShowCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			var path string
 			if len(args) == 0 {
-				path = "pd/api/v2/maintenance"
+				path = maintenancePrefixURI
 			} else {
-				path = fmt.Sprintf("pd/api/v2/maintenance/%s", args[0])
+				path = fmt.Sprintf(maintenancePrefixURI+"/%s", args[0])
 			}
 
 			resp, err := doRequest(cmd, path, http.MethodGet, http.Header{})
@@ -109,7 +111,7 @@ func newMaintenanceDeleteCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			taskType := args[0]
 			taskID := args[1]
-			path := fmt.Sprintf("pd/api/v2/maintenance/%s/%s", taskType, taskID)
+			path := fmt.Sprintf(maintenancePrefixURI+"/%s/%s", taskType, taskID)
 
 			resp, err := doRequest(cmd, path, http.MethodDelete, http.Header{})
 			if err != nil {

--- a/tools/pd-ctl/pdctl/command/maintenance_command.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command.go
@@ -1,0 +1,186 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package command provides CLI commands for maintenance task management.
+// This implementation follows the design specified in RFC-0118:
+// https://github.com/tikv/rfcs/blob/master/text/0118-pd-maintenance-endpoints.md
+//
+// The CLI commands provide a user-friendly interface to manage maintenance tasks
+// that serialize TiKV maintenance operations to prevent Raft quorum loss.
+
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// NewMaintenanceCommand returns the maintenance subcommand for pd-ctl
+func NewMaintenanceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "maintenance",
+		Short: "Manage cluster maintenance tasks",
+	}
+
+	cmd.AddCommand(newMaintenanceSetCommand())
+	cmd.AddCommand(newMaintenanceShowCommand())
+	cmd.AddCommand(newMaintenanceDeleteCommand())
+	return cmd
+}
+
+func newMaintenanceSetCommand() *cobra.Command {
+	var desc string
+	cmd := &cobra.Command{
+		Use:   "set <task_type> <task_id>",
+		Short: "Start a maintenance task",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			taskType := args[0]
+			taskID := args[1]
+			path := fmt.Sprintf("pd/api/v2/maintenance/%s/%s", taskType, taskID)
+
+			var resp string
+			var err error
+			if desc != "" {
+				resp, err = doRequest(cmd, path, http.MethodPut, http.Header{"Content-Type": {"text/plain"}}, WithBody(strings.NewReader(desc)))
+			} else {
+				resp, err = doRequest(cmd, path, http.MethodPut, http.Header{})
+			}
+
+			if err != nil {
+				// Try to extract existing task info from error response
+				if strings.Contains(err.Error(), "[409]") {
+					cmd.Printf("Failed to start maintenance task: Another maintenance task is already running.\n")
+					// Try to parse the existing task from the error response
+					if strings.Contains(err.Error(), "existing_task") {
+						cmd.Printf("Existing task details: %s\n", extractExistingTaskInfo(err.Error()))
+					}
+				} else {
+					cmd.Printf("Failed to start maintenance task: %s\n", err)
+				}
+				return
+			}
+
+			// Success case (200 OK)
+			cmd.Println(resp)
+		},
+	}
+	cmd.Flags().StringVar(&desc, "desc", "", "Description for the maintenance task")
+	return cmd
+}
+
+func newMaintenanceShowCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show [task_type]",
+		Short: "Show maintenance task(s)",
+		Long:  "Show maintenance task(s). If no task_type is provided, shows all current maintenance tasks.",
+		Args:  cobra.RangeArgs(0, 1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var path string
+			if len(args) == 0 {
+				path = "pd/api/v2/maintenance"
+			} else {
+				path = fmt.Sprintf("pd/api/v2/maintenance/%s", args[0])
+			}
+
+			resp, err := doRequest(cmd, path, http.MethodGet, http.Header{})
+			if err != nil {
+				if strings.Contains(err.Error(), "[404]") {
+					if len(args) == 0 {
+						cmd.Println("No maintenance tasks are currently running.")
+					} else {
+						cmd.Printf("No maintenance task found for type: %s\n", args[0])
+					}
+				} else {
+					cmd.Printf("Failed to get maintenance task: %s\n", err)
+				}
+				return
+			}
+
+			// Try to parse as JSON and pretty print
+			var out interface{}
+			if err := json.Unmarshal([]byte(resp), &out); err == nil {
+				jsonPrint(cmd, out)
+				return
+			}
+
+			// Fallback: print raw response
+			cmd.Println(resp)
+		},
+	}
+	return cmd
+}
+
+func newMaintenanceDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <task_type> <task_id>",
+		Short: "End a maintenance task",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			taskType := args[0]
+			taskID := args[1]
+			path := fmt.Sprintf("pd/api/v2/maintenance/%s/%s", taskType, taskID)
+
+			resp, err := doRequest(cmd, path, http.MethodDelete, http.Header{})
+			if err != nil {
+				if strings.Contains(err.Error(), "[404]") {
+					cmd.Printf("Failed to end maintenance task: No maintenance task is running for type %s\n", taskType)
+				} else if strings.Contains(err.Error(), "[409]") {
+					cmd.Printf("Failed to end maintenance task: Task ID does not match the current task.\n")
+					// Try to parse the existing task from the error response
+					if strings.Contains(err.Error(), "existing_task") {
+						cmd.Printf("Current task details: %s\n", extractExistingTaskInfo(err.Error()))
+					}
+				} else {
+					cmd.Printf("Failed to end maintenance task: %s\n", err)
+				}
+				return
+			}
+			cmd.Println(resp)
+		},
+	}
+	return cmd
+}
+
+// extractExistingTaskInfo tries to extract existing task information from error response
+func extractExistingTaskInfo(errorMsg string) string {
+	// Look for JSON content in the error message
+	start := strings.Index(errorMsg, "{")
+	if start == -1 {
+		return "Unable to parse existing task details"
+	}
+
+	end := strings.LastIndex(errorMsg, "}")
+	if end == -1 || end <= start {
+		return "Unable to parse existing task details"
+	}
+
+	jsonStr := errorMsg[start : end+1]
+	var response map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &response); err != nil {
+		return "Unable to parse existing task details"
+	}
+
+	if existingTask, ok := response["existing_task"]; ok {
+		if taskBytes, err := json.MarshalIndent(existingTask, "", "  "); err == nil {
+			return string(taskBytes)
+		}
+	}
+
+	return "No existing task details available"
+}

--- a/tools/pd-ctl/pdctl/command/maintenance_command_test.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command_test.go
@@ -82,7 +82,7 @@ func TestMaintenanceDeleteCommand_Success(t *testing.T) {
 	re := require.New(t)
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader("Maintenance task ended successfully.")),
+		Body:       io.NopCloser(strings.NewReader("Maintenance task deleted successfully.")),
 	}
 	oldClient := dialClient
 	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
@@ -96,7 +96,7 @@ func TestMaintenanceDeleteCommand_Success(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.Execute()
 	result := out.String()
-	re.Contains(result, "Maintenance task ended successfully")
+	re.Contains(result, "Maintenance task deleted successfully")
 }
 
 func TestMaintenanceDeleteCommand_Error(t *testing.T) {
@@ -113,7 +113,7 @@ func TestMaintenanceDeleteCommand_Error(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.Execute()
 	result := out.String()
-	re.Contains(result, "Failed to end maintenance task:")
+	re.Contains(result, "Failed to delete maintenance task:")
 	re.Contains(result, "mock error")
 }
 
@@ -375,7 +375,7 @@ func TestMaintenanceDeleteCommand_NotFound(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.Execute()
 	result := out.String()
-	re.Contains(result, "Failed to end maintenance task: No maintenance task is running for type nonexistent")
+	re.Contains(result, "Failed to delete maintenance task: No maintenance task is running for type nonexistent")
 }
 
 func TestMaintenanceDeleteCommand_Conflict(t *testing.T) {
@@ -398,7 +398,7 @@ func TestMaintenanceDeleteCommand_Conflict(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.Execute()
 	result := out.String()
-	re.Contains(result, "Failed to end maintenance task: Task ID does not match the current task")
+	re.Contains(result, "Failed to delete maintenance task: Task ID does not match the current task")
 	re.Contains(result, "Current task details:")
 	re.Contains(result, "current_task")
 	re.Contains(result, "current maintenance task")

--- a/tools/pd-ctl/pdctl/command/maintenance_command_test.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command_test.go
@@ -33,7 +33,7 @@ type mockRoundTripper struct {
 	err  error
 }
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return m.resp, m.err
 }
 
@@ -290,7 +290,7 @@ func TestMaintenanceShowCommand_NetworkError(t *testing.T) {
 // errorReader implements io.Reader and always returns an error
 type errorReader struct{}
 
-func (e *errorReader) Read(p []byte) (n int, err error) {
+func (_ *errorReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("read error")
 }
 

--- a/tools/pd-ctl/pdctl/command/maintenance_command_test.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command_test.go
@@ -1,0 +1,405 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockRoundTripper implements http.RoundTripper for testing
+// It returns a canned response for any request
+
+type mockRoundTripper struct {
+	resp *http.Response
+	err  error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.resp, m.err
+}
+
+func TestMaintenanceSetCommand_Success(t *testing.T) {
+	re := require.New(t)
+	// Mock response
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("Maintenance task started successfully.")),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceSetCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"tikv", "task1", "--desc=desc"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Maintenance task started successfully")
+}
+
+func TestMaintenanceSetCommand_Error(t *testing.T) {
+	re := require.New(t)
+	// Mock error
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{err: errors.New("mock error")}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceSetCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"tikv", "task1"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to start maintenance task:")
+	re.Contains(result, "mock error")
+}
+
+func TestMaintenanceDeleteCommand_Success(t *testing.T) {
+	re := require.New(t)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("Maintenance task ended successfully.")),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceDeleteCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"tikv", "task1"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Maintenance task ended successfully")
+}
+
+func TestMaintenanceDeleteCommand_Error(t *testing.T) {
+	re := require.New(t)
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{err: errors.New("mock error")}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceDeleteCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"tikv", "task1"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to end maintenance task:")
+	re.Contains(result, "mock error")
+}
+
+func TestMaintenanceShowCommand_Success(t *testing.T) {
+	re := require.New(t)
+	// Mock response for success case
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"type":"tikv","id":"task1","start_timestamp":1234567890,"description":"rolling restart for TiKV store-1"}`)),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+
+	// Check pretty print formatting (should have proper indentation)
+	re.Contains(result, "  \"type\"")
+	re.Contains(result, "  \"id\"")
+	re.Contains(result, "  \"start_timestamp\"")
+	re.Contains(result, "  \"description\"")
+	re.Contains(result, "tikv")
+	re.Contains(result, "task1")
+	re.Contains(result, "1234567890")
+	re.Contains(result, "rolling restart for TiKV store-1")
+}
+
+func TestMaintenanceShowCommand_Error(t *testing.T) {
+	re := require.New(t)
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{err: errors.New("mock error")}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to get maintenance task:")
+	re.Contains(result, "mock error")
+}
+
+func TestMaintenanceShowCommand_AllTasks(t *testing.T) {
+	re := require.New(t)
+	// Mock response for all tasks (single task response since only one can run at a time)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"type":"tikv","id":"task1","start_timestamp":1234567890,"description":"rolling restart for TiKV store-1"}`)),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "tikv")
+	re.Contains(result, "task1")
+	re.Contains(result, "rolling restart for TiKV store-1")
+	re.Contains(result, "1234567890")
+}
+
+func TestMaintenanceShowCommand_SpecificTaskType(t *testing.T) {
+	re := require.New(t)
+	// Mock response for specific task type
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"type":"tikv","id":"task1","start_timestamp":1234567890,"description":"specific task"}`)),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"tikv"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "tikv")
+	re.Contains(result, "task1")
+	re.Contains(result, "specific task")
+}
+
+func TestMaintenanceShowCommand_NotFound_AllTasks(t *testing.T) {
+	re := require.New(t)
+	// Mock 404 response for all tasks
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("No maintenance task is running")),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "No maintenance tasks are currently running")
+}
+
+func TestMaintenanceShowCommand_NotFound_SpecificType(t *testing.T) {
+	re := require.New(t)
+	// Mock 404 response for specific task type
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("No maintenance task is running for this type")),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"nonexistent"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "No maintenance task found for type: nonexistent")
+}
+
+func TestMaintenanceShowCommand_InvalidJSON(t *testing.T) {
+	re := require.New(t)
+	// Mock response with invalid JSON
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("invalid json")),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "invalid json")
+}
+
+func TestMaintenanceShowCommand_NetworkError(t *testing.T) {
+	re := require.New(t)
+	// Mock HTTP client that fails to make the request due to network issues
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{err: errors.New("connection refused")}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to get maintenance task:")
+	re.Contains(result, "connection refused")
+}
+
+// errorReader implements io.Reader that always returns an error
+type errorReader struct{}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("read error")
+}
+
+func TestMaintenanceShowCommand_ReadBodyError(t *testing.T) {
+	re := require.New(t)
+	// Mock response with a body that fails to read
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(&errorReader{}),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceShowCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to get maintenance task:")
+	re.Contains(result, "read error")
+}
+
+func TestMaintenanceSetCommand_Conflict(t *testing.T) {
+	re := require.New(t)
+	// Mock 409 conflict response with existing task
+	conflictResp := `{"error":"Another maintenance task is already running","existing_task":{"type":"tikv","id":"existing_task","start_timestamp":1234567890,"description":"existing maintenance"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusConflict,
+		Body:       io.NopCloser(strings.NewReader(conflictResp)),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceSetCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"tikv", "new_task"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to start maintenance task: Another maintenance task is already running")
+	re.Contains(result, "Existing task details:")
+	re.Contains(result, "existing_task")
+	re.Contains(result, "existing maintenance")
+}
+
+func TestMaintenanceDeleteCommand_NotFound(t *testing.T) {
+	re := require.New(t)
+	// Mock 404 response
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("No maintenance task is running for this type")),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceDeleteCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"nonexistent", "task1"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to end maintenance task: No maintenance task is running for type nonexistent")
+}
+
+func TestMaintenanceDeleteCommand_Conflict(t *testing.T) {
+	re := require.New(t)
+	// Mock 409 conflict response with existing task details
+	conflictResp := `{"error":"Task ID does not match the current task","existing_task":{"type":"tikv","id":"current_task","start_timestamp":1234567890,"description":"current maintenance task"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusConflict,
+		Body:       io.NopCloser(strings.NewReader(conflictResp)),
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: &mockRoundTripper{resp: resp}}
+	defer func() { dialClient = oldClient }()
+
+	cmd := newMaintenanceDeleteCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"tikv", "wrong_task_id"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.Execute()
+	result := out.String()
+	re.Contains(result, "Failed to end maintenance task: Task ID does not match the current task")
+	re.Contains(result, "Current task details:")
+	re.Contains(result, "current_task")
+	re.Contains(result, "current maintenance task")
+}

--- a/tools/pd-ctl/pdctl/command/maintenance_command_test.go
+++ b/tools/pd-ctl/pdctl/command/maintenance_command_test.go
@@ -290,7 +290,7 @@ func TestMaintenanceShowCommand_NetworkError(t *testing.T) {
 // errorReader implements io.Reader and always returns an error
 type errorReader struct{}
 
-func (_ *errorReader) Read(p []byte) (n int, err error) {
+func (*errorReader) Read(_ []byte) (n int, err error) {
 	return 0, errors.New("read error")
 }
 

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -74,6 +74,7 @@ func GetRootCmd() *cobra.Command {
 		command.NewKeyspaceGroupCommand(),
 		command.NewKeyspaceCommand(),
 		command.NewResourceManagerCommand(),
+		command.NewMaintenanceCommand(),
 	)
 
 	return rootCmd


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/9477
### What is changed and how does it work?
  This commit implements the maintenance endpoints feature as specified in [RFC-0118](https://github.com/tikv/rfcs/blob/master/text/0118-pd-maintenance-endpoints.md)
  to prevent Raft quorum loss during TiKV maintenance operations.

  Key features:
  - Add atomic maintenance task storage operations using etcd transactions
  - Implement four HTTP endpoints: PUT, GET, GET by type, DELETE
  - Add pdctl CLI commands for maintenance task management
  - Integrate Prometheus metrics for monitoring
  - Ensure single maintenance task constraint with proper conflict handling<!--


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- [x] Unit test

- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- [x]  Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
