### PR TITLE
owners: add ystaticy and AmoebaProtozoa as community reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,6 +12,8 @@ aliases:
     - howardlau1999
     - shafreeck
     - xhebox
+    - ystaticy
+    - AmoebaProtozoa
   sig-community-approvers:
     - AndreMouche
     - CabinfeverB


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10747

### What is changed and how does it work?

Add `ystaticy` and `AmoebaProtozoa` to `sig-community-reviewers` in `OWNERS_ALIASES`.

```commit-message
owners: add ystaticy and AmoebaProtozoa as community reviewers
```

### Check List

Tests

- No code

Code changes

- Has the configuration change

Side effects

- N/A

Related changes

- N/A

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the community reviewers group with additional members to support code review responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->