### PR TITLE
docs: trim PD-specific AGENTS guidance

### DIFF
--- a/.agents/skills/add-metrics/SKILL.md
+++ b/.agents/skills/add-metrics/SKILL.md
@@ -3,6 +3,45 @@ name: add-metrics
 description: "Add or change Prometheus metrics — cache WithLabelValues, hot path, cleanup, avoid high cardinality, naming, MustRegister, backward compatibility. From tikv/pd metrics PRs."
 ---
 
+# Add Metrics
+
+## Responsibility
+
+Add or change Prometheus instrumentation in `tikv/pd` without regressing hot
+paths, exploding label cardinality, or silently breaking dashboards and alerts.
+
+## Inputs
+
+- target package, file, or code path to instrument
+- metric definition: namespace, subsystem, name, help text, type, unit, and
+  labels
+- lifecycle context: where the entity is created, updated, and removed
+- rollout context: existing metrics, dashboards, alerts, or compatibility
+  constraints that must remain stable
+
+## Outputs
+
+- a patch that updates metric definitions, registration, record sites, cleanup
+  sites, and related tests or docs when needed
+- a short implementation note covering label choices, hot-path tradeoffs, and
+  backward-compatibility or migration impact
+- if the requested metric is unsafe, a concrete alternative such as a lower
+  cardinality design or background aggregation
+
+## Constraints
+
+- cache `WithLabelValues(...)` results instead of recomputing them in hot paths
+- avoid per-request or per-event metric creation on hot paths; prefer background
+  aggregation when feasible
+- keep label cardinality bounded and add cleanup via `DeleteLabelValues(...)`
+  when entities disappear
+- do not rename, remove, or change the type of an existing metric without an
+  explicit migration or rollout plan
+- use `prometheus.MustRegister(...)` and keep dashboards, alerts, and docs
+  aligned with the final metric semantics
+- if a metric is expensive, noisy, or experimental, prefer an existing toggle or
+  rollout gate instead of unconditional always-on instrumentation
+
 ## Principles (checklist + detail)
 
 Before adding or changing metrics, ensure:
@@ -32,3 +71,15 @@ Before adding or changing metrics, ensure:
 12. **Fix wrong metrics and document semantics** — If a metric measures the wrong thing (e.g. “processing time” including network), fix the measurement or add a new metric/version; do not silently change semantics.
 
 13. **Instrument full lifecycle** — For gRPC streams or long-lived resources, add metrics for the full lifecycle and reflect cleanup/end so dashboards don’t show stuck or misleading series.
+
+## Usage Examples
+
+- Add a counter or histogram in a scheduler or API path, but cache
+  `WithLabelValues(...)` during init and only record the fast-path value in the
+  request handler.
+- Add a gauge vector for long-lived resources such as streams, stores, or
+  groups, and pair creation with `DeleteLabelValues(...)` on teardown so old
+  series disappear.
+- Replace or supplement an incorrect metric by introducing a new metric with the
+  right semantics while keeping the old metric stable until dashboards and
+  alerts have migrated.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -4,9 +4,50 @@ description: Push the current branch and create a pull request on tikv/pd follow
 compatibility: Requires gh CLI authenticated with tikv/pd repo access. Must have local commits on a non-master branch.
 ---
 
-# Persona & Goal
+# Create PR
 
-PD contributor assistant. Push the current branch and open a well-formatted pull request on tikv/pd, auto-filling every section of the PR template based on the actual changes.
+## Responsibility
+
+Push the current branch and open a pull request on `tikv/pd` that matches the
+repository template and review expectations.
+
+## Inputs
+
+- current branch name, base branch, and committed diff to be submitted
+- issue references and whether they should be `Close` or `ref`
+- `.github/pull_request_template.md` plus
+  `references/pr-template.md` for the exact PR structure
+- optional head repository or remote details when the PR comes from a fork
+
+## Outputs
+
+- a validated PR title and body draft shown to the user before submission
+- a pushed branch with upstream tracking information
+- a created PR URL, or a blocking error if push/auth/template validation fails
+
+## Implementation Details
+
+- Validation commands are `git status`, `git branch --show-current`,
+  `git log --oneline master..HEAD`, `git diff master...HEAD --stat`, and
+  `git diff master...HEAD`.
+- PR content must be rendered from `.github/pull_request_template.md` and
+  `references/pr-template.md`, not improvised from memory.
+- Push with `git push -u origin <branch-name>` unless the user specifies a
+  different remote or head repo.
+- Create the PR with `gh pr create --repo tikv/pd ... --body-file -` so the
+  template formatting survives.
+- Do not bypass local hooks with `--no-verify`; if a push hook or auth check
+  blocks the operation, surface the error instead of silently skipping it.
+
+## Constraints
+
+- Never force-push without user confirmation.
+- Always show the PR content before submitting. User approval is required.
+- Use `gh` for GitHub operations. Do not guess API URLs.
+- Follow PD commit conventions when deriving the PR title.
+- Ask for the issue number when it is unknown.
+- Do not invent issue references.
+- Do not modify code or rewrite commits as part of this skill.
 
 # Reference Files
 
@@ -61,12 +102,3 @@ If the push or PR creation fails:
 - **Push rejected**: Check if the remote branch exists; suggest force-push only if user confirms.
 - **PR already exists**: Show the existing PR URL; offer to update it instead.
 - **Auth failure**: Remind user to authenticate with `gh auth login`.
-
-# Agent Constraints
-
-- **Never force-push without user confirmation.**
-- **Always show the PR content before submitting.** User must approve title and body.
-- **Use `gh` CLI for GitHub operations.** Do not guess API URLs.
-- **Follow PD commit conventions.** `pkg: message` format for title.
-- **Do not modify code.** This skill only pushes and creates PRs.
-- **Ask for issue number if unknown.** Do not invent issue references.

--- a/.agents/skills/fix-cherry-pick-pr/SKILL.md
+++ b/.agents/skills/fix-cherry-pick-pr/SKILL.md
@@ -10,6 +10,33 @@ description: Repair cherry-pick pull requests in tikv/pd when automated cherry-p
 Repair and verify cherry-pick PRs in `tikv/pd`.
 Compare the source PR and the cherry-pick PR first, then fix the cherry-pick branch without losing release-branch-only code.
 
+## Inputs
+
+- source PR number, or a cherry-pick PR that points back to the source PR
+- cherry-pick PR number, head branch, and the remote that owns that branch
+- touched files or packages that need parity and targeted verification
+- release branch context that may contain branch-only APIs, helpers, or tests
+
+## Outputs
+
+- a repaired cherry-pick branch or PR with committed conflict markers removed
+- a semantic parity report against the source PR, including any intentional
+  release-branch-only differences
+- targeted verification commands and results, especially for failpoint-sensitive
+  code paths
+
+## Implementation Details
+
+- Preserve release-branch-only behavior by comparing the final aggregate patch,
+  not raw commit count or GitHub mergeability state.
+- When conflict markers land beside release-only APIs or helpers, keep the
+  release-branch code and insert the source PR behavior in the correct final
+  location instead of deleting branch-only code.
+- Validate failpoint-sensitive diffs with the repo's explicit failpoint flow:
+  `make failpoint-enable`, targeted `go test`, then `make failpoint-disable`.
+- Core commands in this workflow are `gh pr view`, `gh pr diff`, `diff -u`,
+  `rg -n '<<<<<<<|=======|>>>>>>>'`, `git diff`, `git status`, and `git push`.
+
 ## 1. Identify the PR pair
 
 - Inspect the cherry-pick PR with `gh pr view <pr> --repo tikv/pd --json number,title,body,baseRefName,headRefName,headRepositoryOwner,url,commits`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,5 +71,18 @@
 
 ## Repo-Specific Skills
 - Reusable agent workflows live in `.agents/skills/`.
-- `fix-cherry-pick-pr`: repairs PD cherry-pick PRs while preserving release-branch-only behavior and validating failpoint-sensitive diffs.
-- `create-pr`: pushes the current branch and opens a PR that matches the PD template.
+- [`add-metrics`](.agents/skills/add-metrics/SKILL.md): adds or changes PD
+  Prometheus instrumentation. Inputs: target package or file plus metric name,
+  type, labels, and rollout context. Outputs: metric patch and migration notes.
+  Constraints: cache `WithLabelValues`, avoid hot-path instrumentation, control
+  cardinality, and keep existing metrics backward compatible.
+- [`fix-cherry-pick-pr`](.agents/skills/fix-cherry-pick-pr/SKILL.md): repairs
+  release-branch cherry-pick PRs. Inputs: source PR, cherry-pick PR or branch,
+  and touched files or tests. Outputs: repaired branch plus parity and
+  verification report. Constraints: preserve release-branch-only behavior,
+  compare final aggregate diffs, and follow PD failpoint discipline.
+- [`create-pr`](.agents/skills/create-pr/SKILL.md): pushes the current branch
+  and opens a PR that matches the PD template. Inputs: current branch,
+  committed diff, issue refs, and template context. Outputs: reviewed title and
+  body draft, pushed branch, and PR URL. Constraints: show the draft before
+  submission, use `gh`, and never force-push without approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,16 +20,24 @@
 - `client/` fast tests: `make basic-test`
 - `client/` full tests: `make test`
 
-## Failpoints
-- PD uses `github.com/pingcap/failpoint` for test-only branches, returns, and pauses in specific code paths.
-- Safest path is to use `make gotest`, `make test`, or `make basic-test`, which manage failpoints for you.
-- If a package under test imports `github.com/pingcap/failpoint` and you run raw `go test`, bracket it with `make failpoint-enable` and `make failpoint-disable`.
-- Runtime model: `failpoint.Enable` and `failpoint.Disable` only change runtime evaluation state; a failpoint takes effect only when execution reaches the injected site again; enabling one does not replay startup or initialization logic that already finished.
-- If failpoint semantics are unclear, inspect the injected code path and nearby tests first. Useful lookup: `rg -n "failpoint.Inject|failpoint.InjectCall|failpoint.Enable" pkg tests server`.
-- If tests need controllable fault injection, compare `failpoint` and `mock` before choosing; prefer the simpler option.
-- Do not edit code, build binaries, or commit while failpoints are enabled.
-- If failpoint state is unclear or behavior looks polluted, reset with `make failpoint-disable` or `make clean-test` before continuing.
-- Never commit generated failpoint artifacts.
+## Failpoints Discipline
+- PD uses `github.com/pingcap/failpoint` to inject test-only branches, returns, and pauses into specific code paths.
+- Keep failpoints enabled only for tests; disable immediately after (`make failpoint-disable` or `make clean-test`) to avoid polluting the codebase.
+- Prefer make targets that auto-enable/disable failpoints (recommended: `make gotest ...`, `make test`, `make basic-test`).
+- If you must run `go test` manually, use this rule:
+  - Target uses failpoints (for example imports `github.com/pingcap/failpoint`): `make failpoint-enable` -> `go test ...` -> `make failpoint-disable`.
+  - Target does not use failpoints: run `go test ...` directly.
+- Runtime model:
+  - `failpoint.Enable` / `failpoint.Disable` only change runtime evaluation state.
+  - A failpoint takes effect only when execution reaches the injected site again.
+  - Enabling a failpoint does not replay startup or initialization logic that has already finished.
+- If failpoint semantics are unclear, inspect the injected code path and nearby tests before changing test flow or assertions.
+- Useful lookup pattern: `rg -n "failpoint.Inject|failpoint.InjectCall|failpoint.Enable" pkg tests server`.
+- If that is still not enough, read the upstream `README.md` in `github.com/pingcap/failpoint` before changing the test design.
+- When tests need controllable fault injection, compare `failpoint` and `mock` first; prefer the simpler and more maintainable option instead of defaulting to `mock`.
+- Never edit code or run non-test commands while failpoints are enabled. If unsure about state, run `make failpoint-disable` before continuing.
+- Never commit generated failpoint files or leave failpoints enabled; verify `git status` is clean before pushing.
+- If failpoint-related tests misbehave, rerun after `make failpoint-disable && make failpoint-enable` to ensure a clean state.
 
 ## Generated Or Derived Files
 - `make check` includes `make generate-errdoc`; error-code changes may require updating `errors.toml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,173 +1,63 @@
 # PD Agent Guide
 
-- Scope: Governs the entire repository. If another `AGENTS.md` exists deeper, it overrides in its subtree.
-- Cursor rules: none in `.cursor/rules/` or `.cursorrules`.
-- Copilot rules: see `.github/copilot-instructions.md`.
-- Purpose: Give human and agent contributors a concise, reliable playbook.
+- Scope: applies to the whole repository unless a deeper `AGENTS.md` overrides it.
+- Repo shape: root Go module plus the `client/` submodule.
+- Go baseline: keep the local toolchain aligned with the version declared in the relevant `go.mod`.
+- Main binaries: `pd-server`, `pd-ctl`, `pd-recover`.
 
-## Quick Facts
-- Language: Go modules (root + `client/` submodule).
-- Go version: CI uses 1.25 (install >=1.25).
-- Main binaries: `pd-server`, `pd-ctl`, `pd-recover`, tool suite.
+## Start Here
+- Prefer repo `make` targets over ad-hoc commands; they wire tags, failpoints, generators, and dashboard assets correctly.
+- Check for a deeper `AGENTS.md` before editing a subtree.
 
-## Build Shortcuts
-- Default all: `make build` (pd-server, pd-ctl, pd-recover).
-- Full dev loop: `make dev` (build + check + tools + test).
-- Lightweight: `make dev-basic` (build + check + basic-test).
-- No dashboard: `make pd-server-basic` (sets `SWAGGER=0 DASHBOARD=0`).
-- With swagger spec: `SWAGGER=1 make build` (runs `swagger-spec`).
-- With custom dashboard distro: set `DASHBOARD_DISTRIBUTION_DIR` then `make build`.
-- Specific tool: `make pd-ctl`, `make pd-tso-bench`, etc.
-- Race build: `WITH_RACE=1 make build` (CGO on, `-race`).
-- FIPS/boringcrypto: `ENABLE_FIPS=1 make build`.
-- Simulator: `make simulator`.
-- Docker image: `make docker-image` (needs Docker daemon).
+## Common Entry Points
+- Root build: `make build`
+- Root full loop: `make dev`
+- Root lightweight loop: `make dev-basic`
+- Root validation: `make check`
+- Root fast tests: `make basic-test`
+- Root targeted tests: `make gotest GOTEST_ARGS='./pkg/foo -run TestBar -count=1'`
+- `client/` default pipeline: run `make` inside `client/`
+- `client/` fast tests: `make basic-test`
+- `client/` full tests: `make test`
 
-## Client Module (client/)
-- Default pipeline: from `client/`, run `make` (static + tidy + test).
-- Tests with race/tags: `make test` (deadlock tag, race, cover; auto failpoints).
-- Fast tests: `make basic-test`.
-- CI coverage: `make ci-test-job`.
-- Lint/static: `make static` (gofmt, golangci-lint, leakcheck).
+## Failpoints
+- Many PD test paths rely on failpoints. Safest path is to use `make gotest`, `make test`, or `make basic-test`, which manage them for you.
+- If a package under test imports `github.com/pingcap/failpoint` and you run raw `go test`, bracket it with `make failpoint-enable` and `make failpoint-disable`.
+- Do not edit code, build binaries, or commit while failpoints are enabled.
+- If failpoint state is unclear or behavior looks polluted, reset with `make failpoint-disable` or `make clean-test` before continuing.
+- Never commit generated failpoint artifacts.
 
-## Lint & Static Analysis
-- Primary entry: `make check` (tidy + static + generate-errdoc).
-- Static combo: `make static` runs gofmt -s, golangci-lint, leakcheck (PACKAGE_DIRECTORIES/SUBMODULES respected).
-- Tidy: `make tidy` must leave `go.mod`/`go.sum` clean (CI enforces empty diff).
-- Error docs: `make generate-errdoc` (updates `errors.toml`).
-- golangci-lint config: see `.golangci.yml` (gofmt/goimports/gci formatters; depguard bans `github.com/pkg/errors`, `go.uber.org/atomic`, `math/rand`; prefers `math/rand/v2`; goheader copyright; revive + testifylint extensive; waitgroup-by-value forbidden).
-- leakcheck excludes `tests/server/join/join_test.go`.
-- Formatter order (gci): standard, default, `prefix(github.com/pingcap)`, `prefix(github.com/tikv/pd)`, blank.
+## Generated Or Derived Files
+- `make check` includes `make generate-errdoc`; error-code changes may require updating `errors.toml`.
+- Swagger output is not part of a normal build unless `SWAGGER=1`; use `SWAGGER=1 make build` or `make swagger-spec` when API annotations change.
+- Easyjson generation is explicit: `make generate-easyjson` updates `pkg/response/region.go`.
+- Dashboard assets are embedded; use `make dashboard-ui` when touching UI assets.
+- For faster local server builds, skip dashboard with `DASHBOARD=0` or `make pd-server-basic`.
+- Custom dashboard distributions use `DASHBOARD_DISTRIBUTION_DIR`; distro info replacement uses `make dashboard-replace-distro-info`.
+- Pinned tooling is installed into `.tools/bin` via `make install-tools`.
+- `make tidy` must leave `go.mod` and `go.sum` clean.
 
-## Test Matrix
-- Full suite: `make test` (tags deadlock, CGO=1, race, cover; auto failpoints).
-- Basic fast: `make basic-test` (no tests/ packages, no race; failpoints enabled).
-- Targeted (single pkg/test): `make gotest GOTEST_ARGS='./pkg/foo -run TestBar -count=1'` (auto failpoints).
-- UT binary: `make ut` -> `./bin/pd-ut run --ignore tests --race --junitfile ./junitfile`.
-- CI shard: `make ci-test-job JOB_INDEX=N` (needs dashboard-ui + pd-ut built).
-- TSO function: `make test-tso-function` (tags `without_dashboard,deadlock`, race on).
-- Real cluster: `make test-real-cluster` (uses `tests/integrations/realcluster`; wipes `~/.tiup/data/pd_real_cluster_test`).
-- Coverage split: `make test-with-cover-parallel` after `make split`.
-- Clean test artifacts: `make clean-test` (clears `/tmp/pd_tests*`, go test cache, UT bins, playground log).
+## Lint And CI Traps
+- `.golangci.yml` is intentionally strict; check it before fighting the linter.
+- Non-obvious depguard bans: `github.com/pkg/errors`, `go.uber.org/atomic`, and `math/rand` in favor of `math/rand/v2`.
+- Import order is enforced as: stdlib, third-party, `github.com/pingcap`, `github.com/tikv/pd`, blank.
+- `make static` and `make check` respect repo-specific package selectors and validations; prefer them to handcrafted lint commands.
 
-## Failpoints Discipline
-- Keep failpoints enabled only for tests; disable immediately after (`make failpoint-disable` or `make clean-test`) to avoid polluting the codebase.
-- Prefer make targets that auto-enable/disable failpoints (recommended: `make gotest ...`, `make test`, `make basic-test`).
-- If you must run `go test` manually, use this rule:
-  - Target uses failpoints (for example imports `github.com/pingcap/failpoint`): `make failpoint-enable` -> `go test ...` -> `make failpoint-disable`.
-  - Target does not use failpoints: run `go test ...` directly.
-- Never edit code or run non-test commands while failpoints are enabled. If unsure about state, run `make failpoint-disable` before continuing.
-- Never commit generated failpoint files or leave failpoints enabled; verify `git status` is clean before pushing.
-- If failpoint-related tests misbehave, rerun after `make failpoint-disable && make failpoint-enable` to ensure a clean state.
+## Special Test Modes
+- `make test` is the full deadlock/race/cover path.
+- `make test-tso-function` uses the `without_dashboard,deadlock` tags.
+- `make ci-test-job JOB_INDEX=N` mirrors CI sharding.
+- `make ut` runs the `pd-ut` harness instead of plain `go test`.
+- `make test-real-cluster` uses `tests/integrations/realcluster` and wipes `~/.tiup/data/pd_real_cluster_test`.
+- `NEXT_GEN=1` enables the `nextgen` tag and disables dashboard-related paths.
 
-## Imports & Formatting
-- Use gci/goimports ordering: stdlib | third-party | pingcap | tikv/pd | blank.
-- Avoid dot-imports; revive rule will warn.
-- Keep imports deduped; run gofmt/goimports/gci.
-- gofmt rewrite rule: `interface{}` -> `any` (see `make fmt`).
-- Run `make fmt` or gofmt on touched files; respect project ordering.
+## Contribution Conventions
+- PRs follow `.github/pull_request_template.md` and should include `Issue Number: close|ref #...`.
+- Commit subject format is `pkg: message`, max 70 chars; use `*:` for broad changes.
+- Use `git commit -s`.
+- Before opening a PR, run `make check` and the narrowest relevant test target. In most cases, that means at least `make basic-test` or `make gotest ...`.
 
-## Code Style Essentials
-- Prefer concrete types; keep structs zero-value friendly; init maps/slices before use.
-- Pointers for large structs; avoid pointer-to-interface and copying mutex holders.
-- Typed constants with iota for enums; keep error codes in `errors.toml` (regenerate via `make generate-errdoc`).
-- First param `context.Context` for external effects; never store contexts in structs.
-- Acronyms uppercase (TSO, API, HTTP); package dirs lower_snake; filenames kebab/underscore ok.
-- Exported identifiers need GoDoc starting with the name; avoid stutter (`pd.PDServer` -> `Server`).
-
-## Error Handling
-- Wrap with `github.com/pingcap/errors` (`errors.Wrap`/`Annotate`) or `fmt.Errorf("...: %w", err)`.
-- No ignored errors unless allowed in `.golangci.yml` errcheck exclusions.
-- Error strings: lowercase, no trailing punctuation.
-- Prefer sentinel errors over panic; panic only on programmer bugs/impossible states.
-- HTTP handlers: use errcode + `errorResp`; avoid `http.Error`.
-
-## Logging
-- Use existing structured logging (zap/log); avoid `fmt.Println`.
-- Include useful fields (component, store id, region id); never log secrets/PII.
-
-## Concurrency
-- Cancel timers/tickers; close resources with defer and error checks.
-- `sync.WaitGroup` must be a pointer (revive rule).
-- Prevent goroutine leaks: pair with cancellation; consider errgroup.
-- Guard shared state with mutex/RWMutex; keep lock ordering consistent.
-
-## Collections & Ranges
-- Do not capture loop vars by pointer; copy inside loop (`v := val`).
-- Range-in-closure/address rules enforced; make local copies.
-- Preallocate slices/maps when size known.
-
-## API / JSON / Docs
-- Swagger: `make swagger-spec` (SWAGGER=1) regenerates; keep annotations current.
-- Easyjson: `make generate-easyjson` updates `pkg/response/region.go`.
-- JSON tags explicit; use `omitempty` where sensible.
-- Update docs when API/build/test flows change.
-
-## Metrics & Telemetry
-- Prometheus-style metrics; name with subsystem + unit; avoid high-cardinality labels.
-- `metrics/` package has helpers; add tests for new metrics when feasible.
-
-## Performance
-- Mind allocations; reuse buffers/pools where appropriate.
-- Avoid per-request reflection; keep hot paths lean.
-- Use context-aware timeouts and backoff for retries.
-
-## Security
-- Never commit secrets/keys/tokens.
-- Use `crypto/rand` for security needs; avoid insecure randomness.
-- Do not disable lint/security checks without discussion.
-
-## Dependencies & Tools
-- Tools live in `.tools/bin`; `make install-tools` installs pinned versions (golangci-lint v2.6.0, etc.).
-- `tools.go` pins tool deps; avoid adding runtime deps without justification; run `make tidy` after changes and ensure clean diff.
-
-## Dashboard / UI
-- Assets embedded via `scripts/embed-dashboard-ui.sh`; run through `make dashboard-ui` dependency.
-- Skip dashboard for speed with `DASHBOARD=0` or `make pd-server-basic`.
-- Custom distro info: set `DASHBOARD_DISTRIBUTION_DIR` then `make dashboard-replace-distro-info`.
-
-## Repository Hygiene
-- Run `make tidy` after dep changes; `go.mod`/`go.sum` must stay clean.
-- Run `make fmt`/gofmt; ensure gci/goimports ordering.
-- Clean with `make clean` (removes failpoints, tmp tests, bin, `.tools/bin`).
-- Avoid committing generated artifacts (junitfile, coverage, dashboard caches) unless required.
-
-## PRs & Commits
-- Follow `.github/pull_request_template.md`; include `Issue Number: close|ref #...` line.
-- Commit subject: `pkg: message`, <=70 chars; blank line; body wrapped 80 chars; add `Signed-off-by` via `git commit -s`.
-- Multi-area: separate packages with commas; use `*:` for broad changes.
-
-## Agent Skills
-
-Reusable agent skills live under `.agents/skills/`. Each skill has a `SKILL.md` describing its workflow and constraints.
-
-| Skill | Purpose | Prerequisites | Docs |
-|---|---|---|---|
-| `fix-cherry-pick-pr` | Repair cherry-pick PRs by comparing source and cherry-pick diffs, resolving committed conflict markers, preserving release-branch-only code, and running failpoint-aware verification. | `gh` CLI authenticated with tikv/pd repo access; git remotes for the source repo and cherry-pick branch; PD test environment able to run failpoint-aware verification. | [`.agents/skills/fix-cherry-pick-pr/SKILL.md`](.agents/skills/fix-cherry-pick-pr/SKILL.md) |
-| `create-pr` | Push the current branch and open a well-formatted PR on tikv/pd. Analyzes commits, generates PR title/body following the repository template, and submits via `gh pr create`. | `gh` CLI authenticated with tikv/pd repo access; local commits on a non-master branch. | [`.agents/skills/create-pr/SKILL.md`](.agents/skills/create-pr/SKILL.md) |
-
-## Microservices / NextGen
-- `NEXT_GEN=1` builds/tests use `nextgen` tag and disable dashboard; ensure compatibility.
-- Resource group/keyspace features live under `server/` resource dirs—follow existing patterns.
-
-## Failure Handling
-- Return errors up-stack; use `errors.Is/As` for sentinel checks.
-- Ensure cleanups on all exits; prefer named cleanups with defer.
-
-## Interacting with External Systems
-- gRPC services use interceptors; add auth/validation in handlers, not transport.
-- HTTP handlers validate payloads and return proper status codes; avoid panics.
-
-## Missing Context?
-- Mirror patterns in existing tests for expected behavior.
-- Use `git blame`/`git log` to follow conventions; avoid history rewrites.
-
-## Final Checklist
-- Read this file; look for deeper `AGENTS.md` before editing.
-- Before PR: run `make check` and the narrowest relevant `go test` (with tags). At minimum run `make basic-test` for touched packages.
-- Keep imports ordered, gofmt clean, modules tidy.
-- Respect depguard bans, revive/testifylint findings; fix before submission.
-- Ensure `PD_EDITION` set correctly; enable failpoints where required.
-- Keep error handling consistent with `pingcap/errors` and errcode usage.
-- Avoid new global state; keep concurrency safe; close resources.
-- Leave workspace clean (no stray tmp, coverage, or generated dashboard files).
+## Repo-Specific Skills
+- Reusable agent workflows live in `.agents/skills/`.
+- `fix-cherry-pick-pr`: repairs PD cherry-pick PRs while preserving release-branch-only behavior and validating failpoint-sensitive diffs.
+- `create-pr`: pushes the current branch and opens a PR that matches the PD template.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10206, ref #10226

### What is changed and how does it work?

```commit-message
Trim the root AGENTS guide so it keeps only PD-specific workflows and
non-obvious repository conventions.

Remove generic engineering advice that large models already know, and
keep the document focused on repo-specific make targets, failpoint
handling, generated artifacts, lint traps, special test modes, and
contribution conventions.

Replace the fixed Go version note with guidance to follow the version
declared in the relevant go.mod.
```

### Check List

Tests

- No code

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the long, section-by-section repository playbook with a concise, high-level agent guide emphasizing "Start Here" and common entry points.
  * Added a dedicated "Add Metrics" guidance section covering safe instrumentation practices, lifecycle/caching constraints, label cardinality, and usage examples.
  * Clarified the "Create PR" workflow with explicit responsibilities, inputs/outputs, validation steps, and a rule to surface errors instead of bypassing hooks.
  * Expanded the "Fix cherry-pick PR" guidance with inputs/outputs, implementation details, parity verification, and failpoint validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->