### PR TITLE
pkg/gc: use lock to protect GetGCStates()

### DIFF
--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -606,6 +606,8 @@ func (m *GCStateManager) GetGCState(keyspaceID uint32) (GCState, error) {
 	if err != nil {
 		return GCState{}, err
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	var result GCState
 	err = m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #8978

### What is changed and how does it work?



<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

Add lock to protect `GetGCStates` API.
Without this, pd client calling GC related API may get `ErrEtcdTxnConflict` error and need to retry manually.
Because calling the APIs concurrently would result in concurrent transaction to modify etcd keys.


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- [X] Manual test (add detailed scripts or steps below)

Here is a fuzz test, before this commit, the client side need to retry on ErrEtcdTxnConflict.
And after this commit, I can remove the retry safely.

- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
