### PR TITLE
chore(dashboard): update TiDB Dashboard to v7.5.7-5498b71a [release-7.5]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20250526075340-5030ed622c15
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455
+	github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.55.0
 	github.com/sasha-s/go-deadlock v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455 h1:IiHAI1lf3GKHuzp8RWHEb7WPZF8JclbIlUeyGvpsSek=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf h1:vB+C20rTHZIPPrKAJD8WR8UrUSLaUB2H5kEpRV027qY=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/scripts/dashboard-version
+++ b/scripts/dashboard-version
@@ -1,3 +1,3 @@
 # This file is updated by running scripts/update-dashboard.sh
 # Don't edit it manullay
-7.5.7-c7c76895
+7.5.7-5498b71a

--- a/tests/integrations/client/go.mod
+++ b/tests/integrations/client/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/client/go.sum
+++ b/tests/integrations/client/go.sum
@@ -405,8 +405,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455 h1:IiHAI1lf3GKHuzp8RWHEb7WPZF8JclbIlUeyGvpsSek=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf h1:vB+C20rTHZIPPrKAJD8WR8UrUSLaUB2H5kEpRV027qY=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tests/integrations/mcs/go.mod
+++ b/tests/integrations/mcs/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/mcs/go.sum
+++ b/tests/integrations/mcs/go.sum
@@ -409,8 +409,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455 h1:IiHAI1lf3GKHuzp8RWHEb7WPZF8JclbIlUeyGvpsSek=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf h1:vB+C20rTHZIPPrKAJD8WR8UrUSLaUB2H5kEpRV027qY=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tests/integrations/tso/go.mod
+++ b/tests/integrations/tso/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/tso/go.sum
+++ b/tests/integrations/tso/go.sum
@@ -403,8 +403,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455 h1:IiHAI1lf3GKHuzp8RWHEb7WPZF8JclbIlUeyGvpsSek=
-github.com/pingcap/tidb-dashboard v0.0.0-20250714160803-c7c768954455/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf h1:vB+C20rTHZIPPrKAJD8WR8UrUSLaUB2H5kEpRV027qY=
+github.com/pingcap/tidb-dashboard v0.0.0-20250801104359-5498b71a21cf/go.mod h1:McTdWRKS3qYzn1QO9jXwMtoUjxTCCNR1EkeXcAj0otk=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4257

Update TiDB Dashboard to [v7.5.7-5498b71a](https://github.com/pingcap/tidb-dashboard/releases/tag/v7.5.7-5498b71a).

### Release note

```release-note
None
```