### PR TITLE
tests: fix flaky TestUpdateDefaultReplicaConfig

### DIFF
--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -1051,9 +1051,13 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 		args := []string{"-u", pdAddr, "config", "show", "replication"}
 		testutil.Eventually(re, func() bool { // wait for the config to be synced to the scheduling server
 			output, err := tests.ExecuteCommand(cmd, args...)
-			re.NoError(err)
+			if err != nil {
+				return false
+			}
 			replicationCfg := sc.ReplicationConfig{}
-			re.NoError(json.Unmarshal(output, &replicationCfg))
+			if err := json.Unmarshal(output, &replicationCfg); err != nil {
+				return false
+			}
 			return replicationCfg.MaxReplicas == expect
 		})
 	}
@@ -1062,9 +1066,13 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 		args := []string{"-u", pdAddr, "config", "show", "replication"}
 		testutil.Eventually(re, func() bool { // wait for the config to be synced to the scheduling server
 			output, err := tests.ExecuteCommand(cmd, args...)
-			re.NoError(err)
+			if err != nil {
+				return false
+			}
 			replicationCfg := sc.ReplicationConfig{}
-			re.NoError(json.Unmarshal(output, &replicationCfg))
+			if err := json.Unmarshal(output, &replicationCfg); err != nil {
+				return false
+			}
 			return len(replicationCfg.LocationLabels) == expect
 		})
 	}
@@ -1073,9 +1081,13 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 		args := []string{"-u", pdAddr, "config", "show", "replication"}
 		testutil.Eventually(re, func() bool { // wait for the config to be synced to the scheduling server
 			output, err := tests.ExecuteCommand(cmd, args...)
-			re.NoError(err)
+			if err != nil {
+				return false
+			}
 			replicationCfg := sc.ReplicationConfig{}
-			re.NoError(json.Unmarshal(output, &replicationCfg))
+			if err := json.Unmarshal(output, &replicationCfg); err != nil {
+				return false
+			}
 			return replicationCfg.IsolationLevel == expect
 		})
 	}
@@ -1084,9 +1096,13 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 		args := []string{"-u", pdAddr, "config", "placement-rules", "show", "--group", placement.DefaultGroupID, "--id", placement.DefaultRuleID}
 		testutil.Eventually(re, func() bool { // wait for the config to be synced to the scheduling server
 			output, err := tests.ExecuteCommand(cmd, args...)
-			re.NoError(err)
+			if err != nil {
+				return false
+			}
 			rule := placement.Rule{}
-			re.NoError(json.Unmarshal(output, &rule))
+			if err := json.Unmarshal(output, &rule); err != nil {
+				return false
+			}
 			return rule.Count == expect
 		})
 	}
@@ -1095,9 +1111,13 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 		args := []string{"-u", pdAddr, "config", "placement-rules", "show", "--group", placement.DefaultGroupID, "--id", placement.DefaultRuleID}
 		testutil.Eventually(re, func() bool { // wait for the config to be synced to the scheduling server
 			output, err := tests.ExecuteCommand(cmd, args...)
-			re.NoError(err)
+			if err != nil {
+				return false
+			}
 			rule := placement.Rule{}
-			re.NoError(json.Unmarshal(output, &rule))
+			if err := json.Unmarshal(output, &rule); err != nil {
+				return false
+			}
 			return len(rule.LocationLabels) == expect
 		})
 	}
@@ -1106,9 +1126,13 @@ func (suite *configTestSuite) checkUpdateDefaultReplicaConfig(cluster *pdTests.T
 		args := []string{"-u", pdAddr, "config", "placement-rules", "show", "--group", placement.DefaultGroupID, "--id", placement.DefaultRuleID}
 		testutil.Eventually(re, func() bool { // wait for the config to be synced to the scheduling server
 			output, err := tests.ExecuteCommand(cmd, args...)
-			re.NoError(err)
+			if err != nil {
+				return false
+			}
 			rule := placement.Rule{}
-			re.NoError(json.Unmarshal(output, &rule))
+			if err := json.Unmarshal(output, &rule); err != nil {
+				return false
+			}
 			return rule.IsolationLevel == expect
 		})
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #7410

`TestUpdateDefaultReplicaConfig` is flaky because `re.NoError()` (which calls `t.Errorf()`) is used inside `testutil.Eventually()` retry loops. When errors occur on early retry ticks (e.g., config not yet synced to scheduling server), `re.NoError()` permanently marks the test as failed even though subsequent ticks succeed.

This is the same pattern as #9968 (TestRegionCheck).

### What is changed and how does it work?

Replaced all 12 `re.NoError()` calls inside 6 `testutil.Eventually()` closures in `checkUpdateDefaultReplicaConfig` with plain Go error checks (`if err != nil { return false }`). This allows the retry loop to continue on transient errors without permanently tainting the test result.

```commit-message
tests: fix flaky TestUpdateDefaultReplicaConfig

Replace re.NoError() inside testutil.Eventually() retry loops with
plain Go error checks. re.NoError() permanently marks the test as
failed on early retry ticks even when subsequent ticks succeed.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```