### PR TITLE
resourcemanager: reject invalid RU groups

### DIFF
--- a/pkg/mcs/resourcemanager/server/keyspace_manager.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager.go
@@ -122,6 +122,12 @@ func validateResourceGroupProto(grouppb *rmpb.ResourceGroup) error {
 	if grouppb.GetPriority() > maxPriority {
 		return errs.ErrInvalidGroup.FastGenByArgs("the group priority")
 	}
+	if grouppb.GetMode() == rmpb.GroupMode_RUMode {
+		ruSettings := grouppb.GetRUSettings()
+		if ruSettings == nil || ruSettings.GetRU() == nil || ruSettings.GetRU().GetSettings() == nil {
+			return errs.ErrInvalidGroup.FastGenByArgs("the RU settings")
+		}
+	}
 	return nil
 }
 

--- a/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
+++ b/pkg/mcs/resourcemanager/server/keyspace_manager_test.go
@@ -120,21 +120,30 @@ func TestAddResourceGroup(t *testing.T) {
 	}
 	err = krgm.addResourceGroup(group)
 	re.Error(err)
-
-	// Test adding a valid resource group.
-	group = &rmpb.ResourceGroup{
-		Name:     "test_group",
-		Mode:     rmpb.GroupMode_RUMode,
-		Priority: 5,
-		RUSettings: &rmpb.GroupRequestUnitSettings{
-			RU: &rmpb.TokenBucket{
-				Settings: &rmpb.TokenLimitSettings{
-					FillRate:   100,
-					BurstLimit: 200,
-				},
+	for _, group = range []*rmpb.ResourceGroup{
+		{
+			Name: "missing_ru_settings",
+			Mode: rmpb.GroupMode_RUMode,
+		},
+		{
+			Name:       "missing_token_bucket",
+			Mode:       rmpb.GroupMode_RUMode,
+			RUSettings: &rmpb.GroupRequestUnitSettings{},
+		},
+		{
+			Name: "missing_token_settings",
+			Mode: rmpb.GroupMode_RUMode,
+			RUSettings: &rmpb.GroupRequestUnitSettings{
+				RU: &rmpb.TokenBucket{},
 			},
 		},
+	} {
+		err = krgm.addResourceGroup(group)
+		re.Error(err)
 	}
+
+	// Test adding a valid resource group.
+	group = newTestResourceGroup("test_group", 5, 100, 200)
 	err = krgm.addResourceGroup(group)
 	re.NoError(err)
 
@@ -157,19 +166,7 @@ func TestModifyResourceGroup(t *testing.T) {
 	krgm := newKeyspaceResourceGroupManager(1, storage.NewStorageWithMemoryBackend())
 
 	// Add a resource group first.
-	group := &rmpb.ResourceGroup{
-		Name:     "test_group",
-		Mode:     rmpb.GroupMode_RUMode,
-		Priority: 5,
-		RUSettings: &rmpb.GroupRequestUnitSettings{
-			RU: &rmpb.TokenBucket{
-				Settings: &rmpb.TokenLimitSettings{
-					FillRate:   100,
-					BurstLimit: 200,
-				},
-			},
-		},
-	}
+	group := newTestResourceGroup("test_group", 5, 100, 200)
 	err := krgm.addResourceGroup(group)
 	re.NoError(err)
 
@@ -343,11 +340,7 @@ func TestGetResourceGroupList(t *testing.T) {
 	// Add some resource groups.
 	for i := 1; i <= 3; i++ {
 		name := "group" + string(rune('0'+i))
-		group := &rmpb.ResourceGroup{
-			Name:     name,
-			Mode:     rmpb.GroupMode_RUMode,
-			Priority: uint32(i),
-		}
+		group := newTestResourceGroup(name, uint32(i), 100, 200)
 		err := krgm.addResourceGroup(group)
 		re.NoError(err)
 	}
@@ -726,21 +719,9 @@ func TestGetPriorityQueues(t *testing.T) {
 
 	// Add some resource groups with different priorities.
 	groups := map[uint32]*rmpb.ResourceGroup{
-		1: {
-			Name:     "group_with_priority_1",
-			Mode:     rmpb.GroupMode_RUMode,
-			Priority: 1,
-		},
-		2: {
-			Name:     "group_with_priority_2",
-			Mode:     rmpb.GroupMode_RUMode,
-			Priority: 2,
-		},
-		3: {
-			Name:     "group_with_priority_3",
-			Mode:     rmpb.GroupMode_RUMode,
-			Priority: 3,
-		},
+		1: newTestResourceGroup("group_with_priority_1", 1, 100, 200),
+		2: newTestResourceGroup("group_with_priority_2", 2, 100, 200),
+		3: newTestResourceGroup("group_with_priority_3", 3, 100, 200),
 	}
 	for _, group := range groups {
 		err := krgm.addResourceGroup(group)
@@ -841,10 +822,7 @@ func TestOverrideFillRate(t *testing.T) {
 	}
 	krgm := newKeyspaceResourceGroupManager(1, storage.NewStorageWithMemoryBackend())
 	groupName := "test_group"
-	group := &rmpb.ResourceGroup{
-		Name: groupName,
-		Mode: rmpb.GroupMode_RUMode,
-	}
+	group := newTestResourceGroup(groupName, 0, 100, 200)
 	err := krgm.addResourceGroup(group)
 	re.NoError(err)
 	for idx, tc := range testCases {

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -341,6 +341,11 @@ func TestInitManager(t *testing.T) {
 		Mode:       rmpb.GroupMode_RUMode,
 		Priority:   5,
 		KeyspaceId: &rmpb.KeyspaceIDValue{Value: keyspaceID},
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{},
+			},
+		},
 	}
 	err = m.AddResourceGroup(group)
 	re.NoError(err)
@@ -654,6 +659,11 @@ func TestResourceGroupPersistence(t *testing.T) {
 		Mode:       rmpb.GroupMode_RUMode,
 		Priority:   5,
 		KeyspaceId: &rmpb.KeyspaceIDValue{Value: 1},
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{},
+			},
+		},
 	}
 	err := m.AddResourceGroup(group)
 	re.NoError(err)

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -259,6 +259,18 @@ func waitLeaderServingClient(re *require.Assertions, cli pd.Client, leaderAddr s
 	})
 }
 
+func newMinimalRUResourceGroup(name string) *rmpb.ResourceGroup {
+	return &rmpb.ResourceGroup{
+		Name: name,
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: &rmpb.GroupRequestUnitSettings{
+			RU: &rmpb.TokenBucket{
+				Settings: &rmpb.TokenLimitSettings{},
+			},
+		},
+	}
+}
+
 func waitResourceManagerServiceURL(re *require.Assertions, cli pd.Client, wantNonEmpty bool) {
 	innerCli, ok := cli.(interface{ GetResourceManagerServiceURL() string })
 	re.True(ok)
@@ -1305,10 +1317,8 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 	finalNum := 1
 	// Test Resource Group CURD via gRPC
 	for i, tcase := range testCasesSet1 {
-		group := &rmpb.ResourceGroup{
-			Name: tcase.name,
-			Mode: tcase.mode,
-		}
+		group := newMinimalRUResourceGroup(tcase.name)
+		group.Mode = tcase.mode
 		// Create Resource Group
 		resp, err := cli.AddResourceGroup(suite.ctx, group)
 		checkErr(err, true)
@@ -1373,10 +1383,8 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 	}
 	for i, tcase := range testCasesSet1 {
 		// Create Resource Group
-		group := &rmpb.ResourceGroup{
-			Name: tcase.name,
-			Mode: tcase.mode,
-		}
+		group := newMinimalRUResourceGroup(tcase.name)
+		group.Mode = tcase.mode
 		createJSON, err := json.Marshal(group)
 		re.NoError(err)
 		resp, err := tests.TestDialClient.Post(getAddr(i)+"/resource-manager/api/v1/config/group", "application/json", strings.NewReader(string(createJSON)))
@@ -2340,10 +2348,7 @@ func (suite *resourceManagerClientTestSuite) TestCannotModifyKeyspaceOfResourceG
 
 	// Add a resource group in Keyspace A and check
 	groupName := "keyspace_test"
-	originalGroup := &rmpb.ResourceGroup{
-		Name: groupName,
-		Mode: rmpb.GroupMode_RUMode,
-	}
+	originalGroup := newMinimalRUResourceGroup(groupName)
 	resp, err := clientA.AddResourceGroup(ctx, originalGroup)
 	re.NoError(err)
 	re.Contains(resp, "Success!")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8792

### What is changed and how does it work?

What is fixed

This change rejects invalid `GroupMode_RUMode` resource groups that omit
`RUSettings`, the `RU` token bucket, or the nested token limit settings.

The panic in #8792 comes from background metrics collection calling
`(*ResourceGroup).getFillRate` on an accepted-but-incomplete resource group.
Before this patch, `validateResourceGroupProto` only checked the group name and
priority, so malformed RU-mode groups could be persisted and later panic in the
background flush loop.

Root-cause evidence

- Issue stack points at
  `pkg/mcs/resourcemanager/server.(*ResourceGroup).getFillRate` via
  `(*Manager).backgroundMetricsFlush`.
- The pre-fix validation path in
  `pkg/mcs/resourcemanager/server/keyspace_manager.go` accepted RU-mode groups
  without `RUSettings.RU.Settings`.
- New regression cases fail before the fix for:
  - missing `RUSettings`
  - missing `RUSettings.RU`
  - missing `RUSettings.RU.Settings`

Historical analog

- Pattern 2: Panic Guarding and Nil Safety
- Representative analog: #10073 `resource control: avoid panic when reservation is nil`

Change summary

- tighten `validateResourceGroupProto` for RU-mode groups
- add regression coverage for malformed RU-mode resource groups
- update existing unit and integration fixtures to build valid RU-mode groups

Risk

Low. The change only rejects malformed RU-mode definitions that would later
panic in background metrics paths. Existing valid groups are unchanged.

Verification

- `make static PACKAGES='github.com/tikv/pd/pkg/mcs/resourcemanager/server' PACKAGE_DIRECTORIES='./pkg/mcs/resourcemanager/server' SUBMODULES=''`
  - PASS
- `make basic-test BASIC_TEST_PKGS='github.com/tikv/pd/pkg/mcs/resourcemanager/server'`
  - PASS
- `make failpoint-enable`
  - PASS
- `cd tests/integrations && GOCACHE=/tmp/pd-go-cache GOFLAGS='-tags=without_dashboard' go test ./mcs/resourcemanager -run 'TestResourceManagerClientTestSuite/(pd-resource-manager|standalone-resource-manager-with-client-discovery)/(TestBasicResourceGroupCURD|TestCannotModifyKeyspaceOfResourceGroup)$' -count=1 -v`
  - PASS
- `make failpoint-disable`
  - PASS

For context, an earlier full-repo `make basic-test` run in this workspace hit an
unrelated existing failure in `pkg/storage/endpoint TestDataPhysicalRepresentation`.

### Check List


### Release note

```release-note
None.
```
