### PR TITLE
server: fix silent store heartbeat forwarding failure

### DIFF
--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -71,6 +71,7 @@ var (
 	errScatterRegionSend     = forwardFailCounter.WithLabelValues("scatter_region", "send")
 	errSplitRegionsSend      = forwardFailCounter.WithLabelValues("split_regions", "send")
 	errStoreHeartbeatSend    = forwardFailCounter.WithLabelValues("store_heartbeat", "send")
+	errStoreHeartbeatClient  = forwardFailCounter.WithLabelValues("store_heartbeat", "client")
 	errGetOperatorSend       = forwardFailCounter.WithLabelValues("get_operator", "send")
 )
 
@@ -968,6 +969,8 @@ func (s *GrpcServer) StoreHeartbeat(ctx context.Context, request *pdpb.StoreHear
 					// reset to let it be updated in the next request
 					s.schedulingClient.CompareAndSwap(forwardCli, &schedulingClient{})
 				}
+			} else {
+				errStoreHeartbeatClient.Inc()
 			}
 		}
 	}

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -395,6 +395,29 @@ func (suite *serverTestSuite) TestStoreHeartbeatForwardFailureWithNoSchedulingPr
 		return resp1Err == nil
 	})
 
+	// Snapshot the baseline counter value
+	getCounter := func() float64 {
+		mfs, gatherErr := prometheus.DefaultGatherer.Gather()
+		re.NoError(gatherErr)
+		for _, mf := range mfs {
+			if mf.GetName() == "pd_server_forward_fail_total" {
+				for _, m := range mf.GetMetric() {
+					lbls := m.GetLabel()
+					if len(lbls) >= 2 && lbls[0].GetValue() == "store_heartbeat" && lbls[1].GetValue() == "client" {
+						return m.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+		return 0
+	}
+	baseline := getCounter()
+
+	// Ensure we restore the primary address so the empty primary doesn't leak
+	originalAddr, ok := suite.pdLeader.GetServicePrimaryAddr(suite.ctx, constant.SchedulingServiceName)
+	re.True(ok)
+	defer suite.pdLeader.GetServer().SetServicePrimaryAddr(constant.SchedulingServiceName, originalAddr)
+
 	// Simulate the bug condition: clear the scheduling primary address
 	// so GetServicePrimaryAddr returns "", mimicking a leader switch where
 	// the primary watcher hasn't caught up.
@@ -416,19 +439,7 @@ func (suite *serverTestSuite) TestStoreHeartbeatForwardFailureWithNoSchedulingPr
 	// with label (store_heartbeat, client) should be incremented.
 	// Before the fix, this counter doesn't exist and the failure is silent.
 	re.Eventually(func() bool {
-		mfs, gatherErr := prometheus.DefaultGatherer.Gather()
-		re.NoError(gatherErr)
-		for _, mf := range mfs {
-			if mf.GetName() == "pd_server_forward_fail_total" {
-				for _, m := range mf.GetMetric() {
-					lbls := m.GetLabel()
-					if len(lbls) >= 2 && lbls[0].GetValue() == "store_heartbeat" && lbls[1].GetValue() == "client" {
-						return m.GetCounter().GetValue() > 0
-					}
-				}
-			}
-		}
-		return false
+		return getCounter() > baseline
 	}, 10*time.Second, 100*time.Millisecond)
 }
 

--- a/tests/integrations/mcs/scheduling/server_test.go
+++ b/tests/integrations/mcs/scheduling/server_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
@@ -355,6 +356,80 @@ func (suite *serverTestSuite) TestDisableSchedulingServiceFallback() {
 	testutil.Eventually(re, func() bool {
 		return !suite.pdLeader.GetServer().GetRaftCluster().IsSchedulingControllerRunning()
 	})
+}
+
+func (suite *serverTestSuite) TestStoreHeartbeatForwardFailureWithNoSchedulingPrimary() {
+	re := suite.Require()
+	tc, err := tests.NewTestSchedulingCluster(suite.ctx, 1, suite.cluster)
+	re.NoError(err)
+	defer tc.Destroy()
+	tc.WaitForPrimaryServing(re)
+
+	// Put a store so heartbeats can reference it.
+	s := &server.GrpcServer{Server: suite.pdLeader.GetServer()}
+	resp, err := s.PutStore(
+		context.Background(), &pdpb.PutStoreRequest{
+			Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
+			Store: &metapb.Store{
+				Id:      2,
+				Address: "mock://tikv-2:2",
+				State:   metapb.StoreState_Up,
+				Version: "7.0.0",
+			},
+		},
+	)
+	re.NoError(err)
+	re.Empty(resp.GetHeader().GetError())
+
+	// Wait until PD recognizes scheduling as independent and forwards heartbeats.
+	testutil.Eventually(re, func() bool {
+		_, resp1Err := s.StoreHeartbeat(
+			context.Background(), &pdpb.StoreHeartbeatRequest{
+				Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
+				Stats: &pdpb.StoreStats{
+					StoreId:  2,
+					Capacity: 100,
+				},
+			},
+		)
+		return resp1Err == nil
+	})
+
+	// Simulate the bug condition: clear the scheduling primary address
+	// so GetServicePrimaryAddr returns "", mimicking a leader switch where
+	// the primary watcher hasn't caught up.
+	suite.pdLeader.GetServer().SetServicePrimaryAddr(constant.SchedulingServiceName, "")
+
+	// Send a heartbeat — the forward should fail because no primary address.
+	_, err = s.StoreHeartbeat(
+		context.Background(), &pdpb.StoreHeartbeatRequest{
+			Header: &pdpb.RequestHeader{ClusterId: suite.pdLeader.GetClusterID()},
+			Stats: &pdpb.StoreStats{
+				StoreId:  2,
+				Capacity: 200,
+			},
+		},
+	)
+	re.NoError(err)
+
+	// The failure must be observable: the forward_fail_total counter
+	// with label (store_heartbeat, client) should be incremented.
+	// Before the fix, this counter doesn't exist and the failure is silent.
+	re.Eventually(func() bool {
+		mfs, gatherErr := prometheus.DefaultGatherer.Gather()
+		re.NoError(gatherErr)
+		for _, mf := range mfs {
+			if mf.GetName() == "pd_server_forward_fail_total" {
+				for _, m := range mf.GetMetric() {
+					lbls := m.GetLabel()
+					if len(lbls) >= 2 && lbls[0].GetValue() == "store_heartbeat" && lbls[1].GetValue() == "client" {
+						return m.GetCounter().GetValue() > 0
+					}
+				}
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func (suite *serverTestSuite) TestSchedulerSync() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10619

When PD is deployed in microservice mode, `StoreHeartbeat` requests arriving at the monolithic PD server are handled locally and then forwarded to the scheduling server. 

However, during a PD leader switch, the `servicePrimaryMap` in PD temporarily loses the primary address of the scheduling service until the etcd watcher catches up. During this window, `GetServicePrimaryAddr` returns an empty string, causing the scheduling gRPC client to evaluate to `nil` in `updateSchedulingClient`. 

When the scheduling client was `nil`, the forwarded heartbeat was silently dropped. Because the scheduling service was starved for `StoreHeartbeat`s, the stores' `LastHeartbeatTS` aged out locally on the scheduling server, eventually causing the stores to transition from `disconnected` -> `unhealthy` -> `down`. This triggered a false `SchedulingServerDiscoverDownStore` alert, even though the stores were perfectly healthy and successfully heartbeating to PD.

### What is changed and how does it work?

This PR fixes the silent failure by adding an explicit check for a `nil` client when forwarding store heartbeats. If the client is `nil`, it increments a new Prometheus metric `pd_server_forward_fail_total` with labels `("store_heartbeat", "client")`. This makes the forwarding failure observable and aligns the error handling with the existing `RegionHeartbeat` forwarding logic.

```commit-message
server: fix silent store heartbeat forwarding failure

When PD is in microservice mode but the scheduling primary's address
is not yet available (e.g. during a leader switch where the primary
watcher hasn't caught up), the scheduling client evaluates to nil.

Previously, this resulted in the StoreHeartbeat forward being silently
dropped, which starved the scheduling server of heartbeat information
and caused false 'SchedulingServerDiscoverDownStore' alerts as the
stores aged out locally on the scheduling server.

This commit adds an explicit check and increments a new Prometheus
metric 'pd_server_forward_fail_total' with labels
('store_heartbeat', 'client') when the client is nil, making the
forwarding failure observable and consistent with the region heartbeat
forwarding error handling.
```

### Check List

Tests

- Integration test

Code changes

- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

```release-note
Fix an issue where store heartbeats were silently dropped when forwarded from PD to the scheduling service during a leader switch, which could cause false down-store alerts.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metric counter that distinguishes heartbeat-forwarding failures when the scheduling service client is unavailable.

* **Tests**
  * Added an integration test that verifies the new metric increases when the scheduling primary is unavailable, making heartbeat-forwarding failures observable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->