### PR TITLE
tsoutil: optimize TSO proxy request processing to improve stability and performance

### DIFF
--- a/pkg/utils/tsoutil/tso_dispatcher_test.go
+++ b/pkg/utils/tsoutil/tso_dispatcher_test.go
@@ -110,7 +110,7 @@ func (m *mockRequest) process(forwardStream stream, count uint32) (tsoResp, erro
 	return forwardStream.process(0, count, 0, 0)
 }
 
-func (m *mockRequest) postProcess(countSum int64, _ int64, _ int64) (int64, error) {
+func (m *mockRequest) postProcess(_ context.Context, countSum int64, _ int64, _ int64) (int64, error) {
 	close(m.doneCh)
 	return countSum, m.err
 }

--- a/pkg/utils/tsoutil/tso_request.go
+++ b/pkg/utils/tsoutil/tso_request.go
@@ -48,17 +48,15 @@ type PDProtoRequest struct {
 	forwardedHost string
 	clientConn    *grpc.ClientConn
 	request       *pdpb.TsoRequest
-	stream        pdpb.PD_TsoServer
 	tsoRespCh     chan *pdpb.TsoResponse
 }
 
 // NewPDProtoRequest creates a PDProtoRequest and returns as a Request
-func NewPDProtoRequest(forwardedHost string, clientConn *grpc.ClientConn, request *pdpb.TsoRequest, stream pdpb.PD_TsoServer, tsoRespCh chan *pdpb.TsoResponse) Request {
+func NewPDProtoRequest(forwardedHost string, clientConn *grpc.ClientConn, request *pdpb.TsoRequest, tsoRespCh chan *pdpb.TsoResponse) Request {
 	tsoRequest := &PDProtoRequest{
 		forwardedHost: forwardedHost,
 		clientConn:    clientConn,
 		request:       request,
-		stream:        stream,
 		tsoRespCh:     tsoRespCh,
 	}
 	return tsoRequest

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -564,7 +564,7 @@ func (s *GrpcServer) Tso(stream pdpb.PD_TsoServer) error {
 			}
 
 			start := time.Now()
-			tsoRequest := tsoutil.NewPDProtoRequest(forwardedHost, clientConn, request, stream, tsoRespCh)
+			tsoRequest := tsoutil.NewPDProtoRequest(forwardedHost, clientConn, request, tsoRespCh)
 			// don't pass a stream context here as dispatcher serves multiple streams
 			tsoRequestProxyCtx = s.tsoDispatcher.DispatchRequest(s.ctx, tsoRequest, s.pdProtoFactory, s.tsoPrimaryWatcher)
 			select {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -98,6 +98,15 @@ var (
 			Help:      "Counter of timeouts when tso proxy forwarding tso requests to tso service.",
 		})
 
+	tsoProxyChannelLatency = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "tso_proxy_channel_latency_seconds",
+			Help:      "Bucketed histogram of latency (s) of send/recv TSO from the tso dispatcher channel.",
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20), // 0.1ms ~ 104s
+		})
+
 	tsoHandleDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "pd",
@@ -212,6 +221,7 @@ func init() {
 	prometheus.MustRegister(tsoProxyHandleDuration)
 	prometheus.MustRegister(tsoProxyBatchSize)
 	prometheus.MustRegister(tsoProxyForwardTimeoutCounter)
+	prometheus.MustRegister(tsoProxyChannelLatency)
 	prometheus.MustRegister(tsoHandleDuration)
 	prometheus.MustRegister(queryRegionDuration)
 	prometheus.MustRegister(regionHeartbeatHandleDuration)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9662

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

We introduced a buffered channel for each TSO stream to resolve these issues:

1. Added a block channel (or a buffered channel tsoRespCh with capacity 2) in the gRPC service for each TSO stream
2. Modified PDProtoRequest.postProcess() to send responses to the channel instead of directly to the stream
3. Implemented a select statement with a default case that drops responses when the tso goroutine gone( or channel is full), preventing blocking

```commit-message
```

before this pr
<img width="659" height="305" alt="image" src="https://github.com/user-attachments/assets/c347b8b7-8315-410f-9ca4-c95a40a09a98" />



after this pr
<img width="657" height="574" alt="image" src="https://github.com/user-attachments/assets/81af0567-92f6-4dd7-a69f-3e12f27f8920" />


### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Code changes


Side effects


Related changes


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
