### PR TITLE
pkg/election: cherry-pick lease keepalive metrics (#10622) + live TTL gauge (#10649) to release-8.5-20251204-v8.5.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8
+	github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21
 	github.com/pingcap/tidb-dashboard v0.0.0-20251001025619-8cfdaf48f4b1
@@ -64,6 +64,8 @@ require (
 	google.golang.org/grpc v1.62.1
 	gotest.tools/gotestsum v1.7.0
 )
+
+require github.com/kylelemons/godebug v1.1.0 // indirect
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8 h1:RiYvpna6b7GSGIIFFu6R92T/eq1KgOiK1ry6w/60x+Y=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721 h1:Y8/FeTGB0zVoJ2sRN5o/uRUC7aZjSeY8acryhX4oYFg=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -16122,7 +16122,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": null,
-          "description": "Remaining lease TTL on each instance. Sustained drops indicate keepalive renewal pressure.",
+          "description": "Live estimate of remaining lease seconds, computed at scrape time as `expireTime − now`. The value reflects the actual remaining TTL from the last known expire time rather than being frozen at the configured timeout. Sustained near-zero means the instance is on the verge of losing its lease — correlate with keepalive tick interval and request duration for root cause.",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -16162,7 +16162,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(pd_lease_local_ttl_remaining_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".+ expected primary\"}) by (job, purpose)",
+              "expr": "max(pd_lease_local_ttl_remaining_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".*expected primary.*\"}) by (job, purpose)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -16220,7 +16220,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": null,
-          "description": "Interval between consecutive lease keepalive responses.",
+          "description": "End-to-end interval between consecutive successful etcd keepalive responses, measured in the main keepalive loop outside the worker goroutine. This captures the full renewal cadence: it includes both local scheduling jitter (tick interval) and remote latency (request duration). Sustained increase means the lease is being refreshed less frequently than expected.",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -16260,7 +16260,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(pd_lease_keepalive_response_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".+ expected primary\"}[1m])) by (job, purpose, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(pd_lease_keepalive_response_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".*expected primary.*\"}[1m])) by (job, purpose, le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -16318,7 +16318,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": null,
-          "description": "Duration of etcd Lease.KeepAliveOnce requests observed by PD.",
+          "description": "Latency of individual KeepAliveOnce RPC calls to etcd, recorded for all outcomes (success, error, and canceled). Spikes in the success path point to etcd load, network saturation, or disk latency on the etcd side. If this approaches the lease TTL, renewals will start failing and the lease may expire.",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -16358,7 +16358,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(pd_lease_keepalive_request_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", result=\"success\", purpose!~\".+ expected primary\"}[1m])) by (job, purpose, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(pd_lease_keepalive_request_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", result=\"success\", purpose!~\".*expected primary.*\"}[1m])) by (job, purpose, le))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -16416,7 +16416,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": null,
-          "description": "Lease keepalive loop terminations per reason.",
+          "description": "Rate of keepalive loop stops, broken down by termination reason. `lease_expired` is critical: it means the keepalive timer fired before a renewal arrived and the PD stepped down.",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -16425,9 +16425,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 58
           },
-          "id": 1705,
+          "id": 1707,
           "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -16456,7 +16456,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(pd_lease_renewal_termination_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".+ expected primary\"}[1m])*60) by (job, purpose, reason)",
+              "expr": "sum(rate(pd_lease_renewal_termination_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".*expected primary.*\"}[1m])*60) by (job, purpose, reason)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -16487,6 +16487,104 @@
           "yaxes": [
             {
               "format": "opm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "Interval between consecutive KeepAliveOnce calls as measured by the worker loop. Expected to stay close to leaseTimeout/3. Spikes indicate local scheduling delays — CPU starvation, GC pauses, or goroutine pressure — and can combine with request latency to push the end-to-end response interval past the lease timeout.",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 1705,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(pd_lease_keepalive_tick_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".*expected primary.*\"}[1m])) by (job, purpose, le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{job}}-{{purpose}}-99%",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Lease keepalive tick interval",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -15936,6 +15936,581 @@
       ],
       "title": "GO Runtime",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 1700,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "It indicates the current leader/primary of services",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 1701,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "options": {
+            "showHeader": true
+          },
+          "tableColumn": "instance",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "service_member_role{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "A",
+              "step": 40
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Leader/Primary",
+          "transformations": [
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "fieldName": "Value",
+                    "config": {
+                      "id": "notEqual",
+                      "options": {
+                        "value": "0"
+                      }
+                    }
+                  }
+                ],
+                "type": "include",
+                "match": "all"
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "instance",
+                    "service"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {
+                  "instance": 1,
+                  "service": 0
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "The current term of Raft",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 1702,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pd_server_etcd_state{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", type=\"term\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}} - {{job}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Raft term",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "Remaining lease TTL on each instance. Sustained drops indicate keepalive renewal pressure.",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 1703,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max(pd_lease_local_ttl_remaining_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".+ expected primary\"}) by (job, purpose)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{job}}-{{purpose}}",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Lease local TTL remaining",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "Interval between consecutive lease keepalive responses.",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 1704,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(pd_lease_keepalive_response_interval_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".+ expected primary\"}[1m])) by (job, purpose, le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{job}}-{{purpose}}-99%",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Lease keepalive response interval",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "Duration of etcd Lease.KeepAliveOnce requests observed by PD.",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 1706,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(pd_lease_keepalive_request_duration_seconds_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", result=\"success\", purpose!~\".+ expected primary\"}[1m])) by (job, purpose, le))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{job}}-{{purpose}}-99%",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Lease keepalive request duration",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "description": "Lease keepalive loop terminations per reason.",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 1705,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "paceLength": 10,
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(pd_lease_renewal_termination_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", purpose!~\".+ expected primary\"}[1m])*60) by (job, purpose, reason)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{job}}-{{purpose}}-{{reason}}",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Lease renewal terminations",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "opm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "repeat": null,
+      "title": "Leader",
+      "type": "row"
     }
   ],
   "refresh": "30s",

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -25,6 +25,7 @@ var (
 	tablePrefix  = []byte{'t'}
 	metaPrefix   = []byte{'m'}
 	recordPrefix = []byte("_r")
+	indexPrefix  = []byte("_i")
 )
 
 const (
@@ -189,12 +190,32 @@ func GenerateTableKey(tableID int64) []byte {
 	return buf
 }
 
+func appendRecordKeyPrefix(buf []byte, tableID int64) []byte {
+	buf = append(buf, tablePrefix...)
+	buf = EncodeInt(buf, tableID)
+	return append(buf, recordPrefix...)
+}
+
+// GenerateRecordKeyPrefix generates a table record key prefix.
+func GenerateRecordKeyPrefix(tableID int64) []byte {
+	buf := make([]byte, 0, len(tablePrefix)+len(recordPrefix)+8)
+	return appendRecordKeyPrefix(buf, tableID)
+}
+
 // GenerateRowKey generates a row key.
 func GenerateRowKey(tableID, rowID int64) []byte {
 	buf := make([]byte, 0, len(tablePrefix)+len(recordPrefix)+8*2)
+	buf = appendRecordKeyPrefix(buf, tableID)
+	buf = EncodeInt(buf, rowID)
+	return buf
+}
+
+// GenerateIndexKey generates an index key prefix.
+func GenerateIndexKey(tableID, indexID int64) []byte {
+	buf := make([]byte, 0, len(tablePrefix)+len(indexPrefix)+8*2)
 	buf = append(buf, tablePrefix...)
 	buf = EncodeInt(buf, tableID)
-	buf = append(buf, recordPrefix...)
-	buf = EncodeInt(buf, rowID)
+	buf = append(buf, indexPrefix...)
+	buf = EncodeInt(buf, indexID)
 	return buf
 }

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -47,3 +47,20 @@ func TestTableID(t *testing.T) {
 	key = EncodeBytes([]byte("t\x80\x00\x00\x00\x00\x00\xff"))
 	re.Equal(int64(0), key.TableID())
 }
+
+func TestGenerateRecordAndIndexKeys(t *testing.T) {
+	re := require.New(t)
+	tableID := int64(42)
+	indexID := int64(7)
+
+	rowKeyPrefix := GenerateRecordKeyPrefix(tableID)
+	rowKey := GenerateRowKey(tableID, 1)
+	re.Equal(rowKeyPrefix, rowKey[:len(rowKeyPrefix)])
+	re.Equal(tableID, EncodeBytes(rowKey).TableID())
+
+	indexKey := GenerateIndexKey(tableID, indexID)
+	_, decodedIndexKey, err := DecodeBytes(EncodeBytes(indexKey))
+	re.NoError(err)
+	re.Equal(indexKey, decodedIndexKey)
+	re.Equal(tableID, EncodeBytes(indexKey).TableID())
+}

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -192,7 +192,7 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...cl
 	finalCmps = append(finalCmps, clientv3.Compare(clientv3.CreateRevision(ls.leaderKey), "=", 0))
 	resp, err := kv.NewSlowLogTxn(ls.client).
 		If(finalCmps...).
-		Then(clientv3.OpPut(ls.leaderKey, leaderData, clientv3.WithLease(newLease.ID.Load().(clientv3.LeaseID)))).
+		Then(clientv3.OpPut(ls.leaderKey, leaderData, clientv3.WithLease(newLease.GetID()))).
 		Commit()
 	log.Info("check campaign resp", zap.Any("resp", resp))
 	if err != nil {

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -38,11 +38,11 @@ const (
 // The way to gain and maintain leadership is to update and keep the lease alive continuously.
 type Lease struct {
 	// purpose is used to show what this election for
-	Purpose string
+	purpose string
 	// etcd client and lease
 	client *clientv3.Client
 	lease  clientv3.Lease
-	ID     atomic.Value // store as clientv3.LeaseID
+	id     atomic.Value // store as clientv3.LeaseID
 	// leaseTimeout and expireTime are used to control the lease's lifetime
 	leaseTimeout time.Duration
 	expireTime   atomic.Value
@@ -52,11 +52,31 @@ type Lease struct {
 // NewLease creates a new Lease instance.
 func NewLease(client *clientv3.Client, purpose string) *Lease {
 	return &Lease{
-		Purpose: purpose,
+		purpose: purpose,
 		client:  client,
 		lease:   clientv3.NewLease(client),
 		metrics: newLeaseMetrics(purpose),
 	}
+}
+
+func (l *Lease) setID(id clientv3.LeaseID) {
+	if l == nil {
+		return
+	}
+	l.id.Store(id)
+}
+
+// GetID returns the underlying etcd lease ID. It returns 0 if the lease has not
+// been granted yet.
+func (l *Lease) GetID() clientv3.LeaseID {
+	if l == nil {
+		return 0
+	}
+	loaded := l.id.Load()
+	if loaded == nil {
+		return 0
+	}
+	return loaded.(clientv3.LeaseID)
 }
 
 // Grant uses `lease.Grant` to initialize the lease and expireTime.
@@ -72,12 +92,18 @@ func (l *Lease) Grant(leaseTimeout int64) error {
 		return errs.ErrEtcdGrantLease.Wrap(err).GenWithStackByCause()
 	}
 	if cost := time.Since(start); cost > slowRequestTime {
-		log.Warn("lease grants too slow", zap.Duration("cost", cost), zap.String("purpose", l.Purpose))
+		log.Warn("lease grants too slow",
+			zap.Duration("cost", cost),
+			zap.String("purpose", l.purpose))
 	}
-	log.Info("lease granted", zap.Int64("lease-id", int64(leaseResp.ID)), zap.Int64("lease-timeout", leaseTimeout), zap.String("purpose", l.Purpose))
-	l.ID.Store(leaseResp.ID)
+	log.Info("lease granted",
+		zap.Int64("lease-id", int64(leaseResp.ID)),
+		zap.Int64("lease-timeout", leaseTimeout),
+		zap.String("purpose", l.purpose))
+	l.setID(leaseResp.ID)
 	l.leaseTimeout = time.Duration(leaseTimeout) * time.Second
 	l.expireTime.Store(start.Add(time.Duration(leaseResp.TTL) * time.Second))
+	localTTLRemaining.register(l)
 	return nil
 }
 
@@ -86,18 +112,18 @@ func (l *Lease) Close() error {
 	if l == nil {
 		return nil
 	}
+	localTTLRemaining.unregister(l)
 	// Reset expire time.
 	l.expireTime.Store(typeutil.ZeroTime)
-	l.metrics.ttlRemaining.Set(0)
 	// Try to revoke lease to make subsequent elections faster.
 	ctx, cancel := context.WithTimeout(l.client.Ctx(), revokeLeaseTimeout)
 	defer cancel()
-	var leaseID clientv3.LeaseID
-	if l.ID.Load() != nil {
-		leaseID = l.ID.Load().(clientv3.LeaseID)
-	}
+	leaseID := l.GetID()
 	if _, err := l.lease.Revoke(ctx, leaseID); err != nil {
-		log.Error("revoke lease failed", zap.String("purpose", l.Purpose), errs.ZapError(err))
+		log.Error("revoke lease failed",
+			zap.String("purpose", l.purpose),
+			zap.Int64("lease-id", int64(leaseID)),
+			errs.ZapError(err))
 	}
 	return l.lease.Close()
 }
@@ -129,7 +155,7 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3)
-	defer log.Info("lease keep alive stopped", zap.String("purpose", l.Purpose))
+	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
 		maxExpire        time.Time
@@ -150,7 +176,11 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 				// Check again to make sure the `expireTime` still needs to be updated.
 				select {
 				case <-ctx.Done():
-					log.Info("lease keep alive canceled while applying keepalive response", zap.String("purpose", l.Purpose), zap.Time("last-response-time", lastResponseTime), zap.Time("max-expire", maxExpire), zap.Error(ctx.Err()))
+					log.Info("lease keep alive canceled while applying keepalive response",
+						zap.String("purpose", l.purpose),
+						zap.Time("last-response-time", lastResponseTime),
+						zap.Time("max-expire", maxExpire),
+						zap.Error(ctx.Err()))
 					l.metrics.contextCanceled.Inc()
 					return
 				default:
@@ -166,7 +196,6 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 			}
 			// We need be careful here, see more details in the comments of Timer.Reset.
 			// https://pkg.go.dev/time@master#Timer.Reset
-			l.metrics.observeRemainingTTL(maxExpire.Sub(now))
 			timer.Reset(l.leaseTimeout)
 		case <-timer.C:
 			actualExpire := l.loadExpireTime()
@@ -174,16 +203,24 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 			// cancellation. Treat that race as a clean shutdown so we don't
 			// over-count `lease_expired`.
 			if ctx.Err() != nil {
-				log.Info("lease keep alive timed out during caller cancellation", zap.Duration("timeout-duration", l.leaseTimeout), zap.Time("actual-expire", actualExpire), zap.String("purpose", l.Purpose), zap.Error(ctx.Err()))
+				log.Info("lease keep alive timed out during caller cancellation",
+					zap.Duration("timeout-duration", l.leaseTimeout),
+					zap.Time("actual-expire", actualExpire),
+					zap.String("purpose", l.purpose),
+					zap.Error(ctx.Err()))
 				l.metrics.contextCanceled.Inc()
 				return
 			}
-			l.metrics.observeRemainingTTL(time.Until(actualExpire))
 			l.metrics.leaseExpired.Inc()
-			log.Info("keep alive lease too slow", zap.Duration("timeout-duration", l.leaseTimeout), zap.Time("actual-expire", actualExpire), zap.String("purpose", l.Purpose))
+			log.Info("keep alive lease too slow",
+				zap.Duration("timeout-duration", l.leaseTimeout),
+				zap.Time("actual-expire", actualExpire),
+				zap.String("purpose", l.purpose))
 			return
 		case <-ctx.Done():
-			log.Info("lease keep alive canceled by caller", zap.String("purpose", l.Purpose), zap.Error(ctx.Err()))
+			log.Info("lease keep alive canceled by caller",
+				zap.String("purpose", l.purpose),
+				zap.Error(ctx.Err()))
 			l.metrics.contextCanceled.Inc()
 			return
 		}
@@ -199,33 +236,61 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
-		log.Info("start lease keep alive worker", zap.Duration("interval", interval), zap.String("purpose", l.Purpose))
-		defer log.Info("stop lease keep alive worker", zap.String("purpose", l.Purpose))
-		lastTime := time.Now()
+		logger := log.With(zap.String("purpose", l.purpose),
+			zap.Int64("lease-id", int64(l.GetID())),
+			zap.Duration("interval", interval))
+		logger.Info("start lease keep alive worker")
+		defer logger.Info("stop lease keep alive worker")
+
+		// Although it's very unlikely, under extreme conditions (such as multiple `KeepAliveOnce`
+		// goroutines triggered in a short period of time) there may be race condition updates,
+		// so atomic.Value is used here.
+		var lastTime atomic.Value
+		lastTime.Store(time.Now())
 		for {
+			// Record the start time outside the later `KeepAliveOnce` goroutine
+			// to avoid being affected by the potential runtime schedule delay.
 			start := time.Now()
-			if start.Sub(lastTime) > interval*2 {
-				log.Warn("the interval between keeping alive lease is too long", zap.Time("last-time", lastTime))
-			}
-			go func(start time.Time) {
+			go func() {
 				defer logutil.LogPanic()
+
 				ctx1, cancel := context.WithTimeout(ctx, l.leaseTimeout)
 				defer cancel()
-				var leaseID clientv3.LeaseID
-				if l.ID.Load() != nil {
-					leaseID = l.ID.Load().(clientv3.LeaseID)
-				}
+				// Record the start time of the `KeepAliveOnce` request to track the request duration
+				// and calculate the tick interval between consecutive `KeepAliveOnce` requests later.
 				requestStart := time.Now()
-				res, err := l.lease.KeepAliveOnce(ctx1, leaseID)
+				lastRequestStart, _ := lastTime.Swap(requestStart).(time.Time)
+				res, err := l.lease.KeepAliveOnce(ctx1, l.GetID())
+
+				// Record the duration of the `KeepAliveOnce` request.
 				l.metrics.observeKeepAliveRequestDurationMetrics(time.Since(requestStart), err)
+				// Record the interval between the consecutive `KeepAliveOnce` requests.
+				tickInterval := requestStart.Sub(lastRequestStart)
+				l.metrics.tickInterval.Observe(tickInterval.Seconds())
+				// If the interval is too long, log a warning to indicate the potential runtime schedule delay.
+				if tickInterval > interval*2 {
+					logger.Warn("the interval between keeping alive lease is too long",
+						zap.Time("start", start),
+						zap.Time("current-time", requestStart),
+						zap.Time("last-time", lastRequestStart),
+						zap.Duration("tick-interval", tickInterval))
+				}
+
 				if err != nil {
-					log.Warn("lease keep alive failed", zap.String("purpose", l.Purpose), zap.Time("start", start), errs.ZapError(err))
+					logger.Warn("lease keep alive failed",
+						zap.Time("start", start),
+						zap.Time("current-time", requestStart),
+						errs.ZapError(err))
 					return
 				}
 				// KeepAliveOnce currently returns ErrLeaseNotFound for a non-positive
 				// TTL. Keep this as a defensive guard for mocked or custom lease
 				// implementations that may return a successful response with an invalid TTL.
 				if res.TTL <= 0 {
+					logger.Error("lease keep alive failed with an invalid ttl value received",
+						zap.Time("start", start),
+						zap.Time("current-time", requestStart),
+						zap.Int64("ttl", res.TTL))
 					l.metrics.invalidTTL.Inc()
 					return
 				}
@@ -234,15 +299,17 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 				case ch <- expire:
 				// Here we don't use `ctx1.Done()` because we want to make sure if the keep alive success, we can update the expire time.
 				case <-ctx.Done():
-					log.Info("lease keep alive once exit", zap.String("purpose", l.Purpose), zap.Time("start", start), zap.Time("expire", expire))
+					logger.Info("lease keep alive once exit",
+						zap.Time("start", start),
+						zap.Time("current-time", requestStart),
+						zap.Time("expire", expire))
 				}
-			}(start)
+			}()
 
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastTime = start
 			}
 		}
 	}()

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -46,6 +46,7 @@ type Lease struct {
 	// leaseTimeout and expireTime are used to control the lease's lifetime
 	leaseTimeout time.Duration
 	expireTime   atomic.Value
+	metrics      leaseMetrics
 }
 
 // NewLease creates a new Lease instance.
@@ -54,6 +55,7 @@ func NewLease(client *clientv3.Client, purpose string) *Lease {
 		Purpose: purpose,
 		client:  client,
 		lease:   clientv3.NewLease(client),
+		metrics: newLeaseMetrics(purpose),
 	}
 }
 
@@ -86,6 +88,7 @@ func (l *Lease) Close() error {
 	}
 	// Reset expire time.
 	l.expireTime.Store(typeutil.ZeroTime)
+	l.metrics.ttlRemaining.Set(0)
 	// Try to revoke lease to make subsequent elections faster.
 	ctx, cancel := context.WithTimeout(l.client.Ctx(), revokeLeaseTimeout)
 	defer cancel()
@@ -102,10 +105,18 @@ func (l *Lease) Close() error {
 // IsExpired checks if the lease is expired. If it returns true,
 // current leader should step down and try to re-elect again.
 func (l *Lease) IsExpired() bool {
-	if l == nil || l.expireTime.Load() == nil {
-		return true
+	return time.Now().After(l.loadExpireTime())
+}
+
+func (l *Lease) loadExpireTime() time.Time {
+	if l == nil {
+		return typeutil.ZeroTime
 	}
-	return time.Now().After(l.expireTime.Load().(time.Time))
+	expireTime, ok := l.expireTime.Load().(time.Time)
+	if !ok {
+		return typeutil.ZeroTime
+	}
+	return expireTime
 }
 
 // KeepAlive auto renews the lease and update expireTime.
@@ -120,17 +131,27 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3)
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.Purpose))
 
-	var maxExpire time.Time
+	var (
+		maxExpire        time.Time
+		lastResponseTime time.Time
+	)
 	timer := time.NewTimer(l.leaseTimeout)
 	defer timer.Stop()
 	for {
 		select {
 		case t := <-timeCh:
+			now := time.Now()
+			if !lastResponseTime.IsZero() {
+				l.metrics.responseInterval.Observe(now.Sub(lastResponseTime).Seconds())
+			}
+			lastResponseTime = now
 			if t.After(maxExpire) {
 				maxExpire = t
 				// Check again to make sure the `expireTime` still needs to be updated.
 				select {
 				case <-ctx.Done():
+					log.Info("lease keep alive canceled while applying keepalive response", zap.String("purpose", l.Purpose), zap.Time("last-response-time", lastResponseTime), zap.Time("max-expire", maxExpire), zap.Error(ctx.Err()))
+					l.metrics.contextCanceled.Inc()
 					return
 				default:
 					l.expireTime.Store(t)
@@ -145,11 +166,25 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 			}
 			// We need be careful here, see more details in the comments of Timer.Reset.
 			// https://pkg.go.dev/time@master#Timer.Reset
+			l.metrics.observeRemainingTTL(maxExpire.Sub(now))
 			timer.Reset(l.leaseTimeout)
 		case <-timer.C:
-			log.Info("keep alive lease too slow", zap.Duration("timeout-duration", l.leaseTimeout), zap.Time("actual-expire", l.expireTime.Load().(time.Time)), zap.String("purpose", l.Purpose))
+			actualExpire := l.loadExpireTime()
+			// The keepalive timeout can fire concurrently with a caller-initiated
+			// cancellation. Treat that race as a clean shutdown so we don't
+			// over-count `lease_expired`.
+			if ctx.Err() != nil {
+				log.Info("lease keep alive timed out during caller cancellation", zap.Duration("timeout-duration", l.leaseTimeout), zap.Time("actual-expire", actualExpire), zap.String("purpose", l.Purpose), zap.Error(ctx.Err()))
+				l.metrics.contextCanceled.Inc()
+				return
+			}
+			l.metrics.observeRemainingTTL(time.Until(actualExpire))
+			l.metrics.leaseExpired.Inc()
+			log.Info("keep alive lease too slow", zap.Duration("timeout-duration", l.leaseTimeout), zap.Time("actual-expire", actualExpire), zap.String("purpose", l.Purpose))
 			return
 		case <-ctx.Done():
+			log.Info("lease keep alive canceled by caller", zap.String("purpose", l.Purpose), zap.Error(ctx.Err()))
+			l.metrics.contextCanceled.Inc()
 			return
 		}
 	}
@@ -180,20 +215,26 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 				if l.ID.Load() != nil {
 					leaseID = l.ID.Load().(clientv3.LeaseID)
 				}
+				requestStart := time.Now()
 				res, err := l.lease.KeepAliveOnce(ctx1, leaseID)
+				l.metrics.observeKeepAliveRequestDurationMetrics(time.Since(requestStart), err)
 				if err != nil {
 					log.Warn("lease keep alive failed", zap.String("purpose", l.Purpose), zap.Time("start", start), errs.ZapError(err))
 					return
 				}
-				if res.TTL > 0 {
-					expire := start.Add(time.Duration(res.TTL) * time.Second)
-					select {
-					case ch <- expire:
-					// Here we don't use `ctx1.Done()` because we want to make sure if the keep alive success, we can update the expire time.
-					case <-ctx.Done():
-					}
-				} else {
-					log.Error("keep alive response ttl is zero", zap.String("purpose", l.Purpose))
+				// KeepAliveOnce currently returns ErrLeaseNotFound for a non-positive
+				// TTL. Keep this as a defensive guard for mocked or custom lease
+				// implementations that may return a successful response with an invalid TTL.
+				if res.TTL <= 0 {
+					l.metrics.invalidTTL.Inc()
+					return
+				}
+				expire := start.Add(time.Duration(res.TTL) * time.Second)
+				select {
+				case ch <- expire:
+				// Here we don't use `ctx1.Done()` because we want to make sure if the keep alive success, we can update the expire time.
+				case <-ctx.Done():
+					log.Info("lease keep alive once exit", zap.String("purpose", l.Purpose), zap.Time("start", start), zap.Time("expire", expire))
 				}
 			}(start)
 

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -21,7 +21,27 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
 )
+
+func TestLoadExpireTime(t *testing.T) {
+	re := require.New(t)
+
+	var nilLease *Lease
+	re.Equal(typeutil.ZeroTime, nilLease.loadExpireTime())
+
+	emptyLease := &Lease{}
+	re.Equal(typeutil.ZeroTime, emptyLease.loadExpireTime())
+
+	invalidLease := &Lease{}
+	invalidLease.expireTime.Store("invalid expire time")
+	re.Equal(typeutil.ZeroTime, invalidLease.loadExpireTime())
+
+	expireTime := time.Now()
+	validLease := &Lease{}
+	validLease.expireTime.Store(expireTime)
+	re.Equal(expireTime, validLease.loadExpireTime())
+}
 
 func TestLease(t *testing.T) {
 	re := require.New(t)

--- a/pkg/election/metrics.go
+++ b/pkg/election/metrics.go
@@ -1,0 +1,138 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace    = "pd"
+	metricsSubsystem    = "lease"
+	metricsLabelPurpose = "purpose"
+	metricsLabelReason  = "reason"
+	metricsLabelResult  = "result"
+)
+
+const (
+	reasonInvalidTTL      = "invalid_ttl"
+	reasonLeaseExpired    = "lease_expired"
+	reasonContextCanceled = "context_canceled"
+
+	metricsResultSuccess  = "success"
+	metricsResultError    = "error"
+	metricsResultCanceled = "canceled"
+)
+
+var (
+	keepAliveResponseInterval = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "keepalive_response_interval_seconds",
+			Help:      "Interval between consecutive valid lease keepalive responses received from etcd, by purpose.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 16),
+		},
+		[]string{metricsLabelPurpose},
+	)
+
+	renewalTerminationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "renewal_termination_total",
+			Help:      "Number of lease renewal stop or anomaly events, broken down by purpose and reason. Reason `context_canceled` is benign (caller-initiated shutdown); `lease_expired` indicates keepalive timeout; `invalid_ttl` indicates a successful keepalive response with non-positive TTL.",
+		},
+		[]string{metricsLabelPurpose, metricsLabelReason},
+	)
+
+	localTTLRemaining = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "local_ttl_remaining_seconds",
+			Help:      "PD local estimate of remaining lease TTL, updated on every keepalive response and on keepalive timeout firing; not etcd authoritative TTL.",
+		},
+		[]string{metricsLabelPurpose},
+	)
+
+	keepAliveRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "keepalive_request_duration_seconds",
+			Help:      "Duration of etcd Lease.KeepAliveOnce requests observed by PD, by purpose and result.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 16),
+		},
+		[]string{metricsLabelPurpose, metricsLabelResult},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(keepAliveResponseInterval)
+	prometheus.MustRegister(renewalTerminationTotal)
+	prometheus.MustRegister(localTTLRemaining)
+	prometheus.MustRegister(keepAliveRequestDuration)
+}
+
+type leaseMetrics struct {
+	responseInterval                prometheus.Observer
+	ttlRemaining                    prometheus.Gauge
+	keepAliveRequestSuccessLatency  prometheus.Observer
+	keepAliveRequestErrorLatency    prometheus.Observer
+	keepAliveRequestCanceledLatency prometheus.Observer
+	invalidTTL                      prometheus.Counter
+	leaseExpired                    prometheus.Counter
+	contextCanceled                 prometheus.Counter
+}
+
+func newLeaseMetrics(purpose string) leaseMetrics {
+	return leaseMetrics{
+		responseInterval:                keepAliveResponseInterval.WithLabelValues(purpose),
+		ttlRemaining:                    localTTLRemaining.WithLabelValues(purpose),
+		keepAliveRequestSuccessLatency:  keepAliveRequestDuration.WithLabelValues(purpose, metricsResultSuccess),
+		keepAliveRequestErrorLatency:    keepAliveRequestDuration.WithLabelValues(purpose, metricsResultError),
+		keepAliveRequestCanceledLatency: keepAliveRequestDuration.WithLabelValues(purpose, metricsResultCanceled),
+		invalidTTL:                      renewalTerminationTotal.WithLabelValues(purpose, reasonInvalidTTL),
+		leaseExpired:                    renewalTerminationTotal.WithLabelValues(purpose, reasonLeaseExpired),
+		contextCanceled:                 renewalTerminationTotal.WithLabelValues(purpose, reasonContextCanceled),
+	}
+}
+
+// observeRemainingTTL records the lease's remaining TTL into the gauge,
+// clamping non-positive durations (already expired) to 0.
+func (m leaseMetrics) observeRemainingTTL(remaining time.Duration) {
+	seconds := remaining.Seconds()
+	if seconds < 0 {
+		seconds = 0
+	}
+	m.ttlRemaining.Set(seconds)
+}
+
+func (m leaseMetrics) observeKeepAliveRequestDurationMetrics(duration time.Duration, err error) {
+	if err == nil {
+		m.keepAliveRequestSuccessLatency.Observe(duration.Seconds())
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		m.keepAliveRequestCanceledLatency.Observe(duration.Seconds())
+		return
+	}
+	m.keepAliveRequestErrorLatency.Observe(duration.Seconds())
+}

--- a/pkg/election/metrics.go
+++ b/pkg/election/metrics.go
@@ -17,9 +17,14 @@ package election
 import (
 	"context"
 	"errors"
+	"maps"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/pingcap/log"
 )
 
 const (
@@ -38,9 +43,19 @@ const (
 	metricsResultSuccess  = "success"
 	metricsResultError    = "error"
 	metricsResultCanceled = "canceled"
+
+	// Per-Lease GaugeFunc registered at Grant time computes time.Until(expireTime)
+	// on every scrape, so the metric reflects the actual decay of the lease
+	// between renewals instead of being frozen at TTL.
+	localTTLRemainingName = "local_ttl_remaining_seconds"
+	localTTLRemainingHelp = "PD local estimate of remaining lease TTL, computed at scrape time as time.Until(expireTime), clamped to 0."
 )
 
 var (
+	// keepAliveLatencyBuckets is shared by histograms that measure
+	// etcd lease-operation latencies in the 10 ms–40 s range.
+	keepAliveLatencyBuckets = prometheus.ExponentialBuckets(0.01, 2, 13)
+
 	keepAliveResponseInterval = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
@@ -62,26 +77,29 @@ var (
 		[]string{metricsLabelPurpose, metricsLabelReason},
 	)
 
-	localTTLRemaining = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
-			Name:      "local_ttl_remaining_seconds",
-			Help:      "PD local estimate of remaining lease TTL, updated on every keepalive response and on keepalive timeout firing; not etcd authoritative TTL.",
-		},
-		[]string{metricsLabelPurpose},
-	)
-
 	keepAliveRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "keepalive_request_duration_seconds",
 			Help:      "Duration of etcd Lease.KeepAliveOnce requests observed by PD, by purpose and result.",
-			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 16),
+			Buckets:   keepAliveLatencyBuckets,
 		},
 		[]string{metricsLabelPurpose, metricsLabelResult},
 	)
+
+	keepAliveTickInterval = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "keepalive_tick_interval_seconds",
+			Help:      "Interval between consecutive KeepAliveOnce call start times, observed inside each worker goroutine by purpose. Spikes indicate local scheduling delay (CPU starvation, GC pauses, goroutine pressure) and correlate with the `the interval between keeping alive lease is too long` warning.",
+			Buckets:   keepAliveLatencyBuckets,
+		},
+		[]string{metricsLabelPurpose},
+	)
+
+	localTTLRemaining = newLocalTTLRemainingCollector()
 )
 
 func init() {
@@ -89,14 +107,15 @@ func init() {
 	prometheus.MustRegister(renewalTerminationTotal)
 	prometheus.MustRegister(localTTLRemaining)
 	prometheus.MustRegister(keepAliveRequestDuration)
+	prometheus.MustRegister(keepAliveTickInterval)
 }
 
 type leaseMetrics struct {
 	responseInterval                prometheus.Observer
-	ttlRemaining                    prometheus.Gauge
 	keepAliveRequestSuccessLatency  prometheus.Observer
 	keepAliveRequestErrorLatency    prometheus.Observer
 	keepAliveRequestCanceledLatency prometheus.Observer
+	tickInterval                    prometheus.Observer
 	invalidTTL                      prometheus.Counter
 	leaseExpired                    prometheus.Counter
 	contextCanceled                 prometheus.Counter
@@ -105,24 +124,107 @@ type leaseMetrics struct {
 func newLeaseMetrics(purpose string) leaseMetrics {
 	return leaseMetrics{
 		responseInterval:                keepAliveResponseInterval.WithLabelValues(purpose),
-		ttlRemaining:                    localTTLRemaining.WithLabelValues(purpose),
 		keepAliveRequestSuccessLatency:  keepAliveRequestDuration.WithLabelValues(purpose, metricsResultSuccess),
 		keepAliveRequestErrorLatency:    keepAliveRequestDuration.WithLabelValues(purpose, metricsResultError),
 		keepAliveRequestCanceledLatency: keepAliveRequestDuration.WithLabelValues(purpose, metricsResultCanceled),
+		tickInterval:                    keepAliveTickInterval.WithLabelValues(purpose),
 		invalidTTL:                      renewalTerminationTotal.WithLabelValues(purpose, reasonInvalidTTL),
 		leaseExpired:                    renewalTerminationTotal.WithLabelValues(purpose, reasonLeaseExpired),
 		contextCanceled:                 renewalTerminationTotal.WithLabelValues(purpose, reasonContextCanceled),
 	}
 }
 
-// observeRemainingTTL records the lease's remaining TTL into the gauge,
-// clamping non-positive durations (already expired) to 0.
-func (m leaseMetrics) observeRemainingTTL(remaining time.Duration) {
-	seconds := remaining.Seconds()
-	if seconds < 0 {
-		seconds = 0
+// localTTLRemainingCollector is a custom Prometheus collector that emits the
+// remaining lease TTL per lease purpose at scrape time. Computing the value
+// lazily means the curve naturally decays between renewals instead of being
+// frozen at the configured TTL.
+type localTTLRemainingCollector struct {
+	desc   *prometheus.Desc
+	mu     sync.Mutex
+	leases map[string]*Lease // purpose -> active Lease
+}
+
+func newLocalTTLRemainingCollector() *localTTLRemainingCollector {
+	return &localTTLRemainingCollector{
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(metricsNamespace, metricsSubsystem, localTTLRemainingName),
+			localTTLRemainingHelp,
+			[]string{metricsLabelPurpose},
+			nil,
+		),
+		leases: make(map[string]*Lease),
 	}
-	m.ttlRemaining.Set(seconds)
+}
+
+func (c *localTTLRemainingCollector) register(l *Lease) {
+	c.mu.Lock()
+	existing, ok := c.leases[l.purpose]
+	if !ok {
+		c.leases[l.purpose] = l
+	}
+	c.mu.Unlock()
+
+	leaseID := int64(l.GetID())
+	if ok {
+		log.Warn("skipped registering a duplicate lease to the metrics collector",
+			zap.String("purpose", l.purpose),
+			zap.Int64("existing-lease-id", int64(existing.GetID())),
+			zap.Int64("new-lease-id", leaseID))
+	} else {
+		log.Info("registered a new lease to the metrics collector",
+			zap.String("purpose", l.purpose),
+			zap.Int64("lease-id", leaseID))
+	}
+}
+
+// unregister removes l only if it is the current registered lease for that
+// purpose. This guards against the race where a new Lease has already taken
+// over the slot before the old one's Close() runs.
+func (c *localTTLRemainingCollector) unregister(l *Lease) {
+	var deleted bool
+	c.mu.Lock()
+	if c.leases[l.purpose] == l {
+		deleted = true
+		delete(c.leases, l.purpose)
+	}
+	existing, ok := c.leases[l.purpose]
+	c.mu.Unlock()
+	leaseID := int64(l.GetID())
+	if deleted {
+		log.Info("unregistered a lease from the metrics collector",
+			zap.String("purpose", l.purpose),
+			zap.Int64("lease-id", leaseID))
+	} else if ok {
+		log.Warn("skipped unregistering a different lease from the metrics collector",
+			zap.String("purpose", l.purpose),
+			zap.Int64("existing-lease-id", int64(existing.GetID())),
+			zap.Int64("lease-id", leaseID))
+	} else {
+		log.Warn("skipped unregistering a non-existent lease from the metrics collector",
+			zap.String("purpose", l.purpose),
+			zap.Int64("lease-id", leaseID))
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *localTTLRemainingCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+// Collect implements prometheus.Collector.
+func (c *localTTLRemainingCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.Lock()
+	snapshot := make(map[string]*Lease, len(c.leases))
+	maps.Copy(snapshot, c.leases)
+	c.mu.Unlock()
+	now := time.Now()
+	for purpose, l := range snapshot {
+		remaining := l.loadExpireTime().Sub(now).Seconds()
+		if remaining < 0 {
+			remaining = 0
+		}
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, remaining, purpose)
+	}
 }
 
 func (m leaseMetrics) observeKeepAliveRequestDurationMetrics(duration time.Duration, err error) {

--- a/pkg/election/metrics_test.go
+++ b/pkg/election/metrics_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package election
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func newTestLease(purpose string, id int64) *Lease {
+	l := &Lease{purpose: purpose}
+	l.setID(clientv3.LeaseID(id))
+	return l
+}
+
+func TestLocalTTLRemainingCollector(t *testing.T) {
+	re := require.New(t)
+
+	collector := newLocalTTLRemainingCollector()
+	re.NotNil(collector)
+	re.Empty(collector.leases)
+
+	// Register a new lease.
+	lease1 := newTestLease("test1", 1)
+	collector.register(lease1)
+	re.Len(collector.leases, 1)
+	// Register a duplicate lease.
+	collector.register(lease1)
+	re.Len(collector.leases, 1)
+	// Register a new lease with a different purpose.
+	lease2 := newTestLease("test2", 2)
+	collector.register(lease2)
+	re.Len(collector.leases, 2)
+	// Unregister a non-existent lease.
+	lease3 := newTestLease("test3", 3)
+	collector.unregister(lease3)
+	re.Len(collector.leases, 2)
+	// Unregister a different lease with the same purpose as the existing one.
+	collector.unregister(newTestLease("test1", 1))
+	re.Len(collector.leases, 2)
+	// Unregister exact the same lease as the existing one.
+	collector.unregister(lease1)
+	re.Len(collector.leases, 1)
+	collector.unregister(lease2)
+	re.Empty(collector.leases)
+}

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -309,7 +309,7 @@ func (s *Server) startServer() (err error) {
 		Id:         uniqueID, // id is unique among all participants
 		ListenUrls: []string{s.cfg.GetAdvertiseListenAddr()},
 	}
-	s.participant.InitInfo(p, keypath.ResourceManagerSvcRootPath(), constant.PrimaryKey, "primary election")
+	s.participant.InitInfo(p, keypath.ResourceManagerSvcRootPath(), constant.PrimaryKey, constant.ResourceManagerServiceName+" primary election")
 
 	s.service = &Service{
 		ctx:     s.Context(),

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -340,6 +340,11 @@ func (o *PersistConfig) IsPlacementRulesEnabled() bool {
 	return o.GetReplicationConfig().EnablePlacementRules
 }
 
+// GetSplitScatterScheduleLimit returns the limit for split-scatter schedule.
+func (o *PersistConfig) GetSplitScatterScheduleLimit() uint64 {
+	return o.getTTLUintOr(sc.SplitScatterScheduleLimitKey, o.GetScheduleConfig().SplitScatterScheduleLimit)
+}
+
 // GetLowSpaceRatio returns the low space ratio.
 func (o *PersistConfig) GetLowSpaceRatio() float64 {
 	return o.GetScheduleConfig().LowSpaceRatio

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -326,6 +326,9 @@ func (s *Service) AskBatchSplit(_ context.Context, request *schedulingpb.AskBatc
 	// status may be left, and these regions need to be checked with higher
 	// priority.
 	c.GetCoordinator().GetCheckerController().AddPendingProcessedRegions(false, recordRegions...)
+	// TODO(split-scatter): if load-based split-scatter is supported on the
+	// scheduling-service/NEXT_GEN path, record split-scatter batches here and
+	// plumb SplitReason through the forwarding request.
 
 	return &schedulingpb.AskBatchSplitResponse{
 		Header: wrapHeader(),

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -458,7 +458,7 @@ func (s *Server) startServer() (err error) {
 		Id:         uniqueID, // id is unique among all participants
 		ListenUrls: []string{s.cfg.GetAdvertiseListenAddr()},
 	}
-	s.participant.InitInfo(p, keypath.SchedulingSvcRootPath(), constant.PrimaryKey, "primary election")
+	s.participant.InitInfo(p, keypath.SchedulingSvcRootPath(), constant.PrimaryKey, constant.SchedulingServiceName+" primary election")
 
 	s.service = &Service{Server: s}
 	s.AddServiceReadyCallback(s.startCluster)

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -86,7 +86,7 @@ func KeepExpectedPrimaryAlive(ctx context.Context, cli *clientv3.Client, exitPri
 		return nil, err
 	}
 
-	revision, err := markExpectedPrimaryFlag(cli, leaderPath, memberValue, lease.ID.Load().(clientv3.LeaseID))
+	revision, err := markExpectedPrimaryFlag(cli, leaderPath, memberValue, lease.GetID())
 	if err != nil {
 		log.Error("mark expected primary error", errs.ZapError(err))
 		return nil, err

--- a/pkg/schedule/checker/checker_controller.go
+++ b/pkg/schedule/checker/checker_controller.go
@@ -72,6 +72,7 @@ type Controller struct {
 	mergeChecker            *MergeChecker
 	jointStateChecker       *JointStateChecker
 	priorityInspector       *PriorityInspector
+	splitScatter            *splitScatterController
 	pendingProcessedRegions *cache.TTLUint64
 	suspectKeyRanges        *cache.TTLString // suspect key-range regions that may need fix
 	patrolRegionContext     *PatrolRegionContext
@@ -96,7 +97,7 @@ type Controller struct {
 // NewController create a new Controller.
 func NewController(ctx context.Context, cluster sche.CheckerCluster, conf config.CheckerConfigProvider, ruleManager *placement.RuleManager, labeler *labeler.RegionLabeler, opController *operator.Controller) *Controller {
 	pendingProcessedRegions := cache.NewIDTTL(ctx, time.Minute, 3*time.Minute)
-	return &Controller{
+	c := &Controller{
 		ctx:                     ctx,
 		cluster:                 cluster,
 		conf:                    conf,
@@ -114,6 +115,8 @@ func NewController(ctx context.Context, cluster sche.CheckerCluster, conf config
 		interval:                cluster.GetCheckerConfig().GetPatrolRegionInterval(),
 		patrolRegionScanLimit:   calculateScanLimit(cluster),
 	}
+	c.splitScatter = newSplitScatterController(ctx, cluster, opController, c.AddPendingProcessedRegions)
+	return c
 }
 
 // PatrolRegions is used to scan regions.
@@ -151,6 +154,8 @@ func (c *Controller) PatrolRegions() {
 			c.checkPriorityRegions()
 			// Check pending processed regions first.
 			c.checkPendingProcessedRegions()
+
+			c.splitScatter.dispatchSplitScatterRegions()
 
 			key, regions = c.checkRegions(key)
 			if len(regions) == 0 {

--- a/pkg/schedule/checker/metrics.go
+++ b/pkg/schedule/checker/metrics.go
@@ -39,23 +39,55 @@ var (
 			Name:      "patrol_regions_time",
 			Help:      "Time spent of patrol checks region.",
 		})
+
+	splitScatterPendingExpiredCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "checker",
+			Name:      "split_scatter_pending_expired_total",
+			Help:      "Counter of expired split-scatter pending entries by whether they were selected for dispatch.",
+		}, []string{"attempted"})
+	splitScatterPendingDroppedCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "checker",
+			Name:      "split_scatter_pending_dropped_total",
+			Help:      "Counter of split-scatter pending entries dropped by the capacity limit.",
+		})
+	splitScatterPendingGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "checker",
+			Name:      "split_scatter_pending",
+			Help:      "Number of split-scatter pending entries.",
+		})
+)
+
+// WithLabelValues is a heavy operation, pre-cache the label handles.
+var (
+	splitScatterPendingExpiredAttemptedCounter   = splitScatterPendingExpiredCounter.WithLabelValues("true")
+	splitScatterPendingExpiredUnattemptedCounter = splitScatterPendingExpiredCounter.WithLabelValues("false")
 )
 
 func init() {
 	prometheus.MustRegister(checkerCounter)
 	prometheus.MustRegister(regionListGauge)
 	prometheus.MustRegister(patrolCheckRegionsGauge)
+	prometheus.MustRegister(splitScatterPendingExpiredCounter)
+	prometheus.MustRegister(splitScatterPendingDroppedCounter)
+	prometheus.MustRegister(splitScatterPendingGauge)
 }
 
 const (
 	// NOTE: these types are different from pkg/schedule/config/type.go,
 	// they are only used for prometheus metrics to keep the compatibility.
-	ruleChecker       = "rule_checker"
-	jointStateChecker = "joint_state_checker"
-	learnerChecker    = "learner_checker"
-	mergeChecker      = "merge_checker"
-	replicaChecker    = "replica_checker"
-	splitChecker      = "split_checker"
+	ruleChecker         = "rule_checker"
+	jointStateChecker   = "joint_state_checker"
+	learnerChecker      = "learner_checker"
+	mergeChecker        = "merge_checker"
+	replicaChecker      = "replica_checker"
+	splitChecker        = "split_checker"
+	splitScatterChecker = "split_scatter_checker"
 )
 
 func ruleCheckerCounterWithEvent(event string) prometheus.Counter {
@@ -72,6 +104,10 @@ func mergeCheckerCounterWithEvent(event string) prometheus.Counter {
 
 func replicaCheckerCounterWithEvent(event string) prometheus.Counter {
 	return checkerCounter.WithLabelValues(replicaChecker, event)
+}
+
+func splitScatterCheckerCounterWithEvent(event string) prometheus.Counter {
+	return checkerCounter.WithLabelValues(splitScatterChecker, event)
 }
 
 // WithLabelValues is a heavy operation, define variable to avoid call it every time.
@@ -155,4 +191,15 @@ var (
 
 	splitCheckerCounter       = checkerCounter.WithLabelValues(splitChecker, "check")
 	splitCheckerPausedCounter = checkerCounter.WithLabelValues(splitChecker, "paused")
+
+	splitScatterDispatchDisabledCounter          = splitScatterCheckerCounterWithEvent("dispatch-disabled")
+	splitScatterDispatchScheduleLimitCounter     = splitScatterCheckerCounterWithEvent("dispatch-schedule-limit")
+	splitScatterDispatchRegionMissingCounter     = splitScatterCheckerCounterWithEvent("dispatch-region-missing")
+	splitScatterDispatchScheduleDisabledCounter  = splitScatterCheckerCounterWithEvent("dispatch-schedule-disabled")
+	splitScatterDispatchNotReplicatedCounter     = splitScatterCheckerCounterWithEvent("dispatch-not-fully-replicated")
+	splitScatterDispatchScatterFailedCounter     = splitScatterCheckerCounterWithEvent("dispatch-scatter-failed")
+	splitScatterDispatchStoreLimitCounter        = splitScatterCheckerCounterWithEvent("dispatch-store-limit")
+	splitScatterDispatchAddOperatorFailedCounter = splitScatterCheckerCounterWithEvent("dispatch-add-operator-failed")
+	splitScatterDispatchOperatorCreatedCounter   = splitScatterCheckerCounterWithEvent("dispatch-operator-created")
+	splitScatterDispatchNoOperatorNeededCounter  = splitScatterCheckerCounterWithEvent("dispatch-no-operator-needed")
 )

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -1,0 +1,477 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pingcap/log"
+
+	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/filter"
+	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+	"github.com/tikv/pd/pkg/schedule/types"
+	"github.com/tikv/pd/pkg/utils/syncutil"
+)
+
+const (
+	splitScatterPendingLimit = 4096
+	// The actual retry cadence is also bounded by the checker dispatch loop. This
+	// is only the minimum interval to avoid retrying the same pending item too
+	// frequently when checker ticks are fast.
+	splitScatterRetryBackoff = time.Second
+	// Keep the pending TTL aligned with PD's slow operator step threshold so a
+	// scatter blocked by slow AddLearner/store limits still has time to retry.
+	splitScatterPendingTTL = 10 * time.Minute
+)
+
+type splitScatterPendingItem struct {
+	regionID          uint64
+	group             string
+	sourceRegionID    uint64
+	sourceWaitVersion uint64
+	retryAt           time.Time
+	expireAt          time.Time
+	// attempted means this item has been selected by the dispatcher at least once.
+	attempted bool
+}
+
+type splitScatterController struct {
+	cluster         sche.CheckerCluster
+	opController    *operator.Controller
+	regionScatterer *scatter.RegionScatterer
+
+	pendingMu syncutil.RWMutex
+	// pending maps a pending region ID to its latest split-scatter batch item.
+	// The item keeps its batch group so stale snapshots cannot mutate a newer
+	// pending entry for the same region.
+	pending        map[uint64]splitScatterPendingItem
+	nextDispatchAt time.Time
+}
+
+func newSplitScatterController(
+	ctx context.Context,
+	cluster sche.CheckerCluster,
+	opController *operator.Controller,
+	addPendingProcessedRegions func(needCheckLen bool, ids ...uint64),
+) *splitScatterController {
+	splitScatterPendingGauge.Set(0)
+	return &splitScatterController{
+		cluster:         cluster,
+		opController:    opController,
+		regionScatterer: scatter.NewRegionScatterer(ctx, cluster, opController, addPendingProcessedRegions),
+		pending:         make(map[uint64]splitScatterPendingItem),
+	}
+}
+
+// splitScatterRangeHint is a derived key range for the current table/index
+// group. When available, split-scatter seeds the scatterer's group
+// distribution with the existing region count in this range before dispatch.
+type splitScatterRangeHint struct {
+	startKey     []byte
+	endKey       []byte
+	scatterGroup string
+}
+
+func (c *splitScatterController) collectTopPendingSplitScatter(limit int) []splitScatterPendingItem {
+	if limit <= 0 {
+		return nil
+	}
+	now := time.Now()
+	c.pendingMu.RLock()
+
+	// Keep pendingMu short: cluster reads below can be slower and do not need
+	// to block pending updates. Stale snapshots are safe because candidates
+	// are rechecked before dispatch and delay/delete recheck the pending identity.
+	pendingSnapshot := make([]splitScatterPendingItem, 0, len(c.pending))
+	expiredSnapshot := make([]splitScatterPendingItem, 0)
+	for _, pending := range c.pending {
+		if !pending.expireAt.IsZero() && !now.Before(pending.expireAt) {
+			expiredSnapshot = append(expiredSnapshot, pending)
+			continue
+		}
+		pendingSnapshot = append(pendingSnapshot, pending)
+	}
+	c.pendingMu.RUnlock()
+
+	candidates := make([]splitScatterPendingItem, 0, len(pendingSnapshot))
+	missingSnapshot := make([]splitScatterPendingItem, 0)
+	for _, pending := range pendingSnapshot {
+		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			continue
+		}
+		regionID := pending.regionID
+		region := c.cluster.GetRegion(regionID)
+		if region == nil {
+			missingSnapshot = append(missingSnapshot, pending)
+			continue
+		}
+		sourceRegion := c.cluster.GetRegion(pending.sourceRegionID)
+		if sourceRegion == nil {
+			missingSnapshot = append(missingSnapshot, pending)
+			continue
+		}
+		sourceVersion := uint64(0)
+		if sourceRegion.GetRegionEpoch() != nil {
+			sourceVersion = sourceRegion.GetRegionEpoch().GetVersion()
+		}
+		if pending.sourceWaitVersion > 0 && sourceVersion < pending.sourceWaitVersion {
+			continue
+		}
+		candidates = append(candidates, pending)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].expireAt.Equal(candidates[j].expireAt) {
+			return candidates[i].expireAt.Before(candidates[j].expireAt)
+		}
+		if candidates[i].group != candidates[j].group {
+			return candidates[i].group < candidates[j].group
+		}
+		return candidates[i].regionID < candidates[j].regionID
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	if len(candidates) > 0 {
+		c.pendingMu.Lock()
+		selected := candidates[:0]
+		for _, candidate := range candidates {
+			pending, ok := c.pending[candidate.regionID]
+			if !ok || pending.group != candidate.group || !pending.expireAt.Equal(candidate.expireAt) {
+				continue
+			}
+			pending.attempted = true
+			c.pending[pending.regionID] = pending
+			candidate.attempted = true
+			selected = append(selected, candidate)
+		}
+		candidates = selected
+		c.pendingMu.Unlock()
+	}
+	c.delayMissingPendingSplitScatter(missingSnapshot, now)
+
+	if len(expiredSnapshot) > 0 {
+		attemptedExpiredCount := 0
+		unattemptedExpiredCount := 0
+		c.pendingMu.Lock()
+		for _, expired := range expiredSnapshot {
+			pending, ok := c.pending[expired.regionID]
+			if ok && pending.group == expired.group && pending.expireAt.Equal(expired.expireAt) &&
+				!pending.expireAt.IsZero() && !now.Before(pending.expireAt) {
+				delete(c.pending, expired.regionID)
+				if pending.attempted {
+					attemptedExpiredCount++
+				} else {
+					unattemptedExpiredCount++
+				}
+			}
+		}
+		if attemptedExpiredCount+unattemptedExpiredCount > 0 {
+			c.updatePendingGaugeLocked()
+		}
+		c.pendingMu.Unlock()
+		observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
+	}
+	return candidates
+}
+
+func (c *splitScatterController) delayMissingPendingSplitScatter(missing []splitScatterPendingItem, now time.Time) {
+	if len(missing) == 0 {
+		return
+	}
+	missingCount := 0
+	c.pendingMu.Lock()
+	for _, expected := range missing {
+		pending, ok := c.pending[expected.regionID]
+		if !ok || pending.group != expected.group || !pending.expireAt.Equal(expected.expireAt) {
+			continue
+		}
+		if !pending.retryAt.IsZero() && now.Before(pending.retryAt) {
+			continue
+		}
+		pending.retryAt = now.Add(splitScatterRetryBackoff)
+		c.pending[expected.regionID] = pending
+		missingCount++
+	}
+	c.pendingMu.Unlock()
+	if missingCount > 0 {
+		splitScatterDispatchRegionMissingCounter.Add(float64(missingCount))
+	}
+}
+
+func (c *splitScatterController) delayPendingSplitScatter(expected splitScatterPendingItem) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	pending, ok := c.pending[expected.regionID]
+	if !ok || pending.group != expected.group || !pending.expireAt.Equal(expected.expireAt) {
+		return
+	}
+	pending.retryAt = time.Now().Add(splitScatterRetryBackoff)
+	c.pending[expected.regionID] = pending
+}
+
+func (c *splitScatterController) deletePendingSplitScatter(expected splitScatterPendingItem) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	pending, ok := c.pending[expected.regionID]
+	if !ok || pending.group != expected.group || !pending.expireAt.Equal(expected.expireAt) {
+		return
+	}
+	delete(c.pending, expected.regionID)
+	c.updatePendingGaugeLocked()
+}
+
+func (c *splitScatterController) updatePendingGaugeLocked() {
+	splitScatterPendingGauge.Set(float64(len(c.pending)))
+}
+
+func observeSplitScatterPendingExpired(attemptedCount, unattemptedCount int) {
+	if attemptedCount > 0 {
+		splitScatterPendingExpiredAttemptedCounter.Add(float64(attemptedCount))
+	}
+	if unattemptedCount > 0 {
+		splitScatterPendingExpiredUnattemptedCounter.Add(float64(unattemptedCount))
+	}
+}
+
+func (c *splitScatterController) removeExpiredPendingSplitScatterLocked() (attemptedCount, unattemptedCount int) {
+	now := time.Now()
+	for regionID, pending := range c.pending {
+		if !pending.expireAt.IsZero() && !now.Before(pending.expireAt) {
+			delete(c.pending, regionID)
+			if pending.attempted {
+				attemptedCount++
+			} else {
+				unattemptedCount++
+			}
+		}
+	}
+	if attemptedCount+unattemptedCount > 0 {
+		c.updatePendingGaugeLocked()
+	}
+	return attemptedCount, unattemptedCount
+}
+
+func (c *splitScatterController) cleanupExpiredPendingSplitScatter() int {
+	c.pendingMu.Lock()
+	attemptedExpiredCount, unattemptedExpiredCount := c.removeExpiredPendingSplitScatterLocked()
+	pendingCount := len(c.pending)
+	c.pendingMu.Unlock()
+	observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
+	return pendingCount
+}
+
+func (c *splitScatterController) clearPendingSplitScatter() {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	pendingCount := len(c.pending)
+	if pendingCount > 0 {
+		c.pending = make(map[uint64]splitScatterPendingItem)
+		c.updatePendingGaugeLocked()
+	}
+	c.nextDispatchAt = time.Time{}
+}
+
+func (c *splitScatterController) skipDispatchUntil(now time.Time) bool {
+	c.pendingMu.RLock()
+	defer c.pendingMu.RUnlock()
+	return !c.nextDispatchAt.IsZero() && now.Before(c.nextDispatchAt)
+}
+
+func (c *splitScatterController) delayNextDispatch(now time.Time) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	c.nextDispatchAt = now.Add(splitScatterRetryBackoff)
+}
+
+func makeSplitScatterGroup(sourceRegionID, firstNewRegionID uint64) string {
+	return fmt.Sprintf("split-scatter-%d-%d", sourceRegionID, firstNewRegionID)
+}
+
+// RecordSplitScatterBatch records a newly split batch for later scatter.
+func (c *Controller) RecordSplitScatterBatch(sourceRegionID, sourceWaitVersion uint64, newRegionIDs []uint64) {
+	c.splitScatter.recordSplitScatterBatch(sourceRegionID, sourceWaitVersion, newRegionIDs)
+}
+
+func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceWaitVersion uint64, newRegionIDs []uint64) {
+	if len(newRegionIDs) == 0 {
+		return
+	}
+	if c.cluster.GetCheckerConfig().GetSplitScatterScheduleLimit() == 0 {
+		return
+	}
+	group := makeSplitScatterGroup(sourceRegionID, newRegionIDs[0])
+	expireAt := time.Now().Add(splitScatterPendingTTL)
+	if sourceWaitVersion == 0 {
+		sourceWaitVersion = 1
+	}
+	if sourceRegion := c.cluster.GetRegion(sourceRegionID); sourceRegion != nil && sourceRegion.GetRegionEpoch() != nil {
+		cachedWaitVersion := sourceRegion.GetRegionEpoch().GetVersion() + 1
+		if cachedWaitVersion > sourceWaitVersion {
+			sourceWaitVersion = cachedWaitVersion
+		}
+	}
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	attemptedExpiredCount, unattemptedExpiredCount := c.removeExpiredPendingSplitScatterLocked()
+	observeSplitScatterPendingExpired(attemptedExpiredCount, unattemptedExpiredCount)
+	newPendingCount := 0
+	if _, ok := c.pending[sourceRegionID]; !ok {
+		newPendingCount++
+	}
+	for _, regionID := range newRegionIDs {
+		if _, ok := c.pending[regionID]; !ok {
+			newPendingCount++
+		}
+	}
+	if len(c.pending)+newPendingCount > splitScatterPendingLimit {
+		// Keep each split batch atomic. Recording only part of a source/child
+		// batch would make the scatter group incomplete, so skip the whole batch
+		// when the remaining capacity cannot fit it.
+		splitScatterPendingDroppedCounter.Add(float64(newPendingCount))
+		log.Info("skip recording split scatter batch due to pending limit",
+			zap.Uint64("source-region-id", sourceRegionID),
+			zap.Uint64s("new-region-ids", newRegionIDs),
+			zap.Int("pending-count", len(c.pending)),
+			zap.Int("new-pending-count", newPendingCount),
+			zap.Int("pending-limit", splitScatterPendingLimit))
+		return
+	}
+	for _, regionID := range newRegionIDs {
+		c.pending[regionID] = splitScatterPendingItem{
+			regionID:          regionID,
+			group:             group,
+			sourceRegionID:    sourceRegionID,
+			sourceWaitVersion: sourceWaitVersion,
+			expireAt:          expireAt,
+		}
+	}
+	c.pending[sourceRegionID] = splitScatterPendingItem{
+		regionID:          sourceRegionID,
+		group:             group,
+		sourceRegionID:    sourceRegionID,
+		sourceWaitVersion: sourceWaitVersion,
+		expireAt:          expireAt,
+	}
+	c.updatePendingGaugeLocked()
+	c.nextDispatchAt = time.Time{}
+}
+
+func (c *splitScatterController) dispatchSplitScatterRegions() {
+	now := time.Now()
+	if c.cleanupExpiredPendingSplitScatter() == 0 {
+		return
+	}
+	limit := c.cluster.GetCheckerConfig().GetSplitScatterScheduleLimit()
+	if limit == 0 {
+		splitScatterDispatchDisabledCounter.Inc()
+		c.clearPendingSplitScatter()
+		return
+	}
+	if c.skipDispatchUntil(now) {
+		return
+	}
+	running := c.opController.OperatorCount(operator.OpSplitScatter)
+	if running >= limit {
+		splitScatterDispatchScheduleLimitCounter.Inc()
+		operator.IncOperatorLimitCounter(types.SplitScatterChecker, operator.OpSplitScatter)
+		c.delayNextDispatch(now)
+		return
+	}
+	dispatchLimit := int(limit - running)
+	// Dispatch sequentially so operators added for earlier pending items in this pass
+	// are visible to later ScatterInternal calls through the running-operator delta.
+	pendingItems := c.collectTopPendingSplitScatter(dispatchLimit)
+	if len(pendingItems) == 0 {
+		c.delayNextDispatch(now)
+		return
+	}
+	for _, pending := range pendingItems {
+		region := c.cluster.GetRegion(pending.regionID)
+		if region == nil {
+			splitScatterDispatchRegionMissingCounter.Inc()
+			continue
+		}
+		rangeHint := resolveSplitScatterRangeHint(region)
+		scatterGroup := pending.group
+		if rangeHint.scatterGroup != "" {
+			scatterGroup = rangeHint.scatterGroup
+		}
+		if cl, ok := c.cluster.(interface{ GetRegionLabeler() *labeler.RegionLabeler }); ok {
+			if labeler := cl.GetRegionLabeler(); labeler != nil && labeler.ScheduleDisabled(region) {
+				splitScatterDispatchScheduleDisabledCounter.Inc()
+				c.delayPendingSplitScatter(pending)
+				continue
+			}
+		}
+		if !filter.IsRegionReplicated(c.cluster, region) {
+			splitScatterDispatchNotReplicatedCounter.Inc()
+			c.delayPendingSplitScatter(pending)
+			log.Info("dispatch internal split scatter delayed",
+				zap.Uint64("region-id", pending.regionID),
+				zap.String("batch-group", pending.group),
+				zap.String("scatter-group", scatterGroup),
+				zap.String("reason", "not-fully-replicated"))
+			continue
+		}
+		op, err := c.regionScatterer.ScatterInternal(region, scatterGroup, rangeHint.startKey, rangeHint.endKey)
+		if err != nil {
+			splitScatterDispatchScatterFailedCounter.Inc()
+			c.delayPendingSplitScatter(pending)
+			log.Info("dispatch internal split scatter failed",
+				zap.Uint64("region-id", pending.regionID),
+				zap.String("batch-group", pending.group),
+				zap.String("scatter-group", scatterGroup),
+				zap.Error(err))
+			continue
+		}
+		if op != nil {
+			op.SetAdditionalInfo("batch-group", pending.group)
+			if c.opController.ExceedStoreLimit(op) {
+				splitScatterDispatchStoreLimitCounter.Inc()
+				c.delayPendingSplitScatter(pending)
+				log.Info("dispatch internal split scatter delayed",
+					zap.Uint64("region-id", pending.regionID),
+					zap.String("batch-group", pending.group),
+					zap.String("scatter-group", scatterGroup),
+					zap.String("reason", "exceed-store-limit"),
+					zap.String("operator-desc", op.Desc()))
+				continue
+			}
+			if !c.opController.AddOperator(op) {
+				splitScatterDispatchAddOperatorFailedCounter.Inc()
+				c.delayPendingSplitScatter(pending)
+				log.Info("dispatch internal split scatter add operator failed",
+					zap.Uint64("region-id", pending.regionID),
+					zap.String("batch-group", pending.group),
+					zap.String("scatter-group", scatterGroup),
+					zap.String("operator-desc", op.Desc()))
+				continue
+			}
+			splitScatterDispatchOperatorCreatedCounter.Inc()
+		} else {
+			splitScatterDispatchNoOperatorNeededCounter.Inc()
+		}
+		c.deletePendingSplitScatter(pending)
+	}
+}

--- a/pkg/schedule/checker/split_scatter_group.go
+++ b/pkg/schedule/checker/split_scatter_group.go
@@ -1,0 +1,110 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/core"
+)
+
+var (
+	splitScatterTablePrefix = []byte{'t'}
+	splitScatterIndexPrefix = []byte("_i")
+)
+
+func resolveSplitScatterRangeHint(region *core.RegionInfo) splitScatterRangeHint {
+	_, decoded, err := codec.DecodeBytes(region.GetStartKey())
+	if err != nil || !bytes.HasPrefix(decoded, splitScatterTablePrefix) {
+		return splitScatterRangeHint{}
+	}
+	rest := decoded[len(splitScatterTablePrefix):]
+	rest, tableID, err := codec.DecodeInt(rest)
+	if err != nil {
+		return splitScatterRangeHint{}
+	}
+
+	tablePrefix := append([]byte(nil), codec.GenerateTableKey(tableID)...)
+	tableGroup := makeSplitScatterTableGroup(tableID)
+	if !bytes.HasPrefix(rest, splitScatterIndexPrefix) {
+		return splitScatterPrefixRangeWithGroup(tablePrefix, tableGroup)
+	}
+
+	indexRest := rest[len(splitScatterIndexPrefix):]
+	_, indexID, err := codec.DecodeInt(indexRest)
+	if err != nil {
+		return splitScatterRangeHint{}
+	}
+
+	indexPrefix := codec.GenerateIndexKey(tableID, indexID)
+	indexGroup := makeSplitScatterIndexGroup(tableID, indexID)
+	indexRange := splitScatterPrefixRangeWithGroup(indexPrefix, indexGroup)
+	endKey := region.GetEndKey()
+
+	// We intentionally over-approximate ambiguous table-key ranges. If PD can
+	// no longer prove the region stays within a single index prefix, it falls
+	// back to the table-scoped group instead of dropping back to the family
+	// group, so table-boundary splits and merged ranges still participate in
+	// the broader scatter continuity/baseline.
+	// Both endKey and indexRange.endKey are MemComparable-encoded, so
+	// bytes.Compare correctly reflects the key ordering.
+	if len(endKey) == 0 || len(indexRange.startKey) == 0 || len(indexRange.endKey) == 0 || bytes.Compare(endKey, indexRange.endKey) > 0 {
+		return splitScatterPrefixRangeWithGroup(tablePrefix, tableGroup)
+	}
+	return indexRange
+}
+
+func splitScatterPrefixRange(rawPrefix []byte) splitScatterRangeHint {
+	return splitScatterPrefixRangeWithGroup(rawPrefix, "")
+}
+
+func splitScatterPrefixRangeWithGroup(rawPrefix []byte, scatterGroup string) splitScatterRangeHint {
+	startKey := append([]byte(nil), codec.EncodeBytes(rawPrefix)...)
+	endRawPrefix := splitScatterNextPrefix(rawPrefix)
+	if len(endRawPrefix) == 0 {
+		// Current callers use TiDB table/index prefixes, which always start
+		// with 't' and therefore have a finite next prefix. Keep the fallback
+		// here so this helper remains safe if it is ever used with an all-0xff
+		// prefix.
+		return splitScatterRangeHint{startKey: startKey, scatterGroup: scatterGroup}
+	}
+	return splitScatterRangeHint{
+		startKey:     startKey,
+		endKey:       append([]byte(nil), codec.EncodeBytes(endRawPrefix)...),
+		scatterGroup: scatterGroup,
+	}
+}
+
+func makeSplitScatterTableGroup(tableID int64) string {
+	return fmt.Sprintf("split-scatter-table-%d", tableID)
+}
+
+func makeSplitScatterIndexGroup(tableID, indexID int64) string {
+	return fmt.Sprintf("split-scatter-index-%d-%d", tableID, indexID)
+}
+
+func splitScatterNextPrefix(key []byte) []byte {
+	next := append([]byte(nil), key...)
+	for i := len(next) - 1; i >= 0; i-- {
+		if next[i] == 0xFF {
+			continue
+		}
+		next[i]++
+		return next[:i+1]
+	}
+	return nil
+}

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -1,0 +1,899 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/pkg/mock/mockconfig"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+)
+
+const (
+	splitScatterObservedRegionID      uint64 = 101
+	splitScatterTestTableID           int64  = 42
+	splitScatterTestIndexID           int64  = 7
+	splitScatterTestSourceWaitVersion        = uint64(0)
+	// CPU usage is only populated to mimic load-split region heartbeat data.
+	// Current split-scatter dispatch does not rank pending regions by CPU.
+	splitScatterNoCPUUsage       uint64 = 0
+	splitScatterReportedCPUUsage uint64 = 1
+)
+
+func (c *Controller) collectTopPendingSplitScatter(limit int) []splitScatterPendingItem {
+	return c.splitScatter.collectTopPendingSplitScatter(limit)
+}
+
+func (c *Controller) dispatchSplitScatterRegions() {
+	c.splitScatter.dispatchSplitScatterRegions()
+}
+
+func TestNewSplitScatterControllerResetsPendingGauge(t *testing.T) {
+	re := require.New(t)
+	splitScatterPendingGauge.Set(7)
+
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+}
+
+func TestRecordSplitScatterBatchCollectsPendingRegions(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102, 103})
+	re.Equal(4, splitScatterPendingCount(controller))
+	re.Equal(float64(4), promtestutil.ToFloat64(splitScatterPendingGauge))
+
+	sourceGroup := splitScatterPendingGroup(t, controller, 100)
+	for _, regionID := range []uint64{101, 102, 103} {
+		re.Equal(sourceGroup, splitScatterPendingGroup(t, controller, regionID))
+	}
+
+	putSplitScatterRegion(tc, 101, "m", "n", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 102, "n", "o", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 103, "o", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	re.ElementsMatch([]uint64{100, 101, 102, 103}, pendingRegionIDs(controller.collectTopPendingSplitScatter(4)))
+}
+
+func TestCheckSplitScatterRegionsCreatesScatterOperator(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+	putSplitScatterRegion(tc, 101, "m", "t", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 102, "t", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	group := splitScatterPendingGroup(t, controller, 101)
+
+	controller.dispatchSplitScatterRegions()
+
+	var op *operator.Operator
+	for _, regionID := range []uint64{100, 101, 102} {
+		op = oc.GetOperator(regionID)
+		if op != nil {
+			break
+		}
+	}
+	re.NotNil(op)
+	re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+	re.Equal(group, op.GetAdditionalInfo("group"))
+	re.Equal(group, op.GetAdditionalInfo("batch-group"))
+}
+
+func TestDispatchSplitScatterKeepsPendingUntilSplitHeartbeat(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Equal(2, splitScatterPendingCount(controller))
+	re.Nil(oc.GetOperator(101))
+
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+
+	retrySplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	advanceSplitScatterSourceVersion(t, tc)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
+	re.ElementsMatch([]uint64{100, 101}, pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
+
+	controller.dispatchSplitScatterRegions()
+
+	op := oc.GetOperator(101)
+	re.NotNil(op)
+	re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+}
+
+func TestDispatchSplitScatterUsesRequestWaitVersionWhenCacheLags(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	source := tc.GetRegion(100)
+	re.NotNil(source)
+	tc.PutRegion(source.Clone(core.SetRegionVersion(4)))
+
+	controller.RecordSplitScatterBatch(100, 6, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterRegionVersion(t, tc, 100)
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(2, splitScatterPendingCount(controller))
+
+	advanceSplitScatterRegionVersion(t, tc, 100)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
+	controller.dispatchSplitScatterRegions()
+
+	re.NotNil(oc.GetOperator(101))
+}
+
+func TestDispatchSplitScatterRespectsScheduleLimit(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+	putSplitScatterRegion(tc, 101, "m", "t", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 102, "t", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	tc.SetSplitScatterScheduleLimit(1)
+	controller.dispatchSplitScatterRegions()
+
+	re.Len(oc.GetOperators(), 1)
+	re.Equal(uint64(1), oc.OperatorCount(operator.OpSplitScatter))
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Len(oc.GetOperators(), 1)
+}
+
+func TestRecordSplitScatterBatchSkipsWhenDisabled(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	tc.SetSplitScatterScheduleLimit(0)
+
+	droppedBefore := promtestutil.ToFloat64(splitScatterPendingDroppedCounter)
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingDroppedCounter)-droppedBefore)
+}
+
+func TestDispatchSplitScatterClearsPendingWhenDisabled(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101, 102})
+	re.Equal(3, splitScatterPendingCount(controller))
+
+	tc.SetSplitScatterScheduleLimit(0)
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(splitScatterRetryBackoff))
+	disabledBefore := promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchDisabledCounter)-disabledBefore)
+}
+
+func TestDispatchSplitScatterCleansExpiredPendingBeforeEarlyReturn(t *testing.T) {
+	testCases := []struct {
+		name             string
+		setupEarlyReturn func(*mockcluster.Cluster, *operator.Controller)
+		counter          prometheus.Counter
+	}{
+		{
+			name: "disabled",
+			setupEarlyReturn: func(tc *mockcluster.Cluster, _ *operator.Controller) {
+				tc.SetSplitScatterScheduleLimit(0)
+			},
+			counter: splitScatterDispatchDisabledCounter,
+		},
+		{
+			name: "schedule limit",
+			setupEarlyReturn: func(tc *mockcluster.Cluster, oc *operator.Controller) {
+				tc.SetSplitScatterScheduleLimit(1)
+				region := tc.GetRegion(100)
+				op := operator.NewTestOperator(
+					region.GetID(),
+					region.GetRegionEpoch(),
+					operator.OpSplitScatter|operator.OpRegion,
+					operator.TransferLeader{FromStore: 1, ToStore: 2},
+				)
+				require.True(t, oc.AddOperator(op))
+			},
+			counter: splitScatterDispatchScheduleLimitCounter,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			controller, tc, oc, cleanup := newTestSplitScatterController(t)
+			defer cleanup()
+
+			controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+			expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
+			expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+			testCase.setupEarlyReturn(tc, oc)
+
+			expiredBefore := splitScatterPendingExpiredCount("false")
+			counterBefore := promtestutil.ToFloat64(testCase.counter)
+			controller.dispatchSplitScatterRegions()
+
+			re.Equal(0, splitScatterPendingCount(controller))
+			re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+			re.Equal(float64(2), splitScatterPendingExpiredCount("false")-expiredBefore)
+			re.Equal(float64(0), promtestutil.ToFloat64(testCase.counter)-counterBefore)
+		})
+	}
+}
+
+func TestCollectTopPendingDelaysMissingRegions(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	missingBefore := promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)-missingBefore)
+	pending := splitScatterPending(t, controller, 101)
+	re.True(pending.retryAt.After(time.Now()))
+
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	re.Equal(float64(1), promtestutil.ToFloat64(splitScatterDispatchRegionMissingCounter)-missingBefore)
+}
+
+func TestDispatchSplitScatterBacksOffWhenNoCandidates(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	controller.dispatchSplitScatterRegions()
+
+	re.True(splitScatterNextDispatchAt(t, controller).After(time.Now()))
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+
+	retrySplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+	setSplitScatterNextDispatchAt(t, controller, time.Now().Add(-time.Second))
+	controller.dispatchSplitScatterRegions()
+
+	re.NotNil(oc.GetOperator(101))
+}
+
+func TestDispatchSplitScatterRespectsScheduleDeny(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	re.NoError(tc.GetRegionLabeler().SetLabelRule(&labeler.LabelRule{
+		ID:       "split-scatter-schedule-deny",
+		Labels:   []labeler.RegionLabel{{Key: "schedule", Value: "deny"}},
+		RuleType: labeler.KeyRange,
+		Data:     []any{map[string]any{"start_key": "", "end_key": ""}},
+	}))
+
+	counterBefore := promtestutil.ToFloat64(splitScatterDispatchScheduleDisabledCounter)
+	controller.dispatchSplitScatterRegions()
+
+	re.Empty(oc.GetOperators())
+	re.Equal(2, splitScatterPendingCount(controller))
+	re.Equal(float64(2), promtestutil.ToFloat64(splitScatterDispatchScheduleDisabledCounter)-counterBefore)
+	for _, regionID := range []uint64{100, 101} {
+		pending := splitScatterPending(t, controller, regionID)
+		re.True(pending.retryAt.After(time.Now()))
+	}
+}
+
+func TestCollectTopPendingRemovesExpiredPending(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
+	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+
+	expiredBefore := splitScatterPendingExpiredCount("false")
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(2), splitScatterPendingExpiredCount("false")-expiredBefore)
+}
+
+func TestCollectTopPendingMarksAttemptedBeforeExpiration(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	attemptedBefore := splitScatterPendingExpiredCount("true")
+	unattemptedBefore := splitScatterPendingExpiredCount("false")
+	re.Len(controller.collectTopPendingSplitScatter(1), 1)
+	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(-time.Second))
+	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(-time.Second))
+
+	re.Empty(controller.collectTopPendingSplitScatter(2))
+	re.Equal(0, splitScatterPendingCount(controller))
+	re.Equal(float64(0), promtestutil.ToFloat64(splitScatterPendingGauge))
+	re.Equal(float64(1), splitScatterPendingExpiredCount("true")-attemptedBefore)
+	re.Equal(float64(1), splitScatterPendingExpiredCount("false")-unattemptedBefore)
+}
+
+func TestRecordSplitScatterBatchRespectsPendingLimit(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	fillSplitScatterPending(controller, time.Time{})
+
+	droppedBefore := promtestutil.ToFloat64(splitScatterPendingDroppedCounter)
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	re.Equal(splitScatterPendingLimit, splitScatterPendingCount(controller))
+	re.Equal(float64(2), promtestutil.ToFloat64(splitScatterPendingDroppedCounter)-droppedBefore)
+	controller.splitScatter.pendingMu.RLock()
+	_, sourceExists := controller.splitScatter.pending[100]
+	_, childExists := controller.splitScatter.pending[101]
+	controller.splitScatter.pendingMu.RUnlock()
+	re.False(sourceExists)
+	re.False(childExists)
+}
+
+func TestRecordSplitScatterBatchClearsExpiredPendingBeforeLimitCheck(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	fillSplitScatterPending(controller, time.Now().Add(-time.Second))
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+
+	re.Equal(2, splitScatterPendingCount(controller))
+	re.Equal(makeSplitScatterGroup(100, 101), splitScatterPendingGroup(t, controller, 101))
+}
+
+func TestCollectTopPendingSortsBeforeLimit(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(200, splitScatterTestSourceWaitVersion, []uint64{201})
+	putSplitScatterRegion(tc, 200, "n", "o", splitScatterNoCPUUsage)
+	putSplitScatterRegion(tc, 201, "o", "p", splitScatterReportedCPUUsage)
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegion(tc, 101, "m", "n", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+
+	pending := controller.collectTopPendingSplitScatter(1)
+	re.Len(pending, 1)
+	re.Equal(uint64(100), pending[0].regionID)
+}
+
+func TestCollectTopPendingPrioritizesNearExpiration(t *testing.T) {
+	re := require.New(t)
+	controller, tc, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	controller.RecordSplitScatterBatch(200, splitScatterTestSourceWaitVersion, []uint64{201})
+	putSplitScatterRegion(tc, 100, "m", "n", splitScatterNoCPUUsage)
+	putSplitScatterRegion(tc, 101, "n", "o", splitScatterReportedCPUUsage)
+	putSplitScatterRegion(tc, 200, "o", "p", splitScatterNoCPUUsage)
+	putSplitScatterRegion(tc, 201, "p", "q", splitScatterReportedCPUUsage)
+	advanceSplitScatterSourceVersion(t, tc)
+	advanceSplitScatterRegionVersion(t, tc, 200)
+
+	expireSplitScatterPendingAt(t, controller, 100, time.Now().Add(2*time.Minute))
+	expireSplitScatterPendingAt(t, controller, 101, time.Now().Add(2*time.Minute))
+	expireSplitScatterPendingAt(t, controller, 200, time.Now().Add(time.Minute))
+	expireSplitScatterPendingAt(t, controller, 201, time.Now().Add(time.Minute))
+
+	pending := controller.collectTopPendingSplitScatter(1)
+	re.Len(pending, 1)
+	re.Equal(uint64(200), pending[0].regionID)
+}
+
+func TestCollectTopPendingResolvesRangeHint(t *testing.T) {
+	testCases := []struct {
+		name      string
+		startKey  []byte
+		endKey    []byte
+		wantRange splitScatterRangeHint
+		wantGroup string
+	}{
+		{
+			name:      "index region",
+			startKey:  newSplitScatterIndexKey("a"),
+			endKey:    newSplitScatterIndexKey("m"),
+			wantRange: splitScatterPrefixRange(splitScatterIndexKeyPrefix()),
+			wantGroup: makeSplitScatterIndexGroup(splitScatterTestTableID, splitScatterTestIndexID),
+		},
+		{
+			name:      "record region",
+			startKey:  newSplitScatterRecordKey(42, "a"),
+			endKey:    newSplitScatterRecordKey(42, "m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+		{
+			name:      "bare table boundary",
+			startKey:  newSplitScatterTableBoundaryKey(42),
+			endKey:    newSplitScatterIndexKey("m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+		{
+			name:      "cross entity falls back to table",
+			startKey:  newSplitScatterIndexKey("a"),
+			endKey:    newSplitScatterRecordKey(42, "m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+		{
+			name:      "cross table uses start table",
+			startKey:  newSplitScatterRecordKey(42, "a"),
+			endKey:    newSplitScatterRecordKey(43, "m"),
+			wantRange: splitScatterPrefixRange(codec.GenerateTableKey(42)),
+			wantGroup: makeSplitScatterTableGroup(42),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			controller, tc, _, cleanup := newTestSplitScatterController(t)
+			defer cleanup()
+
+			controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+			putSplitScatterRegionWithKeys(tc, testCase.startKey, testCase.endKey, splitScatterReportedCPUUsage)
+			putSplitScatterRegion(tc, 100, "x", "z", splitScatterNoCPUUsage)
+			advanceSplitScatterSourceVersion(t, tc)
+
+			re.Equal(makeSplitScatterGroup(100, 101), splitScatterPendingGroup(t, controller, 101))
+			re.ElementsMatch([]uint64{100, 101}, pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
+			rangeHint := resolveSplitScatterRangeHint(tc.GetRegion(101))
+			re.Equal(testCase.wantRange.startKey, rangeHint.startKey)
+			re.Equal(testCase.wantRange.endKey, rangeHint.endKey)
+			re.Equal(testCase.wantGroup, rangeHint.scatterGroup)
+		})
+	}
+}
+
+func TestDispatchSplitScatterUsesRangeScatterGroup(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	putSplitScatterRegionWithKeysByID(tc, 90, newSplitScatterIndexKey("m"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage)
+	putSplitScatterRegionWithKeysByID(tc, 101, newSplitScatterIndexKey("a"), newSplitScatterIndexKey("m"), splitScatterReportedCPUUsage)
+	advanceSplitScatterRegionVersion(t, tc, 100)
+
+	batchGroup := splitScatterPendingGroup(t, controller, 101)
+
+	controller.dispatchSplitScatterRegions()
+
+	expectedScatterGroup := makeSplitScatterIndexGroup(splitScatterTestTableID, splitScatterTestIndexID)
+	op := oc.GetOperator(101)
+	re.NotNil(op)
+	re.Equal(expectedScatterGroup, op.GetAdditionalInfo("group"))
+	re.Equal(batchGroup, op.GetAdditionalInfo("batch-group"))
+}
+
+func TestDispatchSplitScatterKeepsStableGroupWhenRegionSplitsAgain(t *testing.T) {
+	re := require.New(t)
+	controller, tc, oc, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	stableGroup := makeSplitScatterIndexGroup(splitScatterTestTableID, splitScatterTestIndexID)
+	sourceID := uint64(100)
+	childIDs := []uint64{101, 201, 301}
+	splitKeys := []string{"m", "t", "x"}
+	previousBatchGroup := ""
+
+	putSplitScatterRegionWithKeysByID(tc, sourceID, newSplitScatterIndexKey("a"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage)
+	for i, childID := range childIDs {
+		controller.RecordSplitScatterBatch(sourceID, splitScatterTestSourceWaitVersion, []uint64{childID})
+		batchGroup := splitScatterPendingGroup(t, controller, childID)
+		re.NotEqual(previousBatchGroup, batchGroup)
+
+		tc.PutRegion(tc.GetRegion(sourceID).Clone(
+			core.WithEndKey(newSplitScatterIndexKey(splitKeys[i])),
+			core.WithIncVersion(),
+		))
+		putSplitScatterRegionWithKeysByID(tc, childID, newSplitScatterIndexKey(splitKeys[i]), newSplitScatterIndexKey("z"), splitScatterReportedCPUUsage)
+
+		controller.dispatchSplitScatterRegions()
+
+		requireInternalScatterOpsUseGroups(t, oc, stableGroup, batchGroup)
+		removeInternalScatterOps(oc)
+		previousBatchGroup = batchGroup
+	}
+}
+
+func TestDispatchSplitScatterBacksOff(t *testing.T) {
+	testCases := []struct {
+		name      string
+		putRegion func(*mockcluster.Cluster)
+	}{
+		{
+			name: "region is not fully replicated",
+			putRegion: func(tc *mockcluster.Cluster) {
+				putSplitScatterRegionWithStores(tc, 101, "m", "", splitScatterReportedCPUUsage, 1, 2)
+			},
+		},
+		{
+			name: "scatter internal fails",
+			putRegion: func(tc *mockcluster.Cluster) {
+				putSplitScatterRegionWithoutLeader(tc, 101, "m", "", splitScatterReportedCPUUsage)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			controller, tc, _, cleanup := newTestSplitScatterController(t)
+			defer cleanup()
+
+			controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+			testCase.putRegion(tc)
+			advanceSplitScatterSourceVersion(t, tc)
+
+			controller.dispatchSplitScatterRegions()
+
+			re.Equal(1, splitScatterPendingCount(controller))
+			pending := splitScatterObservedPending(t, controller)
+			re.True(pending.retryAt.After(time.Now()))
+			re.Empty(pendingRegionIDs(controller.collectTopPendingSplitScatter(2)))
+		})
+	}
+}
+
+func TestDispatchSplitScatterIgnoresStalePendingSnapshot(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	stalePending := splitScatterObservedPending(t, controller)
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{102, 101})
+	currentPending := splitScatterObservedPending(t, controller)
+	re.NotEqual(stalePending.group, currentPending.group)
+	re.Equal(time.Time{}, currentPending.retryAt)
+
+	controller.splitScatter.delayPendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(time.Time{}, currentPending.retryAt)
+
+	controller.splitScatter.deletePendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(makeSplitScatterGroup(100, 102), currentPending.group)
+	re.Equal(time.Time{}, currentPending.retryAt)
+}
+
+func TestDispatchSplitScatterIgnoresStalePendingWithSameGroup(t *testing.T) {
+	re := require.New(t)
+	controller, _, _, cleanup := newTestSplitScatterController(t)
+	defer cleanup()
+
+	controller.RecordSplitScatterBatch(100, splitScatterTestSourceWaitVersion, []uint64{101})
+	stalePending := splitScatterObservedPending(t, controller)
+
+	controller.splitScatter.pendingMu.Lock()
+	currentPending := controller.splitScatter.pending[splitScatterObservedRegionID]
+	currentPending.expireAt = currentPending.expireAt.Add(time.Minute)
+	controller.splitScatter.pending[splitScatterObservedRegionID] = currentPending
+	controller.splitScatter.pendingMu.Unlock()
+
+	controller.splitScatter.delayPendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(time.Time{}, currentPending.retryAt)
+
+	controller.splitScatter.deletePendingSplitScatter(stalePending)
+
+	currentPending = splitScatterObservedPending(t, controller)
+	re.Equal(stalePending.group, currentPending.group)
+	re.NotEqual(stalePending.expireAt, currentPending.expireAt)
+}
+
+func newTestSplitScatterController(t *testing.T) (*Controller, *mockcluster.Cluster, *operator.Controller, func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	for storeID := uint64(1); storeID <= 4; storeID++ {
+		tc.AddRegionStore(storeID, 0)
+	}
+	putSplitScatterRegion(tc, 100, "", "m", splitScatterNoCPUUsage)
+
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	controller := NewController(ctx, tc, tc.GetCheckerConfig(), tc.GetRuleManager(), tc.GetRegionLabeler(), oc)
+
+	cleanup := func() {
+		stream.Close()
+		cancel()
+	}
+	return controller, tc, oc, cleanup
+}
+
+func putSplitScatterRegion(tc *mockcluster.Cluster, regionID uint64, startKey, endKey string, cpuUsage uint64) {
+	tc.AddLeaderRegionWithRange(regionID, startKey, endKey, 1, 2, 3)
+	region := tc.GetRegion(regionID).Clone(core.SetCPUUsage(cpuUsage))
+	tc.PutRegion(region)
+}
+
+func putSplitScatterRegionWithKeys(tc *mockcluster.Cluster, startKey, endKey []byte, cpuUsage uint64) {
+	putSplitScatterRegionWithKeysByID(tc, splitScatterObservedRegionID, startKey, endKey, cpuUsage)
+}
+
+func putSplitScatterRegionWithKeysByID(tc *mockcluster.Cluster, regionID uint64, startKey, endKey []byte, cpuUsage uint64) {
+	peers := []*metapb.Peer{
+		{Id: regionID*10 + 1, StoreId: 1},
+		{Id: regionID*10 + 2, StoreId: 2},
+		{Id: regionID*10 + 3, StoreId: 3},
+	}
+	region := core.NewRegionInfo(
+		&metapb.Region{
+			Id:       regionID,
+			StartKey: startKey,
+			EndKey:   endKey,
+			Peers:    peers,
+			RegionEpoch: &metapb.RegionEpoch{
+				ConfVer: 1,
+				Version: 1,
+			},
+		},
+		peers[0],
+		core.SetCPUUsage(cpuUsage),
+	)
+	tc.PutRegion(region)
+}
+
+func newSplitScatterRegionInfo(
+	regionID uint64,
+	startKey, endKey string,
+	peers []*metapb.Peer,
+	leader *metapb.Peer,
+	cpuUsage uint64,
+) *core.RegionInfo {
+	return core.NewRegionInfo(
+		&metapb.Region{
+			Id:       regionID,
+			StartKey: []byte(startKey),
+			EndKey:   []byte(endKey),
+			Peers:    peers,
+			RegionEpoch: &metapb.RegionEpoch{
+				ConfVer: 1,
+				Version: 1,
+			},
+		},
+		leader,
+		core.SetCPUUsage(cpuUsage),
+	)
+}
+
+func putSplitScatterRegionWithStores(tc *mockcluster.Cluster, regionID uint64, startKey, endKey string, cpuUsage uint64, stores ...uint64) {
+	peers := make([]*metapb.Peer, 0, len(stores))
+	for i, storeID := range stores {
+		peers = append(peers, &metapb.Peer{
+			Id:      regionID*10 + uint64(i) + 1,
+			StoreId: storeID,
+		})
+	}
+	tc.PutRegion(newSplitScatterRegionInfo(regionID, startKey, endKey, peers, peers[0], cpuUsage))
+}
+
+func putSplitScatterRegionWithoutLeader(tc *mockcluster.Cluster, regionID uint64, startKey, endKey string, cpuUsage uint64) {
+	peers := []*metapb.Peer{
+		{Id: regionID*10 + 1, StoreId: 1},
+		{Id: regionID*10 + 2, StoreId: 2},
+		{Id: regionID*10 + 3, StoreId: 3},
+	}
+	tc.PutRegion(newSplitScatterRegionInfo(regionID, startKey, endKey, peers, nil, cpuUsage))
+}
+
+func fillSplitScatterPending(controller *Controller, expireAt time.Time) {
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	for regionID := uint64(1000); regionID < 1000+splitScatterPendingLimit; regionID++ {
+		controller.splitScatter.pending[regionID] = splitScatterPendingItem{
+			regionID: regionID,
+			group:    "old",
+			expireAt: expireAt,
+		}
+	}
+}
+
+func advanceSplitScatterSourceVersion(t *testing.T, tc *mockcluster.Cluster) {
+	advanceSplitScatterRegionVersion(t, tc, 100)
+}
+
+func advanceSplitScatterRegionVersion(t *testing.T, tc *mockcluster.Cluster, regionID uint64) {
+	t.Helper()
+	region := tc.GetRegion(regionID)
+	require.NotNil(t, region)
+	tc.PutRegion(region.Clone(core.WithIncVersion()))
+}
+
+func splitScatterPendingCount(controller *Controller) int {
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	return len(controller.splitScatter.pending)
+}
+
+func splitScatterPendingExpiredCount(attempted string) float64 {
+	return promtestutil.ToFloat64(splitScatterPendingExpiredCounter.WithLabelValues(attempted))
+}
+
+func splitScatterPendingGroup(t *testing.T, controller *Controller, regionID uint64) string {
+	t.Helper()
+	return splitScatterPending(t, controller, regionID).group
+}
+
+func splitScatterPending(t *testing.T, controller *Controller, regionID uint64) splitScatterPendingItem {
+	t.Helper()
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	pending, ok := controller.splitScatter.pending[regionID]
+	require.True(t, ok)
+	return pending
+}
+
+func splitScatterObservedPending(t *testing.T, controller *Controller) splitScatterPendingItem {
+	t.Helper()
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	pending, ok := controller.splitScatter.pending[splitScatterObservedRegionID]
+	require.True(t, ok)
+	return pending
+}
+
+func expireSplitScatterPendingAt(t *testing.T, controller *Controller, regionID uint64, expireAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	pending, ok := controller.splitScatter.pending[regionID]
+	require.True(t, ok)
+	pending.expireAt = expireAt
+	controller.splitScatter.pending[regionID] = pending
+}
+
+func retrySplitScatterPendingAt(t *testing.T, controller *Controller, regionID uint64, retryAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	pending, ok := controller.splitScatter.pending[regionID]
+	require.True(t, ok)
+	pending.retryAt = retryAt
+	controller.splitScatter.pending[regionID] = pending
+}
+
+func setSplitScatterNextDispatchAt(t *testing.T, controller *Controller, nextDispatchAt time.Time) {
+	t.Helper()
+	controller.splitScatter.pendingMu.Lock()
+	defer controller.splitScatter.pendingMu.Unlock()
+	controller.splitScatter.nextDispatchAt = nextDispatchAt
+}
+
+func splitScatterNextDispatchAt(t *testing.T, controller *Controller) time.Time {
+	t.Helper()
+	controller.splitScatter.pendingMu.RLock()
+	defer controller.splitScatter.pendingMu.RUnlock()
+	return controller.splitScatter.nextDispatchAt
+}
+
+func requireInternalScatterOpsUseGroups(t *testing.T, oc *operator.Controller, scatterGroup, batchGroup string) {
+	t.Helper()
+	re := require.New(t)
+	ops := oc.GetOperators()
+	re.NotEmpty(ops)
+	for _, op := range ops {
+		re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+		re.Equal(scatterGroup, op.GetAdditionalInfo("group"))
+		re.Equal(batchGroup, op.GetAdditionalInfo("batch-group"))
+	}
+}
+
+func removeInternalScatterOps(oc *operator.Controller) {
+	for _, op := range oc.GetOperators() {
+		oc.RemoveOperator(op)
+	}
+}
+
+func pendingRegionIDs(regions []splitScatterPendingItem) []uint64 {
+	ids := make([]uint64, 0, len(regions))
+	for _, region := range regions {
+		ids = append(ids, region.regionID)
+	}
+	return ids
+}
+
+func splitScatterIndexKeyPrefix() []byte {
+	return codec.GenerateIndexKey(splitScatterTestTableID, splitScatterTestIndexID)
+}
+
+func newSplitScatterIndexKey(suffix string) []byte {
+	key := append([]byte(nil), splitScatterIndexKeyPrefix()...)
+	key = append(key, suffix...)
+	return codec.EncodeBytes(key)
+}
+
+func newSplitScatterRecordKey(tableID int64, suffix string) []byte {
+	key := append([]byte(nil), codec.GenerateRecordKeyPrefix(tableID)...)
+	key = append(key, suffix...)
+	return codec.EncodeBytes(key)
+}
+
+func newSplitScatterTableBoundaryKey(tableID int64) []byte {
+	return codec.EncodeBytes(codec.GenerateTableKey(tableID))
+}

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -34,16 +34,17 @@ const (
 	// defaultMaxMergeRegionSize is the default maximum size of region when regions can be merged.
 	// After https://github.com/tikv/tikv/issues/17309, the default value is enlarged from 20 to 54,
 	// to make it compatible with the default value of region size of tikv.
-	defaultMaxMergeRegionSize     = 54
-	defaultLeaderScheduleLimit    = 4
-	defaultRegionScheduleLimit    = 2048
-	defaultWitnessScheduleLimit   = 4
-	defaultReplicaScheduleLimit   = 64
-	defaultMergeScheduleLimit     = 8
-	defaultHotRegionScheduleLimit = 4
-	defaultTolerantSizeRatio      = 0
-	defaultLowSpaceRatio          = 0.8
-	defaultHighSpaceRatio         = 0.7
+	defaultMaxMergeRegionSize        = 54
+	defaultLeaderScheduleLimit       = 4
+	defaultRegionScheduleLimit       = 2048
+	defaultWitnessScheduleLimit      = 4
+	defaultReplicaScheduleLimit      = 64
+	defaultMergeScheduleLimit        = 8
+	defaultHotRegionScheduleLimit    = 4
+	defaultSplitScatterScheduleLimit = 4
+	defaultTolerantSizeRatio         = 0
+	defaultLowSpaceRatio             = 0.8
+	defaultHighSpaceRatio            = 0.7
 	// defaultHotRegionCacheHitsThreshold is the low hit number threshold of the
 	// hot region.
 	defaultHotRegionCacheHitsThreshold = 3
@@ -103,6 +104,7 @@ const (
 	ReplicaRescheduleLimitKey      = "schedule.replica-schedule-limit"
 	MergeScheduleLimitKey          = "schedule.merge-schedule-limit"
 	HotRegionScheduleLimitKey      = "schedule.hot-region-schedule-limit"
+	SplitScatterScheduleLimitKey   = "schedule.split-scatter-schedule-limit"
 	SchedulerMaxWaitingOperatorKey = "schedule.scheduler-max-waiting-operator"
 	EnableLocationReplacement      = "schedule.enable-location-replacement"
 	DefaultAddPeer                 = "default-add-peer"
@@ -203,6 +205,8 @@ type ScheduleConfig struct {
 	MergeScheduleLimit uint64 `toml:"merge-schedule-limit" json:"merge-schedule-limit"`
 	// HotRegionScheduleLimit is the max coexist hot region schedules.
 	HotRegionScheduleLimit uint64 `toml:"hot-region-schedule-limit" json:"hot-region-schedule-limit"`
+	// SplitScatterScheduleLimit is the max coexist internal split-scatter schedules. 0 means disabled.
+	SplitScatterScheduleLimit uint64 `toml:"split-scatter-schedule-limit" json:"split-scatter-schedule-limit"`
 	// HotRegionCacheHitThreshold is the cache hits threshold of the hot region.
 	// If the number of times a region hits the hot cache is greater than this
 	// threshold, it is considered a hot region.
@@ -364,6 +368,9 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	}
 	if !meta.IsDefined("hot-region-schedule-limit") {
 		configutil.AdjustUint64(&c.HotRegionScheduleLimit, defaultHotRegionScheduleLimit)
+	}
+	if !meta.IsDefined("split-scatter-schedule-limit") {
+		configutil.AdjustUint64(&c.SplitScatterScheduleLimit, defaultSplitScatterScheduleLimit)
 	}
 	if !meta.IsDefined("hot-region-cache-hits-threshold") {
 		configutil.AdjustUint64(&c.HotRegionCacheHitsThreshold, defaultHotRegionCacheHitsThreshold)

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -99,6 +99,7 @@ type CheckerConfigProvider interface {
 type SharedConfigProvider interface {
 	GetMaxReplicas() int
 	IsPlacementRulesEnabled() bool
+	GetSplitScatterScheduleLimit() uint64
 	GetMaxSnapshotCount() uint64
 	GetMaxPendingPeerCount() uint64
 	GetLowSpaceRatio() float64

--- a/pkg/schedule/operator/builder.go
+++ b/pkg/schedule/operator/builder.go
@@ -164,6 +164,17 @@ func NewBuilder(desc string, ci sche.SharedCluster, region *core.RegionInfo, opt
 	return b
 }
 
+// IsAllowedLeaderTarget checks whether the peer can be selected as a
+// non-forced target leader by the operator builder.
+func IsAllowedLeaderTarget(ci sche.SharedCluster, region *core.RegionInfo, peer *metapb.Peer) bool {
+	b := NewBuilder("check-target-leader", ci, region)
+	if b.err != nil {
+		return false
+	}
+	b.currentPeers, b.currentLeaderStoreID = b.originPeers.copy(), b.originLeaderStoreID
+	return b.allowLeader(peer, false)
+}
+
 // AddPeer records an add Peer operation in Builder. If peer.Id is 0, the builder
 // will allocate a new peer ID later.
 func (b *Builder) AddPeer(peer *metapb.Peer) *Builder {

--- a/pkg/schedule/operator/create_operator.go
+++ b/pkg/schedule/operator/create_operator.go
@@ -235,6 +235,16 @@ func isRegionMatch(a, b *core.RegionInfo) bool {
 
 // CreateScatterRegionOperator creates an operator that scatters the specified region.
 func CreateScatterRegionOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, skipLimitCheck bool) (*Operator, error) {
+	return newScatterRegionOperator(desc, ci, origin, targetPeers, targetLeader, skipLimitCheck, OpAdmin)
+}
+
+// CreateNonAdminScatterRegionOperator creates a scatter operator for internal
+// split-scatter background flows.
+func CreateNonAdminScatterRegionOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, skipLimitCheck bool) (*Operator, error) {
+	return newScatterRegionOperator(desc, ci, origin, targetPeers, targetLeader, skipLimitCheck, OpSplitScatter)
+}
+
+func newScatterRegionOperator(desc string, ci sche.SharedCluster, origin *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, skipLimitCheck bool, kind OpKind) (*Operator, error) {
 	// randomly pick a leader.
 	var ids []uint64
 	for id, peer := range targetPeers {
@@ -255,13 +265,16 @@ func CreateScatterRegionOperator(desc string, ci sche.SharedCluster, origin *cor
 		builder.SetRemoveLightPeer()
 	}
 
-	return builder.
+	builder = builder.
 		SetPeers(targetPeers).
 		SetLeader(leader).
-		SetAddLightPeer().
-		// EnableForceTargetLeader in order to ignore the leader schedule limit
-		EnableForceTargetLeader().
-		Build(OpAdmin)
+		SetAddLightPeer()
+	if kind&OpAdmin != 0 {
+		// Admin scatter keeps the historical behavior: force the selected
+		// target leader so manual scatter can bypass leader scheduling limits.
+		builder.EnableForceTargetLeader()
+	}
+	return builder.Build(kind)
 }
 
 // OpDescLeaveJointState is the expected desc for LeaveJointStateOperator.

--- a/pkg/schedule/operator/create_operator_test.go
+++ b/pkg/schedule/operator/create_operator_test.go
@@ -1141,6 +1141,38 @@ func (suite *createOperatorTestSuite) TestMoveRegionWithoutJointConsensus() {
 	}
 }
 
+func (suite *createOperatorTestSuite) TestNonAdminScatterDoesNotForceTargetLeader() {
+	re := suite.Require()
+	peers := []*metapb.Peer{
+		{Id: 1, StoreId: 1, Role: metapb.PeerRole_Voter},
+		{Id: 2, StoreId: 2, Role: metapb.PeerRole_Voter},
+		{Id: 10, StoreId: 10, Role: metapb.PeerRole_Voter},
+	}
+	region := core.NewRegionInfo(&metapb.Region{Id: 1, Peers: peers}, peers[0])
+	targetPeers := map[uint64]*metapb.Peer{
+		1:  peers[0],
+		2:  peers[1],
+		10: peers[2],
+	}
+
+	adminOp, err := CreateScatterRegionOperator("admin-scatter", suite.cluster, region, targetPeers, 10, false)
+	re.NoError(err)
+	re.NotNil(adminOp)
+	re.Equal(OpAdmin, adminOp.SchedulerKind())
+	re.Zero(adminOp.Kind() & OpSplitScatter)
+
+	nonAdminOp, err := CreateNonAdminScatterRegionOperator("internal-scatter", suite.cluster, region, targetPeers, 2, false)
+	re.NoError(err)
+	re.NotNil(nonAdminOp)
+	re.Equal(OpSplitScatter, nonAdminOp.SchedulerKind())
+	re.NotZero(nonAdminOp.Kind() & OpSplitScatter)
+
+	nonAdminOp, err = CreateNonAdminScatterRegionOperator("internal-scatter", suite.cluster, region, targetPeers, 10, false)
+	re.Error(err)
+	re.Nil(nonAdminOp)
+	re.Contains(err.Error(), "target leader is not allowed")
+}
+
 // Ref https://github.com/tikv/pd/issues/5401
 func TestCreateLeaveJointStateOperatorWithoutFitRules(t *testing.T) {
 	re := require.New(t)

--- a/pkg/schedule/operator/kind.go
+++ b/pkg/schedule/operator/kind.go
@@ -49,6 +49,8 @@ const (
 	OpWitnessLeader
 	// Include witness transfer.
 	OpWitness
+	// Initiated by internal split-scatter dispatcher.
+	OpSplitScatter
 	opMax
 )
 
@@ -63,6 +65,7 @@ var flagToName = map[OpKind]string{
 	OpRange:         "range",
 	OpWitness:       "witness",
 	OpWitnessLeader: "witness-leader",
+	OpSplitScatter:  "split-scatter",
 }
 
 var nameToFlag = map[string]OpKind{
@@ -75,6 +78,7 @@ var nameToFlag = map[string]OpKind{
 	"merge":          OpMerge,
 	"range":          OpRange,
 	"witness-leader": OpWitnessLeader,
+	"split-scatter":  OpSplitScatter,
 }
 
 func (k OpKind) String() string {

--- a/pkg/schedule/operator/operator.go
+++ b/pkg/schedule/operator/operator.go
@@ -216,6 +216,12 @@ func (o *Operator) Kind() OpKind {
 // SchedulerKind return the highest OpKind even if the operator has many OpKind
 // fix #3778
 func (o *Operator) SchedulerKind() OpKind {
+	if o.kind&OpAdmin != 0 {
+		return OpAdmin
+	}
+	if o.kind&OpSplitScatter != 0 {
+		return OpSplitScatter
+	}
 	// LowBit ref: https://en.wikipedia.org/wiki/Find_first_set
 	// 6(110) ==> 2(10)
 	// 5(101) ==> 1(01)

--- a/pkg/schedule/operator/operator_test.go
+++ b/pkg/schedule/operator/operator_test.go
@@ -475,9 +475,40 @@ func (suite *operatorTestSuite) TestSchedulerKind() {
 			op:     NewTestOperator(1, &metapb.RegionEpoch{}, OpLeader),
 			expect: OpLeader,
 		},
+		{
+			op:     NewTestOperator(1, &metapb.RegionEpoch{}, OpSplitScatter|OpRegion),
+			expect: OpSplitScatter,
+		}, {
+			op:     NewTestOperator(1, &metapb.RegionEpoch{}, OpAdmin|OpSplitScatter|OpRegion),
+			expect: OpAdmin,
+		},
 	}
 	for _, v := range testData {
 		re.Equal(v.expect, v.op.SchedulerKind())
+	}
+}
+
+func (suite *operatorTestSuite) TestOpKindValues() {
+	re := suite.Require()
+	testCases := []struct {
+		name string
+		kind OpKind
+		want OpKind
+	}{
+		{"admin", OpAdmin, 1 << 0},
+		{"merge", OpMerge, 1 << 1},
+		{"range", OpRange, 1 << 2},
+		{"replica", OpReplica, 1 << 3},
+		{"split", OpSplit, 1 << 4},
+		{"hot-region", OpHotRegion, 1 << 5},
+		{"region", OpRegion, 1 << 6},
+		{"leader", OpLeader, 1 << 7},
+		{"witness-leader", OpWitnessLeader, 1 << 8},
+		{"witness", OpWitness, 1 << 9},
+		{"split-scatter", OpSplitScatter, 1 << 10},
+	}
+	for _, testCase := range testCases {
+		re.Equal(testCase.want, testCase.kind, "unexpected %s kind value", testCase.name)
 	}
 }
 

--- a/pkg/schedule/scatter/region_scatterer.go
+++ b/pkg/schedule/scatter/region_scatterer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"strconv"
 	"sync"
 	"time"
@@ -42,8 +43,9 @@ import (
 const regionScatterName = "region-scatter"
 
 var (
-	gcInterval = time.Minute
-	gcTTL      = time.Minute * 3
+	gcInterval            = time.Minute
+	gcTTL                 = time.Minute * 3
+	operatorPriorityLevel = constant.High
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	scatterSkipEmptyRegionCounter   = scatterCounter.WithLabelValues("skip", "empty-region")
 	scatterSkipNoRegionCounter      = scatterCounter.WithLabelValues("skip", "no-region")
@@ -53,6 +55,8 @@ var (
 	scatterUnnecessaryCounter       = scatterCounter.WithLabelValues("unnecessary", "")
 	scatterFailCounter              = scatterCounter.WithLabelValues("fail", "")
 	scatterSuccessCounter           = scatterCounter.WithLabelValues("success", "")
+	scatterOperatorRunningCounter   = scatterCounter.WithLabelValues("skip", "running")
+	scatterOperatorExistedCounter   = scatterCounter.WithLabelValues("fail", "other-existed")
 	errRegionNotFound               = errors.New("region not found")
 	errEmptyRegion                  = errors.New("empty region")
 )
@@ -61,7 +65,15 @@ const (
 	maxSleepDuration     = time.Minute
 	initialSleepDuration = 100 * time.Millisecond
 	maxRetryLimit        = 30
+	// AdminScatterOperatorDesc is used by external admin/API scatter requests.
+	AdminScatterOperatorDesc = "scatter-region"
+	// InternalScatterOperatorDesc is used by PD-internal split-scatter dispatch.
+	InternalScatterOperatorDesc = "split-scatter-region"
 )
+
+type selectedStoreCounter interface {
+	Get(id uint64, group string) uint64
+}
 
 type selectedStores struct {
 	mu                syncutil.RWMutex
@@ -72,6 +84,38 @@ func newSelectedStores(ctx context.Context) *selectedStores {
 	return &selectedStores{
 		groupDistribution: cache.NewStringTTL(ctx, gcInterval, gcTTL),
 	}
+}
+
+type localSelectedStores struct {
+	groupDistribution map[string]map[uint64]uint64
+	seededGroups      map[string]struct{}
+}
+
+func newLocalSelectedStores() *localSelectedStores {
+	return &localSelectedStores{
+		groupDistribution: make(map[string]map[uint64]uint64),
+		seededGroups:      make(map[string]struct{}),
+	}
+}
+
+func cloneDistribution(distribution map[uint64]uint64) map[uint64]uint64 {
+	cloned := make(map[uint64]uint64, len(distribution))
+	for id, count := range distribution {
+		cloned[id] = count
+	}
+	return cloned
+}
+
+func decrementDistribution(distribution map[uint64]uint64, id uint64) {
+	count, ok := distribution[id]
+	if !ok {
+		return
+	}
+	if count <= 1 {
+		delete(distribution, id)
+		return
+	}
+	distribution[id] = count - 1
 }
 
 // Put plus count by storeID and group
@@ -117,6 +161,54 @@ func (s *selectedStores) getDistributionByGroupLocked(group string) (map[uint64]
 	return nil, false
 }
 
+// Get the count by storeID and group.
+func (s *localSelectedStores) Get(id uint64, group string) uint64 {
+	distribution, ok := s.groupDistribution[group]
+	if !ok {
+		return 0
+	}
+	count, ok := distribution[id]
+	if !ok {
+		return 0
+	}
+	return count
+}
+
+// InitGroupDistribution seeds the distribution for a group if the group has not
+// been tracked yet.
+func (s *localSelectedStores) InitGroupDistribution(group string, distribution map[uint64]uint64) bool {
+	if _, ok := s.groupDistribution[group]; ok {
+		return false
+	}
+	s.groupDistribution[group] = cloneDistribution(distribution)
+	s.seededGroups[group] = struct{}{}
+	return true
+}
+
+// Update records the group distribution after scattering one more region.
+// For seeded groups it applies the net old->new change. Otherwise it keeps the
+// historical scatter behavior and only counts the new placement.
+func (s *localSelectedStores) Update(group string, oldIDs, newIDs []uint64) {
+	distribution, ok := s.groupDistribution[group]
+	if !ok {
+		distribution = map[uint64]uint64{}
+	}
+	if s.isSeededGroup(group) {
+		for _, id := range oldIDs {
+			decrementDistribution(distribution, id)
+		}
+	}
+	for _, id := range newIDs {
+		distribution[id]++
+	}
+	s.groupDistribution[group] = distribution
+}
+
+func (s *localSelectedStores) isSeededGroup(group string) bool {
+	_, ok := s.seededGroups[group]
+	return ok
+}
+
 // RegionScatterer scatters regions.
 type RegionScatterer struct {
 	ctx               context.Context
@@ -151,14 +243,163 @@ type engineContext struct {
 	selectedLeader *selectedStores
 }
 
+type localEngineContext struct {
+	filterFuncs    []filterFunc
+	selectedPeer   *localSelectedStores
+	selectedLeader *localSelectedStores
+}
+
+type scatterSelectionContext struct {
+	filterFuncs    []filterFunc
+	selectedPeer   selectedStoreCounter
+	selectedLeader selectedStoreCounter
+}
+
 func newEngineContext(ctx context.Context, filterFuncs ...filterFunc) engineContext {
 	filterFuncs = append(filterFuncs, func() filter.Filter {
-		return &filter.StoreStateFilter{ActionScope: regionScatterName, MoveRegion: true, ScatterRegion: true, OperatorLevel: constant.High}
+		return &filter.StoreStateFilter{ActionScope: regionScatterName, MoveRegion: true, ScatterRegion: true, OperatorLevel: operatorPriorityLevel}
 	})
 	return engineContext{
 		filterFuncs:    filterFuncs,
 		selectedPeer:   newSelectedStores(ctx),
 		selectedLeader: newSelectedStores(ctx),
+	}
+}
+
+func (ctx engineContext) asSelectionContext() scatterSelectionContext {
+	return scatterSelectionContext{
+		filterFuncs:    ctx.filterFuncs,
+		selectedPeer:   ctx.selectedPeer,
+		selectedLeader: ctx.selectedLeader,
+	}
+}
+
+func (ctx localEngineContext) asSelectionContext() scatterSelectionContext {
+	return scatterSelectionContext{
+		filterFuncs:    ctx.filterFuncs,
+		selectedPeer:   ctx.selectedPeer,
+		selectedLeader: ctx.selectedLeader,
+	}
+}
+
+func (r *RegionScatterer) getOrCreateSpecialEngineContext(engine string) engineContext {
+	if ctx, ok := r.specialEngines.Load(engine); ok {
+		return ctx.(engineContext)
+	}
+	ctx := newEngineContext(r.ctx, func() filter.Filter {
+		return filter.NewEngineFilter(r.name, placement.LabelConstraint{Key: core.EngineKey, Op: placement.In, Values: []string{engine}})
+	})
+	r.specialEngines.Store(engine, ctx)
+	return ctx
+}
+
+type scatterState struct {
+	ordinaryEngine localEngineContext
+	specialEngines map[string]localEngineContext
+}
+
+func (ctx engineContext) withEmptySelection() localEngineContext {
+	return localEngineContext{
+		filterFuncs:    ctx.filterFuncs,
+		selectedPeer:   newLocalSelectedStores(),
+		selectedLeader: newLocalSelectedStores(),
+	}
+}
+
+func (r *RegionScatterer) newScatterState() *scatterState {
+	return &scatterState{
+		ordinaryEngine: r.ordinaryEngine.withEmptySelection(),
+		specialEngines: make(map[string]localEngineContext),
+	}
+}
+
+func (s *scatterState) getSpecialEngine(engine string) (localEngineContext, bool) {
+	ctx, ok := s.specialEngines[engine]
+	return ctx, ok
+}
+
+func (r *RegionScatterer) getOrCreateSpecialEngineState(state *scatterState, engine string) localEngineContext {
+	if ctx, ok := state.getSpecialEngine(engine); ok {
+		return ctx
+	}
+	ctx := r.getOrCreateSpecialEngineContext(engine).withEmptySelection()
+	state.specialEngines[engine] = ctx
+	return ctx
+}
+
+// seedScatterStateByRange seeds the scatter group with the current live peer and
+// leader distribution of the specified key range.
+func (r *RegionScatterer) seedScatterStateByRange(state *scatterState, group string, startKey, endKey []byte) {
+	if group == "" || len(startKey) == 0 {
+		return
+	}
+	if state.ordinaryEngine.selectedPeer.isSeededGroup(group) {
+		return
+	}
+
+	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
+	ordinaryPeer := make(map[uint64]uint64)
+	ordinaryLeader := make(map[uint64]uint64)
+	specialPeer := make(map[string]map[uint64]uint64)
+	for _, store := range r.cluster.GetStores() {
+		if store == nil {
+			continue
+		}
+		storeID := store.GetID()
+		peerCount := uint64(r.cluster.GetStorePeerCountByRange(storeID, startKey, endKey))
+		if engineFilter.Target(r.cluster.GetSharedConfig(), store).IsOK() {
+			if peerCount > 0 {
+				ordinaryPeer[storeID] = peerCount
+			}
+			if leaderCount := uint64(r.cluster.GetStoreLeaderCountByRange(storeID, startKey, endKey)); leaderCount > 0 {
+				ordinaryLeader[storeID] = leaderCount
+			}
+			continue
+		}
+		if peerCount == 0 {
+			continue
+		}
+
+		engine := store.GetLabelValue(core.EngineKey)
+		if _, ok := specialPeer[engine]; !ok {
+			specialPeer[engine] = make(map[uint64]uint64)
+		}
+		specialPeer[engine][storeID] = peerCount
+	}
+
+	state.ordinaryEngine.selectedPeer.InitGroupDistribution(group, ordinaryPeer)
+	state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, ordinaryLeader)
+	for engine, distribution := range specialPeer {
+		ctx := r.getOrCreateSpecialEngineState(state, engine)
+		ctx.selectedPeer.InitGroupDistribution(group, distribution)
+	}
+}
+
+func (r *RegionScatterer) newInternalScatterState(group string, startKey, endKey []byte) *scatterState {
+	state := r.newScatterState()
+	r.seedScatterStateByRange(state, group, startKey, endKey)
+	r.applyRunningScatterOpsDelta(state, group)
+	return state
+}
+
+func (r *RegionScatterer) applyRunningScatterOpsDelta(state *scatterState, group string) {
+	if group == "" {
+		return
+	}
+	for _, op := range r.opController.GetOperators() {
+		if op == nil || op.Desc() != InternalScatterOperatorDesc {
+			continue
+		}
+		opGroup := op.GetAdditionalInfo("group")
+		if opGroup != group {
+			continue
+		}
+		region := r.cluster.GetRegion(op.RegionID())
+		if region == nil || region.GetLeader() == nil {
+			continue
+		}
+		targetPeers, targetLeader := finalPlacementAfterOperator(region, op)
+		r.applyScatterStateDelta(state, region, targetPeers, targetLeader, group, false)
 	}
 }
 
@@ -274,11 +515,53 @@ func (r *RegionScatterer) scatterRegions(regions map[uint64]*core.RegionInfo, fa
 // Scatter relocates the region. If the group is defined, the regions' leader with the same group would be scattered
 // in a group level instead of cluster level.
 func (r *RegionScatterer) Scatter(region *core.RegionInfo, group string, skipStoreLimit bool) (*operator.Operator, error) {
+	return r.scatterWithOptions(region, group, skipStoreLimit, false, nil)
+}
+
+// ScatterInternal relocates the region for PD-internal split-scatter dispatch.
+func (r *RegionScatterer) ScatterInternal(region *core.RegionInfo, group string, startKey, endKey []byte) (*operator.Operator, error) {
+	return r.scatterWithOptions(region, group, false, true, r.newInternalScatterState(group, startKey, endKey))
+}
+
+func (r *RegionScatterer) scatterWithOptions(region *core.RegionInfo, group string, skipStoreLimit bool, internalScatter bool, state *scatterState) (*operator.Operator, error) {
+	expectedDesc := AdminScatterOperatorDesc
+	if internalScatter {
+		expectedDesc = InternalScatterOperatorDesc
+	}
 	if !filter.IsRegionReplicated(r.cluster, region) {
 		r.addSuspectRegions(false, region.GetID())
 		scatterSkipNotReplicatedCounter.Inc()
 		log.Warn("region not replicated during scatter", zap.Uint64("region-id", region.GetID()))
 		return nil, errors.Errorf("region %d is not fully replicated", region.GetID())
+	}
+
+	// Check if there is any existing operator for the region.
+	// if the exist operator level is higher than scatter operator level, give up to create new scatter operator new.
+	// otherwise, create new scatter operator to replace the existing one.
+	if op := r.opController.GetOperator(region.GetID()); op != nil && op.GetPriorityLevel() >= operatorPriorityLevel {
+		val := op.GetAdditionalInfo("group")
+		// If the existing operator is created by the same group scatterer, just skip creating a new one.
+		if op.Desc() == expectedDesc && val == group {
+			if !isSameRegionEpoch(op.RegionEpoch(), region.GetRegionEpoch()) {
+				scatterOperatorExistedCounter.Inc()
+				log.Debug("same group scatter operator epoch does not match",
+					zap.Uint64("region-id", region.GetID()),
+					zap.Reflect("operator-epoch", op.RegionEpoch()),
+					zap.Reflect("region-epoch", region.GetRegionEpoch()))
+				return nil, errors.Errorf("the operator of region %d already exist with different epoch", region.GetID())
+			}
+			scatterOperatorRunningCounter.Inc()
+			log.Debug("scatter operator is already running",
+				zap.Uint64("region-id", region.GetID()))
+			return nil, nil
+		}
+		scatterOperatorExistedCounter.Inc()
+		log.Debug("the operator exist, but it does not meet requirement",
+			zap.Uint64("region-id", region.GetID()),
+			zap.String("additional-info-group", val),
+			zap.String("operator-des", op.Desc()),
+		)
+		return nil, errors.Errorf("the operator of region %d already exist", region.GetID())
 	}
 
 	if region.GetLeader() == nil {
@@ -287,16 +570,30 @@ func (r *RegionScatterer) Scatter(region *core.RegionInfo, group string, skipSto
 		return nil, errors.Errorf("region %d has no leader", region.GetID())
 	}
 
-	if r.cluster.IsRegionHot(region) {
+	if !internalScatter && r.cluster.IsRegionHot(region) {
 		scatterSkipHotRegionCounter.Inc()
 		log.Warn("region too hot during scatter", zap.Uint64("region-id", region.GetID()))
 		return nil, errors.Errorf("region %d is hot", region.GetID())
 	}
 
-	return r.scatterRegion(region, group, skipStoreLimit)
+	return r.scatterRegionWithType(region, group, skipStoreLimit, internalScatter, state)
 }
 
-func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, skipStoreLimit bool) (*operator.Operator, error) {
+func (r *RegionScatterer) scatterRegionWithType(region *core.RegionInfo, group string, skipStoreLimit bool, internalScatter bool, state *scatterState) (*operator.Operator, error) {
+	desc := AdminScatterOperatorDesc
+	if internalScatter {
+		desc = InternalScatterOperatorDesc
+	}
+	ordinaryContext := r.ordinaryEngine.asSelectionContext()
+	getSpecialEngineContext := func(engine string) scatterSelectionContext {
+		return r.getOrCreateSpecialEngineContext(engine).asSelectionContext()
+	}
+	if state != nil {
+		ordinaryContext = state.ordinaryEngine.asSelectionContext()
+		getSpecialEngineContext = func(engine string) scatterSelectionContext {
+			return r.getOrCreateSpecialEngineState(state, engine).asSelectionContext()
+		}
+	}
 	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
 	ordinaryPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
 	specialPeers := make(map[string]map[uint64]*metapb.Peer)
@@ -318,10 +615,29 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 		}
 	}
 
-	targetPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))                  // StoreID -> Peer
-	selectedStores := make(map[uint64]struct{}, len(region.GetPeers()))                   // selected StoreID set
-	leaderCandidateStores := make([]uint64, 0, len(region.GetPeers()))                    // StoreID allowed to become Leader
-	scatterWithSameEngine := func(peers map[uint64]*metapb.Peer, context engineContext) { // peers: StoreID -> Peer
+	targetPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers())) // StoreID -> Peer
+	selectedStores := make(map[uint64]struct{}, len(region.GetPeers()))  // selected StoreID set
+	leaderCandidateStores := make([]uint64, 0, len(region.GetPeers()))   // StoreID allowed to become Leader
+	if internalScatter {
+		leader := region.GetLeader()
+		if leader == nil {
+			return nil, errs.ErrGetTargetStore.FastGenByArgs(fmt.Sprintf("no source leader store found, region: %v", region))
+		}
+		leaderStoreID := leader.GetStoreId()
+		if !r.isAllowedLeaderSource(leaderStoreID) {
+			peer := region.GetStorePeer(leaderStoreID)
+			if peer == nil {
+				return nil, errs.ErrGetTargetStore.FastGenByArgs(fmt.Sprintf("source leader peer not found, region: %v", region))
+			}
+			targetPeers[leaderStoreID] = peer
+			selectedStores[leaderStoreID] = struct{}{}
+		}
+	}
+	scatterWithSameEngine := func(
+		peers map[uint64]*metapb.Peer,
+		context scatterSelectionContext,
+		collectLeaderCandidates bool,
+	) { // peers: StoreID -> Peer
 		filterLen := len(context.filterFuncs) + 2
 		filters := make([]filter.Filter, filterLen)
 		for i, filterFunc := range context.filterFuncs {
@@ -330,7 +646,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 		filters[filterLen-2] = filter.NewExcludedFilter(r.name, nil, selectedStores)
 		for _, peer := range peers {
 			if _, ok := selectedStores[peer.GetStoreId()]; ok {
-				if allowLeader(oldFit, peer) {
+				if collectLeaderCandidates && allowLeader(oldFit, peer) {
 					leaderCandidateStores = append(leaderCandidateStores, peer.GetStoreId())
 				}
 				// It is both sourcePeer and targetPeer itself, no need to select.
@@ -343,7 +659,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 			}
 			filters[filterLen-1] = filter.NewPlacementSafeguard(r.name, r.cluster.GetSharedConfig(), r.cluster.GetBasicCluster(), r.cluster.GetRuleManager(), region, sourceStore, oldFit)
 			for {
-				newPeer := r.selectNewPeer(context, group, peer, filters)
+				newPeer := r.selectNewPeer(context, group, peer, filters, internalScatter)
 				targetPeers[newPeer.GetStoreId()] = newPeer
 				selectedStores[newPeer.GetStoreId()] = struct{}{}
 				// If the selected peer is a peer other than origin peer in this region,
@@ -351,7 +667,7 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 				// This origin peer re-selects.
 				if _, ok := peers[newPeer.GetStoreId()]; !ok || peer.GetStoreId() == newPeer.GetStoreId() {
 					selectedStores[peer.GetStoreId()] = struct{}{}
-					if allowLeader(oldFit, peer) {
+					if collectLeaderCandidates && allowLeader(oldFit, peer) {
 						leaderCandidateStores = append(leaderCandidateStores, newPeer.GetStoreId())
 					}
 					break
@@ -360,50 +676,109 @@ func (r *RegionScatterer) scatterRegion(region *core.RegionInfo, group string, s
 		}
 	}
 
-	scatterWithSameEngine(ordinaryPeers, r.ordinaryEngine)
+	scatterWithSameEngine(ordinaryPeers, ordinaryContext, true)
+	for engine, peers := range specialPeers {
+		// Special-engine stores are only peer targets for now. Keep them out of
+		// leader candidates so leader selection still only considers ordinary stores.
+		scatterWithSameEngine(peers, getSpecialEngineContext(engine), false)
+	}
+	if internalScatter {
+		leaderCandidateStores = r.filterAllowedLeaderCandidateStores(region, targetPeers, leaderCandidateStores)
+	}
 	// FIXME: target leader only considers the ordinary stores, maybe we need to consider the
 	// special engine stores if the engine supports to become a leader. But now there is only
 	// one engine, tiflash, which does not support the leader, so don't consider it for now.
-	targetLeader, leaderStorePickedCount := r.selectAvailableLeaderStore(group, region, leaderCandidateStores, r.ordinaryEngine)
+	targetLeader, leaderStorePickedCount := r.selectAvailableLeaderStore(group, region, leaderCandidateStores, ordinaryContext, internalScatter)
 	if targetLeader == 0 {
 		scatterSkipNoLeaderCounter.Inc()
 		return nil, errs.ErrGetTargetStore.FastGenByArgs(fmt.Sprintf("no target leader store found, region: %v", region))
 	}
 
-	for engine, peers := range specialPeers {
-		ctx, ok := r.specialEngines.Load(engine)
-		if !ok {
-			ctx = newEngineContext(r.ctx, func() filter.Filter {
-				return filter.NewEngineFilter(r.name, placement.LabelConstraint{Key: core.EngineKey, Op: placement.In, Values: []string{engine}})
-			})
-			r.specialEngines.Store(engine, ctx)
-		}
-		scatterWithSameEngine(peers, ctx.(engineContext))
-	}
-
 	if isSameDistribution(region, targetPeers, targetLeader) {
 		scatterUnnecessaryCounter.Inc()
-		r.Put(targetPeers, targetLeader, group)
+		if state != nil {
+			r.applyScatterStateDelta(state, region, targetPeers, targetLeader, group, !internalScatter)
+		} else {
+			r.Put(targetPeers, targetLeader, group)
+		}
 		return nil, nil
 	}
-	op, err := operator.CreateScatterRegionOperator("scatter-region", r.cluster, region, targetPeers, targetLeader, skipStoreLimit)
+	createScatterOperator := operator.CreateScatterRegionOperator
+	if internalScatter {
+		createScatterOperator = operator.CreateNonAdminScatterRegionOperator
+	}
+	op, err := createScatterOperator(desc, r.cluster, region, targetPeers, targetLeader, skipStoreLimit)
 	if err != nil {
 		scatterFailCounter.Inc()
+		currentPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
 		for _, peer := range region.GetPeers() {
-			targetPeers[peer.GetStoreId()] = peer
+			currentPeers[peer.GetStoreId()] = peer
 		}
-		r.Put(targetPeers, region.GetLeader().GetStoreId(), group)
+		if state != nil {
+			r.applyScatterStateDelta(state, region, currentPeers, region.GetLeader().GetStoreId(), group, !internalScatter)
+		} else {
+			r.Put(currentPeers, region.GetLeader().GetStoreId(), group)
+		}
 		log.Debug("fail to create scatter region operator", errs.ZapError(err))
 		return nil, errs.ErrCreateOperator.FastGenByArgs(fmt.Sprintf("failed to create scatter region operator for region %v", region.GetID()))
 	}
 	if op != nil {
 		scatterSuccessCounter.Inc()
-		r.Put(targetPeers, targetLeader, group)
+		if state == nil {
+			r.Put(targetPeers, targetLeader, group)
+		}
 		op.SetAdditionalInfo("group", group)
-		op.SetAdditionalInfo("leader-picked-count", strconv.FormatUint(leaderStorePickedCount, 10))
-		op.SetPriorityLevel(constant.High)
+		if !internalScatter {
+			op.SetAdditionalInfo("leader-picked-count", strconv.FormatUint(leaderStorePickedCount, 10))
+		}
+		op.SetPriorityLevel(operatorPriorityLevel)
 	}
 	return op, nil
+}
+
+func (r *RegionScatterer) filterAllowedLeaderCandidateStores(
+	region *core.RegionInfo,
+	targetPeers map[uint64]*metapb.Peer,
+	candidateStores []uint64,
+) []uint64 {
+	if len(candidateStores) == 0 {
+		return candidateStores
+	}
+	filtered := candidateStores[:0]
+	leader := region.GetLeader()
+	if leader == nil {
+		return filtered
+	}
+	currentLeaderStoreID := leader.GetStoreId()
+	if !r.isAllowedLeaderSource(currentLeaderStoreID) {
+		for _, storeID := range candidateStores {
+			if storeID == currentLeaderStoreID {
+				return append(filtered, storeID)
+			}
+		}
+		return filtered
+	}
+	for _, storeID := range candidateStores {
+		peer := targetPeers[storeID]
+		if peer == nil {
+			continue
+		}
+		if operator.IsAllowedLeaderTarget(r.cluster, region, peer) {
+			filtered = append(filtered, storeID)
+		}
+	}
+	return filtered
+}
+
+func (r *RegionScatterer) isAllowedLeaderSource(storeID uint64) bool {
+	store := r.cluster.GetStore(storeID)
+	if store == nil {
+		return false
+	}
+	stateFilter := &filter.StoreStateFilter{ActionScope: r.name, TransferLeader: true}
+	return filter.NewCandidates(rand.New(rand.NewSource(time.Now().UnixNano())), []*core.StoreInfo{store}).
+		FilterSource(r.cluster.GetSharedConfig(), nil, nil, stateFilter).
+		Len() > 0
 }
 
 func allowLeader(fit *placement.RegionFit, peer *metapb.Peer) bool {
@@ -435,13 +810,13 @@ func isSameDistribution(region *core.RegionInfo, targetPeers map[uint64]*metapb.
 	return region.GetLeader().GetStoreId() == targetLeader
 }
 
-// selectNewPeer return the new peer which pick the fewest picked count.
+// selectNewPeer returns the new peer which pick the fewest picked count.
 // it keeps the origin peer if the origin store's pick count is equal the fewest pick.
 // it can be divided into three steps:
 // 1. found the max pick count and the min pick count.
 // 2. if max pick count equals min pick count, it means all store picked count are some, return the origin peer.
 // 3. otherwise, select the store which pick count is the min pick count and pass all filter.
-func (r *RegionScatterer) selectNewPeer(context engineContext, group string, peer *metapb.Peer, filters []filter.Filter) *metapb.Peer {
+func (r *RegionScatterer) selectNewPeer(context scatterSelectionContext, group string, peer *metapb.Peer, filters []filter.Filter, internalScatter bool) *metapb.Peer {
 	stores := r.cluster.GetStores()
 	maxStoreTotalCount := uint64(0)
 	minStoreTotalCount := uint64(math.MaxUint64)
@@ -458,6 +833,7 @@ func (r *RegionScatterer) selectNewPeer(context engineContext, group string, pee
 	var newPeer *metapb.Peer
 	minCount := uint64(math.MaxUint64)
 	originStorePickedCount := uint64(math.MaxUint64)
+	bestStoreRegionCount := math.MaxInt
 	for _, store := range stores {
 		storeCount := context.selectedPeer.Get(store.GetID(), group)
 		if store.GetID() == peer.GetStoreId() {
@@ -466,17 +842,29 @@ func (r *RegionScatterer) selectNewPeer(context engineContext, group string, pee
 		// If storeCount is equal to the maxStoreTotalCount, we should skip this store as candidate.
 		// If the storeCount are all the same for the whole cluster(maxStoreTotalCount == minStoreTotalCount), any store
 		// could be selected as candidate.
-		if storeCount < maxStoreTotalCount || maxStoreTotalCount == minStoreTotalCount {
-			if filter.Target(r.cluster.GetSharedConfig(), store, filters) {
-				if storeCount < minCount {
-					minCount = storeCount
-					newPeer = &metapb.Peer{
-						StoreId: store.GetID(),
-						Role:    peer.GetRole(),
-					}
-				}
-			}
+		if storeCount >= maxStoreTotalCount && maxStoreTotalCount != minStoreTotalCount {
+			continue
 		}
+		if !filter.Target(r.cluster.GetSharedConfig(), store, filters) {
+			continue
+		}
+		candidate := &metapb.Peer{
+			StoreId: store.GetID(),
+			Role:    peer.GetRole(),
+		}
+		storeRegionCount := store.GetRegionCount()
+		if storeCount < minCount ||
+			(internalScatter && storeCount == minCount &&
+				(storeRegionCount < bestStoreRegionCount ||
+					(storeRegionCount == bestStoreRegionCount && (newPeer == nil || store.GetID() < newPeer.GetStoreId())))) {
+			minCount = storeCount
+			newPeer = candidate
+			bestStoreRegionCount = storeRegionCount
+		}
+	}
+	if internalScatter && newPeer != nil && peer.GetStoreId() != newPeer.GetStoreId() &&
+		!peerMoveReducesSourceTargetGap(context.selectedPeer, group, peer.GetStoreId(), newPeer.GetStoreId()) {
+		return peer
 	}
 	if originStorePickedCount <= minCount {
 		return peer
@@ -487,33 +875,115 @@ func (r *RegionScatterer) selectNewPeer(context engineContext, group string, pee
 	return newPeer
 }
 
-// selectAvailableLeaderStore select the target leader store from the candidates. The candidates would be collected by
-// the existed peers store depended on the leader counts in the group level. Please use this func before scatter spacial engines.
+// selectAvailableLeaderStore selects the target leader store from candidate
+// peer stores after ordinary and special-engine peer scatter. Special-engine
+// stores are excluded from candidates because they cannot become leaders.
 func (r *RegionScatterer) selectAvailableLeaderStore(group string, region *core.RegionInfo,
-	leaderCandidateStores []uint64, context engineContext) (leaderID uint64, leaderStorePickedCount uint64) {
-	sourceStore := r.cluster.GetStore(region.GetLeader().GetStoreId())
-	if sourceStore == nil {
+	leaderCandidateStores []uint64, context scatterSelectionContext, internalScatter bool) (leaderID uint64, leaderStorePickedCount uint64) {
+	if r.cluster.GetStore(region.GetLeader().GetStoreId()) == nil {
 		log.Error("failed to get the store", zap.Uint64("store-id", region.GetLeader().GetStoreId()), errs.ZapError(errs.ErrGetSourceStore))
 		return 0, 0
 	}
 	minStoreGroupLeader := uint64(math.MaxUint64)
+	minStoreGroupPeer := uint64(math.MaxUint64)
 	id := uint64(0)
+	unusedAlternativeID := uint64(0)
+	unusedAlternativePeerCount := uint64(math.MaxUint64)
+	currentLeaderID := region.GetLeader().GetStoreId()
+	currentLeaderCanStay := false
 	for _, storeID := range leaderCandidateStores {
 		store := r.cluster.GetStore(storeID)
 		if store == nil {
 			continue
 		}
+		if storeID == currentLeaderID {
+			currentLeaderCanStay = true
+		}
 		storeGroupLeaderCount := context.selectedLeader.Get(storeID, group)
-		if minStoreGroupLeader > storeGroupLeaderCount {
+		storeGroupPeerCount := context.selectedPeer.Get(storeID, group)
+		if internalScatter && storeID != currentLeaderID && storeGroupLeaderCount == 0 {
+			if unusedAlternativeID == 0 || storeGroupPeerCount < unusedAlternativePeerCount ||
+				(storeGroupPeerCount == unusedAlternativePeerCount && storeID < unusedAlternativeID) {
+				unusedAlternativeID = storeID
+				unusedAlternativePeerCount = storeGroupPeerCount
+			}
+		}
+		if id == 0 || minStoreGroupLeader > storeGroupLeaderCount ||
+			(internalScatter && minStoreGroupLeader == storeGroupLeaderCount && minStoreGroupPeer > storeGroupPeerCount) {
 			minStoreGroupLeader = storeGroupLeaderCount
+			minStoreGroupPeer = storeGroupPeerCount
 			id = storeID
 		}
 	}
-	return id, minStoreGroupLeader
+	selectedID := id
+	if internalScatter && unusedAlternativeID != 0 {
+		selectedID = unusedAlternativeID
+	}
+	if selectedID == 0 {
+		return 0, 0
+	}
+	if internalScatter && currentLeaderCanStay && selectedID != currentLeaderID &&
+		!leaderMoveReducesSourceTargetGap(context.selectedLeader, group, currentLeaderID, selectedID) {
+		selectedID = currentLeaderID
+	}
+	return selectedID, context.selectedLeader.Get(selectedID, group)
+}
+
+func peerMoveReducesSourceTargetGap(selectedPeers selectedStoreCounter, group string, fromStoreID, toStoreID uint64) bool {
+	fromCount := selectedPeers.Get(fromStoreID, group)
+	toCount := selectedPeers.Get(toStoreID, group)
+	return fromCount > toCount+1
+}
+
+func leaderMoveReducesSourceTargetGap(selectedLeaders selectedStoreCounter, group string, fromStoreID, toStoreID uint64) bool {
+	fromCount := selectedLeaders.Get(fromStoreID, group)
+	toCount := selectedLeaders.Get(toStoreID, group)
+	// A zero source count means this group has no seeded/current leader history
+	// for the origin store, so keep the original scatter fallback behavior.
+	return fromCount == 0 || fromCount > toCount+1
+}
+
+func isSameRegionEpoch(left, right *metapb.RegionEpoch) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.GetVersion() == right.GetVersion() && left.GetConfVer() == right.GetConfVer()
+}
+
+// finalPlacementAfterOperator projects the final target placement of an
+// in-flight operator by walking its steps without considering partial execution
+// progress. This is a forward-looking estimate: the caller uses it to deduct the
+// operator's intended footprint from the next round of store selection, so the
+// estimate is intentionally the end state rather than the current half-done state.
+func finalPlacementAfterOperator(region *core.RegionInfo, op *operator.Operator) (map[uint64]*metapb.Peer, uint64) {
+	targetPeers := make(map[uint64]*metapb.Peer, len(region.GetPeers()))
+	for _, peer := range region.GetPeers() {
+		targetPeers[peer.GetStoreId()] = peer
+	}
+	targetLeader := region.GetLeader().GetStoreId()
+	if op == nil {
+		return targetPeers, targetLeader
+	}
+	for i := range op.Len() {
+		switch step := op.Step(i).(type) {
+		case operator.TransferLeader:
+			targetLeader = step.ToStore
+		case operator.AddPeer:
+			targetPeers[step.ToStore] = &metapb.Peer{StoreId: step.ToStore}
+		case operator.AddLearner:
+			targetPeers[step.ToStore] = &metapb.Peer{StoreId: step.ToStore}
+		case operator.RemovePeer:
+			delete(targetPeers, step.FromStore)
+		}
+	}
+	return targetPeers, targetLeader
 }
 
 // Put put the final distribution in the context no matter the operator was created
 func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint64, group string) {
+	if leaderStoreID == 0 {
+		return
+	}
 	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
 	// Group peers by the engine of their stores
 	for _, peer := range peers {
@@ -528,19 +998,83 @@ func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint6
 				fmt.Sprintf("%v", storeID),
 				fmt.Sprintf("%v", false),
 				core.EngineTiKV).Inc()
-		} else {
-			engine := store.GetLabelValue(core.EngineKey)
-			ctx, _ := r.specialEngines.Load(engine)
-			ctx.(engineContext).selectedPeer.Put(storeID, group)
-			scatterDistributionCounter.WithLabelValues(
-				fmt.Sprintf("%v", storeID),
-				fmt.Sprintf("%v", false),
-				engine).Inc()
+			continue
 		}
+		engine := store.GetLabelValue(core.EngineKey)
+		ctx := r.getOrCreateSpecialEngineContext(engine)
+		ctx.selectedPeer.Put(storeID, group)
+		scatterDistributionCounter.WithLabelValues(
+			strconv.FormatUint(storeID, 10),
+			strconv.FormatBool(false),
+			engine).Inc()
 	}
 	r.ordinaryEngine.selectedLeader.Put(leaderStoreID, group)
 	scatterDistributionCounter.WithLabelValues(
 		fmt.Sprintf("%v", leaderStoreID),
 		fmt.Sprintf("%v", true),
 		core.EngineTiKV).Inc()
+}
+
+// applyScatterStateDelta records a local scatter state change after scattering a
+// region to the target placement. Metrics are only emitted when this delta
+// corresponds to a new scatter decision accepted in the current request/round.
+func (r *RegionScatterer) applyScatterStateDelta(state *scatterState, region *core.RegionInfo, targetPeers map[uint64]*metapb.Peer, targetLeader uint64, group string, recordMetrics bool) {
+	if state == nil || region == nil || region.GetLeader() == nil {
+		return
+	}
+	engineFilter := filter.NewEngineFilter(r.name, filter.NotSpecialEngines)
+	ordinaryOldStores := make([]uint64, 0, len(region.GetPeers()))
+	ordinaryNewStores := make([]uint64, 0, len(targetPeers))
+	specialOldStores := make(map[string][]uint64)
+	specialNewStores := make(map[string][]uint64)
+
+	classifyStore := func(storeID uint64, ordinary *[]uint64, special map[string][]uint64) string {
+		store := r.cluster.GetStore(storeID)
+		if store == nil {
+			return ""
+		}
+		if engineFilter.Target(r.cluster.GetSharedConfig(), store).IsOK() {
+			*ordinary = append(*ordinary, storeID)
+			return core.EngineTiKV
+		}
+		engine := store.GetLabelValue(core.EngineKey)
+		special[engine] = append(special[engine], storeID)
+		return engine
+	}
+
+	for _, peer := range region.GetPeers() {
+		classifyStore(peer.GetStoreId(), &ordinaryOldStores, specialOldStores)
+	}
+	for _, peer := range targetPeers {
+		storeID := peer.GetStoreId()
+		engine := classifyStore(storeID, &ordinaryNewStores, specialNewStores)
+		if recordMetrics && engine != "" {
+			scatterDistributionCounter.WithLabelValues(
+				strconv.FormatUint(storeID, 10),
+				strconv.FormatBool(false),
+				engine).Inc()
+		}
+	}
+
+	state.ordinaryEngine.selectedPeer.Update(group, ordinaryOldStores, ordinaryNewStores)
+	specialEngines := make(map[string]struct{}, len(specialOldStores)+len(specialNewStores))
+	for engine := range specialOldStores {
+		specialEngines[engine] = struct{}{}
+	}
+	for engine := range specialNewStores {
+		specialEngines[engine] = struct{}{}
+	}
+	for engine := range specialEngines {
+		ctx := r.getOrCreateSpecialEngineState(state, engine)
+		ctx.selectedPeer.Update(group, specialOldStores[engine], specialNewStores[engine])
+	}
+
+	oldLeaderStoreID := region.GetLeader().GetStoreId()
+	state.ordinaryEngine.selectedLeader.Update(group, []uint64{oldLeaderStoreID}, []uint64{targetLeader})
+	if recordMetrics {
+		scatterDistributionCounter.WithLabelValues(
+			strconv.FormatUint(targetLeader, 10),
+			strconv.FormatBool(true),
+			core.EngineTiKV).Inc()
+	}
 }

--- a/pkg/schedule/scatter/region_scatterer_test.go
+++ b/pkg/schedule/scatter/region_scatterer_test.go
@@ -27,12 +27,17 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
+	"github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
+	"github.com/tikv/pd/pkg/statistics/utils"
+	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/versioninfo"
 )
 
@@ -74,6 +79,8 @@ func TestScatterRegions(t *testing.T) {
 }
 
 func checkOperator(re *require.Assertions, op *operator.Operator) {
+	re.Equal(operator.OpAdmin, op.SchedulerKind())
+	re.Equal(constant.High, op.GetPriorityLevel())
 	for i := range op.Len() {
 		if rp, ok := op.Step(i).(operator.RemovePeer); ok {
 			for j := i + 1; j < op.Len(); j++ {
@@ -84,6 +91,18 @@ func checkOperator(re *require.Assertions, op *operator.Operator) {
 			}
 		}
 	}
+}
+
+func newTestScatterState(scatterer *RegionScatterer) *scatterState {
+	return scatterer.newScatterState()
+}
+
+func (s *localSelectedStores) getGroupDistributionClone(group string) (map[uint64]uint64, bool) {
+	distribution, ok := s.groupDistribution[group]
+	if !ok {
+		return nil, false
+	}
+	return cloneDistribution(distribution), true
 }
 
 func scatter(re *require.Assertions, numStores, numRegions uint64, useRules bool) {
@@ -363,7 +382,9 @@ func TestSomeStoresFilteredScatterGroupInConcurrency(t *testing.T) {
 func scatterOnce(tc *mockcluster.Cluster, scatter *RegionScatterer, group string, wg *sync.WaitGroup) {
 	regionID := 1
 	for range 100 {
-		scatter.scatterRegion(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3), group, false)
+		if _, err := scatter.Scatter(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3), group, false); err != nil {
+			panic(err)
+		}
 		regionID++
 	}
 	wg.Done()
@@ -409,8 +430,9 @@ func TestScatterGroupInConcurrency(t *testing.T) {
 		regionID := 1
 		for range 100 {
 			for j := range testCase.groupCount {
-				scatterer.scatterRegion(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3),
+				_, err := scatterer.Scatter(tc.AddLeaderRegion(uint64(regionID), 1, 2, 3),
 					fmt.Sprintf("group-%v", j), false)
+				re.NoError(err)
 				regionID++
 			}
 		}
@@ -471,16 +493,6 @@ func TestScatterForManyRegion(t *testing.T) {
 
 func TestScattersGroup(t *testing.T) {
 	re := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	opt := mockconfig.NewTestOptions()
-	tc := mockcluster.NewCluster(ctx, opt)
-	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
-	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
-	// Add 5 stores.
-	for i := uint64(1); i <= 5; i++ {
-		tc.AddRegionStore(i, 0)
-	}
 	testCases := []struct {
 		name    string
 		failure bool
@@ -495,52 +507,76 @@ func TestScattersGroup(t *testing.T) {
 		},
 	}
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/scatter/scatterHbStreamsDrain", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterHbStreamsDrain"))
+	}()
 	for id, testCase := range testCases {
-		group := fmt.Sprintf("gourp-%d", id)
-		t.Log(testCase.name)
-		scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
-		regions := map[uint64]*core.RegionInfo{}
-		for i := 1; i <= 100; i++ {
-			regions[uint64(i)] = tc.AddLightWeightLeaderRegion(uint64(i), 1, 2, 3)
-		}
-		failures := map[uint64]error{}
-		if testCase.failure {
-			re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail", `return(true)`))
-		}
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			opt := mockconfig.NewTestOptions()
+			tc := mockcluster.NewCluster(ctx, opt)
+			stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+			defer stream.Close()
+			oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+			for i := uint64(1); i <= 5; i++ {
+				tc.AddRegionStore(i, 0)
+			}
+			group := fmt.Sprintf("group-%d", id)
+			t.Log(testCase.name)
+			scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+			regions := map[uint64]*core.RegionInfo{}
+			for i := 1; i <= 100; i++ {
+				regions[uint64(i)] = tc.AddLightWeightLeaderRegion(uint64(i), 1, 2, 3)
+			}
+			failures := map[uint64]error{}
+			if testCase.failure {
+				re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail", `return(true)`))
+				defer func() {
+					re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail"))
+				}()
+			}
 
-		scatterer.scatterRegions(regions, failures, group, 3, false)
-		max := uint64(0)
-		min := uint64(math.MaxUint64)
-		groupDistribution, exist := scatterer.ordinaryEngine.selectedLeader.GetGroupDistribution(group)
-		re.True(exist)
-		for _, count := range groupDistribution {
-			if count > max {
-				max = count
+			_, err := scatterer.scatterRegions(regions, failures, group, 3, false)
+			re.NoError(err)
+			max := uint64(0)
+			min := uint64(math.MaxUint64)
+			groupDistribution, exist := scatterer.ordinaryEngine.selectedLeader.GetGroupDistribution(group)
+			re.True(exist)
+			for _, count := range groupDistribution {
+				if count > max {
+					max = count
+				}
+				if count < min {
+					min = count
+				}
 			}
-			if count < min {
-				min = count
+			// 100 regions divided 5 stores, each store expected to have about 20 regions.
+			re.LessOrEqual(min, uint64(20))
+			re.GreaterOrEqual(max, uint64(20))
+			re.LessOrEqual(max-min, uint64(3))
+			if testCase.failure {
+				re.Len(failures, 1)
+				_, ok := failures[1]
+				re.True(ok)
+			} else {
+				re.Empty(failures)
 			}
-		}
-		// 100 regions divided 5 stores, each store expected to have about 20 regions.
-		re.LessOrEqual(min, uint64(20))
-		re.GreaterOrEqual(max, uint64(20))
-		re.LessOrEqual(max-min, uint64(3))
-		if testCase.failure {
-			re.Len(failures, 1)
-			_, ok := failures[1]
-			re.True(ok)
-			re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterFail"))
-		} else {
-			re.Empty(failures)
-		}
+		}()
 	}
-	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/scatter/scatterHbStreamsDrain"))
 }
 
 func TestSelectedStoreGC(t *testing.T) {
 	re := require.New(t)
+	originalGCInterval := gcInterval
+	originalGCTTL := gcTTL
 	gcInterval = time.Second
 	gcTTL = time.Second * 3
+	defer func() {
+		gcInterval = originalGCInterval
+		gcTTL = originalGCTTL
+	}()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stores := newSelectedStores(ctx)
@@ -675,11 +711,237 @@ func TestSelectedStoresTooFewPeers(t *testing.T) {
 	// Try to scatter a region with peer store id 2/3/4
 	for i := uint64(1); i < 20; i++ {
 		region := tc.AddLeaderRegion(i+200, i%3+2, (i+1)%3+2, (i+2)%3+2)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 		if op != nil {
 			re.Equal(group, op.GetAdditionalInfo("group"))
+		}
+	}
+}
+
+func TestSeedGroupDistributionByRange(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(2, "j", "t", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(3, "t", "z", 1, 2, 3)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+
+	group := "seeded"
+	state := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+
+	peerDistribution, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(uint64(3), peerDistribution[1])
+	re.Equal(uint64(3), peerDistribution[2])
+	re.Equal(uint64(3), peerDistribution[3])
+	re.Equal(uint64(0), peerDistribution[4])
+
+	leaderDistribution, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(uint64(3), leaderDistribution[1])
+	re.Equal(uint64(0), leaderDistribution[2])
+	re.Equal(uint64(0), leaderDistribution[3])
+	re.Equal(uint64(0), leaderDistribution[4])
+
+	op, err := scatterer.ScatterInternal(tc.GetRegion(3), group, []byte("a"), []byte("z"))
+	re.NoError(err)
+	re.NotNil(op)
+	re.Equal(operator.OpSplitScatter, op.SchedulerKind())
+	re.Zero(op.Kind() & operator.OpAdmin)
+	re.Equal(constant.High, op.GetPriorityLevel())
+	re.NotZero(op.Kind() & operator.OpSplitScatter)
+	re.NotZero(op.Kind() & operator.OpRegion)
+	re.Equal(group, op.GetAdditionalInfo("group"))
+}
+
+func TestSeedGroupDistributionByRangeAppliesNetChange(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(2, "j", "t", 2, 1, 3)
+	tc.AddLeaderRegionWithRange(3, "t", "z", 3, 1, 2)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	group := "seeded-net-change"
+	state := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+
+	region := tc.GetRegion(1)
+	peerBefore, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	leaderBefore, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	peerSnapshot := cloneDistribution(peerBefore)
+	leaderSnapshot := cloneDistribution(leaderBefore)
+
+	op, err := scatterer.ScatterInternal(region, group, []byte("a"), []byte("z"))
+	re.NoError(err)
+	re.NotNil(op)
+	re.Equal(operator.OpSplitScatter, op.SchedulerKind())
+	re.Zero(op.Kind() & operator.OpAdmin)
+	re.Equal(constant.High, op.GetPriorityLevel())
+	re.NotZero(op.Kind() & operator.OpSplitScatter)
+	re.NotZero(op.Kind() & operator.OpRegion)
+	finalPeers, finalLeaderStoreID := finalPlacementAfterOperator(region, op)
+
+	expectedPeerDistribution := cloneDistribution(peerSnapshot)
+	for _, peer := range region.GetPeers() {
+		expectedPeerDistribution[peer.GetStoreId()]--
+	}
+	for storeID := range finalPeers {
+		expectedPeerDistribution[storeID]++
+	}
+
+	expectedLeaderDistribution := cloneDistribution(leaderSnapshot)
+	expectedLeaderDistribution[region.GetLeader().GetStoreId()]--
+	expectedLeaderDistribution[finalLeaderStoreID]++
+	removeZeroCountEntries(expectedPeerDistribution)
+	removeZeroCountEntries(expectedLeaderDistribution)
+
+	re.True(oc.AddOperator(op))
+	nextState := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+	peerDistribution, ok := nextState.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedPeerDistribution, peerDistribution)
+
+	leaderDistribution, ok := nextState.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedLeaderDistribution, leaderDistribution)
+}
+
+func TestSeededDistributionSkipsUpdateWhenAddOperatorRejected(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(2, "j", "t", 1, 2, 3)
+	tc.AddLeaderRegionWithRange(3, "t", "z", 1, 2, 3)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	group := "seeded-rollback"
+	state := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+
+	peerBefore, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	leaderBefore, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	peerSnapshot := cloneDistribution(peerBefore)
+	leaderSnapshot := cloneDistribution(leaderBefore)
+
+	scheduleCfg := tc.GetScheduleConfig().Clone()
+	scheduleCfg.SchedulerMaxWaitingOperator = 0
+	tc.SetScheduleConfig(scheduleCfg)
+
+	region := tc.GetRegion(1)
+	op, err := scatterer.ScatterInternal(region, group, []byte("a"), []byte("z"))
+	re.NoError(err)
+	re.NotNil(op)
+	re.False(oc.AddOperator(op))
+
+	nextState := scatterer.newInternalScatterState(group, []byte("a"), []byte("z"))
+	peerAfter, ok := nextState.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	for i := uint64(1); i <= 4; i++ {
+		re.Equal(peerSnapshot[i], peerAfter[i])
+	}
+
+	leaderAfter, ok := nextState.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	for i := uint64(1); i <= 4; i++ {
+		re.Equal(leaderSnapshot[i], leaderAfter[i])
+	}
+}
+
+func TestCreateScatterRegionOperatorFailureAccountsCurrentPlacement(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 4; i++ {
+		tc.AddRegionStore(i, 0)
+		tc.SetStoreLastHeartbeatInterval(i, -10*time.Minute)
+	}
+
+	tc.AddLeaderRegionWithRange(1, "a", "j", 1, 2, 3)
+	region := tc.GetRegion(1)
+	region = region.Clone(core.WithRole(region.GetPeers()[1].GetId(), metapb.PeerRole_IncomingVoter))
+	tc.PutRegion(region)
+	region = tc.GetRegion(1)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	group := "create-fail"
+	state := newTestScatterState(scatterer)
+	for _, storeID := range []uint64{1, 2, 3} {
+		state.ordinaryEngine.selectedPeer.Update(group, nil, []uint64{storeID})
+	}
+	state.ordinaryEngine.selectedLeader.Update(group, nil, []uint64{1})
+
+	peerBefore, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	leaderBefore, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	peerSnapshot := cloneDistribution(peerBefore)
+	leaderSnapshot := cloneDistribution(leaderBefore)
+
+	op, err := scatterer.scatterWithOptions(region, group, true, false, state)
+	re.Nil(op)
+	re.Error(err)
+	re.Contains(err.Error(), "failed to create scatter region operator")
+
+	expectedPeerDistribution := cloneDistribution(peerSnapshot)
+	for _, peer := range region.GetPeers() {
+		expectedPeerDistribution[peer.GetStoreId()]++
+	}
+	expectedLeaderDistribution := cloneDistribution(leaderSnapshot)
+	expectedLeaderDistribution[region.GetLeader().GetStoreId()]++
+
+	peerAfter, ok := state.ordinaryEngine.selectedPeer.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedPeerDistribution, peerAfter)
+
+	leaderAfter, ok := state.ordinaryEngine.selectedLeader.getGroupDistributionClone(group)
+	re.True(ok)
+	re.Equal(expectedLeaderDistribution, leaderAfter)
+}
+
+func removeZeroCountEntries(distribution map[uint64]uint64) {
+	for storeID, count := range distribution {
+		if count == 0 {
+			delete(distribution, storeID)
 		}
 	}
 }
@@ -716,7 +978,7 @@ func TestSelectedStoresTooManyPeers(t *testing.T) {
 	// test region with peer 1 2 3
 	for i := uint64(1); i < 20; i++ {
 		region := tc.AddLeaderRegion(i+200, i%3+1, (i+1)%3+1, (i+2)%3+1)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 	}
@@ -741,7 +1003,7 @@ func TestBalanceLeader(t *testing.T) {
 	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
 	for i := uint64(1001); i <= 1300; i++ {
 		region := tc.AddLeaderRegion(i, 2, 3, 4)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 	}
@@ -772,7 +1034,7 @@ func TestBalanceRegion(t *testing.T) {
 	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
 	for i := uint64(1001); i <= 1300; i++ {
 		region := tc.AddLeaderRegion(i, 2, 4, 6)
-		op, err := scatterer.scatterRegion(region, group, false)
+		op, err := scatterer.Scatter(region, group, false)
 		re.NoError(err)
 		re.False(isPeerCountChanged(op))
 	}
@@ -782,9 +1044,9 @@ func TestBalanceRegion(t *testing.T) {
 	// Test for unhealthy region
 	// ref https://github.com/tikv/pd/issues/6099
 	region := tc.AddLeaderRegion(1500, 2, 3, 4, 6)
-	op, err := scatterer.scatterRegion(region, group, false)
-	re.NoError(err)
-	re.False(isPeerCountChanged(op))
+	op, err := scatterer.Scatter(region, group, false)
+	re.ErrorContains(err, "is not fully replicated")
+	re.Nil(op)
 }
 
 func isPeerCountChanged(op *operator.Operator) bool {
@@ -836,4 +1098,325 @@ func TestRemoveStoreLimit(t *testing.T) {
 			re.True(oc.AddOperator(op))
 		}
 	}
+}
+
+func TestScatterReplace(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+
+	// Add stores 1~5.
+	for i := uint64(1); i <= 5; i++ {
+		tc.AddRegionStore(i, 0)
+	}
+	// Add regions 1~5.
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	for i := uint64(2); i <= 5; i++ {
+		tc.AddLeaderRegion(i, 1, 2, 3)
+	}
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+
+	for i := uint64(1); i <= 5; i++ {
+		region := tc.GetRegion(i)
+		if op, err := scatterer.Scatter(region, "", true); op != nil {
+			re.NoError(err)
+			re.True(oc.AddOperator(op))
+		}
+	}
+
+	// same scatter operator should be skipped
+	region := tc.GetRegion(2)
+	op, err := scatterer.Scatter(region, "", true)
+	re.NoError(err)
+	re.Nil(op)
+
+	// A same-group operator from an older epoch must not consume a newer
+	// split-scatter attempt for the same region.
+	tc.PutRegion(tc.MockRegionInfo(2, 1, []uint64{2, 3}, nil, &metapb.RegionEpoch{ConfVer: 1, Version: 2}))
+	op, err = scatterer.Scatter(tc.GetRegion(2), "", true)
+	re.Error(err)
+	re.Nil(op)
+
+	// different scatter operator should be rejected
+	region = tc.GetRegion(3)
+	op, err = scatterer.Scatter(region, "test", true)
+	re.Error(err)
+	re.Nil(op)
+
+	// exist lower operator
+	op = oc.GetOperator(1)
+	if op != nil {
+		re.True(oc.RemoveOperator(op))
+	}
+	region = tc.GetRegion(1)
+	op = operator.NewTestOperator(region.GetID(), region.GetRegionEpoch(), operator.OpRegion)
+	op.SetPriorityLevel(constant.Low)
+	re.True(oc.AddOperator(op))
+
+	testutil.Eventually(re, func() bool {
+		op, err = scatterer.Scatter(tc.GetRegion(1), "", true)
+		re.NoError(err)
+		return op != nil
+	})
+}
+
+func TestScatterInternalSkipsHotOnlyForAdmin(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	tc.SetHotRegionCacheHitsThreshold(0)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+
+	for i := uint64(1); i <= 5; i++ {
+		tc.AddRegionStore(i, 0)
+	}
+
+	tc.AddRegionWithReadInfo(
+		1,
+		1,
+		512*1024*utils.StoreHeartBeatReportInterval,
+		0,
+		0,
+		utils.StoreHeartBeatReportInterval,
+		[]uint64{2, 3},
+	)
+	region := tc.GetRegion(1)
+	re.True(tc.IsRegionHot(region))
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+
+	op, err := scatterer.Scatter(region, "", true)
+	re.ErrorContains(err, "is hot")
+	re.Nil(op)
+
+	op, err = scatterer.ScatterInternal(region, "", region.GetStartKey(), region.GetEndKey())
+	re.NoError(err)
+	if op != nil {
+		re.Equal(InternalScatterOperatorDesc, op.Desc())
+	}
+}
+
+func TestInternalScatterPeerSelection(t *testing.T) {
+	testCases := []struct {
+		name              string
+		storeRegionCounts map[uint64]int
+		peerDistribution  map[uint64]uint64
+		excludedStores    []uint64
+		checkAdmin        bool
+		wantAdmin         uint64
+		want              uint64
+		wantAny           []uint64
+	}{
+		{
+			name:             "keeps origin when peer counts are even",
+			peerDistribution: map[uint64]uint64{},
+			excludedStores:   []uint64{2, 3},
+			checkAdmin:       true,
+			wantAdmin:        1,
+			want:             1,
+		},
+		{
+			name:              "prefers less loaded lowest count store",
+			storeRegionCounts: map[uint64]int{4: 100, 5: 10},
+			peerDistribution:  map[uint64]uint64{1: 3, 2: 3, 3: 3, 4: 1, 5: 1},
+			excludedStores:    []uint64{2, 3},
+			want:              5,
+		},
+		{
+			name:             "keeps origin when source target gap is one",
+			peerDistribution: map[uint64]uint64{1: 2, 2: 2, 3: 2, 4: 1, 5: 1},
+			want:             1,
+		},
+		{
+			name:             "moves when source target gap exceeds one",
+			peerDistribution: map[uint64]uint64{1: 6, 2: 4, 3: 4, 4: 1, 5: 1},
+			wantAny:          []uint64{4, 5},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			scatterer, state, _, peer := newInternalScatterSelectionTestFixture(t, testCase.storeRegionCounts)
+			group := "test-peer-selection"
+			re.True(state.ordinaryEngine.selectedPeer.InitGroupDistribution(group, testCase.peerDistribution))
+			filters := newTestExcludedStoreFilter(testCase.excludedStores...)
+
+			if testCase.checkAdmin {
+				adminPeer := scatterer.selectNewPeer(scatterer.ordinaryEngine.asSelectionContext(), group, peer, filters, false)
+				re.Equal(testCase.wantAdmin, adminPeer.GetStoreId())
+			}
+
+			internalPeer := scatterer.selectNewPeer(state.ordinaryEngine.asSelectionContext(), group, peer, filters, true)
+			if len(testCase.wantAny) > 0 {
+				re.Contains(testCase.wantAny, internalPeer.GetStoreId())
+			} else {
+				re.Equal(testCase.want, internalPeer.GetStoreId())
+			}
+		})
+	}
+}
+
+func TestInternalScatterLeaderSelection(t *testing.T) {
+	testCases := []struct {
+		name               string
+		leaderDistribution map[uint64]uint64
+		peerDistribution   map[uint64]uint64
+		checkAdmin         bool
+		wantAdmin          uint64
+		want               uint64
+	}{
+		{
+			name:               "prefers unused store",
+			leaderDistribution: map[uint64]uint64{1: 2, 4: 0, 5: 0},
+			checkAdmin:         true,
+			wantAdmin:          1,
+			want:               4,
+		},
+		{
+			name:               "keeps origin when source target gap is one",
+			leaderDistribution: map[uint64]uint64{1: 1, 4: 0, 5: 0},
+			want:               1,
+		},
+		{
+			name:               "breaks ties by peer deficit",
+			leaderDistribution: map[uint64]uint64{1: 3, 4: 1, 5: 1},
+			peerDistribution:   map[uint64]uint64{1: 10, 4: 9, 5: 2},
+			checkAdmin:         true,
+			wantAdmin:          1,
+			want:               5,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			scatterer, state, region, _ := newInternalScatterSelectionTestFixture(t, nil)
+			group := "test-leader-selection"
+			candidates := []uint64{1, 4, 5}
+			re.True(state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, testCase.leaderDistribution))
+			if testCase.peerDistribution != nil {
+				re.True(state.ordinaryEngine.selectedPeer.InitGroupDistribution(group, testCase.peerDistribution))
+			}
+
+			if testCase.checkAdmin {
+				adminLeader, adminCount := scatterer.selectAvailableLeaderStore(group, region, candidates, scatterer.ordinaryEngine.asSelectionContext(), false)
+				re.Equal(testCase.wantAdmin, adminLeader)
+				re.Equal(scatterer.ordinaryEngine.selectedLeader.Get(adminLeader, group), adminCount)
+			}
+
+			internalLeader, internalCount := scatterer.selectAvailableLeaderStore(group, region, candidates, state.ordinaryEngine.asSelectionContext(), true)
+			re.Equal(testCase.want, internalLeader)
+			re.Equal(state.ordinaryEngine.selectedLeader.Get(internalLeader, group), internalCount)
+		})
+	}
+}
+
+func TestInternalScatterLeaderFiltersRejectedTarget(t *testing.T) {
+	re := require.New(t)
+	scatterer, state, region, _ := newInternalScatterSelectionTestFixture(t, nil)
+	tc := scatterer.cluster.(*mockcluster.Cluster)
+	tc.SetLabelProperty(config.RejectLeader, "reject", "leader")
+	tc.PutStoreWithLabels(4, "reject", "leader")
+
+	group := "test-leader-target-filter"
+	re.True(state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, map[uint64]uint64{1: 3, 4: 0, 5: 1}))
+	targetPeers := map[uint64]*metapb.Peer{
+		1: region.GetStorePeer(1),
+		4: {StoreId: 4, Role: metapb.PeerRole_Voter},
+		5: {StoreId: 5, Role: metapb.PeerRole_Voter},
+	}
+	candidates := scatterer.filterAllowedLeaderCandidateStores(
+		region,
+		targetPeers,
+		[]uint64{1, 4, 5},
+	)
+	re.NotContains(candidates, uint64(4))
+
+	leader, _ := scatterer.selectAvailableLeaderStore(group, region, candidates, state.ordinaryEngine.asSelectionContext(), true)
+	re.Equal(uint64(5), leader)
+}
+
+func TestInternalScatterLeaderKeepsOriginWhenSourcePausedOut(t *testing.T) {
+	re := require.New(t)
+	scatterer, state, region, _ := newInternalScatterSelectionTestFixture(t, nil)
+	tc := scatterer.cluster.(*mockcluster.Cluster)
+	re.NoError(tc.PauseLeaderTransfer(1))
+
+	group := "test-leader-source-filter"
+	re.True(state.ordinaryEngine.selectedLeader.InitGroupDistribution(group, map[uint64]uint64{1: 3, 4: 0, 5: 1}))
+	targetPeers := map[uint64]*metapb.Peer{
+		1: region.GetStorePeer(1),
+		4: {StoreId: 4, Role: metapb.PeerRole_Voter},
+		5: {StoreId: 5, Role: metapb.PeerRole_Voter},
+	}
+	candidates := scatterer.filterAllowedLeaderCandidateStores(region, targetPeers, []uint64{1, 4, 5})
+	re.Equal([]uint64{1}, candidates)
+
+	leader, _ := scatterer.selectAvailableLeaderStore(group, region, candidates, state.ordinaryEngine.asSelectionContext(), true)
+	re.Equal(uint64(1), leader)
+}
+
+func TestInternalScatterKeepsLeaderPeerWhenSourcePausedOut(t *testing.T) {
+	re := require.New(t)
+	scatterer, _, region, _ := newInternalScatterSelectionTestFixture(t, map[uint64]int{
+		1: 10,
+		2: 10,
+		3: 10,
+		4: 1,
+		5: 1,
+	})
+	tc := scatterer.cluster.(*mockcluster.Cluster)
+	re.NoError(tc.PauseLeaderTransfer(1))
+
+	op, err := scatterer.ScatterInternal(region, "paused-out", []byte(""), []byte(""))
+	re.NoError(err)
+	if op == nil {
+		return
+	}
+	targetPeers, targetLeader := finalPlacementAfterOperator(region, op)
+	re.Contains(targetPeers, uint64(1))
+	re.Equal(uint64(1), targetLeader)
+}
+
+func newInternalScatterSelectionTestFixture(t *testing.T, storeRegionCounts map[uint64]int) (*RegionScatterer, *scatterState, *core.RegionInfo, *metapb.Peer) {
+	t.Helper()
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(ctx, opt)
+	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
+	t.Cleanup(stream.Close)
+	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
+	for i := uint64(1); i <= 5; i++ {
+		tc.AddRegionStore(i, storeRegionCounts[i])
+	}
+	region := tc.AddLeaderRegion(1, 1, 2, 3)
+	peer := region.GetStorePeer(1)
+	re.NotNil(peer)
+
+	scatterer := NewRegionScatterer(ctx, tc, oc, tc.AddPendingProcessedRegions)
+	return scatterer, newTestScatterState(scatterer), region, peer
+}
+
+func newTestExcludedStoreFilter(stores ...uint64) []filter.Filter {
+	if len(stores) == 0 {
+		return nil
+	}
+	excluded := make(map[uint64]struct{}, len(stores))
+	for _, storeID := range stores {
+		excluded[storeID] = struct{}{}
+	}
+	return []filter.Filter{filter.NewExcludedFilter("test", nil, excluded)}
 }

--- a/pkg/schedule/types/type.go
+++ b/pkg/schedule/types/type.go
@@ -35,6 +35,8 @@ const (
 	RuleChecker CheckerSchedulerType = "rule-checker"
 	// SplitChecker is the name for split checker.
 	SplitChecker CheckerSchedulerType = "split-checker"
+	// SplitScatterChecker is the name for internal split-scatter dispatch.
+	SplitScatterChecker CheckerSchedulerType = "split-scatter-checker"
 
 	// BalanceLeaderScheduler is balance leader scheduler name.
 	BalanceLeaderScheduler CheckerSchedulerType = "balance-leader-scheduler"

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -212,6 +212,7 @@ func (s *storeStatistics) collect() {
 	configs["region-schedule-limit"] = float64(s.opt.GetRegionScheduleLimit())
 	configs["merge-schedule-limit"] = float64(s.opt.GetMergeScheduleLimit())
 	configs["replica-schedule-limit"] = float64(s.opt.GetReplicaScheduleLimit())
+	configs["split-scatter-schedule-limit"] = float64(s.opt.GetSplitScatterScheduleLimit())
 	configs["max-replicas"] = float64(s.opt.GetMaxReplicas())
 	configs["high-space-ratio"] = s.opt.GetHighSpaceRatio()
 	configs["low-space-ratio"] = s.opt.GetLowSpaceRatio()

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -53,6 +53,8 @@ import (
 )
 
 const (
+	keyspaceGroupPrimaryElectionPurposePrefix = "keyspace group primary election"
+
 	// mergingCheckInterval is the interval for merging check to see if the keyspace groups
 	// merging process could be moved forward.
 	mergingCheckInterval = 5 * time.Second
@@ -62,6 +64,10 @@ const (
 	defaultPrimaryPriorityCheckInterval = 10 * time.Second
 	groupPatrolInterval                 = time.Minute
 )
+
+func keyspaceGroupPrimaryElectionPurpose(groupID uint32) string {
+	return fmt.Sprintf("%s %05d", keyspaceGroupPrimaryElectionPurposePrefix, groupID)
+}
 
 type state struct {
 	syncutil.RWMutex
@@ -757,7 +763,7 @@ func (kgm *KeyspaceGroupManager) updateKeyspaceGroup(group *endpoint.KeyspaceGro
 		Id:         uniqueID, // id is unique among all participants
 		ListenUrls: []string{kgm.cfg.GetAdvertiseListenAddr()},
 	}
-	participant.InitInfo(p, keypath.KeyspaceGroupsElectionPath(kgm.tsoSvcRootPath, group.ID), constant.PrimaryKey, "keyspace group primary election")
+	participant.InitInfo(p, keypath.KeyspaceGroupsElectionPath(kgm.tsoSvcRootPath, group.ID), constant.PrimaryKey, keyspaceGroupPrimaryElectionPurpose(group.ID))
 	// If the keyspace group is in split, we should ensure that the primary elected by the new keyspace group
 	// is always on the same TSO Server node as the primary of the old keyspace group, and this constraint cannot
 	// be broken until the entire split process is completed.

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -65,6 +65,14 @@ func TestKeyspaceGroupManagerTestSuite(t *testing.T) {
 	suite.Run(t, new(keyspaceGroupManagerTestSuite))
 }
 
+func TestKeyspaceGroupPrimaryElectionPurposeIncludesGroupID(t *testing.T) {
+	re := require.New(t)
+
+	re.Equal("keyspace group primary election 00000", keyspaceGroupPrimaryElectionPurpose(0))
+	re.Equal("keyspace group primary election 00012", keyspaceGroupPrimaryElectionPurpose(12))
+	re.Equal("keyspace group primary election 12345", keyspaceGroupPrimaryElectionPurpose(12345))
+}
+
 func (suite *keyspaceGroupManagerTestSuite) SetupSuite() {
 	t := suite.T()
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -134,6 +134,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 		return nil, errors.New("region split is paused by replication mode")
 	}
 	splitIDs := make([]*pdpb.SplitID, 0, splitCount)
+	newRegionIDs := make([]uint64, 0, splitCount)
 	recordRegions := make([]uint64, 0, splitCount+1)
 
 	for i := 0; i < int(splitCount); i++ {
@@ -149,6 +150,7 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 			}
 		}
 
+		newRegionIDs = append(newRegionIDs, newRegionID)
 		recordRegions = append(recordRegions, newRegionID)
 		splitIDs = append(splitIDs, &pdpb.SplitID{
 			NewRegionId: newRegionID,
@@ -168,6 +170,13 @@ func (c *RaftCluster) HandleAskBatchSplit(request *pdpb.AskBatchSplitRequest) (*
 	// status may be left, and these regions need to be checked with higher
 	// priority.
 	c.AddPendingProcessedRegions(false, recordRegions...)
+	if request.GetReason() == pdpb.SplitReason_LOAD {
+		c.GetCoordinator().GetCheckerController().RecordSplitScatterBatch(
+			reqRegion.GetId(),
+			reqRegion.GetRegionEpoch().GetVersion()+1,
+			newRegionIDs,
+		)
+	}
 
 	resp := &pdpb.AskBatchSplitResponse{Ids: splitIDs}
 

--- a/server/cluster/split_scatter_test.go
+++ b/server/cluster/split_scatter_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockid"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/labeler"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+const (
+	// CPU usage is only populated to mimic load-split region heartbeat data.
+	// Current split-scatter dispatch does not rank pending regions by CPU.
+	splitScatterNoCPUUsage       uint64 = 0
+	splitScatterReportedCPUUsage uint64 = 1
+)
+
+func TestHandleAskBatchSplitSchedulesSplitScatterInPatrol(t *testing.T) {
+	re := require.New(t)
+	cluster, cancelPatrol := newSplitScatterTestCluster(t)
+
+	request := &pdpb.AskBatchSplitRequest{
+		Region:     cluster.GetRegion(100).GetMeta(),
+		SplitCount: 2,
+		Reason:     pdpb.SplitReason_LOAD,
+	}
+	resp, err := cluster.HandleAskBatchSplit(request)
+	re.NoError(err)
+	re.Len(resp.GetIds(), 2)
+
+	splitRegionIDs := []uint64{
+		resp.GetIds()[0].GetNewRegionId(),
+		resp.GetIds()[1].GetNewRegionId(),
+	}
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(100, []byte(""), []byte("m"), splitScatterNoCPUUsage).Clone(core.WithIncVersion())))
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(splitRegionIDs[0], []byte("m"), []byte("t"), splitScatterReportedCPUUsage)))
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(splitRegionIDs[1], []byte("t"), []byte(""), splitScatterReportedCPUUsage)))
+
+	dispatchSplitScatterInPatrol(t, cluster, cancelPatrol, func() bool {
+		return cluster.GetOperatorController().GetOperator(splitRegionIDs[0]) != nil &&
+			cluster.GetOperatorController().GetOperator(splitRegionIDs[1]) != nil
+	})
+
+	group := ""
+	for _, regionID := range splitRegionIDs {
+		op := cluster.GetOperatorController().GetOperator(regionID)
+		re.NotNil(op)
+		re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+		opGroup := op.GetAdditionalInfo("group")
+		if group == "" {
+			group = opGroup
+			re.True(strings.HasPrefix(group, "split-scatter-100-"))
+			continue
+		}
+		re.Equal(group, opGroup)
+	}
+	re.NotEmpty(group)
+}
+
+func TestHandleAskBatchSplitSeedsIndexBaselineForFirstSplitRegion(t *testing.T) {
+	re := require.New(t)
+	cluster, cancelPatrol := newSplitScatterTestCluster(t)
+
+	re.NoError(cluster.putRegion(newSplitScatterRegion(90, newSplitScatterIndexKey("a"), newSplitScatterIndexKey("j"), splitScatterNoCPUUsage)))
+	re.NoError(cluster.putRegion(newSplitScatterRegion(91, newSplitScatterIndexKey("j"), newSplitScatterIndexKey("t"), splitScatterNoCPUUsage)))
+	re.NoError(cluster.putRegion(newSplitScatterRegion(100, newSplitScatterIndexKey("t"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage)))
+
+	request := &pdpb.AskBatchSplitRequest{
+		Region:     cluster.GetRegion(100).GetMeta(),
+		SplitCount: 1,
+		Reason:     pdpb.SplitReason_LOAD,
+	}
+	resp, err := cluster.HandleAskBatchSplit(request)
+	re.NoError(err)
+	re.Len(resp.GetIds(), 1)
+
+	splitRegionID := resp.GetIds()[0].GetNewRegionId()
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), newSplitScatterRegion(100, newSplitScatterIndexKey("w"), newSplitScatterIndexKey("z"), splitScatterNoCPUUsage).Clone(core.WithIncVersion())))
+	re.NoError(cluster.processRegionHeartbeat(
+		core.ContextTODO(),
+		newSplitScatterRegion(splitRegionID, newSplitScatterIndexKey("t"), newSplitScatterIndexKey("w"), splitScatterReportedCPUUsage),
+	))
+
+	dispatchSplitScatterInPatrol(t, cluster, cancelPatrol, func() bool {
+		return cluster.GetOperatorController().GetOperator(splitRegionID) != nil
+	})
+
+	op := cluster.GetOperatorController().GetOperator(splitRegionID)
+	re.NotNil(op)
+	re.Equal(scatter.InternalScatterOperatorDesc, op.Desc())
+	re.Equal("split-scatter-index-42-7", op.GetAdditionalInfo("group"))
+	re.Equal(fmt.Sprintf("split-scatter-100-%d", splitRegionID), op.GetAdditionalInfo("batch-group"))
+}
+
+func TestHandleAskBatchSplitSkipsSplitScatterForSizeReason(t *testing.T) {
+	re := require.New(t)
+	cluster, cancelPatrol := newSplitScatterTestCluster(t)
+
+	request := &pdpb.AskBatchSplitRequest{
+		Region:     cluster.GetRegion(100).GetMeta(),
+		SplitCount: 1,
+		Reason:     pdpb.SplitReason_SIZE,
+	}
+	resp, err := cluster.HandleAskBatchSplit(request)
+	re.NoError(err)
+	re.Len(resp.GetIds(), 1)
+
+	splitRegionID := resp.GetIds()[0].GetNewRegionId()
+	re.NoError(cluster.processRegionHeartbeat(
+		core.ContextTODO(),
+		newSplitScatterRegion(splitRegionID, []byte("m"), []byte(""), splitScatterReportedCPUUsage),
+	))
+
+	dispatchSplitScatterInPatrol(t, cluster, cancelPatrol, func() bool {
+		// PatrolRegions uses a ticker; wait for at least one tick interval
+		// so the dispatch phase is guaranteed to have executed.
+		time.Sleep(100 * time.Millisecond)
+		return true
+	})
+
+	re.Nil(cluster.GetOperatorController().GetOperator(splitRegionID))
+	re.Nil(cluster.GetOperatorController().GetOperator(100))
+}
+
+func newSplitScatterTestCluster(t *testing.T) (*RaftCluster, context.CancelFunc) {
+	t.Helper()
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.regionLabeler, err = labeler.NewRegionLabeler(ctx, cluster.storage, time.Second*5)
+	re.NoError(err)
+	hbStreams := hbstream.NewTestHeartbeatStreams(ctx, cluster.BasicCluster, false)
+	cluster.initCoordinator(ctx, cluster, hbStreams)
+	t.Cleanup(func() {
+		hbStreams.Close()
+	})
+
+	now := time.Now()
+	for _, store := range newTestStores(4, "6.0.0") {
+		re.NoError(cluster.setStore(store.Clone(core.SetLastHeartbeatTS(now))))
+	}
+
+	re.NoError(cluster.putRegion(newSplitScatterRegion(100, []byte(""), []byte("m"), splitScatterNoCPUUsage)))
+	return cluster, cancel
+}
+
+func dispatchSplitScatterInPatrol(t *testing.T, cluster *RaftCluster, cancelPatrol context.CancelFunc, wait func() bool) {
+	t.Helper()
+	checkerController := cluster.GetCoordinator().GetCheckerController()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		checkerController.PatrolRegions()
+	}()
+	testutil.Eventually(require.New(t), wait)
+	cancelPatrol()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("patrol regions did not exit after cancel")
+	}
+}
+
+func newSplitScatterRegion(regionID uint64, start, end []byte, cpuUsage uint64) *core.RegionInfo {
+	return newSplitScatterRegionWithStores(regionID, start, end, cpuUsage, 1, 2, 3)
+}
+
+func newSplitScatterRegionWithStores(regionID uint64, start, end []byte, cpuUsage uint64, stores ...uint64) *core.RegionInfo {
+	peers := []*metapb.Peer{}
+	for i, storeID := range stores {
+		peers = append(peers, &metapb.Peer{
+			Id:      regionID*10 + uint64(i) + 1,
+			StoreId: storeID,
+		})
+	}
+	region := &metapb.Region{
+		Id:       regionID,
+		StartKey: start,
+		EndKey:   end,
+		Peers:    peers,
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	}
+	return core.NewRegionInfo(
+		region,
+		peers[0],
+		core.SetCPUUsage(cpuUsage),
+	)
+}
+
+func newSplitScatterIndexKey(suffix string) []byte {
+	key := codec.GenerateIndexKey(42, 7)
+	key = append(key, suffix...)
+	return codec.EncodeBytes(key)
+}

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -193,6 +193,18 @@ func (o *PersistOptions) IsPlacementRulesEnabled() bool {
 	return o.GetReplicationConfig().EnablePlacementRules
 }
 
+// GetSplitScatterScheduleLimit returns the limit for split-scatter schedule.
+func (o *PersistOptions) GetSplitScatterScheduleLimit() uint64 {
+	return o.getTTLNumberOr(sc.SplitScatterScheduleLimitKey, o.GetScheduleConfig().SplitScatterScheduleLimit)
+}
+
+// SetSplitScatterScheduleLimit sets the limit for split-scatter schedule.
+func (o *PersistOptions) SetSplitScatterScheduleLimit(limit uint64) {
+	v := o.GetScheduleConfig().Clone()
+	v.SplitScatterScheduleLimit = limit
+	o.SetScheduleConfig(v)
+}
+
 // SetPlacementRuleEnabled set PlacementRuleEnabled
 func (o *PersistOptions) SetPlacementRuleEnabled(enabled bool) {
 	v := o.GetReplicationConfig().Clone()
@@ -239,6 +251,7 @@ var supportedTTLConfigs = []string{
 	sc.ReplicaRescheduleLimitKey,
 	sc.MergeScheduleLimitKey,
 	sc.HotRegionScheduleLimitKey,
+	sc.SplitScatterScheduleLimitKey,
 	sc.SchedulerMaxWaitingOperatorKey,
 	sc.EnableLocationReplacement,
 	sc.EnableTiKVSplitRegion,

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1861,6 +1861,8 @@ func (s *GrpcServer) AskBatchSplit(ctx context.Context, request *pdpb.AskBatchSp
 		}
 		cli := forwardCli.getClient()
 		if cli != nil {
+			// TODO(split-scatter): propagate split reason and support load-based split-scatter
+			// after scheduling-service/NEXT_GEN path is explicitly in scope.
 			req := &schedulingpb.AskBatchSplitRequest{
 				Header: &schedulingpb.RequestHeader{
 					ClusterId: request.GetHeader().GetClusterId(),

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8
+	github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -390,8 +390,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8 h1:RiYvpna6b7GSGIIFFu6R92T/eq1KgOiK1ry6w/60x+Y=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721 h1:Y8/FeTGB0zVoJ2sRN5o/uRUC7aZjSeY8acryhX4oYFg=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -418,6 +418,7 @@ var ttlConfig = map[string]any{
 	"schedule.hot-region-schedule-limit":      999,
 	"schedule.replica-schedule-limit":         999,
 	"schedule.merge-schedule-limit":           999,
+	"schedule.split-scatter-schedule-limit":   999,
 	"schedule.enable-tikv-split-region":       false,
 }
 
@@ -436,6 +437,7 @@ type ttlConfigInterface interface {
 	GetHotRegionScheduleLimit() uint64
 	GetReplicaScheduleLimit() uint64
 	GetMergeScheduleLimit() uint64
+	GetSplitScatterScheduleLimit() uint64
 	IsTikvRegionSplitEnabled() bool
 }
 
@@ -459,6 +461,7 @@ func assertTTLConfig(
 		equality(uint64(999), options.GetHotRegionScheduleLimit())
 		equality(uint64(999), options.GetReplicaScheduleLimit())
 		equality(uint64(999), options.GetMergeScheduleLimit())
+		equality(uint64(999), options.GetSplitScatterScheduleLimit())
 		equality(false, options.IsTikvRegionSplitEnabled())
 	}
 	checkFunc(cluster.GetLeaderServer().GetServer().GetPersistOptions())

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8
+	github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.55.0

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -387,8 +387,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8 h1:RiYvpna6b7GSGIIFFu6R92T/eq1KgOiK1ry6w/60x+Y=
-github.com/pingcap/kvproto v0.0.0-20250707084400-caf41f244ad8/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721 h1:Y8/FeTGB0zVoJ2sRN5o/uRUC7aZjSeY8acryhX4oYFg=
+github.com/pingcap/kvproto v0.0.0-20260518035033-ca8835cfa721/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10630

Cherry-pick two observability commits from master onto `release-8.5-20251204-v8.5.4` so that this release line carries the PD lease keepalive metrics. These metrics are needed to quantify keepalive worker stalls and surface live lease TTL so on-call can correlate lease expiry incidents with PD leader stepdowns without parsing logs.

### What is changed and how does it work?

Two cherry-picks from master:

- `pkg/election: add lease keepalive metrics (#10622)` — adds `renewalTerminationTotal` counter (`invalid_ttl` / `lease_expired` / `context_canceled`), `keepAliveRequestDuration` histogram, response interval observation, and the `localTTLRemaining` GaugeVec; reworks `KeepAliveOnce` response handling to early-return on non-positive TTL.
- `pkg/election: add keepalive tick interval metric, live TTL gauge (#10649)` — adds `pd_lease_keepalive_tick_interval_seconds` histogram (per-`purpose` quantitative distribution matching the existing "keepalive interval too long" warning), and replaces the GaugeVec with a custom Prometheus collector that computes `time.Until(expireTime)` at scrape time. Active leases register on `Grant` and unregister on `Close`, so the metric reflects live decay instead of being pinned at `leaseTimeout`.

Conflict resolutions in this cherry-pick:

- `pkg/election/lease.go` — kept this release branch's existing `timer.Stop` / drain block; folded in the upstream metric observations and the early-return on non-positive TTL.
- `pkg/mcs/resourcemanager/server/server.go`, `pkg/mcs/scheduling/server/server.go` — kept this release branch's 4-arg `InitInfo` signature; prefixed the `purpose` argument with the service name (`constant.ResourceManagerServiceName` / `constant.SchedulingServiceName`) to preserve upstream's per-service metric label intent.
- `pkg/tso/keyspace_group_manager.go` — added the `keyspaceGroupPrimaryElectionPurpose(groupID)` helper; passed it as the `purpose` to `InitInfo`. Did not introduce `getBootstrapKeyspaceID` (not used elsewhere on this branch).
- `pkg/mcs/utils/expected_primary.go` — kept this release branch's signature; switched `lease.ID.Load().(clientv3.LeaseID)` to `lease.GetID()` because `#10649` unexports `lease.ID`. Did not adopt the TSO keyspace-group suffix because this branch's signature does not propagate group IDs through this function.

```commit-message
```

### Check List

Tests

- Unit test

Code changes

- None (observability only)

Side effects

- None expected

Related changes

- Need to cherry-pick to the release branch: this PR is the cherry-pick

### Release note

```release-note
None.
```
