### PR TITLE
tests: fix deadlock by introducing a starting state

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -58,6 +58,7 @@ import (
 // TestServer states.
 const (
 	Initial int32 = iota
+	Starting
 	Running
 	Stop
 	Destroy
@@ -142,12 +143,32 @@ func NewTestServer(ctx context.Context, cfg *config.Config, services []string, h
 // Run starts to run a TestServer.
 func (s *TestServer) Run() error {
 	s.Lock()
-	defer s.Unlock()
 	if s.state != Initial && s.state != Stop {
+		s.Unlock()
 		return errors.Errorf("server(state%d) cannot run", s.state)
 	}
-	if err := s.server.Run(); err != nil {
+	// Immediately set state to Starting and unlock
+	s.state = Starting
+	s.Unlock()
+
+	// Run the server which is a slow operation
+	err := s.server.Run()
+
+	s.Lock()
+	defer s.Unlock()
+
+	if err != nil {
+		// If the server is destroyed or stopped while Run(), return nil
+		if s.state == Destroy || s.state == Stop {
+			return nil
+		}
+		s.state = Stop
 		return err
+	}
+	// Close and return nil if the server is destroyed or stopped
+	if s.state == Destroy || s.state == Stop {
+		s.server.Close()
+		return nil
 	}
 	s.state = Running
 	return nil
@@ -157,12 +178,16 @@ func (s *TestServer) Run() error {
 func (s *TestServer) Stop() error {
 	s.Lock()
 	defer s.Unlock()
-	if s.state != Running {
-		return errors.Errorf("server(state%d) cannot stop", s.state)
+	if s.state == Starting {
+		s.state = Stop
+		return nil
 	}
-	s.server.Close()
-	s.state = Stop
-	return nil
+	if s.state == Running {
+		s.server.Close()
+		s.state = Stop
+		return nil
+	}
+	return errors.Errorf("server(state%d) cannot stop", s.state)
 }
 
 // Destroy is used to destroy a TestServer.
@@ -172,11 +197,9 @@ func (s *TestServer) Destroy() error {
 	if s.state == Running {
 		s.server.Close()
 	}
-	if err := os.RemoveAll(s.server.GetConfig().DataDir); err != nil {
-		return err
-	}
+	// Set state to Destroy before RemoveAll
 	s.state = Destroy
-	return nil
+	return os.RemoveAll(s.server.GetConfig().DataDir) // removed redundant if err != nil check, linter fix
 }
 
 // ResetPDLeader resigns the leader of the server.

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -84,6 +84,7 @@ var (
 // TestServer is only for test.
 type TestServer struct {
 	syncutil.RWMutex
+	startMu    sync.Mutex
 	server     *server.Server
 	grpcServer *server.GrpcServer
 	state      int32
@@ -142,10 +143,14 @@ func NewTestServer(ctx context.Context, cfg *config.Config, services []string, h
 
 // Run starts to run a TestServer.
 func (s *TestServer) Run() error {
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+
 	s.Lock()
 	if s.state != Initial && s.state != Stop {
+		state := s.state
 		s.Unlock()
-		return errors.Errorf("server(state%d) cannot run", s.state)
+		return errors.Errorf("server(state%d) cannot run", state)
 	}
 	// Immediately set state to Starting and unlock
 	s.state = Starting
@@ -158,17 +163,15 @@ func (s *TestServer) Run() error {
 	defer s.Unlock()
 
 	if err != nil {
-		// If the server is destroyed or stopped while Run(), return nil
 		if s.state == Destroy || s.state == Stop {
-			return nil
+			return errors.New("server stopped before reaching running state")
 		}
 		s.state = Stop
 		return err
 	}
-	// Close and return nil if the server is destroyed or stopped
 	if s.state == Destroy || s.state == Stop {
 		s.server.Close()
-		return nil
+		return errors.New("server stopped before reaching running state")
 	}
 	s.state = Running
 	return nil
@@ -180,6 +183,7 @@ func (s *TestServer) Stop() error {
 	defer s.Unlock()
 	if s.state == Starting {
 		s.state = Stop
+		s.server.Close()
 		return nil
 	}
 	if s.state == Running {
@@ -194,10 +198,13 @@ func (s *TestServer) Stop() error {
 func (s *TestServer) Destroy() error {
 	s.Lock()
 	defer s.Unlock()
-	if s.state == Running {
+	if s.state == Running || s.state == Starting {
 		s.server.Close()
 	}
+<<<<<<< Updated upstream
 	// Set state to Destroy before RemoveAll
+=======
+>>>>>>> Stashed changes
 	s.state = Destroy
 	return os.RemoveAll(s.server.GetConfig().DataDir) // removed redundant if err != nil check, linter fix
 }

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -197,16 +197,17 @@ func (s *TestServer) Stop() error {
 // Destroy is used to destroy a TestServer.
 func (s *TestServer) Destroy() error {
 	s.Lock()
-	defer s.Unlock()
 	if s.state == Running || s.state == Starting {
 		s.server.Close()
 	}
-<<<<<<< Updated upstream
-	// Set state to Destroy before RemoveAll
-=======
->>>>>>> Stashed changes
 	s.state = Destroy
-	return os.RemoveAll(s.server.GetConfig().DataDir) // removed redundant if err != nil check, linter fix
+	dataDir := s.server.GetConfig().DataDir
+	s.Unlock()
+
+	// Wait for any in-flight Run() to finish before deleting the data dir.
+	s.startMu.Lock()
+	s.startMu.Unlock()
+	return os.RemoveAll(dataDir)
 }
 
 // ResetPDLeader resigns the leader of the server.


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10241 

### What is changed and how does it work?


1. In `tests/cluster.go`, `TestServer.Run()` was holding the write lock (`s.Lock()`) for the entire duration of  `s.server.Run()` call, which can be slow (e.g., waiting for etcd).

2. If another thread tried to inspect the server state (e.g., calling `s.State()` -> s.RLock() in `runInitialServersWithRetry()` during error cleanup), it would block indefinitely waiting for the write lock to be released, causing a deadlock.

3.  Added a Starting state that releases the lock before calling `s.server.Run()`. This allows other operations to read the server state without blocking, preventing the deadlock.

4. Also changed a redundant `if err := os.RemoveAll(s.server.GetConfig().DataDir); err != nil` check caught by linter check in `Destroy()`

cc: @okJiang 

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an intermediate "starting" state and serialized startup to avoid races during test server startup.
  * Stop now cleanly supports stopping while starting; Destroy waits for any in-flight startup to finish before removing data, preventing data-race and cleanup issues.
  * Improved error handling for servers that stop during startup or shutdown, reducing flaky test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->