### PR TITLE
mcs: fix `/config` and `/members` tso forward logic

### DIFF
--- a/tests/integrations/mcs/tso/api_test.go
+++ b/tests/integrations/mcs/tso/api_test.go
@@ -72,7 +72,7 @@ func (suite *tsoAPITestSuite) SetupTest() {
 	pdLeaderServer := suite.pdCluster.GetServer(leaderName)
 	re.NoError(pdLeaderServer.BootstrapCluster())
 	suite.backendEndpoints = pdLeaderServer.GetAddr()
-	suite.tsoCluster, err = tests.NewTestTSOCluster(suite.ctx, 1, suite.backendEndpoints)
+	suite.tsoCluster, err = tests.NewTestTSOCluster(suite.ctx, 2, suite.backendEndpoints)
 	re.NoError(err)
 }
 
@@ -296,4 +296,63 @@ func (suite *tsoAPITestSuite) TestHealth() {
 	re.NoError(err)
 	defer resp.Body.Close()
 	re.Equal(http.StatusOK, resp.StatusCode)
+}
+
+// TestForwardingBehavior specifically tests the API forwarding logic.
+func (suite *tsoAPITestSuite) TestForwardingBehavior() {
+	re := suite.Require()
+
+	primary := suite.tsoCluster.WaitForDefaultPrimaryServing(re)
+	re.NotNil(primary)
+	var follower *tso.Server
+	for _, srv := range suite.tsoCluster.GetServers() {
+		if srv.Name() != primary.Name() {
+			follower = srv
+			break
+		}
+	}
+	re.NotNil(follower)
+	re.True(primary.IsServing())
+	re.False(follower.IsServing())
+	re.NotEqual(follower.GetConfig().GetListenAddr(), primary.GetConfig().GetListenAddr())
+
+	followerAddr := follower.GetAddr()
+	followerURL := func(path string) string {
+		return fmt.Sprintf("%s%s%s", followerAddr, apis.APIPathPrefix, path)
+	}
+
+	// Test: PUT /admin/log should be handled by the follower locally.
+	logURL := followerURL("/admin/log")
+	level := "debug"
+	logPayload, err := json.Marshal(level)
+	re.NoError(err)
+	req, _ := http.NewRequest(http.MethodPut, logURL, bytes.NewBuffer(logPayload))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := tests.TestDialClient.Do(req)
+	re.NoError(err)
+	defer resp.Body.Close()
+	re.Equal(http.StatusOK, resp.StatusCode)
+
+	// Test: GET /config should be handled by the follower locally.
+	configURL := followerURL("/config")
+	var followerCfg tso.Config
+	err = testutil.ReadGetJSON(re, tests.TestDialClient, configURL, &followerCfg)
+	re.NoError(err)
+	re.Equal(follower.GetConfig().GetListenAddr(), followerCfg.GetListenAddr())
+	re.NotEqual(primary.GetConfig().GetListenAddr(), followerCfg.GetListenAddr())
+	re.Equal(level, followerCfg.Log.Level)
+
+	// Test: GET /keyspace-groups/members should be handled by the follower locally.
+	membersURL := followerURL("/keyspace-groups/members")
+	var kgms map[uint32]*apis.KeyspaceGroupMember
+	err = testutil.ReadGetJSON(re, tests.TestDialClient, membersURL, &kgms)
+	re.NoError(err)
+	re.Len(kgms, 1)
+	kgm := kgms[constant.DefaultKeyspaceGroupID]
+	re.NotNil(kgm)
+	re.Len(kgm.Member.ListenUrls, 1)
+	respListenUrl := kgm.Member.ListenUrls[0]
+	re.Equal(follower.GetConfig().GetListenAddr(), respListenUrl)
+	re.NotEqual(primary.GetConfig().GetListenAddr(), respListenUrl)
+	re.False(kgm.IsPrimary)
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

We should not use a ServiceRedirector for all urls. 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
Before:
![img_v3_02qn_0f440e76-095e-4a6b-8fe6-de20ffdb3bdg](https://github.com/user-attachments/assets/6be06bed-7897-4593-b6fd-0f8b6c4f8a8b)
After:
![img_v3_02qn_ac6545c0-4b1b-43f0-a347-ea8d279ddafg](https://github.com/user-attachments/assets/b743a748-b93b-4874-8490-4e64d433656d)
![img_v3_02qn_ac6545c0-4b1b-43f0-a347-ea8d279ddafg](https://github.com/user-attachments/assets/ee559ee7-455e-4854-aed0-aaf78505c432)
![img_v3_02qn_6a542d9e-b4d2-497d-88a6-7cf27eed946g](https://github.com/user-attachments/assets/4f91cd18-f7a1-4931-a5a9-8d4ad6a3de27)


### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
