### PR TITLE
tests: wait for region sync to follower in TestFollowerDirect

### DIFF
--- a/tools/pd-ctl/tests/region/region_test.go
+++ b/tools/pd-ctl/tests/region/region_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/response"
+	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server/api"
 	pdTests "github.com/tikv/pd/tests"
 	ctl "github.com/tikv/pd/tools/pd-ctl/pdctl"
@@ -557,10 +559,13 @@ func (suite *regionTestSuite) followerDirect(cluster *pdTests.TestCluster) {
 			re.NoError(err)
 			re.Contains(string(output), "Failed to get region")
 		} else {
-			output, err := tests.ExecuteCommand(cmd, "-u", serverAddr, "region", "100", "--no-forward")
-			re.NoError(err)
-			outputStr := string(output)
-			re.Contains(outputStr, "\"id\":100")
+			// The region is created on the leader and propagates to followers
+			// asynchronously through the region syncer, so the follower may not
+			// have it yet. Retry until the synced region shows up.
+			testutil.Eventually(re, func() bool {
+				output, err := tests.ExecuteCommand(cmd, "-u", serverAddr, "region", "100", "--no-forward")
+				return err == nil && strings.Contains(string(output), "\"id\":100")
+			})
 		}
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10848

### What is changed and how does it work?

```commit-message
followerDirect writes region 100 on the leader and then immediately queries
each follower with `pd-ctl region 100 --no-forward`. A follower serves the
request from its locally synced region cache, which the region syncer fills
asynchronously, so under CI load the follower can return a 404 before region
100 has been synced, making the test flaky.

Wrap the follower query in testutil.Eventually so it retries until the synced
region shows up.
```

### Check List

Tests

- Integration test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved region test reliability by implementing retry logic with wait mechanisms for follower-side assertions, ensuring tests handle timing-dependent conditions more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->