### PR TITLE
server: add GC request metrics

### DIFF
--- a/.github/workflows/pd-tests.yaml
+++ b/.github/workflows/pd-tests.yaml
@@ -8,6 +8,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
+      - release-fts-202602
       - release-nextgen-20250815
   pull_request:
     branches:
@@ -17,6 +18,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
+      - release-fts-202602
       - release-nextgen-20250815
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/tso-function-test.yaml
+++ b/.github/workflows/tso-function-test.yaml
@@ -7,6 +7,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
+      - release-fts-202602
       - release-nextgen-20250815
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
       - release-6.*
       - release-7.*
       - release-8.*
+      - release-fts-202602
       - release-nextgen-20250815
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/pkg/utils/grpcutil/metrics.go
+++ b/pkg/utils/grpcutil/metrics.go
@@ -31,31 +31,31 @@ const (
 	requestFailed  requestEvent = "failed"
 )
 
-// RequestCounter increments the region request counter with the given method, header, error, and counter.
+// RequestCounter increments the request counter with the given method, header, error, and counter.
 func RequestCounter(method string, header *pdpb.RequestHeader, err *pdpb.Error, counter *prometheus.CounterVec) {
 	if err == nil && rand.IntN(100) != 0 {
-		// sample 1% region requests to avoid high cardinality
+		// sample 1% requests to avoid high cardinality
 		return
 	}
 
 	var (
 		event           = requestSuccess
-		callerID        = header.CallerId
-		callerComponent = header.CallerComponent
+		callerID        = header.GetCallerId()
+		callerComponent = header.GetCallerComponent()
 	)
-	if err != nil {
-		log.Warn("region request encounter error",
-			zap.String("method", method),
-			zap.String("caller_id", callerID),
-			zap.String("caller_component", callerComponent),
-			zap.Stringer("error", err))
-		event = requestFailed
-	}
 	if callerID == "" {
 		callerID = "unknown"
 	}
 	if callerComponent == "" {
 		callerComponent = "unknown"
+	}
+	if err != nil {
+		log.Warn("request encountered error",
+			zap.String("method", method),
+			zap.String("caller-id", callerID),
+			zap.String("caller-component", callerComponent),
+			zap.Stringer("error", err))
+		event = requestFailed
 	}
 	counter.WithLabelValues(method, callerID, callerComponent, string(event)).Inc()
 }

--- a/pkg/utils/grpcutil/metrics_test.go
+++ b/pkg/utils/grpcutil/metrics_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutil
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+func TestRequestCounterCountsFailureAndUnknownCaller(t *testing.T) {
+	re := require.New(t)
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_request_counter_total"},
+		[]string{"request", "caller_id", "caller_component", "event"})
+
+	RequestCounter("GetGCSafePoint", nil, &pdpb.Error{
+		Type:    pdpb.ErrorType_UNKNOWN,
+		Message: "test error",
+	}, counter)
+
+	re.Equal(float64(1), gatherCounterValue(re, counter, "GetGCSafePoint", "unknown", "unknown", "failed"))
+}
+
+func TestRequestCounterCountsFailureWithEmptyCaller(t *testing.T) {
+	re := require.New(t)
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_request_counter_with_empty_caller_total"},
+		[]string{"request", "caller_id", "caller_component", "event"})
+
+	RequestCounter("UpdateGCSafePoint", &pdpb.RequestHeader{}, &pdpb.Error{
+		Type:    pdpb.ErrorType_UNKNOWN,
+		Message: "test error",
+	}, counter)
+
+	re.Equal(float64(1), gatherCounterValue(re, counter, "UpdateGCSafePoint", "unknown", "unknown", "failed"))
+}
+
+func gatherCounterValue(re *require.Assertions, counter *prometheus.CounterVec, values ...string) float64 {
+	registry := prometheus.NewRegistry()
+	re.NoError(registry.Register(counter))
+	metricFamilies, err := registry.Gather()
+	re.NoError(err)
+	expectedLabels := map[string]string{
+		"request":          values[0],
+		"caller_id":        values[1],
+		"caller_component": values[2],
+		"event":            values[3],
+	}
+	for _, metricFamily := range metricFamilies {
+		for _, metric := range metricFamily.GetMetric() {
+			labels := metric.GetLabel()
+			if len(labels) != len(values) {
+				continue
+			}
+			matched := true
+			for _, label := range labels {
+				if expectedLabels[label.GetName()] != label.GetValue() {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}

--- a/server/gc_metrics.go
+++ b/server/gc_metrics.go
@@ -1,0 +1,39 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	"github.com/tikv/pd/pkg/utils/grpcutil"
+)
+
+type gcResponseWithHeader interface {
+	GetHeader() *pdpb.ResponseHeader
+}
+
+func recordGCRequest(method string, requestHeader *pdpb.RequestHeader, response gcResponseWithHeader, err error) {
+	var respErr *pdpb.Error
+	if response != nil && response.GetHeader() != nil {
+		respErr = response.GetHeader().GetError()
+	}
+	if respErr == nil && err != nil {
+		respErr = &pdpb.Error{
+			Type:    pdpb.ErrorType_UNKNOWN,
+			Message: err.Error(),
+		}
+	}
+	grpcutil.RequestCounter(method, requestHeader, respErr, gcRequestCounter)
+}

--- a/server/gc_service.go
+++ b/server/gc_service.go
@@ -65,6 +65,9 @@ func (s *GrpcServer) UpdateGCSafePoint(ctx context.Context, request *pdpb.Update
 	} else if rsp != nil {
 		return rsp.(*pdpb.UpdateGCSafePointResponse), err
 	}
+	defer func() {
+		recordGCRequest("UpdateGCSafePoint", request.GetHeader(), resp, errRet)
+	}()
 
 	rc := s.GetRaftCluster()
 	if rc == nil {
@@ -123,6 +126,9 @@ func (s *GrpcServer) GetGCSafePoint(ctx context.Context, request *pdpb.GetGCSafe
 	} else if rsp != nil {
 		return rsp.(*pdpb.GetGCSafePointResponse), err
 	}
+	defer func() {
+		recordGCRequest("GetGCSafePoint", request.GetHeader(), resp, errRet)
+	}()
 
 	rc := s.GetRaftCluster()
 	if rc == nil {
@@ -183,6 +189,9 @@ func (s *GrpcServer) UpdateServiceGCSafePoint(ctx context.Context, request *pdpb
 	} else if rsp != nil {
 		return rsp.(*pdpb.UpdateServiceGCSafePointResponse), err
 	}
+	defer func() {
+		recordGCRequest("UpdateServiceGCSafePoint", request.GetHeader(), resp, errRet)
+	}()
 
 	rc := s.GetRaftCluster()
 	if rc == nil {
@@ -242,6 +251,9 @@ func (s *GrpcServer) GetGCSafePointV2(ctx context.Context, request *pdpb.GetGCSa
 	} else if rsp != nil {
 		return rsp.(*pdpb.GetGCSafePointV2Response), err
 	}
+	defer func() {
+		recordGCRequest("GetGCSafePointV2", request.GetHeader(), resp, errRet)
+	}()
 
 	rc := s.GetRaftCluster()
 	if rc == nil {
@@ -292,6 +304,9 @@ func (s *GrpcServer) UpdateGCSafePointV2(ctx context.Context, request *pdpb.Upda
 	} else if rsp != nil {
 		return rsp.(*pdpb.UpdateGCSafePointV2Response), err
 	}
+	defer func() {
+		recordGCRequest("UpdateGCSafePointV2", request.GetHeader(), resp, errRet)
+	}()
 
 	rc := s.GetRaftCluster()
 	if rc == nil {
@@ -368,6 +383,9 @@ func (s *GrpcServer) UpdateServiceSafePointV2(ctx context.Context, request *pdpb
 	} else if rsp != nil {
 		return rsp.(*pdpb.UpdateServiceSafePointV2Response), err
 	}
+	defer func() {
+		recordGCRequest("UpdateServiceSafePointV2", request.GetHeader(), resp, errRet)
+	}()
 
 	rc := s.GetRaftCluster()
 	if rc == nil {
@@ -434,6 +452,9 @@ func (s *GrpcServer) GetAllGCSafePointV2(ctx context.Context, request *pdpb.GetA
 	} else if rsp != nil {
 		return rsp.(*pdpb.GetAllGCSafePointV2Response), err
 	}
+	defer func() {
+		recordGCRequest("GetAllGCSafePointV2", request.GetHeader(), resp, errRet)
+	}()
 
 	rc := s.GetRaftCluster()
 	if rc == nil {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -204,6 +204,13 @@ var (
 			Name:      "region_request_cnt",
 			Help:      "Counter of region request.",
 		}, []string{"request", "caller_id", "caller_component", "event"})
+	gcRequestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "gc_api_request_cnt",
+			Help:      "Counter of GC API request.",
+		}, []string{"request", "caller_id", "caller_component", "event"})
 )
 
 func init() {
@@ -229,4 +236,5 @@ func init() {
 	prometheus.MustRegister(forwardFailCounter)
 	prometheus.MustRegister(forwardTsoDuration)
 	prometheus.MustRegister(regionRequestCounter)
+	prometheus.MustRegister(gcRequestCounter)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Adds request counting and error tracking for unary GC gRPC APIs, matching the existing Region request metric shape.

### What is changed and how does it work?

```commit-message
server: add GC request metrics
```

- Add `pd_server_gc_request_cnt` with labels `request`, `caller_id`, `caller_component`, and `event`.
- Count the 7 unary GC APIs after local handling is confirmed, so forwarded requests are not double counted.
- Exclude `WatchGCSafePointV2`.
- Count response-header errors and plain Go errors as failed requests.
- Treat empty caller fields as `unknown`.

### Check List

Tests

- Unit test
- Integration test

Validation

- `go test ./pkg/utils/grpcutil ./server`
- `go test ./client -run TestClientStatefulTestSuite/...GC...` from `tests/integrations` with failpoints enabled
- `go test ./client` from `tests/integrations` was also attempted and failed after 362s with an etcd no-leader/read-index timeout in the full client suite. The GC-related client cases above passed.

Code changes

- No configuration change
- No HTTP API interface change
- No persistent data change

Side effects

- No breaking backward compatibility

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Add GC gRPC request metrics for PD server.
```