### PR TITLE
feat(resourcemanager): invalidate the burstable groups by overriding to service limit

### DIFF
--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -784,7 +784,7 @@ func TestConciliateFillRate(t *testing.T) {
 			// Priority 2: basic 30+40=70, burst 0+5=5, total 75 < service limit 100, so gets full allocation (remaining: 25)
 			// Priority 1: basic 20+30=50, burst 2+0=2, total 52 > service limit 25, so gets basic demand proportionally
 			expectedOverrideFillRateList:   []float64{-1, -1, 10, 15},
-			expectedOverrideBurstLimitList: []int64{-1, -1, 10, 15},
+			expectedOverrideBurstLimitList: []int64{-1, 100, 10, 15},
 		},
 		{
 			name:                  "Unlimited burst limit with service limit constraint",
@@ -796,7 +796,7 @@ func TestConciliateFillRate(t *testing.T) {
 			// Priority 2: demand 30, gets full allocation (remaining: 70)
 			// Priority 1: demand 110 > remaining 70, basic demand 70 = remaining 70, proportional allocation: 70*(30/70)=30, 70*(40/70)=40
 			expectedOverrideFillRateList:   []float64{-1, 30, 40},
-			expectedOverrideBurstLimitList: []int64{-1, 30, 40},
+			expectedOverrideBurstLimitList: []int64{100, 30, 40},
 		},
 		{
 			name:                  "Partial burst demand satisfied with unlimited burst limit",

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -239,15 +239,12 @@ func (m *Manager) loadKeyspaceResourceGroups() error {
 	}); err != nil {
 		return err
 	}
-	// Load service limits from the storage.
-	if err := m.storage.LoadServiceLimits(func(keyspaceID uint32, serviceLimit float64) {
-		m.getOrCreateKeyspaceResourceGroupManager(keyspaceID, false).setServiceLimit(serviceLimit)
-	}); err != nil {
-		return err
-	}
 	// Initialize the reserved keyspace resource group manager and default resource groups.
 	m.initReserved()
-	return nil
+	// Load service limits from the storage after all resource groups are loaded.
+	return m.storage.LoadServiceLimits(func(keyspaceID uint32, serviceLimit float64) {
+		m.getOrCreateKeyspaceResourceGroupManager(keyspaceID, false).setServiceLimit(serviceLimit)
+	})
 }
 
 func (m *Manager) initReserved() {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
By overriding the burst limit with the service limit for burstable groups to enhance the constraint imposed by the service limit.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Mannual test

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/8d15e191-4f96-4c9d-9820-82d914124812" />

<img width="668" height="271" alt="image" src="https://github.com/user-attachments/assets/ad6b0e58-8ecb-4330-9407-46507a857e87" />

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
