### PR TITLE
resourcemanager: make controller config updates atomic

### DIFF
--- a/pkg/mcs/resourcemanager/metadataapi/config_service.go
+++ b/pkg/mcs/resourcemanager/metadataapi/config_service.go
@@ -253,7 +253,11 @@ func (s *ConfigService) SetControllerConfig(c *gin.Context) {
 			c.String(http.StatusForbidden, err.Error())
 			return
 		}
-		c.String(http.StatusBadRequest, err.Error())
+		if rmserver.IsControllerConfigValidationError(err) {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
+		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}
 	c.String(http.StatusOK, "Success!")

--- a/pkg/mcs/resourcemanager/metadataapi/config_service.go
+++ b/pkg/mcs/resourcemanager/metadataapi/config_service.go
@@ -43,6 +43,7 @@ type ConfigStore interface {
 	GetResourceGroupList(uint32, bool) ([]*rmserver.ResourceGroup, error)
 	DeleteResourceGroup(uint32, string) error
 	GetControllerConfig() *rmserver.ControllerConfig
+	UpdateControllerConfigItems(map[string]any) error
 	UpdateControllerConfigItem(string, any) error
 	SetKeyspaceServiceLimit(uint32, float64) error
 	LookupKeyspaceID(context.Context, string) (uint32, error)
@@ -92,6 +93,11 @@ func (s *ManagerStore) GetControllerConfig() *rmserver.ControllerConfig {
 // UpdateControllerConfigItem updates one controller config item.
 func (s *ManagerStore) UpdateControllerConfigItem(key string, value any) error {
 	return s.manager.UpdateControllerConfigItem(key, value)
+}
+
+// UpdateControllerConfigItems updates controller config items atomically.
+func (s *ManagerStore) UpdateControllerConfigItems(items map[string]any) error {
+	return s.manager.UpdateControllerConfigItems(items)
 }
 
 // SetKeyspaceServiceLimit sets keyspace service limit.
@@ -242,15 +248,13 @@ func (s *ConfigService) SetControllerConfig(c *gin.Context) {
 		}
 		resolvedConf[key] = v
 	}
-	for key, v := range resolvedConf {
-		if err := s.configStore.UpdateControllerConfigItem(key, v); err != nil {
-			if rmserver.IsMetadataWriteDisabledError(err) {
-				c.String(http.StatusForbidden, err.Error())
-				return
-			}
-			c.String(http.StatusBadRequest, err.Error())
+	if err := s.configStore.UpdateControllerConfigItems(resolvedConf); err != nil {
+		if rmserver.IsMetadataWriteDisabledError(err) {
+			c.String(http.StatusForbidden, err.Error())
 			return
 		}
+		c.String(http.StatusBadRequest, err.Error())
+		return
 	}
 	c.String(http.StatusOK, "Success!")
 }

--- a/pkg/mcs/resourcemanager/metadataapi/config_service_test.go
+++ b/pkg/mcs/resourcemanager/metadataapi/config_service_test.go
@@ -287,6 +287,13 @@ func (*testStore) GetControllerConfig() *rmserver.ControllerConfig {
 	return &rmserver.ControllerConfig{}
 }
 
+func (s *testStore) UpdateControllerConfigItems(items map[string]any) error {
+	for key := range items {
+		s.updatedControllerConfigItems = append(s.updatedControllerConfigItems, key)
+	}
+	return nil
+}
+
 func (s *testStore) UpdateControllerConfigItem(key string, _ any) error {
 	s.updatedControllerConfigItems = append(s.updatedControllerConfigItems, key)
 	return nil

--- a/pkg/mcs/resourcemanager/metadataapi/config_service_test.go
+++ b/pkg/mcs/resourcemanager/metadataapi/config_service_test.go
@@ -98,17 +98,36 @@ func TestConfigServiceControllerAllOrNothing(t *testing.T) {
 	handler := newTestHTTPHandler(store)
 
 	resp := doJSONRequest(re, handler, http.MethodPost, "/resource-manager/api/v1/config/controller", map[string]any{
-		"enable-controller-trace-log": true,
-		"unknown":                     1,
+		"write-base-cost": 2.0,
+		"unknown":         1,
 	})
 	re.Equal(http.StatusBadRequest, resp.Code)
 	re.Empty(store.updatedControllerConfigItems)
+	re.Zero(store.updateControllerConfigItemsCalls)
+	re.Zero(store.updateControllerConfigItemCalls)
 
 	resp = doJSONRequest(re, handler, http.MethodPost, "/resource-manager/api/v1/config/controller", map[string]any{
-		"enable-controller-trace-log": true,
+		"write-base-cost": 2.0,
 	})
 	re.Equal(http.StatusOK, resp.Code)
 	re.Len(store.updatedControllerConfigItems, 1)
+	re.Equal([]string{"request-unit.write-base-cost"}, store.updatedControllerConfigItems)
+	re.Equal(1, store.updateControllerConfigItemsCalls)
+	re.Zero(store.updateControllerConfigItemCalls)
+}
+
+func TestConfigServiceControllerStoreFailuresReturn500(t *testing.T) {
+	t.Parallel()
+
+	re := require.New(t)
+	store := newTestStore()
+	store.updateControllerConfigItemsErr = errors.New("save controller config failed")
+	handler := newTestHTTPHandler(store)
+
+	resp := doJSONRequest(re, handler, http.MethodPost, "/resource-manager/api/v1/config/controller", map[string]any{
+		"write-base-cost": 2.0,
+	})
+	re.Equal(http.StatusInternalServerError, resp.Code)
 }
 
 func TestConfigServiceKeyspaceServiceLimitAndErrors(t *testing.T) {
@@ -178,9 +197,12 @@ func TestConfigServiceMetadataWriteDisabledReturns403(t *testing.T) {
 	re.Equal(http.StatusForbidden, resp.Code)
 
 	resp = doJSONRequest(re, handler, http.MethodPost, "/resource-manager/api/v1/config/controller", map[string]any{
-		"enable-controller-trace-log": true,
+		"write-base-cost": 1.0,
 	})
 	re.Equal(http.StatusForbidden, resp.Code)
+
+	resp = doJSONRequest(re, handler, http.MethodPost, "/resource-manager/api/v1/config/controller", map[string]any{})
+	re.Equal(http.StatusOK, resp.Code)
 }
 
 func newTestHTTPHandler(configStore ConfigStore) http.Handler {
@@ -209,13 +231,16 @@ func (*tokenOnlyManagerProvider) AddStartCallback(...func()) {}
 func (*tokenOnlyManagerProvider) AddServiceReadyCallback(...func(context.Context) error) {}
 
 type testStore struct {
-	keyspaceIDs                  map[string]uint32
-	validKeyspaceIDs             map[uint32]struct{}
-	groups                       map[string]*rmserver.ResourceGroup
-	serviceLimits                map[uint32]float64
-	addErr                       error
-	setServiceLimitErr           error
-	updatedControllerConfigItems []string
+	keyspaceIDs                      map[string]uint32
+	validKeyspaceIDs                 map[uint32]struct{}
+	groups                           map[string]*rmserver.ResourceGroup
+	serviceLimits                    map[uint32]float64
+	addErr                           error
+	setServiceLimitErr               error
+	updateControllerConfigItemsErr   error
+	updatedControllerConfigItems     []string
+	updateControllerConfigItemsCalls int
+	updateControllerConfigItemCalls  int
 }
 
 func newTestStore() *testStore {
@@ -288,6 +313,10 @@ func (*testStore) GetControllerConfig() *rmserver.ControllerConfig {
 }
 
 func (s *testStore) UpdateControllerConfigItems(items map[string]any) error {
+	s.updateControllerConfigItemsCalls++
+	if s.updateControllerConfigItemsErr != nil {
+		return s.updateControllerConfigItemsErr
+	}
 	for key := range items {
 		s.updatedControllerConfigItems = append(s.updatedControllerConfigItems, key)
 	}
@@ -295,6 +324,7 @@ func (s *testStore) UpdateControllerConfigItems(items map[string]any) error {
 }
 
 func (s *testStore) UpdateControllerConfigItem(key string, _ any) error {
+	s.updateControllerConfigItemCalls++
 	s.updatedControllerConfigItems = append(s.updatedControllerConfigItems, key)
 	return nil
 }

--- a/pkg/mcs/resourcemanager/server/apis/v1/api.go
+++ b/pkg/mcs/resourcemanager/server/apis/v1/api.go
@@ -249,6 +249,8 @@ func (s *Service) getControllerConfig(c *gin.Context) {
 //	@Param		config	body	object	true	"json params, rmserver.ControllerConfig"
 //	@Success	200		{string}	string	"Success!"
 //	@Failure	400 	{string}	error
+//	@Failure	403 	{string}	error
+//	@Failure	500 	{string}	error
 //	@Router		/config/controller [post]
 func (s *Service) setControllerConfig(c *gin.Context) {
 	s.configService.SetControllerConfig(c)

--- a/pkg/mcs/resourcemanager/server/controller_config_errors.go
+++ b/pkg/mcs/resourcemanager/server/controller_config_errors.go
@@ -44,6 +44,7 @@ func (e *controllerConfigValidationError) Unwrap() error {
 	return e.err
 }
 
+// Is makes controllerConfigValidationError match errControllerConfigValidation via errors.Is.
 func (*controllerConfigValidationError) Is(target error) bool {
 	return target == errControllerConfigValidation
 }

--- a/pkg/mcs/resourcemanager/server/controller_config_errors.go
+++ b/pkg/mcs/resourcemanager/server/controller_config_errors.go
@@ -1,0 +1,49 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	stderrors "errors"
+)
+
+var errControllerConfigValidation = stderrors.New("controller config validation failed")
+
+func wrapControllerConfigValidationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &controllerConfigValidationError{err: err}
+}
+
+// IsControllerConfigValidationError reports whether err is a controller-config validation error.
+func IsControllerConfigValidationError(err error) bool {
+	return stderrors.Is(err, errControllerConfigValidation)
+}
+
+type controllerConfigValidationError struct {
+	err error
+}
+
+func (e *controllerConfigValidationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *controllerConfigValidationError) Unwrap() error {
+	return e.err
+}
+
+func (*controllerConfigValidationError) Is(target error) bool {
+	return target == errControllerConfigValidation
+}

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -472,6 +472,9 @@ func (m *Manager) UpdateControllerConfigItem(key string, value any) error {
 
 // UpdateControllerConfigItems updates controller config items atomically.
 func (m *Manager) UpdateControllerConfigItems(items map[string]any) error {
+	if len(items) == 0 {
+		return nil
+	}
 	if !m.writeRole.AllowsMetadataWrite() {
 		return errMetadataWriteDisabled
 	}
@@ -485,7 +488,7 @@ func (m *Manager) UpdateControllerConfigItems(items map[string]any) error {
 		updated, err := applyControllerConfigItem(controllerConfig, key, value)
 		if err != nil {
 			m.Unlock()
-			return err
+			return wrapControllerConfigValidationError(err)
 		}
 		if updated {
 			updatedItems = append(updatedItems, struct {

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -467,49 +467,46 @@ func (m *Manager) initReserved() {
 
 // UpdateControllerConfigItem updates the controller config item.
 func (m *Manager) UpdateControllerConfigItem(key string, value any) error {
+	return m.UpdateControllerConfigItems(map[string]any{key: value})
+}
+
+// UpdateControllerConfigItems updates controller config items atomically.
+func (m *Manager) UpdateControllerConfigItems(items map[string]any) error {
 	if !m.writeRole.AllowsMetadataWrite() {
 		return errMetadataWriteDisabled
 	}
-	kp := strings.Split(key, ".")
-	if len(kp) == 0 {
-		return errors.Errorf("invalid key %s", key)
-	}
 	m.Lock()
 	controllerConfig := cloneControllerConfig(m.controllerConfig)
-	var config any
-	switch kp[0] {
-	case "request-unit":
-		config = &controllerConfig.RequestUnit
-	default:
-		config = controllerConfig
-	}
-	updated, found, err := jsonutil.AddKeyValue(config, kp[len(kp)-1], value)
-	if err != nil {
-		m.Unlock()
-		return err
-	}
-
-	if !found {
-		m.Unlock()
-		return errors.Errorf("config item %s not found", key)
-	}
-	// Validate RUVersionPolicy after any update, regardless of the key path,
-	// since the default branch merges into the full ControllerConfig.
-	if err := controllerConfig.RUVersionPolicy.validate(); err != nil {
-		m.Unlock()
-		return err
-	}
-	if updated {
-		if err := m.storage.SaveControllerConfig(controllerConfig); err != nil {
+	updatedItems := make([]struct {
+		key   string
+		value any
+	}, 0, len(items))
+	for key, value := range items {
+		updated, err := applyControllerConfigItem(controllerConfig, key, value)
+		if err != nil {
 			m.Unlock()
-			log.Error("save controller config failed", zap.Error(err))
 			return err
 		}
-		m.controllerConfig = controllerConfig
+		if updated {
+			updatedItems = append(updatedItems, struct {
+				key   string
+				value any
+			}{key: key, value: value})
+		}
 	}
+	if len(updatedItems) == 0 {
+		m.Unlock()
+		return nil
+	}
+	if err := m.storage.SaveControllerConfig(controllerConfig); err != nil {
+		m.Unlock()
+		log.Error("save controller config failed", zap.Error(err))
+		return err
+	}
+	m.controllerConfig = controllerConfig
 	m.Unlock()
-	if updated {
-		log.Info("updated controller config item", zap.String("key", key), zap.Any("value", value))
+	for _, item := range updatedItems {
+		log.Info("updated controller config item", zap.String("key", item.key), zap.Any("value", item.value))
 	}
 	return nil
 }
@@ -519,6 +516,33 @@ func (m *Manager) GetControllerConfig() *ControllerConfig {
 	m.RLock()
 	defer m.RUnlock()
 	return cloneControllerConfig(m.controllerConfig)
+}
+
+func applyControllerConfigItem(config *ControllerConfig, key string, value any) (bool, error) {
+	kp := strings.Split(key, ".")
+	if len(kp) == 0 {
+		return false, errors.Errorf("invalid key %s", key)
+	}
+	var target any
+	switch kp[0] {
+	case "request-unit":
+		target = &config.RequestUnit
+	default:
+		target = config
+	}
+	updated, found, err := jsonutil.AddKeyValue(target, kp[len(kp)-1], value)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, errors.Errorf("config item %s not found", key)
+	}
+	// Validate RUVersionPolicy after any update, regardless of the key path,
+	// since the default branch merges into the full ControllerConfig.
+	if err := config.RUVersionPolicy.validate(); err != nil {
+		return false, err
+	}
+	return updated, nil
 }
 
 // AddResourceGroup puts a resource group.

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -599,6 +599,27 @@ func TestKeyspaceServiceLimit(t *testing.T) {
 	re.Equal(DefaultResourceGroupName, krgm.getMutableResourceGroup(DefaultResourceGroupName).Name)
 }
 
+func TestUpdateControllerConfigItemsAtomic(t *testing.T) {
+	re := require.New(t)
+	m := prepareManager()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	re.NoError(m.Init(ctx))
+
+	before := *m.GetControllerConfig()
+	err := m.UpdateControllerConfigItems(map[string]any{
+		"request-unit.write-base-cost": 2.0,
+		"ltb-max-wait-duration":        "not-a-duration",
+	})
+	re.Error(err)
+
+	after := m.GetControllerConfig()
+	re.Equal(before.RequestUnit.WriteBaseCost, after.RequestUnit.WriteBaseCost)
+	re.Equal(before.LTBMaxWaitDuration, after.LTBMaxWaitDuration)
+	re.Equal(before.EnableControllerTraceLog, after.EnableControllerTraceLog)
+}
+
 func TestKeyspaceNameLookup(t *testing.T) {
 	re := require.New(t)
 	m := prepareManager()

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -620,6 +620,19 @@ func TestUpdateControllerConfigItemsAtomic(t *testing.T) {
 	re.Equal(before.EnableControllerTraceLog, after.EnableControllerTraceLog)
 }
 
+func TestUpdateControllerConfigValidationError(t *testing.T) {
+	re := require.New(t)
+	m := prepareManager()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	re.NoError(m.Init(ctx))
+
+	err := m.UpdateControllerConfigItem("ltb-max-wait-duration", "not-a-duration")
+	re.Error(err)
+	re.True(IsControllerConfigValidationError(err))
+}
+
 func TestKeyspaceNameLookup(t *testing.T) {
 	re := require.New(t)
 	m := prepareManager()

--- a/tests/integrations/mcs/resourcemanager/api_test.go
+++ b/tests/integrations/mcs/resourcemanager/api_test.go
@@ -336,6 +336,21 @@ func (suite *resourceManagerAPITestSuite) TestControllerConfigAPI() {
 	re.Equal(2.0, config.RequestUnit.WriteBaseCost)
 }
 
+func (suite *resourceManagerAPITestSuite) TestControllerConfigAPIAllOrNothing() {
+	re := suite.Require()
+
+	before := suite.mustGetControllerConfig(re)
+	resp, statusCode := tryToSetControllerConfig(re, suite.cluster.GetLeaderServer().GetAddr(), map[string]any{
+		"enable-controller-trace-log": "true",
+		"ltb-max-wait-duration":       "not-a-duration",
+	})
+	re.Equal(http.StatusBadRequest, statusCode)
+	re.Contains(resp, "time:")
+
+	after := suite.mustGetControllerConfig(re)
+	re.Equal(before, after)
+}
+
 func (suite *resourceManagerAPITestSuite) mustGetControllerConfig(re *require.Assertions) *server.ControllerConfig {
 	bodyBytes := suite.mustSendRequest(re, http.MethodGet, "/config/controller", nil)
 	config := &server.ControllerConfig{}
@@ -344,8 +359,14 @@ func (suite *resourceManagerAPITestSuite) mustGetControllerConfig(re *require.As
 }
 
 func (suite *resourceManagerAPITestSuite) mustSetControllerConfig(re *require.Assertions, config map[string]any) {
-	bodyBytes := suite.mustSendRequest(re, http.MethodPost, "/config/controller", config)
-	re.Equal("Success!", string(bodyBytes))
+	body, statusCode := tryToSetControllerConfig(re, suite.cluster.GetLeaderServer().GetAddr(), config)
+	re.Equal(http.StatusOK, statusCode, body)
+	re.Equal("Success!", body)
+}
+
+func tryToSetControllerConfig(re *require.Assertions, leaderAddr string, config map[string]any) (string, int) {
+	bodyBytes, statusCode := sendRequest(re, leaderAddr, http.MethodPost, "/config/controller", nil, config)
+	return string(bodyBytes), statusCode
 }
 
 func (suite *resourceManagerAPITestSuite) TestKeyspaceServiceLimitAPI() {

--- a/tests/integrations/mcs/resourcemanager/api_test.go
+++ b/tests/integrations/mcs/resourcemanager/api_test.go
@@ -340,15 +340,24 @@ func (suite *resourceManagerAPITestSuite) TestControllerConfigAPIAllOrNothing() 
 	re := suite.Require()
 
 	before := suite.mustGetControllerConfig(re)
-	resp, statusCode := tryToSetControllerConfig(re, suite.cluster.GetLeaderServer().GetAddr(), map[string]any{
-		"enable-controller-trace-log": "true",
-		"ltb-max-wait-duration":       "not-a-duration",
-	})
-	re.Equal(http.StatusBadRequest, statusCode)
-	re.Contains(resp, "time:")
+	payload := map[string]any{
+		"read-base-cost":           2.0,
+		"read-per-batch-base-cost": 3.0,
+		"read-cost-per-byte":       4.0,
+		"write-base-cost":          5.0,
+		"write-cost-per-byte":      6.0,
+		"ltb-max-wait-duration":    "not-a-duration",
+	}
+	for i := 0; i < 8; i++ {
+		// Old code updated fields one by one after decoding into a map, so repeating the
+		// same mixed payload makes a partial write overwhelmingly likely if batching is gone.
+		resp, statusCode := tryToSetControllerConfig(re, suite.cluster.GetLeaderServer().GetAddr(), payload)
+		re.Equal(http.StatusBadRequest, statusCode)
+		re.Contains(resp, "time:")
 
-	after := suite.mustGetControllerConfig(re)
-	re.Equal(before, after)
+		after := suite.mustGetControllerConfig(re)
+		re.Equal(before, after)
+	}
 }
 
 func (suite *resourceManagerAPITestSuite) mustGetControllerConfig(re *require.Assertions) *server.ControllerConfig {

--- a/tests/integrations/mcs/resourcemanager/api_test.go
+++ b/tests/integrations/mcs/resourcemanager/api_test.go
@@ -348,7 +348,7 @@ func (suite *resourceManagerAPITestSuite) TestControllerConfigAPIAllOrNothing() 
 		"write-cost-per-byte":      6.0,
 		"ltb-max-wait-duration":    "not-a-duration",
 	}
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		// Old code updated fields one by one after decoding into a map, so repeating the
 		// same mixed payload makes a partial write overwhelmingly likely if batching is gone.
 		resp, statusCode := tryToSetControllerConfig(re, suite.cluster.GetLeaderServer().GetAddr(), payload)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10335

`POST /resource-manager/api/v1/config/controller` validates request keys before
applying updates, but it still persists each field one at a time through
`UpdateControllerConfigItem`. A mixed valid/invalid payload can therefore write
an earlier field before a later invalid value returns `400`.

### What is changed and how does it work?

```commit-message
resourcemanager: make controller config updates atomic

Batch controller config updates so mixed valid/invalid payloads no longer
persist earlier fields before later validation errors are returned.
```

- collect all resolved controller-config fields before applying any update
- add `UpdateControllerConfigItems` to clone the current controller config,
  apply every requested field to the clone, and persist once on success
- route the existing single-item helper through the batch path so callers keep
  the same entry point
- add unit and integration regression coverage for mixed valid/invalid payloads

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Fix a bug where the resource manager controller config API could partially
persist a multi-field update before returning a validation error.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support bulk controller configuration updates in a single request.

* **Bug Fixes**
  * Configuration updates are atomic: either all changes apply or none do.
  * Validation tightened so invalid values no longer modify configuration and return clear validation errors.

* **API Changes**
  * Config update responses include explicit 400 (validation), 403 (writes disabled), and 500 (server error).

* **Tests**
  * Added unit and integration tests for atomic updates and API error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->