### PR TITLE
mcs: support starting router service

### DIFF
--- a/cmd/pd-server/main.go
+++ b/cmd/pd-server/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/tikv/pd/pkg/dashboard"
 	"github.com/tikv/pd/pkg/errs"
+	router "github.com/tikv/pd/pkg/mcs/router/server"
 	scheduling "github.com/tikv/pd/pkg/mcs/scheduling/server"
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
 	"github.com/tikv/pd/pkg/memory"
@@ -72,10 +73,11 @@ func main() {
 func NewServiceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "services <mode>",
-		Short: "Run services, for example, tso, scheduling",
+		Short: "Run services, for example, tso, scheduling, router",
 	}
 	cmd.AddCommand(NewTSOServiceCommand())
 	cmd.AddCommand(NewSchedulingServiceCommand())
+	cmd.AddCommand(NewRouterServiceCommand())
 	cmd.AddCommand(NewPDServiceCommand())
 	return cmd
 }
@@ -109,6 +111,27 @@ func NewSchedulingServiceCommand() *cobra.Command {
 		Run:   scheduling.CreateServerWrapper,
 	}
 	cmd.Flags().StringP("name", "", "", "human-readable name for this scheduling member")
+	cmd.Flags().BoolP("version", "V", false, "print version information and exit")
+	cmd.Flags().StringP("config", "", "", "config file")
+	cmd.Flags().StringP("backend-endpoints", "", "", "url for etcd client")
+	cmd.Flags().StringP("listen-addr", "", "", "listen address for tso service")
+	cmd.Flags().StringP("advertise-listen-addr", "", "", "advertise urls for listen address (default '${listen-addr}')")
+	cmd.Flags().StringP("cacert", "", "", "path of file that contains list of trusted TLS CAs")
+	cmd.Flags().StringP("cert", "", "", "path of file that contains X509 certificate in PEM format")
+	cmd.Flags().StringP("key", "", "", "path of file that contains X509 key in PEM format")
+	cmd.Flags().StringP("log-level", "L", "", "log level: debug, info, warn, error, fatal (default 'info')")
+	cmd.Flags().StringP("log-file", "", "", "log file path")
+	return cmd
+}
+
+// NewRouterServiceCommand returns the router service command.
+func NewRouterServiceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "router",
+		Short: "Run the router service",
+		Run:   router.CreateServerWrapper,
+	}
+	cmd.Flags().StringP("name", "", "", "human-readable name for this router member")
 	cmd.Flags().BoolP("version", "V", false, "print version information and exit")
 	cmd.Flags().StringP("config", "", "", "config file")
 	cmd.Flags().StringP("backend-endpoints", "", "", "url for etcd client")


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9212.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Manual test

```
$ bin/tiup-playground nightly --pd.mode ms --pd 3 --scheduling 2 --tso 2 --kv 3 --router 2 --tiflash 0 --host 10.2.8.101
```
The result of `ps -ef`:
```
ryan     2118413 2117720  2 17:30 pts/184  00:00:00 /data/nvme0n1/ryan/.tiup/components/pd/v9.0.0-beta.2.pre-nightly/pd-server services router --listen-addr=http://10.2.8.101:2394 --advertise-listen-addr=http://10.2.8.101:2394 --backend-endpoints=http://10.2.8.101:2379,http://10.2.8.101:2382,http://10.2.8.101:2384 --log-file=/data/nvme0n1/ryan/.tiup/data/UxbxWo2/router-0/router.log --config=/data/nvme0n1/ryan/.tiup/data/UxbxWo2/router-0/router.toml --name=router-0
ryan     2118502 2117720  1 17:30 pts/184  00:00:00 /data/nvme0n1/ryan/.tiup/components/pd/v9.0.0-beta.2.pre-nightly/pd-server services router --listen-addr=http://10.2.8.101:2396 --advertise-listen-addr=http://10.2.8.101:2396 --backend-endpoints=http://10.2.8.101:2379,http://10.2.8.101:2382,http://10.2.8.101:2384 --log-file=/data/nvme0n1/ryan/.tiup/data/UxbxWo2/router-1/router.log --config=/data/nvme0n1/ryan/.tiup/data/UxbxWo2/router-1/router.toml --name=router-1
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
