### PR TITLE
config: disable scheduling fallback

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -249,7 +249,7 @@ const (
 	minCheckRegionSplitInterval     = 1 * time.Millisecond
 	maxCheckRegionSplitInterval     = 100 * time.Millisecond
 
-	defaultEnableSchedulingFallback  = true
+	defaultEnableSchedulingFallback  = false
 	defaultEnableTSODynamicSwitching = false
 )
 

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -218,7 +218,6 @@ func (suite *serverTestSuite) TestSchedulingServiceFallback() {
 	re := suite.Require()
 	leaderServer := suite.pdLeader.GetServer()
 	conf := leaderServer.GetMicroserviceConfig().Clone()
-	// Change back to the default value.
 	conf.EnableSchedulingFallback = true
 	err := leaderServer.SetMicroserviceConfig(*conf)
 	re.NoError(err)
@@ -260,6 +259,12 @@ func (suite *serverTestSuite) TestSchedulingServiceFallback() {
 
 func (suite *serverTestSuite) TestDisableSchedulingServiceFallback() {
 	re := suite.Require()
+	// After Enable scheduling service fallback, the PD will scheduling.
+	leaderServer := suite.pdLeader.GetServer()
+	conf := leaderServer.GetMicroserviceConfig().Clone()
+	conf.EnableSchedulingFallback = true
+	err := leaderServer.SetMicroserviceConfig(*conf)
+	re.NoError(err)
 
 	// PD will execute scheduling jobs since there is no scheduling server.
 	testutil.Eventually(re, func() bool {
@@ -267,11 +272,10 @@ func (suite *serverTestSuite) TestDisableSchedulingServiceFallback() {
 		re.NotNil(suite.pdLeader.GetServer().GetRaftCluster())
 		return suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})
-	leaderServer := suite.pdLeader.GetServer()
 	// After Disabling scheduling service fallback, the PD will stop scheduling.
-	conf := leaderServer.GetMicroserviceConfig().Clone()
+	conf = leaderServer.GetMicroserviceConfig().Clone()
 	conf.EnableSchedulingFallback = false
-	err := leaderServer.SetMicroserviceConfig(*conf)
+	err = leaderServer.SetMicroserviceConfig(*conf)
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		return !suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -1272,13 +1272,13 @@ func (suite *configTestSuite) checkMicroserviceConfig(cluster *pdTests.TestClust
 	re.NoError(err)
 	cfg := config.Config{}
 	re.NoError(json.Unmarshal(output, &cfg))
-	re.True(svr.GetMicroserviceConfig().EnableSchedulingFallback)
-	re.True(cfg.Microservice.EnableSchedulingFallback)
+	re.False(svr.GetMicroserviceConfig().EnableSchedulingFallback)
+	re.False(cfg.Microservice.EnableSchedulingFallback)
 	// config set enable-scheduling-fallback <value>
-	args := []string{"-u", pdAddr, "config", "set", "enable-scheduling-fallback", "false"}
+	args := []string{"-u", pdAddr, "config", "set", "enable-scheduling-fallback", "true"}
 	_, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
-	re.False(svr.GetMicroserviceConfig().EnableSchedulingFallback)
+	re.True(svr.GetMicroserviceConfig().EnableSchedulingFallback)
 }
 
 func (suite *configTestSuite) TestRegionRules() {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #5839.

### What is changed and how does it work?

When we deploy the microservice, PD might use fewer resources than before. We should not allow scheduling fallback to PD automatically to avoid PD overload.


<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
