### PR TITLE
statistics: delete cluster status metrics on store deletion

### DIFF
--- a/pkg/core/store.go
+++ b/pkg/core/store.go
@@ -244,6 +244,14 @@ func (s *StoreInfo) IsTiFlashCompute() bool {
 	return IsStoreContainLabel(s.GetMeta(), EngineKey, EngineTiFlashCompute)
 }
 
+// Engine returns the engine type of the store.
+func (s *StoreInfo) Engine() string {
+	if s.IsTiKV() {
+		return EngineTiKV
+	}
+	return EngineTiFlash
+}
+
 // IsUp returns true if store is serving or preparing.
 func (s *StoreInfo) IsUp() bool {
 	return s.IsServing() || s.IsPreparing()

--- a/pkg/mcs/router/server/meta/watcher.go
+++ b/pkg/mcs/router/server/meta/watcher.go
@@ -95,6 +95,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 		origin := w.basicCluster.GetStore(storeID)
 		if origin != nil {
+			statistics.DeleteClusterStatusMetrics(origin)
 			w.basicCluster.DeleteStore(origin)
 			log.Info("delete store meta", zap.Uint64("store-id", storeID))
 		}

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -95,6 +95,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 		origin := w.basicCluster.GetStore(storeID)
 		if origin != nil {
+			statistics.DeleteClusterStatusMetrics(origin)
 			w.basicCluster.DeleteStore(origin)
 			log.Info("delete store meta", zap.Uint64("store-id", storeID))
 		}

--- a/pkg/statistics/metrics.go
+++ b/pkg/statistics/metrics.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/tikv/pd/pkg/core"
 )
 

--- a/pkg/statistics/metrics.go
+++ b/pkg/statistics/metrics.go
@@ -14,7 +14,12 @@
 
 package statistics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tikv/pd/pkg/core"
+)
 
 var (
 	hotCacheStatusGauge = prometheus.NewGaugeVec(
@@ -117,4 +122,11 @@ func init() {
 	prometheus.MustRegister(regionLabelLevelGauge)
 	prometheus.MustRegister(regionAbnormalPeerDuration)
 	prometheus.MustRegister(hotPeerSummary)
+}
+
+func DeleteClusterStatusMetrics(store *core.StoreInfo) {
+	engine := store.Engine()
+	for _, status := range storeStatuses {
+		clusterStatusGauge.DeleteLabelValues(status, engine, strconv.FormatUint(store.GetID(), 10))
+	}
 }

--- a/pkg/statistics/metrics.go
+++ b/pkg/statistics/metrics.go
@@ -124,6 +124,7 @@ func init() {
 	prometheus.MustRegister(hotPeerSummary)
 }
 
+// DeleteClusterStatusMetrics deletes the cluster status metrics of a store.
 func DeleteClusterStatusMetrics(store *core.StoreInfo) {
 	engine := store.Engine()
 	for _, status := range storeStatuses {

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -52,6 +52,21 @@ const (
 	clusterStatusStorageCapacity = "storage_capacity"
 )
 
+var storeStatuses = []string{
+	clusterStatusStoreUpCount,
+	clusterStatusStoreDisconnectedCount,
+	clusterStatusStoreSlowCount,
+	clusterStatusStoreDownCount,
+	clusterStatusStoreUnhealthCount,
+	clusterStatusStoreOfflineCount,
+	clusterStatusStoreTombstoneCount,
+	clusterStatusStoreLowSpaceCount,
+	clusterStatusStorePreparingCount,
+	clusterStatusStoreServingCount,
+	clusterStatusStoreRemovingCount,
+	clusterStatusStoreRemovedCount,
+}
+
 type storeStatistics struct {
 	opt          config.ConfProvider
 	LabelCounter map[string][]uint64
@@ -129,12 +144,7 @@ func (s *storeStatistics) observe(store *core.StoreInfo) {
 	}
 	storeAddress := store.GetAddress()
 	id := strconv.FormatUint(store.GetID(), 10)
-	var engine string
-	if store.IsTiKV() {
-		engine = core.EngineTiKV
-	} else {
-		engine = core.EngineTiFlash
-	}
+	engine := store.Engine()
 	storeStatusStats := s.observeStoreStatus(store)
 	for statusType, value := range storeStatusStats {
 		clusterStatusGauge.WithLabelValues(statusType, engine, id).Set(value)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2008,6 +2008,7 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 			return err
 		}
 	}
+	statistics.DeleteClusterStatusMetrics(store)
 	c.DeleteStore(store)
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/9942

### What is changed and how does it work?

Due to adding `store` label in https://github.com/tikv/pd/pull/9898, we need to delete the related metrics on store deleting, otherwise it will retain forever.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

1. scale-in one tikv
2. pd-ctl store remove-tombstone

<img width="3080" height="1406" alt="img_v3_02s6_fb7a775b-307a-4faf-b493-4184098f657g" src="https://github.com/user-attachments/assets/5efe0008-8bbf-47b0-81ea-a0a90d783979" />



Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
