### PR TITLE
server: fix nil panic in GetProgressByID and GetProgressByAction

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -335,12 +335,20 @@ func (h *Handler) ResetTS(ts uint64, ignoreSmaller, skipUpperBoundCheck bool, _ 
 
 // GetProgressByID returns the progress details for a given store ID.
 func (h *Handler) GetProgressByID(storeID uint64) (*progress.Progress, error) {
-	return h.s.GetRaftCluster().GetProgressByID(storeID)
+	c, err := h.GetRaftCluster()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetProgressByID(storeID)
 }
 
 // GetProgressByAction returns the progress details for a given action.
 func (h *Handler) GetProgressByAction(action string) (*progress.Progress, error) {
-	return h.s.GetRaftCluster().GetProgressByAction(action)
+	c, err := h.GetRaftCluster()
+	if err != nil {
+		return nil, err
+	}
+	return c.GetProgressByAction(action)
 }
 
 // PluginLoad loads the plugin referenced by the pluginPath


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10526 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```
GetProgressByID and GetProgressByAction called GetRaftCluster() on the
Server directly, which returns nil when the cluster is not bootstrapped.
This caused a nil pointer dereference panic on the /stores/progress
HTTP endpoint before bootstrap or when the cluster is unavailable.

Use the Handler's GetRaftCluster() instead, which returns ErrNotBootstrapped
when the cluster is nil, consistent with all other handler methods.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for progress retrieval operations to properly detect and report when the cluster is unavailable, enhancing system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->