### PR TITLE
syncer: close failed follower streams

### DIFF
--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -486,14 +486,13 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 	sender *regionSyncStream,
 	regions *pdpb.SyncRegionResponse,
 ) bool {
-	failpoint.Inject("regionSyncerSendFail", func(val failpoint.Value) {
-		if targetName, ok := val.(string); ok && targetName == name {
-			err := errors.New("injected region sync send failure")
-			log.Warn("region syncer send data meet error", zap.String("name", name),
-				errs.ZapError(errs.ErrGRPCSend, err))
-			failpoint.Return(false)
-		}
-	})
+	var sendErr error
+	failpoint.InjectCall("regionSyncerSendFail", name, &sendErr)
+	if sendErr != nil {
+		log.Warn("region syncer send data meet error", zap.String("name", name),
+			errs.ZapError(errs.ErrGRPCSend, sendErr))
+		return false
+	}
 
 	resultCh := make(chan error, 1)
 	go func() {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -486,6 +486,15 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 	sender *regionSyncStream,
 	regions *pdpb.SyncRegionResponse,
 ) bool {
+	failpoint.Inject("regionSyncerSendFail", func(val failpoint.Value) {
+		if targetName, ok := val.(string); ok && targetName == name {
+			err := errors.New("injected region sync send failure")
+			log.Warn("region syncer send data meet error", zap.String("name", name),
+				errs.ZapError(errs.ErrGRPCSend, err))
+			failpoint.Return(false)
+		}
+	})
+
 	resultCh := make(chan error, 1)
 	go func() {
 		resultCh <- sender.stream.Send(regions)

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/docker/go-units"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -221,6 +223,13 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 			return err
 		}
 		s.bindStream(request.GetMember().GetName(), stream)
+		defer s.unbindStream(request.GetMember().GetName(), stream)
+		select {
+		case <-ctx.Done():
+			return status.Error(codes.Unavailable, "region syncer stopped")
+		case <-stream.Context().Done():
+			return nil
+		}
 	}
 }
 
@@ -354,6 +363,14 @@ func (s *RegionSyncer) bindStream(name string, stream ServerStream) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.streams[name] = stream
+}
+
+func (s *RegionSyncer) unbindStream(name string, stream ServerStream) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.streams[name] == stream {
+		delete(s.mu.streams, name)
+	}
 }
 
 func (s *RegionSyncer) broadcast(ctx context.Context, regions *pdpb.SyncRegionResponse) {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -62,6 +62,25 @@ type ServerStream interface {
 	Send(regions *pdpb.SyncRegionResponse) error
 }
 
+type regionSyncStream struct {
+	stream ServerStream
+	done   chan struct{}
+	once   sync.Once
+}
+
+func newRegionSyncStream(stream ServerStream) *regionSyncStream {
+	return &regionSyncStream{
+		stream: stream,
+		done:   make(chan struct{}),
+	}
+}
+
+func (s *regionSyncStream) close() {
+	s.once.Do(func() {
+		close(s.done)
+	})
+}
+
 // Server is the abstraction of the syncer storage server.
 type Server interface {
 	LoopContext() context.Context
@@ -78,7 +97,7 @@ type Server interface {
 type RegionSyncer struct {
 	mu struct {
 		syncutil.RWMutex
-		streams      map[string]ServerStream
+		streams      map[string]*regionSyncStream
 		clientCtx    context.Context
 		clientCancel context.CancelFunc
 	}
@@ -104,7 +123,7 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 		limit:     ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
 		tlsConfig: s.GetTLSConfig(),
 	}
-	syncer.mu.streams = make(map[string]ServerStream)
+	syncer.mu.streams = make(map[string]*regionSyncStream)
 	return syncer
 }
 
@@ -132,7 +151,10 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 	defer func() {
 		ticker.Stop()
 		s.mu.Lock()
-		s.mu.streams = make(map[string]ServerStream)
+		for _, stream := range s.mu.streams {
+			stream.close()
+		}
+		s.mu.streams = make(map[string]*regionSyncStream)
 		s.mu.Unlock()
 	}()
 
@@ -222,13 +244,15 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 		if err != nil {
 			return err
 		}
-		s.bindStream(request.GetMember().GetName(), stream)
-		defer s.unbindStream(request.GetMember().GetName(), stream)
+		syncStream := s.bindStream(request.GetMember().GetName(), stream)
+		defer s.unbindStream(request.GetMember().GetName(), syncStream)
 		select {
 		case <-ctx.Done():
 			return status.Error(codes.Unavailable, "region syncer stopped")
 		case <-stream.Context().Done():
 			return nil
+		case <-syncStream.done:
+			return status.Error(codes.Unavailable, "region syncer stream closed")
 		}
 	}
 }
@@ -359,18 +383,24 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 }
 
 // bindStream binds the established server stream.
-func (s *RegionSyncer) bindStream(name string, stream ServerStream) {
+func (s *RegionSyncer) bindStream(name string, stream ServerStream) *regionSyncStream {
+	syncStream := newRegionSyncStream(stream)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.mu.streams[name] = stream
+	if oldStream := s.mu.streams[name]; oldStream != nil {
+		oldStream.close()
+	}
+	s.mu.streams[name] = syncStream
+	return syncStream
 }
 
-func (s *RegionSyncer) unbindStream(name string, stream ServerStream) {
+func (s *RegionSyncer) unbindStream(name string, stream *regionSyncStream) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mu.streams[name] == stream {
 		delete(s.mu.streams, name)
 	}
+	stream.close()
 }
 
 func (s *RegionSyncer) broadcast(ctx context.Context, regions *pdpb.SyncRegionResponse) {
@@ -391,13 +421,13 @@ func (s *RegionSyncer) broadcast(ctx context.Context, regions *pdpb.SyncRegionRe
 		}
 
 		wg.Add(1)
-		go func(name string, sender ServerStream) {
+		go func(name string, sender *regionSyncStream) {
 			defer wg.Done()
-			err := sender.Send(regions)
+			err := sender.stream.Send(regions)
 			if err != nil {
 				log.Warn("region syncer send data meet error", zap.String("name", name),
 					errs.ZapError(errs.ErrGRPCSend, err))
-				failed.Store(name, struct{}{})
+				failed.Store(name, sender)
 			}
 		}(name, sender)
 	}
@@ -406,10 +436,14 @@ func (s *RegionSyncer) broadcast(ctx context.Context, regions *pdpb.SyncRegionRe
 	go func() {
 		wg.Wait()
 		s.mu.Lock()
-		failed.Range(func(key, _ any) bool {
+		failed.Range(func(key, value any) bool {
 			name := key.(string)
-			delete(s.mu.streams, name)
-			log.Info("region syncer delete the stream", zap.String("stream", name))
+			stream := value.(*regionSyncStream)
+			if s.mu.streams[name] == stream {
+				delete(s.mu.streams, name)
+				stream.close()
+				log.Info("region syncer delete the stream", zap.String("stream", name))
+			}
 			return true
 		})
 		s.mu.Unlock()
@@ -435,8 +469,9 @@ func (s *RegionSyncer) closeAllClient() {
 				},
 			},
 		}
-		if err := sender.Send(resp); err != nil {
+		if err := sender.stream.Send(resp); err != nil {
 			log.Warn("region syncer send close message meet error", errs.ZapError(errs.ErrGRPCSend, err))
 		}
+		sender.close()
 	}
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -101,11 +101,12 @@ type RegionSyncer struct {
 		clientCtx    context.Context
 		clientCancel context.CancelFunc
 	}
-	server    Server
-	wg        sync.WaitGroup
-	history   *historyBuffer
-	limit     *ratelimit.RateLimiter
-	tlsConfig *grpcutil.TLSConfig
+	server      Server
+	wg          sync.WaitGroup
+	history     *historyBuffer
+	limit       *ratelimit.RateLimiter
+	sendTimeout time.Duration
+	tlsConfig   *grpcutil.TLSConfig
 	// status when as client
 	streamingRunning atomic.Bool
 }
@@ -118,10 +119,11 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 		return nil
 	}
 	syncer := &RegionSyncer{
-		server:    s,
-		history:   newHistoryBuffer(defaultHistoryBufferSize, regionStorage.(kv.Base)),
-		limit:     ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
-		tlsConfig: s.GetTLSConfig(),
+		server:      s,
+		history:     newHistoryBuffer(defaultHistoryBufferSize, regionStorage.(kv.Base)),
+		limit:       ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
+		sendTimeout: syncerKeepAliveInterval,
+		tlsConfig:   s.GetTLSConfig(),
 	}
 	syncer.mu.streams = make(map[string]*regionSyncStream)
 	return syncer
@@ -219,18 +221,18 @@ func (s *RegionSyncer) GetAllDownstreamNames() []string {
 // then to sync the latest records.
 func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServer) error {
 	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-		}
-
-		request, err := stream.Recv()
+		request, err := recvSyncRegionRequest(ctx, stream)
 		if err == io.EOF {
 			return nil
 		}
 		if err != nil {
+			if _, ok := status.FromError(err); ok {
+				return err
+			}
 			return errors.WithStack(err)
+		}
+		if request == nil {
+			return nil
 		}
 		clusterID := request.GetHeader().GetClusterId()
 		if clusterID != keypath.ClusterID() {
@@ -257,6 +259,28 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 			s.unbindStream(name, syncStream)
 			return status.Error(codes.Unavailable, "region syncer stream closed")
 		}
+	}
+}
+
+type syncRegionRequestResult struct {
+	request *pdpb.SyncRegionRequest
+	err     error
+}
+
+func recvSyncRegionRequest(ctx context.Context, stream pdpb.PD_SyncRegionsServer) (*pdpb.SyncRegionRequest, error) {
+	resultCh := make(chan syncRegionRequestResult, 1)
+	go func() {
+		request, err := stream.Recv()
+		resultCh <- syncRegionRequestResult{request: request, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, status.Error(codes.Unavailable, "region syncer stopped")
+	case <-stream.Context().Done():
+		return nil, nil
+	case result := <-resultCh:
+		return result.request, result.err
 	}
 }
 
@@ -426,10 +450,7 @@ func (s *RegionSyncer) broadcast(ctx context.Context, regions *pdpb.SyncRegionRe
 		wg.Add(1)
 		go func(name string, sender *regionSyncStream) {
 			defer wg.Done()
-			err := sender.stream.Send(regions)
-			if err != nil {
-				log.Warn("region syncer send data meet error", zap.String("name", name),
-					errs.ZapError(errs.ErrGRPCSend, err))
+			if !s.sendRegionSyncResponse(ctx, name, sender, regions) {
 				failed.Store(name, sender)
 			}
 		}(name, sender)
@@ -459,10 +480,52 @@ func (s *RegionSyncer) broadcast(ctx context.Context, regions *pdpb.SyncRegionRe
 	}
 }
 
+func (s *RegionSyncer) sendRegionSyncResponse(
+	ctx context.Context,
+	name string,
+	sender *regionSyncStream,
+	regions *pdpb.SyncRegionResponse,
+) bool {
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- sender.stream.Send(regions)
+	}()
+
+	timeout := s.sendTimeout
+	if timeout <= 0 {
+		timeout = syncerKeepAliveInterval
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-resultCh:
+		if err != nil {
+			log.Warn("region syncer send data meet error", zap.String("name", name),
+				errs.ZapError(errs.ErrGRPCSend, err))
+			return false
+		}
+		return true
+	case <-ctx.Done():
+		sender.close()
+		log.Warn("region syncer send data canceled", zap.String("name", name),
+			errs.ZapError(errs.ErrGRPCSend, ctx.Err()))
+		return false
+	case <-timer.C:
+		sender.close()
+		log.Warn("region syncer send data timeout", zap.String("name", name), zap.Duration("timeout", timeout))
+		return false
+	}
+}
+
 func (s *RegionSyncer) closeAllClient() {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	streams := make([]*regionSyncStream, 0, len(s.mu.streams))
 	for _, sender := range s.mu.streams {
+		streams = append(streams, sender)
+	}
+	s.mu.RUnlock()
+	for _, sender := range streams {
 		resp := &pdpb.SyncRegionResponse{
 			Header: &pdpb.ResponseHeader{
 				ClusterId: keypath.ClusterID(),
@@ -472,9 +535,9 @@ func (s *RegionSyncer) closeAllClient() {
 				},
 			},
 		}
+		sender.close()
 		if err := sender.stream.Send(resp); err != nil {
 			log.Warn("region syncer send close message meet error", errs.ZapError(errs.ErrGRPCSend, err))
 		}
-		sender.close()
 	}
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -244,14 +244,17 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 		if err != nil {
 			return err
 		}
-		syncStream := s.bindStream(request.GetMember().GetName(), stream)
-		defer s.unbindStream(request.GetMember().GetName(), syncStream)
+		name := request.GetMember().GetName()
+		syncStream := s.bindStream(name, stream)
 		select {
 		case <-ctx.Done():
+			s.unbindStream(name, syncStream)
 			return status.Error(codes.Unavailable, "region syncer stopped")
 		case <-stream.Context().Done():
+			s.unbindStream(name, syncStream)
 			return nil
 		case <-syncStream.done:
+			s.unbindStream(name, syncStream)
 			return status.Error(codes.Unavailable, "region syncer stream closed")
 		}
 	}

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -40,7 +41,9 @@ func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 	tempDir := t.TempDir()
 	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
 	re.NoError(err)
-	defer re.NoError(regionStorage.Close())
+	defer func() {
+		re.NoError(regionStorage.Close())
+	}()
 
 	server := mockserver.NewMockServer(
 		context.Background(),
@@ -91,7 +94,9 @@ func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 	tempDir := t.TempDir()
 	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
 	re.NoError(err)
-	defer re.NoError(regionStorage.Close())
+	defer func() {
+		re.NoError(regionStorage.Close())
+	}()
 
 	server := mockserver.NewMockServer(
 		context.Background(),
@@ -143,17 +148,208 @@ func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 	re.Empty(syncer.GetAllDownstreamNames())
 }
 
+func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer func() {
+		re.NoError(regionStorage.Close())
+	}()
+
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		core.NewBasicCluster(),
+	)
+	syncer := NewRegionSyncer(server)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newMockSyncRegionsServer()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.Sync(ctx, stream)
+	}()
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name:       "pd-follower",
+			ClientUrls: []string{"http://127.0.0.1:2379"},
+		},
+	}
+	re.NotNil(<-stream.sendCh)
+	testutil.Eventually(re, func() bool {
+		names := syncer.GetAllDownstreamNames()
+		return len(names) == 1 && names[0] == "pd-follower"
+	})
+
+	unblockSend := stream.blockSend()
+	closeDone := make(chan struct{})
+	go func() {
+		syncer.closeAllClient()
+		close(closeDone)
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		if syncErr == nil {
+			select {
+			case syncErr = <-done:
+			default:
+				return false
+			}
+		}
+		st, ok := status.FromError(syncErr)
+		return ok && st.Code() == codes.Unavailable
+	})
+	re.Empty(syncer.GetAllDownstreamNames())
+
+	close(unblockSend)
+	testutil.Eventually(re, func() bool {
+		select {
+		case <-closeDone:
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer func() {
+		re.NoError(regionStorage.Close())
+	}()
+
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		core.NewBasicCluster(),
+	)
+	syncer := NewRegionSyncer(server)
+	syncer.sendTimeout = 10 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newMockSyncRegionsServer()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.Sync(ctx, stream)
+	}()
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name:       "pd-follower",
+			ClientUrls: []string{"http://127.0.0.1:2379"},
+		},
+	}
+	re.NotNil(<-stream.sendCh)
+	testutil.Eventually(re, func() bool {
+		names := syncer.GetAllDownstreamNames()
+		return len(names) == 1 && names[0] == "pd-follower"
+	})
+
+	unblockSend := stream.blockSend()
+	broadcastDone := make(chan struct{})
+	go func() {
+		syncer.broadcast(context.Background(), &pdpb.SyncRegionResponse{
+			Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+			StartIndex: syncer.history.getNextIndex(),
+		})
+		close(broadcastDone)
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+	testutil.Eventually(re, func() bool {
+		select {
+		case <-broadcastDone:
+			return true
+		default:
+			return false
+		}
+	})
+
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		if syncErr == nil {
+			select {
+			case syncErr = <-done:
+			default:
+				return false
+			}
+		}
+		st, ok := status.FromError(syncErr)
+		return ok && st.Code() == codes.Unavailable
+	})
+	re.Empty(syncer.GetAllDownstreamNames())
+	close(unblockSend)
+}
+
+func TestSyncExitsWhenContextCanceledBeforeRequest(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer func() {
+		re.NoError(regionStorage.Close())
+	}()
+
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		core.NewBasicCluster(),
+	)
+	syncer := NewRegionSyncer(server)
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := newMockSyncRegionsServer()
+	defer stream.cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.Sync(ctx, stream)
+	}()
+
+	cancel()
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		if syncErr == nil {
+			select {
+			case syncErr = <-done:
+			default:
+				return false
+			}
+		}
+		st, ok := status.FromError(syncErr)
+		return ok && st.Code() == codes.Unavailable
+	})
+}
+
 type mockSyncRegionsServer struct {
 	mu      sync.Mutex
 	ctx     context.Context
+	cancel  context.CancelFunc
 	recvCh  chan *pdpb.SyncRegionRequest
 	sendCh  chan *pdpb.SyncRegionResponse
 	sendErr error
+	blockCh chan struct{}
+	blocked chan struct{}
+	once    sync.Once
 }
 
 func newMockSyncRegionsServer() *mockSyncRegionsServer {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &mockSyncRegionsServer{
-		ctx:    context.Background(),
+		ctx:    ctx,
+		cancel: cancel,
 		recvCh: make(chan *pdpb.SyncRegionRequest),
 		sendCh: make(chan *pdpb.SyncRegionResponse, 1),
 	}
@@ -162,9 +358,19 @@ func newMockSyncRegionsServer() *mockSyncRegionsServer {
 func (s *mockSyncRegionsServer) Send(resp *pdpb.SyncRegionResponse) error {
 	s.mu.Lock()
 	err := s.sendErr
+	blockCh := s.blockCh
+	blocked := s.blocked
 	s.mu.Unlock()
 	if err != nil {
 		return err
+	}
+	if blockCh != nil {
+		if blocked != nil {
+			s.once.Do(func() {
+				close(blocked)
+			})
+		}
+		<-blockCh
 	}
 	s.sendCh <- resp
 	return nil
@@ -176,12 +382,40 @@ func (s *mockSyncRegionsServer) setSendErr(err error) {
 	s.sendErr = err
 }
 
-func (s *mockSyncRegionsServer) Recv() (*pdpb.SyncRegionRequest, error) {
-	req, ok := <-s.recvCh
-	if !ok {
-		return nil, io.EOF
+func (s *mockSyncRegionsServer) blockSend() chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blockCh = make(chan struct{})
+	s.blocked = make(chan struct{})
+	s.once = sync.Once{}
+	return s.blockCh
+}
+
+func (s *mockSyncRegionsServer) isSendBlocked() bool {
+	s.mu.Lock()
+	blocked := s.blocked
+	s.mu.Unlock()
+	if blocked == nil {
+		return false
 	}
-	return req, nil
+	select {
+	case <-blocked:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *mockSyncRegionsServer) Recv() (*pdpb.SyncRegionRequest, error) {
+	select {
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	case req, ok := <-s.recvCh:
+		if !ok {
+			return nil, io.EOF
+		}
+		return req, nil
+	}
 }
 
 func (*mockSyncRegionsServer) SetHeader(metadata.MD) error {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncer
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockserver"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/keypath"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer re.NoError(regionStorage.Close())
+
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		core.NewBasicCluster(),
+	)
+	syncer := NewRegionSyncer(server)
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := newMockSyncRegionsServer()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.Sync(ctx, stream)
+	}()
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name:       "pd-follower",
+			ClientUrls: []string{"http://127.0.0.1:2379"},
+		},
+	}
+	re.NotNil(<-stream.sendCh)
+	testutil.Eventually(re, func() bool {
+		names := syncer.GetAllDownstreamNames()
+		return len(names) == 1 && names[0] == "pd-follower"
+	})
+
+	cancel()
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		if syncErr == nil {
+			select {
+			case syncErr = <-done:
+			default:
+				return false
+			}
+		}
+		st, ok := status.FromError(syncErr)
+		return ok && st.Code() == codes.Unavailable
+	})
+	re.Empty(syncer.GetAllDownstreamNames())
+}
+
+type mockSyncRegionsServer struct {
+	ctx    context.Context
+	recvCh chan *pdpb.SyncRegionRequest
+	sendCh chan *pdpb.SyncRegionResponse
+}
+
+func newMockSyncRegionsServer() *mockSyncRegionsServer {
+	return &mockSyncRegionsServer{
+		ctx:    context.Background(),
+		recvCh: make(chan *pdpb.SyncRegionRequest),
+		sendCh: make(chan *pdpb.SyncRegionResponse, 1),
+	}
+}
+
+func (s *mockSyncRegionsServer) Send(resp *pdpb.SyncRegionResponse) error {
+	s.sendCh <- resp
+	return nil
+}
+
+func (s *mockSyncRegionsServer) Recv() (*pdpb.SyncRegionRequest, error) {
+	req, ok := <-s.recvCh
+	if !ok {
+		return nil, io.EOF
+	}
+	return req, nil
+}
+
+func (*mockSyncRegionsServer) SetHeader(metadata.MD) error {
+	return nil
+}
+
+func (*mockSyncRegionsServer) SendHeader(metadata.MD) error {
+	return nil
+}
+
+func (*mockSyncRegionsServer) SetTrailer(metadata.MD) {}
+
+func (s *mockSyncRegionsServer) Context() context.Context {
+	return s.ctx
+}
+
+func (*mockSyncRegionsServer) SendMsg(any) error {
+	return nil
+}
+
+func (*mockSyncRegionsServer) RecvMsg(any) error {
+	return nil
+}

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -16,7 +16,9 @@ package syncer
 
 import (
 	"context"
+	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -84,10 +86,69 @@ func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 	re.Empty(syncer.GetAllDownstreamNames())
 }
 
+func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer re.NoError(regionStorage.Close())
+
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		core.NewBasicCluster(),
+	)
+	syncer := NewRegionSyncer(server)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newMockSyncRegionsServer()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.Sync(ctx, stream)
+	}()
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name:       "pd-follower",
+			ClientUrls: []string{"http://127.0.0.1:2379"},
+		},
+	}
+	re.NotNil(<-stream.sendCh)
+	testutil.Eventually(re, func() bool {
+		names := syncer.GetAllDownstreamNames()
+		return len(names) == 1 && names[0] == "pd-follower"
+	})
+
+	stream.setSendErr(errors.New("send failed"))
+	syncer.broadcast(context.Background(), &pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		StartIndex: syncer.history.getNextIndex(),
+	})
+
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		if syncErr == nil {
+			select {
+			case syncErr = <-done:
+			default:
+				return false
+			}
+		}
+		st, ok := status.FromError(syncErr)
+		return ok && st.Code() == codes.Unavailable
+	})
+	re.Empty(syncer.GetAllDownstreamNames())
+}
+
 type mockSyncRegionsServer struct {
-	ctx    context.Context
-	recvCh chan *pdpb.SyncRegionRequest
-	sendCh chan *pdpb.SyncRegionResponse
+	mu      sync.Mutex
+	ctx     context.Context
+	recvCh  chan *pdpb.SyncRegionRequest
+	sendCh  chan *pdpb.SyncRegionResponse
+	sendErr error
 }
 
 func newMockSyncRegionsServer() *mockSyncRegionsServer {
@@ -99,8 +160,20 @@ func newMockSyncRegionsServer() *mockSyncRegionsServer {
 }
 
 func (s *mockSyncRegionsServer) Send(resp *pdpb.SyncRegionResponse) error {
+	s.mu.Lock()
+	err := s.sendErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
 	s.sendCh <- resp
 	return nil
+}
+
+func (s *mockSyncRegionsServer) setSendErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sendErr = err
 }
 
 func (s *mockSyncRegionsServer) Recv() (*pdpb.SyncRegionRequest, error) {

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -16,6 +16,8 @@ package syncer_test
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -222,15 +224,20 @@ func TestRegionSyncerReconnectsAfterLeaderSendFailure(t *testing.T) {
 	re.NoError(rc.HandleRegionHeartbeat(region))
 	waitRegionSynced(re, followerServer, region)
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail", `return("`+followerName+`")`))
-	sendFailEnabled := true
+	var sendFailInjected atomic.Bool
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail",
+		func(name string, err *error) {
+			if name == followerName && sendFailInjected.CompareAndSwap(false, true) {
+				*err = errors.New("injected region sync send failure")
+			}
+		},
+	))
 	defer func() {
-		if sendFailEnabled {
-			re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail"))
-		}
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail"))
 	}()
 	failedRegion := region.Clone(core.WithIncVersion(), core.SetWrittenBytes(100))
 	re.NoError(rc.HandleRegionHeartbeat(failedRegion))
+	testutil.Eventually(re, sendFailInjected.Load)
 
 	testutil.Eventually(re, func() bool {
 		for _, name := range rc.GetRegionSyncer().GetAllDownstreamNames() {
@@ -240,8 +247,6 @@ func TestRegionSyncerReconnectsAfterLeaderSendFailure(t *testing.T) {
 		}
 		return true
 	})
-	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail"))
-	sendFailEnabled = false
 
 	re.True(cluster.WaitRegionSyncerClientsReady(2))
 	testutil.Eventually(re, followerSyncer.IsRunning)

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -189,6 +189,81 @@ func TestRegionSyncer(t *testing.T) {
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/syncRegionChannelFull"))
 }
 
+func TestRegionSyncerReconnectsAfterLeaderSendFailure(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/storage/levelDBStorageFastFlush", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/storage/levelDBStorageFastFlush"))
+	}()
+
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, _ string) {
+		conf.PDServerCfg.UseRegionStorage = true
+	})
+	defer cluster.Destroy()
+	re.NoError(err)
+
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+	leaderServer := cluster.GetLeaderServer()
+	re.NoError(leaderServer.BootstrapCluster())
+	re.True(cluster.WaitRegionSyncerClientsReady(2))
+
+	followerName := cluster.GetFollower()
+	re.NotEmpty(followerName)
+	followerServer := cluster.GetServer(followerName)
+	re.NotNil(followerServer)
+	followerSyncer := followerServer.GetServer().DirectlyGetRaftCluster().GetRegionSyncer()
+	testutil.Eventually(re, followerSyncer.IsRunning)
+
+	rc := leaderServer.GetServer().GetRaftCluster()
+	region := tests.InitRegions(1)[0]
+	re.NoError(rc.HandleRegionHeartbeat(region))
+	waitRegionSynced(re, followerServer, region)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail", `return("`+followerName+`")`))
+	sendFailEnabled := true
+	defer func() {
+		if sendFailEnabled {
+			re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail"))
+		}
+	}()
+	failedRegion := region.Clone(core.WithIncVersion(), core.SetWrittenBytes(100))
+	re.NoError(rc.HandleRegionHeartbeat(failedRegion))
+
+	testutil.Eventually(re, func() bool {
+		for _, name := range rc.GetRegionSyncer().GetAllDownstreamNames() {
+			if name == followerName {
+				return false
+			}
+		}
+		return true
+	})
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/syncer/regionSyncerSendFail"))
+	sendFailEnabled = false
+
+	re.True(cluster.WaitRegionSyncerClientsReady(2))
+	testutil.Eventually(re, followerSyncer.IsRunning)
+	waitRegionSynced(re, followerServer, failedRegion)
+
+	nextRegion := failedRegion.Clone(core.WithIncVersion(), core.SetWrittenBytes(200))
+	re.NoError(rc.HandleRegionHeartbeat(nextRegion))
+	waitRegionSynced(re, followerServer, nextRegion)
+}
+
+func waitRegionSynced(re *require.Assertions, followerServer *tests.TestServer, region *core.RegionInfo) {
+	testutil.Eventually(re, func() bool {
+		r := followerServer.GetServer().GetBasicCluster().GetRegion(region.GetID())
+		if r == nil {
+			return false
+		}
+		return region.GetMeta().String() == r.GetMeta().String() &&
+			region.GetStat().String() == r.GetStat().String() &&
+			region.GetLeader().String() == r.GetLeader().String()
+	})
+}
+
 func TestFullSyncWithAddMember(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10684, ref #10666

### What is changed and how does it work?

```commit-message
Make region syncer close a failed follower stream when broadcast drops it.

Each bound follower stream now carries a close signal owned by the leader-side region syncer. When broadcast fails to send data to a follower and removes that stream from memory, it also closes the signal so the matching Sync handler returns Unavailable. The follower then observes a stream error and uses the existing reconnect path instead of waiting forever on a stream that the leader no longer tracks.

The same close signal is also used when a follower replaces an old stream and when the leader-side region syncer stops.
```

### Test result comparison

Red test on base `master` without this PR fix:

- Branch: `codex/repro-region-syncer-send-failure-master`
- Base: `upstream/master` `8cabcf154`
- Local repro commit: `fb8921ab9` only adds the integration test and a failpoint hook.
- Command: `make gotest GOTEST_ARGS='./tests/server/region_syncer -run TestRegionSyncerReconnectsAfterLeaderSendFailure -count=1 -v'`
- Result: failed at `tests/server/region_syncer/region_syncer_test.go:251`, waiting for `cluster.WaitRegionSyncerClientsReady(2)`.
- Observed logs: the leader injected a send failure, logged `region syncer send data meet error`, then logged `region syncer delete the stream [stream=pd2]`. The follower did not observe a stream error and did not reconnect.

Green test on this PR branch:

- Branch: `codex/region-syncer-close-streams`
- Command: `make gotest GOTEST_ARGS='./tests/server/region_syncer -run TestRegionSyncerReconnectsAfterLeaderSendFailure -count=1'`
- Result: passed, `ok github.com/tikv/pd/tests/server/region_syncer 11.232s`.
- Also passed: `make gotest GOTEST_ARGS='./pkg/syncer -count=1'` and targeted `make static` for `./pkg/syncer ./tests/server/region_syncer`.

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Fix a region syncer issue that could leave a follower waiting on a stream after the PD leader failed to send updates and removed the stream from memory.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream lifecycle and shutdown: stream replacements now close cleanly, stale streams are reliably removed, shutdown responses are delivered even when sends are blocked, and failures or canceled contexts correctly terminate syncs.

* **Tests**
  * Added tests validating sync shutdown, blocked-send shutdown behavior, send-failure handling, and context-canceled-before-request scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
