### PR TITLE
schedulers: wait for cleanup on removal

### DIFF
--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -258,6 +258,7 @@ func (c *Controller) RemoveScheduler(name string) error {
 	}
 
 	s.Stop()
+	s.Wait()
 	schedulerStatusGauge.DeleteLabelValues(name, "allow")
 	delete(c.schedulers, name)
 	return nil
@@ -367,6 +368,7 @@ func (c *Controller) IsSchedulerExisted(name string) (bool, error) {
 
 func (c *Controller) runScheduler(s *ScheduleController) {
 	defer logutil.LogPanic()
+	defer close(s.stopped)
 	defer c.wg.Done()
 	defer s.CleanConfig(c.cluster)
 
@@ -454,6 +456,7 @@ type ScheduleController struct {
 	delayAt            int64
 	delayUntil         int64
 	diagnosticRecorder *DiagnosticRecorder
+	stopped            chan struct{}
 }
 
 // NewScheduleController creates a new ScheduleController.
@@ -467,6 +470,7 @@ func NewScheduleController(ctx context.Context, cluster sche.SchedulerCluster, o
 		ctx:                ctx,
 		cancel:             cancel,
 		diagnosticRecorder: NewDiagnosticRecorder(s.GetType(), cluster.GetSchedulerConfig()),
+		stopped:            make(chan struct{}),
 	}
 }
 
@@ -478,6 +482,11 @@ func (s *ScheduleController) Ctx() context.Context {
 // Stop stops the ScheduleController
 func (s *ScheduleController) Stop() {
 	s.cancel()
+}
+
+// Wait waits for the scheduler goroutine to exit and finish cleanup.
+func (s *ScheduleController) Wait() {
+	<-s.stopped
 }
 
 // Schedule tries to create some operators.

--- a/pkg/schedule/schedulers/scheduler_controller_test.go
+++ b/pkg/schedule/schedulers/scheduler_controller_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedulers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/plan"
+	"github.com/tikv/pd/pkg/schedule/types"
+	"github.com/tikv/pd/pkg/storage"
+)
+
+type blockingCleanupScheduler struct {
+	*BaseScheduler
+	cleanupStarted chan struct{}
+	allowCleanup   <-chan struct{}
+}
+
+func newBlockingCleanupScheduler(oc *operator.Controller, cleanupStarted chan struct{}, allowCleanup <-chan struct{}) *blockingCleanupScheduler {
+	base := NewBaseScheduler(oc, types.EvictLeaderScheduler, nil)
+	base.name = "test-blocking-cleanup-scheduler"
+	return &blockingCleanupScheduler{
+		BaseScheduler:  base,
+		cleanupStarted: cleanupStarted,
+		allowCleanup:   allowCleanup,
+	}
+}
+
+func (*blockingCleanupScheduler) Schedule(sche.SchedulerCluster, bool) ([]*operator.Operator, []plan.Plan) {
+	return nil, nil
+}
+
+func (*blockingCleanupScheduler) IsScheduleAllowed(sche.SchedulerCluster) bool {
+	return false
+}
+
+func (s *blockingCleanupScheduler) CleanConfig(sche.SchedulerCluster) {
+	close(s.cleanupStarted)
+	<-s.allowCleanup
+}
+
+func TestRemoveSchedulerWaitsForCleanup(t *testing.T) {
+	re := require.New(t)
+	cleanup, _, tc, oc := prepareSchedulersTest()
+	defer cleanup()
+
+	controller := NewController(context.Background(), tc, storage.NewStorageWithMemoryBackend(), oc)
+	cleanupStarted := make(chan struct{})
+	allowCleanup := make(chan struct{})
+	scheduler := newBlockingCleanupScheduler(oc, cleanupStarted, allowCleanup)
+
+	re.NoError(controller.AddScheduler(scheduler))
+
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- controller.RemoveScheduler(scheduler.GetName())
+	}()
+
+	select {
+	case <-cleanupStarted:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not start")
+	}
+
+	select {
+	case err := <-removeDone:
+		re.FailNow("remove returned before cleanup finished", "err=%v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowCleanup)
+
+	select {
+	case err := <-removeDone:
+		re.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("remove did not finish after cleanup was released")
+	}
+
+	controller.Wait()
+}


### PR DESCRIPTION
### What problem does this PR solve?

`TestEvictLeaderScheduler` from [#9713](https://github.com/tikv/pd/issues/9713) is flaky because scheduler removal only cancels the scheduler context and returns before the scheduler goroutine finishes `CleanConfig()`.

That leaves a race window where an old scheduler can still run cleanup after the test has already deleted and recreated the scheduler.

Issue Number: close #9713

### What is changed and how does it work?

- wait for the scheduler goroutine to finish cleanup before `Controller.RemoveScheduler()` returns
- add a per-scheduler `stopped` channel so removal can block until `runScheduler()` has exited
- add a regression test that blocks `CleanConfig()` and proves `RemoveScheduler()` no longer returns early

Historical analog:
- Playbook Pattern 5 `Flaky and Unstable Test Stabilization`
- Playbook Pattern 8 `Test Harness and Fixture Alignment`
- Representative PRs: #10203, #9465

Risk:
- Low. This only changes scheduler teardown to be deterministic; it does not alter scheduling decisions.

Verification

- `go test ./pkg/schedule/schedulers -tags without_dashboard -run '^TestRemoveSchedulerWaitsForCleanup$' -count=1` -> PASS
- `make failpoint-enable` -> PASS
- `cd tests/integrations && go test ./mcs/scheduling -tags without_dashboard -run TestServerTestSuite -testify.m TestSchedulerSync -count=1 -v` -> PASS
- `make failpoint-disable` -> PASS
- `make check` -> FAIL, unrelated repository-state failure from failpoint binding files being reformatted during `gofmt`
- `make basic-test` -> FAIL, unrelated failures in `pkg/gctuner`, `pkg/response`, `pkg/storage/endpoint`, and `server/api`

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has the configuration change: No
- Has HTTP APIs changed (Don't forget to add the declarative for the new API): No
- Has persistent data change: No

Side effects

- Possible performance regression: Low, only on scheduler removal path
- Increased code complexity: Low
- Breaking backward compatibility: No

### Release note

```release-note
None.
```
