### PR TITLE
scheduler: add store-level hot direction metric

### DIFF
--- a/pkg/schedule/schedulers/hot_region_solver.go
+++ b/pkg/schedule/schedulers/hot_region_solver.go
@@ -73,6 +73,8 @@ type balanceSolver struct {
 	rank
 }
 
+var hotStoreDirectionLabels = [...]string{"out", "in", "out-for-revert", "in-for-revert"}
+
 func (bs *balanceSolver) init() {
 	// Load the configuration items of the scheduler.
 	bs.resourceTy = toResourceType(bs.rwTy, bs.opTy)
@@ -106,6 +108,7 @@ func (bs *balanceSolver) init() {
 		bs.nthHotPeer[detail.GetID()] = make([]*statistics.HotPeerStat, utils.DimLen)
 		bs.filteredHotPeers[detail.GetID()] = bs.filterHotPeers(detail)
 	}
+	bs.preWarmHotStoreDirectionCounters()
 
 	rankStepRatios := []float64{
 		utils.ByteDim:  bs.sche.conf.getByteRankStepRatio(),
@@ -118,6 +121,16 @@ func (bs *balanceSolver) init() {
 	bs.rankStep = &statistics.StoreLoad{
 		Loads:        stepLoads,
 		HotPeerCount: maxCur.HotPeerCount * bs.sche.conf.getCountRankStepRatio(),
+	}
+}
+
+func (bs *balanceSolver) preWarmHotStoreDirectionCounters() {
+	rwLabel := bs.rwTy.String()
+	for storeID := range bs.stLoadDetail {
+		storeLabel := strconv.FormatUint(storeID, 10)
+		for _, direction := range hotStoreDirectionLabels {
+			hotStoreDirectionCounter.WithLabelValues(rwLabel, storeLabel, direction).Add(0)
+		}
 	}
 }
 
@@ -1097,6 +1110,8 @@ func (bs *balanceSolver) decorateOperator(op *operator.Operator, isRevert bool, 
 	op.FinishedCounters = append(op.FinishedCounters,
 		hotDirectionCounter.WithLabelValues(typ, bs.rwTy.String(), sourceLabel, "out", dim),
 		hotDirectionCounter.WithLabelValues(typ, bs.rwTy.String(), targetLabel, "in", dim),
+		hotStoreDirectionCounter.WithLabelValues(bs.rwTy.String(), sourceLabel, "out"),
+		hotStoreDirectionCounter.WithLabelValues(bs.rwTy.String(), targetLabel, "in"),
 	)
 	op.Counters = append(op.Counters,
 		hotSchedulerNewOperatorCounter,
@@ -1104,7 +1119,9 @@ func (bs *balanceSolver) decorateOperator(op *operator.Operator, isRevert bool, 
 	if isRevert {
 		op.FinishedCounters = append(op.FinishedCounters,
 			hotDirectionCounter.WithLabelValues(typ, bs.rwTy.String(), sourceLabel, "out-for-revert", dim),
-			hotDirectionCounter.WithLabelValues(typ, bs.rwTy.String(), targetLabel, "in-for-revert", dim))
+			hotDirectionCounter.WithLabelValues(typ, bs.rwTy.String(), targetLabel, "in-for-revert", dim),
+			hotStoreDirectionCounter.WithLabelValues(bs.rwTy.String(), sourceLabel, "out-for-revert"),
+			hotStoreDirectionCounter.WithLabelValues(bs.rwTy.String(), targetLabel, "in-for-revert"))
 	}
 }
 

--- a/pkg/schedule/schedulers/hot_region_solver_test.go
+++ b/pkg/schedule/schedulers/hot_region_solver_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -32,6 +33,43 @@ import (
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/storage"
 )
+
+func TestPreWarmHotStoreDirectionCounters(t *testing.T) {
+	re := require.New(t)
+	solver := &balanceSolver{
+		rwTy: utils.Read,
+		stLoadDetail: map[uint64]*statistics.StoreLoadDetail{
+			91001: {},
+			91002: {},
+		},
+	}
+
+	solver.preWarmHotStoreDirectionCounters()
+
+	for _, direction := range hotStoreDirectionLabels {
+		re.Equal(0.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "91001", direction)))
+		re.Equal(0.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "91002", direction)))
+	}
+}
+
+func TestDecorateOperatorAttachHotStoreDirectionCounters(t *testing.T) {
+	re := require.New(t)
+	solver := &balanceSolver{rwTy: utils.Read}
+	op := operator.NewOperator("test", "test", 1, &metapb.RegionEpoch{}, operator.OpHotRegion, 1)
+
+	re.Equal(0.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "92001", "out")))
+	re.Equal(0.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "92002", "in")))
+
+	solver.decorateOperator(op, true, "92001", "92002", "transfer-leader", "cpu")
+	for _, counter := range op.FinishedCounters {
+		counter.Inc()
+	}
+
+	re.Equal(1.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "92001", "out")))
+	re.Equal(1.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "92002", "in")))
+	re.Equal(1.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "92001", "out-for-revert")))
+	re.Equal(1.0, promtest.ToFloat64(hotStoreDirectionCounter.WithLabelValues(utils.Read.String(), "92002", "in-for-revert")))
+}
 
 func TestSplitBucketsBySize(t *testing.T) {
 	re := require.New(t)

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -89,6 +89,16 @@ var (
 			Help:      "Counter of hot region scheduler.",
 		}, []string{"type", "rw", "store", "direction", "dim"})
 
+	// hotStoreDirectionCounter is a low-cardinality store-level companion metric
+	// for paneling hot direction changes without depending on dynamic dim/type labelsets.
+	hotStoreDirectionCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "scheduler",
+			Name:      "hot_region_store_direction",
+			Help:      "Store-level counter of finished hot region operator directions.",
+		}, []string{"rw", "store", "direction"})
+
 	hotPeerHist = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "pd",
@@ -186,6 +196,7 @@ func init() {
 	prometheus.MustRegister(balanceWitnessCounter)
 	prometheus.MustRegister(hotSchedulerResultCounter)
 	prometheus.MustRegister(hotDirectionCounter)
+	prometheus.MustRegister(hotStoreDirectionCounter)
 	prometheus.MustRegister(balanceDirectionCounter)
 	prometheus.MustRegister(opInfluenceStatus)
 	prometheus.MustRegister(tolerantResourceStatus)


### PR DESCRIPTION
## Summary
- add a low-cardinality `pd_scheduler_hot_region_store_direction` counter for store-level hot-direction paneling
- pre-warm the store-direction series for current stores so dashboard queries do not miss first jumps on newly active stores
- keep the existing high-cardinality `pd_scheduler_hot_region_direction` metric for detailed dim/type diagnosis

## Why
The existing dashboard query uses short-window deltas on `pd_scheduler_hot_region_direction`. That metric is split by `type/dim/store/direction`, so newly appearing label series can first be scraped at a non-zero value and the first jump is missed. This makes store-level direction panels inaccurate for stores like `15` in our recent hot-scheduler runs.

## Validation
- `go test ./pkg/schedule/schedulers -run 'TestPreWarmHotStoreDirectionCounters|TestDecorateOperatorAttachHotStoreDirectionCounters|TestFilterHotPeersWithDecisions|TestHotReadRegionScheduleWithSmallHotRegion|TestBucketFirstStat'`\n- `go build -tags without_dashboard ./cmd/pd-server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring metrics for hot region store direction tracking, providing enhanced observability of scheduler operations.

* **Tests**
  * Added unit tests for hot store direction counter initialization and operator decoration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->