### PR TITLE
schedule, server: harden scheduler config input validation

### DIFF
--- a/pkg/schedule/schedulers/balance_range.go
+++ b/pkg/schedule/schedulers/balance_range.go
@@ -90,27 +90,48 @@ func (handler *balanceRangeSchedulerHandler) addJob(w http.ResponseWriter, r *ht
 		Status:  pending,
 		Timeout: defaultJobTimeout,
 	}
-	job.Engine = input["engine"].(string)
-	if job.Engine != core.EngineTiFlash && job.Engine != core.EngineTiKV {
-		handler.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("engine:%s must be tikv or tiflash", input["engine"].(string)))
+	engine, ok := input["engine"].(string)
+	if !ok || len(engine) == 0 {
+		handler.rd.JSON(w, http.StatusBadRequest, "engine is required and must be a string")
 		return
 	}
-	job.Rule = core.NewRule(input["rule"].(string))
+	job.Engine = engine
+	if job.Engine != core.EngineTiFlash && job.Engine != core.EngineTiKV {
+		handler.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("engine:%s must be tikv or tiflash", job.Engine))
+		return
+	}
+	ruleStr, ok := input["rule"].(string)
+	if !ok || len(ruleStr) == 0 {
+		handler.rd.JSON(w, http.StatusBadRequest, "rule is required and must be a string")
+		return
+	}
+	job.Rule = core.NewRule(ruleStr)
 	if job.Rule != core.LeaderScatter && job.Rule != core.PeerScatter && job.Rule != core.LearnerScatter {
 		handler.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("rule:%s must be leader-scatter, learner-scatter or peer-scatter",
-			input["engine"].(string)))
+			ruleStr))
 		return
 	}
 
-	job.Alias = input["alias"].(string)
-	timeoutStr, ok := input["timeout"].(string)
-	if ok && len(timeoutStr) > 0 {
-		timeout, err := time.ParseDuration(timeoutStr)
-		if err != nil {
-			handler.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("timeout:%s is invalid", input["timeout"].(string)))
+	alias, ok := input["alias"].(string)
+	if !ok || len(alias) == 0 {
+		handler.rd.JSON(w, http.StatusBadRequest, "alias is required and must be a string")
+		return
+	}
+	job.Alias = alias
+	if timeoutVal, exists := input["timeout"]; exists {
+		timeoutStr, ok := timeoutVal.(string)
+		if !ok {
+			handler.rd.JSON(w, http.StatusBadRequest, "timeout must be a string")
 			return
 		}
-		job.Timeout = timeout
+		if len(timeoutStr) > 0 {
+			timeout, err := time.ParseDuration(timeoutStr)
+			if err != nil {
+				handler.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("timeout:%s is invalid", timeoutStr))
+				return
+			}
+			job.Timeout = timeout
+		}
 	}
 
 	keys, err := keyutil.DecodeHTTPKeyRanges(input)
@@ -327,6 +348,9 @@ func (job *balanceRangeSchedulerJob) expired(dur time.Duration) bool {
 }
 
 func (job *balanceRangeSchedulerJob) shouldFinished() bool {
+	if job == nil || job.Start == nil {
+		return true
+	}
 	return time.Since(*job.Start) > job.Timeout
 }
 

--- a/pkg/schedule/schedulers/balance_range_test.go
+++ b/pkg/schedule/schedulers/balance_range_test.go
@@ -15,7 +15,11 @@
 package schedulers
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
@@ -23,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/failpoint"
+	"github.com/unrolled/render"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/schedule/operator"
@@ -515,4 +520,40 @@ func TestPersistFail(t *testing.T) {
 	conf.jobs[0].Finish = &finishedTime
 	re.ErrorContains(conf.gcLocked(), errMsg)
 	re.Len(conf.jobs, 1)
+}
+
+func TestAddBalanceRangeJobWithInvalidFieldType(t *testing.T) {
+	re := require.New(t)
+	conf := &balanceRangeSchedulerConfig{
+		schedulerConfig: &baseSchedulerConfig{},
+		jobs:            make([]*balanceRangeSchedulerJob, 0),
+	}
+	conf.init("test", storage.NewStorageWithMemoryBackend(), conf)
+	handler := &balanceRangeSchedulerHandler{
+		config: conf,
+		rd:     render.New(render.Options{IndentJSON: true}),
+	}
+	body, err := json.Marshal(map[string]any{
+		"alias":     "a",
+		"engine":    1,
+		"rule":      "leader-scatter",
+		"start-key": "100",
+		"end-key":   "200",
+	})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPut, "/job", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	re.NotPanics(func() {
+		handler.addJob(resp, req)
+	})
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Empty(conf.jobs)
+}
+
+func TestJobShouldFinishedWhenStartTimeIsMissing(t *testing.T) {
+	re := require.New(t)
+	job := &balanceRangeSchedulerJob{Timeout: time.Minute}
+	re.True(job.shouldFinished())
+	job = nil
+	re.True(job.shouldFinished())
 }

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -173,12 +173,13 @@ func (conf *evictLeaderSchedulerConfig) resumeLeaderTransfer(cluster sche.Schedu
 func (conf *evictLeaderSchedulerConfig) pauseLeaderTransferIfStoreNotExist(id uint64) (bool, error) {
 	conf.RLock()
 	defer conf.RUnlock()
-	if _, exist := conf.StoreIDWithRanges[id]; !exist {
-		if err := conf.cluster.PauseLeaderTransfer(id, constant.In); err != nil {
-			return exist, err
-		}
+	if _, exist := conf.StoreIDWithRanges[id]; exist {
+		return true, nil
 	}
-	return true, nil
+	if err := conf.cluster.PauseLeaderTransfer(id, constant.In); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 func (conf *evictLeaderSchedulerConfig) resumeLeaderTransferIfExist(id uint64) {
@@ -427,8 +428,28 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 		batch = (int)(batchFloat)
 	}
 
-	ranges, ok := (input["ranges"]).([]string)
-	if ok {
+	var ranges []string
+	rangesVal, hasRanges := input["ranges"]
+	if hasRanges {
+		switch val := rangesVal.(type) {
+		case []string:
+			ranges = val
+		case []any:
+			ranges = make([]string, 0, len(val))
+			for _, item := range val {
+				s, ok := item.(string)
+				if !ok {
+					handler.config.resumeLeaderTransferIfExist(id)
+					handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig.FastGenByArgs("ranges"))
+					return
+				}
+				ranges = append(ranges, s)
+			}
+		default:
+			handler.config.resumeLeaderTransferIfExist(id)
+			handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig.FastGenByArgs("ranges"))
+			return
+		}
 		if !inputHasStoreID {
 			handler.config.resumeLeaderTransferIfExist(id)
 			handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig.FastGenByArgs("id"))

--- a/pkg/schedule/schedulers/evict_leader_test.go
+++ b/pkg/schedule/schedulers/evict_leader_test.go
@@ -17,9 +17,12 @@ package schedulers
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unrolled/render"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -250,4 +253,60 @@ func TestEvictLeaderDeleteWithSaveFailure(t *testing.T) {
 	re.Contains(conf.StoreIDWithRanges, uint64(1), "store should be restored after save failure")
 	re.Equal(keyRanges, conf.StoreIDWithRanges[1], "key ranges should be restored")
 	re.Empty(resp)
+}
+
+func TestEvictLeaderUpdateConfigWithStringArrayRanges(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLeaderStore(1, 0)
+	conf := &evictLeaderSchedulerConfig{
+		schedulerConfig:   &baseSchedulerConfig{},
+		StoreIDWithRanges: make(map[uint64][]keyutil.KeyRange),
+		Batch:             EvictLeaderBatchSize,
+		cluster:           tc.GetBasicCluster(),
+	}
+	conf.init("evict-leader-test", storage.NewStorageWithMemoryBackend(), conf)
+	handler := &evictLeaderHandler{config: conf, rd: render.New(render.Options{IndentJSON: true})}
+	body, err := json.Marshal(map[string]any{
+		"store_id": 1,
+		"ranges":   []string{"100", "200"},
+	})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	re.NotPanics(func() {
+		handler.updateConfig(resp, req)
+	})
+	re.Equal(http.StatusOK, resp.Code)
+	re.Len(conf.StoreIDWithRanges[1], 1)
+	re.Equal(keyutil.NewKeyRange("100", "200"), conf.StoreIDWithRanges[1][0])
+}
+
+func TestEvictLeaderUpdateConfigWithInvalidRangesType(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLeaderStore(1, 0)
+	conf := &evictLeaderSchedulerConfig{
+		schedulerConfig:   &baseSchedulerConfig{},
+		StoreIDWithRanges: make(map[uint64][]keyutil.KeyRange),
+		Batch:             EvictLeaderBatchSize,
+		cluster:           tc.GetBasicCluster(),
+	}
+	conf.init("evict-leader-test", storage.NewStorageWithMemoryBackend(), conf)
+	handler := &evictLeaderHandler{config: conf, rd: render.New(render.Options{IndentJSON: true})}
+	body, err := json.Marshal(map[string]any{
+		"store_id": 1,
+		"ranges":   []any{"100", 200},
+	})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	re.NotPanics(func() {
+		handler.updateConfig(resp, req)
+	})
+	re.Equal(http.StatusBadRequest, resp.Code)
 }

--- a/pkg/schedule/schedulers/grant_hot_region.go
+++ b/pkg/schedule/schedulers/grant_hot_region.go
@@ -189,7 +189,12 @@ func (handler *grantHotRegionHandler) updateConfig(w http.ResponseWriter, r *htt
 		}
 		storeIDs = append(storeIDs, id)
 	}
-	leaderID, err := strconv.ParseUint(input["store-leader-id"].(string), 10, 64)
+	leaderStr, ok := input["store-leader-id"].(string)
+	if !ok {
+		handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig)
+		return
+	}
+	leaderID, err := strconv.ParseUint(leaderStr, 10, 64)
 	if err != nil {
 		handler.rd.JSON(w, http.StatusBadRequest, errs.ErrBytesToUint64)
 		return

--- a/pkg/schedule/schedulers/grant_hot_region_test.go
+++ b/pkg/schedule/schedulers/grant_hot_region_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unrolled/render"
+)
+
+func TestGrantHotRegionUpdateConfigWithInvalidLeaderIDType(t *testing.T) {
+	re := require.New(t)
+	handler := &grantHotRegionHandler{
+		config: &grantHotRegionSchedulerConfig{},
+		rd:     render.New(render.Options{IndentJSON: true}),
+	}
+	body, err := json.Marshal(map[string]any{
+		"store-id":        "1,2",
+		"store-leader-id": 1,
+	})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	re.NotPanics(func() {
+		handler.updateConfig(resp, req)
+	})
+	re.Equal(http.StatusBadRequest, resp.Code)
+}

--- a/pkg/schedule/schedulers/grant_leader.go
+++ b/pkg/schedule/schedulers/grant_leader.go
@@ -265,8 +265,32 @@ func (handler *grantLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 		args = append(args, strconv.FormatUint(id, 10))
 	}
 
-	ranges, ok := (input["ranges"]).([]string)
-	if ok {
+	rangesVal, hasRanges := input["ranges"]
+	if hasRanges {
+		var ranges []string
+		switch val := rangesVal.(type) {
+		case []string:
+			ranges = val
+		case []any:
+			ranges = make([]string, 0, len(val))
+			for _, item := range val {
+				s, ok := item.(string)
+				if !ok {
+					handler.config.Lock()
+					handler.config.cluster.ResumeLeaderTransfer(id, constant.Out)
+					handler.config.Unlock()
+					handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig.FastGenByArgs("ranges"))
+					return
+				}
+				ranges = append(ranges, s)
+			}
+		default:
+			handler.config.Lock()
+			handler.config.cluster.ResumeLeaderTransfer(id, constant.Out)
+			handler.config.Unlock()
+			handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig.FastGenByArgs("ranges"))
+			return
+		}
 		args = append(args, ranges...)
 	} else if exists {
 		args = append(args, handler.config.getRanges(id)...)

--- a/pkg/schedule/schedulers/grant_leader_test.go
+++ b/pkg/schedule/schedulers/grant_leader_test.go
@@ -15,13 +15,19 @@
 package schedulers
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/unrolled/render"
 
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/keyutil"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
 )
 
@@ -59,4 +65,58 @@ func TestGrantLeaderScheduler(t *testing.T) {
 	// balance leader scheduler should not add operator from store 3 to store 1
 	ops, _ = bls.Schedule(tc, false)
 	re.Empty(ops)
+}
+
+func TestGrantLeaderUpdateConfigWithStringArrayRanges(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLeaderStore(1, 0)
+	conf := &grantLeaderSchedulerConfig{
+		schedulerConfig:   &baseSchedulerConfig{},
+		StoreIDWithRanges: make(map[uint64][]keyutil.KeyRange),
+		cluster:           tc.GetBasicCluster(),
+	}
+	conf.init("grant-leader-test", storage.NewStorageWithMemoryBackend(), conf)
+	handler := &grantLeaderHandler{config: conf, rd: render.New(render.Options{IndentJSON: true})}
+	body, err := json.Marshal(map[string]any{
+		"store_id": 1,
+		"ranges":   []string{"100", "200"},
+	})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	re.NotPanics(func() {
+		handler.updateConfig(resp, req)
+	})
+	re.Equal(http.StatusOK, resp.Code)
+	re.Len(conf.StoreIDWithRanges[1], 1)
+	re.Equal(keyutil.NewKeyRange("100", "200"), conf.StoreIDWithRanges[1][0])
+}
+
+func TestGrantLeaderUpdateConfigWithInvalidRangesType(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, _ := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLeaderStore(1, 0)
+	conf := &grantLeaderSchedulerConfig{
+		schedulerConfig:   &baseSchedulerConfig{},
+		StoreIDWithRanges: make(map[uint64][]keyutil.KeyRange),
+		cluster:           tc.GetBasicCluster(),
+	}
+	conf.init("grant-leader-test", storage.NewStorageWithMemoryBackend(), conf)
+	handler := &grantLeaderHandler{config: conf, rd: render.New(render.Options{IndentJSON: true})}
+	body, err := json.Marshal(map[string]any{
+		"store_id": 1,
+		"ranges":   []any{"100", 200},
+	})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	re.NotPanics(func() {
+		handler.updateConfig(resp, req)
+	})
+	re.Equal(http.StatusBadRequest, resp.Code)
 }

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -429,8 +429,13 @@ func (c *Controller) CheckTransferWitnessLeader(region *core.RegionInfo) {
 		s, ok := c.schedulers[types.TransferWitnessLeaderScheduler.String()]
 		c.RUnlock()
 		if ok {
+			regionC := RecvRegionInfo(s.Scheduler)
+			if regionC == nil {
+				log.Warn("invalid scheduler type for transfer witness leader", zap.String("scheduler", s.GetName()))
+				return
+			}
 			select {
-			case RecvRegionInfo(s.Scheduler) <- region:
+			case regionC <- region:
 			default:
 				log.Warn("drop transfer witness leader due to recv region channel full", zap.Uint64("region-id", region.GetID()))
 			}

--- a/pkg/schedule/schedulers/transfer_witness_leader.go
+++ b/pkg/schedule/schedulers/transfer_witness_leader.go
@@ -114,5 +114,8 @@ func scheduleTransferWitnessLeader(name string, cluster sche.SchedulerCluster, r
 
 // RecvRegionInfo receives a checked region from coordinator
 func RecvRegionInfo(s Scheduler) chan<- *core.RegionInfo {
-	return s.(*transferWitnessLeaderScheduler).regions
+	if scheduler, ok := s.(*transferWitnessLeaderScheduler); ok {
+		return scheduler.regions
+	}
+	return nil
 }

--- a/pkg/schedule/schedulers/transfer_witness_leader_test.go
+++ b/pkg/schedule/schedulers/transfer_witness_leader_test.go
@@ -89,3 +89,11 @@ func TestTransferWitnessLeaderWithUnhealthyPeer(t *testing.T) {
 	ops, _ = sl.Schedule(tc, false)
 	re.Empty(ops)
 }
+
+func TestRecvRegionInfoWithWrongSchedulerType(t *testing.T) {
+	re := require.New(t)
+	var s Scheduler = &balanceRangeScheduler{}
+	re.NotPanics(func() {
+		re.Nil(RecvRegionInfo(s))
+	})
+}

--- a/server/api/scheduler.go
+++ b/server/api/scheduler.go
@@ -125,15 +125,19 @@ func (h *schedulerHandler) CreateScheduler(w http.ResponseWriter, r *http.Reques
 				handler.ServeHTTP(w, r)
 				return
 			}
-			h.r.JSON(w, http.StatusNotAcceptable, err.Error())
+			if err != nil {
+				h.r.JSON(w, http.StatusNotAcceptable, err.Error())
+				return
+			}
+			h.r.JSON(w, http.StatusNotAcceptable, "scheduler config handler is unavailable")
 			return
 		}
 		if err := apiutil.CollectStringOption("rule", input, collector); err != nil {
-			h.r.JSON(w, http.StatusInternalServerError, err.Error())
+			h.r.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		if err := apiutil.CollectStringOption("engine", input, collector); err != nil {
-			h.r.JSON(w, http.StatusInternalServerError, err.Error())
+			h.r.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -142,13 +146,13 @@ func (h *schedulerHandler) CreateScheduler(w http.ResponseWriter, r *http.Reques
 			if errors.ErrorEqual(err, errs.ErrOptionNotExist) {
 				collector(defaultTimeout)
 			} else {
-				h.r.JSON(w, http.StatusInternalServerError, err.Error())
+				h.r.JSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
 		}
 
 		if err := apiutil.CollectStringOption("alias", input, collector); err != nil {
-			h.r.JSON(w, http.StatusInternalServerError, err.Error())
+			h.r.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -298,7 +302,11 @@ func (h *schedulerHandler) redirectSchedulerDelete(w http.ResponseWriter, name, 
 	}
 	resp, err := apiutil.DoDelete(h.svr.GetHTTPClient(), deleteURL)
 	if err != nil {
-		h.r.JSON(w, resp.StatusCode, err.Error())
+		status := http.StatusInternalServerError
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		h.r.JSON(w, status, err.Error())
 		return
 	}
 	defer resp.Body.Close()
@@ -373,5 +381,9 @@ func (h *schedulerConfigHandler) handleSchedulerConfig(w http.ResponseWriter, r 
 		sh.ServeHTTP(w, r)
 		return
 	}
-	h.rd.JSON(w, http.StatusNotAcceptable, err.Error())
+	if err != nil {
+		h.rd.JSON(w, http.StatusNotAcceptable, err.Error())
+		return
+	}
+	h.rd.JSON(w, http.StatusNotAcceptable, "scheduler config handler is unavailable")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

### What is changed and how does it work?

```commit-message
Improve scheduler API handler robustness by validating request payload types before casting to concrete types, and return clear 4xx errors for invalid input instead of panics or 5xx responses. Also harden scheduler internals against nil/wrong-type assumptions and add focused unit tests that assert invalid payloads no longer panic.
```

### Check List

Tests

- Unit test

Code changes

- Has HTTP APIs changed

### Release note

```release-note
Fix scheduler API handlers to gracefully reject malformed config payloads and avoid panic paths in scheduler internals.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in scheduler configuration with appropriate HTTP status codes for invalid input scenarios.
  * Added nil-safety checks to prevent potential panics during scheduler operations.
  * Enhanced robustness of input validation for configuration updates across schedulers.

* **Tests**
  * Extended test coverage for invalid input types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->