### PR TITLE
server/cluster: avoid shutdown deadlock in RaftCluster.Stop

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -543,7 +543,7 @@ func (c *RaftCluster) startTSOJobsIfNeeded() error {
 }
 
 func (c *RaftCluster) stopTSOJobsIfNeeded() {
-	if !c.tsoAllocator.IsInitialize() {
+	if c.tsoAllocator == nil || !c.tsoAllocator.IsInitialize() {
 		return
 	}
 	log.Info("closing the TSO allocator")
@@ -902,6 +902,15 @@ func (c *RaftCluster) runReplicationMode() {
 
 // Stop stops the cluster.
 func (c *RaftCluster) Stop() {
+	var (
+		cancel             context.CancelFunc
+		stopSchedulingJobs bool
+		heartbeatRunner    ratelimit.Runner
+		miscRunner         ratelimit.Runner
+		logRunner          ratelimit.Runner
+		syncRegionRunner   ratelimit.Runner
+	)
+
 	c.Lock()
 	// We need to try to stop tso jobs whatever the cluster is running or not.
 	// Because we need to call checkTSOService as soon as possible while the cluster is starting,
@@ -915,15 +924,32 @@ func (c *RaftCluster) Stop() {
 		return
 	}
 	c.running = false
-	c.cancel()
-	if !c.IsServiceIndependent(constant.SchedulingServiceName) {
+	cancel = c.cancel
+	stopSchedulingJobs = !c.IsServiceIndependent(constant.SchedulingServiceName)
+	heartbeatRunner = c.heartbeatRunner
+	miscRunner = c.miscRunner
+	logRunner = c.logRunner
+	syncRegionRunner = c.syncRegionRunner
+	c.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if stopSchedulingJobs {
 		c.stopSchedulingJobs()
 	}
-	c.heartbeatRunner.Stop()
-	c.miscRunner.Stop()
-	c.logRunner.Stop()
-	c.syncRegionRunner.Stop()
-	c.Unlock()
+	if heartbeatRunner != nil {
+		heartbeatRunner.Stop()
+	}
+	if miscRunner != nil {
+		miscRunner.Stop()
+	}
+	if logRunner != nil {
+		logRunner.Stop()
+	}
+	if syncRegionRunner != nil {
+		syncRegionRunner.Stop()
+	}
 
 	c.wg.Wait()
 	log.Info("raft cluster is stopped")

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -4295,7 +4295,6 @@ func TestStopDoesNotHoldClusterLockWhileWaitingSchedulingJobs(t *testing.T) {
 	cluster.running = true
 
 	cluster.coordinator = schedule.NewCoordinator(cluster.ctx, cluster, nil)
-	cluster.schedulingController.coordinator = cluster.coordinator
 	cluster.schedulingController.running = true
 
 	blockedOnClusterLock := make(chan struct{})
@@ -4303,8 +4302,8 @@ func TestStopDoesNotHoldClusterLockWhileWaitingSchedulingJobs(t *testing.T) {
 	go func() {
 		defer cluster.schedulingController.wg.Done()
 		<-cluster.schedulingController.ctx.Done()
-		close(blockedOnClusterLock)
 		cluster.RLock()
+		close(blockedOnClusterLock)
 		cluster.RUnlock()
 	}()
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tikv/pd/pkg/mock/mockhbstream"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/progress"
+	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/checker"
 	sc "github.com/tikv/pd/pkg/schedule/config"
@@ -4275,6 +4276,55 @@ func waitNoResponse(re *require.Assertions, stream mockhbstream.HeartbeatStream)
 		res := stream.Recv()
 		return res == nil
 	})
+}
+
+func TestStopDoesNotHoldClusterLockWhileWaitingSchedulingJobs(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.heartbeatRunner = ratelimit.NewSyncRunner()
+	cluster.miscRunner = ratelimit.NewSyncRunner()
+	cluster.logRunner = ratelimit.NewSyncRunner()
+	cluster.syncRegionRunner = ratelimit.NewSyncRunner()
+	cluster.tsoAllocator = nil
+	cluster.running = true
+
+	cluster.coordinator = schedule.NewCoordinator(cluster.ctx, cluster, nil)
+	cluster.schedulingController.coordinator = cluster.coordinator
+	cluster.schedulingController.running = true
+
+	blockedOnClusterLock := make(chan struct{})
+	cluster.schedulingController.wg.Add(1)
+	go func() {
+		defer cluster.schedulingController.wg.Done()
+		<-cluster.schedulingController.ctx.Done()
+		close(blockedOnClusterLock)
+		cluster.RLock()
+		cluster.RUnlock()
+	}()
+
+	stopped := make(chan struct{})
+	go func() {
+		cluster.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-blockedOnClusterLock:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for scheduling job shutdown")
+	}
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("raft cluster stop blocked on scheduling jobs while holding cluster lock")
+	}
 }
 
 func BenchmarkHandleStatsAsync(b *testing.B) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9800.

### What is changed and how does it work?

- snapshot the shutdown callbacks and runners while holding the cluster lock, then release the lock before canceling scheduling jobs and stopping runners
- keep `Stop()` from blocking scheduling job shutdown paths that still need the cluster lock during teardown
- guard `stopTSOJobsIfNeeded()` for nil `tsoAllocator` in minimal test setups
- add `TestStopDoesNotHoldClusterLockWhileWaitingSchedulingJobs` as a deterministic regression test

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster shutdown behavior to prevent lock contention during termination. The shutdown process now releases locks before waiting for dependent services to complete, reducing potential deadlock scenarios.
  * Added null safety checks during initialization to prevent unexpected errors.

* **Tests**
  * Added test coverage for shutdown lock behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->