### PR TITLE
client: use singleflight to reduce request press

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.1.11
 	go.uber.org/zap v1.24.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/grpc/examples v0.0.0-20231221225426-4f03f3ff32c9
 )

--- a/client/go.sum
+++ b/client/go.sum
@@ -130,6 +130,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -923,7 +923,8 @@ func (c *serviceDiscovery) getClusterInfo(ctx context.Context, url string, timeo
 	}
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetClusterInfo.Observe(time.Since(start).Seconds()) }()
-	res, err, _ := c.flight.Do("GetClusterInfo", func() (any, error) {
+	key := "GetClusterInfo-" + url
+	res, err, _ := c.flight.Do(key, func() (any, error) {
 		return pdpb.NewPDClient(cc).GetClusterInfo(ctx, &pdpb.GetClusterInfoRequest{})
 	})
 	if err != nil {
@@ -949,7 +950,8 @@ func (c *serviceDiscovery) getMembers(ctx context.Context, url string, timeout t
 	}
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetMembers.Observe(time.Since(start).Seconds()) }()
-	res, err, _ := c.flight.Do("GetMembers", func() (any, error) {
+	key := "GetMembers-" + url
+	res, err, _ := c.flight.Do(key, func() (any, error) {
 		return pdpb.NewPDClient(cc).GetMembers(ctx, &pdpb.GetMembersRequest{})
 	})
 	if err != nil {

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -443,6 +444,8 @@ type serviceDiscovery struct {
 	tlsCfg               *tls.Config
 	// Client option.
 	option *opt.Option
+
+	flight singleflight.Group
 }
 
 // NewDefaultServiceDiscovery returns a new default service discovery-based client.
@@ -474,6 +477,7 @@ func NewServiceDiscovery(
 		keyspaceID:           keyspaceID,
 		tlsCfg:               tlsCfg,
 		option:               option,
+		flight:               singleflight.Group{},
 	}
 	pdsd.callbacks.setServiceModeUpdateCallback(serviceModeUpdateCb)
 	urls = tlsutil.AddrsToURLs(urls, tlsCfg)
@@ -919,12 +923,15 @@ func (c *serviceDiscovery) getClusterInfo(ctx context.Context, url string, timeo
 	}
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetClusterInfo.Observe(time.Since(start).Seconds()) }()
-	clusterInfo, err := pdpb.NewPDClient(cc).GetClusterInfo(ctx, &pdpb.GetClusterInfoRequest{})
+	res, err, _ := c.flight.Do("GetClusterInfo", func() (interface{}, error) {
+		return pdpb.NewPDClient(cc).GetClusterInfo(ctx, &pdpb.GetClusterInfoRequest{})
+	})
 	if err != nil {
 		metrics.InternalCmdFailedDurationGetClusterInfo.Observe(time.Since(start).Seconds())
 		attachErr := errors.Errorf("error:%s target:%s status:%s", err, cc.Target(), cc.GetState().String())
 		return nil, errs.ErrClientGetClusterInfo.Wrap(attachErr).GenWithStackByCause()
 	}
+	clusterInfo := res.(*pdpb.GetClusterInfoResponse)
 	if clusterInfo.GetHeader().GetError() != nil {
 		metrics.InternalCmdFailedDurationGetClusterInfo.Observe(time.Since(start).Seconds())
 		attachErr := errors.Errorf("error:%s target:%s status:%s", clusterInfo.GetHeader().GetError().String(), cc.Target(), cc.GetState().String())
@@ -942,12 +949,15 @@ func (c *serviceDiscovery) getMembers(ctx context.Context, url string, timeout t
 	}
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetMembers.Observe(time.Since(start).Seconds()) }()
-	members, err := pdpb.NewPDClient(cc).GetMembers(ctx, &pdpb.GetMembersRequest{})
+	res, err, _ := c.flight.Do("GetMembers", func() (interface{}, error) {
+		return pdpb.NewPDClient(cc).GetMembers(ctx, &pdpb.GetMembersRequest{})
+	})
 	if err != nil {
 		metrics.InternalCmdFailedDurationGetMembers.Observe(time.Since(start).Seconds())
 		attachErr := errors.Errorf("error:%s target:%s status:%s", err, cc.Target(), cc.GetState().String())
 		return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
 	}
+	members := res.(*pdpb.GetMembersResponse)
 	if members.GetHeader().GetError() != nil {
 		metrics.InternalCmdFailedDurationGetMembers.Observe(time.Since(start).Seconds())
 		attachErr := errors.Errorf("error:%s target:%s status:%s", members.GetHeader().GetError().String(), cc.Target(), cc.GetState().String())

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -924,21 +924,29 @@ func (c *serviceDiscovery) getClusterInfo(ctx context.Context, url string, timeo
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetClusterInfo.Observe(time.Since(start).Seconds()) }()
 	key := "GetClusterInfo-" + url
-	res, err, _ := c.flight.Do(key, func() (any, error) {
+	r := c.flight.DoChan(key, func() (any, error) {
 		return pdpb.NewPDClient(cc).GetClusterInfo(ctx, &pdpb.GetClusterInfoRequest{})
 	})
-	if err != nil {
+	select {
+	case res := <-r:
+		err = res.Err
+		if err != nil {
+			metrics.InternalCmdFailedDurationGetClusterInfo.Observe(time.Since(start).Seconds())
+			attachErr := errors.Errorf("error:%s target:%s status:%s", err, cc.Target(), cc.GetState().String())
+			return nil, errs.ErrClientGetClusterInfo.Wrap(attachErr).GenWithStackByCause()
+		}
+		val := res.Val
+		clusterInfo := val.(*pdpb.GetClusterInfoResponse)
+		if clusterInfo.GetHeader().GetError() != nil {
+			metrics.InternalCmdFailedDurationGetClusterInfo.Observe(time.Since(start).Seconds())
+			attachErr := errors.Errorf("error:%s target:%s status:%s", clusterInfo.GetHeader().GetError().String(), cc.Target(), cc.GetState().String())
+			return nil, errs.ErrClientGetClusterInfo.Wrap(attachErr).GenWithStackByCause()
+		}
+		return clusterInfo, nil
+	case <-ctx.Done():
 		metrics.InternalCmdFailedDurationGetClusterInfo.Observe(time.Since(start).Seconds())
-		attachErr := errors.Errorf("error:%s target:%s status:%s", err, cc.Target(), cc.GetState().String())
-		return nil, errs.ErrClientGetClusterInfo.Wrap(attachErr).GenWithStackByCause()
+		return nil, errors.WithStack(ctx.Err())
 	}
-	clusterInfo := res.(*pdpb.GetClusterInfoResponse)
-	if clusterInfo.GetHeader().GetError() != nil {
-		metrics.InternalCmdFailedDurationGetClusterInfo.Observe(time.Since(start).Seconds())
-		attachErr := errors.Errorf("error:%s target:%s status:%s", clusterInfo.GetHeader().GetError().String(), cc.Target(), cc.GetState().String())
-		return nil, errs.ErrClientGetClusterInfo.Wrap(attachErr).GenWithStackByCause()
-	}
-	return clusterInfo, nil
 }
 
 func (c *serviceDiscovery) getMembers(ctx context.Context, url string, timeout time.Duration) (*pdpb.GetMembersResponse, error) {
@@ -951,21 +959,29 @@ func (c *serviceDiscovery) getMembers(ctx context.Context, url string, timeout t
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetMembers.Observe(time.Since(start).Seconds()) }()
 	key := "GetMembers-" + url
-	res, err, _ := c.flight.Do(key, func() (any, error) {
+	r := c.flight.DoChan(key, func() (any, error) {
 		return pdpb.NewPDClient(cc).GetMembers(ctx, &pdpb.GetMembersRequest{})
 	})
-	if err != nil {
+	select {
+	case res := <-r:
+		err = res.Err
+		if err != nil {
+			metrics.InternalCmdFailedDurationGetMembers.Observe(time.Since(start).Seconds())
+			attachErr := errors.Errorf("error:%s target:%s status:%s", err, cc.Target(), cc.GetState().String())
+			return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
+		}
+		val := res.Val
+		members := val.(*pdpb.GetMembersResponse)
+		if members.GetHeader().GetError() != nil {
+			metrics.InternalCmdFailedDurationGetMembers.Observe(time.Since(start).Seconds())
+			attachErr := errors.Errorf("error:%s target:%s status:%s", members.GetHeader().GetError().String(), cc.Target(), cc.GetState().String())
+			return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
+		}
+		return members, nil
+	case <-ctx.Done():
 		metrics.InternalCmdFailedDurationGetMembers.Observe(time.Since(start).Seconds())
-		attachErr := errors.Errorf("error:%s target:%s status:%s", err, cc.Target(), cc.GetState().String())
-		return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
+		return nil, errors.WithStack(ctx.Err())
 	}
-	members := res.(*pdpb.GetMembersResponse)
-	if members.GetHeader().GetError() != nil {
-		metrics.InternalCmdFailedDurationGetMembers.Observe(time.Since(start).Seconds())
-		attachErr := errors.Errorf("error:%s target:%s status:%s", members.GetHeader().GetError().String(), cc.Target(), cc.GetState().String())
-		return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
-	}
-	return members, nil
 }
 
 func (c *serviceDiscovery) updateURLs(members []*pdpb.Member) {

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -944,8 +944,9 @@ func (c *serviceDiscovery) getClusterInfo(ctx context.Context, url string, timeo
 		}
 		return clusterInfo, nil
 	case <-ctx.Done():
+		attachErr := errors.Errorf("error:%s target:%s status:%s", ctx.Err(), cc.Target(), cc.GetState().String())
 		metrics.InternalCmdFailedDurationGetClusterInfo.Observe(time.Since(start).Seconds())
-		return nil, errors.WithStack(ctx.Err())
+		return nil, errs.ErrClientGetClusterInfo.Wrap(attachErr).GenWithStackByCause()
 	}
 }
 
@@ -979,8 +980,9 @@ func (c *serviceDiscovery) getMembers(ctx context.Context, url string, timeout t
 		}
 		return members, nil
 	case <-ctx.Done():
+		attachErr := errors.Errorf("error:%s target:%s status:%s", ctx.Err(), cc.Target(), cc.GetState().String())
 		metrics.InternalCmdFailedDurationGetMembers.Observe(time.Since(start).Seconds())
-		return nil, errors.WithStack(ctx.Err())
+		return nil, errs.ErrClientGetMember.Wrap(attachErr).GenWithStackByCause()
 	}
 }
 

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -923,7 +923,7 @@ func (c *serviceDiscovery) getClusterInfo(ctx context.Context, url string, timeo
 	}
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetClusterInfo.Observe(time.Since(start).Seconds()) }()
-	res, err, _ := c.flight.Do("GetClusterInfo", func() (interface{}, error) {
+	res, err, _ := c.flight.Do("GetClusterInfo", func() (any, error) {
 		return pdpb.NewPDClient(cc).GetClusterInfo(ctx, &pdpb.GetClusterInfoRequest{})
 	})
 	if err != nil {
@@ -949,7 +949,7 @@ func (c *serviceDiscovery) getMembers(ctx context.Context, url string, timeout t
 	}
 	start := time.Now()
 	defer func() { metrics.InternalCmdDurationGetMembers.Observe(time.Since(start).Seconds()) }()
-	res, err, _ := c.flight.Do("GetMembers", func() (interface{}, error) {
+	res, err, _ := c.flight.Do("GetMembers", func() (any, error) {
 		return pdpb.NewPDClient(cc).GetMembers(ctx, &pdpb.GetMembersRequest{})
 	})
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10633

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate backend requests by coalescing concurrent calls, improving responsiveness and stability under high concurrency and lowering load on remote services.

* **Chores**
  * Updated a client dependency to a newer sync library version to maintain compatibility and improve long-term reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->