### PR TITLE
schedulers: increase leader batch limit

### DIFF
--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -47,11 +47,13 @@ const (
 	// If you want to increase balance speed more, please increase above-mentioned param.
 	BalanceLeaderBatchSize = 4
 	// MaxBalanceLeaderBatchSize is maximum of balance leader batch size
-	MaxBalanceLeaderBatchSize = 10
+	MaxBalanceLeaderBatchSize = 100
 
 	transferIn  = "transfer-in"
 	transferOut = "transfer-out"
 )
+
+var invalidBalanceLeaderBatchSizeMsg = "invalid batch size which should be an integer between 1 and " + strconv.Itoa(MaxBalanceLeaderBatchSize)
 
 type balanceLeaderSchedulerParam struct {
 	Ranges []keyutil.KeyRange `json:"ranges"`
@@ -80,7 +82,7 @@ func (conf *balanceLeaderSchedulerConfig) update(data []byte) (int, any) {
 			if err := json.Unmarshal(oldConfig, param); err != nil {
 				return http.StatusInternalServerError, err.Error()
 			}
-			return http.StatusBadRequest, "invalid batch size which should be an integer between 1 and 10"
+			return http.StatusBadRequest, invalidBalanceLeaderBatchSizeMsg
 		}
 		conf.balanceLeaderSchedulerParam = *param
 		if err := conf.save(); err != nil {
@@ -101,7 +103,7 @@ func (conf *balanceLeaderSchedulerConfig) update(data []byte) (int, any) {
 }
 
 func (conf *balanceLeaderSchedulerParam) validateLocked() bool {
-	return conf.Batch >= 1 && conf.Batch <= 10
+	return conf.Batch >= 1 && conf.Batch <= MaxBalanceLeaderBatchSize
 }
 
 func (conf *balanceLeaderSchedulerConfig) clone() *balanceLeaderSchedulerParam {

--- a/pkg/schedule/schedulers/balance_leader_test.go
+++ b/pkg/schedule/schedulers/balance_leader_test.go
@@ -15,9 +15,13 @@
 package schedulers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
 	"sort"
 	"testing"
 
@@ -65,6 +69,31 @@ func TestBalanceLeaderSchedulerConfigClone(t *testing.T) {
 	// update conf2
 	conf2.Ranges[1] = keyRanges2[1]
 	re.NotEqual(conf.Ranges, conf2.Ranges)
+}
+
+func TestBalanceLeaderBatchLimit(t *testing.T) {
+	re := require.New(t)
+	cancel, _, _, oc := prepareSchedulersTest()
+	defer cancel()
+
+	lb, err := CreateScheduler(types.BalanceLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{"", ""}))
+	re.NoError(err)
+
+	body, err := json.Marshal(map[string]any{"batch": MaxBalanceLeaderBatchSize})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	lb.ServeHTTP(resp, req)
+	re.Equal(http.StatusOK, resp.Code)
+	re.Equal(MaxBalanceLeaderBatchSize, lb.(*balanceLeaderScheduler).conf.getBatch())
+
+	body, err = json.Marshal(map[string]any{"batch": MaxBalanceLeaderBatchSize + 1})
+	re.NoError(err)
+	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp = httptest.NewRecorder()
+	lb.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal(MaxBalanceLeaderBatchSize, lb.(*balanceLeaderScheduler).conf.getBatch())
 }
 
 type balanceLeaderSchedulerTestSuite struct {
@@ -539,6 +568,28 @@ func (suite *balanceLeaderRangeSchedulerTestSuite) TestBatchBalance() {
 		regions[op.RegionID()] = struct{}{}
 	}
 	re.Len(regions, 4)
+}
+
+func TestBalanceLeaderMaxBatchSchedule(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLeaderStore(1, MaxBalanceLeaderBatchSize*10)
+	tc.AddLeaderStore(2, 0)
+	tc.AddLeaderStore(3, 0)
+	for i := 1; i <= MaxBalanceLeaderBatchSize*20; i++ {
+		tc.AddLeaderRegion(uint64(i), 1, 2, 3)
+	}
+
+	lb, err := CreateScheduler(types.BalanceLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{"", ""}))
+	re.NoError(err)
+	lb.(*balanceLeaderScheduler).conf.Batch = MaxBalanceLeaderBatchSize
+
+	testutil.Eventually(re, func() bool {
+		ops, _ := lb.Schedule(tc, false)
+		return len(ops) == MaxBalanceLeaderBatchSize
+	})
 }
 
 func (suite *balanceLeaderRangeSchedulerTestSuite) TestReSortStores() {

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -41,8 +41,8 @@ import (
 const (
 	// EvictLeaderBatchSize is the number of operators to transfer
 	// leaders by one scheduling
-	EvictLeaderBatchSize = 3
-	lastStoreDeleteInfo  = "The last store has been deleted"
+	EvictLeaderBatchSize    = 3
+	maxEvictLeaderBatchSize = 100
 )
 
 type evictLeaderSchedulerConfig struct {
@@ -228,7 +228,7 @@ func (conf *evictLeaderSchedulerConfig) delete(id uint64) (any, error) {
 		}
 		return resp, err
 	}
-	resp = lastStoreDeleteInfo
+	resp = "The last store has been deleted"
 	return resp, nil
 }
 
@@ -419,9 +419,9 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 	batch := handler.config.getBatch()
 	batchFloat, ok := input["batch"].(float64)
 	if ok {
-		if batchFloat < 1 || batchFloat > 10 {
+		if batchFloat < 1 || batchFloat > maxEvictLeaderBatchSize {
 			handler.config.resumeLeaderTransferIfExist(id)
-			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 10]")
+			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 100]")
 			return
 		}
 		batch = (int)(batchFloat)

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -45,6 +45,12 @@ const (
 	maxEvictLeaderBatchSize = 100
 )
 
+func isValidEvictLeaderBatchSize(batchFloat float64) bool {
+	return batchFloat >= 1 &&
+		batchFloat <= maxEvictLeaderBatchSize &&
+		batchFloat == float64(int(batchFloat))
+}
+
 type evictLeaderSchedulerConfig struct {
 	syncutil.RWMutex
 	schedulerConfig
@@ -419,9 +425,9 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 	batch := handler.config.getBatch()
 	batchFloat, ok := input["batch"].(float64)
 	if ok {
-		if batchFloat < 1 || batchFloat > maxEvictLeaderBatchSize {
+		if !isValidEvictLeaderBatchSize(batchFloat) {
 			handler.config.resumeLeaderTransferIfExist(id)
-			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 100]")
+			handler.rd.JSON(w, http.StatusBadRequest, "batch must be an integer in [1, 100]")
 			return
 		}
 		batch = (int)(batchFloat)

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -15,6 +15,7 @@
 package schedulers
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -433,7 +434,7 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 	batchFloat, inputBatch := input["batch"].(float64)
 	if input["batch"] != nil && !inputBatch {
 		handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
-		handler.rd.JSON(w, http.StatusBadRequest, errors.New("invalid argument for 'batch'").Error())
+		handler.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("invalid argument for 'batch': expected a number, got %T", input["batch"]))
 		return
 	}
 	if inputBatch {

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -43,7 +43,10 @@ const (
 	// leaders by one scheduling
 	EvictLeaderBatchSize    = 3
 	maxEvictLeaderBatchSize = 100
+	lastStoreDeleteInfo     = "The last store has been deleted"
 )
+
+var invalidEvictLeaderBatchSizeMsg = "batch must be an integer in [1, " + strconv.Itoa(maxEvictLeaderBatchSize) + "]"
 
 func isValidEvictLeaderBatchSize(batchFloat float64) bool {
 	return batchFloat >= 1 &&
@@ -183,13 +186,15 @@ func (conf *evictLeaderSchedulerConfig) pauseLeaderTransferIfStoreNotExist(id ui
 		if err := conf.cluster.PauseLeaderTransfer(id, constant.In); err != nil {
 			return exist, err
 		}
+		return false, nil
 	}
 	return true, nil
 }
 
-func (conf *evictLeaderSchedulerConfig) resumeLeaderTransferIfExist(id uint64) {
-	conf.RLock()
-	defer conf.RUnlock()
+func (conf *evictLeaderSchedulerConfig) resumeLeaderTransferIfPaused(id uint64, paused bool) {
+	if !paused {
+		return
+	}
 	conf.cluster.ResumeLeaderTransfer(id, constant.In)
 }
 
@@ -234,7 +239,7 @@ func (conf *evictLeaderSchedulerConfig) delete(id uint64) (any, error) {
 		}
 		return resp, err
 	}
-	resp = "The last store has been deleted"
+	resp = lastStoreDeleteInfo
 	return resp, nil
 }
 
@@ -407,10 +412,11 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 		return
 	}
 	var (
-		exist     bool
-		err       error
-		id        uint64
-		newRanges []keyutil.KeyRange
+		exist                bool
+		err                  error
+		id                   uint64
+		leaderTransferPaused bool
+		newRanges            []keyutil.KeyRange
 	)
 	idFloat, inputHasStoreID := input["store_id"].(float64)
 	if inputHasStoreID {
@@ -420,14 +426,20 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 			handler.rd.JSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		leaderTransferPaused = !exist
 	}
 
 	batch := handler.config.getBatch()
-	batchFloat, ok := input["batch"].(float64)
-	if ok {
+	batchFloat, inputBatch := input["batch"].(float64)
+	if input["batch"] != nil && !inputBatch {
+		handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
+		handler.rd.JSON(w, http.StatusBadRequest, errors.New("invalid argument for 'batch'").Error())
+		return
+	}
+	if inputBatch {
 		if !isValidEvictLeaderBatchSize(batchFloat) {
-			handler.config.resumeLeaderTransferIfExist(id)
-			handler.rd.JSON(w, http.StatusBadRequest, "batch must be an integer in [1, 100]")
+			handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
+			handler.rd.JSON(w, http.StatusBadRequest, invalidEvictLeaderBatchSizeMsg)
 			return
 		}
 		batch = (int)(batchFloat)
@@ -436,7 +448,7 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 	ranges, ok := (input["ranges"]).([]string)
 	if ok {
 		if !inputHasStoreID {
-			handler.config.resumeLeaderTransferIfExist(id)
+			handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
 			handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig.FastGenByArgs("id"))
 			return
 		}
@@ -446,7 +458,7 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 
 	newRanges, err = getKeyRanges(ranges)
 	if err != nil {
-		handler.config.resumeLeaderTransferIfExist(id)
+		handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
 		handler.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/pkg/schedule/schedulers/evict_leader_test.go
+++ b/pkg/schedule/schedulers/evict_leader_test.go
@@ -185,6 +185,44 @@ func TestEvictLeaderBatchLimit(t *testing.T) {
 	sl.ServeHTTP(resp, req)
 	re.Equal(http.StatusBadRequest, resp.Code)
 	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
+
+	body, err = json.Marshal(map[string]any{"batch": "abc"})
+	re.NoError(err)
+	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp = httptest.NewRecorder()
+	sl.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
+}
+
+func TestEvictLeaderInvalidBatchKeepsLeaderTransferState(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLeaderStore(1, 0)
+	tc.AddLeaderStore(2, 0)
+
+	sl, err := CreateScheduler(types.EvictLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictLeaderScheduler, []string{"1"}), func(string) error { return nil })
+	re.NoError(err)
+	re.NoError(sl.PrepareConfig(tc))
+	re.False(tc.GetStore(1).AllowLeaderTransferIn())
+
+	body, err := json.Marshal(map[string]any{"store_id": 1, "batch": "abc"})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	sl.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.False(tc.GetStore(1).AllowLeaderTransferIn())
+
+	body, err = json.Marshal(map[string]any{"store_id": 2, "batch": "abc"})
+	re.NoError(err)
+	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp = httptest.NewRecorder()
+	sl.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.True(tc.GetStore(2).AllowLeaderTransferIn())
 }
 
 func TestEvictLeaderAddWaitingOperatorLimit(t *testing.T) {

--- a/pkg/schedule/schedulers/evict_leader_test.go
+++ b/pkg/schedule/schedulers/evict_leader_test.go
@@ -192,6 +192,7 @@ func TestEvictLeaderBatchLimit(t *testing.T) {
 	resp = httptest.NewRecorder()
 	sl.ServeHTTP(resp, req)
 	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal("\"invalid argument for 'batch': expected a number, got string\"\n", resp.Body.String())
 	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
 }
 
@@ -214,6 +215,7 @@ func TestEvictLeaderInvalidBatchKeepsLeaderTransferState(t *testing.T) {
 	resp := httptest.NewRecorder()
 	sl.ServeHTTP(resp, req)
 	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal("\"invalid argument for 'batch': expected a number, got string\"\n", resp.Body.String())
 	re.False(tc.GetStore(1).AllowLeaderTransferIn())
 
 	body, err = json.Marshal(map[string]any{"store_id": 2, "batch": "abc"})
@@ -222,6 +224,7 @@ func TestEvictLeaderInvalidBatchKeepsLeaderTransferState(t *testing.T) {
 	resp = httptest.NewRecorder()
 	sl.ServeHTTP(resp, req)
 	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal("\"invalid argument for 'batch': expected a number, got string\"\n", resp.Body.String())
 	re.True(tc.GetStore(2).AllowLeaderTransferIn())
 }
 

--- a/pkg/schedule/schedulers/evict_leader_test.go
+++ b/pkg/schedule/schedulers/evict_leader_test.go
@@ -177,6 +177,14 @@ func TestEvictLeaderBatchLimit(t *testing.T) {
 	sl.ServeHTTP(resp, req)
 	re.Equal(http.StatusBadRequest, resp.Code)
 	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
+
+	body, err = json.Marshal(map[string]any{"batch": 1.5})
+	re.NoError(err)
+	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp = httptest.NewRecorder()
+	sl.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
 }
 
 func TestEvictLeaderAddWaitingOperatorLimit(t *testing.T) {
@@ -190,16 +198,35 @@ func TestEvictLeaderAddWaitingOperatorLimit(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			re := require.New(t)
-			cluster, oc, sl := prepareEvictLeaderBatchScenario(t, tc.maxWaiting)
+			cancel, opt, cluster, oc := prepareSchedulersTest(false)
+			t.Cleanup(cancel)
+			if tc.maxWaiting > 0 {
+				cfg := opt.GetScheduleConfig().Clone()
+				cfg.SchedulerMaxWaitingOperator = uint64(tc.maxWaiting)
+				opt.SetScheduleConfig(cfg)
+			}
 
-			var ops []*operator.Operator
-			testutil.Eventually(re, func() bool {
-				ops, _ = sl.Schedule(cluster, false)
-				return len(ops) == maxEvictLeaderBatchSize
-			})
+			cluster.AddLeaderStore(1, 0)
+			cluster.AddLeaderStore(2, 0)
+			cluster.AddLeaderStore(3, 0)
+			ops := newEvictLeaderOperators(t, cluster, maxEvictLeaderBatchSize)
 			re.Equal(tc.expected, oc.AddWaitingOperator(ops...))
 		})
 	}
+}
+
+func newEvictLeaderOperators(tb testing.TB, cluster *mockcluster.Cluster, count int) []*operator.Operator {
+	tb.Helper()
+	ops := make([]*operator.Operator, 0, count)
+	for i := range count {
+		region := cluster.AddLeaderRegion(uint64(i+1), 1, 2, 3)
+		op, err := operator.CreateTransferLeaderOperator(types.EvictLeaderScheduler.String(), cluster, region, 2, []uint64{2, 3}, operator.OpLeader)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		ops = append(ops, op)
+	}
+	return ops
 }
 
 func BenchmarkEvictLeaderScheduleBatch(b *testing.B) {
@@ -207,7 +234,7 @@ func BenchmarkEvictLeaderScheduleBatch(b *testing.B) {
 
 	totalOps := 0
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		ops, _ := sl.Schedule(tc, false)
 		if len(ops) == 0 {
 			b.Fatal("expected evict leader operators")
@@ -234,8 +261,9 @@ func prepareEvictLeaderBatchScenario(tb testing.TB, maxWaiting int) (*mockcluste
 	tc.AddLeaderStore(1, 0)
 	tc.AddLeaderStore(2, 0)
 	tc.AddLeaderStore(3, 0)
-	for i := 1; i <= 100000; i++ {
-		tc.AddLeaderRegion(uint64(i), 1, 2, 3)
+	regionCount := maxEvictLeaderBatchSize * 100
+	for i := range regionCount {
+		tc.AddLeaderRegion(uint64(i+1), 1, 2, 3)
 	}
 
 	sl, err := CreateScheduler(types.EvictLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictLeaderScheduler, []string{"1"}), func(string) error { return nil })

--- a/pkg/schedule/schedulers/evict_leader_test.go
+++ b/pkg/schedule/schedulers/evict_leader_test.go
@@ -17,16 +17,21 @@ package schedulers
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
@@ -142,6 +147,103 @@ func TestBatchEvict(t *testing.T) {
 		ops, _ := sl.Schedule(tc, false)
 		return len(ops) == 5
 	})
+	sl.(*evictLeaderScheduler).conf.Batch = maxEvictLeaderBatchSize
+	testutil.Eventually(re, func() bool {
+		ops, _ := sl.Schedule(tc, false)
+		return len(ops) == maxEvictLeaderBatchSize
+	})
+}
+
+func TestEvictLeaderBatchLimit(t *testing.T) {
+	re := require.New(t)
+	cancel, _, _, oc := prepareSchedulersTest()
+	defer cancel()
+
+	sl, err := CreateScheduler(types.EvictLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictLeaderScheduler, []string{"1"}), func(string) error { return nil })
+	re.NoError(err)
+
+	body, err := json.Marshal(map[string]any{"batch": maxEvictLeaderBatchSize})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	sl.ServeHTTP(resp, req)
+	re.Equal(http.StatusOK, resp.Code)
+	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
+
+	body, err = json.Marshal(map[string]any{"batch": maxEvictLeaderBatchSize + 1})
+	re.NoError(err)
+	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp = httptest.NewRecorder()
+	sl.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
+}
+
+func TestEvictLeaderAddWaitingOperatorLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		maxWaiting int
+		expected   int
+	}{
+		{name: "default-waiting-limit", maxWaiting: 0, expected: 5},
+		{name: "batch-sized-waiting-limit", maxWaiting: maxEvictLeaderBatchSize, expected: maxEvictLeaderBatchSize},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			re := require.New(t)
+			cluster, oc, sl := prepareEvictLeaderBatchScenario(t, tc.maxWaiting)
+
+			var ops []*operator.Operator
+			testutil.Eventually(re, func() bool {
+				ops, _ = sl.Schedule(cluster, false)
+				return len(ops) == maxEvictLeaderBatchSize
+			})
+			re.Equal(tc.expected, oc.AddWaitingOperator(ops...))
+		})
+	}
+}
+
+func BenchmarkEvictLeaderScheduleBatch(b *testing.B) {
+	tc, _, sl := prepareEvictLeaderBatchScenario(b, 0)
+
+	totalOps := 0
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ops, _ := sl.Schedule(tc, false)
+		if len(ops) == 0 {
+			b.Fatal("expected evict leader operators")
+		}
+		totalOps += len(ops)
+	}
+	elapsed := b.Elapsed().Seconds()
+	b.ReportMetric(float64(totalOps)/elapsed, "ops/s")
+	b.ReportMetric(float64(totalOps)*60/elapsed, "ops/min")
+}
+
+func prepareEvictLeaderBatchScenario(tb testing.TB, maxWaiting int) (*mockcluster.Cluster, *operator.Controller, Scheduler) {
+	restoreLogger := log.ReplaceGlobals(zap.NewNop(), nil)
+	tb.Cleanup(restoreLogger)
+
+	cancel, opt, tc, oc := prepareSchedulersTest(false)
+	tb.Cleanup(cancel)
+	if maxWaiting > 0 {
+		cfg := opt.GetScheduleConfig().Clone()
+		cfg.SchedulerMaxWaitingOperator = uint64(maxWaiting)
+		opt.SetScheduleConfig(cfg)
+	}
+
+	tc.AddLeaderStore(1, 0)
+	tc.AddLeaderStore(2, 0)
+	tc.AddLeaderStore(3, 0)
+	for i := 1; i <= 100000; i++ {
+		tc.AddLeaderRegion(uint64(i), 1, 2, 3)
+	}
+
+	sl, err := CreateScheduler(types.EvictLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictLeaderScheduler, []string{"1"}), func(string) error { return nil })
+	if err != nil {
+		tb.Fatal(err)
+	}
+	sl.(*evictLeaderScheduler).conf.Batch = maxEvictLeaderBatchSize
+	return tc, oc, sl
 }
 
 func TestEvictLeaderSchedulerCompatibility(t *testing.T) {

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -310,8 +310,8 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		return
 	}
 	if inputBatch {
-		if batchFloat < 1 || batchFloat > 10 {
-			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 10]")
+		if batchFloat < 1 || batchFloat > maxEvictLeaderBatchSize {
+			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 100]")
 			return
 		}
 	}

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -309,11 +309,9 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		handler.rd.JSON(w, http.StatusBadRequest, perrors.New("invalid argument for 'batch'").Error())
 		return
 	}
-	if inputBatch {
-		if !isValidEvictLeaderBatchSize(batchFloat) {
-			handler.rd.JSON(w, http.StatusBadRequest, "batch must be an integer in [1, 100]")
-			return
-		}
+	if inputBatch && !isValidEvictLeaderBatchSize(batchFloat) {
+		handler.rd.JSON(w, http.StatusBadRequest, invalidEvictLeaderBatchSizeMsg)
+		return
 	}
 
 	enableNetworkSlowStore, inputEnableNetworkSlowStore := input["enable-network-slow-store"].(bool)

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -310,8 +310,8 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		return
 	}
 	if inputBatch {
-		if batchFloat < 1 || batchFloat > maxEvictLeaderBatchSize {
-			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 100]")
+		if !isValidEvictLeaderBatchSize(batchFloat) {
+			handler.rd.JSON(w, http.StatusBadRequest, "batch must be an integer in [1, 100]")
 			return
 		}
 	}

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
+	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
 const (
@@ -644,7 +645,7 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 	tc.AddLeaderStore(2, 0)
 	tc.AddLeaderStore(3, 0)
 	// Add regions with leader in store 1
-	for i := range 10000 {
+	for i := range 100000 {
 		tc.AddLeaderRegion(uint64(i), 1, 2)
 	}
 
@@ -669,6 +670,13 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 	ops, _ = es.Schedule(tc, false)
 	re.Len(ops, 5)
 
+	es.(*evictSlowStoreScheduler).conf.Batch = maxEvictLeaderBatchSize
+	re.NoError(es.(*evictSlowStoreScheduler).conf.save())
+	testutil.Eventually(re, func() bool {
+		ops, _ = es.Schedule(tc, false)
+		return len(ops) == maxEvictLeaderBatchSize
+	})
+
 	newStoreInfo = storeInfo.Clone(func(store *core.StoreInfo) {
 		store.GetStoreStats().SlowScore = 0
 	})
@@ -690,7 +698,7 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 	re.Equal(es2.conf.EvictedStores, persistValue.EvictedStores)
 	re.Zero(persistValue.evictStore())
 	re.True(persistValue.readyForRecovery())
-	re.Equal(5, persistValue.Batch)
+	re.Equal(maxEvictLeaderBatchSize, persistValue.Batch)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
 }
 

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -15,7 +15,11 @@
 package schedulers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -645,7 +649,7 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 	tc.AddLeaderStore(2, 0)
 	tc.AddLeaderStore(3, 0)
 	// Add regions with leader in store 1
-	for i := range 100000 {
+	for i := range 10000 {
 		tc.AddLeaderRegion(uint64(i), 1, 2)
 	}
 
@@ -660,15 +664,20 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 	tc.PutStore(newStoreInfo)
 	re.True(es.IsScheduleAllowed(tc))
 	// Add evict leader scheduler to store 1
-	ops, _ := es.Schedule(tc, false)
-	re.Len(ops, 3)
+	var ops []*operator.Operator
+	testutil.Eventually(re, func() bool {
+		ops, _ = es.Schedule(tc, false)
+		return len(ops) == EvictLeaderBatchSize
+	})
 	operatorutil.CheckMultiTargetTransferLeader(re, ops[0], operator.OpLeader, 1, []uint64{2})
 	re.Equal(types.EvictSlowStoreScheduler.String(), ops[0].Desc())
 
 	es.(*evictSlowStoreScheduler).conf.Batch = 5
 	re.NoError(es.(*evictSlowStoreScheduler).conf.save())
-	ops, _ = es.Schedule(tc, false)
-	re.Len(ops, 5)
+	testutil.Eventually(re, func() bool {
+		ops, _ = es.Schedule(tc, false)
+		return len(ops) == 5
+	})
 
 	es.(*evictSlowStoreScheduler).conf.Batch = maxEvictLeaderBatchSize
 	re.NoError(es.(*evictSlowStoreScheduler).conf.save())
@@ -700,6 +709,31 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 	re.True(persistValue.readyForRecovery())
 	re.Equal(maxEvictLeaderBatchSize, persistValue.Batch)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+}
+
+func TestEvictSlowStoreBatchLimit(t *testing.T) {
+	re := require.New(t)
+	cancel, _, _, oc := prepareSchedulersTest()
+	defer cancel()
+
+	es, err := CreateScheduler(types.EvictSlowStoreScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictSlowStoreScheduler, []string{}), nil)
+	re.NoError(err)
+
+	body, err := json.Marshal(map[string]any{"batch": maxEvictLeaderBatchSize})
+	re.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp := httptest.NewRecorder()
+	es.ServeHTTP(resp, req)
+	re.Equal(http.StatusOK, resp.Code)
+	re.Equal(maxEvictLeaderBatchSize, es.(*evictSlowStoreScheduler).conf.getBatch())
+
+	body, err = json.Marshal(map[string]any{"batch": 1.5})
+	re.NoError(err)
+	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
+	resp = httptest.NewRecorder()
+	es.ServeHTTP(resp, req)
+	re.Equal(http.StatusBadRequest, resp.Code)
+	re.Equal(maxEvictLeaderBatchSize, es.(*evictSlowStoreScheduler).conf.getBatch())
 }
 
 func TestRecoveryTime(t *testing.T) {

--- a/pkg/schedule/schedulers/grant_leader.go
+++ b/pkg/schedule/schedulers/grant_leader.go
@@ -324,7 +324,7 @@ func (handler *grantLeaderHandler) deleteConfig(w http.ResponseWriter, r *http.R
 				}
 				return
 			}
-			resp = "The last store has been deleted"
+			resp = lastStoreDeleteInfo
 		}
 		handler.rd.JSON(w, http.StatusOK, resp)
 		return

--- a/pkg/schedule/schedulers/grant_leader.go
+++ b/pkg/schedule/schedulers/grant_leader.go
@@ -324,7 +324,7 @@ func (handler *grantLeaderHandler) deleteConfig(w http.ResponseWriter, r *http.R
 				}
 				return
 			}
-			resp = lastStoreDeleteInfo
+			resp = "The last store has been deleted"
 		}
 		handler.rd.JSON(w, http.StatusOK, resp)
 		return

--- a/tests/server/api/scheduler_test.go
+++ b/tests/server/api/scheduler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	sc "github.com/tikv/pd/pkg/schedule/config"
+	schedulerpkg "github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/utils/apiutil"
@@ -211,12 +212,12 @@ func (suite *scheduleTestSuite) checkAPI(cluster *tests.TestCluster) {
 				re.NoError(err)
 				// update invalidate batch
 				dataMap = map[string]any{}
-				dataMap["batch"] = 100
+				dataMap["batch"] = schedulerpkg.MaxBalanceLeaderBatchSize + 1
 				body, err = json.Marshal(dataMap)
 				re.NoError(err)
 				err = testutil.CheckPostJSON(tests.TestDialClient, updateURL, body,
 					testutil.Status(re, http.StatusBadRequest),
-					testutil.StringEqual(re, "\"invalid batch size which should be an integer between 1 and 10\"\n"))
+					testutil.StringEqual(re, fmt.Sprintf("\"invalid batch size which should be an integer between 1 and %d\"\n", schedulerpkg.MaxBalanceLeaderBatchSize)))
 				re.NoError(err)
 				resp = make(map[string]any)
 				testutil.Eventually(re, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8265

### What is changed and how does it work?

```commit-message
Increase the maximum configurable batch size for evict-leader-scheduler
and evict-slow-store-scheduler from 10 to 100.

Add tests to cover the new evict leader batch limit and the interaction
with scheduler-max-waiting-operator, so the larger batch size does not
imply changes to the existing waiting operator admission limit.
```

### Check List

Tests

- Unit test

Code changes

- Has the configuration change

Side effects

- Possible performance regression

### Release note

```release-note
Increase the maximum configurable batch size of evict-leader-scheduler and evict-slow-store-scheduler from 10 to 100.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Raised evict-leader and evict-slow-store batch cap to 100.
  * Improved batch validation with clearer 400 responses for non-float, non-integer, or out-of-range inputs.
  * Fixed pause/resume so leader-transfer resumes only when it was actually paused.

* **Tests**
  * Added and expanded tests and a benchmark covering batch limits, invalid inputs, operator caps, and scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->