### PR TITLE
tests: stabilize TestRemovingProgress

### DIFF
--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -896,19 +896,41 @@ func TestRemovingProgress(t *testing.T) {
 		return true
 	})
 
+	ch := make(chan struct{})
+	defer close(ch)
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/blockCheckStores", func() {
+		<-ch
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/blockCheckStores"))
+	}()
+	triggerCheckStores := func() { ch <- struct{}{} }
+
 	// remove store 1 and store 2
 	sendRequest(re, leader.GetAddr()+"/pd/api/v1/store/1", http.MethodDelete, http.StatusOK)
 	sendRequest(re, leader.GetAddr()+"/pd/api/v1/store/2", http.MethodDelete, http.StatusOK)
 
-	time.Sleep(100 * time.Millisecond) // wait for the removing progress to be created
-	// size is not changed.
-	output = sendRequest(re, leader.GetAddr()+"/pd/api/v1/stores/progress?action=removing", http.MethodGet, http.StatusOK)
 	var p api.Progress
-	re.NoError(json.Unmarshal(output, &p))
-	re.Equal("removing", p.Action)
-	re.Equal(0.0, p.Progress)
-	re.Equal(0.0, p.CurrentSpeed)
-	re.Equal(math.MaxFloat64, p.LeftSeconds)
+	testutil.Eventually(re, func() bool {
+		defer triggerCheckStores()
+		url := leader.GetAddr() + "/pd/api/v1/stores/progress?action=removing"
+		req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+		re.NoError(err)
+		resp, err := tests.TestDialClient.Do(req)
+		re.NoError(err)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return false
+		}
+		output, err := io.ReadAll(resp.Body)
+		re.NoError(err)
+		re.NoError(json.Unmarshal(output, &p))
+		re.Equal("removing", p.Action)
+		re.Equal(0.0, p.Progress)
+		re.Equal(0.0, p.CurrentSpeed)
+		re.Equal(math.MaxFloat64, p.LeftSeconds)
+		return true
+	})
 
 	// update size
 	tests.MustPutRegion(re, cluster, 1000, 1, []byte("a"), []byte("b"), core.SetApproximateSize(20))
@@ -916,6 +938,7 @@ func TestRemovingProgress(t *testing.T) {
 
 	if !leader.GetRaftCluster().IsPrepared() {
 		testutil.Eventually(re, func() bool {
+			defer triggerCheckStores()
 			if leader.GetRaftCluster().IsPrepared() {
 				return true
 			}
@@ -928,6 +951,8 @@ func TestRemovingProgress(t *testing.T) {
 			if resp.StatusCode != http.StatusOK {
 				return false
 			}
+			output, err := io.ReadAll(resp.Body)
+			re.NoError(err)
 			// is not prepared
 			re.NoError(json.Unmarshal(output, &p))
 			re.Equal("removing", p.Action)
@@ -939,6 +964,7 @@ func TestRemovingProgress(t *testing.T) {
 	}
 
 	testutil.Eventually(re, func() bool {
+		defer triggerCheckStores()
 		// wait for cluster prepare
 		if leader.GetRaftCluster() == nil {
 			return false


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8992

### What is changed and how does it work?

`TestRemovingProgress` still relied on `time.Sleep(100 * time.Millisecond)` to wait for
the asynchronous `checkStores` job to create removing progress. That makes the test race
the scheduler tick and occasionally hit the same `Condition never satisfied` failure
reported in #8992.

Root-cause evidence:

- #8992 reports `Condition never satisfied` from `TestRemovingProgress`.
- The historical fix in #9465 added the `blockCheckStores` failpoint and explicit
  synchronization to `TestPreparingProgress`, but left `TestRemovingProgress` on a fixed
  sleep.
- A controlled red run with `blockCheckStores` enabled and no release reproduced the
  same failure shape locally:
  `go test -tags without_dashboard ./tests/server/api -run TestRemovingProgress -count=1 -v`
  failed with `Condition never satisfied`.

This patch removes the fixed sleep and makes `TestRemovingProgress` use the existing
`blockCheckStores` failpoint to advance `checkStores` deterministically, matching the
stable pattern already used by `TestPreparingProgress`.

Historical analog:

- #9465 `*: fix flaky test TestPreparingProgress and TestRemovingProgress`
- Playbook pattern 5/8: flaky stabilization via explicit readiness and test harness alignment

Risk:

- Low. This is test-only and narrows timing assumptions instead of changing production logic.

Verification

Focused red:

- `make failpoint-enable && GOCACHE=/tmp/pd-gocache CGO_ENABLED=1 go test -tags without_dashboard ./tests/server/api -run TestRemovingProgress -count=1 -v`
  with `blockCheckStores` enabled but not released: failed with `Condition never satisfied`

Focused green:

- `GOCACHE=/tmp/pd-gocache CGO_ENABLED=1 go test -tags without_dashboard ./tests/server/api -run TestRemovingProgress -count=20 -v`
  passed
- `GOCACHE=/tmp/pd-gocache CGO_ENABLED=1 go test -tags without_dashboard ./tests/server/api -run 'TestRemovingProgress|TestPreparingProgress' -count=1 -v`
  passed

Baseline:

- `GOCACHE=/tmp/pd-gocache make basic-test`
  still fails in unrelated existing packages:
  - `github.com/tikv/pd/pkg/gctuner` (`goleak` in `memory_limit_tuner.go`)
  - `github.com/tikv/pd/pkg/storage/endpoint` (`TestDataPhysicalRepresentation`)

### Check List


### Release note

```release-note
None.
```
