### PR TITLE
syncer: retain history for slow downstreams

### DIFF
--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -122,14 +122,7 @@ func (h *historyBuffer) capacity() int {
 	return h.size - 1
 }
 
-func (h *historyBuffer) record(r *core.RegionInfo) {
-	h.Lock()
-	defer h.Unlock()
-	h.prepareRequiredWindowLocked(1)
-	h.recordLocked(r)
-}
-
-func (h *historyBuffer) recordBatch(records []*core.RegionInfo) {
+func (h *historyBuffer) record(records ...*core.RegionInfo) {
 	if len(records) == 0 {
 		return
 	}

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -125,21 +125,17 @@ func (h *historyBuffer) capacity() int {
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
-	h.prepareRequiredWindowLocked(0, 1)
+	h.prepareRequiredWindowLocked(1)
 	h.recordLocked(r)
 }
 
 func (h *historyBuffer) recordBatch(records []*core.RegionInfo) {
-	h.recordBatchWithRequiredWindow(records, 0)
-}
-
-func (h *historyBuffer) recordBatchWithRequiredWindow(records []*core.RegionInfo, requiredWindow uint64) {
 	if len(records) == 0 {
 		return
 	}
 	h.Lock()
 	defer h.Unlock()
-	h.prepareRequiredWindowLocked(requiredWindow, uint64(len(records)))
+	h.prepareRequiredWindowLocked(uint64(len(records)))
 	for _, r := range records {
 		h.recordLocked(r)
 	}
@@ -160,14 +156,13 @@ func (h *historyBuffer) recordLocked(r *core.RegionInfo) {
 	}
 }
 
-func (h *historyBuffer) prepareRequiredWindowLocked(requiredWindow uint64, appendCount uint64) {
+func (h *historyBuffer) prepareRequiredWindowLocked(appendCount uint64) {
 	if retainIndex, ok := h.minRetainIndexLocked(); ok {
 		endIndex := h.index + appendCount
 		if retainIndex < endIndex {
-			requiredWindow = max(requiredWindow, endIndex-retainIndex)
+			h.growForWindowLocked(endIndex - retainIndex)
 		}
 	}
-	h.growForWindowLocked(requiredWindow)
 }
 
 func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -125,29 +125,21 @@ func (h *historyBuffer) capacity() int {
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
-	h.prepareRequiredWindowLocked(0, false, 1)
+	h.prepareRequiredWindowLocked(0, 1)
 	h.recordLocked(r)
 }
 
 func (h *historyBuffer) recordBatch(records []*core.RegionInfo) {
-	if len(records) == 0 {
-		return
-	}
-	h.Lock()
-	defer h.Unlock()
-	h.prepareRequiredWindowLocked(0, false, uint64(len(records)))
-	for _, r := range records {
-		h.recordLocked(r)
-	}
+	h.recordBatchWithRequiredWindow(records, 0)
 }
 
-func (h *historyBuffer) recordBatchFromReplay(replayFrom uint64, records []*core.RegionInfo) {
+func (h *historyBuffer) recordBatchWithRequiredWindow(records []*core.RegionInfo, requiredWindow uint64) {
 	if len(records) == 0 {
 		return
 	}
 	h.Lock()
 	defer h.Unlock()
-	h.prepareRequiredWindowLocked(replayFrom, true, uint64(len(records)))
+	h.prepareRequiredWindowLocked(requiredWindow, uint64(len(records)))
 	for _, r := range records {
 		h.recordLocked(r)
 	}
@@ -168,16 +160,14 @@ func (h *historyBuffer) recordLocked(r *core.RegionInfo) {
 	}
 }
 
-func (h *historyBuffer) prepareRequiredWindowLocked(replayFrom uint64, hasReplayFrom bool, appendCount uint64) {
-	retainIndex, ok := h.minRequiredIndexLocked(replayFrom, hasReplayFrom)
-	if !ok {
-		return
+func (h *historyBuffer) prepareRequiredWindowLocked(requiredWindow uint64, appendCount uint64) {
+	if retainIndex, ok := h.minRetainIndexLocked(); ok {
+		endIndex := h.index + appendCount
+		if retainIndex < endIndex {
+			requiredWindow = max(requiredWindow, endIndex-retainIndex)
+		}
 	}
-	endIndex := h.index + appendCount
-	if retainIndex >= endIndex {
-		return
-	}
-	h.growForWindowLocked(endIndex - retainIndex)
+	h.growForWindowLocked(requiredWindow)
 }
 
 func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
@@ -262,27 +252,16 @@ func (h *historyBuffer) minRetainIndexLocked() (uint64, bool) {
 	return min, ok
 }
 
-func (h *historyBuffer) minRequiredIndexLocked(replayFrom uint64, hasReplayFrom bool) (uint64, bool) {
-	min, ok := h.minRetainIndexLocked()
-	if hasReplayFrom && (!ok || replayFrom < min) {
-		min = replayFrom
-		ok = true
-	}
-	return min, ok
-}
-
-func (h *historyBuffer) observeReplayWindow(replayFrom, endIndex uint64) {
+func (h *historyBuffer) observeRequiredWindow(window uint64) {
 	h.Lock()
 	defer h.Unlock()
-	h.observeReplayWindowLocked(replayFrom, true, endIndex)
+	h.observeRequiredWindowLocked(window)
 }
 
-func (h *historyBuffer) observeReplayWindowLocked(replayFrom uint64, hasReplayFrom bool, endIndex uint64) {
-	retainIndex, ok := h.minRequiredIndexLocked(replayFrom, hasReplayFrom)
-	if !ok || retainIndex >= endIndex {
+func (h *historyBuffer) observeRequiredWindowLocked(window uint64) {
+	if window == 0 {
 		return
 	}
-	window := endIndex - retainIndex
 	if window > h.observedRequiredWindow {
 		h.observedRequiredWindow = window
 	}

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -136,7 +136,9 @@ func (h *historyBuffer) recordBatch(records []*core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
 	h.prepareRequiredWindowLocked(0, false, uint64(len(records)))
-	h.recordBatchLocked(records)
+	for _, r := range records {
+		h.recordLocked(r)
+	}
 }
 
 func (h *historyBuffer) recordBatchFromReplay(replayFrom uint64, records []*core.RegionInfo) {
@@ -146,10 +148,6 @@ func (h *historyBuffer) recordBatchFromReplay(replayFrom uint64, records []*core
 	h.Lock()
 	defer h.Unlock()
 	h.prepareRequiredWindowLocked(replayFrom, true, uint64(len(records)))
-	h.recordBatchLocked(records)
-}
-
-func (h *historyBuffer) recordBatchLocked(records []*core.RegionInfo) {
 	for _, r := range records {
 		h.recordLocked(r)
 	}

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -125,9 +125,37 @@ func (h *historyBuffer) capacity() int {
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
-	if retainIndex, ok := h.minRetainIndexLocked(); ok && retainIndex <= h.index {
-		h.growForWindowLocked(h.index - retainIndex + 1)
+	h.prepareRequiredWindowLocked(0, false, 1)
+	h.recordLocked(r)
+}
+
+func (h *historyBuffer) recordBatch(records []*core.RegionInfo) {
+	if len(records) == 0 {
+		return
 	}
+	h.Lock()
+	defer h.Unlock()
+	h.prepareRequiredWindowLocked(0, false, uint64(len(records)))
+	h.recordBatchLocked(records)
+}
+
+func (h *historyBuffer) recordBatchFromReplay(replayFrom uint64, records []*core.RegionInfo) {
+	if len(records) == 0 {
+		return
+	}
+	h.Lock()
+	defer h.Unlock()
+	h.prepareRequiredWindowLocked(replayFrom, true, uint64(len(records)))
+	h.recordBatchLocked(records)
+}
+
+func (h *historyBuffer) recordBatchLocked(records []*core.RegionInfo) {
+	for _, r := range records {
+		h.recordLocked(r)
+	}
+}
+
+func (h *historyBuffer) recordLocked(r *core.RegionInfo) {
 	syncIndexGauge.Set(float64(h.index))
 	h.records[h.tail] = r
 	h.tail = (h.tail + 1) % h.size
@@ -140,6 +168,18 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 		h.persist()
 		h.flushCount = defaultFlushCount
 	}
+}
+
+func (h *historyBuffer) prepareRequiredWindowLocked(replayFrom uint64, hasReplayFrom bool, appendCount uint64) {
+	retainIndex, ok := h.minRequiredIndexLocked(replayFrom, hasReplayFrom)
+	if !ok {
+		return
+	}
+	endIndex := h.index + appendCount
+	if retainIndex >= endIndex {
+		return
+	}
+	h.growForWindowLocked(endIndex - retainIndex)
 }
 
 func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
@@ -224,13 +264,27 @@ func (h *historyBuffer) minRetainIndexLocked() (uint64, bool) {
 	return min, ok
 }
 
-func (h *historyBuffer) observeRequiredWindow(window uint64) {
-	h.Lock()
-	defer h.Unlock()
-	h.observeRequiredWindowLocked(window)
+func (h *historyBuffer) minRequiredIndexLocked(replayFrom uint64, hasReplayFrom bool) (uint64, bool) {
+	min, ok := h.minRetainIndexLocked()
+	if hasReplayFrom && (!ok || replayFrom < min) {
+		min = replayFrom
+		ok = true
+	}
+	return min, ok
 }
 
-func (h *historyBuffer) observeRequiredWindowLocked(window uint64) {
+func (h *historyBuffer) observeReplayWindow(replayFrom, endIndex uint64) {
+	h.Lock()
+	defer h.Unlock()
+	h.observeReplayWindowLocked(replayFrom, true, endIndex)
+}
+
+func (h *historyBuffer) observeReplayWindowLocked(replayFrom uint64, hasReplayFrom bool, endIndex uint64) {
+	retainIndex, ok := h.minRequiredIndexLocked(replayFrom, hasReplayFrom)
+	if !ok || retainIndex >= endIndex {
+		return
+	}
+	window := endIndex - retainIndex
 	if window > h.observedRequiredWindow {
 		h.observedRequiredWindow = window
 	}

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -166,17 +166,17 @@ func TestHistoryBufferObservedRequiredWindowKeepsSlowDownstreamRecords(t *testin
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 	h.resetWithIndex(10)
-	h.recordBatch([]*core.RegionInfo{
+	h.record(
 		newHistoryBufferTestRegion(1),
 		newHistoryBufferTestRegion(2),
-	})
+	)
 
 	h.observeRequiredWindow(5)
-	h.recordBatch([]*core.RegionInfo{
+	h.record(
 		newHistoryBufferTestRegion(3),
 		newHistoryBufferTestRegion(4),
 		newHistoryBufferTestRegion(5),
-	})
+	)
 
 	records := h.recordsFrom(10)
 	re.Len(records, 5)
@@ -191,19 +191,19 @@ func TestHistoryBufferFullSyncRetainTakesPriorityOverRequiredWindow(t *testing.T
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 	h.resetWithIndex(10)
-	h.recordBatch([]*core.RegionInfo{
+	h.record(
 		newHistoryBufferTestRegion(1),
 		newHistoryBufferTestRegion(2),
-	})
+	)
 	release := h.retainFrom(10)
 	defer release()
 
 	h.observeRequiredWindow(4)
-	h.recordBatch([]*core.RegionInfo{
+	h.record(
 		newHistoryBufferTestRegion(3),
 		newHistoryBufferTestRegion(4),
 		newHistoryBufferTestRegion(5),
-	})
+	)
 
 	records := h.recordsFrom(10)
 	re.Len(records, 5)

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -162,7 +162,7 @@ func TestHistoryBufferRetainKeepsCatchUpRecords(t *testing.T) {
 	re.Equal(8, h.capacity())
 }
 
-func TestHistoryBufferRecordBatchWithRequiredWindowKeepsSlowDownstreamRecords(t *testing.T) {
+func TestHistoryBufferObservedRequiredWindowKeepsSlowDownstreamRecords(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 	h.resetWithIndex(10)
@@ -171,11 +171,12 @@ func TestHistoryBufferRecordBatchWithRequiredWindowKeepsSlowDownstreamRecords(t 
 		newHistoryBufferTestRegion(2),
 	})
 
-	h.recordBatchWithRequiredWindow([]*core.RegionInfo{
+	h.observeRequiredWindow(5)
+	h.recordBatch([]*core.RegionInfo{
 		newHistoryBufferTestRegion(3),
 		newHistoryBufferTestRegion(4),
 		newHistoryBufferTestRegion(5),
-	}, 5)
+	})
 
 	records := h.recordsFrom(10)
 	re.Len(records, 5)
@@ -197,11 +198,12 @@ func TestHistoryBufferFullSyncRetainTakesPriorityOverRequiredWindow(t *testing.T
 	release := h.retainFrom(10)
 	defer release()
 
-	h.recordBatchWithRequiredWindow([]*core.RegionInfo{
+	h.observeRequiredWindow(4)
+	h.recordBatch([]*core.RegionInfo{
 		newHistoryBufferTestRegion(3),
 		newHistoryBufferTestRegion(4),
 		newHistoryBufferTestRegion(5),
-	}, 4)
+	})
 
 	records := h.recordsFrom(10)
 	re.Len(records, 5)

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -162,7 +162,7 @@ func TestHistoryBufferRetainKeepsCatchUpRecords(t *testing.T) {
 	re.Equal(8, h.capacity())
 }
 
-func TestHistoryBufferRecordBatchFromReplayKeepsSlowDownstreamRecords(t *testing.T) {
+func TestHistoryBufferRecordBatchWithRequiredWindowKeepsSlowDownstreamRecords(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 	h.resetWithIndex(10)
@@ -171,11 +171,11 @@ func TestHistoryBufferRecordBatchFromReplayKeepsSlowDownstreamRecords(t *testing
 		newHistoryBufferTestRegion(2),
 	})
 
-	h.recordBatchFromReplay(10, []*core.RegionInfo{
+	h.recordBatchWithRequiredWindow([]*core.RegionInfo{
 		newHistoryBufferTestRegion(3),
 		newHistoryBufferTestRegion(4),
 		newHistoryBufferTestRegion(5),
-	})
+	}, 5)
 
 	records := h.recordsFrom(10)
 	re.Len(records, 5)
@@ -186,7 +186,7 @@ func TestHistoryBufferRecordBatchFromReplayKeepsSlowDownstreamRecords(t *testing
 	re.Equal(8, h.capacity())
 }
 
-func TestHistoryBufferFullSyncRetainTakesPriorityOverReplayStart(t *testing.T) {
+func TestHistoryBufferFullSyncRetainTakesPriorityOverRequiredWindow(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 	h.resetWithIndex(10)
@@ -197,11 +197,11 @@ func TestHistoryBufferFullSyncRetainTakesPriorityOverReplayStart(t *testing.T) {
 	release := h.retainFrom(10)
 	defer release()
 
-	h.recordBatchFromReplay(11, []*core.RegionInfo{
+	h.recordBatchWithRequiredWindow([]*core.RegionInfo{
 		newHistoryBufferTestRegion(3),
 		newHistoryBufferTestRegion(4),
 		newHistoryBufferTestRegion(5),
-	})
+	}, 4)
 
 	records := h.recordsFrom(10)
 	re.Len(records, 5)
@@ -211,11 +211,11 @@ func TestHistoryBufferFullSyncRetainTakesPriorityOverReplayStart(t *testing.T) {
 	re.Equal(8, h.capacity())
 }
 
-func TestHistoryBufferObserveReplayWindowGrowsWithoutRetain(t *testing.T) {
+func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 
-	h.observeReplayWindow(0, 3)
+	h.observeRequiredWindow(3)
 
 	re.Equal(8, h.capacity())
 }
@@ -223,12 +223,12 @@ func TestHistoryBufferObserveReplayWindowGrowsWithoutRetain(t *testing.T) {
 func TestHistoryBufferShrinksOneStepAfterReplayWindowStaysLow(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
-	h.observeReplayWindow(0, 3)
+	h.observeRequiredWindow(3)
 	re.Equal(8, h.capacity())
 	h.maybeShrink()
 
 	for range historyBufferShrinkRounds {
-		h.observeReplayWindow(h.getNextIndex(), h.getNextIndex())
+		h.observeRequiredWindow(0)
 		h.maybeShrink()
 	}
 

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -162,24 +162,73 @@ func TestHistoryBufferRetainKeepsCatchUpRecords(t *testing.T) {
 	re.Equal(8, h.capacity())
 }
 
-func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {
+func TestHistoryBufferRecordBatchFromReplayKeepsSlowDownstreamRecords(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(10)
+	h.recordBatch([]*core.RegionInfo{
+		newHistoryBufferTestRegion(1),
+		newHistoryBufferTestRegion(2),
+	})
+
+	h.recordBatchFromReplay(10, []*core.RegionInfo{
+		newHistoryBufferTestRegion(3),
+		newHistoryBufferTestRegion(4),
+		newHistoryBufferTestRegion(5),
+	})
+
+	records := h.recordsFrom(10)
+	re.Len(records, 5)
+	re.Equal(uint64(1), records[0].GetID())
+	re.Equal(uint64(5), records[4].GetID())
+	re.Equal(uint64(10), h.getFirstIndex())
+	re.Equal(uint64(15), h.getNextIndex())
+	re.Equal(8, h.capacity())
+}
+
+func TestHistoryBufferFullSyncRetainTakesPriorityOverReplayStart(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(10)
+	h.recordBatch([]*core.RegionInfo{
+		newHistoryBufferTestRegion(1),
+		newHistoryBufferTestRegion(2),
+	})
+	release := h.retainFrom(10)
+	defer release()
+
+	h.recordBatchFromReplay(11, []*core.RegionInfo{
+		newHistoryBufferTestRegion(3),
+		newHistoryBufferTestRegion(4),
+		newHistoryBufferTestRegion(5),
+	})
+
+	records := h.recordsFrom(10)
+	re.Len(records, 5)
+	re.Equal(uint64(1), records[0].GetID())
+	re.Equal(uint64(5), records[4].GetID())
+	re.Equal(uint64(10), h.getFirstIndex())
+	re.Equal(8, h.capacity())
+}
+
+func TestHistoryBufferObserveReplayWindowGrowsWithoutRetain(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
 
-	h.observeRequiredWindow(3)
+	h.observeReplayWindow(0, 3)
 
 	re.Equal(8, h.capacity())
 }
 
-func TestHistoryBufferShrinksOneStepAfterRequiredWindowStaysLow(t *testing.T) {
+func TestHistoryBufferShrinksOneStepAfterReplayWindowStaysLow(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)
-	h.observeRequiredWindow(3)
+	h.observeReplayWindow(0, 3)
 	re.Equal(8, h.capacity())
 	h.maybeShrink()
 
 	for range historyBufferShrinkRounds {
-		h.observeRequiredWindow(1)
+		h.observeReplayWindow(h.getNextIndex(), h.getNextIndex())
 		h.maybeShrink()
 	}
 

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -259,7 +259,7 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 			s.appendHistoryRecords(records)
 			s.broadcast(ctx, records, false)
 		case <-shrinkTicker.C:
-			s.observeDownstreamReplayWindow()
+			s.observeDownstreamReplayWindow(0)
 			s.history.maybeShrink()
 		case <-keepAliveTicker.C:
 			s.broadcast(ctx, nil, true)
@@ -269,23 +269,20 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 }
 
 func (s *RegionSyncer) appendHistoryRecords(records []*core.RegionInfo) {
-	s.history.recordBatchWithRequiredWindow(records, s.downstreamReplayWindow(uint64(len(records))))
+	s.observeDownstreamReplayWindow(uint64(len(records)))
+	s.history.recordBatch(records)
 }
 
-func (s *RegionSyncer) observeDownstreamReplayWindow() {
-	s.history.observeRequiredWindow(s.downstreamReplayWindow(0))
-}
-
-func (s *RegionSyncer) downstreamReplayWindow(appendCount uint64) uint64 {
+func (s *RegionSyncer) observeDownstreamReplayWindow(appendCount uint64) {
 	minSendIndex, ok := s.minDownstreamSendIndex()
 	if !ok {
-		return 0
+		return
 	}
 	endIndex := s.history.getNextIndex() + appendCount
 	if minSendIndex >= endIndex {
-		return 0
+		return
 	}
-	return endIndex - minSendIndex
+	s.history.observeRequiredWindow(endIndex - minSendIndex)
 }
 
 func (s *RegionSyncer) minDownstreamSendIndex() (uint64, bool) {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -102,16 +102,6 @@ func (s *regionSyncStream) getSendIndex() uint64 {
 	return s.sendIndex.Load()
 }
 
-func (s *regionSyncStream) advanceSendIndex(count uint64) {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	s.advanceSendIndexLocked(count)
-}
-
-func (s *regionSyncStream) advanceSendIndexLocked(count uint64) {
-	s.sendIndex.Add(count)
-}
-
 func (s *regionSyncStream) notify(keepAlive bool) {
 	select {
 	case s.notifyCh <- keepAlive:
@@ -581,7 +571,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 		if err := s.syncHistoryRecordsLocked(catchUpStartIndex, records, syncStream); err != nil {
 			return err
 		}
-		syncStream.advanceSendIndexLocked(uint64(len(records)))
+		syncStream.sendIndex.Add(uint64(len(records)))
 	}
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
@@ -696,7 +686,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
 			return sentRecords, errors.Errorf("send region sync response failed")
 		}
-		stream.advanceSendIndexLocked(uint64(len(records)))
+		stream.sendIndex.Add(uint64(len(records)))
 		sentRecords = true
 	}
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -102,14 +102,14 @@ func (s *regionSyncStream) getSendIndex() uint64 {
 	return s.sendIndex.Load()
 }
 
-func (s *regionSyncStream) advanceSendIndex(count int) {
+func (s *regionSyncStream) advanceSendIndex(count uint64) {
 	s.sendMu.Lock()
 	defer s.sendMu.Unlock()
 	s.advanceSendIndexLocked(count)
 }
 
-func (s *regionSyncStream) advanceSendIndexLocked(count int) {
-	s.sendIndex.Add(uint64(count))
+func (s *regionSyncStream) advanceSendIndexLocked(count uint64) {
+	s.sendIndex.Add(count)
 }
 
 func (s *regionSyncStream) notify(keepAlive bool) {
@@ -269,12 +269,20 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 }
 
 func (s *RegionSyncer) appendHistoryRecords(records []*core.RegionInfo) {
-	s.observeDownstreamReplayWindow(uint64(len(records)))
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	s.observeDownstreamReplayWindowLocked(uint64(len(records)))
 	s.history.record(records...)
 }
 
 func (s *RegionSyncer) observeDownstreamReplayWindow(appendCount uint64) {
-	minSendIndex, ok := s.minDownstreamSendIndex()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	s.observeDownstreamReplayWindowLocked(appendCount)
+}
+
+func (s *RegionSyncer) observeDownstreamReplayWindowLocked(appendCount uint64) {
+	minSendIndex, ok := s.minDownstreamSendIndexLocked()
 	if !ok {
 		return
 	}
@@ -288,6 +296,10 @@ func (s *RegionSyncer) observeDownstreamReplayWindow(appendCount uint64) {
 func (s *RegionSyncer) minDownstreamSendIndex() (uint64, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	return s.minDownstreamSendIndexLocked()
+}
+
+func (s *RegionSyncer) minDownstreamSendIndexLocked() (uint64, bool) {
 	var minIndex uint64
 	var ok bool
 	for _, stream := range s.mu.streams {
@@ -569,7 +581,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 		if err := s.syncHistoryRecordsLocked(catchUpStartIndex, records, syncStream); err != nil {
 			return err
 		}
-		syncStream.advanceSendIndexLocked(len(records))
+		syncStream.advanceSendIndexLocked(uint64(len(records)))
 	}
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
@@ -684,7 +696,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
 			return sentRecords, errors.Errorf("send region sync response failed")
 		}
-		stream.advanceSendIndexLocked(len(records))
+		stream.advanceSendIndexLocked(uint64(len(records)))
 		sentRecords = true
 	}
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -124,12 +124,6 @@ func (s *regionSyncStream) checkOpen() error {
 	}
 }
 
-func (s *regionSyncStream) send(regions *pdpb.SyncRegionResponse) error {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	return s.sendStream(regions)
-}
-
 func (s *regionSyncStream) sendStreamIfOpen(regions *pdpb.SyncRegionResponse) error {
 	s.stream.Lock()
 	defer s.stream.Unlock()

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -270,7 +270,7 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 
 func (s *RegionSyncer) appendHistoryRecords(records []*core.RegionInfo) {
 	s.observeDownstreamReplayWindow(uint64(len(records)))
-	s.history.recordBatch(records)
+	s.history.record(records...)
 }
 
 func (s *RegionSyncer) observeDownstreamReplayWindow(appendCount uint64) {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -75,7 +75,7 @@ type regionSyncStream struct {
 	}
 	// sendMu serializes the logical send flow.
 	sendMu struct {
-		syncutil.Mutex
+		sync.Mutex
 	}
 	sendIndex atomic.Uint64
 	notifyCh  chan bool

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -269,20 +269,23 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 }
 
 func (s *RegionSyncer) appendHistoryRecords(records []*core.RegionInfo) {
-	replayFrom, ok := s.minDownstreamSendIndex()
-	if !ok {
-		s.history.recordBatch(records)
-		return
-	}
-	s.history.recordBatchFromReplay(replayFrom, records)
+	s.history.recordBatchWithRequiredWindow(records, s.downstreamReplayWindow(uint64(len(records))))
 }
 
 func (s *RegionSyncer) observeDownstreamReplayWindow() {
-	replayFrom, ok := s.minDownstreamSendIndex()
+	s.history.observeRequiredWindow(s.downstreamReplayWindow(0))
+}
+
+func (s *RegionSyncer) downstreamReplayWindow(appendCount uint64) uint64 {
+	minSendIndex, ok := s.minDownstreamSendIndex()
 	if !ok {
-		return
+		return 0
 	}
-	s.history.observeReplayWindow(replayFrom, s.history.getNextIndex())
+	endIndex := s.history.getNextIndex() + appendCount
+	if minSendIndex >= endIndex {
+		return 0
+	}
+	return endIndex - minSendIndex
 }
 
 func (s *RegionSyncer) minDownstreamSendIndex() (uint64, bool) {
@@ -409,7 +412,7 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
 	if startIndex != 0 && startIndex < endIndex {
-		s.history.observeReplayWindow(startIndex, endIndex)
+		s.history.observeRequiredWindow(endIndex - startIndex)
 	}
 	records := s.history.recordsBetween(startIndex, endIndex)
 	if len(records) == 0 {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -73,43 +73,37 @@ type regionSyncStream struct {
 		syncutil.Mutex
 		ServerStream
 	}
-	// sendMu serializes the logical send flow and protects sendIndex.
+	// sendMu serializes the logical send flow.
 	sendMu struct {
 		syncutil.Mutex
-		sendIndex uint64
 	}
-	notifyCh chan bool
-	done     chan struct{}
-	once     sync.Once
+	sendIndex atomic.Uint64
+	notifyCh  chan bool
+	done      chan struct{}
+	once      sync.Once
 }
 
 func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStream {
-	return &regionSyncStream{
+	syncStream := &regionSyncStream{
 		stream: struct {
 			syncutil.Mutex
 			ServerStream
 		}{
 			ServerStream: stream,
 		},
-		sendMu: struct {
-			syncutil.Mutex
-			sendIndex uint64
-		}{
-			sendIndex: startIndex,
-		},
 		notifyCh: make(chan bool, 1),
 		done:     make(chan struct{}),
 	}
+	syncStream.sendIndex.Store(startIndex)
+	return syncStream
 }
 
 func (s *regionSyncStream) getSendIndex() uint64 {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
 	return s.getSendIndexLocked()
 }
 
 func (s *regionSyncStream) getSendIndexLocked() uint64 {
-	return s.sendMu.sendIndex
+	return s.sendIndex.Load()
 }
 
 func (s *regionSyncStream) advanceSendIndex(count int) {
@@ -119,7 +113,7 @@ func (s *regionSyncStream) advanceSendIndex(count int) {
 }
 
 func (s *regionSyncStream) advanceSendIndexLocked(count int) {
-	s.sendMu.sendIndex += uint64(count)
+	s.sendIndex.Add(uint64(count))
 }
 
 func (s *regionSyncStream) notify(keepAlive bool) {
@@ -238,7 +232,6 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 
 	processRegion := func(region *core.RegionInfo) {
 		records = append(records, region)
-		s.history.record(region)
 	}
 
 	defer func() {
@@ -271,14 +264,53 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 					break loop
 				}
 			}
+			s.appendHistoryRecords(records)
 			s.broadcast(ctx, records, false)
 		case <-shrinkTicker.C:
+			s.observeDownstreamReplayWindow()
 			s.history.maybeShrink()
 		case <-keepAliveTicker.C:
 			s.broadcast(ctx, nil, true)
 		}
 		records = records[:0]
 	}
+}
+
+func (s *RegionSyncer) appendHistoryRecords(records []*core.RegionInfo) {
+	replayFrom, ok := s.minDownstreamSendIndex()
+	if !ok {
+		s.history.recordBatch(records)
+		return
+	}
+	s.history.recordBatchFromReplay(replayFrom, records)
+}
+
+func (s *RegionSyncer) observeDownstreamReplayWindow() {
+	replayFrom, ok := s.minDownstreamSendIndex()
+	if !ok {
+		return
+	}
+	s.history.observeReplayWindow(replayFrom, s.history.getNextIndex())
+}
+
+func (s *RegionSyncer) minDownstreamSendIndex() (uint64, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var minIndex uint64
+	var ok bool
+	for _, stream := range s.mu.streams {
+		select {
+		case <-stream.done:
+			continue
+		default:
+		}
+		sendIndex := stream.getSendIndex()
+		if !ok || sendIndex < minIndex {
+			minIndex = sendIndex
+			ok = true
+		}
+	}
+	return minIndex, ok
 }
 
 // GetAllDownstreamNames tries to get the all bind stream's name.
@@ -385,7 +417,7 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
 	if startIndex != 0 && startIndex < endIndex {
-		s.history.observeRequiredWindow(endIndex - startIndex)
+		s.history.observeReplayWindow(startIndex, endIndex)
 	}
 	records := s.history.recordsBetween(startIndex, endIndex)
 	if len(records) == 0 {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -99,10 +99,6 @@ func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStre
 }
 
 func (s *regionSyncStream) getSendIndex() uint64 {
-	return s.getSendIndexLocked()
-}
-
-func (s *regionSyncStream) getSendIndexLocked() uint64 {
 	return s.sendIndex.Load()
 }
 
@@ -230,10 +226,6 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 	keepAliveTicker := time.NewTicker(syncerKeepAliveInterval)
 	shrinkTicker := time.NewTicker(historyBufferShrinkInterval)
 
-	processRegion := func(region *core.RegionInfo) {
-		records = append(records, region)
-	}
-
 	defer func() {
 		keepAliveTicker.Stop()
 		shrinkTicker.Stop()
@@ -254,12 +246,12 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 		case first := <-regionNotifier:
 			failpoint.InjectCall("syncRegionChannelFull")
 
-			processRegion(first)
+			records = append(records, first)
 		loop:
 			for range maxSyncRegionBatchSize {
 				select {
 				case region := <-regionNotifier:
-					processRegion(region)
+					records = append(records, region)
 				default:
 					break loop
 				}
@@ -627,7 +619,7 @@ func (s *RegionSyncer) sendDownstream(ctx context.Context, name string, stream *
 	}
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
-		StartIndex: stream.getSendIndexLocked(),
+		StartIndex: stream.getSendIndex(),
 	}
 	if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
 		return errors.Errorf("send region sync keepalive failed")
@@ -649,7 +641,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		}
 		s.mu.RUnlock()
 
-		sendIndex := stream.getSendIndexLocked()
+		sendIndex := stream.getSendIndex()
 		firstIndex := s.history.getFirstIndex()
 		if sendIndex < firstIndex {
 			return sentRecords, errors.Errorf("region syncer buffered records from index %d overflow, first available index is %d", sendIndex, firstIndex)

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -790,6 +790,38 @@ func TestAppendHistoryRecordsKeepsSlowestDownstreamWindow(t *testing.T) {
 	re.Equal(uint64(12), pd3SyncStream.getSendIndex())
 }
 
+func TestBindStreamWaitsForAppendHistoryRecordsBoundary(t *testing.T) {
+	re := require.New(t)
+	stream := &testServerStream{}
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{})
+	syncer.history = newTestHistoryBuffer(8)
+	syncer.history.resetWithIndex(10)
+	records := []*core.RegionInfo{
+		newTestRegion(1),
+		newTestRegion(2),
+		newTestRegion(3),
+	}
+
+	syncer.mu.RLock()
+	bindResultCh := make(chan uint64, 1)
+	go func() {
+		syncStream, syncStartIndex := syncer.bindStreamForSync("pd2", stream)
+		defer syncer.unbindStream("pd2", syncStream)
+		bindResultCh <- syncStartIndex
+	}()
+
+	select {
+	case <-bindResultCh:
+		re.Fail("bindStreamForSync should wait for the append history boundary")
+	case <-time.After(10 * time.Millisecond):
+	}
+	syncer.observeDownstreamReplayWindowLocked(uint64(len(records)))
+	syncer.history.record(records...)
+	syncer.mu.RUnlock()
+
+	re.Equal(uint64(13), <-bindResultCh)
+}
+
 func TestAppendHistoryRecordsDoesNotWaitForBusyDownstream(t *testing.T) {
 	re := require.New(t)
 	busySyncStream := newRegionSyncStream(&testServerStream{}, 10)

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -804,7 +804,9 @@ func TestBindStreamWaitsForAppendHistoryRecordsBoundary(t *testing.T) {
 
 	syncer.mu.RLock()
 	bindResultCh := make(chan uint64, 1)
+	bindDoneCh := make(chan struct{})
 	go func() {
+		defer close(bindDoneCh)
 		syncStream, syncStartIndex := syncer.bindStreamForSync("pd2", stream)
 		defer syncer.unbindStream("pd2", syncStream)
 		bindResultCh <- syncStartIndex
@@ -820,6 +822,7 @@ func TestBindStreamWaitsForAppendHistoryRecordsBoundary(t *testing.T) {
 	syncer.mu.RUnlock()
 
 	re.Equal(uint64(13), <-bindResultCh)
+	<-bindDoneCh
 }
 
 func TestAppendHistoryRecordsDoesNotWaitForBusyDownstream(t *testing.T) {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -590,7 +590,7 @@ func TestSendRegionSyncResponseSerializesStreamSendAfterTimeout(t *testing.T) {
 	closeSendDone := make(chan error, 1)
 	go func() {
 		close(closeSendStarted)
-		closeSendDone <- syncStream.send(&pdpb.SyncRegionResponse{
+		closeSendDone <- syncStream.sendStream(&pdpb.SyncRegionResponse{
 			Header: &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 		})
 	}()

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -853,9 +853,9 @@ func TestRemovedStreamDoesNotKeepHistoryWindow(t *testing.T) {
 
 	fastSyncStream.advanceSendIndex(3)
 	syncer.unbindStream("slow", slowSyncStream)
-	replayFrom, ok := syncer.minDownstreamSendIndex()
+	minIndex, ok := syncer.minDownstreamSendIndex()
 	re.True(ok)
-	re.Equal(uint64(15), replayFrom)
+	re.Equal(uint64(15), minIndex)
 	for range historyBufferShrinkRounds {
 		syncer.observeDownstreamReplayWindow()
 		syncer.history.maybeShrink()

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -764,10 +764,10 @@ func TestAppendHistoryRecordsKeepsSlowestDownstreamWindow(t *testing.T) {
 	})
 	syncer.history = newTestHistoryBuffer(8)
 	syncer.history.resetWithIndex(10)
-	syncer.history.recordBatch([]*core.RegionInfo{
+	syncer.history.record(
 		newTestRegion(1),
 		newTestRegion(2),
-	})
+	)
 
 	syncer.appendHistoryRecords([]*core.RegionInfo{
 		newTestRegion(3),
@@ -799,10 +799,10 @@ func TestAppendHistoryRecordsDoesNotWaitForBusyDownstream(t *testing.T) {
 	})
 	syncer.history = newTestHistoryBuffer(8)
 	syncer.history.resetWithIndex(10)
-	syncer.history.recordBatch([]*core.RegionInfo{
+	syncer.history.record(
 		newTestRegion(1),
 		newTestRegion(2),
-	})
+	)
 
 	done := make(chan struct{})
 	go func() {
@@ -840,10 +840,10 @@ func TestRemovedStreamDoesNotKeepHistoryWindow(t *testing.T) {
 	})
 	syncer.history = newTestHistoryBuffer(8)
 	syncer.history.resetWithIndex(10)
-	syncer.history.recordBatch([]*core.RegionInfo{
+	syncer.history.record(
 		newTestRegion(1),
 		newTestRegion(2),
-	})
+	)
 	syncer.appendHistoryRecords([]*core.RegionInfo{
 		newTestRegion(3),
 		newTestRegion(4),

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -666,7 +666,7 @@ func TestBroadcastUsesIndependentDownstreamIndexes(t *testing.T) {
 	records := []*core.RegionInfo{newTestRegion(1), newTestRegion(2)}
 	pd2SyncStream := newRegionSyncStream(pd2Stream, 10)
 	pd3SyncStream := newRegionSyncStream(pd3Stream, 10)
-	pd3SyncStream.advanceSendIndex(1)
+	pd3SyncStream.sendIndex.Add(1)
 	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
 		"pd2": pd2SyncStream,
 		"pd3": pd3SyncStream,
@@ -763,7 +763,7 @@ func TestAppendHistoryRecordsKeepsSlowestDownstreamWindow(t *testing.T) {
 	re := require.New(t)
 	pd2SyncStream := newRegionSyncStream(&testServerStream{}, 10)
 	pd3SyncStream := newRegionSyncStream(&testServerStream{}, 10)
-	pd3SyncStream.advanceSendIndex(2)
+	pd3SyncStream.sendIndex.Add(2)
 	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
 		"pd2": pd2SyncStream,
 		"pd3": pd3SyncStream,
@@ -892,7 +892,7 @@ func TestRemovedStreamDoesNotKeepHistoryWindow(t *testing.T) {
 	})
 	re.Equal(8, syncer.history.capacity())
 
-	fastSyncStream.advanceSendIndex(3)
+	fastSyncStream.sendIndex.Add(3)
 	syncer.unbindStream("slow", slowSyncStream)
 	minIndex, ok := syncer.minDownstreamSendIndex()
 	re.True(ok)

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -856,8 +856,8 @@ func TestRemovedStreamDoesNotKeepHistoryWindow(t *testing.T) {
 	minIndex, ok := syncer.minDownstreamSendIndex()
 	re.True(ok)
 	re.Equal(uint64(15), minIndex)
-	for range historyBufferShrinkRounds {
-		syncer.observeDownstreamReplayWindow()
+	for range historyBufferShrinkRounds + 1 {
+		syncer.observeDownstreamReplayWindow(0)
 		syncer.history.maybeShrink()
 	}
 

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -753,6 +753,145 @@ func TestBroadcastRecordsBusyDownstreamAndDrainsLater(t *testing.T) {
 	re.Equal(uint64(12), busySyncStream.getSendIndex())
 }
 
+func TestAppendHistoryRecordsKeepsSlowestDownstreamWindow(t *testing.T) {
+	re := require.New(t)
+	pd2SyncStream := newRegionSyncStream(&testServerStream{}, 10)
+	pd3SyncStream := newRegionSyncStream(&testServerStream{}, 10)
+	pd3SyncStream.advanceSendIndex(2)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": pd2SyncStream,
+		"pd3": pd3SyncStream,
+	})
+	syncer.history = newTestHistoryBuffer(8)
+	syncer.history.resetWithIndex(10)
+	syncer.history.recordBatch([]*core.RegionInfo{
+		newTestRegion(1),
+		newTestRegion(2),
+	})
+
+	syncer.appendHistoryRecords([]*core.RegionInfo{
+		newTestRegion(3),
+		newTestRegion(4),
+		newTestRegion(5),
+	})
+
+	records := syncer.history.recordsFrom(10)
+	re.Len(records, 5)
+	re.Equal(uint64(1), records[0].GetID())
+	re.Equal(uint64(5), records[4].GetID())
+	re.Equal(8, syncer.history.capacity())
+	re.Equal(uint64(10), pd2SyncStream.getSendIndex())
+	re.Equal(uint64(12), pd3SyncStream.getSendIndex())
+}
+
+func TestAppendHistoryRecordsDoesNotWaitForBusyDownstream(t *testing.T) {
+	re := require.New(t)
+	busySyncStream := newRegionSyncStream(&testServerStream{}, 10)
+	busySyncStream.sendMu.Lock()
+	busyLocked := true
+	defer func() {
+		if busyLocked {
+			busySyncStream.sendMu.Unlock()
+		}
+	}()
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": busySyncStream,
+	})
+	syncer.history = newTestHistoryBuffer(8)
+	syncer.history.resetWithIndex(10)
+	syncer.history.recordBatch([]*core.RegionInfo{
+		newTestRegion(1),
+		newTestRegion(2),
+	})
+
+	done := make(chan struct{})
+	go func() {
+		syncer.appendHistoryRecords([]*core.RegionInfo{
+			newTestRegion(3),
+			newTestRegion(4),
+			newTestRegion(5),
+		})
+		close(done)
+	}()
+
+	testutil.Eventually(re, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	})
+	records := syncer.history.recordsFrom(10)
+	re.Len(records, 5)
+	re.Equal(uint64(10), busySyncStream.getSendIndexLocked())
+
+	busySyncStream.sendMu.Unlock()
+	busyLocked = false
+}
+
+func TestRemovedStreamDoesNotKeepHistoryWindow(t *testing.T) {
+	re := require.New(t)
+	slowSyncStream := newRegionSyncStream(&testServerStream{}, 10)
+	fastSyncStream := newRegionSyncStream(&testServerStream{}, 12)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"slow": slowSyncStream,
+		"fast": fastSyncStream,
+	})
+	syncer.history = newTestHistoryBuffer(8)
+	syncer.history.resetWithIndex(10)
+	syncer.history.recordBatch([]*core.RegionInfo{
+		newTestRegion(1),
+		newTestRegion(2),
+	})
+	syncer.appendHistoryRecords([]*core.RegionInfo{
+		newTestRegion(3),
+		newTestRegion(4),
+		newTestRegion(5),
+	})
+	re.Equal(8, syncer.history.capacity())
+
+	fastSyncStream.advanceSendIndex(3)
+	syncer.unbindStream("slow", slowSyncStream)
+	replayFrom, ok := syncer.minDownstreamSendIndex()
+	re.True(ok)
+	re.Equal(uint64(15), replayFrom)
+	for range historyBufferShrinkRounds {
+		syncer.observeDownstreamReplayWindow()
+		syncer.history.maybeShrink()
+	}
+
+	re.Equal(4, syncer.history.capacity())
+	re.Equal(uint64(11), syncer.history.getFirstIndex())
+}
+
+func TestKeepAliveDoesNotPrecedePendingRecords(t *testing.T) {
+	re := require.New(t)
+	stream := &testServerStream{}
+	syncStream := newRegionSyncStream(stream, 10)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd2": syncStream,
+	})
+	syncer.history.resetWithIndex(10)
+	syncer.appendHistoryRecords([]*core.RegionInfo{
+		newTestRegion(1),
+		newTestRegion(2),
+	})
+
+	re.NoError(syncer.sendDownstream(context.Background(), "pd2", syncStream, true))
+	responses := stream.sentResponses()
+	re.Len(responses, 1)
+	re.Equal(uint64(10), responses[0].GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 1}, {Id: 2}}, responses[0].GetRegions())
+	re.Equal(uint64(12), syncStream.getSendIndex())
+
+	re.NoError(syncer.sendDownstream(context.Background(), "pd2", syncStream, true))
+	responses = stream.sentResponses()
+	re.Len(responses, 2)
+	re.Equal(uint64(12), responses[1].GetStartIndex())
+	re.Empty(responses[1].GetRegions())
+}
+
 func TestDrainDownstreamSendsPendingRecordsSerially(t *testing.T) {
 	re := require.New(t)
 	stream := &testServerStream{}

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -741,7 +741,7 @@ func TestBroadcastRecordsBusyDownstreamAndDrainsLater(t *testing.T) {
 	re.Equal(uint64(10), activeStream.lastResponse().GetStartIndex())
 	re.Equal(uint64(12), activeSyncStream.getSendIndex())
 	re.Nil(busyStream.lastResponse())
-	re.Equal(uint64(10), busySyncStream.getSendIndexLocked())
+	re.Equal(uint64(10), busySyncStream.getSendIndex())
 	re.Equal(records, syncer.history.recordsFrom(10))
 
 	busySyncStream.sendMu.Unlock()
@@ -824,7 +824,7 @@ func TestAppendHistoryRecordsDoesNotWaitForBusyDownstream(t *testing.T) {
 	})
 	records := syncer.history.recordsFrom(10)
 	re.Len(records, 5)
-	re.Equal(uint64(10), busySyncStream.getSendIndexLocked())
+	re.Equal(uint64(10), busySyncStream.getSendIndex())
 
 	busySyncStream.sendMu.Unlock()
 	busyLocked = false


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10734

Follow-up to #10716.

This PR builds on the RegionSyncer shared-history design merged in #10716. After each downstream stream only keeps its own send index, the shared leader history buffer needs to avoid overwriting records that a slow downstream still has not sent during live sync, not only during the one-time history-sync window.

### What is changed and how does it work?

```commit-message
Make the RegionSyncer history buffer account for downstream send progress.

Before appending live region records, the leader reserves enough shared history window for the slowest active downstream stream. The send index itself does not move the buffer first index; it only describes the earliest record still needed by active downstreams. Before shrinking, the leader observes the current downstream window again so shrink will not drop records still needed by a slow downstream.

The history buffer still keeps the base recent replay window for reconnect/history sync and still respects active full-sync retain points. The SyncRegions protocol is unchanged.
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved history retention and replay-window management so retained records aren’t overwritten; append capacity is reserved before recording and downstream windows are observed on shrink ticks.
  * Region batching now reserves history capacity for slow downstreams before recording and notifies downstreams after batching; downstream progress drives retention and windowing decisions.

* **Tests**
  * Added and revised tests validating reserve/observe window behavior, downstream-driven retention, and downstream drain/observe interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->