### PR TITLE
fix(metering): skip empty metrics and avoid emitting empty aggregates

### DIFF
--- a/pkg/mcs/resourcemanager/server/metering.go
+++ b/pkg/mcs/resourcemanager/server/metering.go
@@ -103,6 +103,9 @@ func (c *ruCollector) Aggregate() []map[string]any {
 	keyspaceRUMetering := c.keyspaceRUMetering
 	c.keyspaceRUMetering = make(map[string]*ruMetering)
 	c.Unlock()
+	if len(keyspaceRUMetering) == 0 {
+		return nil
+	}
 	records := make([]map[string]any, 0, len(keyspaceRUMetering))
 	for keyspaceName, ruMetering := range keyspaceRUMetering {
 		// Convert the ruMetering to the map[string]any.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9707.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- In `ruCollector.Aggregate` and `dfsStatsCollector.Aggregate`, return `nil` instead of an empty list when no metrics are available.
- Updated `dfsStatsCollector.Collect` to ignore entries with no written bytes and no write requests, preventing unnecessary data collection.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
