### PR TITLE
tests: stabilize TestRegionCheck offline-peer

### DIFF
--- a/tests/server/api/region_test.go
+++ b/tests/server/api/region_test.go
@@ -435,6 +435,11 @@ func (suite *regionTestSuite) checkRegionCheck(cluster *tests.TestCluster) {
 
 	// ref https://github.com/tikv/pd/issues/3558, we should change size to pass `NeedUpdate` for observing.
 	r = r.Clone(core.SetApproximateKeys(0))
+	// Keep the removing store observable long enough for the offline-peer API.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/doNotBuryStore", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/doNotBuryStore"))
+	}()
 	s := &metapb.Store{
 		Id:        2,
 		State:     metapb.StoreState_Offline,
@@ -442,6 +447,17 @@ func (suite *regionTestSuite) checkRegionCheck(cluster *tests.TestCluster) {
 	}
 	tests.MustPutStore(re, cluster, s)
 	tests.MustPutRegionInfo(re, cluster, r)
+	testutil.Eventually(re, func() bool {
+		store := leader.GetRaftCluster().GetStore(s.GetId())
+		if store == nil || store.GetState() != metapb.StoreState_Offline || store.GetNodeState() != metapb.NodeState_Removing {
+			return false
+		}
+		if sche := cluster.GetSchedulingPrimaryServer(); sche != nil {
+			store = sche.GetCluster().GetStore(s.GetId())
+			return store != nil && store.GetState() == metapb.StoreState_Offline && store.GetNodeState() == metapb.NodeState_Removing
+		}
+		return true
+	})
 	url = fmt.Sprintf("%s/regions/check/%s", urlPrefix, "offline-peer")
 	r8 := &response.RegionsInfo{}
 	testutil.Eventually(re, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9968

`TestRegionTestSuite/TestRegionCheck` was reopened after #10279 because the
microservice run still times out in the final `offline-peer` assertion.

The new CI failure for #9968 points at the current `offline-peer` retry loop:

- issue comment / prow log: `tests/server/api/region_test.go:447`
- symptom: `Condition never satisfied`
- job: `pull-unit-test-next-gen-2`

The same CI log also shows the test fixture drifting before the assertion can
observe the region:

- `start test TestRegionCheck in microservice environment`
- immediately after the test offlines store 2, PD logs
  `store has been Tombstone` for that store
- once the store is auto-buried, `OfflinePeer` no longer remains observable for
  `/pd/api/v1/regions/check/offline-peer`

That matches nearby stable tests in the repo:

- `tests/server/api/store_test.go` enables
  `github.com/tikv/pd/server/cluster/doNotBuryStore`
- `tests/integrations/mcs/scheduling/api_test.go` does the same when asserting
  offline-store visibility

So the remaining flake is not a new product bug; it is the test letting the
background store checker tombstone the removing store before the API assertion.

### What is changed and how does it work?

- enable `doNotBuryStore` only for the `offline-peer` portion of
  `TestRegionCheck`
- wait until store 2 is still `Offline` + `Removing` in both the PD leader
  cluster and the scheduling cluster before querying the API

This keeps the fixture aligned with the existing offline-store API tests and
stabilizes the final `offline-peer` assertion without changing production code.

Risk

- test-only change in `tests/server/api/region_test.go`
- scoped to one assertion path and one existing failpoint
- no user-facing behavior change

Historical analog

- #10203 `test: fix flaky test TestForwardTestSuite in next-gen`
- #10134 `tests: fix some unstable tests`

Both are test-harness alignment fixes that remove non-deterministic background
state changes instead of modifying production behavior.

Does this PR introduce _any_ user-facing change?

No.

### Check List

Tests

- `make gotest GOTEST_ARGS='-tags=without_dashboard ./tests/server/api -run TestRegionTestSuite/TestRegionCheck -count=1 -v'`
  - passed
- `make gotest GOTEST_ARGS='-tags=without_dashboard ./tests/server/api -run TestRegionTestSuite/TestRegionCheck -count=5'`
  - passed (`ok github.com/tikv/pd/tests/server/api 118.034s`)
- `make basic-test`
  - not clean in this worktree due unrelated baseline failures outside touched
    scope:
  - `pkg/gctuner`: goleak on `memoryLimitTuner.tuning.func1`
  - `pkg/storage/endpoint`: `TestDataPhysicalRepresentation` path mismatch
  - `pkg/utils/grpcutil`: `TestToServerTLSConfig` certificate generation killed

### Release note

```release-note
None.
```
