### PR TITLE
schedule: disable split scatter by default

### DIFF
--- a/pkg/mcs/scheduling/server/grpc_service_test.go
+++ b/pkg/mcs/scheduling/server/grpc_service_test.go
@@ -177,6 +177,7 @@ func newTestSchedulingServiceForSplit(
 	re.NoError(err)
 	cfg.Schedule.AffinityScheduleLimit = 4
 	cfg.Schedule.MaxAffinityMergeRegionSize = 10
+	cfg.Schedule.SplitScatterScheduleLimit = 4
 
 	basicCluster := core.NewBasicCluster()
 	for i := uint64(1); i <= 3; i++ {

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -780,6 +780,7 @@ func newTestSplitScatterController(t *testing.T) (*Controller, *mockcluster.Clus
 	}
 	putSplitScatterRegion(tc, 100, "", "m", splitScatterNoCPUUsage)
 
+	tc.SetSplitScatterScheduleLimit(4)
 	stream := hbstream.NewTestHeartbeatStreams(ctx, tc, false)
 	oc := operator.NewController(ctx, tc.GetBasicCluster(), tc.GetSharedConfig(), stream)
 	controller := NewController(ctx, tc, tc.GetCheckerConfig(), oc)

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -42,7 +42,7 @@ const (
 	defaultMergeScheduleLimit        = 8
 	defaultHotRegionScheduleLimit    = 4
 	defaultAffinityScheduleLimit     = 0 // default to disable
-	defaultSplitScatterScheduleLimit = 4
+	defaultSplitScatterScheduleLimit = 0
 	defaultTolerantSizeRatio         = 0
 	defaultLowSpaceRatio             = 0.8
 	defaultHighSpaceRatio            = 0.7

--- a/server/cluster/split_scatter_test.go
+++ b/server/cluster/split_scatter_test.go
@@ -160,6 +160,7 @@ func newSplitScatterTestCluster(t *testing.T) (*RaftCluster, context.CancelFunc)
 
 	_, opt, err := newTestScheduleConfig()
 	re.NoError(err)
+	opt.SetSplitScatterScheduleLimit(4)
 	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
 	cluster.regionLabeler, err = labeler.NewRegionLabeler(ctx, cluster.storage, time.Second*5)
 	re.NoError(err)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -195,6 +195,7 @@ leader-schedule-limit = 0
 	re.Equal(0, cfg.Log.File.MaxDays)
 	re.Equal(0, cfg.Log.File.MaxBackups)
 	re.Equal(uint64(0), cfg.Schedule.MaxMergeRegionKeys)
+	re.Equal(uint64(0), cfg.Schedule.SplitScatterScheduleLimit)
 	re.Equal("http://127.0.0.1:9090", cfg.PDServerCfg.MetricStorage)
 
 	re.Equal(defaultTSOUpdatePhysicalInterval, cfg.TSOUpdatePhysicalInterval.Duration)

--- a/tests/server/config/config_test.go
+++ b/tests/server/config/config_test.go
@@ -373,6 +373,7 @@ func (suite *configTestSuite) checkConfigDefault(cluster *tests.TestCluster) {
 	re.Equal(uint64(3), defaultCfg.Replication.MaxReplicas)
 	re.Equal(typeutil.StringSlice([]string{}), defaultCfg.Replication.LocationLabels)
 	re.Equal(uint64(2048), defaultCfg.Schedule.RegionScheduleLimit)
+	re.Equal(uint64(0), defaultCfg.Schedule.SplitScatterScheduleLimit)
 	re.Equal("", defaultCfg.PDServerCfg.MetricStorage)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Ref #10592, ref #10830

### What is changed and how does it work?

This PR disables internal split scatter by default on release-8.5 by changing the default `split-scatter-schedule-limit` from `4` to `0`.

Users can still explicitly enable split scatter by setting `schedule.split-scatter-schedule-limit` to a positive value.

```commit-message
schedule: disable split scatter by default
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has the configuration change

Side effects

- None

Related changes

- Need to cherry-pick to the release branch: no, this PR targets `release-8.5`

### Release note

```release-note
Disable split scatter by default.
```
