### PR TITLE
tests: stabilize TestSwitchModeDuringWorkload

### DIFF
--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -487,6 +487,11 @@ func TestSwitchModeDuringWorkload(t *testing.T) {
 				waitResourceManagerServiceURL(re, cli, false)
 			}
 			waitLeaderServingClient(re, cli, leader.GetAddr())
+			testutil.Eventually(re, func() bool {
+				// Switching endpoint can transiently leave the controller in degraded mode
+				// until the first successful token-bucket response arrives.
+				return !rgController.IsDegraded()
+			}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 
 			switched.Store(true)
 			testutil.Eventually(re, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10154

`TestSwitchModeDuringWorkload/pd-to-standalone` is flaky.

### What is changed and how does it work?

Root-cause evidence chain

- Issue #10154 and recent rerun logs fail at:
  - `pkg/utils/testutil/testutil.go:68`
  - `tests/integrations/mcs/resourcemanager/resource_manager_test.go:492`
  - `Condition never satisfied`.
- CI job logs (`22856930709` / `66299693231`) show transient RM discovery/connectivity errors around the switch window, e.g. repeated `resource manager error` with `connection refused`, while the test already starts counting post-switch success.
- Current test only gates on leader/service-url checks before setting `switched=true`, but the controller may still be in transient degraded mode until the first successful token-bucket response after endpoint switch.
- Therefore `okAfter` can stay below threshold in the bounded wait even though switch eventually recovers.

Historical analog

- Pattern: `flaky_stabilization` + `test_harness_alignment` from flaky fix playbook.
- Closest corpus analog: #10203 (test readiness synchronization during transient service state) and #10134 (unstable-test stabilization with explicit readiness conditions).

- In `TestSwitchModeDuringWorkload`, after switch + leader/service routing checks and before enabling post-switch counting, add an explicit wait:
  - `testutil.Eventually(... !rgController.IsDegraded() ...)`
- This keeps test intent unchanged (must make post-switch progress), but removes the race where counting starts while controller is still transiently degraded.

Risk

- Low risk; test-only change.
- Slightly longer wait in rare slow environments (bounded to 30s) to avoid false negatives.

Verification

- Focused verification (pass):
  - `cd tests/integrations && make gotest GOTEST_ARGS='-tags without_dashboard ./mcs/resourcemanager -run TestSwitchModeDuringWorkload -count=3'`
  - Result: `ok github.com/tikv/pd/tests/integrations/mcs/resourcemanager 431.983s`
- Baseline verification (has unrelated pre-existing failures in this run):
  - `make basic-test`
  - Result: failed with non-touched-scope flakes/noise in this environment:
    - `pkg/gctuner`: goleak (unexpected goroutine in `memory_limit_tuner`)
    - `pkg/storage/endpoint`: `TestDataPhysicalRepresentation` expected path mismatch (`/pd/0/...` vs `/pd/<cluster-id>/...`)

### Check List


### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability by adding synchronization checks when switching resource manager deployment modes, ensuring proper controller recovery before test continuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
