### PR TITLE
Revert "keyspace: wait region split for system keyspace in next gen (#9880)"

### DIFF
--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -111,12 +111,11 @@ func (opt *newGCStateManagerForTestOptions) generateKeyspacesByCount(count int) 
 func newGCStateManagerForTest(t testing.TB, opt newGCStateManagerForTestOptions) (storage *endpoint.StorageEndpoint, provider endpoint.GCStateProvider, gcStateManager *GCStateManager, clean func(), cancel context.CancelFunc) {
 	cfg := config.NewConfig()
 	re := require.New(t)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
 
 	var etcdClusterOpt etcdutil.TestEtcdClusterOptions
 	etcdClusterOpt.ServerCfgModifier = opt.etcdServerCfgModifier
 
-	_, client, etcdClean := etcdutil.NewTestEtcdCluster(t, 1, &etcdClusterOpt)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, &etcdClusterOpt)
 	kvBase := kv.NewEtcdKVBase(client)
 
 	// Simulate a member which id.Allocator may need to check.
@@ -199,10 +198,6 @@ func newGCStateManagerForTest(t testing.TB, opt newGCStateManagerForTestOptions)
 		}
 	}
 
-	clean = func() {
-		etcdClean()
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
-	}
 	return s, s.GetGCStateProvider(), gcStateManager, clean, cancel
 }
 

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -189,10 +189,7 @@ func (manager *Manager) Bootstrap() error {
 
 func (manager *Manager) initReserveKeyspace(id uint32, name string) error {
 	// Split Keyspace Region for default/system keyspace.
-	// We need to wait region split for system keyspace in next gen
-	// to avoid https://github.com/pingcap/tidb/issues/63959
-	waitRegionSplit := (id == constant.SystemKeyspaceID) && manager.config.ToWaitRegionSplit()
-	if err := manager.splitKeyspaceRegion(id, waitRegionSplit); err != nil {
+	if err := manager.splitKeyspaceRegion(id, false); err != nil {
 		return err
 	}
 	now := time.Now().Unix()

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -44,7 +44,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
-	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/api"
 	"github.com/tikv/pd/server/apiv2"
@@ -518,15 +517,9 @@ func NewTestClusterWithKeyspaceGroup(ctx context.Context, initialServerCount int
 
 func createTestCluster(ctx context.Context, initialServerCount int, services []string, opts ...ConfigOption) (*TestCluster, error) {
 	schedulers.Register()
-	clusterConfig := newClusterConfig(initialServerCount)
+	config := newClusterConfig(initialServerCount)
 	servers := make(map[string]*TestServer)
-	// Skip region split wait in tests by default in next-gen.
-	if kerneltype.IsNextGen() {
-		opts = append(opts, func(conf *config.Config, _ string) {
-			conf.Keyspace.WaitRegionSplit = false
-		})
-	}
-	for _, cfg := range clusterConfig.InitialServers {
+	for _, cfg := range config.InitialServers {
 		serverConf, err := cfg.Generate(opts...)
 		if err != nil {
 			return nil, err
@@ -538,7 +531,7 @@ func createTestCluster(ctx context.Context, initialServerCount int, services []s
 		servers[cfg.Name] = s
 	}
 	return &TestCluster{
-		config:  clusterConfig,
+		config:  config,
 		servers: servers,
 		tsPool: struct {
 			syncutil.Mutex

--- a/tests/server/apiv2/handlers/keyspace_test.go
+++ b/tests/server/apiv2/handlers/keyspace_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server/apiv2/handlers"
-	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 )
 
@@ -54,9 +53,7 @@ func (suite *keyspaceTestSuite) SetupTest() {
 	re := suite.Require()
 	ctx, cancel := context.WithCancel(context.Background())
 	suite.cleanup = cancel
-	cluster, err := tests.NewTestCluster(ctx, 1, func(conf *config.Config, _ string) {
-		conf.Keyspace.WaitRegionSplit = false
-	})
+	cluster, err := tests.NewTestCluster(ctx, 1)
 	suite.cluster = cluster
 	re.NoError(err)
 	re.NoError(cluster.RunInitialServers())

--- a/tests/server/keyspace/keyspace_test.go
+++ b/tests/server/keyspace/keyspace_test.go
@@ -186,9 +186,8 @@ func TestProtectedKeyspace(t *testing.T) {
 			gcConfig:              keyspace.KeyspaceLevelGC,
 		},
 	}
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
+
 	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/versioninfo/kerneltype/mockNextGenBuildFlag"))
 	}()
 	for _, c := range cases {


### PR DESCRIPTION
This reverts commit e4a899a4c151e5b8d5267f55e0135ae4fb37d4fe.

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/9879

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
