### PR TITLE
server/resource_group: add allocation observability

### DIFF
--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -231,6 +231,7 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 				zap.Uint32("keyspace-id", keyspaceID),
 				zap.String("resource-group", resourceGroupName),
 			)
+			keyspaceName := s.manager.getKeyspaceNameForMetrics(s.ctx, keyspaceID)
 			// Get keyspace resource group manager to apply service limit later.
 			krgm, err := s.manager.accessKeyspaceResourceGroupManager(keyspaceID, resourceGroupName)
 			if krgm == nil {
@@ -269,7 +270,7 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 						grt := krgm.getOrCreateGroupRUTracker(rg.Name)
 						grt.sample(clientUniqueID, now, requiredToken)
 						// Request the tokens from the resource group.
-						tokens = rg.RequestRU(now, requiredToken, targetPeriodMs, clientUniqueID, grt, krgm.getServiceLimiter())
+						tokens = rg.RequestRU(now, requiredToken, targetPeriodMs, clientUniqueID, keyspaceName, grt, krgm.getServiceLimiter())
 					}
 					if tokens == nil {
 						continue

--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -231,7 +231,6 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 				zap.Uint32("keyspace-id", keyspaceID),
 				zap.String("resource-group", resourceGroupName),
 			)
-			keyspaceName := s.manager.getKeyspaceNameForMetrics(s.ctx, keyspaceID)
 			// Get keyspace resource group manager to apply service limit later.
 			krgm, err := s.manager.accessKeyspaceResourceGroupManager(keyspaceID, resourceGroupName)
 			if krgm == nil {
@@ -252,6 +251,7 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 			if req.GetIsBackground() {
 				continue
 			}
+			keyspaceName := s.manager.getKeyspaceNameForMetrics(s.ctx, keyspaceID)
 			now := time.Now()
 			resp := &rmpb.TokenBucketResponse{
 				ResourceGroupName: rg.Name,

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -709,6 +709,17 @@ func (m *Manager) getKeyspaceNameByID(ctx context.Context, id uint32) (string, e
 	return loadedName, nil
 }
 
+func (m *Manager) getKeyspaceNameForMetrics(ctx context.Context, id uint32) string {
+	name, err := m.getKeyspaceNameByID(ctx, id)
+	if err == nil {
+		return name
+	}
+	if id == constant.NullKeyspaceID {
+		return ""
+	}
+	return fmt.Sprintf("keyspace-%d", id)
+}
+
 func (m *Manager) updateKeyspaceNameLookup(id uint32, name string) {
 	m.Lock()
 	defer m.Unlock()
@@ -791,10 +802,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				continue
 			}
 			keyspaceID := consumptionInfo.keyspaceID
-			keyspaceName, err := m.getKeyspaceNameByID(ctx, keyspaceID)
-			if err != nil {
-				continue
-			}
+			keyspaceName := m.getKeyspaceNameForMetrics(ctx, keyspaceID)
 			consumptionInfo.keyspaceName = keyspaceName
 			m.ruCollector.Collect(consumptionInfo)
 			m.metrics.recordConsumption(consumptionInfo, m.GetControllerConfig(), time.Now())
@@ -808,10 +816,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				if time.Since(lastTime) <= metricsCleanupTimeout {
 					continue
 				}
-				keyspaceName, err := m.getKeyspaceNameByID(ctx, r.keyspaceID)
-				if err != nil {
-					continue
-				}
+				keyspaceName := m.getKeyspaceNameForMetrics(ctx, r.keyspaceID)
 				m.metrics.cleanupAllMetrics(r, keyspaceName)
 				m.ruCollector.remove(keyspaceName)
 			}
@@ -838,10 +843,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				// Conciliate the fill rates.
 				krgm.conciliateFillRates()
 				// Record the metrics.
-				keyspaceName, err := m.getKeyspaceNameByID(ctx, krgm.keyspaceID)
-				if err != nil {
-					continue
-				}
+				keyspaceName := m.getKeyspaceNameForMetrics(ctx, krgm.keyspaceID)
 				setOrRemoveServiceLimitMetrics(keyspaceName, krgm.getServiceLimiter().getServiceLimit())
 
 				for _, group := range krgm.getResourceGroupList(true, true) {

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -28,7 +28,6 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/goleak"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 
@@ -563,18 +562,12 @@ func TestCleanUpTicker(t *testing.T) {
 		groupName:  "test_group_2",
 		ruType:     defaultTypeLabel,
 	}] = time.Now().Add(-metricsCleanupTimeout / 2)
-	// Start the background metrics flush loop.
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/mcs/resourcemanager/server/fastCleanupTicker", `return(true)`))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/mcs/resourcemanager/server/fastCleanupTicker"))
-	}()
-	err := m.Init(ctx)
-	re.NoError(err)
-	// Ensure the cleanup ticker is triggered.
-	time.Sleep(200 * time.Millisecond)
-	// Close the manager to avoid the data race.
-	m.close()
-
+	keyspaceName := m.getKeyspaceNameForMetrics(ctx, keyspaceID)
+	m.metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  "test_group_1",
+		ruType:     defaultTypeLabel,
+	}, keyspaceName)
 	re.Len(m.metrics.consumptionRecordMap, 1)
 	re.Contains(m.metrics.consumptionRecordMap, consumptionRecordKey{
 		keyspaceID: keyspaceID,
@@ -669,6 +662,7 @@ func TestKeyspaceNameLookup(t *testing.T) {
 	name, err = m.getKeyspaceNameByID(ctx, 1)
 	re.Error(err)
 	re.Empty(name)
+	re.Equal("keyspace-1", m.getKeyspaceNameForMetrics(ctx, 1))
 	// Get the keyspace ID by name first, then get the keyspace name by ID.
 	prepareKeyspaceName(ctx, re, m, &rmpb.KeyspaceIDValue{Value: 1}, "test_keyspace")
 	idValue, err = m.GetKeyspaceIDByName(ctx, "test_keyspace")

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -42,6 +42,9 @@ const (
 	fillRateLabel             = "fill_rate"
 	burstLimitLabel           = "burst_limit"
 	slotEventLabel            = "event"
+	slotCreatedEventLabel     = "created"
+	slotDeletedEventLabel     = "deleted"
+	slotExpiredEventLabel     = "expired"
 	kindLabel                 = "kind"
 	throttleKindLabel         = "throttling"
 	trickleKindLabel          = "trickle"
@@ -268,7 +271,7 @@ var (
 			Namespace: namespace,
 			Subsystem: serverSubsystem,
 			Name:      "request_cause_total",
-			Help:      "Counter of throttling and trickle causes per resource group.",
+			Help:      "Counter of throttling and trickle contributing causes per resource group.",
 		}, []string{newResourceGroupNameLabel, keyspaceNameLabel, kindLabel, "cause"})
 )
 
@@ -554,9 +557,9 @@ func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 		overrideBurstLimitGauge:            overrideSettings.WithLabelValues(groupName, keyspaceName, burstLimitLabel),
 		activeSlotCountGauge:               activeSlotCountGauge.WithLabelValues(groupName, keyspaceName),
 		tokenLoanGauge:                     tokenLoanGauge.WithLabelValues(groupName, keyspaceName),
-		slotCreatedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "created"),
-		slotDeletedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "deleted"),
-		slotExpiredCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "expired"),
+		slotCreatedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotCreatedEventLabel),
+		slotDeletedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotDeletedEventLabel),
+		slotExpiredCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotExpiredEventLabel),
 	}
 }
 
@@ -629,9 +632,9 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)
 	activeSlotCountGauge.DeleteLabelValues(groupName, keyspaceName)
 	tokenLoanGauge.DeleteLabelValues(groupName, keyspaceName)
-	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "created")
-	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "deleted")
-	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "expired")
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotCreatedEventLabel)
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotDeletedEventLabel)
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotExpiredEventLabel)
 	grantedTokensHistogram.DeleteLabelValues(groupName, keyspaceName)
 	trickleDurationHistogram.DeleteLabelValues(groupName, keyspaceName)
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -41,6 +41,12 @@ const (
 	keyspaceNameLabel         = "keyspace_name"
 	fillRateLabel             = "fill_rate"
 	burstLimitLabel           = "burst_limit"
+	slotEventLabel            = "event"
+	kindLabel                 = "kind"
+	throttleKindLabel         = "throttling"
+	trickleKindLabel          = "trickle"
+	serviceLimitCauseLabel    = "service_limit"
+	groupCauseLabel           = "group_fill_rate_or_burst"
 
 	// Labels for the config.
 	ruPerSecLabel   = "ru_per_sec"
@@ -220,6 +226,50 @@ var (
 			Help:      "The duration of pushing RU metrics to Prometheus.",
 			Buckets:   prometheus.DefBuckets,
 		})
+	grantedTokensHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "granted_tokens",
+			Help:      "Histogram of tokens granted per request.",
+			Buckets:   []float64{0, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000},
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	activeSlotCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "active_slot_count",
+			Help:      "Number of active token slots per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	slotEventsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "slot_events_total",
+			Help:      "Counter of slot lifecycle events (created, deleted, expired).",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel, slotEventLabel})
+	tokenLoanGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "token_loan",
+			Help:      "Current total token loan amount per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	trickleDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "trickle_duration_ms",
+			Help:      "Histogram of trickle duration in milliseconds per request.",
+			Buckets:   []float64{0, 100, 500, 1000, 2000, 3000, 4000, 5000, 10000},
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	requestCauseCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "request_cause_total",
+			Help:      "Counter of throttling and trickle causes per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel, kindLabel, "cause"})
 )
 
 type metrics struct {
@@ -274,6 +324,12 @@ func init() {
 	prometheus.MustRegister(overrideSettings)
 	prometheus.MustRegister(serviceLimit)
 	prometheus.MustRegister(pushRUMetricsDuration)
+	prometheus.MustRegister(grantedTokensHistogram)
+	prometheus.MustRegister(activeSlotCountGauge)
+	prometheus.MustRegister(slotEventsCounter)
+	prometheus.MustRegister(tokenLoanGauge)
+	prometheus.MustRegister(trickleDurationHistogram)
+	prometheus.MustRegister(requestCauseCounter)
 }
 
 func newMetrics() *metrics {
@@ -480,6 +536,11 @@ type gaugeMetrics struct {
 	sampledRequestUnitPerSecGauge      prometheus.Gauge
 	overrideFillRateGauge              prometheus.Gauge
 	overrideBurstLimitGauge            prometheus.Gauge
+	activeSlotCountGauge               prometheus.Gauge
+	tokenLoanGauge                     prometheus.Gauge
+	slotCreatedCounter                 prometheus.Counter
+	slotDeletedCounter                 prometheus.Counter
+	slotExpiredCounter                 prometheus.Counter
 }
 
 func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
@@ -491,6 +552,11 @@ func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 		sampledRequestUnitPerSecGauge:      sampledRequestUnitPerSec.WithLabelValues(groupName, keyspaceName),
 		overrideFillRateGauge:              overrideSettings.WithLabelValues(groupName, keyspaceName, fillRateLabel),
 		overrideBurstLimitGauge:            overrideSettings.WithLabelValues(groupName, keyspaceName, burstLimitLabel),
+		activeSlotCountGauge:               activeSlotCountGauge.WithLabelValues(groupName, keyspaceName),
+		tokenLoanGauge:                     tokenLoanGauge.WithLabelValues(groupName, keyspaceName),
+		slotCreatedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "created"),
+		slotDeletedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "deleted"),
+		slotExpiredCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, "expired"),
 	}
 }
 
@@ -516,6 +582,15 @@ func (m *gaugeMetrics) setGroup(group *ResourceGroup, keyspaceName string) {
 		overrideSettings.DeleteLabelValues(group.Name, keyspaceName, burstLimitLabel)
 	} else {
 		m.overrideBurstLimitGauge.Set(float64(overrideBurstLimit))
+	}
+
+	slotMetrics := group.GetSlotMetrics()
+	m.activeSlotCountGauge.Set(float64(slotMetrics.SlotCount))
+	m.tokenLoanGauge.Set(slotMetrics.TokenLoan)
+	if created, deleted, expired := group.DrainSlotEvents(); created+deleted+expired > 0 {
+		m.slotCreatedCounter.Add(float64(created))
+		m.slotDeletedCounter.Add(float64(deleted))
+		m.slotExpiredCounter.Add(float64(expired))
 	}
 }
 
@@ -552,7 +627,30 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	sampledRequestUnitPerSec.DeleteLabelValues(groupName, keyspaceName)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, fillRateLabel)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)
+	activeSlotCountGauge.DeleteLabelValues(groupName, keyspaceName)
+	tokenLoanGauge.DeleteLabelValues(groupName, keyspaceName)
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "created")
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "deleted")
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, "expired")
+	grantedTokensHistogram.DeleteLabelValues(groupName, keyspaceName)
+	trickleDurationHistogram.DeleteLabelValues(groupName, keyspaceName)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, throttleKindLabel, groupCauseLabel)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
 	resourceGroupConfigGauge.DeletePartialMatch(prometheus.Labels{newResourceGroupNameLabel: groupName, keyspaceNameLabel: keyspaceName})
+}
+
+func observeTokenGrant(groupName, keyspaceName string, tokens *rmpb.GrantedRUTokenBucket) {
+	if tokens == nil || tokens.GrantedTokens == nil {
+		return
+	}
+	grantedTokensHistogram.WithLabelValues(groupName, keyspaceName).Observe(tokens.GrantedTokens.GetTokens())
+	trickleDurationHistogram.WithLabelValues(groupName, keyspaceName).Observe(float64(tokens.GetTrickleTimeMs()))
+}
+
+func observeRequestCause(groupName, keyspaceName, kind, cause string) {
+	requestCauseCounter.WithLabelValues(groupName, keyspaceName, kind, cause).Inc()
 }
 
 type maxPerSecCostTracker struct {

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -15,9 +15,12 @@
 package server
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -113,4 +116,105 @@ func TestMaxPerSecCostTracker(t *testing.T) {
 			re.Equal(tracker.rruSum, expectedSum[period])
 		}
 	}
+}
+
+func TestObserveTokenGrantRecordsZeroTrickle(t *testing.T) {
+	re := require.New(t)
+	groupName := "observe_token_group"
+	keyspaceName := "observe_token_keyspace"
+
+	observeTokenGrant(groupName, keyspaceName, &rmpb.GrantedRUTokenBucket{
+		GrantedTokens: &rmpb.TokenBucket{Tokens: 42},
+		TrickleTimeMs: 0,
+	})
+
+	granted := findHistogramMetric(re, "resource_manager_server_granted_tokens", map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	})
+	re.Equal(uint64(1), granted.GetSampleCount())
+	re.Equal(42.0, granted.GetSampleSum())
+
+	trickle := findHistogramMetric(re, "resource_manager_server_trickle_duration_ms", map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	})
+	re.Equal(uint64(1), trickle.GetSampleCount())
+	re.Zero(trickle.GetSampleSum())
+}
+
+func TestObserveRequestCause(t *testing.T) {
+	re := require.New(t)
+	groupName := "observe_request_group"
+	keyspaceName := "observe_request_keyspace"
+	throttleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	trickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+
+	observeRequestCause(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	observeRequestCause(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+
+	re.Equal(1.0, testutil.ToFloat64(throttleCounter))
+	re.Equal(1.0, testutil.ToFloat64(trickleCounter))
+}
+
+func TestGaugeMetricsSetGroupSlotMetrics(t *testing.T) {
+	re := require.New(t)
+	groupName := "slot_group"
+	keyspaceName := "slot_keyspace"
+	rg := &ResourceGroup{
+		Name: groupName,
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: NewRequestUnitSettings(groupName, &rmpb.TokenBucket{
+			Settings: &rmpb.TokenLimitSettings{
+				FillRate:   100,
+				BurstLimit: 200,
+			},
+		}),
+	}
+	rg.RUSettings.RU.tokenSlots[1] = &tokenSlot{curTokenCapacity: -12.5}
+	rg.RUSettings.RU.slotsCreated = 2
+	rg.RUSettings.RU.slotsDeleted = 1
+	rg.RUSettings.RU.slotsExpired = 3
+
+	gm := newGaugeMetrics(keyspaceName, groupName)
+	gm.setGroup(rg, keyspaceName)
+
+	re.Equal(1.0, testutil.ToFloat64(gm.activeSlotCountGauge))
+	re.Equal(12.5, testutil.ToFloat64(gm.tokenLoanGauge))
+	re.Equal(2.0, testutil.ToFloat64(gm.slotCreatedCounter))
+	re.Equal(1.0, testutil.ToFloat64(gm.slotDeletedCounter))
+	re.Equal(3.0, testutil.ToFloat64(gm.slotExpiredCounter))
+	created, deleted, expired := rg.DrainSlotEvents()
+	re.Zero(created)
+	re.Zero(deleted)
+	re.Zero(expired)
+}
+
+func findHistogramMetric(re *require.Assertions, metricName string, labels map[string]string) *dto.Histogram {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	re.NoError(err)
+	for _, mf := range metrics {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if matchMetricLabels(metric.GetLabel(), labels) {
+				return metric.GetHistogram()
+			}
+		}
+	}
+	re.FailNow(fmt.Sprintf("metric %s with labels %v not found", metricName, labels))
+	return nil
+}
+
+func matchMetricLabels(actual []*dto.LabelPair, expected map[string]string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for _, label := range actual {
+		if expected[label.GetName()] != label.GetValue() {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -155,6 +156,40 @@ func TestObserveRequestCause(t *testing.T) {
 
 	re.Equal(1.0, testutil.ToFloat64(throttleCounter))
 	re.Equal(1.0, testutil.ToFloat64(trickleCounter))
+}
+
+func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
+	re := require.New(t)
+	groupName := "request_ru_trickle_group"
+	keyspaceName := "request_ru_trickle_keyspace"
+	t.Cleanup(func() {
+		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+	})
+
+	serviceTrickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	groupTrickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+	now := time.Now()
+	rg := &ResourceGroup{
+		Name: groupName,
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: NewRequestUnitSettings(groupName, &rmpb.TokenBucket{
+			Settings: &rmpb.TokenLimitSettings{
+				FillRate:   100,
+				BurstLimit: 1000,
+			},
+		}),
+	}
+	sl := newServiceLimiter(1, 10, nil)
+	sl.AvailableTokens = 10
+	sl.LastUpdate = now
+
+	tokens := rg.RequestRU(now, 10, 1000, 1, keyspaceName, nil, sl)
+
+	re.NotNil(tokens)
+	re.Equal(10.0, tokens.GetGrantedTokens().GetTokens())
+	re.Equal(int64(1000), tokens.GetTrickleTimeMs())
+	re.Equal(1.0, testutil.ToFloat64(serviceTrickleCounter))
+	re.Zero(testutil.ToFloat64(groupTrickleCounter))
 }
 
 func TestGaugeMetricsSetGroupSlotMetrics(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -198,6 +198,47 @@ func (rg *ResourceGroup) overrideFillRateAndBurstLimit(fillRate float64, burstLi
 	rg.overrideBurstLimitLocked(burstLimit)
 }
 
+// SlotMetrics holds a snapshot of the token slot state for metrics reporting.
+type SlotMetrics struct {
+	SlotCount int
+	TokenLoan float64
+}
+
+// GetSlotMetrics returns the current token slot snapshot under the group lock.
+func (rg *ResourceGroup) GetSlotMetrics() SlotMetrics {
+	rg.RLock()
+	defer rg.RUnlock()
+	if rg.RUSettings == nil || rg.RUSettings.RU == nil {
+		return SlotMetrics{}
+	}
+	var tokenLoan float64
+	for _, slot := range rg.RUSettings.RU.tokenSlots {
+		if slot.curTokenCapacity < 0 {
+			tokenLoan += -slot.curTokenCapacity
+		}
+	}
+	return SlotMetrics{
+		SlotCount: len(rg.RUSettings.RU.tokenSlots),
+		TokenLoan: tokenLoan,
+	}
+}
+
+// DrainSlotEvents returns the accumulated slot event counts and resets them.
+func (rg *ResourceGroup) DrainSlotEvents() (created, deleted, expired uint64) {
+	rg.Lock()
+	defer rg.Unlock()
+	if rg.RUSettings == nil || rg.RUSettings.RU == nil {
+		return 0, 0, 0
+	}
+	created = rg.RUSettings.RU.slotsCreated
+	deleted = rg.RUSettings.RU.slotsDeleted
+	expired = rg.RUSettings.RU.slotsExpired
+	rg.RUSettings.RU.slotsCreated = 0
+	rg.RUSettings.RU.slotsDeleted = 0
+	rg.RUSettings.RU.slotsExpired = 0
+	return
+}
+
 // PatchSettings patches the resource group settings.
 // Only used to patch the resource group when updating.
 // Note: the tokens is the delta value to patch.
@@ -274,6 +315,7 @@ func (rg *ResourceGroup) RequestRU(
 	now time.Time,
 	requiredToken float64,
 	targetPeriodMs, clientUniqueID uint64,
+	keyspaceName string,
 	grt *groupRUTracker, sl *serviceLimiter,
 ) *rmpb.GrantedRUTokenBucket {
 	rg.Lock()
@@ -293,7 +335,8 @@ func (rg *ResourceGroup) RequestRU(
 	// Then, try to apply the service limit.
 	grantedTokens := tb.GetTokens()
 	limitedTokens, minTrickleTimeMs := sl.applyServiceLimit(now, grantedTokens)
-	if limitedTokens < grantedTokens {
+	serviceLimited := limitedTokens < grantedTokens
+	if serviceLimited {
 		tb.Tokens = limitedTokens
 		// Retain the unused tokens for the later requests if it has a burst limit.
 		if rg.getBurstLimitLocked() > 0 {
@@ -302,6 +345,69 @@ func (rg *ResourceGroup) RequestRU(
 	}
 	if trickleTimeMs < minTrickleTimeMs {
 		trickleTimeMs = minTrickleTimeMs
+	}
+	observeTokenGrant(rg.Name, keyspaceName, &rmpb.GrantedRUTokenBucket{
+		GrantedTokens: &rmpb.TokenBucket{Tokens: tb.GetTokens()},
+		TrickleTimeMs: trickleTimeMs,
+	})
+	if serviceLimited {
+		observeRequestCause(rg.Name, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	}
+	if grantedTokens < requiredToken {
+		observeRequestCause(rg.Name, keyspaceName, throttleKindLabel, groupCauseLabel)
+	}
+	if minTrickleTimeMs > 0 {
+		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	}
+	if trickleTimeMs > 0 {
+		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, groupCauseLabel)
+	}
+	if serviceLimited || grantedTokens < requiredToken {
+		cause := groupCauseLabel
+		if serviceLimited {
+			cause = serviceLimitCauseLabel
+		}
+		sampledRUPerSec := 0.0
+		if grt != nil {
+			sampledRUPerSec = grt.getRUPerSec()
+		}
+		serviceLimit := 0.0
+		if sl != nil {
+			serviceLimit = sl.getServiceLimit()
+		}
+		overrideFillRate := rg.RUSettings.RU.overrideFillRate
+		log.Info("resource group token request is limited",
+			zap.String("resource-group", rg.Name),
+			zap.String("keyspace-name", keyspaceName),
+			zap.Uint64("client-unique-id", clientUniqueID),
+			zap.Float64("required-token", requiredToken),
+			zap.Float64("granted-token", tb.GetTokens()),
+			zap.Int64("trickle-ms", trickleTimeMs),
+			zap.Float64("sampled-ru-per-sec", sampledRUPerSec),
+			zap.Float64("override-fill-rate", overrideFillRate),
+			zap.Float64("service-limit", serviceLimit),
+			zap.String("cause", cause),
+		)
+	}
+	if trickleTimeMs > 0 {
+		cause := groupCauseLabel
+		if minTrickleTimeMs > 0 {
+			cause = serviceLimitCauseLabel
+		}
+		serviceLimit := 0.0
+		if sl != nil {
+			serviceLimit = sl.getServiceLimit()
+		}
+		log.Debug("resource group token request is trickled",
+			zap.String("resource-group", rg.Name),
+			zap.String("keyspace-name", keyspaceName),
+			zap.Uint64("client-unique-id", clientUniqueID),
+			zap.Float64("required-token", requiredToken),
+			zap.Float64("granted-token", tb.GetTokens()),
+			zap.Int64("trickle-ms", trickleTimeMs),
+			zap.Float64("service-limit", serviceLimit),
+			zap.String("cause", cause),
+		)
 	}
 	return &rmpb.GrantedRUTokenBucket{GrantedTokens: tb, TrickleTimeMs: trickleTimeMs}
 }

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -334,6 +334,7 @@ func (rg *ResourceGroup) RequestRU(
 	}
 	// Then, try to apply the service limit.
 	grantedTokens := tb.GetTokens()
+	groupTrickleTimeMs := trickleTimeMs
 	limitedTokens, minTrickleTimeMs := sl.applyServiceLimit(now, grantedTokens)
 	serviceLimited := limitedTokens < grantedTokens
 	if serviceLimited {
@@ -359,7 +360,7 @@ func (rg *ResourceGroup) RequestRU(
 	if minTrickleTimeMs > 0 {
 		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
 	}
-	if trickleTimeMs > 0 {
+	if groupTrickleTimeMs > 0 {
 		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, groupCauseLabel)
 	}
 	if serviceLimited || grantedTokens < requiredToken {
@@ -376,7 +377,7 @@ func (rg *ResourceGroup) RequestRU(
 			serviceLimit = sl.getServiceLimit()
 		}
 		overrideFillRate := rg.RUSettings.RU.overrideFillRate
-		log.Info("resource group token request is limited",
+		log.Debug("resource group token request is limited",
 			zap.String("resource-group", rg.Name),
 			zap.String("keyspace-name", keyspaceName),
 			zap.Uint64("client-unique-id", clientUniqueID),

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -195,6 +195,11 @@ type GroupTokenBucketState struct {
 
 	// settingChanged is used to avoid that the number of tokens returned is jitter because of changing fill rate.
 	settingChanged bool
+
+	// Slot event accumulators for metrics reporting.
+	slotsCreated uint64
+	slotsDeleted uint64
+	slotsExpired uint64
 }
 
 func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
@@ -219,6 +224,9 @@ func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
 		tokenSlots:         tokenSlots,
 		overrideFillRate:   gts.overrideFillRate,
 		overrideBurstLimit: gts.overrideBurstLimit,
+		slotsCreated:       gts.slotsCreated,
+		slotsDeleted:       gts.slotsDeleted,
+		slotsExpired:       gts.slotsExpired,
 	}
 }
 
@@ -248,6 +256,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 			zap.Float64("required-token", requiredToken),
 			zap.Int("slot-len", len(gtb.tokenSlots)),
 		)
+		gtb.slotsCreated++
 	} else if exist && requiredToken != 0 {
 		// Update the existing slot.
 		slot.lastReqTime = now
@@ -261,11 +270,15 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 			)
 		}
 		delete(gtb.tokenSlots, clientUniqueID)
+		if exist {
+			gtb.slotsDeleted++
+		}
 	}
 	// Clean up the expired slots.
 	for clientUniqueID, slot := range gtb.tokenSlots {
 		if time.Since(slot.lastReqTime) >= slotExpireTimeout {
 			delete(gtb.tokenSlots, clientUniqueID)
+			gtb.slotsExpired++
 			log.Info("delete resource group slot because expire",
 				zap.Time("last-req-time", slot.lastReqTime),
 				zap.Duration("expire-timeout", slotExpireTimeout),

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -335,6 +335,33 @@ func TestGroupTokenBucketRequestLoop(t *testing.T) {
 	}
 }
 
+func TestGroupTokenBucketSlotEventCounters(t *testing.T) {
+	re := require.New(t)
+	tbSetting := &rmpb.TokenBucket{
+		Tokens: 200000,
+		Settings: &rmpb.TokenLimitSettings{
+			FillRate:   2000,
+			BurstLimit: 20000000,
+		},
+	}
+
+	gtb := NewGroupTokenBucket(testResourceGroupName, tbSetting)
+	now := time.Now()
+	clientUniqueID := uint64(100)
+
+	gtb.request(now, 1000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
+	re.Equal(uint64(1), gtb.slotsCreated)
+
+	gtb.request(now, 0, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
+	re.Equal(uint64(1), gtb.slotsDeleted)
+
+	gtb.request(now, 1000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
+	re.Equal(uint64(2), gtb.slotsCreated)
+	gtb.tokenSlots[clientUniqueID].lastReqTime = now.Add(-(slotExpireTimeout + time.Second))
+	gtb.request(now.Add(2*time.Second), 1000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID+1)
+	re.Equal(uint64(1), gtb.slotsExpired)
+}
+
 func TestBalanceSlotTokensFillRateAllocation(t *testing.T) {
 	re := require.New(t)
 


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #10488

Resource control observability on the server side does not clearly show why tokens are granted slowly, whether `service_limit` is involved, or whether server-side metrics stay correct across cleanup and edge cases.

### What is changed and how does it work?

This PR adds server-side allocation metrics and fixes several correctness gaps so the controller and server can be diagnosed together.

```commit-message
server/resource_group: add allocation observability
```

It includes:
- server metrics for granted tokens, slot counts, slot events, token loan, trickle duration, RU config, and throttling causes
- explicit cause attribution for `service_limit` versus `group_fill_rate_or_burst`
- keyspace-name fallback and cleanup fixes so metrics stay continuous
- tests for immediate grant, trickle grant, slot-event accounting, and metric cleanup

### Check List

Tests

- Unit test
- Manual test (add detailed scripts or steps below)

Manual test:
- Verified in a local `tiup playground` setup with 3 PD, 2 TiDB, and 3 TiKV.
- Ran a shared-`service_limit` scenario with two resource groups and confirmed Grafana shows `service_limit` in throttling causes.
- Ran a low-fill-rate scenario and confirmed Grafana shows `group_fill_rate_or_burst` without false `service_limit` signals.

Code changes

Side effects

- Increased code complexity

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

```release-note
Add server-side resource control metrics for allocation state, token trickle, and throttling causes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metrics for token-slot lifecycle (created, deleted, expired)
  * Added granted-token and trickle-duration instrumentation and request-cause classification
  * Per-request keyspace labeling to improve metrics granularity

* **Bug Fixes**
  * Metrics collection now uses a resilient keyspace-name fallback to avoid skipped metrics

* **Tests**
  * New and expanded tests for slot metrics, token-grant observation, and request-cause tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->