### PR TITLE
test: stabilize flaky TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestWatchWithSingleGroupByKeyspace

### DIFF
--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -689,6 +689,12 @@ func (suite *resourceManagerClientTestSuite) TestWatchWithSingleGroupByKeyspace(
 	resp, err := cli.AddResourceGroup(suite.ctx, group)
 	re.NoError(err)
 	re.Contains(resp, "Success!")
+	// Under standalone RM discovery, metadata writes are applied on PD first and
+	// become visible to the RM service after the metadata watcher catches up.
+	testutil.Eventually(re, func() bool {
+		_, getErr := cli.GetResourceGroup(suite.ctx, group.Name)
+		return getErr == nil
+	}, testutil.WithTickInterval(50*time.Millisecond))
 
 	tcs := tokenConsumptionPerSecond{rruTokensAtATime: 100}
 	_, _, _, _, err = controller.OnRequestWait(suite.ctx, group.Name, tcs.makeReadRequest())

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -626,7 +626,14 @@ func (suite *resourceManagerClientTestSuite) TestWatchResourceGroup() {
 	re.NoError(err)
 	re.Contains(resp, "Success!")
 	// Make sure the resource group active
-	meta, err = controller.GetResourceGroup(group.Name)
+	testutil.Eventually(re, func() bool {
+		meta, err = controller.GetResourceGroup(group.Name)
+		if err != nil || meta == nil {
+			return false
+		}
+		meta = controller.GetActiveResourceGroup(group.Name)
+		return meta != nil
+	}, testutil.WithTickInterval(50*time.Millisecond))
 	re.NotNil(meta)
 	re.NoError(err)
 	modifySettings(group, 30000)
@@ -635,7 +642,7 @@ func (suite *resourceManagerClientTestSuite) TestWatchResourceGroup() {
 	re.Contains(resp, "Success!")
 	testutil.Eventually(re, func() bool {
 		meta = controller.GetActiveResourceGroup(group.Name)
-		return meta.RUSettings.RU.Settings.FillRate == uint64(30000)
+		return meta != nil && meta.RUSettings.RU.Settings.FillRate == uint64(30000)
 	}, testutil.WithTickInterval(100*time.Millisecond))
 	re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/watchStreamError"))
 
@@ -1520,7 +1527,7 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 	_, err := cli.AddResourceGroup(suite.ctx, group)
 	re.NoError(err)
 
-	waitForResourceGroup := func(expected *rmpb.ResourceGroup, opts ...pd.GetResourceGroupOption) *rmpb.ResourceGroup {
+	waitForResourceGroup := func(expected *rmpb.ResourceGroup, opts ...pd.GetResourceGroupOption) {
 		var (
 			got    *rmpb.ResourceGroup
 			getErr error
@@ -1531,10 +1538,9 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 		}, testutil.WithTickInterval(50*time.Millisecond))
 		re.NoError(getErr)
 		re.Equal(expected, got)
-		return got
 	}
 
-	g := waitForResourceGroup(group)
+	waitForResourceGroup(group)
 
 	// Test Resource Group Stats
 	testConsumption := &rmpb.Consumption{
@@ -1562,7 +1568,7 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 	})
 	re.NoError(err)
 	time.Sleep(10 * time.Millisecond)
-	g, err = cli.GetResourceGroup(suite.ctx, group.Name, pd.WithRUStats)
+	g, err := cli.GetResourceGroup(suite.ctx, group.Name, pd.WithRUStats)
 	re.NoError(err)
 	re.Equal(g.RUStats, testConsumption)
 

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -1519,9 +1520,21 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 	_, err := cli.AddResourceGroup(suite.ctx, group)
 	re.NoError(err)
 
-	g, err := cli.GetResourceGroup(suite.ctx, group.Name)
-	re.NoError(err)
-	re.Equal(group, g)
+	waitForResourceGroup := func(expected *rmpb.ResourceGroup, opts ...pd.GetResourceGroupOption) *rmpb.ResourceGroup {
+		var (
+			got    *rmpb.ResourceGroup
+			getErr error
+		)
+		testutil.Eventually(re, func() bool {
+			got, getErr = cli.GetResourceGroup(suite.ctx, expected.Name, opts...)
+			return getErr == nil && reflect.DeepEqual(expected, got)
+		}, testutil.WithTickInterval(50*time.Millisecond))
+		re.NoError(getErr)
+		re.Equal(expected, got)
+		return got
+	}
+
+	g := waitForResourceGroup(group)
 
 	// Test Resource Group Stats
 	testConsumption := &rmpb.Consumption{
@@ -1557,9 +1570,7 @@ func (suite *resourceManagerClientTestSuite) TestResourceGroupRUConsumption() {
 	g.RUSettings.RU.Settings.FillRate = 12345
 	_, err = cli.ModifyResourceGroup(suite.ctx, g)
 	re.NoError(err)
-	g1, err := cli.GetResourceGroup(suite.ctx, group.Name, pd.WithRUStats)
-	re.NoError(err)
-	re.Equal(g1, g)
+	waitForResourceGroup(g, pd.WithRUStats)
 
 	// test leader change
 	time.Sleep(250 * time.Millisecond)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10650

Problem Summary:
Flaky test `TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestWatchWithSingleGroupByKeyspace` in `github.com/tikv/pd/tests/integrations/mcs/resourcemanager` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test did not wait for PD-written RM metadata to become visible through the standalone RM metadata watcher before forcing controller load.

#### Fix

Waiting with `cli.GetResourceGroup` establishes the RM read-path visibility precondition without preloading the controller under test.

#### Verification

Spec:
- target: `github.com/tikv/pd/tests/integrations/mcs/resourcemanager :: TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestWatchWithSingleGroupByKeyspace`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- submission decision: ALLOWED
- note: target_json passed.
package passed.
build passed.

Gate checklist:
- native_target: SKIPPED
- target_json: PASS
- package: PASS
- build: PASS

Commands:
- `bash -lc 'set -e; repo=$(pwd); make failpoint-enable; trap "cd \"$repo\" && make failpoint-disable" EXIT; cd tests/integrations; go test -json -tags without_dashboard ./mcs/resourcemanager -run "^TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestWatchWithSingleGroupByKeyspace$" -count=1'`
- `cd tests/integrations && make gotest GOTEST_ARGS='-tags without_dashboard ./mcs/resourcemanager -count=1'`
- `make build`

### Release note

```release-note
None
```

Fixes #10650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved synchronization in resource manager tests by polling for resource group availability and active metadata before running follow-up assertions, reducing intermittent failures due to propagation and watch timing.
  * Added a reusable wait helper that repeatedly fetches resource group state and performs deep equality checks (including RU stats) until the expected configuration is fully visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->