### PR TITLE
fix(cluster,core): refine DFS stats collection log and filtering

### DIFF
--- a/pkg/core/store_stats_test.go
+++ b/pkg/core/store_stats_test.go
@@ -110,4 +110,28 @@ func TestDFSStats(t *testing.T) {
 	re.Len(scopedDFSStats, 1)
 	re.Equal(storeStats.Dfs[0].WrittenBytes+storeStats.Dfs[1].WrittenBytes, scopedDFSStats[*storeStats.Dfs[0].Scope].WrittenBytes)
 	re.Equal(storeStats.Dfs[0].WriteRequests+storeStats.Dfs[1].WriteRequests, scopedDFSStats[*storeStats.Dfs[0].Scope].WriteRequests)
+
+	storeStats.Dfs = []*pdpb.DfsStatItem{
+		{
+			Scope: &pdpb.DfsStatScope{
+				KeyspaceId: 1,
+				Component:  "test-component",
+			},
+			WrittenBytes:  10,
+			WriteRequests: 0,
+		},
+		{
+			Scope: &pdpb.DfsStatScope{
+				KeyspaceId: 2,
+				Component:  "test-component",
+			},
+			WrittenBytes:  0,
+			WriteRequests: 0,
+		},
+	}
+	store = store.Clone(SetStoreStats(storeStats))
+	scopedDFSStats = store.TakeScopedDFSStats()
+	re.Len(scopedDFSStats, 1)
+	re.Equal(storeStats.Dfs[0].WrittenBytes, scopedDFSStats[*storeStats.Dfs[0].Scope].WrittenBytes)
+	re.Equal(storeStats.Dfs[0].WriteRequests, scopedDFSStats[*storeStats.Dfs[0].Scope].WriteRequests)
 }

--- a/server/cluster/metering_test.go
+++ b/server/cluster/metering_test.go
@@ -159,7 +159,9 @@ func TestCollectDfsStats(t *testing.T) {
 	}
 
 	collector := newDfsStatsCollector()
-	collector.Collect(tc.collectDfsStats(keyspaceManager))
+	keyspaceDFSStats, storeCount := tc.collectDFSStats(keyspaceManager)
+	re.Len(stores, storeCount)
+	collector.Collect(keyspaceDFSStats)
 	records := collector.Aggregate()
 	re.Len(records, 4)
 	// Sort the records by the keyspace name.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9707.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
- Updated store stats collection to skip DFS stat items with zero written bytes and write requests.
- Added logging of collection duration and item count.
- Expanded unit tests to cover filtering of zero-value DFS stat entries and verify aggregation correctness.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
