### PR TITLE
mcs: change the collect time to 5m

### DIFF
--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -85,7 +85,7 @@ type Cluster struct {
 const (
 	regionLabelGCInterval = time.Hour
 	requestTimeout        = 3 * time.Second
-	collectWaitTime       = time.Minute
+	collectWaitTime       = 5 * time.Minute
 
 	// heartbeat relative const
 	heartbeatTaskRunner = "heartbeat-task-runner"
@@ -518,7 +518,7 @@ func (c *Cluster) runUpdateStoreStats() {
 func (c *Cluster) runCoordinator() {
 	defer logutil.LogPanic()
 	defer c.wg.Done()
-	// force wait for 1 minute to make prepare checker won't be directly skipped
+	// force wait for 5 minute to make prepare checker won't be directly skipped
 	runCollectWaitTime := collectWaitTime
 	failpoint.Inject("changeRunCollectWaitTime", func() {
 		runCollectWaitTime = 1 * time.Second


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #7671

### What is changed and how does it work?

Once the PD leader and scheduling primary steps down, maybe due to lease timeout. The time that PD is changed to running state may be longer than the scheduling primary wait collection time. In this case, there could be many scheduling operators even if TIKVs are balanced.

Scheduling service starts to wait for one round region heartbeat at 14:00:10 and finishes at 14:01:07.
```
2025-07-24 14:00:10 | [2025/07/24 06:00:10.162 +00:00] [INFO] [coordinator.go:403] ["coordinator starts to collect cluster information"]
2025-07-24 14:01:07 | [2025/07/24 06:01:07.158 +00:00] [INFO] [prepare_checker.go:72] ["not loaded from storage region number is satisfied, finish prepare checker"] [not-from-storage-region=0] [total-region=0]
2025-07-24 14:01:07 | [2025/07/24 06:01:07.158 +00:00] [INFO] [coordinator.go:406] ["coordinator has finished cluster information preparation"]
2025-07-24 14:01:07 | [2025/07/24 06:01:07.159 +00:00] [INFO] [coordinator.go:416] ["coordinator starts to run schedulers"]
```

But PD cannot redirect any heartbeat to scheduling service because PD is not in the running state until 14:02:00.
```
2025-07-24 14:02:00 | [2025/07/24 06:02:00.263 +00:00] [INFO] [cluster.go:634] ["load stores"] [count=14] [cost=49.330352ms]
2025-07-24 14:02:00 | [2025/07/24 06:02:00.263 +00:00] [INFO] [cluster.go:645] ["load regions"] [count=202339] [cost=1.625µs]
```

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
