### PR TITLE
tests: retry canceled etcd startup

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -88,7 +88,15 @@ const (
 	startServersRetryRecreate
 )
 
-func classifyStartServersError(err error) startServersRetryAction {
+func shouldRetryCurrentServers(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "ErrCancelStartEtcd") || strings.Contains(errMsg, "ErrStartEtcd")
+}
+
+func classifyInitialServersError(err error) startServersRetryAction {
 	if err == nil {
 		return startServersNoRetry
 	}
@@ -96,7 +104,7 @@ func classifyStartServersError(err error) startServersRetryAction {
 	switch {
 	case strings.Contains(errMsg, "address already in use") || strings.Contains(errMsg, "Etcd cluster ID mismatch"):
 		return startServersRetryRecreate
-	case strings.Contains(errMsg, "ErrCancelStartEtcd") || strings.Contains(errMsg, "ErrStartEtcd"):
+	case shouldRetryCurrentServers(err):
 		return startServersRetryCurrent
 	default:
 		return startServersNoRetry
@@ -712,7 +720,7 @@ func (c *TestCluster) runInitialServersWithRetry(maxRetries int) error {
 			return nil
 		}
 
-		switch classifyStartServersError(lastErr) {
+		switch classifyInitialServersError(lastErr) {
 		case startServersRetryRecreate:
 			// `Etcd cluster ID mismatch` can happen when the allocated peer URL happens to
 			// connect to another test's etcd cluster (port reuse across concurrent `go test`
@@ -786,7 +794,7 @@ func RunServersWithRetry(servers []*TestServer, maxRetries int) error {
 			return nil
 		}
 
-		if classifyStartServersError(lastErr) == startServersRetryCurrent {
+		if shouldRetryCurrentServers(lastErr) {
 			log.Warn("etcd start failed, will retry", zap.Error(lastErr))
 			// Stop any partially started servers before retrying
 			for _, s := range servers {

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -29,14 +29,28 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
 }
 
-func TestClassifyStartServersError(t *testing.T) {
+func TestShouldRetryCurrentServers(t *testing.T) {
 	t.Parallel()
 
 	re := require.New(t)
-	re.Equal(startServersRetryCurrent, classifyStartServersError(errors.New("[PD:server:ErrCancelStartEtcd]etcd start canceled")))
-	re.Equal(startServersRetryCurrent, classifyStartServersError(errors.New("[PD:server:ErrStartEtcd]start etcd failed")))
-	re.Equal(startServersRetryRecreate, classifyStartServersError(errors.New("listen tcp 127.0.0.1:2379: bind: address already in use")))
-	re.Equal(startServersRetryRecreate, classifyStartServersError(errors.New("Etcd cluster ID mismatch")))
-	re.Equal(startServersNoRetry, classifyStartServersError(errors.New("some other error")))
-	re.Equal(startServersNoRetry, classifyStartServersError(nil))
+	re.True(shouldRetryCurrentServers(errors.New("[PD:server:ErrCancelStartEtcd]etcd start canceled")))
+	re.True(shouldRetryCurrentServers(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed")))
+	re.True(shouldRetryCurrentServers(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed: listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.False(shouldRetryCurrentServers(errors.New("listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.False(shouldRetryCurrentServers(errors.New("Etcd cluster ID mismatch")))
+	re.False(shouldRetryCurrentServers(errors.New("some other error")))
+	re.False(shouldRetryCurrentServers(nil))
+}
+
+func TestClassifyInitialServersError(t *testing.T) {
+	t.Parallel()
+
+	re := require.New(t)
+	re.Equal(startServersRetryCurrent, classifyInitialServersError(errors.New("[PD:server:ErrCancelStartEtcd]etcd start canceled")))
+	re.Equal(startServersRetryCurrent, classifyInitialServersError(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed")))
+	re.Equal(startServersRetryRecreate, classifyInitialServersError(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed: listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.Equal(startServersRetryRecreate, classifyInitialServersError(errors.New("listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.Equal(startServersRetryRecreate, classifyInitialServersError(errors.New("Etcd cluster ID mismatch")))
+	re.Equal(startServersNoRetry, classifyInitialServersError(errors.New("some other error")))
+	re.Equal(startServersNoRetry, classifyInitialServersError(nil))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10331

### What is changed and how does it work?

`TestTSOFollowerProxy` flakes when a follower etcd start gets canceled during cluster bootstrap. The CI log for #10331 shows `pd2` / `pd3` exiting during startup, followed by repeated connection-refused probes and a final `[PD:server:ErrCancelStartEtcd]etcd start canceled` from `tests/integrations/client/client_test.go`.

This PR restores the retry behavior that `RunInitialServers()` used to have for canceled etcd startup:

- factor startup error handling into `classifyStartServersError`
- retry the current server set for both `ErrCancelStartEtcd` and `ErrStartEtcd`
- keep recreating the server set only for port-conflict-style errors
- add a regression unit test for the classification logic

This also realigns `RunInitialServers()` with `RunServersWithRetry()`, which still treated canceled etcd startup as retryable.

```commit-message
tests: retry canceled etcd startup
```

### Check List

Tests

- Unit test
- Integration test

Code changes

Side effects

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smarter retry classification for etcd startup/stop to decide when to retry, recreate, or stop, improving handling of port conflicts, cluster ID mismatches, and cancellation scenarios.

* **Tests**
  * Added tests validating error classification and retry behavior, plus test harness improvements to detect goroutine leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->