### PR TITLE
api: clarify hex key variable names

### DIFF
--- a/client/http/types.go
+++ b/client/http/types.go
@@ -72,8 +72,8 @@ var NewKeyRange = pd.NewKeyRange
 // RegionInfo stores the information of one region.
 type RegionInfo struct {
 	ID                int64            `json:"id"`
-	StartKey          string           `json:"start_key"`
-	EndKey            string           `json:"end_key"`
+	StartKey          string           `json:"start_key"` // hex-encoded
+	EndKey            string           `json:"end_key"`   // hex-encoded
 	Epoch             RegionEpoch      `json:"epoch"`
 	Peers             []RegionPeer     `json:"peers"`
 	Leader            RegionPeer       `json:"leader"`

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -1296,8 +1296,8 @@ func accelerateRegionsScheduleInRange(c *gin.Context) {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
-	rawStartKey, ok1 := input["start_key"].(string)
-	rawEndKey, ok2 := input["end_key"].(string)
+	startKeyHex, ok1 := input["start_key"].(string)
+	endKeyHex, ok2 := input["end_key"].(string)
 	if !ok1 || !ok2 {
 		c.String(http.StatusBadRequest, "start_key or end_key is not string")
 		return
@@ -1310,12 +1310,12 @@ func accelerateRegionsScheduleInRange(c *gin.Context) {
 		return
 	}
 
-	err = handler.AccelerateRegionsScheduleInRange(rawStartKey, rawEndKey, limit)
+	err = handler.AccelerateRegionsScheduleInRange(startKeyHex, endKeyHex, limit)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}
-	c.String(http.StatusOK, fmt.Sprintf("Accelerate regions scheduling in a given range [%s,%s)", rawStartKey, rawEndKey))
+	c.String(http.StatusOK, fmt.Sprintf("Accelerate regions scheduling in a given range [%s,%s)", startKeyHex, endKeyHex))
 }
 
 // @Tags     region
@@ -1348,19 +1348,19 @@ func accelerateRegionsScheduleInRanges(c *gin.Context) {
 	msgBuilder.WriteString("Accelerate regions scheduling in given ranges: ")
 	var startKeys, endKeys [][]byte
 	for _, rg := range input {
-		startKey, rawStartKey, err := apiutil.ParseKey("start_key", rg)
+		startKey, startKeyHex, err := apiutil.ParseKey("start_key", rg)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
-		endKey, rawEndKey, err := apiutil.ParseKey("end_key", rg)
+		endKey, endKeyHex, err := apiutil.ParseKey("end_key", rg)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
 		startKeys = append(startKeys, startKey)
 		endKeys = append(endKeys, endKey)
-		msgBuilder.WriteString(fmt.Sprintf("[%s,%s), ", rawStartKey, rawEndKey))
+		msgBuilder.WriteString(fmt.Sprintf("[%s,%s), ", startKeyHex, endKeyHex))
 	}
 	err = handler.AccelerateRegionsScheduleInRanges(startKeys, endKeys, limit)
 	if err != nil {
@@ -1387,8 +1387,8 @@ func scatterRegions(c *gin.Context) {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
-	rawStartKey, ok1 := input["start_key"].(string)
-	rawEndKey, ok2 := input["end_key"].(string)
+	startKeyHex, ok1 := input["start_key"].(string)
+	endKeyHex, ok2 := input["end_key"].(string)
 	group, _ := input["group"].(string)
 	retryLimit := 5
 	if rl, ok := input["retry_limit"].(float64); ok {
@@ -1397,7 +1397,7 @@ func scatterRegions(c *gin.Context) {
 
 	opsCount, failures, err := func() (int, map[uint64]error, error) {
 		if ok1 && ok2 {
-			return handler.ScatterRegionsByRange(rawStartKey, rawEndKey, group, retryLimit)
+			return handler.ScatterRegionsByRange(startKeyHex, endKeyHex, group, retryLimit)
 		}
 		ids, ok := typeutil.JSONToUint64Slice(input["regions_id"])
 		if !ok {
@@ -1435,8 +1435,8 @@ func splitRegions(c *gin.Context) {
 		c.String(http.StatusBadRequest, "split_keys should be provided.")
 		return
 	}
-	rawSplitKeys := s.([]any)
-	if len(rawSplitKeys) < 1 {
+	splitKeyHexes := s.([]any)
+	if len(splitKeyHexes) < 1 {
 		c.String(http.StatusBadRequest, "empty split keys.")
 		return
 	}
@@ -1444,7 +1444,7 @@ func splitRegions(c *gin.Context) {
 	if rl, ok := input["retry_limit"].(float64); ok {
 		retryLimit = int(rl)
 	}
-	s, err := handler.SplitRegions(c.Request.Context(), rawSplitKeys, retryLimit)
+	s, err := handler.SplitRegions(c.Request.Context(), splitKeyHexes, retryLimit)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return
@@ -1462,14 +1462,14 @@ func splitRegions(c *gin.Context) {
 // @Router   /regions/replicated [get]
 func checkRegionsReplicated(c *gin.Context) {
 	handler := c.MustGet(handlerKey).(*handler.Handler)
-	rawStartKey, ok1 := c.GetQuery("startKey")
-	rawEndKey, ok2 := c.GetQuery("endKey")
+	startKeyHex, ok1 := c.GetQuery("startKey")
+	endKeyHex, ok2 := c.GetQuery("endKey")
 	if !ok1 || !ok2 {
 		c.String(http.StatusBadRequest, "there is no start_key or end_key")
 		return
 	}
 
-	state, err := handler.CheckRegionsReplicated(rawStartKey, rawEndKey)
+	state, err := handler.CheckRegionsReplicated(startKeyHex, endKeyHex)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -1435,10 +1435,23 @@ func splitRegions(c *gin.Context) {
 		c.String(http.StatusBadRequest, "split_keys should be provided.")
 		return
 	}
-	splitKeyHexes := s.([]any)
-	if len(splitKeyHexes) < 1 {
+	splitKeyValues, ok := s.([]any)
+	if !ok {
+		c.String(http.StatusBadRequest, "split_keys should be an array.")
+		return
+	}
+	if len(splitKeyValues) < 1 {
 		c.String(http.StatusBadRequest, "empty split keys.")
 		return
+	}
+	splitKeyHexes := make([]string, 0, len(splitKeyValues))
+	for _, splitKeyValue := range splitKeyValues {
+		splitKeyHex, ok := splitKeyValue.(string)
+		if !ok {
+			c.String(http.StatusBadRequest, "split_keys should contain only strings.")
+			return
+		}
+		splitKeyHexes = append(splitKeyHexes, splitKeyHex)
 	}
 	retryLimit := 5
 	if rl, ok := input["retry_limit"].(float64); ok {

--- a/pkg/response/region.go
+++ b/pkg/response/region.go
@@ -111,9 +111,10 @@ func fromPeerStatsSlice(peers []*pdpb.PeerStats) []PDPeerStats {
 // NOTE: This type is exported by HTTP API. Please pay more attention when modifying it.
 // easyjson:json
 type RegionInfo struct {
-	ID          uint64              `json:"id"`
-	StartKey    string              `json:"start_key"`
-	EndKey      string              `json:"end_key"`
+	ID       uint64 `json:"id"`
+	StartKey string `json:"start_key"` // hex-encoded
+	EndKey   string `json:"end_key"`   // hex-encoded
+
 	RegionEpoch *metapb.RegionEpoch `json:"epoch,omitempty"`
 	Peers       []MetaPeer          `json:"peers,omitempty"`
 

--- a/pkg/schedule/handler/handler.go
+++ b/pkg/schedule/handler/handler.go
@@ -373,8 +373,8 @@ func (h *Handler) HandleOperatorCreation(input map[string]any) (int, any, error)
 		}
 	case "scatter-regions":
 		// support both receiving key ranges or regionIDs
-		startKey, _ := input["start_key"].(string)
-		endKey, _ := input["end_key"].(string)
+		startKeyHex, _ := input["start_key"].(string)
+		endKeyHex, _ := input["end_key"].(string)
 		ids, ok := typeutil.JSONToUint64Slice(input["region_ids"])
 		if !ok {
 			return http.StatusBadRequest, nil, errors.Errorf("region_ids is invalid")
@@ -385,7 +385,7 @@ func (h *Handler) HandleOperatorCreation(input map[string]any) (int, any, error)
 		if rl, ok := input["retry_limit"].(float64); ok {
 			retryLimit = int(rl)
 		}
-		processedPercentage, err := h.AddScatterRegionsOperators(ids, startKey, endKey, group, retryLimit)
+		processedPercentage, err := h.AddScatterRegionsOperators(ids, startKeyHex, endKeyHex, group, retryLimit)
 		errorMessage := ""
 		if err != nil {
 			errorMessage = err.Error()
@@ -682,8 +682,8 @@ func (h *Handler) AddScatterRegionOperator(regionID uint64, group string) error 
 	return h.addOperator(op)
 }
 
-// AddScatterRegionsOperators add operators to scatter regions and return the processed percentage and error
-func (h *Handler) AddScatterRegionsOperators(regionIDs []uint64, startRawKey, endRawKey, group string, retryLimit int) (int, error) {
+// AddScatterRegionsOperators add operators to scatter regions and return the processed percentage and error.
+func (h *Handler) AddScatterRegionsOperators(regionIDs []uint64, startKeyHex, endKeyHex, group string, retryLimit int) (int, error) {
 	s, err := h.GetRegionScatterer()
 	if err != nil {
 		return 0, err
@@ -691,12 +691,12 @@ func (h *Handler) AddScatterRegionsOperators(regionIDs []uint64, startRawKey, en
 	opsCount := 0
 	var failures map[uint64]error
 	// If startKey and endKey are both defined, use them first.
-	if len(startRawKey) > 0 && len(endRawKey) > 0 {
-		startKey, err := hex.DecodeString(startRawKey)
+	if len(startKeyHex) > 0 && len(endKeyHex) > 0 {
+		startKey, err := hex.DecodeString(startKeyHex)
 		if err != nil {
 			return 0, err
 		}
-		endKey, err := hex.DecodeString(endRawKey)
+		endKey, err := hex.DecodeString(endKeyHex)
 		if err != nil {
 			return 0, err
 		}
@@ -1053,8 +1053,8 @@ type HotBucketsResponse map[uint64][]*HotBucketsItem
 
 // HotBucketsItem is the item of hot buckets.
 type HotBucketsItem struct {
-	StartKey   string `json:"start_key"`
-	EndKey     string `json:"end_key"`
+	StartKey   string `json:"start_key"` // hex-encoded
+	EndKey     string `json:"end_key"`   // hex-encoded
 	HotDegree  int    `json:"hot_degree"`
 	ReadBytes  uint64 `json:"read_bytes"`
 	ReadKeys   uint64 `json:"read_keys"`
@@ -1110,13 +1110,13 @@ func (h *Handler) GetRegionLabeler() (*labeler.RegionLabeler, error) {
 	return c.GetRegionLabeler(), nil
 }
 
-// AccelerateRegionsScheduleInRange accelerates regions scheduling in a given range.
-func (h *Handler) AccelerateRegionsScheduleInRange(rawStartKey, rawEndKey string, limit int) error {
-	startKey, err := hex.DecodeString(rawStartKey)
+// AccelerateRegionsScheduleInRange accelerates regions scheduling in a given hex-encoded key range.
+func (h *Handler) AccelerateRegionsScheduleInRange(startKeyHex, endKeyHex string, limit int) error {
+	startKey, err := hex.DecodeString(startKeyHex)
 	if err != nil {
 		return err
 	}
-	endKey, err := hex.DecodeString(rawEndKey)
+	endKey, err := hex.DecodeString(endKeyHex)
 	if err != nil {
 		return err
 	}
@@ -1209,13 +1209,13 @@ func (*Handler) BuildScatterRegionsResp(opsCount int, failures map[uint64]error)
 	}
 }
 
-// ScatterRegionsByRange scatters regions by range.
-func (h *Handler) ScatterRegionsByRange(rawStartKey, rawEndKey string, group string, retryLimit int) (int, map[uint64]error, error) {
-	startKey, err := hex.DecodeString(rawStartKey)
+// ScatterRegionsByRange scatters regions by hex-encoded key range.
+func (h *Handler) ScatterRegionsByRange(startKeyHex, endKeyHex string, group string, retryLimit int) (int, map[uint64]error, error) {
+	startKey, err := hex.DecodeString(startKeyHex)
 	if err != nil {
 		return 0, nil, err
 	}
-	endKey, err := hex.DecodeString(rawEndKey)
+	endKey, err := hex.DecodeString(endKeyHex)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -1241,15 +1241,15 @@ type SplitRegionsResponse struct {
 	NewRegionsID        []uint64 `json:"regions-id"`
 }
 
-// SplitRegions splits regions by split keys.
-func (h *Handler) SplitRegions(ctx context.Context, rawSplitKeys []any, retryLimit int) (*SplitRegionsResponse, error) {
+// SplitRegions splits regions by hex-encoded split keys.
+func (h *Handler) SplitRegions(ctx context.Context, splitKeyHexes []any, retryLimit int) (*SplitRegionsResponse, error) {
 	co := h.GetCoordinator()
 	if co == nil {
 		return nil, errs.ErrNotBootstrapped.GenWithStackByArgs()
 	}
-	splitKeys := make([][]byte, 0, len(rawSplitKeys))
-	for _, rawKey := range rawSplitKeys {
-		key, err := hex.DecodeString(rawKey.(string))
+	splitKeys := make([][]byte, 0, len(splitKeyHexes))
+	for _, keyHex := range splitKeyHexes {
+		key, err := hex.DecodeString(keyHex.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -1271,13 +1271,13 @@ func (h *Handler) SplitRegions(ctx context.Context, rawSplitKeys []any, retryLim
 	return s, nil
 }
 
-// CheckRegionsReplicated checks if regions are replicated.
-func (h *Handler) CheckRegionsReplicated(rawStartKey, rawEndKey string) (string, error) {
-	startKey, err := hex.DecodeString(rawStartKey)
+// CheckRegionsReplicated checks if regions in a hex-encoded key range are replicated.
+func (h *Handler) CheckRegionsReplicated(startKeyHex, endKeyHex string) (string, error) {
+	startKey, err := hex.DecodeString(startKeyHex)
 	if err != nil {
 		return "", err
 	}
-	endKey, err := hex.DecodeString(rawEndKey)
+	endKey, err := hex.DecodeString(endKeyHex)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/schedule/handler/handler.go
+++ b/pkg/schedule/handler/handler.go
@@ -1242,14 +1242,14 @@ type SplitRegionsResponse struct {
 }
 
 // SplitRegions splits regions by hex-encoded split keys.
-func (h *Handler) SplitRegions(ctx context.Context, splitKeyHexes []any, retryLimit int) (*SplitRegionsResponse, error) {
+func (h *Handler) SplitRegions(ctx context.Context, splitKeyHexes []string, retryLimit int) (*SplitRegionsResponse, error) {
 	co := h.GetCoordinator()
 	if co == nil {
 		return nil, errs.ErrNotBootstrapped.GenWithStackByArgs()
 	}
 	splitKeys := make([][]byte, 0, len(splitKeyHexes))
 	for _, keyHex := range splitKeyHexes {
-		key, err := hex.DecodeString(keyHex.(string))
+		key, err := hex.DecodeString(keyHex)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/apiutil/apiutil.go
+++ b/pkg/utils/apiutil/apiutil.go
@@ -349,21 +349,21 @@ func CollectStringOption(option string, input map[string]any, collectors ...func
 	return nil
 }
 
-// ParseKey is used to parse interface into []byte and string
+// ParseKey decodes a hex-encoded key string and returns the decoded key with the original hex string.
 func ParseKey(name string, input map[string]any) ([]byte, string, error) {
 	k, ok := input[name]
 	if !ok {
 		return nil, "", fmt.Errorf("missing %s", name)
 	}
-	rawKey, ok := k.(string)
+	keyHex, ok := k.(string)
 	if !ok {
 		return nil, "", fmt.Errorf("bad format %s", name)
 	}
-	returned, err := hex.DecodeString(rawKey)
+	key, err := hex.DecodeString(keyHex)
 	if err != nil {
 		return nil, "", fmt.Errorf("split key %s is not in hex format", name)
 	}
-	return returned, rawKey, nil
+	return key, keyHex, nil
 }
 
 // ParseHexKeys decodes hexadecimal src into DecodedLen(len(src)) bytes if the format is "hex".

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -908,10 +908,23 @@ func (h *regionsHandler) SplitRegions(w http.ResponseWriter, r *http.Request) {
 		h.rd.JSON(w, http.StatusBadRequest, "split_keys should be provided.")
 		return
 	}
-	splitKeyHexes := s.([]any)
-	if len(splitKeyHexes) < 1 {
+	splitKeyValues, ok := s.([]any)
+	if !ok {
+		h.rd.JSON(w, http.StatusBadRequest, "split_keys should be an array.")
+		return
+	}
+	if len(splitKeyValues) < 1 {
 		h.rd.JSON(w, http.StatusBadRequest, "empty split keys.")
 		return
+	}
+	splitKeyHexes := make([]string, 0, len(splitKeyValues))
+	for _, splitKeyValue := range splitKeyValues {
+		splitKeyHex, ok := splitKeyValue.(string)
+		if !ok {
+			h.rd.JSON(w, http.StatusBadRequest, "split_keys should contain only strings.")
+			return
+		}
+		splitKeyHexes = append(splitKeyHexes, splitKeyHex)
 	}
 	retryLimit := 5
 	if rl, ok := input["retry_limit"].(float64); ok {

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -145,9 +145,9 @@ func (h *regionHandler) GetRegion(w http.ResponseWriter, r *http.Request) {
 //	@Router		/regions/replicated [get]
 func (h *regionsHandler) CheckRegionsReplicated(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	rawStartKey := vars["startKey"]
-	rawEndKey := vars["endKey"]
-	state, err := h.Handler.CheckRegionsReplicated(rawStartKey, rawEndKey)
+	startKeyHex := vars["startKey"]
+	endKeyHex := vars["endKey"]
+	state, err := h.Handler.CheckRegionsReplicated(startKeyHex, endKeyHex)
 	if err != nil {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
@@ -761,8 +761,8 @@ func (h *regionsHandler) AccelerateRegionsScheduleInRange(w http.ResponseWriter,
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
-	rawStartKey, ok1 := input["start_key"].(string)
-	rawEndKey, ok2 := input["end_key"].(string)
+	startKeyHex, ok1 := input["start_key"].(string)
+	endKeyHex, ok2 := input["end_key"].(string)
 	if !ok1 || !ok2 {
 		h.rd.JSON(w, http.StatusBadRequest, "start_key or end_key is not string")
 		return
@@ -774,12 +774,12 @@ func (h *regionsHandler) AccelerateRegionsScheduleInRange(w http.ResponseWriter,
 		return
 	}
 
-	err = h.Handler.AccelerateRegionsScheduleInRange(rawStartKey, rawEndKey, limit)
+	err = h.Handler.AccelerateRegionsScheduleInRange(startKeyHex, endKeyHex, limit)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.rd.Text(w, http.StatusOK, fmt.Sprintf("Accelerate regions scheduling in a given range [%s,%s)", rawStartKey, rawEndKey))
+	h.rd.Text(w, http.StatusOK, fmt.Sprintf("Accelerate regions scheduling in a given range [%s,%s)", startKeyHex, endKeyHex))
 }
 
 // AccelerateRegionsScheduleInRanges accelerates regions scheduling in given ranges.
@@ -809,19 +809,19 @@ func (h *regionsHandler) AccelerateRegionsScheduleInRanges(w http.ResponseWriter
 	msgBuilder.WriteString("Accelerate regions scheduling in given ranges: ")
 	var startKeys, endKeys [][]byte
 	for _, rg := range input {
-		startKey, rawStartKey, err := apiutil.ParseKey("start_key", rg)
+		startKey, startKeyHex, err := apiutil.ParseKey("start_key", rg)
 		if err != nil {
 			h.rd.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		endKey, rawEndKey, err := apiutil.ParseKey("end_key", rg)
+		endKey, endKeyHex, err := apiutil.ParseKey("end_key", rg)
 		if err != nil {
 			h.rd.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		startKeys = append(startKeys, startKey)
 		endKeys = append(endKeys, endKey)
-		msgBuilder.WriteString(fmt.Sprintf("[%s,%s), ", rawStartKey, rawEndKey))
+		msgBuilder.WriteString(fmt.Sprintf("[%s,%s), ", startKeyHex, endKeyHex))
 	}
 	err = h.Handler.AccelerateRegionsScheduleInRanges(startKeys, endKeys, limit)
 	if err != nil {
@@ -862,8 +862,8 @@ func (h *regionsHandler) ScatterRegions(w http.ResponseWriter, r *http.Request) 
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		return
 	}
-	rawStartKey, ok1 := input["start_key"].(string)
-	rawEndKey, ok2 := input["end_key"].(string)
+	startKeyHex, ok1 := input["start_key"].(string)
+	endKeyHex, ok2 := input["end_key"].(string)
 	group, _ := input["group"].(string)
 	retryLimit := 5
 	if rl, ok := input["retry_limit"].(float64); ok {
@@ -872,7 +872,7 @@ func (h *regionsHandler) ScatterRegions(w http.ResponseWriter, r *http.Request) 
 
 	opsCount, failures, err := func() (int, map[uint64]error, error) {
 		if ok1 && ok2 {
-			return h.ScatterRegionsByRange(rawStartKey, rawEndKey, group, retryLimit)
+			return h.ScatterRegionsByRange(startKeyHex, endKeyHex, group, retryLimit)
 		}
 		ids, ok := typeutil.JSONToUint64Slice(input["regions_id"])
 		if !ok {
@@ -908,8 +908,8 @@ func (h *regionsHandler) SplitRegions(w http.ResponseWriter, r *http.Request) {
 		h.rd.JSON(w, http.StatusBadRequest, "split_keys should be provided.")
 		return
 	}
-	rawSplitKeys := s.([]any)
-	if len(rawSplitKeys) < 1 {
+	splitKeyHexes := s.([]any)
+	if len(splitKeyHexes) < 1 {
 		h.rd.JSON(w, http.StatusBadRequest, "empty split keys.")
 		return
 	}
@@ -917,7 +917,7 @@ func (h *regionsHandler) SplitRegions(w http.ResponseWriter, r *http.Request) {
 	if rl, ok := input["retry_limit"].(float64); ok {
 		retryLimit = int(rl)
 	}
-	s, err := h.Handler.SplitRegions(r.Context(), rawSplitKeys, retryLimit)
+	s, err := h.Handler.SplitRegions(r.Context(), splitKeyHexes, retryLimit)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/tests/integrations/mcs/scheduling/api_test.go
+++ b/tests/integrations/mcs/scheduling/api_test.go
@@ -299,6 +299,14 @@ func (suite *apiTestSuite) checkAPIForward(cluster *tests.TestCluster) {
 	err = testutil.CheckPostJSON(tests.TestDialClient, fmt.Sprintf("%s/%s", urlPrefix, "regions/split"), []byte(body),
 		testutil.StatusOK(re), testutil.WithHeader(re, apiutil.XForwardedToMicroserviceHeader, "true"))
 	re.NoError(err)
+	for _, body := range []string{
+		`{"split_keys":"not-an-array"}`,
+		`{"split_keys":[1]}`,
+	} {
+		err = testutil.CheckPostJSON(tests.TestDialClient, fmt.Sprintf("%s/%s", urlPrefix, "regions/split"), []byte(body),
+			testutil.Status(re, http.StatusBadRequest), testutil.WithHeader(re, apiutil.XForwardedToMicroserviceHeader, "true"))
+		re.NoError(err)
+	}
 	err = testutil.CheckGetJSON(tests.TestDialClient, fmt.Sprintf(`%s/regions/replicated?startKey=%s&endKey=%s`, urlPrefix, hex.EncodeToString([]byte("a1")), hex.EncodeToString([]byte("a2"))), nil,
 		testutil.StatusOK(re), testutil.WithHeader(re, apiutil.XForwardedToMicroserviceHeader, "true"))
 	re.NoError(err)

--- a/tests/server/api/scatter_split_test.go
+++ b/tests/server/api/scatter_split_test.go
@@ -87,6 +87,19 @@ func (suite *scatterSplitSuite) checkSplitRegions(cluster *tests.TestCluster) {
 	err := testutil.CheckPostJSON(tests.TestDialClient, fmt.Sprintf("%s/regions/split", urlPrefix), []byte(body), checkOpt)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/handler/splitResponses"))
 	re.NoError(err)
+
+	for _, body := range []string{
+		`{"split_keys":"not-an-array"}`,
+		`{"split_keys":[1]}`,
+	} {
+		err = testutil.CheckPostJSON(
+			tests.TestDialClient,
+			fmt.Sprintf("%s/regions/split", urlPrefix),
+			[]byte(body),
+			testutil.Status(re, http.StatusBadRequest),
+		)
+		re.NoError(err)
+	}
 }
 
 func (suite *scatterSplitSuite) TestScatterRegions() {

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -206,12 +206,12 @@ func scanRegionCommandFunc(cmd *cobra.Command, _ []string) {
 			return
 		}
 
-		lastEndKey := regions.Regions[len(regions.Regions)-1].EndKey
-		if lastEndKey == "" {
+		lastEndKeyHex := regions.Regions[len(regions.Regions)-1].EndKey
+		if lastEndKeyHex == "" {
 			return
 		}
 
-		key, err = hex.DecodeString(lastEndKey)
+		key, err = hex.DecodeString(lastEndKeyHex)
 		if err != nil {
 			cmd.Println("Bad format region key: ", key)
 			return


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4399

### What is changed and how does it work?

```commit-message
Clarify variable names and comments for hex-encoded region keys.

This renames misleading raw key variables in region scheduling APIs and
schedule handlers to make it explicit that the request values are
hex-encoded key strings before they are decoded. It also documents API
response fields that expose hex-encoded keys and keeps all JSON fields and
HTTP parameters unchanged.

Validate the split_keys request field before decoding split keys so
malformed payloads return HTTP 400 instead of panicking.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation for the **regions/split** API: requests with malformed or unsupported `split_keys` formats now reliably return **HTTP 400**.

* **Refactor**
  * Updated scheduling and region API handling to consistently treat key-range inputs as hex-encoded values for clearer processing and messaging.

* **Documentation**
  * Added inline field annotations clarifying that `start_key` / `end_key` (and related fields) are hex-encoded.

* **Tests**
  * Added integration coverage for invalid `split_keys` payloads on split endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->