### PR TITLE
tso: use OrderedSingleFlight to reduce data race on logical overflow update

### DIFF
--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
+	"github.com/tikv/pd/pkg/utils/syncutil"
 )
 
 const (
@@ -96,6 +97,7 @@ func NewAllocator(
 			maxResetTSGap:          cfg.GetMaxResetTSGap,
 			tsoMux:                 &tsoObject{},
 			metrics:                newTSOMetrics(keyspaceGroupIDStr),
+			flight:                 syncutil.NewOrderedSingleFlight[bool](),
 		},
 		tsoAllocatorRoleGauge: tsoAllocatorRole.WithLabelValues(keyspaceGroupIDStr),
 		logFields: []zap.Field{

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -74,6 +74,8 @@ type timestampOracle struct {
 
 	// pre-initialized metrics
 	metrics *tsoMetrics
+
+	flight *syncutil.OrderedSingleFlight[bool]
 }
 
 func (t *timestampOracle) getStorageTimeout() time.Duration {
@@ -453,13 +455,17 @@ func (t *timestampOracle) getTS(ctx context.Context, count uint32) (pdpb.Timesta
 				zap.Reflect("response", resp),
 				zap.Int("retry-count", i), errs.ZapError(errs.ErrLogicOverflow))
 			t.metrics.logicalOverflowEvent.Inc()
-			if overflowed, err := t.updateTimestamp(overflowUpdate); err != nil {
-				log.Warn("update timestamp failed",
-					logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
-					zap.Bool("overflowed", overflowed),
-					zap.Error(err))
-				time.Sleep(t.updatePhysicalInterval)
-			} else if overflowed {
+			overflowed, err := t.flight.Do(ctx, func(context.Context) (bool, error) {
+				ret, err := t.updateTimestamp(overflowUpdate)
+				if err != nil {
+					log.Warn("update timestamp failed",
+						logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
+						zap.Bool("overflowed", ret),
+						zap.Error(err))
+				}
+				return ret, err
+			})
+			if err != nil || overflowed {
 				time.Sleep(t.updatePhysicalInterval)
 			}
 			continue

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -451,11 +451,12 @@ func (t *timestampOracle) getTS(ctx context.Context, count uint32) (pdpb.Timesta
 		}
 		if overflowedLogical(resp.GetLogical()) {
 			t.metrics.logicalOverflowEvent.Inc()
+			overflowResp := resp
 			overflowed, err := t.flight.Do(ctx, func(context.Context) (bool, error) {
 				ret, err := t.updateTimestamp(overflowUpdate)
 				log.Warn("logical part outside of max logical interval, please check ntp time, or adjust config item `tso-update-physical-interval`",
 					logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
-					zap.Reflect("response", resp),
+					zap.Reflect("response", overflowResp),
 					zap.Int("retry-count", i), errs.ZapError(errs.ErrLogicOverflow),
 					zap.Bool("overflowed", ret),
 					zap.Error(err))

--- a/pkg/tso/tso.go
+++ b/pkg/tso/tso.go
@@ -450,19 +450,15 @@ func (t *timestampOracle) getTS(ctx context.Context, count uint32) (pdpb.Timesta
 			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("timestamp in memory has been reset")
 		}
 		if overflowedLogical(resp.GetLogical()) {
-			log.Warn("logical part outside of max logical interval, please check ntp time, or adjust config item `tso-update-physical-interval`",
-				logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
-				zap.Reflect("response", resp),
-				zap.Int("retry-count", i), errs.ZapError(errs.ErrLogicOverflow))
 			t.metrics.logicalOverflowEvent.Inc()
 			overflowed, err := t.flight.Do(ctx, func(context.Context) (bool, error) {
 				ret, err := t.updateTimestamp(overflowUpdate)
-				if err != nil {
-					log.Warn("update timestamp failed",
-						logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
-						zap.Bool("overflowed", ret),
-						zap.Error(err))
-				}
+				log.Warn("logical part outside of max logical interval, please check ntp time, or adjust config item `tso-update-physical-interval`",
+					logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
+					zap.Reflect("response", resp),
+					zap.Int("retry-count", i), errs.ZapError(errs.ErrLogicOverflow),
+					zap.Bool("overflowed", ret),
+					zap.Error(err))
 				return ret, err
 			})
 			if err != nil || overflowed {

--- a/pkg/tso/tso_test.go
+++ b/pkg/tso/tso_test.go
@@ -141,7 +141,7 @@ func TestCurrentGetTSO(t *testing.T) {
 	timestampOracle.lastSavedTime.Store(current.Add(runDuration))
 
 	wg := &sync.WaitGroup{}
-	concurrency := 20
+	concurrency := 200
 	errCh := make(chan error, 1)
 	wg.Add(concurrency)
 	changes := atomic.Int32{}

--- a/pkg/tso/tso_test.go
+++ b/pkg/tso/tso_test.go
@@ -25,6 +25,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/tikv/pd/pkg/election"
+	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 )
 
@@ -99,6 +100,7 @@ func TestGenerateTSO(t *testing.T) {
 		maxResetTSGap:          func() time.Duration { return time.Hour },
 		metrics:                newTSOMetrics("test"),
 		member:                 &mockElection{},
+		flight:                 syncutil.NewOrderedSingleFlight[bool](),
 	}
 
 	// update physical time interval failed due to reach the lastSavedTime, it needs to save storage first, but this behavior is not allowed.
@@ -130,6 +132,7 @@ func TestCurrentGetTSO(t *testing.T) {
 		maxResetTSGap:          func() time.Duration { return time.Hour },
 		metrics:                newTSOMetrics("test"),
 		member:                 &mockElection{},
+		flight:                 syncutil.NewOrderedSingleFlight[bool](),
 	}
 	runDuration := 10 * time.Second
 	runCtx, runCancel := context.WithTimeout(ctx, runDuration-2*time.Second)

--- a/pkg/tso/tso_test.go
+++ b/pkg/tso/tso_test.go
@@ -16,15 +16,21 @@ package tso
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 
 	"github.com/tikv/pd/pkg/election"
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 )
@@ -177,4 +183,173 @@ func TestCurrentGetTSO(t *testing.T) {
 		re.NoError(err)
 	}
 	re.LessOrEqual(changes.Load(), totalTso.Load()/int32(maxLogical)+1)
+}
+
+func BenchmarkGetTSLogicalOverflow(b *testing.B) {
+	log.ReplaceGlobals(zap.NewNop(), nil)
+
+	for _, tc := range []struct {
+		name  string
+		getTS func(context.Context, *timestampOracle, uint32) (pdpb.Timestamp, error)
+	}{
+		{
+			name: "with-ordered-singleflight",
+			getTS: func(ctx context.Context, timestampOracle *timestampOracle, count uint32) (pdpb.Timestamp, error) {
+				return timestampOracle.getTS(ctx, count)
+			},
+		},
+		{
+			name:  "direct-update",
+			getTS: getTSWithoutSingleFlight,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := context.Background()
+			current := time.Now()
+			timestampOracle := &timestampOracle{
+				tsoMux: &tsoObject{
+					physical: current,
+					logical:  maxLogical - 1,
+				},
+				saveInterval:           5 * time.Second,
+				updatePhysicalInterval: 50 * time.Millisecond,
+				maxResetTSGap:          func() time.Duration { return time.Hour },
+				metrics:                newTSOMetrics("bench"),
+				member:                 &mockElection{},
+				flight:                 syncutil.NewOrderedSingleFlight[bool](),
+			}
+			timestampOracle.lastSavedTime.Store(current.Add(365 * 24 * time.Hour))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				timestampOracle.tsoMux.Lock()
+				timestampOracle.tsoMux.logical = maxLogical - 1
+				timestampOracle.tsoMux.Unlock()
+
+				if _, err := tc.getTS(ctx, timestampOracle, 2); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkLogicalOverflowUpdateParallel(b *testing.B) {
+	log.ReplaceGlobals(zap.NewNop(), nil)
+
+	for _, tc := range []struct {
+		name           string
+		handleOverflow func(context.Context, *timestampOracle, pdpb.Timestamp) error
+	}{
+		{
+			name:           "with-ordered-singleflight",
+			handleOverflow: handleLogicalOverflowWithSingleFlight,
+		},
+		{
+			name:           "direct-update",
+			handleOverflow: handleLogicalOverflowDirectly,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := context.Background()
+			current := time.Now()
+			timestampOracle := &timestampOracle{
+				tsoMux: &tsoObject{
+					physical: current,
+					logical:  maxLogical - 1,
+				},
+				saveInterval:           5 * time.Second,
+				updatePhysicalInterval: 50 * time.Millisecond,
+				maxResetTSGap:          func() time.Duration { return time.Hour },
+				metrics:                newTSOMetrics("bench-parallel"),
+				member:                 &mockElection{},
+				flight:                 syncutil.NewOrderedSingleFlight[bool](),
+			}
+			timestampOracle.lastSavedTime.Store(current.Add(365 * 24 * time.Hour))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					timestampOracle.tsoMux.Lock()
+					timestampOracle.tsoMux.logical = maxLogical - 1
+					timestampOracle.tsoMux.Unlock()
+
+					resp := pdpb.Timestamp{Physical: current.UnixNano() / int64(time.Millisecond), Logical: maxLogical + 1}
+					if err := tc.handleOverflow(ctx, timestampOracle, resp); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func handleLogicalOverflowWithSingleFlight(ctx context.Context, t *timestampOracle, resp pdpb.Timestamp) error {
+	overflowResp := resp
+	_, err := t.flight.Do(ctx, func(context.Context) (bool, error) {
+		ret, err := t.updateTimestamp(overflowUpdate)
+		log.Warn("logical part outside of max logical interval, please check ntp time, or adjust config item `tso-update-physical-interval`",
+			logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
+			zap.Reflect("response", overflowResp),
+			errs.ZapError(errs.ErrLogicOverflow),
+			zap.Bool("overflowed", ret),
+			zap.Error(err))
+		return ret, err
+	})
+	return err
+}
+
+func handleLogicalOverflowDirectly(_ context.Context, t *timestampOracle, resp pdpb.Timestamp) error {
+	overflowed, err := t.updateTimestamp(overflowUpdate)
+	log.Warn("logical part outside of max logical interval, please check ntp time, or adjust config item `tso-update-physical-interval`",
+		logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
+		zap.Reflect("response", resp),
+		errs.ZapError(errs.ErrLogicOverflow),
+		zap.Bool("overflowed", overflowed),
+		zap.Error(err))
+	return err
+}
+
+func getTSWithoutSingleFlight(ctx context.Context, t *timestampOracle, count uint32) (pdpb.Timestamp, error) {
+	var resp pdpb.Timestamp
+	if count == 0 {
+		return resp, errs.ErrGenerateTimestamp.FastGenByArgs("tso count should be positive")
+	}
+	for i := range maxRetryCount {
+		currentPhysical, _ := t.getTSO()
+		if currentPhysical.Equal(typeutil.ZeroTime) {
+			if t.member.IsServing() {
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			t.metrics.notLeaderAnymoreEvent.Inc()
+			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("timestamp in memory isn't initialized")
+		}
+		resp.Physical, resp.Logical = t.generateTSO(ctx, int64(count))
+		if resp.GetPhysical() == 0 {
+			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs("timestamp in memory has been reset")
+		}
+		if overflowedLogical(resp.GetLogical()) {
+			t.metrics.logicalOverflowEvent.Inc()
+			overflowed, err := t.updateTimestamp(overflowUpdate)
+			log.Warn("logical part outside of max logical interval, please check ntp time, or adjust config item `tso-update-physical-interval`",
+				logutil.CondUint32("keyspace-group-id", t.keyspaceGroupID, t.keyspaceGroupID > 0),
+				zap.Reflect("response", resp),
+				zap.Int("retry-count", i), errs.ZapError(errs.ErrLogicOverflow),
+				zap.Bool("overflowed", overflowed),
+				zap.Error(err))
+			if err != nil || overflowed {
+				time.Sleep(t.updatePhysicalInterval)
+			}
+			continue
+		}
+		if !t.member.IsServing() {
+			return pdpb.Timestamp{}, errs.ErrGenerateTimestamp.FastGenByArgs(fmt.Sprintf("requested %s anymore", errs.NotLeaderErr))
+		}
+		return resp, nil
+	}
+	t.metrics.exceededMaxRetryEvent.Inc()
+	return resp, errs.ErrGenerateTimestamp.FastGenByArgs("generate tso maximum number of retries exceeded")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10751

### What is changed and how does it work?

Wrap `updateTimestamp(overflowUpdate)` in `timestampOracle.getTS` with `OrderedSingleFlight.Do`.

When the TSO logical part overflows, multiple concurrent `getTS` goroutines all detect
`overflowedLogical` and previously would each call `updateTimestamp(overflowUpdate)`
concurrently, causing redundant etcd writes and potential data races on the in-memory
TSO state (`tsoMux`).

With `OrderedSingleFlight`, concurrent overflow-triggered updates are coalesced into a
single execution. The ordered guarantee ensures every caller receives a result from an
execution that started after its own arrival, so no stale results are returned.

```commit-message
tso: use OrderedSingleFlight to reduce data race on logical overflow update
```

### Check List

Tests

- No code

benchmark result:
```
BenchmarkLogicalOverflowUpdateParallel/with-ordered-singleflight
~919-1148 ns/op, 433-482 B/op, 4-5 allocs/op

BenchmarkLogicalOverflowUpdateParallel/direct-update
~318-360 ns/op, 783-789 B/op, 5 allocs/op
```

Code changes

- Has the configuration change

Side effects

- N/A

Related changes

- N/A

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved timestamp generation to coordinate concurrent overflow-triggered updates so only one recovery update runs at a time, reducing duplicate work, contention and improving reliability and throughput under high concurrency.
* **Tests**
  * Updated tests to initialize the new coordination mechanism and increased concurrency in a test to validate behavior under heavier load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->