### PR TITLE
agents: link .claude/skills to .agents/skills for Claude Code discovery

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tmp*
 .specstory/
 .cursorindexingignore
 .gocache/
+!.claude/
+.claude/*
+!.claude/skills


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10206, ref #10159

### What is changed and how does it work?

Add a symlink from `.claude/skills` to `.agents/skills` so that Claude Code can automatically discover and use the agent skills defined in the repository. Update `.gitignore` to track only the symlink under `.claude/`.

```commit-message
Add a symlink from .claude/skills to .agents/skills so that Claude Code
can automatically discover and use the agent skills defined in the
repository. Update .gitignore to track only the symlink under .claude/.
```

### Check List

Tests

- No code

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for development environment management and version control handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->