### PR TITLE
client: avoid RM fallback warning spam

### DIFF
--- a/client/servicediscovery/resource_manager_service_discovery.go
+++ b/client/servicediscovery/resource_manager_service_discovery.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/log"
 
@@ -161,11 +160,6 @@ func (r *ResourceManagerDiscovery) GetServiceURL() string {
 func (r *ResourceManagerDiscovery) GetConn() *grpc.ClientConn {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.conn == nil {
-		log.Warn("[resource-manager] gRPC connection is not established yet",
-			zap.String("discovery-key", r.discoveryKey))
-		return nil
-	}
 	return r.conn
 }
 
@@ -178,9 +172,10 @@ func (r *ResourceManagerDiscovery) discoverServiceURL() (string, int64, error) {
 		return "", 0, err
 	}
 	if resp == nil || len(resp.Kvs) == 0 {
-		log.Warn("[resource-manager] no resource-manager serving endpoint found",
-			zap.String("discovery-key", r.discoveryKey))
-		return "", 0, errs.ErrClientGetServingEndpoint
+		if resp == nil || resp.Header == nil {
+			return "", 0, nil
+		}
+		return "", resp.Header.Revision, nil
 	} else if resp.Count > 1 {
 		return "", 0, errs.ErrClientGetMultiResponse.FastGenByArgs(resp.Kvs)
 	}
@@ -229,10 +224,6 @@ func (r *ResourceManagerDiscovery) updateServiceURLLoop(revision int64) {
 			log.Warn("[resource-manager] failed to discover service URL",
 				zap.String("discovery-key", r.discoveryKey),
 				zap.Error(err))
-			// Endpoint is absent; keep connection cleared so the client can fall back to PD.
-			if errors.ErrorEqual(err, errs.ErrClientGetServingEndpoint) {
-				r.resetConn("")
-			}
 			return
 		}
 		if newRevision > revision {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10521

When PD runs without a standalone resource manager, client-side discovery keeps warning even though falling back to the PD-provided resource manager is expected. This makes normal deployments noisy and hides real problems.

### What is changed and how does it work?

```commit-message
Treat a missing standalone resource manager endpoint as a normal fallback state.
Stop warning when the resource manager connection is empty in the expected PD fallback path.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fixed warning spam when PD falls back to its built-in resource manager because no standalone resource manager is deployed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified service discovery error handling for missing serving endpoints
  * Modified endpoint absence handling to return empty results instead of errors
  * Streamlined gRPC connection state management logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->