### PR TITLE
test: stabilize flaky TestLoadLargeRules

### DIFF
--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -98,6 +98,7 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 	re.NoError(err)
 	<-etcd.Server.ReadyNotify()
 
+	ops := make([]clientv3.Op, 0, etcdutil.MaxEtcdTxnOps)
 	for i := 1; i < rulesNum+1; i++ {
 		rule := &labeler.LabelRule{
 			ID:       "test_" + strconv.Itoa(i),
@@ -108,7 +109,15 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 		value, err := json.Marshal(rule)
 		re.NoError(err)
 		key := keypath.RegionLabelKeyPath(rule.ID)
-		_, err = clientv3.NewKV(client).Put(ctx, key, string(value))
+		ops = append(ops, clientv3.OpPut(key, string(value)))
+		if len(ops) == etcdutil.MaxEtcdTxnOps {
+			_, err = client.Txn(ctx).Then(ops...).Commit()
+			re.NoError(err)
+			ops = ops[:0]
+		}
+	}
+	if len(ops) > 0 {
+		_, err = client.Txn(ctx).Then(ops...).Commit()
 		re.NoError(err)
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10346

Problem Summary:
Flaky test `TestLoadLargeRules` in `github.com/tikv/pd/pkg/mcs/scheduling/server/rule` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Serial one-key-per-request etcd setup made the large-rule load test vulnerable to CI timeout before watcher behavior was checked.

#### Fix

Bounded transactions create the same rules with far fewer raft/apply requests, removing the flaky setup bottleneck.

#### Verification

Spec:
- target: `github.com/tikv/pd/pkg/mcs/scheduling/server/rule :: TestLoadLargeRules`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
timing_budget_target passed.
target_flaky_case passed.
package_surface passed.
build passed.

Gate checklist:
- timing_budget_target: PASS
- target_flaky_case: PASS
- package_surface: PASS
- build: PASS
- external_ci: SKIPPED

Commands:
- `go test -json -timeout=5s ./pkg/mcs/scheduling/server/rule -run '^TestLoadLargeRules$' -count=1`
- `go test -json ./pkg/mcs/scheduling/server/rule -run '^TestLoadLargeRules$' -count=1`
- `go test -json ./pkg/mcs/scheduling/server/rule -count=1`
- `make build`

### Release note

```release-note
None
```

Fixes #10346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test data loading efficiency by optimizing how test rules are written to the storage system, using batched operations and transactions to reduce write overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->