### PR TITLE
syncer: extract region sync helpers

### DIFF
--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -85,6 +85,71 @@ func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (C
 
 var regionGuide = core.GenerateRegionGuideFunc(false)
 
+func (s *RegionSyncer) handleRegionSyncResponse(ctx context.Context, resp *pdpb.SyncRegionResponse, bc *core.BasicCluster, regionStorage storage.Storage) {
+	if s.history.getNextIndex() != resp.GetStartIndex() {
+		log.Warn("server sync index not match the leader",
+			zap.String("server", s.server.Name()),
+			zap.Uint64("own", s.history.getNextIndex()),
+			zap.Uint64("leader", resp.GetStartIndex()),
+			zap.Int("records-length", len(resp.GetRegions())))
+		// reset index
+		s.history.resetWithIndex(resp.GetStartIndex())
+	}
+	stats := resp.GetRegionStats()
+	regions := resp.GetRegions()
+	buckets := resp.GetBuckets()
+	regionLeaders := resp.GetRegionLeaders()
+	hasStats := len(stats) == len(regions)
+	hasBuckets := len(buckets) == len(regions)
+	for i, r := range regions {
+		var (
+			region       *core.RegionInfo
+			regionLeader *metapb.Peer
+			opts         = []core.RegionCreateOption{core.SetSource(core.Sync)}
+		)
+		if len(regionLeaders) > i && regionLeaders[i].GetId() != 0 {
+			regionLeader = regionLeaders[i]
+		}
+		if hasStats {
+			opts = append(opts,
+				core.SetWrittenBytes(stats[i].BytesWritten),
+				core.SetWrittenKeys(stats[i].KeysWritten),
+				core.SetReadBytes(stats[i].BytesRead),
+				core.SetReadKeys(stats[i].KeysRead))
+		}
+		if hasBuckets {
+			opts = append(opts, core.SetBuckets(buckets[i]))
+		}
+		region = core.NewRegionInfo(r, regionLeader, opts...)
+
+		origin, _, err := bc.PreCheckPutRegion(region)
+		if err != nil {
+			log.Debug("region is stale", zap.Stringer("origin", origin.GetMeta()), errs.ZapError(err))
+			continue
+		}
+		cctx := &core.MetaProcessContext{
+			Context:    ctx,
+			TaskRunner: ratelimit.NewSyncRunner(),
+			Tracer:     core.NewNoopHeartbeatProcessTracer(),
+			// no limit for followers.
+		}
+		saveKV, _, _, _ := regionGuide(cctx, region, origin)
+		overlaps := bc.PutRegion(region)
+
+		if saveKV {
+			err = regionStorage.SaveRegion(r)
+		}
+		if err == nil {
+			s.history.record(region)
+		}
+		for _, old := range overlaps {
+			_ = regionStorage.DeleteRegion(old.GetMeta())
+		}
+	}
+	// mark the client as running status when it finished the first history region sync.
+	s.streamingRunning.Store(true)
+}
+
 // IsRunning returns whether the region syncer client is running.
 func (s *RegionSyncer) IsRunning() bool {
 	return s.streamingRunning.Load()
@@ -195,68 +260,7 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					}
 					break
 				}
-				if s.history.getNextIndex() != resp.GetStartIndex() {
-					log.Warn("server sync index not match the leader",
-						zap.String("server", s.server.Name()),
-						zap.Uint64("own", s.history.getNextIndex()),
-						zap.Uint64("leader", resp.GetStartIndex()),
-						zap.Int("records-length", len(resp.GetRegions())))
-					// reset index
-					s.history.resetWithIndex(resp.GetStartIndex())
-				}
-				stats := resp.GetRegionStats()
-				regions := resp.GetRegions()
-				buckets := resp.GetBuckets()
-				regionLeaders := resp.GetRegionLeaders()
-				hasStats := len(stats) == len(regions)
-				hasBuckets := len(buckets) == len(regions)
-				for i, r := range regions {
-					var (
-						region       *core.RegionInfo
-						regionLeader *metapb.Peer
-						opts         = []core.RegionCreateOption{core.SetSource(core.Sync)}
-					)
-					if len(regionLeaders) > i && regionLeaders[i].GetId() != 0 {
-						regionLeader = regionLeaders[i]
-					}
-					if hasStats {
-						opts = append(opts,
-							core.SetWrittenBytes(stats[i].BytesWritten),
-							core.SetWrittenKeys(stats[i].KeysWritten),
-							core.SetReadBytes(stats[i].BytesRead),
-							core.SetReadKeys(stats[i].KeysRead))
-					}
-					if hasBuckets {
-						opts = append(opts, core.SetBuckets(buckets[i]))
-					}
-					region = core.NewRegionInfo(r, regionLeader, opts...)
-
-					origin, _, err := bc.PreCheckPutRegion(region)
-					if err != nil {
-						log.Debug("region is stale", zap.Stringer("origin", origin.GetMeta()), errs.ZapError(err))
-						continue
-					}
-					cctx := &core.MetaProcessContext{
-						Context:    ctx,
-						TaskRunner: ratelimit.NewSyncRunner(),
-						Tracer:     core.NewNoopHeartbeatProcessTracer(),
-						// no limit for followers.
-					}
-					saveKV, _, _, _ := regionGuide(cctx, region, origin)
-					overlaps := bc.PutRegion(region)
-
-					if saveKV {
-						err = regionStorage.SaveRegion(r)
-					}
-					if err == nil {
-						s.history.record(region)
-					}
-					for _, old := range overlaps {
-						_ = regionStorage.DeleteRegion(old.GetMeta())
-					}
-				}
-				// mark the client as running status when it finished the first history region sync.
-				s.streamingRunning.Store(true)
+				s.handleRegionSyncResponse(ctx, resp, bc, regionStorage)
 			}
 		}
 	}()

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -245,64 +245,7 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 		}
 		// do full synchronization
 		if startIndex == 0 {
-			regions := s.server.GetRegions()
-			lastIndex := 0
-			start := time.Now()
-			metas := make([]*metapb.Region, 0, maxSyncRegionBatchSize)
-			stats := make([]*pdpb.RegionStat, 0, maxSyncRegionBatchSize)
-			leaders := make([]*metapb.Peer, 0, maxSyncRegionBatchSize)
-			buckets := make([]*metapb.Buckets, 0, maxSyncRegionBatchSize)
-			for syncedIndex, r := range regions {
-				select {
-				case <-ctx.Done():
-					log.Info("discontinue sending sync region response")
-					failpoint.Inject("noFastExitSync", func() {
-						failpoint.Goto("doSync")
-					})
-					return nil
-				default:
-				}
-				failpoint.Label("doSync")
-				metas = append(metas, r.GetMeta())
-				stats = append(stats, r.GetStat())
-				leader := &metapb.Peer{}
-				if r.GetLeader() != nil {
-					leader = r.GetLeader()
-				}
-				leaders = append(leaders, leader)
-				bucket := &metapb.Buckets{}
-				if r.GetBuckets() != nil {
-					bucket = r.GetBuckets()
-				}
-				buckets = append(buckets, bucket)
-				if len(metas) < maxSyncRegionBatchSize && syncedIndex < len(regions)-1 {
-					continue
-				}
-				resp := &pdpb.SyncRegionResponse{
-					Header:        &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-					Regions:       metas,
-					StartIndex:    uint64(lastIndex),
-					RegionStats:   stats,
-					RegionLeaders: leaders,
-					Buckets:       buckets,
-				}
-				if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
-					log.Error("failed to wait rate limit", errs.ZapError(err))
-					return err
-				}
-				lastIndex += len(metas)
-				if err := stream.Send(resp); err != nil {
-					log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
-					return err
-				}
-				metas = metas[:0]
-				stats = stats[:0]
-				leaders = leaders[:0]
-				buckets = buckets[:0]
-			}
-			log.Info("requested server has completed full synchronization with server",
-				zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))
-			return nil
+			return s.syncFullRegions(ctx, name, stream)
 		}
 		log.Warn("no history regions from index, the leader may be restarted", zap.Uint64("index", startIndex))
 		return nil
@@ -312,6 +255,10 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 		zap.Uint64("from-index", startIndex),
 		zap.Uint64("last-index", s.history.getNextIndex()),
 		zap.Int("records-length", len(records)))
+	return s.syncHistoryRecords(startIndex, records, stream)
+}
+
+func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream pdpb.PD_SyncRegionsServer) error {
 	regions := make([]*metapb.Region, len(records))
 	stats := make([]*pdpb.RegionStat, len(records))
 	leaders := make([]*metapb.Peer, len(records))
@@ -339,6 +286,67 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 		Buckets:       buckets,
 	}
 	return stream.Send(resp)
+}
+
+func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) error {
+	regions := s.server.GetRegions()
+	lastIndex := 0
+	start := time.Now()
+	metas := make([]*metapb.Region, 0, maxSyncRegionBatchSize)
+	stats := make([]*pdpb.RegionStat, 0, maxSyncRegionBatchSize)
+	leaders := make([]*metapb.Peer, 0, maxSyncRegionBatchSize)
+	buckets := make([]*metapb.Buckets, 0, maxSyncRegionBatchSize)
+	for syncedIndex, r := range regions {
+		select {
+		case <-ctx.Done():
+			log.Info("discontinue sending sync region response")
+			failpoint.Inject("noFastExitSync", func() {
+				failpoint.Goto("doSync")
+			})
+			return nil
+		default:
+		}
+		failpoint.Label("doSync")
+		metas = append(metas, r.GetMeta())
+		stats = append(stats, r.GetStat())
+		leader := &metapb.Peer{}
+		if r.GetLeader() != nil {
+			leader = r.GetLeader()
+		}
+		leaders = append(leaders, leader)
+		bucket := &metapb.Buckets{}
+		if r.GetBuckets() != nil {
+			bucket = r.GetBuckets()
+		}
+		buckets = append(buckets, bucket)
+		if len(metas) < maxSyncRegionBatchSize && syncedIndex < len(regions)-1 {
+			continue
+		}
+		resp := &pdpb.SyncRegionResponse{
+			Header:        &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+			Regions:       metas,
+			StartIndex:    uint64(lastIndex),
+			RegionStats:   stats,
+			RegionLeaders: leaders,
+			Buckets:       buckets,
+		}
+		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
+			log.Error("failed to wait rate limit", errs.ZapError(err))
+			return err
+		}
+		lastIndex += len(metas)
+		if err := stream.Send(resp); err != nil {
+			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
+			return err
+		}
+		metas = metas[:0]
+		stats = stats[:0]
+		leaders = leaders[:0]
+		buckets = buckets[:0]
+	}
+	log.Info("requested server has completed full synchronization with server",
+		zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))
+	return nil
 }
 
 // bindStream binds the established server stream.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Ref #10668

This is a preparation PR for the region syncer recovery fix. It extracts existing code into smaller helpers so the follow-up behavior change is easier to review.

### What is changed and how does it work?

This PR only extracts existing logic into helper functions:

- `syncHistoryRecords` for sending history records from the leader to a follower.
- `syncFullRegions` for the existing full region sync path.
- `handleRegionSyncResponse` for the follower-side response handling path.

No behavior is intentionally changed in this PR.

### Check List

Tests

- Unit test

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized region synchronization by extracting and consolidating response-processing and full-sync logic into reusable helpers, reducing duplication and improving maintainability.
  * Improved sync robustness: clearer handling of start-index mismatches, history persistence, overlap cleanup, and initiation of streaming after the initial batch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10672)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->