### PR TITLE
test: stabilize flaky TestHotTestSuite/TestBuckets

### DIFF
--- a/tools/pd-ctl/tests/hot/hot_test.go
+++ b/tools/pd-ctl/tests/hot/hot_test.go
@@ -551,4 +551,8 @@ func (suite *hotTestSuite) checkBuckets(cluster *pdTests.TestCluster) {
 	hotBuckets = handler.HotBucketsResponse{}
 	re.NoError(json.Unmarshal(output, &hotBuckets))
 	re.Nil(hotBuckets[2])
+	hotStat := cluster.GetLeaderServer().GetRaftCluster().GetHotStat()
+	// Drain async hot peer updates before TearDownTest resets the hot cache directly.
+	re.NotNil(hotStat.GetHotPeerStats(utils.Write, 0))
+	re.NotNil(hotStat.GetHotPeerStats(utils.Read, 0))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10651

Problem Summary:
Flaky test `TestHotTestSuite/TestBuckets` in `github.com/tikv/pd/tools/pd-ctl/tests/hot` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

TestBuckets teardown can race with queued HotPeerCache worker updates.

#### Fix

Calling synchronous write/read hot peer stat getters drains the queues before TearDownTest resets the cache.

#### Verification

Spec:
- target: `github.com/tikv/pd/tools/pd-ctl/tests/hot :: TestHotTestSuite/TestBuckets`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: failed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
corrected-target passed.
race-diagnostic passed.

Gate checklist:
- supplied-target-path: SKIPPED
- supplied-package-path: SKIPPED
- corrected-target: PASS
- race-diagnostic: PASS
- build: BLOCKED

Commands:
- `cd tools && go test -json -tags without_dashboard ./pd-ctl/tests/hot -run '^TestHotTestSuite/TestBuckets$' -count=1`
- `cd tools && go test -race -tags without_dashboard ./pd-ctl/tests/hot -run '^TestHotTestSuite/TestBuckets$' -count=1`

### Release note

```release-note
None
```

Fixes #10651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced hot-statistics validation by adding assertions to confirm write and read peer stats are present at interval 0 before test teardown, improving test stability and preventing flaky failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->