### PR TITLE
test: stabilize flaky TestAffinityHandlerTestSuite/TestBatchDeleteWithForce

### DIFF
--- a/tests/server/apiv2/handlers/affinity_test.go
+++ b/tests/server/apiv2/handlers/affinity_test.go
@@ -1052,8 +1052,10 @@ func (suite *affinityHandlerTestSuite) TestBatchDeleteWithForce() {
 		mustBatchDeleteAffinityGroups(re, serverAddr, &batchDeleteReq)
 
 		// Verify the group is deleted
-		statusCode, _ = doGetAffinityGroup(re, serverAddr, "force-delete")
-		re.Equal(http.StatusNotFound, statusCode)
+		testutil.Eventually(re, func() bool {
+			statusCode, _ = doGetAffinityGroup(re, serverAddr, "force-delete")
+			return statusCode == http.StatusNotFound
+		})
 	})
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10370

Problem Summary:
Flaky test `TestAffinityHandlerTestSuite/TestBatchDeleteWithForce` in `tests/server/apiv2/handlers` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Immediate post-delete GET assertion raced the API-visible read path; the test should wait for the same 404 it already requires.

#### Fix

`testutil.Eventually` preserves the required 404 while removing the invalid single-read timing assumption.

#### Verification

Spec:
- target: `tests/server/apiv2/handlers :: TestAffinityHandlerTestSuite/TestBatchDeleteWithForce`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky passed.
build passed.

Gate checklist:
- target_flaky: PASS
- nextgen_diagnostic: SKIPPED
- build: PASS
- package: SKIPPED

Commands:
- `go test -json ./tests/server/apiv2/handlers -run '^TestAffinityHandlerTestSuite/TestBatchDeleteWithForce$' -count=1`
- `make build`

### Release note

```release-note
None
```

Fixes #10370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of affinity group deletion checks by making post-delete verification retry until the group is confirmed removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->