### PR TITLE
tests: improve tests with a unified `env.Reset`

### DIFF
--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -50,7 +50,7 @@ var (
 
 func init() {
 	// disable denoising in test.
-	statistics.Denoising = false
+	statistics.DisableDenoising()
 	statisticsInterval = 0
 	RegisterScheduler(writeType, func(opController *operator.Controller, _ endpoint.ConfigStorage, _ ConfigDecoder, _ ...func(string) error) (Scheduler, error) {
 		cfg := initHotRegionScheduleConfig()

--- a/tests/server/api/region_test.go
+++ b/tests/server/api/region_test.go
@@ -62,8 +62,7 @@ func (suite *regionTestSuite) TearDownSuite() {
 
 func (suite *regionTestSuite) TearDownTest() {
 	re := suite.Require()
-	suite.env.RunFunc(cleanRules(re))
-	suite.env.RunFunc(cleanStoresAndRegions(re))
+	suite.env.Reset(re)
 }
 
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRange() {

--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -63,7 +63,7 @@ func (suite *ruleTestSuite) TearDownSuite() {
 
 func (suite *ruleTestSuite) TearDownTest() {
 	re := suite.Require()
-	suite.env.RunFunc(cleanRules(re))
+	suite.env.Reset(re)
 }
 
 func (suite *ruleTestSuite) TestSet() {

--- a/tests/server/api/store_test.go
+++ b/tests/server/api/store_test.go
@@ -57,8 +57,7 @@ func (suite *storeTestSuite) TearDownSuite() {
 }
 func (suite *storeTestSuite) TearDownTest() {
 	re := suite.Require()
-	suite.env.RunFunc(cleanRules(re))
-	suite.env.RunFunc(cleanStoresAndRegions(re))
+	suite.env.Reset(re)
 }
 
 func (suite *storeTestSuite) TestStoresList() {

--- a/tests/server/storage/hot_region_storage_test.go
+++ b/tests/server/storage/hot_region_storage_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 
 func TestHotRegionStorage(t *testing.T) {
 	re := require.New(t)
-	statistics.Denoising = false
+	statistics.DisableDenoising()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cluster, err := tests.NewTestCluster(ctx, 1,
@@ -149,7 +149,7 @@ func TestHotRegionStorage(t *testing.T) {
 
 func TestHotRegionStorageReservedDayConfigChange(t *testing.T) {
 	re := require.New(t)
-	statistics.Denoising = false
+	statistics.DisableDenoising()
 	ctx, cancel := context.WithCancel(context.Background())
 	interval := 100 * time.Millisecond
 	defer cancel()
@@ -244,7 +244,7 @@ func TestHotRegionStorageReservedDayConfigChange(t *testing.T) {
 
 func TestHotRegionStorageWriteIntervalConfigChange(t *testing.T) {
 	re := require.New(t)
-	statistics.Denoising = false
+	statistics.DisableDenoising()
 	ctx, cancel := context.WithCancel(context.Background())
 	interval := 100 * time.Millisecond
 	defer cancel()

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -413,17 +413,16 @@ func (s *SchedulingTestEnvironment) Reset(re *require.Assertions) {
 			return len(respBundle) == 1 && respBundle[0].ID == placement.DefaultGroupID && len(respBundle[0].Rules) == 1 &&
 				respBundle[0].Rules[0].ID == placement.DefaultRuleID && respBundle[0].Rules[0].Count == 3 && respBundle[0].Rules[0].Role == placement.Voter
 		})
-		// clean region cache
+		// clean region storage and cache
 		for _, server := range cluster.GetServers() {
 			pdAddr := cluster.GetConfig().GetClientURL()
 			for _, region := range server.GetRegions() {
-				url := fmt.Sprintf("%s/pd/api/v1/admin/cache/region/%d", pdAddr, region.GetID())
-				err := testutil.CheckDelete(TestDialClient, url, testutil.StatusOK(re))
+				url := fmt.Sprintf("%s/pd/api/v1/admin/storage/region/%d", pdAddr, region.GetID())
+				err = testutil.CheckDelete(TestDialClient, url, testutil.StatusOK(re))
 				re.NoError(err)
 			}
 			re.Empty(server.GetRegions())
 		}
-
 		// clean stores
 		leader := cluster.GetLeaderServer()
 		for _, store := range leader.GetStores() {

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -45,12 +45,15 @@ import (
 
 	bs "github.com/tikv/pd/pkg/basicserver"
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/errs"
 	scheduling "github.com/tikv/pd/pkg/mcs/scheduling/server"
 	sc "github.com/tikv/pd/pkg/mcs/scheduling/server/config"
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/mock/mockid"
+	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
+	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/assertutil"
 	"github.com/tikv/pd/pkg/utils/logutil"
@@ -383,6 +386,121 @@ func (s *SchedulingTestEnvironment) RunTestInNonMicroserviceEnv(test func(*TestC
 func (s *SchedulingTestEnvironment) RunTestInMicroserviceEnv(test func(*TestCluster)) {
 	s.t.Logf("start test %s in microservice environment", getTestName())
 	s.runFuncInMicroserviceEnv(test)
+}
+
+// Reset is to reset the environment.
+// It will reset stores, regions, rules and schedulers.
+func (s *SchedulingTestEnvironment) Reset(re *require.Assertions) {
+	resetFunc := func(cluster *TestCluster) {
+		// replace rules with default rule
+		defaultRule := placement.GroupBundle{
+			ID: placement.DefaultGroupID,
+			Rules: []*placement.Rule{
+				{GroupID: placement.DefaultGroupID, ID: placement.DefaultRuleID, Role: placement.Voter, Count: 3},
+			},
+		}
+		data, err := json.Marshal([]placement.GroupBundle{defaultRule})
+		re.NoError(err)
+		urlPrefix := fmt.Sprintf("%s/pd/api/v1", cluster.GetLeaderServer().GetAddr())
+		ruleURL := fmt.Sprintf("%s/config/placement-rule", urlPrefix)
+		err = testutil.CheckPostJSON(TestDialClient, ruleURL, data, testutil.StatusOK(re))
+		re.NoError(err)
+		respBundle := make([]placement.GroupBundle, 0)
+		testutil.Eventually(re, func() bool {
+			err = testutil.CheckGetJSON(TestDialClient, ruleURL, nil,
+				testutil.StatusOK(re), testutil.ExtractJSON(re, &respBundle))
+			re.NoError(err)
+			return len(respBundle) == 1 && respBundle[0].ID == placement.DefaultGroupID && len(respBundle[0].Rules) == 1 &&
+				respBundle[0].Rules[0].ID == placement.DefaultRuleID && respBundle[0].Rules[0].Count == 3 && respBundle[0].Rules[0].Role == placement.Voter
+		})
+		// clean region cache
+		for _, server := range cluster.GetServers() {
+			pdAddr := cluster.GetConfig().GetClientURL()
+			for _, region := range server.GetRegions() {
+				url := fmt.Sprintf("%s/pd/api/v1/admin/cache/region/%d", pdAddr, region.GetID())
+				err := testutil.CheckDelete(TestDialClient, url, testutil.StatusOK(re))
+				re.NoError(err)
+			}
+			re.Empty(server.GetRegions())
+		}
+
+		// clean stores
+		leader := cluster.GetLeaderServer()
+		for _, store := range leader.GetStores() {
+			if store.NodeState == metapb.NodeState_Removed {
+				continue
+			}
+			err := cluster.GetLeaderServer().GetRaftCluster().RemoveStore(store.GetId(), true)
+			if err != nil {
+				re.ErrorIs(err, errs.ErrStoreRemoved)
+			}
+			re.NoError(cluster.GetLeaderServer().GetRaftCluster().BuryStore(store.GetId(), true))
+		}
+		re.NoError(cluster.GetLeaderServer().GetRaftCluster().RemoveTombStoneRecords())
+		re.Empty(leader.GetStores())
+		testutil.Eventually(re, func() bool {
+			if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
+				for _, s := range sche.GetBasicCluster().GetStores() {
+					if s.GetState() != metapb.StoreState_Tombstone {
+						return false
+					}
+				}
+			}
+			return true
+		})
+		// clean schedulers
+		schedulerURL := fmt.Sprintf("%s/schedulers", urlPrefix)
+		testutil.Eventually(re, func() bool {
+			// get current schedulers
+			var currentSchedulers []string
+			err := testutil.CheckGetJSON(http.DefaultClient, schedulerURL, nil,
+				testutil.StatusOK(re), testutil.ExtractJSON(re, &currentSchedulers))
+			re.NoError(err)
+			// compare schedulers
+			defaultSet := make(map[string]struct{}, len(types.DefaultSchedulers))
+			for _, s := range types.DefaultSchedulers {
+				defaultSet[s.String()] = struct{}{}
+			}
+			currentSet := make(map[string]struct{}, len(currentSchedulers))
+			for _, s := range currentSchedulers {
+				currentSet[s] = struct{}{}
+			}
+			var toAdd, toRemove []string
+			for name := range defaultSet {
+				if _, ok := currentSet[name]; !ok {
+					toAdd = append(toAdd, name)
+				}
+			}
+			for name := range currentSet {
+				if _, ok := defaultSet[name]; !ok {
+					toRemove = append(toRemove, name)
+				}
+			}
+			if len(toAdd) == 0 && len(toRemove) == 0 {
+				return true
+			}
+			// sync schedulers
+			for _, name := range toAdd {
+				input := map[string]any{"name": name}
+				body, err := json.Marshal(input)
+				re.NoError(err)
+				err = testutil.CheckPostJSON(http.DefaultClient, schedulerURL, body)
+				re.NoError(err)
+			}
+			for _, name := range toRemove {
+				err = testutil.CheckDelete(http.DefaultClient, schedulerURL+"/"+name)
+				re.NoError(err)
+			}
+			return false
+		})
+		// clean hot cache
+		hotStat := leader.GetRaftCluster().GetHotStat()
+		if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
+			hotStat = sche.GetCluster().GetHotStat()
+		}
+		hotStat.CleanCache()
+	}
+	s.RunFunc(resetFunc)
 }
 
 // Cleanup is to cleanup the environment.

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -17,7 +17,6 @@ package config_test
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"os"
 	"reflect"
 	"strconv"
@@ -43,13 +42,6 @@ import (
 	"github.com/tikv/pd/tools/pd-ctl/tests"
 )
 
-// testDialClient used to dial http request. only used for test.
-var testDialClient = &http.Client{
-	Transport: &http.Transport{
-		DisableKeepAlives: true,
-	},
-}
-
 type testCase struct {
 	name  string
 	value any
@@ -73,8 +65,7 @@ func TestConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(configTestSuite))
 }
 
-func (suite *configTestSuite) SetupTest() {
-	// use a new environment to avoid affecting other tests
+func (suite *configTestSuite) SetupSuite() {
 	suite.env = pdTests.NewSchedulingTestEnvironment(suite.T())
 }
 
@@ -84,22 +75,7 @@ func (suite *configTestSuite) TearDownSuite() {
 
 func (suite *configTestSuite) TearDownTest() {
 	re := suite.Require()
-	cleanFunc := func(cluster *pdTests.TestCluster) {
-		def := placement.GroupBundle{
-			ID: "pd",
-			Rules: []*placement.Rule{
-				{GroupID: placement.DefaultGroupID, ID: placement.DefaultRuleID, Role: "voter", Count: 3},
-			},
-		}
-		data, err := json.Marshal([]placement.GroupBundle{def})
-		re.NoError(err)
-		leader := cluster.GetLeaderServer()
-		re.NotNil(leader)
-		urlPrefix := leader.GetAddr()
-		err = testutil.CheckPostJSON(testDialClient, urlPrefix+"/pd/api/v1/config/placement-rule", data, testutil.StatusOK(re))
-		re.NoError(err)
-	}
-	suite.env.RunFunc(cleanFunc)
+	suite.env.Reset(re)
 }
 
 func (suite *configTestSuite) TestConfig() {
@@ -236,6 +212,9 @@ func (suite *configTestSuite) checkConfig(cluster *pdTests.TestCluster) {
 	clusterVersion = semver.Version{}
 	re.NoError(json.Unmarshal(output, &clusterVersion))
 	re.Equal(svr.GetClusterVersion(), clusterVersion)
+	args2 = []string{"-u", pdAddr, "config", "set", "cluster-version", "2.0.0"}
+	_, err = tests.ExecuteCommand(cmd, args2...)
+	re.NoError(err)
 
 	// config show label-property
 	args1 = []string{"-u", pdAddr, "config", "show", "label-property"}
@@ -367,7 +346,7 @@ func (suite *configTestSuite) checkConfig(cluster *pdTests.TestCluster) {
 func (suite *configTestSuite) TestConfigForwardControl() {
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/dashboard/adapter/skipDashboardLoop", `return(true)`))
-	suite.env.RunTest(suite.checkConfigForwardControl)
+	suite.env.RunTestInMicroserviceEnv(suite.checkConfigForwardControl) // It only tests scheduling server.
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/dashboard/adapter/skipDashboardLoop"))
 }
 
@@ -522,6 +501,10 @@ func (suite *configTestSuite) checkConfigForwardControl(cluster *pdTests.TestClu
 		sche.GetPersistConfig().SetReplicationConfig(repCfg)
 		re.Equal(uint64(233), sche.GetPersistConfig().GetLeaderScheduleLimit())
 		re.Equal(7, sche.GetPersistConfig().GetMaxReplicas())
+		defer func() {
+			sche.GetPersistConfig().SetScheduleConfig(leaderServer.GetConfig().Schedule.Clone())
+			sche.GetPersistConfig().SetReplicationConfig(leaderServer.GetConfig().Replication.Clone())
+		}()
 	}
 	// show config from PD rather than scheduling server
 	testConfig()
@@ -558,6 +541,10 @@ func (suite *configTestSuite) checkConfigForwardControl(cluster *pdTests.TestClu
 			},
 		}}, true)
 		re.Len(ruleManager.GetAllRules(), 2)
+		defer func() {
+			bundles := leaderServer.GetRaftCluster().GetRuleManager().GetAllGroupBundles()
+			ruleManager.SetAllGroupBundles(bundles, true)
+		}()
 	}
 
 	// show placement rules
@@ -746,6 +733,7 @@ func (suite *configTestSuite) checkPlacementRuleBundle(cluster *pdTests.TestClus
 	re.NoError(json.Unmarshal(output, &bundle))
 	expect := placement.GroupBundle{ID: placement.DefaultGroupID, Index: 0, Override: false, Rules: []*placement.Rule{{GroupID: placement.DefaultGroupID, ID: placement.DefaultRuleID, Role: placement.Voter, Count: 3}}}
 	expect.Rules[0].CreateTimestamp = bundle.Rules[0].CreateTimestamp // skip create timestamp in mcs
+	expect.Rules[0].Version = bundle.Rules[0].Version                 // skip version
 	re.Equal(expect, bundle)
 
 	f, err := os.CreateTemp("", "pd_tests")

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -212,7 +212,7 @@ func (suite *configTestSuite) checkConfig(cluster *pdTests.TestCluster) {
 	clusterVersion = semver.Version{}
 	re.NoError(json.Unmarshal(output, &clusterVersion))
 	re.Equal(svr.GetClusterVersion(), clusterVersion)
-	args2 = []string{"-u", pdAddr, "config", "set", "cluster-version", "2.0.0"}
+	args2 = []string{"-u", pdAddr, "config", "set", "cluster-version", "2.0.0"} // reset to default
 	_, err = tests.ExecuteCommand(cmd, args2...)
 	re.NoError(err)
 

--- a/tools/pd-ctl/tests/hot/hot_test.go
+++ b/tools/pd-ctl/tests/hot/hot_test.go
@@ -42,11 +42,6 @@ import (
 	"github.com/tikv/pd/tools/pd-ctl/tests"
 )
 
-func init() {
-	// disable denoising for hot statistic tests
-	statistics.Denoising = false
-}
-
 type hotTestSuite struct {
 	suite.Suite
 	env *pdTests.SchedulingTestEnvironment
@@ -57,6 +52,7 @@ func TestHotTestSuite(t *testing.T) {
 }
 
 func (suite *hotTestSuite) SetupSuite() {
+	statistics.DisableDenoising()
 	suite.env = pdTests.NewSchedulingTestEnvironment(suite.T(),
 		func(conf *config.Config, _ string) {
 			conf.Schedule.MaxStoreDownTime.Duration = time.Hour
@@ -396,6 +392,7 @@ func TestHistoryHotRegions(t *testing.T) {
 	// TODO: support history hotspot in scheduling server with stateless in the future.
 	// Ref: https://github.com/tikv/pd/pull/7183
 	re := require.New(t)
+	statistics.DisableDenoising()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cluster, err := pdTests.NewTestCluster(ctx, 1,
@@ -518,6 +515,7 @@ func TestHistoryHotRegions(t *testing.T) {
 func TestBuckets(t *testing.T) {
 	// TODO: support forward bucket request in scheduling server in the future.
 	re := require.New(t)
+	statistics.DisableDenoising()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cluster, err := pdTests.NewTestCluster(ctx, 1, func(cfg *config.Config, _ string) { cfg.Schedule.HotRegionCacheHitsThreshold = 0 })

--- a/tools/pd-ctl/tests/hot/hot_test.go
+++ b/tools/pd-ctl/tests/hot/hot_test.go
@@ -42,6 +42,11 @@ import (
 	"github.com/tikv/pd/tools/pd-ctl/tests"
 )
 
+func init() {
+	// disable denoising for hot statistic tests
+	statistics.Denoising = false
+}
+
 type hotTestSuite struct {
 	suite.Suite
 	env *pdTests.SchedulingTestEnvironment
@@ -75,7 +80,6 @@ func (suite *hotTestSuite) TestHot() {
 
 func (suite *hotTestSuite) checkHot(cluster *pdTests.TestCluster) {
 	re := suite.Require()
-	statistics.Denoising = false
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
 
@@ -245,7 +249,6 @@ func (suite *hotTestSuite) TestHotWithStoreID() {
 
 func (suite *hotTestSuite) checkHotWithStoreID(cluster *pdTests.TestCluster) {
 	re := suite.Require()
-	statistics.Denoising = false
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
 	leaderServer := cluster.GetLeaderServer()
@@ -312,7 +315,6 @@ func (suite *hotTestSuite) TestHotWithoutHotPeer() {
 
 func (suite *hotTestSuite) checkHotWithoutHotPeer(cluster *pdTests.TestCluster) {
 	re := suite.Require()
-	statistics.Denoising = false
 
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
@@ -394,7 +396,6 @@ func TestHistoryHotRegions(t *testing.T) {
 	// TODO: support history hotspot in scheduling server with stateless in the future.
 	// Ref: https://github.com/tikv/pd/pull/7183
 	re := require.New(t)
-	statistics.Denoising = false
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cluster, err := pdTests.NewTestCluster(ctx, 1,
@@ -517,7 +518,6 @@ func TestHistoryHotRegions(t *testing.T) {
 func TestBuckets(t *testing.T) {
 	// TODO: support forward bucket request in scheduling server in the future.
 	re := require.New(t)
-	statistics.Denoising = false
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cluster, err := pdTests.NewTestCluster(ctx, 1, func(cfg *config.Config, _ string) { cfg.Schedule.HotRegionCacheHitsThreshold = 0 })

--- a/tools/pd-ctl/tests/hot/hot_test.go
+++ b/tools/pd-ctl/tests/hot/hot_test.go
@@ -65,15 +65,8 @@ func (suite *hotTestSuite) TearDownSuite() {
 }
 
 func (suite *hotTestSuite) TearDownTest() {
-	cleanFunc := func(cluster *pdTests.TestCluster) {
-		leader := cluster.GetLeaderServer()
-		hotStat := leader.GetRaftCluster().GetHotStat()
-		if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
-			hotStat = sche.GetCluster().GetHotStat()
-		}
-		hotStat.CleanCache()
-	}
-	suite.env.RunFunc(cleanFunc)
+	re := suite.Require()
+	suite.env.Reset(re)
 }
 
 func (suite *hotTestSuite) TestHot() {

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -15,6 +15,7 @@
 package scheduler_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	sc "github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/versioninfo"
@@ -41,8 +43,7 @@ import (
 
 type schedulerTestSuite struct {
 	suite.Suite
-	env               *pdTests.SchedulingTestEnvironment
-	defaultSchedulers []string
+	env *pdTests.SchedulingTestEnvironment
 }
 
 func TestSchedulerTestSuite(t *testing.T) {
@@ -52,17 +53,41 @@ func TestSchedulerTestSuite(t *testing.T) {
 func (suite *schedulerTestSuite) SetupSuite() {
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/skipStoreConfigSync", `return(true)`))
-	suite.defaultSchedulers = []string{
-		"balance-leader-scheduler",
-		"balance-region-scheduler",
-		"balance-hot-region-scheduler",
-		"evict-slow-store-scheduler",
-	}
+	suite.env = pdTests.NewSchedulingTestEnvironment(suite.T())
 }
 
 func (suite *schedulerTestSuite) SetupTest() {
-	// use a new environment to avoid affecting other tests
-	suite.env = pdTests.NewSchedulingTestEnvironment(suite.T())
+	re := suite.Require()
+	suite.env.RunFunc(func(cluster *pdTests.TestCluster) {
+		stores := []*metapb.Store{
+			{
+				Id:            1,
+				State:         metapb.StoreState_Up,
+				LastHeartbeat: time.Now().UnixNano(),
+			},
+			{
+				Id:            2,
+				State:         metapb.StoreState_Up,
+				LastHeartbeat: time.Now().UnixNano(),
+			},
+			{
+				Id:            3,
+				State:         metapb.StoreState_Up,
+				LastHeartbeat: time.Now().UnixNano(),
+			},
+			{
+				Id:            4,
+				State:         metapb.StoreState_Up,
+				LastHeartbeat: time.Now().UnixNano(),
+			},
+		}
+		for _, store := range stores {
+			pdTests.MustPutStore(re, cluster, store)
+		}
+
+		// note: because pdqsort is an unstable sort algorithm, set ApproximateSize for this region.
+		pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"), core.SetApproximateSize(10))
+	})
 }
 
 func (suite *schedulerTestSuite) TearDownSuite() {
@@ -72,37 +97,15 @@ func (suite *schedulerTestSuite) TearDownSuite() {
 }
 
 func (suite *schedulerTestSuite) TearDownTest() {
-	cleanFunc := func(cluster *pdTests.TestCluster) {
-		re := suite.Require()
-		pdAddr := cluster.GetConfig().GetClientURL()
-		cmd := ctl.GetRootCmd()
-
-		var currentSchedulers []string
-		mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "show"}, &currentSchedulers)
-		for _, scheduler := range suite.defaultSchedulers {
-			if slice.NoneOf(currentSchedulers, func(i int) bool {
-				return currentSchedulers[i] == scheduler
-			}) {
-				echo := mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", scheduler}, nil)
-				re.Contains(echo, "Success!", scheduler)
-			}
-		}
-		for _, scheduler := range currentSchedulers {
-			if slice.NoneOf(suite.defaultSchedulers, func(i int) bool {
-				return suite.defaultSchedulers[i] == scheduler
-			}) {
-				echo := mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "remove", scheduler}, nil)
-				re.Contains(echo, "Success!")
-			}
-		}
-	}
-	suite.env.RunFunc(cleanFunc)
+	re := suite.Require()
+	suite.env.Reset(re)
 }
 
-func (suite *schedulerTestSuite) checkDefaultSchedulers(re *require.Assertions, cmd *cobra.Command, pdAddr string) {
+func (suite *schedulerTestSuite) checkDefaultSchedulers(cmd *cobra.Command, pdAddr string) {
+	re := suite.Require()
 	expected := make(map[string]bool)
-	for _, scheduler := range suite.defaultSchedulers {
-		expected[scheduler] = true
+	for _, scheduler := range types.DefaultSchedulers {
+		expected[scheduler.String()] = true
 	}
 	checkSchedulerCommand(re, cmd, pdAddr, nil, expected)
 }
@@ -115,29 +118,7 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 	re := suite.Require()
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
-
-	stores := []*metapb.Store{
-		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-	}
+	leaderServer := cluster.GetLeaderServer()
 
 	mustUsage := func(args []string) {
 		output, err := tests.ExecuteCommand(cmd, args...)
@@ -153,16 +134,6 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		})
 	}
 
-	leaderServer := cluster.GetLeaderServer()
-	for _, store := range stores {
-		pdTests.MustPutStore(re, cluster, store)
-	}
-
-	// note: because pdqsort is a unstable sort algorithm, set ApproximateSize for this region.
-	pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"), core.SetApproximateSize(10))
-
-	suite.checkDefaultSchedulers(re, cmd, pdAddr)
-
 	// scheduler delete command
 	args := []string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"}
 	expected := map[string]bool{
@@ -176,6 +147,7 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 	schedulers := []string{"evict-leader-scheduler", "grant-leader-scheduler", "evict-leader-scheduler", "grant-leader-scheduler"}
 
 	checkStorePause := func(changedStores []uint64, schedulerName string) {
+		stores := leaderServer.GetStores()
 		for _, store := range stores {
 			storeInfo := cluster.GetLeaderServer().GetRaftCluster().GetStore(store.GetId())
 			status, isStorePaused := func() (string, bool) {
@@ -415,36 +387,7 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
 
-	stores := []*metapb.Store{
-		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-	}
-	for _, store := range stores {
-		pdTests.MustPutStore(re, cluster, store)
-	}
-
-	// note: because pdqsort is an unstable sort algorithm, set ApproximateSize for this region.
-	pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"), core.SetApproximateSize(10))
-
-	suite.checkDefaultSchedulers(re, cmd, pdAddr)
+	suite.checkDefaultSchedulers(cmd, pdAddr)
 
 	// test evict-slow-store && evict-slow-trend schedulers config
 	evictSlownessSchedulers := []string{"evict-slow-store-scheduler", "evict-slow-trend-scheduler"}
@@ -622,37 +565,6 @@ func (suite *schedulerTestSuite) checkGrantHotRegionScheduler(cluster *pdTests.T
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
 
-	stores := []*metapb.Store{
-		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-	}
-	for _, store := range stores {
-		pdTests.MustPutStore(re, cluster, store)
-	}
-
-	// note: because pdqsort is an unstable sort algorithm, set ApproximateSize for this region.
-	pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"), core.SetApproximateSize(10))
-
-	suite.checkDefaultSchedulers(re, cmd, pdAddr)
-
 	// case 1: add grant-hot-region-scheduler when balance-hot-region-scheduler is running
 	echo := mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "grant-hot-region-scheduler", "1", "1,2,3"}, nil)
 	re.Contains(echo, "balance-hot-region-scheduler is running, please remove it first")
@@ -660,9 +572,11 @@ func (suite *schedulerTestSuite) checkGrantHotRegionScheduler(cluster *pdTests.T
 	// case 2: add grant-hot-region-scheduler when balance-hot-region-scheduler is paused
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "pause", "balance-hot-region-scheduler", "60"}, nil)
 	re.Contains(echo, "Success!")
-	suite.checkDefaultSchedulers(re, cmd, pdAddr)
+	suite.checkDefaultSchedulers(cmd, pdAddr)
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "grant-hot-region-scheduler", "1", "1,2,3"}, nil)
 	re.Contains(echo, "balance-hot-region-scheduler is running, please remove it first")
+	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "resume", "balance-hot-region-scheduler"}, nil)
+	re.Contains(echo, "Success!")
 
 	// case 3: add grant-hot-region-scheduler when balance-hot-region-scheduler is disabled
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "remove", "balance-hot-region-scheduler"}, map[string]bool{
@@ -726,7 +640,7 @@ func (suite *schedulerTestSuite) checkGrantHotRegionScheduler(cluster *pdTests.T
 
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "balance-hot-region-scheduler"}, nil)
 	re.Contains(echo, "Success!")
-	suite.checkDefaultSchedulers(re, cmd, pdAddr)
+	suite.checkDefaultSchedulers(cmd, pdAddr)
 }
 
 func (suite *schedulerTestSuite) TestHotRegionSchedulerConfig() {
@@ -738,37 +652,6 @@ func (suite *schedulerTestSuite) checkHotRegionSchedulerConfig(cluster *pdTests.
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
 
-	stores := []*metapb.Store{
-		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-	}
-	for _, store := range stores {
-		pdTests.MustPutStore(re, cluster, store)
-	}
-	// note: because pdqsort is an unstable sort algorithm, set ApproximateSize for this region.
-	pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"), core.SetApproximateSize(10))
-
-	suite.checkDefaultSchedulers(re, cmd, pdAddr)
-
-	leaderServer := cluster.GetLeaderServer()
 	// test hot region config
 	expected1 := map[string]any{
 		"min-hot-byte-rate":       float64(100),
@@ -874,23 +757,6 @@ func (suite *schedulerTestSuite) checkHotRegionSchedulerConfig(cluster *pdTests.
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "history-sample-interval", "0s"}, nil)
 	re.Contains(echo, "Success!")
 	checkHotSchedulerConfig(expected1)
-
-	// test compatibility
-	re.Equal("2.0.0", leaderServer.GetClusterVersion().String())
-	for _, store := range stores {
-		version := versioninfo.HotScheduleWithQuery
-		store.Version = versioninfo.MinSupportedVersion(version).String()
-		store.LastHeartbeat = time.Now().UnixNano()
-		pdTests.MustPutStore(re, cluster, store)
-	}
-	re.Equal("5.2.0", leaderServer.GetClusterVersion().String())
-	// After upgrading, we can use query.
-	expected1["write-leader-priorities"] = []any{"query", "byte"}
-	checkHotSchedulerConfig(expected1)
-	// cannot set qps as write-peer-priorities
-	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "write-peer-priorities", "query,byte"}, nil)
-	re.Contains(echo, "query is not allowed to be set in priorities for write-peer-priorities")
-	checkHotSchedulerConfig(expected1)
 }
 
 func (suite *schedulerTestSuite) TestSchedulerDiagnostic() {
@@ -910,48 +776,28 @@ func (suite *schedulerTestSuite) checkSchedulerDiagnostic(cluster *pdTests.TestC
 		}, testutil.WithTickInterval(50*time.Millisecond))
 	}
 
-	stores := []*metapb.Store{
-		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-	}
-	for _, store := range stores {
-		pdTests.MustPutStore(re, cluster, store)
-	}
-
-	// note: because pdqsort is an unstable sort algorithm, set ApproximateSize for this region.
-	pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"), core.SetApproximateSize(10))
-
-	suite.checkDefaultSchedulers(re, cmd, pdAddr)
-
 	echo := mustExec(re, cmd, []string{"-u", pdAddr, "config", "set", "enable-diagnostic", "true"}, nil)
 	re.Contains(echo, "Success!")
-	checkSchedulerDescribeCommand("balance-region-scheduler", "pending", "1 store(s) RegionNotMatchRule; ")
+	echo = mustExec(re, cmd, []string{"-u", pdAddr, "config", "set", "region-schedule-limit", "0"}, nil)
+	re.Contains(echo, "Success!")
+	checkSchedulerDescribeCommand("balance-region-scheduler", "pending", "balance-region-scheduler reach limit")
 
 	// scheduler delete command
-	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"}, nil)
+	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "remove", "balance-leader-scheduler"}, nil)
 	re.Contains(echo, "Success!")
-	checkSchedulerDescribeCommand("balance-region-scheduler", "disabled", "")
+	checkSchedulerDescribeCommand("balance-leader-scheduler", "disabled", "")
 
+	// scheduler add command
+	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "balance-leader-scheduler"}, nil)
+	re.Contains(echo, "Success!")
+	checkSchedulerDescribeCommand("balance-leader-scheduler", "normal", "")
+
+	// scheduler pause command
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "pause", "balance-leader-scheduler", "60"}, nil)
 	re.Contains(echo, "Success!")
+	checkSchedulerDescribeCommand("balance-leader-scheduler", "paused", "")
+
+	// scheduler resume command
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "resume", "balance-leader-scheduler"}, nil)
 	re.Contains(echo, "Success!")
 	checkSchedulerDescribeCommand("balance-leader-scheduler", "normal", "")
@@ -966,33 +812,6 @@ func (suite *schedulerTestSuite) checkEvictLeaderScheduler(cluster *pdTests.Test
 	pdAddr := cluster.GetConfig().GetClientURL()
 	cmd := ctl.GetRootCmd()
 
-	stores := []*metapb.Store{
-		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
-		},
-	}
-	for _, store := range stores {
-		pdTests.MustPutStore(re, cluster, store)
-	}
-
-	pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"))
 	output, err := tests.ExecuteCommand(cmd, []string{"-u", pdAddr, "scheduler", "add", "evict-leader-scheduler", "2"}...)
 	re.NoError(err)
 	re.Contains(string(output), "Success!")
@@ -1077,4 +896,80 @@ func compareGrantHotRegionSchedulerConfig(expect, actual map[string]any) bool {
 		}
 	}
 	return true
+}
+
+// TestHotSchedulerUpgrade tests the config change after pd upgrade to 5.2.0
+// It only tests the config change of hot scheduler with non ms.
+// Because it change the cluster version, so need to test in another test.
+func TestHotSchedulerUpgrade(t *testing.T) {
+	re := require.New(t)
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/skipStoreConfigSync", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/skipStoreConfigSync"))
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := pdTests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+	err = cluster.RunInitialServers()
+	re.NoError(err)
+	re.NotEmpty(cluster.WaitLeader())
+	leaderServer := cluster.GetLeaderServer()
+	re.NoError(leaderServer.BootstrapCluster())
+	pdAddr := cluster.GetConfig().GetClientURL()
+	cmd := ctl.GetRootCmd()
+	stores := []*metapb.Store{
+		{
+			Id:            1,
+			State:         metapb.StoreState_Up,
+			LastHeartbeat: time.Now().UnixNano(),
+		},
+		{
+			Id:            2,
+			State:         metapb.StoreState_Up,
+			LastHeartbeat: time.Now().UnixNano(),
+		},
+		{
+			Id:            3,
+			State:         metapb.StoreState_Up,
+			LastHeartbeat: time.Now().UnixNano(),
+		},
+		{
+			Id:            4,
+			State:         metapb.StoreState_Up,
+			LastHeartbeat: time.Now().UnixNano(),
+		},
+	}
+	for _, store := range stores {
+		pdTests.MustPutStore(re, cluster, store)
+	}
+	pdTests.MustPutRegion(re, cluster, 1, 1, []byte("a"), []byte("b"), core.SetApproximateSize(10))
+	// wait scheduelrs run
+	testutil.Eventually(re, func() bool {
+		schedulers := []string{}
+		mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "show"}, &schedulers)
+		return len(schedulers) == len(sc.DefaultSchedulers)
+	})
+	// check config in version 2.0
+	var conf map[string]any
+	mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "list"}, &conf)
+	re.NotContains(conf["write-leader-priorities"], "query")
+	// test compatibility
+	re.Equal("2.0.0", leaderServer.GetClusterVersion().String())
+	for _, store := range stores {
+		version := versioninfo.HotScheduleWithQuery
+		store.Version = versioninfo.MinSupportedVersion(version).String()
+		store.LastHeartbeat = time.Now().UnixNano()
+		pdTests.MustPutStore(re, cluster, store)
+	}
+	re.Equal("5.2.0", leaderServer.GetClusterVersion().String())
+	// after upgrading, we can use query automatically.
+	testutil.Eventually(re, func() bool {
+		mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "list"}, &conf)
+		return slice.Contains(conf["write-leader-priorities"].([]any), "query")
+	})
+	// cannot set qps as write-peer-priorities
+	echo := mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "balance-hot-region-scheduler", "set", "write-peer-priorities", "query,byte"}, nil)
+	re.Contains(echo, "query is not allowed to be set in priorities for write-peer-priorities")
 }

--- a/tools/pd-heartbeat-bench/main.go
+++ b/tools/pd-heartbeat-bench/main.go
@@ -275,7 +275,7 @@ func (s *Stores) update(rs *utils.Regions) {
 
 func main() {
 	rand.New(rand.NewSource(0)) // Ensure consistent behavior multiple times
-	statistics.Denoising = false
+	statistics.DisableDenoising()
 	cfg := config.NewConfig()
 	err := cfg.Parse(os.Args[1:])
 	defer logutil.LogPanic()

--- a/tools/pd-simulator/main.go
+++ b/tools/pd-simulator/main.go
@@ -60,7 +60,7 @@ func main() {
 	flag.Parse()
 
 	simutil.InitLogger(*simLogLevel, *simLogFile)
-	statistics.Denoising = false
+	statistics.DisableDenoising()
 	schedulers.Register() // register schedulers, which is needed by simConfig.Adjust
 	simConfig := sc.NewSimConfig(*serverLogLevel)
 	if simConfig.EnableTransferRegionCounter {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #4399

### What is changed and how does it work?

avoid unnecessarily creating and destroying clusters and use a unified `env.Reset`

Status | Chunk | Time | Link
-- | -- | -- | --
Before Optimization | chunk5 | 7min 18s | [Job 46535627785](https://github.com/tikv/pd/actions/runs/16463556492/job/46535627785)
Optimized | chunk5 | 6min 1s | [Job 46564645823](https://github.com/tikv/pd/actions/runs/16472366678/job/46564645823)
Before Optimization | chunk6 | 6min 37s | [Job 46535627798](https://github.com/tikv/pd/actions/runs/16463556492/job/46535627785)
Optimized | chunk6 | 5min 30s | [Job 46564645831](https://github.com/tikv/pd/actions/runs/16472366678/job/46564645831)



<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
