### PR TITLE
resource_group: set FillRate in non-trickle token bucket responses

### DIFF
--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -543,8 +543,11 @@ func (gtb *GroupTokenBucket) request(
 	slot, ok := gtb.tokenSlots[clientUniqueID]
 	if !ok {
 		return &rmpb.TokenBucket{
-			Settings: &rmpb.TokenLimitSettings{BurstLimit: burstLimit},
-			Tokens:   0.0,
+			Settings: &rmpb.TokenLimitSettings{
+				BurstLimit: burstLimit,
+				FillRate:   uint64(gtb.getFillRate()),
+			},
+			Tokens: 0.0,
 		}, 0
 	}
 	if requiredToken > 0 && slot.fillRate == 0 {
@@ -588,6 +591,7 @@ func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint
 	}
 	// FillRate is used for the token server unavailable in abnormal situation.
 	if requiredToken <= 0 {
+		res.Settings.FillRate = ts.fillRate
 		return res, 0
 	}
 	if ts.fillRate == 0 {
@@ -601,6 +605,7 @@ func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint
 		ts.curTokenCapacity -= requiredToken
 		// granted the total request tokens
 		res.Tokens = requiredToken
+		res.Settings.FillRate = ts.fillRate
 		return res, 0
 	}
 

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -164,10 +164,16 @@ func TestGroupTokenBucketRequest(t *testing.T) {
 	tb, trickle := gtb.request(time1, 190000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
 	re.LessOrEqual(math.Abs(tb.Tokens-190000), 1e-7)
 	re.Zero(trickle)
+	// Non-trickle response must carry the slot's FillRate so the client limiter
+	// can refill tokens locally and avoid InfDuration waits.
+	re.Equal(tbSetting.Settings.FillRate, tb.Settings.FillRate)
 	// need to lend token
 	tb, trickle = gtb.request(time1, 11000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
 	re.LessOrEqual(math.Abs(tb.Tokens-11000), 1e-7)
 	re.Equal(int64(time.Second)*11000./4000./int64(time.Millisecond), trickle)
+	// Trickle response must NOT carry FillRate to avoid double-counting with
+	// the client's own trickle-based fill rate calculation.
+	re.Zero(tb.Settings.FillRate)
 	tb, trickle = gtb.request(time1, 35000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
 	re.LessOrEqual(math.Abs(tb.Tokens-35000), 1e-7)
 	re.Equal(int64(time.Second)*10/int64(time.Millisecond), trickle)

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -1205,6 +1205,106 @@ func (suite *resourceManagerClientTestSuite) TestAcquireTokenBucket() {
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/mcs/resourcemanager/server/fastPersist"))
 }
 
+// TestNonTrickleFillRate verifies issue #10251: when the server grants tokens in non-trickle
+// mode (capacity sufficient), the response must carry FillRate so the client limiter can
+// locally generate tokens instead of hitting InfDuration waits.
+//
+// Without the fix, the server returns FillRate=0 in non-trickle responses. After the client
+// depletes its granted tokens, durationFromTokens() returns InfDuration, causing all subsequent
+// OnRequestWait calls to fail with ErrClientResourceGroupThrottled or context.DeadlineExceeded.
+func (suite *resourceManagerClientTestSuite) TestNonTrickleFillRate() {
+	re := suite.Require()
+	cli := suite.client
+
+	const groupName = "test_non_trickle_fill_rate"
+	const groupFillRate = uint64(10000)
+	const groupBurstLimit = int64(1000000)
+	group := &rmpb.ResourceGroup{
+		Name: groupName,
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{
+					FillRate:   groupFillRate,
+					BurstLimit: groupBurstLimit,
+				},
+				Tokens: 1000000,
+			},
+		},
+	}
+	resp, err := cli.AddResourceGroup(suite.ctx, group)
+	re.NoError(err)
+	re.Contains(resp, "Success!")
+
+	ctx, cancel := context.WithCancel(suite.ctx)
+	defer cancel()
+
+	// Case 1: Non-trickle response when no slot exists (requiredToken=0, initial periodic report).
+	// The server deletes the slot and returns a response directly from the group-level settings.
+	// This response must carry FillRate so the client limiter can refill tokens locally.
+	tokenBucketRequest := &rmpb.TokenBucketsRequest{
+		Requests: []*rmpb.TokenBucketRequest{
+			{
+				ResourceGroupName: groupName,
+				Request: &rmpb.TokenBucketRequest_RuItems{
+					RuItems: &rmpb.TokenBucketRequest_RequestRU{
+						RequestRU: []*rmpb.RequestUnitItem{
+							{
+								Type:  rmpb.RequestUnitType_RU,
+								Value: 0, // no tokens requested — simulates initial periodic report
+							},
+						},
+					},
+				},
+				ConsumptionSinceLastRequest: &rmpb.Consumption{},
+			},
+		},
+		TargetRequestPeriodMs: uint64(time.Second * 5 / time.Millisecond),
+		ClientUniqueId:        1,
+	}
+	token := suite.acquireNonTrickleFillRateTokens(ctx, re, groupName, tokenBucketRequest)
+	re.Equal(groupFillRate, token.GetSettings().GetFillRate(),
+		"non-trickle response (no-slot path) must carry FillRate; "+
+			"without it, the client limiter has fillRate=0 and durationFromTokens returns InfDuration")
+
+	// Case 2: Non-trickle response when slot exists and capacity is sufficient (full-satisfy path).
+	// The server grants the requested tokens directly without trickle.
+	const requestRU = 200.
+	tokenBucketRequest.Requests[0].Request = &rmpb.TokenBucketRequest_RuItems{
+		RuItems: &rmpb.TokenBucketRequest_RequestRU{
+			RequestRU: []*rmpb.RequestUnitItem{
+				{
+					Type:  rmpb.RequestUnitType_RU,
+					Value: requestRU,
+				},
+			},
+		},
+	}
+	tokenBucketRequest.Requests[0].ConsumptionSinceLastRequest = &rmpb.Consumption{RRU: requestRU}
+	token = suite.acquireNonTrickleFillRateTokens(ctx, re, groupName, tokenBucketRequest)
+	re.Equal(requestRU, token.GetTokens(),
+		"full-satisfy path should grant the exact requested tokens")
+	re.Equal(groupFillRate, token.GetSettings().GetFillRate(),
+		"non-trickle response (full-satisfy path) must carry FillRate; "+
+			"without it, the client limiter has fillRate=0 and durationFromTokens returns InfDuration")
+	re.Equal(groupBurstLimit, token.GetSettings().GetBurstLimit())
+}
+
+func (suite *resourceManagerClientTestSuite) acquireNonTrickleFillRateTokens(
+	ctx context.Context, re *require.Assertions, groupName string,
+	tokenBucketRequest *rmpb.TokenBucketsRequest,
+) *rmpb.TokenBucket {
+	resps, err := suite.client.AcquireTokenBuckets(ctx, tokenBucketRequest)
+	re.NoError(err)
+	re.Len(resps, 1)
+	resp := resps[0]
+	re.Equal(groupName, resp.ResourceGroupName)
+	grantedTokens := resp.GetGrantedRUTokens()
+	re.Len(grantedTokens, 1)
+	re.Zero(grantedTokens[0].GetTrickleTimeMs(), "response should be non-trickle (trickleTimeMs=0)")
+	return grantedTokens[0].GetGrantedTokens()
+}
+
 func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 	re := suite.Require()
 	cli := suite.client


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10251

When the resource group FillRate is much larger than actual consumption (e.g., FillRate=1,000,000 vs consumption≈200 RU/s), requests experience ~1s latency spikes.

**Root cause**: The server's `request()` and `assignSlotTokens()` never set `FillRate` in non-trickle responses. The client's `modifyTokenCounter` uses `cfg.newFillRate = float64(bucket.GetSettings().FillRate)`, which gets 0. After the granted tokens are depleted, `durationFromTokens()` returns `InfDuration`, causing all subsequent `OnRequestWait` calls to fail with `ErrClientResourceGroupThrottled` or `context.DeadlineExceeded`.

### What is changed and how does it work?

Set `FillRate` on all three non-trickle return paths in the server so the client limiter can refill tokens locally:

1. **No-slot path in `request()`** — when the slot doesn't exist (initial periodic report with `requiredToken=0`), return `FillRate = gtb.getFillRate()` (group-level fill rate).
2. **`requiredToken<=0` path in `assignSlotTokens()`** — when the slot exists but no tokens are requested, return `FillRate = ts.fillRate` (per-slot fill rate).
3. **Full-satisfy path in `assignSlotTokens()`** — when the slot has enough capacity to fully satisfy the request, return `FillRate = ts.fillRate` (per-slot fill rate).

Trickle paths are intentionally left unchanged to avoid double-counting with the client's own trickle-based fill rate calculation (`cfg.newFillRate = FillRate + granted/trickleTime`).

```commit-message
Set FillRate on all three non-trickle return paths in the server:
1. No-slot path in request() — initial periodic report with no slot yet
2. requiredToken<=0 path in assignSlotTokens() — zero-demand requests
3. Full-satisfy path in assignSlotTokens() — capacity covers demand

Trickle paths are intentionally left unchanged to avoid double-counting
with the client's own trickle-based fill rate calculation.
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has no configuration change
- Has no HTTP API change
- Has no persistent data change

Side effects

- No performance regression
- No increased code complexity
- No breaking backward compatibility

### Release note

```release-note
Fix the issue that the resource group token bucket server does not set FillRate in non-trickle responses, which causes the client limiter to have fillRate=0 and results in ~1s latency spikes when the resource group FillRate is much larger than actual consumption.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved token bucket rate limiting to consistently propagate fill rates across all token grant scenarios, preventing double-counting issues and ensuring accurate token refilling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->