### PR TITLE
agents: add pd-hotspot-troubleshooting skill

### DIFF
--- a/.agents/skills/pd-hotspot-troubleshooting/SKILL.md
+++ b/.agents/skills/pd-hotspot-troubleshooting/SKILL.md
@@ -352,9 +352,6 @@ curl -X POST http://<tidb>:10080/tables/<db>/<table>/scatter
 curl http://<tidb>:10080/tables/<db>/<table>/stop-scatter
 ```
 
-- if the incident was amplified by `tidb_replica_read=leader`, consider
-  temporary rollback to `leader-and-follower` as a mitigation while continuing
-  the root-cause investigation;
 - if a guarded periodic split script consistently improves the workload, treat it
   as temporary mitigation only, and compare its trigger logic against
   load-base-split thresholds to explain the gap;
@@ -402,8 +399,6 @@ Actions:
   often still improve hotspot coverage materially;
 - if `1.0` is discussed, note that it is close to removing the balance
   restriction and should be treated as a last-resort experiment only;
-- if the workload change also forced leader-only reads, consider restoring
-  `tidb_replica_read=leader-and-follower` as a mitigation;
 - if the customer already has a manual split script that is demonstrably better
   than auto split, use it as evidence for the gap and as temporary mitigation,
   but do not mistake it for the root fix;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10206, ref #10159

PD currently lacks a dedicated reusable agent skill for hotspot troubleshooting.

### What is changed and how does it work?

This PR adds a new agent skill:

- Add `.agents/skills/pd-hotspot-troubleshooting/SKILL.md`.
- Provide a standardized troubleshooting order:
  1. PD/TiKV monitoring
  2. Key Visualizer
  3. Top SQL / Slow SQL
  4. `pd-ctl` hotspot/history as fallback evidence
- Include structured decision trees for common hotspot scenarios and rollback-aware
  tuning guidance.

```commit-message
agents: add pd-hotspot-troubleshooting skill
```

### Check List

Tests

- No code

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New comprehensive PD hotspot troubleshooting guide for TiDB/TiKV clusters: step-by-step investigation workflow, primary monitoring paths (PD/TiKV), SQL and hotspot views, pd-ctl fallback usage, a decision tree for hotspot scenarios (A–E), explicit tuning recommendations with rollback guidance, and an output/template for reporting findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->