### PR TITLE
metrics: add gRPC stream send duration and rate Grafana panels

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -8965,6 +8965,222 @@
           "steppedLine": false,
           "timeFrom": null,
           "timeShift": null
+        },
+        {
+          "aliasColors": {},
+          "dashLength": 10,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The P99 duration of gRPC stream Send operations by request type.",
+          "editable": true,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 151
+          },
+          "id": 908,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 300,
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "pluginVersion": "7.5.17",
+          "pointradius": 5,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(pd_server_grpc_stream_send_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[5m])) by (instance, request, le))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-{{request}}",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "gRPC Stream Send Duration (P99)",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "bars": false,
+          "dashes": false,
+          "decimals": null,
+          "error": false,
+          "fillGradient": 0,
+          "hiddenSeries": false,
+          "percentage": false,
+          "points": false,
+          "stack": false,
+          "steppedLine": false,
+          "timeFrom": null,
+          "timeShift": null
+        },
+        {
+          "aliasColors": {},
+          "dashLength": 10,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The rate of gRPC stream Send operations by request type.",
+          "editable": true,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 151
+          },
+          "id": 909,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 300,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "paceLength": 10,
+          "pluginVersion": "7.5.17",
+          "pointradius": 5,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "targets": [
+            {
+              "expr": "sum(rate(pd_server_grpc_stream_send_duration_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance, request)",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-{{request}}",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "gRPC Stream Send Rate",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ops",
+              "label": null,
+              "logBase": 10,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "bars": false,
+          "dashes": false,
+          "decimals": null,
+          "error": false,
+          "fillGradient": 0,
+          "hiddenSeries": false,
+          "percentage": false,
+          "points": false,
+          "stack": false,
+          "steppedLine": false,
+          "timeFrom": null,
+          "timeShift": null
         }
       ],
       "repeat": null,

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -8970,7 +8970,7 @@
           "aliasColors": {},
           "dashLength": 10,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The P99 duration of gRPC stream Send operations by request type.",
+          "description": "The P99 duration of gRPC stream Send operations by request type and target.",
           "editable": true,
           "fieldConfig": {
             "defaults": {},
@@ -9015,10 +9015,10 @@
           "spaceLength": 10,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(pd_server_grpc_stream_send_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[5m])) by (instance, request, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(pd_server_grpc_stream_send_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[5m])) by (instance, request, target, le))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}-{{request}}",
+              "legendFormat": "{{instance}}-{{request}}-{{target}}",
               "refId": "A",
               "step": 4
             }
@@ -9079,7 +9079,7 @@
           "aliasColors": {},
           "dashLength": 10,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "The rate of gRPC stream Send operations by request type.",
+          "description": "The rate of gRPC stream Send operations by request type and target.",
           "editable": true,
           "fieldConfig": {
             "defaults": {},
@@ -9123,9 +9123,9 @@
           "spaceLength": 10,
           "targets": [
             {
-              "expr": "sum(rate(pd_server_grpc_stream_send_duration_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance, request)",
+              "expr": "sum(rate(pd_server_grpc_stream_send_duration_seconds_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance, request, target)",
               "intervalFactor": 2,
-              "legendFormat": "{{instance}}-{{request}}",
+              "legendFormat": "{{instance}}-{{request}}-{{target}}",
               "refId": "A",
               "step": 4
             }

--- a/pkg/utils/grpcutil/stream.go
+++ b/pkg/utils/grpcutil/stream.go
@@ -35,14 +35,14 @@ func NewGRPCStreamSendDuration(namespace, subsystem string) *prometheus.Histogra
 			Name:      "grpc_stream_send_duration_seconds",
 			Help:      "Bucketed histogram of duration (s) of gRPC stream Send operations.",
 			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20), // 0.1ms ~ 52s
-		}, []string{"request", "client_ip"})
+		}, []string{"request", "target"})
 }
 
-// clientIP extracts the client IP (without port) from a gRPC server stream's peer info.
+// targetIP extracts the target IP (without port) from a gRPC server stream's peer info.
 // The port is stripped to avoid high-cardinality Prometheus labels, since ephemeral
 // ports change across reconnections and would create unbounded time series.
 // Returns "unknown" if the peer information is unavailable.
-func clientIP(stream grpc.ServerStream) string {
+func targetIP(stream grpc.ServerStream) string {
 	if stream == nil {
 		return "unknown"
 	}
@@ -72,7 +72,7 @@ type MetricsStream[SendT any, RecvT any] struct {
 }
 
 // NewMetricsStream creates a MetricsStream wrapping the given gRPC server stream.
-// It automatically extracts the client IP from the stream's peer info and combines
+// It automatically extracts the target IP from the stream's peer info and combines
 // it with requestLabel to create the prometheus observer from hist.
 // If hist is nil, no metrics are recorded.
 func NewMetricsStream[SendT any, RecvT any](
@@ -84,7 +84,7 @@ func NewMetricsStream[SendT any, RecvT any](
 ) *MetricsStream[SendT, RecvT] {
 	var obs prometheus.Observer
 	if hist != nil {
-		obs = hist.WithLabelValues(requestLabel, clientIP(stream))
+		obs = hist.WithLabelValues(requestLabel, targetIP(stream))
 	}
 	return &MetricsStream[SendT, RecvT]{
 		ServerStream: stream,

--- a/pkg/utils/grpcutil/stream_test.go
+++ b/pkg/utils/grpcutil/stream_test.go
@@ -126,17 +126,17 @@ func TestMetricsStream(t *testing.T) {
 	})
 }
 
-func TestClientIP(t *testing.T) {
+func TestTargetIP(t *testing.T) {
 	re := require.New(t)
 
 	// nil stream returns "unknown".
-	re.Equal("unknown", clientIP(nil))
+	re.Equal("unknown", targetIP(nil))
 
 	// No peer info in context returns "unknown".
 	s := &fakeServerStream{ctx: context.Background()}
-	re.Equal("unknown", clientIP(s))
+	re.Equal("unknown", targetIP(s))
 
 	// With peer addr, returns IP only (without port).
 	s = newFakeStreamWithPeer()
-	re.Equal("10.0.1.5", clientIP(s))
+	re.Equal("10.0.1.5", targetIP(s))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8281

### What is changed and how does it work?

Add two new Grafana panels to the gRPC section of the PD dashboard (`metrics/grafana/pd.json`):

- **gRPC Stream Send Duration (P99)**: Shows P99 latency of gRPC stream `Send` operations. Uses `histogram_quantile` grouped by `(instance, request, target, le)` for per-node and per-target visibility, matching the convention of panel 902 ("gRPC 99% Completed commands duration").
- **gRPC Stream Send Rate**: Shows the rate of gRPC stream `Send` operations grouped by `(instance, request, target)`.

The two panels are paired on the same row (y=151) following the existing rate(left)/duration(right) layout convention (matching panels 901/902).

Also renames the Prometheus label `client_ip` to `target` across the metric definition, Grafana queries, and tests. The old name was ambiguous — from PD server's perspective, this label represents the Send target (the entity receiving data), not the "client" in the traditional sense.

### Check List

Tests

- Unit tests updated for the label rename (`stream_test.go`)
- Mannual test

<img width="4968" height="1272" alt="image" src="https://github.com/user-attachments/assets/64ef6b5a-2c20-48bf-9f12-b944d0aa26bd" />

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gRPC Stream Send Duration (P99) monitoring panel
  * Added gRPC Stream Send Rate monitoring panel

* **Bug Fixes / Improvements**
  * gRPC stream metrics now label flows by target host (instead of client IP) for clearer attribution and consistency across dashboards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->