### PR TITLE
[DO NOT MERGE / test bundle] resource_control: paging pre-charge for byte-budget RC

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -629,6 +629,7 @@ func (c *ResourceGroupsController) cleanUpResourceGroup() {
 			if gc.inactive || gc.tombstone.Load() {
 				c.groupsController.Delete(resourceGroupName)
 				metrics.ResourceGroupStatusGauge.DeleteLabelValues(resourceGroupName, resourceGroupName)
+				gc.metrics.deletePagingLabels(resourceGroupName)
 				return true
 			}
 			gc.inactive = true

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -76,6 +76,13 @@ type ResourceGroupKVInterceptor interface {
 	// OnResponseWait is used to consume tokens after receiving a response. If the response requires many tokens, we need to wait for the tokens.
 	// This is an optimized version of OnResponse for cases where the response requires many tokens, making the debt smaller and smoother.
 	OnResponseWait(ctx context.Context, resourceGroupName string, req RequestInfo, resp ResponseInfo) (*rmpb.Consumption, time.Duration, error)
+	// OnRequestCancel undoes the pre-charge performed by a preceding successful
+	// OnRequestWait when the underlying RPC fails before producing a response
+	// (e.g. transport error, context cancellation). Without this, the predicted
+	// RU pre-charged in BeforeKVRequest would stay permanently debited.
+	// Callers must invoke it exactly once per cancelled request, with the same
+	// RequestInfo that was passed to OnRequestWait.
+	OnRequestCancel(ctx context.Context, resourceGroupName string, info RequestInfo)
 	// IsBackgroundRequest If the resource group has background jobs, we should not record consumption and wait for it.
 	IsBackgroundRequest(ctx context.Context, resourceGroupName, requestResource string) bool
 	// GetRUVersion returns the current RU calculation version for this keyspace.
@@ -754,6 +761,19 @@ func (c *ResourceGroupsController) OnResponseWait(
 		return &rmpb.Consumption{}, time.Duration(0), nil
 	}
 	return gc.onResponseWaitImpl(ctx, req, resp)
+}
+
+// OnRequestCancel implements ResourceGroupKVInterceptor.
+func (c *ResourceGroupsController) OnRequestCancel(
+	_ context.Context, resourceGroupName string, info RequestInfo,
+) {
+	gc, ok := c.loadGroupController(resourceGroupName)
+	if !ok {
+		log.Warn("[resource group controller] resource group name does not exist on cancel",
+			zap.String("name", resourceGroupName))
+		return
+	}
+	gc.onRequestCancelImpl(info)
 }
 
 // IsBackgroundRequest If the resource group has background jobs, we should not record consumption and wait for it.

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -660,7 +660,7 @@ func (gc *groupCostController) onResponseImpl(
 	if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
 		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes(),
 			getRUValueFromConsumption(count), getRUValueFromConsumption(delta))
-	} else if !req.IsWrite() {
+	} else if !req.IsWrite() && req.IsCop() {
 		gc.metrics.observePagingNonprecharge(resp.ReadBytes())
 	}
 	if !gc.burstable.Load() {
@@ -698,7 +698,7 @@ func (gc *groupCostController) onResponseWaitImpl(
 	if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
 		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes(),
 			getRUValueFromConsumption(count), getRUValueFromConsumption(delta))
-	} else if !req.IsWrite() {
+	} else if !req.IsWrite() && req.IsCop() {
 		gc.metrics.observePagingNonprecharge(resp.ReadBytes())
 	}
 	var waitDuration time.Duration

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -661,9 +661,7 @@ func (gc *groupCostController) onResponseImpl(
 		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes(),
 			getRUValueFromConsumption(count), getRUValueFromConsumption(delta))
 	} else if !req.IsWrite() {
-		if _, ok := req.(predictedReadBytesProvider); ok {
-			gc.metrics.observePagingNonprecharge(resp.ReadBytes())
-		}
+		gc.metrics.observePagingNonprecharge(resp.ReadBytes())
 	}
 	if !gc.burstable.Load() {
 		counter := gc.run.requestUnitTokens
@@ -701,9 +699,7 @@ func (gc *groupCostController) onResponseWaitImpl(
 		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes(),
 			getRUValueFromConsumption(count), getRUValueFromConsumption(delta))
 	} else if !req.IsWrite() {
-		if _, ok := req.(predictedReadBytesProvider); ok {
-			gc.metrics.observePagingNonprecharge(resp.ReadBytes())
-		}
+		gc.metrics.observePagingNonprecharge(resp.ReadBytes())
 	}
 	var waitDuration time.Duration
 	if !gc.burstable.Load() {

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -754,6 +754,32 @@ func (gc *groupCostController) onResponseWaitImpl(
 	return delta, waitDuration, nil
 }
 
+// onRequestCancelImpl undoes onRequestWaitImpl's pre-charge when the RPC
+// fails before producing any response. It recomputes the BeforeKVRequest
+// delta with the same RequestInfo and the same calculators, then subtracts
+// that delta from per-group consumption and refunds the corresponding
+// tokens to the limiter so speculatively reserved RU is not lost.
+//
+// The per-store snapshot maintained by onRequestWaitImpl is intentionally
+// not rolled back — it is bookkeeping for penalty distribution and will be
+// overwritten by the next OnRequestWait against the same store.
+func (gc *groupCostController) onRequestCancelImpl(info RequestInfo) {
+	delta := &rmpb.Consumption{}
+	for _, calc := range gc.calculators {
+		calc.BeforeKVRequest(delta, info)
+	}
+
+	gc.mu.Lock()
+	sub(gc.mu.consumption, delta)
+	gc.mu.Unlock()
+
+	if !gc.burstable.Load() {
+		if v := getRUValueFromConsumption(delta); v > 0 {
+			gc.run.requestUnitTokens.limiter.RefundTokens(time.Now(), v)
+		}
+	}
+}
+
 func (gc *groupCostController) addRUConsumption(consumption *rmpb.Consumption) {
 	gc.mu.Lock()
 	add(gc.mu.consumption, consumption)

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -106,6 +106,21 @@ type groupMetricsCollection struct {
 	tokenRequestCounter               prometheus.Counter
 	runningKVRequestCounter           prometheus.Gauge
 	consumeTokenHistogram             prometheus.Observer
+
+	// Paging pre-charge observability: cached per-RG so the hot path avoids
+	// WithLabelValues on every KV request. Only pre-charged requests (those
+	// with a PredictedReadBytes hint > 0) contribute to these metrics.
+	prechargeCounter        prometheus.Counter
+	prechargeBytesCounter   prometheus.Counter
+	actualBytesCounter      prometheus.Counter
+	predictionResidualBytes prometheus.Observer
+
+	// Nonprecharge bucket: RPCs that implemented the predicted-bytes
+	// interface but reported 0 (EMA cold-start or feature-disabled) and
+	// therefore skipped pre-charge entirely. Recorded at settle time
+	// (AfterKVRequest).
+	nonprechargeCounter     prometheus.Counter
+	nonprechargeActualBytes prometheus.Counter
 }
 
 func initMetrics(oldName, name string) *groupMetricsCollection {
@@ -122,7 +137,40 @@ func initMetrics(oldName, name string) *groupMetricsCollection {
 		tokenRequestCounter:               metrics.ResourceGroupTokenRequestCounter.WithLabelValues(oldName, name),
 		runningKVRequestCounter:           metrics.GroupRunningKVRequestCounter.WithLabelValues(name),
 		consumeTokenHistogram:             metrics.TokenConsumedHistogram.WithLabelValues(name),
+
+		prechargeCounter:        metrics.PagingPrechargeCounter.WithLabelValues(name),
+		prechargeBytesCounter:   metrics.PagingPrechargeBytesCounter.WithLabelValues(name),
+		actualBytesCounter:      metrics.PagingActualBytesCounter.WithLabelValues(name),
+		predictionResidualBytes: metrics.PagingPredictionResidualBytes.WithLabelValues(name),
+
+		nonprechargeCounter:     metrics.PagingNonprechargeCounter.WithLabelValues(name),
+		nonprechargeActualBytes: metrics.PagingNonprechargeActualBytes.WithLabelValues(name),
 	}
+}
+
+// observePagingPrecharge records one pre-charge event. Caller must guarantee
+// bytesForEst > 0; cold-start requests with no hint are not pre-charged and
+// should not be observed here.
+func (gmc *groupMetricsCollection) observePagingPrecharge(bytesForEst uint64) {
+	gmc.prechargeCounter.Inc()
+	gmc.prechargeBytesCounter.Add(float64(bytesForEst))
+}
+
+// observePagingActual records actual read bytes and the signed residual for a
+// pre-charged request. Caller must guarantee predicted > 0.
+func (gmc *groupMetricsCollection) observePagingActual(predicted, actual uint64) {
+	gmc.actualBytesCounter.Add(float64(actual))
+	gmc.predictionResidualBytes.Observe(float64(actual) - float64(predicted))
+}
+
+// observePagingNonprecharge records one RPC that implemented the predicted
+// read-bytes interface but reported 0 (EMA cold or feature disabled) and
+// therefore ran without pre-charge. `actual` is the response's read bytes,
+// settled in AfterKVRequest. Paired with observePagingPrecharge this gives
+// the cold/ready split and the byte volume that bypassed throttling.
+func (gmc *groupMetricsCollection) observePagingNonprecharge(actual uint64) {
+	gmc.nonprechargeCounter.Inc()
+	gmc.nonprechargeActualBytes.Add(float64(actual))
 }
 
 type tokenCounter struct {
@@ -551,6 +599,9 @@ func (gc *groupCostController) onRequestWaitImpl(
 	for _, calc := range gc.calculators {
 		calc.BeforeKVRequest(delta, info)
 	}
+	if bytesForEst := estimatedReadBytes(info); bytesForEst > 0 {
+		gc.metrics.observePagingPrecharge(bytesForEst)
+	}
 
 	gc.mu.Lock()
 	add(gc.mu.consumption, delta)
@@ -601,6 +652,13 @@ func (gc *groupCostController) onResponseImpl(
 	for _, calc := range gc.calculators {
 		calc.AfterKVRequest(delta, req, resp)
 	}
+	if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
+		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes())
+	} else if !req.IsWrite() {
+		if _, ok := req.(predictedReadBytesProvider); ok {
+			gc.metrics.observePagingNonprecharge(resp.ReadBytes())
+		}
+	}
 	if !gc.burstable.Load() {
 		counter := gc.run.requestUnitTokens
 		if v := getRUValueFromConsumption(delta); v > 0 {
@@ -635,6 +693,13 @@ func (gc *groupCostController) onResponseWaitImpl(
 	delta := &rmpb.Consumption{}
 	for _, calc := range gc.calculators {
 		calc.AfterKVRequest(delta, req, resp)
+	}
+	if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
+		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes())
+	} else if !req.IsWrite() {
+		if _, ok := req.(predictedReadBytesProvider); ok {
+			gc.metrics.observePagingNonprecharge(resp.ReadBytes())
+		}
 	}
 	var waitDuration time.Duration
 	if !gc.burstable.Load() {

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -148,6 +148,23 @@ func initMetrics(oldName, name string) *groupMetricsCollection {
 	}
 }
 
+// deletePagingLabels removes the per-resource-group paging_* metric series
+// when the group is being deleted or tombstoned, so stale label series do
+// not linger in Prometheus until the process restarts. Keep this list in
+// sync with initMetrics — adding a paging metric there must be paired
+// with a deletion here.
+func (gmc *groupMetricsCollection) deletePagingLabels(name string) {
+	metrics.PagingPrechargeCounter.DeleteLabelValues(name)
+	metrics.PagingNonprechargeCounter.DeleteLabelValues(name)
+	metrics.PagingPrechargeBytesCounter.DeleteLabelValues(name)
+	metrics.PagingActualBytesCounter.DeleteLabelValues(name)
+	metrics.PagingNonprechargeActualBytes.DeleteLabelValues(name)
+	metrics.PagingPredictionResidualBytes.DeleteLabelValues(name)
+	metrics.PagingPrechargeRU.DeleteLabelValues(name)
+	metrics.PagingSettlementRU.DeleteLabelValues(name)
+	metrics.PagingSettlementRUDelta.DeleteLabelValues(name)
+}
+
 // observePagingPrecharge requires bytesForEst > 0.
 // prechargeRU is the total RU pre-acquired at BeforeKVRequest
 // (base + ReadBytesCost * bytesForEst).

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -598,9 +598,6 @@ func (gc *groupCostController) onRequestWaitImpl(
 	for _, calc := range gc.calculators {
 		calc.BeforeKVRequest(delta, info)
 	}
-	if bytesForEst := estimatedReadBytes(info); bytesForEst > 0 {
-		gc.metrics.observePagingPrecharge(bytesForEst, getRUValueFromConsumption(delta))
-	}
 
 	gc.mu.Lock()
 	add(gc.mu.consumption, delta)
@@ -625,6 +622,9 @@ func (gc *groupCostController) onRequestWaitImpl(
 		}
 		gc.metrics.successfulRequestDuration.Observe(d.Seconds())
 		waitDuration += d
+	}
+	if bytesForEst := estimatedReadBytes(info); bytesForEst > 0 {
+		gc.metrics.observePagingPrecharge(bytesForEst, getRUValueFromConsumption(delta))
 	}
 
 	gc.mu.Lock()

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -115,6 +115,9 @@ type groupMetricsCollection struct {
 	predictionResidualBytes prometheus.Observer
 	nonprechargeCounter     prometheus.Counter
 	nonprechargeActualBytes prometheus.Counter
+	prechargeRU             prometheus.Counter
+	settlementRU            prometheus.Counter
+	settlementRUDelta       prometheus.Observer
 }
 
 func initMetrics(oldName, name string) *groupMetricsCollection {
@@ -139,19 +142,29 @@ func initMetrics(oldName, name string) *groupMetricsCollection {
 
 		nonprechargeCounter:     metrics.PagingNonprechargeCounter.WithLabelValues(name),
 		nonprechargeActualBytes: metrics.PagingNonprechargeActualBytes.WithLabelValues(name),
+		prechargeRU:             metrics.PagingPrechargeRU.WithLabelValues(name),
+		settlementRU:            metrics.PagingSettlementRU.WithLabelValues(name),
+		settlementRUDelta:       metrics.PagingSettlementRUDelta.WithLabelValues(name),
 	}
 }
 
 // observePagingPrecharge requires bytesForEst > 0.
-func (gmc *groupMetricsCollection) observePagingPrecharge(bytesForEst uint64) {
+// prechargeRU is the total RU pre-acquired at BeforeKVRequest
+// (base + ReadBytesCost * bytesForEst).
+func (gmc *groupMetricsCollection) observePagingPrecharge(bytesForEst uint64, prechargeRU float64) {
 	gmc.prechargeCounter.Inc()
 	gmc.prechargeBytesCounter.Add(float64(bytesForEst))
+	gmc.prechargeRU.Add(prechargeRU)
 }
 
 // observePagingActual requires predicted > 0.
-func (gmc *groupMetricsCollection) observePagingActual(predicted, actual uint64) {
+// settlementRU is the total RU finally consumed (base + CPU + ReadBytesCost * actual);
+// vDelta is (settlement_ru - precharge_ru), the signed per-RPC RU adjustment.
+func (gmc *groupMetricsCollection) observePagingActual(predicted, actual uint64, settlementRU, vDelta float64) {
 	gmc.actualBytesCounter.Add(float64(actual))
 	gmc.predictionResidualBytes.Observe(float64(actual) - float64(predicted))
+	gmc.settlementRU.Add(settlementRU)
+	gmc.settlementRUDelta.Observe(vDelta)
 }
 
 func (gmc *groupMetricsCollection) observePagingNonprecharge(actual uint64) {
@@ -586,7 +599,7 @@ func (gc *groupCostController) onRequestWaitImpl(
 		calc.BeforeKVRequest(delta, info)
 	}
 	if bytesForEst := estimatedReadBytes(info); bytesForEst > 0 {
-		gc.metrics.observePagingPrecharge(bytesForEst)
+		gc.metrics.observePagingPrecharge(bytesForEst, getRUValueFromConsumption(delta))
 	}
 
 	gc.mu.Lock()
@@ -638,8 +651,15 @@ func (gc *groupCostController) onResponseImpl(
 	for _, calc := range gc.calculators {
 		calc.AfterKVRequest(delta, req, resp)
 	}
+	// `count` is the full per-request consumption (BeforeKVRequest + AfterKVRequest).
+	count := &rmpb.Consumption{}
+	*count = *delta
+	for _, calc := range gc.calculators {
+		calc.BeforeKVRequest(count, req)
+	}
 	if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
-		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes())
+		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes(),
+			getRUValueFromConsumption(count), getRUValueFromConsumption(delta))
 	} else if !req.IsWrite() {
 		if _, ok := req.(predictedReadBytesProvider); ok {
 			gc.metrics.observePagingNonprecharge(resp.ReadBytes())
@@ -656,15 +676,7 @@ func (gc *groupCostController) onResponseImpl(
 	}
 
 	gc.mu.Lock()
-	// Record the consumption of the request
 	add(gc.mu.consumption, delta)
-	// Record the consumption of the request by store
-	count := &rmpb.Consumption{}
-	*count = *delta
-	// As the penalty is only counted when the request is completed, so here needs to calculate the write cost which is added in `BeforeKVRequest`
-	for _, calc := range gc.calculators {
-		calc.BeforeKVRequest(count, req)
-	}
 	add(gc.mu.storeCounter[req.StoreID()], count)
 	add(gc.mu.globalCounter, count)
 	gc.mu.Unlock()
@@ -679,8 +691,15 @@ func (gc *groupCostController) onResponseWaitImpl(
 	for _, calc := range gc.calculators {
 		calc.AfterKVRequest(delta, req, resp)
 	}
+	// `count` is the full per-request consumption (BeforeKVRequest + AfterKVRequest).
+	count := &rmpb.Consumption{}
+	*count = *delta
+	for _, calc := range gc.calculators {
+		calc.BeforeKVRequest(count, req)
+	}
 	if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
-		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes())
+		gc.metrics.observePagingActual(bytesForEst, resp.ReadBytes(),
+			getRUValueFromConsumption(count), getRUValueFromConsumption(delta))
 	} else if !req.IsWrite() {
 		if _, ok := req.(predictedReadBytesProvider); ok {
 			gc.metrics.observePagingNonprecharge(resp.ReadBytes())
@@ -710,15 +729,7 @@ func (gc *groupCostController) onResponseWaitImpl(
 	}
 
 	gc.mu.Lock()
-	// Record the consumption of the request
 	add(gc.mu.consumption, delta)
-	// Record the consumption of the request by store
-	count := &rmpb.Consumption{}
-	*count = *delta
-	// As the penalty is only counted when the request is completed, so here needs to calculate the write cost which is added in `BeforeKVRequest`
-	for _, calc := range gc.calculators {
-		calc.BeforeKVRequest(count, req)
-	}
 	add(gc.mu.storeCounter[req.StoreID()], count)
 	add(gc.mu.globalCounter, count)
 	gc.mu.Unlock()

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -167,6 +167,10 @@ func (gmc *groupMetricsCollection) observePagingActual(predicted, actual uint64,
 	gmc.settlementRUDelta.Observe(vDelta)
 }
 
+// observePagingNonprecharge counts a coprocessor RPC whose EMA produced no hint
+// (cold-start). Callers must gate the call on RequestInfo.IsCop() && !IsWrite()
+// so the metric stays scoped to coprocessor reads and excludes point gets,
+// batch gets, scans, and other bounded-size reads.
 func (gmc *groupMetricsCollection) observePagingNonprecharge(actual uint64) {
 	gmc.nonprechargeCounter.Inc()
 	gmc.nonprechargeActualBytes.Add(float64(actual))

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -605,6 +605,10 @@ func (gc *groupCostController) onResponseImpl(
 		counter := gc.run.requestUnitTokens
 		if v := getRUValueFromConsumption(delta); v > 0 {
 			counter.limiter.RemoveTokens(time.Now(), v)
+		} else if v < 0 {
+			// RC paging settlement: actual cost was below the pre-charge,
+			// refund the excess so the limiter reflects real consumption.
+			counter.limiter.RefundTokens(time.Now(), -v)
 		}
 	}
 
@@ -634,19 +638,26 @@ func (gc *groupCostController) onResponseWaitImpl(
 	}
 	var waitDuration time.Duration
 	if !gc.burstable.Load() {
-		allowDebt := delta.ReadBytes+delta.WriteBytes < bigRequestThreshold || !gc.isThrottled.Load()
-		d, err := gc.acquireTokens(ctx, delta, &waitDuration, allowDebt)
-		if err != nil {
-			if errs.ErrClientResourceGroupThrottled.Equal(err) {
-				gc.metrics.failedRequestCounterWithThrottled.Inc()
-				gc.metrics.failedLimitReserveDuration.Observe(d.Seconds())
-			} else {
-				gc.metrics.failedRequestCounterWithOthers.Inc()
+		v := getRUValueFromConsumption(delta)
+		if v > 0 {
+			allowDebt := delta.ReadBytes+delta.WriteBytes < bigRequestThreshold || !gc.isThrottled.Load()
+			d, err := gc.acquireTokens(ctx, delta, &waitDuration, allowDebt)
+			if err != nil {
+				if errs.ErrClientResourceGroupThrottled.Equal(err) {
+					gc.metrics.failedRequestCounterWithThrottled.Inc()
+					gc.metrics.failedLimitReserveDuration.Observe(d.Seconds())
+				} else {
+					gc.metrics.failedRequestCounterWithOthers.Inc()
+				}
+				return nil, waitDuration, err
 			}
-			return nil, waitDuration, err
+			gc.metrics.successfulRequestDuration.Observe(d.Seconds())
+			waitDuration += d
+		} else if v < 0 {
+			// RC paging settlement: actual cost was below the pre-charge,
+			// refund the excess so the limiter reflects real consumption.
+			gc.run.requestUnitTokens.limiter.RefundTokens(time.Now(), -v)
 		}
-		gc.metrics.successfulRequestDuration.Observe(d.Seconds())
-		waitDuration += d
 	}
 
 	gc.mu.Lock()

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -107,18 +107,12 @@ type groupMetricsCollection struct {
 	runningKVRequestCounter           prometheus.Gauge
 	consumeTokenHistogram             prometheus.Observer
 
-	// Paging pre-charge observability: cached per-RG so the hot path avoids
-	// WithLabelValues on every KV request. Only pre-charged requests (those
-	// with a PredictedReadBytes hint > 0) contribute to these metrics.
+	// Paging pre-charge observers, cached per-RG to avoid WithLabelValues
+	// on the hot path.
 	prechargeCounter        prometheus.Counter
 	prechargeBytesCounter   prometheus.Counter
 	actualBytesCounter      prometheus.Counter
 	predictionResidualBytes prometheus.Observer
-
-	// Nonprecharge bucket: RPCs that implemented the predicted-bytes
-	// interface but reported 0 (EMA cold-start or feature-disabled) and
-	// therefore skipped pre-charge entirely. Recorded at settle time
-	// (AfterKVRequest).
 	nonprechargeCounter     prometheus.Counter
 	nonprechargeActualBytes prometheus.Counter
 }
@@ -148,26 +142,18 @@ func initMetrics(oldName, name string) *groupMetricsCollection {
 	}
 }
 
-// observePagingPrecharge records one pre-charge event. Caller must guarantee
-// bytesForEst > 0; cold-start requests with no hint are not pre-charged and
-// should not be observed here.
+// observePagingPrecharge requires bytesForEst > 0.
 func (gmc *groupMetricsCollection) observePagingPrecharge(bytesForEst uint64) {
 	gmc.prechargeCounter.Inc()
 	gmc.prechargeBytesCounter.Add(float64(bytesForEst))
 }
 
-// observePagingActual records actual read bytes and the signed residual for a
-// pre-charged request. Caller must guarantee predicted > 0.
+// observePagingActual requires predicted > 0.
 func (gmc *groupMetricsCollection) observePagingActual(predicted, actual uint64) {
 	gmc.actualBytesCounter.Add(float64(actual))
 	gmc.predictionResidualBytes.Observe(float64(actual) - float64(predicted))
 }
 
-// observePagingNonprecharge records one RPC that implemented the predicted
-// read-bytes interface but reported 0 (EMA cold or feature disabled) and
-// therefore ran without pre-charge. `actual` is the response's read bytes,
-// settled in AfterKVRequest. Paired with observePagingPrecharge this gives
-// the cold/ready split and the byte volume that bypassed throttling.
 func (gmc *groupMetricsCollection) observePagingNonprecharge(actual uint64) {
 	gmc.nonprechargeCounter.Inc()
 	gmc.nonprechargeActualBytes.Add(float64(actual))
@@ -664,8 +650,7 @@ func (gc *groupCostController) onResponseImpl(
 		if v := getRUValueFromConsumption(delta); v > 0 {
 			counter.limiter.RemoveTokens(time.Now(), v)
 		} else if v < 0 {
-			// RC paging settlement: actual cost was below the pre-charge,
-			// refund the excess so the limiter reflects real consumption.
+			// Paging over-estimate: refund the excess pre-charge.
 			counter.limiter.RefundTokens(time.Now(), -v)
 		}
 	}
@@ -719,8 +704,7 @@ func (gc *groupCostController) onResponseWaitImpl(
 			gc.metrics.successfulRequestDuration.Observe(d.Seconds())
 			waitDuration += d
 		} else if v < 0 {
-			// RC paging settlement: actual cost was below the pre-charge,
-			// refund the excess so the limiter reflects real consumption.
+			// Paging over-estimate: refund the excess pre-charge.
 			gc.run.requestUnitTokens.limiter.RefundTokens(time.Now(), -v)
 		}
 	}

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -20,12 +20,19 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 
 	"github.com/tikv/pd/client/errs"
 )
+
+func counterValue(re *require.Assertions, c interface{ Write(*dto.Metric) error }) float64 {
+	var m dto.Metric
+	re.NoError(c.Write(&m))
+	return m.GetCounter().GetValue()
+}
 
 func createTestGroupCostController(re *require.Assertions) *groupCostController {
 	group := &rmpb.ResourceGroup{
@@ -450,6 +457,30 @@ func TestResourceGroupThrottledError(t *testing.T) {
 	_, _, _, _, err := gc.onRequestWaitImpl(context.TODO(), req)
 	re.Error(err)
 	re.True(errs.ErrClientResourceGroupThrottled.Equal(err))
+}
+
+func TestPagingPrechargeNotObservedOnThrottle(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+
+	// 4 GiB predicted ~= 65536 RU at default ReadCostPerByte (1/64KiB),
+	// exceeding the LTBMaxWaitDuration budget at the default FillRate so
+	// acquireTokens returns ErrClientResourceGroupThrottled.
+	req := &TestRequestInfo{
+		isWrite:            false,
+		predictedReadBytes: 4 * 1024 * 1024 * 1024,
+	}
+
+	before := counterValue(re, gc.metrics.prechargeCounter)
+	_, _, _, _, err := gc.onRequestWaitImpl(context.TODO(), req)
+	re.Error(err)
+	re.True(errs.ErrClientResourceGroupThrottled.Equal(err))
+	after := counterValue(re, gc.metrics.prechargeCounter)
+
+	// Throttled requests never reach OnResponse for settlement, so the
+	// precharge counter must not be incremented either.
+	re.Equal(before, after,
+		"throttled paging request should not inflate PagingPrechargeCounter")
 }
 
 func TestAcquireTokensSignalAwareWait(t *testing.T) {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -377,6 +377,52 @@ func TestOnResponseImplPagingRefund(t *testing.T) {
 		"onResponseImpl should refund excess pre-charged tokens")
 }
 
+func TestOnRequestCancelRefundsPreCharge(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+
+	gc.run.requestUnitTokens.limiter.Reconfigure(time.Now(), tokenBucketReconfigureArgs{
+		newTokens:   100000,
+		newFillRate: 0,
+		newBurst:    0,
+	})
+	tokensBefore := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+	gc.mu.Lock()
+	consumptionBefore := gc.mu.consumption.RRU
+	gc.mu.Unlock()
+
+	predictedReadBytes := uint64(4 * 1024 * 1024) // 4 MiB pre-charge
+	req := &TestRequestInfo{
+		isWrite:            false,
+		predictedReadBytes: predictedReadBytes,
+		isCop:              true,
+	}
+
+	_, _, _, _, err := gc.onRequestWaitImpl(context.TODO(), req)
+	re.NoError(err)
+	tokensAfterPrecharge := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+	gc.mu.Lock()
+	consumptionAfterPrecharge := gc.mu.consumption.RRU
+	gc.mu.Unlock()
+	re.Less(tokensAfterPrecharge, tokensBefore, "sanity: precharge debited the bucket")
+	re.Greater(consumptionAfterPrecharge, consumptionBefore, "sanity: precharge added to consumption")
+
+	// Simulate transport-level RPC failure: no response was produced, so the
+	// settlement path never runs. OnRequestCancel must roll back the
+	// speculative debit.
+	gc.onRequestCancelImpl(req)
+
+	tokensAfterCancel := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+	gc.mu.Lock()
+	consumptionAfterCancel := gc.mu.consumption.RRU
+	gc.mu.Unlock()
+
+	re.InDelta(tokensBefore, tokensAfterCancel, 1.0,
+		"OnRequestCancel must refund every pre-charged token")
+	re.InDelta(consumptionBefore, consumptionAfterCancel, 1e-6,
+		"OnRequestCancel must reverse the consumption recorded by OnRequestWait")
+}
+
 func TestPagingPreChargeRefundOnFailedRead(t *testing.T) {
 	re := require.New(t)
 	gc := createTestGroupCostController(re)

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -249,6 +249,125 @@ func TestPredictedReadBytesPreCharge(t *testing.T) {
 		"Total RRU across precharge+settle should equal baseCost + actualCost")
 }
 
+func TestPagingPreChargeTokenRefund(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+
+	initialTokens := float64(100000)
+	gc.run.requestUnitTokens.limiter.Reconfigure(time.Now(), tokenBucketReconfigureArgs{
+		newTokens:   initialTokens,
+		newFillRate: 0,
+		newBurst:    0,
+	})
+
+	predictedReadBytes := uint64(4 * 1024 * 1024) // 4 MB pre-charge
+	actualReadBytes := uint64(1 * 1024 * 1024)    // 1 MB actual
+
+	req := &TestRequestInfo{
+		isWrite:            false,
+		predictedReadBytes: predictedReadBytes,
+	}
+	resp := &TestResponseInfo{
+		readBytes: actualReadBytes,
+		succeed:   true,
+	}
+
+	_, _, _, _, err := gc.onRequestWaitImpl(context.TODO(), req)
+	re.NoError(err)
+	tokensAfterPreCharge := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	_, _, err = gc.onResponseWaitImpl(context.TODO(), req, resp)
+	re.NoError(err)
+	tokensAfterSettlement := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	// Refund (pre-charge - actual) should exceed the actual read cost,
+	// so the limiter ends settlement with more tokens than after pre-charge.
+	cfg := DefaultRUConfig()
+	preChargeCost := float64(cfg.ReadBytesCost) * float64(predictedReadBytes)
+	actualCost := float64(cfg.ReadBytesCost) * float64(actualReadBytes)
+	expectedRefund := preChargeCost - actualCost
+	re.Positive(expectedRefund, "sanity: pre-charge should exceed actual cost")
+	re.InDelta(tokensAfterPreCharge+expectedRefund, tokensAfterSettlement, 1.0,
+		"limiter should be refunded the excess pre-charged tokens")
+
+	gc.mu.Lock()
+	netRRU := gc.mu.consumption.RRU
+	gc.mu.Unlock()
+	baseCost := float64(cfg.ReadBaseCost) + float64(cfg.ReadPerBatchBaseCost)*defaultAvgBatchProportion
+	re.InDelta(baseCost+actualCost, netRRU, 1e-6,
+		"net consumption should equal baseCost + actualReadCost")
+}
+
+func TestPagingPreChargeNoRefundWhenActualExceedsEstimate(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+
+	initialTokens := float64(100000)
+	gc.run.requestUnitTokens.limiter.Reconfigure(time.Now(), tokenBucketReconfigureArgs{
+		newTokens:   initialTokens,
+		newFillRate: 0,
+		newBurst:    0,
+	})
+
+	predictedReadBytes := uint64(1 * 1024 * 1024) // 1 MB pre-charge
+	actualReadBytes := uint64(4 * 1024 * 1024)    // 4 MB actual (exceeds estimate)
+
+	req := &TestRequestInfo{
+		isWrite:            false,
+		predictedReadBytes: predictedReadBytes,
+	}
+	resp := &TestResponseInfo{
+		readBytes: actualReadBytes,
+		succeed:   true,
+	}
+
+	_, _, _, _, err := gc.onRequestWaitImpl(context.TODO(), req)
+	re.NoError(err)
+	tokensAfterPreCharge := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	_, _, err = gc.onResponseWaitImpl(context.TODO(), req, resp)
+	re.NoError(err)
+	tokensAfterSettlement := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	re.Less(tokensAfterSettlement, tokensAfterPreCharge,
+		"when actual exceeds pre-charge, settlement should consume tokens")
+}
+
+func TestOnResponseImplPagingRefund(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+
+	initialTokens := float64(100000)
+	gc.run.requestUnitTokens.limiter.Reconfigure(time.Now(), tokenBucketReconfigureArgs{
+		newTokens:   initialTokens,
+		newFillRate: 0,
+		newBurst:    0,
+	})
+
+	predictedReadBytes := uint64(4 * 1024 * 1024) // 4 MB pre-charge
+	actualReadBytes := uint64(512 * 1024)         // 512 KB actual
+
+	req := &TestRequestInfo{
+		isWrite:            false,
+		predictedReadBytes: predictedReadBytes,
+	}
+	resp := &TestResponseInfo{
+		readBytes: actualReadBytes,
+		succeed:   true,
+	}
+
+	_, _, _, _, err := gc.onRequestWaitImpl(context.TODO(), req)
+	re.NoError(err)
+	tokensAfterPreCharge := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	_, err = gc.onResponseImpl(req, resp)
+	re.NoError(err)
+	tokensAfterSettlement := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	re.Greater(tokensAfterSettlement, tokensAfterPreCharge,
+		"onResponseImpl should refund excess pre-charged tokens")
+}
+
 func TestNoPreChargeWithoutPredictedReadBytes(t *testing.T) {
 	re := require.New(t)
 	cfg := DefaultRUConfig()

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -368,6 +368,48 @@ func TestOnResponseImplPagingRefund(t *testing.T) {
 		"onResponseImpl should refund excess pre-charged tokens")
 }
 
+func TestPagingPreChargeRefundOnFailedRead(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+
+	initialTokens := float64(100000)
+	gc.run.requestUnitTokens.limiter.Reconfigure(time.Now(), tokenBucketReconfigureArgs{
+		newTokens:   initialTokens,
+		newFillRate: 0,
+		newBurst:    0,
+	})
+
+	predictedReadBytes := uint64(4 * 1024 * 1024) // 4 MB pre-charge
+
+	req := &TestRequestInfo{
+		isWrite:            false,
+		predictedReadBytes: predictedReadBytes,
+	}
+	// Failed response: no bytes read, no CPU consumed, succeed=false.
+	resp := &TestResponseInfo{
+		readBytes: 0,
+		kvCPU:     0,
+		succeed:   false,
+	}
+
+	_, _, _, _, err := gc.onRequestWaitImpl(context.TODO(), req)
+	re.NoError(err)
+	tokensAfterPreCharge := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	_, _, err = gc.onResponseWaitImpl(context.TODO(), req, resp)
+	re.NoError(err)
+	tokensAfterSettlement := gc.run.requestUnitTokens.limiter.AvailableTokens(time.Now())
+
+	// On a failed read, AfterKVRequest still runs: paging settlement subtracts
+	// ReadBytesCost*predicted and calculateReadCost adds 0, yielding a negative
+	// delta that flows through RefundTokens. ReadBaseCost is not refunded,
+	// matching existing behavior for non-paging read failures.
+	cfg := DefaultRUConfig()
+	expectedRefund := float64(cfg.ReadBytesCost) * float64(predictedReadBytes)
+	re.InDelta(tokensAfterPreCharge+expectedRefund, tokensAfterSettlement, 1.0,
+		"failed read with paging hint should refund ReadBytesCost*predicted")
+}
+
 func TestNoPreChargeWithoutPredictedReadBytes(t *testing.T) {
 	re := require.New(t)
 	cfg := DefaultRUConfig()

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -21,11 +21,13 @@ import (
 	"time"
 
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 
 	"github.com/tikv/pd/client/errs"
+	"github.com/tikv/pd/client/resource_group/controller/metrics"
 )
 
 func counterValue(re *require.Assertions, c interface{ Write(*dto.Metric) error }) float64 {
@@ -415,6 +417,44 @@ func TestPagingPreChargeRefundOnFailedRead(t *testing.T) {
 	expectedRefund := float64(cfg.ReadBytesCost) * float64(predictedReadBytes)
 	re.InDelta(tokensAfterPreCharge+expectedRefund, tokensAfterSettlement, 1.0,
 		"failed read with paging hint should refund ReadBytesCost*predicted")
+}
+
+func TestDeletePagingLabelsResetsSeries(t *testing.T) {
+	re := require.New(t)
+	// Use a name no other test reuses so we measure only our own series.
+	name := "test-paging-cleanup-rg"
+
+	gmc := initMetrics(name, name)
+	// Push a sample through every paging counter / histogram so each label
+	// series actually exists in the underlying Vec.
+	gmc.observePagingPrecharge(100, 1.0)
+	gmc.observePagingActual(100, 80, 2.0, 0.5)
+	gmc.observePagingNonprecharge(200)
+
+	// Sanity: cached counters are non-zero before cleanup.
+	re.Positive(counterValue(re, gmc.prechargeCounter))
+	re.Positive(counterValue(re, gmc.actualBytesCounter))
+	re.Positive(counterValue(re, gmc.nonprechargeCounter))
+
+	gmc.deletePagingLabels(name)
+
+	// After cleanup, refetching each Vec with the same label must yield a
+	// fresh zero-valued series. Covers every counter declared in
+	// initMetrics so a forgotten DeleteLabelValues in deletePagingLabels
+	// surfaces here. Histogram Vecs share the same Delete semantics on
+	// the Vec interface, so counter coverage transitively validates them.
+	for _, vec := range []*prometheus.CounterVec{
+		metrics.PagingPrechargeCounter,
+		metrics.PagingNonprechargeCounter,
+		metrics.PagingPrechargeBytesCounter,
+		metrics.PagingActualBytesCounter,
+		metrics.PagingNonprechargeActualBytes,
+		metrics.PagingPrechargeRU,
+		metrics.PagingSettlementRU,
+	} {
+		re.Zero(counterValue(re, vec.WithLabelValues(name)),
+			"paging counter series for %q should be cleared by deletePagingLabels", name)
+	}
 }
 
 func TestPagingNonprechargeGatedByIsCop(t *testing.T) {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -208,6 +208,76 @@ func TestOnResponseWaitConsumption(t *testing.T) {
 	verify()
 }
 
+func TestPredictedReadBytesPreCharge(t *testing.T) {
+	re := require.New(t)
+	cfg := DefaultRUConfig()
+	kvCalc := newKVCalculator(cfg)
+
+	// BeforeKVRequest with a PredictedReadBytes hint should pre-charge
+	// baseCost + predictedReadBytes * ReadBytesCost.
+	predictedReadBytes := uint64(256 * 1024) // learned EMA estimate
+	req := &TestRequestInfo{
+		isWrite:            false,
+		predictedReadBytes: predictedReadBytes,
+	}
+	precharge := &rmpb.Consumption{}
+	kvCalc.BeforeKVRequest(precharge, req)
+
+	baseCost := float64(cfg.ReadBaseCost) + float64(cfg.ReadPerBatchBaseCost)*defaultAvgBatchProportion
+	hintCost := float64(cfg.ReadBytesCost) * float64(predictedReadBytes)
+	re.InDelta(baseCost+hintCost, precharge.RRU, 1e-6,
+		"BeforeKVRequest should pre-charge based on PredictedReadBytes")
+
+	// AfterKVRequest should subtract the same hint basis, preserving
+	// precharge + settle == baseCost + actualCost.
+	actualReadBytes := uint64(300 * 1024) // close to the prediction
+	resp := &TestResponseInfo{
+		readBytes: actualReadBytes,
+		kvCPU:     10 * time.Millisecond,
+		succeed:   true,
+	}
+	settle := &rmpb.Consumption{}
+	kvCalc.AfterKVRequest(settle, req, resp)
+
+	actualReadCost := float64(cfg.ReadBytesCost) * float64(actualReadBytes)
+	cpuCost := float64(cfg.CPUMsCost) * 10.0
+	re.InDelta(actualReadCost+cpuCost-hintCost, settle.RRU, 1e-6,
+		"AfterKVRequest should settle using the same hint basis as BeforeKVRequest")
+
+	totalRRU := precharge.RRU + settle.RRU
+	re.InDelta(baseCost+actualReadCost+cpuCost, totalRRU, 1e-6,
+		"Total RRU across precharge+settle should equal baseCost + actualCost")
+}
+
+func TestNoPreChargeWithoutPredictedReadBytes(t *testing.T) {
+	re := require.New(t)
+	cfg := DefaultRUConfig()
+	kvCalc := newKVCalculator(cfg)
+	baseCost := float64(cfg.ReadBaseCost) + float64(cfg.ReadPerBatchBaseCost)*defaultAvgBatchProportion
+
+	// Without a PredictedReadBytes hint, BeforeKVRequest must not
+	// pre-charge; AfterKVRequest bills actual read bytes only.
+	req := &TestRequestInfo{isWrite: false}
+	precharge := &rmpb.Consumption{}
+	kvCalc.BeforeKVRequest(precharge, req)
+	re.InDelta(baseCost, precharge.RRU, 1e-6,
+		"Without a hint, BeforeKVRequest should only charge baseCost")
+
+	actualReadBytes := uint64(2 * 1024 * 1024)
+	resp := &TestResponseInfo{
+		readBytes: actualReadBytes,
+		kvCPU:     10 * time.Millisecond,
+		succeed:   true,
+	}
+	settle := &rmpb.Consumption{}
+	kvCalc.AfterKVRequest(settle, req, resp)
+
+	actualReadCost := float64(cfg.ReadBytesCost) * float64(actualReadBytes)
+	cpuCost := float64(cfg.CPUMsCost) * 10.0
+	re.InDelta(actualReadCost+cpuCost, settle.RRU, 1e-6,
+		"AfterKVRequest should bill actual read cost only when nothing was pre-charged")
+}
+
 func TestResourceGroupThrottledError(t *testing.T) {
 	re := require.New(t)
 	gc := createTestGroupCostController(re)

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -417,6 +417,32 @@ func TestPagingPreChargeRefundOnFailedRead(t *testing.T) {
 		"failed read with paging hint should refund ReadBytesCost*predicted")
 }
 
+func TestPagingNonprechargeGatedByIsCop(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+
+	// Reads without a paging hint reach onResponseImpl through the same RC
+	// interceptor regardless of cmd type (CmdGet, CmdBatchGet, CmdCop, ...).
+	// Only IsCop()==true requests should land in paging_nonprecharge_*; the
+	// rest must be ignored so the metric keeps its "paging cold-start"
+	// semantics.
+	resp := &TestResponseInfo{readBytes: 1024, succeed: true}
+	nonCop := &TestRequestInfo{isWrite: false, isCop: false}
+	cop := &TestRequestInfo{isWrite: false, isCop: true}
+
+	before := counterValue(re, gc.metrics.nonprechargeCounter)
+
+	_, err := gc.onResponseImpl(nonCop, resp)
+	re.NoError(err)
+	re.InDelta(before, counterValue(re, gc.metrics.nonprechargeCounter), 1e-9,
+		"non-cop reads must not increment paging_nonprecharge_*")
+
+	_, err = gc.onResponseImpl(cop, resp)
+	re.NoError(err)
+	re.InDelta(before+1, counterValue(re, gc.metrics.nonprechargeCounter), 1e-9,
+		"cop reads without a hint must increment paging_nonprecharge_*")
+}
+
 func TestNoPreChargeWithoutPredictedReadBytes(t *testing.T) {
 	re := require.New(t)
 	cfg := DefaultRUConfig()

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -202,7 +202,7 @@ func (r *Reservation) CancelAt(now time.Time) {
 	tokens += r.tokens
 
 	// update state
-	r.lim.last = now
+	r.lim.updateLast(now)
 	r.lim.tokens = tokens
 }
 
@@ -320,7 +320,7 @@ func (lim *Limiter) RemoveTokens(now time.Time, amount float64) {
 		return
 	}
 	_, tokens := lim.getTokens(now)
-	lim.last = now
+	lim.updateLast(now)
 	lim.tokens = tokens - amount
 	lim.maybeNotify()
 }
@@ -346,7 +346,7 @@ func (lim *Limiter) RefundTokens(now time.Time, amount float64) {
 		return
 	}
 	_, tokens := lim.getTokens(now)
-	lim.last = now
+	lim.updateLast(now)
 	lim.tokens = tokens + amount
 	// Mirror Reconfigure: refunded tokens may unblock acquireTokens retry waits.
 	if lim.reconfiguredCh != nil {
@@ -384,11 +384,11 @@ func (lim *Limiter) Reconfigure(now time.Time,
 		zap.Float64("old-notify-threshold", lim.notifyThreshold),
 		zap.Int64("old-burst", lim.burst))
 	if args.newBurst < 0 {
-		lim.last = now
+		lim.updateLast(now)
 		lim.tokens = args.newTokens
 	} else {
 		_, tokens := lim.getTokens(now)
-		lim.last = now
+		lim.updateLast(now)
 		lim.tokens = tokens + args.newTokens
 	}
 	lim.fillRate = fillRate(args.newFillRate)

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -325,6 +325,26 @@ func (lim *Limiter) RemoveTokens(now time.Time, amount float64) {
 	lim.maybeNotify()
 }
 
+// RefundTokens returns previously consumed tokens back to the limiter.
+// This is the inverse of RemoveTokens: it increases the available token count.
+// It is used when a pre-charged estimate (e.g. a PredictedReadBytes hint)
+// exceeds the actual cost observed after the request completes.
+//
+// No burst cap is applied here — consistent with Reconfigure. The lazy cap
+// in getTokens() normalizes the balance on the next limiter operation.
+// No low-token notification is needed because refunding moves the balance
+// away from the low-token threshold, never toward it.
+func (lim *Limiter) RefundTokens(now time.Time, amount float64) {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	if lim.burst < 0 || lim.fillRate == Inf {
+		return
+	}
+	_, tokens := lim.getTokens(now)
+	lim.last = now
+	lim.tokens = tokens + amount
+}
+
 type tokenBucketReconfigureArgs struct {
 	newTokens          float64
 	newFillRate        float64

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -327,7 +327,18 @@ func (lim *Limiter) RemoveTokens(now time.Time, amount float64) {
 
 // RefundTokens adds tokens back to the limiter.
 //
-// No burst cap is applied here
+// Token overshoot above burst is intentional here: getTokens clamps the
+// value on the next call, so RefundTokens never permanently leaks past
+// the burst cap. maybeNotify is intentionally not called either —
+// refunding can only raise the token count, never push the limiter into
+// the low-token state.
+//
+// Wakes any acquireTokens retry waits via reconfiguredCh so the newly
+// refunded tokens can be picked up immediately instead of after the
+// next retry-interval tick. In-flight WaitReservations sleepers keep
+// honoring their pre-computed timeToAct (whose delay was reserved
+// against the at-reserve-time token count); reservation re-evaluation
+// is out of scope here.
 func (lim *Limiter) RefundTokens(now time.Time, amount float64) {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()
@@ -337,6 +348,11 @@ func (lim *Limiter) RefundTokens(now time.Time, amount float64) {
 	_, tokens := lim.getTokens(now)
 	lim.last = now
 	lim.tokens = tokens + amount
+	// Mirror Reconfigure: refunded tokens may unblock acquireTokens retry waits.
+	if lim.reconfiguredCh != nil {
+		close(lim.reconfiguredCh)
+	}
+	lim.reconfiguredCh = make(chan struct{})
 }
 
 type tokenBucketReconfigureArgs struct {

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -325,15 +325,9 @@ func (lim *Limiter) RemoveTokens(now time.Time, amount float64) {
 	lim.maybeNotify()
 }
 
-// RefundTokens returns previously consumed tokens back to the limiter.
-// This is the inverse of RemoveTokens: it increases the available token count.
-// It is used when a pre-charged estimate (e.g. a PredictedReadBytes hint)
-// exceeds the actual cost observed after the request completes.
+// RefundTokens adds tokens back to the limiter.
 //
-// No burst cap is applied here — consistent with Reconfigure. The lazy cap
-// in getTokens() normalizes the balance on the next limiter operation.
-// No low-token notification is needed because refunding moves the balance
-// away from the low-token threshold, never toward it.
+// No burst cap is applied here
 func (lim *Limiter) RefundTokens(now time.Time, amount float64) {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -173,6 +173,49 @@ func TestRefundTokens(t *testing.T) {
 	checkTokens(re, limUnlimited, t0, 100)
 }
 
+func TestRefundTokensWakesAcquireRetry(t *testing.T) {
+	re := require.New(t)
+	nc := make(chan notifyMsg, 1)
+	// fillRate=0 means no natural recovery; acquireTokens retries can only
+	// proceed when RefundTokens (or Reconfigure) explicitly wakes them.
+	lim := NewLimiter(t0, 0, 0, 100, nc)
+
+	ch := lim.GetReconfiguredCh()
+	select {
+	case <-ch:
+		re.Fail("reconfiguredCh should not be closed before RefundTokens")
+	default:
+	}
+
+	lim.RefundTokens(t0, 50)
+
+	select {
+	case <-ch:
+		// expected: refund closes the old channel
+	case <-time.After(100 * time.Millisecond):
+		re.Fail("RefundTokens must close the existing reconfiguredCh to wake acquireTokens retries")
+	}
+
+	// A fresh reconfiguredCh is now in place, distinct and still open.
+	ch2 := lim.GetReconfiguredCh()
+	re.NotSame(&ch, &ch2)
+	select {
+	case <-ch2:
+		re.Fail("recreated reconfiguredCh should be open after RefundTokens")
+	default:
+	}
+
+	// Burstable (burst < 0) is a no-op for refunds; no wake should fire.
+	limUnlimited := NewLimiter(t0, 0, -1, 100, nc)
+	chU := limUnlimited.GetReconfiguredCh()
+	limUnlimited.RefundTokens(t0, 50)
+	select {
+	case <-chU:
+		re.Fail("RefundTokens on burstable limiter must not close reconfiguredCh")
+	default:
+	}
+}
+
 func TestNotify(t *testing.T) {
 	nc := make(chan notifyMsg, 1)
 	lim := NewLimiter(t0, 1, 0, 0, nc)

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -139,6 +139,40 @@ func TestReconfig(t *testing.T) {
 	re.Equal(int64(-1), lim.GetBurst())
 }
 
+func TestRefundTokens(t *testing.T) {
+	re := require.New(t)
+	nc := make(chan notifyMsg, 1)
+	lim := NewLimiter(t0, 0, 0, 100, nc)
+
+	// Consume some tokens.
+	lim.RemoveTokens(t0, 30)
+	checkTokens(re, lim, t0, 70)
+
+	// Refund part of them.
+	lim.RefundTokens(t0, 20)
+	checkTokens(re, lim, t0, 90)
+
+	// Refund beyond the initial amount - allowed (no burst cap when burst==0).
+	lim.RefundTokens(t0, 50)
+	checkTokens(re, lim, t0, 140)
+
+	// With burst > 0, refund up to burst stays.
+	limBurst := NewLimiter(t0, 0, 100, 50, nc)
+	limBurst.RemoveTokens(t0, 30)
+	checkTokens(re, limBurst, t0, 20)
+	limBurst.RefundTokens(t0, 80) // tokens = 20 + 80 = 100, burst = 100
+	checkTokens(re, limBurst, t0, 100)
+
+	// Refund beyond burst - capped by getTokens.
+	limBurst.RefundTokens(t0, 50) // tokens = 100 + 50 = 150, capped to 100
+	checkTokens(re, limBurst, t0, 100)
+
+	// Burstable (burst < 0): RefundTokens is a no-op.
+	limUnlimited := NewLimiter(t0, 0, -1, 100, nc)
+	limUnlimited.RefundTokens(t0, 50)
+	checkTokens(re, limUnlimited, t0, 100)
+}
+
 func TestNotify(t *testing.T) {
 	nc := make(chan notifyMsg, 1)
 	lim := NewLimiter(t0, 1, 0, 0, nc)

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -139,6 +139,37 @@ func TestReconfig(t *testing.T) {
 	re.Equal(int64(-1), lim.GetBurst())
 }
 
+// TestLastStaysMonotonicOnStaleNow guards against a non-monotonic lim.last:
+// callers capture `now` before taking lim.mu, so under lock contention a
+// mutator can run with a `now` already older than lim.last. A raw
+// `lim.last = now` would rewind the clock and make the next getTokens
+// over-accrue tokens. The mutators must keep lim.last monotonic (updateLast),
+// matching reserveN (see issue #8435).
+func TestLastStaysMonotonicOnStaleNow(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	nc := make(chan notifyMsg, 1)
+
+	// RemoveTokens with a stale now must not rewind last.
+	lim := NewLimiter(t0, 100, 0, 0, nc) // fillRate 100/s, burst 0 (no clamp)
+	r := lim.reserveN(t0.Add(10*time.Second), 10, InfDuration)
+	re.True(r.reserved)
+	_, pool := lim.getTokens(t0.Add(10 * time.Second))
+	re.InDelta(990, pool, 1e-6)
+	lim.RemoveTokens(t0.Add(9*time.Second), 0) // STALE now
+	_, pool = lim.getTokens(t0.Add(11 * time.Second))
+	re.InDelta(1090, pool, 1e-6) // buggy rewind would over-accrue to 1190
+
+	// RefundTokens (the high-frequency paging settlement path) must not rewind
+	// last either.
+	lim2 := NewLimiter(t0, 100, 0, 0, nc)
+	r2 := lim2.reserveN(t0.Add(10*time.Second), 10, InfDuration)
+	re.True(r2.reserved)
+	lim2.RefundTokens(t0.Add(9*time.Second), 0) // STALE now
+	_, pool = lim2.getTokens(t0.Add(11 * time.Second))
+	re.InDelta(1090, pool, 1e-6)
+}
+
 func TestRefundTokens(t *testing.T) {
 	re := require.New(t)
 	nc := make(chan notifyMsg, 1)

--- a/client/resource_group/controller/metrics/metrics.go
+++ b/client/resource_group/controller/metrics/metrics.go
@@ -62,6 +62,9 @@ var (
 	PagingPredictionResidualBytes *prometheus.HistogramVec
 	PagingNonprechargeCounter     *prometheus.CounterVec
 	PagingNonprechargeActualBytes *prometheus.CounterVec
+	PagingPrechargeRU             *prometheus.CounterVec
+	PagingSettlementRU            *prometheus.CounterVec
+	PagingSettlementRUDelta       *prometheus.HistogramVec
 )
 
 func init() {
@@ -225,6 +228,37 @@ func initMetrics(constLabels prometheus.Labels) {
 			Help:        "Sum of actual bytes read by paging RPCs that skipped pre-charge (hint absent or zero). Quantifies read volume settled without pre-charge throttling.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
+
+	PagingPrechargeRU = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_precharge_ru_total",
+			Help:        "Sum of RU pre-acquired at BeforeKVRequest for pre-charged paging read requests (read base cost + ReadBytesCost * predicted_bytes).",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
+	PagingSettlementRU = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_settlement_ru_total",
+			Help:        "Sum of total RU finally consumed by pre-charged paging read requests (read base cost + CPUMsCost * kv_cpu_ms + ReadBytesCost * actual_bytes). Equals precharge_ru + settlement_ru_delta.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
+	PagingSettlementRUDelta = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: requestSubsystem,
+			Name:      "paging_settlement_ru_delta",
+			// v = settlement_ru - precharge_ru = CPUMsCost * kv_cpu_ms + ReadBytesCost * (actual - predicted).
+			// Negative => flows through RefundTokens; positive => flows through RemoveTokens / acquireTokens.
+			// Factor-4 spacing over ±1024 RU covers CPU (±tens of RU) plus bytes residuals up to ±64MB.
+			Buckets:     []float64{-1024, -256, -64, -16, -4, -1, -0.25, -0.0625, 0, 0.0625, 0.25, 1, 4, 16, 64, 256, 1024},
+			Help:        "Per-RPC signed settlement RU delta (settlement_ru - precharge_ru) for pre-charged paging read requests. Negative means refund, positive means extra debit.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
 }
 
 // InitAndRegisterMetrics initializes and register metrics.
@@ -246,4 +280,7 @@ func InitAndRegisterMetrics(constLabels prometheus.Labels) {
 	prometheus.MustRegister(PagingPredictionResidualBytes)
 	prometheus.MustRegister(PagingNonprechargeCounter)
 	prometheus.MustRegister(PagingNonprechargeActualBytes)
+	prometheus.MustRegister(PagingPrechargeRU)
+	prometheus.MustRegister(PagingSettlementRU)
+	prometheus.MustRegister(PagingSettlementRUDelta)
 }

--- a/client/resource_group/controller/metrics/metrics.go
+++ b/client/resource_group/controller/metrics/metrics.go
@@ -54,29 +54,13 @@ var (
 	// SuccessfulTokenRequestDuration comments placeholder, WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	SuccessfulTokenRequestDuration prometheus.Observer
 
-	// PagingPrechargeCounter counts paging pre-charge events (predicted hint
-	// present and > 0), per resource group. Cold starts and unhinted requests
-	// are not pre-charged and therefore not counted here.
-	PagingPrechargeCounter *prometheus.CounterVec
-	// PagingPrechargeBytesCounter sums bytes used as the pre-charge basis.
-	PagingPrechargeBytesCounter *prometheus.CounterVec
-	// PagingActualBytesCounter sums actual read bytes reported after the KV
-	// RPC for pre-charged requests. Ratio against PagingPrechargeBytesCounter
-	// reveals over/under-charge factor.
-	PagingActualBytesCounter *prometheus.CounterVec
-	// PagingPredictionResidualBytes observes (actual - predicted) bytes for
-	// pre-charged requests. Shows EMA prediction accuracy.
+	// Paging pre-charge metrics, per resource group. See each metric's
+	// Help string below for semantics.
+	PagingPrechargeCounter        *prometheus.CounterVec
+	PagingPrechargeBytesCounter   *prometheus.CounterVec
+	PagingActualBytesCounter      *prometheus.CounterVec
 	PagingPredictionResidualBytes *prometheus.HistogramVec
-
-	// PagingNonprechargeCounter counts RPCs that implemented the predicted
-	// read-bytes interface but reported 0 (e.g. EMA cold-start) and therefore
-	// ran without pre-charge. Paired with PagingPrechargeCounter this yields
-	// the cold/ready RPC split from the PD side.
-	PagingNonprechargeCounter *prometheus.CounterVec
-	// PagingNonprechargeActualBytes sums the actual read bytes of RPCs that
-	// skipped pre-charge. Quantifies how much read volume bypassed pre-charge
-	// throttling — the "cold window" signal for token-bucket pressure
-	// analysis.
+	PagingNonprechargeCounter     *prometheus.CounterVec
 	PagingNonprechargeActualBytes *prometheus.CounterVec
 )
 

--- a/client/resource_group/controller/metrics/metrics.go
+++ b/client/resource_group/controller/metrics/metrics.go
@@ -198,9 +198,11 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace: namespace,
 			Subsystem: requestSubsystem,
 			Name:      "paging_prediction_residual_bytes",
-			// Signed residual = actual - predicted. Buckets cover both directions
-			// up to the typical paging budget (a few MB).
-			Buckets:     []float64{-4194304, -1048576, -262144, -65536, -16384, -4096, 0, 4096, 16384, 65536, 262144, 1048576, 4194304},
+			// Signed residual = actual - predicted. Buckets span ±64MB to
+			// absorb large first-page responses on a cold copIterator
+			// (predicted=0) and workload shifts that leave EMA above
+			// actual. Factor-4 spacing keeps resolution near zero.
+			Buckets: []float64{-67108864, -16777216, -4194304, -1048576, -262144, -65536, -16384, -4096, 0, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864},
 			Help:        "Histogram of (actual_read_bytes - predicted_read_bytes) for pre-charged requests. Shows EMA prediction accuracy.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})

--- a/client/resource_group/controller/metrics/metrics.go
+++ b/client/resource_group/controller/metrics/metrics.go
@@ -54,17 +54,26 @@ var (
 	// SuccessfulTokenRequestDuration comments placeholder, WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	SuccessfulTokenRequestDuration prometheus.Observer
 
-	// Paging pre-charge metrics, per resource group. See each metric's
-	// Help string below for semantics.
-	PagingPrechargeCounter        *prometheus.CounterVec
-	PagingPrechargeBytesCounter   *prometheus.CounterVec
-	PagingActualBytesCounter      *prometheus.CounterVec
-	PagingPredictionResidualBytes *prometheus.HistogramVec
-	PagingNonprechargeCounter     *prometheus.CounterVec
+	// PagingPrechargeCounter counts paging read requests that triggered pre-charge (hint > 0).
+	PagingPrechargeCounter *prometheus.CounterVec
+	// PagingNonprechargeCounter counts paging read requests that skipped pre-charge (hint absent or zero).
+	PagingNonprechargeCounter *prometheus.CounterVec
+
+	// PagingPrechargeBytesCounter accumulates bytes used as the pre-charge basis (sum of predicted hints).
+	PagingPrechargeBytesCounter *prometheus.CounterVec
+	// PagingActualBytesCounter accumulates actual bytes read by pre-charged paging requests.
+	PagingActualBytesCounter *prometheus.CounterVec
+	// PagingNonprechargeActualBytes accumulates actual bytes read by paging requests that skipped pre-charge.
 	PagingNonprechargeActualBytes *prometheus.CounterVec
-	PagingPrechargeRU             *prometheus.CounterVec
-	PagingSettlementRU            *prometheus.CounterVec
-	PagingSettlementRUDelta       *prometheus.HistogramVec
+	// PagingPredictionResidualBytes records the distribution of (actual - predicted) read bytes for pre-charged requests.
+	PagingPredictionResidualBytes *prometheus.HistogramVec
+
+	// PagingPrechargeRU accumulates RU pre-acquired at BeforeKVRequest for pre-charged paging read requests.
+	PagingPrechargeRU *prometheus.CounterVec
+	// PagingSettlementRU accumulates total RU finally consumed by pre-charged paging read requests (base + CPU + bytes cost).
+	PagingSettlementRU *prometheus.CounterVec
+	// PagingSettlementRUDelta records the distribution of per-RPC signed RU delta (settlement_ru - precharge_ru) for pre-charged paging read requests.
+	PagingSettlementRUDelta *prometheus.HistogramVec
 )
 
 func init() {
@@ -178,6 +187,15 @@ func initMetrics(constLabels prometheus.Labels) {
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
+	PagingNonprechargeCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_nonprecharge_total",
+			Help:        "Counter of paging read RPCs where no PredictedReadBytes hint was provided (hint absent or zero). These RPCs skip pre-charge and settle entirely on actual read bytes at response time.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
 	PagingPrechargeBytesCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace:   namespace,
@@ -196,6 +214,15 @@ func initMetrics(constLabels prometheus.Labels) {
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
+	PagingNonprechargeActualBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_nonprecharge_actual_bytes_total",
+			Help:        "Sum of actual bytes read by paging RPCs that skipped pre-charge (hint absent or zero). Quantifies read volume settled without pre-charge throttling.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
 	PagingPredictionResidualBytes = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -208,24 +235,6 @@ func initMetrics(constLabels prometheus.Labels) {
 			// resolution near zero.
 			Buckets: []float64{-67108864, -16777216, -4194304, -1048576, -262144, -65536, -16384, -4096, 0, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864},
 			Help:        "Histogram of (actual_read_bytes - predicted_read_bytes) for pre-charged paging requests. Shows predictor accuracy.",
-			ConstLabels: constLabels,
-		}, []string{newResourceGroupNameLabel})
-
-	PagingNonprechargeCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace:   namespace,
-			Subsystem:   requestSubsystem,
-			Name:        "paging_nonprecharge_total",
-			Help:        "Counter of paging read RPCs where no PredictedReadBytes hint was provided (hint absent or zero). These RPCs skip pre-charge and settle entirely on actual read bytes at response time.",
-			ConstLabels: constLabels,
-		}, []string{newResourceGroupNameLabel})
-
-	PagingNonprechargeActualBytes = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace:   namespace,
-			Subsystem:   requestSubsystem,
-			Name:        "paging_nonprecharge_actual_bytes_total",
-			Help:        "Sum of actual bytes read by paging RPCs that skipped pre-charge (hint absent or zero). Quantifies read volume settled without pre-charge throttling.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -275,11 +284,11 @@ func InitAndRegisterMetrics(constLabels prometheus.Labels) {
 	prometheus.MustRegister(LowTokenRequestNotifyCounter)
 	prometheus.MustRegister(TokenConsumedHistogram)
 	prometheus.MustRegister(PagingPrechargeCounter)
+	prometheus.MustRegister(PagingNonprechargeCounter)
 	prometheus.MustRegister(PagingPrechargeBytesCounter)
 	prometheus.MustRegister(PagingActualBytesCounter)
-	prometheus.MustRegister(PagingPredictionResidualBytes)
-	prometheus.MustRegister(PagingNonprechargeCounter)
 	prometheus.MustRegister(PagingNonprechargeActualBytes)
+	prometheus.MustRegister(PagingPredictionResidualBytes)
 	prometheus.MustRegister(PagingPrechargeRU)
 	prometheus.MustRegister(PagingSettlementRU)
 	prometheus.MustRegister(PagingSettlementRUDelta)

--- a/client/resource_group/controller/metrics/metrics.go
+++ b/client/resource_group/controller/metrics/metrics.go
@@ -53,6 +53,31 @@ var (
 	FailedTokenRequestDuration prometheus.Observer
 	// SuccessfulTokenRequestDuration comments placeholder, WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	SuccessfulTokenRequestDuration prometheus.Observer
+
+	// PagingPrechargeCounter counts paging pre-charge events (predicted hint
+	// present and > 0), per resource group. Cold starts and unhinted requests
+	// are not pre-charged and therefore not counted here.
+	PagingPrechargeCounter *prometheus.CounterVec
+	// PagingPrechargeBytesCounter sums bytes used as the pre-charge basis.
+	PagingPrechargeBytesCounter *prometheus.CounterVec
+	// PagingActualBytesCounter sums actual read bytes reported after the KV
+	// RPC for pre-charged requests. Ratio against PagingPrechargeBytesCounter
+	// reveals over/under-charge factor.
+	PagingActualBytesCounter *prometheus.CounterVec
+	// PagingPredictionResidualBytes observes (actual - predicted) bytes for
+	// pre-charged requests. Shows EMA prediction accuracy.
+	PagingPredictionResidualBytes *prometheus.HistogramVec
+
+	// PagingNonprechargeCounter counts RPCs that implemented the predicted
+	// read-bytes interface but reported 0 (e.g. EMA cold-start) and therefore
+	// ran without pre-charge. Paired with PagingPrechargeCounter this yields
+	// the cold/ready RPC split from the PD side.
+	PagingNonprechargeCounter *prometheus.CounterVec
+	// PagingNonprechargeActualBytes sums the actual read bytes of RPCs that
+	// skipped pre-charge. Quantifies how much read volume bypassed pre-charge
+	// throttling — the "cold window" signal for token-bucket pressure
+	// analysis.
+	PagingNonprechargeActualBytes *prometheus.CounterVec
 )
 
 func init() {
@@ -156,6 +181,63 @@ func initMetrics(constLabels prometheus.Labels) {
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	FailedTokenRequestDuration = TokenRequestDuration.WithLabelValues("fail")
 	SuccessfulTokenRequestDuration = TokenRequestDuration.WithLabelValues("success")
+
+	PagingPrechargeCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_precharge_total",
+			Help:        "Counter of RC paging pre-charge events (PredictedReadBytes hint present and > 0).",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
+	PagingPrechargeBytesCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_precharge_bytes_total",
+			Help:        "Sum of bytes used as the RC paging pre-charge basis (predicted hint).",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
+	PagingActualBytesCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_actual_bytes_total",
+			Help:        "Sum of actual bytes read by paging KV requests that were pre-charged.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
+	PagingPredictionResidualBytes = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: requestSubsystem,
+			Name:      "paging_prediction_residual_bytes",
+			// Signed residual = actual - predicted. Buckets cover both directions
+			// up to the typical paging budget (a few MB).
+			Buckets:     []float64{-4194304, -1048576, -262144, -65536, -16384, -4096, 0, 4096, 16384, 65536, 262144, 1048576, 4194304},
+			Help:        "Histogram of (actual_read_bytes - predicted_read_bytes) for pre-charged requests. Shows EMA prediction accuracy.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
+	PagingNonprechargeCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_nonprecharge_total",
+			Help:        "Counter of RC paging RPCs that implemented the predicted hint but reported 0 (e.g. EMA cold-start) and ran without pre-charge.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
+
+	PagingNonprechargeActualBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   requestSubsystem,
+			Name:        "paging_nonprecharge_actual_bytes_total",
+			Help:        "Sum of actual bytes read by paging RPCs that skipped pre-charge (hint=0). Quantifies cold-window read volume bypassing pre-charge throttling.",
+			ConstLabels: constLabels,
+		}, []string{newResourceGroupNameLabel})
 }
 
 // InitAndRegisterMetrics initializes and register metrics.
@@ -171,4 +253,10 @@ func InitAndRegisterMetrics(constLabels prometheus.Labels) {
 	prometheus.MustRegister(ResourceGroupTokenRequestCounter)
 	prometheus.MustRegister(LowTokenRequestNotifyCounter)
 	prometheus.MustRegister(TokenConsumedHistogram)
+	prometheus.MustRegister(PagingPrechargeCounter)
+	prometheus.MustRegister(PagingPrechargeBytesCounter)
+	prometheus.MustRegister(PagingActualBytesCounter)
+	prometheus.MustRegister(PagingPredictionResidualBytes)
+	prometheus.MustRegister(PagingNonprechargeCounter)
+	prometheus.MustRegister(PagingNonprechargeActualBytes)
 }

--- a/client/resource_group/controller/metrics/metrics.go
+++ b/client/resource_group/controller/metrics/metrics.go
@@ -199,11 +199,12 @@ func initMetrics(constLabels prometheus.Labels) {
 			Subsystem: requestSubsystem,
 			Name:      "paging_prediction_residual_bytes",
 			// Signed residual = actual - predicted. Buckets span ±64MB to
-			// absorb large first-page responses on a cold copIterator
-			// (predicted=0) and workload shifts that leave EMA above
-			// actual. Factor-4 spacing keeps resolution near zero.
+			// absorb large first-page responses when the predictor has no
+			// prior observation (predicted=0) and workload shifts that
+			// leave the prediction above actual. Factor-4 spacing keeps
+			// resolution near zero.
 			Buckets: []float64{-67108864, -16777216, -4194304, -1048576, -262144, -65536, -16384, -4096, 0, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864},
-			Help:        "Histogram of (actual_read_bytes - predicted_read_bytes) for pre-charged requests. Shows EMA prediction accuracy.",
+			Help:        "Histogram of (actual_read_bytes - predicted_read_bytes) for pre-charged paging requests. Shows predictor accuracy.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -212,7 +213,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_nonprecharge_total",
-			Help:        "Counter of RC paging RPCs that implemented the predicted hint but reported 0 (e.g. EMA cold-start) and ran without pre-charge.",
+			Help:        "Counter of paging read RPCs where no PredictedReadBytes hint was provided (hint absent or zero). These RPCs skip pre-charge and settle entirely on actual read bytes at response time.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -221,7 +222,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_nonprecharge_actual_bytes_total",
-			Help:        "Sum of actual bytes read by paging RPCs that skipped pre-charge (hint=0). Quantifies cold-window read volume bypassing pre-charge throttling.",
+			Help:        "Sum of actual bytes read by paging RPCs that skipped pre-charge (hint absent or zero). Quantifies read volume settled without pre-charge throttling.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 }

--- a/client/resource_group/controller/metrics/metrics.go
+++ b/client/resource_group/controller/metrics/metrics.go
@@ -54,25 +54,37 @@ var (
 	// SuccessfulTokenRequestDuration comments placeholder, WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	SuccessfulTokenRequestDuration prometheus.Observer
 
-	// PagingPrechargeCounter counts paging read requests that triggered pre-charge (hint > 0).
+	// PagingPrechargeCounter counts coprocessor RPCs that triggered RC paging pre-charge
+	// (PredictedReadBytes hint > 0). Self-gated to coprocessor reads because non-cop callers
+	// never set the hint.
 	PagingPrechargeCounter *prometheus.CounterVec
-	// PagingNonprechargeCounter counts paging read requests that skipped pre-charge (hint absent or zero).
+	// PagingNonprechargeCounter counts coprocessor RPCs that reached the RC interceptor
+	// without a PredictedReadBytes hint (EMA cold-start). Explicitly gated by
+	// RequestInfo.IsCop() so non-cop reads (CmdGet, CmdBatchGet, CmdScan, internal lookups)
+	// do not pollute the metric.
 	PagingNonprechargeCounter *prometheus.CounterVec
 
-	// PagingPrechargeBytesCounter accumulates bytes used as the pre-charge basis (sum of predicted hints).
+	// PagingPrechargeBytesCounter accumulates bytes used as the RC paging pre-charge basis
+	// (sum of predicted hints from coprocessor RPCs).
 	PagingPrechargeBytesCounter *prometheus.CounterVec
-	// PagingActualBytesCounter accumulates actual bytes read by pre-charged paging requests.
+	// PagingActualBytesCounter accumulates actual bytes read by pre-charged coprocessor RPCs.
 	PagingActualBytesCounter *prometheus.CounterVec
-	// PagingNonprechargeActualBytes accumulates actual bytes read by paging requests that skipped pre-charge.
+	// PagingNonprechargeActualBytes accumulates actual bytes read by coprocessor RPCs that
+	// reached the RC interceptor without a hint (EMA cold-start). Same IsCop() gating as
+	// PagingNonprechargeCounter.
 	PagingNonprechargeActualBytes *prometheus.CounterVec
-	// PagingPredictionResidualBytes records the distribution of (actual - predicted) read bytes for pre-charged requests.
+	// PagingPredictionResidualBytes records the distribution of (actual - predicted) read
+	// bytes for pre-charged coprocessor RPCs.
 	PagingPredictionResidualBytes *prometheus.HistogramVec
 
-	// PagingPrechargeRU accumulates RU pre-acquired at BeforeKVRequest for pre-charged paging read requests.
+	// PagingPrechargeRU accumulates RU pre-acquired at BeforeKVRequest for pre-charged
+	// coprocessor RPCs.
 	PagingPrechargeRU *prometheus.CounterVec
-	// PagingSettlementRU accumulates total RU finally consumed by pre-charged paging read requests (base + CPU + bytes cost).
+	// PagingSettlementRU accumulates total RU finally consumed by pre-charged coprocessor RPCs
+	// (base + CPU + bytes cost).
 	PagingSettlementRU *prometheus.CounterVec
-	// PagingSettlementRUDelta records the distribution of per-RPC signed RU delta (settlement_ru - precharge_ru) for pre-charged paging read requests.
+	// PagingSettlementRUDelta records the distribution of per-RPC signed RU delta
+	// (settlement_ru - precharge_ru) for pre-charged coprocessor RPCs.
 	PagingSettlementRUDelta *prometheus.HistogramVec
 )
 
@@ -183,7 +195,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_precharge_total",
-			Help:        "Counter of RC paging pre-charge events (PredictedReadBytes hint present and > 0).",
+			Help:        "Counter of coprocessor RPCs that triggered RC paging pre-charge (PredictedReadBytes hint > 0).",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -192,7 +204,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_nonprecharge_total",
-			Help:        "Counter of paging read RPCs where no PredictedReadBytes hint was provided (hint absent or zero). These RPCs skip pre-charge and settle entirely on actual read bytes at response time.",
+			Help:        "Counter of coprocessor RPCs that reached the RC interceptor without a PredictedReadBytes hint (EMA cold-start). Gated on RequestInfo.IsCop() so non-cop reads do not inflate the metric. These RPCs skip pre-charge and settle on actual read bytes only.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -201,7 +213,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_precharge_bytes_total",
-			Help:        "Sum of bytes used as the RC paging pre-charge basis (predicted hint).",
+			Help:        "Sum of bytes used as the RC paging pre-charge basis (predicted hint from coprocessor RPCs).",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -210,7 +222,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_actual_bytes_total",
-			Help:        "Sum of actual bytes read by paging KV requests that were pre-charged.",
+			Help:        "Sum of actual bytes read by pre-charged coprocessor RPCs.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -219,7 +231,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_nonprecharge_actual_bytes_total",
-			Help:        "Sum of actual bytes read by paging RPCs that skipped pre-charge (hint absent or zero). Quantifies read volume settled without pre-charge throttling.",
+			Help:        "Sum of actual bytes read by coprocessor RPCs that reached the RC interceptor without a hint (EMA cold-start; IsCop()-gated). Quantifies read volume settled without pre-charge throttling.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -234,7 +246,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			// leave the prediction above actual. Factor-4 spacing keeps
 			// resolution near zero.
 			Buckets: []float64{-67108864, -16777216, -4194304, -1048576, -262144, -65536, -16384, -4096, 0, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864},
-			Help:        "Histogram of (actual_read_bytes - predicted_read_bytes) for pre-charged paging requests. Shows predictor accuracy.",
+			Help:        "Histogram of (actual_read_bytes - predicted_read_bytes) for pre-charged coprocessor RPCs. Shows predictor accuracy.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -243,7 +255,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_precharge_ru_total",
-			Help:        "Sum of RU pre-acquired at BeforeKVRequest for pre-charged paging read requests (read base cost + ReadBytesCost * predicted_bytes).",
+			Help:        "Sum of RU pre-acquired at BeforeKVRequest for pre-charged coprocessor RPCs (read base cost + ReadBytesCost * predicted_bytes).",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -252,7 +264,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   requestSubsystem,
 			Name:        "paging_settlement_ru_total",
-			Help:        "Sum of total RU finally consumed by pre-charged paging read requests (read base cost + CPUMsCost * kv_cpu_ms + ReadBytesCost * actual_bytes). Equals precharge_ru + settlement_ru_delta.",
+			Help:        "Sum of total RU finally consumed by pre-charged coprocessor RPCs (read base cost + CPUMsCost * kv_cpu_ms + ReadBytesCost * actual_bytes). Equals precharge_ru + settlement_ru_delta.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 
@@ -265,7 +277,7 @@ func initMetrics(constLabels prometheus.Labels) {
 			// Negative => flows through RefundTokens; positive => flows through RemoveTokens / acquireTokens.
 			// Factor-4 spacing over ±1024 RU covers CPU (±tens of RU) plus bytes residuals up to ±64MB.
 			Buckets:     []float64{-1024, -256, -64, -16, -4, -1, -0.25, -0.0625, 0, 0.0625, 0.25, 1, 4, 16, 64, 256, 1024},
-			Help:        "Per-RPC signed settlement RU delta (settlement_ru - precharge_ru) for pre-charged paging read requests. Negative means refund, positive means extra debit.",
+			Help:        "Per-RPC signed settlement RU delta (settlement_ru - precharge_ru) for pre-charged coprocessor RPCs. Negative means refund, positive means extra debit.",
 			ConstLabels: constLabels,
 		}, []string{newResourceGroupNameLabel})
 }

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -54,6 +54,32 @@ type RequestInfo interface {
 	AccessLocationType() AccessLocationType
 }
 
+// predictedReadBytesProvider is an optional interface that a RequestInfo
+// implementation may satisfy to supply a learned estimate (e.g., from a
+// per-logical-scan EMA maintained in TiDB) of how many bytes the request
+// will read. When present and > 0, it is used as the byte basis for RC
+// paging pre-charge; when absent or zero the request is not pre-charged
+// and will be billed in AfterKVRequest by actual read bytes only.
+//
+// Defined as an optional interface (not a method on RequestInfo) so older
+// RequestInfo implementations that have not been updated still compile;
+// they simply skip pre-charge.
+type predictedReadBytesProvider interface {
+	PredictedReadBytes() uint64
+}
+
+// estimatedReadBytes returns the byte basis used for RC paging pre-charge,
+// or 0 to skip pre-charge entirely. Only a learned PredictedReadBytes hint
+// is honored; the protocol-level paging byte cap is intentionally not
+// consulted here so the paging cap and the RU-billing pre-charge stay
+// decoupled.
+func estimatedReadBytes(req RequestInfo) uint64 {
+	if p, ok := req.(predictedReadBytesProvider); ok {
+		return p.PredictedReadBytes()
+	}
+	return 0
+}
+
 // ResponseInfo is the interface of the response information provider. A response should be
 // able to tell how many bytes it read and KV CPU cost in milliseconds.
 type ResponseInfo interface {
@@ -104,6 +130,14 @@ func (kc *KVCalculator) BeforeKVRequest(consumption *rmpb.Consumption, req Reque
 		// Read bytes could not be known before the request is executed,
 		// so we only add the base cost here.
 		consumption.RRU += float64(kc.ReadBaseCost) + float64(kc.ReadPerBatchBaseCost)*defaultAvgBatchProportion
+		// RC Paging pre-charge: pre-charge the learned read-bytes RU so that
+		// concurrent workers are throttled at BeforeKVRequest instead of all
+		// hitting AfterKVRequest settlement at once. Only applies when the
+		// caller supplies a PredictedReadBytes hint; without it the request
+		// is billed in AfterKVRequest by actual read bytes only.
+		if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
+			consumption.RRU += float64(kc.ReadBytesCost) * float64(bytesForEst)
+		}
 	}
 	if req.AccessLocationType() == AccessCrossZone {
 		if req.IsWrite() {
@@ -138,6 +172,12 @@ func (kc *KVCalculator) AfterKVRequest(consumption *rmpb.Consumption, req Reques
 	if !req.IsWrite() {
 		// For now, we can only collect the KV CPU cost for a read request.
 		kc.calculateCPUCost(consumption, res)
+		// RC Paging settlement: subtract the pre-charged bytes RU added in
+		// BeforeKVRequest so the net total (pre-charge + settlement) equals
+		// baseCost + actualCost. Must mirror the basis used there.
+		if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
+			consumption.RRU -= float64(kc.ReadBytesCost) * float64(bytesForEst)
+		}
 	} else if !res.Succeed() {
 		// If the write request is not successfully returned, we need to pay back the WRU cost.
 		kc.payBackWriteCost(consumption, req)

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -66,7 +66,13 @@ type predictedReadBytesProvider interface {
 	PredictedReadBytes() uint64
 }
 
+// estimatedReadBytes returns the predicted read-bytes hint for read requests.
+// Write requests always get 0 so paging pre-charge / settlement / metrics stay
+// gated to reads even if a future write type implements the optional interface.
 func estimatedReadBytes(req RequestInfo) uint64 {
+	if req.IsWrite() {
+		return 0
+	}
 	if p, ok := req.(predictedReadBytesProvider); ok {
 		return p.PredictedReadBytes()
 	}

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -54,25 +54,18 @@ type RequestInfo interface {
 	AccessLocationType() AccessLocationType
 }
 
-// predictedReadBytesProvider is an optional interface that a RequestInfo
-// implementation may satisfy to supply a learned estimate (e.g., from a
-// per-logical-scan EMA maintained in TiDB) of how many bytes the request
-// will read. When present and > 0, it is used as the byte basis for RC
-// paging pre-charge; when absent or zero the request is not pre-charged
-// and will be billed in AfterKVRequest by actual read bytes only.
+// predictedReadBytesProvider is an optional interface a RequestInfo may
+// satisfy to supply a read-bytes estimate. When PredictedReadBytes > 0
+// it is the byte basis for RC paging pre-charge in BeforeKVRequest and
+// settled symmetrically in AfterKVRequest; otherwise the request is
+// billed by actual read bytes at settlement only.
 //
-// Defined as an optional interface (not a method on RequestInfo) so older
-// RequestInfo implementations that have not been updated still compile;
-// they simply skip pre-charge.
+// Optional (not a method on RequestInfo) so existing implementations
+// keep compiling.
 type predictedReadBytesProvider interface {
 	PredictedReadBytes() uint64
 }
 
-// estimatedReadBytes returns the byte basis used for RC paging pre-charge,
-// or 0 to skip pre-charge entirely. Only a learned PredictedReadBytes hint
-// is honored; the protocol-level paging byte cap is intentionally not
-// consulted here so the paging cap and the RU-billing pre-charge stay
-// decoupled.
 func estimatedReadBytes(req RequestInfo) uint64 {
 	if p, ok := req.(predictedReadBytesProvider); ok {
 		return p.PredictedReadBytes()
@@ -130,11 +123,7 @@ func (kc *KVCalculator) BeforeKVRequest(consumption *rmpb.Consumption, req Reque
 		// Read bytes could not be known before the request is executed,
 		// so we only add the base cost here.
 		consumption.RRU += float64(kc.ReadBaseCost) + float64(kc.ReadPerBatchBaseCost)*defaultAvgBatchProportion
-		// RC Paging pre-charge: pre-charge the learned read-bytes RU so that
-		// concurrent workers are throttled at BeforeKVRequest instead of all
-		// hitting AfterKVRequest settlement at once. Only applies when the
-		// caller supplies a PredictedReadBytes hint; without it the request
-		// is billed in AfterKVRequest by actual read bytes only.
+		// Paging pre-charge
 		if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
 			consumption.RRU += float64(kc.ReadBytesCost) * float64(bytesForEst)
 		}
@@ -172,9 +161,7 @@ func (kc *KVCalculator) AfterKVRequest(consumption *rmpb.Consumption, req Reques
 	if !req.IsWrite() {
 		// For now, we can only collect the KV CPU cost for a read request.
 		kc.calculateCPUCost(consumption, res)
-		// RC Paging settlement: subtract the pre-charged bytes RU added in
-		// BeforeKVRequest so the net total (pre-charge + settlement) equals
-		// baseCost + actualCost. Must mirror the basis used there.
+		// Paging settlement
 		if bytesForEst := estimatedReadBytes(req); bytesForEst > 0 {
 			consumption.RRU -= float64(kc.ReadBytesCost) * float64(bytesForEst)
 		}

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -52,31 +52,20 @@ type RequestInfo interface {
 	StoreID() uint64
 	RequestSize() uint64
 	AccessLocationType() AccessLocationType
-}
-
-// predictedReadBytesProvider is an optional interface a RequestInfo may
-// satisfy to supply a read-bytes estimate. When PredictedReadBytes > 0
-// it is the byte basis for RC paging pre-charge in BeforeKVRequest and
-// settled symmetrically in AfterKVRequest; otherwise the request is
-// billed by actual read bytes at settlement only.
-//
-// Optional (not a method on RequestInfo) so existing implementations
-// keep compiling.
-type predictedReadBytesProvider interface {
+	// PredictedReadBytes returns the read-bytes hint used for RC paging
+	// pre-charge in BeforeKVRequest and settled symmetrically in
+	// AfterKVRequest. Return 0 to opt out; writes always return 0.
 	PredictedReadBytes() uint64
 }
 
 // estimatedReadBytes returns the predicted read-bytes hint for read requests.
-// Write requests always get 0 so paging pre-charge / settlement / metrics stay
-// gated to reads even if a future write type implements the optional interface.
+// Writes always return 0 so paging pre-charge / settlement / metrics stay
+// gated to reads.
 func estimatedReadBytes(req RequestInfo) uint64 {
 	if req.IsWrite() {
 		return 0
 	}
-	if p, ok := req.(predictedReadBytesProvider); ok {
-		return p.PredictedReadBytes()
-	}
-	return 0
+	return req.PredictedReadBytes()
 }
 
 // ResponseInfo is the interface of the response information provider. A response should be

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -56,6 +56,12 @@ type RequestInfo interface {
 	// pre-charge in BeforeKVRequest and settled symmetrically in
 	// AfterKVRequest. Return 0 to opt out; writes always return 0.
 	PredictedReadBytes() uint64
+	// IsCop reports whether this request targets the coprocessor endpoint
+	// (CmdCop / CmdCopStream). Only coprocessor reads participate in the
+	// paging_* accounting; point gets, batch gets, scans and other
+	// bounded-size reads bypass the paging metrics even though they may
+	// reach this controller through the same RC interceptor.
+	IsCop() bool
 }
 
 // estimatedReadBytes returns the predicted read-bytes hint for read requests.

--- a/client/resource_group/controller/testutil.go
+++ b/client/resource_group/controller/testutil.go
@@ -28,6 +28,7 @@ type TestRequestInfo struct {
 	storeID            uint64
 	accessType         AccessLocationType
 	predictedReadBytes uint64
+	isCop              bool
 }
 
 // NewTestRequestInfo creates a new TestRequestInfo.
@@ -74,6 +75,11 @@ func (tri *TestRequestInfo) AccessLocationType() AccessLocationType {
 // PredictedReadBytes implements the RequestInfo interface.
 func (tri *TestRequestInfo) PredictedReadBytes() uint64 {
 	return tri.predictedReadBytes
+}
+
+// IsCop implements the RequestInfo interface.
+func (tri *TestRequestInfo) IsCop() bool {
+	return tri.isCop
 }
 
 // TestResponseInfo is used to test the response info interface.

--- a/client/resource_group/controller/testutil.go
+++ b/client/resource_group/controller/testutil.go
@@ -71,8 +71,7 @@ func (tri *TestRequestInfo) AccessLocationType() AccessLocationType {
 	return tri.accessType
 }
 
-// PredictedReadBytes implements the optional predictedReadBytesProvider
-// interface so tests can exercise the RC paging pre-charge hint path.
+// PredictedReadBytes implements the RequestInfo interface.
 func (tri *TestRequestInfo) PredictedReadBytes() uint64 {
 	return tri.predictedReadBytes
 }

--- a/client/resource_group/controller/testutil.go
+++ b/client/resource_group/controller/testutil.go
@@ -22,11 +22,12 @@ import "time"
 
 // TestRequestInfo is used to test the request info interface.
 type TestRequestInfo struct {
-	isWrite     bool
-	writeBytes  uint64
-	numReplicas int64
-	storeID     uint64
-	accessType  AccessLocationType
+	isWrite            bool
+	writeBytes         uint64
+	numReplicas        int64
+	storeID            uint64
+	accessType         AccessLocationType
+	predictedReadBytes uint64
 }
 
 // NewTestRequestInfo creates a new TestRequestInfo.
@@ -68,6 +69,12 @@ func (tri *TestRequestInfo) RequestSize() uint64 {
 // AccessLocationType implements the AccessLocationType interface.
 func (tri *TestRequestInfo) AccessLocationType() AccessLocationType {
 	return tri.accessType
+}
+
+// PredictedReadBytes implements the optional predictedReadBytesProvider
+// interface so tests can exercise the RC paging pre-charge hint path.
+func (tri *TestRequestInfo) PredictedReadBytes() uint64 {
+	return tri.predictedReadBytes
 }
 
 // TestResponseInfo is used to test the response info interface.

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -74,6 +74,27 @@ var (
 			Name:      "active_request_unit_sum",
 			Help:      "Counter of the active request unit cost for all resource groups.",
 		}, []string{resourceGroupNameLabel, newResourceGroupNameLabel, typeLabel, keyspaceNameLabel})
+	readRequestUnitRefund = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: ruSubsystem,
+			Name:      "read_request_unit_refund_sum",
+			Help:      "Counter of the read request unit refunded for all resource groups.",
+		}, []string{resourceGroupNameLabel, newResourceGroupNameLabel, typeLabel, keyspaceNameLabel})
+	writeRequestUnitRefund = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: ruSubsystem,
+			Name:      "write_request_unit_refund_sum",
+			Help:      "Counter of the write request unit refunded for all resource groups.",
+		}, []string{resourceGroupNameLabel, newResourceGroupNameLabel, typeLabel, keyspaceNameLabel})
+	activeRequestUnitRefund = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: ruSubsystem,
+			Name:      "active_request_unit_refund_sum",
+			Help:      "Counter of the active request unit refunded for all resource groups.",
+		}, []string{resourceGroupNameLabel, newResourceGroupNameLabel, typeLabel, keyspaceNameLabel})
 
 	// RUv2 metrics (experimental v2 RU calculation, recording only).
 	requestUnitV2Cost = prometheus.NewCounterVec(
@@ -246,6 +267,9 @@ func init() {
 	prometheus.MustRegister(readRequestUnitCost)
 	prometheus.MustRegister(writeRequestUnitCost)
 	prometheus.MustRegister(activeRequestUnitCost)
+	prometheus.MustRegister(readRequestUnitRefund)
+	prometheus.MustRegister(writeRequestUnitRefund)
+	prometheus.MustRegister(activeRequestUnitRefund)
 	prometheus.MustRegister(requestUnitV2Cost)
 	prometheus.MustRegister(tikvRequestUnitV2Cost)
 	prometheus.MustRegister(tidbRequestUnitV2Cost)
@@ -355,6 +379,9 @@ type counterMetrics struct {
 	RRUMetrics                 prometheus.Counter
 	WRUMetrics                 prometheus.Counter
 	ActiveRUMetrics            prometheus.Counter
+	RRURefundMetrics           prometheus.Counter
+	WRURefundMetrics           prometheus.Counter
+	ActiveRURefundMetrics      prometheus.Counter
 	TotalRUV2Metrics           prometheus.Counter
 	TiKVRUV2Metrics            prometheus.Counter
 	TiDBRUV2Metrics            prometheus.Counter
@@ -375,6 +402,9 @@ func newCounterMetrics(keyspaceName, groupName, ruLabelType string) *counterMetr
 		RRUMetrics:                 readRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		WRUMetrics:                 writeRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		ActiveRUMetrics:            activeRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
+		RRURefundMetrics:           readRequestUnitRefund.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
+		WRURefundMetrics:           writeRequestUnitRefund.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
+		ActiveRURefundMetrics:      activeRequestUnitRefund.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		TotalRUV2Metrics:           requestUnitV2Cost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		TiKVRUV2Metrics:            tikvRequestUnitV2Cost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		TiDBRUV2Metrics:            tidbRequestUnitV2Cost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
@@ -408,17 +438,20 @@ func calculateActiveRU(consumption *rmpb.Consumption, controllerConfig *Controll
 	return consumption.RRU + consumption.WRU + calculateSQLRU(consumption, controllerConfig)
 }
 
+func addSignedCounter(value float64, debit, refund prometheus.Counter) {
+	if value > 0 {
+		debit.Add(value)
+	} else if value < 0 {
+		refund.Add(-value)
+	}
+}
+
 func (m *counterMetrics) add(consumption *rmpb.Consumption, controllerConfig *ControllerConfig, keyspaceID uint32) {
-	// RU info.
-	if consumption.RRU > 0 {
-		m.RRUMetrics.Add(consumption.RRU)
-	}
-	if consumption.WRU > 0 {
-		m.WRUMetrics.Add(consumption.WRU)
-	}
-	if activeRU := calculateActiveRU(consumption, controllerConfig, keyspaceID); activeRU > 0 {
-		m.ActiveRUMetrics.Add(activeRU)
-	}
+	// RU info. Counters are monotonic, so refunds are recorded in paired
+	// refund counters and subtracted in PromQL when displaying net RU.
+	addSignedCounter(consumption.RRU, m.RRUMetrics, m.RRURefundMetrics)
+	addSignedCounter(consumption.WRU, m.WRUMetrics, m.WRURefundMetrics)
+	addSignedCounter(calculateActiveRU(consumption, controllerConfig, keyspaceID), m.ActiveRUMetrics, m.ActiveRURefundMetrics)
 	// RUv2 info (experimental).
 	if consumption.TikvRUV2 > 0 {
 		m.TiKVRUV2Metrics.Add(consumption.TikvRUV2)
@@ -525,6 +558,9 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	readRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	writeRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	activeRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
+	readRequestUnitRefund.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
+	writeRequestUnitRefund.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
+	activeRequestUnitRefund.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	requestUnitV2Cost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	tikvRequestUnitV2Cost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	tidbRequestUnitV2Cost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -87,6 +87,37 @@ func TestActiveRequestUnitMetricUsesV2ForOverriddenKeyspace(t *testing.T) {
 	re.Equal(float64(31), testutil.ToFloat64(metrics.ActiveRUMetrics))
 }
 
+func TestCounterMetricsRecordsRequestUnitRefund(t *testing.T) {
+	re := require.New(t)
+
+	const (
+		keyspaceName = "refund-keyspace"
+		groupName    = "refund-group"
+		keyspaceID   = uint32(303)
+	)
+
+	t.Cleanup(func() {
+		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+	})
+
+	metrics := newCounterMetrics(keyspaceName, groupName, defaultTypeLabel)
+	metrics.add(&rmpb.Consumption{
+		RRU: 10,
+		WRU: 3,
+	}, &ControllerConfig{}, keyspaceID)
+	metrics.add(&rmpb.Consumption{
+		RRU: -4,
+		WRU: -1,
+	}, &ControllerConfig{}, keyspaceID)
+
+	re.Equal(float64(10), testutil.ToFloat64(metrics.RRUMetrics))
+	re.Equal(float64(4), testutil.ToFloat64(metrics.RRURefundMetrics))
+	re.Equal(float64(3), testutil.ToFloat64(metrics.WRUMetrics))
+	re.Equal(float64(1), testutil.ToFloat64(metrics.WRURefundMetrics))
+	re.Equal(float64(13), testutil.ToFloat64(metrics.ActiveRUMetrics))
+	re.Equal(float64(5), testutil.ToFloat64(metrics.ActiveRURefundMetrics))
+}
+
 func TestMaxPerSecCostTracker(t *testing.T) {
 	re := require.New(t)
 	tracker := newMaxPerSecCostTracker("test", "test", defaultCollectIntervalSec)


### PR DESCRIPTION
Draft / test-bundle PR for the `rc-precharge-classic-test` integration bundle (classic / non-Premium variant of the RC paging pre-charge feature).

## Summary
- `resource_control`: add `PredictedReadBytes` hint for RC paging pre-charge; refund excess pre-charged tokens on response settlement
- `client/resource_group`: paging pre-charge observability metrics, residual histogram (+/-64MB), read-only gating, refund-on-failed-read test, promote `PredictedReadBytes` to `RequestInfo` method, delay metrics until acquire succeeds
- `controller` / `metrics`: paging RU observability, grouped metrics with doc comments

## Sibling PRs (test bundle)
- pingcap/kvproto `rc-precharge-classic-test`
- tikv/client-go `rc-precharge-classic-test`
- pingcap/tidb `rc-precharge-classic-test`
- tikv/tikv `rc-precharge-classic-test`

This branch exists for upstream CI / cross-repo integration testing. Not intended to be merged as-is.