### PR TITLE
api: support to set store limit for tikv engine alone

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -275,6 +275,16 @@ func (h *Handler) SetLabelStoresLimit(ratePerMin float64, limitType storelimit.T
 	}
 	for _, store := range c.GetStores() {
 		for _, label := range labels {
+			// set limit for tikv stores
+			if label.Key == core.EngineKey && label.Value == core.EngineTiKV {
+				if store.IsTiKV() {
+					err = c.SetStoreLimit(store.GetID(), limitType, ratePerMin)
+					if err != nil {
+						return err
+					}
+					continue
+				}
+			}
 			for _, sl := range store.GetLabels() {
 				if label.Key == sl.Key && label.Value == sl.Value {
 					// TODO: need to handle some of stores are persisted, and some of stores are not.

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -502,6 +502,19 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	re.Contains(string(output), "rate should be less than")
+
+	// store limit all engine tikv 21 remove peer for tikv stores
+	args = []string{"-u", pdAddr, "store", "limit", "all", "engine", "tikv", "21", "remove-peer"}
+	_, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+
+	args = []string{"-u", pdAddr, "store", "limit", "remove-peer"}
+	output, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	allRemovePeerLimit = make(map[string]map[string]any)
+	json.Unmarshal(output, &allRemovePeerLimit)
+	re.Equal(float64(21), allRemovePeerLimit["1"]["remove-peer"].(float64))
+	re.Equal(float64(21), allRemovePeerLimit["3"]["remove-peer"].(float64))
 }
 
 // https://github.com/tikv/pd/issues/5024


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9970

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
