### PR TITLE
mcs/tso: support keyspace_group_id in transfer primary API

### DIFF
--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -329,13 +329,27 @@ func transferPrimary(c *gin.Context) {
 		return
 	}
 
+	// The request may be routed to a non-primary replica of the target group,
+	// whose expected primary lease is nil or stale. Reject it with a clear error
+	// instead of letting TransferPrimary fail with a 500.
+	if !allocator.IsServing() {
+		primaryAddr := allocator.GetPrimaryAddr()
+		if primaryAddr == "" {
+			primaryAddr = "unknown"
+		}
+		c.AbortWithStatusJSON(http.StatusBadRequest,
+			fmt.Sprintf("this tso node is not the primary of keyspace group %d, please send the request to its primary %s", keyspaceGroupID, primaryAddr))
+		return
+	}
+	lease := allocator.GetExpectedPrimaryLease()
+
 	// only members of specific group are valid primary candidates.
 	memberMap := make(map[string]bool, len(group.Members))
 	for _, member := range group.Members {
 		memberMap[member.Address] = true
 	}
 
-	if err := utils.TransferPrimary(svr.GetClient(), allocator.GetExpectedPrimaryLease(),
+	if err := utils.TransferPrimary(svr.GetClient(), lease,
 		mcs.TSOServiceName, svr.Name(), input.NewPrimary, keyspaceGroupID, memberMap); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -137,8 +137,10 @@ func (s *Service) RegisterConfigRouter() {
 // RegisterPrimaryRouter registers the router of the primary handler.
 func (s *Service) RegisterPrimaryRouter() {
 	router := s.root.Group("primary")
-	// Transferring primary needs to be forwarded to the primary.
-	router.POST("transfer", multiservicesapi.ServiceRedirector(), transferPrimary)
+	// The caller must send this request to the current primary of the target keyspace group.
+	// We do not redirect here because the redirector only knows group 0's primary, which is
+	// wrong for non-default keyspace groups.
+	router.POST("transfer", transferPrimary)
 }
 
 func changeLogLevel(c *gin.Context) {
@@ -257,7 +259,7 @@ type KeyspaceGroupMember struct {
 func getKeyspaceGroupMembers(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*tsoserver.Service)
 	kgm := svr.GetKeyspaceGroupManager()
-	keyspaceGroups := kgm.GetKeyspaceGroups()
+	keyspaceGroups := kgm.GetServingKeyspaceGroups()
 	members := make(map[uint32]*KeyspaceGroupMember, len(keyspaceGroups))
 	for id, group := range keyspaceGroups {
 		allocator, err := kgm.GetAllocator(id)
@@ -313,18 +315,17 @@ func transferPrimary(c *gin.Context) {
 		keyspaceGroupID = *input.KeyspaceGroupID
 	}
 
-	kgm := svr.GetKeyspaceGroupManager()
-	keyspaceGroups := kgm.GetKeyspaceGroups()
-	group, ok := keyspaceGroups[keyspaceGroupID]
-	if !ok {
+	allocator, err := svr.GetTSOAllocator(keyspaceGroupID)
+	if err != nil {
 		c.AbortWithStatusJSON(http.StatusBadRequest,
 			fmt.Sprintf("keyspace group %d not found on this tso node", keyspaceGroupID))
 		return
 	}
 
-	allocator, err := svr.GetTSOAllocator(keyspaceGroupID)
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+	group := svr.GetKeyspaceGroupManager().GetKeyspaceGroupByID(keyspaceGroupID)
+	if group == nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest,
+			fmt.Sprintf("keyspace group %d not found on this tso node", keyspaceGroupID))
 		return
 	}
 

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -332,7 +332,7 @@ func transferPrimary(c *gin.Context) {
 	// The request may be routed to a non-primary replica of the target group,
 	// whose expected primary lease is nil or stale. Reject it with a clear error
 	// instead of letting TransferPrimary fail with a 500.
-	if !allocator.IsServing() {
+	if !allocator.GetMember().IsServing() {
 		primaryAddr := allocator.GetPrimaryAddr()
 		if primaryAddr == "" {
 			primaryAddr = "unknown"

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -293,21 +293,33 @@ func getConfig(c *gin.Context) {
 // @Tags     primary
 // @Summary  Transfer the primary member to `new_primary`.
 // @Produce  json
-// @Param    new_primary body   string  false "new primary name"
+// @Param    new_primary        body  string  false  "new primary name"
+// @Param    keyspace_group_id  body  integer false  "keyspace group ID (default: 0)"
 // @Success  200  string  string
 // @Router   /primary/transfer [post]
 func transferPrimary(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*tsoserver.Service)
-	var input map[string]string
+	var input struct {
+		NewPrimary      string  `json:"new_primary"`
+		KeyspaceGroupID *uint32 `json:"keyspace_group_id"`
+	}
 	if err := c.BindJSON(&input); err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
 
-	// We only support default keyspace group now.
-	newPrimary, keyspaceGroupID := "", constant.DefaultKeyspaceGroupID
-	if v, ok := input["new_primary"]; ok {
-		newPrimary = v
+	keyspaceGroupID := constant.DefaultKeyspaceGroupID
+	if input.KeyspaceGroupID != nil {
+		keyspaceGroupID = *input.KeyspaceGroupID
+	}
+
+	kgm := svr.GetKeyspaceGroupManager()
+	keyspaceGroups := kgm.GetKeyspaceGroups()
+	group, ok := keyspaceGroups[keyspaceGroupID]
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusBadRequest,
+			fmt.Sprintf("keyspace group %d not found on this tso node", keyspaceGroupID))
+		return
 	}
 
 	allocator, err := svr.GetTSOAllocator(keyspaceGroupID)
@@ -317,14 +329,13 @@ func transferPrimary(c *gin.Context) {
 	}
 
 	// only members of specific group are valid primary candidates.
-	group := svr.GetKeyspaceGroupManager().GetKeyspaceGroups()[keyspaceGroupID]
 	memberMap := make(map[string]bool, len(group.Members))
 	for _, member := range group.Members {
 		memberMap[member.Address] = true
 	}
 
 	if err := utils.TransferPrimary(svr.GetClient(), allocator.GetExpectedPrimaryLease(),
-		mcs.TSOServiceName, svr.Name(), newPrimary, keyspaceGroupID, memberMap); err != nil {
+		mcs.TSOServiceName, svr.Name(), input.NewPrimary, keyspaceGroupID, memberMap); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -313,15 +313,20 @@ func transferPrimary(c *gin.Context) {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
+	// Reject an empty body explicitly. Since this endpoint has side effects, we
+	// must not silently fall back to a random transfer on the default keyspace
+	// group when no body is provided.
+	if len(body) == 0 {
+		c.String(http.StatusBadRequest, "request body is required")
+		return
+	}
 	var input struct {
 		NewPrimary      string  `json:"new_primary"`
 		KeyspaceGroupID *uint32 `json:"keyspace_group_id"`
 	}
-	if len(body) > 0 {
-		if err := json.Unmarshal(body, &input); err != nil {
-			c.String(http.StatusBadRequest, err.Error())
-			return
-		}
+	if err := json.Unmarshal(body, &input); err != nil {
+		c.String(http.StatusBadRequest, err.Error())
+		return
 	}
 
 	keyspaceGroupID := constant.DefaultKeyspaceGroupID

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -15,8 +15,12 @@
 package apis
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/gin-contrib/cors"
@@ -137,9 +141,10 @@ func (s *Service) RegisterConfigRouter() {
 // RegisterPrimaryRouter registers the router of the primary handler.
 func (s *Service) RegisterPrimaryRouter() {
 	router := s.root.Group("primary")
-	// The caller must send this request to the current primary of the target keyspace group.
-	// We do not redirect here because the redirector only knows group 0's primary, which is
-	// wrong for non-default keyspace groups.
+	// We do not use the ServiceRedirector middleware here because it only knows
+	// group 0's primary, which is wrong for non-default keyspace groups. Instead,
+	// transferPrimary forwards the request to the primary of the target keyspace
+	// group itself (see forwardToGroupPrimary).
 	router.POST("transfer", transferPrimary)
 }
 
@@ -301,13 +306,22 @@ func getConfig(c *gin.Context) {
 // @Router   /primary/transfer [post]
 func transferPrimary(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*tsoserver.Service)
+	// Read the raw body first so that it can be replayed when the request needs
+	// to be forwarded to the primary of the target keyspace group.
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.String(http.StatusBadRequest, err.Error())
+		return
+	}
 	var input struct {
 		NewPrimary      string  `json:"new_primary"`
 		KeyspaceGroupID *uint32 `json:"keyspace_group_id"`
 	}
-	if err := c.BindJSON(&input); err != nil {
-		c.String(http.StatusBadRequest, err.Error())
-		return
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &input); err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 
 	keyspaceGroupID := constant.DefaultKeyspaceGroupID
@@ -329,16 +343,14 @@ func transferPrimary(c *gin.Context) {
 		return
 	}
 
-	// The request may be routed to a non-primary replica of the target group,
-	// whose expected primary lease is nil or stale. Reject it with a clear error
-	// instead of letting TransferPrimary fail with a 500.
+	// The transfer must be executed on the current primary of the target keyspace
+	// group. We cannot rely on ServiceRedirector here because it only knows the
+	// default group (0) primary. If this node is not the primary of the group,
+	// forward the request to the group's actual primary. This keeps the original
+	// redirect-on-follower behavior for the default group and extends it to
+	// non-default groups.
 	if !allocator.GetMember().IsServing() {
-		primaryAddr := allocator.GetPrimaryAddr()
-		if primaryAddr == "" {
-			primaryAddr = "unknown"
-		}
-		c.AbortWithStatusJSON(http.StatusBadRequest,
-			fmt.Sprintf("this tso node is not the primary of keyspace group %d, please send the request to its primary %s", keyspaceGroupID, primaryAddr))
+		forwardToGroupPrimary(c, svr, keyspaceGroupID, allocator.GetPrimaryAddr(), body)
 		return
 	}
 	lease := allocator.GetExpectedPrimaryLease()
@@ -355,4 +367,33 @@ func transferPrimary(c *gin.Context) {
 		return
 	}
 	c.IndentedJSON(http.StatusOK, "success")
+}
+
+// forwardToGroupPrimary forwards the transfer primary request to the primary of
+// the given keyspace group, replaying the original request body. The request is
+// fully handled (forwarded or aborted with an error) when this returns.
+func forwardToGroupPrimary(c *gin.Context, svr *tsoserver.Service, keyspaceGroupID uint32, primaryAddr string, body []byte) {
+	// Prevent more than one redirection.
+	if name := c.Request.Header.Get(multiservicesapi.ServiceRedirectorHeader); len(name) != 0 {
+		log.Error("redirect but server is not the primary of the keyspace group",
+			zap.String("from", name), zap.String("server", svr.Name()),
+			zap.Uint32("keyspace-group-id", keyspaceGroupID), errs.ZapError(errs.ErrRedirectToNotPrimary))
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrRedirectToNotPrimary.FastGenByArgs().Error())
+		return
+	}
+	if primaryAddr == "" {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable,
+			fmt.Sprintf("the primary of keyspace group %d is not elected yet", keyspaceGroupID))
+		return
+	}
+	u, err := url.Parse(primaryAddr)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrURLParse.Wrap(err).GenWithStackByCause().Error())
+		return
+	}
+	c.Request.Header.Set(multiservicesapi.ServiceRedirectorHeader, svr.Name())
+	// Replay the original body for the forwarded request.
+	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	apiutil.NewCustomReverseProxies(svr.GetHTTPClient(), []url.URL{*u}).ServeHTTP(c.Writer, c.Request)
+	c.Abort()
 }

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -377,6 +377,12 @@ func (a *Allocator) isServing() bool {
 	return a.member.IsServing()
 }
 
+// IsServing returns whether this allocator is currently the serving primary of
+// its keyspace group.
+func (a *Allocator) IsServing() bool {
+	return a.isServing()
+}
+
 func (a *Allocator) isPrimaryElected() bool {
 	if a == nil || a.member == nil {
 		return false

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -377,12 +377,6 @@ func (a *Allocator) isServing() bool {
 	return a.member.IsServing()
 }
 
-// IsServing returns whether this allocator is currently the serving primary of
-// its keyspace group.
-func (a *Allocator) IsServing() bool {
-	return a.isServing()
-}
-
 func (a *Allocator) isPrimaryElected() bool {
 	if a == nil || a.member == nil {
 		return false

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -1091,6 +1091,26 @@ func (kgm *KeyspaceGroupManager) GetKeyspaceGroups() map[uint32]*endpoint.Keyspa
 	return keyspaceGroups
 }
 
+// GetServingKeyspaceGroups returns all keyspace groups that this TSO node is actively
+// serving (i.e. has an allocator for), regardless of keyspace assignments.
+func (kgm *KeyspaceGroupManager) GetServingKeyspaceGroups() map[uint32]*endpoint.KeyspaceGroup {
+	kgm.RLock()
+	defer kgm.RUnlock()
+	result := make(map[uint32]*endpoint.KeyspaceGroup)
+	for i, allocator := range kgm.allocators {
+		if allocator != nil {
+			result[uint32(i)] = kgm.kgs[i]
+		}
+	}
+	return result
+}
+
+// GetKeyspaceGroupByID returns the keyspace group with the given ID if this TSO node is serving it.
+func (kgm *KeyspaceGroupManager) GetKeyspaceGroupByID(id uint32) *endpoint.KeyspaceGroup {
+	_, kg := kgm.getKeyspaceGroupMeta(id)
+	return kg
+}
+
 // HandleTSORequest forwards TSO allocation requests to correct TSO Allocators of the given keyspace group.
 func (kgm *KeyspaceGroupManager) HandleTSORequest(
 	ctx context.Context,

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -667,9 +667,11 @@ func (kgm *KeyspaceGroupManager) primaryPriorityCheckLoop() {
 							continue
 						}
 						// only members of specific group are valid primary candidates.
-						group := kgm.GetKeyspaceGroups()[kg.ID]
-						memberMap := make(map[string]bool, len(group.Members))
-						for _, m := range group.Members {
+						// Use kg directly instead of GetKeyspaceGroups()[kg.ID], which
+						// is built from the keyspace lookup table and would miss a served
+						// group that has no keyspaces, causing a nil-pointer panic here.
+						memberMap := make(map[string]bool, len(kg.Members))
+						for _, m := range kg.Members {
 							memberMap[m.Address] = true
 						}
 						log.Info("tso priority checker moves primary",
@@ -1105,9 +1107,17 @@ func (kgm *KeyspaceGroupManager) GetServingKeyspaceGroups() map[uint32]*endpoint
 	return result
 }
 
-// GetKeyspaceGroupByID returns the keyspace group with the given ID if this TSO node is serving it.
+// GetKeyspaceGroupByID returns the keyspace group with the given ID if this TSO node is
+// serving it (i.e. has a non-nil allocator for it). It returns nil when the ID is out of
+// range or the group is not served by this node.
 func (kgm *KeyspaceGroupManager) GetKeyspaceGroupByID(id uint32) *endpoint.KeyspaceGroup {
-	_, kg := kgm.getKeyspaceGroupMeta(id)
+	if err := checkKeySpaceGroupID(id); err != nil {
+		return nil
+	}
+	allocator, kg := kgm.getKeyspaceGroupMeta(id)
+	if allocator == nil {
+		return nil
+	}
 	return kg
 }
 

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -617,7 +617,7 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 
 	// Sending the transfer request to a non-primary member of the group should
-	// return 400 instead of a 500, since its expected primary lease is nil.
+	// be forwarded to the group's primary and still succeed.
 	var nonPrimaryAddr string
 	for _, s := range suite.tsoNodes {
 		tsoSvr := s.(*tso.Server)
@@ -632,12 +632,19 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	body["keyspace_group_id"] = testGroupID
 	data, err = json.Marshal(body)
 	re.NoError(err)
-	resp, err = tests.TestDialClient.Post(
-		fmt.Sprintf("%s/tso/api/v1/primary/transfer", nonPrimaryAddr),
-		"application/json", bytes.NewBuffer(data))
-	re.NoError(err)
-	re.Equal(http.StatusBadRequest, resp.StatusCode)
-	resp.Body.Close()
+	// The follower forwards the request to the group's primary. While a primary
+	// election is in flight the primary address can be briefly unavailable, so
+	// retry until the forwarded request succeeds.
+	testutil.Eventually(re, func() bool {
+		resp, err := tests.TestDialClient.Post(
+			fmt.Sprintf("%s/tso/api/v1/primary/transfer", nonPrimaryAddr),
+			"application/json", bytes.NewBuffer(data))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(200*time.Millisecond))
 
 	// Requesting transfer for a non-existent keyspace group should return 400.
 	body["keyspace_group_id"] = uint32(9999)
@@ -651,10 +658,10 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	resp.Body.Close()
 }
 
-// TestTransferPrimaryToDefaultGroupFollower documents an intentional behavior
-// change: the transfer primary request is no longer redirected to the primary.
-// Sending it to a follower of the default keyspace group now returns HTTP 400
-// instead of being forwarded, so the caller must retry against the primary.
+// TestTransferPrimaryToDefaultGroupFollower verifies that the transfer primary
+// request for the default keyspace group is still forwarded from a follower to
+// the primary and succeeds, preserving backward compatibility with the previous
+// ServiceRedirector behavior.
 func (suite *memberTestSuite) TestTransferPrimaryToDefaultGroupFollower() {
 	re := suite.Require()
 
@@ -673,22 +680,20 @@ func (suite *memberTestSuite) TestTransferPrimaryToDefaultGroupFollower() {
 	re.NotEmpty(followerAddr)
 
 	// Omit keyspace_group_id so it defaults to the default keyspace group (0).
+	// The follower should forward the request to the primary and succeed. Retry
+	// to ride over any in-flight primary election.
 	data, err := json.Marshal(map[string]any{"new_primary": ""})
 	re.NoError(err)
-	resp, err := tests.TestDialClient.Post(
-		fmt.Sprintf("%s/tso/api/v1/primary/transfer", followerAddr),
-		"application/json", bytes.NewBuffer(data))
-	re.NoError(err)
-	re.Equal(http.StatusBadRequest, resp.StatusCode)
-	resp.Body.Close()
-
-	// Sending the same request to the primary still succeeds.
-	resp, err = tests.TestDialClient.Post(
-		fmt.Sprintf("%s/tso/api/v1/primary/transfer", primary),
-		"application/json", bytes.NewBuffer(data))
-	re.NoError(err)
-	re.Equal(http.StatusOK, resp.StatusCode)
-	resp.Body.Close()
+	testutil.Eventually(re, func() bool {
+		resp, err := tests.TestDialClient.Post(
+			fmt.Sprintf("%s/tso/api/v1/primary/transfer", followerAddr),
+			"application/json", bytes.NewBuffer(data))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(200*time.Millisecond))
 }
 
 func mustGetKeyspaceGroupMembers(re *require.Assertions, server *tso.Server) map[uint32]*apis.KeyspaceGroupMember {

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -36,9 +36,12 @@ import (
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
 	"github.com/tikv/pd/pkg/mcs/tso/server/apis/v1"
+	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/server/apiv2/handlers"
 	"github.com/tikv/pd/tests"
+	handlersutil "github.com/tikv/pd/tests/server/apiv2/handlers"
 )
 
 func TestMain(m *testing.M) {
@@ -462,6 +465,125 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 		re.NoError(err)
 		re.NotEqual(newPrimary, onlyPrimary)
 	}
+}
+
+// TestTransferPrimaryWithKeyspaceGroup tests that the transfer primary API accepts
+// a keyspace_group_id field and routes the transfer to the correct keyspace group.
+func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes", `return(true)`))
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes"))
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
+	}()
+
+	// Create keyspace group 1 and assign all tso nodes as members.
+	const testGroupID = uint32(1)
+	var memberAddrs []endpoint.KeyspaceGroupMember
+	for addr := range suite.tsoNodes {
+		memberAddrs = append(memberAddrs, endpoint.KeyspaceGroupMember{Address: addr})
+	}
+	handlersutil.MustCreateKeyspaceGroup(re, suite.server, &handlers.CreateKeyspaceGroupParams{
+		KeyspaceGroups: []*endpoint.KeyspaceGroup{
+			{
+				ID:       testGroupID,
+				UserKind: endpoint.Standard.String(),
+				Members:  memberAddrs,
+			},
+		},
+	})
+
+	// Wait until the group is loaded and has a primary on one of the tso nodes.
+	var groupPrimary string
+	testutil.Eventually(re, func() bool {
+		for _, s := range suite.tsoNodes {
+			tsoSvr := s.(*tso.Server)
+			members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+			if m, ok := members[testGroupID]; ok && m.IsPrimary {
+				groupPrimary = tsoSvr.GetAddr()
+				return true
+			}
+		}
+		return false
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+	re.NotEmpty(groupPrimary)
+
+	// Transfer primary within keyspace group 1 (random resign — new_primary left empty).
+	body := map[string]any{
+		"new_primary":       "",
+		"keyspace_group_id": testGroupID,
+	}
+	data, err := json.Marshal(body)
+	re.NoError(err)
+	resp, err := tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", groupPrimary),
+		"application/json", bytes.NewBuffer(data))
+	re.NoError(err)
+	re.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Wait for the primary of group 1 to move to a different node.
+	testutil.Eventually(re, func() bool {
+		for _, s := range suite.tsoNodes {
+			tsoSvr := s.(*tso.Server)
+			members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+			if m, ok := members[testGroupID]; ok && m.IsPrimary {
+				return tsoSvr.GetAddr() != groupPrimary
+			}
+		}
+		return false
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+
+	// Transfer primary to a specific node within keyspace group 1.
+	var newPrimary string
+	for _, s := range suite.tsoNodes {
+		tsoSvr := s.(*tso.Server)
+		members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+		if m, ok := members[testGroupID]; ok && m.IsPrimary {
+			groupPrimary = tsoSvr.GetAddr()
+		} else if _, ok := members[testGroupID]; ok {
+			newPrimary = tsoSvr.Name()
+		}
+	}
+	re.NotEmpty(newPrimary)
+
+	body["new_primary"] = newPrimary
+	body["keyspace_group_id"] = testGroupID
+	data, err = json.Marshal(body)
+	re.NoError(err)
+	resp, err = tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", groupPrimary),
+		"application/json", bytes.NewBuffer(data))
+	re.NoError(err)
+	re.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Verify the specified node becomes primary.
+	testutil.Eventually(re, func() bool {
+		for _, s := range suite.tsoNodes {
+			tsoSvr := s.(*tso.Server)
+			if tsoSvr.Name() != newPrimary {
+				continue
+			}
+			members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+			if m, ok := members[testGroupID]; ok && m.IsPrimary {
+				return true
+			}
+		}
+		return false
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+
+	// Requesting transfer for a non-existent keyspace group should return 400.
+	body["keyspace_group_id"] = uint32(9999)
+	data, err = json.Marshal(body)
+	re.NoError(err)
+	resp, err = tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", groupPrimary),
+		"application/json", bytes.NewBuffer(data))
+	re.NoError(err)
+	re.Equal(http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
 }
 
 func mustGetKeyspaceGroupMembers(re *require.Assertions, server *tso.Server) map[uint32]*apis.KeyspaceGroupMember {

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -584,6 +584,29 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 		return false
 	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 
+	// Sending the transfer request to a non-primary member of the group should
+	// return 400 instead of a 500, since its expected primary lease is nil.
+	var nonPrimaryAddr string
+	for _, s := range suite.tsoNodes {
+		tsoSvr := s.(*tso.Server)
+		members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+		if m, ok := members[testGroupID]; ok && !m.IsPrimary {
+			nonPrimaryAddr = tsoSvr.GetAddr()
+			break
+		}
+	}
+	re.NotEmpty(nonPrimaryAddr)
+	body["new_primary"] = ""
+	body["keyspace_group_id"] = testGroupID
+	data, err = json.Marshal(body)
+	re.NoError(err)
+	resp, err = tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", nonPrimaryAddr),
+		"application/json", bytes.NewBuffer(data))
+	re.NoError(err)
+	re.Equal(http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
+
 	// Requesting transfer for a non-existent keyspace group should return 400.
 	body["keyspace_group_id"] = uint32(9999)
 	data, err = json.Marshal(body)

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -656,6 +656,15 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	re.NoError(err)
 	re.Equal(http.StatusBadRequest, resp.StatusCode)
 	resp.Body.Close()
+
+	// An empty request body must be rejected instead of silently falling back to
+	// a random transfer on the default keyspace group.
+	resp, err = tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", groupPrimary),
+		"application/json", http.NoBody)
+	re.NoError(err)
+	re.Equal(http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
 }
 
 // TestTransferPrimaryToDefaultGroupFollower verifies that the transfer primary

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
 	"github.com/tikv/pd/pkg/mcs/tso/server/apis/v1"
+	mcs "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -471,30 +471,39 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 // a keyspace_group_id field and routes the transfer to the correct keyspace group.
 func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	re := suite.Require()
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes", `return(true)`))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
 	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/acceleratedAllocNodes"))
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
 	}()
 
-	// Create keyspace group 1 and assign all tso nodes as members.
+	// Create keyspace group 1 without members first, then use AllocNodes so that
+	// TSO nodes discover the group via etcd watch and elect a primary.
 	const testGroupID = uint32(1)
-	var memberAddrs []endpoint.KeyspaceGroupMember
-	for addr := range suite.tsoNodes {
-		memberAddrs = append(memberAddrs, endpoint.KeyspaceGroupMember{Address: addr})
-	}
 	handlersutil.MustCreateKeyspaceGroup(re, suite.server, &handlers.CreateKeyspaceGroupParams{
 		KeyspaceGroups: []*endpoint.KeyspaceGroup{
 			{
 				ID:       testGroupID,
 				UserKind: endpoint.Standard.String(),
-				Members:  memberAddrs,
 			},
 		},
 	})
 
-	// Wait until the group is loaded and has a primary on one of the tso nodes.
+	// Allocate nodes for the group via PD's AllocNodes API so TSO nodes can
+	// discover their membership through etcd and start campaigning for primary.
+	allocBody, err := json.Marshal(&handlers.AllocNodesForKeyspaceGroupParams{
+		Replica: mcs.DefaultKeyspaceGroupReplicaCount,
+	})
+	re.NoError(err)
+	allocReq, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("%s/pd/api/v2/tso/keyspace-groups/%d/alloc", suite.backendEndpoints, testGroupID),
+		bytes.NewBuffer(allocBody))
+	re.NoError(err)
+	allocResp, err := tests.TestDialClient.Do(allocReq)
+	re.NoError(err)
+	re.Equal(http.StatusOK, allocResp.StatusCode)
+	allocResp.Body.Close()
+
+	// Wait until the group is loaded on a TSO node and has elected a primary.
 	var groupPrimary string
 	testutil.Eventually(re, func() bool {
 		for _, s := range suite.tsoNodes {
@@ -506,7 +515,7 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 			}
 		}
 		return false
-	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+	}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(200*time.Millisecond))
 	re.NotEmpty(groupPrimary)
 
 	// Transfer primary within keyspace group 1 (random resign — new_primary left empty).

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -468,22 +468,16 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 	}
 }
 
-// TestTransferPrimaryWithKeyspaceGroup tests that the transfer primary API accepts
-// a keyspace_group_id field and routes the transfer to the correct keyspace group.
-func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
-	re := suite.Require()
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
-	}()
-
-	// Create keyspace group 1 without members first, then use AllocNodes so that
+// mustSetupKeyspaceGroupWithoutKeyspaces creates a keyspace group that has no
+// keyspaces assigned, allocates TSO nodes for it, and waits until one of them
+// becomes the primary. It returns the primary's address.
+func (suite *memberTestSuite) mustSetupKeyspaceGroupWithoutKeyspaces(re *require.Assertions, groupID uint32) string {
+	// Create the keyspace group without members first, then use AllocNodes so that
 	// TSO nodes discover the group via etcd watch and elect a primary.
-	const testGroupID = uint32(1)
 	handlersutil.MustCreateKeyspaceGroup(re, suite.server, &handlers.CreateKeyspaceGroupParams{
 		KeyspaceGroups: []*endpoint.KeyspaceGroup{
 			{
-				ID:       testGroupID,
+				ID:       groupID,
 				UserKind: endpoint.Standard.String(),
 			},
 		},
@@ -496,7 +490,7 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	})
 	re.NoError(err)
 	allocReq, err := http.NewRequest(http.MethodPost,
-		fmt.Sprintf("%s/pd/api/v2/tso/keyspace-groups/%d/alloc", suite.backendEndpoints, testGroupID),
+		fmt.Sprintf("%s/pd/api/v2/tso/keyspace-groups/%d/alloc", suite.backendEndpoints, groupID),
 		bytes.NewBuffer(allocBody))
 	re.NoError(err)
 	allocResp, err := tests.TestDialClient.Do(allocReq)
@@ -510,7 +504,7 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 		for _, s := range suite.tsoNodes {
 			tsoSvr := s.(*tso.Server)
 			members := mustGetKeyspaceGroupMembers(re, tsoSvr)
-			if m, ok := members[testGroupID]; ok && m.IsPrimary {
+			if m, ok := members[groupID]; ok && m.IsPrimary {
 				groupPrimary = tsoSvr.GetAddr()
 				return true
 			}
@@ -518,6 +512,44 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 		return false
 	}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(200*time.Millisecond))
 	re.NotEmpty(groupPrimary)
+	return groupPrimary
+}
+
+// TestKeyspaceGroupMembersWithoutKeyspaces verifies that the keyspace-groups
+// members API returns a keyspace group that is served by the node but has no
+// keyspaces assigned. This guards against regressing back to GetKeyspaceGroups(),
+// which is built from the keyspace lookup table and would miss such a group, so
+// its primary would never be observed through this API.
+func (suite *memberTestSuite) TestKeyspaceGroupMembersWithoutKeyspaces() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
+	}()
+
+	const testGroupID = uint32(1)
+	groupPrimary := suite.mustSetupKeyspaceGroupWithoutKeyspaces(re, testGroupID)
+
+	// The group with no keyspaces must be returned by the members API, and its
+	// member list must not carry any keyspace.
+	members := mustGetKeyspaceGroupMembers(re, suite.tsoNodes[groupPrimary].(*tso.Server))
+	m, ok := members[testGroupID]
+	re.True(ok)
+	re.True(m.IsPrimary)
+	re.Empty(m.Group.Keyspaces)
+}
+
+// TestTransferPrimaryWithKeyspaceGroup tests that the transfer primary API accepts
+// a keyspace_group_id field and routes the transfer to the correct keyspace group.
+func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
+	}()
+
+	const testGroupID = uint32(1)
+	groupPrimary := suite.mustSetupKeyspaceGroupWithoutKeyspaces(re, testGroupID)
 
 	// Transfer primary within keyspace group 1 (random resign — new_primary left empty).
 	body := map[string]any{

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -619,6 +619,46 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	resp.Body.Close()
 }
 
+// TestTransferPrimaryToDefaultGroupFollower documents an intentional behavior
+// change: the transfer primary request is no longer redirected to the primary.
+// Sending it to a follower of the default keyspace group now returns HTTP 400
+// instead of being forwarded, so the caller must retry against the primary.
+func (suite *memberTestSuite) TestTransferPrimaryToDefaultGroupFollower() {
+	re := suite.Require()
+
+	primary, err := suite.pdClient.GetMicroservicePrimary(suite.ctx, "tso")
+	re.NoError(err)
+	re.NotEmpty(primary)
+
+	// Pick a follower of the default keyspace group.
+	var followerAddr string
+	for addr := range suite.tsoAvailMembers {
+		if addr != primary {
+			followerAddr = addr
+			break
+		}
+	}
+	re.NotEmpty(followerAddr)
+
+	// Omit keyspace_group_id so it defaults to the default keyspace group (0).
+	data, err := json.Marshal(map[string]any{"new_primary": ""})
+	re.NoError(err)
+	resp, err := tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", followerAddr),
+		"application/json", bytes.NewBuffer(data))
+	re.NoError(err)
+	re.Equal(http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
+
+	// Sending the same request to the primary still succeeds.
+	resp, err = tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", primary),
+		"application/json", bytes.NewBuffer(data))
+	re.NoError(err)
+	re.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
 func mustGetKeyspaceGroupMembers(re *require.Assertions, server *tso.Server) map[uint32]*apis.KeyspaceGroupMember {
 	httpReq, err := http.NewRequest(http.MethodGet, server.GetAddr()+"/tso/api/v1/keyspace-groups/members", nil)
 	re.NoError(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10874

### What is changed and how does it work?

```commit-message
The /primary/transfer endpoint previously hardcoded DefaultKeyspaceGroupID,
making it impossible to transfer the primary for non-default keyspace groups.

- Accepts an optional `keyspace_group_id` field in the request body
  (defaults to 0 for backward compatibility).
- Returns HTTP 400 when the specified keyspace group is not served by the
  current TSO node, fixing a latent nil-dereference in the original code.
- Rejects an empty request body with HTTP 400 instead of silently falling
  back to a random transfer on the default keyspace group.
- Forwards the request to the primary of the target keyspace group when the
  receiving node is not that primary. The default group keeps its previous
  redirect-on-follower behavior, and non-default groups now get the same
  group-aware forwarding (ServiceRedirector only knows group 0's primary, so
  it cannot be reused here). The raw body is replayed on the forwarded
  request and a redirector header guards against redirect loops.
- Adds integration tests covering resign, targeted transfer, invalid group
  ID, forwarding from a non-primary member of a non-default group, and
  forwarding from a follower of the default group; plus a test asserting the
  members API returns a served keyspace group that has no keyspaces.
```

### Check List

Tests

- Integration test

Code changes

- Has HTTP APIs changed

### Release note

```release-note
The TSO `/primary/transfer` API now accepts an optional `keyspace_group_id`
field. When omitted, it defaults to the default keyspace group (ID 0),
preserving backward compatibility. A request received by a node that is not
the primary of the target keyspace group is forwarded to that group's
primary (the default group keeps its previous redirect behavior, and
non-default groups now behave the same way). Requests for a keyspace group
not served by the node return HTTP 400, an empty request body returns HTTP
400, and a not-yet-elected primary returns HTTP 503.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Primary transfer API now accepts an explicit keyspace-group field in request body, defaults missing IDs, validates the group is served by this node, and limits candidate primaries to group members. Updated API annotations accordingly.
  * Keyspace-group listing and lookup now return only groups actively served by the node.

* **Tests**
  * Added integration tests covering random resigns, targeted primary transfers within a keyspace group, and proper 400 response for non-existent groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

