### PR TITLE
schedule: add split-scatter for release-8.5-20251204-v8.5.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.23.12
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.
 // After the PR to kvproto is merged, remember to comment this out and run `go mod tidy`.
 // replace github.com/pingcap/kvproto => github.com/$YourPrivateRepo $YourPrivateBranch
+
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/BurntSushi/toml v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ go 1.23.12
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.
 // After the PR to kvproto is merged, remember to comment this out and run `go mod tidy`.
 // replace github.com/pingcap/kvproto => github.com/$YourPrivateRepo $YourPrivateBranch
-replace github.com/pingcap/kvproto => github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf
-
 require (
 	github.com/AlekSi/gocov-xml v1.0.0
 	github.com/BurntSushi/toml v0.3.1
@@ -35,7 +33,7 @@ require (
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8
+	github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
 	github.com/pingcap/tidb-dashboard v0.0.0-20251001025619-8cfdaf48f4b1
@@ -157,7 +155,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,8 @@ require (
 	gotest.tools/gotestsum v1.7.0
 )
 
+require github.com/kylelemons/godebug v1.1.0 // indirect
+
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
@@ -156,7 +158,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
-	github.com/prometheus/client_model v0.6.1
+	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.23.12
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.
 // After the PR to kvproto is merged, remember to comment this out and run `go mod tidy`.
 // replace github.com/pingcap/kvproto => github.com/$YourPrivateRepo $YourPrivateBranch
+replace github.com/pingcap/kvproto => github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf h1:RnQHw1A6bxOts77JHM5COX2Vw3eRd5RambAlET4+4qQ=
+github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a h1:N9zuLhTvBSRt0gWSiJswwQ2HqDmtX/ZCDJURnKUt1Ik=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,6 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf h1:RnQHw1A6bxOts77JHM5COX2Vw3eRd5RambAlET4+4qQ=
-github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a h1:N9zuLhTvBSRt0gWSiJswwQ2HqDmtX/ZCDJURnKUt1Ik=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
@@ -395,8 +393,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8 h1:RiYvpna6b7GSGIIFFu6R92T/eq1KgOiK1ry6w/60x+Y=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721 h1:Y8/FeTGB0zVoJ2sRN5o/uRUC7aZjSeY8acryhX4oYFg=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -25,6 +25,7 @@ var (
 	tablePrefix  = []byte{'t'}
 	metaPrefix   = []byte{'m'}
 	recordPrefix = []byte("_r")
+	indexPrefix  = []byte("_i")
 )
 
 const (
@@ -189,12 +190,32 @@ func GenerateTableKey(tableID int64) []byte {
 	return buf
 }
 
+func appendRecordKeyPrefix(buf []byte, tableID int64) []byte {
+	buf = append(buf, tablePrefix...)
+	buf = EncodeInt(buf, tableID)
+	return append(buf, recordPrefix...)
+}
+
+// GenerateRecordKeyPrefix generates a table record key prefix.
+func GenerateRecordKeyPrefix(tableID int64) []byte {
+	buf := make([]byte, 0, len(tablePrefix)+len(recordPrefix)+8)
+	return appendRecordKeyPrefix(buf, tableID)
+}
+
 // GenerateRowKey generates a row key.
 func GenerateRowKey(tableID, rowID int64) []byte {
 	buf := make([]byte, 0, len(tablePrefix)+len(recordPrefix)+8*2)
+	buf = appendRecordKeyPrefix(buf, tableID)
+	buf = EncodeInt(buf, rowID)
+	return buf
+}
+
+// GenerateIndexKey generates an index key prefix.
+func GenerateIndexKey(tableID, indexID int64) []byte {
+	buf := make([]byte, 0, len(tablePrefix)+len(indexPrefix)+8*2)
 	buf = append(buf, tablePrefix...)
 	buf = EncodeInt(buf, tableID)
-	buf = append(buf, recordPrefix...)
-	buf = EncodeInt(buf, rowID)
+	buf = append(buf, indexPrefix...)
+	buf = EncodeInt(buf, indexID)
 	return buf
 }

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -47,3 +47,20 @@ func TestTableID(t *testing.T) {
 	key = EncodeBytes([]byte("t\x80\x00\x00\x00\x00\x00\xff"))
 	re.Equal(int64(0), key.TableID())
 }
+
+func TestGenerateRecordAndIndexKeys(t *testing.T) {
+	re := require.New(t)
+	tableID := int64(42)
+	indexID := int64(7)
+
+	rowKeyPrefix := GenerateRecordKeyPrefix(tableID)
+	rowKey := GenerateRowKey(tableID, 1)
+	re.Equal(rowKeyPrefix, rowKey[:len(rowKeyPrefix)])
+	re.Equal(tableID, EncodeBytes(rowKey).TableID())
+
+	indexKey := GenerateIndexKey(tableID, indexID)
+	_, decodedIndexKey, err := DecodeBytes(EncodeBytes(indexKey))
+	re.NoError(err)
+	re.Equal(indexKey, decodedIndexKey)
+	re.Equal(tableID, EncodeBytes(indexKey).TableID())
+}

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -340,6 +340,11 @@ func (o *PersistConfig) IsPlacementRulesEnabled() bool {
 	return o.GetReplicationConfig().EnablePlacementRules
 }
 
+// GetSplitScatterScheduleLimit returns the limit for split-scatter schedule.
+func (o *PersistConfig) GetSplitScatterScheduleLimit() uint64 {
+	return o.getTTLUintOr(sc.SplitScatterScheduleLimitKey, o.GetScheduleConfig().SplitScatterScheduleLimit)
+}
+
 // GetLowSpaceRatio returns the low space ratio.
 func (o *PersistConfig) GetLowSpaceRatio() float64 {
 	return o.GetScheduleConfig().LowSpaceRatio

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -326,6 +326,9 @@ func (s *Service) AskBatchSplit(_ context.Context, request *schedulingpb.AskBatc
 	// status may be left, and these regions need to be checked with higher
 	// priority.
 	c.GetCoordinator().GetCheckerController().AddPendingProcessedRegions(false, recordRegions...)
+	// TODO(split-scatter): if load-based split-scatter is supported on the
+	// scheduling-service/NEXT_GEN path, record split-scatter batches here and
+	// plumb SplitReason through the forwarding request.
 
 	return &schedulingpb.AskBatchSplitResponse{
 		Header: wrapHeader(),

--- a/pkg/schedule/checker/checker_controller.go
+++ b/pkg/schedule/checker/checker_controller.go
@@ -72,6 +72,7 @@ type Controller struct {
 	mergeChecker            *MergeChecker
 	jointStateChecker       *JointStateChecker
 	priorityInspector       *PriorityInspector
+	splitScatter            *splitScatterController
 	pendingProcessedRegions *cache.TTLUint64
 	suspectKeyRanges        *cache.TTLString // suspect key-range regions that may need fix
 	patrolRegionContext     *PatrolRegionContext
@@ -96,7 +97,7 @@ type Controller struct {
 // NewController create a new Controller.
 func NewController(ctx context.Context, cluster sche.CheckerCluster, conf config.CheckerConfigProvider, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler, opController *operator.Controller) *Controller {
 	pendingProcessedRegions := cache.NewIDTTL(ctx, time.Minute, 3*time.Minute)
-	return &Controller{
+	c := &Controller{
 		ctx:                     ctx,
 		cluster:                 cluster,
 		conf:                    conf,
@@ -114,6 +115,8 @@ func NewController(ctx context.Context, cluster sche.CheckerCluster, conf config
 		interval:                cluster.GetCheckerConfig().GetPatrolRegionInterval(),
 		patrolRegionScanLimit:   calculateScanLimit(cluster),
 	}
+	c.splitScatter = newSplitScatterController(ctx, cluster, opController, c.AddPendingProcessedRegions)
+	return c
 }
 
 // PatrolRegions is used to scan regions.
@@ -151,6 +154,8 @@ func (c *Controller) PatrolRegions() {
 			c.checkPriorityRegions()
 			// Check pending processed regions first.
 			c.checkPendingProcessedRegions()
+
+			c.splitScatter.dispatchSplitScatterRegions()
 
 			key, regions = c.checkRegions(key)
 			if len(regions) == 0 {

--- a/pkg/schedule/checker/metrics.go
+++ b/pkg/schedule/checker/metrics.go
@@ -39,23 +39,55 @@ var (
 			Name:      "patrol_regions_time",
 			Help:      "Time spent of patrol checks region.",
 		})
+
+	splitScatterPendingExpiredCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "checker",
+			Name:      "split_scatter_pending_expired_total",
+			Help:      "Counter of expired split-scatter pending entries by whether they were selected for dispatch.",
+		}, []string{"attempted"})
+	splitScatterPendingDroppedCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "checker",
+			Name:      "split_scatter_pending_dropped_total",
+			Help:      "Counter of split-scatter pending entries dropped by the capacity limit.",
+		})
+	splitScatterPendingGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "checker",
+			Name:      "split_scatter_pending",
+			Help:      "Number of split-scatter pending entries.",
+		})
+)
+
+// WithLabelValues is a heavy operation, pre-cache the label handles.
+var (
+	splitScatterPendingExpiredAttemptedCounter   = splitScatterPendingExpiredCounter.WithLabelValues("true")
+	splitScatterPendingExpiredUnattemptedCounter = splitScatterPendingExpiredCounter.WithLabelValues("false")
 )
 
 func init() {
 	prometheus.MustRegister(checkerCounter)
 	prometheus.MustRegister(regionListGauge)
 	prometheus.MustRegister(patrolCheckRegionsGauge)
+	prometheus.MustRegister(splitScatterPendingExpiredCounter)
+	prometheus.MustRegister(splitScatterPendingDroppedCounter)
+	prometheus.MustRegister(splitScatterPendingGauge)
 }
 
 const (
 	// NOTE: these types are different from pkg/schedule/config/type.go,
 	// they are only used for prometheus metrics to keep the compatibility.
-	ruleChecker       = "rule_checker"
-	jointStateChecker = "joint_state_checker"
-	learnerChecker    = "learner_checker"
-	mergeChecker      = "merge_checker"
-	replicaChecker    = "replica_checker"
-	splitChecker      = "split_checker"
+	ruleChecker         = "rule_checker"
+	jointStateChecker   = "joint_state_checker"
+	learnerChecker      = "learner_checker"
+	mergeChecker        = "merge_checker"
+	replicaChecker      = "replica_checker"
+	splitChecker        = "split_checker"
+	splitScatterChecker = "split_scatter_checker"
 )
 
 func ruleCheckerCounterWithEvent(event string) prometheus.Counter {
@@ -72,6 +104,10 @@ func mergeCheckerCounterWithEvent(event string) prometheus.Counter {
 
 func replicaCheckerCounterWithEvent(event string) prometheus.Counter {
 	return checkerCounter.WithLabelValues(replicaChecker, event)
+}
+
+func splitScatterCheckerCounterWithEvent(event string) prometheus.Counter {
+	return checkerCounter.WithLabelValues(splitScatterChecker, event)
 }
 
 // WithLabelValues is a heavy operation, define variable to avoid call it every time.
@@ -155,4 +191,15 @@ var (
 
 	splitCheckerCounter       = checkerCounter.WithLabelValues(splitChecker, "check")
 	splitCheckerPausedCounter = checkerCounter.WithLabelValues(splitChecker, "paused")
+
+	splitScatterDispatchDisabledCounter          = splitScatterCheckerCounterWithEvent("dispatch-disabled")
+	splitScatterDispatchScheduleLimitCounter     = splitScatterCheckerCounterWithEvent("dispatch-schedule-limit")
+	splitScatterDispatchRegionMissingCounter     = splitScatterCheckerCounterWithEvent("dispatch-region-missing")
+	splitScatterDispatchScheduleDisabledCounter  = splitScatterCheckerCounterWithEvent("dispatch-schedule-disabled")
+	splitScatterDispatchNotReplicatedCounter     = splitScatterCheckerCounterWithEvent("dispatch-not-fully-replicated")
+	splitScatterDispatchScatterFailedCounter     = splitScatterCheckerCounterWithEvent("dispatch-scatter-failed")
+	splitScatterDispatchStoreLimitCounter        = splitScatterCheckerCounterWithEvent("dispatch-store-limit")
+	splitScatterDispatchAddOperatorFailedCounter = splitScatterCheckerCounterWithEvent("dispatch-add-operator-failed")
+	splitScatterDispatchOperatorCreatedCounter   = splitScatterCheckerCounterWithEvent("dispatch-operator-created")
+	splitScatterDispatchNoOperatorNeededCounter  = splitScatterCheckerCounterWithEvent("dispatch-no-operator-needed")
 )

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -379,9 +379,6 @@ func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceW
 
 func (c *splitScatterController) dispatchSplitScatterRegions() {
 	now := time.Now()
-	if c.skipDispatchUntil(now) {
-		return
-	}
 	if c.cleanupExpiredPendingSplitScatter() == 0 {
 		return
 	}
@@ -389,6 +386,9 @@ func (c *splitScatterController) dispatchSplitScatterRegions() {
 	if limit == 0 {
 		splitScatterDispatchDisabledCounter.Inc()
 		c.clearPendingSplitScatter()
+		return
+	}
+	if c.skipDispatchUntil(now) {
 		return
 	}
 	running := c.opController.OperatorCount(operator.OpSplitScatter)

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -1,0 +1,409 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pingcap/log"
+
+	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/filter"
+	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+	"github.com/tikv/pd/pkg/schedule/types"
+	"github.com/tikv/pd/pkg/utils/syncutil"
+)
+
+const (
+	splitScatterPendingLimit = 4096
+	// The actual retry cadence is also bounded by the checker dispatch loop. This
+	// is only the minimum interval to avoid retrying the same pending item too
+	// frequently when checker ticks are fast.
+	splitScatterRetryBackoff = time.Second
+	// Keep the pending TTL aligned with PD's slow operator step threshold so a
+	// scatter blocked by slow AddLearner/store limits still has time to retry.
+	splitScatterPendingTTL = 10 * time.Minute
+)
+
+type splitScatterPendingItem struct {
+	regionID          uint64
+	group             string
+	sourceRegionID    uint64
+	sourceWaitVersion uint64
+	retryAt           time.Time
+	expireAt          time.Time
+	// attempted means this item has been selected by the dispatcher at least once.
+	attempted bool
+}
+
+type splitScatterController struct {
+	cluster         sche.CheckerCluster
+	opController    *operator.Controller
+	regionScatterer *scatter.RegionScatterer
+
+	pendingMu syncutil.RWMutex
+	// pending maps a pending region ID to its latest split-scatter batch item.
+	// The item keeps its batch group so stale snapshots cannot mutate a newer
+	// pending entry for the same region.
+	pending map[uint64]splitScatterPendingItem
+}
+
+func newSplitScatterController(
+	ctx context.Context,
+	cluster sche.CheckerCluster,
+	opController *operator.Controller,
+	addPendingProcessedRegions func(needCheckLen bool, ids ...uint64),
+) *splitScatterController {
+	return &splitScatterController{
+		cluster:         cluster,
+		opController:    opController,
+		regionScatterer: scatter.NewRegionScatterer(ctx, cluster, opController, addPendingProcessedRegions),
+		pending:         make(map[uint64]splitScatterPendingItem),
+	}
+}
+
+// splitScatterRangeHint is a derived key range for the current table/index
+// group. When available, split-scatter seeds the scatterer's group
+// distribution with the existing region count in this range before dispatch.
+type splitScatterRangeHint struct {
+	startKey     []byte
+	endKey       []byte
+	scatterGroup string
+}
+
+func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []splitScatterPendingItem {
+	if limit <= 0 {
+		return nil
+	}
+	now := time.Now()
+	c.pendingMu.RLock()
+
+	// Keep pendingMu short: cluster reads below can be slower and do not need
+	// to block pending updates. Stale snapshots are safe because candidates
+	// are rechecked before dispatch and delay/delete recheck the pending identity.
+	pendingSnapshot := make([]splitScatterPendingItem, 0, len(c.pending))
+	expiredSnapshot := make([]splitScatterPendingItem, 0)
+	for _, pending := range c.pending {
+		if !pending.expireAt.IsZero() && !now.Before(pending.expireAt) {
+			expiredSnapshot = append(expiredSnapshot, pending)
+			continue
+		}
+		pendingSnapshot = append(pendingSnapshot, pending)
+	}
+	c.pendingMu.RUnlock()
+
+	candidates := make([]splitScatterPendingItem, 0, len(pendingSnapshot))
+	for _, pending := range pendingSnapshot {
+		regionID := pending.regionID
+		region := c.cluster.GetRegion(regionID)
+		if region == nil {
+			continue
+		}
+		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			continue
+		}
+		sourceRegion := c.cluster.GetRegion(pending.sourceRegionID)
+		if sourceRegion == nil {
+			continue
+		}
+		sourceVersion := uint64(0)
+		if sourceRegion.GetRegionEpoch() != nil {
+			sourceVersion = sourceRegion.GetRegionEpoch().GetVersion()
+		}
+		if pending.sourceWaitVersion > 0 && sourceVersion < pending.sourceWaitVersion {
+			continue
+		}
+		candidates = append(candidates, pending)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].expireAt.Equal(candidates[j].expireAt) {
+			return candidates[i].expireAt.Before(candidates[j].expireAt)
+		}
+		if candidates[i].group != candidates[j].group {
+			return candidates[i].group < candidates[j].group
+		}
+		return candidates[i].regionID < candidates[j].regionID
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	if len(candidates) > 0 {
+		c.pendingMu.Lock()
+		selected := candidates[:0]
+		for _, candidate := range candidates {
+			pending, ok := c.pending[candidate.regionID]
+			if !ok || pending.group != candidate.group || !pending.expireAt.Equal(candidate.expireAt) {
+				continue
+			}
+			pending.attempted = true
+			c.pending[pending.regionID] = pending
+			candidate.attempted = true
+			selected = append(selected, candidate)
+		}
+		candidates = selected
+		c.pendingMu.Unlock()
+	}
+
+	if len(expiredSnapshot) > 0 {
+		attemptedExpiredCount := 0
+		unattemptedExpiredCount := 0
+		c.pendingMu.Lock()
+		for _, expired := range expiredSnapshot {
+			pending, ok := c.pending[expired.regionID]
+			if ok && pending.group == expired.group && pending.expireAt.Equal(expired.expireAt) &&
+				!pending.expireAt.IsZero() && !now.Before(pending.expireAt) {
+				delete(c.pending, expired.regionID)
+				if pending.attempted {
+					attemptedExpiredCount++
+				} else {
+					unattemptedExpiredCount++
+				}
+			}
+		}
+		if attemptedExpiredCount+unattemptedExpiredCount > 0 {
+			c.updatePendingGaugeLocked()
+		}
+		c.pendingMu.Unlock()
+		observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
+	}
+	return candidates
+}
+
+func (c *splitScatterController) delayPendingSplitScatter(expected splitScatterPendingItem) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	pending, ok := c.pending[expected.regionID]
+	if !ok || pending.group != expected.group || !pending.expireAt.Equal(expected.expireAt) {
+		return
+	}
+	pending.retryAt = time.Now().Add(splitScatterRetryBackoff)
+	c.pending[expected.regionID] = pending
+}
+
+func (c *splitScatterController) deletePendingSplitScatter(expected splitScatterPendingItem) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	pending, ok := c.pending[expected.regionID]
+	if !ok || pending.group != expected.group || !pending.expireAt.Equal(expected.expireAt) {
+		return
+	}
+	delete(c.pending, expected.regionID)
+	c.updatePendingGaugeLocked()
+}
+
+func (c *splitScatterController) updatePendingGaugeLocked() {
+	splitScatterPendingGauge.Set(float64(len(c.pending)))
+}
+
+func observeSplitScatterPendingExpired(attemptedCount, unattemptedCount int) {
+	if attemptedCount > 0 {
+		splitScatterPendingExpiredAttemptedCounter.Add(float64(attemptedCount))
+	}
+	if unattemptedCount > 0 {
+		splitScatterPendingExpiredUnattemptedCounter.Add(float64(unattemptedCount))
+	}
+}
+
+func (c *splitScatterController) removeExpiredPendingSplitScatterLocked() (attemptedCount, unattemptedCount int) {
+	now := time.Now()
+	for regionID, pending := range c.pending {
+		if !pending.expireAt.IsZero() && !now.Before(pending.expireAt) {
+			delete(c.pending, regionID)
+			if pending.attempted {
+				attemptedCount++
+			} else {
+				unattemptedCount++
+			}
+		}
+	}
+	if attemptedCount+unattemptedCount > 0 {
+		c.updatePendingGaugeLocked()
+	}
+	return attemptedCount, unattemptedCount
+}
+
+func (c *splitScatterController) cleanupExpiredPendingSplitScatter() int {
+	c.pendingMu.Lock()
+	attemptedExpiredCount, unattemptedExpiredCount := c.removeExpiredPendingSplitScatterLocked()
+	pendingCount := len(c.pending)
+	c.pendingMu.Unlock()
+	observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
+	return pendingCount
+}
+
+func makeSplitScatterGroup(sourceRegionID, firstNewRegionID uint64) string {
+	return fmt.Sprintf("split-scatter-%d-%d", sourceRegionID, firstNewRegionID)
+}
+
+// RecordSplitScatterBatch records a newly split batch for later scatter.
+func (c *Controller) RecordSplitScatterBatch(sourceRegionID, sourceWaitVersion uint64, newRegionIDs []uint64) {
+	c.splitScatter.recordSplitScatterBatch(sourceRegionID, sourceWaitVersion, newRegionIDs)
+}
+
+func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceWaitVersion uint64, newRegionIDs []uint64) {
+	if len(newRegionIDs) == 0 {
+		return
+	}
+	group := makeSplitScatterGroup(sourceRegionID, newRegionIDs[0])
+	expireAt := time.Now().Add(splitScatterPendingTTL)
+	if sourceWaitVersion == 0 {
+		sourceWaitVersion = 1
+	}
+	if sourceRegion := c.cluster.GetRegion(sourceRegionID); sourceRegion != nil && sourceRegion.GetRegionEpoch() != nil {
+		cachedWaitVersion := sourceRegion.GetRegionEpoch().GetVersion() + 1
+		if cachedWaitVersion > sourceWaitVersion {
+			sourceWaitVersion = cachedWaitVersion
+		}
+	}
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	attemptedExpiredCount, unattemptedExpiredCount := c.removeExpiredPendingSplitScatterLocked()
+	observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
+	newPendingCount := 0
+	if _, ok := c.pending[sourceRegionID]; !ok {
+		newPendingCount++
+	}
+	for _, regionID := range newRegionIDs {
+		if _, ok := c.pending[regionID]; !ok {
+			newPendingCount++
+		}
+	}
+	if len(c.pending)+newPendingCount > splitScatterPendingLimit {
+		// Keep each split batch atomic. Recording only part of a source/child
+		// batch would make the scatter group incomplete, so skip the whole batch
+		// when the remaining capacity cannot fit it.
+		splitScatterPendingDroppedCounter.Add(float64(newPendingCount))
+		log.Info("skip recording split scatter batch due to pending limit",
+			zap.Uint64("source-region-id", sourceRegionID),
+			zap.Uint64s("new-region-ids", newRegionIDs),
+			zap.Int("pending-count", len(c.pending)),
+			zap.Int("new-pending-count", newPendingCount),
+			zap.Int("pending-limit", splitScatterPendingLimit))
+		return
+	}
+	for _, regionID := range newRegionIDs {
+		c.pending[regionID] = splitScatterPendingItem{
+			regionID:          regionID,
+			group:             group,
+			sourceRegionID:    sourceRegionID,
+			sourceWaitVersion: sourceWaitVersion,
+			expireAt:          expireAt,
+		}
+	}
+	c.pending[sourceRegionID] = splitScatterPendingItem{
+		regionID:          sourceRegionID,
+		group:             group,
+		sourceRegionID:    sourceRegionID,
+		sourceWaitVersion: sourceWaitVersion,
+		expireAt:          expireAt,
+	}
+	c.updatePendingGaugeLocked()
+}
+
+func (c *splitScatterController) dispatchSplitScatterRegions() {
+	if c.cleanupExpiredPendingSplitScatter() == 0 {
+		return
+	}
+	limit := c.cluster.GetCheckerConfig().GetSplitScatterScheduleLimit()
+	if limit == 0 {
+		splitScatterDispatchDisabledCounter.Inc()
+		return
+	}
+	running := c.opController.OperatorCount(operator.OpSplitScatter)
+	if running >= limit {
+		splitScatterDispatchScheduleLimitCounter.Inc()
+		operator.IncOperatorLimitCounter(types.SplitScatterChecker, operator.OpSplitScatter)
+		return
+	}
+	dispatchLimit := int(limit - running)
+	// Dispatch sequentially so operators added for earlier pending items in this pass
+	// are visible to later ScatterInternal calls through the running-operator delta.
+	for _, pending := range c.collectTopPendingSplitScatter(dispatchLimit) {
+		region := c.cluster.GetRegion(pending.regionID)
+		if region == nil {
+			splitScatterDispatchRegionMissingCounter.Inc()
+			continue
+		}
+		rangeHint := resolveSplitScatterRangeHint(region)
+		scatterGroup := pending.group
+		if rangeHint.scatterGroup != "" {
+			scatterGroup = rangeHint.scatterGroup
+		}
+		if cl, ok := c.cluster.(interface{ GetRegionLabeler() *labeler.RegionLabeler }); ok {
+			if labeler := cl.GetRegionLabeler(); labeler != nil && labeler.ScheduleDisabled(region) {
+				splitScatterDispatchScheduleDisabledCounter.Inc()
+				c.delayPendingSplitScatter(pending)
+				continue
+			}
+		}
+		if !filter.IsRegionReplicated(c.cluster, region) {
+			splitScatterDispatchNotReplicatedCounter.Inc()
+			c.delayPendingSplitScatter(pending)
+			log.Info("dispatch internal split scatter delayed",
+				zap.Uint64("region-id", pending.regionID),
+				zap.String("batch-group", pending.group),
+				zap.String("scatter-group", scatterGroup),
+				zap.String("reason", "not-fully-replicated"))
+			continue
+		}
+		op, err := c.regionScatterer.ScatterInternal(region, scatterGroup, rangeHint.startKey, rangeHint.endKey)
+		if err != nil {
+			splitScatterDispatchScatterFailedCounter.Inc()
+			c.delayPendingSplitScatter(pending)
+			log.Info("dispatch internal split scatter failed",
+				zap.Uint64("region-id", pending.regionID),
+				zap.String("batch-group", pending.group),
+				zap.String("scatter-group", scatterGroup),
+				zap.Error(err))
+			continue
+		}
+		if op != nil {
+			op.SetAdditionalInfo("batch-group", pending.group)
+			if c.opController.ExceedStoreLimit(op) {
+				splitScatterDispatchStoreLimitCounter.Inc()
+				c.delayPendingSplitScatter(pending)
+				log.Info("dispatch internal split scatter delayed",
+					zap.Uint64("region-id", pending.regionID),
+					zap.String("batch-group", pending.group),
+					zap.String("scatter-group", scatterGroup),
+					zap.String("reason", "exceed-store-limit"),
+					zap.String("operator-desc", op.Desc()))
+				continue
+			}
+			if !c.opController.AddOperator(op) {
+				splitScatterDispatchAddOperatorFailedCounter.Inc()
+				c.delayPendingSplitScatter(pending)
+				log.Info("dispatch internal split scatter add operator failed",
+					zap.Uint64("region-id", pending.regionID),
+					zap.String("batch-group", pending.group),
+					zap.String("scatter-group", scatterGroup),
+					zap.String("operator-desc", op.Desc()))
+				continue
+			}
+			splitScatterDispatchOperatorCreatedCounter.Inc()
+		} else {
+			splitScatterDispatchNoOperatorNeededCounter.Inc()
+		}
+		c.deletePendingSplitScatter(pending)
+	}
+}

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -64,7 +64,8 @@ type splitScatterController struct {
 	// pending maps a pending region ID to its latest split-scatter batch item.
 	// The item keeps its batch group so stale snapshots cannot mutate a newer
 	// pending entry for the same region.
-	pending map[uint64]splitScatterPendingItem
+	pending        map[uint64]splitScatterPendingItem
+	nextDispatchAt time.Time
 }
 
 func newSplitScatterController(
@@ -73,6 +74,7 @@ func newSplitScatterController(
 	opController *operator.Controller,
 	addPendingProcessedRegions func(needCheckLen bool, ids ...uint64),
 ) *splitScatterController {
+	splitScatterPendingGauge.Set(0)
 	return &splitScatterController{
 		cluster:         cluster,
 		opController:    opController,
@@ -112,17 +114,20 @@ func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []spli
 	c.pendingMu.RUnlock()
 
 	candidates := make([]splitScatterPendingItem, 0, len(pendingSnapshot))
+	missingSnapshot := make([]splitScatterPendingItem, 0)
 	for _, pending := range pendingSnapshot {
+		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			continue
+		}
 		regionID := pending.regionID
 		region := c.cluster.GetRegion(regionID)
 		if region == nil {
-			continue
-		}
-		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			missingSnapshot = append(missingSnapshot, pending)
 			continue
 		}
 		sourceRegion := c.cluster.GetRegion(pending.sourceRegionID)
 		if sourceRegion == nil {
+			missingSnapshot = append(missingSnapshot, pending)
 			continue
 		}
 		sourceVersion := uint64(0)
@@ -163,6 +168,7 @@ func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []spli
 		candidates = selected
 		c.pendingMu.Unlock()
 	}
+	c.delayMissingPendingSplitScatter(missingSnapshot, now)
 
 	if len(expiredSnapshot) > 0 {
 		attemptedExpiredCount := 0
@@ -187,6 +193,30 @@ func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []spli
 		observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
 	}
 	return candidates
+}
+
+func (c *splitScatterController) delayMissingPendingSplitScatter(missing []splitScatterPendingItem, now time.Time) {
+	if len(missing) == 0 {
+		return
+	}
+	missingCount := 0
+	c.pendingMu.Lock()
+	for _, expected := range missing {
+		pending, ok := c.pending[expected.regionID]
+		if !ok || pending.group != expected.group || !pending.expireAt.Equal(expected.expireAt) {
+			continue
+		}
+		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			continue
+		}
+		pending.retryAt = now.Add(splitScatterRetryBackoff)
+		c.pending[expected.regionID] = pending
+		missingCount++
+	}
+	c.pendingMu.Unlock()
+	if missingCount > 0 {
+		splitScatterDispatchRegionMissingCounter.Add(float64(missingCount))
+	}
 }
 
 func (c *splitScatterController) delayPendingSplitScatter(expected splitScatterPendingItem) {
@@ -251,6 +281,29 @@ func (c *splitScatterController) cleanupExpiredPendingSplitScatter() int {
 	return pendingCount
 }
 
+func (c *splitScatterController) clearPendingSplitScatter() {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	pendingCount := len(c.pending)
+	if pendingCount > 0 {
+		c.pending = make(map[uint64]splitScatterPendingItem)
+		c.updatePendingGaugeLocked()
+	}
+	c.nextDispatchAt = time.Time{}
+}
+
+func (c *splitScatterController) skipDispatchUntil(now time.Time) bool {
+	c.pendingMu.RLock()
+	defer c.pendingMu.RUnlock()
+	return !c.nextDispatchAt.IsZero() && now.Before(c.nextDispatchAt)
+}
+
+func (c *splitScatterController) delayNextDispatch(now time.Time) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	c.nextDispatchAt = now.Add(splitScatterRetryBackoff)
+}
+
 func makeSplitScatterGroup(sourceRegionID, firstNewRegionID uint64) string {
 	return fmt.Sprintf("split-scatter-%d-%d", sourceRegionID, firstNewRegionID)
 }
@@ -262,6 +315,9 @@ func (c *Controller) RecordSplitScatterBatch(sourceRegionID, sourceWaitVersion u
 
 func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceWaitVersion uint64, newRegionIDs []uint64) {
 	if len(newRegionIDs) == 0 {
+		return
+	}
+	if c.cluster.GetCheckerConfig().GetSplitScatterScheduleLimit() == 0 {
 		return
 	}
 	group := makeSplitScatterGroup(sourceRegionID, newRegionIDs[0])
@@ -318,27 +374,39 @@ func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceW
 		expireAt:          expireAt,
 	}
 	c.updatePendingGaugeLocked()
+	c.nextDispatchAt = time.Time{}
 }
 
 func (c *splitScatterController) dispatchSplitScatterRegions() {
+	now := time.Now()
+	if c.skipDispatchUntil(now) {
+		return
+	}
 	if c.cleanupExpiredPendingSplitScatter() == 0 {
 		return
 	}
 	limit := c.cluster.GetCheckerConfig().GetSplitScatterScheduleLimit()
 	if limit == 0 {
 		splitScatterDispatchDisabledCounter.Inc()
+		c.clearPendingSplitScatter()
 		return
 	}
 	running := c.opController.OperatorCount(operator.OpSplitScatter)
 	if running >= limit {
 		splitScatterDispatchScheduleLimitCounter.Inc()
 		operator.IncOperatorLimitCounter(types.SplitScatterChecker, operator.OpSplitScatter)
+		c.delayNextDispatch(now)
 		return
 	}
 	dispatchLimit := int(limit - running)
 	// Dispatch sequentially so operators added for earlier pending items in this pass
 	// are visible to later ScatterInternal calls through the running-operator delta.
-	for _, pending := range c.collectTopPendingSplitScatter(dispatchLimit) {
+	pendingItems := c.collectTopPendingSplitScatter(dispatchLimit)
+	if len(pendingItems) == 0 {
+		c.delayNextDispatch(now)
+		return
+	}
+	for _, pending := range pendingItems {
 		region := c.cluster.GetRegion(pending.regionID)
 		if region == nil {
 			splitScatterDispatchRegionMissingCounter.Inc()

--- a/pkg/schedule/checker/split_scatter_group.go
+++ b/pkg/schedule/checker/split_scatter_group.go
@@ -1,0 +1,110 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/core"
+)
+
+var (
+	splitScatterTablePrefix = []byte{'t'}
+	splitScatterIndexPrefix = []byte("_i")
+)
+
+func resolveSplitScatterRangeHint(region *core.RegionInfo) splitScatterRangeHint {
+	_, decoded, err := codec.DecodeBytes(region.GetStartKey())
+	if err != nil || !bytes.HasPrefix(decoded, splitScatterTablePrefix) {
+		return splitScatterRangeHint{}
+	}
+	rest := decoded[len(splitScatterTablePrefix):]
+	rest, tableID, err := codec.DecodeInt(rest)
+	if err != nil {
+		return splitScatterRangeHint{}
+	}
+
+	tablePrefix := append([]byte(nil), codec.GenerateTableKey(tableID)...)
+	tableGroup := makeSplitScatterTableGroup(tableID)
+	if !bytes.HasPrefix(rest, splitScatterIndexPrefix) {
+		return splitScatterPrefixRangeWithGroup(tablePrefix, tableGroup)
+	}
+
+	indexRest := rest[len(splitScatterIndexPrefix):]
+	_, indexID, err := codec.DecodeInt(indexRest)
+	if err != nil {
+		return splitScatterRangeHint{}
+	}
+
+	indexPrefix := codec.GenerateIndexKey(tableID, indexID)
+	indexGroup := makeSplitScatterIndexGroup(tableID, indexID)
+	indexRange := splitScatterPrefixRangeWithGroup(indexPrefix, indexGroup)
+	endKey := region.GetEndKey()
+
+	// We intentionally over-approximate ambiguous table-key ranges. If PD can
+	// no longer prove the region stays within a single index prefix, it falls
+	// back to the table-scoped group instead of dropping back to the family
+	// group, so table-boundary splits and merged ranges still participate in
+	// the broader scatter continuity/baseline.
+	// Both endKey and indexRange.endKey are MemComparable-encoded, so
+	// bytes.Compare correctly reflects the key ordering.
+	if len(endKey) == 0 || len(indexRange.startKey) == 0 || len(indexRange.endKey) == 0 || bytes.Compare(endKey, indexRange.endKey) > 0 {
+		return splitScatterPrefixRangeWithGroup(tablePrefix, tableGroup)
+	}
+	return indexRange
+}
+
+func splitScatterPrefixRange(rawPrefix []byte) splitScatterRangeHint {
+	return splitScatterPrefixRangeWithGroup(rawPrefix, "")
+}
+
+func splitScatterPrefixRangeWithGroup(rawPrefix []byte, scatterGroup string) splitScatterRangeHint {
+	startKey := append([]byte(nil), codec.EncodeBytes(rawPrefix)...)
+	endRawPrefix := splitScatterNextPrefix(rawPrefix)
+	if len(endRawPrefix) == 0 {
+		// Current callers use TiDB table/index prefixes, which always start
+		// with 't' and therefore have a finite next prefix. Keep the fallback
+		// here so this helper remains safe if it is ever used with an all-0xff
+		// prefix.
+		return splitScatterRangeHint{startKey: startKey, scatterGroup: scatterGroup}
+	}
+	return splitScatterRangeHint{
+		startKey:     startKey,
+		endKey:       append([]byte(nil), codec.EncodeBytes(endRawPrefix)...),
+		scatterGroup: scatterGroup,
+	}
+}
+
+func makeSplitScatterTableGroup(tableID int64) string {
+	return fmt.Sprintf("split-scatter-table-%d", tableID)
+}
+
+func makeSplitScatterIndexGroup(tableID, indexID int64) string {
+	return fmt.Sprintf("split-scatter-index-%d-%d", tableID, indexID)
+}
+
+func splitScatterNextPrefix(key []byte) []byte {
+	next := append([]byte(nil), key...)
+	for i := len(next) - 1; i >= 0; i-- {
+		if next[i] == 0xFF {
+			continue
+		}
+		next[i]++
+		return next[:i+1]
+	}
+	return nil
+}

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -62,7 +62,7 @@ func TestNewSplitScatterControllerResetsPendingGauge(t *testing.T) {
 	defer cleanup()
 
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
 }
 
 func TestRecordSplitScatterBatchCollectsPendingRegions(t *testing.T) {
@@ -72,7 +72,7 @@ func TestRecordSplitScatterBatchCollectsPendingRegions(t *testing.T) {
 
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102, 103})
 	re.Equal(4, splitScatterPendingCount(controller))
-	re.Equal(float64(4), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(4), promtestutil.ToFloat64(splitScatterPendingGauge))
 
 	sourceGroup := splitScatterPendingGroup(t, controller, 100)
 	for _, regionID := range []uint64{101, 102, 103} {
@@ -194,12 +194,12 @@ func TestRecordSplitScatterBatchSkipsWhenDisabled(t *testing.T) {
 
 	tc.SetSplitScatterScheduleLimit(0)
 
-	droppedBefore := metricValue(t, splitScatterPendingDroppedCounter)
+	droppedBefore := promtestutil.ToFloat64(splitScatterPendingDroppedCounter)
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
 
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingDroppedCounter)-droppedBefore)
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingDroppedCounter)-droppedBefore)
 }
 
 func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
@@ -211,13 +211,13 @@ func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
 	re.Equal(3, splitScatterPendingCount(controller))
 
 	tc.SetSplitScatterScheduleLimit(0)
-	disabledBefore := metricValue(t, splitScatterDispatchDisabledCounter)
+	disabledBefore := promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)
 	controller.dispatchSplitScatterRegions()
 
 	re.Empty(oc.GetOperators())
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
-	re.Equal(float64(1), metricValue(t, splitScatterDispatchDisabledCounter)-disabledBefore)
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)-disabledBefore)
 }
 
 func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T) {
@@ -261,14 +261,14 @@ func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T)
 			expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
 			testCase.setupEarlyReturn(tc, oc)
 
-			expiredBefore := splitScatterPendingExpiredCount(t, "false")
-			counterBefore := metricValue(t, testCase.counter)
+			expiredBefore := splitScatterPendingExpiredCount("false")
+			counterBefore := promtestutil.ToFloat64(testCase.counter)
 			controller.dispatchSplitScatterRegions()
 
 			re.Equal(0, splitScatterPendingCount(controller))
-			re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
-			re.Equal(float64(2), splitScatterPendingExpiredCount(t, "false")-expiredBefore)
-			re.Equal(float64(0), metricValue(t, testCase.counter)-counterBefore)
+			re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+			re.Equal(float64(2), splitScatterPendingExpiredCount("false")-expiredBefore)
+			re.Equal(float64(0), promtestutil.ToFloat64(testCase.counter)-counterBefore)
 		})
 	}
 }
@@ -280,15 +280,15 @@ func TestCollectTopPendingDelaysMissingRegions(t *testing.T) {
 
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
 
-	missingBefore := metricValue(t, splitScatterDispatchRegionMissingCounter)
+	missingBefore := promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)
 	re.Empty(controller.collectTopPendingSplitScatter(2))
 
-	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)-missingBefore)
 	pending := splitScatterPending(t, controller, 101)
 	re.True(pending.retryAt.After(time.Now()))
 
 	re.Empty(controller.collectTopPendingSplitScatter(2))
-	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)-missingBefore)
 }
 
 func TestDispatchSplitScatterBacksOffWhenNoCandidates(t *testing.T) {
@@ -331,12 +331,12 @@ func TestDispatchSplitScatterRespectsScheduleDeny(t *testing.T) {
 		Data:     []any{map[string]any{"start_key": "", "end_key": ""}},
 	}))
 
-	counterBefore := metricValue(t, splitScatterDispatchScheduleDisabledCounter)
+	counterBefore := promtestutil.ToFloat64(splitScatterDispatchScheduleDisabledCounter)
 	controller.dispatchSplitScatterRegions()
 
 	re.Empty(oc.GetOperators())
 	re.Equal(2, splitScatterPendingCount(controller))
-	re.Equal(float64(2), metricValue(t, splitScatterDispatchScheduleDisabledCounter)-counterBefore)
+	re.Equal(float64(2), promtestutil.ToFloat64(splitScatterDispatchScheduleDisabledCounter)-counterBefore)
 	for _, regionID := range []uint64{100, 101} {
 		pending := splitScatterPending(t, controller, regionID)
 		re.True(pending.retryAt.After(time.Now()))
@@ -352,11 +352,11 @@ func TestCollectTopPendingRemovesExpiredPending(t *testing.T) {
 	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
 	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
 
-	expiredBefore := splitScatterPendingExpiredCount(t, "false")
+	expiredBefore := splitScatterPendingExpiredCount("false")
 	re.Empty(controller.collectTopPendingSplitScatter(2))
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
-	re.Equal(float64(2), splitScatterPendingExpiredCount(t, "false")-expiredBefore)
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(2), splitScatterPendingExpiredCount("false")-expiredBefore)
 }
 
 func TestCollectTopPendingMarksAttemptedBeforeExpiration(t *testing.T) {
@@ -368,17 +368,17 @@ func TestCollectTopPendingMarksAttemptedBeforeExpiration(t *testing.T) {
 	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
 	advanceSplitScatterSourceVersion(t, tc)
 
-	attemptedBefore := splitScatterPendingExpiredCount(t, "true")
-	unattemptedBefore := splitScatterPendingExpiredCount(t, "false")
+	attemptedBefore := splitScatterPendingExpiredCount("true")
+	unattemptedBefore := splitScatterPendingExpiredCount("false")
 	re.Len(controller.collectTopPendingSplitScatter(1), 1)
 	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
 	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
 
 	re.Empty(controller.collectTopPendingSplitScatter(2))
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
-	re.Equal(float64(1), splitScatterPendingExpiredCount(t, "true")-attemptedBefore)
-	re.Equal(float64(1), splitScatterPendingExpiredCount(t, "false")-unattemptedBefore)
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(1), splitScatterPendingExpiredCount("true")-attemptedBefore)
+	re.Equal(float64(1), splitScatterPendingExpiredCount("false")-unattemptedBefore)
 }
 
 func TestRecordSplitScatterBatchRespectsPendingLimit(t *testing.T) {
@@ -388,11 +388,11 @@ func TestRecordSplitScatterBatchRespectsPendingLimit(t *testing.T) {
 
 	fillSplitScatterPending(controller, time.Time{})
 
-	droppedBefore := metricValue(t, splitScatterPendingDroppedCounter)
+	droppedBefore := promtestutil.ToFloat64(splitScatterPendingDroppedCounter)
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
 
 	re.Equal(splitScatterPendingLimit, splitScatterPendingCount(controller))
-	re.Equal(float64(2), metricValue(t, splitScatterPendingDroppedCounter)-droppedBefore)
+	re.Equal(float64(2), promtestutil.ToFloat64(splitScatterPendingDroppedCounter)-droppedBefore)
 	controller.splitScatter.pendingMu.RLock()
 	_, sourceExists := controller.splitScatter.pending[100]
 	_, childExists := controller.splitScatter.pending[101]
@@ -790,24 +790,8 @@ func splitScatterPendingCount(controller *Controller) int {
 	return len(controller.splitScatter.pending)
 }
 
-func metricValue(t *testing.T, metric prometheus.Metric) float64 {
-	t.Helper()
-	pb := &dto.Metric{}
-	require.NoError(t, metric.Write(pb))
-	switch {
-	case pb.GetGauge() != nil:
-		return pb.GetGauge().GetValue()
-	case pb.GetCounter() != nil:
-		return pb.GetCounter().GetValue()
-	default:
-		require.FailNow(t, "metric has no gauge or counter")
-		return 0
-	}
-}
-
-func splitScatterPendingExpiredCount(t *testing.T, attempted string) float64 {
-	t.Helper()
-	return metricValue(t, splitScatterPendingExpiredCounter.WithLabelValues(attempted))
+func splitScatterPendingExpiredCount(attempted string) float64 {
+	return promtestutil.ToFloat64(splitScatterPendingExpiredCounter.WithLabelValues(attempted))
 }
 
 func splitScatterPendingGroup(t *testing.T, controller *Controller, regionID uint64) string {

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -211,6 +211,7 @@ func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
 	re.Equal(3, splitScatterPendingCount(controller))
 
 	tc.SetSplitScatterScheduleLimit(0)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(splitScatterRetryBackoff))
 	disabledBefore := promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)
 	controller.dispatchSplitScatterRegions()
 

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -54,6 +54,17 @@ func (c *Controller) dispatchSplitScatterRegions() {
 	c.splitScatter.dispatchSplitScatterRegions()
 }
 
+func TestNewSplitScatterControllerResetsPendingGauge(t *testing.T) {
+	re := require.New(t)
+	splitScatterPendingGauge.Set(7)
+
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+}
+
 func TestRecordSplitScatterBatchCollectsPendingRegions(t *testing.T) {
 	re := require.New(t)
 	controller, tc, _, cleanup := newTestSplitScatterController(t)
@@ -117,8 +128,10 @@ func TestDispatchSplitScatterKeepsPendingUntilSplitHeartbeat(t *testing.T) {
 
 	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
 
+	retrySplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
 	re.Empty(controller.collectTopPendingSplitScatter(2))
 	advanceSplitScatterSourceVersion(t, tc)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
 	re.ElementsMatch([]uint64{100, 101}, pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
 
 	controller.dispatchSplitScatterRegions()
@@ -147,6 +160,7 @@ func TestDispatchSplitScatterUsesRequestWaitVersionWhenCacheLags(t *testing.T) {
 	re.Equal(2, splitScatterPendingCount(controller))
 
 	advanceSplitScatterRegionVersion(t, tc, 100)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
 	controller.dispatchSplitScatterRegions()
 
 	re.NotNil(oc.GetOperator(101))
@@ -157,16 +171,10 @@ func TestDispatchSplitScatterRespectsScheduleLimit(t *testing.T) {
 	controller, tc, oc, cleanup := newTestSplitScatterController(t)
 	defer cleanup()
 
-	tc.SetSplitScatterScheduleLimit(0)
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
 	putSplitScatterRegion(tc, 101, "m", "t", splitScatterReportedCPUUsage)
 	putSplitScatterRegion(tc, 102, "t", "", splitScatterReportedCPUUsage)
 	advanceSplitScatterSourceVersion(t, tc)
-
-	controller.dispatchSplitScatterRegions()
-
-	re.Empty(oc.GetOperators())
-	re.Equal(3, splitScatterPendingCount(controller))
 
 	tc.SetSplitScatterScheduleLimit(1)
 	controller.dispatchSplitScatterRegions()
@@ -177,6 +185,39 @@ func TestDispatchSplitScatterRespectsScheduleLimit(t *testing.T) {
 	controller.dispatchSplitScatterRegions()
 
 	re.Len(oc.GetOperators(), 1)
+}
+
+func TestRecordSplitScatterBatchSkipsWhenDisabled(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	tc.SetSplitScatterScheduleLimit(0)
+
+	droppedBefore := metricValue(t, splitScatterPendingDroppedCounter)
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingDroppedCounter)-droppedBefore)
+}
+
+func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+	re.Equal(3, splitScatterPendingCount(controller))
+
+	tc.SetSplitScatterScheduleLimit(0)
+	disabledBefore := metricValue(t, splitScatterDispatchDisabledCounter)
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(1), metricValue(t, splitScatterDispatchDisabledCounter)-disabledBefore)
 }
 
 func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T) {
@@ -230,6 +271,48 @@ func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T)
 			re.Equal(float64(0), metricValue(t, testCase.counter)-counterBefore)
 		})
 	}
+}
+
+func TestCollectTopPendingDelaysMissingRegions(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	missingBefore := metricValue(t, splitScatterDispatchRegionMissingCounter)
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+
+	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+	pending := splitScatterPending(t, controller, 101)
+	re.True(pending.retryAt.After(time.Now()))
+
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+}
+
+func TestDispatchSplitScatterBacksOffWhenNoCandidates(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	controller.dispatchSplitScatterRegions()
+
+	re.True(splitScatterNextDispatchAt(t, controller).After(time.Now()))
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+
+	retrySplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
+	controller.dispatchSplitScatterRegions()
+
+	re.NotNil(oc.GetOperator(101))
 }
 
 func TestDispatchSplitScatterRespectsScheduleDeny(t *testing.T) {
@@ -758,6 +841,30 @@ func expireSplitScatterPendingAt(t *testing.T, controller *Controller, regionID 
 	require.True(t, ok)
 	pending.expireAt = expireAt
 	controller.splitScatter.pending[regionID] = pending
+}
+
+func retrySplitScatterPendingAt(t *testing.T, controller *Controller, regionID uint64, retryAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	pending, ok := controller.splitScatter.pending[regionID]
+	require.True(t, ok)
+	pending.retryAt = retryAt
+	controller.splitScatter.pending[regionID] = pending
+}
+
+func setSplitScatterNextDispatchAt(t *testing.T, controller *Controller, nextDispatchAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	controller.splitScatter.nextDispatchAt = nextDispatchAt
+}
+
+func splitScatterNextDispatchAt(t *testing.T, controller *Controller) time.Time {
+	t.Helper()
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	return controller.splitScatter.nextDispatchAt
 }
 
 func requireInternalScatterOpsUseGroups(t *testing.T, oc *operator.Controller, scatterGroup, batchGroup string) {

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -795,10 +795,10 @@ func metricValue(t *testing.T, metric prometheus.Metric) float64 {
 	pb := &dto.Metric{}
 	require.NoError(t, metric.Write(pb))
 	switch {
-	case pb.Gauge != nil:
-		return pb.Gauge.GetValue()
-	case pb.Counter != nil:
-		return pb.Counter.GetValue()
+	case pb.GetGauge() != nil:
+		return pb.GetGauge().GetValue()
+	case pb.GetCounter() != nil:
+		return pb.GetCounter().GetValue()
 	default:
 		require.FailNow(t, "metric has no gauge or counter")
 		return 0

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -1,0 +1,807 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/pkg/mock/mockconfig"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+)
+
+const (
+	splitScatterObservedRegionID      uint64 = 101
+	splitScatterTestTableID           int64  = 42
+	splitScatterTestIndexID           int64  = 7
+	splitScatterTestSourceWaitVersion        = uint64(0)
+	// CPU usage is only populated to mimic load-split region heartbeat data.
+	// Current split-scatter dispatch does not rank pending regions by CPU.
+	splitScatterNoCPUUsage       uint64 = 0
+	splitScatterReportedCPUUsage uint64 = 1
+)
+
+func (c *Controller) collectTopPendingSplitScatter(limit int) []splitScatterPendingItem {
+	return c.splitScatter.collectTopPendingSplitScatter(limit)
+}
+
+func (c *Controller) dispatchSplitScatterRegions() {
+	c.splitScatter.dispatchSplitScatterRegions()
+}
+
+func TestRecordSplitScatterBatchCollectsPendingRegions(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102, 103})
+	re.Equal(4, splitScatterPendingCount(controller))
+	re.Equal(float64(4), metricValue(t, splitScatterPendingGauge))
+
+	sourceGroup := splitScatterPendingGroup(t, controller, 100)
+	for _, regionID := range []uint64{101, 102, 103} {
+		re.Equal(sourceGroup, splitScatterPendingGroup(t, controller, regionID))
+	}
+
+	putSplitScatterRegion(tc, 101, "m", "n", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 102, "n", "o", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 103, "o", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	re.ElementsMatch([]uint64{100, 101, 102, 103}, pendingRegionIDs(controller.collectTopPendingSplitScatter(4)))
+}
+
+func TestCheckSplitScatterRegionsCreatesScatterOperator(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+	putSplitScatterRegion(tc, 101, "m", "t", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 102, "t", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	group := splitScatterPendingGroup(t, controller, 101)
+
+	controller.dispatchSplitScatterRegions()
+
+	var op *operator.Operator
+	for _, regionID := range []uint64{100, 101, 102} {
+		op = oc.GetOperator(regionID)
+		if op != nil {
+			break
+		}
+	}
+	re.NotNil(op)
+	re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+	re.Equal(group, op.GetAdditionalInfo("group"))
+	re.Equal(group, op.GetAdditionalInfo("batch-group"))
+}
+
+func TestDispatchSplitScatterKeepsPendingUntilSplitHeartbeat(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Equal(2, splitScatterPendingCount(controller))
+	re.Nil(oc.GetOperator(101))
+
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	advanceSplitScatterSourceVersion(t, tc)
+	re.ElementsMatch([]uint64{100, 101}, pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
+
+	controller.dispatchSplitScatterRegions()
+
+	op := oc.GetOperator(101)
+	re.NotNil(op)
+	re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+}
+
+func TestDispatchSplitScatterUsesRequestWaitVersionWhenCacheLags(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	source := tc.GetRegion(100)
+	re.NotNil(source)
+	tc.PutRegion(source.Clone(core.SetRegionVersion(4)))
+
+	controller.RecordSplitScatterBatch(100, 6, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterRegionVersion(t, tc, 100)
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(2, splitScatterPendingCount(controller))
+
+	advanceSplitScatterRegionVersion(t, tc, 100)
+	controller.dispatchSplitScatterRegions()
+
+	re.NotNil(oc.GetOperator(101))
+}
+
+func TestDispatchSplitScatterRespectsScheduleLimit(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	tc.SetSplitScatterScheduleLimit(0)
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+	putSplitScatterRegion(tc, 101, "m", "t", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 102, "t", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(3, splitScatterPendingCount(controller))
+
+	tc.SetSplitScatterScheduleLimit(1)
+	controller.dispatchSplitScatterRegions()
+
+	re.Len(oc.GetOperators(), 1)
+	re.Equal(uint64(1), oc.OperatorCount(operator.OpSplitScatter))
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Len(oc.GetOperators(), 1)
+}
+
+func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T) {
+	testCases := []struct {
+		name             string
+		setupEarlyReturn func(*mockcluster.Cluster, *operator.Controller)
+		counter          prometheus.Counter
+	}{
+		{
+			name: "disabled",
+			setupEarlyReturn: func(tc *mockcluster.Cluster, _ *operator.Controller) {
+				tc.SetSplitScatterScheduleLimit(0)
+			},
+			counter: splitScatterDispatchDisabledCounter,
+		},
+		{
+			name: "schedule limit",
+			setupEarlyReturn: func(tc *mockcluster.Cluster, oc *operator.Controller) {
+				tc.SetSplitScatterScheduleLimit(1)
+				region := tc.GetRegion(100)
+				op := operator.NewTestOperator(
+					region.GetID(),
+					region.GetRegionEpoch(),
+					operator.OpSplitScatter|operator.OpRegion,
+					operator.TransferLeader{FromStore: 1, ToStore: 2},
+				)
+				require.True(t, oc.AddOperator(op))
+			},
+			counter: splitScatterDispatchScheduleLimitCounter,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			controller, tc, oc, cleanup := newTestSplitScatterController(t)
+			defer cleanup()
+
+			controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+			expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
+			expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+			testCase.setupEarlyReturn(tc, oc)
+
+			expiredBefore := splitScatterPendingExpiredCount(t, "false")
+			counterBefore := metricValue(t, testCase.counter)
+			controller.dispatchSplitScatterRegions()
+
+			re.Equal(0, splitScatterPendingCount(controller))
+			re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+			re.Equal(float64(2), splitScatterPendingExpiredCount(t, "false")-expiredBefore)
+			re.Equal(float64(0), metricValue(t, testCase.counter)-counterBefore)
+		})
+	}
+}
+
+func TestDispatchSplitScatterRespectsScheduleDeny(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	re.NoError(tc.GetRegionLabeler().SetLabelRule(&labeler.LabelRule{
+		ID:       "split-scatter-schedule-deny",
+		Labels:   []labeler.RegionLabel{{Key: "schedule", Value: "deny"}},
+		RuleType: labeler.KeyRange,
+		Data:     []any{map[string]any{"start_key": "", "end_key": ""}},
+	}))
+
+	counterBefore := metricValue(t, splitScatterDispatchScheduleDisabledCounter)
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(2, splitScatterPendingCount(controller))
+	re.Equal(float64(2), metricValue(t, splitScatterDispatchScheduleDisabledCounter)-counterBefore)
+	for _, regionID := range []uint64{100, 101} {
+		pending := splitScatterPending(t, controller, regionID)
+		re.True(pending.retryAt.After(time.Now()))
+	}
+}
+
+func TestCollectTopPendingRemovesExpiredPending(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
+	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+
+	expiredBefore := splitScatterPendingExpiredCount(t, "false")
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(2), splitScatterPendingExpiredCount(t, "false")-expiredBefore)
+}
+
+func TestCollectTopPendingMarksAttemptedBeforeExpiration(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	attemptedBefore := splitScatterPendingExpiredCount(t, "true")
+	unattemptedBefore := splitScatterPendingExpiredCount(t, "false")
+	re.Len(controller.collectTopPendingSplitScatter(1), 1)
+	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
+	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(1), splitScatterPendingExpiredCount(t, "true")-attemptedBefore)
+	re.Equal(float64(1), splitScatterPendingExpiredCount(t, "false")-unattemptedBefore)
+}
+
+func TestRecordSplitScatterBatchRespectsPendingLimit(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	fillSplitScatterPending(controller, time.Time{})
+
+	droppedBefore := metricValue(t, splitScatterPendingDroppedCounter)
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	re.Equal(splitScatterPendingLimit, splitScatterPendingCount(controller))
+	re.Equal(float64(2), metricValue(t, splitScatterPendingDroppedCounter)-droppedBefore)
+	controller.splitScatter.pendingMu.RLock()
+	_, sourceExists := controller.splitScatter.pending[100]
+	_, childExists := controller.splitScatter.pending[101]
+	controller.splitScatter.pendingMu.RUnlock()
+	re.False(sourceExists)
+	re.False(childExists)
+}
+
+func TestRecordSplitScatterBatchClearsExpiredPendingBeforeLimitCheck(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	fillSplitScatterPending(controller, time.Now().Add(-time.Second))
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	re.Equal(2, splitScatterPendingCount(controller))
+	re.Equal(makeSplitScatterGroup(100, 101), splitScatterPendingGroup(t, controller, 101))
+}
+
+func TestCollectTopPendingSortsBeforeLimit(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(200, splitScatterTestSourceWaitVersion, []uint64{201})
+	putSplitScatterRegion(tc, 200, "n", "o", splitScatterNoCPUUsage)
+	putSplitScatterRegion(tc, 201, "o", "p", splitScatterReportedCPUUsage)
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "n", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	pending := controller.collectTopPendingSplitScatter(1)
+	re.Len(pending, 1)
+	re.Equal(uint64(100), pending[0].regionID)
+}
+
+func TestCollectTopPendingPrioritizesNearExpiration(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	controller.RecordSplitScatterBatch(200, splitScatterTestSourceWaitVersion, []uint64{201})
+	putSplitScatterRegion(tc, 100, "m", "n", splitScatterNoCPUUsage)
+	putSplitScatterRegion(tc, 101, "n", "o", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 200, "o", "p", splitScatterNoCPUUsage)
+	putSplitScatterRegion(tc, 201, "p", "q", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+	advanceSplitScatterRegionVersion(t, tc, 200)
+
+	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(2*time.Minute))
+	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(2*time.Minute))
+	expireSplitScatterPendingAt(t, controller, 200, time.Now().Add(time.Minute))
+	expireSplitScatterPendingAt(t, controller, 201, time.Now().Add(time.Minute))
+
+	pending := controller.collectTopPendingSplitScatter(1)
+	re.Len(pending, 1)
+	re.Equal(uint64(200), pending[0].regionID)
+}
+
+func TestCollectTopPendingResolvesRangeHint(t *testing.T) {
+	testCases := []struct {
+		name      string
+		startKey  []byte
+		endKey    []byte
+		wantRange splitScatterRangeHint
+		wantGroup string
+	}{
+		{
+			name:      "index region",
+			startKey:  newSplitScatterIndexKey("a"),
+			endKey:    newSplitScatterIndexKey("m"),
+			wantRange: splitScatterPrefixRange(splitScatterIndexKeyPrefix()),
+			wantGroup: makeSplitScatterIndexGroup(splitScatterTestTableID, splitScatterTestIndexID),
+		},
+		{
+			name:      "record region",
+			startKey:  newSplitScatterRecordKey(42, "a"),
+			endKey:    newSplitScatterRecordKey(42, "m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+		{
+			name:      "bare table boundary",
+			startKey:  newSplitScatterTableBoundaryKey(42),
+			endKey:    newSplitScatterIndexKey("m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+		{
+			name:      "cross entity falls back to table",
+			startKey:  newSplitScatterIndexKey("a"),
+			endKey:    newSplitScatterRecordKey(42, "m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+		{
+			name:      "cross table uses start table",
+			startKey:  newSplitScatterRecordKey(42, "a"),
+			endKey:    newSplitScatterRecordKey(43, "m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			controller, tc, _, cleanup := newTestSplitScatterController(t)
+			defer cleanup()
+
+			controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+			putSplitScatterRegionWithKeys(tc, testCase.startKey, testCase.endKey, splitScatterReportedCPUUsage)
+			putSplitScatterRegion(tc, 100, "x", "z", splitScatterNoCPUUsage)
+			advanceSplitScatterSourceVersion(t, tc)
+
+			re.Equal(makeSplitScatterGroup(100, 101), splitScatterPendingGroup(t, controller, 101))
+			re.ElementsMatch([]uint64{100, 101}, pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
+			rangeHint := resolveSplitScatterRangeHint(tc.GetRegion(101))
+			re.Equal(testCase.wantRange.startKey, rangeHint.startKey)
+			re.Equal(testCase.wantRange.endKey, rangeHint.endKey)
+			re.Equal(testCase.wantGroup, rangeHint.scatterGroup)
+		})
+	}
+}
+
+func TestDispatchSplitScatterUsesRangeScatterGroup(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegionWithKeysByID(tc, 90, newSplitScatterIndexKey("m"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage)
+	putSplitScatterRegionWithKeysByID(tc, 101, newSplitScatterIndexKey("a"), newSplitScatterIndexKey("m"), splitScatterReportedCPUUsage)
+	advanceSplitScatterRegionVersion(t, tc, 100)
+
+	batchGroup := splitScatterPendingGroup(t, controller, 101)
+
+	controller.dispatchSplitScatterRegions()
+
+	expectedScatterGroup := makeSplitScatterIndexGroup(splitScatterTestTableID, splitScatterTestIndexID)
+	op := oc.GetOperator(101)
+	re.NotNil(op)
+	re.Equal(expectedScatterGroup, op.GetAdditionalInfo("group"))
+	re.Equal(batchGroup, op.GetAdditionalInfo("batch-group"))
+}
+
+func TestDispatchSplitScatterKeepsStableGroupWhenRegionSplitsAgain(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	stableGroup := makeSplitScatterIndexGroup(splitScatterTestTableID, splitScatterTestIndexID)
+	sourceID := uint64(100)
+	childIDs := []uint64{101, 201, 301}
+	splitKeys := []string{"m", "t", "x"}
+	previousBatchGroup := ""
+
+	putSplitScatterRegionWithKeysByID(tc, sourceID, newSplitScatterIndexKey("a"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage)
+	for i, childID := range childIDs {
+		controller.RecordSplitScatterBatch(sourceID, splitScatterTestSourceWaitVersion, []uint64{childID})
+		batchGroup := splitScatterPendingGroup(t, controller, childID)
+		re.NotEqual(previousBatchGroup, batchGroup)
+
+		tc.PutRegion(tc.GetRegion(sourceID).Clone(
+			core.WithEndKey(newSplitScatterIndexKey(splitKeys[i])),
+			core.WithIncVersion(),
+		))
+		putSplitScatterRegionWithKeysByID(tc, childID, newSplitScatterIndexKey(splitKeys[i]), newSplitScatterIndexKey("z"), splitScatterReportedCPUUsage)
+
+		controller.dispatchSplitScatterRegions()
+
+		requireInternalScatterOpsUseGroups(t, oc, stableGroup, batchGroup)
+		removeInternalScatterOps(oc)
+		previousBatchGroup = batchGroup
+	}
+}
+
+func TestDispatchSplitScatterBacksOff(t *testing.T) {
+	testCases := []struct {
+		name      string
+		putRegion func(*mockcluster.Cluster)
+	}{
+		{
+			name: "region is not fully replicated",
+			putRegion: func(tc *mockcluster.Cluster) {
+				putSplitScatterRegionWithStores(tc, 101, "m", "", splitScatterReportedCPUUsage, 1, 2)
+			},
+		},
+		{
+			name: "scatter internal fails",
+			putRegion: func(tc *mockcluster.Cluster) {
+				putSplitScatterRegionWithoutLeader(tc, 101, "m", "", splitScatterReportedCPUUsage)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			controller, tc, _, cleanup := newTestSplitScatterController(t)
+			defer cleanup()
+
+			controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+			testCase.putRegion(tc)
+			advanceSplitScatterSourceVersion(t, tc)
+
+			controller.dispatchSplitScatterRegions()
+
+			re.Equal(1, splitScatterPendingCount(controller))
+			pending := splitScatterObservedPending(t, controller)
+			re.True(pending.retryAt.After(time.Now()))
+			re.Empty(pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
+		})
+	}
+}
+
+func TestDispatchSplitScatterIgnoresStalePendingSnapshot(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	stalePending := splitScatterObservedPending(t, controller)
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{102, 101})
+	currentPending := splitScatterObservedPending(t, controller)
+	re.NotEqual(stalePending.group, currentPending.group)
+	re.Equal(time.Time{}, currentPending.retryAt)
+
+	controller.splitScatter.delayPendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(time.Time{}, currentPending.retryAt)
+
+	controller.splitScatter.deletePendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(makeSplitScatterGroup(100, 102), currentPending.group)
+	re.Equal(time.Time{}, currentPending.retryAt)
+}
+
+func TestDispatchSplitScatterIgnoresStalePendingWithSameGroup(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	stalePending := splitScatterObservedPending(t, controller)
+
+	controller.splitScatter.pendingMu.Lock()
+	currentPending := controller.splitScatter.pending[splitScatterObservedRegionID]
+	currentPending.expireAt = currentPending.expireAt.Add(time.Minute)
+	controller.splitScatter.pending[splitScatterObservedRegionID] = currentPending
+	controller.splitScatter.pendingMu.Unlock()
+
+	controller.splitScatter.delayPendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(time.Time{}, currentPending.retryAt)
+
+	controller.splitScatter.deletePendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(stalePending.group, currentPending.group)
+	re.NotEqual(stalePending.expireAt, currentPending.expireAt)
+}
+
+func newTestSplitScatterController(t *testing.T) (*Controller, *mockcluster.Cluster, *operator.Controller, func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	for storeID := uint64(1); storeID <= 4; storeID++ {
+		tc.AddRegionStore(storeID, 0)
+	}
+	putSplitScatterRegion(tc, 100, "", "m", splitScatterNoCPUUsage)
+
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	controller := NewController(ctx, tc, tc.GetCheckerConfig(), tc.GetRuleManager(), tc.GetRegionLabeler(), oc)
+
+	cleanup := func() {
+		stream.Close()
+		cancel()
+	}
+	return controller, tc, oc, cleanup
+}
+
+func putSplitScatterRegion(tc *mockcluster.Cluster, regionID uint64, startKey, endKey string, cpuUsage uint64) {
+	tc.AddLeaderRegionWithRange(regionID, startKey, endKey, 1, 2, 3)
+	region := tc.GetRegion(regionID).Clone(core.SetCPUUsage(cpuUsage))
+	tc.PutRegion(region)
+}
+
+func putSplitScatterRegionWithKeys(tc *mockcluster.Cluster, startKey, endKey []byte, cpuUsage uint64) {
+	putSplitScatterRegionWithKeysByID(tc, splitScatterObservedRegionID, startKey, endKey, cpuUsage)
+}
+
+func putSplitScatterRegionWithKeysByID(tc *mockcluster.Cluster, regionID uint64, startKey, endKey []byte, cpuUsage uint64) {
+	peers := []*metapb.Peer{
+		{Id: regionID*10 + 1, StoreId: 1},
+		{Id: regionID*10 + 2, StoreId: 2},
+		{Id: regionID*10 + 3, StoreId: 3},
+	}
+	region := core.NewRegionInfo(
+		&metapb.Region{
+			Id:       regionID,
+			StartKey: startKey,
+			EndKey:   endKey,
+			Peers:    peers,
+			RegionEpoch: &metapb.RegionEpoch{
+				ConfVer: 1,
+				Version: 1,
+			},
+		},
+		peers[0],
+		core.SetCPUUsage(cpuUsage),
+	)
+	tc.PutRegion(region)
+}
+
+func newSplitScatterRegionInfo(
+	regionID uint64,
+	startKey, endKey string,
+	peers []*metapb.Peer,
+	leader *metapb.Peer,
+	cpuUsage uint64,
+) *core.RegionInfo {
+	return core.NewRegionInfo(
+		&metapb.Region{
+			Id:       regionID,
+			StartKey: []byte(startKey),
+			EndKey:   []byte(endKey),
+			Peers:    peers,
+			RegionEpoch: &metapb.RegionEpoch{
+				ConfVer: 1,
+				Version: 1,
+			},
+		},
+		leader,
+		core.SetCPUUsage(cpuUsage),
+	)
+}
+
+func putSplitScatterRegionWithStores(tc *mockcluster.Cluster, regionID uint64, startKey, endKey string, cpuUsage uint64, stores ...uint64) {
+	peers := make([]*metapb.Peer, 0, len(stores))
+	for i, storeID := range stores {
+		peers = append(peers, &metapb.Peer{
+			Id:      regionID*10 + uint64(i) + 1,
+			StoreId: storeID,
+		})
+	}
+	tc.PutRegion(newSplitScatterRegionInfo(regionID, startKey, endKey, peers, peers[0], cpuUsage))
+}
+
+func putSplitScatterRegionWithoutLeader(tc *mockcluster.Cluster, regionID uint64, startKey, endKey string, cpuUsage uint64) {
+	peers := []*metapb.Peer{
+		{Id: regionID*10 + 1, StoreId: 1},
+		{Id: regionID*10 + 2, StoreId: 2},
+		{Id: regionID*10 + 3, StoreId: 3},
+	}
+	tc.PutRegion(newSplitScatterRegionInfo(regionID, startKey, endKey, peers, nil, cpuUsage))
+}
+
+func fillSplitScatterPending(controller *Controller, expireAt time.Time) {
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	for regionID := uint64(1000); regionID < 1000+splitScatterPendingLimit; regionID++ {
+		controller.splitScatter.pending[regionID] = splitScatterPendingItem{
+			regionID: regionID,
+			group:    "old",
+			expireAt: expireAt,
+		}
+	}
+}
+
+func advanceSplitScatterSourceVersion(t *testing.T, tc *mockcluster.Cluster) {
+	advanceSplitScatterRegionVersion(t, tc, 100)
+}
+
+func advanceSplitScatterRegionVersion(t *testing.T, tc *mockcluster.Cluster, regionID uint64) {
+	t.Helper()
+	region := tc.GetRegion(regionID)
+	require.NotNil(t, region)
+	tc.PutRegion(region.Clone(core.WithIncVersion()))
+}
+
+func splitScatterPendingCount(controller *Controller) int {
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	return len(controller.splitScatter.pending)
+}
+
+func metricValue(t *testing.T, metric prometheus.Metric) float64 {
+	t.Helper()
+	pb := &dto.Metric{}
+	require.NoError(t, metric.Write(pb))
+	switch {
+	case pb.Gauge != nil:
+		return pb.Gauge.GetValue()
+	case pb.Counter != nil:
+		return pb.Counter.GetValue()
+	default:
+		require.FailNow(t, "metric has no gauge or counter")
+		return 0
+	}
+}
+
+func splitScatterPendingExpiredCount(t *testing.T, attempted string) float64 {
+	t.Helper()
+	return metricValue(t, splitScatterPendingExpiredCounter.WithLabelValues(attempted))
+}
+
+func splitScatterPendingGroup(t *testing.T, controller *Controller, regionID uint64) string {
+	t.Helper()
+	return splitScatterPending(t, controller, regionID).group
+}
+
+func splitScatterPending(t *testing.T, controller *Controller, regionID uint64) splitScatterPendingItem {
+	t.Helper()
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	pending, ok := controller.splitScatter.pending[regionID]
+	require.True(t, ok)
+	return pending
+}
+
+func splitScatterObservedPending(t *testing.T, controller *Controller) splitScatterPendingItem {
+	t.Helper()
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	pending, ok := controller.splitScatter.pending[splitScatterObservedRegionID]
+	require.True(t, ok)
+	return pending
+}
+
+func expireSplitScatterPendingAt(t *testing.T, controller *Controller, regionID uint64, expireAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	pending, ok := controller.splitScatter.pending[regionID]
+	require.True(t, ok)
+	pending.expireAt = expireAt
+	controller.splitScatter.pending[regionID] = pending
+}
+
+func requireInternalScatterOpsUseGroups(t *testing.T, oc *operator.Controller, scatterGroup, batchGroup string) {
+	t.Helper()
+	re := require.New(t)
+	ops := oc.GetOperators()
+	re.NotEmpty(ops)
+	for _, op := range ops {
+		re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+		re.Equal(scatterGroup, op.GetAdditionalInfo("group"))
+		re.Equal(batchGroup, op.GetAdditionalInfo("batch-group"))
+	}
+}
+
+func removeInternalScatterOps(oc *operator.Controller) {
+	for _, op := range oc.GetOperators() {
+		oc.RemoveOperator(op)
+	}
+}
+
+func pendingRegionIDs(regions []splitScatterPendingItem) []uint64 {
+	ids := make([]uint64, 0, len(regions))
+	for _, region := range regions {
+		ids = append(ids, region.regionID)
+	}
+	return ids
+}
+
+func splitScatterIndexKeyPrefix() []byte {
+	return codec.GenerateIndexKey(splitScatterTestTableID, splitScatterTestIndexID)
+}
+
+func newSplitScatterIndexKey(suffix string) []byte {
+	key := append([]byte(nil), splitScatterIndexKeyPrefix()...)
+	key = append(key, suffix...)
+	return codec.EncodeBytes(key)
+}
+
+func newSplitScatterRecordKey(tableID int64, suffix string) []byte {
+	key := append([]byte(nil), codec.GenerateRecordKeyPrefix(tableID)...)
+	key = append(key, suffix...)
+	return codec.EncodeBytes(key)
+}
+
+func newSplitScatterTableBoundaryKey(tableID int64) []byte {
+	return codec.EncodeBytes(codec.GenerateTableKey(tableID))
+}

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -34,16 +34,17 @@ const (
 	// defaultMaxMergeRegionSize is the default maximum size of region when regions can be merged.
 	// After https://github.com/tikv/tikv/issues/17309, the default value is enlarged from 20 to 54,
 	// to make it compatible with the default value of region size of tikv.
-	defaultMaxMergeRegionSize     = 54
-	defaultLeaderScheduleLimit    = 4
-	defaultRegionScheduleLimit    = 2048
-	defaultWitnessScheduleLimit   = 4
-	defaultReplicaScheduleLimit   = 64
-	defaultMergeScheduleLimit     = 8
-	defaultHotRegionScheduleLimit = 4
-	defaultTolerantSizeRatio      = 0
-	defaultLowSpaceRatio          = 0.8
-	defaultHighSpaceRatio         = 0.7
+	defaultMaxMergeRegionSize        = 54
+	defaultLeaderScheduleLimit       = 4
+	defaultRegionScheduleLimit       = 2048
+	defaultWitnessScheduleLimit      = 4
+	defaultReplicaScheduleLimit      = 64
+	defaultMergeScheduleLimit        = 8
+	defaultHotRegionScheduleLimit    = 4
+	defaultSplitScatterScheduleLimit = 4
+	defaultTolerantSizeRatio         = 0
+	defaultLowSpaceRatio             = 0.8
+	defaultHighSpaceRatio            = 0.7
 	// defaultHotRegionCacheHitsThreshold is the low hit number threshold of the
 	// hot region.
 	defaultHotRegionCacheHitsThreshold = 3
@@ -103,6 +104,7 @@ const (
 	ReplicaRescheduleLimitKey      = "schedule.replica-schedule-limit"
 	MergeScheduleLimitKey          = "schedule.merge-schedule-limit"
 	HotRegionScheduleLimitKey      = "schedule.hot-region-schedule-limit"
+	SplitScatterScheduleLimitKey   = "schedule.split-scatter-schedule-limit"
 	SchedulerMaxWaitingOperatorKey = "schedule.scheduler-max-waiting-operator"
 	EnableLocationReplacement      = "schedule.enable-location-replacement"
 	DefaultAddPeer                 = "default-add-peer"
@@ -203,6 +205,8 @@ type ScheduleConfig struct {
 	MergeScheduleLimit uint64 `toml:"merge-schedule-limit" json:"merge-schedule-limit"`
 	// HotRegionScheduleLimit is the max coexist hot region schedules.
 	HotRegionScheduleLimit uint64 `toml:"hot-region-schedule-limit" json:"hot-region-schedule-limit"`
+	// SplitScatterScheduleLimit is the max coexist internal split-scatter schedules. 0 means disabled.
+	SplitScatterScheduleLimit uint64 `toml:"split-scatter-schedule-limit" json:"split-scatter-schedule-limit"`
 	// HotRegionCacheHitThreshold is the cache hits threshold of the hot region.
 	// If the number of times a region hits the hot cache is greater than this
 	// threshold, it is considered a hot region.
@@ -364,6 +368,9 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	}
 	if !meta.IsDefined("hot-region-schedule-limit") {
 		configutil.AdjustUint64(&c.HotRegionScheduleLimit, defaultHotRegionScheduleLimit)
+	}
+	if !meta.IsDefined("split-scatter-schedule-limit") {
+		configutil.AdjustUint64(&c.SplitScatterScheduleLimit, defaultSplitScatterScheduleLimit)
 	}
 	if !meta.IsDefined("hot-region-cache-hits-threshold") {
 		configutil.AdjustUint64(&c.HotRegionCacheHitsThreshold, defaultHotRegionCacheHitsThreshold)

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -99,6 +99,7 @@ type CheckerConfigProvider interface {
 type SharedConfigProvider interface {
 	GetMaxReplicas() int
 	IsPlacementRulesEnabled() bool
+	GetSplitScatterScheduleLimit() uint64
 	GetMaxSnapshotCount() uint64
 	GetMaxPendingPeerCount() uint64
 	GetLowSpaceRatio() float64

--- a/pkg/schedule/operator/builder.go
+++ b/pkg/schedule/operator/builder.go
@@ -164,6 +164,17 @@ func NewBuilder(desc string, ci sche.SharedCluster, region *core.RegionInfo, opt
 	return b
 }
 
+// IsAllowedLeaderTarget checks whether the peer can be selected as a
+// non-forced target leader by the operator builder.
+func IsAllowedLeaderTarget(ci sche.SharedCluster, region *core.RegionInfo, peer *metapb.Peer) bool {
+	b := NewBuilder("check-target-leader", ci, region)
+	if b.err != nil {
+		return false
+	}
+	b.currentPeers, b.currentLeaderStoreID = b.originPeers.copy(), b.originLeaderStoreID
+	return b.allowLeader(peer, false)
+}
+
 // AddPeer records an add Peer operation in Builder. If peer.Id is 0, the builder
 // will allocate a new peer ID later.
 func (b *Builder) AddPeer(peer *metapb.Peer) *Builder {

--- a/pkg/schedule/operator/create_operator.go
+++ b/pkg/schedule/operator/create_operator.go
@@ -235,6 +235,16 @@ func isRegionMatch(a, b *core.RegionInfo) bool {
 
 // CreateScatterRegionOperator creates an operator that scatters the specified region.
 func CreateScatterRegionOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, skipLimitCheck bool) (*Operator, error) {
+	return newScatterRegionOperator(desc, ci, origin, targetPeers, targetLeader, skipLimitCheck, OpAdmin)
+}
+
+// CreateNonAdminScatterRegionOperator creates a scatter operator for internal
+// split-scatter background flows.
+func CreateNonAdminScatterRegionOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, skipLimitCheck bool) (*Operator, error) {
+	return newScatterRegionOperator(desc, ci, origin, targetPeers, targetLeader, skipLimitCheck, OpSplitScatter)
+}
+
+func newScatterRegionOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, skipLimitCheck bool, kind OpKind) (*Operator, error) {
 	// randomly pick a leader.
 	var ids []uint64
 	for id, peer := range targetPeers {
@@ -255,13 +265,16 @@ func CreateScatterRegionOperator(desc string, ci sche.SharedCluster, origin *cor
 		builder.SetRemoveLightPeer()
 	}
 
-	return builder.
+	builder = builder.
 		SetPeers(targetPeers).
 		SetLeader(leader).
-		SetAddLightPeer().
-		// EnableForceTargetLeader in order to ignore the leader schedule limit
-		EnableForceTargetLeader().
-		Build(OpAdmin)
+		SetAddLightPeer()
+	if kind&OpAdmin != 0 {
+		// Admin scatter keeps the historical behavior: force the selected
+		// target leader so manual scatter can bypass leader scheduling limits.
+		builder.EnableForceTargetLeader()
+	}
+	return builder.Build(kind)
 }
 
 // OpDescLeaveJointState is the expected desc for LeaveJointStateOperator.

--- a/pkg/schedule/operator/create_operator_test.go
+++ b/pkg/schedule/operator/create_operator_test.go
@@ -1141,6 +1141,38 @@ func (suite *createOperatorTestSuite) TestMoveRegionWithoutJointConsensus() {
 	}
 }
 
+func (suite *createOperatorTestSuite) TestNonAdminScatterDoesNotForceTargetLeader() {
+	re := suite.Require()
+	peers := []*metapb.Peer{
+		{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
+		{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter},
+		{Id: 10, StoreId: 10, Role: metapb.PeerRole_Voter},
+	}
+	region := core.NewRegionInfo(&metapb.Region{Id: 1, Peers: peers}, peers[0])
+	targetPeers := map[uint64]*metapb.Peer{
+		1:  peers[0],
+		2:  peers[1],
+		10: peers[2],
+	}
+
+	adminOp, err := CreateScatterRegionOperator("admin-scatter", suite.cluster, region, targetPeers, 10, false)
+	re.NoError(err)
+	re.NotNil(adminOp)
+	re.Equal(OpAdmin, adminOp.SchedulerKind())
+	re.Zero(adminOp.Kind() & OpSplitScatter)
+
+	nonAdminOp, err := CreateNonAdminScatterRegionOperator("internal-scatter", suite.cluster, region, targetPeers, 2, false)
+	re.NoError(err)
+	re.NotNil(nonAdminOp)
+	re.Equal(OpSplitScatter, nonAdminOp.SchedulerKind())
+	re.NotZero(nonAdminOp.Kind() & OpSplitScatter)
+
+	nonAdminOp, err = CreateNonAdminScatterRegionOperator("internal-scatter", suite.cluster, region, targetPeers, 10, false)
+	re.Error(err)
+	re.Nil(nonAdminOp)
+	re.Contains(err.Error(), "target leader is not allowed")
+}
+
 // Ref https://github.com/tikv/pd/issues/5401
 func TestCreateLeaveJointStateOperatorWithoutFitRules(t *testing.T) {
 	re := require.New(t)

--- a/pkg/schedule/operator/kind.go
+++ b/pkg/schedule/operator/kind.go
@@ -49,6 +49,8 @@ const (
 	OpWitnessLeader
 	// Include witness transfer.
 	OpWitness
+	// Initiated by internal split-scatter dispatcher.
+	OpSplitScatter
 	opMax
 )
 
@@ -63,6 +65,7 @@ var flagToName = map[OpKind]string{
 	OpRange:         "range",
 	OpWitness:       "witness",
 	OpWitnessLeader: "witness-leader",
+	OpSplitScatter:  "split-scatter",
 }
 
 var nameToFlag = map[string]OpKind{
@@ -75,6 +78,7 @@ var nameToFlag = map[string]OpKind{
 	"merge":          OpMerge,
 	"range":          OpRange,
 	"witness-leader": OpWitnessLeader,
+	"split-scatter":  OpSplitScatter,
 }
 
 func (k OpKind) String() string {

--- a/pkg/schedule/operator/operator.go
+++ b/pkg/schedule/operator/operator.go
@@ -216,6 +216,12 @@ func (o *Operator) Kind() OpKind {
 // SchedulerKind return the highest OpKind even if the operator has many OpKind
 // fix #3778
 func (o *Operator) SchedulerKind() OpKind {
+	if o.kind&OpAdmin != 0 {
+		return OpAdmin
+	}
+	if o.kind&OpSplitScatter != 0 {
+		return OpSplitScatter
+	}
 	// LowBit ref: https://en.wikipedia.org/wiki/Find_first_set
 	// 6(110) ==> 2(10)
 	// 5(101) ==> 1(01)

--- a/pkg/schedule/operator/operator_test.go
+++ b/pkg/schedule/operator/operator_test.go
@@ -475,9 +475,40 @@ func (suite *operatorTestSuite) TestSchedulerKind() {
 			op:     NewTestOperator(1, &metapb.RegionEpoch{}, OpLeader),
 			expect: OpLeader,
 		},
+		{
+			op:     NewTestOperator(1, &metapb.RegionEpoch{}, OpSplitScatter|OpRegion),
+			expect: OpSplitScatter,
+		}, {
+			op:     NewTestOperator(1, &metapb.RegionEpoch{}, OpAdmin|OpSplitScatter|OpRegion),
+			expect: OpAdmin,
+		},
 	}
 	for _, v := range testData {
 		re.Equal(v.expect, v.op.SchedulerKind())
+	}
+}
+
+func (suite *operatorTestSuite) TestOpKindValues() {
+	re := suite.Require()
+	testCases := []struct {
+		name string
+		kind OpKind
+		want OpKind
+	}{
+		{"admin", OpAdmin, 1 << 0},
+		{"merge", OpMerge, 1 << 1},
+		{"range", OpRange, 1 << 2},
+		{"replica", OpReplica, 1 << 3},
+		{"split", OpSplit, 1 << 4},
+		{"hot-region", OpHotRegion, 1 << 5},
+		{"region", OpRegion, 1 << 6},
+		{"leader", OpLeader, 1 << 7},
+		{"witness-leader", OpWitnessLeader, 1 << 8},
+		{"witness", OpWitness, 1 << 9},
+		{"split-scatter", OpSplitScatter, 1 << 10},
+	}
+	for _, testCase := range testCases {
+		re.Equal(testCase.want, testCase.kind, "unexpected %s kind value", testCase.name)
 	}
 }
 

--- a/pkg/schedule/scatter/region_scatterer.go
+++ b/pkg/schedule/scatter/region_scatterer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"strconv"
 	"sync"
 	"time"
@@ -42,8 +43,9 @@ import (
 const regionScatterName = "region-scatter"
 
 var (
-	gcInterval = time.Minute
-	gcTTL      = time.Minute * 3
+	gcInterval            = time.Minute
+	gcTTL                 = time.Minute * 3
+	operatorPriorityLevel = constant.High
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	scatterSkipEmptyRegionCounter   = scatterCounter.WithLabelValues("skip", "empty-region")
 	scatterSkipNoRegionCounter      = scatterCounter.WithLabelValues("skip", "no-region")
@@ -53,6 +55,8 @@ var (
 	scatterUnnecessaryCounter       = scatterCounter.WithLabelValues("unnecessary", "")
 	scatterFailCounter              = scatterCounter.WithLabelValues("fail", "")
 	scatterSuccessCounter           = scatterCounter.WithLabelValues("success", "")
+	scatterOperatorRunningCounter   = scatterCounter.WithLabelValues("skip", "running")
+	scatterOperatorExistedCounter   = scatterCounter.WithLabelValues("fail", "other-existed")
 	errRegionNotFound               = errors.New("region not found")
 	errEmptyRegion                  = errors.New("empty region")
 )
@@ -61,7 +65,15 @@ const (
 	maxSleepDuration     = time.Minute
 	initialSleepDuration = 100 * time.Millisecond
 	maxRetryLimit        = 30
+	// AdminScatterOperatorDesc is used by external admin/API scatter requests.
+	AdminScatterOperatorDesc = "scatter-region"
+	// InternalScatterOperatorDesc is used by PD-internal split-scatter dispatch.
+	InternalScatterOperatorDesc = "split-scatter-region"
 )
+
+type selectedStoreCounter interface {
+	Get(id uint64, group string) uint64
+}
 
 type selectedStores struct {
 	mu                syncutil.RWMutex
@@ -72,6 +84,38 @@ func newSelectedStores(ctx context.Context) *selectedStores {
 	return &selectedStores{
 		groupDistribution: cache.NewStringTTL(ctx, gcInterval, gcTTL),
 	}
+}
+
+type localSelectedStores struct {
+	groupDistribution map[string]map[uint64]uint64
+	seededGroups      map[string]struct{}
+}
+
+func newLocalSelectedStores() *localSelectedStores {
+	return &localSelectedStores{
+		groupDistribution: make(map[string]map[uint64]uint64),
+		seededGroups:      make(map[string]struct{}),
+	}
+}
+
+func cloneDistribution(distribution map[uint64]uint64) map[uint64]uint64 {
+	cloned := make(map[uint64]uint64, len(distribution))
+	for id, count := range distribution {
+		cloned[id] = count
+	}
+	return cloned
+}
+
+func decrementDistribution(distribution map[uint64]uint64, id uint64) {
+	count, ok := distribution[id]
+	if !ok {
+		return
+	}
+	if count <= 1 {
+		delete(distribution, id)
+		return
+	}
+	distribution[id] = count - 1
 }
 
 // Put plus count by storeID and group
@@ -117,6 +161,54 @@ func (s *selectedStores) getDistributionByGroupLocked(group string) (map[uint64]
 	return nil, false
 }
 
+// Get the count by storeID and group.
+func (s *localSelectedStores) Get(id uint64, group string) uint64 {
+	distribution, ok := s.groupDistribution[group]
+	if !ok {
+		return 0
+	}
+	count, ok := distribution[id]
+	if !ok {
+		return 0
+	}
+	return count
+}
+
+// InitGroupDistribution seeds the distribution for a group if the group has not
+// been tracked yet.
+func (s *localSelectedStores) InitGroupDistribution(group string, distribution map[uint64]uint64) bool {
+	if _, ok := s.groupDistribution[group]; ok {
+		return false
+	}
+	s.groupDistribution[group] = cloneDistribution(distribution)
+	s.seededGroups[group] = struct{}{}
+	return true
+}
+
+// Update records the group distribution after scattering one more region.
+// For seeded groups it applies the net old->new change. Otherwise it keeps the
+// historical scatter behavior and only counts the new placement.
+func (s *localSelectedStores) Update(group string, oldIDs, newIDs []uint64) {
+	distribution, ok := s.groupDistribution[group]
+	if !ok {
+		distribution = map[uint64]uint64{}
+	}
+	if s.isSeededGroup(group) {
+		for _, id := range oldIDs {
+			decrementDistribution(distribution, id)
+		}
+	}
+	for _, id := range newIDs {
+		distribution[id]++
+	}
+	s.groupDistribution[group] = distribution
+}
+
+func (s *localSelectedStores) isSeededGroup(group string) bool {
+	_, ok := s.seededGroups[group]
+	return ok
+}
+
 // RegionScatterer scatters regions.
 type RegionScatterer struct {
 	ctx               context.Context
@@ -151,14 +243,163 @@ type engineContext struct {
 	selectedLeader *selectedStores
 }
 
+type localEngineContext struct {
+	filterFuncs    []filterFunc
+	selectedPeer   *localSelectedStores
+	selectedLeader *localSelectedStores
+}
+
+type scatterSelectionContext struct {
+	filterFuncs    []filterFunc
+	selectedPeer   selectedStoreCounter
+	selectedLeader selectedStoreCounter
+}
+
 func newEngineContext(ctx context.Context, filterFuncs ...filterFunc) engineContext {
 	filterFuncs = append(filterFuncs, func() filter.Filter {
-		return &filter.StoreStateFilter{ActionScope: regionScatterName, MoveRegion: true, ScatterRegion: true, OperatorLevel: constant.High}
+		return &filter.StoreStateFilter{ActionScope: regionScatterName, MoveRegion: true, ScatterRegion: true, OperatorLevel: operatorPriorityLevel}
 	})
 	return engineContext{
 		filterFuncs:    filterFuncs,
 		selectedPeer:   newSelectedStores(ctx),
 		selectedLeader: newSelectedStores(ctx),
+	}
+}
+
+func (ctx engineContext) asSelectionContext() scatterSelectionContext {
+	return scatterSelectionContext{
+		filterFuncs:    ctx.filterFuncs,
+		selectedPeer:   ctx.selectedPeer,
+		selectedLeader: ctx.selectedLeader,
+	}
+}
+
+func (ctx localEngineContext) asSelectionContext() scatterSelectionContext {
+	return scatterSelectionContext{
+		filterFuncs:    ctx.filterFuncs,
+		selectedPeer:   ctx.selectedPeer,
+		selectedLeader: ctx.selectedLeader,
+	}
+}
+
+func (r *RegionScatterer) getOrCreateSpecialEngineContext(engine string) engineContext {
+	if ctx, ok := r.specialEngines.Load(engine); ok {
+		return ctx.(engineContext)
+	}
+	ctx := newEngineContext(r.ctx, func() filter.Filter {
+		return filter.NewEngineFilter(r.name, placement.LabelConstraint{Key: core.EngineKey, Op: placement.In, Values: []string{engine}})
+	})
+	r.specialEngines.Store(engine, ctx)
+	return ctx
+}
+
+type scatterState struct {
+	ordinaryEngine localEngineContext
+	specialEngines map[string]localEngineContext
+}
+
+func (ctx engineContext) withEmptySelection() localEngineContext {
+	return localEngineContext{
+		filterFuncs:    ctx.filterFuncs,
+		selectedPeer:   newLocalSelectedStores(),
+		selectedLeader: newLocalSelectedStores(),
+	}
+}
+
+func (r *RegionScatterer) newScatterState() *scatterState {
+	return &scatterState{
+		ordinaryEngine: r.ordinaryEngine.withEmptySelection(),
+		specialEngines: make(map[string]localEngineContext),
+	}
+}
+
+func (s *scatterState) getSpecialEngine(engine string) (localEngineContext, bool) {
+	ctx, ok := s.specialEngines[engine]
+	return ctx, ok
+}
+
+func (r *RegionScatterer) getOrCreateSpecialEngineState(state *scatterState, engine string) localEngineContext {
+	if ctx, ok := state.getSpecialEngine(engine); ok {
+		return ctx
+	}
+	ctx := r.getOrCreateSpecialEngineContext(engine).withEmptySelection()
+	state.specialEngines[engine] = ctx
+	return ctx
+}
+
+// seedScatterStateByRange seeds the scatter group with the current live peer and
+// leader distribution of the specified key range.
+func (r *RegionScatterer) seedScatterStateByRange(state *scatterState, group string, startKey, endKey []byte) {
+	if group == "" || len(startKey) == 0 {
+		return
+	}
+	if state.ordinaryEngine.selectedPeer.isSeededGroup(group) {
+		return
+	}
+
+	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
+	ordinaryPeer := make(map[uint64]uint64)
+	ordinaryLeader := make(map[uint64]uint64)
+	specialPeer := make(map[string]map[uint64]uint64)
+	for _, store := range r.cluster.GetStores() {
+		if store == nil {
+			continue
+		}
+		storeID := store.GetID()
+		peerCount := uint64(r.cluster.GetStorePeerCountByRange(storeID, startKey, endKey))
+		if engineFilter.Target(r.cluster.GetSharedConfig(), store).IsOK() {
+			if peerCount > 0 {
+				ordinaryPeer[storeID] = peerCount
+			}
+			if leaderCount := uint64(r.cluster.GetStoreLeaderCountByRange(storeID, startKey, endKey)); leaderCount > 0 {
+				ordinaryLeader[storeID] = leaderCount
+			}
+			continue
+		}
+		if peerCount == 0 {
+			continue
+		}
+
+		engine := store.GetLabelValue(core.EngineKey)
+		if _, ok := specialPeer[engine]; !ok {
+			specialPeer[engine] = make(map[uint64]uint64)
+		}
+		specialPeer[engine][storeID] = peerCount
+	}
+
+	state.ordinaryEngine.selectedPeer.InitGroupDistribution(group, ordinaryPeer)
+	state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, ordinaryLeader)
+	for engine, distribution := range specialPeer {
+		ctx := r.getOrCreateSpecialEngineState(state, engine)
+		ctx.selectedPeer.InitGroupDistribution(group, distribution)
+	}
+}
+
+func (r *RegionScatterer) newInternalScatterState(group string, startKey, endKey []byte) *scatterState {
+	state := r.newScatterState()
+	r.seedScatterStateByRange(state, group, startKey, endKey)
+	r.applyRunningScatterOpsDelta(state, group)
+	return state
+}
+
+func (r *RegionScatterer) applyRunningScatterOpsDelta(state *scatterState, group string) {
+	if group == "" {
+		return
+	}
+	for _, op := range r.opController.GetOperators() {
+		if op == nil || op.Desc() != InternalScatterOperatorDesc {
+			continue
+		}
+		opGroup := op.GetAdditionalInfo("group")
+		if opGroup != group {
+			continue
+		}
+		region := r.cluster.GetRegion(op.RegionID())
+		if region == nil || region.GetLeader() == nil {
+			continue
+		}
+		targetPeers, targetLeader := finalPlacementAfterOperator(region, op)
+		r.applyScatterStateDelta(state, region, targetPeers, targetLeader, group, false)
 	}
 }
 
@@ -274,11 +515,53 @@ func (r *RegionScatterer) scatterRegions(regions map[uint64]*core.RegionInfo, fa
 // Scatter relocates the region. If the group is defined, the regions' leader with the same group would be scattered
 // in a group level instead of cluster level.
 func (r *RegionScatterer) Scatter(region *core.RegionInfo, group string, skipStoreLimit bool) (*operator.Operator, error) {
+	return r.scatterWithOptions(region, group, skipStoreLimit, false, nil)
+}
+
+// ScatterInternal relocates the region for PD-internal split-scatter dispatch.
+func (r *RegionScatterer) ScatterInternal(region *core.RegionInfo, group string, startKey, endKey []byte) (*operator.Operator, error) {
+	return r.scatterWithOptions(region, group, false, true, r.newInternalScatterState(group, startKey, endKey))
+}
+
+func (r *RegionScatterer) scatterWithOptions(region *core.RegionInfo, group string, skipStoreLimit bool, internalScatter bool, state *scatterState) (*operator.Operator, error) {
+	expectedDesc := AdminScatterOperatorDesc
+	if internalScatter {
+		expectedDesc = InternalScatterOperatorDesc
+	}
 	if !filter.IsRegionReplicated(r.cluster, region) {
 		r.addSuspectRegions(false, region.GetID())
 		scatterSkipNotReplicatedCounter.Inc()
 		log.Warn("region not replicated during scatter", zap.Uint64("region-id", region.GetID()))
 		return nil, errors.Errorf("region %d is not fully replicated", region.GetID())
+	}
+
+	// Check if there is any existing operator for the region.
+	// if the exist operator level is higher than scatter operator level, give up to create new scatter operator new.
+	// otherwise, create new scatter operator to replace the existing one.
+	if op := r.opController.GetOperator(region.GetID()); op != nil && op.GetPriorityLevel() >= operatorPriorityLevel {
+		val := op.GetAdditionalInfo("group")
+		// If the existing operator is created by the same group scatterer, just skip creating a new one.
+		if op.Desc() == expectedDesc && val == group {
+			if !isSameRegionEpoch(op.RegionEpoch(), region.GetRegionEpoch()) {
+				scatterOperatorExistedCounter.Inc()
+				log.Debug("same group scatter operator epoch does not match",
+					zap.Uint64("region-id", region.GetID()),
+					zap.Reflect("operator-epoch", op.RegionEpoch()),
+					zap.Reflect("region-epoch", region.GetRegionEpoch()))
+				return nil, errors.Errorf("the operator of region %d already exist with different epoch", region.GetID())
+			}
+			scatterOperatorRunningCounter.Inc()
+			log.Debug("scatter operator is already running",
+				zap.Uint64("region-id", region.GetID()))
+			return nil, nil
+		}
+		scatterOperatorExistedCounter.Inc()
+		log.Debug("the operator exist, but it does not meet requirement",
+			zap.Uint64("region-id", region.GetID()),
+			zap.String("additional-info-group", val),
+			zap.String("operator-des", op.Desc()),
+		)
+		return nil, errors.Errorf("the operator of region %d already exist", region.GetID())
 	}
 
 	if region.GetLeader() == nil {
@@ -287,16 +570,30 @@ func (r *RegionScatterer) Scatter(region *core.RegionInfo, group string, skipSto
 		return nil, errors.Errorf("region %d has no leader", region.GetID())
 	}
 
-	if r.cluster.IsRegionHot(region) {
+	if !internalScatter && r.cluster.IsRegionHot(region) {
 		scatterSkipHotRegionCounter.Inc()
 		log.Warn("region too hot during scatter", zap.Uint64("region-id", region.GetID()))
 		return nil, errors.Errorf("region %d is hot", region.GetID())
 	}
 
-	return r.scatterRegion(region, group, skipStoreLimit)
+	return r.scatterRegionWithType(region, group, skipStoreLimit, internalScatter, state)
 }
 
-func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, skipStoreLimit bool) (*operator.Operator, error) {
+func (r *RegionScatterer) scatterRegionWithType(region *core.RegionInfo, group string, skipStoreLimit bool, internalScatter bool, state *scatterState) (*operator.Operator, error) {
+	desc := AdminScatterOperatorDesc
+	if internalScatter {
+		desc = InternalScatterOperatorDesc
+	}
+	ordinaryContext := r.ordinaryEngine.asSelectionContext()
+	getSpecialEngineContext := func(engine string) scatterSelectionContext {
+		return r.getOrCreateSpecialEngineContext(engine).asSelectionContext()
+	}
+	if state != nil {
+		ordinaryContext = state.ordinaryEngine.asSelectionContext()
+		getSpecialEngineContext = func(engine string) scatterSelectionContext {
+			return r.getOrCreateSpecialEngineState(state, engine).asSelectionContext()
+		}
+	}
 	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
 	ordinaryPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
 	specialPeers := make(map[string]map[uint64]*metapb.Peer)
@@ -318,10 +615,29 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 		}
 	}
 
-	targetPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))                  // StoreID -> Peer
-	selectedStores := make(map[uint64]struct{}, len(region.GetPeers()))                   // selected StoreID set
-	leaderCandidateStores := make([]uint64, 0, len(region.GetPeers()))                    // StoreID allowed to become Leader
-	scatterWithSameEngine := func(peers map[uint64]*metapb.Peer, context engineContext) { // peers: StoreID -> Peer
+	targetPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers())) // StoreID -> Peer
+	selectedStores := make(map[uint64]struct{}, len(region.GetPeers()))  // selected StoreID set
+	leaderCandidateStores := make([]uint64, 0, len(region.GetPeers()))   // StoreID allowed to become Leader
+	if internalScatter {
+		leader := region.GetLeader()
+		if leader == nil {
+			return nil, errs.ErrGetTargetStore.FastGenByArgs(fmt.Sprintf("no source leader store found, region: %v", region))
+		}
+		leaderStoreID := leader.GetStoreId()
+		if !r.isAllowedLeaderSource(leaderStoreID) {
+			peer := region.GetStorePeer(leaderStoreID)
+			if peer == nil {
+				return nil, errs.ErrGetTargetStore.FastGenByArgs(fmt.Sprintf("source leader peer not found, region: %v", region))
+			}
+			targetPeers[leaderStoreID] = peer
+			selectedStores[leaderStoreID] = struct{}{}
+		}
+	}
+	scatterWithSameEngine := func(
+		peers map[uint64]*metapb.Peer,
+		context scatterSelectionContext,
+		collectLeaderCandidates bool,
+	) { // peers: StoreID -> Peer
 		filterLen := len(context.filterFuncs) + 2
 		filters := make([]filter.Filter, filterLen)
 		for i, filterFunc := range context.filterFuncs {
@@ -330,7 +646,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 		filters[filterLen-2] = filter.NewExcludedFilter(r.name, nil, selectedStores)
 		for _, peer := range peers {
 			if _, ok := selectedStores[peer.GetStoreId()]; ok {
-				if allowLeader(oldFit, peer) {
+				if collectLeaderCandidates && allowLeader(oldFit, peer) {
 					leaderCandidateStores = append(leaderCandidateStores, peer.GetStoreId())
 				}
 				// It is both sourcePeer and targetPeer itself, no need to select.
@@ -343,7 +659,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 			}
 			filters[filterLen-1] = filter.NewPlacementSafeguard(r.name, r.cluster.GetSharedConfig(), r.cluster.GetBasicCluster(), r.cluster.GetRuleManager(), region, sourceStore, oldFit)
 			for {
-				newPeer := r.selectNewPeer(context, group, peer, filters)
+				newPeer := r.selectNewPeer(context, group, peer, filters, internalScatter)
 				targetPeers[newPeer.GetStoreId()] = newPeer
 				selectedStores[newPeer.GetStoreId()] = struct{}{}
 				// If the selected peer is a peer other than origin peer in this region,
@@ -351,7 +667,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 				// This origin peer re-selects.
 				if _, ok := peers[newPeer.GetStoreId()]; !ok || peer.GetStoreId() == newPeer.GetStoreId() {
 					selectedStores[peer.GetStoreId()] = struct{}{}
-					if allowLeader(oldFit, peer) {
+					if collectLeaderCandidates && allowLeader(oldFit, peer) {
 						leaderCandidateStores = append(leaderCandidateStores, newPeer.GetStoreId())
 					}
 					break
@@ -360,50 +676,109 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 		}
 	}
 
-	scatterWithSameEngine(ordinaryPeers, r.ordinaryEngine)
+	scatterWithSameEngine(ordinaryPeers, ordinaryContext, true)
+	for engine, peers := range specialPeers {
+		// Special-engine stores are only peer targets for now. Keep them out of
+		// leader candidates so leader selection still only considers ordinary stores.
+		scatterWithSameEngine(peers, getSpecialEngineContext(engine), false)
+	}
+	if internalScatter {
+		leaderCandidateStores = r.filterAllowedLeaderCandidateStores(region, targetPeers, leaderCandidateStores)
+	}
 	// FIXME: target leader only considers the ordinary stores, maybe we need to consider the
 	// special engine stores if the engine supports to become a leader. But now there is only
 	// one engine, tiflash, which does not support the leader, so don't consider it for now.
-	targetLeader, leaderStorePickedCount := r.selectAvailableLeaderStore(group, region, leaderCandidateStores, r.ordinaryEngine)
+	targetLeader, leaderStorePickedCount := r.selectAvailableLeaderStore(group, region, leaderCandidateStores, ordinaryContext, internalScatter)
 	if targetLeader == 0 {
 		scatterSkipNoLeaderCounter.Inc()
 		return nil, errs.ErrGetTargetStore.FastGenByArgs(fmt.Sprintf("no target leader store found, region: %v", region))
 	}
 
-	for engine, peers := range specialPeers {
-		ctx, ok := r.specialEngines.Load(engine)
-		if !ok {
-			ctx = newEngineContext(r.ctx, func() filter.Filter {
-				return filter.NewEngineFilter(r.name, placement.LabelConstraint{Key: core.EngineKey, Op: placement.In, Values: []string{engine}})
-			})
-			r.specialEngines.Store(engine, ctx)
-		}
-		scatterWithSameEngine(peers, ctx.(engineContext))
-	}
-
 	if isSameDistribution(region, targetPeers, targetLeader) {
 		scatterUnnecessaryCounter.Inc()
-		r.Put(targetPeers, targetLeader, group)
+		if state != nil {
+			r.applyScatterStateDelta(state, region, targetPeers, targetLeader, group, !internalScatter)
+		} else {
+			r.Put(targetPeers, targetLeader, group)
+		}
 		return nil, nil
 	}
-	op, err := operator.CreateScatterRegionOperator("scatter-region", r.cluster, region, targetPeers, targetLeader, skipStoreLimit)
+	createScatterOperator := operator.CreateScatterRegionOperator
+	if internalScatter {
+		createScatterOperator = operator.CreateNonAdminScatterRegionOperator
+	}
+	op, err := createScatterOperator(desc, r.cluster, region, targetPeers, targetLeader, skipStoreLimit)
 	if err != nil {
 		scatterFailCounter.Inc()
+		currentPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
 		for _, peer := range region.GetPeers() {
-			targetPeers[peer.GetStoreId()] = peer
+			currentPeers[peer.GetStoreId()] = peer
 		}
-		r.Put(targetPeers, region.GetLeader().GetStoreId(), group)
+		if state != nil {
+			r.applyScatterStateDelta(state, region, currentPeers, region.GetLeader().GetStoreId(), group, !internalScatter)
+		} else {
+			r.Put(currentPeers, region.GetLeader().GetStoreId(), group)
+		}
 		log.Debug("fail to create scatter region operator", errs.ZapError(err))
 		return nil, errs.ErrCreateOperator.FastGenByArgs(fmt.Sprintf("failed to create scatter region operator for region %v", region.GetID()))
 	}
 	if op != nil {
 		scatterSuccessCounter.Inc()
-		r.Put(targetPeers, targetLeader, group)
+		if state == nil {
+			r.Put(targetPeers, targetLeader, group)
+		}
 		op.SetAdditionalInfo("group", group)
-		op.SetAdditionalInfo("leader-picked-count", strconv.FormatUint(leaderStorePickedCount, 10))
-		op.SetPriorityLevel(constant.High)
+		if !internalScatter {
+			op.SetAdditionalInfo("leader-picked-count", strconv.FormatUint(leaderStorePickedCount, 10))
+		}
+		op.SetPriorityLevel(operatorPriorityLevel)
 	}
 	return op, nil
+}
+
+func (r *RegionScatterer) filterAllowedLeaderCandidateStores(
+	region *core.RegionInfo,
+	targetPeers map[uint64]*metapb.Peer,
+	candidateStores []uint64,
+) []uint64 {
+	if len(candidateStores) == 0 {
+		return candidateStores
+	}
+	filtered := candidateStores[:0]
+	leader := region.GetLeader()
+	if leader == nil {
+		return filtered
+	}
+	currentLeaderStoreID := leader.GetStoreId()
+	if !r.isAllowedLeaderSource(currentLeaderStoreID) {
+		for _, storeID := range candidateStores {
+			if storeID == currentLeaderStoreID {
+				return append(filtered, storeID)
+			}
+		}
+		return filtered
+	}
+	for _, storeID := range candidateStores {
+		peer := targetPeers[storeID]
+		if peer == nil {
+			continue
+		}
+		if operator.IsAllowedLeaderTarget(r.cluster, region, peer) {
+			filtered = append(filtered, storeID)
+		}
+	}
+	return filtered
+}
+
+func (r *RegionScatterer) isAllowedLeaderSource(storeID uint64) bool {
+	store := r.cluster.GetStore(storeID)
+	if store == nil {
+		return false
+	}
+	stateFilter := &filter.StoreStateFilter{ActionScope: r.name, TransferLeader: true}
+	return filter.NewCandidates(rand.New(rand.NewSource(time.Now().UnixNano())), []*core.StoreInfo{store}).
+		FilterSource(r.cluster.GetSharedConfig(), nil, nil, stateFilter).
+		Len() > 0
 }
 
 func allowLeader(fit *placement.RegionFit, peer *metapb.Peer) bool {
@@ -435,13 +810,13 @@ func isSameDistribution(region *core.RegionInfo, targetPeers map[uint64]*metapb.
 	return region.GetLeader().GetStoreId() == targetLeader
 }
 
-// selectNewPeer return the new peer which pick the fewest picked count.
+// selectNewPeer returns the new peer which pick the fewest picked count.
 // it keeps the origin peer if the origin store's pick count is equal the fewest pick.
 // it can be divided into three steps:
 // 1. found the max pick count and the min pick count.
 // 2. if max pick count equals min pick count, it means all store picked count are some, return the origin peer.
 // 3. otherwise, select the store which pick count is the min pick count and pass all filter.
-func (r *RegionScatterer) selectNewPeer(context engineContext, group string, peer *metapb.Peer, filters []filter.Filter) *metapb.Peer {
+func (r *RegionScatterer) selectNewPeer(context scatterSelectionContext, group string, peer *metapb.Peer, filters []filter.Filter, internalScatter bool) *metapb.Peer {
 	stores := r.cluster.GetStores()
 	maxStoreTotalCount := uint64(0)
 	minStoreTotalCount := uint64(math.MaxUint64)
@@ -458,6 +833,7 @@ func (r *RegionScatterer) selectNewPeer(context engineContext, group string, pee
 	var newPeer *metapb.Peer
 	minCount := uint64(math.MaxUint64)
 	originStorePickedCount := uint64(math.MaxUint64)
+	bestStoreRegionCount := math.MaxInt
 	for _, store := range stores {
 		storeCount := context.selectedPeer.Get(store.GetID(), group)
 		if store.GetID() == peer.GetStoreId() {
@@ -466,17 +842,29 @@ func (r *RegionScatterer) selectNewPeer(context engineContext, group string, pee
 		// If storeCount is equal to the maxStoreTotalCount, we should skip this store as candidate.
 		// If the storeCount are all the same for the whole cluster(maxStoreTotalCount == minStoreTotalCount), any store
 		// could be selected as candidate.
-		if storeCount < maxStoreTotalCount || maxStoreTotalCount == minStoreTotalCount {
-			if filter.Target(r.cluster.GetSharedConfig(), store, filters) {
-				if storeCount < minCount {
-					minCount = storeCount
-					newPeer = &metapb.Peer{
-						StoreId: store.GetID(),
-						Role:    peer.GetRole(),
-					}
-				}
-			}
+		if storeCount >= maxStoreTotalCount && maxStoreTotalCount != minStoreTotalCount {
+			continue
 		}
+		if !filter.Target(r.cluster.GetSharedConfig(), store, filters) {
+			continue
+		}
+		candidate := &metapb.Peer{
+			StoreId: store.GetID(),
+			Role:    peer.GetRole(),
+		}
+		storeRegionCount := store.GetRegionCount()
+		if storeCount < minCount ||
+			(internalScatter && storeCount == minCount &&
+				(storeRegionCount < bestStoreRegionCount ||
+					(storeRegionCount == bestStoreRegionCount && (newPeer == nil || store.GetID() < newPeer.GetStoreId())))) {
+			minCount = storeCount
+			newPeer = candidate
+			bestStoreRegionCount = storeRegionCount
+		}
+	}
+	if internalScatter && newPeer != nil && peer.GetStoreId() != newPeer.GetStoreId() &&
+		!peerMoveReducesSourceTargetGap(context.selectedPeer, group, peer.GetStoreId(), newPeer.GetStoreId()) {
+		return peer
 	}
 	if originStorePickedCount <= minCount {
 		return peer
@@ -487,33 +875,115 @@ func (r *RegionScatterer) selectNewPeer(context engineContext, group string, pee
 	return newPeer
 }
 
-// selectAvailableLeaderStore select the target leader store from the candidates. The candidates would be collected by
-// the existed peers store depended on the leader counts in the group level. Please use this func before scatter spacial engines.
+// selectAvailableLeaderStore selects the target leader store from candidate
+// peer stores after ordinary and special-engine peer scatter. Special-engine
+// stores are excluded from candidates because they cannot become leaders.
 func (r *RegionScatterer) selectAvailableLeaderStore(group string, region *core.RegionInfo,
-	leaderCandidateStores []uint64, context engineContext) (leaderID uint64, leaderStorePickedCount uint64) {
-	sourceStore := r.cluster.GetStore(region.GetLeader().GetStoreId())
-	if sourceStore == nil {
+	leaderCandidateStores []uint64, context scatterSelectionContext, internalScatter bool) (leaderID uint64, leaderStorePickedCount uint64) {
+	if r.cluster.GetStore(region.GetLeader().GetStoreId()) == nil {
 		log.Error("failed to get the store", zap.Uint64("store-id", region.GetLeader().GetStoreId()), errs.ZapError(errs.ErrGetSourceStore))
 		return 0, 0
 	}
 	minStoreGroupLeader := uint64(math.MaxUint64)
+	minStoreGroupPeer := uint64(math.MaxUint64)
 	id := uint64(0)
+	unusedAlternativeID := uint64(0)
+	unusedAlternativePeerCount := uint64(math.MaxUint64)
+	currentLeaderID := region.GetLeader().GetStoreId()
+	currentLeaderCanStay := false
 	for _, storeID := range leaderCandidateStores {
 		store := r.cluster.GetStore(storeID)
 		if store == nil {
 			continue
 		}
+		if storeID == currentLeaderID {
+			currentLeaderCanStay = true
+		}
 		storeGroupLeaderCount := context.selectedLeader.Get(storeID, group)
-		if minStoreGroupLeader > storeGroupLeaderCount {
+		storeGroupPeerCount := context.selectedPeer.Get(storeID, group)
+		if internalScatter && storeID != currentLeaderID && storeGroupLeaderCount == 0 {
+			if unusedAlternativeID == 0 || storeGroupPeerCount < unusedAlternativePeerCount ||
+				(storeGroupPeerCount == unusedAlternativePeerCount && storeID < unusedAlternativeID) {
+				unusedAlternativeID = storeID
+				unusedAlternativePeerCount = storeGroupPeerCount
+			}
+		}
+		if id == 0 || minStoreGroupLeader > storeGroupLeaderCount ||
+			(internalScatter && minStoreGroupLeader == storeGroupLeaderCount && minStoreGroupPeer > storeGroupPeerCount) {
 			minStoreGroupLeader = storeGroupLeaderCount
+			minStoreGroupPeer = storeGroupPeerCount
 			id = storeID
 		}
 	}
-	return id, minStoreGroupLeader
+	selectedID := id
+	if internalScatter && unusedAlternativeID != 0 {
+		selectedID = unusedAlternativeID
+	}
+	if selectedID == 0 {
+		return 0, 0
+	}
+	if internalScatter && currentLeaderCanStay && selectedID != currentLeaderID &&
+		!leaderMoveReducesSourceTargetGap(context.selectedLeader, group, currentLeaderID, selectedID) {
+		selectedID = currentLeaderID
+	}
+	return selectedID, context.selectedLeader.Get(selectedID, group)
+}
+
+func peerMoveReducesSourceTargetGap(selectedPeers selectedStoreCounter, group string, fromStoreID, toStoreID uint64) bool {
+	fromCount := selectedPeers.Get(fromStoreID, group)
+	toCount := selectedPeers.Get(toStoreID, group)
+	return fromCount > toCount+1
+}
+
+func leaderMoveReducesSourceTargetGap(selectedLeaders selectedStoreCounter, group string, fromStoreID, toStoreID uint64) bool {
+	fromCount := selectedLeaders.Get(fromStoreID, group)
+	toCount := selectedLeaders.Get(toStoreID, group)
+	// A zero source count means this group has no seeded/current leader history
+	// for the origin store, so keep the original scatter fallback behavior.
+	return fromCount == 0 || fromCount > toCount+1
+}
+
+func isSameRegionEpoch(left, right *metapb.RegionEpoch) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.GetVersion() == right.GetVersion() && left.GetConfVer() == right.GetConfVer()
+}
+
+// finalPlacementAfterOperator projects the final target placement of an
+// in-flight operator by walking its steps without considering partial execution
+// progress. This is a forward-looking estimate: the caller uses it to deduct the
+// operator's intended footprint from the next round of store selection, so the
+// estimate is intentionally the end state rather than the current half-done state.
+func finalPlacementAfterOperator(region *core.RegionInfo, op *operator.Operator) (map[uint64]*metapb.Peer, uint64) {
+	targetPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
+	for _, peer := range region.GetPeers() {
+		targetPeers[peer.GetStoreId()] = peer
+	}
+	targetLeader := region.GetLeader().GetStoreId()
+	if op == nil {
+		return targetPeers, targetLeader
+	}
+	for i := range op.Len() {
+		switch step := op.Step(i).(type) {
+		case operator.TransferLeader:
+			targetLeader = step.ToStore
+		case operator.AddPeer:
+			targetPeers[step.ToStore] = &metapb.Peer{StoreId: step.ToStore}
+		case operator.AddLearner:
+			targetPeers[step.ToStore] = &metapb.Peer{StoreId: step.ToStore}
+		case operator.RemovePeer:
+			delete(targetPeers, step.FromStore)
+		}
+	}
+	return targetPeers, targetLeader
 }
 
 // Put put the final distribution in the context no matter the operator was created
 func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint64, group string) {
+	if leaderStoreID == 0 {
+		return
+	}
 	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
 	// Group peers by the engine of their stores
 	for _, peer := range peers {
@@ -528,19 +998,83 @@ func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint6
 				fmt.Sprintf("%v", storeID),
 				fmt.Sprintf("%v", false),
 				core.EngineTiKV).Inc()
-		} else {
-			engine := store.GetLabelValue(core.EngineKey)
-			ctx, _ := r.specialEngines.Load(engine)
-			ctx.(engineContext).selectedPeer.Put(storeID, group)
-			scatterDistributionCounter.WithLabelValues(
-				fmt.Sprintf("%v", storeID),
-				fmt.Sprintf("%v", false),
-				engine).Inc()
+			continue
 		}
+		engine := store.GetLabelValue(core.EngineKey)
+		ctx := r.getOrCreateSpecialEngineContext(engine)
+		ctx.selectedPeer.Put(storeID, group)
+		scatterDistributionCounter.WithLabelValues(
+			strconv.FormatUint(storeID, 10),
+			strconv.FormatBool(false),
+			engine).Inc()
 	}
 	r.ordinaryEngine.selectedLeader.Put(leaderStoreID, group)
 	scatterDistributionCounter.WithLabelValues(
 		fmt.Sprintf("%v", leaderStoreID),
 		fmt.Sprintf("%v", true),
 		core.EngineTiKV).Inc()
+}
+
+// applyScatterStateDelta records a local scatter state change after scattering a
+// region to the target placement. Metrics are only emitted when this delta
+// corresponds to a new scatter decision accepted in the current request/round.
+func (r *RegionScatterer) applyScatterStateDelta(state *scatterState, region *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, group string, recordMetrics bool) {
+	if state == nil || region == nil || region.GetLeader() == nil {
+		return
+	}
+	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
+	ordinaryOldStores := make([]uint64, 0, len(region.GetPeers()))
+	ordinaryNewStores := make([]uint64, 0, len(targetPeers))
+	specialOldStores := make(map[string][]uint64)
+	specialNewStores := make(map[string][]uint64)
+
+	classifyStore := func(storeID uint64, ordinary *[]uint64, special map[string][]uint64) string {
+		store := r.cluster.GetStore(storeID)
+		if store == nil {
+			return ""
+		}
+		if engineFilter.Target(r.cluster.GetSharedConfig(), store).IsOK() {
+			*ordinary = append(*ordinary, storeID)
+			return core.EngineTiKV
+		}
+		engine := store.GetLabelValue(core.EngineKey)
+		special[engine] = append(special[engine], storeID)
+		return engine
+	}
+
+	for _, peer := range region.GetPeers() {
+		classifyStore(peer.GetStoreId(), &ordinaryOldStores, specialOldStores)
+	}
+	for _, peer := range targetPeers {
+		storeID := peer.GetStoreId()
+		engine := classifyStore(storeID, &ordinaryNewStores, specialNewStores)
+		if recordMetrics && engine != "" {
+			scatterDistributionCounter.WithLabelValues(
+				strconv.FormatUint(storeID, 10),
+				strconv.FormatBool(false),
+				engine).Inc()
+		}
+	}
+
+	state.ordinaryEngine.selectedPeer.Update(group, ordinaryOldStores, ordinaryNewStores)
+	specialEngines := make(map[string]struct{}, len(specialOldStores)+len(specialNewStores))
+	for engine := range specialOldStores {
+		specialEngines[engine] = struct{}{}
+	}
+	for engine := range specialNewStores {
+		specialEngines[engine] = struct{}{}
+	}
+	for engine := range specialEngines {
+		ctx := r.getOrCreateSpecialEngineState(state, engine)
+		ctx.selectedPeer.Update(group, specialOldStores[engine], specialNewStores[engine])
+	}
+
+	oldLeaderStoreID := region.GetLeader().GetStoreId()
+	state.ordinaryEngine.selectedLeader.Update(group, []uint64{oldLeaderStoreID}, []uint64{targetLeader})
+	if recordMetrics {
+		scatterDistributionCounter.WithLabelValues(
+			strconv.FormatUint(targetLeader, 10),
+			strconv.FormatBool(true),
+			core.EngineTiKV).Inc()
+	}
 }

--- a/pkg/schedule/scatter/region_scatterer_test.go
+++ b/pkg/schedule/scatter/region_scatterer_test.go
@@ -27,12 +27,17 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
+	"github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
+	"github.com/tikv/pd/pkg/statistics/utils"
+	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/versioninfo"
 )
 
@@ -74,6 +79,8 @@ func TestScatterRegions(t *testing.T) {
 }
 
 func checkOperator(re *require.Assertions, op *operator.Operator) {
+	re.Equal(operator.OpAdmin, op.SchedulerKind())
+	re.Equal(constant.High, op.GetPriorityLevel())
 	for i := range op.Len() {
 		if rp, ok := op.Step(i).(operator.RemovePeer); ok {
 			for j := i + 1; j < op.Len(); j++ {
@@ -84,6 +91,18 @@ func checkOperator(re *require.Assertions, op *operator.Operator) {
 			}
 		}
 	}
+}
+
+func newTestScatterState(scatterer *RegionScatterer) *scatterState {
+	return scatterer.newScatterState()
+}
+
+func (s *localSelectedStores) getGroupDistributionClone(group string) (map[uint64]uint64, bool) {
+	distribution, ok := s.groupDistribution[group]
+	if !ok {
+		return nil, false
+	}
+	return cloneDistribution(distribution), true
 }
 
 func scatter(re *require.Assertions, numStores, numRegions uint64, useRules bool) {
@@ -363,7 +382,9 @@ func TestSomeStoresFilteredScatterGroupInConcurrency(t *testing.T) {
 func scatterOnce(tc *mockcluster.Cluster, scatter *RegionScatterer, group string, wg *sync.WaitGroup) {
 	regionID := 1
 	for range 100 {
-		scatter.scatterRegion(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3), group, false)
+		if _, err := scatter.Scatter(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3), group, false); err != nil {
+			panic(err)
+		}
 		regionID++
 	}
 	wg.Done()
@@ -409,8 +430,9 @@ func TestScatterGroupInConcurrency(t *testing.T) {
 		regionID := 1
 		for range 100 {
 			for j := range testCase.groupCount {
-				scatterer.scatterRegion(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3),
+				_, err := scatterer.Scatter(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3),
 					fmt.Sprintf("group-%v", j), false)
+				re.NoError(err)
 				regionID++
 			}
 		}
@@ -471,16 +493,6 @@ func TestScatterForManyRegion(t *testing.T) {
 
 func TestScattersGroup(t *testing.T) {
 	re := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	opt := mockconfig.NewTestOptions()
-	tc := mockcluster.NewCluster(ctx, opt)
-	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
-	// Add 5 stores.
-	for i := uint64(1); i <= 5; i++ {
-		tc.AddRegionStore(i, 0)
-	}
 	testCases := []struct {
 		name    string
 		failure bool
@@ -495,52 +507,76 @@ func TestScattersGroup(t *testing.T) {
 		},
 	}
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/scatter/scatterHbStreamsDrain", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterHbStreamsDrain"))
+	}()
 	for id, testCase := range testCases {
-		group := fmt.Sprintf("gourp-%d", id)
-		t.Log(testCase.name)
-		scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
-		regions := map[uint64]*core.RegionInfo{}
-		for i := 1; i <= 100; i++ {
-			regions[uint64(i)] = tc.AddLightWeightLeaderRegion(uint64(i), 1, 2, 3)
-		}
-		failures := map[uint64]error{}
-		if testCase.failure {
-			re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail", `return(true)`))
-		}
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			opt := mockconfig.NewTestOptions()
+			tc := mockcluster.NewCluster(ctx, opt)
+			stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+			defer stream.Close()
+			oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+			for i := uint64(1); i <= 5; i++ {
+				tc.AddRegionStore(i, 0)
+			}
+			group := fmt.Sprintf("group-%d", id)
+			t.Log(testCase.name)
+			scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+			regions := map[uint64]*core.RegionInfo{}
+			for i := 1; i <= 100; i++ {
+				regions[uint64(i)] = tc.AddLightWeightLeaderRegion(uint64(i), 1, 2, 3)
+			}
+			failures := map[uint64]error{}
+			if testCase.failure {
+				re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail", `return(true)`))
+				defer func() {
+					re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail"))
+				}()
+			}
 
-		scatterer.scatterRegions(regions, failures, group, 3, false)
-		max := uint64(0)
-		min := uint64(math.MaxUint64)
-		groupDistribution, exist := scatterer.ordinaryEngine.selectedLeader.GetGroupDistribution(group)
-		re.True(exist)
-		for _, count := range groupDistribution {
-			if count > max {
-				max = count
+			_, err := scatterer.scatterRegions(regions, failures, group, 3, false)
+			re.NoError(err)
+			max := uint64(0)
+			min := uint64(math.MaxUint64)
+			groupDistribution, exist := scatterer.ordinaryEngine.selectedLeader.GetGroupDistribution(group)
+			re.True(exist)
+			for _, count := range groupDistribution {
+				if count > max {
+					max = count
+				}
+				if count < min {
+					min = count
+				}
 			}
-			if count < min {
-				min = count
+			// 100 regions divided 5 stores, each store expected to have about 20 regions.
+			re.LessOrEqual(min, uint64(20))
+			re.GreaterOrEqual(max, uint64(20))
+			re.LessOrEqual(max-min, uint64(3))
+			if testCase.failure {
+				re.Len(failures, 1)
+				_, ok := failures[1]
+				re.True(ok)
+			} else {
+				re.Empty(failures)
 			}
-		}
-		// 100 regions divided 5 stores, each store expected to have about 20 regions.
-		re.LessOrEqual(min, uint64(20))
-		re.GreaterOrEqual(max, uint64(20))
-		re.LessOrEqual(max-min, uint64(3))
-		if testCase.failure {
-			re.Len(failures, 1)
-			_, ok := failures[1]
-			re.True(ok)
-			re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail"))
-		} else {
-			re.Empty(failures)
-		}
+		}()
 	}
-	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterHbStreamsDrain"))
 }
 
 func TestSelectedStoreGC(t *testing.T) {
 	re := require.New(t)
+	originalGCInterval := gcInterval
+	originalGCTTL := gcTTL
 	gcInterval = time.Second
 	gcTTL = time.Second * 3
+	defer func() {
+		gcInterval = originalGCInterval
+		gcTTL = originalGCTTL
+	}()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stores := newSelectedStores(ctx)
@@ -675,11 +711,237 @@ func TestSelectedStoresTooFewPeers(t *testing.T) {
 	// Try to scatter a region with peer store id 2/3/4
 	for i := uint64(1); i < 20; i++ {
 		region := tc.AddLeaderRegion(i+200, i%3+2, (i+1)%3+2, (i+2)%3+2)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 		if op != nil {
 			re.Equal(group, op.GetAdditionalInfo("group"))
+		}
+	}
+}
+
+func TestSeedGroupDistributionByRange(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(2, "j", "t", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(3, "t", "z", 1, 2, 3)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+
+	group := "seeded"
+	state := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+
+	peerDistribution, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(uint64(3), peerDistribution[1])
+	re.Equal(uint64(3), peerDistribution[2])
+	re.Equal(uint64(3), peerDistribution[3])
+	re.Equal(uint64(0), peerDistribution[4])
+
+	leaderDistribution, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(uint64(3), leaderDistribution[1])
+	re.Equal(uint64(0), leaderDistribution[2])
+	re.Equal(uint64(0), leaderDistribution[3])
+	re.Equal(uint64(0), leaderDistribution[4])
+
+	op, err := scatterer.ScatterInternal(tc.GetRegion(3), group, []byte("a"), []byte("z"))
+	re.NoError(err)
+	re.NotNil(op)
+	re.Equal(operator.OpSplitScatter, op.SchedulerKind())
+	re.Zero(op.Kind() & operator.OpAdmin)
+	re.Equal(constant.High, op.GetPriorityLevel())
+	re.NotZero(op.Kind() & operator.OpSplitScatter)
+	re.NotZero(op.Kind() & operator.OpRegion)
+	re.Equal(group, op.GetAdditionalInfo("group"))
+}
+
+func TestSeedGroupDistributionByRangeAppliesNetChange(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(2, "j", "t", 2, 1, 3)
+	tc.AddLeaderRegionWithRange(3, "t", "z", 3, 1, 2)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	group := "seeded-net-change"
+	state := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+
+	region := tc.GetRegion(1)
+	peerBefore, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	leaderBefore, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	peerSnapshot := cloneDistribution(peerBefore)
+	leaderSnapshot := cloneDistribution(leaderBefore)
+
+	op, err := scatterer.ScatterInternal(region, group, []byte("a"), []byte("z"))
+	re.NoError(err)
+	re.NotNil(op)
+	re.Equal(operator.OpSplitScatter, op.SchedulerKind())
+	re.Zero(op.Kind() & operator.OpAdmin)
+	re.Equal(constant.High, op.GetPriorityLevel())
+	re.NotZero(op.Kind() & operator.OpSplitScatter)
+	re.NotZero(op.Kind() & operator.OpRegion)
+	finalPeers, finalLeaderStoreID := finalPlacementAfterOperator(region, op)
+
+	expectedPeerDistribution := cloneDistribution(peerSnapshot)
+	for _, peer := range region.GetPeers() {
+		expectedPeerDistribution[peer.GetStoreId()]--
+	}
+	for storeID := range finalPeers {
+		expectedPeerDistribution[storeID]++
+	}
+
+	expectedLeaderDistribution := cloneDistribution(leaderSnapshot)
+	expectedLeaderDistribution[region.GetLeader().GetStoreId()]--
+	expectedLeaderDistribution[finalLeaderStoreID]++
+	removeZeroCountEntries(expectedPeerDistribution)
+	removeZeroCountEntries(expectedLeaderDistribution)
+
+	re.True(oc.AddOperator(op))
+	nextState := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+	peerDistribution, ok := nextState.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedPeerDistribution, peerDistribution)
+
+	leaderDistribution, ok := nextState.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedLeaderDistribution, leaderDistribution)
+}
+
+func TestSeededDistributionSkipsUpdateWhenAddOperatorRejected(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(2, "j", "t", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(3, "t", "z", 1, 2, 3)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	group := "seeded-rollback"
+	state := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+
+	peerBefore, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	leaderBefore, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	peerSnapshot := cloneDistribution(peerBefore)
+	leaderSnapshot := cloneDistribution(leaderBefore)
+
+	scheduleCfg := tc.GetScheduleConfig().Clone()
+	scheduleCfg.SchedulerMaxWaitingOperator = 0
+	tc.SetScheduleConfig(scheduleCfg)
+
+	region := tc.GetRegion(1)
+	op, err := scatterer.ScatterInternal(region, group, []byte("a"), []byte("z"))
+	re.NoError(err)
+	re.NotNil(op)
+	re.False(oc.AddOperator(op))
+
+	nextState := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+	peerAfter, ok := nextState.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	for i := uint64(1); i <= 4; i++ {
+		re.Equal(peerSnapshot[i], peerAfter[i])
+	}
+
+	leaderAfter, ok := nextState.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	for i := uint64(1); i <= 4; i++ {
+		re.Equal(leaderSnapshot[i], leaderAfter[i])
+	}
+}
+
+func TestCreateScatterRegionOperatorFailureAccountsCurrentPlacement(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	region := tc.GetRegion(1)
+	region = region.Clone(core.WithRole(region.GetPeers()[1].GetId(), metapb.PeerRole_IncomingVoter))
+	tc.PutRegion(region)
+	region = tc.GetRegion(1)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	group := "create-fail"
+	state := newTestScatterState(scatterer)
+	for _, storeID := range []uint64{1, 2, 3} {
+		state.ordinaryEngine.selectedPeer.Update(group, nil, []uint64{storeID})
+	}
+	state.ordinaryEngine.selectedLeader.Update(group, nil, []uint64{1})
+
+	peerBefore, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	leaderBefore, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	peerSnapshot := cloneDistribution(peerBefore)
+	leaderSnapshot := cloneDistribution(leaderBefore)
+
+	op, err := scatterer.scatterWithOptions(region, group, true, false, state)
+	re.Nil(op)
+	re.Error(err)
+	re.Contains(err.Error(), "failed to create scatter region operator")
+
+	expectedPeerDistribution := cloneDistribution(peerSnapshot)
+	for _, peer := range region.GetPeers() {
+		expectedPeerDistribution[peer.GetStoreId()]++
+	}
+	expectedLeaderDistribution := cloneDistribution(leaderSnapshot)
+	expectedLeaderDistribution[region.GetLeader().GetStoreId()]++
+
+	peerAfter, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedPeerDistribution, peerAfter)
+
+	leaderAfter, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedLeaderDistribution, leaderAfter)
+}
+
+func removeZeroCountEntries(distribution map[uint64]uint64) {
+	for storeID, count := range distribution {
+		if count == 0 {
+			delete(distribution, storeID)
 		}
 	}
 }
@@ -716,7 +978,7 @@ func TestSelectedStoresTooManyPeers(t *testing.T) {
 	// test region with peer 1 2 3
 	for i := uint64(1); i < 20; i++ {
 		region := tc.AddLeaderRegion(i+200, i%3+1, (i+1)%3+1, (i+2)%3+1)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 	}
@@ -741,7 +1003,7 @@ func TestBalanceLeader(t *testing.T) {
 	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
 	for i := uint64(1001); i <= 1300; i++ {
 		region := tc.AddLeaderRegion(i, 2, 3, 4)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 	}
@@ -772,7 +1034,7 @@ func TestBalanceRegion(t *testing.T) {
 	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
 	for i := uint64(1001); i <= 1300; i++ {
 		region := tc.AddLeaderRegion(i, 2, 4, 6)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 	}
@@ -782,9 +1044,9 @@ func TestBalanceRegion(t *testing.T) {
 	// Test for unhealthy region
 	// ref https://github.com/tikv/pd/issues/6099
 	region := tc.AddLeaderRegion(1500, 2, 3, 4, 6)
-	op, err := scatterer.scatterRegion(region, group, false)
-	re.NoError(err)
-	re.False(isPeerCountChanged(op))
+	op, err := scatterer.Scatter(region, group, false)
+	re.ErrorContains(err, "is not fully replicated")
+	re.Nil(op)
 }
 
 func isPeerCountChanged(op *operator.Operator) bool {
@@ -836,4 +1098,325 @@ func TestRemoveStoreLimit(t *testing.T) {
 			re.True(oc.AddOperator(op))
 		}
 	}
+}
+
+func TestScatterReplace(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+
+	// Add stores 1~5.
+	for i := uint64(1); i <= 5; i++ {
+		tc.AddRegionStore(i, 0)
+	}
+	// Add regions 1~5.
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	for i := uint64(2); i <= 5; i++ {
+		tc.AddLeaderRegion(i, 1, 2, 3)
+	}
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+
+	for i := uint64(1); i <= 5; i++ {
+		region := tc.GetRegion(i)
+		if op, err := scatterer.Scatter(region, "", true); op != nil {
+			re.NoError(err)
+			re.True(oc.AddOperator(op))
+		}
+	}
+
+	// same scatter operator should be skipped
+	region := tc.GetRegion(2)
+	op, err := scatterer.Scatter(region, "", true)
+	re.NoError(err)
+	re.Nil(op)
+
+	// A same-group operator from an older epoch must not consume a newer
+	// split-scatter attempt for the same region.
+	tc.PutRegion(tc.MockRegionInfo(2, 1, []uint64{2, 3}, nil, &metapb.RegionEpoch{ConfVer: 1, Version: 2}))
+	op, err = scatterer.Scatter(tc.GetRegion(2), "", true)
+	re.Error(err)
+	re.Nil(op)
+
+	// different scatter operator should be rejected
+	region = tc.GetRegion(3)
+	op, err = scatterer.Scatter(region, "test", true)
+	re.Error(err)
+	re.Nil(op)
+
+	// exist lower operator
+	op = oc.GetOperator(1)
+	if op != nil {
+		re.True(oc.RemoveOperator(op))
+	}
+	region = tc.GetRegion(1)
+	op = operator.NewTestOperator(region.GetID(), region.GetRegionEpoch(), operator.OpRegion)
+	op.SetPriorityLevel(constant.Low)
+	re.True(oc.AddOperator(op))
+
+	testutil.Eventually(re, func() bool {
+		op, err = scatterer.Scatter(tc.GetRegion(1), "", true)
+		re.NoError(err)
+		return op != nil
+	})
+}
+
+func TestScatterInternalSkipsHotOnlyForAdmin(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	tc.SetHotRegionCacheHitsThreshold(0)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+
+	for i := uint64(1); i <= 5; i++ {
+		tc.AddRegionStore(i, 0)
+	}
+
+	tc.AddRegionWithReadInfo(
+		1,
+		1,
+		512*1024*utils.StoreHeartBeatReportInterval,
+		0,
+		0,
+		utils.StoreHeartBeatReportInterval,
+		[]uint64{2, 3},
+	)
+	region := tc.GetRegion(1)
+	re.True(tc.IsRegionHot(region))
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+
+	op, err := scatterer.Scatter(region, "", true)
+	re.ErrorContains(err, "is hot")
+	re.Nil(op)
+
+	op, err = scatterer.ScatterInternal(region, "", region.GetStartKey(), region.GetEndKey())
+	re.NoError(err)
+	if op != nil {
+		re.Equal(InternalScatterOperatorDesc, op.Desc())
+	}
+}
+
+func TestInternalScatterPeerSelection(t *testing.T) {
+	testCases := []struct {
+		name              string
+		storeRegionCounts map[uint64]int
+		peerDistribution  map[uint64]uint64
+		excludedStores    []uint64
+		checkAdmin        bool
+		wantAdmin         uint64
+		want              uint64
+		wantAny           []uint64
+	}{
+		{
+			name:             "keeps origin when peer counts are even",
+			peerDistribution: map[uint64]uint64{},
+			excludedStores:   []uint64{2, 3},
+			checkAdmin:       true,
+			wantAdmin:        1,
+			want:             1,
+		},
+		{
+			name:              "prefers less loaded lowest count store",
+			storeRegionCounts: map[uint64]int{4: 100, 5: 10},
+			peerDistribution:  map[uint64]uint64{1: 3, 2: 3, 3: 3, 4: 1, 5: 1},
+			excludedStores:    []uint64{2, 3},
+			want:              5,
+		},
+		{
+			name:             "keeps origin when source target gap is one",
+			peerDistribution: map[uint64]uint64{1: 2, 2: 2, 3: 2, 4: 1, 5: 1},
+			want:             1,
+		},
+		{
+			name:             "moves when source target gap exceeds one",
+			peerDistribution: map[uint64]uint64{1: 6, 2: 4, 3: 4, 4: 1, 5: 1},
+			wantAny:          []uint64{4, 5},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			scatterer, state, _, peer := newInternalScatterSelectionTestFixture(t, testCase.storeRegionCounts)
+			group := "test-peer-selection"
+			re.True(state.ordinaryEngine.selectedPeer.InitGroupDistribution(group, testCase.peerDistribution))
+			filters := newTestExcludedStoreFilter(testCase.excludedStores...)
+
+			if testCase.checkAdmin {
+				adminPeer := scatterer.selectNewPeer(scatterer.ordinaryEngine.asSelectionContext(), group, peer, filters, false)
+				re.Equal(testCase.wantAdmin, adminPeer.GetStoreId())
+			}
+
+			internalPeer := scatterer.selectNewPeer(state.ordinaryEngine.asSelectionContext(), group, peer, filters, true)
+			if len(testCase.wantAny) > 0 {
+				re.Contains(testCase.wantAny, internalPeer.GetStoreId())
+			} else {
+				re.Equal(testCase.want, internalPeer.GetStoreId())
+			}
+		})
+	}
+}
+
+func TestInternalScatterLeaderSelection(t *testing.T) {
+	testCases := []struct {
+		name               string
+		leaderDistribution map[uint64]uint64
+		peerDistribution   map[uint64]uint64
+		checkAdmin         bool
+		wantAdmin          uint64
+		want               uint64
+	}{
+		{
+			name:               "prefers unused store",
+			leaderDistribution: map[uint64]uint64{1: 2, 4: 0, 5: 0},
+			checkAdmin:         true,
+			wantAdmin:          1,
+			want:               4,
+		},
+		{
+			name:               "keeps origin when source target gap is one",
+			leaderDistribution: map[uint64]uint64{1: 1, 4: 0, 5: 0},
+			want:               1,
+		},
+		{
+			name:               "breaks ties by peer deficit",
+			leaderDistribution: map[uint64]uint64{1: 3, 4: 1, 5: 1},
+			peerDistribution:   map[uint64]uint64{1: 10, 4: 9, 5: 2},
+			checkAdmin:         true,
+			wantAdmin:          1,
+			want:               5,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			scatterer, state, region, _ := newInternalScatterSelectionTestFixture(t, nil)
+			group := "test-leader-selection"
+			candidates := []uint64{1, 4, 5}
+			re.True(state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, testCase.leaderDistribution))
+			if testCase.peerDistribution != nil {
+				re.True(state.ordinaryEngine.selectedPeer.InitGroupDistribution(group, testCase.peerDistribution))
+			}
+
+			if testCase.checkAdmin {
+				adminLeader, adminCount := scatterer.selectAvailableLeaderStore(group, region, candidates, scatterer.ordinaryEngine.asSelectionContext(), false)
+				re.Equal(testCase.wantAdmin, adminLeader)
+				re.Equal(scatterer.ordinaryEngine.selectedLeader.Get(adminLeader, group), adminCount)
+			}
+
+			internalLeader, internalCount := scatterer.selectAvailableLeaderStore(group, region, candidates, state.ordinaryEngine.asSelectionContext(), true)
+			re.Equal(testCase.want, internalLeader)
+			re.Equal(state.ordinaryEngine.selectedLeader.Get(internalLeader, group), internalCount)
+		})
+	}
+}
+
+func TestInternalScatterLeaderFiltersRejectedTarget(t *testing.T) {
+	re := require.New(t)
+	scatterer, state, region, _ := newInternalScatterSelectionTestFixture(t, nil)
+	tc := scatterer.cluster.(*mockcluster.Cluster)
+	tc.SetLabelProperty(config.RejectLeader, "reject", "leader")
+	tc.PutStoreWithLabels(4, "reject", "leader")
+
+	group := "test-leader-target-filter"
+	re.True(state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, map[uint64]uint64{1: 3, 4: 0, 5: 1}))
+	targetPeers := map[uint64]*metapb.Peer{
+		1: region.GetStorePeer(1),
+		4: {StoreId: 4, Role: metapb.PeerRole_Voter},
+		5: {StoreId: 5, Role: metapb.PeerRole_Voter},
+	}
+	candidates := scatterer.filterAllowedLeaderCandidateStores(
+		region,
+		targetPeers,
+		[]uint64{1, 4, 5},
+	)
+	re.NotContains(candidates, uint64(4))
+
+	leader, _ := scatterer.selectAvailableLeaderStore(group, region, candidates, state.ordinaryEngine.asSelectionContext(), true)
+	re.Equal(uint64(5), leader)
+}
+
+func TestInternalScatterLeaderKeepsOriginWhenSourcePausedOut(t *testing.T) {
+	re := require.New(t)
+	scatterer, state, region, _ := newInternalScatterSelectionTestFixture(t, nil)
+	tc := scatterer.cluster.(*mockcluster.Cluster)
+	re.NoError(tc.PauseLeaderTransfer(1))
+
+	group := "test-leader-source-filter"
+	re.True(state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, map[uint64]uint64{1: 3, 4: 0, 5: 1}))
+	targetPeers := map[uint64]*metapb.Peer{
+		1: region.GetStorePeer(1),
+		4: {StoreId: 4, Role: metapb.PeerRole_Voter},
+		5: {StoreId: 5, Role: metapb.PeerRole_Voter},
+	}
+	candidates := scatterer.filterAllowedLeaderCandidateStores(region, targetPeers, []uint64{1, 4, 5})
+	re.Equal([]uint64{1}, candidates)
+
+	leader, _ := scatterer.selectAvailableLeaderStore(group, region, candidates, state.ordinaryEngine.asSelectionContext(), true)
+	re.Equal(uint64(1), leader)
+}
+
+func TestInternalScatterKeepsLeaderPeerWhenSourcePausedOut(t *testing.T) {
+	re := require.New(t)
+	scatterer, _, region, _ := newInternalScatterSelectionTestFixture(t, map[uint64]int{
+		1: 10,
+		2: 10,
+		3: 10,
+		4: 1,
+		5: 1,
+	})
+	tc := scatterer.cluster.(*mockcluster.Cluster)
+	re.NoError(tc.PauseLeaderTransfer(1))
+
+	op, err := scatterer.ScatterInternal(region, "paused-out", []byte(""), []byte(""))
+	re.NoError(err)
+	if op == nil {
+		return
+	}
+	targetPeers, targetLeader := finalPlacementAfterOperator(region, op)
+	re.Contains(targetPeers, uint64(1))
+	re.Equal(uint64(1), targetLeader)
+}
+
+func newInternalScatterSelectionTestFixture(t *testing.T, storeRegionCounts map[uint64]int) (*RegionScatterer, *scatterState, *core.RegionInfo, *metapb.Peer) {
+	t.Helper()
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	t.Cleanup(stream.Close)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 5; i++ {
+		tc.AddRegionStore(i, storeRegionCounts[i])
+	}
+	region := tc.AddLeaderRegion(1, 1, 2, 3)
+	peer := region.GetStorePeer(1)
+	re.NotNil(peer)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	return scatterer, newTestScatterState(scatterer), region, peer
+}
+
+func newTestExcludedStoreFilter(stores ...uint64) []filter.Filter {
+	if len(stores) == 0 {
+		return nil
+	}
+	excluded := make(map[uint64]struct{}, len(stores))
+	for _, storeID := range stores {
+		excluded[storeID] = struct{}{}
+	}
+	return []filter.Filter{filter.NewExcludedFilter("test", nil, excluded)}
 }

--- a/pkg/schedule/types/type.go
+++ b/pkg/schedule/types/type.go
@@ -35,6 +35,8 @@ const (
 	RuleChecker CheckerSchedulerType = "rule-checker"
 	// SplitChecker is the name for split checker.
 	SplitChecker CheckerSchedulerType = "split-checker"
+	// SplitScatterChecker is the name for internal split-scatter dispatch.
+	SplitScatterChecker CheckerSchedulerType = "split-scatter-checker"
 
 	// BalanceLeaderScheduler is balance leader scheduler name.
 	BalanceLeaderScheduler CheckerSchedulerType = "balance-leader-scheduler"

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -212,6 +212,7 @@ func (s *storeStatistics) collect() {
 	configs["region-schedule-limit"] = float64(s.opt.GetRegionScheduleLimit())
 	configs["merge-schedule-limit"] = float64(s.opt.GetMergeScheduleLimit())
 	configs["replica-schedule-limit"] = float64(s.opt.GetReplicaScheduleLimit())
+	configs["split-scatter-schedule-limit"] = float64(s.opt.GetSplitScatterScheduleLimit())
 	configs["max-replicas"] = float64(s.opt.GetMaxReplicas())
 	configs["high-space-ratio"] = s.opt.GetHighSpaceRatio()
 	configs["low-space-ratio"] = s.opt.GetLowSpaceRatio()

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -134,6 +134,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 		return nil, errors.New("region split is paused by replication mode")
 	}
 	splitIDs := make([]*pdpb.SplitID, 0, splitCount)
+	newRegionIDs := make([]uint64, 0, splitCount)
 	recordRegions := make([]uint64, 0, splitCount+1)
 
 	for i := 0; i < int(splitCount); i++ {
@@ -149,6 +150,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 			}
 		}
 
+		newRegionIDs = append(newRegionIDs, newRegionID)
 		recordRegions = append(recordRegions, newRegionID)
 		splitIDs = append(splitIDs, &pdpb.SplitID{
 			NewRegionId: newRegionID,
@@ -168,6 +170,13 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	// status may be left, and these regions need to be checked with higher
 	// priority.
 	c.AddPendingProcessedRegions(false, recordRegions...)
+	if request.GetReason() == pdpb.SplitReason_LOAD {
+		c.GetCoordinator().GetCheckerController().RecordSplitScatterBatch(
+			reqRegion.GetId(),
+			reqRegion.GetRegionEpoch().GetVersion()+1,
+			newRegionIDs,
+		)
+	}
 
 	resp := &pdpb.AskBatchSplitResponse{Ids: splitIDs}
 

--- a/server/cluster/split_scatter_test.go
+++ b/server/cluster/split_scatter_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockid"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+const (
+	// CPU usage is only populated to mimic load-split region heartbeat data.
+	// Current split-scatter dispatch does not rank pending regions by CPU.
+	splitScatterNoCPUUsage       uint64 = 0
+	splitScatterReportedCPUUsage uint64 = 1
+)
+
+func TestHandleAskBatchSplitSchedulesSplitScatterInPatrol(t *testing.T) {
+	re := require.New(t)
+	cluster, cancelPatrol := newSplitScatterTestCluster(t)
+
+	request := &pdpb.AskBatchSplitRequest{
+		Region:     cluster.GetRegion(100).GetMeta(),
+		SplitCount: 2,
+		Reason:     pdpb.SplitReason_LOAD,
+	}
+	resp, err := cluster.HandleAskBatchSplit(request)
+	re.NoError(err)
+	re.Len(resp.GetIds(), 2)
+
+	splitRegionIDs := []uint64{
+		resp.GetIds()[0].GetNewRegionId(),
+		resp.GetIds()[1].GetNewRegionId(),
+	}
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(100, []byte(""), []byte("m"), splitScatterNoCPUUsage).Clone(core.WithIncVersion())))
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(splitRegionIDs[0], []byte("m"), []byte("t"), splitScatterReportedCPUUsage)))
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(splitRegionIDs[1], []byte("t"), []byte(""), splitScatterReportedCPUUsage)))
+
+	dispatchSplitScatterInPatrol(t, cluster, cancelPatrol, func() bool {
+		return cluster.GetOperatorController().GetOperator(splitRegionIDs[0]) != nil &&
+			cluster.GetOperatorController().GetOperator(splitRegionIDs[1]) != nil
+	})
+
+	group := ""
+	for _, regionID := range splitRegionIDs {
+		op := cluster.GetOperatorController().GetOperator(regionID)
+		re.NotNil(op)
+		re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+		opGroup := op.GetAdditionalInfo("group")
+		if group == "" {
+			group = opGroup
+			re.True(strings.HasPrefix(group, "split-scatter-100-"))
+			continue
+		}
+		re.Equal(group, opGroup)
+	}
+	re.NotEmpty(group)
+}
+
+func TestHandleAskBatchSplitSeedsIndexBaselineForFirstSplitRegion(t *testing.T) {
+	re := require.New(t)
+	cluster, cancelPatrol := newSplitScatterTestCluster(t)
+
+	re.NoError(cluster.putRegion(newSplitScatterRegion(90, newSplitScatterIndexKey("a"), newSplitScatterIndexKey("j"), splitScatterNoCPUUsage)))
+	re.NoError(cluster.putRegion(newSplitScatterRegion(91, newSplitScatterIndexKey("j"), newSplitScatterIndexKey("t"), splitScatterNoCPUUsage)))
+	re.NoError(cluster.putRegion(newSplitScatterRegion(100, newSplitScatterIndexKey("t"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage)))
+
+	request := &pdpb.AskBatchSplitRequest{
+		Region:     cluster.GetRegion(100).GetMeta(),
+		SplitCount: 1,
+		Reason:     pdpb.SplitReason_LOAD,
+	}
+	resp, err := cluster.HandleAskBatchSplit(request)
+	re.NoError(err)
+	re.Len(resp.GetIds(), 1)
+
+	splitRegionID := resp.GetIds()[0].GetNewRegionId()
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(100, newSplitScatterIndexKey("w"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage).Clone(core.WithIncVersion())))
+	re.NoError(cluster.processRegionHeartbeat(
+		core.ContextTODO(),
+		newSplitScatterRegion(splitRegionID, newSplitScatterIndexKey("t"), newSplitScatterIndexKey("w"), splitScatterReportedCPUUsage),
+	))
+
+	dispatchSplitScatterInPatrol(t, cluster, cancelPatrol, func() bool {
+		return cluster.GetOperatorController().GetOperator(splitRegionID) != nil
+	})
+
+	op := cluster.GetOperatorController().GetOperator(splitRegionID)
+	re.NotNil(op)
+	re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+	re.Equal("split-scatter-index-42-7", op.GetAdditionalInfo("group"))
+	re.Equal(fmt.Sprintf("split-scatter-100-%d", splitRegionID), op.GetAdditionalInfo("batch-group"))
+}
+
+func TestHandleAskBatchSplitSkipsSplitScatterForSizeReason(t *testing.T) {
+	re := require.New(t)
+	cluster, cancelPatrol := newSplitScatterTestCluster(t)
+
+	request := &pdpb.AskBatchSplitRequest{
+		Region:     cluster.GetRegion(100).GetMeta(),
+		SplitCount: 1,
+		Reason:     pdpb.SplitReason_SIZE,
+	}
+	resp, err := cluster.HandleAskBatchSplit(request)
+	re.NoError(err)
+	re.Len(resp.GetIds(), 1)
+
+	splitRegionID := resp.GetIds()[0].GetNewRegionId()
+	re.NoError(cluster.processRegionHeartbeat(
+		core.ContextTODO(),
+		newSplitScatterRegion(splitRegionID, []byte("m"), []byte(""), splitScatterReportedCPUUsage),
+	))
+
+	dispatchSplitScatterInPatrol(t, cluster, cancelPatrol, func() bool {
+		// PatrolRegions uses a ticker; wait for at least one tick interval
+		// so the dispatch phase is guaranteed to have executed.
+		time.Sleep(100 * time.Millisecond)
+		return true
+	})
+
+	re.Nil(cluster.GetOperatorController().GetOperator(splitRegionID))
+	re.Nil(cluster.GetOperatorController().GetOperator(100))
+}
+
+func newSplitScatterTestCluster(t *testing.T) (*RaftCluster, context.CancelFunc) {
+	t.Helper()
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.regionLabeler, err = labeler.NewRegionLabeler(ctx, cluster.storage, time.Second*5)
+	re.NoError(err)
+	hbStreams := hbstream.NewTestHeartbeatStreams(ctx, cluster.BasicCluster, false)
+	cluster.initCoordinator(ctx, cluster, hbStreams)
+	t.Cleanup(func() {
+		hbStreams.Close()
+	})
+
+	now := time.Now()
+	for _, store := range newTestStores(4, "6.0.0") {
+		re.NoError(cluster.setStore(store.Clone(core.SetLastHeartbeatTS(now))))
+	}
+
+	re.NoError(cluster.putRegion(newSplitScatterRegion(100, []byte(""), []byte("m"), splitScatterNoCPUUsage)))
+	return cluster, cancel
+}
+
+func dispatchSplitScatterInPatrol(t *testing.T, cluster *RaftCluster, cancelPatrol context.CancelFunc, wait func() bool) {
+	t.Helper()
+	checkerController := cluster.GetCoordinator().GetCheckerController()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		checkerController.PatrolRegions()
+	}()
+	testutil.Eventually(require.New(t), wait)
+	cancelPatrol()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("patrol regions did not exit after cancel")
+	}
+}
+
+func newSplitScatterRegion(regionID uint64, start, end []byte, cpuUsage uint64) *core.RegionInfo {
+	return newSplitScatterRegionWithStores(regionID, start, end, cpuUsage, 1, 2, 3)
+}
+
+func newSplitScatterRegionWithStores(regionID uint64, start, end []byte, cpuUsage uint64, stores ...uint64) *core.RegionInfo {
+	peers := []*metapb.Peer{}
+	for i, storeID := range stores {
+		peers = append(peers, &metapb.Peer{
+			Id:      regionID*10 + uint64(i) + 1,
+			StoreId: storeID,
+		})
+	}
+	region := &metapb.Region{
+		Id:       regionID,
+		StartKey: start,
+		EndKey:   end,
+		Peers:    peers,
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	}
+	return core.NewRegionInfo(
+		region,
+		peers[0],
+		core.SetCPUUsage(cpuUsage),
+	)
+}
+
+func newSplitScatterIndexKey(suffix string) []byte {
+	key := codec.GenerateIndexKey(42, 7)
+	key = append(key, suffix...)
+	return codec.EncodeBytes(key)
+}

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -193,6 +193,18 @@ func (o *PersistOptions) IsPlacementRulesEnabled() bool {
 	return o.GetReplicationConfig().EnablePlacementRules
 }
 
+// GetSplitScatterScheduleLimit returns the limit for split-scatter schedule.
+func (o *PersistOptions) GetSplitScatterScheduleLimit() uint64 {
+	return o.getTTLNumberOr(sc.SplitScatterScheduleLimitKey, o.GetScheduleConfig().SplitScatterScheduleLimit)
+}
+
+// SetSplitScatterScheduleLimit sets the limit for split-scatter schedule.
+func (o *PersistOptions) SetSplitScatterScheduleLimit(limit uint64) {
+	v := o.GetScheduleConfig().Clone()
+	v.SplitScatterScheduleLimit = limit
+	o.SetScheduleConfig(v)
+}
+
 // SetPlacementRuleEnabled set PlacementRuleEnabled
 func (o *PersistOptions) SetPlacementRuleEnabled(enabled bool) {
 	v := o.GetReplicationConfig().Clone()
@@ -239,6 +251,7 @@ var supportedTTLConfigs = []string{
 	sc.ReplicaRescheduleLimitKey,
 	sc.MergeScheduleLimitKey,
 	sc.HotRegionScheduleLimitKey,
+	sc.SplitScatterScheduleLimitKey,
 	sc.SchedulerMaxWaitingOperatorKey,
 	sc.EnableLocationReplacement,
 	sc.EnableTiKVSplitRegion,

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1861,6 +1861,8 @@ func (s *GrpcServer) AskBatchSplit(ctx context.Context, request *pdpb.AskBatchSp
 		}
 		cli := forwardCli.getClient()
 		if cli != nil {
+			// TODO(split-scatter): propagate split reason and support load-based split-scatter
+			// after scheduling-service/NEXT_GEN path is explicitly in scope.
 			req := &schedulingpb.AskBatchSplitRequest{
 				Header: &schedulingpb.RequestHeader{
 					ClusterId: request.GetHeader().GetClusterId(),

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8
+	github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -390,8 +390,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8 h1:RiYvpna6b7GSGIIFFu6R92T/eq1KgOiK1ry6w/60x+Y=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721 h1:Y8/FeTGB0zVoJ2sRN5o/uRUC7aZjSeY8acryhX4oYFg=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -418,6 +418,7 @@ var ttlConfig = map[string]any{
 	"schedule.hot-region-schedule-limit":      999,
 	"schedule.replica-schedule-limit":         999,
 	"schedule.merge-schedule-limit":           999,
+	"schedule.split-scatter-schedule-limit":   999,
 	"schedule.enable-tikv-split-region":       false,
 }
 
@@ -436,6 +437,7 @@ type ttlConfigInterface interface {
 	GetHotRegionScheduleLimit() uint64
 	GetReplicaScheduleLimit() uint64
 	GetMergeScheduleLimit() uint64
+	GetSplitScatterScheduleLimit() uint64
 	IsTikvRegionSplitEnabled() bool
 }
 
@@ -459,6 +461,7 @@ func assertTTLConfig(
 		equality(uint64(999), options.GetHotRegionScheduleLimit())
 		equality(uint64(999), options.GetReplicaScheduleLimit())
 		equality(uint64(999), options.GetMergeScheduleLimit())
+		equality(uint64(999), options.GetSplitScatterScheduleLimit())
 		equality(false, options.IsTikvRegionSplitEnabled())
 	}
 	checkFunc(cluster.GetLeaderServer().GetServer().GetPersistOptions())

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,6 +3,7 @@ module github.com/tikv/pd/tools
 go 1.23.12
 
 replace (
+	github.com/pingcap/kvproto => github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf
 	github.com/tikv/pd => ../
 	github.com/tikv/pd/client => ../client
 )

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,6 @@ module github.com/tikv/pd/tools
 go 1.23.12
 
 replace (
-	github.com/pingcap/kvproto => github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf
 	github.com/tikv/pd => ../
 	github.com/tikv/pd/client => ../client
 )
@@ -23,7 +22,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8
+	github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.55.0

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -318,6 +318,8 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf h1:RnQHw1A6bxOts77JHM5COX2Vw3eRd5RambAlET4+4qQ=
+github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a h1:N9zuLhTvBSRt0gWSiJswwQ2HqDmtX/ZCDJURnKUt1Ik=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -318,8 +318,6 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf h1:RnQHw1A6bxOts77JHM5COX2Vw3eRd5RambAlET4+4qQ=
-github.com/lhy1024/kvproto v0.0.0-20260514094805-07f3062a25cf/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a h1:N9zuLhTvBSRt0gWSiJswwQ2HqDmtX/ZCDJURnKUt1Ik=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
@@ -389,8 +387,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8 h1:RiYvpna6b7GSGIIFFu6R92T/eq1KgOiK1ry6w/60x+Y=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721 h1:Y8/FeTGB0zVoJ2sRN5o/uRUC7aZjSeY8acryhX4oYFg=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10621

### What is changed and how does it work?

```commit-message
Cherry-pick #10621 to support load-based split-scatter on release-8.5-20251204-v8.5.4.

PD records split batches reported with SplitReason_LOAD after AskBatchSplit allocates split IDs, keeps pending split-scatter regions, and dispatches internal scatter operators with range-aware scatter groups.

This PR also adds the split-scatter schedule limit config and updates kvproto to pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721, which includes pingcap/kvproto#1464.
```

### Cherry-pick / dependency handling

Source PR: #10621, merge commit `38a0f9ab0a3e373c2da23fa7c556423b4a67a6db`.
Target branch: `release-8.5-20251204-v8.5.4`.
Current head: `44949721a3483de54eec810979bbc5cba1532e38`.

- The source PR #10621 does not change Go module files; this backport changes them only because the release branch needs the split-reason kvproto backport.
- Updated root, `tools/`, and `tests/integrations/` modules to `github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721`.
- Removed the temporary `github.com/lhy1024/kvproto@07f3062a` replace and stale checksums after pingcap/kvproto#1464 was merged.
- Restored the split-scatter metric tests to the source PR's `prometheus/testutil` style; root `github.com/prometheus/client_model v0.6.1` remains indirect after `go mod tidy`.
- No master-only affinity checker/operator code or checker metrics refactor was brought into this release backport.
- MCS/NEXT_GEN split-scatter behavior remains out of scope; the existing TODOs are preserved and only the shared config getter is added for interface compatibility.

### Check List

Tests

- Unit test
- Manual test

Manual test commands:

```sh
PATH="$PWD/.tools/bin:$PATH" GOTOOLCHAIN=go1.23.12 make check
.tools/bin/failpoint-ctl enable . && go test ./pkg/schedule/checker -run SplitScatter -count=1; rc=$?; .tools/bin/failpoint-ctl disable .; exit $rc
.tools/bin/failpoint-ctl enable . && (cd tests/integrations && GOTOOLCHAIN=go1.23.12 go test ./mcs/resourcemanager -run 'TestResourceManagerClientTestSuite/TestSwitchBurst' -count=1); rc=$?; .tools/bin/failpoint-ctl disable .; exit $rc
git diff --check
```

Code changes

- Has the configuration change

Side effects

- Increased code complexity

Related changes

- kvproto PR: https://github.com/pingcap/kvproto/pull/1464

### Release note

```release-note
PD now supports load-based split-scatter for regions split by TiKV load-based splitting.
```
