### PR TITLE
resource_group: add server-side allocation metrics for Resource Manager

### DIFF
--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -252,6 +252,9 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 					if tokens == nil {
 						continue
 					}
+					if keyspaceName, err := s.manager.getKeyspaceNameByID(s.ctx, keyspaceID); err == nil {
+						observeTokenGrant(rg.Name, keyspaceName, tokens)
+					}
 					resp.GrantedRUTokens = append(resp.GrantedRUTokens, tokens)
 				}
 			case rmpb.GroupMode_RawMode:

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -789,11 +789,20 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 					groupName := group.Name
 					// Record the sum of RRU and WRU every second.
 					m.metrics.getMaxPerSecTracker(krgm.keyspaceID, keyspaceName, groupName).flushMetrics()
-					metrics := m.metrics.getGaugeMetrics(krgm.keyspaceID, keyspaceName, groupName)
-					metrics.setGroup(group, keyspaceName)
+					gaugeM := m.metrics.getGaugeMetrics(krgm.keyspaceID, keyspaceName, groupName)
+					gaugeM.setGroup(group, keyspaceName)
 					// Record the tracked RU per second.
 					if grt := krgm.getGroupRUTracker(groupName); grt != nil {
-						metrics.setSampledRUPerSec(grt.getRUPerSec())
+						gaugeM.setSampledRUPerSec(grt.getRUPerSec())
+					}
+					// Record slot metrics (active count, loan, events).
+					sm := group.GetSlotMetrics()
+					gaugeM.activeSlotCountGauge.Set(float64(sm.SlotCount))
+					gaugeM.tokenLoanGauge.Set(sm.TokenLoan)
+					if created, deleted, expired := group.DrainSlotEvents(); created+deleted+expired > 0 {
+						gaugeM.slotCreatedCounter.Add(float64(created))
+						gaugeM.slotDeletedCounter.Add(float64(deleted))
+						gaugeM.slotExpiredCounter.Add(float64(expired))
 					}
 				}
 			}

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -211,6 +211,48 @@ var (
 			Name:      "service_limit",
 			Help:      "Gauge of the total RU limit of specific keyspace.",
 		}, []string{keyspaceNameLabel})
+
+	grantedTokensHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "granted_tokens",
+			Help:      "Histogram of tokens granted per token bucket request.",
+			Buckets:   []float64{0, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000},
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+
+	activeSlotCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "active_slot_count",
+			Help:      "Number of active token slots per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+
+	slotEventsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "slot_events_total",
+			Help:      "Counter of slot lifecycle events (created, deleted, expired).",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel, "event"})
+
+	tokenLoanGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "token_loan",
+			Help:      "Current total token loan amount (negative tokens in slots) per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+
+	trickleDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "trickle_duration_ms",
+			Help:      "Histogram of trickle duration in milliseconds per token grant.",
+			Buckets:   []float64{0, 100, 500, 1000, 2000, 3000, 4000, 5000, 10000},
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
 )
 
 type metrics struct {
@@ -264,6 +306,11 @@ func init() {
 	prometheus.MustRegister(sampledRequestUnitPerSec)
 	prometheus.MustRegister(overrideSettings)
 	prometheus.MustRegister(serviceLimit)
+	prometheus.MustRegister(grantedTokensHistogram)
+	prometheus.MustRegister(activeSlotCountGauge)
+	prometheus.MustRegister(slotEventsCounter)
+	prometheus.MustRegister(tokenLoanGauge)
+	prometheus.MustRegister(trickleDurationHistogram)
 }
 
 func newMetrics() *metrics {
@@ -470,6 +517,13 @@ type gaugeMetrics struct {
 	sampledRequestUnitPerSecGauge      prometheus.Gauge
 	overrideFillRateGauge              prometheus.Gauge
 	overrideBurstLimitGauge            prometheus.Gauge
+	grantedTokensObserver              prometheus.Observer
+	activeSlotCountGauge               prometheus.Gauge
+	slotCreatedCounter                 prometheus.Counter
+	slotDeletedCounter                 prometheus.Counter
+	slotExpiredCounter                 prometheus.Counter
+	tokenLoanGauge                     prometheus.Gauge
+	trickleDurationObserver            prometheus.Observer
 }
 
 func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
@@ -481,6 +535,13 @@ func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 		sampledRequestUnitPerSecGauge:      sampledRequestUnitPerSec.WithLabelValues(groupName, keyspaceName),
 		overrideFillRateGauge:              overrideSettings.WithLabelValues(groupName, keyspaceName, fillRateLabel),
 		overrideBurstLimitGauge:            overrideSettings.WithLabelValues(groupName, keyspaceName, burstLimitLabel),
+		grantedTokensObserver:              grantedTokensHistogram.WithLabelValues(groupName, keyspaceName),
+		activeSlotCountGauge:               activeSlotCountGauge.WithLabelValues(groupName, keyspaceName),
+		slotCreatedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "created"),
+		slotDeletedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "deleted"),
+		slotExpiredCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "expired"),
+		tokenLoanGauge:                     tokenLoanGauge.WithLabelValues(groupName, keyspaceName),
+		trickleDurationObserver:            trickleDurationHistogram.WithLabelValues(groupName, keyspaceName),
 	}
 }
 
@@ -543,6 +604,26 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, fillRateLabel)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)
 	resourceGroupConfigGauge.DeletePartialMatch(prometheus.Labels{newResourceGroupNameLabel: groupName, keyspaceNameLabel: keyspaceName})
+	grantedTokensHistogram.DeleteLabelValues(groupName, keyspaceName)
+	activeSlotCountGauge.DeleteLabelValues(groupName, keyspaceName)
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "created")
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "deleted")
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "expired")
+	tokenLoanGauge.DeleteLabelValues(groupName, keyspaceName)
+	trickleDurationHistogram.DeleteLabelValues(groupName, keyspaceName)
+}
+
+// observeTokenGrant records granted tokens and trickle duration metrics.
+// It uses global Prometheus metric vectors directly (concurrency-safe) instead
+// of the cached gaugeMetrics map to avoid race conditions from gRPC goroutines.
+func observeTokenGrant(groupName, keyspaceName string, tokens *rmpb.GrantedRUTokenBucket) {
+	if tokens == nil {
+		return
+	}
+	grantedTokensHistogram.WithLabelValues(groupName, keyspaceName).Observe(tokens.GrantedTokens.GetTokens())
+	if tokens.TrickleTimeMs > 0 {
+		trickleDurationHistogram.WithLabelValues(groupName, keyspaceName).Observe(float64(tokens.TrickleTimeMs))
+	}
 }
 
 type maxPerSecCostTracker struct {

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -198,6 +198,47 @@ func (rg *ResourceGroup) overrideFillRateAndBurstLimit(fillRate float64, burstLi
 	rg.overrideBurstLimitLocked(burstLimit)
 }
 
+// SlotMetrics holds snapshot data of token slot state for metrics reporting.
+type SlotMetrics struct {
+	SlotCount int
+	TokenLoan float64
+}
+
+// GetSlotMetrics returns a snapshot of the token slot metrics under the group lock.
+func (rg *ResourceGroup) GetSlotMetrics() SlotMetrics {
+	rg.RLock()
+	defer rg.RUnlock()
+	if rg.RUSettings == nil || rg.RUSettings.RU == nil {
+		return SlotMetrics{}
+	}
+	var loan float64
+	for _, slot := range rg.RUSettings.RU.tokenSlots {
+		if slot.curTokenCapacity < 0 {
+			loan += -slot.curTokenCapacity
+		}
+	}
+	return SlotMetrics{
+		SlotCount: len(rg.RUSettings.RU.tokenSlots),
+		TokenLoan: loan,
+	}
+}
+
+// DrainSlotEvents returns the accumulated slot event counts and resets them.
+func (rg *ResourceGroup) DrainSlotEvents() (created, deleted, expired uint64) {
+	rg.Lock()
+	defer rg.Unlock()
+	if rg.RUSettings == nil || rg.RUSettings.RU == nil {
+		return 0, 0, 0
+	}
+	created = rg.RUSettings.RU.slotsCreated
+	deleted = rg.RUSettings.RU.slotsDeleted
+	expired = rg.RUSettings.RU.slotsExpired
+	rg.RUSettings.RU.slotsCreated = 0
+	rg.RUSettings.RU.slotsDeleted = 0
+	rg.RUSettings.RU.slotsExpired = 0
+	return
+}
+
 // PatchSettings patches the resource group settings.
 // Only used to patch the resource group when updating.
 // Note: the tokens is the delta value to patch.

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -195,6 +195,12 @@ type GroupTokenBucketState struct {
 
 	// settingChanged is used to avoid that the number of tokens returned is jitter because of changing fill rate.
 	settingChanged bool
+
+	// Slot event accumulators for metrics reporting.
+	// These are incremented in balanceSlotTokens() and read+reset in backgroundMetricsFlush().
+	slotsCreated uint64
+	slotsDeleted uint64
+	slotsExpired uint64
 }
 
 func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
@@ -242,6 +248,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		// Create a new slot if the slot is not exist and the required token is not 0.
 		slot = newTokenSlot(clientUniqueID, now)
 		gtb.tokenSlots[clientUniqueID] = slot
+		gtb.slotsCreated++
 		log.Debug("create resource group slot",
 			zap.String("resource-group-name", gtb.resourceGroupName),
 			zap.Uint64("client-unique-id", clientUniqueID),
@@ -254,6 +261,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 	} else if requiredToken == 0 {
 		// Clean up the slot that required 0.
 		if exist {
+			gtb.slotsDeleted++
 			log.Debug("delete resource group slot because required token is 0",
 				zap.String("resource-group-name", gtb.resourceGroupName),
 				zap.Uint64("client-unique-id", clientUniqueID),
@@ -266,6 +274,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 	for clientUniqueID, slot := range gtb.tokenSlots {
 		if time.Since(slot.lastReqTime) >= slotExpireTimeout {
 			delete(gtb.tokenSlots, clientUniqueID)
+			gtb.slotsExpired++
 			log.Info("delete resource group slot because expire",
 				zap.Time("last-req-time", slot.lastReqTime),
 				zap.Duration("expire-timeout", slotExpireTimeout),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10488

### What is changed and how does it work?

This is **Phase 2** of the Resource Control observability improvements. It adds server-side metrics to the Resource Manager (`pkg/mcs/resourcemanager/server/`) for visibility into token allocation decisions, slot lifecycle, loan state, and trickle behavior.

#### Changes:

**B2 — Granted tokens histogram**
- `resource_manager_server_granted_tokens` — histogram of tokens granted per token bucket request
- Observed in `AcquireTokenBuckets` gRPC handler after each successful token grant

**B3 — Slot lifecycle metrics**
- `resource_manager_server_active_slot_count` — gauge of active client slots per resource group
- `resource_manager_server_slot_events_total` — counter of slot events (created/deleted/expired)
- Slot events accumulated via `slotsCreated`/`slotsDeleted`/`slotsExpired` fields in `GroupTokenBucketState`, drained in 1Hz `backgroundMetricsFlush`
- Active count read via thread-safe `GetSlotMetrics()` accessor

**B4 — Token loan + trickle duration**
- `resource_manager_server_token_loan` — gauge of total loan (negative tokens in slots) per group
- `resource_manager_server_trickle_duration_ms` — histogram of trickle duration per grant
- Loan observed in 1Hz tick; trickle duration observed in gRPC handler

All new gauge metrics follow the existing `gaugeMetrics` caching pattern (pre-resolved `WithLabelValues`). Cleanup handled in `deleteLabelValues`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Existing tests verified (1 pre-existing failure: TestCleanUpTicker, confirmed on master)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded observability: added metrics for granted token amounts, trickle durations, active slot counts, token loans, and slot lifecycle events (created/deleted/expired).
  * Per-resource-group/keyspace metric tracking and automatic cleanup when groups/keyspaces are removed.
  * Resource group snapshot and event-drain capabilities to surface slot counts, token loan totals, and recent slot events for reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->