### PR TITLE
cluster: fix TiFlash store removal being blocked by TiKV replica check

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1538,7 +1538,7 @@ func (c *RaftCluster) RemoveStore(storeID uint64, physicallyDestroyed bool) erro
 		return errs.ErrStoreDestroyed.FastGenByArgs(storeID)
 	}
 	if (store.IsPreparing() || store.IsServing()) && !physicallyDestroyed {
-		if err := c.checkReplicaBeforeOfflineStore(storeID); err != nil {
+		if err := c.checkTikvReplicaBeforeOfflineStore(storeID); err != nil {
 			return err
 		}
 	}
@@ -1566,7 +1566,7 @@ func (c *RaftCluster) RemoveStore(storeID uint64, physicallyDestroyed bool) erro
 	return nil
 }
 
-func (c *RaftCluster) checkReplicaBeforeOfflineStore(storeID uint64) error {
+func (c *RaftCluster) checkTikvReplicaBeforeOfflineStore(storeID uint64) error {
 	store := c.GetStore(storeID)
 	if store == nil {
 		return errs.ErrStoreNotFound.FastGenByArgs(storeID)
@@ -1579,7 +1579,7 @@ func (c *RaftCluster) checkReplicaBeforeOfflineStore(storeID uint64) error {
 		return nil
 	}
 
-	upStores := c.getUpStores()
+	upStores := c.getUpTikvStores()
 	expectUpStoresNum := len(upStores) - 1
 	if expectUpStoresNum < c.opt.GetMaxReplicas() {
 		return errs.ErrStoresNotEnough.FastGenByArgs(storeID, expectUpStoresNum, c.opt.GetMaxReplicas())
@@ -1613,8 +1613,8 @@ func (c *RaftCluster) checkReplicaBeforeOfflineStore(storeID uint64) error {
 	return nil
 }
 
-// getUpStores gets all up TiKV stores.
-func (c *RaftCluster) getUpStores() []uint64 {
+// getUpTikvStores gets all up TiKV stores.
+func (c *RaftCluster) getUpTikvStores() []uint64 {
 	upStores := make([]uint64, 0)
 	for _, store := range c.GetStores() {
 		if !store.IsTiKV() {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1584,7 +1584,7 @@ func TestStoreConfigUpdate(t *testing.T) {
 	for _, s := range stores {
 		re.NoError(tc.setStore(s))
 	}
-	re.Len(tc.getUpStores(), 5)
+	re.Len(tc.getUpTikvStores(), 5)
 	// Case1: big region.
 	{
 		body := `{ "coprocessor": {
@@ -1701,7 +1701,7 @@ func TestStoreConfigSync(t *testing.T) {
 	for _, s := range stores {
 		re.NoError(tc.setStore(s))
 	}
-	re.Len(tc.getUpStores(), 5)
+	re.Len(tc.getUpTikvStores(), 5)
 
 	re.Equal(uint64(144), tc.GetStoreConfig().GetRegionMaxSize())
 	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/mockFetchStoreConfigFromTiKV", `return("10MiB")`))
@@ -4107,7 +4107,7 @@ func TestConcurrentStoreStats(t *testing.T) {
 	// If we check store state first, the store state will be changed to state serving and then removing.
 	wg := sync.WaitGroup{}
 	for i := range storeCount {
-		if len(cluster.getUpStores()) == int(replica) {
+		if len(cluster.getUpTikvStores()) == int(replica) {
 			// it means we can't remove store anymore
 			break
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10350

### What is changed and how does it work?

```commit-message
When attempting to remove a TiFlash store, PD incorrectly applied
TiKV replica count validation, causing removal failures with
"ErrStoresNotEnough" even when TiKV stores were sufficient.

Root cause:
- checkReplicaBeforeOfflineStore() used getUpStores() which only
  returns TiKV stores
- The function assumed ANY store deletion reduces TiKV count by 1
- This is incorrect for non-TiKV stores which don't affect Raft replicas

Fix:
- Add store type check at the beginning of checkReplicaBeforeOfflineStore()
- Skip TiKV replica validation for non-TiKV stores using !store.IsTiKV()
- Only TiKV stores participate in Raft voting; non-TiKV stores (TiFlash, etc.)
  use learners and can be removed without affecting Raft replica count
```

### Check List

Tests

- Unit test (TestRemoveTiFlashStore)

Code changes

- Modified server/cluster/cluster.go to add non-TiKV store check in checkReplicaBeforeOfflineStore()

Side effects

- No

Related changes

- No

### Release note

```release-note
Fix TiFlash store removal being incorrectly blocked by TiKV replica check
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added null-checks for store references to prevent errors during offline operations.
  * Replica validation now applies only to TiKV stores; other store types can bypass TiKV-specific replica checks during removal.

* **Tests**
  * Added test coverage validating removal of TiFlash stores while ensuring TiKV replication requirements and proper state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->