### PR TITLE
client/tso: fix race in stream setup that cancels in-flight requests

### DIFF
--- a/client/clients/router/client.go
+++ b/client/clients/router/client.go
@@ -458,7 +458,11 @@ func (c *Cli) updateMsConnection(ctx context.Context) {
 		}
 		// Store the stream connection context if it is successfully created.
 		if stream != nil {
-			c.msConCtxMgr.Store(cctx, cancel, url, stream)
+			if !c.msConCtxMgr.Store(cctx, cancel, url, stream) {
+				log.Info("[router] already exists router service stream connection", zap.String("url", url))
+				cancel()
+				continue
+			}
 			log.Info("[router] successfully established the router service stream connection", zap.String("url", url))
 		} else {
 			log.Warn("[router] failed to create the router service stream connection")
@@ -490,7 +494,11 @@ func (c *Cli) updateConnection(ctx context.Context) {
 		}
 		// Store the stream connection context if it is successfully created.
 		if stream != nil {
-			c.conCtxMgr.Store(cctx, cancel, url, stream)
+			if !c.conCtxMgr.Store(cctx, cancel, url, stream) {
+				log.Info("[router] already exists leader router stream connection", zap.String("url", url))
+				cancel()
+				return
+			}
 			log.Info("[router] successfully established the leader router stream connection", zap.String("url", url))
 		} else {
 			log.Warn("[router] failed to create the leader router stream connection")
@@ -519,7 +527,11 @@ func (c *Cli) updateConnection(ctx context.Context) {
 			}
 			// Store the stream connection context if it is successfully created.
 			if stream != nil {
-				c.conCtxMgr.Store(cctx, cancel, url, stream)
+				if !c.conCtxMgr.Store(cctx, cancel, url, stream) {
+					log.Info("[router] already exists router stream connection", zap.String("url", url))
+					cancel()
+					continue
+				}
 				log.Info("[router] successfully established the router stream connection", zap.String("url", url))
 			} else {
 				log.Warn("[router] failed to create the router stream connection")

--- a/client/clients/tso/client.go
+++ b/client/clients/tso/client.go
@@ -331,9 +331,8 @@ func (c *Cli) tryConnectToTSO(ctx context.Context) error {
 		c.svcDiscovery.ScheduleCheckMemberChanged()
 		cc, url = c.getTSOLeaderClientConn()
 		if c.conCtxMgr.Exist(url) {
-			cctx, cancel := context.WithCancel(ctx)
 			// Just trigger the clean up of the stale connection contexts.
-			c.conCtxMgr.CleanAllAndStore(cctx, cancel, url)
+			c.conCtxMgr.GC(func(curURL string) bool { return curURL != url })
 			return nil
 		}
 		if cc != nil {
@@ -345,8 +344,11 @@ func (c *Cli) tryConnectToTSO(ctx context.Context) error {
 			})
 			if stream != nil && err == nil {
 				failpoint.InjectCall("pauseBeforeBackgroundStoreTSOLeaderStream")
-				c.conCtxMgr.CleanAllAndStore(cctx, cancel, url, stream)
+				stored := c.conCtxMgr.CleanAllAndStore(cctx, cancel, url, stream)
 				failpoint.InjectCall("notifyAfterBackgroundStoreTSOLeaderStream")
+				if !stored {
+					cancel()
+				}
 				return nil
 			}
 
@@ -388,10 +390,13 @@ func (c *Cli) tryConnectToTSO(ctx context.Context) error {
 			if err == nil {
 				forwardedHostTrim := tlsutil.TrimHTTPPrefix(forwardedHost)
 				addr := tlsutil.TrimHTTPPrefix(backupURL)
+				if !c.conCtxMgr.CleanAllAndStore(cctx, cancel, backupURL, stream) {
+					cancel()
+					return nil
+				}
 				// the goroutine is used to check the network and change back to the original stream
 				go c.checkLeader(ctx, cancel, forwardedHostTrim, addr, url)
 				metrics.RequestForwarded.WithLabelValues(forwardedHostTrim, addr).Set(1)
-				c.conCtxMgr.CleanAllAndStore(cctx, cancel, backupURL, stream)
 				return nil
 			}
 			cancel()
@@ -436,7 +441,9 @@ func (c *Cli) checkLeader(
 				stream, err := c.tsoStreamBuilderFactory.makeBuilder(cc).build(cctx, cancel, c.option.Timeout)
 				if err == nil && stream != nil {
 					log.Info("[tso] recover the original tso stream since the network has become normal", zap.String("url", url))
-					c.conCtxMgr.CleanAllAndStore(cctx, cancel, url, stream)
+					if !c.conCtxMgr.CleanAllAndStore(cctx, cancel, url, stream) {
+						cancel()
+					}
 					return
 				}
 			}
@@ -490,7 +497,10 @@ func (c *Cli) tryConnectToTSOWithProxy(ctx context.Context) error {
 				addrTrim := tlsutil.TrimHTTPPrefix(addr)
 				metrics.RequestForwarded.WithLabelValues(forwardedHostTrim, addrTrim).Set(1)
 			}
-			c.conCtxMgr.Store(cctx, cancel, addr, stream)
+			if !c.conCtxMgr.Store(cctx, cancel, addr, stream) {
+				log.Info("[tso] already exists tso stream", zap.String("addr", addr))
+				cancel()
+			}
 			continue
 		}
 		log.Error("[tso] create the tso stream failed",

--- a/client/clients/tso/client.go
+++ b/client/clients/tso/client.go
@@ -344,7 +344,9 @@ func (c *Cli) tryConnectToTSO(ctx context.Context) error {
 				err = status.New(codes.Unavailable, "unavailable").Err()
 			})
 			if stream != nil && err == nil {
+				failpoint.InjectCall("pauseBeforeBackgroundStoreTSOLeaderStream")
 				c.conCtxMgr.CleanAllAndStore(cctx, cancel, url, stream)
+				failpoint.InjectCall("notifyAfterBackgroundStoreTSOLeaderStream")
 				return nil
 			}
 

--- a/client/clients/tso/dispatcher_test.go
+++ b/client/clients/tso/dispatcher_test.go
@@ -77,8 +77,7 @@ func (m *mockTSOServiceProvider) updateConnectionCtxs(ctx context.Context) bool 
 	} else {
 		stream = m.createStream(ctx)
 	}
-	m.conCtxMgr.Store(cctx, cancel, mockStreamURL, stream)
-	return true
+	return m.conCtxMgr.Store(cctx, cancel, mockStreamURL, stream)
 }
 
 type testTSODispatcherSuite struct {

--- a/client/clients/tso/stream.go
+++ b/client/clients/tso/stream.go
@@ -305,6 +305,7 @@ func (s *tsoStream) processRequests(
 	}
 	s.state.Store(prevState)
 
+	failpoint.InjectCall("pauseAfterTSORequestAttachedToStream")
 	if err := s.stream.Send(clusterID, keyspaceID, keyspaceGroupID, count); err != nil {
 		// As the request is already put into `pendingRequests`, the request should finally be canceled by the recvLoop.
 		// So skip returning error here to avoid

--- a/client/pkg/connectionctx/manager.go
+++ b/client/pkg/connectionctx/manager.go
@@ -53,7 +53,9 @@ func (c *Manager[T]) Exist(url string) bool {
 
 // Store is used to store the connection context, `overwrite` is used to force the store operation
 // no matter whether the connection context exists before, which is false by default.
-func (c *Manager[T]) Store(ctx context.Context, cancel context.CancelFunc, url string, stream T, overwrite ...bool) {
+// It returns whether the manager took ownership of ctx/cancel/stream. If false, the caller
+// must cancel ctx to avoid leaking the stream and its associated resources.
+func (c *Manager[T]) Store(ctx context.Context, cancel context.CancelFunc, url string, stream T, overwrite ...bool) bool {
 	c.Lock()
 	defer c.Unlock()
 	overwriteFlag := false
@@ -62,9 +64,10 @@ func (c *Manager[T]) Store(ctx context.Context, cancel context.CancelFunc, url s
 	}
 	_, ok := c.connectionCtxs[url]
 	if !overwriteFlag && ok {
-		return
+		return false
 	}
 	c.storeLocked(ctx, cancel, url, stream)
+	return true
 }
 
 func (c *Manager[T]) storeLocked(ctx context.Context, cancel context.CancelFunc, url string, stream T) {
@@ -73,19 +76,23 @@ func (c *Manager[T]) storeLocked(ctx context.Context, cancel context.CancelFunc,
 }
 
 // CleanAllAndStore is used to store the connection context exclusively. It will release
-// all other connection contexts. `stream` is optional, if it is not provided, all
-// connection contexts other than the given `url` will be released.
-func (c *Manager[T]) CleanAllAndStore(ctx context.Context, cancel context.CancelFunc, url string, stream ...T) {
+// all other connection contexts.
+// It returns whether the manager took ownership of ctx/cancel/stream. If a connection is
+// already registered with the url it returns false, and the caller must cancel ctx to avoid
+// leaking the stream and its associated resources. Otherwise it returns true, meaning the
+// manager now owns ctx/cancel/stream and will cancel them when the entry is released.
+func (c *Manager[T]) CleanAllAndStore(ctx context.Context, cancel context.CancelFunc, url string, stream T) bool {
 	c.Lock()
 	defer c.Unlock()
 	// Remove all other `connectionCtx`s.
 	c.gcLocked(func(curURL string) bool {
 		return curURL != url
 	})
-	if len(stream) == 0 {
-		return
+	if _, ok := c.connectionCtxs[url]; ok {
+		return false
 	}
-	c.storeLocked(ctx, cancel, url, stream[0])
+	c.storeLocked(ctx, cancel, url, stream)
+	return true
 }
 
 // GC is used to release all connection contexts that match the given condition.

--- a/client/pkg/connectionctx/manager_test.go
+++ b/client/pkg/connectionctx/manager_test.go
@@ -34,7 +34,7 @@ func TestCancelFunc(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	manager := NewManager[int]()
 	url := "test-url"
-	manager.Store(ctx, cancel, url, 1)
+	re.True(manager.Store(ctx, cancel, url, 1))
 	re.True(manager.Exist(url))
 	manager.GC(func(url string) bool {
 		return url == "test-url"
@@ -53,7 +53,7 @@ func TestManager(t *testing.T) {
 	manager := NewManager[int]()
 
 	re.False(manager.Exist("test-url"))
-	manager.Store(ctx, cancel, "test-url", 1)
+	re.True(manager.Store(ctx, cancel, "test-url", 1))
 	re.True(manager.Exist("test-url"))
 
 	cctx := manager.RandomlyPick()
@@ -61,19 +61,19 @@ func TestManager(t *testing.T) {
 	re.Equal(1, cctx.Stream)
 	re.Equal(cctx, manager.GetConnectionCtx("test-url"))
 
-	manager.Store(ctx, cancel, "test-url", 2)
+	re.False(manager.Store(ctx, cancel, "test-url", 2))
 	cctx = manager.RandomlyPick()
 	re.Equal("test-url", cctx.StreamURL)
 	re.Equal(1, cctx.Stream)
 	re.Equal(cctx, manager.GetConnectionCtx("test-url"))
 
-	manager.Store(ctx, cancel, "test-url", 2, true)
+	re.True(manager.Store(ctx, cancel, "test-url", 2, true))
 	cctx = manager.RandomlyPick()
 	re.Equal("test-url", cctx.StreamURL)
 	re.Equal(2, cctx.Stream)
 	re.Equal(cctx, manager.GetConnectionCtx("test-url"))
 
-	manager.Store(ctx, cancel, "test-another-url", 3)
+	re.True(manager.Store(ctx, cancel, "test-another-url", 3))
 	pickedCount := make(map[string]int)
 	for range 1000 {
 		cctx = manager.RandomlyPick()
@@ -91,14 +91,15 @@ func TestManager(t *testing.T) {
 	re.True(manager.Exist("test-another-url"))
 	re.Equal(3, manager.GetConnectionCtx("test-another-url").Stream)
 
-	manager.CleanAllAndStore(ctx, cancel, "test-url", 1)
+	re.True(manager.CleanAllAndStore(ctx, cancel, "test-url", 1))
 	re.True(manager.Exist("test-url"))
+	re.False(manager.CleanAllAndStore(ctx, cancel, "test-url", 2))
 	re.Equal(1, manager.GetConnectionCtx("test-url").Stream)
 	re.False(manager.Exist("test-another-url"))
 	re.Nil(manager.GetConnectionCtx("test-another-url"))
 
 	manager.Store(ctx, cancel, "test-another-url", 3)
-	manager.CleanAllAndStore(ctx, cancel, "test-unique-url", 4)
+	re.True(manager.CleanAllAndStore(ctx, cancel, "test-unique-url", 4))
 	re.True(manager.Exist("test-unique-url"))
 	re.Equal(4, manager.GetConnectionCtx("test-unique-url").Stream)
 	re.False(manager.Exist("test-url"))

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -858,7 +858,7 @@ func (suite *tsoClientTestSuite) TestTSOStreamSetupRace() {
 	close(releaseBackgroundStore)
 	select {
 	case err := <-errCh:
-		re.ErrorContains(err, "context canceled")
+		re.NoError(err)
 	case <-time.After(30 * time.Second):
 		re.Failf("timed out", "GetTS has not returned")
 	}

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
 
 	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/client/clients/tso"
@@ -753,5 +754,112 @@ func checkServiceDiscovery(re *require.Assertions, client pd.Client, urlsLen int
 			urls := tsoDiscovery.(interface{ GetURLs() []string }).GetURLs()
 			re.Len(urls, urlsLen)
 		}
+	}
+}
+
+// Race condition test between TSO request dispatcher and background connection updater
+
+// Connection updater view:
+// 1.1. Builds a stream A for TSO primary upon initialization.
+// 1.2. Store the stream A into connection context manager.
+
+// Request dispatcher view:
+// 2.1. Upon no stream ready, builds a stream B for TSO primary.
+// 2.2. Process the requests via stream B.
+
+// Race timeline:
+// 1.1. Creates stream A but haven't registered it.
+// 2.1. Creates stream B and registers it to the connection context manager.
+// 1.2. Registered stream A and cancelled the context of stream B.
+// 2.2. Observes canceled context of stream B.
+func (suite *tsoClientTestSuite) TestTSOStreamSetupRace() {
+	if !suite.legacy {
+		suite.T().Skip("race is in tryConnectToTSO, which is the non-proxy path")
+	}
+	re := suite.Require()
+
+	const tsoFailpointPrefix = "github.com/tikv/pd/client/clients/tso/"
+
+	backgroundBeforeStore := make(chan struct{})
+	releaseBackgroundStore := make(chan struct{})
+
+	re.NoError(failpoint.EnableCall(tsoFailpointPrefix+"pauseBeforeBackgroundStoreTSOLeaderStream", func() {
+		log.Info("[tso race] 1.1.1 pause background goroutine before CleanAllAndStore")
+		close(backgroundBeforeStore)
+		<-releaseBackgroundStore
+		log.Info("[tso race] 1.2.1 released pause for CleanAllAndStore")
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable(tsoFailpointPrefix + "pauseBeforeBackgroundStoreTSOLeaderStream"))
+	}()
+
+	ctx, cancel := context.WithCancel(suite.ctx)
+	pdClient, err := pd.NewClientWithContext(ctx, caller.TestComponent, suite.getBackendEndpoints(), pd.SecurityOption{})
+	re.NoError(err)
+
+	safeClose := func(ch chan struct{}) {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+	defer func() {
+		safeClose(releaseBackgroundStore)
+		pdClient.Close()
+		cancel()
+	}()
+
+	waitFor := func(ch <-chan struct{}, desc string) {
+		select {
+		case <-ch:
+			log.Info("[tso race] " + desc)
+		case <-time.After(30 * time.Second):
+			re.Failf("timed out", "timed out waiting for: %s", desc)
+		}
+	}
+	waitFor(backgroundBeforeStore, "1.1.2 background goroutine reaching CleanAllAndStore")
+
+	re.NoError(failpoint.Disable(tsoFailpointPrefix + "pauseBeforeBackgroundStoreTSOLeaderStream"))
+
+	requestAttachedToStream := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	defer func() {
+		safeClose(releaseRequest)
+	}()
+
+	re.NoError(failpoint.EnableCall(tsoFailpointPrefix+"pauseAfterTSORequestAttachedToStream", func() {
+		log.Info("[tso race] 2.1.1 pausing tso request after attached to stream")
+		close(requestAttachedToStream)
+		<-releaseRequest
+		log.Info("[tso race] 2.2.2 tso request released")
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable(tsoFailpointPrefix + "pauseAfterTSORequestAttachedToStream"))
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := pdClient.GetTS(context.Background())
+		errCh <- err
+	}()
+
+	waitFor(requestAttachedToStream, "2.1.2 request attached to dispatcher's stream")
+
+	re.NoError(failpoint.EnableCall(tsoFailpointPrefix+"notifyAfterBackgroundStoreTSOLeaderStream", func() {
+		log.Info("[tso race] 1.2.2 background goroutine finished CleanAllAndStore")
+		close(releaseRequest)
+		log.Info("[tso race] 2.2.1 releasing pause for TSO request")
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable(tsoFailpointPrefix + "notifyAfterBackgroundStoreTSOLeaderStream"))
+	}()
+
+	close(releaseBackgroundStore)
+	select {
+	case err := <-errCh:
+		re.ErrorContains(err, "context canceled")
+	case <-time.After(30 * time.Second):
+		re.Failf("timed out", "GetTS has not returned")
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10655

On a freshly-created TSO client, the background `connectionCtxsUpdater` goroutine and the dispatcher's no-stream fallback both call `updateConnectionCtxs` concurrently. Both can observe an empty `conCtxMgr`, each build a gRPC stream to the TSO primary, and each call `CleanAllAndStore`. The second call's `storeLocked` cancels the first stream's context via `releaseLocked`, propagating `context.Canceled` to any request already attached to that stream.

### What is changed and how does it work?

```commit-message
client/tso: fix race in stream setup that cancels in-flight requests

`CleanAllAndStore` now aborts instead of overwriting when the URL is
already registered: it cancels the new (redundant) context and returns
without touching the existing entry or any in-flight requests on it.

The early-return path in `tryConnectToTSO` that previously called
`CleanAllAndStore` with no stream now calls `GC` directly, removing
the unnecessary context allocation.

The backup-stream store in the forwarding path is moved before the
`checkLeader` goroutine spawn so the entry is visible in the manager
before the goroutine can interact with it.

Four `failpoint.InjectCall` sites are added at the key scheduling
points of the race, and `TestTSOStreamSetupRace` uses them to
deterministically reproduce the interleaving: pause the background
updater before its first store, let the dispatcher build and attach a
request to its own stream, then release the background updater.
Without the fix the test fails with `context.Canceled`; with the fix
it passes.
```

### Check List

Tests

- Integration test

Side effects

- None

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Fix a race on TSO client cold startup where the background connection updater and the dispatcher's no-stream fallback could both build streams to the same TSO primary; the second `CleanAllAndStore` would cancel the first stream, failing any in-flight request with `context canceled`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race conditions during TSO connection and stream setup; improved context/store checks to avoid stale or duplicate connections and ensure reliable cancellation on failure.
  * Improved robustness of leader/follower failover and forwarded-request handling.

* **Tests**
  * Added an integration test to validate TSO stream setup under concurrent pauses and recoveries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->