### PR TITLE
scatter: keep current placement on build failure

### DIFF
--- a/pkg/schedule/scatter/region_scatterer.go
+++ b/pkg/schedule/scatter/region_scatterer.go
@@ -436,10 +436,11 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 	op, err := operator.CreateScatterRegionOperator(scatterOperatorDesc, r.cluster, region, targetPeers, targetLeader, skipStoreLimit)
 	if err != nil {
 		scatterFailCounter.Inc()
+		currentPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
 		for _, peer := range region.GetPeers() {
-			targetPeers[peer.GetStoreId()] = peer
+			currentPeers[peer.GetStoreId()] = peer
 		}
-		r.Put(targetPeers, region.GetLeader().GetStoreId(), group)
+		r.Put(currentPeers, region.GetLeader().GetStoreId(), group)
 		log.Debug("fail to create scatter region operator", errs.ZapError(err))
 		return nil, errs.ErrCreateOperator.FastGenByArgs(fmt.Sprintf("failed to create scatter region operator for region %v", region.GetID()))
 	}

--- a/pkg/schedule/scatter/region_scatterer_test.go
+++ b/pkg/schedule/scatter/region_scatterer_test.go
@@ -747,6 +747,48 @@ func TestSelectedStoresTooManyPeers(t *testing.T) {
 	}
 }
 
+func TestCreateScatterRegionOperatorFailureAccountsCurrentPlacement(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	group := "group"
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	for range 100 {
+		scatterer.ordinaryEngine.selectedPeer.Put(1, group)
+		scatterer.ordinaryEngine.selectedPeer.Put(2, group)
+		scatterer.ordinaryEngine.selectedPeer.Put(3, group)
+	}
+
+	region := tc.AddLeaderRegion(100, 2, 1, 3).Clone(
+		core.SetPeers([]*metapb.Peer{
+			{Id: 11, StoreId: 1, Role: metapb.PeerRole_DemotingVoter},
+			{Id: 12, StoreId: 2, Role: metapb.PeerRole_Voter},
+			{Id: 13, StoreId: 3, Role: metapb.PeerRole_IncomingVoter},
+		}),
+		core.WithLeader(&metapb.Peer{Id: 12, StoreId: 2, Role: metapb.PeerRole_Voter}),
+	)
+
+	op, err := scatterer.scatterRegion(region, group, false)
+	re.Nil(op)
+	re.Error(err)
+
+	distribution, ok := scatterer.ordinaryEngine.selectedPeer.GetGroupDistribution(group)
+	re.True(ok)
+	re.Equal(uint64(101), distribution[1])
+	re.Equal(uint64(101), distribution[2])
+	re.Equal(uint64(101), distribution[3])
+	re.Zero(distribution[4])
+}
+
 // TestBalanceLeader only tests whether region leaders are balanced after scatter.
 func TestBalanceLeader(t *testing.T) {
 	re := require.New(t)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #7838

### What is changed and how does it work?

```commit-message
When CreateScatterRegionOperator fails, region scatter should account for the
region's current placement instead of reusing the partially-built targetPeers
map.

This keeps the failure path from recording stores that were only planned
targets but never actually applied, so later scatter decisions do not see a
skewed group distribution from this build failure path.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region scattering to correctly account for current peer placement when operator creation fails. Ensures accurate distribution tracking and prevents incorrect state records during error scenarios.

* **Tests**
  * Added comprehensive test cases validating correct peer placement tracking when region scattering operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->