### PR TITLE
*: refresh outdated README build and example info

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Using `curl` to view PD members:
 curl http://${HOST_IP}:2379/pd/api/v1/members
 
 {
+  "header": {
+    "cluster_id": 7637715636087433014
+  },
   "members": [
     {
       "name": "pd",
@@ -58,7 +61,33 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
       "binary_version": "v8.5.6",
       "git_hash": "<git-commit-hash>"
     }
-  ]
+  ],
+  "leader": {
+    "name": "pd",
+    "member_id": 15980934438217023866,
+    "peer_urls": [
+      "http://192.168.199.105:2380"
+    ],
+    "client_urls": [
+      "http://192.168.199.105:2379"
+    ],
+    "deploy_path": "/",
+    "binary_version": "v8.5.6",
+    "git_hash": "<git-commit-hash>"
+  },
+  "etcd_leader": {
+    "name": "pd",
+    "member_id": 15980934438217023866,
+    "peer_urls": [
+      "http://192.168.199.105:2380"
+    ],
+    "client_urls": [
+      "http://192.168.199.105:2379"
+    ],
+    "deploy_path": "/",
+    "binary_version": "v8.5.6",
+    "git_hash": "<git-commit-hash>"
+  }
 }
 ```
 
@@ -70,11 +99,14 @@ http http://${HOST_IP}:2379/pd/api/v1/members
 Access-Control-Allow-Headers: accept, content-type, authorization
 Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE
 Access-Control-Allow-Origin: *
-Content-Length: 1003
+Content-Length: <length>
 Content-Type: application/json; charset=UTF-8
 Date: <response-date>
 
 {
+  "header": {
+    "cluster_id": 7637715636087433014
+  },
   "members": [
     {
       "name": "pd",
@@ -89,7 +121,33 @@ Date: <response-date>
       "binary_version": "v8.5.6",
       "git_hash": "<git-commit-hash>"
     }
-  ]
+  ],
+  "leader": {
+    "name": "pd",
+    "member_id": 15980934438217023866,
+    "peer_urls": [
+      "http://192.168.199.105:2380"
+    ],
+    "client_urls": [
+      "http://192.168.199.105:2379"
+    ],
+    "deploy_path": "/",
+    "binary_version": "v8.5.6",
+    "git_hash": "<git-commit-hash>"
+  },
+  "etcd_leader": {
+    "name": "pd",
+    "member_id": 15980934438217023866,
+    "peer_urls": [
+      "http://192.168.199.105:2380"
+    ],
+    "client_urls": [
+      "http://192.168.199.105:2379"
+    ],
+    "deploy_path": "/",
+    "binary_version": "v8.5.6",
+    "git_hash": "<git-commit-hash>"
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ If you're interested in contributing to PD, see [CONTRIBUTING.md](./CONTRIBUTING
 
 ## Build
 
-1. Make sure [*Go*](https://golang.org/) (version 1.23) is installed.
-2. Use `make` to install PD. `pd-server` will be installed in the `bin` directory.
+1. Make sure [*Go*](https://golang.org/) (version 1.25 or later) is installed.
+2. Run `make` (equivalent to `make build`) to build PD. `pd-server`, `pd-ctl`, and `pd-recover` will be produced in the `bin` directory.
 
 ## Usage
 
@@ -55,14 +55,14 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
         "http://192.168.199.105:2379"
       ],
       "deploy_path": "/",
-      "binary_version": "v6.1.3",
-      "git_hash": "1a4e975892512a97fb0e5b45c9be69aa76148793"
+      "binary_version": "v8.5.6",
+      "git_hash": "<git-commit-hash>"
     }
   ]
 }
 ```
 
-You can also use [httpie](https://github.com/jkbrzt/httpie) to call the API:
+You can also use [httpie](https://github.com/httpie/cli) to call the API:
 
 ```bash
 http http://${HOST_IP}:2379/pd/api/v1/members
@@ -72,7 +72,7 @@ Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE
 Access-Control-Allow-Origin: *
 Content-Length: 1003
 Content-Type: application/json; charset=UTF-8
-Date: Mon, 12 Dec 2022 13:46:33 GMT
+Date: <response-date>
 
 {
   "members": [
@@ -86,8 +86,8 @@ Date: Mon, 12 Dec 2022 13:46:33 GMT
         "http://192.168.199.105:2379"
       ],
       "deploy_path": "/",
-      "binary_version": "v6.1.3",
-      "git_hash": "1a4e975892512a97fb0e5b45c9be69aa76148793"
+      "binary_version": "v8.5.6",
+      "git_hash": "<git-commit-hash>"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
       ],
       "deploy_path": "/",
       "binary_version": "v8.5.6",
-      "git_hash": "<git-commit-hash>"
+      "git_hash": "21bd0a379e5f9d2be11a92d17645a6ada19f02c1"
     }
   ],
   "leader": {
@@ -73,7 +73,7 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
-    "git_hash": "<git-commit-hash>"
+    "git_hash": "21bd0a379e5f9d2be11a92d17645a6ada19f02c1"
   },
   "etcd_leader": {
     "name": "pd",
@@ -86,7 +86,7 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
-    "git_hash": "<git-commit-hash>"
+    "git_hash": "21bd0a379e5f9d2be11a92d17645a6ada19f02c1"
   }
 }
 ```
@@ -119,7 +119,7 @@ Date: <response-date>
       ],
       "deploy_path": "/",
       "binary_version": "v8.5.6",
-      "git_hash": "<git-commit-hash>"
+      "git_hash": "21bd0a379e5f9d2be11a92d17645a6ada19f02c1"
     }
   ],
   "leader": {
@@ -133,7 +133,7 @@ Date: <response-date>
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
-    "git_hash": "<git-commit-hash>"
+    "git_hash": "21bd0a379e5f9d2be11a92d17645a6ada19f02c1"
   },
   "etcd_leader": {
     "name": "pd",
@@ -146,7 +146,7 @@ Date: <response-date>
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
-    "git_hash": "<git-commit-hash>"
+    "git_hash": "21bd0a379e5f9d2be11a92d17645a6ada19f02c1"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
       "name": "pd",
       "member_id": 15980934438217023866,
       "peer_urls": [
-        "http://<host-ip>:2380"
+        "http://192.168.199.105:2380"
       ],
       "client_urls": [
-        "http://<host-ip>:2379"
+        "http://192.168.199.105:2379"
       ],
       "deploy_path": "/",
       "binary_version": "v8.5.6",
@@ -66,10 +66,10 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://<host-ip>:2380"
+      "http://192.168.199.105:2380"
     ],
     "client_urls": [
-      "http://<host-ip>:2379"
+      "http://192.168.199.105:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
@@ -79,10 +79,10 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://<host-ip>:2380"
+      "http://192.168.199.105:2380"
     ],
     "client_urls": [
-      "http://<host-ip>:2379"
+      "http://192.168.199.105:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
@@ -112,10 +112,10 @@ Date: <response-date>
       "name": "pd",
       "member_id": 15980934438217023866,
       "peer_urls": [
-        "http://<host-ip>:2380"
+        "http://192.168.199.105:2380"
       ],
       "client_urls": [
-        "http://<host-ip>:2379"
+        "http://192.168.199.105:2379"
       ],
       "deploy_path": "/",
       "binary_version": "v8.5.6",
@@ -126,10 +126,10 @@ Date: <response-date>
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://<host-ip>:2380"
+      "http://192.168.199.105:2380"
     ],
     "client_urls": [
-      "http://<host-ip>:2379"
+      "http://192.168.199.105:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
@@ -139,10 +139,10 @@ Date: <response-date>
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://<host-ip>:2380"
+      "http://192.168.199.105:2380"
     ],
     "client_urls": [
-      "http://<host-ip>:2379"
+      "http://192.168.199.105:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
       "name": "pd",
       "member_id": 15980934438217023866,
       "peer_urls": [
-        "http://192.168.199.105:2380"
+        "http://<host-ip>:2380"
       ],
       "client_urls": [
-        "http://192.168.199.105:2379"
+        "http://<host-ip>:2379"
       ],
       "deploy_path": "/",
       "binary_version": "v8.5.6",
@@ -66,10 +66,10 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://192.168.199.105:2380"
+      "http://<host-ip>:2380"
     ],
     "client_urls": [
-      "http://192.168.199.105:2379"
+      "http://<host-ip>:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
@@ -79,10 +79,10 @@ curl http://${HOST_IP}:2379/pd/api/v1/members
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://192.168.199.105:2380"
+      "http://<host-ip>:2380"
     ],
     "client_urls": [
-      "http://192.168.199.105:2379"
+      "http://<host-ip>:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
@@ -112,10 +112,10 @@ Date: <response-date>
       "name": "pd",
       "member_id": 15980934438217023866,
       "peer_urls": [
-        "http://192.168.199.105:2380"
+        "http://<host-ip>:2380"
       ],
       "client_urls": [
-        "http://192.168.199.105:2379"
+        "http://<host-ip>:2379"
       ],
       "deploy_path": "/",
       "binary_version": "v8.5.6",
@@ -126,10 +126,10 @@ Date: <response-date>
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://192.168.199.105:2380"
+      "http://<host-ip>:2380"
     ],
     "client_urls": [
-      "http://192.168.199.105:2379"
+      "http://<host-ip>:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",
@@ -139,10 +139,10 @@ Date: <response-date>
     "name": "pd",
     "member_id": 15980934438217023866,
     "peer_urls": [
-      "http://192.168.199.105:2380"
+      "http://<host-ip>:2380"
     ],
     "client_urls": [
-      "http://192.168.199.105:2379"
+      "http://<host-ip>:2379"
     ],
     "deploy_path": "/",
     "binary_version": "v8.5.6",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4399

The README has several outdated/inaccurate pieces of information:

- The required Go version is documented as 1.23, but `go.mod` is already on `go 1.25.7` and CI uses Go 1.25.
- The build step says `make` installs only `pd-server`, while `make build` actually produces `pd-server`, `pd-ctl`, and `pd-recover`.
- The httpie link points to the old `jkbrzt/httpie` repository, which has moved to `httpie/cli`.
- The sample `members` API output uses `v6.1.3` (released in 2022) and a fixed `Date` header, both of which keep going stale.

### What is changed and how does it work?

Documentation-only update to `README.md`:

- Bump the required Go version from 1.23 to 1.25 or later.
- Clarify that `make` (equivalent to `make build`) builds `pd-server`, `pd-ctl`, and `pd-recover` into the `bin` directory.
- Update the httpie link from `jkbrzt/httpie` to `httpie/cli`.
- Refresh `binary_version` in the example output to `v8.5.6`, and replace `git_hash` / `Date` with placeholders so they do not go stale again.

```commit-message
README: refresh outdated build and example info
```

### Check List

Tests

- No code

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Minimum Go version raised to 1.25+ for building
  * Build instructions clarified: use make to produce binaries into bin
  * API examples updated: bumped binary version and git hash, added top-level cluster header and leader sections
  * Example responses now use placeholders for Content-Length and response dates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->