### PR TITLE
chore(dashboard): update TiDB Dashboard to 20260330041600-b189ae3f181f [release-8.5]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20251212013835-ed676560b3b4
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300
+	github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.55.0
 	github.com/sasha-s/go-deadlock v0.3.6

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300 h1:f5/Ldek0H2K5zEIjFmZYbO6dLDo//p0zDxm9wKFGQn4=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300/go.mod h1:I6/izeYukxYPXYyjYYNNXw2+SQIF83rx4JHHFX4p25Q=
+github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f h1:yz4xstExz91lDuxZX/s2CazVQAh74ai3fa8p8NQ0P4s=
+github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f/go.mod h1:tIS0ksGqghvIWvRdBx+qA95tYGaTE1aYsD9YgKxzpu8=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -387,8 +387,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300 h1:f5/Ldek0H2K5zEIjFmZYbO6dLDo//p0zDxm9wKFGQn4=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300/go.mod h1:I6/izeYukxYPXYyjYYNNXw2+SQIF83rx4JHHFX4p25Q=
+github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f h1:yz4xstExz91lDuxZX/s2CazVQAh74ai3fa8p8NQ0P4s=
+github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f/go.mod h1:tIS0ksGqghvIWvRdBx+qA95tYGaTE1aYsD9YgKxzpu8=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d // indirect
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -384,8 +384,8 @@ github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300 h1:f5/Ldek0H2K5zEIjFmZYbO6dLDo//p0zDxm9wKFGQn4=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316034444-321d01b0e300/go.mod h1:I6/izeYukxYPXYyjYYNNXw2+SQIF83rx4JHHFX4p25Q=
+github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f h1:yz4xstExz91lDuxZX/s2CazVQAh74ai3fa8p8NQ0P4s=
+github.com/pingcap/tidb-dashboard v0.0.0-20260330041600-b189ae3f181f/go.mod h1:tIS0ksGqghvIWvRdBx+qA95tYGaTE1aYsD9YgKxzpu8=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10511

### What is changed and how does it work?

This PR updates `github.com/pingcap/tidb-dashboard` in `release-8.5` from `v0.0.0-20260316034444-321d01b0e300` to `v0.0.0-20260330041600-b189ae3f181f`, which is the latest commit on `pingcap/tidb-dashboard:release-8.5` on 2026-03-30.

```commit-message
chore(dashboard): update TiDB Dashboard to 20260330041600-b189ae3f181f [release-8.5]
```

### Check List

Tests
- Unit test: `go test ./pkg/dashboard/... ./tests/dashboard/... -count=1`
- Manual test: `make pd-server DASHBOARD=SKIP`

Code changes
- No configuration change
- No HTTP API change
- No persistent data change

Side effects
- No known side effects

Related changes
- Need to cherry-pick to the release branch: No

### Release note

```release-note
None.
```