### PR TITLE
*: bump Go version to 1.25.8 in all go.mod files

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/client
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd
 
-go 1.25.7
+go 1.25.8
 
 // When you modify PD cooperatively with kvproto, this will be useful to submit the PR to PD and the PR to
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/tests/integrations
 
-go 1.25.7
+go 1.25.8
 
 replace (
 	github.com/tikv/pd => ../../

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/pd/tools
 
-go 1.25.7
+go 1.25.8
 
 replace (
 	github.com/tikv/pd => ../


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10501

### What is changed and how does it work?

Bump the `go` directive from 1.25.7 to 1.25.8 in all four `go.mod` files (`go.mod`, `client/go.mod`, `tests/integrations/go.mod`, `tools/go.mod`) on the `release-8.5` branch to pick up the latest security fixes and bug fixes.

```commit-message
Bump the `go` directive from 1.25.7 to 1.25.8 in all four
go.mod files to pick up the latest security and bug fixes.
```

### Check List

Tests

- No code

### Release note

```release-note
None.
```