### PR TITLE
config: `max-store-preparing-time` can be set 0s

### DIFF
--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -368,7 +368,10 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	configutil.AdjustDuration(&c.PatrolRegionInterval, defaultPatrolRegionInterval)
 	configutil.AdjustDuration(&c.MaxStoreDownTime, defaultMaxStoreDownTime)
 	configutil.AdjustDuration(&c.HotRegionsWriteInterval, defaultHotRegionsWriteInterval)
-	configutil.AdjustDuration(&c.MaxStorePreparingTime, defaultMaxStorePreparingTime)
+	if !meta.IsDefined("max-store-preparing-time") {
+		configutil.AdjustDuration(&c.MaxStorePreparingTime, defaultMaxStorePreparingTime)
+	}
+
 	if !meta.IsDefined("leader-schedule-limit") {
 		configutil.AdjustUint64(&c.LeaderScheduleLimit, defaultLeaderScheduleLimit)
 	}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -491,16 +491,24 @@ hot-regions-write-interval= "30m"
 
 func TestMaxStorePreparingTime(t *testing.T) {
 	re := require.New(t)
-	cfgData := `
-[schedule]
-max-store-preparing-time = "48h"
-`
+	cfgData := ``
 	cfg := NewConfig()
 	meta, err := toml.Decode(cfgData, &cfg)
 	re.NoError(err)
 	err = cfg.Adjust(&meta, false)
 	re.NoError(err)
 	re.Equal(48*time.Hour, cfg.Schedule.MaxStorePreparingTime.Duration)
+
+	cfgData = `
+[schedule]
+max-store-preparing-time = "40h"
+`
+	cfg = NewConfig()
+	meta, err = toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.NoError(err)
+	re.Equal(40*time.Hour, cfg.Schedule.MaxStorePreparingTime.Duration)
 
 	cfgData = `
 [schedule]
@@ -511,7 +519,6 @@ max-store-preparing-time = "0s"
 	err = cfg.Adjust(&meta, false)
 	re.NoError(err)
 	re.Equal(0*time.Second, cfg.Schedule.MaxStorePreparingTime.Duration)
-
 }
 
 func TestConfigClone(t *testing.T) {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -489,6 +489,31 @@ hot-regions-write-interval= "30m"
 	re.Equal(uint64(7), cfg.Schedule.HotRegionsReservedDays)
 }
 
+func TestMaxStorePreparingTime(t *testing.T) {
+	re := require.New(t)
+	cfgData := `
+[schedule]
+max-store-preparing-time = "48h"
+`
+	cfg := NewConfig()
+	meta, err := toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.NoError(err)
+	re.Equal(48*time.Hour, cfg.Schedule.MaxStorePreparingTime.Duration)
+
+	cfgData = `
+[schedule]
+max-store-preparing-time = "0s"
+`
+	meta, err = toml.Decode(cfgData, &cfg)
+	re.NoError(err)
+	err = cfg.Adjust(&meta, false)
+	re.NoError(err)
+	re.Equal(0*time.Second, cfg.Schedule.MaxStorePreparingTime.Duration)
+
+}
+
 func TestConfigClone(t *testing.T) {
 	re := require.New(t)
 	cfg := &Config{}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10262

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MaxStorePreparingTime now correctly respects user-provided values while still falling back to a 48-hour default when not specified, preventing unintended overrides.

* **Tests**
  * Added test coverage validating MaxStorePreparingTime behavior across default, custom, and zero-duration settings to ensure consistent configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->