### PR TITLE
Revert "core: caller can't scan too much regions in one lock even if limit equals -1 "

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -47,9 +47,9 @@ import (
 
 const (
 	randomRegionMaxRetry = 10
-	// MaxScanRegionLimit is the maximum number of regions to scan in one lock.
-	MaxScanRegionLimit = 1000
-	batchSearchSize    = 16
+	// ScanRegionLimit is the default limit for the number of regions to scan in a region scan request.
+	ScanRegionLimit = 1000
+	batchSearchSize = 16
 	// CollectFactor is the factor to collect the count of region.
 	CollectFactor = 0.9
 )
@@ -2026,34 +2026,22 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 	return r.tree.GetCountByRange(startKey, endKey)
 }
 
-func (r *RegionsInfo) scanRegionsInner(startKey, endKey []byte, limit int, fns ...scanRegionFunc) ([]*RegionInfo, error) {
-	var res []*RegionInfo
-	for {
-		scanLimit := limit - len(res)
-		regions, err := r.scanRegionsOnce(startKey, endKey, scanLimit, fns...)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, regions...)
-		if limit >= 0 && len(res) >= limit {
-			break
-		}
-		if len(regions) == 0 {
-			break
-		}
-		startKey = regions[len(regions)-1].GetEndKey()
-		// if startKey is empty, it means there is no more region to scan.
-		if len(startKey) == 0 {
-			break
-		}
-	}
-	return res, nil
-}
-
 // ScanRegions scans regions intersecting [start key, end key), returns at most
 // `limit` regions. limit <= 0 means no limit.
 func (r *RegionsInfo) ScanRegions(startKey, endKey []byte, limit int) []*RegionInfo {
-	res, _ := r.scanRegionsInner(startKey, endKey, limit)
+	r.t.RLock()
+	defer r.t.RUnlock()
+	var res []*RegionInfo
+	r.tree.scanRange(startKey, func(region *RegionInfo) bool {
+		if len(endKey) > 0 && bytes.Compare(region.GetStartKey(), endKey) >= 0 {
+			return false
+		}
+		if limit > 0 && len(res) >= limit {
+			return false
+		}
+		res = append(res, region)
+		return true
+	})
 	return res
 }
 
@@ -2070,8 +2058,10 @@ func (r *RegionsInfo) BatchScanRegions(keyRanges *keyutil.KeyRanges, opts ...Bat
 		opt(scanOptions)
 	}
 
+	r.t.RLock()
+	defer r.t.RUnlock()
 	for _, keyRange := range krs {
-		regions, err := r.scanRegion(keyRange, scanOptions.limit, scanOptions.outputMustContainAllKeyRange)
+		regions, err := scanRegion(r.tree, keyRange, scanOptions.limit, scanOptions.outputMustContainAllKeyRange)
 		if err != nil {
 			return nil, err
 		}
@@ -2088,48 +2078,26 @@ func (r *RegionsInfo) BatchScanRegions(keyRanges *keyutil.KeyRanges, opts ...Bat
 	return res, nil
 }
 
-type scanRegionFunc = func(region *RegionInfo) error
-
-func (r *RegionsInfo) scanRegionsOnce(startKey, endKey []byte, limit int, fns ...scanRegionFunc) ([]*RegionInfo, error) {
-	scanLimit := limit
-	// limit <= 0 means no limit.
-	if limit > MaxScanRegionLimit || limit <= 0 {
-		scanLimit = MaxScanRegionLimit
-	}
-	regions := make([]*RegionInfo, 0)
-	r.t.RLock()
-	defer r.t.RUnlock()
-	var err error
-	r.tree.scanRange(startKey, func(region *RegionInfo) bool {
-		if len(endKey) > 0 && bytes.Compare(region.GetStartKey(), endKey) >= 0 {
-			return false
-		}
-		if len(regions) >= scanLimit {
-			return false
-		}
-		for _, fn := range fns {
-			if err = fn(region); err != nil {
-				return false
-			}
-		}
-		regions = append(regions, region)
-		return true
-	})
-	return regions, err
-}
-
-func (r *RegionsInfo) scanRegion(keyRange *keyutil.KeyRange, limit int, outputMustContainAllKeyRange bool) ([]*RegionInfo, error) {
+func scanRegion(regionTree *regionTree, keyRange *keyutil.KeyRange, limit int, outputMustContainAllKeyRange bool) ([]*RegionInfo, error) {
 	var (
 		res        []*RegionInfo
 		lastRegion = &RegionInfo{
 			meta: &metapb.Region{EndKey: keyRange.StartKey},
 		}
 		exceedLimit = func() bool { return limit > 0 && len(res) >= limit }
+		err         error
 	)
-	fn := func(region *RegionInfo) error {
+	regionTree.scanRange(keyRange.StartKey, func(region *RegionInfo) bool {
+		if len(keyRange.EndKey) > 0 && len(region.GetStartKey()) > 0 &&
+			bytes.Compare(region.GetStartKey(), keyRange.EndKey) >= 0 {
+			return false
+		}
+		if exceedLimit() {
+			return false
+		}
 		if len(lastRegion.GetEndKey()) > 0 && len(region.GetStartKey()) > 0 &&
 			bytes.Compare(region.GetStartKey(), lastRegion.GetEndKey()) > 0 {
-			err := errs.ErrRegionNotAdjacent.FastGen(
+			err = errs.ErrRegionNotAdjacent.FastGen(
 				"key range[%x, %x) found a hole region between region[%x, %x) and region[%x, %x)",
 				keyRange.StartKey, keyRange.EndKey,
 				lastRegion.GetStartKey(), lastRegion.GetEndKey(),
@@ -2137,18 +2105,19 @@ func (r *RegionsInfo) scanRegion(keyRange *keyutil.KeyRange, limit int, outputMu
 			log.Warn("scan regions failed", zap.Bool("contain-all-key-range",
 				outputMustContainAllKeyRange), zap.Error(err))
 			if outputMustContainAllKeyRange {
-				return err
+				return false
 			}
 		}
+
 		lastRegion = region
-		return nil
-	}
-	res, err := r.scanRegionsInner(keyRange.StartKey, keyRange.EndKey, limit, fn)
+		res = append(res, region)
+		return true
+	})
 	if outputMustContainAllKeyRange && err != nil {
 		return nil, err
 	}
-	if !(exceedLimit()) && len(keyRange.EndKey) > 0 &&
-		len(lastRegion.GetEndKey()) > 0 &&
+
+	if !(exceedLimit()) && len(keyRange.EndKey) > 0 && len(lastRegion.GetEndKey()) > 0 &&
 		bytes.Compare(lastRegion.GetEndKey(), keyRange.EndKey) < 0 {
 		err = errs.ErrRegionNotAdjacent.FastGen(
 			"key range[%x, %x) found a hole region in the last, the last scanned region is [%x, %x), [%x, %x) is missing",
@@ -2188,7 +2157,7 @@ func (r *RegionsInfo) GetRegionSizeByRange(startKey, endKey []byte) int64 {
 			if len(endKey) > 0 && bytes.Compare(region.GetStartKey(), endKey) >= 0 {
 				return false
 			}
-			if cnt >= MaxScanRegionLimit {
+			if cnt >= ScanRegionLimit {
 				return false
 			}
 			cnt++

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1163,21 +1163,20 @@ func TestCntRefAfterResetRegionCache(t *testing.T) {
 func TestScanRegion(t *testing.T) {
 	var (
 		re                   = require.New(t)
-		r                    = NewRegionsInfo()
+		tree                 = newRegionTree()
 		needContainAllRanges = true
 		regions              []*RegionInfo
 		err                  error
 	)
 	scanError := func(startKey, endKey []byte, limit int) {
-		regions, err = r.scanRegion(&keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
+		regions, err = scanRegion(tree, &keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
 		re.Error(err)
 	}
 	scanNoError := func(startKey, endKey []byte, limit int) []*RegionInfo {
-		regions, err = r.scanRegion(&keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
+		regions, err = scanRegion(tree, &keyutil.KeyRange{StartKey: startKey, EndKey: endKey}, limit, needContainAllRanges)
 		re.NoError(err)
 		return regions
 	}
-	tree := r.tree
 	// region1
 	// [a, b)
 	updateNewItem(tree, NewTestRegionInfo(1, 1, []byte("a"), []byte("b")))
@@ -1348,45 +1347,6 @@ func TestCodecRule(t *testing.T) {
 		var rule2 Rule
 		re.NoError(json.Unmarshal(body, &rule2))
 		re.Equal(rule.String(), rule2.String())
-	}
-}
-
-func TestStatsRegions(t *testing.T) {
-	re := require.New(t)
-	regions := NewRegionsInfo()
-	count := 10000
-	for i := range count {
-		endKey := []byte(fmt.Sprintf("%20d", i+1))
-		if i == count-1 {
-			endKey = nil
-		}
-		regions.CheckAndPutRegion(NewTestRegionInfo(uint64(i), 1, []byte(fmt.Sprintf("%20d", i)), endKey))
-	}
-	startKey := []byte(fmt.Sprintf("%20d", 0))
-	for _, l := range []int{-1, MaxScanRegionLimit - 1, MaxScanRegionLimit, MaxScanRegionLimit + 1, count} {
-		rs := regions.ScanRegions(startKey, nil, l)
-		limit := l
-		if limit <= 0 {
-			limit = count
-		}
-		re.Len(rs, limit)
-		endKey := []byte(fmt.Sprintf("%20d", limit))
-		if limit == count {
-			endKey = nil
-		}
-		re.Equal(endKey, rs[len(rs)-1].GetEndKey())
-		re.Equal(startKey, rs[0].GetStartKey())
-	}
-
-	for _, startIdx := range []int{count - MaxScanRegionLimit - 1, count - MaxScanRegionLimit, count - MaxScanRegionLimit + 1} {
-		if startIdx < 0 {
-			startIdx = 0
-		}
-		startKey = []byte(fmt.Sprintf("%20d", startIdx))
-		expectLen := count - startIdx
-		rs := regions.ScanRegions(startKey, []byte(""), -1)
-		re.Len(rs, expectLen)
-		re.Equal(startKey, rs[0].GetStartKey())
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9674, Ref #9628

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
revert reason: Ensuring view consistency  of the region between two scans 
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

reopen link： https://github.com/you06/pd/commit/e2509bed526d0a8f7d885961dd9ed50e4755afdd

Code changes



Side effects



Related changes



### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
