### PR TITLE
tests: fix data race in TestUnavailableTimeAfterLeaderIsReady

### DIFF
--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -410,10 +410,8 @@ func TestUnavailableTimeAfterLeaderIsReady(t *testing.T) {
 		defer wg.Done()
 		var lastTS uint64
 		for range tsoRequestRound {
-			var physical, logical int64
-			var ts uint64
-			physical, logical, err = cli.GetTS(context.Background())
-			ts = tsoutil.ComposeTS(physical, logical)
+			physical, logical, err := cli.GetTS(context.Background())
+			ts := tsoutil.ComposeTS(physical, logical)
 			if err != nil {
 				maxUnavailableTime = time.Now()
 				continue
@@ -430,7 +428,7 @@ func TestUnavailableTimeAfterLeaderIsReady(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		leader := cluster.GetLeaderServer()
-		err = leader.Stop()
+		err := leader.Stop()
 		re.NoError(err)
 		re.NotEmpty(cluster.WaitLeader())
 		leaderReadyTime = time.Now()
@@ -448,7 +446,7 @@ func TestUnavailableTimeAfterLeaderIsReady(t *testing.T) {
 		defer wg.Done()
 		leader := cluster.GetLeaderServer()
 		re.NoError(failpoint.Enable("github.com/tikv/pd/client/clients/tso/unreachableNetwork", "return(true)"))
-		err = leader.Stop()
+		err := leader.Stop()
 		re.NoError(err)
 		re.NotEmpty(cluster.WaitLeader())
 		re.NoError(failpoint.Disable("github.com/tikv/pd/client/clients/tso/unreachableNetwork"))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #9917

`TestUnavailableTimeAfterLeaderIsReady` has a data race detected by `-race`. The test declares an `err` variable at function scope, and three goroutines concurrently write to it:

- `getTsoFunc` goroutine: `physical, logical, err = cli.GetTS(...)` (line 415)
- Anonymous goroutine 1: `err = leader.Stop()` (line 433)
- Anonymous goroutine 2: `err = leader.Stop()` (line 451)

### What is changed and how does it work?

Changed all three goroutines to use local `err` variables via `:=` (short variable declaration) instead of `=` (assignment to the outer scope variable). This eliminates the concurrent writes to the shared outer `err`.

```commit-message
Change shared err variable to goroutine-local variables to prevent
concurrent write race between getTsoFunc and server stop goroutines.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```