### PR TITLE
core, server, scheduling: refactor bucket report CAS logic into RegionInfo

### DIFF
--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -108,6 +108,23 @@ var (
 	queryRegionKeysCount     = queryRegionCount.WithLabelValues("keys")
 	queryRegionPrevKeysCount = queryRegionCount.WithLabelValues("prev-keys")
 	queryRegionIDsCount      = queryRegionCount.WithLabelValues("ids")
+
+	bucketEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "cluster",
+			Name:      "bucket_event",
+			Help:      "Counter of the bucket event",
+		}, []string{"event"})
+
+	versionStaleCounter     = bucketEventCounter.WithLabelValues("version_stale")
+	versionNotChangeCounter = bucketEventCounter.WithLabelValues("version_no_change")
+	// RegionCacheMissCounter  is the counter of region cache miss when processing report bucket.
+	RegionCacheMissCounter = bucketEventCounter.WithLabelValues("region_cache_miss")
+	// UpdateFailedCounter is the counter of region bucket update failed when processing report bucket.
+	UpdateFailedCounter = bucketEventCounter.WithLabelValues("update_failed")
+	// UpdateSuccessCounter is the counter of cas report bucket point success.
+	UpdateSuccessCounter = bucketEventCounter.WithLabelValues("update_success")
 )
 
 func init() {
@@ -117,6 +134,7 @@ func init() {
 	prometheus.MustRegister(AcquireRegionsLockWaitCount)
 	prometheus.MustRegister(queryRegionDuration)
 	prometheus.MustRegister(queryRegionCount)
+	prometheus.MustRegister(bucketEventCounter)
 }
 
 var tracerPool = &sync.Pool{

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -86,9 +86,9 @@ type RegionInfo struct {
 	replicationStatus         *replication_modepb.RegionReplicationStatus
 	queryStats                *pdpb.QueryStats
 	flowRoundDivisor          uint64
-	// buckets is not thread unsafe, it should be accessed by the request `report buckets` with greater version.
+	// reportBuckets is not thread unsafe, it should be accessed by the request `report reportBuckets` with greater version.
 	// todo: keep it compatible with previous design, we can remove it later.
-	buckets unsafe.Pointer
+	reportBuckets unsafe.Pointer
 	// source is used to indicate region's source, such as Storage/Sync/Heartbeat.
 	source RegionSource
 	// ref is used to indicate the reference count of the region in root-tree and sub-tree.
@@ -304,10 +304,9 @@ func (r *RegionInfo) Inherit(origin *RegionInfo, bucketEnable bool) {
 			r.approximateSize = EmptyRegionApproximateSize
 		}
 	}
-	// skip bucket meta update if tikv has report bucket meta.
-	if bucket := r.GetBuckets(); bucketEnable && bucket == nil && origin != nil {
-		inherited := atomic.LoadPointer(&origin.buckets)
-		atomic.StorePointer(&r.buckets, inherited)
+	if bucketEnable && origin != nil && atomic.LoadPointer(&r.reportBuckets) == nil {
+		inherited := atomic.LoadPointer(&origin.reportBuckets)
+		atomic.StorePointer(&r.reportBuckets, inherited)
 	}
 }
 
@@ -339,7 +338,7 @@ func (r *RegionInfo) Clone(opts ...RegionCreateOption) *RegionInfo {
 		approximateKeys:           r.approximateKeys,
 		interval:                  typeutil.DeepClone(r.interval, TimeIntervalFactory),
 		replicationStatus:         r.replicationStatus,
-		buckets:                   r.buckets,
+		reportBuckets:             atomic.LoadPointer(&r.reportBuckets),
 		queryStats:                typeutil.DeepClone(r.queryStats, QueryStatsFactory),
 		bucketMeta:                r.bucketMeta,
 	}
@@ -633,18 +632,10 @@ func (r *RegionInfo) GetStat() *pdpb.RegionStat {
 	}
 }
 
-// SetBucketMeta sets the bucket meta of the region, used by region sync.
-func (r *RegionInfo) SetBucketMeta(buckets *metapb.Buckets) {
-	r.bucketMeta = &metapb.BucketMeta{
-		Version: buckets.GetVersion(),
-		Keys:    buckets.GetKeys(),
-	}
-}
-
-// UpdateBuckets sets the buckets of the region, used by bucket report.
+// UpdateBuckets sets the buckets of the region, only use by tests.
 func (r *RegionInfo) UpdateBuckets(buckets, old *metapb.Buckets) bool {
 	if buckets == nil {
-		atomic.StorePointer(&r.buckets, nil)
+		atomic.StorePointer(&r.reportBuckets, nil)
 		return true
 	}
 	// only need to update bucket keys, versions.
@@ -653,7 +644,32 @@ func (r *RegionInfo) UpdateBuckets(buckets, old *metapb.Buckets) bool {
 		Version:  buckets.GetVersion(),
 		Keys:     buckets.GetKeys(),
 	}
-	return atomic.CompareAndSwapPointer(&r.buckets, unsafe.Pointer(old), unsafe.Pointer(newBuckets))
+	return atomic.CompareAndSwapPointer(&r.reportBuckets, unsafe.Pointer(old), unsafe.Pointer(newBuckets))
+}
+
+// GetReportBuckets returns the buckets of the region, only use by tests.
+func (r *RegionInfo) GetReportBuckets() *metapb.Buckets {
+	return (*metapb.Buckets)(atomic.LoadPointer(&r.reportBuckets))
+}
+
+// CompareAndSetReportBuckets compares and sets the report buckets of the region.
+func (r *RegionInfo) CompareAndSetReportBuckets(buckets *metapb.Buckets) bool {
+	old := (*metapb.Buckets)(atomic.LoadPointer(&r.reportBuckets))
+	// region should not update if the version of the buckets is less than the old one.
+	if old != nil {
+		reportVersion := buckets.GetVersion()
+		if reportVersion < old.GetVersion() {
+			versionStaleCounter.Inc()
+			return true
+		} else if reportVersion == old.GetVersion() {
+			versionNotChangeCounter.Inc()
+			return true
+		}
+	}
+	failpoint.Inject("concurrentBucketHeartbeat", func() {
+		time.Sleep(500 * time.Millisecond)
+	})
+	return atomic.CompareAndSwapPointer(&r.reportBuckets, unsafe.Pointer(old), unsafe.Pointer(buckets))
 }
 
 // GetBuckets returns the buckets of the region.
@@ -668,7 +684,7 @@ func (r *RegionInfo) GetBuckets() *metapb.Buckets {
 			Keys:     meta.GetKeys(),
 		}
 	}
-	buckets := atomic.LoadPointer(&r.buckets)
+	buckets := atomic.LoadPointer(&r.reportBuckets)
 	return (*metapb.Buckets)(buckets)
 }
 

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
@@ -279,6 +280,28 @@ func TestInherit(t *testing.T) {
 			re.NotEqual(d.originBuckets, newRegion.GetBuckets())
 		}
 	}
+
+	origin := NewRegionInfo(&metapb.Region{Id: 100}, nil, SetBuckets(&metapb.Buckets{
+		Version: 2,
+		Keys:    [][]byte{{'a'}, {'b'}},
+	}))
+	origin.reportBuckets = unsafe.Pointer(&metapb.Buckets{
+		Version: 1,
+		Keys:    [][]byte{{'a'}, {'b'}},
+	})
+
+	// region hasn't bucket meta, report buckets should be inherited.
+	new := NewRegionInfo(&metapb.Region{Id: 100}, nil)
+	new.Inherit(origin, true)
+	re.Equal(uint64(1), new.GetReportBuckets().Version)
+
+	// region has bucket meta, report buckets should be inherited also.
+	new1 := NewRegionInfo(&metapb.Region{Id: 100}, nil, SetBuckets(&metapb.Buckets{
+		Version: 2,
+		Keys:    [][]byte{{'a'}, {'b'}},
+	}))
+	new1.Inherit(origin, true)
+	re.Equal(uint64(1), new1.GetReportBuckets().Version)
 }
 
 func TestRegionRoundingFlow(t *testing.T) {

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -809,20 +809,7 @@ func (c *Cluster) processRegionBuckets(buckets *metapb.Buckets) error {
 	// the A will pass the check and set the version to 3, the B will fail because the region.bucket has changed.
 	// the retry should keep the old version and the new version will be set to the region.bucket, like two requests (A:2,B:3).
 	for range 3 {
-		old := region.GetBuckets()
-		// region should not update if the version of the buckets is less than the old one.
-		if old != nil {
-			reportVersion := buckets.GetVersion()
-			if reportVersion < old.GetVersion() {
-				return nil
-			} else if reportVersion == old.GetVersion() {
-				return nil
-			}
-		}
-		failpoint.Inject("concurrentBucketHeartbeat", func() {
-			time.Sleep(500 * time.Millisecond)
-		})
-		if ok := region.UpdateBuckets(buckets, old); ok {
+		if success := region.CompareAndSetReportBuckets(buckets); success {
 			return nil
 		}
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -86,11 +86,6 @@ var (
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	regionUpdateCacheEventCounter = regionEventCounter.WithLabelValues("update_cache")
 	regionUpdateKVEventCounter    = regionEventCounter.WithLabelValues("update_kv")
-	regionCacheMissCounter        = bucketEventCounter.WithLabelValues("region_cache_miss")
-	versionStaleCounter           = bucketEventCounter.WithLabelValues("version_stale")
-	versionNotChangeCounter       = bucketEventCounter.WithLabelValues("version_no_change")
-	updateFailedCounter           = bucketEventCounter.WithLabelValues("update_failed")
-	updateSuccessCounter          = bucketEventCounter.WithLabelValues("update_success")
 )
 
 const (
@@ -1182,7 +1177,7 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) error {
 	region := c.GetRegion(buckets.GetRegionId())
 	if region == nil {
-		regionCacheMissCounter.Inc()
+		core.RegionCacheMissCounter.Inc()
 		return errors.Errorf("region %v not found", buckets.GetRegionId())
 	}
 	// use CAS to update the bucket information.
@@ -1190,27 +1185,12 @@ func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) error {
 	// the A will pass the check and set the version to 3, the B will fail because the region.bucket has changed.
 	// the retry should keep the old version and the new version will be set to the region.bucket, like two requests (A:2,B:3).
 	for range 3 {
-		old := region.GetBuckets()
-		// region should not update if the version of the buckets is less than the old one.
-		if old != nil {
-			reportVersion := buckets.GetVersion()
-			if reportVersion < old.GetVersion() {
-				versionStaleCounter.Inc()
-				return nil
-			} else if reportVersion == old.GetVersion() {
-				versionNotChangeCounter.Inc()
-				return nil
-			}
-		}
-		failpoint.Inject("concurrentBucketHeartbeat", func() {
-			time.Sleep(500 * time.Millisecond)
-		})
-		if ok := region.UpdateBuckets(buckets, old); ok {
-			updateSuccessCounter.Inc()
+		if success := region.CompareAndSetReportBuckets(buckets); success {
+			core.UpdateSuccessCounter.Inc()
 			return nil
 		}
 	}
-	updateFailedCounter.Inc()
+	core.UpdateFailedCounter.Inc()
 	return nil
 }
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -742,6 +742,24 @@ func TestBucketCompatibility(t *testing.T) {
 	region3 := region2.Clone(core.WithIncVersion())
 	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), region3))
 	re.Equal(bucket2, cluster.GetRegion(1).GetBuckets())
+
+	// tikv upgrade, send region heartbeat with bucket meta and report bucket stream enabled
+	bucket3 := &metapb.Buckets{
+		RegionId: 1,
+		Version:  4,
+		Keys:     [][]byte{{'a'}, {'e'}},
+	}
+	region4 := region3.Clone(core.WithIncVersion(), core.SetBuckets(bucket3))
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), region4))
+	re.Equal(bucket3, cluster.GetRegion(1).GetBuckets())
+	bucket4 := &metapb.Buckets{
+		RegionId: 1,
+		Version:  5,
+		Keys:     [][]byte{{'a'}, {'e'}},
+	}
+	re.NoError(cluster.processRegionBuckets(bucket4))
+	re.Equal(bucket3, cluster.GetRegion(1).GetBuckets())
+	re.Equal(bucket4, cluster.GetRegion(1).GetReportBuckets())
 }
 
 func TestStaleBucketMeta(t *testing.T) {
@@ -777,7 +795,7 @@ func TestStaleBucketMeta(t *testing.T) {
 	bucket2 := &metapb.Buckets{
 		RegionId: 1,
 		Version:  3,
-		Keys:     [][]byte{{'a'}, {'d'}},
+		Keys:     [][]byte{{'c'}, {'d'}},
 	}
 	region2 := newRegion.Clone(core.WithIncVersion(), core.SetBuckets(bucket2))
 	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), region2))
@@ -1257,14 +1275,14 @@ func TestConcurrentReportBucket(t *testing.T) {
 	bucket2 := &metapb.Buckets{RegionId: 1, Version: 2}
 	var wg sync.WaitGroup
 	wg.Add(1)
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/concurrentBucketHeartbeat", "return(true)"))
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/core/concurrentBucketHeartbeat", "return(true)"))
 	go func() {
 		defer wg.Done()
 		err := cluster.processRegionBuckets(bucket1)
 		re.NoError(err)
 	}()
 	time.Sleep(100 * time.Millisecond)
-	re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/concurrentBucketHeartbeat"))
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/core/concurrentBucketHeartbeat"))
 	re.NoError(cluster.processRegionBuckets(bucket2))
 	wg.Wait()
 	re.Equal(bucket1, cluster.GetRegion(1).GetBuckets())

--- a/server/cluster/metrics.go
+++ b/server/cluster/metrics.go
@@ -33,14 +33,6 @@ var (
 			Help:      "Counter of the region event",
 		}, []string{"event"})
 
-	bucketEventCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "pd",
-			Subsystem: "cluster",
-			Name:      "bucket_event",
-			Help:      "Counter of the bucket event",
-		}, []string{"event"})
-
 	updateStoreStatsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
@@ -86,7 +78,6 @@ func init() {
 	prometheus.MustRegister(healthStatusGauge)
 	prometheus.MustRegister(clusterStateCPUGauge)
 	prometheus.MustRegister(clusterStateCurrent)
-	prometheus.MustRegister(bucketEventCounter)
 	prometheus.MustRegister(storeSyncConfigEvent)
 	prometheus.MustRegister(updateStoreStatsGauge)
 	prometheus.MustRegister(storeTriggerNetworkSlowEvict)

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -705,7 +705,7 @@ func InitRegions(regionLen int) []*core.RegionInfo {
 				Version:  1,
 			}
 			region := core.NewRegionInfo(r, r.Peers[0], core.SetSource(core.Heartbeat), core.SetBuckets(buckets))
-			region.UpdateBuckets(buckets, nil)
+			region.UpdateBuckets(buckets, region.GetBuckets())
 			regions = append(regions, region)
 		} else {
 			region := core.NewRegionInfo(r, r.Peers[0], core.SetSource(core.Heartbeat))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10308
Ref: https://github.com/tikv/pd/pull/10302
### What is changed and how does it work?

```commit-message
Refactor the bucket report CAS (compare-and-swap) logic from
server/cluster and mcs/scheduling into RegionInfo.CompareAndSetReportBuckets.

Previously, the CAS for report buckets used GetBuckets() which returns
bucketMeta (from region heartbeat) when reportBuckets is nil. This caused
CAS to always fail when bucket meta existed because the old pointer didn't
match. This PR:

- Renames the internal `buckets` field to `reportBuckets` for clarity.
- Introduces CompareAndSetReportBuckets on RegionInfo that encapsulates
  the version check and atomic CAS using the reportBuckets pointer directly.
- Moves bucket event metrics (version_stale, version_no_change,
  update_failed, update_success, region_cache_miss) from server/cluster
  to pkg/core so they can be used by both server/cluster and
  mcs/scheduling.
- Fixes Inherit to always inherit reportBuckets from origin regardless
  of whether the new region already has bucketMeta.
- Adds tests for the new behavior.
```

### Check List

Tests

- Unit test

Code changes

Side effects

- Possible performance regression

### Release note

```release-note
Fix report bucket CAS logic to work correctly when region bucket meta exists.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new metrics for monitoring bucket events: region cache misses, successful updates, and failed updates.

* **Bug Fixes**
  * Improved bucket update reliability through refined concurrency handling mechanisms.

* **Tests**
  * Extended test coverage for bucket compatibility and concurrent update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->