### PR TITLE
syncer: adapt region history buffer size

### DIFF
--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -19,7 +19,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
@@ -32,7 +31,6 @@ const (
 	historyKey                = "historyIndex"
 	defaultFlushCount         = 100
 	historyBufferCapacityUnit = 10000
-	historyBufferGrowFactor   = 8
 	historyBufferShrinkRounds = 3
 )
 
@@ -42,8 +40,6 @@ var (
 	firstIndexGauge = regionSyncerStatus.WithLabelValues("first_index")
 	lastIndexGauge  = regionSyncerStatus.WithLabelValues("last_index")
 )
-
-var errHistoryBufferRetainOverflow = errors.New("history buffer retained range exceeds maximum capacity")
 
 type historyBuffer struct {
 	syncutil.RWMutex
@@ -55,22 +51,14 @@ type historyBuffer struct {
 	baseCapacity           int
 	maxCapacity            int
 	capacityUnit           int
-	retains                map[uint64]uint64
-	nextRetainID           uint64
 	observedRequiredWindow uint64
 	lowWindowRounds        int
 	kv                     kv.Base
 	flushCount             int
 }
 
-type historyRetainer struct {
-	h  *historyBuffer
-	id uint64
-}
-
-func newHistoryBuffer(size int, kv kv.Base) *historyBuffer {
-	baseCapacity := normalizeHistoryBufferCapacity(size, historyBufferCapacityUnit)
-	return newHistoryBufferWithConfig(baseCapacity, baseCapacity*historyBufferGrowFactor, historyBufferCapacityUnit, kv)
+func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer {
+	return newHistoryBufferWithConfig(baseCapacity, maxCapacity, historyBufferCapacityUnit, kv)
 }
 
 func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv kv.Base) *historyBuffer {
@@ -91,7 +79,6 @@ func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv 
 		baseCapacity: baseCapacity,
 		maxCapacity:  maxCapacity,
 		capacityUnit: capacityUnit,
-		retains:      make(map[uint64]uint64),
 		kv:           kv,
 		flushCount:   defaultFlushCount,
 	}
@@ -136,13 +123,6 @@ func (h *historyBuffer) capacity() int {
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
-	if retainIndex, ok := h.minRetainIndexLocked(); ok {
-		window := uint64(0)
-		if h.index+1 > retainIndex {
-			window = h.index + 1 - retainIndex
-		}
-		h.ensureWindowLocked(window)
-	}
 	syncIndexGauge.Set(float64(h.index))
 	h.records[h.tail] = r
 	h.tail = (h.tail + 1) % h.size
@@ -173,50 +153,6 @@ func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
 	return records
 }
 
-func (h *historyBuffer) retainFrom(index uint64) *historyRetainer {
-	h.Lock()
-	defer h.Unlock()
-	h.nextRetainID++
-	id := h.nextRetainID
-	h.retains[id] = index
-	window := uint64(0)
-	if h.index > index {
-		window = h.index - index
-	}
-	h.ensureWindowLocked(window)
-	return &historyRetainer{h: h, id: id}
-}
-
-func (r *historyRetainer) release() {
-	if r == nil || r.h == nil {
-		return
-	}
-	r.h.releaseRetain(r.id)
-}
-
-func (r *historyRetainer) overflowed() bool {
-	if r == nil || r.h == nil {
-		return false
-	}
-	return r.h.retainOverflowed(r.id)
-}
-
-func (h *historyBuffer) releaseRetain(id uint64) {
-	h.Lock()
-	defer h.Unlock()
-	delete(h.retains, id)
-}
-
-func (h *historyBuffer) retainOverflowed(id uint64) bool {
-	h.RLock()
-	defer h.RUnlock()
-	index, ok := h.retains[id]
-	if !ok {
-		return false
-	}
-	return index < h.firstIndex()
-}
-
 func (h *historyBuffer) observeRequiredWindow(window uint64) {
 	h.Lock()
 	defer h.Unlock()
@@ -235,7 +171,7 @@ func (h *historyBuffer) observeRequiredWindowLocked(window uint64) {
 func (h *historyBuffer) maybeShrink() {
 	h.Lock()
 	defer h.Unlock()
-	if len(h.retains) > 0 || h.capacity() <= h.baseCapacity {
+	if h.capacity() <= h.baseCapacity {
 		h.observedRequiredWindow = 0
 		h.lowWindowRounds = 0
 		return
@@ -250,12 +186,15 @@ func (h *historyBuffer) maybeShrink() {
 		h.observedRequiredWindow = 0
 		return
 	}
-	target := h.baseCapacity
+	target := h.capacity() / 2
 	if h.observedRequiredWindow > 0 {
-		target = normalizeHistoryBufferCapacity(int(h.observedRequiredWindow*2), h.capacityUnit)
-		if target < h.baseCapacity {
-			target = h.baseCapacity
+		required := normalizeHistoryBufferCapacity(int(h.observedRequiredWindow*2), h.capacityUnit)
+		if required > target {
+			target = required
 		}
+	}
+	if target < h.baseCapacity {
+		target = h.baseCapacity
 	}
 	if target < h.capacity() {
 		h.resizeLocked(target)
@@ -275,7 +214,6 @@ func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	h.head = 0
 	h.tail = 0
 	h.flushCount = defaultFlushCount
-	h.retains = make(map[uint64]uint64)
 	h.observedRequiredWindow = 0
 	h.lowWindowRounds = 0
 	if h.capacity() > h.baseCapacity {
@@ -316,16 +254,6 @@ func (h *historyBuffer) persist() {
 	if err != nil {
 		log.Warn("persist history index failed", zap.Uint64("persist-index", h.nextIndex()), errs.ZapError(err))
 	}
-}
-
-func (h *historyBuffer) ensureWindowLocked(window uint64) {
-	if window > h.observedRequiredWindow {
-		h.observedRequiredWindow = window
-	}
-	if window <= uint64(h.capacity()) {
-		return
-	}
-	h.growForWindowLocked(window * 2)
 }
 
 func (h *historyBuffer) growForWindowLocked(window uint64) {
@@ -370,18 +298,4 @@ func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
 		return h.records[pos]
 	}
 	return nil
-}
-
-func (h *historyBuffer) minRetainIndexLocked() (uint64, bool) {
-	var (
-		minIndex uint64
-		ok       bool
-	)
-	for _, index := range h.retains {
-		if !ok || index < minIndex {
-			minIndex = index
-			ok = true
-		}
-	}
-	return minIndex, ok
 }

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -56,8 +56,10 @@ type historyBuffer struct {
 	observedRequiredWindow uint64
 	// lowWindowRounds counts consecutive shrink checks where the required window stays low.
 	lowWindowRounds int
-	kv              kv.Base
-	flushCount      int
+	// retains tracks full-sync start indexes that must stay replayable until catch-up finishes.
+	retains    map[uint64]int
+	kv         kv.Base
+	flushCount int
 }
 
 func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer {
@@ -123,6 +125,9 @@ func (h *historyBuffer) capacity() int {
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
+	if retainIndex, ok := h.minRetainIndexLocked(); ok && retainIndex <= h.index {
+		h.growForWindowLocked(h.index - retainIndex + 1)
+	}
 	syncIndexGauge.Set(float64(h.index))
 	h.records[h.tail] = r
 	h.tail = (h.tail + 1) % h.size
@@ -140,6 +145,10 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
 	h.RLock()
 	defer h.RUnlock()
+	return h.recordsFromLocked(index)
+}
+
+func (h *historyBuffer) recordsFromLocked(index uint64) []*core.RegionInfo {
 	var pos int
 	if index < h.nextIndex() && index >= h.firstIndex() {
 		pos = (h.head + int(index-h.firstIndex())) % h.size
@@ -151,6 +160,63 @@ func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
 		records = append(records, h.records[i])
 	}
 	return records
+}
+
+func (h *historyBuffer) observeAndRecordsFrom(index uint64) ([]*core.RegionInfo, uint64) {
+	h.Lock()
+	defer h.Unlock()
+	nextIndex := h.nextIndex()
+	if index != 0 && index < nextIndex {
+		h.observeRequiredWindowLocked(nextIndex - index)
+	}
+	return h.recordsFromLocked(index), nextIndex
+}
+
+func (h *historyBuffer) retainedRecordsFrom(index uint64) ([]*core.RegionInfo, uint64, bool) {
+	h.RLock()
+	defer h.RUnlock()
+	nextIndex := h.nextIndex()
+	if index == nextIndex {
+		return nil, nextIndex, true
+	}
+	records := h.recordsFromLocked(index)
+	return records, nextIndex, len(records) == int(nextIndex-index)
+}
+
+func (h *historyBuffer) retainFromCurrent() (uint64, func()) {
+	h.Lock()
+	defer h.Unlock()
+	index := h.nextIndex()
+	if h.retains == nil {
+		h.retains = make(map[uint64]int)
+	}
+	h.retains[index]++
+	return index, func() {
+		h.releaseRetain(index)
+	}
+}
+
+func (h *historyBuffer) releaseRetain(index uint64) {
+	h.Lock()
+	defer h.Unlock()
+	count := h.retains[index]
+	if count <= 1 {
+		delete(h.retains, index)
+		return
+	}
+	h.retains[index] = count - 1
+}
+
+func (h *historyBuffer) minRetainIndexLocked() (uint64, bool) {
+	var min uint64
+	var ok bool
+	for index := range h.retains {
+		if !ok || index < min {
+			min = index
+			ok = true
+		}
+	}
+	return min, ok
 }
 
 func (h *historyBuffer) observeRequiredWindow(window uint64) {
@@ -174,6 +240,11 @@ func (h *historyBuffer) observeRequiredWindowLocked(window uint64) {
 func (h *historyBuffer) maybeShrink() {
 	h.Lock()
 	defer h.Unlock()
+	if len(h.retains) > 0 {
+		h.observedRequiredWindow = 0
+		h.lowWindowRounds = 0
+		return
+	}
 	if h.capacity() <= h.baseCapacity {
 		h.observedRequiredWindow = 0
 		h.lowWindowRounds = 0
@@ -190,12 +261,6 @@ func (h *historyBuffer) maybeShrink() {
 		return
 	}
 	target := h.capacity() / 2
-	if h.observedRequiredWindow > 0 {
-		required := normalizeHistoryBufferCapacity(int(h.observedRequiredWindow*2), h.capacityUnit)
-		if required > target {
-			target = required
-		}
-	}
 	if target < h.baseCapacity {
 		target = h.baseCapacity
 	}
@@ -219,6 +284,7 @@ func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	h.flushCount = defaultFlushCount
 	h.observedRequiredWindow = 0
 	h.lowWindowRounds = 0
+	h.retains = nil
 	if h.capacity() > h.baseCapacity {
 		h.resizeLocked(h.baseCapacity)
 	}

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -43,18 +43,21 @@ var (
 
 type historyBuffer struct {
 	syncutil.RWMutex
-	index                  uint64
-	records                []*core.RegionInfo
-	head                   int
-	tail                   int
-	size                   int
-	baseCapacity           int
-	maxCapacity            int
-	capacityUnit           int
+	// index is the next index to assign to a recorded region change.
+	index        uint64
+	records      []*core.RegionInfo
+	head         int // Position of the first valid record in the ring.
+	tail         int // Position where the next record will be written.
+	size         int // Physical ring size; one slot is reserved to distinguish full and empty states.
+	baseCapacity int
+	maxCapacity  int
+	capacityUnit int
+	// observedRequiredWindow is the largest replay window requested since the last shrink check.
 	observedRequiredWindow uint64
-	lowWindowRounds        int
-	kv                     kv.Base
-	flushCount             int
+	// lowWindowRounds counts consecutive shrink checks where the required window stays low.
+	lowWindowRounds int
+	kv              kv.Base
+	flushCount      int
 }
 
 func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer {
@@ -168,6 +171,9 @@ func (h *historyBuffer) observeRequiredWindowLocked(window uint64) {
 	}
 }
 
+// maybeShrink gradually reduces capacity after the required replay window
+// remains low for several checks. It shrinks by at most half each time and
+// never below the base capacity.
 func (h *historyBuffer) maybeShrink() {
 	h.Lock()
 	defer h.Unlock()

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -72,9 +72,6 @@ func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv 
 	}
 	// use an empty space to simplify operation
 	size := baseCapacity + 1
-	if size < 2 {
-		size = 2
-	}
 	records := make([]*core.RegionInfo, size)
 	h := &historyBuffer{
 		records:      records,

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -19,6 +19,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
@@ -28,8 +29,11 @@ import (
 )
 
 const (
-	historyKey        = "historyIndex"
-	defaultFlushCount = 100
+	historyKey                = "historyIndex"
+	defaultFlushCount         = 100
+	historyBufferCapacityUnit = 10000
+	historyBufferGrowFactor   = 8
+	historyBufferShrinkRounds = 3
 )
 
 var (
@@ -39,32 +43,71 @@ var (
 	lastIndexGauge  = regionSyncerStatus.WithLabelValues("last_index")
 )
 
+var errHistoryBufferRetainOverflow = errors.New("history buffer retained range exceeds maximum capacity")
+
 type historyBuffer struct {
 	syncutil.RWMutex
-	index      uint64
-	records    []*core.RegionInfo
-	head       int
-	tail       int
-	size       int
-	kv         kv.Base
-	flushCount int
+	index                  uint64
+	records                []*core.RegionInfo
+	head                   int
+	tail                   int
+	size                   int
+	baseCapacity           int
+	maxCapacity            int
+	capacityUnit           int
+	retains                map[uint64]uint64
+	nextRetainID           uint64
+	observedRequiredWindow uint64
+	lowWindowRounds        int
+	kv                     kv.Base
+	flushCount             int
+}
+
+type historyRetainer struct {
+	h  *historyBuffer
+	id uint64
 }
 
 func newHistoryBuffer(size int, kv kv.Base) *historyBuffer {
+	baseCapacity := normalizeHistoryBufferCapacity(size, historyBufferCapacityUnit)
+	return newHistoryBufferWithConfig(baseCapacity, baseCapacity*historyBufferGrowFactor, historyBufferCapacityUnit, kv)
+}
+
+func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv kv.Base) *historyBuffer {
+	baseCapacity = normalizeHistoryBufferCapacity(baseCapacity, capacityUnit)
+	maxCapacity = normalizeHistoryBufferCapacity(maxCapacity, capacityUnit)
+	if maxCapacity < baseCapacity {
+		maxCapacity = baseCapacity
+	}
 	// use an empty space to simplify operation
-	size++
+	size := baseCapacity + 1
 	if size < 2 {
 		size = 2
 	}
 	records := make([]*core.RegionInfo, size)
 	h := &historyBuffer{
-		records:    records,
-		size:       size,
-		kv:         kv,
-		flushCount: defaultFlushCount,
+		records:      records,
+		size:         size,
+		baseCapacity: baseCapacity,
+		maxCapacity:  maxCapacity,
+		capacityUnit: capacityUnit,
+		retains:      make(map[uint64]uint64),
+		kv:           kv,
+		flushCount:   defaultFlushCount,
 	}
 	h.reload()
 	return h
+}
+
+func normalizeHistoryBufferCapacity(size, capacityUnit int) int {
+	if capacityUnit <= 0 {
+		capacityUnit = historyBufferCapacityUnit
+	}
+	capacity := capacityUnit
+	for capacity < size {
+		capacity *= 2
+	}
+	return capacity
 }
 
 func (h *historyBuffer) len() int {
@@ -86,9 +129,20 @@ func (h *historyBuffer) firstIndex() uint64 {
 	return h.index - uint64(h.len())
 }
 
+func (h *historyBuffer) capacity() int {
+	return h.size - 1
+}
+
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
+	if retainIndex, ok := h.minRetainIndexLocked(); ok {
+		window := uint64(0)
+		if h.index+1 > retainIndex {
+			window = h.index + 1 - retainIndex
+		}
+		h.ensureWindowLocked(window)
+	}
 	syncIndexGauge.Set(float64(h.index))
 	h.records[h.tail] = r
 	h.tail = (h.tail + 1) % h.size
@@ -119,13 +173,114 @@ func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
 	return records
 }
 
+func (h *historyBuffer) retainFrom(index uint64) *historyRetainer {
+	h.Lock()
+	defer h.Unlock()
+	h.nextRetainID++
+	id := h.nextRetainID
+	h.retains[id] = index
+	window := uint64(0)
+	if h.index > index {
+		window = h.index - index
+	}
+	h.ensureWindowLocked(window)
+	return &historyRetainer{h: h, id: id}
+}
+
+func (r *historyRetainer) release() {
+	if r == nil || r.h == nil {
+		return
+	}
+	r.h.releaseRetain(r.id)
+}
+
+func (r *historyRetainer) overflowed() bool {
+	if r == nil || r.h == nil {
+		return false
+	}
+	return r.h.retainOverflowed(r.id)
+}
+
+func (h *historyBuffer) releaseRetain(id uint64) {
+	h.Lock()
+	defer h.Unlock()
+	delete(h.retains, id)
+}
+
+func (h *historyBuffer) retainOverflowed(id uint64) bool {
+	h.RLock()
+	defer h.RUnlock()
+	index, ok := h.retains[id]
+	if !ok {
+		return false
+	}
+	return index < h.firstIndex()
+}
+
+func (h *historyBuffer) observeRequiredWindow(window uint64) {
+	h.Lock()
+	defer h.Unlock()
+	h.observeRequiredWindowLocked(window)
+}
+
+func (h *historyBuffer) observeRequiredWindowLocked(window uint64) {
+	if window > h.observedRequiredWindow {
+		h.observedRequiredWindow = window
+	}
+	if window > uint64(h.capacity()/2) {
+		h.growForWindowLocked(window * 2)
+	}
+}
+
+func (h *historyBuffer) maybeShrink() {
+	h.Lock()
+	defer h.Unlock()
+	if len(h.retains) > 0 || h.capacity() <= h.baseCapacity {
+		h.observedRequiredWindow = 0
+		h.lowWindowRounds = 0
+		return
+	}
+	if h.observedRequiredWindow > uint64(h.capacity()/4) {
+		h.observedRequiredWindow = 0
+		h.lowWindowRounds = 0
+		return
+	}
+	h.lowWindowRounds++
+	if h.lowWindowRounds < historyBufferShrinkRounds {
+		h.observedRequiredWindow = 0
+		return
+	}
+	target := h.baseCapacity
+	if h.observedRequiredWindow > 0 {
+		target = normalizeHistoryBufferCapacity(int(h.observedRequiredWindow*2), h.capacityUnit)
+		if target < h.baseCapacity {
+			target = h.baseCapacity
+		}
+	}
+	if target < h.capacity() {
+		h.resizeLocked(target)
+	}
+	h.observedRequiredWindow = 0
+	h.lowWindowRounds = 0
+}
+
 func (h *historyBuffer) resetWithIndex(index uint64) {
 	h.Lock()
 	defer h.Unlock()
+	h.resetWithIndexLocked(index)
+}
+
+func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	h.index = index
 	h.head = 0
 	h.tail = 0
 	h.flushCount = defaultFlushCount
+	h.retains = make(map[uint64]uint64)
+	h.observedRequiredWindow = 0
+	h.lowWindowRounds = 0
+	if h.capacity() > h.baseCapacity {
+		h.resizeLocked(h.baseCapacity)
+	}
 }
 
 func (h *historyBuffer) getNextIndex() uint64 {
@@ -137,11 +292,7 @@ func (h *historyBuffer) getNextIndex() uint64 {
 func (h *historyBuffer) get(index uint64) *core.RegionInfo {
 	h.RLock()
 	defer h.RUnlock()
-	if index < h.nextIndex() && index >= h.firstIndex() {
-		pos := (h.head + int(index-h.firstIndex())) % h.size
-		return h.records[pos]
-	}
-	return nil
+	return h.getLocked(index)
 }
 
 func (h *historyBuffer) reload() {
@@ -165,4 +316,72 @@ func (h *historyBuffer) persist() {
 	if err != nil {
 		log.Warn("persist history index failed", zap.Uint64("persist-index", h.nextIndex()), errs.ZapError(err))
 	}
+}
+
+func (h *historyBuffer) ensureWindowLocked(window uint64) {
+	if window > h.observedRequiredWindow {
+		h.observedRequiredWindow = window
+	}
+	if window <= uint64(h.capacity()) {
+		return
+	}
+	h.growForWindowLocked(window * 2)
+}
+
+func (h *historyBuffer) growForWindowLocked(window uint64) {
+	target := normalizeHistoryBufferCapacity(int(window), h.capacityUnit)
+	if target > h.maxCapacity {
+		target = h.maxCapacity
+	}
+	if target > h.capacity() {
+		h.resizeLocked(target)
+	}
+}
+
+func (h *historyBuffer) resizeLocked(newCapacity int) {
+	newCapacity = normalizeHistoryBufferCapacity(newCapacity, h.capacityUnit)
+	if newCapacity < h.baseCapacity {
+		newCapacity = h.baseCapacity
+	}
+	if newCapacity > h.maxCapacity {
+		newCapacity = h.maxCapacity
+	}
+	if newCapacity == h.capacity() {
+		return
+	}
+	keep := h.len()
+	if keep > newCapacity {
+		keep = newCapacity
+	}
+	startIndex := h.index - uint64(keep)
+	records := make([]*core.RegionInfo, newCapacity+1)
+	for i := range keep {
+		records[i] = h.getLocked(startIndex + uint64(i))
+	}
+	h.records = records
+	h.size = newCapacity + 1
+	h.head = 0
+	h.tail = keep % h.size
+}
+
+func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
+	if index < h.nextIndex() && index >= h.firstIndex() {
+		pos := (h.head + int(index-h.firstIndex())) % h.size
+		return h.records[pos]
+	}
+	return nil
+}
+
+func (h *historyBuffer) minRetainIndexLocked() (uint64, bool) {
+	var (
+		minIndex uint64
+		ok       bool
+	)
+	for _, index := range h.retains {
+		if !ok || index < minIndex {
+			minIndex = index
+			ok = true
+		}
+	}
+	return minIndex, ok
 }

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -143,60 +143,6 @@ func TestHistoryBufferPersistsNextIndexOnly(t *testing.T) {
 	re.Equal("3", s)
 }
 
-func TestHistoryBufferRetainGrowsAndPreservesRecords(t *testing.T) {
-	re := require.New(t)
-	h := newTestHistoryBuffer(8)
-	h.resetWithIndex(100)
-
-	retainer := h.retainFrom(100)
-	defer retainer.release()
-	for i := 1; i <= 3; i++ {
-		h.record(newHistoryBufferTestRegion(uint64(i)))
-	}
-
-	re.Equal(8, h.capacity())
-	re.False(retainer.overflowed())
-	records := h.recordsFrom(100)
-	re.Len(records, 3)
-	for i, record := range records {
-		re.Equal(uint64(i+1), record.GetID())
-	}
-}
-
-func TestHistoryBufferMultipleRetainsKeepEarliestIndex(t *testing.T) {
-	re := require.New(t)
-	h := newTestHistoryBuffer(8)
-	h.resetWithIndex(100)
-
-	first := h.retainFrom(100)
-	defer first.release()
-	second := h.retainFrom(101)
-	defer second.release()
-	for i := 1; i <= 3; i++ {
-		h.record(newHistoryBufferTestRegion(uint64(i)))
-	}
-
-	re.False(first.overflowed())
-	re.False(second.overflowed())
-	records := h.recordsFrom(100)
-	re.Len(records, 3)
-}
-
-func TestHistoryBufferRetainOverflowAtMaxCapacity(t *testing.T) {
-	re := require.New(t)
-	h := newTestHistoryBuffer(4)
-	h.resetWithIndex(100)
-
-	retainer := h.retainFrom(100)
-	defer retainer.release()
-	for i := 1; i <= 5; i++ {
-		h.record(newHistoryBufferTestRegion(uint64(i)))
-	}
-
-	re.Equal(4, h.capacity())
-	re.True(retainer.overflowed())
-}
-
 func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
@@ -206,18 +152,19 @@ func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {
 	re.Equal(8, h.capacity())
 }
 
-func TestHistoryBufferShrinksAfterRequiredWindowStaysLow(t *testing.T) {
+func TestHistoryBufferShrinksOneStepAfterRequiredWindowStaysLow(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 	h.observeRequiredWindow(3)
 	re.Equal(8, h.capacity())
+	h.maybeShrink()
 
-	for range historyBufferShrinkRounds + 1 {
+	for range historyBufferShrinkRounds {
 		h.observeRequiredWindow(1)
 		h.maybeShrink()
 	}
 
-	re.Equal(2, h.capacity())
+	re.Equal(4, h.capacity())
 }
 
 func newTestHistoryBuffer(maxCapacity int) *historyBuffer {

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -22,18 +22,56 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/storage/kv"
 )
 
-func TestBufferSize(t *testing.T) {
-	re := require.New(t)
-	var regions []*core.RegionInfo
-	for i := range 101 {
-		regions = append(regions, core.NewRegionInfo(&metapb.Region{Id: uint64(i)}, nil))
+func TestNormalizeHistoryBufferCapacity(t *testing.T) {
+	testCases := []struct {
+		name     string
+		size     int
+		unit     int
+		expected int
+	}{
+		{name: "below-unit", size: 1, unit: historyBufferCapacityUnit, expected: historyBufferCapacityUnit},
+		{name: "one-unit", size: historyBufferCapacityUnit, unit: historyBufferCapacityUnit, expected: historyBufferCapacityUnit},
+		{name: "round-to-two-units", size: historyBufferCapacityUnit + 1, unit: historyBufferCapacityUnit, expected: 2 * historyBufferCapacityUnit},
+		{name: "round-to-four-units", size: 3 * historyBufferCapacityUnit, unit: historyBufferCapacityUnit, expected: 4 * historyBufferCapacityUnit},
+		{name: "test-unit", size: 3, unit: 1, expected: 4},
 	}
 
-	// size equals 1
-	h := newHistoryBuffer(1, kv.NewMemoryKV())
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, normalizeHistoryBufferCapacity(testCase.size, testCase.unit))
+		})
+	}
+}
+
+func TestHistoryBufferKeepsRingBehaviorWithoutRetain(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(100)
+
+	for i := 1; i <= 3; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	re.Equal(2, h.capacity())
+	re.Nil(h.recordsFrom(100))
+	records := h.recordsFrom(101)
+	re.Len(records, 2)
+	re.Equal(uint64(2), records[0].GetID())
+	re.Equal(uint64(3), records[1].GetID())
+}
+
+func TestHistoryBufferRecordsAndFlushes(t *testing.T) {
+	re := require.New(t)
+	regions := make([]*core.RegionInfo, 0, 101)
+	for i := range 101 {
+		regions = append(regions, newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	h := newHistoryBufferWithConfig(1, 1, 1, kv.NewMemoryKV())
 	re.Equal(0, h.len())
 	for _, r := range regions {
 		h.record(r)
@@ -42,8 +80,7 @@ func TestBufferSize(t *testing.T) {
 	re.Equal(regions[h.nextIndex()-1], h.get(100))
 	re.Nil(h.get(99))
 
-	// size equals 2
-	h = newHistoryBuffer(2, kv.NewMemoryKV())
+	h = newHistoryBufferWithConfig(2, 2, 1, kv.NewMemoryKV())
 	for _, r := range regions {
 		h.record(r)
 	}
@@ -52,9 +89,8 @@ func TestBufferSize(t *testing.T) {
 	re.Equal(regions[h.nextIndex()-2], h.get(99))
 	re.Nil(h.get(98))
 
-	// size equals 100
 	kvMem := kv.NewMemoryKV()
-	h1 := newHistoryBuffer(100, kvMem)
+	h1 := newHistoryBufferWithConfig(100, 100, 100, kvMem)
 	for i := range 6 {
 		h1.record(regions[i])
 	}
@@ -62,11 +98,10 @@ func TestBufferSize(t *testing.T) {
 	re.Equal(uint64(6), h1.nextIndex())
 	h1.persist()
 
-	// restart the buffer
-	h2 := newHistoryBuffer(100, kvMem)
+	h2 := newHistoryBufferWithConfig(100, 100, 100, kvMem)
 	re.Equal(uint64(6), h2.nextIndex())
 	re.Equal(uint64(6), h2.firstIndex())
-	re.Nil(h2.get(h.nextIndex() - 1))
+	re.Nil(h2.get(5))
 	re.Equal(0, h2.len())
 	for _, r := range regions {
 		index := h2.nextIndex()
@@ -78,13 +113,117 @@ func TestBufferSize(t *testing.T) {
 	re.Nil(h2.get(h2.nextIndex()))
 	s, err := h2.kv.Load(historyKey)
 	re.NoError(err)
-	// flush in index 106
 	re.Equal("106", s)
 
-	histories := h2.recordsFrom(uint64(1))
+	histories := h2.recordsFrom(1)
 	re.Empty(histories)
 	histories = h2.recordsFrom(h2.firstIndex())
 	re.Len(histories, 100)
 	re.Equal(uint64(7), h2.firstIndex())
 	re.Equal(regions[1:], histories)
+}
+
+func TestHistoryBufferPersistsNextIndexOnly(t *testing.T) {
+	re := require.New(t)
+	kvMem := kv.NewMemoryKV()
+	h1 := newHistoryBufferWithConfig(4, 8, 1, kvMem)
+	for i := 1; i <= 3; i++ {
+		h1.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+	re.Equal(3, h1.len())
+	h1.persist()
+
+	h2 := newHistoryBufferWithConfig(4, 8, 1, kvMem)
+	re.Equal(uint64(3), h2.nextIndex())
+	re.Equal(uint64(3), h2.firstIndex())
+	re.Equal(0, h2.len())
+	re.Nil(h2.get(2))
+	s, err := h2.kv.Load(historyKey)
+	re.NoError(err)
+	re.Equal("3", s)
+}
+
+func TestHistoryBufferRetainGrowsAndPreservesRecords(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(100)
+
+	retainer := h.retainFrom(100)
+	defer retainer.release()
+	for i := 1; i <= 3; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	re.Equal(8, h.capacity())
+	re.False(retainer.overflowed())
+	records := h.recordsFrom(100)
+	re.Len(records, 3)
+	for i, record := range records {
+		re.Equal(uint64(i+1), record.GetID())
+	}
+}
+
+func TestHistoryBufferMultipleRetainsKeepEarliestIndex(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(100)
+
+	first := h.retainFrom(100)
+	defer first.release()
+	second := h.retainFrom(101)
+	defer second.release()
+	for i := 1; i <= 3; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	re.False(first.overflowed())
+	re.False(second.overflowed())
+	records := h.recordsFrom(100)
+	re.Len(records, 3)
+}
+
+func TestHistoryBufferRetainOverflowAtMaxCapacity(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(4)
+	h.resetWithIndex(100)
+
+	retainer := h.retainFrom(100)
+	defer retainer.release()
+	for i := 1; i <= 5; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	re.Equal(4, h.capacity())
+	re.True(retainer.overflowed())
+}
+
+func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+
+	h.observeRequiredWindow(3)
+
+	re.Equal(8, h.capacity())
+}
+
+func TestHistoryBufferShrinksAfterRequiredWindowStaysLow(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.observeRequiredWindow(3)
+	re.Equal(8, h.capacity())
+
+	for range historyBufferShrinkRounds + 1 {
+		h.observeRequiredWindow(1)
+		h.maybeShrink()
+	}
+
+	re.Equal(2, h.capacity())
+}
+
+func newTestHistoryBuffer(maxCapacity int) *historyBuffer {
+	return newHistoryBufferWithConfig(2, maxCapacity, 1, storage.NewStorageWithMemoryBackend())
+}
+
+func newHistoryBufferTestRegion(regionID uint64) *core.RegionInfo {
+	return core.NewRegionInfo(&metapb.Region{Id: regionID}, nil)
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -70,6 +70,7 @@ type regionSyncStream struct {
 	stream ServerStream
 	done   chan struct{}
 	once   sync.Once
+	sendMu sync.Mutex
 }
 
 func newRegionSyncStream(stream ServerStream) *regionSyncStream {
@@ -83,6 +84,12 @@ func (s *regionSyncStream) close() {
 	s.once.Do(func() {
 		close(s.done)
 	})
+}
+
+func (s *regionSyncStream) send(regions *pdpb.SyncRegionResponse) error {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	return s.stream.Send(regions)
 }
 
 // Server is the abstraction of the syncer storage server.
@@ -266,12 +273,14 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 			zap.String("requested-server", request.GetMember().GetName()),
 			zap.String("url", request.GetMember().GetClientUrls()[0]))
 
-		err = s.syncHistoryRegion(ctx, request, stream)
+		name := request.GetMember().GetName()
+		syncStream, err := s.syncHistoryRegion(ctx, request, stream)
 		if err != nil {
 			return err
 		}
-		name := request.GetMember().GetName()
-		syncStream := s.bindStream(name, stream)
+		if syncStream == nil {
+			syncStream = s.bindStream(name, stream)
+		}
 		select {
 		case <-ctx.Done():
 			s.unbindStream(name, syncStream)
@@ -308,16 +317,12 @@ func recvSyncRegionRequest(ctx context.Context, stream pdpb.PD_SyncRegionsServer
 	}
 }
 
-func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.SyncRegionRequest, stream pdpb.PD_SyncRegionsServer) error {
+func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.SyncRegionRequest, stream pdpb.PD_SyncRegionsServer) (*regionSyncStream, error) {
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
-	nextIndex := s.history.getNextIndex()
-	if startIndex < nextIndex {
-		s.history.observeRequiredWindow(nextIndex - startIndex)
-	}
-	records := s.history.recordsFrom(startIndex)
+	records, nextIndex := s.history.observeAndRecordsFrom(startIndex)
 	if len(records) == 0 {
-		if s.history.getNextIndex() == startIndex {
+		if nextIndex == startIndex {
 			log.Info("requested server has already in sync with server",
 				zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Uint64("last-index", startIndex))
 			// still send a response to follower to show the history region sync.
@@ -329,21 +334,20 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 				RegionLeaders: nil,
 				Buckets:       nil,
 			}
-			return stream.Send(resp)
+			return nil, stream.Send(resp)
 		}
-		// do full synchronization
-		if startIndex == 0 {
+		if startIndex < nextIndex {
 			return s.syncFullRegions(ctx, name, stream)
 		}
 		log.Warn("no history regions from index, the leader may be restarted", zap.Uint64("index", startIndex))
-		return nil
+		return nil, nil
 	}
 	log.Info("sync the history regions with server",
 		zap.String("server", name),
 		zap.Uint64("from-index", startIndex),
-		zap.Uint64("last-index", s.history.getNextIndex()),
+		zap.Uint64("last-index", nextIndex),
 		zap.Int("records-length", len(records)))
-	return s.syncHistoryRecords(startIndex, records, stream)
+	return nil, s.syncHistoryRecords(startIndex, records, stream)
 }
 
 func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream pdpb.PD_SyncRegionsServer) error {
@@ -376,7 +380,9 @@ func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.Regio
 	return stream.Send(resp)
 }
 
-func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) error {
+func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) (*regionSyncStream, error) {
+	retainIndex, releaseRetain := s.history.retainFromCurrent()
+	defer releaseRetain()
 	regions := s.server.GetRegions()
 	lastIndex := 0
 	start := time.Now()
@@ -391,7 +397,7 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 			failpoint.Inject("noFastExitSync", func() {
 				failpoint.Goto("doSync")
 			})
-			return nil
+			return nil, nil
 		default:
 		}
 		failpoint.Label("doSync")
@@ -420,12 +426,12 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 		}
 		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
 			log.Error("failed to wait rate limit", errs.ZapError(err))
-			return err
+			return nil, err
 		}
 		lastIndex += len(metas)
 		if err := stream.Send(resp); err != nil {
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
-			return err
+			return nil, err
 		}
 		metas = metas[:0]
 		stats = stats[:0]
@@ -434,12 +440,35 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 	}
 	log.Info("requested server has completed full synchronization with server",
 		zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))
-	return nil
+	syncStream := newRegionSyncStream(stream)
+	syncStream.sendMu.Lock()
+	s.bindRegionSyncStream(name, syncStream)
+	records, nextIndex, ok := s.history.retainedRecordsFrom(retainIndex)
+	if !ok {
+		s.unbindStream(name, syncStream)
+		syncStream.sendMu.Unlock()
+		return nil, status.Errorf(codes.ResourceExhausted,
+			"history records from full sync start index %d to %d are no longer available",
+			retainIndex, nextIndex)
+	}
+	if len(records) > 0 {
+		if err := s.syncHistoryRecords(retainIndex, records, stream); err != nil {
+			s.unbindStream(name, syncStream)
+			syncStream.sendMu.Unlock()
+			return nil, err
+		}
+	}
+	syncStream.sendMu.Unlock()
+	return syncStream, nil
 }
 
 // bindStream binds the established server stream.
 func (s *RegionSyncer) bindStream(name string, stream ServerStream) *regionSyncStream {
 	syncStream := newRegionSyncStream(stream)
+	return s.bindRegionSyncStream(name, syncStream)
+}
+
+func (s *RegionSyncer) bindRegionSyncStream(name string, syncStream *regionSyncStream) *regionSyncStream {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if oldStream := s.mu.streams[name]; oldStream != nil {
@@ -524,7 +553,7 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 
 	resultCh := make(chan error, 1)
 	go func() {
-		resultCh <- sender.stream.Send(regions)
+		resultCh <- sender.send(regions)
 	}()
 
 	timeout := s.sendTimeout

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/memory"
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/storage/kv"
@@ -49,6 +50,8 @@ const (
 	maxSyncRegionBatchSize   = 1000
 	syncerKeepAliveInterval  = 10 * time.Second
 	defaultHistoryBufferSize = 10000
+	historyBufferMemoryStep  = 4 * 1024 * 1024 * 1024
+	maxHistoryBufferBaseSize = 80000
 )
 
 // ClientStream is the client side of the region syncer.
@@ -118,15 +121,31 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 	if regionStorage == nil {
 		return nil
 	}
+	historyBufferSize := historyBufferSizeFromMemory(memory.GetMemTotalIgnoreErr())
 	syncer := &RegionSyncer{
 		server:      s,
-		history:     newHistoryBuffer(defaultHistoryBufferSize, regionStorage.(kv.Base)),
+		history:     newHistoryBuffer(historyBufferSize, regionStorage.(kv.Base)),
 		limit:       ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
 		sendTimeout: syncerKeepAliveInterval,
 		tlsConfig:   s.GetTLSConfig(),
 	}
 	syncer.mu.streams = make(map[string]*regionSyncStream)
 	return syncer
+}
+
+func historyBufferSizeFromMemory(totalMemory uint64) int {
+	if totalMemory == 0 {
+		return defaultHistoryBufferSize
+	}
+	size := int(uint64(defaultHistoryBufferSize) * totalMemory / historyBufferMemoryStep)
+	if size < defaultHistoryBufferSize {
+		return defaultHistoryBufferSize
+	}
+	size = normalizeHistoryBufferCapacity(size, historyBufferCapacityUnit)
+	if size > maxHistoryBufferBaseSize {
+		return maxHistoryBufferBaseSize
+	}
+	return size
 }
 
 // RunServer runs the server of the region syncer.
@@ -192,6 +211,7 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 			}
 			s.broadcast(ctx, regions)
 		case <-ticker.C:
+			s.history.maybeShrink()
 			alive := &pdpb.SyncRegionResponse{
 				Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 				StartIndex: s.history.getNextIndex(),
@@ -287,6 +307,10 @@ func recvSyncRegionRequest(ctx context.Context, stream pdpb.PD_SyncRegionsServer
 func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.SyncRegionRequest, stream pdpb.PD_SyncRegionsServer) error {
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
+	nextIndex := s.history.getNextIndex()
+	if startIndex < nextIndex {
+		s.history.observeRequiredWindow(nextIndex - startIndex)
+	}
 	records := s.history.recordsFrom(startIndex)
 	if len(records) == 0 {
 		if s.history.getNextIndex() == startIndex {
@@ -349,6 +373,8 @@ func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.Regio
 }
 
 func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) error {
+	retainer := s.history.retainFrom(s.history.getNextIndex())
+	defer retainer.release()
 	regions := s.server.GetRegions()
 	lastIndex := 0
 	start := time.Now()
@@ -399,10 +425,16 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}
+		if retainer.overflowed() {
+			return errHistoryBufferRetainOverflow
+		}
 		metas = metas[:0]
 		stats = stats[:0]
 		leaders = leaders[:0]
 		buckets = buckets[:0]
+	}
+	if retainer.overflowed() {
+		return errHistoryBufferRetainOverflow
 	}
 	log.Info("requested server has completed full synchronization with server",
 		zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -347,37 +347,47 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 		zap.Uint64("from-index", startIndex),
 		zap.Uint64("last-index", nextIndex),
 		zap.Int("records-length", len(records)))
+	// TODO: Incremental history replay is sent before binding the stream, so
+	// broadcasts produced during this replay are not delivered to this follower.
+	// Handle this existing ordering gap in a follow-up PR together with stream
+	// binding and send-ordering semantics.
 	return nil, s.syncHistoryRecords(startIndex, records, stream)
 }
 
 func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream pdpb.PD_SyncRegionsServer) error {
-	regions := make([]*metapb.Region, len(records))
-	stats := make([]*pdpb.RegionStat, len(records))
-	leaders := make([]*metapb.Peer, len(records))
-	buckets := make([]*metapb.Buckets, len(records))
-	for i, r := range records {
-		regions[i] = r.GetMeta()
-		stats[i] = r.GetStat()
-		leader := &metapb.Peer{}
-		if r.GetLeader() != nil {
-			leader = r.GetLeader()
+	for start := 0; start < len(records); start += maxSyncRegionBatchSize {
+		end := min(start+maxSyncRegionBatchSize, len(records))
+		regions := make([]*metapb.Region, end-start)
+		stats := make([]*pdpb.RegionStat, end-start)
+		leaders := make([]*metapb.Peer, end-start)
+		buckets := make([]*metapb.Buckets, end-start)
+		for i, r := range records[start:end] {
+			regions[i] = r.GetMeta()
+			stats[i] = r.GetStat()
+			leader := &metapb.Peer{}
+			if r.GetLeader() != nil {
+				leader = r.GetLeader()
+			}
+			leaders[i] = leader
+			// bucket should not be nil to avoid grpc marshal panic.
+			buckets[i] = &metapb.Buckets{}
+			if r.GetBuckets() != nil {
+				buckets[i] = r.GetBuckets()
+			}
 		}
-		leaders[i] = leader
-		// bucket should not be nil to avoid grpc marshal panic.
-		buckets[i] = &metapb.Buckets{}
-		if r.GetBuckets() != nil {
-			buckets[i] = r.GetBuckets()
+		resp := &pdpb.SyncRegionResponse{
+			Header:        &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+			Regions:       regions,
+			StartIndex:    startIndex + uint64(start),
+			RegionStats:   stats,
+			RegionLeaders: leaders,
+			Buckets:       buckets,
+		}
+		if err := stream.Send(resp); err != nil {
+			return err
 		}
 	}
-	resp := &pdpb.SyncRegionResponse{
-		Header:        &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-		Regions:       regions,
-		StartIndex:    startIndex,
-		RegionStats:   stats,
-		RegionLeaders: leaders,
-		Buckets:       buckets,
-	}
-	return stream.Send(resp)
+	return nil
 }
 
 func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) (*regionSyncStream, error) {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -51,7 +51,7 @@ const (
 	syncerKeepAliveInterval  = 10 * time.Second
 	defaultHistoryBufferSize = 10000
 	historyBufferMemoryStep  = 4 * 1024 * 1024 * 1024
-	maxHistoryBufferBaseSize = 80000
+	maxHistoryBufferSize     = 80000
 )
 
 // ClientStream is the client side of the region syncer.
@@ -121,10 +121,10 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 	if regionStorage == nil {
 		return nil
 	}
-	historyBufferSize := historyBufferSizeFromMemory(memory.GetMemTotalIgnoreErr())
+	historyBufferMaxSize := historyBufferMaxSizeFromMemory(memory.GetMemTotalIgnoreErr())
 	syncer := &RegionSyncer{
 		server:      s,
-		history:     newHistoryBuffer(historyBufferSize, regionStorage.(kv.Base)),
+		history:     newHistoryBuffer(defaultHistoryBufferSize, historyBufferMaxSize, regionStorage.(kv.Base)),
 		limit:       ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
 		sendTimeout: syncerKeepAliveInterval,
 		tlsConfig:   s.GetTLSConfig(),
@@ -133,7 +133,7 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 	return syncer
 }
 
-func historyBufferSizeFromMemory(totalMemory uint64) int {
+func historyBufferMaxSizeFromMemory(totalMemory uint64) int {
 	if totalMemory == 0 {
 		return defaultHistoryBufferSize
 	}
@@ -142,8 +142,8 @@ func historyBufferSizeFromMemory(totalMemory uint64) int {
 		return defaultHistoryBufferSize
 	}
 	size = normalizeHistoryBufferCapacity(size, historyBufferCapacityUnit)
-	if size > maxHistoryBufferBaseSize {
-		return maxHistoryBufferBaseSize
+	if size > maxHistoryBufferSize {
+		return maxHistoryBufferSize
 	}
 	return size
 }
@@ -373,8 +373,6 @@ func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.Regio
 }
 
 func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) error {
-	retainer := s.history.retainFrom(s.history.getNextIndex())
-	defer retainer.release()
 	regions := s.server.GetRegions()
 	lastIndex := 0
 	start := time.Now()
@@ -425,16 +423,10 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}
-		if retainer.overflowed() {
-			return errHistoryBufferRetainOverflow
-		}
 		metas = metas[:0]
 		stats = stats[:0]
 		leaders = leaders[:0]
 		buckets = buckets[:0]
-	}
-	if retainer.overflowed() {
-		return errHistoryBufferRetainOverflow
 	}
 	log.Info("requested server has completed full synchronization with server",
 		zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -601,7 +601,7 @@ func (s *RegionSyncer) closeAllClient() {
 			},
 		}
 		sender.close()
-		if err := sender.stream.Send(resp); err != nil {
+		if err := sender.send(resp); err != nil {
 			log.Warn("region syncer send close message meet error", errs.ZapError(errs.ErrGRPCSend, err))
 		}
 	}

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -45,13 +45,14 @@ import (
 )
 
 const (
-	defaultBucketRate        = 20 * units.MiB // 20MB/s
-	defaultBucketCapacity    = 20 * units.MiB // 20MB
-	maxSyncRegionBatchSize   = 1000
-	syncerKeepAliveInterval  = 10 * time.Second
-	defaultHistoryBufferSize = 10000
-	historyBufferMemoryStep  = 4 * 1024 * 1024 * 1024
-	maxHistoryBufferSize     = 80000
+	defaultBucketRate           = 20 * units.MiB // 20MB/s
+	defaultBucketCapacity       = 20 * units.MiB // 20MB
+	maxSyncRegionBatchSize      = 1000
+	syncerKeepAliveInterval     = 10 * time.Second
+	historyBufferShrinkInterval = 5 * time.Minute
+	defaultHistoryBufferSize    = 10000
+	historyBufferMemoryStep     = 4 * 1024 * 1024 * 1024
+	maxHistoryBufferSize        = 80000
 )
 
 // ClientStream is the client side of the region syncer.
@@ -155,7 +156,8 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 	var stats []*pdpb.RegionStat
 	var leaders []*metapb.Peer
 	var buckets []*metapb.Buckets
-	ticker := time.NewTicker(syncerKeepAliveInterval)
+	keepAliveTicker := time.NewTicker(syncerKeepAliveInterval)
+	shrinkTicker := time.NewTicker(historyBufferShrinkInterval)
 
 	processRegion := func(region *core.RegionInfo) {
 		requests = append(requests, region.GetMeta())
@@ -170,7 +172,8 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 	}
 
 	defer func() {
-		ticker.Stop()
+		keepAliveTicker.Stop()
+		shrinkTicker.Stop()
 		s.mu.Lock()
 		for _, stream := range s.mu.streams {
 			stream.close()
@@ -210,8 +213,9 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 				Buckets:       buckets,
 			}
 			s.broadcast(ctx, regions)
-		case <-ticker.C:
+		case <-shrinkTicker.C:
 			s.history.maybeShrink()
+		case <-keepAliveTicker.C:
 			alive := &pdpb.SyncRegionResponse{
 				Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 				StartIndex: s.history.getNextIndex(),

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -112,6 +112,63 @@ func TestFullSyncReturnsErrorWhenRetainedHistoryExceedsMaxCapacity(t *testing.T)
 	})
 }
 
+func TestFullSyncRetainsHistoryWithinMaxCapacity(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer func() {
+		re.NoError(regionStorage.Close())
+	}()
+
+	cluster := core.NewBasicCluster()
+	cluster.CheckAndPutRegion(newServerTestRegion(1))
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		cluster,
+	)
+	syncer := NewRegionSyncer(server)
+	syncer.history = newHistoryBufferWithConfig(1, 4, 1, syncer.history.kv)
+	syncer.history.resetWithIndex(100)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newMockSyncRegionsServer()
+	unblockSend := stream.blockSend()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.syncFullRegions(ctx, "pd-follower", stream)
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	syncer.history.record(newServerTestRegion(2))
+	syncer.history.record(newServerTestRegion(3))
+	close(unblockSend)
+
+	resp := <-stream.sendCh
+	re.Equal(uint64(0), resp.GetStartIndex())
+	re.Len(resp.GetRegions(), 1)
+	re.Equal(uint64(1), resp.GetRegions()[0].GetId())
+
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		select {
+		case syncErr = <-done:
+			return true
+		default:
+			return false
+		}
+	})
+	re.NoError(syncErr)
+	records := syncer.history.recordsFrom(100)
+	re.Len(records, 2)
+	re.Equal(uint64(2), records[0].GetID())
+	re.Equal(uint64(3), records[1].GetID())
+}
+
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 	re := require.New(t)
 	tempDir := t.TempDir()

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -57,6 +57,100 @@ func TestHistoryBufferMaxSizeFromMemory(t *testing.T) {
 	}
 }
 
+func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
+	re := require.New(t)
+	syncer := newTestRegionSyncer(t, core.NewBasicCluster())
+	syncer.history = newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
+	syncer.history.resetWithIndex(10)
+
+	stream := newMockSyncRegionsServer()
+	syncStream, err := syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
+		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member:     &pdpb.Member{Name: "pd-follower", ClientUrls: []string{"http://127.0.0.1:2379"}},
+		StartIndex: 0,
+	}, stream)
+	if syncStream != nil {
+		defer syncer.unbindStream("pd-follower", syncStream)
+	}
+
+	re.NoError(err)
+	re.Equal(2, syncer.history.capacity())
+}
+
+func TestSyncFullRegionsRetainsCatchUpHistory(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	bc.PutRegion(newHistoryBufferTestRegion(1))
+	syncer := newTestRegionSyncer(t, bc)
+	syncer.history = newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
+	syncer.history.resetWithIndex(10)
+
+	stream := newMockSyncRegionsServer()
+	unblockSend := stream.blockSend()
+	startIndex := syncer.history.getNextIndex()
+	done := make(chan syncFullRegionsResult, 1)
+	go func() {
+		syncStream, err := syncer.syncFullRegions(context.Background(), "pd-follower", stream)
+		done <- syncFullRegionsResult{syncStream: syncStream, err: err}
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	for i := range 5 {
+		syncer.history.record(newHistoryBufferTestRegion(uint64(100 + i)))
+	}
+	records := syncer.history.recordsFrom(startIndex)
+
+	close(unblockSend)
+	fullResp := <-stream.sendCh
+	catchUpResp := <-stream.sendCh
+	result := <-done
+	if result.syncStream != nil {
+		defer syncer.unbindStream("pd-follower", result.syncStream)
+	}
+
+	re.NoError(result.err)
+	re.Len(fullResp.GetRegions(), 1)
+	re.Len(records, 5)
+	re.Equal(startIndex, catchUpResp.GetStartIndex())
+	re.Len(catchUpResp.GetRegions(), 5)
+}
+
+func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	bc.PutRegion(newHistoryBufferTestRegion(1))
+	syncer := newTestRegionSyncer(t, bc)
+	syncer.history = newHistoryBufferWithConfig(2, 2, 1, storage.NewStorageWithMemoryBackend())
+	syncer.history.resetWithIndex(10)
+
+	stream := newMockSyncRegionsServer()
+	unblockSend := stream.blockSend()
+	done := make(chan syncFullRegionsResult, 1)
+	go func() {
+		syncStream, err := syncer.syncFullRegions(context.Background(), "pd-follower", stream)
+		done <- syncFullRegionsResult{syncStream: syncStream, err: err}
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	for i := range 3 {
+		syncer.history.record(newHistoryBufferTestRegion(uint64(200 + i)))
+	}
+
+	close(unblockSend)
+	re.NotNil(<-stream.sendCh)
+	result := <-done
+	if result.syncStream != nil {
+		defer syncer.unbindStream("pd-follower", result.syncStream)
+	}
+
+	re.Error(result.err)
+}
+
+type syncFullRegionsResult struct {
+	syncStream *regionSyncStream
+	err        error
+}
+
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 	re := require.New(t)
 	tempDir := t.TempDir()
@@ -374,6 +468,25 @@ func newMockSyncRegionsServer() *mockSyncRegionsServer {
 		recvCh: make(chan *pdpb.SyncRegionRequest),
 		sendCh: make(chan *pdpb.SyncRegionResponse, 1),
 	}
+}
+
+func newTestRegionSyncer(t *testing.T, bc *core.BasicCluster) *RegionSyncer {
+	t.Helper()
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	t.Cleanup(func() {
+		re.NoError(regionStorage.Close())
+	})
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		bc,
+	)
+	return NewRegionSyncer(server)
 }
 
 func (s *mockSyncRegionsServer) Send(resp *pdpb.SyncRegionResponse) error {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -77,6 +77,25 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 	re.Equal(2, syncer.history.capacity())
 }
 
+func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
+	re := require.New(t)
+	syncer := newTestRegionSyncer(t, core.NewBasicCluster())
+	records := make([]*core.RegionInfo, 0, maxSyncRegionBatchSize+1)
+	for i := range maxSyncRegionBatchSize + 1 {
+		records = append(records, newHistoryBufferTestRegion(uint64(i)))
+	}
+	stream := newMockSyncRegionsServer()
+	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
+
+	re.NoError(syncer.syncHistoryRecords(10, records, stream))
+	first := <-stream.sendCh
+	second := <-stream.sendCh
+	re.Equal(uint64(10), first.GetStartIndex())
+	re.Len(first.GetRegions(), maxSyncRegionBatchSize)
+	re.Equal(uint64(10+maxSyncRegionBatchSize), second.GetStartIndex())
+	re.Len(second.GetRegions(), 1)
+}
+
 func TestSyncFullRegionsRetainsCatchUpHistory(t *testing.T) {
 	re := require.New(t)
 	bc := core.NewBasicCluster()

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -37,7 +36,7 @@ import (
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
-func TestHistoryBufferSizeFromMemory(t *testing.T) {
+func TestHistoryBufferMaxSizeFromMemory(t *testing.T) {
 	testCases := []struct {
 		name        string
 		totalMemory uint64
@@ -48,125 +47,14 @@ func TestHistoryBufferSizeFromMemory(t *testing.T) {
 		{name: "one-step", totalMemory: historyBufferMemoryStep, expected: defaultHistoryBufferSize},
 		{name: "round-to-two-steps", totalMemory: 2 * historyBufferMemoryStep, expected: 2 * defaultHistoryBufferSize},
 		{name: "round-to-four-steps", totalMemory: 3 * historyBufferMemoryStep, expected: 4 * defaultHistoryBufferSize},
-		{name: "clamp-to-max", totalMemory: historyBufferMemoryStep * 100, expected: maxHistoryBufferBaseSize},
+		{name: "clamp-to-max", totalMemory: historyBufferMemoryStep * 100, expected: maxHistoryBufferSize},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			require.Equal(t, testCase.expected, historyBufferSizeFromMemory(testCase.totalMemory))
+			require.Equal(t, testCase.expected, historyBufferMaxSizeFromMemory(testCase.totalMemory))
 		})
 	}
-}
-
-func TestFullSyncReturnsErrorWhenRetainedHistoryExceedsMaxCapacity(t *testing.T) {
-	re := require.New(t)
-	tempDir := t.TempDir()
-	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
-	re.NoError(err)
-	defer func() {
-		re.NoError(regionStorage.Close())
-	}()
-
-	cluster := core.NewBasicCluster()
-	cluster.CheckAndPutRegion(newServerTestRegion(1))
-	server := mockserver.NewMockServer(
-		context.Background(),
-		nil,
-		nil,
-		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
-		cluster,
-	)
-	syncer := NewRegionSyncer(server)
-	syncer.history = newHistoryBufferWithConfig(1, 1, 1, syncer.history.kv)
-	syncer.history.resetWithIndex(100)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	stream := newMockSyncRegionsServer()
-	unblockSend := stream.blockSend()
-	done := make(chan error, 1)
-	go func() {
-		done <- syncer.syncFullRegions(ctx, "pd-follower", stream)
-	}()
-	testutil.Eventually(re, stream.isSendBlocked)
-
-	syncer.history.record(newServerTestRegion(2))
-	syncer.history.record(newServerTestRegion(3))
-	close(unblockSend)
-
-	resp := <-stream.sendCh
-	re.Equal(uint64(0), resp.GetStartIndex())
-	re.Len(resp.GetRegions(), 1)
-	re.Equal(uint64(1), resp.GetRegions()[0].GetId())
-
-	var syncErr error
-	testutil.Eventually(re, func() bool {
-		if syncErr == nil {
-			select {
-			case syncErr = <-done:
-			default:
-				return false
-			}
-		}
-		return errors.Is(syncErr, errHistoryBufferRetainOverflow)
-	})
-}
-
-func TestFullSyncRetainsHistoryWithinMaxCapacity(t *testing.T) {
-	re := require.New(t)
-	tempDir := t.TempDir()
-	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
-	re.NoError(err)
-	defer func() {
-		re.NoError(regionStorage.Close())
-	}()
-
-	cluster := core.NewBasicCluster()
-	cluster.CheckAndPutRegion(newServerTestRegion(1))
-	server := mockserver.NewMockServer(
-		context.Background(),
-		nil,
-		nil,
-		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
-		cluster,
-	)
-	syncer := NewRegionSyncer(server)
-	syncer.history = newHistoryBufferWithConfig(1, 4, 1, syncer.history.kv)
-	syncer.history.resetWithIndex(100)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	stream := newMockSyncRegionsServer()
-	unblockSend := stream.blockSend()
-	done := make(chan error, 1)
-	go func() {
-		done <- syncer.syncFullRegions(ctx, "pd-follower", stream)
-	}()
-	testutil.Eventually(re, stream.isSendBlocked)
-
-	syncer.history.record(newServerTestRegion(2))
-	syncer.history.record(newServerTestRegion(3))
-	close(unblockSend)
-
-	resp := <-stream.sendCh
-	re.Equal(uint64(0), resp.GetStartIndex())
-	re.Len(resp.GetRegions(), 1)
-	re.Equal(uint64(1), resp.GetRegions()[0].GetId())
-
-	var syncErr error
-	testutil.Eventually(re, func() bool {
-		select {
-		case syncErr = <-done:
-			return true
-		default:
-			return false
-		}
-	})
-	re.NoError(syncErr)
-	records := syncer.history.recordsFrom(100)
-	re.Len(records, 2)
-	re.Equal(uint64(2), records[0].GetID())
-	re.Equal(uint64(3), records[1].GetID())
 }
 
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
@@ -571,16 +459,4 @@ func (*mockSyncRegionsServer) SendMsg(any) error {
 
 func (*mockSyncRegionsServer) RecvMsg(any) error {
 	return nil
-}
-
-func newServerTestRegion(regionID uint64) *core.RegionInfo {
-	peer := &metapb.Peer{Id: regionID + 10, StoreId: 1}
-	return core.NewRegionInfo(&metapb.Region{
-		Id: regionID,
-		RegionEpoch: &metapb.RegionEpoch{
-			ConfVer: 1,
-			Version: 1,
-		},
-		Peers: []*metapb.Peer{peer},
-	}, peer)
 }

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -35,6 +36,81 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
+
+func TestHistoryBufferSizeFromMemory(t *testing.T) {
+	testCases := []struct {
+		name        string
+		totalMemory uint64
+		expected    int
+	}{
+		{name: "unknown-memory", totalMemory: 0, expected: defaultHistoryBufferSize},
+		{name: "below-step", totalMemory: historyBufferMemoryStep / 2, expected: defaultHistoryBufferSize},
+		{name: "one-step", totalMemory: historyBufferMemoryStep, expected: defaultHistoryBufferSize},
+		{name: "round-to-two-steps", totalMemory: 2 * historyBufferMemoryStep, expected: 2 * defaultHistoryBufferSize},
+		{name: "round-to-four-steps", totalMemory: 3 * historyBufferMemoryStep, expected: 4 * defaultHistoryBufferSize},
+		{name: "clamp-to-max", totalMemory: historyBufferMemoryStep * 100, expected: maxHistoryBufferBaseSize},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, historyBufferSizeFromMemory(testCase.totalMemory))
+		})
+	}
+}
+
+func TestFullSyncReturnsErrorWhenRetainedHistoryExceedsMaxCapacity(t *testing.T) {
+	re := require.New(t)
+	tempDir := t.TempDir()
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+	re.NoError(err)
+	defer func() {
+		re.NoError(regionStorage.Close())
+	}()
+
+	cluster := core.NewBasicCluster()
+	cluster.CheckAndPutRegion(newServerTestRegion(1))
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
+		cluster,
+	)
+	syncer := NewRegionSyncer(server)
+	syncer.history = newHistoryBufferWithConfig(1, 1, 1, syncer.history.kv)
+	syncer.history.resetWithIndex(100)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newMockSyncRegionsServer()
+	unblockSend := stream.blockSend()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.syncFullRegions(ctx, "pd-follower", stream)
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	syncer.history.record(newServerTestRegion(2))
+	syncer.history.record(newServerTestRegion(3))
+	close(unblockSend)
+
+	resp := <-stream.sendCh
+	re.Equal(uint64(0), resp.GetStartIndex())
+	re.Len(resp.GetRegions(), 1)
+	re.Equal(uint64(1), resp.GetRegions()[0].GetId())
+
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		if syncErr == nil {
+			select {
+			case syncErr = <-done:
+			default:
+				return false
+			}
+		}
+		return errors.Is(syncErr, errHistoryBufferRetainOverflow)
+	})
+}
 
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 	re := require.New(t)
@@ -438,4 +514,16 @@ func (*mockSyncRegionsServer) SendMsg(any) error {
 
 func (*mockSyncRegionsServer) RecvMsg(any) error {
 	return nil
+}
+
+func newServerTestRegion(regionID uint64) *core.RegionInfo {
+	peer := &metapb.Peer{Id: regionID + 10, StoreId: 1}
+	return core.NewRegionInfo(&metapb.Region{
+		Id: regionID,
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+		Peers: []*metapb.Peer{peer},
+	}, peer)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10711

### What is changed and how does it work?

This PR is based on `master` and is independent from #10689. It only includes the adaptive history buffer core logic and tests. Metrics and dashboard changes are left to a follow-up PR.

```commit-message
Make the region syncer history buffer adaptive instead of fixed at startup.

The buffer now uses a memory-aware base capacity in 2^n * 10000 units, grows from the observed replay window, retains full-sync catch-up history, and shrinks after the required window stays low with no active full-sync retain.

If full sync produces more change logs than the maximum retained window can hold, the leader returns an explicit sync error instead of binding a follower that can no longer catch up incrementally.
```

### Check List

Tests

- Unit test

Side effects

- Increased code complexity

### Release note

```release-note
Improve PD region synchronization by adaptively resizing the history buffer to reduce repeated full sync caused by history buffer overflow.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History buffer now dynamically resizes with memory-aware max sizing, automatic grow/shrink, periodic shrink ticker, and retention support to preserve replay windows during sync; outbound sync sends are serialized to reduce concurrency issues.

* **Bug Fixes**
  * Improved retention and overflow handling to avoid losing needed records, stabilize catch-up behavior, and reduce sync failures after restarts.

* **Tests**
  * Added/extended unit tests for memory-based sizing, resize/growth/shrink behavior, persistence across restart, and sync catch-up scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->