### PR TITLE
core, mcs: fix region heartbeat tracer panic on non-monotonic clock

### DIFF
--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 )
 
 var (
@@ -143,15 +142,6 @@ var tracerPool = &sync.Pool{
 	},
 }
 
-type saveCacheStats struct {
-	startTime              time.Time
-	lastCheckTime          time.Time
-	checkOverlapsDuration  time.Duration
-	validateRegionDuration time.Duration
-	setRegionDuration      time.Duration
-	updateSubTreeDuration  time.Duration
-}
-
 // RegionHeartbeatProcessTracer is used to trace the process of handling region heartbeat.
 type RegionHeartbeatProcessTracer interface {
 	// Begin starts the tracing.
@@ -178,8 +168,6 @@ type RegionHeartbeatProcessTracer interface {
 	OnCollectRegionStatsFinished()
 	// OnAllStageFinished will be called when all stages are finished.
 	OnAllStageFinished()
-	// LogFields returns the log fields.
-	LogFields() []zap.Field
 	// Release releases the tracer.
 	Release()
 }
@@ -227,22 +215,15 @@ func (*noopHeartbeatProcessTracer) OnCollectRegionStatsFinished() {}
 // OnAllStageFinished implements the RegionHeartbeatProcessTracer interface.
 func (*noopHeartbeatProcessTracer) OnAllStageFinished() {}
 
-// LogFields implements the RegionHeartbeatProcessTracer interface.
-func (*noopHeartbeatProcessTracer) LogFields() []zap.Field {
-	return nil
-}
-
 // Release implements the RegionHeartbeatProcessTracer interface.
 func (*noopHeartbeatProcessTracer) Release() {}
 
+// regionHeartbeatProcessTracer measures the duration of each region-heartbeat
+// processing stage and reports it to the breakdown metrics. It keeps a single
+// checkpoint: a stage's duration is the time elapsed since the previous stage
+// advanced the checkpoint.
 type regionHeartbeatProcessTracer struct {
-	startTime             time.Time
-	lastCheckTime         time.Time
-	preCheckDuration      time.Duration
-	asyncHotStatsDuration time.Duration
-	regionGuideDuration   time.Duration
-	saveCacheStats        saveCacheStats
-	OtherDuration         time.Duration
+	lastCheckTime time.Time
 }
 
 // NewHeartbeatProcessTracer returns a heartbeat process tracer.
@@ -252,116 +233,91 @@ func NewHeartbeatProcessTracer() RegionHeartbeatProcessTracer {
 
 // Begin implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) Begin() {
+	h.lastCheckTime = time.Now()
+}
+
+// measure records one processing stage: it reads the clock once, computes the
+// duration since the previous checkpoint, advances the checkpoint, and updates
+// the stage's duration-sum and count counters.
+//
+// A non-positive duration is not added to the sum counter. time.Now() normally
+// carries a monotonic reading, so two consecutive reads never go backwards; but
+// on some virtualized hosts the OS monotonic clock (CLOCK_MONOTONIC) can briefly
+// regress -- e.g. an unsynchronized TSC across vCPUs, or a live migration.
+// Without this guard the negative value would reach prometheus.Counter.Add,
+// which panics with "counter cannot decrease in value" and crashes pd-server.
+// Guarding turns that rare, external clock glitch into a negligibly
+// under-counted metric instead of a fatal panic.
+func (h *regionHeartbeatProcessTracer) measure(durationSum, count prometheus.Counter) {
 	now := time.Now()
-	h.startTime = now
+	duration := now.Sub(h.lastCheckTime)
 	h.lastCheckTime = now
+	if duration > 0 {
+		durationSum.Add(duration.Seconds())
+	}
+	count.Inc()
+}
+
+// resetCheckpoint starts a fresh measurement window at the current time. It is
+// used at the SaveCache boundaries, whose enclosed sub-stages are timed on their
+// own and should not be attributed to the surrounding stages.
+func (h *regionHeartbeatProcessTracer) resetCheckpoint() {
+	h.lastCheckTime = time.Now()
 }
 
 // OnPreCheckFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnPreCheckFinished() {
-	now := time.Now()
-	h.preCheckDuration = now.Sub(h.lastCheckTime)
-	h.lastCheckTime = now
-	preCheckDurationSum.Add(h.preCheckDuration.Seconds())
-	preCheckCount.Inc()
+	h.measure(preCheckDurationSum, preCheckCount)
 }
 
 // OnAsyncHotStatsFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnAsyncHotStatsFinished() {
-	now := time.Now()
-	h.asyncHotStatsDuration = now.Sub(h.lastCheckTime)
-	h.lastCheckTime = now
-	asyncHotStatsDurationSum.Add(h.preCheckDuration.Seconds())
-	asyncHotStatsCount.Inc()
+	h.measure(asyncHotStatsDurationSum, asyncHotStatsCount)
 }
 
 // OnRegionGuideFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnRegionGuideFinished() {
-	now := time.Now()
-	h.regionGuideDuration = now.Sub(h.lastCheckTime)
-	h.lastCheckTime = now
-	regionGuideDurationSum.Add(h.regionGuideDuration.Seconds())
-	regionGuideCount.Inc()
+	h.measure(regionGuideDurationSum, regionGuideCount)
 }
 
 // OnSaveCacheBegin implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnSaveCacheBegin() {
-	now := time.Now()
-	h.saveCacheStats.startTime = now
-	h.saveCacheStats.lastCheckTime = now
-	h.lastCheckTime = now
+	h.resetCheckpoint()
 }
 
 // OnSaveCacheFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnSaveCacheFinished() {
-	// update the outer checkpoint time
-	h.lastCheckTime = time.Now()
-}
-
-// OnCollectRegionStatsFinished implements the RegionHeartbeatProcessTracer interface.
-func (h *regionHeartbeatProcessTracer) OnCollectRegionStatsFinished() {
-	now := time.Now()
-	regionCollectDurationSum.Add(now.Sub(h.lastCheckTime).Seconds())
-	regionCollectCount.Inc()
-	h.lastCheckTime = now
+	h.resetCheckpoint()
 }
 
 // OnCheckOverlapsFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnCheckOverlapsFinished() {
-	now := time.Now()
-	h.saveCacheStats.checkOverlapsDuration = now.Sub(h.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	checkOverlapsDurationSum.Add(h.saveCacheStats.checkOverlapsDuration.Seconds())
-	checkOverlapsCount.Inc()
+	h.measure(checkOverlapsDurationSum, checkOverlapsCount)
 }
 
 // OnValidateRegionFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnValidateRegionFinished() {
-	now := time.Now()
-	h.saveCacheStats.validateRegionDuration = now.Sub(h.saveCacheStats.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	validateRegionDurationSum.Add(h.saveCacheStats.validateRegionDuration.Seconds())
-	validateRegionCount.Inc()
+	h.measure(validateRegionDurationSum, validateRegionCount)
 }
 
 // OnSetRegionFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnSetRegionFinished() {
-	now := time.Now()
-	h.saveCacheStats.setRegionDuration = now.Sub(h.saveCacheStats.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	setRegionDurationSum.Add(h.saveCacheStats.setRegionDuration.Seconds())
-	setRegionCount.Inc()
+	h.measure(setRegionDurationSum, setRegionCount)
 }
 
 // OnUpdateSubTreeFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnUpdateSubTreeFinished() {
-	now := time.Now()
-	h.saveCacheStats.updateSubTreeDuration = now.Sub(h.saveCacheStats.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	updateSubTreeDurationSum.Add(h.saveCacheStats.updateSubTreeDuration.Seconds())
-	updateSubTreeCount.Inc()
+	h.measure(updateSubTreeDurationSum, updateSubTreeCount)
+}
+
+// OnCollectRegionStatsFinished implements the RegionHeartbeatProcessTracer interface.
+func (h *regionHeartbeatProcessTracer) OnCollectRegionStatsFinished() {
+	h.measure(regionCollectDurationSum, regionCollectCount)
 }
 
 // OnAllStageFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnAllStageFinished() {
-	now := time.Now()
-	h.OtherDuration = now.Sub(h.lastCheckTime)
-	otherDurationSum.Add(h.OtherDuration.Seconds())
-	otherCount.Inc()
-}
-
-// LogFields implements the RegionHeartbeatProcessTracer interface.
-func (h *regionHeartbeatProcessTracer) LogFields() []zap.Field {
-	return []zap.Field{
-		zap.Duration("pre-check-duration", h.preCheckDuration),
-		zap.Duration("async-hot-stats-duration", h.asyncHotStatsDuration),
-		zap.Duration("region-guide-duration", h.regionGuideDuration),
-		zap.Duration("check-overlaps-duration", h.saveCacheStats.checkOverlapsDuration),
-		zap.Duration("validate-region-duration", h.saveCacheStats.validateRegionDuration),
-		zap.Duration("set-region-duration", h.saveCacheStats.setRegionDuration),
-		zap.Duration("update-sub-tree-duration", h.saveCacheStats.updateSubTreeDuration),
-		zap.Duration("other-duration", h.OtherDuration),
-	}
+	h.measure(otherDurationSum, otherCount)
 }
 
 // Release implements the RegionHeartbeatProcessTracer interface.

--- a/pkg/core/metrics_test.go
+++ b/pkg/core/metrics_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingStage couples a tracer stage method with the counters it feeds, so a
+// single table can drive the tests over every measuring stage uniformly.
+type recordingStage struct {
+	name   string
+	finish func(*regionHeartbeatProcessTracer)
+	sum    prometheus.Counter
+	count  prometheus.Counter
+}
+
+func recordingStages() []recordingStage {
+	return []recordingStage{
+		{"PreCheck", (*regionHeartbeatProcessTracer).OnPreCheckFinished, preCheckDurationSum, preCheckCount},
+		{"AsyncHotStats", (*regionHeartbeatProcessTracer).OnAsyncHotStatsFinished, asyncHotStatsDurationSum, asyncHotStatsCount},
+		{"RegionGuide", (*regionHeartbeatProcessTracer).OnRegionGuideFinished, regionGuideDurationSum, regionGuideCount},
+		{"CheckOverlaps", (*regionHeartbeatProcessTracer).OnCheckOverlapsFinished, checkOverlapsDurationSum, checkOverlapsCount},
+		{"ValidateRegion", (*regionHeartbeatProcessTracer).OnValidateRegionFinished, validateRegionDurationSum, validateRegionCount},
+		{"SetRegion", (*regionHeartbeatProcessTracer).OnSetRegionFinished, setRegionDurationSum, setRegionCount},
+		{"UpdateSubTree", (*regionHeartbeatProcessTracer).OnUpdateSubTreeFinished, updateSubTreeDurationSum, updateSubTreeCount},
+		{"CollectRegionStats", (*regionHeartbeatProcessTracer).OnCollectRegionStatsFinished, regionCollectDurationSum, regionCollectCount},
+		{"Other", (*regionHeartbeatProcessTracer).OnAllStageFinished, otherDurationSum, otherCount},
+	}
+}
+
+// TestRegionHeartbeatTracerToleratesNonMonotonicClock checks the tracer is
+// robust to a backwards jump of the OS monotonic clock, which can happen on
+// virtualized hosts (an unsynchronized TSC across vCPUs, or a live migration).
+// For every stage, a checkpoint left in the future must not make the stage panic
+// or push a negative value into its duration counter (prometheus.Counter.Add
+// panics on a negative value).
+func TestRegionHeartbeatTracerToleratesNonMonotonicClock(t *testing.T) {
+	re := require.New(t)
+	for _, s := range recordingStages() {
+		h := &regionHeartbeatProcessTracer{}
+		h.lastCheckTime = time.Now().Add(time.Hour) // the clock appears to run backwards
+		before := testutil.ToFloat64(s.sum)
+		re.NotPanics(func() { s.finish(h) }, s.name)
+		re.GreaterOrEqual(testutil.ToFloat64(s.sum), before, s.name) // the counter never decreases
+	}
+}
+
+// TestRegionHeartbeatTracerRecordsEachStageIndependently checks that every stage
+// reports the time spent in that stage -- and only that stage -- into its own
+// counters, exactly once. Each stage is given a distinct, controlled interval by
+// rewinding the checkpoint, then matched against its own sum and count counters.
+func TestRegionHeartbeatTracerRecordsEachStageIndependently(t *testing.T) {
+	re := require.New(t)
+	h := &regionHeartbeatProcessTracer{}
+	for i, s := range recordingStages() {
+		interval := time.Duration(i+1) * 100 * time.Millisecond // distinct per stage
+		sumBefore := testutil.ToFloat64(s.sum)
+		countBefore := testutil.ToFloat64(s.count)
+		// No real time is spent: rewinding the checkpoint makes the stage measure
+		// exactly `interval`.
+		h.lastCheckTime = time.Now().Add(-interval)
+		s.finish(h)
+		re.InDelta(interval.Seconds(), testutil.ToFloat64(s.sum)-sumBefore, 0.05, s.name)
+		re.Equal(1.0, testutil.ToFloat64(s.count)-countBefore, s.name)
+	}
+}

--- a/pkg/core/metrics_test.go
+++ b/pkg/core/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 TiKV Project Authors.
+// Copyright 2026 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -455,7 +455,12 @@ func (m *counterMetrics) add(consumption *rmpb.Consumption, controllerConfig *Co
 			m.SQLLayerRUMetrics.Add(sqlRU)
 			m.SQLCPUMetrics.Add(consumption.SqlLayerCpuTimeMs)
 		}
-		m.KvCPUMetrics.Add(consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs)
+		// A well-behaved client keeps TotalCpuTimeMs >= SqlLayerCpuTimeMs, but the
+		// values are reported by the client and not validated here. Guard against a
+		// negative KV CPU time so a malformed report cannot panic prometheus.Counter.Add.
+		if kvCPUTimeMs := consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs; kvCPUTimeMs > 0 {
+			m.KvCPUMetrics.Add(kvCPUTimeMs)
+		}
 	}
 	// RPC count info.
 	if consumption.KvReadRpcCount > 0 {

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -786,6 +786,7 @@ func (c *Cluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 	if c.persistConfig.GetScheduleConfig().EnableHeartbeatBreakdownMetrics {
 		tracer = core.NewHeartbeatProcessTracer()
 	}
+	defer tracer.Release()
 	var taskRunner, miscRunner, logRunner ratelimit.Runner
 	taskRunner, miscRunner, logRunner = syncRunner, syncRunner, syncRunner
 	if c.persistConfig.GetScheduleConfig().EnableHeartbeatConcurrentRunner {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -59,7 +59,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/schedule/types"
-	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/storage"
@@ -1160,10 +1159,6 @@ func TestRegionHeartbeat(t *testing.T) {
 		ctx.Tracer = tracer
 		re.NoError(cluster.processRegionHeartbeat(ctx, overlapRegion))
 		tracer.OnAllStageFinished()
-		re.Condition(func() bool {
-			fields := tracer.LogFields()
-			return slice.AllOf(fields, func(i int) bool { return fields[i].Integer > 0 })
-		}, "should have stats")
 		region = &metapb.Region{}
 		ok, err = storage.LoadRegion(regions[n-1].GetID(), region)
 		re.False(ok)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10901

### What is changed and how does it work?

On virtualized hosts the OS monotonic clock can briefly move backwards (an unsynchronized TSC across vCPUs, or a live migration). The region heartbeat breakdown tracer fed `now.Sub(lastCheckTime)` straight into prometheus counters, so a backwards jump produced a negative value; `prometheus.Counter.Add` panics on a negative value and crashed `pd-server`. The crash concentrated on the `"Other"` stage because that is the shortest window (with the concurrent runner the trailing work is async-enqueued), so the smallest clock jitter is enough to flip it negative.

The tracer is reworked around a single `measure()` primitive and a single checkpoint. `measure()` reads the clock once, advances the checkpoint, drops a non-positive delta (so the monotonic counters can never receive a negative value), and updates the stage's sum/count counters. Collapsing the duplicated per-stage blocks into this one primitive also clears up the problems that the duplication had bred:

- **Fixes an actual metric bug**: `OnAsyncHotStatsFinished` added `preCheckDuration` to the async-hot-stats sum counter (a copy-paste slip), so the `AsyncHotStatsDuration` series was reporting the pre-check timing rather than its own. The single primitive can only add the interval it just measured, so this can no longer happen.
- **Removes a latent checkpoint inconsistency**: a redundant second SaveCache checkpoint meant `OnCheckOverlapsFinished` read a different checkpoint variable than its sibling SaveCache stages. The two were set to the same instant at `OnSaveCacheBegin` and `OnCheckOverlapsFinished` runs first, so the value was correct in the current call order — but any measured stage later inserted before it would have made the two diverge and mis-measured the overlap check. The single checkpoint removes that footgun.
- **Drops dead code**: the unused `LogFields` method — and the per-stage duration fields it was the sole reader of — is removed; the breakdown durations already live in the counters.
- **Plugs a pooled-tracer leak**: the scheduling service's `HandleRegionHeartbeat` was missing `defer tracer.Release()`, so its tracers were taken from the pool but never returned. Added, matching the existing `server/cluster` path. The async heartbeat tasks (`CheckAndPutSubTree`, `Collect`, `HandleOverlaps`) do not capture the tracer, so releasing it on return is safe.

While auditing every `prometheus.Counter.Add` call site for the same negative-value hazard, one more unguarded spot turned up and is hardened in the same PR:

- `mcs/resourcemanager`: `KvCPUMetrics.Add(consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs)`. A well-behaved client keeps `TotalCpuTimeMs >= SqlLayerCpuTimeMs`, but those two fields are reported by the client and not validated server-side; a report with `SqlLayerCpuTimeMs > TotalCpuTimeMs` would feed a negative value into the counter and panic. The KV CPU time is now recorded only when it is positive, matching the surrounding `if consumption.X > 0` guards.

```commit-message
Rework the region heartbeat breakdown tracer around a single measure() primitive and a single checkpoint. measure() reads the clock, advances the checkpoint, drops a non-positive delta so the duration counters never receive a negative value (the OS monotonic clock can briefly regress on virtualized hosts, which previously made prometheus.Counter.Add panic and crash pd-server), and updates the stage's sum/count counters.

This also fixes the async-hot-stats stage recording the pre-check duration, removes a redundant SaveCache checkpoint, drops the unused LogFields method and its per-stage duration fields, and adds the missing defer tracer.Release() in the scheduling service's HandleRegionHeartbeat.
```

### Check List

Tests

- Unit test
- Manual test

Built `pd-server` from this branch, ran a `tiup playground` (nightly TiKV/TiDB) cluster, split a table into 200 regions and drove a TPC-C workload. All nine breakdown stages keep recording, every duration-sum stays non-negative, and `pd-server` stays up with no `"counter cannot decrease in value"` panic.

<img width="1912" height="618" alt="image" src="https://github.com/user-attachments/assets/ba36acad-cea2-4a37-a3e2-b63755ed534b" />


Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Fix a pd-server panic ("counter cannot decrease in value") raised by the region heartbeat breakdown metrics when the host's monotonic clock briefly moves backwards.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed KV CPU time metrics to prevent negative values from being recorded
  * Improved heartbeat process metrics reliability to gracefully handle clock anomalies

* **Tests**
  * Added comprehensive tests for heartbeat process metrics validation and clock robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
