### PR TITLE
scheduler: skip split bucket feat if disabled bucket

### DIFF
--- a/pkg/schedule/schedulers/hot_region_solver.go
+++ b/pkg/schedule/schedulers/hot_region_solver.go
@@ -172,6 +172,9 @@ func (bs *balanceSolver) solve() []*operator.Operator {
 			return
 		}
 		if bs.isAvailable(bs.cur) && bs.betterThan(bs.best) {
+			if !bs.isReadyToBuild() {
+				return
+			}
 			if newOps := bs.buildOperators(); len(newOps) > 0 {
 				bs.ops = newOps
 				clone := *bs.cur
@@ -842,12 +845,10 @@ func (bs *balanceSolver) isReadyToBuild() bool {
 }
 
 func (bs *balanceSolver) buildOperators() (ops []*operator.Operator) {
-	if !bs.isReadyToBuild() {
-		return nil
-	}
-
+	enabledBucket := bs.GetStoreConfig().IsEnableRegionBucket()
 	splitRegions := make([]*core.RegionInfo, 0)
-	if bs.opTy == movePeer {
+
+	if bs.opTy == movePeer && enabledBucket {
 		for _, region := range []*core.RegionInfo{bs.cur.region, bs.cur.revertRegion} {
 			if region == nil {
 				continue

--- a/pkg/schedule/schedulers/hot_region_solver_test.go
+++ b/pkg/schedule/schedulers/hot_region_solver_test.go
@@ -42,8 +42,11 @@ func TestSplitBucketsBySize(t *testing.T) {
 	re.NoError(err)
 	solve := newBalanceSolver(hb.(*hotScheduler), tc, utils.Read, transferLeader)
 	solve.cur = &solution{}
-	region := core.NewTestRegionInfo(1, 1, []byte("a"), []byte("f"))
-
+	region := core.NewTestRegionInfo(1, 1, []byte("a"), []byte("f"), core.SetApproximateSize(1000))
+	solve.opTy = movePeer
+	store := core.NewStoreInfoWithLabel(1, nil)
+	solve.cur.srcStore = &statistics.StoreLoadDetail{StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: store}}
+	solve.cur.dstStore = &statistics.StoreLoadDetail{StoreSummaryInfo: &statistics.StoreSummaryInfo{StoreInfo: store}}
 	testdata := []struct {
 		hotBuckets [][]byte
 		splitKeys  [][]byte
@@ -61,27 +64,37 @@ func TestSplitBucketsBySize(t *testing.T) {
 			nil,
 		},
 	}
+	checkFn := func() {
+		enabledBucket := tc.IsEnableRegionBucket()
+		for _, data := range testdata {
+			b := &metapb.Buckets{
+				RegionId:   1,
+				PeriodInMs: 1000,
+				Keys:       data.hotBuckets,
+			}
+			region.UpdateBuckets(b, region.GetBuckets())
+			solve.cur.region = region
+			ops := solve.buildOperators()
+			if data.splitKeys == nil {
+				re.Empty(ops)
+				continue
+			}
+			if !enabledBucket {
+				re.Empty(ops)
+				return
+			}
+			re.Len(ops, 1)
+			op := ops[0]
+			re.Equal(splitHotReadBuckets, op.Desc())
 
-	for _, data := range testdata {
-		b := &metapb.Buckets{
-			RegionId:   1,
-			PeriodInMs: 1000,
-			Keys:       data.hotBuckets,
+			expectOp, err := operator.CreateSplitRegionOperator(splitHotReadBuckets, region, operator.OpSplit, pdpb.CheckPolicy_USEKEY, data.splitKeys)
+			re.NoError(err)
+			re.Equal(expectOp.Brief(), op.Brief())
 		}
-		region.UpdateBuckets(b, region.GetBuckets())
-		ops := solve.createSplitOperator([]*core.RegionInfo{region}, bySize)
-		if data.splitKeys == nil {
-			re.Empty(ops)
-			continue
-		}
-		re.Len(ops, 1)
-		op := ops[0]
-		re.Equal(splitHotReadBuckets, op.Desc())
-
-		expectOp, err := operator.CreateSplitRegionOperator(splitHotReadBuckets, region, operator.OpSplit, pdpb.CheckPolicy_USEKEY, data.splitKeys)
-		re.NoError(err)
-		re.Equal(expectOp.Brief(), op.Brief())
 	}
+	checkFn()
+	tc.SetRegionBucketEnabled(false)
+	checkFn()
 }
 
 func TestSplitBucketsByLoad(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9726

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
