### PR TITLE
*: move initialization to coordinator

### DIFF
--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -94,9 +94,8 @@ type Cluster struct {
 }
 
 const (
-	regionLabelGCInterval = time.Hour
-	requestTimeout        = 3 * time.Second
-	requestInterval       = 10 * time.Second
+	requestTimeout  = 3 * time.Second
+	requestInterval = 10 * time.Second
 
 	// heartbeat relative const
 	heartbeatTaskRunner = "heartbeat-task-runner"
@@ -118,11 +117,7 @@ func NewCluster(
 	backendAddress string,
 ) (*Cluster, error) {
 	ctx, cancel := context.WithCancel(parentCtx)
-	labelerManager, err := labeler.NewRegionLabeler(ctx, storage, regionLabelGCInterval)
-	if err != nil {
-		cancel()
-		return nil, err
-	}
+	labelerManager := labeler.NewRegionLabeler(ctx, storage)
 	ruleManager := placement.NewRuleManager(ctx, storage, basicCluster, persistConfig)
 	affinityManager, err := affinity.NewManager(ctx, storage, basicCluster, persistConfig, labelerManager)
 	if err != nil {
@@ -550,7 +545,7 @@ func (c *Cluster) runUpdateStoreStats() {
 func (c *Cluster) runCoordinator() {
 	defer logutil.LogPanic()
 	defer c.wg.Done()
-	c.coordinator.RunUntilStop()
+	c.coordinator.RunUntilStop(true)
 }
 
 // GetPrepareRegionCount returns the count of regions that are in prepare state.

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -66,7 +66,8 @@ func BenchmarkLoadLargeRules(b *testing.B) {
 
 func runWatcherLoadLabelRule(ctx context.Context, re *require.Assertions, client *clientv3.Client) {
 	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
-	labelerManager, err := labeler.NewRegionLabeler(ctx, storage, time.Hour)
+	labelerManager := labeler.NewRegionLabeler(ctx, storage)
+	err := labelerManager.Initialize(time.Hour)
 	re.NoError(err)
 	ctx, cancel := context.WithCancel(ctx)
 	rw := &Watcher{

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -88,12 +88,12 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 	c.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.HotScheduleWithQuery))
 	c.RegionLabeler = labeler.NewRegionLabeler(ctx, c.Storage)
 	if err := c.RegionLabeler.Initialize(time.Second * 5); err != nil {
-		log.Error("failed to initialize region labeler", errs.ZapError(err))
+		panic(err)
 	}
 
 	c.AffinityManager, _ = affinity.NewManager(c.ctx, c.GetStorage(), c, c.GetSharedConfig(), c.RegionLabeler)
 	if err := c.AffinityManager.Initialize(); err != nil {
-		log.Error("failed to initialize affinity manager", errs.ZapError(err))
+		panic(err)
 	}
 
 	return c
@@ -224,7 +224,7 @@ func (mc *Cluster) initRuleManager() {
 		mc.RuleManager = placement.NewRuleManager(mc.ctx, mc.GetStorage(), mc, mc.GetSharedConfig())
 		err := mc.RuleManager.Initialize(int(mc.GetReplicationConfig().MaxReplicas), mc.GetReplicationConfig().LocationLabels, mc.GetReplicationConfig().IsolationLevel, false)
 		if err != nil {
-			log.Info("failed to initialize rule manager", errs.ZapError(err))
+			panic(err)
 		}
 	}
 }

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -86,8 +86,16 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 	}
 	// It should be updated to the latest feature version.
 	c.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.HotScheduleWithQuery))
-	c.RegionLabeler, _ = labeler.NewRegionLabeler(ctx, c.Storage, time.Second*5)
+	c.RegionLabeler = labeler.NewRegionLabeler(ctx, c.Storage)
+	if err := c.RegionLabeler.Initialize(time.Second * 5); err != nil {
+		log.Error("failed to initialize region labeler", errs.ZapError(err))
+	}
+
 	c.AffinityManager, _ = affinity.NewManager(c.ctx, c.GetStorage(), c, c.GetSharedConfig(), c.RegionLabeler)
+	if err := c.AffinityManager.Initialize(); err != nil {
+		log.Error("failed to initialize affinity manager", errs.ZapError(err))
+	}
+
 	return c
 }
 
@@ -214,7 +222,7 @@ func (mc *Cluster) AllocPeer(storeID uint64) (*metapb.Peer, error) {
 func (mc *Cluster) initRuleManager() {
 	if mc.RuleManager == nil {
 		mc.RuleManager = placement.NewRuleManager(mc.ctx, mc.GetStorage(), mc, mc.GetSharedConfig())
-		err := mc.Initialize(int(mc.GetReplicationConfig().MaxReplicas), mc.GetReplicationConfig().LocationLabels, mc.GetReplicationConfig().IsolationLevel, false)
+		err := mc.RuleManager.Initialize(int(mc.GetReplicationConfig().MaxReplicas), mc.GetReplicationConfig().LocationLabels, mc.GetReplicationConfig().IsolationLevel, false)
 		if err != nil {
 			log.Info("failed to initialize rule manager", errs.ZapError(err))
 		}

--- a/pkg/schedule/affinity/group_test.go
+++ b/pkg/schedule/affinity/group_test.go
@@ -67,9 +67,12 @@ func TestAdjustGroup(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	group := &Group{

--- a/pkg/schedule/affinity/manager.go
+++ b/pkg/schedule/affinity/manager.go
@@ -93,14 +93,12 @@ func NewManager(ctx context.Context, storage endpoint.AffinityStorage, storeSetI
 		keyRanges:           make(map[string]GroupKeyRanges),
 		unavailableStores:   make(map[uint64]storeCondition),
 	}
-	if err := m.initialize(); err != nil {
-		return nil, err
-	}
+
 	return m, nil
 }
 
-// initialize loads affinity groups from storage and rebuilds the group-label mapping.
-func (m *Manager) initialize() error {
+// Initialize loads affinity groups from storage and rebuilds the group-label mapping.
+func (m *Manager) Initialize() error {
 	// metaMutex must be locked, because loadRegionLabel will acquire RWMutex to protect keyRanges
 	m.metaMutex.Lock()
 	defer m.metaMutex.Unlock()

--- a/pkg/schedule/affinity/manager_test.go
+++ b/pkg/schedule/affinity/manager_test.go
@@ -48,10 +48,13 @@ func TestGetRegionAffinityGroupState(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create affinity group with 6 key ranges for testing
@@ -155,10 +158,13 @@ func TestBasicGroupOperations(t *testing.T) {
 	conf := mockconfig.NewTestOptions()
 
 	// Create region labeler
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a group
@@ -187,9 +193,12 @@ func TestRegionCountStaleCache(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	ranges := createGroupForTest(re, manager, "g", 2)
@@ -256,9 +265,12 @@ func TestDeleteGroupClearsCache(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a group and add regions
@@ -321,9 +333,12 @@ func TestAvailabilityChangeRegionCount(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a group
@@ -381,9 +396,12 @@ func TestInvalidCacheMultipleTimes(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a group
@@ -445,9 +463,12 @@ func TestConcurrentOperations(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create initial groups
@@ -557,9 +578,12 @@ func TestDegradedExpiration(t *testing.T) {
 	}
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a healthy group

--- a/pkg/schedule/affinity/policy_test.go
+++ b/pkg/schedule/affinity/policy_test.go
@@ -59,9 +59,12 @@ func TestCollectUnavailableStores(t *testing.T) {
 	storeInfos := core.NewStoresInfo()
 	conf := mockconfig.NewTestOptions()
 	conf.SetLabelProperty("reject-leader", "reject", "leader")
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, memoryStorage, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, memoryStorage)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, memoryStorage, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	stores := make([]*core.StoreInfo, 12)
@@ -129,10 +132,13 @@ func TestObserveAvailableRegion(t *testing.T) {
 	conf := mockconfig.NewTestOptions()
 
 	// Create region labeler
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	group := &Group{ID: "g", LeaderStoreID: 0, VoterStoreIDs: nil}
@@ -220,10 +226,13 @@ func TestAvailabilityCheckInvalidatesGroup(t *testing.T) {
 	conf := mockconfig.NewTestOptions()
 
 	// Create region labeler
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	group := &Group{ID: "avail", LeaderStoreID: 1, VoterStoreIDs: []uint64{1, 2}}
@@ -274,11 +283,14 @@ func TestStoreHealthCheck(t *testing.T) {
 	conf := mockconfig.NewTestOptions()
 
 	// Create region labeler
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	// Create affinity manager
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a test affinity group with healthy stores
@@ -367,10 +379,13 @@ func TestDegradedGroupShouldExpire(t *testing.T) {
 
 	conf := mockconfig.NewTestOptions()
 
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a healthy group first.
@@ -413,9 +428,12 @@ func TestGroupAvailabilityPriority(t *testing.T) {
 		storeInfos.PutStore(storeInfo)
 	}
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Case 1: leader-only constraint should degrade when on leader, ignored on followers.

--- a/pkg/schedule/affinity/split_test.go
+++ b/pkg/schedule/affinity/split_test.go
@@ -52,10 +52,13 @@ func TestAllowSplit(t *testing.T) {
 	cfg.AffinityScheduleLimit = 4 // Enable affinity scheduling
 	conf.SetScheduleConfig(cfg)
 
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	groupID := "g1"

--- a/pkg/schedule/affinity/txn_test.go
+++ b/pkg/schedule/affinity/txn_test.go
@@ -46,11 +46,14 @@ func TestKeyRangeOverlapValidation(t *testing.T) {
 	conf := mockconfig.NewTestOptions()
 
 	// Create region labeler
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	// Create manager with region labeler
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	validate := func(ranges []GroupKeyRanges) error {
@@ -125,10 +128,13 @@ func TestKeyRangeOverlapRebuild(t *testing.T) {
 	conf := mockconfig.NewTestOptions()
 
 	// Create region labeler
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create two groups without key ranges for basic testing
@@ -149,9 +155,12 @@ func TestKeyRangeOverlapRebuild(t *testing.T) {
 	re.True(manager.IsGroupExist("group2"))
 
 	// Create a new manager to simulate restart
-	regionLabeler2, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler2 := labeler.NewRegionLabeler(ctx, store)
+	err = regionLabeler2.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager2, err := NewManager(ctx, store, storeInfos, conf, regionLabeler2)
+	re.NoError(err)
+	err = manager2.Initialize()
 	re.NoError(err)
 
 	// Verify groups were loaded from storage
@@ -181,10 +190,13 @@ func TestAffinityPersistenceWithLabeler(t *testing.T) {
 
 	conf := mockconfig.NewTestOptions()
 
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	keyRanges := createGroupForTest(re, manager, "persist", 10)
@@ -199,6 +211,8 @@ func TestAffinityPersistenceWithLabeler(t *testing.T) {
 
 	// Reload manager to verify persistence and loadRegionLabel integration.
 	manager2, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager2.Initialize()
 	re.NoError(err)
 	state2 := manager2.GetAffinityGroupState("persist")
 	re.NotNil(state2)
@@ -232,7 +246,8 @@ func TestLoadRegionLabelIgnoreUnknownGroup(t *testing.T) {
 	store := storage.NewStorageWithMemoryBackend()
 	storeInfos := core.NewStoresInfo()
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	// Inject a leftover label rule for a non-existent group "ghost".
@@ -251,6 +266,8 @@ func TestLoadRegionLabelIgnoreUnknownGroup(t *testing.T) {
 
 	// Manager initialization should ignore the unknown label rule.
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 	re.False(manager.IsGroupExist("ghost"))
 
@@ -281,10 +298,13 @@ func TestLabelRuleIntegration(t *testing.T) {
 	conf := mockconfig.NewTestOptions()
 
 	// Create region labeler
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Test: Group with no key ranges should not create label rule
@@ -321,9 +341,12 @@ func TestUpdateAffinityGroupKeyRangesAddToEmptyGroup(t *testing.T) {
 
 	conf := mockconfig.NewTestOptions()
 
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a group without key ranges or peers.
@@ -356,9 +379,12 @@ func TestDuplicateRangeAdd(t *testing.T) {
 
 	conf := mockconfig.NewTestOptions()
 
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	r := keyutil.KeyRange{StartKey: []byte{0x00}, EndKey: []byte{0x10}}
@@ -388,9 +414,12 @@ func TestDeleteAffinityGroupsForceMissing(t *testing.T) {
 
 	conf := mockconfig.NewTestOptions()
 
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create a group with a key range.
@@ -421,9 +450,12 @@ func TestSameGroupNonOverlappingAdd(t *testing.T) {
 	storeInfos.PutStore(store1)
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	r1 := keyutil.KeyRange{StartKey: []byte{0x00}, EndKey: []byte{0x10}}
@@ -457,9 +489,12 @@ func TestOverlapDuringMigration(t *testing.T) {
 	storeInfos.PutStore(store1)
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	r := keyutil.KeyRange{StartKey: []byte{0x00}, EndKey: []byte{0x10}}
@@ -486,9 +521,12 @@ func TestPartialOverlapSameGroup(t *testing.T) {
 	storeInfos.PutStore(store1)
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	rOld := keyutil.KeyRange{StartKey: []byte{0x00}, EndKey: []byte{0x10}}
@@ -519,9 +557,12 @@ func TestNewGroupOverlapWithExistingGroup(t *testing.T) {
 	storeInfos.PutStore(store1)
 
 	conf := mockconfig.NewTestOptions()
-	regionLabeler, err := labeler.NewRegionLabeler(ctx, store, time.Second*5)
+	regionLabeler := labeler.NewRegionLabeler(ctx, store)
+	err := regionLabeler.Initialize(time.Second * 5)
 	re.NoError(err)
 	manager, err := NewManager(ctx, store, storeInfos, conf, regionLabeler)
+	re.NoError(err)
+	err = manager.Initialize()
 	re.NoError(err)
 
 	// Create group A with range [0x00, 0x20]

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -240,15 +240,15 @@ func (c *Coordinator) RunUntilStop(skipLoadRules bool) {
 		}
 		err := c.ruleManager.Initialize(c.config.GetMaxReplicas(), c.config.GetLocationLabels(), c.config.GetIsolationLevel(), skipLoadRules)
 		if err != nil {
-			log.Error("rule manager initialize failed", errs.ZapError(err))
+			log.Warn("rule manager initialize failed", errs.ZapError(err))
 			continue
 		}
 		if err := c.regionLabeler.Initialize(regionLabelGCInterval); err != nil {
-			log.Error("region labeler initialize failed", errs.ZapError(err))
+			log.Warn("region labeler initialize failed", errs.ZapError(err))
 			continue
 		}
 		if err := c.affinityManager.Initialize(); err != nil {
-			log.Error("affinity manager initialize failed", errs.ZapError(err))
+			log.Warn("affinity manager initialize failed", errs.ZapError(err))
 			continue
 		}
 		break

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -43,7 +43,7 @@ type RegionLabeler struct {
 }
 
 // NewRegionLabeler creates a Labeler instance.
-func NewRegionLabeler(ctx context.Context, storage endpoint.RuleStorage, gcInterval time.Duration) (*RegionLabeler, error) {
+func NewRegionLabeler(ctx context.Context, storage endpoint.RuleStorage) *RegionLabeler {
 	l := &RegionLabeler{
 		storage:    storage,
 		labelRules: make(map[string]*LabelRule),
@@ -51,11 +51,16 @@ func NewRegionLabeler(ctx context.Context, storage endpoint.RuleStorage, gcInter
 		minExpire:  nil,
 	}
 
+	return l
+}
+
+// Initialize loads existing label rules from storage and starts GC routine.
+func (l *RegionLabeler) Initialize(gcInterval time.Duration) error {
 	if err := l.loadRules(); err != nil {
-		return nil, err
+		return err
 	}
 	go l.doGC(gcInterval)
-	return l, nil
+	return nil
 }
 
 func (l *RegionLabeler) doGC(gcInterval time.Duration) {

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -129,7 +129,9 @@ func (l *RegionLabeler) loadRules() error {
 			toDelete = append(toDelete, k)
 			return
 		}
+		l.Lock()
 		l.labelRules[r.ID] = r
+		l.Unlock()
 	})
 	if err != nil {
 		return err
@@ -141,7 +143,10 @@ func (l *RegionLabeler) loadRules() error {
 			return err
 		}
 	}
+
+	l.Lock()
 	l.BuildRangeListLocked()
+	l.Unlock()
 	return nil
 }
 

--- a/pkg/schedule/labeler/labeler_test.go
+++ b/pkg/schedule/labeler/labeler_test.go
@@ -104,7 +104,8 @@ func TestGetSetRule(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 	rules := []*LabelRule{
 		{ID: "rule1", Labels: []RegionLabel{{Key: "k1", Value: "v1"}}, RuleType: "key-range", Data: MakeKeyRanges("1234", "5678")},
@@ -161,7 +162,8 @@ func TestTxnWithEtcd(t *testing.T) {
 	store := storage.NewStorageWithEtcdBackend(client)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 	// test patch rules in batch
 	rulesNum := 200
@@ -228,7 +230,8 @@ func TestIndex(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 	rules := []*LabelRule{
 		{ID: "rule0", Labels: []RegionLabel{{Key: "k1", Value: "v0"}}, RuleType: "key-range", Data: MakeKeyRanges("", "")},
@@ -274,7 +277,8 @@ func TestSaveLoadRule(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 	rules := []*LabelRule{
 		{ID: "rule1", Labels: []RegionLabel{{Key: "k1", Value: "v1"}}, RuleType: "key-range", Data: MakeKeyRanges("1234", "5678")},
@@ -287,7 +291,8 @@ func TestSaveLoadRule(t *testing.T) {
 	}
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
-	labeler, err = NewRegionLabeler(ctx1, store, time.Millisecond*100)
+	labeler = NewRegionLabeler(ctx1, store)
+	err = labeler.Initialize(time.Millisecond * 100)
 	re.NoError(err)
 	for _, r := range rules {
 		r2 := labeler.GetLabelRule(r.ID)
@@ -325,7 +330,8 @@ func TestKeyRange(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 	rules := []*LabelRule{
 		{ID: "rule1", Labels: []RegionLabel{{Key: "k1", Value: "v1"}}, RuleType: "key-range", Data: MakeKeyRanges("1234", "5678")},
@@ -370,7 +376,8 @@ func TestLabelerRuleTTL(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Minute)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Minute)
 	re.NoError(err)
 	rules := []*LabelRule{
 		{
@@ -451,7 +458,8 @@ func TestGC(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Hour)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Hour)
 	re.NoError(err)
 	ttls := []string{"1ms", "1ms", "1ms", "5ms", "5ms", "10ms", "1h", "24h"}
 	start, err := hex.DecodeString("1234")

--- a/pkg/schedule/labeler/plan_test.go
+++ b/pkg/schedule/labeler/plan_test.go
@@ -31,7 +31,8 @@ func TestPlanSetLabelRule(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 
 	plan := labeler.NewPlan()
@@ -77,7 +78,8 @@ func TestPlanDeleteLabelRule(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 
 	plan := labeler.NewPlan()
@@ -100,7 +102,8 @@ func TestPlanCommitOps(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 
 	plan := labeler.NewPlan()
@@ -142,7 +145,8 @@ func TestPlanApply(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 
 	// First, add a rule to the labeler
@@ -208,7 +212,8 @@ func TestPlanApplyWithError(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 
 	plan := labeler.NewPlan()
@@ -238,7 +243,8 @@ func TestPlanMultipleOperations(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 
 	plan := labeler.NewPlan()
@@ -291,7 +297,8 @@ func TestPlanDeleteNonExistentRule(t *testing.T) {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
+	labeler := NewRegionLabeler(ctx, store)
+	err := labeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 
 	plan := labeler.NewPlan()

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -109,8 +109,6 @@ const (
 	persistLimitRetryTimes  = 5
 	persistLimitWaitTime    = 100 * time.Millisecond
 	gcTunerCheckCfgInterval = 10 * time.Second
-	// regionLabelGCInterval is the interval to run region-label's GC work.
-	regionLabelGCInterval = time.Hour
 	// storageSizeCollectorInterval is the interval to run storage size collector.
 	storageSizeCollectorInterval = time.Minute
 
@@ -371,17 +369,8 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 		log.Warn("cluster is not bootstrapped")
 		return nil
 	}
-	if c.opt.IsPlacementRulesEnabled() {
-		err := c.ruleManager.Initialize(c.opt.GetMaxReplicas(), c.opt.GetLocationLabels(), c.opt.GetIsolationLevel(), false)
-		if err != nil {
-			return err
-		}
-	}
 
-	c.regionLabeler, err = labeler.NewRegionLabeler(c.ctx, c.storage, regionLabelGCInterval)
-	if err != nil {
-		return err
-	}
+	c.regionLabeler = labeler.NewRegionLabeler(c.ctx, c.storage)
 
 	// create affinity manager with region labeler for key range validation and rebuild
 	c.affinityManager, err = affinity.NewManager(c.ctx, c.storage, c, c.GetOpts(), c.regionLabeler)

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/progress"
 	"github.com/tikv/pd/pkg/schedule"
+	"github.com/tikv/pd/pkg/schedule/affinity"
 	"github.com/tikv/pd/pkg/schedule/checker"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	sche "github.com/tikv/pd/pkg/schedule/core"
@@ -1411,7 +1412,7 @@ func TestStoreConfigUpdate(t *testing.T) {
 
 	_, opt, err := newTestScheduleConfig()
 	re.NoError(err)
-	tc := newTestCluster(ctx, re, opt)
+	tc := newTestCluster(ctx, opt)
 	stores := newTestStores(5, "2.0.0")
 	for _, s := range stores {
 		re.NoError(tc.setStore(s))
@@ -1481,7 +1482,7 @@ func TestSyncConfigContext(t *testing.T) {
 
 	_, opt, err := newTestScheduleConfig()
 	re.NoError(err)
-	tc := newTestCluster(ctx, re, opt)
+	tc := newTestCluster(ctx, opt)
 	tc.httpClient = &http.Client{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -1528,7 +1529,7 @@ func TestStoreConfigSync(t *testing.T) {
 
 	_, opt, err := newTestScheduleConfig()
 	re.NoError(err)
-	tc := newTestCluster(ctx, re, opt)
+	tc := newTestCluster(ctx, opt)
 	stores := newTestStores(5, "2.0.0")
 	for _, s := range stores {
 		re.NoError(tc.setStore(s))
@@ -1572,7 +1573,7 @@ func TestUpdateStorePendingPeerCount(t *testing.T) {
 
 	_, opt, err := newTestScheduleConfig()
 	re.NoError(err)
-	tc := newTestCluster(ctx, re, opt)
+	tc := newTestCluster(ctx, opt)
 	tc.coordinator = schedule.NewCoordinator(ctx, tc.RaftCluster, nil)
 	stores := newTestStores(5, "2.0.0")
 	for _, s := range stores {
@@ -2139,13 +2140,8 @@ func newTestScheduleConfig() (*sc.ScheduleConfig, *config.PersistOptions, error)
 	return &cfg.Schedule, opt, nil
 }
 
-func newTestCluster(ctx context.Context, re *require.Assertions, opt *config.PersistOptions) *testCluster {
-	var err error
+func newTestCluster(ctx context.Context, opt *config.PersistOptions) *testCluster {
 	rc := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
-	storage := storage.NewStorageWithMemoryBackend()
-	rc.regionLabeler, err = labeler.NewRegionLabeler(ctx, storage, time.Second*5)
-	re.NoError(err)
-
 	return &testCluster{RaftCluster: rc}
 }
 
@@ -2166,13 +2162,14 @@ func newTestRaftCluster(
 	if err != nil {
 		panic(err)
 	}
-	rc.ruleManager = placement.NewRuleManager(ctx, storage.NewStorageWithMemoryBackend(), rc, opt)
 	if opt.IsPlacementRulesEnabled() {
 		err := rc.ruleManager.Initialize(opt.GetMaxReplicas(), opt.GetLocationLabels(), opt.GetIsolationLevel(), false)
 		if err != nil {
 			panic(err)
 		}
 	}
+	rc.regionLabeler = labeler.NewRegionLabeler(ctx, s)
+	rc.affinityManager, err = affinity.NewManager(ctx, s, rc.BasicCluster, opt, rc.regionLabeler)
 	rc.schedulingController = newSchedulingController(rc.ctx, rc.BasicCluster, rc.opt, rc.ruleManager)
 	return rc
 }
@@ -2486,7 +2483,7 @@ func TestDispatch(t *testing.T) {
 	re.NoError(tc.updateLeaderCount(1, 10))
 	re.NoError(tc.addLeaderRegion(2, 4, 3, 2))
 
-	go co.RunUntilStop()
+	go co.RunUntilStop(false)
 
 	// Wait for schedule and turn off balance.
 	waitOperator(re, co, 1)
@@ -2622,7 +2619,7 @@ func prepare(setCfg func(*sc.ScheduleConfig), setTc func(*testCluster), run func
 	if setCfg != nil {
 		setCfg(cfg)
 	}
-	tc := newTestCluster(ctx, re, opt)
+	tc := newTestCluster(ctx, opt)
 	hbStreams := hbstream.NewTestHeartbeatStreams(ctx, tc, true /* need to run */)
 	if setTc != nil {
 		setTc(tc)
@@ -2676,7 +2673,7 @@ func TestCheckRegion(t *testing.T) {
 	re.NoError(tc.putRegion(r))
 	checkRegionAndOperator(re, tc, co, 1, 0)
 
-	tc = newTestCluster(ctx, re, opt)
+	tc = newTestCluster(ctx, opt)
 	co = schedule.NewCoordinator(ctx, tc.RaftCluster, hbStreams)
 
 	re.NoError(tc.addRegionStore(4, 4))

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -2170,6 +2170,9 @@ func newTestRaftCluster(
 	}
 	rc.regionLabeler = labeler.NewRegionLabeler(ctx, s)
 	rc.affinityManager, err = affinity.NewManager(ctx, s, rc.BasicCluster, opt, rc.regionLabeler)
+	if err != nil {
+		panic(err)
+	}
 	rc.schedulingController = newSchedulingController(rc.ctx, rc.BasicCluster, rc.opt, rc.ruleManager)
 	return rc
 }

--- a/server/cluster/metering_test.go
+++ b/server/cluster/metering_test.go
@@ -47,7 +47,8 @@ func TestCollectStorageSize(t *testing.T) {
 		re.NoError(err)
 	}
 
-	tc.regionLabeler, err = labeler.NewRegionLabeler(ctx, tc.storage, time.Second*5)
+	tc.regionLabeler = labeler.NewRegionLabeler(ctx, tc.storage)
+	err = tc.regionLabeler.Initialize(time.Millisecond * 10)
 	re.NoError(err)
 	keyspaceGroupManager := keyspace.NewKeyspaceGroupManager(ctx, tc.storage, tc.etcdClient)
 	re.NoError(keyspaceGroupManager.Bootstrap(ctx))

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -120,7 +120,7 @@ func (sc *schedulingController) initCoordinatorLocked(ctx context.Context, clust
 func (sc *schedulingController) runCoordinator() {
 	defer logutil.LogPanic()
 	defer sc.wg.Done()
-	sc.coordinator.RunUntilStop()
+	sc.coordinator.RunUntilStop(false)
 }
 
 func (sc *schedulingController) runStatsBackgroundJobs() {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10118.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
