### PR TITLE
resource_group: push RU metrics to metering server

### DIFF
--- a/pkg/mcs/resourcemanager/server/config.go
+++ b/pkg/mcs/resourcemanager/server/config.go
@@ -174,6 +174,12 @@ type ControllerConfig struct {
 	// EnableControllerTraceLog is to control whether resource control client enable trace.
 	EnableControllerTraceLog bool `toml:"enable-controller-trace-log" json:"enable-controller-trace-log,string"`
 
+	// PushMetricsAddress is the address to push metrics.
+	PushMetricsAddress string `toml:"push-metrics-address" json:"push-metrics-address"`
+
+	// PushMetricsInterval is the interval to push metrics.
+	PushMetricsInterval typeutil.Duration `toml:"push-metrics-interval" json:"push-metrics-interval"`
+
 	RUVersionPolicy *RUVersionPolicy `toml:"ru-version-policy" json:"ru-version-policy,omitempty"`
 }
 

--- a/pkg/mcs/resourcemanager/server/config.go
+++ b/pkg/mcs/resourcemanager/server/config.go
@@ -205,6 +205,10 @@ func (rmc *ControllerConfig) Adjust(meta *configutil.ConfigMetaData) {
 	if !meta.IsDefined("ltb-token-rpc-max-delay") {
 		configutil.AdjustDuration(&rmc.LTBTokenRPCMaxDelay, defaultLTBTokenRPCMaxDelay)
 	}
+	if rmc.PushMetricsAddress != "" && rmc.PushMetricsInterval.Duration <= 0 {
+		log.Warn("push-metrics-address is set but push-metrics-interval is invalid, metrics push disabled")
+		rmc.PushMetricsAddress = ""
+	}
 	failpoint.Inject("enableDegradedModeAndTraceLog", func() {
 		configutil.AdjustDuration(&rmc.DegradedModeWaitDuration, time.Second)
 		configutil.AdjustBool(&rmc.EnableControllerTraceLog, true)

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -69,23 +69,22 @@ func getPushMetricsConfig(controllerConfig *ControllerConfig) pushMetricsConfig 
 	}
 }
 
-func syncPushMetricsTicker(
-	ticker *time.Ticker,
-	tickerC <-chan time.Time,
-	current, next pushMetricsConfig,
-) (*time.Ticker, <-chan time.Time, pushMetricsConfig) {
-	if current == next {
-		return ticker, tickerC, current
+func (cfg *pushMetricsConfig) syncPushMetricsTicker(
+	newCfg pushMetricsConfig, ticker *time.Ticker,
+) *time.Ticker {
+	if *cfg == newCfg {
+		return ticker
 	}
+	*cfg = newCfg
 	if ticker != nil {
 		ticker.Stop()
 		ticker = nil
 	}
-	if next.address == "" {
-		return nil, nil, next
+	if newCfg.address == "" {
+		return nil
 	}
-	ticker = time.NewTicker(next.interval)
-	return ticker, ticker.C, next
+	ticker = time.NewTicker(newCfg.interval)
+	return ticker
 }
 
 // Manager is the manager of resource group.
@@ -765,14 +764,17 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 	var (
 		pushMetricsTicker  *time.Ticker
 		pushMetricsTickerC <-chan time.Time
-		pushMetricsConfig  pushMetricsConfig
 	)
-	pushMetricsTicker, pushMetricsTickerC, pushMetricsConfig = syncPushMetricsTicker(
-		pushMetricsTicker,
-		pushMetricsTickerC,
-		pushMetricsConfig,
+	pushMetricsConfig := pushMetricsConfig{}
+	pushMetricsTicker = pushMetricsConfig.syncPushMetricsTicker(
 		getPushMetricsConfig(m.GetControllerConfig()),
+		pushMetricsTicker,
 	)
+	if pushMetricsTicker != nil {
+		pushMetricsTickerC = pushMetricsTicker.C
+	} else {
+		pushMetricsTickerC = make(<-chan time.Time)
+	}
 	defer func() {
 		if pushMetricsTicker != nil {
 			pushMetricsTicker.Stop()
@@ -854,19 +856,20 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 					}
 				}
 			}
-			pushMetricsTicker, pushMetricsTickerC, pushMetricsConfig = syncPushMetricsTicker(
-				pushMetricsTicker,
-				pushMetricsTickerC,
-				pushMetricsConfig,
-				getPushMetricsConfig(m.GetControllerConfig()),
-			)
+			newPushMetricsConfig := getPushMetricsConfig(m.GetControllerConfig())
+			if pushMetricsConfig != newPushMetricsConfig {
+				pushMetricsTicker = pushMetricsConfig.syncPushMetricsTicker(
+					newPushMetricsConfig,
+					pushMetricsTicker,
+				)
+				if pushMetricsTicker != nil {
+					pushMetricsTickerC = pushMetricsTicker.C
+					log.Info("push metrics ticker updated", zap.Duration("interval", pushMetricsConfig.interval))
+				} else {
+					pushMetricsTickerC = make(<-chan time.Time)
+				}
+			}
 		case <-pushMetricsTickerC:
-			pushMetricsTicker, pushMetricsTickerC, pushMetricsConfig = syncPushMetricsTicker(
-				pushMetricsTicker,
-				pushMetricsTickerC,
-				pushMetricsConfig,
-				getPushMetricsConfig(m.GetControllerConfig()),
-			)
 			if pushMetricsConfig.address == "" {
 				continue
 			}

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -52,6 +52,42 @@ const (
 	pushMetricsTimeout = 10 * time.Second
 )
 
+type pushMetricsConfig struct {
+	address  string
+	interval time.Duration
+}
+
+func getPushMetricsConfig(controllerConfig *ControllerConfig) pushMetricsConfig {
+	if controllerConfig == nil ||
+		controllerConfig.PushMetricsAddress == "" ||
+		controllerConfig.PushMetricsInterval.Duration <= 0 {
+		return pushMetricsConfig{}
+	}
+	return pushMetricsConfig{
+		address:  controllerConfig.PushMetricsAddress,
+		interval: controllerConfig.PushMetricsInterval.Duration,
+	}
+}
+
+func syncPushMetricsTicker(
+	ticker *time.Ticker,
+	tickerC <-chan time.Time,
+	current, next pushMetricsConfig,
+) (*time.Ticker, <-chan time.Time, pushMetricsConfig) {
+	if current == next {
+		return ticker, tickerC, current
+	}
+	if ticker != nil {
+		ticker.Stop()
+		ticker = nil
+	}
+	if next.address == "" {
+		return nil, nil, next
+	}
+	ticker = time.NewTicker(next.interval)
+	return ticker, ticker.C, next
+}
+
 // Manager is the manager of resource group.
 type Manager struct {
 	syncutil.RWMutex
@@ -726,13 +762,22 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 		cleanUpTicker.Reset(100 * time.Millisecond)
 	})
 
-	pushMetricsTickerC := make(<-chan time.Time)
-	controllerConfig := m.GetControllerConfig()
-	if controllerConfig.PushMetricsAddress != "" && controllerConfig.PushMetricsInterval.Duration > 0 {
-		pushMetricsTicker := time.NewTicker(controllerConfig.PushMetricsInterval.Duration)
-		defer pushMetricsTicker.Stop()
-		pushMetricsTickerC = pushMetricsTicker.C
-	}
+	var (
+		pushMetricsTicker  *time.Ticker
+		pushMetricsTickerC <-chan time.Time
+		pushMetricsConfig  pushMetricsConfig
+	)
+	pushMetricsTicker, pushMetricsTickerC, pushMetricsConfig = syncPushMetricsTicker(
+		pushMetricsTicker,
+		pushMetricsTickerC,
+		pushMetricsConfig,
+		getPushMetricsConfig(m.GetControllerConfig()),
+	)
+	defer func() {
+		if pushMetricsTicker != nil {
+			pushMetricsTicker.Stop()
+		}
+	}()
 
 	for {
 		select {
@@ -809,14 +854,29 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 					}
 				}
 			}
+			pushMetricsTicker, pushMetricsTickerC, pushMetricsConfig = syncPushMetricsTicker(
+				pushMetricsTicker,
+				pushMetricsTickerC,
+				pushMetricsConfig,
+				getPushMetricsConfig(m.GetControllerConfig()),
+			)
 		case <-pushMetricsTickerC:
+			pushMetricsTicker, pushMetricsTickerC, pushMetricsConfig = syncPushMetricsTicker(
+				pushMetricsTicker,
+				pushMetricsTickerC,
+				pushMetricsConfig,
+				getPushMetricsConfig(m.GetControllerConfig()),
+			)
+			if pushMetricsConfig.address == "" {
+				continue
+			}
 			podName := os.Getenv("HOSTNAME")
 			if podName == "" {
 				podName = "default"
 			}
 			pushCtx, cancel := context.WithTimeout(ctx, pushMetricsTimeout)
 			start := time.Now()
-			err := push.New(controllerConfig.PushMetricsAddress, "resource_group_svc").
+			err := push.New(pushMetricsConfig.address, "resource_group_svc").
 				Grouping("pod", podName).
 				Collector(readRequestUnitCost).
 				Collector(writeRequestUnitCost).

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -824,7 +824,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				PushContext(pushCtx)
 			cancel()
 			if err != nil {
-				log.Error("push metrics to Prometheus failed", zap.Error(err))
+				log.Warn("push metrics to Prometheus failed", zap.Error(err))
 			}
 			pushRUMetricsDuration.Observe(time.Since(start).Seconds())
 		}

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/push"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/errors"
@@ -46,6 +48,8 @@ const (
 	metricsCleanupTimeout     = 20 * time.Minute
 	defaultCollectIntervalSec = 20
 	tickPerSecond             = time.Second
+
+	pushMetricsTimeout = 10 * time.Second
 )
 
 // Manager is the manager of resource group.
@@ -721,6 +725,13 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 	failpoint.Inject("fastCleanupTicker", func() {
 		cleanUpTicker.Reset(100 * time.Millisecond)
 	})
+	pushMetricsTickerC := make(<-chan time.Time)
+	controllerConfig := m.GetControllerConfig()
+	if controllerConfig.PushMetricsAddress != "" && controllerConfig.PushMetricsInterval.Duration > 0 {
+		pushMetricsTicker := time.NewTicker(controllerConfig.PushMetricsInterval.Duration)
+		pushMetricsTickerC = pushMetricsTicker.C
+		defer pushMetricsTicker.Stop()
+	}
 
 	for {
 		select {
@@ -797,6 +808,24 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 					}
 				}
 			}
+		case <-pushMetricsTickerC:
+			podName := os.Getenv("HOSTNAME")
+			if podName == "" {
+				podName = "default"
+			}
+			pushCtx, cancel := context.WithTimeout(ctx, pushMetricsTimeout)
+			start := time.Now()
+			err := push.New(controllerConfig.PushMetricsAddress, "resource_group_svc").
+				Grouping("pod", podName).
+				Collector(readRequestUnitCost).
+				Collector(writeRequestUnitCost).
+				Collector(sqlLayerRequestUnitCost).
+				PushContext(pushCtx)
+			cancel()
+			if err != nil {
+				log.Error("push metrics to Prometheus failed", zap.Error(err))
+			}
+			pushRUMetricsDuration.Observe(time.Since(start).Seconds())
 		}
 	}
 }

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -725,12 +725,13 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 	failpoint.Inject("fastCleanupTicker", func() {
 		cleanUpTicker.Reset(100 * time.Millisecond)
 	})
+
 	pushMetricsTickerC := make(<-chan time.Time)
 	controllerConfig := m.GetControllerConfig()
 	if controllerConfig.PushMetricsAddress != "" && controllerConfig.PushMetricsInterval.Duration > 0 {
 		pushMetricsTicker := time.NewTicker(controllerConfig.PushMetricsInterval.Duration)
-		pushMetricsTickerC = pushMetricsTicker.C
 		defer pushMetricsTicker.Stop()
+		pushMetricsTickerC = pushMetricsTicker.C
 	}
 
 	for {

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
 )
 
 func TestMain(m *testing.M) {
@@ -318,6 +319,51 @@ func TestManagerControllerConfigSnapshots(t *testing.T) {
 		re.Same(previous, m.controllerConfig)
 		re.InDelta(0.5, m.controllerConfig.RequestUnit.ReadBaseCost, 0.00001)
 	})
+}
+
+func TestPushMetricsConfig(t *testing.T) {
+	re := require.New(t)
+
+	re.Equal(pushMetricsConfig{}, getPushMetricsConfig(nil))
+	re.Equal(pushMetricsConfig{}, getPushMetricsConfig(&ControllerConfig{
+		PushMetricsAddress: "127.0.0.1:9091",
+	}))
+	re.Equal(pushMetricsConfig{
+		address:  "127.0.0.1:9091",
+		interval: time.Second,
+	}, getPushMetricsConfig(&ControllerConfig{
+		PushMetricsAddress: "127.0.0.1:9091",
+		PushMetricsInterval: typeutil.Duration{
+			Duration: time.Second,
+		},
+	}))
+}
+
+func TestSyncPushMetricsTicker(t *testing.T) {
+	re := require.New(t)
+
+	ticker, tickerC, current := syncPushMetricsTicker(nil, nil, pushMetricsConfig{}, pushMetricsConfig{
+		address:  "127.0.0.1:9091",
+		interval: time.Second,
+	})
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+	}()
+	re.NotNil(ticker)
+	re.NotNil(tickerC)
+	re.Equal(pushMetricsConfig{address: "127.0.0.1:9091", interval: time.Second}, current)
+
+	sameTicker, sameTickerC, sameCurrent := syncPushMetricsTicker(ticker, tickerC, current, current)
+	re.Same(ticker, sameTicker)
+	re.Equal(tickerC, sameTickerC)
+	re.Equal(current, sameCurrent)
+
+	ticker, tickerC, current = syncPushMetricsTicker(ticker, tickerC, current, pushMetricsConfig{})
+	re.Nil(ticker)
+	re.Nil(tickerC)
+	re.Equal(pushMetricsConfig{}, current)
 }
 
 func TestInitManager(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -342,27 +342,26 @@ func TestPushMetricsConfig(t *testing.T) {
 func TestSyncPushMetricsTicker(t *testing.T) {
 	re := require.New(t)
 
-	ticker, tickerC, current := syncPushMetricsTicker(nil, nil, pushMetricsConfig{}, pushMetricsConfig{
+	current := pushMetricsConfig{}
+	ticker := current.syncPushMetricsTicker(pushMetricsConfig{
 		address:  "127.0.0.1:9091",
 		interval: time.Second,
-	})
+	}, nil)
 	defer func() {
 		if ticker != nil {
 			ticker.Stop()
 		}
 	}()
 	re.NotNil(ticker)
-	re.NotNil(tickerC)
+	re.NotNil(ticker.C)
+	re.NotEqual(pushMetricsConfig{address: "127.0.0.1:9090", interval: time.Second}, current)
+
+	sameTicker := current.syncPushMetricsTicker(current, ticker)
+	re.Same(ticker, sameTicker)
 	re.Equal(pushMetricsConfig{address: "127.0.0.1:9091", interval: time.Second}, current)
 
-	sameTicker, sameTickerC, sameCurrent := syncPushMetricsTicker(ticker, tickerC, current, current)
-	re.Same(ticker, sameTicker)
-	re.Equal(tickerC, sameTickerC)
-	re.Equal(current, sameCurrent)
-
-	ticker, tickerC, current = syncPushMetricsTicker(ticker, tickerC, current, pushMetricsConfig{})
+	ticker = current.syncPushMetricsTicker(pushMetricsConfig{}, ticker)
 	re.Nil(ticker)
-	re.Nil(tickerC)
 	re.Equal(pushMetricsConfig{}, current)
 }
 

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -211,6 +211,15 @@ var (
 			Name:      "service_limit",
 			Help:      "Gauge of the total RU limit of specific keyspace.",
 		}, []string{keyspaceNameLabel})
+
+	pushRUMetricsDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: ruSubsystem,
+			Name:      "push_ru_metrics_duration_seconds",
+			Help:      "The duration of pushing RU metrics to Prometheus.",
+			Buckets:   prometheus.DefBuckets,
+		})
 )
 
 type metrics struct {
@@ -264,6 +273,7 @@ func init() {
 	prometheus.MustRegister(sampledRequestUnitPerSec)
 	prometheus.MustRegister(overrideSettings)
 	prometheus.MustRegister(serviceLimit)
+	prometheus.MustRegister(pushRUMetricsDuration)
 }
 
 func newMetrics() *metrics {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10833, ref #10516

Problem Summary:

This cherry-picks the resource manager change that pushes RU metrics to a metering/Prometheus pushgateway endpoint.

Original author: @zeminzhou, @disksing
Cherry-picked from: 04affc4157a74cb27ae8c176b92fe13ea9c82a74

online config：

`"push-metrics-address":"http://serverless-metering.serverless-metering:9091","push-metrics-interval":"10s"`


### What is changed and how does it work?

- Add resource manager controller config fields for `push-metrics-address` and `push-metrics-interval`.
- Add a periodic push path in the resource manager background metrics loop.
- Push read RU, write RU, and SQL-layer RU metrics with pod grouping.
- Add a histogram for RU metrics push duration.

### Check List

Tests

- Unit test
- Manual test (add detailed scripts or steps below)

Validation:

- `go test ./pkg/mcs/resourcemanager/server -run TestNonExistent -count=0`
- `go test ./pkg/mcs/resourcemanager/server -run 'TestManagerControllerConfigSnapshots|TestResourceGroupFromRawBehavior|TestSetRawStatesIntoResourceGroup' -count=1`
- `git diff upstream/master...HEAD --check`
- `GOFLAGS=-buildvcs=false make check`

Known existing baseline issue:

- `go test ./pkg/mcs/resourcemanager/server -count=1` fails on `TestCleanUpTicker`; the same test also fails on clean `upstream/master` (`9f1c47b1e`) with the same assertion, so it is not introduced by this PR.

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional periodic push of RU cost metrics to Prometheus via a configurable address and interval.
  * Added a metric measuring duration of each metrics-push operation.

* **Bug Fixes / Behavior**
  * If the configured push interval is non-positive, metrics pushing is disabled and a warning is logged to avoid misconfiguration.

* **Tests**
  * Added unit tests covering metrics push configuration and ticker synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->