### PR TITLE
election: use fixed lease keepalive interval

### DIFF
--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -158,7 +158,7 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	timeCh := l.keepAliveWorker(ctx, leaseKeepAliveInterval, leaseKeepAliveInterval)
+	timeCh := l.keepAliveWorker(ctx)
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -223,17 +223,17 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.
-func (l *Lease) keepAliveWorker(ctx context.Context, interval, timeout time.Duration) <-chan time.Time {
+func (l *Lease) keepAliveWorker(ctx context.Context) <-chan time.Time {
 	ch := make(chan time.Time)
 
 	go func() {
 		defer logutil.LogPanic()
-		ticker := time.NewTicker(interval)
+		ticker := time.NewTicker(leaseKeepAliveInterval)
 		defer ticker.Stop()
 
 		logger := log.With(zap.String("purpose", l.purpose),
 			zap.Int64("lease-id", int64(l.GetID())),
-			zap.Duration("interval", interval))
+			zap.Duration("interval", leaseKeepAliveInterval))
 		logger.Info("start lease keep alive worker")
 		defer logger.Info("stop lease keep alive worker")
 
@@ -249,7 +249,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval, timeout time.Dura
 			go func() {
 				defer logutil.LogPanic()
 
-				ctx1, cancel := context.WithTimeout(ctx, timeout)
+				ctx1, cancel := context.WithTimeout(ctx, leaseKeepAliveInterval)
 				defer cancel()
 				// Record the start time of the `KeepAliveOnce` request to track the request duration
 				// and calculate the tick interval between consecutive `KeepAliveOnce` requests later.
@@ -263,7 +263,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval, timeout time.Dura
 				tickInterval := requestStart.Sub(lastRequestStart)
 				l.metrics.tickInterval.Observe(tickInterval.Seconds())
 				// If the interval is too long, log a warning to indicate the potential runtime schedule delay.
-				if tickInterval > interval*2 {
+				if tickInterval > leaseKeepAliveInterval*2 {
 					logger.Warn("the interval between keeping alive lease is too long",
 						zap.Time("start", start),
 						zap.Time("current-time", requestStart),

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -31,14 +31,11 @@ import (
 )
 
 const (
-	// DefaultLeaderLease is the default election leader lease in seconds.
-	DefaultLeaderLease = int64(5)
-
 	revokeLeaseTimeout = time.Second
 	requestTimeout     = etcdutil.DefaultRequestTimeout
 	slowRequestTime    = etcdutil.DefaultSlowRequestTime
-	// maxLeaseKeepAliveInterval keeps the default leader lease renewal cadence as an upper bound.
-	maxLeaseKeepAliveInterval = time.Duration(DefaultLeaderLease) * time.Second / 3
+	// leaseKeepAliveInterval is fixed to renew leases frequently regardless of the configured lease timeout.
+	leaseKeepAliveInterval = 500 * time.Millisecond
 )
 
 // Lease is used as the low-level mechanism for campaigning and renewing elected leadership.
@@ -161,8 +158,7 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	keepAliveInterval := getLeaseKeepAliveInterval(l.leaseTimeout)
-	timeCh := l.keepAliveWorker(ctx, keepAliveInterval, getLeaseKeepAliveTimeout(l.leaseTimeout))
+	timeCh := l.keepAliveWorker(ctx, leaseKeepAliveInterval, leaseKeepAliveInterval)
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -224,22 +220,6 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 			return
 		}
 	}
-}
-
-func getLeaseKeepAliveInterval(leaseTimeout time.Duration) time.Duration {
-	interval := leaseTimeout / 3
-	if interval > maxLeaseKeepAliveInterval {
-		return maxLeaseKeepAliveInterval
-	}
-	return interval
-}
-
-func getLeaseKeepAliveTimeout(leaseTimeout time.Duration) time.Duration {
-	timeout := getLeaseKeepAliveInterval(leaseTimeout)
-	if leaseTimeout < timeout {
-		return leaseTimeout
-	}
-	return timeout
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -31,11 +31,14 @@ import (
 )
 
 const (
+	// DefaultLeaderLease is the default election leader lease in seconds.
+	DefaultLeaderLease = int64(5)
+
 	revokeLeaseTimeout = time.Second
 	requestTimeout     = etcdutil.DefaultRequestTimeout
 	slowRequestTime    = etcdutil.DefaultSlowRequestTime
-	// maxLeaseKeepAliveInterval keeps the default 5-second lease renewal cadence as an upper bound.
-	maxLeaseKeepAliveInterval = 5 * time.Second / 3
+	// maxLeaseKeepAliveInterval keeps the default leader lease renewal cadence as an upper bound.
+	maxLeaseKeepAliveInterval = time.Duration(DefaultLeaderLease) * time.Second / 3
 )
 
 // Lease is used as the low-level mechanism for campaigning and renewing elected leadership.

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -34,8 +34,13 @@ const (
 	revokeLeaseTimeout = time.Second
 	requestTimeout     = etcdutil.DefaultRequestTimeout
 	slowRequestTime    = etcdutil.DefaultSlowRequestTime
-	// leaseKeepAliveInterval is fixed to renew leases frequently regardless of the configured lease timeout.
-	leaseKeepAliveInterval = 500 * time.Millisecond
+	// maxLeaseKeepAliveInterval caps the keepalive cadence at 500ms, decoupling
+	// renewal frequency from the configured lease timeout. etcd's clientv3
+	// keepalive uses TTL/3 with no upper bound; we deviate so that operators who
+	// raise the lease TTL (e.g. to tolerate longer GC pauses) do not also slow
+	// down PD's leader-failover reaction time. PD has only a handful of leases
+	// per cluster, so the extra RPCs at large TTLs are negligible.
+	maxLeaseKeepAliveInterval = 500 * time.Millisecond
 )
 
 // Lease is used as the low-level mechanism for campaigning and renewing elected leadership.
@@ -149,6 +154,17 @@ func (l *Lease) loadExpireTime() time.Time {
 	return expireTime
 }
 
+// getKeepAliveInterval returns the interval used to drive the keepalive ticker.
+// It takes the minimum of `leaseTimeout/3` and `maxLeaseKeepAliveInterval` so the
+// renewal cadence never gets slower as the lease timeout grows.
+func (l *Lease) getKeepAliveInterval() time.Duration {
+	interval := l.leaseTimeout / 3
+	if interval > maxLeaseKeepAliveInterval {
+		return maxLeaseKeepAliveInterval
+	}
+	return interval
+}
+
 // KeepAlive auto renews the lease and update expireTime.
 func (l *Lease) KeepAlive(ctx context.Context) {
 	defer logutil.LogPanic()
@@ -226,14 +242,15 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 func (l *Lease) keepAliveWorker(ctx context.Context) <-chan time.Time {
 	ch := make(chan time.Time)
 
+	interval := l.getKeepAliveInterval()
 	go func() {
 		defer logutil.LogPanic()
-		ticker := time.NewTicker(leaseKeepAliveInterval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
 		logger := log.With(zap.String("purpose", l.purpose),
 			zap.Int64("lease-id", int64(l.GetID())),
-			zap.Duration("interval", leaseKeepAliveInterval))
+			zap.Duration("interval", interval))
 		logger.Info("start lease keep alive worker")
 		defer logger.Info("stop lease keep alive worker")
 
@@ -249,7 +266,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context) <-chan time.Time {
 			go func() {
 				defer logutil.LogPanic()
 
-				ctx1, cancel := context.WithTimeout(ctx, leaseKeepAliveInterval)
+				ctx1, cancel := context.WithTimeout(ctx, l.leaseTimeout)
 				defer cancel()
 				// Record the start time of the `KeepAliveOnce` request to track the request duration
 				// and calculate the tick interval between consecutive `KeepAliveOnce` requests later.
@@ -263,7 +280,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context) <-chan time.Time {
 				tickInterval := requestStart.Sub(lastRequestStart)
 				l.metrics.tickInterval.Observe(tickInterval.Seconds())
 				// If the interval is too long, log a warning to indicate the potential runtime schedule delay.
-				if tickInterval > leaseKeepAliveInterval*2 {
+				if tickInterval > interval*2 {
 					logger.Warn("the interval between keeping alive lease is too long",
 						zap.Time("start", start),
 						zap.Time("current-time", requestStart),

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -161,7 +161,8 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	timeCh := l.keepAliveWorker(ctx, getLeaseKeepAliveInterval(l.leaseTimeout))
+	keepAliveInterval := getLeaseKeepAliveInterval(l.leaseTimeout)
+	timeCh := l.keepAliveWorker(ctx, keepAliveInterval, getLeaseKeepAliveTimeout(l.leaseTimeout))
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -233,8 +234,16 @@ func getLeaseKeepAliveInterval(leaseTimeout time.Duration) time.Duration {
 	return interval
 }
 
+func getLeaseKeepAliveTimeout(leaseTimeout time.Duration) time.Duration {
+	timeout := getLeaseKeepAliveInterval(leaseTimeout)
+	if leaseTimeout < timeout {
+		return leaseTimeout
+	}
+	return timeout
+}
+
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.
-func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-chan time.Time {
+func (l *Lease) keepAliveWorker(ctx context.Context, interval, timeout time.Duration) <-chan time.Time {
 	ch := make(chan time.Time)
 
 	go func() {
@@ -260,7 +269,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 			go func() {
 				defer logutil.LogPanic()
 
-				ctx1, cancel := context.WithTimeout(ctx, l.leaseTimeout)
+				ctx1, cancel := context.WithTimeout(ctx, timeout)
 				defer cancel()
 				// Record the start time of the `KeepAliveOnce` request to track the request duration
 				// and calculate the tick interval between consecutive `KeepAliveOnce` requests later.

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -34,6 +34,8 @@ const (
 	revokeLeaseTimeout = time.Second
 	requestTimeout     = etcdutil.DefaultRequestTimeout
 	slowRequestTime    = etcdutil.DefaultSlowRequestTime
+	// maxLeaseKeepAliveInterval keeps the default 5-second lease renewal cadence as an upper bound.
+	maxLeaseKeepAliveInterval = 5 * time.Second / 3
 )
 
 // Lease is used as the low-level mechanism for campaigning and renewing elected leadership.
@@ -156,7 +158,7 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3)
+	timeCh := l.keepAliveWorker(ctx, getLeaseKeepAliveInterval(l.leaseTimeout))
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -218,6 +220,14 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 			return
 		}
 	}
+}
+
+func getLeaseKeepAliveInterval(leaseTimeout time.Duration) time.Duration {
+	interval := leaseTimeout / 3
+	if interval > maxLeaseKeepAliveInterval {
+		return maxLeaseKeepAliveInterval
+	}
+	return interval
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -122,6 +122,6 @@ func TestLeaseKeepAliveInterval(t *testing.T) {
 	re := require.New(t)
 
 	re.Equal(time.Second/3, getLeaseKeepAliveInterval(time.Second))
-	re.Equal(5*time.Second/3, getLeaseKeepAliveInterval(5*time.Second))
-	re.Equal(5*time.Second/3, getLeaseKeepAliveInterval(300*time.Second))
+	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveInterval(time.Duration(DefaultLeaderLease)*time.Second))
+	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveInterval(300*time.Second))
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -117,3 +117,11 @@ func TestLeaseKeepAlive(t *testing.T) {
 	<-ch
 	re.NoError(lease.Close())
 }
+
+func TestLeaseKeepAliveInterval(t *testing.T) {
+	re := require.New(t)
+
+	re.Equal(time.Second/3, getLeaseKeepAliveInterval(time.Second))
+	re.Equal(5*time.Second/3, getLeaseKeepAliveInterval(5*time.Second))
+	re.Equal(5*time.Second/3, getLeaseKeepAliveInterval(300*time.Second))
+}

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -115,7 +115,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 	ch := lease.keepAliveWorker(ctx)
 	select {
 	case <-ch:
-	case <-time.After(2 * time.Second):
+	case <-time.After(2 * lease.getKeepAliveInterval()):
 		re.Fail("timed out waiting for lease keepalive")
 	}
 	re.NoError(lease.Close())

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -121,15 +121,5 @@ func TestLeaseKeepAlive(t *testing.T) {
 func TestLeaseKeepAliveInterval(t *testing.T) {
 	re := require.New(t)
 
-	re.Equal(time.Second/3, getLeaseKeepAliveInterval(time.Second))
-	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveInterval(time.Duration(DefaultLeaderLease)*time.Second))
-	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveInterval(300*time.Second))
-}
-
-func TestLeaseKeepAliveTimeout(t *testing.T) {
-	re := require.New(t)
-
-	re.Equal(time.Second/3, getLeaseKeepAliveTimeout(time.Second))
-	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveTimeout(time.Duration(DefaultLeaderLease)*time.Second))
-	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveTimeout(300*time.Second))
+	re.Equal(500*time.Millisecond, leaseKeepAliveInterval)
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -115,14 +115,8 @@ func TestLeaseKeepAlive(t *testing.T) {
 	ch := lease.keepAliveWorker(ctx)
 	select {
 	case <-ch:
-	case <-time.After(3 * time.Second):
+	case <-time.After(2 * time.Second):
 		re.Fail("timed out waiting for lease keepalive")
 	}
 	re.NoError(lease.Close())
-}
-
-func TestLeaseKeepAliveInterval(t *testing.T) {
-	re := require.New(t)
-
-	re.Equal(500*time.Millisecond, leaseKeepAliveInterval)
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -112,7 +112,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 	lease := NewLease(client, "test_lease")
 
 	re.NoError(lease.Grant(defaultLeaseTimeout))
-	ch := lease.keepAliveWorker(ctx, 2*time.Second)
+	ch := lease.keepAliveWorker(ctx, 2*time.Second, 2*time.Second)
 	time.Sleep(2 * time.Second)
 	<-ch
 	re.NoError(lease.Close())
@@ -124,4 +124,12 @@ func TestLeaseKeepAliveInterval(t *testing.T) {
 	re.Equal(time.Second/3, getLeaseKeepAliveInterval(time.Second))
 	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveInterval(time.Duration(DefaultLeaderLease)*time.Second))
 	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveInterval(300*time.Second))
+}
+
+func TestLeaseKeepAliveTimeout(t *testing.T) {
+	re := require.New(t)
+
+	re.Equal(time.Second/3, getLeaseKeepAliveTimeout(time.Second))
+	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveTimeout(time.Duration(DefaultLeaderLease)*time.Second))
+	re.Equal(time.Duration(DefaultLeaderLease)*time.Second/3, getLeaseKeepAliveTimeout(300*time.Second))
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -112,9 +112,12 @@ func TestLeaseKeepAlive(t *testing.T) {
 	lease := NewLease(client, "test_lease")
 
 	re.NoError(lease.Grant(defaultLeaseTimeout))
-	ch := lease.keepAliveWorker(ctx, 2*time.Second, 2*time.Second)
-	time.Sleep(2 * time.Second)
-	<-ch
+	ch := lease.keepAliveWorker(ctx)
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		re.Fail("timed out waiting for lease keepalive")
+	}
 	re.NoError(lease.Close())
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/metering_sdk/config"
 
+	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
 	rm "github.com/tikv/pd/pkg/mcs/resourcemanager/server"
 	sc "github.com/tikv/pd/pkg/schedule/config"
@@ -175,7 +176,7 @@ func NewConfig() *Config {
 }
 
 const (
-	defaultLeaderLease             = int64(5)
+	defaultLeaderLease             = election.DefaultLeaderLease
 	defaultCompactionMode          = "periodic"
 	defaultAutoCompactionRetention = "1h"
 	defaultQuotaBackendBytes       = typeutil.ByteSize(8 * units.GiB) // 8GB

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/metering_sdk/config"
 
-	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
 	rm "github.com/tikv/pd/pkg/mcs/resourcemanager/server"
 	sc "github.com/tikv/pd/pkg/schedule/config"
@@ -176,7 +175,7 @@ func NewConfig() *Config {
 }
 
 const (
-	defaultLeaderLease             = election.DefaultLeaderLease
+	defaultLeaderLease             = int64(5)
 	defaultCompactionMode          = "periodic"
 	defaultAutoCompactionRetention = "1h"
 	defaultQuotaBackendBytes       = typeutil.ByteSize(8 * units.GiB) // 8GB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10653

### What is changed and how does it work?

```commit-message
Cap the election lease keepalive interval at 500ms.

PD's election lease renewal previously derived its `KeepAliveOnce` cadence
from `leaseTimeout/3`, so raising the lease TTL also slowed renewal. The
keepalive ticker interval is now `min(leaseTimeout/3, 500ms)`:

- Small leases keep the existing `leaseTimeout/3` behavior, matching etcd's
  built-in `clientv3.KeepAlive` cadence.
- Large leases are capped at 500ms so PD's leader-failover reaction time
  stays sub-second regardless of the configured TTL.

The per-call `KeepAliveOnce` context timeout continues to use the full
`leaseTimeout`, leaving enough RPC budget to absorb etcd tail latency above
the keepalive interval without prematurely cancelling renewals.
```

### Check List

Tests

- Unit test
- Manual test

<img width="2254" height="1266" alt="image" src="https://github.com/user-attachments/assets/b4b9fd3d-d428-44b9-9ddb-ea3163e7a301" />

### Release note

```release-note
Fixed an issue where increasing PD leader lease could also slow down lease keepalive renewal.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capped lease keep-alive renewal cadence at 500ms for more consistent and reliable lease renewals.

* **Tests**
  * Updated keep-alive tests to wait for renewal signals with improved timeout handling to validate the new cadence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10654)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
