### PR TITLE
client: cherry-pick resource control bugfixes (#10543, #10724)

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -322,10 +322,6 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 			stateUpdateTicker.Reset(time.Millisecond * 100)
 		})
 
-		_, metaRevision, err := c.provider.LoadResourceGroups(ctx)
-		if err != nil {
-			log.Warn("load resource group revision failed", zap.Error(err))
-		}
 		resp, err := c.provider.Get(ctx, []byte(controllerConfigPath))
 		if err != nil {
 			log.Warn("load resource group revision failed", zap.Error(err))
@@ -335,7 +331,7 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 		if !c.ruConfig.isSingleGroupByKeyspace {
 			// Use WithPrevKV() to get the previous key-value pair when get Delete Event.
 			prefix := pd.GroupSettingsPathPrefixBytes(c.keyspaceID)
-			watchMetaChannel, err = c.provider.Watch(ctx, prefix, opt.WithRev(metaRevision), opt.WithPrefix(), opt.WithPrevKV())
+			watchMetaChannel, err = c.provider.Watch(ctx, prefix, opt.WithPrefix(), opt.WithPrevKV())
 			if err != nil {
 				log.Warn("watch resource group meta failed", zap.Error(err))
 			}
@@ -363,7 +359,7 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 				if !c.ruConfig.isSingleGroupByKeyspace && watchMetaChannel == nil {
 					// Use WithPrevKV() to get the previous key-value pair when get Delete Event.
 					prefix := pd.GroupSettingsPathPrefixBytes(c.keyspaceID)
-					watchMetaChannel, err = c.provider.Watch(ctx, prefix, opt.WithRev(metaRevision), opt.WithPrefix(), opt.WithPrevKV())
+					watchMetaChannel, err = c.provider.Watch(ctx, prefix, opt.WithPrefix(), opt.WithPrevKV())
 					if err != nil {
 						log.Warn("watch resource group meta failed", zap.Error(err))
 						watchRetryTimer.Reset(watchRetryInterval)
@@ -417,7 +413,6 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 					continue
 				}
 				for _, item := range resp {
-					metaRevision = item.Kv.ModRevision
 					group := &rmpb.ResourceGroup{}
 					switch item.Type {
 					case meta_storagepb.Event_PUT:

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -141,6 +141,8 @@ type tokenCounter struct {
 		setupNotificationCh        <-chan time.Time
 		setupNotificationThreshold float64
 		setupNotificationTimer     *time.Timer
+		// cancelCh wakes up handleTokenBucketUpdateEvent when the timer is stopped.
+		cancelCh chan struct{}
 	}
 
 	lastDeadline time.Time
@@ -283,18 +285,27 @@ func (gc *groupCostController) handleTokenBucketUpdateEvent(ctx context.Context)
 	counter := gc.run.requestUnitTokens
 	counter.notify.mu.Lock()
 	ch := counter.notify.setupNotificationCh
+	cancelCh := counter.notify.cancelCh
 	counter.notify.mu.Unlock()
-	if ch == nil {
+	if ch == nil || cancelCh == nil {
 		return
 	}
 	select {
 	case <-ch:
 		counter.notify.mu.Lock()
-		counter.notify.setupNotificationTimer = nil
-		counter.notify.setupNotificationCh = nil
+		if counter.notify.setupNotificationCh != ch || counter.notify.cancelCh != cancelCh {
+			counter.notify.mu.Unlock()
+			return
+		}
 		threshold := counter.notify.setupNotificationThreshold
-		counter.notify.mu.Unlock()
+		cancelCh = resetCounterNotifyLocked(counter)
 		counter.limiter.SetupNotificationThreshold(threshold)
+		counter.notify.mu.Unlock()
+		if cancelCh != nil {
+			close(cancelCh)
+		}
+	case <-cancelCh:
+		return
 	case <-ctx.Done():
 		return
 	}
@@ -395,6 +406,7 @@ func (gc *groupCostController) modifyTokenCounter(counter *tokenCounter, bucket 
 		}
 		counter.notify.setupNotificationTimer = time.NewTimer(timerDuration)
 		counter.notify.setupNotificationCh = counter.notify.setupNotificationTimer.C
+		counter.notify.cancelCh = make(chan struct{})
 		counter.notify.setupNotificationThreshold = 1
 		counter.notify.mu.Unlock()
 		counter.lastDeadline = deadline
@@ -411,12 +423,22 @@ func (gc *groupCostController) modifyTokenCounter(counter *tokenCounter, bucket 
 
 func initCounterNotify(counter *tokenCounter) {
 	counter.notify.mu.Lock()
+	cancelCh := resetCounterNotifyLocked(counter)
+	counter.notify.mu.Unlock()
+	if cancelCh != nil {
+		close(cancelCh)
+	}
+}
+
+func resetCounterNotifyLocked(counter *tokenCounter) chan struct{} {
 	if counter.notify.setupNotificationTimer != nil {
 		counter.notify.setupNotificationTimer.Stop()
-		counter.notify.setupNotificationTimer = nil
-		counter.notify.setupNotificationCh = nil
 	}
-	counter.notify.mu.Unlock()
+	cancelCh := counter.notify.cancelCh
+	counter.notify.setupNotificationTimer = nil
+	counter.notify.setupNotificationCh = nil
+	counter.notify.cancelCh = nil
+	return cancelCh
 }
 
 func (gc *groupCostController) collectRequestAndConsumption(selectTyp selectType) *rmpb.TokenBucketRequest {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -209,6 +209,83 @@ func TestOnResponseWaitConsumption(t *testing.T) {
 	verify()
 }
 
+func TestHandleTokenBucketUpdateEventCanceledByInitCounterNotify(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	counter := gc.run.requestUnitTokens
+
+	counter.notify.mu.Lock()
+	counter.notify.setupNotificationTimer = time.NewTimer(time.Hour)
+	counter.notify.setupNotificationCh = counter.notify.setupNotificationTimer.C
+	counter.notify.setupNotificationThreshold = 1
+	counter.notify.cancelCh = make(chan struct{})
+	counter.notify.mu.Unlock()
+	defer initCounterNotify(counter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		gc.handleTokenBucketUpdateEvent(ctx)
+		close(done)
+	}()
+
+	require.Never(t, func() bool {
+		return isClosed(done)
+	}, 50*time.Millisecond, 5*time.Millisecond)
+
+	initCounterNotify(counter)
+	require.Eventually(t, func() bool {
+		return isClosed(done)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestHandleTokenBucketUpdateEventCleansNotifyOnTimer(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	counter := gc.run.requestUnitTokens
+	threshold := 42.0
+
+	counter.notify.mu.Lock()
+	counter.notify.setupNotificationTimer = time.NewTimer(10 * time.Millisecond)
+	counter.notify.setupNotificationCh = counter.notify.setupNotificationTimer.C
+	counter.notify.setupNotificationThreshold = threshold
+	counter.notify.cancelCh = make(chan struct{})
+	counter.notify.mu.Unlock()
+	defer initCounterNotify(counter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		gc.handleTokenBucketUpdateEvent(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return isClosed(done)
+	}, time.Second, 10*time.Millisecond)
+
+	counter.notify.mu.Lock()
+	re.Nil(counter.notify.setupNotificationTimer)
+	re.Nil(counter.notify.setupNotificationCh)
+	re.Nil(counter.notify.cancelCh)
+	counter.notify.mu.Unlock()
+
+	counter.limiter.mu.Lock()
+	re.Equal(threshold, counter.limiter.notifyThreshold)
+	counter.limiter.mu.Unlock()
+}
+
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
 func TestResourceGroupThrottledError(t *testing.T) {
 	re := require.New(t)
 	gc := createTestGroupCostController(re)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10516, ref #10542, ref #9745

Align the basic Resource Control capability of `release-nextgen-202603` with `master` by carrying over the client-side bugfixes that landed on `master` after this branch was cut:

- #10543: client: remove meta revision
- #10724: client: signal RG GC goroutines to exit properly

Together with the already-merged #10845 (pick of #10745), all Resource Control bugfixes on `master` since the branch point are now covered on this branch.

### What is changed and how does it work?

Two cherry-picks from `master`, both with `-x` provenance:

1. **client: remove meta revision (#10543)** — cherry picked from e430bd0966
   - Stop loading the initial resource-group revision only for watch startup, stop passing `WithRev(metaRevision)` when (re)creating the resource group meta watch, and stop updating `metaRevision` from watched events. This avoids watch failures caused by stale revisions.
   - Note: the upstream commit also contained a whitespace-only gofmt re-alignment in `server/cluster/cluster.go`. That hunk is dropped here because it realigns the `RaftCluster` struct around the `tsoDynamicSwitchingState` field introduced by #10439, which does not exist on this branch; keeping this branch's original alignment is the gofmt-correct form. Verified with `git range-diff` that this is the only deviation from the upstream commit.

2. **client: signal RG GC goroutines to exit properly (#10724)** — cherry picked from 88f4e3d0eb, applied cleanly
   - Add a cancellation channel for pending token bucket notification timers so that resetting the token counter wakes `handleTokenBucketUpdateEvent` instead of leaving it blocked on a stopped timer. Reuse the cleanup path when the timer fires normally, with regression tests covering both the reset and normal-firing paths.

Local verification: `git range-diff` against both upstream commits, client module build, and the full `client/resource_group/controller` test suite (failpoints enabled) all pass.

```commit-message
Carry over two Resource Control client bugfixes from master:
- Remove the resource-group meta revision cursor from the client watch
  path so the meta watch no longer starts from a possibly stale revision.
- Add a cancellation channel for pending token bucket notification timers
  so resetting the counter wakes handleTokenBucketUpdateEvent instead of
  leaving it blocked on a stopped timer.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix a goroutine leak in the resource group client controller when token bucket notification timers are reset.
```