### PR TITLE
tests: fix flaky TestTransferLeaderForScheduler

### DIFF
--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -1652,7 +1652,7 @@ func TestTransferLeaderForScheduler(t *testing.T) {
 	id = leaderServer.GetAllocator()
 	putRegionWithLeader(re, rc1, id, 1)
 	testutil.Eventually(re, func() bool {
-		return leaderServer.GetRaftCluster().IsPrepared()
+		return rc1.GetCoordinator().AreSchedulersInitialized()
 	})
 	// Check scheduler updated.
 	schedulersController = rc1.GetCoordinator().GetSchedulersController()
@@ -1677,7 +1677,7 @@ func TestTransferLeaderForScheduler(t *testing.T) {
 	id = leaderServer.GetAllocator()
 	putRegionWithLeader(re, rc, id, 1)
 	testutil.Eventually(re, func() bool {
-		return leaderServer.GetRaftCluster().IsPrepared()
+		return rc.GetCoordinator().AreSchedulersInitialized()
 	})
 	// Check scheduler updated
 	schedulersController = rc.GetCoordinator().GetSchedulersController()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10305

### What is changed and how does it work?

```commit-message
Replace `time.Sleep(time.Second)` followed by a direct `re.True(IsPrepared())`
assertion with `testutil.Eventually` to properly wait for the raft cluster to
become prepared after leader transfer. This matches the pattern already used
in the third leader transfer block of the same test.

Under CI resource pressure, a fixed 1-second sleep may not be enough for the
new leader to fully prepare, causing the subsequent scheduler count check to
time out.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced fixed timing in cluster tests with a polling-based wait for scheduler readiness, improving reliability of leader-transfer scenarios and timing-sensitive assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->