### PR TITLE
resourcegroup: replace blind sleep with signal-aware wait in acquireTokens

### DIFF
--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -264,7 +264,11 @@ func TestAcquireTokensSignalAwareWait(t *testing.T) {
 	}()
 
 	// Wait for notify — Reserve has failed and the retry path is entered.
-	<-notifyCh
+	select {
+	case <-notifyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for low-RU notification")
+	}
 
 	// Now reconfigure with enough tokens and a real fillRate.
 	// This closes the reconfiguredCh (waking the select) and provides

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -87,6 +87,10 @@ type Limiter struct {
 	remainingNotifyTimes int
 	name                 string
 
+	// reconfiguredCh is closed on every Reconfigure() call to wake up
+	// goroutines waiting in acquireTokens() retry loops.
+	reconfiguredCh chan struct{}
+
 	// metrics
 	metrics *limiterMetricsCollection
 }
@@ -110,6 +114,7 @@ func NewLimiter(now time.Time, r fillRate, b int64, tokens float64, lowTokensNot
 		tokens:              tokens,
 		burst:               b,
 		lowTokensNotifyChan: lowTokensNotifyChan,
+		reconfiguredCh:      make(chan struct{}),
 	}
 	log.Debug("new limiter", zap.String("limiter", fmt.Sprintf("%+v", lim)))
 	return lim
@@ -126,6 +131,7 @@ func NewLimiterWithCfg(name string, now time.Time, cfg tokenBucketReconfigureArg
 		burst:               cfg.newBurst,
 		notifyThreshold:     cfg.newNotifyThreshold,
 		lowTokensNotifyChan: lowTokensNotifyChan,
+		reconfiguredCh:      make(chan struct{}),
 	}
 	lim.metrics = &limiterMetricsCollection{
 		lowTokenNotifyCounter: metrics.LowTokenRequestNotifyCounter.WithLabelValues(lim.name),
@@ -248,6 +254,15 @@ func (lim *Limiter) SetName(name string) *Limiter {
 	return lim
 }
 
+// GetReconfiguredCh returns a channel that is closed when the limiter is
+// reconfigured. Callers can select on this to be woken up immediately
+// when new tokens arrive, instead of blind-sleeping.
+func (lim *Limiter) GetReconfiguredCh() <-chan struct{} {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	return lim.reconfiguredCh
+}
+
 // notify tries to send a non-blocking notification on notifyCh and disables
 // further notifications (until the next Reconfigure or StartNotification).
 func (lim *Limiter) notify() {
@@ -350,6 +365,9 @@ func (lim *Limiter) Reconfigure(now time.Time,
 		opt(lim)
 	}
 	lim.maybeNotify()
+	// Wake up all goroutines waiting in acquireTokens retry loops.
+	close(lim.reconfiguredCh)
+	lim.reconfiguredCh = make(chan struct{})
 	logControllerTrace("[resource group controller] after reconfigure",
 		zap.String("name", lim.name), zap.Float64("tokens", lim.tokens),
 		zap.Float64("rate", float64(lim.fillRate)),


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: close #10251.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
Add a close-and-recreate channel on the `Limiter` that is closed on every `Reconfigure()` call.
The retry loop in `acquireTokens` now selects on this channel instead of blind-sleeping,
waking up immediately when new tokens arrive. The timer serves as a fallback to preserve original
behavior when no `Reconfigure` occurs.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token acquisition retry now uses an interruptible wait so reconfiguration cancels unnecessary delays, improving responsiveness during limiter changes.

* **New Features**
  * Limiter now signals reconfiguration to promptly wake waiting operations.

* **Tests**
  * Added coverage for signal-aware wakeups, timer fallback behavior, and waking multiple waiters during reconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->