### PR TITLE
tests: stabilize TestStoreWatch tombstone transition

### DIFF
--- a/tests/integrations/mcs/scheduling/meta_test.go
+++ b/tests/integrations/mcs/scheduling/meta_test.go
@@ -99,6 +99,9 @@ func (suite *metaTestSuite) TestStoreWatch() {
 	})
 	re.Len(cluster.GetStores(), 4)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/doNotBuryStore"))
+	// Trigger burying explicitly so the test does not depend on the leader's
+	// background store check running in time under slow etcd or lease churn.
+	re.NoError(suite.getRaftCluster().BuryStore(2, false))
 	testutil.Eventually(re, func() bool {
 		return cluster.GetStore(2).GetState() == metapb.StoreState_Tombstone
 	})


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8692

### What is changed and how does it work?

Root-cause evidence

- The current flaky report for `TestMeta/TestStoreWatch` was reopened after the earlier fix and now fails on the tombstone wait (`meta_test.go:101` in the 2024-12 report).
- Issue comments for #8692 show slow etcd requests and leader lease churn. That keeps the leader-side background `checkStores` bury flow from running deterministically within `Eventually`, so the test can observe `Offline` but time out waiting for `Tombstone`.
- The test already uses `doNotBuryStore` to hold the store in `Offline`, but after disabling that failpoint it still relied on the asynchronous background bury path.

Historical analog

- #8724 (`test: make TestStoreWatch stable`) fixed the earlier variant of the same issue by preventing the store from being buried before the test observed the `Offline` state.
- This patch addresses the remaining asynchronous tombstone transition by driving the bury step explicitly in the test.

Fix summary

- Keep the existing `doNotBuryStore` guard for the `Offline` assertion.
- After confirming `Offline`, call `BuryStore(2, false)` directly before asserting `Tombstone`.
- This removes the timing dependency on the leader background store checker while preserving the watcher assertions.

Risk

- Low. The change is test-only and only makes the tombstone transition deterministic.

Verification

- `GOCACHE=/tmp/pd-gocache-integration go test -tags without_dashboard ./mcs/scheduling -run TestMeta/TestStoreWatch -count=10 -v`
  - Passed (`ok github.com/tikv/pd/tests/integrations/mcs/scheduling 29.352s`).
- `GOCACHE=/tmp/pd-gocache-basic GOFLAGS='-tags=without_dashboard' make basic-test`
  - Failed in pre-existing unrelated packages:
    - `github.com/tikv/pd/pkg/gctuner` (`goleak` on `memoryLimitTuner.tuning`)
    - `github.com/tikv/pd/pkg/storage/endpoint` (`TestDataPhysicalRepresentation` expected `/pd/0/...`, got `/pd/<cluster-id>/...`)

### Check List


### Release note

```release-note
None.
```
