### PR TITLE
cherry-pick: scheduler: graceful shutdown implement (#9720)

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00
-	github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31
+	github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.18.0
 	github.com/stretchr/testify v1.8.2

--- a/client/go.sum
+++ b/client/go.sum
@@ -46,8 +46,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 h1:C3N3itkduZXDZFh4N3vQ5HEtld3S+Y+StULhWVvumU0=
 github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31 h1:6BY+3T6Hqpw9UZ/D7Om/xB+Xik3NkkYxBV6qCzUdUvU=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599 h1:57fBeBND/j/dp7nVlw+cWEwYlt4u8CAe4ApsmAEb1ow=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
-	github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00
-	github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31
+	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c
+	github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
 	github.com/pingcap/tidb-dashboard v0.0.0-20240924035706-618b5cded5bf

--- a/go.sum
+++ b/go.sum
@@ -387,11 +387,11 @@ github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTw
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTmyFqUwr+jcCvpVkK7sumiz+ko5H9eq4=
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
-github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 h1:C3N3itkduZXDZFh4N3vQ5HEtld3S+Y+StULhWVvumU0=
-github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
+github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c h1:CgbKAHto5CQgWM9fSBIvaxsJHuGP0uM74HXtv3MyyGQ=
+github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31 h1:6BY+3T6Hqpw9UZ/D7Om/xB+Xik3NkkYxBV6qCzUdUvU=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599 h1:57fBeBND/j/dp7nVlw+cWEwYlt4u8CAe4ApsmAEb1ow=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/pkg/core/basic_cluster.go
+++ b/pkg/core/basic_cluster.go
@@ -141,7 +141,9 @@ type StoreSetController interface {
 	ResumeLeaderTransfer(id uint64)
 
 	SlowStoreEvicted(id uint64) error
+	StoppingStoreEvicted(id uint64) error
 	SlowStoreRecovered(id uint64)
+	StoppingStoreRecovered(id uint64)
 	SlowTrendEvicted(id uint64) error
 	SlowTrendRecovered(id uint64)
 }

--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -149,6 +149,11 @@ func (s *StoreInfo) EvictedAsSlowStore() bool {
 	return s.slowStoreEvicted
 }
 
+// EvictedAsStoppingStore returns if the store should be evicted as a stopping store.
+func (s *StoreInfo) EvictedAsStoppingStore() bool {
+	return s.rawStats.IsStopping
+}
+
 // IsEvictedAsSlowTrend returns if the store should be evicted as a slow store by trend.
 func (s *StoreInfo) IsEvictedAsSlowTrend() bool {
 	return s.slowTrendEvicted
@@ -208,6 +213,13 @@ func (s *StoreInfo) IsSlow() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.slowTrendEvicted || s.rawStats.GetSlowScore() >= slowStoreThreshold
+}
+
+// IsStopping checks if the store is in stopping state.
+func (s *StoreInfo) IsStopping() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.rawStats.GetIsStopping()
 }
 
 // GetSlowTrend returns the slow trend information of the store.
@@ -820,6 +832,19 @@ func (s *StoresInfo) SlowStoreEvicted(storeID uint64) error {
 	return nil
 }
 
+// StoppingStoreEvicted marks a store as a stopping store and prevents transferring
+// leader to the store
+func (s *StoresInfo) StoppingStoreEvicted(storeID uint64) error {
+	s.Lock()
+	defer s.Unlock()
+	store, ok := s.stores[storeID]
+	if !ok {
+		return errs.ErrStoreNotFound.FastGenByArgs(storeID)
+	}
+	s.stores[storeID] = store.Clone(StoppingStoreEvicted())
+	return nil
+}
+
 // SlowStoreRecovered cleans the evicted state of a store.
 func (s *StoresInfo) SlowStoreRecovered(storeID uint64) {
 	s.Lock()
@@ -831,6 +856,19 @@ func (s *StoresInfo) SlowStoreRecovered(storeID uint64) {
 		return
 	}
 	s.stores[storeID] = store.Clone(SlowStoreRecovered())
+}
+
+// StoppingStoreRecovered cleans the evicted state of a store.
+func (s *StoresInfo) StoppingStoreRecovered(storeID uint64) {
+	s.Lock()
+	defer s.Unlock()
+	store, ok := s.stores[storeID]
+	if !ok {
+		log.Warn("try to clean a store's evicted as a stopping store state, but it is not found. It may be cleanup",
+			zap.Uint64("store-id", storeID))
+		return
+	}
+	s.stores[storeID] = store.Clone(StoppingStoreRecovered())
 }
 
 // SlowTrendEvicted marks a store as a slow trend and prevents transferring

--- a/pkg/core/store_option.go
+++ b/pkg/core/store_option.go
@@ -122,6 +122,14 @@ func SlowStoreEvicted() StoreCreateOption {
 	}
 }
 
+// StoppingStoreEvicted marks a store as a stopping store and prevents transferring
+// leader to the store
+func StoppingStoreEvicted() StoreCreateOption {
+	return func(store *StoreInfo) {
+		store.rawStats.IsStopping = true
+	}
+}
+
 // SlowTrendEvicted marks a store as a slow store by trend and prevents transferring
 // leader to the store
 func SlowTrendEvicted() StoreCreateOption {
@@ -141,6 +149,13 @@ func SlowTrendRecovered() StoreCreateOption {
 func SlowStoreRecovered() StoreCreateOption {
 	return func(store *StoreInfo) {
 		store.slowStoreEvicted = false
+	}
+}
+
+// StoppingStoreRecovered cleans the evicted state of a store.
+func StoppingStoreRecovered() StoreCreateOption {
+	return func(store *StoreInfo) {
+		store.rawStats.IsStopping = false
 	}
 }
 

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -333,6 +333,11 @@ func (s *Service) AskBatchSplit(_ context.Context, request *schedulingpb.AskBatc
 	}, nil
 }
 
+// RegionBuckets implements gRPC SchedulingServer.
+func (s *Service) RegionBuckets(stream schedulingpb.Scheduling_RegionBucketsServer) error {
+	return status.Errorf(codes.Unimplemented, "RegionBuckets not implemented")
+}
+
 // RegisterGRPCService registers the service to gRPC server.
 func (s *Service) RegisterGRPCService(g *grpc.Server) {
 	schedulingpb.RegisterSchedulingServer(g, s)

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -334,7 +334,7 @@ func (s *Service) AskBatchSplit(_ context.Context, request *schedulingpb.AskBatc
 }
 
 // RegionBuckets implements gRPC SchedulingServer.
-func (s *Service) RegionBuckets(stream schedulingpb.Scheduling_RegionBucketsServer) error {
+func (*Service) RegionBuckets(_ schedulingpb.Scheduling_RegionBucketsServer) error {
 	return status.Errorf(codes.Unimplemented, "RegionBuckets not implemented")
 }
 

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -584,6 +584,7 @@ var DefaultSchedulers = SchedulerConfigs{
 	{Type: types.SchedulerTypeCompatibleMap[types.BalanceLeaderScheduler]},
 	{Type: types.SchedulerTypeCompatibleMap[types.BalanceHotRegionScheduler]},
 	{Type: types.SchedulerTypeCompatibleMap[types.EvictSlowStoreScheduler]},
+	{Type: types.SchedulerTypeCompatibleMap[types.EvictStoppingStoreScheduler]},
 }
 
 // IsDefaultScheduler checks whether the scheduler is enabled by default.

--- a/pkg/schedule/filter/counter.go
+++ b/pkg/schedule/filter/counter.go
@@ -59,6 +59,7 @@ const (
 	storeStateOffline
 	storeStatePauseLeader
 	storeStateSlow
+	storeStateStopping
 	storeStateDisconnected
 	storeStateBusy
 	storeStateExceedRemoveLimit
@@ -88,6 +89,7 @@ var filters = [filtersLen]string{
 	"store-state-offline-filter",
 	"store-state-pause-leader-filter",
 	"store-state-slow-filter",
+	"store-state-stopping-filter",
 	"store-state-disconnect-filter",
 	"store-state-busy-filter",
 	"store-state-exceed-remove-limit-filter",

--- a/pkg/schedule/filter/filters.go
+++ b/pkg/schedule/filter/filters.go
@@ -408,6 +408,15 @@ func (f *StoreStateFilter) slowStoreEvicted(_ config.SharedConfigProvider, store
 	return statusOK
 }
 
+func (f *StoreStateFilter) stoppingStoreEvicted(_ config.SharedConfigProvider, store *core.StoreInfo) *plan.Status {
+	if store.EvictedAsStoppingStore() {
+		f.Reason = storeStateStopping
+		return statusStoreRejectLeader
+	}
+	f.Reason = storeStateOK
+	return statusOK
+}
+
 func (f *StoreStateFilter) slowTrendEvicted(_ config.SharedConfigProvider, store *core.StoreInfo) *plan.Status {
 	if store.IsEvictedAsSlowTrend() {
 		f.Reason = storeStateSlowTrend
@@ -518,7 +527,7 @@ func (f *StoreStateFilter) anyConditionMatch(typ int, conf config.SharedConfigPr
 		funcs = []conditionFunc{f.isBusy}
 	case leaderTarget:
 		funcs = []conditionFunc{f.isRemoved, f.isRemoving, f.isDown, f.pauseLeaderTransfer,
-			f.slowStoreEvicted, f.slowTrendEvicted, f.isDisconnected, f.isBusy, f.hasRejectLeaderProperty}
+			f.slowStoreEvicted, f.stoppingStoreEvicted, f.slowTrendEvicted, f.isDisconnected, f.isBusy, f.hasRejectLeaderProperty}
 	case regionTarget:
 		funcs = []conditionFunc{f.isRemoved, f.isRemoving, f.isDown, f.isDisconnected, f.isBusy,
 			f.exceedAddLimit, f.tooManySnapshots, f.tooManyPendingPeers}

--- a/pkg/schedule/schedulers/evict_stopping_store.go
+++ b/pkg/schedule/schedulers/evict_stopping_store.go
@@ -1,0 +1,340 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/unrolled/render"
+	"go.uber.org/zap"
+
+	perrors "github.com/pingcap/errors"
+	"github.com/pingcap/log"
+
+	"github.com/tikv/pd/pkg/core"
+	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/plan"
+	"github.com/tikv/pd/pkg/schedule/types"
+	"github.com/tikv/pd/pkg/utils/apiutil"
+)
+
+type evictStoppingStoreSchedulerConfig struct {
+	baseDefaultSchedulerConfig
+
+	cluster *core.BasicCluster
+	// EvictedStores stores the stopping stores that are being evicted
+	EvictedStores []uint64 `json:"evicted-stores"`
+	// Batch is used to generate multiple operators by one scheduling
+	Batch int `json:"batch"`
+}
+
+func initEvictStoppingStoreSchedulerConfig() *evictStoppingStoreSchedulerConfig {
+	return &evictStoppingStoreSchedulerConfig{
+		baseDefaultSchedulerConfig: newBaseDefaultSchedulerConfig(),
+		EvictedStores:              make([]uint64, 0),
+		Batch:                      EvictLeaderBatchSize,
+	}
+}
+
+func (conf *evictStoppingStoreSchedulerConfig) persistLocked(updateFn func()) error {
+	var (
+		oldEvictedStores = conf.EvictedStores
+		oldBatch         = conf.Batch
+	)
+	updateFn()
+	if err := conf.save(); err != nil {
+		conf.EvictedStores = oldEvictedStores
+		conf.Batch = oldBatch
+		return err
+	}
+	return nil
+}
+
+func (conf *evictStoppingStoreSchedulerConfig) getStores() []uint64 {
+	conf.RLock()
+	defer conf.RUnlock()
+	return conf.EvictedStores
+}
+
+func (conf *evictStoppingStoreSchedulerConfig) getKeyRangesByID(id uint64) []core.KeyRange {
+	if conf.evictStore() != id {
+		return nil
+	}
+	return []core.KeyRange{core.NewKeyRange("", "")}
+}
+
+func (conf *evictStoppingStoreSchedulerConfig) getBatch() int {
+	conf.RLock()
+	defer conf.RUnlock()
+	return conf.Batch
+}
+
+func (conf *evictStoppingStoreSchedulerConfig) evictStore() uint64 {
+	conf.RLock()
+	defer conf.RUnlock()
+	if len(conf.EvictedStores) == 0 {
+		return 0
+	}
+	return conf.EvictedStores[0]
+}
+
+func (conf *evictStoppingStoreSchedulerConfig) setStoreAndPersist(id uint64) error {
+	conf.Lock()
+	defer conf.Unlock()
+	return conf.persistLocked(func() {
+		conf.EvictedStores = []uint64{id}
+	})
+}
+
+func (conf *evictStoppingStoreSchedulerConfig) clearEvictedAndPersist() (oldID uint64, err error) {
+	oldID = conf.evictStore()
+	conf.Lock()
+	defer conf.Unlock()
+	if oldID > 0 {
+		err = conf.persistLocked(func() {
+			conf.EvictedStores = []uint64{}
+		})
+	}
+	return
+}
+
+type evictStoppingStoreHandler struct {
+	rd     *render.Render
+	config *evictStoppingStoreSchedulerConfig
+}
+
+func newEvictStoppingStoreHandler(config *evictStoppingStoreSchedulerConfig) http.Handler {
+	h := &evictStoppingStoreHandler{
+		config: config,
+		rd:     render.New(render.Options{IndentJSON: true}),
+	}
+	router := mux.NewRouter()
+	router.HandleFunc("/config", h.updateConfig).Methods(http.MethodPost)
+	router.HandleFunc("/list", h.listConfig).Methods(http.MethodGet)
+	return router
+}
+
+func (handler *evictStoppingStoreHandler) updateConfig(w http.ResponseWriter, r *http.Request) {
+	var input map[string]any
+	if err := apiutil.ReadJSONRespondError(handler.rd, w, r.Body, &input); err != nil {
+		return
+	}
+
+	batchFloat, inputBatch := input["batch"].(float64)
+	if input["batch"] != nil && !inputBatch {
+		handler.rd.JSON(w, http.StatusBadRequest, perrors.New("invalid argument for 'batch'").Error())
+		return
+	}
+	if inputBatch {
+		if batchFloat < 1 || batchFloat > 10 {
+			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 10]")
+			return
+		}
+	}
+
+	handler.config.Lock()
+	defer handler.config.Unlock()
+
+	if err := handler.config.persistLocked(func() {
+		if inputBatch {
+			handler.config.Batch = int(batchFloat)
+		}
+	}); err != nil {
+		handler.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	log.Info("evict-stopping-store-scheduler update config",
+		zap.Float64("cur-batch", batchFloat),
+	)
+
+	handler.rd.JSON(w, http.StatusOK, "Config updated.")
+}
+
+func (handler *evictStoppingStoreHandler) listConfig(w http.ResponseWriter, _ *http.Request) {
+	handler.config.RLock()
+	defer handler.config.RUnlock()
+	conf := &evictStoppingStoreSchedulerConfig{
+		Batch:         handler.config.Batch,
+		EvictedStores: handler.config.EvictedStores,
+	}
+	handler.rd.JSON(w, http.StatusOK, conf)
+}
+
+type evictStoppingStoreScheduler struct {
+	*BaseScheduler
+	conf    *evictStoppingStoreSchedulerConfig
+	handler http.Handler
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (s *evictStoppingStoreScheduler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.handler.ServeHTTP(w, r)
+}
+
+// EncodeConfig implements the Scheduler interface.
+func (s *evictStoppingStoreScheduler) EncodeConfig() ([]byte, error) {
+	return EncodeConfig(s.conf)
+}
+
+// ReloadConfig implements the Scheduler interface.
+func (s *evictStoppingStoreScheduler) ReloadConfig() error {
+	s.conf.Lock()
+	defer s.conf.Unlock()
+
+	newCfg := &evictStoppingStoreSchedulerConfig{}
+	if err := s.conf.load(newCfg); err != nil {
+		return err
+	}
+	if newCfg.Batch == 0 {
+		newCfg.Batch = EvictLeaderBatchSize
+	}
+
+	s.conf.EvictedStores = newCfg.EvictedStores
+	s.conf.Batch = newCfg.Batch
+	return nil
+}
+
+// PrepareConfig implements the Scheduler interface.
+func (s *evictStoppingStoreScheduler) PrepareConfig(cluster sche.SchedulerCluster) error {
+	evictStore := s.conf.evictStore()
+	if evictStore != 0 {
+		if err := cluster.StoppingStoreEvicted(evictStore); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CleanConfig implements the Scheduler interface.
+func (s *evictStoppingStoreScheduler) CleanConfig(cluster sche.SchedulerCluster) {
+	s.cleanupEvictLeader(cluster)
+}
+
+func (s *evictStoppingStoreScheduler) prepareEvictLeader(cluster sche.SchedulerCluster, storeID uint64) error {
+	if err := cluster.StoppingStoreEvicted(storeID); err != nil {
+		log.Info("failed to evict stopping store", zap.Uint64("store-id", storeID), zap.Error(err))
+		return err
+	}
+
+	if err := s.conf.setStoreAndPersist(storeID); err != nil {
+		log.Info("failed to persist evicted stopping store", zap.Uint64("store-id", storeID), zap.Error(err))
+		cluster.StoppingStoreRecovered(storeID)
+		return err
+	}
+
+	return nil
+}
+
+func (s *evictStoppingStoreScheduler) cleanupEvictLeader(cluster sche.SchedulerCluster) {
+	evictStoppingStore, err := s.conf.clearEvictedAndPersist()
+	if err != nil {
+		log.Warn("evict-stopping-store-scheduler persist config failed", zap.Uint64("store-id", evictStoppingStore))
+	}
+	if evictStoppingStore == 0 {
+		return
+	}
+	cluster.StoppingStoreRecovered(evictStoppingStore)
+	// Reset the stopping store evicted status metric.
+	storeIDStr := strconv.FormatUint(evictStoppingStore, 10)
+	evictedStoppingStoreStatusGauge.WithLabelValues(storeIDStr).Set(0)
+}
+
+func (s *evictStoppingStoreScheduler) schedulerEvictLeader(cluster sche.SchedulerCluster) []*operator.Operator {
+	return scheduleEvictLeaderBatch(s.R, s.GetName(), cluster, s.conf)
+}
+
+// IsScheduleAllowed implements the Scheduler interface.
+func (s *evictStoppingStoreScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
+	if s.conf.evictStore() != 0 {
+		allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetSchedulerConfig().GetLeaderScheduleLimit()
+		if !allowed {
+			operator.IncOperatorLimitCounter(s.GetType(), operator.OpLeader)
+		}
+		return allowed
+	}
+	return true
+}
+
+// Schedule implements the Scheduler interface.
+func (s *evictStoppingStoreScheduler) Schedule(cluster sche.SchedulerCluster, _ bool) ([]*operator.Operator, []plan.Plan) {
+	evictStoppingStoreCounter.Inc()
+	s.scheduleStoppingStore(cluster)
+	return s.schedulerEvictLeader(cluster), nil
+}
+
+func (s *evictStoppingStoreScheduler) scheduleStoppingStore(cluster sche.SchedulerCluster) {
+	if s.conf.evictStore() != 0 {
+		store := cluster.GetStore(s.conf.evictStore())
+		if store == nil || store.IsRemoved() {
+			// Previous stopping store had been removed, remove the scheduler and check next time.
+			log.Info("stopping store has been removed", zap.Uint64("store-id", s.conf.evictStore()))
+			s.cleanupEvictLeader(cluster)
+			return
+		}
+
+		// recover stopping store if it's no longer in stopping state.
+		if !store.IsStopping() {
+			log.Info("stopping store has been recovered", zap.Uint64("store-id", store.GetID()))
+			s.cleanupEvictLeader(cluster)
+			return
+		}
+		return
+	}
+
+	var stoppingStore *core.StoreInfo
+
+	for _, store := range cluster.GetStores() {
+		if store.IsRemoved() {
+			continue
+		}
+
+		if (store.IsPreparing() || store.IsServing()) && store.IsStopping() {
+			// Do nothing if there is more than one stopping store.
+			if stoppingStore != nil {
+				return
+			}
+			stoppingStore = store
+		}
+	}
+
+	if stoppingStore == nil {
+		return
+	}
+
+	// If there is only one stopping store, evict leaders from that store.
+	stoppingStoreID := stoppingStore.GetID()
+	log.Info("detected stopping store, start to evict leaders", zap.Uint64("store-id", stoppingStoreID))
+	err := s.prepareEvictLeader(cluster, stoppingStoreID)
+	if err != nil {
+		log.Info("prepare for evicting leader failed", zap.Error(err), zap.Uint64("store-id", stoppingStoreID))
+		return
+	}
+	// Record the stopping store evicted status.
+	storeIDStr := strconv.FormatUint(stoppingStoreID, 10)
+	evictedStoppingStoreStatusGauge.WithLabelValues(storeIDStr).Set(1)
+}
+
+// newEvictStoppingStoreScheduler creates a scheduler that detects and evicts stopping stores.
+func newEvictStoppingStoreScheduler(opController *operator.Controller, conf *evictStoppingStoreSchedulerConfig) Scheduler {
+	handler := newEvictStoppingStoreHandler(conf)
+	return &evictStoppingStoreScheduler{
+		BaseScheduler: NewBaseScheduler(opController, types.EvictStoppingStoreScheduler, conf),
+		conf:          conf,
+		handler:       handler,
+	}
+}

--- a/pkg/schedule/schedulers/evict_stopping_store_test.go
+++ b/pkg/schedule/schedulers/evict_stopping_store_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/types"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/operatorutil"
+)
+
+type evictStoppingStoreTestSuite struct {
+	suite.Suite
+	cancel context.CancelFunc
+	tc     *mockcluster.Cluster
+	es     Scheduler
+	bs     Scheduler
+	oc     *operator.Controller
+}
+
+func TestEvictStoppingStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(evictStoppingStoreTestSuite))
+}
+
+func (suite *evictStoppingStoreTestSuite) SetupTest() {
+	re := suite.Require()
+	suite.cancel, _, suite.tc, suite.oc = prepareSchedulersTest()
+
+	// Add stores 1, 2, 3, 4
+	suite.tc.AddLeaderStore(1, 0)
+	suite.tc.AddLeaderStore(2, 0)
+	suite.tc.AddLeaderStore(3, 0)
+	suite.tc.AddLeaderStore(4, 0)
+	// Add regions 1, 2 with leaders in stores 1, 2
+	suite.tc.AddLeaderRegion(1, 1, 2)
+	suite.tc.AddLeaderRegion(2, 2, 1)
+	suite.tc.UpdateLeaderCount(2, 16)
+
+	storage := storage.NewStorageWithMemoryBackend()
+	var err error
+	suite.es, err = CreateScheduler(types.EvictStoppingStoreScheduler, suite.oc, storage, ConfigSliceDecoder(types.EvictStoppingStoreScheduler, []string{}), nil)
+	re.NoError(err)
+	suite.bs, err = CreateScheduler(types.BalanceLeaderScheduler, suite.oc, storage, ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{}), nil)
+	re.NoError(err)
+}
+
+func (suite *evictStoppingStoreTestSuite) TearDownTest() {
+	suite.cancel()
+}
+
+func (suite *evictStoppingStoreTestSuite) TestEvictStoppingStore() {
+	re := suite.Require()
+
+	// Set store 1 as stopping
+	storeInfo := suite.tc.GetStore(1)
+	newStoreInfo := storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().IsStopping = true
+	})
+	suite.tc.PutStore(newStoreInfo)
+
+	re.True(suite.es.IsScheduleAllowed(suite.tc))
+	// Add evict leader scheduler to store 1
+	ops, _ := suite.es.Schedule(suite.tc, false)
+	operatorutil.CheckMultiTargetTransferLeader(re, ops[0], operator.OpLeader, 1, []uint64{2})
+	re.Equal(types.EvictStoppingStoreScheduler.String(), ops[0].Desc())
+
+	// Cannot balance leaders to store 1
+	ops, _ = suite.bs.Schedule(suite.tc, false)
+	re.Empty(ops)
+}
+
+func (suite *evictStoppingStoreTestSuite) TestEvictStoppingStoreRecovery() {
+	re := suite.Require()
+
+	// Set store 1 as stopping
+	storeInfo := suite.tc.GetStore(1)
+	newStoreInfo := storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().IsStopping = true
+	})
+	suite.tc.PutStore(newStoreInfo)
+
+	// Should generate evict leader operator
+	ops, _ := suite.es.Schedule(suite.tc, false)
+	re.NotEmpty(ops)
+	operatorutil.CheckMultiTargetTransferLeader(re, ops[0], operator.OpLeader, 1, []uint64{2})
+
+	// Set store 1 as recovered (not stopping)
+	storeInfo = suite.tc.GetStore(1)
+	newStoreInfo = storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().IsStopping = false
+	})
+	suite.tc.PutStore(newStoreInfo)
+
+	// Should not generate evict leader operator after recovery
+	ops, _ = suite.es.Schedule(suite.tc, false)
+	re.Empty(ops)
+
+	// Balance leader scheduler should work normally
+	ops, _ = suite.bs.Schedule(suite.tc, false)
+	re.NotEmpty(ops)
+}
+
+func (suite *evictStoppingStoreTestSuite) TestRemovedStoppingStore() {
+	re := suite.Require()
+
+	// Set store 1 as stopping
+	storeInfo := suite.tc.GetStore(1)
+	newStoreInfo := storeInfo.Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().IsStopping = true
+	})
+	suite.tc.PutStore(newStoreInfo)
+
+	// Should generate evict leader operator
+	ops, _ := suite.es.Schedule(suite.tc, false)
+	re.NotEmpty(ops)
+
+	// Mark store 1 as removed
+	storeInfo = suite.tc.GetStore(1)
+	newStoreInfo = storeInfo.Clone(core.SetStoreState(metapb.StoreState_Tombstone))
+	suite.tc.PutStore(newStoreInfo)
+
+	// Should not panic and not generate any operators
+	ops, _ = suite.es.Schedule(suite.tc, false)
+	re.Empty(ops)
+}

--- a/pkg/schedule/schedulers/init.go
+++ b/pkg/schedule/schedulers/init.go
@@ -180,6 +180,13 @@ func schedulersRegister() {
 		}
 	})
 
+	// evict stopping store
+	RegisterSliceDecoderBuilder(types.EvictStoppingStoreScheduler, func([]string) ConfigDecoder {
+		return func(any) error {
+			return nil
+		}
+	})
+
 	RegisterScheduler(types.EvictSlowStoreScheduler, func(opController *operator.Controller,
 		storage endpoint.ConfigStorage, decoder ConfigDecoder, _ ...func(string) error) (Scheduler, error) {
 		conf := initEvictSlowStoreSchedulerConfig()
@@ -188,6 +195,21 @@ func schedulersRegister() {
 		}
 		conf.cluster = opController.GetCluster()
 		sche := newEvictSlowStoreScheduler(opController, conf)
+		conf.init(sche.GetName(), storage, conf)
+		return sche, nil
+	})
+
+	RegisterScheduler(types.EvictStoppingStoreScheduler, func(opController *operator.Controller,
+		storage endpoint.ConfigStorage, decoder ConfigDecoder, _ ...func(string) error) (Scheduler, error) {
+		conf := initEvictStoppingStoreSchedulerConfig()
+		if err := decoder(conf); err != nil {
+			return nil, err
+		}
+		if conf.Batch == 0 {
+			conf.Batch = EvictLeaderBatchSize
+		}
+		conf.cluster = opController.GetCluster()
+		sche := newEvictStoppingStoreScheduler(opController, conf)
 		conf.init(sche.GetName(), storage, conf)
 		return sche, nil
 	})

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -105,6 +105,14 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 30),
 		}, []string{"type", "rw", "dim"})
 
+	evictedStoppingStoreStatusGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "scheduler",
+			Name:      "evicted_stopping_store_status",
+			Help:      "Store evicted status due to stopping",
+		}, []string{"store"})
+
 	storeSlowTrendEvictedStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
@@ -159,6 +167,7 @@ func init() {
 	prometheus.MustRegister(tolerantResourceStatus)
 	prometheus.MustRegister(hotPendingStatus)
 	prometheus.MustRegister(hotPeerHist)
+	prometheus.MustRegister(evictedStoppingStoreStatusGauge)
 	prometheus.MustRegister(storeSlowTrendEvictedStatusGauge)
 	prometheus.MustRegister(storeSlowTrendActionStatusGauge)
 	prometheus.MustRegister(storeSlowTrendMiscGauge)
@@ -246,7 +255,8 @@ var (
 	evictLeaderNoTargetStoreCounter = evictLeaderCounterWithEvent("no-target-store")
 	evictLeaderNewOperatorCounter   = evictLeaderCounterWithEvent("new-operator")
 
-	evictSlowStoreCounter = schedulerCounter.WithLabelValues(types.EvictSlowStoreScheduler.String(), "schedule")
+	evictSlowStoreCounter     = schedulerCounter.WithLabelValues(types.EvictSlowStoreScheduler.String(), "schedule")
+	evictStoppingStoreCounter = schedulerCounter.WithLabelValues(types.EvictStoppingStoreScheduler.String(), "schedule")
 
 	grantHotRegionCounter     = grantHotRegionCounterWithEvent("schedule")
 	grantHotRegionSkipCounter = grantHotRegionCounterWithEvent("skip")

--- a/pkg/schedule/types/type.go
+++ b/pkg/schedule/types/type.go
@@ -48,6 +48,8 @@ const (
 	EvictSlowStoreScheduler CheckerSchedulerType = "evict-slow-store-scheduler"
 	// EvictSlowTrendScheduler is evict leader by slow trend scheduler name.
 	EvictSlowTrendScheduler CheckerSchedulerType = "evict-slow-trend-scheduler"
+	// EvictStoppingStoreScheduler is evict stopping store scheduler name.
+	EvictStoppingStoreScheduler CheckerSchedulerType = "evict-stopping-store-scheduler"
 	// GrantLeaderScheduler is grant leader scheduler name.
 	GrantLeaderScheduler CheckerSchedulerType = "grant-leader-scheduler"
 	// GrantHotRegionScheduler is grant hot region scheduler name.
@@ -86,6 +88,7 @@ var (
 		EvictLeaderScheduler:           "evict-leader",
 		EvictSlowStoreScheduler:        "evict-slow-store",
 		EvictSlowTrendScheduler:        "evict-slow-trend",
+		EvictStoppingStoreScheduler:    "evict-stopping-store",
 		GrantLeaderScheduler:           "grant-leader",
 		GrantHotRegionScheduler:        "grant-hot-region",
 		BalanceHotRegionScheduler:      "hot-region",
@@ -109,6 +112,7 @@ var (
 		"evict-leader":            EvictLeaderScheduler,
 		"evict-slow-store":        EvictSlowStoreScheduler,
 		"evict-slow-trend":        EvictSlowTrendScheduler,
+		"evict-stopping-store":    EvictStoppingStoreScheduler,
 		"grant-leader":            GrantLeaderScheduler,
 		"grant-hot-region":        GrantHotRegionScheduler,
 		"hot-region":              BalanceHotRegionScheduler,
@@ -124,17 +128,18 @@ var (
 
 	// StringToSchedulerType is a map to convert the scheduler string to the CheckerSchedulerType.
 	StringToSchedulerType = map[string]CheckerSchedulerType{
-		"balance-leader-scheduler":     BalanceLeaderScheduler,
-		"balance-region-scheduler":     BalanceRegionScheduler,
-		"balance-witness-scheduler":    BalanceWitnessScheduler,
-		"evict-leader-scheduler":       EvictLeaderScheduler,
-		"evict-slow-store-scheduler":   EvictSlowStoreScheduler,
-		"evict-slow-trend-scheduler":   EvictSlowTrendScheduler,
-		"grant-leader-scheduler":       GrantLeaderScheduler,
-		"grant-hot-region-scheduler":   GrantHotRegionScheduler,
-		"balance-hot-region-scheduler": BalanceHotRegionScheduler,
-		"random-merge-scheduler":       RandomMergeScheduler,
-		"scatter-range-scheduler":      ScatterRangeScheduler,
+		"balance-leader-scheduler":       BalanceLeaderScheduler,
+		"balance-region-scheduler":       BalanceRegionScheduler,
+		"balance-witness-scheduler":      BalanceWitnessScheduler,
+		"evict-leader-scheduler":         EvictLeaderScheduler,
+		"evict-slow-store-scheduler":     EvictSlowStoreScheduler,
+		"evict-slow-trend-scheduler":     EvictSlowTrendScheduler,
+		"evict-stopping-store-scheduler": EvictStoppingStoreScheduler,
+		"grant-leader-scheduler":         GrantLeaderScheduler,
+		"grant-hot-region-scheduler":     GrantHotRegionScheduler,
+		"balance-hot-region-scheduler":   BalanceHotRegionScheduler,
+		"random-merge-scheduler":         RandomMergeScheduler,
+		"scatter-range-scheduler":        ScatterRangeScheduler,
 		// TODO: remove `scatter-range` after remove `NewScatterRangeSchedulerCommand` from pd-ctl
 		"scatter-range":                     ScatterRangeScheduler,
 		"shuffle-hot-region-scheduler":      ShuffleHotRegionScheduler,
@@ -156,5 +161,6 @@ var (
 		BalanceRegionScheduler,
 		BalanceHotRegionScheduler,
 		EvictSlowStoreScheduler,
+		EvictStoppingStoreScheduler,
 	}
 )

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3171,6 +3171,7 @@ func TestAddScheduler(t *testing.T) {
 	re.NoError(controller.RemoveScheduler(types.BalanceRegionScheduler.String()))
 	re.NoError(controller.RemoveScheduler(types.BalanceHotRegionScheduler.String()))
 	re.NoError(controller.RemoveScheduler(types.EvictSlowStoreScheduler.String()))
+	re.NoError(controller.RemoveScheduler(types.EvictStoppingStoreScheduler.String()))
 	re.Empty(controller.GetSchedulerNames())
 
 	stream := mockhbstream.NewHeartbeatStream()
@@ -3266,6 +3267,7 @@ func TestPersistScheduler(t *testing.T) {
 	re.NoError(controller.RemoveScheduler(types.BalanceRegionScheduler.String()))
 	re.NoError(controller.RemoveScheduler(types.BalanceHotRegionScheduler.String()))
 	re.NoError(controller.RemoveScheduler(types.EvictSlowStoreScheduler.String()))
+	re.NoError(controller.RemoveScheduler(types.EvictStoppingStoreScheduler.String()))
 	// only remains 2 items with independent config.
 	re.Len(controller.GetSchedulerNames(), 2)
 	re.NoError(co.GetCluster().GetSchedulerConfig().Persist(storage))
@@ -3380,6 +3382,7 @@ func TestRemoveScheduler(t *testing.T) {
 	re.NoError(controller.RemoveScheduler(types.BalanceHotRegionScheduler.String()))
 	re.NoError(controller.RemoveScheduler(types.GrantLeaderScheduler.String()))
 	re.NoError(controller.RemoveScheduler(types.EvictSlowStoreScheduler.String()))
+	re.NoError(controller.RemoveScheduler(types.EvictStoppingStoreScheduler.String()))
 	// all removed
 	sches, _, err = storage.LoadAllSchedulerConfigs()
 	re.NoError(err)

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -3140,61 +3140,61 @@ func currentFunction() string {
 }
 
 // QueryRegion implements gRPC PDServer.
-func (s *GrpcServer) QueryRegion(stream pdpb.PD_QueryRegionServer) error {
+func (*GrpcServer) QueryRegion(_ pdpb.PD_QueryRegionServer) error {
 	return status.Errorf(codes.Unimplemented, "QueryRegion not implemented")
 }
 
 // AdvanceGCSafePoint implements gRPC PDServer.
-func (s *GrpcServer) AdvanceGCSafePoint(ctx context.Context, request *pdpb.AdvanceGCSafePointRequest) (*pdpb.AdvanceGCSafePointResponse, error) {
+func (*GrpcServer) AdvanceGCSafePoint(_ context.Context, _ *pdpb.AdvanceGCSafePointRequest) (*pdpb.AdvanceGCSafePointResponse, error) {
 	return &pdpb.AdvanceGCSafePointResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "AdvanceGCSafePoint not implemented"),
 	}, nil
 }
 
 // AdvanceTxnSafePoint implements gRPC PDServer.
-func (s *GrpcServer) AdvanceTxnSafePoint(ctx context.Context, request *pdpb.AdvanceTxnSafePointRequest) (*pdpb.AdvanceTxnSafePointResponse, error) {
+func (*GrpcServer) AdvanceTxnSafePoint(_ context.Context, _ *pdpb.AdvanceTxnSafePointRequest) (*pdpb.AdvanceTxnSafePointResponse, error) {
 	return &pdpb.AdvanceTxnSafePointResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "AdvanceTxnSafePoint not implemented"),
 	}, nil
 }
 
 // SetGCBarrier implements gRPC PDServer.
-func (s *GrpcServer) SetGCBarrier(ctx context.Context, request *pdpb.SetGCBarrierRequest) (*pdpb.SetGCBarrierResponse, error) {
+func (*GrpcServer) SetGCBarrier(_ context.Context, _ *pdpb.SetGCBarrierRequest) (*pdpb.SetGCBarrierResponse, error) {
 	return &pdpb.SetGCBarrierResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "SetGCBarrier not implemented"),
 	}, nil
 }
 
 // DeleteGCBarrier implements gRPC PDServer.
-func (s *GrpcServer) DeleteGCBarrier(ctx context.Context, request *pdpb.DeleteGCBarrierRequest) (*pdpb.DeleteGCBarrierResponse, error) {
+func (*GrpcServer) DeleteGCBarrier(_ context.Context, _ *pdpb.DeleteGCBarrierRequest) (*pdpb.DeleteGCBarrierResponse, error) {
 	return &pdpb.DeleteGCBarrierResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "DeleteGCBarrier not implemented"),
 	}, nil
 }
 
 // SetGlobalGCBarrier implements gRPC PDServer.
-func (s *GrpcServer) SetGlobalGCBarrier(ctx context.Context, request *pdpb.SetGlobalGCBarrierRequest) (*pdpb.SetGlobalGCBarrierResponse, error) {
+func (*GrpcServer) SetGlobalGCBarrier(_ context.Context, _ *pdpb.SetGlobalGCBarrierRequest) (*pdpb.SetGlobalGCBarrierResponse, error) {
 	return &pdpb.SetGlobalGCBarrierResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "SetGlobalGCBarrier not implemented"),
 	}, nil
 }
 
 // DeleteGlobalGCBarrier implements gRPC PDServer.
-func (s *GrpcServer) DeleteGlobalGCBarrier(ctx context.Context, request *pdpb.DeleteGlobalGCBarrierRequest) (*pdpb.DeleteGlobalGCBarrierResponse, error) {
+func (*GrpcServer) DeleteGlobalGCBarrier(_ context.Context, _ *pdpb.DeleteGlobalGCBarrierRequest) (*pdpb.DeleteGlobalGCBarrierResponse, error) {
 	return &pdpb.DeleteGlobalGCBarrierResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "DeleteGlobalGCBarrier not implemented"),
 	}, nil
 }
 
 // GetGCState implements gRPC PDServer.
-func (s *GrpcServer) GetGCState(ctx context.Context, request *pdpb.GetGCStateRequest) (*pdpb.GetGCStateResponse, error) {
+func (*GrpcServer) GetGCState(_ context.Context, _ *pdpb.GetGCStateRequest) (*pdpb.GetGCStateResponse, error) {
 	return &pdpb.GetGCStateResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "GetGCState not implemented"),
 	}, nil
 }
 
 // GetAllKeyspacesGCStates implements gRPC PDServer.
-func (s *GrpcServer) GetAllKeyspacesGCStates(ctx context.Context, request *pdpb.GetAllKeyspacesGCStatesRequest) (*pdpb.GetAllKeyspacesGCStatesResponse, error) {
+func (*GrpcServer) GetAllKeyspacesGCStates(_ context.Context, _ *pdpb.GetAllKeyspacesGCStatesRequest) (*pdpb.GetAllKeyspacesGCStatesResponse, error) {
 	return &pdpb.GetAllKeyspacesGCStatesResponse{
 		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "GetAllKeyspacesGCStates not implemented"),
 	}, nil

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -3138,3 +3138,64 @@ func currentFunction() string {
 	s := strings.Split(runtime.FuncForPC(counter).Name(), ".")
 	return s[len(s)-1]
 }
+
+// QueryRegion implements gRPC PDServer.
+func (s *GrpcServer) QueryRegion(stream pdpb.PD_QueryRegionServer) error {
+	return status.Errorf(codes.Unimplemented, "QueryRegion not implemented")
+}
+
+// AdvanceGCSafePoint implements gRPC PDServer.
+func (s *GrpcServer) AdvanceGCSafePoint(ctx context.Context, request *pdpb.AdvanceGCSafePointRequest) (*pdpb.AdvanceGCSafePointResponse, error) {
+	return &pdpb.AdvanceGCSafePointResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "AdvanceGCSafePoint not implemented"),
+	}, nil
+}
+
+// AdvanceTxnSafePoint implements gRPC PDServer.
+func (s *GrpcServer) AdvanceTxnSafePoint(ctx context.Context, request *pdpb.AdvanceTxnSafePointRequest) (*pdpb.AdvanceTxnSafePointResponse, error) {
+	return &pdpb.AdvanceTxnSafePointResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "AdvanceTxnSafePoint not implemented"),
+	}, nil
+}
+
+// SetGCBarrier implements gRPC PDServer.
+func (s *GrpcServer) SetGCBarrier(ctx context.Context, request *pdpb.SetGCBarrierRequest) (*pdpb.SetGCBarrierResponse, error) {
+	return &pdpb.SetGCBarrierResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "SetGCBarrier not implemented"),
+	}, nil
+}
+
+// DeleteGCBarrier implements gRPC PDServer.
+func (s *GrpcServer) DeleteGCBarrier(ctx context.Context, request *pdpb.DeleteGCBarrierRequest) (*pdpb.DeleteGCBarrierResponse, error) {
+	return &pdpb.DeleteGCBarrierResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "DeleteGCBarrier not implemented"),
+	}, nil
+}
+
+// SetGlobalGCBarrier implements gRPC PDServer.
+func (s *GrpcServer) SetGlobalGCBarrier(ctx context.Context, request *pdpb.SetGlobalGCBarrierRequest) (*pdpb.SetGlobalGCBarrierResponse, error) {
+	return &pdpb.SetGlobalGCBarrierResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "SetGlobalGCBarrier not implemented"),
+	}, nil
+}
+
+// DeleteGlobalGCBarrier implements gRPC PDServer.
+func (s *GrpcServer) DeleteGlobalGCBarrier(ctx context.Context, request *pdpb.DeleteGlobalGCBarrierRequest) (*pdpb.DeleteGlobalGCBarrierResponse, error) {
+	return &pdpb.DeleteGlobalGCBarrierResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "DeleteGlobalGCBarrier not implemented"),
+	}, nil
+}
+
+// GetGCState implements gRPC PDServer.
+func (s *GrpcServer) GetGCState(ctx context.Context, request *pdpb.GetGCStateRequest) (*pdpb.GetGCStateResponse, error) {
+	return &pdpb.GetGCStateResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "GetGCState not implemented"),
+	}, nil
+}
+
+// GetAllKeyspacesGCStates implements gRPC PDServer.
+func (s *GrpcServer) GetAllKeyspacesGCStates(ctx context.Context, request *pdpb.GetAllKeyspacesGCStatesRequest) (*pdpb.GetAllKeyspacesGCStatesResponse, error) {
+	return &pdpb.GetAllKeyspacesGCStatesResponse{
+		Header: wrapErrorToHeader(pdpb.ErrorType_UNKNOWN, "GetAllKeyspacesGCStates not implemented"),
+	}, nil
+}

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c
-	github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31
+	github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/client_model v0.6.0

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -387,8 +387,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c h1:CgbKAHto5CQgWM9fSBIvaxsJHuGP0uM74HXtv3MyyGQ=
 github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31 h1:6BY+3T6Hqpw9UZ/D7Om/xB+Xik3NkkYxBV6qCzUdUvU=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599 h1:57fBeBND/j/dp7nVlw+cWEwYlt4u8CAe4ApsmAEb1ow=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -145,7 +145,7 @@ func (suite *serverTestSuite) TestPrimaryChange() {
 	testutil.Eventually(re, func() bool {
 		watchedAddr, ok := suite.pdLeader.GetServicePrimaryAddr(suite.ctx, constant.SchedulingServiceName)
 		return ok && oldPrimaryAddr == watchedAddr &&
-			len(primary.GetCluster().GetCoordinator().GetSchedulersController().GetSchedulerNames()) == 4
+			len(primary.GetCluster().GetCoordinator().GetSchedulersController().GetSchedulerNames()) == 5
 	})
 	// change primary
 	primary.Close()
@@ -156,7 +156,7 @@ func (suite *serverTestSuite) TestPrimaryChange() {
 	testutil.Eventually(re, func() bool {
 		watchedAddr, ok := suite.pdLeader.GetServicePrimaryAddr(suite.ctx, constant.SchedulingServiceName)
 		return ok && newPrimaryAddr == watchedAddr &&
-			len(primary.GetCluster().GetCoordinator().GetSchedulersController().GetSchedulerNames()) == 4
+			len(primary.GetCluster().GetCoordinator().GetSchedulersController().GetSchedulerNames()) == 5
 	})
 }
 

--- a/tests/server/api/scheduler_test.go
+++ b/tests/server/api/scheduler_test.go
@@ -530,6 +530,10 @@ func (suite *scheduleTestSuite) checkAPI(cluster *tests.TestCluster) {
 			name:        "evict-slow-store-scheduler",
 			createdName: "evict-slow-store-scheduler",
 		},
+		{
+			name:        "evict-stopping-store-scheduler",
+			createdName: "evict-stopping-store-scheduler",
+		},
 	}
 	for _, testCase := range testCases {
 		input := make(map[string]any)

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/influxdata/tdigest v0.0.1
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
-	github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00
-	github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31
+	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c
+	github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.51.1

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -381,11 +381,11 @@ github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTw
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTmyFqUwr+jcCvpVkK7sumiz+ko5H9eq4=
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
-github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00 h1:C3N3itkduZXDZFh4N3vQ5HEtld3S+Y+StULhWVvumU0=
-github.com/pingcap/failpoint v0.0.0-20210918120811-547c13e3eb00/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
+github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c h1:CgbKAHto5CQgWM9fSBIvaxsJHuGP0uM74HXtv3MyyGQ=
+github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31 h1:6BY+3T6Hqpw9UZ/D7Om/xB+Xik3NkkYxBV6qCzUdUvU=
-github.com/pingcap/kvproto v0.0.0-20240910154453-b242104f8d31/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599 h1:57fBeBND/j/dp7nVlw+cWEwYlt4u8CAe4ApsmAEb1ow=
+github.com/pingcap/kvproto v0.0.0-20250923091925-d79d11002599/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/tools/pd-ctl/pdctl/command/scheduler.go
+++ b/tools/pd-ctl/pdctl/command/scheduler.go
@@ -161,6 +161,7 @@ func NewAddSchedulerCommand() *cobra.Command {
 	c.AddCommand(NewSlowTrendEvictLeaderSchedulerCommand())
 	c.AddCommand(NewBalanceWitnessSchedulerCommand())
 	c.AddCommand(NewTransferWitnessLeaderSchedulerCommand())
+	c.AddCommand(NewEvictStoppingStoreSchedulerCommand())
 	return c
 }
 
@@ -297,6 +298,16 @@ func NewEvictSlowStoreSchedulerCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "evict-slow-store-scheduler",
 		Short: "add a scheduler to detect and evict slow stores",
+		Run:   addSchedulerCommandFunc,
+	}
+	return c
+}
+
+// NewEvictStoppingStoreSchedulerCommand returns a command to add a evict-stopping-store-scheduler.
+func NewEvictStoppingStoreSchedulerCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "evict-stopping-store-scheduler",
+		Short: "add a scheduler to detect and evict stopping stores",
 		Run:   addSchedulerCommandFunc,
 	}
 	return c
@@ -520,6 +531,7 @@ func NewConfigSchedulerCommand() *cobra.Command {
 		newConfigBalanceLeaderCommand(),
 		newSplitBucketCommand(),
 		newConfigEvictSlowStoreCommand(),
+		newConfigEvictStoppingStoreCommand(),
 		newConfigShuffleHotRegionSchedulerCommand(),
 		newConfigEvictSlowTrendCommand(),
 	)
@@ -904,6 +916,25 @@ func newConfigEvictSlowTrendCommand() *cobra.Command {
 	c.AddCommand(&cobra.Command{
 		Use:   "show",
 		Short: "list the config item",
+		Run:   listSchedulerConfigCommandFunc,
+	}, &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "set the config item",
+		Run:   func(cmd *cobra.Command, args []string) { postSchedulerConfigCommandFunc(cmd, c.Name(), args) },
+	})
+	return c
+}
+
+func newConfigEvictStoppingStoreCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "evict-stopping-store-scheduler",
+		Short: "evict-stopping-store-scheduler config",
+		Run:   listSchedulerConfigCommandFunc,
+	}
+
+	c.AddCommand(&cobra.Command{
+		Use:   "show",
+		Short: "show the config item",
 		Run:   listSchedulerConfigCommandFunc,
 	}, &cobra.Command{
 		Use:   "set <key> <value>",

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -165,9 +165,10 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 	// scheduler delete command
 	args := []string{"-u", pdAddr, "scheduler", "remove", "balance-region-scheduler"}
 	expected := map[string]bool{
-		"balance-leader-scheduler":     true,
-		"balance-hot-region-scheduler": true,
-		"evict-slow-store-scheduler":   true,
+		"balance-leader-scheduler":       true,
+		"balance-hot-region-scheduler":   true,
+		"evict-slow-store-scheduler":     true,
+		"evict-stopping-store-scheduler": true,
 	}
 	checkSchedulerCommand(re, cmd, pdAddr, args, expected)
 
@@ -214,10 +215,11 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		// scheduler add command
 		args = []string{"-u", pdAddr, "scheduler", "add", schedulers[idx], "2"}
 		expected = map[string]bool{
-			"balance-leader-scheduler":     true,
-			"balance-hot-region-scheduler": true,
-			schedulers[idx]:                true,
-			"evict-slow-store-scheduler":   true,
+			"balance-leader-scheduler":       true,
+			"balance-hot-region-scheduler":   true,
+			schedulers[idx]:                  true,
+			"evict-slow-store-scheduler":     true,
+			"evict-stopping-store-scheduler": true,
 		}
 		checkSchedulerCommand(re, cmd, pdAddr, args, expected)
 
@@ -230,10 +232,11 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		// scheduler config update command
 		args = []string{"-u", pdAddr, "scheduler", "config", schedulers[idx], "add-store", "3"}
 		expected = map[string]bool{
-			"balance-leader-scheduler":     true,
-			"balance-hot-region-scheduler": true,
-			schedulers[idx]:                true,
-			"evict-slow-store-scheduler":   true,
+			"balance-leader-scheduler":       true,
+			"balance-hot-region-scheduler":   true,
+			schedulers[idx]:                  true,
+			"evict-slow-store-scheduler":     true,
+			"evict-stopping-store-scheduler": true,
 		}
 
 		// check update success
@@ -245,9 +248,10 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		// scheduler delete command
 		args = []string{"-u", pdAddr, "scheduler", "remove", schedulers[idx]}
 		expected = map[string]bool{
-			"balance-leader-scheduler":     true,
-			"balance-hot-region-scheduler": true,
-			"evict-slow-store-scheduler":   true,
+			"balance-leader-scheduler":       true,
+			"balance-hot-region-scheduler":   true,
+			"evict-slow-store-scheduler":     true,
+			"evict-stopping-store-scheduler": true,
 		}
 		checkSchedulerCommand(re, cmd, pdAddr, args, expected)
 		checkStorePause([]uint64{}, schedulers[idx])
@@ -255,10 +259,11 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		// scheduler add command
 		args = []string{"-u", pdAddr, "scheduler", "add", schedulers[idx], "2"}
 		expected = map[string]bool{
-			"balance-leader-scheduler":     true,
-			"balance-hot-region-scheduler": true,
-			schedulers[idx]:                true,
-			"evict-slow-store-scheduler":   true,
+			"balance-leader-scheduler":       true,
+			"balance-hot-region-scheduler":   true,
+			schedulers[idx]:                  true,
+			"evict-slow-store-scheduler":     true,
+			"evict-stopping-store-scheduler": true,
 		}
 		checkSchedulerCommand(re, cmd, pdAddr, args, expected)
 		checkStorePause([]uint64{2}, schedulers[idx])
@@ -266,10 +271,11 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		// scheduler add command twice
 		args = []string{"-u", pdAddr, "scheduler", "add", schedulers[idx], "4"}
 		expected = map[string]bool{
-			"balance-leader-scheduler":     true,
-			"balance-hot-region-scheduler": true,
-			schedulers[idx]:                true,
-			"evict-slow-store-scheduler":   true,
+			"balance-leader-scheduler":       true,
+			"balance-hot-region-scheduler":   true,
+			schedulers[idx]:                  true,
+			"evict-slow-store-scheduler":     true,
+			"evict-stopping-store-scheduler": true,
 		}
 		checkSchedulerCommand(re, cmd, pdAddr, args, expected)
 
@@ -281,10 +287,11 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		// scheduler remove command [old]
 		args = []string{"-u", pdAddr, "scheduler", "remove", schedulers[idx] + "-4"}
 		expected = map[string]bool{
-			"balance-leader-scheduler":     true,
-			"balance-hot-region-scheduler": true,
-			schedulers[idx]:                true,
-			"evict-slow-store-scheduler":   true,
+			"balance-leader-scheduler":       true,
+			"balance-hot-region-scheduler":   true,
+			schedulers[idx]:                  true,
+			"evict-slow-store-scheduler":     true,
+			"evict-stopping-store-scheduler": true,
 		}
 		checkSchedulerCommand(re, cmd, pdAddr, args, expected)
 
@@ -296,9 +303,10 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 		// scheduler remove command, when remove the last store, it should remove whole scheduler
 		args = []string{"-u", pdAddr, "scheduler", "remove", schedulers[idx] + "-2"}
 		expected = map[string]bool{
-			"balance-leader-scheduler":     true,
-			"balance-hot-region-scheduler": true,
-			"evict-slow-store-scheduler":   true,
+			"balance-leader-scheduler":       true,
+			"balance-hot-region-scheduler":   true,
+			"evict-slow-store-scheduler":     true,
+			"evict-stopping-store-scheduler": true,
 		}
 		checkSchedulerCommand(re, cmd, pdAddr, args, expected)
 		checkStorePause([]uint64{}, schedulers[idx])
@@ -332,6 +340,11 @@ func (suite *schedulerTestSuite) checkScheduler(cluster *pdTests.TestCluster) {
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "remove", "balance-hot-region-scheduler"}, nil)
 	re.Contains(echo, "Success")
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "balance-hot-region-scheduler"}, nil)
+	re.Contains(echo, "Success")
+
+	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "remove", "evict-stopping-store-scheduler"}, nil)
+	re.Contains(echo, "Success")
+	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "evict-stopping-store-scheduler"}, nil)
 	re.Contains(echo, "Success")
 
 	// test show scheduler with paused and disabled status.
@@ -467,10 +480,11 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 	}
 	// test shuffle region config
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "add", "shuffle-region-scheduler"}, map[string]bool{
-		"balance-region-scheduler":     true,
-		"balance-leader-scheduler":     true,
-		"balance-hot-region-scheduler": true,
-		"shuffle-region-scheduler":     true,
+		"balance-region-scheduler":       true,
+		"balance-leader-scheduler":       true,
+		"balance-hot-region-scheduler":   true,
+		"shuffle-region-scheduler":       true,
+		"evict-stopping-store-scheduler": true,
 	})
 	var roles []string
 	mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "shuffle-region-scheduler", "show-roles"}, &roles)
@@ -485,9 +499,10 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 	re.Equal([]string{"learner"}, roles)
 
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "remove", "shuffle-region-scheduler"}, map[string]bool{
-		"balance-region-scheduler":     true,
-		"balance-leader-scheduler":     true,
-		"balance-hot-region-scheduler": true,
+		"balance-region-scheduler":       true,
+		"balance-leader-scheduler":       true,
+		"balance-hot-region-scheduler":   true,
+		"evict-stopping-store-scheduler": true,
 	})
 
 	// test shuffle hot region scheduler
@@ -557,6 +572,20 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 	})
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "balance-leader-scheduler"}, nil)
 	re.Contains(echo, "Success!")
+
+	// test evict-stopping-store scheduler config
+	conf = make(map[string]any)
+	conf1 = make(map[string]any)
+	testutil.Eventually(re, func() bool {
+		mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-stopping-store-scheduler", "show"}, &conf)
+		return conf["batch"] == 3.
+	})
+	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-stopping-store-scheduler", "set", "batch", "10"}, nil)
+	re.Contains(echo, "Success!")
+	testutil.Eventually(re, func() bool {
+		mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-stopping-store-scheduler"}, &conf1)
+		return conf1["batch"] == 10.
+	})
 }
 
 func (suite *schedulerTestSuite) TestGrantHotRegionScheduler() {
@@ -612,16 +641,18 @@ func (suite *schedulerTestSuite) checkGrantHotRegionScheduler(cluster *pdTests.T
 
 	// case 3: add grant-hot-region-scheduler when balance-hot-region-scheduler is disabled
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "remove", "balance-hot-region-scheduler"}, map[string]bool{
-		"balance-region-scheduler":   true,
-		"balance-leader-scheduler":   true,
-		"evict-slow-store-scheduler": true,
+		"balance-region-scheduler":       true,
+		"balance-leader-scheduler":       true,
+		"evict-slow-store-scheduler":     true,
+		"evict-stopping-store-scheduler": true,
 	})
 
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "add", "grant-hot-region-scheduler", "1", "2,3"}, map[string]bool{
-		"balance-region-scheduler":   true,
-		"balance-leader-scheduler":   true,
-		"grant-hot-region-scheduler": true,
-		"evict-slow-store-scheduler": true,
+		"balance-region-scheduler":       true,
+		"balance-leader-scheduler":       true,
+		"grant-hot-region-scheduler":     true,
+		"evict-slow-store-scheduler":     true,
+		"evict-stopping-store-scheduler": true,
 	})
 
 	// case 4: test grant-hot-region-scheduler config
@@ -642,17 +673,19 @@ func (suite *schedulerTestSuite) checkGrantHotRegionScheduler(cluster *pdTests.T
 	})
 
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "remove", "grant-hot-region-scheduler"}, map[string]bool{
-		"balance-region-scheduler":   true,
-		"balance-leader-scheduler":   true,
-		"evict-slow-store-scheduler": true,
+		"balance-region-scheduler":       true,
+		"balance-leader-scheduler":       true,
+		"evict-slow-store-scheduler":     true,
+		"evict-stopping-store-scheduler": true,
 	})
 
 	// use duplicate store id
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "add", "grant-hot-region-scheduler", "3", "1,2,3"}, map[string]bool{
-		"balance-region-scheduler":   true,
-		"balance-leader-scheduler":   true,
-		"grant-hot-region-scheduler": true,
-		"evict-slow-store-scheduler": true,
+		"balance-region-scheduler":       true,
+		"balance-leader-scheduler":       true,
+		"grant-hot-region-scheduler":     true,
+		"evict-slow-store-scheduler":     true,
+		"evict-stopping-store-scheduler": true,
 	})
 	expected3["store-leader-id"] = float64(3)
 	testutil.Eventually(re, func() bool {
@@ -665,9 +698,10 @@ func (suite *schedulerTestSuite) checkGrantHotRegionScheduler(cluster *pdTests.T
 	re.Contains(echo, "grant-hot-region-scheduler is running, please remove it first")
 
 	checkSchedulerCommand(re, cmd, pdAddr, []string{"-u", pdAddr, "scheduler", "remove", "grant-hot-region-scheduler"}, map[string]bool{
-		"balance-region-scheduler":   true,
-		"balance-leader-scheduler":   true,
-		"evict-slow-store-scheduler": true,
+		"balance-region-scheduler":       true,
+		"balance-leader-scheduler":       true,
+		"evict-slow-store-scheduler":     true,
+		"evict-stopping-store-scheduler": true,
 	})
 
 	echo = mustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "add", "balance-hot-region-scheduler"}, nil)

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -55,6 +55,7 @@ func (suite *schedulerTestSuite) SetupSuite() {
 		"balance-region-scheduler",
 		"balance-hot-region-scheduler",
 		"evict-slow-store-scheduler",
+		"evict-stopping-store-scheduler",
 	}
 }
 


### PR DESCRIPTION
close tikv/pd#9719

Add an is_stopping status to the StoreHeartbeat message. When TiKV receives a SIGTERM, it sets this flag. This change adds a new evict-stopping-store-scheduler to PD, which is analogous to the evict-slow-store-scheduler. It proactively transfers leaders away from nodes by inspecting the is_stopping status from store heartbeats.

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9719 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Add an is_stopping status to the StoreHeartbeat message. When TiKV receives a SIGTERM, it sets this flag. This change adds a new evict-stopping-store-scheduler to PD, which is analogous to the evict-slow-store-scheduler. It proactively transfers leaders away from nodes by inspecting the is_stopping status from store heartbeats.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes

- Has the configuration change

Side effects

- Increased code complexity

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
