### PR TITLE
test: stabilize the TSO client tests

### DIFF
--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -517,7 +517,8 @@ func TestTSONotLeaderWhenRebaseErr(t *testing.T) {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/rebaseErr", "return(true)"))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/skipRetry", "return(true)"))
 	// Resign the leader to trigger the rebase error.
-	pdLeader.ResignLeaderWithRetry(re)
+	err = pdLeader.ResignLeaderWithRetry()
+	re.NoError(err)
 	// Trying to get TSO should fail with "not leader" error.
 	_, _, err = pdClient.GetTS(ctx)
 	re.ErrorContains(err, "not leader")
@@ -569,7 +570,8 @@ func TestMixedTSODeployment(t *testing.T) {
 	for range 2 {
 		n := r.Intn(2) + 1
 		time.Sleep(time.Duration(n) * time.Second)
-		leaderServer.ResignLeaderWithRetry(re)
+		err = leaderServer.ResignLeaderWithRetry()
+		re.NoError(err)
 		leaderServer = cluster.GetServer(cluster.WaitLeader())
 		re.NotNil(leaderServer)
 	}
@@ -708,7 +710,8 @@ func TestRetryGetTSNotLeader(t *testing.T) {
 
 	for range 5 {
 		time.Sleep(time.Second)
-		pdLeader.ResignLeaderWithRetry(re)
+		err = pdLeader.ResignLeaderWithRetry()
+		re.NoError(err)
 		leaderName = pdCluster.WaitLeader()
 		re.NotEmpty(leaderName)
 		pdLeader = pdCluster.GetServer(leaderName)

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -302,7 +302,8 @@ func TestMoveLeader(t *testing.T) {
 	re.NotNil(originalLeaderServer)
 
 	// First, resign the original leader.
-	originalLeaderServer.ResignLeaderWithRetry(re)
+	err = originalLeaderServer.ResignLeaderWithRetry()
+	re.NoError(err)
 	newLeader := cluster.WaitLeader()
 	re.NotEmpty(newLeader)
 	re.NotEqual(originalLeader, newLeader)

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -117,7 +117,8 @@ func TestDelaySyncTimestamp(t *testing.T) {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/delaySyncTimestamp", `return(true)`))
 
 	// Make the old leader resign and wait for the new leader to get a lease
-	leaderServer.ResignLeaderWithRetry(re)
+	err = leaderServer.ResignLeaderWithRetry()
+	re.NoError(err)
 	re.True(nextLeaderServer.WaitLeader())
 
 	ctx = grpcutil.BuildForwardContext(ctx, nextLeaderServer.GetAddr())


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #9412, close #9551.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Stabilize TSO client tests by implementing resilient leader resignation with retries and enhancing the tests to accommodate leader change scenarios.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
