### PR TITLE
server/api: Add PD HTTP Endpoints for PiTR Restore Mode Marker

### DIFF
--- a/pkg/utils/keypath/absolute_key_path.go
+++ b/pkg/utils/keypath/absolute_key_path.go
@@ -44,9 +44,10 @@ const (
 	storeLeaderWeightPathFormat = "/pd/%d/schedule/store_weight/%020d/leader" // "/pd/{cluster_id}/schedule/store_weight/{store_id}/leader"
 	storeRegionWeightPathFormat = "/pd/%d/schedule/store_weight/%020d/region" // "/pd/{cluster_id}/schedule/store_weight/{store_id}/region"
 
-	serviceMiddlewarePathFormat = "/pd/%d/service_middleware"                  // "/pd/{cluster_id}/service_middleware"
-	replicationModePathFormat   = "/pd/%d/replication_mode/%s"                 // "/pd/{cluster_id}/replication_mode/{mode}"
-	recoveringMarkPathFormat    = "/pd/%d/cluster/markers/snapshot-recovering" // "/pd/{cluster_id}/cluster/markers/snapshot-recovering"
+	serviceMiddlewarePathFormat  = "/pd/%d/service_middleware"                  // "/pd/{cluster_id}/service_middleware"
+	replicationModePathFormat    = "/pd/%d/replication_mode/%s"                 // "/pd/{cluster_id}/replication_mode/{mode}"
+	recoveringMarkPathFormat     = "/pd/%d/cluster/markers/snapshot-recovering" // "/pd/{cluster_id}/cluster/markers/snapshot-recovering"
+	pitrRecoveringMarkPathFormat = "/pd/%d/cluster/markers/pitr-recovering"     // "/pd/{cluster_id}/cluster/markers/pitr-recovering"
 
 	memberBinaryDeployPathFormat   = "/pd/%d/member/%d/deploy_path"     // "/pd/{cluster_id}/member/{member_id}/deploy_path"
 	memberGitHashPath              = "/pd/%d/member/%d/git_hash"        // "/pd/{cluster_id}/member/{member_id}/git_hash"
@@ -201,6 +202,11 @@ func ExternalTimestampPath() string {
 // RecoveringMarkPath returns the path to save the recovering mark.
 func RecoveringMarkPath() string {
 	return fmt.Sprintf(recoveringMarkPathFormat, ClusterID())
+}
+
+// PitrRecoveringMarkPath returns the path to save the pitr recovering mark.
+func PitrRecoveringMarkPath() string {
+	return fmt.Sprintf(pitrRecoveringMarkPathFormat, ClusterID())
 }
 
 // KeyspaceMetaPrefix returns the prefix of keyspaces' metadata.

--- a/server/api/admin.go
+++ b/server/api/admin.go
@@ -193,6 +193,34 @@ func (h *adminHandler) unmarkSnapshotRecovering(w http.ResponseWriter, r *http.R
 	h.rd.Text(w, http.StatusOK, "")
 }
 
+func (h *adminHandler) markPitrRecovering(w http.ResponseWriter, _ *http.Request) {
+	if err := h.svr.MarkPitrRecovering(); err != nil {
+		h.rd.Text(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.rd.Text(w, http.StatusOK, "")
+}
+
+func (h *adminHandler) isPitrRecovering(w http.ResponseWriter, r *http.Request) {
+	marked, err := h.svr.IsPitrRecovering(r.Context())
+	if err != nil {
+		h.rd.Text(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	type resStruct struct {
+		Marked bool `json:"marked"`
+	}
+	h.rd.JSON(w, http.StatusOK, &resStruct{Marked: marked})
+}
+
+func (h *adminHandler) unmarkPitrRecovering(w http.ResponseWriter, r *http.Request) {
+	if err := h.svr.UnmarkPitrRecovering(r.Context()); err != nil {
+		h.rd.Text(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.rd.Text(w, http.StatusOK, "")
+}
+
 // RecoverAllocID recover base alloc id
 // body should be in {"id": "123"} format
 func (h *adminHandler) recoverAllocID(w http.ResponseWriter, r *http.Request) {

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -313,6 +313,9 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(apiRouter, "/admin/cluster/markers/snapshot-recovering", adminHandler.isSnapshotRecovering, setMethods(http.MethodGet), setAuditBackend(localLog, prometheus))
 	registerFunc(apiRouter, "/admin/cluster/markers/snapshot-recovering", adminHandler.markSnapshotRecovering, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(apiRouter, "/admin/cluster/markers/snapshot-recovering", adminHandler.unmarkSnapshotRecovering, setMethods(http.MethodDelete), setAuditBackend(localLog, prometheus))
+	registerFunc(apiRouter, "/admin/cluster/markers/pitr-recovering", adminHandler.isPitrRecovering, setMethods(http.MethodGet), setAuditBackend(localLog, prometheus))
+	registerFunc(apiRouter, "/admin/cluster/markers/pitr-recovering", adminHandler.markPitrRecovering, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
+	registerFunc(apiRouter, "/admin/cluster/markers/pitr-recovering", adminHandler.unmarkPitrRecovering, setMethods(http.MethodDelete), setAuditBackend(localLog, prometheus))
 	registerFunc(apiRouter, "/admin/base-alloc-id", adminHandler.recoverAllocID, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 
 	serviceMiddlewareHandler := newServiceMiddlewareHandler(svr, rd)

--- a/tests/server/api/admin_test.go
+++ b/tests/server/api/admin_test.go
@@ -301,6 +301,10 @@ func (suite *adminTestSuite) TestMarkSnapshotRecovering() {
 	suite.env.RunTest(suite.checkMarkSnapshotRecovering)
 }
 
+func (suite *adminTestSuite) TestMarkPitrRecovering() {
+	suite.env.RunTest(suite.checkMarkPitrRecovering)
+}
+
 func (suite *adminTestSuite) checkMarkSnapshotRecovering(cluster *tests.TestCluster) {
 	re := suite.Require()
 	leader := cluster.GetLeaderServer()
@@ -320,6 +324,27 @@ func (suite *adminTestSuite) checkMarkSnapshotRecovering(cluster *tests.TestClus
 	resp, err2 := grpcServer.IsSnapshotRecovering(context.Background(), &pdpb.IsSnapshotRecoveringRequest{})
 	re.NoError(err2)
 	re.True(resp.Marked)
+	// unmark
+	err := testutil.CheckDelete(tests.TestDialClient, url, testutil.StatusOK(re))
+	re.NoError(err)
+	re.NoError(testutil.CheckGetJSON(tests.TestDialClient, url, nil,
+		testutil.StatusOK(re), testutil.StringContain(re, "false")))
+}
+
+func (suite *adminTestSuite) checkMarkPitrRecovering(cluster *tests.TestCluster) {
+	re := suite.Require()
+	leader := cluster.GetLeaderServer()
+	urlPrefix := leader.GetAddr() + "/pd/api/v1"
+	url := fmt.Sprintf("%s/admin/cluster/markers/pitr-recovering", urlPrefix)
+	// default to false
+	re.NoError(testutil.CheckGetJSON(tests.TestDialClient, url, nil,
+		testutil.StatusOK(re), testutil.StringContain(re, "false")))
+
+	// mark
+	re.NoError(testutil.CheckPostJSON(tests.TestDialClient, url, nil,
+		testutil.StatusOK(re)))
+	re.NoError(testutil.CheckGetJSON(tests.TestDialClient, url, nil,
+		testutil.StatusOK(re), testutil.StringContain(re, "true")))
 	// unmark
 	err := testutil.CheckDelete(tests.TestDialClient, url, testutil.StatusOK(re))
 	re.NoError(err)


### PR DESCRIPTION

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close [#9638 ](https://github.com/tikv/pd/issues/9638)

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

This PR adds a new set of PD HTTP endpoints (v1 API) to support a pitr-recovering marker, following the same pattern as the existing snapshot-recovering marker implementation.

### New endpoints:
- `GET /admin/cluster/markers/pitr-recovering` – check whether the pitr recovery marker is set
- `POST /admin/cluster/markers/pitr-recovering` – mark the cluster as under pitr recovery••
- `DELETE /admin/cluster/markers/pitr-recovering` – clear the pitr recovery marker

### Implementation details:

1. **Keypath support**: Added `pitrRecoveringMarkPathFormat` and `PitrRecoveringMarkPath()` function in `pkg/utils/keypath/absolute_key_path.go`

2. **Server functions**: Added three new methods to `server/server.go`:
   - `MarkPitrRecovering()` - Sets the PITR recovery marker in etcd
   - `IsPitrRecovering(ctx)` - Checks if PITR recovery marker exists
   - `UnmarkPitrRecovering(ctx)` - Removes the PITR recovery marker

3. **HTTP handlers**: Added corresponding HTTP handlers in `server/api/admin.go`:
   - `markPitrRecovering` - POST handler
   - `isPitrRecovering` - GET handler (returns JSON with `marked` boolean field)
   - `unmarkPitrRecovering` - DELETE handler

4. **Routing**: Added three route registrations in `server/api/router.go` with proper audit logging

5. **Testing**: Added comprehensive test `TestMarkPitrRecovering` that validates:
   - Default state (marker not set)
   - Setting the marker (POST)
   - Checking marker is set (GET returns true)
   - Clearing the marker (DELETE)
   - Verifying marker is cleared (GET returns false)
### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- [x] Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- [x] Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
