### PR TITLE
Unsafe Recovery: Add tombstoned tiflash learners into DemoteFailedVoters

### DIFF
--- a/pkg/unsaferecovery/unsafe_recovery_controller.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller.go
@@ -134,6 +134,12 @@ type Controller struct {
 	storePlanExpires   map[uint64]time.Time
 	storeRecoveryPlans map[uint64]*pdpb.RecoveryPlan
 
+	// Orphaned peers are the peers that exist in the forced leader but not in the target stores' reports
+	// they are expected to exist when some of the peers were destoryed by TombstoneTiFlashLearner phase.
+	// we need to explicitly remove them in DemoteFailedVoter phase, in case there is only one candidate store
+	// for this peer, and PD is not able to remove it through the down peer removal mechanism.
+	orphanedPeers map[uint64][]*metapb.Peer
+
 	// accumulated output for the whole recovery process
 	output []StageOutput
 	// exposed to the outside for testing
@@ -172,6 +178,7 @@ func (u *Controller) reset() {
 	u.AffectedTableIDs = make(map[int64]struct{}, 0)
 	u.affectedMetaRegions = make(map[uint64]struct{}, 0)
 	u.newlyCreatedRegions = make(map[uint64]struct{}, 0)
+	u.orphanedPeers = make(map[uint64][]*metapb.Peer)
 	u.err = nil
 }
 
@@ -576,6 +583,7 @@ func (u *Controller) changeStage(stage stage) {
 	for k := range u.storeReports {
 		u.storeReports[k] = nil
 	}
+	u.orphanedPeers = map[uint64][]*metapb.Peer{}
 	u.numStoresReported = 0
 	u.step += 1
 }
@@ -739,10 +747,20 @@ func (u *Controller) getFailedPeers(region *metapb.Region) []*metapb.Peer {
 
 	var failedPeers []*metapb.Peer
 	for _, peer := range region.Peers {
-		if u.isFailed(peer) {
+		exists := func(peers []*metapb.Peer, peer *metapb.Peer) bool {
+			for _, p := range peers {
+				if p.GetId() == peer.GetId() || p.GetStoreId() == peer.GetStoreId() {
+					return true
+				}
+			}
+			return false
+		}
+
+		if u.isFailed(peer) || exists(u.orphanedPeers[region.GetId()], peer) {
 			failedPeers = append(failedPeers, peer)
 		}
 	}
+
 	return failedPeers
 }
 
@@ -945,6 +963,23 @@ func (u *Controller) buildUpFromReports() (*regionTree, map[uint64][]*regionItem
 			continue
 		}
 		newestPeerReports = append(newestPeerReports, latest)
+
+		// find the orphaned peers, i.e. the peers exist in the forced leader but not in the target stores' reports
+		// this is expected when some of the peers were destoryed by TombstoneTiFlashLearner phase.
+		exists := func(peers []*regionItem, peer *metapb.Peer) bool {
+			for _, p := range peers {
+				if p.storeID == peer.StoreId {
+					return true
+				}
+			}
+			return false
+		}
+
+		for _, peer := range latest.report.RegionState.GetRegion().Peers {
+			if !exists(peers, peer) {
+				u.orphanedPeers[latest.region().GetId()] = append(u.orphanedPeers[latest.region().GetId()], peer)
+			}
+		}
 	}
 
 	// sort in descending order of epoch

--- a/pkg/unsaferecovery/unsafe_recovery_controller_test.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller_test.go
@@ -1867,6 +1867,132 @@ func getTestDeployPath(storeID uint64) string {
 	return fmt.Sprintf("test/store%d", storeID)
 }
 
+func TestTiFlashOrphanedPeerDemote(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	coordinator := schedule.NewCoordinator(ctx, cluster, hbstream.NewTestHeartbeatStreams(ctx, cluster, true))
+	coordinator.Run()
+	for _, store := range newTestStores(4, "6.0.0") {
+		if store.GetID() == 3 {
+			store.GetMeta().Labels = []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}}
+		}
+		cluster.PutStore(store)
+	}
+	recoveryController := NewController(cluster)
+	// Mark stores 2 and 4 as failed (2 voters down)
+	re.NoError(recoveryController.RemoveFailedStores(map[uint64]struct{}{
+		2: {},
+		4: {},
+	}, 60, false))
+
+	reports := map[uint64]*pdpb.StoreReport{
+		// Store 1: voter with older data than TiFlash learner (last index 10) - only live voter
+		1: {PeerReports: []*pdpb.PeerReport{
+			{
+				RaftState: &raft_serverpb.RaftLocalState{LastIndex: 10, HardState: &eraftpb.HardState{Term: 1, Commit: 10}},
+				RegionState: &raft_serverpb.RegionLocalState{
+					Region: &metapb.Region{
+						Id:          1001,
+						StartKey:    []byte(""),
+						EndKey:      []byte("x"),
+						RegionEpoch: &metapb.RegionEpoch{ConfVer: 7, Version: 10},
+						Peers: []*metapb.Peer{
+							{Id: 11, StoreId: 1, Role: metapb.PeerRole_Voter},
+							{Id: 12, StoreId: 2, Role: metapb.PeerRole_Voter},
+							{Id: 13, StoreId: 3, Role: metapb.PeerRole_Learner},
+							{Id: 14, StoreId: 4, Role: metapb.PeerRole_Voter},
+						}}}},
+		}},
+		// Store 3: TiFlash learner with newer data (last index 12)
+		3: {PeerReports: []*pdpb.PeerReport{
+			{
+				RaftState: &raft_serverpb.RaftLocalState{LastIndex: 12, HardState: &eraftpb.HardState{Term: 1, Commit: 12}},
+				RegionState: &raft_serverpb.RegionLocalState{
+					Region: &metapb.Region{
+						Id:          1001,
+						StartKey:    []byte(""),
+						EndKey:      []byte("x"),
+						RegionEpoch: &metapb.RegionEpoch{ConfVer: 7, Version: 10},
+						Peers: []*metapb.Peer{
+							{Id: 11, StoreId: 1, Role: metapb.PeerRole_Voter},
+							{Id: 12, StoreId: 2, Role: metapb.PeerRole_Voter},
+							{Id: 13, StoreId: 3, Role: metapb.PeerRole_Learner},
+							{Id: 14, StoreId: 4, Role: metapb.PeerRole_Voter},
+						}}}},
+		}},
+	}
+
+	retry := 0
+	forcedLeaderFound := false
+	tombstoneFound := false
+	demoteStageFound := false
+
+	for {
+		for storeID, report := range reports {
+			req := newStoreHeartbeat(storeID, report)
+			req.StoreReport = report
+			resp := &pdpb.StoreHeartbeatResponse{}
+			recoveryController.HandleStoreHeartbeat(req, resp)
+
+			plan := resp.GetRecoveryPlan()
+			if plan != nil {
+				stage := recoveryController.GetStage()
+				
+				if stage == TombstoneTiFlashLearner && len(plan.GetTombstones()) > 0 {
+					tombstoneFound = true
+					re.Contains(plan.GetTombstones(), uint64(1001))
+					re.Equal(uint64(3), storeID)
+				}
+				
+				if stage == ForceLeader && plan.GetForceLeader() != nil && len(plan.GetForceLeader().GetEnterForceLeaders()) > 0 {
+					forcedLeaderFound = true
+					re.Contains(plan.GetForceLeader().GetEnterForceLeaders(), uint64(1001))
+					// Only store 1 should get force leader (the only live voter)
+					re.Equal(uint64(1), storeID)
+				}
+				
+				if stage == DemoteFailedVoter && len(plan.GetDemotes()) > 0 {
+					demoteStageFound = true
+					found := false
+					for _, demote := range plan.GetDemotes() {
+						if demote.GetRegionId() == 1001 {
+							found = true
+							re.NotEmpty(demote.GetFailedVoters())
+							// Should include failed voters (stores 2, 4) and orphaned TiFlash peer (store 3)
+							failedStoreIds := make(map[uint64]bool)
+							for _, peer := range demote.GetFailedVoters() {
+								failedStoreIds[peer.GetStoreId()] = true
+							}
+							re.True(failedStoreIds[2], "Failed voter store 2 should be demoted")
+							re.True(failedStoreIds[4], "Failed voter store 4 should be demoted") 
+							re.True(failedStoreIds[3], "Orphaned TiFlash peer store 3 should be demoted")
+						}
+					}
+					re.True(found)
+				}
+			}
+			
+			applyRecoveryPlan(re, storeID, reports, resp)
+		}
+		if recoveryController.GetStage() == Finished {
+			break
+		} else if recoveryController.GetStage() == Failed {
+			panic("Failed to recovery")
+		} else if retry >= 15 {
+			panic("retry timeout")
+		}
+		retry += 1
+	}
+
+	re.True(tombstoneFound, "TiFlash learner should be tombstoned")
+	re.True(forcedLeaderFound, "Another peer should be forced as leader")
+	re.True(demoteStageFound, "Demote stage should include the orphaned TiFlash peer")
+}
+
 func TestSelectLeader(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
