### PR TITLE
resource_manager: reflow future reservations

### DIFF
--- a/client/resource_group/controller/config.go
+++ b/client/resource_group/controller/config.go
@@ -37,7 +37,8 @@ const (
 	// targetPeriod indicate how long it is expected to cost token when acquiring token.
 	// According to the resource control Grafana panel and Prometheus sampling period, the period should be the factor of 15.
 	defaultTargetPeriod = 5 * time.Second
-	// defaultMaxWaitDuration is the max duration to wait for the token before throwing error.
+	// defaultMaxWaitDuration is the maximum predicted wait allowed at initial
+	// token reservation. Accepted reservations may wait longer after reflow.
 	defaultMaxWaitDuration = 30 * time.Second
 	// defaultLTBTokenRPCMaxDelay is the upper bound of backoff delay for local token bucket RPC.
 	defaultLTBTokenRPCMaxDelay = 1 * time.Second
@@ -90,7 +91,9 @@ type BaseConfig struct {
 	// EnableDegradedMode is to control whether resource control client enable degraded mode when server is disconnect.
 	DegradedModeWaitDuration Duration `toml:"degraded-mode-wait-duration" json:"degraded-mode-wait-duration"`
 
-	// LTBMaxWaitDuration is the max wait time duration for local token bucket.
+	// LTBMaxWaitDuration is the maximum predicted wait accepted when initially
+	// reserving from the local token bucket. Accepted reservations may wait
+	// longer after reflow; callers provide a context deadline for a hard bound.
 	LTBMaxWaitDuration Duration `toml:"ltb-max-wait-duration" json:"ltb-max-wait-duration"`
 
 	// LTBTokenRPCMaxDelay is the upper bound of backoff delay for local token bucket RPC.

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -108,7 +108,10 @@ func EnableSingleGroupByKeyspace() ResourceControlCreateOption {
 	}
 }
 
-// WithMaxWaitDuration is the option to set the max wait duration for acquiring token buckets.
+// WithMaxWaitDuration sets the maximum predicted wait accepted when a request
+// first reserves tokens. A reservation accepted within this limit keeps its
+// queue position if later limiter changes extend its actual wait; callers that
+// need an end-to-end hard deadline should set one on the request context.
 func WithMaxWaitDuration(d time.Duration) ResourceControlCreateOption {
 	return func(controller *ResourceGroupsController) {
 		controller.ruConfig.LTBMaxWaitDuration = d

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -581,7 +581,7 @@ retryLoop:
 		counter := gc.run.requestUnitTokens
 		reconfiguredCh := counter.limiter.GetReconfiguredCh()
 		now := time.Now()
-		var res *Reservation
+		d, err = 0, nil
 		if v := getRUValueFromConsumption(delta); v > 0 {
 			// record the consume token histogram if enable controller debug mode.
 			if enableControllerTraceLog.Load() {
@@ -592,9 +592,9 @@ retryLoop:
 				counter.limiter.RemoveTokens(now, v)
 				break retryLoop
 			}
-			res = counter.limiter.Reserve(ctx, gc.mainCfg.LTBMaxWaitDuration, now, v)
+			d, err = counter.limiter.waitN(ctx, gc.mainCfg.LTBMaxWaitDuration, now, v)
 		}
-		if d, err = WaitReservations(ctx, now, []*Reservation{res}); err == nil || errs.ErrClientResourceGroupThrottled.NotEqual(err) {
+		if err == nil || errs.ErrClientResourceGroupThrottled.NotEqual(err) {
 			break retryLoop
 		}
 		gc.metrics.requestRetryCounter.Inc()

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -1145,6 +1145,52 @@ func TestAcquireTokensFallbackToTimer(t *testing.T) {
 	re.GreaterOrEqual(waitDuration, gc.mainCfg.WaitRetryInterval*time.Duration(gc.mainCfg.WaitRetryTimes))
 }
 
+func TestAcquireTokensAcceptedReservationIsPulledForwardByRefund(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	gc.mainCfg.LTBMaxWaitDuration = 2 * time.Second
+	gc.mainCfg.WaitRetryTimes = 1
+	limiter := gc.run.requestUnitTokens.limiter
+	now := time.Now()
+	limiter.Reconfigure(now, tokenBucketReconfigureArgs{newBurst: -1})
+	limiter.Reconfigure(now, tokenBucketReconfigureArgs{
+		newTokens:   0,
+		newFillRate: 1000,
+		newBurst:    0,
+	})
+
+	const fp = "github.com/tikv/pd/client/resource_group/controller/waitReservationsBeforeSelect"
+	reached := make(chan struct{}, 1)
+	re.NoError(failpoint.EnableCall(fp, func() {
+		select {
+		case reached <- struct{}{}:
+		default:
+		}
+	}))
+	defer func() { re.NoError(failpoint.Disable(fp)) }()
+
+	resultCh := make(chan error, 1)
+	go func() {
+		var waitDuration time.Duration
+		_, err := gc.acquireTokens(context.Background(), &rmpb.Consumption{RRU: 1000}, &waitDuration, false)
+		resultCh <- err
+	}()
+
+	select {
+	case <-reached:
+	case <-time.After(time.Second):
+		t.Fatal("acquireTokens did not start waiting for its accepted reservation")
+	}
+
+	limiter.RefundTokens(time.Now(), 1000)
+	select {
+	case err := <-resultCh:
+		re.NoError(err)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("refund did not pull forward the accepted acquireTokens reservation")
+	}
+}
+
 // TestAcquireTokensCancelKeepsLastMonotonic checks that a stale CancelAt does
 // not rewind lim.last, exercised through two concurrent acquireTokens calls
 // pinned by the waitReservationsBeforeSelect failpoint: A reserves

--- a/client/resource_group/controller/limiter.go
+++ b/client/resource_group/controller/limiter.go
@@ -92,6 +92,16 @@ type Limiter struct {
 	// goroutines waiting in acquireTokens() retry loops.
 	reconfiguredCh chan struct{}
 
+	// queuedHead and queuedTail track the dynamically scheduled reservations
+	// used by the resource-control request path. Public Reservations remain
+	// fixed tickets and are never added to this queue.
+	queuedHead *queuedReservation
+	queuedTail *queuedReservation
+	// queuedUpdateCh is replaced whenever a queued reservation's schedule or
+	// state changes. All dynamic waiters share it so a mutation needs one wakeup
+	// broadcast rather than one channel allocation per reservation.
+	queuedUpdateCh chan struct{}
+
 	// metrics
 	metrics *limiterMetricsCollection
 }
@@ -198,21 +208,25 @@ func (r *Reservation) CancelAt(now time.Time) {
 	if r.tokens == 0 || r.lim.burst < 0 || r.lim.fillRate == Inf {
 		return
 	}
-	_, tokens := r.lim.getTokens(now)
+	effectiveNow := r.lim.effectiveNowLocked(now)
+	_, tokens := r.lim.getTokens(effectiveNow)
 	// calculate new number of tokens
 	tokens += r.tokens
 
 	// update state
-	r.lim.updateLast(now)
+	r.lim.updateLast(effectiveNow)
 	r.lim.tokens = tokens
+	r.lim.reflowQueuedReservationsLocked(r.lim.last)
 }
 
 // Reserve returns a Reservation that indicates how long the caller must wait before n events happen.
 // The Limiter takes this Reservation into account when allowing future events.
 // The returned Reservation's Reserved() method returns false if wait duration exceeds deadline.
+// Its scheduled action time is fixed when Reserve returns; later token or
+// configuration changes do not rewrite the Reservation.
 // Usage example:
 //
-//	r := lim.Reserve(time.Now(), 1)
+//	r := lim.Reserve(context.Background(), time.Second, time.Now(), 1)
 //	if !r.Reserved() {
 //	  // Not allowed to act! Did you remember to set lim.burst to be > 0 ?
 //	  return
@@ -320,28 +334,39 @@ func (lim *Limiter) RemoveTokens(now time.Time, amount float64) {
 	if lim.burst < 0 || lim.fillRate == Inf {
 		return
 	}
-	_, tokens := lim.getTokens(now)
-	lim.updateLast(now)
+	effectiveNow := lim.effectiveNowLocked(now)
+	_, tokens := lim.getTokens(effectiveNow)
+	lim.updateLast(effectiveNow)
 	lim.tokens = tokens - amount
+	lim.reflowQueuedReservationsLocked(lim.last)
 	lim.maybeNotify()
 }
 
 // RefundTokens adds tokens back to the limiter.
 //
-// Token overshoot above burst is intentional here: getTokens clamps the
-// value on the next call, so RefundTokens never permanently leaks past
-// the burst cap. maybeNotify is intentionally not called either —
-// refunding can only raise the token count, never push the limiter into
-// the low-token state.
+// Without queued reservations, token overshoot above burst is intentional:
+// getTokens clamps the value on the next call. Reflowing queued reservations
+// preserves credit already committed to them; a later admission clamps any
+// unused positive balance.
+// maybeNotify is intentionally not called because refunding cannot push the
+// limiter into the low-token state.
 func (lim *Limiter) RefundTokens(now time.Time, amount float64) {
 	lim.mu.Lock()
 	defer lim.mu.Unlock()
 	if lim.burst < 0 || lim.fillRate == Inf {
 		return
 	}
-	_, tokens := lim.getTokens(now)
-	lim.updateLast(now)
+	effectiveNow := lim.effectiveNowLocked(now)
+	_, tokens := lim.getTokens(effectiveNow)
+	lim.updateLast(effectiveNow)
 	lim.tokens = tokens + amount
+	lim.reflowQueuedReservationsLocked(lim.last)
+	// Reflow first so accepted reservations keep their FIFO priority, then wake
+	// retry loops whose initial admission may now succeed with the refund.
+	if lim.reconfiguredCh != nil {
+		close(lim.reconfiguredCh)
+		lim.reconfiguredCh = nil
+	}
 }
 
 type tokenBucketReconfigureArgs struct {
@@ -372,12 +397,18 @@ func (lim *Limiter) Reconfigure(now time.Time,
 		zap.Float64("old-rate", float64(lim.fillRate)),
 		zap.Float64("old-notify-threshold", lim.notifyThreshold),
 		zap.Int64("old-burst", lim.burst))
+	effectiveNow := lim.effectiveNowLocked(now)
+	if lim.admitDueQueuedReservationsLocked(effectiveNow) {
+		lim.signalQueuedUpdateLocked()
+	}
 	if args.newBurst < 0 {
-		lim.updateLast(now)
-		lim.tokens = args.newTokens
+		lim.updateLast(effectiveNow)
+		// reflowQueuedReservationsLocked restores pending debits before it
+		// admits the whole queue under the unlimited configuration.
+		lim.tokens = args.newTokens - lim.queuedTokensLocked()
 	} else {
-		_, tokens := lim.getTokens(now)
-		lim.updateLast(now)
+		_, tokens := lim.getTokens(effectiveNow)
+		lim.updateLast(effectiveNow)
 		lim.tokens = tokens + args.newTokens
 	}
 	lim.fillRate = fillRate(args.newFillRate)
@@ -386,6 +417,7 @@ func (lim *Limiter) Reconfigure(now time.Time,
 	for _, opt := range opts {
 		opt(lim)
 	}
+	lim.reflowQueuedReservationsLocked(lim.last)
 	lim.maybeNotify()
 	// Wake up all goroutines waiting in acquireTokens retry loops.
 	if lim.reconfiguredCh != nil {
@@ -405,6 +437,31 @@ func (lim *Limiter) AvailableTokens(now time.Time) float64 {
 	defer lim.mu.Unlock()
 	_, tokens := lim.getTokens(now)
 	return tokens
+}
+
+func (lim *Limiter) onReservationRejectedLocked(
+	last time.Time, waitDuration, waitLimit time.Duration, tokensToReserve float64,
+) {
+	if time.Since(lim.last) > reserveWarnLogInterval {
+		log.Warn("[resource group controller] cannot reserve enough tokens",
+			zap.Duration("need-wait-duration", waitDuration),
+			zap.Duration("max-wait-duration", waitLimit),
+			zap.Float64("current-ltb-tokens", lim.tokens),
+			zap.Float64("current-ltb-rate", float64(lim.fillRate)),
+			zap.Float64("request-tokens", tokensToReserve),
+			zap.Float64("notify-threshold", lim.notifyThreshold),
+			zap.Bool("is-low-process", lim.isLowProcess),
+			zap.Int64("burst", lim.burst),
+			zap.Int("remaining-notify-times", lim.remainingNotifyTimes),
+			zap.String("name", lim.name))
+	}
+	lim.updateLast(last)
+	if lim.fillRate == 0 {
+		lim.notify()
+	} else if lim.remainingNotifyTimes > 0 {
+		lim.remainingNotifyTimes--
+		lim.notify()
+	}
 }
 
 func (lim *Limiter) updateLast(t time.Time) {
@@ -463,30 +520,7 @@ func (lim *Limiter) reserveN(now time.Time, n float64, maxFutureReserve time.Dur
 		lim.tokens = tokens
 		lim.maybeNotify()
 	} else {
-		// print log if the limiter cannot reserve for a while.
-		if time.Since(lim.last) > reserveWarnLogInterval {
-			log.Warn("[resource group controller] cannot reserve enough tokens",
-				zap.Duration("need-wait-duration", waitDuration),
-				zap.Duration("max-wait-duration", maxFutureReserve),
-				zap.Float64("current-ltb-tokens", lim.tokens),
-				zap.Float64("current-ltb-rate", float64(lim.fillRate)),
-				zap.Float64("request-tokens", n),
-				zap.Float64("notify-threshold", lim.notifyThreshold),
-				zap.Bool("is-low-process", lim.isLowProcess),
-				zap.Int64("burst", lim.burst),
-				zap.Int("remaining-notify-times", lim.remainingNotifyTimes),
-				zap.String("name", lim.name))
-		}
-		lim.updateLast(last)
-		if lim.fillRate == 0 {
-			lim.notify()
-		} else if lim.remainingNotifyTimes > 0 {
-			// When fillrate is greater than 0, the speed limit is already set.
-			// If limiter are in limit state, the server has allocated tokens as much as possible. Don't need to request tokens.
-			// But there is a special case, see issue https://github.com/tikv/pd/issues/6300.
-			lim.remainingNotifyTimes--
-			lim.notify()
-		}
+		lim.onReservationRejectedLocked(last, waitDuration, maxFutureReserve, n)
 	}
 	return r
 }
@@ -549,7 +583,9 @@ func WaitReservations(ctx context.Context, now time.Time, reservations []*Reserv
 	}
 	cancel := func() {
 		for _, res := range reservations {
-			res.CancelAt(now)
+			if res != nil {
+				res.CancelAt(now)
+			}
 		}
 	}
 	longestDelayDuration := time.Duration(0)
@@ -562,10 +598,10 @@ func WaitReservations(ctx context.Context, now time.Time, reservations []*Reserv
 			if res.err != nil {
 				return res.needWaitDuration, res.err
 			}
-			return res.needWaitDuration, errs.ErrClientResourceGroupThrottled.FastGenByArgs(res.needWaitDuration, res.fillRate, res.remainingTokens)
+			return res.needWaitDuration, errs.ErrClientResourceGroupThrottled.FastGenByArgs(
+				res.needWaitDuration, res.fillRate, res.remainingTokens)
 		}
-		delay := res.DelayFrom(now)
-		if delay > longestDelayDuration {
+		if delay := res.DelayFrom(now); delay > longestDelayDuration {
 			longestDelayDuration = delay
 		}
 	}
@@ -573,16 +609,13 @@ func WaitReservations(ctx context.Context, now time.Time, reservations []*Reserv
 		return 0, nil
 	}
 	failpoint.InjectCall("waitReservationsBeforeSelect")
-	t := time.NewTimer(longestDelayDuration)
-	defer t.Stop()
+	timer := time.NewTimer(longestDelayDuration)
+	defer timer.Stop()
 
 	select {
-	case <-t.C:
-		// We can proceed.
+	case <-timer.C:
 		return longestDelayDuration, nil
 	case <-ctx.Done():
-		// Context was canceled before we could proceed.  Cancel the
-		// reservation, which may permit other events to proceed sooner.
 		cancel()
 		return 0, ctx.Err()
 	}

--- a/client/resource_group/controller/limiter_bench_test.go
+++ b/client/resource_group/controller/limiter_bench_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+var queuedReservationBenchmarkDepths = []int{1, 10, 100, 1000, 10000}
+
+func BenchmarkQueuedReservationRefundRemoveCycle(b *testing.B) {
+	for _, depth := range queuedReservationBenchmarkDepths {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			lim, now := newBenchmarkLimiterWithQueue(b, depth)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				lim.RefundTokens(now, 1)
+				lim.RemoveTokens(now, 1)
+			}
+		})
+	}
+}
+
+func BenchmarkQueuedReservationReconfigureCycle(b *testing.B) {
+	for _, depth := range queuedReservationBenchmarkDepths {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			lim, now := newBenchmarkLimiterWithQueue(b, depth)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				lim.Reconfigure(now, tokenBucketReconfigureArgs{newFillRate: 1_000_001})
+				lim.Reconfigure(now, tokenBucketReconfigureArgs{newFillRate: 1_000_000})
+			}
+		})
+	}
+}
+
+func BenchmarkQueuedReservationCancelAndReplace(b *testing.B) {
+	for _, depth := range queuedReservationBenchmarkDepths {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			lim, now := newBenchmarkLimiterWithQueue(b, depth)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				lim.mu.Lock()
+				reservation := lim.queuedHead
+				lim.mu.Unlock()
+				if !reservation.cancelAt(now) {
+					b.Fatal("queued reservation was not canceled")
+				}
+				if replacement := lim.reserveQueued(context.Background(), InfDuration, now, 1_000_000); replacement.state != queuedReservationWaiting {
+					b.Fatalf("replacement reservation state is %d", replacement.state)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkQueuedReservationBroadcastAndTimerRearm measures the scheduler,
+// mutex, and timer-allocation amplification caused by closing the shared queue
+// generation channel. The workers mirror the relevant part of
+// queuedReservation.wait without requiring a production-only benchmark hook.
+func BenchmarkQueuedReservationBroadcastAndTimerRearm(b *testing.B) {
+	for _, depth := range queuedReservationBenchmarkDepths {
+		b.Run(fmt.Sprintf("waiters=%d", depth), func(b *testing.B) {
+			lim := NewLimiter(time.Now(), 1, 0, 0, make(chan notifyMsg, 1))
+			ackCh := make(chan struct{}, depth)
+			stopCh := make(chan struct{})
+			var ready sync.WaitGroup
+			var stopped sync.WaitGroup
+			ready.Add(depth)
+			stopped.Add(depth)
+			for range depth {
+				go func() {
+					defer stopped.Done()
+					lim.mu.Lock()
+					updateCh := lim.queuedUpdateChannelLocked()
+					lim.mu.Unlock()
+					timer := time.NewTimer(time.Hour)
+					ready.Done()
+					for {
+						select {
+						case <-updateCh:
+							stopAndDrainTimer(timer)
+							lim.mu.Lock()
+							updateCh = lim.queuedUpdateChannelLocked()
+							lim.mu.Unlock()
+							timer = time.NewTimer(time.Hour)
+							ackCh <- struct{}{}
+						case <-stopCh:
+							stopAndDrainTimer(timer)
+							return
+						}
+					}
+				}()
+			}
+			ready.Wait()
+			b.Cleanup(func() {
+				close(stopCh)
+				stopped.Wait()
+			})
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				lim.mu.Lock()
+				lim.signalQueuedUpdateLocked()
+				lim.mu.Unlock()
+				for range depth {
+					<-ackCh
+				}
+			}
+		})
+	}
+}
+
+func newBenchmarkLimiterWithQueue(b *testing.B, depth int) (*Limiter, time.Time) {
+	b.Helper()
+	now := time.Unix(1_700_000_000, 0)
+	lim := NewLimiter(now, 1_000_000, 0, 0, make(chan notifyMsg, 1))
+	for range depth {
+		reservation := lim.reserveQueued(context.Background(), InfDuration, now, 1_000_000)
+		if reservation.state != queuedReservationWaiting {
+			b.Fatalf("reservation state is %d", reservation.state)
+		}
+	}
+	return lim, now
+}
+
+func stopAndDrainTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/client/resource_group/controller/limiter_test.go
+++ b/client/resource_group/controller/limiter_test.go
@@ -28,6 +28,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/failpoint"
+
+	"github.com/tikv/pd/client/errs"
 )
 
 const (
@@ -261,6 +265,19 @@ func TestRefundTokens(t *testing.T) {
 	checkTokens(re, limUnlimited, t0, 100)
 }
 
+func TestRefundTokensWakesAcquireRetry(t *testing.T) {
+	lim := NewLimiter(t0, 0, 0, 100, make(chan notifyMsg, 1))
+	reconfiguredCh := lim.GetReconfiguredCh()
+
+	lim.RefundTokens(t0, 50)
+
+	select {
+	case <-reconfiguredCh:
+	default:
+		t.Fatal("RefundTokens should wake acquireTokens retry loops after reflowing accepted reservations")
+	}
+}
+
 func TestNotify(t *testing.T) {
 	nc := make(chan notifyMsg, 1)
 	lim := NewLimiter(t0, 1, 0, 0, nc)
@@ -421,6 +438,626 @@ func TestReconfiguredChWakesMultipleWaiters(t *testing.T) {
 	wg.Wait()
 
 	require.Len(t, wokenUp, numWaiters)
+}
+
+func TestReservationDelayRemainsFixedAfterLimiterMutations(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	reservation := lim.Reserve(context.Background(), InfDuration, t0, 500)
+
+	re.True(reservation.Reserved())
+	re.Equal(5*time.Second, reservation.DelayFrom(t0))
+
+	lim.RemoveTokens(t1, 500)
+	re.Equal(4*time.Second, reservation.DelayFrom(t1))
+
+	lim.RefundTokens(t1, 1000)
+	re.Equal(4*time.Second, reservation.DelayFrom(t1))
+
+	lim.Reconfigure(t1, tokenBucketReconfigureArgs{
+		newTokens:   1000,
+		newFillRate: 1000,
+	})
+	re.Equal(4*time.Second, reservation.DelayFrom(t1))
+}
+
+func TestWaitNRefundPullsForwardAcceptedReservation(t *testing.T) {
+	re := require.New(t)
+	now := time.Now()
+	lim := NewLimiter(now, 1000, 0, 0, make(chan notifyMsg, 1))
+
+	const fp = "github.com/tikv/pd/client/resource_group/controller/waitReservationsBeforeSelect"
+	reached := make(chan struct{}, 1)
+	re.NoError(failpoint.EnableCall(fp, func() {
+		select {
+		case reached <- struct{}{}:
+		default:
+		}
+	}))
+	defer func() { re.NoError(failpoint.Disable(fp)) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := lim.waitN(ctx, time.Second, now, 1000)
+		resultCh <- err
+	}()
+
+	select {
+	case <-reached:
+	case <-time.After(time.Second):
+		t.Fatal("waitN did not start waiting for the accepted reservation")
+	}
+
+	lim.RefundTokens(time.Now(), 1000)
+	select {
+	case err := <-resultCh:
+		re.NoError(err)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("refund did not pull forward and wake the accepted reservation")
+	}
+}
+
+func TestQueuedReservationsWithFixedFillRateAreSequenced(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	lim := NewLimiter(t0, 5000, 0, 0, make(chan notifyMsg, 1))
+
+	const (
+		requestRU  = 1000
+		requestCnt = 10
+	)
+	expectedInterval := time.Duration(float64(time.Second) * requestRU / 5000)
+	var previous time.Time
+	for i := range requestCnt {
+		reservation := lim.reserveQueued(context.Background(), InfDuration, t0, requestRU)
+		re.Equal(queuedReservationWaiting, reservation.state)
+		expected := t0.Add(time.Duration(i+1) * expectedInterval)
+		re.Equal(expected, reservation.timeToAct)
+		if i > 0 {
+			re.False(reservation.timeToAct.Before(previous))
+			re.Equal(expectedInterval, reservation.timeToAct.Sub(previous))
+		}
+		previous = reservation.timeToAct
+	}
+}
+
+func TestReconfigureReflowsQueuedReservations(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	ctx := context.Background()
+
+	oldReservations := make([]*queuedReservation, 3)
+	for i := range oldReservations {
+		oldReservations[i] = lim.reserveQueued(ctx, InfDuration, t0, 1000)
+		re.Equal(queuedReservationWaiting, oldReservations[i].state)
+	}
+	re.Equal(t0.Add(10*time.Second), oldReservations[0].timeToAct)
+	re.Equal(t0.Add(20*time.Second), oldReservations[1].timeToAct)
+	re.Equal(t0.Add(30*time.Second), oldReservations[2].timeToAct)
+
+	lim.Reconfigure(t1, tokenBucketReconfigureArgs{
+		newTokens:   5000,
+		newFillRate: 1000,
+	})
+
+	for i := range oldReservations {
+		re.Zero(queuedDelayFrom(oldReservations[i], t1),
+			"existing sleeping reservations should be reflowed after Reconfigure")
+	}
+
+	newReservation := lim.reserveQueued(ctx, InfDuration, t1, 1000)
+	re.Equal(queuedReservationReady, newReservation.state)
+	re.Equal(t1, newReservation.timeToAct)
+	re.False(newReservation.timeToAct.Before(oldReservations[0].timeToAct),
+		"new reservations must not slip ahead of old sleepers after Reconfigure")
+}
+
+func TestReconfigureWakesQueuedReservationWaiter(t *testing.T) {
+	re := require.New(t)
+	now := time.Now()
+	lim := NewLimiter(now, 1000, 0, 0, make(chan notifyMsg, 1))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	reservation := lim.reserveQueued(ctx, time.Second, now, 1000)
+	re.Equal(queuedReservationWaiting, reservation.state)
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := reservation.wait(ctx)
+		resultCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	lim.Reconfigure(now.Add(20*time.Millisecond), tokenBucketReconfigureArgs{
+		newTokens:   1000,
+		newFillRate: 1000,
+	})
+
+	select {
+	case err := <-resultCh:
+		re.NoError(err)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("reconfigure should reflow and wake the existing future reservation")
+	}
+}
+
+func TestReconfigureToUnlimitedWakesQueuedReservationWaiter(t *testing.T) {
+	re := require.New(t)
+	now := time.Now()
+	lim := NewLimiter(now, 1000, 0, 0, make(chan notifyMsg, 1))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	reservation := lim.reserveQueued(ctx, 2*time.Second, now, 1000)
+	re.Equal(queuedReservationWaiting, reservation.state)
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := reservation.wait(ctx)
+		resultCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	lim.Reconfigure(now.Add(20*time.Millisecond), tokenBucketReconfigureArgs{
+		newTokens:   0,
+		newFillRate: 0,
+		newBurst:    -1,
+	})
+
+	select {
+	case err := <-resultCh:
+		re.NoError(err)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("unlimited reconfigure should wake the existing future reservation")
+	}
+}
+
+func TestReconfigureToUnlimitedResetsLedgerAfterDueReservation(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	reservation := lim.reserveQueued(context.Background(), InfDuration, t0, 100)
+
+	lim.Reconfigure(t2, tokenBucketReconfigureArgs{
+		newTokens: 50,
+		newBurst:  -1,
+	})
+
+	re.Equal(queuedReservationReady, reservation.state)
+	re.InDelta(50, lim.tokens, 1e-9)
+}
+
+func TestQueuedReservationWaitWakesWhenCanceled(t *testing.T) {
+	re := require.New(t)
+	now := time.Now()
+	lim := NewLimiter(now, 1000, 0, 0, make(chan notifyMsg, 1))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	reservation := lim.reserveQueued(ctx, 2*time.Second, now, 1000)
+	re.Equal(queuedReservationWaiting, reservation.state)
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := reservation.wait(ctx)
+		resultCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	reservation.cancelAt(now.Add(20 * time.Millisecond))
+
+	select {
+	case err := <-resultCh:
+		re.ErrorIs(err, errQueuedReservationCanceled)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("canceling the queued reservation should wake its waiter")
+	}
+}
+
+func TestReconfigureKeepsQueuedReservationsWithinNewFillRateEnvelope(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	lim := NewLimiter(t0, 5000, 0, 0, make(chan notifyMsg, 1))
+
+	const (
+		pageRU           = 256
+		reservationCount = 20
+	)
+	ctx := context.Background()
+	oldReservations := make([]*queuedReservation, reservationCount)
+	for i := range oldReservations {
+		oldReservations[i] = lim.reserveQueued(ctx, InfDuration, t0, pageRU)
+		re.Equal(queuedReservationWaiting, oldReservations[i].state)
+	}
+
+	reconfigureAt := t0.Add(50 * time.Millisecond)
+	lim.Reconfigure(reconfigureAt, tokenBucketReconfigureArgs{
+		newTokens:   0,
+		newFillRate: 1000,
+		newBurst:    0,
+	})
+
+	reflowedRU := reservedRUInWindow(oldReservations, reconfigureAt, reconfigureAt.Add(time.Second))
+
+	lim.mu.Lock()
+	fillRateAfterReconfigure := lim.fillRate
+	lim.mu.Unlock()
+	re.LessOrEqual(reflowedRU, float64(fillRateAfterReconfigure)+pageRU,
+		"reflow keeps old reservations close to the post-reconfigure envelope")
+}
+
+func TestRemoveTokensReflowsQueuedReservations(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	ctx := context.Background()
+
+	a := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	b := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	re.Equal(5*time.Second, queuedDelayFrom(a, t0))
+	re.Equal(10*time.Second, queuedDelayFrom(b, t0))
+
+	lim.RemoveTokens(t1, 500)
+	re.Equal(9*time.Second, queuedDelayFrom(a, t1))
+	re.Equal(14*time.Second, queuedDelayFrom(b, t1))
+}
+
+func TestAcceptedQueuedReservationCanMoveBeyondInitialWaitLimit(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	reservation := lim.reserveQueued(context.Background(), 5*time.Second, t0, 500)
+
+	re.Equal(queuedReservationWaiting, reservation.state)
+	re.Equal(t5, reservation.timeToAct)
+
+	lim.RemoveTokens(t1, 1000)
+	re.Equal(queuedReservationWaiting, reservation.state)
+	re.Equal(t0.Add(15*time.Second), reservation.timeToAct)
+}
+
+func TestMutationDoesNotRevokeDueQueuedReservation(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 100, 0, make(chan notifyMsg, 1))
+	reservation := lim.reserveQueued(context.Background(), InfDuration, t0, 1000)
+
+	re.Equal(queuedReservationWaiting, reservation.state)
+	re.Equal(t0.Add(10*time.Second), reservation.timeToAct)
+
+	lim.RemoveTokens(t0.Add(20*time.Second), 100)
+	re.Equal(queuedReservationReady, reservation.state)
+	re.Equal(t0.Add(10*time.Second), reservation.timeToAct)
+}
+
+func TestRefundTokensReflowsQueuedReservations(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	ctx := context.Background()
+
+	a := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	b := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	c := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	re.Equal(5*time.Second, queuedDelayFrom(a, t0))
+	re.Equal(10*time.Second, queuedDelayFrom(b, t0))
+	re.Equal(15*time.Second, queuedDelayFrom(c, t0))
+
+	lim.RefundTokens(t1, 600)
+	re.Zero(queuedDelayFrom(a, t1))
+	re.Equal(3*time.Second, queuedDelayFrom(b, t1))
+	re.Equal(8*time.Second, queuedDelayFrom(c, t1))
+	re.False(b.timeToAct.After(c.timeToAct), "refund reflow must preserve FIFO order")
+
+	lim.RefundTokens(t1, 300)
+	re.Zero(queuedDelayFrom(b, t1))
+	re.Equal(5*time.Second, queuedDelayFrom(c, t1))
+
+	lim.RefundTokens(t1, 1000)
+	re.Zero(queuedDelayFrom(c, t1))
+}
+
+func TestRefundReflowPreservesCommittedCreditAboveBurst(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 100, 0, make(chan notifyMsg, 1))
+	ctx := context.Background()
+	a := lim.reserveQueued(ctx, InfDuration, t0, 100)
+	b := lim.reserveQueued(ctx, InfDuration, t0, 100)
+
+	lim.RefundTokens(t0, 1000)
+	re.Zero(queuedDelayFrom(a, t0))
+	re.Zero(queuedDelayFrom(b, t0))
+	re.InDelta(800, lim.tokens, 1e-9)
+
+	c := lim.reserveQueued(ctx, InfDuration, t0, 100)
+	re.Equal(queuedReservationReady, a.state)
+	re.Equal(queuedReservationReady, b.state)
+	re.Equal(t0, c.timeToAct)
+	re.InDelta(0, lim.tokens, 1e-9,
+		"new admission clamps unused credit to burst after committed reservations become ready")
+}
+
+func TestRefundDoesNotDiscardAccruedCreditForLargeQueuedReservation(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 100, 0, make(chan notifyMsg, 1))
+	reservation := lim.reserveQueued(context.Background(), InfDuration, t0, 500)
+	re.Equal(t5, reservation.timeToAct)
+
+	lim.RefundTokens(t2, 50)
+	re.Equal(t0.Add(4500*time.Millisecond), reservation.timeToAct)
+	re.InDelta(-250, lim.tokens, 1e-9)
+}
+
+func TestStaleNowReflowUsesLimiterLogicalClock(t *testing.T) {
+	resetTime()
+	tests := []struct {
+		name      string
+		mutate    func(lim *Limiter, first *queuedReservation, staleNow time.Time)
+		wantFirst time.Time
+		wantLast  time.Time
+	}{
+		{
+			name: "remove tokens",
+			mutate: func(lim *Limiter, _ *queuedReservation, staleNow time.Time) {
+				lim.RemoveTokens(staleNow, 100)
+			},
+			wantFirst: t6,
+			wantLast:  t0.Add(11 * time.Second),
+		},
+		{
+			name: "refund tokens",
+			mutate: func(lim *Limiter, _ *queuedReservation, staleNow time.Time) {
+				lim.RefundTokens(staleNow, 100)
+			},
+			wantFirst: t4,
+			wantLast:  t0.Add(9 * time.Second),
+		},
+		{
+			name: "reconfigure",
+			mutate: func(lim *Limiter, _ *queuedReservation, staleNow time.Time) {
+				lim.Reconfigure(staleNow, tokenBucketReconfigureArgs{
+					newTokens:   100,
+					newFillRate: 100,
+				})
+			},
+			wantFirst: t4,
+			wantLast:  t0.Add(9 * time.Second),
+		},
+		{
+			name: "cancel",
+			mutate: func(_ *Limiter, first *queuedReservation, staleNow time.Time) {
+				first.cancelAt(staleNow)
+			},
+			wantLast: t5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re := require.New(t)
+			lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+			first := lim.reserveQueued(context.Background(), InfDuration, t0, 500)
+			last := lim.reserveQueued(context.Background(), InfDuration, t0, 500)
+
+			lim.RemoveTokens(t2, 0)
+			tt.mutate(lim, first, t1)
+
+			re.Equal(t2, lim.last)
+			if !tt.wantFirst.IsZero() {
+				re.Equal(tt.wantFirst, first.timeToAct)
+			}
+			re.Equal(tt.wantLast, last.timeToAct)
+		})
+	}
+}
+
+func TestQueuedReservationUsesLimiterLogicalClockForStaleNow(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	lim.RemoveTokens(t2, 200)
+
+	reservation := lim.reserveQueued(context.Background(), InfDuration, t1, 100)
+	re.Equal(t2, lim.last)
+	re.Equal(t0.Add(3*time.Second), reservation.timeToAct)
+}
+
+func TestRejectedQueuedReservationCleanupAdvancesLogicalClock(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	first := lim.reserveQueued(context.Background(), InfDuration, t0, 500)
+	last := lim.reserveQueued(context.Background(), InfDuration, t0, 1500)
+
+	rejected := lim.reserveQueued(context.Background(), 0, t0.Add(10*time.Second), 2000)
+	re.Equal(queuedReservationRejected, rejected.state)
+	re.Equal(queuedReservationReady, first.state)
+	re.Equal(t0.Add(10*time.Second), lim.last)
+
+	lim.Reconfigure(t1, tokenBucketReconfigureArgs{
+		newFillRate: 200,
+		newBurst:    0,
+	})
+	re.Equal(t0.Add(10*time.Second), lim.last)
+	re.Equal(t0.Add(15*time.Second), last.timeToAct)
+}
+
+func TestQueuedReservationAdmissionUsesShorterContextDeadline(t *testing.T) {
+	re := require.New(t)
+	now := time.Now()
+	lim := NewLimiter(now, 1000, 0, 0, make(chan notifyMsg, 1))
+	ctx, cancel := context.WithDeadline(context.Background(), now.Add(100*time.Millisecond))
+	defer cancel()
+
+	reservation := lim.reserveQueued(ctx, time.Second, now, 500)
+	re.Equal(queuedReservationRejected, reservation.state)
+	delay, err := reservation.wait(ctx)
+	re.Equal(500*time.Millisecond, delay)
+	re.True(errs.ErrClientResourceGroupThrottled.Equal(err))
+}
+
+func TestCancelAtReflowsRemainingQueuedReservations(t *testing.T) {
+	re := require.New(t)
+	resetTime()
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	ctx := context.Background()
+
+	a := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	b := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	c := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	re.Equal(5*time.Second, queuedDelayFrom(a, t0))
+	re.Equal(10*time.Second, queuedDelayFrom(b, t0))
+	re.Equal(15*time.Second, queuedDelayFrom(c, t0))
+
+	a.cancelAt(t1)
+	re.Equal(4*time.Second, queuedDelayFrom(b, t1))
+	re.Equal(9*time.Second, queuedDelayFrom(c, t1))
+	tokensAfterFirstCancel := lim.tokens
+	a.cancelAt(t1)
+	re.Equal(tokensAfterFirstCancel, lim.tokens, "cancelAt must not refund the same reservation twice")
+}
+
+func TestCancelAtDoesNotCancelOverdueQueuedReservation(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	reservation := lim.reserveQueued(context.Background(), InfDuration, t0, 100)
+	re.Equal(t1, reservation.timeToAct)
+
+	canceled := reservation.cancelAt(t2)
+	re.False(canceled)
+	re.Equal(queuedReservationReady, reservation.state)
+	re.Equal(t2, lim.last)
+	re.InDelta(100, lim.tokens, 1e-9)
+}
+
+func TestCancelAtUnlinksMiddleAndTailQueuedReservations(t *testing.T) {
+	re := require.New(t)
+	lim := NewLimiter(t0, 100, 0, 0, make(chan notifyMsg, 1))
+	ctx := context.Background()
+	a := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	b := lim.reserveQueued(ctx, InfDuration, t0, 500)
+	c := lim.reserveQueued(ctx, InfDuration, t0, 500)
+
+	b.cancelAt(t1)
+	re.Equal(4*time.Second, queuedDelayFrom(a, t1))
+	re.Equal(9*time.Second, queuedDelayFrom(c, t1))
+
+	c.cancelAt(t1)
+	d := lim.reserveQueued(ctx, InfDuration, t1, 500)
+	re.Equal(9*time.Second, queuedDelayFrom(d, t1))
+}
+
+func TestWaitReservationsCancelHandlesNilReservation(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	lim := NewLimiter(t0, 1, 0, 0, make(chan notifyMsg, 1))
+	failed := lim.Reserve(ctx, InfDuration, t0, 1)
+
+	delay, err := WaitReservations(context.Background(), t0, []*Reservation{nil, failed})
+	re.Zero(delay)
+	re.ErrorIs(err, context.Canceled)
+}
+
+func TestQueuedReservationWaitFailpointRunsOnceAcrossReflow(t *testing.T) {
+	re := require.New(t)
+	now := time.Now()
+	lim := NewLimiter(now, 1000, 0, 0, make(chan notifyMsg, 1))
+	reservation := lim.reserveQueued(context.Background(), 2*time.Second, now, 1000)
+	re.Equal(queuedReservationWaiting, reservation.state)
+
+	const fp = "github.com/tikv/pd/client/resource_group/controller/waitReservationsBeforeSelect"
+	reached := make(chan struct{}, 1)
+	var calls atomic.Int32
+	re.NoError(failpoint.EnableCall(fp, func() {
+		if calls.Add(1) == 1 {
+			reached <- struct{}{}
+		}
+	}))
+	defer func() { re.NoError(failpoint.Disable(fp)) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := reservation.wait(ctx)
+		resultCh <- err
+	}()
+
+	select {
+	case <-reached:
+	case <-time.After(time.Second):
+		t.Fatal("queued reservation wait did not reach the pre-select hook")
+	}
+
+	lim.RefundTokens(now.Add(10*time.Millisecond), 100)
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		re.ErrorIs(err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("queued reservation wait did not exit after cancellation")
+	}
+	re.Equal(int32(1), calls.Load(), "the synchronization failpoint must remain a one-shot hook")
+}
+
+func TestQueuedReservationWaitReturnsSuccessWhenReadyBeatsContextCancel(t *testing.T) {
+	re := require.New(t)
+	now := time.Now()
+	lim := NewLimiter(now, 1000, 0, 0, make(chan notifyMsg, 1))
+	reservation := lim.reserveQueued(context.Background(), 2*time.Second, now, 1000)
+	re.Equal(queuedReservationWaiting, reservation.state)
+
+	const fp = "github.com/tikv/pd/client/resource_group/controller/waitReservationsBeforeSelect"
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	re.NoError(failpoint.EnableCall(fp, func() {
+		close(reached)
+		<-release
+	}))
+	defer func() { re.NoError(failpoint.Disable(fp)) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := reservation.wait(ctx)
+		resultCh <- err
+	}()
+
+	select {
+	case <-reached:
+	case <-time.After(time.Second):
+		t.Fatal("queued reservation wait did not reach the pre-select hook")
+	}
+
+	lim.mu.Lock()
+	lim.removeQueuedReservationLocked(reservation)
+	reservation.state = queuedReservationReady
+	lim.mu.Unlock()
+	cancel()
+	close(release)
+
+	select {
+	case err := <-resultCh:
+		re.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("queued reservation wait did not resolve the ready/cancel race")
+	}
+}
+
+func queuedDelayFrom(reservation *queuedReservation, now time.Time) time.Duration {
+	delay := reservation.timeToAct.Sub(now)
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+func reservedRUInWindow(reservations []*queuedReservation, start, end time.Time) float64 {
+	var total float64
+	for _, reservation := range reservations {
+		if !reservation.timeToAct.Before(start) && reservation.timeToAct.Before(end) {
+			total += reservation.tokens
+		}
+	}
+	return total
 }
 
 const testCaseRunTime = 4 * time.Second

--- a/client/resource_group/controller/queued_reservation.go
+++ b/client/resource_group/controller/queued_reservation.go
@@ -1,0 +1,357 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/pingcap/failpoint"
+
+	"github.com/tikv/pd/client/errs"
+)
+
+type queuedReservationState uint8
+
+const (
+	queuedReservationRejected queuedReservationState = iota
+	queuedReservationWaiting
+	queuedReservationReady
+	queuedReservationCanceled
+)
+
+// queuedReservation is the internal, dynamically scheduled counterpart of the
+// public fixed Reservation. It is intentionally unexported and pointer-only:
+// the limiter owns its FIFO links and all state transitions happen under
+// lim.mu.
+type queuedReservation struct {
+	lim              *Limiter
+	prev             *queuedReservation
+	next             *queuedReservation
+	state            queuedReservationState
+	tokens           float64
+	timeToAct        time.Time
+	needWaitDuration time.Duration
+	fillRate         fillRate
+	remainingTokens  float64
+	err              error
+}
+
+var errQueuedReservationCanceled = errors.New("queued reservation canceled")
+
+func (lim *Limiter) effectiveNowLocked(now time.Time) time.Time {
+	if now.Before(lim.last) {
+		return lim.last
+	}
+	return now
+}
+
+func (lim *Limiter) queuedUpdateChannelLocked() <-chan struct{} {
+	if lim.queuedUpdateCh == nil {
+		lim.queuedUpdateCh = make(chan struct{})
+	}
+	return lim.queuedUpdateCh
+}
+
+func (lim *Limiter) signalQueuedUpdateLocked() {
+	if lim.queuedUpdateCh != nil {
+		close(lim.queuedUpdateCh)
+	}
+	lim.queuedUpdateCh = make(chan struct{})
+}
+
+func (lim *Limiter) appendQueuedReservationLocked(reservation *queuedReservation) {
+	reservation.prev = lim.queuedTail
+	if lim.queuedTail == nil {
+		lim.queuedHead = reservation
+	} else {
+		lim.queuedTail.next = reservation
+	}
+	lim.queuedTail = reservation
+}
+
+func (lim *Limiter) removeQueuedReservationLocked(reservation *queuedReservation) {
+	if reservation.prev == nil {
+		lim.queuedHead = reservation.next
+	} else {
+		reservation.prev.next = reservation.next
+	}
+	if reservation.next == nil {
+		lim.queuedTail = reservation.prev
+	} else {
+		reservation.next.prev = reservation.prev
+	}
+	reservation.prev = nil
+	reservation.next = nil
+}
+
+func (lim *Limiter) queuedTokensLocked() float64 {
+	var tokens float64
+	for reservation := lim.queuedHead; reservation != nil; reservation = reservation.next {
+		tokens += reservation.tokens
+	}
+	return tokens
+}
+
+func (lim *Limiter) admitDueQueuedReservationsLocked(now time.Time) bool {
+	changed := false
+	for lim.queuedHead != nil && !lim.queuedHead.timeToAct.After(now) {
+		reservation := lim.queuedHead
+		lim.removeQueuedReservationLocked(reservation)
+		reservation.state = queuedReservationReady
+		changed = true
+	}
+	return changed
+}
+
+// reflowQueuedReservationsLocked rebuilds the dynamic queue from the current
+// bucket state. lim.tokens already includes every waiting reservation's debit;
+// the rebuild first restores those debits, then replays the FIFO and writes the
+// resulting tail debt back to lim.tokens. The restored balance is virtual
+// credit already committed to the queued reservations, so it must not be
+// clamped to burst here. A later admission clamps any unused positive balance
+// through getTokens.
+func (lim *Limiter) reflowQueuedReservationsLocked(now time.Time) {
+	changed := lim.admitDueQueuedReservationsLocked(now)
+	if lim.queuedHead == nil {
+		if changed {
+			lim.signalQueuedUpdateLocked()
+		}
+		return
+	}
+
+	available := lim.tokens + lim.queuedTokensLocked()
+
+	if lim.burst < 0 || lim.fillRate == Inf {
+		for reservation := lim.queuedHead; reservation != nil; {
+			next := reservation.next
+			reservation.prev = nil
+			reservation.next = nil
+			reservation.timeToAct = now
+			reservation.state = queuedReservationReady
+			reservation = next
+		}
+		lim.queuedHead = nil
+		lim.queuedTail = nil
+		lim.tokens = available
+		lim.signalQueuedUpdateLocked()
+		return
+	}
+
+	for reservation := lim.queuedHead; reservation != nil; reservation = reservation.next {
+		available -= reservation.tokens
+		newTimeToAct := now
+		if available < 0 {
+			newTimeToAct = now.Add(lim.fillRate.durationFromTokens(-available))
+		}
+		if !reservation.timeToAct.Equal(newTimeToAct) {
+			reservation.timeToAct = newTimeToAct
+			changed = true
+		}
+	}
+	lim.tokens = available
+	if changed {
+		lim.signalQueuedUpdateLocked()
+	}
+}
+
+// waitN reserves tokens for the resource-control request path and waits until
+// the dynamically reflowed reservation is ready. maxInitialWait is checked
+// only when the reservation is admitted; an accepted reservation keeps its
+// FIFO position until it is ready or its context is canceled.
+func (lim *Limiter) waitN(
+	ctx context.Context, maxInitialWait time.Duration, now time.Time, tokens float64,
+) (time.Duration, error) {
+	return lim.reserveQueued(ctx, maxInitialWait, now, tokens).wait(ctx)
+}
+
+func (lim *Limiter) reserveQueued(
+	ctx context.Context, maxInitialWait time.Duration, now time.Time, tokensToReserve float64,
+) *queuedReservation {
+	if err := ctx.Err(); err != nil {
+		return &queuedReservation{state: queuedReservationRejected, err: err}
+	}
+
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	effectiveNow := lim.effectiveNowLocked(now)
+	_, currentTokens := lim.getTokens(effectiveNow)
+	if lim.admitDueQueuedReservationsLocked(effectiveNow) {
+		lim.signalQueuedUpdateLocked()
+	}
+	waitLimit := maxInitialWait
+	if deadline, ok := ctx.Deadline(); ok {
+		if deadlineWait := deadline.Sub(effectiveNow); deadlineWait < waitLimit {
+			waitLimit = deadlineWait
+		}
+	}
+	if lim.burst < 0 || lim.fillRate == Inf {
+		lim.updateLast(effectiveNow)
+		lim.tokens = currentTokens
+		return &queuedReservation{
+			lim:       lim,
+			state:     queuedReservationReady,
+			tokens:    tokensToReserve,
+			timeToAct: effectiveNow,
+		}
+	}
+
+	remainingTokens := currentTokens - tokensToReserve
+	var waitDuration time.Duration
+	if remainingTokens < 0 {
+		waitDuration = lim.fillRate.durationFromTokens(-remainingTokens)
+	}
+	reservation := &queuedReservation{
+		lim:              lim,
+		state:            queuedReservationRejected,
+		tokens:           tokensToReserve,
+		needWaitDuration: waitDuration,
+		fillRate:         lim.fillRate,
+		remainingTokens:  remainingTokens,
+	}
+	if waitDuration > waitLimit {
+		lim.tokens = currentTokens
+		lim.onReservationRejectedLocked(effectiveNow, waitDuration, waitLimit, tokensToReserve)
+		return reservation
+	}
+
+	lim.updateLast(effectiveNow)
+	lim.tokens = remainingTokens
+	lim.maybeNotify()
+	reservation.timeToAct = effectiveNow.Add(waitDuration)
+	if waitDuration <= 0 {
+		reservation.state = queuedReservationReady
+		return reservation
+	}
+	reservation.state = queuedReservationWaiting
+	lim.appendQueuedReservationLocked(reservation)
+	return reservation
+}
+
+func (reservation *queuedReservation) wait(ctx context.Context) (time.Duration, error) {
+	if reservation == nil {
+		return 0, nil
+	}
+	if reservation.lim == nil {
+		if reservation.err != nil {
+			return reservation.needWaitDuration, reservation.err
+		}
+		return reservation.needWaitDuration, errs.ErrClientResourceGroupThrottled.FastGenByArgs(
+			reservation.needWaitDuration, reservation.fillRate, reservation.remainingTokens)
+	}
+
+	start := time.Now()
+	firstSelect := true
+	for {
+		now := time.Now()
+		reservation.lim.mu.Lock()
+		switch reservation.state {
+		case queuedReservationRejected:
+			reservation.lim.mu.Unlock()
+			if reservation.err != nil {
+				return reservation.needWaitDuration, reservation.err
+			}
+			return reservation.needWaitDuration, errs.ErrClientResourceGroupThrottled.FastGenByArgs(
+				reservation.needWaitDuration, reservation.fillRate, reservation.remainingTokens)
+		case queuedReservationReady:
+			reservation.lim.mu.Unlock()
+			if firstSelect {
+				return 0, nil
+			}
+			return time.Since(start), nil
+		case queuedReservationCanceled:
+			reservation.lim.mu.Unlock()
+			return 0, errQueuedReservationCanceled
+		case queuedReservationWaiting:
+			if !reservation.timeToAct.After(now) {
+				reservation.state = queuedReservationReady
+				reservation.lim.removeQueuedReservationLocked(reservation)
+				reservation.lim.mu.Unlock()
+				return time.Since(start), nil
+			}
+			delay := reservation.timeToAct.Sub(now)
+			updateCh := reservation.lim.queuedUpdateChannelLocked()
+			reservation.lim.mu.Unlock()
+
+			if firstSelect {
+				failpoint.InjectCall("waitReservationsBeforeSelect")
+				firstSelect = false
+			}
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-updateCh:
+			case <-ctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				if reservation.cancelAt(time.Now()) {
+					return 0, ctx.Err()
+				}
+				reservation.lim.mu.Lock()
+				state := reservation.state
+				reservation.lim.mu.Unlock()
+				if state == queuedReservationReady {
+					return time.Since(start), nil
+				}
+				if state == queuedReservationCanceled {
+					return 0, errQueuedReservationCanceled
+				}
+				return 0, ctx.Err()
+			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// cancelAt reports whether it won the waiting-to-canceled state transition.
+func (reservation *queuedReservation) cancelAt(now time.Time) bool {
+	if reservation == nil || reservation.lim == nil {
+		return false
+	}
+	reservation.lim.mu.Lock()
+	defer reservation.lim.mu.Unlock()
+	if reservation.state != queuedReservationWaiting {
+		return false
+	}
+
+	effectiveNow := reservation.lim.effectiveNowLocked(now)
+	_, tokens := reservation.lim.getTokens(effectiveNow)
+	reservation.lim.updateLast(effectiveNow)
+	reservation.lim.tokens = tokens
+	if reservation.lim.admitDueQueuedReservationsLocked(effectiveNow) {
+		reservation.lim.signalQueuedUpdateLocked()
+	}
+	if reservation.state != queuedReservationWaiting {
+		return false
+	}
+
+	reservation.lim.tokens += reservation.tokens
+	reservation.lim.removeQueuedReservationLocked(reservation)
+	reservation.state = queuedReservationCanceled
+	reservation.lim.signalQueuedUpdateLocked()
+	reservation.lim.reflowQueuedReservationsLocked(effectiveNow)
+	return true
+}

--- a/pkg/mcs/resourcemanager/server/config.go
+++ b/pkg/mcs/resourcemanager/server/config.go
@@ -57,7 +57,8 @@ const (
 	// Because the resource manager has not been deployed in microservice mode,
 	// do not enable this function.
 	defaultDegradedModeWaitDuration = time.Second * 0
-	// defaultMaxWaitDuration is the max duration to wait for the token before throwing error.
+	// defaultMaxWaitDuration is the maximum predicted wait accepted at initial
+	// local token reservation. Accepted reservations may wait longer after reflow.
 	defaultMaxWaitDuration = 30 * time.Second
 	// defaultLTBTokenRPCMaxDelay is the upper bound of backoff delay for local token bucket RPC.
 	defaultLTBTokenRPCMaxDelay = 1 * time.Second
@@ -161,7 +162,9 @@ type ControllerConfig struct {
 	// EnableDegradedMode is to control whether resource control client enable degraded mode when server is disconnect.
 	DegradedModeWaitDuration typeutil.Duration `toml:"degraded-mode-wait-duration" json:"degraded-mode-wait-duration"`
 
-	// LTBMaxWaitDuration is the max wait time duration for local token bucket.
+	// LTBMaxWaitDuration is the maximum predicted wait accepted when initially
+	// reserving from the local token bucket. Accepted reservations may wait
+	// longer after reflow; callers provide a context deadline for a hard bound.
 	LTBMaxWaitDuration typeutil.Duration `toml:"ltb-max-wait-duration" json:"ltb-max-wait-duration"`
 
 	// LTBTokenRPCMaxDelay is the upper bound of backoff delay for local token bucket RPC.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10761

> **Status: Draft.** Correctness validation passes, but local TiUP testing confirmed a P1 thundering-herd CPU regression in the shared waiter-broadcast design. This PR should not merge unchanged.

Future reservations in the resource-control limiter are calculated from the token balance and fill rate observed at reservation time. If `Reconfigure`, `RemoveTokens`, `RefundTokens`, or cancellation changes that state while a request is waiting, the old schedule becomes stale. This can admit requests too early, prevent refunds or cancellations from pulling later requests forward, or allow newly retried requests to pass already accepted requests.

### What is changed and how does it work?

```commit-message
resource_manager: reflow future reservations

Keep the exported reservation API compatible while dynamically reflowing the resource-control request queue after limiter state changes.
```

The implementation separates two contracts:

- Exported `Limiter.Reserve`, `Reservation.Delay/DelayFrom`, and `WaitReservations` remain fixed-ticket APIs. Later limiter changes do not rewrite their scheduled action time.
- The resource-control request path uses an internal `queuedReservation` and `Limiter.waitN`. Accepted requests stay in a limiter-owned FIFO and are dynamically rescheduled after limiter mutations.

The dynamic queue:

- uses a doubly linked FIFO for O(1) enqueue and unlink and a monotonic limiter logical clock;
- reflows after `Reconfigure`, `RemoveTokens`, `RefundTokens`, and dynamic cancellation;
- restores queued debits, preserves committed credit, replays accepted reservations in FIFO order, and writes the resulting tail debt back to the limiter ledger;
- makes due reservations `ready` before later mutations or cancellation and reflows accepted reservations before waking initial-admission retries, preventing new retries from overtaking the accepted queue.

#### `LTBMaxWaitDuration` semantics

`LTBMaxWaitDuration` is an **initial admission limit**, not an end-to-end hard deadline. A request is rejected when its predicted wait at reservation time exceeds the limit. Once accepted, it keeps its FIFO position even if a later debit or rate change pushes its action time beyond the configured duration. Callers requiring a hard bound must provide a context deadline; if the fill rate remains zero, an accepted request can remain queued until capacity returns or its context is canceled.

#### Performance validation

The semantic repair works: compared with current master, a two-sample local TiUP A/B improved QPS by 45.5%, reduced mean latency by 30.9%, produced no workload errors, and kept p95 net RU/s below the 5,000 RU/s grant. However, mean TiDB CPU increased by 92.3%, CPU per QPS increased by about 32%, controller-related CPU samples increased from 0.04% to 15.8%, and cumulative mutex delay under controller stacks increased from about 82 seconds to 1,323 seconds.

Microbenchmarks show approximately linear reflow scans, but broadcasting and rearming timers for 10,000 waiters costs about 9.66 ms, 2.49 MiB, and 30,000 allocations per mutation. Profiles confirm a real thundering-herd cost from waking all queued waiters to contend on the limiter mutex and recreate timers. This is the current merge blocker. See the [full validation data and medium-or-higher issue summary](https://github.com/tikv/pd/pull/10762#issuecomment-5041348425).

### Check List

Tests

- [x] Unit tests
- [x] Race detector
- [x] Static and leak checks
- [x] Dynamic-queue microbenchmarks and profiles
- [x] Local TiUP end-to-end A/B comparison (performance blocker found)
- [x] `release-nextgen-202603` compatibility audit

Code changes

- [x] This PR changes a public configuration's documented semantics: `LTBMaxWaitDuration` is the initial predicted-wait limit; context deadlines provide a hard end-to-end bound.

Known issues and follow-ups

- **P1:** Shared generation-channel broadcasts cause a confirmed thundering-herd CPU and mutex-contention regression.
- **P2:** Every refund, removal, reconfiguration, or dynamic cancellation performs O(queue depth) replay under `lim.mu`.
- **P2:** Accepted requests may wait beyond `LTBMaxWaitDuration`, or indefinitely after fill rate becomes zero, unless their context has a deadline or is canceled.
- **P2:** The new queue lacks production metrics for depth, oldest age, reflow duration, broadcasts, and waiter wake/rearm count.
- **P2:** `release-nextgen-202603` needs one manual `acquireTokens` adaptation and has not received a full integration run because the master implementation already failed performance validation.

Validation summary

Unit, race, static, leak, microbenchmark, profiling, and TiUP A/B validation completed. Correctness and tooling checks pass; performance validation fails because of confirmed broadcast wakeup amplification. Full commands, data, profiles, and conclusions are recorded in the linked validation comment.

### Release note

```release-note
Fix resource-control admission bursts caused by stale future-reservation schedules after limiter state changes. Accepted reservations retain FIFO order after reflow and may wait longer than `LTBMaxWaitDuration`; callers requiring a hard deadline should provide one through the request context.
```
