### PR TITLE
member: add leader priority metric

### DIFF
--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -287,7 +287,7 @@ func (m *Member) CheckPriority(ctx context.Context) {
 		return
 	}
 	// Record leader priority for current instance.
-	memberLeaderPriorityGauge.WithLabelValues(m.Name()).Set(float64(myPriority))
+	memberLeaderPriorityGauge.WithLabelValues().Set(float64(myPriority))
 
 	etcdLeader := m.GetEtcdLeader()
 	if etcdLeader == m.ID() || etcdLeader == 0 {

--- a/pkg/member/metrics.go
+++ b/pkg/member/metrics.go
@@ -32,7 +32,7 @@ var (
 			Subsystem: "server",
 			Name:      "member_leader_priority",
 			Help:      "Etcd leader priority of this PD instance.",
-		}, []string{"instance"})
+		}, []string{})
 )
 
 func init() {

--- a/tests/server/member_leader_priority_metrics_test.go
+++ b/tests/server/member_leader_priority_metrics_test.go
@@ -40,21 +40,16 @@ func TestMemberLeaderPriorityMetrics(t *testing.T) {
 	re.NoError(leaderServer.BootstrapCluster())
 
 	s := leaderServer.GetServer()
-	instance := s.GetMemberInfo().GetName()
 
 	s.GetMember().CheckPriority(ctx)
-	val, ok := getGaugeValue(re, "pd_server_member_leader_priority", map[string]string{
-		"instance": instance,
-	})
+	val, ok := getGaugeValue(re, "pd_server_member_leader_priority", nil)
 	re.True(ok)
 	re.Equal(0.0, val)
 
 	re.NoError(s.GetMember().SetMemberLeaderPriority(s.GetMemberInfo().GetMemberId(), 42))
 	s.GetMember().CheckPriority(ctx)
 
-	val, ok = getGaugeValue(re, "pd_server_member_leader_priority", map[string]string{
-		"instance": instance,
-	})
+	val, ok = getGaugeValue(re, "pd_server_member_leader_priority", nil)
 	re.True(ok)
 	re.Equal(42.0, val)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10515

### What is changed and how does it work?

```commit-message
Add a Prometheus gauge to expose the current PD member's leader priority.
Update CheckPriority to record the local member priority before evaluating whether leadership should move.
Add a UT that verifies the metric is exported with the default value and updated after changing the member leader priority.
```



### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

[x] Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
Add the `pd_server_member_leader_priority` metric to expose the current PD member's leader priority.
```


