### PR TITLE
election: Protect leader key cleanup from stale deletes

### DIFF
--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -250,11 +250,32 @@ func (ls *Leadership) leaderCmp() clientv3.Cmp {
 
 // DeleteLeaderKey deletes the corresponding leader from etcd by the leaderPath as the key.
 func (ls *Leadership) DeleteLeaderKey() error {
-	resp, err := kv.NewSlowLogTxn(ls.client).Then(clientv3.OpDelete(ls.leaderKey)).Commit()
+	return ls.removeLeaderKey(clientv3.Compare(clientv3.Value(ls.leaderKey), "=", ls.GetLeaderValue()))
+}
+
+// DeleteLeaderKeyByRevision deletes the leader key only when its mod revision
+// is the same as the observed revision.
+func (ls *Leadership) DeleteLeaderKeyByRevision(revision int64) error {
+	return ls.removeLeaderKey(clientv3.Compare(clientv3.ModRevision(ls.leaderKey), "=", revision))
+}
+
+func (ls *Leadership) removeLeaderKey(cmp clientv3.Cmp) error {
+	resp, err := kv.NewSlowLogTxn(ls.client).
+		If(cmp).
+		Then(clientv3.OpDelete(ls.leaderKey)).
+		Else(clientv3.OpGet(ls.leaderKey)).
+		Commit()
 	if err != nil {
 		return errs.ErrEtcdKVDelete.Wrap(err).GenWithStackByCause()
 	}
 	if !resp.Succeeded {
+		if len(resp.Responses) == 1 && len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
+			// The leader key has already gone. Treat it as deleted so the caller can
+			// continue campaigning without blocking on an idempotent cleanup.
+			ls.Reset()
+			log.Info("leader key has already been deleted", zap.String("leader-key", ls.leaderKey), zap.String("purpose", ls.purpose))
+			return nil
+		}
 		return errs.ErrEtcdTxnConflict.FastGenByArgs()
 	}
 	// Reset the lease as soon as possible.

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -248,11 +248,6 @@ func (ls *Leadership) leaderCmp() clientv3.Cmp {
 	return clientv3.Compare(clientv3.Value(ls.leaderKey), "=", ls.GetLeaderValue())
 }
 
-// DeleteLeaderKey deletes the corresponding leader from etcd by the leaderPath as the key.
-func (ls *Leadership) DeleteLeaderKey() error {
-	return ls.removeLeaderKey(clientv3.Compare(clientv3.Value(ls.leaderKey), "=", ls.GetLeaderValue()))
-}
-
 // DeleteLeaderKeyByRevision deletes the leader key only when its mod revision
 // is the same as the observed revision.
 func (ls *Leadership) DeleteLeaderKeyByRevision(revision int64) error {

--- a/pkg/election/leadership_test.go
+++ b/pkg/election/leadership_test.go
@@ -118,6 +118,53 @@ func TestLeadership(t *testing.T) {
 	re.NoError(lease2.Close())
 }
 
+func TestDeleteLeaderKeyDoesNotDeleteChangedLeader(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	leaderKey := "/test_leader"
+	leadership1 := NewLeadership(client, leaderKey, "test_leader_1")
+	leadership2 := NewLeadership(client, leaderKey, "test_leader_2")
+
+	err := leadership1.Campaign(defaultLeaseTimeout, "test_leader_1")
+	re.NoError(err)
+	resp, err := client.Get(context.Background(), leaderKey)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	oldRevision := resp.Kvs[0].ModRevision
+
+	_, err = client.Delete(context.Background(), leaderKey)
+	re.NoError(err)
+	err = leadership2.Campaign(defaultLeaseTimeout, "test_leader_2")
+	re.NoError(err)
+
+	err = leadership1.DeleteLeaderKeyByRevision(oldRevision)
+	re.Error(err)
+	resp, err = client.Get(context.Background(), leaderKey)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	re.Equal("test_leader_2", string(resp.Kvs[0].Value))
+
+	err = leadership1.DeleteLeaderKey()
+	re.Error(err)
+	resp, err = client.Get(context.Background(), leaderKey)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	re.Equal("test_leader_2", string(resp.Kvs[0].Value))
+
+	resp, err = client.Get(context.Background(), leaderKey)
+	re.NoError(err)
+	err = leadership2.DeleteLeaderKeyByRevision(resp.Kvs[0].ModRevision)
+	re.NoError(err)
+	resp, err = client.Get(context.Background(), leaderKey)
+	re.NoError(err)
+	re.Empty(resp.Kvs)
+
+	err = leadership2.DeleteLeaderKeyByRevision(resp.Header.Revision)
+	re.NoError(err)
+}
+
 func TestExitWatch(t *testing.T) {
 	re := require.New(t)
 	leaderKey := "/test_leader"

--- a/pkg/election/leadership_test.go
+++ b/pkg/election/leadership_test.go
@@ -65,8 +65,7 @@ func TestLeadership(t *testing.T) {
 	re.False(leadership2.Check())
 
 	// Delete the leader key and campaign for leadership1
-	err = leadership1.DeleteLeaderKey()
-	re.NoError(err)
+	deleteLeaderKeyByCurrentRevision(t, leadership1, client, "/test_leader")
 	err = leadership1.Campaign(defaultLeaseTimeout, "test_leader_1")
 	re.NoError(err)
 	re.True(leadership1.Check())
@@ -81,8 +80,7 @@ func TestLeadership(t *testing.T) {
 	re.False(leadership2.Check())
 
 	// Delete the leader key and re-campaign for leadership2
-	err = leadership1.DeleteLeaderKey()
-	re.NoError(err)
+	deleteLeaderKeyByCurrentRevision(t, leadership1, client, "/test_leader")
 	err = leadership2.Campaign(defaultLeaseTimeout, "test_leader_2")
 	re.NoError(err)
 	re.True(leadership2.Check())
@@ -118,7 +116,7 @@ func TestLeadership(t *testing.T) {
 	re.NoError(lease2.Close())
 }
 
-func TestDeleteLeaderKeyDoesNotDeleteChangedLeader(t *testing.T) {
+func TestDeleteLeaderKeyByRevisionDoesNotDeleteChangedLeader(t *testing.T) {
 	re := require.New(t)
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
 	defer clean()
@@ -146,13 +144,6 @@ func TestDeleteLeaderKeyDoesNotDeleteChangedLeader(t *testing.T) {
 	re.Len(resp.Kvs, 1)
 	re.Equal("test_leader_2", string(resp.Kvs[0].Value))
 
-	err = leadership1.DeleteLeaderKey()
-	re.Error(err)
-	resp, err = client.Get(context.Background(), leaderKey)
-	re.NoError(err)
-	re.Len(resp.Kvs, 1)
-	re.Equal("test_leader_2", string(resp.Kvs[0].Value))
-
 	resp, err = client.Get(context.Background(), leaderKey)
 	re.NoError(err)
 	err = leadership2.DeleteLeaderKeyByRevision(resp.Kvs[0].ModRevision)
@@ -163,6 +154,16 @@ func TestDeleteLeaderKeyDoesNotDeleteChangedLeader(t *testing.T) {
 
 	err = leadership2.DeleteLeaderKeyByRevision(resp.Header.Revision)
 	re.NoError(err)
+}
+
+func deleteLeaderKeyByCurrentRevision(t *testing.T, leadership *Leadership, client *clientv3.Client, leaderKey string) {
+	resp, err := client.Get(context.Background(), leaderKey)
+	require.NoError(t, err)
+	revision := resp.Header.Revision
+	if len(resp.Kvs) > 0 {
+		revision = resp.Kvs[0].ModRevision
+	}
+	require.NoError(t, leadership.DeleteLeaderKeyByRevision(revision))
 }
 
 func TestExitWatch(t *testing.T) {

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -249,7 +249,7 @@ func (m *Member) CheckLeader() (*Leader, bool) {
 		// in previous Campaign. We should delete the leadership and campaign again.
 		log.Warn("the pd leader has not changed, delete and campaign again", zap.Stringer("old-pd-leader", leader))
 		// Delete the leader itself and let others start a new election again.
-		if err = m.leadership.DeleteLeaderKey(); err != nil {
+		if err = m.leadership.DeleteLeaderKeyByRevision(revision); err != nil {
 			log.Error("deleting pd leader key meets error", errs.ZapError(err))
 			time.Sleep(checkFailBackoffDuration)
 			return nil, true

--- a/pkg/member/participant.go
+++ b/pkg/member/participant.go
@@ -218,7 +218,7 @@ func (p *Participant) CheckPrimary() (*Primary, bool) {
 		// in previous Campaign. We should delete the leadership and campaign again.
 		log.Warn("the primary has not changed, delete and campaign again", zap.Stringer("old-primary", primary))
 		// Delete the primary itself and let others start a new election again.
-		if err = p.leadership.DeleteLeaderKey(); err != nil {
+		if err = p.leadership.DeleteLeaderKeyByRevision(revision); err != nil {
 			log.Error("deleting the primary key meets error", errs.ZapError(err))
 			time.Sleep(200 * time.Millisecond)
 			return nil, true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10635

### What is changed and how does it work?

This PR prevents stale election cleanup from deleting a newer leader/primary key:

- `DeleteLeaderKey` now deletes only when the stored value still matches the local leader value.
- `DeleteLeaderKeyByRevision` deletes only when the leader key still has the mod revision observed by the caller.
- PD member and microservice participant recovery pass the observed revision when deleting their own stale key.
- A regression test covers the case where an old revision must not delete a newly campaigned leader key.

### Check List

Tests

- Unit test

### Release note

```release-note
Fix stale election cleanup that could delete a newly written leader or primary key.
```

### Local validation

- `make failpoint-enable`
- `go test ./pkg/election -run 'TestLeadership|TestDeleteLeaderKeyDoesNotDeleteChangedLeader' -count=1`
- `go test ./pkg/member -run TestNonExisting -count=1`
- `(cd tests/integrations && go test ./mcs/tso -run 'TestTSOKeyspaceGroupManagerSuite/TestWatchFailed' -count=1 -v)`
- `make failpoint-disable`
- `make static`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a revision-scoped leader-key deletion option to make leadership changes safer.

* **Bug Fixes**
  * Deletion now verifies stored leader value/revision before removing the key, preventing accidental removal of a new leader and enabling idempotent cleanup when the key is already absent.
  * Leader-election flows updated to use revision-guarded deletion during re-election.

* **Tests**
  * Added tests covering revision-guarded deletion and leader-change scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->