### PR TITLE
config: preserve raw size units in /config output

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/unrolled/render"
 
 	"github.com/pingcap/errcode"
@@ -38,6 +39,7 @@ import (
 	"github.com/tikv/pd/pkg/utils/jsonutil"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/reflectutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/config"
 )
@@ -75,7 +77,7 @@ func (h *confHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 		mergedCfg := localCfg
 		mergedCfg.Replication = leaderCfg.Replication
 		mergedCfg.Schedule = leaderCfg.Schedule
-		h.rd.JSON(w, http.StatusOK, mergedCfg)
+		h.renderConfigWithRawSize(w, mergedCfg)
 		return
 	}
 	cfg := h.svr.GetConfig()
@@ -91,7 +93,7 @@ func (h *confHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	} else {
 		cfg.Schedule.MaxMergeRegionKeys = cfg.Schedule.GetMaxMergeRegionKeys()
 	}
-	h.rd.JSON(w, http.StatusOK, cfg)
+	h.renderConfigWithRawSize(w, cfg)
 }
 
 // GetDefaultConfig gets the default config.
@@ -158,26 +160,126 @@ func (h *confHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rawSizeUpdates := make(map[string]string)
 	for k, v := range conf {
+		fullKey := k
 		if s := strings.Split(k, "."); len(s) > 1 {
 			if err := h.updateConfig(cfg, k, v); err != nil {
 				h.rd.JSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
-			continue
+		} else {
+			key := reflectutil.FindJSONFullTagByChildTag(reflect.TypeOf(config.Config{}), k)
+			if key == "" {
+				h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("config item %s not found", k))
+				return
+			}
+			fullKey = key
+			if err := h.updateConfig(cfg, key, v); err != nil {
+				h.rd.JSON(w, http.StatusBadRequest, err.Error())
+				return
+			}
 		}
-		key := reflectutil.FindJSONFullTagByChildTag(reflect.TypeOf(config.Config{}), k)
-		if key == "" {
-			h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("config item %s not found", k))
-			return
-		}
-		if err := h.updateConfig(cfg, key, v); err != nil {
-			h.rd.JSON(w, http.StatusBadRequest, err.Error())
-			return
+		if rawValue, ok := parseRawSizeValue(fullKey, v); ok {
+			rawSizeUpdates[fullKey] = rawValue
 		}
 	}
 
+	if err := h.svr.UpdateRawSizeConfig(rawSizeUpdates); err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
 	h.rd.JSON(w, http.StatusOK, "The config is updated.")
+}
+
+func (h *confHandler) renderConfigWithRawSize(w http.ResponseWriter, cfg *config.Config) {
+	raw := h.svr.GetRawSizeConfig()
+	if len(raw) == 0 {
+		h.rd.JSON(w, http.StatusOK, cfg)
+		return
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	var output map[string]any
+	if err := json.Unmarshal(data, &output); err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	applyRawSizeConfig(output, raw)
+	h.rd.JSON(w, http.StatusOK, output)
+}
+
+func applyRawSizeConfig(config map[string]any, raw map[string]string) {
+	for path, rawValue := range raw {
+		segments := strings.Split(path, ".")
+		if len(segments) == 0 {
+			continue
+		}
+		cursor := config
+		for i, segment := range segments {
+			isLast := i == len(segments)-1
+			if isLast {
+				if current, ok := cursor[segment]; ok && rawSizeMatches(current, rawValue) {
+					cursor[segment] = rawValue
+				}
+				break
+			}
+			next, ok := cursor[segment].(map[string]any)
+			if !ok {
+				break
+			}
+			cursor = next
+		}
+	}
+}
+
+func rawSizeMatches(current any, rawValue string) bool {
+	rawBytes, err := units.RAMInBytes(rawValue)
+	if err != nil {
+		return false
+	}
+	switch value := current.(type) {
+	case string:
+		currentBytes, err := units.RAMInBytes(value)
+		if err != nil {
+			return false
+		}
+		return currentBytes == rawBytes
+	case float64:
+		return int64(value) == rawBytes
+	default:
+		return false
+	}
+}
+
+func parseRawSizeValue(key string, value any) (string, bool) {
+	if !isByteSizeConfigKey(key) {
+		return "", false
+	}
+	rawValue, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	if _, err := units.RAMInBytes(rawValue); err != nil {
+		return "", false
+	}
+	return rawValue, true
+}
+
+func isByteSizeConfigKey(path string) bool {
+	tags := strings.Split(path, ".")
+	field := reflectutil.FindFieldByJSONTag(reflect.TypeOf(config.Config{}), tags)
+	if field == nil {
+		return false
+	}
+	if field.Kind() == reflect.Ptr {
+		field = field.Elem()
+	}
+	return field == reflect.TypeOf(typeutil.ByteSize(0))
 }
 
 func (h *confHandler) updateConfig(cfg *config.Config, key string, value any) error {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -58,6 +58,7 @@ type PersistOptions struct {
 	microservice    atomic.Value
 	storeConfig     atomic.Value
 	clusterVersion  unsafe.Pointer
+	rawSizeConfig   atomic.Value
 }
 
 // NewPersistOptions creates a new PersistOptions instance.
@@ -74,6 +75,7 @@ func NewPersistOptions(cfg *Config) *PersistOptions {
 	// set it to an empty config here first.
 	o.storeConfig.Store(&sc.StoreConfig{})
 	o.SetClusterVersion(&cfg.ClusterVersion)
+	o.rawSizeConfig.Store(map[string]string{})
 	o.ttl = nil
 	return o
 }
@@ -156,6 +158,20 @@ func (o *PersistOptions) GetStoreConfig() *sc.StoreConfig {
 // SetStoreConfig sets the store configuration.
 func (o *PersistOptions) SetStoreConfig(cfg *sc.StoreConfig) {
 	o.storeConfig.Store(cfg)
+}
+
+// GetRawSizeConfig returns the raw size config map.
+func (o *PersistOptions) GetRawSizeConfig() map[string]string {
+	raw, ok := o.rawSizeConfig.Load().(map[string]string)
+	if !ok || raw == nil {
+		return map[string]string{}
+	}
+	return cloneRawSizeConfig(raw)
+}
+
+// SetRawSizeConfig sets the raw size config map.
+func (o *PersistOptions) SetRawSizeConfig(cfg map[string]string) {
+	o.rawSizeConfig.Store(cloneRawSizeConfig(cfg))
 }
 
 // GetClusterVersion returns the cluster version.
@@ -798,7 +814,8 @@ func (o *PersistOptions) DeleteLabelProperty(typ, labelKey, labelValue string) {
 type persistedConfig struct {
 	*Config
 	// StoreConfig is injected into Config to avoid breaking the original API.
-	StoreConfig sc.StoreConfig `json:"store"`
+	StoreConfig   sc.StoreConfig     `json:"store"`
+	RawSizeConfig map[string]string `json:"raw-size-config,omitempty"`
 }
 
 // SwitchRaftV2 update some config if tikv raft engine switch into partition raft v2
@@ -820,7 +837,8 @@ func (o *PersistOptions) Persist(storage endpoint.ConfigStorage) error {
 			Microservice:    *o.GetMicroserviceConfig(),
 			ClusterVersion:  *o.GetClusterVersion(),
 		},
-		StoreConfig: *o.GetStoreConfig(),
+		StoreConfig:   *o.GetStoreConfig(),
+		RawSizeConfig: o.GetRawSizeConfig(),
 	}
 	failpoint.Inject("persistFail", func() {
 		failpoint.Return(errors.New("fail to persist"))
@@ -853,8 +871,20 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 		o.microservice.Store(&cfg.Microservice)
 		o.storeConfig.Store(&cfg.StoreConfig)
 		o.SetClusterVersion(&cfg.ClusterVersion)
+		o.SetRawSizeConfig(cfg.RawSizeConfig)
 	}
 	return nil
+}
+
+func cloneRawSizeConfig(raw map[string]string) map[string]string {
+	if raw == nil {
+		return map[string]string{}
+	}
+	clone := make(map[string]string, len(raw))
+	for k, v := range raw {
+		clone[k] = v
+	}
+	return clone
 }
 
 func adjustScheduleCfg(scheduleCfg *sc.ScheduleConfig) {

--- a/server/server.go
+++ b/server/server.go
@@ -1069,6 +1069,33 @@ func (s *Server) GetReplicationConfig() *sc.ReplicationConfig {
 	return s.persistOptions.GetReplicationConfig().Clone()
 }
 
+// GetRawSizeConfig returns the raw size config map.
+func (s *Server) GetRawSizeConfig() map[string]string {
+	return s.persistOptions.GetRawSizeConfig()
+}
+
+// UpdateRawSizeConfig updates the raw size config map and persists it.
+func (s *Server) UpdateRawSizeConfig(raw map[string]string) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	old := s.persistOptions.GetRawSizeConfig()
+	merged := make(map[string]string, len(old)+len(raw))
+	for k, v := range old {
+		merged[k] = v
+	}
+	for k, v := range raw {
+		merged[k] = v
+	}
+	s.persistOptions.SetRawSizeConfig(merged)
+	if err := s.persistOptions.Persist(s.storage); err != nil {
+		s.persistOptions.SetRawSizeConfig(old)
+		log.Error("failed to update raw size config", errs.ZapError(err))
+		return err
+	}
+	return nil
+}
+
 // SetReplicationConfig sets the replication config.
 func (s *Server) SetReplicationConfig(cfg sc.ReplicationConfig) error {
 	if err := cfg.Validate(); err != nil {


### PR DESCRIPTION
## Summary
- Preserve original human-readable size units (e.g., "24MB", "512MiB") in /config API output instead of converting everything to bytes
- Store raw size config values and apply them to JSON responses when byte values match
- Persist raw size config to storage

## Test plan
- Manual testing of /config API endpoint
- Existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)