### PR TITLE
server/api: Return pseudo service safe point for gc_worker to provide compabitility for some existing tests of CDC (#9626)

### DIFF
--- a/tools/pd-ctl/tests/safepoint/safepoint_test.go
+++ b/tools/pd-ctl/tests/safepoint/safepoint_test.go
@@ -17,6 +17,7 @@ package safepoint_test
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"sort"
 	"testing"
 	"time"
@@ -51,19 +52,28 @@ func TestSafepoint(t *testing.T) {
 	list := &api.ListServiceGCSafepoint{
 		ServiceGCSafepoints: []*endpoint.ServiceSafePoint{
 			{
-				ServiceID: "AAA",
-				ExpiredAt: now.Unix() + 10,
-				SafePoint: 1,
+				ServiceID:  "AAA",
+				ExpiredAt:  now.Unix() + 10,
+				SafePoint:  10,
+				KeyspaceID: constant.NullKeyspaceID,
 			},
 			{
-				ServiceID: "BBB",
-				ExpiredAt: now.Unix() + 10,
-				SafePoint: 2,
+				ServiceID:  "BBB",
+				ExpiredAt:  now.Unix() + 10,
+				SafePoint:  20,
+				KeyspaceID: constant.NullKeyspaceID,
 			},
 			{
-				ServiceID: "CCC",
-				ExpiredAt: now.Unix() + 10,
-				SafePoint: 3,
+				ServiceID:  "CCC",
+				ExpiredAt:  now.Unix() + 10,
+				SafePoint:  30,
+				KeyspaceID: constant.NullKeyspaceID,
+			},
+			{
+				ServiceID:  "gc_worker",
+				ExpiredAt:  math.MaxInt64,
+				SafePoint:  1,
+				KeyspaceID: constant.NullKeyspaceID,
 			},
 		},
 		GCSafePoint:           1,
@@ -71,7 +81,8 @@ func TestSafepoint(t *testing.T) {
 	}
 
 	gcStateManager := leaderServer.GetServer().GetGCStateManager()
-	for _, ssp := range list.ServiceGCSafepoints {
+	// Skip writing "gc_worker.
+	for _, ssp := range list.ServiceGCSafepoints[:3] {
 		_, _, err = gcStateManager.CompatibleUpdateServiceGCSafePoint(constant.NullKeyspaceID, ssp.ServiceID, ssp.SafePoint, ssp.ExpiredAt-now.Unix(), now)
 		re.NoError(err)
 	}
@@ -92,7 +103,7 @@ func TestSafepoint(t *testing.T) {
 	// test if the points are what we expected
 	re.Equal(uint64(1), l.GCSafePoint)
 	re.Equal(uint64(1), l.MinServiceGcSafepoint)
-	re.Len(l.ServiceGCSafepoints, 3)
+	re.Len(l.ServiceGCSafepoints, 4)
 
 	// sort the gc safepoints based on order of ServiceID
 	sort.Slice(l.ServiceGCSafepoints, func(i, j int) bool {
@@ -119,12 +130,14 @@ func TestSafepoint(t *testing.T) {
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 
+	// "gc_worker" will still exist in the result set as it's pseudo.
 	var ll api.ListServiceGCSafepoint
 	re.NoError(json.Unmarshal(output, &ll))
 
 	re.Equal(uint64(1), ll.GCSafePoint)
-	re.Equal(uint64(0), ll.MinServiceGcSafepoint)
-	re.Empty(ll.ServiceGCSafepoints)
+	re.Equal(uint64(1), ll.MinServiceGcSafepoint)
+	re.Len(ll.ServiceGCSafepoints, 1)
+	re.Equal("gc_worker", ll.ServiceGCSafepoints[0].ServiceID)
 
 	// try delete the "gc_worker"
 	args = []string{"-u", pdAddr, "service-gc-safepoint", "delete", "gc_worker"}
@@ -136,6 +149,17 @@ func TestSafepoint(t *testing.T) {
 	var msg string
 	re.NoError(json.Unmarshal(output, &msg))
 	re.Equal("Delete service GC safepoint successfully.", msg)
+
+	// "gc_worker" still exist after the deletion as it's pseudo.
+	args = []string{"-u", pdAddr, "service-gc-safepoint"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.NoError(json.Unmarshal(output, &ll))
+
+	re.Equal(uint64(1), ll.GCSafePoint)
+	re.Equal(uint64(1), ll.MinServiceGcSafepoint)
+	re.Len(ll.ServiceGCSafepoints, 1)
+	re.Equal("gc_worker", ll.ServiceGCSafepoints[0].ServiceID)
 
 	// try delete a non-exist safepoint, should return normally
 	args = []string{"-u", pdAddr, "service-gc-safepoint", "delete", "non_exist"}


### PR DESCRIPTION
Cherry-picks #9626 to release-next-gen-20250815 branch

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #8978

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Make the service safe point HTTP API return a pseudo service safe point for "gc_worker". 
```

There's some existing integration tests of CDC that assumes the minimal service safe point returned by the command `pd-ctl service-gc-safepoint` should be the lower bound of readable snapshots. However, as new GC states API is adopted, the result of this command becomes 1-to-1 mapped from GC barriers,  and the thing whose semantics matches those tests' requirement becomes the txn safe point. As new GC states related HTTP APIs and pd-ctl commands are not yet implemented, we provide this compatibility logic to make them work.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Increased code complexity

Related changes

\-

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```

