### PR TITLE
server, storage: speed up large region load

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1050,6 +1050,7 @@ type RegionsInfo struct {
 	t            RWLockStats
 	tree         *regionTree
 	regions      map[uint64]*regionItem // regionID -> regionInfo
+	regionCount  int64                  // lock-free total count for read-only status APIs
 	st           RWLockStats
 	subRegions   map[uint64]*regionItem // regionID -> regionInfo
 	leaders      map[uint64]*regionTree // storeID -> sub regionTree
@@ -1107,6 +1108,20 @@ func (r *RegionsInfo) CheckAndPutRegion(region *RegionInfo) []*RegionInfo {
 		return []*RegionInfo{region}
 	}
 	origin, overlaps, rangeChanged := r.setRegionLocked(region, true, ols...)
+	r.t.Unlock()
+	r.UpdateSubTree(region, origin, overlaps, rangeChanged)
+	return overlaps
+}
+
+// CheckAndPutRegionNoOverlap puts a region when the caller has proved it has no range overlap.
+func (r *RegionsInfo) CheckAndPutRegionNoOverlap(region *RegionInfo) []*RegionInfo {
+	r.t.Lock()
+	origin := r.getRegionLocked(region.GetID())
+	if origin != nil {
+		r.t.Unlock()
+		return r.CheckAndPutRegion(region)
+	}
+	origin, overlaps, rangeChanged := r.setRegionLocked(region, true)
 	r.t.Unlock()
 	r.UpdateSubTree(region, origin, overlaps, rangeChanged)
 	return overlaps
@@ -1255,9 +1270,10 @@ func (r *RegionsInfo) preUpdateSubTreeLocked(
 }
 
 func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionInfo, region *RegionInfo) {
+	overlapsProvided := overlaps != nil
 	if rangeChanged {
 		// TODO: only perform the remove operation on the overlapped peer.
-		if len(overlaps) == 0 {
+		if !overlapsProvided {
 			// If the range has changed but the overlapped regions are not provided, collect them by `[]*regionItem`.
 			for _, item := range r.getOverlapRegionFromOverlapTreeLocked(region) {
 				r.removeRegionFromSubTreeLocked(item)
@@ -1272,7 +1288,8 @@ func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionI
 	// Reinsert the region into all subtrees.
 	item := &regionItem{region}
 	r.subRegions[region.GetID()] = item
-	r.overlapTree.update(item, false)
+	skipOverlapCheck := overlapsProvided && len(overlaps) == 0
+	r.overlapTree.update(item, skipOverlapCheck)
 	// Add leaders and followers.
 	setPeer := func(peersMap map[uint64]*regionTree, storeID uint64) {
 		store, ok := peersMap[storeID]
@@ -1280,7 +1297,7 @@ func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionI
 			store = newRegionTree()
 			peersMap[storeID] = store
 		}
-		store.update(item, false)
+		store.update(item, skipOverlapCheck)
 	}
 	for _, peer := range region.GetVoters() {
 		storeID := peer.GetStoreId()
@@ -1384,12 +1401,16 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol 
 		// If this ID does not exist, generate a new regionItem and save it in the regionMap.
 		item = &regionItem{RegionInfo: region}
 		r.regions[region.GetID()] = item
+		atomic.AddInt64(&r.regionCount, 1)
 	}
 	var overlaps []*RegionInfo
 	if rangeChanged {
 		overlaps = r.tree.update(item, withOverlaps, ol...)
 		for _, old := range overlaps {
-			delete(r.regions, old.GetID())
+			if _, ok := r.regions[old.GetID()]; ok {
+				delete(r.regions, old.GetID())
+				atomic.AddInt64(&r.regionCount, -1)
+			}
 		}
 	}
 	// return rangeChanged to prevent duplicated calculation
@@ -1458,7 +1479,10 @@ func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
 	defer r.t.Unlock()
 	// Remove from tree and regions.
 	r.tree.remove(region)
-	delete(r.regions, region.GetID())
+	if _, ok := r.regions[region.GetID()]; ok {
+		delete(r.regions, region.GetID())
+		atomic.AddInt64(&r.regionCount, -1)
+	}
 }
 
 // ResetRegionCache resets the regions info.
@@ -1466,6 +1490,7 @@ func (r *RegionsInfo) ResetRegionCache() {
 	r.t.Lock()
 	r.tree = newRegionTreeWithCountRef()
 	r.regions = make(map[uint64]*regionItem)
+	atomic.StoreInt64(&r.regionCount, 0)
 	r.t.Unlock()
 	r.st.Lock()
 	defer r.st.Unlock()
@@ -1899,9 +1924,7 @@ func (r *RegionsInfo) GetStoreStats(storeID uint64) (leader, region, witness, le
 
 // GetTotalRegionCount gets the total count of RegionInfo of regionMap
 func (r *RegionsInfo) GetTotalRegionCount() int {
-	r.t.RLock()
-	defer r.t.RUnlock()
-	return len(r.regions)
+	return int(atomic.LoadInt64(&r.regionCount))
 }
 
 // GetStoreRegionCount gets the total count of a store's leader, follower and learner RegionInfo by storeID

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1459,6 +1459,64 @@ func TestRegionCount(t *testing.T) {
 	}
 }
 
+func TestTotalRegionCount(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+
+	re.Zero(regions.GetTotalRegionCount())
+
+	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("c"))
+	region2 := NewTestRegionInfo(2, 1, []byte("c"), []byte("e"))
+	region3 := NewTestRegionInfo(3, 1, []byte("e"), []byte("g"))
+	regions.CheckAndPutRegion(region1)
+	regions.CheckAndPutRegion(region2)
+	regions.CheckAndPutRegion(region3)
+	re.Equal(3, regions.GetTotalRegionCount())
+
+	// Updating an existing region without changing the range should not change the count.
+	regions.CheckAndPutRegion(NewTestRegionInfo(2, 2, []byte("c"), []byte("e")))
+	re.Equal(3, regions.GetTotalRegionCount())
+
+	// Adding a region that overlaps two old regions should count as +1 -2.
+	overlaps := regions.CheckAndPutRegion(NewTestRegionInfo(4, 1, []byte("b"), []byte("d")))
+	re.Len(overlaps, 2)
+	re.Equal(2, regions.GetTotalRegionCount())
+
+	regions.RemoveRegion(region3)
+	re.Equal(1, regions.GetTotalRegionCount())
+	regions.RemoveRegion(region3)
+	re.Equal(1, regions.GetTotalRegionCount())
+
+	regions.ResetRegionCache()
+	re.Zero(regions.GetTotalRegionCount())
+}
+
+func TestCheckAndPutRegionNoOverlap(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+
+	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("c"))
+	overlaps := regions.CheckAndPutRegionNoOverlap(region1)
+	re.Empty(overlaps)
+	re.Equal(1, regions.GetTotalRegionCount())
+	re.Equal(1, regions.TreeLen())
+	re.Equal(1, regions.GetStoreRegionCount(1))
+	re.Equal(int32(2), region1.GetRef())
+
+	region2 := NewTestRegionInfo(2, 1, []byte("c"), []byte("e"))
+	overlaps = regions.CheckAndPutRegionNoOverlap(region2)
+	re.Empty(overlaps)
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Equal(2, regions.TreeLen())
+	re.Equal(2, regions.GetStoreRegionCount(1))
+	re.Equal(int32(2), region2.GetRef())
+
+	// Existing IDs fall back to the normal checked path.
+	regions.CheckAndPutRegionNoOverlap(NewTestRegionInfo(2, 2, []byte("c"), []byte("e")))
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Equal(2, regions.TreeLen())
+}
+
 func TestResetRegionCache(t *testing.T) {
 	re := require.New(t)
 	regions := NewRegionsInfo()

--- a/pkg/storage/endpoint/meta.go
+++ b/pkg/storage/endpoint/meta.go
@@ -58,9 +58,15 @@ var _ MetaStorage = (*StorageEndpoint)(nil)
 const (
 	// MaxKVRangeLimit is the max limit of the number of keys in a range.
 	MaxKVRangeLimit = 10000
+	// MaxLocalKVRangeLimit is the max limit of the number of keys in a local KV range.
+	MaxLocalKVRangeLimit = 100000
 	// MinKVRangeLimit is the min limit of the number of keys in a range.
 	MinKVRangeLimit = 100
 )
+
+type regionBytesLoader interface {
+	LoadRangeValues(startKey, endKey string, limit int) ([][]byte, error)
+}
 
 // LoadMeta loads cluster meta from the storage. This method will only
 // be used by the PD server, so we should only implement it for the etcd storage.
@@ -177,14 +183,14 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 	// Since the region key may be very long, using a larger rangeLimit will cause
 	// the message packet to exceed the grpc message size limit (4MB). Here we use
 	// a variable rangeLimit to work around.
-	rangeLimit := MaxKVRangeLimit
+	rangeLimit := se.regionLoadRangeLimit()
 	for {
 		failpoint.Inject("slowLoadRegion", func() {
 			rangeLimit = 1
 			time.Sleep(time.Second)
 		})
 		startKey := keypath.RegionPath(se.nextRegionID)
-		_, res, err := se.LoadRange(startKey, endKey, rangeLimit)
+		res, err := se.loadRegionValues(startKey, endKey, rangeLimit)
 		if err != nil {
 			if rangeLimit /= 2; rangeLimit >= MinKVRangeLimit {
 				continue
@@ -199,7 +205,7 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 
 		for _, r := range res {
 			region := &metapb.Region{}
-			if err := region.Unmarshal([]byte(r)); err != nil {
+			if err := region.Unmarshal(r); err != nil {
 				return errs.ErrProtoUnmarshal.Wrap(err).GenWithStackByArgs()
 			}
 			if err = encryption.DecryptRegion(region, se.encryptionKeyManager); err != nil {
@@ -219,6 +225,28 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 			return nil
 		}
 	}
+}
+
+func (se *StorageEndpoint) regionLoadRangeLimit() int {
+	if _, ok := se.Base.(regionBytesLoader); ok {
+		return MaxLocalKVRangeLimit
+	}
+	return MaxKVRangeLimit
+}
+
+func (se *StorageEndpoint) loadRegionValues(startKey, endKey string, limit int) ([][]byte, error) {
+	if loader, ok := se.Base.(regionBytesLoader); ok {
+		return loader.LoadRangeValues(startKey, endKey, limit)
+	}
+	_, values, err := se.LoadRange(startKey, endKey, limit)
+	if err != nil {
+		return nil, err
+	}
+	res := make([][]byte, 0, len(values))
+	for _, value := range values {
+		res = append(res, []byte(value))
+	}
+	return res, nil
 }
 
 // SaveRegion saves one region to storage.

--- a/pkg/storage/endpoint/meta_test.go
+++ b/pkg/storage/endpoint/meta_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/storage/kv"
+)
+
+type testRegionBytesLoader struct {
+	kv.Base
+	called    bool
+	lastLimit int
+}
+
+func (l *testRegionBytesLoader) LoadRangeValues(startKey, endKey string, limit int) ([][]byte, error) {
+	l.called = true
+	l.lastLimit = limit
+	_, values, err := l.Base.LoadRange(startKey, endKey, limit)
+	if err != nil {
+		return nil, err
+	}
+	res := make([][]byte, 0, len(values))
+	for _, value := range values {
+		res = append(res, []byte(value))
+	}
+	return res, nil
+}
+
+func TestLoadRegionsWithBytesLoader(t *testing.T) {
+	re := require.New(t)
+	loader := &testRegionBytesLoader{Base: kv.NewMemoryKV()}
+	storage := NewStorageEndpoint(loader, nil)
+	region := &metapb.Region{
+		Id:       1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("b"),
+	}
+	re.NoError(storage.SaveRegion(region))
+
+	var loaded []*core.RegionInfo
+	re.NoError(storage.LoadRegions(context.Background(), func(region *core.RegionInfo) []*core.RegionInfo {
+		loaded = append(loaded, region)
+		return nil
+	}))
+
+	re.True(loader.called)
+	re.Equal(MaxLocalKVRangeLimit, loader.lastLimit)
+	re.Len(loaded, 1)
+	re.Equal(region, loaded[0].GetMeta())
+}

--- a/pkg/storage/kv/levedb_kv.go
+++ b/pkg/storage/kv/levedb_kv.go
@@ -67,7 +67,33 @@ func (kv *LevelDBKV) LoadRange(startKey, endKey string, limit int) (keys, values
 		count++
 	}
 	iter.Release()
+	if err = iter.Error(); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
 	return keys, values, nil
+}
+
+// LoadRangeValues gets raw values for a given key range.
+func (kv *LevelDBKV) LoadRangeValues(startKey, endKey string, limit int) (values [][]byte, err error) {
+	iter := kv.NewIterator(&util.Range{Start: []byte(startKey), Limit: []byte(endKey)}, nil)
+	capacity := limit
+	if capacity < 0 {
+		capacity = 0
+	}
+	values = make([][]byte, 0, capacity)
+	count := 0
+	for iter.Next() {
+		if limit > 0 && count >= limit {
+			break
+		}
+		values = append(values, append([]byte(nil), iter.Value()...))
+		count++
+	}
+	iter.Release()
+	if err = iter.Error(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return values, nil
 }
 
 // Save stores a key-value pair.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	errorspkg "errors"
@@ -869,7 +870,8 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 	start = time.Now()
 
 	// used to load region from kv storage to cache storage.
-	if err = storage.TryLoadRegionsOnce(c.ctx, c.storage, c.CheckAndPutRegion); err != nil {
+	regionLoader := newLoadedRegionChecker(c)
+	if err = storage.TryLoadRegionsOnce(c.ctx, c.storage, regionLoader.checkAndPut); err != nil {
 		return nil, err
 	}
 	log.Info("load regions",
@@ -878,6 +880,50 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 	)
 
 	return c, nil
+}
+
+type loadedRegionChecker struct {
+	cluster           *RaftCluster
+	hasMaxEndKey      bool
+	maxEndKeyInfinite bool
+	maxEndKey         []byte
+}
+
+func newLoadedRegionChecker(cluster *RaftCluster) *loadedRegionChecker {
+	return &loadedRegionChecker{cluster: cluster}
+}
+
+func (l *loadedRegionChecker) checkAndPut(region *core.RegionInfo) []*core.RegionInfo {
+	noOverlap := l.hasNoOverlap(region)
+	l.updateMaxEndKey(region)
+	if noOverlap {
+		return l.cluster.CheckAndPutRegionNoOverlap(region)
+	}
+	return l.cluster.CheckAndPutRegion(region)
+}
+
+func (l *loadedRegionChecker) hasNoOverlap(region *core.RegionInfo) bool {
+	if !l.hasMaxEndKey {
+		return true
+	}
+	return !l.maxEndKeyInfinite && bytes.Compare(l.maxEndKey, region.GetStartKey()) <= 0
+}
+
+func (l *loadedRegionChecker) updateMaxEndKey(region *core.RegionInfo) {
+	if l.maxEndKeyInfinite {
+		return
+	}
+	endKey := region.GetEndKey()
+	if len(endKey) == 0 {
+		l.hasMaxEndKey = true
+		l.maxEndKeyInfinite = true
+		l.maxEndKey = nil
+		return
+	}
+	if !l.hasMaxEndKey || bytes.Compare(l.maxEndKey, endKey) < 0 {
+		l.hasMaxEndKey = true
+		l.maxEndKey = endKey
+	}
 }
 
 func (c *RaftCluster) runMetricsCollectionJob() {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -77,6 +77,30 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
 }
 
+func TestLoadedRegionCheckerNoOverlapHint(t *testing.T) {
+	re := require.New(t)
+	checker := newLoadedRegionChecker(nil)
+
+	region1 := core.NewRegionInfo(&metapb.Region{Id: 1, StartKey: []byte("a"), EndKey: []byte("c")}, nil)
+	re.True(checker.hasNoOverlap(region1))
+	checker.updateMaxEndKey(region1)
+
+	region2 := core.NewRegionInfo(&metapb.Region{Id: 2, StartKey: []byte("b"), EndKey: []byte("d")}, nil)
+	re.False(checker.hasNoOverlap(region2))
+	checker.updateMaxEndKey(region2)
+
+	region3 := core.NewRegionInfo(&metapb.Region{Id: 3, StartKey: []byte("d"), EndKey: []byte("e")}, nil)
+	re.True(checker.hasNoOverlap(region3))
+	checker.updateMaxEndKey(region3)
+
+	region4 := core.NewRegionInfo(&metapb.Region{Id: 4, StartKey: []byte("e")}, nil)
+	re.True(checker.hasNoOverlap(region4))
+	checker.updateMaxEndKey(region4)
+
+	region5 := core.NewRegionInfo(&metapb.Region{Id: 5, StartKey: []byte("f"), EndKey: []byte("g")}, nil)
+	re.False(checker.hasNoOverlap(region5))
+}
+
 func TestStoreHeartbeat(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/server.go
+++ b/server/server.go
@@ -842,6 +842,24 @@ func (s *Server) createRaftCluster() error {
 	return s.cluster.Start(s, false)
 }
 
+func (s *Server) startEmbeddedTSOService() (bool, error) {
+	if s.IsKeyspaceGroupEnabled() || s.tsoAllocator == nil || s.tsoAllocator.IsInitialize() {
+		return false, nil
+	}
+	log.Info("initializing the embedded TSO allocator")
+	if err := s.tsoAllocator.Initialize(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Server) resetEmbeddedTSOService() {
+	if s.IsKeyspaceGroupEnabled() || s.tsoAllocator == nil || !s.tsoAllocator.IsInitialize() {
+		return
+	}
+	s.tsoAllocator.Reset(false)
+}
+
 func (s *Server) stopRaftCluster() {
 	failpoint.Inject("raftclusterIsBusy", func() {})
 	s.cluster.Stop()
@@ -1805,15 +1823,19 @@ func (s *Server) campaignLeader() {
 	callbacksDuration := time.Since(callbacksStart)
 	log.Info("trigger leader callback functions completed", zap.Duration("cost", callbacksDuration))
 
-	// Try to create raft cluster.
-	createRaftClusterStart := time.Now()
-	if err := s.createRaftCluster(); err != nil {
-		log.Warn("failed to create raft cluster", errs.ZapError(err), zap.Duration("cost", time.Since(createRaftClusterStart)))
+	tsoStart := time.Now()
+	embeddedTSOStarted, err := s.startEmbeddedTSOService()
+	if err != nil {
+		log.Warn("failed to start embedded TSO service", errs.ZapError(err), zap.Duration("cost", time.Since(tsoStart)))
 		return
 	}
-	createRaftClusterDuration := time.Since(createRaftClusterStart)
-	log.Info("create raft cluster completed", zap.Duration("cost", createRaftClusterDuration))
-	defer s.stopRaftCluster()
+	log.Info("start embedded TSO service completed",
+		zap.Bool("started", embeddedTSOStarted),
+		zap.Duration("cost", time.Since(tsoStart)))
+	if embeddedTSOStarted {
+		defer s.resetEmbeddedTSOService()
+	}
+
 	failpoint.Inject("rebaseErr", func() {
 		failpoint.Return()
 	})
@@ -1824,25 +1846,42 @@ func (s *Server) campaignLeader() {
 	}
 	rebaseDuration := time.Since(rebaseStart)
 	log.Info("sync id from etcd completed", zap.Duration("cost", rebaseDuration))
-	// PromoteSelf to accept the remaining service, such as GetStore, GetRegion.
+	// PromoteSelf to accept core services, such as TSO. Region-related services
+	// still wait until the raft cluster is fully started below.
 	enableLeaderStart := time.Now()
 	s.member.PromoteSelf()
 	enableLeaderDuration := time.Since(enableLeaderStart)
 	member.ServiceMemberGauge.WithLabelValues(PD).Set(1)
+	defer member.ServiceMemberGauge.WithLabelValues(PD).Set(0)
 	totalDuration := time.Since(leaderReadyStart)
+	CheckPDVersionWithClusterVersion(s.persistOptions)
+	log.Info("PD leader is ready to serve core services",
+		zap.String("leader-name", s.Name()),
+		zap.Duration("total-cost", totalDuration),
+		zap.Duration("cost", enableLeaderDuration))
+
+	failpoint.Inject("delayCreateRaftCluster", func(val failpoint.Value) {
+		if delay, ok := val.(int); ok {
+			time.Sleep(time.Duration(delay) * time.Millisecond)
+		}
+	})
+
+	// Try to create raft cluster.
+	createRaftClusterStart := time.Now()
+	if err := s.createRaftCluster(); err != nil {
+		log.Warn("failed to create raft cluster", errs.ZapError(err), zap.Duration("cost", time.Since(createRaftClusterStart)))
+		return
+	}
+	createRaftClusterDuration := time.Since(createRaftClusterStart)
+	log.Info("create raft cluster completed", zap.Duration("cost", createRaftClusterDuration))
+	defer s.stopRaftCluster()
 	defer resetLeaderOnce.Do(func() {
 		// as soon as cancel the leadership keepalive, then other member have chance
 		// to be new leader.
 		cancel()
 		s.member.Resign()
-		member.ServiceMemberGauge.WithLabelValues(PD).Set(0)
 	})
 
-	CheckPDVersionWithClusterVersion(s.persistOptions)
-	log.Info("PD leader is ready to serve",
-		zap.String("leader-name", s.Name()),
-		zap.Duration("total-cost", totalDuration),
-		zap.Duration("cost", enableLeaderDuration))
 	leaderTicker := time.NewTicker(mcs.LeaderTickInterval)
 	defer leaderTicker.Stop()
 

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -113,6 +113,55 @@ func (s *tsoTestSuite) TestDelaySyncTimestamp() {
 	s.env.RunTestInNonMicroserviceEnv(s.checkDelaySyncTimestamp)
 }
 
+func (s *tsoTestSuite) TestServeBeforeRaftClusterLoaded() {
+	s.env.RunTestInNonMicroserviceEnv(s.checkServeBeforeRaftClusterLoaded)
+}
+
+func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestCluster) {
+	re := s.Require()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	leaderServer := cluster.GetLeaderServer()
+	var nextLeaderServer *tests.TestServer
+	for _, s := range cluster.GetServers() {
+		if s.GetConfig().Name != cluster.GetLeader() {
+			nextLeaderServer = s
+		}
+	}
+	re.NotNil(nextLeaderServer)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayCreateRaftCluster", `return(5000)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayCreateRaftCluster"))
+	}()
+
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	re.True(nextLeaderServer.WaitLeader())
+	re.Nil(nextLeaderServer.GetRaftCluster())
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, nextLeaderServer.GetAddr())
+	defer conn.Close()
+	req := &pdpb.TsoRequest{
+		Header: testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		Count:  1,
+	}
+	tsoClient, err := grpcPDClient.Tso(ctx)
+	re.NoError(err)
+	defer func() {
+		err = tsoClient.CloseSend()
+		re.NoError(err)
+	}()
+	re.NoError(tsoClient.Send(req))
+	resp, err := tsoClient.Recv()
+	re.NoError(err)
+	re.NotNil(checkAndReturnTimestampResponse(re, req, resp))
+
+	testutil.Eventually(re, func() bool {
+		return nextLeaderServer.GetRaftCluster() != nil
+	})
+}
+
 func (s *tsoTestSuite) checkDelaySyncTimestamp(cluster *tests.TestCluster) {
 	re := s.Require()
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10768, Close #10769

### What is changed and how does it work?

```commit-message
Use a local LevelDB bytes fast path when loading region metadata so startup region load avoids the string -> []byte conversion path and can use a larger local batch without changing the etcd range limit.

Reuse known-empty overlap results while updating region subtrees, and use an ordered-load no-overlap hint during startup loading when the current region start key is beyond the maximum end key loaded so far. This avoids redundant overlap scans for monotonic, non-overlapping region data while falling back to the normal checked path for unordered ranges.

Maintain the total region count with an atomic counter so read-only count APIs do not need to acquire the region tree lock.
```

### Check List

Tests

- Unit test
- Manual test (add detailed scripts or steps below)

Manual test details:

- Focused tests:
  - `make gotest GOTEST_ARGS="./pkg/core ./server/cluster ./pkg/storage/endpoint ./pkg/storage -run TestCheckAndPutRegionNoOverlap\\|TestLoadedRegionCheckerNoOverlapHint\\|TestSetRegion\\|TestCheckAndPutSubTree\\|TestRegionCount\\|TestTotalRegionCount\\|TestResetRegionCache\\|TestLoadRegionsWithBytesLoader\\|TestLoadRegions\\|TestLoadRegionsToCache\\|TestLoadRegionsExceedRangeLimit\\|TestRegionReload\\|TestRegionStorage -count=1"`
- Local LevelDB load benchmark smoke test:
  - `make gotest GOTEST_ARGS="./pkg/storage -run=TestNoSuchTest -bench=BenchmarkLoadRegionsByVolume/input.size.100000 -benchtime=1x -count=1"`
- 100M-region PD environment validation on testbed `8123033`:
  - Region count: `100,015,214`.
  - Pod was not deleted or recreated; pod UID stayed `77ab2a82-4262-4c31-9013-d03d6cceeba9`, container restartCount stayed `0`.
  - Original process-only restart baseline: `load regions` `18m14.087s`.
  - Intermediate local-bytes-only candidate: `load regions` `17m27.657s`.
  - Final candidate in this PR: `load regions` `10m32.815s`; `/health` + direct TSO ready in `10m42s` after TERM; direct TSO latency `37.338ms`.
  - `/pd/api/v1/regions/count` at 100M returned HTTP `200` in `76.944ms` with count `100,015,214`.
  - Post-ready CPU/heap profiles were collected; CPU was dominated by GC over the large live heap, and the largest heap holders remained region metadata, protobuf region objects, and btree/subtree storage.

### Release note

```release-note
Improve PD startup region loading performance and reduce /regions/count lock contention for large clusters.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimized fast-path for inserting non-overlapping regions
  * Byte-based storage loader for more efficient region loading

* **Bug Fixes**
  * Better error handling for key-value range iteration

* **Performance**
  * Atomic region-count tracking to reduce lock contention
  * Faster cluster load path that can skip unnecessary overlap checks

* **Tests**
  * Added tests for region counting, fast-path inserts, byte-loader, and startup/TSO behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->