### PR TITLE
tools: support QueryRegion in pd-api-bench

### DIFF
--- a/tools/pd-api-bench/README.md
+++ b/tools/pd-api-bench/README.md
@@ -23,6 +23,8 @@ The api bench cases we support are as follows:
 2. gRPC
 
     + GetRegion
+    + GetPrevRegion
+    + GetRegionByID
     + GetStore
     + GetStores
     + ScanRegions
@@ -60,6 +62,9 @@ The api bench cases we support are as follows:
 
 -debug
 > print the output of api response for debug
+
+-enable-router-client
+> enable the PD client router client. When enabled, `GetRegion`, `GetPrevRegion`, and `GetRegionByID` use QueryRegion. Set `--enable-router-client=false` to run unary region lookup benchmarks.
 
 ### Run Shell
 

--- a/tools/pd-api-bench/cases/cases.go
+++ b/tools/pd-api-bench/cases/cases.go
@@ -29,6 +29,7 @@ import (
 	pd "github.com/tikv/pd/client"
 	pdHttp "github.com/tikv/pd/client/http"
 	"github.com/tikv/pd/client/opt"
+	"github.com/tikv/pd/pkg/codec"
 )
 
 var (
@@ -40,7 +41,7 @@ var (
 	storesID    []uint64
 )
 
-const defaultKeyLen = 56
+const defaultSimulatorReplica = 3
 
 // InitCluster initializes the cluster.
 func InitCluster(ctx context.Context, cli pd.Client, httpCli pdHttp.Client) error {
@@ -151,6 +152,8 @@ type GRPCCreateFn func() GRPCCase
 var GRPCCaseFnMap = map[string]GRPCCreateFn{
 	"GetRegion":                newGetRegion(),
 	"GetRegionEnableFollower":  newGetRegionEnableFollower(),
+	"GetPrevRegion":            newGetPrevRegion(),
+	"GetRegionByID":            newGetRegionByID(),
 	"GetStore":                 newGetStore(),
 	"GetStores":                newGetStores(),
 	"ScanRegions":              newScanRegions(),
@@ -223,8 +226,8 @@ func (c *regionsStats) do(ctx context.Context, cli pdHttp.Client) error {
 		upperBound = 1
 	}
 	random := rand.IntN(upperBound)
-	startID := c.regionSample*random*4 + 1
-	endID := c.regionSample*(random+1)*4 + 1
+	startID := c.regionSample * random
+	endID := c.regionSample * (random + 1)
 	regionStats, err := cli.GetRegionStatusByKeyRange(ctx,
 		pdHttp.NewKeyRange(generateKeyForSimulator(startID), generateKeyForSimulator(endID)), false)
 	if Debug {
@@ -303,8 +306,8 @@ func newGetRegion() func() GRPCCase {
 }
 
 func (*getRegion) unary(ctx context.Context, cli pd.Client) error {
-	id := rand.IntN(totalRegion)*4 + 1
-	_, err := cli.GetRegion(ctx, generateKeyForSimulator(id))
+	index := rand.IntN(totalRegion)
+	_, err := cli.GetRegion(ctx, generateKeyForSimulator(index))
 	if err != nil {
 		return err
 	}
@@ -327,8 +330,59 @@ func newGetRegionEnableFollower() func() GRPCCase {
 }
 
 func (*getRegionEnableFollower) unary(ctx context.Context, cli pd.Client) error {
-	id := rand.IntN(totalRegion)*4 + 1
-	_, err := cli.GetRegion(ctx, generateKeyForSimulator(id), opt.WithAllowFollowerHandle())
+	index := rand.IntN(totalRegion)
+	_, err := cli.GetRegion(ctx, generateKeyForSimulator(index), opt.WithAllowFollowerHandle())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type getPrevRegion struct {
+	*baseCase
+}
+
+func newGetPrevRegion() func() GRPCCase {
+	return func() GRPCCase {
+		return &getPrevRegion{
+			baseCase: &baseCase{
+				name: "GetPrevRegion",
+				cfg:  newConfig(),
+			},
+		}
+	}
+}
+
+func (*getPrevRegion) unary(ctx context.Context, cli pd.Client) error {
+	index := 0
+	if totalRegion > 1 {
+		index = rand.IntN(totalRegion-1) + 1
+	}
+	_, err := cli.GetPrevRegion(ctx, generateKeyForSimulator(index))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type getRegionByID struct {
+	*baseCase
+}
+
+func newGetRegionByID() func() GRPCCase {
+	return func() GRPCCase {
+		return &getRegionByID{
+			baseCase: &baseCase{
+				name: "GetRegionByID",
+				cfg:  newConfig(),
+			},
+		}
+	}
+}
+
+func (*getRegionByID) unary(ctx context.Context, cli pd.Client) error {
+	id := generateRegionIDForSimulator(rand.IntN(totalRegion))
+	_, err := cli.GetRegionByID(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -354,9 +408,12 @@ func newScanRegions() func() GRPCCase {
 
 func (c *scanRegions) unary(ctx context.Context, cli pd.Client) error {
 	upperBound := totalRegion / c.regionSample
+	if upperBound < 1 {
+		upperBound = 1
+	}
 	random := rand.IntN(upperBound)
-	startID := c.regionSample*random*4 + 1
-	endID := c.regionSample*(random+1)*4 + 1
+	startID := c.regionSample * random
+	endID := c.regionSample * (random + 1)
 	//nolint:staticcheck
 	_, err := cli.ScanRegions(ctx, generateKeyForSimulator(startID), generateKeyForSimulator(endID), c.regionSample)
 	if err != nil {
@@ -436,9 +493,11 @@ func (*getStores) unary(ctx context.Context, cli pd.Client) error {
 }
 
 func generateKeyForSimulator(id int) []byte {
-	k := make([]byte, defaultKeyLen)
-	copy(k, fmt.Sprintf("%010d", id))
-	return k
+	return codec.GenerateTableKey(int64(id))
+}
+
+func generateRegionIDForSimulator(index int) uint64 {
+	return uint64(index*(defaultSimulatorReplica+1) + 1)
 }
 
 type getKV struct {

--- a/tools/pd-api-bench/config/config.go
+++ b/tools/pd-api-bench/config/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	LogProps *log.ZapProperties
 
 	Client int64 `toml:"client" json:"client"`
+	// EnableRouterClient controls the client-side router client, which uses
+	// QueryRegion for GetRegion/GetPrevRegion/GetRegionByID.
+	EnableRouterClient bool `toml:"enable-router-client" json:"enable-router-client"`
 
 	// tls
 	CaPath   string `toml:"ca-path" json:"ca-path"`
@@ -59,6 +62,7 @@ func NewConfig(flagSet *flag.FlagSet) *Config {
 	fs.StringVar(&cfg.Log.File.Filename, "log-file", "", "log file path")
 	fs.StringVar(&cfg.StatusAddr, "status", "127.0.0.1:10081", "status address")
 	fs.Int64Var(&cfg.Client, "client", 1, "client number")
+	fs.BoolVar(&cfg.EnableRouterClient, "enable-router-client", true, "enable client-side router client for QueryRegion")
 	fs.StringVar(&cfg.CaPath, "cacert", "", "path of file that contains list of trusted SSL CAs")
 	fs.StringVar(&cfg.CertPath, "cert", "", "path of file that contains X509 certificate in PEM format")
 	fs.StringVar(&cfg.KeyPath, "key", "", "path of file that contains X509 key in PEM format")

--- a/tools/pd-api-bench/main.go
+++ b/tools/pd-api-bench/main.go
@@ -379,19 +379,22 @@ func newEtcdClient(cfg *config.Config) *clientv3.Client {
 // newPDClient returns a pd client.
 func newPDClient(ctx context.Context, cfg *config.Config) pd.Client {
 	addrs := []string{cfg.PDAddr}
-	pdCli, err := pd.NewClientWithContext(ctx, caller.TestComponent,
-		addrs, pd.SecurityOption{
-			CAPath:   cfg.CaPath,
-			CertPath: cfg.CertPath,
-			KeyPath:  cfg.KeyPath,
-		},
+	opts := []opt.ClientOption{
 		//nolint:staticcheck
 		opt.WithGRPCDialOptions(
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time:    keepaliveTime,
 				Timeout: keepaliveTimeout,
 			}),
-		))
+		),
+		opt.WithEnableRouterClient(cfg.EnableRouterClient),
+	}
+	pdCli, err := pd.NewClientWithContext(ctx, caller.TestComponent,
+		addrs, pd.SecurityOption{
+			CAPath:   cfg.CaPath,
+			CertPath: cfg.CertPath,
+			KeyPath:  cfg.KeyPath,
+		}, opts...)
 	if err != nil {
 		log.Fatal("fail to create pd client", zap.Error(err))
 	}


### PR DESCRIPTION
## Summary
- Add pd-api-bench coverage for `GetPrevRegion` and `GetRegionByID`.
- Add `--enable-router-client` so region lookup benchmarks can compare QueryRegion and unary paths.
- Align generated benchmark keys with the heartbeat bench table-key layout.

## Test Plan
- `git diff --check HEAD~1..HEAD`
- `cd tools && go test ./pd-api-bench/... -count=1`
- `make pd-api-bench`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `GetPrevRegion` and `GetRegionByID` benchmark test cases to expand PD API performance testing coverage
  * Added `--enable-router-client` configuration flag to customize routing behavior for region lookup operations

* **Documentation**
  * Updated benchmark documentation to reflect newly supported test cases and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->