### PR TITLE
core: caller can't scan too much regions in one lock even if limit equals -1 

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -2061,8 +2061,6 @@ func (r *RegionsInfo) BatchScanRegions(keyRanges *keyutil.KeyRanges, opts ...Bat
 		opt(scanOptions)
 	}
 
-	r.t.RLock()
-	defer r.t.RUnlock()
 	for _, keyRange := range krs {
 		regions, err := r.scanRegion(keyRange, scanOptions.limit, scanOptions.outputMustContainAllKeyRange)
 		if err != nil {

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1163,20 +1163,21 @@ func TestCntRefAfterResetRegionCache(t *testing.T) {
 func TestScanRegion(t *testing.T) {
 	var (
 		re                   = require.New(t)
-		tree                 = newRegionTree()
+		r                    = NewRegionsInfo()
 		needContainAllRanges = true
 		regions              []*RegionInfo
 		err                  error
 	)
 	scanError := func(startKey, endKey []byte, limit int) {
-		regions, err = scanRegion(tree, &keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
+		regions, err = r.scanRegion(&keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
 		re.Error(err)
 	}
 	scanNoError := func(startKey, endKey []byte, limit int) []*RegionInfo {
-		regions, err = scanRegion(tree, &keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
+		regions, err = r.scanRegion(&keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
 		re.NoError(err)
 		return regions
 	}
+	tree := r.tree
 	// region1
 	// [a, b)
 	updateNewItem(tree, NewTestRegionInfo(1, 1, []byte("a"), []byte("b")))

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1363,7 +1363,7 @@ func TestStatsRegions(t *testing.T) {
 		regions.CheckAndPutRegion(NewTestRegionInfo(uint64(i), 1, []byte(fmt.Sprintf("%20d", i)), endKey))
 	}
 	startKey := []byte(fmt.Sprintf("%20d", 0))
-	for _, l := range []int{-1, maxScanRegionLimit - 1, maxScanRegionLimit, maxScanRegionLimit + 1, count} {
+	for _, l := range []int{-1, MaxScanRegionLimit - 1, MaxScanRegionLimit, MaxScanRegionLimit + 1, count} {
 		rs := regions.ScanRegions(startKey, nil, l)
 		limit := l
 		if limit <= 0 {
@@ -1378,7 +1378,7 @@ func TestStatsRegions(t *testing.T) {
 		re.Equal(startKey, rs[0].GetStartKey())
 	}
 
-	for _, startIdx := range []int{count - maxScanRegionLimit - 1, count - maxScanRegionLimit, count - maxScanRegionLimit + 1} {
+	for _, startIdx := range []int{count - MaxScanRegionLimit - 1, count - MaxScanRegionLimit, count - MaxScanRegionLimit + 1} {
 		if startIdx < 0 {
 			startIdx = 0
 		}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2068,21 +2068,13 @@ func (c *RaftCluster) PutMetaCluster(meta *metapb.Cluster) error {
 
 func (c *RaftCluster) getRegionStats(startKey, endKey []byte, useHot bool, opts ...statistics.GetRegionStatsOption) *statistics.RegionStats {
 	stats := statistics.NewRegionStats()
-	for {
-		regions := c.ScanRegions(startKey, endKey, core.ScanRegionLimit)
-
-		for _, region := range regions {
-			if useHot {
-				stats.Observe(region, c, opts...)
-			} else {
-				stats.Observe(region, nil, opts...)
-			}
+	regions := c.ScanRegions(startKey, endKey, -1)
+	for _, region := range regions {
+		if useHot {
+			stats.Observe(region, c, opts...)
+		} else {
+			stats.Observe(region, nil, opts...)
 		}
-		if len(regions) < core.ScanRegionLimit {
-			break
-		}
-
-		startKey = regions[len(regions)-1].GetEndKey()
 	}
 	return stats
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9674, Ref #9628

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
The caller can only scan the fixed regions in one lock.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes



Side effects



Related changes



### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
