### PR TITLE
tests: stabilize TestPreparingProgress

### DIFF
--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -1257,15 +1257,35 @@ func TestPreparingProgress(t *testing.T) {
 		return leader.GetRaftCluster().GetTotalRegionCount() == core.InitClusterRegionThreshold
 	})
 
-	ch := make(chan struct{})
-	defer close(ch)
+	checkStoresRelease := make(chan struct{})
+	checkStoresBlocked := make(chan struct{}, 1)
+	defer close(checkStoresRelease)
 	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/blockCheckStores", func() {
-		<-ch
+		select {
+		case checkStoresBlocked <- struct{}{}:
+		default:
+		}
+		<-checkStoresRelease
 	}))
 	defer func() {
 		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/blockCheckStores"))
 	}()
-	triggerCheckStores := func() { ch <- struct{}{} }
+	waitCheckStoresBlocked := func() {
+		testutil.Eventually(re, func() bool {
+			select {
+			case <-checkStoresBlocked:
+				return true
+			default:
+				return false
+			}
+		})
+	}
+	releaseCheckStores := func() {
+		checkStoresRelease <- struct{}{}
+		waitCheckStoresBlocked()
+	}
+
+	waitCheckStoresBlocked()
 
 	// to avoid forcing the store to the `serving` state with too few regions
 	for _, store := range stores[2:] {
@@ -1300,7 +1320,7 @@ func TestPreparingProgress(t *testing.T) {
 
 	var p api.Progress
 	testutil.Eventually(re, func() bool {
-		defer triggerCheckStores()
+		defer releaseCheckStores()
 		if len(cluster.GetLeader()) == 0 {
 			return false
 		}
@@ -1339,7 +1359,7 @@ func TestPreparingProgress(t *testing.T) {
 	tests.MustPutRegion(re, cluster, 1001, 5, []byte(fmt.Sprintf("%20d", 1001)), []byte(fmt.Sprintf("%20d", 1002)), core.SetApproximateSize(40))
 
 	testutil.Eventually(re, func() bool {
-		defer triggerCheckStores()
+		defer releaseCheckStores()
 		output := sendRequest(re, leader.GetAddr()+"/pd/api/v1/stores/progress?action=preparing", http.MethodGet, http.StatusOK)
 		re.NoError(json.Unmarshal(output, &p))
 		t.Logf("progress: %v", p)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9511

`TestPreparingProgress` is still timing-sensitive. The test enables
`blockCheckStores`, but it did not wait until the background `checkStores`
loop had actually reached the failpoint. That leaves a race where a pending
node-state-check tick can run after stores 4/5 are inserted and create the
preparing progress before the test enters its `404 not found` assertions.
That matches the flaky signatures on the issue: intermittent
`Condition never satisfied` and `expected: 404, actual: 200`.

### What is changed and how does it work?

The test now synchronizes with the `blockCheckStores` failpoint explicitly:

- signal when a `checkStores` iteration is blocked
- wait for the first blocked iteration before inserting preparing stores
- release one blocked iteration at a time for the later progress assertions

This keeps the original intent of asserting the pre-progress `404` window, but
removes the race on whether `blockCheckStores` has actually taken effect.

Historical analog:

- `#9465` first stabilized this test family by blocking `checkStores` to hold
  the intermediate state open
- `#10167` later removed a separate leader-election race in the same test

This patch addresses the remaining gap between those fixes: the test now waits
for the block to be active before it relies on the intermediate state.

Verification:

- red on the strengthened harness before the final fix:
  - `GOCACHE=/tmp/pd-gocache GOTMPDIR=/tmp/pd-gotmp make gotest GOTEST_ARGS='-tags=without_dashboard ./tests/server/api -run TestPreparingProgress -count=1 -v'`
  - failed with `Condition never satisfied` once the test intentionally released a blocked `checkStores` cycle before the `404` assertions
- focused verification after the fix:
  - `bash -c 'set -euo pipefail; export GOCACHE=/tmp/pd-gocache; export GOTMPDIR=/tmp/pd-gotmp; FAILPOINT_CTL="$PWD/.tools/bin/failpoint-ctl"; trap '"'"'"$FAILPOINT_CTL" disable ./server/cluster >/dev/null 2>&1 || true'"'"' EXIT; "$FAILPOINT_CTL" disable ./server/cluster >/dev/null 2>&1 || true; "$FAILPOINT_CTL" enable ./server/cluster >/dev/null; go test -tags=without_dashboard ./tests/server/api -run TestPreparingProgress -count=20 -v'`
  - PASS (`ok github.com/tikv/pd/tests/server/api 94.702s`)
- basic-test scope baseline:
  - `bash -c 'set -euo pipefail; export GOCACHE=/tmp/pd-gocache; export GOTMPDIR=/tmp/pd-gotmp; FAILPOINT_CTL="$PWD/.tools/bin/failpoint-ctl"; PKGS=$(make -n basic-test | sed -n '"'"'"'"'"'"'"'"'s/^go test //p'"'"'"'"'"'"'"'"' | sed '"'"'"'"'"'"'"'"'s/ || {.*$//'"'"'"'"'"'"'"'"'); trap '"'"'"'"'"'"'"'"'find "$PWD/pkg" "$PWD/server" -type d | xargs "$FAILPOINT_CTL" disable >/dev/null 2>&1 || true'"'"'"'"'"'"'"'"' EXIT; find "$PWD/pkg" "$PWD/server" -type d | xargs "$FAILPOINT_CTL" disable >/dev/null 2>&1 || true; find "$PWD/pkg" "$PWD/server" -type d | xargs "$FAILPOINT_CTL" enable >/dev/null; go test $PKGS'`
  - FAIL in unrelated baseline packages:
    - `github.com/tikv/pd/pkg/gctuner`: goleak in `memoryLimitTuner.tuning.func1`
    - `github.com/tikv/pd/pkg/storage/endpoint`: `TestDataPhysicalRepresentation` expected `/pd/0/...`, got `/pd/<cluster-id>/...`
  - touched scope still passed:
    - `github.com/tikv/pd/server/api`
    - `github.com/tikv/pd/server/cluster`

Risk:

- low, test-only change
- no production behavior change

### Check List


### Release note

```release-note
None.
```
