### PR TITLE
resource_group: fix equalRU to also compare TikvRUV2 and TidbRUV2 fields

### DIFF
--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -311,7 +311,10 @@ func sub(custom1 *rmpb.Consumption, custom2 *rmpb.Consumption) {
 }
 
 func equalRU(custom1 rmpb.Consumption, custom2 rmpb.Consumption) bool {
-	return custom1.RRU == custom2.RRU && custom1.WRU == custom2.WRU
+	return custom1.RRU == custom2.RRU &&
+		custom1.WRU == custom2.WRU &&
+		custom1.TikvRUV2 == custom2.TikvRUV2 &&
+		custom1.TidbRUV2 == custom2.TidbRUV2
 }
 
 // getSQLProcessCPUTime returns the cumulative user+system time (in ms) since the process start.

--- a/client/resource_group/controller/model_test.go
+++ b/client/resource_group/controller/model_test.go
@@ -129,3 +129,20 @@ func TestUpdateDeltaConsumption(t *testing.T) {
 	re.Equal(now.TikvRUV2, last.TikvRUV2)
 	re.Equal(now.TidbRUV2, last.TidbRUV2)
 }
+
+func TestEqualRU(t *testing.T) {
+	re := require.New(t)
+
+	re.True(equalRU(
+		rmpb.Consumption{RRU: 1, WRU: 2, TikvRUV2: 3, TidbRUV2: 4},
+		rmpb.Consumption{RRU: 1, WRU: 2, TikvRUV2: 3, TidbRUV2: 4},
+	))
+	re.False(equalRU(
+		rmpb.Consumption{RRU: 1, WRU: 2, TikvRUV2: 3, TidbRUV2: 4},
+		rmpb.Consumption{RRU: 1, WRU: 2, TikvRUV2: 5, TidbRUV2: 4},
+	))
+	re.False(equalRU(
+		rmpb.Consumption{RRU: 1, WRU: 2, TikvRUV2: 3, TidbRUV2: 4},
+		rmpb.Consumption{RRU: 1, WRU: 2, TikvRUV2: 3, TidbRUV2: 6},
+	))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10318

The `equalRU` function only compared `RRU` and `WRU` fields but missed `TikvRUV2` and `TidbRUV2`, which are already handled in `add`, `sub`, and `updateDeltaConsumption`. This could lead to incorrect equality checks when RUv2 values differ.

### What is changed and how does it work?

```commit-message
Fix equalRU to compare TikvRUV2 and TidbRUV2 fields in addition to
RRU and WRU, making it consistent with add/sub/updateDeltaConsumption.
Add TestEqualRU covering equal and unequal cases.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource consumption comparison logic to validate all relevant attributes, improving accuracy of consumption tracking.

* **Tests**
  * Added test coverage for resource consumption equality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->