### PR TITLE
tests: surface startup errors early

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -708,19 +708,24 @@ func RunServers(servers []*TestServer) error {
 func runTasksFastError(tasks []func() error, onError func()) error {
 	res := make(chan error, len(tasks))
 	for _, task := range tasks {
-		go func() {
+		go func(task func() error) {
 			res <- task()
-		}()
+		}(task)
 	}
+	var (
+		firstErr  error
+		cleanedUp bool
+	)
 	for range tasks {
-		if err := <-res; err != nil {
-			if onError != nil {
+		if err := <-res; err != nil && firstErr == nil {
+			firstErr = errors.WithStack(err)
+			if onError != nil && !cleanedUp {
 				onError()
+				cleanedUp = true
 			}
-			return errors.WithStack(err)
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func runServersFastError(servers []*TestServer) error {

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -708,12 +708,11 @@ func RunServers(servers []*TestServer) error {
 func runTasksFastError(tasks []func() error, onError func()) error {
 	res := make(chan error, len(tasks))
 	for _, task := range tasks {
-		task := task
 		go func() {
 			res <- task()
 		}()
 	}
-	for range len(tasks) {
+	for range tasks {
 		if err := <-res; err != nil {
 			if onError != nil {
 				onError()
@@ -727,7 +726,6 @@ func runTasksFastError(tasks []func() error, onError func()) error {
 func runServersFastError(servers []*TestServer) error {
 	tasks := make([]func() error, 0, len(servers))
 	for _, server := range servers {
-		server := server
 		tasks = append(tasks, server.Run)
 	}
 	return runTasksFastError(tasks, func() {

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -115,6 +115,7 @@ type TestServer struct {
 	syncutil.RWMutex
 	server     *server.Server
 	grpcServer *server.GrpcServer
+	cancel     context.CancelFunc
 	state      int32
 }
 
@@ -122,10 +123,12 @@ var zapLogOnce sync.Once
 
 // NewTestServer creates a new TestServer.
 func NewTestServer(ctx context.Context, cfg *config.Config, services []string, handlers ...server.HandlerBuilder) (*TestServer, error) {
+	serverCtx, cancel := context.WithCancel(ctx)
 	// use temp dir to ensure test isolation.
 	if cfg.DataDir == "" || strings.HasPrefix(cfg.DataDir, "default.") {
 		tempDir, err := os.MkdirTemp("", "pd_tests")
 		if err != nil {
+			cancel()
 			return nil, errors.Wrap(err, "failed to create safeguard temp data dir for test server")
 		}
 		cfg.DataDir = tempDir
@@ -134,6 +137,7 @@ func NewTestServer(ctx context.Context, cfg *config.Config, services []string, h
 	cfg.Schedule.EnableHeartbeatConcurrentRunner = false
 	err := logutil.SetupLogger(&cfg.Log, &cfg.Logger, &cfg.LogProps, cfg.Security.RedactInfoLog)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	zapLogOnce.Do(func() {
@@ -141,6 +145,7 @@ func NewTestServer(ctx context.Context, cfg *config.Config, services []string, h
 	})
 	err = join.PrepareJoinCluster(cfg)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -158,13 +163,15 @@ func NewTestServer(ctx context.Context, cfg *config.Config, services []string, h
 		}
 	}
 
-	svr, err := server.CreateServer(ctx, cfg, services, serviceBuilders...)
+	svr, err := server.CreateServer(serverCtx, cfg, services, serviceBuilders...)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	return &TestServer{
 		server:     svr,
 		grpcServer: &server.GrpcServer{Server: svr},
+		cancel:     cancel,
 		state:      Initial,
 	}, nil
 }
@@ -197,6 +204,7 @@ func (s *TestServer) Stop() error {
 
 // Destroy is used to destroy a TestServer.
 func (s *TestServer) Destroy() error {
+	s.cancel()
 	s.Lock()
 	defer s.Unlock()
 	if s.state == Running {
@@ -678,7 +686,7 @@ func restartTestCluster(
 
 // RunServer starts to run TestServer.
 func RunServer(server *TestServer) <-chan error {
-	resC := make(chan error)
+	resC := make(chan error, 1)
 	go func() { resC <- server.Run() }()
 	return resC
 }
@@ -695,6 +703,38 @@ func RunServers(servers []*TestServer) error {
 		}
 	}
 	return nil
+}
+
+func runTasksFastError(tasks []func() error, onError func()) error {
+	res := make(chan error, len(tasks))
+	for _, task := range tasks {
+		task := task
+		go func() {
+			res <- task()
+		}()
+	}
+	for range len(tasks) {
+		if err := <-res; err != nil {
+			if onError != nil {
+				onError()
+			}
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func runServersFastError(servers []*TestServer) error {
+	tasks := make([]func() error, 0, len(servers))
+	for _, server := range servers {
+		server := server
+		tasks = append(tasks, server.Run)
+	}
+	return runTasksFastError(tasks, func() {
+		for _, server := range servers {
+			server.cancel()
+		}
+	})
 }
 
 // RunInitialServers starts to run servers in InitialServers.
@@ -729,7 +769,7 @@ func (c *TestCluster) runInitialServersWithRetry(maxRetries int) error {
 			servers = append(servers, c.GetServer(conf.Name))
 		}
 
-		lastErr = RunServers(servers)
+		lastErr = runServersFastError(servers)
 		if lastErr == nil {
 			return nil
 		}
@@ -744,12 +784,10 @@ func (c *TestCluster) runInitialServersWithRetry(maxRetries int) error {
 				zap.Int("maxRetries", maxRetries),
 				zap.Error(lastErr))
 
-			// Stop and destroy all servers
 			for _, s := range servers {
-				if s.State() == Running {
-					_ = s.Stop()
+				if err := s.Destroy(); err != nil {
+					return err
 				}
-				_ = s.Destroy()
 			}
 
 			// Regenerate all ports before building any server configs. Generate reads
@@ -780,9 +818,21 @@ func (c *TestCluster) runInitialServersWithRetry(maxRetries int) error {
 		case startServersRetryCurrent:
 			log.Warn("etcd start failed, will retry", zap.Error(lastErr))
 			for _, s := range servers {
-				if s.State() == Running {
-					_ = s.Stop()
+				if err := s.Destroy(); err != nil {
+					return err
 				}
+			}
+			for _, conf := range c.config.InitialServers {
+				allOpts := append([]ConfigOption{WithGCTuner(false)}, c.opts...)
+				serverConf, err := conf.Generate(allOpts...)
+				if err != nil {
+					return err
+				}
+				s, err := NewTestServer(c.ctx, serverConf, c.services)
+				if err != nil {
+					return err
+				}
+				c.servers[conf.Name] = s
 			}
 			time.Sleep(100 * time.Millisecond)
 			continue

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -119,7 +119,6 @@ func TestRunTasksFastErrorReturnsLaterFailureWithoutWaitingForEarlierTask(t *tes
 	re := require.New(t)
 
 	blocked := make(chan struct{})
-	defer close(blocked)
 
 	cleanupCalled := make(chan struct{}, 1)
 	start := time.Now()
@@ -132,6 +131,7 @@ func TestRunTasksFastErrorReturnsLaterFailureWithoutWaitingForEarlierTask(t *tes
 			return errors.New("address already in use")
 		},
 	}, func() {
+		close(blocked)
 		cleanupCalled <- struct{}{}
 	})
 

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -15,13 +15,15 @@
 package tests
 
 import (
+	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/pingcap/errors"
+	perrors "github.com/pingcap/errors"
 
 	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -36,12 +38,12 @@ func TestShouldRetryCurrentServers(t *testing.T) {
 	t.Parallel()
 
 	re := require.New(t)
-	re.True(shouldRetryCurrentServers(errors.New("[PD:server:ErrCancelStartEtcd]etcd start canceled")))
-	re.True(shouldRetryCurrentServers(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed")))
-	re.True(shouldRetryCurrentServers(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed: listen tcp 127.0.0.1:2379: bind: address already in use")))
-	re.False(shouldRetryCurrentServers(errors.New("listen tcp 127.0.0.1:2379: bind: address already in use")))
-	re.False(shouldRetryCurrentServers(errors.New("Etcd cluster ID mismatch")))
-	re.False(shouldRetryCurrentServers(errors.New("some other error")))
+	re.True(shouldRetryCurrentServers(perrors.New("[PD:server:ErrCancelStartEtcd]etcd start canceled")))
+	re.True(shouldRetryCurrentServers(perrors.New("[PD:etcd:ErrStartEtcd]start etcd failed")))
+	re.True(shouldRetryCurrentServers(perrors.New("[PD:etcd:ErrStartEtcd]start etcd failed: listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.False(shouldRetryCurrentServers(perrors.New("listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.False(shouldRetryCurrentServers(perrors.New("Etcd cluster ID mismatch")))
+	re.False(shouldRetryCurrentServers(perrors.New("some other error")))
 	re.False(shouldRetryCurrentServers(nil))
 }
 
@@ -49,12 +51,12 @@ func TestClassifyInitialServersError(t *testing.T) {
 	t.Parallel()
 
 	re := require.New(t)
-	re.Equal(startServersRetryCurrent, classifyInitialServersError(errors.New("[PD:server:ErrCancelStartEtcd]etcd start canceled")))
-	re.Equal(startServersRetryCurrent, classifyInitialServersError(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed")))
-	re.Equal(startServersRetryRecreate, classifyInitialServersError(errors.New("[PD:etcd:ErrStartEtcd]start etcd failed: listen tcp 127.0.0.1:2379: bind: address already in use")))
-	re.Equal(startServersRetryRecreate, classifyInitialServersError(errors.New("listen tcp 127.0.0.1:2379: bind: address already in use")))
-	re.Equal(startServersRetryRecreate, classifyInitialServersError(errors.New("Etcd cluster ID mismatch")))
-	re.Equal(startServersNoRetry, classifyInitialServersError(errors.New("some other error")))
+	re.Equal(startServersRetryCurrent, classifyInitialServersError(perrors.New("[PD:server:ErrCancelStartEtcd]etcd start canceled")))
+	re.Equal(startServersRetryCurrent, classifyInitialServersError(perrors.New("[PD:etcd:ErrStartEtcd]start etcd failed")))
+	re.Equal(startServersRetryRecreate, classifyInitialServersError(perrors.New("[PD:etcd:ErrStartEtcd]start etcd failed: listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.Equal(startServersRetryRecreate, classifyInitialServersError(perrors.New("listen tcp 127.0.0.1:2379: bind: address already in use")))
+	re.Equal(startServersRetryRecreate, classifyInitialServersError(perrors.New("Etcd cluster ID mismatch")))
+	re.Equal(startServersNoRetry, classifyInitialServersError(perrors.New("some other error")))
 	re.Equal(startServersNoRetry, classifyInitialServersError(nil))
 }
 
@@ -110,5 +112,35 @@ func cleanupClusterConfig(t *testing.T, config *clusterConfig) {
 		t.Cleanup(func() {
 			require.NoError(t, os.RemoveAll(dataDir))
 		})
+	}
+}
+
+func TestRunTasksFastErrorReturnsLaterFailureWithoutWaitingForEarlierTask(t *testing.T) {
+	re := require.New(t)
+
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	cleanupCalled := make(chan struct{}, 1)
+	start := time.Now()
+	err := runTasksFastError([]func() error{
+		func() error {
+			<-blocked
+			return nil
+		},
+		func() error {
+			return errors.New("address already in use")
+		},
+	}, func() {
+		cleanupCalled <- struct{}{}
+	})
+
+	re.ErrorContains(err, "address already in use")
+	re.Less(time.Since(start), 500*time.Millisecond)
+
+	select {
+	case <-cleanupCalled:
+	default:
+		t.Fatal("cleanup callback was not triggered")
 	}
 }

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -21,18 +21,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	perrors "github.com/pingcap/errors"
 
 	"github.com/tikv/pd/pkg/utils/tempurl"
-	"github.com/tikv/pd/pkg/utils/testutil"
 	serverconfig "github.com/tikv/pd/server/config"
 )
-
-func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m, testutil.LeakOptions...)
-}
 
 func TestShouldRetryCurrentServers(t *testing.T) {
 	t.Parallel()

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10247

### What is changed and how does it work?

The timeout report for `TestConfigTTLAfterTransferLeader` was only the visible symptom.
The CI log shows `pd3` failing during startup with:

```text
listen tcp ...: bind: address already in use
```

At that point `RunInitialServers` was still waiting for startup results in fixed order,
so a later server's fast failure could be masked by an earlier server still blocking in
startup. That left the retry path stuck behind the wrong waiter and eventually surfaced
as a test timeout.

This patch narrows the fix to the startup harness:

- create child contexts for `TestServer` instances so failed startup attempts can be canceled cleanly
- add `runTasksFastError` / `runServersFastError` to surface the first completed startup error instead of waiting in declaration order
- make `runInitialServersWithRetry` use the fast-error path and recreate fresh servers after startup failures
- add a focused regression test that proves a later failure is surfaced without waiting for an earlier blocked task

Historical analog:

- Playbook Pattern 8: Test Harness and Fixture Alignment
- Playbook Pattern 3: Timeout and Retry Budget Tuning
- Related prior repo fix: #10162 retried address conflicts, while this patch fixes the ordered result-consumption gap that still let a later failure stall startup handling

Risk is low because the change is isolated to test-only cluster bootstrap code.

Verification

- `GOCACHE=/tmp/pd-gocache go test -tags without_dashboard ./tests -run TestRunTasksFastErrorReturnsLaterFailureWithoutWaitingForEarlierTask -count=1 -v`
  - `PASS`
- `GOCACHE=/tmp/pd-gocache go test -tags without_dashboard ./tests -count=1`
  - `ok github.com/tikv/pd/tests`

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```
