### PR TITLE
server/cluster: cancel ctx on Start failure

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -344,6 +344,14 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 	if err != nil {
 		return err
 	}
+	// `Start` may create components that start background goroutines using `c.ctx`.
+	// If a later step fails before `running` is set to true, `Stop` will return
+	// early and cannot reliably clean them up.
+	defer func() {
+		if err != nil {
+			c.cancel()
+		}
+	}()
 	// We should not manage tso service when bootstrap try to start raft cluster.
 	// It only is controlled by leader election.
 	// Ref: https://github.com/tikv/pd/issues/8836

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"math"
 	"math/rand/v2"
@@ -44,6 +45,8 @@ import (
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/id"
+	"github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/pkg/metering"
 	"github.com/tikv/pd/pkg/mock/mockhbstream"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/progress"
@@ -62,6 +65,8 @@ import (
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/keyutil"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
@@ -74,6 +79,100 @@ import (
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+var errBootstrapKeyspaceGroup = stderrors.New("bootstrap keyspace group error")
+
+type failingBootstrapKeyspaceGroupStorage struct {
+	*endpoint.StorageEndpoint
+}
+
+func (*failingBootstrapKeyspaceGroupStorage) SaveKeyspaceGroup(kv.Txn, *endpoint.KeyspaceGroup) error {
+	return errBootstrapKeyspaceGroup
+}
+
+type startFailureTestServer struct {
+	allocator            id.Allocator
+	cfg                  *config.Config
+	persistOptions       *config.PersistOptions
+	storage              storage.Storage
+	hbStreams            *hbstream.HeartbeatStreams
+	raftCluster          *RaftCluster
+	keyspaceGroupManager *keyspace.GroupManager
+	keyspaceEnabled      bool
+}
+
+func (s *startFailureTestServer) GetAllocator() id.Allocator { return s.allocator }
+
+func (s *startFailureTestServer) GetConfig() *config.Config { return s.cfg }
+
+func (s *startFailureTestServer) GetPersistOptions() *config.PersistOptions { return s.persistOptions }
+
+func (s *startFailureTestServer) GetStorage() storage.Storage { return s.storage }
+
+func (s *startFailureTestServer) GetHBStreams() *hbstream.HeartbeatStreams { return s.hbStreams }
+
+func (s *startFailureTestServer) GetRaftCluster() *RaftCluster { return s.raftCluster }
+
+func (s *startFailureTestServer) GetBasicCluster() *core.BasicCluster {
+	return s.raftCluster.BasicCluster
+}
+
+func (*startFailureTestServer) GetMembers() ([]*pdpb.Member, error) { return nil, nil }
+
+func (*startFailureTestServer) ReplicateFileToMember(context.Context, *pdpb.Member, string, []byte) error {
+	return nil
+}
+
+func (*startFailureTestServer) GetKeyspaceManager() *keyspace.Manager { return nil }
+
+func (s *startFailureTestServer) GetKeyspaceGroupManager() *keyspace.GroupManager {
+	return s.keyspaceGroupManager
+}
+
+func (s *startFailureTestServer) IsKeyspaceGroupEnabled() bool { return s.keyspaceEnabled }
+
+func (*startFailureTestServer) GetMeteringWriter() *metering.Writer { return nil }
+
+func TestStartCancelsContextOnBootstrapFailure(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	store := storage.NewStorageWithMemoryBackend()
+	re.NoError(store.SaveMeta(&metapb.Cluster{Id: 1, MaxPeerCount: 1}))
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+
+	rc := &RaftCluster{
+		serverCtx:      ctx,
+		BasicCluster:   core.NewBasicCluster(),
+		storage:        store,
+		storeStateLock: syncutil.NewLockGroup(syncutil.WithRemoveEntryOnUnlock(true)),
+	}
+
+	keyspaceStore := &failingBootstrapKeyspaceGroupStorage{StorageEndpoint: endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)}
+	keyspaceGroupManager := keyspace.NewKeyspaceGroupManager(ctx, keyspaceStore, nil)
+	t.Cleanup(func() {
+		keyspaceGroupManager.Close()
+	})
+
+	server := &startFailureTestServer{
+		allocator:            mockid.NewIDAllocator(),
+		cfg:                  config.NewConfig(),
+		persistOptions:       opt,
+		storage:              store,
+		raftCluster:          rc,
+		keyspaceGroupManager: keyspaceGroupManager,
+		keyspaceEnabled:      true,
+	}
+
+	err = rc.Start(server, true)
+	re.ErrorIs(err, errBootstrapKeyspaceGroup)
+	re.NotNil(rc.regionLabeler)
+	re.NotNil(rc.affinityManager)
+	re.False(rc.IsRunning())
+	re.NotNil(rc.ctx)
+	re.ErrorIs(rc.ctx.Err(), context.Canceled)
 }
 
 func TestStoreHeartbeat(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10309

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
fix RaftCluster.Start leaks goroutines on startup failure
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test

Code changes


Side effects


Related changes

- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cluster initialization robustness by ensuring all background processes are properly terminated if startup fails, preventing resource leaks and enhancing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->