### PR TITLE
syncer: trigger full sync on history gap

### DIFF
--- a/pkg/mcs/router/server/sync.go
+++ b/pkg/mcs/router/server/sync.go
@@ -281,6 +281,8 @@ func (s *RegionSyncer) sync(ctx context.Context, leaderAddr string) {
 			continue
 		}
 		log.Info("server starts to synchronize with leader", zap.String("server", s.name), zap.String("leader", leaderAddr), zap.Uint64("request-index", s.nextSyncIndex))
+		syncingHistory := true
+		fullSyncing := false
 		for {
 			resp, err := stream.Recv()
 			failpoint.Inject("syncMetError", func() {
@@ -309,6 +311,10 @@ func (s *RegionSyncer) sync(ctx context.Context, leaderAddr string) {
 				log.Warn("server broken the connection, it needs to reconnect again", zap.String("error-message", e.GetMessage()))
 				s.triggerMembershipCheck()
 				return
+			}
+			if syncingHistory && resp.GetStartIndex() == 0 && s.nextSyncIndex != 0 {
+				bc.ResetRegionCache()
+				fullSyncing = true
 			}
 			// client maybe loss some region info, need to reset the nextSyncIndex
 			if s.nextSyncIndex != resp.GetStartIndex() {
@@ -352,6 +358,12 @@ func (s *RegionSyncer) sync(ctx context.Context, leaderAddr string) {
 					lastIndexGauge.Set(float64(s.nextSyncIndex))
 					s.nextSyncIndex++
 				}
+			}
+			if fullSyncing && len(regions) == 0 {
+				fullSyncing = false
+				syncingHistory = false
+			} else if syncingHistory && !fullSyncing {
+				syncingHistory = false
 			}
 		}
 	}

--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -85,14 +85,50 @@ func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (C
 
 var regionGuide = core.GenerateRegionGuideFunc(false)
 
-func (s *RegionSyncer) handleRegionSyncResponse(ctx context.Context, resp *pdpb.SyncRegionResponse, bc *core.BasicCluster, regionStorage storage.Storage) bool {
+type regionSyncState struct {
+	syncingHistory bool
+	fullSyncing    bool
+}
+
+func (*RegionSyncer) resetRegionCacheAndStorage(ctx context.Context, bc *core.BasicCluster, regionStorage storage.Storage) error {
+	if err := regionStorage.Flush(); err != nil {
+		return err
+	}
+	for _, region := range bc.GetRegions() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if err := regionStorage.DeleteRegion(region.GetMeta()); err != nil {
+			return err
+		}
+	}
+	bc.ResetRegionCache()
+	return nil
+}
+
+func (s *RegionSyncer) handleRegionSyncResponse(
+	ctx context.Context,
+	resp *pdpb.SyncRegionResponse,
+	bc *core.BasicCluster,
+	regionStorage storage.Storage,
+	state *regionSyncState,
+) (bool, error) {
 	if syncErr := resp.GetHeader().GetError(); syncErr != nil {
 		s.streamingRunning.Store(false)
 		log.Warn("region sync with leader received error response",
 			zap.String("server", s.server.Name()),
 			zap.String("error-type", syncErr.GetType().String()),
 			zap.String("error-message", syncErr.GetMessage()))
-		return false
+		return false, nil
+	}
+	if state.syncingHistory && resp.GetStartIndex() == 0 && s.history.getNextIndex() != 0 {
+		s.streamingRunning.Store(false)
+		if err := s.resetRegionCacheAndStorage(ctx, bc, regionStorage); err != nil {
+			return true, err
+		}
+		state.fullSyncing = true
 	}
 	if s.history.getNextIndex() != resp.GetStartIndex() {
 		log.Warn("server sync index not match the leader",
@@ -154,9 +190,20 @@ func (s *RegionSyncer) handleRegionSyncResponse(ctx context.Context, resp *pdpb.
 			_ = regionStorage.DeleteRegion(old.GetMeta())
 		}
 	}
+	if state.fullSyncing && len(regions) == 0 {
+		if err := regionStorage.Flush(); err != nil {
+			return true, err
+		}
+		state.fullSyncing = false
+		state.syncingHistory = false
+	} else if state.syncingHistory && !state.fullSyncing {
+		state.syncingHistory = false
+	}
 	// mark the client as running status when it finished the first history region sync.
-	s.streamingRunning.Store(true)
-	return true
+	if !state.fullSyncing {
+		s.streamingRunning.Store(true)
+	}
+	return true, nil
 }
 
 // IsRunning returns whether the region syncer client is running.
@@ -242,6 +289,7 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 				continue
 			}
 			log.Info("server starts to synchronize with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), zap.Uint64("request-index", s.history.getNextIndex()))
+			syncState := &regionSyncState{syncingHistory: true}
 			for {
 				resp, err := stream.Recv()
 				if err == io.EOF {
@@ -259,7 +307,18 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					}
 					break
 				}
-				if !s.handleRegionSyncResponse(ctx, resp, bc, regionStorage) {
+				handled, err := s.handleRegionSyncResponse(ctx, resp, bc, regionStorage, syncState)
+				if err != nil {
+					log.Warn("failed to handle region sync response",
+						zap.String("server", s.server.Name()),
+						zap.String("leader", s.server.GetLeader().GetName()),
+						errs.ZapError(err))
+					if err = stream.CloseSend(); err != nil {
+						log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
+					}
+					break
+				}
+				if !handled {
 					if err = stream.CloseSend(); err != nil {
 						log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
 					}

--- a/pkg/syncer/client_test.go
+++ b/pkg/syncer/client_test.go
@@ -213,17 +213,21 @@ func TestHandleFullSyncResponseResetsStaleRegions(t *testing.T) {
 			Version: 2,
 		},
 	}
-	re.NoError(rc.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+	handled, err := rc.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 		StartIndex: 0,
 		Regions:    []*metapb.Region{latestRegion},
-	}, bc, storageWithRegionStorage, state))
+	}, bc, storageWithRegionStorage, state)
+	re.NoError(err)
+	re.True(handled)
 	re.False(rc.IsRunning())
 	re.True(state.fullSyncing)
-	re.NoError(rc.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+	handled, err = rc.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 		StartIndex: 20,
-	}, bc, storageWithRegionStorage, state))
+	}, bc, storageWithRegionStorage, state)
+	re.NoError(err)
+	re.True(handled)
 
 	re.True(rc.IsRunning())
 	re.False(state.fullSyncing)

--- a/pkg/syncer/client_test.go
+++ b/pkg/syncer/client_test.go
@@ -103,7 +103,8 @@ func TestHandleRegionSyncResponseSkipsErrorResponse(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 	syncer.streamingRunning.Store(true)
 
-	handled := syncer.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+	state := &regionSyncState{syncingHistory: true}
+	handled, err := syncer.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
 		Header: &pdpb.ResponseHeader{
 			ClusterId: keypath.ClusterID(),
 			Error: &pdpb.Error{
@@ -111,9 +112,134 @@ func TestHandleRegionSyncResponseSkipsErrorResponse(t *testing.T) {
 				Message: "server stopped, close the region syncer client",
 			},
 		},
-	}, nil, nil)
+	}, nil, nil, state)
 
+	re.NoError(err)
 	re.False(handled)
 	re.Equal(uint64(10), syncer.history.getNextIndex())
 	re.False(syncer.IsRunning())
+}
+
+func TestResetRegionCacheAndStorage(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	rs, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer func() {
+		re.NoError(rs.Close())
+	}()
+	storageWithRegionStorage := storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), rs)
+	storage.TrySwitchRegionStorage(storageWithRegionStorage, true)
+	bc := core.NewBasicCluster()
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storageWithRegionStorage,
+		bc,
+	)
+	for i := range 2 {
+		region := &metapb.Region{
+			Id:       uint64(i + 1),
+			StartKey: []byte{byte(i)},
+			EndKey:   []byte{byte(i + 1)},
+		}
+		re.NoError(storageWithRegionStorage.SaveRegion(region))
+		bc.PutRegion(core.NewRegionInfo(region, nil))
+	}
+	re.NoError(storageWithRegionStorage.Flush())
+
+	rc := NewRegionSyncer(server)
+	re.NoError(rc.resetRegionCacheAndStorage(context.Background(), bc, storageWithRegionStorage))
+	re.Empty(bc.GetRegions())
+	for i := range 2 {
+		region := &metapb.Region{}
+		ok, err := storageWithRegionStorage.LoadRegion(uint64(i+1), region)
+		re.NoError(err)
+		re.False(ok)
+	}
+}
+
+func TestHandleFullSyncResponseResetsStaleRegions(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	rs, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer func() {
+		re.NoError(rs.Close())
+	}()
+	storageWithRegionStorage := storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), rs)
+	storage.TrySwitchRegionStorage(storageWithRegionStorage, true)
+	bc := core.NewBasicCluster()
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storageWithRegionStorage,
+		bc,
+	)
+	staleRegion1 := &metapb.Region{
+		Id:       1,
+		StartKey: []byte{0},
+		EndKey:   []byte{1},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	}
+	staleRegion2 := &metapb.Region{
+		Id:       2,
+		StartKey: []byte{1},
+		EndKey:   []byte{2},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	}
+	for _, region := range []*metapb.Region{staleRegion1, staleRegion2} {
+		re.NoError(storageWithRegionStorage.SaveRegion(region))
+		bc.PutRegion(core.NewRegionInfo(region, nil))
+	}
+
+	rc := NewRegionSyncer(server)
+	rc.history.resetWithIndex(10)
+	state := &regionSyncState{syncingHistory: true}
+	latestRegion := &metapb.Region{
+		Id:       1,
+		StartKey: []byte{0},
+		EndKey:   []byte{1},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 2,
+		},
+	}
+	re.NoError(rc.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		StartIndex: 0,
+		Regions:    []*metapb.Region{latestRegion},
+	}, bc, storageWithRegionStorage, state))
+	re.False(rc.IsRunning())
+	re.True(state.fullSyncing)
+	re.NoError(rc.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		StartIndex: 20,
+	}, bc, storageWithRegionStorage, state))
+
+	re.True(rc.IsRunning())
+	re.False(state.fullSyncing)
+	re.False(state.syncingHistory)
+	re.Equal(uint64(20), rc.history.getNextIndex())
+	historyIndex, err := rs.Load(historyKey)
+	re.NoError(err)
+	re.Equal("20", historyIndex)
+	re.Len(bc.GetRegions(), 1)
+	re.Equal(uint64(2), bc.GetRegion(1).GetRegionEpoch().GetVersion())
+	storedRegion := &metapb.Region{}
+	ok, err := storageWithRegionStorage.LoadRegion(1, storedRegion)
+	re.NoError(err)
+	re.True(ok)
+	re.Equal(uint64(2), storedRegion.GetRegionEpoch().GetVersion())
+	ok, err = storageWithRegionStorage.LoadRegion(2, storedRegion)
+	re.NoError(err)
+	re.False(ok)
 }

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -293,6 +293,7 @@ func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	if h.capacity() > h.baseCapacity {
 		h.resizeLocked(h.baseCapacity)
 	}
+	h.persist()
 }
 
 func (h *historyBuffer) getNextIndex() uint64 {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -384,11 +384,27 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 ) error {
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
+	if startIndex == 0 {
+		log.Warn("requested server needs full synchronization",
+			zap.String("requested-server", name),
+			zap.String("server", s.server.Name()))
+		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
+	}
 	if startIndex != 0 && startIndex < endIndex {
 		s.history.observeRequiredWindow(endIndex - startIndex)
 	}
 	records := s.history.recordsBetween(startIndex, endIndex)
 	if len(records) == 0 {
+		firstIndex := s.history.getFirstIndex()
+		if startIndex < firstIndex || startIndex > endIndex {
+			log.Warn("requested server cannot catch up with history buffer, trigger full synchronization",
+				zap.String("requested-server", name),
+				zap.String("server", s.server.Name()),
+				zap.Uint64("request-index", startIndex),
+				zap.Uint64("first-index", firstIndex),
+				zap.Uint64("last-index", endIndex))
+			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
+		}
 		if endIndex == startIndex {
 			log.Info("requested server has already in sync with server",
 				zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Uint64("last-index", startIndex))
@@ -471,6 +487,16 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 	regions := s.server.GetRegions()
 	lastIndex := 0
 	start := time.Now()
+	if len(regions) == 0 && syncStartIndex != 0 {
+		resp := &pdpb.SyncRegionResponse{
+			Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+			StartIndex: 0,
+		}
+		if err := syncStream.sendStreamIfOpen(resp); err != nil {
+			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
+			return err
+		}
+	}
 	metas := make([]*metapb.Region, 0, maxSyncRegionBatchSize)
 	stats := make([]*pdpb.RegionStat, 0, maxSyncRegionBatchSize)
 	leaders := make([]*metapb.Peer, 0, maxSyncRegionBatchSize)
@@ -539,6 +565,14 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 			return err
 		}
 		syncStream.advanceSendIndexLocked(len(records))
+	}
+	resp := &pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		StartIndex: nextIndex,
+	}
+	if err := syncStream.sendStreamIfOpen(resp); err != nil {
+		log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
+		return err
 	}
 	return nil
 }

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -33,6 +34,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockserver"
 	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
@@ -65,6 +67,7 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newMockSyncRegionsServer()
+	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
 	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	err := syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
@@ -310,6 +313,293 @@ func TestIncrementalHistoryReplayOverflowDisconnectsStream(t *testing.T) {
 			return false
 		}
 	})
+}
+
+type testSyncRegionsServer struct {
+	grpc.ServerStream
+	responses []*pdpb.SyncRegionResponse
+	onSend    func(resp *pdpb.SyncRegionResponse)
+}
+
+func (s *testSyncRegionsServer) Send(resp *pdpb.SyncRegionResponse) error {
+	s.responses = append(s.responses, resp)
+	if s.onSend != nil {
+		s.onSend(resp)
+	}
+	return nil
+}
+
+func (*testSyncRegionsServer) Recv() (*pdpb.SyncRegionRequest, error) {
+	return nil, nil
+}
+
+func syncHistoryRegionForTest(
+	ctx context.Context,
+	syncer *RegionSyncer,
+	req *pdpb.SyncRegionRequest,
+	stream ServerStream,
+) (*regionSyncStream, error) {
+	syncStream, syncStartIndex := syncer.bindStreamForSync(req.GetMember().GetName(), stream)
+	if err := syncer.syncHistoryRegion(ctx, req, syncStream, syncStartIndex); err != nil {
+		syncer.unbindStream(req.GetMember().GetName(), syncStream)
+		return nil, err
+	}
+	return syncStream, nil
+}
+
+func TestSyncHistoryRegionFallsBackToFullSyncWhenHistoryGapIsTooLarge(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	for i := range 3 {
+		bc.PutRegion(core.NewRegionInfo(&metapb.Region{
+			Id:       uint64(i + 1),
+			StartKey: []byte{byte(i)},
+			EndKey:   []byte{byte(i + 1)},
+			RegionEpoch: &metapb.RegionEpoch{
+				ConfVer: 1,
+				Version: 1,
+			},
+		}, nil))
+	}
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewStorageWithMemoryBackend(),
+		bc,
+	)
+	rc := NewRegionSyncer(server)
+	rc.history = newHistoryBufferWithConfig(2, 2, 1, kv.NewMemoryKV())
+	for i := range 4 {
+		rc.history.record(core.NewRegionInfo(&metapb.Region{Id: uint64(i + 10)}, nil))
+	}
+	re.Equal(uint64(2), rc.history.getFirstIndex())
+
+	stream := &testSyncRegionsServer{}
+	req := &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name: "pd-follower",
+		},
+		StartIndex: 1,
+	}
+	syncStream, err := syncHistoryRegionForTest(context.Background(), rc, req, stream)
+	re.NoError(err)
+	re.NotNil(syncStream)
+	defer rc.unbindStream("pd-follower", syncStream)
+	re.Len(stream.responses, 2)
+	re.Equal(uint64(0), stream.responses[0].GetStartIndex())
+	re.Len(stream.responses[0].GetRegions(), 3)
+	re.Equal(uint64(4), stream.responses[1].GetStartIndex())
+	re.Empty(stream.responses[1].GetRegions())
+}
+
+func TestSyncHistoryRegionFallsBackToFullSyncWhenRequestedIndexIsZero(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	for i := range 3 {
+		bc.PutRegion(core.NewRegionInfo(&metapb.Region{
+			Id:       uint64(i + 1),
+			StartKey: []byte{byte(i)},
+			EndKey:   []byte{byte(i + 1)},
+			RegionEpoch: &metapb.RegionEpoch{
+				ConfVer: 1,
+				Version: 1,
+			},
+		}, nil))
+	}
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewStorageWithMemoryBackend(),
+		bc,
+	)
+	rc := NewRegionSyncer(server)
+	rc.history = newHistoryBufferWithConfig(4, 4, 1, kv.NewMemoryKV())
+	for i := range 2 {
+		rc.history.record(core.NewRegionInfo(&metapb.Region{Id: uint64(i + 10)}, nil))
+	}
+
+	stream := &testSyncRegionsServer{}
+	req := &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name: "pd-follower",
+		},
+		StartIndex: 0,
+	}
+	syncStream, err := syncHistoryRegionForTest(context.Background(), rc, req, stream)
+	re.NoError(err)
+	re.NotNil(syncStream)
+	defer rc.unbindStream("pd-follower", syncStream)
+	re.Len(stream.responses, 2)
+	re.Equal(uint64(0), stream.responses[0].GetStartIndex())
+	re.Len(stream.responses[0].GetRegions(), 3)
+	re.Equal(uint64(2), stream.responses[1].GetStartIndex())
+	re.Empty(stream.responses[1].GetRegions())
+}
+
+func TestSyncHistoryRegionFallsBackToFullSyncWhenRequestedIndexIsAhead(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	bc.PutRegion(core.NewRegionInfo(&metapb.Region{
+		Id:       1,
+		StartKey: []byte{0},
+		EndKey:   []byte{1},
+	}, nil))
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewStorageWithMemoryBackend(),
+		bc,
+	)
+	rc := NewRegionSyncer(server)
+	rc.history = newHistoryBufferWithConfig(2, 2, 1, kv.NewMemoryKV())
+	for i := range 2 {
+		rc.history.record(core.NewRegionInfo(&metapb.Region{Id: uint64(i + 10)}, nil))
+	}
+
+	stream := &testSyncRegionsServer{}
+	req := &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name: "pd-follower",
+		},
+		StartIndex: rc.history.getNextIndex() + 1,
+	}
+	syncStream, err := syncHistoryRegionForTest(context.Background(), rc, req, stream)
+	re.NoError(err)
+	re.NotNil(syncStream)
+	defer rc.unbindStream("pd-follower", syncStream)
+	re.Len(stream.responses, 2)
+	re.Equal(uint64(0), stream.responses[0].GetStartIndex())
+	re.Len(stream.responses[0].GetRegions(), 1)
+	re.Equal(uint64(2), stream.responses[1].GetStartIndex())
+	re.Empty(stream.responses[1].GetRegions())
+}
+
+func TestSyncHistoryRegionSendsIncrementalRecords(t *testing.T) {
+	re := require.New(t)
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewStorageWithMemoryBackend(),
+		core.NewBasicCluster(),
+	)
+	rc := NewRegionSyncer(server)
+	rc.history = newHistoryBufferWithConfig(2, 2, 1, kv.NewMemoryKV())
+	for i := range 4 {
+		rc.history.record(core.NewRegionInfo(&metapb.Region{Id: uint64(i + 10)}, nil))
+	}
+	re.Equal(uint64(2), rc.history.getFirstIndex())
+
+	stream := &testSyncRegionsServer{}
+	req := &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name: "pd-follower",
+		},
+		StartIndex: rc.history.getFirstIndex(),
+	}
+	syncStream, err := syncHistoryRegionForTest(context.Background(), rc, req, stream)
+	re.NoError(err)
+	re.NotNil(syncStream)
+	defer rc.unbindStream("pd-follower", syncStream)
+	re.Len(stream.responses, 1)
+	re.Equal(uint64(2), stream.responses[0].GetStartIndex())
+	re.Len(stream.responses[0].GetRegions(), 2)
+}
+
+func TestSyncHistoryRegionSendsInSyncResponse(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	for i := range 3 {
+		bc.PutRegion(core.NewRegionInfo(&metapb.Region{Id: uint64(i + 1)}, nil))
+	}
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewStorageWithMemoryBackend(),
+		bc,
+	)
+	rc := NewRegionSyncer(server)
+	rc.history = newHistoryBufferWithConfig(2, 2, 1, kv.NewMemoryKV())
+	for i := range 4 {
+		rc.history.record(core.NewRegionInfo(&metapb.Region{Id: uint64(i + 10)}, nil))
+	}
+
+	stream := &testSyncRegionsServer{}
+	req := &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name: "pd-follower",
+		},
+		StartIndex: rc.history.getNextIndex(),
+	}
+	syncStream, err := syncHistoryRegionForTest(context.Background(), rc, req, stream)
+	re.NoError(err)
+	re.NotNil(syncStream)
+	defer rc.unbindStream("pd-follower", syncStream)
+	re.Len(stream.responses, 1)
+	re.Equal(uint64(4), stream.responses[0].GetStartIndex())
+	re.Empty(stream.responses[0].GetRegions())
+}
+
+func TestSyncFullRegionsCatchesUpHistoryBeforeBindingStream(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	bc.PutRegion(core.NewRegionInfo(&metapb.Region{
+		Id:       1,
+		StartKey: []byte{0},
+		EndKey:   []byte{1},
+	}, nil))
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewStorageWithMemoryBackend(),
+		bc,
+	)
+	rc := NewRegionSyncer(server)
+	rc.history = newHistoryBufferWithConfig(4, 4, 1, kv.NewMemoryKV())
+	for i := range 6 {
+		rc.history.record(core.NewRegionInfo(&metapb.Region{Id: uint64(i + 10)}, nil))
+	}
+	stream := &testSyncRegionsServer{}
+	stream.onSend = func(resp *pdpb.SyncRegionResponse) {
+		if len(resp.GetRegions()) == 1 && resp.GetRegions()[0].GetId() == 1 {
+			rc.history.record(core.NewRegionInfo(&metapb.Region{
+				Id:       2,
+				StartKey: []byte{1},
+				EndKey:   []byte{2},
+			}, nil))
+			stream.onSend = nil
+		}
+	}
+	req := &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name: "pd-follower",
+		},
+		StartIndex: 1,
+	}
+
+	syncStream, err := syncHistoryRegionForTest(context.Background(), rc, req, stream)
+	re.NoError(err)
+	re.NotNil(syncStream)
+	defer rc.unbindStream("pd-follower", syncStream)
+	re.Len(stream.responses, 3)
+	re.Equal(uint64(0), stream.responses[0].GetStartIndex())
+	re.Len(stream.responses[0].GetRegions(), 1)
+	re.Equal(uint64(6), stream.responses[1].GetStartIndex())
+	re.Len(stream.responses[1].GetRegions(), 1)
+	re.Equal(uint64(7), stream.responses[2].GetStartIndex())
+	re.Empty(stream.responses[2].GetRegions())
+	re.ElementsMatch([]string{"pd-follower"}, rc.GetAllDownstreamNames())
 }
 
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -225,9 +225,9 @@ func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 
 	re.NoError(syncer.sendDownstream(context.Background(), "pd-follower", syncStream, false))
 	responses := stream.sentResponses()
-	re.Len(responses, 3)
-	re.Equal(liveStartIndex, responses[2].GetStartIndex())
-	re.Equal([]*metapb.Region{{Id: 102}}, responses[2].GetRegions())
+	re.Len(responses, 4)
+	re.Equal(liveStartIndex, responses[3].GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 102}}, responses[3].GetRegions())
 	re.Equal(liveStartIndex+1, syncStream.getSendIndex())
 }
 
@@ -1077,6 +1077,7 @@ func TestDrainDownstreamSendsPendingRecordsSerially(t *testing.T) {
 func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 	re := require.New(t)
 	syncer := &RegionSyncer{history: newTestHistoryBuffer(defaultHistoryBufferSize)}
+	syncer.history.resetWithIndex(10)
 	first := newTestRegion(1)
 	second := newTestRegion(2)
 	syncer.history.record(first)
@@ -1086,14 +1087,14 @@ func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 	request := &pdpb.SyncRegionRequest{
 		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
 		Member:     &pdpb.Member{Name: "pd2"},
-		StartIndex: 0,
+		StartIndex: 10,
 	}
 
 	syncStream := newRegionSyncStream(stream, syncStartIndex)
 	err := syncer.syncHistoryRegion(context.Background(), request, syncStream, syncStartIndex)
 
 	re.NoError(err)
-	re.Equal(uint64(0), stream.lastResponse().GetStartIndex())
+	re.Equal(uint64(10), stream.lastResponse().GetStartIndex())
 	re.Equal([]*metapb.Region{{Id: 1}}, stream.lastResponse().GetRegions())
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10668

When a PD follower requests a region sync index that is no longer available in the leader's history buffer, the leader used to return no records and keep the stream alive. The follower could then keep stale region metadata in memory and in local region storage.

### What is changed and how does it work?

- Make the leader fall back to full region synchronization when the follower's requested index is zero, older than the history buffer, or ahead of the leader.
- Keep the stream unbound until the full snapshot and any catch-up history records are sent, so updates generated during the snapshot are not missed.
- Make the follower clear local region cache and persisted region storage when a full sync is triggered after it already had a non-zero history index.
- Persist the reset history index so follower restarts do not reload an old index after a full-sync reset.
- Apply the same full-sync reset handling to the router region syncer cache path.

### Check List

Tests

- Unit test

### Release note

```release-note
Fix PD follower region sync recovery when the follower falls behind the leader history buffer.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable transitions between history sync and full sync to avoid stale/duplicate data.
  * Automatically reset stale region cache and storage when switching sync modes to ensure consistency.
  * Improved detection of sync completion and safer stream handling to prevent stuck or stale streams.

* **Refactor**
  * Centralized stateful response handling and deferred stream binding for clearer sync flow.

* **Tests**
  * Added end-to-end coverage for history catch-up, full-sync transitions, and cache/storage reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->