### PR TITLE
tests: avoid startup wait hang in RunServers

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -653,18 +654,31 @@ func RunServer(server *TestServer) <-chan error {
 	return resC
 }
 
+// waitServerRunResults waits for startup results from all servers and returns once any error is observed.
+func waitServerRunResults(results []<-chan error) error {
+	cases := make([]reflect.SelectCase, len(results))
+	for i, ch := range results {
+		cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)}
+	}
+
+	for range results {
+		chosen, recv, _ := reflect.Select(cases)
+		if err, _ := recv.Interface().(error); err != nil {
+			return errors.WithStack(err)
+		}
+		// Disable the consumed channel because each RunServer only sends once.
+		cases[chosen].Chan = reflect.ValueOf((<-chan error)(nil))
+	}
+	return nil
+}
+
 // RunServers starts to run multiple TestServer.
 func RunServers(servers []*TestServer) error {
 	res := make([]<-chan error, len(servers))
 	for i, s := range servers {
 		res[i] = RunServer(s)
 	}
-	for _, c := range res {
-		if err := <-c; err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	return nil
+	return waitServerRunResults(res)
 }
 
 // RunInitialServers starts to run servers in InitialServers.

--- a/tests/cluster_runservers_test.go
+++ b/tests/cluster_runservers_test.go
@@ -1,0 +1,32 @@
+package tests
+
+import (
+	stderrors "errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitServerRunResultsReturnsFastOnAnyError(t *testing.T) {
+	re := require.New(t)
+	blocked := make(chan error)
+	fail := make(chan error, 1)
+	fail <- stderrors.New("boom")
+
+	start := time.Now()
+	err := waitServerRunResults([]<-chan error{blocked, fail})
+	re.Error(err)
+	re.ErrorContains(err, "boom")
+	re.Less(time.Since(start), 200*time.Millisecond)
+}
+
+func TestWaitServerRunResultsAllSuccess(t *testing.T) {
+	re := require.New(t)
+	c1 := make(chan error, 1)
+	c2 := make(chan error, 1)
+	c1 <- nil
+	c2 <- nil
+
+	re.NoError(waitServerRunResults([]<-chan error{c1, c2}))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10347

`TestNotLeader` is flaky with a 5m timeout in `tests/server/cluster`.

Root-cause evidence chain:
- Issue: https://github.com/tikv/pd/issues/10347
- CI log: https://storage.googleapis.com/prow-tidb-logs/pr-logs/pull/tikv_pd/10246/pull-unit-test-next-gen-2/2031989614872367104/build-log.txt
- Timeout stack is in startup path, not RPC assertion:
  - `tests/server/cluster/cluster_test.go:841` (`tc.RunInitialServers()`)
  - `tests/cluster.go:687` (`runInitialServersWithRetry`)
  - `tests/cluster.go:663` (`RunServers` waiting receive)
  - `tests/cluster.go:652` (`RunServer.func1` blocked send)
- In this failure mode, one server startup result can be ready early (often an error), but `RunServers` consumed channels in fixed order and can block on another startup forever, delaying retries and causing the global test timeout.

### What is changed and how does it work?

Historical analog:
- https://github.com/tikv/pd/pull/10203
- Relevance: same class of flaky stabilization around test harness startup/readiness sequencing and avoiding brittle blocking paths in CI.

Fix strategy (minimal):
- Add `waitServerRunResults` in `tests/cluster.go` to wait on startup result channels with `reflect.Select` (first-ready semantics), instead of fixed-order receive.
- Keep `RunServer` behavior unchanged; only change collection semantics in `RunServers` so startup errors are observed promptly.
- Add regression tests in `tests/cluster_runservers_test.go`:
  - `TestWaitServerRunResultsReturnsFastOnAnyError`
  - `TestWaitServerRunResultsAllSuccess`

Risk:
- Low. The change is limited to test harness startup result collection and does not affect production code paths.

### Check List

Tests

- Unit test

### Verification commands + results

- `make gotest GOTEST_ARGS='-tags without_dashboard ./tests -run TestWaitServerRunResults -count=1 -v'`: PASS
- `make gotest GOTEST_ARGS='-tags without_dashboard ./tests/server/cluster -run TestNotLeader -count=1 -v'`: PASS
- `make basic-test`: FAIL (unrelated pre-existing failures in this run)
  - `pkg/gctuner`: goleak found goroutine in `memory_limit_tuner.go`
  - `pkg/storage/endpoint`: `TestDataPhysicalRepresentation` assertion mismatch on gc state revision path

### Release note

```release-note
None.
```
