### PR TITLE
test: stabilize flaky TestRegionSyncer

### DIFF
--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -87,18 +87,46 @@ func TestRegionSyncer(t *testing.T) {
 	})
 	close(mockSyncFull)
 
-	checkRegions := func() {
+	checkRegions := func(expectedRegions []*core.RegionInfo) {
 		// ensure flush to region storage, we use a duration larger than the
 		// region storage flush rate limit (3s).
 		time.Sleep(4 * time.Second)
 
 		// test All regions have been synchronized to the cache of followerServer
 		re.NotNil(followerServer)
-		cacheRegions := leaderServer.GetServer().GetBasicCluster().GetRegions()
-		re.Len(cacheRegions, regionLen)
 		testutil.Eventually(re, func() bool {
-			for _, region := range cacheRegions {
+			leaderRegions := leaderServer.GetServer().GetBasicCluster().GetRegions()
+			followerRegions := followerServer.GetServer().GetBasicCluster().GetRegions()
+			if len(leaderRegions) != len(expectedRegions) || len(followerRegions) != len(expectedRegions) {
+				return false
+			}
+			for _, region := range expectedRegions {
+				leaderRegion := leaderServer.GetServer().GetBasicCluster().GetRegion(region.GetID())
+				if leaderRegion == nil {
+					t.Logf("leader region %d is nil", region.GetID())
+					return false
+				}
+				if region.GetMeta().String() != leaderRegion.GetMeta().String() {
+					t.Logf("region.Meta: %v, leaderRegion.Meta: %v", region.GetMeta().String(), leaderRegion.GetMeta().String())
+					return false
+				}
+				if region.GetStat().String() != leaderRegion.GetStat().String() {
+					t.Logf("region.Stat: %v, leaderRegion.Stat: %v", region.GetStat().String(), leaderRegion.GetStat().String())
+					return false
+				}
+				if region.GetLeader().String() != leaderRegion.GetLeader().String() {
+					t.Logf("region.Leader: %v, leaderRegion.Leader: %v", region.GetLeader().String(), leaderRegion.GetLeader().String())
+					return false
+				}
+				if region.GetBuckets().String() != leaderRegion.GetBuckets().String() {
+					t.Logf("region.Buckets: %v, leaderRegion.Buckets: %v", region.GetBuckets().String(), leaderRegion.GetBuckets().String())
+					return false
+				}
 				r := followerServer.GetServer().GetBasicCluster().GetRegion(region.GetID())
+				if r == nil {
+					t.Logf("follower region %d is nil", region.GetID())
+					return false
+				}
 				if region.GetMeta().String() != r.GetMeta().String() {
 					t.Logf("region.Meta: %v, r.Meta: %v", region.GetMeta().String(), r.GetMeta().String())
 					return false
@@ -117,9 +145,9 @@ func TestRegionSyncer(t *testing.T) {
 				}
 			}
 			return true
-		})
+		}, testutil.WithWaitFor(time.Minute))
 	}
-	checkRegions()
+	checkRegions(regions)
 
 	// merge case
 	// region2 -> region1 -> region0
@@ -166,7 +194,7 @@ func TestRegionSyncer(t *testing.T) {
 		re.NoError(err)
 	}
 
-	checkRegions()
+	checkRegions(regions)
 
 	err = leaderServer.Stop()
 	re.NoError(err)

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -145,7 +145,7 @@ func TestRegionSyncer(t *testing.T) {
 				}
 			}
 			return true
-		}, testutil.WithWaitFor(time.Minute))
+		})
 	}
 	checkRegions(regions)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10546

Problem Summary:
Flaky test `TestRegionSyncer` in `tests/server/region_syncer` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test observed async follower sync through a frozen/default-wait assertion that could expire before the intended region state reached the follower.

#### Fix

The helper now waits for live leader and follower caches to match the intended region set, preserving the original semantic check.

#### Verification

Spec:
- target: `tests/server/region_syncer :: TestRegionSyncer`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target-region-syncer passed.
build passed.

Gate checklist:
- target-region-syncer: PASS
- full-region-syncer-package: SKIPPED
- build: PASS
- native-no-dashboard-repeat: SKIPPED

Commands:
- `go test -json ./tests/server/region_syncer -run '^TestRegionSyncer$' -count=1`
- `make build`

### Release note

```release-note
None
```

Fixes #10546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced region synchronization validation to ensure consistency between leader and follower region caches across updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->