### PR TITLE
tests: stabilize resource group controller timing

### DIFF
--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -822,12 +822,12 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupController() {
 				wreq := cas.tcs[i].makeWriteRequest()
 				rres := cas.tcs[i].makeReadResponse()
 				wres := cas.tcs[i].makeWriteResponse()
-				startTime := time.Now()
-				_, _, _, _, err := rgsController.OnRequestWait(suite.ctx, cas.resourceGroupName, rreq)
+				_, _, waitDuration, _, err := rgsController.OnRequestWait(suite.ctx, cas.resourceGroupName, rreq)
 				re.NoError(err)
-				_, _, _, _, err = rgsController.OnRequestWait(suite.ctx, cas.resourceGroupName, wreq)
+				sum += waitDuration
+				_, _, waitDuration, _, err = rgsController.OnRequestWait(suite.ctx, cas.resourceGroupName, wreq)
 				re.NoError(err)
-				sum += time.Since(startTime)
+				sum += waitDuration
 				_, err = rgsController.OnResponse(cas.resourceGroupName, rreq, rres)
 				re.NoError(err)
 				_, err = rgsController.OnResponse(cas.resourceGroupName, wreq, wres)
@@ -970,12 +970,12 @@ func (suite *resourceManagerClientTestSuite) TestSwitchBurst() {
 				wreq := cas.tcs[i].makeWriteRequest()
 				rres := cas.tcs[i].makeReadResponse()
 				wres := cas.tcs[i].makeWriteResponse()
-				startTime := time.Now()
-				_, _, _, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName, rreq)
+				_, _, waitDuration, _, err := controller.OnRequestWait(suite.ctx, resourceGroupName, rreq)
 				re.NoError(err)
-				_, _, _, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName, wreq)
+				sum += waitDuration
+				_, _, waitDuration, _, err = controller.OnRequestWait(suite.ctx, resourceGroupName, wreq)
 				re.NoError(err)
-				sum += time.Since(startTime)
+				sum += waitDuration
 				_, err = controller.OnResponse(resourceGroupName, rreq, rres)
 				re.NoError(err)
 				_, err = controller.OnResponse(resourceGroupName, wreq, wres)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8512

### What is changed and how does it work?

Summary

- use the exact wait duration returned by OnRequestWait in the resource manager integration assertions
- stop accumulating outer wall-clock time that includes etcd and leader-transfer noise

Root-cause evidence

- issue #8512 and a later reproduction comment both show failures around 492-499ms > 300ms while the test only intends to bound controller wait time
- TestResourceGroupController was summing time.Since(startTime) around two OnRequestWait calls, so unrelated scheduling and cluster delays were counted
- commit 259435d93 (#7488) already changed OnRequestWait to return total wait duration, but this test continued to assert on wall-clock time

Historical analog

- matches the flaky-fix playbook timing/assertion stabilization pattern
- closest repo precedent: 259435d93 `client: return total wait duration in resource interceptor OnRequestWait call (#7488)`

Fix

- accumulate the returned waitDuration from each OnRequestWait call in TestResourceGroupController
- apply the same correction to the analogous skipped TestSwitchBurst path to keep the suite consistent

Risk

- test-only change; production logic is unchanged
- the assertion now matches the API contract rather than host scheduling noise

Verification

- `cd tests/integrations && go test -tags without_dashboard ./mcs/resourcemanager -run TestResourceManagerClientTestSuite/pd-resource-manager -testify.m '^TestResourceGroupController$' -count=3 -v`
  - PASS
- root `make basic-test` is not a valid coverage gate for this change because the repo Makefile filters out `tests%` packages from `BASIC_TEST_PKGS`

### Check List


### Release note

```release-note
None.
```
