### PR TITLE
server: skip campaign until region syncer history phase is done

### DIFF
--- a/pkg/storage/endpoint/region_syncer.go
+++ b/pkg/storage/endpoint/region_syncer.go
@@ -1,0 +1,54 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"strconv"
+
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/utils/keypath"
+)
+
+// RegionSyncerStorage defines the storage operations on the region syncer's
+// cluster-level committed state.
+type RegionSyncerStorage interface {
+	LoadRegionSyncerCommittedRegionCount() (uint64, error)
+	SaveRegionSyncerCommittedRegionCount(count uint64) error
+}
+
+var _ RegionSyncerStorage = (*StorageEndpoint)(nil)
+
+// LoadRegionSyncerCommittedRegionCount loads the region count the current
+// leader last published. It returns (0, nil) when the key is absent (a fresh
+// cluster or one upgraded from a version that never wrote it), which callers
+// treat as "no committed regions".
+func (se *StorageEndpoint) LoadRegionSyncerCommittedRegionCount() (uint64, error) {
+	value, err := se.Load(keypath.RegionSyncerCommittedRegionCountPath())
+	if err != nil || value == "" {
+		return 0, err
+	}
+	count, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, errs.ErrStrconvParseUint.Wrap(err).GenWithStackByArgs()
+	}
+	return count, nil
+}
+
+// SaveRegionSyncerCommittedRegionCount persists the region count the current
+// leader is serving so other members can tell whether they are caught up
+// before campaigning for PD leadership.
+func (se *StorageEndpoint) SaveRegionSyncerCommittedRegionCount(count uint64) error {
+	return se.Save(keypath.RegionSyncerCommittedRegionCountPath(), strconv.FormatUint(count, 10))
+}

--- a/pkg/storage/endpoint/region_syncer_test.go
+++ b/pkg/storage/endpoint/region_syncer_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/keypath"
+)
+
+// newMemStorageEndpoint returns a StorageEndpoint backed by an in-memory KV,
+// for tests that exercise endpoint encode/decode round-trips without etcd.
+func newMemStorageEndpoint() *StorageEndpoint {
+	return NewStorageEndpoint(kv.NewMemoryKV(), nil)
+}
+
+// TestRegionSyncerCommittedRegionCountAbsent verifies the back-compat path the
+// leader-election gate relies on: an unwritten key (fresh or pre-upgrade
+// cluster) must read back as (0, nil) rather than an error, so the gate treats
+// it as "no committed regions" and allows the campaign.
+func TestRegionSyncerCommittedRegionCountAbsent(t *testing.T) {
+	re := require.New(t)
+	se := newMemStorageEndpoint()
+
+	count, err := se.LoadRegionSyncerCommittedRegionCount()
+	re.NoError(err)
+	re.Equal(uint64(0), count)
+}
+
+// TestRegionSyncerCommittedRegionCountRoundTrip verifies Save/Load preserves the
+// value across the uint64<->string boundary, including the zero (empty cluster)
+// and max-uint64 edges, and that a later Save overwrites the prior value.
+func TestRegionSyncerCommittedRegionCountRoundTrip(t *testing.T) {
+	re := require.New(t)
+	se := newMemStorageEndpoint()
+
+	for _, want := range []uint64{0, 1, 110, math.MaxUint64} {
+		re.NoError(se.SaveRegionSyncerCommittedRegionCount(want))
+		got, err := se.LoadRegionSyncerCommittedRegionCount()
+		re.NoError(err)
+		re.Equal(want, got)
+	}
+
+	// A subsequent write replaces the prior value (counts shrink on merges).
+	re.NoError(se.SaveRegionSyncerCommittedRegionCount(42))
+	got, err := se.LoadRegionSyncerCommittedRegionCount()
+	re.NoError(err)
+	re.Equal(uint64(42), got)
+}
+
+// TestRegionSyncerCommittedRegionCountCorruptValue verifies a non-numeric value
+// (corruption or a manual edit) surfaces as an error so the gate falls back to
+// allowing the campaign rather than silently treating it as zero.
+func TestRegionSyncerCommittedRegionCountCorruptValue(t *testing.T) {
+	re := require.New(t)
+	se := newMemStorageEndpoint()
+
+	re.NoError(se.Save(keypath.RegionSyncerCommittedRegionCountPath(), "not-a-number"))
+	_, err := se.LoadRegionSyncerCommittedRegionCount()
+	re.Error(err)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -43,6 +43,7 @@ type Storage interface {
 	endpoint.GCStateStorage
 	endpoint.MinResolvedTSStorage
 	endpoint.ExternalTSStorage
+	endpoint.RegionSyncerStorage
 	endpoint.KeyspaceStorage
 	endpoint.ResourceGroupStorage
 	endpoint.TSOStorage

--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -53,6 +53,14 @@ const (
 func (s *RegionSyncer) StopSyncWithLeader() {
 	s.reset()
 	s.wg.Wait()
+	// If this sync session never observed an end-of-history marker, the
+	// in-memory history index reflects a partial transfer that the leader
+	// never confirmed. Roll back to the last committed (persisted) index
+	// so the next leader sees a StartIndex that triggers a fresh bulk
+	// rather than a stale offset into a different leader's history space.
+	if !s.historySynced.Load() {
+		s.history.rollback()
+	}
 }
 
 func (s *RegionSyncer) reset() {
@@ -68,6 +76,22 @@ func (s *RegionSyncer) reset() {
 // ResetHistoryIndex resets and persists the next region sync history index.
 func (s *RegionSyncer) ResetHistoryIndex(index uint64) {
 	s.history.resetWithIndexAndPersist(index)
+}
+
+// HasAttemptedSync reports whether StartSyncWithLeader has ever been called
+// during this process's lifetime. Used by the leader-election path to tell
+// "I am a fresh single-node cluster" apart from "I am a follower that needs
+// to be caught up before campaigning".
+func (s *RegionSyncer) HasAttemptedSync() bool {
+	return s.attemptedSync.Load()
+}
+
+// IsHistorySynced reports whether this server has, at some point during its
+// lifetime, observed that it was caught up to a leader's history. The signal
+// is sticky: once true, the local region storage is durably populated and
+// further syncs only extend that state.
+func (s *RegionSyncer) IsHistorySynced() bool {
+	return s.historySynced.Load()
 }
 
 func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (ClientStream, error) {
@@ -126,6 +150,22 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 	}
 	hasStats := len(stats) == len(regions)
 	hasBuckets := len(buckets) == len(regions)
+	// An empty-regions response is the explicit end-of-history
+	// marker: sent by the leader at the end of a bulk transfer,
+	// at the end of an incremental catch-up, as an "already in
+	// sync" reply, or as a keepalive. Receiving one commits the
+	// historical phase — we flush the accumulated history index
+	// to disk and flip historySynced, which both opens the
+	// leader-election gate and switches subsequent records from
+	// the non-persisting catch-up path to the normal persisting
+	// live-stream path.
+	if len(regions) == 0 {
+		if !s.historySynced.Load() {
+			s.history.commit()
+		}
+		s.historySynced.Store(true)
+	}
+	inCatchup := !s.historySynced.Load()
 	for i, r := range regions {
 		var (
 			region       *core.RegionInfo
@@ -165,7 +205,16 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 			err = regionStorage.SaveRegion(r)
 		}
 		if err == nil && !inFullSync {
-			s.history.record(region)
+			// Full-sync frames carry positional offsets, not reusable history
+			// indices, so they are applied to storage but not recorded here.
+			// Records during historical catch-up are buffered without persisting
+			// and flushed by commit() on the end-of-history marker; live records
+			// after catch-up persist normally.
+			if inCatchup {
+				s.history.recordNoPersist(region)
+			} else {
+				s.history.record(region)
+			}
 		}
 		for _, old := range overlaps {
 			_ = regionStorage.DeleteRegion(old.GetMeta())
@@ -187,7 +236,7 @@ func (s *RegionSyncer) IsRunning() bool {
 // StartSyncWithLeader starts to sync with leader.
 func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 	s.wg.Add(1)
-
+	s.attemptedSync.Store(true)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.clientCtx, s.mu.clientCancel = context.WithCancel(s.server.LoopContext())

--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -114,6 +114,9 @@ func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (C
 
 var regionGuide = core.GenerateRegionGuideFunc(false)
 
+// handleRegionSyncResponse applies one sync response from the leader to the
+// follower's region cache, storage, and history buffer. It returns whether the
+// response was handled and whether a full sync is still in progress.
 func (s *RegionSyncer) handleRegionSyncResponse(
 	ctx context.Context,
 	resp *pdpb.SyncRegionResponse,

--- a/pkg/syncer/client_test.go
+++ b/pkg/syncer/client_test.go
@@ -16,6 +16,7 @@ package syncer
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockserver"
 	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -71,6 +73,54 @@ func TestLoadRegion(t *testing.T) {
 	rc.StopSyncWithLeader()
 	re.Greater(time.Since(start), time.Second) // make sure failpoint is injected
 	re.Less(time.Since(start), time.Second*2)
+}
+
+// TestHistorySyncedInitFromDurableState verifies that NewRegionSyncer
+// seeds historySynced from the persisted history index so a node that
+// previously completed a sync can still campaign after a restart followed
+// by a leader death mid-sync. A fresh-on-disk node must stay false so it
+// is forced through a real catch-up before it can campaign.
+func TestHistorySyncedInitFromDurableState(t *testing.T) {
+	re := require.New(t)
+
+	newSyncer := func(seed func(kv.Base)) *RegionSyncer {
+		tempDir := t.TempDir()
+		rs, err := storage.NewRegionStorageWithLevelDBBackend(context.Background(), tempDir, nil)
+		re.NoError(err)
+		t.Cleanup(func() { re.NoError(rs.Close()) })
+		seed(rs)
+		server := mockserver.NewMockServer(
+			context.Background(),
+			nil,
+			nil,
+			storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), rs),
+			core.NewBasicCluster(),
+		)
+		return NewRegionSyncer(server)
+	}
+
+	// Fresh KV: no persisted historyIndex. Stays false so the node is
+	// gated until it actually catches up to a leader.
+	rc := newSyncer(func(kv.Base) {})
+	re.False(rc.IsHistorySynced(),
+		"fresh KV should not be treated as already synced")
+
+	// Persisted historyIndex from a prior successful sync. The index only
+	// ever lands on disk after SaveRegion calls succeeded (via commit() or
+	// record()'s flushCount path), so a non-zero index is sufficient
+	// evidence of durable region state.
+	rc = newSyncer(func(b kv.Base) {
+		re.NoError(b.Save(historyKey, "42"))
+	})
+	re.True(rc.IsHistorySynced(),
+		"persisted history index must initialize historySynced to true")
+	re.Equal(uint64(42), rc.history.getNextIndex(),
+		"history index should reload the persisted value")
+	// Sanity: a value that round-trips through strconv matches what
+	// history_buffer's persist path writes.
+	v, err := strconv.ParseUint("42", 10, 64)
+	re.NoError(err)
+	re.Equal(rc.history.getNextIndex(), v)
 }
 
 func TestErrorCode(t *testing.T) {

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -142,6 +142,23 @@ func (h *historyBuffer) record(r *core.RegionInfo) {
 	}
 }
 
+// recordNoPersist is like record but does not advance the on-disk
+// historyIndex. The syncer client uses it during a historical catch-up
+// so that a partially-received bulk does not commit a non-zero index; if
+// the catch-up is interrupted (leader failover, process crash), the next
+// sync starts from the last committed index instead of the middle of a
+// half-applied transfer.
+func (h *historyBuffer) recordNoPersist(r *core.RegionInfo) {
+	h.Lock()
+	defer h.Unlock()
+	syncIndexGauge.Set(float64(h.index))
+	h.records[h.tail] = r
+	h.tail = (h.tail + 1) % h.size
+	if h.tail == h.head {
+		h.head = (h.head + 1) % h.size
+	}
+	h.index++
+}
 func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
 	h.RLock()
 	defer h.RUnlock()
@@ -385,4 +402,29 @@ func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
 		return h.records[pos]
 	}
 	return nil
+}
+
+// commit persists the current historyIndex. The syncer client calls this
+// when an end-of-history marker is received, to atomically commit a bulk
+// or catch-up transfer.
+func (h *historyBuffer) commit() {
+	h.Lock()
+	defer h.Unlock()
+	h.persist()
+	h.flushCount = defaultFlushCount
+}
+
+// rollback resets the in-memory historyIndex back to the last value
+// persisted on disk and clears the ring buffer. The syncer client calls
+// this when a sync session ends without ever receiving an end-of-history
+// marker, so the next sync starts from the last committed index (0 for a
+// fresh member that never completed a catch-up).
+func (h *historyBuffer) rollback() {
+	h.Lock()
+	defer h.Unlock()
+	h.index = 0
+	h.head = 0
+	h.tail = 0
+	h.flushCount = defaultFlushCount
+	h.reload()
 }

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -122,6 +122,8 @@ func (h *historyBuffer) capacity() int {
 	return h.size - 1
 }
 
+// record appends a region change to the history buffer, advancing the next
+// index and periodically persisting it to the backing storage.
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
@@ -396,6 +398,8 @@ func (h *historyBuffer) resizeLocked(newCapacity int) {
 	h.tail = keep % h.size
 }
 
+// getLocked returns the region recorded at the given history index, or nil if
+// the index is outside the retained window. The caller must hold the lock.
 func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
 	if index < h.nextIndex() && index >= h.firstIndex() {
 		pos := (h.head + int(index-h.firstIndex())) % h.size

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -186,6 +186,8 @@ func TestHistoryBufferShrinksOneStepAfterRequiredWindowStaysLow(t *testing.T) {
 	re.Equal(4, h.capacity())
 }
 
+// newTestHistoryBuffer returns a history buffer backed by in-memory storage for
+// use in tests.
 func newTestHistoryBuffer(maxCapacity int) *historyBuffer {
 	return newHistoryBufferWithConfig(2, maxCapacity, 1, storage.NewStorageWithMemoryBackend())
 }

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -193,3 +193,77 @@ func newTestHistoryBuffer(maxCapacity int) *historyBuffer {
 func newHistoryBufferTestRegion(regionID uint64) *core.RegionInfo {
 	return core.NewRegionInfo(&metapb.Region{Id: regionID}, nil)
 }
+
+// TestCatchupCommitRollback exercises the catch-up gating semantics added
+// for the leader-election gate: a half-applied catch-up that is cut short
+// must not leave a non-zero persisted index behind, and a clean end-of-
+// history must commit the new index atomically.
+func TestCatchupCommitRollback(t *testing.T) {
+	re := require.New(t)
+	var regions []*core.RegionInfo
+	for i := range 10 {
+		regions = append(regions, core.NewRegionInfo(&metapb.Region{Id: uint64(i + 1)}, nil))
+	}
+
+	// Fresh member: nothing persisted, in-memory index starts at 0.
+	kvMem := kv.NewMemoryKV()
+	h := newHistoryBufferWithConfig(100, 100, 1, kvMem)
+	re.Equal(uint64(0), h.nextIndex())
+	s, err := kvMem.Load(historyKey)
+	re.NoError(err)
+	re.Empty(s)
+
+	// Apply a catch-up batch without persisting. In-memory index advances
+	// but the on-disk index must stay at 0.
+	for _, r := range regions[:5] {
+		h.recordNoPersist(r)
+	}
+	re.Equal(uint64(5), h.nextIndex())
+	s, err = kvMem.Load(historyKey)
+	re.NoError(err)
+	re.Empty(s)
+
+	// Simulate leader failover before end-of-history: rollback must wipe
+	// the buffered records and restore the in-memory index to the last
+	// persisted value (0 here).
+	h.rollback()
+	re.Equal(uint64(0), h.nextIndex())
+	re.Equal(0, h.len())
+	re.Nil(h.get(0))
+	re.Nil(h.get(4))
+
+	// Re-attempt the catch-up against a new leader. This time we receive
+	// the end-of-history marker, so commit() persists the index.
+	for _, r := range regions[:5] {
+		h.recordNoPersist(r)
+	}
+	h.commit()
+	re.Equal(uint64(5), h.nextIndex())
+	s, err = kvMem.Load(historyKey)
+	re.NoError(err)
+	re.Equal("5", s)
+
+	// After a successful commit, a subsequent rollback (e.g., the next
+	// sync session ends without its own end-of-history marker before any
+	// further records arrive) must keep the committed index intact.
+	h.rollback()
+	re.Equal(uint64(5), h.nextIndex())
+	s, err = kvMem.Load(historyKey)
+	re.NoError(err)
+	re.Equal("5", s)
+
+	// A fresh buffer built against the same KV must see the committed
+	// index — this is the StartIndex the next sync session would send.
+	h2 := newHistoryBufferWithConfig(100, 100, 1, kvMem)
+	re.Equal(uint64(5), h2.nextIndex())
+
+	// Records appended after the committed point and rolled back again
+	// must not leak past the committed index.
+	for _, r := range regions[5:] {
+		h2.recordNoPersist(r)
+	}
+	re.Equal(uint64(10), h2.nextIndex())
+	h2.rollback()
+	re.Equal(uint64(5), h2.nextIndex())
+	re.Equal(0, h2.len())
+}

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -267,7 +267,19 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 	// -1 forces an initial publish on the first tick.
 	lastPublishedRegionCount := -1
 	publishCommittedRegionCount := func() {
-		if count := s.server.GetBasicCluster().GetTotalRegionCount(); count != lastPublishedRegionCount {
+		count := s.server.GetBasicCluster().GetTotalRegionCount()
+		// Only advertise a non-zero committed count once regions have actually
+		// entered the syncer history and thus become syncable by followers.
+		// Regions present in the basic cluster but that never flowed through the
+		// heartbeat -> changedRegions -> history path (most notably the bootstrap
+		// region) cannot have been synced by any follower. Counting them would
+		// keep the region-syncer campaign gate (canCampaignAsRegionSyncerCaughtUp)
+		// permanently closed and stall the next leader election until the grace
+		// elapses, even though no follower could possibly be caught up.
+		if s.history.getNextIndex() == 0 {
+			count = 0
+		}
+		if count != lastPublishedRegionCount {
 			if err := s.server.GetStorage().SaveRegionSyncerCommittedRegionCount(uint64(count)); err != nil {
 				log.Warn("failed to persist committed region count", errs.ZapError(err))
 			} else {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -50,9 +50,13 @@ const (
 	maxSyncRegionBatchSize      = 1000
 	syncerKeepAliveInterval     = 10 * time.Second
 	historyBufferShrinkInterval = 5 * time.Minute
-	defaultHistoryBufferSize    = 10000
-	historyBufferMemoryStep     = 4 * 1024 * 1024 * 1024
-	maxHistoryBufferSize        = 80000
+	// The frequency to check and publish the region count the leader is
+	// serving so that other members can tell whether they are caught up
+	// before campaigning.
+	committedRegionCountInterval = time.Second
+	defaultHistoryBufferSize     = 10000
+	historyBufferMemoryStep      = 4 * 1024 * 1024 * 1024
+	maxHistoryBufferSize         = 80000
 )
 
 // ClientStream is the client side of the region syncer.
@@ -193,6 +197,13 @@ type RegionSyncer struct {
 	tlsConfig   *grpcutil.TLSConfig
 	// status when as client
 	streamingRunning atomic.Bool
+	// attempted sync status as client, sticky for the process lifetime.
+	// It is used to distinguish follower from never attempted to sync (e.g., bootstrapp).
+	attemptedSync atomic.Bool
+	// status of the historitcal catch-up as client, sticky for the process lifetime.
+	// set to true once the client has observed that it has completed the historitcal
+	// catch-up/ the local region storage is durably populated.
+	historySynced atomic.Bool
 }
 
 // NewRegionSyncer returns a region syncer that ensures final consistency through the heartbeat,
@@ -211,6 +222,7 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 		tlsConfig:   s.GetTLSConfig(),
 	}
 	syncer.mu.streams = make(map[string]*regionSyncStream)
+	syncer.reloadHistorySyncedFromDurableState()
 	return syncer
 }
 
@@ -229,12 +241,44 @@ func historyBufferMaxSizeFromMemory(totalMemory uint64) int {
 	return size
 }
 
+// This function seeds the in-memory historySynced
+// flag from the persisted historyIndex so a node that previously completed
+// a sync isn't permanently locked out of campaigning after a restart
+// followed by a leader death mid-sync. A non-zero index only ever lands on
+// disk via commit() (after a bulk applied via SaveRegion) or via record()'s
+// flushCount path, so a non-zero index implies the local region storage was
+// populated by a prior successful catch-up — sufficient evidence of durable
+// state without any extra probe. Invoked once from NewRegionSyncer; safe to
+// call before any sync session because nothing else has touched historySynced yet.
+// TODO : this doesn't attempt to fix the gap problem https://github.com/tikv/pd/issues/10668
+func (s *RegionSyncer) reloadHistorySyncedFromDurableState() {
+	if s.history.getNextIndex() > 0 {
+		s.historySynced.Store(true)
+	}
+}
+
 // RunServer runs the server of the region syncer.
 // regionNotifier is used to get the changed regions.
 func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *core.RegionInfo) {
 	var records []*core.RegionInfo
 	keepAliveTicker := time.NewTicker(syncerKeepAliveInterval)
 	shrinkTicker := time.NewTicker(historyBufferShrinkInterval)
+	committedCountTicker := time.NewTicker(committedRegionCountInterval)
+	// -1 forces an initial publish on the first tick.
+	lastPublishedRegionCount := -1
+	publishCommittedRegionCount := func() {
+		if count := s.server.GetBasicCluster().GetTotalRegionCount(); count != lastPublishedRegionCount {
+			if err := s.server.GetStorage().SaveRegionSyncerCommittedRegionCount(uint64(count)); err != nil {
+				log.Warn("failed to persist committed region count", errs.ZapError(err))
+			} else {
+				lastPublishedRegionCount = count
+			}
+		}
+	}
+	// Publish the region count immediately to minimize the poissibility of a leader dies
+	// immediately and a new campaign gate misclassifies an unsynced follower as
+	// already caught up.
+	publishCommittedRegionCount()
 
 	processRegion := func(region *core.RegionInfo) {
 		records = append(records, region)
@@ -244,6 +288,7 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 	defer func() {
 		keepAliveTicker.Stop()
 		shrinkTicker.Stop()
+		committedCountTicker.Stop()
 		s.mu.Lock()
 		for _, stream := range s.mu.streams {
 			stream.close()
@@ -274,6 +319,12 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 			s.broadcast(ctx, records, false)
 		case <-shrinkTicker.C:
 			s.history.maybeShrink()
+		case <-committedCountTicker.C:
+			// Publish the region count this leader is serving so that a member
+			// that has not finished a history sync can still decide, after this
+			// leader is gone, whether it is caught up enough to campaign. Only
+			// the leader runs RunServer, so only the leader writes this.
+			publishCommittedRegionCount()
 		case <-keepAliveTicker.C:
 			s.broadcast(ctx, nil, true)
 		}
@@ -420,7 +471,7 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 		zap.Uint64("from-index", startIndex),
 		zap.Uint64("last-index", endIndex),
 		zap.Int("records-length", len(records)))
-	return s.syncHistoryRecordsLocked(startIndex, records, syncStream)
+	return s.syncHistoryRecordsLocked(startIndex, records, syncStream, true)
 }
 
 func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdpb.SyncRegionResponse {
@@ -455,17 +506,28 @@ func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdp
 func (s *RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.RegionInfo, stream *regionSyncStream) error {
 	stream.sendMu.Lock()
 	defer stream.sendMu.Unlock()
-	return s.syncHistoryRecordsLocked(startIndex, records, stream)
+	return s.syncHistoryRecordsLocked(startIndex, records, stream, true)
 }
 
-func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core.RegionInfo, stream *regionSyncStream) error {
+// syncHistoryRecordsLocked streams records in batches. When sendEndMarker is
+// true it appends an end-of-history marker (empty regions) so the follower can
+// commit its history index and flip historySynced. The full-sync path passes
+// false because it streams positional batches and sends its own completion
+// marker at the leader's real next index instead.
+func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core.RegionInfo, stream *regionSyncStream, sendEndMarker bool) error {
 	for start := 0; start < len(records); start += maxSyncRegionBatchSize {
 		end := min(start+maxSyncRegionBatchSize, len(records))
 		if err := stream.sendStreamIfOpen(buildSyncRegionResponse(startIndex+uint64(start), records[start:end])); err != nil {
 			return err
 		}
 	}
-	return nil
+	if !sendEndMarker {
+		return nil
+	}
+	return stream.sendStreamIfOpen(&pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		StartIndex: startIndex + uint64(len(records)),
+	})
 }
 
 func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, syncStream *regionSyncStream, syncStartIndex uint64) error {
@@ -542,11 +604,16 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 		if len(regions) == 0 {
 			catchUpStartIndex = 0
 		}
-		if err := s.syncHistoryRecordsLocked(catchUpStartIndex, records, syncStream); err != nil {
+		// Full-sync batches are positional, so stream them without an
+		// end-of-history marker; the completion marker below carries the real
+		// next index.
+		if err := s.syncHistoryRecordsLocked(catchUpStartIndex, records, syncStream, false); err != nil {
 			return err
 		}
 		syncStream.advanceSendIndexLocked(len(records))
 	}
+	// End-of-history marker at the leader's real next index so the follower
+	// commits the correct history index and flips historySynced.
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 		StartIndex: nextIndex,

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -226,6 +226,8 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 	return syncer
 }
 
+// historyBufferMaxSizeFromMemory returns the maximum history buffer size scaled
+// to the total system memory, bounded by the default and maximum sizes.
 func historyBufferMaxSizeFromMemory(totalMemory uint64) int {
 	if totalMemory == 0 {
 		return defaultHistoryBufferSize
@@ -241,7 +243,7 @@ func historyBufferMaxSizeFromMemory(totalMemory uint64) int {
 	return size
 }
 
-// This function seeds the in-memory historySynced
+// reloadHistorySyncedFromDurableState seeds the in-memory historySynced
 // flag from the persisted historyIndex so a node that previously completed
 // a sync isn't permanently locked out of campaigning after a restart
 // followed by a leader death mid-sync. A non-zero index only ever lands on
@@ -439,6 +441,10 @@ func (s *RegionSyncer) syncHistoryRegion(
 	return s.syncHistoryRegionLocked(ctx, request, syncStream, endIndex)
 }
 
+// syncHistoryRegionLocked serves a follower's history sync request: it replays
+// the buffered records in [request.StartIndex, endIndex), or falls back to a
+// full sync when the requested range is no longer available. The caller must
+// hold the stream's send lock.
 func (s *RegionSyncer) syncHistoryRegionLocked(
 	ctx context.Context,
 	request *pdpb.SyncRegionRequest,
@@ -486,6 +492,8 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 	return s.syncHistoryRecordsLocked(startIndex, records, syncStream, true)
 }
 
+// buildSyncRegionResponse builds a SyncRegionResponse carrying the given records
+// starting at startIndex.
 func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdpb.SyncRegionResponse {
 	regions := make([]*metapb.Region, len(records))
 	stats := make([]*pdpb.RegionStat, len(records))
@@ -542,6 +550,10 @@ func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core
 	})
 }
 
+// syncFullRegionsLocked streams a full snapshot of the leader's regions to a
+// follower, followed by any catch-up records and an end-of-history marker at the
+// leader's next index so the follower can commit. The caller must hold the
+// stream's send lock.
 func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, syncStream *regionSyncStream, syncStartIndex uint64) error {
 	releaseRetain := s.history.retainFrom(syncStartIndex)
 	defer releaseRetain()

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -198,10 +198,10 @@ type RegionSyncer struct {
 	// status when as client
 	streamingRunning atomic.Bool
 	// attempted sync status as client, sticky for the process lifetime.
-	// It is used to distinguish follower from never attempted to sync (e.g., bootstrapp).
+	// It is used to distinguish follower from never attempted to sync (e.g., bootstrap).
 	attemptedSync atomic.Bool
-	// status of the historitcal catch-up as client, sticky for the process lifetime.
-	// set to true once the client has observed that it has completed the historitcal
+	// status of the historical catch-up as client, sticky for the process lifetime.
+	// set to true once the client has observed that it has completed the historical
 	// catch-up/ the local region storage is durably populated.
 	historySynced atomic.Bool
 }
@@ -259,6 +259,25 @@ func (s *RegionSyncer) reloadHistorySyncedFromDurableState() {
 	}
 }
 
+// publishCommittedRegionCount persists the region count this leader is serving
+// via SaveRegionSyncerCommittedRegionCount, so that a member deciding whether
+// to campaign (canCampaignAsRegionSyncerCaughtUp) can tell whether it might be
+// behind on region-syncer data. Only the leader runs RunServer, so only the
+// leader writes this. It skips the write when the count is unchanged from
+// lastPublished and returns the count now published (== lastPublished when the
+// write was skipped or failed).
+func (s *RegionSyncer) publishCommittedRegionCount(lastPublished int) int {
+	count := s.server.GetBasicCluster().GetTotalRegionCount()
+	if count == lastPublished {
+		return lastPublished
+	}
+	if err := s.server.GetStorage().SaveRegionSyncerCommittedRegionCount(uint64(count)); err != nil {
+		log.Warn("failed to persist committed region count", errs.ZapError(err))
+		return lastPublished
+	}
+	return count
+}
+
 // RunServer runs the server of the region syncer.
 // regionNotifier is used to get the changed regions.
 func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *core.RegionInfo) {
@@ -268,31 +287,10 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 	committedCountTicker := time.NewTicker(committedRegionCountInterval)
 	// -1 forces an initial publish on the first tick.
 	lastPublishedRegionCount := -1
-	publishCommittedRegionCount := func() {
-		count := s.server.GetBasicCluster().GetTotalRegionCount()
-		// Only advertise a non-zero committed count once regions have actually
-		// entered the syncer history and thus become syncable by followers.
-		// Regions present in the basic cluster but that never flowed through the
-		// heartbeat -> changedRegions -> history path (most notably the bootstrap
-		// region) cannot have been synced by any follower. Counting them would
-		// keep the region-syncer campaign gate (canCampaignAsRegionSyncerCaughtUp)
-		// permanently closed and stall the next leader election until the grace
-		// elapses, even though no follower could possibly be caught up.
-		if s.history.getNextIndex() == 0 {
-			count = 0
-		}
-		if count != lastPublishedRegionCount {
-			if err := s.server.GetStorage().SaveRegionSyncerCommittedRegionCount(uint64(count)); err != nil {
-				log.Warn("failed to persist committed region count", errs.ZapError(err))
-			} else {
-				lastPublishedRegionCount = count
-			}
-		}
-	}
-	// Publish the region count immediately to minimize the poissibility of a leader dies
+	// Publish the region count immediately to minimize the possibility of a leader dies
 	// immediately and a new campaign gate misclassifies an unsynced follower as
 	// already caught up.
-	publishCommittedRegionCount()
+	lastPublishedRegionCount = s.publishCommittedRegionCount(lastPublishedRegionCount)
 
 	processRegion := func(region *core.RegionInfo) {
 		records = append(records, region)
@@ -338,7 +336,7 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 			// that has not finished a history sync can still decide, after this
 			// leader is gone, whether it is caught up enough to campaign. Only
 			// the leader runs RunServer, so only the leader writes this.
-			publishCommittedRegionCount()
+			lastPublishedRegionCount = s.publishCommittedRegionCount(lastPublishedRegionCount)
 		case <-keepAliveTicker.C:
 			s.broadcast(ctx, nil, true)
 		}

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -78,6 +78,8 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 	re.Equal(2, syncer.history.capacity())
 }
 
+// TestSyncHistoryRecordsSplitBatches verifies that history records are streamed
+// in batches followed by a trailing end-of-history marker.
 func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	re := require.New(t)
 	syncer, _ := newTestRegionSyncer(t)
@@ -187,6 +189,9 @@ func syncFullRegionsForTest(ctx context.Context, syncer *RegionSyncer, syncStrea
 	return syncer.syncFullRegionsLocked(ctx, "pd-follower", syncStream, syncStartIndex)
 }
 
+// TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp verifies that records
+// appended while a full sync is in progress are still streamed to the follower
+// after the snapshot, followed by the end-of-history marker.
 func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 	re := require.New(t)
 	bc := core.NewBasicCluster()
@@ -799,6 +804,9 @@ func TestDrainDownstreamSendsPendingRecordsSerially(t *testing.T) {
 	re.Equal(uint64(13), syncStream.getSendIndex())
 }
 
+// TestSyncHistoryRegionStopsAtSyncStartIndex verifies that an incremental
+// history replay stops at the sync start index and is followed by an
+// end-of-history marker.
 func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 	re := require.New(t)
 	syncer := &RegionSyncer{history: newTestHistoryBuffer(defaultHistoryBufferSize)}

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -58,6 +58,62 @@ func TestHistoryBufferMaxSizeFromMemory(t *testing.T) {
 	}
 }
 
+// TestPublishCommittedRegionCount pins down the region count the leader
+// persists for the campaign gate, especially the reachable
+// regions > 0 && historyIndex == 0 state (bootstrap-with-existing-regions,
+// restart/upgrade reloading regions before the history advances). In that
+// state the leader must publish the real region count: a freshly joined member
+// can already have pulled all of these regions via a full-sync dump
+// (syncFullRegionsLocked streams the whole basic cluster on first connect), so
+// publishing 0 would let a stale/empty member win the campaign ahead of a
+// caught-up peer. The persisted value is asserted directly, so the test does
+// not depend on RunServer's ticker or any timing.
+func TestPublishCommittedRegionCount(t *testing.T) {
+	re := require.New(t)
+	syncer, bc := newTestRegionSyncer(t,
+		newTestSyncRegion(1, 1),
+		newTestSyncRegion(2, 2),
+		newTestSyncRegion(3, 3),
+	)
+	re.Equal(3, bc.GetTotalRegionCount())
+
+	loadCommitted := func() uint64 {
+		got, err := syncer.server.GetStorage().LoadRegionSyncerCommittedRegionCount()
+		re.NoError(err)
+		return got
+	}
+
+	// Regions are in the basic cluster but the syncer history is still at
+	// index 0 (nothing flowed through the heartbeat -> history path). These
+	// regions are still syncable via the full-sync dump, so the real count
+	// must be persisted, not 0.
+	re.Zero(syncer.history.getNextIndex())
+	published := syncer.publishCommittedRegionCount(-1)
+	re.Equal(3, published)
+	re.Equal(uint64(3), loadCommitted())
+
+	// Advancing the history does not change the published count: it always
+	// reflects the live basic-cluster region count.
+	syncer.history.record(newTestSyncRegion(4, 4))
+	re.NotZero(syncer.history.getNextIndex())
+	re.Equal(3, syncer.publishCommittedRegionCount(published))
+
+	// A new region grows the count and persists the new value.
+	bc.PutRegion(newTestSyncRegion(5, 5))
+	published = syncer.publishCommittedRegionCount(published)
+	re.Equal(4, published)
+	re.Equal(uint64(4), loadCommitted())
+
+	// An empty basic cluster reports 0 regardless of the history index: there
+	// is genuinely nothing for a follower to be behind on.
+	empty, _ := newTestRegionSyncer(t)
+	empty.history.record(newTestSyncRegion(1, 1))
+	re.Zero(empty.publishCommittedRegionCount(-1))
+	got, err := empty.server.GetStorage().LoadRegionSyncerCommittedRegionCount()
+	re.NoError(err)
+	re.Zero(got)
+}
+
 func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 	re := require.New(t)
 	syncer, _ := newTestRegionSyncer(t)

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -87,15 +87,21 @@ func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	}
 	stream := newMockSyncRegionsServer()
 	syncStream := newRegionSyncStream(stream, 10)
-	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
+	// Buffer the two record batches plus the trailing end-of-history marker so
+	// the synchronous syncHistoryRecords below never blocks on Send.
+	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 3)
 
 	re.NoError(syncer.syncHistoryRecords(10, records, syncStream))
 	first := <-stream.sendCh
 	second := <-stream.sendCh
+	marker := <-stream.sendCh
 	re.Equal(uint64(10), first.GetStartIndex())
 	re.Len(first.GetRegions(), maxSyncRegionBatchSize)
 	re.Equal(uint64(10+maxSyncRegionBatchSize), second.GetStartIndex())
 	re.Len(second.GetRegions(), 1)
+	// The end-of-history marker carries the next index and no regions.
+	re.Empty(marker.GetRegions())
+	re.Equal(uint64(10+len(records)), marker.GetStartIndex())
 
 	closedStream := &testServerStream{}
 	closedSyncStream := newRegionSyncStream(closedStream, 10)
@@ -222,8 +228,11 @@ func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 	re.NoError(syncer.sendDownstream(context.Background(), "pd-follower", syncStream, false))
 	responses := stream.sentResponses()
 	re.Len(responses, 4)
-	re.Equal(liveStartIndex, responses[2].GetStartIndex())
+	// responses[2] is the end-of-history marker emitted after the catch-up
+	// (empty regions, carrying the caught-up index).
 	re.Empty(responses[2].GetRegions())
+	re.Equal(liveStartIndex, responses[2].GetStartIndex())
+	// responses[3] is the live record appended during catch-up, sent downstream.
 	re.Equal(liveStartIndex, responses[3].GetStartIndex())
 	re.Equal([]*metapb.Region{{Id: 102}}, responses[3].GetRegions())
 	re.Equal(liveStartIndex+1, syncStream.getSendIndex())
@@ -810,8 +819,14 @@ func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 	err := syncer.syncHistoryRegion(context.Background(), request, syncStream, syncStartIndex)
 
 	re.NoError(err)
-	re.Equal(uint64(10), stream.lastResponse().GetStartIndex())
-	re.Equal([]*metapb.Region{{Id: 1}}, stream.lastResponse().GetRegions())
+	responses := stream.sentResponses()
+	re.Len(responses, 2)
+	// Replay stops before syncStartIndex: only region 1 (at index 10), not region 2.
+	re.Equal(uint64(10), responses[0].GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 1}}, responses[0].GetRegions())
+	// Followed by the end-of-history marker at syncStartIndex.
+	re.Empty(responses[1].GetRegions())
+	re.Equal(syncStartIndex, responses[1].GetStartIndex())
 }
 
 type testServerStream struct {

--- a/pkg/utils/keypath/absolute_key_path.go
+++ b/pkg/utils/keypath/absolute_key_path.go
@@ -91,6 +91,10 @@ const (
 	storePathFormat                = "/pd/%d/raft/s/%020d"                    // "/pd/{cluster_id}/raft/s/{store_id}"
 	minResolvedTSPathFormat        = "/pd/%d/raft/min_resolved_ts"            // "/pd/{cluster_id}/raft/min_resolved_ts"
 	externalTimestampPathFormat    = "/pd/%d/raft/external_timestamp"         // "/pd/{cluster_id}/raft/external_timestamp"
+	// regionSyncerCommittedRegionCountPathFormat holds the region count the
+	// current leader is serving, published so other members can tell whether
+	// they are caught up before campaigning for PD leadership.
+	regionSyncerCommittedRegionCountPathFormat = "/pd/%d/raft/region_syncer_committed_region_count" // "/pd/{cluster_id}/raft/region_syncer_committed_region_count"
 
 	keyspaceMetaPrefixFormat    = "/pd/%d/keyspaces/meta/"                     // "/pd/{cluster_id}/keyspaces/meta/"
 	keyspaceMetaPathFormat      = "/pd/%d/keyspaces/meta/%08d"                 // "/pd/{cluster_id}/keyspaces/meta/{keyspace_id}"
@@ -202,6 +206,12 @@ func MinResolvedTSPath() string {
 // ExternalTimestampPath returns the external timestamp path.
 func ExternalTimestampPath() string {
 	return fmt.Sprintf(externalTimestampPathFormat, ClusterID())
+}
+
+// RegionSyncerCommittedRegionCountPath returns the path that stores the region
+// count the current leader is serving.
+func RegionSyncerCommittedRegionCountPath() string {
+	return fmt.Sprintf(regionSyncerCommittedRegionCountPathFormat, ClusterID())
 }
 
 // RecoveringMarkPath returns the path to save the recovering mark.

--- a/server/server.go
+++ b/server/server.go
@@ -112,6 +112,16 @@ const (
 
 	lostPDLeaderMaxTimeoutSecs   = 10
 	lostPDLeaderReElectionFactor = 10
+
+	// regionSyncerCampaignGrace bounds how long a member will refuse to campaign
+	// without a leader in the cluster because its region syncer has not caught up.
+	// This prevents a permanently leaderless cluster (the gate's circular dependency:
+	// a follower cannot finish syncing once the leader it would sync from is
+	// gone).
+	// It is set to the floor of the lost-PD-leader re-election timeout
+	// (randomTimeout in leaderLoop, whose minimum is lostPDLeaderMaxTimeoutSecs
+	// seconds plus lostPDLeaderReElectionFactor*ElectionInterval).
+	regionSyncerCampaignGrace = lostPDLeaderMaxTimeoutSecs * time.Second
 )
 
 // EtcdStartTimeout the timeout of the startup etcd.
@@ -1835,6 +1845,12 @@ func (s *Server) leaderLoop() {
 	defer logutil.LogPanic()
 	defer s.serverLoopWg.Done()
 
+	// gateBlockedSince records when this server first got blocked from
+	// campaigning by the region-syncer gate while leaderless; it bounds that
+	// wait via regionSyncerCampaignGrace. Reset whenever a leader exists or we
+	// proceed to campaign.
+	var gateBlockedSince time.Time
+
 	for {
 		if s.IsClosed() {
 			log.Info("server is closed, return PD leader loop")
@@ -1854,6 +1870,9 @@ func (s *Server) leaderLoop() {
 			continue
 		}
 		if leader != nil {
+			// A leader exists to (re)sync from, so the gate's leaderless grace
+			// no longer applies; reset it.
+			gateBlockedSince = time.Time{}
 			err := s.reloadConfigFromKV()
 			if err != nil {
 				log.Error("reload config failed", errs.ZapError(err))
@@ -1905,8 +1924,89 @@ func (s *Server) leaderLoop() {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
+		// Refuse to campaign until the region syncer has caught up to the
+		// previous leader. Without this gate, a freshly joined follower
+		// whose syncer never produced a populated local store can win
+		// leadership immediately after the leader dies and serve a
+		// partial/empty region set until TiKV heartbeats repopulate it.
+		// `HasAttemptedSync` distinguishes "I was a follower" from "I
+		// started fresh and there is no leader to sync from" (the latter
+		// must be allowed to campaign so the cluster can bootstrap).
+		if !s.canCampaignAsRegionSyncerCaughtUp() {
+			if gateBlockedSince.IsZero() {
+				gateBlockedSince = time.Now()
+			}
+			if blocked := time.Since(gateBlockedSince); blocked < regionSyncerCampaignGrace {
+				log.Warn("skip campaigning of pd leader: region syncer has not caught up to the previous leader",
+					zap.String("server-name", s.Name()),
+					zap.Uint64("member-id", s.member.ID()),
+					zap.Duration("blocked-for", blocked))
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			// Leaderless past the grace window with no caught-up member taking
+			// over: campaign anyway to restore availability rather than stay
+			// blocked forever. Any region gap on the new leader is repopulated
+			// by TiKV heartbeats.
+			log.Warn("region syncer has not caught up but campaign grace elapsed; campaigning to avoid a leaderless cluster",
+				zap.String("server-name", s.Name()),
+				zap.Uint64("member-id", s.member.ID()),
+				zap.Duration("grace", regionSyncerCampaignGrace))
+		}
+		gateBlockedSince = time.Time{}
 		s.campaignLeader()
 	}
+}
+
+// This function returns true when this server is eligible
+// to campaign for PD leadership from a region-syncer correctness standpoint:
+//   - region storage is not in use (regions live in etcd, no syncer needed), or
+//   - the syncer was never started on this process (single-node bootstrap, or
+//     no leader has ever existed to sync from), or
+//   - the syncer has at some point observed that it was caught up to a
+//     leader's history (and thus the local region storage is durable), or
+//   - no leader has published any committed regions yet (a fresh or empty
+//     cluster, where there is nothing to be behind on).
+//
+// Otherwise this is a member that has been syncing from a leader that has
+// region data but has not yet confirmed catch-up, so it must wait rather than
+// win leadership with a stale/empty store ahead of its caught-up peers.
+func (s *Server) canCampaignAsRegionSyncerCaughtUp() bool {
+	if !s.persistOptions.IsUseRegionStorage() {
+		return true
+	}
+	syncer := s.cluster.GetRegionSyncer()
+	if syncer == nil {
+		return true
+	}
+	if !syncer.HasAttemptedSync() {
+		return true
+	}
+	if syncer.IsHistorySynced() {
+		return true
+	}
+	// Not history-synced this session. Consult the durable region count the
+	// leader published so we neither deadlock the election nor let an empty
+	// member win.
+	committed, err := s.storage.LoadRegionSyncerCommittedRegionCount()
+	if err != nil {
+		// Missing state is already handled as committed == 0 by the storage
+		// endpoint. Any real error here means we cannot prove this member is
+		// safe to lead yet, so keep the gate closed.
+		log.Warn("failed to load committed region count, skipping campaign",
+			zap.String("server-name", s.Name()), errs.ZapError(err))
+		return false
+	}
+	// committed == 0 means a fresh or empty cluster: nothing to be behind on.
+	// Note: the committed value could be reduced to a boolean "cluster has committed regions"
+	// flag. We keep the published region count for now until we are certain the magnitude is
+	// never needed (e.g. for a future tolerance/threshold policy).
+	if committed == 0 {
+		return true
+	}
+	// The cluster has committed regions and this member has not confirmed
+	// catch-up: it is behind, so it must not campaign yet.
+	return false
 }
 
 func (s *Server) campaignLeader() {

--- a/server/server.go
+++ b/server/server.go
@@ -1958,7 +1958,7 @@ func (s *Server) leaderLoop() {
 	}
 }
 
-// This function returns true when this server is eligible
+// canCampaignAsRegionSyncerCaughtUp returns true when this server is eligible
 // to campaign for PD leadership from a region-syncer correctness standpoint:
 //   - region storage is not in use (regions live in etcd, no syncer needed), or
 //   - the syncer was never started on this process (single-node bootstrap, or

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -426,3 +426,117 @@ func TestPrepareCheckerWithTransferLeader(t *testing.T) {
 	re.True(rc.IsPrepared())
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/changeCoordinatorTicker"))
 }
+
+// TestUnsyncedMemberRefusesLeadership is a regression test for the race where
+// a freshly joined PD with empty region storage could take over leadership
+// before its region syncer had populated the local store. The fix gates the
+// campaign in leaderLoop on the region syncer having observed catch-up with
+// the previous leader.
+//
+// Test plan:
+//  1. Bring up a 1-node cluster (pd1) with UseRegionStorage = true, populate
+//     it with regions, and wait for them to flush to leveldb.
+//  2. Enable the `disableClientStreaming` failpoint so any new follower's
+//     syncer client fails to receive any regions — modelling a brand-new
+//     member that has not (yet) caught up.
+//  3. Join pd2. It comes up as a follower but cannot sync.
+//  4. Resign pd1's leadership. Without the fix, pd2 would campaign and win
+//     with an empty cache; with the fix, pd2 must refuse to campaign.
+//  5. Poll for a window after the resign, asserting pd2 never holds
+//     leadership with a partial region set and that the syncer state
+//     machine stays in "attempted but not synced" — the precise state the
+//     gate is supposed to catch.
+//
+// Recovery (releasing the failpoint and letting pd2 eventually catch up and
+// take leadership) is not exercised here because, in a 2-node cluster after
+// `ResignLeader`, the cluster sits leaderless until the `leaderLoop`'s
+// lost-PD-leader timeout (~40 s) fires and reclaims etcd leadership for
+// pd1 — longer than a reasonable Eventually deadline. The gate's recovery
+// behaviour is the same path the cluster takes on any natural leader
+// failover and is covered by the existing TestRegionSyncer / TestFullSync*
+// scenarios.
+func TestUnsyncedMemberRefusesLeadership(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/storage/levelDBStorageFastFlush", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/storage/levelDBStorageFastFlush"))
+	}()
+
+	cluster, err := tests.NewTestCluster(ctx, 1, func(conf *config.Config, _ string) {
+		conf.PDServerCfg.UseRegionStorage = true
+	})
+	defer cluster.Destroy()
+	re.NoError(err)
+
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+	leaderServer := cluster.GetLeaderServer()
+	re.NoError(leaderServer.BootstrapCluster())
+	rc := leaderServer.GetServer().GetRaftCluster()
+	re.NotNil(rc)
+
+	// Populate the leader with regions and wait for them to be flushed to
+	// leveldb (the local region storage flush interval is ~3s).
+	regionLen := 110
+	regions := tests.InitRegions(regionLen)
+	for _, region := range regions {
+		re.NoError(rc.HandleRegionHeartbeat(region))
+	}
+	time.Sleep(4 * time.Second)
+	re.Len(leaderServer.GetServer().GetBasicCluster().GetRegions(), regionLen)
+
+	// Block region-syncer clients from establishing a stream. Any follower
+	// that joins after this point will never receive history regions.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/syncer/disableClientStreaming", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/syncer/disableClientStreaming"))
+	}()
+
+	// Join a brand-new PD. Its leveldb starts empty and the failpoint
+	// prevents its syncer client from filling it.
+	pd2, err := cluster.Join(ctx)
+	re.NoError(err)
+	re.NoError(pd2.Run())
+	re.Equal("pd1", cluster.WaitLeader())
+
+	// Confirm pd2 is wired up as a follower whose local region cache is still
+	// empty: the disableClientStreaming failpoint stops its syncer from ever
+	// establishing a stream, so it never catches up to pd1's history.
+	testutil.Eventually(re, func() bool {
+		return pd2.GetServer().DirectlyGetRaftCluster() != nil
+	})
+	re.Empty(pd2.GetServer().GetBasicCluster().GetRegions())
+
+	// Resign pd1. Without the fix, pd2's leaderLoop would unblock from
+	// leader.Watch(), call StopSyncWithLeader, then campaign and win with an
+	// empty region cache. With the fix the gate forces pd2 to skip the
+	// campaign while it is not caught up.
+	re.NoError(cluster.ResignLeader())
+
+	// Observe the gate firing. pd2 must log "skip campaigning of pd leader:
+	// region syncer has not caught up" on every leader-loop iteration as long
+	// as the failpoint keeps its syncer from catching up. We poll for a few
+	// seconds to confirm the gate stays closed rather than flipping open by
+	// accident.
+	const observeWindow = 3 * time.Second
+	deadline := time.Now().Add(observeWindow)
+	for time.Now().Before(deadline) {
+		if pd2.IsLeader() && len(pd2.GetServer().GetBasicCluster().GetRegions()) < regionLen {
+			re.FailNowf("gate failed",
+				"unsynced pd2 became leader with %d/%d regions",
+				len(pd2.GetServer().GetBasicCluster().GetRegions()), regionLen)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Final guard: pd2 must not hold leadership while its region cache is
+	// still empty. On unfixed code (no campaign gate) pd2 wins the election
+	// pd1 vacated and serves an empty region set, so this assertion — or the
+	// observe loop above — fails, reproducing the bug.
+	re.False(pd2.IsLeader(), "pd2 must not hold leadership while unsynced")
+	re.Empty(pd2.GetServer().GetBasicCluster().GetRegions(),
+		"pd2 region cache must stay empty while the syncer stream is blocked")
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10843

When a node with an empty region cache joins the PD cluster (either a new node or an existing node that lost its LevelDB state), it can become the leader by entering the campaign loop without waiting for asynchronous region sync to complete. When there are hundreds of thousands of regions, the new leader is unable to rebuild the region cache in a timely manner, causing a spike in `GetRegion` requests, increasing region heartbeat and `GetRegion` latency, and ultimately resulting in query errors and elevated latencies.

### What is changed and how does it work?

When a new member joins the PD cluster, it waits until the historical region sync phase is done before start campaigning for the leadership.

```commit-message
server: skip campaign until region syncer history phase is done
```

### Check List

[x] - Unit and integration tests

Tests
```
Unit tests (no failpoints needed — run directly)

  # pkg/storage/endpoint — RegionSyncerStorage Load/Save (3 tests)
  go test ./pkg/storage/endpoint/ -count=1 -v \
    -run 'TestRegionSyncerCommittedRegionCount'

  # pkg/syncer — historySynced durable reload + catch-up commit/rollback (2 tests)
  go test ./pkg/syncer/ -count=1 -v \
    -run 'TestHistorySyncedInitFromDurableState|TestCatchupCommitRollback'

 Integration tests (require failpoints enabled)

  These call failpoint.Enable(...), so the failpoints must be rewritten in first — otherwise the inject sites are no-ops and the tests won't behave
  correctly.

  # enable once for the failpoint-dependent runs
  make failpoint-enable

  # tests/server/region_syncer — unsynced member must not win leadership
  go test ./tests/server/region_syncer/ -count=1 -v -timeout 300s \
    -run 'TestUnsyncedMemberRefusesLeadership'

  # cluster-formation fuzzer (opt-in via env; honors PD_FUZZ_SEED / PD_FUZZ_ITERATIONS)
  PD_RUN_FUZZ=1 go test ./tests/server/region_syncer/ -count=1 -v -timeout 1200s \
    -run 'TestClusterFormationFuzz'

  # restore when done
  make failpoint-disable
```
Code changes

- Has persistent data change
- - New storage endpoint to save region counts to `etcd`

Side effects

- Increased code complexity
-- Increasing the state space of node/cluster startup/bootstrap state machine


### Release note

```release-note
When a new member joins the PD cluster, it waits until the historical region sync phase is done before start campaigning for the leadership. This avoids 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted region-sync state (committed region count & history sync markers) and sticky sync status to survive restarts.
  * Protocol sends explicit end-of-history markers to improve catch-up behavior.
  * Leadership gate prevents promotion until region sync state is safe.

* **Bug Fixes**
  * Prevents stale history offsets on leadership changes by rolling back uncommitted catch-up state.

* **Tests**
  * New tests covering persistence, catch-up commit/rollback, and leadership eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->