### PR TITLE
mcs/scheduling: clean up resources on primary exit

### DIFF
--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -131,12 +131,16 @@ func NewCluster(
 	ctx, cancel := context.WithCancel(parentCtx)
 	labelerManager, err := labeler.NewRegionLabeler(ctx, storage, regionLabelGCInterval)
 	if err != nil {
+		storage.Close()
+		hbStreams.Close()
 		cancel()
 		return nil, err
 	}
 	ruleManager := placement.NewRuleManager(ctx, storage, basicCluster, persistConfig)
 	affinityManager, err := affinity.NewManager(ctx, storage, basicCluster, persistConfig, labelerManager)
 	if err != nil {
+		storage.Close()
+		hbStreams.Close()
 		cancel()
 		return nil, err
 	}
@@ -166,6 +170,8 @@ func NewCluster(
 	c.coordinator = schedule.NewCoordinator(ctx, c, hbStreams)
 	err = c.ruleManager.Initialize(persistConfig.GetMaxReplicas(), persistConfig.GetLocationLabels(), persistConfig.GetIsolationLevel(), true)
 	if err != nil {
+		storage.Close()
+		hbStreams.Close()
 		cancel()
 		return nil, err
 	}
@@ -200,6 +206,9 @@ func (c *Cluster) GetLabelStats() *statistics.LabelStatistics {
 
 // GetBasicCluster returns the basic cluster.
 func (c *Cluster) GetBasicCluster() *core.BasicCluster {
+	if c == nil {
+		return nil
+	}
 	return c.BasicCluster
 }
 
@@ -317,6 +326,11 @@ func (c *Cluster) SetRuntimeResources(
 	c.affinityWatcher = affinityWatcher
 }
 
+func (c *Cluster) stopCluster() {
+	c.StopBackgroundJobs()
+	c.cleanupRuntimeResources()
+}
+
 func (c *Cluster) cleanupRuntimeResources() {
 	c.runtimeMu.Lock()
 	affinityWatcher := c.affinityWatcher
@@ -324,6 +338,7 @@ func (c *Cluster) cleanupRuntimeResources() {
 	metaWatcher := c.metaWatcher
 	configWatcher := c.configWatcher
 	hbStreams := c.hbStreams
+	storage := c.storage
 	c.affinityWatcher = nil
 	c.ruleWatcher = nil
 	c.metaWatcher = nil
@@ -344,6 +359,9 @@ func (c *Cluster) cleanupRuntimeResources() {
 	}
 	if configWatcher != nil {
 		configWatcher.Close()
+	}
+	if storage != nil {
+		storage.Close()
 	}
 	if hbStreams != nil {
 		start := time.Now()
@@ -742,17 +760,19 @@ func (c *Cluster) StartBackgroundJobs() {
 }
 
 // StopBackgroundJobs stops background jobs, these jobs is created by NewCluster.
-func (c *Cluster) StopBackgroundJobs() bool {
+func (c *Cluster) StopBackgroundJobs() {
+	// always cancel the context to stop the background jobs, even if the cluster is not running, to avoid goroutine leak.
+	if c.cancel != nil {
+		c.cancel()
+	}
 	if !c.running.CompareAndSwap(true, false) {
-		return false
+		return
 	}
 	c.coordinator.Stop()
 	c.heartbeatRunner.Stop()
 	c.miscRunner.Stop()
 	c.logRunner.Stop()
-	c.cancel()
 	c.wg.Wait()
-	return true
 }
 
 // IsBackgroundJobsRunning returns whether the background jobs are running. Only for test purpose.

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -510,20 +510,10 @@ func (s *Server) startCluster(ctx context.Context) error {
 		metaWatcher     *meta.Watcher
 		ruleWatcher     *rule.Watcher
 		affinityWatcher *affinity.Watcher
+		cluster         *Cluster
 		err             error
 	)
-	metaWatcher, configWatcher, err = s.startMetaConfWatcher(ctx, basicCluster, storage)
-	if err != nil {
-		if configWatcher != nil {
-			configWatcher.Close()
-		}
-		if metaWatcher != nil {
-			metaWatcher.Close()
-		}
-		return err
-	}
-	hbStreams = hbstream.NewHeartbeatStreams(ctx, constant.SchedulingServiceName, basicCluster)
-	cluster, err := NewCluster(ctx, s.persistConfig, storage, basicCluster, hbStreams, s.checkMembershipCh, s.GetHTTPClient(), s.GetBackendEndpoints())
+
 	var initSucceeded bool
 	defer func() {
 		if initSucceeded {
@@ -531,12 +521,7 @@ func (s *Server) startCluster(ctx context.Context) error {
 		}
 		// make sure cancel context done when some initialization step failed, to avoid goroutine leak in cluster.
 		if cluster != nil {
-			if stopped := cluster.StopBackgroundJobs(); !stopped {
-				if cluster.cancel != nil {
-					cluster.cancel()
-					cluster.cancel = nil
-				}
-			}
+			cluster.stopCluster()
 		}
 		// clean new sources
 		if hbStreams != nil {
@@ -559,15 +544,25 @@ func (s *Server) startCluster(ctx context.Context) error {
 			affinityWatcher.Close()
 			affinityWatcher = nil
 		}
-		storage.Close()
+		if storage != nil {
+			storage.Close()
+		}
 	}()
+	metaWatcher, configWatcher, err = s.startMetaConfWatcher(ctx, basicCluster, storage)
+	if err != nil {
+		return err
+	}
+	hbStreams = hbstream.NewHeartbeatStreams(ctx, constant.SchedulingServiceName, basicCluster)
+	cluster, err = NewCluster(ctx, s.persistConfig, storage, basicCluster, hbStreams, s.checkMembershipCh, s.GetHTTPClient(), s.GetBackendEndpoints())
+	storage = nil
+	hbStreams = nil
 	if err != nil {
 		return err
 	}
 
 	am := cluster.GetAffinityManager()
 	configWatcher.SetSchedulersController(cluster.GetCoordinator().GetSchedulersController())
-	ruleWatcher, err = rule.NewWatcher(ctx, s.GetClient(), storage,
+	ruleWatcher, err = rule.NewWatcher(ctx, s.GetClient(), cluster.GetStorage(),
 		cluster.GetCoordinator().GetCheckerController(), cluster.GetRuleManager(), cluster.GetRegionLabeler())
 	if err != nil {
 		return err
@@ -578,8 +573,14 @@ func (s *Server) startCluster(ctx context.Context) error {
 	}
 
 	cluster.SetRuntimeResources(metaWatcher, configWatcher, ruleWatcher, affinityWatcher)
-	s.cluster.Store(cluster)
+	// Set watchers to nil to avoid being closed in defer when cluster initialization is successful,
+	// since cluster will take over the ownership of these watchers and close them when stopping cluster.
+	metaWatcher = nil
+	configWatcher = nil
+	ruleWatcher = nil
+	affinityWatcher = nil
 	cluster.StartBackgroundJobs()
+	s.cluster.Store(cluster)
 	initSucceeded = true
 	return nil
 }
@@ -587,8 +588,7 @@ func (s *Server) startCluster(ctx context.Context) error {
 func (s *Server) stopCluster() {
 	if cluster := s.GetCluster(); cluster != nil {
 		s.cluster.Store((*Cluster)(nil))
-		cluster.StopBackgroundJobs()
-		cluster.cleanupRuntimeResources()
+		cluster.stopCluster()
 	}
 }
 

--- a/pkg/mcs/scheduling/server/server_test.go
+++ b/pkg/mcs/scheduling/server/server_test.go
@@ -54,6 +54,16 @@ func TestStopCluster(t *testing.T) {
 	re.Nil(cluster.GetStorage())
 }
 
+func TestGetClusterBeforeStoredDoesNotPanic(t *testing.T) {
+	re := require.New(t)
+	s := &Server{}
+
+	re.NotPanics(func() {
+		re.Nil(s.GetCluster())
+		re.Nil(s.GetBasicCluster())
+	})
+}
+
 // TestMultipleLeaderTermsNoHbStreamGoroutineLeak is a regression test for the
 // production memory leak where each leader→follower transition left behind a
 // leaked hbstream.run() goroutine. The leaked goroutines held a strong GC root

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -296,6 +296,12 @@ func (c *Controller) PauseOrResumeScheduler(name string, t int64) error {
 
 // ReloadSchedulerConfig reloads a scheduler's config if it exists.
 func (c *Controller) ReloadSchedulerConfig(name string) error {
+	c.RLock()
+	if c.cluster == nil {
+		c.RUnlock()
+		return errs.ErrNotBootstrapped.FastGenByArgs()
+	}
+	c.RUnlock()
 	if exist, _ := c.IsSchedulerExisted(name); !exist {
 		return errs.ErrSchedulerNotFound.FastGenByArgs()
 	}

--- a/pkg/schedule/schedulers/scheduler_test.go
+++ b/pkg/schedule/schedulers/scheduler_test.go
@@ -62,6 +62,19 @@ func prepareSchedulersTest(needToRunStream ...bool) (func(), config.SchedulerCon
 	return clean, opt, tc, oc
 }
 
+func TestReloadSchedulerConfigWithoutSchedulerDoesNotPanic(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	c := NewController(context.Background(), tc, storage.NewStorageWithMemoryBackend(), oc)
+	c.schedulerHandlers["test-scheduler"] = nil
+
+	re.NotPanics(func() {
+		re.Error(c.ReloadSchedulerConfig("test-scheduler"))
+	})
+}
+
 func TestShuffleLeader(t *testing.T) {
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10644

This PR fixes leaked scheduling primary-scoped resources after the scheduling
primary exits or fails during startup.

### What is changed and how does it work?

```commit-message
Clean up scheduling primary-scoped runtime resources when the primary exits.
Close heartbeat streams, storage, and metadata/config/rule/affinity watchers on
primary shutdown or failed startup, and make background-job cancellation run even
when jobs have not been fully started.

Also guard scheduler config reload and basic cluster access against nil cluster
state during primary transitions.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix resource leaks when the scheduling primary exits or fails to start.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer, deterministic shutdown and cleanup during startup failures; background jobs and runtime resources are stopped and closed in a clearer order to avoid leaks or double-close.
  * Getters now return nil rather than panic when the cluster isn't initialized.
  * Scheduler reloads handle missing schedulers without races or panics.

* **Tests**
  * Added regression tests ensuring early-access getters and scheduler reloads do not panic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->