### PR TITLE
server, core: backport QueryRegion support to release-8.5

### DIFF
--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -82,6 +82,32 @@ var (
 	regionCollectCount        = HeartbeatBreakdownHandleCount.WithLabelValues("CollectRegionStats")
 	otherDurationSum          = HeartbeatBreakdownHandleDurationSum.WithLabelValues("Other")
 	otherCount                = HeartbeatBreakdownHandleCount.WithLabelValues("Other")
+
+	// QueryRegion statistics
+	queryRegionDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "pd",
+			Subsystem: "core",
+			Name:      "query_region_duration_seconds",
+			Help:      "Bucketed histogram of processing time (s) of region query.",
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
+		}, []string{"type"})
+
+	queryRegionCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "core",
+			Name:      "query_region_count",
+			Help:      "The number of region query types.",
+		}, []string{"type"})
+
+	queryRegionByKeysDuration     = queryRegionDuration.WithLabelValues("by-keys")
+	queryRegionByPrevKeysDuration = queryRegionDuration.WithLabelValues("by-prev-keys")
+	queryRegionByIDsDuration      = queryRegionDuration.WithLabelValues("by-ids")
+
+	queryRegionKeysCount     = queryRegionCount.WithLabelValues("keys")
+	queryRegionPrevKeysCount = queryRegionCount.WithLabelValues("prev-keys")
+	queryRegionIDsCount      = queryRegionCount.WithLabelValues("ids")
 )
 
 func init() {
@@ -89,6 +115,8 @@ func init() {
 	prometheus.MustRegister(HeartbeatBreakdownHandleCount)
 	prometheus.MustRegister(AcquireRegionsLockWaitDurationSum)
 	prometheus.MustRegister(AcquireRegionsLockWaitCount)
+	prometheus.MustRegister(queryRegionDuration)
+	prometheus.MustRegister(queryRegionCount)
 }
 
 var tracerPool = &sync.Pool{

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1455,22 +1455,14 @@ func SortedPeersStatsEqual(peersA, peersB []*pdpb.PeerStats) bool {
 func (r *RegionsInfo) GetRegionByKey(regionKey []byte) *RegionInfo {
 	r.t.RLock()
 	defer r.t.RUnlock()
-	region := r.tree.search(regionKey)
-	if region == nil {
-		return nil
-	}
-	return r.getRegionLocked(region.GetID())
+	return r.tree.search(regionKey)
 }
 
 // GetPrevRegionByKey searches previous RegionInfo from regionTree
 func (r *RegionsInfo) GetPrevRegionByKey(regionKey []byte) *RegionInfo {
 	r.t.RLock()
 	defer r.t.RUnlock()
-	region := r.tree.searchPrev(regionKey)
-	if region == nil {
-		return nil
-	}
-	return r.getRegionLocked(region.GetID())
+	return r.tree.searchPrev(regionKey)
 }
 
 // GetRegions gets all RegionInfo from regionMap
@@ -2200,10 +2192,10 @@ func (r *RegionsInfo) GetAdjacentRegions(region *RegionInfo) (*RegionInfo, *Regi
 	var prev, next *RegionInfo
 	// check key to avoid key range hole
 	if p != nil && bytes.Equal(p.GetEndKey(), region.GetStartKey()) {
-		prev = r.getRegionLocked(p.GetID())
+		prev = p.RegionInfo
 	}
 	if n != nil && bytes.Equal(region.GetEndKey(), n.GetStartKey()) {
-		next = r.getRegionLocked(n.GetID())
+		next = n.RegionInfo
 	}
 	return prev, next
 }

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1518,7 +1518,7 @@ func (r *RegionsInfo) QueryRegions(
 		panic("returned prev regions count mismatch with the input keys")
 	}
 	// Build the key -> ID map for the final results.
-	regionsByID := make(map[uint64]*pdpb.RegionResponse, len(regions))
+	regionsByID := make(map[uint64]*pdpb.RegionResponse, len(regions)+len(prevRegions)+len(ids))
 	keyIDMap := sortOutKeyIDMap(regionsByID, regions, needBuckets)
 	prevKeyIDMap := sortOutKeyIDMap(regionsByID, prevRegions, needBuckets)
 	// Iterate the region IDs to find the regions.

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/replication_modepb"
 	"github.com/pingcap/log"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/utils/keyutil"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
@@ -47,7 +48,8 @@ const (
 	randomRegionMaxRetry = 10
 	// ScanRegionLimit is the default limit for the number of regions to scan in a region scan request.
 	ScanRegionLimit = 1000
-	batchSearchSize = 16
+	// batchSearchSize is the default size for the number of IDs/keys/prevKeys to search in a batch.
+	batchSearchSize = 128
 	// CollectFactor is the factor to collect the count of region.
 	CollectFactor = 0.9
 )
@@ -1516,10 +1518,6 @@ func (r *RegionsInfo) QueryRegions(
 		start = time.Now()
 		regions = r.getRegionsByKeys(keys)
 		queryRegionByKeysDuration.Observe(time.Since(start).Seconds())
-		// Assert the returned regions count matches the input keys.
-		if len(regions) != len(keys) {
-			panic("returned regions count mismatch with the input keys")
-		}
 	}
 
 	// Iterate the prevKeys to find the regions.
@@ -1528,10 +1526,6 @@ func (r *RegionsInfo) QueryRegions(
 		start = time.Now()
 		prevRegions = r.getRegionsByPrevKeys(prevKeys)
 		queryRegionByPrevKeysDuration.Observe(time.Since(start).Seconds())
-		// Assert the returned regions count matches the input keys.
-		if len(prevRegions) != len(prevKeys) {
-			panic("returned prev regions count mismatch with the input keys")
-		}
 	}
 
 	// Build the key -> ID map for the final results.
@@ -1543,13 +1537,20 @@ func (r *RegionsInfo) QueryRegions(
 	if len(ids) > 0 {
 		queryRegionIDsCount.Add(float64(len(ids)))
 		start = time.Now()
+		// Filter out IDs that have already been found or are invalid.
+		idsToQuery := make([]uint64, 0, len(ids))
 		for _, id := range ids {
 			// Check if the region has been found.
 			if regionFound, ok := regionsByID[id]; (ok && regionFound != nil) || id == 0 {
 				continue
 			}
-			// If the given region ID is not found in the region tree, set the region to nil.
-			if region := r.GetRegion(id); region == nil {
+			idsToQuery = append(idsToQuery, id)
+		}
+		// Batch query the regions by IDs to reduce lock contention.
+		regions := r.getRegionsByIDs(idsToQuery)
+		for i, id := range idsToQuery {
+			region := regions[i]
+			if region == nil {
 				regionsByID[id] = nil
 			} else {
 				regionResp := &pdpb.RegionResponse{
@@ -1575,7 +1576,7 @@ func (r *RegionsInfo) getRegionsByKeys(keys [][]byte) []*RegionInfo {
 	regions := make([]*RegionInfo, 0, len(keys))
 	// Split the keys into multiple batches, and search each batch separately.
 	// This is to avoid the lock contention on the `regionTree`.
-	for _, batch := range splitKeysIntoBatches(keys) {
+	for _, batch := range slice.SplitIntoBatches(keys, batchSearchSize) {
 		r.t.RLock()
 		results := r.tree.searchByKeys(batch)
 		r.t.RUnlock()
@@ -1584,26 +1585,26 @@ func (r *RegionsInfo) getRegionsByKeys(keys [][]byte) []*RegionInfo {
 	return regions
 }
 
-func splitKeysIntoBatches(keys [][]byte) [][][]byte {
-	keysLen := len(keys)
-	batches := make([][][]byte, 0, (keysLen+batchSearchSize-1)/batchSearchSize)
-	for i := 0; i < keysLen; i += batchSearchSize {
-		end := i + batchSearchSize
-		if end > keysLen {
-			end = keysLen
-		}
-		batches = append(batches, keys[i:end])
-	}
-	return batches
-}
-
 func (r *RegionsInfo) getRegionsByPrevKeys(prevKeys [][]byte) []*RegionInfo {
 	regions := make([]*RegionInfo, 0, len(prevKeys))
-	for _, batch := range splitKeysIntoBatches(prevKeys) {
+	for _, batch := range slice.SplitIntoBatches(prevKeys, batchSearchSize) {
 		r.t.RLock()
 		results := r.tree.searchByPrevKeys(batch)
 		r.t.RUnlock()
 		regions = append(regions, results...)
+	}
+	return regions
+}
+
+// getRegionsByIDs searches RegionInfo from regionMap by IDs in batch.
+func (r *RegionsInfo) getRegionsByIDs(ids []uint64) []*RegionInfo {
+	regions := make([]*RegionInfo, 0, len(ids))
+	for _, batch := range slice.SplitIntoBatches(ids, batchSearchSize) {
+		r.t.RLock()
+		for _, id := range batch {
+			regions = append(regions, r.getRegionLocked(id))
+		}
+		r.t.RUnlock()
 	}
 	return regions
 }

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1505,44 +1505,68 @@ func (r *RegionsInfo) GetStoreRegions(storeID uint64) []*RegionInfo {
 func (r *RegionsInfo) QueryRegions(
 	keys, prevKeys [][]byte, ids []uint64, needBuckets bool,
 ) ([]uint64, []uint64, map[uint64]*pdpb.RegionResponse) {
+	var (
+		start                time.Time
+		regions, prevRegions []*RegionInfo
+	)
+
 	// Iterate the region keys to find the regions.
-	regions := r.getRegionsByKeys(keys)
-	// Assert the returned regions count matches the input keys.
-	if len(regions) != len(keys) {
-		panic("returned regions count mismatch with the input keys")
+	if len(keys) > 0 {
+		queryRegionKeysCount.Add(float64(len(keys)))
+		start = time.Now()
+		regions = r.getRegionsByKeys(keys)
+		queryRegionByKeysDuration.Observe(time.Since(start).Seconds())
+		// Assert the returned regions count matches the input keys.
+		if len(regions) != len(keys) {
+			panic("returned regions count mismatch with the input keys")
+		}
 	}
+
 	// Iterate the prevKeys to find the regions.
-	prevRegions := r.getRegionsByPrevKeys(prevKeys)
-	// Assert the returned regions count matches the input keys.
-	if len(prevRegions) != len(prevKeys) {
-		panic("returned prev regions count mismatch with the input keys")
+	if len(prevKeys) > 0 {
+		queryRegionPrevKeysCount.Add(float64(len(prevKeys)))
+		start = time.Now()
+		prevRegions = r.getRegionsByPrevKeys(prevKeys)
+		queryRegionByPrevKeysDuration.Observe(time.Since(start).Seconds())
+		// Assert the returned regions count matches the input keys.
+		if len(prevRegions) != len(prevKeys) {
+			panic("returned prev regions count mismatch with the input keys")
+		}
 	}
+
 	// Build the key -> ID map for the final results.
 	regionsByID := make(map[uint64]*pdpb.RegionResponse, len(regions)+len(prevRegions)+len(ids))
 	keyIDMap := sortOutKeyIDMap(regionsByID, regions, needBuckets)
 	prevKeyIDMap := sortOutKeyIDMap(regionsByID, prevRegions, needBuckets)
+
 	// Iterate the region IDs to find the regions.
-	for _, id := range ids {
-		// Check if the region has been found.
-		if regionFound, ok := regionsByID[id]; (ok && regionFound != nil) || id == 0 {
-			continue
-		}
-		// If the given region ID is not found in the region tree, set the region to nil.
-		if region := r.GetRegion(id); region == nil {
-			regionsByID[id] = nil
-		} else {
-			regionResp := &pdpb.RegionResponse{
-				Region:       region.GetMeta(),
-				Leader:       region.GetLeader(),
-				DownPeers:    region.GetDownPeers(),
-				PendingPeers: region.GetPendingPeers(),
+	if len(ids) > 0 {
+		queryRegionIDsCount.Add(float64(len(ids)))
+		start = time.Now()
+		for _, id := range ids {
+			// Check if the region has been found.
+			if regionFound, ok := regionsByID[id]; (ok && regionFound != nil) || id == 0 {
+				continue
 			}
-			if needBuckets {
-				regionResp.Buckets = region.GetBuckets()
+			// If the given region ID is not found in the region tree, set the region to nil.
+			if region := r.GetRegion(id); region == nil {
+				regionsByID[id] = nil
+			} else {
+				regionResp := &pdpb.RegionResponse{
+					Region:       region.GetMeta(),
+					Leader:       region.GetLeader(),
+					DownPeers:    region.GetDownPeers(),
+					PendingPeers: region.GetPendingPeers(),
+				}
+				if needBuckets {
+					regionResp.Buckets = region.GetBuckets()
+				}
+				regionsByID[id] = regionResp
 			}
-			regionsByID[id] = regionResp
 		}
+		queryRegionByIDsDuration.Observe(time.Since(start).Seconds())
 	}
+
 	return keyIDMap, prevKeyIDMap, regionsByID
 }
 

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -47,6 +47,7 @@ const (
 	randomRegionMaxRetry = 10
 	// ScanRegionLimit is the default limit for the number of regions to scan in a region scan request.
 	ScanRegionLimit = 1000
+	batchSearchSize = 16
 	// CollectFactor is the factor to collect the count of region.
 	CollectFactor = 0.9
 )
@@ -1497,6 +1498,122 @@ func (r *RegionsInfo) GetStoreRegions(storeID uint64) []*RegionInfo {
 	}
 	// no need to consider witness, as it is already included in leaders, followers and learners
 	return regions
+}
+
+// TODO: benchmark the performance of `QueryRegions`.
+// QueryRegions searches RegionInfo from regionTree by keys and IDs in batch.
+func (r *RegionsInfo) QueryRegions(
+	keys, prevKeys [][]byte, ids []uint64, needBuckets bool,
+) ([]uint64, []uint64, map[uint64]*pdpb.RegionResponse) {
+	// Iterate the region keys to find the regions.
+	regions := r.getRegionsByKeys(keys)
+	// Assert the returned regions count matches the input keys.
+	if len(regions) != len(keys) {
+		panic("returned regions count mismatch with the input keys")
+	}
+	// Iterate the prevKeys to find the regions.
+	prevRegions := r.getRegionsByPrevKeys(prevKeys)
+	// Assert the returned regions count matches the input keys.
+	if len(prevRegions) != len(prevKeys) {
+		panic("returned prev regions count mismatch with the input keys")
+	}
+	// Build the key -> ID map for the final results.
+	regionsByID := make(map[uint64]*pdpb.RegionResponse, len(regions))
+	keyIDMap := sortOutKeyIDMap(regionsByID, regions, needBuckets)
+	prevKeyIDMap := sortOutKeyIDMap(regionsByID, prevRegions, needBuckets)
+	// Iterate the region IDs to find the regions.
+	for _, id := range ids {
+		// Check if the region has been found.
+		if regionFound, ok := regionsByID[id]; (ok && regionFound != nil) || id == 0 {
+			continue
+		}
+		// If the given region ID is not found in the region tree, set the region to nil.
+		if region := r.GetRegion(id); region == nil {
+			regionsByID[id] = nil
+		} else {
+			regionResp := &pdpb.RegionResponse{
+				Region:       region.GetMeta(),
+				Leader:       region.GetLeader(),
+				DownPeers:    region.GetDownPeers(),
+				PendingPeers: region.GetPendingPeers(),
+			}
+			if needBuckets {
+				regionResp.Buckets = region.GetBuckets()
+			}
+			regionsByID[id] = regionResp
+		}
+	}
+	return keyIDMap, prevKeyIDMap, regionsByID
+}
+
+// getRegionsByKeys searches RegionInfo from regionTree by keys.
+func (r *RegionsInfo) getRegionsByKeys(keys [][]byte) []*RegionInfo {
+	regions := make([]*RegionInfo, 0, len(keys))
+	// Split the keys into multiple batches, and search each batch separately.
+	// This is to avoid the lock contention on the `regionTree`.
+	for _, batch := range splitKeysIntoBatches(keys) {
+		r.t.RLock()
+		results := r.tree.searchByKeys(batch)
+		r.t.RUnlock()
+		regions = append(regions, results...)
+	}
+	return regions
+}
+
+func splitKeysIntoBatches(keys [][]byte) [][][]byte {
+	keysLen := len(keys)
+	batches := make([][][]byte, 0, (keysLen+batchSearchSize-1)/batchSearchSize)
+	for i := 0; i < keysLen; i += batchSearchSize {
+		end := i + batchSearchSize
+		if end > keysLen {
+			end = keysLen
+		}
+		batches = append(batches, keys[i:end])
+	}
+	return batches
+}
+
+func (r *RegionsInfo) getRegionsByPrevKeys(prevKeys [][]byte) []*RegionInfo {
+	regions := make([]*RegionInfo, 0, len(prevKeys))
+	for _, batch := range splitKeysIntoBatches(prevKeys) {
+		r.t.RLock()
+		results := r.tree.searchByPrevKeys(batch)
+		r.t.RUnlock()
+		regions = append(regions, results...)
+	}
+	return regions
+}
+
+// sortOutKeyIDMap will iterate the regions, convert it to a slice of regionID that corresponds to the input regions.
+// It will also update `regionsByID` with the regionID and regionResponse.
+func sortOutKeyIDMap(
+	regionsByID map[uint64]*pdpb.RegionResponse, regions []*RegionInfo, needBuckets bool,
+) []uint64 {
+	keyIDMap := make([]uint64, len(regions))
+	for idx, region := range regions {
+		regionID := region.GetMeta().GetId()
+		keyIDMap[idx] = regionID
+		// Check if the region has been found.
+		if regionFound, ok := regionsByID[regionID]; (ok && regionFound != nil) || regionID == 0 {
+			continue
+		}
+		// If the given key is not found in the region tree, set the region to nil.
+		if region == nil {
+			regionsByID[regionID] = nil
+		} else {
+			regionResp := &pdpb.RegionResponse{
+				Region:       region.GetMeta(),
+				Leader:       region.GetLeader(),
+				DownPeers:    region.GetDownPeers(),
+				PendingPeers: region.GetPendingPeers(),
+			}
+			if needBuckets {
+				regionResp.Buckets = region.GetBuckets()
+			}
+			regionsByID[regionID] = regionResp
+		}
+	}
+	return keyIDMap
 }
 
 // SubTreeRegionType is the type of sub tree region.

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1292,3 +1292,91 @@ func TestScanRegionLimit(t *testing.T) {
 		re.Len(resp, limit)
 	}
 }
+
+func TestQueryRegions(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	regions.CheckAndPutRegion(NewTestRegionInfo(1, 1, []byte("a"), []byte("b")))
+	regions.CheckAndPutRegion(NewTestRegionInfo(2, 1, []byte("b"), []byte("c")))
+	regions.CheckAndPutRegion(NewTestRegionInfo(3, 1, []byte("d"), []byte("e")))
+	// Query regions by keys.
+	keyIDMap, prevKeyIDMap, regionsByID := regions.QueryRegions(
+		[][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		nil,
+		nil,
+		false,
+	)
+	re.Len(keyIDMap, 3)
+	re.Empty(prevKeyIDMap)
+	re.Equal(uint64(1), keyIDMap[0])
+	re.Equal(uint64(2), keyIDMap[1])
+	re.Zero(keyIDMap[2]) // The key is not in the region tree, so its ID should be 0.
+	re.Len(regionsByID, 2)
+	re.Equal(uint64(1), regionsByID[1].GetRegion().GetId())
+	re.Equal(uint64(2), regionsByID[2].GetRegion().GetId())
+	// Query regions by IDs.
+	keyIDMap, prevKeyIDMap, regionsByID = regions.QueryRegions(
+		nil,
+		nil,
+		[]uint64{1, 2, 3},
+		false,
+	)
+	re.Empty(keyIDMap)
+	re.Empty(prevKeyIDMap)
+	re.Len(regionsByID, 3)
+	re.Equal(uint64(1), regionsByID[1].GetRegion().GetId())
+	re.Equal(uint64(2), regionsByID[2].GetRegion().GetId())
+	re.Equal(uint64(3), regionsByID[3].GetRegion().GetId())
+	// Query the region that does not exist.
+	keyIDMap, prevKeyIDMap, regionsByID = regions.QueryRegions(
+		nil,
+		nil,
+		[]uint64{4},
+		false,
+	)
+	re.Empty(keyIDMap)
+	re.Empty(prevKeyIDMap)
+	re.Len(regionsByID, 1)
+	re.Nil(regionsByID[4])
+	keyIDMap, prevKeyIDMap, regionsByID = regions.QueryRegions(
+		[][]byte{[]byte("c")},
+		nil,
+		nil,
+		false,
+	)
+	re.Len(keyIDMap, 1)
+	re.Empty(prevKeyIDMap)
+	re.Zero(keyIDMap[0])
+	re.Empty(regionsByID)
+	keyIDMap, prevKeyIDMap, regionsByID = regions.QueryRegions(
+		[][]byte{[]byte("c")},
+		nil,
+		[]uint64{4},
+		false,
+	)
+	re.Len(keyIDMap, 1)
+	re.Empty(prevKeyIDMap)
+	re.Zero(keyIDMap[0])
+	re.Nil(regionsByID[4])
+	// Query regions by keys, previous keys and IDs.
+	keyIDMap, prevKeyIDMap, regionsByID = regions.QueryRegions(
+		[][]byte{[]byte("b"), []byte("c")},
+		[][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e"), []byte("f")},
+		[]uint64{1, 3},
+		false,
+	)
+	re.Len(keyIDMap, 2)
+	re.Len(prevKeyIDMap, 6)
+	re.Equal(uint64(2), keyIDMap[0])
+	re.Zero(keyIDMap[1])
+	re.Zero(prevKeyIDMap[0])
+	re.Equal(uint64(1), prevKeyIDMap[1])
+	re.Zero(prevKeyIDMap[2])
+	re.Zero(prevKeyIDMap[3])
+	re.Zero(prevKeyIDMap[4])
+	re.Zero(prevKeyIDMap[5])
+	re.Len(regionsByID, 3)
+	re.Equal(uint64(1), regionsByID[1].GetRegion().GetId())
+	re.Equal(uint64(2), regionsByID[2].GetRegion().GetId())
+	re.Equal(uint64(3), regionsByID[3].GetRegion().GetId())
+}

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1380,3 +1380,80 @@ func TestQueryRegions(t *testing.T) {
 	re.Equal(uint64(2), regionsByID[2].GetRegion().GetId())
 	re.Equal(uint64(3), regionsByID[3].GetRegion().GetId())
 }
+
+func BenchmarkQueryRegions(b *testing.B) {
+	regionSizes := []int{100, 1000, 10000, 100000}
+	querySizes := []int{10, 50, 100, 500, 1000}
+
+	for _, regionSize := range regionSizes {
+		regions := NewRegionsInfo()
+		var regionIDs []uint64
+		var keys [][]byte
+		var prevKeys [][]byte
+
+		for i := range regionSize {
+			peer := &metapb.Peer{StoreId: 1, Id: uint64(i + 1)}
+			startKey := []byte(fmt.Sprintf("%20d", i*10))
+			endKey := []byte(fmt.Sprintf("%20d", (i+1)*10))
+			region := NewRegionInfo(&metapb.Region{
+				Id:       uint64(i + 1),
+				Peers:    []*metapb.Peer{peer},
+				StartKey: startKey,
+				EndKey:   endKey,
+			}, peer)
+			regions.CheckAndPutRegion(region)
+			regionIDs = append(regionIDs, uint64(i+1))
+			keys = append(keys, startKey)
+			prevKeys = append(prevKeys, endKey)
+		}
+
+		for _, querySize := range querySizes {
+			if querySize > regionSize {
+				continue
+			}
+
+			queryIDs := make([]uint64, querySize)
+			queryKeys := make([][]byte, querySize)
+			queryPrevKeys := make([][]byte, querySize)
+			step := regionSize / querySize
+			for i := range querySize {
+				idx := i * step
+				queryIDs[i] = regionIDs[idx]
+				queryKeys[i] = keys[idx]
+				queryPrevKeys[i] = prevKeys[idx]
+			}
+
+			b.Run(fmt.Sprintf("QueryByKeys_regions=%d_queries=%d", regionSize, querySize), func(b *testing.B) {
+				b.ResetTimer()
+				for range b.N {
+					regions.QueryRegions(queryKeys, nil, nil, false)
+				}
+			})
+
+			b.Run(fmt.Sprintf("QueryByPrevKeys_regions=%d_queries=%d", regionSize, querySize), func(b *testing.B) {
+				b.ResetTimer()
+				for range b.N {
+					regions.QueryRegions(nil, queryPrevKeys, nil, false)
+				}
+			})
+
+			b.Run(fmt.Sprintf("QueryByIDs_regions=%d_queries=%d", regionSize, querySize), func(b *testing.B) {
+				b.ResetTimer()
+				for range b.N {
+					regions.QueryRegions(nil, nil, queryIDs, false)
+				}
+			})
+
+			b.Run(fmt.Sprintf("QueryMixed_regions=%d_queries=%d", regionSize, querySize), func(b *testing.B) {
+				halfSize := querySize / 2
+				mixedKeys := queryKeys[:halfSize]
+				mixedPrevKeys := queryPrevKeys[:halfSize]
+				mixedIDs := queryIDs[:halfSize]
+				b.ResetTimer()
+				for range b.N {
+					regions.QueryRegions(mixedKeys, mixedPrevKeys, mixedIDs, false)
+				}
+			})
+		}
+	}
+}

--- a/pkg/core/region_tree.go
+++ b/pkg/core/region_tree.go
@@ -289,6 +289,26 @@ func (t *regionTree) searchPrev(regionKey []byte) *RegionInfo {
 	return prevRegionItem.RegionInfo
 }
 
+// searchByKeys searches the regions by keys and return a slice of `*RegionInfo` whose order is the same as the input keys.
+func (t *regionTree) searchByKeys(keys [][]byte) []*RegionInfo {
+	regions := make([]*RegionInfo, len(keys))
+	// TODO: do we need to deduplicate the input keys?
+	for idx, key := range keys {
+		regions[idx] = t.search(key)
+	}
+	return regions
+}
+
+// searchByPrevKeys searches the regions by prevKeys and return a slice of `*RegionInfo` whose order is the same as the input keys.
+func (t *regionTree) searchByPrevKeys(prevKeys [][]byte) []*RegionInfo {
+	regions := make([]*RegionInfo, len(prevKeys))
+	// TODO: do we need to deduplicate the input keys?
+	for idx, key := range prevKeys {
+		regions[idx] = t.searchPrev(key)
+	}
+	return regions
+}
+
 // find returns the range item contains the start key.
 func (t *regionTree) find(item *regionItem) *regionItem {
 	var result *regionItem

--- a/pkg/slice/slice.go
+++ b/pkg/slice/slice.go
@@ -68,3 +68,20 @@ func HasDupInSorted[T comparable](sortedSlice []T) bool {
 	}
 	return false
 }
+
+// SplitIntoBatches splits the slice of items of type T into batches with `batchSize` items per batch.
+func SplitIntoBatches[T any](slice []T, batchSize int) [][]T {
+	if batchSize <= 0 {
+		return [][]T{slice}
+	}
+	sliceLen := len(slice)
+	batches := make([][]T, 0, (sliceLen+batchSize-1)/batchSize)
+	for i := 0; i < sliceLen; i += batchSize {
+		end := i + batchSize
+		if end > sliceLen {
+			end = sliceLen
+		}
+		batches = append(batches, slice[i:end])
+	}
+	return batches
+}

--- a/pkg/slice/slice_test.go
+++ b/pkg/slice/slice_test.go
@@ -102,3 +102,15 @@ func TestSliceHasDupInSorted(t *testing.T) {
 	re.True(slice.HasDupInSorted([]string{"a", "b", "b"}))
 	re.False(slice.HasDupInSorted([]string(nil)))
 }
+
+func TestSliceSplitIntoBatches(t *testing.T) {
+	re := require.New(t)
+	re.Equal([][]int{{1, 2, 3, 4, 5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, 6))
+	re.Equal([][]int{{1, 2, 3, 4, 5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, 5))
+	re.Equal([][]int{{1, 2, 3, 4}, {5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, 4))
+	re.Equal([][]int{{1, 2, 3}, {4, 5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, 3))
+	re.Equal([][]int{{1, 2}, {3, 4}, {5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, 2))
+	re.Equal([][]int{{1}, {2}, {3}, {4}, {5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, 1))
+	re.Equal([][]int{{1, 2, 3, 4, 5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, 0))
+	re.Equal([][]int{{1, 2, 3, 4, 5}}, slice.SplitIntoBatches([]int{1, 2, 3, 4, 5}, -1))
+}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1663,17 +1663,34 @@ func (s *GrpcServer) QueryRegion(stream pdpb.PD_QueryRegionServer) error {
 			return status.Errorf(codes.FailedPrecondition,
 				"mismatch cluster id, need %d but got %d", clusterID, request.GetHeader().GetClusterId())
 		}
-		rc := s.GetRaftCluster()
-		if rc == nil {
-			resp := &pdpb.QueryRegionResponse{
-				Header: notBootstrappedHeader(),
+		var (
+			rc          *cluster.RaftCluster
+			needBuckets bool
+		)
+		if s.member.IsLeader() {
+			rc = s.GetRaftCluster()
+			if rc == nil {
+				resp := &pdpb.QueryRegionResponse{
+					Header: notBootstrappedHeader(),
+				}
+				if err = stream.Send(resp); err != nil {
+					return errors.WithStack(err)
+				}
+				continue
 			}
-			if err = stream.Send(resp); err != nil {
-				return errors.WithStack(err)
+			needBuckets = rc.GetStoreConfig().IsEnableRegionBucket() && request.GetNeedBuckets()
+		} else {
+			rc = s.cluster
+			if !rc.GetRegionSyncer().IsRunning() {
+				resp := &pdpb.QueryRegionResponse{
+					Header: regionNotFound(),
+				}
+				if err = stream.Send(resp); err != nil {
+					return errors.WithStack(err)
+				}
+				continue
 			}
-			continue
 		}
-		needBuckets := rc.GetStoreConfig().IsEnableRegionBucket() && request.GetNeedBuckets()
 
 		start := time.Now()
 		keyIDMap, prevKeyIDMap, regionsByID := rc.QueryRegions(

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1682,7 +1682,7 @@ func (s *GrpcServer) QueryRegion(stream pdpb.PD_QueryRegionServer) error {
 			request.GetIds(),
 			needBuckets,
 		)
-		regionQueryDuration.Observe(time.Since(start).Seconds())
+		queryRegionDuration.Observe(time.Since(start).Seconds())
 		// Build the response and send it to the client.
 		response := &pdpb.QueryRegionResponse{
 			Header:       wrapHeader(),

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1636,12 +1636,64 @@ func (s *GrpcServer) GetRegionByID(ctx context.Context, request *pdpb.GetRegionB
 	}, nil
 }
 
-// QueryRegion implements gRPC PDServer.
-//
-// release-8.5 has not backported the QueryRegion feature. Keep the new
-// kvproto RPC explicitly unimplemented instead of pulling in unrelated logic.
-func (*GrpcServer) QueryRegion(_ pdpb.PD_QueryRegionServer) error {
-	return status.Error(codes.Unimplemented, "query region is not supported in release-8.5")
+// QueryRegion provides a stream processing of the region query.
+func (s *GrpcServer) QueryRegion(stream pdpb.PD_QueryRegionServer) error {
+	if s.GetServiceMiddlewarePersistOptions().IsGRPCRateLimitEnabled() {
+		fName := currentFunction()
+		limiter := s.GetGRPCRateLimiter()
+		if done, err := limiter.Allow(fName); err == nil {
+			defer done()
+		} else {
+			return err
+		}
+	}
+
+	for {
+		request, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// TODO: add forwarding logic.
+
+		if clusterID := keypath.ClusterID(); request.GetHeader().GetClusterId() != clusterID {
+			return status.Errorf(codes.FailedPrecondition,
+				"mismatch cluster id, need %d but got %d", clusterID, request.GetHeader().GetClusterId())
+		}
+		rc := s.GetRaftCluster()
+		if rc == nil {
+			resp := &pdpb.QueryRegionResponse{
+				Header: notBootstrappedHeader(),
+			}
+			if err = stream.Send(resp); err != nil {
+				return errors.WithStack(err)
+			}
+			continue
+		}
+		needBuckets := rc.GetStoreConfig().IsEnableRegionBucket() && request.GetNeedBuckets()
+
+		start := time.Now()
+		keyIDMap, prevKeyIDMap, regionsByID := rc.QueryRegions(
+			request.GetKeys(),
+			request.GetPrevKeys(),
+			request.GetIds(),
+			needBuckets,
+		)
+		regionQueryDuration.Observe(time.Since(start).Seconds())
+		// Build the response and send it to the client.
+		response := &pdpb.QueryRegionResponse{
+			Header:       wrapHeader(),
+			KeyIdMap:     keyIDMap,
+			PrevKeyIdMap: prevKeyIDMap,
+			RegionsById:  regionsByID,
+		}
+		if err := stream.Send(response); err != nil {
+			return errors.WithStack(err)
+		}
+	}
 }
 
 // Deprecated: use BatchScanRegions instead.

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -99,11 +99,11 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
 		})
 
-	regionQueryDuration = prometheus.NewHistogram(
+	queryRegionDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "pd",
 			Subsystem: "server",
-			Name:      "region_query_duration_seconds",
+			Name:      "query_region_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) of region query requests.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
 		})
@@ -197,7 +197,7 @@ func init() {
 	prometheus.MustRegister(tsoProxyBatchSize)
 	prometheus.MustRegister(tsoProxyForwardTimeoutCounter)
 	prometheus.MustRegister(tsoHandleDuration)
-	prometheus.MustRegister(regionQueryDuration)
+	prometheus.MustRegister(queryRegionDuration)
 	prometheus.MustRegister(regionHeartbeatHandleDuration)
 	prometheus.MustRegister(storeHeartbeatHandleDuration)
 	prometheus.MustRegister(bucketReportCounter)

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -99,6 +99,15 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
 		})
 
+	regionQueryDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "pd",
+			Subsystem: "server",
+			Name:      "region_query_duration_seconds",
+			Help:      "Bucketed histogram of processing time (s) of region query requests.",
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
+		})
+
 	bucketReportLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "pd",
@@ -188,6 +197,7 @@ func init() {
 	prometheus.MustRegister(tsoProxyBatchSize)
 	prometheus.MustRegister(tsoProxyForwardTimeoutCounter)
 	prometheus.MustRegister(tsoHandleDuration)
+	prometheus.MustRegister(regionQueryDuration)
 	prometheus.MustRegister(regionHeartbeatHandleDuration)
 	prometheus.MustRegister(storeHeartbeatHandleDuration)
 	prometheus.MustRegister(bucketReportCounter)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8690

QueryRegion (tracked by #8690) is a gRPC streaming service that lets clients resolve regions by keys, previous keys, and region IDs over one bidirectional stream. Its server/core implementation landed on `master` across #8979, #9055, #9076, #9196, and #10194.

This PR backports only the server/core side of QueryRegion support to `release-8.5`. It also includes the related core cleanup from #9079 to avoid redundant region lookups while reading adjacent or key-matched regions. It intentionally does not include the PD client QueryRegion stream path, router client changes, router microservice, `routerpb`, or the master inner-client package layout.

### What is changed and how does it work?

```commit-message
Backport QueryRegion server/core support to release-8.5:

- Add RegionsInfo.QueryRegions and the GrpcServer.QueryRegion stream handler, resolving regions by keys, previous keys, and IDs via batched region-tree lookups.
- Avoid redundant region-map lookups in GetRegionByKey, GetPrevRegionByKey, and GetAdjacentRegions (#9079).
- Allow followers to serve QueryRegion from the region syncer, mirroring the existing follower handling of GetRegion.
- Add per-query-type metrics (pd_core_query_region_duration_seconds, pd_core_query_region_count) and the server query_region_duration_seconds metric.
- Optimize batched ID lookups with getRegionsByIDs and a generic slice.SplitIntoBatches helper.
- Raise batchSearchSize to 128.

Adaptations for release-8.5: rateLimitCheck and errs.ErrMismatchClusterID do not exist on this branch, so the QueryRegion handler inlines the equivalent rate-limit check and cluster-id mismatch error. The branch keeps the current release-8.5 kvproto version and avoids all client/router-service/routerpb changes.
```

### Check List

Tests

- Unit test (`go test ./pkg/core ./pkg/slice ./server`)

### Release note

```release-note
Improve PD server region lookup performance by supporting batched region queries.
```
