### PR TITLE
[release-nextgen-202603] server/resource_group: add allocation observability

### DIFF
--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -251,6 +251,7 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 			if req.GetIsBackground() {
 				continue
 			}
+			keyspaceName := s.manager.getKeyspaceNameForMetrics(s.ctx, keyspaceID)
 			now := time.Now()
 			resp := &rmpb.TokenBucketResponse{
 				ResourceGroupName: rg.Name,
@@ -269,7 +270,7 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 						grt := krgm.getOrCreateGroupRUTracker(rg.Name)
 						grt.sample(clientUniqueID, now, requiredToken)
 						// Request the tokens from the resource group.
-						tokens = rg.RequestRU(now, requiredToken, targetPeriodMs, clientUniqueID, grt, krgm.getServiceLimiter())
+						tokens = rg.RequestRU(now, requiredToken, targetPeriodMs, clientUniqueID, keyspaceName, grt, krgm.getServiceLimiter())
 					}
 					if tokens == nil {
 						continue

--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -269,8 +269,9 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 						// Sample the latest RU demand.
 						grt := krgm.getOrCreateGroupRUTracker(rg.Name)
 						grt.sample(clientUniqueID, now, requiredToken)
+						metrics := s.manager.metrics.getRequestMetrics(keyspaceID, keyspaceName, rg.Name, now)
 						// Request the tokens from the resource group.
-						tokens = rg.RequestRU(now, requiredToken, targetPeriodMs, clientUniqueID, keyspaceName, grt, krgm.getServiceLimiter())
+						tokens = rg.RequestRU(now, requiredToken, targetPeriodMs, clientUniqueID, keyspaceName, grt, krgm.getServiceLimiter(), metrics)
 					}
 					if tokens == nil {
 						continue

--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -251,7 +251,7 @@ func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBu
 			if req.GetIsBackground() {
 				continue
 			}
-			keyspaceName := s.manager.getKeyspaceNameForMetrics(s.ctx, keyspaceID)
+			keyspaceName := s.manager.getCachedKeyspaceNameForMetrics(keyspaceID)
 			now := time.Now()
 			resp := &rmpb.TokenBucketResponse{
 				ResourceGroupName: rg.Name,

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -670,6 +670,17 @@ func (m *Manager) getKeyspaceNameByID(ctx context.Context, id uint32) (string, e
 	return loadedName, nil
 }
 
+func (m *Manager) getKeyspaceNameForMetrics(ctx context.Context, id uint32) string {
+	name, err := m.getKeyspaceNameByID(ctx, id)
+	if err == nil {
+		return name
+	}
+	if id == constant.NullKeyspaceID {
+		return ""
+	}
+	return fmt.Sprintf("keyspace-%d", id)
+}
+
 func (m *Manager) updateKeyspaceNameLookup(id uint32, name string) {
 	m.Lock()
 	defer m.Unlock()
@@ -732,10 +743,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				continue
 			}
 			keyspaceID := consumptionInfo.keyspaceID
-			keyspaceName, err := m.getKeyspaceNameByID(ctx, keyspaceID)
-			if err != nil {
-				continue
-			}
+			keyspaceName := m.getKeyspaceNameForMetrics(ctx, keyspaceID)
 			consumptionInfo.keyspaceName = keyspaceName
 			m.ruCollector.Collect(consumptionInfo)
 			m.metrics.recordConsumption(consumptionInfo, m.GetControllerConfig(), time.Now())
@@ -749,10 +757,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				if time.Since(lastTime) <= metricsCleanupTimeout {
 					continue
 				}
-				keyspaceName, err := m.getKeyspaceNameByID(ctx, r.keyspaceID)
-				if err != nil {
-					continue
-				}
+				keyspaceName := m.getKeyspaceNameForMetrics(ctx, r.keyspaceID)
 				m.metrics.cleanupAllMetrics(r, keyspaceName)
 				m.ruCollector.remove(keyspaceName)
 			}
@@ -779,10 +784,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				// Conciliate the fill rates.
 				krgm.conciliateFillRates()
 				// Record the metrics.
-				keyspaceName, err := m.getKeyspaceNameByID(ctx, krgm.keyspaceID)
-				if err != nil {
-					continue
-				}
+				keyspaceName := m.getKeyspaceNameForMetrics(ctx, krgm.keyspaceID)
 				setOrRemoveServiceLimitMetrics(keyspaceName, krgm.getServiceLimiter().getServiceLimit())
 
 				for _, group := range krgm.getResourceGroupList(true, true) {

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -767,9 +767,10 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 		case <-cleanUpTicker.C:
 			// Clean up the metrics that have not been updated for a long time.
 			for _, r := range m.metrics.getStaleConsumptionRecords(time.Now()) {
-				keyspaceName := m.getKeyspaceNameForMetrics(ctx, r.keyspaceID)
-				m.metrics.cleanupAllMetrics(r, keyspaceName)
-				m.ruCollector.remove(keyspaceName)
+				keyspaceName := m.getKeyspaceNameForMetrics(ctx, r.key.keyspaceID)
+				if m.metrics.cleanupStaleMetrics(r, keyspaceName) {
+					m.ruCollector.remove(keyspaceName)
+				}
 			}
 			// Clean up the stale RU trackers.
 			for _, krgm := range m.getKeyspaceResourceGroupManagers() {
@@ -802,7 +803,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 
 func (m *Manager) flushResourceGroupMetrics(ctx context.Context, krgm *keyspaceResourceGroupManager) {
 	keyspaceName := m.getKeyspaceNameForMetrics(ctx, krgm.keyspaceID)
-	setOrRemoveServiceLimitMetrics(keyspaceName, krgm.getServiceLimiter().getServiceLimit())
+	m.metrics.setOrRemoveServiceLimitMetrics(krgm.keyspaceID, keyspaceName, krgm.getServiceLimiter().getServiceLimit())
 
 	for _, group := range krgm.getMutableResourceGroupList() {
 		groupName := group.Name

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -681,6 +681,19 @@ func (m *Manager) getKeyspaceNameForMetrics(ctx context.Context, id uint32) stri
 	return fmt.Sprintf("keyspace-%d", id)
 }
 
+func (m *Manager) getCachedKeyspaceNameForMetrics(id uint32) string {
+	if id == constant.NullKeyspaceID {
+		return ""
+	}
+	m.RLock()
+	name, ok := m.keyspaceNameLookup[id]
+	m.RUnlock()
+	if ok {
+		return name
+	}
+	return fmt.Sprintf("keyspace-%d", id)
+}
+
 func (m *Manager) updateKeyspaceNameLookup(id uint32, name string) {
 	m.Lock()
 	defer m.Unlock()

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -784,21 +784,25 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 				// Conciliate the fill rates.
 				krgm.conciliateFillRates()
 				// Record the metrics.
-				keyspaceName := m.getKeyspaceNameForMetrics(ctx, krgm.keyspaceID)
-				setOrRemoveServiceLimitMetrics(keyspaceName, krgm.getServiceLimiter().getServiceLimit())
-
-				for _, group := range krgm.getResourceGroupList(true, true) {
-					groupName := group.Name
-					// Record the sum of RRU and WRU every second.
-					m.metrics.getMaxPerSecTracker(krgm.keyspaceID, keyspaceName, groupName).flushMetrics()
-					metrics := m.metrics.getGaugeMetrics(krgm.keyspaceID, keyspaceName, groupName)
-					metrics.setGroup(group, keyspaceName)
-					// Record the tracked RU per second.
-					if grt := krgm.getGroupRUTracker(groupName); grt != nil {
-						metrics.setSampledRUPerSec(grt.getRUPerSec())
-					}
-				}
+				m.flushResourceGroupMetrics(ctx, krgm)
 			}
+		}
+	}
+}
+
+func (m *Manager) flushResourceGroupMetrics(ctx context.Context, krgm *keyspaceResourceGroupManager) {
+	keyspaceName := m.getKeyspaceNameForMetrics(ctx, krgm.keyspaceID)
+	setOrRemoveServiceLimitMetrics(keyspaceName, krgm.getServiceLimiter().getServiceLimit())
+
+	for _, group := range krgm.getMutableResourceGroupList() {
+		groupName := group.Name
+		// Record the sum of RRU and WRU every second.
+		m.metrics.getMaxPerSecTracker(krgm.keyspaceID, keyspaceName, groupName).flushMetrics()
+		metrics := m.metrics.getGaugeMetrics(krgm.keyspaceID, keyspaceName, groupName)
+		metrics.setGroup(group, keyspaceName)
+		// Record the tracked RU per second.
+		if grt := krgm.getGroupRUTracker(groupName); grt != nil {
+			metrics.setSampledRUPerSec(grt.getRUPerSec())
 		}
 	}
 }

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -753,10 +753,7 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 			}
 		case <-cleanUpTicker.C:
 			// Clean up the metrics that have not been updated for a long time.
-			for r, lastTime := range m.metrics.consumptionRecordMap {
-				if time.Since(lastTime) <= metricsCleanupTimeout {
-					continue
-				}
+			for _, r := range m.metrics.getStaleConsumptionRecords(time.Now()) {
 				keyspaceName := m.getKeyspaceNameForMetrics(ctx, r.keyspaceID)
 				m.metrics.cleanupAllMetrics(r, keyspaceName)
 				m.ruCollector.remove(keyspaceName)

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -28,7 +28,6 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/goleak"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 
@@ -518,18 +517,12 @@ func TestCleanUpTicker(t *testing.T) {
 		groupName:  "test_group_2",
 		ruType:     defaultTypeLabel,
 	}] = time.Now().Add(-metricsCleanupTimeout / 2)
-	// Start the background metrics flush loop.
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/mcs/resourcemanager/server/fastCleanupTicker", `return(true)`))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/mcs/resourcemanager/server/fastCleanupTicker"))
-	}()
-	err := m.Init(ctx)
-	re.NoError(err)
-	// Ensure the cleanup ticker is triggered.
-	time.Sleep(200 * time.Millisecond)
-	// Close the manager to avoid the data race.
-	m.close()
-
+	keyspaceName := m.getKeyspaceNameForMetrics(ctx, keyspaceID)
+	m.metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  "test_group_1",
+		ruType:     defaultTypeLabel,
+	}, keyspaceName)
 	re.Len(m.metrics.consumptionRecordMap, 1)
 	re.Contains(m.metrics.consumptionRecordMap, consumptionRecordKey{
 		keyspaceID: keyspaceID,
@@ -624,6 +617,7 @@ func TestKeyspaceNameLookup(t *testing.T) {
 	name, err = m.getKeyspaceNameByID(ctx, 1)
 	re.Error(err)
 	re.Empty(name)
+	re.Equal("keyspace-1", m.getKeyspaceNameForMetrics(ctx, 1))
 	// Get the keyspace ID by name first, then get the keyspace name by ID.
 	prepareKeyspaceName(ctx, re, m, &rmpb.KeyspaceIDValue{Value: 1}, "test_keyspace")
 	idValue, err = m.GetKeyspaceIDByName(ctx, "test_keyspace")

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -564,7 +564,9 @@ func TestFlushResourceGroupMetricsDrainsLiveSlotEvents(t *testing.T) {
 			},
 		}),
 	}
-	rg.RUSettings.RU.tokenSlots[1] = &tokenSlot{curTokenCapacity: -12.5}
+	slot := newTokenSlot(1, time.Now())
+	rg.RUSettings.RU.tokenSlots[1] = slot
+	rg.RUSettings.RU.setSlotTokenCapacity(slot, -12.5)
 	rg.RUSettings.RU.slotsCreated = 2
 	rg.RUSettings.RU.slotsDeleted = 1
 	rg.RUSettings.RU.slotsExpired = 3

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -675,6 +675,7 @@ func TestKeyspaceNameLookup(t *testing.T) {
 	re.Error(err)
 	re.Empty(name)
 	re.Equal("keyspace-1", m.getKeyspaceNameForMetrics(ctx, 1))
+	re.Equal("keyspace-1", m.getCachedKeyspaceNameForMetrics(1))
 	// Get the keyspace ID by name first, then get the keyspace name by ID.
 	prepareKeyspaceName(ctx, re, m, &rmpb.KeyspaceIDValue{Value: 1}, "test_keyspace")
 	idValue, err = m.GetKeyspaceIDByName(ctx, "test_keyspace")
@@ -684,6 +685,8 @@ func TestKeyspaceNameLookup(t *testing.T) {
 	name, err = m.getKeyspaceNameByID(ctx, 1)
 	re.NoError(err)
 	re.Equal("test_keyspace", name)
+	re.Equal("test_keyspace", m.getCachedKeyspaceNameForMetrics(1))
+	re.Empty(m.getCachedKeyspaceNameForMetrics(constant.NullKeyspaceID))
 	// Get the keyspace name by ID first, then get the keyspace ID by name.
 	prepareKeyspaceName(ctx, re, m, &rmpb.KeyspaceIDValue{Value: 2}, "test_keyspace_2")
 	name, err = m.getKeyspaceNameByID(ctx, 2)

--- a/pkg/mcs/resourcemanager/server/manager_test.go
+++ b/pkg/mcs/resourcemanager/server/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -532,6 +533,62 @@ func TestCleanUpTicker(t *testing.T) {
 	keyspaceName, err := m.getKeyspaceNameByID(ctx, keyspaceID)
 	re.NoError(err)
 	re.Equal("test_keyspace", keyspaceName)
+}
+
+func TestFlushResourceGroupMetricsDrainsLiveSlotEvents(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID   = uint32(10867)
+		keyspaceName = "slot_metrics_keyspace"
+		groupName    = "slot_metrics_group"
+	)
+
+	m := prepareManager()
+	m.updateKeyspaceNameLookup(keyspaceID, keyspaceName)
+	t.Cleanup(func() {
+		m.metrics.cleanupAllMetrics(consumptionRecordKey{
+			keyspaceID: keyspaceID,
+			groupName:  groupName,
+			ruType:     defaultTypeLabel,
+		}, keyspaceName)
+	})
+
+	krgm := newKeyspaceResourceGroupManager(keyspaceID, m.storage)
+	rg := &ResourceGroup{
+		Name: groupName,
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: NewRequestUnitSettings(groupName, &rmpb.TokenBucket{
+			Settings: &rmpb.TokenLimitSettings{
+				FillRate:   100,
+				BurstLimit: 200,
+			},
+		}),
+	}
+	rg.RUSettings.RU.tokenSlots[1] = &tokenSlot{curTokenCapacity: -12.5}
+	rg.RUSettings.RU.slotsCreated = 2
+	rg.RUSettings.RU.slotsDeleted = 1
+	rg.RUSettings.RU.slotsExpired = 3
+	krgm.groups[groupName] = rg
+
+	gm := m.metrics.getGaugeMetrics(keyspaceID, keyspaceName, groupName)
+	m.flushResourceGroupMetrics(context.Background(), krgm)
+
+	re.Equal(1.0, promtestutil.ToFloat64(gm.activeSlotCountGauge))
+	re.Equal(12.5, promtestutil.ToFloat64(gm.tokenLoanGauge))
+	re.Equal(2.0, promtestutil.ToFloat64(gm.slotCreatedCounter))
+	re.Equal(1.0, promtestutil.ToFloat64(gm.slotDeletedCounter))
+	re.Equal(3.0, promtestutil.ToFloat64(gm.slotExpiredCounter))
+
+	created, deleted, expired := rg.DrainSlotEvents()
+	re.Zero(created)
+	re.Zero(deleted)
+	re.Zero(expired)
+
+	m.flushResourceGroupMetrics(context.Background(), krgm)
+
+	re.Equal(2.0, promtestutil.ToFloat64(gm.slotCreatedCounter))
+	re.Equal(1.0, promtestutil.ToFloat64(gm.slotDeletedCounter))
+	re.Equal(3.0, promtestutil.ToFloat64(gm.slotExpiredCounter))
 }
 
 func TestKeyspaceServiceLimit(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -792,10 +792,7 @@ func (m *requestMetrics) deleteLabelValues() {
 
 func (m *requestMetrics) shouldTouchRecord(now time.Time) bool {
 	last := m.lastRecordUnix.Load()
-	if now.Sub(time.Unix(0, last)) < metricsCleanupInterval {
-		return false
-	}
-	return true
+	return now.Sub(time.Unix(0, last)) >= metricsCleanupInterval
 }
 
 func (m *requestMetrics) observe(observation requestMetricsObservation) {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -281,12 +281,19 @@ type metrics struct {
 	gaugeMetricsMap map[metricsKey]*gaugeMetrics
 	// cached request metrics for each keyspace and resource group.
 	requestMetricsMap map[requestMetricsKey]*requestMetrics
+	// cached service limit metric labels for each keyspace.
+	serviceLimitMetricsMap map[uint32]string
 }
 
 type consumptionRecordKey struct {
 	keyspaceID uint32
 	groupName  string
 	ruType     string
+}
+
+type staleConsumptionRecord struct {
+	key        consumptionRecordKey
+	lastUpdate time.Time
 }
 
 type metricsKey struct {
@@ -338,11 +345,12 @@ func init() {
 
 func newMetrics() *metrics {
 	return &metrics{
-		consumptionRecordMap: make(map[consumptionRecordKey]time.Time),
-		maxPerSecTrackerMap:  make(map[trackerKey]*maxPerSecCostTracker),
-		counterMetricsMap:    make(map[metricsKey]*counterMetrics),
-		gaugeMetricsMap:      make(map[metricsKey]*gaugeMetrics),
-		requestMetricsMap:    make(map[requestMetricsKey]*requestMetrics),
+		consumptionRecordMap:   make(map[consumptionRecordKey]time.Time),
+		maxPerSecTrackerMap:    make(map[trackerKey]*maxPerSecCostTracker),
+		counterMetricsMap:      make(map[metricsKey]*counterMetrics),
+		gaugeMetricsMap:        make(map[metricsKey]*gaugeMetrics),
+		requestMetricsMap:      make(map[requestMetricsKey]*requestMetrics),
+		serviceLimitMetricsMap: make(map[uint32]string),
 	}
 }
 
@@ -362,12 +370,6 @@ func (m *metrics) insertConsumptionRecordLocked(keyspaceID uint32, groupName str
 	m.consumptionRecordMap[key] = now
 }
 
-func (m *metrics) deleteConsumptionRecord(record consumptionRecordKey) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.consumptionRecordMap, record)
-}
-
 func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName string) *maxPerSecCostTracker {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -381,19 +383,6 @@ func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName
 	return tracker
 }
 
-func (m *metrics) deleteMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	key := trackerKey{keyspaceID, groupName}
-	tracker := m.maxPerSecTrackerMap[key]
-	delete(m.maxPerSecTrackerMap, key)
-	if tracker != nil {
-		tracker.deleteLabelValues()
-		return
-	}
-	deleteMaxPerSecTrackerLabelValues(keyspaceName, groupName)
-}
-
 func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) *counterMetrics {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -401,7 +390,10 @@ func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, 
 	cm := m.counterMetricsMap[key]
 	if cm == nil || !cm.matchLabels(keyspaceName, groupName, ruType) {
 		if cm != nil {
-			cm.deleteLabelValues()
+			cm.deleteTypeLabelValues()
+			if !m.hasOtherCounterMetricsWithLabelsLocked(key, cm.keyspaceName, cm.groupName) {
+				deleteSharedCounterMetricLabelValues(cm.keyspaceName, cm.groupName)
+			}
 		}
 		cm = newCounterMetrics(keyspaceName, groupName, ruType)
 		m.counterMetricsMap[key] = cm
@@ -429,11 +421,14 @@ func (m *metrics) getRequestMetrics(keyspaceID uint32, keyspaceName, groupName s
 	m.mu.RLock()
 	rm := m.requestMetricsMap[key]
 	if rm != nil && rm.matchLabels(keyspaceName, groupName) {
+		if !rm.shouldTouchRecord(now) {
+			m.mu.RUnlock()
+			return rm
+		}
 		m.mu.RUnlock()
-		rm.touchRecord(m, keyspaceID, groupName, now)
-		return rm
+	} else {
+		m.mu.RUnlock()
 	}
-	m.mu.RUnlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -445,49 +440,94 @@ func (m *metrics) getRequestMetrics(keyspaceID uint32, keyspaceName, groupName s
 		rm = newRequestMetrics(keyspaceName, groupName)
 		m.requestMetricsMap[key] = rm
 	}
-	rm.lastRecordUnix.Store(now.UnixNano())
-	m.insertConsumptionRecordLocked(keyspaceID, groupName, defaultTypeLabel, now)
+	if rm.shouldTouchRecord(now) {
+		rm.lastRecordUnix.Store(now.UnixNano())
+		m.insertConsumptionRecordLocked(keyspaceID, groupName, defaultTypeLabel, now)
+	}
 	return rm
 }
 
-func (m *metrics) deleteMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
+func (m *metrics) deleteMetricsLocked(keyspaceID uint32, keyspaceName, groupName, ruType string, deleteGroupMetrics bool) {
 	counterKey := metricsKey{keyspaceID, groupName, ruType}
 	cm := m.counterMetricsMap[counterKey]
 	delete(m.counterMetricsMap, counterKey)
+	if cm != nil {
+		cm.deleteTypeLabelValues()
+		if !m.hasCounterMetricsWithLabelsLocked(keyspaceID, groupName, cm.keyspaceName, cm.groupName) {
+			deleteSharedCounterMetricLabelValues(cm.keyspaceName, cm.groupName)
+		}
+	} else {
+		deleteTypeCounterMetricLabelValues(keyspaceName, groupName, ruType)
+	}
+
+	deleteRequestMetrics := ruType == defaultTypeLabel
+	if deleteRequestMetrics {
+		m.deleteRequestMetricsLocked(keyspaceID, keyspaceName, groupName)
+	}
+
+	if !deleteGroupMetrics {
+		return
+	}
+	if cm != nil {
+		deleteSharedCounterMetricLabelValues(cm.keyspaceName, cm.groupName)
+	} else {
+		deleteSharedCounterMetricLabelValues(keyspaceName, groupName)
+	}
+	for key, counter := range m.counterMetricsMap {
+		if key.keyspaceID != keyspaceID || key.groupName != groupName {
+			continue
+		}
+		delete(m.counterMetricsMap, key)
+		if counter != nil {
+			counter.deleteLabelValues()
+		} else {
+			deleteCounterMetricLabelValues(keyspaceName, groupName, key.ruType)
+		}
+	}
+
 	gaugeKey := metricsKey{keyspaceID, groupName, ""}
 	gm := m.gaugeMetricsMap[gaugeKey]
 	delete(m.gaugeMetricsMap, gaugeKey)
-	requestKey := requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}
-	rm := m.requestMetricsMap[requestKey]
-	delete(m.requestMetricsMap, requestKey)
+	tKey := trackerKey{keyspaceID, groupName}
+	tracker := m.maxPerSecTrackerMap[tKey]
+	delete(m.maxPerSecTrackerMap, tKey)
 
-	if cm != nil {
-		cm.deleteLabelValues()
-	} else {
-		deleteCounterMetricLabelValues(keyspaceName, groupName, ruType)
-	}
 	if gm != nil {
 		gm.deleteLabelValues()
 	} else {
 		deleteGaugeMetricLabelValues(keyspaceName, groupName)
 	}
-	if rm != nil {
-		rm.deleteLabelValues()
+	if !deleteRequestMetrics {
+		m.deleteRequestMetricsLocked(keyspaceID, keyspaceName, groupName)
+	}
+	if tracker != nil {
+		tracker.deleteLabelValues()
 	} else {
-		deleteRequestMetricLabelValues(keyspaceName, groupName)
+		deleteMaxPerSecTrackerLabelValues(keyspaceName, groupName)
 	}
 }
 
-func (m *metrics) getStaleConsumptionRecords(now time.Time) []consumptionRecordKey {
+func (m *metrics) deleteRequestMetricsLocked(keyspaceID uint32, keyspaceName, groupName string) {
+	requestKey := requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}
+	rm := m.requestMetricsMap[requestKey]
+	delete(m.requestMetricsMap, requestKey)
+	if rm != nil {
+		rm.deleteLabelValues()
+		return
+	}
+	deleteRequestMetricLabelValues(keyspaceName, groupName)
+}
+
+func (m *metrics) getStaleConsumptionRecords(now time.Time) []staleConsumptionRecord {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	records := make([]consumptionRecordKey, 0)
+	records := make([]staleConsumptionRecord, 0)
 	for r, lastTime := range m.consumptionRecordMap {
 		if now.Sub(lastTime) > metricsCleanupTimeout {
-			records = append(records, r)
+			records = append(records, staleConsumptionRecord{
+				key:        r,
+				lastUpdate: lastTime,
+			})
 		}
 	}
 	return records
@@ -515,9 +555,59 @@ func (m *metrics) recordConsumption(
 }
 
 func (m *metrics) cleanupAllMetrics(r consumptionRecordKey, keyspaceName string) {
-	m.deleteConsumptionRecord(r)
-	m.deleteMetrics(r.keyspaceID, keyspaceName, r.groupName, r.ruType)
-	m.deleteMaxPerSecTracker(r.keyspaceID, keyspaceName, r.groupName)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanupAllMetricsLocked(r, keyspaceName)
+}
+
+func (m *metrics) cleanupStaleMetrics(r staleConsumptionRecord, keyspaceName string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lastUpdate, ok := m.consumptionRecordMap[r.key]
+	if !ok || !lastUpdate.Equal(r.lastUpdate) {
+		return false
+	}
+	m.cleanupAllMetricsLocked(r.key, keyspaceName)
+	return true
+}
+
+func (m *metrics) cleanupAllMetricsLocked(r consumptionRecordKey, keyspaceName string) {
+	delete(m.consumptionRecordMap, r)
+	deleteGroupMetrics := !m.hasConsumptionRecordLocked(r.keyspaceID, r.groupName)
+	m.deleteMetricsLocked(r.keyspaceID, keyspaceName, r.groupName, r.ruType, deleteGroupMetrics)
+}
+
+func (m *metrics) hasConsumptionRecordLocked(keyspaceID uint32, groupName string) bool {
+	for r := range m.consumptionRecordMap {
+		if r.keyspaceID == keyspaceID && r.groupName == groupName {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *metrics) hasCounterMetricsWithLabelsLocked(keyspaceID uint32, groupName, keyspaceName, labelGroupName string) bool {
+	for key, counter := range m.counterMetricsMap {
+		if key.keyspaceID != keyspaceID || key.groupName != groupName {
+			continue
+		}
+		if counter != nil && counter.keyspaceName == keyspaceName && counter.groupName == labelGroupName {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *metrics) hasOtherCounterMetricsWithLabelsLocked(excludedKey metricsKey, keyspaceName, labelGroupName string) bool {
+	for key, counter := range m.counterMetricsMap {
+		if key == excludedKey || key.keyspaceID != excludedKey.keyspaceID || key.groupName != excludedKey.groupName {
+			continue
+		}
+		if counter != nil && counter.keyspaceName == keyspaceName && counter.groupName == labelGroupName {
+			return true
+		}
+	}
+	return false
 }
 
 type counterMetrics struct {
@@ -575,6 +665,13 @@ func (m *counterMetrics) deleteLabelValues() {
 		return
 	}
 	deleteCounterMetricLabelValues(m.keyspaceName, m.groupName, m.ruLabelType)
+}
+
+func (m *counterMetrics) deleteTypeLabelValues() {
+	if m == nil {
+		return
+	}
+	deleteTypeCounterMetricLabelValues(m.keyspaceName, m.groupName, m.ruLabelType)
 }
 
 func calculateSQLRU(consumption *rmpb.Consumption, controllerConfig *ControllerConfig) float64 {
@@ -693,15 +790,12 @@ func (m *requestMetrics) deleteLabelValues() {
 	deleteRequestMetricLabelValues(m.keyspaceName, m.groupName)
 }
 
-func (m *requestMetrics) touchRecord(metrics *metrics, keyspaceID uint32, groupName string, now time.Time) {
+func (m *requestMetrics) shouldTouchRecord(now time.Time) bool {
 	last := m.lastRecordUnix.Load()
 	if now.Sub(time.Unix(0, last)) < metricsCleanupInterval {
-		return
+		return false
 	}
-	if !m.lastRecordUnix.CompareAndSwap(last, now.UnixNano()) {
-		return
-	}
-	metrics.insertConsumptionRecord(keyspaceID, groupName, defaultTypeLabel, now)
+	return true
 }
 
 func (m *requestMetrics) observe(observation requestMetricsObservation) {
@@ -809,15 +903,28 @@ func (m *gaugeMetrics) setSampledRUPerSec(ruPerSec float64) {
 	m.sampledRequestUnitPerSecGauge.Set(ruPerSec)
 }
 
-func setOrRemoveServiceLimitMetrics(keyspaceName string, limit float64) {
+func (m *metrics) setOrRemoveServiceLimitMetrics(keyspaceID uint32, keyspaceName string, limit float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if oldKeyspaceName, ok := m.serviceLimitMetricsMap[keyspaceID]; ok && oldKeyspaceName != keyspaceName {
+		serviceLimit.DeleteLabelValues(oldKeyspaceName)
+		delete(m.serviceLimitMetricsMap, keyspaceID)
+	}
 	if limit > 0 {
 		serviceLimit.WithLabelValues(keyspaceName).Set(limit)
+		m.serviceLimitMetricsMap[keyspaceID] = keyspaceName
 	} else {
 		serviceLimit.DeleteLabelValues(keyspaceName)
+		delete(m.serviceLimitMetricsMap, keyspaceID)
 	}
 }
 
 func deleteCounterMetricLabelValues(keyspaceName, groupName, ruLabelType string) {
+	deleteTypeCounterMetricLabelValues(keyspaceName, groupName, ruLabelType)
+	deleteSharedCounterMetricLabelValues(keyspaceName, groupName)
+}
+
+func deleteTypeCounterMetricLabelValues(keyspaceName, groupName, ruLabelType string) {
 	readRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	writeRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	activeRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
@@ -825,13 +932,16 @@ func deleteCounterMetricLabelValues(keyspaceName, groupName, ruLabelType string)
 	tikvRequestUnitV2Cost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	tidbRequestUnitV2Cost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	tiflashRequestUnitV2Cost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
-	sqlLayerRequestUnitCost.DeleteLabelValues(groupName, groupName, keyspaceName)
 	readByteCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	writeByteCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
-	crossAZTrafficCost.DeleteLabelValues(groupName, readTypeLabel, keyspaceName)
-	crossAZTrafficCost.DeleteLabelValues(groupName, writeTypeLabel, keyspaceName)
 	kvCPUCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	sqlCPUCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
+}
+
+func deleteSharedCounterMetricLabelValues(keyspaceName, groupName string) {
+	sqlLayerRequestUnitCost.DeleteLabelValues(groupName, groupName, keyspaceName)
+	crossAZTrafficCost.DeleteLabelValues(groupName, readTypeLabel, keyspaceName)
+	crossAZTrafficCost.DeleteLabelValues(groupName, writeTypeLabel, keyspaceName)
 	requestCount.DeleteLabelValues(groupName, groupName, readTypeLabel, keyspaceName)
 	requestCount.DeleteLabelValues(groupName, groupName, writeTypeLabel, keyspaceName)
 }

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -16,6 +16,8 @@ package server
 
 import (
 	"math"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -268,7 +270,8 @@ var (
 )
 
 type metrics struct {
-	// record update time of each resource group
+	mu sync.RWMutex
+	// record update time of each resource group metrics.
 	consumptionRecordMap map[consumptionRecordKey]time.Time
 	// max per sec trackers for each keyspace and resource group.
 	maxPerSecTrackerMap map[trackerKey]*maxPerSecCostTracker
@@ -276,6 +279,8 @@ type metrics struct {
 	counterMetricsMap map[metricsKey]*counterMetrics
 	// cached gauge metrics for each keyspace, resource group and RU type.
 	gaugeMetricsMap map[metricsKey]*gaugeMetrics
+	// cached request metrics for each keyspace and resource group.
+	requestMetricsMap map[requestMetricsKey]*requestMetrics
 }
 
 type consumptionRecordKey struct {
@@ -291,6 +296,11 @@ type metricsKey struct {
 }
 
 type trackerKey struct {
+	keyspaceID uint32
+	groupName  string
+}
+
+type requestMetricsKey struct {
 	keyspaceID uint32
 	groupName  string
 }
@@ -332,11 +342,18 @@ func newMetrics() *metrics {
 		maxPerSecTrackerMap:  make(map[trackerKey]*maxPerSecCostTracker),
 		counterMetricsMap:    make(map[metricsKey]*counterMetrics),
 		gaugeMetricsMap:      make(map[metricsKey]*gaugeMetrics),
+		requestMetricsMap:    make(map[requestMetricsKey]*requestMetrics),
 	}
 }
 
 // insertConsumptionRecord inserts the consumption record.
 func (m *metrics) insertConsumptionRecord(keyspaceID uint32, groupName string, ruType string, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.insertConsumptionRecordLocked(keyspaceID, groupName, ruType, now)
+}
+
+func (m *metrics) insertConsumptionRecordLocked(keyspaceID uint32, groupName string, ruType string, now time.Time) {
 	key := consumptionRecordKey{
 		keyspaceID: keyspaceID,
 		groupName:  groupName,
@@ -346,10 +363,14 @@ func (m *metrics) insertConsumptionRecord(keyspaceID uint32, groupName string, r
 }
 
 func (m *metrics) deleteConsumptionRecord(record consumptionRecordKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	delete(m.consumptionRecordMap, record)
 }
 
 func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName string) *maxPerSecCostTracker {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	tracker := m.maxPerSecTrackerMap[trackerKey{keyspaceID, groupName}]
 	if tracker == nil {
 		tracker = newMaxPerSecCostTracker(keyspaceName, groupName, defaultCollectIntervalSec)
@@ -359,10 +380,14 @@ func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName
 }
 
 func (m *metrics) deleteMaxPerSecTracker(keyspaceID uint32, groupName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	delete(m.maxPerSecTrackerMap, trackerKey{keyspaceID, groupName})
 }
 
 func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) *counterMetrics {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	key := metricsKey{keyspaceID, groupName, ruType}
 	if m.counterMetricsMap[key] == nil {
 		m.counterMetricsMap[key] = newCounterMetrics(keyspaceName, groupName, ruType)
@@ -371,6 +396,8 @@ func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, 
 }
 
 func (m *metrics) getGaugeMetrics(keyspaceID uint32, keyspaceName, groupName string) *gaugeMetrics {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	key := metricsKey{keyspaceID, groupName, ""}
 	if m.gaugeMetricsMap[key] == nil {
 		m.gaugeMetricsMap[key] = newGaugeMetrics(keyspaceName, groupName)
@@ -378,10 +405,47 @@ func (m *metrics) getGaugeMetrics(keyspaceID uint32, keyspaceName, groupName str
 	return m.gaugeMetricsMap[key]
 }
 
+func (m *metrics) getRequestMetrics(keyspaceID uint32, keyspaceName, groupName string, now time.Time) *requestMetrics {
+	key := requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}
+	m.mu.RLock()
+	rm := m.requestMetricsMap[key]
+	m.mu.RUnlock()
+	if rm != nil {
+		rm.touchRecord(m, keyspaceID, groupName, now)
+		return rm
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rm = m.requestMetricsMap[key]
+	if rm == nil {
+		rm = newRequestMetrics(keyspaceName, groupName)
+		rm.lastRecordUnix.Store(now.UnixNano())
+		m.requestMetricsMap[key] = rm
+	}
+	m.insertConsumptionRecordLocked(keyspaceID, groupName, defaultTypeLabel, now)
+	return rm
+}
+
 func (m *metrics) deleteMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) {
+	m.mu.Lock()
 	delete(m.counterMetricsMap, metricsKey{keyspaceID, groupName, ruType})
 	delete(m.gaugeMetricsMap, metricsKey{keyspaceID, groupName, ""})
+	delete(m.requestMetricsMap, requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName})
+	m.mu.Unlock()
 	deleteLabelValues(keyspaceName, groupName, ruType)
+}
+
+func (m *metrics) getStaleConsumptionRecords(now time.Time) []consumptionRecordKey {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	records := make([]consumptionRecordKey, 0)
+	for r, lastTime := range m.consumptionRecordMap {
+		if now.Sub(lastTime) > metricsCleanupTimeout {
+			records = append(records, r)
+		}
+	}
+	return records
 }
 
 func (m *metrics) recordConsumption(
@@ -522,6 +586,67 @@ func (m *counterMetrics) add(consumption *rmpb.Consumption, controllerConfig *Co
 	}
 }
 
+type requestMetrics struct {
+	grantedTokensObserver       prometheus.Observer
+	trickleDurationObserver     prometheus.Observer
+	serviceLimitThrottleCounter prometheus.Counter
+	groupThrottleCounter        prometheus.Counter
+	serviceLimitTrickleCounter  prometheus.Counter
+	groupTrickleCounter         prometheus.Counter
+	lastRecordUnix              atomic.Int64
+}
+
+type requestMetricsObservation struct {
+	grantedTokens   float64
+	trickleTimeMs   int64
+	serviceLimited  bool
+	groupLimited    bool
+	serviceTrickled bool
+	groupTrickled   bool
+}
+
+func newRequestMetrics(keyspaceName, groupName string) *requestMetrics {
+	return &requestMetrics{
+		grantedTokensObserver:       grantedTokensHistogram.WithLabelValues(groupName, keyspaceName),
+		trickleDurationObserver:     trickleDurationHistogram.WithLabelValues(groupName, keyspaceName),
+		serviceLimitThrottleCounter: requestCauseCounter.WithLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel),
+		groupThrottleCounter:        requestCauseCounter.WithLabelValues(groupName, keyspaceName, throttleKindLabel, groupCauseLabel),
+		serviceLimitTrickleCounter:  requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel),
+		groupTrickleCounter:         requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel),
+	}
+}
+
+func (m *requestMetrics) touchRecord(metrics *metrics, keyspaceID uint32, groupName string, now time.Time) {
+	last := m.lastRecordUnix.Load()
+	if now.Sub(time.Unix(0, last)) < metricsCleanupInterval {
+		return
+	}
+	if !m.lastRecordUnix.CompareAndSwap(last, now.UnixNano()) {
+		return
+	}
+	metrics.insertConsumptionRecord(keyspaceID, groupName, defaultTypeLabel, now)
+}
+
+func (m *requestMetrics) observe(observation requestMetricsObservation) {
+	if m == nil {
+		return
+	}
+	m.grantedTokensObserver.Observe(observation.grantedTokens)
+	m.trickleDurationObserver.Observe(float64(observation.trickleTimeMs))
+	if observation.serviceLimited {
+		m.serviceLimitThrottleCounter.Inc()
+	}
+	if observation.groupLimited {
+		m.groupThrottleCounter.Inc()
+	}
+	if observation.serviceTrickled {
+		m.serviceLimitTrickleCounter.Inc()
+	}
+	if observation.groupTrickled {
+		m.groupTrickleCounter.Inc()
+	}
+}
+
 type gaugeMetrics struct {
 	availableRUCounter                 prometheus.Gauge
 	priorityResourceGroupConfigGauge   prometheus.Gauge
@@ -633,18 +758,6 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
 	resourceGroupConfigGauge.DeletePartialMatch(prometheus.Labels{newResourceGroupNameLabel: groupName, keyspaceNameLabel: keyspaceName})
-}
-
-func observeTokenGrant(groupName, keyspaceName string, tokens *rmpb.GrantedRUTokenBucket) {
-	if tokens == nil || tokens.GrantedTokens == nil {
-		return
-	}
-	grantedTokensHistogram.WithLabelValues(groupName, keyspaceName).Observe(tokens.GrantedTokens.GetTokens())
-	trickleDurationHistogram.WithLabelValues(groupName, keyspaceName).Observe(float64(tokens.GetTrickleTimeMs()))
-}
-
-func observeRequestCause(groupName, keyspaceName, kind, cause string) {
-	requestCauseCounter.WithLabelValues(groupName, keyspaceName, kind, cause).Inc()
 }
 
 type maxPerSecCostTracker struct {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -433,12 +433,13 @@ func (m *metrics) getRequestMetrics(keyspaceID uint32, keyspaceName, groupName s
 
 func (m *metrics) deleteMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	delete(m.counterMetricsMap, metricsKey{keyspaceID, groupName, ruType})
 	delete(m.gaugeMetricsMap, metricsKey{keyspaceID, groupName, ""})
 	requestKey := requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}
 	rm := m.requestMetricsMap[requestKey]
 	delete(m.requestMetricsMap, requestKey)
-	m.mu.Unlock()
 
 	deleteLabelValues(keyspaceName, groupName, ruType)
 	rm.deleteLabelValues()

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -41,6 +41,15 @@ const (
 	keyspaceNameLabel         = "keyspace_name"
 	fillRateLabel             = "fill_rate"
 	burstLimitLabel           = "burst_limit"
+	slotEventLabel            = "event"
+	slotCreatedEventLabel     = "created"
+	slotDeletedEventLabel     = "deleted"
+	slotExpiredEventLabel     = "expired"
+	kindLabel                 = "kind"
+	throttleKindLabel         = "throttling"
+	trickleKindLabel          = "trickle"
+	serviceLimitCauseLabel    = "service_limit"
+	groupCauseLabel           = "group_fill_rate_or_burst"
 
 	// Labels for the config.
 	ruPerSecLabel   = "ru_per_sec"
@@ -211,6 +220,51 @@ var (
 			Name:      "service_limit",
 			Help:      "Gauge of the total RU limit of specific keyspace.",
 		}, []string{keyspaceNameLabel})
+
+	grantedTokensHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "granted_tokens",
+			Help:      "Histogram of tokens granted per request.",
+			Buckets:   []float64{0, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000},
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	activeSlotCountGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "active_slot_count",
+			Help:      "Number of active token slots per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	slotEventsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "slot_events_total",
+			Help:      "Counter of slot lifecycle events (created, deleted, expired).",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel, slotEventLabel})
+	tokenLoanGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "token_loan",
+			Help:      "Current total token loan amount per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	trickleDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "trickle_duration_ms",
+			Help:      "Histogram of trickle duration in milliseconds per request.",
+			Buckets:   []float64{0, 100, 500, 1000, 2000, 3000, 4000, 5000, 10000},
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel})
+	requestCauseCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: serverSubsystem,
+			Name:      "request_cause_total",
+			Help:      "Counter of throttling and trickle contributing causes per resource group.",
+		}, []string{newResourceGroupNameLabel, keyspaceNameLabel, kindLabel, "cause"})
 )
 
 type metrics struct {
@@ -264,6 +318,12 @@ func init() {
 	prometheus.MustRegister(sampledRequestUnitPerSec)
 	prometheus.MustRegister(overrideSettings)
 	prometheus.MustRegister(serviceLimit)
+	prometheus.MustRegister(grantedTokensHistogram)
+	prometheus.MustRegister(activeSlotCountGauge)
+	prometheus.MustRegister(slotEventsCounter)
+	prometheus.MustRegister(tokenLoanGauge)
+	prometheus.MustRegister(trickleDurationHistogram)
+	prometheus.MustRegister(requestCauseCounter)
 }
 
 func newMetrics() *metrics {
@@ -470,6 +530,11 @@ type gaugeMetrics struct {
 	sampledRequestUnitPerSecGauge      prometheus.Gauge
 	overrideFillRateGauge              prometheus.Gauge
 	overrideBurstLimitGauge            prometheus.Gauge
+	activeSlotCountGauge               prometheus.Gauge
+	tokenLoanGauge                     prometheus.Gauge
+	slotCreatedCounter                 prometheus.Counter
+	slotDeletedCounter                 prometheus.Counter
+	slotExpiredCounter                 prometheus.Counter
 }
 
 func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
@@ -481,6 +546,11 @@ func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 		sampledRequestUnitPerSecGauge:      sampledRequestUnitPerSec.WithLabelValues(groupName, keyspaceName),
 		overrideFillRateGauge:              overrideSettings.WithLabelValues(groupName, keyspaceName, fillRateLabel),
 		overrideBurstLimitGauge:            overrideSettings.WithLabelValues(groupName, keyspaceName, burstLimitLabel),
+		activeSlotCountGauge:               activeSlotCountGauge.WithLabelValues(groupName, keyspaceName),
+		tokenLoanGauge:                     tokenLoanGauge.WithLabelValues(groupName, keyspaceName),
+		slotCreatedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotCreatedEventLabel),
+		slotDeletedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotDeletedEventLabel),
+		slotExpiredCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotExpiredEventLabel),
 	}
 }
 
@@ -506,6 +576,15 @@ func (m *gaugeMetrics) setGroup(group *ResourceGroup, keyspaceName string) {
 		overrideSettings.DeleteLabelValues(group.Name, keyspaceName, burstLimitLabel)
 	} else {
 		m.overrideBurstLimitGauge.Set(float64(overrideBurstLimit))
+	}
+
+	slotMetrics := group.GetSlotMetrics()
+	m.activeSlotCountGauge.Set(float64(slotMetrics.SlotCount))
+	m.tokenLoanGauge.Set(slotMetrics.TokenLoan)
+	if created, deleted, expired := group.DrainSlotEvents(); created+deleted+expired > 0 {
+		m.slotCreatedCounter.Add(float64(created))
+		m.slotDeletedCounter.Add(float64(deleted))
+		m.slotExpiredCounter.Add(float64(expired))
 	}
 }
 
@@ -542,7 +621,30 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	sampledRequestUnitPerSec.DeleteLabelValues(groupName, keyspaceName)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, fillRateLabel)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)
+	activeSlotCountGauge.DeleteLabelValues(groupName, keyspaceName)
+	tokenLoanGauge.DeleteLabelValues(groupName, keyspaceName)
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotCreatedEventLabel)
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotDeletedEventLabel)
+	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotExpiredEventLabel)
+	grantedTokensHistogram.DeleteLabelValues(groupName, keyspaceName)
+	trickleDurationHistogram.DeleteLabelValues(groupName, keyspaceName)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, throttleKindLabel, groupCauseLabel)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
 	resourceGroupConfigGauge.DeletePartialMatch(prometheus.Labels{newResourceGroupNameLabel: groupName, keyspaceNameLabel: keyspaceName})
+}
+
+func observeTokenGrant(groupName, keyspaceName string, tokens *rmpb.GrantedRUTokenBucket) {
+	if tokens == nil || tokens.GrantedTokens == nil {
+		return
+	}
+	grantedTokensHistogram.WithLabelValues(groupName, keyspaceName).Observe(tokens.GrantedTokens.GetTokens())
+	trickleDurationHistogram.WithLabelValues(groupName, keyspaceName).Observe(float64(tokens.GetTrickleTimeMs()))
+}
+
+func observeRequestCause(groupName, keyspaceName, kind, cause string) {
+	requestCauseCounter.WithLabelValues(groupName, keyspaceName, kind, cause).Inc()
 }
 
 type maxPerSecCostTracker struct {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -381,10 +381,17 @@ func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName
 	return tracker
 }
 
-func (m *metrics) deleteMaxPerSecTracker(keyspaceID uint32, groupName string) {
+func (m *metrics) deleteMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	delete(m.maxPerSecTrackerMap, trackerKey{keyspaceID, groupName})
+	key := trackerKey{keyspaceID, groupName}
+	tracker := m.maxPerSecTrackerMap[key]
+	delete(m.maxPerSecTrackerMap, key)
+	if tracker != nil {
+		tracker.deleteLabelValues()
+		return
+	}
+	deleteMaxPerSecTrackerLabelValues(keyspaceName, groupName)
 }
 
 func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) *counterMetrics {
@@ -447,14 +454,31 @@ func (m *metrics) deleteMetrics(keyspaceID uint32, keyspaceName, groupName, ruTy
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.counterMetricsMap, metricsKey{keyspaceID, groupName, ruType})
-	delete(m.gaugeMetricsMap, metricsKey{keyspaceID, groupName, ""})
+	counterKey := metricsKey{keyspaceID, groupName, ruType}
+	cm := m.counterMetricsMap[counterKey]
+	delete(m.counterMetricsMap, counterKey)
+	gaugeKey := metricsKey{keyspaceID, groupName, ""}
+	gm := m.gaugeMetricsMap[gaugeKey]
+	delete(m.gaugeMetricsMap, gaugeKey)
 	requestKey := requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}
 	rm := m.requestMetricsMap[requestKey]
 	delete(m.requestMetricsMap, requestKey)
 
-	deleteLabelValues(keyspaceName, groupName, ruType)
-	rm.deleteLabelValues()
+	if cm != nil {
+		cm.deleteLabelValues()
+	} else {
+		deleteCounterMetricLabelValues(keyspaceName, groupName, ruType)
+	}
+	if gm != nil {
+		gm.deleteLabelValues()
+	} else {
+		deleteGaugeMetricLabelValues(keyspaceName, groupName)
+	}
+	if rm != nil {
+		rm.deleteLabelValues()
+	} else {
+		deleteRequestMetricLabelValues(keyspaceName, groupName)
+	}
 }
 
 func (m *metrics) getStaleConsumptionRecords(now time.Time) []consumptionRecordKey {
@@ -493,7 +517,7 @@ func (m *metrics) recordConsumption(
 func (m *metrics) cleanupAllMetrics(r consumptionRecordKey, keyspaceName string) {
 	m.deleteConsumptionRecord(r)
 	m.deleteMetrics(r.keyspaceID, keyspaceName, r.groupName, r.ruType)
-	m.deleteMaxPerSecTracker(r.keyspaceID, r.groupName)
+	m.deleteMaxPerSecTracker(r.keyspaceID, keyspaceName, r.groupName)
 }
 
 type counterMetrics struct {
@@ -550,22 +574,7 @@ func (m *counterMetrics) deleteLabelValues() {
 	if m == nil {
 		return
 	}
-	readRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	writeRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	activeRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	requestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	tikvRequestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	tidbRequestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	tiflashRequestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	sqlLayerRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.keyspaceName)
-	readByteCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	writeByteCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	crossAZTrafficCost.DeleteLabelValues(m.groupName, readTypeLabel, m.keyspaceName)
-	crossAZTrafficCost.DeleteLabelValues(m.groupName, writeTypeLabel, m.keyspaceName)
-	kvCPUCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	sqlCPUCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
-	requestCount.DeleteLabelValues(m.groupName, m.groupName, readTypeLabel, m.keyspaceName)
-	requestCount.DeleteLabelValues(m.groupName, m.groupName, writeTypeLabel, m.keyspaceName)
+	deleteCounterMetricLabelValues(m.keyspaceName, m.groupName, m.ruLabelType)
 }
 
 func calculateSQLRU(consumption *rmpb.Consumption, controllerConfig *ControllerConfig) float64 {
@@ -681,12 +690,7 @@ func (m *requestMetrics) deleteLabelValues() {
 	if m == nil {
 		return
 	}
-	grantedTokensHistogram.DeleteLabelValues(m.groupName, m.keyspaceName)
-	trickleDurationHistogram.DeleteLabelValues(m.groupName, m.keyspaceName)
-	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
-	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, throttleKindLabel, groupCauseLabel)
-	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
-	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, trickleKindLabel, groupCauseLabel)
+	deleteRequestMetricLabelValues(m.keyspaceName, m.groupName)
 }
 
 func (m *requestMetrics) touchRecord(metrics *metrics, keyspaceID uint32, groupName string, now time.Time) {
@@ -764,18 +768,7 @@ func (m *gaugeMetrics) deleteLabelValues() {
 	if m == nil {
 		return
 	}
-	availableRUCounter.DeleteLabelValues(m.groupName, m.groupName, m.keyspaceName)
-	resourceGroupConfigGauge.DeleteLabelValues(m.groupName, priorityLabel, m.keyspaceName)
-	resourceGroupConfigGauge.DeleteLabelValues(m.groupName, ruPerSecLabel, m.keyspaceName)
-	resourceGroupConfigGauge.DeleteLabelValues(m.groupName, ruCapacityLabel, m.keyspaceName)
-	sampledRequestUnitPerSec.DeleteLabelValues(m.groupName, m.keyspaceName)
-	overrideSettings.DeleteLabelValues(m.groupName, m.keyspaceName, fillRateLabel)
-	overrideSettings.DeleteLabelValues(m.groupName, m.keyspaceName, burstLimitLabel)
-	activeSlotCountGauge.DeleteLabelValues(m.groupName, m.keyspaceName)
-	tokenLoanGauge.DeleteLabelValues(m.groupName, m.keyspaceName)
-	slotEventsCounter.DeleteLabelValues(m.groupName, m.keyspaceName, slotCreatedEventLabel)
-	slotEventsCounter.DeleteLabelValues(m.groupName, m.keyspaceName, slotDeletedEventLabel)
-	slotEventsCounter.DeleteLabelValues(m.groupName, m.keyspaceName, slotExpiredEventLabel)
+	deleteGaugeMetricLabelValues(m.keyspaceName, m.groupName)
 }
 
 func (m *gaugeMetrics) setGroup(group *ResourceGroup, keyspaceName string) {
@@ -824,7 +817,7 @@ func setOrRemoveServiceLimitMetrics(keyspaceName string, limit float64) {
 	}
 }
 
-func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
+func deleteCounterMetricLabelValues(keyspaceName, groupName, ruLabelType string) {
 	readRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	writeRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	activeRequestUnitCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
@@ -835,13 +828,19 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	sqlLayerRequestUnitCost.DeleteLabelValues(groupName, groupName, keyspaceName)
 	readByteCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	writeByteCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
+	crossAZTrafficCost.DeleteLabelValues(groupName, readTypeLabel, keyspaceName)
+	crossAZTrafficCost.DeleteLabelValues(groupName, writeTypeLabel, keyspaceName)
 	kvCPUCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	sqlCPUCost.DeleteLabelValues(groupName, groupName, ruLabelType, keyspaceName)
 	requestCount.DeleteLabelValues(groupName, groupName, readTypeLabel, keyspaceName)
 	requestCount.DeleteLabelValues(groupName, groupName, writeTypeLabel, keyspaceName)
+}
+
+func deleteGaugeMetricLabelValues(keyspaceName, groupName string) {
 	availableRUCounter.DeleteLabelValues(groupName, groupName, keyspaceName)
-	readRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
-	writeRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
+	resourceGroupConfigGauge.DeleteLabelValues(groupName, priorityLabel, keyspaceName)
+	resourceGroupConfigGauge.DeleteLabelValues(groupName, ruPerSecLabel, keyspaceName)
+	resourceGroupConfigGauge.DeleteLabelValues(groupName, ruCapacityLabel, keyspaceName)
 	sampledRequestUnitPerSec.DeleteLabelValues(groupName, keyspaceName)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, fillRateLabel)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)
@@ -850,13 +849,27 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotCreatedEventLabel)
 	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotDeletedEventLabel)
 	slotEventsCounter.DeleteLabelValues(groupName, keyspaceName, slotExpiredEventLabel)
+}
+
+func deleteMaxPerSecTrackerLabelValues(keyspaceName, groupName string) {
+	readRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
+	writeRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
+}
+
+func deleteRequestMetricLabelValues(keyspaceName, groupName string) {
 	grantedTokensHistogram.DeleteLabelValues(groupName, keyspaceName)
 	trickleDurationHistogram.DeleteLabelValues(groupName, keyspaceName)
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, throttleKindLabel, groupCauseLabel)
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
-	resourceGroupConfigGauge.DeletePartialMatch(prometheus.Labels{newResourceGroupNameLabel: groupName, keyspaceNameLabel: keyspaceName})
+}
+
+func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
+	deleteCounterMetricLabelValues(keyspaceName, groupName, ruLabelType)
+	deleteGaugeMetricLabelValues(keyspaceName, groupName)
+	deleteMaxPerSecTrackerLabelValues(keyspaceName, groupName)
+	deleteRequestMetricLabelValues(keyspaceName, groupName)
 }
 
 type maxPerSecCostTracker struct {
@@ -892,8 +905,7 @@ func (t *maxPerSecCostTracker) deleteLabelValues() {
 	if t == nil {
 		return
 	}
-	readRequestUnitMaxPerSecCost.DeleteLabelValues(t.groupName, t.keyspaceName)
-	writeRequestUnitMaxPerSecCost.DeleteLabelValues(t.groupName, t.keyspaceName)
+	deleteMaxPerSecTrackerLabelValues(t.keyspaceName, t.groupName)
 }
 
 func (t *maxPerSecCostTracker) rebindLabels(keyspaceName, groupName string) {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -375,6 +375,8 @@ func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName
 	if tracker == nil {
 		tracker = newMaxPerSecCostTracker(keyspaceName, groupName, defaultCollectIntervalSec)
 		m.maxPerSecTrackerMap[trackerKey{keyspaceID, groupName}] = tracker
+	} else if !tracker.matchLabels(keyspaceName, groupName) {
+		tracker.rebindLabels(keyspaceName, groupName)
 	}
 	return tracker
 }
@@ -389,20 +391,30 @@ func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	key := metricsKey{keyspaceID, groupName, ruType}
-	if m.counterMetricsMap[key] == nil {
-		m.counterMetricsMap[key] = newCounterMetrics(keyspaceName, groupName, ruType)
+	cm := m.counterMetricsMap[key]
+	if cm == nil || !cm.matchLabels(keyspaceName, groupName, ruType) {
+		if cm != nil {
+			cm.deleteLabelValues()
+		}
+		cm = newCounterMetrics(keyspaceName, groupName, ruType)
+		m.counterMetricsMap[key] = cm
 	}
-	return m.counterMetricsMap[key]
+	return cm
 }
 
 func (m *metrics) getGaugeMetrics(keyspaceID uint32, keyspaceName, groupName string) *gaugeMetrics {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	key := metricsKey{keyspaceID, groupName, ""}
-	if m.gaugeMetricsMap[key] == nil {
-		m.gaugeMetricsMap[key] = newGaugeMetrics(keyspaceName, groupName)
+	gm := m.gaugeMetricsMap[key]
+	if gm == nil || !gm.matchLabels(keyspaceName, groupName) {
+		if gm != nil {
+			gm.deleteLabelValues()
+		}
+		gm = newGaugeMetrics(keyspaceName, groupName)
+		m.gaugeMetricsMap[key] = gm
 	}
-	return m.gaugeMetricsMap[key]
+	return gm
 }
 
 func (m *metrics) getRequestMetrics(keyspaceID uint32, keyspaceName, groupName string, now time.Time) *requestMetrics {
@@ -485,6 +497,9 @@ func (m *metrics) cleanupAllMetrics(r consumptionRecordKey, keyspaceName string)
 }
 
 type counterMetrics struct {
+	keyspaceName               string
+	groupName                  string
+	ruLabelType                string
 	RRUMetrics                 prometheus.Counter
 	WRUMetrics                 prometheus.Counter
 	ActiveRUMetrics            prometheus.Counter
@@ -505,6 +520,9 @@ type counterMetrics struct {
 
 func newCounterMetrics(keyspaceName, groupName, ruLabelType string) *counterMetrics {
 	return &counterMetrics{
+		keyspaceName:               keyspaceName,
+		groupName:                  groupName,
+		ruLabelType:                ruLabelType,
 		RRUMetrics:                 readRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		WRUMetrics:                 writeRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		ActiveRUMetrics:            activeRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
@@ -522,6 +540,32 @@ func newCounterMetrics(keyspaceName, groupName, ruLabelType string) *counterMetr
 		ReadRequestCountMetrics:    requestCount.WithLabelValues(groupName, groupName, readTypeLabel, keyspaceName),
 		WriteRequestCountMetrics:   requestCount.WithLabelValues(groupName, groupName, writeTypeLabel, keyspaceName),
 	}
+}
+
+func (m *counterMetrics) matchLabels(keyspaceName, groupName, ruLabelType string) bool {
+	return m != nil && m.keyspaceName == keyspaceName && m.groupName == groupName && m.ruLabelType == ruLabelType
+}
+
+func (m *counterMetrics) deleteLabelValues() {
+	if m == nil {
+		return
+	}
+	readRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	writeRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	activeRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	requestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	tikvRequestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	tidbRequestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	tiflashRequestUnitV2Cost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	sqlLayerRequestUnitCost.DeleteLabelValues(m.groupName, m.groupName, m.keyspaceName)
+	readByteCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	writeByteCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	crossAZTrafficCost.DeleteLabelValues(m.groupName, readTypeLabel, m.keyspaceName)
+	crossAZTrafficCost.DeleteLabelValues(m.groupName, writeTypeLabel, m.keyspaceName)
+	kvCPUCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	sqlCPUCost.DeleteLabelValues(m.groupName, m.groupName, m.ruLabelType, m.keyspaceName)
+	requestCount.DeleteLabelValues(m.groupName, m.groupName, readTypeLabel, m.keyspaceName)
+	requestCount.DeleteLabelValues(m.groupName, m.groupName, writeTypeLabel, m.keyspaceName)
 }
 
 func calculateSQLRU(consumption *rmpb.Consumption, controllerConfig *ControllerConfig) float64 {
@@ -677,6 +721,8 @@ func (m *requestMetrics) observe(observation requestMetricsObservation) {
 }
 
 type gaugeMetrics struct {
+	keyspaceName                       string
+	groupName                          string
 	availableRUCounter                 prometheus.Gauge
 	priorityResourceGroupConfigGauge   prometheus.Gauge
 	ruPerSecResourceGroupConfigGauge   prometheus.Gauge
@@ -693,6 +739,8 @@ type gaugeMetrics struct {
 
 func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 	return &gaugeMetrics{
+		keyspaceName:                       keyspaceName,
+		groupName:                          groupName,
 		availableRUCounter:                 availableRUCounter.WithLabelValues(groupName, groupName, keyspaceName),
 		priorityResourceGroupConfigGauge:   resourceGroupConfigGauge.WithLabelValues(groupName, priorityLabel, keyspaceName),
 		ruPerSecResourceGroupConfigGauge:   resourceGroupConfigGauge.WithLabelValues(groupName, ruPerSecLabel, keyspaceName),
@@ -706,6 +754,28 @@ func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 		slotDeletedCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotDeletedEventLabel),
 		slotExpiredCounter:                 slotEventsCounter.WithLabelValues(groupName, keyspaceName, slotExpiredEventLabel),
 	}
+}
+
+func (m *gaugeMetrics) matchLabels(keyspaceName, groupName string) bool {
+	return m != nil && m.keyspaceName == keyspaceName && m.groupName == groupName
+}
+
+func (m *gaugeMetrics) deleteLabelValues() {
+	if m == nil {
+		return
+	}
+	availableRUCounter.DeleteLabelValues(m.groupName, m.groupName, m.keyspaceName)
+	resourceGroupConfigGauge.DeleteLabelValues(m.groupName, priorityLabel, m.keyspaceName)
+	resourceGroupConfigGauge.DeleteLabelValues(m.groupName, ruPerSecLabel, m.keyspaceName)
+	resourceGroupConfigGauge.DeleteLabelValues(m.groupName, ruCapacityLabel, m.keyspaceName)
+	sampledRequestUnitPerSec.DeleteLabelValues(m.groupName, m.keyspaceName)
+	overrideSettings.DeleteLabelValues(m.groupName, m.keyspaceName, fillRateLabel)
+	overrideSettings.DeleteLabelValues(m.groupName, m.keyspaceName, burstLimitLabel)
+	activeSlotCountGauge.DeleteLabelValues(m.groupName, m.keyspaceName)
+	tokenLoanGauge.DeleteLabelValues(m.groupName, m.keyspaceName)
+	slotEventsCounter.DeleteLabelValues(m.groupName, m.keyspaceName, slotCreatedEventLabel)
+	slotEventsCounter.DeleteLabelValues(m.groupName, m.keyspaceName, slotDeletedEventLabel)
+	slotEventsCounter.DeleteLabelValues(m.groupName, m.keyspaceName, slotExpiredEventLabel)
 }
 
 func (m *gaugeMetrics) setGroup(group *ResourceGroup, keyspaceName string) {
@@ -812,6 +882,26 @@ func newMaxPerSecCostTracker(keyspaceName, groupName string, flushPeriod int) *m
 		rruMaxMetrics: readRequestUnitMaxPerSecCost.WithLabelValues(groupName, keyspaceName),
 		wruMaxMetrics: writeRequestUnitMaxPerSecCost.WithLabelValues(groupName, keyspaceName),
 	}
+}
+
+func (t *maxPerSecCostTracker) matchLabels(keyspaceName, groupName string) bool {
+	return t != nil && t.keyspaceName == keyspaceName && t.groupName == groupName
+}
+
+func (t *maxPerSecCostTracker) deleteLabelValues() {
+	if t == nil {
+		return
+	}
+	readRequestUnitMaxPerSecCost.DeleteLabelValues(t.groupName, t.keyspaceName)
+	writeRequestUnitMaxPerSecCost.DeleteLabelValues(t.groupName, t.keyspaceName)
+}
+
+func (t *maxPerSecCostTracker) rebindLabels(keyspaceName, groupName string) {
+	t.deleteLabelValues()
+	t.keyspaceName = keyspaceName
+	t.groupName = groupName
+	t.rruMaxMetrics = readRequestUnitMaxPerSecCost.WithLabelValues(groupName, keyspaceName)
+	t.wruMaxMetrics = writeRequestUnitMaxPerSecCost.WithLabelValues(groupName, keyspaceName)
 }
 
 func (t *maxPerSecCostTracker) collect(consume *rmpb.Consumption) {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -409,20 +409,24 @@ func (m *metrics) getRequestMetrics(keyspaceID uint32, keyspaceName, groupName s
 	key := requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}
 	m.mu.RLock()
 	rm := m.requestMetricsMap[key]
-	m.mu.RUnlock()
-	if rm != nil {
+	if rm != nil && rm.matchLabels(keyspaceName, groupName) {
+		m.mu.RUnlock()
 		rm.touchRecord(m, keyspaceID, groupName, now)
 		return rm
 	}
+	m.mu.RUnlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	rm = m.requestMetricsMap[key]
-	if rm == nil {
+	if rm == nil || !rm.matchLabels(keyspaceName, groupName) {
+		if rm != nil {
+			rm.deleteLabelValues()
+		}
 		rm = newRequestMetrics(keyspaceName, groupName)
-		rm.lastRecordUnix.Store(now.UnixNano())
 		m.requestMetricsMap[key] = rm
 	}
+	rm.lastRecordUnix.Store(now.UnixNano())
 	m.insertConsumptionRecordLocked(keyspaceID, groupName, defaultTypeLabel, now)
 	return rm
 }
@@ -431,9 +435,13 @@ func (m *metrics) deleteMetrics(keyspaceID uint32, keyspaceName, groupName, ruTy
 	m.mu.Lock()
 	delete(m.counterMetricsMap, metricsKey{keyspaceID, groupName, ruType})
 	delete(m.gaugeMetricsMap, metricsKey{keyspaceID, groupName, ""})
-	delete(m.requestMetricsMap, requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName})
+	requestKey := requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}
+	rm := m.requestMetricsMap[requestKey]
+	delete(m.requestMetricsMap, requestKey)
 	m.mu.Unlock()
+
 	deleteLabelValues(keyspaceName, groupName, ruType)
+	rm.deleteLabelValues()
 }
 
 func (m *metrics) getStaleConsumptionRecords(now time.Time) []consumptionRecordKey {
@@ -587,6 +595,8 @@ func (m *counterMetrics) add(consumption *rmpb.Consumption, controllerConfig *Co
 }
 
 type requestMetrics struct {
+	keyspaceName                string
+	groupName                   string
 	grantedTokensObserver       prometheus.Observer
 	trickleDurationObserver     prometheus.Observer
 	serviceLimitThrottleCounter prometheus.Counter
@@ -607,6 +617,8 @@ type requestMetricsObservation struct {
 
 func newRequestMetrics(keyspaceName, groupName string) *requestMetrics {
 	return &requestMetrics{
+		keyspaceName:                keyspaceName,
+		groupName:                   groupName,
 		grantedTokensObserver:       grantedTokensHistogram.WithLabelValues(groupName, keyspaceName),
 		trickleDurationObserver:     trickleDurationHistogram.WithLabelValues(groupName, keyspaceName),
 		serviceLimitThrottleCounter: requestCauseCounter.WithLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel),
@@ -614,6 +626,22 @@ func newRequestMetrics(keyspaceName, groupName string) *requestMetrics {
 		serviceLimitTrickleCounter:  requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel),
 		groupTrickleCounter:         requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel),
 	}
+}
+
+func (m *requestMetrics) matchLabels(keyspaceName, groupName string) bool {
+	return m != nil && m.keyspaceName == keyspaceName && m.groupName == groupName
+}
+
+func (m *requestMetrics) deleteLabelValues() {
+	if m == nil {
+		return
+	}
+	grantedTokensHistogram.DeleteLabelValues(m.groupName, m.keyspaceName)
+	trickleDurationHistogram.DeleteLabelValues(m.groupName, m.keyspaceName)
+	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, throttleKindLabel, groupCauseLabel)
+	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	requestCauseCounter.DeleteLabelValues(m.groupName, m.keyspaceName, trickleKindLabel, groupCauseLabel)
 }
 
 func (m *requestMetrics) touchRecord(metrics *metrics, keyspaceID uint32, groupName string, now time.Time) {

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -865,13 +865,6 @@ func deleteRequestMetricLabelValues(keyspaceName, groupName string) {
 	requestCauseCounter.DeleteLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
 }
 
-func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
-	deleteCounterMetricLabelValues(keyspaceName, groupName, ruLabelType)
-	deleteGaugeMetricLabelValues(keyspaceName, groupName)
-	deleteMaxPerSecTrackerLabelValues(keyspaceName, groupName)
-	deleteRequestMetricLabelValues(keyspaceName, groupName)
-}
-
 type maxPerSecCostTracker struct {
 	keyspaceName  string
 	groupName     string

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -166,6 +166,31 @@ func TestObserveRequestCause(t *testing.T) {
 	re.Equal(1.0, testutil.ToFloat64(trickleCounter))
 }
 
+func TestServiceLimitMetricsDeletesCachedFallbackLabelWhenKeyspaceNameChanges(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID   = uint32(10879)
+		fallbackName = "keyspace-10879"
+		loadedName   = "loaded-service-limit-keyspace"
+		metricName   = "resource_manager_resource_unit_service_limit"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		serviceLimit.DeleteLabelValues(fallbackName)
+		serviceLimit.DeleteLabelValues(loadedName)
+	})
+
+	metrics.setOrRemoveServiceLimitMetrics(keyspaceID, fallbackName, 100)
+	re.True(hasMetric(metricName, map[string]string{keyspaceNameLabel: fallbackName}))
+
+	metrics.setOrRemoveServiceLimitMetrics(keyspaceID, loadedName, 100)
+	re.False(hasMetric(metricName, map[string]string{keyspaceNameLabel: fallbackName}))
+	re.True(hasMetric(metricName, map[string]string{keyspaceNameLabel: loadedName}))
+
+	metrics.setOrRemoveServiceLimitMetrics(keyspaceID, loadedName, 0)
+	re.False(hasMetric(metricName, map[string]string{keyspaceNameLabel: loadedName}))
+}
+
 func TestRequestMetricsCachedAndCleanedUp(t *testing.T) {
 	re := require.New(t)
 	const (
@@ -206,6 +231,141 @@ func TestRequestMetricsCachedAndCleanedUp(t *testing.T) {
 	metrics.mu.RUnlock()
 	re.False(ok)
 	re.False(recordExists)
+}
+
+func TestCleanupStaleRecordSkipsRefreshedRecord(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID         = uint32(10876)
+		keyspaceName       = "refreshed_request_metrics_keyspace"
+		groupName          = "refreshed_request_metrics_group"
+		grantedTokenMetric = "resource_manager_server_granted_tokens"
+	)
+	t.Cleanup(func() {
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
+	})
+	staleTime := time.Now().Add(-metricsCleanupTimeout - time.Second)
+	cleanupTime := staleTime.Add(metricsCleanupTimeout + time.Second)
+	refreshTime := cleanupTime.Add(time.Second)
+	metrics := newMetrics()
+
+	first := metrics.getRequestMetrics(keyspaceID, keyspaceName, groupName, staleTime)
+	first.observe(requestMetricsObservation{grantedTokens: 1})
+	staleRecords := metrics.getStaleConsumptionRecords(cleanupTime)
+	re.Len(staleRecords, 1)
+
+	second := metrics.getRequestMetrics(keyspaceID, keyspaceName, groupName, refreshTime)
+	re.Same(first, second)
+	metrics.cleanupStaleMetrics(staleRecords[0], keyspaceName)
+
+	labels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	recordKey := consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     defaultTypeLabel,
+	}
+	metrics.mu.RLock()
+	_, requestExists := metrics.requestMetricsMap[requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}]
+	recordTime, recordExists := metrics.consumptionRecordMap[recordKey]
+	metrics.mu.RUnlock()
+	re.True(requestExists)
+	re.True(recordExists)
+	re.Equal(refreshTime, recordTime)
+	re.True(hasMetric(grantedTokenMetric, labels))
+}
+
+func TestCleanupStaleDefaultRUTypeDeletesRequestMetricsWithActiveBackground(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID         = uint32(10878)
+		keyspaceName       = "stale_default_active_background_keyspace"
+		groupName          = "stale_default_active_background_group"
+		grantedTokenMetric = "resource_manager_server_granted_tokens"
+		backgroundRUMetric = "resource_manager_resource_unit_read_request_unit_sum"
+		availableRUMetric  = "resource_manager_resource_unit_available_ru"
+		maxPerSecMetric    = "resource_manager_resource_unit_read_request_unit_max_per_sec"
+		requestCauseMetric = "resource_manager_server_request_cause_total"
+	)
+	t.Cleanup(func() {
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
+		deleteCounterMetricLabelValues(keyspaceName, groupName, backgroundTypeLabel)
+	})
+	staleTime := time.Now().Add(-metricsCleanupTimeout - time.Second)
+	cleanupTime := staleTime.Add(metricsCleanupTimeout + time.Second)
+	freshTime := cleanupTime
+	metrics := newMetrics()
+
+	requestMetrics := metrics.getRequestMetrics(keyspaceID, keyspaceName, groupName, staleTime)
+	requestMetrics.observe(requestMetricsObservation{
+		grantedTokens:  1,
+		serviceLimited: true,
+	})
+	backgroundMetrics := metrics.getCounterMetrics(keyspaceID, keyspaceName, groupName, backgroundTypeLabel)
+	backgroundMetrics.add(&rmpb.Consumption{RRU: 2}, &ControllerConfig{}, keyspaceID)
+	metrics.insertConsumptionRecord(keyspaceID, groupName, backgroundTypeLabel, freshTime)
+	gaugeMetrics := metrics.getGaugeMetrics(keyspaceID, keyspaceName, groupName)
+	gaugeMetrics.availableRUCounter.Set(3)
+	tracker := metrics.getMaxPerSecTracker(keyspaceID, keyspaceName, groupName)
+	tracker.rruMaxMetrics.Set(4)
+
+	staleRecords := metrics.getStaleConsumptionRecords(cleanupTime)
+	re.Len(staleRecords, 1)
+	re.True(metrics.cleanupStaleMetrics(staleRecords[0], keyspaceName))
+
+	requestLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	backgroundRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 backgroundTypeLabel,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	groupLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	groupKeyspaceLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	re.False(hasMetric(grantedTokenMetric, requestLabels))
+	re.False(hasMetric(requestCauseMetric, map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+		kindLabel:                 throttleKindLabel,
+		"cause":                   serviceLimitCauseLabel,
+	}))
+	re.True(hasMetric(backgroundRUMetric, backgroundRULabels))
+	re.True(hasMetric(availableRUMetric, groupLabels))
+	re.True(hasMetric(maxPerSecMetric, groupKeyspaceLabels))
+	metrics.mu.RLock()
+	_, requestExists := metrics.requestMetricsMap[requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}]
+	_, defaultRecordExists := metrics.consumptionRecordMap[consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     defaultTypeLabel,
+	}]
+	_, backgroundRecordExists := metrics.consumptionRecordMap[consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     backgroundTypeLabel,
+	}]
+	_, backgroundCounterExists := metrics.counterMetricsMap[metricsKey{keyspaceID: keyspaceID, groupName: groupName, ruType: backgroundTypeLabel}]
+	_, gaugeExists := metrics.gaugeMetricsMap[metricsKey{keyspaceID: keyspaceID, groupName: groupName, ruType: ""}]
+	_, trackerExists := metrics.maxPerSecTrackerMap[trackerKey{keyspaceID: keyspaceID, groupName: groupName}]
+	metrics.mu.RUnlock()
+	re.False(requestExists)
+	re.False(defaultRecordExists)
+	re.True(backgroundRecordExists)
+	re.True(backgroundCounterExists)
+	re.True(gaugeExists)
+	re.True(trackerExists)
 }
 
 func TestRequestMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T) {
@@ -306,6 +466,74 @@ func TestCounterMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T)
 		keyspaceNameLabel:         loadedName,
 	}
 	re.True(hasMetric(metricName, loadedLabels))
+}
+
+func TestCounterMetricsRebindKeepsSharedLabelsUsedByOtherRUType(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID         = uint32(10877)
+		fallbackName       = "keyspace-10877"
+		loadedName         = "loaded-counter-shared-keyspace"
+		groupName          = "counter_metrics_shared_label_group"
+		readRUMetric       = "resource_manager_resource_unit_read_request_unit_sum"
+		crossAZMetric      = "resource_manager_resource_cross_az_traffic_byte_sum"
+		requestCountMetric = "resource_manager_resource_request_count"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		deleteDefaultLabelValuesForTest(fallbackName, groupName)
+		deleteDefaultLabelValuesForTest(loadedName, groupName)
+		deleteCounterMetricLabelValues(fallbackName, groupName, backgroundTypeLabel)
+	})
+
+	defaultMetrics := metrics.getCounterMetrics(keyspaceID, fallbackName, groupName, defaultTypeLabel)
+	defaultMetrics.add(&rmpb.Consumption{
+		RRU:                     1,
+		KvReadRpcCount:          1,
+		ReadCrossAzTrafficBytes: 1,
+	}, &ControllerConfig{}, keyspaceID)
+	backgroundMetrics := metrics.getCounterMetrics(keyspaceID, fallbackName, groupName, backgroundTypeLabel)
+	backgroundMetrics.add(&rmpb.Consumption{
+		RRU:                     2,
+		KvReadRpcCount:          2,
+		ReadCrossAzTrafficBytes: 2,
+	}, &ControllerConfig{}, keyspaceID)
+
+	defaultFallbackLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 defaultTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	backgroundFallbackLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 backgroundTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	fallbackCrossAZLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	fallbackRequestCountLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	re.True(hasMetric(readRUMetric, defaultFallbackLabels))
+	re.True(hasMetric(readRUMetric, backgroundFallbackLabels))
+	re.True(hasMetric(crossAZMetric, fallbackCrossAZLabels))
+	re.True(hasMetric(requestCountMetric, fallbackRequestCountLabels))
+
+	defaultLoadedMetrics := metrics.getCounterMetrics(keyspaceID, loadedName, groupName, defaultTypeLabel)
+	defaultLoadedMetrics.add(&rmpb.Consumption{RRU: 3}, &ControllerConfig{}, keyspaceID)
+
+	re.False(hasMetric(readRUMetric, defaultFallbackLabels))
+	re.True(hasMetric(readRUMetric, backgroundFallbackLabels))
+	re.True(hasMetric(crossAZMetric, fallbackCrossAZLabels))
+	re.True(hasMetric(requestCountMetric, fallbackRequestCountLabels))
 }
 
 func TestGaugeMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T) {
@@ -466,6 +694,203 @@ func TestCleanupAllMetricsDeletesCachedLabelsWhenKeyspaceNameChanges(t *testing.
 	re.False(gaugeExists)
 	re.False(trackerExists)
 	re.False(requestExists)
+}
+
+func TestCleanupStaleRUTypeKeepsActiveGroupMetrics(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID          = uint32(10874)
+		keyspaceName        = "mixed_cleanup_keyspace"
+		groupName           = "mixed_cleanup_group"
+		readRUMetric        = "resource_manager_resource_unit_read_request_unit_sum"
+		crossAZMetric       = "resource_manager_resource_cross_az_traffic_byte_sum"
+		requestCountMetric  = "resource_manager_resource_request_count"
+		availableRUMetric   = "resource_manager_resource_unit_available_ru"
+		maxPerSecMetric     = "resource_manager_resource_unit_read_request_unit_max_per_sec"
+		grantedTokensMetric = "resource_manager_server_granted_tokens"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
+		deleteCounterMetricLabelValues(keyspaceName, groupName, backgroundTypeLabel)
+	})
+
+	defaultMetrics := metrics.getCounterMetrics(keyspaceID, keyspaceName, groupName, defaultTypeLabel)
+	defaultMetrics.add(&rmpb.Consumption{
+		RRU:                     1,
+		KvReadRpcCount:          1,
+		ReadCrossAzTrafficBytes: 1,
+	}, &ControllerConfig{}, keyspaceID)
+	backgroundMetrics := metrics.getCounterMetrics(keyspaceID, keyspaceName, groupName, backgroundTypeLabel)
+	backgroundMetrics.add(&rmpb.Consumption{
+		RRU:                     2,
+		KvReadRpcCount:          2,
+		ReadCrossAzTrafficBytes: 2,
+	}, &ControllerConfig{}, keyspaceID)
+	gaugeMetrics := metrics.getGaugeMetrics(keyspaceID, keyspaceName, groupName)
+	gaugeMetrics.availableRUCounter.Set(3)
+	tracker := metrics.getMaxPerSecTracker(keyspaceID, keyspaceName, groupName)
+	tracker.rruMaxMetrics.Set(4)
+	requestMetrics := metrics.getRequestMetrics(keyspaceID, keyspaceName, groupName, time.Now())
+	requestMetrics.observe(requestMetricsObservation{grantedTokens: 5})
+	metrics.insertConsumptionRecord(keyspaceID, groupName, backgroundTypeLabel, time.Now())
+
+	defaultReadRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 defaultTypeLabel,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	backgroundReadRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 backgroundTypeLabel,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	crossAZLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	requestCountLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	availableRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	groupKeyspaceLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	re.True(hasMetric(readRUMetric, defaultReadRULabels))
+	re.True(hasMetric(readRUMetric, backgroundReadRULabels))
+	re.True(hasMetric(crossAZMetric, crossAZLabels))
+	re.True(hasMetric(requestCountMetric, requestCountLabels))
+	re.True(hasMetric(availableRUMetric, availableRULabels))
+	re.True(hasMetric(maxPerSecMetric, groupKeyspaceLabels))
+	re.True(hasMetric(grantedTokensMetric, groupKeyspaceLabels))
+
+	metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     backgroundTypeLabel,
+	}, keyspaceName)
+
+	re.True(hasMetric(readRUMetric, defaultReadRULabels))
+	re.False(hasMetric(readRUMetric, backgroundReadRULabels))
+	re.True(hasMetric(crossAZMetric, crossAZLabels))
+	re.True(hasMetric(requestCountMetric, requestCountLabels))
+	re.True(hasMetric(availableRUMetric, availableRULabels))
+	re.True(hasMetric(maxPerSecMetric, groupKeyspaceLabels))
+	re.True(hasMetric(grantedTokensMetric, groupKeyspaceLabels))
+	metrics.mu.RLock()
+	_, defaultCounterExists := metrics.counterMetricsMap[metricsKey{keyspaceID: keyspaceID, groupName: groupName, ruType: defaultTypeLabel}]
+	_, backgroundCounterExists := metrics.counterMetricsMap[metricsKey{keyspaceID: keyspaceID, groupName: groupName, ruType: backgroundTypeLabel}]
+	_, gaugeExists := metrics.gaugeMetricsMap[metricsKey{keyspaceID: keyspaceID, groupName: groupName, ruType: ""}]
+	_, trackerExists := metrics.maxPerSecTrackerMap[trackerKey{keyspaceID: keyspaceID, groupName: groupName}]
+	_, requestExists := metrics.requestMetricsMap[requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}]
+	metrics.mu.RUnlock()
+	re.True(defaultCounterExists)
+	re.False(backgroundCounterExists)
+	re.True(gaugeExists)
+	re.True(trackerExists)
+	re.True(requestExists)
+}
+
+func TestCleanupStaleRUTypeDeletesItsFallbackSharedCounterLabels(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID         = uint32(10875)
+		fallbackName       = "keyspace-10875"
+		loadedName         = "loaded-mixed-cleanup-keyspace"
+		groupName          = "mixed_fallback_cleanup_group"
+		readRUMetric       = "resource_manager_resource_unit_read_request_unit_sum"
+		crossAZMetric      = "resource_manager_resource_cross_az_traffic_byte_sum"
+		requestCountMetric = "resource_manager_resource_request_count"
+		availableRUMetric  = "resource_manager_resource_unit_available_ru"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		deleteDefaultLabelValuesForTest(fallbackName, groupName)
+		deleteDefaultLabelValuesForTest(loadedName, groupName)
+		deleteCounterMetricLabelValues(fallbackName, groupName, backgroundTypeLabel)
+	})
+
+	backgroundMetrics := metrics.getCounterMetrics(keyspaceID, fallbackName, groupName, backgroundTypeLabel)
+	backgroundMetrics.add(&rmpb.Consumption{
+		RRU:                     1,
+		KvReadRpcCount:          1,
+		ReadCrossAzTrafficBytes: 1,
+	}, &ControllerConfig{}, keyspaceID)
+	metrics.insertConsumptionRecord(keyspaceID, groupName, backgroundTypeLabel, time.Now())
+	defaultMetrics := metrics.getCounterMetrics(keyspaceID, loadedName, groupName, defaultTypeLabel)
+	defaultMetrics.add(&rmpb.Consumption{
+		RRU:                     2,
+		KvReadRpcCount:          2,
+		ReadCrossAzTrafficBytes: 2,
+	}, &ControllerConfig{}, keyspaceID)
+	gaugeMetrics := metrics.getGaugeMetrics(keyspaceID, loadedName, groupName)
+	gaugeMetrics.availableRUCounter.Set(3)
+	requestMetrics := metrics.getRequestMetrics(keyspaceID, loadedName, groupName, time.Now())
+	requestMetrics.observe(requestMetricsObservation{grantedTokens: 4})
+
+	fallbackReadRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 backgroundTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	fallbackCrossAZLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	fallbackRequestCountLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	loadedCrossAZLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         loadedName,
+	}
+	loadedRequestCountLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         loadedName,
+	}
+	loadedAvailableRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         loadedName,
+	}
+	re.True(hasMetric(readRUMetric, fallbackReadRULabels))
+	re.True(hasMetric(crossAZMetric, fallbackCrossAZLabels))
+	re.True(hasMetric(requestCountMetric, fallbackRequestCountLabels))
+	re.True(hasMetric(crossAZMetric, loadedCrossAZLabels))
+	re.True(hasMetric(requestCountMetric, loadedRequestCountLabels))
+	re.True(hasMetric(availableRUMetric, loadedAvailableRULabels))
+
+	metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     backgroundTypeLabel,
+	}, loadedName)
+
+	re.False(hasMetric(readRUMetric, fallbackReadRULabels))
+	re.False(hasMetric(crossAZMetric, fallbackCrossAZLabels))
+	re.False(hasMetric(requestCountMetric, fallbackRequestCountLabels))
+	re.True(hasMetric(crossAZMetric, loadedCrossAZLabels))
+	re.True(hasMetric(requestCountMetric, loadedRequestCountLabels))
+	re.True(hasMetric(availableRUMetric, loadedAvailableRULabels))
 }
 
 func TestDeleteCounterMetricLabelValuesUsesRUType(t *testing.T) {

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -15,9 +15,13 @@
 package server
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -113,4 +117,139 @@ func TestMaxPerSecCostTracker(t *testing.T) {
 			re.Equal(tracker.rruSum, expectedSum[period])
 		}
 	}
+}
+
+func TestObserveTokenGrantRecordsZeroTrickle(t *testing.T) {
+	re := require.New(t)
+	groupName := "observe_token_group"
+	keyspaceName := "observe_token_keyspace"
+
+	observeTokenGrant(groupName, keyspaceName, &rmpb.GrantedRUTokenBucket{
+		GrantedTokens: &rmpb.TokenBucket{Tokens: 42},
+		TrickleTimeMs: 0,
+	})
+
+	granted := findHistogramMetric(re, "resource_manager_server_granted_tokens", map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	})
+	re.Equal(uint64(1), granted.GetSampleCount())
+	re.Equal(42.0, granted.GetSampleSum())
+
+	trickle := findHistogramMetric(re, "resource_manager_server_trickle_duration_ms", map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         keyspaceName,
+	})
+	re.Equal(uint64(1), trickle.GetSampleCount())
+	re.Zero(trickle.GetSampleSum())
+}
+
+func TestObserveRequestCause(t *testing.T) {
+	re := require.New(t)
+	groupName := "observe_request_group"
+	keyspaceName := "observe_request_keyspace"
+	throttleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	trickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+
+	observeRequestCause(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	observeRequestCause(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+
+	re.Equal(1.0, testutil.ToFloat64(throttleCounter))
+	re.Equal(1.0, testutil.ToFloat64(trickleCounter))
+}
+
+func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
+	re := require.New(t)
+	groupName := "request_ru_trickle_group"
+	keyspaceName := "request_ru_trickle_keyspace"
+	t.Cleanup(func() {
+		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+	})
+
+	serviceTrickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	groupTrickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+	now := time.Now()
+	rg := &ResourceGroup{
+		Name: groupName,
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: NewRequestUnitSettings(groupName, &rmpb.TokenBucket{
+			Settings: &rmpb.TokenLimitSettings{
+				FillRate:   100,
+				BurstLimit: 1000,
+			},
+		}),
+	}
+	sl := newServiceLimiter(1, 10, nil)
+	sl.AvailableTokens = 10
+	sl.LastUpdate = now
+
+	tokens := rg.RequestRU(now, 10, 1000, 1, keyspaceName, nil, sl)
+
+	re.NotNil(tokens)
+	re.Equal(10.0, tokens.GetGrantedTokens().GetTokens())
+	re.Equal(int64(1000), tokens.GetTrickleTimeMs())
+	re.Equal(1.0, testutil.ToFloat64(serviceTrickleCounter))
+	re.Zero(testutil.ToFloat64(groupTrickleCounter))
+}
+
+func TestGaugeMetricsSetGroupSlotMetrics(t *testing.T) {
+	re := require.New(t)
+	groupName := "slot_group"
+	keyspaceName := "slot_keyspace"
+	rg := &ResourceGroup{
+		Name: groupName,
+		Mode: rmpb.GroupMode_RUMode,
+		RUSettings: NewRequestUnitSettings(groupName, &rmpb.TokenBucket{
+			Settings: &rmpb.TokenLimitSettings{
+				FillRate:   100,
+				BurstLimit: 200,
+			},
+		}),
+	}
+	rg.RUSettings.RU.tokenSlots[1] = &tokenSlot{curTokenCapacity: -12.5}
+	rg.RUSettings.RU.slotsCreated = 2
+	rg.RUSettings.RU.slotsDeleted = 1
+	rg.RUSettings.RU.slotsExpired = 3
+
+	gm := newGaugeMetrics(keyspaceName, groupName)
+	gm.setGroup(rg, keyspaceName)
+
+	re.Equal(1.0, testutil.ToFloat64(gm.activeSlotCountGauge))
+	re.Equal(12.5, testutil.ToFloat64(gm.tokenLoanGauge))
+	re.Equal(2.0, testutil.ToFloat64(gm.slotCreatedCounter))
+	re.Equal(1.0, testutil.ToFloat64(gm.slotDeletedCounter))
+	re.Equal(3.0, testutil.ToFloat64(gm.slotExpiredCounter))
+	created, deleted, expired := rg.DrainSlotEvents()
+	re.Zero(created)
+	re.Zero(deleted)
+	re.Zero(expired)
+}
+
+func findHistogramMetric(re *require.Assertions, metricName string, labels map[string]string) *dto.Histogram {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	re.NoError(err)
+	for _, mf := range metrics {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if matchMetricLabels(metric.GetLabel(), labels) {
+				return metric.GetHistogram()
+			}
+		}
+	}
+	re.FailNow(fmt.Sprintf("metric %s with labels %v not found", metricName, labels))
+	return nil
+}
+
+func matchMetricLabels(actual []*dto.LabelPair, expected map[string]string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for _, label := range actual {
+		if expected[label.GetName()] != label.GetValue() {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -388,6 +388,86 @@ func TestMaxPerSecTrackerRebindsLabelsWhenKeyspaceNameChanges(t *testing.T) {
 	re.True(hasMetric(metricName, loadedLabels))
 }
 
+func TestCleanupAllMetricsDeletesCachedLabelsWhenKeyspaceNameChanges(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID          = uint32(10872)
+		fallbackName        = "keyspace-10872"
+		loadedName          = "loaded-cleanup-keyspace"
+		groupName           = "cleanup_metrics_label_group"
+		readRUMetric        = "resource_manager_resource_unit_read_request_unit_sum"
+		crossAZMetric       = "resource_manager_resource_cross_az_traffic_byte_sum"
+		availableRUMetric   = "resource_manager_resource_unit_available_ru"
+		maxPerSecMetric     = "resource_manager_resource_unit_read_request_unit_max_per_sec"
+		grantedTokensMetric = "resource_manager_server_granted_tokens"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
+		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+	})
+
+	counterMetrics := metrics.getCounterMetrics(keyspaceID, fallbackName, groupName, defaultTypeLabel)
+	counterMetrics.add(&rmpb.Consumption{
+		RRU:                     1,
+		ReadCrossAzTrafficBytes: 2,
+	}, &ControllerConfig{}, keyspaceID)
+	gaugeMetrics := metrics.getGaugeMetrics(keyspaceID, fallbackName, groupName)
+	gaugeMetrics.availableRUCounter.Set(3)
+	tracker := metrics.getMaxPerSecTracker(keyspaceID, fallbackName, groupName)
+	tracker.rruMaxMetrics.Set(4)
+	requestMetrics := metrics.getRequestMetrics(keyspaceID, fallbackName, groupName, time.Now())
+	requestMetrics.observe(requestMetricsObservation{grantedTokens: 5})
+
+	readRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 defaultTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	crossAZLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 readTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	availableRULabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         fallbackName,
+	}
+	groupKeyspaceLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         fallbackName,
+	}
+	re.True(hasMetric(readRUMetric, readRULabels))
+	re.True(hasMetric(crossAZMetric, crossAZLabels))
+	re.True(hasMetric(availableRUMetric, availableRULabels))
+	re.True(hasMetric(maxPerSecMetric, groupKeyspaceLabels))
+	re.True(hasMetric(grantedTokensMetric, groupKeyspaceLabels))
+
+	metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     defaultTypeLabel,
+	}, loadedName)
+
+	re.False(hasMetric(readRUMetric, readRULabels))
+	re.False(hasMetric(crossAZMetric, crossAZLabels))
+	re.False(hasMetric(availableRUMetric, availableRULabels))
+	re.False(hasMetric(maxPerSecMetric, groupKeyspaceLabels))
+	re.False(hasMetric(grantedTokensMetric, groupKeyspaceLabels))
+	metrics.mu.RLock()
+	_, counterExists := metrics.counterMetricsMap[metricsKey{keyspaceID: keyspaceID, groupName: groupName, ruType: defaultTypeLabel}]
+	_, gaugeExists := metrics.gaugeMetricsMap[metricsKey{keyspaceID: keyspaceID, groupName: groupName, ruType: ""}]
+	_, trackerExists := metrics.maxPerSecTrackerMap[trackerKey{keyspaceID: keyspaceID, groupName: groupName}]
+	_, requestExists := metrics.requestMetricsMap[requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}]
+	metrics.mu.RUnlock()
+	re.False(counterExists)
+	re.False(gaugeExists)
+	re.False(trackerExists)
+	re.False(requestExists)
+}
+
 func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
 	re := require.New(t)
 	groupName := "request_ru_trickle_group"

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -208,6 +208,67 @@ func TestRequestMetricsCachedAndCleanedUp(t *testing.T) {
 	re.False(recordExists)
 }
 
+func TestRequestMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID       = uint32(10868)
+		fallbackName     = "keyspace-10868"
+		loadedName       = "loaded-keyspace"
+		groupName        = "request_metrics_label_group"
+		grantedMetric    = "resource_manager_server_granted_tokens"
+		trickleMetric    = "resource_manager_server_trickle_duration_ms"
+		requestCauseName = "resource_manager_server_request_cause_total"
+	)
+	now := time.Now()
+	metrics := newMetrics()
+
+	first := metrics.getRequestMetrics(keyspaceID, fallbackName, groupName, now)
+	first.observe(requestMetricsObservation{
+		grantedTokens:  3,
+		trickleTimeMs:  100,
+		serviceLimited: true,
+		groupTrickled:  true,
+	})
+
+	fallbackLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         fallbackName,
+	}
+	re.True(hasMetric(grantedMetric, fallbackLabels))
+	re.True(hasMetric(trickleMetric, fallbackLabels))
+	re.True(hasMetric(requestCauseName, map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         fallbackName,
+		kindLabel:                 throttleKindLabel,
+		"cause":                   serviceLimitCauseLabel,
+	}))
+
+	second := metrics.getRequestMetrics(keyspaceID, loadedName, groupName, now.Add(metricsCleanupInterval+time.Second))
+	re.NotSame(first, second)
+	re.False(hasMetric(grantedMetric, fallbackLabels))
+	re.False(hasMetric(trickleMetric, fallbackLabels))
+	re.False(hasMetric(requestCauseName, map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         fallbackName,
+		kindLabel:                 throttleKindLabel,
+		"cause":                   serviceLimitCauseLabel,
+	}))
+
+	second.observe(requestMetricsObservation{grantedTokens: 5})
+	loadedLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         loadedName,
+	}
+	re.True(hasMetric(grantedMetric, loadedLabels))
+
+	metrics.cleanupAllMetrics(consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     defaultTypeLabel,
+	}, loadedName)
+	re.False(hasMetric(grantedMetric, loadedLabels))
+}
+
 func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
 	re := require.New(t)
 	groupName := "request_ru_trickle_group"
@@ -291,6 +352,24 @@ func findHistogramMetric(re *require.Assertions, metricName string, labels map[s
 	}
 	re.FailNow(fmt.Sprintf("metric %s with labels %v not found", metricName, labels))
 	return nil
+}
+
+func hasMetric(metricName string, labels map[string]string) bool {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return false
+	}
+	for _, mf := range metrics {
+		if mf.GetName() != metricName {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if matchMetricLabels(metric.GetLabel(), labels) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func matchMetricLabels(actual []*dto.LabelPair, expected map[string]string) bool {

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -123,10 +123,14 @@ func TestObserveTokenGrantRecordsZeroTrickle(t *testing.T) {
 	re := require.New(t)
 	groupName := "observe_token_group"
 	keyspaceName := "observe_token_keyspace"
+	t.Cleanup(func() {
+		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+	})
 
-	observeTokenGrant(groupName, keyspaceName, &rmpb.GrantedRUTokenBucket{
-		GrantedTokens: &rmpb.TokenBucket{Tokens: 42},
-		TrickleTimeMs: 0,
+	metrics := newRequestMetrics(keyspaceName, groupName)
+	metrics.observe(requestMetricsObservation{
+		grantedTokens: 42,
+		trickleTimeMs: 0,
 	})
 
 	granted := findHistogramMetric(re, "resource_manager_server_granted_tokens", map[string]string{
@@ -148,14 +152,60 @@ func TestObserveRequestCause(t *testing.T) {
 	re := require.New(t)
 	groupName := "observe_request_group"
 	keyspaceName := "observe_request_keyspace"
+	t.Cleanup(func() {
+		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+	})
 	throttleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
 	trickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+	metrics := newRequestMetrics(keyspaceName, groupName)
 
-	observeRequestCause(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
-	observeRequestCause(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
+	metrics.observe(requestMetricsObservation{serviceLimited: true})
+	metrics.observe(requestMetricsObservation{groupTrickled: true})
 
 	re.Equal(1.0, testutil.ToFloat64(throttleCounter))
 	re.Equal(1.0, testutil.ToFloat64(trickleCounter))
+}
+
+func TestRequestMetricsCachedAndCleanedUp(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID   = uint32(10867)
+		keyspaceName = "request_metrics_keyspace"
+		groupName    = "request_metrics_group"
+	)
+	now := time.Now()
+	metrics := newMetrics()
+
+	first := metrics.getRequestMetrics(keyspaceID, keyspaceName, groupName, now)
+	second := metrics.getRequestMetrics(keyspaceID, keyspaceName, groupName, now.Add(time.Second))
+	re.Same(first, second)
+
+	recordKey := consumptionRecordKey{
+		keyspaceID: keyspaceID,
+		groupName:  groupName,
+		ruType:     defaultTypeLabel,
+	}
+	metrics.mu.RLock()
+	re.Equal(now, metrics.consumptionRecordMap[recordKey])
+	_, ok := metrics.requestMetricsMap[requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}]
+	metrics.mu.RUnlock()
+	re.True(ok)
+
+	touchTime := now.Add(metricsCleanupInterval + time.Second)
+	third := metrics.getRequestMetrics(keyspaceID, keyspaceName, groupName, touchTime)
+	re.Same(first, third)
+	metrics.mu.RLock()
+	re.Equal(touchTime, metrics.consumptionRecordMap[recordKey])
+	metrics.mu.RUnlock()
+
+	metrics.cleanupAllMetrics(recordKey, keyspaceName)
+
+	metrics.mu.RLock()
+	_, ok = metrics.requestMetricsMap[requestMetricsKey{keyspaceID: keyspaceID, groupName: groupName}]
+	_, recordExists := metrics.consumptionRecordMap[recordKey]
+	metrics.mu.RUnlock()
+	re.False(ok)
+	re.False(recordExists)
 }
 
 func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
@@ -182,8 +232,9 @@ func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
 	sl := newServiceLimiter(1, 10, nil)
 	sl.AvailableTokens = 10
 	sl.LastUpdate = now
+	metrics := newRequestMetrics(keyspaceName, groupName)
 
-	tokens := rg.RequestRU(now, 10, 1000, 1, keyspaceName, nil, sl)
+	tokens := rg.RequestRU(now, 10, 1000, 1, keyspaceName, nil, sl, metrics)
 
 	re.NotNil(tokens)
 	re.Equal(10.0, tokens.GetGrantedTokens().GetTokens())

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -318,7 +318,9 @@ func TestGaugeMetricsSetGroupSlotMetrics(t *testing.T) {
 			},
 		}),
 	}
-	rg.RUSettings.RU.tokenSlots[1] = &tokenSlot{curTokenCapacity: -12.5}
+	slot := newTokenSlot(1, time.Now())
+	rg.RUSettings.RU.tokenSlots[1] = slot
+	rg.RUSettings.RU.setSlotTokenCapacity(slot, -12.5)
 	rg.RUSettings.RU.slotsCreated = 2
 	rg.RUSettings.RU.slotsDeleted = 1
 	rg.RUSettings.RU.slotsExpired = 3

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -37,7 +37,7 @@ func TestActiveRequestUnitMetricUsesV1ByDefault(t *testing.T) {
 	)
 
 	t.Cleanup(func() {
-		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
 	})
 
 	metrics := newCounterMetrics(keyspaceName, groupName, defaultTypeLabel)
@@ -66,7 +66,7 @@ func TestActiveRequestUnitMetricUsesV2ForOverriddenKeyspace(t *testing.T) {
 	)
 
 	t.Cleanup(func() {
-		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
 	})
 
 	metrics := newCounterMetrics(keyspaceName, groupName, defaultTypeLabel)
@@ -124,7 +124,7 @@ func TestObserveTokenGrantRecordsZeroTrickle(t *testing.T) {
 	groupName := "observe_token_group"
 	keyspaceName := "observe_token_keyspace"
 	t.Cleanup(func() {
-		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
 	})
 
 	metrics := newRequestMetrics(keyspaceName, groupName)
@@ -153,7 +153,7 @@ func TestObserveRequestCause(t *testing.T) {
 	groupName := "observe_request_group"
 	keyspaceName := "observe_request_keyspace"
 	t.Cleanup(func() {
-		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
 	})
 	throttleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
 	trickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, groupCauseLabel)
@@ -280,8 +280,8 @@ func TestCounterMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T)
 	)
 	metrics := newMetrics()
 	t.Cleanup(func() {
-		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
-		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(fallbackName, groupName)
+		deleteDefaultLabelValuesForTest(loadedName, groupName)
 	})
 
 	first := metrics.getCounterMetrics(keyspaceID, fallbackName, groupName, defaultTypeLabel)
@@ -319,8 +319,8 @@ func TestGaugeMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T) {
 	)
 	metrics := newMetrics()
 	t.Cleanup(func() {
-		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
-		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(fallbackName, groupName)
+		deleteDefaultLabelValuesForTest(loadedName, groupName)
 	})
 
 	first := metrics.getGaugeMetrics(keyspaceID, fallbackName, groupName)
@@ -356,8 +356,8 @@ func TestMaxPerSecTrackerRebindsLabelsWhenKeyspaceNameChanges(t *testing.T) {
 	)
 	metrics := newMetrics()
 	t.Cleanup(func() {
-		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
-		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(fallbackName, groupName)
+		deleteDefaultLabelValuesForTest(loadedName, groupName)
 	})
 
 	first := metrics.getMaxPerSecTracker(keyspaceID, fallbackName, groupName)
@@ -403,8 +403,8 @@ func TestCleanupAllMetricsDeletesCachedLabelsWhenKeyspaceNameChanges(t *testing.
 	)
 	metrics := newMetrics()
 	t.Cleanup(func() {
-		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
-		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(fallbackName, groupName)
+		deleteDefaultLabelValuesForTest(loadedName, groupName)
 	})
 
 	counterMetrics := metrics.getCounterMetrics(keyspaceID, fallbackName, groupName, defaultTypeLabel)
@@ -468,12 +468,50 @@ func TestCleanupAllMetricsDeletesCachedLabelsWhenKeyspaceNameChanges(t *testing.
 	re.False(requestExists)
 }
 
+func TestDeleteCounterMetricLabelValuesUsesRUType(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID   = uint32(10873)
+		keyspaceName = "counter_cleanup_keyspace"
+		groupName    = "counter_cleanup_group"
+		metricName   = "resource_manager_resource_unit_read_request_unit_sum"
+	)
+	t.Cleanup(func() {
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
+		deleteCounterMetricLabelValues(keyspaceName, groupName, backgroundTypeLabel)
+	})
+
+	defaultMetrics := newCounterMetrics(keyspaceName, groupName, defaultTypeLabel)
+	defaultMetrics.add(&rmpb.Consumption{RRU: 1}, &ControllerConfig{}, keyspaceID)
+	backgroundMetrics := newCounterMetrics(keyspaceName, groupName, backgroundTypeLabel)
+	backgroundMetrics.add(&rmpb.Consumption{RRU: 2}, &ControllerConfig{}, keyspaceID)
+	defaultLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 defaultTypeLabel,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	backgroundLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 backgroundTypeLabel,
+		keyspaceNameLabel:         keyspaceName,
+	}
+	re.True(hasMetric(metricName, defaultLabels))
+	re.True(hasMetric(metricName, backgroundLabels))
+
+	deleteCounterMetricLabelValues(keyspaceName, groupName, backgroundTypeLabel)
+
+	re.True(hasMetric(metricName, defaultLabels))
+	re.False(hasMetric(metricName, backgroundLabels))
+}
+
 func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
 	re := require.New(t)
 	groupName := "request_ru_trickle_group"
 	keyspaceName := "request_ru_trickle_keyspace"
 	t.Cleanup(func() {
-		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+		deleteDefaultLabelValuesForTest(keyspaceName, groupName)
 	})
 
 	serviceTrickleCounter := requestCauseCounter.WithLabelValues(groupName, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
@@ -536,6 +574,13 @@ func TestGaugeMetricsSetGroupSlotMetrics(t *testing.T) {
 	re.Zero(created)
 	re.Zero(deleted)
 	re.Zero(expired)
+}
+
+func deleteDefaultLabelValuesForTest(keyspaceName, groupName string) {
+	deleteCounterMetricLabelValues(keyspaceName, groupName, defaultTypeLabel)
+	deleteGaugeMetricLabelValues(keyspaceName, groupName)
+	deleteMaxPerSecTrackerLabelValues(keyspaceName, groupName)
+	deleteRequestMetricLabelValues(keyspaceName, groupName)
 }
 
 func findHistogramMetric(re *require.Assertions, metricName string, labels map[string]string) *dto.Histogram {

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -269,6 +269,125 @@ func TestRequestMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T)
 	re.False(hasMetric(grantedMetric, loadedLabels))
 }
 
+func TestCounterMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID   = uint32(10869)
+		fallbackName = "keyspace-10869"
+		loadedName   = "loaded-counter-keyspace"
+		groupName    = "counter_metrics_label_group"
+		metricName   = "resource_manager_resource_unit_read_request_unit_sum"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
+		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+	})
+
+	first := metrics.getCounterMetrics(keyspaceID, fallbackName, groupName, defaultTypeLabel)
+	first.add(&rmpb.Consumption{RRU: 1}, &ControllerConfig{}, keyspaceID)
+	fallbackLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 defaultTypeLabel,
+		keyspaceNameLabel:         fallbackName,
+	}
+	re.True(hasMetric(metricName, fallbackLabels))
+
+	second := metrics.getCounterMetrics(keyspaceID, loadedName, groupName, defaultTypeLabel)
+	re.NotSame(first, second)
+	re.False(hasMetric(metricName, fallbackLabels))
+
+	second.add(&rmpb.Consumption{RRU: 2}, &ControllerConfig{}, keyspaceID)
+	loadedLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		typeLabel:                 defaultTypeLabel,
+		keyspaceNameLabel:         loadedName,
+	}
+	re.True(hasMetric(metricName, loadedLabels))
+}
+
+func TestGaugeMetricsDeletesCreatedLabelsWhenKeyspaceNameChanges(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID   = uint32(10870)
+		fallbackName = "keyspace-10870"
+		loadedName   = "loaded-gauge-keyspace"
+		groupName    = "gauge_metrics_label_group"
+		metricName   = "resource_manager_resource_unit_available_ru"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
+		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+	})
+
+	first := metrics.getGaugeMetrics(keyspaceID, fallbackName, groupName)
+	first.availableRUCounter.Set(1)
+	fallbackLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         fallbackName,
+	}
+	re.True(hasMetric(metricName, fallbackLabels))
+
+	second := metrics.getGaugeMetrics(keyspaceID, loadedName, groupName)
+	re.NotSame(first, second)
+	re.False(hasMetric(metricName, fallbackLabels))
+
+	second.availableRUCounter.Set(2)
+	loadedLabels := map[string]string{
+		resourceGroupNameLabel:    groupName,
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         loadedName,
+	}
+	re.True(hasMetric(metricName, loadedLabels))
+}
+
+func TestMaxPerSecTrackerRebindsLabelsWhenKeyspaceNameChanges(t *testing.T) {
+	re := require.New(t)
+	const (
+		keyspaceID   = uint32(10871)
+		fallbackName = "keyspace-10871"
+		loadedName   = "loaded-tracker-keyspace"
+		groupName    = "tracker_metrics_label_group"
+		metricName   = "resource_manager_resource_unit_read_request_unit_max_per_sec"
+	)
+	metrics := newMetrics()
+	t.Cleanup(func() {
+		deleteLabelValues(fallbackName, groupName, defaultTypeLabel)
+		deleteLabelValues(loadedName, groupName, defaultTypeLabel)
+	})
+
+	first := metrics.getMaxPerSecTracker(keyspaceID, fallbackName, groupName)
+	first.rruMaxMetrics.Set(1)
+	first.rruSum = 10
+	first.lastRRUSum = 4
+	first.maxPerSecRRU = 6
+	first.cnt = 3
+	fallbackLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         fallbackName,
+	}
+	re.True(hasMetric(metricName, fallbackLabels))
+
+	second := metrics.getMaxPerSecTracker(keyspaceID, loadedName, groupName)
+	re.Same(first, second)
+	re.Equal(10.0, second.rruSum)
+	re.Equal(4.0, second.lastRRUSum)
+	re.Equal(6.0, second.maxPerSecRRU)
+	re.Equal(3, second.cnt)
+	re.False(hasMetric(metricName, fallbackLabels))
+
+	second.rruMaxMetrics.Set(2)
+	loadedLabels := map[string]string{
+		newResourceGroupNameLabel: groupName,
+		keyspaceNameLabel:         loadedName,
+	}
+	re.True(hasMetric(metricName, loadedLabels))
+}
+
 func TestRequestRUSeparatesServiceAndGroupTrickleCause(t *testing.T) {
 	re := require.New(t)
 	groupName := "request_ru_trickle_group"

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -198,6 +198,47 @@ func (rg *ResourceGroup) overrideFillRateAndBurstLimit(fillRate float64, burstLi
 	rg.overrideBurstLimitLocked(burstLimit)
 }
 
+// SlotMetrics holds a snapshot of the token slot state for metrics reporting.
+type SlotMetrics struct {
+	SlotCount int
+	TokenLoan float64
+}
+
+// GetSlotMetrics returns the current token slot snapshot under the group lock.
+func (rg *ResourceGroup) GetSlotMetrics() SlotMetrics {
+	rg.RLock()
+	defer rg.RUnlock()
+	if rg.RUSettings == nil || rg.RUSettings.RU == nil {
+		return SlotMetrics{}
+	}
+	var tokenLoan float64
+	for _, slot := range rg.RUSettings.RU.tokenSlots {
+		if slot.curTokenCapacity < 0 {
+			tokenLoan += -slot.curTokenCapacity
+		}
+	}
+	return SlotMetrics{
+		SlotCount: len(rg.RUSettings.RU.tokenSlots),
+		TokenLoan: tokenLoan,
+	}
+}
+
+// DrainSlotEvents returns the accumulated slot event counts and resets them.
+func (rg *ResourceGroup) DrainSlotEvents() (created, deleted, expired uint64) {
+	rg.Lock()
+	defer rg.Unlock()
+	if rg.RUSettings == nil || rg.RUSettings.RU == nil {
+		return 0, 0, 0
+	}
+	created = rg.RUSettings.RU.slotsCreated
+	deleted = rg.RUSettings.RU.slotsDeleted
+	expired = rg.RUSettings.RU.slotsExpired
+	rg.RUSettings.RU.slotsCreated = 0
+	rg.RUSettings.RU.slotsDeleted = 0
+	rg.RUSettings.RU.slotsExpired = 0
+	return
+}
+
 // PatchSettings patches the resource group settings.
 // Only used to patch the resource group when updating.
 // Note: the tokens is the delta value to patch.
@@ -274,6 +315,7 @@ func (rg *ResourceGroup) RequestRU(
 	now time.Time,
 	requiredToken float64,
 	targetPeriodMs, clientUniqueID uint64,
+	keyspaceName string,
 	grt *groupRUTracker, sl *serviceLimiter,
 ) *rmpb.GrantedRUTokenBucket {
 	rg.Lock()
@@ -292,8 +334,10 @@ func (rg *ResourceGroup) RequestRU(
 	}
 	// Then, try to apply the service limit.
 	grantedTokens := tb.GetTokens()
+	groupTrickleTimeMs := trickleTimeMs
 	limitedTokens, minTrickleTimeMs := sl.applyServiceLimit(now, grantedTokens)
-	if limitedTokens < grantedTokens {
+	serviceLimited := limitedTokens < grantedTokens
+	if serviceLimited {
 		tb.Tokens = limitedTokens
 		// Retain the unused tokens for the later requests if it has a burst limit.
 		if rg.getBurstLimitLocked() > 0 {
@@ -302,6 +346,69 @@ func (rg *ResourceGroup) RequestRU(
 	}
 	if trickleTimeMs < minTrickleTimeMs {
 		trickleTimeMs = minTrickleTimeMs
+	}
+	observeTokenGrant(rg.Name, keyspaceName, &rmpb.GrantedRUTokenBucket{
+		GrantedTokens: &rmpb.TokenBucket{Tokens: tb.GetTokens()},
+		TrickleTimeMs: trickleTimeMs,
+	})
+	if serviceLimited {
+		observeRequestCause(rg.Name, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	}
+	if grantedTokens < requiredToken {
+		observeRequestCause(rg.Name, keyspaceName, throttleKindLabel, groupCauseLabel)
+	}
+	if minTrickleTimeMs > 0 {
+		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	}
+	if groupTrickleTimeMs > 0 {
+		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, groupCauseLabel)
+	}
+	if serviceLimited || grantedTokens < requiredToken {
+		cause := groupCauseLabel
+		if serviceLimited {
+			cause = serviceLimitCauseLabel
+		}
+		sampledRUPerSec := 0.0
+		if grt != nil {
+			sampledRUPerSec = grt.getRUPerSec()
+		}
+		serviceLimit := 0.0
+		if sl != nil {
+			serviceLimit = sl.getServiceLimit()
+		}
+		overrideFillRate := rg.RUSettings.RU.overrideFillRate
+		log.Debug("resource group token request is limited",
+			zap.String("resource-group", rg.Name),
+			zap.String("keyspace-name", keyspaceName),
+			zap.Uint64("client-unique-id", clientUniqueID),
+			zap.Float64("required-token", requiredToken),
+			zap.Float64("granted-token", tb.GetTokens()),
+			zap.Int64("trickle-ms", trickleTimeMs),
+			zap.Float64("sampled-ru-per-sec", sampledRUPerSec),
+			zap.Float64("override-fill-rate", overrideFillRate),
+			zap.Float64("service-limit", serviceLimit),
+			zap.String("cause", cause),
+		)
+	}
+	if trickleTimeMs > 0 {
+		cause := groupCauseLabel
+		if minTrickleTimeMs > 0 {
+			cause = serviceLimitCauseLabel
+		}
+		serviceLimit := 0.0
+		if sl != nil {
+			serviceLimit = sl.getServiceLimit()
+		}
+		log.Debug("resource group token request is trickled",
+			zap.String("resource-group", rg.Name),
+			zap.String("keyspace-name", keyspaceName),
+			zap.Uint64("client-unique-id", clientUniqueID),
+			zap.Float64("required-token", requiredToken),
+			zap.Float64("granted-token", tb.GetTokens()),
+			zap.Int64("trickle-ms", trickleTimeMs),
+			zap.Float64("service-limit", serviceLimit),
+			zap.String("cause", cause),
+		)
 	}
 	return &rmpb.GrantedRUTokenBucket{GrantedTokens: tb, TrickleTimeMs: trickleTimeMs}
 }

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -317,10 +317,11 @@ func (rg *ResourceGroup) RequestRU(
 	targetPeriodMs, clientUniqueID uint64,
 	keyspaceName string,
 	grt *groupRUTracker, sl *serviceLimiter,
+	metrics *requestMetrics,
 ) *rmpb.GrantedRUTokenBucket {
 	rg.Lock()
-	defer rg.Unlock()
 	if rg.RUSettings == nil || rg.RUSettings.RU.Settings == nil {
+		rg.Unlock()
 		return nil
 	}
 	// Inject the group RU tracker into the resource group.
@@ -330,6 +331,7 @@ func (rg *ResourceGroup) RequestRU(
 	// First, try to get tokens from the resource group.
 	tb, trickleTimeMs := rg.RUSettings.RU.request(now, requiredToken, targetPeriodMs, clientUniqueID)
 	if tb == nil {
+		rg.Unlock()
 		return nil
 	}
 	// Then, try to apply the service limit.
@@ -347,70 +349,63 @@ func (rg *ResourceGroup) RequestRU(
 	if trickleTimeMs < minTrickleTimeMs {
 		trickleTimeMs = minTrickleTimeMs
 	}
-	observeTokenGrant(rg.Name, keyspaceName, &rmpb.GrantedRUTokenBucket{
-		GrantedTokens: &rmpb.TokenBucket{Tokens: tb.GetTokens()},
-		TrickleTimeMs: trickleTimeMs,
-	})
-	if serviceLimited {
-		observeRequestCause(rg.Name, keyspaceName, throttleKindLabel, serviceLimitCauseLabel)
+	groupLimited := grantedTokens < requiredToken
+	observation := requestMetricsObservation{
+		grantedTokens:   tb.GetTokens(),
+		trickleTimeMs:   trickleTimeMs,
+		serviceLimited:  serviceLimited,
+		groupLimited:    groupLimited,
+		serviceTrickled: minTrickleTimeMs > 0,
+		groupTrickled:   groupTrickleTimeMs > 0,
 	}
-	if grantedTokens < requiredToken {
-		observeRequestCause(rg.Name, keyspaceName, throttleKindLabel, groupCauseLabel)
+	sampledRUPerSec := 0.0
+	if grt != nil {
+		sampledRUPerSec = grt.getRUPerSec()
 	}
-	if minTrickleTimeMs > 0 {
-		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, serviceLimitCauseLabel)
+	serviceLimit := 0.0
+	if sl != nil {
+		serviceLimit = sl.getServiceLimit()
 	}
-	if groupTrickleTimeMs > 0 {
-		observeRequestCause(rg.Name, keyspaceName, trickleKindLabel, groupCauseLabel)
-	}
-	if serviceLimited || grantedTokens < requiredToken {
+	overrideFillRate := rg.RUSettings.RU.overrideFillRate
+	result := &rmpb.GrantedRUTokenBucket{GrantedTokens: tb, TrickleTimeMs: trickleTimeMs}
+	rg.Unlock()
+
+	metrics.observe(observation)
+	if observation.serviceLimited || observation.groupLimited {
 		cause := groupCauseLabel
-		if serviceLimited {
+		if observation.serviceLimited {
 			cause = serviceLimitCauseLabel
 		}
-		sampledRUPerSec := 0.0
-		if grt != nil {
-			sampledRUPerSec = grt.getRUPerSec()
-		}
-		serviceLimit := 0.0
-		if sl != nil {
-			serviceLimit = sl.getServiceLimit()
-		}
-		overrideFillRate := rg.RUSettings.RU.overrideFillRate
 		log.Debug("resource group token request is limited",
 			zap.String("resource-group", rg.Name),
 			zap.String("keyspace-name", keyspaceName),
 			zap.Uint64("client-unique-id", clientUniqueID),
 			zap.Float64("required-token", requiredToken),
-			zap.Float64("granted-token", tb.GetTokens()),
-			zap.Int64("trickle-ms", trickleTimeMs),
+			zap.Float64("granted-token", observation.grantedTokens),
+			zap.Int64("trickle-ms", observation.trickleTimeMs),
 			zap.Float64("sampled-ru-per-sec", sampledRUPerSec),
 			zap.Float64("override-fill-rate", overrideFillRate),
 			zap.Float64("service-limit", serviceLimit),
 			zap.String("cause", cause),
 		)
 	}
-	if trickleTimeMs > 0 {
+	if observation.trickleTimeMs > 0 {
 		cause := groupCauseLabel
-		if minTrickleTimeMs > 0 {
+		if observation.serviceTrickled {
 			cause = serviceLimitCauseLabel
-		}
-		serviceLimit := 0.0
-		if sl != nil {
-			serviceLimit = sl.getServiceLimit()
 		}
 		log.Debug("resource group token request is trickled",
 			zap.String("resource-group", rg.Name),
 			zap.String("keyspace-name", keyspaceName),
 			zap.Uint64("client-unique-id", clientUniqueID),
 			zap.Float64("required-token", requiredToken),
-			zap.Float64("granted-token", tb.GetTokens()),
-			zap.Int64("trickle-ms", trickleTimeMs),
+			zap.Float64("granted-token", observation.grantedTokens),
+			zap.Int64("trickle-ms", observation.trickleTimeMs),
 			zap.Float64("service-limit", serviceLimit),
 			zap.String("cause", cause),
 		)
 	}
-	return &rmpb.GrantedRUTokenBucket{GrantedTokens: tb, TrickleTimeMs: trickleTimeMs}
+	return result
 }
 
 // IntoProtoResourceGroup converts a ResourceGroup to a rmpb.ResourceGroup.

--- a/pkg/mcs/resourcemanager/server/resource_group.go
+++ b/pkg/mcs/resourcemanager/server/resource_group.go
@@ -211,15 +211,9 @@ func (rg *ResourceGroup) GetSlotMetrics() SlotMetrics {
 	if rg.RUSettings == nil || rg.RUSettings.RU == nil {
 		return SlotMetrics{}
 	}
-	var tokenLoan float64
-	for _, slot := range rg.RUSettings.RU.tokenSlots {
-		if slot.curTokenCapacity < 0 {
-			tokenLoan += -slot.curTokenCapacity
-		}
-	}
 	return SlotMetrics{
 		SlotCount: len(rg.RUSettings.RU.tokenSlots),
-		TokenLoan: tokenLoan,
+		TokenLoan: rg.RUSettings.RU.getTokenLoan(),
 	}
 }
 

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -195,6 +195,11 @@ type GroupTokenBucketState struct {
 
 	// settingChanged is used to avoid that the number of tokens returned is jitter because of changing fill rate.
 	settingChanged bool
+
+	// Slot event accumulators for metrics reporting.
+	slotsCreated uint64
+	slotsDeleted uint64
+	slotsExpired uint64
 }
 
 func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
@@ -219,6 +224,9 @@ func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
 		tokenSlots:         tokenSlots,
 		overrideFillRate:   gts.overrideFillRate,
 		overrideBurstLimit: gts.overrideBurstLimit,
+		slotsCreated:       gts.slotsCreated,
+		slotsDeleted:       gts.slotsDeleted,
+		slotsExpired:       gts.slotsExpired,
 	}
 }
 
@@ -248,6 +256,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 			zap.Float64("required-token", requiredToken),
 			zap.Int("slot-len", len(gtb.tokenSlots)),
 		)
+		gtb.slotsCreated++
 	} else if exist && requiredToken != 0 {
 		// Update the existing slot.
 		slot.lastReqTime = now
@@ -261,11 +270,15 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 			)
 		}
 		delete(gtb.tokenSlots, clientUniqueID)
+		if exist {
+			gtb.slotsDeleted++
+		}
 	}
 	// Clean up the expired slots.
 	for clientUniqueID, slot := range gtb.tokenSlots {
 		if time.Since(slot.lastReqTime) >= slotExpireTimeout {
 			delete(gtb.tokenSlots, clientUniqueID)
+			gtb.slotsExpired++
 			log.Info("delete resource group slot because expire",
 				zap.Time("last-req-time", slot.lastReqTime),
 				zap.Duration("expire-timeout", slotExpireTimeout),

--- a/pkg/mcs/resourcemanager/server/token_buckets.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets.go
@@ -200,14 +200,18 @@ type GroupTokenBucketState struct {
 	slotsCreated uint64
 	slotsDeleted uint64
 	slotsExpired uint64
+	// Cached token loan for metrics reporting. It is derived from tokenSlots and
+	// should not be used by token allocation logic.
+	tokenLoan float64
 }
 
 func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
 	var tokenSlots map[uint64]*tokenSlot
 	if gts.tokenSlots != nil {
 		tokenSlots = make(map[uint64]*tokenSlot)
-		for id, tokens := range gts.tokenSlots {
-			tokenSlots[id] = tokens
+		for id, slot := range gts.tokenSlots {
+			slotClone := *slot
+			tokenSlots[id] = &slotClone
 		}
 	}
 
@@ -227,6 +231,7 @@ func (gts *GroupTokenBucketState) clone() *GroupTokenBucketState {
 		slotsCreated:       gts.slotsCreated,
 		slotsDeleted:       gts.slotsDeleted,
 		slotsExpired:       gts.slotsExpired,
+		tokenLoan:          gts.tokenLoan,
 	}
 }
 
@@ -235,9 +240,45 @@ func (gts *GroupTokenBucketState) resetLoan() {
 	gts.Tokens = 0
 	// Reset all slots.
 	for _, slot := range gts.tokenSlots {
-		slot.curTokenCapacity = 0
+		gts.setSlotTokenCapacity(slot, 0)
 		slot.lastTokenCapacity = 0
 	}
+}
+
+func (gts *GroupTokenBucketState) getTokenLoan() float64 {
+	return gts.tokenLoan
+}
+
+func (gts *GroupTokenBucketState) setSlotTokenCapacity(slot *tokenSlot, capacity float64) {
+	gts.tokenLoan += tokenLoanContribution(capacity) - tokenLoanContribution(slot.curTokenCapacity)
+	if math.Abs(gts.tokenLoan) < 1e-9 {
+		gts.tokenLoan = 0
+	}
+	slot.curTokenCapacity = capacity
+}
+
+func (gts *GroupTokenBucketState) addSlotTokenCapacity(slot *tokenSlot, delta float64) {
+	gts.setSlotTokenCapacity(slot, slot.curTokenCapacity+delta)
+}
+
+func (gts *GroupTokenBucketState) removeTokenSlot(clientUniqueID uint64) bool {
+	slot, exist := gts.tokenSlots[clientUniqueID]
+	if !exist {
+		return false
+	}
+	gts.tokenLoan -= tokenLoanContribution(slot.curTokenCapacity)
+	if math.Abs(gts.tokenLoan) < 1e-9 {
+		gts.tokenLoan = 0
+	}
+	delete(gts.tokenSlots, clientUniqueID)
+	return true
+}
+
+func tokenLoanContribution(tokenCapacity float64) float64 {
+	if tokenCapacity < 0 {
+		return -tokenCapacity
+	}
+	return 0
 }
 
 func (gtb *GroupTokenBucket) balanceSlotTokens(
@@ -269,15 +310,14 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 				zap.Int("slot-len", len(gtb.tokenSlots)),
 			)
 		}
-		delete(gtb.tokenSlots, clientUniqueID)
-		if exist {
+		if gtb.removeTokenSlot(clientUniqueID) {
 			gtb.slotsDeleted++
 		}
 	}
 	// Clean up the expired slots.
 	for clientUniqueID, slot := range gtb.tokenSlots {
 		if time.Since(slot.lastReqTime) >= slotExpireTimeout {
-			delete(gtb.tokenSlots, clientUniqueID)
+			gtb.removeTokenSlot(clientUniqueID)
 			gtb.slotsExpired++
 			log.Info("delete resource group slot because expire",
 				zap.Time("last-req-time", slot.lastReqTime),
@@ -309,10 +349,10 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		for _, slot := range gtb.tokenSlots {
 			// If fill rate is 0 (e.g. service limit throttled), don't grant any existing tokens.
 			if fillRate == 0 {
-				slot.curTokenCapacity = 0
+				gtb.setSlotTokenCapacity(slot, 0)
 				slot.lastTokenCapacity = 0
 			} else {
-				slot.curTokenCapacity = gtb.Tokens
+				gtb.setSlotTokenCapacity(slot, gtb.Tokens)
 				slot.lastTokenCapacity = gtb.Tokens
 			}
 			slot.fillRate, slot.burstLimit = fillRate, burstLimit
@@ -343,7 +383,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 		for _, slot := range gtb.tokenSlots {
 			slot.fillRate = 0
 			slot.burstLimit = 0
-			slot.curTokenCapacity = 0
+			gtb.setSlotTokenCapacity(slot, 0)
 			slot.lastTokenCapacity = 0
 		}
 		return
@@ -399,7 +439,7 @@ func (gtb *GroupTokenBucket) balanceSlotTokens(
 			assignTokens -= reservedTokens
 		}
 		// Update the slot token capacity.
-		slot.curTokenCapacity += assignTokens
+		gtb.addSlotTokenCapacity(slot, assignTokens)
 		slot.lastTokenCapacity += assignTokens
 		// Update the slot fill rate and burst limit.
 		slot.fillRate = uint64(fillRate)
@@ -571,7 +611,7 @@ func (gtb *GroupTokenBucket) request(
 			zap.Int("slot-len", len(gtb.tokenSlots)),
 		)
 	}
-	res, trickleDuration := slot.assignSlotTokens(requiredToken, targetPeriodMs)
+	res, trickleDuration := gtb.assignSlotTokens(slot, requiredToken, targetPeriodMs)
 	// Inspect the group token bucket and the assigned token result to catch any anomalies.
 	if isAnomaly := gtb.inspectAnomalies(res, slot, []zap.Field{
 		zap.Time("now", now),
@@ -590,7 +630,7 @@ func (gtb *GroupTokenBucket) request(
 	return res, trickleDuration
 }
 
-func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint64) (*rmpb.TokenBucket, int64) {
+func (gtb *GroupTokenBucket) assignSlotTokens(ts *tokenSlot, requiredToken float64, targetPeriodMs uint64) (*rmpb.TokenBucket, int64) {
 	res := &rmpb.TokenBucket{
 		Settings: &rmpb.TokenLimitSettings{BurstLimit: ts.burstLimit},
 		Tokens:   0.0,
@@ -605,13 +645,13 @@ func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint
 	}
 	if ts.fillRate == 0 {
 		// Throttled: avoid granting any existing tokens and keep client retrying in next period.
-		ts.curTokenCapacity = 0
+		gtb.setSlotTokenCapacity(ts, 0)
 		ts.lastTokenCapacity = 0
 		return res, int64(targetPeriodMs)
 	}
 	// If the current tokens can directly meet the requirement, returns the need token.
 	if ts.curTokenCapacity >= requiredToken {
-		ts.curTokenCapacity -= requiredToken
+		gtb.addSlotTokenCapacity(ts, -requiredToken)
 		// granted the total request tokens
 		res.Tokens = requiredToken
 		return res, 0
@@ -623,7 +663,7 @@ func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint
 	if ts.curTokenCapacity > 0 {
 		grantedTokens = ts.curTokenCapacity
 		requiredToken -= grantedTokens
-		ts.curTokenCapacity = 0
+		gtb.setSlotTokenCapacity(ts, 0)
 		hasConsumedExistingTokens = true
 	}
 
@@ -682,7 +722,7 @@ func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint
 		roundReserveTokens := p[i] - loan
 		fillRate := float64(loanCoefficient-i) * float64(fillRate)
 		if roundReserveTokens > requiredToken {
-			ts.curTokenCapacity -= requiredToken
+			gtb.addSlotTokenCapacity(ts, -requiredToken)
 			grantedTokens += requiredToken
 			trickleTime += grantedTokens / fillRate
 			requiredToken = 0
@@ -691,20 +731,20 @@ func (ts *tokenSlot) assignSlotTokens(requiredToken float64, targetPeriodMs uint
 			if roundReserveTime+trickleTime >= targetPeriodTimeSec {
 				roundTokens := (targetPeriodTimeSec - trickleTime) * fillRate
 				requiredToken -= roundTokens
-				ts.curTokenCapacity -= roundTokens
+				gtb.addSlotTokenCapacity(ts, -roundTokens)
 				grantedTokens += roundTokens
 				trickleTime = targetPeriodTimeSec
 			} else {
 				grantedTokens += roundReserveTokens
 				requiredToken -= roundReserveTokens
-				ts.curTokenCapacity -= roundReserveTokens
+				gtb.addSlotTokenCapacity(ts, -roundReserveTokens)
 				trickleTime += roundReserveTime
 			}
 		}
 	}
 	if requiredToken > 0 && grantedTokens < defaultReserveRatio*float64(fillRate)*targetPeriodTimeSec {
 		reservedTokens := math.Min(requiredToken+grantedTokens, defaultReserveRatio*float64(fillRate)*targetPeriodTimeSec)
-		ts.curTokenCapacity -= reservedTokens - grantedTokens
+		gtb.addSlotTokenCapacity(ts, -(reservedTokens - grantedTokens))
 		grantedTokens = reservedTokens
 	}
 	res.Tokens = grantedTokens

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -335,6 +335,33 @@ func TestGroupTokenBucketRequestLoop(t *testing.T) {
 	}
 }
 
+func TestGroupTokenBucketSlotEventCounters(t *testing.T) {
+	re := require.New(t)
+	tbSetting := &rmpb.TokenBucket{
+		Tokens: 200000,
+		Settings: &rmpb.TokenLimitSettings{
+			FillRate:   2000,
+			BurstLimit: 20000000,
+		},
+	}
+
+	gtb := NewGroupTokenBucket(testResourceGroupName, tbSetting)
+	now := time.Now()
+	clientUniqueID := uint64(100)
+
+	gtb.request(now, 1000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
+	re.Equal(uint64(1), gtb.slotsCreated)
+
+	gtb.request(now, 0, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
+	re.Equal(uint64(1), gtb.slotsDeleted)
+
+	gtb.request(now, 1000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID)
+	re.Equal(uint64(2), gtb.slotsCreated)
+	gtb.tokenSlots[clientUniqueID].lastReqTime = now.Add(-(slotExpireTimeout + time.Second))
+	gtb.request(now.Add(2*time.Second), 1000, uint64(time.Second)*10/uint64(time.Millisecond), clientUniqueID+1)
+	re.Equal(uint64(1), gtb.slotsExpired)
+}
+
 func TestBalanceSlotTokensFillRateAllocation(t *testing.T) {
 	re := require.New(t)
 

--- a/pkg/mcs/resourcemanager/server/token_buckets_test.go
+++ b/pkg/mcs/resourcemanager/server/token_buckets_test.go
@@ -362,6 +362,77 @@ func TestGroupTokenBucketSlotEventCounters(t *testing.T) {
 	re.Equal(uint64(1), gtb.slotsExpired)
 }
 
+func TestGroupTokenBucketTokenLoanMetricIsMaintainedIncrementally(t *testing.T) {
+	re := require.New(t)
+	gtb := NewGroupTokenBucket(testResourceGroupName, &rmpb.TokenBucket{
+		Tokens: 0,
+		Settings: &rmpb.TokenLimitSettings{
+			FillRate:   10,
+			BurstLimit: 100,
+		},
+	})
+	now := time.Now()
+	targetPeriodMs := uint64(time.Second / time.Millisecond)
+	gtb.init(now)
+	gtb.Tokens = 0
+
+	assertCachedLoan := func() {
+		re.InDelta(scanTokenLoan(gtb), gtb.getTokenLoan(), 1e-7)
+	}
+	assertCachedLoan()
+
+	_, _ = gtb.request(now, 100, targetPeriodMs, 1)
+	re.Positive(gtb.getTokenLoan())
+	assertCachedLoan()
+
+	_, _ = gtb.request(now, 100, targetPeriodMs, 2)
+	assertCachedLoan()
+
+	_, _ = gtb.request(now, 0, targetPeriodMs, 1)
+	assertCachedLoan()
+
+	gtb.tokenSlots[2].lastReqTime = time.Now().Add(-(slotExpireTimeout + time.Second))
+	_, _ = gtb.request(now, 100, targetPeriodMs, 3)
+	assertCachedLoan()
+
+	gtb.overrideFillRate = 0
+	gtb.overrideBurstLimit = 0
+	_, _ = gtb.request(now, 100, targetPeriodMs, 3)
+	assertCachedLoan()
+}
+
+func TestGroupTokenBucketCloneDoesNotShareTokenSlots(t *testing.T) {
+	re := require.New(t)
+	gtb := NewGroupTokenBucket(testResourceGroupName, &rmpb.TokenBucket{
+		Tokens: 0,
+		Settings: &rmpb.TokenLimitSettings{
+			FillRate:   10,
+			BurstLimit: 100,
+		},
+	})
+	slot := newTokenSlot(1, time.Now())
+	gtb.tokenSlots[1] = slot
+	gtb.setSlotTokenCapacity(slot, -10)
+
+	cloned := gtb.clone()
+	cloned.setSlotTokenCapacity(cloned.tokenSlots[1], -20)
+
+	re.InDelta(-10.0, gtb.tokenSlots[1].curTokenCapacity, 1e-7)
+	re.InDelta(10.0, gtb.getTokenLoan(), 1e-7)
+	re.InDelta(-20.0, cloned.tokenSlots[1].curTokenCapacity, 1e-7)
+	re.InDelta(20.0, cloned.getTokenLoan(), 1e-7)
+}
+
+func scanTokenLoan(gtb *GroupTokenBucket) float64 {
+	var tokenLoan float64
+	for _, slot := range gtb.tokenSlots {
+		if slot.curTokenCapacity < 0 {
+			tokenLoan += -slot.curTokenCapacity
+		}
+	}
+	return tokenLoan
+}
+
 func TestBalanceSlotTokensFillRateAllocation(t *testing.T) {
 	re := require.New(t)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10488

Backport of #10605 to `release-nextgen-202603`.

Related dashboard PR: pingcap/tidb#69090

### What is changed and how does it work?

This PR adds server-side Resource Control allocation observability on the release-nextgen branch. The metrics are organized by the Resource Control diagnosis chain:

1. PD Resource Manager grant path

- `resource_manager_server_granted_tokens`
  - Histogram of RU tokens granted by PD for resource group token bucket requests.
  - Shows the PD Server-side grant decision for each resource group/keyspace.

2. PD ResourceGroup slot allocation

- `resource_manager_server_active_slot_count`
  - Current number of active client slots per resource group/keyspace.
- `resource_manager_server_slot_events_total{event="created|deleted|expired"}`
  - Slot lifecycle events.
- `resource_manager_server_token_loan`
  - Outstanding token loan state.
- These metrics are used by the TiDB dashboard `Server Slots, Loan, And Trickle` panel.
- The metrics flush path now reads live `ResourceGroup` instances for slot event counters, so `slot_events_total` drains the live event deltas once per metrics tick instead of repeatedly counting cloned snapshots.

3. PD trickle duration

- `resource_manager_server_trickle_duration_ms`
  - Histogram of trickle duration returned by PD.
  - Includes zero-trickle grants, so dashboard averages represent all grants rather than only throttled/trickled grants.
- Used by the TiDB dashboard `Server Slots, Loan, And Trickle` panel.

4. PD service limit and group fill/burst cause attribution

- `resource_manager_server_request_cause_total{kind,cause}`
  - Distinguishes `kind="throttling|trickle"`.
  - Distinguishes `cause="service_limit"` from `cause="group_fill_rate_or_burst"`.
- Used by the TiDB dashboard `Throttling Causes` panel.
- This helps identify whether throttling comes from keyspace-level service limit or resource-group fill-rate/burst constraints.

5. Resource group configuration and keyspace labels

- Reuses `resource_manager_server_group_config{type="ru_per_sec|ru_capacity"}` for dashboard config context.
- Adds keyspace-name fallback and cleanup fixes so metrics stay continuous when keyspace lookup fails.
- Used by the TiDB dashboard `RU Config` panel and `keyspace_name` template variable.

### Validation

- `GOCACHE=/tmp/pd-nextgen-10605-gocache go test ./pkg/mcs/resourcemanager/server -run 'Test(RequestRUSeparatesServiceAndGroupTrickleCause|GaugeMetricsSetGroupSlotMetrics|GroupTokenBucketSlotEventCounters|KeyspaceNameLookup|CleanUpTicker|ObserveTokenGrantRecordsZeroTrickle|ObserveRequestCause)$' -count=1`
- `GOCACHE=/tmp/pd-nextgen-10605-gocache go test ./pkg/mcs/resourcemanager/server -run 'Test(RequestRUSeparatesServiceAndGroupTrickleCause|GaugeMetricsSetGroupSlotMetrics|GroupTokenBucketSlotEventCounters|KeyspaceNameLookup|CleanUpTicker|ObserveTokenGrantRecordsZeroTrickle|ObserveRequestCause|FlushResourceGroupMetricsDrainsLiveSlotEvents)$' -count=1`
- `GOCACHE=/tmp/pd-nextgen-10605-gocache make gotest GOTEST_ARGS='./pkg/mcs/resourcemanager/server -run TestFlushResourceGroupMetricsDrainsLiveSlotEvents -count=1'`
- `git diff --check HEAD~1 HEAD`

### Notes

This PR provides the PD Server metrics consumed by the appended Resource Control diagnosis panels in pingcap/tidb#69090.

This is intentionally draft. Additional release-nextgen-specific changes may be added before marking ready for review.

### Release note

```release-note
Add server-side resource control metrics for allocation state, token trickle, and throttling causes.
```
