### PR TITLE
tests: retry when address already in use

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -576,8 +576,11 @@ func restartTestCluster(
 ) (newTestCluster *TestCluster, err error) {
 	schedulers.Register()
 	newTestCluster = &TestCluster{
-		config:  cluster.config,
-		servers: make(map[string]*TestServer, len(cluster.servers)),
+		ctx:      ctx,
+		config:   cluster.config,
+		servers:  make(map[string]*TestServer, len(cluster.servers)),
+		services: cluster.services,
+		opts:     cluster.opts,
 		tsPool: struct {
 			syncutil.Mutex
 			pool map[uint64]struct{}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #8511.

### What is changed and how does it work?

```
[2026/01/19 10:39:07.054 +08:00] [WARN] [cluster.go:665] ["etcd start failed, will retry"] [error="[PD:etcd:ErrStartEtcd]listen tcp 127.0.0.1:43255: bind: address already in use: listen tcp 127.0.0.1:43255: bind: address already in use"]
[2026/01/19 10:39:07.055 +08:00] [WARN] [cluster.go:665] ["etcd start failed, will retry"] [error="[PD:etcd:ErrStartEtcd]listen tcp 127.0.0.1:43255: bind: address already in use: listen tcp 127.0.0.1:43255: bind: address already in use"]
    client_test.go:896: 
        	Error Trace:	/home/prow/go/src/github.com/tikv/pd/tests/integrations/client/client_test.go:896
        	            				/home/prow/go/src/github.com/tikv/pd/tests/integrations/client/router_client_test.go:73
        	            				/home/prow/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:157
        	            				/home/prow/go/src/github.com/tikv/pd/tests/integrations/client/router_client_test.go:46
        	Error:      	Received unexpected error:
        	            	[PD:etcd:ErrStartEtcd]listen tcp 127.0.0.1:43255: bind: address already in use: listen tcp 127.0.0.1:43255: bind: address already in use
```

We do have a retry when the address is already in use, but we use the same port, which is useless.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test cluster startup now retries on port/address conflicts: ports are reallocated and servers recreated to recover while preserving original services and options.
  * Added configurable retry limits and backoff to improve automated recovery when startup conflicts occur.

* **Chores**
  * Test infrastructure now retains startup context and initial configuration to support reliable restart flows and clearer errors when retries are exhausted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->