### PR TITLE
tests: fix nil panic in TestDisableSchedulingServiceFallback

### DIFF
--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -304,8 +304,9 @@ func (suite *serverTestSuite) TestDisableSchedulingServiceFallback() {
 
 	// PD will execute scheduling jobs since there is no scheduling server.
 	testutil.Eventually(re, func() bool {
-		re.NotNil(suite.pdLeader.GetServer())
-		re.NotNil(suite.pdLeader.GetServer().GetRaftCluster())
+		if suite.pdLeader.GetServer() == nil || suite.pdLeader.GetServer().GetRaftCluster() == nil {
+			return false
+		}
 		return suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})
 	leaderServer := suite.pdLeader.GetServer()
@@ -335,7 +336,15 @@ func (suite *serverTestSuite) TestDisableSchedulingServiceFallback() {
 	})
 	// Scheduling server is responsible for executing scheduling jobs.
 	testutil.Eventually(re, func() bool {
-		return tc.GetPrimaryServer().GetCluster().IsBackgroundJobsRunning()
+		primaryServer := tc.GetPrimaryServer()
+		if primaryServer == nil {
+			return false
+		}
+		cluster := primaryServer.GetCluster()
+		if cluster == nil {
+			return false
+		}
+		return cluster.IsBackgroundJobsRunning()
 	})
 	// Disable scheduling service fallback and stop scheduling server. PD won't execute scheduling jobs again.
 	conf.EnableSchedulingFallback = false


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #8926

`TestDisableSchedulingServiceFallback` is flaky due to a nil pointer dereference inside an `assert.Eventually` callback. The test calls `tc.GetPrimaryServer().GetCluster().IsBackgroundJobsRunning()` without nil checks, causing a SIGSEGV panic when either `GetPrimaryServer()` or `GetCluster()` returns nil during the scheduling server's initialization window.

Additionally, the test used `re.NotNil()` (a `require` assertion) inside an `Eventually` callback. Since `Eventually` may run the callback in a goroutine context, calling `FailNow()` from a non-test goroutine can cause a panic.

### What is changed and how does it work?

1. Replaced `re.NotNil()` require assertions inside the first `Eventually` callback with proper nil-check-and-return-false guards, preventing `FailNow` panics from non-test goroutines.
2. Added nil guards for `GetPrimaryServer()` and `GetCluster()` in the second `Eventually` callback before calling `IsBackgroundJobsRunning()`, matching the existing defensive pattern already used in the sibling test `TestSchedulingServiceFallback`.

```commit-message
Add nil guards in Eventually callbacks to prevent nil pointer dereference.
Replace re.NotNil() require assertions with nil-check-and-return-false
guards to avoid FailNow panics from non-test goroutines.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```