### PR TITLE
keyspace: fix max valid keyspace region bound

### DIFF
--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -16,6 +16,7 @@ package keyspace
 
 import (
 	"container/heap"
+	"encoding/binary"
 	"encoding/hex"
 	"regexp"
 	"strconv"
@@ -96,9 +97,11 @@ func MaskKeyspaceID(id uint32) uint32 {
 // For a keyspace with id ['a', 'b', 'c'], it has four boundaries:
 //
 //	Lower bound for raw mode: ['r', 'a', 'b', 'c']
-//	Upper bound for raw mode: next prefix of ['r', 'a', 'b', 'c']
+//	Upper bound for raw mode: next prefix of ['r', 'a', 'b', 'c'].
+//	For non-maximum keyspace IDs, it is ['r', 'a', 'b', 'c + 1'].
 //	Lower bound for txn mode: ['x', 'a', 'b', 'c']
-//	Upper bound for txn mode: next prefix of ['x', 'a', 'b', 'c']
+//	Upper bound for txn mode: next prefix of ['x', 'a', 'b', 'c'].
+//	For non-maximum keyspace IDs, it is ['x', 'a', 'b', 'c + 1'].
 //
 // From which it shares the lower bound with keyspace with id ['a', 'b', 'c-1'].
 // And shares upper bound with keyspace with id ['a', 'b', 'c + 1'].
@@ -113,22 +116,21 @@ type RegionBound struct {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	rawLeftBound := makeKeyspaceModePrefix('r', id)
-	rawRightBound := nextKeyspaceModePrefix(rawLeftBound)
-	txnLeftBound := makeKeyspaceModePrefix('x', id)
-	txnRightBound := nextKeyspaceModePrefix(txnLeftBound)
+	keyspaceIDBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(keyspaceIDBytes, id)
+	rawLeftBound := append([]byte{'r'}, keyspaceIDBytes[1:]...)
+	txnLeftBound := append([]byte{'x'}, keyspaceIDBytes[1:]...)
 	return &RegionBound{
 		RawLeftBound:  codec.EncodeBytes(rawLeftBound),
-		RawRightBound: codec.EncodeBytes(rawRightBound),
+		RawRightBound: codec.EncodeBytes(nextKeyspaceModePrefix(rawLeftBound)),
 		TxnLeftBound:  codec.EncodeBytes(txnLeftBound),
-		TxnRightBound: codec.EncodeBytes(txnRightBound),
+		TxnRightBound: codec.EncodeBytes(nextKeyspaceModePrefix(txnLeftBound)),
 	}
 }
 
-func makeKeyspaceModePrefix(mode byte, id uint32) []byte {
-	return []byte{mode, byte(id >> 16), byte(id >> 8), byte(id)}
-}
-
+// nextKeyspaceModePrefix returns the exclusive upper bound of a mode-prefixed
+// keyspace prefix. It carries into the mode byte for the max keyspace ID instead
+// of wrapping the low 24 bits back to zero under the same mode.
 func nextKeyspaceModePrefix(prefix []byte) []byte {
 	next := append([]byte(nil), prefix...)
 	for i := len(next) - 1; i >= 0; i-- {

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -16,7 +16,6 @@ package keyspace
 
 import (
 	"container/heap"
-	"encoding/binary"
 	"encoding/hex"
 	"regexp"
 	"strconv"
@@ -97,9 +96,9 @@ func MaskKeyspaceID(id uint32) uint32 {
 // For a keyspace with id ['a', 'b', 'c'], it has four boundaries:
 //
 //	Lower bound for raw mode: ['r', 'a', 'b', 'c']
-//	Upper bound for raw mode: ['r', 'a', 'b', 'c + 1']
+//	Upper bound for raw mode: next prefix of ['r', 'a', 'b', 'c']
 //	Lower bound for txn mode: ['x', 'a', 'b', 'c']
-//	Upper bound for txn mode: ['x', 'a', 'b', 'c + 1']
+//	Upper bound for txn mode: next prefix of ['x', 'a', 'b', 'c']
 //
 // From which it shares the lower bound with keyspace with id ['a', 'b', 'c-1'].
 // And shares upper bound with keyspace with id ['a', 'b', 'c + 1'].
@@ -114,16 +113,33 @@ type RegionBound struct {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	keyspaceIDBytes := make([]byte, 4)
-	nextKeyspaceIDBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(keyspaceIDBytes, id)
-	binary.BigEndian.PutUint32(nextKeyspaceIDBytes, id+1)
+	rawLeftBound := makeKeyspaceModePrefix('r', id)
+	rawRightBound := nextKeyspaceModePrefix(rawLeftBound)
+	txnLeftBound := makeKeyspaceModePrefix('x', id)
+	txnRightBound := nextKeyspaceModePrefix(txnLeftBound)
 	return &RegionBound{
-		RawLeftBound:  codec.EncodeBytes(append([]byte{'r'}, keyspaceIDBytes[1:]...)),
-		RawRightBound: codec.EncodeBytes(append([]byte{'r'}, nextKeyspaceIDBytes[1:]...)),
-		TxnLeftBound:  codec.EncodeBytes(append([]byte{'x'}, keyspaceIDBytes[1:]...)),
-		TxnRightBound: codec.EncodeBytes(append([]byte{'x'}, nextKeyspaceIDBytes[1:]...)),
+		RawLeftBound:  codec.EncodeBytes(rawLeftBound),
+		RawRightBound: codec.EncodeBytes(rawRightBound),
+		TxnLeftBound:  codec.EncodeBytes(txnLeftBound),
+		TxnRightBound: codec.EncodeBytes(txnRightBound),
 	}
+}
+
+func makeKeyspaceModePrefix(mode byte, id uint32) []byte {
+	return []byte{mode, byte(id >> 16), byte(id >> 8), byte(id)}
+}
+
+func nextKeyspaceModePrefix(prefix []byte) []byte {
+	next := append([]byte(nil), prefix...)
+	for i := len(next) - 1; i >= 0; i-- {
+		if next[i] == 0xff {
+			next[i] = 0
+			continue
+		}
+		next[i]++
+		return next
+	}
+	return nil
 }
 
 // MakeKeyRanges encodes keyspace ID to correct LabelRule data.

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -97,11 +97,9 @@ func MaskKeyspaceID(id uint32) uint32 {
 // For a keyspace with id ['a', 'b', 'c'], it has four boundaries:
 //
 //	Lower bound for raw mode: ['r', 'a', 'b', 'c']
-//	Upper bound for raw mode: next prefix of ['r', 'a', 'b', 'c'].
-//	For non-maximum keyspace IDs, it is ['r', 'a', 'b', 'c + 1'].
+//	Upper bound for raw mode: ['r', 'a', 'b', 'c + 1']
 //	Lower bound for txn mode: ['x', 'a', 'b', 'c']
-//	Upper bound for txn mode: next prefix of ['x', 'a', 'b', 'c'].
-//	For non-maximum keyspace IDs, it is ['x', 'a', 'b', 'c + 1'].
+//	Upper bound for txn mode: ['x', 'a', 'b', 'c + 1']
 //
 // From which it shares the lower bound with keyspace with id ['a', 'b', 'c-1'].
 // And shares upper bound with keyspace with id ['a', 'b', 'c + 1'].
@@ -117,31 +115,22 @@ type RegionBound struct {
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
 	keyspaceIDBytes := make([]byte, 4)
+	nextKeyspaceIDBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(keyspaceIDBytes, id)
-	rawLeftBound := append([]byte{'r'}, keyspaceIDBytes[1:]...)
-	txnLeftBound := append([]byte{'x'}, keyspaceIDBytes[1:]...)
+	binary.BigEndian.PutUint32(nextKeyspaceIDBytes, id+1)
+	rawRightBound := append([]byte{'r'}, nextKeyspaceIDBytes[1:]...)
+	txnRightBound := append([]byte{'x'}, nextKeyspaceIDBytes[1:]...)
+	if id == constant.MaxValidKeyspaceID {
+		// The right bound is an exclusive fencepost, not a real keyspace prefix.
+		rawRightBound = []byte{'s', 0, 0, 0}
+		txnRightBound = []byte{'y', 0, 0, 0}
+	}
 	return &RegionBound{
-		RawLeftBound:  codec.EncodeBytes(rawLeftBound),
-		RawRightBound: codec.EncodeBytes(nextKeyspaceModePrefix(rawLeftBound)),
-		TxnLeftBound:  codec.EncodeBytes(txnLeftBound),
-		TxnRightBound: codec.EncodeBytes(nextKeyspaceModePrefix(txnLeftBound)),
+		RawLeftBound:  codec.EncodeBytes(append([]byte{'r'}, keyspaceIDBytes[1:]...)),
+		RawRightBound: codec.EncodeBytes(rawRightBound),
+		TxnLeftBound:  codec.EncodeBytes(append([]byte{'x'}, keyspaceIDBytes[1:]...)),
+		TxnRightBound: codec.EncodeBytes(txnRightBound),
 	}
-}
-
-// nextKeyspaceModePrefix returns the exclusive upper bound of a mode-prefixed
-// keyspace prefix. It carries into the mode byte for the max keyspace ID instead
-// of wrapping the low 24 bits back to zero under the same mode.
-func nextKeyspaceModePrefix(prefix []byte) []byte {
-	next := append([]byte(nil), prefix...)
-	for i := len(next) - 1; i >= 0; i-- {
-		if next[i] == 0xff {
-			next[i] = 0
-			continue
-		}
-		next[i]++
-		return next
-	}
-	return nil
 }
 
 // MakeKeyRanges encodes keyspace ID to correct LabelRule data.

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -41,6 +41,15 @@ const (
 	namePattern = "^[-A-Za-z0-9_]{1,20}$"
 )
 
+const (
+	// RawKeyspaceModePrefix is the raw keyspace prefix mode byte.
+	RawKeyspaceModePrefix = byte('r')
+	// TxnKeyspaceModePrefix is the txn keyspace prefix mode byte.
+	TxnKeyspaceModePrefix = byte('x')
+	// KeyspacePrefixLen is the encoded keyspace prefix length.
+	KeyspacePrefixLen = 4
+)
+
 var (
 	// stateTransitionTable lists all allowed next state for the given current state.
 	// Note that transit from any state to itself is allowed for idempotence.
@@ -93,6 +102,30 @@ func MaskKeyspaceID(id uint32) uint32 {
 	return id & 0xFF
 }
 
+// MakeKeyspacePrefix constructs the raw keyspace prefix for the given mode and keyspace ID.
+// Keyspace keys encode the lower 24 bits of the keyspace ID after the mode byte.
+func MakeKeyspacePrefix(mode byte, id uint32) []byte {
+	prefix := make([]byte, KeyspacePrefixLen)
+	binary.BigEndian.PutUint32(prefix, id)
+	prefix[0] = mode
+	return prefix
+}
+
+// ParseKeyspacePrefix parses a raw keyspace prefix from key.
+// It returns false for keys that do not start with a known keyspace mode byte.
+func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
+	if len(key) < KeyspacePrefixLen {
+		return 0, 0, false
+	}
+	mode = key[0]
+	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
+		return 0, 0, false
+	}
+	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
+	id = binary.BigEndian.Uint32(idBytes[:])
+	return mode, id, true
+}
+
 // RegionBound represents the region boundary of the given keyspace.
 // For a keyspace with id ['a', 'b', 'c'], it has four boundaries:
 //
@@ -115,21 +148,17 @@ type RegionBound struct {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	keyspaceIDBytes := make([]byte, 4)
-	nextKeyspaceIDBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(keyspaceIDBytes, id)
-	binary.BigEndian.PutUint32(nextKeyspaceIDBytes, id+1)
-	rawRightBound := append([]byte{'r'}, nextKeyspaceIDBytes[1:]...)
-	txnRightBound := append([]byte{'x'}, nextKeyspaceIDBytes[1:]...)
+	rawRightBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id+1)
+	txnRightBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id+1)
 	if id == constant.MaxValidKeyspaceID {
 		// The right bound is an exclusive fencepost, not a real keyspace prefix.
 		rawRightBound = []byte{'s', 0, 0, 0}
 		txnRightBound = []byte{'y', 0, 0, 0}
 	}
 	return &RegionBound{
-		RawLeftBound:  codec.EncodeBytes(append([]byte{'r'}, keyspaceIDBytes[1:]...)),
+		RawLeftBound:  codec.EncodeBytes(MakeKeyspacePrefix(RawKeyspaceModePrefix, id)),
 		RawRightBound: codec.EncodeBytes(rawRightBound),
-		TxnLeftBound:  codec.EncodeBytes(append([]byte{'x'}, keyspaceIDBytes[1:]...)),
+		TxnLeftBound:  codec.EncodeBytes(MakeKeyspacePrefix(TxnKeyspaceModePrefix, id)),
 		TxnRightBound: codec.EncodeBytes(txnRightBound),
 	}
 }

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -133,7 +133,9 @@ type RegionBound struct {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
+	rawLeftBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id)
 	rawRightBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id+1)
+	txnLeftBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id)
 	txnRightBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id+1)
 	if id == constant.MaxValidKeyspaceID {
 		// The right bound is an exclusive fencepost, not a real keyspace prefix.
@@ -141,9 +143,9 @@ func MakeRegionBound(id uint32) *RegionBound {
 		txnRightBound = []byte{'y', 0, 0, 0}
 	}
 	return &RegionBound{
-		RawLeftBound:  codec.EncodeBytes(MakeKeyspacePrefix(RawKeyspaceModePrefix, id)),
+		RawLeftBound:  codec.EncodeBytes(rawLeftBound),
 		RawRightBound: codec.EncodeBytes(rawRightBound),
-		TxnLeftBound:  codec.EncodeBytes(MakeKeyspacePrefix(TxnKeyspaceModePrefix, id)),
+		TxnLeftBound:  codec.EncodeBytes(txnLeftBound),
 		TxnRightBound: codec.EncodeBytes(txnRightBound),
 	}
 }

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -46,7 +46,7 @@ const (
 	RawKeyspaceModePrefix = byte('r')
 	// TxnKeyspaceModePrefix is the txn keyspace prefix mode byte.
 	TxnKeyspaceModePrefix = byte('x')
-	// KeyspacePrefixLen is the encoded keyspace prefix length.
+	// KeyspacePrefixLen is the raw keyspace prefix length before memcomparable encoding.
 	KeyspacePrefixLen = 4
 )
 

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -111,21 +111,6 @@ func MakeKeyspacePrefix(mode byte, id uint32) []byte {
 	return prefix
 }
 
-// ParseKeyspacePrefix parses a raw keyspace prefix from key.
-// It returns false for keys that do not start with a known keyspace mode byte.
-func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
-	if len(key) < KeyspacePrefixLen {
-		return 0, 0, false
-	}
-	mode = key[0]
-	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
-		return 0, 0, false
-	}
-	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
-	id = binary.BigEndian.Uint32(idBytes[:])
-	return mode, id, true
-}
-
 // RegionBound represents the region boundary of the given keyspace.
 // For a keyspace with id ['a', 'b', 'c'], it has four boundaries:
 //

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -100,6 +100,7 @@ func MaskKeyspaceID(id uint32) uint32 {
 //	Upper bound for raw mode: ['r', 'a', 'b', 'c + 1']
 //	Lower bound for txn mode: ['x', 'a', 'b', 'c']
 //	Upper bound for txn mode: ['x', 'a', 'b', 'c + 1']
+//	For the max valid keyspace ID, the upper bound advances the mode byte as an exclusive fencepost.
 //
 // From which it shares the lower bound with keyspace with id ['a', 'b', 'c-1'].
 // And shares upper bound with keyspace with id ['a', 'b', 'c + 1'].

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -84,6 +84,46 @@ func TestMakeRegionBound(t *testing.T) {
 	re.Equal(encodeKey([]byte{'y', 0x00, 0x00, 0x00}), maxRegionBound.TxnRightBound)
 }
 
+func TestKeyspacePrefix(t *testing.T) {
+	re := require.New(t)
+
+	testCases := []struct {
+		name       string
+		mode       byte
+		id         uint32
+		wantPrefix []byte
+	}{
+		{
+			name:       "raw",
+			mode:       RawKeyspaceModePrefix,
+			id:         0x010203,
+			wantPrefix: []byte{'r', 0x01, 0x02, 0x03},
+		},
+		{
+			name:       "txn",
+			mode:       TxnKeyspaceModePrefix,
+			id:         constant.MaxValidKeyspaceID,
+			wantPrefix: []byte{'x', 0xff, 0xff, 0xff},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(_ *testing.T) {
+			prefix := MakeKeyspacePrefix(testCase.mode, testCase.id)
+			re.Equal(testCase.wantPrefix, prefix)
+			mode, id, ok := ParseKeyspacePrefix(prefix)
+			re.True(ok)
+			re.Equal(testCase.mode, mode)
+			re.Equal(testCase.id, id)
+		})
+	}
+
+	_, _, ok := ParseKeyspacePrefix([]byte{'x', 0x01, 0x02})
+	re.False(ok)
+	_, _, ok = ParseKeyspacePrefix([]byte{'t', 0x01, 0x02, 0x03})
+	re.False(ok)
+}
+
 func TestValidateName(t *testing.T) {
 	re := require.New(t)
 	testCases := []struct {

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -61,6 +61,25 @@ func TestValidateID(t *testing.T) {
 	}
 }
 
+func TestMakeRegionBound(t *testing.T) {
+	re := require.New(t)
+	encodeKey := func(key []byte) []byte {
+		return []byte(codec.EncodeBytes(key))
+	}
+
+	regionBound := MakeRegionBound(0x010203)
+	re.Equal(encodeKey([]byte{'r', 0x01, 0x02, 0x03}), regionBound.RawLeftBound)
+	re.Equal(encodeKey([]byte{'r', 0x01, 0x02, 0x04}), regionBound.RawRightBound)
+	re.Equal(encodeKey([]byte{'x', 0x01, 0x02, 0x03}), regionBound.TxnLeftBound)
+	re.Equal(encodeKey([]byte{'x', 0x01, 0x02, 0x04}), regionBound.TxnRightBound)
+
+	maxRegionBound := MakeRegionBound(constant.MaxValidKeyspaceID)
+	re.Equal(encodeKey([]byte{'r', 0xff, 0xff, 0xff}), maxRegionBound.RawLeftBound)
+	re.Equal(encodeKey([]byte{'s', 0x00, 0x00, 0x00}), maxRegionBound.RawRightBound)
+	re.Equal(encodeKey([]byte{'x', 0xff, 0xff, 0xff}), maxRegionBound.TxnLeftBound)
+	re.Equal(encodeKey([]byte{'y', 0x00, 0x00, 0x00}), maxRegionBound.TxnRightBound)
+}
+
 func TestValidateName(t *testing.T) {
 	re := require.New(t)
 	testCases := []struct {

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -15,9 +15,11 @@
 package keyspace
 
 import (
+	"context"
 	"encoding/hex"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -26,6 +28,8 @@ import (
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
 
@@ -112,6 +116,28 @@ func TestMakeKeyspacePrefix(t *testing.T) {
 			re.Equal(testCase.wantPrefix, MakeKeyspacePrefix(testCase.mode, testCase.id))
 		})
 	}
+}
+
+func TestMaxKeyspaceLabelRuleSplitKeys(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	regionLabeler, err := labeler.NewRegionLabeler(ctx, endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil), time.Hour)
+	re.NoError(err)
+
+	re.NoError(regionLabeler.SetLabelRule(MakeLabelRule(constant.MaxValidKeyspaceID)))
+	encodeKey := func(key []byte) []byte {
+		return []byte(codec.EncodeBytes(key))
+	}
+	re.Equal(
+		[][]byte{
+			encodeKey([]byte{'r', 0xff, 0xff, 0xff}),
+			encodeKey([]byte{'s', 0x00, 0x00, 0x00}),
+			encodeKey([]byte{'x', 0xff, 0xff, 0xff}),
+			encodeKey([]byte{'y', 0x00, 0x00, 0x00}),
+		},
+		regionLabeler.GetSplitKeys(nil, nil),
+	)
 }
 
 func TestValidateName(t *testing.T) {

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -73,6 +73,10 @@ func TestMakeRegionBound(t *testing.T) {
 	re.Equal(encodeKey([]byte{'x', 0x01, 0x02, 0x03}), regionBound.TxnLeftBound)
 	re.Equal(encodeKey([]byte{'x', 0x01, 0x02, 0x04}), regionBound.TxnRightBound)
 
+	carryRegionBound := MakeRegionBound(0x0102ff)
+	re.Equal(encodeKey([]byte{'r', 0x01, 0x03, 0x00}), carryRegionBound.RawRightBound)
+	re.Equal(encodeKey([]byte{'x', 0x01, 0x03, 0x00}), carryRegionBound.TxnRightBound)
+
 	maxRegionBound := MakeRegionBound(constant.MaxValidKeyspaceID)
 	re.Equal(encodeKey([]byte{'r', 0xff, 0xff, 0xff}), maxRegionBound.RawLeftBound)
 	re.Equal(encodeKey([]byte{'s', 0x00, 0x00, 0x00}), maxRegionBound.RawRightBound)

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -84,7 +84,7 @@ func TestMakeRegionBound(t *testing.T) {
 	re.Equal(encodeKey([]byte{'y', 0x00, 0x00, 0x00}), maxRegionBound.TxnRightBound)
 }
 
-func TestKeyspacePrefix(t *testing.T) {
+func TestMakeKeyspacePrefix(t *testing.T) {
 	re := require.New(t)
 
 	testCases := []struct {
@@ -109,19 +109,9 @@ func TestKeyspacePrefix(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(_ *testing.T) {
-			prefix := MakeKeyspacePrefix(testCase.mode, testCase.id)
-			re.Equal(testCase.wantPrefix, prefix)
-			mode, id, ok := ParseKeyspacePrefix(prefix)
-			re.True(ok)
-			re.Equal(testCase.mode, mode)
-			re.Equal(testCase.id, id)
+			re.Equal(testCase.wantPrefix, MakeKeyspacePrefix(testCase.mode, testCase.id))
 		})
 	}
-
-	_, _, ok := ParseKeyspacePrefix([]byte{'x', 0x01, 0x02})
-	re.False(ok)
-	_, _, ok = ParseKeyspacePrefix([]byte{'t', 0x01, 0x02, 0x03})
-	re.False(ok)
 }
 
 func TestValidateName(t *testing.T) {

--- a/tools/pd-ctl/pdctl/command/keyspace_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command_test.go
@@ -15,7 +15,6 @@
 package command
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,10 +32,10 @@ func TestMakeKeyRanges(t *testing.T) {
 		goldenTxnStart string
 		goldenTxnEnd   string
 	}{
-		{keyspaceID: 0},
-		{keyspaceID: 1},
-		{keyspaceID: 10},
-		{keyspaceID: 100},
+		{0, "7200000000000000fb", "7200000100000000fb", "7800000000000000fb", "7800000100000000fb"},
+		{1, "7200000100000000fb", "7200000200000000fb", "7800000100000000fb", "7800000200000000fb"},
+		{10, "7200000a00000000fb", "7200000b00000000fb", "7800000a00000000fb", "7800000b00000000fb"},
+		{100, "7200006400000000fb", "7200006500000000fb", "7800006400000000fb", "7800006500000000fb"},
 		{
 			keyspaceID:     16777215, // max valid keyspace ID (2^24 - 1)
 			goldenRawStart: "72ffffff00000000fb",
@@ -64,16 +63,9 @@ func TestMakeKeyRanges(t *testing.T) {
 		re.NotEmpty(txnStart)
 		re.NotEmpty(txnEnd)
 
-		regionBound := keyspace.MakeRegionBound(tc.keyspaceID)
-		re.Equal(hex.EncodeToString(regionBound.RawLeftBound), rawStart)
-		re.Equal(hex.EncodeToString(regionBound.RawRightBound), rawEnd)
-		re.Equal(hex.EncodeToString(regionBound.TxnLeftBound), txnStart)
-		re.Equal(hex.EncodeToString(regionBound.TxnRightBound), txnEnd)
-		if tc.goldenRawStart != "" {
-			re.Equal(tc.goldenRawStart, rawStart)
-			re.Equal(tc.goldenRawEnd, rawEnd)
-			re.Equal(tc.goldenTxnStart, txnStart)
-			re.Equal(tc.goldenTxnEnd, txnEnd)
-		}
+		re.Equal(tc.goldenRawStart, rawStart)
+		re.Equal(tc.goldenRawEnd, rawEnd)
+		re.Equal(tc.goldenTxnStart, txnStart)
+		re.Equal(tc.goldenTxnEnd, txnEnd)
 	}
 }

--- a/tools/pd-ctl/pdctl/command/keyspace_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command_test.go
@@ -27,22 +27,22 @@ func TestMakeKeyRanges(t *testing.T) {
 	re := require.New(t)
 
 	testCases := []struct {
-		keyspaceID     uint32
-		goldenRawStart string
-		goldenRawEnd   string
-		goldenTxnStart string
-		goldenTxnEnd   string
+		keyspaceID       uint32
+		expectedRawStart string
+		expectedRawEnd   string
+		expectedTxnStart string
+		expectedTxnEnd   string
 	}{
 		{0, "7200000000000000fb", "7200000100000000fb", "7800000000000000fb", "7800000100000000fb"},
 		{1, "7200000100000000fb", "7200000200000000fb", "7800000100000000fb", "7800000200000000fb"},
 		{10, "7200000a00000000fb", "7200000b00000000fb", "7800000a00000000fb", "7800000b00000000fb"},
 		{100, "7200006400000000fb", "7200006500000000fb", "7800006400000000fb", "7800006500000000fb"},
 		{
-			keyspaceID:     constant.MaxValidKeyspaceID,
-			goldenRawStart: "72ffffff00000000fb",
-			goldenRawEnd:   "7300000000000000fb",
-			goldenTxnStart: "78ffffff00000000fb",
-			goldenTxnEnd:   "7900000000000000fb",
+			keyspaceID:       constant.MaxValidKeyspaceID,
+			expectedRawStart: "72ffffff00000000fb",
+			expectedRawEnd:   "7300000000000000fb",
+			expectedTxnStart: "78ffffff00000000fb",
+			expectedTxnEnd:   "7900000000000000fb",
 		},
 	}
 
@@ -64,9 +64,9 @@ func TestMakeKeyRanges(t *testing.T) {
 		re.NotEmpty(txnStart)
 		re.NotEmpty(txnEnd)
 
-		re.Equal(tc.goldenRawStart, rawStart)
-		re.Equal(tc.goldenRawEnd, rawEnd)
-		re.Equal(tc.goldenTxnStart, txnStart)
-		re.Equal(tc.goldenTxnEnd, txnEnd)
+		re.Equal(tc.expectedRawStart, rawStart)
+		re.Equal(tc.expectedRawEnd, rawEnd)
+		re.Equal(tc.expectedTxnStart, txnStart)
+		re.Equal(tc.expectedTxnEnd, txnEnd)
 	}
 }

--- a/tools/pd-ctl/pdctl/command/keyspace_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/pkg/keyspace/constant"
 )
 
 func TestMakeKeyRanges(t *testing.T) {
@@ -37,7 +38,7 @@ func TestMakeKeyRanges(t *testing.T) {
 		{10, "7200000a00000000fb", "7200000b00000000fb", "7800000a00000000fb", "7800000b00000000fb"},
 		{100, "7200006400000000fb", "7200006500000000fb", "7800006400000000fb", "7800006500000000fb"},
 		{
-			keyspaceID:     16777215, // max valid keyspace ID (2^24 - 1)
+			keyspaceID:     constant.MaxValidKeyspaceID,
 			goldenRawStart: "72ffffff00000000fb",
 			goldenRawEnd:   "7300000000000000fb",
 			goldenTxnStart: "78ffffff00000000fb",

--- a/tools/pd-ctl/pdctl/command/keyspace_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command_test.go
@@ -15,13 +15,11 @@
 package command
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/keyspace"
 )
 
@@ -29,13 +27,23 @@ func TestMakeKeyRanges(t *testing.T) {
 	re := require.New(t)
 
 	testCases := []struct {
-		keyspaceID uint32
+		keyspaceID     uint32
+		goldenRawStart string
+		goldenRawEnd   string
+		goldenTxnStart string
+		goldenTxnEnd   string
 	}{
 		{keyspaceID: 0},
 		{keyspaceID: 1},
 		{keyspaceID: 10},
 		{keyspaceID: 100},
-		{keyspaceID: 16777215}, // max valid keyspace ID (2^24 - 1)
+		{
+			keyspaceID:     16777215, // max valid keyspace ID (2^24 - 1)
+			goldenRawStart: "72ffffff00000000fb",
+			goldenRawEnd:   "7300000000000000fb",
+			goldenTxnStart: "78ffffff00000000fb",
+			goldenTxnEnd:   "7900000000000000fb",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -56,20 +64,16 @@ func TestMakeKeyRanges(t *testing.T) {
 		re.NotEmpty(txnStart)
 		re.NotEmpty(txnEnd)
 
-		// Verify the encoding matches the expected format
-		keyspaceIDBytes := make([]byte, 4)
-		nextKeyspaceIDBytes := make([]byte, 4)
-		binary.BigEndian.PutUint32(keyspaceIDBytes, tc.keyspaceID)
-		binary.BigEndian.PutUint32(nextKeyspaceIDBytes, tc.keyspaceID+1)
-
-		expectedRawLeft := codec.EncodeBytes(append([]byte{'r'}, keyspaceIDBytes[1:]...))
-		expectedRawRight := codec.EncodeBytes(append([]byte{'r'}, nextKeyspaceIDBytes[1:]...))
-		expectedTxnLeft := codec.EncodeBytes(append([]byte{'x'}, keyspaceIDBytes[1:]...))
-		expectedTxnRight := codec.EncodeBytes(append([]byte{'x'}, nextKeyspaceIDBytes[1:]...))
-
-		re.Equal(hex.EncodeToString(expectedRawLeft), rawStart)
-		re.Equal(hex.EncodeToString(expectedRawRight), rawEnd)
-		re.Equal(hex.EncodeToString(expectedTxnLeft), txnStart)
-		re.Equal(hex.EncodeToString(expectedTxnRight), txnEnd)
+		regionBound := keyspace.MakeRegionBound(tc.keyspaceID)
+		re.Equal(hex.EncodeToString(regionBound.RawLeftBound), rawStart)
+		re.Equal(hex.EncodeToString(regionBound.RawRightBound), rawEnd)
+		re.Equal(hex.EncodeToString(regionBound.TxnLeftBound), txnStart)
+		re.Equal(hex.EncodeToString(regionBound.TxnRightBound), txnEnd)
+		if tc.goldenRawStart != "" {
+			re.Equal(tc.goldenRawStart, rawStart)
+			re.Equal(tc.goldenRawEnd, rawEnd)
+			re.Equal(tc.goldenTxnStart, txnStart)
+			re.Equal(tc.goldenTxnEnd, txnEnd)
+		}
 	}
 }

--- a/tools/pd-ctl/pdctl/command/keyspace_command_test.go
+++ b/tools/pd-ctl/pdctl/command/keyspace_command_test.go
@@ -33,10 +33,34 @@ func TestMakeKeyRanges(t *testing.T) {
 		expectedTxnStart string
 		expectedTxnEnd   string
 	}{
-		{0, "7200000000000000fb", "7200000100000000fb", "7800000000000000fb", "7800000100000000fb"},
-		{1, "7200000100000000fb", "7200000200000000fb", "7800000100000000fb", "7800000200000000fb"},
-		{10, "7200000a00000000fb", "7200000b00000000fb", "7800000a00000000fb", "7800000b00000000fb"},
-		{100, "7200006400000000fb", "7200006500000000fb", "7800006400000000fb", "7800006500000000fb"},
+		{
+			keyspaceID:       0,
+			expectedRawStart: "7200000000000000fb",
+			expectedRawEnd:   "7200000100000000fb",
+			expectedTxnStart: "7800000000000000fb",
+			expectedTxnEnd:   "7800000100000000fb",
+		},
+		{
+			keyspaceID:       1,
+			expectedRawStart: "7200000100000000fb",
+			expectedRawEnd:   "7200000200000000fb",
+			expectedTxnStart: "7800000100000000fb",
+			expectedTxnEnd:   "7800000200000000fb",
+		},
+		{
+			keyspaceID:       10,
+			expectedRawStart: "7200000a00000000fb",
+			expectedRawEnd:   "7200000b00000000fb",
+			expectedTxnStart: "7800000a00000000fb",
+			expectedTxnEnd:   "7800000b00000000fb",
+		},
+		{
+			keyspaceID:       100,
+			expectedRawStart: "7200006400000000fb",
+			expectedRawEnd:   "7200006500000000fb",
+			expectedTxnStart: "7800006400000000fb",
+			expectedTxnEnd:   "7800006500000000fb",
+		},
 		{
 			keyspaceID:       constant.MaxValidKeyspaceID,
 			expectedRawStart: "72ffffff00000000fb",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10664 ref #10592

`MakeRegionBound` used `id + 1` to build the upper bound. For the max valid keyspace ID, the low 24 bits wrap to zero, so the generated upper bound becomes `r/x 00 00 00` instead of the next prefix after `r/x ff ff ff`.

### What is changed and how does it work?

```commit-message
Fix keyspace region-bound generation to use the next prefix of the current mode-prefixed keyspace ID.

This keeps ordinary keyspace bounds unchanged and gives the max valid keyspace ID a non-wrapping upper bound for both raw and txn modes.
```

### Check List

Tests

- Unit test

Test commands:

```bash
go test ./pkg/keyspace -run TestMakeRegionBound -count=1
(cd tools && go test ./pd-ctl/pdctl/command -run TestMakeKeyRanges -count=1)
```

### Release note

```release-note
Fix incorrect keyspace range encoding for the max valid keyspace ID.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved region-bound computation to ensure correct exclusive upper-bound semantics across edge cases, including the maximum keyspace value.

* **Tests**
  * Added unit tests validating region/range boundary encodings, including carry/overflow edge cases and the maximum keyspace value.
  * Converted an existing test to table-driven golden cases for raw and transactional ranges.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10665)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10665)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->