### PR TITLE
keyspace: fix missing slices.Sort in UpdateKeyspaceGroup

### DIFF
--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -17,6 +17,7 @@ package keyspace
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -594,6 +595,7 @@ func (m *GroupManager) UpdateKeyspaceGroup(oldGroupID, newGroupID string, oldUse
 	var updateOld, updateNew bool
 	if !slice.Contains(newKG.Keyspaces, keyspaceID) {
 		newKG.Keyspaces = append(newKG.Keyspaces, keyspaceID)
+		slices.Sort(newKG.Keyspaces)
 		updateNew = true
 	}
 
@@ -606,6 +608,7 @@ func (m *GroupManager) UpdateKeyspaceGroup(oldGroupID, newGroupID string, oldUse
 	if err := m.saveKeyspaceGroups([]*endpoint.KeyspaceGroup{oldKG, newKG}, true); err != nil {
 		if updateOld {
 			oldKG.Keyspaces = append(oldKG.Keyspaces, keyspaceID)
+			slices.Sort(oldKG.Keyspaces)
 		}
 		if updateNew {
 			newKG.Keyspaces = slice.Remove(newKG.Keyspaces, keyspaceID)

--- a/pkg/keyspace/tso_keyspace_group_test.go
+++ b/pkg/keyspace/tso_keyspace_group_test.go
@@ -298,6 +298,53 @@ func (suite *keyspaceGroupTestSuite) TestUpdateKeyspaceGroupRollbackOnSaveError(
 	re.Equal([]uint32{222}, storedNew.Keyspaces)
 }
 
+// TestUpdateKeyspaceGroupRollbackRestoresSortedOrder verifies that when
+// saveKeyspaceGroups fails the rollback at line 610 (slices.Sort) correctly
+// restores oldKG.Keyspaces to sorted order.
+// The existing TestUpdateKeyspaceGroupRollbackOnSaveError only uses a single-element
+// oldKG.Keyspaces, so sorting is a no-op there and does not cover this path.
+func (suite *keyspaceGroupTestSuite) TestUpdateKeyspaceGroupRollbackRestoresSortedOrder() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	errorStore := &errorKeyspaceGroupStorage{StorageEndpoint: store}
+	kgm := NewKeyspaceGroupManager(ctx, errorStore, nil)
+	re.NoError(kgm.Bootstrap(ctx))
+
+	// oldKG has multiple keyspaces so that after Remove + append the slice is
+	// temporarily out of order ([100, 300, 222]) and needs Sort to be restored.
+	keyspaceID := uint32(222)
+	keyspaceGroups := []*endpoint.KeyspaceGroup{
+		{
+			ID:        uint32(1),
+			UserKind:  endpoint.Standard.String(),
+			Keyspaces: []uint32{100, keyspaceID, 300},
+		},
+		{
+			ID:        uint32(2),
+			UserKind:  endpoint.Standard.String(),
+			Keyspaces: []uint32{10, 500},
+		},
+	}
+	re.NoError(kgm.CreateKeyspaceGroups(keyspaceGroups))
+
+	errorStore.failOnSaveID = 2
+	err := kgm.UpdateKeyspaceGroup("1", "2", endpoint.Standard, endpoint.Standard, keyspaceID)
+	re.ErrorIs(err, errSaveKeyspaceGroup)
+
+	// After rollback oldKG.Keyspaces must be sorted back to [100, 222, 300].
+	// Without the slices.Sort on line 610 it would be [100, 300, 222].
+	oldKG := kgm.groups[endpoint.Standard].Get(1)
+	re.NotNil(oldKG)
+	re.Equal([]uint32{100, keyspaceID, 300}, oldKG.Keyspaces)
+
+	newKG := kgm.groups[endpoint.Standard].Get(2)
+	re.NotNil(newKG)
+	re.Equal([]uint32{10, 500}, newKG.Keyspaces)
+}
+
 func (suite *keyspaceGroupTestSuite) TestKeyspaceGroupSplit() {
 	re := suite.Require()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10757

### What is changed and how does it work?

`UpdateKeyspaceGroup` missed `slices.Sort` in two places:

1. **Rollback path**: on `saveKeyspaceGroups` failure, `keyspaceID` is appended
   back to `oldKG.Keyspaces` but the slice is not re-sorted, leaving it out of
   order for source groups with more than one keyspace.
2. **Success path**: `keyspaceID` is appended to `newKG.Keyspaces` without
   sorting.

Both paths now call `slices.Sort` after the append.
A new test `TestUpdateKeyspaceGroupRollbackRestoresSortedOrder` covers the
rollback sort path with a multi-element source group (the existing test used a
single-element group, making sort a no-op there).

```commit-message
Fix two missing slices.Sort calls in UpdateKeyspaceGroup:
- Rollback path: sort oldKG.Keyspaces after appending keyspaceID back on save failure.
- Success path: sort newKG.Keyspaces after appending keyspaceID.

Add TestUpdateKeyspaceGroupRollbackRestoresSortedOrder to cover the rollback
sort with a multi-element source group.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix `UpdateKeyspaceGroup` leaving keyspace group `Keyspaces` slices unsorted
after a move or a failed-save rollback.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent ordering of keyspace groups during updates to improve data reliability.

* **Tests**
  * Added test coverage for keyspace group rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->