### PR TITLE
server: lower missing bucket store log level

### DIFF
--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -214,7 +214,7 @@ func (s *Service) RegionBuckets(stream schedulingpb.Scheduling_RegionBucketsServ
 		if store == nil {
 			// As TiKV report buckets just after the region heartbeat, for new created region, PD may receive buckets report before the first region heartbeat is handled.
 			// So we should not return error here.
-			log.Warn("the store of the bucket in region is not found ", zap.Uint64("region-id", buckets.GetRegionId()))
+			log.Debug("the store of the bucket in region is not found", zap.Uint64("region-id", buckets.GetRegionId()))
 		} else {
 			storeLabel = strconv.FormatUint(store.GetID(), 10)
 			storeAddress = store.GetAddress()

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1152,7 +1152,7 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 		if store == nil {
 			// As TiKV report buckets just after the region heartbeat, for new created region, PD may receive buckets report before the first region heartbeat is handled.
 			// So we should not return error here.
-			log.Warn("the store of the bucket in region is not found ", zap.Uint64("region-id", buckets.GetRegionId()))
+			log.Debug("the store of the bucket in region is not found", zap.Uint64("region-id", buckets.GetRegionId()))
 		} else {
 			storeLabel = strconv.FormatUint(store.GetID(), 10)
 			storeAddress = store.GetAddress()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4399 

Bucket reports may arrive before the corresponding region heartbeat has been handled, so the leader store can be temporarily unavailable. This case is already tolerated by continuing the stream, but warn-level logs can create noise for an expected transient condition.

### What is changed and how does it work?

```commit-message
Lower the log level from warn to debug when bucket reports cannot find
the leader store in both PD and scheduling service gRPC handlers.

Normalize the log message by removing the trailing space.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging levels for improved operational clarity during edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->