### PR TITLE
tests: make TestHotWriteRegionScheduleWithPendingInfluence stable

### DIFF
--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -977,7 +977,6 @@ func TestHotWriteRegionScheduleWithLeader(t *testing.T) {
 }
 
 func TestHotWriteRegionScheduleWithPendingInfluence(t *testing.T) {
-	t.Skip("Skip flaky test")
 	re := require.New(t)
 	checkHotWriteRegionScheduleWithPendingInfluence(re, 0) // 0: byte rate
 	checkHotWriteRegionScheduleWithPendingInfluence(re, 1) // 1: key rate
@@ -1031,7 +1030,7 @@ func checkHotWriteRegionScheduleWithPendingInfluence(re *require.Assertions, dim
 	default:
 	}
 
-	for range 20 {
+	for range 3 {
 		clearPendingInfluence(hb.(*hotScheduler))
 		cnt := 0
 	testLoop:


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/9364

When we run `make ut`, we are actually running `go test -tags deadlock -run ^TestHotWriteRegionScheduleWithPendingInfluence$ github.com/tikv/pd/pkg/schedule/schedulers -race`. 

After we add deadlock tag, the test will slow down. Some time-dependent statistics and scheduling will not function properly.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
```
make ut
...
building task finish, parallelism=32, count=835, takes=21.586714667s
run all tasks takes 2m17.888815811s
```

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
