### PR TITLE
mcs: reduce some unnecessary logs

### DIFF
--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -191,7 +191,7 @@ var (
 	ErrSchedulerConfig                  = errors.Normalize("wrong scheduler config %s", errors.RFCCodeText("PD:scheduler:ErrSchedulerConfig"))
 	ErrCacheOverflow                    = errors.Normalize("cache overflow", errors.RFCCodeText("PD:scheduler:ErrCacheOverflow"))
 	ErrInternalGrowth                   = errors.Normalize("unknown interval growth type error", errors.RFCCodeText("PD:scheduler:ErrInternalGrowth"))
-	ErrSchedulerCreateFuncNotRegistered = errors.Normalize("create func of %v is not registered", errors.RFCCodeText("PD:scheduler:ErrSchedulerCreateFuncNotRegistered"))
+	ErrSchedulerCreateFuncNotRegistered = errors.Normalize("create func is not registered", errors.RFCCodeText("PD:scheduler:ErrSchedulerCreateFuncNotRegistered"))
 	ErrSchedulerTiKVSplitDisabled       = errors.Normalize("tikv split region disabled", errors.RFCCodeText("PD:scheduler:ErrSchedulerTiKVSplitDisabled"))
 )
 

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -362,7 +362,7 @@ func (c *Cluster) updateScheduler() {
 			}
 			name := s.GetName()
 			if existed, _ := schedulersController.IsSchedulerExisted(name); existed {
-				log.Info("scheduler has already existed, skip adding it",
+				log.Debug("scheduler has already existed, skip adding it",
 					zap.String("scheduler-name", name),
 					zap.Strings("scheduler-args", scheduler.Args))
 				continue

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -326,7 +326,7 @@ func (c *Coordinator) InitSchedulers(needRun bool) {
 		s, err := schedulers.CreateScheduler(tp, c.opController,
 			c.cluster.GetStorage(), schedulers.ConfigSliceDecoder(tp, schedulerCfg.Args), c.schedulers.RemoveScheduler)
 		if err != nil {
-			log.Error("can not create scheduler", zap.Stringer("type", tp), zap.String("scheduler-type", schedulerCfg.Type),
+			log.Error("can not create scheduler", zap.String("scheduler-type", schedulerCfg.Type),
 				zap.Strings("scheduler-args", schedulerCfg.Args), errs.ZapError(err))
 			continue
 		}

--- a/pkg/schedule/schedulers/config.go
+++ b/pkg/schedule/schedulers/config.go
@@ -102,6 +102,6 @@ func (b *baseDefaultSchedulerConfig) setDisable(disabled bool) error {
 	b.Lock()
 	defer b.Unlock()
 	b.Disabled = disabled
-	log.Info("set scheduler disable", zap.Bool("disabled", disabled))
+	log.Debug("set scheduler disable", zap.Bool("disabled", disabled))
 	return b.save()
 }

--- a/pkg/schedule/schedulers/scheduler.go
+++ b/pkg/schedule/schedulers/scheduler.go
@@ -158,7 +158,7 @@ func CreateScheduler(
 ) (Scheduler, error) {
 	fn, ok := schedulerMap[typ]
 	if !ok {
-		return nil, errs.ErrSchedulerCreateFuncNotRegistered.FastGenByArgs(typ)
+		return nil, errs.ErrSchedulerCreateFuncNotRegistered.FastGenByArgs()
 	}
 
 	return fn(oc, storage, dec, removeSchedulerCb...)

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -16,7 +16,6 @@ package schedulers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -298,7 +297,7 @@ func (c *Controller) PauseOrResumeScheduler(name string, t int64) error {
 // ReloadSchedulerConfig reloads a scheduler's config if it exists.
 func (c *Controller) ReloadSchedulerConfig(name string) error {
 	if exist, _ := c.IsSchedulerExisted(name); !exist {
-		return fmt.Errorf("scheduler %s is not existed", name)
+		return errs.ErrSchedulerNotFound.FastGenByArgs()
 	}
 	return c.GetScheduler(name).ReloadConfig()
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test

```
[2025/08/04 14:30:53.601 +08:00] [INFO] [watcher.go:189] ["update scheduler config"] [name=balance-region-scheduler] [value="{\"disabled\":false,\"ranges\":[{\"end-key\":\"\",\"start-key\":\"\"}]}"]
[2025/08/04 14:30:53.601 +08:00] [ERROR] [etcdutil.go:594] ["put failed in watch loop"] [error="scheduler balance-region-scheduler is not existed"] [revision=9] [name=scheduling-scheduler-config-watcher] [watch-key
=/pd/7534614101345316697/scheduler_config] [event-kv-key=/pd/7534614101345316697/scheduler_config/balance-region-scheduler]
[2025/08/04 14:30:53.602 +08:00] [INFO] [watcher.go:189] ["update scheduler config"] [name=balance-region-scheduler] [value="{\"disabled\":false,\"ranges\":[{\"end-key\":\"\",\"start-key\":\"\"}]}"]
[2025/08/04 14:30:53.602 +08:00] [ERROR] [etcdutil.go:594] ["put failed in watch loop"] [error="scheduler balance-region-scheduler is not existed"] [revision=25] [name=scheduling-scheduler-config-watcher] [watch-ke
y=/pd/7534614101345316697/scheduler_config] [event-kv-key=/pd/7534614101345316697/scheduler_config/balance-region-scheduler]
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
