### PR TITLE
fix(metering): ensure the order of collector registration and writer startup

### DIFF
--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -103,11 +103,12 @@ func NewManager[T factoryProvider](srv bs.Server) *Manager {
 			nil,
 		)
 		m.srv = srv
+		// Register the RU collector to the metering writer after the server is started.
+		// This ensure the metering writer is started before the RU collector is registered.
+		fp.GetMeteringWriter().RegisterCollector(m.ruCollector)
 	})
 	// The second initialization after becoming serving.
 	srv.AddServiceReadyCallback(m.Init)
-	// Register the RU collector to the metering writer.
-	fp.GetMeteringWriter().RegisterCollector(m.ruCollector)
 	return m
 }
 

--- a/pkg/mcs/resourcemanager/server/metering.go
+++ b/pkg/mcs/resourcemanager/server/metering.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	resourceManagerCategory = "resource-manager"
+	// ResourceManagerCategory is the category of the resource manager.
+	ResourceManagerCategory = "resource-manager"
 	ruMeteringVersion       = "1"
 	sourceName              = "pd"
 
@@ -96,7 +97,7 @@ func (c *ruCollector) remove(keyspaceName string) {
 }
 
 // Category returns the category of the collector.
-func (*ruCollector) Category() string { return resourceManagerCategory }
+func (*ruCollector) Category() string { return ResourceManagerCategory }
 
 // Collect collects the RU metering data.
 func (c *ruCollector) Collect(data any) {

--- a/pkg/metering/writer.go
+++ b/pkg/metering/writer.go
@@ -134,12 +134,14 @@ func (mw *Writer) RegisterCollector(collector Collector) {
 	if mw == nil {
 		return
 	}
+	category := collector.Category()
+	log.Info("registering metering collector", zap.String("category", category))
 	mw.Lock()
 	defer mw.Unlock()
 	if mw.collectors == nil {
 		mw.collectors = make(map[string]Collector)
 	}
-	mw.collectors[collector.Category()] = collector
+	mw.collectors[category] = collector
 }
 
 // meteringLoop runs the background loop to flush metering data periodically.
@@ -176,7 +178,7 @@ func (mw *Writer) meteringLoop() {
 
 // flushMeteringData flushes aggregated metering data to the underlying storage
 func (mw *Writer) flushMeteringData(ctx context.Context, ts int64) {
-	collectors := mw.getCollectors()
+	collectors := mw.GetCollectors()
 	if len(collectors) == 0 {
 		return
 	}
@@ -220,7 +222,8 @@ func (mw *Writer) flushMeteringData(ctx context.Context, ts int64) {
 	}
 }
 
-func (mw *Writer) getCollectors() map[string]Collector {
+// GetCollectors returns the registered collectors.
+func (mw *Writer) GetCollectors() map[string]Collector {
 	mw.RLock()
 	defer mw.RUnlock()
 	collectors := make(map[string]Collector, len(mw.collectors))

--- a/pkg/metering/writer_test.go
+++ b/pkg/metering/writer_test.go
@@ -128,7 +128,7 @@ func TestRegisterCollector(t *testing.T) {
 	collector1 := newMockCollector("category1")
 	writer.RegisterCollector(collector1)
 
-	collectors := writer.getCollectors()
+	collectors := writer.GetCollectors()
 	re.Len(collectors, 1)
 	re.Contains(collectors, "category1")
 	re.Equal(collector1, collectors["category1"])
@@ -137,7 +137,7 @@ func TestRegisterCollector(t *testing.T) {
 	collector2 := newMockCollector("category2")
 	writer.RegisterCollector(collector2)
 
-	collectors = writer.getCollectors()
+	collectors = writer.GetCollectors()
 	re.Len(collectors, 2)
 	re.Contains(collectors, "category1")
 	re.Contains(collectors, "category2")
@@ -146,7 +146,7 @@ func TestRegisterCollector(t *testing.T) {
 	collector1New := newMockCollector("category1")
 	writer.RegisterCollector(collector1New)
 
-	collectors = writer.getCollectors()
+	collectors = writer.GetCollectors()
 	re.Len(collectors, 2)
 	re.Equal("category1", collectors["category1"].Category())
 	// Verify it's a different instance by checking if it's not the original.

--- a/server/server.go
+++ b/server/server.go
@@ -489,6 +489,8 @@ func (s *Server) startServer(ctx context.Context) error {
 		} else {
 			s.meteringWriter.Start()
 		}
+	} else {
+		log.Info("no metering config provided, the metering writer will not be started")
 	}
 	s.gcStateManager = gc.NewGCStateManager(s.storage.GetGCStateProvider(), s.cfg.PDServerCfg, s.keyspaceManager)
 	s.hbStreams = hbstream.NewHeartbeatStreams(ctx, "", s.cluster)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9707.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- Delay registration of RU collector until after the metering writer has been started to ensure correct initialization order.
- Add integration test confirming that the metering writer starts correctly with config, and that RU collector is properly registered.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
