### PR TITLE
tests: stabilize TestResignTSOPrimaryForward

### DIFF
--- a/tests/integrations/mcs/tso/server_test.go
+++ b/tests/integrations/mcs/tso/server_test.go
@@ -350,15 +350,8 @@ func TestResignTSOPrimaryForward(t *testing.T) {
 		err = tc.ResignPrimary(constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID)
 		re.NoError(err)
 		tc.WaitForDefaultPrimaryServing(re)
-		var err error
-		for range 3 { // try 3 times
-			_, _, err = suite.pdClient.GetTS(suite.ctx)
-			if err == nil {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		re.NoError(err)
+		// The server-side primary election may finish before the PD client refreshes
+		// its TSO forwarding target.
 		suite.checkAvailableTSO(re)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8737

### What is changed and how does it work?

Root-cause evidence

- The issue body captured an older `address already in use` symptom while starting the PD test cluster.
- On current `master`, that symptom is already covered by `tests: retry when address already in use (#10162)` in `tests/cluster.go`.
- Reproducing `TestResignTSOPrimaryForward` on current `master` still fails, but now at `tests/integrations/mcs/tso/server_test.go:361` with `[PD:client:ErrClientGetTSO]get TSO failed, tso client is nil`.
- The failing test only waited `3 * 100ms` after `ResignPrimary`, while `tests/integrations/tso/client_test.go` already documents that TSO service discovery around primary changes can take longer than one second.

Historical analog

unavailable (`references/flaky-fix-playbook.md` is missing in this worktree)

Fix summary

- Remove the ad hoc 300ms `GetTS` retry loop from `TestResignTSOPrimaryForward`.
- Reuse the existing `suite.checkAvailableTSO` path, which already waits for the PD client to refresh its TSO forwarding target before asserting forwarded TSO APIs.

Risk

- Test-only change.
- The behavioral coverage stays the same; the patch only removes a brittle timing assumption.

Verification

- `cd tests/integrations && make gotest GOTEST_ARGS='-tags without_dashboard ./mcs/tso -run TestResignTSOPrimaryForward -count=5 -v'`
  - Passed: `ok github.com/tikv/pd/tests/integrations/mcs/tso 113.653s`
- `make basic-test`
  - Unrelated failure: `pkg/gctuner` goleak reports a sleeping goroutine rooted at `pkg/gctuner/memory_limit_tuner.go:86`
- `go test ./pkg/gctuner -count=1`
  - Same unrelated goleak reproduced independently

### Check List


### Release note

```release-note
None.
```
