### PR TITLE
core: reset subRegions field in ResetRegionCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ embedded_assets_handler.go
 *.bin
 third_bin
 tmp*
+.specstory/
+.cursorindexingignore  

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1374,6 +1374,7 @@ func (r *RegionsInfo) ResetRegionCache() {
 	r.t.Lock()
 	r.tree = newRegionTreeWithCountRef()
 	r.regions = make(map[uint64]*regionItem)
+	r.subRegions = make(map[uint64]*regionItem)
 	r.t.Unlock()
 	r.st.Lock()
 	defer r.st.Unlock()

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1375,3 +1375,56 @@ func TestRegionCount(t *testing.T) {
 		re.Equal(count, scanCount, "startKey: %s", key)
 	}
 }
+
+func TestResetRegionCache(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+
+	// Create and add some regions
+	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("b"))
+	region2 := NewTestRegionInfo(2, 1, []byte("b"), []byte("c"))
+	region3 := NewTestRegionInfo(3, 1, []byte("c"), []byte("d"))
+
+	// Put regions to populate all the maps and trees
+	regions.CheckAndPutRegion(region1)
+	regions.CheckAndPutRegion(region2)
+	regions.CheckAndPutRegion(region3)
+
+	// Verify that regions are populated
+	re.Equal(3, regions.GetTotalRegionCount())
+	re.NotNil(regions.GetRegion(1))
+	re.NotNil(regions.GetRegion(2))
+	re.NotNil(regions.GetRegion(3))
+
+	// Verify that subRegions is populated
+	re.NotEmpty(regions.subRegions)
+
+	// Reset the cache
+	regions.ResetRegionCache()
+
+	// Verify that all fields are properly reset
+	re.Equal(0, regions.GetTotalRegionCount())
+	re.Nil(regions.GetRegion(1))
+	re.Nil(regions.GetRegion(2))
+	re.Nil(regions.GetRegion(3))
+
+	// Verify that subRegions is properly reset
+	re.Empty(regions.subRegions)
+
+	// Verify that all other maps are reset
+	re.Empty(regions.leaders)
+	re.Empty(regions.followers)
+	re.Empty(regions.learners)
+	re.Empty(regions.witnesses)
+	re.Empty(regions.pendingPeers)
+
+	// Verify that trees are reset
+	re.Equal(0, regions.tree.length())
+	re.Equal(0, regions.overlapTree.length())
+
+	// Verify that we can add new regions after reset
+	newRegion := NewTestRegionInfo(4, 1, []byte("d"), []byte("e"))
+	regions.CheckAndPutRegion(newRegion)
+	re.Equal(1, regions.GetTotalRegionCount())
+	re.NotNil(regions.GetRegion(4))
+}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/9657
### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
core: reset subRegions field in ResetRegionCache
The subRegions field was not being reset, which could lead to:
- Potential access to invalid subRegions data
- Inconsistent state after cache reset operations
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
