### PR TITLE
client: signal RG GC goroutines to exit properly

### DIFF
--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -299,11 +299,11 @@ func (gc *groupCostController) handleTokenBucketUpdateEvent(ctx context.Context)
 		}
 		threshold := counter.notify.setupNotificationThreshold
 		cancelCh = resetCounterNotifyLocked(counter)
+		counter.limiter.SetupNotificationThreshold(threshold)
 		counter.notify.mu.Unlock()
 		if cancelCh != nil {
 			close(cancelCh)
 		}
-		counter.limiter.SetupNotificationThreshold(threshold)
 	case <-cancelCh:
 		return
 	case <-ctx.Done():

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -141,6 +141,8 @@ type tokenCounter struct {
 		setupNotificationCh        <-chan time.Time
 		setupNotificationThreshold float64
 		setupNotificationTimer     *time.Timer
+		// cancelCh wakes up handleTokenBucketUpdateEvent when the timer is stopped.
+		cancelCh chan struct{}
 	}
 
 	lastDeadline time.Time
@@ -283,18 +285,27 @@ func (gc *groupCostController) handleTokenBucketUpdateEvent(ctx context.Context)
 	counter := gc.run.requestUnitTokens
 	counter.notify.mu.Lock()
 	ch := counter.notify.setupNotificationCh
+	cancelCh := counter.notify.cancelCh
 	counter.notify.mu.Unlock()
-	if ch == nil {
+	if ch == nil || cancelCh == nil {
 		return
 	}
 	select {
 	case <-ch:
 		counter.notify.mu.Lock()
-		counter.notify.setupNotificationTimer = nil
-		counter.notify.setupNotificationCh = nil
+		if counter.notify.setupNotificationCh != ch || counter.notify.cancelCh != cancelCh {
+			counter.notify.mu.Unlock()
+			return
+		}
 		threshold := counter.notify.setupNotificationThreshold
+		cancelCh = resetCounterNotifyLocked(counter)
 		counter.notify.mu.Unlock()
+		if cancelCh != nil {
+			close(cancelCh)
+		}
 		counter.limiter.SetupNotificationThreshold(threshold)
+	case <-cancelCh:
+		return
 	case <-ctx.Done():
 		return
 	}
@@ -395,6 +406,7 @@ func (gc *groupCostController) modifyTokenCounter(counter *tokenCounter, bucket 
 		}
 		counter.notify.setupNotificationTimer = time.NewTimer(timerDuration)
 		counter.notify.setupNotificationCh = counter.notify.setupNotificationTimer.C
+		counter.notify.cancelCh = make(chan struct{})
 		counter.notify.setupNotificationThreshold = 1
 		counter.notify.mu.Unlock()
 		counter.lastDeadline = deadline
@@ -411,12 +423,22 @@ func (gc *groupCostController) modifyTokenCounter(counter *tokenCounter, bucket 
 
 func initCounterNotify(counter *tokenCounter) {
 	counter.notify.mu.Lock()
+	cancelCh := resetCounterNotifyLocked(counter)
+	counter.notify.mu.Unlock()
+	if cancelCh != nil {
+		close(cancelCh)
+	}
+}
+
+func resetCounterNotifyLocked(counter *tokenCounter) chan struct{} {
 	if counter.notify.setupNotificationTimer != nil {
 		counter.notify.setupNotificationTimer.Stop()
-		counter.notify.setupNotificationTimer = nil
-		counter.notify.setupNotificationCh = nil
 	}
-	counter.notify.mu.Unlock()
+	cancelCh := counter.notify.cancelCh
+	counter.notify.setupNotificationTimer = nil
+	counter.notify.setupNotificationCh = nil
+	counter.notify.cancelCh = nil
+	return cancelCh
 }
 
 func (gc *groupCostController) collectRequestAndConsumption(selectTyp selectType) *rmpb.TokenBucketRequest {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -208,6 +208,83 @@ func TestOnResponseWaitConsumption(t *testing.T) {
 	verify()
 }
 
+func TestHandleTokenBucketUpdateEventCanceledByInitCounterNotify(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	counter := gc.run.requestUnitTokens
+
+	counter.notify.mu.Lock()
+	counter.notify.setupNotificationTimer = time.NewTimer(time.Hour)
+	counter.notify.setupNotificationCh = counter.notify.setupNotificationTimer.C
+	counter.notify.setupNotificationThreshold = 1
+	counter.notify.cancelCh = make(chan struct{})
+	counter.notify.mu.Unlock()
+	defer initCounterNotify(counter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		gc.handleTokenBucketUpdateEvent(ctx)
+		close(done)
+	}()
+
+	require.Never(t, func() bool {
+		return isClosed(done)
+	}, 50*time.Millisecond, 5*time.Millisecond)
+
+	initCounterNotify(counter)
+	require.Eventually(t, func() bool {
+		return isClosed(done)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHandleTokenBucketUpdateEventCleansNotifyOnTimer(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	counter := gc.run.requestUnitTokens
+	threshold := 42.0
+
+	counter.notify.mu.Lock()
+	counter.notify.setupNotificationTimer = time.NewTimer(10 * time.Millisecond)
+	counter.notify.setupNotificationCh = counter.notify.setupNotificationTimer.C
+	counter.notify.setupNotificationThreshold = threshold
+	counter.notify.cancelCh = make(chan struct{})
+	counter.notify.mu.Unlock()
+	defer initCounterNotify(counter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		gc.handleTokenBucketUpdateEvent(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return isClosed(done)
+	}, time.Second, 10*time.Millisecond)
+
+	counter.notify.mu.Lock()
+	re.Nil(counter.notify.setupNotificationTimer)
+	re.Nil(counter.notify.setupNotificationCh)
+	re.Nil(counter.notify.cancelCh)
+	counter.notify.mu.Unlock()
+
+	counter.limiter.mu.Lock()
+	re.Equal(threshold, counter.limiter.notifyThreshold)
+	counter.limiter.mu.Unlock()
+}
+
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
 func TestResourceGroupThrottledError(t *testing.T) {
 	re := require.New(t)
 	gc := createTestGroupCostController(re)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #9745

This is a follow-up/replacement for #9749 by @yzhan1. The commit author is kept as yzhan1; this version ports the fix to the current controller split and adds regression coverage.

When a throttled RU token bucket schedules a delayed notification, `handleTokenBucketUpdateEvent` waits on the timer channel. If the token counter is reinitialized before the timer fires, `Timer.Stop` does not close the timer channel, so the goroutine can stay blocked until the parent controller context is canceled.

### What is changed and how does it work?

Add a cancellation channel for pending token bucket notification timers so resetting the counter wakes `handleTokenBucketUpdateEvent` instead of leaving it blocked on a stopped timer.

The notification cleanup path now clears the timer channel and cancellation channel both when the notification is reset and when the timer fires normally. The timer-fired path also checks that it is still handling the current notification before applying the threshold.

```commit-message
Add a cancellation channel for pending token bucket notification timers so resetting the counter wakes handleTokenBucketUpdateEvent instead of leaving it blocked on a stopped timer. Reuse the cleanup path when the timer fires normally and cover both reset and normal timer paths with unit tests.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix a goroutine leak in the resource group client controller when token bucket notification timers are reset.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation of token-notification timers to prevent background goroutine leaks and avoid acting on stale timer events.
  * Ensured notification state is reliably cleared when scheduling changes occur so thresholds and timers stay consistent.

* **Tests**
  * Added concurrency tests that validate notification lifecycle and cleanup across edge-case timing and cancellation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->