### PR TITLE
affinity: use isRegionPlacementRuleSatisfiedWithBestLocation instead of IsRegionReplicated

### DIFF
--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
+	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/utils/logutil"
 )
 
@@ -527,6 +528,10 @@ func (c *AffinityChecker) isRegionPlacementRuleSatisfiedWithBestLocation(region 
 		// filterByTempState being true means a better placement exists but is temporarily unschedulable.
 		// This is also considered not satisfied.
 		if newStoreID != 0 || filterByTempState {
+			return false
+		}
+		// If the isolation level does not meet the requirement, it is also considered not to be at the best location.
+		if !statistics.IsRegionLabelIsolationSatisfied(rf.Stores, rf.Rule.LocationLabels, rf.Rule.IsolationLevel) {
 			return false
 		}
 	}

--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -44,6 +44,7 @@ const recentMergeTTL = time.Minute
 type AffinityChecker struct {
 	PauseController
 	cluster          sche.CheckerCluster
+	ruleManager      *placement.RuleManager
 	affinityManager  *affinity.Manager
 	conf             config.CheckerConfigProvider
 	recentMergeCache *cache.TTLUint64
@@ -54,6 +55,7 @@ type AffinityChecker struct {
 func NewAffinityChecker(ctx context.Context, cluster sche.CheckerCluster, conf config.CheckerConfigProvider) *AffinityChecker {
 	return &AffinityChecker{
 		cluster:          cluster,
+		ruleManager:      cluster.GetRuleManager(),
 		affinityManager:  cluster.GetAffinityManager(),
 		conf:             conf,
 		recentMergeCache: cache.NewIDTTL(ctx, gcInterval, recentMergeTTL),
@@ -93,7 +95,7 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		affinityCheckerUnhealthyRegionCounter.Inc()
 		return nil
 	}
-	if !filter.IsRegionReplicated(c.cluster, region) {
+	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(region, true /* isRealRegion */) {
 		affinityCheckerAbnormalReplicaCounter.Inc()
 		return nil
 	}
@@ -115,7 +117,7 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		// so expire the group first, then provide the available Region information and fetch the Group state again.
 		if !isAffinity {
 			targetRegion := cloneRegionWithReplacePeerStores(region, group.LeaderStoreID, group.VoterStoreIDs...)
-			if targetRegion == nil || !filter.IsRegionReplicated(c.cluster, targetRegion) {
+			if targetRegion == nil || !c.isRegionPlacementRuleSatisfiedWithBestLocation(targetRegion, false /* isRealRegion */) {
 				c.affinityManager.ExpireAffinityGroup(group.ID)
 				needRefetch = true
 			}
@@ -381,7 +383,7 @@ func (c *AffinityChecker) checkAffinityMergeTarget(region, adjacent *core.Region
 		return false
 	}
 
-	if !filter.IsRegionReplicated(c.cluster, adjacent) {
+	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(adjacent, true /* isRealRegion */) {
 		affinityMergeCheckerAdjAbnormalReplicaCounter.Inc()
 		return false
 	}
@@ -490,4 +492,56 @@ func (c *AffinityChecker) RecordOpSuccess(op *operator.Operator) {
 	}
 	c.recentMergeCache.PutWithTTL(op.RegionID(), nil, recentMergeTTL)
 	c.recentMergeCache.PutWithTTL(relatedID, nil, recentMergeTTL)
+}
+
+func (c *AffinityChecker) isRegionPlacementRuleSatisfiedWithBestLocation(region *core.RegionInfo, isRealRegion bool) bool {
+	// Return false if Placement Rules are not enabled.
+	if c.cluster.GetSharedConfig().IsPlacementRulesEnabled() {
+		return false
+	}
+
+	// Get the RegionFit for the given Region. If the Region is not a real existing Region but a virtual target state,
+	// use FitRegionWithoutCache to bypass the cache.
+	var fit *placement.RegionFit
+	if isRealRegion {
+		fit = c.ruleManager.FitRegion(c.cluster, region)
+	} else {
+		fit = c.ruleManager.FitRegionWithoutCache(c.cluster, region)
+	}
+
+	// Check region is satisfied
+	if !fit.IsSatisfied() {
+		return false
+	}
+
+	// Check whether all peers covered by the rules are at the best isolation level.
+	// This logic is based on `RuleChecker.fixBetterLocation`.
+	for _, rf := range fit.RuleFits {
+		if len(rf.Rule.LocationLabels) == 0 {
+			continue
+		}
+		isWitness := rf.Rule.IsWitness && isWitnessEnabled(c.cluster)
+		// If the peer to be moved is a witness, since no snapshot is needed, we also reuse the fast failover logic.
+		strategy := c.strategy(region, rf.Rule, isWitness)
+		_, newStoreID, filterByTempState := strategy.getBetterLocation(c.cluster, region, fit, rf)
+		// filterByTempState being true means a better placement exists but is temporarily unschedulable.
+		// This is also considered not satisfied.
+		if newStoreID != 0 || filterByTempState {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *AffinityChecker) strategy(region *core.RegionInfo, rule *placement.Rule, fastFailover bool) *ReplicaStrategy {
+	return &ReplicaStrategy{
+		checkerName:    c.Name(),
+		cluster:        c.cluster,
+		isolationLevel: rule.IsolationLevel,
+		locationLabels: rule.LocationLabels,
+		region:         region,
+		extraFilters:   []filter.Filter{filter.NewLabelConstraintFilter(c.Name(), rule.LabelConstraints)},
+		fastFailover:   fastFailover,
+	}
 }

--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -100,7 +100,7 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		affinityCheckerUnhealthyRegionCounter.Inc()
 		return nil
 	}
-	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(region, true /* isRealRegion */) {
+	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(region, true /* isExistingRegion */) {
 		affinityCheckerAbnormalReplicaCounter.Inc()
 		return nil
 	}
@@ -122,7 +122,7 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		// so expire the group first, then provide the available Region information and fetch the Group state again.
 		if !isAffinity {
 			targetRegion := cloneRegionWithReplacePeerStores(region, group.LeaderStoreID, group.VoterStoreIDs...)
-			if targetRegion == nil || !c.isRegionPlacementRuleSatisfiedWithBestLocation(targetRegion, false /* isRealRegion */) {
+			if targetRegion == nil || !c.isRegionPlacementRuleSatisfiedWithBestLocation(targetRegion, false /* isExistingRegion */) {
 				c.affinityManager.ExpireAffinityGroup(group.ID)
 				group = c.affinityManager.GetAffinityGroupState(group.ID)
 				needRefetch = true
@@ -389,7 +389,7 @@ func (c *AffinityChecker) checkAffinityMergeTarget(region, adjacent *core.Region
 		return false
 	}
 
-	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(adjacent, true /* isRealRegion */) {
+	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(adjacent, true /* isExistingRegion */) {
 		affinityMergeCheckerAdjAbnormalReplicaCounter.Inc()
 		return false
 	}
@@ -506,11 +506,11 @@ func (c *AffinityChecker) RecordOpSuccess(op *operator.Operator) {
 // under the current topology and that the matched rule's isolation level is
 // satisfied. This is intentionally stricter than filter.IsRegionReplicated and
 // should not be used as a general replicated-state check.
-func (c *AffinityChecker) isRegionPlacementRuleSatisfiedWithBestLocation(region *core.RegionInfo, isRealRegion bool) bool {
-	// Get the RegionFit for the given Region. If the Region is not a real existing Region but a virtual target state,
+func (c *AffinityChecker) isRegionPlacementRuleSatisfiedWithBestLocation(region *core.RegionInfo, isExistingRegion bool) bool {
+	// Get the RegionFit for the given Region. If the Region is not an existing Region but a virtual target state,
 	// use FitRegionWithoutCache to bypass the cache.
 	var fit *placement.RegionFit
-	if isRealRegion {
+	if isExistingRegion {
 		fit = c.ruleManager.FitRegion(c.cluster, region)
 	} else {
 		fit = c.ruleManager.FitRegionWithoutCache(c.cluster, region)

--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -511,7 +511,7 @@ func (c *AffinityChecker) isRegionPlacementRuleSatisfiedWithBestLocation(region 
 	}
 
 	// Check region is satisfied
-	if !fit.IsSatisfied() {
+	if fit == nil || !fit.IsSatisfied() {
 		return false
 	}
 

--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -500,6 +500,12 @@ func (c *AffinityChecker) RecordOpSuccess(op *operator.Operator) {
 	c.recentMergeCache.PutWithTTL(relatedID, nil, recentMergeTTL)
 }
 
+// isRegionPlacementRuleSatisfiedWithBestLocation is an affinity-specific
+// scheduling gate. Besides requiring the region to satisfy placement rules, it
+// also requires that affinity scheduling cannot find a strictly better location
+// under the current topology and that the matched rule's isolation level is
+// satisfied. This is intentionally stricter than filter.IsRegionReplicated and
+// should not be used as a general replicated-state check.
 func (c *AffinityChecker) isRegionPlacementRuleSatisfiedWithBestLocation(region *core.RegionInfo, isRealRegion bool) bool {
 	// Get the RegionFit for the given Region. If the Region is not a real existing Region but a virtual target state,
 	// use FitRegionWithoutCache to bypass the cache.

--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -123,6 +123,7 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 			targetRegion := cloneRegionWithReplacePeerStores(region, group.LeaderStoreID, group.VoterStoreIDs...)
 			if targetRegion == nil || !c.isRegionPlacementRuleSatisfiedWithBestLocation(targetRegion, false /* isRealRegion */) {
 				c.affinityManager.ExpireAffinityGroup(group.ID)
+				group = c.affinityManager.GetAffinityGroupState(group.ID)
 				needRefetch = true
 			}
 		}

--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -85,6 +85,10 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		affinityCheckerPausedCounter.Inc()
 		return nil
 	}
+	if !c.cluster.GetSharedConfig().IsPlacementRulesEnabled() {
+		affinityCheckerPlacementRulesDisabledCounter.Inc()
+		return nil
+	}
 
 	// Check region state
 	if region.GetLeader() == nil {
@@ -495,11 +499,6 @@ func (c *AffinityChecker) RecordOpSuccess(op *operator.Operator) {
 }
 
 func (c *AffinityChecker) isRegionPlacementRuleSatisfiedWithBestLocation(region *core.RegionInfo, isRealRegion bool) bool {
-	// Return false if Placement Rules are not enabled.
-	if c.cluster.GetSharedConfig().IsPlacementRulesEnabled() {
-		return false
-	}
-
 	// Get the RegionFit for the given Region. If the Region is not a real existing Region but a virtual target state,
 	// use FitRegionWithoutCache to bypass the cache.
 	var fit *placement.RegionFit

--- a/pkg/schedule/checker/affinity_checker.go
+++ b/pkg/schedule/checker/affinity_checker.go
@@ -100,15 +100,21 @@ func (c *AffinityChecker) Check(region *core.RegionInfo) []*operator.Operator {
 		affinityCheckerUnhealthyRegionCounter.Inc()
 		return nil
 	}
-	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(region, true /* isExistingRegion */) {
-		affinityCheckerAbnormalReplicaCounter.Inc()
+
+	if !c.hasAffinityGroups() {
 		return nil
 	}
 
-	// Get the affinity group for this region
+	// Check the affinity group before the heavier best-location gate. Most regions
+	// are not affinity regions.
 	group, isAffinity := c.affinityManager.GetAndCacheRegionAffinityGroupState(region)
 	if group == nil {
-		// Region doesn't belong to any affinity group
+		// Region doesn't belong to any affinity group.
+		return nil
+	}
+
+	if !c.isRegionPlacementRuleSatisfiedWithBestLocation(region, true /* isExistingRegion */) {
+		affinityCheckerAbnormalReplicaCounter.Inc()
 		return nil
 	}
 

--- a/pkg/schedule/checker/affinity_checker_test.go
+++ b/pkg/schedule/checker/affinity_checker_test.go
@@ -2052,9 +2052,9 @@ func TestAffinityCheckerExpireGroupWhenPlacementRuleMismatch(t *testing.T) {
 
 	groupState := affinityManager.GetAffinityGroupState("test_group")
 	re.NotNil(groupState)
-	re.False(groupState.AffinitySchedulingAllowed, "Group should be expired when peer count violates placement rules")
-	re.Equal(affinity.PhasePending, groupState.Phase)
-	re.Equal([]uint64{1, 2, 3, 4}, groupState.VoterStoreIDs, "Peers remain as configured until a valid available region is observed")
+	re.True(groupState.AffinitySchedulingAllowed)
+	re.Equal(affinity.PhaseStable, groupState.Phase)
+	re.Equal([]uint64{1, 2, 3}, groupState.VoterStoreIDs)
 }
 
 // TestAffinityCheckerTargetStoreEvictLeader tests that operator is not created when target store has evict-leader.

--- a/pkg/schedule/checker/affinity_checker_test.go
+++ b/pkg/schedule/checker/affinity_checker_test.go
@@ -2199,6 +2199,45 @@ func TestAffinityCheckerRegionHasBetterLocation(t *testing.T) {
 	re.Nil(ops)
 }
 
+func TestAffinityBestLocationFilteredByTemporarySourceState(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opt := newAffinityTestOptions()
+	opt.SetLocationLabels([]string{"region", "zone", "host"})
+	tc := mockcluster.NewCluster(ctx, opt)
+
+	tc.AddLabelsStore(1, 0, map[string]string{"region": "r1", "zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"region": "r1", "zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(3, 0, map[string]string{"region": "r1", "zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(4, 0, map[string]string{"region": "r1", "zone": "z2", "host": "h1"})
+	tc.AddLabelsStore(5, 0, map[string]string{"region": "r1", "zone": "z3", "host": "h1"})
+	tc.AddLabelsStore(6, 0, map[string]string{"region": "r1", "zone": "z3", "host": "h2"})
+
+	checker := newTestAffinityChecker(ctx, tc, opt)
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	region := tc.GetRegion(1)
+
+	fit := checker.ruleManager.FitRegion(tc, region)
+	re.NotNil(fit)
+	re.True(fit.IsSatisfied())
+	re.NotEmpty(fit.RuleFits)
+	strategy := checker.strategy(region, fit.RuleFits[0].Rule, false)
+	oldStoreID, newStoreID, filterByTempState := strategy.getBetterLocation(tc, region, fit, fit.RuleFits[0])
+	re.NotZero(oldStoreID)
+	re.NotZero(newStoreID)
+	re.False(filterByTempState)
+
+	tc.SetStoreBusy(1, true)
+	tc.SetStoreBusy(3, true)
+	oldStoreID, newStoreID, filterByTempState = strategy.getBetterLocation(tc, region, fit, fit.RuleFits[0])
+	re.Zero(oldStoreID)
+	re.Zero(newStoreID)
+	re.True(filterByTempState)
+	re.False(checker.isRegionPlacementRuleSatisfiedWithBestLocation(region, true))
+}
+
 // TestAffinityStrictCheckDivergesFromIsRegionReplicated documents the intended
 // semantic split: affinity scheduling may reject a region that is already
 // placement-rule replicated when a strictly better location still exists.

--- a/pkg/schedule/checker/affinity_checker_test.go
+++ b/pkg/schedule/checker/affinity_checker_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule/affinity"
 	scheconfig "github.com/tikv/pd/pkg/schedule/config"
 	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
@@ -2196,6 +2197,34 @@ func TestAffinityCheckerRegionHasBetterLocation(t *testing.T) {
 	re.NoError(tc.GetRuleManager().SetRule(rule))
 	ops = checker.Check(region)
 	re.Nil(ops)
+}
+
+// TestAffinityStrictCheckDivergesFromIsRegionReplicated documents the intended
+// semantic split: affinity scheduling may reject a region that is already
+// placement-rule replicated when a strictly better location still exists.
+func TestAffinityStrictCheckDivergesFromIsRegionReplicated(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opt := mockconfig.NewTestOptions()
+	opt.SetLocationLabels([]string{"zone", "host"})
+	tc := mockcluster.NewCluster(ctx, opt)
+	tc.SetEnablePlacementRules(true)
+	tc.SetMaxReplicas(3)
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h2"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h3"})
+
+	checker := newTestAffinityChecker(ctx, tc, opt)
+
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	region := tc.GetRegion(1)
+
+	re.True(filter.IsRegionReplicated(tc, region))
+	re.False(checker.isRegionPlacementRuleSatisfiedWithBestLocation(region, true))
 }
 
 // TestAffinityMergeCheckPeerStoreMismatch tests that merge is rejected when peer stores don't match.

--- a/pkg/schedule/checker/affinity_checker_test.go
+++ b/pkg/schedule/checker/affinity_checker_test.go
@@ -2015,9 +2015,9 @@ func TestAffinityCheckerGroupScheduleDisallowed(t *testing.T) {
 	re.Nil(ops, "Affinity scheduling should be blocked when group is not allowed")
 }
 
-// TestAffinityCheckerExpireGroupWhenPlacementRuleMismatch verifies that when the affinity group peers
-// don't satisfy placement rules, the group will be expired and scheduling is disabled.
-func TestAffinityCheckerExpireGroupWhenPlacementRuleMismatch(t *testing.T) {
+// TestAffinityCheckerNormalizeGroupWhenPlacementRuleMismatch verifies that when the affinity group peers
+// don't satisfy placement rules, the checker keeps the group schedulable by normalizing it to the valid Region peers.
+func TestAffinityCheckerNormalizeGroupWhenPlacementRuleMismatch(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2038,8 +2038,8 @@ func TestAffinityCheckerExpireGroupWhenPlacementRuleMismatch(t *testing.T) {
 	affinityManager := tc.GetAffinityManager()
 	checker := newTestAffinityChecker(ctx, tc, opt)
 
-	// Affinity group expects 4 voters while placement rules (and the region) only allow 3,
-	// so isGroupReplicated should be false and the group should be expired/refreshed.
+	// Affinity group expects 4 voters while placement rules (and the region) only allow 3.
+	// The checker should normalize the group to the valid Region peers and keep it schedulable.
 	group := &affinity.Group{
 		ID:            "test_group",
 		LeaderStoreID: 1,
@@ -2131,7 +2131,7 @@ func TestAffinityCheckerRegionHasBetterLocation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	opt := mockconfig.NewTestOptions()
+	opt := newAffinityTestOptions()
 	opt.SetLocationLabels([]string{"region", "zone", "host"})
 	tc := mockcluster.NewCluster(ctx, opt)
 

--- a/pkg/schedule/checker/affinity_checker_test.go
+++ b/pkg/schedule/checker/affinity_checker_test.go
@@ -2163,7 +2163,7 @@ func TestAffinityCheckerRegionHasBetterLocation(t *testing.T) {
 	re.NotNil(groupState)
 	re.Equal([]uint64{1, 2, 3}, groupState.VoterStoreIDs)
 
-	//Because the Group’s currently specified Peers are not at the best location,
+	// Because the Group’s currently specified Peers are not at the best location,
 	// they are cleared and replaced with the source Region’s Peers.
 	// In this case, no scheduling is generated, but the Peers are updated.
 	tc.AddLeaderRegion(200, 1, 4, 5)

--- a/pkg/schedule/checker/affinity_checker_test.go
+++ b/pkg/schedule/checker/affinity_checker_test.go
@@ -2124,6 +2124,80 @@ func TestAffinityCheckerTargetStoreRejectLeader(t *testing.T) {
 	re.Nil(ops, "Should not create operator when target store has reject-leader label")
 }
 
+// TestAffinityCheckerRegionHasBetterLocation tests how the checker handles a Region where isRegionPlacementRuleSatisfiedWithBestLocation returns false.
+func TestAffinityCheckerRegionHasBetterLocation(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opt := mockconfig.NewTestOptions()
+	opt.SetLocationLabels([]string{"region", "zone", "host"})
+	tc := mockcluster.NewCluster(ctx, opt)
+
+	tc.AddLabelsStore(1, 0, map[string]string{"region": "r1", "zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"region": "r1", "zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(3, 0, map[string]string{"region": "r1", "zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(4, 0, map[string]string{"region": "r1", "zone": "z2", "host": "h1"})
+	tc.AddLabelsStore(5, 0, map[string]string{"region": "r1", "zone": "z3", "host": "h1"})
+	tc.AddLabelsStore(6, 0, map[string]string{"region": "r1", "zone": "z3", "host": "h2"})
+
+	affinityManager := tc.GetAffinityManager()
+	checker := newTestAffinityChecker(ctx, tc, opt)
+
+	// Create affinity group without best location
+	group := &affinity.Group{
+		ID:            "test_group",
+		LeaderStoreID: 2,
+		VoterStoreIDs: []uint64{1, 2, 3},
+	}
+	err := createAffinityGroupForTest(affinityManager, group, []byte(""), []byte(""))
+	re.NoError(err)
+
+	// No scheduling is generated because the source Region is not at the best location.
+	tc.AddLeaderRegion(100, 1, 3, 4)
+	region := tc.GetRegion(100)
+	re.False(checker.isRegionPlacementRuleSatisfiedWithBestLocation(region, true))
+	ops := checker.Check(region)
+	re.Nil(ops)
+	groupState := affinityManager.GetAffinityGroupState("test_group")
+	re.NotNil(groupState)
+	re.Equal([]uint64{1, 2, 3}, groupState.VoterStoreIDs)
+
+	//Because the Group’s currently specified Peers are not at the best location,
+	// they are cleared and replaced with the source Region’s Peers.
+	// In this case, no scheduling is generated, but the Peers are updated.
+	tc.AddLeaderRegion(200, 1, 4, 5)
+	region = tc.GetRegion(200)
+	re.True(checker.isRegionPlacementRuleSatisfiedWithBestLocation(region, false))
+	ops = checker.Check(region)
+	re.Nil(ops)
+	groupState = affinityManager.GetAffinityGroupState("test_group")
+	re.NotNil(groupState)
+	re.Equal([]uint64{1, 4, 5}, groupState.VoterStoreIDs)
+
+	// When both the source Region and the target Region are at the best location, scheduling is generated.
+	tc.AddLeaderRegion(300, 1, 4, 6)
+	region = tc.GetRegion(300)
+	re.True(checker.isRegionPlacementRuleSatisfiedWithBestLocation(region, true))
+	ops = checker.Check(region)
+	re.NotNil(ops)
+	re.Len(ops, 1)
+
+	// No scheduling is generated when Placement Rules are disabled.
+	tc.SetEnablePlacementRules(false)
+	ops = checker.Check(region)
+	re.Nil(ops)
+
+	// If an IsolationLevel is configured, no scheduling is generated when the required isolation level cannot be met.
+	tc.SetEnablePlacementRules(true)
+	rule := tc.GetRuleManager().GetRule(placement.DefaultGroupID, placement.DefaultRuleID)
+	re.NotNil(rule)
+	rule.IsolationLevel = "region"
+	re.NoError(tc.GetRuleManager().SetRule(rule))
+	ops = checker.Check(region)
+	re.Nil(ops)
+}
+
 // TestAffinityMergeCheckPeerStoreMismatch tests that merge is rejected when peer stores don't match.
 func TestAffinityMergeCheckPeerStoreMismatch(t *testing.T) {
 	re := require.New(t)

--- a/pkg/schedule/checker/metrics.go
+++ b/pkg/schedule/checker/metrics.go
@@ -293,6 +293,7 @@ var (
 
 	affinityCheckerCounter                        = checkerCounter.WithLabelValues(affinityChecker, "check")
 	affinityCheckerPausedCounter                  = checkerCounter.WithLabelValues(affinityChecker, "paused")
+	affinityCheckerPlacementRulesDisabledCounter  = checkerCounter.WithLabelValues(affinityChecker, "placement-rules-disabled")
 	affinityCheckerRegionNoLeaderCounter          = checkerCounter.WithLabelValues(affinityChecker, "region-no-leader")
 	affinityCheckerGroupSchedulingDisabledCounter = checkerCounter.WithLabelValues(affinityChecker, "group-scheduling-disabled")
 	affinityCheckerNewOpCounter                   = checkerCounter.WithLabelValues(affinityChecker, "new-operator")

--- a/pkg/schedule/checker/replica_checker.go
+++ b/pkg/schedule/checker/replica_checker.go
@@ -191,8 +191,8 @@ func (c *ReplicaChecker) checkRemoveExtraReplica(region *core.RegionInfo) *opera
 	}
 	log.Debug("region has more than max replicas", zap.Uint64("region-id", region.GetID()), zap.Int("peers", len(region.GetPeers())))
 	regionStores := c.cluster.GetRegionStores(region)
-	old := c.strategy(region).SelectStoreToRemove(regionStores)
-	if old == 0 {
+	old, filterByTempState := c.strategy(region).SelectStoreToRemove(regionStores)
+	if old == 0 || filterByTempState {
 		replicaCheckerNoWorstPeerCounter.Inc()
 		c.pendingProcessedRegions.Put(region.GetID(), nil)
 		return nil
@@ -212,8 +212,8 @@ func (c *ReplicaChecker) checkLocationReplacement(region *core.RegionInfo) *oper
 
 	strategy := c.strategy(region)
 	regionStores := c.cluster.GetRegionStores(region)
-	oldStore := strategy.SelectStoreToRemove(regionStores)
-	if oldStore == 0 {
+	oldStore, filterByTempState := strategy.SelectStoreToRemove(regionStores)
+	if oldStore == 0 || filterByTempState {
 		replicaCheckerAllRightCounter.Inc()
 		return nil
 	}

--- a/pkg/schedule/checker/replica_checker.go
+++ b/pkg/schedule/checker/replica_checker.go
@@ -191,8 +191,8 @@ func (c *ReplicaChecker) checkRemoveExtraReplica(region *core.RegionInfo) *opera
 	}
 	log.Debug("region has more than max replicas", zap.Uint64("region-id", region.GetID()), zap.Int("peers", len(region.GetPeers())))
 	regionStores := c.cluster.GetRegionStores(region)
-	old, filterByTempState := c.strategy(region).SelectStoreToRemove(regionStores)
-	if old == 0 || filterByTempState {
+	old := c.strategy(region).SelectStoreToRemove(regionStores)
+	if old == 0 {
 		replicaCheckerNoWorstPeerCounter.Inc()
 		c.pendingProcessedRegions.Put(region.GetID(), nil)
 		return nil
@@ -212,8 +212,8 @@ func (c *ReplicaChecker) checkLocationReplacement(region *core.RegionInfo) *oper
 
 	strategy := c.strategy(region)
 	regionStores := c.cluster.GetRegionStores(region)
-	oldStore, filterByTempState := strategy.SelectStoreToRemove(regionStores)
-	if oldStore == 0 || filterByTempState {
+	oldStore := strategy.SelectStoreToRemove(regionStores)
+	if oldStore == 0 {
 		replicaCheckerAllRightCounter.Inc()
 		return nil
 	}

--- a/pkg/schedule/checker/replica_strategy.go
+++ b/pkg/schedule/checker/replica_strategy.go
@@ -194,7 +194,7 @@ func isWitnessEnabled(cluster sche.CheckerCluster) bool {
 }
 
 func getRuleFitStores(cluster sche.SharedCluster, rf *placement.RuleFit) []*core.StoreInfo {
-	var stores []*core.StoreInfo
+	stores := make([]*core.StoreInfo, 0, len(rf.Peers))
 	for _, p := range rf.Peers {
 		if s := cluster.GetStore(p.GetStoreId()); s != nil {
 			stores = append(stores, s)

--- a/pkg/schedule/checker/replica_strategy.go
+++ b/pkg/schedule/checker/replica_strategy.go
@@ -141,26 +141,34 @@ func swapStoreToFirst(stores []*core.StoreInfo, id uint64) {
 }
 
 // SelectStoreToRemove returns the best option to remove from the region.
-func (s *ReplicaStrategy) SelectStoreToRemove(coLocationStores []*core.StoreInfo) uint64 {
+// The second return value is true when the returned source is filtered by
+// temporary store state.
+func (s *ReplicaStrategy) SelectStoreToRemove(coLocationStores []*core.StoreInfo) (uint64, bool) {
 	isolationComparer := filter.IsolationComparer(s.locationLabels, coLocationStores)
 	level := constant.High
 	if s.fastFailover {
 		level = constant.Urgent
 	}
-	source := filter.NewCandidates(coLocationStores).
-		FilterSource(s.cluster.GetCheckerConfig(), nil, nil, &filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, OperatorLevel: level}).
-		KeepTheTopStores(isolationComparer, true).
-		PickTheTopStore(filter.RegionScoreComparer(s.cluster.GetCheckerConfig()), false)
-	if source == nil {
+	sourceCandidate := filter.NewCandidates(coLocationStores).
+		FilterSource(s.cluster.GetCheckerConfig(), nil, nil, &filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, AllowTemporaryStates: true, OperatorLevel: level}).
+		KeepTheTopStores(isolationComparer, true)
+	if sourceCandidate.Len() == 0 {
 		log.Debug("no removable store", zap.Uint64("region-id", s.region.GetID()))
-		return 0
+		return 0, false
 	}
-	return source.GetID()
+	source := filter.NewCandidates(sourceCandidate.Stores).
+		FilterSource(s.cluster.GetCheckerConfig(), nil, nil, &filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, OperatorLevel: level}).
+		PickTheTopStore(filter.RegionScoreComparer(s.cluster.GetCheckerConfig()), false)
+	if source != nil {
+		return source.GetID(), false
+	}
+	source = sourceCandidate.PickTheTopStore(filter.RegionScoreComparer(s.cluster.GetCheckerConfig()), false)
+	return source.GetID(), true
 }
 
 func (s *ReplicaStrategy) getBetterLocation(cluster sche.SharedCluster, region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (oldStoreID, newStoreID uint64, filterByTempState bool) {
 	ruleStores := getRuleFitStores(cluster, rf)
-	oldStoreID = s.SelectStoreToRemove(ruleStores)
+	oldStoreID, sourceFilterByTempState := s.SelectStoreToRemove(ruleStores)
 	if oldStoreID == 0 {
 		return 0, 0, false
 	}
@@ -185,6 +193,12 @@ func (s *ReplicaStrategy) getBetterLocation(cluster sche.SharedCluster, region *
 		}
 	}
 	newStoreID, filterByTempState = s.SelectStoreToImprove(coLocationStores, oldStoreID)
+	if sourceFilterByTempState {
+		if newStoreID != 0 || filterByTempState {
+			return 0, 0, true
+		}
+		return 0, 0, false
+	}
 	return
 }
 

--- a/pkg/schedule/checker/replica_strategy.go
+++ b/pkg/schedule/checker/replica_strategy.go
@@ -141,9 +141,24 @@ func swapStoreToFirst(stores []*core.StoreInfo, id uint64) {
 }
 
 // SelectStoreToRemove returns the best option to remove from the region.
-// The second return value is true when the returned source is filtered by
-// temporary store state.
-func (s *ReplicaStrategy) SelectStoreToRemove(coLocationStores []*core.StoreInfo) (uint64, bool) {
+func (s *ReplicaStrategy) SelectStoreToRemove(coLocationStores []*core.StoreInfo) uint64 {
+	isolationComparer := filter.IsolationComparer(s.locationLabels, coLocationStores)
+	level := constant.High
+	if s.fastFailover {
+		level = constant.Urgent
+	}
+	source := filter.NewCandidates(coLocationStores).
+		FilterSource(s.cluster.GetCheckerConfig(), nil, nil, &filter.StoreStateFilter{ActionScope: s.checkerName, MoveRegion: true, OperatorLevel: level}).
+		KeepTheTopStores(isolationComparer, true).
+		PickTheTopStore(filter.RegionScoreComparer(s.cluster.GetCheckerConfig()), false)
+	if source == nil {
+		log.Debug("no removable store", zap.Uint64("region-id", s.region.GetID()))
+		return 0
+	}
+	return source.GetID()
+}
+
+func (s *ReplicaStrategy) selectStoreToRemoveWithTempState(coLocationStores []*core.StoreInfo) (uint64, bool) {
 	isolationComparer := filter.IsolationComparer(s.locationLabels, coLocationStores)
 	level := constant.High
 	if s.fastFailover {
@@ -168,7 +183,7 @@ func (s *ReplicaStrategy) SelectStoreToRemove(coLocationStores []*core.StoreInfo
 
 func (s *ReplicaStrategy) getBetterLocation(cluster sche.SharedCluster, region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (oldStoreID, newStoreID uint64, filterByTempState bool) {
 	ruleStores := getRuleFitStores(cluster, rf)
-	oldStoreID, sourceFilterByTempState := s.SelectStoreToRemove(ruleStores)
+	oldStoreID, sourceFilterByTempState := s.selectStoreToRemoveWithTempState(ruleStores)
 	if oldStoreID == 0 {
 		return 0, 0, false
 	}

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -604,16 +604,6 @@ func (c *RuleChecker) strategy(region *core.RegionInfo, rule *placement.Rule, fa
 	}
 }
 
-func (c *RuleChecker) getRuleFitStores(rf *placement.RuleFit) []*core.StoreInfo {
-	var stores []*core.StoreInfo
-	for _, p := range rf.Peers {
-		if s := c.cluster.GetStore(p.GetStoreId()); s != nil {
-			stores = append(stores, s)
-		}
-	}
-	return stores
-}
-
 func (c *RuleChecker) handleFilterState(region *core.RegionInfo, filterByTempState bool) {
 	if filterByTempState {
 		c.pendingProcessedRegions.Put(region.GetID(), nil)

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -35,7 +35,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/utils/syncutil"
-	"github.com/tikv/pd/pkg/versioninfo"
 )
 
 const maxPendingListLen = 100000
@@ -146,11 +145,6 @@ func (c *RuleChecker) RecordRegionPromoteToNonWitness(regionID uint64) {
 	c.switchWitnessCache.PutWithTTL(regionID, nil, c.cluster.GetCheckerConfig().GetSwitchWitnessInterval())
 }
 
-func (c *RuleChecker) isWitnessEnabled() bool {
-	return versioninfo.IsFeatureSupported(c.cluster.GetCheckerConfig().GetClusterVersion(), versioninfo.SwitchWitness) &&
-		c.cluster.GetCheckerConfig().IsWitnessAllowed()
-}
-
 func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (*operator.Operator, error) {
 	// make up peers.
 	if len(rf.Peers) < rf.Rule.Count {
@@ -164,7 +158,7 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 				return c.replaceUnexpectedRulePeer(region, rf, fit, peer, downStatus)
 			}
 			// When witness placement rule is enabled, promotes the witness to voter when region has down voter.
-			if c.isWitnessEnabled() && core.IsVoter(peer) {
+			if isWitnessEnabled(c.cluster) && core.IsVoter(peer) {
 				if witness, ok := c.hasAvailableWitness(region, peer); ok {
 					ruleCheckerPromoteWitnessCounter.Inc()
 					return operator.CreateNonWitnessPeerOperator("promote-witness-for-down", c.cluster, region, witness)
@@ -191,8 +185,8 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 
 func (c *RuleChecker) addRulePeer(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (*operator.Operator, error) {
 	ruleCheckerAddRulePeerCounter.Inc()
-	ruleStores := c.getRuleFitStores(rf)
-	isWitness := rf.Rule.IsWitness && c.isWitnessEnabled()
+	ruleStores := getRuleFitStores(c.cluster, rf)
+	isWitness := rf.Rule.IsWitness && isWitnessEnabled(c.cluster)
 	// If the peer to be added is a witness, since no snapshot is needed, we also reuse the fast failover logic.
 	store, filterByTempState := c.strategy(region, rf.Rule, isWitness).SelectStoreToAdd(ruleStores)
 	if store == 0 {
@@ -232,7 +226,7 @@ func (c *RuleChecker) addRulePeer(region *core.RegionInfo, fit *placement.Region
 func (c *RuleChecker) replaceUnexpectedRulePeer(region *core.RegionInfo, rf *placement.RuleFit, fit *placement.RegionFit, peer *metapb.Peer, status string) (*operator.Operator, error) {
 	var fastFailover bool
 	// If the store to which the original peer belongs is TiFlash, the new peer cannot be set to witness, nor can it perform fast failover
-	if c.isWitnessEnabled() && c.cluster.GetStore(peer.StoreId).IsTiKV() {
+	if isWitnessEnabled(c.cluster) && c.cluster.GetStore(peer.StoreId).IsTiKV() {
 		// No matter whether witness placement rule is enabled or disabled, when peer's downtime
 		// exceeds the threshold(30min), quickly add a witness to speed up failover, then promoted
 		// to non-witness gradually to improve availability.
@@ -244,7 +238,7 @@ func (c *RuleChecker) replaceUnexpectedRulePeer(region *core.RegionInfo, rf *pla
 	} else {
 		fastFailover = false
 	}
-	ruleStores := c.getRuleFitStores(rf)
+	ruleStores := getRuleFitStores(c.cluster, rf)
 	store, filterByTempState := c.strategy(region, rf.Rule, fastFailover).SelectStoreToFix(ruleStores, peer.GetStoreId())
 	if store == 0 {
 		ruleCheckerNoStoreReplaceCounter.Inc()
@@ -331,7 +325,7 @@ func (c *RuleChecker) fixLooseMatchPeer(region *core.RegionInfo, fit *placement.
 	if region.GetLeader().GetId() == peer.GetId() && rf.Rule.IsWitness {
 		return nil, errs.ErrPeerCannotBeWitness
 	}
-	if !core.IsWitness(peer) && rf.Rule.IsWitness && c.isWitnessEnabled() {
+	if !core.IsWitness(peer) && rf.Rule.IsWitness && isWitnessEnabled(c.cluster) {
 		c.switchWitnessCache.UpdateTTL(c.cluster.GetCheckerConfig().GetSwitchWitnessInterval())
 		if c.switchWitnessCache.Exists(region.GetID()) {
 			ruleCheckerRecentlyPromoteToNonWitnessCounter.Inc()
@@ -347,7 +341,7 @@ func (c *RuleChecker) fixLooseMatchPeer(region *core.RegionInfo, fit *placement.
 			ruleCheckerSetVoterWitnessCounter.Inc()
 		}
 		return operator.CreateWitnessPeerOperator("fix-witness-peer", c.cluster, region, peer)
-	} else if core.IsWitness(peer) && (!rf.Rule.IsWitness || !c.isWitnessEnabled()) {
+	} else if core.IsWitness(peer) && (!rf.Rule.IsWitness || !isWitnessEnabled(c.cluster)) {
 		if core.IsLearner(peer) {
 			ruleCheckerSetLearnerNonWitnessCounter.Inc()
 		} else {
@@ -384,43 +378,17 @@ func (c *RuleChecker) fixBetterLocation(region *core.RegionInfo, fit *placement.
 		return nil, nil
 	}
 
-	isWitness := rf.Rule.IsWitness && c.isWitnessEnabled()
+	isWitness := rf.Rule.IsWitness && isWitnessEnabled(c.cluster)
 	// If the peer to be moved is a witness, since no snapshot is needed, we also reuse the fast failover logic.
 	strategy := c.strategy(region, rf.Rule, isWitness)
-	ruleStores := c.getRuleFitStores(rf)
-	oldStoreID := strategy.SelectStoreToRemove(ruleStores)
-	if oldStoreID == 0 {
-		return nil, nil
-	}
-	oldStore := c.cluster.GetStore(oldStoreID)
-	if oldStore == nil {
-		return nil, nil
-	}
-	var coLocationStores []*core.StoreInfo
-	regionStores := c.cluster.GetRegionStores(region)
-	for _, s := range regionStores {
-		if s.GetLabelValue(core.EngineKey) != oldStore.GetLabelValue(core.EngineKey) {
-			continue
-		}
-		for _, r := range fit.GetRules() {
-			if r.Role != rf.Rule.Role {
-				continue
-			}
-			if placement.MatchLabelConstraints(s, r.LabelConstraints) {
-				coLocationStores = append(coLocationStores, s)
-				break
-			}
-		}
-	}
-
-	newStore, filterByTempState := strategy.SelectStoreToImprove(coLocationStores, oldStoreID)
-	if newStore == 0 {
+	oldStoreID, newStoreID, filterByTempState := strategy.getBetterLocation(c.cluster, region, fit, rf)
+	if newStoreID == 0 {
 		log.Debug("no replacement store", zap.Uint64("region-id", region.GetID()))
 		c.handleFilterState(region, filterByTempState)
 		return nil, nil
 	}
 	ruleCheckerMoveToBetterLocationCounter.Inc()
-	newPeer := &metapb.Peer{StoreId: newStore, Role: rf.Rule.Role.MetaPeerRole(), IsWitness: isWitness}
+	newPeer := &metapb.Peer{StoreId: newStoreID, Role: rf.Rule.Role.MetaPeerRole(), IsWitness: isWitness}
 	return operator.CreateMovePeerOperator("move-to-better-location", c.cluster, region, operator.OpReplica, oldStoreID, newPeer)
 }
 

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -225,8 +225,13 @@ func (c *RuleChecker) addRulePeer(region *core.RegionInfo, fit *placement.Region
 // The peer's store may in Offline or Down, need to be replace.
 func (c *RuleChecker) replaceUnexpectedRulePeer(region *core.RegionInfo, rf *placement.RuleFit, fit *placement.RegionFit, peer *metapb.Peer, status string) (*operator.Operator, error) {
 	var fastFailover bool
+	store := c.cluster.GetStore(peer.StoreId)
+	if store == nil {
+		log.Warn("lost the store, maybe you are recovering the PD cluster", zap.Uint64("store-id", peer.StoreId))
+		return nil, errs.ErrNoStoreToReplace
+	}
 	// If the store to which the original peer belongs is TiFlash, the new peer cannot be set to witness, nor can it perform fast failover
-	if isWitnessEnabled(c.cluster) && c.cluster.GetStore(peer.StoreId).IsTiKV() {
+	if isWitnessEnabled(c.cluster) && store.IsTiKV() {
 		// No matter whether witness placement rule is enabled or disabled, when peer's downtime
 		// exceeds the threshold(30min), quickly add a witness to speed up failover, then promoted
 		// to non-witness gradually to improve availability.
@@ -239,13 +244,13 @@ func (c *RuleChecker) replaceUnexpectedRulePeer(region *core.RegionInfo, rf *pla
 		fastFailover = false
 	}
 	ruleStores := getRuleFitStores(c.cluster, rf)
-	store, filterByTempState := c.strategy(region, rf.Rule, fastFailover).SelectStoreToFix(ruleStores, peer.GetStoreId())
-	if store == 0 {
+	storeID, filterByTempState := c.strategy(region, rf.Rule, fastFailover).SelectStoreToFix(ruleStores, peer.GetStoreId())
+	if storeID == 0 {
 		ruleCheckerNoStoreReplaceCounter.Inc()
 		c.handleFilterState(region, filterByTempState)
 		return nil, errs.ErrNoStoreToReplace
 	}
-	newPeer := &metapb.Peer{StoreId: store, Role: rf.Rule.Role.MetaPeerRole(), IsWitness: fastFailover}
+	newPeer := &metapb.Peer{StoreId: storeID, Role: rf.Rule.Role.MetaPeerRole(), IsWitness: fastFailover}
 	//  pick the smallest leader store to avoid the Offline store be snapshot generator bottleneck.
 	var newLeader *metapb.Peer
 	if region.GetLeader().GetId() == peer.GetId() {

--- a/pkg/schedule/placement/fit.go
+++ b/pkg/schedule/placement/fit.go
@@ -139,7 +139,7 @@ type RuleFit struct {
 	IsolationScore float64 `json:"isolation-score"`
 	WitnessScore   int     `json:"witness-score"`
 	// Stores is the stores that the peers are placed in.
-	Stores []*core.StoreInfo
+	Stores []*core.StoreInfo `json:"-"`
 }
 
 // IsSatisfied returns if the rule is properly satisfied.

--- a/pkg/schedule/placement/fit.go
+++ b/pkg/schedule/placement/fit.go
@@ -64,7 +64,7 @@ func (f *RegionFit) Replace(srcStoreID uint64, dstStore *core.StoreInfo) bool {
 		return false
 	}
 
-	score := isolationStoreScore(srcStoreID, dstStore, fit.stores, fit.Rule.LocationLabels)
+	score := isolationStoreScore(srcStoreID, dstStore, fit.Stores, fit.Rule.LocationLabels)
 	// restore the source store.
 	return fit.IsolationScore <= score
 }
@@ -138,8 +138,8 @@ type RuleFit struct {
 	// isolated. A larger value is better.
 	IsolationScore float64 `json:"isolation-score"`
 	WitnessScore   int     `json:"witness-score"`
-	// stores is the stores that the peers are placed in.
-	stores []*core.StoreInfo
+	// Stores is the stores that the peers are placed in.
+	Stores []*core.StoreInfo
 }
 
 // IsSatisfied returns if the rule is properly satisfied.
@@ -371,7 +371,7 @@ func newRuleFit(rule *Rule, peers []*fitPeer, supportWitness bool) *RuleFit {
 	rf := &RuleFit{Rule: rule, IsolationScore: isolationScore(peers, rule.LocationLabels), WitnessScore: witnessScore(peers, supportWitness && rule.IsWitness)}
 	for _, p := range peers {
 		rf.Peers = append(rf.Peers, p.Peer)
-		rf.stores = append(rf.stores, p.store)
+		rf.Stores = append(rf.Stores, p.store)
 		if !p.matchRoleStrict(rule.Role) ||
 			(supportWitness && (p.IsWitness != rule.IsWitness)) ||
 			(!supportWitness && p.IsWitness) {

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -428,7 +428,7 @@ func (m *RuleManager) IsRegionFitCached(storeSet StoreSet, region *core.RegionIn
 	return isCached
 }
 
-// FitRegionWithoutCache fits a region to the rules it matches. This function does not use or populate the cache,
+// FitRegionWithoutCache fits a region to the rules it matches. This function does not use or save the cache,
 // and the Region being fitted is usually not a real Region.
 func (m *RuleManager) FitRegionWithoutCache(storeSet StoreSet, region *core.RegionInfo) (fit *RegionFit) {
 	regionStores := getStoresByRegion(storeSet, region)

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -428,6 +428,17 @@ func (m *RuleManager) IsRegionFitCached(storeSet StoreSet, region *core.RegionIn
 	return isCached
 }
 
+// FitRegionWithoutCache fits a region to the rules it matches. This function does not use or populate the cache,
+// and the Region being fitted is usually not a real Region.
+func (m *RuleManager) FitRegionWithoutCache(storeSet StoreSet, region *core.RegionInfo) (fit *RegionFit) {
+	regionStores := getStoresByRegion(storeSet, region)
+	rules := m.GetRulesForApplyRegion(region)
+	fit = fitRegion(regionStores, region, rules, m.conf.IsWitnessAllowed())
+	fit.regionStores = regionStores
+	fit.rules = rules
+	return fit
+}
+
 // FitRegion fits a region to the rules it matches.
 func (m *RuleManager) FitRegion(storeSet StoreSet, region *core.RegionInfo) (fit *RegionFit) {
 	regionStores := getStoresByRegion(storeSet, region)

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -277,9 +277,8 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 	re.Equal(0, level)
 
 	regionID = 1
-	isolationResSet = []string{"rack", "none", "zone", "rack", "none", "rack", "none"}
-	counter = map[string]int{"none": 3, "host": 0, "rack": 3, "zone": 1}
 	locationLabels = []string{"zone", "rack"}
+	isolationResSet = []string{"rack", "none", "zone", "rack", "none", "rack", "none"}
 	levelResSet = []int{1, -1, 0, 1, -1, 1, -1}
 	satisfiedResSet = []map[string]bool{
 		{"zone": false, "rack": true, "bar": false, "none": true, "": true},
@@ -290,6 +289,7 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 		{"zone": false, "rack": true, "bar": false, "none": true, "": true},
 		{"zone": false, "rack": false, "bar": false, "none": true, "": true},
 	}
+	counter = map[string]int{"none": 3, "host": 0, "rack": 3, "zone": 1}
 
 	for i, labels := range labelsSet {
 		f(locationLabels, labels, isolationResSet[i], levelResSet[i], satisfiedResSet[i])

--- a/pkg/statistics/region_collection_test.go
+++ b/pkg/statistics/region_collection_test.go
@@ -238,7 +238,7 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 			stores = append(stores, s)
 		}
 		region := core.NewRegionInfo(&metapb.Region{Id: uint64(regionID)}, nil)
-		label := GetRegionLabelIsolation(stores, locationLabels)
+		label, _ := GetRegionLabelIsolation(stores, locationLabels)
 		labelLevelStats.Observe(region, stores, locationLabels)
 		re.Equal(res, label)
 		regionID++
@@ -251,13 +251,16 @@ func TestRegionLabelIsolationLevel(t *testing.T) {
 		re.Equal(res, labelLevelStats.labelCounter[i])
 	}
 
-	label := GetRegionLabelIsolation(nil, locationLabels)
+	label, level := GetRegionLabelIsolation(nil, locationLabels)
 	re.Equal(nonIsolation, label)
-	label = GetRegionLabelIsolation(nil, nil)
+	re.Equal(-1, level)
+	label, level = GetRegionLabelIsolation(nil, nil)
 	re.Equal(nonIsolation, label)
+	re.Equal(-1, level)
 	store := core.NewStoreInfo(&metapb.Store{Id: 1, Address: "mock://tikv-1:1"}, core.SetStoreLabels([]*metapb.StoreLabel{{Key: "foo", Value: "bar"}}))
-	label = GetRegionLabelIsolation([]*core.StoreInfo{store}, locationLabels)
+	label, level = GetRegionLabelIsolation([]*core.StoreInfo{store}, locationLabels)
 	re.Equal("zone", label)
+	re.Equal(0, level)
 
 	regionID = 1
 	res = []string{"rack", "none", "zone", "rack", "none", "rack", "none"}

--- a/tools/pd-ctl/pdctl/command/label_command.go
+++ b/tools/pd-ctl/pdctl/command/label_command.go
@@ -183,7 +183,7 @@ func checkIsolationLabel(cmd *cobra.Command, args []string) {
 				stores = append(stores, s)
 			}
 		}
-		isolationLabel := statistics.GetRegionLabelIsolation(stores, locationLabels)
+		isolationLabel, _ := statistics.GetRegionLabelIsolation(stores, locationLabels)
 		if len(checkLabel) == 0 || isolationLabel == checkLabel {
 			regionMap[region.ID] = isolationLabel
 			labelCount[isolationLabel]++


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #10149

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
check location labels in AffinityChecker
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Affinity checks now evaluate placement-rule satisfaction (including a cached and cacheless region fit path) and region label isolation reports a numeric level for level-based checks.

* **Bug Fixes**
  * Better detection and handling of superior replica placements, stricter enforcement of isolation constraints, preservation of learners, and early exit when placement rules are disabled.

* **Metrics**
  * Added a counter for placement-rules-disabled occurrences.

* **Tests**
  * Expanded and updated tests for placement-rule, isolation-level, normalization, and placement interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->