### PR TITLE
tso: fix fallback group 0 return and add metrics

### DIFF
--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -32,12 +32,14 @@ import (
 
 	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/tsopb"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	"github.com/tikv/pd/pkg/mcs/utils"
@@ -261,6 +263,48 @@ func (s *state) checkGroupMerge(
 	return errs.ErrKeyspaceGroupIsMerging.FastGenByArgs(groupID)
 }
 
+// checkKeyspaceHasConfiguredGroup checks if the keyspace has configured a group in its metadata.
+// This is used to determine if we should allow fallback to default group.
+func checkKeyspaceHasConfiguredGroup(storage *endpoint.StorageEndpoint, keyspaceID uint32) bool {
+	// Null keyspace is always allowed to fallback to default group
+	// NullKeyspaceID is used for api v1 or legacy path where is keyspace agnostic
+	if keyspaceID == constant.NullKeyspaceID {
+		log.Debug("[tso] null keyspace, allow fallback to default group",
+			zap.Uint32("keyspace-id", keyspaceID))
+		return false
+	}
+
+	log.Info("[tso] checking keyspace meta for group configuration before fallback",
+		zap.Uint32("keyspace-id", keyspaceID))
+
+	// Load keyspace metadata from storage
+	var meta *keyspacepb.KeyspaceMeta
+	err := storage.RunInTxn(context.Background(), func(txn kv.Txn) error {
+		var err error
+		meta, err = storage.LoadKeyspaceMeta(txn, keyspaceID)
+		return err
+	})
+
+	if err != nil || meta == nil {
+		// If can't load or not found, assume no group configured (legacy keyspace)
+		log.Info("[tso] keyspace meta not found or failed to load, assume legacy keyspace",
+			zap.Uint32("keyspace-id", keyspaceID), zap.Error(err))
+		return false
+	}
+
+	// Check if Config has TSOKeyspaceGroupIDKey
+	_, hasGroup := meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]
+	if hasGroup {
+		log.Info("[tso] keyspace has configured group in meta, should not fallback to default group",
+			zap.Uint32("keyspace-id", keyspaceID),
+			zap.String("configured-group-id", meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]))
+	} else {
+		log.Info("[tso] keyspace has no group configuration in meta, can fallback to default group",
+			zap.Uint32("keyspace-id", keyspaceID))
+	}
+	return hasGroup
+}
+
 // getKeyspaceGroupMetaWithCheck returns the keyspace group meta of the given keyspace.
 // It also checks if the keyspace is served by the given keyspace group. If not, it returns the meta
 // of the keyspace group to which the keyspace currently belongs and returns NotServed (by the given
@@ -269,6 +313,7 @@ func (s *state) checkGroupMerge(
 // keyspace movement between keyspace groups.
 func (s *state) getKeyspaceGroupMetaWithCheck(
 	keyspaceID, keyspaceGroupID uint32,
+	kgm *KeyspaceGroupManager,
 ) (*Allocator, *endpoint.KeyspaceGroup, uint32, uint64, error) {
 	s.RLock()
 	defer s.RUnlock()
@@ -303,6 +348,23 @@ func (s *state) getKeyspaceGroupMetaWithCheck(
 		return nil, nil, constant.DefaultKeyspaceGroupID, s.modRevision,
 			errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
 	}
+	// Before fallback to default group, check if the keyspace has configured a group in its metadata.
+	// If it has, don't fallback to avoid incorrect switching when state is inconsistent.
+	if kgm != nil && checkKeyspaceHasConfiguredGroup(kgm.storage, keyspaceID) {
+		if kgm.metrics != nil {
+			kgm.metrics.keyspaceFallbackRejectedCounter.Inc()
+		}
+		log.Debug("[tso] keyspace has configured group but not found in lookup table, skip fallback to default group",
+			zap.Uint32("keyspace-id", keyspaceID),
+			zap.Uint32("requested-group-id", keyspaceGroupID))
+		return nil, nil, keyspaceGroupID, s.modRevision, errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
+	}
+	if kgm != nil && kgm.metrics != nil {
+		kgm.metrics.keyspaceFallbackToDefaultCounter.Inc()
+	}
+	log.Debug("[tso] keyspace not found in any group, fallback to default group",
+		zap.Uint32("keyspace-id", keyspaceID),
+		zap.Uint32("requested-group-id", keyspaceGroupID))
 	return s.allocators[constant.DefaultKeyspaceGroupID],
 		s.kgs[constant.DefaultKeyspaceGroupID],
 		constant.DefaultKeyspaceGroupID, s.modRevision, nil
@@ -1050,7 +1112,7 @@ func (kgm *KeyspaceGroupManager) FindGroupByKeyspaceID(
 	keyspaceID uint32,
 ) (*Allocator, *endpoint.KeyspaceGroup, uint32, uint64, error) {
 	curAllocator, curKeyspaceGroup, curKeyspaceGroupID, modRevision, err :=
-		kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, constant.DefaultKeyspaceGroupID)
+		kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, constant.DefaultKeyspaceGroupID, kgm)
 	if err != nil {
 		return nil, nil, curKeyspaceGroupID, modRevision, err
 	}
@@ -1064,7 +1126,7 @@ func (kgm *KeyspaceGroupManager) GetMember(
 	if err := checkKeySpaceGroupID(keyspaceGroupID); err != nil {
 		return nil, err
 	}
-	allocator, _, _, _, err := kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, keyspaceGroupID)
+	allocator, _, _, _, err := kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, keyspaceGroupID, kgm)
 	if err != nil {
 		return nil, err
 	}
@@ -1094,7 +1156,7 @@ func (kgm *KeyspaceGroupManager) HandleTSORequest(
 	if err := checkKeySpaceGroupID(keyspaceGroupID); err != nil {
 		return pdpb.Timestamp{}, keyspaceGroupID, err
 	}
-	allocator, _, curKeyspaceGroupID, _, err := kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, keyspaceGroupID)
+	allocator, _, curKeyspaceGroupID, _, err := kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, keyspaceGroupID, kgm)
 	if err != nil {
 		return pdpb.Timestamp{}, curKeyspaceGroupID, err
 	}

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -263,45 +264,6 @@ func (s *state) checkGroupMerge(
 	return errs.ErrKeyspaceGroupIsMerging.FastGenByArgs(groupID)
 }
 
-// checkKeyspaceHasConfiguredGroup checks if the keyspace has configured a group in its metadata.
-// This is used to determine if we should allow fallback to default group.
-func checkKeyspaceHasConfiguredGroup(ctx context.Context, storage *endpoint.StorageEndpoint, keyspaceID uint32) bool {
-	// Null keyspace is always allowed to fallback to default group
-	// NullKeyspaceID is used for api v1 or legacy path where is keyspace agnostic
-	if keyspaceID == constant.NullKeyspaceID {
-		log.Debug("null keyspace, allow fallback to default group",
-			zap.Uint32("keyspace-id", keyspaceID))
-		return false
-	}
-
-	// Load keyspace metadata from storage
-	var meta *keyspacepb.KeyspaceMeta
-	var err error
-	err = storage.RunInTxn(ctx, func(txn kv.Txn) error {
-		meta, err = storage.LoadKeyspaceMeta(txn, keyspaceID)
-		return err
-	})
-
-	if err != nil || meta == nil {
-		// If can't load or not found, assume no group configured (legacy keyspace)
-		log.Info("[tso] keyspace meta not found or failed to load, assume legacy keyspace",
-			zap.Uint32("keyspace-id", keyspaceID), zap.Error(err))
-		return false
-	}
-
-	// Check if Config has TSOKeyspaceGroupIDKey
-	_, hasGroup := meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]
-	if hasGroup {
-		log.Info("keyspace has configured group in meta, should not fallback to default group",
-			zap.Uint32("keyspace-id", keyspaceID),
-			zap.String("configured-group-id", meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]))
-	} else {
-		log.Info("keyspace has no group configuration in meta, can fallback to default group",
-			zap.Uint32("keyspace-id", keyspaceID))
-	}
-	return hasGroup
-}
-
 // getKeyspaceGroupMetaWithCheck returns the keyspace group meta of the given keyspace.
 // It also checks if the keyspace is served by the given keyspace group. If not, it returns the meta
 // of the keyspace group to which the keyspace currently belongs and returns NotServed (by the given
@@ -348,7 +310,7 @@ func (s *state) getKeyspaceGroupMetaWithCheck(
 	// Before fallback to default group, check if the keyspace has configured a group in its metadata.
 	// If it has, don't fallback to avoid incorrect switching when state is inconsistent.
 	if kgm != nil && kgm.checkKeyspaceHasConfiguredGroup(keyspaceID) {
-		log.Debug("[tso] keyspace has configured group but not found in lookup table, skip fallback to default group",
+		log.Debug("tso keyspace has configured group but not found in lookup table, skip fallback to default group",
 			zap.Uint32("keyspace-id", keyspaceID),
 			zap.Uint32("requested-group-id", keyspaceGroupID))
 		return nil, nil, keyspaceGroupID, s.modRevision, errs.ErrKeyspaceNotAssigned.FastGenByArgs(keyspaceID)
@@ -356,7 +318,7 @@ func (s *state) getKeyspaceGroupMetaWithCheck(
 	if kgm != nil && kgm.metrics != nil {
 		kgm.metrics.keyspaceFallbackToDefaultCounter.Inc()
 	}
-	log.Debug("[tso] keyspace not found in any group, fallback to default group",
+	log.Debug("tso keyspace not found in any group, fallback to default group",
 		zap.Uint32("keyspace-id", keyspaceID),
 		zap.Uint32("requested-group-id", keyspaceGroupID))
 	return s.allocators[constant.DefaultKeyspaceGroupID],
@@ -597,17 +559,31 @@ func (kgm *KeyspaceGroupManager) checkKeyspaceHasConfiguredGroup(keyspaceID uint
 
 	if err != nil {
 		// If can't load or not found, assume no group configured (legacy keyspace)
-		log.Info("[tso] keyspace meta not found or failed to load, assume legacy keyspace",
+		log.Info("tso keyspace meta not found or failed to load, assume legacy keyspace",
 			zap.Uint32("keyspace-id", keyspaceID), zap.Error(err))
 		return false
 	}
+	if meta == nil {
+		return false
+	}
 
-	// Check if Config has TSOKeyspaceGroupIDKey
-	_, hasGroup := meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]
-	if kgm.metrics != nil && hasGroup {
+	configuredGroupID, hasGroup := meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]
+	if !hasGroup {
+		return false
+	}
+	groupID, err := strconv.ParseUint(configuredGroupID, 10, 32)
+	if err != nil {
+		log.Warn("failed to parse configured tso keyspace group id, skip fallback to default group",
+			zap.Uint32("keyspace-id", keyspaceID),
+			zap.String("configured-group-id", configuredGroupID),
+			zap.Error(err))
+		return true
+	}
+	hasNonDefaultGroup := uint32(groupID) != constant.DefaultKeyspaceGroupID
+	if kgm.metrics != nil && hasNonDefaultGroup {
 		kgm.metrics.keyspaceFallbackRejectedCounter.Inc()
 	}
-	return hasGroup
+	return hasNonDefaultGroup
 }
 
 // InitializeGroupWatchLoop initializes the watch loop monitoring the path for storing keyspace group

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -265,22 +265,19 @@ func (s *state) checkGroupMerge(
 
 // checkKeyspaceHasConfiguredGroup checks if the keyspace has configured a group in its metadata.
 // This is used to determine if we should allow fallback to default group.
-func checkKeyspaceHasConfiguredGroup(storage *endpoint.StorageEndpoint, keyspaceID uint32) bool {
+func checkKeyspaceHasConfiguredGroup(ctx context.Context, storage *endpoint.StorageEndpoint, keyspaceID uint32) bool {
 	// Null keyspace is always allowed to fallback to default group
 	// NullKeyspaceID is used for api v1 or legacy path where is keyspace agnostic
 	if keyspaceID == constant.NullKeyspaceID {
-		log.Debug("[tso] null keyspace, allow fallback to default group",
+		log.Debug("null keyspace, allow fallback to default group",
 			zap.Uint32("keyspace-id", keyspaceID))
 		return false
 	}
 
-	log.Info("[tso] checking keyspace meta for group configuration before fallback",
-		zap.Uint32("keyspace-id", keyspaceID))
-
 	// Load keyspace metadata from storage
 	var meta *keyspacepb.KeyspaceMeta
-	err := storage.RunInTxn(context.Background(), func(txn kv.Txn) error {
-		var err error
+	var err error
+	err = storage.RunInTxn(ctx, func(txn kv.Txn) error {
 		meta, err = storage.LoadKeyspaceMeta(txn, keyspaceID)
 		return err
 	})
@@ -295,11 +292,11 @@ func checkKeyspaceHasConfiguredGroup(storage *endpoint.StorageEndpoint, keyspace
 	// Check if Config has TSOKeyspaceGroupIDKey
 	_, hasGroup := meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]
 	if hasGroup {
-		log.Info("[tso] keyspace has configured group in meta, should not fallback to default group",
+		log.Info("keyspace has configured group in meta, should not fallback to default group",
 			zap.Uint32("keyspace-id", keyspaceID),
 			zap.String("configured-group-id", meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]))
 	} else {
-		log.Info("[tso] keyspace has no group configuration in meta, can fallback to default group",
+		log.Info("keyspace has no group configuration in meta, can fallback to default group",
 			zap.Uint32("keyspace-id", keyspaceID))
 	}
 	return hasGroup
@@ -350,10 +347,7 @@ func (s *state) getKeyspaceGroupMetaWithCheck(
 	}
 	// Before fallback to default group, check if the keyspace has configured a group in its metadata.
 	// If it has, don't fallback to avoid incorrect switching when state is inconsistent.
-	if kgm != nil && checkKeyspaceHasConfiguredGroup(kgm.storage, keyspaceID) {
-		if kgm.metrics != nil {
-			kgm.metrics.keyspaceFallbackRejectedCounter.Inc()
-		}
+	if kgm != nil && kgm.checkKeyspaceHasConfiguredGroup(keyspaceID) {
 		log.Debug("[tso] keyspace has configured group but not found in lookup table, skip fallback to default group",
 			zap.Uint32("keyspace-id", keyspaceID),
 			zap.Uint32("requested-group-id", keyspaceGroupID))
@@ -580,6 +574,40 @@ func (kgm *KeyspaceGroupManager) InitializeTSOServerWatchLoop() error {
 	}
 
 	return nil
+}
+
+// checkKeyspaceHasConfiguredGroup checks if the keyspace has configured a group in its metadata.
+// This is used to determine if we should allow fallback to default group.
+func (kgm *KeyspaceGroupManager) checkKeyspaceHasConfiguredGroup(keyspaceID uint32) bool {
+	// Null keyspace is always allowed to fallback to default group
+	// NullKeyspaceID is used for api v1 or legacy path where is keyspace agnostic
+	if keyspaceID == constant.NullKeyspaceID {
+		log.Debug("null keyspace, allow fallback to default group",
+			zap.Uint32("keyspace-id", keyspaceID))
+		return false
+	}
+
+	// Load keyspace metadata from storage
+	var meta *keyspacepb.KeyspaceMeta
+	var err error
+	err = kgm.storage.RunInTxn(kgm.ctx, func(txn kv.Txn) error {
+		meta, err = kgm.storage.LoadKeyspaceMeta(txn, keyspaceID)
+		return err
+	})
+
+	if err != nil {
+		// If can't load or not found, assume no group configured (legacy keyspace)
+		log.Info("[tso] keyspace meta not found or failed to load, assume legacy keyspace",
+			zap.Uint32("keyspace-id", keyspaceID), zap.Error(err))
+		return false
+	}
+
+	// Check if Config has TSOKeyspaceGroupIDKey
+	_, hasGroup := meta.GetConfig()[keyspace.TSOKeyspaceGroupIDKey]
+	if kgm.metrics != nil && hasGroup {
+		kgm.metrics.keyspaceFallbackRejectedCounter.Inc()
+	}
+	return hasGroup
 }
 
 // InitializeGroupWatchLoop initializes the watch loop monitoring the path for storing keyspace group

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/failpoint"
-	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
@@ -36,11 +34,13 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/goleak"
 
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	mcs "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/storage/endpoint"
-
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
@@ -1459,7 +1459,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestCheckKeyspaceGroupFallback() {
 	keyspaceID2 := uint32(200)
 	configuredGroupID := uint32(5)
 
-	allocator, kg, groupID, _, err := mgr.state.getKeyspaceGroupMetaWithCheck(
+	allocator, kg, groupID, _, err := mgr.getKeyspaceGroupMetaWithCheck(
 		constant.NullKeyspaceID, constant.DefaultKeyspaceGroupID, mgr)
 	re.NoError(err)
 	re.NotNil(allocator)
@@ -1479,7 +1479,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestCheckKeyspaceGroupFallback() {
 	})
 	re.NoError(err)
 
-	allocator, kg, groupID, _, err = mgr.state.getKeyspaceGroupMetaWithCheck(
+	allocator, kg, groupID, _, err = mgr.getKeyspaceGroupMetaWithCheck(
 		keyspaceID1, constant.DefaultKeyspaceGroupID, mgr)
 	re.Nil(allocator)
 	re.Nil(kg)
@@ -1496,7 +1496,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestCheckKeyspaceGroupFallback() {
 	})
 	re.NoError(err)
 
-	allocator, kg, groupID, _, err = mgr.state.getKeyspaceGroupMetaWithCheck(
+	allocator, kg, groupID, _, err = mgr.getKeyspaceGroupMetaWithCheck(
 		keyspaceID2, constant.DefaultKeyspaceGroupID, mgr)
 	re.NoError(err)
 	re.NotNil(allocator)
@@ -1505,7 +1505,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestCheckKeyspaceGroupFallback() {
 	re.Equal(constant.DefaultKeyspaceGroupID, kg.ID)
 
 	keyspaceID3 := uint32(300)
-	allocator, kg, groupID, _, err = mgr.state.getKeyspaceGroupMetaWithCheck(
+	allocator, kg, groupID, _, err = mgr.getKeyspaceGroupMetaWithCheck(
 		keyspaceID3, constant.DefaultKeyspaceGroupID, mgr)
 	re.NoError(err)
 	re.NotNil(allocator)

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
@@ -34,12 +36,12 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/goleak"
 
-	"github.com/pingcap/failpoint"
-
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	mcs "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/storage/endpoint"
+
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/syncutil"
@@ -428,43 +430,43 @@ func (suite *keyspaceGroupManagerTestSuite) TestGetKeyspaceGroupMetaWithCheck() 
 	re.NoError(err)
 
 	// Should be able to get the allocators for the default/null keyspace and keyspace 1, 2 in keyspace group 0.
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 0)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 0, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
 	re.NotNil(kg)
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.NullKeyspaceID, 0)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.NullKeyspaceID, 0, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
 	re.NotNil(kg)
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(1, 0)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(1, 0, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
 	re.NotNil(kg)
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(2, 0)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(2, 0, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
 	re.NotNil(kg)
 	// Should still succeed even keyspace 3 isn't explicitly assigned to any
 	// keyspace group. It will be assigned to the default keyspace group.
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(3, 0)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(3, 0, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
 	re.NotNil(kg)
 	// Should succeed and get the meta of keyspace group 0, because keyspace 0
 	// belongs to group 0, though the specified group 1 doesn't exist.
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 1)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 1, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
 	re.NotNil(kg)
 	// Should fail because keyspace 3 isn't explicitly assigned to any keyspace
 	// group, and the specified group isn't the default keyspace group.
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(3, 100)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(3, 100, mgr)
 	re.Error(err)
 	re.Equal(uint32(100), kgid)
 	re.Nil(allocator)
@@ -509,7 +511,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestDefaultMembershipRestriction() {
 
 	// Should be able to get the allocator for keyspace 0 in keyspace group 0.
 	allocator, kg, kgid, modRevision, err = mgr.getKeyspaceGroupMetaWithCheck(
-		constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID)
+		constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
@@ -531,7 +533,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestDefaultMembershipRestriction() {
 	// Behavior differs between Classic and NextGen modes
 	if kerneltype.IsNextGen() {
 		// In NextGen mode, keyspace 0 should be allowed to move to keyspace group 3
-		allocator, kg, kgid, modRevision, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 3)
+		allocator, kg, kgid, modRevision, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 3, mgr)
 		re.NoError(err)
 		re.Equal(uint32(3), kgid) // Should be in group 3
 		re.NotNil(allocator)
@@ -540,13 +542,13 @@ func (suite *keyspaceGroupManagerTestSuite) TestDefaultMembershipRestriction() {
 	} else {
 		// In Classic mode, keyspace 0 should stay in the default keyspace group 0
 		allocator, kg, kgid, modRevision, err = mgr.getKeyspaceGroupMetaWithCheck(
-			constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID)
+			constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID, mgr)
 		re.NoError(err)
 		re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 		re.NotNil(allocator)
 		re.NotNil(kg)
 		// Should succeed and return the keyspace group meta from the default keyspace group
-		allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 3)
+		allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(constant.DefaultKeyspaceID, 3, mgr)
 		re.NoError(err)
 		re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 		re.NotNil(allocator)
@@ -595,7 +597,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestKeyspaceMovementConsistency() {
 	re.NoError(err)
 
 	// Should be able to get the allocator for keyspace 10 in keyspace group 0.
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(10, constant.DefaultKeyspaceGroupID)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(10, constant.DefaultKeyspaceGroupID, mgr)
 	re.NoError(err)
 	re.Equal(constant.DefaultKeyspaceGroupID, kgid)
 	re.NotNil(allocator)
@@ -608,7 +610,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestKeyspaceMovementConsistency() {
 	re.NoError(err)
 	// Wait until the keyspace 10 is served by keyspace group 1.
 	testutil.Eventually(re, func() bool {
-		_, _, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(10, 1)
+		_, _, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(10, 1, mgr)
 		return err == nil && kgid == 1
 	}, testutil.WithWaitFor(3*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 
@@ -621,7 +623,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestKeyspaceMovementConsistency() {
 	// it will cause random failure.
 	time.Sleep(1 * time.Second)
 	// Should still be able to get the allocator for keyspace 10 in keyspace group 1.
-	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(10, 1)
+	allocator, kg, kgid, _, err = mgr.getKeyspaceGroupMetaWithCheck(10, 1, mgr)
 	re.NoError(err)
 	re.Equal(uint32(1), kgid)
 	re.NotNil(allocator)
@@ -1435,4 +1437,79 @@ func (suite *keyspaceGroupManagerTestSuite) TestStaleCache() {
 		re.True(ok, id)
 		re.Equal(groupID, groupID1)
 	}
+}
+
+// TestCheckKeyspaceGroupFallback tests the fallback logic when keyspace is not found in lookup table.
+func (suite *keyspaceGroupManagerTestSuite) TestCheckKeyspaceGroupFallback() {
+	re := suite.Require()
+
+	mgr := suite.newUniqueKeyspaceGroupManager(0)
+	re.NotNil(mgr)
+	defer mgr.Close()
+	err := mgr.Initialize()
+	re.NoError(err)
+
+	testutil.Eventually(re, func() bool {
+		allocator, _, _, _, err := mgr.getKeyspaceGroupMetaWithCheck(
+			constant.DefaultKeyspaceID, constant.DefaultKeyspaceGroupID, mgr)
+		return err == nil && allocator != nil
+	})
+
+	keyspaceID1 := uint32(100)
+	keyspaceID2 := uint32(200)
+	configuredGroupID := uint32(5)
+
+	allocator, kg, groupID, _, err := mgr.state.getKeyspaceGroupMetaWithCheck(
+		constant.NullKeyspaceID, constant.DefaultKeyspaceGroupID, mgr)
+	re.NoError(err)
+	re.NotNil(allocator)
+	re.NotNil(kg)
+	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
+	re.Equal(constant.DefaultKeyspaceGroupID, kg.ID)
+
+	meta1 := &keyspacepb.KeyspaceMeta{
+		Id:   keyspaceID1,
+		Name: "test_keyspace_1",
+		Config: map[string]string{
+			"tso_keyspace_group_id": strconv.FormatUint(uint64(configuredGroupID), 10),
+		},
+	}
+	err = mgr.storage.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+		return mgr.storage.SaveKeyspaceMeta(txn, meta1)
+	})
+	re.NoError(err)
+
+	allocator, kg, groupID, _, err = mgr.state.getKeyspaceGroupMetaWithCheck(
+		keyspaceID1, constant.DefaultKeyspaceGroupID, mgr)
+	re.Nil(allocator)
+	re.Nil(kg)
+	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
+	re.Error(err)
+
+	meta2 := &keyspacepb.KeyspaceMeta{
+		Id:     keyspaceID2,
+		Name:   "test_keyspace_2",
+		Config: map[string]string{},
+	}
+	err = mgr.storage.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+		return mgr.storage.SaveKeyspaceMeta(txn, meta2)
+	})
+	re.NoError(err)
+
+	allocator, kg, groupID, _, err = mgr.state.getKeyspaceGroupMetaWithCheck(
+		keyspaceID2, constant.DefaultKeyspaceGroupID, mgr)
+	re.NoError(err)
+	re.NotNil(allocator)
+	re.NotNil(kg)
+	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
+	re.Equal(constant.DefaultKeyspaceGroupID, kg.ID)
+
+	keyspaceID3 := uint32(300)
+	allocator, kg, groupID, _, err = mgr.state.getKeyspaceGroupMetaWithCheck(
+		keyspaceID3, constant.DefaultKeyspaceGroupID, mgr)
+	re.NoError(err)
+	re.NotNil(allocator)
+	re.NotNil(kg)
+	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
+	re.Equal(constant.DefaultKeyspaceGroupID, kg.ID)
 }

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1457,6 +1457,8 @@ func (suite *keyspaceGroupManagerTestSuite) TestCheckKeyspaceGroupFallback() {
 
 	keyspaceID1 := uint32(100)
 	keyspaceID2 := uint32(200)
+	keyspaceID3 := uint32(300)
+	keyspaceID4 := uint32(400)
 	configuredGroupID := uint32(5)
 
 	allocator, kg, groupID, _, err := mgr.getKeyspaceGroupMetaWithCheck(
@@ -1504,9 +1506,28 @@ func (suite *keyspaceGroupManagerTestSuite) TestCheckKeyspaceGroupFallback() {
 	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
 	re.Equal(constant.DefaultKeyspaceGroupID, kg.ID)
 
-	keyspaceID3 := uint32(300)
 	allocator, kg, groupID, _, err = mgr.getKeyspaceGroupMetaWithCheck(
 		keyspaceID3, constant.DefaultKeyspaceGroupID, mgr)
+	re.NoError(err)
+	re.NotNil(allocator)
+	re.NotNil(kg)
+	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
+	re.Equal(constant.DefaultKeyspaceGroupID, kg.ID)
+
+	meta4 := &keyspacepb.KeyspaceMeta{
+		Id:   keyspaceID4,
+		Name: "test_keyspace_4",
+		Config: map[string]string{
+			"tso_keyspace_group_id": strconv.FormatUint(uint64(constant.DefaultKeyspaceGroupID), 10),
+		},
+	}
+	err = mgr.storage.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+		return mgr.storage.SaveKeyspaceMeta(txn, meta4)
+	})
+	re.NoError(err)
+
+	allocator, kg, groupID, _, err = mgr.getKeyspaceGroupMetaWithCheck(
+		keyspaceID4, constant.DefaultKeyspaceGroupID, mgr)
 	re.NoError(err)
 	re.NotNil(allocator)
 	re.NotNil(kg)

--- a/pkg/tso/metrics.go
+++ b/pkg/tso/metrics.go
@@ -89,6 +89,14 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
 		}, []string{typeLabel})
 
+	keyspaceFallbackCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: tsoNamespace,
+			Subsystem: "keyspace",
+			Name:      "fallback_events",
+			Help:      "Counter of keyspace fallback events.",
+		}, []string{typeLabel})
+
 	// keyspaceGroupKeyspaceCountGauge records the keyspace list length of each keyspace group.
 	keyspaceGroupKeyspaceCountGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -111,6 +119,7 @@ func init() {
 	prometheus.MustRegister(keyspaceGroupStateGauge)
 	prometheus.MustRegister(keyspaceGroupOpDuration)
 	prometheus.MustRegister(keyspaceGroupKeyspaceCountGauge)
+	prometheus.MustRegister(keyspaceFallbackCounter)
 }
 
 type tsoMetrics struct {
@@ -186,30 +195,34 @@ func newTSOMetrics(groupID string) *tsoMetrics {
 }
 
 type keyspaceGroupMetrics struct {
-	splitSourceGauge        prometheus.Gauge
-	splitTargetGauge        prometheus.Gauge
-	mergeSourceGauge        prometheus.Gauge
-	mergeTargetGauge        prometheus.Gauge
-	splitDuration           prometheus.Observer
-	mergeDuration           prometheus.Observer
-	finishSplitSendDuration prometheus.Observer
-	finishSplitDuration     prometheus.Observer
-	finishMergeSendDuration prometheus.Observer
-	finishMergeDuration     prometheus.Observer
+	splitSourceGauge                 prometheus.Gauge
+	splitTargetGauge                 prometheus.Gauge
+	mergeSourceGauge                 prometheus.Gauge
+	mergeTargetGauge                 prometheus.Gauge
+	splitDuration                    prometheus.Observer
+	mergeDuration                    prometheus.Observer
+	finishSplitSendDuration          prometheus.Observer
+	finishSplitDuration              prometheus.Observer
+	finishMergeSendDuration          prometheus.Observer
+	finishMergeDuration              prometheus.Observer
+	keyspaceFallbackRejectedCounter  prometheus.Counter
+	keyspaceFallbackToDefaultCounter prometheus.Counter
 }
 
 func newKeyspaceGroupMetrics() *keyspaceGroupMetrics {
 	return &keyspaceGroupMetrics{
-		splitSourceGauge:        keyspaceGroupStateGauge.WithLabelValues("split-source"),
-		splitTargetGauge:        keyspaceGroupStateGauge.WithLabelValues("split-target"),
-		mergeSourceGauge:        keyspaceGroupStateGauge.WithLabelValues("merge-source"),
-		mergeTargetGauge:        keyspaceGroupStateGauge.WithLabelValues("merge-target"),
-		splitDuration:           keyspaceGroupOpDuration.WithLabelValues("split"),
-		mergeDuration:           keyspaceGroupOpDuration.WithLabelValues("merge"),
-		finishSplitSendDuration: keyspaceGroupOpDuration.WithLabelValues("finish-split-send"),
-		finishSplitDuration:     keyspaceGroupOpDuration.WithLabelValues("finish-split"),
-		finishMergeSendDuration: keyspaceGroupOpDuration.WithLabelValues("finish-merge-send"),
-		finishMergeDuration:     keyspaceGroupOpDuration.WithLabelValues("finish-merge"),
+		splitSourceGauge:                 keyspaceGroupStateGauge.WithLabelValues("split-source"),
+		splitTargetGauge:                 keyspaceGroupStateGauge.WithLabelValues("split-target"),
+		mergeSourceGauge:                 keyspaceGroupStateGauge.WithLabelValues("merge-source"),
+		mergeTargetGauge:                 keyspaceGroupStateGauge.WithLabelValues("merge-target"),
+		splitDuration:                    keyspaceGroupOpDuration.WithLabelValues("split"),
+		mergeDuration:                    keyspaceGroupOpDuration.WithLabelValues("merge"),
+		finishSplitSendDuration:          keyspaceGroupOpDuration.WithLabelValues("finish-split-send"),
+		finishSplitDuration:              keyspaceGroupOpDuration.WithLabelValues("finish-split"),
+		finishMergeSendDuration:          keyspaceGroupOpDuration.WithLabelValues("finish-merge-send"),
+		finishMergeDuration:              keyspaceGroupOpDuration.WithLabelValues("finish-merge"),
+		keyspaceFallbackRejectedCounter:  keyspaceFallbackCounter.WithLabelValues("rejected"),
+		keyspaceFallbackToDefaultCounter: keyspaceFallbackCounter.WithLabelValues("to_default"),
 	}
 }
 

--- a/pkg/tso/metrics.go
+++ b/pkg/tso/metrics.go
@@ -222,7 +222,7 @@ func newKeyspaceGroupMetrics() *keyspaceGroupMetrics {
 		finishMergeSendDuration:          keyspaceGroupOpDuration.WithLabelValues("finish-merge-send"),
 		finishMergeDuration:              keyspaceGroupOpDuration.WithLabelValues("finish-merge"),
 		keyspaceFallbackRejectedCounter:  keyspaceFallbackCounter.WithLabelValues("rejected"),
-		keyspaceFallbackToDefaultCounter: keyspaceFallbackCounter.WithLabelValues("to_default"),
+		keyspaceFallbackToDefaultCounter: keyspaceFallbackCounter.WithLabelValues("fallback-default"),
 	}
 }
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -165,13 +165,13 @@ type RaftCluster struct {
 	etcdClient *clientv3.Client
 	httpClient *http.Client
 
-	running                bool
-	isKeyspaceGroupEnabled bool
+	running                  bool
+	isKeyspaceGroupEnabled   bool
 	tsoDynamicSwitchingState atomic.Int32
-	meta                   *metapb.Cluster
-	storage                storage.Storage
-	minResolvedTS          atomic.Value // Store as uint64
-	externalTS             atomic.Value // Store as uint64
+	meta                     *metapb.Cluster
+	storage                  storage.Storage
+	minResolvedTS            atomic.Value // Store as uint64
+	externalTS               atomic.Value // Store as uint64
 
 	// Keep the previous store limit settings when removing a store.
 	prevStoreLimit sync.Map // map[uint64]map[storelimit.Type]float64


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10516, Close #10554, Close #10601

This PR cherry-picks TSO keyspace group fallback fixes and fallback metrics from the release keyspace branch.

Author: @ystaticy

CP:
- cp [`7786830e`](https://github.com/bufferflies/pd/commit/7786830edce80c337b26f815ca6e0d4a82b48b5c)
- cp [`271ac93b`](https://github.com/bufferflies/pd/commit/271ac93bedef65f692c09b0ad6c37ce207f9973b)

### What is changed and how does it work?

```commit-message
Fix stale TSO keyspace group lookup fallback so a keyspace with a configured TSO group no longer falls back to group 0 when the group state is stale.

Add TSO fallback outcome metrics for rejected fallback and fallback-to-default cases.

Keep the current master branch formatting clean for server cluster startup fields.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix an issue that could incorrectly return the default TSO keyspace group when a keyspace already has a configured TSO group, and add metrics for TSO fallback outcomes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyspace group assignment logic to properly respect configured keyspace groups and prevent unintended fallback to defaults.

* **Monitoring**
  * Added metrics to track keyspace group fallback events for improved system observability.

* **Tests**
  * Added comprehensive test coverage for keyspace group assignment and fallback validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->