### PR TITLE
test: stabilize flaky TestControllerWithTwoLimiters

### DIFF
--- a/pkg/ratelimit/controller_test.go
+++ b/pkg/ratelimit/controller_test.go
@@ -49,6 +49,7 @@ func runMulitLabelLimiter(t *testing.T, limiter *Controller, testCase []labelCas
 		caseWG.Add(1)
 		cas := tempCas
 		go func() {
+			defer caseWG.Done()
 			var lock syncutil.Mutex
 			successCount, failedCount := 0, 0
 			var wg sync.WaitGroup
@@ -72,7 +73,6 @@ func runMulitLabelLimiter(t *testing.T, limiter *Controller, testCase []labelCas
 				failedCount -= rd.fail
 				successCount -= rd.success
 			}
-			caseWG.Done()
 		}()
 	}
 	caseWG.Wait()
@@ -324,6 +324,7 @@ func TestControllerWithTwoLimiters(t *testing.T) {
 	re := require.New(t)
 	limiter := NewController(context.Background(), "grpc", nil)
 	defer limiter.Close()
+	slowQPSLimit := rate.Every(time.Hour)
 	testCase := []labelCase{
 		{
 			label: "test1",
@@ -375,7 +376,7 @@ func TestControllerWithTwoLimiters(t *testing.T) {
 			label: "test2",
 			round: []changeAndResult{
 				{
-					opt: UpdateQPSLimiter(50, 5),
+					opt: UpdateQPSLimiter(float64(slowQPSLimit), 5),
 					checkOptionStatus: func(label string, o Option) {
 						status := limiter.Update(label, o)
 						re.NotZero(status & LimiterUpdated)
@@ -386,7 +387,7 @@ func TestControllerWithTwoLimiters(t *testing.T) {
 					waitDuration: time.Second,
 					checkStatusFunc: func(label string) {
 						limit, burst := limiter.GetQPSLimiterStatus(label)
-						re.Equal(rate.Limit(50), limit)
+						re.Equal(slowQPSLimit, limit)
 						re.Equal(5, burst)
 					},
 				},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10357

Problem Summary:
Flaky test `TestControllerWithTwoLimiters` in `pkg/ratelimit` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The burst-count assertion used a limiter that could refill during the request batch under slow scheduling.

#### Fix

Slowing refill for the burst-only case preserves the intended burst check, and deferred Done prevents assertion-induced hangs.

#### Verification

Spec:
- target: `pkg/ratelimit :: TestControllerWithTwoLimiters`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_validation passed.
package_validation passed.
build_safety_gate passed.

Gate checklist:
- diagnostic_timing_repro: SKIPPED
- target_flaky_validation: PASS
- package_validation: PASS
- build_safety_gate: PASS
- diff_whitespace: SKIPPED
- external_ci: SKIPPED

Commands:
- `go test -json ./pkg/ratelimit -run '^TestControllerWithTwoLimiters$' -count=1`
- `go test -json ./pkg/ratelimit -count=1`
- `make build`

### Release note

```release-note
None
```

Fixes #10357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved rate limiting controller tests with enhanced goroutine synchronization and updated test configurations for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->