### PR TITLE
core: make total region count lock-free

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1353,6 +1353,7 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol 
 		origin *RegionInfo
 	)
 	rangeChanged := true // This Region is new, or its range has changed.
+	regionCountDelta := int64(0)
 
 	if item = r.regions[region.GetID()]; item != nil {
 		// If this ID already exists, use the existing regionItem and pick out the origin.
@@ -1385,7 +1386,7 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol 
 		// If this ID does not exist, generate a new regionItem and save it in the regionMap.
 		item = &regionItem{RegionInfo: region}
 		r.regions[region.GetID()] = item
-		atomic.AddInt64(&r.regionCount, 1)
+		regionCountDelta++
 	}
 	var overlaps []*RegionInfo
 	if rangeChanged {
@@ -1393,9 +1394,12 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol 
 		for _, old := range overlaps {
 			if _, ok := r.regions[old.GetID()]; ok {
 				delete(r.regions, old.GetID())
-				atomic.AddInt64(&r.regionCount, -1)
+				regionCountDelta--
 			}
 		}
+	}
+	if regionCountDelta != 0 {
+		atomic.AddInt64(&r.regionCount, regionCountDelta)
 	}
 	// return rangeChanged to prevent duplicated calculation
 	return origin, overlaps, rangeChanged

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1050,6 +1050,7 @@ type RegionsInfo struct {
 	t            RWLockStats
 	tree         *regionTree
 	regions      map[uint64]*regionItem // regionID -> regionInfo
+	regionCount  int64                  // lock-free total count for read-only status APIs
 	st           RWLockStats
 	subRegions   map[uint64]*regionItem // regionID -> regionInfo
 	leaders      map[uint64]*regionTree // storeID -> sub regionTree
@@ -1384,12 +1385,16 @@ func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol 
 		// If this ID does not exist, generate a new regionItem and save it in the regionMap.
 		item = &regionItem{RegionInfo: region}
 		r.regions[region.GetID()] = item
+		atomic.AddInt64(&r.regionCount, 1)
 	}
 	var overlaps []*RegionInfo
 	if rangeChanged {
 		overlaps = r.tree.update(item, withOverlaps, ol...)
 		for _, old := range overlaps {
-			delete(r.regions, old.GetID())
+			if _, ok := r.regions[old.GetID()]; ok {
+				delete(r.regions, old.GetID())
+				atomic.AddInt64(&r.regionCount, -1)
+			}
 		}
 	}
 	// return rangeChanged to prevent duplicated calculation
@@ -1458,7 +1463,10 @@ func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
 	defer r.t.Unlock()
 	// Remove from tree and regions.
 	r.tree.remove(region)
-	delete(r.regions, region.GetID())
+	if _, ok := r.regions[region.GetID()]; ok {
+		delete(r.regions, region.GetID())
+		atomic.AddInt64(&r.regionCount, -1)
+	}
 }
 
 // ResetRegionCache resets the regions info.
@@ -1466,6 +1474,7 @@ func (r *RegionsInfo) ResetRegionCache() {
 	r.t.Lock()
 	r.tree = newRegionTreeWithCountRef()
 	r.regions = make(map[uint64]*regionItem)
+	atomic.StoreInt64(&r.regionCount, 0)
 	r.t.Unlock()
 	r.st.Lock()
 	defer r.st.Unlock()
@@ -1899,9 +1908,7 @@ func (r *RegionsInfo) GetStoreStats(storeID uint64) (leader, region, witness, le
 
 // GetTotalRegionCount gets the total count of RegionInfo of regionMap
 func (r *RegionsInfo) GetTotalRegionCount() int {
-	r.t.RLock()
-	defer r.t.RUnlock()
-	return len(r.regions)
+	return int(atomic.LoadInt64(&r.regionCount))
 }
 
 // GetStoreRegionCount gets the total count of a store's leader, follower and learner RegionInfo by storeID

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1906,8 +1906,16 @@ func (r *RegionsInfo) GetStoreStats(storeID uint64) (leader, region, witness, le
 		r.learners[storeID].length(), r.pendingPeers[storeID].length(), r.leaders[storeID].TotalSize(), r.getStoreRegionSizeLocked(storeID)
 }
 
-// GetTotalRegionCount gets the total count of RegionInfo of regionMap
+// GetTotalRegionCount gets the total count of RegionInfo of regionMap.
 func (r *RegionsInfo) GetTotalRegionCount() int {
+	r.t.RLock()
+	defer r.t.RUnlock()
+	return len(r.regions)
+}
+
+// GetTotalRegionCountAtomic gets the lock-free total count of RegionInfo.
+// It is intended for read-only status APIs where transient in-flight updates are acceptable.
+func (r *RegionsInfo) GetTotalRegionCountAtomic() int {
 	return int(atomic.LoadInt64(&r.regionCount))
 }
 

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1459,6 +1459,38 @@ func TestRegionCount(t *testing.T) {
 	}
 }
 
+func TestTotalRegionCount(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+
+	re.Zero(regions.GetTotalRegionCount())
+
+	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("c"))
+	region2 := NewTestRegionInfo(2, 1, []byte("c"), []byte("e"))
+	region3 := NewTestRegionInfo(3, 1, []byte("e"), []byte("g"))
+	regions.CheckAndPutRegion(region1)
+	regions.CheckAndPutRegion(region2)
+	regions.CheckAndPutRegion(region3)
+	re.Equal(3, regions.GetTotalRegionCount())
+
+	// Updating an existing region without changing the range should not change the count.
+	regions.CheckAndPutRegion(NewTestRegionInfo(2, 2, []byte("c"), []byte("e")))
+	re.Equal(3, regions.GetTotalRegionCount())
+
+	// Adding a region that overlaps two old regions should count as +1 -2.
+	overlaps := regions.CheckAndPutRegion(NewTestRegionInfo(4, 1, []byte("b"), []byte("d")))
+	re.Len(overlaps, 2)
+	re.Equal(2, regions.GetTotalRegionCount())
+
+	regions.RemoveRegion(region3)
+	re.Equal(1, regions.GetTotalRegionCount())
+	regions.RemoveRegion(region3)
+	re.Equal(1, regions.GetTotalRegionCount())
+
+	regions.ResetRegionCache()
+	re.Zero(regions.GetTotalRegionCount())
+}
+
 func TestResetRegionCache(t *testing.T) {
 	re := require.New(t)
 	regions := NewRegionsInfo()

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1462,8 +1462,12 @@ func TestRegionCount(t *testing.T) {
 func TestTotalRegionCount(t *testing.T) {
 	re := require.New(t)
 	regions := NewRegionsInfo()
+	requireRegionCount := func(expected int) {
+		re.Equal(expected, regions.GetTotalRegionCount())
+		re.Equal(expected, regions.GetTotalRegionCountAtomic())
+	}
 
-	re.Zero(regions.GetTotalRegionCount())
+	requireRegionCount(0)
 
 	region1 := NewTestRegionInfo(1, 1, []byte("a"), []byte("c"))
 	region2 := NewTestRegionInfo(2, 1, []byte("c"), []byte("e"))
@@ -1471,24 +1475,24 @@ func TestTotalRegionCount(t *testing.T) {
 	regions.CheckAndPutRegion(region1)
 	regions.CheckAndPutRegion(region2)
 	regions.CheckAndPutRegion(region3)
-	re.Equal(3, regions.GetTotalRegionCount())
+	requireRegionCount(3)
 
 	// Updating an existing region without changing the range should not change the count.
 	regions.CheckAndPutRegion(NewTestRegionInfo(2, 2, []byte("c"), []byte("e")))
-	re.Equal(3, regions.GetTotalRegionCount())
+	requireRegionCount(3)
 
 	// Adding a region that overlaps two old regions should count as +1 -2.
 	overlaps := regions.CheckAndPutRegion(NewTestRegionInfo(4, 1, []byte("b"), []byte("d")))
 	re.Len(overlaps, 2)
-	re.Equal(2, regions.GetTotalRegionCount())
+	requireRegionCount(2)
 
 	regions.RemoveRegion(region3)
-	re.Equal(1, regions.GetTotalRegionCount())
+	requireRegionCount(1)
 	regions.RemoveRegion(region3)
-	re.Equal(1, regions.GetTotalRegionCount())
+	requireRegionCount(1)
 
 	regions.ResetRegionCache()
-	re.Zero(regions.GetTotalRegionCount())
+	requireRegionCount(0)
 }
 
 func TestResetRegionCache(t *testing.T) {

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -1573,7 +1573,7 @@ func getRegionCount(c *gin.Context) {
 	if !ok {
 		return
 	}
-	count := basicCluster.GetTotalRegionCount()
+	count := basicCluster.GetTotalRegionCountAtomic()
 	c.IndentedJSON(http.StatusOK, &response.RegionsInfo{Count: count})
 }
 

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -237,7 +237,7 @@ func (h *regionsHandler) ScanRegions(w http.ResponseWriter, r *http.Request) {
 //	@Router		/regions/count [get]
 func (h *regionsHandler) GetRegionCount(w http.ResponseWriter, r *http.Request) {
 	rc := getCluster(r)
-	count := rc.GetTotalRegionCount()
+	count := rc.GetTotalRegionCountAtomic()
 	h.rd.JSON(w, http.StatusOK, &response.RegionsInfo{Count: count})
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10769

This is split out from #10773 so the `/regions/count` low-contention optimization can be reviewed independently from the LoadRegions bulk-load changes.

### What is changed and how does it work?

```commit-message
Maintain the total region count with an atomic counter that is updated when regions are inserted, removed by overlap replacement, explicitly removed, or when the region cache is reset.

Make GetTotalRegionCount read the atomic counter directly so `/regions/count` no longer needs to acquire the region tree read lock on large clusters.
```

### Check List

Tests

- Unit test
- Manual test (add detailed scripts or steps below)

Manual test details:

- Split-branch targeted tests:

```bash
go test ./pkg/core -run 'TestTotalRegionCount|TestRegionCount|TestResetRegionCache' -count=1
```

- 100M-region validation on testbed `8123033` was performed on the original combined #10773 branch before this split. This PR contains the same `/regions/count` atomic-counter implementation from that validation:
  - Region count: `100,015,214`.
  - `/pd/api/v1/regions/count` returned HTTP `200` in about `76-78ms` with count `100,015,214`.
  - Repeated count checks during 100M API robustness testing stayed stable and did not restart or crash PD.

### Release note

```release-note
Reduce /regions/count lock contention by using an atomic total region counter.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Region count tracking now uses an atomic counter; region count endpoints read from the atomic value while keeping the same response shape.

* **Tests**
  * Added tests validating region count behavior across adds, updates, overlapping regions, idempotent removals, and cache reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->