### PR TITLE
RU: AcquireTokenBuckets fallback

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -520,7 +520,7 @@ func isAcquireTokenBucketsRPCError(err error) bool {
 // any server-side RU; it grants tokens locally at the degraded fill rate so
 // the client-side limiter can continue. Called repeatedly (e.g. RM down) only
 // re-applies the same rate each time.
-func (c *ResourceGroupsController) buildDegradedTokenBucketResponses(
+func buildDegradedTokenBucketResponses(
 	requests []*rmpb.TokenBucketRequest,
 	degradedRUSettings *rmpb.GroupRequestUnitSettings,
 ) []*rmpb.TokenBucketResponse {
@@ -731,7 +731,7 @@ func (c *ResourceGroupsController) sendTokenBucketRequests(ctx context.Context, 
 			// Only use degraded fallback for RPC/transport errors (e.g. RM down, timeout).
 			// Logical errors (e.g. resource group not found) are not masked so the caller can handle them.
 			if isAcquireTokenBucketsRPCError(err) && c.degradedRUSettings != nil {
-				resp = c.buildDegradedTokenBucketResponses(req.Requests, c.degradedRUSettings)
+				resp = buildDegradedTokenBucketResponses(req.Requests, c.degradedRUSettings)
 				if resp != nil {
 					if !errors.ErrorEqual(err, context.Canceled) {
 						log.Info("[resource group controller] use degraded token bucket response due to rpc error, ru path continues", zap.Error(err))

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -454,8 +454,6 @@ func TestIsAcquireTokenBucketsRPCError(t *testing.T) {
 // the degraded fallback response builder.
 func TestBuildDegradedTokenBucketResponses(t *testing.T) {
 	re := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	degradedSettings := &rmpb.GroupRequestUnitSettings{
 		RU: &rmpb.TokenBucket{
@@ -465,20 +463,16 @@ func TestBuildDegradedTokenBucketResponses(t *testing.T) {
 			},
 		},
 	}
-	mockProvider := newMockResourceGroupProvider()
-	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID, WithDegradedRUSettings(degradedSettings))
-	re.NoError(err)
-
 	requests := []*rmpb.TokenBucketRequest{
 		{ResourceGroupName: "rg1"},
 		{ResourceGroupName: "rg2"},
 	}
 
 	// Nil degraded settings -> nil response
-	re.Nil(controller.buildDegradedTokenBucketResponses(requests, nil))
+	re.Nil(buildDegradedTokenBucketResponses(requests, nil))
 
 	// Valid settings -> one response per request with correct settings
-	resp := controller.buildDegradedTokenBucketResponses(requests, degradedSettings)
+	resp := buildDegradedTokenBucketResponses(requests, degradedSettings)
 	re.Len(resp, 2)
 	re.Equal("rg1", resp[0].ResourceGroupName)
 	re.Len(resp[0].GrantedRUTokens, 1)


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added degraded fallback mode for token requests during RPC/transport errors to allow graceful request handling and informational logging when used.

* **Bug Fixes**
  * Improved classification and handling of transport-level errors (Unavailable, DeadlineExceeded, Canceled, Internal, ResourceExhausted) to trigger fallback only when appropriate while preserving existing latency metrics.

* **Tests**
  * Added tests covering error classification, degraded fallback responses, and fallback vs. logical error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->