### PR TITLE
testutil: fix LastHeartbeat assignment and streamline PutMetaStore call

### DIFF
--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -873,22 +873,19 @@ func TestRemovingProgress(t *testing.T) {
 	re.Nil(resp.GetHeader().GetError())
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        1,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        2,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        3,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 	}
 
@@ -1109,35 +1106,30 @@ func TestPreparingProgress(t *testing.T) {
 			Id:             1,
 			State:          metapb.StoreState_Up,
 			NodeState:      metapb.NodeState_Serving,
-			LastHeartbeat:  time.Now().UnixNano(),
 			StartTimestamp: time.Now().UnixNano() - 100,
 		},
 		{
 			Id:             2,
 			State:          metapb.StoreState_Up,
 			NodeState:      metapb.NodeState_Serving,
-			LastHeartbeat:  time.Now().UnixNano(),
 			StartTimestamp: time.Now().UnixNano() - 100,
 		},
 		{
 			Id:             3,
 			State:          metapb.StoreState_Up,
 			NodeState:      metapb.NodeState_Serving,
-			LastHeartbeat:  time.Now().UnixNano(),
 			StartTimestamp: time.Now().UnixNano() - 100,
 		},
 		{
 			Id:             4,
 			State:          metapb.StoreState_Up,
 			NodeState:      metapb.NodeState_Preparing,
-			LastHeartbeat:  time.Now().UnixNano(),
 			StartTimestamp: time.Now().UnixNano() - 100,
 		},
 		{
 			Id:             5,
 			State:          metapb.StoreState_Up,
 			NodeState:      metapb.NodeState_Preparing,
-			LastHeartbeat:  time.Now().UnixNano(),
 			StartTimestamp: time.Now().UnixNano() - 100,
 		},
 	}

--- a/tests/server/api/operator_test.go
+++ b/tests/server/api/operator_test.go
@@ -65,22 +65,19 @@ func (suite *operatorTestSuite) checkAddRemovePeer(cluster *tests.TestCluster) {
 	pauseAllCheckers(re, cluster)
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        1,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        2,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        3,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 	}
 
@@ -174,22 +171,19 @@ func (suite *operatorTestSuite) checkMergeRegionOperator(cluster *tests.TestClus
 	re := suite.Require()
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        1,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        2,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        3,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 	}
 
@@ -238,25 +232,22 @@ func (suite *operatorTestSuite) checkTransferRegionWithPlacementRule(cluster *te
 	pauseAllCheckers(re, cluster)
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
-			Labels:        []*metapb.StoreLabel{{Key: "key", Value: "1"}},
+			Id:        1,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
+			Labels:    []*metapb.StoreLabel{{Key: "key", Value: "1"}},
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
-			Labels:        []*metapb.StoreLabel{{Key: "key", Value: "2"}},
+			Id:        2,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
+			Labels:    []*metapb.StoreLabel{{Key: "key", Value: "2"}},
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
-			Labels:        []*metapb.StoreLabel{{Key: "key", Value: "3"}},
+			Id:        3,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
+			Labels:    []*metapb.StoreLabel{{Key: "key", Value: "3"}},
 		},
 	}
 
@@ -518,22 +509,19 @@ func (suite *operatorTestSuite) checkGetOperatorsAsObject(cluster *tests.TestClu
 	pauseAllCheckers(re, cluster)
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        1,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        2,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        3,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 	}
 
@@ -613,22 +601,19 @@ func (suite *operatorTestSuite) checkRemoveOperators(cluster *tests.TestCluster)
 	re := suite.Require()
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        1,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        2,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        4,
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		},
 	}
 

--- a/tests/server/api/scheduler_test.go
+++ b/tests/server/api/scheduler_test.go
@@ -84,10 +84,9 @@ func (suite *scheduleTestSuite) checkOriginAPI(cluster *tests.TestCluster) {
 	urlPrefix := fmt.Sprintf("%s/pd/api/v1/schedulers", leaderAddr)
 	for i := 1; i <= 4; i++ {
 		store := &metapb.Store{
-			Id:            uint64(i),
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        uint64(i),
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		}
 		tests.MustPutStore(re, cluster, store)
 	}
@@ -166,10 +165,9 @@ func (suite *scheduleTestSuite) checkAPI(cluster *tests.TestCluster) {
 	urlPrefix := fmt.Sprintf("%s/pd/api/v1/schedulers", leaderAddr)
 	for i := 1; i <= 4; i++ {
 		store := &metapb.Store{
-			Id:            uint64(i),
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        uint64(i),
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		}
 		tests.MustPutStore(re, cluster, store)
 	}
@@ -621,10 +619,9 @@ func (suite *scheduleTestSuite) checkDisable(cluster *tests.TestCluster) {
 	urlPrefix := fmt.Sprintf("%s/pd/api/v1/schedulers", leaderAddr)
 	for i := 1; i <= 4; i++ {
 		store := &metapb.Store{
-			Id:            uint64(i),
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        uint64(i),
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		}
 		tests.MustPutStore(re, cluster, store)
 	}
@@ -733,10 +730,9 @@ func (suite *scheduleTestSuite) checkEmptySchedulers(cluster *tests.TestCluster)
 	urlPrefix := fmt.Sprintf("%s/pd/api/v1/schedulers", leaderAddr)
 	for i := 1; i <= 4; i++ {
 		store := &metapb.Store{
-			Id:            uint64(i),
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        uint64(i),
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		}
 		tests.MustPutStore(re, cluster, store)
 	}

--- a/tests/server/storage/hot_region_storage_test.go
+++ b/tests/server/storage/hot_region_storage_test.go
@@ -57,14 +57,12 @@ func TestHotRegionStorage(t *testing.T) {
 	re.NotEmpty(cluster.WaitLeader())
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 	}
 
@@ -167,14 +165,12 @@ func TestHotRegionStorageReservedDayConfigChange(t *testing.T) {
 	re.NotEmpty(cluster.WaitLeader())
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 	}
 
@@ -262,14 +258,12 @@ func TestHotRegionStorageWriteIntervalConfigChange(t *testing.T) {
 	re.NotEmpty(cluster.WaitLeader())
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 	}
 

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -227,11 +227,10 @@ func MustPutStore(re *require.Assertions, tc *TestCluster, store *metapb.Store) 
 		// Wait for the raft cluster on the leader to be bootstrapped.
 		return raftCluster != nil && raftCluster.IsRunning()
 	})
-	re.NoError(raftCluster.PutMetaStore(store))
-	ts := store.GetLastHeartbeat()
-	if ts == 0 {
-		ts = time.Now().UnixNano()
+	if store.LastHeartbeat == 0 {
+		store.LastHeartbeat = time.Now().UnixNano()
 	}
+	re.NoError(raftCluster.PutMetaStore(store))
 
 	storeInfo := raftCluster.GetStore(store.GetId())
 	newStore := storeInfo.Clone(
@@ -242,7 +241,6 @@ func MustPutStore(re *require.Assertions, tc *TestCluster, store *metapb.Store) 
 		}),
 		core.SetStoreState(store.GetState(), store.GetPhysicallyDestroyed()),
 		core.SetNodeState(store.GetNodeState()),
-		core.SetLastHeartbeatTS(time.Unix(ts/1e9, ts%1e9)),
 	)
 	raftCluster.GetBasicCluster().PutStore(newStore)
 	raftCluster.UpdateAllStoreStatus()

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -231,6 +231,10 @@ func MustPutStore(re *require.Assertions, tc *TestCluster, store *metapb.Store) 
 		store.LastHeartbeat = time.Now().UnixNano()
 	}
 	re.NoError(raftCluster.PutMetaStore(store))
+	ts := store.GetLastHeartbeat()
+	if ts == 0 {
+		ts = time.Now().UnixNano()
+	}
 
 	storeInfo := raftCluster.GetStore(store.GetId())
 	newStore := storeInfo.Clone(
@@ -241,6 +245,7 @@ func MustPutStore(re *require.Assertions, tc *TestCluster, store *metapb.Store) 
 		}),
 		core.SetStoreState(store.GetState(), store.GetPhysicallyDestroyed()),
 		core.SetNodeState(store.GetNodeState()),
+		core.SetLastHeartbeatTS(time.Unix(ts/1e9, ts%1e9)),
 	)
 	raftCluster.GetBasicCluster().PutStore(newStore)
 	raftCluster.UpdateAllStoreStatus()

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -570,9 +570,8 @@ func (suite *configTestSuite) checkPlacementRules(cluster *pdTests.TestCluster) 
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	pdTests.MustPutStore(re, cluster, store)
 
@@ -639,9 +638,8 @@ func (suite *configTestSuite) checkPlacementRuleGroups(cluster *pdTests.TestClus
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	pdTests.MustPutStore(re, cluster, store)
 	output, err := tests.ExecuteCommand(cmd, "-u", pdAddr, "config", "placement-rules", "enable")
@@ -716,9 +714,8 @@ func (suite *configTestSuite) checkPlacementRuleBundle(cluster *pdTests.TestClus
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	pdTests.MustPutStore(re, cluster, store)
 
@@ -908,9 +905,8 @@ func TestReplicationMode(t *testing.T) {
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetLeaderServer()
 	re.NoError(leaderServer.BootstrapCluster())
@@ -967,9 +963,8 @@ func TestServiceMiddlewareConfig(t *testing.T) {
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetLeaderServer()
 	re.NoError(leaderServer.BootstrapCluster())
@@ -1250,9 +1245,8 @@ func (suite *configTestSuite) checkPDServerConfig(cluster *pdTests.TestCluster) 
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	pdTests.MustPutStore(re, cluster, store)
 
@@ -1283,9 +1277,8 @@ func (suite *configTestSuite) checkMicroserviceConfig(cluster *pdTests.TestClust
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	pdTests.MustPutStore(re, cluster, store)
 	svr := leaderServer.GetServer()

--- a/tools/pd-ctl/tests/hot/hot_test.go
+++ b/tools/pd-ctl/tests/hot/hot_test.go
@@ -80,15 +80,13 @@ func (suite *hotTestSuite) checkHot(cluster *pdTests.TestCluster) {
 	cmd := ctl.GetRootCmd()
 
 	store1 := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	store2 := &metapb.Store{
-		Id:            2,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
-		Labels:        []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}},
+		Id:     2,
+		State:  metapb.StoreState_Up,
+		Labels: []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}},
 	}
 
 	pdTests.MustPutStore(re, cluster, store1)
@@ -251,14 +249,12 @@ func (suite *hotTestSuite) checkHotWithStoreID(cluster *pdTests.TestCluster) {
 
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 	}
 
@@ -317,14 +313,12 @@ func (suite *hotTestSuite) checkHotWithoutHotPeer(cluster *pdTests.TestCluster) 
 
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 	}
 
@@ -412,19 +406,16 @@ func TestHistoryHotRegions(t *testing.T) {
 
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    3,
+			State: metapb.StoreState_Up,
 		},
 	}
 
@@ -529,14 +520,12 @@ func TestBuckets(t *testing.T) {
 
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 	}
 

--- a/tools/pd-ctl/tests/label/label_test.go
+++ b/tools/pd-ctl/tests/label/label_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -57,7 +56,6 @@ func TestLabel(t *testing.T) {
 							Value: "us-west",
 						},
 					},
-					LastHeartbeat: time.Now().UnixNano(),
 				},
 				StateName: metapb.StoreState_Up.String(),
 			},
@@ -73,7 +71,6 @@ func TestLabel(t *testing.T) {
 							Value: "us-east",
 						},
 					},
-					LastHeartbeat: time.Now().UnixNano(),
 				},
 				StateName: metapb.StoreState_Up.String(),
 			},
@@ -89,7 +86,6 @@ func TestLabel(t *testing.T) {
 							Value: "us-west",
 						},
 					},
-					LastHeartbeat: time.Now().UnixNano(),
 				},
 				StateName: metapb.StoreState_Up.String(),
 			},

--- a/tools/pd-ctl/tests/region/region_test.go
+++ b/tools/pd-ctl/tests/region/region_test.go
@@ -50,9 +50,8 @@ func TestRegionKeyFormat(t *testing.T) {
 	re.NotEmpty(cluster.WaitLeader())
 	url := cluster.GetConfig().GetClientURL()
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetLeaderServer()
 	re.NoError(leaderServer.BootstrapCluster())
@@ -78,9 +77,8 @@ func TestRegion(t *testing.T) {
 	cmd := ctl.GetRootCmd()
 
 	store := &metapb.Store{
-		Id:            1,
-		State:         metapb.StoreState_Up,
-		LastHeartbeat: time.Now().UnixNano(),
+		Id:    1,
+		State: metapb.StoreState_Up,
 	}
 	leaderServer := cluster.GetLeaderServer()
 	re.NoError(leaderServer.BootstrapCluster())
@@ -282,19 +280,16 @@ func TestRegionNoLeader(t *testing.T) {
 	url := cluster.GetConfig().GetClientURL()
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    3,
+			State: metapb.StoreState_Up,
 		},
 	}
 

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -61,24 +61,20 @@ func (suite *schedulerTestSuite) SetupTest() {
 	suite.env.RunFunc(func(cluster *pdTests.TestCluster) {
 		stores := []*metapb.Store{
 			{
-				Id:            1,
-				State:         metapb.StoreState_Up,
-				LastHeartbeat: time.Now().UnixNano(),
+				Id:    1,
+				State: metapb.StoreState_Up,
 			},
 			{
-				Id:            2,
-				State:         metapb.StoreState_Up,
-				LastHeartbeat: time.Now().UnixNano(),
+				Id:    2,
+				State: metapb.StoreState_Up,
 			},
 			{
-				Id:            3,
-				State:         metapb.StoreState_Up,
-				LastHeartbeat: time.Now().UnixNano(),
+				Id:    3,
+				State: metapb.StoreState_Up,
 			},
 			{
-				Id:            4,
-				State:         metapb.StoreState_Up,
-				LastHeartbeat: time.Now().UnixNano(),
+				Id:    4,
+				State: metapb.StoreState_Up,
 			},
 		}
 		for _, store := range stores {
@@ -911,24 +907,20 @@ func TestHotSchedulerUpgrade(t *testing.T) {
 	cmd := ctl.GetRootCmd()
 	stores := []*metapb.Store{
 		{
-			Id:            1,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    1,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            2,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    2,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            3,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    3,
+			State: metapb.StoreState_Up,
 		},
 		{
-			Id:            4,
-			State:         metapb.StoreState_Up,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:    4,
+			State: metapb.StoreState_Up,
 		},
 	}
 	for _, store := range stores {

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -89,10 +89,9 @@ func TestStore(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            1,
-					State:         metapb.StoreState_Up,
-					NodeState:     metapb.NodeState_Serving,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        1,
+					State:     metapb.StoreState_Up,
+					NodeState: metapb.NodeState_Serving,
 				},
 				StateName: metapb.StoreState_Up.String(),
 			},
@@ -100,10 +99,9 @@ func TestStore(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            3,
-					State:         metapb.StoreState_Up,
-					NodeState:     metapb.NodeState_Serving,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        3,
+					State:     metapb.StoreState_Up,
+					NodeState: metapb.NodeState_Serving,
 				},
 				StateName: metapb.StoreState_Up.String(),
 			},
@@ -111,10 +109,9 @@ func TestStore(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            2,
-					State:         metapb.StoreState_Tombstone,
-					NodeState:     metapb.NodeState_Removed,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        2,
+					State:     metapb.StoreState_Tombstone,
+					NodeState: metapb.NodeState_Removed,
 				},
 				StateName: metapb.StoreState_Tombstone.String(),
 			},
@@ -330,10 +327,9 @@ func TestStore(t *testing.T) {
 	// put enough stores for replica.
 	for id := 1000; id <= 1005; id++ {
 		store2 := &metapb.Store{
-			Id:            uint64(id),
-			State:         metapb.StoreState_Up,
-			NodeState:     metapb.NodeState_Serving,
-			LastHeartbeat: time.Now().UnixNano(),
+			Id:        uint64(id),
+			State:     metapb.StoreState_Up,
+			NodeState: metapb.NodeState_Serving,
 		}
 		pdTests.MustPutStore(re, cluster, store2)
 	}
@@ -511,10 +507,9 @@ func TestTombstoneStore(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            2,
-					State:         metapb.StoreState_Tombstone,
-					NodeState:     metapb.NodeState_Removed,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        2,
+					State:     metapb.StoreState_Tombstone,
+					NodeState: metapb.NodeState_Removed,
 				},
 				StateName: metapb.StoreState_Tombstone.String(),
 			},
@@ -522,10 +517,9 @@ func TestTombstoneStore(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            3,
-					State:         metapb.StoreState_Tombstone,
-					NodeState:     metapb.NodeState_Removed,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        3,
+					State:     metapb.StoreState_Tombstone,
+					NodeState: metapb.NodeState_Removed,
 				},
 				StateName: metapb.StoreState_Tombstone.String(),
 			},
@@ -533,10 +527,9 @@ func TestTombstoneStore(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            4,
-					State:         metapb.StoreState_Tombstone,
-					NodeState:     metapb.NodeState_Removed,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        4,
+					State:     metapb.StoreState_Tombstone,
+					NodeState: metapb.NodeState_Removed,
 				},
 				StateName: metapb.StoreState_Tombstone.String(),
 			},
@@ -611,10 +604,9 @@ func TestStoreTLS(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            1,
-					State:         metapb.StoreState_Up,
-					NodeState:     metapb.NodeState_Serving,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        1,
+					State:     metapb.StoreState_Up,
+					NodeState: metapb.NodeState_Serving,
 				},
 				StateName: metapb.StoreState_Up.String(),
 			},
@@ -622,10 +614,9 @@ func TestStoreTLS(t *testing.T) {
 		{
 			Store: &response.MetaStore{
 				Store: &metapb.Store{
-					Id:            2,
-					State:         metapb.StoreState_Up,
-					NodeState:     metapb.NodeState_Serving,
-					LastHeartbeat: time.Now().UnixNano(),
+					Id:        2,
+					State:     metapb.StoreState_Up,
+					NodeState: metapb.NodeState_Serving,
 				},
 				StateName: metapb.StoreState_Up.String(),
 			},


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/9481

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

`NodeState_Removed` store may be removed from memory due to its `LastHeartbeat` is zero

https://github.com/tikv/pd/blob/a1d89da95263b0407c6fb5d1c01d86f5e2329b45/server/cluster/cluster.go#L1856-L1861

```commit-message
test: fix flaky test that store may panic during test
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
