### PR TITLE
core, mcs: guard prometheus counters against negative-value panics

### DIFF
--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -250,6 +250,25 @@ func NewHeartbeatProcessTracer() RegionHeartbeatProcessTracer {
 	return tracerPool.Get().(*regionHeartbeatProcessTracer)
 }
 
+// addDurationSum adds the duration (in seconds) to the counter, clamping
+// non-positive values to zero.
+//
+// The duration is derived from time.Now().Sub(...). Although Go's monotonic
+// clock is normally non-decreasing, on some virtualized hosts the underlying OS
+// monotonic clock (CLOCK_MONOTONIC, read via the vDSO) can briefly move
+// backwards, e.g. an unstable/unsynchronized TSC across vCPUs or after a live
+// migration. NTP/chrony does not prevent this: it disciplines CLOCK_REALTIME and
+// can only slew the rate of CLOCK_MONOTONIC, never step it backwards. A negative
+// duration passed to prometheus.Counter.Add panics ("counter cannot decrease in
+// value") and crashes pd-server. Clamping downgrades such a transient clock
+// glitch to an at-most negligibly under-counted metric.
+func addDurationSum(c prometheus.Counter, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	c.Add(d.Seconds())
+}
+
 // Begin implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) Begin() {
 	now := time.Now()
@@ -262,7 +281,7 @@ func (h *regionHeartbeatProcessTracer) OnPreCheckFinished() {
 	now := time.Now()
 	h.preCheckDuration = now.Sub(h.lastCheckTime)
 	h.lastCheckTime = now
-	preCheckDurationSum.Add(h.preCheckDuration.Seconds())
+	addDurationSum(preCheckDurationSum, h.preCheckDuration)
 	preCheckCount.Inc()
 }
 
@@ -271,7 +290,7 @@ func (h *regionHeartbeatProcessTracer) OnAsyncHotStatsFinished() {
 	now := time.Now()
 	h.asyncHotStatsDuration = now.Sub(h.lastCheckTime)
 	h.lastCheckTime = now
-	asyncHotStatsDurationSum.Add(h.preCheckDuration.Seconds())
+	addDurationSum(asyncHotStatsDurationSum, h.asyncHotStatsDuration)
 	asyncHotStatsCount.Inc()
 }
 
@@ -280,7 +299,7 @@ func (h *regionHeartbeatProcessTracer) OnRegionGuideFinished() {
 	now := time.Now()
 	h.regionGuideDuration = now.Sub(h.lastCheckTime)
 	h.lastCheckTime = now
-	regionGuideDurationSum.Add(h.regionGuideDuration.Seconds())
+	addDurationSum(regionGuideDurationSum, h.regionGuideDuration)
 	regionGuideCount.Inc()
 }
 
@@ -301,7 +320,7 @@ func (h *regionHeartbeatProcessTracer) OnSaveCacheFinished() {
 // OnCollectRegionStatsFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnCollectRegionStatsFinished() {
 	now := time.Now()
-	regionCollectDurationSum.Add(now.Sub(h.lastCheckTime).Seconds())
+	addDurationSum(regionCollectDurationSum, now.Sub(h.lastCheckTime))
 	regionCollectCount.Inc()
 	h.lastCheckTime = now
 }
@@ -309,9 +328,9 @@ func (h *regionHeartbeatProcessTracer) OnCollectRegionStatsFinished() {
 // OnCheckOverlapsFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnCheckOverlapsFinished() {
 	now := time.Now()
-	h.saveCacheStats.checkOverlapsDuration = now.Sub(h.lastCheckTime)
+	h.saveCacheStats.checkOverlapsDuration = now.Sub(h.saveCacheStats.lastCheckTime)
 	h.saveCacheStats.lastCheckTime = now
-	checkOverlapsDurationSum.Add(h.saveCacheStats.checkOverlapsDuration.Seconds())
+	addDurationSum(checkOverlapsDurationSum, h.saveCacheStats.checkOverlapsDuration)
 	checkOverlapsCount.Inc()
 }
 
@@ -320,7 +339,7 @@ func (h *regionHeartbeatProcessTracer) OnValidateRegionFinished() {
 	now := time.Now()
 	h.saveCacheStats.validateRegionDuration = now.Sub(h.saveCacheStats.lastCheckTime)
 	h.saveCacheStats.lastCheckTime = now
-	validateRegionDurationSum.Add(h.saveCacheStats.validateRegionDuration.Seconds())
+	addDurationSum(validateRegionDurationSum, h.saveCacheStats.validateRegionDuration)
 	validateRegionCount.Inc()
 }
 
@@ -329,7 +348,7 @@ func (h *regionHeartbeatProcessTracer) OnSetRegionFinished() {
 	now := time.Now()
 	h.saveCacheStats.setRegionDuration = now.Sub(h.saveCacheStats.lastCheckTime)
 	h.saveCacheStats.lastCheckTime = now
-	setRegionDurationSum.Add(h.saveCacheStats.setRegionDuration.Seconds())
+	addDurationSum(setRegionDurationSum, h.saveCacheStats.setRegionDuration)
 	setRegionCount.Inc()
 }
 
@@ -338,7 +357,7 @@ func (h *regionHeartbeatProcessTracer) OnUpdateSubTreeFinished() {
 	now := time.Now()
 	h.saveCacheStats.updateSubTreeDuration = now.Sub(h.saveCacheStats.lastCheckTime)
 	h.saveCacheStats.lastCheckTime = now
-	updateSubTreeDurationSum.Add(h.saveCacheStats.updateSubTreeDuration.Seconds())
+	addDurationSum(updateSubTreeDurationSum, h.saveCacheStats.updateSubTreeDuration)
 	updateSubTreeCount.Inc()
 }
 
@@ -346,7 +365,7 @@ func (h *regionHeartbeatProcessTracer) OnUpdateSubTreeFinished() {
 func (h *regionHeartbeatProcessTracer) OnAllStageFinished() {
 	now := time.Now()
 	h.OtherDuration = now.Sub(h.lastCheckTime)
-	otherDurationSum.Add(h.OtherDuration.Seconds())
+	addDurationSum(otherDurationSum, h.OtherDuration)
 	otherCount.Inc()
 }
 

--- a/pkg/core/metrics_test.go
+++ b/pkg/core/metrics_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddDurationSumClampsNegative ensures a negative duration never reaches
+// prometheus.Counter.Add (which panics on negative input).
+func TestAddDurationSumClampsNegative(t *testing.T) {
+	re := require.New(t)
+	c := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_add_duration_sum"})
+
+	re.NotPanics(func() {
+		addDurationSum(c, -time.Second)
+	})
+	re.Equal(float64(0), testCounterValue(c), "negative duration must not be added")
+
+	addDurationSum(c, time.Second)
+	re.Equal(float64(1), testCounterValue(c), "positive duration must be added")
+
+	addDurationSum(c, 0)
+	re.Equal(float64(1), testCounterValue(c), "zero duration must be a no-op")
+}
+
+// TestOnAllStageFinishedBackwardClock reproduces the original panic: when the OS
+// monotonic clock moves backwards, now.Sub(lastCheckTime) is negative. The tracer
+// stage callbacks must not crash pd-server in that case.
+func TestTracerStagesToleranceBackwardClock(t *testing.T) {
+	re := require.New(t)
+	// lastCheckTime in the future simulates a backward clock step between two
+	// time.Now() reads; the monotonic reading is preserved so Sub goes negative.
+	future := time.Now().Add(time.Hour)
+	h := &regionHeartbeatProcessTracer{
+		startTime:     future,
+		lastCheckTime: future,
+	}
+	h.saveCacheStats.startTime = future
+	h.saveCacheStats.lastCheckTime = future
+
+	re.NotPanics(func() {
+		h.OnPreCheckFinished()
+		h.OnAsyncHotStatsFinished()
+		h.OnRegionGuideFinished()
+		h.OnCheckOverlapsFinished()
+		h.OnValidateRegionFinished()
+		h.OnSetRegionFinished()
+		h.OnUpdateSubTreeFinished()
+		h.OnCollectRegionStatsFinished()
+		h.OnAllStageFinished()
+	})
+}
+
+func testCounterValue(c prometheus.Counter) float64 {
+	var m dto.Metric
+	if err := c.Write(&m); err != nil {
+		return -1
+	}
+	return m.GetCounter().GetValue()
+}

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -455,7 +455,13 @@ func (m *counterMetrics) add(consumption *rmpb.Consumption, controllerConfig *Co
 			m.SQLLayerRUMetrics.Add(sqlRU)
 			m.SQLCPUMetrics.Add(consumption.SqlLayerCpuTimeMs)
 		}
-		m.KvCPUMetrics.Add(consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs)
+		// TotalCpuTimeMs and SqlLayerCpuTimeMs are reported independently by the
+		// client, so accounting skew can make the SQL layer value exceed the total.
+		// A negative diff would panic prometheus.Counter.Add ("counter cannot
+		// decrease in value"), so only record a positive KV CPU time.
+		if kvCPUTimeMs := consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs; kvCPUTimeMs > 0 {
+			m.KvCPUMetrics.Add(kvCPUTimeMs)
+		}
 	}
 	// RPC count info.
 	if consumption.KvReadRpcCount > 0 {

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -87,6 +87,34 @@ func TestActiveRequestUnitMetricUsesV2ForOverriddenKeyspace(t *testing.T) {
 	re.Equal(float64(31), testutil.ToFloat64(metrics.ActiveRUMetrics))
 }
 
+func TestCounterMetricsAddToleratesNegativeKvCPUTime(t *testing.T) {
+	re := require.New(t)
+
+	const (
+		keyspaceName = "billing-neg-kvcpu-keyspace"
+		groupName    = "billing-neg-kvcpu-group"
+		keyspaceID   = uint32(303)
+	)
+
+	t.Cleanup(func() {
+		deleteLabelValues(keyspaceName, groupName, defaultTypeLabel)
+	})
+
+	metrics := newCounterMetrics(keyspaceName, groupName, defaultTypeLabel)
+	// SqlLayerCpuTimeMs exceeds TotalCpuTimeMs: the two are reported independently
+	// by the client, so accounting skew can make the KV CPU diff negative. It must
+	// not panic prometheus.Counter.Add.
+	re.NotPanics(func() {
+		metrics.add(&rmpb.Consumption{
+			TotalCpuTimeMs:    3,
+			SqlLayerCpuTimeMs: 5,
+		}, &ControllerConfig{
+			RequestUnit: RequestUnitConfig{CPUMsCost: 2},
+		}, keyspaceID)
+	})
+	re.Equal(float64(0), testutil.ToFloat64(metrics.KvCPUMetrics), "negative KV CPU time must not be recorded")
+}
+
 func TestMaxPerSecCostTracker(t *testing.T) {
 	re := require.New(t)
 	tracker := newMaxPerSecCostTracker("test", "test", defaultCollectIntervalSec)

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -786,6 +786,7 @@ func (c *Cluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 	if c.persistConfig.GetScheduleConfig().EnableHeartbeatBreakdownMetrics {
 		tracer = core.NewHeartbeatProcessTracer()
 	}
+	defer tracer.Release()
 	var taskRunner, miscRunner, logRunner ratelimit.Runner
 	taskRunner, miscRunner, logRunner = syncRunner, syncRunner, syncRunner
 	if c.persistConfig.GetScheduleConfig().EnableHeartbeatConcurrentRunner {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10901, ref #10897

### What is changed and how does it work?

`prometheus.Counter.Add` panics on negative input (`counter cannot decrease in value`), and that panic happens inside gRPC handlers with no recovery interceptor, so it crashes the whole `pd-server` process. This PR fixes the known crash and one more instance of the same anti-pattern.

**1. Region heartbeat breakdown metrics (the reported crash, #10901/#10897).**
The breakdown tracer feeds `time.Now().Sub(...)` durations straight into counters. On virtualized hosts the OS monotonic clock (`CLOCK_MONOTONIC`, read via the vDSO) can briefly move backwards — unstable/unsynchronized TSC across vCPUs, or after a live migration — producing a negative duration. The `"Other"` stage is hit most because, with the concurrent runner, its window is only tens of nanoseconds, the same order as the clock jitter. Added an `addDurationSum` helper that clamps non-positive durations to zero and used it at every duration-derived `Counter.Add` site.

**2. Resource manager KV CPU counter.**
`counterMetrics.add` fed `consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs` into the `KvCPUMetrics` counter. These two fields are reported independently by the client, so accounting skew can make the SQL-layer value exceed the total, producing a negative diff and the same panic. Now only recorded when the diff is positive.

```commit-message
Guard duration- and diff-derived prometheus.Counter.Add sites against negative
values so a transient clock glitch or client accounting skew can no longer
crash pd-server.

Also fix three latent bugs found in the heartbeat tracer:
- OnAsyncHotStatsFinished added preCheckDuration instead of asyncHotStatsDuration.
- OnCheckOverlapsFinished used h.lastCheckTime instead of the saveCache
  checkpoint h.saveCacheStats.lastCheckTime, inconsistent with the other
  SaveCache_* stages.
- The scheduling microservice HandleRegionHeartbeat never released the pooled
  tracer; add defer tracer.Release() to stop leaking pool objects.
```

### Check List

Tests

- Unit test

Side effects

- None

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Fix a panic ("counter cannot decrease in value") that could crash pd-server: during region heartbeat processing when the host's monotonic clock steps backwards (with enable-heartbeat-breakdown-metrics on), and in the resource manager when client-reported SQL CPU time exceeds total CPU time.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metrics stability by clamping negative/zero duration values before incrementing counters.
  * Prevented KV CPU metric panics when SQL CPU time temporarily exceeds total CPU time.
  * Ensured heartbeat tracers are properly released after handling a region heartbeat.
* **Tests**
  * Added coverage for negative duration tolerance and backward-clock tracer behavior.
  * Added a test ensuring KV CPU metrics stay at zero when CPU time accounting becomes skewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->