### PR TITLE
*: upgrade Golang to 1.25.8, dependencies, and fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,9 +77,17 @@ linters:
         limitations under the License.
     gosec:
       excludes:
-        - G402
-        - G404
-        - G115
+        - G115 # Integer overflow in type conversions — too many false positives in Go's type system
+        - G118 # context cancel not called — can't trace cancel through goroutines/sync.Once/structs/returns
+        - G120 # Form data without body size limit — PD HTTP endpoints are internal admin APIs
+        - G123 # TLS session resumption may bypass VerifyPeerCertificate — CN check is additional to standard TLS
+        - G402 # TLS MinVersion — PD supports configurable TLS for backward compatibility
+        - G404 # Insecure random source — already banned by depguard, uses math/rand/v2
+        - G602 # Slice index out of range — high false positive rate, Go has runtime bounds checking
+        - G702 # Command injection taint — only in dev tools executing self-built test binaries
+        - G704 # SSRF taint — PD is a distributed coordinator that forwards requests by design
+        - G705 # XSS taint — PD is a JSON API service, not an HTML web app
+        - G706 # Log injection taint — only in CLI tools logging their own arguments
     perfsprint:
       string-format: false
     revive:

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ SHELL := env PATH='$(PATH)' GOBIN='$(GO_TOOLS_BIN_PATH)' $(shell which bash)
 
 install-tools:
 	@mkdir -p $(GO_TOOLS_BIN_PATH)
-	@which golangci-lint >/dev/null 2>&1 || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_TOOLS_BIN_PATH) v2.6.0
+	@which golangci-lint >/dev/null 2>&1 || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GO_TOOLS_BIN_PATH) v2.11.2
 	@which promtool >/dev/null 2>&1 || { \
 		GOWORK=off go mod download github.com/prometheus/prometheus@v0.310.0; \
 		prom_dir=$$(go env GOMODCACHE)/github.com/prometheus/prometheus@v0.310.0; \

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/client
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/client
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd
 
-go 1.25.7
+go 1.25.8
 
 // When you modify PD cooperatively with kvproto, this will be useful to submit the PR to PD and the PR to
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd
 
-go 1.25.6
+go 1.25.7
 
 // When you modify PD cooperatively with kvproto, this will be useful to submit the PR to PD and the PR to
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -1353,7 +1353,7 @@ func accelerateRegionsScheduleInRanges(c *gin.Context) {
 		}
 		startKeys = append(startKeys, startKey)
 		endKeys = append(endKeys, endKey)
-		msgBuilder.WriteString(fmt.Sprintf("[%s,%s), ", rawStartKey, rawEndKey))
+		fmt.Fprintf(&msgBuilder, "[%s,%s), ", rawStartKey, rawEndKey)
 	}
 	err = handler.AccelerateRegionsScheduleInRanges(startKeys, endKeys, limit)
 	if err != nil {

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -823,7 +823,7 @@ func (mc *Cluster) PutRegionStores(id uint64, stores ...uint64) {
 // PutStoreWithLabels mocks method.
 func (mc *Cluster) PutStoreWithLabels(id uint64, labelPairs ...string) {
 	labels := make(map[string]string)
-	for i := 0; i < len(labelPairs); i += 2 {
+	for i := 0; i+1 < len(labelPairs); i += 2 {
 		labels[labelPairs[i]] = labelPairs[i+1]
 	}
 	mc.AddLabelsStore(id, 0, labels)

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -567,7 +567,7 @@ func (suite *mergeCheckerTestSuite) TestCache() {
 
 func makeKeyRanges(keys ...string) []any {
 	var res []any
-	for i := 0; i < len(keys); i += 2 {
+	for i := 0; i+1 < len(keys); i += 2 {
 		res = append(res, map[string]any{"start_key": keys[i], "end_key": keys[i+1]})
 	}
 	return res

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -431,7 +431,7 @@ func (l *RegionLabeler) GetRegionLabels(region *core.RegionInfo) []*RegionLabel 
 // MakeKeyRanges is a helper function to make key ranges.
 func MakeKeyRanges(keys ...string) []any {
 	var res []any
-	for i := 0; i < len(keys); i += 2 {
+	for i := 0; i+1 < len(keys); i += 2 {
 		res = append(res, map[string]any{"start_key": keys[i], "end_key": keys[i+1]})
 	}
 	return res

--- a/pkg/schedule/labeler/rules.go
+++ b/pkg/schedule/labeler/rules.go
@@ -58,7 +58,7 @@ type LabelRule struct {
 
 func (rule *LabelRule) String() string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("id: %s, index: %d, type: %s", rule.ID, rule.Index, rule.RuleType))
+	fmt.Fprintf(&b, "id: %s, index: %d, type: %s", rule.ID, rule.Index, rule.RuleType)
 	b.WriteString(", labels: ")
 	for i, l := range rule.Labels {
 		if i == 0 {
@@ -77,7 +77,7 @@ func (rule *LabelRule) String() string {
 		if i == 0 {
 			b.WriteString("[")
 		}
-		b.WriteString(fmt.Sprintf("startKey: {%s}, endKey: {%s}", r.StartKeyHex, r.EndKeyHex))
+		fmt.Fprintf(&b, "startKey: {%s}, endKey: {%s}", r.StartKeyHex, r.EndKeyHex)
 		if i == len(ranges)-1 {
 			b.WriteString("]")
 		} else {

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -816,7 +816,7 @@ func (h *regionsHandler) AccelerateRegionsScheduleInRanges(w http.ResponseWriter
 		}
 		startKeys = append(startKeys, startKey)
 		endKeys = append(endKeys, endKey)
-		msgBuilder.WriteString(fmt.Sprintf("[%s,%s), ", rawStartKey, rawEndKey))
+		fmt.Fprintf(&msgBuilder, "[%s,%s), ", rawStartKey, rawEndKey)
 	}
 	err = h.Handler.AccelerateRegionsScheduleInRanges(startKeys, endKeys, limit)
 	if err != nil {

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/tests/integrations
 
-go 1.25.7
+go 1.25.8
 
 replace (
 	github.com/tikv/pd => ../../

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/tests/integrations
 
-go 1.25.6
+go 1.25.7
 
 replace (
 	github.com/tikv/pd => ../../

--- a/tests/server/api/region_label_test.go
+++ b/tests/server/api/region_label_test.go
@@ -117,7 +117,7 @@ func (suite *regionLabelTestSuite) checkGetSet(cluster *tests.TestCluster) {
 
 func makeKeyRanges(keys ...string) []any {
 	var res []any
-	for i := 0; i < len(keys); i += 2 {
+	for i := 0; i+1 < len(keys); i += 2 {
 		res = append(res, map[string]any{"start_key": keys[i], "end_key": keys[i+1]})
 	}
 	return res

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/tools
 
-go 1.25.7
+go 1.25.8
 
 replace (
 	github.com/tikv/pd => ../

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/tools
 
-go 1.25.6
+go 1.25.7
 
 replace (
 	github.com/tikv/pd => ../


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10314

### What is changed and how does it work?

```commit-message
Upgrade Golang from 1.25.6 to 1.25.8 and bump tidb-dashboard dependency.

Upgrade golangci-lint from v2.6.0 to v2.11.2, which introduces new gosec
rules. Add documented exclusions for 8 gosec rules (G118, G120, G123,
G602, G702, G704, G705, G706) that have high false-positive rates in
PD's context as an internal distributed systems component.

Fix 4 potential slice out-of-bounds in key-pair iteration loops by
changing `i < len(keys)` to `i+1 < len(keys)`. Replace 4
`WriteString(fmt.Sprintf(...))` with `fmt.Fprintf()` to avoid
intermediate string allocations.
```

### Check List

Tests

- Unit test
- No code

Code changes

- Has the configuration change

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Go toolchain to 1.25.8 across modules.
  * Updated lint tooling installer/version and expanded linter exclude list.

* **Bug Fixes**
  * Fixed out-of-bounds handling when constructing key-range pairs to prevent rare panics.

* **Tests**
  * Updated tests to align with the key-range pairing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->