### PR TITLE
*: migrate simple failpoint.Inject to failpoint.InjectCall

### DIFF
--- a/client/clients/tso/client.go
+++ b/client/clients/tso/client.go
@@ -567,9 +567,7 @@ func (c *Cli) DispatchRequest(request *Request) (bool, error) {
 		return true, c.ctx.Err()
 	default:
 		// This failpoint will increase the possibility that the request is sent to a closed dispatcher.
-		failpoint.Inject("delayDispatchTSORequest", func() {
-			time.Sleep(time.Second)
-		})
+		failpoint.InjectCall("delayDispatchTSORequest")
 		c.getDispatcher().push(request)
 	}
 	// Check the contexts again to make sure the request is not been sent to a closed dispatcher.

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -292,7 +292,7 @@ func (ls *Leadership) Watch(serverCtx context.Context, revision int64) {
 	lastReceivedResponseTime := time.Now()
 
 	for {
-		failpoint.Inject("delayWatcher", nil)
+		failpoint.InjectCall("delayWatcher")
 
 		// When etcd is not available, the watcher.Watch will block,
 		// so we check the etcd availability first.

--- a/pkg/election/leadership_test.go
+++ b/pkg/election/leadership_test.go
@@ -125,8 +125,10 @@ func TestExitWatch(t *testing.T) {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/utils/etcdutil/fastTick", "return(true)"))
 	// Case1: close the client before the watch loop starts
 	checkExitWatch(t, leaderKey, func(_ *embed.Etcd, client *clientv3.Client) func() {
-		re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/delayWatcher", `pause`))
+		ch := make(chan struct{})
+		re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/election/delayWatcher", func() { <-ch }))
 		client.Close()
+		close(ch)
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/delayWatcher"))
 		return func() {}
 	})
@@ -146,8 +148,10 @@ func TestExitWatch(t *testing.T) {
 	})
 	// Case4: close the server before the watch loop starts
 	checkExitWatch(t, leaderKey, func(server *embed.Etcd, _ *clientv3.Client) func() {
-		re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/delayWatcher", `pause`))
+		ch := make(chan struct{})
+		re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/election/delayWatcher", func() { <-ch }))
 		server.Close()
+		close(ch)
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/delayWatcher"))
 		return func() {}
 	})

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -701,7 +701,7 @@ func (m *GCStateManager) GetGCState(keyspaceID uint32) (GCState, error) {
 func (m *GCStateManager) GetAllKeyspacesGCStates(ctx context.Context) (map[uint32]GCState, error) {
 	return m.allKeyspacesGCStatesSingleFlight.Do(ctx, func(execCtx context.Context) (map[uint32]GCState, error) {
 		result, err := m.getAllKeyspacesGCStatesImpl(execCtx)
-		failpoint.Inject("onGetAllKeyspacesGCStatesFinish", func() {})
+		failpoint.InjectCall("onGetAllKeyspacesGCStatesFinish")
 		return result, err
 	})
 }

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -2021,7 +2021,8 @@ func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesConcurrentCallShari
 
 	var executionCount atomic.Int64
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/gc/onGetAllKeyspacesGCStatesFinish", "pause"))
+	fpCh := make(chan struct{})
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/gc/onGetAllKeyspacesGCStatesFinish", func() { <-fpCh }))
 	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/gc/onGetAllKeyspacesGCStatesStart", func() {
 		executionCount.Add(1)
 	}))
@@ -2066,6 +2067,7 @@ func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesConcurrentCallShari
 	}
 
 	// Resume execution
+	close(fpCh)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/gc/onGetAllKeyspacesGCStatesFinish"))
 	// The first call finishes with the old result
 	var res result

--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -720,7 +720,7 @@ func (m *GroupManager) FinishSplitKeyspaceByID(splitTargetID uint32) error {
 	m.Lock()
 	defer m.Unlock()
 
-	failpoint.Inject("pauseFinishSplitBeforeTxn", nil)
+	failpoint.InjectCall("pauseFinishSplitBeforeTxn")
 
 	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) (err error) {
 		// Load the split target keyspace group first.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -819,9 +819,7 @@ func (c *Cluster) processRegionBuckets(buckets *metapb.Buckets) error {
 				return nil
 			}
 		}
-		failpoint.Inject("concurrentBucketHeartbeat", func() {
-			time.Sleep(500 * time.Millisecond)
-		})
+		failpoint.InjectCall("concurrentBucketHeartbeat")
 		if ok := region.UpdateBuckets(buckets, old); ok {
 			return nil
 		}

--- a/pkg/schedule/checker/checker_controller.go
+++ b/pkg/schedule/checker/checker_controller.go
@@ -313,14 +313,10 @@ func (c *Controller) CheckRegion(region *core.RegionInfo) []*operator.Operator {
 				c.cluster.GetRuleManager().IsRegionFitCached(c.cluster, region)
 			if skipRuleCheck {
 				// If the fit is fetched from cache, it seems that the region doesn't need check
-				failpoint.Inject("assertShouldNotCache", func() {
-					panic("cached shouldn't be used")
-				})
+				failpoint.InjectCall("assertShouldNotCache")
 				ruleCheckerGetCacheCounter.Inc()
 			} else {
-				failpoint.Inject("assertShouldCache", func() {
-					panic("cached should be used")
-				})
+				failpoint.InjectCall("assertShouldCache")
 				fit := c.priorityInspector.Inspect(region)
 				if opController.OperatorCount(operator.OpReplica) < c.conf.GetReplicaScheduleLimit() {
 					return []*operator.Operator{c.ruleChecker.CheckWithFit(region, fit)}

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -1829,11 +1829,11 @@ func (suite *ruleCheckerTestSuite) TestRuleCache() {
 	for _, testCase := range testCases {
 		suite.T().Log(testCase.name)
 		if testCase.stillCached {
-			re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/checker/assertShouldCache", "return(true)"))
+			re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/schedule/checker/assertShouldCache", func() { panic("cached should be used") }))
 			suite.rc.Check(testCase.region)
 			re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/checker/assertShouldCache"))
 		} else {
-			re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/checker/assertShouldNotCache", "return(true)"))
+			re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/schedule/checker/assertShouldNotCache", func() { panic("cached shouldn't be used") }))
 			suite.rc.Check(testCase.region)
 			re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/checker/assertShouldNotCache"))
 		}

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -151,9 +151,7 @@ func (oc *Controller) GetHBStreams() *hbstream.HeartbeatStreams {
 func (oc *Controller) Dispatch(region *core.RegionInfo, source string, recordOpStepWithTTL func(regionID uint64)) {
 	// Check existed
 	if op := oc.GetOperator(region.GetID()); op != nil {
-		failpoint.Inject("concurrentRemoveOperator", func() {
-			time.Sleep(500 * time.Millisecond)
-		})
+		failpoint.InjectCall("concurrentRemoveOperator")
 		// Update operator status:
 		// The operator status should be STARTED.
 		// Check will call CheckSuccess and CheckTimeout.

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -315,7 +315,7 @@ func (suite *operatorControllerTestSuite) TestConcurrentRemoveOperator() {
 	re.True(op1.Start())
 	oc.SetOperator(op1)
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/operator/concurrentRemoveOperator", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/schedule/operator/concurrentRemoveOperator", func() { time.Sleep(500 * time.Millisecond) }))
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {

--- a/pkg/storage/kv/etcd_kv.go
+++ b/pkg/storage/kv/etcd_kv.go
@@ -282,9 +282,7 @@ func (txn *etcdTxn) LoadRange(key, endKey string, limit int) (keys []string, val
 
 // commit perform the operations on etcd, with pre-condition that values observed by user have not been changed.
 func (txn *etcdTxn) commit() error {
-	failpoint.Inject("slowTxn", func() {
-		time.Sleep(10 * time.Second)
-	})
+	failpoint.InjectCall("slowTxn")
 	// Using slowLogTxn to commit transaction.
 	slowLogTxn := NewSlowLogTxnWithContext(txn.ctx, txn.kv.client)
 	slowLogTxn.If(txn.conditions...)

--- a/pkg/storage/storage_tso_test.go
+++ b/pkg/storage/storage_tso_test.go
@@ -47,7 +47,7 @@ func prepare(t *testing.T) (storage Storage, clean func(), leadership *election.
 
 func TestSaveTimestampWithTimeout(t *testing.T) {
 	re := require.New(t)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/storage/kv/slowTxn", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/storage/kv/slowTxn", func() { time.Sleep(10 * time.Second) }))
 	defer func() {
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/storage/kv/slowTxn"))
 	}()

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -166,9 +166,7 @@ func (t *timestampOracle) syncTimestamp() error {
 	log.Info("start to sync timestamp", logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0))
 	t.metrics.syncEvent.Inc()
 
-	failpoint.Inject("delaySyncTimestamp", func() {
-		time.Sleep(time.Second)
-	})
+	failpoint.InjectCall("delaySyncTimestamp")
 
 	last, err := t.storage.LoadTimestamp(t.keyspaceGroupID)
 	if err != nil {

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/unrolled/render"
@@ -174,10 +173,7 @@ func newRegionsHandler(svr *server.Server, rd *render.Render) *regionsHandler {
 func (h *regionsHandler) GetRegions(w http.ResponseWriter, r *http.Request) {
 	rc := getCluster(r)
 	regions := rc.GetRegions()
-	failpoint.Inject("slowRequest", func() {
-		// Simulate a slow request.
-		<-time.After(5 * time.Second)
-	})
+	failpoint.InjectCall("slowRequest")
 
 	b, err := response.MarshalRegionsInfoJSON(r.Context(), regions)
 	if err != nil {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1202,9 +1202,7 @@ func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) error {
 				return nil
 			}
 		}
-		failpoint.Inject("concurrentBucketHeartbeat", func() {
-			time.Sleep(500 * time.Millisecond)
-		})
+		failpoint.InjectCall("concurrentBucketHeartbeat")
 		if ok := region.UpdateBuckets(buckets, old); ok {
 			updateSuccessCounter.Inc()
 			return nil
@@ -1266,9 +1264,7 @@ func (c *RaftCluster) processRegionHeartbeat(ctx *core.MetaProcessContext, regio
 		}
 		return nil
 	}
-	failpoint.Inject("concurrentRegionHeartbeat", func() {
-		time.Sleep(500 * time.Millisecond)
-	})
+	failpoint.InjectCall("concurrentRegionHeartbeat")
 	tracer.OnSaveCacheBegin()
 	var overlaps []*core.RegionInfo
 	if saveCache {
@@ -2066,9 +2062,7 @@ func (c *RaftCluster) OnStoreVersionChange() {
 	clusterVersion := c.opt.GetClusterVersion()
 	// If the cluster version of PD is less than the minimum version of all stores,
 	// it will update the cluster version.
-	failpoint.Inject("versionChangeConcurrency", func() {
-		time.Sleep(500 * time.Millisecond)
-	})
+	failpoint.InjectCall("versionChangeConcurrency")
 	if minVersion == nil || clusterVersion.Equal(*minVersion) {
 		return
 	}

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1173,7 +1173,7 @@ func TestConcurrentReportBucket(t *testing.T) {
 	bucket2 := &metapb.Buckets{RegionId: 1, Version: 2}
 	var wg sync.WaitGroup
 	wg.Add(1)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/concurrentBucketHeartbeat", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/concurrentBucketHeartbeat", func() { time.Sleep(500 * time.Millisecond) }))
 	go func() {
 		defer wg.Done()
 		err := cluster.processRegionBuckets(bucket1)
@@ -1212,7 +1212,7 @@ func TestConcurrentRegionHeartbeat(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/concurrentRegionHeartbeat", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/concurrentRegionHeartbeat", func() { time.Sleep(500 * time.Millisecond) }))
 	go func() {
 		defer wg.Done()
 		err := cluster.processRegionHeartbeat(core.ContextTODO(), source)

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -226,9 +226,7 @@ func (s *GrpcServer) unaryMiddleware(ctx context.Context, req request, fn forwar
 
 // unaryFollowerMiddleware adds the check of followers enable compared to unaryMiddleware.
 func (s *GrpcServer) unaryFollowerMiddleware(ctx context.Context, req request, fn forwardFn, allowFollower *bool) (rsp any, err error) {
-	failpoint.Inject("customTimeout", func() {
-		time.Sleep(5 * time.Second)
-	})
+	failpoint.InjectCall("customTimeout")
 	forwardedHost := grpcutil.GetForwardedHost(ctx)
 	if !s.isLocalRequest(forwardedHost) {
 		client, err := s.getDelegateClient(ctx, forwardedHost)
@@ -1484,7 +1482,7 @@ func (s *GrpcServer) GetRegion(ctx context.Context, request *pdpb.GetRegionReque
 	defer func() {
 		grpcutil.RequestCounter("GetRegion", request.Header, resp.Header.Error, regionRequestCounter)
 	}()
-	failpoint.Inject("delayProcess", nil)
+	failpoint.InjectCall("delayProcess")
 	rc, header := s.getRaftCluster(*followerHandle)
 	if header != nil {
 		return &pdpb.GetRegionResponse{Header: header}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -452,9 +452,7 @@ func (s *Server) initMember(ctx context.Context, etcd *embed.Etcd) error {
 			}
 		}
 	}
-	failpoint.Inject("memberNil", func() {
-		time.Sleep(1500 * time.Millisecond)
-	})
+	failpoint.InjectCall("memberNil")
 	s.member = member.NewMember(etcd, s.electionClient, etcdServerID)
 	return nil
 }
@@ -662,9 +660,7 @@ func (s *Server) Run() error {
 
 	s.cgMonitor.StartMonitor(s.ctx)
 
-	failpoint.Inject("delayStartServerLoop", func() {
-		time.Sleep(2 * time.Second)
-	})
+	failpoint.InjectCall("delayStartServerLoop")
 	s.startServerLoop(s.ctx)
 
 	return nil
@@ -835,7 +831,7 @@ func (s *Server) createRaftCluster() error {
 }
 
 func (s *Server) stopRaftCluster() {
-	failpoint.Inject("raftclusterIsBusy", func() {})
+	failpoint.InjectCall("raftclusterIsBusy")
 	s.cluster.Stop()
 }
 

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -471,7 +471,7 @@ func TestCustomTimeout(t *testing.T) {
 	defer cli.Close()
 
 	start := time.Now()
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/customTimeout", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/customTimeout", func() { time.Sleep(5 * time.Second) }))
 	_, err = cli.GetAllStores(context.TODO())
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/customTimeout"))
 	re.Error(err)

--- a/tests/integrations/mcs/router/server_test.go
+++ b/tests/integrations/mcs/router/server_test.go
@@ -137,7 +137,7 @@ func (suite *serverTestSuite) TearDownTest() {
 
 func (suite *serverTestSuite) TestStoreAPI() {
 	re := suite.Require()
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/customTimeout", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/customTimeout", func() { time.Sleep(5 * time.Second) }))
 	defer func() {
 		re.NoError(failpoint.Disable("github.com/tikv/pd/server/customTimeout"))
 	}()

--- a/tests/integrations/mcs/tso/api_test.go
+++ b/tests/integrations/mcs/tso/api_test.go
@@ -134,7 +134,7 @@ func mustGetKeyspaceGroupMembers(re *require.Assertions, server *tso.Server) map
 
 func TestTSOServerStartFirst(t *testing.T) {
 	re := require.New(t)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/delayStartServerLoop", func() { time.Sleep(2 * time.Second) }))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/tests/integrations/mcs/tso/keyspace_group_manager_test.go
+++ b/tests/integrations/mcs/tso/keyspace_group_manager_test.go
@@ -463,7 +463,8 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) requestTSO(
 func (suite *tsoKeyspaceGroupManagerTestSuite) TestTSOKeyspaceGroupSplitElection() {
 	re := suite.Require()
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/pauseFinishSplitBeforeTxn", `pause`))
+	ch := make(chan struct{})
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/keyspace/pauseFinishSplitBeforeTxn", func() { <-ch }))
 
 	// Create the keyspace group `oldID` with keyspaces [444, 555, 666].
 	oldID := suite.allocID()
@@ -520,6 +521,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) TestTSOKeyspaceGroupSplitElection
 	})
 	re.Equal(primary1.GetServingUrls(), primary2.GetServingUrls())
 	// Wait for the keyspace groups to finish the split.
+	close(ch)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/pauseFinishSplitBeforeTxn"))
 	waitFinishSplit(re, suite.pdLeaderServer, oldID, newID, []uint32{444}, []uint32{555, 666})
 }

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -371,7 +371,7 @@ func (suite *tsoClientTestSuite) TestUpdateAfterResetTSO() {
 			return err == nil
 		})
 		// Transfer leader back.
-		re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/delaySyncTimestamp", `return(true)`))
+		re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/tso/delaySyncTimestamp", func() { time.Sleep(time.Second) }))
 		err = suite.cluster.GetServer(newLeaderName).ResignLeader()
 		re.NoError(err)
 		// Should NOT panic here.
@@ -457,7 +457,7 @@ func (suite *tsoClientTestSuite) TestRandomShutdown() {
 
 func (suite *tsoClientTestSuite) TestGetTSWhileResettingTSOClient() {
 	re := suite.Require()
-	re.NoError(failpoint.Enable("github.com/tikv/pd/client/clients/tso/delayDispatchTSORequest", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/client/clients/tso/delayDispatchTSORequest", func() { time.Sleep(time.Second) }))
 	var (
 		stopSignal atomic.Bool
 		wg         sync.WaitGroup

--- a/tests/server/api/region_test.go
+++ b/tests/server/api/region_test.go
@@ -613,7 +613,7 @@ func (suite *regionTestSuite) checkRegionsWithKillRequest(cluster *tests.TestClu
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	re.NoError(err)
 	doneCh := make(chan struct{}, 1)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/api/slowRequest", "return(true)"))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/api/slowRequest", func() { time.Sleep(5 * time.Second) }))
 	go func() {
 		resp, err := tests.TestDialClient.Do(req)
 		defer func() {

--- a/tests/server/api/version_test.go
+++ b/tests/server/api/version_test.go
@@ -45,7 +45,7 @@ func TestGetVersion(t *testing.T) {
 	re.NoError(err)
 	defer cluster.Destroy()
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/memberNil", `return(true)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/memberNil", func() { time.Sleep(1500 * time.Millisecond) }))
 	defer func() {
 		re.NoError(failpoint.Disable("github.com/tikv/pd/server/memberNil"))
 	}()

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -877,7 +877,7 @@ func TestStoreVersionChange(t *testing.T) {
 	re.NoError(err)
 	store := newMetaStore(storeID, "mock://tikv-1:1", "2.1.0", metapb.StoreState_Up, getTestDeployPath(storeID))
 	var wg sync.WaitGroup
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/versionChangeConcurrency", `return(true)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/versionChangeConcurrency", func() { time.Sleep(500 * time.Millisecond) }))
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -239,11 +239,13 @@ func TestLeaderResignWithBlock(t *testing.T) {
 	re.NotEmpty(leader1)
 	addr1 := cluster.GetServer(leader1).GetConfig().ClientUrls
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/raftclusterIsBusy", `pause`))
+	ch := make(chan struct{})
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/raftclusterIsBusy", func() { <-ch }))
 	post(t, re, addr1+"/pd/api/v1/leader/resign", "")
 	leader2 := waitLeaderChange(re, cluster, leader1)
 	t.Log("leader2:", leader2)
 	re.NotEqual(leader1, leader2)
+	close(ch)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/raftclusterIsBusy"))
 }
 

--- a/tests/server/server_test.go
+++ b/tests/server/server_test.go
@@ -222,7 +222,8 @@ func TestGRPCRateLimit(t *testing.T) {
 	err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix, jsonBody,
 		testutil.StatusOK(re), testutil.StringContain(re, "gRPC limiter is updated"))
 	re.NoError(err)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayProcess", `pause`))
+	ch := make(chan struct{})
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/delayProcess", func() { <-ch }))
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -256,6 +257,7 @@ func TestGRPCRateLimit(t *testing.T) {
 	}()
 	errStr := <-errCh
 	re.Contains(errStr, "rate limit exceeded")
+	close(ch)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayProcess"))
 	<-okCh
 	wg.Wait()

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -135,7 +135,7 @@ func (s *tsoTestSuite) checkDelaySyncTimestamp(cluster *tests.TestCluster) {
 		Count:  1,
 	}
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/delaySyncTimestamp", `return(true)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/tso/delaySyncTimestamp", func() { time.Sleep(time.Second) }))
 
 	// Make the old leader resign and wait for the new leader to get a lease
 	err := leaderServer.ResignLeaderWithRetry()

--- a/tests/server/watch/leader_watch_test.go
+++ b/tests/server/watch/leader_watch_test.go
@@ -58,7 +58,8 @@ func TestWatcher(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	pd3, err := cluster.Join(ctx)
 	re.NoError(err)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/delayWatcher", `pause`))
+	ch := make(chan struct{})
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/election/delayWatcher", func() { <-ch }))
 	err = pd3.Run()
 	re.NoError(err)
 	re.NotEmpty(cluster.WaitLeader())
@@ -68,6 +69,7 @@ func TestWatcher(t *testing.T) {
 	re.NoError(err)
 	re.NotEmpty(cluster.WaitLeader())
 	re.Equal(pd2.GetConfig().Name, pd2.GetLeader().GetName())
+	close(ch)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/delayWatcher"))
 	testutil.Eventually(re, func() bool {
 		return pd3.GetLeader().GetName() == pd2.GetConfig().Name

--- a/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_group_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -61,7 +62,7 @@ func (suite *keyspaceGroupTestSuite) SetupTest() {
 	re := suite.Require()
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes", `return(true)`))
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/delayStartServerLoop", func() { time.Sleep(2 * time.Second) }))
 
 	suite.idAllocator = mockid.NewIDAllocator()
 	// we test the case which exceed the default max txn ops limit in etcd, which is 128.

--- a/tools/pd-ctl/tests/keyspace/keyspace_test.go
+++ b/tools/pd-ctl/tests/keyspace/keyspace_test.go
@@ -52,7 +52,7 @@ func TestKeyspace(t *testing.T) {
 	defer cancel()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes", `return(true)`))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/fastGroupSplitPatroller", `return(true)`))
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/delayStartServerLoop", func() { time.Sleep(2 * time.Second) }))
 	keyspaces := make([]string, 0)
 	for i := 1; i < 10; i++ {
 		keyspaces = append(keyspaces, fmt.Sprintf("keyspace_%d", i))
@@ -134,7 +134,7 @@ func TestKeyspaceTestsuite(t *testing.T) {
 func (suite *keyspaceTestSuite) SetupTest() {
 	re := suite.Require()
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayStartServerLoop", `return(true)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/delayStartServerLoop", func() { time.Sleep(2 * time.Second) }))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
 	tc, err := pdTests.NewTestClusterWithKeyspaceGroup(suite.ctx, 1)
 	re.NoError(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10297

### What is changed and how does it work?

Migrate 19 simple `failpoint.Inject()` call sites to the newer
`failpoint.InjectCall()` / `failpoint.EnableCall()` APIs. This eliminates
closure bodies from production code and consolidates test injection logic
in test files with type-safe callbacks.

Categories migrated:
- **Empty/nil callbacks** (5 sites): `Inject("name", func(){})` / `nil` → bare `InjectCall("name")`
- **Sleep-only callbacks** (12 sites): move `time.Sleep` to test-side `EnableCall`
- **Panic callbacks** (2 sites): move `panic` to test-side `EnableCall`

For "pause" failpoints, the pattern is converted from
`failpoint.Enable(path, "pause")` to a channel-based
`failpoint.EnableCall(path, func() { <-ch })` approach.

```commit-message
Migrate 19 simple failpoint.Inject() call sites to failpoint.InjectCall() / EnableCall() APIs.

- Empty/nil callbacks (5 sites): bare InjectCall("name")
- Sleep-only callbacks (12 sites): move time.Sleep to test-side EnableCall
- Panic callbacks (2 sites): move panic to test-side EnableCall
- "pause" failpoints converted to channel-based EnableCall pattern
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored failpoint infrastructure to use call-based invocation patterns instead of direct injection.
  * Modernized test synchronization mechanisms to utilize channel-based blocking instead of pause-based approaches.

* **Chores**
  * Simplified failpoint triggers by removing hardcoded delays from production code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->