### PR TITLE
Add 'store' label to metric pd_cluster_status in 7.5. (#9865)

### DIFF
--- a/pkg/statistics/metrics.go
+++ b/pkg/statistics/metrics.go
@@ -47,7 +47,7 @@ var (
 			Subsystem: "cluster",
 			Name:      "status",
 			Help:      "Status of the cluster.",
-		}, []string{"type"})
+		}, []string{"type", "store"})
 
 	placementStatusGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/pkg/statistics/store_collection_test.go
+++ b/pkg/statistics/store_collection_test.go
@@ -72,19 +72,6 @@ func TestStoreStatistics(t *testing.T) {
 	}
 	stats := storeStats.stats
 
-	re.Equal(6, stats.Up)
-	re.Equal(7, stats.Preparing)
-	re.Equal(0, stats.Serving)
-	re.Equal(1, stats.Removing)
-	re.Equal(1, stats.Removed)
-	re.Equal(1, stats.Down)
-	re.Equal(1, stats.Offline)
-	re.Equal(0, stats.RegionCount)
-	re.Equal(0, stats.WitnessCount)
-	re.Equal(0, stats.Unhealthy)
-	re.Equal(0, stats.Disconnect)
-	re.Equal(1, stats.Tombstone)
-	re.Equal(1, stats.LowSpace)
 	re.Equal(2, stats.LabelCounter["zone:z1"])
 	re.Equal(2, stats.LabelCounter["zone:z2"])
 	re.Equal(2, stats.LabelCounter["zone:z3"])

--- a/pkg/statistics/utils/labels.go
+++ b/pkg/statistics/utils/labels.go
@@ -1,0 +1,22 @@
+// Copyright 2020 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// SingleLabel build a labels map containing only a single label
+func SingleLabel(key, value string) prometheus.Labels {
+	return prometheus.Labels{key: value}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #9855 

### What is changed and how does it work?

```commit-message
Add 'store' label to metric pd_cluster_status in 7.5.
```

### Check List

Tests

- Unit test

Code changes

- Code now emit Gauge metric pd_cluster_status for each store separately and adds label 'store' containing storeId. Previously code aggregated this metric across all stores and then emitted one time.

Side effects

- metric pd_cluster_status now needs to be aggregated in metic system across all stores if you need value across whole cluster.

Related changes

None

### Release note

```release-note
We added 'store' label to metric pd_cluster_status. This new label contains store ID for which datapoint is emitted. How if you still need the value from this metric for the whole cluster, then you need to aggregate it across all stores
```

Signed-off-by: Sergey Kolosov <sergey.kolosov@airbnb.com>

Co-authored-by: Sergey Kolosov <sergey.kolosov@airbnb.com>
(cherry picked from commit b0500cdcf5e0a12a66eb08dfde4c4a5f218c6de6)
Signed-off-by: Sergey Kolosov <sergey.kolosov@airbnb.com>