### PR TITLE
client/tso: reject requests during recv teardown

### DIFF
--- a/client/clients/tso/stream.go
+++ b/client/clients/tso/stream.go
@@ -336,11 +336,6 @@ func (s *tsoStream) recvLoop(ctx context.Context) {
 			log.Fatal("tsoStream.recvLoop exited without error info", zap.String("stream", s.streamID))
 		}
 
-		if hasReq {
-			// There's an unfinished request, cancel it, otherwise it will be blocked forever.
-			currentReq.callback(tsoRequestResult{}, currentReq.reqKeyspaceGroupID, finishWithErr)
-		}
-
 		s.stoppedWithErr.Store(&finishWithErr)
 		s.cancel()
 		for !s.state.CompareAndSwap(streamStateIdle, streamStateClosing) {
@@ -354,6 +349,11 @@ func (s *tsoStream) recvLoop(ctx context.Context) {
 			default:
 				log.Fatal("unknown tsoStream state", zap.String("stream", s.streamID), zap.Int32("state", state))
 			}
+		}
+
+		if hasReq {
+			// Mark the stream as closing before invoking callbacks so new requests are rejected even if the callback is slow.
+			currentReq.callback(tsoRequestResult{}, currentReq.reqKeyspaceGroupID, finishWithErr)
 		}
 
 		log.Info("tsoStream.recvLoop ended", zap.String("stream", s.streamID), zap.Error(finishWithErr))

--- a/client/clients/tso/stream_test.go
+++ b/client/clients/tso/stream_test.go
@@ -364,6 +364,47 @@ func (s *testTSOStreamSuite) TestTSOStreamBasic() {
 	})
 }
 
+func (s *testTSOStreamSuite) TestTSOStreamRejectsRequestsDuringErrorTeardown() {
+	currentReqErrCh := make(chan error, 1)
+	nextReqErrCh := make(chan error, 1)
+	currentReqCallbackStarted := make(chan struct{})
+	releaseCurrentReqCallback := make(chan struct{})
+
+	err := s.stream.processRequests(1, 2, 3, 1, time.Now(), func(_ tsoRequestResult, _ uint32, err error) {
+		close(currentReqCallbackStarted)
+		<-releaseCurrentReqCallback
+		currentReqErrCh <- err
+	})
+	s.re.NoError(err)
+
+	s.inner.returnError(errors.New("mock rpc error"))
+
+	select {
+	case <-currentReqCallbackStarted:
+	case <-time.After(time.Second):
+		s.re.FailNow("recv loop did not start teardown callback in time")
+	}
+
+	err = s.stream.processRequests(1, 2, 3, 1, time.Now(), func(_ tsoRequestResult, _ uint32, err error) {
+		nextReqErrCh <- err
+	})
+
+	close(releaseCurrentReqCallback)
+
+	s.re.Error(err)
+	s.re.ErrorContains(err, "mock rpc error")
+	s.re.Error(<-currentReqErrCh)
+
+	s.stream.WaitForClosed()
+
+	select {
+	case err := <-nextReqErrCh:
+		s.re.Error(err)
+		s.re.ErrorContains(err, "mock rpc error")
+	default:
+	}
+}
+
 func (s *testTSOStreamSuite) testTSOStreamBrokenImpl(err error, pendingRequests int) {
 	var resultCh []<-chan callbackInvocation
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9809

`TestTSOStreamBasic` can still sneak in a new `processRequests` call after `recvLoop` has already observed the terminal RPC error but before the stream state flips to `closing`.

The issue stack for #9809 shows that exact path:

- the panic happens in the callback created at `client/clients/tso/stream_test.go:360`
- that callback is invoked from `client/clients/tso/stream.go:365` inside `recvLoop` teardown
- in the old ordering, `recvLoop` ran the current request callback before storing `stoppedWithErr` and switching the stream state to `closing`

That leaves a teardown window where a slow callback can let a new request into `pendingRequests`. In the flaky test, that extra callback runs on the recvLoop goroutine and trips the test in the wrong execution context.

### What is changed and how does it work?

- mark the stream as stopped and switch its state to `closing` before invoking the unfinished request callback in `recvLoop`
- add a deterministic unit test that blocks the teardown callback and proves a second `processRequests` call is rejected immediately once recv teardown starts

This removes the gap that let new requests race into a stream that had already failed.

Risk

- scoped to `client/clients/tso` recv-loop teardown ordering
- no API or config surface changes
- added a focused regression test for the exact interleaving

Historical analog

- #10203 `test: fix flaky test TestForwardTestSuite in next-gen`
- #10134 `tests: fix some unstable tests`

Both are test-stabilization fixes that remove readiness/teardown nondeterminism instead of changing user-facing behavior.

Verification

- `cd client && make gotest GOTEST_ARGS="./clients/tso -run 'TestTSOStreamTestSuite/(TestTSOStreamBasic|TestTSOStreamRejectsRequestsDuringErrorTeardown)' -count=20 -v"`
  - passed
- `cd client && make static`
  - passed
- `cd client && make basic-test`
  - failed outside the touched scope in `client/http`:
  - `TestWithTargetURL` expected `connect: connection refused` from `http://127.0.0.2/pd/api/v1/status`, but this environment returned `context deadline exceeded`

Does this PR introduce _any_ user-facing change?

No.

### Check List


### Release note

```release-note
None.
```
