### PR TITLE
tests: stabilize flaky rule suspect key-range checks

### DIFF
--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -121,6 +121,11 @@ func (suite *ruleTestSuite) checkRegionLabeler(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestSet() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/checker/skipCheckSuspectRanges", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/checker/skipCheckSuspectRanges"))
+	}()
 	suite.env.RunTest(suite.checkSet)
 }
 
@@ -614,6 +619,11 @@ func (suite *ruleTestSuite) checkGetAllByKey(cluster *tests.TestCluster) {
 }
 
 func (suite *ruleTestSuite) TestDelete() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/checker/skipCheckSuspectRanges", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/checker/skipCheckSuspectRanges"))
+	}()
 	suite.env.RunTest(suite.checkDelete)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10237

### What is changed and how does it work?

`TestRuleTestSuite/TestSet` is flaky because it asserts `PopOneSuspectKeyRange()` immediately after posting a rule update, while `checker.Controller.CheckSuspectRanges()` can consume the same queue asynchronously.

This PR stabilizes the assertion path by temporarily enabling `skipCheckSuspectRanges` in tests that verify suspect key-range enqueueing:

- `TestSet`
- `TestDelete`

The failpoint is enabled only within each test and disabled via `defer`, so test isolation is preserved.

```commit-message
tests: stabilize rule suspect key-range assertions
```

### Check List

Tests

- Integration test

Code changes

- No code

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Modified test cases to enable failpoint mechanism during testing for improved test control flow and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->