### PR TITLE
tests: fix flaky TestAPI/TestStores

### DIFF
--- a/tests/integrations/mcs/scheduling/api_test.go
+++ b/tests/integrations/mcs/scheduling/api_test.go
@@ -681,6 +681,24 @@ func (suite *apiTestSuite) checkStores(cluster *tests.TestCluster) {
 	re.Equal(3, int(resp["count"].(float64)))
 	re.Len(resp["stores"].([]any), 3)
 	// Test /stores/{id}
+	// Wait until all stores (including the tombstone store 7) are available on
+	// the scheduling server before checking individual stores. The store metadata
+	// may not be immediately available via the scheduling server API due to the
+	// asynchronous nature of the store watcher propagation.
+	testutil.Eventually(re, func() bool {
+		for _, storeID := range []int{1, 6, 7} {
+			url := fmt.Sprintf("%s/scheduling/api/v1/stores/%d", scheServerAddr, storeID)
+			resp, err := tests.TestDialClient.Get(url)
+			if err != nil {
+				return false
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return false
+			}
+		}
+		return true
+	})
 	urlPrefix = fmt.Sprintf("%s/scheduling/api/v1/stores/1", scheServerAddr)
 	err = testutil.ReadGetJSON(re, tests.TestDialClient, urlPrefix, &resp)
 	re.NoError(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #9591

`TestAPI/TestStores` is flaky because the scheduling server API may return 404 for store 7 (tombstone) immediately after `MustPutStore` returns. Although `MustPutStore` directly puts the store into the scheduling server's basic cluster, the store metadata may not be immediately visible via the API due to the asynchronous nature of the store watcher propagation through etcd.

### What is changed and how does it work?

Add a `testutil.Eventually` wait loop before querying individual stores on the scheduling server. The retry ensures all stores (including the tombstone store 7) are available via the scheduling server API before asserting on their metadata. The wait loop uses raw HTTP calls without `require` assertions to avoid the known anti-pattern of calling `t.FailNow()` inside a retry callback.

```commit-message
Add a testutil.Eventually wait loop before querying individual stores
on the scheduling server. In the microservice environment, store
metadata (particularly for the tombstone store 7) may not be
immediately visible via the scheduling server API after MustPutStore
returns, because the store watcher propagates changes asynchronously
through etcd.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```