### PR TITLE
tests: fix flaky TestSwitchModeDuringWorkload

### DIFF
--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -491,7 +491,7 @@ func TestSwitchModeDuringWorkload(t *testing.T) {
 			switched.Store(true)
 			testutil.Eventually(re, func() bool {
 				return atomic.LoadInt64(&okAfter) >= 10
-			}, testutil.WithTickInterval(20*time.Millisecond))
+			}, testutil.WithWaitFor(time.Minute), testutil.WithTickInterval(20*time.Millisecond))
 
 			log.Info("switch during workload finished",
 				zap.Int("startMode", int(tc.startMode)),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10154

`TestSwitchModeDuringWorkload/pd-to-standalone` is flaky in CI. After the mode switch, the resource group controller may remain in degraded mode while waiting for the token bucket stream to reconnect to the new standalone RM service and receive a successful response. The default 20-second `testutil.Eventually` timeout is insufficient in slow CI environments where reconnection retries (6 x 500ms), RPC timeouts, and the 1-second state update interval compound to delay the controller's exit from degraded mode.

### What is changed and how does it work?

Extend the `testutil.Eventually` timeout from 20 seconds (default) to 1 minute for the post-switch `okAfter >= 10` assertion. This gives the controller adequate time to complete the token bucket round-trip and exit degraded mode, even in resource-constrained CI environments.

```commit-message
Extend post-switch Eventually timeout from 20s to 1m to accommodate
slow CI environments where token bucket reconnection may be delayed.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```