### PR TITLE
grafana: render stacked nulls as zero

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -2467,7 +2467,7 @@
           "lines": false,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
@@ -6897,7 +6897,7 @@
           "lines": false,
           "linewidth": 1,
           "links": [],
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "paceLength": 10,
           "percentage": false,
           "pointradius": 1,


### PR DESCRIPTION
## Summary
- set stacked Grafana graph panels to render null points as zero
- avoid misleading stacked visualizations when a series has data gaps

## Test
- parsed dashboard JSON files
- verified every `stack: true` graph panel has `nullPointMode: "null as zero"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Grafana dashboard visualization settings to display missing data points as zeros in performance monitoring panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->