### PR TITLE
tests: stabilize TestResourceGroupRUConsumption

### DIFF
--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -732,7 +732,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				continue
 			}
 			failpoint.Inject("github.com/tikv/pd/pkg/mcs/resourcemanager/server/delayConsume", func(val failpoint.Value) {
-				time.Sleep(time.Duration(val.(int)) * time.Millisecond)
+				time.Sleep(time.Duration(val.(int) * int(time.Millisecond)))
 			})
 			keyspaceID := consumptionInfo.keyspaceID
 			keyspaceName, err := m.getKeyspaceNameByID(ctx, keyspaceID)

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -731,7 +731,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 			if consumptionInfo == nil || consumptionInfo.Consumption == nil {
 				continue
 			}
-			if val, _err_ := failpoint.Eval(_curpkg_("delayConsume")); _err_ == nil {
+			if val, _err_ := failpoint.Eval("github.com/tikv/pd/pkg/mcs/resourcemanager/server/delayConsume"); _err_ == nil {
 				time.Sleep(time.Duration(val.(int)) * time.Millisecond)
 			}
 			keyspaceID := consumptionInfo.keyspaceID

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -731,9 +731,9 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 			if consumptionInfo == nil || consumptionInfo.Consumption == nil {
 				continue
 			}
-			if val, _err_ := failpoint.Eval("github.com/tikv/pd/pkg/mcs/resourcemanager/server/delayConsume"); _err_ == nil {
+			failpoint.Inject("github.com/tikv/pd/pkg/mcs/resourcemanager/server/delayConsume", func(val failpoint.Value) {
 				time.Sleep(time.Duration(val.(int)) * time.Millisecond)
-			}
+			})
 			keyspaceID := consumptionInfo.keyspaceID
 			keyspaceName, err := m.getKeyspaceNameByID(ctx, keyspaceID)
 			if err != nil {

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -731,6 +731,9 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 			if consumptionInfo == nil || consumptionInfo.Consumption == nil {
 				continue
 			}
+			if val, _err_ := failpoint.Eval(_curpkg_("delayConsume")); _err_ == nil {
+				time.Sleep(time.Duration(val.(int)) * time.Millisecond)
+			}
 			keyspaceID := consumptionInfo.keyspaceID
 			keyspaceName, err := m.getKeyspaceNameByID(ctx, keyspaceID)
 			if err != nil {

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -1492,6 +1492,10 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 	re := suite.Require()
 	cli := suite.client
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/mcs/resourcemanager/server/delayConsume", `return(100)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/mcs/resourcemanager/server/delayConsume"))
+	}()
 	group := &rmpb.ResourceGroup{
 		Name: "test_ru_consumption",
 		Mode: rmpb.GroupMode_RUMode,
@@ -1532,10 +1536,23 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 		ClientUniqueId:        1,
 	})
 	re.NoError(err)
-	time.Sleep(10 * time.Millisecond)
-	g, err = cli.GetResourceGroup(suite.ctx, group.Name, pd.WithRUStats)
-	re.NoError(err)
-	re.Equal(g.RUStats, testConsumption)
+	checkRUStats := func() {
+		testutil.Eventually(re, func() bool {
+			g, err = cli.GetResourceGroup(suite.ctx, group.Name, pd.WithRUStats)
+			if err != nil || g == nil || g.RUStats == nil {
+				return false
+			}
+			return g.RUStats.RRU == testConsumption.RRU &&
+				g.RUStats.WRU == testConsumption.WRU &&
+				g.RUStats.ReadBytes == testConsumption.ReadBytes &&
+				g.RUStats.WriteBytes == testConsumption.WriteBytes &&
+				g.RUStats.TotalCpuTimeMs == testConsumption.TotalCpuTimeMs &&
+				g.RUStats.SqlLayerCpuTimeMs == testConsumption.SqlLayerCpuTimeMs &&
+				g.RUStats.KvReadRpcCount == testConsumption.KvReadRpcCount &&
+				g.RUStats.KvWriteRpcCount == testConsumption.KvWriteRpcCount
+		})
+	}
+	checkRUStats()
 
 	// update resource group, ru stats not change
 	g.RUSettings.RU.Settings.FillRate = 12345
@@ -1554,9 +1571,7 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 	suite.client = suite.setupPDClient(re)
 	cli = suite.client
 	// check ru stats not loss after restart
-	g, err = cli.GetResourceGroup(suite.ctx, group.Name, pd.WithRUStats)
-	re.NoError(err)
-	re.Equal(g.RUStats, testConsumption)
+	checkRUStats()
 }
 
 func (suite *resourceManagerClientTestSuite) TestResourceManagerClientFailover() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8739

`TestResourceGroupRUConsumption` is unstable because it assumes RU consumption
statistics are visible immediately after `AcquireTokenBuckets` returns.

The test currently sleeps for 10ms and then asserts `GetResourceGroup(...,
pd.WithRUStats)` already reflects the reported consumption. That assumption is
not guaranteed: `AcquireTokenBuckets` only enqueues consumption into
`Manager.consumptionDispatcher`, and the actual `RUStats` update happens later
in `backgroundMetricsFlush`.

To make that race deterministic, this patch adds a test-only failpoint
`delayConsume` in `backgroundMetricsFlush` and enables it in the flaky test.
With `delayConsume=100ms`, the old fixed-sleep assertion fails reproducibly:
`g.RUStats` is still zero while `testConsumption` already contains the expected
values.

### What is changed and how does it work?

- add a test-only `delayConsume` failpoint before the background consumption
  worker applies RU stats
- update `TestResourceGroupRUConsumption` to wait on the observable condition
  instead of sleeping for a fixed 10ms
- reuse the same condition-based check after leader transfer so the test waits
  for persisted stats to become visible again

This keeps production behavior unchanged. The new failpoint only activates when
a test explicitly enables it.

Root-cause evidence

- `pkg/mcs/resourcemanager/server/manager.go:730+`: consumption is processed
  asynchronously from `consumptionDispatcher`
- `tests/integrations/mcs/resourcemanager/resource_manager_test.go` previously
  slept 10ms before asserting RU stats had already updated
- red test with `delayConsume=100ms`:
  - `GOCACHE=/tmp/pd-go-cache make gotest GOTEST_ARGS='-tags=without_dashboard ./mcs/resourcemanager -run TestResourceManagerClientTestSuite/pd-resource-manager/TestResourceGroupRUConsumption -count=1 -vet=off'`
  - failed before the fix because `g.RUStats` remained zero

Historical analog

- Playbook Pattern 5: Flaky and Unstable Test Stabilization
- Representative merged PRs:
  - #10134 `tests: fix some unstable tests`
  - #9465 `*: fix flaky test TestPreparingProgress and TestRemovingProgress`
- Prior issue-specific attempt:
  - #10303 `tests: fix multiple flaky tests, panics, deadlocks, and goroutine leaks`

Risk

- scoped to one flaky integration test plus a failpoint-only hook in the
  asynchronous RU stats path
- no production behavior, API, or config changes unless the failpoint is
  explicitly enabled in tests

Verification

- red before the fix:
  - `GOCACHE=/tmp/pd-go-cache make gotest GOTEST_ARGS='-tags=without_dashboard ./mcs/resourcemanager -run TestResourceManagerClientTestSuite/pd-resource-manager/TestResourceGroupRUConsumption -count=1 -vet=off'`
  - failed deterministically with `delayConsume=100ms`
- green after the fix:
  - `GOCACHE=/tmp/pd-go-cache make gotest GOTEST_ARGS='-tags=without_dashboard ./mcs/resourcemanager -run TestResourceManagerClientTestSuite/pd-resource-manager/TestResourceGroupRUConsumption -count=1 -vet=off'`
  - passed
- green in standalone RM discovery mode:
  - `GOCACHE=/tmp/pd-go-cache make gotest GOTEST_ARGS='-tags=without_dashboard ./mcs/resourcemanager -run TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestResourceGroupRUConsumption -count=1 -vet=off'`
  - passed
- touched manager path:
  - `GOCACHE=/tmp/pd-go-cache make gotest GOTEST_ARGS='./pkg/mcs/resourcemanager/server -run TestCleanUpTicker -count=1'`
  - passed
- repo baseline:
  - `GOCACHE=/tmp/pd-go-cache make basic-test`
  - not clean in this worktree due an unrelated existing failure in
    `pkg/mcs/resourcemanager/server TestSetServiceLimit`

### Check List


### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness for resource consumption metrics by implementing polling-based validation instead of fixed delays, and adding test infrastructure for simulating consumption processing delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->