### PR TITLE
refine(resourcemanager): adjust demand deduction to better support RU consumption growth

### DIFF
--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -824,13 +824,21 @@ func TestConciliateFillRate(t *testing.T) {
 			expectedOverrideBurstLimitList: []int64{100},
 		},
 		{
-			name:                           "Proportional allocation with normalization check - case 1",
-			serviceLimit:                   100,
-			priorityList:                   []uint32{1, 1, 1},
-			fillRateSettingList:            []uint64{100, 100, 100},
-			ruDemandList:                   []float64{40, 80, 10},
-			expectedOverrideFillRateList:   []float64{40, 50, 10},
-			expectedOverrideBurstLimitList: []int64{40, 50, 10},
+			name:                "Proportional allocation with normalization check - case 1",
+			serviceLimit:        100,
+			priorityList:        []uint32{1, 1, 1},
+			fillRateSettingList: []uint64{100, 100, 100},
+			ruDemandList:        []float64{40, 80, 10},
+			expectedOverrideFillRateList: []float64{
+				(100.0 - 10.0) * 100 / 200,
+				(100.0 - 10.0 - 40.0) * 100 / 100,
+				100 * 100.0 / 300.0,
+			},
+			expectedOverrideBurstLimitList: []int64{
+				(100.0 - 10.0) * 100 / 200,
+				50,
+				100 * 100 / 300,
+			},
 		},
 		{
 			name:                           "Proportional allocation with normalization check - case 2",


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- Update the allocation to set override fill rate proportionally based on fill rate settings.
- Modify the remaining service limit deduction to use the minimum of basic RU demand and the allocated override fill rate, allowing more flexible growth.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
