### PR TITLE
gc: Implement GC state cache 

### DIFF
--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -355,6 +355,10 @@ func (m *GCStateManager) advanceGCSafePointImpl(ctx context.Context, keyspaceID 
 		if err1 != nil {
 			return err1
 		}
+		txnSafePoint, err1 = m.gcMetaStorage.LoadTxnSafePoint(keyspaceID)
+		if err1 != nil {
+			return err1
+		}
 		if target < oldGCSafePoint {
 			if compatible {
 				// When in compatible mode, trying to update the safe point to a smaller value fails silently, returning
@@ -367,10 +371,6 @@ func (m *GCStateManager) advanceGCSafePointImpl(ctx context.Context, keyspaceID 
 			}
 			// Otherwise, return error to reject the operation explicitly.
 			return errs.ErrDecreasingGCSafePoint.GenWithStackByArgs(oldGCSafePoint, target)
-		}
-		txnSafePoint, err1 = m.gcMetaStorage.LoadTxnSafePoint(keyspaceID)
-		if err1 != nil {
-			return err1
 		}
 		if target > txnSafePoint {
 			return errs.ErrGCSafePointExceedsTxnSafePoint.GenWithStackByArgs(oldGCSafePoint, target, txnSafePoint)

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -1028,7 +1028,7 @@ func (m *GCStateManager) iterateAllKeyspacesGCStates(
 		}
 
 		// Workaround: Check unified GC before checking `keyspacePred`. This breaks the semantics of
-		// the function, but it makes sure keyspaces that chagned from keyspace-level GC to unified GC, the invalidated
+		// the function, but it makes sure keyspaces that changed from keyspace-level GC to unified GC, the invalidated
 		// cached GC states (if any) are always overwritten by the unified GC ones.
 
 		if keyspaceMeta.Config[keyspace.GCManagementType] != keyspace.KeyspaceLevelGC {

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -922,7 +922,8 @@ func (m *GCStateManager) GetAllKeyspacesGCStates(ctx context.Context, excludeGCB
 				func(_keyspaceID uint32) bool { return true },
 				func(gcState GCState) {
 					result[gcState.KeyspaceID] = gcState
-				})
+				},
+				nil)
 			failpoint.Inject("onGetAllKeyspacesGCStatesFinish", func() {})
 			return result, err
 		})
@@ -932,27 +933,57 @@ func (m *GCStateManager) GetAllKeyspacesGCStates(ctx context.Context, excludeGCB
 	// Note that the invocation with and without `excludeGCBarriers` should go to different singleflights, otherwise
 	// invocation with different parameters may share their results incorrectly.
 	return m.allKeyspacesGCStatesExcludeGCBarriersSingleFlight.Do(ctx, func(execCtx context.Context) (map[uint32]GCState, error) {
-		cachedGCStates := make(map[uint32]GCState)
+		gcStates := make(map[uint32]GCState)
 		if m.nodeIsLeader() {
-			cachedGCStates = m.gcStateCache.cloneAllAsGCStates()
+			gcStates = m.gcStateCache.cloneAllAsGCStates()
 		}
-		err := m.iterateAllKeyspacesGCStates(execCtx, excludeGCBarriers, func(keyspaceID uint32) bool {
-			_, ok := cachedGCStates[keyspaceID]
-			return !ok
-		}, func(gcState GCState) {
-			cachedGCStates[gcState.KeyspaceID] = gcState
-		})
+
+		actualKeyspaces := make(map[uint32]struct{}, len(gcStates))
+
+		err := m.iterateAllKeyspacesGCStates(execCtx, excludeGCBarriers,
+			func(keyspaceID uint32) bool {
+				_, ok := gcStates[keyspaceID]
+				return !ok
+			},
+			func(gcState GCState) {
+				actualKeyspaces[gcState.KeyspaceID] = struct{}{}
+				gcStates[gcState.KeyspaceID] = gcState
+			},
+			func(meta *keyspacepb.KeyspaceMeta) {
+				keyspaceID := constant.NullKeyspaceID
+				if meta != nil {
+					keyspaceID = meta.GetId()
+				}
+				actualKeyspaces[keyspaceID] = struct{}{}
+			})
+
+		// Filter out invalid GC states that may be stale in the cache.
+		keyspacesToRemove := make([]uint32, 0)
+		for keyspaceID := range gcStates {
+			if _, ok := actualKeyspaces[keyspaceID]; !ok {
+				keyspacesToRemove = append(keyspacesToRemove, keyspaceID)
+			}
+		}
+		for _, keyspaceID := range keyspacesToRemove {
+			delete(gcStates, keyspaceID)
+		}
+
 		failpoint.Inject("onGetAllKeyspacesGCStatesFinish", func() {})
-		return cachedGCStates, err
+		return gcStates, err
 	})
 }
 
 // iterateAllKeyspacesGCStates iterates GC states of all keyspaces, and calls the given callback on each of them.
+// `keyspacePred` will be used to filter keyspaces to be handled, including the null keyspace.
+// For unfiltered keyspaces, its GCState will be loaded and passed to `cb`; for keyspaces filtered by `keyspacePred`,
+// its keyspace meta (or nil for null keyspace) will be passed to `filteredKeyspaceCb`.
+// Keyspaces not in ENABLED state or keyspaces with keyspace-level GC disabled won't be used to call either callback.
 func (m *GCStateManager) iterateAllKeyspacesGCStates(
 	ctx context.Context,
 	excludeGCBarriers bool,
 	keyspacePred func(keyspaceID uint32) bool,
 	cb func(GCState),
+	filteredKeyspaceCb func(meta *keyspacepb.KeyspaceMeta),
 ) error {
 	failpoint.InjectCall("onGetAllKeyspacesGCStatesStart")
 	failpoint.Inject("iterateAllKeyspacesGCStatesError", func(val failpoint.Value) {
@@ -964,14 +995,14 @@ func (m *GCStateManager) iterateAllKeyspacesGCStates(
 
 	keyspaceIterator := m.keyspaceManager.IterateKeyspaces()
 
-	// Do not guarantee atomicity among different keyspaces here.
-
 	if keyspacePred(constant.NullKeyspaceID) {
 		nullKeyspaceGCState, err := m.getGCStateImpl(constant.NullKeyspaceID, excludeGCBarriers)
 		if err != nil {
 			return err
 		}
 		cb(nullKeyspaceGCState)
+	} else if filteredKeyspaceCb != nil {
+		filteredKeyspaceCb(nil)
 	}
 
 	for {
@@ -989,7 +1020,14 @@ func (m *GCStateManager) iterateAllKeyspacesGCStates(
 			break
 		}
 
-		if !keyspacePred(keyspaceMeta.GetId()) || keyspaceMeta.State != keyspacepb.KeyspaceState_ENABLED {
+		if keyspaceMeta.State != keyspacepb.KeyspaceState_ENABLED {
+			continue
+		}
+
+		if !keyspacePred(keyspaceMeta.GetId()) {
+			if filteredKeyspaceCb != nil {
+				filteredKeyspaceCb(keyspaceMeta)
+			}
 			continue
 		}
 

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -968,6 +968,7 @@ func (m *GCStateManager) GetAllKeyspacesGCStates(ctx context.Context, excludeGCB
 		}
 		for _, keyspaceID := range keyspacesToRemove {
 			delete(gcStates, keyspaceID)
+			m.gcStateCache.remove(keyspaceID)
 		}
 
 		failpoint.Inject("onGetAllKeyspacesGCStatesFinish", func() {})

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -1027,12 +1027,9 @@ func (m *GCStateManager) iterateAllKeyspacesGCStates(
 			continue
 		}
 
-		if !keyspacePred(keyspaceMeta.GetId()) {
-			if filteredKeyspaceCb != nil {
-				filteredKeyspaceCb(keyspaceMeta)
-			}
-			continue
-		}
+		// Workaround: Check unified GC before checking `keyspacePred`. This breaks the semantics of
+		// the function, but it makes sure keyspaces that chagned from keyspace-level GC to unified GC, the invalidated
+		// cached GC states (if any) are always overwritten by the unified GC ones.
 
 		if keyspaceMeta.Config[keyspace.GCManagementType] != keyspace.KeyspaceLevelGC {
 			gcState := GCState{
@@ -1040,6 +1037,13 @@ func (m *GCStateManager) iterateAllKeyspacesGCStates(
 				IsKeyspaceLevel: false,
 			}
 			cb(gcState)
+			continue
+		}
+
+		if !keyspacePred(keyspaceMeta.GetId()) {
+			if filteredKeyspaceCb != nil {
+				filteredKeyspaceCb(keyspaceMeta)
+			}
 			continue
 		}
 

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -301,8 +301,10 @@ func (m *GCStateManager) CompatibleLoadGCSafePoint(keyspaceID uint32) (uint64, e
 		return 0, err
 	}
 
-	if cachedGCState, ok := m.gcStateCache.load(keyspaceID); ok {
-		return cachedGCState.GCSafePoint, nil
+	if m.nodeIsLeader() {
+		if cachedGCState, ok := m.gcStateCache.load(keyspaceID); ok {
+			return cachedGCState.GCSafePoint, nil
+		}
 	}
 
 	// No need to acquire the lock as a single-key read operation is atomic.

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -102,9 +103,85 @@ import (
 //  4. (weakened) For each GC barrier `b`, each advancement of the txn safe point should not push it to a new value
 //     that is larger than `b.BarrierTS` (`t' <= max{t, min(b.BarrierTS for b in B)}` where `B` is the set of GC
 //     barriers).
-//
-// TODO: Explicitly state the versions that GCStateManager starts to be functional and the old APIs/concepts/terms is
-//       deprecated when these work are all done.
+
+type gcStateCacheEntry struct {
+	TxnSafePoint uint64
+	GCSafePoint  uint64
+}
+
+const gcStateCacheShardBits = 5 // 32 shards
+
+type gcStateCacheShard struct {
+	mu           syncutil.RWMutex
+	gcStateCache map[uint32]gcStateCacheEntry
+}
+
+type gcStateCache struct {
+	shards [1 << gcStateCacheShardBits]gcStateCacheShard
+}
+
+func newGCStateCache() *gcStateCache {
+	c := &gcStateCache{}
+	for i := range len(c.shards) {
+		c.shards[i] = gcStateCacheShard{
+			gcStateCache: make(map[uint32]gcStateCacheEntry),
+		}
+	}
+	return c
+}
+
+func (c *gcStateCache) getShard(keyspaceID uint32) *gcStateCacheShard {
+	return &c.shards[keyspaceID&((1<<gcStateCacheShardBits)-1)]
+}
+
+func (c *gcStateCache) load(keyspaceID uint32) (gcStateCacheEntry, bool) {
+	shard := c.getShard(keyspaceID)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+	res, ok := shard.gcStateCache[keyspaceID]
+	return res, ok
+}
+
+func (c *gcStateCache) store(keyspaceID uint32, entry gcStateCacheEntry) {
+	shard := c.getShard(keyspaceID)
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+	shard.gcStateCache[keyspaceID] = entry
+}
+
+func (c *gcStateCache) remove(keyspaceID uint32) {
+	shard := c.getShard(keyspaceID)
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+	delete(shard.gcStateCache, keyspaceID)
+}
+
+func (c *gcStateCache) cloneAllAsGCStates() map[uint32]GCState {
+	res := make(map[uint32]GCState)
+	for i := range c.shards {
+		shard := &c.shards[i]
+		shard.mu.RLock()
+		for keyspaceID, entry := range shard.gcStateCache {
+			res[keyspaceID] = GCState{
+				KeyspaceID:      keyspaceID,
+				IsKeyspaceLevel: keyspaceID != constant.NullKeyspaceID,
+				TxnSafePoint:    entry.TxnSafePoint,
+				GCSafePoint:     entry.GCSafePoint,
+			}
+		}
+		shard.mu.RUnlock()
+	}
+	return res
+}
+
+func (c *gcStateCache) clearAll() {
+	for i := range c.shards {
+		shard := &c.shards[i]
+		shard.mu.Lock()
+		shard.gcStateCache = make(map[uint32]gcStateCacheEntry)
+		shard.mu.Unlock()
+	}
+}
 
 // GCStateManager is the manager for all kinds of states of TiKV's GC for MVCC data.
 // nolint:revive
@@ -118,8 +195,17 @@ type GCStateManager struct {
 	cfg             config.PDServerConfig
 	keyspaceManager *keyspace.Manager
 
+	// A read/write - update cache procedure must be done while holding the outer mutex `GCStateManager.mu`.
+	// A read-only operation can be done on gcStateCache directly without locking `GCStateManager.mu`.
+	gcStateCache *gcStateCache
+
 	allKeyspacesGCStatesSingleFlight                  *syncutil.OrderedSingleFlight[map[uint32]GCState]
 	allKeyspacesGCStatesExcludeGCBarriersSingleFlight *syncutil.OrderedSingleFlight[map[uint32]GCState]
+
+	// Note that nodeLeadership is a counter instead of a bool. Theoretically, it's possible that an
+	// OnNodeBecomesFollower invocation of the previous lease is later than the OnNodeBecomesLeader call of the new
+	// lease during PD leader changes. Making this a counter helps in guaranteeing the eventual consistency.
+	nodeLeadership atomic.Int32
 }
 
 // NewGCStateManager creates a GCStateManager of GC and services.
@@ -128,6 +214,7 @@ func NewGCStateManager(store endpoint.GCStateProvider, cfg config.PDServerConfig
 		gcMetaStorage:                    store,
 		cfg:                              cfg,
 		keyspaceManager:                  keyspaceManager,
+		gcStateCache:                     newGCStateCache(),
 		allKeyspacesGCStatesSingleFlight: syncutil.NewOrderedSingleFlight[map[uint32]GCState](),
 		allKeyspacesGCStatesExcludeGCBarriersSingleFlight: syncutil.NewOrderedSingleFlight[map[uint32]GCState](),
 	}
@@ -149,6 +236,33 @@ func getKeyspaceNameFromCtx(ctx context.Context) string {
 		return value
 	}
 	return "<unknown>"
+}
+
+// OnNodeBecomesLeader marks the current PD node as leader for GC state watches.
+func (m *GCStateManager) OnNodeBecomesLeader() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.nodeLeadership.Add(1)
+
+	// Also trigger cache invalidation even when transitioning from follower to leader, as a protection against
+	// potential inconsistent cache state left from the last leadership.
+	m.gcStateCache.clearAll()
+}
+
+// OnNodeBecomesFollower marks the current PD node as follower and closes all existing GC state watches.
+func (m *GCStateManager) OnNodeBecomesFollower() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.nodeLeadership.Add(-1)
+
+	// Invalidate the cache.
+	m.gcStateCache.clearAll()
+}
+
+func (m *GCStateManager) nodeIsLeader() bool {
+	return m.nodeLeadership.Load() > 0
 }
 
 // redirectKeyspace checks the given keyspaceID, and returns the actual keyspaceID to operate on.
@@ -185,6 +299,10 @@ func (m *GCStateManager) CompatibleLoadGCSafePoint(keyspaceID uint32) (uint64, e
 	keyspaceID, _, err := m.redirectKeyspace(keyspaceID, false)
 	if err != nil {
 		return 0, err
+	}
+
+	if cachedGCState, ok := m.gcStateCache.load(keyspaceID); ok {
+		return cachedGCState.GCSafePoint, nil
 	}
 
 	// No need to acquire the lock as a single-key read operation is atomic.
@@ -229,6 +347,7 @@ func (m *GCStateManager) CompatibleUpdateGCSafePoint(keyspaceID uint32, target u
 
 func (m *GCStateManager) advanceGCSafePointImpl(ctx context.Context, keyspaceID uint32, target uint64, compatible bool) (oldGCSafePoint uint64, newGCSafePoint uint64, err error) {
 	newGCSafePoint = target
+	var txnSafePoint uint64
 
 	err = m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
 		var err1 error
@@ -249,7 +368,7 @@ func (m *GCStateManager) advanceGCSafePointImpl(ctx context.Context, keyspaceID 
 			// Otherwise, return error to reject the operation explicitly.
 			return errs.ErrDecreasingGCSafePoint.GenWithStackByArgs(oldGCSafePoint, target)
 		}
-		txnSafePoint, err1 := m.gcMetaStorage.LoadTxnSafePoint(keyspaceID)
+		txnSafePoint, err1 = m.gcMetaStorage.LoadTxnSafePoint(keyspaceID)
 		if err1 != nil {
 			return err1
 		}
@@ -263,8 +382,16 @@ func (m *GCStateManager) advanceGCSafePointImpl(ctx context.Context, keyspaceID 
 		log.Error("failed to advance GC safe point",
 			zap.Uint32("keyspace-id", keyspaceID), zap.String("keyspace-name", getKeyspaceNameFromCtx(ctx)),
 			zap.Uint64("target", target), zap.Bool("compatible-mode", compatible), zap.Error(err))
+		// Invalidate cache on error.
+		m.gcStateCache.remove(keyspaceID)
 		return 0, 0, err
 	}
+
+	// Update cache.
+	m.gcStateCache.store(keyspaceID, gcStateCacheEntry{
+		TxnSafePoint: txnSafePoint,
+		GCSafePoint:  newGCSafePoint,
+	})
 
 	if newGCSafePoint != oldGCSafePoint {
 		log.Info("advanced GC safe point",
@@ -330,11 +457,16 @@ func (m *GCStateManager) advanceTxnSafePointImpl(ctx context.Context, keyspaceID
 		blockingBarrier         *endpoint.GCBarrier
 		blockingGlobalBarrier   *endpoint.GlobalGCBarrier
 		blockingMinStartTSOwner *string
+		gcSafePoint             uint64
 	)
 
 	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
 		var err1 error
 		oldTxnSafePoint, err1 = m.gcMetaStorage.LoadTxnSafePoint(keyspaceID)
+		if err1 != nil {
+			return err1
+		}
+		gcSafePoint, err1 = m.gcMetaStorage.LoadGCSafePoint(keyspaceID)
 		if err1 != nil {
 			return err1
 		}
@@ -422,8 +554,20 @@ func (m *GCStateManager) advanceTxnSafePointImpl(ctx context.Context, keyspaceID
 		return wb.SetTxnSafePoint(keyspaceID, newTxnSafePoint)
 	})
 	if err != nil {
+		log.Error("failed to advance GC safe point",
+			zap.Uint32("keyspace-id", keyspaceID), zap.String("keyspace-name", getKeyspaceNameFromCtx(ctx)),
+			zap.Uint64("old-txn-safe-point", oldTxnSafePoint), zap.Uint64("target", target),
+			zap.Uint64("new-txn-safe-point", newTxnSafePoint), zap.Bool("downgrade-compatible-mode", downgradeCompatibleMode), zap.Error(err))
+		// Invalidate cache on error.
+		m.gcStateCache.remove(keyspaceID)
 		return AdvanceTxnSafePointResult{}, err
 	}
+
+	// Update cache.
+	m.gcStateCache.store(keyspaceID, gcStateCacheEntry{
+		TxnSafePoint: newTxnSafePoint,
+		GCSafePoint:  gcSafePoint,
+	})
 
 	blockerDesc := ""
 	simulatedServiceID := ""
@@ -629,6 +773,76 @@ func (m *GCStateManager) deleteGCBarrierImpl(ctx context.Context, keyspaceID uin
 	return deletedBarrier, nil
 }
 
+func (m *GCStateManager) getGCStateImpl(keyspaceID uint32, excludeGCBarriers bool) (GCState, error) {
+	// Try getting from cache if possible.
+	if excludeGCBarriers && m.nodeIsLeader() {
+		if cachedGCState, ok := m.gcStateCache.load(keyspaceID); ok {
+			failpoint.InjectCall("getGCStateCacheAccess", "hit")
+			gcStateCacheAccessHitCounter.Inc()
+			return GCState{
+				KeyspaceID:      keyspaceID,
+				IsKeyspaceLevel: keyspaceID != constant.NullKeyspaceID,
+				TxnSafePoint:    cachedGCState.TxnSafePoint,
+				GCSafePoint:     cachedGCState.GCSafePoint,
+			}, nil
+		}
+	}
+
+	return m.getGCStateImplSlow(keyspaceID, excludeGCBarriers)
+}
+
+func (m *GCStateManager) getGCStateImplSlow(keyspaceID uint32, excludeGCBarriers bool) (GCState, error) {
+	// Keep this hook before taking the manager lock so leader transitions are
+	// not blocked while tests pin the request at the slow-path boundary.
+	failpoint.InjectCall("getGCStateBeforeSlowPath")
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if excludeGCBarriers && m.nodeIsLeader() {
+		// Check cache again after entering the lock.
+		// When entering this slow path after a cache miss, it's possible that some other concurrent call has caused
+		// cache update before we acquire the mutex.
+		if cachedGCState, ok := m.gcStateCache.load(keyspaceID); ok {
+			failpoint.InjectCall("getGCStateCacheAccess", "slow_hit")
+			gcStateCacheAccessSlowHitCounter.Inc()
+			return GCState{
+				KeyspaceID:      keyspaceID,
+				IsKeyspaceLevel: keyspaceID != constant.NullKeyspaceID,
+				TxnSafePoint:    cachedGCState.TxnSafePoint,
+				GCSafePoint:     cachedGCState.GCSafePoint,
+			}, nil
+		}
+	}
+
+	failpoint.InjectCall("getGCStateCacheAccess", "miss")
+	gcStateCacheAccessMissCounter.Inc()
+
+	var result GCState
+	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
+		var err1 error
+		result, err1 = m.getGCStateInTransaction(keyspaceID, excludeGCBarriers, wb)
+		return err1
+	})
+	if err != nil {
+		return GCState{}, err
+	}
+
+	// Update cache on successfully load GC states from IO.
+	// Note that we don't update cache when excludeGCBarriers is set to false. The reason is that, when
+	// excludeGCBarrier is set and the code executes to here, it must be because that there was a cache miss; but if
+	// it's not set, as it won't go through the cache, here it's likely that the cache is actually valid, and updating
+	// it causes unnecessary overhead and locking.
+	if excludeGCBarriers {
+		m.gcStateCache.store(keyspaceID, gcStateCacheEntry{
+			TxnSafePoint: result.TxnSafePoint,
+			GCSafePoint:  result.GCSafePoint,
+		})
+	}
+
+	return result, nil
+}
+
 // getGCStateInTransaction gets all properties in GC states within a context of gcMetaStorage.RunInGCStateTransaction.
 // This read only and won't write anything to the GCStateWriteBatch. It still receives a write batch to ensure
 // it's running in a in-transaction context.
@@ -676,21 +890,19 @@ func (m *GCStateManager) getGCStateInTransaction(keyspaceID uint32, excludeGCBar
 // When this method is called on a keyspace without keyspace-level GC enabled, it will be equivalent to calling it on
 // the NullKeyspace.
 func (m *GCStateManager) GetGCState(keyspaceID uint32, excludeGCBarriers bool) (GCState, error) {
-	keyspaceID, _, err := m.redirectKeyspace(keyspaceID, true)
+	keyspaceID, keyspaceName, err := m.redirectKeyspace(keyspaceID, true)
 	if err != nil {
 		return GCState{}, err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 
-	var result GCState
-	err = m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
-		var err1 error
-		result, err1 = m.getGCStateInTransaction(keyspaceID, excludeGCBarriers, wb)
-		return err1
-	})
+	gcState, err := m.getGCStateImpl(keyspaceID, excludeGCBarriers)
 
-	return result, err
+	if err != nil {
+		log.Error("failed to get GC satete", zap.Uint32("keyspace-id", keyspaceID),
+			zap.String("keyspace-name", keyspaceName), zap.Bool("exclude-gc-barriers", excludeGCBarriers), zap.Error(err))
+	}
+
+	return gcState, err
 }
 
 // GetAllKeyspacesGCStates returns the GC state of all keyspaces.
@@ -705,101 +917,99 @@ func (m *GCStateManager) GetGCState(keyspaceID uint32, excludeGCBarriers bool) (
 func (m *GCStateManager) GetAllKeyspacesGCStates(ctx context.Context, excludeGCBarriers bool) (map[uint32]GCState, error) {
 	if !excludeGCBarriers {
 		return m.allKeyspacesGCStatesSingleFlight.Do(ctx, func(execCtx context.Context) (map[uint32]GCState, error) {
-			result, err := m.getAllKeyspacesGCStatesImpl(execCtx, excludeGCBarriers)
+			result := make(map[uint32]GCState)
+			err := m.iterateAllKeyspacesGCStates(execCtx, excludeGCBarriers,
+				func(_keyspaceID uint32) bool { return true },
+				func(gcState GCState) {
+					result[gcState.KeyspaceID] = gcState
+				})
 			failpoint.Inject("onGetAllKeyspacesGCStatesFinish", func() {})
 			return result, err
 		})
 	}
 
+	// If excludeGCBarriers is set, most required information should be available in the cache.
+	// Note that the invocation with and without `excludeGCBarriers` should go to different singleflights, otherwise
+	// invocation with different parameters may share their results incorrectly.
 	return m.allKeyspacesGCStatesExcludeGCBarriersSingleFlight.Do(ctx, func(execCtx context.Context) (map[uint32]GCState, error) {
-		result, err := m.getAllKeyspacesGCStatesImpl(execCtx, excludeGCBarriers)
+		cachedGCStates := make(map[uint32]GCState)
+		if m.nodeIsLeader() {
+			cachedGCStates = m.gcStateCache.cloneAllAsGCStates()
+		}
+		err := m.iterateAllKeyspacesGCStates(execCtx, excludeGCBarriers, func(keyspaceID uint32) bool {
+			_, ok := cachedGCStates[keyspaceID]
+			return !ok
+		}, func(gcState GCState) {
+			cachedGCStates[gcState.KeyspaceID] = gcState
+		})
 		failpoint.Inject("onGetAllKeyspacesGCStatesFinish", func() {})
-		return result, err
+		return cachedGCStates, err
 	})
 }
 
-func (m *GCStateManager) getAllKeyspacesGCStatesImpl(ctx context.Context, excludeGCBarriers bool) (map[uint32]GCState, error) {
+// iterateAllKeyspacesGCStates iterates GC states of all keyspaces, and calls the given callback on each of them.
+func (m *GCStateManager) iterateAllKeyspacesGCStates(
+	ctx context.Context,
+	excludeGCBarriers bool,
+	keyspacePred func(keyspaceID uint32) bool,
+	cb func(GCState),
+) error {
 	failpoint.InjectCall("onGetAllKeyspacesGCStatesStart")
-
-	mutexLocked := false
-	lock := func() {
-		m.mu.Lock()
-		mutexLocked = true
-	}
-	unlock := func() {
-		m.mu.Unlock()
-		mutexLocked = false
-	}
-
-	ensureUnlocked := func() {
-		if mutexLocked {
-			unlock()
+	failpoint.Inject("iterateAllKeyspacesGCStatesError", func(val failpoint.Value) {
+		if errMsg, ok := val.(string); ok {
+			failpoint.Return(errors.New(errMsg))
 		}
-	}
-	defer ensureUnlocked()
+		failpoint.Return(errors.New("mock iterate all keyspaces gc states error"))
+	})
 
 	keyspaceIterator := m.keyspaceManager.IterateKeyspaces()
 
 	// Do not guarantee atomicity among different keyspaces here.
-	results := make(map[uint32]GCState)
-	lock()
-	err := m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
-		nullKeyspaceState, err1 := m.getGCStateInTransaction(constant.NullKeyspaceID, excludeGCBarriers, wb)
-		if err1 != nil {
-			return err1
+
+	if keyspacePred(constant.NullKeyspaceID) {
+		nullKeyspaceGCState, err := m.getGCStateImpl(constant.NullKeyspaceID, excludeGCBarriers)
+		if err != nil {
+			return err
 		}
-		results[constant.NullKeyspaceID] = nullKeyspaceState
-		return nil
-	})
-	unlock()
-	if err != nil {
-		return nil, err
+		cb(nullKeyspaceGCState)
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return ctx.Err()
 		default:
 		}
 
 		keyspaceMeta, ok, err := keyspaceIterator.Next()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if !ok {
 			break
 		}
 
-		// Just handle the active keyspace, leave the others up to keyspace management.
-		if keyspaceMeta.State != keyspacepb.KeyspaceState_ENABLED {
+		if !keyspacePred(keyspaceMeta.GetId()) || keyspaceMeta.State != keyspacepb.KeyspaceState_ENABLED {
 			continue
 		}
 
 		if keyspaceMeta.Config[keyspace.GCManagementType] != keyspace.KeyspaceLevelGC {
-			results[keyspaceMeta.Id] = GCState{
+			gcState := GCState{
 				KeyspaceID:      keyspaceMeta.Id,
 				IsKeyspaceLevel: false,
 			}
+			cb(gcState)
 			continue
 		}
 
-		lock()
-		err = m.gcMetaStorage.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
-			state, err1 := m.getGCStateInTransaction(keyspaceMeta.Id, excludeGCBarriers, wb)
-			if err1 != nil {
-				return err1
-			}
-			results[keyspaceMeta.Id] = state
-			return nil
-		})
-		unlock()
+		gcState, err := m.getGCStateImpl(keyspaceMeta.GetId(), excludeGCBarriers)
 		if err != nil {
-			return nil, err
+			return err
 		}
+		cb(gcState)
 	}
 
-	return results, nil
+	return nil
 }
 
 // LoadAllGlobalGCBarriers returns global GC barriers.

--- a/pkg/gc/gc_state_manager.go
+++ b/pkg/gc/gc_state_manager.go
@@ -556,7 +556,7 @@ func (m *GCStateManager) advanceTxnSafePointImpl(ctx context.Context, keyspaceID
 		return wb.SetTxnSafePoint(keyspaceID, newTxnSafePoint)
 	})
 	if err != nil {
-		log.Error("failed to advance GC safe point",
+		log.Error("failed to advance txn safe point",
 			zap.Uint32("keyspace-id", keyspaceID), zap.String("keyspace-name", getKeyspaceNameFromCtx(ctx)),
 			zap.Uint64("old-txn-safe-point", oldTxnSafePoint), zap.Uint64("target", target),
 			zap.Uint64("new-txn-safe-point", newTxnSafePoint), zap.Bool("downgrade-compatible-mode", downgradeCompatibleMode), zap.Error(err))
@@ -900,7 +900,7 @@ func (m *GCStateManager) GetGCState(keyspaceID uint32, excludeGCBarriers bool) (
 	gcState, err := m.getGCStateImpl(keyspaceID, excludeGCBarriers)
 
 	if err != nil {
-		log.Error("failed to get GC satete", zap.Uint32("keyspace-id", keyspaceID),
+		log.Error("failed to get GC state", zap.Uint32("keyspace-id", keyspaceID),
 			zap.String("keyspace-name", keyspaceName), zap.Bool("exclude-gc-barriers", excludeGCBarriers), zap.Error(err))
 	}
 

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -2046,11 +2046,15 @@ func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriers
 	re.Len(allStates, len(s.keyspacePresets.all)-1)
 	_, ok = allStates[keyspaceID]
 	re.False(ok)
+	_, ok = s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
 
 	allStates, err = s.manager.GetAllKeyspacesGCStates(context.Background(), true)
 	re.NoError(err)
 	re.Len(allStates, len(s.keyspacePresets.all)-1)
 	_, ok = allStates[keyspaceID]
+	re.False(ok)
+	_, ok = s.manager.gcStateCache.load(keyspaceID)
 	re.False(ok)
 }
 

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -2021,15 +2021,57 @@ func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriers
 	}
 }
 
-func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriersFiltersArchivedCachedState() {
+func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriersFiltersStaleCachedState() {
 	re := s.Require()
 
-	const keyspaceID = uint32(2)
+	const (
+		keyspaceIDArchived = uint32(2)
+		keyspaceIDUnified  = uint32(3)
+	)
 
-	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 20, time.Now())
+	_, err := s.manager.keyspaceManager.UpdateKeyspaceConfig("ks3", []*keyspace.Mutation{{
+		Op:    keyspace.OpPut,
+		Key:   keyspace.GCManagementType,
+		Value: keyspace.KeyspaceLevelGC,
+	}})
 	re.NoError(err)
 
-	_, ok := s.manager.gcStateCache.load(keyspaceID)
+	_, err = s.manager.AdvanceTxnSafePoint(keyspaceIDUnified, 20, time.Now())
+	re.NoError(err)
+
+	_, ok := s.manager.gcStateCache.load(keyspaceIDUnified)
+	re.True(ok)
+
+	_, err = s.manager.keyspaceManager.UpdateKeyspaceConfig("ks3", []*keyspace.Mutation{{
+		Op:    keyspace.OpPut,
+		Key:   keyspace.GCManagementType,
+		Value: keyspace.UnifiedGC,
+	}})
+	re.NoError(err)
+
+	// The keyspace config change itself does not invalidate GCStateManager's local cache.
+	cachedState, ok := s.manager.gcStateCache.load(keyspaceIDUnified)
+	re.True(ok)
+	re.Equal(uint64(20), cachedState.TxnSafePoint)
+
+	allStates, err := s.manager.GetAllKeyspacesGCStates(context.Background(), false)
+	re.NoError(err)
+	re.Len(allStates, len(s.keyspacePresets.all))
+	state, ok := allStates[keyspaceIDUnified]
+	re.True(ok)
+	re.False(state.IsKeyspaceLevel)
+	re.Zero(state.TxnSafePoint)
+	re.Zero(state.GCSafePoint)
+
+	allStates, err = s.manager.GetAllKeyspacesGCStates(context.Background(), true)
+	re.NoError(err)
+	re.Len(allStates, len(s.keyspacePresets.all))
+	state, ok = allStates[keyspaceIDUnified]
+	re.True(ok)
+	re.False(state.IsKeyspaceLevel)
+	re.Zero(state.TxnSafePoint)
+	re.Zero(state.GCSafePoint)
+	_, ok = s.manager.gcStateCache.load(keyspaceIDUnified)
 	re.True(ok)
 
 	_, err = s.manager.keyspaceManager.UpdateKeyspaceState("ks2", keyspacepb.KeyspaceState_DISABLED, time.Now().Unix())
@@ -2038,23 +2080,23 @@ func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriers
 	re.NoError(err)
 
 	// The keyspace state change itself does not invalidate GCStateManager's local cache.
-	_, ok = s.manager.gcStateCache.load(keyspaceID)
+	_, ok = s.manager.gcStateCache.load(keyspaceIDArchived)
 	re.True(ok)
 
-	allStates, err := s.manager.GetAllKeyspacesGCStates(context.Background(), false)
+	allStates, err = s.manager.GetAllKeyspacesGCStates(context.Background(), false)
 	re.NoError(err)
 	re.Len(allStates, len(s.keyspacePresets.all)-1)
-	_, ok = allStates[keyspaceID]
+	_, ok = allStates[keyspaceIDArchived]
 	re.False(ok)
-	_, ok = s.manager.gcStateCache.load(keyspaceID)
+	_, ok = s.manager.gcStateCache.load(keyspaceIDArchived)
 	re.True(ok)
 
 	allStates, err = s.manager.GetAllKeyspacesGCStates(context.Background(), true)
 	re.NoError(err)
 	re.Len(allStates, len(s.keyspacePresets.all)-1)
-	_, ok = allStates[keyspaceID]
+	_, ok = allStates[keyspaceIDArchived]
 	re.False(ok)
-	_, ok = s.manager.gcStateCache.load(keyspaceID)
+	_, ok = s.manager.gcStateCache.load(keyspaceIDArchived)
 	re.False(ok)
 }
 

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -2297,6 +2297,44 @@ func (s *gcStateManagerTestSuite) TestAdvanceGCSafePointUpdatesWarmCache() {
 	re.Equal(beforeAdvance.miss, afterRead.miss)
 }
 
+func (s *gcStateManagerTestSuite) TestCompatibleUpdateGCSafePointSmallerTargetKeepsWarmCacheUsable() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 50, time.Now())
+	re.NoError(err)
+	_, _, err = s.manager.AdvanceGCSafePoint(keyspaceID, 40)
+	re.NoError(err)
+
+	state, err := s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(50), state.TxnSafePoint)
+	re.Equal(uint64(40), state.GCSafePoint)
+
+	beforeUpdate := tracker.snapshot()
+	oldGCSafePoint, newGCSafePoint, err := s.manager.CompatibleUpdateGCSafePoint(keyspaceID, 35)
+	re.NoError(err)
+	re.Equal(uint64(40), oldGCSafePoint)
+	re.Equal(uint64(40), newGCSafePoint)
+
+	cachedState, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
+	re.Equal(uint64(50), cachedState.TxnSafePoint)
+	re.Equal(uint64(40), cachedState.GCSafePoint)
+
+	state, err = s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(50), state.TxnSafePoint)
+	re.Equal(uint64(40), state.GCSafePoint)
+
+	afterRead := tracker.snapshot()
+	re.Equal(beforeUpdate.hit+1, afterRead.hit)
+	re.Equal(beforeUpdate.slowHit, afterRead.slowHit)
+	re.Equal(beforeUpdate.miss, afterRead.miss)
+}
+
 func (s *gcStateManagerTestSuite) TestSetGCBarrierKeepsWarmSafePointCacheUsable() {
 	re := s.Require()
 	s.ensureMarkedLeader()

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"os"
 	"slices"
 	"strconv"
@@ -29,8 +30,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/goleak"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -91,7 +94,9 @@ type newGCStateManagerForTestOptions struct {
 	// Nil for generating initial keyspaces by the default preset
 	// Non-nil (including empty) for generating specified keyspaces
 	specifyInitialKeyspaces []*keyspace.CreateKeyspaceByIDRequest
+	serverNodes             int
 	etcdServerCfgModifier   func(cfg *embed.Config)
+	etcdClientCfgModifier   etcdutil.CreateEtcdClientOpt
 }
 
 func (opt *newGCStateManagerForTestOptions) generateKeyspacesByCount(count int) {
@@ -114,8 +119,13 @@ func newGCStateManagerForTest(t testing.TB, opt newGCStateManagerForTestOptions)
 
 	var etcdClusterOpt etcdutil.TestEtcdClusterOptions
 	etcdClusterOpt.ServerCfgModifier = opt.etcdServerCfgModifier
+	etcdClusterOpt.ClientCfgModifier = opt.etcdClientCfgModifier
 
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, &etcdClusterOpt)
+	numNodes := opt.serverNodes
+	if numNodes <= 0 {
+		numNodes = 1
+	}
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, numNodes, &etcdClusterOpt)
 	kvBase := kv.NewEtcdKVBase(client)
 
 	// Simulate a member which id.Allocator may need to check.
@@ -198,6 +208,8 @@ func newGCStateManagerForTest(t testing.TB, opt newGCStateManagerForTestOptions)
 		}
 	}
 
+	gcStateManager.OnNodeBecomesLeader()
+
 	return s, s.GetGCStateProvider(), gcStateManager, clean, cancel
 }
 
@@ -226,6 +238,61 @@ func (s *gcStateManagerTestSuite) SetupTest() {
 func (s *gcStateManagerTestSuite) TearDownTest() {
 	s.cancel()
 	s.clean()
+}
+
+type gcStateCacheAccessCount struct {
+	hit     int
+	slowHit int
+	miss    int
+}
+
+type gcStateCacheAccessCounters struct {
+	sync.Mutex
+	gcStateCacheAccessCount
+}
+
+type gcStateCacheAccessCounterSnapshot struct {
+	gcStateCacheAccessCount
+}
+
+func (s *gcStateManagerTestSuite) ensureMarkedLeader() {
+	if !s.manager.nodeIsLeader() {
+		s.manager.OnNodeBecomesLeader()
+	}
+}
+
+func (s *gcStateManagerTestSuite) trackGCStateCacheAccessCounters() *gcStateCacheAccessCounters {
+	tracker := &gcStateCacheAccessCounters{}
+	failpointName := "github.com/tikv/pd/pkg/gc/getGCStateCacheAccess"
+	// Track cache access through a failpoint instead of reading Prometheus metrics directly.
+	// This keeps the test local to this suite and avoids adding a direct go.mod dependency
+	// on Prometheus' client_model package just for test assertions.
+	s.Require().NoError(failpoint.EnableCall(failpointName, func(result string) {
+		tracker.Lock()
+		defer tracker.Unlock()
+		switch result {
+		case "hit":
+			tracker.hit++
+		case "slow_hit":
+			tracker.slowHit++
+		case "miss":
+			tracker.miss++
+		default:
+			s.Require().FailNowf("unexpected GC state cache access result", "result: %s", result)
+		}
+	}))
+	s.T().Cleanup(func() {
+		s.Require().NoError(failpoint.Disable(failpointName))
+	})
+	return tracker
+}
+
+func (c *gcStateCacheAccessCounters) snapshot() gcStateCacheAccessCounterSnapshot {
+	c.Lock()
+	defer c.Unlock()
+	return gcStateCacheAccessCounterSnapshot{
+		gcStateCacheAccessCount: c.gcStateCacheAccessCount,
+	}
 }
 
 func (s *gcStateManagerTestSuite) checkTxnSafePoint(keyspaceID uint32, expectedTxnSafePoint uint64) {
@@ -1924,6 +1991,322 @@ func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriers
 	}
 }
 
+func (s *gcStateManagerTestSuite) TestGetGCStateCacheMissConcurrent() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	before := tracker.snapshot()
+
+	// Make every worker stop after the fast-path cache miss but before it can
+	// continue the slow path. Once released, every request is already past the
+	// fast-path cache lookup, so each request can only end up as either a
+	// slow-path miss or a slow-path cache hit, depending on scheduler
+	// interleaving around the cache update.
+	reachedSlowPath := make(chan struct{})
+	releaseSlowPath := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWorkers := func() {
+		releaseOnce.Do(func() {
+			close(releaseSlowPath)
+		})
+	}
+	defer releaseWorkers()
+
+	const concurrency = 6
+	var reachedCount atomic.Int32
+	failpointName := "github.com/tikv/pd/pkg/gc/getGCStateBeforeSlowPath"
+	re.NoError(failpoint.EnableCall(failpointName, func() {
+		if reachedCount.Add(1) == concurrency {
+			close(reachedSlowPath)
+		}
+		<-releaseSlowPath
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable(failpointName))
+	}()
+
+	type result struct {
+		state GCState
+		err   error
+	}
+	results := make(chan result, concurrency)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			state, err := s.manager.GetGCState(keyspaceID, true)
+			results <- result{state: state, err: err}
+		}()
+	}
+
+	select {
+	case <-reachedSlowPath:
+	case <-time.After(5 * time.Second):
+		re.FailNow("not all concurrent GetGCState calls reached the slow path")
+	}
+	releaseWorkers()
+
+	wg.Wait()
+	close(results)
+
+	var first GCState
+	for i := range concurrency {
+		res := <-results
+		re.NoError(res.err)
+		if i == 0 {
+			first = res.state
+			continue
+		}
+		re.Equal(first, res.state)
+	}
+
+	after := tracker.snapshot()
+	re.Equal(before.hit, after.hit)
+	re.Greater(after.miss, before.miss)
+	re.Equal(
+		before.miss+before.slowHit+concurrency,
+		after.miss+after.slowHit,
+	)
+
+	cachedState, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
+	re.Equal(first.TxnSafePoint, cachedState.TxnSafePoint)
+	re.Equal(first.GCSafePoint, cachedState.GCSafePoint)
+}
+
+func (s *gcStateManagerTestSuite) TestGetGCStateCacheHitConcurrent() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	// Warm the cache once. Every concurrent request below should then stay on
+	// the read-lock-protected fast path and avoid both slow hits and storage reads.
+	expected, err := s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+
+	before := tracker.snapshot()
+
+	const concurrency = 6
+	type result struct {
+		state GCState
+		err   error
+	}
+	results := make(chan result, concurrency)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer wg.Done()
+			state, err := s.manager.GetGCState(keyspaceID, true)
+			results <- result{state: state, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	for res := range results {
+		re.NoError(res.err)
+		re.Equal(expected, res.state)
+	}
+
+	after := tracker.snapshot()
+	re.Equal(before.hit+concurrency, after.hit)
+	re.Equal(before.slowHit, after.slowHit)
+	re.Equal(before.miss, after.miss)
+}
+
+func (s *gcStateManagerTestSuite) TestGetGCStateReadFailureDoesNotPopulateCache() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	before := tracker.snapshot()
+
+	// Corrupt only the persisted txn safe point. A failed load must return an
+	// error and, more importantly, must not install a zero-valued partial state
+	// into the cache.
+	re.NoError(s.storage.Save(keypath.TxnSafePointPath(keyspaceID), "invalid-txn-safe-point"))
+
+	_, err := s.manager.GetGCState(keyspaceID, true)
+	re.Error(err)
+	re.Contains(err.Error(), "invalid syntax")
+	_, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.False(ok)
+
+	afterFailure := tracker.snapshot()
+	re.Equal(before.miss+1, afterFailure.miss)
+	re.Equal(before.hit, afterFailure.hit)
+	re.Equal(before.slowHit, afterFailure.slowHit)
+
+	re.NoError(s.storage.Save(keypath.TxnSafePointPath(keyspaceID), "123"))
+
+	// After repairing storage, GetGCState must go back to storage again instead
+	// of returning a stale/empty cached value from the previous failed attempt.
+	state, err := s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(123), state.TxnSafePoint)
+	re.Empty(state.GCBarriers)
+
+	cachedState, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
+	re.Equal(uint64(123), cachedState.TxnSafePoint)
+
+	afterRecovery := tracker.snapshot()
+	re.Equal(before.miss+2, afterRecovery.miss)
+	re.Equal(before.hit, afterRecovery.hit)
+	re.Equal(before.slowHit, afterRecovery.slowHit)
+}
+
+func (s *gcStateManagerTestSuite) TestDeleteGCBarrierWithoutCacheTriggersFreshRead() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	now := time.Now().Truncate(time.Second)
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 20, now)
+	re.NoError(err)
+	s.manager.gcStateCache.remove(keyspaceID)
+	_, err = s.manager.SetGCBarrier(keyspaceID, "b1", 30, time.Hour, now)
+	re.NoError(err)
+
+	// GC barrier mutations do not populate the safe-point cache.
+	_, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.False(ok)
+
+	_, err = s.manager.DeleteGCBarrier(keyspaceID, "b1")
+	re.NoError(err)
+	_, ok = s.manager.gcStateCache.load(keyspaceID)
+	re.False(ok)
+
+	before := tracker.snapshot()
+
+	// Since no cache exists, the first excludeGCBarriers read after deletion
+	// must miss and reload the safe points from storage.
+	state, err := s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(20), state.TxnSafePoint)
+
+	after := tracker.snapshot()
+	re.Equal(before.miss+1, after.miss)
+	re.Equal(before.hit, after.hit)
+	re.Equal(before.slowHit, after.slowHit)
+}
+
+func (s *gcStateManagerTestSuite) TestDeleteGCBarrierKeepsWarmSafePointCacheUsable() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	now := time.Now().Truncate(time.Second)
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 20, now)
+	re.NoError(err)
+	_, err = s.manager.SetGCBarrier(keyspaceID, "b1", 30, time.Hour, now)
+	re.NoError(err)
+
+	_, err = s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+
+	// The cache only stores safe points. Deleting a barrier does not change
+	// those values, so a warmed excludeGCBarriers cache should stay reusable.
+	beforeDelete := tracker.snapshot()
+	_, err = s.manager.DeleteGCBarrier(keyspaceID, "b1")
+	re.NoError(err)
+
+	cachedState, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
+	re.Equal(uint64(20), cachedState.TxnSafePoint)
+
+	state, err := s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(20), state.TxnSafePoint)
+
+	afterRead := tracker.snapshot()
+	re.Equal(beforeDelete.hit+1, afterRead.hit)
+	re.Equal(beforeDelete.slowHit, afterRead.slowHit)
+	re.Equal(beforeDelete.miss, afterRead.miss)
+}
+
+func (s *gcStateManagerTestSuite) TestAdvanceGCSafePointUpdatesWarmCache() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 50, time.Now())
+	re.NoError(err)
+
+	state, err := s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(0), state.GCSafePoint)
+
+	beforeAdvance := tracker.snapshot()
+	oldGCSafePoint, newGCSafePoint, err := s.manager.AdvanceGCSafePoint(keyspaceID, 40)
+	re.NoError(err)
+	re.Equal(uint64(0), oldGCSafePoint)
+	re.Equal(uint64(40), newGCSafePoint)
+
+	state, err = s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(40), state.GCSafePoint)
+
+	// AdvanceGCSafePoint is expected to patch an existing cache entry rather
+	// than invalidate it or force the next read through storage.
+	afterRead := tracker.snapshot()
+	re.Equal(beforeAdvance.hit+1, afterRead.hit)
+	re.Equal(beforeAdvance.slowHit, afterRead.slowHit)
+	re.Equal(beforeAdvance.miss, afterRead.miss)
+}
+
+func (s *gcStateManagerTestSuite) TestSetGCBarrierKeepsWarmSafePointCacheUsable() {
+	re := s.Require()
+	s.ensureMarkedLeader()
+	tracker := s.trackGCStateCacheAccessCounters()
+
+	const keyspaceID = uint32(2)
+	now := time.Now().Truncate(time.Second)
+
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 25, now)
+	re.NoError(err)
+	_, _, err = s.manager.AdvanceGCSafePoint(keyspaceID, 10)
+	re.NoError(err)
+
+	state, err := s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(25), state.TxnSafePoint)
+	re.Equal(uint64(10), state.GCSafePoint)
+
+	// Setting a barrier should not invalidate or mutate the safe-point-only
+	// cache entry. excludeGCBarriers reads should keep hitting the warmed cache.
+	beforeSet := tracker.snapshot()
+	_, err = s.manager.SetGCBarrier(keyspaceID, "b1", 30, time.Hour, now)
+	re.NoError(err)
+
+	state, err = s.manager.GetGCState(keyspaceID, true)
+	re.NoError(err)
+	re.Equal(uint64(25), state.TxnSafePoint)
+	re.Equal(uint64(10), state.GCSafePoint)
+
+	afterFirstRead := tracker.snapshot()
+	re.Equal(beforeSet.hit+1, afterFirstRead.hit)
+	re.Equal(beforeSet.slowHit, afterFirstRead.slowHit)
+	re.Equal(beforeSet.miss, afterFirstRead.miss)
+
+	// A full read still sees the barrier from storage, showing that the cache
+	// remains intentionally limited to safe points.
+	state, err = s.manager.GetGCState(keyspaceID, false)
+	re.NoError(err)
+	re.Equal([]*endpoint.GCBarrier{
+		endpoint.NewGCBarrier("b1", 30, ptime(now.Add(time.Hour))),
+	}, state.GCBarriers)
+}
+
 func (s *gcStateManagerTestSuite) TestGetAllKeyspacesMaxTxnSafePoint() {
 	re := s.Require()
 
@@ -2335,15 +2718,20 @@ func TestGetMaxTxnSafePointAmongAllKeyspacesOnTooManyKeyspaces(t *testing.T) {
 	}
 }
 
-func benchmarkGetAllKeyspacesGCStatesImpl(b *testing.B, keyspacesCount int, parallelism int) {
+func benchmarkGetAllKeyspacesGCStatesImpl(b *testing.B, excludeGCBarriers bool, keyspacesCount int, parallelism int) {
 	re := require.New(b)
 	fname := testutil.InitTempFileLogger("info")
 	defer os.Remove(fname)
 
 	opt := newGCStateManagerForTestOptions{
 		specifyInitialKeyspaces: make([]*keyspace.CreateKeyspaceByIDRequest, 0, keyspacesCount),
+		serverNodes:             1,
 		etcdServerCfgModifier: func(cfg *embed.Config) {
 			cfg.LogOutputs = []string{fname}
+			cfg.LogLevel = "error"
+		},
+		etcdClientCfgModifier: func(cfg *clientv3.Config) {
+			cfg.LogConfig.Level.SetLevel(zapcore.ErrorLevel)
 		},
 	}
 	createTime := time.Now().Unix()
@@ -2368,52 +2756,230 @@ func benchmarkGetAllKeyspacesGCStatesImpl(b *testing.B, keyspacesCount int, para
 	b.ResetTimer()
 	if parallelism == 0 {
 		for range b.N {
-			_, err := gcStateManager.GetAllKeyspacesGCStates(context.Background(), false)
+			_, err := gcStateManager.GetAllKeyspacesGCStates(context.Background(), excludeGCBarriers)
 			re.NoError(err)
 		}
 	} else {
 		b.SetParallelism(parallelism)
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				_, err := gcStateManager.GetAllKeyspacesGCStates(context.Background(), false)
+				_, err := gcStateManager.GetAllKeyspacesGCStates(context.Background(), excludeGCBarriers)
 				re.NoError(err)
 			}
 		})
 	}
 	b.StopTimer()
 	execCount := gcStateManager.allKeyspacesGCStatesSingleFlight.ExecCount()
+	if excludeGCBarriers {
+		execCount = gcStateManager.allKeyspacesGCStatesExcludeGCBarriersSingleFlight.ExecCount()
+	}
 	b.ReportMetric(float64(execCount), "exec/op")
 	b.ReportMetric(1-float64(execCount)/float64(b.N), "reusing_rate")
 }
 
 func BenchmarkGetAllKeyspacesGCStates_KS1_SingleThread(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 1, 0)
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 1, 0)
 }
 
 func BenchmarkGetAllKeyspacesGCStates_KS1_P1(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 1, 1)
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 1, 1)
 }
 
 func BenchmarkGetAllKeyspacesGCStates_KS1_P8(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 1, 8)
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 1, 8)
 }
 
 func BenchmarkGetAllKeyspacesGCStates_KS1_P128(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 1, 128)
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 1, 128)
 }
 
-func BenchmarkGetAllKeyspacesGCStates_KS10_SingleThread(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 10, 0)
+func BenchmarkGetAllKeyspacesGCStates_KS100_SingleThread(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 100, 0)
 }
 
-func BenchmarkGetAllKeyspacesGCStates_KS10_P1(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 10, 1)
+func BenchmarkGetAllKeyspacesGCStates_KS100_P1(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 100, 1)
 }
 
-func BenchmarkGetAllKeyspacesGCStates_KS10_P8(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 10, 8)
+func BenchmarkGetAllKeyspacesGCStates_KS100_P8(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 100, 8)
 }
 
-func BenchmarkGetAllKeyspacesGCStates_KS10_P128(b *testing.B) {
-	benchmarkGetAllKeyspacesGCStatesImpl(b, 10, 128)
+func BenchmarkGetAllKeyspacesGCStates_KS100_P128(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, false, 100, 128)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS1_SingleThread(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 1, 0)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS1_P1(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 1, 1)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS1_P8(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 1, 8)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS1_P128(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 1, 128)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS100_SingleThread(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 100, 0)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS100_P1(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 100, 1)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS100_P8(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 100, 8)
+}
+
+func BenchmarkGetAllKeyspacesGCStates_ExcludeGCBarriers_KS100_P128(b *testing.B) {
+	benchmarkGetAllKeyspacesGCStatesImpl(b, true, 100, 128)
+}
+
+func benchmarkGetGCStateImpl(b *testing.B, excludeGCBarriers bool, keyspacesCount int, parallelism int, concurrentWriteThreads int) {
+	re := require.New(b)
+
+	fname := testutil.InitTempFileLogger("info")
+	defer os.Remove(fname)
+
+	opt := newGCStateManagerForTestOptions{
+		specifyInitialKeyspaces: make([]*keyspace.CreateKeyspaceByIDRequest, 0, keyspacesCount),
+		serverNodes:             1,
+		etcdServerCfgModifier: func(cfg *embed.Config) {
+			cfg.LogOutputs = []string{fname}
+			cfg.LogLevel = "error"
+		},
+		etcdClientCfgModifier: func(cfg *clientv3.Config) {
+			cfg.LogConfig.Level.SetLevel(zapcore.ErrorLevel)
+		},
+	}
+	createTime := time.Now().Unix()
+	for i := range keyspacesCount {
+		id := new(uint32)
+		*id = uint32(i + 1)
+		opt.specifyInitialKeyspaces = append(opt.specifyInitialKeyspaces, &keyspace.CreateKeyspaceByIDRequest{
+			ID:         id,
+			Name:       fmt.Sprintf("ks%d", *id),
+			Config:     map[string]string{keyspace.GCManagementType: keyspace.KeyspaceLevelGC},
+			CreateTime: createTime,
+		})
+	}
+
+	_, _, gcStateManager, clean, cancel := newGCStateManagerForTest(b, opt)
+	defer func() {
+		b.StopTimer()
+		cancel()
+		clean()
+	}()
+
+	stopWriteCh := make(chan struct{}, 1)
+	var wg sync.WaitGroup
+	wg.Add(concurrentWriteThreads)
+	for range concurrentWriteThreads {
+		go func() {
+			defer wg.Done()
+			for i := uint64(1); ; i++ {
+				select {
+				case <-stopWriteCh:
+					return
+				default:
+				}
+				keyspaceID := rand.Uint32N(uint32(keyspacesCount)) + 1
+				_, err := gcStateManager.AdvanceTxnSafePoint(keyspaceID, i, time.Now())
+				re.NoError(err)
+			}
+		}()
+	}
+	defer func() {
+		close(stopWriteCh)
+		wg.Wait()
+	}()
+
+	b.ResetTimer()
+	if parallelism == 0 {
+		for range b.N {
+			keyspaceID := rand.Uint32N(uint32(keyspacesCount)) + 1
+			_, err := gcStateManager.GetGCState(keyspaceID, excludeGCBarriers)
+			re.NoError(err)
+		}
+	} else {
+		b.SetParallelism(parallelism)
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				keyspaceID := rand.Uint32N(uint32(keyspacesCount)) + 1
+				_, err := gcStateManager.GetGCState(keyspaceID, excludeGCBarriers)
+				re.NoError(err)
+			}
+		})
+	}
+	b.StopTimer()
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS1_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 1, 0, 0)
+}
+
+func BenchmarkGetGCState_KS1_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 1, 0, 0)
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS1_W10_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 1, 0, 10)
+}
+
+func BenchmarkGetGCState_KS1_W10_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 1, 0, 10)
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS1_P64(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 1, 64, 0)
+}
+
+func BenchmarkGetGCState_KS1_P64(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 1, 64, 0)
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS1_P64_W10(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 1, 64, 10)
+}
+
+func BenchmarkGetGCState_KS1_P64_W10(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 1, 64, 10)
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS128_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 128, 0, 0)
+}
+
+func BenchmarkGetGCState_KS128_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 128, 0, 0)
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS128_W10_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 128, 0, 10)
+}
+
+func BenchmarkGetGCState_KS128_W10_SingleThread(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 128, 0, 10)
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS128_P64(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 128, 64, 0)
+}
+
+func BenchmarkGetGCState_KS128_P64(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 128, 64, 0)
+}
+
+func BenchmarkGetGCState_ExcludeGCBarriers_KS128_P64_W10(b *testing.B) {
+	benchmarkGetGCStateImpl(b, true, 128, 64, 10)
+}
+
+func BenchmarkGetGCState_KS128_P64_W10(b *testing.B) {
+	benchmarkGetGCStateImpl(b, false, 128, 64, 10)
 }

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -541,11 +541,41 @@ func (s *gcStateManagerTestSuite) testCompatibleGCSafePointUpdateSequentiallyImp
 }
 
 func (s *gcStateManagerTestSuite) TestCompatibleUpdateGCSafePointSequentiallyWithLegacyLoad() {
+	re := s.Require()
+
 	for _, keyspaceID := range s.keyspacePresets.manageable {
 		s.testCompatibleGCSafePointUpdateSequentiallyImpl(keyspaceID, func(keyspaceID uint32) (uint64, error) {
 			return s.manager.CompatibleLoadGCSafePoint(keyspaceID)
 		})
 	}
+
+	// Legacy load must bypass the local cache once this PD node is no longer leader.
+	const keyspaceID = uint32(2)
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 200, time.Now())
+	re.NoError(err)
+	_, newGCSafePoint, err := s.manager.CompatibleUpdateGCSafePoint(keyspaceID, 100)
+	re.NoError(err)
+	re.Equal(uint64(100), newGCSafePoint)
+
+	gcSafePoint, err := s.manager.CompatibleLoadGCSafePoint(keyspaceID)
+	re.NoError(err)
+	re.Equal(uint64(100), gcSafePoint)
+
+	cachedState, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
+	re.Equal(uint64(100), cachedState.GCSafePoint)
+
+	err = s.provider.RunInGCStateTransaction(func(wb *endpoint.GCStateWriteBatch) error {
+		return wb.SetGCSafePoint(keyspaceID, 101)
+	})
+	re.NoError(err)
+	oldLeadership := s.manager.nodeLeadership.Load()
+	s.manager.nodeLeadership.Store(0)
+	defer s.manager.nodeLeadership.Store(oldLeadership)
+
+	gcSafePoint, err = s.manager.CompatibleLoadGCSafePoint(keyspaceID)
+	re.NoError(err)
+	re.Equal(uint64(101), gcSafePoint)
 }
 
 func (s *gcStateManagerTestSuite) TestCompatibleUpdateGCSafePointSequentiallyWithNewLoad() {

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -1991,6 +1991,39 @@ func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriers
 	}
 }
 
+func (s *gcStateManagerTestSuite) TestGetAllKeyspacesGCStatesExcludingGCBarriersFiltersArchivedCachedState() {
+	re := s.Require()
+
+	const keyspaceID = uint32(2)
+
+	_, err := s.manager.AdvanceTxnSafePoint(keyspaceID, 20, time.Now())
+	re.NoError(err)
+
+	_, ok := s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
+
+	_, err = s.manager.keyspaceManager.UpdateKeyspaceState("ks2", keyspacepb.KeyspaceState_DISABLED, time.Now().Unix())
+	re.NoError(err)
+	_, err = s.manager.keyspaceManager.UpdateKeyspaceState("ks2", keyspacepb.KeyspaceState_ARCHIVED, time.Now().Unix())
+	re.NoError(err)
+
+	// The keyspace state change itself does not invalidate GCStateManager's local cache.
+	_, ok = s.manager.gcStateCache.load(keyspaceID)
+	re.True(ok)
+
+	allStates, err := s.manager.GetAllKeyspacesGCStates(context.Background(), false)
+	re.NoError(err)
+	re.Len(allStates, len(s.keyspacePresets.all)-1)
+	_, ok = allStates[keyspaceID]
+	re.False(ok)
+
+	allStates, err = s.manager.GetAllKeyspacesGCStates(context.Background(), true)
+	re.NoError(err)
+	re.Len(allStates, len(s.keyspacePresets.all)-1)
+	_, ok = allStates[keyspaceID]
+	re.False(ok)
+}
+
 func (s *gcStateManagerTestSuite) TestGetGCStateCacheMissConcurrent() {
 	re := s.Require()
 	s.ensureMarkedLeader()

--- a/pkg/gc/gc_state_manager_test.go
+++ b/pkg/gc/gc_state_manager_test.go
@@ -2979,20 +2979,27 @@ func benchmarkGetGCStateImpl(b *testing.B, excludeGCBarriers bool, keyspacesCoun
 	}()
 
 	stopWriteCh := make(chan struct{}, 1)
+	var txnSafePointAlloc atomic.Uint64
 	var wg sync.WaitGroup
 	wg.Add(concurrentWriteThreads)
 	for range concurrentWriteThreads {
 		go func() {
 			defer wg.Done()
-			for i := uint64(1); ; i++ {
+			for {
 				select {
 				case <-stopWriteCh:
 					return
 				default:
 				}
+				nextTxnSafePoint := txnSafePointAlloc.Add(1)
 				keyspaceID := rand.Uint32N(uint32(keyspacesCount)) + 1
-				_, err := gcStateManager.AdvanceTxnSafePoint(keyspaceID, i, time.Now())
-				re.NoError(err)
+				_, err := gcStateManager.AdvanceTxnSafePoint(keyspaceID, nextTxnSafePoint, time.Now())
+				if err != nil {
+					if errors.ErrorEqual(err, errs.ErrDecreasingTxnSafePoint) {
+						continue
+					}
+					re.NoError(err)
+				}
 			}
 		}()
 	}

--- a/pkg/gc/metrics.go
+++ b/pkg/gc/metrics.go
@@ -24,8 +24,20 @@ var (
 			Name:      "gc_safepoint",
 			Help:      "The ts of gc safepoint",
 		}, []string{"type"})
+	gcStateCacheAccessCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "gc",
+			Name:      "gc_state_cache_access_total",
+			Help:      "Counter of GC state cache accesses by result.",
+		}, []string{"result"})
+
+	gcStateCacheAccessHitCounter     = gcStateCacheAccessCounter.WithLabelValues("hit")
+	gcStateCacheAccessSlowHitCounter = gcStateCacheAccessCounter.WithLabelValues("slow_hit")
+	gcStateCacheAccessMissCounter    = gcStateCacheAccessCounter.WithLabelValues("miss")
 )
 
 func init() {
 	prometheus.MustRegister(gcSafePointGauge)
+	prometheus.MustRegister(gcStateCacheAccessCounter)
 }

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -277,30 +277,37 @@ const (
 	McsEtcdClientPurpose EtcdClientPurpose = "mcs-etcd-client"
 )
 
-func newClient(tlsConfig *tls.Config, endpoints ...string) (*clientv3.Client, error) {
+// CreateEtcdClientOpt is an alias of the function that edits clientv3.Config.
+type CreateEtcdClientOpt func(*clientv3.Config)
+
+func newClient(tlsConfig *tls.Config, endpoints []string, opts ...CreateEtcdClientOpt) (*clientv3.Client, error) {
 	if len(endpoints) == 0 {
 		return nil, errs.ErrNewEtcdClient.FastGenByArgs("empty etcd endpoints")
 	}
 	lgc := zap.NewProductionConfig()
 	lgc.Encoding = log.ZapEncodingName
-	client, err := clientv3.New(clientv3.Config{
+	cfg := clientv3.Config{
 		Endpoints:            endpoints,
 		DialTimeout:          defaultEtcdClientTimeout,
 		TLS:                  tlsConfig,
 		LogConfig:            &lgc,
 		DialKeepAliveTime:    defaultDialKeepAliveTime,
 		DialKeepAliveTimeout: defaultDialKeepAliveTimeout,
-	})
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	client, err := clientv3.New(cfg)
 	return client, err
 }
 
 // CreateEtcdClient creates etcd v3 client with detecting endpoints.
-func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL, purpose EtcdClientPurpose, enableChecker bool) (*clientv3.Client, error) {
+func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL, purpose EtcdClientPurpose, enableChecker bool, opts ...CreateEtcdClientOpt) (*clientv3.Client, error) {
 	urls := make([]string, 0, len(acURLs))
 	for _, u := range acURLs {
 		urls = append(urls, u.String())
 	}
-	client, err := newClient(tlsConfig, urls...)
+	client, err := newClient(tlsConfig, urls, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +317,7 @@ func CreateEtcdClient(tlsConfig *tls.Config, acURLs []url.URL, purpose EtcdClien
 		tickerInterval = 100 * time.Millisecond
 	})
 	if enableChecker {
-		initHealthChecker(tickerInterval, tlsConfig, client, purpose)
+		initHealthChecker(tickerInterval, tlsConfig, client, purpose, opts...)
 	}
 
 	return client, err

--- a/pkg/utils/etcdutil/health_checker.go
+++ b/pkg/utils/etcdutil/health_checker.go
@@ -62,6 +62,8 @@ type healthChecker struct {
 	// the checked healthy endpoints dynamically and periodically.
 	client *clientv3.Client
 
+	clientOpts []CreateEtcdClientOpt
+
 	endpointCountState prometheus.Gauge
 }
 
@@ -71,12 +73,14 @@ func initHealthChecker(
 	tlsConfig *tls.Config,
 	client *clientv3.Client,
 	purpose EtcdClientPurpose,
+	opts ...CreateEtcdClientOpt,
 ) {
 	healthChecker := &healthChecker{
 		source:             string(purpose),
 		tickerInterval:     tickerInterval,
 		tlsConfig:          tlsConfig,
 		client:             client,
+		clientOpts:         opts,
 		endpointCountState: etcdStateGauge.WithLabelValues(string(purpose), endpointLabel),
 	}
 	// A health checker has the same lifetime with the given etcd client.
@@ -362,7 +366,7 @@ func (checker *healthChecker) update() {
 	for ep := range epMap {
 		client := checker.loadClient(ep)
 		if client == nil {
-			checker.initClient(ep)
+			checker.initClient(ep, checker.clientOpts...)
 			continue
 		}
 		since := time.Since(client.lastHealth)
@@ -413,8 +417,8 @@ func (checker *healthChecker) loadClient(ep string) *healthyClient {
 	return nil
 }
 
-func (checker *healthChecker) initClient(ep string) {
-	client, err := newClient(checker.tlsConfig, ep)
+func (checker *healthChecker) initClient(ep string, opts ...CreateEtcdClientOpt) {
+	client, err := newClient(checker.tlsConfig, []string{ep}, opts...)
 	if err != nil {
 		log.Error("failed to create etcd healthy client",
 			zap.String("endpoint", ep),

--- a/pkg/utils/etcdutil/testutil.go
+++ b/pkg/utils/etcdutil/testutil.go
@@ -66,6 +66,7 @@ func genRandName() string {
 // TestEtcdClusterOptions is the options for NewTestEtcdCluster.
 type TestEtcdClusterOptions struct {
 	ServerCfgModifier func(cfg *embed.Config)
+	ClientCfgModifier CreateEtcdClientOpt
 }
 
 // NewTestEtcdCluster is used to create a etcd cluster for the unit test purpose.
@@ -80,7 +81,11 @@ func NewTestEtcdCluster(t testing.TB, count int, opt *TestEtcdClusterOptions) (s
 	}
 	etcd, err := embed.StartEtcd(cfg)
 	re.NoError(err)
-	etcdClient, err = CreateEtcdClient(nil, cfg.ListenClientUrls, TestEtcdClientPurpose, true)
+	var clientOpts []CreateEtcdClientOpt
+	if opt != nil && opt.ClientCfgModifier != nil {
+		clientOpts = append(clientOpts, opt.ClientCfgModifier)
+	}
+	etcdClient, err = CreateEtcdClient(nil, cfg.ListenClientUrls, TestEtcdClientPurpose, true, clientOpts...)
 	re.NoError(err)
 	<-etcd.Server.ReadyNotify()
 	servers = append(servers, etcd)
@@ -127,6 +132,7 @@ func MustAddEtcdMember(t testing.TB, cfg1 *embed.Config, client *clientv3.Client
 	cfg2.Name = genRandName()
 	cfg2.InitialCluster = cfg1.InitialCluster + fmt.Sprintf(",%s=%s", cfg2.Name, &cfg2.ListenPeerUrls[0])
 	cfg2.ClusterState = embed.ClusterStateFlagExisting
+	cfg2.LogLevel = cfg1.LogLevel
 	peerURL := cfg2.ListenPeerUrls[0].String()
 	addResp, err := AddEtcdMember(client, []string{peerURL})
 	re.NoError(err)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -43,6 +43,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/gc"
 	"github.com/tikv/pd/pkg/gctuner"
 	"github.com/tikv/pd/pkg/id"
 	"github.com/tikv/pd/pkg/keyspace"
@@ -141,6 +142,7 @@ type Server interface {
 	GetKeyspaceGroupManager() *keyspace.GroupManager
 	IsKeyspaceGroupEnabled() bool
 	GetMeteringWriter() *metering.Writer
+	GetGCStateManager() *gc.GCStateManager
 }
 
 // RaftCluster is used for cluster config management.
@@ -202,6 +204,8 @@ type RaftCluster struct {
 	logRunner ratelimit.Runner
 	// syncRegionRunner is used to sync region asynchronously.
 	syncRegionRunner ratelimit.Runner
+
+	stopGCStateManager func()
 }
 
 // Status saves some state information.
@@ -470,6 +474,10 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 	go c.startGCTuner()
 	go c.startProgressGC()
 	go c.runStorageSizeCollector(s.GetMeteringWriter(), c.regionLabeler, s.GetKeyspaceManager())
+
+	s.GetGCStateManager().OnNodeBecomesLeader()
+	c.stopGCStateManager = s.GetGCStateManager().OnNodeBecomesFollower
+
 	log.Info("start background jobs completed", zap.Duration("cost", time.Since(backgroundJobsStart)))
 	runnersStart := time.Now()
 	c.running = true
@@ -981,6 +989,9 @@ func (c *RaftCluster) Stop() {
 	c.miscRunner.Stop()
 	c.logRunner.Stop()
 	c.syncRegionRunner.Stop()
+	if c.stopGCStateManager != nil {
+		c.stopGCStateManager()
+	}
 	c.Unlock()
 
 	c.wg.Wait()

--- a/server/gc_service.go
+++ b/server/gc_service.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 
@@ -710,6 +711,8 @@ func (s *GrpcServer) GetGCState(ctx context.Context, request *pdpb.GetGCStateReq
 			Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
 		}, nil
 	}
+
+	failpoint.InjectCall("postGetGCStateCall")
 
 	return &pdpb.GetGCStateResponse{
 		Header:  grpcutil.WrapHeader(),

--- a/tests/server/api/service_gc_safepoint_test.go
+++ b/tests/server/api/service_gc_safepoint_test.go
@@ -115,6 +115,9 @@ func (suite *serviceGCSafepointTestSuite) checkServiceGCSafepoint(cluster *tests
 	re.NoError(err)
 	re.Equal(list, listResp)
 
+	// The following delete bypasses GCStateManager and writes storage directly.
+	// Subsequent reads through both the manager and the public HTTP endpoint
+	// should still reflect the deletion.
 	err = testutil.CheckDelete(tests.TestDialClient, sspURL+"/a", testutil.StatusOK(re))
 	re.NoError(err)
 
@@ -127,4 +130,18 @@ func (suite *serviceGCSafepointTestSuite) checkServiceGCSafepoint(cluster *tests
 	}
 	// Exclude the gc_worker as it's not included in GetGCState's result.
 	re.Equal(list.ServiceGCSafepoints[1:3], leftSsps)
+
+	resAfterDelete, err := tests.TestDialClient.Get(sspURL)
+	re.NoError(err)
+	defer resAfterDelete.Body.Close()
+	listRespAfterDelete := &api.ListServiceGCSafepoint{}
+	err = apiutil.ReadJSON(resAfterDelete.Body, listRespAfterDelete)
+	re.NoError(err)
+	// Also verify the public HTTP view, not only the direct GCStateManager read.
+	expectedAfterDelete := &api.ListServiceGCSafepoint{
+		ServiceGCSafepoints:   list.ServiceGCSafepoints[1:],
+		GCSafePoint:           list.GCSafePoint,
+		MinServiceGcSafepoint: list.MinServiceGcSafepoint,
+	}
+	re.Equal(expectedAfterDelete, listRespAfterDelete)
 }

--- a/tests/server/gc/gc_test.go
+++ b/tests/server/gc/gc_test.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"math"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/keyspace"
@@ -39,6 +41,95 @@ import (
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+const (
+	postGetGCStateCallFailpoint       = "github.com/tikv/pd/server/postGetGCStateCall"
+	getGCStateBeforeSlowPathFailpoint = "github.com/tikv/pd/pkg/gc/getGCStateBeforeSlowPath"
+	skipCampaignLeaderCheckFailpoint  = "github.com/tikv/pd/pkg/member/skipCampaignLeaderCheck"
+)
+
+func newGCStateLeaderTransitionCluster(t *testing.T) (*tests.TestCluster, *pdpb.GetGCStateRequest, func()) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// These tests need two PDs so the request can target a concrete old leader
+	// while another node takes over leadership.
+	cluster, err := tests.NewTestCluster(ctx, 2, func(conf *config.Config, _ string) {
+		conf.Keyspace.WaitRegionSplit = false
+	})
+	re.NoError(err)
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+	re.NoError(failpoint.Enable(skipCampaignLeaderCheckFailpoint, "return(true)"))
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	re.NoError(leaderServer.BootstrapCluster())
+
+	req := &pdpb.GetGCStateRequest{
+		Header:        testutil.NewRequestHeader(leaderServer.GetClusterID()),
+		KeyspaceScope: &pdpb.KeyspaceScope{KeyspaceId: constant.NullKeyspaceID},
+	}
+	cleanup := func() {
+		re.NoError(failpoint.Disable(skipCampaignLeaderCheckFailpoint))
+		cancel()
+		cluster.Destroy()
+	}
+	return cluster, req, cleanup
+}
+
+func getGCStateFromAddr(ctx context.Context, re *require.Assertions, addr string, req *pdpb.GetGCStateRequest) (*pdpb.GetGCStateResponse, error) {
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, addr)
+	defer conn.Close()
+	return grpcPDClient.GetGCState(ctx, req)
+}
+
+type blockingFailpoint struct {
+	name        string
+	reached     chan struct{}
+	release     chan struct{}
+	reachedOnce sync.Once
+	releaseOnce sync.Once
+	disableOnce sync.Once
+}
+
+func enableBlockingFailpoint(re *require.Assertions, name string) *blockingFailpoint {
+	point := &blockingFailpoint{
+		name:    name,
+		reached: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	re.NoError(failpoint.EnableCall(name, func() {
+		point.reachedOnce.Do(func() {
+			close(point.reached)
+		})
+		<-point.release
+	}))
+	return point
+}
+
+func (p *blockingFailpoint) wait(re *require.Assertions, description string) {
+	// Always use a bounded wait: if a future refactor moves/removes the target
+	// failpoint, the test should fail quickly instead of hanging until the
+	// request context times out.
+	select {
+	case <-p.reached:
+	case <-time.After(5 * time.Second):
+		re.FailNow("GetGCState did not reach the failpoint", description)
+	}
+}
+
+func (p *blockingFailpoint) releaseAndDisable(re *require.Assertions) {
+	// Tests may release explicitly and still run deferred cleanup. Make both
+	// operations idempotent so failure paths do not panic on double close or
+	// double disable.
+	p.releaseOnce.Do(func() {
+		close(p.release)
+	})
+	p.disableOnce.Do(func() {
+		re.NoError(failpoint.Disable(p.name))
+	})
 }
 
 func TestGCOperations(t *testing.T) {
@@ -413,4 +504,206 @@ func TestGCOperations(t *testing.T) {
 		re.Equal(uint64(20), resp.GetOldTxnSafePoint())
 		re.Contains(resp.GetBlockerDescription(), "b2")
 	}
+}
+
+func TestGetGCStateRejectsOldLeaderAfterTransfer(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	oldLeader := cluster.GetLeader()
+	re.NotEmpty(oldLeader)
+	oldLeaderServer := cluster.GetServer(oldLeader)
+	re.NotNil(oldLeaderServer)
+
+	// Once the cluster agrees on a new PD leader, the old leader should reject a
+	// direct GetGCState request at the normal gRPC role check, regardless of any
+	// local GC state cache it may have had.
+	re.NoError(oldLeaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	_, err := getGCStateFromAddr(context.Background(), re, oldLeaderServer.GetAddr(), req)
+	re.ErrorContains(err, "not leader")
+}
+
+func TestGetGCStateReturnsCachedStateIfLeaderLostBeforeReply(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	req.ExcludeGcBarriers = true
+
+	// Warm the local cache so the blocked request has already obtained its
+	// cached result before the leadership transfer happens.
+	_, err := leaderServer.GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 10, time.Now())
+	re.NoError(err)
+	resp, err := getGCStateFromAddr(context.Background(), re, leaderServer.GetAddr(), req)
+	re.NoError(err)
+	re.Nil(resp.GetHeader().GetError())
+	re.Equal(uint64(10), resp.GetGcState().GetTxnSafePoint())
+
+	point := enableBlockingFailpoint(re, postGetGCStateCallFailpoint)
+	defer point.releaseAndDisable(re)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+
+	type result struct {
+		resp *pdpb.GetGCStateResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() {
+		resp, err := grpcPDClient.GetGCState(reqCtx, req)
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	point.wait(re, "after GetGCState has returned and before the handler replies")
+	oldLeader := leaderServer.GetConfig().Name
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	// Even if another leader advances the persisted state while the request is
+	// blocked, this already-read cache-hit request should still return the value
+	// it obtained before the transfer.
+	_, err = cluster.GetLeaderServer().GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 20, time.Now())
+	re.NoError(err)
+
+	point.releaseAndDisable(re)
+	res := <-resultCh
+	re.NoError(res.err)
+	re.Nil(res.resp.GetHeader().GetError())
+	re.Equal(uint64(10), res.resp.GetGcState().GetTxnSafePoint())
+
+	freshResp, err := getGCStateFromAddr(context.Background(), re, cluster.GetLeaderServer().GetAddr(), req)
+	re.NoError(err)
+	re.Nil(freshResp.GetHeader().GetError())
+	re.Equal(uint64(20), freshResp.GetGcState().GetTxnSafePoint())
+}
+
+func TestGetGCStateReturnsCachedStateAfterLeadershipRecovery(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	oldLeader := leaderServer.GetConfig().Name
+	req.ExcludeGcBarriers = true
+
+	_, err := leaderServer.GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 10, time.Now())
+	re.NoError(err)
+	resp, err := getGCStateFromAddr(context.Background(), re, leaderServer.GetAddr(), req)
+	re.NoError(err)
+	re.Nil(resp.GetHeader().GetError())
+	re.Equal(uint64(10), resp.GetGcState().GetTxnSafePoint())
+
+	// This test pins the current cache-hit behavior; it does not claim that this
+	// is the ideal long-term contract. Once the request has already obtained the
+	// cached GC state and is paused in the handler, leadership churn does not
+	// change that already-read value. If GetGCState is intentionally tightened in
+	// the future, update this test together with the corresponding semantics
+	// documentation.
+	point := enableBlockingFailpoint(re, postGetGCStateCallFailpoint)
+	defer point.releaseAndDisable(re)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+
+	type result struct {
+		resp *pdpb.GetGCStateResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() {
+		resp, err := grpcPDClient.GetGCState(reqCtx, req)
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	point.wait(re, "after GetGCState has returned and before the handler replies")
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	// Let the temporary new leader advance the persisted state. The blocked
+	// request should still return its already-read cached value after the old
+	// leader regains leadership, while a later fresh request should see this
+	// newer value.
+	_, err = cluster.GetLeaderServer().GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 20, time.Now())
+	re.NoError(err)
+
+	re.NoError(cluster.GetServer(newLeader).ResignLeaderWithRetry())
+	re.Equal(oldLeader, cluster.WaitLeader())
+
+	point.releaseAndDisable(re)
+	res := <-resultCh
+	re.NoError(res.err)
+	re.Nil(res.resp.GetHeader().GetError())
+	re.Equal(uint64(10), res.resp.GetGcState().GetTxnSafePoint())
+
+	freshResp, err := getGCStateFromAddr(context.Background(), re, cluster.GetServer(oldLeader).GetAddr(), req)
+	re.NoError(err)
+	re.Nil(freshResp.GetHeader().GetError())
+	re.Equal(uint64(20), freshResp.GetGcState().GetTxnSafePoint())
+}
+
+func TestGetGCStateSlowPathReadsLatestStateIfLeaderLostBeforeRead(t *testing.T) {
+	re := require.New(t)
+	cluster, req, cleanup := newGCStateLeaderTransitionCluster(t)
+	defer cleanup()
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	oldLeader := leaderServer.GetConfig().Name
+	req.ExcludeGcBarriers = true
+
+	// Start with no local cache and stop immediately before the slow path. The
+	// request has already passed the initial server-side role check, but after
+	// the transfer the manager must bypass cache and continue with the IO read.
+	point := enableBlockingFailpoint(re, getGCStateBeforeSlowPathFailpoint)
+	defer point.releaseAndDisable(re)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+
+	type result struct {
+		resp *pdpb.GetGCStateResponse
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	go func() {
+		resp, err := grpcPDClient.GetGCState(reqCtx, req)
+		resultCh <- result{resp: resp, err: err}
+	}()
+
+	point.wait(re, "before the no-cache slow path reads from storage")
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	newLeader := cluster.WaitLeader()
+	re.NotEmpty(newLeader)
+	re.NotEqual(oldLeader, newLeader)
+
+	// The new leader advances the persisted state while the old leader's request
+	// is blocked. Once released, the in-flight request should still succeed on
+	// the old follower by reading the latest state from storage.
+	_, err := cluster.GetLeaderServer().GetServer().GetGCStateManager().AdvanceTxnSafePoint(constant.NullKeyspaceID, 20, time.Now())
+	re.NoError(err)
+
+	point.releaseAndDisable(re)
+	res := <-resultCh
+	re.NoError(res.err)
+	re.Nil(res.resp.GetHeader().GetError())
+	re.Equal(uint64(20), res.resp.GetGcState().GetTxnSafePoint())
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref #10659 , Close #10607

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
This PR implements GC state cache. It now caches GC safe points and txn safe points of all keyspaces in memory, and can be used by GetGCState and GetAllKeyspacesGCStates.
This is a formal version of #10615 , and includes tests from #10617 with proper adaptions
```

**Requires**:

* https://github.com/pingcap/kvproto/pull/1461
* https://github.com/tikv/pd/pull/10669

**Note**:

This PR has some different behavior from #10615 :

* The second leader check in `GrpcServer` after invoking `GCStateManager` is removed.
* `GCStateManager` has built-in leader check. Cache-read is disallowed when it's not leader, but it can still try etcd IO read in this case, as etcd should be able to guarantee the consistency.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Option to exclude GC barriers from GC state views; new metric reporting cache access outcomes.

* **Performance Improvements**
  - Leader-aware, sharded in-memory per-keyspace GC state cache with automatic invalidation on leadership changes to reduce safe-point read latency.

* **Tests**
  - Expanded unit/integration tests and benchmarks for cache semantics, concurrency, leadership churn, exclusion behavior, and failure recovery.

* **Chores**
  - Cluster lifecycle integration and client/health-checker test harness configurability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->