### PR TITLE
client/resource_group: use RUv2 token debt for RUv2 keyspaces

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -429,7 +429,7 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 							continue
 						}
 						// If the resource group is marked as tombstone before, re-create the resource group controller.
-						newGC, err := newGroupCostController(group, c.ruConfig, c.lowTokenNotifyChan, c.tokenBucketUpdateChan)
+						newGC, err := newGroupCostController(group, c.ruConfig, c.lowTokenNotifyChan, c.tokenBucketUpdateChan, c.GetRUVersion)
 						if err != nil {
 							log.Warn("[resource group controller] re-create resource group cost controller for tombstone failed",
 								zap.String("name", name), zap.Error(err))
@@ -565,7 +565,7 @@ func (c *ResourceGroupsController) tryGetResourceGroupController(
 		return gc, nil
 	}
 	// Initialize the resource group controller.
-	gc, err = newGroupCostController(group, c.ruConfig, c.lowTokenNotifyChan, c.tokenBucketUpdateChan)
+	gc, err = newGroupCostController(group, c.ruConfig, c.lowTokenNotifyChan, c.tokenBucketUpdateChan, c.GetRUVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +601,7 @@ func (c *ResourceGroupsController) tombstoneGroupCostController(name string) {
 		return
 	}
 	// Create a default resource group controller for the tombstone resource group independently.
-	gc, err := newGroupCostController(defaultGC.getMeta(), c.ruConfig, c.lowTokenNotifyChan, c.tokenBucketUpdateChan)
+	gc, err := newGroupCostController(defaultGC.getMeta(), c.ruConfig, c.lowTokenNotifyChan, c.tokenBucketUpdateChan, c.GetRUVersion)
 	if err != nil {
 		log.Warn("[resource group controller] create default resource group cost controller for tombstone failed",
 			zap.String("name", name), zap.Error(err))
@@ -812,7 +812,8 @@ func (c *ResourceGroupsController) ReportConsumption(resourceGroupName string, c
 
 // ReportRUV2Consumption is used to report the experimental v2 RU consumption
 // split by engine (TiKV, TiDB, TiFlash).
-// RUv2 is only recorded for observation purposes without actual token deduction.
+// When this keyspace uses RUv2, the reported value is also deducted from the
+// local token bucket as debt.
 func (c *ResourceGroupsController) ReportRUV2Consumption(resourceGroupName string, tikvRUV2, tidbRUV2, tiflashRUV2 float64) {
 	gc, ok := c.loadGroupController(resourceGroupName)
 	if !ok {

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -43,6 +43,9 @@ type groupCostController struct {
 
 	// following fields are used for token limiter.
 	calculators []ResourceCalculator
+	// getRUVersion returns the current RU calculation version for the
+	// controller's keyspace.
+	getRUVersion func() RUVersion
 
 	// metrics
 	metrics *groupMetricsCollection
@@ -135,6 +138,7 @@ type tokenCounter struct {
 	// lastSecRU is the consumption.RU value when avgRUPerSec was last updated.
 	avgRUPerSecLastRU float64
 	avgLastTime       time.Time
+	avgRUVersion      RUVersion
 
 	notify struct {
 		mu                         sync.Mutex
@@ -158,6 +162,7 @@ func newGroupCostController(
 	mainCfg *RUConfig,
 	lowRUNotifyChan chan notifyMsg,
 	tokenBucketUpdateChan chan *groupCostController,
+	getRUVersion func() RUVersion,
 ) (*groupCostController, error) {
 	switch group.Mode {
 	case rmpb.GroupMode_RUMode:
@@ -167,13 +172,17 @@ func newGroupCostController(
 	default:
 		return nil, errs.ErrClientResourceGroupConfigUnavailable.FastGenByArgs("not supports the resource type")
 	}
+	if getRUVersion == nil {
+		getRUVersion = defaultRUVersionProvider
+	}
 	ms := initMetrics(group.Name, group.Name)
 	gc := &groupCostController{
-		meta:    group,
-		name:    group.Name,
-		mainCfg: mainCfg,
-		mode:    group.GetMode(),
-		metrics: ms,
+		meta:         group,
+		name:         group.Name,
+		mainCfg:      mainCfg,
+		mode:         group.GetMode(),
+		metrics:      ms,
+		getRUVersion: getRUVersion,
 		calculators: []ResourceCalculator{
 			newKVCalculator(mainCfg),
 			newSQLCalculator(mainCfg),
@@ -190,6 +199,25 @@ func newGroupCostController(
 	// TODO: re-init the state if user change mode from RU to RAW mode.
 	gc.initRunState()
 	return gc, nil
+}
+
+func defaultRUVersionProvider() RUVersion {
+	return DefaultRUVersion
+}
+
+func (gc *groupCostController) currentRUVersion() RUVersion {
+	if gc.getRUVersion == nil {
+		return DefaultRUVersion
+	}
+	return gc.getRUVersion()
+}
+
+func (gc *groupCostController) useRUV2() bool {
+	return gc.currentRUVersion() == RUVersionV2
+}
+
+func (gc *groupCostController) getRUValueFromConsumption(consumption *rmpb.Consumption) float64 {
+	return getRUValueFromConsumptionByVersion(consumption, gc.currentRUVersion())
 }
 
 func (gc *groupCostController) initRunState() {
@@ -222,10 +250,11 @@ func (gc *groupCostController) initRunState() {
 	defer gc.metaLock.RUnlock()
 	limiter := NewLimiterWithCfg(gc.name, now, cfgFunc(gc.meta.RUSettings.RU), gc.lowRUNotifyChan)
 	counter := &tokenCounter{
-		limiter:     limiter,
-		avgRUPerSec: 0,
-		avgLastTime: now,
-		fillRate:    gc.meta.RUSettings.RU.Settings.FillRate,
+		limiter:      limiter,
+		avgRUPerSec:  0,
+		avgLastTime:  now,
+		avgRUVersion: gc.currentRUVersion(),
+		fillRate:     gc.meta.RUSettings.RU.Settings.FillRate,
 	}
 	gc.run.requestUnitTokens = counter
 	gc.burstable.Store(isBurstable)
@@ -270,7 +299,17 @@ func (gc *groupCostController) updateAvgRequestResourcePerSec() {
 	if counter.limiter.GetBurst() >= 0 {
 		isBurstable = false
 	}
-	if !gc.calcAvg(counter, getRUValueFromConsumption(gc.run.consumption)) {
+	ruVersion := gc.currentRUVersion()
+	newValue := getRUValueFromConsumptionByVersion(gc.run.consumption, ruVersion)
+	if counter.avgRUVersion != ruVersion {
+		counter.avgRUVersion = ruVersion
+		counter.avgRUPerSec = 0
+		counter.avgRUPerSecLastRU = newValue
+		counter.avgLastTime = gc.run.now
+		gc.burstable.Store(isBurstable)
+		return
+	}
+	if !gc.calcAvg(counter, newValue) {
 		return
 	}
 	logControllerTrace("[resource group controller] update avg ru per sec", zap.String("name", gc.name), zap.Float64("avg-ru-per-sec", counter.avgRUPerSec), zap.Bool("is-throttled", gc.isThrottled.Load()))
@@ -345,7 +384,7 @@ func (gc *groupCostController) shouldReportConsumption() bool {
 		if timeSinceLastRequest >= extendedReportingPeriodFactor*defaultTargetPeriod {
 			return true
 		}
-		if getRUValueFromConsumption(gc.run.consumption)-getRUValueFromConsumption(gc.run.lastRequestConsumption) >= consumptionsReportingThreshold {
+		if gc.getRUValueFromConsumption(gc.run.consumption)-gc.getRUValueFromConsumption(gc.run.lastRequestConsumption) >= consumptionsReportingThreshold {
 			return true
 		}
 	}
@@ -512,6 +551,14 @@ func (gc *groupCostController) calcRequest(counter *tokenCounter) float64 {
 }
 
 func (gc *groupCostController) acquireTokens(ctx context.Context, delta *rmpb.Consumption, waitDuration *time.Duration, allowDebt bool) (time.Duration, error) {
+	return gc.acquireTokenValue(ctx, gc.getRUValueFromConsumption(delta), waitDuration, allowDebt, false)
+}
+
+func (gc *groupCostController) waitForRUV2Debt(ctx context.Context, waitDuration *time.Duration) (time.Duration, error) {
+	return gc.acquireTokenValue(ctx, 0, waitDuration, false, true)
+}
+
+func (gc *groupCostController) acquireTokenValue(ctx context.Context, v float64, waitDuration *time.Duration, allowDebt bool, waitForDebt bool) (time.Duration, error) {
 	gc.metrics.runningKVRequestCounter.Inc()
 	defer gc.metrics.runningKVRequestCounter.Dec()
 	var (
@@ -524,7 +571,7 @@ retryLoop:
 		reconfiguredCh := counter.limiter.GetReconfiguredCh()
 		now := time.Now()
 		var res *Reservation
-		if v := getRUValueFromConsumption(delta); v > 0 {
+		if v > 0 {
 			// record the consume token histogram if enable controller debug mode.
 			if enableControllerTraceLog.Load() {
 				gc.metrics.consumeTokenHistogram.Observe(v)
@@ -534,8 +581,10 @@ retryLoop:
 				counter.limiter.RemoveTokens(now, v)
 				break retryLoop
 			}
-			res = counter.limiter.Reserve(ctx, gc.mainCfg.LTBMaxWaitDuration, now, v)
+		} else if !waitForDebt {
+			break retryLoop
 		}
+		res = counter.limiter.Reserve(ctx, gc.mainCfg.LTBMaxWaitDuration, now, v)
 		if d, err = WaitReservations(ctx, now, []*Reservation{res}); err == nil || errs.ErrClientResourceGroupThrottled.NotEqual(err) {
 			break retryLoop
 		}
@@ -579,7 +628,12 @@ func (gc *groupCostController) onRequestWaitImpl(
 	gc.mu.Unlock()
 
 	if !gc.burstable.Load() {
-		d, err := gc.acquireTokens(ctx, delta, &waitDuration, false)
+		var d time.Duration
+		if gc.useRUV2() {
+			d, err = gc.waitForRUV2Debt(ctx, &waitDuration)
+		} else {
+			d, err = gc.acquireTokens(ctx, delta, &waitDuration, false)
+		}
 		if err != nil {
 			if errs.ErrClientResourceGroupThrottled.Equal(err) {
 				gc.metrics.failedRequestCounterWithThrottled.Inc()
@@ -625,7 +679,7 @@ func (gc *groupCostController) onResponseImpl(
 	}
 	if !gc.burstable.Load() {
 		counter := gc.run.requestUnitTokens
-		if v := getRUValueFromConsumption(delta); v > 0 {
+		if v := gc.getRUValueFromConsumption(delta); v > 0 {
 			counter.limiter.RemoveTokens(time.Now(), v)
 		}
 	}
@@ -695,10 +749,18 @@ func (gc *groupCostController) addRUConsumption(consumption *rmpb.Consumption) {
 }
 
 func (gc *groupCostController) addRUV2Consumption(tikvRUV2, tidbRUV2, tiflashRUV2 float64) {
+	consumption := &rmpb.Consumption{
+		TikvRUV2:    tikvRUV2,
+		TidbRUV2:    tidbRUV2,
+		TiflashRUV2: tiflashRUV2,
+	}
+	if gc.useRUV2() && !gc.burstable.Load() {
+		if v := gc.getRUValueFromConsumption(consumption); v > 0 {
+			gc.run.requestUnitTokens.limiter.RemoveTokens(time.Now(), v)
+		}
+	}
 	gc.mu.Lock()
-	gc.mu.consumption.TikvRUV2 += tikvRUV2
-	gc.mu.consumption.TidbRUV2 += tidbRUV2
-	gc.mu.consumption.TiflashRUV2 += tiflashRUV2
+	add(gc.mu.consumption, consumption)
 	gc.mu.Unlock()
 }
 

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -46,9 +46,20 @@ func createTestGroupCostController(re *require.Assertions) *groupCostController 
 	}
 	ch1 := make(chan notifyMsg)
 	ch2 := make(chan *groupCostController)
-	gc, err := newGroupCostController(group, DefaultRUConfig(), ch1, ch2)
+	gc, err := newGroupCostController(group, DefaultRUConfig(), ch1, ch2, defaultRUVersionProvider)
 	re.NoError(err)
 	return gc
+}
+
+func setTestLimiterState(lim *Limiter, tokens, rate float64, burst int64) {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	lim.tokens = tokens
+	lim.fillRate = fillRate(rate)
+	lim.burst = burst
+	lim.last = time.Now()
+	lim.notifyThreshold = 0
+	lim.isLowProcess = false
 }
 
 func TestGroupControlBurstable(t *testing.T) {
@@ -209,6 +220,50 @@ func TestOnResponseWaitConsumption(t *testing.T) {
 	verify()
 }
 
+func TestRUV2ReportDeductsTokensOnlyWhenEnabled(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	counter := gc.run.requestUnitTokens
+	setTestLimiterState(counter.limiter, 1000, 0, 0)
+
+	gc.addRUV2Consumption(10, 20, 30)
+	re.Equal(float64(1000), counter.limiter.AvailableTokens(time.Now()))
+
+	gc.getRUVersion = func() RUVersion { return RUVersionV2 }
+	gc.addRUV2Consumption(10, 20, 30)
+	re.Equal(float64(940), counter.limiter.AvailableTokens(time.Now()))
+}
+
+func TestRUV2ModeUsesReportInsteadOfV1ResponseForTokens(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	gc.getRUVersion = func() RUVersion { return RUVersionV2 }
+	counter := gc.run.requestUnitTokens
+	setTestLimiterState(counter.limiter, 1000, 0, 0)
+
+	_, err := gc.onResponseImpl(&TestRequestInfo{}, &TestResponseInfo{readBytes: 2000 * 64 * 1024})
+	re.NoError(err)
+	re.Equal(float64(1000), counter.limiter.AvailableTokens(time.Now()))
+
+	gc.addRUV2Consumption(200, 30, 20)
+	re.Equal(float64(750), counter.limiter.AvailableTokens(time.Now()))
+}
+
+func TestRUV2DebtWaitsOnNextRequest(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	gc.getRUVersion = func() RUVersion { return RUVersionV2 }
+	gc.mainCfg.WaitRetryTimes = 1
+	gc.mainCfg.LTBMaxWaitDuration = time.Second
+	counter := gc.run.requestUnitTokens
+	setTestLimiterState(counter.limiter, 0, 1000, 0)
+	gc.addRUV2Consumption(10, 0, 0)
+
+	_, _, waitTime, _, err := gc.onRequestWaitImpl(context.Background(), &TestRequestInfo{})
+	re.NoError(err)
+	re.Positive(waitTime)
+}
+
 func TestHandleTokenBucketUpdateEventCanceledByInitCounterNotify(t *testing.T) {
 	re := require.New(t)
 	gc := createTestGroupCostController(re)
@@ -317,7 +372,7 @@ func TestAcquireTokensSignalAwareWait(t *testing.T) {
 	cfg := DefaultRUConfig()
 	cfg.WaitRetryInterval = 5 * time.Second
 	cfg.WaitRetryTimes = 3
-	gc, err := newGroupCostController(group, cfg, notifyCh, make(chan *groupCostController, 1))
+	gc, err := newGroupCostController(group, cfg, notifyCh, make(chan *groupCostController, 1), defaultRUVersionProvider)
 	re.NoError(err)
 
 	// Set fillRate=0 so reservation always fails with InfDuration,

--- a/client/resource_group/controller/model.go
+++ b/client/resource_group/controller/model.go
@@ -215,8 +215,15 @@ func (*SQLCalculator) AfterKVRequest(*rmpb.Consumption, RequestInfo, ResponseInf
 }
 
 func getRUValueFromConsumption(custom *rmpb.Consumption) float64 {
+	return getRUValueFromConsumptionByVersion(custom, RUVersionV1)
+}
+
+func getRUValueFromConsumptionByVersion(custom *rmpb.Consumption, ruVersion RUVersion) float64 {
 	if custom == nil {
 		return 0
+	}
+	if ruVersion == RUVersionV2 {
+		return custom.TikvRUV2 + custom.TidbRUV2 + custom.TiflashRUV2
 	}
 	return custom.RRU + custom.WRU
 }

--- a/client/resource_group/controller/model_test.go
+++ b/client/resource_group/controller/model_test.go
@@ -25,11 +25,12 @@ import (
 func TestGetRUValueFromConsumption(t *testing.T) {
 	// Positive test case
 	re := require.New(t)
-	custom := &rmpb.Consumption{RRU: 2.5, WRU: 3.5}
+	custom := &rmpb.Consumption{RRU: 2.5, WRU: 3.5, TikvRUV2: 4, TidbRUV2: 5, TiflashRUV2: 6}
 	expected := float64(6)
 
 	result := getRUValueFromConsumption(custom)
 	re.Equal(expected, result)
+	re.Equal(float64(15), getRUValueFromConsumptionByVersion(custom, RUVersionV2))
 
 	// When custom is nil
 	custom = nil
@@ -37,6 +38,7 @@ func TestGetRUValueFromConsumption(t *testing.T) {
 
 	result = getRUValueFromConsumption(custom)
 	re.Equal(expected, result)
+	re.Equal(expected, getRUValueFromConsumptionByVersion(custom, RUVersionV2))
 }
 
 func TestAdd(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Resource control already tracks the RU version policy per keyspace and TiDB reports statement-level RUv2 consumption back to the PD client. However, client-side token deduction still uses v1 RU (`RRU + WRU`), so a keyspace configured for RUv2 does not use RUv2 as its local resource-control judgement.

Issue Number: Close #10894

### What is changed and how does it work?

This PR makes the PD client resource-group controller version-aware:

- v1 keyspaces continue to use `RRU + WRU` for local token deduction and request averaging.
- v2 keyspaces use `TikvRUV2 + TidbRUV2 + TiflashRUV2`.
- `ReportRUV2Consumption` deducts the reported RUv2 from the local token bucket as debt when the keyspace is in RUv2 mode.
- the next KV request in RUv2 mode waits on existing local token debt before continuing.
- moving-average accounting resets its baseline when the active RU version changes.

```commit-message
resource control: use RUv2 for token debt
```

### Check List

Tests

- Unit test

Code changes

- None

Side effects

- Increased code complexity

Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: None
- PR to update `pingcap/tiup`: None
- Need to cherry-pick to the release branch: No

### Release note

```release-note
None.
```

Validation:

```bash
cd client
go test ./resource_group/controller -run 'Test(GetRUValueFromConsumption|RUV2ReportDeductsTokensOnlyWhenEnabled|RUV2ModeUsesReportInsteadOfV1ResponseForTokens|RUV2DebtWaitsOnNextRequest|RequestAndResponseConsumption|OnResponseWaitConsumption|AcquireTokensSignalAwareWait|AcquireTokensFallbackToTimer)$'
go test ./resource_group/controller -run '^$'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced resource group controller with RU version 2 support, including improved token acquisition logic and debt handling for better resource management.

* **Tests**
  * Added comprehensive test coverage for RU v2 functionality, including token deduction behavior, consumption tracking, and debt wait scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->