### PR TITLE
core: return the region tree size if scan all the regions

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -2127,12 +2127,14 @@ func (r *RegionsInfo) ScanRegionWithIterator(startKey []byte, iterator func(regi
 
 // GetRegionSizeByRange scans regions intersecting [start key, end key), returns the total region size of this range.
 func (r *RegionsInfo) GetRegionSizeByRange(startKey, endKey []byte) int64 {
+	if len(startKey) == 0 && len(endKey) == 0 {
+		r.t.RLock()
+		defer r.t.RUnlock()
+		return r.tree.totalSize
+	}
 	var size int64
 	for {
 		r.t.RLock()
-		if len(startKey) == 0 && len(endKey) == 0 {
-			return r.tree.totalSize
-		}
 		var cnt int
 		r.tree.scanRange(startKey, func(region *RegionInfo) bool {
 			if len(endKey) > 0 && bytes.Compare(region.GetStartKey(), endKey) >= 0 {

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -2130,6 +2130,9 @@ func (r *RegionsInfo) GetRegionSizeByRange(startKey, endKey []byte) int64 {
 	var size int64
 	for {
 		r.t.RLock()
+		if len(startKey) == 0 && len(endKey) == 0 {
+			return r.tree.totalSize
+		}
 		var cnt int
 		r.tree.scanRange(startKey, func(region *RegionInfo) bool {
 			if len(endKey) > 0 && bytes.Compare(region.GetStartKey(), endKey) >= 0 {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #9574

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
The region tree record the data size, and can retrun the size direct if we needs to scan all the region.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
https://github.com/tikv/pd/blob/4bddd644013eb39327feb82676a04ae7c3ad3191/pkg/core/region_test.go#L741-L767
- Integration test

Code changes


Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes



### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
