### PR TITLE
openclaw: add router cluster benchmark skill

### DIFF
--- a/.openclaw/benchmark-router-cluster/SKILL.md
+++ b/.openclaw/benchmark-router-cluster/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: benchmark-router-cluster
+description: Controller-style sysbench benchmarking on router/TiDB cluster hosts over SSH with strict round sequencing by thread list, mandatory wait gates, run-only or prepare+run modes, stale session/process checks, and explicit plan+permit before execution. Use when user asks to benchmark with different thread counts, repeated rounds, or long-running router cluster tests.
+---
+
+# Benchmark Router Cluster (Controller)
+
+Always operate as a controller. Do not jump straight to execution.
+
+## Mandatory interaction contract
+
+Before any benchmark command:
+1. Print execution plan (host, workload, DB args, rounds, wait seconds, prepare/cleanup policy).
+2. Ask for explicit permit.
+3. Run only after user says permit/approved/run now.
+
+If user changes parameters, reprint plan and request permit again.
+
+## Required requirements
+
+Always require these before execution:
+1. SSH remote machine target (`target_host` + `ssh_user`).
+2. Per-round `threads` parameter (single `threads` or ordered `thread_list` for controller rounds).
+
+## Inputs
+
+Collect/confirm:
+- `target_host` (SSH target)
+- `ssh_user`
+- fixed `topology_yaml`: `references/tiup-router-cluster-template.yaml` (do not ask user to provide another yaml unless explicitly requested)
+- `workload` (`oltp_read_write` by default; optional override: `oltp_point_select`)
+- `time` (default `300`), `tables`, `table_size`
+- one of:
+  - `threads` (single-round), or
+  - `thread_list` (multi-round controller; each round must use its own thread value)
+- `wait_seconds_between_rounds` (for multi-round)
+- `prepare_mode` (`prepare_once` or `skip_prepare`)
+- `cleanup_mode` (`skip_cleanup` by default)
+
+Do not require mysql host/port as user input. Resolve TiDB host/port from `tidb_servers` in fixed yaml `references/tiup-router-cluster-template.yaml`.
+Default to first TiDB server entry when not specified.
+## TiUP topology template
+
+Use this fixed file for router-cluster deploy topology:
+- `references/tiup-router-cluster-template.yaml`
+
+Deploy policy:
+- Always deploy cluster with this template yaml unless user explicitly overrides.
+- Use `tiup-cluster deploy` with `--skip-create-user`.
+- Default cluster name: `router`.
+- In fresh or unknown environments, perform deploy/start readiness before mysql connectivity/auth preflight.
+- Build and package TiDB binary on the remote machine during prepare stage:
+  - Target package path: `~/tidb/bin/tidb.tar.gz`.
+  - If package exists, mark build/package as `[SKIP]`.
+  - Otherwise build TiDB and create package tarball at that path.
+- After preflight checks pass (before benchmark run), patch TiDB with the packaged tarball:
+  - `tiup-cluster patch router ~/tidb/bin/tidb.tar.gz -R tidb -y`
+
+## Prepare for router cluster (preconditions)
+
+Preconditions output must be step-by-step and explicit:
+- Print each step header and action details.
+- Print outcome markers for every sub-step: `[OK]` / `[SKIP]` / `[FAIL]`.
+- On failure, print the failing step id/name and stop immediately.
+
+When user asks to prepare router cluster environment (or when benchmark environment is not ready), run:
+
+```bash
+bash scripts/prepare_router_cluster.sh \
+  --target-host "$target_host" \
+  --ssh-user "$ssh_user"
+```
+
+Prepare behavior must:
+1. Verify SSH connectivity.
+2. Install runtime tools: `sysbench`, mysql client, and **latest** `golang` (from go.dev release tarball, not distro-pinned old versions).
+3. Persist PATH in `~/.bashrc` + `~/.profile` (ensure `sysbench`/`mysql`/`go` are directly runnable, include `/usr/local/go/bin` when present).
+4. Verify `tiup`/`tiup-cluster` availability.
+5. If `tiup` and `tiup-cluster` already exist, mark precondition as `[SKIP]` for tiup bootstrap.
+6. If missing, ensure `~/tiup` repo exists (`git clone https://github.com/pingcap/tiup.git` when absent).
+7. If `~/tiup/bin` is empty, run `go mod tidy` first, then run `make tiup cluster` in `~/tiup` to build required binaries (`tiup` + `tiup-cluster`) without full lint gate.
+8. After successful build, export `~/tiup/bin` into PATH immediately and persist it in `~/.bashrc` + `~/.profile`.
+9. Build TiDB binary and package `~/tidb/bin/tidb.tar.gz` (skip if package already exists).
+
+Do **not** install/configure MinIO in this skill.
+
+## Preflight checks
+
+Run preflight before benchmark:
+1. SSH reachable.
+2. `sysbench` exists remotely.
+3. Parse TiDB host/port from fixed topology yaml `references/tiup-router-cluster-template.yaml` (`tidb_servers`) unless user explicitly overrides.
+4. **Cluster readiness gate (must happen before mysql auth check):**
+   - Check whether TiDB is reachable at parsed host/port.
+   - If unreachable, deploy/start router cluster first (using fixed topology + `--skip-create-user`) and wait until TiDB port is ready.
+   - Only continue after readiness is `[OK]`.
+5. DB auth check with `mysql` command using parsed host/port.
+6. Patch gate: patch `~/tidb/bin/tidb.tar.gz` to cluster tidb before benchmark run.
+7. If `skip_prepare`, verify table count/range matches `--tables` expectation.
+
+If mismatch:
+- Suggest either adjusting `--tables` to existing table count,
+- or using fresh DB and `prepare_once`.
+
+## Execution model
+
+Use strict sequential controller logic.
+
+### Single round
+- Optional `prepare_once`.
+- Run one benchmark with given `threads`.
+- Never run cleanup unless explicitly requested.
+
+### Multi round
+- Optional `prepare_once` once before round loop.
+- For each round in order:
+  1. announce `Round i / N` with current threads
+  2. run benchmark
+  3. capture round summary (TPS/QPS, avg/p95/max latency, errors)
+  4. wait `wait_seconds_between_rounds` (except final round)
+
+Do not skip round index.
+
+## Long-running process handling
+
+Prefer remote background mode for long tests:
+- Start via `nohup ... > /tmp/<name>.log 2>&1 &`
+- Return PID and log file path.
+- Verify process exists with `pgrep -af`.
+- If local tool session hangs but remote process is gone, report clearly and offer restart.
+
+If user asks to stop:
+- kill the tracked process/session first,
+- confirm stopped,
+- then (only if asked) start a new run.
+
+## Error policy
+
+Handle and report clearly:
+- auth failure (`Access denied`)
+- table exists on prepare (1050)
+- missing tables on run (`sbtestNNN doesn't exist`)
+- TiDB retryable transaction errors (e.g., 8022 / TxnLockNotFound)
+
+When failing, propose one concrete next action and wait for user confirmation.
+
+## Output format
+
+For each completed round report:
+- Threads
+- TPS/QPS (final)
+- Latency avg/p95/max
+- Errors/Reconnects
+
+For multi-round, append final comparison table ordered by round/thread.

--- a/.openclaw/benchmark-router-cluster/references/tiup-router-cluster-template.yaml
+++ b/.openclaw/benchmark-router-cluster/references/tiup-router-cluster-template.yaml
@@ -1,0 +1,63 @@
+global:
+  user: "admin"
+  ssh_port: 22
+  deploy_dir: "/tidb-deploy"
+  data_dir: "/tidb-data"
+  pd_mode: "ms"
+
+server_configs:
+  pd:
+    replication.location-labels: ["zone", "dc", "host"]
+
+pd_servers:
+  - host: 127.0.0.1
+    client_port: 2379
+    peer_port: 2380
+
+tso_servers:
+  - host: 127.0.0.1
+    port: 2479
+
+router_servers:
+  - host: 127.0.0.1
+    port: 2579
+
+scheduling_servers:
+  - host: 127.0.0.1
+    port: 2679
+
+tidb_servers:
+  - host: 127.0.0.1
+    port: 4000
+    status_port: 40001
+
+tikv_servers:
+  - host: 127.0.0.1
+    port: 12800
+    status_port: 12801
+    config:
+      server.grpc-concurrency: 4
+      server.labels: { zone: "zone1", dc: "dc1", host: "host1" }
+  - host: 127.0.0.1
+    port: 12900
+    status_port: 12901
+    config:
+      server.grpc-concurrency: 4
+      server.labels: { zone: "zone1", dc: "dc1", host: "host2" }
+  - host: 127.0.0.1
+    port: 12700
+    status_port: 12701
+    config:
+      server.grpc-concurrency: 4
+      server.labels: { zone: "zone1", dc: "dc1", host: "host3" }
+
+monitoring_servers:
+  - host: 127.0.0.1
+    port: 3001
+
+grafana_servers:
+  - host: 127.0.0.1
+    port: 3000
+
+alertmanager_servers:
+  - host: 127.0.0.1

--- a/.openclaw/benchmark-router-cluster/scripts/prepare_router_cluster.sh
+++ b/.openclaw/benchmark-router-cluster/scripts/prepare_router_cluster.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Benchmark-router-cluster preflight bootstrap.
+# Installs runtime dependencies and bootstraps tiup/tiup-cluster only.
+# Intentionally excludes pd/tidb/tikv binary builds and MinIO setup.
+
+TARGET_HOST=""
+SSH_USER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-host) TARGET_HOST="$2"; shift 2 ;;
+    --ssh-user) SSH_USER="$2"; shift 2 ;;
+    *) echo "[FAIL] unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$TARGET_HOST" || -z "$SSH_USER" ]]; then
+  echo "[FAIL] missing required args: --target-host --ssh-user"
+  exit 1
+fi
+
+REMOTE="${SSH_USER}@${TARGET_HOST}"
+
+ok() { echo "[OK] $*"; }
+skip() { echo "[SKIP] $*"; }
+fail() { echo "[FAIL] $*"; exit 1; }
+run_remote() { ssh "$REMOTE" "$@"; }
+
+step() { echo "\n-- $* --"; }
+
+echo "== router cluster prepare(start): runtime + tiup bootstrap =="
+step "S1 SSH connectivity"
+if run_remote "hostname" >/tmp/router_prepare_host.out 2>/tmp/router_prepare_host.err; then
+  ok "S1 host reachable: $(tr -d '\n' </tmp/router_prepare_host.out)"
+else
+  fail "S1 ssh connectivity failed: $(cat /tmp/router_prepare_host.err)"
+fi
+
+step "S2 Runtime install + PATH + tiup bootstrap"
+run_remote 'bash -se' <<'EOS'
+set -euo pipefail
+ok(){ echo "[OK] $*"; }
+skip(){ echo "[SKIP] $*"; }
+fail(){ echo "[FAIL] $*"; exit 1; }
+sub(){ echo "   - $*"; }
+
+sub "S2.1 detect package manager"
+if command -v apt-get >/dev/null 2>&1; then
+  ok "S2.1 package manager: apt"
+  export DEBIAN_FRONTEND=noninteractive
+  sub "S2.2 apt update"
+  sudo apt-get update -y >/dev/null || fail "S2.2 apt update failed"
+  ok "S2.2 apt update done"
+  sub "S2.3 install runtime packages (sysbench/mysql-client/git/make/gcc/curl/tar)"
+  sudo apt-get install -y sysbench default-mysql-client git make gcc g++ curl tar >/dev/null || fail "S2.3 apt install failed"
+  ok "S2.3 runtime packages installed"
+elif command -v yum >/dev/null 2>&1; then
+  ok "S2.1 package manager: yum"
+  sub "S2.3 install runtime packages (sysbench/mysql/git/make/gcc/curl/tar)"
+  sudo yum install -y sysbench mysql git make gcc gcc-c++ curl tar >/dev/null || fail "S2.3 yum install failed"
+  ok "S2.3 runtime packages installed"
+else
+  skip "S2.1 unknown package manager; skip package install"
+fi
+
+sub "S2.4 install latest golang from go.dev"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) GOARCH="amd64" ;;
+  aarch64|arm64) GOARCH="arm64" ;;
+  *) fail "S2.4 unsupported architecture for Go install: $ARCH" ;;
+esac
+GO_VER="$(curl -fsSL https://go.dev/VERSION?m=text | head -n1)" || fail "S2.4 fetch latest go version failed"
+GO_TARBALL="${GO_VER}.linux-${GOARCH}.tar.gz"
+curl -fsSL "https://go.dev/dl/${GO_TARBALL}" -o "/tmp/${GO_TARBALL}" || fail "S2.4 download ${GO_TARBALL} failed"
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf "/tmp/${GO_TARBALL}" || fail "S2.4 extract go tarball failed"
+/usr/local/go/bin/go version >/dev/null || fail "S2.4 go install verification failed"
+export PATH="/usr/local/go/bin:$PATH"
+hash -r
+ok "S2.4 latest golang installed: $(go version)"
+
+sub "S2.5 persist PATH for runtime commands"
+export_line='export PATH="/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:$PATH"'
+touch ~/.bashrc ~/.profile
+grep -qF "$export_line" ~/.bashrc || echo "$export_line" >> ~/.bashrc
+grep -qF "$export_line" ~/.profile || echo "$export_line" >> ~/.profile
+ok "S2.5 PATH persisted to ~/.bashrc and ~/.profile"
+
+sub "S2.6 verify sysbench/mysql/go commands"
+bash -lc 'command -v sysbench >/dev/null && command -v mysql >/dev/null && command -v go >/dev/null' || fail "S2.6 command verify failed"
+ok "S2.6 sysbench/mysql/go available"
+
+sub "S2.7 verify tiup/tiup-cluster or bootstrap from ~/tiup"
+if command -v tiup >/dev/null 2>&1 && command -v tiup-cluster >/dev/null 2>&1; then
+  skip "S2.7 tiup and tiup-cluster already exist; skip tiup bootstrap"
+elif command -v tiup-cluster >/dev/null 2>&1; then
+  skip "S2.7 tiup-cluster already exists; skip tiup bootstrap"
+else
+  sub "S2.7.1 tiup-cluster missing; check/clone ~/tiup repo"
+  if [ -d ~/tiup/.git ]; then
+    (cd ~/tiup && git fetch --all --tags --prune >/dev/null) || fail "S2.7.1 fetch ~/tiup failed"
+    ok "S2.7.1 ~/tiup repo fetched"
+  else
+    rm -rf ~/tiup
+    git clone https://github.com/pingcap/tiup.git ~/tiup >/dev/null 2>&1 || fail "S2.7.1 clone ~/tiup failed"
+    ok "S2.7.1 ~/tiup repo cloned"
+  fi
+
+  sub "S2.7.2 build ~/tiup when ~/tiup/bin empty"
+  if [ -d ~/tiup/bin ] && [ "$(ls -A ~/tiup/bin 2>/dev/null | wc -l)" -gt 0 ]; then
+    skip "S2.7.2 ~/tiup/bin already non-empty"
+  else
+    sub "S2.7.2.1 run go mod tidy before make"
+    (cd ~/tiup && go mod tidy) || fail "S2.7.2.1 go mod tidy failed"
+    ok "S2.7.2.1 go mod tidy done"
+    (cd ~/tiup && make tiup cluster) || fail "S2.7.2 tiup targeted build failed (make tiup cluster)"
+    ok "S2.7.2 tiup and tiup-cluster built by make tiup cluster"
+  fi
+
+  sub "S2.7.3 export ~/tiup/bin PATH now + persist"
+  export PATH="$HOME/tiup/bin:$PATH"
+  export_line_tiup='export PATH="$HOME/tiup/bin:$PATH"'
+  grep -qF "$export_line_tiup" ~/.bashrc || echo "$export_line_tiup" >> ~/.bashrc
+  grep -qF "$export_line_tiup" ~/.profile || echo "$export_line_tiup" >> ~/.profile
+  command -v tiup-cluster >/dev/null || fail "S2.7.3 current shell tiup-cluster missing"
+  bash -lc 'command -v tiup-cluster >/dev/null' || fail "S2.7.3 login shell tiup-cluster missing"
+  ok "S2.7.3 tiup-cluster available and PATH persisted"
+fi
+EOS
+
+echo "== router cluster prepare(done): runtime + tiup bootstrap =="

--- a/.openclaw/benchmark-router-cluster/scripts/run_sysbench_controller.sh
+++ b/.openclaw/benchmark-router-cluster/scripts/run_sysbench_controller.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic sysbench runner for benchmark-router-cluster.
+# Resolves TiDB endpoint from topology yaml, then executes single or multi-round runs in strict order.
+
+usage() {
+  cat <<'EOF'
+Usage:
+  run_sysbench_controller.sh \
+    --topology-yaml /path/to/topology.yaml \
+    --workload oltp_read_write|oltp_point_select \
+    [--mysql-user root] [--mysql-password xxx] [--mysql-db sbtest] \
+    --time 300 --tables 100 --table-size 10000 \
+    (--threads 32 | --thread-list 16,32,64,128) \
+    [--prepare] [--wait-seconds 60] [--report-interval 30]
+
+Notes:
+- mysql host/port are auto-resolved from first tidb_servers entry in topology yaml.
+EOF
+}
+
+TOPOLOGY_YAML=""
+WORKLOAD="oltp_read_write"
+MYSQL_HOST=""
+MYSQL_PORT=""
+MYSQL_USER="root"
+MYSQL_PASSWORD=""
+MYSQL_DB="sbtest"
+TIME=""
+TABLES=""
+TABLE_SIZE=""
+THREADS=""
+THREAD_LIST=""
+DO_PREPARE=0
+WAIT_SECONDS=60
+REPORT_INTERVAL=30
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --topology-yaml) TOPOLOGY_YAML="$2"; shift 2 ;;
+    --workload) WORKLOAD="$2"; shift 2 ;;
+    --mysql-user) MYSQL_USER="$2"; shift 2 ;;
+    --mysql-password) MYSQL_PASSWORD="$2"; shift 2 ;;
+    --mysql-db) MYSQL_DB="$2"; shift 2 ;;
+    --time) TIME="$2"; shift 2 ;;
+    --tables) TABLES="$2"; shift 2 ;;
+    --table-size) TABLE_SIZE="$2"; shift 2 ;;
+    --threads) THREADS="$2"; shift 2 ;;
+    --thread-list) THREAD_LIST="$2"; shift 2 ;;
+    --prepare) DO_PREPARE=1; shift 1 ;;
+    --wait-seconds) WAIT_SECONDS="$2"; shift 2 ;;
+    --report-interval) REPORT_INTERVAL="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1"; usage; exit 1 ;;
+  esac
+done
+
+[[ -n "$TOPOLOGY_YAML" && -n "$TIME" && -n "$TABLES" && -n "$TABLE_SIZE" ]] || { usage; exit 1; }
+[[ -n "$THREADS" || -n "$THREAD_LIST" ]] || { echo "Need --threads or --thread-list"; exit 1; }
+[[ -f "$TOPOLOGY_YAML" ]] || { echo "Topology yaml not found: $TOPOLOGY_YAML"; exit 1; }
+
+# Resolve first tidb_servers host/port from topology yaml (simple parser for expected TiUP format)
+MYSQL_HOST="$(awk '
+  /tidb_servers:/ {in=1; next}
+  in && /^\S/ {in=0}
+  in && /host:/ {print $2; exit}
+' "$TOPOLOGY_YAML")"
+
+MYSQL_PORT="$(awk '
+  /tidb_servers:/ {in=1; next}
+  in && /^\S/ {in=0}
+  in && /port:/ {print $2; exit}
+' "$TOPOLOGY_YAML")"
+
+[[ -n "$MYSQL_HOST" && -n "$MYSQL_PORT" ]] || {
+  echo "Failed to parse tidb host/port from topology: $TOPOLOGY_YAML"; exit 1;
+}
+
+echo "== TOPOLOGY RESOLVED tidb=${MYSQL_HOST}:${MYSQL_PORT} =="
+
+BASE=(
+  --db-driver=mysql
+  --mysql-host="$MYSQL_HOST"
+  --mysql-port="$MYSQL_PORT"
+  --mysql-user="$MYSQL_USER"
+  --mysql-db="$MYSQL_DB"
+  --time="$TIME"
+  --tables="$TABLES"
+  --table-size="$TABLE_SIZE"
+)
+
+if [[ -n "$MYSQL_PASSWORD" ]]; then
+  BASE+=(--mysql-password="$MYSQL_PASSWORD")
+fi
+
+run_once() {
+  local t="$1"
+  echo "== ROUND threads=${t} START $(date '+%F %T') =="
+  sysbench "$WORKLOAD" "${BASE[@]}" --threads="$t" --report-interval="$REPORT_INTERVAL" run
+  echo "== ROUND threads=${t} DONE $(date '+%F %T') =="
+}
+
+if [[ "$DO_PREPARE" -eq 1 ]]; then
+  echo "== PREPARE START $(date '+%F %T') =="
+  sysbench "$WORKLOAD" "${BASE[@]}" prepare
+  echo "== PREPARE DONE $(date '+%F %T') =="
+fi
+
+if [[ -n "$THREADS" ]]; then
+  run_once "$THREADS"
+else
+  IFS=',' read -r -a arr <<< "$THREAD_LIST"
+  n=${#arr[@]}
+  for ((i=0; i<n; i++)); do
+    run_once "${arr[$i]}"
+    if (( i < n-1 )); then
+      echo "== WAIT ${WAIT_SECONDS}s =="
+      sleep "$WAIT_SECONDS"
+    fi
+  done
+fi
+
+echo "== ALL ROUNDS DONE $(date '+%F %T') =="


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10470

### What is changed and how does it work?

```commit-message
Add a benchmark-router-cluster skill that documents the controller workflow for
remote router/TiDB sysbench benchmarking. Add helper scripts for preparing the
remote environment and running deterministic single-round or multi-round
benchmarks using the repository's fixed router topology template.
```

### Check List

Tests

- Manual test (add detailed scripts or steps below)

Code changes

- Has the configuration change

Side effects

- Increased code complexity

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive benchmarking procedure guide including execution requirements, multi-round support, and error handling policies.

* **New Features**
  * Added cluster bootstrap tooling for remote environment setup with dependency installation and validation.
  * Added benchmark execution controller supporting single and multi-round runs with configurable thread sequences.
  * Added cluster configuration template for router topology setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->