### PR TITLE
tools: add show region by keyspace-id or table-id

### DIFF
--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -538,7 +538,7 @@ func NewRegionWithKeyspaceCommand() *cobra.Command {
 	}
 	r.AddCommand(&cobra.Command{
 		Use:   "id <keyspace_id> [table-id <table_id>] [<limit>]",
-		Short: "show region information for the given keyspace id",
+		Short: "show region information for the given keyspace id, optionally filtered by table id",
 		Run:   showRegionWithKeyspaceCommandFunc,
 	})
 	return r

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -17,6 +17,7 @@ package command
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -535,7 +536,7 @@ func NewRegionWithKeyspaceCommand() *cobra.Command {
 		Short: "show region information of the given keyspace",
 	}
 	r.AddCommand(&cobra.Command{
-		Use:   "id <keyspace_id> <limit>",
+		Use:   "id <keyspace_id> [table-id <table_id>] [<limit>]",
 		Short: "show region information for the given keyspace id",
 		Run:   showRegionWithKeyspaceCommandFunc,
 	})
@@ -543,26 +544,64 @@ func NewRegionWithKeyspaceCommand() *cobra.Command {
 }
 
 func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
-	if len(args) < 1 || len(args) > 2 {
+	if len(args) < 1 || len(args) > 4 {
 		cmd.Println(cmd.UsageString())
 		return
 	}
 
-	keyspaceID := args[0]
-	prefix := regionsKeyspacePrefix + "/id/" + keyspaceID
+	if _, err := strconv.ParseUint(args[0], 10, 32); err != nil {
+		cmd.Println("keyspace_id should be a number")
+		return
+	}
+
+	prefix := regionsKeyspacePrefix + "/id/" + args[0]
 	if len(args) == 2 {
 		if _, err := strconv.Atoi(args[1]); err != nil {
 			cmd.Println("limit should be a number")
 			return
 		}
 		prefix += "?limit=" + args[1]
+	} else if len(args) >= 3 {
+		if args[1] != "table-id" {
+			cmd.Println("the second argument should be table-id")
+			return
+		}
+		tableID, err := strconv.ParseInt(args[2], 10, 64)
+		if err != nil {
+			cmd.Println("table-id should be a number")
+			return
+		}
+		query := make(url.Values)
+		startKey, endKey := makeTableRangeInKeyspace(args[0], tableID)
+		query.Set("key", url.QueryEscape(string(startKey)))
+		query.Set("end_key", url.QueryEscape(string(endKey)))
+		if len(args) == 4 {
+			if _, err := strconv.Atoi(args[3]); err != nil {
+				cmd.Println("limit should be a number")
+				return
+			}
+			query.Set("limit", args[3])
+		}
+		prefix = regionsKeyPrefix + "?" + query.Encode()
 	}
+
 	r, err := doRequest(cmd, prefix, http.MethodGet, http.Header{})
 	if err != nil {
 		cmd.Printf("Failed to get regions with the given keyspace: %s\n", err)
 		return
 	}
 	cmd.Println(r)
+}
+
+func makeTableRangeInKeyspace(keyspaceID string, tableID int64) ([]byte, []byte) {
+	keyspaceIDUint64, _ := strconv.ParseUint(keyspaceID, 10, 32)
+	keyspaceIDBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(keyspaceIDBytes, uint32(keyspaceIDUint64))
+
+	keyPrefix := append([]byte{'x'}, keyspaceIDBytes[1:]...)
+	startKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID)...)...))
+	endKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID+1)...)...))
+	return startKey, endKey
 }
 
 const (

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -35,9 +35,9 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/tikv/pd/client/constants"
 
 	"github.com/tikv/pd/client/clients/router"
+	"github.com/tikv/pd/client/constants"
 	pd "github.com/tikv/pd/client/http"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/tools/pd-ctl/helper/mok"
@@ -601,13 +601,13 @@ func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 	cmd.Println(r)
 }
 
-func makeTableRangeInKeyspace(keyspaceID uint32, tableID int64) ([]byte, []byte) {
+func makeTableRangeInKeyspace(keyspaceID uint32, tableID int64) (startKey, endKey []byte) {
 	keyspaceIDBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(keyspaceIDBytes, keyspaceID)
 
 	keyPrefix := append([]byte{'x'}, keyspaceIDBytes[1:]...)
-	startKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID)...)...))
-	endKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID+1)...)...))
+	startKey = codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID)...)...))
+	endKey = codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID+1)...)...))
 	return startKey, endKey
 }
 

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/tikv/pd/client/constants"
 
 	"github.com/tikv/pd/client/clients/router"
 	pd "github.com/tikv/pd/client/http"
@@ -549,8 +550,15 @@ func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if _, err := strconv.ParseUint(args[0], 10, 32); err != nil {
+	keyspaceIDUint64, err := strconv.ParseUint(args[0], 10, 32)
+	if err != nil {
 		cmd.Println("keyspace_id should be a number")
+		return
+	}
+	keyspaceID := uint32(keyspaceIDUint64)
+	if keyspaceID < constants.DefaultKeyspaceID || keyspaceID > constants.MaxKeyspaceID {
+		cmd.Printf("invalid keyspace id %d. It must be in the range of [%d, %d]\n",
+			keyspaceID, constants.DefaultKeyspaceID, constants.MaxKeyspaceID)
 		return
 	}
 
@@ -572,9 +580,9 @@ func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 			return
 		}
 		query := make(url.Values)
-		startKey, endKey := makeTableRangeInKeyspace(args[0], tableID)
-		query.Set("key", url.QueryEscape(string(startKey)))
-		query.Set("end_key", url.QueryEscape(string(endKey)))
+		startKey, endKey := makeTableRangeInKeyspace(keyspaceID, tableID)
+		query.Set("key", string(startKey))
+		query.Set("end_key", string(endKey))
 		if len(args) == 4 {
 			if _, err := strconv.Atoi(args[3]); err != nil {
 				cmd.Println("limit should be a number")
@@ -593,10 +601,9 @@ func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 	cmd.Println(r)
 }
 
-func makeTableRangeInKeyspace(keyspaceID string, tableID int64) ([]byte, []byte) {
-	keyspaceIDUint64, _ := strconv.ParseUint(keyspaceID, 10, 32)
+func makeTableRangeInKeyspace(keyspaceID uint32, tableID int64) ([]byte, []byte) {
 	keyspaceIDBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(keyspaceIDBytes, uint32(keyspaceIDUint64))
+	binary.BigEndian.PutUint32(keyspaceIDBytes, keyspaceID)
 
 	keyPrefix := append([]byte{'x'}, keyspaceIDBytes[1:]...)
 	startKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID)...)...))

--- a/tools/pd-ctl/pdctl/command/region_command_test.go
+++ b/tools/pd-ctl/pdctl/command/region_command_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 TiKV Project Authors.
+// Copyright 2026 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/pd-ctl/pdctl/command/region_command_test.go
+++ b/tools/pd-ctl/pdctl/command/region_command_test.go
@@ -1,0 +1,205 @@
+// Copyright 2025 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/tools/pd-ctl/helper/tidb/codec"
+)
+
+type captureRegionRoundTripper struct {
+	path     string
+	rawQuery string
+	body     string
+	err      error
+}
+
+func (m *captureRegionRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.path = req.URL.Path
+	m.rawQuery = req.URL.RawQuery
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(m.body)),
+	}, nil
+}
+
+func TestRegionKeyspaceIDPath(t *testing.T) {
+	re := require.New(t)
+	rt := &captureRegionRoundTripper{body: `{"ok":true}`}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Equal("/pd/api/v1/regions/keyspace/id/1", rt.path)
+	re.Empty(rt.rawQuery)
+	re.Contains(out.String(), `{"ok":true}`)
+}
+
+func TestRegionKeyspaceIDTableIDPath(t *testing.T) {
+	re := require.New(t)
+	rt := &captureRegionRoundTripper{body: `{"ok":true}`}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	startKey, endKey := expectedTableRangeInKeyspace(1, 100)
+	query := make(url.Values)
+	query.Set("key", url.QueryEscape(string(startKey)))
+	query.Set("end_key", url.QueryEscape(string(endKey)))
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "table-id", "100"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Equal("/pd/api/v1/regions/key", rt.path)
+	re.Equal(query.Encode(), rt.rawQuery)
+	re.Contains(out.String(), `{"ok":true}`)
+}
+
+func TestRegionKeyspaceIDPathWithLimit(t *testing.T) {
+	re := require.New(t)
+	rt := &captureRegionRoundTripper{body: `{"ok":true}`}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "16"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Equal("/pd/api/v1/regions/keyspace/id/1", rt.path)
+	re.Equal("limit=16", rt.rawQuery)
+	re.Contains(out.String(), `{"ok":true}`)
+}
+
+func TestRegionKeyspaceIDTableIDPathWithLimit(t *testing.T) {
+	re := require.New(t)
+	rt := &captureRegionRoundTripper{body: `{"ok":true}`}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	startKey, endKey := expectedTableRangeInKeyspace(1, 100)
+	query := make(url.Values)
+	query.Set("key", url.QueryEscape(string(startKey)))
+	query.Set("end_key", url.QueryEscape(string(endKey)))
+	query.Set("limit", "16")
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "table-id", "100", "16"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Equal("/pd/api/v1/regions/key", rt.path)
+	re.Equal(query.Encode(), rt.rawQuery)
+	re.Contains(out.String(), `{"ok":true}`)
+}
+
+func TestRegionKeyspaceIDInvalidKeyspaceID(t *testing.T) {
+	re := require.New(t)
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "invalid"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Contains(out.String(), "keyspace_id should be a number")
+}
+
+func TestRegionKeyspaceIDInvalidTableID(t *testing.T) {
+	re := require.New(t)
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "table-id", "invalid"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Contains(out.String(), "table-id should be a number")
+}
+
+func TestRegionKeyspaceIDInvalidLimit(t *testing.T) {
+	re := require.New(t)
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "table-id", "100", "invalid"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Contains(out.String(), "limit should be a number")
+}
+
+func TestRegionKeyspaceIDWrongTableIDLiteral(t *testing.T) {
+	re := require.New(t)
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "table", "100"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Contains(out.String(), "the second argument should be table-id")
+}
+
+func expectedTableRangeInKeyspace(keyspaceID uint32, tableID int64) ([]byte, []byte) {
+	keyspaceIDBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(keyspaceIDBytes, keyspaceID)
+
+	keyPrefix := append([]byte{'x'}, keyspaceIDBytes[1:]...)
+	startKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID)...)...))
+	endKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID+1)...)...))
+	return startKey, endKey
+}

--- a/tools/pd-ctl/pdctl/command/region_command_test.go
+++ b/tools/pd-ctl/pdctl/command/region_command_test.go
@@ -76,8 +76,8 @@ func TestRegionKeyspaceIDTableIDPath(t *testing.T) {
 
 	startKey, endKey := expectedTableRangeInKeyspace(1, 100)
 	query := make(url.Values)
-	query.Set("key", url.QueryEscape(string(startKey)))
-	query.Set("end_key", url.QueryEscape(string(endKey)))
+	query.Set("key", string(startKey))
+	query.Set("end_key", string(endKey))
 
 	cmd := NewRegionWithKeyspaceCommand()
 	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
@@ -121,8 +121,8 @@ func TestRegionKeyspaceIDTableIDPathWithLimit(t *testing.T) {
 
 	startKey, endKey := expectedTableRangeInKeyspace(1, 100)
 	query := make(url.Values)
-	query.Set("key", url.QueryEscape(string(startKey)))
-	query.Set("end_key", url.QueryEscape(string(endKey)))
+	query.Set("key", string(startKey))
+	query.Set("end_key", string(endKey))
 	query.Set("limit", "16")
 
 	cmd := NewRegionWithKeyspaceCommand()
@@ -150,6 +150,20 @@ func TestRegionKeyspaceIDInvalidKeyspaceID(t *testing.T) {
 
 	re.NoError(cmd.Execute())
 	re.Contains(out.String(), "keyspace_id should be a number")
+}
+
+func TestRegionKeyspaceIDOutOfRangeKeyspaceID(t *testing.T) {
+	re := require.New(t)
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "16777216"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Contains(out.String(), "invalid keyspace id 16777216. It must be in the range of [0, 16777215]")
 }
 
 func TestRegionKeyspaceIDInvalidTableID(t *testing.T) {

--- a/tools/pd-ctl/pdctl/command/region_command_test.go
+++ b/tools/pd-ctl/pdctl/command/region_command_test.go
@@ -208,12 +208,12 @@ func TestRegionKeyspaceIDWrongTableIDLiteral(t *testing.T) {
 	re.Contains(out.String(), "the second argument should be table-id")
 }
 
-func expectedTableRangeInKeyspace(keyspaceID uint32, tableID int64) ([]byte, []byte) {
+func expectedTableRangeInKeyspace(keyspaceID uint32, tableID int64) (startKey, endKey []byte) {
 	keyspaceIDBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(keyspaceIDBytes, keyspaceID)
 
 	keyPrefix := append([]byte{'x'}, keyspaceIDBytes[1:]...)
-	startKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID)...)...))
-	endKey := codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID+1)...)...))
+	startKey = codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID)...)...))
+	endKey = codec.EncodeBytes(nil, append(keyPrefix, append([]byte{'t'}, codec.EncodeInt(nil, tableID+1)...)...))
 	return startKey, endKey
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref #9707, cp https://github.com/tidbcloud/pd-cse/pull/355, close https://github.com/tikv/pd/issues/10531

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: `region keyspace id` accepts an optional table-id and a flexible limit, enforces stricter keyspace-ID validation with clearer error messages, and constructs either a table-specific key-range query or a limit-only query as appropriate.

* **Tests**
  * New tests capture outgoing requests to verify endpoint paths, query parameters (including computed key/end_key ranges) and argument validation/error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->