### PR TITLE
server,storage: speed up large region load

### DIFF
--- a/pkg/btree/btree_generic.go
+++ b/pkg/btree/btree_generic.go
@@ -449,6 +449,22 @@ func (n *node[T]) maybeSplitChild(i, maxItems int) bool {
 	return true
 }
 
+func (n *node[T]) append(item T, maxItems int) {
+	if len(n.children) == 0 {
+		n.items = append(n.items, item)
+		return
+	}
+	i := len(n.children) - 1
+	if n.maybeSplitChild(i, maxItems) {
+		if !n.items[len(n.items)-1].Less(item) {
+			panic("btree append item is not greater than current max")
+		}
+		i++
+	}
+	n.mutableChild(i).append(item, maxItems)
+	n.indices.addAt(i, 1)
+}
+
 // insert inserts an item into the subtree rooted at this node, making sure
 // no nodes in the subtree exceed maxItems items.  Should an equivalent item be
 // be found/replaced by insert, it will be returned.
@@ -907,6 +923,49 @@ func (t *BTreeG[T]) ReplaceOrInsert(item T) (_ T, _ bool) {
 		t.length++
 	}
 	return out, found
+}
+
+// Append inserts the given item when it is greater than the current max item.
+// It returns false and leaves the tree unchanged when the item is not ordered
+// after the current max item.
+func (t *BTreeG[T]) Append(item T) bool {
+	if t.root == nil {
+		t.root = t.cow.newNode()
+		t.root.items = append(t.root.items, item)
+		t.length++
+		return true
+	}
+	maxItem, ok := t.Max()
+	if !ok {
+		return false
+	}
+	if !maxItem.Less(item) {
+		return false
+	}
+	t.AppendHint(item)
+	return true
+}
+
+// AppendHint inserts an item that the caller has proved is greater than the
+// current max item.
+func (t *BTreeG[T]) AppendHint(item T) {
+	if t.root == nil {
+		t.root = t.cow.newNode()
+		t.root.items = append(t.root.items, item)
+		t.length++
+		return
+	}
+	t.root = t.root.mutableFor(t.cow)
+	if len(t.root.items) >= t.maxItems() {
+		item2, second := t.root.split(t.maxItems() / 2)
+		oldroot := t.root
+		t.root = t.cow.newNode()
+		t.root.items = append(t.root.items, item2)
+		t.root.children = append(t.root.children, oldroot, second)
+		t.root.initSize()
+	}
+	t.root.append(item, t.maxItems())
+	t.length++
 }
 
 // Delete removes an item equal to the passed in item from the tree, returning

--- a/pkg/btree/btree_generic_test.go
+++ b/pkg/btree/btree_generic_test.go
@@ -173,6 +173,39 @@ func TestBTreeSizeInfo(t *testing.T) {
 	}
 }
 
+func TestAppendG(t *testing.T) {
+	tr := NewG[Int](4)
+	const treeSize = 1000
+	for i := range treeSize {
+		if ok := tr.Append(Int(i)); !ok {
+			t.Fatalf("append %d failed", i)
+		}
+		assertEq(t, "root length after append", tr.getRootLength(), tr.Len())
+	}
+	assertEq(t, "append len", tr.Len(), treeSize)
+	assertEq(t, "append ordered items", all(tr), rang(treeSize))
+	for k := range treeSize {
+		assertEq(t, "append get k-th", tr.GetAt(k), Int(k))
+		y, rk := tr.GetWithIndex(Int(k))
+		assertEq(t, "append get", y, Int(k))
+		assertEq(t, "append get rank", rk, k)
+	}
+
+	if ok := tr.Append(Int(treeSize - 1)); ok {
+		t.Fatalf("append accepted duplicate max item")
+	}
+	if ok := tr.Append(Int(treeSize / 2)); ok {
+		t.Fatalf("append accepted non-monotonic item")
+	}
+	assertEq(t, "append reject keeps len", tr.Len(), treeSize)
+	assertEq(t, "append reject keeps items", all(tr), rang(treeSize))
+
+	if _, found := tr.ReplaceOrInsert(Int(treeSize + 1)); found {
+		t.Fatalf("replace-or-insert unexpectedly replaced appended tree item")
+	}
+	assertEq(t, "replace after append", tr.GetAt(tr.Len()-1), Int(treeSize+1))
+}
+
 func TestBTreeG(t *testing.T) {
 	tr := NewG[Int](*btreeDegree)
 	const treeSize = 10000
@@ -457,6 +490,40 @@ const benchmarkTreeSize = 10000
 func BenchmarkInsert(b *testing.B) {
 	b.StopTimer()
 	insertP := perm(benchmarkTreeSize)
+	b.StartTimer()
+	i := 0
+	for i < b.N {
+		tr := NewG[Int](*btreeDegree)
+		for _, item := range insertP {
+			tr.ReplaceOrInsert(item)
+			i++
+			if i >= b.N {
+				return
+			}
+		}
+	}
+}
+
+func BenchmarkAppendOrdered(b *testing.B) {
+	b.StopTimer()
+	insertP := rang(benchmarkTreeSize)
+	b.StartTimer()
+	i := 0
+	for i < b.N {
+		tr := NewG[Int](*btreeDegree)
+		for _, item := range insertP {
+			tr.Append(item)
+			i++
+			if i >= b.N {
+				return
+			}
+		}
+	}
+}
+
+func BenchmarkInsertOrdered(b *testing.B) {
+	b.StopTimer()
+	insertP := rang(benchmarkTreeSize)
 	b.StartTimer()
 	i := 0
 	for i < b.N {

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -94,6 +94,9 @@ type RegionInfo struct {
 	reportBuckets unsafe.Pointer
 	// source is used to indicate region's source, such as Storage/Sync/Heartbeat.
 	source RegionSource
+	// peersClassified is false when a storage-loaded region is first inserted
+	// into the root tree. Subtree rebuild classifies peers before using them.
+	peersClassified bool
 	// ref is used to indicate the reference count of the region in root-tree and sub-tree.
 	ref atomic.Int32
 	// bucketMeta is used to store the bucket meta reported by tikv.
@@ -151,11 +154,25 @@ func NewRegionInfo(region *metapb.Region, leader *metapb.Peer, opts ...RegionCre
 	return regionInfo
 }
 
+// NewStorageRegionInfo creates a RegionInfo loaded from persistent storage.
+// Storage load first needs the root key/id/range index; store-scoped subtree
+// state is rebuilt after region read APIs become available.
+func NewStorageRegionInfo(region *metapb.Region) *RegionInfo {
+	return &RegionInfo{
+		meta:   region,
+		source: Storage,
+	}
+}
+
 // classifyVoterAndLearner sorts out voter and learner from peers into different slice.
 func classifyVoterAndLearner(region *RegionInfo) {
-	region.learners = make([]*metapb.Peer, 0, 1)
-	region.voters = make([]*metapb.Peer, 0, len(region.meta.Peers))
-	region.witnesses = make([]*metapb.Peer, 0, 1)
+	region.learners = nil
+	region.witnesses = nil
+	if cap(region.voters) < len(region.meta.Peers) {
+		region.voters = make([]*metapb.Peer, 0, len(region.meta.Peers))
+	} else {
+		region.voters = region.voters[:0]
+	}
 	for _, p := range region.meta.Peers {
 		if IsLearner(p) {
 			region.learners = append(region.learners, p)
@@ -169,6 +186,14 @@ func classifyVoterAndLearner(region *RegionInfo) {
 	sort.Sort(peerSlice(region.learners))
 	sort.Sort(peerSlice(region.voters))
 	sort.Sort(peerSlice(region.witnesses))
+	region.peersClassified = true
+}
+
+func (r *RegionInfo) ensurePeerClassification() {
+	if r == nil || r.peersClassified {
+		return
+	}
+	classifyVoterAndLearner(r)
 }
 
 // peersEqualTo returns true when the peers are not changed, which may caused by: the region leader not changed,
@@ -342,12 +367,15 @@ func (r *RegionInfo) Clone(opts ...RegionCreateOption) *RegionInfo {
 		reportBuckets:             atomic.LoadPointer(&r.reportBuckets),
 		queryStats:                typeutil.DeepClone(r.queryStats, QueryStatsFactory),
 		bucketMeta:                r.bucketMeta,
+		peersClassified:           r.peersClassified,
 	}
 
 	for _, opt := range opts {
 		opt(region)
 	}
-	classifyVoterAndLearner(region)
+	if r.peersClassified {
+		classifyVoterAndLearner(region)
+	}
 	return region
 }
 
@@ -1101,7 +1129,7 @@ func (r *RegionsInfo) CheckAndPutRegion(region *RegionInfo) []*RegionInfo {
 	}
 	err := check(region, origin, ols)
 	if err != nil {
-		log.Debug("region is stale", zap.Stringer("origin", origin.GetMeta()), errs.ZapError(err))
+		logStaleRegion(region, origin, err)
 		// return the state region to delete.
 		r.t.Unlock()
 		return []*RegionInfo{region}
@@ -1124,6 +1152,84 @@ func (r *RegionsInfo) CheckAndPutRegionNoOverlap(region *RegionInfo) []*RegionIn
 	r.t.Unlock()
 	r.updateSubTree(region, origin, overlaps, rangeChanged, true)
 	return overlaps
+}
+
+// CheckAndPutRootRegion checks if the region is valid and only updates the root region tree.
+// It is used during startup to make key/id/range region reads available before rebuilding
+// store-scoped subtrees and scheduling statistics.
+func (r *RegionsInfo) CheckAndPutRootRegion(region *RegionInfo) []*RegionInfo {
+	r.t.Lock()
+	origin := r.getRegionLocked(region.GetID())
+	var ols []*RegionInfo
+	if origin == nil || !bytes.Equal(origin.GetStartKey(), region.GetStartKey()) || !bytes.Equal(origin.GetEndKey(), region.GetEndKey()) {
+		ols = r.tree.overlaps(&regionItem{RegionInfo: region})
+	}
+	err := check(region, origin, ols)
+	if err != nil {
+		logStaleRegion(region, origin, err)
+		r.t.Unlock()
+		return []*RegionInfo{region}
+	}
+	_, overlaps, _ := r.setRegionLocked(region, true, ols...)
+	r.t.Unlock()
+	return overlaps
+}
+
+// CheckAndPutRootRegionNoOverlap puts a region into the root tree when the caller has proved
+// it has no range overlap. It does not update store-scoped subtrees.
+func (r *RegionsInfo) CheckAndPutRootRegionNoOverlap(region *RegionInfo) []*RegionInfo {
+	r.t.Lock()
+	origin := r.getRegionLocked(region.GetID())
+	if origin != nil {
+		r.t.Unlock()
+		return r.CheckAndPutRootRegion(region)
+	}
+	_, overlaps, _ := r.setRegionLocked(region, true)
+	r.t.Unlock()
+	return overlaps
+}
+
+// AppendRootRegionNoOverlap appends a region to the root tree when the caller has
+// proved the loaded region has no overlap and is ordered after the current max key.
+func (r *RegionsInfo) AppendRootRegionNoOverlap(region *RegionInfo) bool {
+	r.t.Lock()
+	defer r.t.Unlock()
+	if r.getRegionLocked(region.GetID()) != nil {
+		return false
+	}
+	item := &regionItem{RegionInfo: region}
+	if maxItem, ok := r.tree.tree.Max(); ok && !maxItem.Less(item) {
+		return false
+	}
+	r.tree.append(item)
+	r.regions[region.GetID()] = item
+	return true
+}
+
+// AppendRootRegionNoOverlapHint appends a region to the root tree when the
+// caller has proved the region has no overlap and is ordered after the current
+// max key. It is intended for startup bulk loading from ordered storage records.
+func (r *RegionsInfo) AppendRootRegionNoOverlapHint(region *RegionInfo) bool {
+	r.t.Lock()
+	defer r.t.Unlock()
+	if r.getRegionLocked(region.GetID()) != nil {
+		return false
+	}
+	item := &regionItem{RegionInfo: region}
+	r.tree.append(item)
+	r.regions[region.GetID()] = item
+	return true
+}
+
+// AppendRootRegionNoOverlapUnchecked appends a region to an empty root tree
+// fast path. The caller must guarantee the loaded regions have unique IDs, no
+// range overlap, and monotonically increasing start keys.
+func (r *RegionsInfo) AppendRootRegionNoOverlapUnchecked(region *RegionInfo) {
+	r.t.Lock()
+	defer r.t.Unlock()
+	item := &regionItem{RegionInfo: region}
+	r.tree.append(item)
+	r.regions[region.GetID()] = item
 }
 
 // PutRegion put a region.
@@ -1269,6 +1375,7 @@ func (r *RegionsInfo) preUpdateSubTreeLocked(
 }
 
 func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionInfo, region *RegionInfo, skipOverlapCheck bool) {
+	region.ensurePeerClassification()
 	if rangeChanged {
 		// TODO: only perform the remove operation on the overlapped peer.
 		if !skipOverlapCheck {
@@ -1353,6 +1460,17 @@ func check(region, origin *RegionInfo, overlaps []*RegionInfo) error {
 	}
 
 	return nil
+}
+
+func logStaleRegion(region, origin *RegionInfo, err error) {
+	fields := []zap.Field{errs.ZapError(err)}
+	if region != nil {
+		fields = append(fields, zap.Stringer("region", region.GetMeta()))
+	}
+	if origin != nil {
+		fields = append(fields, zap.Stringer("origin", origin.GetMeta()))
+	}
+	log.Debug("region is stale", fields...)
 }
 
 // SetRegion sets the RegionInfo to regionTree and regionMap and return the update info of subtree.
@@ -1738,27 +1856,26 @@ func sortOutKeyIDMap(
 ) []uint64 {
 	keyIDMap := make([]uint64, len(regions))
 	for idx, region := range regions {
+		// Check if the region has been found.
+		// If the given key is not found in the region tree, set the region to nil.
+		if region == nil {
+			continue
+		}
 		regionID := region.GetMeta().GetId()
 		keyIDMap[idx] = regionID
-		// Check if the region has been found.
 		if regionFound, ok := regionsByID[regionID]; (ok && regionFound != nil) || regionID == 0 {
 			continue
 		}
-		// If the given key is not found in the region tree, set the region to nil.
-		if region == nil {
-			regionsByID[regionID] = nil
-		} else {
-			regionResp := &pdpb.RegionResponse{
-				Region:       region.GetMeta(),
-				Leader:       region.GetLeader(),
-				DownPeers:    region.GetDownPeers(),
-				PendingPeers: region.GetPendingPeers(),
-			}
-			if needBuckets {
-				regionResp.Buckets = region.GetBuckets()
-			}
-			regionsByID[regionID] = regionResp
+		regionResp := &pdpb.RegionResponse{
+			Region:       region.GetMeta(),
+			Leader:       region.GetLeader(),
+			DownPeers:    region.GetDownPeers(),
+			PendingPeers: region.GetPendingPeers(),
 		}
+		if needBuckets {
+			regionResp.Buckets = region.GetBuckets()
+		}
+		regionsByID[regionID] = regionResp
 	}
 	return keyIDMap
 }

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1465,10 +1465,10 @@ func check(region, origin *RegionInfo, overlaps []*RegionInfo) error {
 func logStaleRegion(region, origin *RegionInfo, err error) {
 	fields := []zap.Field{errs.ZapError(err)}
 	if region != nil {
-		fields = append(fields, zap.Stringer("region", region.GetMeta()))
+		fields = append(fields, logutil.ZapRedactStringer("region", RegionToHexMeta(region.GetMeta())))
 	}
 	if origin != nil {
-		fields = append(fields, zap.Stringer("origin", origin.GetMeta()))
+		fields = append(fields, logutil.ZapRedactStringer("origin", RegionToHexMeta(origin.GetMeta())))
 	}
 	log.Debug("region is stale", fields...)
 }

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -97,6 +97,9 @@ type RegionInfo struct {
 	// peersClassified is false when a storage-loaded region is first inserted
 	// into the root tree. Subtree rebuild classifies peers before using them.
 	peersClassified bool
+	// readLeaderHintEnabled allows storage-loaded regions to expose a transient
+	// leader in read responses while heartbeat has not refreshed runtime fields.
+	readLeaderHintEnabled bool
 	// ref is used to indicate the reference count of the region in root-tree and sub-tree.
 	ref atomic.Int32
 	// bucketMeta is used to store the bucket meta reported by tikv.
@@ -159,8 +162,9 @@ func NewRegionInfo(region *metapb.Region, leader *metapb.Peer, opts ...RegionCre
 // state is rebuilt after region read APIs become available.
 func NewStorageRegionInfo(region *metapb.Region) *RegionInfo {
 	return &RegionInfo{
-		meta:   region,
-		source: Storage,
+		meta:                  region,
+		source:                Storage,
+		readLeaderHintEnabled: true,
 	}
 }
 
@@ -368,6 +372,7 @@ func (r *RegionInfo) Clone(opts ...RegionCreateOption) *RegionInfo {
 		queryStats:                typeutil.DeepClone(r.queryStats, QueryStatsFactory),
 		bucketMeta:                r.bucketMeta,
 		peersClassified:           r.peersClassified,
+		readLeaderHintEnabled:     r.readLeaderHintEnabled,
 	}
 
 	for _, opt := range opts {
@@ -834,6 +839,30 @@ func (r *RegionInfo) GetWriteRate() (bytesRate, keysRate float64) {
 // GetLeader returns the leader of the region.
 func (r *RegionInfo) GetLeader() *metapb.Peer {
 	return r.leader
+}
+
+// GetLeaderForRead returns the best-effort leader used in region read responses.
+//
+// Storage-loaded regions do not have heartbeat runtime fields yet. Returning a
+// voter as a transient leader keeps router clients from treating all loaded
+// regions as no-leader while the true leader is refreshed by heartbeat or TiKV
+// NotLeader responses.
+func (r *RegionInfo) GetLeaderForRead() *metapb.Peer {
+	if r == nil {
+		return nil
+	}
+	if leader := r.GetLeader(); leader != nil && leader.GetId() != 0 {
+		return leader
+	}
+	if !r.readLeaderHintEnabled {
+		return r.GetLeader()
+	}
+	for _, peer := range r.GetPeers() {
+		if peer != nil && peer.GetId() != 0 && IsVoterOrIncomingVoter(peer) && !IsWitness(peer) {
+			return peer
+		}
+	}
+	return r.GetLeader()
 }
 
 // GetStartKey returns the start key of the region.
@@ -1795,7 +1824,7 @@ func (r *RegionsInfo) QueryRegions(
 			} else {
 				regionResp := &pdpb.RegionResponse{
 					Region:       region.GetMeta(),
-					Leader:       region.GetLeader(),
+					Leader:       region.GetLeaderForRead(),
 					DownPeers:    region.GetDownPeers(),
 					PendingPeers: region.GetPendingPeers(),
 				}
@@ -1868,7 +1897,7 @@ func sortOutKeyIDMap(
 		}
 		regionResp := &pdpb.RegionResponse{
 			Region:       region.GetMeta(),
-			Leader:       region.GetLeader(),
+			Leader:       region.GetLeaderForRead(),
 			DownPeers:    region.GetDownPeers(),
 			PendingPeers: region.GetPendingPeers(),
 		}

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1122,7 +1122,7 @@ func (r *RegionsInfo) CheckAndPutRegionNoOverlap(region *RegionInfo) []*RegionIn
 	}
 	origin, overlaps, rangeChanged := r.setRegionLocked(region, true)
 	r.t.Unlock()
-	r.UpdateSubTree(region, origin, overlaps, rangeChanged)
+	r.updateSubTree(region, origin, overlaps, rangeChanged, true)
 	return overlaps
 }
 
@@ -1224,7 +1224,7 @@ func (r *RegionsInfo) UpdateSubTreeOrderInsensitive(region *RegionInfo) {
 			return
 		}
 	}
-	r.updateSubTreeLocked(rangeChanged, nil, region)
+	r.updateSubTreeLocked(rangeChanged, nil, region, false)
 }
 
 func (r *RegionsInfo) preUpdateSubTreeLocked(
@@ -1268,26 +1268,26 @@ func (r *RegionsInfo) preUpdateSubTreeLocked(
 	return false
 }
 
-func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionInfo, region *RegionInfo) {
-	overlapsProvided := overlaps != nil
+func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionInfo, region *RegionInfo, skipOverlapCheck bool) {
 	if rangeChanged {
 		// TODO: only perform the remove operation on the overlapped peer.
-		if !overlapsProvided {
-			// If the range has changed but the overlapped regions are not provided, collect them by `[]*regionItem`.
-			for _, item := range r.getOverlapRegionFromOverlapTreeLocked(region) {
-				r.removeRegionFromSubTreeLocked(item)
-			}
-		} else {
-			// Remove all provided overlapped regions from the subtrees.
-			for _, overlap := range overlaps {
-				r.removeRegionFromSubTreeLocked(overlap)
+		if !skipOverlapCheck {
+			if len(overlaps) == 0 {
+				// If the range has changed but the overlapped regions are not provided, collect them by `[]*regionItem`.
+				for _, item := range r.getOverlapRegionFromOverlapTreeLocked(region) {
+					r.removeRegionFromSubTreeLocked(item)
+				}
+			} else {
+				// Remove all provided overlapped regions from the subtrees.
+				for _, overlap := range overlaps {
+					r.removeRegionFromSubTreeLocked(overlap)
+				}
 			}
 		}
 	}
 	// Reinsert the region into all subtrees.
 	item := &regionItem{region}
 	r.subRegions[region.GetID()] = item
-	skipOverlapCheck := overlapsProvided && len(overlaps) == 0
 	r.overlapTree.update(item, skipOverlapCheck)
 	// Add leaders and followers.
 	setPeer := func(peersMap map[uint64]*regionTree, storeID uint64) {
@@ -1414,6 +1414,10 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol 
 
 // UpdateSubTree updates the subtree.
 func (r *RegionsInfo) UpdateSubTree(region, origin *RegionInfo, overlaps []*RegionInfo, rangeChanged bool) {
+	r.updateSubTree(region, origin, overlaps, rangeChanged, false)
+}
+
+func (r *RegionsInfo) updateSubTree(region, origin *RegionInfo, overlaps []*RegionInfo, rangeChanged, skipOverlapCheck bool) {
 	failpoint.Inject("UpdateSubTree", func() {
 		if origin == nil {
 			time.Sleep(time.Second)
@@ -1426,7 +1430,7 @@ func (r *RegionsInfo) UpdateSubTree(region, origin *RegionInfo, overlaps []*Regi
 			return
 		}
 	}
-	r.updateSubTreeLocked(rangeChanged, overlaps, region)
+	r.updateSubTreeLocked(rangeChanged, overlaps, region, skipOverlapCheck)
 }
 
 func (r *RegionsInfo) updateSubTreeStat(origin *RegionInfo, region *RegionInfo) {

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1112,6 +1112,20 @@ func (r *RegionsInfo) CheckAndPutRegion(region *RegionInfo) []*RegionInfo {
 	return overlaps
 }
 
+// CheckAndPutRegionNoOverlap puts a region when the caller has proved it has no range overlap.
+func (r *RegionsInfo) CheckAndPutRegionNoOverlap(region *RegionInfo) []*RegionInfo {
+	r.t.Lock()
+	origin := r.getRegionLocked(region.GetID())
+	if origin != nil {
+		r.t.Unlock()
+		return r.CheckAndPutRegion(region)
+	}
+	origin, overlaps, rangeChanged := r.setRegionLocked(region, true)
+	r.t.Unlock()
+	r.UpdateSubTree(region, origin, overlaps, rangeChanged)
+	return overlaps
+}
+
 // PutRegion put a region.
 func (r *RegionsInfo) PutRegion(region *RegionInfo) []*RegionInfo {
 	origin, overlaps, rangeChanged := r.SetRegion(region)
@@ -1255,9 +1269,10 @@ func (r *RegionsInfo) preUpdateSubTreeLocked(
 }
 
 func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionInfo, region *RegionInfo) {
+	overlapsProvided := overlaps != nil
 	if rangeChanged {
 		// TODO: only perform the remove operation on the overlapped peer.
-		if len(overlaps) == 0 {
+		if !overlapsProvided {
 			// If the range has changed but the overlapped regions are not provided, collect them by `[]*regionItem`.
 			for _, item := range r.getOverlapRegionFromOverlapTreeLocked(region) {
 				r.removeRegionFromSubTreeLocked(item)
@@ -1272,7 +1287,8 @@ func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionI
 	// Reinsert the region into all subtrees.
 	item := &regionItem{region}
 	r.subRegions[region.GetID()] = item
-	r.overlapTree.update(item, false)
+	skipOverlapCheck := overlapsProvided && len(overlaps) == 0
+	r.overlapTree.update(item, skipOverlapCheck)
 	// Add leaders and followers.
 	setPeer := func(peersMap map[uint64]*regionTree, storeID uint64) {
 		store, ok := peersMap[storeID]
@@ -1280,7 +1296,7 @@ func (r *RegionsInfo) updateSubTreeLocked(rangeChanged bool, overlaps []*RegionI
 			store = newRegionTree()
 			peersMap[storeID] = store
 		}
-		store.update(item, false)
+		store.update(item, skipOverlapCheck)
 	}
 	for _, peer := range region.GetVoters() {
 		storeID := peer.GetStoreId()

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1459,6 +1459,32 @@ func TestRegionCount(t *testing.T) {
 	}
 }
 
+func TestCheckAndPutRegionNoOverlap(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+
+	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("c"))
+	overlaps := regions.CheckAndPutRegionNoOverlap(region1)
+	re.Empty(overlaps)
+	re.Equal(1, regions.GetTotalRegionCount())
+	re.Equal(1, regions.TreeLen())
+	re.Equal(1, regions.GetStoreRegionCount(1))
+	re.Equal(int32(2), region1.GetRef())
+
+	region2 := NewTestRegionInfo(2, 1, []byte("c"), []byte("e"))
+	overlaps = regions.CheckAndPutRegionNoOverlap(region2)
+	re.Empty(overlaps)
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Equal(2, regions.TreeLen())
+	re.Equal(2, regions.GetStoreRegionCount(1))
+	re.Equal(int32(2), region2.GetRef())
+
+	// Existing IDs fall back to the normal checked path.
+	regions.CheckAndPutRegionNoOverlap(NewTestRegionInfo(2, 2, []byte("c"), []byte("e")))
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Equal(2, regions.TreeLen())
+}
+
 func TestResetRegionCache(t *testing.T) {
 	re := require.New(t)
 	regions := NewRegionsInfo()

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1553,6 +1553,61 @@ func TestStorageRegionInfoDefersPeerClassificationUntilSubTreeUpdate(t *testing.
 	re.Same(region, regions.GetStoreRegions(2)[0])
 }
 
+func TestStorageRegionInfoLeaderForRead(t *testing.T) {
+	re := require.New(t)
+	newRegionMeta := func() *metapb.Region {
+		return &metapb.Region{
+			Id:       1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("b"),
+			Peers: []*metapb.Peer{
+				{Id: 11, StoreId: 1, Role: metapb.PeerRole_Learner},
+				{Id: 12, StoreId: 2, IsWitness: true},
+				{Id: 13, StoreId: 3},
+				{Id: 14, StoreId: 4, Role: metapb.PeerRole_IncomingVoter},
+			},
+			RegionEpoch: &metapb.RegionEpoch{
+				ConfVer: 1,
+				Version: 1,
+			},
+		}
+	}
+
+	ordinary := NewRegionInfo(newRegionMeta(), nil)
+	re.Nil(ordinary.GetLeader())
+	re.Nil(ordinary.GetLeaderForRead())
+
+	storageLoaded := NewStorageRegionInfo(newRegionMeta())
+	re.Nil(storageLoaded.GetLeader())
+	re.Equal(uint64(13), storageLoaded.GetLeaderForRead().GetId())
+	re.Equal(uint64(3), storageLoaded.GetLeaderForRead().GetStoreId())
+
+	storageLoaded.leader = storageLoaded.GetPeers()[3]
+	re.Equal(uint64(14), storageLoaded.GetLeaderForRead().GetId())
+	storageLoaded.leader = nil
+
+	cloned := storageLoaded.Clone()
+	re.Nil(cloned.GetLeader())
+	re.Equal(uint64(13), cloned.GetLeaderForRead().GetId())
+
+	noAvailableVoter := NewStorageRegionInfo(&metapb.Region{
+		Id:       2,
+		StartKey: []byte("b"),
+		EndKey:   []byte("c"),
+		Peers: []*metapb.Peer{
+			{Id: 21, StoreId: 1, Role: metapb.PeerRole_Learner},
+			{Id: 22, StoreId: 2, IsWitness: true},
+			{StoreId: 3},
+		},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	})
+	re.Nil(noAvailableVoter.GetLeader())
+	re.Nil(noAvailableVoter.GetLeaderForRead())
+}
+
 func TestCheckAndPutRegionCleansPendingSubTreeOverlap(t *testing.T) {
 	re := require.New(t)
 	ctx := ContextTODO()

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1485,6 +1485,35 @@ func TestCheckAndPutRegionNoOverlap(t *testing.T) {
 	re.Equal(2, regions.TreeLen())
 }
 
+func TestCheckAndPutRegionCleansPendingSubTreeOverlap(t *testing.T) {
+	re := require.New(t)
+	ctx := ContextTODO()
+	regions := NewRegionsInfo()
+
+	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("c"))
+	regions.CheckAndPutRegion(region1)
+	re.Equal(1, regions.GetStoreRegionCount(1))
+
+	// Simulate the split root/subtree update window in region heartbeat:
+	// region1 is removed from the root tree but still exists in the subtree.
+	left := NewTestRegionInfo(2, 1, []byte("a"), []byte("b"))
+	overlaps, err := regions.CheckAndPutRootTree(ctx, left)
+	re.NoError(err)
+	re.Len(overlaps, 1)
+	re.Equal(1, regions.GetStoreRegionCount(1))
+	re.Nil(regions.GetRegion(1))
+
+	// The normal checked path sees no root-tree overlap, but it still must scan
+	// and clean the pending subtree overlap from region1.
+	right := NewTestRegionInfo(3, 1, []byte("b"), []byte("c"))
+	overlaps = regions.CheckAndPutRegion(right)
+	re.Empty(overlaps)
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Equal(2, regions.TreeLen())
+	re.Equal(1, regions.GetStoreRegionCount(1))
+	re.ElementsMatch([]*RegionInfo{right}, regions.GetStoreRegions(1))
+}
+
 func TestResetRegionCache(t *testing.T) {
 	re := require.New(t)
 	regions := NewRegionsInfo()

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1485,6 +1485,74 @@ func TestCheckAndPutRegionNoOverlap(t *testing.T) {
 	re.Equal(2, regions.TreeLen())
 }
 
+func TestAppendRootRegionNoOverlap(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+
+	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("c"))
+	re.True(regions.AppendRootRegionNoOverlap(region1))
+	re.Equal(1, regions.GetTotalRegionCount())
+	re.Equal(1, regions.TreeLen())
+	re.Equal(0, regions.GetStoreRegionCount(1))
+	re.Equal(int32(1), region1.GetRef())
+	re.Same(region1, regions.GetRegion(1))
+	re.Same(region1, regions.GetRegionByKey([]byte("b")))
+
+	region2 := NewTestRegionInfo(2, 1, []byte("c"), []byte("e"))
+	re.True(regions.AppendRootRegionNoOverlap(region2))
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Equal(2, regions.TreeLen())
+	re.Equal(0, regions.GetStoreRegionCount(1))
+	re.Equal(int32(1), region2.GetRef())
+	re.Same(region2, regions.GetRegionByKey([]byte("d")))
+
+	duplicateID := NewTestRegionInfo(2, 1, []byte("e"), []byte("g"))
+	re.False(regions.AppendRootRegionNoOverlap(duplicateID))
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Same(region2, regions.GetRegion(2))
+
+	nonMonotonic := NewTestRegionInfo(3, 1, []byte("b"), []byte("c"))
+	re.False(regions.AppendRootRegionNoOverlap(nonMonotonic))
+	re.Equal(2, regions.GetTotalRegionCount())
+	re.Nil(regions.GetRegion(3))
+
+	region3 := NewTestRegionInfo(3, 1, []byte("e"), []byte("g"))
+	re.True(regions.AppendRootRegionNoOverlapHint(region3))
+	re.Equal(3, regions.GetTotalRegionCount())
+	re.Same(region3, regions.GetRegionByKey([]byte("f")))
+}
+
+func TestStorageRegionInfoDefersPeerClassificationUntilSubTreeUpdate(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	leader := &metapb.Peer{Id: 11, StoreId: 1}
+	learner := &metapb.Peer{Id: 12, StoreId: 2, Role: metapb.PeerRole_Learner}
+	region := NewStorageRegionInfo(&metapb.Region{
+		Id:       1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("b"),
+		Peers:    []*metapb.Peer{leader, learner},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	})
+	re.False(region.peersClassified)
+
+	re.True(regions.AppendRootRegionNoOverlap(region))
+	re.False(region.peersClassified)
+	re.Equal(1, regions.GetTotalRegionCount())
+	re.Equal(0, regions.GetStoreRegionCount(1))
+	re.Equal(0, regions.GetStoreRegionCount(2))
+
+	regions.CheckAndPutSubTree(region)
+	re.True(region.peersClassified)
+	re.Equal(1, regions.GetStoreRegionCount(1))
+	re.Equal(1, regions.GetStoreRegionCount(2))
+	re.Same(region, regions.GetStoreRegions(1)[0])
+	re.Same(region, regions.GetStoreRegions(2)[0])
+}
+
 func TestCheckAndPutRegionCleansPendingSubTreeOverlap(t *testing.T) {
 	re := require.New(t)
 	ctx := ContextTODO()

--- a/pkg/core/region_tree.go
+++ b/pkg/core/region_tree.go
@@ -215,6 +215,21 @@ func (t *regionTree) update(item *regionItem, withOverlaps bool, overlaps ...*Re
 	return result
 }
 
+func (t *regionTree) append(item *regionItem) {
+	region := item.RegionInfo
+	t.tree.AppendHint(item)
+	t.totalSize += region.approximateSize
+	regionWriteBytesRate, regionWriteKeysRate := region.GetWriteRate()
+	t.totalWriteBytesRate += regionWriteBytesRate
+	t.totalWriteKeysRate += regionWriteKeysRate
+	if !region.LoadedFromStorage() {
+		t.notFromStorageRegionsCnt++
+	}
+	if t.countRef {
+		item.IncRef()
+	}
+}
+
 // updateStat is used to update statistics when RegionInfo is directly replaced.
 func (t *regionTree) updateStat(origin *RegionInfo, region *RegionInfo) {
 	t.totalSize += region.approximateSize

--- a/pkg/response/region.go
+++ b/pkg/response/region.go
@@ -168,7 +168,7 @@ func InitRegion(r *core.RegionInfo, s *RegionInfo) *RegionInfo {
 	s.EndKey = core.HexRegionKeyStr(r.GetEndKey())
 	s.RegionEpoch = r.GetRegionEpoch()
 	s.Peers = fromPeerSlice(r.GetPeers())
-	s.Leader = fromPeer(r.GetLeader())
+	s.Leader = fromPeer(r.GetLeaderForRead())
 	s.DownPeers = fromPeerStatsSlice(r.GetDownPeers())
 	s.PendingPeers = fromPeerSlice(r.GetPendingPeers())
 	s.CPUUsage = r.GetCPUUsage()

--- a/pkg/storage/endpoint/meta.go
+++ b/pkg/storage/endpoint/meta.go
@@ -17,7 +17,10 @@ package endpoint
 import (
 	"context"
 	"math"
+	"runtime"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -62,6 +65,9 @@ const (
 	MaxLocalKVRangeLimit = 100000
 	// MinKVRangeLimit is the min limit of the number of keys in a range.
 	MinKVRangeLimit = 100
+	// minParallelRegionDecodeBatch is the minimum batch size to decode storage
+	// regions concurrently. Small batches stay serial to avoid worker overhead.
+	minParallelRegionDecodeBatch = 1024
 )
 
 type regionBytesLoader interface {
@@ -203,17 +209,13 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 		default:
 		}
 
-		for _, r := range res {
-			region := &metapb.Region{}
-			if err := region.Unmarshal(r); err != nil {
-				return errs.ErrProtoUnmarshal.Wrap(err).GenWithStackByArgs()
-			}
-			if err = encryption.DecryptRegion(region, se.encryptionKeyManager); err != nil {
-				return err
-			}
-
+		regions, err := se.decodeStorageRegions(res)
+		if err != nil {
+			return err
+		}
+		for _, region := range regions {
 			se.nextRegionID = region.GetId() + 1
-			overlaps := f(core.NewRegionInfo(region, nil, core.SetSource(core.Storage)))
+			overlaps := f(core.NewStorageRegionInfo(region))
 			for _, item := range overlaps {
 				if err := se.DeleteRegion(item.GetMeta()); err != nil {
 					return err
@@ -225,6 +227,68 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 			return nil
 		}
 	}
+}
+
+func (se *StorageEndpoint) decodeStorageRegions(values [][]byte) ([]*metapb.Region, error) {
+	if len(values) < minParallelRegionDecodeBatch {
+		regions := make([]*metapb.Region, 0, len(values))
+		for _, value := range values {
+			region, err := se.decodeStorageRegion(value)
+			if err != nil {
+				return nil, err
+			}
+			regions = append(regions, region)
+		}
+		return regions, nil
+	}
+
+	regions := make([]*metapb.Region, len(values))
+	workers := min(runtime.GOMAXPROCS(0), len(values))
+	index := atomic.Int64{}
+	hasErr := atomic.Bool{}
+	var errOnce sync.Once
+	var firstErr error
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for {
+				if hasErr.Load() {
+					return
+				}
+				i := int(index.Add(1)) - 1
+				if i >= len(values) {
+					return
+				}
+				region, err := se.decodeStorageRegion(values[i])
+				if err != nil {
+					errOnce.Do(func() {
+						firstErr = err
+						hasErr.Store(true)
+					})
+					return
+				}
+				regions[i] = region
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return regions, nil
+}
+
+func (se *StorageEndpoint) decodeStorageRegion(value []byte) (*metapb.Region, error) {
+	region := &metapb.Region{}
+	if err := region.Unmarshal(value); err != nil {
+		return nil, errs.ErrProtoUnmarshal.Wrap(err).GenWithStackByArgs()
+	}
+	if err := encryption.DecryptRegion(region, se.encryptionKeyManager); err != nil {
+		return nil, err
+	}
+	return region, nil
 }
 
 func (se *StorageEndpoint) regionLoadRangeLimit() int {

--- a/pkg/storage/endpoint/meta.go
+++ b/pkg/storage/endpoint/meta.go
@@ -58,9 +58,15 @@ var _ MetaStorage = (*StorageEndpoint)(nil)
 const (
 	// MaxKVRangeLimit is the max limit of the number of keys in a range.
 	MaxKVRangeLimit = 10000
+	// MaxLocalKVRangeLimit is the max limit of the number of keys in a local KV range.
+	MaxLocalKVRangeLimit = 100000
 	// MinKVRangeLimit is the min limit of the number of keys in a range.
 	MinKVRangeLimit = 100
 )
+
+type regionBytesLoader interface {
+	LoadRangeValues(startKey, endKey string, limit int) ([][]byte, error)
+}
 
 // LoadMeta loads cluster meta from the storage. This method will only
 // be used by the PD server, so we should only implement it for the etcd storage.
@@ -177,14 +183,14 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 	// Since the region key may be very long, using a larger rangeLimit will cause
 	// the message packet to exceed the grpc message size limit (4MB). Here we use
 	// a variable rangeLimit to work around.
-	rangeLimit := MaxKVRangeLimit
+	rangeLimit := se.regionLoadRangeLimit()
 	for {
 		failpoint.Inject("slowLoadRegion", func() {
 			rangeLimit = 1
 			time.Sleep(time.Second)
 		})
 		startKey := keypath.RegionPath(se.nextRegionID)
-		_, res, err := se.LoadRange(startKey, endKey, rangeLimit)
+		res, err := se.loadRegionValues(startKey, endKey, rangeLimit)
 		if err != nil {
 			if rangeLimit /= 2; rangeLimit >= MinKVRangeLimit {
 				continue
@@ -199,7 +205,7 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 
 		for _, r := range res {
 			region := &metapb.Region{}
-			if err := region.Unmarshal([]byte(r)); err != nil {
+			if err := region.Unmarshal(r); err != nil {
 				return errs.ErrProtoUnmarshal.Wrap(err).GenWithStackByArgs()
 			}
 			if err = encryption.DecryptRegion(region, se.encryptionKeyManager); err != nil {
@@ -219,6 +225,28 @@ func (se *StorageEndpoint) LoadRegions(ctx context.Context, f func(region *core.
 			return nil
 		}
 	}
+}
+
+func (se *StorageEndpoint) regionLoadRangeLimit() int {
+	if _, ok := se.Base.(regionBytesLoader); ok {
+		return MaxLocalKVRangeLimit
+	}
+	return MaxKVRangeLimit
+}
+
+func (se *StorageEndpoint) loadRegionValues(startKey, endKey string, limit int) ([][]byte, error) {
+	if loader, ok := se.Base.(regionBytesLoader); ok {
+		return loader.LoadRangeValues(startKey, endKey, limit)
+	}
+	_, values, err := se.LoadRange(startKey, endKey, limit)
+	if err != nil {
+		return nil, err
+	}
+	res := make([][]byte, 0, len(values))
+	for _, value := range values {
+		res = append(res, []byte(value))
+	}
+	return res, nil
 }
 
 // SaveRegion saves one region to storage.

--- a/pkg/storage/endpoint/meta_test.go
+++ b/pkg/storage/endpoint/meta_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/keypath"
+)
+
+type testRegionBytesLoader struct {
+	kv.Base
+	called    bool
+	lastLimit int
+}
+
+func (l *testRegionBytesLoader) LoadRangeValues(startKey, endKey string, limit int) ([][]byte, error) {
+	l.called = true
+	l.lastLimit = limit
+	_, values, err := l.Base.LoadRange(startKey, endKey, limit)
+	if err != nil {
+		return nil, err
+	}
+	res := make([][]byte, 0, len(values))
+	for _, value := range values {
+		res = append(res, []byte(value))
+	}
+	return res, nil
+}
+
+func TestLoadRegionsWithBytesLoader(t *testing.T) {
+	re := require.New(t)
+	loader := &testRegionBytesLoader{Base: kv.NewMemoryKV()}
+	storage := NewStorageEndpoint(loader, nil)
+	region := &metapb.Region{
+		Id:       1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("b"),
+	}
+	re.NoError(storage.SaveRegion(region))
+
+	var loaded []*core.RegionInfo
+	re.NoError(storage.LoadRegions(context.Background(), func(region *core.RegionInfo) []*core.RegionInfo {
+		loaded = append(loaded, region)
+		return nil
+	}))
+
+	re.True(loader.called)
+	re.Equal(MaxLocalKVRangeLimit, loader.lastLimit)
+	re.Len(loaded, 1)
+	re.Equal(region, loaded[0].GetMeta())
+}
+
+func TestLoadRegionsWithLevelDBBytesLoader(t *testing.T) {
+	re := require.New(t)
+	levelDB, err := kv.NewLevelDBKV(t.TempDir())
+	re.NoError(err)
+	defer func() {
+		re.NoError(levelDB.Close())
+	}()
+	storage := NewStorageEndpoint(levelDB, nil)
+	regions := []*metapb.Region{
+		{
+			Id:       1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("b"),
+		},
+		{
+			Id:       2,
+			StartKey: []byte("b"),
+			EndKey:   []byte("c"),
+		},
+	}
+	for _, region := range regions {
+		re.NoError(storage.SaveRegion(region))
+	}
+
+	values, err := levelDB.LoadRangeValues(keypath.RegionPath(0), keypath.RegionPath(math.MaxUint64), len(regions))
+	re.NoError(err)
+	re.Len(values, len(regions))
+	for i, value := range values {
+		region := &metapb.Region{}
+		re.NoError(region.Unmarshal(value))
+		re.Equal(regions[i], region)
+	}
+
+	var loaded []*core.RegionInfo
+	re.NoError(storage.LoadRegions(context.Background(), func(region *core.RegionInfo) []*core.RegionInfo {
+		loaded = append(loaded, region)
+		return nil
+	}))
+	re.Len(loaded, len(regions))
+	for i, region := range loaded {
+		re.Equal(regions[i], region.GetMeta())
+	}
+}

--- a/pkg/storage/endpoint/meta_test.go
+++ b/pkg/storage/endpoint/meta_test.go
@@ -71,6 +71,29 @@ func TestLoadRegionsWithBytesLoader(t *testing.T) {
 	re.Equal(region, loaded[0].GetMeta())
 }
 
+func TestLoadRegionsReturnsBeforePuttingDecodedBatchOnDecodeError(t *testing.T) {
+	re := require.New(t)
+	loader := &testRegionBytesLoader{Base: kv.NewMemoryKV()}
+	storage := NewStorageEndpoint(loader, nil)
+	for i := uint64(1); i <= minParallelRegionDecodeBatch+1; i++ {
+		region := &metapb.Region{
+			Id:       i,
+			StartKey: []byte{byte(i >> 8), byte(i)},
+			EndKey:   []byte{byte((i + 1) >> 8), byte(i + 1)},
+		}
+		re.NoError(storage.SaveRegion(region))
+	}
+	re.NoError(loader.Save(keypath.RegionPath(2), string([]byte{0xff})))
+
+	var loaded []*core.RegionInfo
+	err := storage.LoadRegions(context.Background(), func(region *core.RegionInfo) []*core.RegionInfo {
+		loaded = append(loaded, region)
+		return nil
+	})
+	re.Error(err)
+	re.Empty(loaded)
+}
+
 func TestLoadRegionsWithLevelDBBytesLoader(t *testing.T) {
 	re := require.New(t)
 	levelDB, err := kv.NewLevelDBKV(t.TempDir())

--- a/pkg/storage/kv/levedb_kv.go
+++ b/pkg/storage/kv/levedb_kv.go
@@ -67,7 +67,33 @@ func (kv *LevelDBKV) LoadRange(startKey, endKey string, limit int) (keys, values
 		count++
 	}
 	iter.Release()
+	if err = iter.Error(); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
 	return keys, values, nil
+}
+
+// LoadRangeValues gets raw values for a given key range.
+func (kv *LevelDBKV) LoadRangeValues(startKey, endKey string, limit int) (values [][]byte, err error) {
+	iter := kv.NewIterator(&util.Range{Start: []byte(startKey), Limit: []byte(endKey)}, nil)
+	capacity := limit
+	if capacity < 0 {
+		capacity = 0
+	}
+	values = make([][]byte, 0, capacity)
+	count := 0
+	for iter.Next() {
+		if limit > 0 && count >= limit {
+			break
+		}
+		values = append(values, append([]byte(nil), iter.Value()...))
+		count++
+	}
+	iter.Release()
+	if err = iter.Error(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return values, nil
 }
 
 // Save stores a key-value pair.

--- a/pkg/utils/grpcutil/cluster.go
+++ b/pkg/utils/grpcutil/cluster.go
@@ -53,7 +53,7 @@ func GetRegion(rc *core.BasicCluster, request *pdpb.GetRegionRequest, isFollower
 	return &pdpb.GetRegionResponse{
 		Header:       WrapHeader(),
 		Region:       region.GetMeta(),
-		Leader:       region.GetLeader(),
+		Leader:       region.GetLeaderForRead(),
 		DownPeers:    region.GetDownPeers(),
 		PendingPeers: region.GetPendingPeers(),
 		Buckets:      buckets,
@@ -80,7 +80,7 @@ func GetPrevRegion(rc *core.BasicCluster, request *pdpb.GetRegionRequest, isFoll
 	return &pdpb.GetRegionResponse{
 		Header:       WrapHeader(),
 		Region:       region.GetMeta(),
-		Leader:       region.GetLeader(),
+		Leader:       region.GetLeaderForRead(),
 		DownPeers:    region.GetDownPeers(),
 		PendingPeers: region.GetPendingPeers(),
 		Buckets:      buckets,
@@ -106,7 +106,7 @@ func GetRegionByID(rc *core.BasicCluster, request *pdpb.GetRegionByIDRequest, is
 	return &pdpb.GetRegionResponse{
 		Header:       WrapHeader(),
 		Region:       region.GetMeta(),
-		Leader:       region.GetLeader(),
+		Leader:       region.GetLeaderForRead(),
 		DownPeers:    region.GetDownPeers(),
 		PendingPeers: region.GetPendingPeers(),
 		Buckets:      buckets,
@@ -125,7 +125,7 @@ func ScanRegions(rc *core.BasicCluster, request *pdpb.ScanRegionsRequest, isFoll
 	}
 	resp = &pdpb.ScanRegionsResponse{Header: WrapHeader()}
 	for _, r := range regions {
-		leader := r.GetLeader()
+		leader := r.GetLeaderForRead()
 		if leader == nil {
 			leader = &metapb.Peer{}
 		}
@@ -181,7 +181,7 @@ func BatchScanRegions(rc *core.BasicCluster, request *pdpb.BatchScanRegionsReque
 	}
 	regions := make([]*pdpb.Region, 0, len(res))
 	for _, r := range res {
-		leader := r.GetLeader()
+		leader := r.GetLeaderForRead()
 		if leader == nil {
 			leader = &metapb.Peer{}
 		}

--- a/pkg/utils/grpcutil/cluster_test.go
+++ b/pkg/utils/grpcutil/cluster_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -47,6 +48,93 @@ func (suite *clusterSuite) SetupSuite() {
 
 func (suite *clusterSuite) TearDownSuite() {
 	keypath.SetClusterID(suite.oldClusterID)
+}
+
+func (suite *clusterSuite) TestStorageLoadedRegionLeaderForReadResponse() {
+	re := suite.Require()
+	rc := core.NewBasicCluster()
+	region := core.NewStorageRegionInfo(&metapb.Region{
+		Id:       10,
+		StartKey: []byte("a"),
+		EndKey:   []byte("b"),
+		Peers: []*metapb.Peer{
+			{Id: 101, StoreId: 1, Role: metapb.PeerRole_Learner},
+			{Id: 102, StoreId: 2, IsWitness: true},
+			{Id: 103, StoreId: 3},
+		},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	})
+	re.True(rc.AppendRootRegionNoOverlap(region))
+	re.True(rc.AppendRootRegionNoOverlap(core.NewStorageRegionInfo(&metapb.Region{
+		Id:       11,
+		StartKey: []byte("b"),
+		EndKey:   []byte("c"),
+		Peers: []*metapb.Peer{
+			{Id: 111, StoreId: 4},
+		},
+		RegionEpoch: &metapb.RegionEpoch{
+			ConfVer: 1,
+			Version: 1,
+		},
+	})))
+	expectedLeader := region.GetPeers()[2]
+
+	regionByKeyResp, err := GetRegion(rc, &pdpb.GetRegionRequest{
+		RegionKey: []byte("a"),
+	}, false)
+	re.NoError(err)
+	re.Nil(regionByKeyResp.GetHeader().GetError())
+	re.Equal(expectedLeader, regionByKeyResp.GetLeader())
+
+	prevRegionResp, err := GetPrevRegion(rc, &pdpb.GetRegionRequest{
+		RegionKey: []byte("b"),
+	}, false)
+	re.NoError(err)
+	re.Nil(prevRegionResp.GetHeader().GetError())
+	re.Equal(expectedLeader, prevRegionResp.GetLeader())
+
+	regionByIDResp, err := GetRegionByID(rc, &pdpb.GetRegionByIDRequest{
+		RegionId: region.GetID(),
+	}, false)
+	re.NoError(err)
+	re.Nil(regionByIDResp.GetHeader().GetError())
+	re.Equal(expectedLeader, regionByIDResp.GetLeader())
+
+	scanResp, err := ScanRegions(rc, &pdpb.ScanRegionsRequest{
+		StartKey: []byte("a"),
+		EndKey:   []byte("b"),
+		Limit:    1,
+	}, false)
+	re.NoError(err)
+	re.Nil(scanResp.GetHeader().GetError())
+	re.Len(scanResp.GetRegions(), 1)
+	re.Equal(expectedLeader, scanResp.GetRegions()[0].GetLeader())
+	re.Equal(expectedLeader, scanResp.GetLeaders()[0])
+
+	batchScanResp, err := BatchScanRegions(rc, &pdpb.BatchScanRegionsRequest{
+		Ranges: []*pdpb.KeyRange{{
+			StartKey: []byte("a"),
+			EndKey:   []byte("b"),
+		}},
+		Limit: 1,
+	}, false)
+	re.NoError(err)
+	re.Nil(batchScanResp.GetHeader().GetError())
+	re.Len(batchScanResp.GetRegions(), 1)
+	re.Equal(expectedLeader, batchScanResp.GetRegions()[0].GetLeader())
+
+	queryRegionResp := QueryRegion(rc, &pdpb.QueryRegionRequest{
+		Ids:      []uint64{region.GetID()},
+		Keys:     [][]byte{[]byte("a")},
+		PrevKeys: [][]byte{[]byte("b")},
+	})
+	re.Nil(queryRegionResp.GetHeader().GetError())
+	re.Equal(expectedLeader, queryRegionResp.GetRegionsById()[region.GetID()].GetLeader())
+	re.Equal([]uint64{region.GetID()}, queryRegionResp.GetKeyIdMap())
+	re.Equal([]uint64{region.GetID()}, queryRegionResp.GetPrevKeyIdMap())
 }
 
 func (suite *clusterSuite) TestScanRegions() {

--- a/server/api/middleware.go
+++ b/server/api/middleware.go
@@ -83,6 +83,7 @@ type clusterMiddleware struct {
 	s                         *server.Server
 	rd                        *render.Render
 	allowFollowerSyncedRegion bool
+	regionReadOnly            bool
 }
 
 type clusterMiddlewareOption func(*clusterMiddleware)
@@ -90,6 +91,12 @@ type clusterMiddlewareOption func(*clusterMiddleware)
 func withFollowerSyncedRegion() clusterMiddlewareOption {
 	return func(m *clusterMiddleware) {
 		m.allowFollowerSyncedRegion = true
+	}
+}
+
+func withRegionReadOnly() clusterMiddlewareOption {
+	return func(m *clusterMiddleware) {
+		m.regionReadOnly = true
 	}
 }
 
@@ -106,6 +113,20 @@ func newClusterMiddleware(s *server.Server, opts ...clusterMiddlewareOption) clu
 
 func (m clusterMiddleware) middleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.regionReadOnly {
+			rc := m.s.GetRegionReadRaftCluster()
+			if rc == nil {
+				rc = m.getFollowerSyncedCluster(r)
+			}
+			if rc == nil {
+				m.rd.JSON(w, http.StatusInternalServerError, errs.ErrNotBootstrapped.FastGenByArgs().Error())
+				return
+			}
+			ctx := context.WithValue(r.Context(), clusterCtxKey{}, rc)
+			h.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
 		rc := m.s.GetRaftCluster()
 		if rc == nil {
 			rc = m.getFollowerSyncedCluster(r)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -132,9 +132,11 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	clusterRouter.Use(newClusterMiddleware(svr).middleware)
 	regionReadRouter := apiRouter.NewRoute().Subrouter()
 	regionReadRouter.Use(newClusterMiddleware(svr, withFollowerSyncedRegion()).middleware)
+	regionRootReadRouter := apiRouter.NewRoute().Subrouter()
+	regionRootReadRouter.Use(newClusterMiddleware(svr, withRegionReadOnly(), withFollowerSyncedRegion()).middleware)
 
 	escapeRouter := clusterRouter.NewRoute().Subrouter().UseEncodedPath()
-	regionReadEscapeRouter := regionReadRouter.NewRoute().Subrouter().UseEncodedPath()
+	regionRootReadEscapeRouter := regionRootReadRouter.NewRoute().Subrouter().UseEncodedPath()
 
 	operatorHandler := newOperatorHandler(handler, rd)
 	registerFunc(apiRouter, "/operators", operatorHandler.GetOperators, setMethods(http.MethodGet), setAuditBackend(prometheus))
@@ -248,16 +250,16 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 	registerFunc(apiRouter, "/hotspot/buckets", hotStatusHandler.GetHotBuckets, setMethods(http.MethodGet), setAuditBackend(prometheus))
 
 	regionHandler := newRegionHandler(svr, rd)
-	registerFunc(regionReadRouter, "/region/id/{id}", regionHandler.GetRegionByID, setMethods(http.MethodGet), setAuditBackend(prometheus))
-	registerFunc(regionReadEscapeRouter, "/region/key/{key}", regionHandler.GetRegion, setMethods(http.MethodGet), setAuditBackend(prometheus))
+	registerFunc(regionRootReadRouter, "/region/id/{id}", regionHandler.GetRegionByID, setMethods(http.MethodGet), setAuditBackend(prometheus))
+	registerFunc(regionRootReadEscapeRouter, "/region/key/{key}", regionHandler.GetRegion, setMethods(http.MethodGet), setAuditBackend(prometheus))
 
 	srd := createStreamingRender()
 	regionsAllHandler := newRegionsHandler(svr, srd)
 	registerFunc(regionReadRouter, "/regions", regionsAllHandler.GetRegions, setMethods(http.MethodGet), setAuditBackend(localLog, prometheus))
 
 	regionsHandler := newRegionsHandler(svr, rd)
-	registerFunc(regionReadRouter, "/regions/key", regionsHandler.ScanRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
-	registerFunc(regionReadRouter, "/regions/count", regionsHandler.GetRegionCount, setMethods(http.MethodGet), setAuditBackend(prometheus))
+	registerFunc(regionRootReadRouter, "/regions/key", regionsHandler.ScanRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
+	registerFunc(regionRootReadRouter, "/regions/count", regionsHandler.GetRegionCount, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(regionReadRouter, "/regions/store/{id}", regionsHandler.GetStoreRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(regionReadRouter, "/regions/keyspace/id/{id}", regionsHandler.GetKeyspaceRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(regionReadRouter, "/regions/writeflow", regionsHandler.GetTopWriteFlowRegions, setMethods(http.MethodGet), setAuditBackend(prometheus))
@@ -281,7 +283,7 @@ func createRouter(prefix string, svr *server.Server) *mux.Router {
 
 	registerFunc(regionReadRouter, "/regions/check/hist-size", regionsHandler.GetSizeHistogram, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(regionReadRouter, "/regions/check/hist-keys", regionsHandler.GetKeysHistogram, setMethods(http.MethodGet), setAuditBackend(prometheus))
-	registerFunc(regionReadRouter, "/regions/sibling/{id}", regionsHandler.GetRegionSiblings, setMethods(http.MethodGet), setAuditBackend(prometheus))
+	registerFunc(regionRootReadRouter, "/regions/sibling/{id}", regionsHandler.GetRegionSiblings, setMethods(http.MethodGet), setAuditBackend(prometheus))
 	registerFunc(clusterRouter, "/regions/accelerate-schedule", regionsHandler.AccelerateRegionsScheduleInRange, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/accelerate-schedule/batch", regionsHandler.AccelerateRegionsScheduleInRanges, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))
 	registerFunc(clusterRouter, "/regions/scatter", regionsHandler.ScatterRegions, setMethods(http.MethodPost), setAuditBackend(localLog, prometheus))

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -384,9 +384,11 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 	}
 	c.initClusterContext()
 	c.setRegionReadReady(false)
+	started := false
 	defer func() {
-		if err != nil {
+		if !started {
 			c.setRegionReadReady(false)
+			c.cancelClusterContext()
 		}
 	}()
 
@@ -516,6 +518,7 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 	log.Info("start background jobs completed", zap.Duration("cost", time.Since(backgroundJobsStart)))
 	runnersStart := time.Now()
 	c.running = true
+	started = true
 	c.heartbeatRunner.Start(c.ctx)
 	c.miscRunner.Start(c.ctx)
 	c.logRunner.Start(c.ctx)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -159,6 +159,7 @@ type RaftCluster struct {
 	serverCtx context.Context
 	ctx       context.Context
 	cancel    context.CancelFunc
+	ctxMu     sync.Mutex
 
 	*core.BasicCluster // cached cluster info
 	member             *member.Member
@@ -167,6 +168,7 @@ type RaftCluster struct {
 	httpClient *http.Client
 
 	running                  bool
+	regionReadReady          atomic.Bool
 	isKeyspaceGroupEnabled   bool
 	tsoDynamicSwitchingState atomic.Int32
 	meta                     *metapb.Cluster
@@ -319,7 +321,7 @@ func (c *RaftCluster) InitCluster(
 	hbstreams *hbstream.HeartbeatStreams,
 	keyspaceGroupManager *keyspace.GroupManager) error {
 	c.opt, c.id = opt.(*config.PersistOptions), id
-	c.ctx, c.cancel = context.WithCancel(c.serverCtx)
+	c.ensureClusterContext()
 	c.changedRegions = make(chan *core.RegionInfo, defaultChangedRegionsLimit)
 	failpoint.Inject("syncRegionChannelFull", func() {
 		c.changedRegions = make(chan *core.RegionInfo, 100)
@@ -331,6 +333,35 @@ func (c *RaftCluster) InitCluster(
 	c.keyRangeManager = keyrange.NewManager()
 	c.schedulingController = newSchedulingController(c.ctx, c.BasicCluster, c.opt, c.ruleManager)
 	return nil
+}
+
+func (c *RaftCluster) initClusterContext() {
+	ctx, cancel := context.WithCancel(c.serverCtx)
+	c.ctxMu.Lock()
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.ctx = ctx
+	c.cancel = cancel
+	c.ctxMu.Unlock()
+}
+
+func (c *RaftCluster) ensureClusterContext() {
+	c.ctxMu.Lock()
+	defer c.ctxMu.Unlock()
+	if c.ctx != nil {
+		return
+	}
+	c.ctx, c.cancel = context.WithCancel(c.serverCtx)
+}
+
+func (c *RaftCluster) cancelClusterContext() {
+	c.ctxMu.Lock()
+	cancel := c.cancel
+	c.ctxMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }
 
 // Start starts a cluster.
@@ -351,11 +382,22 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 		log.Warn("raft cluster has already been started")
 		return nil
 	}
+	c.initClusterContext()
+	c.setRegionReadReady(false)
+	defer func() {
+		if err != nil {
+			c.setRegionReadReady(false)
+		}
+	}()
+
 	c.isKeyspaceGroupEnabled = s.IsKeyspaceGroupEnabled()
 	initClusterStart := time.Now()
 	err = c.InitCluster(s.GetAllocator(), s.GetPersistOptions(), s.GetHBStreams(), s.GetKeyspaceGroupManager())
 	if err != nil {
 		log.Warn("failed to initialize cluster", errs.ZapError(err), zap.Duration("cost", time.Since(initClusterStart)))
+		return err
+	}
+	if err = c.ctx.Err(); err != nil {
 		return err
 	}
 	initClusterDuration := time.Since(initClusterStart)
@@ -878,6 +920,18 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 		zap.Int("count", c.GetTotalRegionCount()),
 		zap.Duration("cost", time.Since(start)),
 	)
+	c.setRegionReadReady(true)
+	failpoint.InjectCall("pauseAfterRegionReadReady")
+
+	start = time.Now()
+	if err := c.rebuildRegionSubTree(c.ctx); err != nil {
+		c.setRegionReadReady(false)
+		return nil, err
+	}
+	log.Info("rebuild region subtrees",
+		zap.Int("count", c.GetTotalRegionCount()),
+		zap.Duration("cost", time.Since(start)),
+	)
 
 	return c, nil
 }
@@ -887,24 +941,67 @@ type loadedRegionChecker struct {
 	hasMaxEndKey      bool
 	maxEndKeyInfinite bool
 	maxEndKey         []byte
+	maxStartKey       []byte
+	emptyRootFastPath bool
 }
 
 func newLoadedRegionChecker(cluster *RaftCluster) *loadedRegionChecker {
-	return &loadedRegionChecker{cluster: cluster}
+	return &loadedRegionChecker{
+		cluster:           cluster,
+		emptyRootFastPath: cluster != nil && cluster.GetTotalRegionCount() == 0,
+	}
 }
 
 func (l *loadedRegionChecker) checkAndPut(region *core.RegionInfo) []*core.RegionInfo {
 	noOverlap := l.hasNoOverlap(region)
 	var overlaps []*core.RegionInfo
 	if noOverlap {
-		overlaps = l.cluster.CheckAndPutRegionNoOverlap(region)
+		if l.emptyRootFastPath && l.hasMonotonicStartKey(region) {
+			l.cluster.AppendRootRegionNoOverlapUnchecked(region)
+			l.updateMaxEndKey(region)
+			return nil
+		}
+		l.emptyRootFastPath = false
+		if l.hasMonotonicStartKey(region) && l.cluster.AppendRootRegionNoOverlapHint(region) {
+			l.updateMaxEndKey(region)
+			return nil
+		}
+		if l.cluster.AppendRootRegionNoOverlap(region) {
+			l.updateMaxEndKey(region)
+			return nil
+		}
+		overlaps = l.cluster.CheckAndPutRootRegionNoOverlap(region)
 	} else {
-		overlaps = l.cluster.CheckAndPutRegion(region)
+		l.emptyRootFastPath = false
+		overlaps = l.cluster.CheckAndPutRootRegion(region)
 	}
 	if !isLoadedRegionRejected(region, overlaps) {
 		l.updateMaxEndKey(region)
 	}
 	return overlaps
+}
+
+func (c *RaftCluster) rebuildRegionSubTree(ctx context.Context) error {
+	var err error
+	scanned := 0
+	c.ScanRegionWithIterator(nil, func(region *core.RegionInfo) bool {
+		if scanned%1024 == 0 {
+			if err = ctx.Err(); err != nil {
+				return false
+			}
+		}
+		failpoint.InjectCall("pauseDuringRegionSubTreeRebuild")
+		if err = ctx.Err(); err != nil {
+			return false
+		}
+		c.CheckAndPutSubTree(region)
+		scanned++
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	return ctx.Err()
 }
 
 func isLoadedRegionRejected(region *core.RegionInfo, overlaps []*core.RegionInfo) bool {
@@ -919,7 +1016,14 @@ func (l *loadedRegionChecker) hasNoOverlap(region *core.RegionInfo) bool {
 	return !l.maxEndKeyInfinite && bytes.Compare(l.maxEndKey, region.GetStartKey()) <= 0
 }
 
+func (l *loadedRegionChecker) hasMonotonicStartKey(region *core.RegionInfo) bool {
+	return l.maxStartKey == nil || bytes.Compare(l.maxStartKey, region.GetStartKey()) < 0
+}
+
 func (l *loadedRegionChecker) updateMaxEndKey(region *core.RegionInfo) {
+	if l.maxStartKey == nil || bytes.Compare(l.maxStartKey, region.GetStartKey()) < 0 {
+		l.maxStartKey = region.GetStartKey()
+	}
 	if l.maxEndKeyInfinite {
 		return
 	}
@@ -1017,13 +1121,15 @@ func (c *RaftCluster) runReplicationMode() {
 // Stop stops the cluster.
 func (c *RaftCluster) Stop() {
 	var (
-		cancel             context.CancelFunc
 		stopSchedulingJobs bool
 		heartbeatRunner    ratelimit.Runner
 		miscRunner         ratelimit.Runner
 		logRunner          ratelimit.Runner
 		syncRegionRunner   ratelimit.Runner
 	)
+
+	c.setRegionReadReady(false)
+	c.cancelClusterContext()
 
 	c.Lock()
 	// We need to try to stop tso jobs whatever the cluster is running or not.
@@ -1038,7 +1144,6 @@ func (c *RaftCluster) Stop() {
 		return
 	}
 	c.running = false
-	cancel = c.cancel
 	stopSchedulingJobs = !c.IsServiceIndependent(constant.SchedulingServiceName)
 	heartbeatRunner = c.heartbeatRunner
 	miscRunner = c.miscRunner
@@ -1046,9 +1151,6 @@ func (c *RaftCluster) Stop() {
 	syncRegionRunner = c.syncRegionRunner
 	c.Unlock()
 
-	if cancel != nil {
-		cancel()
-	}
 	if stopSchedulingJobs {
 		c.stopSchedulingJobs()
 	}
@@ -1079,6 +1181,15 @@ func (c *RaftCluster) IsRunning() bool {
 	c.RLock()
 	defer c.RUnlock()
 	return c.running
+}
+
+// IsRegionReadReady returns whether the root region index is ready for region read APIs.
+func (c *RaftCluster) IsRegionReadReady() bool {
+	return c.regionReadReady.Load()
+}
+
+func (c *RaftCluster) setRegionReadReady(ready bool) {
+	c.regionReadReady.Store(ready)
 }
 
 // Context returns the context of RaftCluster.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -895,11 +895,21 @@ func newLoadedRegionChecker(cluster *RaftCluster) *loadedRegionChecker {
 
 func (l *loadedRegionChecker) checkAndPut(region *core.RegionInfo) []*core.RegionInfo {
 	noOverlap := l.hasNoOverlap(region)
-	l.updateMaxEndKey(region)
+	var overlaps []*core.RegionInfo
 	if noOverlap {
-		return l.cluster.CheckAndPutRegionNoOverlap(region)
+		overlaps = l.cluster.CheckAndPutRegionNoOverlap(region)
+	} else {
+		overlaps = l.cluster.CheckAndPutRegion(region)
 	}
-	return l.cluster.CheckAndPutRegion(region)
+	if !isLoadedRegionRejected(region, overlaps) {
+		l.updateMaxEndKey(region)
+	}
+	return overlaps
+}
+
+func isLoadedRegionRejected(region *core.RegionInfo, overlaps []*core.RegionInfo) bool {
+	// CheckAndPutRegion returns the input region itself when it rejects a stale record.
+	return len(overlaps) == 1 && overlaps[0] == region
 }
 
 func (l *loadedRegionChecker) hasNoOverlap(region *core.RegionInfo) bool {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	errorspkg "errors"
@@ -869,7 +870,8 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 	start = time.Now()
 
 	// used to load region from kv storage to cache storage.
-	if err = storage.TryLoadRegionsOnce(c.ctx, c.storage, c.CheckAndPutRegion); err != nil {
+	regionLoader := newLoadedRegionChecker(c)
+	if err = storage.TryLoadRegionsOnce(c.ctx, c.storage, regionLoader.checkAndPut); err != nil {
 		return nil, err
 	}
 	log.Info("load regions",
@@ -878,6 +880,50 @@ func (c *RaftCluster) LoadClusterInfo() (*RaftCluster, error) {
 	)
 
 	return c, nil
+}
+
+type loadedRegionChecker struct {
+	cluster           *RaftCluster
+	hasMaxEndKey      bool
+	maxEndKeyInfinite bool
+	maxEndKey         []byte
+}
+
+func newLoadedRegionChecker(cluster *RaftCluster) *loadedRegionChecker {
+	return &loadedRegionChecker{cluster: cluster}
+}
+
+func (l *loadedRegionChecker) checkAndPut(region *core.RegionInfo) []*core.RegionInfo {
+	noOverlap := l.hasNoOverlap(region)
+	l.updateMaxEndKey(region)
+	if noOverlap {
+		return l.cluster.CheckAndPutRegionNoOverlap(region)
+	}
+	return l.cluster.CheckAndPutRegion(region)
+}
+
+func (l *loadedRegionChecker) hasNoOverlap(region *core.RegionInfo) bool {
+	if !l.hasMaxEndKey {
+		return true
+	}
+	return !l.maxEndKeyInfinite && bytes.Compare(l.maxEndKey, region.GetStartKey()) <= 0
+}
+
+func (l *loadedRegionChecker) updateMaxEndKey(region *core.RegionInfo) {
+	if l.maxEndKeyInfinite {
+		return
+	}
+	endKey := region.GetEndKey()
+	if len(endKey) == 0 {
+		l.hasMaxEndKey = true
+		l.maxEndKeyInfinite = true
+		l.maxEndKey = nil
+		return
+	}
+	if !l.hasMaxEndKey || bytes.Compare(l.maxEndKey, endKey) < 0 {
+		l.hasMaxEndKey = true
+		l.maxEndKey = endKey
+	}
 }
 
 func (c *RaftCluster) runMetricsCollectionJob() {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -101,6 +101,30 @@ func TestLoadedRegionCheckerNoOverlapHint(t *testing.T) {
 	re.False(checker.hasNoOverlap(region5))
 }
 
+func TestLoadedRegionCheckerDoesNotAdvanceOnRejectedRegion(t *testing.T) {
+	re := require.New(t)
+	cluster := &RaftCluster{BasicCluster: core.NewBasicCluster()}
+	checker := newLoadedRegionChecker(cluster)
+
+	region1 := core.NewTestRegionInfo(1, 1, []byte("a"), []byte("c"), core.SetRegionVersion(3))
+	re.Empty(checker.checkAndPut(region1))
+	re.Equal([]byte("c"), checker.maxEndKey)
+	re.False(checker.maxEndKeyInfinite)
+
+	staleFullRange := core.NewTestRegionInfo(2, 1, []byte("b"), nil, core.SetRegionVersion(2))
+	overlaps := checker.checkAndPut(staleFullRange)
+	re.Len(overlaps, 1)
+	re.Same(staleFullRange, overlaps[0])
+	re.Nil(cluster.GetRegion(staleFullRange.GetID()))
+	re.Equal([]byte("c"), checker.maxEndKey)
+	re.False(checker.maxEndKeyInfinite)
+
+	nextRegion := core.NewTestRegionInfo(3, 1, []byte("c"), []byte("d"))
+	re.True(checker.hasNoOverlap(nextRegion))
+	re.Empty(checker.checkAndPut(nextRegion))
+	re.Same(nextRegion, cluster.GetRegion(nextRegion.GetID()))
+}
+
 func TestStoreHeartbeat(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -83,22 +83,29 @@ func TestLoadedRegionCheckerNoOverlapHint(t *testing.T) {
 
 	region1 := core.NewRegionInfo(&metapb.Region{Id: 1, StartKey: []byte("a"), EndKey: []byte("c")}, nil)
 	re.True(checker.hasNoOverlap(region1))
+	re.True(checker.hasMonotonicStartKey(region1))
 	checker.updateMaxEndKey(region1)
 
 	region2 := core.NewRegionInfo(&metapb.Region{Id: 2, StartKey: []byte("b"), EndKey: []byte("d")}, nil)
 	re.False(checker.hasNoOverlap(region2))
+	re.True(checker.hasMonotonicStartKey(region2))
 	checker.updateMaxEndKey(region2)
 
 	region3 := core.NewRegionInfo(&metapb.Region{Id: 3, StartKey: []byte("d"), EndKey: []byte("e")}, nil)
 	re.True(checker.hasNoOverlap(region3))
+	re.True(checker.hasMonotonicStartKey(region3))
 	checker.updateMaxEndKey(region3)
 
 	region4 := core.NewRegionInfo(&metapb.Region{Id: 4, StartKey: []byte("e")}, nil)
 	re.True(checker.hasNoOverlap(region4))
+	re.True(checker.hasMonotonicStartKey(region4))
 	checker.updateMaxEndKey(region4)
 
 	region5 := core.NewRegionInfo(&metapb.Region{Id: 5, StartKey: []byte("f"), EndKey: []byte("g")}, nil)
 	re.False(checker.hasNoOverlap(region5))
+
+	region6 := core.NewRegionInfo(&metapb.Region{Id: 6, StartKey: []byte("d"), EndKey: []byte("e")}, nil)
+	re.False(checker.hasMonotonicStartKey(region6))
 }
 
 func TestLoadedRegionCheckerDoesNotAdvanceOnRejectedRegion(t *testing.T) {
@@ -123,6 +130,36 @@ func TestLoadedRegionCheckerDoesNotAdvanceOnRejectedRegion(t *testing.T) {
 	re.True(checker.hasNoOverlap(nextRegion))
 	re.Empty(checker.checkAndPut(nextRegion))
 	re.Same(nextRegion, cluster.GetRegion(nextRegion.GetID()))
+	re.Same(nextRegion, cluster.GetRegionByKey([]byte("c")))
+	re.Zero(cluster.GetStoreRegionCount(1))
+	re.Equal([]byte("d"), checker.maxEndKey)
+	re.False(checker.maxEndKeyInfinite)
+}
+
+func TestLoadedRegionCheckerEmptyRootFastPath(t *testing.T) {
+	re := require.New(t)
+	cluster := &RaftCluster{BasicCluster: core.NewBasicCluster()}
+	checker := newLoadedRegionChecker(cluster)
+	re.True(checker.emptyRootFastPath)
+
+	region1 := core.NewTestRegionInfo(1, 1, []byte("a"), []byte("b"))
+	re.Empty(checker.checkAndPut(region1))
+	re.True(checker.emptyRootFastPath)
+	re.Equal(1, cluster.GetTotalRegionCount())
+
+	region2 := core.NewTestRegionInfo(2, 1, []byte("b"), []byte("c"))
+	re.Empty(checker.checkAndPut(region2))
+	re.True(checker.emptyRootFastPath)
+	re.Equal(2, cluster.GetTotalRegionCount())
+
+	overlap := core.NewTestRegionInfo(3, 1, []byte("bb"), []byte("d"))
+	overlaps := checker.checkAndPut(overlap)
+	re.Len(overlaps, 1)
+	re.False(checker.emptyRootFastPath)
+
+	nonEmptyCluster := &RaftCluster{BasicCluster: core.NewBasicCluster()}
+	re.Empty(nonEmptyCluster.CheckAndPutRootRegion(region1))
+	re.False(newLoadedRegionChecker(nonEmptyCluster).emptyRootFastPath)
 }
 
 func TestStoreHeartbeat(t *testing.T) {
@@ -4390,6 +4427,78 @@ func TestStopDoesNotHoldClusterLockWhileWaitingSchedulingJobs(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("raft cluster stop blocked on scheduling jobs while holding cluster lock")
 	}
+}
+
+func TestStopCancelsRegionSubTreeRebuildWhileStarting(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	testStorage := storage.NewStorageWithMemoryBackend()
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, testStorage)
+	cluster.tsoAllocator = nil
+
+	re.NoError(testStorage.SaveMeta(&metapb.Cluster{Id: 1}))
+	re.NoError(testStorage.SaveStoreMeta(&metapb.Store{Id: 1}))
+	for i := uint64(1); i <= 3; i++ {
+		re.NoError(testStorage.SaveRegion(&metapb.Region{
+			Id:          i,
+			StartKey:    []byte(fmt.Sprintf("%020d", i)),
+			EndKey:      []byte(fmt.Sprintf("%020d", i+1)),
+			RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1},
+			Peers:       []*metapb.Peer{{Id: i + 100, StoreId: 1}},
+		}))
+	}
+	re.NoError(testStorage.Flush())
+
+	rebuildPaused := make(chan struct{})
+	var pauseOnce sync.Once
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/pauseDuringRegionSubTreeRebuild", func() {
+		pauseOnce.Do(func() {
+			close(rebuildPaused)
+		})
+		<-cluster.ctx.Done()
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/pauseDuringRegionSubTreeRebuild"))
+	}()
+
+	loadDone := make(chan error, 1)
+	go func() {
+		cluster.Lock()
+		defer cluster.Unlock()
+		_, loadErr := cluster.LoadClusterInfo()
+		loadDone <- loadErr
+	}()
+
+	select {
+	case <-rebuildPaused:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for region subtree rebuild to pause")
+	}
+	re.True(cluster.IsRegionReadReady())
+
+	stopDone := make(chan struct{})
+	go func() {
+		cluster.Stop()
+		close(stopDone)
+	}()
+
+	select {
+	case loadErr := <-loadDone:
+		re.ErrorIs(loadErr, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for region subtree rebuild cancellation")
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("raft cluster stop blocked while startup held the cluster lock")
+	}
+	re.False(cluster.IsRegionReadReady())
 }
 
 func BenchmarkHandleStatsAsync(b *testing.B) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -44,6 +44,8 @@ import (
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/id"
+	"github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/pkg/metering"
 	"github.com/tikv/pd/pkg/mock/mockhbstream"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/progress"
@@ -4499,6 +4501,121 @@ func TestStopCancelsRegionSubTreeRebuildWhileStarting(t *testing.T) {
 		t.Fatal("raft cluster stop blocked while startup held the cluster lock")
 	}
 	re.False(cluster.IsRegionReadReady())
+}
+
+func TestStartCancelsContextOnAbort(t *testing.T) {
+	re := require.New(t)
+
+	testCases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:    "error",
+			value:   `return(true)`,
+			wantErr: true,
+		},
+		{
+			name:  "early return without running",
+			value: `return(false)`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			_, opt, err := newTestScheduleConfig()
+			re.NoError(err)
+			testStorage := storage.NewStorageWithMemoryBackend()
+			cluster := NewRaftCluster(ctx, nil, core.NewBasicCluster(), testStorage, nil, nil, nil, nil)
+			svr := &testClusterServer{
+				allocator: mockid.NewIDAllocator(),
+				cfg:       config.NewConfig(),
+				opt:       opt,
+				storage:   testStorage,
+				cluster:   cluster,
+				basic:     cluster.BasicCluster,
+			}
+
+			re.NoError(failpoint.Enable("github.com/tikv/pd/server/cluster/raftClusterReturn", testCase.value))
+			defer func() {
+				re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/raftClusterReturn"))
+			}()
+
+			err = cluster.Start(svr, true)
+			if testCase.wantErr {
+				re.Error(err)
+			} else {
+				re.NoError(err)
+			}
+			re.ErrorIs(cluster.ctx.Err(), context.Canceled)
+			re.False(cluster.IsRegionReadReady())
+		})
+	}
+}
+
+type testClusterServer struct {
+	allocator id.Allocator
+	cfg       *config.Config
+	opt       *config.PersistOptions
+	storage   storage.Storage
+	cluster   *RaftCluster
+	basic     *core.BasicCluster
+}
+
+func (s *testClusterServer) GetAllocator() id.Allocator {
+	return s.allocator
+}
+
+func (s *testClusterServer) GetConfig() *config.Config {
+	return s.cfg
+}
+
+func (s *testClusterServer) GetPersistOptions() *config.PersistOptions {
+	return s.opt
+}
+
+func (s *testClusterServer) GetStorage() storage.Storage {
+	return s.storage
+}
+
+func (*testClusterServer) GetHBStreams() *hbstream.HeartbeatStreams {
+	return nil
+}
+
+func (s *testClusterServer) GetRaftCluster() *RaftCluster {
+	return s.cluster
+}
+
+func (s *testClusterServer) GetBasicCluster() *core.BasicCluster {
+	return s.basic
+}
+
+func (*testClusterServer) GetMembers() ([]*pdpb.Member, error) {
+	return nil, nil
+}
+
+func (*testClusterServer) ReplicateFileToMember(context.Context, *pdpb.Member, string, []byte) error {
+	return nil
+}
+
+func (*testClusterServer) GetKeyspaceManager() *keyspace.Manager {
+	return nil
+}
+
+func (*testClusterServer) GetKeyspaceGroupManager() *keyspace.GroupManager {
+	return nil
+}
+
+func (*testClusterServer) IsKeyspaceGroupEnabled() bool {
+	return false
+}
+
+func (*testClusterServer) GetMeteringWriter() *metering.Writer {
+	return nil
 }
 
 func BenchmarkHandleStatsAsync(b *testing.B) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -77,6 +77,30 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
 }
 
+func TestLoadedRegionCheckerNoOverlapHint(t *testing.T) {
+	re := require.New(t)
+	checker := newLoadedRegionChecker(nil)
+
+	region1 := core.NewRegionInfo(&metapb.Region{Id: 1, StartKey: []byte("a"), EndKey: []byte("c")}, nil)
+	re.True(checker.hasNoOverlap(region1))
+	checker.updateMaxEndKey(region1)
+
+	region2 := core.NewRegionInfo(&metapb.Region{Id: 2, StartKey: []byte("b"), EndKey: []byte("d")}, nil)
+	re.False(checker.hasNoOverlap(region2))
+	checker.updateMaxEndKey(region2)
+
+	region3 := core.NewRegionInfo(&metapb.Region{Id: 3, StartKey: []byte("d"), EndKey: []byte("e")}, nil)
+	re.True(checker.hasNoOverlap(region3))
+	checker.updateMaxEndKey(region3)
+
+	region4 := core.NewRegionInfo(&metapb.Region{Id: 4, StartKey: []byte("e")}, nil)
+	re.True(checker.hasNoOverlap(region4))
+	checker.updateMaxEndKey(region4)
+
+	region5 := core.NewRegionInfo(&metapb.Region{Id: 5, StartKey: []byte("f"), EndKey: []byte("g")}, nil)
+	re.False(checker.hasNoOverlap(region5))
+}
+
 func TestStoreHeartbeat(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -4504,8 +4504,6 @@ func TestStopCancelsRegionSubTreeRebuildWhileStarting(t *testing.T) {
 }
 
 func TestStartCancelsContextOnAbort(t *testing.T) {
-	re := require.New(t)
-
 	testCases := []struct {
 		name    string
 		value   string
@@ -4524,6 +4522,7 @@ func TestStartCancelsContextOnAbort(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1580,7 +1580,7 @@ func (s *GrpcServer) QueryRegion(stream pdpb.PD_QueryRegionServer) error {
 		var rc *cluster.RaftCluster
 
 		if s.member.IsServing() {
-			rc = s.GetRaftCluster()
+			rc = s.GetRegionReadRaftCluster()
 			if rc == nil {
 				resp := &pdpb.QueryRegionResponse{
 					Header: grpcutil.NotBootstrappedHeader(),
@@ -2694,7 +2694,7 @@ func (s *GrpcServer) getRaftCluster(isFollower bool) (*cluster.RaftCluster, *pdp
 			return nil, grpcutil.RegionNotFound()
 		}
 	} else {
-		rc = s.GetRaftCluster()
+		rc = s.GetRegionReadRaftCluster()
 		if rc == nil {
 			return nil, grpcutil.NotBootstrappedHeader()
 		}

--- a/server/grpc_service_test.go
+++ b/server/grpc_service_test.go
@@ -15,6 +15,8 @@
 package server
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +26,13 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/schedulingpb"
 
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/member"
+	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/utils/grpcutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/server/cluster"
+	"github.com/tikv/pd/server/config"
 )
 
 func TestMain(m *testing.M) {
@@ -44,6 +52,52 @@ func TestNewSchedulingAskBatchSplitRequestPreservesReason(t *testing.T) {
 	re.Equal(uint64(100), req.GetRegion().GetId())
 	re.Equal(uint32(3), req.GetSplitCount())
 	re.Equal(pdpb.SplitReason_LOAD, req.GetReason())
+}
+
+func TestRegionReadRaftClusterGate(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	cfg := config.NewConfig()
+	serviceMiddlewareCfg := config.NewServiceMiddlewareConfig()
+	serviceMiddlewareCfg.GRPCRateLimitConfig.EnableRateLimit = false
+	svr := &Server{
+		cfg:                             cfg,
+		persistOptions:                  config.NewPersistOptions(cfg),
+		serviceMiddlewareCfg:            serviceMiddlewareCfg,
+		serviceMiddlewarePersistOptions: config.NewServiceMiddlewarePersistOptions(serviceMiddlewareCfg),
+		member:                          &member.Member{},
+		ctx:                             ctx,
+	}
+	atomic.StoreInt64(&svr.isRunning, 1)
+
+	basicCluster := core.NewBasicCluster()
+	region := core.NewTestRegionInfo(1, 1, []byte("a"), []byte("z"))
+	basicCluster.PutRegion(region)
+	svr.cluster = cluster.NewRaftCluster(
+		ctx,
+		svr.GetMember(),
+		basicCluster,
+		storage.NewStorageWithMemoryBackend(),
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	// The root index may already contain the region while startup is still
+	// loading. Region read APIs must wait for the explicit region-read gate
+	// instead of returning a false empty/not-found result.
+	directResp, err := grpcutil.GetRegionByID(basicCluster, &pdpb.GetRegionByIDRequest{
+		RegionId: region.GetID(),
+	}, false)
+	re.NoError(err)
+	re.Equal(region.GetID(), directResp.GetRegion().GetId())
+
+	re.Nil(svr.GetRegionReadRaftCluster())
+	grpcServer := &GrpcServer{Server: svr}
+	rc, header := grpcServer.getRaftCluster(false)
+	re.Nil(rc)
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, header.GetError().GetType())
 }
 
 func TestConvertSchedulingHeaderPreservesError(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -842,6 +842,24 @@ func (s *Server) createRaftCluster() error {
 	return s.cluster.Start(s, false)
 }
 
+func (s *Server) startEmbeddedTSOService() (bool, error) {
+	if s.IsKeyspaceGroupEnabled() || s.tsoAllocator == nil || s.tsoAllocator.IsInitialize() {
+		return false, nil
+	}
+	log.Info("initializing the embedded TSO allocator")
+	if err := s.tsoAllocator.Initialize(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Server) resetEmbeddedTSOService() {
+	if s.IsKeyspaceGroupEnabled() || s.tsoAllocator == nil || !s.tsoAllocator.IsInitialize() {
+		return
+	}
+	s.tsoAllocator.Reset(false)
+}
+
 func (s *Server) stopRaftCluster() {
 	failpoint.Inject("raftclusterIsBusy", func() {})
 	s.cluster.Stop()
@@ -1805,15 +1823,19 @@ func (s *Server) campaignLeader() {
 	callbacksDuration := time.Since(callbacksStart)
 	log.Info("trigger leader callback functions completed", zap.Duration("cost", callbacksDuration))
 
-	// Try to create raft cluster.
-	createRaftClusterStart := time.Now()
-	if err := s.createRaftCluster(); err != nil {
-		log.Warn("failed to create raft cluster", errs.ZapError(err), zap.Duration("cost", time.Since(createRaftClusterStart)))
+	tsoStart := time.Now()
+	embeddedTSOStarted, err := s.startEmbeddedTSOService()
+	if err != nil {
+		log.Warn("failed to start embedded TSO service", errs.ZapError(err), zap.Duration("cost", time.Since(tsoStart)))
 		return
 	}
-	createRaftClusterDuration := time.Since(createRaftClusterStart)
-	log.Info("create raft cluster completed", zap.Duration("cost", createRaftClusterDuration))
-	defer s.stopRaftCluster()
+	log.Info("start embedded TSO service completed",
+		zap.Bool("started", embeddedTSOStarted),
+		zap.Duration("cost", time.Since(tsoStart)))
+	if embeddedTSOStarted {
+		defer s.resetEmbeddedTSOService()
+	}
+
 	failpoint.Inject("rebaseErr", func() {
 		failpoint.Return()
 	})
@@ -1824,25 +1846,48 @@ func (s *Server) campaignLeader() {
 	}
 	rebaseDuration := time.Since(rebaseStart)
 	log.Info("sync id from etcd completed", zap.Duration("cost", rebaseDuration))
-	// PromoteSelf to accept the remaining service, such as GetStore, GetRegion.
+	// PromoteSelf to accept core services, such as TSO. Region-related services
+	// still wait until the raft cluster is fully started below.
 	enableLeaderStart := time.Now()
 	s.member.PromoteSelf()
 	enableLeaderDuration := time.Since(enableLeaderStart)
 	member.ServiceMemberGauge.WithLabelValues(PD).Set(1)
+	defer member.ServiceMemberGauge.WithLabelValues(PD).Set(0)
 	totalDuration := time.Since(leaderReadyStart)
+	CheckPDVersionWithClusterVersion(s.persistOptions)
+	log.Info("PD leader is ready to serve core services",
+		zap.String("leader-name", s.Name()),
+		zap.Duration("total-cost", totalDuration),
+		zap.Duration("cost", enableLeaderDuration))
+
+	failpoint.Inject("delayCreateRaftCluster", func(val failpoint.Value) {
+		if delay, ok := val.(int); ok {
+			timer := time.NewTimer(time.Duration(delay) * time.Millisecond)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				failpoint.Return()
+			}
+		}
+	})
+
+	// Try to create raft cluster.
+	createRaftClusterStart := time.Now()
+	if err := s.createRaftCluster(); err != nil {
+		log.Warn("failed to create raft cluster", errs.ZapError(err), zap.Duration("cost", time.Since(createRaftClusterStart)))
+		return
+	}
+	createRaftClusterDuration := time.Since(createRaftClusterStart)
+	log.Info("create raft cluster completed", zap.Duration("cost", createRaftClusterDuration))
+	defer s.stopRaftCluster()
 	defer resetLeaderOnce.Do(func() {
 		// as soon as cancel the leadership keepalive, then other member have chance
 		// to be new leader.
 		cancel()
 		s.member.Resign()
-		member.ServiceMemberGauge.WithLabelValues(PD).Set(0)
 	})
 
-	CheckPDVersionWithClusterVersion(s.persistOptions)
-	log.Info("PD leader is ready to serve",
-		zap.String("leader-name", s.Name()),
-		zap.Duration("total-cost", totalDuration),
-		zap.Duration("cost", enableLeaderDuration))
 	leaderTicker := time.NewTicker(mcs.LeaderTickInterval)
 	defer leaderTicker.Stop()
 

--- a/server/server.go
+++ b/server/server.go
@@ -1870,6 +1870,8 @@ func (s *Server) campaignLeader() {
 		zap.Duration("total-cost", totalDuration),
 		zap.Duration("cost", enableLeaderDuration))
 
+	failpoint.InjectCall("pauseBeforeCreateRaftCluster")
+
 	failpoint.Inject("delayCreateRaftCluster", func(val failpoint.Value) {
 		if delay, ok := val.(int); ok {
 			timer := time.NewTimer(time.Duration(delay) * time.Millisecond)

--- a/server/server.go
+++ b/server/server.go
@@ -1478,6 +1478,16 @@ func (s *Server) GetRaftCluster() *cluster.RaftCluster {
 	return s.cluster
 }
 
+// GetRegionReadRaftCluster gets Raft cluster when the root region index is ready.
+// It allows key/id/range region read APIs to serve before scheduling-related
+// state is fully started.
+func (s *Server) GetRegionReadRaftCluster() *cluster.RaftCluster {
+	if s.IsClosed() || !s.cluster.IsRegionReadReady() {
+		return nil
+	}
+	return s.cluster
+}
+
 // IsServiceIndependent returns whether the service is independent.
 func (s *Server) IsServiceIndependent(name string) bool {
 	if s.isKeyspaceGroupEnabled && !s.IsClosed() {

--- a/tests/server/cluster/cluster_test.go
+++ b/tests/server/cluster/cluster_test.go
@@ -1133,6 +1133,7 @@ func TestLoadClusterInfo(t *testing.T) {
 			StartKey:    []byte(fmt.Sprintf("%20d", i)),
 			EndKey:      []byte(fmt.Sprintf("%20d", i+1)),
 			RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1},
+			Peers:       []*metapb.Peer{{Id: i + 100, StoreId: 1, Role: metapb.PeerRole_Voter}},
 		}
 		regions = append(regions, region)
 	}
@@ -1142,11 +1143,60 @@ func TestLoadClusterInfo(t *testing.T) {
 	}
 	re.NoError(testStorage.Flush())
 
+	regionReadReadyPaused := make(chan struct{})
+	resumeAfterRegionReadReady := make(chan struct{})
+	var pauseOnce sync.Once
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/pauseAfterRegionReadReady", func() {
+		pauseOnce.Do(func() {
+			close(regionReadReadyPaused)
+		})
+		<-resumeAfterRegionReadReady
+	}))
+	defer func() {
+		select {
+		case <-resumeAfterRegionReadReady:
+		default:
+			close(resumeAfterRegionReadReady)
+		}
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/pauseAfterRegionReadReady"))
+	}()
+
 	raftCluster = cluster.NewRaftCluster(ctx, svr.GetMember(), basicCluster,
 		testStorage, syncer.NewRegionSyncer(svr), svr.GetClient(), svr.GetHTTPClient(), svr.GetTSOAllocator())
 	err = raftCluster.InitCluster(mockid.NewIDAllocator(), svr.GetPersistOptions(), svr.GetHBStreams(), svr.GetKeyspaceGroupManager())
 	re.NoError(err)
-	raftCluster, err = raftCluster.LoadClusterInfo()
+	type loadClusterInfoResult struct {
+		cluster *cluster.RaftCluster
+		err     error
+	}
+	loadClusterInfoDone := make(chan loadClusterInfoResult, 1)
+	go func() {
+		loadedCluster, loadErr := raftCluster.LoadClusterInfo()
+		loadClusterInfoDone <- loadClusterInfoResult{
+			cluster: loadedCluster,
+			err:     loadErr,
+		}
+	}()
+	select {
+	case <-regionReadReadyPaused:
+	case <-time.After(10 * time.Second):
+		re.FailNow("timed out waiting for region read readiness pause")
+	}
+
+	re.True(raftCluster.IsRegionReadReady())
+	re.Equal(n, raftCluster.GetTotalRegionCount())
+	re.NotNil(raftCluster.GetRegionByKey([]byte(fmt.Sprintf("%20d", 0))))
+	re.Len(raftCluster.ScanRegions(nil, nil, 1), 1)
+	re.Zero(raftCluster.GetStoreRegionCount(1))
+
+	close(resumeAfterRegionReadReady)
+	select {
+	case result := <-loadClusterInfoDone:
+		raftCluster = result.cluster
+		err = result.err
+	case <-time.After(10 * time.Second):
+		re.FailNow("timed out waiting for load cluster info to finish")
+	}
 	re.NoError(err)
 	re.NotNil(raftCluster)
 
@@ -1160,6 +1210,8 @@ func TestLoadClusterInfo(t *testing.T) {
 	for _, region := range raftCluster.GetMetaRegions() {
 		re.Equal(regions[region.GetId()], region)
 	}
+	re.True(raftCluster.IsRegionReadReady())
+	re.Equal(n, raftCluster.GetStoreRegionCount(1))
 
 	m := 20
 	regions = make([]*metapb.Region, 0, n)

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -232,6 +232,12 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	}
 
 	re.True(rc.IsRegionReadReady())
+	expectedLeader := region.GetLeader()
+	re.NotNil(expectedLeader)
+	loadedRegion := rc.GetRegion(regionID)
+	re.NotNil(loadedRegion)
+	re.Nil(loadedRegion.GetLeader())
+	assertLeaderForRead(re, expectedLeader, loadedRegion.GetLeaderForRead())
 
 	regionRPCContext, regionRPCCancel := context.WithTimeout(ctx, time.Second)
 	defer regionRPCCancel()
@@ -243,6 +249,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.NoError(err)
 	re.Nil(regionByIDResp.GetHeader().GetError())
 	re.Equal(regionID, regionByIDResp.GetRegion().GetId())
+	assertLeaderForRead(re, expectedLeader, regionByIDResp.GetLeader())
 
 	regionByKeyResp, err := grpcPDClient.GetRegion(regionRPCContext, &pdpb.GetRegionRequest{
 		Header:      testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
@@ -252,6 +259,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.NoError(err)
 	re.Nil(regionByKeyResp.GetHeader().GetError())
 	re.Equal(regionID, regionByKeyResp.GetRegion().GetId())
+	assertLeaderForRead(re, expectedLeader, regionByKeyResp.GetLeader())
 
 	prevRegionResp, err := grpcPDClient.GetPrevRegion(regionRPCContext, &pdpb.GetRegionRequest{
 		Header:      testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
@@ -261,6 +269,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.NoError(err)
 	re.Nil(prevRegionResp.GetHeader().GetError())
 	re.Equal(regionID, prevRegionResp.GetRegion().GetId())
+	assertLeaderForRead(re, expectedLeader, prevRegionResp.GetLeader())
 
 	scanContext, scanCancel := context.WithTimeout(ctx, time.Second)
 	defer scanCancel()
@@ -274,6 +283,9 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.Nil(scanResp.GetHeader().GetError())
 	re.Len(scanResp.GetRegions(), 1)
 	re.Equal(regionID, scanResp.GetRegions()[0].GetRegion().GetId())
+	assertLeaderForRead(re, expectedLeader, scanResp.GetRegions()[0].GetLeader())
+	re.Len(scanResp.GetLeaders(), 1)
+	assertLeaderForRead(re, expectedLeader, scanResp.GetLeaders()[0])
 
 	batchScanResp, err := grpcPDClient.BatchScanRegions(scanContext, &pdpb.BatchScanRegionsRequest{
 		Header: testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
@@ -287,6 +299,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.Nil(batchScanResp.GetHeader().GetError())
 	re.Len(batchScanResp.GetRegions(), 1)
 	re.Equal(regionID, batchScanResp.GetRegions()[0].GetRegion().GetId())
+	assertLeaderForRead(re, expectedLeader, batchScanResp.GetRegions()[0].GetLeader())
 
 	queryRegionCtx, queryRegionCancel := context.WithTimeout(ctx, time.Second)
 	defer queryRegionCancel()
@@ -302,6 +315,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.NoError(err)
 	re.Nil(queryRegionResp.GetHeader().GetError())
 	re.Equal(regionID, queryRegionResp.GetRegionsById()[regionID].GetRegion().GetId())
+	assertLeaderForRead(re, expectedLeader, queryRegionResp.GetRegionsById()[regionID].GetLeader())
 	re.Equal([]uint64{regionID}, queryRegionResp.GetKeyIdMap())
 	re.Equal([]uint64{regionID}, queryRegionResp.GetPrevKeyIdMap())
 	re.NoError(queryRegionClient.CloseSend())
@@ -311,6 +325,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 		fmt.Sprintf("%s/pd/api/v1/region/id/%d", nextLeaderServer.GetAddr(), regionID),
 		&httpRegion))
 	re.Equal(regionID, httpRegion.ID)
+	assertLeaderForRead(re, expectedLeader, httpRegion.Leader.Peer)
 
 	var scannedRegions response.RegionsInfo
 	re.NoError(testutil.ReadGetJSON(re, httpClient,
@@ -319,6 +334,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.Equal(1, scannedRegions.Count)
 	re.Len(scannedRegions.Regions, 1)
 	re.Equal(regionID, scannedRegions.Regions[0].ID)
+	assertLeaderForRead(re, expectedLeader, scannedRegions.Regions[0].Leader.Peer)
 
 	var regionCount response.RegionsInfo
 	re.NoError(testutil.ReadGetJSON(re, httpClient,
@@ -330,6 +346,12 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	testutil.Eventually(re, func() bool {
 		return nextLeaderServer.GetRaftCluster() != nil
 	}, testutil.WithWaitFor(20*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+}
+
+func assertLeaderForRead(re *require.Assertions, expected, actual *metapb.Peer) {
+	re.NotNil(actual)
+	re.Equal(expected.GetId(), actual.GetId())
+	re.Equal(expected.GetStoreId(), actual.GetStoreId())
 }
 
 func assertRegionReadsNotBootstrapped(

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -139,16 +139,22 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.NotNil(nextLeaderServer)
 
 	regionID := uint64(10)
-	region := tests.MustPutRegion(re, cluster, regionID, 1, []byte("a"), []byte("z"))
+	region := tests.MustPutRegion(re, cluster, regionID, 1, []byte("a"), []byte("m"))
+	nextRegionID := uint64(11)
+	nextRegion := tests.MustPutRegion(re, cluster, nextRegionID, 1, []byte("m"), []byte("z"))
 	testutil.Eventually(re, func() bool {
-		return leaderServer.GetRaftCluster().GetRegion(regionID) != nil
+		return leaderServer.GetRaftCluster().GetRegion(regionID) != nil &&
+			leaderServer.GetRaftCluster().GetRegion(nextRegionID) != nil
 	})
-	testutil.Eventually(re, func() bool {
-		loadedRegion := &metapb.Region{}
-		ok, err := leaderServer.GetServer().GetStorage().LoadRegion(regionID, loadedRegion)
-		re.NoError(err)
-		return ok && loadedRegion.GetId() == regionID
-	})
+	for _, id := range []uint64{regionID, nextRegionID} {
+		regionID := id
+		testutil.Eventually(re, func() bool {
+			loadedRegion := &metapb.Region{}
+			ok, err := leaderServer.GetServer().GetStorage().LoadRegion(regionID, loadedRegion)
+			re.NoError(err)
+			return ok && loadedRegion.GetId() == regionID
+		})
+	}
 
 	beforeCreateRaftClusterPaused := make(chan struct{})
 	resumeBeforeCreateRaftCluster := make(chan struct{})
@@ -215,7 +221,7 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.False(rc.IsRegionReadReady())
 	assertRegionReadsNotBootstrapped(
 		re, ctx, grpcPDClient, httpClient, nextLeaderServer,
-		region.GetStartKey(), region.GetEndKey(), regionID,
+		region.GetStartKey(), nextRegion.GetEndKey(), nextRegion.GetStartKey(), regionID,
 	)
 
 	close(resumeBeforeCreateRaftCluster)
@@ -238,18 +244,67 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.Nil(regionByIDResp.GetHeader().GetError())
 	re.Equal(regionID, regionByIDResp.GetRegion().GetId())
 
+	regionByKeyResp, err := grpcPDClient.GetRegion(regionRPCContext, &pdpb.GetRegionRequest{
+		Header:      testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		RegionKey:   region.GetStartKey(),
+		NeedBuckets: true,
+	})
+	re.NoError(err)
+	re.Nil(regionByKeyResp.GetHeader().GetError())
+	re.Equal(regionID, regionByKeyResp.GetRegion().GetId())
+
+	prevRegionResp, err := grpcPDClient.GetPrevRegion(regionRPCContext, &pdpb.GetRegionRequest{
+		Header:      testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		RegionKey:   nextRegion.GetStartKey(),
+		NeedBuckets: true,
+	})
+	re.NoError(err)
+	re.Nil(prevRegionResp.GetHeader().GetError())
+	re.Equal(regionID, prevRegionResp.GetRegion().GetId())
+
 	scanContext, scanCancel := context.WithTimeout(ctx, time.Second)
 	defer scanCancel()
 	scanResp, err := grpcPDClient.ScanRegions(scanContext, &pdpb.ScanRegionsRequest{
 		Header:   testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
 		StartKey: region.GetStartKey(),
-		EndKey:   region.GetEndKey(),
+		EndKey:   nextRegion.GetEndKey(),
 		Limit:    1,
 	})
 	re.NoError(err)
 	re.Nil(scanResp.GetHeader().GetError())
 	re.Len(scanResp.GetRegions(), 1)
 	re.Equal(regionID, scanResp.GetRegions()[0].GetRegion().GetId())
+
+	batchScanResp, err := grpcPDClient.BatchScanRegions(scanContext, &pdpb.BatchScanRegionsRequest{
+		Header: testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		Ranges: []*pdpb.KeyRange{{
+			StartKey: region.GetStartKey(),
+			EndKey:   nextRegion.GetEndKey(),
+		}},
+		Limit: 1,
+	})
+	re.NoError(err)
+	re.Nil(batchScanResp.GetHeader().GetError())
+	re.Len(batchScanResp.GetRegions(), 1)
+	re.Equal(regionID, batchScanResp.GetRegions()[0].GetRegion().GetId())
+
+	queryRegionCtx, queryRegionCancel := context.WithTimeout(ctx, time.Second)
+	defer queryRegionCancel()
+	queryRegionClient, err := grpcPDClient.QueryRegion(queryRegionCtx)
+	re.NoError(err)
+	re.NoError(queryRegionClient.Send(&pdpb.QueryRegionRequest{
+		Header:   testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		Ids:      []uint64{regionID},
+		Keys:     [][]byte{region.GetStartKey()},
+		PrevKeys: [][]byte{nextRegion.GetStartKey()},
+	}))
+	queryRegionResp, err := queryRegionClient.Recv()
+	re.NoError(err)
+	re.Nil(queryRegionResp.GetHeader().GetError())
+	re.Equal(regionID, queryRegionResp.GetRegionsById()[regionID].GetRegion().GetId())
+	re.Equal([]uint64{regionID}, queryRegionResp.GetKeyIdMap())
+	re.Equal([]uint64{regionID}, queryRegionResp.GetPrevKeyIdMap())
+	re.NoError(queryRegionClient.CloseSend())
 
 	var httpRegion response.RegionInfo
 	re.NoError(testutil.ReadGetJSON(re, httpClient,
@@ -283,7 +338,7 @@ func assertRegionReadsNotBootstrapped(
 	grpcPDClient pdpb.PDClient,
 	httpClient *http.Client,
 	svr *tests.TestServer,
-	startKey, endKey []byte,
+	startKey, endKey, prevKey []byte,
 	regionID uint64,
 ) {
 	requestHeader := testutil.NewRequestHeader(svr.GetClusterID())
@@ -296,6 +351,20 @@ func assertRegionReadsNotBootstrapped(
 	re.NoError(err)
 	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, regionByIDResp.GetHeader().GetError().GetType())
 
+	regionByKeyResp, err := grpcPDClient.GetRegion(regionRPCContext, &pdpb.GetRegionRequest{
+		Header:    requestHeader,
+		RegionKey: startKey,
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, regionByKeyResp.GetHeader().GetError().GetType())
+
+	prevRegionResp, err := grpcPDClient.GetPrevRegion(regionRPCContext, &pdpb.GetRegionRequest{
+		Header:    requestHeader,
+		RegionKey: prevKey,
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, prevRegionResp.GetHeader().GetError().GetType())
+
 	scanContext, scanCancel := context.WithTimeout(ctx, time.Second)
 	defer scanCancel()
 	scanResp, err := grpcPDClient.ScanRegions(scanContext, &pdpb.ScanRegionsRequest{
@@ -306,6 +375,32 @@ func assertRegionReadsNotBootstrapped(
 	})
 	re.NoError(err)
 	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, scanResp.GetHeader().GetError().GetType())
+
+	batchScanResp, err := grpcPDClient.BatchScanRegions(scanContext, &pdpb.BatchScanRegionsRequest{
+		Header: requestHeader,
+		Ranges: []*pdpb.KeyRange{{
+			StartKey: startKey,
+			EndKey:   endKey,
+		}},
+		Limit: 1,
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, batchScanResp.GetHeader().GetError().GetType())
+
+	queryRegionCtx, queryRegionCancel := context.WithTimeout(ctx, time.Second)
+	defer queryRegionCancel()
+	queryRegionClient, err := grpcPDClient.QueryRegion(queryRegionCtx)
+	re.NoError(err)
+	re.NoError(queryRegionClient.Send(&pdpb.QueryRegionRequest{
+		Header:   requestHeader,
+		Ids:      []uint64{regionID},
+		Keys:     [][]byte{startKey},
+		PrevKeys: [][]byte{prevKey},
+	}))
+	queryRegionResp, err := queryRegionClient.Recv()
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, queryRegionResp.GetHeader().GetError().GetType())
+	re.NoError(queryRegionClient.CloseSend())
 
 	checkHTTPNotBootstrapped := func(url string) {
 		req, err := http.NewRequest(http.MethodGet, url, http.NoBody)

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -113,6 +113,57 @@ func (s *tsoTestSuite) TestDelaySyncTimestamp() {
 	s.env.RunTestInNonMicroserviceEnv(s.checkDelaySyncTimestamp)
 }
 
+func (s *tsoTestSuite) TestServeBeforeRaftClusterLoaded() {
+	s.env.RunTestInNonMicroserviceEnv(s.checkServeBeforeRaftClusterLoaded)
+}
+
+func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestCluster) {
+	re := s.Require()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	leaderServer := cluster.GetLeaderServer()
+	var nextLeaderServer *tests.TestServer
+	for _, s := range cluster.GetServers() {
+		if s.GetConfig().Name != cluster.GetLeader() {
+			nextLeaderServer = s
+		}
+	}
+	re.NotNil(nextLeaderServer)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayCreateRaftCluster", `return(5000)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayCreateRaftCluster"))
+	}()
+
+	re.NoError(leaderServer.ResignLeaderWithRetry())
+	re.True(nextLeaderServer.WaitLeader())
+	re.Nil(nextLeaderServer.GetRaftCluster())
+
+	grpcPDClient, conn := testutil.MustNewGrpcClient(re, nextLeaderServer.GetAddr())
+	defer conn.Close()
+	req := &pdpb.TsoRequest{
+		Header: testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		Count:  1,
+	}
+	rpcCtx, rpcCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer rpcCancel()
+	tsoClient, err := grpcPDClient.Tso(rpcCtx)
+	re.NoError(err)
+	defer func() {
+		err = tsoClient.CloseSend()
+		re.NoError(err)
+	}()
+	re.NoError(tsoClient.Send(req))
+	resp, err := tsoClient.Recv()
+	re.NoError(err)
+	re.NotNil(checkAndReturnTimestampResponse(re, req, resp))
+
+	testutil.Eventually(re, func() bool {
+		return nextLeaderServer.GetRaftCluster() != nil
+	})
+}
+
 func (s *tsoTestSuite) checkDelaySyncTimestamp(cluster *tests.TestCluster) {
 	re := s.Require()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -17,6 +17,7 @@ package tso_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"testing"
@@ -149,28 +150,46 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 		return ok && loadedRegion.GetId() == regionID
 	})
 
+	beforeCreateRaftClusterPaused := make(chan struct{})
+	resumeBeforeCreateRaftCluster := make(chan struct{})
+	var beforeCreateRaftClusterPauseOnce sync.Once
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/pauseBeforeCreateRaftCluster", func() {
+		beforeCreateRaftClusterPauseOnce.Do(func() {
+			close(beforeCreateRaftClusterPaused)
+		})
+		<-resumeBeforeCreateRaftCluster
+	}))
 	regionReadReadyPaused := make(chan struct{})
 	resumeAfterRegionReadReady := make(chan struct{})
-	var pauseOnce sync.Once
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayCreateRaftCluster", `return(1000)`))
+	var regionReadReadyPauseOnce sync.Once
 	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/pauseAfterRegionReadReady", func() {
-		pauseOnce.Do(func() {
+		regionReadReadyPauseOnce.Do(func() {
 			close(regionReadReadyPaused)
 		})
 		<-resumeAfterRegionReadReady
 	}))
 	defer func() {
 		select {
+		case <-resumeBeforeCreateRaftCluster:
+		default:
+			close(resumeBeforeCreateRaftCluster)
+		}
+		select {
 		case <-resumeAfterRegionReadReady:
 		default:
 			close(resumeAfterRegionReadReady)
 		}
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/pauseBeforeCreateRaftCluster"))
 		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/pauseAfterRegionReadReady"))
-		re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayCreateRaftCluster"))
 	}()
 
 	re.NoError(leaderServer.ResignLeaderWithRetry())
 	re.True(nextLeaderServer.WaitLeader())
+	select {
+	case <-beforeCreateRaftClusterPaused:
+	case <-time.After(20 * time.Second):
+		re.FailNow("timed out waiting before raft cluster creation")
+	}
 	grpcPDClient, conn := testutil.MustNewGrpcClient(re, nextLeaderServer.GetAddr())
 	defer conn.Close()
 	req := &pdpb.TsoRequest{
@@ -191,13 +210,21 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.NotNil(checkAndReturnTimestampResponse(re, req, resp))
 
 	httpClient := &http.Client{Timeout: time.Second}
+	rc := nextLeaderServer.GetServer().DirectlyGetRaftCluster()
+	re.NotNil(rc)
+	re.False(rc.IsRegionReadReady())
+	assertRegionReadsNotBootstrapped(
+		re, ctx, grpcPDClient, httpClient, nextLeaderServer,
+		region.GetStartKey(), region.GetEndKey(), regionID,
+	)
+
+	close(resumeBeforeCreateRaftCluster)
 	select {
 	case <-regionReadReadyPaused:
 	case <-time.After(20 * time.Second):
 		re.FailNow("timed out waiting for region read readiness pause")
 	}
 
-	rc := nextLeaderServer.GetServer().DirectlyGetRaftCluster()
 	re.True(rc.IsRegionReadReady())
 
 	regionRPCContext, regionRPCCancel := context.WithTimeout(ctx, time.Second)
@@ -248,6 +275,52 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	testutil.Eventually(re, func() bool {
 		return nextLeaderServer.GetRaftCluster() != nil
 	}, testutil.WithWaitFor(20*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+}
+
+func assertRegionReadsNotBootstrapped(
+	re *require.Assertions,
+	ctx context.Context,
+	grpcPDClient pdpb.PDClient,
+	httpClient *http.Client,
+	svr *tests.TestServer,
+	startKey, endKey []byte,
+	regionID uint64,
+) {
+	requestHeader := testutil.NewRequestHeader(svr.GetClusterID())
+	regionRPCContext, regionRPCCancel := context.WithTimeout(ctx, time.Second)
+	defer regionRPCCancel()
+	regionByIDResp, err := grpcPDClient.GetRegionByID(regionRPCContext, &pdpb.GetRegionByIDRequest{
+		Header:   requestHeader,
+		RegionId: regionID,
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, regionByIDResp.GetHeader().GetError().GetType())
+
+	scanContext, scanCancel := context.WithTimeout(ctx, time.Second)
+	defer scanCancel()
+	scanResp, err := grpcPDClient.ScanRegions(scanContext, &pdpb.ScanRegionsRequest{
+		Header:   requestHeader,
+		StartKey: startKey,
+		EndKey:   endKey,
+		Limit:    1,
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_NOT_BOOTSTRAPPED, scanResp.GetHeader().GetError().GetType())
+
+	checkHTTPNotBootstrapped := func(url string) {
+		req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+		re.NoError(err)
+		resp, err := httpClient.Do(req)
+		re.NoError(err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		re.NoError(err)
+		re.Equal(http.StatusInternalServerError, resp.StatusCode, string(body))
+		re.Contains(string(body), "not bootstrapped")
+	}
+	checkHTTPNotBootstrapped(fmt.Sprintf("%s/pd/api/v1/region/id/%d", svr.GetAddr(), regionID))
+	checkHTTPNotBootstrapped(fmt.Sprintf("%s/pd/api/v1/regions/key?key=a&end_key=z&limit=1", svr.GetAddr()))
+	checkHTTPNotBootstrapped(svr.GetAddr() + "/pd/api/v1/regions/count")
 }
 
 func (s *tsoTestSuite) checkDelaySyncTimestamp(cluster *tests.TestCluster) {

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -16,6 +16,9 @@ package tso_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,8 +27,10 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
+	"github.com/tikv/pd/pkg/response"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
@@ -52,6 +57,7 @@ func (s *tsoTestSuite) SetupSuite() {
 	s.updateInterval = config.MaxTSOUpdatePhysicalInterval
 	s.env = tests.NewSchedulingTestEnvironment(s.T(), func(conf *config.Config, _ string) {
 		conf.TSOUpdatePhysicalInterval = typeutil.Duration{Duration: s.updateInterval}
+		conf.PDServerCfg.UseRegionStorage = false
 	})
 	s.env.PDCount = 2
 }
@@ -131,15 +137,40 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	}
 	re.NotNil(nextLeaderServer)
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayCreateRaftCluster", `return(5000)`))
+	regionID := uint64(10)
+	region := tests.MustPutRegion(re, cluster, regionID, 1, []byte("a"), []byte("z"))
+	testutil.Eventually(re, func() bool {
+		return leaderServer.GetRaftCluster().GetRegion(regionID) != nil
+	})
+	testutil.Eventually(re, func() bool {
+		loadedRegion := &metapb.Region{}
+		ok, err := leaderServer.GetServer().GetStorage().LoadRegion(regionID, loadedRegion)
+		re.NoError(err)
+		return ok && loadedRegion.GetId() == regionID
+	})
+
+	regionReadReadyPaused := make(chan struct{})
+	resumeAfterRegionReadReady := make(chan struct{})
+	var pauseOnce sync.Once
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/delayCreateRaftCluster", `return(1000)`))
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/cluster/pauseAfterRegionReadReady", func() {
+		pauseOnce.Do(func() {
+			close(regionReadReadyPaused)
+		})
+		<-resumeAfterRegionReadReady
+	}))
 	defer func() {
+		select {
+		case <-resumeAfterRegionReadReady:
+		default:
+			close(resumeAfterRegionReadReady)
+		}
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/cluster/pauseAfterRegionReadReady"))
 		re.NoError(failpoint.Disable("github.com/tikv/pd/server/delayCreateRaftCluster"))
 	}()
 
 	re.NoError(leaderServer.ResignLeaderWithRetry())
 	re.True(nextLeaderServer.WaitLeader())
-	re.Nil(nextLeaderServer.GetRaftCluster())
-
 	grpcPDClient, conn := testutil.MustNewGrpcClient(re, nextLeaderServer.GetAddr())
 	defer conn.Close()
 	req := &pdpb.TsoRequest{
@@ -159,9 +190,64 @@ func (s *tsoTestSuite) checkServeBeforeRaftClusterLoaded(cluster *tests.TestClus
 	re.NoError(err)
 	re.NotNil(checkAndReturnTimestampResponse(re, req, resp))
 
+	httpClient := &http.Client{Timeout: time.Second}
+	select {
+	case <-regionReadReadyPaused:
+	case <-time.After(20 * time.Second):
+		re.FailNow("timed out waiting for region read readiness pause")
+	}
+
+	rc := nextLeaderServer.GetServer().DirectlyGetRaftCluster()
+	re.True(rc.IsRegionReadReady())
+
+	regionRPCContext, regionRPCCancel := context.WithTimeout(ctx, time.Second)
+	defer regionRPCCancel()
+	regionByIDResp, err := grpcPDClient.GetRegionByID(regionRPCContext, &pdpb.GetRegionByIDRequest{
+		Header:      testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		RegionId:    regionID,
+		NeedBuckets: true,
+	})
+	re.NoError(err)
+	re.Nil(regionByIDResp.GetHeader().GetError())
+	re.Equal(regionID, regionByIDResp.GetRegion().GetId())
+
+	scanContext, scanCancel := context.WithTimeout(ctx, time.Second)
+	defer scanCancel()
+	scanResp, err := grpcPDClient.ScanRegions(scanContext, &pdpb.ScanRegionsRequest{
+		Header:   testutil.NewRequestHeader(nextLeaderServer.GetClusterID()),
+		StartKey: region.GetStartKey(),
+		EndKey:   region.GetEndKey(),
+		Limit:    1,
+	})
+	re.NoError(err)
+	re.Nil(scanResp.GetHeader().GetError())
+	re.Len(scanResp.GetRegions(), 1)
+	re.Equal(regionID, scanResp.GetRegions()[0].GetRegion().GetId())
+
+	var httpRegion response.RegionInfo
+	re.NoError(testutil.ReadGetJSON(re, httpClient,
+		fmt.Sprintf("%s/pd/api/v1/region/id/%d", nextLeaderServer.GetAddr(), regionID),
+		&httpRegion))
+	re.Equal(regionID, httpRegion.ID)
+
+	var scannedRegions response.RegionsInfo
+	re.NoError(testutil.ReadGetJSON(re, httpClient,
+		fmt.Sprintf("%s/pd/api/v1/regions/key?key=a&end_key=z&limit=1", nextLeaderServer.GetAddr()),
+		&scannedRegions))
+	re.Equal(1, scannedRegions.Count)
+	re.Len(scannedRegions.Regions, 1)
+	re.Equal(regionID, scannedRegions.Regions[0].ID)
+
+	var regionCount response.RegionsInfo
+	re.NoError(testutil.ReadGetJSON(re, httpClient,
+		nextLeaderServer.GetAddr()+"/pd/api/v1/regions/count",
+		&regionCount))
+	re.Equal(rc.GetTotalRegionCount(), regionCount.Count)
+
+	close(resumeAfterRegionReadReady)
 	testutil.Eventually(re, func() bool {
 		return nextLeaderServer.GetRaftCluster() != nil
-	})
+	}, testutil.WithWaitFor(20*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 }
 
 func (s *tsoTestSuite) checkDelaySyncTimestamp(cluster *tests.TestCluster) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10768

This is split out from #10773 so the LoadRegions/recovery-time optimization can be reviewed independently from the `/regions/count` low-contention change.

### What is changed and how does it work?

```commit-message
Use a local LevelDB bytes fast path when loading region metadata so startup region load avoids the string -> []byte conversion path and can use a larger local batch without changing the etcd range limit.

Reuse known-empty overlap results while updating region subtrees, and use an ordered-load no-overlap hint during startup loading when the current region start key is beyond the maximum end key loaded so far. This avoids redundant overlap scans for monotonic, non-overlapping region data while falling back to the normal checked path for unordered ranges.

Initialize embedded TSO and promote the PD member before the full raft cluster finishes region-cache loading, so core TSO service can recover while region APIs and scheduling remain gated by raft-cluster readiness.
```

### Check List

Tests

- Unit test
- Manual test (add detailed scripts or steps below)

Manual test details:

- Split-branch targeted tests:

```bash
make failpoint-enable && go test -tags without_dashboard ./tests/server/tso ./server/cluster ./pkg/core ./pkg/storage/endpoint ./pkg/storage -run 'TestTSOSuite/TestServeBeforeRaftClusterLoaded|TestCheckAndPutRegionNoOverlap|TestLoadedRegionCheckerNoOverlapHint|TestLoadRegionsWithBytesLoader|TestLoadRegionsWithLevelDBBytesLoader|TestLoadRegions$|TestLoadRegionsToCache|TestLoadRegionsExceedRangeLimit|TestRegionStorage' -count=1; rc=$?; make failpoint-disable; exit $rc
```

- 100M-region validation on testbed `8123033` was performed on the original combined #10773 branch before this split. The count optimization removed from this split does not affect the measured `LoadRegions` or early TSO readiness path:
  - Region count: `100,015,214`.
  - Pod was not deleted or recreated; pod UID stayed `77ab2a82-4262-4c31-9013-d03d6cceeba9`, container restartCount stayed `0`.
  - Original process-only restart baseline: `load regions` `18m14.087s`.
  - Cache-build optimization candidate: `load regions` `10m32.815s`.
  - Core-service early-ready candidate: full `load regions` `10m24.196s` in the background; `/health + direct TSO` ready in `8s` from TERM and `3s` from new process start.
  - Direct TSO latency after early readiness: about `37-39ms`.

### Release note

```release-note
Improve PD region loading performance and core TSO service recovery time for clusters with a very large number of regions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster region loading via an optimized local-range path and append-optimized insertion for ordered data
  * Option to insert regions without overlap checks for faster safe bulk restores
  * PD leaders can serve TSO and region-read endpoints earlier via a region-read gating path

* **Bug Fixes**
  * Cleaner removal of pending region overlaps during updates
  * Better error propagation when decoding region data and on storage iteration failures
  * Safer startup/shutdown coordination for region loading and leader transitions

* **Tests**
  * Added coverage for region insertion/loading, overlap cleanup, region-read gating, and TSO-before-raft scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->