### PR TITLE
gc,server: add GC state cache test coverage

### DIFF
--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -803,10 +803,17 @@ func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 	m.mu.RLock()
 	if cachedGCState, ok := m.tryGetGCStateFromCacheLocked(keyspaceID); ok {
 		m.mu.RUnlock()
+		failpoint.InjectCall("getGCStateCacheAccess", "hit")
 		gcStateCacheAccessHitCounter.Inc()
 		return cachedGCState, nil
 	}
 	m.mu.RUnlock()
+
+	// This hook is intentionally before taking the write lock. Tests use it to
+	// cover leadership churn after the first leader-gated cache check but before
+	// the slow path reads from storage, without blocking leadership callbacks on
+	// GCStateManager's lock.
+	failpoint.InjectCall("getGCStateBeforeSlowPath")
 
 	// Slow path
 	m.mu.Lock()
@@ -814,10 +821,12 @@ func (m *GCStateManager) getGCStateImpl(keyspaceID uint32) (GCState, error) {
 
 	// Check cache again: it may be updated by other concurrent invocations when the lock is not held.
 	if cachedGCState, ok := m.tryGetGCStateFromCacheLocked(keyspaceID); ok {
+		failpoint.InjectCall("getGCStateCacheAccess", "slow_hit")
 		gcStateCacheAccessSlowHitCounter.Inc()
 		return cachedGCState, nil
 	}
 
+	failpoint.InjectCall("getGCStateCacheAccess", "miss")
 	gcStateCacheAccessMissCounter.Inc()
 
 	var result GCState

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -228,6 +228,61 @@ func (s *gcStateManagerTestSuite) TearDownTest() {
 	s.clean()
 }
 
+type gcStateCacheAccessCount struct {
+	hit     int
+	slowHit int
+	miss    int
+}
+
+type gcStateCacheAccessCounters struct {
+	sync.Mutex
+	gcStateCacheAccessCount
+}
+
+type gcStateCacheAccessCounterSnapshot struct {
+	gcStateCacheAccessCount
+}
+
+func (s *gcStateManagerTestSuite) makeManagerLeader() {
+	if !s.manager.nodeIsLeader() {
+		s.manager.OnNodeBecomesLeader()
+	}
+}
+
+func (s *gcStateManagerTestSuite) trackGCStateCacheAccessCounters() *gcStateCacheAccessCounters {
+	tracker := &gcStateCacheAccessCounters{}
+	failpointName := "github.com/tikv/pd/pkg/gc/getGCStateCacheAccess"
+	// Track cache access through a failpoint instead of reading Prometheus metrics directly.
+	// This keeps the test local to this suite and avoids adding a direct go.mod dependency
+	// on Prometheus' client_model package just for test assertions.
+	s.Require().NoError(failpoint.EnableCall(failpointName, func(result string) {
+		tracker.Lock()
+		defer tracker.Unlock()
+		switch result {
+		case "hit":
+			tracker.hit++
+		case "slow_hit":
+			tracker.slowHit++
+		case "miss":
+			tracker.miss++
+		default:
+			s.Require().FailNowf("unexpected GC state cache access result", "result: %s", result)
+		}
+	}))
+	s.T().Cleanup(func() {
+		s.Require().NoError(failpoint.Disable(failpointName))
+	})
+	return tracker
+}
+
+func (c *gcStateCacheAccessCounters) snapshot() gcStateCacheAccessCounterSnapshot {
+	c.Lock()
+	defer c.Unlock()
+	return gcStateCacheAccessCounterSnapshot{
+		gcStateCacheAccessCount: c.gcStateCacheAccessCount,
+	}
+}
+
 func (s *gcStateManagerTestSuite) checkTxnSafePoint(keyspaceID uint32, expectedTxnSafePoint uint64) {
 	re := s.Require()
 	state, err := s.manager.GetGCState(keyspaceID)
@@ -1882,6 +1937,320 @@ func (s *gcStateManagerTestSuite) TestGetGCState() {
 	}, state.GCBarriers)
 
 	checkAllKeyspaceGCStates()
+}
+
+func (s *gcStateManagerTestSuite) TestGetGCStateCacheMissConcurrent() {
+	re := s.Require()
+	s.makeManagerLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	before := tracker.snapshot()
+
+	// Make every worker stop after the fast-path cache miss but before it can
+	// enter the serialized slow path. Once released, exactly one worker should
+	// load from storage and populate cache; all remaining workers should reuse
+	// that loaded value through the second cache check.
+	reachedSlowPath := make(chan struct{})
+	releaseSlowPath := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWorkers := func() {
+		releaseOnce.Do(func() {
+			close(releaseSlowPath)
+		})
+	}
+	defer releaseWorkers()
+
+	const concurrency = 6
+	var reachedCount atomic.Int32
+	failpointName := "github.com/tikv/pd/pkg/gc/getGCStateBeforeSlowPath"
+	re.NoError(failpoint.EnableCall(failpointName, func() {
+		if reachedCount.Add(1) == concurrency {
+			close(reachedSlowPath)
+		}
+		<-releaseSlowPath
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable(failpointName))
+	}()
+
+	type result struct {
+		state GCState
+		err   error
+	}
+	results := make(chan result, concurrency)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			state, err := s.manager.GetGCState(keyspaceID)
+			results <- result{state: state, err: err}
+		}()
+	}
+
+	select {
+	case <-reachedSlowPath:
+	case <-time.After(5 * time.Second):
+		re.FailNow("not all concurrent GetGCState calls reached the slow path")
+	}
+	releaseWorkers()
+
+	wg.Wait()
+	close(results)
+
+	var first GCState
+	for i := range concurrency {
+		res := <-results
+		re.NoError(res.err)
+		if i == 0 {
+			first = res.state
+			continue
+		}
+		re.Equal(first, res.state)
+	}
+
+	after := tracker.snapshot()
+	re.Equal(before.miss+1, after.miss)
+	// The first request is a miss. Depending on scheduler interleaving, the
+	// rest may either hit the fast path after the first one returns, or hit the
+	// second cache check while waiting on the slow-path lock. Both are valid
+	// cache reuse paths, so assert their combined count.
+	re.Equal(before.hit+before.slowHit+concurrency-1, after.hit+after.slowHit)
+
+	cachedState, ok := s.manager.gcStatesCache[keyspaceID]
+	re.True(ok)
+	re.Equal(first, cachedState)
+}
+
+func (s *gcStateManagerTestSuite) TestGetGCStateCacheHitConcurrent() {
+	re := s.Require()
+	s.makeManagerLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	// Warm the cache once. Every concurrent request below should then stay on
+	// the read-lock-protected fast path and avoid both slow hits and storage reads.
+	expected, err := s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+
+	before := tracker.snapshot()
+
+	const concurrency = 6
+	type result struct {
+		state GCState
+		err   error
+	}
+	results := make(chan result, concurrency)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			state, err := s.manager.GetGCState(keyspaceID)
+			results <- result{state: state, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	for res := range results {
+		re.NoError(res.err)
+		re.Equal(expected, res.state)
+	}
+
+	after := tracker.snapshot()
+	re.Equal(before.hit+concurrency, after.hit)
+	re.Equal(before.slowHit, after.slowHit)
+	re.Equal(before.miss, after.miss)
+}
+
+func (s *gcStateManagerTestSuite) TestGetGCStateReadFailureDoesNotPopulateCache() {
+	re := s.Require()
+	s.makeManagerLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	before := tracker.snapshot()
+
+	// Corrupt only the persisted txn safe point. A failed load must return an
+	// error and, more importantly, must not install a zero-valued partial state
+	// into the cache.
+	re.NoError(s.storage.Save(keypath.TxnSafePointPath(keyspaceID), "invalid-txn-safe-point"))
+
+	_, err := s.manager.GetGCState(keyspaceID)
+	re.Error(err)
+	re.Contains(err.Error(), "invalid syntax")
+	_, ok := s.manager.gcStatesCache[keyspaceID]
+	re.False(ok)
+
+	afterFailure := tracker.snapshot()
+	re.Equal(before.miss+1, afterFailure.miss)
+	re.Equal(before.hit, afterFailure.hit)
+	re.Equal(before.slowHit, afterFailure.slowHit)
+
+	re.NoError(s.storage.Save(keypath.TxnSafePointPath(keyspaceID), "123"))
+
+	// After repairing storage, GetGCState must go back to storage again instead
+	// of returning a stale/empty cached value from the previous failed attempt.
+	state, err := s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Equal(uint64(123), state.TxnSafePoint)
+	re.Empty(state.GCBarriers)
+
+	cachedState, ok := s.manager.gcStatesCache[keyspaceID]
+	re.True(ok)
+	re.Equal(uint64(123), cachedState.TxnSafePoint)
+
+	afterRecovery := tracker.snapshot()
+	re.Equal(before.miss+2, afterRecovery.miss)
+	re.Equal(before.hit, afterRecovery.hit)
+	re.Equal(before.slowHit, afterRecovery.slowHit)
+}
+
+func (s *gcStateManagerTestSuite) TestDeleteGCBarrierWithoutCacheTriggersFreshRead() {
+	re := s.Require()
+	s.makeManagerLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	now := time.Now().Truncate(time.Second)
+	_, err := s.manager.SetGCBarrier(keyspaceID, "b1", 30, time.Hour, now)
+	re.NoError(err)
+
+	// SetGCBarrier only updates cache if it already exists. This keeps the
+	// keyspace uncached so DeleteGCBarrier also only mutates storage.
+	_, ok := s.manager.gcStatesCache[keyspaceID]
+	re.False(ok)
+
+	_, err = s.manager.DeleteGCBarrier(keyspaceID, "b1")
+	re.NoError(err)
+	_, ok = s.manager.gcStatesCache[keyspaceID]
+	re.False(ok)
+
+	before := tracker.snapshot()
+
+	// Since no cache exists, the first GetGCState after deletion must miss and
+	// read the post-delete state from storage.
+	state, err := s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Empty(state.GCBarriers)
+
+	after := tracker.snapshot()
+	re.Equal(before.miss+1, after.miss)
+	re.Equal(before.hit, after.hit)
+	re.Equal(before.slowHit, after.slowHit)
+}
+
+func (s *gcStateManagerTestSuite) TestDeleteGCBarrierUpdatesWarmCache() {
+	re := s.Require()
+	s.makeManagerLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	now := time.Now().Truncate(time.Second)
+	_, err := s.manager.SetGCBarrier(keyspaceID, "b1", 30, time.Hour, now)
+	re.NoError(err)
+
+	_, err = s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+
+	// With cache warmed, DeleteGCBarrier should remove the barrier from the
+	// cached GC state in-place. The next GetGCState should be a cache hit and
+	// should not read storage again.
+	beforeDelete := tracker.snapshot()
+	_, err = s.manager.DeleteGCBarrier(keyspaceID, "b1")
+	re.NoError(err)
+
+	cachedState, ok := s.manager.gcStatesCache[keyspaceID]
+	re.True(ok)
+	re.Empty(cachedState.GCBarriers)
+
+	state, err := s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Empty(state.GCBarriers)
+
+	afterRead := tracker.snapshot()
+	re.Equal(beforeDelete.hit+1, afterRead.hit)
+	re.Equal(beforeDelete.slowHit, afterRead.slowHit)
+	re.Equal(beforeDelete.miss, afterRead.miss)
+}
+
+func (s *gcStateManagerTestSuite) TestAdvanceGCSafePointUpdatesWarmCache() {
+	re := s.Require()
+	s.makeManagerLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 50, time.Now())
+	re.NoError(err)
+
+	state, err := s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Equal(uint64(0), state.GCSafePoint)
+
+	beforeAdvance := tracker.snapshot()
+	oldGCSafePoint, newGCSafePoint, err := s.manager.AdvanceGCSafePoint(keyspaceID, 40)
+	re.NoError(err)
+	re.Equal(uint64(0), oldGCSafePoint)
+	re.Equal(uint64(40), newGCSafePoint)
+
+	state, err = s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Equal(uint64(40), state.GCSafePoint)
+
+	// AdvanceGCSafePoint is expected to patch an existing cache entry rather
+	// than invalidate it or force the next read through storage.
+	afterRead := tracker.snapshot()
+	re.Equal(beforeAdvance.hit+1, afterRead.hit)
+	re.Equal(beforeAdvance.slowHit, afterRead.slowHit)
+	re.Equal(beforeAdvance.miss, afterRead.miss)
+}
+
+func (s *gcStateManagerTestSuite) TestSetGCBarrierUpdatesWarmCache() {
+	re := s.Require()
+	s.makeManagerLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	now := time.Now().Truncate(time.Second)
+
+	state, err := s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Empty(state.GCBarriers)
+
+	// Start with a warm cache that has no barriers. SetGCBarrier should append
+	// the new barrier to the cached slice so the following read is a hit.
+	beforeSet := tracker.snapshot()
+	_, err = s.manager.SetGCBarrier(keyspaceID, "b1", 30, time.Hour, now)
+	re.NoError(err)
+
+	state, err = s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Equal([]*endpoint.GCBarrier{
+		endpoint.NewGCBarrier("b1", 30, ptime(now.Add(time.Hour))),
+	}, state.GCBarriers)
+
+	afterFirstRead := tracker.snapshot()
+	re.Equal(beforeSet.hit+1, afterFirstRead.hit)
+	re.Equal(beforeSet.slowHit, afterFirstRead.slowHit)
+	re.Equal(beforeSet.miss, afterFirstRead.miss)
+
+	_, err = s.manager.SetGCBarrier(keyspaceID, "b1", 35, time.Hour*2, now)
+	re.NoError(err)
+
+	// Setting the same barrier ID again should replace the cached barrier,
+	// not append a duplicate entry.
+	state, err = s.manager.GetGCState(keyspaceID)
+	re.NoError(err)
+	re.Equal([]*endpoint.GCBarrier{
+		endpoint.NewGCBarrier("b1", 35, ptime(now.Add(time.Hour*2))),
+	}, state.GCBarriers)
+
+	afterSecondRead := tracker.snapshot()
+	re.Equal(afterFirstRead.hit+1, afterSecondRead.hit)
+	re.Equal(afterFirstRead.slowHit, afterSecondRead.slowHit)
+	re.Equal(afterFirstRead.miss, afterSecondRead.miss)
 }
 
 func (s *gcStateManagerTestSuite) TestGetAllKeyspacesMaxTxnSafePoint() {

--- a/server/gc_service.go
+++ b/server/gc_service.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 
@@ -731,6 +732,11 @@ func (s *GrpcServer) GetGCState(ctx context.Context, request *pdpb.GetGCStateReq
 			Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
 		}, nil
 	}
+
+	// Keep this hook immediately before the second cluster check so tests can
+	// deterministically cover requests that lose leadership after GC state is
+	// loaded but before the response is committed.
+	failpoint.InjectCall("getGCStateBeforeSecondClusterCheck")
 
 	rc = s.GetRaftCluster()
 	if rc == nil {

--- a/tests/server/api/service_gc_safepoint_test.go
+++ b/tests/server/api/service_gc_safepoint_test.go
@@ -115,6 +115,9 @@ func (suite *serviceGCSafepointTestSuite) checkServiceGCSafepoint(cluster *tests
 	re.NoError(err)
 	re.Equal(list, listResp)
 
+	// The GET above warms GCStateManager's local cache. The following delete
+	// bypasses the manager and writes storage directly, so this test verifies
+	// that DeleteGCSafePoint also invalidates the warmed cache.
 	err = testutil.CheckDelete(tests.TestDialClient, sspURL+"/a", testutil.StatusOK(re))
 	re.NoError(err)
 
@@ -127,4 +130,19 @@ func (suite *serviceGCSafepointTestSuite) checkServiceGCSafepoint(cluster *tests
 	}
 	// Exclude the gc_worker as it's not included in GetGCState's result.
 	re.Equal(list.ServiceGCSafepoints[1:3], leftSsps)
+
+	res, err = tests.TestDialClient.Get(sspURL)
+	re.NoError(err)
+	defer res.Body.Close()
+	listResp = &api.ListServiceGCSafepoint{}
+	err = apiutil.ReadJSON(res.Body, listResp)
+	re.NoError(err)
+	// Also verify the public HTTP view. This catches stale cache reuse in
+	// GetGCSafePoint itself, not only direct GCStateManager reads.
+	expectedAfterDelete := &api.ListServiceGCSafepoint{
+		ServiceGCSafepoints:   list.ServiceGCSafepoints[1:],
+		GCSafePoint:           list.GCSafePoint,
+		MinServiceGcSafepoint: list.MinServiceGcSafepoint,
+	}
+	re.Equal(expectedAfterDelete, listResp)
 }

--- a/tests/server/api/service_gc_safepoint_test.go
+++ b/tests/server/api/service_gc_safepoint_test.go
@@ -131,11 +131,11 @@ func (suite *serviceGCSafepointTestSuite) checkServiceGCSafepoint(cluster *tests
 	// Exclude the gc_worker as it's not included in GetGCState's result.
 	re.Equal(list.ServiceGCSafepoints[1:3], leftSsps)
 
-	res, err = tests.TestDialClient.Get(sspURL)
+	resAfterDelete, err := tests.TestDialClient.Get(sspURL)
 	re.NoError(err)
-	defer res.Body.Close()
-	listResp = &api.ListServiceGCSafepoint{}
-	err = apiutil.ReadJSON(res.Body, listResp)
+	defer resAfterDelete.Body.Close()
+	listRespAfterDelete := &api.ListServiceGCSafepoint{}
+	err = apiutil.ReadJSON(resAfterDelete.Body, listRespAfterDelete)
 	re.NoError(err)
 	// Also verify the public HTTP view. This catches stale cache reuse in
 	// GetGCSafePoint itself, not only direct GCStateManager reads.
@@ -144,5 +144,5 @@ func (suite *serviceGCSafepointTestSuite) checkServiceGCSafepoint(cluster *tests
 		GCSafePoint:           list.GCSafePoint,
 		MinServiceGcSafepoint: list.MinServiceGcSafepoint,
 	}
-	re.Equal(expectedAfterDelete, listResp)
+	re.Equal(expectedAfterDelete, listRespAfterDelete)
 }

--- a/tests/server/gc/gc_test.go
+++ b/tests/server/gc/gc_test.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"math"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/keyspace"
@@ -39,6 +41,92 @@ import (
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+const (
+	getGCStateBeforeSecondClusterCheckFailpoint = "github.com/tikv/pd/server/getGCStateBeforeSecondClusterCheck"
+	getGCStateBeforeSlowPathFailpoint           = "github.com/tikv/pd/pkg/gc/getGCStateBeforeSlowPath"
+)
+
+func newGCStateLeaderTransitionCluster(t *testing.T) (*tests.TestCluster, *pdpb.GetGCStateRequest, func()) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// These tests need two PDs so the request can target a concrete old leader
+	// while another node takes over leadership.
+	cluster, err := tests.NewTestCluster(ctx, 2, func(conf *config.Config, _ string) {
+		conf.Keyspace.WaitRegionSplit = false
+	})
+	re.NoError(err)
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	re.NoError(leaderServer.BootstrapCluster())
+
+	req := &pdpb.GetGCStateRequest{
+		Header:        testutil.NewRequestHeader(leaderServer.GetClusterID()),
+		KeyspaceScope: &pdpb.KeyspaceScope{KeyspaceId: constant.NullKeyspaceID},
+	}
+	cleanup := func() {
+		cancel()
+		cluster.Destroy()
+	}
+	return cluster, req, cleanup
+}
+
+func getGCStateFromAddr(ctx context.Context, re *require.Assertions, addr string, req *pdpb.GetGCStateRequest) (*pdpb.GetGCStateResponse, error) {
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, addr)
+	defer conn.Close()
+	return grpcPDClient.GetGCState(ctx, req)
+}
+
+type blockingFailpoint struct {
+	name        string
+	reached     chan struct{}
+	release     chan struct{}
+	reachedOnce sync.Once
+	releaseOnce sync.Once
+	disableOnce sync.Once
+}
+
+func enableBlockingFailpoint(re *require.Assertions, name string) *blockingFailpoint {
+	point := &blockingFailpoint{
+		name:    name,
+		reached: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	re.NoError(failpoint.EnableCall(name, func() {
+		point.reachedOnce.Do(func() {
+			close(point.reached)
+		})
+		<-point.release
+	}))
+	return point
+}
+
+func (p *blockingFailpoint) wait(re *require.Assertions, description string) {
+	// Always use a bounded wait: if a future refactor moves/removes the target
+	// failpoint, the test should fail quickly instead of hanging until the
+	// request context times out.
+	select {
+	case <-p.reached:
+	case <-time.After(5 * time.Second):
+		re.FailNow("GetGCState did not reach the failpoint", description)
+	}
+}
+
+func (p *blockingFailpoint) releaseAndDisable(re *require.Assertions) {
+	// Tests may release explicitly and still run deferred cleanup. Make both
+	// operations idempotent so failure paths do not panic on double close or
+	// double disable.
+	p.releaseOnce.Do(func() {
+		close(p.release)
+	})
+	p.disableOnce.Do(func() {
+		re.NoError(failpoint.Disable(p.name))
+	})
 }
 
 func TestGCOperations(t *testing.T) {
@@ -385,4 +473,271 @@ func TestGCOperations(t *testing.T) {
 		re.Equal(uint64(20), resp.GetOldTxnSafePoint())
 		re.Contains(resp.GetBlockerDescription(), "b2")
 	}
+}
+
+func TestGetGCStateRejectsOldLeaderAfterTransfer(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
+	}()
+
+	oldLeader := cluster.GetLeader()
+	re.NotEmpty(oldLeader)
+	oldLeaderServer := cluster.GetServer(oldLeader)
+	re.NotNil(oldLeaderServer)
+
+	// Once the cluster agrees on a new PD leader, the old leader should reject a
+	// direct GetGCState request at the normal gRPC role check, regardless of any
+	// local GC state cache it may have had.
+	re.NoError(oldLeaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	_, err := getGCStateFromAddr(context.Background(), re, oldLeaderServer.GetAddr(), req)
+	re.ErrorContains(err, "not leader")
+}
+
+func TestGetGCStateFailsIfLeaderLostBeforeReply(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
+	}()
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+
+	// Warm the local cache first so the request is guaranteed to pass the manager
+	// quickly and block only on the server-side recheck window.
+	_, err := leaderServer.GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 10, time.Now())
+	re.NoError(err)
+	resp, err := getGCStateFromAddr(context.Background(), re, leaderServer.GetAddr(), req)
+	re.NoError(err)
+	re.Nil(resp.GetHeader().GetError())
+
+	// Block after GCStateManager has returned but before GetGCState's second
+	// cluster check. This isolates the exact window where the handler has a
+	// state result but must still avoid replying as a non-leader.
+	point := enableBlockingFailpoint(re, getGCStateBeforeSecondClusterCheckFailpoint)
+	defer point.releaseAndDisable(re)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+
+	type result struct {
+		resp *pdpb.GetGCStateResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() {
+		resp, err := grpcPDClient.GetGCState(reqCtx, req)
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	point.wait(re, "before the second cluster check")
+	oldLeader := leaderServer.GetConfig().Name
+	// The old leader does not recover before the blocked request continues, so
+	// the final cluster check should translate the leadership loss into a
+	// NOT_BOOTSTRAPPED response header.
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+	point.releaseAndDisable(re)
+
+	res := <-resultCh
+	re.NoError(res.err)
+	re.NotNil(res.resp.GetHeader().GetError())
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, res.resp.GetHeader().GetError().GetType())
+}
+
+func TestGetGCStateReturnsCachedStateAfterLeadershipRecovery(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
+	}()
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	oldLeader := leaderServer.GetConfig().Name
+
+	_, err := leaderServer.GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 10, time.Now())
+	re.NoError(err)
+	resp, err := getGCStateFromAddr(context.Background(), re, leaderServer.GetAddr(), req)
+	re.NoError(err)
+	re.Nil(resp.GetHeader().GetError())
+	re.Equal(uint64(10), resp.GetGcState().GetTxnSafePoint())
+
+	// This test intentionally documents the current cache-hit semantics. The
+	// request already obtained the old cached state before leadership churn, so
+	// if the same PD regains leadership before the final response check, it can
+	// return that old cached value.
+	point := enableBlockingFailpoint(re, getGCStateBeforeSecondClusterCheckFailpoint)
+	defer point.releaseAndDisable(re)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+
+	type result struct {
+		resp *pdpb.GetGCStateResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() {
+		resp, err := grpcPDClient.GetGCState(reqCtx, req)
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	point.wait(re, "before the second cluster check")
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	// Let the temporary new leader advance the persisted state. The blocked
+	// request should still return its already-read cached value after the old
+	// leader regains leadership, while a later fresh request should see this
+	// newer value.
+	_, err = cluster.GetLeaderServer().GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 20, time.Now())
+	re.NoError(err)
+
+	re.NoError(cluster.GetServer(newLeader).ResignLeaderWithRetry())
+	re.Equal(oldLeader, cluster.WaitLeader())
+
+	point.releaseAndDisable(re)
+	res := <-resultCh
+	re.NoError(res.err)
+	re.Nil(res.resp.GetHeader().GetError())
+	re.Equal(uint64(10), res.resp.GetGcState().GetTxnSafePoint())
+
+	freshResp, err := getGCStateFromAddr(context.Background(), re, cluster.GetServer(oldLeader).GetAddr(), req)
+	re.NoError(err)
+	re.Nil(freshResp.GetHeader().GetError())
+	re.Equal(uint64(20), freshResp.GetGcState().GetTxnSafePoint())
+}
+
+func TestGetGCStateSlowPathFailsIfLeaderLostBeforeRead(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
+	}()
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	oldLeader := leaderServer.GetConfig().Name
+
+	// Unlike the cache-hit cases above, this request starts with no local cache.
+	// It will pass the first leader-gated cache check and then block before the
+	// slow path reads storage.
+	point := enableBlockingFailpoint(re, getGCStateBeforeSlowPathFailpoint)
+	defer point.releaseAndDisable(re)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+
+	type result struct {
+		resp *pdpb.GetGCStateResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() {
+		resp, err := grpcPDClient.GetGCState(reqCtx, req)
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	// This request has no cache. It already passed the first leader-gated cache
+	// check, then waits before serializing the slow path and reading storage.
+	point.wait(re, "before the no-cache slow path reads from storage")
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	// The old leader is still not running the cluster when the slow path resumes.
+	// It may finish reading storage, but the handler's final cluster check must
+	// reject the response.
+	point.releaseAndDisable(re)
+	res := <-resultCh
+	re.NoError(res.err)
+	re.NotNil(res.resp.GetHeader().GetError())
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, res.resp.GetHeader().GetError().GetType())
+}
+
+func TestGetGCStateSlowPathReadsLatestStateAfterLeadershipRecovery(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
+	}()
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	oldLeader := leaderServer.GetConfig().Name
+
+	// Start with no local cache and stop immediately before the slow path. This
+	// ensures the request has not read storage yet, so it can observe updates
+	// made by the temporary new leader before the old leader resumes.
+	point := enableBlockingFailpoint(re, getGCStateBeforeSlowPathFailpoint)
+	defer point.releaseAndDisable(re)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+
+	type result struct {
+		resp *pdpb.GetGCStateResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() {
+		resp, err := grpcPDClient.GetGCState(reqCtx, req)
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	point.wait(re, "before the no-cache slow path reads from storage")
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	// The new leader writes a newer GC state while the old leader's request is
+	// blocked. Because the old request has not entered RunInGCStateTransaction
+	// yet, it should read this latest value after leadership returns.
+	_, err := cluster.GetLeaderServer().GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 20, time.Now())
+	re.NoError(err)
+
+	re.NoError(cluster.GetServer(newLeader).ResignLeaderWithRetry())
+	re.Equal(oldLeader, cluster.WaitLeader())
+
+	point.releaseAndDisable(re)
+	res := <-resultCh
+	re.NoError(res.err)
+	re.Nil(res.resp.GetHeader().GetError())
+	re.Equal(uint64(20), res.resp.GetGcState().GetTxnSafePoint())
 }

--- a/tests/server/gc/gc_test.go
+++ b/tests/server/gc/gc_test.go
@@ -46,6 +46,7 @@ func TestMain(m *testing.M) {
 const (
 	getGCStateBeforeSecondClusterCheckFailpoint = "github.com/tikv/pd/server/getGCStateBeforeSecondClusterCheck"
 	getGCStateBeforeSlowPathFailpoint           = "github.com/tikv/pd/pkg/gc/getGCStateBeforeSlowPath"
+	skipCampaignLeaderCheckFailpoint            = "github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"
 )
 
 func newGCStateLeaderTransitionCluster(t *testing.T) (*tests.TestCluster, *pdpb.GetGCStateRequest, func()) {
@@ -60,6 +61,7 @@ func newGCStateLeaderTransitionCluster(t *testing.T) (*tests.TestCluster, *pdpb.
 	re.NoError(err)
 	re.NoError(cluster.RunInitialServers())
 	re.NotEmpty(cluster.WaitLeader())
+	re.NoError(failpoint.Enable(skipCampaignLeaderCheckFailpoint, "return(true)"))
 
 	leaderServer := cluster.GetLeaderServer()
 	re.NotNil(leaderServer)
@@ -70,6 +72,7 @@ func newGCStateLeaderTransitionCluster(t *testing.T) (*tests.TestCluster, *pdpb.
 		KeyspaceScope: &pdpb.KeyspaceScope{KeyspaceId: constant.NullKeyspaceID},
 	}
 	cleanup := func() {
+		re.NoError(failpoint.Disable(skipCampaignLeaderCheckFailpoint))
 		cancel()
 		cluster.Destroy()
 	}
@@ -480,11 +483,6 @@ func TestGetGCStateRejectsOldLeaderAfterTransfer(t *testing.T) {
 	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
 	defer cleanup()
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
-	}()
-
 	oldLeader := cluster.GetLeader()
 	re.NotEmpty(oldLeader)
 	oldLeaderServer := cluster.GetServer(oldLeader)
@@ -506,11 +504,6 @@ func TestGetGCStateFailsIfLeaderLostBeforeReply(t *testing.T) {
 	re := require.New(t)
 	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
 	defer cleanup()
-
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
-	}()
 
 	leaderServer := cluster.GetLeaderServer()
 	re.NotNil(leaderServer)
@@ -566,11 +559,6 @@ func TestGetGCStateReturnsCachedStateAfterLeadershipRecovery(t *testing.T) {
 	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
 	defer cleanup()
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
-	}()
-
 	leaderServer := cluster.GetLeaderServer()
 	re.NotNil(leaderServer)
 	oldLeader := leaderServer.GetConfig().Name
@@ -582,10 +570,12 @@ func TestGetGCStateReturnsCachedStateAfterLeadershipRecovery(t *testing.T) {
 	re.Nil(resp.GetHeader().GetError())
 	re.Equal(uint64(10), resp.GetGcState().GetTxnSafePoint())
 
-	// This test intentionally documents the current cache-hit semantics. The
-	// request already obtained the old cached state before leadership churn, so
-	// if the same PD regains leadership before the final response check, it can
-	// return that old cached value.
+	// This test pins the current cache-hit behavior; it does not claim that this
+	// is the ideal long-term contract. Once the request has already obtained the
+	// cached GC state before leadership churn, regaining leadership before the
+	// final response check currently lets it return that earlier cached value.
+	// If GetGCState is intentionally tightened in the future, update this test
+	// together with the corresponding semantics documentation.
 	point := enableBlockingFailpoint(re, getGCStateBeforeSecondClusterCheckFailpoint)
 	defer point.releaseAndDisable(re)
 
@@ -637,11 +627,6 @@ func TestGetGCStateSlowPathFailsIfLeaderLostBeforeRead(t *testing.T) {
 	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
 	defer cleanup()
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
-	}()
-
 	leaderServer := cluster.GetLeaderServer()
 	re.NotNil(leaderServer)
 	oldLeader := leaderServer.GetConfig().Name
@@ -689,11 +674,6 @@ func TestGetGCStateSlowPathReadsLatestStateAfterLeadershipRecovery(t *testing.T)
 	re := require.New(t)
 	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
 	defer cleanup()
-
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck", "return(true)"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"))
-	}()
 
 	leaderServer := cluster.GetLeaderServer()
 	re.NotNil(leaderServer)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Ref #10607

### What is changed and how does it work?

```commit-message
gc,server: add GC state cache test coverage

Add focused unit and integration coverage for the GC state cache behavior
introduced by GetGCState caching.

The added tests cover cache hit/miss behavior, cache update and invalidation
paths, and leader transition semantics for both cached and uncached requests.
```

This PR supplements the GC state cache change with focused test coverage.

Checklist of covered scenarios:

- [x] The target keyspace has no cache beforehand
  - [x] Concurrent `GetGCState` on the same uncached keyspace
  - [x] Request old leader after leader switch
  - [x] No-cache slow path loses leadership and does not recover
  - [x] No-cache slow path loses and then regains leadership
  - [x] Storage read failure does not populate cache
  - [x] Delete barrier before cache exists
- [x] The target keyspace already has cache
  - [x] Concurrent `GetGCState` on the same cached keyspace
  - [x] Request old leader after leader switch
  - [x] Cache-hit request loses leadership before response
  - [x] Cache-hit request loses and then regains leadership
  - [x] Delete barrier after cache exists
  - [x] Advance GC safepoint after cache exists
  - [x] Add or update barrier after cache exists
  - [x] Delete legacy service GC safepoint

### Check List

Tests

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has the configuration change
- [ ] Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [x] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [ ] PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- [ ] PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- [ ] Need to cherry-pick to the release branch

### Release note

```release-note
None.
```
