### PR TITLE
client/router: only return buckets to requests that asked for them

### DIFF
--- a/client/clients/router/client.go
+++ b/client/clients/router/client.go
@@ -297,6 +297,13 @@ func requestFinisher(resp *pdpb.QueryRegionResponse) batch.FinisherFunc[*Request
 			// Since the region results may be modified by the requester,
 			// we need to ensure each region result returned is unique.
 			req.region = convertToRegionCopy(regionResp)
+			// NeedBuckets is a batch-wide flag in the QueryRegion request, so the
+			// response may carry buckets for a region even when this particular
+			// request did not ask for them. Drop them here to match the
+			// per-request semantics of the unary GetRegion path.
+			if req.region != nil && !req.options.NeedBuckets {
+				req.region.Buckets = nil
+			}
 		}
 		req.tryDone(nil)
 	}

--- a/client/clients/router/client_test.go
+++ b/client/clients/router/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
+	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/utils/testutil"
 )
 
@@ -37,6 +38,21 @@ func newMockRegionResponse(id uint64) *pdpb.RegionResponse {
 		Leader:  &metapb.Peer{Id: id},
 		Buckets: &metapb.Buckets{},
 	}
+}
+
+// newTestRequest builds a *Request directly for finisher tests, mirroring the
+// invariants that the production newRequest guarantees: a non-nil options and a
+// buffered done channel. Callers set key/prevKey/id afterwards.
+func newTestRequest(ctx context.Context, opts ...opt.GetRegionOption) *Request {
+	req := &Request{
+		requestCtx: ctx,
+		options:    &opt.GetRegionOp{},
+		done:       make(chan error, 1),
+	}
+	for _, o := range opts {
+		o(req.options)
+	}
+	return req
 }
 
 func TestRequestFinisherNoDataRace(t *testing.T) {
@@ -61,31 +77,22 @@ func TestRequestFinisherNoDataRace(t *testing.T) {
 
 	// Requests that use `key`.
 	for range 2 {
-		req := &Request{
-			requestCtx: ctx,
-			key:        []byte("dummy-key"),
-			done:       make(chan error, 1),
-		}
+		req := newTestRequest(ctx)
+		req.key = []byte("dummy-key")
 		requests = append(requests, req)
 	}
 
 	// Requests that use `prevKey`.
 	for range 2 {
-		req := &Request{
-			requestCtx: ctx,
-			prevKey:    []byte("dummy-prev-key"),
-			done:       make(chan error, 1),
-		}
+		req := newTestRequest(ctx)
+		req.prevKey = []byte("dummy-prev-key")
 		requests = append(requests, req)
 	}
 
 	// Requests that use `id`.
 	for _, id := range []uint64{1, 2} {
-		req := &Request{
-			requestCtx: ctx,
-			id:         id,
-			done:       make(chan error, 1),
-		}
+		req := newTestRequest(ctx)
+		req.id = id
 		requests = append(requests, req)
 	}
 
@@ -104,4 +111,40 @@ func TestRequestFinisherNoDataRace(t *testing.T) {
 	for idx, req := range requests {
 		re.Equal([]byte{byte(idx + 1)}, req.region.Meta.StartKey)
 	}
+}
+
+// TestRequestFinisherClearsUnrequestedBuckets verifies that buckets are only
+// returned to requests that actually asked for them. `NeedBuckets` is a
+// batch-wide flag in the QueryRegion request, so when any request in a batch
+// sets it, the response carries buckets for every region in the batch. The
+// finisher must drop those buckets for the requests that did not ask, matching
+// the per-request semantics of the unary GetRegion path.
+func TestRequestFinisherClearsUnrequestedBuckets(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+
+	// The response carries buckets for every region, simulating a batch where
+	// at least one request set NeedBuckets.
+	resp := &pdpb.QueryRegionResponse{
+		RegionsById: map[uint64]*pdpb.RegionResponse{
+			1: newMockRegionResponse(1),
+			2: newMockRegionResponse(2),
+		},
+	}
+
+	reqWithBuckets := newTestRequest(ctx, opt.WithBuckets())
+	reqWithBuckets.id = 1
+	reqWithoutBuckets := newTestRequest(ctx)
+	reqWithoutBuckets.id = 2
+
+	finisher := requestFinisher(resp)
+	finisher(0, reqWithBuckets, nil)
+	re.NoError(<-reqWithBuckets.done)
+	finisher(1, reqWithoutBuckets, nil)
+	re.NoError(<-reqWithoutBuckets.done)
+
+	// The request that asked for buckets keeps them.
+	re.NotNil(reqWithBuckets.region.Buckets)
+	// The request that did not ask for buckets must not receive them.
+	re.Nil(reqWithoutBuckets.region.Buckets)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8690

`NeedBuckets` is a batch-wide flag in the `QueryRegion` request: when any
request in a batch sets it, the server returns buckets for every region in the
batch. Because of that, requests that did not ask for buckets still received
them via `RegionsById`, diverging from the unary `GetRegion` path where
`NeedBuckets` is per-request.

### What is changed and how does it work?

```commit-message
`NeedBuckets` is a batch-wide flag in the QueryRegion request, so when any
request in a batch sets it, the server returns buckets for every region in the
batch. As a result, requests that did not ask for buckets still received them
via RegionsById, diverging from the unary GetRegion path where the flag is
per-request.

Clear Buckets in the request finisher for requests that did not set
NeedBuckets, so each request only gets what it asked for. Add a regression test
covering the mixed-batch case.
```

### Check List

Tests

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Router responses now include bucket data only for requests that explicitly ask for it, preventing unintended bucket information from appearing in other requests' results.

* **Tests**
  * Added tests to ensure bucket data is preserved for requests that request it and cleared for those that do not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->