### PR TITLE
core: keep RegionInfo ref count consistent on flow-only updates

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1239,6 +1239,8 @@ func (r *RegionsInfo) preUpdateSubTreeLocked(
 		// t4: thread-A: update region subtree
 		// to keep region tree consistent with subtree, we need to drop this update.
 		if tree, ok := r.subRegions[region.GetID()]; ok {
+			// Fetch the origin region info from the subtree again to ensure it is up-to-date.
+			origin := tree.RegionInfo
 			r.updateSubTreeStat(origin, region)
 			// overlapTree is the only ref-counted subtree and the shared item is
 			// repointed to region below, so transfer its reference here. Otherwise

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1240,6 +1240,12 @@ func (r *RegionsInfo) preUpdateSubTreeLocked(
 		// to keep region tree consistent with subtree, we need to drop this update.
 		if tree, ok := r.subRegions[region.GetID()]; ok {
 			r.updateSubTreeStat(origin, region)
+			// overlapTree is the only ref-counted subtree and we repoint its
+			// shared item to region below, so move that one reference from origin
+			// to region. Otherwise a flow-only update leaves the live region stuck
+			// at ref 1 while it is still present in the subtree.
+			origin.DecRef()
+			region.IncRef()
 			tree.RegionInfo = region
 		}
 		return true

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1240,12 +1240,11 @@ func (r *RegionsInfo) preUpdateSubTreeLocked(
 		// to keep region tree consistent with subtree, we need to drop this update.
 		if tree, ok := r.subRegions[region.GetID()]; ok {
 			r.updateSubTreeStat(origin, region)
-			// overlapTree is the only ref-counted subtree and we repoint its
-			// shared item to region below, so move that one reference from origin
-			// to region. Otherwise a flow-only update leaves the live region stuck
-			// at ref 1 while it is still present in the subtree.
-			origin.DecRef()
-			region.IncRef()
+			// overlapTree is the only ref-counted subtree and the shared item is
+			// repointed to region below, so transfer its reference here. Otherwise
+			// a flow-only update leaves the live region stuck at ref 1 while it is
+			// still present in the subtree.
+			r.overlapTree.updateRef(origin, region)
 			tree.RegionInfo = region
 		}
 		return true

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1212,6 +1212,37 @@ func TestCntRefAfterResetRegionCache(t *testing.T) {
 	re.Equal(int32(2), region.GetRef())
 }
 
+func TestCntRefAfterFlowOnlyUpdate(t *testing.T) {
+	re := require.New(t)
+	ctx := ContextTODO()
+	regions := NewRegionsInfo()
+
+	// Initial put: the region lives in both the root tree and the subtree, so ref == 2.
+	region := NewTestRegionInfo(1, 1, []byte("a"), []byte("b"), SetWrittenBytes(100))
+	regions.CheckAndPutRegion(region)
+	re.Equal(int32(2), region.GetRef())
+	re.Equal(1, regions.GetStoreLeaderCount(1))
+
+	// Flow-only heartbeat: same range and peers, only the flow differs. This mirrors
+	// processRegionHeartbeat: a synchronous root tree update plus an async subtree update.
+	flowOnly := region.Clone(SetWrittenBytes(999))
+	re.True(region.rangeEqualsTo(flowOnly))
+	re.True(region.peersEqualTo(flowOnly))
+	_, err := regions.CheckAndPutRootTree(ctx, flowOnly)
+	re.NoError(err)
+	regions.CheckAndPutSubTree(flowOnly)
+
+	// The region is still present in the subtree and is the live cached object,
+	// so its ref must stay at 2 (root tree + overlapTree).
+	re.Equal(1, regions.GetStoreLeaderCount(1))
+	re.Same(flowOnly, regions.GetRegion(1))
+	re.Equal(int32(2), flowOnly.GetRef())
+
+	// A redundant subtree update (the origin.GetRef() < 2 repair path) must not break the count.
+	regions.CheckAndPutSubTree(regions.GetRegion(1))
+	re.Equal(int32(2), regions.GetRegion(1).GetRef())
+}
+
 func TestScanRegion(t *testing.T) {
 	var (
 		re                   = require.New(t)

--- a/pkg/core/region_tree.go
+++ b/pkg/core/region_tree.go
@@ -157,6 +157,17 @@ func (t *regionTree) overlaps(item *regionItem) []*RegionInfo {
 	return overlaps
 }
 
+// updateRef transfers the reference from origin to region when an item is
+// replaced in place, i.e. the tree keeps the same item and only its embedded
+// RegionInfo changes. It is a no-op for trees that do not count references.
+func (t *regionTree) updateRef(origin, region *RegionInfo) {
+	if !t.countRef {
+		return
+	}
+	origin.DecRef()
+	region.IncRef()
+}
+
 // update updates the tree with the region.
 // It finds and deletes all the overlapped regions first, and then
 // insert the region.
@@ -224,10 +235,7 @@ func (t *regionTree) updateStat(origin *RegionInfo, region *RegionInfo) {
 	if !origin.LoadedFromStorage() && region.LoadedFromStorage() {
 		t.notFromStorageRegionsCnt--
 	}
-	if t.countRef {
-		origin.DecRef()
-		region.IncRef()
-	}
+	t.updateRef(origin, region)
 }
 
 // remove removes a region if the region is in the tree.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10722

Flow-only region heartbeats (only `RoundBytesWritten` / `RoundBytesRead` changed) update the root tree via `r.tree.updateStat`, which moves the ref count from the previous `RegionInfo` to the new one. However, the same-range / same-peer fast path in `preUpdateSubTreeLocked` only reassigns the shared `regionItem` (`tree.RegionInfo = region`) and never moves the ref-counted `overlapTree` reference.

As a result, the live region is left at `ref == 1` even though it is still present in the subtree. Later no-change heartbeats then keep hitting:

```go
if origin.GetRef() < 2 {
    ctx.TaskRunner.RunTask(
        regionID,
        ratelimit.UpdateSubTree,
        func(context.Context) { c.CheckAndPutSubTree(region) },
        ratelimit.WithRetained(true),
    )
}
```

which enqueues retained `UpdateSubTree` tasks that can never repair the count (the repair re-runs the same fast path), causing redundant subtree scheduling and retained task buildup after heartbeat bursts (e.g. a full re-report following a PD leader switch).

### What is changed and how does it work?

`overlapTree` is the only ref-counted subtree, and the fast path repoints its shared item to the new `RegionInfo`. So its single reference must be transferred from `origin` to `region`, mirroring what the root tree's `updateStat` already does for the in-place replacement.

- Add `regionTree.updateRef(origin, region)`, which transfers the reference for an in-place item replacement and is a no-op for trees that do not count references (keyed off the tree's `countRef` property).
- Call it on `overlapTree` in the flow-only fast path so a fully tracked region keeps `ref == 2`.
- Reuse the same helper inside `regionTree.updateStat`, since it performs the identical `countRef`-gated transfer.

No extra tree operations or stat recomputation are introduced; only the reference is transferred.

### Check List

Tests

- Unit test

Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed region reference handling so shared region references remain correct when only flow/statistics change, preventing incorrect live-state drift after updates.

* **Tests**
  * Added a test ensuring reference counts and leadership remain stable across flow-only updates and redundant subtree updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->