### PR TITLE
test: stabilize flaky TestUpgradingPDAndTSOClusters

### DIFF
--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -684,6 +684,9 @@ func TestUpgradingPDAndTSOClusters(t *testing.T) {
 
 	// Create a PD client in microservice env to let the PD leader to forward requests to the TSO cluster.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/client/servicediscovery/usePDServiceMode", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/client/servicediscovery/usePDServiceMode"))
+	}()
 	pdClient, err := pd.NewClientWithContext(ctx,
 		caller.TestComponent,
 		[]string{backendEndpoints}, pd.SecurityOption{}, opt.WithMaxErrorRetry(1))
@@ -693,6 +696,11 @@ func TestUpgradingPDAndTSOClusters(t *testing.T) {
 	// Create a TSO cluster which has 2 servers
 	tsoCluster, err := tests.NewTestTSOCluster(ctx, 2, backendEndpoints)
 	re.NoError(err)
+	defer func() {
+		if tsoCluster != nil {
+			tsoCluster.Destroy()
+		}
+	}()
 	tsoCluster.WaitForDefaultPrimaryServing(re)
 	// The TSO service should be eventually healthy
 	utils.WaitForTSOServiceAvailable(ctx, re, pdClient)
@@ -706,11 +714,9 @@ func TestUpgradingPDAndTSOClusters(t *testing.T) {
 	// Restart the TSO cluster
 	tsoCluster, err = tests.RestartTestTSOCluster(ctx, tsoCluster)
 	re.NoError(err)
-	defer tsoCluster.Destroy()
+	tsoCluster.WaitForDefaultPrimaryServing(re)
 	// The TSO service should be eventually healthy
 	utils.WaitForTSOServiceAvailable(ctx, re, pdClient)
-
-	re.NoError(failpoint.Disable("github.com/tikv/pd/client/servicediscovery/usePDServiceMode"))
 }
 
 func checkTSO(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10858

Problem Summary:
Flaky test `TestUpgradingPDAndTSOClusters` in `github.com/tikv/pd/tests/integrations/tso` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test probed TSO availability immediately after restarting the TSO cluster without first waiting for the restarted default primary to serve.

#### Fix

Waiting for the restarted default primary preserves the upgrade availability check while closing the readiness race; deferred cleanup prevents failpoint/cluster leakage on early failure.

#### Verification

Spec:
- target: `github.com/tikv/pd/tests/integrations/tso :: TestUpgradingPDAndTSOClusters`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- submission decision: ALLOWED
- note: failpoint_target_flaky passed.
build passed.

Gate checklist:
- raw_prompt_target_path_mismatch: SKIPPED
- failpoint_target_flaky: PASS
- raw_prompt_package_path_mismatch: SKIPPED
- build: PASS

Commands:
- `cd tests/integrations && make gotest GOTEST_ARGS="-json -tags=without_dashboard ./tso -run TestUpgradingPDAndTSOClusters -count=1"`
- `make build`

### Release note

```release-note
None
```

Fixes #10858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TSO cluster integration test reliability through enhanced resource cleanup handling and deferred function registration.

* **Chores**
  * Tightened test cleanup sequences for better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->