### PR TITLE
tools: add show region by keyspace-id and table-id

### DIFF
--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -437,9 +437,9 @@ func showRegionsByKeyspaceTableIDCommandFunc(cmd *cobra.Command, args []string) 
 		cmd.Println(cmd.UsageString())
 		return
 	}
-	keyspaceID, err := strconv.ParseInt(args[0], 10, 32)
+	keyspaceID, err := strconv.ParseUint(args[0], 10, 24)
 	if err != nil {
-		cmd.Println("Error: ", "keyspace-id should be a number")
+		cmd.Println("Error: ", "keyspace-id should be a number between 0 and 16777215")
 		return
 	}
 	startKey := []byte{'x', byte(keyspaceID >> 16), byte(keyspaceID >> 8), byte(keyspaceID)}
@@ -456,10 +456,9 @@ func showRegionsByKeyspaceTableIDCommandFunc(cmd *cobra.Command, args []string) 
 			return
 		}
 		nextTableID := tableID + 1
-		startKey = append(startKey, 't')
-		startKey = codec.EncodeInt(startKey, tableID)
-		endKey = append(startKey, 't')
-		endKey = codec.EncodeInt(endKey, nextTableID)
+		tablePrefix := []byte{'x', byte(keyspaceID >> 16), byte(keyspaceID >> 8), byte(keyspaceID), 't'}
+		startKey = codec.EncodeInt(append([]byte{}, tablePrefix...), tableID)
+		endKey = codec.EncodeInt(append([]byte{}, tablePrefix...), nextTableID)
 	}
 
 	encodedStartKey := codec.EncodeBytes(nil, startKey)

--- a/tools/pd-ctl/pdctl/command/region_test.go
+++ b/tools/pd-ctl/pdctl/command/region_test.go
@@ -188,14 +188,27 @@ func TestShowRegionsByKeyspaceTableIDCommandFuncWithTableIDAndLimit(t *testing.T
 
 	re.NotNil(requestURL)
 	re.Equal("/pd/api/v1/regions/key", requestURL.Path)
-	startKey := []byte{'x', 0, 0, 17, 't'}
-	startKey = codec.EncodeInt(startKey, 45)
-	endKey := append(startKey, 't')
-	endKey = codec.EncodeInt(endKey, 46)
+	tablePrefix := []byte{'x', 0, 0, 17, 't'}
+	startKey := codec.EncodeInt(append([]byte{}, tablePrefix...), 45)
+	endKey := codec.EncodeInt(append([]byte{}, tablePrefix...), 46)
 	re.Equal(string(codec.EncodeBytes(nil, startKey)), mustQueryUnescape(t, requestURL.Query().Get("key")))
 	re.Equal(string(codec.EncodeBytes(nil, endKey)), mustQueryUnescape(t, requestURL.Query().Get("end_key")))
 	re.Equal("3", requestURL.Query().Get("limit"))
 	re.Equal(resp+"\n", out.String())
+}
+
+func TestShowRegionsByKeyspaceTableIDCommandFuncWithInvalidKeyspaceIDRange(t *testing.T) {
+	re := require.New(t)
+
+	cmd := NewRegionsByKeyspaceTableIDCommand()
+	cmd.Flags().String("pd", "http://mock-pd:2379", "")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"16777216"})
+	re.NoError(cmd.Execute())
+
+	re.Contains(out.String(), "keyspace-id should be a number between 0 and 16777215")
 }
 
 func TestShowRegionsByKeyspaceTableIDCommandFuncWithInvalidTableIDKeyword(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref tikv/pd#10516, closed #10531

This PR ports the `pd-ctl` region lookup enhancement tracked in `tikv/pd#10516` onto the current `master` branch so operators can query regions by keyspace ID and optional table ID.

Source change: `bufferflies/pd@c93399a176f8ffc13580fe7ef35c43aa3830902e`.

### What is changed and how does it work?

```commit-message
add a pd-ctl region subcommand to query regions by keyspace id and
optional table id.

build the encoded region key range from the keyspace and table values
and send the request through the existing region key API.

adapt the encoded key construction to the current codec helper
signature on master.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Support querying regions by keyspace ID and table ID in pd-ctl.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a region query subcommand that accepts keyspace-id with optional table-id and optional limit.
* **Improvements**
  * Validates arguments more strictly with clearer error messages.
  * Builds precise start/end key ranges for keyspace- and table-scoped queries.
  * Supports JSON filtering (--jq) or raw response printing.
* **Tests**
  * Added tests for keyspace/table ranges, limit handling, request URL construction, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->