### PR TITLE
client: unify get resource group error

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -34,6 +34,7 @@ import (
 
 	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/client/clients/metastorage"
+	"github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/resource_group/controller/metrics"
 )
@@ -469,7 +470,7 @@ func (c *ResourceGroupsController) loadOrStoreGroupController(name string, gc *g
 // NewResourceGroupNotExistErr returns a new error that indicates the resource group does not exist.
 // It's exported for testing.
 func NewResourceGroupNotExistErr(name string) error {
-	return errors.Errorf("%s does not exist", name)
+	return &errs.ErrClientGetResourceGroup{ResourceGroupName: name, Cause: "resource group does not exist"}
 }
 
 func (c *ResourceGroupsController) getDegradedResourceGroup(resourceGroupName string) *rmpb.ResourceGroup {


### PR DESCRIPTION
Issue Number: ref #4399

### What is changed and how does it work?

Unifiy the error type for when encountering error during `GetResourceGroup`. After it we can check error type and apply proper error handling and retry.

### Check List

<!-- Remove the items that are not applicable. -->

Tests
- Unit test


### Release note


```release-note
None.
```
