### PR TITLE
syncer: isolate downstream state by stream

### DIFF
--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -57,10 +57,10 @@ type historyBuffer struct {
 	// lowWindowRounds counts consecutive shrink checks where the required window stays low.
 	lowWindowRounds int
 	// retains tracks full-sync start indexes that must stay replayable until catch-up finishes.
-	retains      map[uint64]int
-	kv           kv.Base
-	persistIndex bool
-	flushCount   int
+	retains             map[uint64]int
+	kv                  kv.Base
+	persistHistoryIndex bool
+	flushCount          int
 }
 
 func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer {
@@ -73,11 +73,13 @@ func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv 
 	return h
 }
 
+// newMemoryHistoryBuffer creates a process-local buffer with an explicit next index.
+// It does not reload from KV because downstream buffers are not persisted.
 func newMemoryHistoryBuffer(size int, index uint64) *historyBuffer {
 	return newHistoryBufferWithConfigAndIndex(size, size, historyBufferCapacityUnit, index, nil, false)
 }
 
-func newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit int, index uint64, kv kv.Base, persistIndex bool) *historyBuffer {
+func newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit int, index uint64, kv kv.Base, persistHistoryIndex bool) *historyBuffer {
 	baseCapacity = normalizeHistoryBufferCapacity(baseCapacity, capacityUnit)
 	maxCapacity = normalizeHistoryBufferCapacity(maxCapacity, capacityUnit)
 	if maxCapacity < baseCapacity {
@@ -87,15 +89,15 @@ func newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit 
 	size := baseCapacity + 1
 	records := make([]*core.RegionInfo, size)
 	return &historyBuffer{
-		index:        index,
-		records:      records,
-		size:         size,
-		baseCapacity: baseCapacity,
-		maxCapacity:  maxCapacity,
-		capacityUnit: capacityUnit,
-		kv:           kv,
-		persistIndex: persistIndex,
-		flushCount:   defaultFlushCount,
+		index:               index,
+		records:             records,
+		size:                size,
+		baseCapacity:        baseCapacity,
+		maxCapacity:         maxCapacity,
+		capacityUnit:        capacityUnit,
+		kv:                  kv,
+		persistHistoryIndex: persistHistoryIndex,
+		flushCount:          defaultFlushCount,
 	}
 }
 
@@ -139,7 +141,7 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 	if retainIndex, ok := h.minRetainIndexLocked(); ok && retainIndex <= h.index {
 		h.growForWindowLocked(h.index - retainIndex + 1)
 	}
-	if h.persistIndex {
+	if h.persistHistoryIndex {
 		syncIndexGauge.Set(float64(h.index))
 	}
 	h.records[h.tail] = r
@@ -148,7 +150,7 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 		h.head = (h.head + 1) % h.size
 	}
 	h.index++
-	if !h.persistIndex {
+	if !h.persistHistoryIndex {
 		return
 	}
 	h.flushCount--
@@ -298,6 +300,14 @@ func (h *historyBuffer) resetWithIndex(index uint64) {
 	h.resetWithIndexLocked(index)
 }
 
+func (h *historyBuffer) advanceToIndex(index uint64) {
+	h.Lock()
+	defer h.Unlock()
+	if h.index <= index {
+		h.resetWithIndexLocked(index)
+	}
+}
+
 func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	h.index = index
 	h.head = 0
@@ -330,7 +340,7 @@ func (h *historyBuffer) get(index uint64) *core.RegionInfo {
 }
 
 func (h *historyBuffer) reload() {
-	if !h.persistIndex {
+	if !h.persistHistoryIndex {
 		return
 	}
 	v, err := h.kv.Load(historyKey)
@@ -347,7 +357,7 @@ func (h *historyBuffer) reload() {
 }
 
 func (h *historyBuffer) persist() {
-	if !h.persistIndex {
+	if !h.persistHistoryIndex {
 		return
 	}
 	firstIndexGauge.Set(float64(h.firstIndex()))

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -57,9 +57,10 @@ type historyBuffer struct {
 	// lowWindowRounds counts consecutive shrink checks where the required window stays low.
 	lowWindowRounds int
 	// retains tracks full-sync start indexes that must stay replayable until catch-up finishes.
-	retains    map[uint64]int
-	kv         kv.Base
-	flushCount int
+	retains      map[uint64]int
+	kv           kv.Base
+	persistIndex bool
+	flushCount   int
 }
 
 func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer {
@@ -67,6 +68,16 @@ func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer 
 }
 
 func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv kv.Base) *historyBuffer {
+	h := newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit, 0, kv, true)
+	h.reload()
+	return h
+}
+
+func newMemoryHistoryBuffer(size int, index uint64) *historyBuffer {
+	return newHistoryBufferWithConfigAndIndex(size, size, historyBufferCapacityUnit, index, nil, false)
+}
+
+func newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit int, index uint64, kv kv.Base, persistIndex bool) *historyBuffer {
 	baseCapacity = normalizeHistoryBufferCapacity(baseCapacity, capacityUnit)
 	maxCapacity = normalizeHistoryBufferCapacity(maxCapacity, capacityUnit)
 	if maxCapacity < baseCapacity {
@@ -75,17 +86,17 @@ func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv 
 	// use an empty space to simplify operation
 	size := baseCapacity + 1
 	records := make([]*core.RegionInfo, size)
-	h := &historyBuffer{
+	return &historyBuffer{
+		index:        index,
 		records:      records,
 		size:         size,
 		baseCapacity: baseCapacity,
 		maxCapacity:  maxCapacity,
 		capacityUnit: capacityUnit,
 		kv:           kv,
+		persistIndex: persistIndex,
 		flushCount:   defaultFlushCount,
 	}
-	h.reload()
-	return h
 }
 
 func normalizeHistoryBufferCapacity(size, capacityUnit int) int {
@@ -128,13 +139,18 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 	if retainIndex, ok := h.minRetainIndexLocked(); ok && retainIndex <= h.index {
 		h.growForWindowLocked(h.index - retainIndex + 1)
 	}
-	syncIndexGauge.Set(float64(h.index))
+	if h.persistIndex {
+		syncIndexGauge.Set(float64(h.index))
+	}
 	h.records[h.tail] = r
 	h.tail = (h.tail + 1) % h.size
 	if h.tail == h.head {
 		h.head = (h.head + 1) % h.size
 	}
 	h.index++
+	if !h.persistIndex {
+		return
+	}
 	h.flushCount--
 	if h.flushCount <= 0 {
 		h.persist()
@@ -149,27 +165,29 @@ func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
 }
 
 func (h *historyBuffer) recordsFromLocked(index uint64) []*core.RegionInfo {
-	var pos int
-	if index < h.nextIndex() && index >= h.firstIndex() {
-		pos = (h.head + int(index-h.firstIndex())) % h.size
-	} else {
-		return nil
-	}
-	records := make([]*core.RegionInfo, 0, h.distanceToTail(pos))
-	for i := pos; i != h.tail; i = (i + 1) % h.size {
-		records = append(records, h.records[i])
-	}
-	return records
+	return h.recordsBetweenLocked(index, h.nextIndex())
 }
 
-func (h *historyBuffer) observeAndRecordsFrom(index uint64) ([]*core.RegionInfo, uint64) {
-	h.Lock()
-	defer h.Unlock()
-	nextIndex := h.nextIndex()
-	if index != 0 && index < nextIndex {
-		h.observeRequiredWindowLocked(nextIndex - index)
+func (h *historyBuffer) recordsBetween(index, endIndex uint64) []*core.RegionInfo {
+	h.RLock()
+	defer h.RUnlock()
+	return h.recordsBetweenLocked(index, endIndex)
+}
+
+func (h *historyBuffer) recordsBetweenLocked(index, endIndex uint64) []*core.RegionInfo {
+	if endIndex > h.nextIndex() {
+		endIndex = h.nextIndex()
 	}
-	return h.recordsFromLocked(index), nextIndex
+	if index >= endIndex || index < h.firstIndex() || index > h.nextIndex() {
+		return nil
+	}
+	pos := (h.head + int(index-h.firstIndex())) % h.size
+	records := make([]*core.RegionInfo, 0, int(endIndex-index))
+	for i := pos; index < endIndex; i = (i + 1) % h.size {
+		records = append(records, h.records[i])
+		index++
+	}
+	return records
 }
 
 func (h *historyBuffer) retainedRecordsFrom(index uint64) ([]*core.RegionInfo, uint64, bool) {
@@ -183,15 +201,18 @@ func (h *historyBuffer) retainedRecordsFrom(index uint64) ([]*core.RegionInfo, u
 	return records, nextIndex, len(records) == int(nextIndex-index)
 }
 
-func (h *historyBuffer) retainFromCurrent() (uint64, func()) {
+func (h *historyBuffer) retainFrom(index uint64) func() {
 	h.Lock()
 	defer h.Unlock()
-	index := h.nextIndex()
+	return h.retainLocked(index)
+}
+
+func (h *historyBuffer) retainLocked(index uint64) func() {
 	if h.retains == nil {
 		h.retains = make(map[uint64]int)
 	}
 	h.retains[index]++
-	return index, func() {
+	return func() {
 		h.releaseRetain(index)
 	}
 }
@@ -296,6 +317,12 @@ func (h *historyBuffer) getNextIndex() uint64 {
 	return h.index
 }
 
+func (h *historyBuffer) getFirstIndex() uint64 {
+	h.RLock()
+	defer h.RUnlock()
+	return h.firstIndex()
+}
+
 func (h *historyBuffer) get(index uint64) *core.RegionInfo {
 	h.RLock()
 	defer h.RUnlock()
@@ -303,6 +330,9 @@ func (h *historyBuffer) get(index uint64) *core.RegionInfo {
 }
 
 func (h *historyBuffer) reload() {
+	if !h.persistIndex {
+		return
+	}
 	v, err := h.kv.Load(historyKey)
 	if err != nil {
 		log.Warn("load history index failed", zap.String("error", err.Error()))
@@ -317,6 +347,9 @@ func (h *historyBuffer) reload() {
 }
 
 func (h *historyBuffer) persist() {
+	if !h.persistIndex {
+		return
+	}
 	firstIndexGauge.Set(float64(h.firstIndex()))
 	lastIndexGauge.Set(float64(h.nextIndex()))
 	err := h.kv.Save(historyKey, strconv.FormatUint(h.nextIndex(), 10))

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -57,10 +57,9 @@ type historyBuffer struct {
 	// lowWindowRounds counts consecutive shrink checks where the required window stays low.
 	lowWindowRounds int
 	// retains tracks full-sync start indexes that must stay replayable until catch-up finishes.
-	retains             map[uint64]int
-	kv                  kv.Base
-	persistHistoryIndex bool
-	flushCount          int
+	retains    map[uint64]int
+	kv         kv.Base
+	flushCount int
 }
 
 func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer {
@@ -68,18 +67,6 @@ func newHistoryBuffer(baseCapacity, maxCapacity int, kv kv.Base) *historyBuffer 
 }
 
 func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv kv.Base) *historyBuffer {
-	h := newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit, 0, kv, true)
-	h.reload()
-	return h
-}
-
-// newMemoryHistoryBuffer creates a process-local buffer with an explicit next index.
-// It does not reload from KV because downstream buffers are not persisted.
-func newMemoryHistoryBuffer(size int, index uint64) *historyBuffer {
-	return newHistoryBufferWithConfigAndIndex(size, size, historyBufferCapacityUnit, index, nil, false)
-}
-
-func newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit int, index uint64, kv kv.Base, persistHistoryIndex bool) *historyBuffer {
 	baseCapacity = normalizeHistoryBufferCapacity(baseCapacity, capacityUnit)
 	maxCapacity = normalizeHistoryBufferCapacity(maxCapacity, capacityUnit)
 	if maxCapacity < baseCapacity {
@@ -88,17 +75,17 @@ func newHistoryBufferWithConfigAndIndex(baseCapacity, maxCapacity, capacityUnit 
 	// use an empty space to simplify operation
 	size := baseCapacity + 1
 	records := make([]*core.RegionInfo, size)
-	return &historyBuffer{
-		index:               index,
-		records:             records,
-		size:                size,
-		baseCapacity:        baseCapacity,
-		maxCapacity:         maxCapacity,
-		capacityUnit:        capacityUnit,
-		kv:                  kv,
-		persistHistoryIndex: persistHistoryIndex,
-		flushCount:          defaultFlushCount,
+	h := &historyBuffer{
+		records:      records,
+		size:         size,
+		baseCapacity: baseCapacity,
+		maxCapacity:  maxCapacity,
+		capacityUnit: capacityUnit,
+		kv:           kv,
+		flushCount:   defaultFlushCount,
 	}
+	h.reload()
+	return h
 }
 
 func normalizeHistoryBufferCapacity(size, capacityUnit int) int {
@@ -141,18 +128,13 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 	if retainIndex, ok := h.minRetainIndexLocked(); ok && retainIndex <= h.index {
 		h.growForWindowLocked(h.index - retainIndex + 1)
 	}
-	if h.persistHistoryIndex {
-		syncIndexGauge.Set(float64(h.index))
-	}
+	syncIndexGauge.Set(float64(h.index))
 	h.records[h.tail] = r
 	h.tail = (h.tail + 1) % h.size
 	if h.tail == h.head {
 		h.head = (h.head + 1) % h.size
 	}
 	h.index++
-	if !h.persistHistoryIndex {
-		return
-	}
 	h.flushCount--
 	if h.flushCount <= 0 {
 		h.persist()
@@ -300,14 +282,6 @@ func (h *historyBuffer) resetWithIndex(index uint64) {
 	h.resetWithIndexLocked(index)
 }
 
-func (h *historyBuffer) advanceToIndex(index uint64) {
-	h.Lock()
-	defer h.Unlock()
-	if h.index <= index {
-		h.resetWithIndexLocked(index)
-	}
-}
-
 func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	h.index = index
 	h.head = 0
@@ -340,9 +314,6 @@ func (h *historyBuffer) get(index uint64) *core.RegionInfo {
 }
 
 func (h *historyBuffer) reload() {
-	if !h.persistHistoryIndex {
-		return
-	}
 	v, err := h.kv.Load(historyKey)
 	if err != nil {
 		log.Warn("load history index failed", zap.String("error", err.Error()))
@@ -357,9 +328,6 @@ func (h *historyBuffer) reload() {
 }
 
 func (h *historyBuffer) persist() {
-	if !h.persistHistoryIndex {
-		return
-	}
 	firstIndexGauge.Set(float64(h.firstIndex()))
 	lastIndexGauge.Set(float64(h.nextIndex()))
 	err := h.kv.Save(historyKey, strconv.FormatUint(h.nextIndex(), 10))

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -143,38 +143,6 @@ func TestHistoryBufferPersistsNextIndexOnly(t *testing.T) {
 	re.Equal("3", s)
 }
 
-func TestMemoryHistoryBuffer(t *testing.T) {
-	re := require.New(t)
-	h := newMemoryHistoryBuffer(2, 10)
-	h.flushCount = 1
-
-	region := core.NewRegionInfo(&metapb.Region{Id: 1}, nil)
-	h.record(region)
-
-	re.Equal(uint64(11), h.getNextIndex())
-	re.Equal(region, h.get(10))
-	re.Nil(h.kv)
-	re.False(h.persistHistoryIndex)
-}
-
-func TestHistoryBufferAdvanceToIndexPreservesNewerRecords(t *testing.T) {
-	re := require.New(t)
-	h := newMemoryHistoryBuffer(4, 10)
-	h.record(newHistoryBufferTestRegion(10))
-	h.record(newHistoryBufferTestRegion(11))
-
-	h.advanceToIndex(11)
-
-	re.Equal(uint64(12), h.getNextIndex())
-	records := h.recordsFrom(11)
-	re.Len(records, 1)
-	re.Equal(uint64(11), records[0].GetID())
-
-	h.advanceToIndex(12)
-	re.Equal(uint64(12), h.getNextIndex())
-	re.Empty(h.recordsFrom(11))
-}
-
 func TestHistoryBufferRetainKeepsCatchUpRecords(t *testing.T) {
 	re := require.New(t)
 	h := newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -143,6 +143,39 @@ func TestHistoryBufferPersistsNextIndexOnly(t *testing.T) {
 	re.Equal("3", s)
 }
 
+func TestMemoryHistoryBuffer(t *testing.T) {
+	re := require.New(t)
+	h := newMemoryHistoryBuffer(2, 10)
+	h.flushCount = 1
+
+	region := core.NewRegionInfo(&metapb.Region{Id: 1}, nil)
+	h.record(region)
+
+	re.Equal(uint64(11), h.getNextIndex())
+	re.Equal(region, h.get(10))
+	re.Nil(h.kv)
+	re.False(h.persistIndex)
+}
+
+func TestHistoryBufferRetainKeepsCatchUpRecords(t *testing.T) {
+	re := require.New(t)
+	h := newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
+	h.resetWithIndex(10)
+	release := h.retainFrom(10)
+	defer release()
+
+	for i := range 5 {
+		h.record(newHistoryBufferTestRegion(uint64(100 + i)))
+	}
+
+	records, nextIndex, ok := h.retainedRecordsFrom(10)
+	re.True(ok)
+	re.Equal(uint64(15), nextIndex)
+	re.Equal(uint64(10), h.getFirstIndex())
+	re.Len(records, 5)
+	re.Equal(8, h.capacity())
+}
+
 func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -154,7 +154,25 @@ func TestMemoryHistoryBuffer(t *testing.T) {
 	re.Equal(uint64(11), h.getNextIndex())
 	re.Equal(region, h.get(10))
 	re.Nil(h.kv)
-	re.False(h.persistIndex)
+	re.False(h.persistHistoryIndex)
+}
+
+func TestHistoryBufferAdvanceToIndexPreservesNewerRecords(t *testing.T) {
+	re := require.New(t)
+	h := newMemoryHistoryBuffer(4, 10)
+	h.record(newHistoryBufferTestRegion(10))
+	h.record(newHistoryBufferTestRegion(11))
+
+	h.advanceToIndex(11)
+
+	re.Equal(uint64(12), h.getNextIndex())
+	records := h.recordsFrom(11)
+	re.Len(records, 1)
+	re.Equal(uint64(11), records[0].GetID())
+
+	h.advanceToIndex(12)
+	re.Equal(uint64(12), h.getNextIndex())
+	re.Empty(h.recordsFrom(11))
 }
 
 func TestHistoryBufferRetainKeepsCatchUpRecords(t *testing.T) {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -71,13 +71,14 @@ type downstreamSendSignal struct {
 }
 
 type regionSyncStream struct {
-	stream    ServerStream
-	sendMu    sync.Mutex
-	indexMu   syncutil.RWMutex
-	sendIndex uint64
-	notifyCh  chan downstreamSendSignal
-	done      chan struct{}
-	once      sync.Once
+	stream       ServerStream
+	sendMu       sync.Mutex
+	streamSendMu sync.Mutex
+	indexMu      syncutil.RWMutex
+	sendIndex    uint64
+	notifyCh     chan downstreamSendSignal
+	done         chan struct{}
+	once         sync.Once
 }
 
 func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStream {
@@ -117,6 +118,12 @@ func (s *regionSyncStream) close() {
 func (s *regionSyncStream) send(regions *pdpb.SyncRegionResponse) error {
 	s.sendMu.Lock()
 	defer s.sendMu.Unlock()
+	return s.sendStream(regions)
+}
+
+func (s *regionSyncStream) sendStream(regions *pdpb.SyncRegionResponse) error {
+	s.streamSendMu.Lock()
+	defer s.streamSendMu.Unlock()
 	return s.stream.Send(regions)
 }
 
@@ -413,7 +420,7 @@ func (s *RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.Reg
 func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core.RegionInfo, stream *regionSyncStream) error {
 	for start := 0; start < len(records); start += maxSyncRegionBatchSize {
 		end := min(start+maxSyncRegionBatchSize, len(records))
-		if err := stream.stream.Send(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
+		if err := stream.sendStream(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
 			return err
 		}
 	}
@@ -475,7 +482,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 			return err
 		}
 		lastIndex += len(metas)
-		if err := syncStream.stream.Send(resp); err != nil {
+		if err := syncStream.sendStream(resp); err != nil {
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}
@@ -587,12 +594,13 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		if sendIndex == bufferNextIndex {
 			return sentRecords, nil
 		}
-		records := s.history.recordsBetween(sendIndex, bufferNextIndex)
-		if len(records) == 0 {
-			return sentRecords, errors.Errorf("region syncer has no buffered records from index %d to %d", sendIndex, bufferNextIndex)
+		endIndex := bufferNextIndex
+		if endIndex-sendIndex > uint64(maxSyncRegionBatchSize) {
+			endIndex = sendIndex + uint64(maxSyncRegionBatchSize)
 		}
-		if len(records) > maxSyncRegionBatchSize {
-			records = records[:maxSyncRegionBatchSize]
+		records := s.history.recordsBetween(sendIndex, endIndex)
+		if len(records) == 0 {
+			return sentRecords, errors.Errorf("region syncer has no buffered records from index %d to %d", sendIndex, endIndex)
 		}
 		resp := buildSyncRegionResponse(sendIndex, records)
 		if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
@@ -639,7 +647,7 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 
 	resultCh := make(chan error, 1)
 	go func() {
-		resultCh <- sender.stream.Send(regions)
+		resultCh <- sender.sendStream(regions)
 	}()
 
 	timeout := s.sendTimeout

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -71,35 +71,49 @@ type downstreamSendSignal struct {
 }
 
 type regionSyncStream struct {
-	stream       ServerStream
-	sendMu       sync.Mutex
-	streamSendMu sync.Mutex
-	indexMu      syncutil.RWMutex
-	sendIndex    uint64
-	notifyCh     chan downstreamSendSignal
-	done         chan struct{}
-	once         sync.Once
+	stream struct {
+		syncutil.Mutex
+		ServerStream
+	}
+	sendMu syncutil.Mutex
+	index  struct {
+		syncutil.RWMutex
+		sendIndex uint64
+	}
+	notifyCh chan downstreamSendSignal
+	done     chan struct{}
+	once     sync.Once
 }
 
 func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStream {
 	return &regionSyncStream{
-		stream:    stream,
-		sendIndex: startIndex,
-		notifyCh:  make(chan downstreamSendSignal, 1),
-		done:      make(chan struct{}),
+		stream: struct {
+			syncutil.Mutex
+			ServerStream
+		}{
+			ServerStream: stream,
+		},
+		index: struct {
+			syncutil.RWMutex
+			sendIndex uint64
+		}{
+			sendIndex: startIndex,
+		},
+		notifyCh: make(chan downstreamSendSignal, 1),
+		done:     make(chan struct{}),
 	}
 }
 
 func (s *regionSyncStream) getSendIndex() uint64 {
-	s.indexMu.RLock()
-	defer s.indexMu.RUnlock()
-	return s.sendIndex
+	s.index.RLock()
+	defer s.index.RUnlock()
+	return s.index.sendIndex
 }
 
 func (s *regionSyncStream) advanceSendIndex(count int) {
-	s.indexMu.Lock()
-	defer s.indexMu.Unlock()
-	s.sendIndex += uint64(count)
+	s.index.Lock()
+	defer s.index.Unlock()
+	s.index.sendIndex += uint64(count)
 }
 
 func (s *regionSyncStream) notify(keepAlive bool) {
@@ -122,8 +136,8 @@ func (s *regionSyncStream) send(regions *pdpb.SyncRegionResponse) error {
 }
 
 func (s *regionSyncStream) sendStream(regions *pdpb.SyncRegionResponse) error {
-	s.streamSendMu.Lock()
-	defer s.streamSendMu.Unlock()
+	s.stream.Lock()
+	defer s.stream.Unlock()
 	return s.stream.Send(regions)
 }
 
@@ -363,7 +377,7 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 				RegionLeaders: nil,
 				Buckets:       nil,
 			}
-			return syncStream.stream.Send(resp)
+			return syncStream.sendStream(resp)
 		}
 		if startIndex < endIndex {
 			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -701,10 +701,15 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 }
 
 func (s *RegionSyncer) closeAllClient() {
+	type namedStream struct {
+		name   string
+		stream *regionSyncStream
+	}
+
 	s.mu.RLock()
-	streams := make([]*regionSyncStream, 0, len(s.mu.streams))
-	for _, sender := range s.mu.streams {
-		streams = append(streams, sender)
+	streams := make([]namedStream, 0, len(s.mu.streams))
+	for name, sender := range s.mu.streams {
+		streams = append(streams, namedStream{name: name, stream: sender})
 	}
 	s.mu.RUnlock()
 	for _, sender := range streams {
@@ -717,9 +722,9 @@ func (s *RegionSyncer) closeAllClient() {
 				},
 			},
 		}
-		sender.close()
-		if err := sender.send(resp); err != nil {
-			log.Warn("region syncer send close message meet error", errs.ZapError(errs.ErrGRPCSend, err))
+		if !s.sendRegionSyncResponse(context.Background(), sender.name, sender.stream, resp) {
+			log.Warn("region syncer send close message meet error", zap.String("name", sender.name))
 		}
+		sender.stream.close()
 	}
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -135,10 +135,28 @@ func (s *regionSyncStream) close() {
 	})
 }
 
+func (s *regionSyncStream) checkOpen() error {
+	select {
+	case <-s.done:
+		return status.Error(codes.Unavailable, "region syncer stream closed")
+	default:
+		return nil
+	}
+}
+
 func (s *regionSyncStream) send(regions *pdpb.SyncRegionResponse) error {
 	s.sendMu.Lock()
 	defer s.sendMu.Unlock()
 	return s.sendStream(regions)
+}
+
+func (s *regionSyncStream) sendStreamIfOpen(regions *pdpb.SyncRegionResponse) error {
+	s.stream.Lock()
+	defer s.stream.Unlock()
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	return s.stream.Send(regions)
 }
 
 func (s *regionSyncStream) sendStream(regions *pdpb.SyncRegionResponse) error {
@@ -383,7 +401,7 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 				RegionLeaders: nil,
 				Buckets:       nil,
 			}
-			return syncStream.sendStream(resp)
+			return syncStream.sendStreamIfOpen(resp)
 		}
 		if startIndex < endIndex {
 			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
@@ -440,7 +458,7 @@ func (s *RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.Reg
 func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core.RegionInfo, stream *regionSyncStream) error {
 	for start := 0; start < len(records); start += maxSyncRegionBatchSize {
 		end := min(start+maxSyncRegionBatchSize, len(records))
-		if err := stream.sendStream(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
+		if err := stream.sendStreamIfOpen(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
 			return err
 		}
 	}
@@ -497,12 +515,15 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 			RegionLeaders: leaders,
 			Buckets:       buckets,
 		}
+		if err := syncStream.checkOpen(); err != nil {
+			return err
+		}
 		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
 			log.Error("failed to wait rate limit", errs.ZapError(err))
 			return err
 		}
 		lastIndex += len(metas)
-		if err := syncStream.sendStream(resp); err != nil {
+		if err := syncStream.sendStreamIfOpen(resp); err != nil {
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -66,17 +66,47 @@ type ServerStream interface {
 	Send(regions *pdpb.SyncRegionResponse) error
 }
 
-type regionSyncStream struct {
-	stream ServerStream
-	done   chan struct{}
-	once   sync.Once
-	sendMu sync.Mutex
+type downstreamSendSignal struct {
+	keepAlive bool
 }
 
-func newRegionSyncStream(stream ServerStream) *regionSyncStream {
+type regionSyncStream struct {
+	stream    ServerStream
+	history   *historyBuffer
+	sendMu    sync.Mutex
+	indexMu   syncutil.RWMutex
+	sendIndex uint64
+	notifyCh  chan downstreamSendSignal
+	done      chan struct{}
+	once      sync.Once
+}
+
+func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStream {
 	return &regionSyncStream{
-		stream: stream,
-		done:   make(chan struct{}),
+		stream:    stream,
+		history:   newMemoryHistoryBuffer(defaultHistoryBufferSize, startIndex),
+		sendIndex: startIndex,
+		notifyCh:  make(chan downstreamSendSignal, 1),
+		done:      make(chan struct{}),
+	}
+}
+
+func (s *regionSyncStream) getSendIndex() uint64 {
+	s.indexMu.RLock()
+	defer s.indexMu.RUnlock()
+	return s.sendIndex
+}
+
+func (s *regionSyncStream) advanceSendIndex(count int) {
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+	s.sendIndex += uint64(count)
+}
+
+func (s *regionSyncStream) notify(keepAlive bool) {
+	select {
+	case s.notifyCh <- downstreamSendSignal{keepAlive: keepAlive}:
+	default:
 	}
 }
 
@@ -159,23 +189,13 @@ func historyBufferMaxSizeFromMemory(totalMemory uint64) int {
 // RunServer runs the server of the region syncer.
 // regionNotifier is used to get the changed regions.
 func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *core.RegionInfo) {
-	var requests []*metapb.Region
-	var stats []*pdpb.RegionStat
-	var leaders []*metapb.Peer
-	var buckets []*metapb.Buckets
+	var records []*core.RegionInfo
 	keepAliveTicker := time.NewTicker(syncerKeepAliveInterval)
 	shrinkTicker := time.NewTicker(historyBufferShrinkInterval)
 
 	processRegion := func(region *core.RegionInfo) {
-		requests = append(requests, region.GetMeta())
-		stats = append(stats, region.GetStat())
-		// bucket should not be nil to avoid grpc marshal panic.
-		bucket := &metapb.Buckets{}
-		if b := region.GetBuckets(); b != nil {
-			bucket = b
-		}
-		buckets = append(buckets, bucket)
-		leaders = append(leaders, region.GetLeader())
+		records = append(records, region)
+		s.history.record(region)
 	}
 
 	defer func() {
@@ -198,41 +218,24 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 		case first := <-regionNotifier:
 			failpoint.InjectCall("syncRegionChannelFull")
 
-			processRegion(first)
 			startIndex := s.history.getNextIndex()
-			s.history.record(first)
+			processRegion(first)
 		loop:
 			for range maxSyncRegionBatchSize {
 				select {
 				case region := <-regionNotifier:
 					processRegion(region)
-					s.history.record(region)
 				default:
 					break loop
 				}
 			}
-			regions := &pdpb.SyncRegionResponse{
-				Header:        &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-				Regions:       requests,
-				StartIndex:    startIndex,
-				RegionStats:   stats,
-				RegionLeaders: leaders,
-				Buckets:       buckets,
-			}
-			s.broadcast(ctx, regions)
+			s.broadcast(ctx, startIndex, records, false)
 		case <-shrinkTicker.C:
 			s.history.maybeShrink()
 		case <-keepAliveTicker.C:
-			alive := &pdpb.SyncRegionResponse{
-				Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-				StartIndex: s.history.getNextIndex(),
-			}
-			s.broadcast(ctx, alive)
+			s.broadcast(ctx, s.history.getNextIndex(), nil, true)
 		}
-		requests = requests[:0]
-		stats = stats[:0]
-		leaders = leaders[:0]
-		buckets = buckets[:0]
+		records = records[:0]
 	}
 }
 
@@ -274,13 +277,13 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 			zap.String("url", request.GetMember().GetClientUrls()[0]))
 
 		name := request.GetMember().GetName()
-		syncStream, err := s.syncHistoryRegion(ctx, request, stream)
+		syncStream, syncStartIndex := s.bindStreamForSync(name, stream)
+		err = s.syncHistoryRegion(ctx, request, stream, syncStream, syncStartIndex)
 		if err != nil {
+			s.unbindStream(name, syncStream)
 			return err
 		}
-		if syncStream == nil {
-			syncStream = s.bindStream(name, stream)
-		}
+		go s.runDownstreamSender(ctx, name, syncStream)
 		select {
 		case <-ctx.Done():
 			s.unbindStream(name, syncStream)
@@ -304,7 +307,10 @@ func recvSyncRegionRequest(ctx context.Context, stream pdpb.PD_SyncRegionsServer
 	resultCh := make(chan syncRegionRequestResult, 1)
 	go func() {
 		request, err := stream.Recv()
-		resultCh <- syncRegionRequestResult{request: request, err: err}
+		select {
+		case resultCh <- syncRegionRequestResult{request: request, err: err}:
+		default:
+		}
 	}()
 
 	select {
@@ -317,12 +323,21 @@ func recvSyncRegionRequest(ctx context.Context, stream pdpb.PD_SyncRegionsServer
 	}
 }
 
-func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.SyncRegionRequest, stream pdpb.PD_SyncRegionsServer) (*regionSyncStream, error) {
+func (s *RegionSyncer) syncHistoryRegion(
+	ctx context.Context,
+	request *pdpb.SyncRegionRequest,
+	stream ServerStream,
+	syncStream *regionSyncStream,
+	endIndex uint64,
+) error {
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
-	records, nextIndex := s.history.observeAndRecordsFrom(startIndex)
+	if startIndex != 0 && startIndex < endIndex {
+		s.history.observeRequiredWindow(endIndex - startIndex)
+	}
+	records := s.history.recordsBetween(startIndex, endIndex)
 	if len(records) == 0 {
-		if nextIndex == startIndex {
+		if endIndex == startIndex {
 			log.Info("requested server has already in sync with server",
 				zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Uint64("last-index", startIndex))
 			// still send a response to follower to show the history region sync.
@@ -334,64 +349,66 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 				RegionLeaders: nil,
 				Buckets:       nil,
 			}
-			return nil, stream.Send(resp)
+			return stream.Send(resp)
 		}
-		if startIndex < nextIndex {
-			return s.syncFullRegions(ctx, name, stream)
+		if startIndex < endIndex {
+			return s.syncFullRegions(ctx, name, stream, syncStream, endIndex)
 		}
 		log.Warn("no history regions from index, the leader may be restarted", zap.Uint64("index", startIndex))
-		return nil, nil
+		return nil
+	}
+	if len(records) != int(endIndex-startIndex) {
+		return s.syncFullRegions(ctx, name, stream, syncStream, endIndex)
 	}
 	log.Info("sync the history regions with server",
 		zap.String("server", name),
 		zap.Uint64("from-index", startIndex),
-		zap.Uint64("last-index", nextIndex),
+		zap.Uint64("last-index", endIndex),
 		zap.Int("records-length", len(records)))
-	// TODO: Incremental history replay is sent before binding the stream, so
-	// broadcasts produced during this replay are not delivered to this follower.
-	// Handle this existing ordering gap in a follow-up PR together with stream
-	// binding and send-ordering semantics.
-	return nil, s.syncHistoryRecords(startIndex, records, stream)
+	return s.syncHistoryRecords(startIndex, records, stream)
 }
 
-func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream pdpb.PD_SyncRegionsServer) error {
+func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdpb.SyncRegionResponse {
+	regions := make([]*metapb.Region, len(records))
+	stats := make([]*pdpb.RegionStat, len(records))
+	leaders := make([]*metapb.Peer, len(records))
+	buckets := make([]*metapb.Buckets, len(records))
+	for i, r := range records {
+		regions[i] = r.GetMeta()
+		stats[i] = r.GetStat()
+		leader := &metapb.Peer{}
+		if r.GetLeader() != nil {
+			leader = r.GetLeader()
+		}
+		leaders[i] = leader
+		bucket := &metapb.Buckets{}
+		if r.GetBuckets() != nil {
+			bucket = r.GetBuckets()
+		}
+		buckets[i] = bucket
+	}
+	return &pdpb.SyncRegionResponse{
+		Header:        &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		Regions:       regions,
+		StartIndex:    startIndex,
+		RegionStats:   stats,
+		RegionLeaders: leaders,
+		Buckets:       buckets,
+	}
+}
+
+func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream ServerStream) error {
 	for start := 0; start < len(records); start += maxSyncRegionBatchSize {
 		end := min(start+maxSyncRegionBatchSize, len(records))
-		regions := make([]*metapb.Region, end-start)
-		stats := make([]*pdpb.RegionStat, end-start)
-		leaders := make([]*metapb.Peer, end-start)
-		buckets := make([]*metapb.Buckets, end-start)
-		for i, r := range records[start:end] {
-			regions[i] = r.GetMeta()
-			stats[i] = r.GetStat()
-			leader := &metapb.Peer{}
-			if r.GetLeader() != nil {
-				leader = r.GetLeader()
-			}
-			leaders[i] = leader
-			// bucket should not be nil to avoid grpc marshal panic.
-			buckets[i] = &metapb.Buckets{}
-			if r.GetBuckets() != nil {
-				buckets[i] = r.GetBuckets()
-			}
-		}
-		resp := &pdpb.SyncRegionResponse{
-			Header:        &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-			Regions:       regions,
-			StartIndex:    startIndex + uint64(start),
-			RegionStats:   stats,
-			RegionLeaders: leaders,
-			Buckets:       buckets,
-		}
-		if err := stream.Send(resp); err != nil {
+		if err := stream.Send(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) (*regionSyncStream, error) {
-	retainIndex, releaseRetain := s.history.retainFromCurrent()
+func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream ServerStream, syncStream *regionSyncStream, syncStartIndex uint64) error {
+	releaseRetain := s.history.retainFrom(syncStartIndex)
 	defer releaseRetain()
 	regions := s.server.GetRegions()
 	lastIndex := 0
@@ -407,7 +424,7 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 			failpoint.Inject("noFastExitSync", func() {
 				failpoint.Goto("doSync")
 			})
-			return nil, nil
+			return nil
 		default:
 		}
 		failpoint.Label("doSync")
@@ -436,12 +453,12 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 		}
 		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
 			log.Error("failed to wait rate limit", errs.ZapError(err))
-			return nil, err
+			return err
 		}
 		lastIndex += len(metas)
 		if err := stream.Send(resp); err != nil {
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
-			return nil, err
+			return err
 		}
 		metas = metas[:0]
 		stats = stats[:0]
@@ -450,42 +467,33 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 	}
 	log.Info("requested server has completed full synchronization with server",
 		zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))
-	syncStream := newRegionSyncStream(stream)
-	syncStream.sendMu.Lock()
-	s.bindRegionSyncStream(name, syncStream)
-	records, nextIndex, ok := s.history.retainedRecordsFrom(retainIndex)
+	records, nextIndex, ok := s.history.retainedRecordsFrom(syncStartIndex)
 	if !ok {
-		s.unbindStream(name, syncStream)
-		syncStream.sendMu.Unlock()
-		return nil, status.Errorf(codes.ResourceExhausted,
+		return status.Errorf(codes.ResourceExhausted,
 			"history records from full sync start index %d to %d are no longer available",
-			retainIndex, nextIndex)
+			syncStartIndex, nextIndex)
 	}
 	if len(records) > 0 {
-		if err := s.syncHistoryRecords(retainIndex, records, stream); err != nil {
-			s.unbindStream(name, syncStream)
-			syncStream.sendMu.Unlock()
-			return nil, err
+		if err := s.syncHistoryRecords(syncStartIndex, records, stream); err != nil {
+			return err
 		}
+		syncStream.advanceSendIndex(len(records))
 	}
-	syncStream.sendMu.Unlock()
-	return syncStream, nil
+	syncStream.history.resetWithIndex(nextIndex)
+	return nil
 }
 
-// bindStream binds the established server stream.
-func (s *RegionSyncer) bindStream(name string, stream ServerStream) *regionSyncStream {
-	syncStream := newRegionSyncStream(stream)
-	return s.bindRegionSyncStream(name, syncStream)
-}
-
-func (s *RegionSyncer) bindRegionSyncStream(name string, syncStream *regionSyncStream) *regionSyncStream {
+func (s *RegionSyncer) bindStreamForSync(name string, stream ServerStream) (*regionSyncStream, uint64) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	startIndex := s.history.getNextIndex()
+	syncStream := newRegionSyncStream(stream, startIndex)
 	if oldStream := s.mu.streams[name]; oldStream != nil {
 		oldStream.close()
 	}
 	s.mu.streams[name] = syncStream
-	return syncStream
+	s.mu.Unlock()
+
+	return syncStream, startIndex
 }
 
 func (s *RegionSyncer) unbindStream(name string, stream *regionSyncStream) {
@@ -497,54 +505,135 @@ func (s *RegionSyncer) unbindStream(name string, stream *regionSyncStream) {
 	stream.close()
 }
 
-func (s *RegionSyncer) broadcast(ctx context.Context, regions *pdpb.SyncRegionResponse) {
-	broadcastDone := make(chan struct{})
-
+func (s *RegionSyncer) runDownstreamSender(ctx context.Context, name string, stream *regionSyncStream) {
 	defer logutil.LogPanic()
-	var (
-		failed sync.Map
-		wg     sync.WaitGroup
-	)
-	s.mu.RLock()
-	for name, sender := range s.mu.streams {
+	for {
 		select {
 		case <-ctx.Done():
-			s.mu.RUnlock()
 			return
-		default:
-		}
-
-		wg.Add(1)
-		go func(name string, sender *regionSyncStream) {
-			defer wg.Done()
-			if !s.sendRegionSyncResponse(ctx, name, sender, regions) {
-				failed.Store(name, sender)
+		case <-stream.done:
+			return
+		case signal := <-stream.notifyCh:
+			if err := s.sendDownstream(ctx, name, stream, signal.keepAlive); err != nil {
+				log.Warn("region syncer send downstream records meet error",
+					zap.String("name", name), errs.ZapError(errs.ErrGRPCSend, err))
+				s.unbindStream(name, stream)
+				return
 			}
-		}(name, sender)
+		}
+	}
+}
+
+func (s *RegionSyncer) sendDownstream(ctx context.Context, name string, stream *regionSyncStream, keepAlive bool) error {
+	stream.sendMu.Lock()
+	defer stream.sendMu.Unlock()
+	sentRecords, err := s.drainDownstreamLocked(ctx, name, stream)
+	if err != nil {
+		return err
+	}
+	if !keepAlive || sentRecords {
+		return nil
+	}
+	resp := &pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		StartIndex: stream.getSendIndex(),
+	}
+	if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
+		return errors.Errorf("send region sync keepalive failed")
+	}
+	_, err = s.drainDownstreamLocked(ctx, name, stream)
+	return err
+}
+
+func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, stream *regionSyncStream) (bool, error) {
+	sentRecords := false
+	for {
+		if ctx.Err() != nil {
+			return sentRecords, status.Error(codes.Unavailable, "region syncer stopped")
+		}
+		s.mu.RLock()
+		if s.mu.streams[name] != stream {
+			s.mu.RUnlock()
+			return sentRecords, status.Error(codes.Unavailable, "region syncer stream closed")
+		}
+		s.mu.RUnlock()
+
+		sendIndex := stream.getSendIndex()
+		firstIndex := stream.history.getFirstIndex()
+		if sendIndex < firstIndex {
+			return sentRecords, errors.Errorf("region syncer buffered records from index %d overflow, first available index is %d", sendIndex, firstIndex)
+		}
+		bufferNextIndex := stream.history.getNextIndex()
+		if sendIndex > bufferNextIndex {
+			return sentRecords, errors.Errorf("region syncer buffered records index %d exceeds next index %d", sendIndex, bufferNextIndex)
+		}
+		if sendIndex == bufferNextIndex {
+			return sentRecords, nil
+		}
+		records := stream.history.recordsBetween(sendIndex, bufferNextIndex)
+		if len(records) == 0 {
+			return sentRecords, errors.Errorf("region syncer has no buffered records from index %d to %d", sendIndex, bufferNextIndex)
+		}
+		if len(records) > maxSyncRegionBatchSize {
+			records = records[:maxSyncRegionBatchSize]
+		}
+		resp := buildSyncRegionResponse(sendIndex, records)
+		if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
+			return sentRecords, errors.Errorf("send region sync response failed")
+		}
+		stream.advanceSendIndex(len(records))
+		sentRecords = true
+	}
+}
+
+func (s *RegionSyncer) broadcast(ctx context.Context, startIndex uint64, records []*core.RegionInfo, keepAlive bool) {
+	defer logutil.LogPanic()
+	var failed sync.Map
+	s.mu.RLock()
+	for name, sender := range s.mu.streams {
+		if ctx.Err() != nil {
+			break
+		}
+		if !sender.recordBroadcastRecords(startIndex, records) {
+			failed.Store(name, sender)
+			continue
+		}
+		if len(records) != 0 || keepAlive {
+			sender.notify(keepAlive)
+		}
 	}
 	s.mu.RUnlock()
 
-	go func() {
-		wg.Wait()
-		s.mu.Lock()
-		failed.Range(func(key, value any) bool {
-			name := key.(string)
-			stream := value.(*regionSyncStream)
-			if s.mu.streams[name] == stream {
-				delete(s.mu.streams, name)
-				stream.close()
-				log.Info("region syncer delete the stream", zap.String("stream", name))
-			}
-			return true
-		})
-		s.mu.Unlock()
-		close(broadcastDone)
-	}()
+	s.mu.Lock()
+	failed.Range(func(key, value any) bool {
+		name := key.(string)
+		stream := value.(*regionSyncStream)
+		if s.mu.streams[name] == stream {
+			delete(s.mu.streams, name)
+			stream.close()
+			log.Info("region syncer delete the stream", zap.String("stream", name))
+		}
+		return true
+	})
+	s.mu.Unlock()
+}
 
-	select {
-	case <-broadcastDone:
-	case <-ctx.Done():
+func (s *regionSyncStream) recordBroadcastRecords(startIndex uint64, records []*core.RegionInfo) bool {
+	if len(records) == 0 {
+		return true
 	}
+	endIndex := startIndex + uint64(len(records))
+	nextIndex := s.history.getNextIndex()
+	if nextIndex >= endIndex {
+		return true
+	}
+	if nextIndex < startIndex {
+		return false
+	}
+	for _, record := range records[nextIndex-startIndex:] {
+		s.history.record(record)
+	}
+	return true
 }
 
 func (s *RegionSyncer) sendRegionSyncResponse(
@@ -561,9 +650,15 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 		return false
 	}
 
+	select {
+	case <-sender.done:
+		return false
+	default:
+	}
+
 	resultCh := make(chan error, 1)
 	go func() {
-		resultCh <- sender.send(regions)
+		resultCh <- sender.stream.Send(regions)
 	}()
 
 	timeout := s.sendTimeout
@@ -585,6 +680,9 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 		sender.close()
 		log.Warn("region syncer send data canceled", zap.String("name", name),
 			errs.ZapError(errs.ErrGRPCSend, ctx.Err()))
+		return false
+	case <-sender.done:
+		log.Warn("region syncer send data canceled because stream is closed", zap.String("name", name))
 		return false
 	case <-timer.C:
 		sender.close()

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -465,12 +465,6 @@ func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core
 	return nil
 }
 
-func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, syncStream *regionSyncStream, syncStartIndex uint64) error {
-	syncStream.sendMu.Lock()
-	defer syncStream.sendMu.Unlock()
-	return s.syncFullRegionsLocked(ctx, name, syncStream, syncStartIndex)
-}
-
 func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, syncStream *regionSyncStream, syncStartIndex uint64) error {
 	releaseRetain := s.history.retainFrom(syncStartIndex)
 	defer releaseRetain()

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -72,7 +72,6 @@ type downstreamSendSignal struct {
 
 type regionSyncStream struct {
 	stream    ServerStream
-	history   *historyBuffer
 	sendMu    sync.Mutex
 	indexMu   syncutil.RWMutex
 	sendIndex uint64
@@ -84,7 +83,6 @@ type regionSyncStream struct {
 func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStream {
 	return &regionSyncStream{
 		stream:    stream,
-		history:   newMemoryHistoryBuffer(defaultHistoryBufferSize, startIndex),
 		sendIndex: startIndex,
 		notifyCh:  make(chan downstreamSendSignal, 1),
 		done:      make(chan struct{}),
@@ -218,7 +216,6 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 		case first := <-regionNotifier:
 			failpoint.InjectCall("syncRegionChannelFull")
 
-			startIndex := s.history.getNextIndex()
 			processRegion(first)
 		loop:
 			for range maxSyncRegionBatchSize {
@@ -229,11 +226,11 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 					break loop
 				}
 			}
-			s.broadcast(ctx, startIndex, records, false)
+			s.broadcast(ctx, records, false)
 		case <-shrinkTicker.C:
 			s.history.maybeShrink()
 		case <-keepAliveTicker.C:
-			s.broadcast(ctx, s.history.getNextIndex(), nil, true)
+			s.broadcast(ctx, nil, true)
 		}
 		records = records[:0]
 	}
@@ -501,7 +498,6 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 		}
 		syncStream.advanceSendIndex(len(records))
 	}
-	syncStream.history.advanceToIndex(nextIndex)
 	return nil
 }
 
@@ -580,18 +576,18 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		s.mu.RUnlock()
 
 		sendIndex := stream.getSendIndex()
-		firstIndex := stream.history.getFirstIndex()
+		firstIndex := s.history.getFirstIndex()
 		if sendIndex < firstIndex {
 			return sentRecords, errors.Errorf("region syncer buffered records from index %d overflow, first available index is %d", sendIndex, firstIndex)
 		}
-		bufferNextIndex := stream.history.getNextIndex()
+		bufferNextIndex := s.history.getNextIndex()
 		if sendIndex > bufferNextIndex {
 			return sentRecords, errors.Errorf("region syncer buffered records index %d exceeds next index %d", sendIndex, bufferNextIndex)
 		}
 		if sendIndex == bufferNextIndex {
 			return sentRecords, nil
 		}
-		records := stream.history.recordsBetween(sendIndex, bufferNextIndex)
+		records := s.history.recordsBetween(sendIndex, bufferNextIndex)
 		if len(records) == 0 {
 			return sentRecords, errors.Errorf("region syncer has no buffered records from index %d to %d", sendIndex, bufferNextIndex)
 		}
@@ -607,54 +603,18 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 	}
 }
 
-func (s *RegionSyncer) broadcast(ctx context.Context, startIndex uint64, records []*core.RegionInfo, keepAlive bool) {
+func (s *RegionSyncer) broadcast(ctx context.Context, records []*core.RegionInfo, keepAlive bool) {
 	defer logutil.LogPanic()
-	var failed sync.Map
 	s.mu.RLock()
-	for name, sender := range s.mu.streams {
+	for _, sender := range s.mu.streams {
 		if ctx.Err() != nil {
 			break
-		}
-		if !sender.recordBroadcastRecords(startIndex, records) {
-			failed.Store(name, sender)
-			continue
 		}
 		if len(records) != 0 || keepAlive {
 			sender.notify(keepAlive)
 		}
 	}
 	s.mu.RUnlock()
-
-	s.mu.Lock()
-	failed.Range(func(key, value any) bool {
-		name := key.(string)
-		stream := value.(*regionSyncStream)
-		if s.mu.streams[name] == stream {
-			delete(s.mu.streams, name)
-			stream.close()
-			log.Info("region syncer delete the stream", zap.String("stream", name))
-		}
-		return true
-	})
-	s.mu.Unlock()
-}
-
-func (s *regionSyncStream) recordBroadcastRecords(startIndex uint64, records []*core.RegionInfo) bool {
-	if len(records) == 0 {
-		return true
-	}
-	endIndex := startIndex + uint64(len(records))
-	nextIndex := s.history.getNextIndex()
-	if nextIndex >= endIndex {
-		return true
-	}
-	if nextIndex < startIndex {
-		return false
-	}
-	for _, record := range records[nextIndex-startIndex:] {
-		s.history.record(record)
-	}
-	return true
 }
 
 func (s *RegionSyncer) sendRegionSyncResponse(

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -278,7 +278,7 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 
 		name := request.GetMember().GetName()
 		syncStream, syncStartIndex := s.bindStreamForSync(name, stream)
-		err = s.syncHistoryRegion(ctx, request, stream, syncStream, syncStartIndex)
+		err = s.syncHistoryRegion(ctx, request, syncStream, syncStartIndex)
 		if err != nil {
 			s.unbindStream(name, syncStream)
 			return err
@@ -326,7 +326,17 @@ func recvSyncRegionRequest(ctx context.Context, stream pdpb.PD_SyncRegionsServer
 func (s *RegionSyncer) syncHistoryRegion(
 	ctx context.Context,
 	request *pdpb.SyncRegionRequest,
-	stream ServerStream,
+	syncStream *regionSyncStream,
+	endIndex uint64,
+) error {
+	syncStream.sendMu.Lock()
+	defer syncStream.sendMu.Unlock()
+	return s.syncHistoryRegionLocked(ctx, request, syncStream, endIndex)
+}
+
+func (s *RegionSyncer) syncHistoryRegionLocked(
+	ctx context.Context,
+	request *pdpb.SyncRegionRequest,
 	syncStream *regionSyncStream,
 	endIndex uint64,
 ) error {
@@ -349,23 +359,23 @@ func (s *RegionSyncer) syncHistoryRegion(
 				RegionLeaders: nil,
 				Buckets:       nil,
 			}
-			return stream.Send(resp)
+			return syncStream.stream.Send(resp)
 		}
 		if startIndex < endIndex {
-			return s.syncFullRegions(ctx, name, stream, syncStream, endIndex)
+			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
 		}
 		log.Warn("no history regions from index, the leader may be restarted", zap.Uint64("index", startIndex))
 		return nil
 	}
 	if len(records) != int(endIndex-startIndex) {
-		return s.syncFullRegions(ctx, name, stream, syncStream, endIndex)
+		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
 	}
 	log.Info("sync the history regions with server",
 		zap.String("server", name),
 		zap.Uint64("from-index", startIndex),
 		zap.Uint64("last-index", endIndex),
 		zap.Int("records-length", len(records)))
-	return s.syncHistoryRecords(startIndex, records, stream)
+	return s.syncHistoryRecordsLocked(startIndex, records, syncStream)
 }
 
 func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdpb.SyncRegionResponse {
@@ -397,17 +407,29 @@ func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdp
 	}
 }
 
-func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream ServerStream) error {
+func (s *RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream *regionSyncStream) error {
+	stream.sendMu.Lock()
+	defer stream.sendMu.Unlock()
+	return s.syncHistoryRecordsLocked(startIndex, records, stream)
+}
+
+func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core.RegionInfo, stream *regionSyncStream) error {
 	for start := 0; start < len(records); start += maxSyncRegionBatchSize {
 		end := min(start+maxSyncRegionBatchSize, len(records))
-		if err := stream.Send(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
+		if err := stream.stream.Send(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream ServerStream, syncStream *regionSyncStream, syncStartIndex uint64) error {
+func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, syncStream *regionSyncStream, syncStartIndex uint64) error {
+	syncStream.sendMu.Lock()
+	defer syncStream.sendMu.Unlock()
+	return s.syncFullRegionsLocked(ctx, name, syncStream, syncStartIndex)
+}
+
+func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, syncStream *regionSyncStream, syncStartIndex uint64) error {
 	releaseRetain := s.history.retainFrom(syncStartIndex)
 	defer releaseRetain()
 	regions := s.server.GetRegions()
@@ -456,7 +478,7 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 			return err
 		}
 		lastIndex += len(metas)
-		if err := stream.Send(resp); err != nil {
+		if err := syncStream.stream.Send(resp); err != nil {
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}
@@ -474,25 +496,24 @@ func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream 
 			syncStartIndex, nextIndex)
 	}
 	if len(records) > 0 {
-		if err := s.syncHistoryRecords(syncStartIndex, records, stream); err != nil {
+		if err := s.syncHistoryRecordsLocked(syncStartIndex, records, syncStream); err != nil {
 			return err
 		}
 		syncStream.advanceSendIndex(len(records))
 	}
-	syncStream.history.resetWithIndex(nextIndex)
+	syncStream.history.advanceToIndex(nextIndex)
 	return nil
 }
 
 func (s *RegionSyncer) bindStreamForSync(name string, stream ServerStream) (*regionSyncStream, uint64) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	startIndex := s.history.getNextIndex()
 	syncStream := newRegionSyncStream(stream, startIndex)
 	if oldStream := s.mu.streams[name]; oldStream != nil {
 		oldStream.close()
 	}
 	s.mu.streams[name] = syncStream
-	s.mu.Unlock()
-
 	return syncStream, startIndex
 }
 

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -66,21 +66,19 @@ type ServerStream interface {
 	Send(regions *pdpb.SyncRegionResponse) error
 }
 
-type downstreamSendSignal struct {
-	keepAlive bool
-}
-
 type regionSyncStream struct {
+	// stream serializes the underlying gRPC Send calls. A timed-out send may
+	// still be blocked after sendMu is released.
 	stream struct {
 		syncutil.Mutex
 		ServerStream
 	}
-	sendMu syncutil.Mutex
-	index  struct {
-		syncutil.RWMutex
+	// sendMu serializes the logical send flow and protects sendIndex.
+	sendMu struct {
+		syncutil.Mutex
 		sendIndex uint64
 	}
-	notifyCh chan downstreamSendSignal
+	notifyCh chan bool
 	done     chan struct{}
 	once     sync.Once
 }
@@ -93,32 +91,40 @@ func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStre
 		}{
 			ServerStream: stream,
 		},
-		index: struct {
-			syncutil.RWMutex
+		sendMu: struct {
+			syncutil.Mutex
 			sendIndex uint64
 		}{
 			sendIndex: startIndex,
 		},
-		notifyCh: make(chan downstreamSendSignal, 1),
+		notifyCh: make(chan bool, 1),
 		done:     make(chan struct{}),
 	}
 }
 
 func (s *regionSyncStream) getSendIndex() uint64 {
-	s.index.RLock()
-	defer s.index.RUnlock()
-	return s.index.sendIndex
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	return s.getSendIndexLocked()
+}
+
+func (s *regionSyncStream) getSendIndexLocked() uint64 {
+	return s.sendMu.sendIndex
 }
 
 func (s *regionSyncStream) advanceSendIndex(count int) {
-	s.index.Lock()
-	defer s.index.Unlock()
-	s.index.sendIndex += uint64(count)
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	s.advanceSendIndexLocked(count)
+}
+
+func (s *regionSyncStream) advanceSendIndexLocked(count int) {
+	s.sendMu.sendIndex += uint64(count)
 }
 
 func (s *regionSyncStream) notify(keepAlive bool) {
 	select {
-	case s.notifyCh <- downstreamSendSignal{keepAlive: keepAlive}:
+	case s.notifyCh <- keepAlive:
 	default:
 	}
 }
@@ -517,7 +523,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 		if err := s.syncHistoryRecordsLocked(syncStartIndex, records, syncStream); err != nil {
 			return err
 		}
-		syncStream.advanceSendIndex(len(records))
+		syncStream.advanceSendIndexLocked(len(records))
 	}
 	return nil
 }
@@ -551,8 +557,8 @@ func (s *RegionSyncer) runDownstreamSender(ctx context.Context, name string, str
 			return
 		case <-stream.done:
 			return
-		case signal := <-stream.notifyCh:
-			if err := s.sendDownstream(ctx, name, stream, signal.keepAlive); err != nil {
+		case keepAlive := <-stream.notifyCh:
+			if err := s.sendDownstream(ctx, name, stream, keepAlive); err != nil {
 				log.Warn("region syncer send downstream records meet error",
 					zap.String("name", name), errs.ZapError(errs.ErrGRPCSend, err))
 				s.unbindStream(name, stream)
@@ -574,7 +580,7 @@ func (s *RegionSyncer) sendDownstream(ctx context.Context, name string, stream *
 	}
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-		StartIndex: stream.getSendIndex(),
+		StartIndex: stream.getSendIndexLocked(),
 	}
 	if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
 		return errors.Errorf("send region sync keepalive failed")
@@ -596,7 +602,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		}
 		s.mu.RUnlock()
 
-		sendIndex := stream.getSendIndex()
+		sendIndex := stream.getSendIndexLocked()
 		firstIndex := s.history.getFirstIndex()
 		if sendIndex < firstIndex {
 			return sentRecords, errors.Errorf("region syncer buffered records from index %d overflow, first available index is %d", sendIndex, firstIndex)
@@ -620,7 +626,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
 			return sentRecords, errors.Errorf("send region sync response failed")
 		}
-		stream.advanceSendIndex(len(records))
+		stream.advanceSendIndexLocked(len(records))
 		sentRecords = true
 	}
 }

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -71,7 +71,7 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
 		Member:     &pdpb.Member{Name: "pd-follower", ClientUrls: []string{"http://127.0.0.1:2379"}},
 		StartIndex: 0,
-	}, stream, syncStream, syncStartIndex)
+	}, syncStream, syncStartIndex)
 
 	re.NoError(err)
 	re.Equal(2, syncer.history.capacity())
@@ -85,9 +85,10 @@ func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 		records = append(records, newHistoryBufferTestRegion(uint64(i)))
 	}
 	stream := newMockSyncRegionsServer()
+	syncStream := newRegionSyncStream(stream, 10)
 	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
 
-	re.NoError(syncer.syncHistoryRecords(10, records, stream))
+	re.NoError(syncer.syncHistoryRecords(10, records, syncStream))
 	first := <-stream.sendCh
 	second := <-stream.sendCh
 	re.Equal(uint64(10), first.GetStartIndex())
@@ -110,7 +111,7 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	unblockSend := stream.blockSend()
 	done := make(chan error, 1)
 	go func() {
-		done <- syncer.syncFullRegions(context.Background(), "pd-follower", stream, syncStream, startIndex)
+		done <- syncer.syncFullRegions(context.Background(), "pd-follower", syncStream, startIndex)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 
@@ -133,6 +134,52 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	re.Equal(startIndex+5, syncStream.history.getNextIndex())
 }
 
+func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
+	re := require.New(t)
+	bc := core.NewBasicCluster()
+	bc.PutRegion(newHistoryBufferTestRegion(1))
+	syncer := newTestRegionSyncer(t, bc)
+	syncer.history = newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
+	syncer.history.resetWithIndex(10)
+
+	stream := newBlockingSendStream(2)
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream)
+	defer syncer.unbindStream("pd-follower", syncStream)
+
+	catchUpRecords := []*core.RegionInfo{
+		newHistoryBufferTestRegion(100),
+		newHistoryBufferTestRegion(101),
+	}
+	for _, record := range catchUpRecords {
+		syncer.history.record(record)
+	}
+	syncer.broadcast(context.Background(), startIndex, catchUpRecords, false)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.syncFullRegions(context.Background(), "pd-follower", syncStream, startIndex)
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	liveStartIndex := startIndex + uint64(len(catchUpRecords))
+	liveRecords := []*core.RegionInfo{newHistoryBufferTestRegion(102)}
+	syncer.history.record(liveRecords[0])
+	syncer.broadcast(context.Background(), liveStartIndex, liveRecords, false)
+
+	stream.unblockSend()
+	re.NoError(<-done)
+	re.Equal(liveStartIndex, syncStream.getSendIndex())
+	re.Equal(liveStartIndex+1, syncStream.history.getNextIndex())
+	re.Equal(liveRecords, syncStream.history.recordsFrom(liveStartIndex))
+
+	re.NoError(syncer.sendDownstream(context.Background(), "pd-follower", syncStream, false))
+	responses := stream.sentResponses()
+	re.Len(responses, 3)
+	re.Equal(liveStartIndex, responses[2].GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 102}}, responses[2].GetRegions())
+	re.Equal(liveStartIndex+1, syncStream.getSendIndex())
+}
+
 func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	re := require.New(t)
 	bc := core.NewBasicCluster()
@@ -147,7 +194,7 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	unblockSend := stream.blockSend()
 	done := make(chan error, 1)
 	go func() {
-		done <- syncer.syncFullRegions(context.Background(), "pd-follower", stream, syncStream, startIndex)
+		done <- syncer.syncFullRegions(context.Background(), "pd-follower", syncStream, startIndex)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 
@@ -590,7 +637,7 @@ func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 	}
 
 	syncStream := newRegionSyncStream(stream, syncStartIndex)
-	err := syncer.syncHistoryRegion(context.Background(), request, stream, syncStream, syncStartIndex)
+	err := syncer.syncHistoryRegion(context.Background(), request, syncStream, syncStartIndex)
 
 	re.NoError(err)
 	re.Equal(uint64(0), stream.lastResponse().GetStartIndex())
@@ -601,6 +648,64 @@ type testServerStream struct {
 	mu        sync.Mutex
 	sendErr   error
 	responses []*pdpb.SyncRegionResponse
+}
+
+type blockingSendStream struct {
+	mu          sync.Mutex
+	responses   []*pdpb.SyncRegionResponse
+	blockOnSend int
+	sendCount   int
+	blocked     chan struct{}
+	unblock     chan struct{}
+	once        sync.Once
+}
+
+func newBlockingSendStream(blockOnSend int) *blockingSendStream {
+	return &blockingSendStream{
+		blockOnSend: blockOnSend,
+		blocked:     make(chan struct{}),
+		unblock:     make(chan struct{}),
+	}
+}
+
+func (s *blockingSendStream) Send(resp *pdpb.SyncRegionResponse) error {
+	s.mu.Lock()
+	s.sendCount++
+	block := s.sendCount == s.blockOnSend
+	if block {
+		s.once.Do(func() {
+			close(s.blocked)
+		})
+	}
+	s.mu.Unlock()
+
+	if block {
+		<-s.unblock
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.responses = append(s.responses, resp)
+	return nil
+}
+
+func (s *blockingSendStream) isSendBlocked() bool {
+	select {
+	case <-s.blocked:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *blockingSendStream) unblockSend() {
+	close(s.unblock)
+}
+
+func (s *blockingSendStream) sentResponses() []*pdpb.SyncRegionResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*pdpb.SyncRegionResponse(nil), s.responses...)
 }
 
 func (s *testServerStream) Send(resp *pdpb.SyncRegionResponse) error {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -316,7 +316,7 @@ func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 	re.Empty(syncer.GetAllDownstreamNames())
 }
 
-func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
+func TestCloseAllClientTimesOutBlockedSend(t *testing.T) {
 	re := require.New(t)
 	tempDir := t.TempDir()
 	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
@@ -333,6 +333,7 @@ func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
 		core.NewBasicCluster(),
 	)
 	syncer := NewRegionSyncer(server)
+	syncer.sendTimeout = 10 * time.Millisecond
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stream := newMockSyncRegionsServer()
@@ -362,6 +363,15 @@ func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 
+	testutil.Eventually(re, func() bool {
+		select {
+		case <-closeDone:
+			return true
+		default:
+			return false
+		}
+	})
+
 	var syncErr error
 	testutil.Eventually(re, func() bool {
 		if syncErr == nil {
@@ -377,14 +387,6 @@ func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
 	re.Empty(syncer.GetAllDownstreamNames())
 
 	close(unblockSend)
-	testutil.Eventually(re, func() bool {
-		select {
-		case <-closeDone:
-			return true
-		default:
-			return false
-		}
-	})
 }
 
 func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -95,6 +95,20 @@ func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	re.Len(first.GetRegions(), maxSyncRegionBatchSize)
 	re.Equal(uint64(10+maxSyncRegionBatchSize), second.GetStartIndex())
 	re.Len(second.GetRegions(), 1)
+
+	closedStream := &testServerStream{}
+	closedSyncStream := newRegionSyncStream(closedStream, 10)
+	closedStream.onSend = func(*pdpb.SyncRegionResponse) {
+		closedSyncStream.close()
+	}
+
+	err := syncer.syncHistoryRecords(10, records, closedSyncStream)
+
+	re.Equal(codes.Unavailable, status.Code(err))
+	responses := closedStream.sentResponses()
+	re.Len(responses, 1)
+	re.Equal(uint64(10), responses[0].GetStartIndex())
+	re.Len(responses[0].GetRegions(), maxSyncRegionBatchSize)
 }
 
 func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
@@ -132,6 +146,34 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	re.Len(catchUpResp.GetRegions(), 5)
 	re.Equal(startIndex+5, syncStream.getSendIndex())
 	re.Equal(startIndex+5, syncer.history.getNextIndex())
+
+	closedBC := core.NewBasicCluster()
+	for i := range maxSyncRegionBatchSize + 1 {
+		startKey := []byte{byte(i >> 8), byte(i)}
+		endIndex := i + 1
+		endKey := []byte{byte(endIndex >> 8), byte(endIndex)}
+		region := core.NewRegionInfo(&metapb.Region{
+			Id:       uint64(i + 1),
+			StartKey: startKey,
+			EndKey:   endKey,
+		}, nil)
+		closedBC.PutRegion(region)
+	}
+	closedSyncer := newTestRegionSyncer(t, closedBC)
+	closedSyncer.history = newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
+	closedSyncer.history.resetWithIndex(10)
+	closedStream := &testServerStream{}
+	closedSyncStream := newRegionSyncStream(closedStream, 10)
+	closedStream.onSend = func(*pdpb.SyncRegionResponse) {
+		closedSyncStream.close()
+	}
+
+	err := closedSyncer.syncFullRegions(context.Background(), "pd-follower", closedSyncStream, 10)
+
+	re.Equal(codes.Unavailable, status.Code(err))
+	closedResponses := closedStream.sentResponses()
+	re.Len(closedResponses, 1)
+	re.Len(closedResponses[0].GetRegions(), maxSyncRegionBatchSize)
 }
 
 func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
@@ -205,6 +247,63 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	close(unblockSend)
 	re.NotNil(<-stream.sendCh)
 	re.Error(<-done)
+}
+
+func TestIncrementalHistoryReplayOverflowDisconnectsStream(t *testing.T) {
+	re := require.New(t)
+	syncer := newTestRegionSyncer(t, core.NewBasicCluster())
+	syncer.history = newHistoryBufferWithConfig(2, 2, 1, storage.NewStorageWithMemoryBackend())
+	syncer.history.resetWithIndex(10)
+	syncer.history.record(newHistoryBufferTestRegion(10))
+
+	stream := newMockSyncRegionsServer()
+	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream)
+	defer syncer.unbindStream("pd-follower", syncStream)
+	unblockSend := stream.blockSend()
+	replayDone := make(chan error, 1)
+	go func() {
+		replayDone <- syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
+			Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+			Member:     &pdpb.Member{Name: "pd-follower", ClientUrls: []string{"http://127.0.0.1:2379"}},
+			StartIndex: 10,
+		}, syncStream, syncStartIndex)
+	}()
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	liveRecords := []*core.RegionInfo{
+		newHistoryBufferTestRegion(11),
+		newHistoryBufferTestRegion(12),
+		newHistoryBufferTestRegion(13),
+	}
+	for _, record := range liveRecords {
+		syncer.history.record(record)
+	}
+	syncer.broadcast(context.Background(), liveRecords, false)
+	re.Greater(syncer.history.getFirstIndex(), syncStartIndex)
+
+	close(unblockSend)
+	re.NotNil(<-stream.sendCh)
+	re.NoError(<-replayDone)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	senderDone := make(chan struct{})
+	go func() {
+		syncer.runDownstreamSender(ctx, "pd-follower", syncStream)
+		close(senderDone)
+	}()
+
+	testutil.Eventually(re, func() bool {
+		return len(syncer.GetAllDownstreamNames()) == 0
+	})
+	testutil.Eventually(re, func() bool {
+		select {
+		case <-senderDone:
+			return true
+		default:
+			return false
+		}
+	})
 }
 
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
@@ -705,6 +804,7 @@ func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 type testServerStream struct {
 	mu        sync.Mutex
 	sendErr   error
+	onSend    func(*pdpb.SyncRegionResponse)
 	responses []*pdpb.SyncRegionResponse
 }
 
@@ -774,11 +874,16 @@ func (s *blockingSendStream) sentResponses() []*pdpb.SyncRegionResponse {
 
 func (s *testServerStream) Send(resp *pdpb.SyncRegionResponse) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.sendErr != nil {
+		s.mu.Unlock()
 		return s.sendErr
 	}
 	s.responses = append(s.responses, resp)
+	onSend := s.onSend
+	s.mu.Unlock()
+	if onSend != nil {
+		onSend(resp)
+	}
 	return nil
 }
 

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -458,6 +458,54 @@ func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {
 	close(unblockSend)
 }
 
+func TestSendRegionSyncResponseSerializesStreamSendAfterTimeout(t *testing.T) {
+	re := require.New(t)
+	stream := newBlockingSendStream(1)
+	syncStream := newRegionSyncStream(stream, 10)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": syncStream,
+	})
+	syncer.sendTimeout = 10 * time.Millisecond
+	syncer.history.resetWithIndex(10)
+	syncer.history.record(newTestRegion(1))
+
+	err := syncer.sendDownstream(context.Background(), "pd2", syncStream, false)
+	re.Error(err)
+	testutil.Eventually(re, stream.isSendBlocked)
+
+	closeSendStarted := make(chan struct{})
+	closeSendDone := make(chan error, 1)
+	go func() {
+		close(closeSendStarted)
+		closeSendDone <- syncStream.send(&pdpb.SyncRegionResponse{
+			Header: &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		})
+	}()
+	<-closeSendStarted
+
+	time.Sleep(20 * time.Millisecond)
+	re.Equal(1, stream.sendCountValue())
+	select {
+	case err := <-closeSendDone:
+		re.NoError(err)
+		re.Fail("close response send should wait for the in-flight send")
+	default:
+	}
+
+	stream.unblockSend()
+	var closeSendErr error
+	testutil.Eventually(re, func() bool {
+		select {
+		case closeSendErr = <-closeSendDone:
+			return true
+		default:
+			return false
+		}
+	})
+	re.NoError(closeSendErr)
+	re.Equal(2, stream.sendCountValue())
+}
+
 func TestSyncExitsWhenContextCanceledBeforeRequest(t *testing.T) {
 	re := require.New(t)
 	tempDir := t.TempDir()
@@ -708,6 +756,12 @@ func (s *blockingSendStream) isSendBlocked() bool {
 
 func (s *blockingSendStream) unblockSend() {
 	close(s.unblock)
+}
+
+func (s *blockingSendStream) sendCountValue() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sendCount
 }
 
 func (s *blockingSendStream) sentResponses() []*pdpb.SyncRegionResponse {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -125,7 +125,7 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	unblockSend := stream.blockSend()
 	done := make(chan error, 1)
 	go func() {
-		done <- syncer.syncFullRegions(context.Background(), "pd-follower", syncStream, startIndex)
+		done <- syncFullRegionsForTest(context.Background(), syncer, syncStream, startIndex)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 
@@ -168,12 +168,18 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 		closedSyncStream.close()
 	}
 
-	err := closedSyncer.syncFullRegions(context.Background(), "pd-follower", closedSyncStream, 10)
+	err := syncFullRegionsForTest(context.Background(), closedSyncer, closedSyncStream, 10)
 
 	re.Equal(codes.Unavailable, status.Code(err))
 	closedResponses := closedStream.sentResponses()
 	re.Len(closedResponses, 1)
 	re.Len(closedResponses[0].GetRegions(), maxSyncRegionBatchSize)
+}
+
+func syncFullRegionsForTest(ctx context.Context, syncer *RegionSyncer, syncStream *regionSyncStream, syncStartIndex uint64) error {
+	syncStream.sendMu.Lock()
+	defer syncStream.sendMu.Unlock()
+	return syncer.syncFullRegionsLocked(ctx, "pd-follower", syncStream, syncStartIndex)
 }
 
 func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
@@ -199,7 +205,7 @@ func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- syncer.syncFullRegions(context.Background(), "pd-follower", syncStream, startIndex)
+		done <- syncFullRegionsForTest(context.Background(), syncer, syncStream, startIndex)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 
@@ -236,7 +242,7 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	unblockSend := stream.blockSend()
 	done := make(chan error, 1)
 	go func() {
-		done <- syncer.syncFullRegions(context.Background(), "pd-follower", syncStream, startIndex)
+		done <- syncFullRegionsForTest(context.Background(), syncer, syncStream, startIndex)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -121,7 +121,7 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 		records = append(records, record)
 		syncer.history.record(record)
 	}
-	syncer.broadcast(context.Background(), startIndex, records, false)
+	syncer.broadcast(context.Background(), records, false)
 
 	close(unblockSend)
 	fullResp := <-stream.sendCh
@@ -131,7 +131,7 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	re.Equal(startIndex, catchUpResp.GetStartIndex())
 	re.Len(catchUpResp.GetRegions(), 5)
 	re.Equal(startIndex+5, syncStream.getSendIndex())
-	re.Equal(startIndex+5, syncStream.history.getNextIndex())
+	re.Equal(startIndex+5, syncer.history.getNextIndex())
 }
 
 func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
@@ -153,7 +153,7 @@ func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 	for _, record := range catchUpRecords {
 		syncer.history.record(record)
 	}
-	syncer.broadcast(context.Background(), startIndex, catchUpRecords, false)
+	syncer.broadcast(context.Background(), catchUpRecords, false)
 
 	done := make(chan error, 1)
 	go func() {
@@ -164,13 +164,13 @@ func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 	liveStartIndex := startIndex + uint64(len(catchUpRecords))
 	liveRecords := []*core.RegionInfo{newHistoryBufferTestRegion(102)}
 	syncer.history.record(liveRecords[0])
-	syncer.broadcast(context.Background(), liveStartIndex, liveRecords, false)
+	syncer.broadcast(context.Background(), liveRecords, false)
 
 	stream.unblockSend()
 	re.NoError(<-done)
 	re.Equal(liveStartIndex, syncStream.getSendIndex())
-	re.Equal(liveStartIndex+1, syncStream.history.getNextIndex())
-	re.Equal(liveRecords, syncStream.history.recordsFrom(liveStartIndex))
+	re.Equal(liveStartIndex+1, syncer.history.getNextIndex())
+	re.Equal(liveRecords, syncer.history.recordsFrom(liveStartIndex))
 
 	re.NoError(syncer.sendDownstream(context.Background(), "pd-follower", syncStream, false))
 	responses := stream.sentResponses()
@@ -299,7 +299,7 @@ func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 	})
 
 	stream.setSendErr(errors.New("send failed"))
-	syncer.broadcast(context.Background(), syncer.history.getNextIndex(), nil, true)
+	syncer.broadcast(context.Background(), nil, true)
 
 	var syncErr error
 	testutil.Eventually(re, func() bool {
@@ -429,7 +429,7 @@ func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {
 	unblockSend := stream.blockSend()
 	broadcastDone := make(chan struct{})
 	go func() {
-		syncer.broadcast(context.Background(), syncer.history.getNextIndex(), nil, true)
+		syncer.broadcast(context.Background(), nil, true)
 		close(broadcastDone)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
@@ -498,21 +498,24 @@ func TestSyncExitsWhenContextCanceledBeforeRequest(t *testing.T) {
 	})
 }
 
-func TestBroadcastUsesIndependentDownstreamHistory(t *testing.T) {
+func TestBroadcastUsesIndependentDownstreamIndexes(t *testing.T) {
 	re := require.New(t)
 	pd2Stream := &testServerStream{}
 	pd3Stream := &testServerStream{}
 	records := []*core.RegionInfo{newTestRegion(1), newTestRegion(2)}
 	pd2SyncStream := newRegionSyncStream(pd2Stream, 10)
 	pd3SyncStream := newRegionSyncStream(pd3Stream, 10)
-	pd3SyncStream.history.record(records[0])
 	pd3SyncStream.advanceSendIndex(1)
 	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
 		"pd2": pd2SyncStream,
 		"pd3": pd3SyncStream,
 	})
+	syncer.history.resetWithIndex(10)
+	for _, record := range records {
+		syncer.history.record(record)
+	}
 
-	syncer.broadcast(context.Background(), 10, records, false)
+	syncer.broadcast(context.Background(), records, false)
 
 	testutil.Eventually(re, func() bool {
 		return pd2Stream.lastResponse() != nil && pd3Stream.lastResponse() != nil
@@ -523,8 +526,7 @@ func TestBroadcastUsesIndependentDownstreamHistory(t *testing.T) {
 	re.Equal([]*metapb.Region{{Id: 2}}, pd3Stream.lastResponse().GetRegions())
 	re.Equal(uint64(12), pd2SyncStream.getSendIndex())
 	re.Equal(uint64(12), pd3SyncStream.getSendIndex())
-	re.Equal(records, pd2SyncStream.history.recordsFrom(10))
-	re.Equal(records, pd3SyncStream.history.recordsFrom(10))
+	re.Equal(records, syncer.history.recordsFrom(10))
 }
 
 func TestBroadcastRemovesOnlyFailedDownstream(t *testing.T) {
@@ -538,8 +540,10 @@ func TestBroadcastRemovesOnlyFailedDownstream(t *testing.T) {
 		"pd3": pd3SyncStream,
 	})
 	records := []*core.RegionInfo{newTestRegion(1)}
+	syncer.history.resetWithIndex(10)
+	syncer.history.record(records[0])
 
-	syncer.broadcast(context.Background(), 10, records, false)
+	syncer.broadcast(context.Background(), records, false)
 
 	testutil.Eventually(re, func() bool {
 		return len(syncer.GetAllDownstreamNames()) == 1 && pd3Stream.lastResponse() != nil
@@ -547,7 +551,6 @@ func TestBroadcastRemovesOnlyFailedDownstream(t *testing.T) {
 	re.ElementsMatch([]string{"pd3"}, syncer.GetAllDownstreamNames())
 	re.Nil(pd2Stream.lastResponse())
 	re.Equal(uint64(10), pd2SyncStream.getSendIndex())
-	re.Equal(uint64(11), pd2SyncStream.history.getNextIndex())
 	re.Equal(uint64(10), pd3Stream.lastResponse().GetStartIndex())
 	re.Equal(uint64(11), pd3SyncStream.getSendIndex())
 }
@@ -570,8 +573,12 @@ func TestBroadcastRecordsBusyDownstreamAndDrainsLater(t *testing.T) {
 		"pd3": busySyncStream,
 	})
 	records := []*core.RegionInfo{newTestRegion(1), newTestRegion(2)}
+	syncer.history.resetWithIndex(10)
+	for _, record := range records {
+		syncer.history.record(record)
+	}
 
-	syncer.broadcast(context.Background(), 10, records, false)
+	syncer.broadcast(context.Background(), records, false)
 
 	testutil.Eventually(re, func() bool {
 		return activeStream.lastResponse() != nil
@@ -580,8 +587,7 @@ func TestBroadcastRecordsBusyDownstreamAndDrainsLater(t *testing.T) {
 	re.Equal(uint64(12), activeSyncStream.getSendIndex())
 	re.Nil(busyStream.lastResponse())
 	re.Equal(uint64(10), busySyncStream.getSendIndex())
-	re.Equal(uint64(12), busySyncStream.history.getNextIndex())
-	re.Equal(records, busySyncStream.history.recordsFrom(10))
+	re.Equal(records, syncer.history.recordsFrom(10))
 
 	busySyncStream.sendMu.Unlock()
 	busyLocked = false
@@ -600,8 +606,9 @@ func TestDrainDownstreamSendsPendingRecordsSerially(t *testing.T) {
 		"pd2": syncStream,
 	})
 	bufferedRecords := []*core.RegionInfo{newTestRegion(1), newTestRegion(2)}
+	syncer.history.resetWithIndex(10)
 	for _, record := range bufferedRecords {
-		syncStream.history.record(record)
+		syncer.history.record(record)
 	}
 
 	re.NoError(syncer.sendDownstream(context.Background(), "pd2", syncStream, false))
@@ -611,7 +618,8 @@ func TestDrainDownstreamSendsPendingRecordsSerially(t *testing.T) {
 	re.Equal([]*metapb.Region{{Id: 1}, {Id: 2}}, stream.lastResponse().GetRegions())
 
 	liveRecords := []*core.RegionInfo{newTestRegion(3)}
-	syncer.broadcast(context.Background(), 12, liveRecords, false)
+	syncer.history.record(liveRecords[0])
+	syncer.broadcast(context.Background(), liveRecords, false)
 
 	testutil.Eventually(re, func() bool {
 		return len(stream.sentResponses()) == 2
@@ -623,7 +631,7 @@ func TestDrainDownstreamSendsPendingRecordsSerially(t *testing.T) {
 
 func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 	re := require.New(t)
-	syncer := &RegionSyncer{history: newMemoryHistoryBuffer(defaultHistoryBufferSize, 0)}
+	syncer := &RegionSyncer{history: newTestHistoryBuffer(defaultHistoryBufferSize)}
 	first := newTestRegion(1)
 	second := newTestRegion(2)
 	syncer.history.record(first)
@@ -738,7 +746,10 @@ func newTestRegion(id uint64) *core.RegionInfo {
 }
 
 func newTestRegionSyncerWithStreams(t *testing.T, streams map[string]*regionSyncStream) *RegionSyncer {
-	syncer := &RegionSyncer{sendTimeout: syncerKeepAliveInterval}
+	syncer := &RegionSyncer{
+		history:     newTestHistoryBuffer(defaultHistoryBufferSize),
+		sendTimeout: syncerKeepAliveInterval,
+	}
 	syncer.mu.streams = streams
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -634,7 +634,7 @@ func TestBroadcastRecordsBusyDownstreamAndDrainsLater(t *testing.T) {
 	re.Equal(uint64(10), activeStream.lastResponse().GetStartIndex())
 	re.Equal(uint64(12), activeSyncStream.getSendIndex())
 	re.Nil(busyStream.lastResponse())
-	re.Equal(uint64(10), busySyncStream.getSendIndex())
+	re.Equal(uint64(10), busySyncStream.getSendIndexLocked())
 	re.Equal(records, syncer.history.recordsFrom(10))
 
 	busySyncStream.sendMu.Unlock()

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -64,14 +65,13 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newMockSyncRegionsServer()
-	syncStream, err := syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
+	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream)
+	defer syncer.unbindStream("pd-follower", syncStream)
+	err := syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
 		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
 		Member:     &pdpb.Member{Name: "pd-follower", ClientUrls: []string{"http://127.0.0.1:2379"}},
 		StartIndex: 0,
-	}, stream)
-	if syncStream != nil {
-		defer syncer.unbindStream("pd-follower", syncStream)
-	}
+	}, stream, syncStream, syncStartIndex)
 
 	re.NoError(err)
 	re.Equal(2, syncer.history.capacity())
@@ -96,7 +96,7 @@ func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	re.Len(second.GetRegions(), 1)
 }
 
-func TestSyncFullRegionsRetainsCatchUpHistory(t *testing.T) {
+func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	re := require.New(t)
 	bc := core.NewBasicCluster()
 	bc.PutRegion(newHistoryBufferTestRegion(1))
@@ -105,33 +105,32 @@ func TestSyncFullRegionsRetainsCatchUpHistory(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newMockSyncRegionsServer()
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream)
+	defer syncer.unbindStream("pd-follower", syncStream)
 	unblockSend := stream.blockSend()
-	startIndex := syncer.history.getNextIndex()
-	done := make(chan syncFullRegionsResult, 1)
+	done := make(chan error, 1)
 	go func() {
-		syncStream, err := syncer.syncFullRegions(context.Background(), "pd-follower", stream)
-		done <- syncFullRegionsResult{syncStream: syncStream, err: err}
+		done <- syncer.syncFullRegions(context.Background(), "pd-follower", stream, syncStream, startIndex)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 
+	records := make([]*core.RegionInfo, 0, 5)
 	for i := range 5 {
-		syncer.history.record(newHistoryBufferTestRegion(uint64(100 + i)))
+		record := newHistoryBufferTestRegion(uint64(100 + i))
+		records = append(records, record)
+		syncer.history.record(record)
 	}
-	records := syncer.history.recordsFrom(startIndex)
+	syncer.broadcast(context.Background(), startIndex, records, false)
 
 	close(unblockSend)
 	fullResp := <-stream.sendCh
 	catchUpResp := <-stream.sendCh
-	result := <-done
-	if result.syncStream != nil {
-		defer syncer.unbindStream("pd-follower", result.syncStream)
-	}
-
-	re.NoError(result.err)
+	re.NoError(<-done)
 	re.Len(fullResp.GetRegions(), 1)
-	re.Len(records, 5)
 	re.Equal(startIndex, catchUpResp.GetStartIndex())
 	re.Len(catchUpResp.GetRegions(), 5)
+	re.Equal(startIndex+5, syncStream.getSendIndex())
+	re.Equal(startIndex+5, syncStream.history.getNextIndex())
 }
 
 func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
@@ -143,11 +142,12 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newMockSyncRegionsServer()
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream)
+	defer syncer.unbindStream("pd-follower", syncStream)
 	unblockSend := stream.blockSend()
-	done := make(chan syncFullRegionsResult, 1)
+	done := make(chan error, 1)
 	go func() {
-		syncStream, err := syncer.syncFullRegions(context.Background(), "pd-follower", stream)
-		done <- syncFullRegionsResult{syncStream: syncStream, err: err}
+		done <- syncer.syncFullRegions(context.Background(), "pd-follower", stream, syncStream, startIndex)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
 
@@ -157,17 +157,7 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 
 	close(unblockSend)
 	re.NotNil(<-stream.sendCh)
-	result := <-done
-	if result.syncStream != nil {
-		defer syncer.unbindStream("pd-follower", result.syncStream)
-	}
-
-	re.Error(result.err)
-}
-
-type syncFullRegionsResult struct {
-	syncStream *regionSyncStream
-	err        error
+	re.Error(<-done)
 }
 
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
@@ -262,10 +252,7 @@ func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 	})
 
 	stream.setSendErr(errors.New("send failed"))
-	syncer.broadcast(context.Background(), &pdpb.SyncRegionResponse{
-		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-		StartIndex: syncer.history.getNextIndex(),
-	})
+	syncer.broadcast(context.Background(), syncer.history.getNextIndex(), nil, true)
 
 	var syncErr error
 	testutil.Eventually(re, func() bool {
@@ -395,10 +382,7 @@ func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {
 	unblockSend := stream.blockSend()
 	broadcastDone := make(chan struct{})
 	go func() {
-		syncer.broadcast(context.Background(), &pdpb.SyncRegionResponse{
-			Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-			StartIndex: syncer.history.getNextIndex(),
-		})
+		syncer.broadcast(context.Background(), syncer.history.getNextIndex(), nil, true)
 		close(broadcastDone)
 	}()
 	testutil.Eventually(re, stream.isSendBlocked)
@@ -465,6 +449,203 @@ func TestSyncExitsWhenContextCanceledBeforeRequest(t *testing.T) {
 		st, ok := status.FromError(syncErr)
 		return ok && st.Code() == codes.Unavailable
 	})
+}
+
+func TestBroadcastUsesIndependentDownstreamHistory(t *testing.T) {
+	re := require.New(t)
+	pd2Stream := &testServerStream{}
+	pd3Stream := &testServerStream{}
+	records := []*core.RegionInfo{newTestRegion(1), newTestRegion(2)}
+	pd2SyncStream := newRegionSyncStream(pd2Stream, 10)
+	pd3SyncStream := newRegionSyncStream(pd3Stream, 10)
+	pd3SyncStream.history.record(records[0])
+	pd3SyncStream.advanceSendIndex(1)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": pd2SyncStream,
+		"pd3": pd3SyncStream,
+	})
+
+	syncer.broadcast(context.Background(), 10, records, false)
+
+	testutil.Eventually(re, func() bool {
+		return pd2Stream.lastResponse() != nil && pd3Stream.lastResponse() != nil
+	})
+	re.Equal(uint64(10), pd2Stream.lastResponse().GetStartIndex())
+	re.Equal(uint64(11), pd3Stream.lastResponse().GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 1}, {Id: 2}}, pd2Stream.lastResponse().GetRegions())
+	re.Equal([]*metapb.Region{{Id: 2}}, pd3Stream.lastResponse().GetRegions())
+	re.Equal(uint64(12), pd2SyncStream.getSendIndex())
+	re.Equal(uint64(12), pd3SyncStream.getSendIndex())
+	re.Equal(records, pd2SyncStream.history.recordsFrom(10))
+	re.Equal(records, pd3SyncStream.history.recordsFrom(10))
+}
+
+func TestBroadcastRemovesOnlyFailedDownstream(t *testing.T) {
+	re := require.New(t)
+	pd2Stream := &testServerStream{sendErr: errors.New("send failed")}
+	pd3Stream := &testServerStream{}
+	pd2SyncStream := newRegionSyncStream(pd2Stream, 10)
+	pd3SyncStream := newRegionSyncStream(pd3Stream, 10)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": pd2SyncStream,
+		"pd3": pd3SyncStream,
+	})
+	records := []*core.RegionInfo{newTestRegion(1)}
+
+	syncer.broadcast(context.Background(), 10, records, false)
+
+	testutil.Eventually(re, func() bool {
+		return len(syncer.GetAllDownstreamNames()) == 1 && pd3Stream.lastResponse() != nil
+	})
+	re.ElementsMatch([]string{"pd3"}, syncer.GetAllDownstreamNames())
+	re.Nil(pd2Stream.lastResponse())
+	re.Equal(uint64(10), pd2SyncStream.getSendIndex())
+	re.Equal(uint64(11), pd2SyncStream.history.getNextIndex())
+	re.Equal(uint64(10), pd3Stream.lastResponse().GetStartIndex())
+	re.Equal(uint64(11), pd3SyncStream.getSendIndex())
+}
+
+func TestBroadcastRecordsBusyDownstreamAndDrainsLater(t *testing.T) {
+	re := require.New(t)
+	activeStream := &testServerStream{}
+	busyStream := &testServerStream{}
+	activeSyncStream := newRegionSyncStream(activeStream, 10)
+	busySyncStream := newRegionSyncStream(busyStream, 10)
+	busySyncStream.sendMu.Lock()
+	busyLocked := true
+	defer func() {
+		if busyLocked {
+			busySyncStream.sendMu.Unlock()
+		}
+	}()
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": activeSyncStream,
+		"pd3": busySyncStream,
+	})
+	records := []*core.RegionInfo{newTestRegion(1), newTestRegion(2)}
+
+	syncer.broadcast(context.Background(), 10, records, false)
+
+	testutil.Eventually(re, func() bool {
+		return activeStream.lastResponse() != nil
+	})
+	re.Equal(uint64(10), activeStream.lastResponse().GetStartIndex())
+	re.Equal(uint64(12), activeSyncStream.getSendIndex())
+	re.Nil(busyStream.lastResponse())
+	re.Equal(uint64(10), busySyncStream.getSendIndex())
+	re.Equal(uint64(12), busySyncStream.history.getNextIndex())
+	re.Equal(records, busySyncStream.history.recordsFrom(10))
+
+	busySyncStream.sendMu.Unlock()
+	busyLocked = false
+	testutil.Eventually(re, func() bool {
+		return busyStream.lastResponse() != nil
+	})
+	re.Equal(uint64(10), busyStream.lastResponse().GetStartIndex())
+	re.Equal(uint64(12), busySyncStream.getSendIndex())
+}
+
+func TestDrainDownstreamSendsPendingRecordsSerially(t *testing.T) {
+	re := require.New(t)
+	stream := &testServerStream{}
+	syncStream := newRegionSyncStream(stream, 10)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": syncStream,
+	})
+	bufferedRecords := []*core.RegionInfo{newTestRegion(1), newTestRegion(2)}
+	for _, record := range bufferedRecords {
+		syncStream.history.record(record)
+	}
+
+	re.NoError(syncer.sendDownstream(context.Background(), "pd2", syncStream, false))
+	re.Equal(uint64(12), syncStream.getSendIndex())
+	re.Len(stream.sentResponses(), 1)
+	re.Equal(uint64(10), stream.lastResponse().GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 1}, {Id: 2}}, stream.lastResponse().GetRegions())
+
+	liveRecords := []*core.RegionInfo{newTestRegion(3)}
+	syncer.broadcast(context.Background(), 12, liveRecords, false)
+
+	testutil.Eventually(re, func() bool {
+		return len(stream.sentResponses()) == 2
+	})
+	re.Len(stream.sentResponses(), 2)
+	re.Equal(uint64(12), stream.lastResponse().GetStartIndex())
+	re.Equal(uint64(13), syncStream.getSendIndex())
+}
+
+func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
+	re := require.New(t)
+	syncer := &RegionSyncer{history: newMemoryHistoryBuffer(defaultHistoryBufferSize, 0)}
+	first := newTestRegion(1)
+	second := newTestRegion(2)
+	syncer.history.record(first)
+	syncStartIndex := syncer.history.getNextIndex()
+	syncer.history.record(second)
+	stream := &testServerStream{}
+	request := &pdpb.SyncRegionRequest{
+		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member:     &pdpb.Member{Name: "pd2"},
+		StartIndex: 0,
+	}
+
+	syncStream := newRegionSyncStream(stream, syncStartIndex)
+	err := syncer.syncHistoryRegion(context.Background(), request, stream, syncStream, syncStartIndex)
+
+	re.NoError(err)
+	re.Equal(uint64(0), stream.lastResponse().GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 1}}, stream.lastResponse().GetRegions())
+}
+
+type testServerStream struct {
+	mu        sync.Mutex
+	sendErr   error
+	responses []*pdpb.SyncRegionResponse
+}
+
+func (s *testServerStream) Send(resp *pdpb.SyncRegionResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.responses = append(s.responses, resp)
+	return nil
+}
+
+func (s *testServerStream) lastResponse() *pdpb.SyncRegionResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.responses) == 0 {
+		return nil
+	}
+	return s.responses[len(s.responses)-1]
+}
+
+func (s *testServerStream) sentResponses() []*pdpb.SyncRegionResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*pdpb.SyncRegionResponse(nil), s.responses...)
+}
+
+func newTestRegion(id uint64) *core.RegionInfo {
+	return core.NewRegionInfo(&metapb.Region{Id: id}, nil)
+}
+
+func newTestRegionSyncerWithStreams(t *testing.T, streams map[string]*regionSyncStream) *RegionSyncer {
+	syncer := &RegionSyncer{sendTimeout: syncerKeepAliveInterval}
+	syncer.mu.streams = streams
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		for _, stream := range streams {
+			stream.close()
+		}
+	})
+	for name, stream := range streams {
+		go syncer.runDownstreamSender(ctx, name, stream)
+	}
+	return syncer
 }
 
 type mockSyncRegionsServer struct {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10715

Related to #10666.

Prerequisite for #10668 and #10690.

This PR prepares RegionSyncer for safe follower recovery. The important case is when one follower is doing history sync or full region sync while other healthy followers continue receiving live region updates. The syncing follower must not inherit another follower's send progress.

### What is changed and how does it work?

```commit-message
Split RegionSyncer leader-side downstream send progress by follower stream.

The leader keeps one shared RegionSyncer history buffer. Each downstream stream keeps only its own next send index and serial send lock. Live region updates are recorded once in the shared history, and each stream drains pending records from that shared history according to its own index.

A successful send advances only that stream. A failed send removes only that stream. History/full sync and live sync on the same follower stream are serialized by the same send lock, so live records cannot interleave with the initial sync. Other followers continue sending and advancing independently while one follower is still catching up.

This preserves the current SyncRegions protocol and does not add ack handling. The full history-gap fallback, follower cache reset/rebuild, and client follower-read readiness changes remain in follow-up issues #10668 and #10690.
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None.
```
