### PR TITLE
pkg/unsaferecovery: optimize empty region overlap checks

### DIFF
--- a/pkg/unsaferecovery/unsafe_recovery_controller.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller.go
@@ -42,7 +42,7 @@ import (
 type stage int
 
 const (
-	storeRequestInterval = time.Second * 40
+	defaultPlanExecutionTimeout = time.Second * 60
 )
 
 // Stage transition graph: for more details, please check `Controller.HandleStoreHeartbeat()`
@@ -124,6 +124,12 @@ type Controller struct {
 	failedStores map[uint64]struct{}
 	timeout      time.Time
 	autoDetect   bool
+	// planExecutionTimeout is the duration PD waits for a store to execute the recovery plan
+	// before dispatching the same plan again.
+	planExecutionTimeout time.Duration
+	// disableParanoidCheck skips the sanity check that newly created empty regions
+	// don't overlap with any collected peer report.
+	disableParanoidCheck bool
 
 	// collected reports from store, if not reported yet, it would be nil
 	storeReports      map[uint64]*pdpb.StoreReport
@@ -171,6 +177,8 @@ func (u *Controller) reset() {
 	u.affectedMetaRegions = make(map[uint64]struct{}, 0)
 	u.newlyCreatedRegions = make(map[uint64]struct{}, 0)
 	u.err = nil
+	u.planExecutionTimeout = defaultPlanExecutionTimeout
+	u.disableParanoidCheck = false
 }
 
 // IsRunning returns whether there is ongoing unsafe recovery process. If yes, further unsafe
@@ -185,8 +193,24 @@ func isRunning(s stage) bool {
 	return s != Idle && s != Finished && s != Failed
 }
 
+// RemoveFailedStoresOptions controls optional unsafe recovery behavior.
+type RemoveFailedStoresOptions struct {
+	PlanExecutionTimeout time.Duration
+	DisableParanoidCheck bool
+}
+
 // RemoveFailedStores removes Failed stores from the cluster.
 func (u *Controller) RemoveFailedStores(failedStores map[uint64]struct{}, timeout uint64, autoDetect bool) error {
+	return u.RemoveFailedStoresWithOptions(failedStores, timeout, autoDetect, RemoveFailedStoresOptions{})
+}
+
+// RemoveFailedStoresWithOptions removes Failed stores from the cluster with options.
+func (u *Controller) RemoveFailedStoresWithOptions(
+	failedStores map[uint64]struct{},
+	timeout uint64,
+	autoDetect bool,
+	options RemoveFailedStoresOptions,
+) error {
 	u.Lock()
 	defer u.Unlock()
 
@@ -230,6 +254,10 @@ func (u *Controller) RemoveFailedStores(failedStores map[uint64]struct{}, timeou
 	u.timeout = time.Now().Add(time.Duration(timeout) * time.Second)
 	u.failedStores = failedStores
 	u.autoDetect = autoDetect
+	if options.PlanExecutionTimeout > 0 {
+		u.planExecutionTimeout = options.PlanExecutionTimeout
+	}
+	u.disableParanoidCheck = options.DisableParanoidCheck
 	u.changeStage(CollectReport)
 	return nil
 }
@@ -308,7 +336,7 @@ func (u *Controller) handleErr(err error) bool {
 	// blocks reads and writes.
 	u.storePlanExpires = make(map[uint64]time.Time)
 	u.storeRecoveryPlans = make(map[uint64]*pdpb.RecoveryPlan)
-	u.timeout = time.Now().Add(storeRequestInterval * 2)
+	u.timeout = time.Now().Add(u.planExecutionTimeout * 2)
 	// empty recovery plan would trigger exit force leader
 	u.changeStage(ExitForceLeader)
 	return false
@@ -450,7 +478,7 @@ func (u *Controller) dispatchPlan(heartbeat *pdpb.StoreHeartbeatRequest, resp *p
 		// Dispatch the recovery plan to the store, and the plan may be empty.
 		resp.RecoveryPlan = u.getRecoveryPlan(storeID)
 		resp.RecoveryPlan.Step = u.step
-		u.storePlanExpires[storeID] = now.Add(storeRequestInterval)
+		u.storePlanExpires[storeID] = now.Add(u.planExecutionTimeout)
 	}
 }
 
@@ -519,6 +547,12 @@ func (u *Controller) changeStage(stage stage) {
 				}
 			}
 			output.Details = append(output.Details, fmt.Sprintf("Failed stores %s", stores))
+		}
+		if u.disableParanoidCheck {
+			output.Details = append(output.Details, "paranoid check disabled")
+		}
+		if u.planExecutionTimeout != defaultPlanExecutionTimeout {
+			output.Details = append(output.Details, fmt.Sprintf("plan execution timeout %s", u.planExecutionTimeout))
 		}
 
 	case TombstoneTiFlashLearner:
@@ -912,6 +946,68 @@ func (t *regionTree) insert(item *regionItem) (bool, error) {
 	return true, nil
 }
 
+type emptyRegionIndex struct {
+	regions []*metapb.Region
+}
+
+// findOverlap returns an empty region that overlaps with the half-open range of region.
+// An empty end key means positive infinity.
+// The empty regions are generated in ascending key order and don't overlap with each other.
+func (idx *emptyRegionIndex) findOverlap(region *metapb.Region) *metapb.Region {
+	start, end := region.GetStartKey(), region.GetEndKey()
+	i := sort.Search(len(idx.regions), func(i int) bool {
+		return endGreaterThanKey(idx.regions[i].GetEndKey(), start)
+	})
+	if i == len(idx.regions) {
+		return nil
+	}
+	emptyRegion := idx.regions[i]
+	if startBeforeEnd(emptyRegion.GetStartKey(), end) {
+		return emptyRegion
+	}
+	return nil
+}
+
+func endGreaterThanKey(end, key []byte) bool {
+	return len(end) == 0 || bytes.Compare(end, key) > 0
+}
+
+func startBeforeEnd(start, end []byte) bool {
+	return len(end) == 0 || bytes.Compare(start, end) < 0
+}
+
+func sameRangeVersion(left, right *metapb.Region) bool {
+	return left.GetRegionEpoch().GetVersion() == right.GetRegionEpoch().GetVersion() &&
+		bytes.Equal(left.GetStartKey(), right.GetStartKey()) &&
+		bytes.Equal(left.GetEndKey(), right.GetEndKey())
+}
+
+func findOverlapPeerWithEmptyRegions(peersMap map[uint64][]*regionItem, emptyRegions []*metapb.Region) (*regionItem, *metapb.Region) {
+	if len(emptyRegions) == 0 {
+		return nil, nil
+	}
+	index := &emptyRegionIndex{regions: emptyRegions}
+	for _, peers := range peersMap {
+		var checkedNoOverlapRegion *metapb.Region
+		for _, peer := range peers {
+			if !peer.IsInitialized() {
+				continue
+			}
+			region := peer.Region()
+			// Peers of the same region with the same version and range share the same overlap result,
+			// so no need to check again, just skip.
+			if checkedNoOverlapRegion != nil && sameRangeVersion(region, checkedNoOverlapRegion) {
+				continue
+			}
+			if emptyRegion := index.findOverlap(region); emptyRegion != nil {
+				return peer, emptyRegion
+			}
+			checkedNoOverlapRegion = region
+		}
+	}
+	return nil, nil
+}
+
 func (u *Controller) getRecoveryPlan(storeID uint64) *pdpb.RecoveryPlan {
 	if _, exists := u.storeRecoveryPlans[storeID]; !exists {
 		u.storeRecoveryPlans[storeID] = &pdpb.RecoveryPlan{}
@@ -1178,73 +1274,67 @@ func (u *Controller) generateCreateEmptyRegionPlan(newestRegionTree *regionTree,
 	var err error
 	// There may be ranges that are covered by no one. Find these empty ranges, create new
 	// regions that cover them and evenly distribute newly created regions among all stores.
+	type createPlan struct {
+		storeID uint64
+		region  *metapb.Region
+	}
+
 	lastEnd := []byte("")
 	var lastStoreID uint64
+	var createPlans []createPlan
+	var emptyRegions []*metapb.Region
+	appendCreatePlan := func(startKey, endKey []byte, storeID uint64) error {
+		store := u.cluster.GetStore(storeID)
+		if storeID == 0 || store == nil || store.IsTiFlash() {
+			storeID = getRandomStoreID()
+			if storeID == 0 {
+				return errors.New("can't find available store(exclude tiflash) to create new region")
+			}
+		}
+		newRegion, createRegionErr := createRegion(startKey, endKey, storeID)
+		if createRegionErr != nil {
+			return createRegionErr
+		}
+		createPlans = append(createPlans, createPlan{storeID: storeID, region: newRegion})
+		emptyRegions = append(emptyRegions, newRegion)
+		return nil
+	}
 	newestRegionTree.tree.Ascend(func(item *regionItem) bool {
 		region := item.Region()
-		storeID := item.storeID
 		if !bytes.Equal(region.StartKey, lastEnd) {
-			if u.cluster.GetStore(storeID).IsTiFlash() {
-				storeID = getRandomStoreID()
-				// can't create new region on tiflash store, choose a random one
-				if storeID == 0 {
-					err = errors.New("can't find available store(exclude tiflash) to create new region")
-					return false
-				}
-			}
-			newRegion, createRegionErr := createRegion(lastEnd, region.StartKey, storeID)
-			if createRegionErr != nil {
+			if createRegionErr := appendCreatePlan(lastEnd, region.StartKey, item.storeID); createRegionErr != nil {
 				err = createRegionErr
 				return false
 			}
-			// paranoid check: shouldn't overlap with any of the peers
-			for _, peers := range peersMap {
-				for _, peer := range peers {
-					if !peer.IsInitialized() {
-						continue
-					}
-					if (bytes.Compare(newRegion.StartKey, peer.Region().StartKey) <= 0 &&
-						(len(newRegion.EndKey) == 0 || bytes.Compare(peer.Region().StartKey, newRegion.EndKey) < 0)) ||
-						((len(peer.Region().EndKey) == 0 || bytes.Compare(newRegion.StartKey, peer.Region().EndKey) < 0) &&
-							(len(newRegion.EndKey) == 0 || (len(peer.Region().EndKey) != 0 && bytes.Compare(peer.Region().EndKey, newRegion.EndKey) <= 0))) {
-						err = errors.Errorf(
-							"Find overlap peer %v with newly created empty region %v",
-							logutil.RedactStringer(core.RegionToHexMeta(peer.Region())),
-							logutil.RedactStringer(core.RegionToHexMeta(newRegion)),
-						)
-						return false
-					}
-				}
-			}
-			storeRecoveryPlan := u.getRecoveryPlan(storeID)
-			storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, newRegion)
-			u.recordAffectedRegion(newRegion)
-			u.newlyCreatedRegions[newRegion.GetId()] = struct{}{}
-			hasPlan = true
 		}
 		lastEnd = region.EndKey
-		lastStoreID = storeID
+		lastStoreID = item.storeID
 		return true
 	})
 	if err != nil {
 		return false, err
 	}
-
 	if !bytes.Equal(lastEnd, []byte("")) || newestRegionTree.size() == 0 {
-		if lastStoreID == 0 {
-			// the last store id is invalid, so choose a random one
-			lastStoreID = getRandomStoreID()
-			if lastStoreID == 0 {
-				return false, errors.New("can't find available store(exclude tiflash) to create new region")
-			}
-		}
-		newRegion, err := createRegion(lastEnd, []byte(""), lastStoreID)
-		if err != nil {
+		if err := appendCreatePlan(lastEnd, []byte(""), lastStoreID); err != nil {
 			return false, err
 		}
-		storeRecoveryPlan := u.getRecoveryPlan(lastStoreID)
-		storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, newRegion)
-		u.recordAffectedRegion(newRegion)
+	}
+
+	if !u.disableParanoidCheck {
+		// paranoid check: newly created empty regions shouldn't overlap with any of the peers.
+		if peer, emptyRegion := findOverlapPeerWithEmptyRegions(peersMap, emptyRegions); peer != nil {
+			return false, errors.Errorf(
+				"Find overlap peer %v with newly created empty region %v",
+				logutil.RedactStringer(core.RegionToHexMeta(peer.Region())),
+				logutil.RedactStringer(core.RegionToHexMeta(emptyRegion)),
+			)
+		}
+	}
+	for _, createPlan := range createPlans {
+		storeRecoveryPlan := u.getRecoveryPlan(createPlan.storeID)
+		storeRecoveryPlan.Creates = append(storeRecoveryPlan.Creates, createPlan.region)
+		u.recordAffectedRegion(createPlan.region)
+		u.newlyCreatedRegions[createPlan.region.GetId()] = struct{}{}
 		hasPlan = true
 	}
 	return hasPlan, nil

--- a/pkg/unsaferecovery/unsafe_recovery_controller_test.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller_test.go
@@ -43,6 +43,226 @@ func newStoreHeartbeat(storeID uint64, report *pdpb.StoreReport) *pdpb.StoreHear
 	}
 }
 
+func newTestRegionItemWithEpoch(id uint64, start, end string, confVer, version uint64, initialized bool) *regionItem {
+	region := &metapb.Region{
+		Id:          id,
+		StartKey:    []byte(start),
+		EndKey:      []byte(end),
+		RegionEpoch: &metapb.RegionEpoch{ConfVer: confVer, Version: version},
+	}
+	if initialized {
+		region.Peers = []*metapb.Peer{{Id: id + 1000, StoreId: 1}}
+	}
+	return &regionItem{
+		report: &pdpb.PeerReport{
+			RegionState: &raft_serverpb.RegionLocalState{Region: region},
+		},
+		storeID: 1,
+	}
+}
+
+func newTestRegionItem(id uint64, start, end string, initialized bool) *regionItem {
+	return newTestRegionItemWithEpoch(id, start, end, 1, 1, initialized)
+}
+
+func TestEmptyRegionIndex(t *testing.T) {
+	re := require.New(t)
+
+	index := &emptyRegionIndex{regions: []*metapb.Region{
+		newTestRegionItem(1, "b", "d", true).Region(),
+		newTestRegionItem(2, "f", "h", true).Region(),
+		newTestRegionItem(3, "z", "", true).Region(),
+	}}
+
+	re.Equal(uint64(1), index.findOverlap(newTestRegionItem(4, "a", "c", true).Region()).GetId())
+	re.Equal(uint64(2), index.findOverlap(newTestRegionItem(5, "g", "i", true).Region()).GetId())
+	re.Equal(uint64(3), index.findOverlap(newTestRegionItem(6, "z", "", true).Region()).GetId())
+	re.Nil(index.findOverlap(newTestRegionItem(7, "d", "f", true).Region()))
+}
+
+func TestFindOverlapPeerWithEmptyRegions(t *testing.T) {
+	re := require.New(t)
+
+	emptyRegions := []*metapb.Region{
+		newTestRegionItem(1, "b", "d", true).Region(),
+	}
+	peersMap := map[uint64][]*regionItem{
+		1: {newTestRegionItem(2, "a", "z", true)},
+		2: {newTestRegionItem(3, "b", "y", false)},
+	}
+	peer, emptyRegion := findOverlapPeerWithEmptyRegions(peersMap, emptyRegions)
+	re.Equal(uint64(2), peer.Region().GetId())
+	re.Equal(uint64(1), emptyRegion.GetId())
+
+	peer, emptyRegion = findOverlapPeerWithEmptyRegions(map[uint64][]*regionItem{
+		1: {newTestRegionItem(3, "b", "y", false)},
+	}, emptyRegions)
+	re.Nil(peer)
+	re.Nil(emptyRegion)
+}
+
+func TestFindOverlapPeerWithEmptyRegionsFastPath(t *testing.T) {
+	re := require.New(t)
+
+	emptyRegions := []*metapb.Region{
+		newTestRegionItem(1, "b", "d", true).Region(),
+	}
+	peer, emptyRegion := findOverlapPeerWithEmptyRegions(map[uint64][]*regionItem{
+		1: {
+			newTestRegionItemWithEpoch(2, "x", "z", 1, 10, true),
+			newTestRegionItemWithEpoch(3, "x", "z", 2, 10, true),
+		},
+	}, emptyRegions)
+	re.Nil(peer)
+	re.Nil(emptyRegion)
+
+	peer, emptyRegion = findOverlapPeerWithEmptyRegions(map[uint64][]*regionItem{
+		1: {
+			newTestRegionItemWithEpoch(2, "x", "z", 1, 10, true),
+			newTestRegionItemWithEpoch(3, "a", "z", 1, 10, true),
+		},
+	}, emptyRegions)
+	re.Equal(uint64(3), peer.Region().GetId())
+	re.Equal(uint64(1), emptyRegion.GetId())
+}
+
+func TestRemoveFailedStoresWithOptions(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+
+	recoveryController := NewController(cluster)
+	err := recoveryController.RemoveFailedStoresWithOptions(nil, 60, true, RemoveFailedStoresOptions{
+		PlanExecutionTimeout: 5 * time.Minute,
+		DisableParanoidCheck: true,
+	})
+	re.NoError(err)
+	re.Equal(5*time.Minute, recoveryController.planExecutionTimeout)
+	re.True(recoveryController.disableParanoidCheck)
+	re.Contains(recoveryController.output[0].Details, "paranoid check disabled")
+	re.Contains(recoveryController.output[0].Details, "plan execution timeout 5m0s")
+
+	resp := &pdpb.StoreHeartbeatResponse{}
+	recoveryController.dispatchPlan(newStoreHeartbeat(1, nil), resp)
+	re.NotNil(resp.GetRecoveryPlan())
+	re.WithinDuration(time.Now().Add(5*time.Minute), recoveryController.storePlanExpires[1], time.Second)
+}
+
+func TestCreateEmptyRegionDisableParanoidCheck(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+	newestRegionTree := newRegionTree()
+	inserted, err := newestRegionTree.insert(newTestRegionItem(1, "m", "", true))
+	re.True(inserted)
+	re.NoError(err)
+
+	peersMap := map[uint64][]*regionItem{
+		2: {newTestRegionItem(2, "a", "z", true)},
+	}
+
+	recoveryController := NewController(cluster)
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, peersMap)
+	re.False(hasPlan)
+	re.ErrorContains(err, "Find overlap peer")
+
+	recoveryController = NewController(cluster)
+	recoveryController.disableParanoidCheck = true
+	hasPlan, err = recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, peersMap)
+	re.True(hasPlan)
+	re.NoError(err)
+	re.Len(recoveryController.storeRecoveryPlans[1].GetCreates(), 1)
+}
+
+func TestCreateEmptyRegionTailParanoidCheck(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+	newestRegionTree := newRegionTree()
+	inserted, err := newestRegionTree.insert(newTestRegionItem(1, "a", "m", true))
+	re.True(inserted)
+	re.NoError(err)
+
+	peersMap := map[uint64][]*regionItem{
+		1: {newTestRegionItem(2, "x", "z", true)},
+	}
+
+	recoveryController := NewController(cluster)
+	recoveryController.storeReports = map[uint64]*pdpb.StoreReport{1: nil}
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, peersMap)
+	re.False(hasPlan)
+	re.ErrorContains(err, "Find overlap peer")
+}
+
+func TestCreateEmptyRegionFullRangeParanoidCheck(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+
+	peersMap := map[uint64][]*regionItem{
+		1: {newTestRegionItem(2, "a", "z", true)},
+	}
+
+	recoveryController := NewController(cluster)
+	recoveryController.storeReports = map[uint64]*pdpb.StoreReport{1: nil}
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newRegionTree(), peersMap)
+	re.False(hasPlan)
+	re.ErrorContains(err, "Find overlap peer")
+}
+
+func TestCreateEmptyRegionTailUsesTiKVStore(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, opts)
+	for _, store := range newTestStores(2, "6.0.0") {
+		if store.GetID() == 1 {
+			store.GetMeta().Labels = []*metapb.StoreLabel{{Key: "engine", Value: "tiflash"}}
+		}
+		cluster.PutStore(store)
+	}
+	newestRegionTree := newRegionTree()
+	inserted, err := newestRegionTree.insert(newTestRegionItem(1, "", "m", true))
+	re.True(inserted)
+	re.NoError(err)
+
+	recoveryController := NewController(cluster)
+	recoveryController.storeReports = map[uint64]*pdpb.StoreReport{1: nil, 2: nil}
+	hasPlan, err := recoveryController.generateCreateEmptyRegionPlan(newestRegionTree, nil)
+	re.True(hasPlan)
+	re.NoError(err)
+	re.Nil(recoveryController.storeRecoveryPlans[1])
+	re.Len(recoveryController.storeRecoveryPlans[2].GetCreates(), 1)
+	re.Equal([]byte("m"), recoveryController.storeRecoveryPlans[2].GetCreates()[0].GetStartKey())
+	re.Empty(recoveryController.storeRecoveryPlans[2].GetCreates()[0].GetEndKey())
+}
+
 func hasQuorum(region *metapb.Region, failedStores []uint64) bool {
 	hasQuorum := func(voters []*metapb.Peer) bool {
 		numFailedVoters := 0

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -15,13 +15,20 @@
 package api
 
 import (
+	"errors"
+	"math"
 	"net/http"
+	"time"
 
+	"github.com/unrolled/render"
+
+	"github.com/tikv/pd/pkg/unsaferecovery"
 	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server"
-	"github.com/unrolled/render"
 )
+
+var maxPlanExecutionTimeoutSeconds = float64(time.Duration(math.MaxInt64/2) / time.Second)
 
 type unsafeOperationHandler struct {
 	svr *server.Server
@@ -65,21 +72,101 @@ func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *ht
 		}
 	}
 
-	timeout := uint64(600)
-	if rawTimeout, exists := input["timeout"].(float64); exists {
-		timeout = uint64(rawTimeout)
+	timeout, err := parseTimeout(input)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
-	if err := rc.GetUnsafeRecoveryController().RemoveFailedStores(stores, timeout, autoDetect); err != nil {
+	planExecutionTimeout, err := parsePlanExecutionTimeout(input)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	disableParanoidCheck, err := parseDisableParanoidCheck(input)
+	if err != nil {
+		h.rd.JSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := rc.GetUnsafeRecoveryController().RemoveFailedStoresWithOptions(stores, timeout, autoDetect, unsaferecovery.RemoveFailedStoresOptions{
+		PlanExecutionTimeout: planExecutionTimeout,
+		DisableParanoidCheck: disableParanoidCheck,
+	}); err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	h.rd.JSON(w, http.StatusOK, "Request has been accepted.")
 }
 
-// @Tags     unsafe
-// @Summary  Show the current status of failed stores removal.
-// @Produce  json
+func parseTimeout(input map[string]any) (uint64, error) {
+	raw, exists := input["timeout"]
+	if !exists {
+		return 600, nil
+	}
+	rawTimeout, ok := raw.(float64)
+	if !ok || rawTimeout <= 0 || rawTimeout != math.Trunc(rawTimeout) || rawTimeout > maxPlanExecutionTimeoutSeconds {
+		return 0, errors.New("timeout is invalid")
+	}
+	return uint64(rawTimeout), nil
+}
+
+func parsePlanExecutionTimeout(input map[string]any) (time.Duration, error) {
+	raw, exists, err := getAliasedOption(input, "plan-execution-timeout", "plan_execution_timeout")
+	if err != nil {
+		return 0, err
+	}
+	if !exists {
+		return 0, nil
+	}
+	rawTimeout, ok := raw.(float64)
+	if !ok || rawTimeout <= 0 || rawTimeout != math.Trunc(rawTimeout) || rawTimeout > maxPlanExecutionTimeoutSeconds {
+		return 0, errors.New("plan-execution-timeout is invalid")
+	}
+	return time.Duration(int64(rawTimeout)) * time.Second, nil
+}
+
+func parseDisableParanoidCheck(input map[string]any) (bool, error) {
+	raw, exists, err := getAliasedOption(input, "disable-paranoid-check", "disable_paranoid_check")
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	rawDisableParanoidCheck, ok := raw.(bool)
+	if !ok {
+		return false, errors.New("disable-paranoid-check is invalid")
+	}
+	return rawDisableParanoidCheck, nil
+}
+
+func getAliasedOption(input map[string]any, keys ...string) (any, bool, error) {
+	var (
+		raw   any
+		exist bool
+	)
+	for _, key := range keys {
+		value, ok := input[key]
+		if !ok {
+			continue
+		}
+		if exist {
+			return nil, false, errors.New(keys[0] + " is specified multiple times")
+		}
+		raw = value
+		exist = true
+	}
+	return raw, exist, nil
+}
+
+// GetFailedStoresRemovalStatus gets the current status of failed stores removal.
+//
+//	@Tags		unsafe
+//	@Summary	Show the current status of failed stores removal.
+//	@Produce	json
+//
 // Success 200 {object} []StageOutput
 // @Router   /admin/unsafe/remove-failed-stores/show [get]
 func (h *unsafeOperationHandler) GetFailedStoresRemovalStatus(w http.ResponseWriter, r *http.Request) {

--- a/server/api/unsafe_operation_test.go
+++ b/server/api/unsafe_operation_test.go
@@ -18,8 +18,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/pd/pkg/unsaferecovery"
 	tu "github.com/tikv/pd/pkg/utils/testutil"
@@ -74,7 +76,54 @@ func (suite *unsafeOperationTestSuite) TestRemoveFailedStores() {
 		tu.StringEqual(re, "\"[PD:unsaferecovery:ErrUnsafeRecoveryInvalidInput]invalid input store 2 doesn't exist\"\n"))
 	re.NoError(err)
 
-	input = map[string]any{"stores": []uint64{1}}
+	for _, input := range []map[string]any{
+		{"stores": []uint64{1}, "timeout": -1},
+		{"stores": []uint64{1}, "timeout": 1.5},
+		{"stores": []uint64{1}, "timeout": maxPlanExecutionTimeoutSeconds + 1},
+		{"stores": []uint64{1}, "timeout": "60"},
+	} {
+		data, _ = json.Marshal(input)
+		err = tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/remove-failed-stores", data, tu.StatusNotOK(re),
+			tu.StringContain(re, "timeout is invalid"))
+		re.NoError(err)
+	}
+
+	for _, input := range []map[string]any{
+		{"stores": []uint64{1}, "plan-execution-timeout": -1},
+		{"stores": []uint64{1}, "plan-execution-timeout": 1.5},
+		{"stores": []uint64{1}, "plan-execution-timeout": maxPlanExecutionTimeoutSeconds + 1},
+		{"stores": []uint64{1}, "plan_execution_timeout": "60"},
+	} {
+		data, _ = json.Marshal(input)
+		err = tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/remove-failed-stores", data, tu.StatusNotOK(re),
+			tu.StringContain(re, "plan-execution-timeout is invalid"))
+		re.NoError(err)
+	}
+
+	data, _ = json.Marshal(map[string]any{"stores": []uint64{1}, "disable-paranoid-check": "true"})
+	err = tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/remove-failed-stores", data, tu.StatusNotOK(re),
+		tu.StringContain(re, "disable-paranoid-check is invalid"))
+	re.NoError(err)
+
+	data, _ = json.Marshal(map[string]any{
+		"stores":                 []uint64{1},
+		"plan-execution-timeout": 300,
+		"plan_execution_timeout": 600,
+	})
+	err = tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/remove-failed-stores", data, tu.StatusNotOK(re),
+		tu.StringContain(re, "plan-execution-timeout is specified multiple times"))
+	re.NoError(err)
+
+	data, _ = json.Marshal(map[string]any{
+		"stores":                 []uint64{1},
+		"disable-paranoid-check": true,
+		"disable_paranoid_check": false,
+	})
+	err = tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/remove-failed-stores", data, tu.StatusNotOK(re),
+		tu.StringContain(re, "disable-paranoid-check is specified multiple times"))
+	re.NoError(err)
+
+	input = map[string]any{"stores": []uint64{1}, "plan-execution-timeout": 300, "disable-paranoid-check": true}
 	data, _ = json.Marshal(input)
 	err = tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/remove-failed-stores", data, tu.StatusOK(re))
 	re.NoError(err)
@@ -83,6 +132,9 @@ func (suite *unsafeOperationTestSuite) TestRemoveFailedStores() {
 	var output []unsaferecovery.StageOutput
 	err = tu.ReadGetJSON(re, testDialClient, suite.urlPrefix+"/remove-failed-stores/show", &output)
 	re.NoError(err)
+	re.NotEmpty(output)
+	re.Contains(output[0].Details, "paranoid check disabled")
+	re.Contains(output[0].Details, "plan execution timeout 5m0s")
 }
 
 func (suite *unsafeOperationTestSuite) TestRemoveFailedStoresAutoDetect() {
@@ -98,4 +150,96 @@ func (suite *unsafeOperationTestSuite) TestRemoveFailedStoresAutoDetect() {
 	data, _ = json.Marshal(input)
 	err = tu.CheckPostJSON(testDialClient, suite.urlPrefix+"/remove-failed-stores", data, tu.StatusOK(re))
 	re.NoError(err)
+}
+
+func TestParsePlanExecutionTimeout(t *testing.T) {
+	re := require.New(t)
+
+	timeout, err := parsePlanExecutionTimeout(map[string]any{})
+	re.NoError(err)
+	re.Zero(timeout)
+
+	timeout, err = parsePlanExecutionTimeout(map[string]any{"plan-execution-timeout": float64(300)})
+	re.NoError(err)
+	re.Equal(5*time.Minute, timeout)
+
+	timeout, err = parsePlanExecutionTimeout(map[string]any{
+		"plan-execution-timeout": maxPlanExecutionTimeoutSeconds,
+	})
+	re.NoError(err)
+	re.Equal(time.Duration(int64(maxPlanExecutionTimeoutSeconds))*time.Second, timeout)
+
+	for _, input := range []map[string]any{
+		{"plan-execution-timeout": float64(0)},
+		{"plan-execution-timeout": float64(-1)},
+		{"plan-execution-timeout": 1.5},
+		{"plan-execution-timeout": maxPlanExecutionTimeoutSeconds + 1},
+		{"plan-execution-timeout": "60"},
+	} {
+		_, err = parsePlanExecutionTimeout(input)
+		re.Error(err)
+	}
+
+	_, err = parsePlanExecutionTimeout(map[string]any{
+		"plan-execution-timeout": float64(300),
+		"plan_execution_timeout": float64(600),
+	})
+	re.EqualError(err, "plan-execution-timeout is specified multiple times")
+}
+
+func TestParseTimeout(t *testing.T) {
+	re := require.New(t)
+
+	timeout, err := parseTimeout(map[string]any{})
+	re.NoError(err)
+	re.Equal(uint64(600), timeout)
+
+	timeout, err = parseTimeout(map[string]any{"timeout": float64(300)})
+	re.NoError(err)
+	re.Equal(uint64(300), timeout)
+
+	timeout, err = parseTimeout(map[string]any{"timeout": maxPlanExecutionTimeoutSeconds})
+	re.NoError(err)
+	re.Equal(uint64(maxPlanExecutionTimeoutSeconds), timeout)
+
+	for _, input := range []map[string]any{
+		{"timeout": float64(0)},
+		{"timeout": float64(-1)},
+		{"timeout": 1.5},
+		{"timeout": maxPlanExecutionTimeoutSeconds + 1},
+		{"timeout": "60"},
+	} {
+		_, err = parseTimeout(input)
+		re.EqualError(err, "timeout is invalid")
+	}
+}
+
+func TestParseDisableParanoidCheck(t *testing.T) {
+	re := require.New(t)
+
+	disableParanoidCheck, err := parseDisableParanoidCheck(map[string]any{})
+	re.NoError(err)
+	re.False(disableParanoidCheck)
+
+	disableParanoidCheck, err = parseDisableParanoidCheck(map[string]any{"disable-paranoid-check": true})
+	re.NoError(err)
+	re.True(disableParanoidCheck)
+
+	disableParanoidCheck, err = parseDisableParanoidCheck(map[string]any{"disable_paranoid_check": false})
+	re.NoError(err)
+	re.False(disableParanoidCheck)
+
+	for _, input := range []map[string]any{
+		{"disable-paranoid-check": "true"},
+		{"disable_paranoid_check": 1},
+	} {
+		_, err = parseDisableParanoidCheck(input)
+		re.Error(err)
+	}
+
+	_, err = parseDisableParanoidCheck(map[string]any{
+		"disable-paranoid-check": true,
+		"disable_paranoid_check": false,
+	})
+	re.EqualError(err, "disable-paranoid-check is specified multiple times")
 }

--- a/tools/pd-ctl/pdctl/command/unsafe_command.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command.go
@@ -16,14 +16,18 @@ package command
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 const unsafePrefix = "pd/api/v1/admin/unsafe"
+
+var maxPlanExecutionTimeoutSeconds = float64(time.Duration(math.MaxInt64/2) / time.Second)
 
 // NewUnsafeCommand returns the unsafe subcommand of rootCmd.
 func NewUnsafeCommand() *cobra.Command {
@@ -43,9 +47,11 @@ func NewRemoveFailedStoresCommand() *cobra.Command {
 		Run:   removeFailedStoresCommandFunc,
 	}
 	cmd.PersistentFlags().Float64("timeout", 300, "timeout in seconds")
+	cmd.PersistentFlags().Float64("plan-execution-timeout", 60, "plan execution timeout in seconds before dispatching the plan again")
+	cmd.PersistentFlags().Bool("disable-paranoid-check", false, "disable the empty region overlap paranoid check")
 	cmd.PersistentFlags().Bool("auto-detect", false, `detect failed stores automatically without needing to pass failed store ids, and all stores not in PD stores list are regarded as failed; 
-Note: DO NOT RECOMMEND to use this flag for general use, it's used only for case that PD doesn't have the store information of failed stores after pd-recover;
-Note: Do it with caution to make sure all live stores's heartbeats has been reported PD already, otherwise it may regarded some stores as failed mistakenly.`)
+	Note: DO NOT RECOMMEND to use this flag for general use, it's used only for case that PD doesn't have the store information of failed stores after pd-recover;
+	Note: Do it with caution to make sure all live stores's heartbeats has been reported PD already, otherwise it may regarded some stores as failed mistakenly.`)
 	cmd.AddCommand(NewRemoveFailedStoresShowCommand())
 	return cmd
 }
@@ -103,10 +109,37 @@ func removeFailedStoresCommandFunc(cmd *cobra.Command, args []string) {
 		postInput["timeout"] = timeout
 	}
 
+	planExecutionTimeout, err := cmd.Flags().GetFloat64("plan-execution-timeout")
+	if err != nil {
+		cmd.Println(err)
+		return
+	} else if planExecutionTimeout != 60 {
+		if err := validatePlanExecutionTimeoutSeconds(planExecutionTimeout); err != nil {
+			cmd.Println(err)
+			return
+		}
+		postInput["plan-execution-timeout"] = planExecutionTimeout
+	}
+
+	disableParanoidCheck, err := cmd.Flags().GetBool("disable-paranoid-check")
+	if err != nil {
+		cmd.Println(err)
+		return
+	} else if disableParanoidCheck {
+		postInput["disable-paranoid-check"] = disableParanoidCheck
+	}
+
 	postJSON(cmd, prefix, postInput)
 }
 
-func removeFailedStoresShowCommandFunc(cmd *cobra.Command, args []string) {
+func validatePlanExecutionTimeoutSeconds(timeout float64) error {
+	if timeout <= 0 || timeout != math.Trunc(timeout) || timeout > maxPlanExecutionTimeoutSeconds {
+		return fmt.Errorf("plan-execution-timeout must be a positive integer number of seconds no greater than %.0f", maxPlanExecutionTimeoutSeconds)
+	}
+	return nil
+}
+
+func removeFailedStoresShowCommandFunc(cmd *cobra.Command, _ []string) {
 	var resp string
 	var err error
 	prefix := fmt.Sprintf("%s/remove-failed-stores/show", unsafePrefix)

--- a/tools/pd-ctl/pdctl/command/unsafe_command_test.go
+++ b/tools/pd-ctl/pdctl/command/unsafe_command_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePlanExecutionTimeoutSeconds(t *testing.T) {
+	re := require.New(t)
+
+	for _, timeout := range []float64{1, 60, maxPlanExecutionTimeoutSeconds} {
+		re.NoError(validatePlanExecutionTimeoutSeconds(timeout))
+	}
+
+	for _, timeout := range []float64{0, -1, 1.5, maxPlanExecutionTimeoutSeconds + 1} {
+		re.Error(validatePlanExecutionTimeoutSeconds(timeout))
+	}
+}

--- a/tools/pd-ctl/tests/unsafe/unsafe_operation_test.go
+++ b/tools/pd-ctl/tests/unsafe/unsafe_operation_test.go
@@ -46,6 +46,9 @@ func TestRemoveFailedStores(t *testing.T) {
 	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "3600"}
 	_, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
+	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--plan-execution-timeout", "600", "--disable-paranoid-check"}
+	_, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
 	args = []string{"-u", pdAddr, "unsafe", "remove-failed-stores", "1,2,3", "--timeout", "abc"}
 	_, err = tests.ExecuteCommand(cmd, args...)
 	re.Error(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10638

This cherry-picks #10639 onto release-8.1 for the v8.1.2 line.

Unsafe recovery can spend excessive time checking newly created empty regions against collected peer reports when many range holes exist, while holding the unsafe recovery controller lock.

### What is changed and how does it work?

```commit-message
Optimize unsafe recovery empty-region overlap checks by indexing generated empty regions and scanning peer reports once.

Add request-level unsafe recovery options for plan execution timeout and disabling the paranoid overlap check, and expose them through pd-ctl.
```

### Check List

Tests

- Unit test

Code changes

- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

```release-note
Optimize unsafe recovery empty-region plan generation when many regions and gaps exist
```