### PR TITLE
 test:add  some tso config test for active-active

### DIFF
--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -488,6 +488,72 @@ hot-regions-write-interval= "30m"
 	re.Equal(uint64(7), cfg.Schedule.HotRegionsReservedDays)
 }
 
+func TestTSOIndexConfig(t *testing.T) {
+	re := require.New(t)
+
+	// Test case 1: max-index less than unique-index (should fail)
+	cfgData := `
+tso-max-index = 2
+tso-unique-index = 3
+`
+	cfg := NewConfig()
+	meta, err := toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.Error(err)
+	re.Contains(err.Error(), "tso max index:2 is less than unique index:3")
+
+	// Test case 2: max-index equal to unique-index (should fail)
+	cfgData = `
+tso-max-index = 3
+tso-unique-index = 3
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.Error(err)
+	re.Contains(err.Error(), "tso max index:3 is less than unique index:3")
+
+	// Test case 3: max-index greater than tsoMaxIndexUpperLimit (should fail)
+	cfgData = `
+tso-max-index = 11
+tso-unique-index = 1
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.Error(err)
+	re.Contains(err.Error(), "tso max index:11 should be less than 10")
+
+	// Test case 4: valid configuration (max-index > unique-index and max-index <= tsoMaxIndexUpperLimit)
+	cfgData = `
+tso-max-index = 5
+tso-unique-index = 2
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.NoError(err)
+	re.Equal(int64(5), cfg.TSOMaxIndex)
+	re.Equal(int64(2), cfg.TSOUniqueIndex)
+
+	// Test case 5: max-index at upper limit (should succeed)
+	cfgData = `
+tso-max-index = 10
+tso-unique-index = 5
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.NoError(err)
+	re.Equal(int64(10), cfg.TSOMaxIndex)
+	re.Equal(int64(5), cfg.TSOUniqueIndex)
+}
+
 func TestConfigClone(t *testing.T) {
 	re := require.New(t)
 	cfg := &Config{}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
