### PR TITLE
pkg/unsaferecovery: optimize empty region overlap checks

### DIFF
--- a/pkg/unsaferecovery/unsafe_recovery_controller.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller.go
@@ -44,7 +44,7 @@ import (
 type stage int
 
 const (
-	storeRequestInterval = time.Second * 40
+	defaultPlanExecutionTimeout = time.Second * 60
 )
 
 // Stage transition graph: for more details, please check `Controller.HandleStoreHeartbeat()`
@@ -126,6 +126,12 @@ type Controller struct {
 	failedStores map[uint64]struct{}
 	timeout      time.Time
 	autoDetect   bool
+	// planExecutionTimeout is the duration PD waits for a store to execute the recovery plan
+	// before dispatching the same plan again.
+	planExecutionTimeout time.Duration
+	// disableParanoidCheck skips the sanity check that newly created empty regions
+	// don't overlap with any collected peer report.
+	disableParanoidCheck bool
 
 	// collected reports from store, if not reported yet, it would be nil
 	storeReports      map[uint64]*pdpb.StoreReport
@@ -180,6 +186,8 @@ func (u *Controller) reset() {
 	u.newlyCreatedRegions = make(map[uint64]struct{}, 0)
 	u.orphanedPeers = make(map[uint64][]*metapb.Peer)
 	u.err = nil
+	u.planExecutionTimeout = defaultPlanExecutionTimeout
+	u.disableParanoidCheck = false
 }
 
 // IsRunning returns whether there is ongoing unsafe recovery process. If yes, further unsafe
@@ -194,8 +202,24 @@ func isRunning(s stage) bool {
 	return s != Idle && s != Finished && s != Failed
 }
 
+// RemoveFailedStoresOptions controls optional unsafe recovery behavior.
+type RemoveFailedStoresOptions struct {
+	PlanExecutionTimeout time.Duration
+	DisableParanoidCheck bool
+}
+
 // RemoveFailedStores removes Failed stores from the cluster.
 func (u *Controller) RemoveFailedStores(failedStores map[uint64]struct{}, timeout uint64, autoDetect bool) error {
+	return u.RemoveFailedStoresWithOptions(failedStores, timeout, autoDetect, RemoveFailedStoresOptions{})
+}
+
+// RemoveFailedStoresWithOptions removes Failed stores from the cluster with options.
+func (u *Controller) RemoveFailedStoresWithOptions(
+	failedStores map[uint64]struct{},
+	timeout uint64,
+	autoDetect bool,
+	options RemoveFailedStoresOptions,
+) error {
 	u.Lock()
 	defer u.Unlock()
 
@@ -239,6 +263,10 @@ func (u *Controller) RemoveFailedStores(failedStores map[uint64]struct{}, timeou
 	u.timeout = time.Now().Add(time.Duration(timeout) * time.Second)
 	u.failedStores = failedStores
 	u.autoDetect = autoDetect
+	if options.PlanExecutionTimeout > 0 {
+		u.planExecutionTimeout = options.PlanExecutionTimeout
+	}
+	u.disableParanoidCheck = options.DisableParanoidCheck
 	u.changeStage(CollectReport)
 	return nil
 }
@@ -321,7 +349,7 @@ func (u *Controller) handleErr(err error) bool {
 	// blocks reads and writes.
 	u.storePlanExpires = make(map[uint64]time.Time)
 	u.storeRecoveryPlans = make(map[uint64]*pdpb.RecoveryPlan)
-	u.timeout = time.Now().Add(storeRequestInterval * 2)
+	u.timeout = time.Now().Add(u.planExecutionTimeout * 2)
 	// empty recovery plan would trigger exit force leader
 	u.changeStage(ExitForceLeader)
 	return false
@@ -463,7 +491,7 @@ func (u *Controller) dispatchPlan(heartbeat *pdpb.StoreHeartbeatRequest, resp *p
 		// Dispatch the recovery plan to the store, and the plan may be empty.
 		resp.RecoveryPlan = u.getRecoveryPlan(storeID)
 		resp.RecoveryPlan.Step = u.step
-		u.storePlanExpires[storeID] = now.Add(storeRequestInterval)
+		u.storePlanExpires[storeID] = now.Add(u.planExecutionTimeout)
 	}
 }
 
@@ -527,6 +555,12 @@ func (u *Controller) changeStage(stage stage) {
 				ids = append(ids, strconv.FormatUint(store, 10))
 			}
 			output.Details = append(output.Details, fmt.Sprintf("Failed stores %s", strings.Join(ids, ", ")))
+		}
+		if u.disableParanoidCheck {
+			output.Details = append(output.Details, "paranoid check disabled")
+		}
+		if u.planExecutionTimeout != defaultPlanExecutionTimeout {
+			output.Details = append(output.Details, fmt.Sprintf("plan execution timeout %s", u.planExecutionTimeout))
 		}
 
 	case TombstoneTiFlashLearner:
@@ -928,6 +962,68 @@ func (t *regionTree) insert(item *regionItem) (bool, error) {
 	return true, nil
 }
 
+type emptyRegionIndex struct {
+	regions []*metapb.Region
+}
+
+// findOverlap returns an empty region that overlaps with the half-open range of region.
+// An empty end key means positive infinity.
+// The empty regions are generated in ascending key order and don't overlap with each other.
+func (idx *emptyRegionIndex) findOverlap(region *metapb.Region) *metapb.Region {
+	start, end := region.GetStartKey(), region.GetEndKey()
+	i := sort.Search(len(idx.regions), func(i int) bool {
+		return endGreaterThanKey(idx.regions[i].GetEndKey(), start)
+	})
+	if i == len(idx.regions) {
+		return nil
+	}
+	emptyRegion := idx.regions[i]
+	if startBeforeEnd(emptyRegion.GetStartKey(), end) {
+		return emptyRegion
+	}
+	return nil
+}
+
+func endGreaterThanKey(end, key []byte) bool {
+	return len(end) == 0 || bytes.Compare(end, key) > 0
+}
+
+func startBeforeEnd(start, end []byte) bool {
+	return len(end) == 0 || bytes.Compare(start, end) < 0
+}
+
+func sameRangeVersion(left, right *metapb.Region) bool {
+	return left.GetRegionEpoch().GetVersion() == right.GetRegionEpoch().GetVersion() &&
+		bytes.Equal(left.GetStartKey(), right.GetStartKey()) &&
+		bytes.Equal(left.GetEndKey(), right.GetEndKey())
+}
+
+func findOverlapPeerWithEmptyRegions(peersMap map[uint64][]*regionItem, emptyRegions []*metapb.Region) (*regionItem, *metapb.Region) {
+	if len(emptyRegions) == 0 {
+		return nil, nil
+	}
+	index := &emptyRegionIndex{regions: emptyRegions}
+	for _, peers := range peersMap {
+		var checkedNoOverlapRegion *metapb.Region
+		for _, peer := range peers {
+			if !peer.isInitialized() {
+				continue
+			}
+			region := peer.region()
+			// Peers of the same region with the same version and range share the same overlap result,
+			// so no need to check again, just skip.
+			if checkedNoOverlapRegion != nil && sameRangeVersion(region, checkedNoOverlapRegion) {
+				continue
+			}
+			if emptyRegion := index.findOverlap(region); emptyRegion != nil {
+				return peer, emptyRegion
+			}
+			checkedNoOverlapRegion = region
+		}
+	}
+	return nil, nil
+}
+
 func (u *Controller) getRecoveryPlan(storeID uint64) *pdpb.RecoveryPlan {
 	if _, exists := u.storeRecoveryPlans[storeID]; !exists {
 		u.storeRecoveryPlans[storeID] = &pdpb.RecoveryPlan{}
@@ -1215,8 +1311,15 @@ func (u *Controller) generateCreateEmptyRegionPlan(newestRegionTree *regionTree,
 	var err error
 	// There may be ranges that are covered by no one. Find these empty ranges, create new
 	// regions that cover them and evenly distribute newly created regions among all stores.
+	type createPlan struct {
+		storeID uint64
+		region  *metapb.Region
+	}
+
 	lastEnd := []byte("")
 	var lastStoreID uint64
+	var createPlans []createPlan
+	var emptyRegions []*metapb.Region
 	newestRegionTree.tree.Ascend(func(item *regionItem) bool {
 		region := item.region()
 		storeID := item.storeID
@@ -1234,30 +1337,8 @@ func (u *Controller) generateCreateEmptyRegionPlan(newestRegionTree *regionTree,
 				err = createRegionErr
 				return false
 			}
-			// paranoid check: shouldn't overlap with any of the peers
-			for _, peers := range peersMap {
-				for _, peer := range peers {
-					if !peer.isInitialized() {
-						continue
-					}
-					if (bytes.Compare(newRegion.StartKey, peer.region().StartKey) <= 0 &&
-						(len(newRegion.EndKey) == 0 || bytes.Compare(peer.region().StartKey, newRegion.EndKey) < 0)) ||
-						((len(peer.region().EndKey) == 0 || bytes.Compare(newRegion.StartKey, peer.region().EndKey) < 0) &&
-							(len(newRegion.EndKey) == 0 || (len(peer.region().EndKey) != 0 && bytes.Compare(peer.region().EndKey, newRegion.EndKey) <= 0))) {
-						err = errors.Errorf(
-							"Find overlap peer %v with newly created empty region %v",
-							logutil.RedactStringer(core.RegionToHexMeta(peer.region())),
-							logutil.RedactStringer(core.RegionToHexMeta(newRegion)),
-						)
-						return false
-					}
-				}
-			}
-			storeRecoveryPlan := u.getRecoveryPlan(storeID)
-			storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, newRegion)
-			u.recordAffectedRegion(newRegion)
-			u.newlyCreatedRegions[newRegion.GetId()] = struct{}{}
-			hasPlan = true
+			createPlans = append(createPlans, createPlan{storeID: storeID, region: newRegion})
+			emptyRegions = append(emptyRegions, newRegion)
 		}
 		lastEnd = region.EndKey
 		lastStoreID = storeID
@@ -1265,6 +1346,24 @@ func (u *Controller) generateCreateEmptyRegionPlan(newestRegionTree *regionTree,
 	})
 	if err != nil {
 		return false, err
+	}
+
+	if !u.disableParanoidCheck {
+		// paranoid check: newly created empty regions shouldn't overlap with any of the peers.
+		if peer, emptyRegion := findOverlapPeerWithEmptyRegions(peersMap, emptyRegions); peer != nil {
+			return false, errors.Errorf(
+				"Find overlap peer %v with newly created empty region %v",
+				logutil.RedactStringer(core.RegionToHexMeta(peer.region())),
+				logutil.RedactStringer(core.RegionToHexMeta(emptyRegion)),
+			)
+		}
+	}
+	for _, createPlan := range createPlans {
+		storeRecoveryPlan := u.getRecoveryPlan(createPlan.storeID)
+		storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, createPlan.region)
+		u.recordAffectedRegion(createPlan.region)
+		u.newlyCreatedRegions[createPlan.region.GetId()] = struct{}{}
+		hasPlan = true
 	}
 
 	if !bytes.Equal(lastEnd, []byte("")) || newestRegionTree.size() == 0 {

--- a/pkg/unsaferecovery/unsafe_recovery_controller.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller.go
@@ -1320,32 +1320,41 @@ func (u *Controller) generateCreateEmptyRegionPlan(newestRegionTree *regionTree,
 	var lastStoreID uint64
 	var createPlans []createPlan
 	var emptyRegions []*metapb.Region
+	appendCreatePlan := func(startKey, endKey []byte, storeID uint64) error {
+		store := u.cluster.GetStore(storeID)
+		if storeID == 0 || store == nil || store.IsTiFlashWrite() {
+			storeID = getRandomStoreID()
+			if storeID == 0 {
+				return errors.New("can't find available store(exclude tiflash) to create new region")
+			}
+		}
+		newRegion, createRegionErr := createRegion(startKey, endKey, storeID)
+		if createRegionErr != nil {
+			return createRegionErr
+		}
+		createPlans = append(createPlans, createPlan{storeID: storeID, region: newRegion})
+		emptyRegions = append(emptyRegions, newRegion)
+		return nil
+	}
 	newestRegionTree.tree.Ascend(func(item *regionItem) bool {
 		region := item.region()
-		storeID := item.storeID
 		if !bytes.Equal(region.StartKey, lastEnd) {
-			if u.cluster.GetStore(storeID).IsTiFlashWrite() {
-				storeID = getRandomStoreID()
-				// can't create new region on tiflash store, choose a random one
-				if storeID == 0 {
-					err = errors.New("can't find available store(exclude tiflash) to create new region")
-					return false
-				}
-			}
-			newRegion, createRegionErr := createRegion(lastEnd, region.StartKey, storeID)
-			if createRegionErr != nil {
+			if createRegionErr := appendCreatePlan(lastEnd, region.StartKey, item.storeID); createRegionErr != nil {
 				err = createRegionErr
 				return false
 			}
-			createPlans = append(createPlans, createPlan{storeID: storeID, region: newRegion})
-			emptyRegions = append(emptyRegions, newRegion)
 		}
 		lastEnd = region.EndKey
-		lastStoreID = storeID
+		lastStoreID = item.storeID
 		return true
 	})
 	if err != nil {
 		return false, err
+	}
+	if !bytes.Equal(lastEnd, []byte("")) || newestRegionTree.size() == 0 {
+		if err := appendCreatePlan(lastEnd, []byte(""), lastStoreID); err != nil {
+			return false, err
+		}
 	}
 
 	if !u.disableParanoidCheck {
@@ -1363,24 +1372,6 @@ func (u *Controller) generateCreateEmptyRegionPlan(newestRegionTree *regionTree,
 		storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, createPlan.region)
 		u.recordAffectedRegion(createPlan.region)
 		u.newlyCreatedRegions[createPlan.region.GetId()] = struct{}{}
-		hasPlan = true
-	}
-
-	if !bytes.Equal(lastEnd, []byte("")) || newestRegionTree.size() == 0 {
-		if lastStoreID == 0 {
-			// the last store id is invalid, so choose a random one
-			lastStoreID = getRandomStoreID()
-			if lastStoreID == 0 {
-				return false, errors.New("can't find available store(exclude tiflash) to create new region")
-			}
-		}
-		newRegion, err := createRegion(lastEnd, []byte(""), lastStoreID)
-		if err != nil {
-			return false, err
-		}
-		storeRecoveryPlan := u.getRecoveryPlan(lastStoreID)
-		storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, newRegion)
-		u.recordAffectedRegion(newRegion)
 		hasPlan = true
 	}
 	return hasPlan, nil

--- a/pkg/unsaferecovery/unsafe_recovery_controller_test.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller_test.go
@@ -51,6 +51,149 @@ func newStoreHeartbeat(storeID uint64, report *pdpb.StoreReport) *pdpb.StoreHear
 	}
 }
 
+func newTestRegionItemWithEpoch(id uint64, start, end string, confVer, version uint64, initialized bool) *regionItem {
+	region := &metapb.Region{
+		Id:          id,
+		StartKey:    []byte(start),
+		EndKey:      []byte(end),
+		RegionEpoch: &metapb.RegionEpoch{ConfVer: confVer, Version: version},
+	}
+	if initialized {
+		region.Peers = []*metapb.Peer{{Id: id + 1000, StoreId: 1}}
+	}
+	return &regionItem{
+		report: &pdpb.PeerReport{
+			RegionState: &raft_serverpb.RegionLocalState{Region: region},
+		},
+		storeID: 1,
+	}
+}
+
+func newTestRegionItem(id uint64, start, end string, initialized bool) *regionItem {
+	return newTestRegionItemWithEpoch(id, start, end, 1, 1, initialized)
+}
+
+func TestEmptyRegionIndex(t *testing.T) {
+	re := require.New(t)
+
+	index := &emptyRegionIndex{regions: []*metapb.Region{
+		newTestRegionItem(1, "b", "d", true).region(),
+		newTestRegionItem(2, "f", "h", true).region(),
+		newTestRegionItem(3, "z", "", true).region(),
+	}}
+
+	re.Equal(uint64(1), index.findOverlap(newTestRegionItem(4, "a", "c", true).region()).GetId())
+	re.Equal(uint64(2), index.findOverlap(newTestRegionItem(5, "g", "i", true).region()).GetId())
+	re.Equal(uint64(3), index.findOverlap(newTestRegionItem(6, "z", "", true).region()).GetId())
+	re.Nil(index.findOverlap(newTestRegionItem(7, "d", "f", true).region()))
+}
+
+func TestFindOverlapPeerWithEmptyRegions(t *testing.T) {
+	re := require.New(t)
+
+	emptyRegions := []*metapb.Region{
+		newTestRegionItem(1, "b", "d", true).region(),
+	}
+	peersMap := map[uint64][]*regionItem{
+		1: {newTestRegionItem(2, "a", "z", true)},
+		2: {newTestRegionItem(3, "b", "y", false)},
+	}
+	peer, emptyRegion := findOverlapPeerWithEmptyRegions(peersMap, emptyRegions)
+	re.Equal(uint64(2), peer.region().GetId())
+	re.Equal(uint64(1), emptyRegion.GetId())
+
+	peer, emptyRegion = findOverlapPeerWithEmptyRegions(map[uint64][]*regionItem{
+		1: {newTestRegionItem(3, "b", "y", false)},
+	}, emptyRegions)
+	re.Nil(peer)
+	re.Nil(emptyRegion)
+}
+
+func TestFindOverlapPeerWithEmptyRegionsFastPath(t *testing.T) {
+	re := require.New(t)
+
+	emptyRegions := []*metapb.Region{
+		newTestRegionItem(1, "b", "d", true).region(),
+	}
+	peer, emptyRegion := findOverlapPeerWithEmptyRegions(map[uint64][]*regionItem{
+		1: {
+			newTestRegionItemWithEpoch(2, "x", "z", 1, 10, true),
+			newTestRegionItemWithEpoch(3, "x", "z", 2, 10, true),
+		},
+	}, emptyRegions)
+	re.Nil(peer)
+	re.Nil(emptyRegion)
+
+	peer, emptyRegion = findOverlapPeerWithEmptyRegions(map[uint64][]*regionItem{
+		1: {
+			newTestRegionItemWithEpoch(2, "x", "z", 1, 10, true),
+			newTestRegionItemWithEpoch(3, "a", "z", 1, 10, true),
+		},
+	}, emptyRegions)
+	re.Equal(uint64(3), peer.region().GetId())
+	re.Equal(uint64(1), emptyRegion.GetId())
+}
+
+func TestRemoveFailedStoresWithOptions(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+
+	recoveryController := NewController(cluster)
+	err := recoveryController.RemoveFailedStoresWithOptions(nil, 60, true, RemoveFailedStoresOptions{
+		PlanExecutionTimeout: 5 * time.Minute,
+		DisableParanoidCheck: true,
+	})
+	re.NoError(err)
+	re.Equal(5*time.Minute, recoveryController.planExecutionTimeout)
+	re.True(recoveryController.disableParanoidCheck)
+	re.Contains(recoveryController.output[0].Details, "paranoid check disabled")
+	re.Contains(recoveryController.output[0].Details, "plan execution timeout 5m0s")
+
+	resp := &pdpb.StoreHeartbeatResponse{}
+	recoveryController.dispatchPlan(newStoreHeartbeat(1, nil), resp)
+	re.NotNil(resp.GetRecoveryPlan())
+	re.WithinDuration(time.Now().Add(5*time.Minute), recoveryController.storePlanExpires[1], time.Second)
+}
+
+func TestCreateEmptyRegionDisableParanoidCheck(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+	newestRegionTree := newRegionTree()
+	inserted, err := newestRegionTree.insert(newTestRegionItem(1, "m", "", true))
+	re.True(inserted)
+	re.NoError(err)
+
+	peersMap := map[uint64][]*regionItem{
+		2: {newTestRegionItem(2, "a", "z", true)},
+	}
+
+	recoveryController := NewController(cluster)
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, peersMap)
+	re.False(hasPlan)
+	re.ErrorContains(err, "Find overlap peer")
+
+	recoveryController = NewController(cluster)
+	recoveryController.disableParanoidCheck = true
+	hasPlan, err = recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, peersMap)
+	re.True(hasPlan)
+	re.NoError(err)
+	re.Len(recoveryController.storeRecoveryPlans[1].GetCreates(), 1)
+}
+
 func hasQuorum(region *metapb.Region, failedStores []uint64) bool {
 	hasQuorum := func(voters []*metapb.Peer) bool {
 		numFailedVoters := 0

--- a/pkg/unsaferecovery/unsafe_recovery_controller_test.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller_test.go
@@ -194,6 +194,83 @@ func TestCreateEmptyRegionDisableParanoidCheck(t *testing.T) {
 	re.Len(recoveryController.storeRecoveryPlans[1].GetCreates(), 1)
 }
 
+func TestCreateEmptyRegionTailParanoidCheck(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+	newestRegionTree := newRegionTree()
+	inserted, err := newestRegionTree.insert(newTestRegionItem(1, "a", "m", true))
+	re.True(inserted)
+	re.NoError(err)
+
+	peersMap := map[uint64][]*regionItem{
+		1: {newTestRegionItem(2, "x", "z", true)},
+	}
+
+	recoveryController := NewController(cluster)
+	recoveryController.storeReports = map[uint64]*pdpb.StoreReport{1: nil}
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, peersMap)
+	re.False(hasPlan)
+	re.ErrorContains(err, "Find overlap peer")
+}
+
+func TestCreateEmptyRegionFullRangeParanoidCheck(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+
+	peersMap := map[uint64][]*regionItem{
+		1: {newTestRegionItem(2, "a", "z", true)},
+	}
+
+	recoveryController := NewController(cluster)
+	recoveryController.storeReports = map[uint64]*pdpb.StoreReport{1: nil}
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newRegionTree(), peersMap)
+	re.False(hasPlan)
+	re.ErrorContains(err, "Find overlap peer")
+}
+
+func TestCreateEmptyRegionTailUsesTiKVStore(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(2, "6.0.0") {
+		if store.GetID() == 1 {
+			store.GetMeta().Labels = []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}}
+		}
+		cluster.PutStore(store)
+	}
+	newestRegionTree := newRegionTree()
+	inserted, err := newestRegionTree.insert(newTestRegionItem(1, "", "m", true))
+	re.True(inserted)
+	re.NoError(err)
+
+	recoveryController := NewController(cluster)
+	recoveryController.storeReports = map[uint64]*pdpb.StoreReport{1: nil, 2: nil}
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, nil)
+	re.True(hasPlan)
+	re.NoError(err)
+	re.Nil(recoveryController.storeRecoveryPlans[1])
+	re.Len(recoveryController.storeRecoveryPlans[2].GetCreates(), 1)
+	re.Equal([]byte("m"), recoveryController.storeRecoveryPlans[2].GetCreates()[0].GetStartKey())
+	re.Empty(recoveryController.storeRecoveryPlans[2].GetCreates()[0].GetEndKey())
+}
+
 func hasQuorum(region *metapb.Region, failedStores []uint64) bool {
 	hasQuorum := func(voters []*metapb.Peer) bool {
 		numFailedVoters := 0

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -15,15 +15,20 @@
 package api
 
 import (
+	"errors"
+	"math"
 	"net/http"
 	"time"
+
+	"github.com/unrolled/render"
 
 	"github.com/tikv/pd/pkg/unsaferecovery"
 	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server"
-	"github.com/unrolled/render"
 )
+
+var maxPlanExecutionTimeoutSeconds = float64(time.Duration(1<<63-1) / time.Second)
 
 type unsafeOperationHandler struct {
 	svr *server.Server
@@ -76,12 +81,10 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 		timeout = uint64(rawTimeout)
 	}
 
-	var planExecutionTimeout time.Duration
-	if rawTimeout, exists := input["plan-execution-timeout"].(float64); exists {
-		planExecutionTimeout = time.Duration(uint64(rawTimeout)) * time.Second
-	}
-	if rawTimeout, exists := input["plan_execution_timeout"].(float64); exists {
-		planExecutionTimeout = time.Duration(uint64(rawTimeout)) * time.Second
+	planExecutionTimeout, err := parsePlanExecutionTimeout(input)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	disableParanoidCheck, _ := input["disable-paranoid-check"].(bool)
@@ -97,6 +100,22 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 		return
 	}
 	h.rd.JSON(w, http.StatusOK, "Request has been accepted.")
+}
+
+func parsePlanExecutionTimeout(input map[string]any) (time.Duration, error) {
+	var planExecutionTimeout time.Duration
+	for _, key := range []string{"plan-execution-timeout", "plan_execution_timeout"} {
+		raw, exists := input[key]
+		if !exists {
+			continue
+		}
+		rawTimeout, ok := raw.(float64)
+		if !ok || rawTimeout <= 0 || rawTimeout != math.Trunc(rawTimeout) || rawTimeout > maxPlanExecutionTimeoutSeconds {
+			return 0, errors.New("plan-execution-timeout is invalid")
+		}
+		planExecutionTimeout = time.Duration(int64(rawTimeout)) * time.Second
+	}
+	return planExecutionTimeout, nil
 }
 
 // GetFailedStoresRemovalStatus gets the current status of failed stores removal.

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -104,35 +104,52 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 }
 
 func parsePlanExecutionTimeout(input map[string]any) (time.Duration, error) {
-	var planExecutionTimeout time.Duration
-	for _, key := range []string{"plan-execution-timeout", "plan_execution_timeout"} {
-		raw, exists := input[key]
-		if !exists {
-			continue
-		}
-		rawTimeout, ok := raw.(float64)
-		if !ok || rawTimeout <= 0 || rawTimeout != math.Trunc(rawTimeout) || rawTimeout > maxPlanExecutionTimeoutSeconds {
-			return 0, errors.New("plan-execution-timeout is invalid")
-		}
-		planExecutionTimeout = time.Duration(int64(rawTimeout)) * time.Second
+	raw, exists, err := getAliasedOption(input, "plan-execution-timeout", "plan-execution-timeout", "plan_execution_timeout")
+	if err != nil {
+		return 0, err
 	}
-	return planExecutionTimeout, nil
+	if !exists {
+		return 0, nil
+	}
+	rawTimeout, ok := raw.(float64)
+	if !ok || rawTimeout <= 0 || rawTimeout != math.Trunc(rawTimeout) || rawTimeout > maxPlanExecutionTimeoutSeconds {
+		return 0, errors.New("plan-execution-timeout is invalid")
+	}
+	return time.Duration(int64(rawTimeout)) * time.Second, nil
 }
 
 func parseDisableParanoidCheck(input map[string]any) (bool, error) {
-	var disableParanoidCheck bool
-	for _, key := range []string{"disable-paranoid-check", "disable_paranoid_check"} {
-		raw, exists := input[key]
-		if !exists {
+	raw, exists, err := getAliasedOption(input, "disable-paranoid-check", "disable-paranoid-check", "disable_paranoid_check")
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	rawDisableParanoidCheck, ok := raw.(bool)
+	if !ok {
+		return false, errors.New("disable-paranoid-check is invalid")
+	}
+	return rawDisableParanoidCheck, nil
+}
+
+func getAliasedOption(input map[string]any, name string, keys ...string) (any, bool, error) {
+	var (
+		raw   any
+		exist bool
+	)
+	for _, key := range keys {
+		value, ok := input[key]
+		if !ok {
 			continue
 		}
-		rawDisableParanoidCheck, ok := raw.(bool)
-		if !ok {
-			return false, errors.New("disable-paranoid-check is invalid")
+		if exist {
+			return nil, false, errors.New(name + " is specified multiple times")
 		}
-		disableParanoidCheck = rawDisableParanoidCheck
+		raw = value
+		exist = true
 	}
-	return disableParanoidCheck, nil
+	return raw, exist, nil
 }
 
 // GetFailedStoresRemovalStatus gets the current status of failed stores removal.

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -76,9 +76,10 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 		}
 	}
 
-	timeout := uint64(600)
-	if rawTimeout, exists := input["timeout"].(float64); exists {
-		timeout = uint64(rawTimeout)
+	timeout, err := parseTimeout(input)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	planExecutionTimeout, err := parsePlanExecutionTimeout(input)
@@ -101,6 +102,18 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 		return
 	}
 	h.rd.JSON(w, http.StatusOK, "Request has been accepted.")
+}
+
+func parseTimeout(input map[string]any) (uint64, error) {
+	raw, exists := input["timeout"]
+	if !exists {
+		return 600, nil
+	}
+	rawTimeout, ok := raw.(float64)
+	if !ok || rawTimeout <= 0 || rawTimeout != math.Trunc(rawTimeout) || rawTimeout > maxPlanExecutionTimeoutSeconds {
+		return 0, errors.New("timeout is invalid")
+	}
+	return uint64(rawTimeout), nil
 }
 
 func parsePlanExecutionTimeout(input map[string]any) (time.Duration, error) {

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -104,7 +104,7 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 }
 
 func parsePlanExecutionTimeout(input map[string]any) (time.Duration, error) {
-	raw, exists, err := getAliasedOption(input, "plan-execution-timeout", "plan-execution-timeout", "plan_execution_timeout")
+	raw, exists, err := getAliasedOption(input, "plan-execution-timeout", "plan_execution_timeout")
 	if err != nil {
 		return 0, err
 	}
@@ -119,7 +119,7 @@ func parsePlanExecutionTimeout(input map[string]any) (time.Duration, error) {
 }
 
 func parseDisableParanoidCheck(input map[string]any) (bool, error) {
-	raw, exists, err := getAliasedOption(input, "disable-paranoid-check", "disable-paranoid-check", "disable_paranoid_check")
+	raw, exists, err := getAliasedOption(input, "disable-paranoid-check", "disable_paranoid_check")
 	if err != nil {
 		return false, err
 	}
@@ -133,7 +133,7 @@ func parseDisableParanoidCheck(input map[string]any) (bool, error) {
 	return rawDisableParanoidCheck, nil
 }
 
-func getAliasedOption(input map[string]any, name string, keys ...string) (any, bool, error) {
+func getAliasedOption(input map[string]any, keys ...string) (any, bool, error) {
 	var (
 		raw   any
 		exist bool
@@ -144,7 +144,7 @@ func getAliasedOption(input map[string]any, name string, keys ...string) (any, b
 			continue
 		}
 		if exist {
-			return nil, false, errors.New(name + " is specified multiple times")
+			return nil, false, errors.New(keys[0] + " is specified multiple times")
 		}
 		raw = value
 		exist = true

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -16,12 +16,13 @@ package api
 
 import (
 	"net/http"
+	"time"
 
-	"github.com/unrolled/render"
-
+	"github.com/tikv/pd/pkg/unsaferecovery"
 	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server"
+	"github.com/unrolled/render"
 )
 
 type unsafeOperationHandler struct {
@@ -75,7 +76,23 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 		timeout = uint64(rawTimeout)
 	}
 
-	if err := rc.GetUnsafeRecoveryController().RemoveFailedStores(stores, timeout, autoDetect); err != nil {
+	var planExecutionTimeout time.Duration
+	if rawTimeout, exists := input["plan-execution-timeout"].(float64); exists {
+		planExecutionTimeout = time.Duration(uint64(rawTimeout)) * time.Second
+	}
+	if rawTimeout, exists := input["plan_execution_timeout"].(float64); exists {
+		planExecutionTimeout = time.Duration(uint64(rawTimeout)) * time.Second
+	}
+
+	disableParanoidCheck, _ := input["disable-paranoid-check"].(bool)
+	if rawDisableParanoidCheck, exists := input["disable_paranoid_check"].(bool); exists {
+		disableParanoidCheck = rawDisableParanoidCheck
+	}
+
+	if err := rc.GetUnsafeRecoveryController().RemoveFailedStoresWithOptions(stores, timeout, autoDetect, unsaferecovery.RemoveFailedStoresOptions{
+		PlanExecutionTimeout: planExecutionTimeout,
+		DisableParanoidCheck: disableParanoidCheck,
+	}); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -28,7 +28,7 @@ import (
 	"github.com/tikv/pd/server"
 )
 
-var maxPlanExecutionTimeoutSeconds = float64(time.Duration(1<<63-1) / time.Second)
+var maxPlanExecutionTimeoutSeconds = float64(time.Duration(math.MaxInt64/2) / time.Second)
 
 type unsafeOperationHandler struct {
 	svr *server.Server
@@ -87,9 +87,10 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 		return
 	}
 
-	disableParanoidCheck, _ := input["disable-paranoid-check"].(bool)
-	if rawDisableParanoidCheck, exists := input["disable_paranoid_check"].(bool); exists {
-		disableParanoidCheck = rawDisableParanoidCheck
+	disableParanoidCheck, err := parseDisableParanoidCheck(input)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	if err := rc.GetUnsafeRecoveryController().RemoveFailedStoresWithOptions(stores, timeout, autoDetect, unsaferecovery.RemoveFailedStoresOptions{
@@ -116,6 +117,22 @@ func parsePlanExecutionTimeout(input map[string]any) (time.Duration, error) {
 		planExecutionTimeout = time.Duration(int64(rawTimeout)) * time.Second
 	}
 	return planExecutionTimeout, nil
+}
+
+func parseDisableParanoidCheck(input map[string]any) (bool, error) {
+	var disableParanoidCheck bool
+	for _, key := range []string{"disable-paranoid-check", "disable_paranoid_check"} {
+		raw, exists := input[key]
+		if !exists {
+			continue
+		}
+		rawDisableParanoidCheck, ok := raw.(bool)
+		if !ok {
+			return false, errors.New("disable-paranoid-check is invalid")
+		}
+		disableParanoidCheck = rawDisableParanoidCheck
+	}
+	return disableParanoidCheck, nil
 }
 
 // GetFailedStoresRemovalStatus gets the current status of failed stores removal.

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -33,13 +33,6 @@ func TestParsePlanExecutionTimeout(t *testing.T) {
 	re.Equal(5*time.Minute, timeout)
 
 	timeout, err = parsePlanExecutionTimeout(map[string]any{
-		"plan-execution-timeout": float64(300),
-		"plan_execution_timeout": float64(600),
-	})
-	re.NoError(err)
-	re.Equal(10*time.Minute, timeout)
-
-	timeout, err = parsePlanExecutionTimeout(map[string]any{
 		"plan-execution-timeout": maxPlanExecutionTimeoutSeconds,
 	})
 	re.NoError(err)
@@ -55,19 +48,18 @@ func TestParsePlanExecutionTimeout(t *testing.T) {
 		_, err = parsePlanExecutionTimeout(input)
 		re.Error(err)
 	}
+
+	_, err = parsePlanExecutionTimeout(map[string]any{
+		"plan-execution-timeout": float64(300),
+		"plan_execution_timeout": float64(600),
+	})
+	re.EqualError(err, "plan-execution-timeout is specified multiple times")
 }
 
 func TestParseDisableParanoidCheck(t *testing.T) {
 	re := require.New(t)
 
 	disableParanoidCheck, err := parseDisableParanoidCheck(map[string]any{})
-	re.NoError(err)
-	re.False(disableParanoidCheck)
-
-	disableParanoidCheck, err = parseDisableParanoidCheck(map[string]any{
-		"disable-paranoid-check": true,
-		"disable_paranoid_check": false,
-	})
 	re.NoError(err)
 	re.False(disableParanoidCheck)
 
@@ -78,4 +70,10 @@ func TestParseDisableParanoidCheck(t *testing.T) {
 		_, err = parseDisableParanoidCheck(input)
 		re.Error(err)
 	}
+
+	_, err = parseDisableParanoidCheck(map[string]any{
+		"disable-paranoid-check": true,
+		"disable_paranoid_check": false,
+	})
+	re.EqualError(err, "disable-paranoid-check is specified multiple times")
 }

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -56,6 +56,33 @@ func TestParsePlanExecutionTimeout(t *testing.T) {
 	re.EqualError(err, "plan-execution-timeout is specified multiple times")
 }
 
+func TestParseTimeout(t *testing.T) {
+	re := require.New(t)
+
+	timeout, err := parseTimeout(map[string]any{})
+	re.NoError(err)
+	re.Equal(uint64(600), timeout)
+
+	timeout, err = parseTimeout(map[string]any{"timeout": float64(300)})
+	re.NoError(err)
+	re.Equal(uint64(300), timeout)
+
+	timeout, err = parseTimeout(map[string]any{"timeout": maxPlanExecutionTimeoutSeconds})
+	re.NoError(err)
+	re.Equal(uint64(maxPlanExecutionTimeoutSeconds), timeout)
+
+	for _, input := range []map[string]any{
+		{"timeout": float64(0)},
+		{"timeout": float64(-1)},
+		{"timeout": 1.5},
+		{"timeout": maxPlanExecutionTimeoutSeconds + 1},
+		{"timeout": "60"},
+	} {
+		_, err = parseTimeout(input)
+		re.EqualError(err, "timeout is invalid")
+	}
+}
+
 func TestParseDisableParanoidCheck(t *testing.T) {
 	re := require.New(t)
 

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePlanExecutionTimeout(t *testing.T) {
+	re := require.New(t)
+
+	timeout, err := parsePlanExecutionTimeout(map[string]any{})
+	re.NoError(err)
+	re.Zero(timeout)
+
+	timeout, err = parsePlanExecutionTimeout(map[string]any{"plan-execution-timeout": float64(300)})
+	re.NoError(err)
+	re.Equal(5*time.Minute, timeout)
+
+	timeout, err = parsePlanExecutionTimeout(map[string]any{
+		"plan-execution-timeout": float64(300),
+		"plan_execution_timeout": float64(600),
+	})
+	re.NoError(err)
+	re.Equal(10*time.Minute, timeout)
+
+	for _, input := range []map[string]any{
+		{"plan-execution-timeout": float64(0)},
+		{"plan-execution-timeout": float64(-1)},
+		{"plan-execution-timeout": 1.5},
+		{"plan-execution-timeout": maxPlanExecutionTimeoutSeconds + 1},
+		{"plan-execution-timeout": "60"},
+	} {
+		_, err = parsePlanExecutionTimeout(input)
+		re.Error(err)
+	}
+}

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -63,6 +63,14 @@ func TestParseDisableParanoidCheck(t *testing.T) {
 	re.NoError(err)
 	re.False(disableParanoidCheck)
 
+	disableParanoidCheck, err = parseDisableParanoidCheck(map[string]any{"disable-paranoid-check": true})
+	re.NoError(err)
+	re.True(disableParanoidCheck)
+
+	disableParanoidCheck, err = parseDisableParanoidCheck(map[string]any{"disable_paranoid_check": false})
+	re.NoError(err)
+	re.False(disableParanoidCheck)
+
 	for _, input := range []map[string]any{
 		{"disable-paranoid-check": "true"},
 		{"disable_paranoid_check": 1},

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -39,6 +39,12 @@ func TestParsePlanExecutionTimeout(t *testing.T) {
 	re.NoError(err)
 	re.Equal(10*time.Minute, timeout)
 
+	timeout, err = parsePlanExecutionTimeout(map[string]any{
+		"plan-execution-timeout": maxPlanExecutionTimeoutSeconds,
+	})
+	re.NoError(err)
+	re.Equal(time.Duration(int64(maxPlanExecutionTimeoutSeconds))*time.Second, timeout)
+
 	for _, input := range []map[string]any{
 		{"plan-execution-timeout": float64(0)},
 		{"plan-execution-timeout": float64(-1)},
@@ -47,6 +53,29 @@ func TestParsePlanExecutionTimeout(t *testing.T) {
 		{"plan-execution-timeout": "60"},
 	} {
 		_, err = parsePlanExecutionTimeout(input)
+		re.Error(err)
+	}
+}
+
+func TestParseDisableParanoidCheck(t *testing.T) {
+	re := require.New(t)
+
+	disableParanoidCheck, err := parseDisableParanoidCheck(map[string]any{})
+	re.NoError(err)
+	re.False(disableParanoidCheck)
+
+	disableParanoidCheck, err = parseDisableParanoidCheck(map[string]any{
+		"disable-paranoid-check": true,
+		"disable_paranoid_check": false,
+	})
+	re.NoError(err)
+	re.False(disableParanoidCheck)
+
+	for _, input := range []map[string]any{
+		{"disable-paranoid-check": "true"},
+		{"disable_paranoid_check": 1},
+	} {
+		_, err = parseDisableParanoidCheck(input)
 		re.Error(err)
 	}
 }

--- a/tests/server/api/unsafe_operation_test.go
+++ b/tests/server/api/unsafe_operation_test.go
@@ -87,6 +87,18 @@ func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.Te
 		testutil.StringEqual(re, "\"[PD:unsaferecovery:ErrUnsafeRecoveryInvalidInput]invalid input store 2 doesn't exist\"\n"))
 	re.NoError(err)
 
+	for _, input := range []map[string]any{
+		{"stores": []uint64{1}, "plan-execution-timeout": -1},
+		{"stores": []uint64{1}, "plan-execution-timeout": 1.5},
+		{"stores": []uint64{1}, "plan_execution_timeout": "60"},
+	} {
+		data, err = json.Marshal(input)
+		re.NoError(err)
+		err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/remove-failed-stores", data, testutil.StatusNotOK(re),
+			testutil.StringContain(re, "plan-execution-timeout is invalid"))
+		re.NoError(err)
+	}
+
 	input = map[string]any{"stores": []uint64{1}, "plan-execution-timeout": 300, "disable-paranoid-check": true}
 	data, err = json.Marshal(input)
 	re.NoError(err)

--- a/tests/server/api/unsafe_operation_test.go
+++ b/tests/server/api/unsafe_operation_test.go
@@ -87,7 +87,7 @@ func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.Te
 		testutil.StringEqual(re, "\"[PD:unsaferecovery:ErrUnsafeRecoveryInvalidInput]invalid input store 2 doesn't exist\"\n"))
 	re.NoError(err)
 
-	input = map[string]any{"stores": []uint64{1}}
+	input = map[string]any{"stores": []uint64{1}, "plan-execution-timeout": 300, "disable-paranoid-check": true}
 	data, err = json.Marshal(input)
 	re.NoError(err)
 	err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/remove-failed-stores", data, testutil.StatusOK(re))
@@ -97,6 +97,9 @@ func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.Te
 	var output []unsaferecovery.StageOutput
 	err = testutil.ReadGetJSON(re, tests.TestDialClient, urlPrefix+"/remove-failed-stores/show", &output)
 	re.NoError(err)
+	re.NotEmpty(output)
+	re.Contains(output[0].Details, "paranoid check disabled")
+	re.Contains(output[0].Details, "plan execution timeout 5m0s")
 }
 
 func (suite *unsafeOperationTestSuite) TestRemoveFailedStoresAutoDetect() {

--- a/tests/server/api/unsafe_operation_test.go
+++ b/tests/server/api/unsafe_operation_test.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
@@ -53,6 +54,7 @@ func (suite *unsafeOperationTestSuite) TestRemoveFailedStores() {
 
 func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.TestCluster) {
 	re := suite.Require()
+	maxPlanExecutionTimeoutSeconds := float64(time.Duration(math.MaxInt64/2) / time.Second)
 
 	tests.MustPutStore(re, cluster, &metapb.Store{
 		Id:            1,
@@ -90,6 +92,7 @@ func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.Te
 	for _, input := range []map[string]any{
 		{"stores": []uint64{1}, "plan-execution-timeout": -1},
 		{"stores": []uint64{1}, "plan-execution-timeout": 1.5},
+		{"stores": []uint64{1}, "plan-execution-timeout": maxPlanExecutionTimeoutSeconds + 1},
 		{"stores": []uint64{1}, "plan_execution_timeout": "60"},
 	} {
 		data, err = json.Marshal(input)
@@ -98,6 +101,12 @@ func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.Te
 			testutil.StringContain(re, "plan-execution-timeout is invalid"))
 		re.NoError(err)
 	}
+
+	data, err = json.Marshal(map[string]any{"stores": []uint64{1}, "disable-paranoid-check": "true"})
+	re.NoError(err)
+	err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/remove-failed-stores", data, testutil.StatusNotOK(re),
+		testutil.StringContain(re, "disable-paranoid-check is invalid"))
+	re.NoError(err)
 
 	input = map[string]any{"stores": []uint64{1}, "plan-execution-timeout": 300, "disable-paranoid-check": true}
 	data, err = json.Marshal(input)

--- a/tests/server/api/unsafe_operation_test.go
+++ b/tests/server/api/unsafe_operation_test.go
@@ -108,6 +108,26 @@ func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.Te
 		testutil.StringContain(re, "disable-paranoid-check is invalid"))
 	re.NoError(err)
 
+	data, err = json.Marshal(map[string]any{
+		"stores":                 []uint64{1},
+		"plan-execution-timeout": 300,
+		"plan_execution_timeout": 600,
+	})
+	re.NoError(err)
+	err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/remove-failed-stores", data, testutil.StatusNotOK(re),
+		testutil.StringContain(re, "plan-execution-timeout is specified multiple times"))
+	re.NoError(err)
+
+	data, err = json.Marshal(map[string]any{
+		"stores":                 []uint64{1},
+		"disable-paranoid-check": true,
+		"disable_paranoid_check": false,
+	})
+	re.NoError(err)
+	err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/remove-failed-stores", data, testutil.StatusNotOK(re),
+		testutil.StringContain(re, "disable-paranoid-check is specified multiple times"))
+	re.NoError(err)
+
 	input = map[string]any{"stores": []uint64{1}, "plan-execution-timeout": 300, "disable-paranoid-check": true}
 	data, err = json.Marshal(input)
 	re.NoError(err)

--- a/tests/server/api/unsafe_operation_test.go
+++ b/tests/server/api/unsafe_operation_test.go
@@ -90,6 +90,19 @@ func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.Te
 	re.NoError(err)
 
 	for _, input := range []map[string]any{
+		{"stores": []uint64{1}, "timeout": -1},
+		{"stores": []uint64{1}, "timeout": 1.5},
+		{"stores": []uint64{1}, "timeout": maxPlanExecutionTimeoutSeconds + 1},
+		{"stores": []uint64{1}, "timeout": "60"},
+	} {
+		data, err = json.Marshal(input)
+		re.NoError(err)
+		err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/remove-failed-stores", data, testutil.StatusNotOK(re),
+			testutil.StringContain(re, "timeout is invalid"))
+		re.NoError(err)
+	}
+
+	for _, input := range []map[string]any{
 		{"stores": []uint64{1}, "plan-execution-timeout": -1},
 		{"stores": []uint64{1}, "plan-execution-timeout": 1.5},
 		{"stores": []uint64{1}, "plan-execution-timeout": maxPlanExecutionTimeoutSeconds + 1},

--- a/tools/pd-ctl/pdctl/command/unsafe_command.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command.go
@@ -43,9 +43,11 @@ func NewRemoveFailedStoresCommand() *cobra.Command {
 		Run:   removeFailedStoresCommandFunc,
 	}
 	cmd.PersistentFlags().Float64("timeout", 300, "timeout in seconds")
+	cmd.PersistentFlags().Float64("plan-execution-timeout", 60, "plan execution timeout in seconds before dispatching the plan again")
+	cmd.PersistentFlags().Bool("disable-paranoid-check", false, "disable the empty region overlap paranoid check")
 	cmd.PersistentFlags().Bool("auto-detect", false, `detect failed stores automatically without needing to pass failed store ids, and all stores not in PD stores list are regarded as failed; 
-Note: DO NOT RECOMMEND to use this flag for general use, it's used only for case that PD doesn't have the store information of failed stores after pd-recover;
-Note: Do it with caution to make sure all live stores's heartbeats has been reported PD already, otherwise it may regarded some stores as failed mistakenly.`)
+	Note: DO NOT RECOMMEND to use this flag for general use, it's used only for case that PD doesn't have the store information of failed stores after pd-recover;
+	Note: Do it with caution to make sure all live stores's heartbeats has been reported PD already, otherwise it may regarded some stores as failed mistakenly.`)
 	cmd.AddCommand(NewRemoveFailedStoresShowCommand())
 	return cmd
 }
@@ -101,6 +103,22 @@ func removeFailedStoresCommandFunc(cmd *cobra.Command, args []string) {
 		return
 	} else if timeout != 300 {
 		postInput["timeout"] = timeout
+	}
+
+	planExecutionTimeout, err := cmd.Flags().GetFloat64("plan-execution-timeout")
+	if err != nil {
+		cmd.Println(err)
+		return
+	} else if planExecutionTimeout != 60 {
+		postInput["plan-execution-timeout"] = planExecutionTimeout
+	}
+
+	disableParanoidCheck, err := cmd.Flags().GetBool("disable-paranoid-check")
+	if err != nil {
+		cmd.Println(err)
+		return
+	} else if disableParanoidCheck {
+		postInput["disable-paranoid-check"] = disableParanoidCheck
 	}
 
 	postJSON(cmd, prefix, postInput)

--- a/tools/pd-ctl/pdctl/command/unsafe_command.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command.go
@@ -16,14 +16,18 @@ package command
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 const unsafePrefix = "pd/api/v1/admin/unsafe"
+
+var maxPlanExecutionTimeoutSeconds = float64(time.Duration(1<<63-1) / time.Second)
 
 // NewUnsafeCommand returns the unsafe subcommand of rootCmd.
 func NewUnsafeCommand() *cobra.Command {
@@ -110,6 +114,10 @@ func removeFailedStoresCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Println(err)
 		return
 	} else if planExecutionTimeout != 60 {
+		if err := validatePlanExecutionTimeoutSeconds(planExecutionTimeout); err != nil {
+			cmd.Println(err)
+			return
+		}
 		postInput["plan-execution-timeout"] = planExecutionTimeout
 	}
 
@@ -122,6 +130,13 @@ func removeFailedStoresCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	postJSON(cmd, prefix, postInput)
+}
+
+func validatePlanExecutionTimeoutSeconds(timeout float64) error {
+	if timeout <= 0 || timeout != math.Trunc(timeout) || timeout > maxPlanExecutionTimeoutSeconds {
+		return fmt.Errorf("plan-execution-timeout must be a positive integer number of seconds no greater than %.0f", maxPlanExecutionTimeoutSeconds)
+	}
+	return nil
 }
 
 func removeFailedStoresShowCommandFunc(cmd *cobra.Command, _ []string) {

--- a/tools/pd-ctl/pdctl/command/unsafe_command.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command.go
@@ -27,7 +27,7 @@ import (
 
 const unsafePrefix = "pd/api/v1/admin/unsafe"
 
-var maxPlanExecutionTimeoutSeconds = float64(time.Duration(1<<63-1) / time.Second)
+var maxPlanExecutionTimeoutSeconds = float64(time.Duration(math.MaxInt64/2) / time.Second)
 
 // NewUnsafeCommand returns the unsafe subcommand of rootCmd.
 func NewUnsafeCommand() *cobra.Command {

--- a/tools/pd-ctl/pdctl/command/unsafe_command_test.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePlanExecutionTimeoutSeconds(t *testing.T) {
+	re := require.New(t)
+
+	for _, timeout := range []float64{1, 60, maxPlanExecutionTimeoutSeconds} {
+		re.NoError(validatePlanExecutionTimeoutSeconds(timeout))
+	}
+
+	for _, timeout := range []float64{0, -1, 1.5, maxPlanExecutionTimeoutSeconds + 1} {
+		re.Error(validatePlanExecutionTimeoutSeconds(timeout))
+	}
+}

--- a/tools/pd-ctl/tests/unsafe/unsafe_operation_test.go
+++ b/tools/pd-ctl/tests/unsafe/unsafe_operation_test.go
@@ -46,6 +46,9 @@ func TestRemoveFailedStores(t *testing.T) {
 	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "3600"}
 	_, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
+	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--plan-execution-timeout", "600", "--disable-paranoid-check"}
+	_, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
 	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "abc"}
 	_, err = tests.ExecuteCommand(cmd, args...)
 	re.Error(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10638

Unsafe recovery creates empty regions to fill range holes. The paranoid overlap check currently scans every collected peer for each generated empty region, which can make plan generation O(number of holes * number of peer reports). On large clusters this work happens while the unsafe recovery controller lock is held, delaying schedulers/checkers and related unsafe-recovery operations.

PD also re-dispatches a store recovery plan after a fixed 40s execution window. When TiKV spends longer executing create-empty-region plans, PD may repeatedly log `unsafe recovery store recovery plan execution timeout, retry` and send duplicate plans.

### What is changed and how does it work?

```commit-message
pkg/unsaferecovery: optimize empty region overlap checks
```

Collect newly created empty regions while scanning the newest region tree. These empty regions are generated in key order and do not overlap with each other, so they can be used as a small sorted index. Then scan collected peer reports once and binary-search the empty-region index to detect any overlap.

This changes the paranoid overlap check from O(empty regions * peer reports) to O(newest regions + empty regions + peer reports * log(empty regions)). When there is no generated empty region, the extra check returns immediately. For multiple peer reports of the same region, duplicate same-version same-range reports reuse the first no-overlap result and skip another binary search.

The check uses half-open region range semantics and keeps the existing error path when an overlap is found.

### Before/after comparison

For a recovery round with about 1.5M existing regions and 5k generated empty regions:

| Item | Before this PR | After this PR |
| --- | --- | --- |
| Paranoid check algorithm | For every generated empty region, scan every collected initialized peer report. | Build an index from generated empty regions, then scan peer reports once and binary-search the empty-region index. |
| Complexity | O(empty regions * peer reports). | O(newest regions + empty regions + peer reports * log(empty regions)). |
| Work for 1.5M regions / 5k holes | Estimated from the original data-structure benchmark: about 36 minutes to more than 1 hour locally, and could become several hours in production while holding the unsafe recovery controller lock. | Expected paranoid-check cost is sub-second at this scale; remaining wall time mostly depends on the existing newest-region tree scan and ID allocation for generated regions. |
| Lock impact | The O(empty regions * peer reports) scan runs while the unsafe recovery controller lock is held, so large recoveries can delay schedulers, checkers, and related unsafe-recovery handling. | The lock is still held during plan generation, but the expensive paranoid-check part is reduced from a several-hour worst-case risk to sub-second scale in the estimate above. |

The exact wall time still depends on key length, CPU, report fanout, the existing newest-region tree scan, and ID allocation for generated regions, so the numbers above are rough estimates rather than a strict production SLA.

This PR also extends the default plan execution timeout from 40s to 60s, and adds request-level options for large unsafe recovery operations:

```json
{
  "stores": [1, 2, 3],
  "timeout": 600,
  "plan-execution-timeout": 600,
  "disable-paranoid-check": true
}
```

The same options are exposed in `pd-ctl`:

```bash
pd-ctl unsafe remove-failed-stores 1,2,3 --timeout 600 --plan-execution-timeout 600 --disable-paranoid-check
```

- `plan-execution-timeout` controls how long PD waits for a store to execute a dispatched recovery plan before re-dispatching it. The default is 60s.
- `disable-paranoid-check` skips the empty-region overlap paranoid check. The default remains enabled.

When either option is set, the recovery status output records it, for example `plan execution timeout 10m0s` and `paranoid check disabled`.

### Check List

Tests

- Unit test

### Release note

```release-note
Optimize unsafe recovery empty-region plan generation when many regions and gaps exist
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable plan execution timeout for unsafe recovery operations.
  * Option to disable the paranoid empty-region overlap check.
  * API and CLI support to pass these options for removal operations.

* **Improvements**
  * Batched empty-region creation with overlap guarding; tracks created and affected regions.
  * Status output now reports paranoid-check state and configured plan execution timeout.

* **Tests**
  * Added validation and parsing tests for timeouts and paranoid-check flags; CLI validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->