### PR TITLE
storage: split raw txn capability from Base

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -428,7 +428,7 @@ internal etcd transaction error occurred
 
 ["PD:etcd:ErrEtcdTxnResponse"]
 error = '''
-etcd transaction returned invalid response: %v
+etcd transaction returned unexpected response: %v
 '''
 
 ["PD:etcd:ErrEtcdURLMap"]

--- a/pkg/errs/errno.go
+++ b/pkg/errs/errno.go
@@ -387,7 +387,7 @@ var (
 	ErrEtcdGrantLease    = errors.Normalize("etcd lease failed", errors.RFCCodeText("PD:etcd:ErrEtcdGrantLease"))
 	ErrEtcdTxnInternal   = errors.Normalize("internal etcd transaction error occurred", errors.RFCCodeText("PD:etcd:ErrEtcdTxnInternal"))
 	ErrEtcdTxnConflict   = errors.Normalize("etcd transaction failed, conflicted and rolled back", errors.RFCCodeText("PD:etcd:ErrEtcdTxnConflict"))
-	ErrEtcdTxnResponse   = errors.Normalize("etcd transaction returned invalid response: %v", errors.RFCCodeText("PD:etcd:ErrEtcdTxnResponse"))
+	ErrEtcdTxnResponse   = errors.Normalize("etcd transaction returned unexpected response: %v", errors.RFCCodeText("PD:etcd:ErrEtcdTxnResponse"))
 	ErrEtcdKVPut         = errors.Normalize("etcd KV put failed", errors.RFCCodeText("PD:etcd:ErrEtcdKVPut"))
 	ErrEtcdKVDelete      = errors.Normalize("etcd KV delete failed", errors.RFCCodeText("PD:etcd:ErrEtcdKVDelete"))
 	ErrEtcdKVGet         = errors.Normalize("etcd KV get failed", errors.RFCCodeText("PD:etcd:ErrEtcdKVGet"))

--- a/pkg/storage/endpoint/endpoint.go
+++ b/pkg/storage/endpoint/endpoint.go
@@ -19,6 +19,8 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"github.com/pingcap/errors"
+
 	"github.com/tikv/pd/pkg/encryption"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/storage/kv"
@@ -45,6 +47,14 @@ func NewStorageEndpoint(
 		encryptionKeyManager,
 		0,
 	}
+}
+
+func (se *StorageEndpoint) createRawTxn() (kv.RawTxn, error) {
+	rawTxnCapable, ok := se.Base.(kv.RawTxnCapable)
+	if !ok {
+		return nil, errors.New("storage endpoint does not support raw transaction")
+	}
+	return rawTxnCapable.CreateRawTxn(), nil
 }
 
 // loadJSON loads a specific key from the StorageEndpoint, and parses it as JSON into type T.

--- a/pkg/storage/endpoint/gc_states.go
+++ b/pkg/storage/endpoint/gc_states.go
@@ -474,7 +474,10 @@ func (p GCStateProvider) RunInGCStateTransaction(f func(wb *GCStateWriteBatch) e
 		})
 	}
 
-	txn := p.storage.CreateRawTxn()
+	txn, err := p.storage.createRawTxn()
+	if err != nil {
+		return errors.AddStack(err)
+	}
 	result, err := txn.If(condition).Then(ops...).Commit()
 	if err != nil {
 		return errs.ErrEtcdTxnInternal.Wrap(err).GenWithStackByArgs()

--- a/pkg/storage/endpoint/maintenance.go
+++ b/pkg/storage/endpoint/maintenance.go
@@ -89,7 +89,10 @@ func (se *StorageEndpoint) TryStartMaintenanceTaskAtomic(_ context.Context, task
 	logger := log.L().With(zap.String("component", "maintenance"), zap.String("op", "TryStartMaintenanceTaskAtomic"))
 	logger.Debug("Attempting to start maintenance task", zap.String("type", task.Type), zap.String("id", task.ID))
 	// Use a single atomic transaction with proper etcd pattern
-	rawTxn := se.CreateRawTxn()
+	rawTxn, err := se.createRawTxn()
+	if err != nil {
+		return false, nil, err
+	}
 
 	// Maintenance lock key to enforce single task type constraint
 	lockKey := keypath.MaintenanceTaskPath(MaintenanceLockName)
@@ -188,7 +191,10 @@ func (se *StorageEndpoint) TryDeleteMaintenanceTaskAtomic(_ context.Context, tas
 	logger := log.L().With(zap.String("component", "maintenance"), zap.String("op", "TryDeleteMaintenanceTaskAtomic"))
 	logger.Debug("Attempting to delete maintenance task", zap.String("type", taskType), zap.String("id", taskID))
 	// Use a single atomic transaction
-	rawTxn := se.CreateRawTxn()
+	rawTxn, err := se.createRawTxn()
+	if err != nil {
+		return false, nil, err
+	}
 
 	lockKey := keypath.MaintenanceTaskPath(MaintenanceLockName)
 	taskKey := keypath.MaintenanceTaskPath(taskType)

--- a/pkg/storage/kv/kv.go
+++ b/pkg/storage/kv/kv.go
@@ -87,8 +87,7 @@ type RawTxnResponse struct {
 }
 
 // RawTxn is a low-level transaction interface. It follows the same pattern of etcd's transaction
-// API. When the backend is etcd, it simply calls etcd's equivalent APIs internally. Otherwise, the
-// behavior is simulated.
+// API.
 // Avoid reading/writing the same key multiple times in a single transaction, otherwise the behavior
 // would be undefined.
 type RawTxn interface {
@@ -96,6 +95,11 @@ type RawTxn interface {
 	Then(ops ...RawTxnOp) RawTxn
 	Else(ops ...RawTxnOp) RawTxn
 	Commit() (RawTxnResponse, error)
+}
+
+// RawTxnCapable is implemented by KV backends that support creating raw transactions.
+type RawTxnCapable interface {
+	CreateRawTxn() RawTxn
 }
 
 // BaseReadWrite is the API set, shared by Base and Txn interfaces, that provides basic KV read and write operations.
@@ -132,8 +136,8 @@ type Base interface {
 	// range there will be a condition constructed. Be aware of the
 	// possibility of causing phantom read.
 	// RunInTxn may not suit all use cases. When RunInTxn is found
-	// improper to use, consider using CreateRawTxn instead, which
-	// is available when the backend is etcd.
+	// improper to use, require RawTxnCapable explicitly and use
+	// CreateRawTxn instead.
 	//
 	// Note that transaction are not committed until RunInTxn returns nil.
 	// Note:
@@ -143,10 +147,4 @@ type Base interface {
 	// 2. Only when storage is etcd, does RunInTxn checks that
 	// values loaded during transaction has not been modified before commit.
 	RunInTxn(ctx context.Context, f func(txn Txn) error) error
-
-	// CreateRawTxn creates a transaction that provides the if-then-else
-	// API pattern when the backend is etcd, makes it possible
-	// to precisely control how etcd's transaction API is used. When the
-	// backend is not etcd, it panics.
-	CreateRawTxn() RawTxn
 }

--- a/pkg/storage/kv/kv_test.go
+++ b/pkg/storage/kv/kv_test.go
@@ -182,7 +182,10 @@ func mustHaveKeys(re *require.Assertions, kv Base, prefix string, expected ...Ke
 	}
 }
 
-func testRawTxn(re *require.Assertions, kv Base) {
+func testRawTxn(re *require.Assertions, kv interface {
+	Base
+	RawTxnCapable
+}) {
 	// Test NotExists condition, putting in transaction.
 	res, err := kv.CreateRawTxn().If(
 		RawTxnCondition{

--- a/pkg/storage/kv/levedb_kv.go
+++ b/pkg/storage/kv/levedb_kv.go
@@ -80,11 +80,6 @@ func (kv *LevelDBKV) Remove(key string) error {
 	return errors.WithStack(kv.Delete([]byte(key), nil))
 }
 
-// CreateRawTxn implements kv.Base interface.
-func (*LevelDBKV) CreateRawTxn() RawTxn {
-	panic("unimplemented")
-}
-
 // levelDBTxn implements kv.Txn.
 // It utilizes leveldb.Batch to batch user operations to an atomic execution unit.
 type levelDBTxn struct {

--- a/pkg/storage/kv/mem_kv.go
+++ b/pkg/storage/kv/mem_kv.go
@@ -99,11 +99,6 @@ func (kv *memoryKV) Remove(key string) error {
 	return nil
 }
 
-// CreateRawTxn implements kv.Base interface.
-func (*memoryKV) CreateRawTxn() RawTxn {
-	panic("unimplemented")
-}
-
 // memTxn implements kv.Txn.
 type memTxn struct {
 	kv  *memoryKV


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Ref #8978

This ports two review fixes from #10686 back to master.

`kv.Base` currently exposes `CreateRawTxn()`, but the non-etcd backends
implement it by panicking. This makes callers believe every `kv.Base` backend
supports raw transactions even though only etcd does.

The `ErrEtcdTxnResponse` message also says "invalid response", which is
ambiguous. The error actually means that etcd returned an unexpected response
shape.

### What is changed and how does it work?

```commit-message
Split raw transaction creation into a separate `kv.RawTxnCapable` interface
and keep `kv.Base` limited to operations supported by all backends. Remove the
panic-only `CreateRawTxn()` methods from MemKV and LevelDBKV.

Rename the `ErrEtcdTxnResponse` text from "invalid response" to
"unexpected response" while keeping the error code unchanged.
```

### Check List

Tests

- Unit test

Code changes

Side effects

Related changes

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message clarity for etcd transaction failures by updating wording from "invalid response" to "unexpected response".

* **Refactor**
  * Restructured raw transaction API for better separation of concerns.
  * Enhanced error handling for raw transaction creation operations across storage endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->