### PR TITLE
checker: support force merge ranges for physical table drop

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -381,6 +381,16 @@ error = '''
 failed to convert a path to absolute path
 '''
 
+["PD:forcemerge:ErrForceMergeRangeContent"]
+error = '''
+invalid force merge range content, %s
+'''
+
+["PD:forcemerge:ErrLoadForceMergeRange"]
+error = '''
+load force merge range failed
+'''
+
 ["PD:gin:ErrBindJSON"]
 error = '''
 bind JSON error

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -113,6 +113,12 @@ var (
 	ErrBuildRuleList = errors.Normalize("build rule list failed, %s", errors.RFCCodeText("PD:placement:ErrBuildRuleList"))
 )
 
+// force merge errors
+var (
+	ErrForceMergeRangeContent = errors.Normalize("invalid force merge range content, %s", errors.RFCCodeText("PD:forcemerge:ErrForceMergeRangeContent"))
+	ErrLoadForceMergeRange    = errors.Normalize("load force merge range failed", errors.RFCCodeText("PD:forcemerge:ErrLoadForceMergeRange"))
+)
+
 // region label errors
 var (
 	ErrRegionRuleContent  = errors.Normalize("invalid region rule content, %s", errors.RFCCodeText("PD:region:ErrRegionRuleContent"))

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tikv/pd/server/core/storelimit"
 	"github.com/tikv/pd/server/id"
 	"github.com/tikv/pd/server/schedule/labeler"
+	"github.com/tikv/pd/server/schedule/pkdbforcemerge"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/statistics"
 	"github.com/tikv/pd/server/statistics/buckets"
@@ -49,6 +50,7 @@ type Cluster struct {
 	*core.BasicCluster
 	*mockid.IDAllocator
 	*placement.RuleManager
+	ForceMergeManager *pkdbforcemerge.Manager
 	*labeler.RegionLabeler
 	*statistics.HotStat
 	*config.PersistOptions
@@ -61,6 +63,7 @@ type Cluster struct {
 
 // NewCluster creates a new Cluster
 func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
+	store := storage.NewStorageWithMemoryBackend()
 	clus := &Cluster{
 		BasicCluster:       core.NewBasicCluster(),
 		IDAllocator:        mockid.NewIDAllocator(),
@@ -76,7 +79,8 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 	}
 	// It should be updated to the latest feature version.
 	clus.PersistOptions.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.HotScheduleWithQuery))
-	clus.RegionLabeler, _ = labeler.NewRegionLabeler(ctx, storage.NewStorageWithMemoryBackend(), time.Second*5)
+	clus.ForceMergeManager, _ = pkdbforcemerge.NewManager(store)
+	clus.RegionLabeler, _ = labeler.NewRegionLabeler(ctx, store, time.Second*5)
 	return clus
 }
 
@@ -198,6 +202,11 @@ func (mc *Cluster) initRuleManager() {
 // GetRuleManager returns the ruleManager of the cluster.
 func (mc *Cluster) GetRuleManager() *placement.RuleManager {
 	return mc.RuleManager
+}
+
+// GetForceMergeManager returns the force merge manager of the cluster.
+func (mc *Cluster) GetForceMergeManager() *pkdbforcemerge.Manager {
+	return mc.ForceMergeManager
 }
 
 // GetRegionLabeler returns the region labeler of the cluster.

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -953,6 +953,26 @@ func (h *regionsHandler) AddForceMergeRanges(w http.ResponseWriter, r *http.Requ
 	h.rd.Text(w, http.StatusOK, "Add force merge ranges successfully.")
 }
 
+// @Tags     region
+// @Summary  Clear force merge ranges.
+// @Produce  plain
+// @Success  200  {string}  string  "Clear force merge ranges successfully."
+// @Failure  500  {string}  string  "PD server failed to proceed the request."
+// @Router   /regions/force-merge [delete]
+func (h *regionsHandler) DeleteForceMergeRanges(w http.ResponseWriter, r *http.Request) {
+	rc := getCluster(r)
+	manager := rc.GetForceMergeManager()
+	if manager == nil {
+		h.rd.JSON(w, http.StatusInternalServerError, "force merge manager is not initialized")
+		return
+	}
+	if err := manager.ClearRanges(); err != nil {
+		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.rd.Text(w, http.StatusOK, "Clear force merge ranges successfully.")
+}
+
 func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, less func(a, b *core.RegionInfo) bool) {
 	rc := getCluster(r)
 	limit := defaultRegionLimit

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/replication_modepb"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/apiutil"
+	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/typeutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/core"
@@ -229,6 +230,11 @@ func (s *RegionsInfo) Adjust() {
 type regionHandler struct {
 	svr *server.Server
 	rd  *render.Render
+}
+
+type addForceMergeRangesRequest struct {
+	StartKeysHex []string `json:"start_keys"`
+	EndKeysHex   []string `json:"end_keys"`
 }
 
 func newRegionHandler(svr *server.Server, rd *render.Render) *regionHandler {
@@ -905,6 +911,46 @@ func (h *regionsHandler) AccelerateRegionsScheduleInRanges(w http.ResponseWriter
 		rc.AddSuspectRegions(regionsIDList...)
 	}
 	h.rd.Text(w, http.StatusOK, msgBuilder.String())
+}
+
+// @Tags     region
+// @Summary  Add force merge ranges.
+// @Accept   json
+// @Param    body  body  object  true  "json params"
+// @Produce  plain
+// @Success  200  {string}  string  "Add force merge ranges successfully."
+// @Failure  400  {string}  string  "The input is invalid."
+// @Failure  500  {string}  string  "PD server failed to proceed the request."
+// @Router   /regions/force-merge [post]
+func (h *regionsHandler) AddForceMergeRanges(w http.ResponseWriter, r *http.Request) {
+	rc := getCluster(r)
+	var input addForceMergeRangesRequest
+	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
+		return
+	}
+	if rc.GetOpts().IsCrossTableMergeEnabled() {
+		h.rd.JSON(w, http.StatusBadRequest, "enable-cross-table-merge is true")
+		return
+	}
+	if keyType := rc.GetOpts().GetKeyType(); keyType != core.Table {
+		h.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("key-type %s does not support force merge", keyType.String()))
+		return
+	}
+
+	manager := rc.GetForceMergeManager()
+	if manager == nil {
+		h.rd.JSON(w, http.StatusInternalServerError, "force merge manager is not initialized")
+		return
+	}
+	if err := manager.AddRanges(input.StartKeysHex, input.EndKeysHex); err != nil {
+		if errs.ErrForceMergeRangeContent.Equal(err) || errs.ErrHexDecodingString.Equal(err) {
+			h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		} else {
+			h.rd.JSON(w, http.StatusInternalServerError, err.Error())
+		}
+		return
+	}
+	h.rd.Text(w, http.StatusOK, "Add force merge ranges successfully.")
 }
 
 func (h *regionsHandler) GetTopNRegions(w http.ResponseWriter, r *http.Request, less func(a, b *core.RegionInfo) bool) {

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -374,6 +374,129 @@ func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRanges() {
 	suite.Len(idList, 4)
 }
 
+func (suite *regionTestSuite) TestAddForceMergeRanges() {
+	re := suite.Require()
+	suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"false"}`), tu.StatusOK(re)))
+	defer func() {
+		suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"true"}`), tu.StatusOK(re)))
+	}()
+
+	manager := suite.svr.GetRaftCluster().GetForceMergeManager()
+	re.NotNil(manager)
+
+	startKey := []byte("force-merge/a")
+	middleKey := []byte("force-merge/b")
+	endKey := []byte("force-merge/c")
+	cleanupEndKey := []byte("force-merge/d")
+	body, err := json.Marshal(addForceMergeRangesRequest{
+		StartKeysHex: []string{
+			hex.EncodeToString(startKey),
+			hex.EncodeToString(middleKey),
+		},
+		EndKeysHex: []string{
+			hex.EncodeToString(middleKey),
+			hex.EncodeToString(endKey),
+		},
+	})
+	suite.NoError(err)
+
+	err = tu.CheckPostJSON(testDialClient, fmt.Sprintf("%s/regions/force-merge", suite.urlPrefix), body, tu.StatusOK(re))
+	suite.NoError(err)
+
+	exactRegion := core.NewRegionInfo(&metapb.Region{Id: 10001, StartKey: startKey, EndKey: endKey}, nil)
+	suite.True(manager.SolveRegion(exactRegion))
+
+	cleanupRegion := core.NewRegionInfo(&metapb.Region{Id: 10002, StartKey: startKey, EndKey: cleanupEndKey}, nil)
+	suite.False(manager.SolveRegion(cleanupRegion))
+	suite.False(manager.SolveRegion(exactRegion))
+}
+
+func (suite *regionTestSuite) TestAddForceMergeRangesValidation() {
+	re := suite.Require()
+	suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"false"}`), tu.StatusOK(re)))
+	defer func() {
+		suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"true"}`), tu.StatusOK(re)))
+	}()
+
+	startKey := []byte("force-merge/x")
+	endKey := []byte("force-merge/y")
+	body, err := json.Marshal(addForceMergeRangesRequest{
+		StartKeysHex: []string{hex.EncodeToString(startKey)},
+	})
+	suite.NoError(err)
+
+	err = tu.CheckPostJSON(
+		testDialClient,
+		fmt.Sprintf("%s/regions/force-merge", suite.urlPrefix),
+		body,
+		tu.Status(re, http.StatusBadRequest),
+		tu.StringContain(re, "start key count 1 does not match end key count 0"),
+	)
+	suite.NoError(err)
+
+	exactRegion := core.NewRegionInfo(&metapb.Region{Id: 10003, StartKey: startKey, EndKey: endKey}, nil)
+	suite.False(suite.svr.GetRaftCluster().GetForceMergeManager().SolveRegion(exactRegion))
+}
+
+func (suite *regionTestSuite) TestAddForceMergeRangesCrossTableMergeEnabled() {
+	re := suite.Require()
+	startKey := []byte("force-merge/enable/x")
+	endKey := []byte("force-merge/enable/y")
+	body, err := json.Marshal(addForceMergeRangesRequest{
+		StartKeysHex: []string{hex.EncodeToString(startKey)},
+		EndKeysHex:   []string{hex.EncodeToString(endKey)},
+	})
+	suite.NoError(err)
+
+	err = tu.CheckPostJSON(
+		testDialClient,
+		fmt.Sprintf("%s/regions/force-merge", suite.urlPrefix),
+		body,
+		tu.Status(re, http.StatusBadRequest),
+		tu.StringContain(re, "enable-cross-table-merge is true"),
+	)
+	suite.NoError(err)
+
+	exactRegion := core.NewRegionInfo(&metapb.Region{Id: 10004, StartKey: startKey, EndKey: endKey}, nil)
+	suite.False(suite.svr.GetRaftCluster().GetForceMergeManager().SolveRegion(exactRegion))
+}
+
+func (suite *regionTestSuite) TestAddForceMergeRangesNonTableKeyType() {
+	re := suite.Require()
+	suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"false"}`), tu.StatusOK(re)))
+	defer func() {
+		suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"true"}`), tu.StatusOK(re)))
+	}()
+
+	originalCfg := suite.svr.GetConfig().PDServerCfg
+	rawCfg := originalCfg
+	rawCfg.KeyType = core.Raw.String()
+	suite.NoError(suite.svr.SetPDServerConfig(rawCfg))
+	defer func() {
+		suite.NoError(suite.svr.SetPDServerConfig(originalCfg))
+	}()
+
+	startKey := []byte("force-merge/raw/x")
+	endKey := []byte("force-merge/raw/y")
+	body, err := json.Marshal(addForceMergeRangesRequest{
+		StartKeysHex: []string{hex.EncodeToString(startKey)},
+		EndKeysHex:   []string{hex.EncodeToString(endKey)},
+	})
+	suite.NoError(err)
+
+	err = tu.CheckPostJSON(
+		testDialClient,
+		fmt.Sprintf("%s/regions/force-merge", suite.urlPrefix),
+		body,
+		tu.Status(re, http.StatusBadRequest),
+		tu.StringContain(re, "key-type raw does not support force merge"),
+	)
+	suite.NoError(err)
+
+	exactRegion := core.NewRegionInfo(&metapb.Region{Id: 10005, StartKey: startKey, EndKey: endKey}, nil)
+	suite.False(suite.svr.GetRaftCluster().GetForceMergeManager().SolveRegion(exactRegion))
+}
+
 func (suite *regionTestSuite) TestScatterRegions() {
 	re := suite.Require()
 	r1 := newTestRegionInfo(601, 13, []byte("b1"), []byte("b2"))

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -497,6 +497,43 @@ func (suite *regionTestSuite) TestAddForceMergeRangesNonTableKeyType() {
 	suite.False(suite.svr.GetRaftCluster().GetForceMergeManager().SolveRegion(exactRegion))
 }
 
+func (suite *regionTestSuite) TestDeleteForceMergeRanges() {
+	re := suite.Require()
+	suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"false"}`), tu.StatusOK(re)))
+	defer func() {
+		suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"true"}`), tu.StatusOK(re)))
+	}()
+
+	startKey := []byte("force-merge/delete/x")
+	endKey := []byte("force-merge/delete/y")
+	body, err := json.Marshal(addForceMergeRangesRequest{
+		StartKeysHex: []string{hex.EncodeToString(startKey)},
+		EndKeysHex:   []string{hex.EncodeToString(endKey)},
+	})
+	suite.NoError(err)
+	suite.NoError(tu.CheckPostJSON(
+		testDialClient,
+		fmt.Sprintf("%s/regions/force-merge", suite.urlPrefix),
+		body,
+		tu.StatusOK(re),
+	))
+
+	manager := suite.svr.GetRaftCluster().GetForceMergeManager()
+	exactRegion := core.NewRegionInfo(&metapb.Region{Id: 10006, StartKey: startKey, EndKey: endKey}, nil)
+	suite.True(manager.SolveRegion(exactRegion))
+
+	suite.NoError(tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/config", []byte(`{"enable-cross-table-merge":"true"}`), tu.StatusOK(re)))
+
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/regions/force-merge", suite.urlPrefix), nil)
+	suite.NoError(err)
+	resp, err := testDialClient.Do(req)
+	suite.NoError(err)
+	defer resp.Body.Close()
+	suite.Equal(http.StatusOK, resp.StatusCode)
+
+	suite.False(manager.SolveRegion(exactRegion))
+}
+
 func (suite *regionTestSuite) TestScatterRegions() {
 	re := suite.Require()
 	r1 := newTestRegionInfo(601, 13, []byte("b1"), []byte("b2"))

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -267,6 +267,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(clusterRouter, "/regions/sibling/{id}", regionsHandler.GetRegionSiblings, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/regions/accelerate-schedule", regionsHandler.AccelerateRegionsScheduleInRange, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/accelerate-schedule/batch", regionsHandler.AccelerateRegionsScheduleInRanges, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
+	registerFunc(clusterRouter, "/regions/force-merge", regionsHandler.AddForceMergeRanges, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/scatter", regionsHandler.ScatterRegions, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/split", regionsHandler.SplitRegions, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/range-holes", regionsHandler.GetRangeHoles, setMethods(http.MethodGet), setAuditBackend(prometheus))

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -268,6 +268,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(clusterRouter, "/regions/accelerate-schedule", regionsHandler.AccelerateRegionsScheduleInRange, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/accelerate-schedule/batch", regionsHandler.AccelerateRegionsScheduleInRanges, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/force-merge", regionsHandler.AddForceMergeRanges, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
+	registerFunc(clusterRouter, "/regions/force-merge", regionsHandler.DeleteForceMergeRanges, setMethods(http.MethodDelete), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/scatter", regionsHandler.ScatterRegions, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/split", regionsHandler.SplitRegions, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/range-holes", regionsHandler.GetRangeHoles, setMethods(http.MethodGet), setAuditBackend(prometheus))

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -49,6 +49,7 @@ import (
 	"github.com/tikv/pd/server/schedule/checker"
 	"github.com/tikv/pd/server/schedule/hbstream"
 	"github.com/tikv/pd/server/schedule/labeler"
+	"github.com/tikv/pd/server/schedule/pkdbforcemerge"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/schedulers"
 	"github.com/tikv/pd/server/statistics"
@@ -143,6 +144,7 @@ type RaftCluster struct {
 	hotStat                  *statistics.HotStat
 	hotBuckets               *buckets.HotBucketCache
 	ruleManager              *placement.RuleManager
+	forceMergeManager        *pkdbforcemerge.Manager
 	regionLabeler            *labeler.RegionLabeler
 	replicationMode          *replication.ModeManager
 	unsafeRecoveryController *unsafeRecoveryController
@@ -263,6 +265,10 @@ func (c *RaftCluster) Start(s Server) error {
 		if err != nil {
 			return err
 		}
+	}
+	c.forceMergeManager, err = pkdbforcemerge.NewManager(c.storage)
+	if err != nil {
+		return err
 	}
 
 	c.regionLabeler, err = labeler.NewRegionLabeler(c.ctx, c.storage, regionLabelGCInterval)
@@ -644,6 +650,11 @@ func (c *RaftCluster) GetReplicationMode() *replication.ModeManager {
 // GetRuleManager returns the rule manager reference.
 func (c *RaftCluster) GetRuleManager() *placement.RuleManager {
 	return c.ruleManager
+}
+
+// GetForceMergeManager returns the force merge manager reference.
+func (c *RaftCluster) GetForceMergeManager() *pkdbforcemerge.Manager {
+	return c.forceMergeManager
 }
 
 // GetRegionLabeler returns the region labeler.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/tikv/pd/server/schedule"
 	"github.com/tikv/pd/server/schedule/filter"
 	"github.com/tikv/pd/server/schedule/labeler"
+	"github.com/tikv/pd/server/schedule/pkdbforcemerge"
 	"github.com/tikv/pd/server/schedule/placement"
 	"github.com/tikv/pd/server/schedulers"
 	"github.com/tikv/pd/server/statistics"
@@ -1962,6 +1963,18 @@ type testCluster struct {
 	*RaftCluster
 }
 
+func TestGetForceMergeManager(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend(), core.NewBasicCluster())
+	re.NotNil(cluster.GetForceMergeManager())
+}
+
 func newTestScheduleConfig() (*config.ScheduleConfig, *config.PersistOptions, error) {
 	cfg := config.NewConfig()
 	cfg.Schedule.TolerantSizeRatio = 5
@@ -1997,6 +2010,11 @@ func newTestRaftCluster(
 			panic(err)
 		}
 	}
+	forceMergeManager, err := pkdbforcemerge.NewManager(s)
+	if err != nil {
+		panic(err)
+	}
+	rc.forceMergeManager = forceMergeManager
 	return rc
 }
 

--- a/server/core/region.go
+++ b/server/core/region.go
@@ -22,11 +22,13 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/docker/go-units"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/replication_modepb"
@@ -884,6 +886,11 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo) (*RegionInfo, []*Regio
 
 // UpdateSubTree updates the subtree.
 func (r *RegionsInfo) UpdateSubTree(region, origin *RegionInfo, toRemove []*RegionInfo, rangeChanged bool) {
+	failpoint.Inject("UpdateSubTree", func() {
+		if origin == nil {
+			time.Sleep(time.Second)
+		}
+	})
 	r.st.Lock()
 	defer r.st.Unlock()
 	if origin != nil {
@@ -892,8 +899,17 @@ func (r *RegionsInfo) UpdateSubTree(region, origin *RegionInfo, toRemove []*Regi
 			// TODO: Improve performance by deleting only the different peers.
 			r.removeRegionFromSubTreeLocked(origin)
 		} else {
-			r.updateSubTreeStat(origin, region)
-			r.subRegions[region.GetID()].RegionInfo = region
+			// The region tree and the subtree update is not atomic and the region tree is updated first.
+			// If there are two thread needs to update region tree,
+			// t1: thread-A  update region tree
+			// 										t2: thread-B: update region tree again
+			//										t3: thread-B: update subtree
+			// t4: thread-A: update region subtree
+			// to keep region tree consistent with subtree, we need to drop this update.
+			if tree, ok := r.subRegions[region.GetID()]; ok {
+				r.updateSubTreeStat(origin, region)
+				tree.RegionInfo = region
+			}
 			return
 		}
 	}

--- a/server/core/region_test.go
+++ b/server/core/region_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/stretchr/testify/require"
@@ -449,6 +450,18 @@ func TestRegionKey(t *testing.T) {
 		re.Regexp(".*EndKey Changed.*", s)
 		re.Contains(s, test.expect)
 	}
+}
+
+func TestSetRegionConcurrence(t *testing.T) {
+	re := require.New(t)
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/core/UpdateSubTree", `return()`))
+	regions := NewRegionsInfo()
+	region := NewTestRegionInfo([]byte("a"), []byte("b"))
+	go func() {
+		regions.AtomicCheckAndPutRegion(region)
+	}()
+	regions.AtomicCheckAndPutRegion(region)
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/core/UpdateSubTree"))
 }
 
 func TestSetRegion(t *testing.T) {

--- a/server/schedule/checker/merge_checker.go
+++ b/server/schedule/checker/merge_checker.go
@@ -262,14 +262,30 @@ func AllowMerge(cluster schedule.Cluster, region, adjacent *core.RegionInfo) boo
 		if cluster.GetOpts().IsCrossTableMergeEnabled() {
 			return true
 		}
+		if allowByForceMerge(cluster, region, adjacent) {
+			return true
+		}
 		return isTableIDSame(region, adjacent)
 	case core.Raw:
 		return true
 	case core.Txn:
 		return true
 	default:
+		if allowByForceMerge(cluster, region, adjacent) {
+			return true
+		}
 		return isTableIDSame(region, adjacent)
 	}
+}
+
+func allowByForceMerge(cluster schedule.Cluster, region, adjacent *core.RegionInfo) bool {
+	manager := cluster.GetForceMergeManager()
+	if manager == nil {
+		return false
+	}
+	regionNeedForceMerge := manager.SolveRegion(region)
+	adjacentNeedForceMerge := manager.SolveRegion(adjacent)
+	return regionNeedForceMerge || adjacentNeedForceMerge
 }
 
 func isTableIDSame(region, adjacent *core.RegionInfo) bool {

--- a/server/schedule/checker/merge_checker_test.go
+++ b/server/schedule/checker/merge_checker_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/suite"
+	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/testutil"
 	"github.com/tikv/pd/server/config"
@@ -510,6 +511,66 @@ func (suite *mergeCheckerTestSuite) TestStoreLimitWithMerge() {
 	}
 }
 
+func (suite *mergeCheckerTestSuite) TestAllowMergeByForceMerge() {
+	cfg := config.NewTestOptions()
+	tc := mockcluster.NewCluster(suite.ctx, cfg)
+	scheduleCfg := tc.GetScheduleConfig().Clone()
+	scheduleCfg.EnableCrossTableMerge = false
+	tc.SetScheduleConfig(scheduleCfg)
+
+	startKey1 := []byte(codec.EncodeBytes(codec.GenerateTableKey(1)))
+	startKey2 := []byte(codec.EncodeBytes(codec.GenerateTableKey(2)))
+	startKey3 := []byte(codec.EncodeBytes(codec.GenerateTableKey(3)))
+	region := newRegionInfoWithKeys(1, startKey1, startKey2, 1, 1, []uint64{101, 1}, []uint64{101, 1}, []uint64{102, 2})
+	adjacent := newRegionInfoWithKeys(2, startKey2, startKey3, 1, 1, []uint64{103, 1}, []uint64{103, 1}, []uint64{104, 2})
+
+	suite.False(AllowMerge(tc, region, adjacent))
+
+	manager := tc.GetForceMergeManager()
+	suite.Require().NotNil(manager)
+
+	suite.NoError(manager.AddRanges(
+		[]string{hex.EncodeToString(region.GetStartKey())},
+		[]string{hex.EncodeToString(region.GetEndKey())},
+	))
+	suite.True(AllowMerge(tc, region, adjacent))
+	suite.True(manager.SolveRegion(region))
+
+	suite.NoError(manager.AddRanges(
+		[]string{hex.EncodeToString(adjacent.GetStartKey())},
+		[]string{hex.EncodeToString(adjacent.GetEndKey())},
+	))
+	suite.True(AllowMerge(tc, region, adjacent))
+	suite.True(manager.SolveRegion(adjacent))
+
+	cfg2 := config.NewTestOptions()
+	tc2 := mockcluster.NewCluster(suite.ctx, cfg2)
+	scheduleCfg2 := tc2.GetScheduleConfig().Clone()
+	scheduleCfg2.EnableCrossTableMerge = false
+	tc2.SetScheduleConfig(scheduleCfg2)
+
+	startKey4 := []byte(codec.EncodeBytes(codec.GenerateTableKey(4)))
+	startKey5 := []byte(codec.EncodeBytes(codec.GenerateTableKey(5)))
+	region2 := newRegionInfoWithKeys(3, startKey1, startKey2, 1, 1, []uint64{105, 1}, []uint64{105, 1}, []uint64{106, 2})
+	expandedAdjacent := newRegionInfoWithKeys(4, startKey2, startKey5, 1, 1, []uint64{107, 1}, []uint64{107, 1}, []uint64{108, 2})
+	coveredRange := newRegionInfoWithKeys(5, startKey3, startKey4, 1, 1, []uint64{109, 1}, []uint64{109, 1}, []uint64{110, 2})
+
+	manager2 := tc2.GetForceMergeManager()
+	suite.Require().NotNil(manager2)
+	suite.NoError(manager2.AddRanges(
+		[]string{
+			hex.EncodeToString(region2.GetStartKey()),
+			hex.EncodeToString(coveredRange.GetStartKey()),
+		},
+		[]string{
+			hex.EncodeToString(region2.GetEndKey()),
+			hex.EncodeToString(coveredRange.GetEndKey()),
+		},
+	))
+	suite.True(AllowMerge(tc2, region2, expandedAdjacent))
+	suite.False(manager2.SolveRegion(coveredRange))
+}
+
 func (suite *mergeCheckerTestSuite) TestCache() {
 	cfg := config.NewTestOptions()
 	suite.cluster = mockcluster.NewCluster(suite.ctx, cfg)
@@ -551,6 +612,10 @@ func makeKeyRanges(keys ...string) []interface{} {
 }
 
 func newRegionInfo(id uint64, startKey, endKey string, size, keys int64, leader []uint64, peers ...[]uint64) *core.RegionInfo {
+	return newRegionInfoWithKeys(id, []byte(startKey), []byte(endKey), size, keys, leader, peers...)
+}
+
+func newRegionInfoWithKeys(id uint64, startKey, endKey []byte, size, keys int64, leader []uint64, peers ...[]uint64) *core.RegionInfo {
 	prs := make([]*metapb.Peer, 0, len(peers))
 	for _, peer := range peers {
 		prs = append(prs, &metapb.Peer{Id: peer[0], StoreId: peer[1]})
@@ -558,8 +623,8 @@ func newRegionInfo(id uint64, startKey, endKey string, size, keys int64, leader 
 	return core.NewRegionInfo(
 		&metapb.Region{
 			Id:       id,
-			StartKey: []byte(startKey),
-			EndKey:   []byte(endKey),
+			StartKey: startKey,
+			EndKey:   endKey,
 			Peers:    prs,
 		},
 		&metapb.Peer{Id: leader[0], StoreId: leader[1]},

--- a/server/schedule/cluster.go
+++ b/server/schedule/cluster.go
@@ -17,6 +17,7 @@ package schedule
 import (
 	"github.com/tikv/pd/server/core"
 	"github.com/tikv/pd/server/schedule/operator"
+	"github.com/tikv/pd/server/schedule/pkdbforcemerge"
 	"github.com/tikv/pd/server/statistics"
 	"github.com/tikv/pd/server/statistics/buckets"
 )
@@ -37,4 +38,5 @@ type Cluster interface {
 	AddSuspectRegions(ids ...uint64)
 	SetHotPendingInfluenceMetrics(storeLabel, rwTy, dim string, load float64)
 	RecordOpStepWithTTL(regionID uint64)
+	GetForceMergeManager() *pkdbforcemerge.Manager
 }

--- a/server/schedule/pkdbforcemerge/pkdb_manager.go
+++ b/server/schedule/pkdbforcemerge/pkdb_manager.go
@@ -340,6 +340,29 @@ func (m *Manager) AddRanges(startKeysHex, endKeysHex []string) error {
 	return nil
 }
 
+// ClearRanges removes all managed force merge ranges.
+func (m *Manager) ClearRanges() error {
+	m.Lock()
+	defer m.Unlock()
+
+	items := make([]*RangeItem, 0, m.tree.Len())
+	m.tree.Ascend(func(item *RangeItem) bool {
+		items = append(items, item)
+		return true
+	})
+	for i, item := range items {
+		if err := m.removeRangeLocked(item); err != nil {
+			log.Error("failed to clear force merge range",
+				logutil.ZapRedactString("failed-start-key", item.StartKeyHex),
+				logutil.ZapRedactString("failed-end-key", item.EndKeyHex),
+				logutil.ZapRedactString("pending-ranges", rangeItemsLogString(items[i+1:])),
+				zap.Error(err))
+			return err
+		}
+	}
+	return nil
+}
+
 // SolveRegion checks whether the region should force merge and clears merged ranges.
 // Regions with empty end key are ignored so the internal range helpers can rely on non-empty endKey.
 // Exactly matched ranges are kept so the region can continue merging with its neighbors.

--- a/server/schedule/pkdbforcemerge/pkdb_manager.go
+++ b/server/schedule/pkdbforcemerge/pkdb_manager.go
@@ -1,0 +1,371 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkdbforcemerge
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/pingcap/log"
+
+	"github.com/tikv/pd/pkg/btree"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/logutil"
+	"github.com/tikv/pd/pkg/syncutil"
+	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/storage/endpoint"
+)
+
+const defaultBTreeDegree = 64
+
+// RangeItem is the managed range unit for force merge.
+type RangeItem struct {
+	StartKey    []byte `json:"-"`
+	StartKeyHex string `json:"start_key"`
+	EndKey      []byte `json:"-"`
+	EndKeyHex   string `json:"end_key"`
+}
+
+// Less returns true when the start key is smaller than the other's start key.
+func (r *RangeItem) Less(other *RangeItem) bool {
+	return bytes.Compare(r.StartKey, other.StartKey) < 0
+}
+
+// String returns the JSON form of the range item.
+func (r *RangeItem) String() string {
+	data, _ := json.Marshal(r)
+	return string(data)
+}
+
+// Manager manages force merge ranges in memory.
+type Manager struct {
+	syncutil.Mutex
+	tree    *btree.BTreeG[*RangeItem]
+	storage endpoint.ForceMergeStorage
+}
+
+// NewManager creates a force merge manager.
+func NewManager(storage endpoint.ForceMergeStorage) (*Manager, error) {
+	manager := &Manager{
+		tree:    btree.NewG[*RangeItem](defaultBTreeDegree),
+		storage: storage,
+	}
+	if err := manager.loadRanges(); err != nil {
+		log.Error("failed to initialize force merge manager", zap.Error(err))
+		return nil, err
+	}
+	return manager, nil
+}
+
+func newRangeItem(startKeyHex, endKeyHex string) (*RangeItem, error) {
+	item := &RangeItem{
+		StartKeyHex: startKeyHex,
+		EndKeyHex:   endKeyHex,
+	}
+	if err := adjustRangeItem(item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+func adjustRangeItem(item *RangeItem) error {
+	if item.EndKeyHex == "" {
+		return errs.ErrForceMergeRangeContent.FastGenByArgs("end key should not be empty")
+	}
+
+	startKey, err := decodeHexKey(item.StartKeyHex)
+	if err != nil {
+		return err
+	}
+	endKey, err := decodeHexKey(item.EndKeyHex)
+	if err != nil {
+		return err
+	}
+	if bytes.Compare(endKey, startKey) <= 0 {
+		return errs.ErrForceMergeRangeContent.FastGenByArgs("end key should be greater than start key")
+	}
+
+	item.StartKey = startKey
+	item.StartKeyHex = hex.EncodeToString(startKey)
+	item.EndKey = endKey
+	item.EndKeyHex = hex.EncodeToString(endKey)
+	return nil
+}
+
+func decodeHexKey(keyHex string) ([]byte, error) {
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		return nil, errs.ErrHexDecodingString.FastGenByArgs(keyHex)
+	}
+	return key, nil
+}
+
+func cloneBytes(data []byte) []byte {
+	return append([]byte(nil), data...)
+}
+
+func rangeItemsLogString(items []*RangeItem) string {
+	data, _ := json.Marshal(items)
+	return string(data)
+}
+
+// coveredByRange assumes endKey is non-empty.
+func coveredByRange(item *RangeItem, startKey, endKey []byte) bool {
+	if bytes.Compare(item.StartKey, startKey) < 0 {
+		return false
+	}
+	return bytes.Compare(item.EndKey, endKey) <= 0
+}
+
+// coversEnd assumes endKey is non-empty.
+func coversEnd(item *RangeItem, endKey []byte) bool {
+	if bytes.Compare(item.StartKey, endKey) > 0 {
+		return false
+	}
+	return bytes.Compare(item.EndKey, endKey) > 0
+}
+
+// searchRangeLocked finds the ranges around the queried range.
+// The caller must ensure endKey is non-empty.
+func (m *Manager) searchRangeLocked(startKey, endKey []byte) (left, right *RangeItem, overlaps []*RangeItem) {
+	if m.tree.Len() == 0 {
+		return nil, nil, nil
+	}
+
+	var candidate *RangeItem
+	m.tree.DescendLessOrEqual(&RangeItem{StartKey: startKey}, func(item *RangeItem) bool {
+		candidate = item
+		return false
+	})
+	if candidate != nil && bytes.Compare(candidate.StartKey, startKey) < 0 && bytes.Compare(startKey, candidate.EndKey) <= 0 {
+		left = candidate
+	}
+
+	m.tree.AscendGreaterOrEqual(&RangeItem{StartKey: startKey}, func(item *RangeItem) bool {
+		if bytes.Compare(item.StartKey, endKey) > 0 {
+			return false
+		}
+		if coveredByRange(item, startKey, endKey) {
+			overlaps = append(overlaps, item)
+			return true
+		}
+		if coversEnd(item, endKey) {
+			right = item
+		}
+		return false
+	})
+	return left, right, overlaps
+}
+
+func (m *Manager) loadRanges() error {
+	if m.storage == nil {
+		return nil
+	}
+
+	var (
+		toSave   []*RangeItem
+		toDelete []string
+	)
+	err := m.storage.LoadForceMergeRanges(func(key, value string) {
+		item := &RangeItem{}
+		if err := json.Unmarshal([]byte(value), item); err != nil {
+			log.Error("failed to unmarshal force merge range",
+				zap.String("range-key", key),
+				zap.String("range-value", value),
+				errs.ZapError(errs.ErrLoadForceMergeRange))
+			toDelete = append(toDelete, key)
+			return
+		}
+		if err := adjustRangeItem(item); err != nil {
+			log.Error("force merge range is in bad format",
+				zap.String("range-key", key),
+				zap.String("range-value", value),
+				errs.ZapError(errs.ErrLoadForceMergeRange, err))
+			toDelete = append(toDelete, key)
+			return
+		}
+		if key != item.EndKeyHex {
+			log.Error("mismatch force merge range key, need to restore",
+				zap.String("range-key", key),
+				zap.String("expected-key", item.EndKeyHex),
+				errs.ZapError(errs.ErrLoadForceMergeRange))
+			toDelete = append(toDelete, key)
+			toSave = append(toSave, item)
+		}
+		m.tree.ReplaceOrInsert(item)
+	})
+	if err != nil {
+		log.Error("failed to load force merge ranges", errs.ZapError(errs.ErrLoadForceMergeRange, err))
+		return err
+	}
+	for _, item := range toSave {
+		if err := m.storage.SaveForceMergeRange(item.EndKeyHex, item); err != nil {
+			log.Error("failed to restore force merge range",
+				logutil.ZapRedactString("start-key", item.StartKeyHex),
+				logutil.ZapRedactString("end-key", item.EndKeyHex),
+				zap.Error(err))
+			return err
+		}
+	}
+	for _, key := range toDelete {
+		if err := m.storage.DeleteForceMergeRange(key); err != nil {
+			log.Error("failed to delete invalid force merge range",
+				zap.String("range-key", key),
+				zap.Error(err))
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Manager) removeRangeLocked(item *RangeItem) error {
+	if m.storage != nil {
+		if err := m.storage.DeleteForceMergeRange(item.EndKeyHex); err != nil {
+			log.Error("failed to persist force merge range deletion",
+				logutil.ZapRedactString("start-key", item.StartKeyHex),
+				logutil.ZapRedactString("end-key", item.EndKeyHex),
+				zap.Error(err))
+			return err
+		}
+	}
+	m.tree.Delete(item)
+	return nil
+}
+
+// addRangeLocked adds a range and merges all overlapped ranges.
+func (m *Manager) addRangeLocked(item *RangeItem) error {
+	left, right, overlaps := m.searchRangeLocked(item.StartKey, item.EndKey)
+	exactOverlap := len(overlaps) == 1 && bytes.Equal(overlaps[0].StartKey, item.StartKey) && bytes.Equal(overlaps[0].EndKey, item.EndKey)
+	if exactOverlap ||
+		(left != nil && bytes.Compare(left.EndKey, item.EndKey) >= 0) ||
+		(right != nil && bytes.Equal(right.StartKey, item.StartKey)) {
+		return nil
+	}
+	if left != nil {
+		if err := m.removeRangeLocked(left); err != nil {
+			return err
+		}
+		item.StartKey = cloneBytes(left.StartKey)
+		item.StartKeyHex = left.StartKeyHex
+	}
+	for _, overlap := range overlaps {
+		if err := m.removeRangeLocked(overlap); err != nil {
+			return err
+		}
+	}
+	if right != nil {
+		if err := m.removeRangeLocked(right); err != nil {
+			return err
+		}
+		item.EndKey = cloneBytes(right.EndKey)
+		item.EndKeyHex = right.EndKeyHex
+	}
+
+	if m.storage != nil {
+		if err := m.storage.SaveForceMergeRange(item.EndKeyHex, item); err != nil {
+			log.Error("failed to persist force merge range",
+				logutil.ZapRedactString("start-key", item.StartKeyHex),
+				logutil.ZapRedactString("end-key", item.EndKeyHex),
+				zap.Error(err))
+			return err
+		}
+	}
+	m.tree.ReplaceOrInsert(item)
+	return nil
+}
+
+// AddRanges validates and adds the ranges into the manager.
+func (m *Manager) AddRanges(startKeysHex, endKeysHex []string) error {
+	if len(startKeysHex) != len(endKeysHex) {
+		return errs.ErrForceMergeRangeContent.FastGenByArgs(
+			fmt.Sprintf("start key count %d does not match end key count %d", len(startKeysHex), len(endKeysHex)))
+	}
+
+	items := make([]*RangeItem, 0, len(startKeysHex))
+	var prevStartKey, prevEndKey []byte
+	for i := range startKeysHex {
+		item, err := newRangeItem(startKeysHex[i], endKeysHex[i])
+		if err != nil {
+			return err
+		}
+		if i > 0 {
+			if bytes.Compare(prevStartKey, item.StartKey) > 0 {
+				return errs.ErrForceMergeRangeContent.FastGenByArgs("start keys should be sorted")
+			}
+			if bytes.Compare(prevEndKey, item.EndKey) > 0 {
+				return errs.ErrForceMergeRangeContent.FastGenByArgs("end keys should be sorted")
+			}
+			if bytes.Compare(prevEndKey, item.StartKey) > 0 {
+				return errs.ErrForceMergeRangeContent.FastGenByArgs("ranges should not overlap")
+			}
+		}
+		prevStartKey = item.StartKey
+		prevEndKey = item.EndKey
+		if len(items) > 0 && bytes.Equal(items[len(items)-1].EndKey, item.StartKey) {
+			items[len(items)-1].EndKey = item.EndKey
+			items[len(items)-1].EndKeyHex = item.EndKeyHex
+			continue
+		}
+		items = append(items, item)
+	}
+
+	m.Lock()
+	defer m.Unlock()
+	for i, item := range items {
+		if err := m.addRangeLocked(item); err != nil {
+			log.Error("failed to add force merge range",
+				logutil.ZapRedactString("failed-start-key", item.StartKeyHex),
+				logutil.ZapRedactString("failed-end-key", item.EndKeyHex),
+				logutil.ZapRedactString("pending-ranges", rangeItemsLogString(items[i+1:])),
+				zap.Error(err))
+			return err
+		}
+	}
+	return nil
+}
+
+// SolveRegion checks whether the region should force merge and clears merged ranges.
+// Regions with empty end key are ignored so the internal range helpers can rely on non-empty endKey.
+// Exactly matched ranges are kept so the region can continue merging with its neighbors.
+func (m *Manager) SolveRegion(region *core.RegionInfo) (needForceMerge bool) {
+	if region == nil {
+		return false
+	}
+	if len(region.GetEndKey()) == 0 {
+		return false
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	startKey := region.GetStartKey()
+	endKey := region.GetEndKey()
+	left, right, overlaps := m.searchRangeLocked(startKey, endKey)
+	exactOverlap := len(overlaps) == 1 && bytes.Equal(overlaps[0].StartKey, startKey) && bytes.Equal(overlaps[0].EndKey, endKey)
+	if exactOverlap {
+		return true
+	}
+	for _, overlap := range overlaps {
+		if err := m.removeRangeLocked(overlap); err != nil {
+			return false
+		}
+	}
+	return (left != nil && bytes.Compare(left.EndKey, endKey) >= 0) ||
+		(right != nil && bytes.Equal(right.StartKey, startKey))
+}

--- a/server/schedule/pkdbforcemerge/pkdb_manager_test.go
+++ b/server/schedule/pkdbforcemerge/pkdb_manager_test.go
@@ -369,3 +369,33 @@ func TestAddRangesMergesAdjacentRangesInCheckPhase(t *testing.T) {
 		"0b": "07-0b",
 	}, collectStoredRanges(t, store))
 }
+
+func TestClearRanges(t *testing.T) {
+	re := require.New(t)
+	store, manager := newTestManager(t)
+	re.NoError(manager.AddRanges([]string{"01", "05"}, []string{"03", "07"}))
+
+	re.NoError(manager.ClearRanges())
+	re.NoError(manager.ClearRanges())
+
+	re.Empty(collectTreeRanges(manager))
+	re.Empty(collectStoredRanges(t, store))
+}
+
+func TestClearRangesStopsAfterPersistError(t *testing.T) {
+	re := require.New(t)
+	baseStore, manager := newTestManager(t)
+	re.NoError(manager.AddRanges([]string{"01", "05"}, []string{"03", "07"}))
+
+	failStore := &failingForceMergeStorage{
+		Storage:       baseStore,
+		failDeleteKey: "07",
+	}
+	manager.storage = failStore
+
+	err := manager.ClearRanges()
+	re.Error(err)
+	re.Equal(2, failStore.deleteCalls)
+	re.Equal([]string{"05-07"}, collectTreeRanges(manager))
+	re.Equal(map[string]string{"07": "05-07"}, collectStoredRanges(t, baseStore))
+}

--- a/server/schedule/pkdbforcemerge/pkdb_manager_test.go
+++ b/server/schedule/pkdbforcemerge/pkdb_manager_test.go
@@ -1,0 +1,371 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkdbforcemerge
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/server/core"
+	"github.com/tikv/pd/server/storage"
+)
+
+func newTestManager(t *testing.T) (storage.Storage, *Manager) {
+	t.Helper()
+	re := require.New(t)
+	store := storage.NewStorageWithMemoryBackend()
+	manager, err := NewManager(store)
+	re.NoError(err)
+	return store, manager
+}
+
+func mustHexDecode(t *testing.T, key string) []byte {
+	t.Helper()
+	if key == "" {
+		return nil
+	}
+	data, err := hex.DecodeString(key)
+	require.NoError(t, err)
+	return data
+}
+
+func newTestRegion(t *testing.T, startKeyHex, endKeyHex string) *core.RegionInfo {
+	t.Helper()
+	return core.NewRegionInfo(&metapb.Region{
+		StartKey: mustHexDecode(t, startKeyHex),
+		EndKey:   mustHexDecode(t, endKeyHex),
+	}, nil)
+}
+
+func collectTreeRanges(m *Manager) []string {
+	ranges := make([]string, 0, m.tree.Len())
+	m.tree.Ascend(func(item *RangeItem) bool {
+		ranges = append(ranges, item.StartKeyHex+"-"+item.EndKeyHex)
+		return true
+	})
+	return ranges
+}
+
+func collectStoredRanges(t *testing.T, store storage.Storage) map[string]string {
+	t.Helper()
+	re := require.New(t)
+	ranges := make(map[string]string)
+	err := store.LoadForceMergeRanges(func(key, value string) {
+		item := &RangeItem{}
+		re.NoError(json.Unmarshal([]byte(value), item))
+		re.NoError(adjustRangeItem(item))
+		ranges[key] = item.StartKeyHex + "-" + item.EndKeyHex
+	})
+	re.NoError(err)
+	return ranges
+}
+
+type failingForceMergeStorage struct {
+	storage.Storage
+	failSaveKey   string
+	failDeleteKey string
+	saveCalls     int
+	deleteCalls   int
+}
+
+func (s *failingForceMergeStorage) SaveForceMergeRange(rangeKey string, data interface{}) error {
+	s.saveCalls++
+	if rangeKey == s.failSaveKey {
+		return errors.New("save failed")
+	}
+	return s.Storage.SaveForceMergeRange(rangeKey, data)
+}
+
+func (s *failingForceMergeStorage) DeleteForceMergeRange(rangeKey string) error {
+	s.deleteCalls++
+	if rangeKey == s.failDeleteKey {
+		return errors.New("delete failed")
+	}
+	return s.Storage.DeleteForceMergeRange(rangeKey)
+}
+
+func TestSearchRangeLocked(t *testing.T) {
+	re := require.New(t)
+	_, manager := newTestManager(t)
+	re.NoError(manager.AddRanges([]string{"01", "04", "07"}, []string{"03", "06", "09"}))
+
+	manager.Lock()
+	left, right, overlaps := manager.searchRangeLocked(mustHexDecode(t, "02"), mustHexDecode(t, "08"))
+	manager.Unlock()
+	re.NotNil(left)
+	re.Equal("01", left.StartKeyHex)
+	re.Equal("03", left.EndKeyHex)
+	re.NotNil(right)
+	re.Equal("07", right.StartKeyHex)
+	re.Equal("09", right.EndKeyHex)
+	re.Len(overlaps, 1)
+	re.Equal("04", overlaps[0].StartKeyHex)
+	re.Equal("06", overlaps[0].EndKeyHex)
+
+	manager.Lock()
+	left, right, overlaps = manager.searchRangeLocked(mustHexDecode(t, "04"), mustHexDecode(t, "06"))
+	manager.Unlock()
+	re.Nil(left)
+	re.Nil(right)
+	re.Len(overlaps, 1)
+	re.Equal("04", overlaps[0].StartKeyHex)
+	re.Equal("06", overlaps[0].EndKeyHex)
+
+	re.NoError(manager.AddRanges([]string{"0b", "0f"}, []string{"0d", "11"}))
+	manager.Lock()
+	left, right, overlaps = manager.searchRangeLocked(mustHexDecode(t, "0d"), mustHexDecode(t, "0f"))
+	manager.Unlock()
+	re.NotNil(left)
+	re.Equal("0b", left.StartKeyHex)
+	re.Equal("0d", left.EndKeyHex)
+	re.NotNil(right)
+	re.Equal("0f", right.StartKeyHex)
+	re.Equal("11", right.EndKeyHex)
+	re.Empty(overlaps)
+}
+
+func TestAddRangeLockedMergeAndPersist(t *testing.T) {
+	re := require.New(t)
+	store, manager := newTestManager(t)
+	re.NoError(manager.AddRanges([]string{"01", "05"}, []string{"03", "07"}))
+
+	item, err := newRangeItem("02", "06")
+	re.NoError(err)
+
+	manager.Lock()
+	err = manager.addRangeLocked(item)
+	manager.Unlock()
+	re.NoError(err)
+
+	re.Equal([]string{"01-07"}, collectTreeRanges(manager))
+	re.Equal(map[string]string{"07": "01-07"}, collectStoredRanges(t, store))
+}
+
+func TestAddRangeLockedMergesAdjacentRanges(t *testing.T) {
+	re := require.New(t)
+	store, manager := newTestManager(t)
+	re.NoError(manager.AddRanges([]string{"01", "05"}, []string{"03", "07"}))
+
+	item, err := newRangeItem("03", "05")
+	re.NoError(err)
+
+	manager.Lock()
+	err = manager.addRangeLocked(item)
+	manager.Unlock()
+	re.NoError(err)
+
+	re.Equal([]string{"01-07"}, collectTreeRanges(manager))
+	re.Equal(map[string]string{"07": "01-07"}, collectStoredRanges(t, store))
+}
+
+func TestAddRangeLockedKeepsContainingRange(t *testing.T) {
+	re := require.New(t)
+	baseStore, manager := newTestManager(t)
+	re.NoError(manager.AddRanges([]string{"01"}, []string{"09"}))
+
+	failStore := &failingForceMergeStorage{Storage: baseStore}
+	manager.storage = failStore
+
+	item, err := newRangeItem("03", "05")
+	re.NoError(err)
+
+	manager.Lock()
+	err = manager.addRangeLocked(item)
+	manager.Unlock()
+	re.NoError(err)
+	re.Equal(0, failStore.deleteCalls)
+	re.Equal(0, failStore.saveCalls)
+
+	re.Equal([]string{"01-09"}, collectTreeRanges(manager))
+	re.Equal(map[string]string{"09": "01-09"}, collectStoredRanges(t, baseStore))
+}
+
+func TestSolveRegion(t *testing.T) {
+	testCases := []struct {
+		name           string
+		startKeysHex   []string
+		endKeysHex     []string
+		regionStart    string
+		regionEnd      string
+		needForceMerge bool
+		expectTree     []string
+		expectStore    map[string]string
+	}{
+		{
+			name:           "exact-overlap",
+			startKeysHex:   []string{"01"},
+			endKeysHex:     []string{"03"},
+			regionStart:    "01",
+			regionEnd:      "03",
+			needForceMerge: true,
+			expectTree:     []string{"01-03"},
+			expectStore:    map[string]string{"03": "01-03"},
+		},
+		{
+			name:           "merged-region-removes-previous-exact-overlap",
+			startKeysHex:   []string{"01"},
+			endKeysHex:     []string{"03"},
+			regionStart:    "01",
+			regionEnd:      "05",
+			needForceMerge: false,
+			expectTree:     []string{},
+			expectStore:    map[string]string{},
+		},
+		{
+			name:           "left-boundary-equal",
+			startKeysHex:   []string{"01"},
+			endKeysHex:     []string{"04"},
+			regionStart:    "01",
+			regionEnd:      "03",
+			needForceMerge: true,
+			expectTree:     []string{"01-04"},
+			expectStore:    map[string]string{"04": "01-04"},
+		},
+		{
+			name:           "right-boundary-equal",
+			startKeysHex:   []string{"02"},
+			endKeysHex:     []string{"05"},
+			regionStart:    "03",
+			regionEnd:      "05",
+			needForceMerge: true,
+			expectTree:     []string{"02-05"},
+			expectStore:    map[string]string{"05": "02-05"},
+		},
+		{
+			name:           "strict-cover",
+			startKeysHex:   []string{"02"},
+			endKeysHex:     []string{"06"},
+			regionStart:    "03",
+			regionEnd:      "05",
+			needForceMerge: true,
+			expectTree:     []string{"02-06"},
+			expectStore:    map[string]string{"06": "02-06"},
+		},
+		{
+			name:           "empty-end-key-region",
+			startKeysHex:   []string{"02"},
+			endKeysHex:     []string{"06"},
+			regionStart:    "03",
+			regionEnd:      "",
+			needForceMerge: false,
+			expectTree:     []string{"02-06"},
+			expectStore:    map[string]string{"06": "02-06"},
+		},
+		{
+			name:           "multi-range-no-cover-removes-overlaps",
+			startKeysHex:   []string{"01", "04", "07"},
+			endKeysHex:     []string{"03", "06", "09"},
+			regionStart:    "02",
+			regionEnd:      "08",
+			needForceMerge: false,
+			expectTree:     []string{"01-03", "07-09"},
+			expectStore:    map[string]string{"03": "01-03", "09": "07-09"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			re := require.New(t)
+			store, manager := newTestManager(t)
+			re.NoError(manager.AddRanges(tc.startKeysHex, tc.endKeysHex))
+
+			needForceMerge := manager.SolveRegion(newTestRegion(t, tc.regionStart, tc.regionEnd))
+			re.Equal(tc.needForceMerge, needForceMerge)
+			re.Equal(tc.expectTree, collectTreeRanges(manager))
+			re.Equal(tc.expectStore, collectStoredRanges(t, store))
+		})
+	}
+}
+
+func TestLoadRangesRestoresCanonicalKeyAndDeletesInvalidData(t *testing.T) {
+	re := require.New(t)
+	store := storage.NewStorageWithMemoryBackend()
+
+	re.NoError(store.SaveForceMergeRange("BB", &RangeItem{StartKeyHex: "AA", EndKeyHex: "BB"}))
+	re.NoError(store.Save(path.Join("force_merge", "cc"), "{bad-json"))
+	re.NoError(store.Save(path.Join("force_merge", "dd"), `{"start_key":"01","end_key":""}`))
+
+	manager, err := NewManager(store)
+	re.NoError(err)
+	re.Equal([]string{"aa-bb"}, collectTreeRanges(manager))
+	re.Equal(map[string]string{"bb": "aa-bb"}, collectStoredRanges(t, store))
+}
+
+func TestAddRangeLockedStopsAfterPersistError(t *testing.T) {
+	re := require.New(t)
+	baseStore, manager := newTestManager(t)
+	re.NoError(manager.AddRanges([]string{"01", "05"}, []string{"03", "07"}))
+
+	failStore := &failingForceMergeStorage{
+		Storage:       baseStore,
+		failDeleteKey: "03",
+	}
+	manager.storage = failStore
+
+	item, err := newRangeItem("02", "06")
+	re.NoError(err)
+
+	manager.Lock()
+	err = manager.addRangeLocked(item)
+	manager.Unlock()
+	re.Error(err)
+	re.Equal(1, failStore.deleteCalls)
+	re.Equal(0, failStore.saveCalls)
+	re.Equal([]string{"01-03", "05-07"}, collectTreeRanges(manager))
+	re.Equal(map[string]string{"03": "01-03", "07": "05-07"}, collectStoredRanges(t, baseStore))
+}
+
+func TestAddRangesValidation(t *testing.T) {
+	re := require.New(t)
+	_, manager := newTestManager(t)
+
+	err := manager.AddRanges([]string{"01"}, []string{})
+	re.ErrorContains(err, "start key count 1 does not match end key count 0")
+
+	err = manager.AddRanges([]string{"02", "01"}, []string{"03", "04"})
+	re.ErrorContains(err, "start keys should be sorted")
+
+	err = manager.AddRanges([]string{"01", "02"}, []string{"04", "03"})
+	re.ErrorContains(err, "end keys should be sorted")
+
+	err = manager.AddRanges([]string{"01", "03"}, []string{"04", "05"})
+	re.ErrorContains(err, "ranges should not overlap")
+
+	re.Empty(collectTreeRanges(manager))
+}
+
+func TestAddRangesMergesAdjacentRangesInCheckPhase(t *testing.T) {
+	re := require.New(t)
+	store, manager := newTestManager(t)
+
+	err := manager.AddRanges(
+		[]string{"01", "03", "07", "09"},
+		[]string{"03", "05", "09", "0b"},
+	)
+	re.NoError(err)
+
+	re.Equal([]string{"01-05", "07-0b"}, collectTreeRanges(manager))
+	re.Equal(map[string]string{
+		"05": "01-05",
+		"0b": "07-0b",
+	}, collectStoredRanges(t, store))
+}

--- a/server/storage/endpoint/key_path.go
+++ b/server/storage/endpoint/key_path.go
@@ -28,6 +28,7 @@ const (
 	schedulePath               = "schedule"
 	gcPath                     = "gc"
 	rulesPath                  = "rules"
+	forceMergePath             = "force_merge"
 	ruleGroupPath              = "rule_group"
 	regionLabelPath            = "region_label"
 	replicationPath            = "replication_mode"
@@ -106,6 +107,10 @@ func RegionPath(regionID uint64) string {
 
 func ruleKeyPath(ruleKey string) string {
 	return path.Join(rulesPath, ruleKey)
+}
+
+func forceMergeRangePath(rangeKey string) string {
+	return path.Join(forceMergePath, rangeKey)
 }
 
 func ruleGroupIDPath(groupID string) string {

--- a/server/storage/endpoint/pkdb_force_merge.go
+++ b/server/storage/endpoint/pkdb_force_merge.go
@@ -1,0 +1,39 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+// ForceMergeStorage defines the storage operations on force merge ranges.
+type ForceMergeStorage interface {
+	LoadForceMergeRanges(f func(k, v string)) error
+	SaveForceMergeRange(rangeKey string, data interface{}) error
+	DeleteForceMergeRange(rangeKey string) error
+}
+
+var _ ForceMergeStorage = (*StorageEndpoint)(nil)
+
+// LoadForceMergeRanges loads all force merge ranges from storage.
+func (se *StorageEndpoint) LoadForceMergeRanges(f func(k, v string)) error {
+	return se.loadRangeByPrefix(forceMergePath+"/", f)
+}
+
+// SaveForceMergeRange stores a force merge range config to storage.
+func (se *StorageEndpoint) SaveForceMergeRange(rangeKey string, data interface{}) error {
+	return se.saveJSON(forceMergePath, rangeKey, data)
+}
+
+// DeleteForceMergeRange removes a force merge range from storage.
+func (se *StorageEndpoint) DeleteForceMergeRange(rangeKey string) error {
+	return se.Remove(forceMergeRangePath(rangeKey))
+}

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -36,6 +36,7 @@ type Storage interface {
 	endpoint.ConfigStorage
 	endpoint.MetaStorage
 	endpoint.RuleStorage
+	endpoint.ForceMergeStorage
 	endpoint.ReplicationStatusStorage
 	endpoint.GCSafePointStorage
 	endpoint.MinResolvedTSStorage


### PR DESCRIPTION
For CI Only

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
