### PR TITLE
chore(dashboard): update TiDB Dashboard to 20260305120502-70e5bb19e006 [master]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0
+	github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/rleungx/leakcheck v1.0.1-0.20250721100113-2eb456ffd3e3

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc h1:WQYup3tMJq
 github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc/go.mod h1:Qj77xzm/Bscv47607+/BkP0ovAHnf4j7HWSLKQaKwBw=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0 h1:jUD9Z6MSlaRIHNVtTpZ6fVxNAPjnRU1+jiDFY0SS42Q=
-github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0/go.mod h1:DeFjEkm5RJE3ZMIZS/wqnnMFVzZLSSys+faMWVq7upc=
+github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006 h1:S4dgP65gYb68U7StBUje/R3YCxdRdCpu4OnAK8HvwY8=
+github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006/go.mod h1:DeFjEkm5RJE3ZMIZS/wqnnMFVzZLSSys+faMWVq7upc=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -462,8 +462,8 @@ github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc h1:WQYup3tMJq
 github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc/go.mod h1:Qj77xzm/Bscv47607+/BkP0ovAHnf4j7HWSLKQaKwBw=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0 h1:jUD9Z6MSlaRIHNVtTpZ6fVxNAPjnRU1+jiDFY0SS42Q=
-github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0/go.mod h1:DeFjEkm5RJE3ZMIZS/wqnnMFVzZLSSys+faMWVq7upc=
+github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006 h1:S4dgP65gYb68U7StBUje/R3YCxdRdCpu4OnAK8HvwY8=
+github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006/go.mod h1:DeFjEkm5RJE3ZMIZS/wqnnMFVzZLSSys+faMWVq7upc=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -159,7 +159,7 @@ require (
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -467,8 +467,8 @@ github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc h1:WQYup3tMJq
 github.com/pingcap/metering_sdk v0.0.0-20250918015914-468cd6feb1dc/go.mod h1:Qj77xzm/Bscv47607+/BkP0ovAHnf4j7HWSLKQaKwBw=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0 h1:jUD9Z6MSlaRIHNVtTpZ6fVxNAPjnRU1+jiDFY0SS42Q=
-github.com/pingcap/tidb-dashboard v0.0.0-20260112071732-805c56a830e0/go.mod h1:DeFjEkm5RJE3ZMIZS/wqnnMFVzZLSSys+faMWVq7upc=
+github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006 h1:S4dgP65gYb68U7StBUje/R3YCxdRdCpu4OnAK8HvwY8=
+github.com/pingcap/tidb-dashboard v0.0.0-20260305120502-70e5bb19e006/go.mod h1:DeFjEkm5RJE3ZMIZS/wqnnMFVzZLSSys+faMWVq7upc=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10323

### What is changed and how does it work?

- Bump `github.com/pingcap/tidb-dashboard` to `v0.0.0-20260305120502-70e5bb19e006` (tidb-dashboard `master` @ `70e5bb19e006`).
- Keep the version consistent in the root module as well as the `tests/integrations` and `tools` sub-modules.

```commit-message
```

### Check List

Tests

- Manual test
  - `make pd-server`

Code changes

- No configuration change
- No HTTP APIs changed
- No persistent data change

Side effects

- None

Related changes

- None

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated tidb-dashboard dependency to the latest version across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->