### PR TITLE
[wip]: different cluster can allocate unique tso

### DIFF
--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -84,6 +84,7 @@ func NewAllocator(
 ) *Allocator {
 	ctx, cancel := context.WithCancel(ctx)
 	keyspaceGroupIDStr := strconv.FormatUint(uint64(keyspaceGroupID), 10)
+	maxIndex, uniqueIndex := cfg.GetTSOIndex()
 	a := &Allocator{
 		ctx:             ctx,
 		cancel:          cancel,
@@ -98,6 +99,8 @@ func NewAllocator(
 			updatePhysicalInterval: cfg.GetTSOUpdatePhysicalInterval(),
 			maxResetTSGap:          cfg.GetMaxResetTSGap,
 			tsoMux:                 &tsoObject{},
+			uniqueIndex:            uniqueIndex,
+			maxIndex:               maxIndex,
 			metrics:                newTSOMetrics(keyspaceGroupIDStr, GlobalDCLocation),
 		},
 		tsoAllocatorRoleGauge: tsoAllocatorRole.WithLabelValues(keyspaceGroupIDStr, GlobalDCLocation),

--- a/pkg/tso/config.go
+++ b/pkg/tso/config.go
@@ -46,4 +46,6 @@ type Config interface {
 	GetMaxResetTSGap() time.Duration
 	// GetTLSConfig returns the TLS config.
 	GetTLSConfig() *grpcutil.TLSConfig
+
+	GetTSOIndex() (int64, int64)
 }

--- a/pkg/tso/testutil.go
+++ b/pkg/tso/testutil.go
@@ -79,3 +79,7 @@ func (c *TestServiceConfig) GetMaxResetTSGap() time.Duration {
 func (c *TestServiceConfig) GetTLSConfig() *grpcutil.TLSConfig {
 	return c.TLSConfig
 }
+
+func (c *TestServiceConfig) GetTSOIndex() (int64, int64) {
+	return 1, 0
+}

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -73,6 +73,9 @@ type timestampOracle struct {
 
 	// pre-initialized metrics
 	metrics *tsoMetrics
+
+	uniqueIndex int64
+	maxIndex    int64
 }
 
 func (t *timestampOracle) saveTimestamp(ts time.Time) error {
@@ -108,10 +111,10 @@ func (t *timestampOracle) generateTSO(ctx context.Context, count int64) (physica
 	t.tsoMux.Lock()
 	defer t.tsoMux.Unlock()
 	if t.tsoMux.physical.Equal(typeutil.ZeroTime) {
-		return 0, 0
+		return 0, t.uniqueIndex - 1
 	}
 	physical = t.tsoMux.physical.UnixNano() / int64(time.Millisecond)
-	t.tsoMux.logical += count
+	t.tsoMux.logical += count*t.maxIndex + t.uniqueIndex
 	logical = t.tsoMux.logical
 	return physical, logical
 }

--- a/pkg/tso/util_test.go
+++ b/pkg/tso/util_test.go
@@ -15,7 +15,10 @@
 package tso
 
 import (
+	"context"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -69,5 +72,39 @@ func TestExtractKeyspaceGroupIDFromKeyspaceGroupMembershipPath(t *testing.T) {
 	for _, tt := range wrongCases {
 		_, err := ExtractKeyspaceGroupIDFromPath(compiledRegexp, tt.path)
 		re.Error(err)
+	}
+}
+
+func TestTSOIndex(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for range 10 {
+		count := rand.Int63n(100)
+		for _, ts := range []*timestampOracle{
+			{
+				tsoMux: &tsoObject{
+					physical: time.Now(),
+				},
+				maxIndex:    2,
+				uniqueIndex: 0,
+			},
+			{
+				tsoMux: &tsoObject{
+					physical: time.Now(),
+				},
+				maxIndex:    2,
+				uniqueIndex: 1,
+			},
+			{
+				tsoMux: &tsoObject{
+					physical: time.Now(),
+				},
+				maxIndex:    100,
+				uniqueIndex: 1,
+			},
+		} {
+			_, p := ts.generateTSO(ctx, count)
+			require.Equal(t, ts.uniqueIndex, p%ts.maxIndex)
+		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
