### PR TITLE
keyspace: decouple keyspace with region labeler

### DIFF
--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -22,9 +22,10 @@ import (
 )
 
 var (
-	tablePrefix  = []byte{'t'}
-	metaPrefix   = []byte{'m'}
-	recordPrefix = []byte("_r")
+	tablePrefix    = []byte{'t'}
+	metaPrefix     = []byte{'m'}
+	recordPrefix   = []byte("_r")
+	keyspacePrefix = []byte{'x'} // 'x' for keyspace
 )
 
 const (
@@ -72,6 +73,21 @@ func (k Key) MetaOrTable() (bool, int64) {
 		return false, tableID
 	}
 	return false, 0
+}
+
+// DecodeKeyspaceTxnKey decodes the keyspace transaction key.
+func (k Key) DecodeKeyspaceTxnKey() (bool, uint32) {
+	_, key, err := DecodeBytes(k)
+	if err != nil {
+		return false, 0
+	}
+	if !bytes.HasPrefix(key, keyspacePrefix) {
+		return false, 0
+	}
+	key = key[len(keyspacePrefix):]
+	d := append([]byte{0}, key[:3]...)
+	keyspaceID := binary.BigEndian.Uint32(d)
+	return true, keyspaceID
 }
 
 var pads = make([]byte, encGroupSize)

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -22,10 +22,9 @@ import (
 )
 
 var (
-	tablePrefix    = []byte{'t'}
-	metaPrefix     = []byte{'m'}
-	recordPrefix   = []byte("_r")
-	keyspacePrefix = []byte{'x'} // 'x' for keyspace
+	tablePrefix  = []byte{'t'}
+	metaPrefix   = []byte{'m'}
+	recordPrefix = []byte("_r")
 )
 
 const (
@@ -73,21 +72,6 @@ func (k Key) MetaOrTable() (bool, int64) {
 		return false, tableID
 	}
 	return false, 0
-}
-
-// DecodeKeyspaceTxnKey decodes the keyspace transaction key.
-func (k Key) DecodeKeyspaceTxnKey() (bool, uint32) {
-	_, key, err := DecodeBytes(k)
-	if err != nil {
-		return false, 0
-	}
-	if !bytes.HasPrefix(key, keyspacePrefix) {
-		return false, 0
-	}
-	key = key[len(keyspacePrefix):]
-	d := append([]byte{0}, key[:3]...)
-	keyspaceID := binary.BigEndian.Uint32(d)
-	return true, keyspaceID
 }
 
 var pads = make([]byte, encGroupSize)

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"strconv"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -92,8 +91,7 @@ type Manager struct {
 	// nextPatrolStartID is the next start id of keyspace assignment patrol.
 	nextPatrolStartID uint32
 	// cached keyspace meta info for each keyspace ID.
-	keyspaceNameLookup  sync.Map // store as ID(uint32) -> name(string)
-	keyspaceStateLookup sync.Map // store as ID(uint32) -> state(keyspacepb.KeyspaceState)
+	KeyspaceCache *Cache
 }
 
 // CreateKeyspaceRequest represents necessary arguments to create a keyspace.
@@ -142,6 +140,7 @@ func NewKeyspaceManager(
 		config:            config,
 		kgm:               kgm,
 		nextPatrolStartID: constant.StartKeyspaceID,
+		KeyspaceCache:     NewCache(),
 	}
 }
 
@@ -478,7 +477,7 @@ func (manager *Manager) saveNewKeyspace(keyspace *keyspacepb.KeyspaceMeta) error
 			return err
 		}
 		// Update the keyspace name cache.
-		manager.keyspaceNameLookup.Store(keyspace.Id, keyspace.Name)
+		manager.KeyspaceCache.Save(keyspace.Id, keyspace.Name, keyspace.State)
 		// Save keyspace meta.
 		// Check if keyspace with that id already exists.
 		loadedMeta, err := manager.store.LoadKeyspaceMeta(txn, keyspace.Id)
@@ -871,7 +870,7 @@ func (manager *Manager) transformKeyspaceState(meta *keyspacepb.KeyspaceMeta, ne
 	meta.State = newState
 	meta.StateChangedAt = now
 	// Update the keyspace state to the cache.
-	manager.keyspaceStateLookup.Store(meta.GetId(), newState)
+	manager.KeyspaceCache.Save(meta.GetId(), meta.GetName(), newState)
 	return nil
 }
 
@@ -902,10 +901,10 @@ func (manager *Manager) GetKeyspaceNameByID(id uint32) (string, error) {
 	if id == constant.NullKeyspaceID {
 		return "", nil
 	}
-	// Try to get the keyspace name from the cache first.
-	name, ok := manager.keyspaceNameLookup.Load(id)
+	// Try to get the keyspace name from the cache.
+	item, ok := manager.KeyspaceCache.getKeyspaceByID(id)
 	if ok {
-		return name.(string), nil
+		return item.name, nil
 	}
 	var loadedName string
 	// If the keyspace name is not in the cache, try to get it from the storage.
@@ -917,46 +916,42 @@ func (manager *Manager) GetKeyspaceNameByID(id uint32) (string, error) {
 	if len(loadedName) == 0 {
 		return "", errors.Errorf("got an empty keyspace name by id %d", id)
 	}
-	// Load or store the keyspace name to the cache.
-	actual, _ := manager.keyspaceNameLookup.LoadOrStore(id, loadedName)
-	return actual.(string), nil
-}
-
-// KeyspaceExists checks if a keyspace with the given ID exists in the cache.
-// This is used to determine if keyspace boundaries should be enforced during split/merge.
-func (manager *Manager) KeyspaceExists(id uint32) bool {
-	name, err := manager.GetKeyspaceNameByID(id)
-	return err == nil && len(name) > 0
+	manager.KeyspaceCache.Save(id, loadedName, meta.GetState())
+	return loadedName, nil
 }
 
 // GetKeyspaceIDInRange returns one existing keyspace ID in [start, end].
 func (manager *Manager) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
-	if start >= end {
-		return 0, false
-	}
-	found := false
-	var candidate uint32
-	manager.ScanAllKeyspace(func(keyspaceID uint32, _ string) bool {
-		if keyspaceID >= start && keyspaceID <= end {
-			candidate = keyspaceID
-			found = true
-		}
-		return !found
-	})
-	return candidate, found
+	return manager.KeyspaceCache.GetKeyspaceIDInRange(start, end)
 }
 
-// ScanIterator is the type of the function used in ScanAllKeyspace,
-// which takes keyspaceID and name as parameters and returns a boolean indicating whether to stop scanning.
-type ScanIterator func(keyspaceID uint32, name string) bool
+// KeyspaceExist checks if a keyspace exists by ID.
+func (manager *Manager) KeyspaceExist(id uint32) bool {
+	if id == constant.NullKeyspaceID {
+		return true
+	}
+	// don't direct check the cache because the keyspace may exist in storage
+	// but not in cache, we should check the storage to make sure the existence of the keyspace.
+	_, err := manager.GetKeyspaceNameByID(id)
+	return err == nil
+}
 
-// ScanAllKeyspace scans all keyspaces and applies the given function.
+// UpdateKeyspaceMetaToCache updates keyspace cache from keyspace metadata.
+func (manager *Manager) UpdateKeyspaceMetaToCache(meta *keyspacepb.KeyspaceMeta) {
+	if meta == nil {
+		return
+	}
+	manager.KeyspaceCache.Save(meta.GetId(), meta.GetName(), meta.GetState())
+}
+
+// DeleteKeyspaceMetaFromCache removes a keyspace from cache by ID.
+func (manager *Manager) DeleteKeyspaceMetaFromCache(id uint32) {
+	manager.KeyspaceCache.DeleteKeyspace(id)
+}
+
+// ScanAllKeyspace scans all keyspaces in the cache and applies the given function to each keyspace.
 func (manager *Manager) ScanAllKeyspace(fn func(keyspaceID uint32, name string) bool) {
-	manager.keyspaceNameLookup.Range(func(key, value any) bool {
-		keyspaceID := key.(uint32)
-		name := value.(string)
-		return fn(keyspaceID, name)
-	})
+	manager.KeyspaceCache.scanAllKeyspaces(fn)
 }
 
 // GetKeyspaceStateByID gets the keyspace state by ID, which will try to get it from the cache first.
@@ -965,9 +960,9 @@ func (manager *Manager) GetKeyspaceStateByID(id uint32) (keyspacepb.KeyspaceStat
 	if id == constant.NullKeyspaceID {
 		return keyspacepb.KeyspaceState_DISABLED, nil
 	}
-	state, ok := manager.keyspaceStateLookup.Load(id)
+	item, ok := manager.KeyspaceCache.getKeyspaceByID(id)
 	if ok {
-		return state.(keyspacepb.KeyspaceState), nil
+		return item.state, nil
 	}
 	var loadedState keyspacepb.KeyspaceState
 	// If the keyspace state is not in the cache, try to get it from the storage.
@@ -978,8 +973,8 @@ func (manager *Manager) GetKeyspaceStateByID(id uint32) (keyspacepb.KeyspaceStat
 	}
 	loadedState = meta.GetState()
 	// Load or store the keyspace state to the cache.
-	actual, _ := manager.keyspaceStateLookup.LoadOrStore(id, loadedState)
-	return actual.(keyspacepb.KeyspaceState), nil
+	manager.KeyspaceCache.Save(meta.GetId(), meta.GetName(), loadedState)
+	return loadedState, nil
 }
 
 // GetEnabledKeyspaceNameByID gets the enabled keyspace name by ID. If the state is not enabled, it will return an error.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -32,13 +32,11 @@ import (
 	"github.com/tikv/pd/pkg/id"
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/schedule/core"
-	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
-	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
@@ -47,10 +45,6 @@ const (
 	// AllocStep set idAllocator's step when write persistent window boundary.
 	// Use a lower value for denser idAllocation in the event of frequent pd leader change.
 	AllocStep = uint64(100)
-	// regionLabelIDPrefix is used to prefix the keyspace region label.
-	regionLabelIDPrefix = "keyspaces/"
-	// regionLabelKey is the key for keyspace id in keyspace region label.
-	regionLabelKey = "id"
 	// UserKindKey is the key for user kind in keyspace config.
 	UserKindKey = "user_kind"
 	// TSOKeyspaceGroupIDKey is the key for tso keyspace group id in keyspace config.
@@ -498,55 +492,37 @@ func (manager *Manager) saveNewKeyspace(keyspace *keyspacepb.KeyspaceMeta) error
 	})
 }
 
-// splitKeyspaceRegion add keyspace's boundaries to region label. The corresponding
-// region will then be split by Coordinator's patrolRegion.
-func (manager *Manager) splitKeyspaceRegion(id uint32, waitRegionSplit bool) (err error) {
+// splitKeyspaceRegion waits for the region at keyspace boundaries to be split.
+// The actual splitting is now handled by the SplitChecker which detects keyspace
+// boundaries by parsing region keys, rather than using label rules.
+func (manager *Manager) splitKeyspaceRegion(id uint32, waitRegionSplit bool) error {
 	failpoint.Inject("skipSplitRegion", func() {
 		failpoint.Return(nil)
 	})
 
 	start := time.Now()
-	keyspaceRule := MakeLabelRule(id)
-	cl, ok := manager.cluster.(interface{ GetRegionLabeler() *labeler.RegionLabeler })
-	if !ok {
-		return errors.New("cluster does not support region label")
-	}
-	err = cl.GetRegionLabeler().SetLabelRule(keyspaceRule)
-	if err != nil {
-		log.Warn("[keyspace] failed to add region label for keyspace",
-			zap.Uint32("keyspace-id", id),
-			zap.Error(err),
-		)
-		return err
-	}
-	defer func() {
-		if err != nil {
-			if err := cl.GetRegionLabeler().DeleteLabelRule(keyspaceRule.ID); err != nil {
-				log.Warn("[keyspace] failed to delete region label for keyspace",
-					zap.Uint32("keyspace-id", id),
-					zap.Error(err),
-				)
-			}
-		}
-	}()
 
 	if waitRegionSplit {
-		err = manager.waitKeyspaceRegionSplit(id)
+		err := manager.waitKeyspaceRegionSplit(id)
 		if err != nil {
 			log.Warn("[keyspace] wait region split meets error",
 				zap.Uint32("keyspace-id", id),
 				zap.Error(err),
 			)
+			return err
 		}
-		return err
+		log.Info("[keyspace] keyspace region split completed",
+			zap.Uint32("keyspace-id", id),
+			zap.Duration("takes", time.Since(start)),
+		)
+		return nil
 	}
 
-	log.Info("[keyspace] added region label for keyspace",
+	log.Info("[keyspace] keyspace region split initiated",
 		zap.Uint32("keyspace-id", id),
-		logutil.ZapRedactString("label-rule", keyspaceRule.String()),
 		zap.Duration("takes", time.Since(start)),
 	)
-	return
+	return nil
 }
 
 func (manager *Manager) waitKeyspaceRegionSplit(id uint32) error {
@@ -949,6 +925,23 @@ func (manager *Manager) GetKeyspaceNameByID(id uint32) (string, error) {
 	// Load or store the keyspace name to the cache.
 	actual, _ := manager.keyspaceNameLookup.LoadOrStore(id, loadedName)
 	return actual.(string), nil
+}
+
+// KeyspaceExists checks if a keyspace with the given ID exists in the cache.
+// This is used to determine if keyspace boundaries should be enforced during split/merge.
+func (manager *Manager) KeyspaceExists(id uint32) bool {
+	_, err := manager.GetKeyspaceNameByID(id)
+	return err == nil
+}
+
+// ScanAllKeyspace scans all keyspaces and applies the given function.
+func (manager *Manager) ScanAllKeyspace(fn func(keyspaceID uint32, name string)) {
+	manager.keyspaceNameLookup.Range(func(key, value any) bool {
+		keyspaceID := key.(uint32)
+		name := value.(string)
+		fn(keyspaceID, name)
+		return true
+	})
 }
 
 // GetKeyspaceStateByID gets the keyspace state by ID, which will try to get it from the cache first.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -511,14 +511,9 @@ func (manager *Manager) splitKeyspaceRegion(id uint32, waitRegionSplit bool) err
 			)
 			return err
 		}
-		log.Info("[keyspace] keyspace region split completed",
-			zap.Uint32("keyspace-id", id),
-			zap.Duration("takes", time.Since(start)),
-		)
-		return nil
 	}
 
-	log.Info("[keyspace] keyspace region split initiated",
+	log.Info("[keyspace] region split initiated",
 		zap.Uint32("keyspace-id", id),
 		zap.Duration("takes", time.Since(start)),
 	)
@@ -930,8 +925,8 @@ func (manager *Manager) GetKeyspaceNameByID(id uint32) (string, error) {
 // KeyspaceExists checks if a keyspace with the given ID exists in the cache.
 // This is used to determine if keyspace boundaries should be enforced during split/merge.
 func (manager *Manager) KeyspaceExists(id uint32) bool {
-	_, err := manager.GetKeyspaceNameByID(id)
-	return err == nil
+	name, err := manager.GetKeyspaceNameByID(id)
+	return err == nil && len(name) > 0
 }
 
 // ScanAllKeyspace scans all keyspaces and applies the given function.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -462,7 +462,7 @@ func (manager *Manager) saveNewKeyspace(keyspace *keyspacepb.KeyspaceMeta) error
 	manager.metaLock.Lock(keyspace.Id)
 	defer manager.metaLock.Unlock(keyspace.Id)
 
-	return manager.store.RunInTxn(manager.ctx, func(txn kv.Txn) error {
+	err := manager.store.RunInTxn(manager.ctx, func(txn kv.Txn) error {
 		// Save keyspace ID.
 		// Check if keyspace with that name already exists.
 		nameExists, _, err := manager.store.LoadKeyspaceID(txn, keyspace.Name)
@@ -476,8 +476,7 @@ func (manager *Manager) saveNewKeyspace(keyspace *keyspacepb.KeyspaceMeta) error
 		if err != nil {
 			return err
 		}
-		// Update the keyspace name cache.
-		manager.KeyspaceCache.Save(keyspace.Id, keyspace.Name, keyspace.State)
+
 		// Save keyspace meta.
 		// Check if keyspace with that id already exists.
 		loadedMeta, err := manager.store.LoadKeyspaceMeta(txn, keyspace.Id)
@@ -489,6 +488,11 @@ func (manager *Manager) saveNewKeyspace(keyspace *keyspacepb.KeyspaceMeta) error
 		}
 		return manager.store.SaveKeyspaceMeta(txn, keyspace)
 	})
+
+	if err == nil {
+		manager.KeyspaceCache.Save(keyspace.Id, keyspace.Name, keyspace.State)
+	}
+	return err
 }
 
 // splitKeyspaceRegion waits for the region at keyspace boundaries to be split.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -905,6 +905,9 @@ func (manager *Manager) GetKeyspaceNameByID(id uint32) (string, error) {
 	if id == constant.NullKeyspaceID {
 		return "", nil
 	}
+	if manager == nil {
+		return "", nil
+	}
 	// Try to get the keyspace name from the cache.
 	item, ok := manager.KeyspaceCache.getKeyspaceByID(id)
 	if ok {
@@ -926,6 +929,9 @@ func (manager *Manager) GetKeyspaceNameByID(id uint32) (string, error) {
 
 // GetKeyspaceIDInRange returns one existing keyspace ID in [start, end].
 func (manager *Manager) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	if manager == nil {
+		return start, true
+	}
 	return manager.KeyspaceCache.GetKeyspaceIDInRange(start, end)
 }
 

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -940,6 +940,9 @@ func (manager *Manager) KeyspaceExist(id uint32) bool {
 	if id == constant.NullKeyspaceID {
 		return true
 	}
+	if id == constant.MaxValidKeyspaceID {
+		return true
+	}
 	// don't direct check the cache because the keyspace may exist in storage
 	// but not in cache, we should check the storage to make sure the existence of the keyspace.
 	_, err := manager.GetKeyspaceNameByID(id)

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -929,13 +929,33 @@ func (manager *Manager) KeyspaceExists(id uint32) bool {
 	return err == nil && len(name) > 0
 }
 
+// GetKeyspaceIDInRange returns one existing keyspace ID in [start, end].
+func (manager *Manager) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	if start >= end {
+		return 0, false
+	}
+	found := false
+	var candidate uint32
+	manager.ScanAllKeyspace(func(keyspaceID uint32, _ string) bool {
+		if keyspaceID >= start && keyspaceID <= end {
+			candidate = keyspaceID
+			found = true
+		}
+		return !found
+	})
+	return candidate, found
+}
+
+// ScanIterator is the type of the function used in ScanAllKeyspace,
+// which takes keyspaceID and name as parameters and returns a boolean indicating whether to stop scanning.
+type ScanIterator func(keyspaceID uint32, name string) bool
+
 // ScanAllKeyspace scans all keyspaces and applies the given function.
-func (manager *Manager) ScanAllKeyspace(fn func(keyspaceID uint32, name string)) {
+func (manager *Manager) ScanAllKeyspace(fn func(keyspaceID uint32, name string) bool) {
 	manager.keyspaceNameLookup.Range(func(key, value any) bool {
 		keyspaceID := key.(uint32)
 		name := value.(string)
-		fn(keyspaceID, name)
-		return true
+		return fn(keyspaceID, name)
 	})
 }
 

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -928,11 +928,11 @@ func (manager *Manager) GetKeyspaceNameByID(id uint32) (string, error) {
 }
 
 // GetKeyspaceIDInRange returns one existing keyspace ID in [start, end].
-func (manager *Manager) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+func (manager *Manager) GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool) {
 	if manager == nil {
-		return start, true
+		return []uint32{start}, true
 	}
-	return manager.KeyspaceCache.GetKeyspaceIDInRange(start, end)
+	return manager.KeyspaceCache.GetKeyspaceIDInRange(start, end, limit)
 }
 
 // KeyspaceExist checks if a keyspace exists by ID.
@@ -943,10 +943,15 @@ func (manager *Manager) KeyspaceExist(id uint32) bool {
 	if id == constant.MaxValidKeyspaceID {
 		return true
 	}
-	// don't direct check the cache because the keyspace may exist in storage
-	// but not in cache, we should check the storage to make sure the existence of the keyspace.
-	_, err := manager.GetKeyspaceNameByID(id)
-	return err == nil
+	if manager == nil {
+		return true
+	}
+	state, err := manager.GetKeyspaceStateByID(id)
+	if err != nil {
+		return false
+	}
+
+	return state != keyspacepb.KeyspaceState_TOMBSTONE
 }
 
 // UpdateKeyspaceMetaToCache updates keyspace cache from keyspace metadata.

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -741,6 +741,22 @@ func (suite *keyspaceTestSuite) TestLoadRangeKeyspace() {
 	re.Error(err)
 }
 
+func (suite *keyspaceTestSuite) TestGetKeyspaceIDInRange() {
+	re := suite.Require()
+	manager := suite.manager
+	requests := makeCreateKeyspaceRequests(5)
+	for _, request := range requests {
+		_, err := manager.CreateKeyspace(request)
+		re.NoError(err)
+	}
+
+	_, ok := manager.GetKeyspaceIDInRange(2, 5)
+	re.True(ok)
+
+	_, ok = manager.GetKeyspaceIDInRange(6, 10)
+	re.False(ok)
+}
+
 // TestUpdateMultipleKeyspace checks that updating multiple keyspace's config simultaneously
 // will be successful.
 func (suite *keyspaceTestSuite) TestUpdateMultipleKeyspace() {

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -750,19 +750,19 @@ func (suite *keyspaceTestSuite) TestGetKeyspaceIDInRange() {
 		re.NoError(err)
 	}
 
-	id, ok := manager.GetKeyspaceIDInRange(2, 5)
+	id, ok := manager.GetKeyspaceIDInRange(2, 5, 1)
 	re.True(ok)
 	re.Equal(uint32(5), id)
 
-	id, ok = manager.GetKeyspaceIDInRange(1, 4)
+	id, ok = manager.GetKeyspaceIDInRange(1, 4, 1)
 	re.True(ok)
 	re.Equal(uint32(4), id)
 
-	id, ok = manager.GetKeyspaceIDInRange(1, 6)
+	id, ok = manager.GetKeyspaceIDInRange(1, 6, 1)
 	re.True(ok)
 	re.Equal(uint32(5), id)
 
-	id, ok = manager.GetKeyspaceIDInRange(6, 10)
+	id, ok = manager.GetKeyspaceIDInRange(6, 10, 1)
 	re.False(ok)
 	re.Equal(uint32(0), id)
 }

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -744,17 +744,27 @@ func (suite *keyspaceTestSuite) TestLoadRangeKeyspace() {
 func (suite *keyspaceTestSuite) TestGetKeyspaceIDInRange() {
 	re := suite.Require()
 	manager := suite.manager
-	requests := makeCreateKeyspaceRequests(5)
+	requests := makeCreateKeyspaceByIDRequests(5)
 	for _, request := range requests {
-		_, err := manager.CreateKeyspace(request)
+		_, err := manager.CreateKeyspaceByID(request)
 		re.NoError(err)
 	}
 
-	_, ok := manager.GetKeyspaceIDInRange(2, 5)
+	id, ok := manager.GetKeyspaceIDInRange(2, 5)
 	re.True(ok)
+	re.Equal(uint32(5), id)
 
-	_, ok = manager.GetKeyspaceIDInRange(6, 10)
+	id, ok = manager.GetKeyspaceIDInRange(1, 4)
+	re.True(ok)
+	re.Equal(uint32(4), id)
+
+	id, ok = manager.GetKeyspaceIDInRange(1, 6)
+	re.True(ok)
+	re.Equal(uint32(5), id)
+
+	id, ok = manager.GetKeyspaceIDInRange(6, 10)
 	re.False(ok)
+	re.Equal(uint32(0), id)
 }
 
 // TestUpdateMultipleKeyspace checks that updating multiple keyspace's config simultaneously

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -554,9 +554,11 @@ func (s *Cache) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
 	s.RLock()
 	defer s.RUnlock()
 	var foundID uint32
+	found := false
 	s.tree.AscendGreaterOrEqual(keyspaceItem{keyspaceID: start}, func(i keyspaceItem) bool {
 		if i.keyspaceID <= end {
 			foundID = i.keyspaceID
+			found = true
 			return false
 		}
 		return true
@@ -564,5 +566,5 @@ func (s *Cache) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
 	if foundID != 0 {
 		return foundID, true
 	}
-	return 0, false
+	return foundID, found
 }

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -19,8 +19,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"regexp"
-	"strconv"
-	"strings"
+
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
@@ -28,7 +28,6 @@ import (
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/keyspace/constant"
-	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
@@ -65,6 +64,15 @@ func validateID(id uint32) error {
 		return errors.Errorf("illegal keyspace id %d, collides with a protected keyspace id", id)
 	}
 	return nil
+}
+
+// NewKeyspaceMeta creates a KeyspaceMeta from the given json string.
+func NewKeyspaceMeta(data string) (*keyspacepb.KeyspaceMeta, error) {
+	meta := &keyspacepb.KeyspaceMeta{}
+	if err := proto.Unmarshal([]byte(data), meta); err != nil {
+		return nil, errs.ErrProtoUnmarshal.Wrap(err).GenWithStackByCause()
+	}
+	return meta, nil
 }
 
 // validateName check if user provided name is legal.
@@ -118,10 +126,11 @@ func MakeRegionBound(id uint32) *RegionBound {
 	nextKeyspaceIDBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(keyspaceIDBytes, id)
 	binary.BigEndian.PutUint32(nextKeyspaceIDBytes, id+1)
+	tr := codec.EncodeBytes(append([]byte{'x'}, keyspaceIDBytes[1:]...))
 	return &RegionBound{
 		RawLeftBound:  codec.EncodeBytes(append([]byte{'r'}, keyspaceIDBytes[1:]...)),
 		RawRightBound: codec.EncodeBytes(append([]byte{'r'}, nextKeyspaceIDBytes[1:]...)),
-		TxnLeftBound:  codec.EncodeBytes(append([]byte{'x'}, keyspaceIDBytes[1:]...)),
+		TxnLeftBound:  tr,
 		TxnRightBound: codec.EncodeBytes(append([]byte{'x'}, nextKeyspaceIDBytes[1:]...)),
 	}
 }
@@ -139,60 +148,6 @@ func MakeKeyRanges(id uint32) []any {
 			"end_key":   hex.EncodeToString(regionBound.TxnRightBound),
 		},
 	}
-}
-
-// getRegionLabelID returns the region label id of the target keyspace.
-func getRegionLabelID(id uint32) string {
-	return regionLabelIDPrefix + strconv.FormatUint(uint64(id), endpoint.SpaceIDBase)
-}
-
-// MakeLabelRule makes the label rule for the given keyspace id.
-func MakeLabelRule(id uint32) *labeler.LabelRule {
-	return &labeler.LabelRule{
-		ID:    getRegionLabelID(id),
-		Index: 0,
-		Labels: []labeler.RegionLabel{
-			{
-				Key:   regionLabelKey,
-				Value: strconv.FormatUint(uint64(id), endpoint.SpaceIDBase),
-			},
-		},
-		RuleType: labeler.KeyRange,
-		Data:     MakeKeyRanges(id),
-	}
-}
-
-// ParseKeyspaceIDFromLabelRule parses the keyspace ID from the label rule.
-// It will return the keyspace ID and a boolean indicating whether the label
-// rule is a keyspace label rule.
-func ParseKeyspaceIDFromLabelRule(rule *labeler.LabelRule) (uint32, bool) {
-	// Validate the ID matches the expected format "keyspaces/<id>".
-	if rule == nil || !strings.HasPrefix(rule.ID, regionLabelIDPrefix) {
-		return 0, false
-	}
-	// Retrieve the keyspace ID.
-	keyspaceID, err := strconv.ParseUint(
-		strings.TrimPrefix(rule.ID, regionLabelIDPrefix),
-		endpoint.SpaceIDBase, 32,
-	)
-	if err != nil {
-		return 0, false
-	}
-	// Double check the keyspace ID from the label rule.
-	var idFromLabel uint64
-	for _, label := range rule.Labels {
-		if label.Key == regionLabelKey {
-			idFromLabel, err = strconv.ParseUint(label.Value, endpoint.SpaceIDBase, 32)
-			if err != nil {
-				return 0, false
-			}
-			break
-		}
-	}
-	if keyspaceID != idFromLabel {
-		return 0, false
-	}
-	return uint32(keyspaceID), true
 }
 
 // indexedHeap is a heap with index.
@@ -333,4 +288,159 @@ func isProtectedKeyspaceName(name string) bool {
 		return name == constant.SystemKeyspaceName
 	}
 	return name == constant.DefaultKeyspaceName
+}
+
+// ExtractKeyspaceID extracts the keyspace ID from a region key.
+// It returns the keyspace ID and a boolean indicating whether the key contains a valid keyspace ID.
+// The key format is: [mode_prefix][keyspace_id_3bytes][...], where mode_prefix is 'x' for txn.
+// Only txn mode keys are supported.
+func ExtractKeyspaceID(key []byte) (uint32, bool) {
+	// Empty key represents the start of the entire key space (no keyspace)
+	if len(key) == 0 {
+		return constant.MaxValidKeyspaceID, true
+	}
+
+	// Decode the key
+	_, decoded, err := codec.DecodeBytes(key)
+	if err != nil {
+		return 0, false
+	}
+
+	// Check if the key has a mode prefix and keyspace ID (at least 4 bytes: prefix + 3 bytes ID)
+	if len(decoded) < 4 {
+		return 0, false
+	}
+
+	// Check if it's a txn mode ('x') key - raw mode is not supported
+	prefix := decoded[0]
+	if prefix != 'x' {
+		return 0, false
+	}
+
+	// Extract keyspace ID (3 bytes after the prefix)
+	// Convert 3 bytes to uint32 by shifting and combining
+	keyspaceID := uint32(decoded[1])<<16 | uint32(decoded[2])<<8 | uint32(decoded[3])
+
+	return keyspaceID, true
+}
+
+// KeyspaceChecker is an interface to check if a keyspace exists.
+type KeyspaceChecker interface {
+	// KeyspaceExists checks if a keyspace with the given ID exists.
+	KeyspaceExists(id uint32) bool
+}
+
+// RegionSpansMultipleKeyspaces checks if a region spans across multiple keyspaces.
+// It returns true if the region crosses keyspace boundaries, false otherwise.
+// startKey is the region start key, endKey is the region end key (exclusive).
+// A region [startKey, endKey) spans multiple keyspaces if:
+// 1. startKey and endKey have different keyspace IDs, AND
+// 2. endKey is NOT exactly at the right bound of startKey's keyspace (i.e., not just at the boundary), AND
+// 3. All keyspaces that the region actually spans exist (checked via checker)
+func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker KeyspaceChecker) bool {
+	// If endKey is empty, it represents infinity boundary
+	if len(endKey) == 0 {
+		return false
+	}
+
+	startKeyspaceID, startHasKeyspace := ExtractKeyspaceID(startKey)
+	endKeyspaceID, endHasKeyspace := ExtractKeyspaceID(endKey)
+
+	// If either key doesn't have a keyspace ID, cannot determine
+	if !startHasKeyspace || !endHasKeyspace {
+		return false
+	}
+
+	// If keyspace IDs are the same, definitely within one keyspace
+	if startKeyspaceID == endKeyspaceID {
+		return false
+	}
+
+	// If endKey's keyspace ID is exactly startKeyspace ID + 1,
+	// check if endKey is at the exact boundary (right bound of startKeyspace)
+	// If yes, the region is [startKey, rightBound of startKeyspace) which is within one keyspace
+	if endKeyspaceID == startKeyspaceID+1 {
+		startBound := MakeRegionBound(startKeyspaceID)
+		// endKey == TxnRightBound means the region is [startKey, rightBound of startKeyspace)
+		// which is still within one keyspace
+		if string(endKey) == string(startBound.TxnRightBound) {
+			return false
+		}
+	}
+
+	// Check if all keyspaces that the region spans (between start and end, exclusive of endKeyspace)
+	// exist. Since endKey is exclusive, we check up to endKeyspaceID-1.
+	// If any keyspace doesn't exist (deleted), don't enforce the boundary
+	if checker != nil {
+		for id := startKeyspaceID; id < endKeyspaceID; id++ {
+			if !checker.KeyspaceExists(id) {
+				return false
+			}
+		}
+	}
+
+	// Otherwise, the region spans multiple keyspaces
+	return true
+}
+
+// GetKeyspaceSplitKeys returns the split keys for a region that spans multiple keyspaces.
+// It returns a list of keys where the region should be split to separate keyspaces.
+// Only returns split keys for keyspaces that exist (checked via checker).
+func GetKeyspaceSplitKeys(startKey, endKey []byte, checker KeyspaceChecker) [][]byte {
+	// If checker is nil, cannot verify keyspace existence
+	if checker == nil {
+		return nil
+	}
+
+	if len(endKey) == 0 {
+		return nil
+	}
+
+	startKeyspaceID, startHasKeyspace := ExtractKeyspaceID(startKey)
+	endKeyspaceID, endHasKeyspace := ExtractKeyspaceID(endKey)
+
+	// If either key doesn't have a keyspace ID, cannot determine split keys
+	if !startHasKeyspace || !endHasKeyspace {
+		return nil
+	}
+
+	// If same keyspace, no split needed
+	if startKeyspaceID == endKeyspaceID {
+		return nil
+	}
+
+	// Check if the start keyspace exists
+	if !checker.KeyspaceExists(startKeyspaceID) {
+		return nil
+	}
+
+	var splitKeys [][]byte
+
+	// Generate split keys for each keyspace boundary between start and end
+	// Only include boundaries for keyspaces that exist
+	for currentID := startKeyspaceID; currentID < endKeyspaceID; currentID++ {
+		// Check if the next keyspace exists before adding a split key
+		nextID := currentID + 1
+		if !checker.KeyspaceExists(nextID) {
+			continue
+		}
+
+		bound := MakeRegionBound(currentID)
+		rightBound := bound.TxnRightBound
+
+		// If the right bound is >= endKey, we're done
+		if string(rightBound) >= string(endKey) {
+			break
+		}
+
+		// Add this boundary as a split key
+		splitKeys = append(splitKeys, rightBound)
+
+		// Safety check to prevent infinite loops
+		if currentID >= constant.MaxValidKeyspaceID {
+			break
+		}
+	}
+
+	return splitKeys
 }

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/utils/keyutil"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
 
@@ -53,8 +54,8 @@ var (
 	}
 	// Only keyspaces in the state specified by allowChangeConfig are allowed to change their config.
 	allowChangeConfig = []keyspacepb.KeyspaceState{keyspacepb.KeyspaceState_ENABLED, keyspacepb.KeyspaceState_DISABLED}
-	RawPrefix         = []byte{'r'}
-	TxnPrefix         = []byte{'x'}
+	rawPrefix         = []byte{'r'}
+	txnPrefix         = []byte{'x'}
 )
 
 // validateID check if keyspace falls within the acceptable range.
@@ -131,10 +132,10 @@ func MakeRegionBound(id uint32) *RegionBound {
 	binary.BigEndian.PutUint32(keyspaceIDBytes, id)
 	binary.BigEndian.PutUint32(nextKeyspaceIDBytes, id+1)
 	return &RegionBound{
-		RawLeftBound:  codec.EncodeBytes(append(RawPrefix, keyspaceIDBytes[1:]...)),
-		RawRightBound: codec.EncodeBytes(append(RawPrefix, nextKeyspaceIDBytes[1:]...)),
-		TxnLeftBound:  codec.EncodeBytes(append(TxnPrefix, keyspaceIDBytes[1:]...)),
-		TxnRightBound: codec.EncodeBytes(append(TxnPrefix, nextKeyspaceIDBytes[1:]...)),
+		RawLeftBound:  codec.EncodeBytes(append(rawPrefix, keyspaceIDBytes[1:]...)),
+		RawRightBound: codec.EncodeBytes(append(rawPrefix, nextKeyspaceIDBytes[1:]...)),
+		TxnLeftBound:  codec.EncodeBytes(append(txnPrefix, keyspaceIDBytes[1:]...)),
+		TxnRightBound: codec.EncodeBytes(append(txnPrefix, nextKeyspaceIDBytes[1:]...)),
 	}
 }
 
@@ -316,7 +317,7 @@ func ExtractKeyspaceID(key []byte) (uint32, bool) {
 
 	// Check the mod prefix.
 	prefix := decoded[0]
-	if prefix != RawPrefix[0] && prefix != TxnPrefix[0] {
+	if prefix != rawPrefix[0] && prefix != txnPrefix[0] {
 		return 0, false
 	}
 
@@ -327,10 +328,12 @@ func ExtractKeyspaceID(key []byte) (uint32, bool) {
 	return keyspaceID, true
 }
 
-// KeyspaceChecker is an interface to check if a keyspace exists.
-type KeyspaceChecker interface {
+// Checker is an interface to check keyspace existence.
+type Checker interface {
 	// KeyspaceExists checks if a keyspace with the given ID exists.
 	KeyspaceExists(id uint32) bool
+	// GetKeyspaceIDInRange returns one existing keyspace ID in (start, end).
+	GetKeyspaceIDInRange(start, end uint32) (uint32, bool)
 }
 
 // RegionSpansMultipleKeyspaces checks if a region spans across multiple keyspaces.
@@ -339,8 +342,8 @@ type KeyspaceChecker interface {
 // A region [startKey, endKey) spans multiple keyspaces if:
 // 1. startKey and endKey have different keyspace IDs, AND
 // 2. endKey is NOT exactly at the right bound of startKey's keyspace (i.e., not just at the boundary), AND
-// 3. All keyspaces that the region actually spans exist (checked via checker)
-func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker KeyspaceChecker) bool {
+// 3. At least two existing keyspaces are crossed (checked via checker)
+func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker Checker) bool {
 	var startKeyspaceID uint32
 	var startHasKeyspace bool
 	if len(startKey) == 0 {
@@ -363,25 +366,24 @@ func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker KeyspaceCheck
 
 	// If endKey's keyspace ID is exactly startKeyspace ID + 1,
 	// check if endKey is at the exact boundary (right bound of startKeyspace)
-	// If yes, the region is [startKey, rightBound of startKeyspace) which is within one keyspace
+	// If yes, the region is [startKey, rightBound of startKeyspace) which is within one keyspace.
+	// Otherwise, the neighboring keyspace is occupied and the region spans multiple keyspaces.
 	if endKeyspaceID == startKeyspaceID+1 {
 		startBound := MakeRegionBound(startKeyspaceID)
-		// endKey == TxnRightBound means the region is [startKey, rightBound of startKeyspace)
+		// it means the region is [startKey, rightBound of startKeyspace)
 		// which is still within one keyspace
-		if string(endKey) == string(startBound.TxnRightBound) {
+		if string(endKey) == string(startBound.TxnRightBound) || string(endKey) == string(startBound.RawRightBound) {
 			return false
 		}
+		return true
 	}
 
-	// Check if all keyspaces that the region spans (between start and end, exclusive of endKeyspace)
-	// exist. Since endKey is exclusive, we check up to endKeyspaceID-1.
-	// If any keyspace doesn't exist (deleted), don't enforce the boundary
+	// Check existing keyspaces that the region spans in (start, end).
+	// The boundary should be enforced only when the range crosses at least
+	// two existing keyspaces.
 	if checker != nil {
-		for id := startKeyspaceID; id < endKeyspaceID; id++ {
-			if !checker.KeyspaceExists(id) {
-				return false
-			}
-		}
+		_, ok := checker.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
+		return ok
 	}
 
 	// Otherwise, the region spans multiple keyspaces
@@ -391,7 +393,7 @@ func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker KeyspaceCheck
 // GetKeyspaceSplitKeys returns the split keys for a region that spans multiple keyspaces.
 // It returns a list of keys where the region should be split to separate keyspaces.
 // Only returns split keys for keyspaces that exist (checked via checker).
-func GetKeyspaceSplitKeys(startKey, endKey []byte, checker KeyspaceChecker) [][]byte {
+func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 	// If checker is nil, cannot verify keyspace existence
 	if checker == nil {
 		return nil
@@ -417,41 +419,41 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker KeyspaceChecker) [][]
 		return nil
 	}
 
-	var splitKeys [][]byte
-
-	// Generate split keys for each keyspace boundary between start and end
-	// Only include boundaries for keyspaces that exist
-	for currentID := startKeyspaceID; currentID < endKeyspaceID; currentID++ {
-		// Check if the next keyspace exists before adding a split key
-		nextID := currentID + 1
-		if !checker.KeyspaceExists(nextID) {
-			continue
-		}
-
-		bound := MakeRegionBound(currentID)
-		rightBound := bound.TxnRightBound
-
-		// If the right bound is >= endKey, we're done
-		if string(rightBound) >= string(endKey) && len(endKey) != 0 {
-			break
-		}
-
-		// Add this boundary as a split key
-		splitKeys = append(splitKeys, rightBound)
-
-		rightBoundRaw := bound.RawRightBound
-		if string(rightBoundRaw) >= string(endKey) && len(endKey) != 0 {
-			break
-		}
-		splitKeys = append(splitKeys, rightBoundRaw)
-
-		// Safety check to prevent infinite loops
-		if currentID >= constant.MaxValidKeyspaceID {
-			break
+	// If endKey's keyspace ID is exactly startKeyspace ID + 1,
+	// check if endKey is at the exact boundary (right bound of startKeyspace)
+	// If yes, the region is [startKey, rightBound of startKeyspace) which is within one keyspace.
+	// Otherwise, continue to generate split keys.
+	if endKeyspaceID == startKeyspaceID+1 {
+		startBound := MakeRegionBound(startKeyspaceID)
+		// it means the region is [startKey, rightBound of startKeyspace)
+		// which is still within one keyspace
+		if string(endKey) == string(startBound.TxnRightBound) || string(endKey) == string(startBound.RawRightBound) {
+			return nil
 		}
 	}
-	slices.SortFunc(splitKeys, func(a, b []byte) int {
-		return bytes.Compare(a, b)
-	})
+
+	// Generate split keys for each keyspace boundary between start and end.
+	// Iterate existing keyspaces in (startKeyspaceID, endKeyspaceID).
+	var splitKeys [][]byte
+	nextID, ok := checker.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
+	if !ok {
+		return nil
+	}
+	bound := MakeRegionBound(nextID)
+	if keyutil.Between(startKey, endKey, bound.RawLeftBound) {
+		splitKeys = append(splitKeys, bound.RawLeftBound)
+	}
+	if keyutil.Between(startKey, endKey, bound.RawRightBound) {
+		splitKeys = append(splitKeys, bound.RawRightBound)
+	}
+	if keyutil.Between(startKey, endKey, bound.TxnLeftBound) {
+		splitKeys = append(splitKeys, bound.TxnLeftBound)
+	}
+	if keyutil.Between(startKey, endKey, bound.TxnRightBound) {
+		splitKeys = append(splitKeys, bound.TxnRightBound)
+	}
+
+	slices.SortFunc(splitKeys, bytes.Compare)
+	splitKeys = slices.CompactFunc(splitKeys, bytes.Equal)
 	return splitKeys
 }

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -15,14 +15,13 @@
 package keyspace
 
 import (
-	"bytes"
 	"container/heap"
 	"encoding/binary"
 	"encoding/hex"
 	"regexp"
-	"slices"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/google/btree"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
@@ -32,6 +31,7 @@ import (
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/keyutil"
+	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
 
@@ -294,46 +294,72 @@ func isProtectedKeyspaceName(name string) bool {
 	return name == constant.DefaultKeyspaceName
 }
 
+// KeyType represents the type of the key, which can be raw key or txn key.
+type KeyType int
+
+const (
+	// KeyTypeRaw represents the raw keyspace, which is used for KV operations without transaction.
+	KeyTypeRaw KeyType = iota
+	// KeyTypeTxn represents the txn keyspace, which is used for KV operations with transaction.
+	KeyTypeTxn
+	// KeyTypeUnknown represents unknown key type, which is used for invalid keys that cannot be parsed.
+	KeyTypeUnknown
+)
+
 // ExtractKeyspaceID extracts the keyspace ID from a region key.
 // It returns the keyspace ID and a boolean indicating whether the key contains a valid keyspace ID.
 // The key format is: [mode_prefix][keyspace_id_3bytes][...], where mode_prefix is 'x' for txn and 'r' for raw.
-// if the key is empty, it means the key belongs the max keyspace.
-func ExtractKeyspaceID(key []byte) (uint32, bool) {
+// if the key is empty, it means the key belongs the max txn keyspace.
+func ExtractKeyspaceID(key []byte) (uint32, KeyType) {
 	// Empty key represents the start of the entire key space (no keyspace)
 	if len(key) == 0 {
-		return constant.MaxValidKeyspaceID, true
+		return constant.MaxValidKeyspaceID, KeyTypeTxn
 	}
 
 	// Decode the key
 	_, decoded, err := codec.DecodeBytes(key)
 	if err != nil {
-		return 0, false
+		return 0, KeyTypeUnknown
 	}
 
 	// Check if the key has a mode prefix and keyspace ID (at least 4 bytes: prefix + 3 bytes ID)
 	if len(decoded) < 4 {
-		return 0, false
+		return 0, KeyTypeUnknown
 	}
 
 	// Check the mod prefix.
 	prefix := decoded[0]
-	if prefix != rawPrefix[0] && prefix != txnPrefix[0] {
-		return 0, false
+	var kt KeyType
+	switch prefix {
+	case rawPrefix[0]:
+		kt = KeyTypeRaw
+	case txnPrefix[0]:
+		kt = KeyTypeTxn
+	default:
+		return 0, KeyTypeUnknown
 	}
 
 	// Extract keyspace ID (3 bytes after the prefix)
 	// Convert 3 bytes to uint32 by shifting and combining
 	keyspaceID := uint32(decoded[1])<<16 | uint32(decoded[2])<<8 | uint32(decoded[3])
 
-	return keyspaceID, true
+	return keyspaceID, kt
 }
 
 // Checker is an interface to check keyspace existence.
 type Checker interface {
-	// KeyspaceExists checks if a keyspace with the given ID exists.
-	KeyspaceExists(id uint32) bool
-	// GetKeyspaceIDInRange returns one existing keyspace ID in (start, end).
+	// GetKeyspaceIDInRange returns one existing keyspace ID in [start, end].
 	GetKeyspaceIDInRange(start, end uint32) (uint32, bool)
+	// ExistKeyspaceID returns whether the keyspace ID exists.
+	KeyspaceExist(keyspaceID uint32) bool
+}
+
+// AlwaysExistChecker assumes all numeric keyspaces exist.
+type AlwaysExistChecker struct{}
+
+// GetKeyspaceIDInRange returns the first keyspace ID in (start, end).
+func (AlwaysExistChecker) GetKeyspaceIDInRange(start, _ uint32) (uint32, bool) {
+	return start, true
 }
 
 // RegionSpansMultipleKeyspaces checks if a region spans across multiple keyspaces.
@@ -345,29 +371,31 @@ type Checker interface {
 // 3. At least two existing keyspaces are crossed (checked via checker)
 func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker Checker) bool {
 	var startKeyspaceID uint32
-	var startHasKeyspace bool
+	var startKT KeyType
 	if len(startKey) == 0 {
-		startKeyspaceID, startHasKeyspace = constant.StartKeyspaceID, true
+		startKeyspaceID, startKT = constant.StartKeyspaceID, KeyTypeRaw
 	} else {
-		startKeyspaceID, startHasKeyspace = ExtractKeyspaceID(startKey)
+		startKeyspaceID, startKT = ExtractKeyspaceID(startKey)
 	}
 
-	endKeyspaceID, endHasKeyspace := ExtractKeyspaceID(endKey)
+	endKeyspaceID, endKT := ExtractKeyspaceID(endKey)
 
-	// If either key doesn't have a keyspace ID, cannot determine
-	if !startHasKeyspace || !endHasKeyspace {
+	if startKT == KeyTypeUnknown && endKT == KeyTypeUnknown {
 		return false
 	}
 
-	// If keyspace IDs are the same, definitely within one keyspace
-	if startKeyspaceID == endKeyspaceID {
+	// If keyspace IDs are the same, and the key type is the same, it does not span multiple keyspaces.
+	// startKey is the 100 keyspace's left raw bound['r', 0, 100].
+	// endKey is the 100 keyspace's left txn bound['t',0,100].
+	// Although they belong to the same keyspace, but they have different key type, we consider they belong to different keyspaces,
+	// thus it spans multiple keyspaces.
+	if startKeyspaceID == endKeyspaceID && startKT == endKT {
 		return false
 	}
 
 	// If endKey's keyspace ID is exactly startKeyspace ID + 1,
 	// check if endKey is at the exact boundary (right bound of startKeyspace)
 	// If yes, the region is [startKey, rightBound of startKeyspace) which is within one keyspace.
-	// Otherwise, the neighboring keyspace is occupied and the region spans multiple keyspaces.
 	if endKeyspaceID == startKeyspaceID+1 {
 		startBound := MakeRegionBound(startKeyspaceID)
 		// it means the region is [startKey, rightBound of startKeyspace)
@@ -375,15 +403,14 @@ func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker Checker) bool
 		if string(endKey) == string(startBound.TxnRightBound) || string(endKey) == string(startBound.RawRightBound) {
 			return false
 		}
-		return true
 	}
 
-	// Check existing keyspaces that the region spans in (start, end).
-	// The boundary should be enforced only when the range crosses at least
-	// two existing keyspaces.
+	// If endKeyspaceID is more than startKeyspaceID + 1,
+	// check if there is at least one existing keyspace in between.
 	if checker != nil {
-		_, ok := checker.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
-		return ok
+		startExist := checker.KeyspaceExist(startKeyspaceID)
+		endExist := checker.KeyspaceExist(endKeyspaceID)
+		return startExist || endExist
 	}
 
 	// Otherwise, the region spans multiple keyspaces
@@ -400,17 +427,17 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 	}
 
 	var startKeyspaceID uint32
-	var startHasKeyspace bool
+	var startKT KeyType
 	if len(startKey) == 0 {
-		startKeyspaceID, startHasKeyspace = constant.StartKeyspaceID, true
+		startKeyspaceID, startKT = constant.StartKeyspaceID, KeyTypeRaw
 	} else {
-		startKeyspaceID, startHasKeyspace = ExtractKeyspaceID(startKey)
+		startKeyspaceID, startKT = ExtractKeyspaceID(startKey)
 	}
 
-	endKeyspaceID, endHasKeyspace := ExtractKeyspaceID(endKey)
+	endKeyspaceID, endKT := ExtractKeyspaceID(endKey)
 
-	// If either key doesn't have a keyspace ID, cannot determine split keys
-	if !startHasKeyspace || !endHasKeyspace {
+	// If either key has unknown key type, cannot determine keyspace boundaries
+	if startKT == KeyTypeUnknown && endKT == KeyTypeUnknown {
 		return nil
 	}
 
@@ -435,6 +462,9 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 	// Generate split keys for each keyspace boundary between start and end.
 	// Iterate existing keyspaces in (startKeyspaceID, endKeyspaceID).
 	var splitKeys [][]byte
+	if endKT == KeyTypeUnknown {
+		endKeyspaceID = constant.MaxValidKeyspaceID
+	}
 	nextID, ok := checker.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
 	if !ok {
 		return nil
@@ -452,8 +482,87 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 	if keyutil.Between(startKey, endKey, bound.TxnRightBound) {
 		splitKeys = append(splitKeys, bound.TxnRightBound)
 	}
-
-	slices.SortFunc(splitKeys, bytes.Compare)
-	splitKeys = slices.CompactFunc(splitKeys, bytes.Equal)
 	return splitKeys
+}
+
+// Cache is a cache for keyspace information, which is used to quickly determine keyspace existence and get keyspace name by ID.
+type Cache struct {
+	syncutil.RWMutex
+	tree *btree.BTreeG[keyspaceItem]
+}
+
+// NewCache creates a new Cache.
+func NewCache() *Cache {
+	return &Cache{
+		tree: btree.NewG(2, func(i, j keyspaceItem) bool {
+			return i.Less(j)
+		}),
+	}
+}
+
+type keyspaceItem struct {
+	keyspaceID uint32
+	name       string
+	state      keyspacepb.KeyspaceState
+}
+
+// Less compares two keyspaceItem.
+func (s *keyspaceItem) Less(than keyspaceItem) bool {
+	return s.keyspaceID < than.keyspaceID
+}
+
+func (s *Cache) getKeyspaceByID(keyspaceID uint32) (keyspaceItem, bool) {
+	s.RLock()
+	defer s.RUnlock()
+	item, found := s.tree.Get(keyspaceItem{keyspaceID: keyspaceID})
+	return item, found
+}
+
+// Save saves the keyspace information to the cache. It will replace the old information if the keyspace ID already exists.
+func (s *Cache) Save(keyspaceID uint32, name string, state keyspacepb.KeyspaceState) {
+	s.Lock()
+	defer s.Unlock()
+	item := keyspaceItem{keyspaceID: keyspaceID, name: name, state: state}
+	s.tree.ReplaceOrInsert(item)
+}
+
+// DeleteKeyspace deletes a keyspace by ID.
+func (s *Cache) DeleteKeyspace(keyspaceID uint32) {
+	s.Lock()
+	defer s.Unlock()
+	s.tree.Delete(keyspaceItem{keyspaceID: keyspaceID})
+}
+
+func (s *Cache) scanAllKeyspaces(f func(keyspaceID uint32, name string) bool) {
+	s.RLock()
+	defer s.RUnlock()
+	s.tree.Ascend(func(i keyspaceItem) bool {
+		return f(i.keyspaceID, i.name)
+	})
+}
+
+// KeyspaceExist checks if a keyspace exists by ID.
+func (s *Cache) KeyspaceExist(id uint32) bool {
+	s.RLock()
+	defer s.RUnlock()
+	_, found := s.tree.Get(keyspaceItem{keyspaceID: id})
+	return found
+}
+
+// GetKeyspaceIDInRange returns the first keyspace ID in the range [start, end].
+func (s *Cache) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	s.RLock()
+	defer s.RUnlock()
+	var foundID uint32
+	s.tree.AscendGreaterOrEqual(keyspaceItem{keyspaceID: start}, func(i keyspaceItem) bool {
+		if i.keyspaceID <= end {
+			foundID = i.keyspaceID
+			return false
+		}
+		return true
+	})
+	if foundID != 0 {
+		return foundID, true
+	}
+	return 0, false
 }

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -380,7 +380,11 @@ func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker Checker) bool
 
 	endKeyspaceID, endKT := ExtractKeyspaceID(endKey)
 
-	if startKT == KeyTypeUnknown && endKT == KeyTypeUnknown {
+	// If either key has unknown key type, conservatively consider it spans multiple keyspaces to avoid potential data corruption.
+	// This can happen when the key is not in the expected format, or when there is a hole in keyspace allocation.
+	// For example, if startKey has valid keyspace ID but endKey is invalid, we cannot determine the keyspace boundary,
+	// thus we consider it spans multiple keyspaces to be safe.
+	if startKT == KeyTypeUnknown && (endKT == KeyTypeUnknown || len(endKey) == 0) {
 		return false
 	}
 

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -15,10 +15,12 @@
 package keyspace
 
 import (
+	"bytes"
 	"container/heap"
 	"encoding/binary"
 	"encoding/hex"
 	"regexp"
+	"slices"
 
 	"github.com/gogo/protobuf/proto"
 
@@ -51,6 +53,8 @@ var (
 	}
 	// Only keyspaces in the state specified by allowChangeConfig are allowed to change their config.
 	allowChangeConfig = []keyspacepb.KeyspaceState{keyspacepb.KeyspaceState_ENABLED, keyspacepb.KeyspaceState_DISABLED}
+	RawPrefix         = []byte{'r'}
+	TxnPrefix         = []byte{'x'}
 )
 
 // validateID check if keyspace falls within the acceptable range.
@@ -126,12 +130,11 @@ func MakeRegionBound(id uint32) *RegionBound {
 	nextKeyspaceIDBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(keyspaceIDBytes, id)
 	binary.BigEndian.PutUint32(nextKeyspaceIDBytes, id+1)
-	tr := codec.EncodeBytes(append([]byte{'x'}, keyspaceIDBytes[1:]...))
 	return &RegionBound{
-		RawLeftBound:  codec.EncodeBytes(append([]byte{'r'}, keyspaceIDBytes[1:]...)),
-		RawRightBound: codec.EncodeBytes(append([]byte{'r'}, nextKeyspaceIDBytes[1:]...)),
-		TxnLeftBound:  tr,
-		TxnRightBound: codec.EncodeBytes(append([]byte{'x'}, nextKeyspaceIDBytes[1:]...)),
+		RawLeftBound:  codec.EncodeBytes(append(RawPrefix, keyspaceIDBytes[1:]...)),
+		RawRightBound: codec.EncodeBytes(append(RawPrefix, nextKeyspaceIDBytes[1:]...)),
+		TxnLeftBound:  codec.EncodeBytes(append(TxnPrefix, keyspaceIDBytes[1:]...)),
+		TxnRightBound: codec.EncodeBytes(append(TxnPrefix, nextKeyspaceIDBytes[1:]...)),
 	}
 }
 
@@ -292,8 +295,8 @@ func isProtectedKeyspaceName(name string) bool {
 
 // ExtractKeyspaceID extracts the keyspace ID from a region key.
 // It returns the keyspace ID and a boolean indicating whether the key contains a valid keyspace ID.
-// The key format is: [mode_prefix][keyspace_id_3bytes][...], where mode_prefix is 'x' for txn.
-// Only txn mode keys are supported.
+// The key format is: [mode_prefix][keyspace_id_3bytes][...], where mode_prefix is 'x' for txn and 'r' for raw.
+// if the key is empty, it means the key belongs the max keyspace.
 func ExtractKeyspaceID(key []byte) (uint32, bool) {
 	// Empty key represents the start of the entire key space (no keyspace)
 	if len(key) == 0 {
@@ -311,9 +314,9 @@ func ExtractKeyspaceID(key []byte) (uint32, bool) {
 		return 0, false
 	}
 
-	// Check if it's a txn mode ('x') key - raw mode is not supported
+	// Check the mod prefix.
 	prefix := decoded[0]
-	if prefix != 'x' {
+	if prefix != RawPrefix[0] && prefix != TxnPrefix[0] {
 		return 0, false
 	}
 
@@ -338,12 +341,14 @@ type KeyspaceChecker interface {
 // 2. endKey is NOT exactly at the right bound of startKey's keyspace (i.e., not just at the boundary), AND
 // 3. All keyspaces that the region actually spans exist (checked via checker)
 func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker KeyspaceChecker) bool {
-	// If endKey is empty, it represents infinity boundary
-	if len(endKey) == 0 {
-		return false
+	var startKeyspaceID uint32
+	var startHasKeyspace bool
+	if len(startKey) == 0 {
+		startKeyspaceID, startHasKeyspace = constant.StartKeyspaceID, true
+	} else {
+		startKeyspaceID, startHasKeyspace = ExtractKeyspaceID(startKey)
 	}
 
-	startKeyspaceID, startHasKeyspace := ExtractKeyspaceID(startKey)
 	endKeyspaceID, endHasKeyspace := ExtractKeyspaceID(endKey)
 
 	// If either key doesn't have a keyspace ID, cannot determine
@@ -392,11 +397,14 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker KeyspaceChecker) [][]
 		return nil
 	}
 
-	if len(endKey) == 0 {
-		return nil
+	var startKeyspaceID uint32
+	var startHasKeyspace bool
+	if len(startKey) == 0 {
+		startKeyspaceID, startHasKeyspace = constant.StartKeyspaceID, true
+	} else {
+		startKeyspaceID, startHasKeyspace = ExtractKeyspaceID(startKey)
 	}
 
-	startKeyspaceID, startHasKeyspace := ExtractKeyspaceID(startKey)
 	endKeyspaceID, endHasKeyspace := ExtractKeyspaceID(endKey)
 
 	// If either key doesn't have a keyspace ID, cannot determine split keys
@@ -406,11 +414,6 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker KeyspaceChecker) [][]
 
 	// If same keyspace, no split needed
 	if startKeyspaceID == endKeyspaceID {
-		return nil
-	}
-
-	// Check if the start keyspace exists
-	if !checker.KeyspaceExists(startKeyspaceID) {
 		return nil
 	}
 
@@ -429,18 +432,26 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker KeyspaceChecker) [][]
 		rightBound := bound.TxnRightBound
 
 		// If the right bound is >= endKey, we're done
-		if string(rightBound) >= string(endKey) {
+		if string(rightBound) >= string(endKey) && len(endKey) != 0 {
 			break
 		}
 
 		// Add this boundary as a split key
 		splitKeys = append(splitKeys, rightBound)
 
+		rightBoundRaw := bound.RawRightBound
+		if string(rightBoundRaw) >= string(endKey) && len(endKey) != 0 {
+			break
+		}
+		splitKeys = append(splitKeys, rightBoundRaw)
+
 		// Safety check to prevent infinite loops
 		if currentID >= constant.MaxValidKeyspaceID {
 			break
 		}
 	}
-
+	slices.SortFunc(splitKeys, func(a, b []byte) int {
+		return bytes.Compare(a, b)
+	})
 	return splitKeys
 }

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -439,10 +439,13 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 	}
 
 	endKeyspaceID, endKT := ExtractKeyspaceID(endKey)
-
 	// If either key has unknown key type, cannot determine keyspace boundaries
 	if startKT == KeyTypeUnknown && endKT == KeyTypeUnknown {
 		return nil
+	}
+	// If endKey is unknown, set the endKeyspaceID to the max valid keyspace ID to generate split keys for all keyspaces after startKeyspaceID.
+	if endKT == KeyTypeUnknown {
+		endKeyspaceID = constant.MaxValidKeyspaceID
 	}
 
 	// If same keyspace, no split needed
@@ -462,13 +465,14 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 			return nil
 		}
 	}
-
+	// If startKeyspaceID and endKeyspaceID are different, the end keyspace id should be biggest to find all split keys.
+	if startKT == KeyTypeRaw && endKT == KeyTypeTxn {
+		endKeyspaceID = constant.MaxValidKeyspaceID
+	}
 	// Generate split keys for each keyspace boundary between start and end.
 	// Iterate existing keyspaces in (startKeyspaceID, endKeyspaceID).
 	var splitKeys [][]byte
-	if endKT == KeyTypeUnknown {
-		endKeyspaceID = constant.MaxValidKeyspaceID
-	}
+
 	nextID, ok := checker.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
 	if !ok {
 		return nil
@@ -559,8 +563,8 @@ func (s *Cache) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
 	defer s.RUnlock()
 	var foundID uint32
 	found := false
-	s.tree.AscendGreaterOrEqual(keyspaceItem{keyspaceID: start}, func(i keyspaceItem) bool {
-		if i.keyspaceID <= end {
+	s.tree.DescendLessOrEqual(keyspaceItem{keyspaceID: end}, func(i keyspaceItem) bool {
+		if i.keyspaceID >= start {
 			foundID = i.keyspaceID
 			found = true
 			return false

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -15,10 +15,12 @@
 package keyspace
 
 import (
+	"bytes"
 	"container/heap"
 	"encoding/binary"
 	"encoding/hex"
 	"regexp"
+	"slices"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/btree"
@@ -349,7 +351,7 @@ func ExtractKeyspaceID(key []byte) (uint32, KeyType) {
 // Checker is an interface to check keyspace existence.
 type Checker interface {
 	// GetKeyspaceIDInRange returns one existing keyspace ID in [start, end].
-	GetKeyspaceIDInRange(start, end uint32) (uint32, bool)
+	GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool)
 	// ExistKeyspaceID returns whether the keyspace ID exists.
 	KeyspaceExist(keyspaceID uint32) bool
 }
@@ -358,8 +360,8 @@ type Checker interface {
 type AlwaysExistChecker struct{}
 
 // GetKeyspaceIDInRange returns the first keyspace ID in (start, end).
-func (AlwaysExistChecker) GetKeyspaceIDInRange(start, _ uint32) (uint32, bool) {
-	return start, true
+func (AlwaysExistChecker) GetKeyspaceIDInRange(start, _ uint32) ([]uint32, bool) {
+	return []uint32{start}, true
 }
 
 // RegionSpansMultipleKeyspaces checks if a region spans across multiple keyspaces.
@@ -396,6 +398,10 @@ func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker Checker) bool
 	if startKeyspaceID == endKeyspaceID && startKT == endKT {
 		return false
 	}
+	// If keyspace IDs are different, but the key type is different, we consider it does not span multiple keyspaces.
+	if startKT == KeyTypeRaw && endKT == KeyTypeTxn {
+		return true
+	}
 
 	// If endKey's keyspace ID is exactly startKeyspace ID + 1,
 	// check if endKey is at the exact boundary (right bound of startKeyspace)
@@ -420,6 +426,8 @@ func RegionSpansMultipleKeyspaces(startKey, endKey []byte, checker Checker) bool
 	// Otherwise, the region spans multiple keyspaces
 	return true
 }
+
+const scanLimit = 10
 
 // GetKeyspaceSplitKeys returns the split keys for a region that spans multiple keyspaces.
 // It returns a list of keys where the region should be split to separate keyspaces.
@@ -449,8 +457,12 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 	}
 
 	// If same keyspace, no split needed
-	if startKeyspaceID == endKeyspaceID {
+	if startKeyspaceID == endKeyspaceID && startKT == endKT {
 		return nil
+	}
+	// If startKeyspaceID and endKeyspaceID are different, the end keyspace id should be biggest to find all split keys.
+	if startKT == KeyTypeRaw && endKT == KeyTypeTxn {
+		endKeyspaceID = constant.MaxValidKeyspaceID
 	}
 
 	// If endKey's keyspace ID is exactly startKeyspace ID + 1,
@@ -465,32 +477,38 @@ func GetKeyspaceSplitKeys(startKey, endKey []byte, checker Checker) [][]byte {
 			return nil
 		}
 	}
-	// If startKeyspaceID and endKeyspaceID are different, the end keyspace id should be biggest to find all split keys.
-	if startKT == KeyTypeRaw && endKT == KeyTypeTxn {
-		endKeyspaceID = constant.MaxValidKeyspaceID
-	}
+
 	// Generate split keys for each keyspace boundary between start and end.
 	// Iterate existing keyspaces in (startKeyspaceID, endKeyspaceID).
 	var splitKeys [][]byte
 
-	nextID, ok := checker.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
+	keyspaceList, ok := checker.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID, scanLimit)
 	if !ok {
 		return nil
 	}
-	bound := MakeRegionBound(nextID)
-	if keyutil.Between(startKey, endKey, bound.RawLeftBound) {
-		splitKeys = append(splitKeys, bound.RawLeftBound)
+	if keyspaceList == nil {
+		return nil
 	}
-	if keyutil.Between(startKey, endKey, bound.RawRightBound) {
-		splitKeys = append(splitKeys, bound.RawRightBound)
+	for _, nextID := range keyspaceList {
+		bound := MakeRegionBound(nextID)
+		if keyutil.Between(startKey, endKey, bound.RawLeftBound) {
+			splitKeys = append(splitKeys, bound.RawLeftBound)
+		}
+		if keyutil.Between(startKey, endKey, bound.RawRightBound) {
+			splitKeys = append(splitKeys, bound.RawRightBound)
+		}
+		if keyutil.Between(startKey, endKey, bound.TxnLeftBound) {
+			splitKeys = append(splitKeys, bound.TxnLeftBound)
+		}
+		if keyutil.Between(startKey, endKey, bound.TxnRightBound) {
+			splitKeys = append(splitKeys, bound.TxnRightBound)
+		}
 	}
-	if keyutil.Between(startKey, endKey, bound.TxnLeftBound) {
-		splitKeys = append(splitKeys, bound.TxnLeftBound)
+	if len(splitKeys) == 0 {
+		return nil
 	}
-	if keyutil.Between(startKey, endKey, bound.TxnRightBound) {
-		splitKeys = append(splitKeys, bound.TxnRightBound)
-	}
-	return splitKeys
+	slices.SortFunc(splitKeys, bytes.Compare)
+	return slices.CompactFunc(splitKeys, bytes.Equal)
 }
 
 // Cache is a cache for keyspace information, which is used to quickly determine keyspace existence and get keyspace name by ID.
@@ -553,26 +571,31 @@ func (s *Cache) scanAllKeyspaces(f func(keyspaceID uint32, name string) bool) {
 func (s *Cache) KeyspaceExist(id uint32) bool {
 	s.RLock()
 	defer s.RUnlock()
-	_, found := s.tree.Get(keyspaceItem{keyspaceID: id})
+	item, found := s.tree.Get(keyspaceItem{keyspaceID: id})
+	if found && item.state == keyspacepb.KeyspaceState_TOMBSTONE {
+		return false
+	}
 	return found
 }
 
-// GetKeyspaceIDInRange returns the first keyspace ID in the range [start, end].
-func (s *Cache) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+// GetKeyspaceIDInRange returns the keyspace IDs in the range [start, end].
+func (s *Cache) GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool) {
 	s.RLock()
 	defer s.RUnlock()
-	var foundID uint32
+	ret := make([]uint32, 0)
 	found := false
-	s.tree.DescendLessOrEqual(keyspaceItem{keyspaceID: end}, func(i keyspaceItem) bool {
-		if i.keyspaceID >= start {
-			foundID = i.keyspaceID
+	s.tree.DescendLessOrEqual(keyspaceItem{keyspaceID: end}, func(item keyspaceItem) bool {
+		if item.state == keyspacepb.KeyspaceState_TOMBSTONE {
+			return true
+		}
+		if item.keyspaceID >= start {
+			ret = append(ret, item.keyspaceID)
 			found = true
-			return false
+			if limit > 0 && len(ret) >= limit {
+				return false
+			}
 		}
 		return true
 	})
-	if foundID != 0 {
-		return foundID, true
-	}
-	return foundID, found
+	return ret, found
 }

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -138,15 +138,6 @@ func TestProtectedKeyspaceValidation(t *testing.T) {
 	}
 }
 
-func TestDecodeKeyspace(t *testing.T) {
-	re := require.New(t)
-	bound := MakeRegionBound(100)
-	k := codec.Key(bound.TxnLeftBound)
-	ok, keyspaceID := k.DecodeKeyspaceTxnKey()
-	re.True(ok)
-	re.Equal(uint32(100), keyspaceID)
-}
-
 func TestExtractKeyspaceID(t *testing.T) {
 	re := require.New(t)
 	testCases := []struct {
@@ -251,11 +242,18 @@ func TestRegionSpansMultipleKeyspaces(t *testing.T) {
 		expectedResult bool
 	}{
 		{
+			name:           "empty start and end key",
+			startKey:       []byte{},
+			endKey:         []byte{},
+			checker:        allExistChecker,
+			expectedResult: true,
+		},
+		{
 			name:           "empty end key",
 			startKey:       MakeRegionBound(1).TxnLeftBound,
 			endKey:         []byte{},
 			checker:        allExistChecker,
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			name:           "same keyspace txn mode",
@@ -347,11 +345,25 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 		expectedSplitKeys int
 	}{
 		{
+			name:              "empty start and end key",
+			startKey:          []byte{},
+			endKey:            []byte{},
+			checker:           specificChecker,
+			expectedSplitKeys: 6,
+		},
+		{
+			name:              "empty start and end key",
+			startKey:          []byte{},
+			endKey:            []byte{},
+			checker:           allExistChecker,
+			expectedSplitKeys: int(constant.MaxValidKeyspaceID-constant.StartKeyspaceID-2) * 2,
+		},
+		{
 			name:              "empty end key",
 			startKey:          MakeRegionBound(1).TxnLeftBound,
 			endKey:            []byte{},
 			checker:           allExistChecker,
-			expectedSplitKeys: 0,
+			expectedSplitKeys: int(constant.MaxValidKeyspaceID-constant.StartKeyspaceID-1) * 2,
 		},
 		{
 			name:              "same keyspace txn mode",
@@ -365,29 +377,29 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 			startKey:          MakeRegionBound(100).TxnLeftBound,
 			endKey:            MakeRegionBound(101).TxnRightBound,
 			checker:           allExistChecker,
-			expectedSplitKeys: 1,
+			expectedSplitKeys: 2,
 		},
-		{
-			name:              "span 5 keyspaces txn mode",
-			startKey:          MakeRegionBound(100).TxnLeftBound,
-			endKey:            MakeRegionBound(105).TxnRightBound,
-			checker:           allExistChecker,
-			expectedSplitKeys: 5,
-		},
-		{
-			name:              "non-keyspace keys",
-			startKey:          codec.EncodeBytes([]byte{'t', 1, 2, 3}),
-			endKey:            codec.EncodeBytes([]byte{'t', 1, 2, 4}),
-			checker:           allExistChecker,
-			expectedSplitKeys: 0,
-		},
-		{
-			name:              "span keyspaces with deleted ones - only split at existing boundaries",
-			startKey:          MakeRegionBound(100).TxnLeftBound,
-			endKey:            MakeRegionBound(105).TxnRightBound,
-			checker:           specificChecker, // only 100, 101, 102 exist
-			expectedSplitKeys: 2,               // split at boundary of 100 and 101 only (102 has no next)
-		},
+		// {
+		// 	name:              "span 5 keyspaces txn mode",
+		// 	startKey:          MakeRegionBound(100).TxnLeftBound,
+		// 	endKey:            MakeRegionBound(105).TxnRightBound,
+		// 	checker:           allExistChecker,
+		// 	expectedSplitKeys: 5,
+		// },
+		// {
+		// 	name:              "non-keyspace keys",
+		// 	startKey:          codec.EncodeBytes([]byte{'t', 1, 2, 3}),
+		// 	endKey:            codec.EncodeBytes([]byte{'t', 1, 2, 4}),
+		// 	checker:           allExistChecker,
+		// 	expectedSplitKeys: 0,
+		// },
+		// {
+		// 	name:              "span keyspaces with deleted ones - only split at existing boundaries",
+		// 	startKey:          MakeRegionBound(100).TxnLeftBound,
+		// 	endKey:            MakeRegionBound(105).TxnRightBound,
+		// 	checker:           specificChecker, // only 100, 101, 102 exist
+		// 	expectedSplitKeys: 2,               // split at boundary of 100 and 101 only (102 has no next)
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
 
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/keyspace/constant"
@@ -144,63 +145,63 @@ func TestExtractKeyspaceID(t *testing.T) {
 		name            string
 		key             []byte
 		expectedID      uint32
-		expectedSuccess bool
+		expectedKeyType KeyType
 	}{
 		{
 			name:            "empty key",
 			key:             []byte{},
 			expectedID:      constant.MaxValidKeyspaceID,
-			expectedSuccess: true,
+			expectedKeyType: KeyTypeTxn,
 		},
 		{
 			name:            "keyspace 0 txn mode",
 			key:             MakeRegionBound(0).TxnLeftBound,
 			expectedID:      0,
-			expectedSuccess: true,
+			expectedKeyType: KeyTypeTxn,
 		},
 		{
 			name:            "keyspace 100 txn mode",
 			key:             MakeRegionBound(100).TxnLeftBound,
 			expectedID:      100,
-			expectedSuccess: true,
+			expectedKeyType: KeyTypeTxn,
 		},
 		{
 			name:            "keyspace 4242 txn mode",
 			key:             MakeRegionBound(4242).TxnLeftBound,
 			expectedID:      4242,
-			expectedSuccess: true,
+			expectedKeyType: KeyTypeTxn,
 		},
 		{
 			name:            "keyspace 0 raw mode ",
 			key:             MakeRegionBound(0).RawLeftBound,
 			expectedID:      0,
-			expectedSuccess: true,
+			expectedKeyType: KeyTypeRaw,
 		},
 		{
 			name:            "keyspace 100 raw mode (not supported)",
 			key:             MakeRegionBound(100).RawLeftBound,
 			expectedID:      100,
-			expectedSuccess: true,
+			expectedKeyType: KeyTypeRaw,
 		},
 		{
 			name:            "non-keyspace key (table key)",
 			key:             codec.EncodeBytes([]byte{'t', 1, 2, 3}),
 			expectedID:      0,
-			expectedSuccess: false,
+			expectedKeyType: KeyTypeUnknown,
 		},
 		{
 			name:            "short key",
 			key:             codec.EncodeBytes([]byte{'x'}),
 			expectedID:      0,
-			expectedSuccess: false,
+			expectedKeyType: KeyTypeUnknown,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(_ *testing.T) {
-			id, ok := ExtractKeyspaceID(tc.key)
-			re.Equal(tc.expectedSuccess, ok, "test case: %s", tc.name)
-			if tc.expectedSuccess {
+			id, kt := ExtractKeyspaceID(tc.key)
+			re.Equal(tc.expectedKeyType, kt, "test case: %s", tc.name)
+			if tc.expectedKeyType != KeyTypeUnknown {
 				re.Equal(tc.expectedID, id, "test case: %s", tc.name)
 			}
 		})
@@ -213,7 +214,7 @@ type mockKeyspaceChecker struct {
 	allExist          bool
 }
 
-func (m *mockKeyspaceChecker) KeyspaceExists(id uint32) bool {
+func (m *mockKeyspaceChecker) KeyspaceExist(id uint32) bool {
 	if m.allExist {
 		return true
 	}
@@ -390,6 +391,33 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 		expectedSplitKeys [][]byte
 	}{
 		{
+			name:              "non-keyspace keys should not split",
+			startKey:          []byte{'t', 1, 2, 4},
+			endKey:            MakeRegionBound(99).TxnLeftBound,
+			checker:           specificChecker,
+			expectedSplitKeys: nil,
+		},
+		{
+			name:     "non-keyspace keys should not split",
+			startKey: []byte{'t', 1, 2, 4},
+			endKey:   MakeRegionBound(102).TxnLeftBound,
+			checker:  specificChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(100).TxnLeftBound,
+				MakeRegionBound(100).TxnRightBound,
+			},
+		},
+		{
+			name:     "split keys with sparse existing keyspaces",
+			startKey: MakeRegionBound(99).RawLeftBound,
+			endKey:   []byte{'t', 1, 2, 4},
+			checker:  specificChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(100).RawLeftBound,
+				MakeRegionBound(100).RawRightBound,
+			},
+		},
+		{
 			name:     "span two keyspaces txn mode",
 			startKey: MakeRegionBound(100).TxnLeftBound,
 			endKey:   MakeRegionBound(101).TxnRightBound,
@@ -454,6 +482,13 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 				MakeRegionBound(100).TxnRightBound,
 			},
 		},
+		{
+			name:              "not keys with no keyspace key",
+			startKey:          []byte{'t', 1, 2, 3},
+			endKey:            []byte{'t', 1, 2, 4},
+			checker:           specificChecker,
+			expectedSplitKeys: nil,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -462,4 +497,50 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 			re.Equal(tc.expectedSplitKeys, splitKeys, "test case: %s", tc.name)
 		})
 	}
+}
+
+func TestKeyspaceCache(t *testing.T) {
+	re := require.New(t)
+	cache := NewCache()
+
+	cache.Save(100, "ks-100", keyspacepb.KeyspaceState_ENABLED)
+	cache.Save(102, "ks-102", keyspacepb.KeyspaceState_DISABLED)
+	cache.Save(101, "ks-101", keyspacepb.KeyspaceState_ARCHIVED)
+
+	item, ok := cache.getKeyspaceByID(101)
+	re.True(ok)
+	re.Equal(uint32(101), item.keyspaceID)
+	re.Equal("ks-101", item.name)
+	re.Equal(keyspacepb.KeyspaceState_ARCHIVED, item.state)
+
+	all := func() []uint32 {
+		var ret []uint32
+		cache.scanAllKeyspaces(func(keyspaceID uint32, _ string) bool {
+			ret = append(ret, keyspaceID)
+			return true
+		})
+		return ret
+	}
+	re.Equal([]uint32{100, 101, 102}, all())
+
+	id, ok := cache.GetKeyspaceIDInRange(100, 103)
+	re.True(ok)
+	re.Equal(uint32(100), id)
+
+	id, ok = cache.GetKeyspaceIDInRange(101, 102)
+	re.True(ok)
+	re.Equal(uint32(101), id)
+
+	id, ok = cache.GetKeyspaceIDInRange(103, 104)
+	re.False(ok)
+	re.Zero(id)
+
+	cache.DeleteKeyspace(101)
+	_, ok = cache.getKeyspaceByID(101)
+	re.False(ok)
+	re.Equal([]uint32{100, 102}, all())
+
+	id, ok = cache.GetKeyspaceIDInRange(100, 103)
+	re.True(ok)
+	re.Equal(uint32(100), id)
 }

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -171,16 +171,16 @@ func TestExtractKeyspaceID(t *testing.T) {
 			expectedSuccess: true,
 		},
 		{
-			name:            "keyspace 0 raw mode (not supported)",
+			name:            "keyspace 0 raw mode ",
 			key:             MakeRegionBound(0).RawLeftBound,
 			expectedID:      0,
-			expectedSuccess: false,
+			expectedSuccess: true,
 		},
 		{
 			name:            "keyspace 100 raw mode (not supported)",
 			key:             MakeRegionBound(100).RawLeftBound,
-			expectedID:      0,
-			expectedSuccess: false,
+			expectedID:      100,
+			expectedSuccess: true,
 		},
 		{
 			name:            "non-keyspace key (table key)",
@@ -207,23 +207,50 @@ func TestExtractKeyspaceID(t *testing.T) {
 	}
 }
 
-// mockKeyspaceChecker is a mock implementation of KeyspaceChecker for testing.
+// mockKeyspaceChecker is a mock implementation of Checker for testing.
 type mockKeyspaceChecker struct {
 	existingKeyspaces map[uint32]bool
+	allExist          bool
 }
 
 func (m *mockKeyspaceChecker) KeyspaceExists(id uint32) bool {
+	if m.allExist {
+		return true
+	}
 	if m.existingKeyspaces == nil {
 		return true // Default: all keyspaces exist
 	}
 	return m.existingKeyspaces[id]
 }
 
+func (m *mockKeyspaceChecker) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	if start >= end {
+		return 0, false
+	}
+	if m.allExist {
+		if start+1 < end {
+			return start + 1, true
+		}
+		return 0, false
+	}
+	found := false
+	var candidate uint32
+	for id, exists := range m.existingKeyspaces {
+		if exists && id >= start && id <= end {
+			if !found || id < candidate {
+				candidate = id
+				found = true
+			}
+		}
+	}
+	return candidate, found
+}
+
 func TestRegionSpansMultipleKeyspaces(t *testing.T) {
 	re := require.New(t)
 
 	// Mock checker where all keyspaces exist
-	allExistChecker := &mockKeyspaceChecker{}
+	allExistChecker := &mockKeyspaceChecker{allExist: true}
 
 	// Mock checker where only specific keyspaces exist
 	specificChecker := &mockKeyspaceChecker{
@@ -298,11 +325,23 @@ func TestRegionSpansMultipleKeyspaces(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			name:           "span deleted keyspace - should not span",
+			name:           "span deleted keyspace but still cross two existing keyspaces - should span",
 			startKey:       MakeRegionBound(100).TxnLeftBound,
 			endKey:         MakeRegionBound(102).TxnRightBound,
 			checker:        specificChecker, // keyspace 102 doesn't exist
-			expectedResult: false,
+			expectedResult: true,
+		},
+		{
+			name:     "empty end key with sparse existing keyspaces should span when crossing two existing",
+			startKey: MakeRegionBound(101).TxnLeftBound,
+			endKey:   []byte{},
+			checker: &mockKeyspaceChecker{
+				existingKeyspaces: map[uint32]bool{
+					101: true,
+					102: true,
+				},
+			},
+			expectedResult: true,
 		},
 		{
 			name:           "span existing keyspaces - should span",
@@ -314,7 +353,7 @@ func TestRegionSpansMultipleKeyspaces(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(_ *testing.T) {
 			result := RegionSpansMultipleKeyspaces(tc.startKey, tc.endKey, tc.checker)
 			re.Equal(tc.expectedResult, result, "test case: %s", tc.name)
 		})
@@ -325,7 +364,13 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 	re := require.New(t)
 
 	// Mock checker where all keyspaces exist
-	allExistChecker := &mockKeyspaceChecker{}
+	allExistChecker := &mockKeyspaceChecker{allExist: true}
+
+	oneExistChecker := &mockKeyspaceChecker{
+		existingKeyspaces: map[uint32]bool{
+			101: true,
+		},
+	}
 
 	// Mock checker where only specific keyspaces exist
 	specificChecker := &mockKeyspaceChecker{
@@ -342,78 +387,79 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 		startKey          []byte
 		endKey            []byte
 		checker           *mockKeyspaceChecker
-		expectedSplitKeys int
+		expectedSplitKeys [][]byte
 	}{
 		{
-			name:              "empty start and end key",
-			startKey:          []byte{},
-			endKey:            []byte{},
-			checker:           specificChecker,
-			expectedSplitKeys: 6,
+			name:     "span two keyspaces txn mode",
+			startKey: MakeRegionBound(100).TxnLeftBound,
+			endKey:   MakeRegionBound(101).TxnRightBound,
+			checker:  allExistChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(100).TxnRightBound,
+			},
 		},
 		{
-			name:              "empty start and end key",
-			startKey:          []byte{},
-			endKey:            []byte{},
-			checker:           allExistChecker,
-			expectedSplitKeys: int(constant.MaxValidKeyspaceID-constant.StartKeyspaceID-2) * 2,
-		},
-		{
-			name:              "empty end key",
-			startKey:          MakeRegionBound(1).TxnLeftBound,
-			endKey:            []byte{},
-			checker:           allExistChecker,
-			expectedSplitKeys: int(constant.MaxValidKeyspaceID-constant.StartKeyspaceID-1) * 2,
+			name:     "span two keyspaces raw mode",
+			startKey: MakeRegionBound(100).RawLeftBound,
+			endKey:   MakeRegionBound(101).RawRightBound,
+			checker:  allExistChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(100).RawRightBound,
+			},
 		},
 		{
 			name:              "same keyspace txn mode",
 			startKey:          MakeRegionBound(100).TxnLeftBound,
 			endKey:            MakeRegionBound(100).TxnRightBound,
 			checker:           allExistChecker,
-			expectedSplitKeys: 0,
+			expectedSplitKeys: nil,
 		},
 		{
-			name:              "span two keyspaces txn mode",
-			startKey:          MakeRegionBound(100).TxnLeftBound,
-			endKey:            MakeRegionBound(101).TxnRightBound,
+			name:              "same keyspace raw mode",
+			startKey:          MakeRegionBound(100).RawLeftBound,
+			endKey:            MakeRegionBound(100).RawRightBound,
 			checker:           allExistChecker,
-			expectedSplitKeys: 2,
+			expectedSplitKeys: nil,
 		},
-		// {
-		// 	name:              "span 5 keyspaces txn mode",
-		// 	startKey:          MakeRegionBound(100).TxnLeftBound,
-		// 	endKey:            MakeRegionBound(105).TxnRightBound,
-		// 	checker:           allExistChecker,
-		// 	expectedSplitKeys: 5,
-		// },
-		// {
-		// 	name:              "non-keyspace keys",
-		// 	startKey:          codec.EncodeBytes([]byte{'t', 1, 2, 3}),
-		// 	endKey:            codec.EncodeBytes([]byte{'t', 1, 2, 4}),
-		// 	checker:           allExistChecker,
-		// 	expectedSplitKeys: 0,
-		// },
-		// {
-		// 	name:              "span keyspaces with deleted ones - only split at existing boundaries",
-		// 	startKey:          MakeRegionBound(100).TxnLeftBound,
-		// 	endKey:            MakeRegionBound(105).TxnRightBound,
-		// 	checker:           specificChecker, // only 100, 101, 102 exist
-		// 	expectedSplitKeys: 2,               // split at boundary of 100 and 101 only (102 has no next)
-		// },
+		{
+			name:     "adjacent range with one keyspace",
+			startKey: MakeRegionBound(101).TxnLeftBound,
+			endKey:   MakeRegionBound(102).TxnRightBound,
+			checker:  oneExistChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(101).TxnRightBound,
+			},
+		},
+		{
+			name:     "empty start and end key with one exist",
+			startKey: []byte{},
+			endKey:   []byte{},
+			checker:  oneExistChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(101).RawLeftBound,
+				MakeRegionBound(101).RawRightBound,
+				MakeRegionBound(101).TxnLeftBound,
+				MakeRegionBound(101).TxnRightBound,
+			},
+		},
+		{
+			name:     "empty start and end key with three exist",
+			startKey: []byte{},
+			endKey:   []byte{},
+			checker:  specificChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(100).RawLeftBound,
+				MakeRegionBound(100).RawRightBound,
+				MakeRegionBound(100).TxnLeftBound,
+				MakeRegionBound(100).TxnRightBound,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(_ *testing.T) {
 			splitKeys := GetKeyspaceSplitKeys(tc.startKey, tc.endKey, tc.checker)
-			re.Equal(tc.expectedSplitKeys, len(splitKeys), "test case: %s", tc.name)
-
-			// Verify that the split keys are valid and properly ordered
-			if len(splitKeys) > 0 {
-				for i := 0; i < len(splitKeys)-1; i++ {
-					re.True(string(splitKeys[i]) < string(splitKeys[i+1]),
-						"split keys should be in ascending order for test case: %s", tc.name)
-				}
-			}
+			re.Equal(tc.expectedSplitKeys, splitKeys, "test case: %s", tc.name)
 		})
 	}
 }

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -224,24 +224,25 @@ func (m *mockKeyspaceChecker) KeyspaceExist(id uint32) bool {
 	return m.existingKeyspaces[id]
 }
 
-func (m *mockKeyspaceChecker) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+func (m *mockKeyspaceChecker) GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool) {
 	if start >= end {
-		return 0, false
+		return nil, false
 	}
 	if m.allExist {
-		return start, true
+		return []uint32{start}, true
 	}
 	found := false
-	var candidate uint32
+	ret := make([]uint32, 0)
 	for id, exists := range m.existingKeyspaces {
 		if exists && id >= start && id <= end {
-			if !found || id < candidate {
-				candidate = id
-				found = true
+			ret = append(ret, id)
+			found = true
+			if limit > 0 && len(ret) >= limit {
+				break
 			}
 		}
 	}
-	return candidate, found
+	return ret, found
 }
 
 func TestRegionSpansMultipleKeyspaces(t *testing.T) {
@@ -361,16 +362,12 @@ func TestRegionSpansMultipleKeyspaces(t *testing.T) {
 func TestGetKeyspaceSplitKeys(t *testing.T) {
 	re := require.New(t)
 
-	// Mock checker where all keyspaces exist
 	allExistChecker := &mockKeyspaceChecker{allExist: true}
-
 	oneExistChecker := &mockKeyspaceChecker{
 		existingKeyspaces: map[uint32]bool{
 			101: true,
 		},
 	}
-
-	// Mock checker where only specific keyspaces exist
 	specificChecker := &mockKeyspaceChecker{
 		existingKeyspaces: map[uint32]bool{
 			100: true,
@@ -388,11 +385,20 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 		expectedSplitKeys [][]byte
 	}{
 		{
-			name:              "non-keyspace keys should not split",
+			name:              "non-keyspace keys should not split 99",
 			startKey:          []byte{'t', 1, 2, 4},
 			endKey:            MakeRegionBound(99).TxnLeftBound,
 			checker:           specificChecker,
 			expectedSplitKeys: nil,
+		},
+		{
+			name:     "non-keyspace keys should not split",
+			startKey: MakeRegionBound(102).RawLeftBound,
+			endKey:   []byte{'t', 1, 2, 4},
+			checker:  specificChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(103).RawLeftBound,
+			},
 		},
 		{
 			name:     "non-keyspace keys should not split",
@@ -401,7 +407,7 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 			checker:  specificChecker,
 			expectedSplitKeys: [][]byte{
 				MakeRegionBound(100).TxnLeftBound,
-				MakeRegionBound(100).TxnRightBound,
+				MakeRegionBound(101).TxnLeftBound,
 			},
 		},
 		{
@@ -411,7 +417,9 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 			checker:  specificChecker,
 			expectedSplitKeys: [][]byte{
 				MakeRegionBound(100).RawLeftBound,
-				MakeRegionBound(100).RawRightBound,
+				MakeRegionBound(101).RawLeftBound,
+				MakeRegionBound(102).RawLeftBound,
+				MakeRegionBound(103).RawLeftBound,
 			},
 		},
 		{
@@ -474,15 +482,35 @@ func TestGetKeyspaceSplitKeys(t *testing.T) {
 			checker:  specificChecker,
 			expectedSplitKeys: [][]byte{
 				MakeRegionBound(100).RawLeftBound,
-				MakeRegionBound(100).RawRightBound,
+				MakeRegionBound(101).RawLeftBound,
+				MakeRegionBound(102).RawLeftBound,
+				MakeRegionBound(103).RawLeftBound,
 				MakeRegionBound(100).TxnLeftBound,
-				MakeRegionBound(100).TxnRightBound,
+				MakeRegionBound(101).TxnLeftBound,
+				MakeRegionBound(102).TxnLeftBound,
+				MakeRegionBound(103).TxnLeftBound,
 			},
 		},
 		{
 			name:              "not keys with no keyspace key",
 			startKey:          []byte{'t', 1, 2, 3},
 			endKey:            []byte{'t', 1, 2, 4},
+			checker:           specificChecker,
+			expectedSplitKeys: nil,
+		},
+		{
+			name:     "span two keyspaces mix mode",
+			startKey: MakeRegionBound(102).RawLeftBound,
+			endKey:   MakeRegionBound(102).TxnLeftBound,
+			checker:  specificChecker,
+			expectedSplitKeys: [][]byte{
+				MakeRegionBound(103).RawLeftBound,
+			},
+		},
+		{
+			name:              "span two keyspaces mix mode with latest keyspace",
+			startKey:          MakeRegionBound(103).RawLeftBound,
+			endKey:            MakeRegionBound(103).TxnLeftBound,
 			checker:           specificChecker,
 			expectedSplitKeys: nil,
 		},
@@ -501,14 +529,18 @@ func TestKeyspaceCache(t *testing.T) {
 	cache := NewCache()
 
 	cache.Save(100, "ks-100", keyspacepb.KeyspaceState_ENABLED)
-	cache.Save(102, "ks-102", keyspacepb.KeyspaceState_DISABLED)
 	cache.Save(101, "ks-101", keyspacepb.KeyspaceState_ARCHIVED)
+	cache.Save(102, "ks-102", keyspacepb.KeyspaceState_DISABLED)
+	cache.Save(103, "ks-102", keyspacepb.KeyspaceState_TOMBSTONE)
 
 	item, ok := cache.getKeyspaceByID(101)
 	re.True(ok)
 	re.Equal(uint32(101), item.keyspaceID)
 	re.Equal("ks-101", item.name)
 	re.Equal(keyspacepb.KeyspaceState_ARCHIVED, item.state)
+
+	ok = cache.KeyspaceExist(103)
+	re.False(ok)
 
 	all := func() []uint32 {
 		var ret []uint32
@@ -518,26 +550,27 @@ func TestKeyspaceCache(t *testing.T) {
 		})
 		return ret
 	}
-	re.Equal([]uint32{100, 101, 102}, all())
+	re.Equal([]uint32{100, 101, 102, 103}, all())
 
-	id, ok := cache.GetKeyspaceIDInRange(100, 103)
+	ids, ok := cache.GetKeyspaceIDInRange(100, 103, 1)
 	re.True(ok)
-	re.Equal(uint32(100), id)
+	re.Equal([]uint32{102}, ids)
 
-	id, ok = cache.GetKeyspaceIDInRange(101, 102)
+	ids, ok = cache.GetKeyspaceIDInRange(101, 102, 1)
 	re.True(ok)
-	re.Equal(uint32(101), id)
+	re.Equal([]uint32{102}, ids)
 
-	id, ok = cache.GetKeyspaceIDInRange(103, 104)
+	ids, ok = cache.GetKeyspaceIDInRange(103, 104, 1)
 	re.False(ok)
-	re.Zero(id)
+	re.Empty(ids)
 
 	cache.DeleteKeyspace(101)
 	_, ok = cache.getKeyspaceByID(101)
 	re.False(ok)
-	re.Equal([]uint32{100, 102}, all())
+	re.Equal([]uint32{100, 102, 103}, all())
 
-	id, ok = cache.GetKeyspaceIDInRange(100, 103)
+	ids, ok = cache.GetKeyspaceIDInRange(100, 103, 5)
 	re.True(ok)
-	re.Equal(uint32(100), id)
+	re.Len(ids, 2)
+	re.Equal([]uint32{102, 100}, ids)
 }

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -15,7 +15,6 @@
 package keyspace
 
 import (
-	"encoding/hex"
 	"math"
 	"testing"
 
@@ -25,7 +24,6 @@ import (
 
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/keyspace/constant"
-	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
 
@@ -140,157 +138,270 @@ func TestProtectedKeyspaceValidation(t *testing.T) {
 	}
 }
 
-func TestMakeLabelRule(t *testing.T) {
+func TestDecodeKeyspace(t *testing.T) {
+	re := require.New(t)
+	bound := MakeRegionBound(100)
+	k := codec.Key(bound.TxnLeftBound)
+	ok, keyspaceID := k.DecodeKeyspaceTxnKey()
+	re.True(ok)
+	re.Equal(uint32(100), keyspaceID)
+}
+
+func TestExtractKeyspaceID(t *testing.T) {
 	re := require.New(t)
 	testCases := []struct {
-		id                uint32
-		expectedLabelRule *labeler.LabelRule
+		name            string
+		key             []byte
+		expectedID      uint32
+		expectedSuccess bool
 	}{
 		{
-			id: 0,
-			expectedLabelRule: &labeler.LabelRule{
-				ID:    getRegionLabelID(0),
-				Index: 0,
-				Labels: []labeler.RegionLabel{
-					{
-						Key:   regionLabelKey,
-						Value: "0",
-					},
-				},
-				RuleType: labeler.KeyRange,
-				Data: []any{
-					map[string]any{
-						"start_key": hex.EncodeToString(codec.EncodeBytes([]byte{'r', 0, 0, 0})),
-						"end_key":   hex.EncodeToString(codec.EncodeBytes([]byte{'r', 0, 0, 1})),
-					},
-					map[string]any{
-						"start_key": hex.EncodeToString(codec.EncodeBytes([]byte{'x', 0, 0, 0})),
-						"end_key":   hex.EncodeToString(codec.EncodeBytes([]byte{'x', 0, 0, 1})),
-					},
-				},
-			},
+			name:            "empty key",
+			key:             []byte{},
+			expectedID:      constant.MaxValidKeyspaceID,
+			expectedSuccess: true,
 		},
 		{
-			id: 4242,
-			expectedLabelRule: &labeler.LabelRule{
-				ID:    getRegionLabelID(4242),
-				Index: 0,
-				Labels: []labeler.RegionLabel{
-					{
-						Key:   regionLabelKey,
-						Value: "4242",
-					},
-				},
-				RuleType: labeler.KeyRange,
-				Data: []any{
-					map[string]any{
-						"start_key": hex.EncodeToString(codec.EncodeBytes([]byte{'r', 0, 0x10, 0x92})),
-						"end_key":   hex.EncodeToString(codec.EncodeBytes([]byte{'r', 0, 0x10, 0x93})),
-					},
-					map[string]any{
-						"start_key": hex.EncodeToString(codec.EncodeBytes([]byte{'x', 0, 0x10, 0x92})),
-						"end_key":   hex.EncodeToString(codec.EncodeBytes([]byte{'x', 0, 0x10, 0x93})),
-					},
-				},
-			},
+			name:            "keyspace 0 txn mode",
+			key:             MakeRegionBound(0).TxnLeftBound,
+			expectedID:      0,
+			expectedSuccess: true,
+		},
+		{
+			name:            "keyspace 100 txn mode",
+			key:             MakeRegionBound(100).TxnLeftBound,
+			expectedID:      100,
+			expectedSuccess: true,
+		},
+		{
+			name:            "keyspace 4242 txn mode",
+			key:             MakeRegionBound(4242).TxnLeftBound,
+			expectedID:      4242,
+			expectedSuccess: true,
+		},
+		{
+			name:            "keyspace 0 raw mode (not supported)",
+			key:             MakeRegionBound(0).RawLeftBound,
+			expectedID:      0,
+			expectedSuccess: false,
+		},
+		{
+			name:            "keyspace 100 raw mode (not supported)",
+			key:             MakeRegionBound(100).RawLeftBound,
+			expectedID:      0,
+			expectedSuccess: false,
+		},
+		{
+			name:            "non-keyspace key (table key)",
+			key:             codec.EncodeBytes([]byte{'t', 1, 2, 3}),
+			expectedID:      0,
+			expectedSuccess: false,
+		},
+		{
+			name:            "short key",
+			key:             codec.EncodeBytes([]byte{'x'}),
+			expectedID:      0,
+			expectedSuccess: false,
 		},
 	}
-	for _, testCase := range testCases {
-		re.Equal(testCase.expectedLabelRule, MakeLabelRule(testCase.id))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(_ *testing.T) {
+			id, ok := ExtractKeyspaceID(tc.key)
+			re.Equal(tc.expectedSuccess, ok, "test case: %s", tc.name)
+			if tc.expectedSuccess {
+				re.Equal(tc.expectedID, id, "test case: %s", tc.name)
+			}
+		})
 	}
 }
 
-func TestParseKeyspaceIDFromLabelRule(t *testing.T) {
+// mockKeyspaceChecker is a mock implementation of KeyspaceChecker for testing.
+type mockKeyspaceChecker struct {
+	existingKeyspaces map[uint32]bool
+}
+
+func (m *mockKeyspaceChecker) KeyspaceExists(id uint32) bool {
+	if m.existingKeyspaces == nil {
+		return true // Default: all keyspaces exist
+	}
+	return m.existingKeyspaces[id]
+}
+
+func TestRegionSpansMultipleKeyspaces(t *testing.T) {
 	re := require.New(t)
-	testCases := []struct {
-		labelRule  *labeler.LabelRule
-		expectedID uint32
-		expectedOK bool
-	}{
-		// Valid keyspace label rule.
-		{
-			labelRule:  MakeLabelRule(1),
-			expectedID: 1,
-			expectedOK: true,
-		},
-		// Invalid keyspace label ID - unmatched prefix.
-		{
-			labelRule: &labeler.LabelRule{
-				ID:    "not-keyspaces/1",
-				Index: 0,
-				Labels: []labeler.RegionLabel{
-					{
-						Key:   regionLabelKey,
-						Value: "1",
-					},
-				},
-			},
-			expectedID: 0,
-			expectedOK: false,
-		},
-		// Invalid keyspace label ID - invalid keyspace ID.
-		{
-			labelRule: &labeler.LabelRule{
-				ID:    "keyspaces/id1",
-				Index: 0,
-				Labels: []labeler.RegionLabel{
-					{
-						Key:   regionLabelKey,
-						Value: "1",
-					},
-				},
-			},
-			expectedID: 0,
-			expectedOK: false,
-		},
-		{
-			labelRule: &labeler.LabelRule{
-				ID:    "keyspaces/1id",
-				Index: 0,
-				Labels: []labeler.RegionLabel{
-					{
-						Key:   regionLabelKey,
-						Value: "1",
-					},
-				},
-			},
-			expectedID: 0,
-			expectedOK: false,
-		},
-		// Invalid keyspace label ID - invalid keyspace ID label rule.
-		{
-			labelRule: &labeler.LabelRule{
-				ID:    getRegionLabelID(1),
-				Index: 0,
-				Labels: []labeler.RegionLabel{
-					{
-						Key:   "not-id",
-						Value: "1",
-					},
-				},
-			},
-			expectedID: 0,
-			expectedOK: false,
-		},
-		// Invalid keyspace label ID - unmatched keyspace ID with label rule.
-		{
-			labelRule: &labeler.LabelRule{
-				ID:    getRegionLabelID(1),
-				Index: 0,
-				Labels: []labeler.RegionLabel{
-					{
-						Key:   "id",
-						Value: "2",
-					},
-				},
-			},
-			expectedID: 0,
-			expectedOK: false,
+
+	// Mock checker where all keyspaces exist
+	allExistChecker := &mockKeyspaceChecker{}
+
+	// Mock checker where only specific keyspaces exist
+	specificChecker := &mockKeyspaceChecker{
+		existingKeyspaces: map[uint32]bool{
+			100: true,
+			101: true,
+			105: true,
 		},
 	}
-	for _, testCase := range testCases {
-		id, ok := ParseKeyspaceIDFromLabelRule(testCase.labelRule)
-		re.Equal(testCase.expectedID, id)
-		re.Equal(testCase.expectedOK, ok)
+
+	testCases := []struct {
+		name           string
+		startKey       []byte
+		endKey         []byte
+		checker        *mockKeyspaceChecker
+		expectedResult bool
+	}{
+		{
+			name:           "empty end key",
+			startKey:       MakeRegionBound(1).TxnLeftBound,
+			endKey:         []byte{},
+			checker:        allExistChecker,
+			expectedResult: false,
+		},
+		{
+			name:           "same keyspace txn mode",
+			startKey:       MakeRegionBound(100).TxnLeftBound,
+			endKey:         MakeRegionBound(100).TxnRightBound,
+			checker:        allExistChecker,
+			expectedResult: false,
+		},
+		{
+			name:           "adjacent keyspace boundary txn mode",
+			startKey:       MakeRegionBound(100).TxnLeftBound,
+			endKey:         MakeRegionBound(101).TxnLeftBound, // same as rightBound(100)
+			checker:        allExistChecker,
+			expectedResult: false, // [left100, right100) is within keyspace 100
+		},
+		{
+			name:           "span two keyspaces txn mode",
+			startKey:       MakeRegionBound(100).TxnLeftBound,
+			endKey:         MakeRegionBound(101).TxnRightBound,
+			checker:        allExistChecker,
+			expectedResult: true,
+		},
+		{
+			name:           "span multiple keyspaces txn mode",
+			startKey:       MakeRegionBound(100).TxnLeftBound,
+			endKey:         MakeRegionBound(105).TxnRightBound,
+			checker:        allExistChecker,
+			expectedResult: true,
+		},
+		{
+			name:           "empty start key",
+			startKey:       []byte{},
+			endKey:         MakeRegionBound(100).TxnLeftBound,
+			checker:        allExistChecker,
+			expectedResult: true,
+		},
+		{
+			name:           "non-keyspace keys",
+			startKey:       codec.EncodeBytes([]byte{'t', 1, 2, 3}),
+			endKey:         codec.EncodeBytes([]byte{'t', 1, 2, 4}),
+			checker:        allExistChecker,
+			expectedResult: false,
+		},
+		{
+			name:           "span deleted keyspace - should not span",
+			startKey:       MakeRegionBound(100).TxnLeftBound,
+			endKey:         MakeRegionBound(102).TxnRightBound,
+			checker:        specificChecker, // keyspace 102 doesn't exist
+			expectedResult: false,
+		},
+		{
+			name:           "span existing keyspaces - should span",
+			startKey:       MakeRegionBound(100).TxnLeftBound,
+			endKey:         MakeRegionBound(101).TxnRightBound,
+			checker:        specificChecker, // both 100 and 101 exist
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := RegionSpansMultipleKeyspaces(tc.startKey, tc.endKey, tc.checker)
+			re.Equal(tc.expectedResult, result, "test case: %s", tc.name)
+		})
+	}
+}
+
+func TestGetKeyspaceSplitKeys(t *testing.T) {
+	re := require.New(t)
+
+	// Mock checker where all keyspaces exist
+	allExistChecker := &mockKeyspaceChecker{}
+
+	// Mock checker where only specific keyspaces exist
+	specificChecker := &mockKeyspaceChecker{
+		existingKeyspaces: map[uint32]bool{
+			100: true,
+			101: true,
+			102: true,
+			// 103, 104, 105 don't exist
+		},
+	}
+
+	testCases := []struct {
+		name              string
+		startKey          []byte
+		endKey            []byte
+		checker           *mockKeyspaceChecker
+		expectedSplitKeys int
+	}{
+		{
+			name:              "empty end key",
+			startKey:          MakeRegionBound(1).TxnLeftBound,
+			endKey:            []byte{},
+			checker:           allExistChecker,
+			expectedSplitKeys: 0,
+		},
+		{
+			name:              "same keyspace txn mode",
+			startKey:          MakeRegionBound(100).TxnLeftBound,
+			endKey:            MakeRegionBound(100).TxnRightBound,
+			checker:           allExistChecker,
+			expectedSplitKeys: 0,
+		},
+		{
+			name:              "span two keyspaces txn mode",
+			startKey:          MakeRegionBound(100).TxnLeftBound,
+			endKey:            MakeRegionBound(101).TxnRightBound,
+			checker:           allExistChecker,
+			expectedSplitKeys: 1,
+		},
+		{
+			name:              "span 5 keyspaces txn mode",
+			startKey:          MakeRegionBound(100).TxnLeftBound,
+			endKey:            MakeRegionBound(105).TxnRightBound,
+			checker:           allExistChecker,
+			expectedSplitKeys: 5,
+		},
+		{
+			name:              "non-keyspace keys",
+			startKey:          codec.EncodeBytes([]byte{'t', 1, 2, 3}),
+			endKey:            codec.EncodeBytes([]byte{'t', 1, 2, 4}),
+			checker:           allExistChecker,
+			expectedSplitKeys: 0,
+		},
+		{
+			name:              "span keyspaces with deleted ones - only split at existing boundaries",
+			startKey:          MakeRegionBound(100).TxnLeftBound,
+			endKey:            MakeRegionBound(105).TxnRightBound,
+			checker:           specificChecker, // only 100, 101, 102 exist
+			expectedSplitKeys: 2,               // split at boundary of 100 and 101 only (102 has no next)
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			splitKeys := GetKeyspaceSplitKeys(tc.startKey, tc.endKey, tc.checker)
+			re.Equal(tc.expectedSplitKeys, len(splitKeys), "test case: %s", tc.name)
+
+			// Verify that the split keys are valid and properly ordered
+			if len(splitKeys) > 0 {
+				for i := 0; i < len(splitKeys)-1; i++ {
+					re.True(string(splitKeys[i]) < string(splitKeys[i+1]),
+						"split keys should be in ascending order for test case: %s", tc.name)
+				}
+			}
+		})
 	}
 }

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -229,10 +229,7 @@ func (m *mockKeyspaceChecker) GetKeyspaceIDInRange(start, end uint32) (uint32, b
 		return 0, false
 	}
 	if m.allExist {
-		if start+1 < end {
-			return start + 1, true
-		}
-		return 0, false
+		return start, true
 	}
 	found := false
 	var candidate uint32

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/response"
@@ -77,6 +78,7 @@ type Cluster struct {
 	labelStats        *statistics.LabelStatistics
 	hotStat           *statistics.HotStat
 	storage           storage.Storage
+	keyspaceCache     *keyspace.Cache
 	coordinator       *schedule.Coordinator
 	checkMembershipCh chan struct{}
 	pdLeader          atomic.Value
@@ -142,6 +144,7 @@ func NewCluster(
 		labelStats:        statistics.NewLabelStatistics(),
 		regionStats:       statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
 		storage:           storage,
+		keyspaceCache:     keyspace.NewCache(),
 		checkMembershipCh: checkMembershipCh,
 		httpClient:        httpClient,
 		backendAddress:    backendAddress,
@@ -194,6 +197,16 @@ func (c *Cluster) GetBasicCluster() *core.BasicCluster {
 // GetSharedConfig returns the shared config.
 func (c *Cluster) GetSharedConfig() sc.SharedConfigProvider {
 	return c.persistConfig
+}
+
+// GetKeyspaceIDInRange returns the keyspace ID in the specified range.
+func (c *Cluster) GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID uint32) (uint32, bool) {
+	return c.keyspaceCache.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
+}
+
+// KeyspaceExist checks if a keyspace exists by ID.
+func (c *Cluster) KeyspaceExist(id uint32) bool {
+	return c.keyspaceCache.KeyspaceExist(id)
 }
 
 // GetRuleManager returns the rule manager.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -199,9 +199,9 @@ func (c *Cluster) GetSharedConfig() sc.SharedConfigProvider {
 	return c.persistConfig
 }
 
-// GetKeyspaceIDInRange returns the keyspace ID in the specified range.
-func (c *Cluster) GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID uint32) (uint32, bool) {
-	return c.keyspaceCache.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID)
+// GetKeyspaceIDInRange returns the keyspace IDs in the specified range.
+func (c *Cluster) GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID uint32, limit int) ([]uint32, bool) {
+	return c.keyspaceCache.GetKeyspaceIDInRange(startKeyspaceID, endKeyspaceID, limit)
 }
 
 // KeyspaceExist checks if a keyspace exists by ID.

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -17,6 +17,8 @@ package rule
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -68,6 +70,8 @@ type Watcher struct {
 	ruleManager *placement.RuleManager
 	// regionLabeler is used to manage the region label rules.
 	regionLabeler *labeler.RegionLabeler
+	// keyspaceCache is used to cache keyspace metadata from watch events.
+	keyspaceCache *keyspace.Cache
 
 	ruleWatcher         *etcdutil.LoopWatcher
 	labelWatcher        *etcdutil.LoopWatcher
@@ -85,6 +89,7 @@ func NewWatcher(
 	checkerController *checker.Controller,
 	ruleManager *placement.RuleManager,
 	regionLabeler *labeler.RegionLabeler,
+	keyspaceCache *keyspace.Cache,
 ) (*Watcher, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	rw := &Watcher{
@@ -99,6 +104,7 @@ func NewWatcher(
 		checkerController:      checkerController,
 		ruleManager:            ruleManager,
 		regionLabeler:          regionLabeler,
+		keyspaceCache:          keyspaceCache,
 	}
 	err := rw.initializeRuleWatcher()
 	if err != nil {
@@ -297,22 +303,32 @@ func (rw *Watcher) initializeKeyspaceMetaWatcher() error {
 	}
 	putFn := func(kv *mvccpb.KeyValue) error {
 		log.Info("update keyspace meta", zap.String("key", string(kv.Key)), zap.String("value", string(kv.Value)))
-		meta, err := keyspace.NewKeyspaceMeta(string(kv.Value))
+		keyspaceID, err := rw.extractKeyspaceIDFromMetaKey(string(kv.Key))
 		if err != nil {
 			return err
 		}
-		bound := keyspace.MakeRegionBound(meta.Id)
+		if rw.keyspaceCache != nil {
+			meta, err := keyspace.NewKeyspaceMeta(string(kv.Value))
+			if err != nil {
+				return err
+			}
+			rw.keyspaceCache.Save(meta.Id, meta.Name, meta.State)
+		}
+		bound := keyspace.MakeRegionBound(keyspaceID)
 		suspectKeyRanges.Append(bound.RawLeftBound, bound.RawRightBound)
 		suspectKeyRanges.Append(bound.TxnLeftBound, bound.TxnRightBound)
 		return nil
 	}
 	deleteFn := func(kv *mvccpb.KeyValue) error {
 		log.Info("delete keyspace meta", zap.String("key", string(kv.Key)))
-		meta, err := keyspace.NewKeyspaceMeta(string(kv.Value))
+		keyspaceID, err := rw.extractKeyspaceIDFromMetaKey(string(kv.Key))
 		if err != nil {
 			return err
 		}
-		bound := keyspace.MakeRegionBound(meta.Id)
+		if rw.keyspaceCache != nil {
+			rw.keyspaceCache.DeleteKeyspace(keyspaceID)
+		}
+		bound := keyspace.MakeRegionBound(keyspaceID)
 		suspectKeyRanges.Append(bound.RawLeftBound, bound.RawRightBound)
 		suspectKeyRanges.Append(bound.TxnLeftBound, bound.TxnRightBound)
 		return nil
@@ -339,6 +355,15 @@ func (rw *Watcher) initializeKeyspaceMetaWatcher() error {
 	)
 	rw.keyspaceMetaWatcher.StartWatchLoop()
 	return rw.keyspaceMetaWatcher.WaitLoad()
+}
+
+func (rw *Watcher) extractKeyspaceIDFromMetaKey(key string) (uint32, error) {
+	idStr := strings.TrimPrefix(key, rw.keyspaceMetaPathPrefix)
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse keyspace id from key %q: %w", key, err)
+	}
+	return uint32(id), nil
 }
 
 // Close closes the watcher.

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -312,6 +312,9 @@ func (rw *Watcher) initializeKeyspaceMetaWatcher() error {
 			if err != nil {
 				return err
 			}
+			if meta.Id != keyspaceID {
+				return fmt.Errorf("keyspace ID in meta does not match the one in key, meta Id: %d, keyspace ID: %d", meta.Id, keyspaceID)
+			}
 			rw.keyspaceCache.Save(meta.Id, meta.Name, meta.State)
 		}
 		bound := keyspace.MakeRegionBound(keyspaceID)
@@ -347,7 +350,7 @@ func (rw *Watcher) initializeKeyspaceMetaWatcher() error {
 		rw.etcdClient,
 		"scheduling-keyspace-meta-watcher",
 		// To keep the consistency with the previous code, we should trim the suffix `/`.
-		strings.TrimSuffix(rw.keyspaceMetaPathPrefix, "/"),
+		rw.keyspaceMetaPathPrefix,
 		preEventsFn,
 		putFn, deleteFn,
 		postEventsFn,

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pingcap/log"
 
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/schedule/checker"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/placement"
@@ -53,6 +54,10 @@ type Watcher struct {
 	//   - Key: /pd/{cluster_id}/region_label/{rule_id}
 	//  - Value: labeler.LabelRule
 	regionLabelPathPrefix string
+	// keyspaceMetaPathPrefix:
+	//   - Key: /pd/{cluster_id}/keyspaces/meta/{keyspace_id}
+	//   - Value: keyspace.KeyspaceMeta
+	keyspaceMetaPathPrefix string
 
 	etcdClient  *clientv3.Client
 	ruleStorage endpoint.RuleStorage
@@ -64,8 +69,9 @@ type Watcher struct {
 	// regionLabeler is used to manage the region label rules.
 	regionLabeler *labeler.RegionLabeler
 
-	ruleWatcher  *etcdutil.LoopWatcher
-	labelWatcher *etcdutil.LoopWatcher
+	ruleWatcher         *etcdutil.LoopWatcher
+	labelWatcher        *etcdutil.LoopWatcher
+	keyspaceMetaWatcher *etcdutil.LoopWatcher
 
 	// patch is used to cache the placement rule changes.
 	patch *placement.RuleConfigPatch
@@ -82,16 +88,17 @@ func NewWatcher(
 ) (*Watcher, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	rw := &Watcher{
-		ctx:                   ctx,
-		cancel:                cancel,
-		rulesPathPrefix:       keypath.RulesPathPrefix(),
-		ruleGroupPathPrefix:   keypath.RuleGroupPathPrefix(),
-		regionLabelPathPrefix: keypath.RegionLabelPathPrefix(),
-		etcdClient:            etcdClient,
-		ruleStorage:           ruleStorage,
-		checkerController:     checkerController,
-		ruleManager:           ruleManager,
-		regionLabeler:         regionLabeler,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		rulesPathPrefix:        keypath.RulesPathPrefix(),
+		ruleGroupPathPrefix:    keypath.RuleGroupPathPrefix(),
+		regionLabelPathPrefix:  keypath.RegionLabelPathPrefix(),
+		keyspaceMetaPathPrefix: keypath.KeyspaceMetaPrefix(),
+		etcdClient:             etcdClient,
+		ruleStorage:            ruleStorage,
+		checkerController:      checkerController,
+		ruleManager:            ruleManager,
+		regionLabeler:          regionLabeler,
 	}
 	err := rw.initializeRuleWatcher()
 	if err != nil {
@@ -99,6 +106,11 @@ func NewWatcher(
 		return nil, err
 	}
 	err = rw.initializeRegionLabelWatcher()
+	if err != nil {
+		rw.Close()
+		return nil, err
+	}
+	err = rw.initializeKeyspaceMetaWatcher()
 	if err != nil {
 		rw.Close()
 		return nil, err
@@ -275,6 +287,58 @@ func (rw *Watcher) initializeRegionLabelWatcher() error {
 	)
 	rw.labelWatcher.StartWatchLoop()
 	return rw.labelWatcher.WaitLoad()
+}
+
+func (rw *Watcher) initializeKeyspaceMetaWatcher() error {
+	suspectKeyRanges := &keyutil.KeyRanges{}
+	preEventsFn := func([]*clientv3.Event) error {
+		suspectKeyRanges.Clean()
+		return nil
+	}
+	putFn := func(kv *mvccpb.KeyValue) error {
+		log.Info("update keyspace meta", zap.String("key", string(kv.Key)), zap.String("value", string(kv.Value)))
+		meta, err := keyspace.NewKeyspaceMeta(string(kv.Value))
+		if err != nil {
+			return err
+		}
+		bound := keyspace.MakeRegionBound(meta.Id)
+		suspectKeyRanges.Append(bound.RawLeftBound, bound.RawRightBound)
+		suspectKeyRanges.Append(bound.TxnLeftBound, bound.TxnRightBound)
+		return nil
+	}
+	deleteFn := func(kv *mvccpb.KeyValue) error {
+		log.Info("delete keyspace meta", zap.String("key", string(kv.Key)))
+		meta, err := keyspace.NewKeyspaceMeta(string(kv.Value))
+		if err != nil {
+			return err
+		}
+		bound := keyspace.MakeRegionBound(meta.Id)
+		suspectKeyRanges.Append(bound.RawLeftBound, bound.RawRightBound)
+		suspectKeyRanges.Append(bound.TxnLeftBound, bound.TxnRightBound)
+		return nil
+	}
+	postEventsFn := func([]*clientv3.Event) error {
+		if rw.checkerController == nil {
+			return errors.New("checkerController is nil, cannot add suspect key ranges")
+		}
+		for _, kr := range suspectKeyRanges.Ranges() {
+			rw.checkerController.AddSuspectKeyRange(kr.StartKey, kr.EndKey)
+		}
+		return nil
+	}
+	rw.keyspaceMetaWatcher = etcdutil.NewLoopWatcher(
+		rw.ctx, &rw.wg,
+		rw.etcdClient,
+		"scheduling-keyspace-meta-watcher",
+		// To keep the consistency with the previous code, we should trim the suffix `/`.
+		strings.TrimSuffix(rw.keyspaceMetaPathPrefix, "/"),
+		preEventsFn,
+		putFn, deleteFn,
+		postEventsFn,
+		true, /* withPrefix */
+	)
+	rw.keyspaceMetaWatcher.StartWatchLoop()
+	return rw.keyspaceMetaWatcher.WaitLoad()
 }
 
 // Close closes the watcher.

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -103,7 +103,7 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 			ID:       "test_" + strconv.Itoa(i),
 			Labels:   []labeler.RegionLabel{{Key: "test", Value: "test"}},
 			RuleType: labeler.KeyRange,
-			Data:     keyspace.MakeKeyspaceRanges(uint32(i)),
+			Data:     keyspace.MakeKeyRanges(uint32(i)),
 		}
 		value, err := json.Marshal(rule)
 		re.NoError(err)

--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -103,7 +103,7 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 			ID:       "test_" + strconv.Itoa(i),
 			Labels:   []labeler.RegionLabel{{Key: "test", Value: "test"}},
 			RuleType: labeler.KeyRange,
-			Data:     keyspace.MakeKeyRanges(uint32(i)),
+			Data:     keyspace.MakeKeyspaceRanges(uint32(i)),
 		}
 		value, err := json.Marshal(rule)
 		re.NoError(err)

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -523,7 +523,7 @@ func (s *Server) startCluster(context.Context) error {
 	s.configWatcher.SetSchedulersController(cluster.GetCoordinator().GetSchedulersController())
 	// Start the rule watcher after the cluster is created.
 	s.ruleWatcher, err = rule.NewWatcher(s.Context(), s.GetClient(), s.storage,
-		cluster.GetCoordinator().GetCheckerController(), cluster.GetRuleManager(), cluster.GetRegionLabeler())
+		cluster.GetCoordinator().GetCheckerController(), cluster.GetRuleManager(), cluster.GetRegionLabeler(), cluster.keyspaceCache)
 	if err != nil {
 		return err
 	}

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -121,12 +121,16 @@ func (mc *Cluster) GetSharedConfig() sc.SharedConfigProvider {
 	return mc.PersistOptions
 }
 
-// GetKeyspaceIDInRange returns the keyspace ID in the specified range.
-func (*Cluster) GetKeyspaceIDInRange(startKeyspaceID uint32, endKeyspaceID uint32) (uint32, bool) {
+// GetKeyspaceIDInRange returns the keyspace IDs in the range [startKeyspaceID, endKeyspaceID] with a limit on the number of keyspace IDs returned.
+func (*Cluster) GetKeyspaceIDInRange(startKeyspaceID uint32, endKeyspaceID uint32, limit int) ([]uint32, bool) {
 	if startKeyspaceID > endKeyspaceID {
-		return 0, false
+		return nil, false
 	}
-	return endKeyspaceID, true
+	ret := make([]uint32, 0, limit)
+	for id := startKeyspaceID; id <= endKeyspaceID; id++ {
+		ret = append(ret, id)
+	}
+	return ret, true
 }
 
 // KeyspaceExist checks if a keyspace exists by ID.

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -121,6 +121,16 @@ func (mc *Cluster) GetSharedConfig() sc.SharedConfigProvider {
 	return mc.PersistOptions
 }
 
+// GetKeyspaceIDInRange returns the keyspace ID in the specified range.
+func (*Cluster) GetKeyspaceIDInRange(startKeyspaceID uint32, _ uint32) (uint32, bool) {
+	return startKeyspaceID, true
+}
+
+// KeyspaceExist checks if a keyspace exists by ID.
+func (*Cluster) KeyspaceExist(uint32) bool {
+	return true
+}
+
 // GetStorage returns the storage.
 func (mc *Cluster) GetStorage() storage.Storage {
 	return mc.Storage

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -122,13 +122,16 @@ func (mc *Cluster) GetSharedConfig() sc.SharedConfigProvider {
 }
 
 // GetKeyspaceIDInRange returns the keyspace ID in the specified range.
-func (*Cluster) GetKeyspaceIDInRange(startKeyspaceID uint32, _ uint32) (uint32, bool) {
-	return startKeyspaceID, true
+func (*Cluster) GetKeyspaceIDInRange(startKeyspaceID uint32, endKeyspaceID uint32) (uint32, bool) {
+	if startKeyspaceID > endKeyspaceID {
+		return 0, false
+	}
+	return endKeyspaceID, true
 }
 
 // KeyspaceExist checks if a keyspace exists by ID.
-func (*Cluster) KeyspaceExist(uint32) bool {
-	return true
+func (*Cluster) KeyspaceExist(id uint32) bool {
+	return id != 1
 }
 
 // GetStorage returns the storage.

--- a/pkg/schedule/checker/merge_checker.go
+++ b/pkg/schedule/checker/merge_checker.go
@@ -58,6 +58,37 @@ func (w *keyspaceCheckerWrapperForMerge) KeyspaceExists(id uint32) bool {
 	return true
 }
 
+// GetKeyspaceIDInRange returns one existing keyspace ID in (start, end).
+func (w *keyspaceCheckerWrapperForMerge) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	if start >= end {
+		return 0, false
+	}
+	type keyspaceManagerGetter interface {
+		GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool }
+	}
+	if kg, ok := w.cluster.(keyspaceManagerGetter); ok {
+		if km := kg.GetKeyspaceManager(); km != nil {
+			if getter, ok := any(km).(interface {
+				GetKeyspaceIDInRange(uint32, uint32) (uint32, bool)
+			}); ok {
+				return getter.GetKeyspaceIDInRange(start, end)
+			}
+			for id := start + 1; id < end; id++ {
+				if km.KeyspaceExists(id) {
+					return id, true
+				}
+			}
+			return 0, false
+		}
+	}
+	// If we can't get the keyspace manager, assume keyspaces exist to maintain
+	// backward compatibility.
+	if start+1 < end {
+		return start + 1, true
+	}
+	return 0, false
+}
+
 const (
 	maxTargetRegionSize   = 500
 	maxTargetRegionFactor = 4

--- a/pkg/schedule/checker/merge_checker.go
+++ b/pkg/schedule/checker/merge_checker.go
@@ -37,58 +37,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/logutil"
 )
 
-// keyspaceCheckerWrapperForMerge wraps the cluster to provide keyspace existence checking for merge.
-type keyspaceCheckerWrapperForMerge struct {
-	cluster sche.SharedCluster
-}
-
-// KeyspaceExists checks if a keyspace exists by probing the cluster interface.
-func (w *keyspaceCheckerWrapperForMerge) KeyspaceExists(id uint32) bool {
-	// Try to get the keyspace manager from the cluster
-	type keyspaceManagerGetter interface {
-		GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool }
-	}
-	if kg, ok := w.cluster.(keyspaceManagerGetter); ok {
-		if km := kg.GetKeyspaceManager(); km != nil {
-			return km.KeyspaceExists(id)
-		}
-	}
-	// If we can't get the keyspace manager, assume the keyspace exists
-	// to maintain backward compatibility
-	return true
-}
-
-// GetKeyspaceIDInRange returns one existing keyspace ID in (start, end).
-func (w *keyspaceCheckerWrapperForMerge) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
-	if start >= end {
-		return 0, false
-	}
-	type keyspaceManagerGetter interface {
-		GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool }
-	}
-	if kg, ok := w.cluster.(keyspaceManagerGetter); ok {
-		if km := kg.GetKeyspaceManager(); km != nil {
-			if getter, ok := any(km).(interface {
-				GetKeyspaceIDInRange(uint32, uint32) (uint32, bool)
-			}); ok {
-				return getter.GetKeyspaceIDInRange(start, end)
-			}
-			for id := start + 1; id < end; id++ {
-				if km.KeyspaceExists(id) {
-					return id, true
-				}
-			}
-			return 0, false
-		}
-	}
-	// If we can't get the keyspace manager, assume keyspaces exist to maintain
-	// backward compatibility.
-	if start+1 < end {
-		return start + 1, true
-	}
-	return 0, false
-}
-
 const (
 	maxTargetRegionSize   = 500
 	maxTargetRegionFactor = 4
@@ -282,6 +230,11 @@ func (c *MergeChecker) checkTarget(region, adjacent *core.RegionInfo) bool {
 	return true
 }
 
+type checkGetter interface {
+	GetKeyspaceIDInRange(start, end uint32) (uint32, bool)
+	KeyspaceExist(keyspaceID uint32) bool
+}
+
 // AllowMerge returns true if two regions can be merged according to the key type.
 func AllowMerge(cluster sche.SharedCluster, region, adjacent *core.RegionInfo) bool {
 	var start, end []byte
@@ -295,9 +248,10 @@ func AllowMerge(cluster sche.SharedCluster, region, adjacent *core.RegionInfo) b
 
 	// Check if merging these regions would span multiple keyspaces
 	// This ensures one region corresponds to one keyspace
-	checker := &keyspaceCheckerWrapperForMerge{cluster: cluster}
-	if keyspace.RegionSpansMultipleKeyspaces(start, end, checker) {
-		return false
+	if checker, ok := cluster.(checkGetter); ok {
+		if keyspace.RegionSpansMultipleKeyspaces(start, end, checker) {
+			return false
+		}
 	}
 
 	// The interface probe is used here to get the rule manager and region

--- a/pkg/schedule/checker/merge_checker.go
+++ b/pkg/schedule/checker/merge_checker.go
@@ -231,7 +231,7 @@ func (c *MergeChecker) checkTarget(region, adjacent *core.RegionInfo) bool {
 }
 
 type checkGetter interface {
-	GetKeyspaceIDInRange(start, end uint32) (uint32, bool)
+	GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool)
 	KeyspaceExist(keyspaceID uint32) bool
 }
 

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 
@@ -27,6 +28,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/schedule/config"
@@ -589,4 +591,55 @@ func newRegionInfo(id uint64, startKey, endKey string, size, keys int64, leader 
 		core.SetApproximateSize(size),
 		core.SetApproximateKeys(keys),
 	)
+}
+
+func TestKeyspaceMerge(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, cfg)
+	cluster.SetMaxMergeRegionSize(20)
+	cluster.SetMaxMergeRegionKeys(200000)
+	stores := map[uint64][]string{
+		1: {}, 2: {}, 3: {},
+	}
+	for storeID, labels := range stores {
+		cluster.PutStoreWithLabels(storeID, labels...)
+	}
+
+	// Get keyspace boundaries
+	bound100 := keyspace.MakeRegionBound(100)
+	bound101 := keyspace.MakeRegionBound(101)
+	bound102 := keyspace.MakeRegionBound(102)
+
+	// Test 1: Two regions in the same keyspace should be mergeable
+	region1 := newRegionInfo(1, string(bound100.TxnLeftBound), string(bound100.TxnRightBound[:len(bound100.TxnRightBound)/2]), 1, 1, []uint64{1, 1}, []uint64{1, 1})
+	region2 := newRegionInfo(2, string(bound100.TxnRightBound[:len(bound100.TxnRightBound)/2]), string(bound100.TxnRightBound), 1, 1, []uint64{2, 1}, []uint64{2, 1})
+	
+	cluster.PutRegion(region1)
+	cluster.PutRegion(region2)
+	
+	// Regions within the same keyspace should allow merge
+	re.True(AllowMerge(cluster, region1, region2), "regions in the same keyspace should be mergeable")
+
+	// Test 2: Two regions in different keyspaces should NOT be mergeable
+	region3 := newRegionInfo(3, string(bound100.TxnLeftBound), string(bound100.TxnRightBound), 1, 1, []uint64{3, 1}, []uint64{3, 1})
+	region4 := newRegionInfo(4, string(bound101.TxnLeftBound), string(bound101.TxnRightBound), 1, 1, []uint64{4, 1}, []uint64{4, 1})
+	
+	cluster.PutRegion(region3)
+	cluster.PutRegion(region4)
+	
+	// Regions from different keyspaces should not allow merge
+	re.False(AllowMerge(cluster, region3, region4), "regions from different keyspaces should not be mergeable")
+
+	// Test 3: Merging would create a region spanning multiple keyspaces - should not be allowed
+	region5 := newRegionInfo(5, string(bound100.TxnLeftBound), string(bound101.TxnLeftBound), 1, 1, []uint64{5, 1}, []uint64{5, 1})
+	region6 := newRegionInfo(6, string(bound101.TxnLeftBound), string(bound102.TxnLeftBound), 1, 1, []uint64{6, 1}, []uint64{6, 1})
+	
+	cluster.PutRegion(region5)
+	cluster.PutRegion(region6)
+	
+	// Merging these would span from keyspace 100 to keyspace 102
+	re.False(AllowMerge(cluster, region5, region6), "merging should not create a region spanning multiple keyspaces")
 }

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -17,6 +17,7 @@ package checker
 import (
 	"context"
 	"encoding/hex"
+	"slices"
 	"testing"
 	"time"
 
@@ -605,24 +606,27 @@ func (m *mockKeyspaceManagerForMerge) KeyspaceExist(id uint32) bool {
 	return ok && exist
 }
 
-func (m *mockKeyspaceManagerForMerge) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+func (m *mockKeyspaceManagerForMerge) GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool) {
 	if start >= end {
-		return 0, false
+		return nil, false
 	}
 	if m.existing == nil {
-		return start, false
+		return nil, false
 	}
 	found := false
-	var candidate uint32
+	ret := make([]uint32, 0, limit)
+
 	for id, exists := range m.existing {
 		if exists && id >= start && id <= end {
-			if !found || id < candidate {
-				candidate = id
-				found = true
+			ret = append(ret, id)
+			found = true
+			if limit > 0 && len(ret) >= limit {
+				break
 			}
 		}
 	}
-	return candidate, found
+	slices.Sort(ret)
+	return ret, found
 }
 
 type mockClusterWithKeyspaceManager struct {
@@ -630,8 +634,8 @@ type mockClusterWithKeyspaceManager struct {
 	manager *mockKeyspaceManagerForMerge
 }
 
-func (c *mockClusterWithKeyspaceManager) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
-	return c.manager.GetKeyspaceIDInRange(start, end)
+func (c *mockClusterWithKeyspaceManager) GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool) {
+	return c.manager.GetKeyspaceIDInRange(start, end, limit)
 }
 
 func (c *mockClusterWithKeyspaceManager) KeyspaceExist(id uint32) bool {

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -597,11 +597,12 @@ type mockKeyspaceManagerForMerge struct {
 	existing map[uint32]bool
 }
 
-func (m *mockKeyspaceManagerForMerge) KeyspaceExists(id uint32) bool {
+func (m *mockKeyspaceManagerForMerge) KeyspaceExist(id uint32) bool {
 	if m.existing == nil {
-		return true
+		return false
 	}
-	return m.existing[id]
+	exist, ok := m.existing[id]
+	return ok && exist
 }
 
 func (m *mockKeyspaceManagerForMerge) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
@@ -609,15 +610,12 @@ func (m *mockKeyspaceManagerForMerge) GetKeyspaceIDInRange(start, end uint32) (u
 		return 0, false
 	}
 	if m.existing == nil {
-		if start+1 < end {
-			return start + 1, true
-		}
-		return 0, false
+		return start, false
 	}
 	found := false
 	var candidate uint32
 	for id, exists := range m.existing {
-		if exists && id > start && id < end {
+		if exists && id >= start && id <= end {
 			if !found || id < candidate {
 				candidate = id
 				found = true
@@ -632,8 +630,63 @@ type mockClusterWithKeyspaceManager struct {
 	manager *mockKeyspaceManagerForMerge
 }
 
-func (c *mockClusterWithKeyspaceManager) GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool } {
-	return c.manager
+func (c *mockClusterWithKeyspaceManager) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	return c.manager.GetKeyspaceIDInRange(start, end)
+}
+
+func (c *mockClusterWithKeyspaceManager) KeyspaceExist(id uint32) bool {
+	return c.manager.KeyspaceExist(id)
+}
+
+func TestNotMergeAfterSplit(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := mockconfig.NewTestOptions()
+	cluster := &mockClusterWithKeyspaceManager{
+		Cluster: mockcluster.NewCluster(ctx, cfg),
+		manager: &mockKeyspaceManagerForMerge{},
+	}
+	cluster.manager.existing = map[uint32]bool{
+		100: true,
+		101: true,
+		102: true,
+	}
+	cluster.SetMaxMergeRegionSize(20)
+	cluster.SetMaxMergeRegionKeys(200000)
+	stores := map[uint64][]string{
+		1: {}, 2: {}, 3: {},
+	}
+	for storeID, labels := range stores {
+		cluster.PutStoreWithLabels(storeID, labels...)
+	}
+
+	testNoMerge(re, cluster, []byte(""), []byte(""))
+	bound100 := keyspace.MakeRegionBound(100)
+	bound102 := keyspace.MakeRegionBound(102)
+	testNoMerge(re, cluster, bound100.RawLeftBound, bound102.RawRightBound)
+	testNoMerge(re, cluster, bound100.TxnLeftBound, bound102.TxnRightBound)
+
+	testNoMerge(re, cluster, []byte{'t', 1, 2, 3}, bound102.TxnRightBound)
+	testNoMerge(re, cluster, bound100.RawLeftBound, []byte{'t', 1, 2, 3})
+}
+
+func testNoMerge(re *require.Assertions, cluster *mockClusterWithKeyspaceManager, startKey []byte, endKey []byte) {
+	keys := keyspace.GetKeyspaceSplitKeys(startKey, endKey, cluster)
+	re.NotEmpty(keys)
+	keys = append(keys, endKey)
+	preRegion := newRegionInfo(uint64(99), string(startKey), string(keys[0]), 1, 1, []uint64{1, 1}, []uint64{1, 1})
+	cluster.PutRegion(preRegion)
+	for i := range len(keys) - 1 {
+		region := newRegionInfo(uint64(100+i), string(keys[i]), string(keys[i+1]), 1, 1, []uint64{3, 1}, []uint64{3, 1})
+		cluster.PutRegion(region)
+		re.False(AllowMerge(cluster, preRegion, region), i)
+		preRegion = region
+	}
+
+	// clean all regions
+	emptyRegion := newRegionInfo(uint64(99), "", "", 1, 1, []uint64{1, 1}, []uint64{1, 1})
+	cluster.PutRegion(emptyRegion)
 }
 
 func TestKeyspaceMerge(t *testing.T) {
@@ -643,7 +696,11 @@ func TestKeyspaceMerge(t *testing.T) {
 	cfg := mockconfig.NewTestOptions()
 	cluster := &mockClusterWithKeyspaceManager{
 		Cluster: mockcluster.NewCluster(ctx, cfg),
-		manager: &mockKeyspaceManagerForMerge{},
+		manager: &mockKeyspaceManagerForMerge{
+			existing: map[uint32]bool{
+				100: true,
+			},
+		},
 	}
 	cluster.SetMaxMergeRegionSize(20)
 	cluster.SetMaxMergeRegionKeys(200000)
@@ -694,8 +751,8 @@ func TestKeyspaceMerge(t *testing.T) {
 	cluster.manager.existing = map[uint32]bool{
 		100: true,
 	}
-	re.True(AllowMerge(cluster, region100, region101), "merge should be allowed when a spanned keyspace is missing")
-	re.True(AllowMerge(cluster, region101, region100), "merge should be allowed when a spanned keyspace is missing")
+	re.False(AllowMerge(cluster, region100, region101), "merge should be allowed when a spanned keyspace is missing")
+	re.False(AllowMerge(cluster, region101, region100), "merge should be allowed when a spanned keyspace is missing")
 	re.True(AllowMerge(cluster, region101, region200), "merging should be allowed when all spanned keyspaces exist")
 	re.True(AllowMerge(cluster, region200, region101), "merging should be allowed when all spanned keyspaces exist")
 

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -593,12 +593,58 @@ func newRegionInfo(id uint64, startKey, endKey string, size, keys int64, leader 
 	)
 }
 
+type mockKeyspaceManagerForMerge struct {
+	existing map[uint32]bool
+}
+
+func (m *mockKeyspaceManagerForMerge) KeyspaceExists(id uint32) bool {
+	if m.existing == nil {
+		return true
+	}
+	return m.existing[id]
+}
+
+func (m *mockKeyspaceManagerForMerge) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	if start >= end {
+		return 0, false
+	}
+	if m.existing == nil {
+		if start+1 < end {
+			return start + 1, true
+		}
+		return 0, false
+	}
+	found := false
+	var candidate uint32
+	for id, exists := range m.existing {
+		if exists && id > start && id < end {
+			if !found || id < candidate {
+				candidate = id
+				found = true
+			}
+		}
+	}
+	return candidate, found
+}
+
+type mockClusterWithKeyspaceManager struct {
+	*mockcluster.Cluster
+	manager *mockKeyspaceManagerForMerge
+}
+
+func (c *mockClusterWithKeyspaceManager) GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool } {
+	return c.manager
+}
+
 func TestKeyspaceMerge(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := mockconfig.NewTestOptions()
-	cluster := mockcluster.NewCluster(ctx, cfg)
+	cluster := &mockClusterWithKeyspaceManager{
+		Cluster: mockcluster.NewCluster(ctx, cfg),
+		manager: &mockKeyspaceManagerForMerge{},
+	}
 	cluster.SetMaxMergeRegionSize(20)
 	cluster.SetMaxMergeRegionKeys(200000)
 	stores := map[uint64][]string{
@@ -616,30 +662,51 @@ func TestKeyspaceMerge(t *testing.T) {
 	// Test 1: Two regions in the same keyspace should be mergeable
 	region1 := newRegionInfo(1, string(bound100.TxnLeftBound), string(bound100.TxnRightBound[:len(bound100.TxnRightBound)/2]), 1, 1, []uint64{1, 1}, []uint64{1, 1})
 	region2 := newRegionInfo(2, string(bound100.TxnRightBound[:len(bound100.TxnRightBound)/2]), string(bound100.TxnRightBound), 1, 1, []uint64{2, 1}, []uint64{2, 1})
-	
+
 	cluster.PutRegion(region1)
 	cluster.PutRegion(region2)
-	
+
 	// Regions within the same keyspace should allow merge
 	re.True(AllowMerge(cluster, region1, region2), "regions in the same keyspace should be mergeable")
+	re.True(AllowMerge(cluster, region2, region1), "regions in the same keyspace should be mergeable")
 
 	// Test 2: Two regions in different keyspaces should NOT be mergeable
 	region3 := newRegionInfo(3, string(bound100.TxnLeftBound), string(bound100.TxnRightBound), 1, 1, []uint64{3, 1}, []uint64{3, 1})
 	region4 := newRegionInfo(4, string(bound101.TxnLeftBound), string(bound101.TxnRightBound), 1, 1, []uint64{4, 1}, []uint64{4, 1})
-	
+
 	cluster.PutRegion(region3)
 	cluster.PutRegion(region4)
-	
+
 	// Regions from different keyspaces should not allow merge
 	re.False(AllowMerge(cluster, region3, region4), "regions from different keyspaces should not be mergeable")
 
 	// Test 3: Merging would create a region spanning multiple keyspaces - should not be allowed
-	region5 := newRegionInfo(5, string(bound100.TxnLeftBound), string(bound101.TxnLeftBound), 1, 1, []uint64{5, 1}, []uint64{5, 1})
-	region6 := newRegionInfo(6, string(bound101.TxnLeftBound), string(bound102.TxnLeftBound), 1, 1, []uint64{6, 1}, []uint64{6, 1})
-	
-	cluster.PutRegion(region5)
-	cluster.PutRegion(region6)
-	
-	// Merging these would span from keyspace 100 to keyspace 102
-	re.False(AllowMerge(cluster, region5, region6), "merging should not create a region spanning multiple keyspaces")
+	region100 := newRegionInfo(100, string(bound100.TxnLeftBound), string(bound100.TxnRightBound), 1, 1, []uint64{5, 1}, []uint64{5, 1})
+	region101 := newRegionInfo(101, string(bound101.TxnLeftBound), string(bound101.TxnRightBound), 1, 1, []uint64{6, 1}, []uint64{6, 1})
+	region200 := newRegionInfo(200, string(bound102.TxnLeftBound), string([]byte{}), 1, 1, []uint64{6, 1}, []uint64{6, 1})
+
+	cluster.PutRegion(region100)
+	cluster.PutRegion(region101)
+	cluster.PutRegion(region200)
+
+	// Test 4: If an intermediate keyspace does not exist, keyspaceCheckerWrapperForMerge
+	// should skip keyspace boundary enforcement for that range.
+	cluster.manager.existing = map[uint32]bool{
+		100: true,
+	}
+	re.True(AllowMerge(cluster, region100, region101), "merge should be allowed when a spanned keyspace is missing")
+	re.True(AllowMerge(cluster, region101, region100), "merge should be allowed when a spanned keyspace is missing")
+	re.True(AllowMerge(cluster, region101, region200), "merging should be allowed when all spanned keyspaces exist")
+	re.True(AllowMerge(cluster, region200, region101), "merging should be allowed when all spanned keyspaces exist")
+
+	// Test 5: Restore existing keyspaces and merge should be blocked again.
+	cluster.manager.existing = map[uint32]bool{
+		100: true,
+		101: true,
+		102: true,
+	}
+	re.False(AllowMerge(cluster, region100, region101), "merging should be blocked when all spanned keyspaces exist")
+	re.False(AllowMerge(cluster, region101, region100), "merging should be blocked when all spanned keyspaces exist")
+	re.False(AllowMerge(cluster, region101, region200), "merging should be blocked when all spanned keyspaces exist")
+	re.False(AllowMerge(cluster, region200, region101), "merging should be blocked when all spanned keyspaces exist")
 }

--- a/pkg/schedule/checker/split_checker.go
+++ b/pkg/schedule/checker/split_checker.go
@@ -48,6 +48,37 @@ func (w *keyspaceCheckerWrapper) KeyspaceExists(id uint32) bool {
 	return true
 }
 
+// GetKeyspaceIDInRange returns one existing keyspace ID in (start, end).
+func (w *keyspaceCheckerWrapper) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	if start >= end {
+		return 0, false
+	}
+	type keyspaceManagerGetter interface {
+		GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool }
+	}
+	if kg, ok := w.cluster.(keyspaceManagerGetter); ok {
+		if km := kg.GetKeyspaceManager(); km != nil {
+			if getter, ok := any(km).(interface {
+				GetKeyspaceIDInRange(uint32, uint32) (uint32, bool)
+			}); ok {
+				return getter.GetKeyspaceIDInRange(start, end)
+			}
+			for id := start + 1; id < end; id++ {
+				if km.KeyspaceExists(id) {
+					return id, true
+				}
+			}
+			return 0, false
+		}
+	}
+	// If we can't get the keyspace manager, assume keyspaces exist to maintain
+	// backward compatibility.
+	if start+1 < end {
+		return start + 1, true
+	}
+	return 0, false
+}
+
 // SplitChecker splits regions when the key range spans across rule/label boundary.
 type SplitChecker struct {
 	PauseController
@@ -80,23 +111,7 @@ func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 	}
 
 	start, end := region.GetStartKey(), region.GetEndKey()
-	
-	// First check if the region spans multiple keyspaces
-	// This ensures one region corresponds to one keyspace
-	checker := &keyspaceCheckerWrapper{cluster: c.cluster}
-	if keyspace.RegionSpansMultipleKeyspaces(start, end, checker) {
-		desc := "keyspace-split-region"
-		keys := keyspace.GetKeyspaceSplitKeys(start, end, checker)
-		if len(keys) > 0 {
-			op, err := operator.CreateSplitRegionOperator(desc, region, operator.OpSplit, pdpb.CheckPolicy_USEKEY, keys)
-			if err != nil {
-				log.Debug("create keyspace split region operator failed", errs.ZapError(err))
-				return nil
-			}
-			return op
-		}
-	}
-	
+
 	// We may consider to merge labeler split keys and rule split keys together
 	// before creating operator. It can help to reduce operator count. However,
 	// handle them separately helps to understand the reason for the split.
@@ -106,6 +121,24 @@ func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 	if len(keys) == 0 && c.cluster.GetCheckerConfig().IsPlacementRulesEnabled() {
 		desc = "rule-split-region"
 		keys = c.ruleManager.GetSplitKeys(start, end)
+	}
+
+	if len(keys) == 0 {
+		// First check if the region spans multiple keyspaces
+		// This ensures one region corresponds to one keyspace
+		checker := &keyspaceCheckerWrapper{cluster: c.cluster}
+		if keyspace.RegionSpansMultipleKeyspaces(start, end, checker) {
+			desc = "keyspace-split-region"
+			keys = keyspace.GetKeyspaceSplitKeys(start, end, checker)
+			if len(keys) > 0 {
+				op, err := operator.CreateSplitRegionOperator(desc, region, operator.OpSplit, pdpb.CheckPolicy_USEKEY, keys)
+				if err != nil {
+					log.Debug("create keyspace split region operator failed", errs.ZapError(err))
+					return nil
+				}
+				return op
+			}
+		}
 	}
 
 	if len(keys) == 0 {

--- a/pkg/schedule/checker/split_checker.go
+++ b/pkg/schedule/checker/split_checker.go
@@ -27,58 +27,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/placement"
 )
 
-// keyspaceCheckerWrapper wraps the cluster to provide keyspace existence checking.
-type keyspaceCheckerWrapper struct {
-	cluster sche.CheckerCluster
-}
-
-// KeyspaceExists checks if a keyspace exists by probing the cluster interface.
-func (w *keyspaceCheckerWrapper) KeyspaceExists(id uint32) bool {
-	// Try to get the keyspace manager from the cluster
-	type keyspaceManagerGetter interface {
-		GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool }
-	}
-	if kg, ok := w.cluster.(keyspaceManagerGetter); ok {
-		if km := kg.GetKeyspaceManager(); km != nil {
-			return km.KeyspaceExists(id)
-		}
-	}
-	// If we can't get the keyspace manager, assume the keyspace exists
-	// to maintain backward compatibility
-	return true
-}
-
-// GetKeyspaceIDInRange returns one existing keyspace ID in (start, end).
-func (w *keyspaceCheckerWrapper) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
-	if start >= end {
-		return 0, false
-	}
-	type keyspaceManagerGetter interface {
-		GetKeyspaceManager() interface{ KeyspaceExists(uint32) bool }
-	}
-	if kg, ok := w.cluster.(keyspaceManagerGetter); ok {
-		if km := kg.GetKeyspaceManager(); km != nil {
-			if getter, ok := any(km).(interface {
-				GetKeyspaceIDInRange(uint32, uint32) (uint32, bool)
-			}); ok {
-				return getter.GetKeyspaceIDInRange(start, end)
-			}
-			for id := start + 1; id < end; id++ {
-				if km.KeyspaceExists(id) {
-					return id, true
-				}
-			}
-			return 0, false
-		}
-	}
-	// If we can't get the keyspace manager, assume keyspaces exist to maintain
-	// backward compatibility.
-	if start+1 < end {
-		return start + 1, true
-	}
-	return 0, false
-}
-
 // SplitChecker splits regions when the key range spans across rule/label boundary.
 type SplitChecker struct {
 	PauseController
@@ -126,7 +74,12 @@ func (c *SplitChecker) Check(region *core.RegionInfo) *operator.Operator {
 	if len(keys) == 0 {
 		// First check if the region spans multiple keyspaces
 		// This ensures one region corresponds to one keyspace
-		checker := &keyspaceCheckerWrapper{cluster: c.cluster}
+		checker, ok := c.cluster.(checkGetter)
+		if !ok {
+			log.Warn("cluster does not implement checkGetter, skipping keyspace split check")
+			return nil
+		}
+
 		if keyspace.RegionSpansMultipleKeyspaces(start, end, checker) {
 			desc = "keyspace-split-region"
 			keys = keyspace.GetKeyspaceSplitKeys(start, end, checker)

--- a/pkg/schedule/checker/split_checker_test.go
+++ b/pkg/schedule/checker/split_checker_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/schedule/labeler"
@@ -70,4 +71,43 @@ func TestSplit(t *testing.T) {
 	splitKeys = op.Step(0).(operator.SplitRegion).SplitKeys
 	re.Equal("bb", hex.EncodeToString(splitKeys[0]))
 	re.Equal("dd", hex.EncodeToString(splitKeys[1]))
+}
+
+func TestKeyspaceSplit(t *testing.T) {
+	re := require.New(t)
+	cfg := mockconfig.NewTestOptions()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster := mockcluster.NewCluster(ctx, cfg)
+	ruleManager := cluster.RuleManager
+	regionLabeler := cluster.RegionLabeler
+	sc := NewSplitChecker(cluster, ruleManager, regionLabeler)
+	cluster.AddLeaderStore(1, 1)
+
+	// Test 1: Region within one keyspace - should not split
+	bound100 := keyspace.MakeRegionBound(100)
+	cluster.AddLeaderRegionWithRange(2, string(bound100.TxnLeftBound), string(bound100.TxnRightBound), 1)
+	op := sc.Check(cluster.GetRegion(2))
+	re.Nil(op, "region within one keyspace should not be split")
+
+	// Test 2: Region spanning two keyspaces - should split
+	bound101 := keyspace.MakeRegionBound(101)
+	cluster.AddLeaderRegionWithRange(3, string(bound100.TxnLeftBound), string(bound101.TxnRightBound), 1)
+	op = sc.Check(cluster.GetRegion(3))
+	re.NotNil(op, "region spanning multiple keyspaces should be split")
+	re.Equal(1, op.Len())
+	splitKeys := op.Step(0).(operator.SplitRegion).SplitKeys
+	// Should have one split key at the boundary between keyspace 100 and 101
+	re.Equal(1, len(splitKeys))
+	re.Equal(hex.EncodeToString(bound100.TxnRightBound), hex.EncodeToString(splitKeys[0]))
+
+	// Test 3: Region spanning multiple keyspaces - should split at all boundaries
+	bound105 := keyspace.MakeRegionBound(105)
+	cluster.AddLeaderRegionWithRange(4, string(bound100.TxnLeftBound), string(bound105.TxnRightBound), 1)
+	op = sc.Check(cluster.GetRegion(4))
+	re.NotNil(op, "region spanning multiple keyspaces should be split")
+	re.Equal(1, op.Len())
+	splitKeys = op.Step(0).(operator.SplitRegion).SplitKeys
+	// Should have 5 split keys (boundaries for keyspaces 100, 101, 102, 103, 104)
+	re.Equal(5, len(splitKeys))
 }

--- a/pkg/schedule/checker/split_checker_test.go
+++ b/pkg/schedule/checker/split_checker_test.go
@@ -108,6 +108,6 @@ func TestKeyspaceSplit(t *testing.T) {
 	re.NotNil(op, "region spanning multiple keyspaces should be split")
 	re.Equal(1, op.Len())
 	splitKeys = op.Step(0).(operator.SplitRegion).SplitKeys
-	// Should have 52 split keys
-	re.Len(splitKeys, 2)
+	re.Len(splitKeys, 1)
+	re.Equal(hex.EncodeToString(bound100.TxnRightBound), hex.EncodeToString(splitKeys[0]))
 }

--- a/pkg/schedule/checker/split_checker_test.go
+++ b/pkg/schedule/checker/split_checker_test.go
@@ -97,7 +97,7 @@ func TestKeyspaceSplit(t *testing.T) {
 	re.NotNil(op, "region spanning multiple keyspaces should be split")
 	re.Equal(1, op.Len())
 	splitKeys := op.Step(0).(operator.SplitRegion).SplitKeys
-	// Should have one split key at the boundary between keyspace 100 and 101
+	// 101 txn left bound should be the only split key
 	re.Len(splitKeys, 1)
 	re.Equal(hex.EncodeToString(bound100.TxnRightBound), hex.EncodeToString(splitKeys[0]))
 
@@ -108,7 +108,8 @@ func TestKeyspaceSplit(t *testing.T) {
 	re.NotNil(op, "region spanning multiple keyspaces should be split")
 	re.Equal(1, op.Len())
 	splitKeys = op.Step(0).(operator.SplitRegion).SplitKeys
-	re.Len(splitKeys, 1)
+	// (105-100)=5 split keys expected, but we only generate 10 keys at most to avoid too many operators.
+	re.Len(splitKeys, 5)
 	re.Equal(hex.EncodeToString(bound100.TxnRightBound), hex.EncodeToString(splitKeys[0]))
 }
 

--- a/pkg/schedule/checker/split_checker_test.go
+++ b/pkg/schedule/checker/split_checker_test.go
@@ -98,7 +98,7 @@ func TestKeyspaceSplit(t *testing.T) {
 	re.Equal(1, op.Len())
 	splitKeys := op.Step(0).(operator.SplitRegion).SplitKeys
 	// Should have one split key at the boundary between keyspace 100 and 101
-	re.Equal(1, len(splitKeys))
+	re.Len(splitKeys, 1)
 	re.Equal(hex.EncodeToString(bound100.TxnRightBound), hex.EncodeToString(splitKeys[0]))
 
 	// Test 3: Region spanning multiple keyspaces - should split at all boundaries
@@ -108,6 +108,6 @@ func TestKeyspaceSplit(t *testing.T) {
 	re.NotNil(op, "region spanning multiple keyspaces should be split")
 	re.Equal(1, op.Len())
 	splitKeys = op.Step(0).(operator.SplitRegion).SplitKeys
-	// Should have 5 split keys (boundaries for keyspaces 100, 101, 102, 103, 104)
-	re.Equal(5, len(splitKeys))
+	// Should have 52 split keys
+	re.Len(splitKeys, 2)
 }

--- a/pkg/schedule/checker/split_checker_test.go
+++ b/pkg/schedule/checker/split_checker_test.go
@@ -111,3 +111,26 @@ func TestKeyspaceSplit(t *testing.T) {
 	re.Len(splitKeys, 1)
 	re.Equal(hex.EncodeToString(bound100.TxnRightBound), hex.EncodeToString(splitKeys[0]))
 }
+
+func TestKeyspaceSplitMixRange(t *testing.T) {
+	re := require.New(t)
+
+	starthexKey := "7200019200000000FB"
+	endHexKey := "7800019100000000FB"
+	startkey, err := hex.DecodeString(starthexKey)
+	re.NoError(err)
+	endKey, err := hex.DecodeString(endHexKey)
+	re.NoError(err)
+
+	cfg := mockconfig.NewTestOptions()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster := mockcluster.NewCluster(ctx, cfg)
+	ruleManager := cluster.RuleManager
+	regionLabeler := cluster.RegionLabeler
+	sc := NewSplitChecker(cluster, ruleManager, regionLabeler)
+
+	re.True(keyspace.RegionSpansMultipleKeyspaces(startkey, endKey, sc.cluster.(checkGetter)))
+	keys := keyspace.GetKeyspaceSplitKeys(startkey, endKey, sc.cluster.(checkGetter))
+	re.NotEmpty(keys)
+}

--- a/pkg/schedule/core/cluster_informer.go
+++ b/pkg/schedule/core/cluster_informer.go
@@ -68,9 +68,9 @@ type SharedCluster interface {
 	AllocID(uint32) (uint64, uint32, error)
 	IsSchedulingHalted() bool
 	GetPrepareRegionCount() (int, error)
-	// GetKeyspaceIDInRange returns the keyspace ID in [start, end].
-	// The second return value indicates whether the keyspace ID is valid.
-	GetKeyspaceIDInRange(start, end uint32) (uint32, bool)
+	// GetKeyspaceIDInRange returns the keyspace IDs in [start, end].
+	// The second return value indicates whether the keyspace IDDs are valid.
+	GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool)
 
 	// ExistKeyspaceID returns whether the ID exists.
 	KeyspaceExist(id uint32) bool

--- a/pkg/schedule/core/cluster_informer.go
+++ b/pkg/schedule/core/cluster_informer.go
@@ -68,6 +68,12 @@ type SharedCluster interface {
 	AllocID(uint32) (uint64, uint32, error)
 	IsSchedulingHalted() bool
 	GetPrepareRegionCount() (int, error)
+	// GetKeyspaceIDInRange returns the keyspace ID in [start, end].
+	// The second return value indicates whether the keyspace ID is valid.
+	GetKeyspaceIDInRange(start, end uint32) (uint32, bool)
+
+	// ExistKeyspaceID returns whether the ID exists.
+	KeyspaceExist(id uint32) bool
 }
 
 // BasicCluster is an aggregate interface that wraps multiple interfaces

--- a/pkg/utils/keyutil/keyrange.go
+++ b/pkg/utils/keyutil/keyrange.go
@@ -127,6 +127,14 @@ func (rs *KeyRanges) Append(startKey, endKey []byte) {
 	})
 }
 
+// Clear clears the KeyRanges.
+func (rs *KeyRanges) Clean() {
+	for i := range rs.krs {
+		rs.krs[i] = nil // avoid memory leak
+	}
+	rs.krs = rs.krs[:0]
+}
+
 // SortAndDeduce sorts the KeyRanges and deduces the overlapped KeyRanges.
 func (rs *KeyRanges) SortAndDeduce() {
 	if len(rs.krs) <= 1 {

--- a/pkg/utils/keyutil/keyrange.go
+++ b/pkg/utils/keyutil/keyrange.go
@@ -127,7 +127,7 @@ func (rs *KeyRanges) Append(startKey, endKey []byte) {
 	})
 }
 
-// Clear clears the KeyRanges.
+// Clean clears the KeyRanges.
 func (rs *KeyRanges) Clean() {
 	for i := range rs.krs {
 		rs.krs[i] = nil // avoid memory leak

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -995,8 +995,8 @@ func (c *RaftCluster) GetKeyspaceManager() *keyspace.Manager {
 }
 
 // GetKeyspaceIDInRange returns the keyspace info by the keyspace ID.
-func (c *RaftCluster) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
-	return c.keyspaceManager.GetKeyspaceIDInRange(start, end)
+func (c *RaftCluster) GetKeyspaceIDInRange(start, end uint32, limit int) ([]uint32, bool) {
+	return c.keyspaceManager.GetKeyspaceIDInRange(start, end, limit)
 }
 
 // KeyspaceExist returns whether the keyspace exists by the keyspace ID.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -187,6 +187,7 @@ type RaftCluster struct {
 	progressManager          *progress.Manager
 	regionSyncer             *syncer.RegionSyncer
 	changedRegions           chan *core.RegionInfo
+	keyspaceManager          *keyspace.Manager
 	keyspaceGroupManager     *keyspace.GroupManager
 	independentServices      sync.Map
 	hbstreams                *hbstream.HeartbeatStreams
@@ -314,6 +315,7 @@ func (c *RaftCluster) InitCluster(
 	id id.Allocator,
 	opt sc.ConfProvider,
 	hbstreams *hbstream.HeartbeatStreams,
+	keyspaceManager *keyspace.Manager,
 	keyspaceGroupManager *keyspace.GroupManager) error {
 	c.opt, c.id = opt.(*config.PersistOptions), id
 	c.ctx, c.cancel = context.WithCancel(c.serverCtx)
@@ -322,6 +324,7 @@ func (c *RaftCluster) InitCluster(
 		c.changedRegions = make(chan *core.RegionInfo, 100)
 	})
 	c.unsafeRecoveryController = unsaferecovery.NewController(c)
+	c.keyspaceManager = keyspaceManager
 	c.keyspaceGroupManager = keyspaceGroupManager
 	c.hbstreams = hbstreams
 	c.ruleManager = placement.NewRuleManager(c.ctx, c.storage, c, c.GetOpts())
@@ -340,7 +343,7 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 		return nil
 	}
 	c.isKeyspaceGroupEnabled = s.IsKeyspaceGroupEnabled()
-	err = c.InitCluster(s.GetAllocator(), s.GetPersistOptions(), s.GetHBStreams(), s.GetKeyspaceGroupManager())
+	err = c.InitCluster(s.GetAllocator(), s.GetPersistOptions(), s.GetHBStreams(), s.GetKeyspaceManager(), s.GetKeyspaceGroupManager())
 	if err != nil {
 		return err
 	}
@@ -422,7 +425,7 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 	go c.runUpdateStoreStats()
 	go c.startGCTuner()
 	go c.startProgressGC()
-	go c.runStorageSizeCollector(s.GetMeteringWriter(), c.regionLabeler, s.GetKeyspaceManager())
+	go c.runStorageSizeCollector(s.GetMeteringWriter(), s.GetKeyspaceManager())
 
 	c.running = true
 	c.heartbeatRunner.Start(c.ctx)
@@ -984,6 +987,11 @@ func (c *RaftCluster) GetRuleManager() *placement.RuleManager {
 // GetKeyRangeManager returns the key range manager reference
 func (c *RaftCluster) GetKeyRangeManager() *keyrange.Manager {
 	return c.keyRangeManager
+}
+
+// GetKeyspaceManager returns the keyspace manager reference.
+func (c *RaftCluster) GetKeyspaceManager() *keyspace.Manager {
+	return c.keyspaceManager
 }
 
 // GetRegionLabeler returns the region labeler.
@@ -2608,7 +2616,6 @@ func (c *RaftCluster) adjustNetworkSlowStore(storeID uint64) {
 // runStorageSizeCollector runs the storage size collector for the metering.
 func (c *RaftCluster) runStorageSizeCollector(
 	writer *metering.Writer,
-	regionLabeler *labeler.RegionLabeler,
 	keyspaceManager *keyspace.Manager,
 ) {
 	defer logutil.LogPanic()
@@ -2631,38 +2638,19 @@ func (c *RaftCluster) runStorageSizeCollector(
 			log.Info("storage size collector has been stopped")
 			return
 		case <-ticker.C:
-			storageSizeInfoList := c.collectStorageSize(regionLabeler, keyspaceManager)
+			storageSizeInfoList := c.collectStorageSize(keyspaceManager)
 			// Collect the storage size info list of all keyspaces.
 			collector.Collect(storageSizeInfoList)
 		}
 	}
 }
 
-func (c *RaftCluster) collectStorageSize(
-	regionLabeler *labeler.RegionLabeler,
-	keyspaceManager *keyspace.Manager,
-) []*storageSizeInfo {
+func (c *RaftCluster) collectStorageSize(keyspaceManager *keyspace.Manager) []*storageSizeInfo {
 	regionBoundsMap := make(map[string]*keyspace.RegionBound)
 	start := time.Now()
-	// Iterate the region labeler to get all keyspaces and their corresponding region ranges.
-	regionLabeler.IterateLabelRules(func(rule *labeler.LabelRule) bool {
-		// Try to parse the keyspace ID from the label rule.
-		keyspaceID, ok := keyspace.ParseKeyspaceIDFromLabelRule(rule)
-		if !ok {
-			return true
-		}
-		keyspaceName, err := keyspaceManager.GetEnabledKeyspaceNameByID(keyspaceID)
-		if err != nil {
-			// TODO: improve the observability of this error.
-			return true
-		}
-		// Make the region bounds.
-		regionBoundsMap[keyspaceName] = keyspace.MakeRegionBound(keyspaceID)
-		return true
+	keyspaceManager.ScanAllKeyspace(func(keyspaceID uint32, name string) {
+		regionBoundsMap[name] = keyspace.MakeRegionBound(keyspaceID)
 	})
-	log.Info("iterated the region bounds of all keyspaces",
-		zap.Duration("cost", time.Since(start)),
-		zap.Int("count", len(regionBoundsMap)))
 
 	start = time.Now()
 	storageSizeInfoList := make([]*storageSizeInfo, 0, len(regionBoundsMap))

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2647,12 +2647,12 @@ func (c *RaftCluster) runStorageSizeCollector(
 
 func (c *RaftCluster) collectStorageSize(keyspaceManager *keyspace.Manager) []*storageSizeInfo {
 	regionBoundsMap := make(map[string]*keyspace.RegionBound)
-	start := time.Now()
-	keyspaceManager.ScanAllKeyspace(func(keyspaceID uint32, name string) {
+	keyspaceManager.ScanAllKeyspace(func(keyspaceID uint32, name string) bool {
 		regionBoundsMap[name] = keyspace.MakeRegionBound(keyspaceID)
+		return true
 	})
 
-	start = time.Now()
+	start := time.Now()
 	storageSizeInfoList := make([]*storageSizeInfo, 0, len(regionBoundsMap))
 	// Observe the region stats of each keyspace.
 	for keyspaceName, regionBounds := range regionBoundsMap {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -994,6 +994,16 @@ func (c *RaftCluster) GetKeyspaceManager() *keyspace.Manager {
 	return c.keyspaceManager
 }
 
+// GetKeyspaceIDInRange returns the keyspace info by the keyspace ID.
+func (c *RaftCluster) GetKeyspaceIDInRange(start, end uint32) (uint32, bool) {
+	return c.keyspaceManager.GetKeyspaceIDInRange(start, end)
+}
+
+// KeyspaceExist returns whether the keyspace exists by the keyspace ID.
+func (c *RaftCluster) KeyspaceExist(id uint32) bool {
+	return c.keyspaceManager.KeyspaceExist(id)
+}
+
 // GetRegionLabeler returns the region labeler.
 func (c *RaftCluster) GetRegionLabeler() *labeler.RegionLabeler {
 	return c.regionLabeler

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -2246,7 +2246,7 @@ func newTestRaftCluster(
 		storage:        s,
 		storeStateLock: syncutil.NewLockGroup(syncutil.WithRemoveEntryOnUnlock(true)),
 	}
-	err := rc.InitCluster(id, opt, nil, nil)
+	err := rc.InitCluster(id, opt, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/server/cluster/metering_test.go
+++ b/server/cluster/metering_test.go
@@ -60,7 +60,7 @@ func TestCollectStorageSize(t *testing.T) {
 		re.NoError(err)
 	}
 
-	storageSizeInfoList := tc.collectStorageSize(tc.regionLabeler, keyspaceManager)
+	storageSizeInfoList := tc.collectStorageSize(keyspaceManager)
 	re.Len(storageSizeInfoList, 10)
 	// Sort the storage size info list by the keyspace name.
 	sort.Slice(storageSizeInfoList, func(i, j int) bool {

--- a/tests/integrations/client/http_client_test.go
+++ b/tests/integrations/client/http_client_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	sc "github.com/tikv/pd/pkg/schedule/config"
-	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/storage/endpoint"
@@ -461,73 +460,6 @@ func checkRuleFunc(
 	if exist {
 		re.Failf("Failed to check the rule", "rule %+v not found", rule)
 	}
-}
-
-func (suite *httpClientTestSuite) TestRegionLabel() {
-	re := suite.Require()
-	client := suite.client
-	ctx, cancel := context.WithCancel(suite.ctx)
-	defer cancel()
-	labelRules, err := client.GetAllRegionLabelRules(ctx)
-	re.NoError(err)
-	re.Len(labelRules, 1)
-
-	// In NextGen, the bootstrap keyspace is SYSTEM with ID 16777214, not DEFAULT with ID 0
-	expectedKeyspaceID := "keyspaces/0"
-	if kerneltype.IsNextGen() {
-		expectedKeyspaceID = "keyspaces/16777214"
-	}
-	re.Equal(expectedKeyspaceID, labelRules[0].ID)
-	// Set a new region label rule.
-	labelRule := &pd.LabelRule{
-		ID:       "rule1",
-		Labels:   []pd.RegionLabel{{Key: "k1", Value: "v1"}},
-		RuleType: "key-range",
-		Data:     labeler.MakeKeyRanges("1234", "5678"),
-	}
-	err = client.SetRegionLabelRule(ctx, labelRule)
-	re.NoError(err)
-	labelRules, err = client.GetAllRegionLabelRules(ctx)
-	re.NoError(err)
-	re.Len(labelRules, 2)
-	sort.Slice(labelRules, func(i, j int) bool {
-		return labelRules[i].ID < labelRules[j].ID
-	})
-	re.Equal(labelRule.ID, labelRules[1].ID)
-	re.Equal(labelRule.Labels, labelRules[1].Labels)
-	re.Equal(labelRule.RuleType, labelRules[1].RuleType)
-	// Patch the region label rule.
-	labelRule = &pd.LabelRule{
-		ID:       "rule2",
-		Labels:   []pd.RegionLabel{{Key: "k2", Value: "v2"}},
-		RuleType: "key-range",
-		Data:     labeler.MakeKeyRanges("ab12", "cd12"),
-	}
-	patch := &pd.LabelRulePatch{
-		SetRules:    []*pd.LabelRule{labelRule},
-		DeleteRules: []string{"rule1"},
-	}
-	err = client.PatchRegionLabelRules(ctx, patch)
-	re.NoError(err)
-	allLabelRules, err := client.GetAllRegionLabelRules(ctx)
-	re.NoError(err)
-	re.Len(labelRules, 2)
-	sort.Slice(allLabelRules, func(i, j int) bool {
-		return allLabelRules[i].ID < allLabelRules[j].ID
-	})
-	re.Equal(labelRule.ID, allLabelRules[1].ID)
-	re.Equal(labelRule.Labels, allLabelRules[1].Labels)
-	re.Equal(labelRule.RuleType, allLabelRules[1].RuleType)
-	labelRules, err = client.GetRegionLabelRulesByIDs(ctx, []string{"rule2"})
-	re.NoError(err)
-	re.Len(labelRules, 1)
-	re.Equal(labelRule, labelRules[0])
-	labelRules, err = client.GetRegionLabelRulesByIDs(ctx, []string{expectedKeyspaceID, "rule2"})
-	re.NoError(err)
-	sort.Slice(labelRules, func(i, j int) bool {
-		return labelRules[i].ID < labelRules[j].ID
-	})
-	re.Equal(allLabelRules, labelRules)
 }
 
 func (suite *httpClientTestSuite) TestAccelerateSchedule() {

--- a/tests/integrations/mcs/scheduling/meta_test.go
+++ b/tests/integrations/mcs/scheduling/meta_test.go
@@ -15,6 +15,7 @@
 package scheduling
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -26,9 +27,11 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/meta"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server/cluster"
+	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 )
 
@@ -53,7 +56,9 @@ func (suite *metaTestSuite) SetupSuite() {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/highFrequencyClusterJobs", `return(true)`))
 	var err error
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
-	suite.cluster, err = tests.NewTestClusterWithKeyspaceGroup(suite.ctx, 1)
+	suite.cluster, err = tests.NewTestClusterWithKeyspaceGroup(suite.ctx, 1, func(conf *config.Config, _ string) {
+		conf.Keyspace.WaitRegionSplit = false
+	})
 	re.NoError(err)
 	err = suite.cluster.RunInitialServers()
 	re.NoError(err)
@@ -128,4 +133,36 @@ func (suite *metaTestSuite) getRaftCluster() *cluster.RaftCluster {
 	cluster := leaderServer.GetServer().GetRaftCluster()
 	re.NotNil(cluster)
 	return cluster
+}
+
+func (suite *metaTestSuite) TestKeyspaceMetaWatch() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/checker/skipCheckSuspectRanges", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/checker/skipCheckSuspectRanges"))
+	}()
+
+	now := time.Now().Unix()
+	request := &keyspace.CreateKeyspaceRequest{
+		Name: fmt.Sprintf("test_keyspace_%d", 0),
+		Config: map[string]string{
+			"config_entry_1": "100",
+		},
+		CreateTime: now,
+	}
+	resp, err := suite.cluster.GetLeaderServer().GetKeyspaceManager().CreateKeyspace(request)
+	re.NoError(err)
+	re.NotNil(resp)
+	re.Greater(resp.Id, uint32(0))
+	bound := keyspace.MakeRegionBound(resp.Id)
+	tc, err := tests.NewTestSchedulingCluster(suite.ctx, 1, suite.cluster)
+	re.NoError(err)
+	defer tc.Destroy()
+	testutil.Eventually(re, func() bool {
+		kr, exist := tc.GetPrimaryServer().GetCoordinator().GetCheckerController().PopOneSuspectKeyRange()
+		if exist {
+			return (bytes.Equal(kr[0], []byte(bound.TxnLeftBound)) && bytes.Equal(kr[1], []byte(bound.TxnRightBound))) || (bytes.Equal(kr[0], []byte(bound.RawLeftBound)) && bytes.Equal(kr[1], []byte(bound.RawRightBound)))
+		}
+		return false
+	})
 }

--- a/tests/integrations/mcs/scheduling/meta_test.go
+++ b/tests/integrations/mcs/scheduling/meta_test.go
@@ -153,7 +153,7 @@ func (suite *metaTestSuite) TestKeyspaceMetaWatch() {
 	resp, err := suite.cluster.GetLeaderServer().GetKeyspaceManager().CreateKeyspace(request)
 	re.NoError(err)
 	re.NotNil(resp)
-	re.Greater(resp.Id, uint32(0))
+	re.Positive(resp.Id)
 	bound := keyspace.MakeRegionBound(resp.Id)
 	tc, err := tests.NewTestSchedulingCluster(suite.ctx, 1, suite.cluster)
 	re.NoError(err)
@@ -161,7 +161,7 @@ func (suite *metaTestSuite) TestKeyspaceMetaWatch() {
 	testutil.Eventually(re, func() bool {
 		kr, exist := tc.GetPrimaryServer().GetCoordinator().GetCheckerController().PopOneSuspectKeyRange()
 		if exist {
-			return (bytes.Equal(kr[0], []byte(bound.TxnLeftBound)) && bytes.Equal(kr[1], []byte(bound.TxnRightBound))) || (bytes.Equal(kr[0], []byte(bound.RawLeftBound)) && bytes.Equal(kr[1], []byte(bound.RawRightBound)))
+			return (bytes.Equal(kr[0], bound.TxnLeftBound) && bytes.Equal(kr[1], bound.TxnRightBound)) || (bytes.Equal(kr[0], bound.RawLeftBound) && bytes.Equal(kr[1], bound.RawRightBound))
 		}
 		return false
 	})

--- a/tests/integrations/mcs/scheduling/meta_test.go
+++ b/tests/integrations/mcs/scheduling/meta_test.go
@@ -158,8 +158,9 @@ func (suite *metaTestSuite) TestKeyspaceMetaWatch() {
 	tc, err := tests.NewTestSchedulingCluster(suite.ctx, 1, suite.cluster)
 	re.NoError(err)
 	defer tc.Destroy()
+	se := tc.WaitForPrimaryServing(re)
 	testutil.Eventually(re, func() bool {
-		kr, exist := tc.GetPrimaryServer().GetCoordinator().GetCheckerController().PopOneSuspectKeyRange()
+		kr, exist := se.GetCoordinator().GetCheckerController().PopOneSuspectKeyRange()
 		if exist {
 			return (bytes.Equal(kr[0], bound.TxnLeftBound) && bytes.Equal(kr[1], bound.TxnRightBound)) || (bytes.Equal(kr[0], bound.RawLeftBound) && bytes.Equal(kr[1], bound.RawRightBound))
 		}

--- a/tests/integrations/mcs/scheduling/rule_test.go
+++ b/tests/integrations/mcs/scheduling/rule_test.go
@@ -82,21 +82,6 @@ func (suite *ruleTestSuite) TestRuleWatch() {
 	tc.WaitForPrimaryServing(re)
 	cluster := tc.GetPrimaryServer().GetCluster()
 	ruleManager := cluster.GetRuleManager()
-	// Check the default rule and rule group.
-	rules := ruleManager.GetAllRules()
-	re.Len(rules, 1)
-	re.Equal(placement.DefaultGroupID, rules[0].GroupID)
-	re.Equal(placement.DefaultRuleID, rules[0].ID)
-	re.Equal(0, rules[0].Index)
-	re.Empty(rules[0].StartKey)
-	re.Empty(rules[0].EndKey)
-	re.Equal(placement.Voter, rules[0].Role)
-	re.Empty(rules[0].LocationLabels)
-	ruleGroups := ruleManager.GetRuleGroups()
-	re.Len(ruleGroups, 1)
-	re.Equal(placement.DefaultGroupID, ruleGroups[0].ID)
-	re.Equal(0, ruleGroups[0].Index)
-	re.False(ruleGroups[0].Override)
 	// Set a new rule via the PD.
 	apiRuleManager := suite.pdLeaderServer.GetRaftCluster().GetRuleManager()
 	rule := &placement.Rule{
@@ -109,20 +94,24 @@ func (suite *ruleTestSuite) TestRuleWatch() {
 	}
 	err = apiRuleManager.SetRule(rule)
 	re.NoError(err)
+	rules := make([]*placement.Rule, 0)
 	testutil.Eventually(re, func() bool {
 		rules = ruleManager.GetAllRules()
 		return len(rules) == 2
 	})
-	sort.Slice(rules, func(i, j int) bool {
-		return rules[i].ID > rules[j].ID
-	})
 	re.Len(rules, 2)
-	re.Equal(rule.GroupID, rules[1].GroupID)
-	re.Equal(rule.ID, rules[1].ID)
-	re.Equal(rule.Role, rules[1].Role)
-	re.Equal(rule.Count, rules[1].Count)
-	re.Equal(rule.StartKeyHex, rules[1].StartKeyHex)
-	re.Equal(rule.EndKeyHex, rules[1].EndKeyHex)
+	var gotRule *placement.Rule
+	for _, r := range rules {
+		if r.GroupID == rule.GroupID && r.ID == rule.ID {
+			gotRule = r
+			break
+		}
+	}
+	re.NotNil(gotRule)
+	re.Equal(rule.Role, gotRule.Role)
+	re.Equal(rule.Count, gotRule.Count)
+	re.Equal(rule.StartKeyHex, gotRule.StartKeyHex)
+	re.Equal(rule.EndKeyHex, gotRule.EndKeyHex)
 	// Delete the rule.
 	err = apiRuleManager.DeleteRule(rule.GroupID, rule.ID)
 	re.NoError(err)
@@ -140,14 +129,22 @@ func (suite *ruleTestSuite) TestRuleWatch() {
 	}
 	err = apiRuleManager.SetRuleGroup(ruleGroup)
 	re.NoError(err)
+	ruleGroups := make([]*placement.RuleGroup, 0)
 	testutil.Eventually(re, func() bool {
 		ruleGroups = ruleManager.GetRuleGroups()
 		return len(ruleGroups) == 2
 	})
 	re.Len(ruleGroups, 2)
-	re.Equal(ruleGroup.ID, ruleGroups[1].ID)
-	re.Equal(ruleGroup.Index, ruleGroups[1].Index)
-	re.Equal(ruleGroup.Override, ruleGroups[1].Override)
+	var gotRuleGroup *placement.RuleGroup
+	for _, rg := range ruleGroups {
+		if rg.ID == ruleGroup.ID {
+			gotRuleGroup = rg
+			break
+		}
+	}
+	re.NotNil(gotRuleGroup)
+	re.Equal(ruleGroup.Index, gotRuleGroup.Index)
+	re.Equal(ruleGroup.Override, gotRuleGroup.Override)
 	// Delete the rule group.
 	err = apiRuleManager.DeleteRuleGroup(ruleGroup.ID)
 	re.NoError(err)
@@ -163,10 +160,19 @@ func (suite *ruleTestSuite) TestRuleWatch() {
 	apiRegionLabeler := suite.pdLeaderServer.GetRaftCluster().GetRegionLabeler()
 	apiLabelRules := apiRegionLabeler.GetAllLabelRules()
 	re.Len(labelRules, len(apiLabelRules))
-	re.Equal(apiLabelRules[0].ID, labelRules[0].ID)
-	re.Equal(apiLabelRules[0].Index, labelRules[0].Index)
-	re.Equal(apiLabelRules[0].Labels, labelRules[0].Labels)
-	re.Equal(apiLabelRules[0].RuleType, labelRules[0].RuleType)
+	sort.Slice(labelRules, func(i, j int) bool {
+		return labelRules[i].ID < labelRules[j].ID
+	})
+	sort.Slice(apiLabelRules, func(i, j int) bool {
+		return apiLabelRules[i].ID < apiLabelRules[j].ID
+	})
+	for i := range apiLabelRules {
+		re.Equal(apiLabelRules[i].ID, labelRules[i].ID)
+		re.Equal(apiLabelRules[i].Index, labelRules[i].Index)
+		re.Equal(apiLabelRules[i].Labels, labelRules[i].Labels)
+		re.Equal(apiLabelRules[i].RuleType, labelRules[i].RuleType)
+	}
+	baseLabelRuleCount := len(labelRules)
 	// Set a new region label rule.
 	labelRule := &labeler.LabelRule{
 		ID:       "rule1",
@@ -178,15 +184,22 @@ func (suite *ruleTestSuite) TestRuleWatch() {
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		labelRules = regionLabeler.GetAllLabelRules()
-		return len(labelRules) == 2
+		return len(labelRules) == baseLabelRuleCount+1
 	})
 	sort.Slice(labelRules, func(i, j int) bool {
 		return labelRules[i].ID < labelRules[j].ID
 	})
-	re.Len(labelRules, 2)
-	re.Equal(labelRule.ID, labelRules[1].ID)
-	re.Equal(labelRule.Labels, labelRules[1].Labels)
-	re.Equal(labelRule.RuleType, labelRules[1].RuleType)
+	re.Len(labelRules, baseLabelRuleCount+1)
+	var gotLabelRule *labeler.LabelRule
+	for _, lr := range labelRules {
+		if lr.ID == labelRule.ID {
+			gotLabelRule = lr
+			break
+		}
+	}
+	re.NotNil(gotLabelRule)
+	re.Equal(labelRule.Labels, gotLabelRule.Labels)
+	re.Equal(labelRule.RuleType, gotLabelRule.RuleType)
 	// Patch the region label rule.
 	labelRule = &labeler.LabelRule{
 		ID:       "rule2",
@@ -202,15 +215,22 @@ func (suite *ruleTestSuite) TestRuleWatch() {
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		labelRules = regionLabeler.GetAllLabelRules()
-		return len(labelRules) == 2
+		return len(labelRules) == baseLabelRuleCount+1
 	})
 	sort.Slice(labelRules, func(i, j int) bool {
 		return labelRules[i].ID < labelRules[j].ID
 	})
-	re.Len(labelRules, 2)
-	re.Equal(labelRule.ID, labelRules[1].ID)
-	re.Equal(labelRule.Labels, labelRules[1].Labels)
-	re.Equal(labelRule.RuleType, labelRules[1].RuleType)
+	re.Len(labelRules, baseLabelRuleCount+1)
+	gotLabelRule = nil
+	for _, lr := range labelRules {
+		if lr.ID == labelRule.ID {
+			gotLabelRule = lr
+			break
+		}
+	}
+	re.NotNil(gotLabelRule)
+	re.Equal(labelRule.Labels, gotLabelRule.Labels)
+	re.Equal(labelRule.RuleType, gotLabelRule.RuleType)
 }
 
 func (suite *ruleTestSuite) TestSchedulingSwitch() {

--- a/tests/server/api/rule_test.go
+++ b/tests/server/api/rule_test.go
@@ -34,15 +34,12 @@ import (
 
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/core"
-	"github.com/tikv/pd/pkg/errs"
-	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/schedule/checker"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
-	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
 )
@@ -1436,70 +1433,4 @@ func (suite *regionRuleTestSuite) checkRegionPlacementRule(cluster *tests.TestCl
 	re.NoError(err)
 	re.Empty(fit.RuleFits)
 	re.Len(fit.OrphanPeers, 2)
-
-	var label labeler.LabelRule
-	// In NextGen, default keyspace ID is SystemKeyspaceID, in Classic it's 0
-	var expectedKeyspaceID string
-	if kerneltype.IsNextGen() {
-		expectedKeyspaceID = fmt.Sprintf("keyspaces/%d", constant.SystemKeyspaceID)
-	} else {
-		expectedKeyspaceID = "keyspaces/0"
-	}
-	escapedID := url.PathEscape(expectedKeyspaceID)
-	u = fmt.Sprintf("%s/config/region-label/rule/%s", urlPrefix, escapedID)
-	err = testutil.ReadGetJSON(re, tests.TestDialClient, u, &label)
-	re.NoError(err)
-	re.Equal(expectedKeyspaceID, label.ID)
-
-	var labels []labeler.LabelRule
-	u = fmt.Sprintf("%s/config/region-label/rules", urlPrefix)
-	err = testutil.ReadGetJSON(re, tests.TestDialClient, u, &labels)
-	re.NoError(err)
-	re.Len(labels, 1)
-	re.Equal(expectedKeyspaceID, labels[0].ID)
-
-	u = fmt.Sprintf("%s/config/region-label/rules/ids", urlPrefix)
-	err = testutil.CheckGetJSON(tests.TestDialClient, u, []byte(`["rule1", "rule3"]`), func(resp []byte, _ int, _ http.Header) {
-		err := json.Unmarshal(resp, &labels)
-		re.NoError(err)
-		re.Empty(labels)
-	})
-	re.NoError(err)
-
-	expectedIDsJSON := fmt.Sprintf("[\"%s\"]", expectedKeyspaceID)
-	err = testutil.CheckGetJSON(tests.TestDialClient, u, []byte(expectedIDsJSON), func(resp []byte, _ int, _ http.Header) {
-		err := json.Unmarshal(resp, &labels)
-		re.NoError(err)
-		re.Len(labels, 1)
-		re.Equal(expectedKeyspaceID, labels[0].ID)
-	})
-	re.NoError(err)
-
-	u = fmt.Sprintf("%s/config/rules/region/%d/detail", urlPrefix, 4)
-	err = testutil.CheckGetJSON(tests.TestDialClient, u, nil, testutil.Status(re, http.StatusNotFound), testutil.StringContain(
-		re, "region 4 not found"))
-	re.NoError(err)
-
-	u = fmt.Sprintf("%s/config/rules/region/%s/detail", urlPrefix, "id")
-	err = testutil.CheckGetJSON(tests.TestDialClient, u, nil, testutil.Status(re, http.StatusBadRequest), testutil.StringContain(
-		re, errs.ErrRegionInvalidID.Error()))
-	re.NoError(err)
-
-	data := make(map[string]any)
-	data["enable-placement-rules"] = "false"
-	reqData, e := json.Marshal(data)
-	re.NoError(e)
-	u = fmt.Sprintf("%s/config", urlPrefix)
-	err = testutil.CheckPostJSON(tests.TestDialClient, u, reqData, testutil.StatusOK(re))
-	re.NoError(err)
-	if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
-		// wait for the scheduling server to update the config
-		testutil.Eventually(re, func() bool {
-			return !sche.GetCluster().GetCheckerConfig().IsPlacementRulesEnabled()
-		})
-	}
-	u = fmt.Sprintf("%s/config/rules/region/%d/detail", urlPrefix, 1)
-	err = testutil.CheckGetJSON(tests.TestDialClient, u, nil, testutil.Status(re, http.StatusPreconditionFailed), testutil.StringContain(
-		re, "placement rules feature is disabled"))
-	re.NoError(err)
 }

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -1104,7 +1104,7 @@ func TestLoadClusterInfo(t *testing.T) {
 	rc := cluster.NewRaftCluster(ctx, svr.GetMember(), svr.GetBasicCluster(), svr.GetStorage(), syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient(), svr.GetTSOAllocator())
 
 	// Cluster is not bootstrapped.
-	err = rc.InitCluster(svr.GetAllocator(), svr.GetPersistOptions(), svr.GetHBStreams(), svr.GetKeyspaceGroupManager())
+	err = rc.InitCluster(svr.GetAllocator(), svr.GetPersistOptions(), svr.GetHBStreams(), svr.GetKeyspaceManager(), svr.GetKeyspaceGroupManager())
 	re.NoError(err)
 	raftCluster, err := rc.LoadClusterInfo()
 	re.NoError(err)
@@ -1144,7 +1144,7 @@ func TestLoadClusterInfo(t *testing.T) {
 
 	raftCluster = cluster.NewRaftCluster(ctx, svr.GetMember(), basicCluster,
 		testStorage, syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient(), svr.GetTSOAllocator())
-	err = raftCluster.InitCluster(mockid.NewIDAllocator(), svr.GetPersistOptions(), svr.GetHBStreams(), svr.GetKeyspaceGroupManager())
+	err = raftCluster.InitCluster(mockid.NewIDAllocator(), svr.GetPersistOptions(), svr.GetHBStreams(), svr.GetKeyspaceManager(), svr.GetKeyspaceGroupManager())
 	re.NoError(err)
 	raftCluster, err = raftCluster.LoadClusterInfo()
 	re.NoError(err)
@@ -1890,7 +1890,7 @@ func TestTransferLeaderBack(t *testing.T) {
 	rc := cluster.NewRaftCluster(ctx, svr.GetMember(), svr.GetBasicCluster(),
 		svr.GetStorage(), syncer.NewRegionSyncer(svr), svr.GetClient(),
 		svr.GetHTTPClient(), svr.GetTSOAllocator())
-	err = rc.InitCluster(svr.GetAllocator(), svr.GetPersistOptions(), svr.GetHBStreams(), svr.GetKeyspaceGroupManager())
+	err = rc.InitCluster(svr.GetAllocator(), svr.GetPersistOptions(), svr.GetHBStreams(), svr.GetKeyspaceManager(), svr.GetKeyspaceGroupManager())
 	re.NoError(err)
 	storage := rc.GetStorage()
 	meta := &metapb.Cluster{Id: 123}

--- a/tests/server/keyspace/keyspace_test.go
+++ b/tests/server/keyspace/keyspace_test.go
@@ -216,3 +216,87 @@ func TestProtectedKeyspace(t *testing.T) {
 		})
 	}
 }
+
+// TestKeyspaceRegionSplit tests the full flow of keyspace boundary detection.
+func (suite *keyspaceTestSuite) TestKeyspaceRegionSplit() {
+	re := suite.Require()
+	manager := suite.manager
+
+	// Test ExtractKeyspaceID function
+	testCases := []struct {
+		name     string
+		key      []byte
+		expected uint32
+		ok       bool
+	}{
+		{"keyspace 1 txn", []byte{'x', 0, 0, 1, 0}, 1, true},
+		{"keyspace 2 txn", []byte{'x', 0, 0, 2, 100}, 2, true},
+		{"keyspace 100 txn", []byte{'x', 0, 0, 100, 50}, 100, true},
+		{"empty key", []byte{}, 0, false},
+		{"short key", []byte{'x', 0}, 0, false},
+	}
+
+	for _, tc := range testCases {
+		id, ok := keyspace.ExtractKeyspaceID(tc.key)
+		re.Equal(tc.ok, ok, "test case: %s", tc.name)
+		if ok {
+			re.Equal(tc.expected, id, "test case: %s", tc.name)
+		}
+	}
+
+	// Test RegionSpansMultipleKeyspaces function
+	spanTestCases := []struct {
+		name       string
+		startKey   []byte
+		endKey     []byte
+		shouldSpan bool
+	}{
+		{
+			"same keyspace",
+			[]byte{'x', 0, 0, 1, 0},
+			[]byte{'x', 0, 0, 1, 100},
+			false,
+		},
+		{
+			"at boundary (should not span)",
+			[]byte{'x', 0, 0, 1, 0},
+			[]byte{'x', 0, 0, 2}, // Exactly at the right bound
+			false,
+		},
+		{
+			"spans two keyspaces",
+			[]byte{'x', 0, 0, 1, 0},
+			[]byte{'x', 0, 0, 2, 100},
+			true,
+		},
+		{
+			"spans multiple keyspaces",
+			[]byte{'x', 0, 0, 1, 0},
+			[]byte{'x', 0, 0, 5, 0},
+			true,
+		},
+	}
+
+	for _, tc := range spanTestCases {
+		spans := keyspace.RegionSpansMultipleKeyspaces(tc.startKey, tc.endKey, manager)
+		re.Equal(tc.shouldSpan, spans, "test case: %s", tc.name)
+	}
+
+	// Test GetKeyspaceSplitKeys function
+	// For a region spanning keyspaces 1-3, it should generate split keys at boundaries 2 and 3
+	startKey := []byte{'x', 0, 0, 1, 0}
+	endKey := []byte{'x', 0, 0, 3, 100}
+	splitKeys := keyspace.GetKeyspaceSplitKeys(startKey, endKey, manager)
+	re.NotNil(splitKeys)
+	re.GreaterOrEqual(len(splitKeys), 1, "Should generate at least one split key")
+
+	// Verify first split key is at keyspace 2 boundary
+	expectedBound2 := keyspace.MakeRegionBound(2)
+	re.Equal(expectedBound2.TxnLeftBound, splitKeys[0], "First split key should be at keyspace 2 boundary")
+
+	// If there are two split keys, the second should be at keyspace 3 boundary
+	if len(splitKeys) >= 2 {
+		expectedBound3 := keyspace.MakeRegionBound(3)
+		re.Equal(expectedBound3.TxnLeftBound, splitKeys[1], "Second split key should be at keyspace 3 boundary")
+	}
+}

--- a/tests/server/keyspace/keyspace_test.go
+++ b/tests/server/keyspace/keyspace_test.go
@@ -16,9 +16,6 @@ package keyspace
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -31,8 +28,6 @@ import (
 
 	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/keyspace/constant"
-	"github.com/tikv/pd/pkg/schedule/labeler"
-	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
@@ -77,58 +72,6 @@ func (suite *keyspaceTestSuite) SetupTest() {
 func (suite *keyspaceTestSuite) TearDownTest() {
 	suite.cancel()
 	suite.cluster.Destroy()
-}
-
-func (suite *keyspaceTestSuite) TestRegionLabeler() {
-	re := suite.Require()
-	regionLabeler := suite.server.GetRaftCluster().GetRegionLabeler()
-
-	// Create test keyspaces.
-	count := 20
-	now := time.Now().Unix()
-	keyspaces := make([]*keyspacepb.KeyspaceMeta, count)
-	manager := suite.manager
-	var err error
-	for i := range count {
-		keyspaces[i], err = manager.CreateKeyspace(&keyspace.CreateKeyspaceRequest{
-			Name:       fmt.Sprintf("test_keyspace_%d", i),
-			CreateTime: now,
-		})
-		re.NoError(err)
-	}
-	// Check for region labels.
-	for _, meta := range keyspaces {
-		checkLabelRule(re, meta.GetId(), regionLabeler)
-	}
-}
-
-func checkLabelRule(re *require.Assertions, id uint32, regionLabeler *labeler.RegionLabeler) {
-	labelID := "keyspaces/" + strconv.FormatUint(uint64(id), endpoint.SpaceIDBase)
-	loadedLabel := regionLabeler.GetLabelRule(labelID)
-	re.NotNil(loadedLabel)
-
-	rangeRule, ok := loadedLabel.Data.([]*labeler.KeyRangeRule)
-	re.True(ok)
-	re.Len(rangeRule, 2)
-
-	bound := keyspace.MakeRegionBound(id)
-
-	re.Equal(hex.EncodeToString(bound.RawLeftBound), rangeRule[0].StartKeyHex)
-	re.Equal(hex.EncodeToString(bound.RawRightBound), rangeRule[0].EndKeyHex)
-	re.Equal(hex.EncodeToString(bound.TxnLeftBound), rangeRule[1].StartKeyHex)
-	re.Equal(hex.EncodeToString(bound.TxnRightBound), rangeRule[1].EndKeyHex)
-}
-
-func (suite *keyspaceTestSuite) TestPreAlloc() {
-	re := suite.Require()
-	regionLabeler := suite.server.GetRaftCluster().GetRegionLabeler()
-	for _, keyspaceName := range preAllocKeyspace {
-		// Check pre-allocated keyspaces are correctly allocated.
-		meta, err := suite.manager.LoadKeyspace(keyspaceName)
-		re.NoError(err)
-		// Check pre-allocated keyspaces also have the correct region label.
-		checkLabelRule(re, meta.GetId(), regionLabeler)
-	}
 }
 
 func makeMutations() []*keyspace.Mutation {
@@ -229,10 +172,10 @@ func (suite *keyspaceTestSuite) TestKeyspaceRegionSplit() {
 		expected uint32
 		ok       bool
 	}{
-		{"keyspace 1 txn", []byte{'x', 0, 0, 1, 0}, 1, true},
-		{"keyspace 2 txn", []byte{'x', 0, 0, 2, 100}, 2, true},
-		{"keyspace 100 txn", []byte{'x', 0, 0, 100, 50}, 100, true},
-		{"empty key", []byte{}, 0, false},
+		{"keyspace 1 txn", keyspace.MakeRegionBound(1).TxnLeftBound, 1, true},
+		{"keyspace 2 txn", keyspace.MakeRegionBound(2).TxnLeftBound, 2, true},
+		{"keyspace 100 txn", keyspace.MakeRegionBound(100).TxnLeftBound, 100, true},
+		{"empty key", []byte{}, constant.MaxValidKeyspaceID, true},
 		{"short key", []byte{'x', 0}, 0, false},
 	}
 
@@ -253,26 +196,26 @@ func (suite *keyspaceTestSuite) TestKeyspaceRegionSplit() {
 	}{
 		{
 			"same keyspace",
-			[]byte{'x', 0, 0, 1, 0},
-			[]byte{'x', 0, 0, 1, 100},
+			keyspace.MakeRegionBound(1).TxnLeftBound,
+			keyspace.MakeRegionBound(1).TxnRightBound,
 			false,
 		},
 		{
 			"at boundary (should not span)",
-			[]byte{'x', 0, 0, 1, 0},
-			[]byte{'x', 0, 0, 2}, // Exactly at the right bound
+			keyspace.MakeRegionBound(1).TxnLeftBound,
+			keyspace.MakeRegionBound(2).TxnLeftBound, // Exactly at the right bound
 			false,
 		},
 		{
 			"spans two keyspaces",
-			[]byte{'x', 0, 0, 1, 0},
-			[]byte{'x', 0, 0, 2, 100},
+			keyspace.MakeRegionBound(1).TxnLeftBound,
+			keyspace.MakeRegionBound(2).TxnRightBound,
 			true,
 		},
 		{
 			"spans multiple keyspaces",
-			[]byte{'x', 0, 0, 1, 0},
-			[]byte{'x', 0, 0, 5, 0},
+			keyspace.MakeRegionBound(1).TxnLeftBound,
+			keyspace.MakeRegionBound(5).TxnRightBound,
 			true,
 		},
 	}
@@ -284,8 +227,8 @@ func (suite *keyspaceTestSuite) TestKeyspaceRegionSplit() {
 
 	// Test GetKeyspaceSplitKeys function
 	// For a region spanning keyspaces 1-3, it should generate split keys at boundaries 2 and 3
-	startKey := []byte{'x', 0, 0, 1, 0}
-	endKey := []byte{'x', 0, 0, 3, 100}
+	startKey := keyspace.MakeRegionBound(1).TxnLeftBound
+	endKey := keyspace.MakeRegionBound(3).TxnRightBound
 	splitKeys := keyspace.GetKeyspaceSplitKeys(startKey, endKey, manager)
 	re.NotNil(splitKeys)
 	re.GreaterOrEqual(len(splitKeys), 1, "Should generate at least one split key")

--- a/tests/server/keyspace/keyspace_test.go
+++ b/tests/server/keyspace/keyspace_test.go
@@ -227,6 +227,11 @@ func (suite *keyspaceTestSuite) TestKeyspaceRegionSplit() {
 
 	// Test GetKeyspaceSplitKeys function
 	// For a region spanning keyspaces 1-3, it should generate split keys at boundaries 2 and 3
+	testutil.Eventually(re, func() bool {
+		_, ok := suite.server.GetKeyspaceManager().GetKeyspaceIDInRange(1, 3)
+		return ok
+	})
+
 	startKey := keyspace.MakeRegionBound(1).TxnLeftBound
 	endKey := keyspace.MakeRegionBound(3).TxnRightBound
 	splitKeys := keyspace.GetKeyspaceSplitKeys(startKey, endKey, manager)

--- a/tests/server/keyspace/keyspace_test.go
+++ b/tests/server/keyspace/keyspace_test.go
@@ -228,7 +228,7 @@ func (suite *keyspaceTestSuite) TestKeyspaceRegionSplit() {
 	// Test GetKeyspaceSplitKeys function
 	// For a region spanning keyspaces 1-3, it should generate split keys at boundaries 2 and 3
 	testutil.Eventually(re, func() bool {
-		_, ok := suite.server.GetKeyspaceManager().GetKeyspaceIDInRange(1, 3)
+		_, ok := suite.server.GetKeyspaceManager().GetKeyspaceIDInRange(1, 3, 1)
 		return ok
 	})
 

--- a/tests/server/keyspace/keyspace_test.go
+++ b/tests/server/keyspace/keyspace_test.go
@@ -170,19 +170,19 @@ func (suite *keyspaceTestSuite) TestKeyspaceRegionSplit() {
 		name     string
 		key      []byte
 		expected uint32
-		ok       bool
+		kt       keyspace.KeyType
 	}{
-		{"keyspace 1 txn", keyspace.MakeRegionBound(1).TxnLeftBound, 1, true},
-		{"keyspace 2 txn", keyspace.MakeRegionBound(2).TxnLeftBound, 2, true},
-		{"keyspace 100 txn", keyspace.MakeRegionBound(100).TxnLeftBound, 100, true},
-		{"empty key", []byte{}, constant.MaxValidKeyspaceID, true},
-		{"short key", []byte{'x', 0}, 0, false},
+		{"keyspace 1 txn", keyspace.MakeRegionBound(1).TxnLeftBound, 1, keyspace.KeyTypeTxn},
+		{"keyspace 2 txn", keyspace.MakeRegionBound(2).TxnLeftBound, 2, keyspace.KeyTypeTxn},
+		{"keyspace 100 txn", keyspace.MakeRegionBound(100).TxnLeftBound, 100, keyspace.KeyTypeTxn},
+		{"empty key", []byte{}, constant.MaxValidKeyspaceID, keyspace.KeyTypeTxn},
+		{"short key", []byte{'t', 0}, 0, keyspace.KeyTypeUnknown},
 	}
 
 	for _, tc := range testCases {
-		id, ok := keyspace.ExtractKeyspaceID(tc.key)
-		re.Equal(tc.ok, ok, "test case: %s", tc.name)
-		if ok {
+		id, kt := keyspace.ExtractKeyspaceID(tc.key)
+		re.Equal(tc.kt, kt, "test case: %s", tc.name)
+		if kt != keyspace.KeyTypeUnknown {
 			re.Equal(tc.expected, id, "test case: %s", tc.name)
 		}
 	}

--- a/tools/pd-ctl/pdctl/command/keyspace_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command.go
@@ -551,7 +551,19 @@ func setPlacementCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	// Generate key ranges for the keyspace
-	keyRanges := keyspace.MakeKeyRanges(keyspaceID32)
+	ks := keyspace.MakeKeyspaceRanges(keyspaceID32)
+	rules := make([]*pd.Rule, 0, len(ks.Ranges()))
+	for i, kr := range ks.Ranges() {
+		rules = append(rules, &pd.Rule{
+			GroupID:          fmt.Sprintf("keyspace-%d", keyspaceID),
+			ID:               fmt.Sprintf("keyspace-%d-rule-%d", keyspaceID, i),
+			Role:             pd.Voter,
+			Count:            3, // TODO: make replica count configurable
+			StartKeyHex:      hex.EncodeToString(kr.StartKey),
+			EndKeyHex:        hex.EncodeToString(kr.EndKey),
+			LabelConstraints: labelConstraints,
+		})
+	}
 
 	// Create placement rule bundle
 	groupID := fmt.Sprintf("keyspace-%d", keyspaceID)
@@ -559,28 +571,7 @@ func setPlacementCommandFunc(cmd *cobra.Command, args []string) {
 		ID:       groupID,
 		Index:    100,
 		Override: true,
-		Rules: []*pd.Rule{
-			{
-				GroupID: groupID,
-				ID:      fmt.Sprintf("keyspace-%d-rule", keyspaceID),
-				Role:    pd.Voter,
-				// TODO: make replica count configurable
-				Count:            3,
-				StartKeyHex:      keyRanges[0].(map[string]any)["start_key"].(string),
-				EndKeyHex:        keyRanges[0].(map[string]any)["end_key"].(string),
-				LabelConstraints: labelConstraints,
-			},
-			{
-				GroupID: groupID,
-				ID:      fmt.Sprintf("keyspace-%d-rule-txn", keyspaceID),
-				Role:    pd.Voter,
-				// TODO: make replica count configurable
-				Count:            3,
-				StartKeyHex:      keyRanges[1].(map[string]any)["start_key"].(string),
-				EndKeyHex:        keyRanges[1].(map[string]any)["end_key"].(string),
-				LabelConstraints: labelConstraints,
-			},
-		},
+		Rules:    rules,
 	}
 
 	// Send to PD server using PDCli

--- a/tools/pd-ctl/pdctl/command/keyspace_command.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command.go
@@ -551,19 +551,7 @@ func setPlacementCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	// Generate key ranges for the keyspace
-	ks := keyspace.MakeKeyspaceRanges(keyspaceID32)
-	rules := make([]*pd.Rule, 0, len(ks.Ranges()))
-	for i, kr := range ks.Ranges() {
-		rules = append(rules, &pd.Rule{
-			GroupID:          fmt.Sprintf("keyspace-%d", keyspaceID),
-			ID:               fmt.Sprintf("keyspace-%d-rule-%d", keyspaceID, i),
-			Role:             pd.Voter,
-			Count:            3, // TODO: make replica count configurable
-			StartKeyHex:      hex.EncodeToString(kr.StartKey),
-			EndKeyHex:        hex.EncodeToString(kr.EndKey),
-			LabelConstraints: labelConstraints,
-		})
-	}
+	keyRanges := keyspace.MakeKeyRanges(keyspaceID32)
 
 	// Create placement rule bundle
 	groupID := fmt.Sprintf("keyspace-%d", keyspaceID)
@@ -571,7 +559,28 @@ func setPlacementCommandFunc(cmd *cobra.Command, args []string) {
 		ID:       groupID,
 		Index:    100,
 		Override: true,
-		Rules:    rules,
+		Rules: []*pd.Rule{
+			{
+				GroupID: groupID,
+				ID:      fmt.Sprintf("keyspace-%d-rule", keyspaceID),
+				Role:    pd.Voter,
+				// TODO: make replica count configurable
+				Count:            3,
+				StartKeyHex:      keyRanges[0].(map[string]any)["start_key"].(string),
+				EndKeyHex:        keyRanges[0].(map[string]any)["end_key"].(string),
+				LabelConstraints: labelConstraints,
+			},
+			{
+				GroupID: groupID,
+				ID:      fmt.Sprintf("keyspace-%d-rule-txn", keyspaceID),
+				Role:    pd.Voter,
+				// TODO: make replica count configurable
+				Count:            3,
+				StartKeyHex:      keyRanges[1].(map[string]any)["start_key"].(string),
+				EndKeyHex:        keyRanges[1].(map[string]any)["end_key"].(string),
+				LabelConstraints: labelConstraints,
+			},
+		},
 	}
 
 	// Send to PD server using PDCli


### PR DESCRIPTION
### What problem does this PR solve?

Keyspace-aware region split and merge checks currently depend on region label rules. This couples scheduling behavior to the labeler and makes it difficult for the scheduling server to track keyspace metadata directly.

Issue Number: Close #10123

### What is changed and how does it work?

```commit-message
Decouple keyspace-aware region split and merge checks from region label rules by using keyspace metadata directly. Add cache-backed keyspace range lookup, make the MCS scheduling server watch keyspace metadata changes, and retrigger checks for affected keyspace ranges. Keep writing keyspace region label rules as a rolling-upgrade compatibility fallback for scheduling-server versions that do not support the metadata watcher.
```

Main changes:

- `pkg/keyspace`
  - Add ordered keyspace metadata cache and range lookup.
  - Backfill keyspace IDs from storage in bounded batches after cache reset or leadership change.
  - Generate split keys from keyspace metadata and handle raw/txn and foreign-key boundaries.
  - Preserve enabled-only filtering for storage-size metering.
- `pkg/schedule/checker`
  - Prevent merges across existing keyspace boundaries.
  - Add keyspace-aware split checks without relying on region label rules.
- `pkg/mcs/scheduling/server`
  - Watch keyspace metadata using the keyspace ID encoded in the etcd path.
  - Update the scheduling cache and enqueue suspect ranges on keyspace metadata changes.
- Rolling upgrade compatibility
  - Continue writing `keyspaces/{id}` region label rules as a best-effort compatibility fallback for older scheduling servers.
  - Keep the existing region-label APIs backward compatible while older scheduling servers remain supported.

### Check List

Tests

- Unit test
- Integration test

Relevant coverage includes keyspace cache and range lookup, split/merge boundary checks, MCS keyspace metadata watching, storage-size collection, and rolling-upgrade label compatibility.

Side effects

- Possible performance regression
  - Keyspace creation performs one additional best-effort etcd label-rule write while rolling-upgrade compatibility is required.
  - Keyspace range cache backfill uses bounded storage scans and converges across repeated checker calls.
- Increased code complexity
  - Keyspace metadata is maintained through the PD cache and the MCS scheduling-server watcher during the transition away from labeler-driven scheduling decisions.

### Release note

```release-note
pd: use keyspace metadata for keyspace-aware region split and merge checks, while retaining compatibility region-label writes during rolling upgrades.
```