### PR TITLE
feat(resourcemanager): add trickle-time enforcement to service limiter

### DIFF
--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -530,7 +530,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				if err != nil {
 					continue
 				}
-				setOrRemoveServiceLimitMetrics(keyspaceName, krgm.getServiceLimiter().GetServiceLimit())
+				setOrRemoveServiceLimitMetrics(keyspaceName, krgm.getServiceLimiter().getServiceLimit())
 
 				for _, group := range krgm.getResourceGroupList(true, true) {
 					groupName := group.Name

--- a/pkg/mcs/resourcemanager/server/service_limit.go
+++ b/pkg/mcs/resourcemanager/server/service_limit.go
@@ -159,7 +159,7 @@ func (krl *serviceLimiter) applyServiceLimit(
 	}
 
 	// Calculate a minimum trickle time to ensure the granted tokens' rate in client won't exceed the service limit.
-	minTrickleTimeMs = int64(limitedTokens * 1000.0 / krl.getServiceLimitLocked())
+	minTrickleTimeMs = int64(math.Round(limitedTokens * 1000.0 / krl.getServiceLimitLocked()))
 
 	return limitedTokens, minTrickleTimeMs
 }

--- a/pkg/mcs/resourcemanager/server/service_limit.go
+++ b/pkg/mcs/resourcemanager/server/service_limit.go
@@ -91,13 +91,16 @@ func (krl *serviceLimiter) setServiceLimit(newServiceLimit float64) {
 	}
 }
 
-// GetServiceLimit return the service limit value of this keyspace.
-func (krl *serviceLimiter) GetServiceLimit() float64 {
+func (krl *serviceLimiter) getServiceLimit() float64 {
 	if krl == nil {
 		return 0.0
 	}
 	krl.RLock()
 	defer krl.RUnlock()
+	return krl.getServiceLimitLocked()
+}
+
+func (krl *serviceLimiter) getServiceLimitLocked() float64 {
 	return krl.ServiceLimit
 }
 
@@ -130,16 +133,16 @@ func (krl *serviceLimiter) refillTokensLocked(now time.Time) {
 func (krl *serviceLimiter) applyServiceLimit(
 	now time.Time,
 	requestedTokens float64,
-) (limitedTokens float64) {
+) (limitedTokens float64, minTrickleTimeMs int64) {
 	if krl == nil {
-		return requestedTokens
+		return requestedTokens, 0
 	}
 	krl.Lock()
 	defer krl.Unlock()
 
 	// No limit configured, allow all tokens.
 	if krl.ServiceLimit <= 0 {
-		return requestedTokens
+		return requestedTokens, 0
 	}
 
 	// Refill first to ensure the available tokens is up to date.
@@ -147,18 +150,18 @@ func (krl *serviceLimiter) applyServiceLimit(
 
 	// If the requested tokens is less than the available tokens, grant all tokens.
 	if requestedTokens <= krl.AvailableTokens {
+		limitedTokens = requestedTokens
 		krl.AvailableTokens -= requestedTokens
-		return requestedTokens
-	}
-
-	// If the requested tokens is greater than the available tokens, grant all available tokens.
-	if requestedTokens > krl.AvailableTokens {
+	} else {
+		// If the requested tokens is greater than the available tokens, grant all available tokens.
 		limitedTokens = math.Max(0, krl.AvailableTokens)
-		// TODO: allow the loan to decrease the allocation at a smooth rate.
 		krl.AvailableTokens = 0
 	}
 
-	return limitedTokens
+	// Calculate a minimum trickle time to ensure the granted tokens' rate in client won't exceed the service limit.
+	minTrickleTimeMs = int64(limitedTokens * 1000.0 / krl.getServiceLimitLocked())
+
+	return limitedTokens, minTrickleTimeMs
 }
 
 // Clone returns a copy of the service limiter.

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -438,7 +438,7 @@ func (gtb *GroupTokenBucket) inspectAnomalies(
 ) bool {
 	var errMsg string
 	// Verify whether the allocated token is invalid, such as negative values, math.Inf, or math.NaN.
-	if tb.Tokens <= 0 || math.IsInf(tb.Tokens, 0) || math.IsNaN(tb.Tokens) {
+	if tb.Tokens < 0 || math.IsInf(tb.Tokens, 0) || math.IsNaN(tb.Tokens) {
 		errMsg = "assigned token is invalid"
 	}
 	// Verify whether the state of the slot is abnormal.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #9668, ref #9296.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Enhance `serviceLimiter.applyServiceLimit` to return both limited tokens and a minimum trickle time, ensuring client-side rate does not exceed service limit.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

<img width="1632" height="556" alt="image" src="https://github.com/user-attachments/assets/3ebdbb17-07b9-401c-b654-23b1b4b35e63" />

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
