### PR TITLE
syncer: handle region sync close responses safely

### DIFF
--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -85,7 +85,15 @@ func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (C
 
 var regionGuide = core.GenerateRegionGuideFunc(false)
 
-func (s *RegionSyncer) handleRegionSyncResponse(ctx context.Context, resp *pdpb.SyncRegionResponse, bc *core.BasicCluster, regionStorage storage.Storage) {
+func (s *RegionSyncer) handleRegionSyncResponse(ctx context.Context, resp *pdpb.SyncRegionResponse, bc *core.BasicCluster, regionStorage storage.Storage) bool {
+	if syncErr := resp.GetHeader().GetError(); syncErr != nil {
+		s.streamingRunning.Store(false)
+		log.Warn("region sync with leader received error response",
+			zap.String("server", s.server.Name()),
+			zap.String("error-type", syncErr.GetType().String()),
+			zap.String("error-message", syncErr.GetMessage()))
+		return false
+	}
 	if s.history.getNextIndex() != resp.GetStartIndex() {
 		log.Warn("server sync index not match the leader",
 			zap.String("server", s.server.Name()),
@@ -148,6 +156,7 @@ func (s *RegionSyncer) handleRegionSyncResponse(ctx context.Context, resp *pdpb.
 	}
 	// mark the client as running status when it finished the first history region sync.
 	s.streamingRunning.Store(true)
+	return true
 }
 
 // IsRunning returns whether the region syncer client is running.
@@ -245,23 +254,38 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 					if err = stream.CloseSend(); err != nil {
 						log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
 					}
-					// Check if the leader is still there to avoid waiting for a `retryInterval`.
-					if s.server.GetLeader() == nil {
-						log.Warn("stop synchronizing with leader due to leader stepped down",
-							zap.String("server", s.server.Name()), zap.Uint64("next-index", s.history.getNextIndex()))
+					if !s.waitRegionSyncRetryInterval(ctx) {
 						return
-					}
-					select {
-					case <-ctx.Done():
-						log.Info("stop synchronizing with leader due to context canceled",
-							zap.String("server", s.server.Name()), zap.Uint64("next-index", s.history.getNextIndex()))
-						return
-					case <-time.After(retryInterval):
 					}
 					break
 				}
-				s.handleRegionSyncResponse(ctx, resp, bc, regionStorage)
+				if !s.handleRegionSyncResponse(ctx, resp, bc, regionStorage) {
+					if err = stream.CloseSend(); err != nil {
+						log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
+					}
+					if !s.waitRegionSyncRetryInterval(ctx) {
+						return
+					}
+					break
+				}
 			}
 		}
 	}()
+}
+
+func (s *RegionSyncer) waitRegionSyncRetryInterval(ctx context.Context) bool {
+	// Check if the leader is still there to avoid waiting for a `retryInterval`.
+	if s.server.GetLeader() == nil {
+		log.Warn("stop synchronizing with leader due to leader stepped down",
+			zap.String("server", s.server.Name()), zap.Uint64("next-index", s.history.getNextIndex()))
+		return false
+	}
+	select {
+	case <-ctx.Done():
+		log.Info("stop synchronizing with leader due to context canceled",
+			zap.String("server", s.server.Name()), zap.Uint64("next-index", s.history.getNextIndex()))
+		return false
+	case <-time.After(retryInterval):
+		return true
+	}
 }

--- a/pkg/syncer/client_test.go
+++ b/pkg/syncer/client_test.go
@@ -26,11 +26,13 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockserver"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
+	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
@@ -93,4 +95,25 @@ func TestErrorCode(t *testing.T) {
 	ev, ok := status.FromError(err)
 	re.True(ok)
 	re.Equal(codes.Canceled, ev.Code())
+}
+
+func TestHandleRegionSyncResponseSkipsErrorResponse(t *testing.T) {
+	re := require.New(t)
+	syncer := newTestRegionSyncer(t, core.NewBasicCluster())
+	syncer.history.resetWithIndex(10)
+	syncer.streamingRunning.Store(true)
+
+	handled := syncer.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+		Header: &pdpb.ResponseHeader{
+			ClusterId: keypath.ClusterID(),
+			Error: &pdpb.Error{
+				Type:    pdpb.ErrorType_UNKNOWN,
+				Message: "server stopped, close the region syncer client",
+			},
+		},
+	}, nil, nil)
+
+	re.False(handled)
+	re.Equal(uint64(10), syncer.history.getNextIndex())
+	re.False(syncer.IsRunning())
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -621,7 +621,6 @@ func (s *RegionSyncer) closeAllClient() {
 				},
 			},
 		}
-		stream := stream
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -594,24 +594,19 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 }
 
 func (s *RegionSyncer) closeAllClient() {
-	type streamWithName struct {
-		name   string
-		sender *regionSyncStream
-	}
-
 	s.mu.RLock()
-	streams := make([]streamWithName, 0, len(s.mu.streams))
+	streams := make(map[string]*regionSyncStream, len(s.mu.streams))
 	for name, sender := range s.mu.streams {
-		streams = append(streams, streamWithName{name: name, sender: sender})
+		streams[name] = sender
 	}
 	s.mu.RUnlock()
 
-	for _, stream := range streams {
-		stream.sender.close()
+	for _, sender := range streams {
+		sender.close()
 	}
 
-	var wg sync.WaitGroup
-	for _, stream := range streams {
+	wg := &sync.WaitGroup{}
+	for name, sender := range streams {
 		resp := &pdpb.SyncRegionResponse{
 			Header: &pdpb.ResponseHeader{
 				ClusterId: keypath.ClusterID(),
@@ -622,10 +617,10 @@ func (s *RegionSyncer) closeAllClient() {
 			},
 		}
 		wg.Add(1)
-		go func() {
+		go func(name string, sender *regionSyncStream, resp *pdpb.SyncRegionResponse) {
 			defer wg.Done()
-			s.sendRegionSyncResponse(context.Background(), stream.name, stream.sender, resp)
-		}()
+			s.sendRegionSyncResponse(context.Background(), name, sender, resp)
+		}(name, sender, resp)
 	}
 	wg.Wait()
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -594,13 +594,24 @@ func (s *RegionSyncer) sendRegionSyncResponse(
 }
 
 func (s *RegionSyncer) closeAllClient() {
+	type streamWithName struct {
+		name   string
+		sender *regionSyncStream
+	}
+
 	s.mu.RLock()
-	streams := make([]*regionSyncStream, 0, len(s.mu.streams))
-	for _, sender := range s.mu.streams {
-		streams = append(streams, sender)
+	streams := make([]streamWithName, 0, len(s.mu.streams))
+	for name, sender := range s.mu.streams {
+		streams = append(streams, streamWithName{name: name, sender: sender})
 	}
 	s.mu.RUnlock()
-	for _, sender := range streams {
+
+	for _, stream := range streams {
+		stream.sender.close()
+	}
+
+	var wg sync.WaitGroup
+	for _, stream := range streams {
 		resp := &pdpb.SyncRegionResponse{
 			Header: &pdpb.ResponseHeader{
 				ClusterId: keypath.ClusterID(),
@@ -610,9 +621,12 @@ func (s *RegionSyncer) closeAllClient() {
 				},
 			},
 		}
-		sender.close()
-		if err := sender.send(resp); err != nil {
-			log.Warn("region syncer send close message meet error", errs.ZapError(errs.ErrGRPCSend, err))
-		}
+		stream := stream
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.sendRegionSyncResponse(context.Background(), stream.name, stream.sender, resp)
+		}()
 	}
+	wg.Wait()
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -620,7 +620,7 @@ func (s *RegionSyncer) closeAllClient() {
 		go func(name string, sender *regionSyncStream, resp *pdpb.SyncRegionResponse) {
 			defer logutil.LogPanic()
 			defer wg.Done()
-			s.sendRegionSyncResponse(context.Background(), name, sender, resp)
+			s.sendRegionSyncResponse(s.server.LoopContext(), name, sender, resp)
 		}(name, sender, resp)
 	}
 	wg.Wait()

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -618,6 +618,7 @@ func (s *RegionSyncer) closeAllClient() {
 		}
 		wg.Add(1)
 		go func(name string, sender *regionSyncStream, resp *pdpb.SyncRegionResponse) {
+			defer logutil.LogPanic()
 			defer wg.Done()
 			s.sendRegionSyncResponse(context.Background(), name, sender, resp)
 		}(name, sender, resp)

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -299,6 +299,7 @@ func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
 		core.NewBasicCluster(),
 	)
 	syncer := NewRegionSyncer(server)
+	syncer.sendTimeout = 10 * time.Millisecond
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	stream := newMockSyncRegionsServer()
@@ -342,7 +343,6 @@ func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
 	})
 	re.Empty(syncer.GetAllDownstreamNames())
 
-	close(unblockSend)
 	testutil.Eventually(re, func() bool {
 		select {
 		case <-closeDone:
@@ -351,6 +351,7 @@ func TestCloseAllClientClosesStreamsBeforeSend(t *testing.T) {
 			return false
 		}
 	})
+	close(unblockSend)
 }
 
 func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10731

Region syncer shutdown can currently hit two unsafe paths:

- A follower treats a `SyncRegionResponse` with `Header.Error` as normal sync data, so a close response without `StartIndex` can reset the local history index to `0`.
- `closeAllClient` closes and sends shutdown responses one stream at a time, so one blocked send can delay closing the remaining streams.

### What changed?

- Check `resp.GetHeader().GetError()` before normal region sync response handling and skip local history mutation for error responses.
- Close all tracked streams first in `closeAllClient`, then send shutdown responses through the existing timeout-safe send path in parallel.
- Add regression tests for both behaviors.

### Tests

- `go test ./pkg/syncer -run 'TestHandleRegionSyncResponseSkipsErrorResponse|TestCloseAllClientClosesStreamsBeforeSend|TestBroadcastClosesStreamWhenSendBlocks|TestSyncExitsWhenBroadcastSendFails' -count=1 -v -timeout=2m`\n- `go test ./pkg/syncer -count=1 -timeout=2m`

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region synchronization to detect leader errors, stop broken streams, and automatically retry with a controlled wait interval.
  * Sync loops now reliably close and retry streams when the leader steps down or context is canceled.
* **Refactor**
  * Server shutdown now snapshots and closes client streams promptly, sending shutdown notices concurrently for more reliable termination.
* **Tests**
  * Added coverage for handling error responses in sync flows.
  * Reduced flakiness in shutdown tests with tighter timing control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->