### PR TITLE
test: stabilize flaky TestAffinityHandlerTestSuite/TestAffinityListWithEmptyID

### DIFF
--- a/tests/server/apiv2/handlers/affinity_test.go
+++ b/tests/server/apiv2/handlers/affinity_test.go
@@ -900,9 +900,13 @@ func (suite *affinityHandlerTestSuite) TestAffinityListWithEmptyID() {
 		mustCreateAffinityGroups(re, serverAddr, &createReq)
 
 		var result handlers.AffinityGroupsResponse
-		err := testutil.ReadGetJSON(re, tests.TestDialClient, getAffinityGroupURL(serverAddr)+"?ids=&ids=group-2", &result)
-		re.NoError(err)
-		re.Len(result.AffinityGroups, 1)
+		testutil.Eventually(re, func() bool {
+			result = handlers.AffinityGroupsResponse{}
+			err := testutil.ReadGetJSON(re, tests.TestDialClient, getAffinityGroupURL(serverAddr)+"?ids=&ids=group-2", &result)
+			re.NoError(err)
+			_, ok := result.AffinityGroups["group-2"]
+			return len(result.AffinityGroups) == 1 && ok
+		})
 		re.Contains(result.AffinityGroups, "group-2")
 	})
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10857

Problem Summary:
Flaky test `TestAffinityHandlerTestSuite/TestAffinityListWithEmptyID` in `github.com/tikv/pd/tests/server/apiv2/handlers` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Immediate assertion raced asynchronous scheduling microservice watcher propagation after affinity group creation.

#### Fix

Waiting for the intended group visibility removes the invalid read-your-write timing assumption while still requiring exactly one returned group.

#### Verification

Spec:
- target: `github.com/tikv/pd/tests/server/apiv2/handlers :: TestAffinityHandlerTestSuite/TestAffinityListWithEmptyID`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_acceptance passed.
build passed.

Gate checklist:
- timing_repro: SKIPPED
- target_acceptance: PASS
- package_advisory: SKIPPED
- build: PASS
- external_ci: SKIPPED

Commands:
- `go test -json ./tests/server/apiv2/handlers -run '^TestAffinityHandlerTestSuite/TestAffinityListWithEmptyID$' -count=1`
- `make build`

### Release note

```release-note
None
```

Fixes #10857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved resilience of affinity-group listing test to handle asynchronous state updates more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->