### PR TITLE
syncer: scale history buffer with visible memory

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -13672,7 +13672,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"sync_index\"}",
+              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=~\".*pd.*\", type=\"sync_index\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -13755,7 +13755,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"last_index\"}",
+              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=~\".*pd.*\", type=\"last_index\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -13846,14 +13846,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"last_index\"}) - min(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"sync_index\"})",
+              "expr": "max(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=~\".*pd.*\", type=\"last_index\"}) - min(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=~\".*pd.*\", type=\"sync_index\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "index gap",
               "refId": "A"
             },
             {
-              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"history_buffer_size\"}",
+              "expr": "max(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=~\".*pd.*\", type=\"history_buffer_size\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "history buffer size",

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -13798,6 +13798,172 @@
               "show": true
             }
           ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 220
+          },
+          "id": 1503,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"last_index\"}) - min(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"sync_index\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "index gap",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "History index gap",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 220
+          },
+          "id": 1504,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"history_buffer_size\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "History buffer size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
         }
       ],
       "repeat": null,

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -13672,7 +13672,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"sync_index\"}",
+              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"sync_index\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -13755,7 +13755,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"last_index\"}",
+              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"last_index\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -13808,7 +13808,7 @@
           "fill": 1,
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 24,
             "x": 0,
             "y": 220
           },
@@ -13832,17 +13832,32 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "history buffer size",
+              "color": "#E24D42",
+              "dashes": true,
+              "fill": 0,
+              "linewidth": 3
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"last_index\"}) - min(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"sync_index\"})",
+              "expr": "max(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"last_index\"}) - min(pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"sync_index\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "index gap",
               "refId": "A"
+            },
+            {
+              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", container=\"pd\", type=\"history_buffer_size\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "history buffer size",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -13850,89 +13865,6 @@
           "timeRegions": [],
           "timeShift": null,
           "title": "History index gap",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 220
-          },
-          "id": 1504,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "pd_region_syncer_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"history_buffer_size\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "History buffer size",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -36,9 +36,10 @@ const (
 
 var (
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
-	syncIndexGauge  = regionSyncerStatus.WithLabelValues("sync_index")
-	firstIndexGauge = regionSyncerStatus.WithLabelValues("first_index")
-	lastIndexGauge  = regionSyncerStatus.WithLabelValues("last_index")
+	syncIndexGauge         = regionSyncerStatus.WithLabelValues("sync_index")
+	firstIndexGauge        = regionSyncerStatus.WithLabelValues("first_index")
+	lastIndexGauge         = regionSyncerStatus.WithLabelValues("last_index")
+	historyBufferSizeGauge = regionSyncerStatus.WithLabelValues("history_buffer_size")
 )
 
 type historyBuffer struct {
@@ -85,6 +86,8 @@ func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv 
 		flushCount:   defaultFlushCount,
 	}
 	h.reload()
+	h.updateHistoryIndexMetrics()
+	h.updateHistoryBufferSizeMetric()
 	return h
 }
 
@@ -135,6 +138,7 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 		h.head = (h.head + 1) % h.size
 	}
 	h.index++
+	h.updateHistoryIndexMetrics()
 	h.flushCount--
 	if h.flushCount <= 0 {
 		h.persist()
@@ -288,6 +292,7 @@ func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	if h.capacity() > h.baseCapacity {
 		h.resizeLocked(h.baseCapacity)
 	}
+	h.updateHistoryIndexMetrics()
 }
 
 func (h *historyBuffer) getNextIndex() uint64 {
@@ -317,8 +322,6 @@ func (h *historyBuffer) reload() {
 }
 
 func (h *historyBuffer) persist() {
-	firstIndexGauge.Set(float64(h.firstIndex()))
-	lastIndexGauge.Set(float64(h.nextIndex()))
 	err := h.kv.Save(historyKey, strconv.FormatUint(h.nextIndex(), 10))
 	if err != nil {
 		log.Warn("persist history index failed", zap.Uint64("persist-index", h.nextIndex()), errs.ZapError(err))
@@ -359,6 +362,7 @@ func (h *historyBuffer) resizeLocked(newCapacity int) {
 	h.size = newCapacity + 1
 	h.head = 0
 	h.tail = keep % h.size
+	h.updateHistoryBufferSizeMetric()
 }
 
 func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
@@ -367,4 +371,13 @@ func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
 		return h.records[pos]
 	}
 	return nil
+}
+
+func (h *historyBuffer) updateHistoryIndexMetrics() {
+	firstIndexGauge.Set(float64(h.firstIndex()))
+	lastIndexGauge.Set(float64(h.nextIndex()))
+}
+
+func (h *historyBuffer) updateHistoryBufferSizeMetric() {
+	historyBufferSizeGauge.Set(float64(h.capacity()))
 }

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -51,7 +51,7 @@ func TestHistoryBufferMaxSizeFromMemory(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
+		t.Run(testCase.name, func(_ *testing.T) {
 			require.Equal(t, testCase.expected, historyBufferMaxSizeFromMemory(testCase.totalMemory))
 		})
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10692, ref #10666, ref #10668

### What is changed and how does it work?

```commit-message
Scale the region syncer history buffer size from the visible memory capacity
instead of using a fixed 10000-entry default.

The new sizing keeps 10000 entries as the minimum, allocates another 10000
entries per 4 GiB of visible memory, and caps the buffer at 100000 entries.
The visible memory source is cgroup-aware through pkg/memory.

Add unit coverage for the sizing boundaries and linear scaling behavior.
```

### Check List

- Unit test

<img width="1884" height="656" alt="image" src="https://github.com/user-attachments/assets/21abd6b9-18fe-4cf6-a669-f178be7f1a9d" />


### Release note

```release-note
Scale PD region syncer history buffer capacity with visible memory, allocating 10,000 entries per 4 GiB and capping the buffer at 100,000 entries.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * History buffer sizing now adjusts dynamically based on available system memory with sensible lower and upper bounds for better resource use and stability.

* **Observability**
  * Added a runtime metric for history buffer size and more consistent history index metrics.
  * Updated dashboard queries to better scope PD-sourced series and added a panel showing the history index gap and buffer size.

* **Tests**
  * Added unit tests validating buffer sizing across low, scaled, and upper-clamped memory scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->