### PR TITLE
tools, ci: support pd-ctl cert paths via env vars

### DIFF
--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -71,6 +71,7 @@ jobs:
         with:
           name: cover-reports-${{ matrix.worker_id }}
           path: covprofile_${{ matrix.worker_id }}
+          overwrite: true
   report-coverage:
     needs: chunks
     if: always()

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -44,9 +44,9 @@ func GetRootCmd() *cobra.Command {
 	}
 
 	rootCmd.PersistentFlags().StringP("pd", "u", "http://127.0.0.1:2379", "address of PD")
-	rootCmd.PersistentFlags().String("cacert", "", "path of file that contains list of trusted SSL CAs")
-	rootCmd.PersistentFlags().String("cert", "", "path of file that contains X509 certificate in PEM format")
-	rootCmd.PersistentFlags().String("key", "", "path of file that contains X509 key in PEM format")
+	rootCmd.PersistentFlags().String("cacert", os.Getenv("CA_PATH"), "path of file that contains list of trusted SSL CAs")
+	rootCmd.PersistentFlags().String("cert", os.Getenv("CERT_PATH"), "path of file that contains X509 certificate in PEM format")
+	rootCmd.PersistentFlags().String("key", os.Getenv("KEY_PATH"), "path of file that contains X509 key in PEM format")
 
 	rootCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref tikv/pd#10516, closed #10532

This PR ports the `pd-ctl` mTLS environment-variable defaults tracked in `tikv/pd#10516` onto the current `master` branch so TLS certificate paths can be supplied through environment variables instead of flags only.

Source change: `bufferflies/pd@dc3b174ccee8aceb1888d5ba8bfb915b344527dd`.

### What is changed and how does it work?

```commit-message
allow pd-ctl to use CA_PATH, CERT_PATH, and KEY_PATH as the default
values of the --cacert, --cert, and --key flags.

keep the workflow artifact upload overwrite behavior from the source
change so reruns can replace the same coverage artifact.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Support using environment variables as the default values for pd-ctl TLS certificate path flags.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS file path flags (`--cacert`, `--cert`, `--key`) can now default from environment variables for easier configuration.

* **Chores**
  * CI artifact uploads updated to overwrite existing artifacts with the same name, ensuring the latest coverage reports replace prior uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->