### PR TITLE
[WIP]resource_group: add rcu tracker and record consume rate

### DIFF
--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -46,6 +46,7 @@ const (
 	metricsCleanupTimeout     = 20 * time.Minute
 	defaultCollectIntervalSec = 20
 	tickPerSecond             = time.Second
+	rcuMetricsInterval        = 10 * time.Second
 )
 
 // Manager is the manager of resource group.
@@ -718,6 +719,8 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 	defer cleanUpTicker.Stop()
 	metricsTicker := time.NewTicker(tickPerSecond)
 	defer metricsTicker.Stop()
+	rcuTicker := time.NewTicker(rcuMetricsInterval)
+	defer rcuTicker.Stop()
 	failpoint.Inject("fastCleanupTicker", func() {
 		cleanUpTicker.Reset(100 * time.Millisecond)
 	})
@@ -795,6 +798,21 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 					if grt := krgm.getGroupRUTracker(groupName); grt != nil {
 						metrics.setSampledRUPerSec(grt.getRUPerSec())
 					}
+				}
+			}
+		case <-rcuTicker.C:
+			controllerConfig := m.GetControllerConfig()
+			if controllerConfig == nil {
+				continue
+			}
+			for _, krgm := range m.getKeyspaceResourceGroupManagers() {
+				for _, group := range krgm.getResourceGroupList(true, true) {
+					m.metrics.flushRCUTracker(
+						krgm.keyspaceID,
+						group.Name,
+						group.getFillRate(),
+						controllerConfig.RequestUnit.CPUMsCost,
+					)
 				}
 			}
 		}

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -332,14 +332,25 @@ func (m *metrics) getRCUTracker(keyspaceID uint32, keyspaceName, groupName strin
 	return tracker
 }
 
-func (m *metrics) deleteRCUTracker(keyspaceID uint32, groupName string) {
+func (m *metrics) deleteRCUTracker(keyspaceID uint32, keyspaceName, groupName string) {
 	delete(m.rcuTrackerMap, trackerKey{keyspaceID, groupName})
+	requestUnitSumPerSec.DeleteLabelValues(groupName, keyspaceName)
+	requestUnitConsumeRate.DeleteLabelValues(groupName, keyspaceName)
 }
 
 func (m *metrics) flushRCUTracker(keyspaceID uint32, groupName string, fillRate, cpuMsCost float64) {
 	if tracker := m.rcuTrackerMap[trackerKey{keyspaceID, groupName}]; tracker != nil {
 		tracker.flushMetrics(fillRate, cpuMsCost)
 	}
+}
+
+func (m *metrics) hasConsumptionRecord(keyspaceID uint32, groupName string) bool {
+	for r := range m.consumptionRecordMap {
+		if r.keyspaceID == keyspaceID && r.groupName == groupName {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) *counterMetrics {
@@ -390,7 +401,9 @@ func (m *metrics) cleanupAllMetrics(r consumptionRecordKey, keyspaceName string)
 	m.deleteConsumptionRecord(r)
 	m.deleteMetrics(r.keyspaceID, keyspaceName, r.groupName, r.ruType)
 	m.deleteMaxPerSecTracker(r.keyspaceID, r.groupName)
-	m.deleteRCUTracker(r.keyspaceID, r.groupName)
+	if !m.hasConsumptionRecord(r.keyspaceID, r.groupName) {
+		m.deleteRCUTracker(r.keyspaceID, keyspaceName, r.groupName)
+	}
 }
 
 type counterMetrics struct {
@@ -582,8 +595,6 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	readRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
 	writeRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
 	sampledRequestUnitPerSec.DeleteLabelValues(groupName, keyspaceName)
-	requestUnitSumPerSec.DeleteLabelValues(groupName, keyspaceName)
-	requestUnitConsumeRate.DeleteLabelValues(groupName, keyspaceName)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, fillRateLabel)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)
 	resourceGroupConfigGauge.DeletePartialMatch(prometheus.Labels{newResourceGroupNameLabel: groupName, keyspaceNameLabel: keyspaceName})
@@ -684,6 +695,8 @@ func (t *rcuTracker) flushMetrics(fillRate, cpuMsCost float64) {
 	t.rcuMetrics.Set(rcu)
 	if fillRate > 0 {
 		t.consumeRateMetrics.Set(rcu / fillRate)
+	} else {
+		t.consumeRateMetrics.Set(0)
 	}
 }
 

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -211,6 +211,22 @@ var (
 			Name:      "service_limit",
 			Help:      "Gauge of the total RU limit of specific keyspace.",
 		}, []string{keyspaceNameLabel})
+
+	requestUnitSumPerSec = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: ruSubsystem,
+			Name:      "request_unit_sum_per_sec",
+			Help:      "The number of the request unit cost per second for all resource groups.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+
+	requestUnitConsumeRate = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: ruSubsystem,
+			Name:      "request_unit_consume_rate",
+			Help:      "request_unit_per_second/fill_rate for all resource groups.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
 )
 
 type metrics struct {
@@ -218,6 +234,8 @@ type metrics struct {
 	consumptionRecordMap map[consumptionRecordKey]time.Time
 	// max per sec trackers for each keyspace and resource group.
 	maxPerSecTrackerMap map[trackerKey]*maxPerSecCostTracker
+	// rcu trackers for each keyspace and resource group.
+	rcuTrackerMap map[trackerKey]*rcuTracker
 	// cached counter metrics for each keyspace, resource group and RU type.
 	counterMetricsMap map[metricsKey]*counterMetrics
 	// cached gauge metrics for each keyspace, resource group and RU type.
@@ -264,12 +282,15 @@ func init() {
 	prometheus.MustRegister(sampledRequestUnitPerSec)
 	prometheus.MustRegister(overrideSettings)
 	prometheus.MustRegister(serviceLimit)
+	prometheus.MustRegister(requestUnitSumPerSec)
+	prometheus.MustRegister(requestUnitConsumeRate)
 }
 
 func newMetrics() *metrics {
 	return &metrics{
 		consumptionRecordMap: make(map[consumptionRecordKey]time.Time),
 		maxPerSecTrackerMap:  make(map[trackerKey]*maxPerSecCostTracker),
+		rcuTrackerMap:        make(map[trackerKey]*rcuTracker),
 		counterMetricsMap:    make(map[metricsKey]*counterMetrics),
 		gaugeMetricsMap:      make(map[metricsKey]*gaugeMetrics),
 	}
@@ -300,6 +321,25 @@ func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName
 
 func (m *metrics) deleteMaxPerSecTracker(keyspaceID uint32, groupName string) {
 	delete(m.maxPerSecTrackerMap, trackerKey{keyspaceID, groupName})
+}
+
+func (m *metrics) getRCUTracker(keyspaceID uint32, keyspaceName, groupName string) *rcuTracker {
+	tracker := m.rcuTrackerMap[trackerKey{keyspaceID, groupName}]
+	if tracker == nil {
+		tracker = newRCUTracker(keyspaceName, groupName)
+		m.rcuTrackerMap[trackerKey{keyspaceID, groupName}] = tracker
+	}
+	return tracker
+}
+
+func (m *metrics) deleteRCUTracker(keyspaceID uint32, groupName string) {
+	delete(m.rcuTrackerMap, trackerKey{keyspaceID, groupName})
+}
+
+func (m *metrics) flushRCUTracker(keyspaceID uint32, groupName string, fillRate, cpuMsCost float64) {
+	if tracker := m.rcuTrackerMap[trackerKey{keyspaceID, groupName}]; tracker != nil {
+		tracker.flushMetrics(fillRate, cpuMsCost)
+	}
 }
 
 func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) *counterMetrics {
@@ -341,6 +381,7 @@ func (m *metrics) recordConsumption(
 	}
 	consumption := consumptionInfo.Consumption
 	m.getMaxPerSecTracker(keyspaceID, keyspaceName, groupName).collect(consumption)
+	m.getRCUTracker(keyspaceID, keyspaceName, groupName).collect(consumption)
 	m.getCounterMetrics(keyspaceID, keyspaceName, groupName, ruLabelType).add(consumption, controllerConfig, keyspaceID)
 	m.insertConsumptionRecord(keyspaceID, groupName, ruLabelType, now)
 }
@@ -349,6 +390,7 @@ func (m *metrics) cleanupAllMetrics(r consumptionRecordKey, keyspaceName string)
 	m.deleteConsumptionRecord(r)
 	m.deleteMetrics(r.keyspaceID, keyspaceName, r.groupName, r.ruType)
 	m.deleteMaxPerSecTracker(r.keyspaceID, r.groupName)
+	m.deleteRCUTracker(r.keyspaceID, r.groupName)
 }
 
 type counterMetrics struct {
@@ -540,6 +582,8 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	readRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
 	writeRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
 	sampledRequestUnitPerSec.DeleteLabelValues(groupName, keyspaceName)
+	requestUnitSumPerSec.DeleteLabelValues(groupName, keyspaceName)
+	requestUnitConsumeRate.DeleteLabelValues(groupName, keyspaceName)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, fillRateLabel)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)
 	resourceGroupConfigGauge.DeletePartialMatch(prometheus.Labels{newResourceGroupNameLabel: groupName, keyspaceNameLabel: keyspaceName})
@@ -598,6 +642,48 @@ func (t *maxPerSecCostTracker) flushMetrics() {
 		t.wruMaxMetrics.Set(t.maxPerSecWRU)
 		t.maxPerSecRRU = 0
 		t.maxPerSecWRU = 0
+	}
+}
+
+type rcuTracker struct {
+	totalRU, totalCPUTimeMs float64
+	lastRU, lastCPUTimeMs   float64
+	lastFlushTime           time.Time
+	rcuMetrics              prometheus.Gauge
+	consumeRateMetrics      prometheus.Gauge
+}
+
+func newRCUTracker(keyspaceName, groupName string) *rcuTracker {
+	return &rcuTracker{
+		rcuMetrics:         requestUnitSumPerSec.WithLabelValues(groupName, keyspaceName),
+		consumeRateMetrics: requestUnitConsumeRate.WithLabelValues(groupName, keyspaceName),
+	}
+}
+
+func (t *rcuTracker) collect(consume *rmpb.Consumption) {
+	t.totalRU += consume.RRU + consume.WRU
+	t.totalCPUTimeMs += consume.TotalCpuTimeMs
+}
+
+func (t *rcuTracker) flushMetrics(fillRate, cpuMsCost float64) {
+	if t.lastRU == 0 && t.lastCPUTimeMs == 0 {
+		t.lastRU, t.lastCPUTimeMs = t.totalRU, t.totalCPUTimeMs
+		t.lastFlushTime = time.Now()
+		return
+	}
+
+	deltaRU := t.totalRU - t.lastRU + (t.totalCPUTimeMs-t.lastCPUTimeMs)*cpuMsCost
+	deltaTime := time.Since(t.lastFlushTime).Seconds()
+	if deltaTime <= 0 {
+		return
+	}
+	rcu := deltaRU / deltaTime
+	t.lastRU, t.lastCPUTimeMs = t.totalRU, t.totalCPUTimeMs
+	t.lastFlushTime = time.Now()
+
+	t.rcuMetrics.Set(rcu)
+	if fillRate > 0 {
+		t.consumeRateMetrics.Set(rcu / fillRate)
 	}
 }
 

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -147,4 +147,53 @@ func TestRCUTracker(t *testing.T) {
 
 	re.InEpsilon(float64(20), testutil.ToFloat64(tracker.rcuMetrics), 0.01)
 	re.InEpsilon(float64(0.2), testutil.ToFloat64(tracker.consumeRateMetrics), 0.01)
+
+	tracker.collect(&rmpb.Consumption{
+		RRU:            20,
+		WRU:            10,
+		TotalCpuTimeMs: 5,
+	})
+	tracker.lastFlushTime = time.Now().Add(-2 * time.Second)
+	tracker.flushMetrics(0, 2)
+
+	re.InEpsilon(float64(20), testutil.ToFloat64(tracker.rcuMetrics), 0.01)
+	re.Zero(testutil.ToFloat64(tracker.consumeRateMetrics))
+}
+
+func TestCleanupAllMetricsKeepsRCUTrackerForActiveGroup(t *testing.T) {
+	re := require.New(t)
+
+	const (
+		keyspaceName = "cleanup-rcu-keyspace"
+		groupName    = "cleanup-rcu-group"
+		keyspaceID   = uint32(303)
+	)
+
+	t.Cleanup(func() {
+		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+		deleteLabelValues(keyspaceName, groupName, backgroundTypeLabel)
+		requestUnitSumPerSec.DeleteLabelValues(groupName, keyspaceName)
+		requestUnitConsumeRate.DeleteLabelValues(groupName, keyspaceName)
+	})
+
+	metrics := newMetrics()
+	metrics.getRCUTracker(keyspaceID, keyspaceName, groupName)
+	metrics.insertConsumptionRecord(keyspaceID, groupName, defaultTypeLabel, time.Now())
+	metrics.insertConsumptionRecord(keyspaceID, groupName, backgroundTypeLabel, time.Now())
+
+	metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     defaultTypeLabel,
+	}, keyspaceName)
+
+	re.Contains(metrics.rcuTrackerMap, trackerKey{keyspaceID: keyspaceID, groupName: groupName})
+
+	metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     backgroundTypeLabel,
+	}, keyspaceName)
+
+	re.NotContains(metrics.rcuTrackerMap, trackerKey{keyspaceID: keyspaceID, groupName: groupName})
 }

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -113,4 +114,37 @@ func TestMaxPerSecCostTracker(t *testing.T) {
 			re.Equal(tracker.rruSum, expectedSum[period])
 		}
 	}
+}
+
+func TestRCUTracker(t *testing.T) {
+	re := require.New(t)
+
+	const (
+		keyspaceName = "rcu-test-keyspace"
+		groupName    = "rcu-test-group"
+	)
+
+	t.Cleanup(func() {
+		requestUnitSumPerSec.DeleteLabelValues(groupName, keyspaceName)
+		requestUnitConsumeRate.DeleteLabelValues(groupName, keyspaceName)
+	})
+
+	tracker := newRCUTracker(keyspaceName, groupName)
+	tracker.collect(&rmpb.Consumption{
+		RRU:            10,
+		WRU:            5,
+		TotalCpuTimeMs: 2,
+	})
+	tracker.flushMetrics(100, 2)
+
+	tracker.collect(&rmpb.Consumption{
+		RRU:            20,
+		WRU:            10,
+		TotalCpuTimeMs: 5,
+	})
+	tracker.lastFlushTime = time.Now().Add(-2 * time.Second)
+	tracker.flushMetrics(100, 2)
+
+	re.InEpsilon(float64(20), testutil.ToFloat64(tracker.rcuMetrics), 0.01)
+	re.InEpsilon(float64(0.2), testutil.ToFloat64(tracker.consumeRateMetrics), 0.01)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10840, ref #10516

### What is changed and how does it work?

```commit-message
resource_group: add rcu tracker and record consume rate
```

This cherry-picks and adapts the Resource Manager RCU tracking change from `a6b85376d74f87e23c5ab71a962181e387ba3446` by @disksing.

The change records:
- `resource_manager_resource_unit_request_unit_sum_per_sec`
- `resource_manager_resource_unit_request_unit_consume_rate`

Adaptation notes:
- Integrated the tracker into the current keyspace-aware Resource Manager metrics cache.
- Preserved the 10s RCU flush interval from the source change.
- Added unit coverage for the RCU tracker calculation.

Validation:
- `go test ./pkg/mcs/resourcemanager/server -run 'TestRCUTracker|TestMaxPerSecCostTracker|TestActiveRequestUnitMetric' -count=1`
- `git diff --check HEAD~1..HEAD`
- `GOFLAGS=-buildvcs=false make check`

Known baseline:
- `go test ./pkg/mcs/resourcemanager/server -count=1` still fails on `TestCleanUpTicker`, which was already reproduced on clean latest master before this task.

### Check List

Tests

- Unit test

Code changes

- None

Side effects

- Increased code complexity

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-keyspace and per-resource-group RUv2 metrics: total RU/s and consumption rate (RU/s vs fill rate), with periodic flushing driven by controller configuration.
* **Tests**
  * Unit tests added for the Request Unit tracker and metric flush/cleanup behavior to validate rate calculations and lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->