### PR TITLE
mcs: handle nil scheduling cluster in API handler

### DIFF
--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -95,6 +95,7 @@ type AffinityGroupsResponse struct {
 func (s *server) GetCluster() sche.SchedulerCluster {
 	cluster := s.Server.GetCluster()
 	if cluster == nil {
+		// Avoid converting a nil *Cluster into a non-nil SchedulerCluster interface.
 		return nil
 	}
 	return cluster

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -93,7 +93,11 @@ type AffinityGroupsResponse struct {
 
 // GetCluster returns the cluster.
 func (s *server) GetCluster() sche.SchedulerCluster {
-	return s.Server.GetCluster()
+	cluster := s.Server.GetCluster()
+	if cluster == nil {
+		return nil
+	}
+	return cluster
 }
 
 func createIndentRender() *render.Render {

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -96,6 +96,7 @@ func (s *server) GetCluster() sche.SchedulerCluster {
 	cluster := s.Server.GetCluster()
 	if cluster == nil {
 		// Avoid converting a nil *Cluster into a non-nil SchedulerCluster interface.
+		// Otherwise, scheduling APIs can panic before the cluster is bootstrapped.
 		return nil
 	}
 	return cluster

--- a/pkg/mcs/scheduling/server/apis/v1/api_test.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/errs"
+	scheserver "github.com/tikv/pd/pkg/mcs/scheduling/server"
+	"github.com/tikv/pd/pkg/schedule/handler"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestHandlerReturnsNotBootstrappedWhenClusterMissing(t *testing.T) {
+	re := require.New(t)
+	h := handler.NewHandler(&server{Server: &scheserver.Server{}})
+
+	re.NotPanics(func() {
+		_, err := h.GetStoresLoads()
+		re.ErrorIs(err, errs.ErrNotBootstrapped)
+	})
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4399
The scheduling API wrapper returned `(*scheserver.Server).GetCluster()` directly as `sche.SchedulerCluster`. When the scheduling server is not bootstrapped, the underlying `*Cluster` is nil, but converting it to the interface type produces a non-nil typed-nil interface.

Shared schedule handlers then skip their `c == nil` guard and may panic when calling cluster methods.

### What is changed and how does it work?

```commit-message
Check the scheduling server cluster pointer before converting it to the SchedulerCluster interface, so a missing cluster is returned as a nil interface.

Add a unit test that builds the shared schedule handler with an unbootstrapped scheduling server and verifies GetStoresLoads returns ErrNotBootstrapped without panicking.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix a possible panic in scheduling service APIs when the scheduling cluster is not bootstrapped.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the cluster is unavailable: affected endpoints now return a clear "not bootstrapped" response instead of panicking, improving stability and error clarity.

* **Tests**
  * Added tests verifying missing-cluster behavior and installed goroutine leak detection to catch regressions and ensure handler reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->