### PR TITLE
server, config: support updating leader lease online

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -80,6 +80,7 @@ func (h *confHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 		mergedCfg := localCfg
 		mergedCfg.Replication = leaderCfg.Replication
 		mergedCfg.Schedule = leaderCfg.Schedule
+		mergedCfg.LeaderLease = leaderCfg.LeaderLease
 		h.rd.JSON(w, http.StatusOK, mergedCfg)
 		return
 	}
@@ -215,6 +216,8 @@ func (h *confHandler) updateConfig(cfg *config.Config, key string, value any) er
 		return h.updateMicroserviceConfig(cfg, kp[len(kp)-1], value)
 	case "controller":
 		return h.updateControllerConfig(kp[len(kp)-1], value)
+	case "lease":
+		return h.updateLeaderLease(cfg, value)
 	}
 	return errors.Errorf("config prefix %s not found", kp[0])
 }
@@ -252,6 +255,20 @@ func (h *confHandler) updateMicroserviceConfig(config *config.Config, key string
 		err = h.svr.SetMicroserviceConfig(config.Microservice)
 	}
 	return err
+}
+
+func (h *confHandler) updateLeaderLease(config *config.Config, value any) error {
+	updated, found, err := jsonutil.AddKeyValue(config, "lease", value)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("config item lease not found")
+	}
+	if updated {
+		return h.svr.SetLeaderLease(config.LeaderLease)
+	}
+	return nil
 }
 
 func (h *confHandler) updateSchedule(config *config.Config, key string, value any) error {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -175,7 +175,9 @@ func NewConfig() *Config {
 }
 
 const (
-	defaultLeaderLease             = int64(5)
+	defaultLeaderLease = int64(5)
+	// MaxLeaderLease is the maximum accepted PD leader lease timeout in seconds.
+	MaxLeaderLease                 = int64(60)
 	defaultCompactionMode          = "periodic"
 	defaultAutoCompactionRetention = "1h"
 	defaultQuotaBackendBytes       = typeutil.ByteSize(8 * units.GiB) // 8GB
@@ -401,6 +403,14 @@ func (c *Config) Adjust(meta *toml.MetaData, reloading bool) error {
 	configutil.AdjustDuration(&c.TSOProxyRecvFromClientTimeout, defaultTSOProxyRecvFromClientTimeout)
 
 	configutil.AdjustInt64(&c.LeaderLease, defaultLeaderLease)
+	if c.LeaderLease > MaxLeaderLease {
+		msg := fmt.Sprintf("leader lease %d exceeds max %d, using %d", c.LeaderLease, MaxLeaderLease, MaxLeaderLease)
+		c.WarningMsgs = append(c.WarningMsgs, msg)
+		log.Warn("leader lease exceeds max, use max",
+			zap.Int64("leader-lease", c.LeaderLease),
+			zap.Int64("max-leader-lease", MaxLeaderLease))
+		c.LeaderLease = MaxLeaderLease
+	}
 	configutil.AdjustDuration(&c.TSOSaveInterval, DefaultTSOSaveInterval)
 	configutil.AdjustDuration(&c.TSOUpdatePhysicalInterval, defaultTSOUpdatePhysicalInterval)
 

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -81,6 +81,96 @@ func TestReloadConfig(t *testing.T) {
 	re.Equal(int64(512), newOpt.GetMaxMovableHotPeerSize())
 }
 
+func TestLeaderLeasePersistAndReload(t *testing.T) {
+	re := require.New(t)
+	cfg := NewConfig()
+	re.NoError(cfg.Adjust(nil, false))
+	cfg.LeaderLease = 7
+	opt := NewPersistOptions(cfg)
+	opt.SetMaxReplicas(5)
+	storage := storage.NewStorageWithMemoryBackend()
+	re.NoError(opt.Persist(storage))
+
+	var stored struct {
+		LeaderLease int64 `json:"lease"`
+	}
+	exists, err := storage.LoadConfig(&stored)
+	re.NoError(err)
+	re.True(exists)
+	re.Equal(int64(7), stored.LeaderLease)
+
+	cfg.LeaderLease = 9
+	newOpt := NewPersistOptions(cfg)
+	re.NoError(newOpt.Reload(storage))
+	re.Equal(int64(7), newOpt.GetLeaderLease())
+}
+
+func TestLeaderLeaseSetPersistAndReload(t *testing.T) {
+	re := require.New(t)
+	opt, err := newTestScheduleOption()
+	re.NoError(err)
+	opt.SetLeaderLease(7)
+	storage := storage.NewStorageWithMemoryBackend()
+	re.NoError(opt.Persist(storage))
+	var stored struct {
+		LeaderLease int64 `json:"lease"`
+	}
+	exists, err := storage.LoadConfig(&stored)
+	re.NoError(err)
+	re.True(exists)
+	re.Equal(int64(7), stored.LeaderLease)
+
+	cfg := NewConfig()
+	re.NoError(cfg.Adjust(nil, false))
+	cfg.LeaderLease = 9
+	newOpt := NewPersistOptions(cfg)
+	re.NoError(newOpt.Reload(storage))
+	re.Equal(int64(7), newOpt.GetLeaderLease())
+}
+
+func TestLeaderLeaseReloadIgnoresNonPositivePersistedValues(t *testing.T) {
+	for _, persistedLease := range []int64{0, -1} {
+		t.Run(fmt.Sprintf("lease-%d", persistedLease), func(t *testing.T) {
+			re := require.New(t)
+			storage := storage.NewStorageWithMemoryBackend()
+			re.NoError(storage.SaveConfig(struct {
+				LeaderLease int64 `json:"lease"`
+			}{LeaderLease: persistedLease}))
+
+			cfg := NewConfig()
+			re.NoError(cfg.Adjust(nil, false))
+			cfg.LeaderLease = 7
+			opt := NewPersistOptions(cfg)
+			re.NoError(opt.Reload(storage))
+			re.Equal(int64(7), opt.GetLeaderLease())
+		})
+	}
+}
+
+func TestReloadKeepsCustomLeaderLeaseWhenPersistedConfigMissesLease(t *testing.T) {
+	re := require.New(t)
+	storage := storage.NewStorageWithMemoryBackend()
+
+	opt, err := newTestScheduleOption()
+	re.NoError(err)
+	type OldConfig struct {
+		Schedule    sc.ScheduleConfig    `toml:"schedule" json:"schedule"`
+		Replication sc.ReplicationConfig `toml:"replication" json:"replication"`
+	}
+	old := &OldConfig{
+		Schedule:    *opt.GetScheduleConfig(),
+		Replication: *opt.GetReplicationConfig(),
+	}
+	re.NoError(storage.SaveConfig(old))
+
+	cfg := NewConfig()
+	re.NoError(cfg.Adjust(nil, false))
+	cfg.LeaderLease = 7
+	newOpt := NewPersistOptions(cfg)
+	re.NoError(newOpt.Reload(storage))
+	re.Equal(int64(7), newOpt.GetLeaderLease())
+}
+
 func TestReloadUpgrade(t *testing.T) {
 	re := require.New(t)
 	opt, err := newTestScheduleOption()

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -83,110 +83,63 @@ func TestReloadConfig(t *testing.T) {
 	re.Equal(int64(512), newOpt.GetMaxMovableHotPeerSize())
 }
 
-func TestLeaderLeasePersistAndReload(t *testing.T) {
+func TestReloadLeaderLease(t *testing.T) {
 	re := require.New(t)
-	cfg := NewConfig()
-	re.NoError(cfg.Adjust(nil, false))
-	cfg.LeaderLease = 7
-	opt := NewPersistOptions(cfg)
-	opt.SetMaxReplicas(5)
-	storage := storage.NewStorageWithMemoryBackend()
-	re.NoError(opt.Persist(storage))
+	const startupLease = int64(9)
 
-	var stored struct {
-		LeaderLease int64 `json:"lease"`
-	}
-	exists, err := storage.LoadConfig(&stored)
-	re.NoError(err)
-	re.True(exists)
-	re.Equal(int64(7), stored.LeaderLease)
-
-	cfg.LeaderLease = 9
-	newOpt := NewPersistOptions(cfg)
-	re.NoError(newOpt.Reload(storage))
-	re.Equal(int64(7), newOpt.GetLeaderLease())
-}
-
-func TestLeaderLeaseSetPersistAndReload(t *testing.T) {
-	re := require.New(t)
-	opt, err := newTestScheduleOption()
-	re.NoError(err)
-	opt.SetLeaderLease(7)
-	storage := storage.NewStorageWithMemoryBackend()
-	re.NoError(opt.Persist(storage))
-	var stored struct {
-		LeaderLease int64 `json:"lease"`
-	}
-	exists, err := storage.LoadConfig(&stored)
-	re.NoError(err)
-	re.True(exists)
-	re.Equal(int64(7), stored.LeaderLease)
-
-	cfg := NewConfig()
-	re.NoError(cfg.Adjust(nil, false))
-	cfg.LeaderLease = 9
-	newOpt := NewPersistOptions(cfg)
-	re.NoError(newOpt.Reload(storage))
-	re.Equal(int64(7), newOpt.GetLeaderLease())
-}
-
-func TestLeaderLeaseReloadIgnoresNonPositivePersistedValues(t *testing.T) {
-	re := require.New(t)
-	assertReloadKeepsLeaderLeaseForPersistedValue := func(persistedLease int64) {
-		storage := storage.NewStorageWithMemoryBackend()
-		re.NoError(storage.SaveConfig(struct {
-			LeaderLease int64 `json:"lease"`
-		}{LeaderLease: persistedLease}))
-
+	newOpt := func() *PersistOptions {
 		cfg := NewConfig()
 		re.NoError(cfg.Adjust(nil, false))
-		cfg.LeaderLease = 7
-		opt := NewPersistOptions(cfg)
-		re.NoError(opt.Reload(storage))
-		re.Equal(int64(7), opt.GetLeaderLease())
+		cfg.LeaderLease = startupLease
+		return NewPersistOptions(cfg)
 	}
 
-	assertReloadKeepsLeaderLeaseForPersistedValue(0)
-	assertReloadKeepsLeaderLeaseForPersistedValue(-1)
-}
+	// No persisted config: keep the in-memory startup value.
+	st := storage.NewStorageWithMemoryBackend()
+	opt := newOpt()
+	re.NoError(opt.Reload(st))
+	re.Equal(startupLease, opt.GetLeaderLease())
 
-func TestLeaderLeaseReloadClampsPersistedValueAboveMax(t *testing.T) {
-	re := require.New(t)
-	storage := storage.NewStorageWithMemoryBackend()
-	re.NoError(storage.SaveConfig(struct {
+	// A positive persisted lease is adopted over the startup value.
+	st = storage.NewStorageWithMemoryBackend()
+	writer, err := newTestScheduleOption()
+	re.NoError(err)
+	writer.SetLeaderLease(7)
+	re.NoError(writer.Persist(st))
+	opt = newOpt()
+	re.NoError(opt.Reload(st))
+	re.Equal(int64(7), opt.GetLeaderLease())
+
+	// A persisted blob without the lease field keeps the startup value.
+	st = storage.NewStorageWithMemoryBackend()
+	re.NoError(st.SaveConfig(struct {
+		Schedule sc.ScheduleConfig `json:"schedule"`
+	}{}))
+	opt = newOpt()
+	re.NoError(opt.Reload(st))
+	re.Equal(startupLease, opt.GetLeaderLease())
+
+	// A non-positive persisted lease is ignored, keeping the startup value.
+	assertReloadKeepsStartupLease := func(persistedLease int64) {
+		st := storage.NewStorageWithMemoryBackend()
+		re.NoError(st.SaveConfig(struct {
+			LeaderLease int64 `json:"lease"`
+		}{LeaderLease: persistedLease}))
+		opt := newOpt()
+		re.NoError(opt.Reload(st))
+		re.Equal(startupLease, opt.GetLeaderLease())
+	}
+	assertReloadKeepsStartupLease(0)
+	assertReloadKeepsStartupLease(-1)
+
+	// A persisted lease above the maximum is clamped.
+	st = storage.NewStorageWithMemoryBackend()
+	re.NoError(st.SaveConfig(struct {
 		LeaderLease int64 `json:"lease"`
 	}{LeaderLease: MaxLeaderLease + 1}))
-
-	cfg := NewConfig()
-	re.NoError(cfg.Adjust(nil, false))
-	cfg.LeaderLease = 7
-	opt := NewPersistOptions(cfg)
-	re.NoError(opt.Reload(storage))
+	opt = newOpt()
+	re.NoError(opt.Reload(st))
 	re.Equal(MaxLeaderLease, opt.GetLeaderLease())
-}
-
-func TestReloadKeepsCustomLeaderLeaseWhenPersistedConfigMissesLease(t *testing.T) {
-	re := require.New(t)
-	storage := storage.NewStorageWithMemoryBackend()
-
-	opt, err := newTestScheduleOption()
-	re.NoError(err)
-	type OldConfig struct {
-		Schedule    sc.ScheduleConfig    `toml:"schedule" json:"schedule"`
-		Replication sc.ReplicationConfig `toml:"replication" json:"replication"`
-	}
-	old := &OldConfig{
-		Schedule:    *opt.GetScheduleConfig(),
-		Replication: *opt.GetReplicationConfig(),
-	}
-	re.NoError(storage.SaveConfig(old))
-
-	cfg := NewConfig()
-	re.NoError(cfg.Adjust(nil, false))
-	cfg.LeaderLease = 7
-	newOpt := NewPersistOptions(cfg)
-	re.NoError(newOpt.Reload(storage))
-	re.Equal(int64(7), newOpt.GetLeaderLease())
 }
 
 func TestValidateLeaderLease(t *testing.T) {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -32,6 +32,7 @@ import (
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/configutil"
+	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
@@ -200,6 +201,12 @@ func TestLoadPersistedLeaderLease(t *testing.T) {
 	re.NoError(err)
 	writer.SetLeaderLease(11)
 	re.NoError(writer.Persist(st))
+	lease, err = newOpt().LoadPersistedLeaderLease(st)
+	re.NoError(err)
+	re.Equal(int64(11), lease)
+
+	st = storage.NewStorageWithMemoryBackend()
+	re.NoError(st.Save(keypath.ConfigPath(), `{"lease":11,"schedule":1}`))
 	lease, err = newOpt().LoadPersistedLeaderLease(st)
 	re.NoError(err)
 	re.Equal(int64(11), lease)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -171,6 +171,65 @@ func TestReloadKeepsCustomLeaderLeaseWhenPersistedConfigMissesLease(t *testing.T
 	re.Equal(int64(7), newOpt.GetLeaderLease())
 }
 
+func TestValidateLeaderLease(t *testing.T) {
+	re := require.New(t)
+	re.NoError(ValidateLeaderLease(1))
+	re.Error(ValidateLeaderLease(0))
+	re.Error(ValidateLeaderLease(-1))
+}
+
+func TestLoadPersistedLeaderLease(t *testing.T) {
+	re := require.New(t)
+	const inMemoryLease = int64(7)
+
+	newOpt := func() *PersistOptions {
+		cfg := NewConfig()
+		re.NoError(cfg.Adjust(nil, false))
+		cfg.LeaderLease = inMemoryLease
+		return NewPersistOptions(cfg)
+	}
+
+	t.Run("no persisted config falls back to in-memory", func(t *testing.T) {
+		st := storage.NewStorageWithMemoryBackend()
+		lease, err := newOpt().LoadPersistedLeaderLease(st)
+		re.NoError(err)
+		re.Equal(inMemoryLease, lease)
+	})
+
+	t.Run("valid persisted lease is used", func(t *testing.T) {
+		st := storage.NewStorageWithMemoryBackend()
+		writer, err := newTestScheduleOption()
+		re.NoError(err)
+		writer.SetLeaderLease(11)
+		re.NoError(writer.Persist(st))
+		lease, err := newOpt().LoadPersistedLeaderLease(st)
+		re.NoError(err)
+		re.Equal(int64(11), lease)
+	})
+
+	t.Run("blob missing lease falls back to in-memory", func(t *testing.T) {
+		st := storage.NewStorageWithMemoryBackend()
+		re.NoError(st.SaveConfig(struct {
+			Schedule sc.ScheduleConfig `json:"schedule"`
+		}{}))
+		lease, err := newOpt().LoadPersistedLeaderLease(st)
+		re.NoError(err)
+		re.Equal(inMemoryLease, lease)
+	})
+
+	for _, persisted := range []int64{0, -1} {
+		t.Run(fmt.Sprintf("non-positive persisted lease %d falls back", persisted), func(t *testing.T) {
+			st := storage.NewStorageWithMemoryBackend()
+			re.NoError(st.SaveConfig(struct {
+				LeaderLease int64 `json:"lease"`
+			}{LeaderLease: persisted}))
+			lease, err := newOpt().LoadPersistedLeaderLease(st)
+			re.NoError(err)
+			re.Equal(inMemoryLease, lease)
+		})
+	}
+}
+
 func TestReloadUpgrade(t *testing.T) {
 	re := require.New(t)
 	opt, err := newTestScheduleOption()

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -149,6 +150,21 @@ func TestLeaderLeaseReloadIgnoresNonPositivePersistedValues(t *testing.T) {
 	assertReloadKeepsLeaderLeaseForPersistedValue(-1)
 }
 
+func TestLeaderLeaseReloadClampsPersistedValueAboveMax(t *testing.T) {
+	re := require.New(t)
+	storage := storage.NewStorageWithMemoryBackend()
+	re.NoError(storage.SaveConfig(struct {
+		LeaderLease int64 `json:"lease"`
+	}{LeaderLease: MaxLeaderLease + 1}))
+
+	cfg := NewConfig()
+	re.NoError(cfg.Adjust(nil, false))
+	cfg.LeaderLease = 7
+	opt := NewPersistOptions(cfg)
+	re.NoError(opt.Reload(storage))
+	re.Equal(MaxLeaderLease, opt.GetLeaderLease())
+}
+
 func TestReloadKeepsCustomLeaderLeaseWhenPersistedConfigMissesLease(t *testing.T) {
 	re := require.New(t)
 	storage := storage.NewStorageWithMemoryBackend()
@@ -176,8 +192,22 @@ func TestReloadKeepsCustomLeaderLeaseWhenPersistedConfigMissesLease(t *testing.T
 func TestValidateLeaderLease(t *testing.T) {
 	re := require.New(t)
 	re.NoError(ValidateLeaderLease(1))
+	re.NoError(ValidateLeaderLease(MaxLeaderLease))
 	re.Error(ValidateLeaderLease(0))
 	re.Error(ValidateLeaderLease(-1))
+	re.Error(ValidateLeaderLease(MaxLeaderLease + 1))
+}
+
+func TestAdjustClampsLeaderLeaseAboveMax(t *testing.T) {
+	re := require.New(t)
+	cfg := NewConfig()
+	meta, err := toml.Decode(fmt.Sprintf("lease = %d", MaxLeaderLease+1), cfg)
+	re.NoError(err)
+	re.NoError(cfg.Adjust(&meta, false))
+	re.Equal(MaxLeaderLease, cfg.LeaderLease)
+	re.Len(cfg.WarningMsgs, 1)
+	re.Contains(cfg.WarningMsgs[0], "leader lease")
+	re.Contains(cfg.WarningMsgs[0], strconv.FormatInt(MaxLeaderLease+1, 10))
 }
 
 func TestLoadPersistedLeaderLease(t *testing.T) {
@@ -230,6 +260,14 @@ func TestLoadPersistedLeaderLease(t *testing.T) {
 	}
 	assertLoadKeepsLeaderLeaseForPersistedValue(0)
 	assertLoadKeepsLeaderLeaseForPersistedValue(-1)
+
+	st = storage.NewStorageWithMemoryBackend()
+	re.NoError(st.SaveConfig(struct {
+		LeaderLease int64 `json:"lease"`
+	}{LeaderLease: MaxLeaderLease + 1}))
+	lease, err = newOpt().LoadPersistedLeaderLease(st)
+	re.NoError(err)
+	re.Equal(MaxLeaderLease, lease)
 }
 
 func TestReloadUpgrade(t *testing.T) {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -189,14 +189,14 @@ func TestLoadPersistedLeaderLease(t *testing.T) {
 		return NewPersistOptions(cfg)
 	}
 
-	t.Run("no persisted config falls back to in-memory", func(t *testing.T) {
+	t.Run("no persisted config falls back to in-memory", func(_ *testing.T) {
 		st := storage.NewStorageWithMemoryBackend()
 		lease, err := newOpt().LoadPersistedLeaderLease(st)
 		re.NoError(err)
 		re.Equal(inMemoryLease, lease)
 	})
 
-	t.Run("valid persisted lease is used", func(t *testing.T) {
+	t.Run("valid persisted lease is used", func(_ *testing.T) {
 		st := storage.NewStorageWithMemoryBackend()
 		writer, err := newTestScheduleOption()
 		re.NoError(err)
@@ -207,7 +207,7 @@ func TestLoadPersistedLeaderLease(t *testing.T) {
 		re.Equal(int64(11), lease)
 	})
 
-	t.Run("blob missing lease falls back to in-memory", func(t *testing.T) {
+	t.Run("blob missing lease falls back to in-memory", func(_ *testing.T) {
 		st := storage.NewStorageWithMemoryBackend()
 		re.NoError(st.SaveConfig(struct {
 			Schedule sc.ScheduleConfig `json:"schedule"`
@@ -218,7 +218,7 @@ func TestLoadPersistedLeaderLease(t *testing.T) {
 	})
 
 	for _, persisted := range []int64{0, -1} {
-		t.Run(fmt.Sprintf("non-positive persisted lease %d falls back", persisted), func(t *testing.T) {
+		t.Run(fmt.Sprintf("non-positive persisted lease %d falls back", persisted), func(_ *testing.T) {
 			st := storage.NewStorageWithMemoryBackend()
 			re.NoError(st.SaveConfig(struct {
 				LeaderLease int64 `json:"lease"`

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -129,22 +129,23 @@ func TestLeaderLeaseSetPersistAndReload(t *testing.T) {
 }
 
 func TestLeaderLeaseReloadIgnoresNonPositivePersistedValues(t *testing.T) {
-	for _, persistedLease := range []int64{0, -1} {
-		t.Run(fmt.Sprintf("lease-%d", persistedLease), func(t *testing.T) {
-			re := require.New(t)
-			storage := storage.NewStorageWithMemoryBackend()
-			re.NoError(storage.SaveConfig(struct {
-				LeaderLease int64 `json:"lease"`
-			}{LeaderLease: persistedLease}))
+	re := require.New(t)
+	assertReloadKeepsLeaderLeaseForPersistedValue := func(persistedLease int64) {
+		storage := storage.NewStorageWithMemoryBackend()
+		re.NoError(storage.SaveConfig(struct {
+			LeaderLease int64 `json:"lease"`
+		}{LeaderLease: persistedLease}))
 
-			cfg := NewConfig()
-			re.NoError(cfg.Adjust(nil, false))
-			cfg.LeaderLease = 7
-			opt := NewPersistOptions(cfg)
-			re.NoError(opt.Reload(storage))
-			re.Equal(int64(7), opt.GetLeaderLease())
-		})
+		cfg := NewConfig()
+		re.NoError(cfg.Adjust(nil, false))
+		cfg.LeaderLease = 7
+		opt := NewPersistOptions(cfg)
+		re.NoError(opt.Reload(storage))
+		re.Equal(int64(7), opt.GetLeaderLease())
 	}
+
+	assertReloadKeepsLeaderLeaseForPersistedValue(0)
+	assertReloadKeepsLeaderLeaseForPersistedValue(-1)
 }
 
 func TestReloadKeepsCustomLeaderLeaseWhenPersistedConfigMissesLease(t *testing.T) {
@@ -189,45 +190,39 @@ func TestLoadPersistedLeaderLease(t *testing.T) {
 		return NewPersistOptions(cfg)
 	}
 
-	t.Run("no persisted config falls back to in-memory", func(_ *testing.T) {
-		st := storage.NewStorageWithMemoryBackend()
-		lease, err := newOpt().LoadPersistedLeaderLease(st)
-		re.NoError(err)
-		re.Equal(inMemoryLease, lease)
-	})
+	st := storage.NewStorageWithMemoryBackend()
+	lease, err := newOpt().LoadPersistedLeaderLease(st)
+	re.NoError(err)
+	re.Equal(inMemoryLease, lease)
 
-	t.Run("valid persisted lease is used", func(_ *testing.T) {
-		st := storage.NewStorageWithMemoryBackend()
-		writer, err := newTestScheduleOption()
-		re.NoError(err)
-		writer.SetLeaderLease(11)
-		re.NoError(writer.Persist(st))
-		lease, err := newOpt().LoadPersistedLeaderLease(st)
-		re.NoError(err)
-		re.Equal(int64(11), lease)
-	})
+	st = storage.NewStorageWithMemoryBackend()
+	writer, err := newTestScheduleOption()
+	re.NoError(err)
+	writer.SetLeaderLease(11)
+	re.NoError(writer.Persist(st))
+	lease, err = newOpt().LoadPersistedLeaderLease(st)
+	re.NoError(err)
+	re.Equal(int64(11), lease)
 
-	t.Run("blob missing lease falls back to in-memory", func(_ *testing.T) {
+	st = storage.NewStorageWithMemoryBackend()
+	re.NoError(st.SaveConfig(struct {
+		Schedule sc.ScheduleConfig `json:"schedule"`
+	}{}))
+	lease, err = newOpt().LoadPersistedLeaderLease(st)
+	re.NoError(err)
+	re.Equal(inMemoryLease, lease)
+
+	assertLoadKeepsLeaderLeaseForPersistedValue := func(persistedLease int64) {
 		st := storage.NewStorageWithMemoryBackend()
 		re.NoError(st.SaveConfig(struct {
-			Schedule sc.ScheduleConfig `json:"schedule"`
-		}{}))
+			LeaderLease int64 `json:"lease"`
+		}{LeaderLease: persistedLease}))
 		lease, err := newOpt().LoadPersistedLeaderLease(st)
 		re.NoError(err)
 		re.Equal(inMemoryLease, lease)
-	})
-
-	for _, persisted := range []int64{0, -1} {
-		t.Run(fmt.Sprintf("non-positive persisted lease %d falls back", persisted), func(_ *testing.T) {
-			st := storage.NewStorageWithMemoryBackend()
-			re.NoError(st.SaveConfig(struct {
-				LeaderLease int64 `json:"lease"`
-			}{LeaderLease: persisted}))
-			lease, err := newOpt().LoadPersistedLeaderLease(st)
-			re.NoError(err)
-			re.Equal(inMemoryLease, lease)
-		})
 	}
+	assertLoadKeepsLeaderLeaseForPersistedValue(0)
+	assertLoadKeepsLeaderLeaseForPersistedValue(-1)
 }
 
 func TestReloadUpgrade(t *testing.T) {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -859,9 +859,44 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 	return nil
 }
 
+// LoadPersistedLeaderLease returns the leader lease that should be used for the
+// next campaign. It reads only the persisted leader lease instead of reloading
+// the whole configuration, so it is cheap enough to run on the election path.
+// When the persisted blob carries no valid lease (e.g. a blob written before
+// online lease update was supported), the current in-memory value is returned,
+// preserving the previous campaign behavior. Storage and decode errors are
+// returned to the caller, which decides whether to fall back.
+func (o *PersistOptions) LoadPersistedLeaderLease(storage endpoint.ConfigStorage) (int64, error) {
+	failpoint.Inject("loadLeaderLeaseFail", func() {
+		failpoint.Return(int64(0), errors.New("failpoint: fail to load persisted leader lease"))
+	})
+	cfg := &persistedConfig{Config: &Config{}}
+	isExist, err := storage.LoadConfig(cfg)
+	if err != nil {
+		return 0, err
+	}
+	if isExist && cfg.hasValidLeaderLease() {
+		return cfg.LeaderLease, nil
+	}
+	return o.GetLeaderLease(), nil
+}
+
 // IsValidLeaderLease returns whether the given PD leader lease timeout is valid.
+// It only checks positivity, because it also gates whether a persisted lease
+// should be honored on reload.
 func IsValidLeaderLease(lease int64) bool {
 	return lease > 0
+}
+
+// ValidateLeaderLease validates a leader lease (in seconds) supplied through
+// the online update API. Keep the accepted range aligned with file config
+// behavior: reject explicit non-positive updates, but do not add an online-only
+// upper bound.
+func ValidateLeaderLease(lease int64) error {
+	if !IsValidLeaderLease(lease) {
+		return errors.Errorf("leader lease must be positive, got %d", lease)
+	}
+	return nil
 }
 
 func adjustScheduleCfg(scheduleCfg *sc.ScheduleConfig) {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"strconv"
 	"sync/atomic"
@@ -55,6 +56,7 @@ type PersistOptions struct {
 	keyspace        atomic.Value
 	microservice    atomic.Value
 	storeConfig     atomic.Value
+	leaderLease     atomic.Int64
 	clusterVersion  unsafe.Pointer
 }
 
@@ -68,6 +70,7 @@ func NewPersistOptions(cfg *Config) *PersistOptions {
 	o.labelProperty.Store(cfg.LabelProperty)
 	o.keyspace.Store(&cfg.Keyspace)
 	o.microservice.Store(&cfg.Microservice)
+	o.leaderLease.Store(cfg.LeaderLease)
 	// storeConfig will be fetched from TiKV later,
 	// set it to an empty config here first.
 	o.storeConfig.Store(&sc.StoreConfig{})
@@ -154,6 +157,16 @@ func (o *PersistOptions) GetStoreConfig() *sc.StoreConfig {
 // SetStoreConfig sets the store configuration.
 func (o *PersistOptions) SetStoreConfig(cfg *sc.StoreConfig) {
 	o.storeConfig.Store(cfg)
+}
+
+// GetLeaderLease returns the PD leader lease timeout in seconds.
+func (o *PersistOptions) GetLeaderLease() int64 {
+	return o.leaderLease.Load()
+}
+
+// SetLeaderLease sets the PD leader lease timeout in seconds.
+func (o *PersistOptions) SetLeaderLease(lease int64) {
+	o.leaderLease.Store(lease)
 }
 
 // GetClusterVersion returns the cluster version.
@@ -761,6 +774,30 @@ type persistedConfig struct {
 	*Config
 	// StoreConfig is injected into Config to avoid breaking the original API.
 	StoreConfig sc.StoreConfig `json:"store"`
+	// leaseLoaded records whether the persisted etcd blob explicitly included
+	// the top-level "lease" field. Older blobs without that field should not
+	// silently overwrite the startup value with the default-filled lease.
+	leaseLoaded bool
+}
+
+// UnmarshalJSON records whether the persisted blob explicitly contains the
+// leader lease field while preserving the default Config JSON decoding.
+func (cfg *persistedConfig) UnmarshalJSON(data []byte) error {
+	if cfg.Config == nil {
+		cfg.Config = &Config{}
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	_, cfg.leaseLoaded = fields["lease"]
+
+	type persistedConfigAlias persistedConfig
+	return json.Unmarshal(data, (*persistedConfigAlias)(cfg))
+}
+
+func (cfg *persistedConfig) hasValidLeaderLease() bool {
+	return cfg.leaseLoaded && IsValidLeaderLease(cfg.LeaderLease)
 }
 
 // SwitchRaftV2 update some config if tikv raft engine switch into partition raft v2
@@ -781,6 +818,7 @@ func (o *PersistOptions) Persist(storage endpoint.ConfigStorage) error {
 			Keyspace:        *o.GetKeyspaceConfig(),
 			Microservice:    *o.GetMicroserviceConfig(),
 			ClusterVersion:  *o.GetClusterVersion(),
+			LeaderLease:     o.GetLeaderLease(),
 		},
 		StoreConfig: *o.GetStoreConfig(),
 	}
@@ -797,7 +835,6 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 	if err := cfg.Adjust(nil, true); err != nil {
 		return err
 	}
-
 	isExist, err := storage.LoadConfig(cfg)
 	if err != nil {
 		return err
@@ -813,10 +850,18 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 		o.labelProperty.Store(cfg.LabelProperty)
 		o.keyspace.Store(&cfg.Keyspace)
 		o.microservice.Store(&cfg.Microservice)
+		if cfg.hasValidLeaderLease() {
+			o.SetLeaderLease(cfg.LeaderLease)
+		}
 		o.storeConfig.Store(&cfg.StoreConfig)
 		o.SetClusterVersion(&cfg.ClusterVersion)
 	}
 	return nil
+}
+
+// IsValidLeaderLease returns whether the given PD leader lease timeout is valid.
+func IsValidLeaderLease(lease int64) bool {
+	return lease > 0
 }
 
 func adjustScheduleCfg(scheduleCfg *sc.ScheduleConfig) {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -796,16 +796,35 @@ func (cfg *persistedConfig) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, (*persistedConfigAlias)(cfg))
 }
 
-func (cfg *persistedConfig) hasValidLeaderLease() bool {
-	return cfg.leaseLoaded && IsValidLeaderLease(cfg.LeaderLease)
+func (cfg *persistedConfig) getValidLeaderLease() (int64, bool) {
+	if !cfg.leaseLoaded {
+		return 0, false
+	}
+	return normalizePersistedLeaderLease(cfg.LeaderLease)
 }
 
 type persistedLeaderLease struct {
 	LeaderLease *int64 `json:"lease"`
 }
 
-func (cfg *persistedLeaderLease) hasValidLeaderLease() bool {
-	return cfg.LeaderLease != nil && IsValidLeaderLease(*cfg.LeaderLease)
+func (cfg *persistedLeaderLease) getValidLeaderLease() (int64, bool) {
+	if cfg.LeaderLease == nil {
+		return 0, false
+	}
+	return normalizePersistedLeaderLease(*cfg.LeaderLease)
+}
+
+func normalizePersistedLeaderLease(lease int64) (int64, bool) {
+	if !IsValidLeaderLease(lease) {
+		return 0, false
+	}
+	if lease > MaxLeaderLease {
+		log.Warn("persisted leader lease exceeds max, use max",
+			zap.Int64("leader-lease", lease),
+			zap.Int64("max-leader-lease", MaxLeaderLease))
+		return MaxLeaderLease, true
+	}
+	return lease, true
 }
 
 // SwitchRaftV2 update some config if tikv raft engine switch into partition raft v2
@@ -858,8 +877,8 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 		o.labelProperty.Store(cfg.LabelProperty)
 		o.keyspace.Store(&cfg.Keyspace)
 		o.microservice.Store(&cfg.Microservice)
-		if cfg.hasValidLeaderLease() {
-			o.SetLeaderLease(cfg.LeaderLease)
+		if lease, ok := cfg.getValidLeaderLease(); ok {
+			o.SetLeaderLease(lease)
 		}
 		o.storeConfig.Store(&cfg.StoreConfig)
 		o.SetClusterVersion(&cfg.ClusterVersion)
@@ -883,26 +902,27 @@ func (o *PersistOptions) LoadPersistedLeaderLease(storage endpoint.ConfigStorage
 	if err != nil {
 		return 0, err
 	}
-	if isExist && cfg.hasValidLeaderLease() {
-		return *cfg.LeaderLease, nil
+	if isExist {
+		if lease, ok := cfg.getValidLeaderLease(); ok {
+			return lease, nil
+		}
 	}
 	return o.GetLeaderLease(), nil
 }
 
-// IsValidLeaderLease returns whether the given PD leader lease timeout is valid.
-// It only checks positivity, because it also gates whether a persisted lease
-// should be honored on reload.
+// IsValidLeaderLease returns whether the given PD leader lease timeout is positive.
 func IsValidLeaderLease(lease int64) bool {
 	return lease > 0
 }
 
 // ValidateLeaderLease validates a leader lease (in seconds) supplied through
-// the online update API. Keep the accepted range aligned with file config
-// behavior: reject explicit non-positive updates, but do not add an online-only
-// upper bound.
+// the online update API.
 func ValidateLeaderLease(lease int64) error {
 	if !IsValidLeaderLease(lease) {
 		return errors.Errorf("leader lease must be positive, got %d", lease)
+	}
+	if lease > MaxLeaderLease {
+		return errors.Errorf("leader lease must not exceed %d seconds, got %d", MaxLeaderLease, lease)
 	}
 	return nil
 }

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -800,6 +800,14 @@ func (cfg *persistedConfig) hasValidLeaderLease() bool {
 	return cfg.leaseLoaded && IsValidLeaderLease(cfg.LeaderLease)
 }
 
+type persistedLeaderLease struct {
+	LeaderLease *int64 `json:"lease"`
+}
+
+func (cfg *persistedLeaderLease) hasValidLeaderLease() bool {
+	return cfg.LeaderLease != nil && IsValidLeaderLease(*cfg.LeaderLease)
+}
+
 // SwitchRaftV2 update some config if tikv raft engine switch into partition raft v2
 func (o *PersistOptions) SwitchRaftV2(storage endpoint.ConfigStorage) error {
 	o.GetScheduleConfig().StoreLimitVersion = "v2"
@@ -870,13 +878,13 @@ func (o *PersistOptions) LoadPersistedLeaderLease(storage endpoint.ConfigStorage
 	failpoint.Inject("loadLeaderLeaseFail", func() {
 		failpoint.Return(int64(0), errors.New("failpoint: fail to load persisted leader lease"))
 	})
-	cfg := &persistedConfig{Config: &Config{}}
+	cfg := &persistedLeaderLease{}
 	isExist, err := storage.LoadConfig(cfg)
 	if err != nil {
 		return 0, err
 	}
 	if isExist && cfg.hasValidLeaderLease() {
-		return cfg.LeaderLease, nil
+		return *cfg.LeaderLease, nil
 	}
 	return o.GetLeaderLease(), nil
 }

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"context"
-	"encoding/json"
 	"reflect"
 	"strconv"
 	"sync/atomic"
@@ -774,48 +773,20 @@ type persistedConfig struct {
 	*Config
 	// StoreConfig is injected into Config to avoid breaking the original API.
 	StoreConfig sc.StoreConfig `json:"store"`
-	// leaseLoaded records whether the persisted etcd blob explicitly included
-	// the top-level "lease" field. Older blobs without that field should not
-	// silently overwrite the startup value with the default-filled lease.
-	leaseLoaded bool
 }
 
-// UnmarshalJSON records whether the persisted blob explicitly contains the
-// leader lease field while preserving the default Config JSON decoding.
-func (cfg *persistedConfig) UnmarshalJSON(data []byte) error {
-	if cfg.Config == nil {
-		cfg.Config = &Config{}
-	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(data, &fields); err != nil {
-		return err
-	}
-	_, cfg.leaseLoaded = fields["lease"]
-
-	type persistedConfigAlias persistedConfig
-	return json.Unmarshal(data, (*persistedConfigAlias)(cfg))
-}
-
-func (cfg *persistedConfig) getValidLeaderLease() (int64, bool) {
-	if !cfg.leaseLoaded {
-		return 0, false
-	}
-	return normalizePersistedLeaderLease(cfg.LeaderLease)
-}
-
+// persistedLeaderLease decodes only the leader lease from the persisted config
+// blob, so the election path can read it without reloading everything else.
 type persistedLeaderLease struct {
-	LeaderLease *int64 `json:"lease"`
+	LeaderLease int64 `json:"lease"`
 }
 
-func (cfg *persistedLeaderLease) getValidLeaderLease() (int64, bool) {
-	if cfg.LeaderLease == nil {
-		return 0, false
-	}
-	return normalizePersistedLeaderLease(*cfg.LeaderLease)
-}
-
+// normalizePersistedLeaderLease reports whether a persisted leader lease should
+// be adopted. A non-positive value means no lease was set online (an absent
+// "lease" field decodes to zero), so the caller keeps its in-memory value; a
+// value above the maximum is clamped to it.
 func normalizePersistedLeaderLease(lease int64) (int64, bool) {
-	if !IsValidLeaderLease(lease) {
+	if lease <= 0 {
 		return 0, false
 	}
 	if lease > MaxLeaderLease {
@@ -862,6 +833,10 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 	if err := cfg.Adjust(nil, true); err != nil {
 		return err
 	}
+	// Adjust fills LeaderLease with its default; reset it so a persisted blob
+	// that omits or zeroes "lease" falls back to the in-memory startup value
+	// instead of adopting the default.
+	cfg.LeaderLease = 0
 	isExist, err := storage.LoadConfig(cfg)
 	if err != nil {
 		return err
@@ -877,7 +852,7 @@ func (o *PersistOptions) Reload(storage endpoint.ConfigStorage) error {
 		o.labelProperty.Store(cfg.LabelProperty)
 		o.keyspace.Store(&cfg.Keyspace)
 		o.microservice.Store(&cfg.Microservice)
-		if lease, ok := cfg.getValidLeaderLease(); ok {
+		if lease, ok := normalizePersistedLeaderLease(cfg.LeaderLease); ok {
 			o.SetLeaderLease(lease)
 		}
 		o.storeConfig.Store(&cfg.StoreConfig)
@@ -903,22 +878,17 @@ func (o *PersistOptions) LoadPersistedLeaderLease(storage endpoint.ConfigStorage
 		return 0, err
 	}
 	if isExist {
-		if lease, ok := cfg.getValidLeaderLease(); ok {
+		if lease, ok := normalizePersistedLeaderLease(cfg.LeaderLease); ok {
 			return lease, nil
 		}
 	}
 	return o.GetLeaderLease(), nil
 }
 
-// IsValidLeaderLease returns whether the given PD leader lease timeout is positive.
-func IsValidLeaderLease(lease int64) bool {
-	return lease > 0
-}
-
 // ValidateLeaderLease validates a leader lease (in seconds) supplied through
 // the online update API.
 func ValidateLeaderLease(lease int64) error {
-	if !IsValidLeaderLease(lease) {
+	if lease <= 0 {
 		return errors.Errorf("leader lease must be positive, got %d", lease)
 	}
 	if lease > MaxLeaderLease {

--- a/server/server.go
+++ b/server/server.go
@@ -1013,6 +1013,7 @@ func (s *Server) GetServiceMiddlewareConfig() *config.ServiceMiddlewareConfig {
 // GetConfig gets the config information.
 func (s *Server) GetConfig() *config.Config {
 	cfg := s.cfg.Clone()
+	cfg.LeaderLease = s.persistOptions.GetLeaderLease()
 	cfg.Schedule = *s.persistOptions.GetScheduleConfig().Clone()
 	cfg.Replication = *s.persistOptions.GetReplicationConfig().Clone()
 	cfg.PDServerCfg = *s.persistOptions.GetPDServerConfig().Clone()
@@ -1353,6 +1354,25 @@ func (s *Server) SetPDServerConfig(cfg config.PDServerConfig) error {
 		return err
 	}
 	log.Info("PD server config is updated", zap.Reflect("new", cfg), zap.Reflect("old", old))
+	return nil
+}
+
+// SetLeaderLease sets the PD leader lease timeout.
+func (s *Server) SetLeaderLease(lease int64) error {
+	if !config.IsValidLeaderLease(lease) {
+		return errors.Errorf("leader lease must be positive, got %d", lease)
+	}
+	old := s.persistOptions.GetLeaderLease()
+	s.persistOptions.SetLeaderLease(lease)
+	if err := s.persistOptions.Persist(s.storage); err != nil {
+		s.persistOptions.SetLeaderLease(old)
+		log.Error("failed to update leader lease",
+			zap.Int64("new", lease),
+			zap.Int64("old", old),
+			errs.ZapError(err))
+		return err
+	}
+	log.Info("leader lease is updated", zap.Int64("new", lease), zap.Int64("old", old))
 	return nil
 }
 
@@ -1737,7 +1757,13 @@ func (s *Server) leaderLoop() {
 
 func (s *Server) campaignLeader() {
 	log.Info("start to campaign PD leader", zap.String("campaign-leader-name", s.Name()))
-	if err := s.member.Campaign(s.ctx, s.cfg.LeaderLease); err != nil {
+	if err := s.persistOptions.Reload(s.storage); err != nil {
+		log.Warn("failed to reload persisted configuration before campaign",
+			errs.ZapError(err),
+			zap.String("campaign-leader-name", s.Name()))
+		return
+	}
+	if err := s.member.Campaign(s.ctx, s.persistOptions.GetLeaderLease()); err != nil {
 		if err.Error() == errs.ErrEtcdTxnConflict.Error() {
 			log.Info("campaign PD leader meets error due to txn conflict, another PD may campaign successfully",
 				zap.String("campaign-leader-name", s.Name()))
@@ -1770,12 +1796,12 @@ func (s *Server) campaignLeader() {
 	keepLeaderDuration := time.Since(keepLeaderStart)
 	log.Info("keep leader lease completed", zap.Duration("cost", keepLeaderDuration), zap.String("campaign-leader-name", s.Name()))
 
-	reloadConfigStart := time.Now()
+	postKeepReloadStart := time.Now()
 	if err := s.reloadConfigFromKV(); err != nil {
-		log.Warn("failed to reload configuration", errs.ZapError(err), zap.Duration("cost", time.Since(reloadConfigStart)))
+		log.Warn("failed to reload configuration", errs.ZapError(err), zap.Duration("cost", time.Since(postKeepReloadStart)))
 		return
 	}
-	reloadConfigDuration := time.Since(reloadConfigStart)
+	reloadConfigDuration := time.Since(postKeepReloadStart)
 	log.Info("reload config from KV completed", zap.Duration("cost", reloadConfigDuration))
 
 	loadTTLStart := time.Now()
@@ -2230,7 +2256,7 @@ func (s *Server) GetTSOProxyRecvFromClientTimeout() time.Duration {
 
 // GetLease returns the leader lease.
 func (s *Server) GetLease() int64 {
-	return s.cfg.GetLease()
+	return s.persistOptions.GetLeaderLease()
 }
 
 // GetTSOSaveInterval returns TSO save interval.

--- a/server/server.go
+++ b/server/server.go
@@ -1359,8 +1359,8 @@ func (s *Server) SetPDServerConfig(cfg config.PDServerConfig) error {
 
 // SetLeaderLease sets the PD leader lease timeout.
 func (s *Server) SetLeaderLease(lease int64) error {
-	if !config.IsValidLeaderLease(lease) {
-		return errors.Errorf("leader lease must be positive, got %d", lease)
+	if err := config.ValidateLeaderLease(lease); err != nil {
+		return err
 	}
 	old := s.persistOptions.GetLeaderLease()
 	s.persistOptions.SetLeaderLease(lease)
@@ -1757,13 +1757,25 @@ func (s *Server) leaderLoop() {
 
 func (s *Server) campaignLeader() {
 	log.Info("start to campaign PD leader", zap.String("campaign-leader-name", s.Name()))
-	if err := s.persistOptions.Reload(s.storage); err != nil {
-		log.Warn("failed to reload persisted configuration before campaign",
+	// Only the leader lease has to be refreshed from storage before campaigning,
+	// so that an online update done on a previous leader takes effect on the
+	// next election. The rest of the configuration is still reloaded after the
+	// leadership is kept (reloadConfigFromKV below). A storage error here must
+	// not abort the campaign, otherwise leader election availability would
+	// regress whenever etcd is briefly degraded; fall back to the current
+	// in-memory value.
+	lease, err := s.persistOptions.LoadPersistedLeaderLease(s.storage)
+	if err != nil {
+		lease = s.persistOptions.GetLeaderLease()
+		log.Warn("failed to load persisted leader lease before campaign, fall back to in-memory value",
 			errs.ZapError(err),
+			zap.Int64("leader-lease", lease),
 			zap.String("campaign-leader-name", s.Name()))
-		return
 	}
-	if err := s.member.Campaign(s.ctx, s.persistOptions.GetLeaderLease()); err != nil {
+	// Keep the in-memory value consistent with the lease this server is about
+	// to campaign with, so GetLease()/GetConfig() reflect the effective value.
+	s.persistOptions.SetLeaderLease(lease)
+	if err := s.member.Campaign(s.ctx, lease); err != nil {
 		if err.Error() == errs.ErrEtcdTxnConflict.Error() {
 			log.Info("campaign PD leader meets error due to txn conflict, another PD may campaign successfully",
 				zap.String("campaign-leader-name", s.Name()))

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -164,6 +164,79 @@ func TestLeaderLeaseConfigAPI(t *testing.T) {
 	}
 }
 
+// TestLeaderLeaseTakesEffectAfterTransfer proves the user-visible behavior:
+// after a leader lease update and a leader change, the new leader and the
+// surviving follower converge to the persisted lease instead of staying on
+// their startup config.
+func TestLeaderLeaseTakesEffectAfterTransfer(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	const startupLease, updatedLease = int64(5), int64(2)
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, _ string) {
+		conf.LeaderLease = startupLease
+	})
+	re.NoError(err)
+	defer cluster.Destroy()
+
+	re.NoError(cluster.RunInitialServers())
+	oldLeaderName := cluster.WaitLeader()
+	re.NotEmpty(oldLeaderName)
+	oldLeader := cluster.GetLeaderServer()
+	re.Equal(startupLease, oldLeader.GetServer().GetPersistOptions().GetLeaderLease())
+
+	configURL := oldLeader.GetAddr() + "/pd/api/v1/config"
+	data, err := json.Marshal(map[string]any{"lease": updatedLease})
+	re.NoError(err)
+	re.NoError(testutil.CheckPostJSON(tests.TestDialClient, configURL, data, testutil.StatusOK(re)))
+
+	// Stopping the old leader guarantees a different node wins the next
+	// election, so the assertion below cannot be satisfied by the API call's
+	// in-memory write on the old leader.
+	re.NoError(cluster.GetServer(oldLeaderName).Stop())
+	newLeaderName := cluster.WaitLeader()
+	re.NotEmpty(newLeaderName)
+	re.NotEqual(oldLeaderName, newLeaderName)
+
+	for name, srv := range cluster.GetServers() {
+		if name == oldLeaderName {
+			continue // stopped; its frozen state is irrelevant
+		}
+		// newLeaderName picks it up via campaign (LoadPersistedLeaderLease),
+		// the surviving follower via its leaderLoop reloadConfigFromKV.
+		testutil.Eventually(re, func() bool {
+			return srv.GetServer().GetPersistOptions().GetLeaderLease() == updatedLease
+		})
+	}
+}
+
+// TestLeaderLeaseCampaignSurvivesLoadFailure proves the availability guarantee:
+// if reading the persisted leader lease fails right before campaigning (etcd
+// briefly degraded), the election must still succeed using the in-memory
+// value instead of looping forever. Without the fallback, WaitLeader below
+// would never return because campaignLeader would bail out every iteration.
+func TestLeaderLeaseCampaignSurvivesLoadFailure(t *testing.T) {
+	re := require.New(t)
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/config/loadLeaderLeaseFail", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/config/loadLeaderLeaseFail"))
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	const startupLease = int64(3)
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, _ string) {
+		conf.LeaderLease = startupLease
+	})
+	re.NoError(err)
+	defer cluster.Destroy()
+
+	re.NoError(cluster.RunInitialServers())
+	leaderName := cluster.WaitLeader()
+	re.NotEmpty(leaderName)
+	re.Equal(startupLease, cluster.GetLeaderServer().GetServer().GetPersistOptions().GetLeaderLease())
+}
+
 type middlewareTestSuite struct {
 	suite.Suite
 	cleanup func()

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -110,6 +110,60 @@ func TestReconnect(t *testing.T) {
 	}
 }
 
+func TestLeaderLeaseConfigAPI(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, _ string) {
+		conf.LeaderLease = 7
+	})
+	re.NoError(err)
+	defer cluster.Destroy()
+
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+	leader := cluster.GetLeaderServer()
+	configURL := leader.GetAddr() + "/pd/api/v1/config"
+
+	var cfg map[string]any
+	err = testutil.ReadGetJSON(re, tests.TestDialClient, configURL, &cfg)
+	re.NoError(err)
+	re.Equal(float64(7), cfg["lease"])
+	_, hasLeader := cfg["leader"]
+	re.False(hasLeader)
+
+	data, err := json.Marshal(map[string]any{"lease": 10})
+	re.NoError(err)
+	err = testutil.CheckPostJSON(tests.TestDialClient, configURL, data, testutil.StatusOK(re))
+	re.NoError(err)
+	re.Equal(int64(10), leader.GetServer().GetPersistOptions().GetLeaderLease())
+
+	err = testutil.ReadGetJSON(re, tests.TestDialClient, configURL, &cfg)
+	re.NoError(err)
+	re.Equal(float64(10), cfg["lease"])
+	_, hasLeader = cfg["leader"]
+	re.False(hasLeader)
+
+	for _, s := range cluster.GetServers() {
+		if s.GetServer().Name() == leader.GetServer().Name() {
+			continue
+		}
+		followerConfigURL := s.GetAddr() + "/pd/api/v1/config"
+		err = testutil.ReadGetJSON(re, tests.TestDialClient, followerConfigURL, &cfg)
+		re.NoError(err)
+		re.Equal(float64(10), cfg["lease"])
+		break
+	}
+
+	for _, lease := range []int64{0, -1} {
+		data, err = json.Marshal(map[string]any{"lease": lease})
+		re.NoError(err)
+		err = testutil.CheckPostJSON(tests.TestDialClient, configURL, data, testutil.Status(re, http.StatusBadRequest))
+		re.NoError(err)
+		re.Equal(int64(10), leader.GetServer().GetPersistOptions().GetLeaderLease())
+	}
+}
+
 type middlewareTestSuite struct {
 	suite.Suite
 	cleanup func()

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -156,12 +156,18 @@ func TestLeaderLeaseConfigAPI(t *testing.T) {
 		re.Equal(float64(10), cfg["lease"])
 	}
 
-	for _, lease := range []int64{0, -1} {
+	data, err = json.Marshal(map[string]any{"lease": config.MaxLeaderLease})
+	re.NoError(err)
+	err = testutil.CheckPostJSON(tests.TestDialClient, configURL, data, testutil.StatusOK(re))
+	re.NoError(err)
+	re.Equal(config.MaxLeaderLease, leader.GetServer().GetPersistOptions().GetLeaderLease())
+
+	for _, lease := range []int64{0, -1, config.MaxLeaderLease + 1} {
 		data, err = json.Marshal(map[string]any{"lease": lease})
 		re.NoError(err)
 		err = testutil.CheckPostJSON(tests.TestDialClient, configURL, data, testutil.Status(re, http.StatusBadRequest))
 		re.NoError(err)
-		re.Equal(int64(10), leader.GetServer().GetPersistOptions().GetLeaderLease())
+		re.Equal(config.MaxLeaderLease, leader.GetServer().GetPersistOptions().GetLeaderLease())
 	}
 }
 

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -125,7 +125,7 @@ func TestLeaderLeaseConfigAPI(t *testing.T) {
 	leader := cluster.GetLeaderServer()
 	configURL := leader.GetAddr() + "/pd/api/v1/config"
 
-	var cfg map[string]any
+	cfg := map[string]any{}
 	err = testutil.ReadGetJSON(re, tests.TestDialClient, configURL, &cfg)
 	re.NoError(err)
 	re.Equal(float64(7), cfg["lease"])
@@ -138,6 +138,7 @@ func TestLeaderLeaseConfigAPI(t *testing.T) {
 	re.NoError(err)
 	re.Equal(int64(10), leader.GetServer().GetPersistOptions().GetLeaderLease())
 
+	cfg = map[string]any{}
 	err = testutil.ReadGetJSON(re, tests.TestDialClient, configURL, &cfg)
 	re.NoError(err)
 	re.Equal(float64(10), cfg["lease"])
@@ -149,10 +150,10 @@ func TestLeaderLeaseConfigAPI(t *testing.T) {
 			continue
 		}
 		followerConfigURL := s.GetAddr() + "/pd/api/v1/config"
+		cfg = map[string]any{}
 		err = testutil.ReadGetJSON(re, tests.TestDialClient, followerConfigURL, &cfg)
 		re.NoError(err)
 		re.Equal(float64(10), cfg["lease"])
-		break
 	}
 
 	for _, lease := range []int64{0, -1} {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10630

Production clusters can see PD leader lease keepalive p99 latency approach the
5s default lease timeout, leaving little safety margin before leader churn.
Operators need a way to tune the PD leader lease online between releases without
editing the local config file and restarting PD.

### What is changed and how does it work?

```commit-message
Support updating the PD leader lease timeout through POST /pd/api/v1/config with the top-level lease field.
Store the effective leader lease in PersistOptions and persist it with the existing config blob.
Before campaigning, load only the persisted leader lease so the next PD leader campaign uses the runtime lease value.
Keep existing toml startup behavior unchanged for `lease = 0`, cap the effective lease at 60 seconds, and reject invalid API values.
```

Implementation notes:

- `GET /pd/api/v1/config` returns the effective top-level `lease` value (the in-memory value of the queried member).
- `POST /pd/api/v1/config` accepts `{"lease": <seconds>}` and persists it through the existing config blob. The accepted online range is `1..60` seconds; `0`, negative, and `> 60` are rejected.
- The current leader's etcd lease TTL is fixed at grant time, so an online update takes effect on the **next** PD leader campaign. Use leader transfer or resign to apply it immediately.
- Before campaigning, the server loads only the persisted leader lease (a cheap election-path read). A **positive** persisted value is adopted; otherwise (absent, non-positive, or a load error) the current in-memory value is used, preserving the previous campaign behavior.
- The full config reload (run on becoming leader, and on followers when the leader changes) likewise adopts a positive persisted lease and otherwise keeps the in-memory value, so `GET /config` converges to the effective lease.
- Once a positive lease has been persisted it is authoritative: it overrides the local `lease` in the config file on reload/campaign. To change the lease on a running cluster, use the online API — editing the config file and restarting has **no effect** while a positive lease is persisted. This matches how PD already treats other persisted config.
- Older blobs with an absent or non-positive `lease` (e.g. clusters upgraded from a version without this feature) keep the startup toml value.
- File config `lease = 0` keeps the existing startup behavior and defaults to `5` through `AdjustInt64`. File config or persisted values above `60` are clamped to `60` with a warning, so existing deployments do not fail to start after upgrade while the effective leader lease stays within the supported range.
- The `60s` upper bound is a failover availability guard. Leader lease does not affect TSO correctness; TSO save-window protection is independent of this runtime lease value.
- Use the online lease API after all PD members are upgraded. In a mixed-version rolling upgrade, an old PD member may persist the config blob without the online lease value, reverting the setting. Re-apply the online lease after all PD members are upgraded.

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Increased code complexity

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn): TBD

Manual test

Unit / integration:

- `go test ./server/config -run 'TestReloadLeaderLease|TestValidateLeaderLease|TestAdjustClampsLeaderLeaseAboveMax|TestLoadPersistedLeaderLease' -count=1`
- `go test -tags without_dashboard ./tests/server/api -run 'TestLeaderLeaseConfigAPI|TestLeaderLeaseTakesEffectAfterTransfer|TestLeaderLeaseCampaignSurvivesLoadFailure' -count=1`
- `golangci-lint run ./server/config`
- `gofmt -l server/config/config.go server/config/config_test.go server/config/persist_options.go server/server.go tests/server/api/api_test.go`
- `git diff --check`

End-to-end (3-node PD cluster; the leadership lease TTL was read directly from etcd to confirm the lease each campaign actually used):

| Scenario | Expectation | Observed |
|---|---|---|
| Fresh cluster, file `lease = 7`, blob absent | campaign uses the local value | leadership TTL = `7`; all `GET /config` = `7` |
| `POST {"lease":15}` on the leader | in-memory + persisted update is immediate; current leader unchanged | `GET /config` = `15`, blob = `15`, current leadership TTL still `7` |
| Resign the leader after the update | next campaign adopts the persisted value | new leader leadership TTL = `15`; all nodes converge to `15` |
| Restart a node with file `lease = 30` while blob = `15` | persisted overrides the local file | node `GET /config` = `15`; after transfer its campaign leadership TTL = `15` (not `30`) |
| Persisted `lease = 0`, restart all with file `lease = 33` | non-positive persisted value ignored → local fallback | leadership TTL = `33` |
| `POST` `lease` = `0` / `-1` / `61` | rejected, value unchanged | HTTP `400`; `GET /config` unchanged |
| Persisted `lease = 200`, next campaign | clamped to the `60s` max | leadership TTL = `60`; clamp warning logged |

### Release note

```release-note
Support updating the PD leader lease timeout online through `POST /pd/api/v1/config` with the `lease` field. The new value takes effect on the next PD leader campaign; use leader transfer or resign to apply it immediately. The API accepts `1..60` seconds and rejects values outside that range. Once set online the lease is persisted and authoritative across restarts, so to change it on a running cluster use this API rather than editing the local config file. File config `lease = 0` keeps the existing default-to-5 startup behavior, while file config or persisted values above `60` are clamped to `60` with a warning. Use this API after all PD members are upgraded; during a mixed-version rolling upgrade, an old PD member may persist the config blob without the online lease value, reverting the setting. Re-apply the online lease after all PD members are upgraded.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leader lease is now persisted, surfaced in the config API (GET/POST), and applied at runtime; server provides a validated API to update the lease.

* **Bug Fixes**
  * Reload now ignores non‑positive persisted lease values and preserves other persisted options when updating the lease.

* **Tests**
  * Added unit and end‑to‑end tests for API behavior, persistence, reload semantics, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
