### PR TITLE
ci: match all nextgen release branches in GitHub Actions

### DIFF
--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -8,7 +8,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
-      - release-nextgen-20250815
+      - release-nextgen-*
   pull_request:
     branches:
       - master
@@ -17,7 +17,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
-      - release-nextgen-20250815
+      - release-nextgen-*
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/tso-function-test.yaml
+++ b/.github/workflows/tso-function-test.yaml
@@ -7,7 +7,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
-      - release-nextgen-20250815
+      - release-nextgen-*
   pull_request:
     branches:
       - master
@@ -15,7 +15,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
-      - release-nextgen-20250815
+      - release-nextgen-*
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Ref #10560

### What is changed and how does it work?

```commit-message
ci(actions): match all nextgen release branches
```

Port the GitHub Actions branch filter update to `release-nextgen-202603` by replacing the hardcoded `release-nextgen-20250815` workflow filter with `release-nextgen-*` in:
- `.github/workflows/pd-tests.yaml`
- `.github/workflows/tso-function-test.yaml`

This keeps the existing non-nextgen branch coverage unchanged while allowing future nextgen release branches to trigger the same GitHub Actions workflows.

### Check List

Tests

- Manual test (add detailed scripts or steps below)
  - `git diff --check`
  - verified only the two workflow branch filters changed
  - confirmed the nextgen workflow branch filters now use `release-nextgen-*`

Code changes

- Has the configuration change

### Release note

```release-note
None.
```
