### PR TITLE
tso: improve the high availability of etcd client for etcd save timestamp

### DIFF
--- a/pkg/election/leadership_test.go
+++ b/pkg/election/leadership_test.go
@@ -164,7 +164,7 @@ func TestExitWatch(t *testing.T) {
 		etcd2 := etcdutil.MustAddEtcdMember(t, &cfg1, client)
 		cfg2 := etcd2.Config()
 		etcd3 := etcdutil.MustAddEtcdMember(t, &cfg2, client)
-		client2, err := etcdutil.CreateEtcdClient(nil, etcd2.Config().ListenClientUrls, etcdutil.TestEtcdClientUsager, true)
+		client2, err := etcdutil.CreateEtcdClient(nil, etcd2.Config().ListenClientUrls, etcdutil.TestEtcdClientPurpose, true)
 		re.NoError(err)
 		// close the original leader
 		server.Server.HardStop()
@@ -208,7 +208,7 @@ func checkExitWatch(t *testing.T, leaderKey string, injectFunc func(server *embe
 	re := require.New(t)
 	servers, client1, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
 	defer clean()
-	client2, err := etcdutil.CreateEtcdClient(nil, servers[0].Config().ListenClientUrls, etcdutil.TestEtcdClientUsager, true)
+	client2, err := etcdutil.CreateEtcdClient(nil, servers[0].Config().ListenClientUrls, etcdutil.TestEtcdClientPurpose, true)
 	re.NoError(err)
 	defer client2.Close()
 
@@ -244,7 +244,7 @@ func TestRequestProgress(t *testing.T) {
 		defer os.RemoveAll(fname)
 		servers, client1, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
 		defer clean()
-		client2, err := etcdutil.CreateEtcdClient(nil, servers[0].Config().ListenClientUrls, etcdutil.TestEtcdClientUsager, true)
+		client2, err := etcdutil.CreateEtcdClient(nil, servers[0].Config().ListenClientUrls, etcdutil.TestEtcdClientPurpose, true)
 		re.NoError(err)
 		defer client2.Close()
 

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -95,7 +95,7 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 	os.RemoveAll(cfg.Dir)
 	etcd, err := embed.StartEtcd(cfg)
 	re.NoError(err)
-	client, err := etcdutil.CreateEtcdClient(nil, cfg.ListenClientUrls, etcdutil.TestEtcdClientUsager, true)
+	client, err := etcdutil.CreateEtcdClient(nil, cfg.ListenClientUrls, etcdutil.TestEtcdClientPurpose, true)
 	re.NoError(err)
 	<-etcd.Server.ReadyNotify()
 

--- a/pkg/mcs/utils/util.go
+++ b/pkg/mcs/utils/util.go
@@ -113,7 +113,7 @@ func InitClient(s server) error {
 	if err != nil {
 		return err
 	}
-	etcdClient, err := etcdutil.CreateEtcdClient(tlsConfig, backendUrls, etcdutil.McsEtcdClientUsager, true)
+	etcdClient, err := etcdutil.CreateEtcdClient(tlsConfig, backendUrls, etcdutil.McsEtcdClientPurpose, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/endpoint/tso.go
+++ b/pkg/storage/endpoint/tso.go
@@ -32,7 +32,7 @@ import (
 
 // TSOStorage is the interface for timestamp storage.
 type TSOStorage interface {
-	LoadTimestamp(ctx context.Context, groupID uint32) (time.Time, error)
+	LoadTimestamp(groupID uint32) (time.Time, error)
 	SaveTimestamp(ctx context.Context, groupID uint32, ts time.Time, leadership *election.Leadership) error
 	DeleteTimestamp(ctx context.Context, groupID uint32) error
 }
@@ -44,7 +44,7 @@ var _ TSOStorage = (*StorageEndpoint)(nil)
 // we must ensure that all keyspace groups are merged into the default
 // keyspace group. This guarantees the monotonicity of the TSO by loading
 // the timestamp from a single key.
-func (se *StorageEndpoint) LoadTimestamp(_ context.Context, groupID uint32) (time.Time, error) {
+func (se *StorageEndpoint) LoadTimestamp(groupID uint32) (time.Time, error) {
 	key := keypath.TimestampPath(groupID)
 	value, err := se.Load(key)
 	if err != nil {

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -1378,7 +1378,7 @@ mergeLoop:
 		// calculate the newly merged TSO to make sure it is greater than the original ones.
 		var mergedTS time.Time
 		for _, id := range mergeList {
-			ts, err := kgm.storage.LoadTimestamp(ctx, id)
+			ts, err := kgm.storage.LoadTimestamp(id)
 			if err != nil {
 				log.Error("failed to load the keyspace group TSO",
 					zap.String("member", kgm.tsoServiceID.ServiceAddr),

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -111,7 +111,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeletedGroupCleanup() {
 	suite.applyEtcdEvents(re, []*etcdEvent{generateKeyspaceGroupPutEvent(1, []uint32{1}, []string{svcAddr})})
 	// Check if the TSO key is created.
 	testutil.Eventually(re, func() bool {
-		ts, err := mgr.storage.LoadTimestamp(context.Background(), 1)
+		ts, err := mgr.storage.LoadTimestamp(1)
 		re.NoError(err)
 		return ts != typeutil.ZeroTime
 	})
@@ -119,7 +119,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeletedGroupCleanup() {
 	suite.applyEtcdEvents(re, []*etcdEvent{generateKeyspaceGroupDeleteEvent(1)})
 	// Check if the TSO key is deleted.
 	testutil.Eventually(re, func() bool {
-		ts, err := mgr.storage.LoadTimestamp(context.Background(), 1)
+		ts, err := mgr.storage.LoadTimestamp(1)
 		re.NoError(err)
 		return ts.Equal(typeutil.ZeroTime)
 	})
@@ -138,7 +138,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeletedGroupCleanup() {
 	re.NotContains(mgr.deletedGroups, constant.DefaultKeyspaceGroupID)
 	mgr.RUnlock()
 	// Default keyspace group TSO key should NOT be deleted.
-	ts, err := mgr.storage.LoadTimestamp(context.Background(), constant.DefaultKeyspaceGroupID)
+	ts, err := mgr.storage.LoadTimestamp(constant.DefaultKeyspaceGroupID)
 	re.NoError(err)
 	re.NotEmpty(ts)
 

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -263,18 +263,18 @@ const (
 	etcdServerDisconnectedTimeout = 1 * time.Minute
 )
 
-// EtcdClientUsager marks the usager of the etcd client.
-type EtcdClientUsager string
+// EtcdClientPurpose marks the purpose of the etcd client.
+type EtcdClientPurpose string
 
 const (
-	// TestEtcdClientUsager is the default etcd client usager, used for testing.
-	TestEtcdClientUsager EtcdClientUsager = "default-etcd-client"
-	// ServerEtcdClientUsager is the etcd client usager for server, most of the time.
-	ServerEtcdClientUsager EtcdClientUsager = "server-etcd-client"
-	// ElectionEtcdClientUsager is the etcd client usager for election and tso.
-	ElectionEtcdClientUsager EtcdClientUsager = "election-etcd-client"
-	// McsEtcdClientUsager is the etcd client usager for mcs.
-	McsEtcdClientUsager EtcdClientUsager = "mcs-etcd-client"
+	// TestEtcdClientPurpose is the default etcd client purpose, used for testing.
+	TestEtcdClientPurpose EtcdClientPurpose = "default-etcd-client"
+	// ServerEtcdClientPurpose is the etcd client purpose for server, most of the time.
+	ServerEtcdClientPurpose EtcdClientPurpose = "server-etcd-client"
+	// ElectionEtcdClientPurpose is the etcd client purpose for election and tso.
+	ElectionEtcdClientPurpose EtcdClientPurpose = "election-etcd-client"
+	// McsEtcdClientPurpose is the etcd client purpose for mcs.
+	McsEtcdClientPurpose EtcdClientPurpose = "mcs-etcd-client"
 )
 
 func newClient(tlsConfig *tls.Config, endpoints ...string) (*clientv3.Client, error) {
@@ -295,7 +295,7 @@ func newClient(tlsConfig *tls.Config, endpoints ...string) (*clientv3.Client, er
 }
 
 // CreateEtcdClient creates etcd v3 client with detecting endpoints.
-func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL, usager EtcdClientUsager, enableChecker bool) (*clientv3.Client, error) {
+func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL, purpose EtcdClientPurpose, enableChecker bool) (*clientv3.Client, error) {
 	urls := make([]string, 0, len(acURLs))
 	for _, u := range acURLs {
 		urls = append(urls, u.String())
@@ -310,7 +310,7 @@ func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL, usager EtcdClient
 		tickerInterval = 100 * time.Millisecond
 	})
 	if enableChecker {
-		initHealthChecker(tickerInterval, tlsConfig, client, usager)
+		initHealthChecker(tickerInterval, tlsConfig, client, purpose)
 	}
 
 	return client, err

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -226,10 +226,10 @@ func TestEtcdScaleInAndOut(t *testing.T) {
 	etcd1, cfg1 := servers[0], servers[0].Config()
 
 	// Create two etcd clients with etcd1 as endpoint.
-	client1, err := CreateEtcdClient(nil, cfg1.ListenClientUrls, TestEtcdClientUsager, true) // execute member change operation with this client
+	client1, err := CreateEtcdClient(nil, cfg1.ListenClientUrls, TestEtcdClientPurpose, true) // execute member change operation with this client
 	re.NoError(err)
 	defer client1.Close()
-	client2, err := CreateEtcdClient(nil, cfg1.ListenClientUrls, TestEtcdClientUsager, true) // check member change with this client
+	client2, err := CreateEtcdClient(nil, cfg1.ListenClientUrls, TestEtcdClientPurpose, true) // check member change with this client
 	re.NoError(err)
 	defer client2.Close()
 
@@ -240,7 +240,7 @@ func TestEtcdScaleInAndOut(t *testing.T) {
 
 	// Create a client connected to etcd2 to perform the removal
 	cfg2 := etcd2.Config()
-	client3, err := CreateEtcdClient(nil, cfg2.ListenClientUrls, TestEtcdClientUsager, true)
+	client3, err := CreateEtcdClient(nil, cfg2.ListenClientUrls, TestEtcdClientPurpose, true)
 	re.NoError(err)
 	defer client3.Close()
 
@@ -311,7 +311,7 @@ func checkEtcdWithHangLeader(t *testing.T, enableChecker bool) error {
 	// Create an etcd client with etcd1 as endpoint.
 	urls, err := etcdtypes.NewURLs([]string{proxyAddr})
 	re.NoError(err)
-	client1, err := CreateEtcdClient(nil, urls, TestEtcdClientUsager, enableChecker)
+	client1, err := CreateEtcdClient(nil, urls, TestEtcdClientPurpose, enableChecker)
 	re.NoError(err)
 	defer client1.Close()
 
@@ -428,7 +428,7 @@ func (suite *loopWatcherTestSuite) SetupSuite() {
 	suite.config = NewTestSingleConfig()
 	suite.config.Dir = suite.T().TempDir()
 	suite.startEtcd(re)
-	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientUsager, true)
+	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientPurpose, true)
 	re.NoError(err)
 	suite.cleans = append(suite.cleans, func() {
 		suite.client.Close()
@@ -687,7 +687,7 @@ func (suite *loopWatcherTestSuite) TestWatcherBreak() {
 
 	// Case2: close the etcd client and put a new value after watcher restarts
 	suite.client.Close()
-	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientUsager, true)
+	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientPurpose, true)
 	re.NoError(err)
 	watcher.updateClientCh <- suite.client
 	suite.put(re, "TestWatcherBreak", "2")
@@ -695,7 +695,7 @@ func (suite *loopWatcherTestSuite) TestWatcherBreak() {
 
 	// Case3: close the etcd client and put a new value before watcher restarts
 	suite.client.Close()
-	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientUsager, true)
+	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientPurpose, true)
 	re.NoError(err)
 	suite.put(re, "TestWatcherBreak", "3")
 	watcher.updateClientCh <- suite.client
@@ -703,7 +703,7 @@ func (suite *loopWatcherTestSuite) TestWatcherBreak() {
 
 	// Case4: close the etcd client and put a new value with compact
 	suite.client.Close()
-	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientUsager, true)
+	suite.client, err = CreateEtcdClient(nil, suite.config.ListenClientUrls, TestEtcdClientPurpose, true)
 	re.NoError(err)
 	suite.put(re, "TestWatcherBreak", "4")
 	resp, err := EtcdKVGet(suite.client, "TestWatcherBreak")

--- a/pkg/utils/etcdutil/health_checker.go
+++ b/pkg/utils/etcdutil/health_checker.go
@@ -48,7 +48,7 @@ type healthyClient struct {
 // healthChecker is used to check the health of etcd endpoints. Inside the checker,
 // we will maintain a map from each available etcd endpoint to its healthyClient.
 type healthChecker struct {
-	source         EtcdClientUsager
+	source         string
 	tickerInterval time.Duration
 	tlsConfig      *tls.Config
 
@@ -70,14 +70,14 @@ func initHealthChecker(
 	tickerInterval time.Duration,
 	tlsConfig *tls.Config,
 	client *clientv3.Client,
-	source EtcdClientUsager,
+	purpose EtcdClientPurpose,
 ) {
 	healthChecker := &healthChecker{
-		source:             source,
+		source:             string(purpose),
 		tickerInterval:     tickerInterval,
 		tlsConfig:          tlsConfig,
 		client:             client,
-		endpointCountState: etcdStateGauge.WithLabelValues(string(source), endpointLabel),
+		endpointCountState: etcdStateGauge.WithLabelValues(string(purpose), endpointLabel),
 	}
 	// A health checker has the same lifetime with the given etcd client.
 	ctx := client.Ctx()
@@ -96,7 +96,7 @@ func (checker *healthChecker) syncer(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			log.Info("etcd client is closed, exit the endpoint syncer goroutine",
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 			return
 		case <-ticker.C:
 			checker.update()
@@ -113,7 +113,7 @@ func (checker *healthChecker) inspector(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			log.Info("etcd client is closed, exit the health inspector goroutine",
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 			checker.close()
 			return
 		case <-ticker.C:
@@ -127,7 +127,7 @@ func (checker *healthChecker) inspector(ctx context.Context) {
 				if time.Since(lastAvailable) > etcdServerDisconnectedTimeout {
 					log.Info("no available endpoint, try to reset endpoints",
 						zap.Strings("last-endpoints", lastEps),
-						zap.String("source", string(checker.source)))
+						zap.String("source", checker.source))
 					resetClientEndpoints(checker.client, lastEps...)
 				}
 				continue
@@ -140,7 +140,7 @@ func (checker *healthChecker) inspector(ctx context.Context) {
 					zap.String("num-change", fmt.Sprintf("%d->%d", oldNum, newNum)),
 					zap.Strings("last-endpoints", lastEps),
 					zap.Strings("endpoints", checker.client.Endpoints()),
-					zap.String("source", string(checker.source)))
+					zap.String("source", checker.source))
 			}
 			lastAvailable = time.Now()
 		}
@@ -196,7 +196,7 @@ func (checker *healthChecker) patrol(ctx context.Context) (lastEps, pickedEps []
 				log.Warn("etcd endpoint is unhealthy",
 					zap.String("endpoint", ep),
 					zap.Duration("took", took),
-					zap.String("source", string(checker.source)))
+					zap.String("source", checker.source))
 				return
 			}
 			healthState.Set(1)
@@ -256,7 +256,7 @@ func (checker *healthChecker) pickEps(probeCh <-chan healthProbe) []string {
 					zap.Duration("max-latency", maxLatency),
 					zap.Duration("took", probe.took),
 					zap.String("endpoint", probe.ep),
-					zap.String("source", string(checker.source)))
+					zap.String("source", checker.source))
 				pickedEps = append(pickedEps, probe.ep)
 			}
 		}
@@ -282,7 +282,7 @@ func (checker *healthChecker) updateEvictedEps(lastEps, pickedEps []string) {
 			log.Info("reset evicted etcd endpoint picked count",
 				zap.String("endpoint", ep),
 				zap.Int("previous-count", count),
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 		}
 		return true
 	})
@@ -298,7 +298,7 @@ func (checker *healthChecker) updateEvictedEps(lastEps, pickedEps []string) {
 		checker.evictedEps.Store(ep, 0)
 		log.Info("evicted etcd endpoint found",
 			zap.String("endpoint", ep),
-			zap.String("source", string(checker.source)))
+			zap.String("source", checker.source))
 	}
 	// Find all endpoints which are in both `pickedEps` and `evictedEps` to
 	// increase their picked count.
@@ -310,7 +310,7 @@ func (checker *healthChecker) updateEvictedEps(lastEps, pickedEps []string) {
 				zap.Int("picked-count-threshold", pickedCountThreshold),
 				zap.Int("picked-count", count.(int)+1),
 				zap.String("endpoint", ep),
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 		}
 	}
 }
@@ -330,7 +330,7 @@ func (checker *healthChecker) filterEps(eps []string) []string {
 				zap.Int("picked-count-threshold", pickedCountThreshold),
 				zap.Int("picked-count", count.(int)),
 				zap.String("endpoint", ep),
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 		}
 		pickedEps = append(pickedEps, ep)
 	}
@@ -339,7 +339,7 @@ func (checker *healthChecker) filterEps(eps []string) []string {
 	if len(pickedEps) == 0 {
 		log.Warn("all etcd endpoints are evicted, use the picked endpoints directly",
 			zap.Strings("endpoints", eps),
-			zap.String("source", string(checker.source)))
+			zap.String("source", checker.source))
 		return eps
 	}
 	return pickedEps
@@ -349,7 +349,7 @@ func (checker *healthChecker) update() {
 	eps := checker.syncURLs()
 	if len(eps) == 0 {
 		log.Warn("no available etcd endpoint returned by etcd cluster",
-			zap.String("source", string(checker.source)))
+			zap.String("source", checker.source))
 		return
 	}
 	epMap := make(map[string]struct{}, len(eps))
@@ -371,7 +371,7 @@ func (checker *healthChecker) update() {
 			log.Info("etcd server might be offline, try to remove it",
 				zap.Duration("since-last-health", since),
 				zap.String("endpoint", ep),
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 			checker.removeClient(ep)
 			continue
 		}
@@ -380,7 +380,7 @@ func (checker *healthChecker) update() {
 			log.Info("etcd server might be disconnected, try to reconnect",
 				zap.Duration("since-last-health", since),
 				zap.String("endpoint", ep),
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 			resetClientEndpoints(client.Client, ep)
 		}
 	}
@@ -390,7 +390,7 @@ func (checker *healthChecker) update() {
 		if _, ok := epMap[ep]; !ok {
 			log.Info("remove stale etcd client",
 				zap.String("endpoint", ep),
-				zap.String("source", string(checker.source)))
+				zap.String("source", checker.source))
 			checker.removeClient(ep)
 		}
 		return true
@@ -418,7 +418,7 @@ func (checker *healthChecker) initClient(ep string) {
 	if err != nil {
 		log.Error("failed to create etcd healthy client",
 			zap.String("endpoint", ep),
-			zap.String("source", string(checker.source)),
+			zap.String("source", checker.source),
 			zap.Error(err))
 		return
 	}
@@ -429,8 +429,8 @@ func (checker *healthChecker) storeClient(ep string, client *clientv3.Client, la
 	checker.healthyClients.Store(ep, &healthyClient{
 		Client:      client,
 		lastHealth:  lastHealth,
-		healthState: etcdStateGauge.WithLabelValues(string(checker.source), ep),
-		latency:     etcdEndpointLatency.WithLabelValues(string(checker.source), ep),
+		healthState: etcdStateGauge.WithLabelValues(checker.source, ep),
+		latency:     etcdEndpointLatency.WithLabelValues(checker.source, ep),
 	})
 }
 
@@ -441,7 +441,7 @@ func (checker *healthChecker) removeClient(ep string) {
 		if err := healthyCli.Close(); err != nil {
 			log.Error("failed to close etcd healthy client",
 				zap.String("endpoint", ep),
-				zap.String("source", string(checker.source)),
+				zap.String("source", checker.source),
 				zap.Error(err))
 		}
 	}
@@ -453,7 +453,7 @@ func (checker *healthChecker) syncURLs() (eps []string) {
 	resp, err := ListEtcdMembers(clientv3.WithRequireLeader(checker.client.Ctx()), checker.client)
 	if err != nil {
 		log.Warn("failed to list members",
-			zap.String("source", string(checker.source)),
+			zap.String("source", checker.source),
 			errs.ZapError(err))
 		return nil
 	}

--- a/pkg/utils/etcdutil/testutil.go
+++ b/pkg/utils/etcdutil/testutil.go
@@ -80,7 +80,7 @@ func NewTestEtcdCluster(t testing.TB, count int, opt *TestEtcdClusterOptions) (s
 	}
 	etcd, err := embed.StartEtcd(cfg)
 	re.NoError(err)
-	etcdClient, err = CreateEtcdClient(nil, cfg.ListenClientUrls, TestEtcdClientUsager, true)
+	etcdClient, err = CreateEtcdClient(nil, cfg.ListenClientUrls, TestEtcdClientPurpose, true)
 	re.NoError(err)
 	<-etcd.Server.ReadyNotify()
 	servers = append(servers, etcd)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -54,11 +54,10 @@ type Config struct {
 	AdvertiseClientUrls string `toml:"advertise-client-urls" json:"advertise-client-urls"`
 	AdvertisePeerUrls   string `toml:"advertise-peer-urls" json:"advertise-peer-urls"`
 
-	Name                       string `toml:"name" json:"name"`
-	DataDir                    string `toml:"data-dir" json:"data-dir"`
-	ForceNewCluster            bool   `json:"force-new-cluster"`
-	EnableGRPCGateway          bool   `json:"enable-grpc-gateway"`
-	EnableLeaderClientAutoSync bool   `toml:"enable-leader-client-auto-sync" json:"enable-leader-client-auto-sync"`
+	Name              string `toml:"name" json:"name"`
+	DataDir           string `toml:"data-dir" json:"data-dir"`
+	ForceNewCluster   bool   `json:"force-new-cluster"`
+	EnableGRPCGateway bool   `json:"enable-grpc-gateway"`
 
 	InitialCluster      string `toml:"initial-cluster" json:"initial-cluster"`
 	InitialClusterState string `toml:"initial-cluster-state" json:"initial-cluster-state"`
@@ -215,9 +214,8 @@ const (
 	// DefaultMinResolvedTSPersistenceInterval is the default value of min resolved ts persistent interval.
 	DefaultMinResolvedTSPersistenceInterval = time.Second
 
-	defaultEnableGRPCGateway          = true
-	defaultEnableLeaderClientAutoSync = false
-	defaultDisableErrorVerbose        = true
+	defaultEnableGRPCGateway   = true
+	defaultDisableErrorVerbose = true
 
 	defaultDashboardAddress = "auto"
 
@@ -226,7 +224,8 @@ const (
 	defaultMaxConcurrentTSOProxyStreamings = 5000
 	defaultTSOProxyRecvFromClientTimeout   = 1 * time.Hour
 
-	defaultTSOSaveInterval = time.Duration(defaultLeaderLease) * time.Second
+	// DefaultTSOSaveInterval is the default value of the config `TSOSaveInterval`.
+	DefaultTSOSaveInterval = time.Duration(defaultLeaderLease) * time.Second
 	// defaultTSOUpdatePhysicalInterval is the default value of the config `TSOUpdatePhysicalInterval`.
 	defaultTSOUpdatePhysicalInterval = 50 * time.Millisecond
 	// MaxTSOUpdatePhysicalInterval is the max value of the config `TSOUpdatePhysicalInterval`.
@@ -401,7 +400,7 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	configutil.AdjustDuration(&c.TSOProxyRecvFromClientTimeout, defaultTSOProxyRecvFromClientTimeout)
 
 	configutil.AdjustInt64(&c.LeaderLease, defaultLeaderLease)
-	configutil.AdjustDuration(&c.TSOSaveInterval, defaultTSOSaveInterval)
+	configutil.AdjustDuration(&c.TSOSaveInterval, DefaultTSOSaveInterval)
 	configutil.AdjustDuration(&c.TSOUpdatePhysicalInterval, defaultTSOUpdatePhysicalInterval)
 
 	if c.TSOUpdatePhysicalInterval.Duration > MaxTSOUpdatePhysicalInterval {
@@ -452,9 +451,6 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	}
 	if !configMetaData.IsDefined("enable-grpc-gateway") {
 		c.EnableGRPCGateway = defaultEnableGRPCGateway
-	}
-	if !configMetaData.IsDefined("enable-leader-client-auto-sync") {
-		c.EnableLeaderClientAutoSync = defaultEnableLeaderClientAutoSync
 	}
 
 	c.Dashboard.adjust(configMetaData.Child("dashboard"))

--- a/server/server.go
+++ b/server/server.go
@@ -384,12 +384,12 @@ func (s *Server) startClient() error {
 	}
 	/* Starting two different etcd clients here is to avoid the throttling. */
 	// This etcd client will be used to access the etcd cluster to read and write all kinds of meta data.
-	s.client, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.AdvertiseClientUrls, etcdutil.ServerEtcdClientUsager, false)
+	s.client, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.AdvertiseClientUrls, etcdutil.ServerEtcdClientPurpose, true)
 	if err != nil {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()
 	}
 	// This etcd client will only be used to read and write the election-related data, such as leader key.
-	s.electionClient, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.AdvertiseClientUrls, etcdutil.ElectionEtcdClientUsager, s.cfg.EnableLeaderClientAutoSync)
+	s.electionClient, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.AdvertiseClientUrls, etcdutil.ElectionEtcdClientPurpose, false)
 	if err != nil {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()
 	}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #9981
tcms: https://tcms.pingcap.net/dashboard/executions/plan/8014293

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
1. The timeout of the operator `saveTimeStamp` should depend on the server configuration tso save interval 
2. The etcd client of the tso should be same with the election and only connect the local address 
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
