### PR TITLE
metrics: add PD_leader_service_stuck alert for etcd-leader without PD service

### DIFF
--- a/metrics/alertmanager/pd.rules.yml
+++ b/metrics/alertmanager/pd.rules.yml
@@ -165,7 +165,7 @@ groups:
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, PD service is not the PD leader while being the embedded etcd leader; values:{{ $value }}'
       value: '{{ $value }}'
-      summary: PD leader service is stuck in non-leader state
+      summary: PD service is not the leader while embedded etcd leader is healthy
 
   - alert: PD_cluster_store_space_used_more_than_80%
     expr: sum(pd_cluster_status{type="storage_size"}) / sum(pd_cluster_status{type="storage_capacity"}) * 100  > 80

--- a/tests/alertmanager/pd.rules.test.yml
+++ b/tests/alertmanager/pd.rules.test.yml
@@ -142,7 +142,7 @@ tests:
               instance: pd-1
               expr: '(service_member_role{job="pd",service="PD"} == 0) and on(instance,job) (etcd_server_is_leader{job="pd"} == 1)'
             exp_annotations:
-              summary: 'PD leader service is stuck in non-leader state'
+              summary: 'PD service is not the leader while embedded etcd leader is healthy'
               description: 'cluster: ENV_LABELS_ENV, instance: pd-1, PD service is not the PD leader while being the embedded etcd leader; values:0'
               value: '0'
       - eval_time: 6m
@@ -156,7 +156,7 @@ tests:
               instance: pd-1
               expr: '(service_member_role{job="pd",service="PD"} == 0) and on(instance,job) (etcd_server_is_leader{job="pd"} == 1)'
             exp_annotations:
-              summary: 'PD leader service is stuck in non-leader state'
+              summary: 'PD service is not the leader while embedded etcd leader is healthy'
               description: 'cluster: ENV_LABELS_ENV, instance: pd-1, PD service is not the PD leader while being the embedded etcd leader; values:0'
               value: '0'
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10320

When `service_member_role` drops to `0` and never recovers — while `etcd_server_is_leader` stays stable and the process has not restarted — no existing alert fires. The cluster has no PD leader serving requests, but the entire alert suite is silent (see issue for the full per-rule analysis).

### What is changed and how does it work?

Add `PD_leader_service_stuck` (level: critical, `for: 1m`):

```promql
(service_member_role{job="pd",service="PD"} == 0)
and on(instance,job) (etcd_server_is_leader{job="pd"} == 1)
```

Fires when the etcd-leader node's PD service layer is not serving as PD leader for a sustained period. Normal failovers are naturally excluded: when etcd leadership transfers, the departing node's `etcd_server_is_leader` drops to `0`, making the join condition false without any extra suppression logic.

Two `promtool` unit tests are added:
- **`pd-leader-service-stuck`** — positive: service drops at minute 3, stays down, fires at `eval_time: 6m`
- **`pd-leader-service-stuck-suppressed-by-failover`** — negative: pd-1 loses both PD and etcd leadership to pd-2; no alert fires

```commit-message
When service_member_role drops to 0 and never recovers while
etcd_server_is_leader stays stable, no existing alert fires:
- PD_leader_lease_drop_without_failover requires service_member_role==1
  at eval time and changes>=2 (persistent drop gives changes==1, value=0)
- PD_leader_change detects TSO-save handoff; with no active PD leader,
  no saves are emitted and the count stays below threshold
- All cluster-health alerts rely on pd_cluster_status/pd_regions_status,
  which are only emitted by the active PD leader

Add PD_leader_service_stuck (critical, for:1m) that fires when the etcd
leader node's PD service layer is not serving as PD leader. Normal
failovers are naturally excluded: when etcd leadership transfers, the
departing node's etcd_server_is_leader drops to 0, making the join
condition false without any extra suppression logic.
```

### Check List

Tests

- Unit test

Code changes

- No code (alert rule + promtool tests only)

Side effects

- None

### Release note

```release-note
Add `PD_leader_service_stuck` alert (critical) that fires when the embedded etcd leader node's PD service layer is not serving as PD leader for more than 1 minute, covering a previously undetected failure mode where no existing alert would trigger.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a critical alert that detects when a PD service is not acting as leader while the embedded etcd reports leader health; includes severity, summary, description and a 1-minute firing window.

* **Tests**
  * Added alert tests for stuck-service, failover-suppressed, and staggered-failover scenarios with multiple evaluation times to validate alert firing and suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->