### PR TITLE
client: Expose service safe point v2 interfaces for legacy PD migration

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1172,7 +1172,7 @@ func (c *client) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint6
 // Deprecated: This API is deprecated and replaced by SetGCBarrier and DeleteGCBarrier.
 func (c *client) UpdateServiceGCSafePoint(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	if c.inner.keyspaceID != constants.NullKeyspaceID {
-		return c.updateServiceSafePointV2(ctx, c.inner.keyspaceID, serviceID, ttl, safePoint)
+		return c.UpdateServiceSafePointV2(ctx, c.inner.keyspaceID, serviceID, ttl, safePoint)
 	}
 
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -111,7 +111,6 @@ type RPCClient interface {
 	tso.Client
 	metastorage.Client
 	gc.Client
-	gc.LegacyClientV2
 	// KeyspaceClient manages keyspace metadata.
 	KeyspaceClient
 	// ResourceManagerClient manages resource group metadata and token assignment.

--- a/client/client.go
+++ b/client/client.go
@@ -111,6 +111,7 @@ type RPCClient interface {
 	tso.Client
 	metastorage.Client
 	gc.Client
+	gc.LegacyClientV2
 	// KeyspaceClient manages keyspace metadata.
 	KeyspaceClient
 	// ResourceManagerClient manages resource group metadata and token assignment.
@@ -1172,7 +1173,7 @@ func (c *client) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint6
 // Deprecated: This API is deprecated and replaced by SetGCBarrier and DeleteGCBarrier.
 func (c *client) UpdateServiceGCSafePoint(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	if c.inner.keyspaceID != constants.NullKeyspaceID {
-		return c.UpdateServiceSafePointV2(ctx, c.inner.keyspaceID, serviceID, ttl, safePoint)
+		return c.updateServiceSafePointV2(ctx, c.inner.keyspaceID, serviceID, ttl, safePoint)
 	}
 
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {

--- a/client/clients/gc/client.go
+++ b/client/clients/gc/client.go
@@ -378,8 +378,8 @@ func (s ClusterGCStates) GetGlobalGCBarriers() ([]*GlobalGCBarrierInfo, error) {
 // This interface is intentionally not added to RPCClient to avoid misuse or breaking existing stub and mock implementations.
 // Will be removed after the migration is done.
 type LegacyClientV2 interface {
-	// GetSafePointV2 returns the current minimum service GC safe point for the given keyspace.
-	GetSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error)
+	// GetMinServiceSafePointV2 returns the current minimum service GC safe point for the given keyspace.
+	GetMinServiceSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error)
 	// SetServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
 	SetServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error)
 	// DeleteServiceSafePointV2 deletes a service GC safe point for the given keyspace and returns the new minimum safe point.

--- a/client/clients/gc/client.go
+++ b/client/clients/gc/client.go
@@ -373,15 +373,15 @@ func (s ClusterGCStates) GetGlobalGCBarriers() ([]*GlobalGCBarrierInfo, error) {
 	return s.globalGCBarriers, nil
 }
 
-// LegacyClientV2 is the GC client interface for legacy PD servers.
-//
-// 2026.6.1 (pingyu): Add the interface to migrate legacy PD servers which do not support the "new GC API" for multi-tenant usage (e.g. TiCDC nextgen).
-// Remove after the migration is done.
+// LegacyClientV2 is the GC client interface for legacy PD servers using (old) GC API V2.
+// Used to migrate legacy PD servers which do not support the "new GC API" for multi-tenant usage (e.g. TiCDC nextgen).
+// This interface is intentionally not added to RPCClient to avoid misuse or breaking existing stub and mock implementations.
+// Will be removed after the migration is done.
 type LegacyClientV2 interface {
 	// GetSafePointV2 returns the current minimum service GC safe point for the given keyspace.
-	GetSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error)
-	// UpdateServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
-	UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error)
+	GetSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error)
+	// SetServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
+	SetServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error)
 	// DeleteServiceSafePointV2 deletes a service GC safe point for the given keyspace and returns the new minimum safe point.
 	DeleteServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string) (uint64, error)
 }

--- a/client/clients/gc/client.go
+++ b/client/clients/gc/client.go
@@ -372,3 +372,16 @@ func (s ClusterGCStates) GetGlobalGCBarriers() ([]*GlobalGCBarrierInfo, error) {
 	}
 	return s.globalGCBarriers, nil
 }
+
+// LegacyClientV2 is the GC client interface for legacy PD servers.
+//
+// 2026.6.1 (pingyu): Add the interface to migrate legacy PD servers which do not support the "new GC API" for multi-tenant usage (e.g. TiCDC nextgen).
+// Remove after the migration is done.
+type LegacyClientV2 interface {
+	// GetSafePointV2 returns the current minimum service GC safe point for the given keyspace.
+	GetSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error)
+	// UpdateServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
+	UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error)
+	// DeleteServiceSafePointV2 deletes a service GC safe point for the given keyspace and returns the new minimum safe point.
+	DeleteServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string) (uint64, error)
+}

--- a/client/gc_client.go
+++ b/client/gc_client.go
@@ -61,9 +61,12 @@ func (c *client) updateGCSafePointV2(ctx context.Context, keyspaceID uint32, saf
 	return resp.GetNewSafePoint(), nil
 }
 
-// updateServiceSafePointV2 update service safe point for the given keyspace.
+// UpdateServiceSafePointV2 update service safe point for the given keyspace.
 // Only used for handling `UpdateServiceGCSafePoint` in keyspace context, which is a deprecated usage.
-func (c *client) updateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+//
+// 2026.6.1 (pingyu): Make this method public to migrate legacy PD servers which do not support the "new GC API" for multi-tenant usage (e.g. TiCDC nextgen).
+// Should revert to private after the migration is done.
+func (c *client) UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span = span.Tracer().StartSpan("pdclient.UpdateServiceSafePointV2", opentracing.ChildOf(span.Context()))
 		defer span.Finish()

--- a/client/gc_client.go
+++ b/client/gc_client.go
@@ -65,7 +65,7 @@ func (c *client) updateGCSafePointV2(ctx context.Context, keyspaceID uint32, saf
 // Only used for handling `UpdateServiceGCSafePoint` in keyspace context, which is a deprecated usage.
 //
 // 2026.6.1 (pingyu): Make this method public to migrate legacy PD servers which do not support the "new GC API" for multi-tenant usage (e.g. TiCDC nextgen).
-// Should revert to private after the migration is done.
+// Revert to private after the migration is done.
 func (c *client) UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span = span.Tracer().StartSpan("pdclient.UpdateServiceSafePointV2", opentracing.ChildOf(span.Context()))

--- a/client/gc_client.go
+++ b/client/gc_client.go
@@ -450,12 +450,15 @@ func (c gcStatesClient) GetAllKeyspacesGCStates(ctx context.Context, opts ...gc.
 	return gc.NewClusterGCStatesWithGlobalGCBarriers(gcStates, globalGCBarriers), nil
 }
 
-// GetSafePointV2 returns the current minimum service GC safe point for the given keyspace.
-func (c *client) GetSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error) {
+// GetMinServiceSafePointV2 returns the current minimum service GC safe point for the given keyspace.
+func (c *client) GetMinServiceSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error) {
 	return c.updateServiceSafePointV2(ctx, keyspaceID, "", 0, 0)
 }
 
 // SetServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
+//
+// NOTE: Must check the returned new minimum safe point.
+// When it is smaller than the input safe point, it means the update is rejected because of the existing safe point exceeding the input safe point.
 func (c *client) SetServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	return c.updateServiceSafePointV2(ctx, keyspaceID, serviceID, ttl, safePoint)
 }

--- a/client/gc_client.go
+++ b/client/gc_client.go
@@ -61,12 +61,9 @@ func (c *client) updateGCSafePointV2(ctx context.Context, keyspaceID uint32, saf
 	return resp.GetNewSafePoint(), nil
 }
 
-// UpdateServiceSafePointV2 update service safe point for the given keyspace.
+// updateServiceSafePointV2 update service safe point for the given keyspace.
 // Only used for handling `UpdateServiceGCSafePoint` in keyspace context, which is a deprecated usage.
-//
-// 2026.6.1 (pingyu): Make this method public to migrate legacy PD servers which do not support the "new GC API" for multi-tenant usage (e.g. TiCDC nextgen).
-// Revert to private after the migration is done.
-func (c *client) UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+func (c *client) updateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span = span.Tracer().StartSpan("pdclient.UpdateServiceSafePointV2", opentracing.ChildOf(span.Context()))
 		defer span.Finish()
@@ -451,4 +448,19 @@ func (c gcStatesClient) GetAllKeyspacesGCStates(ctx context.Context, opts ...gc.
 		globalGCBarriers = append(globalGCBarriers, pbToGlobalGCBarrierInfo(barrier, start))
 	}
 	return gc.NewClusterGCStatesWithGlobalGCBarriers(gcStates, globalGCBarriers), nil
+}
+
+// GetSafePointV2 returns the current minimum service GC safe point for the given keyspace.
+func (c *client) GetSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+	return c.updateServiceSafePointV2(ctx, keyspaceID, "", 0, 0)
+}
+
+// UpdateServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
+func (c *client) UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+	return c.updateServiceSafePointV2(ctx, keyspaceID, serviceID, ttl, safePoint)
+}
+
+// DeleteServiceSafePointV2 deletes a service GC safe point for the given keyspace and returns the new minimum safe point.
+func (c *client) DeleteServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string) (uint64, error) {
+	return c.updateServiceSafePointV2(ctx, keyspaceID, serviceID, -1, 0)
 }

--- a/client/gc_client.go
+++ b/client/gc_client.go
@@ -451,19 +451,28 @@ func (c gcStatesClient) GetAllKeyspacesGCStates(ctx context.Context, opts ...gc.
 }
 
 // GetMinServiceSafePointV2 returns the current minimum service GC safe point for the given keyspace.
+//
+// The deprecated V2 API has no read-only "get minimum" RPC, so it reuses updateServiceSafePointV2.
+//   - serviceID = "get_min_ssp": Just a placeholder. Must be non-empty to pass the argument validation.
+//   - ttl = 1: to reach the GCStateManager.setGCBarrierImpl.
+//   - safePoint = 0: to make GCStateManager.setGCBarrierImpl return "ErrGCBarrierTSBehindTxnSafePoint", then GCStateManager.CompatibleUpdateServiceGCSafePoint return the TxnSafePoint.
+//     There is a corner case that if current TxnSafePoint is 0, this API will set a GC barrier with safe point 0 and ttl 1, which is low impact (last for 1 second) and do not break correctness.
 func (c *client) GetMinServiceSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error) {
-	return c.updateServiceSafePointV2(ctx, keyspaceID, "", 0, 0)
+	return c.updateServiceSafePointV2(ctx, keyspaceID, "get_min_ssp", 1, 0)
 }
 
 // SetServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
 //
-// NOTE: Must check the returned new minimum safe point.
-// When it is smaller than the input safe point, it means the update is rejected because of the existing safe point exceeding the input safe point.
+// NOTE: MUST check the returned new `MinSafePoint`.
+// When `MinSafePoint > input safe point`, it means the update is rejected because of the TxnSafePoint (or MinServiceSafePoint from legacy PD servers) already exceeds the input safe point.
 func (c *client) SetServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	return c.updateServiceSafePointV2(ctx, keyspaceID, serviceID, ttl, safePoint)
 }
 
 // DeleteServiceSafePointV2 deletes a service GC safe point for the given keyspace and returns the new minimum safe point.
+// Missing safe point with `serviceID` are no-op success, and return is still the current minimum safe point.
+//
+// * ttl = -1: to reach the GCStateManager.deleteGCBarrierImpl.
 func (c *client) DeleteServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string) (uint64, error) {
 	return c.updateServiceSafePointV2(ctx, keyspaceID, serviceID, -1, 0)
 }

--- a/client/gc_client.go
+++ b/client/gc_client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/client/clients/gc"
@@ -450,15 +451,17 @@ func (c gcStatesClient) GetAllKeyspacesGCStates(ctx context.Context, opts ...gc.
 	return gc.NewClusterGCStatesWithGlobalGCBarriers(gcStates, globalGCBarriers), nil
 }
 
+const reservedGetMinServiceSafePointServiceID = "_reserved_get_min_ssp"
+
 // GetMinServiceSafePointV2 returns the current minimum service GC safe point for the given keyspace.
 //
 // The deprecated V2 API has no read-only "get minimum" RPC, so it reuses updateServiceSafePointV2.
-//   - serviceID = "get_min_ssp": Just a placeholder. Must be non-empty to pass the argument validation.
+//   - serviceID = reservedGetMinServiceSafePointServiceID: Just a placeholder. Must be non-empty to pass the argument validation.
 //   - ttl = 1: to reach the GCStateManager.setGCBarrierImpl.
 //   - safePoint = 0: to make GCStateManager.setGCBarrierImpl return "ErrGCBarrierTSBehindTxnSafePoint", then GCStateManager.CompatibleUpdateServiceGCSafePoint return the TxnSafePoint.
 //     There is a corner case that if current TxnSafePoint is 0, this API will set a GC barrier with safe point 0 and ttl 1, which is low impact (last for 1 second) and do not break correctness.
 func (c *client) GetMinServiceSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error) {
-	return c.updateServiceSafePointV2(ctx, keyspaceID, "get_min_ssp", 1, 0)
+	return c.updateServiceSafePointV2(ctx, keyspaceID, reservedGetMinServiceSafePointServiceID, 1, 0)
 }
 
 // SetServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
@@ -466,6 +469,12 @@ func (c *client) GetMinServiceSafePointV2(ctx context.Context, keyspaceID uint32
 // NOTE: MUST check the returned new `MinSafePoint`.
 // When `MinSafePoint > input safe point`, it means the update is rejected because of the TxnSafePoint (or MinServiceSafePoint from legacy PD servers) already exceeds the input safe point.
 func (c *client) SetServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+	if ttl <= 0 {
+		return 0, errors.Errorf("[gc] invalid ttl %d. It should be positive", ttl)
+	}
+	if serviceID == reservedGetMinServiceSafePointServiceID {
+		return 0, errors.Errorf("[gc] invalid serviceID %q. It is reserved for GetMinServiceSafePointV2", serviceID)
+	}
 	return c.updateServiceSafePointV2(ctx, keyspaceID, serviceID, ttl, safePoint)
 }
 

--- a/client/gc_client.go
+++ b/client/gc_client.go
@@ -451,12 +451,12 @@ func (c gcStatesClient) GetAllKeyspacesGCStates(ctx context.Context, opts ...gc.
 }
 
 // GetSafePointV2 returns the current minimum service GC safe point for the given keyspace.
-func (c *client) GetSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+func (c *client) GetSafePointV2(ctx context.Context, keyspaceID uint32) (uint64, error) {
 	return c.updateServiceSafePointV2(ctx, keyspaceID, "", 0, 0)
 }
 
-// UpdateServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
-func (c *client) UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+// SetServiceSafePointV2 updates a service GC safe point for the given keyspace and returns the new minimum safe point.
+func (c *client) SetServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
 	return c.updateServiceSafePointV2(ctx, keyspaceID, serviceID, ttl, safePoint)
 }
 

--- a/tests/integrations/client/gc_test.go
+++ b/tests/integrations/client/gc_test.go
@@ -88,6 +88,20 @@ func TestServiceSafePointV2Operations(t *testing.T) {
 	re.Equal(uint64(10), minSafePoint)
 	re.Empty(getGCBarriers())
 
+	for _, ttl := range []int64{0, -1} {
+		minSafePoint, err = legacyClientV2.SetServiceSafePointV2(ctx, ks1.Id, "v2-service-safe-point", ttl, 20)
+		re.Error(err)
+		re.ErrorContains(err, "invalid ttl")
+		re.Equal(uint64(0), minSafePoint)
+	}
+	re.Empty(getGCBarriers())
+
+	minSafePoint, err = legacyClientV2.SetServiceSafePointV2(ctx, ks1.Id, "_reserved_get_min_ssp", 3600, 20)
+	re.Error(err)
+	re.ErrorContains(err, "reserved for GetMinServiceSafePointV2")
+	re.Equal(uint64(0), minSafePoint)
+	re.Empty(getGCBarriers())
+
 	// The safePoint < minSafePoint is rejected, and the returned minSafePoint is still 10.
 	minSafePoint, err = legacyClientV2.SetServiceSafePointV2(ctx, ks1.Id, "v2-service-safe-point", 3600, 5)
 	re.NoError(err)

--- a/tests/integrations/client/gc_test.go
+++ b/tests/integrations/client/gc_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	pd "github.com/tikv/pd/client"
+	clientgc "github.com/tikv/pd/client/clients/gc"
+	"github.com/tikv/pd/client/pkg/caller"
+	"github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/server/config"
+	"github.com/tikv/pd/tests"
+)
+
+func TestServiceSafePointV2Operations(t *testing.T) {
+	re := require.New(t)
+	ctx := t.Context()
+	cluster, err := tests.NewTestCluster(ctx, 1, func(conf *config.Config, _ string) {
+		conf.Keyspace.WaitRegionSplit = false
+	})
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+
+	leaderServer := cluster.GetLeaderServer()
+	re.NotNil(leaderServer)
+	re.NoError(leaderServer.BootstrapCluster())
+
+	ks1, err := leaderServer.GetKeyspaceManager().CreateKeyspace(&keyspace.CreateKeyspaceRequest{
+		Name:       "ks1",
+		Config:     map[string]string{keyspace.GCManagementType: keyspace.KeyspaceLevelGC},
+		CreateTime: time.Now().Unix(),
+	})
+	re.NoError(err)
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, leaderServer.GetAddr())
+	defer conn.Close()
+	header := testutil.NewRequestHeader(leaderServer.GetClusterID())
+
+	advanceTxnSafePointReq := &pdpb.AdvanceTxnSafePointRequest{
+		Header:        header,
+		KeyspaceScope: &pdpb.KeyspaceScope{KeyspaceId: ks1.Id},
+		Target:        10,
+	}
+	advanceTxnSafePointResp, err := grpcPDClient.AdvanceTxnSafePoint(ctx, advanceTxnSafePointReq)
+	re.NoError(err)
+	re.NotNil(advanceTxnSafePointResp.Header)
+	re.Nil(advanceTxnSafePointResp.Header.Error)
+	re.Equal(uint64(10), advanceTxnSafePointResp.GetNewTxnSafePoint())
+
+	cli, err := pd.NewClientWithContext(ctx, caller.TestComponent, []string{leaderServer.GetAddr()}, pd.SecurityOption{})
+	re.NoError(err)
+	defer cli.Close()
+	legacyClientV2, ok := cli.(clientgc.LegacyClientV2)
+	re.True(ok)
+	gcStatesClient := cli.GetGCStatesClient(ks1.Id)
+	getGCBarriers := func() []*clientgc.GCBarrierInfo {
+		gcState, err := gcStatesClient.GetGCState(ctx, clientgc.ExcludeGCBarriers(false))
+		re.NoError(err)
+		re.Equal(ks1.Id, gcState.KeyspaceID)
+		gcBarriers, err := gcState.GetGCBarriers()
+		re.NoError(err)
+		return gcBarriers
+	}
+
+	minSafePoint, err := legacyClientV2.GetMinServiceSafePointV2(ctx, ks1.Id)
+	re.NoError(err)
+	re.Equal(uint64(10), minSafePoint)
+	re.Empty(getGCBarriers())
+
+	// The safePoint < minSafePoint is rejected, and the returned minSafePoint is still 10.
+	minSafePoint, err = legacyClientV2.SetServiceSafePointV2(ctx, ks1.Id, "v2-service-safe-point", 3600, 5)
+	re.NoError(err)
+	re.Equal(uint64(10), minSafePoint)
+	gcBarriers := getGCBarriers()
+	re.Empty(gcBarriers)
+
+	minSafePoint, err = legacyClientV2.SetServiceSafePointV2(ctx, ks1.Id, "v2-service-safe-point", 3600, 20)
+	re.NoError(err)
+	re.Equal(uint64(10), minSafePoint)
+	gcBarriers = getGCBarriers()
+	re.Len(gcBarriers, 1)
+	re.Equal("v2-service-safe-point", gcBarriers[0].BarrierID)
+	re.Equal(uint64(20), gcBarriers[0].BarrierTS)
+	re.Greater(gcBarriers[0].TTL, 3595*time.Second)
+	re.LessOrEqual(gcBarriers[0].TTL, 3600*time.Second)
+
+	minSafePoint, err = legacyClientV2.DeleteServiceSafePointV2(ctx, ks1.Id, "v2-service-safe-point")
+	re.NoError(err)
+	re.Equal(uint64(10), minSafePoint)
+	re.Empty(getGCBarriers())
+}


### PR DESCRIPTION
### What problem does this PR solve?

Legacy PD migration flows that still rely on the older GC behavior do not have a public keyspace-aware client API for updating service safe points directly.

Issue Number: close #10750

### What is changed and how does it work?

```commit-message
client: Expose service safe point v2 interfaces for legacy PD migration.
```

Usage:

```go
import (
	pd "github.com/tikv/pd/client"
	pdgc "github.com/tikv/pd/client/clients/gc"
)


pdClient, err := pd.NewClientWithContext(...)
...
...
legacyCli, ok := pdClient.(pdgc.LegacyClientV2)
if !ok {
	...
}

legacyCli.GetSafePointV2(...) / legacyCli.SetServiceSafePointV2(...) / legacyCli.DeleteServiceSafePointV2(...)
```

### Check List

Tests

#### Manual test (with PD-CSE)

##### Get

```bash
➜  bin/pd-gc-legacy --pd http://x.x.x.x:40379 get 10
{
  "keyspace_id": 10,
  "min_safe_point": 466691421721329664
}
➜  scripts etcdctl --endpoints http://x.x.x.x:40379 get --prefix /pd/7646250026545686026/keyspaces
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/gc_worker
{"keyspace_id":10,"service_id":"gc_worker","expired_at":9223372036854775807,"safe_point":466691421721329664}
```

##### Reject stale safe point

```bash
➜  bin/pd-gc-legacy --pd http://x.x.x.x:40379 update 10 cdc-ssp 10 466691421721329663
{
  "keyspace_id": 10,
  "service_id": "cdc-ssp",
  "ttl": 10,
  "safe_point": 466691421721329663,
  "min_safe_point": 466691421721329664
}
➜  scripts etcdctl --endpoints http://x.x.x.x:40379 get --prefix /pd/7646250026545686026/keyspaces
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/gc_worker
{"keyspace_id":10,"service_id":"gc_worker","expired_at":9223372036854775807,"safe_point":466691421721329664}
```

##### Set

```bash
➜  bin/pd-gc-legacy --pd http://x.x.x.x:40379 update 10 cdc-ssp 10 466691421721329665
{
  "keyspace_id": 10,
  "service_id": "cdc-ssp",
  "ttl": 10,
  "safe_point": 466691421721329665,
  "min_safe_point": 466691421721329664
}
➜  scripts etcdctl --endpoints http://x.x.x.x:40379 get --prefix /pd/7646250026545686026/keyspaces
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/cdc-ssp
{"keyspace_id":10,"service_id":"cdc-ssp","expired_at":1780288567,"safe_point":466691421721329665}
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/gc_worker
{"keyspace_id":10,"service_id":"gc_worker","expired_at":9223372036854775807,"safe_point":466691421721329664}
```

##### TTL expire (Run get to make server remove the expired service safe point)

```bash
➜  bin/pd-gc-legacy --pd http://x.x.x.x:40379 get 10
{
  "keyspace_id": 10,
  "min_safe_point": 466691421721329664
}
➜  etcdctl --endpoints http://x.x.x.x:40379 get --prefix /pd/7646250026545686026/keyspaces
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/gc_worker
{"keyspace_id":10,"service_id":"gc_worker","expired_at":9223372036854775807,"safe_point":466691421721329664}
```

##### Set again, then Remove

```bash
➜  bin/pd-gc-legacy --pd http://x.x.x.x:40379 update 10 cdc-ssp 600 466691421721329665
{
  "keyspace_id": 10,
  "service_id": "cdc-ssp",
  "ttl": 600,
  "safe_point": 466691421721329665,
  "min_safe_point": 466691421721329664
}
➜  etcdctl --endpoints http://x.x.x.x:40379 get --prefix /pd/7646250026545686026/keyspaces
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/cdc-ssp
{"keyspace_id":10,"service_id":"cdc-ssp","expired_at":1780288567,"safe_point":466691421721329665}
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/gc_worker
{"keyspace_id":10,"service_id":"gc_worker","expired_at":9223372036854775807,"safe_point":466691421721329664}
➜  bin/pd-gc-legacy --pd http://x.x.x.x:40379 remove 10 cdc-ssp
{
  "keyspace_id": 10,
  "service_id": "cdc-ssp",
  "min_safe_point": 466691421721329664
}
➜  etcdctl --endpoints http://x.x.x.x:40379 get --prefix /pd/7646250026545686026/keyspaces
/pd/7646250026545686026/keyspaces/service_safe_point/00000010/gc_worker
{"keyspace_id":10,"service_id":"gc_worker","expired_at":9223372036854775807,"safe_point":466691421721329664}
```

### Release note

```release-note
client: Expose service safe point v2 interfaces for legacy PD migration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operations to manage service garbage-collection safe points: read the current minimum, set per-service safe points with TTL (with input validation), and delete per-service safe points.
  * Exposed a legacy client interface providing the new V2 service safe-point operations.
* **Tests**
  * Added an integration test validating V2 service safe-point flows: read/min checks, invalid inputs, setting above/below minimum, barrier creation and TTL bounds, and deletion clearing barriers.
* **Chores**
  * Added a build target for a new gc-legacy tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->