### PR TITLE
tso: avoid blocking reads during split finish

### DIFF
--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -388,6 +388,8 @@ type KeyspaceGroupManager struct {
 
 	// mergeCheckerCancelMap is the cancel function map for the merge checker of each keyspace group.
 	mergeCheckerCancelMap sync.Map // GroupID -> context.CancelFunc
+	// finishSplitInFlight tracks split targets that already have an in-flight finish request.
+	finishSplitInFlight sync.Map // GroupID -> struct{}
 
 	primaryPriorityCheckInterval time.Duration
 
@@ -1350,20 +1352,28 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 	return nil, errs.ErrURLParse.FastGenByArgs("no valid backend endpoint configured")
 }
 
-// Put the code below into the critical section to prevent from sending too many HTTP requests.
 func (kgm *KeyspaceGroupManager) finishSplitKeyspaceGroup(id uint32) error {
 	start := time.Now()
 	kgm.Lock()
-	defer kgm.Unlock()
 	// Check if the keyspace group is in split state.
 	splitGroup := kgm.kgs[id]
-	if !splitGroup.IsSplitTarget() {
+	if splitGroup == nil || !splitGroup.IsSplitTarget() {
+		kgm.Unlock()
 		return nil
 	}
 	// Check if the HTTP client is initialized.
 	if kgm.httpClient == nil {
+		kgm.Unlock()
 		return nil
 	}
+	// Avoid sending duplicate finish requests while the current one is still in flight.
+	if _, loaded := kgm.finishSplitInFlight.LoadOrStore(id, struct{}{}); loaded {
+		kgm.Unlock()
+		return nil
+	}
+	kgm.Unlock()
+	defer kgm.finishSplitInFlight.Delete(id)
+
 	startRequest := time.Now()
 	resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI(fmt.Sprintf("/%d/split", id))
 	if err != nil {
@@ -1377,10 +1387,17 @@ func (kgm *KeyspaceGroupManager) finishSplitKeyspaceGroup(id uint32) error {
 		return errs.ErrSendRequest.FastGenByArgs()
 	}
 	kgm.metrics.finishSplitSendDuration.Observe(time.Since(startRequest).Seconds())
+
+	kgm.Lock()
+	defer kgm.Unlock()
 	// Pre-update the split keyspace group's split state in memory.
 	// Note: to avoid data race with state read APIs, we always replace the group in memory as a whole.
 	// For now, we only have scenarios to update split state/merge state, and the other fields are always
 	// loaded from etcd without any modification, so we can simply copy the group and replace the state.
+	splitGroup = kgm.kgs[id]
+	if splitGroup == nil || !splitGroup.IsSplitTarget() {
+		return nil
+	}
 	newSplitGroup := *splitGroup
 	newSplitGroup.SplitState = nil
 	kgm.kgs[id] = &newSplitGroup

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1051,6 +1053,96 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSplitUpdateRetry() {
 		assignedGroupIDs := collectAssignedKeyspaceGroupIDs(re, mgr)
 		return reflect.DeepEqual(expectedGroupIDs, assignedGroupIDs)
 	})
+}
+
+func (suite *keyspaceGroupManagerTestSuite) TestFinishSplitKeyspaceGroupDoesNotBlockReads() {
+	re := suite.Require()
+
+	const (
+		groupID    = uint32(1)
+		keyspaceID = uint32(111)
+	)
+
+	var requestCount atomic.Int32
+	requestStarted := make(chan struct{}, 1)
+	releaseRequest := make(chan struct{})
+	var releaseOnce sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		re.Equal(http.MethodDelete, r.Method)
+		re.Equal(fmt.Sprintf("%s/%d/split", keyspaceGroupsAPIPrefix, groupID), r.URL.Path)
+		requestCount.Add(1)
+		select {
+		case requestStarted <- struct{}{}:
+		default:
+		}
+		<-releaseRequest
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	defer releaseOnce.Do(func() {
+		close(releaseRequest)
+	})
+
+	cfg := suite.createConfig()
+	cfg.BackendEndpoints = srv.URL
+	kgm := &KeyspaceGroupManager{
+		state:      state{keyspaceLookupTable: make(map[uint32]uint32)},
+		httpClient: srv.Client(),
+		cfg:        cfg,
+		metrics:    newKeyspaceGroupMetrics(),
+	}
+	kgm.kgs[groupID] = &endpoint.KeyspaceGroup{
+		ID:                  groupID,
+		Keyspaces:           []uint32{keyspaceID},
+		KeyspaceLookupTable: map[uint32]struct{}{keyspaceID: {}},
+		SplitState:          &endpoint.SplitState{SplitSource: constant.DefaultKeyspaceGroupID},
+	}
+	kgm.allocators[groupID] = &Allocator{}
+	kgm.keyspaceLookupTable[keyspaceID] = groupID
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- kgm.finishSplitKeyspaceGroup(groupID)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		suite.T().Fatal("split completion request did not start")
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, _, currentGroupID, _, err := kgm.FindGroupByKeyspaceID(keyspaceID)
+		if err == nil && currentGroupID != groupID {
+			err = fmt.Errorf("unexpected keyspace group id %d", currentGroupID)
+		}
+		readDone <- err
+	}()
+
+	go func() {
+		errCh <- kgm.finishSplitKeyspaceGroup(groupID)
+	}()
+
+	select {
+	case err := <-readDone:
+		re.NoError(err)
+	case <-time.After(time.Second):
+		suite.T().Fatal("FindGroupByKeyspaceID blocked during split completion")
+	}
+
+	re.Equal(int32(1), requestCount.Load())
+
+	releaseOnce.Do(func() {
+		close(releaseRequest)
+	})
+
+	re.NoError(<-errCh)
+	re.NoError(<-errCh)
+
+	re.NotNil(kgm.kgs[groupID])
+	re.Nil(kgm.kgs[groupID].SplitState)
 }
 
 // TestPrimaryPriorityChange tests the case that the primary priority of a keyspace group changes


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9842

`TestTSOKeyspaceGroupManagerSuite/TestTSOKeyspaceGroupSplitElection` flakes because
`finishSplitKeyspaceGroup` holds the keyspace-group manager lock while sending the
backend `DELETE /pd/api/v2/tso/keyspace-groups/<id>/split` request.

The latest issue comment for #9842 shows the resulting wait chain:

- the split patroller enters `pkg/tso/keyspace_group_manager.go:1238` and keeps
  `kgm.Lock()` while `apiutil.DoDelete` is blocked
- the test is simultaneously waiting in
  `tests/tso_cluster.go:173 -> IsKeyspaceServingByGroup -> FindGroupByKeyspaceID`
- that read path needs `state.RLock()`, so it cannot proceed until the HTTP
  request returns

With `pauseFinishSplitBeforeTxn` enabled in the test, the HTTP request can pause
long enough for `WaitForPrimaryServing` to time out even though the split logic
itself is still healthy.

### What is changed and how does it work?

- move the blocking HTTP delete out of the manager critical section in
  `finishSplitKeyspaceGroup`
- keep a per-group in-flight marker so concurrent split-completion paths still
  send at most one backend finish request
- add a deterministic unit test that blocks the backend `/split` request and
  proves `FindGroupByKeyspaceID` can still make progress while the request is
  in flight

This preserves the original split-finish behavior, but removes the circular wait
between split completion and read-side keyspace lookup.

Risk

- scoped to split-finish coordination in `pkg/tso/keyspace_group_manager.go`
- test coverage added for the exact blocked-request scenario
- no API or config surface change

Historical analog

- #6723 `Fix data race between read APIs and finshiSplit/finishMerge in keyspace group manager`
- #10203 `test: fix flaky test TestForwardTestSuite in next-gen`

### Check List

Tests

- `make gotest GOTEST_ARGS='./pkg/tso -run TestKeyspaceGroupManagerTestSuite/TestFinishSplitKeyspaceGroupDoesNotBlockReads -count=1 -v -vet=off'`
  - passed
- `cd tests/integrations && make gotest GOTEST_ARGS='-tags=without_dashboard ./mcs/tso -run TestTSOKeyspaceGroupManagerSuite/TestTSOKeyspaceGroupSplitElection -count=10 -failfast'`
  - passed (`ok github.com/tikv/pd/tests/integrations/mcs/tso 60.286s`)
- `make basic-test`
  - not clean in this worktree due pre-existing baseline failures outside the
    touched scope:
  - `pkg/gctuner`: goleak in `memoryLimitTuner.tuning.func1`
  - `pkg/storage/endpoint`: `TestDataPhysicalRepresentation` expects `/pd/0/...`
    but gets a cluster-scoped path

### Release note

```release-note
None.
```
