### PR TITLE
gc_state_manager: Workaround mutex contention in high-concurrency scenario

### DIFF
--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -120,6 +120,7 @@ type GCStateManager struct {
 	cfg             config.PDServerConfig
 	keyspaceManager *keyspace.Manager
 
+	// Maps from keyspaceID to the cached GCState of that keyspace.
 	gcStatesCache map[uint32]GCState
 
 	allKeyspacesGCStatesSingleFlight *syncutil.OrderedSingleFlight[map[uint32]GCState]
@@ -794,7 +795,7 @@ func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 	m.mu.RLock()
 	if cachedGCState, ok := m.tryGetGCStateFromCacheLocked(keyspaceID); ok {
 		m.mu.RUnlock()
-		gcStateCacheAccessCounter.WithLabelValues("hit").Inc()
+		gcStateCacheAccessHitCounter.Inc()
 		return cachedGCState, nil
 	}
 	m.mu.RUnlock()
@@ -805,11 +806,11 @@ func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 
 	// Check cache again: it may be updated by other concurrent invocations when the lock is not held.
 	if cachedGCState, ok := m.tryGetGCStateFromCacheLocked(keyspaceID); ok {
-		gcStateCacheAccessCounter.WithLabelValues("slow_hit").Inc()
+		gcStateCacheAccessSlowHitCounter.Inc()
 		return cachedGCState, nil
 	}
 
-	gcStateCacheAccessCounter.WithLabelValues("cache_miss").Inc()
+	gcStateCacheAccessMissCounter.Inc()
 
 	var result GCState
 	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -790,6 +790,14 @@ func (m *GCStateManager) tryGetGCStateFromCacheLocked(keyspaceID uint32) (GCStat
 	return res, ok
 }
 
+// ForceInvalidateGCStateCache invalidates all the GCState cache.
+func (m *GCStateManager) ForceInvalidateGCStateCache() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.gcStatesCache = make(map[uint32]GCState)
+}
+
 func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 	// Fast path
 	m.mu.RLock()

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -633,7 +633,7 @@ func (m *GCStateManager) setGCBarrierImpl(ctx context.Context, keyspaceID uint32
 	}
 
 	{
-		// For simplicity, only update if the cache already exists. In this
+		// For simplicity, only update if the cache already exists.
 		cachedGCState, ok := m.gcStatesCache[keyspaceID]
 		if ok {
 			replaced := false
@@ -770,10 +770,7 @@ func (m *GCStateManager) getGCStateInTransaction(keyspaceID uint32, _ *endpoint.
 	return result, nil
 }
 
-func (m *GCStateManager) tryGetGCStateFromCache(keyspaceID uint32) (GCState, bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
+func (m *GCStateManager) tryGetGCStateFromCacheLocked(keyspaceID uint32) (GCState, bool) {
 	if !m.nodeIsLeader() {
 		return GCState{}, false
 	}
@@ -794,17 +791,20 @@ func (m *GCStateManager) tryGetGCStateFromCache(keyspaceID uint32) (GCState, boo
 
 func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 	// Fast path
-	if cachedGCState, ok := m.tryGetGCStateFromCache(keyspaceID); ok {
+	m.mu.RLock()
+	if cachedGCState, ok := m.tryGetGCStateFromCacheLocked(keyspaceID); ok {
+		m.mu.RUnlock()
 		gcStateCacheAccessCounter.WithLabelValues("hit").Inc()
 		return cachedGCState, nil
 	}
+	m.mu.RUnlock()
 
 	// Slow path
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	// Check cache again: it may be updated by other concurrent invocations when the lock is not held.
-	if cachedGCState, ok := m.gcStatesCache[keyspaceID]; ok {
+	if cachedGCState, ok := m.tryGetGCStateFromCacheLocked(keyspaceID); ok {
 		gcStateCacheAccessCounter.WithLabelValues("slow_hit").Inc()
 		return cachedGCState, nil
 	}
@@ -817,6 +817,9 @@ func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 		result, err1 = m.getGCStateInTransaction(keyspaceID, wb)
 		return err1
 	})
+	if err != nil {
+		return GCState{}, err
+	}
 
 	m.gcStatesCache[keyspaceID] = result
 

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -794,6 +794,7 @@ func (m *GCStateManager) tryGetGCStateFromCache(keyspaceID uint32) (GCState, boo
 func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 	// Fast path
 	if cachedGCState, ok := m.tryGetGCStateFromCache(keyspaceID); ok {
+		gcStateCacheAccessCounter.WithLabelValues("hit").Inc()
 		return cachedGCState, nil
 	}
 
@@ -803,8 +804,11 @@ func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 
 	// Check cache again: it may be updated by other concurrent invocations when the lock is not held.
 	if cachedGCState, ok := m.gcStatesCache[keyspaceID]; ok {
+		gcStateCacheAccessCounter.WithLabelValues("slow_hit").Inc()
 		return cachedGCState, nil
 	}
+
+	gcStateCacheAccessCounter.WithLabelValues("cache_miss").Inc()
 
 	var result GCState
 	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -118,6 +119,8 @@ type GCStateManager struct {
 	cfg             config.PDServerConfig
 	keyspaceManager *keyspace.Manager
 
+	gcStatesCache map[uint32]GCState
+
 	allKeyspacesGCStatesSingleFlight *syncutil.OrderedSingleFlight[map[uint32]GCState]
 }
 
@@ -127,6 +130,7 @@ func NewGCStateManager(store endpoint.GCStateProvider, cfg config.PDServerConfig
 		gcMetaStorage:                    store,
 		cfg:                              cfg,
 		keyspaceManager:                  keyspaceManager,
+		gcStatesCache:                    make(map[uint32]GCState),
 		allKeyspacesGCStatesSingleFlight: syncutil.NewOrderedSingleFlight[map[uint32]GCState](),
 	}
 }
@@ -265,6 +269,16 @@ func (m *GCStateManager) advanceGCSafePointImpl(ctx context.Context, keyspaceID 
 	}
 
 	if newGCSafePoint != oldGCSafePoint {
+		// For simplicity, only update cache when it exists, as AdvanceGCSafePoint is likely to be called soon after
+		// AdvanceTxnSafePoint.
+		cachedGCState, ok := m.gcStatesCache[keyspaceID]
+		if ok {
+			cachedGCState.GCSafePoint = newGCSafePoint
+			m.gcStatesCache[keyspaceID] = cachedGCState
+		}
+	}
+
+	if newGCSafePoint != oldGCSafePoint {
 		log.Info("advanced GC safe point",
 			zap.Uint32("keyspace-id", keyspaceID), zap.String("keyspace-name", getKeyspaceNameFromCtx(ctx)),
 			zap.Uint64("old-gc-safe-point", oldGCSafePoint), zap.Uint64("target", target),
@@ -328,11 +342,20 @@ func (m *GCStateManager) advanceTxnSafePointImpl(ctx context.Context, keyspaceID
 		blockingBarrier         *endpoint.GCBarrier
 		blockingGlobalBarrier   *endpoint.GlobalGCBarrier
 		blockingMinStartTSOwner *string
+
+		gcSafePoint                uint64
+		gcBarriersAfterLazyCleanup []*endpoint.GCBarrier
 	)
 
 	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
 		var err1 error
 		oldTxnSafePoint, err1 = m.gcMetaStorage.LoadTxnSafePoint(keyspaceID)
+		if err1 != nil {
+			return err1
+		}
+
+		// Retrieve GC safe point for caching purpose. Not used in the calculation.
+		gcSafePoint, err1 = m.gcMetaStorage.LoadGCSafePoint(keyspaceID)
 		if err1 != nil {
 			return err1
 		}
@@ -372,6 +395,8 @@ func (m *GCStateManager) advanceTxnSafePointImpl(ctx context.Context, keyspaceID
 				minBlocker = barrier.BarrierTS
 				blockingBarrier = barrier
 			}
+
+			gcBarriersAfterLazyCleanup = append(gcBarriersAfterLazyCleanup, barrier)
 		}
 
 		// Compatible with old TiDB nodes that use TiDBMinStartTS to block GC.
@@ -421,6 +446,19 @@ func (m *GCStateManager) advanceTxnSafePointImpl(ctx context.Context, keyspaceID
 	})
 	if err != nil {
 		return AdvanceTxnSafePointResult{}, err
+	}
+
+	{
+		newCachedGCState := GCState{
+			KeyspaceID: keyspaceID,
+			// advanceTxnSafePointImpl is only called on manageable keyspaces, which are either NullKeyspace or
+			// keyspaces with keyspace-level GC enabled.
+			IsKeyspaceLevel: keyspaceID != constant.NullKeyspaceID,
+			TxnSafePoint:    newTxnSafePoint,
+			GCSafePoint:     gcSafePoint,
+			GCBarriers:      gcBarriersAfterLazyCleanup,
+		}
+		m.gcStatesCache[keyspaceID] = newCachedGCState
 	}
 
 	blockerDesc := ""
@@ -561,6 +599,28 @@ func (m *GCStateManager) setGCBarrierImpl(ctx context.Context, keyspaceID uint32
 		return nil, err
 	}
 
+	{
+		// For simplicity, only update if the cache already exists. In this
+		cachedGCState, ok := m.gcStatesCache[keyspaceID]
+		if ok {
+			replaced := false
+			for i, b := range cachedGCState.GCBarriers {
+				if b.BarrierID == barrierID {
+					cachedGCState.GCBarriers[i] = newBarrier
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				cachedGCState.GCBarriers = append(cachedGCState.GCBarriers, newBarrier)
+				slices.SortFunc(cachedGCState.GCBarriers, func(a, b *endpoint.GCBarrier) int {
+					return strings.Compare(a.BarrierID, b.BarrierID)
+				})
+			}
+			m.gcStatesCache[keyspaceID] = cachedGCState
+		}
+	}
+
 	log.Info("GC barrier set",
 		zap.Uint32("keyspace-id", keyspaceID), zap.String("keyspace-name", getKeyspaceNameFromCtx(ctx)),
 		zap.String("barrier-id", barrierID), zap.Uint64("barrier-ts", barrierTS), zap.Duration("ttl", ttl),
@@ -606,12 +666,22 @@ func (m *GCStateManager) deleteGCBarrierImpl(ctx context.Context, keyspaceID uin
 		}
 		return wb.DeleteGCBarrier(keyspaceID, barrierID)
 	})
-
 	if err != nil {
 		log.Error("failed to delete GC barrier",
 			zap.Uint32("keyspace-id", keyspaceID), zap.String("keyspace-name", getKeyspaceNameFromCtx(ctx)),
 			zap.String("barrier-id", barrierID), zap.Error(err))
 		return nil, err
+	}
+
+	if deletedBarrier != nil {
+		// For simplicity, only update the cache if it already exists.
+		cachedGCState, ok := m.gcStatesCache[keyspaceID]
+		if ok {
+			cachedGCState.GCBarriers = slices.DeleteFunc(cachedGCState.GCBarriers, func(b *endpoint.GCBarrier) bool {
+				return b.BarrierID == barrierID
+			})
+			m.gcStatesCache[keyspaceID] = cachedGCState
+		}
 	}
 
 	if deletedBarrier == nil {
@@ -667,6 +737,51 @@ func (m *GCStateManager) getGCStateInTransaction(keyspaceID uint32, _ *endpoint.
 	return result, nil
 }
 
+func (m *GCStateManager) tryGetGCStateFromCache(keyspaceID uint32) (GCState, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	res, ok := m.gcStatesCache[keyspaceID]
+
+	// Deep copy the GCBarriers field to avoid unintentional mutation.
+	if ok && res.GCBarriers != nil {
+		clonedGCBarriers := make([]*endpoint.GCBarrier, len(res.GCBarriers))
+		for i, barrier := range res.GCBarriers {
+			clonedBarrier := *barrier
+			clonedGCBarriers[i] = &clonedBarrier
+		}
+		res.GCBarriers = clonedGCBarriers
+	}
+	return res, ok
+}
+
+func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
+	// Fast path
+	if cachedGCState, ok := m.tryGetGCStateFromCache(keyspaceID); ok {
+		return cachedGCState, nil
+	}
+
+	// Slow path
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check cache again: it may be updated by other concurrent invocations when the lock is not held.
+	if cachedGCState, ok := m.gcStatesCache[keyspaceID]; ok {
+		return cachedGCState, nil
+	}
+
+	var result GCState
+	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
+		var err1 error
+		result, err1 = m.getGCStateInTransaction(keyspaceID, wb)
+		return err1
+	})
+
+	m.gcStatesCache[keyspaceID] = result
+
+	return result, err
+}
+
 // GetGCState returns the GC state of the given keyspace.
 //
 // When this method is called on a keyspace without keyspace-level GC enabled, it will be equivalent to calling it on
@@ -676,17 +791,8 @@ func (m *GCStateManager) GetGCState(keyspaceID uint32) (GCState, error) {
 	if err != nil {
 		return GCState{}, err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 
-	var result GCState
-	err = m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
-		var err1 error
-		result, err1 = m.getGCStateInTransaction(keyspaceID, wb)
-		return err1
-	})
-
-	return result, err
+	return m.getGCStateImpl(keyspaceID)
 }
 
 // GetAllKeyspacesGCStates returns the GC state of all keyspaces.
@@ -709,39 +815,16 @@ func (m *GCStateManager) GetAllKeyspacesGCStates(ctx context.Context) (map[uint3
 func (m *GCStateManager) getAllKeyspacesGCStatesImpl(ctx context.Context) (map[uint32]GCState, error) {
 	failpoint.InjectCall("onGetAllKeyspacesGCStatesStart")
 
-	mutexLocked := false
-	lock := func() {
-		m.mu.Lock()
-		mutexLocked = true
-	}
-	unlock := func() {
-		m.mu.Unlock()
-		mutexLocked = false
-	}
-
-	ensureUnlocked := func() {
-		if mutexLocked {
-			unlock()
-		}
-	}
-	defer ensureUnlocked()
-
 	keyspaceIterator := m.keyspaceManager.IterateKeyspaces()
 
 	// Do not guarantee atomicity among different keyspaces here.
 	results := make(map[uint32]GCState)
-	lock()
-	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
-		nullKeyspaceState, err1 := m.getGCStateInTransaction(constant.NullKeyspaceID, wb)
-		if err1 != nil {
-			return err1
+	{
+		gcState, err := m.getGCStateImpl(constant.NullKeyspaceID)
+		if err != nil {
+			return nil, err
 		}
-		results[constant.NullKeyspaceID] = nullKeyspaceState
-		return nil
-	})
-	unlock()
-	if err != nil {
-		return nil, err
+		results[constant.NullKeyspaceID] = gcState
 	}
 
 	for {
@@ -772,18 +855,12 @@ func (m *GCStateManager) getAllKeyspacesGCStatesImpl(ctx context.Context) (map[u
 			continue
 		}
 
-		lock()
-		err = m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
-			state, err1 := m.getGCStateInTransaction(keyspaceMeta.Id, wb)
-			if err1 != nil {
-				return err1
+		{
+			gcState, err := m.getGCStateImpl(keyspaceMeta.Id)
+			if err != nil {
+				return nil, err
 			}
-			results[keyspaceMeta.Id] = state
-			return nil
-		})
-		unlock()
-		if err != nil {
-			return nil, err
+			results[keyspaceMeta.Id] = gcState
 		}
 	}
 

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -168,6 +168,7 @@ func (m *GCStateManager) OnNodeBecomesLeader() {
 
 	// Also trigger cache invalidation even when transitioning from follower to leader, as a protection against
 	// potential inconsistent cache state left from the last leadership.
+	m.gcStatesCache = make(map[uint32]GCState)
 }
 
 // OnNodeBecomesFollower marks the current PD node as follower and closes all existing GC state watches.

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -122,6 +123,11 @@ type GCStateManager struct {
 	gcStatesCache map[uint32]GCState
 
 	allKeyspacesGCStatesSingleFlight *syncutil.OrderedSingleFlight[map[uint32]GCState]
+
+	// Note that nodeLeadership is a counter instead of a bool. Theoretically, it's possible that an
+	// OnNodeBecomesFollower invocation of the previous lease is later than the OnNodeBecomesLeader call of the new
+	// lease during PD leader changes. Making this a counter helps in guaranteeing the eventual consistency.
+	nodeLeadership atomic.Int32
 }
 
 // NewGCStateManager creates a GCStateManager of GC and services.
@@ -151,6 +157,32 @@ func getKeyspaceNameFromCtx(ctx context.Context) string {
 		return value
 	}
 	return "<unknown>"
+}
+
+// OnNodeBecomesLeader marks the current PD node as leader for GC state watches.
+func (m *GCStateManager) OnNodeBecomesLeader() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.nodeLeadership.Add(1)
+
+	// Also trigger cache invalidation even when transitioning from follower to leader, as a protection against
+	// potential inconsistent cache state left from the last leadership.
+}
+
+// OnNodeBecomesFollower marks the current PD node as follower and closes all existing GC state watches.
+func (m *GCStateManager) OnNodeBecomesFollower() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.nodeLeadership.Add(-1)
+
+	// Invalidate the cache.
+	m.gcStatesCache = make(map[uint32]GCState)
+}
+
+func (m *GCStateManager) nodeIsLeader() bool {
+	return m.nodeLeadership.Load() > 0
 }
 
 // redirectKeyspace checks the given keyspaceID, and returns the actual keyspaceID to operate on.
@@ -740,6 +772,10 @@ func (m *GCStateManager) getGCStateInTransaction(keyspaceID uint32, _ *endpoint.
 func (m *GCStateManager) tryGetGCStateFromCache(keyspaceID uint32) (GCState, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	if !m.nodeIsLeader() {
+		return GCState{}, false
+	}
 
 	res, ok := m.gcStatesCache[keyspaceID]
 

--- a/pkg/gc/metrics.go
+++ b/pkg/gc/metrics.go
@@ -31,6 +31,10 @@ var (
 			Name:      "gc_state_cache_access_total",
 			Help:      "Counter of GC state cache accesses by result.",
 		}, []string{"result"})
+
+	gcStateCacheAccessHitCounter     = gcStateCacheAccessCounter.WithLabelValues("hit")
+	gcStateCacheAccessSlowHitCounter = gcStateCacheAccessCounter.WithLabelValues("slow_hit")
+	gcStateCacheAccessMissCounter    = gcStateCacheAccessCounter.WithLabelValues("miss")
 )
 
 func init() {

--- a/pkg/gc/metrics.go
+++ b/pkg/gc/metrics.go
@@ -24,8 +24,16 @@ var (
 			Name:      "gc_safepoint",
 			Help:      "The ts of gc safepoint",
 		}, []string{"type"})
+	gcStateCacheAccessCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "gc",
+			Name:      "gc_state_cache_access_total",
+			Help:      "Counter of GC state cache accesses by result.",
+		}, []string{"result"})
 )
 
 func init() {
 	prometheus.MustRegister(gcSafePointGauge)
+	prometheus.MustRegister(gcStateCacheAccessCounter)
 }

--- a/server/api/service_gc_safepoint.go
+++ b/server/api/service_gc_safepoint.go
@@ -134,5 +134,6 @@ func (h *serviceGCSafepointHandler) DeleteGCSafePoint(w http.ResponseWriter, r *
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	h.svr.GetGCStateManager().ForceInvalidateGCStateCache()
 	h.rd.JSON(w, http.StatusOK, "Delete service GC safepoint successfully.")
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
+
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -38,11 +38,11 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
-
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/gc"
 	"github.com/tikv/pd/pkg/gctuner"
 	"github.com/tikv/pd/pkg/id"
 	"github.com/tikv/pd/pkg/keyspace"
@@ -140,6 +140,7 @@ type Server interface {
 	GetKeyspaceGroupManager() *keyspace.GroupManager
 	IsKeyspaceGroupEnabled() bool
 	GetMeteringWriter() *metering.Writer
+	GetGCStateManager() *gc.GCStateManager
 }
 
 // RaftCluster is used for cluster config management.
@@ -200,6 +201,8 @@ type RaftCluster struct {
 	logRunner ratelimit.Runner
 	// syncRegionRunner is used to sync region asynchronously.
 	syncRegionRunner ratelimit.Runner
+
+	stopGCStateManager func()
 }
 
 // Status saves some state information.
@@ -423,6 +426,9 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 	go c.startGCTuner()
 	go c.startProgressGC()
 	go c.runStorageSizeCollector(s.GetMeteringWriter(), c.regionLabeler, s.GetKeyspaceManager())
+
+	s.GetGCStateManager().OnNodeBecomesLeader()
+	c.stopGCStateManager = s.GetGCStateManager().OnNodeBecomesFollower
 
 	c.running = true
 	c.heartbeatRunner.Start(c.ctx)
@@ -923,6 +929,9 @@ func (c *RaftCluster) Stop() {
 	c.miscRunner.Stop()
 	c.logRunner.Stop()
 	c.syncRegionRunner.Stop()
+	if c.stopGCStateManager != nil {
+		c.stopGCStateManager()
+	}
 	c.Unlock()
 
 	c.wg.Wait()

--- a/server/gc_service.go
+++ b/server/gc_service.go
@@ -711,6 +711,11 @@ func (s *GrpcServer) GetGCState(ctx context.Context, request *pdpb.GetGCStateReq
 		}, nil
 	}
 
+	rc = s.GetRaftCluster()
+	if rc == nil {
+		return &pdpb.GetGCStateResponse{Header: grpcutil.NotBootstrappedHeader()}, nil
+	}
+
 	return &pdpb.GetGCStateResponse{
 		Header:  grpcutil.WrapHeader(),
 		GcState: gcStateToProto(gcState, time.Now()),


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #10607

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
This PR provides a simpler workaround to the issue that when PD receives too many GC-related requests, it may suffer bad performace on the mutex of GCStateManager's mutex.

In the follwing cases, the GCState will be fully loaded and inserted to a memory cache:
* When GetGCState/GetAllKeyspacesGCState encounters a cache miss and reads the actual GCState from etcd
* When AdvanceTxnSafePoint is called

In the following cases, the GCState cache will be incrementally updated if it already exists in the cache:
* When AdvanceGCSafePoint/SetGCBarrier/DeleteGCBarrier is called

Also note that UpdateServiceGCSafePoint is internally redirected to one of AdvanceTxnSafePoint SetGCBarrier or DeleteGCBarrier.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test (Covered by existing tests)
- Integration test (Covered by existing tests)

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
