### PR TITLE
pkg/storage/kv: adjust txn duration histogram buckets

### DIFF
--- a/pkg/storage/kv/metrics.go
+++ b/pkg/storage/kv/metrics.go
@@ -31,7 +31,8 @@ var (
 			Subsystem: "txn",
 			Name:      "handle_txns_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) of handled txns.",
-			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
+			// 1ms ~ 65s， according to the latency distribution of Txn in production
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 17),
 		}, []string{"result"})
 )
 


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: Close #10705

### What is changed and how does it work?

```commit-message
Tune the txn duration histogram buckets in pkg/storage/kv to better match production latency distribution.
The bucket lower bound is changed from 0.5ms to 1ms, and bucket count is expanded from 13 to 17.
This extends the observed range to about 1ms ~ 65s while keeping metric name and labels unchanged.
```

### Check List

Tests

- Manual test (add detailed scripts or steps below)

Manual test steps:
1. Start PD and scrape `pd_txn_handle_txns_duration_seconds_bucket` from `/metrics`.
2. Verify the smallest bucket is around `0.001` and bucket boundaries extend to around `65` seconds.

Side effects

- Possible performance regression

### Release note

```release-note
Adjust PD txn duration histogram buckets to better fit production latency distribution.
```