### PR TITLE
chore(dashboard): update version to v9.0.0-8efaf2f7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
-	github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657
+	github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/rleungx/leakcheck v1.0.1-0.20250721100113-2eb456ffd3e3

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654 h1:ot11W01XEr
 github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654/go.mod h1:qMqVMFM+BtxbUQD8tzHKjvXF+fGHTs/YM/L8xleGgvw=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657 h1:o/epSPBAWPf4LC4qTAw/AkDRid5ejP4EOcV2CSZ06gw=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657/go.mod h1:3C4RKDXCp3OtN0EsL4Qec3/LFXyJsWITsLCmvNV3bZ4=
+github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41 h1:fIsZkvHSM2NwfoPwuR5FM6h9OdFpbK/VKwWwe35gK8U=
+github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41/go.mod h1:3C4RKDXCp3OtN0EsL4Qec3/LFXyJsWITsLCmvNV3bZ4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/scripts/dashboard-version
+++ b/scripts/dashboard-version
@@ -1,3 +1,3 @@
 # This file is updated by running scripts/update-dashboard.sh
 # Don't edit it manually
-9.0.0-e1f8338b
+9.0.0-8efaf2f7

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -482,8 +482,8 @@ github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654 h1:ot11W01XEr
 github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654/go.mod h1:qMqVMFM+BtxbUQD8tzHKjvXF+fGHTs/YM/L8xleGgvw=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657 h1:o/epSPBAWPf4LC4qTAw/AkDRid5ejP4EOcV2CSZ06gw=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657/go.mod h1:3C4RKDXCp3OtN0EsL4Qec3/LFXyJsWITsLCmvNV3bZ4=
+github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41 h1:fIsZkvHSM2NwfoPwuR5FM6h9OdFpbK/VKwWwe35gK8U=
+github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41/go.mod h1:3C4RKDXCp3OtN0EsL4Qec3/LFXyJsWITsLCmvNV3bZ4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -166,7 +166,7 @@ require (
 	github.com/pingcap/errcode v0.3.0 // indirect
 	github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 // indirect
-	github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657 // indirect
+	github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41 // indirect
 	github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -487,8 +487,8 @@ github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654 h1:ot11W01XEr
 github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654/go.mod h1:qMqVMFM+BtxbUQD8tzHKjvXF+fGHTs/YM/L8xleGgvw=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21 h1:QV6jqlfOkh8hqvEAgwBZa+4bSgO0EeKC7s5c6Luam2I=
 github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21/go.mod h1:QYnjfA95ZaMefyl1NO8oPtKeb8pYUdnDVhQgf+qdpjM=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657 h1:o/epSPBAWPf4LC4qTAw/AkDRid5ejP4EOcV2CSZ06gw=
-github.com/pingcap/tidb-dashboard v0.0.0-20260316045729-aa6178a60657/go.mod h1:3C4RKDXCp3OtN0EsL4Qec3/LFXyJsWITsLCmvNV3bZ4=
+github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41 h1:fIsZkvHSM2NwfoPwuR5FM6h9OdFpbK/VKwWwe35gK8U=
+github.com/pingcap/tidb-dashboard v0.0.0-20260424073400-8efaf2f70a41/go.mod h1:3C4RKDXCp3OtN0EsL4Qec3/LFXyJsWITsLCmvNV3bZ4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
### What problem does this PR solve?

Update TiDB Dashboard to v9.0.0-8efaf2f7.

Issue Number: Close #10699

### What is changed and how does it work?

Related tidb-dashboard release: https://github.com/pingcap/tidb-dashboard/releases/tag/v9.0.0-8efaf2f7

- Update `scripts/dashboard-version` to `9.0.0-8efaf2f7`.
- Refresh the TiDB Dashboard Go module pseudo-version in the root module, `tests/integrations`, and `tools`.

```commit-message
*: update tidb-dashboard to v9.0.0-8efaf2f7
```

### Check List

Tests

- Manual test (add detailed scripts or steps below)

```
./scripts/update-dashboard.sh v9.0.0-8efaf2f7
make pd-server
```

- No code

### Release note

```release-note
None.
```