### PR TITLE
resource_group/controller: keep lim.last monotonic on token updates

### DIFF
--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/pingcap/failpoint"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 
 	"github.com/tikv/pd/client/errs"
@@ -391,4 +392,65 @@ func TestAcquireTokensFallbackToTimer(t *testing.T) {
 	re.True(errs.ErrClientResourceGroupThrottled.Equal(err))
 	// waitDuration should be roughly retryTimes * retryInterval.
 	re.GreaterOrEqual(waitDuration, gc.mainCfg.WaitRetryInterval*time.Duration(gc.mainCfg.WaitRetryTimes))
+}
+
+// TestAcquireTokensCancelKeepsLastMonotonic checks that a stale CancelAt does
+// not rewind lim.last, exercised through two concurrent acquireTokens calls
+// pinned by the waitReservationsBeforeSelect failpoint: A reserves
+// (lim.last = now_A) and parks; B advances lim.last to now_B (> now_A); A is
+// then cancelled so CancelAt runs with the stale now_A. lim.last must stay at
+// now_B, not rewind to now_A.
+func TestAcquireTokensCancelKeepsLastMonotonic(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	gc.mainCfg.LTBMaxWaitDuration = 30 * time.Second
+	gc.mainCfg.WaitRetryTimes = 1
+	counter := gc.run.requestUnitTokens
+
+	// Throttled bucket: a 10000-RU request reserves with a multi-second delay and
+	// parks in WaitReservations rather than being granted immediately.
+	counter.limiter.Reconfigure(time.Now(), tokenBucketReconfigureArgs{newTokens: 0, newFillRate: 1000, newBurst: 0})
+
+	const fp = "github.com/tikv/pd/client/resource_group/controller/waitReservationsBeforeSelect"
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	re.NoError(failpoint.EnableCall(fp, func() {
+		reached <- struct{}{}
+		<-release
+	}))
+	defer func() { re.NoError(failpoint.Disable(fp)) }()
+
+	// A reserves with a delay and parks at the hook. Only A reaches the hook;
+	// the allowDebt sibling B never enters WaitReservations.
+	ctxA, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	resultCh := make(chan error, 1)
+	go func() {
+		var wd time.Duration
+		_, err := gc.acquireTokens(ctxA, &rmpb.Consumption{RRU: 10000}, &wd, false)
+		resultCh <- err
+	}()
+
+	select {
+	case <-reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the request to reserve and park")
+	}
+	tMid := time.Now() // now_A < tMid <= now_B
+
+	// B advances lim.last to now_B via the allowDebt RemoveTokens path.
+	var wd time.Duration
+	_, err := gc.acquireTokens(context.Background(), &rmpb.Consumption{RRU: 1}, &wd, true)
+	re.NoError(err)
+
+	cancelA()
+	close(release)
+	select {
+	case err := <-resultCh:
+		re.Error(err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for acquireTokens to return")
+	}
+
+	re.False(counter.limiter.last.Before(tMid), "stale CancelAt rewound lim.last")
 }

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -202,7 +202,7 @@ func (r *Reservation) CancelAt(now time.Time) {
 	tokens += r.tokens
 
 	// update state
-	r.lim.last = now
+	r.lim.updateLast(now)
 	r.lim.tokens = tokens
 }
 
@@ -320,7 +320,7 @@ func (lim *Limiter) RemoveTokens(now time.Time, amount float64) {
 		return
 	}
 	_, tokens := lim.getTokens(now)
-	lim.last = now
+	lim.updateLast(now)
 	lim.tokens = tokens - amount
 	lim.maybeNotify()
 }
@@ -354,11 +354,11 @@ func (lim *Limiter) Reconfigure(now time.Time,
 		zap.Float64("old-notify-threshold", lim.notifyThreshold),
 		zap.Int64("old-burst", lim.burst))
 	if args.newBurst < 0 {
-		lim.last = now
+		lim.updateLast(now)
 		lim.tokens = args.newTokens
 	} else {
 		_, tokens := lim.getTokens(now)
-		lim.last = now
+		lim.updateLast(now)
 		lim.tokens = tokens + args.newTokens
 	}
 	lim.fillRate = fillRate(args.newFillRate)

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/client/errs"
@@ -553,6 +554,7 @@ func WaitReservations(ctx context.Context, now time.Time, reservations []*Reserv
 	if longestDelayDuration <= 0 {
 		return 0, nil
 	}
+	failpoint.InjectCall("waitReservationsBeforeSelect")
 	t := time.NewTimer(longestDelayDuration)
 	defer t.Stop()
 

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -139,32 +139,85 @@ func TestReconfig(t *testing.T) {
 	re.Equal(int64(-1), lim.GetBurst())
 }
 
-// TestLastStaysMonotonicOnStaleNow guards against a non-monotonic lim.last:
-// callers capture `now` before taking lim.mu, so under lock contention a
-// mutator can run with a `now` that is already older than lim.last. A raw
-// `lim.last = now` would rewind the clock and make the next getTokens
-// over-accrue tokens. The mutators must keep lim.last monotonic (updateLast),
-// matching reserveN (see issue #8435).
+// TestLastStaysMonotonicOnStaleNow guards the assumption used by
+// groupCostController.acquireTokens: callers capture now before entering the
+// limiter, so stale timestamps must not rewind the limiter's logical clock.
 func TestLastStaysMonotonicOnStaleNow(t *testing.T) {
-	re := require.New(t)
-	resetTime()
-	nc := make(chan notifyMsg, 1)
-	lim := NewLimiter(t0, 100, 0, 0, nc) // fillRate 100/s, burst 0 (no clamp)
+	tests := []struct {
+		name         string
+		mutate       func(lim *Limiter, r *Reservation, staleNow time.Time)
+		expectedPool float64
+		checkPool    bool
+	}{
+		{
+			name: "remove tokens",
+			mutate: func(lim *Limiter, _ *Reservation, staleNow time.Time) {
+				lim.RemoveTokens(staleNow, 0)
+			},
+			expectedPool: 1090,
+			checkPool:    true,
+		},
+		{
+			name: "cancel reservation",
+			mutate: func(_ *Limiter, r *Reservation, staleNow time.Time) {
+				r.CancelAt(staleNow)
+			},
+			expectedPool: 1100,
+			checkPool:    true,
+		},
+		{
+			name: "reconfigure",
+			mutate: func(lim *Limiter, _ *Reservation, staleNow time.Time) {
+				lim.Reconfigure(staleNow, tokenBucketReconfigureArgs{
+					newTokens:   10,
+					newFillRate: 100,
+				})
+			},
+			expectedPool: 1100,
+			checkPool:    true,
+		},
+		{
+			name: "reconfigure unlimited",
+			mutate: func(lim *Limiter, _ *Reservation, staleNow time.Time) {
+				lim.Reconfigure(staleNow, tokenBucketReconfigureArgs{
+					newTokens:   10,
+					newFillRate: 100,
+					newBurst:    -1,
+				})
+			},
+			checkPool: false,
+		},
+	}
 
-	// Advance last to t0+10s and leave pool = 100*10 - 10 = 990.
-	r := lim.reserveN(t0.Add(10*time.Second), 10, InfDuration)
-	re.True(r.reserved)
-	_, pool := lim.getTokens(t0.Add(10 * time.Second))
-	re.InDelta(990, pool, 1e-6)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := require.New(t)
+			resetTime()
+			nc := make(chan notifyMsg, 1)
+			lim := NewLimiter(t0, 100, 0, 0, nc) // fillRate 100/s, burst 0 (no clamp)
 
-	// A mutator runs with a STALE now (older than last). It must not rewind
-	// last. amount 0 isolates the clock effect.
-	lim.RemoveTokens(t0.Add(9*time.Second), 0)
+			advancedAt := t0.Add(10 * time.Second)
+			staleNow := t0.Add(9 * time.Second)
+			checkAt := t0.Add(11 * time.Second)
 
-	// Accrual over t0+10s..t0+11s is 1s*100 = 100, so pool == 1090.
-	// A rewound last (to t0+9s) would over-accrue to 1190.
-	_, pool = lim.getTokens(t0.Add(11 * time.Second))
-	re.InDelta(1090, pool, 1e-6)
+			// Advance last through the public API to t0+10s and leave pool =
+			// 100*10 - 10 = 990.
+			r := lim.Reserve(context.Background(), InfDuration, advancedAt, 10)
+			re.True(r.reserved)
+			_, pool := lim.getTokens(advancedAt)
+			re.InDelta(990, pool, 1e-6)
+
+			tt.mutate(lim, r, staleNow)
+			re.Equal(advancedAt, lim.last)
+
+			if tt.checkPool {
+				// Accrual over t0+10s..t0+11s is 1s*100 = 100. A rewound
+				// last (to t0+9s) would over-accrue by another 100 tokens.
+				_, pool = lim.getTokens(checkAt)
+				re.InDelta(tt.expectedPool, pool, 1e-6)
+			}
+		})
+	}
 }
 
 func TestNotify(t *testing.T) {

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -163,19 +163,7 @@ func TestLastStaysMonotonicOnStaleNow(t *testing.T) {
 			expectedPool: 1090,
 			checkPool:    true,
 		},
-		{
-			name: "cancel reservation",
-			// The cancelled reservation is the *own* request: it reserved at its
-			// own now (staleNow) before the sibling above advanced lim.last, so
-			// cancelling at staleNow is the realistic stale-now path (a flow
-			// never cancels earlier than its own reserve in a single goroutine).
-			mutate: func(lim *Limiter, _ *Reservation, staleNow time.Time) {
-				own := lim.Reserve(context.Background(), InfDuration, staleNow, 10)
-				own.CancelAt(staleNow)
-			},
-			expectedPool: 1090,
-			checkPool:    true,
-		},
+		// CancelAt is covered by TestAcquireTokensCancelKeepsLastMonotonic.
 		{
 			name: "reconfigure",
 			mutate: func(lim *Limiter, _ *Reservation, staleNow time.Time) {

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -139,6 +139,34 @@ func TestReconfig(t *testing.T) {
 	re.Equal(int64(-1), lim.GetBurst())
 }
 
+// TestLastStaysMonotonicOnStaleNow guards against a non-monotonic lim.last:
+// callers capture `now` before taking lim.mu, so under lock contention a
+// mutator can run with a `now` that is already older than lim.last. A raw
+// `lim.last = now` would rewind the clock and make the next getTokens
+// over-accrue tokens. The mutators must keep lim.last monotonic (updateLast),
+// matching reserveN (see issue #8435).
+func TestLastStaysMonotonicOnStaleNow(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	nc := make(chan notifyMsg, 1)
+	lim := NewLimiter(t0, 100, 0, 0, nc) // fillRate 100/s, burst 0 (no clamp)
+
+	// Advance last to t0+10s and leave pool = 100*10 - 10 = 990.
+	r := lim.reserveN(t0.Add(10*time.Second), 10, InfDuration)
+	re.True(r.reserved)
+	_, pool := lim.getTokens(t0.Add(10 * time.Second))
+	re.InDelta(990, pool, 1e-6)
+
+	// A mutator runs with a STALE now (older than last). It must not rewind
+	// last. amount 0 isolates the clock effect.
+	lim.RemoveTokens(t0.Add(9*time.Second), 0)
+
+	// Accrual over t0+10s..t0+11s is 1s*100 = 100, so pool == 1090.
+	// A rewound last (to t0+9s) would over-accrue to 1190.
+	_, pool = lim.getTokens(t0.Add(11 * time.Second))
+	re.InDelta(1090, pool, 1e-6)
+}
+
 func TestNotify(t *testing.T) {
 	nc := make(chan notifyMsg, 1)
 	lim := NewLimiter(t0, 1, 0, 0, nc)

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -140,8 +140,14 @@ func TestReconfig(t *testing.T) {
 }
 
 // TestLastStaysMonotonicOnStaleNow guards the assumption used by
-// groupCostController.acquireTokens: callers capture now before entering the
-// limiter, so stale timestamps must not rewind the limiter's logical clock.
+// groupCostController.acquireTokens: a mutator's now is captured before it
+// takes lim.mu, so under concurrency a sibling request on the same per-group
+// limiter can advance lim.last past that now. The stale (backward) now must
+// not rewind the limiter's logical clock.
+//
+// In every sub-case the shared Reserve below plays that concurrent sibling: it
+// advances lim.last to advancedAt, after which each mutator runs with the
+// earlier staleNow.
 func TestLastStaysMonotonicOnStaleNow(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -159,10 +165,15 @@ func TestLastStaysMonotonicOnStaleNow(t *testing.T) {
 		},
 		{
 			name: "cancel reservation",
-			mutate: func(_ *Limiter, r *Reservation, staleNow time.Time) {
-				r.CancelAt(staleNow)
+			// The cancelled reservation is the *own* request: it reserved at its
+			// own now (staleNow) before the sibling above advanced lim.last, so
+			// cancelling at staleNow is the realistic stale-now path (a flow
+			// never cancels earlier than its own reserve in a single goroutine).
+			mutate: func(lim *Limiter, _ *Reservation, staleNow time.Time) {
+				own := lim.Reserve(context.Background(), InfDuration, staleNow, 10)
+				own.CancelAt(staleNow)
 			},
-			expectedPool: 1100,
+			expectedPool: 1090,
 			checkPool:    true,
 		},
 		{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10744

The local token-bucket `Limiter` accrues tokens as
`lim.tokens + fillRate * (now - lim.last)`. `RemoveTokens`,
`(*Reservation).CancelAt` and `Reconfigure` persisted the clock with a raw
`lim.last = now`. Callers capture `now := time.Now()` *before* acquiring
`lim.mu`, so under lock contention a mutator can run with a `now` that is
already older than `lim.last` (another goroutine advanced it first). The raw
assignment then **rewinds `lim.last` backward**, and the next `getTokens`
computes an inflated `now - lim.last`, minting phantom tokens. Under sustained
concurrency the limiter accrues faster than its configured fill rate, weakening
rate limiting; the error scales with mutation frequency and lock contention.

`reserveN` already avoids this with the monotonic `updateLast` helper (issue
#8435); these methods did not.

### What is changed and how does it work?

Use `updateLast(now)` instead of the raw `lim.last = now` in `RemoveTokens`,
`CancelAt` and both branches of `Reconfigure`, so a stale/backward `now` never
rewinds the clock. When `now >= last` the behavior is identical to before.

Adds `TestLastStaysMonotonicOnStaleNow`: a reservation advances `last` to
`t+10s`; a mutator called with a stale `now = t+9s` must not rewind it, so
`getTokens(t+11s)` reads `1090` (accrue one second) rather than the buggy
`1190` (accrue from the rewound `t+9s`).

```commit-message
resource_group/controller: keep lim.last monotonic on token updates

RemoveTokens, (*Reservation).CancelAt and Reconfigure persisted the clock with
a raw `lim.last = now`, which can rewind lim.last under concurrent stale-now and
make getTokens over-accrue tokens. Use the monotonic updateLast helper, matching
reserveN (issue #8435). Adds a regression test.
```

### Check List

Tests

- Unit test

Side effects

- None

Release note

```release-note
Fix a token-bucket limiter bug where concurrent updates could rewind the
internal clock and over-accrue tokens, weakening resource-control rate limiting.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the rate limiter’s internal timestamp stays monotonic so cancellations or reconfigurations using stale times do not rewind time or cause token over‑accrual.

* **Tests**
  * Added concurrency tests validating timestamp monotonicity across reserve/cancel/remove/reconfigure scenarios and introduced a deterministic test hook to reproduce timing interleavings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->