### PR TITLE
client/http: expose approximate_kv_size in RegionInfo

### DIFF
--- a/client/http/types.go
+++ b/client/http/types.go
@@ -71,20 +71,21 @@ var NewKeyRange = pd.NewKeyRange
 
 // RegionInfo stores the information of one region.
 type RegionInfo struct {
-	ID              int64            `json:"id"`
-	StartKey        string           `json:"start_key"`
-	EndKey          string           `json:"end_key"`
-	Epoch           RegionEpoch      `json:"epoch"`
-	Peers           []RegionPeer     `json:"peers"`
-	Leader          RegionPeer       `json:"leader"`
-	DownPeers       []RegionPeerStat `json:"down_peers"`
-	PendingPeers    []RegionPeer     `json:"pending_peers"`
-	WrittenBytes    uint64           `json:"written_bytes"`
-	ReadBytes       uint64           `json:"read_bytes"`
-	WrittenKeys     uint64           `json:"written_keys"`
-	ReadKeys        uint64           `json:"read_keys"`
-	ApproximateSize int64            `json:"approximate_size"`
-	ApproximateKeys int64            `json:"approximate_keys"`
+	ID                int64            `json:"id"`
+	StartKey          string           `json:"start_key"`
+	EndKey            string           `json:"end_key"`
+	Epoch             RegionEpoch      `json:"epoch"`
+	Peers             []RegionPeer     `json:"peers"`
+	Leader            RegionPeer       `json:"leader"`
+	DownPeers         []RegionPeerStat `json:"down_peers"`
+	PendingPeers      []RegionPeer     `json:"pending_peers"`
+	WrittenBytes      uint64           `json:"written_bytes"`
+	ReadBytes         uint64           `json:"read_bytes"`
+	WrittenKeys       uint64           `json:"written_keys"`
+	ReadKeys          uint64           `json:"read_keys"`
+	ApproximateSize   int64            `json:"approximate_size"`
+	ApproximateKvSize int64            `json:"approximate_kv_size"`
+	ApproximateKeys   int64            `json:"approximate_keys"`
 
 	ReplicationStatus *ReplicationStatus `json:"replication_status,omitempty"`
 }

--- a/client/http/types_test.go
+++ b/client/http/types_test.go
@@ -159,6 +159,24 @@ func TestMergeRegionsInfo(t *testing.T) {
 	}
 }
 
+func TestRegionInfoApproximateKvSizeDecode(t *testing.T) {
+	re := require.New(t)
+
+	var region RegionInfo
+	err := json.Unmarshal([]byte(`{"approximate_kv_size":123}`), &region)
+	re.NoError(err)
+	re.Equal(int64(123), region.ApproximateKvSize)
+}
+
+func TestRegionInfoApproximateKvSizeDefaultZero(t *testing.T) {
+	re := require.New(t)
+
+	var region RegionInfo
+	err := json.Unmarshal([]byte(`{}`), &region)
+	re.NoError(err)
+	re.Zero(region.ApproximateKvSize)
+}
+
 func TestRuleStartEndKey(t *testing.T) {
 	re := require.New(t)
 	// Empty start/end key and key hex.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10567

PD HTTP API responses can include `approximate_kv_size` for a region, but `client/http.RegionInfo` did not decode/expose this field. Downstream TiDB code that reads region stats from the PD HTTP client could not access this value.

### What is changed and how does it work?

- Add `ApproximateKvSize int64 `json:"approximate_kv_size"`` to `client/http.RegionInfo`.
- Add `TestRegionInfoApproximateKvSizeDecode` to verify decoding when `approximate_kv_size` is present.
- Add `TestRegionInfoApproximateKvSizeDefaultZero` to verify zero-value fallback when the field is absent.
- Compatibility: existing payloads without `approximate_kv_size` continue to decode with zero value.

```commit-message
client/http: expose approximate_kv_size in RegionInfo
```

### Check List

Tests

- Unit test

Code changes

- Has HTTP APIs changed (client type exposure only; no server API behavior change)

Side effects

- Breaking backward compatibility (none)

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn): N/A
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup): N/A
- Need to cherry-pick to the release branch: N/A

### Release note

```release-note
Expose `approximate_kv_size` in `client/http.RegionInfo` and add decode tests for present/missing field handling.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Region information responses now include approximate KV size metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->