### PR TITLE
checker: replace persistently down peers when store is up

### DIFF
--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -193,6 +193,14 @@ func (c *Cluster) GetRegionStats() *statistics.RegionStatistics {
 	return c.regionStats
 }
 
+// GetRegionDownDuration returns how long a region has had down peers.
+func (c *Cluster) GetRegionDownDuration(regionID uint64) time.Duration {
+	if c.regionStats == nil {
+		return 0
+	}
+	return c.regionStats.GetRegionDownDuration(regionID)
+}
+
 // GetLabelStats gets label statistics.
 func (c *Cluster) GetLabelStats() *statistics.LabelStatistics {
 	return c.labelStats

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -336,6 +336,11 @@ func (o *PersistConfig) GetMaxStoreDownTime() time.Duration {
 	return o.GetScheduleConfig().MaxStoreDownTime.Duration
 }
 
+// GetMaxDownPeerDuration returns the max duration a peer can be down before replacement.
+func (o *PersistConfig) GetMaxDownPeerDuration() time.Duration {
+	return o.GetScheduleConfig().MaxDownPeerDuration.Duration
+}
+
 // GetIsolationLevel returns the isolation label for each region.
 func (o *PersistConfig) GetIsolationLevel() string {
 	return o.GetReplicationConfig().IsolationLevel

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -65,6 +65,7 @@ type Cluster struct {
 	pendingProcessedRegions map[uint64]struct{}
 	*buckets.HotBucketCache
 	storage.Storage
+	regionDownDurations map[uint64]time.Duration
 }
 
 // NewCluster creates a new Cluster
@@ -80,6 +81,7 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 		KeyRangeManager:         keyrange.NewManager(),
 		pendingProcessedRegions: map[uint64]struct{}{},
 		Storage:                 storage.NewStorageWithMemoryBackend(),
+		regionDownDurations:     map[uint64]time.Duration{},
 	}
 	if c.PersistOptions.GetReplicationConfig().EnablePlacementRules {
 		c.initRuleManager()
@@ -153,6 +155,16 @@ func (mc *Cluster) GetStoresLoads() map[uint64]statistics.StoreKindLoads {
 // IsRegionHot checks if the region is hot.
 func (mc *Cluster) IsRegionHot(region *core.RegionInfo) bool {
 	return mc.HotCache.IsRegionHot(region, mc.GetHotRegionCacheHitsThreshold())
+}
+
+// GetRegionDownDuration returns the mock down duration for a region, or 0 if not set.
+func (mc *Cluster) GetRegionDownDuration(regionID uint64) time.Duration {
+	return mc.regionDownDurations[regionID]
+}
+
+// SetRegionDownDuration sets the mock down duration for a region.
+func (mc *Cluster) SetRegionDownDuration(regionID uint64, d time.Duration) {
+	mc.regionDownDurations[regionID] = d
 }
 
 // GetHotPeerStat returns hot peer stat with specified regionID and storeID.

--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -65,7 +65,7 @@ type Cluster struct {
 	pendingProcessedRegions map[uint64]struct{}
 	*buckets.HotBucketCache
 	storage.Storage
-	regionDownDurations map[uint64]time.Duration
+	regionStats *statistics.RegionStatistics
 }
 
 // NewCluster creates a new Cluster
@@ -81,7 +81,7 @@ func NewCluster(ctx context.Context, opts *config.PersistOptions) *Cluster {
 		KeyRangeManager:         keyrange.NewManager(),
 		pendingProcessedRegions: map[uint64]struct{}{},
 		Storage:                 storage.NewStorageWithMemoryBackend(),
-		regionDownDurations:     map[uint64]time.Duration{},
+		regionStats:             statistics.NewRegionStatistics(bc, opts, nil),
 	}
 	if c.PersistOptions.GetReplicationConfig().EnablePlacementRules {
 		c.initRuleManager()
@@ -157,14 +157,14 @@ func (mc *Cluster) IsRegionHot(region *core.RegionInfo) bool {
 	return mc.HotCache.IsRegionHot(region, mc.GetHotRegionCacheHitsThreshold())
 }
 
-// GetRegionDownDuration returns the mock down duration for a region, or 0 if not set.
+// GetRegionDownDuration returns how long a region has had down peers.
 func (mc *Cluster) GetRegionDownDuration(regionID uint64) time.Duration {
-	return mc.regionDownDurations[regionID]
+	return mc.regionStats.GetRegionDownDuration(regionID)
 }
 
-// SetRegionDownDuration sets the mock down duration for a region.
-func (mc *Cluster) SetRegionDownDuration(regionID uint64, d time.Duration) {
-	mc.regionDownDurations[regionID] = d
+// HandleRegionHeartbeat processes RegionInfo reports from client.
+func (mc *Cluster) HandleRegionHeartbeat(region *core.RegionInfo) {
+	mc.regionStats.Observe(region, mc.GetStores())
 }
 
 // GetHotPeerStat returns hot peer stat with specified regionID and storeID.

--- a/pkg/schedule/checker/metrics.go
+++ b/pkg/schedule/checker/metrics.go
@@ -207,6 +207,7 @@ var (
 	ruleCheckerNeedSplitCounter                   = ruleCheckerCounterWithEvent("need-split")
 	ruleCheckerSetCacheCounter                    = ruleCheckerCounterWithEvent("set-cache")
 	ruleCheckerReplaceDownCounter                 = ruleCheckerCounterWithEvent("replace-down")
+	ruleCheckerReplaceDownByDurationCounter       = ruleCheckerCounterWithEvent("replace-down-by-duration")
 	ruleCheckerPromoteWitnessCounter              = ruleCheckerCounterWithEvent("promote-witness")
 	ruleCheckerReplaceOfflineCounter              = ruleCheckerCounterWithEvent("replace-offline")
 	ruleCheckerAddRulePeerCounter                 = ruleCheckerCounterWithEvent("add-rule-peer")
@@ -275,6 +276,7 @@ var (
 	replicaCheckerNoStoreOfflineCounter           = replicaCheckerCounterWithEvent("no-store-offline")
 	replicaCheckerNoStoreDownCounter              = replicaCheckerCounterWithEvent("no-store-down")
 	replicaCheckerReplaceOfflineFailedCounter     = replicaCheckerCounterWithEvent("replace-offline-replica-failed")
+	replicaCheckerReplaceDownByDurationCounter    = replicaCheckerCounterWithEvent("replace-down-by-duration")
 	replicaCheckerReplaceDownFailedCounter        = replicaCheckerCounterWithEvent("replace-down-replica-failed")
 
 	splitCheckerCounter       = checkerCounter.WithLabelValues(splitChecker, "check")

--- a/pkg/schedule/checker/replica_checker.go
+++ b/pkg/schedule/checker/replica_checker.go
@@ -117,8 +117,9 @@ func (c *ReplicaChecker) checkDownPeer(region *core.RegionInfo) *operator.Operat
 			log.Warn("lost the store, maybe you are recovering the PD cluster", zap.Uint64("store-id", storeID))
 			return nil
 		}
-		// Only consider the state of the Store, not `stats.DownSeconds`.
-		if store.DownTime() < c.conf.GetMaxStoreDownTime() {
+		if c.isPeerDownTooLong(region) {
+			replicaCheckerReplaceDownByDurationCounter.Inc()
+		} else if store.DownTime() < c.conf.GetMaxStoreDownTime() {
 			continue
 		}
 		return c.fixPeer(region, storeID, downStatus)
@@ -291,4 +292,12 @@ func (c *ReplicaChecker) strategy(region *core.RegionInfo) *ReplicaStrategy {
 		isolationLevel: c.conf.GetIsolationLevel(),
 		region:         region,
 	}
+}
+
+func (c *ReplicaChecker) isPeerDownTooLong(region *core.RegionInfo) bool {
+	downDuration := c.cluster.GetRegionDownDuration(region.GetID())
+	if downDuration <= 0 {
+		return false
+	}
+	return downDuration >= c.conf.GetMaxDownPeerDuration()
 }

--- a/pkg/schedule/checker/replica_checker.go
+++ b/pkg/schedule/checker/replica_checker.go
@@ -117,7 +117,7 @@ func (c *ReplicaChecker) checkDownPeer(region *core.RegionInfo) *operator.Operat
 			log.Warn("lost the store, maybe you are recovering the PD cluster", zap.Uint64("store-id", storeID))
 			return nil
 		}
-		if c.isPeerDownTooLong(region) {
+		if hasPeerDownTooLong(c.cluster, region) {
 			replicaCheckerReplaceDownByDurationCounter.Inc()
 		} else if store.DownTime() < c.conf.GetMaxStoreDownTime() {
 			continue
@@ -294,10 +294,11 @@ func (c *ReplicaChecker) strategy(region *core.RegionInfo) *ReplicaStrategy {
 	}
 }
 
-func (c *ReplicaChecker) isPeerDownTooLong(region *core.RegionInfo) bool {
-	downDuration := c.cluster.GetRegionDownDuration(region.GetID())
+// hasPeerDownTooLong checks whether a region has had down peers longer than the configured threshold.
+func hasPeerDownTooLong(cluster sche.CheckerCluster, region *core.RegionInfo) bool {
+	downDuration := cluster.GetRegionDownDuration(region.GetID())
 	if downDuration <= 0 {
 		return false
 	}
-	return downDuration >= c.conf.GetMaxDownPeerDuration()
+	return downDuration >= cluster.GetCheckerConfig().GetMaxDownPeerDuration()
 }

--- a/pkg/schedule/checker/replica_checker_test.go
+++ b/pkg/schedule/checker/replica_checker_test.go
@@ -33,7 +33,9 @@ import (
 	"github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/pkg/versioninfo"
+	serverconfig "github.com/tikv/pd/server/config"
 )
 
 type replicaCheckerTestSuite struct {
@@ -579,7 +581,9 @@ func (suite *replicaCheckerTestSuite) TestFixDownPeer() {
 
 func (suite *replicaCheckerTestSuite) TestReplaceDownPeerWhenStoreUp() {
 	re := suite.Require()
-	opt := mockconfig.NewTestOptions()
+	c := serverconfig.NewConfig()
+	c.Schedule.MaxDownPeerDuration = typeutil.NewDuration(5 * time.Second)
+	opt := serverconfig.NewPersistOptions(c)
 	tc := mockcluster.NewCluster(suite.ctx, opt)
 	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
 	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewIDTTL(suite.ctx, time.Minute, 3*time.Minute))
@@ -593,15 +597,13 @@ func (suite *replicaCheckerTestSuite) TestReplaceDownPeerWhenStoreUp() {
 	region := tc.GetRegion(1)
 	re.Nil(rc.Check(region))
 
-	// Store 3 is UP but peer on store 3 is down.
 	r := region.Clone(core.WithDownPeers([]*pdpb.PeerStats{
 		{Peer: region.GetStorePeer(3), DownSeconds: 600},
 	}))
-	// Default MaxDownPeerDuration is 30min, peer only down for 10min → no replacement.
+	tc.HandleRegionHeartbeat(r)
 	re.Nil(rc.Check(r))
 
-	// Peer has been down 1h, exceeds default 30min MaxDownPeerDuration → should replace.
-	tc.SetRegionDownDuration(1, 1*time.Hour)
+	time.Sleep(5 * time.Second)
 	op := rc.Check(r)
 	re.NotNil(op)
 	re.Contains(op.Desc(), "replace-down-replica")

--- a/pkg/schedule/checker/replica_checker_test.go
+++ b/pkg/schedule/checker/replica_checker_test.go
@@ -577,6 +577,36 @@ func (suite *replicaCheckerTestSuite) TestFixDownPeer() {
 	re.Nil(rc.Check(region))
 }
 
+func (suite *replicaCheckerTestSuite) TestReplaceDownPeerWhenStoreUp() {
+	re := suite.Require()
+	opt := mockconfig.NewTestOptions()
+	tc := mockcluster.NewCluster(suite.ctx, opt)
+	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
+	rc := NewReplicaChecker(tc, tc.GetCheckerConfig(), cache.NewIDTTL(suite.ctx, time.Minute, 3*time.Minute))
+
+	tc.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
+	tc.AddLabelsStore(2, 1, map[string]string{"zone": "z2"})
+	tc.AddLabelsStore(3, 1, map[string]string{"zone": "z3"})
+	tc.AddLabelsStore(4, 1, map[string]string{"zone": "z4"})
+
+	tc.AddLeaderRegion(1, 1, 2, 3)
+	region := tc.GetRegion(1)
+	re.Nil(rc.Check(region))
+
+	// Store 3 is UP but peer on store 3 is down.
+	r := region.Clone(core.WithDownPeers([]*pdpb.PeerStats{
+		{Peer: region.GetStorePeer(3), DownSeconds: 600},
+	}))
+	// Default MaxDownPeerDuration is 30min, peer only down for 10min → no replacement.
+	re.Nil(rc.Check(r))
+
+	// Peer has been down 1h, exceeds default 30min MaxDownPeerDuration → should replace.
+	tc.SetRegionDownDuration(1, 1*time.Hour)
+	op := rc.Check(r)
+	re.NotNil(op)
+	re.Contains(op.Desc(), "replace-down-replica")
+}
+
 // See issue: https://github.com/tikv/pd/issues/3705
 func (suite *replicaCheckerTestSuite) TestFixOfflinePeer() {
 	re := suite.Require()

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -157,7 +157,7 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 				ruleCheckerReplaceDownCounter.Inc()
 				return c.replaceUnexpectedRulePeer(region, rf, fit, peer, downStatus)
 			}
-			if c.isPeerDownTooLong(region) {
+			if hasPeerDownTooLong(c.cluster, region) {
 				ruleCheckerReplaceDownByDurationCounter.Inc()
 				return c.replaceUnexpectedRulePeer(region, rf, fit, peer, downStatus)
 			}
@@ -568,14 +568,6 @@ func (c *RuleChecker) isStoreDownTimeHitMaxDownTime(storeID uint64) bool {
 		return false
 	}
 	return store.DownTime() >= c.cluster.GetCheckerConfig().GetMaxStoreDownTime()
-}
-
-func (c *RuleChecker) isPeerDownTooLong(region *core.RegionInfo) bool {
-	downDuration := c.cluster.GetRegionDownDuration(region.GetID())
-	if downDuration <= 0 {
-		return false
-	}
-	return downDuration >= c.cluster.GetCheckerConfig().GetMaxDownPeerDuration()
 }
 
 func (c *RuleChecker) isOfflinePeer(peer *metapb.Peer) bool {

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -157,6 +157,10 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 				ruleCheckerReplaceDownCounter.Inc()
 				return c.replaceUnexpectedRulePeer(region, rf, fit, peer, downStatus)
 			}
+			if c.isPeerDownTooLong(region) {
+				ruleCheckerReplaceDownByDurationCounter.Inc()
+				return c.replaceUnexpectedRulePeer(region, rf, fit, peer, downStatus)
+			}
 			// When witness placement rule is enabled, promotes the witness to voter when region has down voter.
 			if isWitnessEnabled(c.cluster) && core.IsVoter(peer) {
 				if witness, ok := c.hasAvailableWitness(region, peer); ok {
@@ -564,6 +568,14 @@ func (c *RuleChecker) isStoreDownTimeHitMaxDownTime(storeID uint64) bool {
 		return false
 	}
 	return store.DownTime() >= c.cluster.GetCheckerConfig().GetMaxStoreDownTime()
+}
+
+func (c *RuleChecker) isPeerDownTooLong(region *core.RegionInfo) bool {
+	downDuration := c.cluster.GetRegionDownDuration(region.GetID())
+	if downDuration <= 0 {
+		return false
+	}
+	return downDuration >= c.cluster.GetCheckerConfig().GetMaxDownPeerDuration()
 }
 
 func (c *RuleChecker) isOfflinePeer(peer *metapb.Peer) bool {

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -1528,7 +1528,7 @@ func (suite *ruleCheckerTestSuite) TestReplaceDownPeerWhenStoreUp() {
 	r := region.Clone(core.WithDownPeers([]*pdpb.PeerStats{
 		{Peer: region.GetStorePeer(3), DownSeconds: 600},
 	}))
-	// Default MaxDownPeerDuration is 1h, peer only down for 10min → no replacement.
+	// Default MaxDownPeerDuration is 30min, peer only down for 10min → no replacement.
 	re.Nil(suite.rc.Check(r))
 
 	// Peer has been down 1h, exceeds default 30min MaxDownPeerDuration → should replace.

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -37,7 +37,9 @@ import (
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/pkg/versioninfo"
+	serverconfig "github.com/tikv/pd/server/config"
 )
 
 func TestRuleCheckerTestSuite(t *testing.T) {
@@ -1515,25 +1517,32 @@ func (suite *ruleCheckerTestSuite) TestFixDownPeerWithNoWitness() {
 
 func (suite *ruleCheckerTestSuite) TestReplaceDownPeerWhenStoreUp() {
 	re := suite.Require()
-	suite.cluster.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
-	suite.cluster.AddLabelsStore(2, 1, map[string]string{"zone": "z2"})
-	suite.cluster.AddLabelsStore(3, 1, map[string]string{"zone": "z3"})
-	suite.cluster.AddLabelsStore(4, 1, map[string]string{"zone": "z4"})
-	suite.cluster.AddLeaderRegion(1, 1, 2, 3)
+	c := serverconfig.NewConfig()
+	c.Schedule.MaxDownPeerDuration = typeutil.NewDuration(5 * time.Second)
+	opt := serverconfig.NewPersistOptions(c)
+	tc := mockcluster.NewCluster(suite.ctx, opt)
+	tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.SwitchWitness))
+	tc.SetEnablePlacementRules(true)
+	rc := NewRuleChecker(suite.ctx, tc, tc.GetRuleManager(), cache.NewIDTTL(suite.ctx, time.Minute, 3*time.Minute))
 
-	region := suite.cluster.GetRegion(1)
-	re.Nil(suite.rc.Check(region))
+	tc.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
+	tc.AddLabelsStore(2, 1, map[string]string{"zone": "z2"})
+	tc.AddLabelsStore(3, 1, map[string]string{"zone": "z3"})
+	tc.AddLabelsStore(4, 1, map[string]string{"zone": "z4"})
+	tc.AddLeaderRegion(1, 1, 2, 3)
 
-	// Store 3 is UP but peer on store 3 is down.
+	region := tc.GetRegion(1)
+	re.Nil(rc.Check(region))
+
 	r := region.Clone(core.WithDownPeers([]*pdpb.PeerStats{
 		{Peer: region.GetStorePeer(3), DownSeconds: 600},
 	}))
-	// Default MaxDownPeerDuration is 30min, peer only down for 10min → no replacement.
-	re.Nil(suite.rc.Check(r))
 
-	// Peer has been down 1h, exceeds default 30min MaxDownPeerDuration → should replace.
-	suite.cluster.SetRegionDownDuration(1, 1*time.Hour)
-	op := suite.rc.Check(r)
+	tc.HandleRegionHeartbeat(r)
+	re.Nil(rc.Check(r))
+
+	time.Sleep(5 * time.Second)
+	op := rc.Check(r)
 	re.NotNil(op)
 	re.Contains(op.Desc(), "replace-rule-down-peer")
 }

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -1513,6 +1513,31 @@ func (suite *ruleCheckerTestSuite) TestFixDownPeerWithNoWitness() {
 	re.Nil(suite.rc.Check(r))
 }
 
+func (suite *ruleCheckerTestSuite) TestReplaceDownPeerWhenStoreUp() {
+	re := suite.Require()
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"zone": "z2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"zone": "z3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"zone": "z4"})
+	suite.cluster.AddLeaderRegion(1, 1, 2, 3)
+
+	region := suite.cluster.GetRegion(1)
+	re.Nil(suite.rc.Check(region))
+
+	// Store 3 is UP but peer on store 3 is down.
+	r := region.Clone(core.WithDownPeers([]*pdpb.PeerStats{
+		{Peer: region.GetStorePeer(3), DownSeconds: 600},
+	}))
+	// Default MaxDownPeerDuration is 1h, peer only down for 10min → no replacement.
+	re.Nil(suite.rc.Check(r))
+
+	// Peer has been down 1h, exceeds default 30min MaxDownPeerDuration → should replace.
+	suite.cluster.SetRegionDownDuration(1, 1*time.Hour)
+	op := suite.rc.Check(r)
+	re.NotNil(op)
+	re.Contains(op.Desc(), "replace-rule-down-peer")
+}
+
 func (suite *ruleCheckerTestSuite) TestFixDownWitnessPeer() {
 	re := suite.Require()
 	suite.cluster.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -79,6 +79,7 @@ const (
 	defaultSwitchWitnessInterval   = time.Hour
 	defaultPatrolRegionInterval    = 10 * time.Millisecond
 	defaultMaxStoreDownTime        = 30 * time.Minute
+	defaultMaxDownPeerDuration     = 30 * time.Minute
 	defaultHotRegionsWriteInterval = 10 * time.Minute
 	// It means we skip the preparing stage after the 48 hours no matter if the store has finished preparing stage.
 	defaultMaxStorePreparingTime = 48 * time.Hour
@@ -199,6 +200,10 @@ type ScheduleConfig struct {
 	// MaxStoreDownTime is the max duration after which
 	// a store will be considered to be down if it hasn't reported heartbeats.
 	MaxStoreDownTime typeutil.Duration `toml:"max-store-down-time" json:"max-store-down-time"`
+	// MaxDownPeerDuration is the max duration a peer can be down before PD replaces it,
+	// even if the store itself is still up (sending heartbeats). This handles scenarios
+	// where a store is in a crash-loop or specific peers are persistently down.
+	MaxDownPeerDuration typeutil.Duration `toml:"max-down-peer-duration" json:"max-down-peer-duration"`
 	// MaxStorePreparingTime is the max duration after which
 	// a store will be considered to be preparing.
 	MaxStorePreparingTime typeutil.Duration `toml:"max-store-preparing-time" json:"max-store-preparing-time"`
@@ -371,6 +376,7 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	configutil.AdjustDuration(&c.SwitchWitnessInterval, defaultSwitchWitnessInterval)
 	configutil.AdjustDuration(&c.PatrolRegionInterval, defaultPatrolRegionInterval)
 	configutil.AdjustDuration(&c.MaxStoreDownTime, defaultMaxStoreDownTime)
+	configutil.AdjustDuration(&c.MaxDownPeerDuration, defaultMaxDownPeerDuration)
 	configutil.AdjustDuration(&c.HotRegionsWriteInterval, defaultHotRegionsWriteInterval)
 	if !meta.IsDefined("max-store-preparing-time") {
 		configutil.AdjustDuration(&c.MaxStorePreparingTime, defaultMaxStorePreparingTime)

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -104,6 +104,7 @@ type SharedConfigProvider interface {
 	GetLowSpaceRatio() float64
 	GetHighSpaceRatio() float64
 	GetMaxStoreDownTime() time.Duration
+	GetMaxDownPeerDuration() time.Duration
 	GetLocationLabels() []string
 	CheckLabelProperty(string, []*metapb.StoreLabel) bool
 	GetClusterVersion() *semver.Version

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -552,9 +552,9 @@ func (r *RegionStatistics) GetRegionDownDuration(regionID uint64) time.Duration 
 	if !ok || info == nil {
 		return 0
 	}
-	ts := info.(*RegionInfoWithTS).startDownPeerTS
-	if ts == 0 {
+	ri, ok := info.(*RegionInfoWithTS)
+	if !ok || ri.startDownPeerTS == 0 {
 		return 0
 	}
-	return time.Since(time.Unix(ts, 0))
+	return time.Since(time.Unix(ri.startDownPeerTS, 0))
 }

--- a/pkg/statistics/region_collection.go
+++ b/pkg/statistics/region_collection.go
@@ -541,3 +541,20 @@ func logDownPeerWithNoDisconnectedStore(region *core.RegionInfo, stores []*core.
 			zap.Uint64("store-id", p.GetPeer().GetStoreId()))
 	}
 }
+
+// GetRegionDownDuration returns how long the region has had down peers,
+// based on PD's own tracking (startDownPeerTS). Returns 0 if the region
+// is not tracked as having down peers.
+func (r *RegionStatistics) GetRegionDownDuration(regionID uint64) time.Duration {
+	r.RLock()
+	defer r.RUnlock()
+	info, ok := r.stats[DownPeer][regionID]
+	if !ok || info == nil {
+		return 0
+	}
+	ts := info.(*RegionInfoWithTS).startDownPeerTS
+	if ts == 0 {
+		return 0
+	}
+	return time.Since(time.Unix(ts, 0))
+}

--- a/pkg/statistics/region_stat_informer.go
+++ b/pkg/statistics/region_stat_informer.go
@@ -15,12 +15,17 @@
 package statistics
 
 import (
+	"time"
+
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/statistics/utils"
 )
 
 // RegionStatInformer provides access to a shared informer of statistics.
 type RegionStatInformer interface {
+	// GetRegionDownDuration returns how long a region has had down peers,
+	// based on PD's own startDownPeerTS tracking. Returns 0 if not tracked.
+	GetRegionDownDuration(regionID uint64) time.Duration
 	GetHotPeerStat(rw utils.RWType, regionID, storeID uint64) *HotPeerStat
 	IsRegionHot(region *core.RegionInfo) bool
 	// GetHotPeerStats return the read or write statistics for hot regions.

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -261,6 +261,14 @@ func (sc *schedulingController) GetStoresLoads() map[uint64]statistics.StoreKind
 	return sc.hotStat.GetStoresLoads()
 }
 
+// GetRegionDownDuration returns how long a region has had down peers.
+func (sc *schedulingController) GetRegionDownDuration(regionID uint64) time.Duration {
+	if sc.regionStats == nil {
+		return 0
+	}
+	return sc.regionStats.GetRegionDownDuration(regionID)
+}
+
 // IsRegionHot checks if a region is in hot state.
 func (sc *schedulingController) IsRegionHot(region *core.RegionInfo) bool {
 	return sc.hotStat.IsRegionHot(region, sc.opt.GetHotRegionCacheHitsThreshold())

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -448,6 +448,11 @@ func (o *PersistOptions) GetMaxStoreDownTime() time.Duration {
 	return o.GetScheduleConfig().MaxStoreDownTime.Duration
 }
 
+// GetMaxDownPeerDuration returns the max duration a peer can be down before replacement.
+func (o *PersistOptions) GetMaxDownPeerDuration() time.Duration {
+	return o.GetScheduleConfig().MaxDownPeerDuration.Duration
+}
+
 // GetMaxStorePreparingTime returns the max preparing time of a store.
 func (o *PersistOptions) GetMaxStorePreparingTime() time.Duration {
 	return o.GetScheduleConfig().MaxStorePreparingTime.Duration


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10778

### What is changed and how does it work?

```commit-message
Add MaxDownPeerDuration config (default 30min) to replace down peers
even when the store itself is up. Previously PD only checked store-level
downtime, so when a node crash-looped (store comes back up but specific
peers stay down), no replacement happened.

Expose RegionStatistics.startDownPeerTS to checkers via
GetRegionDownDuration() on RegionStatInformer. Both rule_checker and
replica_checker now check isPeerDownTooLong() as an additional condition.
```

### Check List

Tests

- Unit test

Code changes

- Has the configuration change

### Release note

```release-note
Add `max-down-peer-duration` configuration (default 30min) to replace
down peers when the store is up. This fixes an issue where PD would not
replace persistently down peers when the store was in a crash loop.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added max-down-peer-duration config (default 30m) to control when region peers become eligible for replacement; checkers now consider per-region down duration in replacement decisions.

* **Metrics**
  * Added counters to track "replace-down-by-duration" events for rule and replica checkers.

* **Tests**
  * New tests verifying replacement occurs only after the configured down-peer duration elapses while stores remain online.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->