### PR TITLE
checker: address split scatter pending follow-ups

### DIFF
--- a/pkg/schedule/checker/checker_controller.go
+++ b/pkg/schedule/checker/checker_controller.go
@@ -131,6 +131,7 @@ func NewController(ctx context.Context, cluster sche.CheckerCluster, conf config
 func (c *Controller) PatrolRegions() {
 	c.patrolRegionContext.init(c.ctx)
 	c.patrolRegionContext.startPatrolRegionWorkers(c)
+	defer c.splitScatter.clearPendingSplitScatter()
 	defer c.patrolRegionContext.stop()
 	ticker := time.NewTicker(c.interval)
 	defer ticker.Stop()

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -63,7 +63,8 @@ type splitScatterController struct {
 	// pending maps a pending region ID to its latest split-scatter batch item.
 	// The item keeps its batch group so stale snapshots cannot mutate a newer
 	// pending entry for the same region.
-	pending map[uint64]splitScatterPendingItem
+	pending        map[uint64]splitScatterPendingItem
+	nextDispatchAt time.Time
 }
 
 func newSplitScatterController(
@@ -72,6 +73,7 @@ func newSplitScatterController(
 	opController *operator.Controller,
 	addPendingProcessedRegions func(needCheckLen bool, ids ...uint64),
 ) *splitScatterController {
+	splitScatterPendingGauge.Set(0)
 	return &splitScatterController{
 		cluster:         cluster,
 		opController:    opController,
@@ -111,17 +113,20 @@ func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []spli
 	c.pendingMu.RUnlock()
 
 	candidates := make([]splitScatterPendingItem, 0, len(pendingSnapshot))
+	missingSnapshot := make([]splitScatterPendingItem, 0)
 	for _, pending := range pendingSnapshot {
+		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			continue
+		}
 		regionID := pending.regionID
 		region := c.cluster.GetRegion(regionID)
 		if region == nil {
-			continue
-		}
-		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			missingSnapshot = append(missingSnapshot, pending)
 			continue
 		}
 		sourceRegion := c.cluster.GetRegion(pending.sourceRegionID)
 		if sourceRegion == nil {
+			missingSnapshot = append(missingSnapshot, pending)
 			continue
 		}
 		sourceVersion := uint64(0)
@@ -162,6 +167,7 @@ func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []spli
 		candidates = selected
 		c.pendingMu.Unlock()
 	}
+	c.delayMissingPendingSplitScatter(missingSnapshot, now)
 
 	if len(expiredSnapshot) > 0 {
 		attemptedExpiredCount := 0
@@ -186,6 +192,30 @@ func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []spli
 		observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
 	}
 	return candidates
+}
+
+func (c *splitScatterController) delayMissingPendingSplitScatter(missing []splitScatterPendingItem, now time.Time) {
+	if len(missing) == 0 {
+		return
+	}
+	missingCount := 0
+	c.pendingMu.Lock()
+	for _, expected := range missing {
+		pending, ok := c.pending[expected.regionID]
+		if !ok || pending.group != expected.group || !pending.expireAt.Equal(expected.expireAt) {
+			continue
+		}
+		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			continue
+		}
+		pending.retryAt = now.Add(splitScatterRetryBackoff)
+		c.pending[expected.regionID] = pending
+		missingCount++
+	}
+	c.pendingMu.Unlock()
+	if missingCount > 0 {
+		splitScatterDispatchRegionMissingCounter.Add(float64(missingCount))
+	}
 }
 
 func (c *splitScatterController) delayPendingSplitScatter(expected splitScatterPendingItem) {
@@ -250,6 +280,29 @@ func (c *splitScatterController) cleanupExpiredPendingSplitScatter() int {
 	return pendingCount
 }
 
+func (c *splitScatterController) clearPendingSplitScatter() {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	pendingCount := len(c.pending)
+	if pendingCount > 0 {
+		c.pending = make(map[uint64]splitScatterPendingItem)
+		c.updatePendingGaugeLocked()
+	}
+	c.nextDispatchAt = time.Time{}
+}
+
+func (c *splitScatterController) skipDispatchUntil(now time.Time) bool {
+	c.pendingMu.RLock()
+	defer c.pendingMu.RUnlock()
+	return !c.nextDispatchAt.IsZero() && now.Before(c.nextDispatchAt)
+}
+
+func (c *splitScatterController) delayNextDispatch(now time.Time) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	c.nextDispatchAt = now.Add(splitScatterRetryBackoff)
+}
+
 func makeSplitScatterGroup(sourceRegionID, firstNewRegionID uint64) string {
 	return fmt.Sprintf("split-scatter-%d-%d", sourceRegionID, firstNewRegionID)
 }
@@ -261,6 +314,9 @@ func (c *Controller) RecordSplitScatterBatch(sourceRegionID, sourceWaitVersion u
 
 func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceWaitVersion uint64, newRegionIDs []uint64) {
 	if len(newRegionIDs) == 0 {
+		return
+	}
+	if c.cluster.GetCheckerConfig().GetSplitScatterScheduleLimit() == 0 {
 		return
 	}
 	group := makeSplitScatterGroup(sourceRegionID, newRegionIDs[0])
@@ -317,27 +373,39 @@ func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceW
 		expireAt:          expireAt,
 	}
 	c.updatePendingGaugeLocked()
+	c.nextDispatchAt = time.Time{}
 }
 
 func (c *splitScatterController) dispatchSplitScatterRegions() {
+	now := time.Now()
+	if c.skipDispatchUntil(now) {
+		return
+	}
 	if c.cleanupExpiredPendingSplitScatter() == 0 {
 		return
 	}
 	limit := c.cluster.GetCheckerConfig().GetSplitScatterScheduleLimit()
 	if limit == 0 {
 		splitScatterDispatchDisabledCounter.Inc()
+		c.clearPendingSplitScatter()
 		return
 	}
 	running := c.opController.OperatorCount(operator.OpSplitScatter)
 	if running >= limit {
 		splitScatterDispatchScheduleLimitCounter.Inc()
 		operator.IncOperatorLimitCounter(types.SplitScatterChecker, operator.OpSplitScatter)
+		c.delayNextDispatch(now)
 		return
 	}
 	dispatchLimit := int(limit - running)
 	// Dispatch sequentially so operators added for earlier pending items in this pass
 	// are visible to later ScatterInternal calls through the running-operator delta.
-	for _, pending := range c.collectTopPendingSplitScatter(dispatchLimit) {
+	pendingItems := c.collectTopPendingSplitScatter(dispatchLimit)
+	if len(pendingItems) == 0 {
+		c.delayNextDispatch(now)
+		return
+	}
+	for _, pending := range pendingItems {
 		region := c.cluster.GetRegion(pending.regionID)
 		if region == nil {
 			splitScatterDispatchRegionMissingCounter.Inc()

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -73,7 +73,6 @@ func newSplitScatterController(
 	opController *operator.Controller,
 	addPendingProcessedRegions func(needCheckLen bool, ids ...uint64),
 ) *splitScatterController {
-	splitScatterPendingGauge.Set(0)
 	return &splitScatterController{
 		cluster:         cluster,
 		opController:    opController,
@@ -283,11 +282,8 @@ func (c *splitScatterController) cleanupExpiredPendingSplitScatter() int {
 func (c *splitScatterController) clearPendingSplitScatter() {
 	c.pendingMu.Lock()
 	defer c.pendingMu.Unlock()
-	pendingCount := len(c.pending)
-	if pendingCount > 0 {
-		c.pending = make(map[uint64]splitScatterPendingItem)
-		c.updatePendingGaugeLocked()
-	}
+	c.pending = make(map[uint64]splitScatterPendingItem)
+	c.updatePendingGaugeLocked()
 	c.nextDispatchAt = time.Time{}
 }
 

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -378,9 +378,6 @@ func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceW
 
 func (c *splitScatterController) dispatchSplitScatterRegions() {
 	now := time.Now()
-	if c.skipDispatchUntil(now) {
-		return
-	}
 	if c.cleanupExpiredPendingSplitScatter() == 0 {
 		return
 	}
@@ -388,6 +385,9 @@ func (c *splitScatterController) dispatchSplitScatterRegions() {
 	if limit == 0 {
 		splitScatterDispatchDisabledCounter.Inc()
 		c.clearPendingSplitScatter()
+		return
+	}
+	if c.skipDispatchUntil(now) {
 		return
 	}
 	running := c.opController.OperatorCount(operator.OpSplitScatter)

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -215,6 +215,7 @@ func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
 	re.Equal(3, splitScatterPendingCount(controller))
 
 	tc.SetSplitScatterScheduleLimit(0)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(splitScatterRetryBackoff))
 	disabledBefore := promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)
 	controller.dispatchSplitScatterRegions()
 

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -62,7 +62,7 @@ func TestNewSplitScatterControllerResetsPendingGauge(t *testing.T) {
 	defer cleanup()
 
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
 }
 
 func TestRecordSplitScatterBatchCollectsPendingRegions(t *testing.T) {
@@ -198,12 +198,12 @@ func TestRecordSplitScatterBatchSkipsWhenDisabled(t *testing.T) {
 
 	tc.SetSplitScatterScheduleLimit(0)
 
-	droppedBefore := metricValue(t, splitScatterPendingDroppedCounter)
+	droppedBefore := promtestutil.ToFloat64(splitScatterPendingDroppedCounter)
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
 
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingDroppedCounter)-droppedBefore)
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingDroppedCounter)-droppedBefore)
 }
 
 func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
@@ -215,13 +215,13 @@ func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
 	re.Equal(3, splitScatterPendingCount(controller))
 
 	tc.SetSplitScatterScheduleLimit(0)
-	disabledBefore := metricValue(t, splitScatterDispatchDisabledCounter)
+	disabledBefore := promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)
 	controller.dispatchSplitScatterRegions()
 
 	re.Empty(oc.GetOperators())
 	re.Equal(0, splitScatterPendingCount(controller))
-	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
-	re.Equal(float64(1), metricValue(t, splitScatterDispatchDisabledCounter)-disabledBefore)
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)-disabledBefore)
 }
 
 func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T) {
@@ -284,15 +284,15 @@ func TestCollectTopPendingDelaysMissingRegions(t *testing.T) {
 
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
 
-	missingBefore := metricValue(t, splitScatterDispatchRegionMissingCounter)
+	missingBefore := promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)
 	re.Empty(controller.collectTopPendingSplitScatter(2))
 
-	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)-missingBefore)
 	pending := splitScatterPending(t, controller, 101)
 	re.True(pending.retryAt.After(time.Now()))
 
 	re.Empty(controller.collectTopPendingSplitScatter(2))
-	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)-missingBefore)
 }
 
 func TestDispatchSplitScatterBacksOffWhenNoCandidates(t *testing.T) {

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -54,12 +54,12 @@ func (c *Controller) dispatchSplitScatterRegions() {
 	c.splitScatter.dispatchSplitScatterRegions()
 }
 
-func TestNewSplitScatterControllerResetsPendingGauge(t *testing.T) {
+func TestSplitScatterControllerCleanupResetsPendingGauge(t *testing.T) {
 	re := require.New(t)
 	splitScatterPendingGauge.Set(7)
 
 	controller, _, _, cleanup := newTestSplitScatterController(t)
-	defer cleanup()
+	cleanup()
 
 	re.Equal(0, splitScatterPendingCount(controller))
 	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
@@ -688,6 +688,7 @@ func newTestSplitScatterController(t *testing.T) (*Controller, *mockcluster.Clus
 	controller := NewController(ctx, tc, tc.GetCheckerConfig(), oc)
 
 	cleanup := func() {
+		controller.splitScatter.clearPendingSplitScatter()
 		stream.Close()
 		cancel()
 	}

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -54,6 +54,17 @@ func (c *Controller) dispatchSplitScatterRegions() {
 	c.splitScatter.dispatchSplitScatterRegions()
 }
 
+func TestNewSplitScatterControllerResetsPendingGauge(t *testing.T) {
+	re := require.New(t)
+	splitScatterPendingGauge.Set(7)
+
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+}
+
 func TestRecordSplitScatterBatchCollectsPendingRegions(t *testing.T) {
 	re := require.New(t)
 	controller, tc, _, cleanup := newTestSplitScatterController(t)
@@ -121,8 +132,10 @@ func TestDispatchSplitScatterKeepsPendingUntilSplitHeartbeat(t *testing.T) {
 
 	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
 
+	retrySplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
 	re.Empty(controller.collectTopPendingSplitScatter(2))
 	advanceSplitScatterSourceVersion(t, tc)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
 	re.ElementsMatch([]uint64{100, 101}, pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
 
 	controller.dispatchSplitScatterRegions()
@@ -151,6 +164,7 @@ func TestDispatchSplitScatterUsesRequestWaitVersionWhenCacheLags(t *testing.T) {
 	re.Equal(2, splitScatterPendingCount(controller))
 
 	advanceSplitScatterRegionVersion(t, tc, 100)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
 	controller.dispatchSplitScatterRegions()
 
 	re.NotNil(oc.GetOperator(101))
@@ -161,16 +175,10 @@ func TestDispatchSplitScatterRespectsScheduleLimit(t *testing.T) {
 	controller, tc, oc, cleanup := newTestSplitScatterController(t)
 	defer cleanup()
 
-	tc.SetSplitScatterScheduleLimit(0)
 	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
 	putSplitScatterRegion(tc, 101, "m", "t", splitScatterReportedCPUUsage)
 	putSplitScatterRegion(tc, 102, "t", "", splitScatterReportedCPUUsage)
 	advanceSplitScatterSourceVersion(t, tc)
-
-	controller.dispatchSplitScatterRegions()
-
-	re.Empty(oc.GetOperators())
-	re.Equal(3, splitScatterPendingCount(controller))
 
 	tc.SetSplitScatterScheduleLimit(1)
 	controller.dispatchSplitScatterRegions()
@@ -181,6 +189,39 @@ func TestDispatchSplitScatterRespectsScheduleLimit(t *testing.T) {
 	controller.dispatchSplitScatterRegions()
 
 	re.Len(oc.GetOperators(), 1)
+}
+
+func TestRecordSplitScatterBatchSkipsWhenDisabled(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	tc.SetSplitScatterScheduleLimit(0)
+
+	droppedBefore := metricValue(t, splitScatterPendingDroppedCounter)
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingDroppedCounter)-droppedBefore)
+}
+
+func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+	re.Equal(3, splitScatterPendingCount(controller))
+
+	tc.SetSplitScatterScheduleLimit(0)
+	disabledBefore := metricValue(t, splitScatterDispatchDisabledCounter)
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), metricValue(t, splitScatterPendingGauge))
+	re.Equal(float64(1), metricValue(t, splitScatterDispatchDisabledCounter)-disabledBefore)
 }
 
 func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T) {
@@ -234,6 +275,48 @@ func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T)
 			re.Equal(float64(0), promtestutil.ToFloat64(testCase.counter)-counterBefore)
 		})
 	}
+}
+
+func TestCollectTopPendingDelaysMissingRegions(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	missingBefore := metricValue(t, splitScatterDispatchRegionMissingCounter)
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+
+	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+	pending := splitScatterPending(t, controller, 101)
+	re.True(pending.retryAt.After(time.Now()))
+
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	re.Equal(float64(1), metricValue(t, splitScatterDispatchRegionMissingCounter)-missingBefore)
+}
+
+func TestDispatchSplitScatterBacksOffWhenNoCandidates(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	controller.dispatchSplitScatterRegions()
+
+	re.True(splitScatterNextDispatchAt(t, controller).After(time.Now()))
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+
+	retrySplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
+	controller.dispatchSplitScatterRegions()
+
+	re.NotNil(oc.GetOperator(101))
 }
 
 func TestDispatchSplitScatterRespectsScheduleDeny(t *testing.T) {
@@ -750,6 +833,30 @@ func expireSplitScatterPendingAt(t *testing.T, controller *Controller, regionID 
 	require.True(t, ok)
 	pending.expireAt = expireAt
 	controller.splitScatter.pending[regionID] = pending
+}
+
+func retrySplitScatterPendingAt(t *testing.T, controller *Controller, regionID uint64, retryAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	pending, ok := controller.splitScatter.pending[regionID]
+	require.True(t, ok)
+	pending.retryAt = retryAt
+	controller.splitScatter.pending[regionID] = pending
+}
+
+func setSplitScatterNextDispatchAt(t *testing.T, controller *Controller, nextDispatchAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	controller.splitScatter.nextDispatchAt = nextDispatchAt
+}
+
+func splitScatterNextDispatchAt(t *testing.T, controller *Controller) time.Time {
+	t.Helper()
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	return controller.splitScatter.nextDispatchAt
 }
 
 func requireInternalScatterOpsUseGroups(t *testing.T, oc *operator.Controller, scatterGroup, batchGroup string) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10592 pick from #10678

### What is changed and how does it work?

```commit-message
Backport the split-scatter pending follow-up fixes from the release-8.5 cherry-pick back to master.

Reset the process-global pending gauge when creating a split-scatter controller, avoid recording or retaining pending split-scatter entries while split-scatter scheduling is disabled, add dispatch backoff for blocked pending work, and count missing pending regions when delaying retries.

Keep the master test style by using prometheus/testutil for metric assertions.
```

### Check List

Tests

- Unit test

### Release note

```release-note
PD now avoids stale pending load-based split-scatter entries and excessive retry loops when split-scatter scheduling is disabled or pending split regions are not ready.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dispatch throttling and explicit retry delays for split-scatter scheduling; pending items with missing regions are delayed and retried later. Pending counters are initialized/reset correctly.

* **Bug Fixes**
  * Prevented recording/dispatch when scheduling is disabled and ensured pending state is cleared.
  * Improved backoff when operator limits are reached or no candidates are available; missing-region occurrences now increment a metric.

* **Tests**
  * Added coverage for pending gauge reset, disabled scheduling, missing-region retries, and dispatch backoff.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->