### PR TITLE
schedule: cancel operators before unsafe recovery

### DIFF
--- a/pkg/mock/mockcluster/mockcluster.go
+++ b/pkg/mock/mockcluster/mockcluster.go
@@ -116,6 +116,9 @@ func (mc *Cluster) GetSchedulerConfig() sc.SchedulerConfigProvider {
 	return mc.PersistOptions
 }
 
+// CancelAllOperators cancels all running and waiting operators.
+func (*Cluster) CancelAllOperators() {}
+
 // GetSharedConfig returns the shared config.
 func (mc *Cluster) GetSharedConfig() sc.SharedConfigProvider {
 	return mc.PersistOptions

--- a/pkg/schedule/checker/checker_controller.go
+++ b/pkg/schedule/checker/checker_controller.go
@@ -287,7 +287,9 @@ func (c *Controller) checkPriorityRegions() {
 			continue
 		}
 		if !c.opController.ExceedStoreLimit(ops...) {
-			c.opController.AddWaitingOperator(ops...)
+			c.opController.AddWaitingOperatorWithGuard(func() bool {
+				return !c.cluster.GetSharedConfig().IsSchedulingHalted()
+			}, operator.SchedulingHalted, ops...)
 		}
 	}
 	for _, v := range removes {
@@ -409,7 +411,9 @@ func (c *Controller) tryAddOperators(region *core.RegionInfo) {
 	}
 
 	if !c.opController.ExceedStoreLimit(ops...) {
-		c.opController.AddWaitingOperator(ops...)
+		c.opController.AddWaitingOperatorWithGuard(func() bool {
+			return !c.cluster.GetSharedConfig().IsSchedulingHalted()
+		}, operator.SchedulingHalted, ops...)
 		c.RemovePendingProcessedRegion(id)
 	} else {
 		c.AddPendingProcessedRegions(true, id)

--- a/pkg/schedule/checker/checker_controller.go
+++ b/pkg/schedule/checker/checker_controller.go
@@ -272,6 +272,10 @@ func (c *Controller) checkPendingProcessedRegions() {
 
 // checkPriorityRegions checks priority regions
 func (c *Controller) checkPriorityRegions() {
+	generation := c.opController.GetOperatorGeneration()
+	if c.cluster.IsSchedulingHalted() {
+		return
+	}
 	items := c.GetPriorityRegions()
 	removes := make([]uint64, 0)
 	priorityListGauge.Set(float64(len(items)))
@@ -287,9 +291,7 @@ func (c *Controller) checkPriorityRegions() {
 			continue
 		}
 		if !c.opController.ExceedStoreLimit(ops...) {
-			c.opController.AddWaitingOperatorWithGuard(func() bool {
-				return !c.cluster.GetSharedConfig().IsSchedulingHalted()
-			}, operator.SchedulingHalted, ops...)
+			c.opController.AddWaitingOperatorWithGeneration(generation, operator.SchedulingHalted, ops...)
 		}
 	}
 	for _, v := range removes {
@@ -400,6 +402,10 @@ func (c *Controller) tryAddOperators(region *core.RegionInfo) {
 		// the region could be recent split, continue to wait.
 		return
 	}
+	generation := c.opController.GetOperatorGeneration()
+	if c.cluster.IsSchedulingHalted() {
+		return
+	}
 	id := region.GetID()
 	if c.opController.GetOperator(id) != nil {
 		c.RemovePendingProcessedRegion(id)
@@ -411,9 +417,7 @@ func (c *Controller) tryAddOperators(region *core.RegionInfo) {
 	}
 
 	if !c.opController.ExceedStoreLimit(ops...) {
-		c.opController.AddWaitingOperatorWithGuard(func() bool {
-			return !c.cluster.GetSharedConfig().IsSchedulingHalted()
-		}, operator.SchedulingHalted, ops...)
+		c.opController.AddWaitingOperatorWithGeneration(generation, operator.SchedulingHalted, ops...)
 		c.RemovePendingProcessedRegion(id)
 	} else {
 		c.AddPendingProcessedRegions(true, id)

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -463,7 +463,9 @@ func (c *splitScatterController) dispatchSplitScatterRegions() {
 					zap.String("operator-desc", op.Desc()))
 				continue
 			}
-			if !c.opController.AddOperator(op) {
+			if !c.opController.AddOperatorWithGuard(func() bool {
+				return !c.cluster.GetSharedConfig().IsSchedulingHalted()
+			}, operator.SchedulingHalted, op) {
 				splitScatterDispatchAddOperatorFailedCounter.Inc()
 				c.delayPendingSplitScatter(pending)
 				log.Info("dispatch internal split scatter add operator failed",

--- a/pkg/schedule/checker/split_scatter.go
+++ b/pkg/schedule/checker/split_scatter.go
@@ -385,6 +385,10 @@ func (c *splitScatterController) recordSplitScatterBatch(sourceRegionID, sourceW
 }
 
 func (c *splitScatterController) dispatchSplitScatterRegions() {
+	generation := c.opController.GetOperatorGeneration()
+	if c.cluster.IsSchedulingHalted() {
+		return
+	}
 	now := time.Now()
 	if c.cleanupExpiredPendingSplitScatter() == 0 {
 		return
@@ -463,9 +467,7 @@ func (c *splitScatterController) dispatchSplitScatterRegions() {
 					zap.String("operator-desc", op.Desc()))
 				continue
 			}
-			if !c.opController.AddOperatorWithGuard(func() bool {
-				return !c.cluster.GetSharedConfig().IsSchedulingHalted()
-			}, operator.SchedulingHalted, op) {
+			if !c.opController.AddOperatorWithGeneration(generation, operator.SchedulingHalted, op) {
 				splitScatterDispatchAddOperatorFailedCounter.Inc()
 				c.delayPendingSplitScatter(pending)
 				log.Info("dispatch internal split scatter add operator failed",

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -118,7 +118,6 @@ type SharedConfigProvider interface {
 	IsWitnessAllowed() bool
 	IsPlacementRulesCacheEnabled() bool
 	SetHaltScheduling(bool, string)
-	IsSchedulingHalted() bool
 	GetHotRegionCacheHitsThreshold() int
 
 	// for test purpose

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -118,6 +118,7 @@ type SharedConfigProvider interface {
 	IsWitnessAllowed() bool
 	IsPlacementRulesCacheEnabled() bool
 	SetHaltScheduling(bool, string)
+	IsSchedulingHalted() bool
 	GetHotRegionCacheHitsThreshold() int
 
 	// for test purpose

--- a/pkg/schedule/hbstream/heartbeat_streams.go
+++ b/pkg/schedule/hbstream/heartbeat_streams.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -65,12 +64,6 @@ type streamUpdate struct {
 	stream  HeartbeatStream
 }
 
-type heartbeatMessage struct {
-	response        core.RegionHeartbeatResponse
-	scheduleCommand bool
-	scheduleEpoch   uint64
-}
-
 // HeartbeatStreams is the bridge of communication with TIKV instance.
 type HeartbeatStreams struct {
 	wg             sync.WaitGroup
@@ -78,13 +71,11 @@ type HeartbeatStreams struct {
 	hbStreamCancel context.CancelFunc
 	clusterID      uint64
 	streams        map[uint64]HeartbeatStream
-	msgCh          chan heartbeatMessage
+	msgCh          chan core.RegionHeartbeatResponse
 	streamCh       chan streamUpdate
 	storeInformer  core.StoreSetInformer
 	typ            string
 	needRun        bool // For test only.
-	scheduleEpoch  atomic.Uint64
-	scheduleSendMu sync.Mutex
 }
 
 // NewHeartbeatStreams creates a new HeartbeatStreams which enable background running by default.
@@ -105,7 +96,7 @@ func newHbStreams(ctx context.Context, typ string, storeInformer core.StoreSetIn
 		hbStreamCancel: hbStreamCancel,
 		clusterID:      keypath.ClusterID(),
 		streams:        make(map[uint64]HeartbeatStream),
-		msgCh:          make(chan heartbeatMessage, heartbeatChanCapacity),
+		msgCh:          make(chan core.RegionHeartbeatResponse, heartbeatChanCapacity),
 		streamCh:       make(chan streamUpdate, 1),
 		storeInformer:  storeInformer,
 		typ:            typ,
@@ -146,11 +137,7 @@ func (s *HeartbeatStreams) run() {
 		select {
 		case update := <-s.streamCh:
 			s.streams[update.storeID] = update.stream
-		case item := <-s.msgCh:
-			if s.isStaleScheduleCommand(item) {
-				continue
-			}
-			msg := item.response
+		case msg := <-s.msgCh:
 			storeID := msg.GetTargetPeer().GetStoreId()
 			storeLabel := strconv.FormatUint(storeID, 10)
 			store := s.storeInformer.GetStore(storeID)
@@ -163,11 +150,7 @@ func (s *HeartbeatStreams) run() {
 			}
 			storeAddress := store.GetAddress()
 			if stream, ok := s.streams[storeID]; ok {
-				sent, err := s.sendHeartbeatMessage(stream, item)
-				if !sent {
-					continue
-				}
-				if err != nil {
+				if err := stream.Send(msg); err != nil {
 					log.Warn("send heartbeat message fail",
 						zap.Uint64("region-id", msg.GetRegionId()), errs.ZapError(errs.ErrGRPCSend, err))
 					delete(s.streams, storeID)
@@ -208,47 +191,6 @@ func (s *HeartbeatStreams) run() {
 	}
 }
 
-func (s *HeartbeatStreams) sendHeartbeatMessage(stream HeartbeatStream, msg heartbeatMessage) (bool, error) {
-	if !msg.scheduleCommand {
-		return true, stream.Send(msg.response)
-	}
-	s.scheduleSendMu.Lock()
-	defer s.scheduleSendMu.Unlock()
-	if s.isStaleScheduleCommand(msg) {
-		return false, nil
-	}
-	return true, stream.Send(msg.response)
-}
-
-func (s *HeartbeatStreams) isStaleScheduleCommand(msg heartbeatMessage) bool {
-	return msg.scheduleCommand && msg.scheduleEpoch != s.scheduleEpoch.Load()
-}
-
-// ClearPendingScheduleCommands drops queued operator schedule commands.
-func (s *HeartbeatStreams) ClearPendingScheduleCommands() {
-	s.scheduleEpoch.Add(1)
-	kept := make([]heartbeatMessage, 0, len(s.msgCh))
-	for {
-		select {
-		case msg := <-s.msgCh:
-			if !msg.scheduleCommand {
-				kept = append(kept, msg)
-			}
-		default:
-			for _, msg := range kept {
-				select {
-				case s.msgCh <- msg:
-				case <-s.hbStreamCtx.Done():
-					return
-				}
-			}
-			s.scheduleSendMu.Lock()
-			s.scheduleSendMu.Unlock()
-			return
-		}
-	}
-}
-
 // Close closes background running.
 func (s *HeartbeatStreams) Close() {
 	s.hbStreamCancel()
@@ -269,17 +211,35 @@ func (s *HeartbeatStreams) BindStream(storeID uint64, stream HeartbeatStream) {
 
 // SendMsg sends a message to related store.
 func (s *HeartbeatStreams) SendMsg(region *core.RegionInfo, op *Operation) {
-	_ = s.enqueueMsg(region, op, false)
+	resp := s.prepareMessage(region, op)
+	if resp == nil {
+		return
+	}
+	select {
+	case s.msgCh <- resp:
+	case <-s.hbStreamCtx.Done():
+	}
 }
 
-// SendScheduleCommand sends an operator schedule command to related store.
+// SendScheduleCommand tries to enqueue an operator schedule command without blocking.
 func (s *HeartbeatStreams) SendScheduleCommand(region *core.RegionInfo, op *Operation) bool {
-	return s.enqueueMsg(region, op, true)
+	resp := s.prepareMessage(region, op)
+	if resp == nil {
+		return false
+	}
+	select {
+	case s.msgCh <- resp:
+		return true
+	case <-s.hbStreamCtx.Done():
+		return false
+	default:
+		return false
+	}
 }
 
-func (s *HeartbeatStreams) enqueueMsg(region *core.RegionInfo, op *Operation, scheduleCommand bool) bool {
+func (s *HeartbeatStreams) prepareMessage(region *core.RegionInfo, op *Operation) core.RegionHeartbeatResponse {
 	if region.GetLeader() == nil {
-		return false
+		return nil
 	}
 
 	// TODO: use generic
@@ -315,25 +275,7 @@ func (s *HeartbeatStreams) enqueueMsg(region *core.RegionInfo, op *Operation, sc
 		}
 	}
 
-	item := heartbeatMessage{response: resp, scheduleCommand: scheduleCommand}
-	if scheduleCommand {
-		item.scheduleEpoch = s.scheduleEpoch.Load()
-		select {
-		case s.msgCh <- item:
-			return true
-		case <-s.hbStreamCtx.Done():
-			return false
-		default:
-			return false
-		}
-	}
-
-	select {
-	case s.msgCh <- item:
-		return true
-	case <-s.hbStreamCtx.Done():
-		return false
-	}
+	return resp
 }
 
 // SendErr sends a error message to related store.
@@ -350,7 +292,7 @@ func (s *HeartbeatStreams) SendErr(errType pdpb.ErrorType, errMsg string, target
 	}
 
 	select {
-	case s.msgCh <- heartbeatMessage{response: msg}:
+	case s.msgCh <- msg:
 	case <-s.hbStreamCtx.Done():
 	}
 }

--- a/pkg/schedule/hbstream/heartbeat_streams.go
+++ b/pkg/schedule/hbstream/heartbeat_streams.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -64,6 +65,12 @@ type streamUpdate struct {
 	stream  HeartbeatStream
 }
 
+type heartbeatMessage struct {
+	response        core.RegionHeartbeatResponse
+	scheduleCommand bool
+	scheduleEpoch   uint64
+}
+
 // HeartbeatStreams is the bridge of communication with TIKV instance.
 type HeartbeatStreams struct {
 	wg             sync.WaitGroup
@@ -71,11 +78,13 @@ type HeartbeatStreams struct {
 	hbStreamCancel context.CancelFunc
 	clusterID      uint64
 	streams        map[uint64]HeartbeatStream
-	msgCh          chan core.RegionHeartbeatResponse
+	msgCh          chan heartbeatMessage
 	streamCh       chan streamUpdate
 	storeInformer  core.StoreSetInformer
 	typ            string
 	needRun        bool // For test only.
+	scheduleEpoch  atomic.Uint64
+	scheduleSendMu sync.Mutex
 }
 
 // NewHeartbeatStreams creates a new HeartbeatStreams which enable background running by default.
@@ -96,7 +105,7 @@ func newHbStreams(ctx context.Context, typ string, storeInformer core.StoreSetIn
 		hbStreamCancel: hbStreamCancel,
 		clusterID:      keypath.ClusterID(),
 		streams:        make(map[uint64]HeartbeatStream),
-		msgCh:          make(chan core.RegionHeartbeatResponse, heartbeatChanCapacity),
+		msgCh:          make(chan heartbeatMessage, heartbeatChanCapacity),
 		streamCh:       make(chan streamUpdate, 1),
 		storeInformer:  storeInformer,
 		typ:            typ,
@@ -137,7 +146,11 @@ func (s *HeartbeatStreams) run() {
 		select {
 		case update := <-s.streamCh:
 			s.streams[update.storeID] = update.stream
-		case msg := <-s.msgCh:
+		case item := <-s.msgCh:
+			if s.isStaleScheduleCommand(item) {
+				continue
+			}
+			msg := item.response
 			storeID := msg.GetTargetPeer().GetStoreId()
 			storeLabel := strconv.FormatUint(storeID, 10)
 			store := s.storeInformer.GetStore(storeID)
@@ -150,7 +163,11 @@ func (s *HeartbeatStreams) run() {
 			}
 			storeAddress := store.GetAddress()
 			if stream, ok := s.streams[storeID]; ok {
-				if err := stream.Send(msg); err != nil {
+				sent, err := s.sendHeartbeatMessage(stream, item)
+				if !sent {
+					continue
+				}
+				if err != nil {
 					log.Warn("send heartbeat message fail",
 						zap.Uint64("region-id", msg.GetRegionId()), errs.ZapError(errs.ErrGRPCSend, err))
 					delete(s.streams, storeID)
@@ -191,6 +208,47 @@ func (s *HeartbeatStreams) run() {
 	}
 }
 
+func (s *HeartbeatStreams) sendHeartbeatMessage(stream HeartbeatStream, msg heartbeatMessage) (bool, error) {
+	if !msg.scheduleCommand {
+		return true, stream.Send(msg.response)
+	}
+	s.scheduleSendMu.Lock()
+	defer s.scheduleSendMu.Unlock()
+	if s.isStaleScheduleCommand(msg) {
+		return false, nil
+	}
+	return true, stream.Send(msg.response)
+}
+
+func (s *HeartbeatStreams) isStaleScheduleCommand(msg heartbeatMessage) bool {
+	return msg.scheduleCommand && msg.scheduleEpoch != s.scheduleEpoch.Load()
+}
+
+// ClearPendingScheduleCommands drops queued operator schedule commands.
+func (s *HeartbeatStreams) ClearPendingScheduleCommands() {
+	s.scheduleEpoch.Add(1)
+	kept := make([]heartbeatMessage, 0, len(s.msgCh))
+	for {
+		select {
+		case msg := <-s.msgCh:
+			if !msg.scheduleCommand {
+				kept = append(kept, msg)
+			}
+		default:
+			for _, msg := range kept {
+				select {
+				case s.msgCh <- msg:
+				case <-s.hbStreamCtx.Done():
+					return
+				}
+			}
+			s.scheduleSendMu.Lock()
+			s.scheduleSendMu.Unlock()
+			return
+		}
+	}
+}
+
 // Close closes background running.
 func (s *HeartbeatStreams) Close() {
 	s.hbStreamCancel()
@@ -211,8 +269,17 @@ func (s *HeartbeatStreams) BindStream(storeID uint64, stream HeartbeatStream) {
 
 // SendMsg sends a message to related store.
 func (s *HeartbeatStreams) SendMsg(region *core.RegionInfo, op *Operation) {
+	_ = s.enqueueMsg(region, op, false)
+}
+
+// SendScheduleCommand sends an operator schedule command to related store.
+func (s *HeartbeatStreams) SendScheduleCommand(region *core.RegionInfo, op *Operation) bool {
+	return s.enqueueMsg(region, op, true)
+}
+
+func (s *HeartbeatStreams) enqueueMsg(region *core.RegionInfo, op *Operation, scheduleCommand bool) bool {
 	if region.GetLeader() == nil {
-		return
+		return false
 	}
 
 	// TODO: use generic
@@ -248,9 +315,24 @@ func (s *HeartbeatStreams) SendMsg(region *core.RegionInfo, op *Operation) {
 		}
 	}
 
+	item := heartbeatMessage{response: resp, scheduleCommand: scheduleCommand}
+	if scheduleCommand {
+		item.scheduleEpoch = s.scheduleEpoch.Load()
+		select {
+		case s.msgCh <- item:
+			return true
+		case <-s.hbStreamCtx.Done():
+			return false
+		default:
+			return false
+		}
+	}
+
 	select {
-	case s.msgCh <- resp:
+	case s.msgCh <- item:
+		return true
 	case <-s.hbStreamCtx.Done():
+		return false
 	}
 }
 
@@ -268,7 +350,7 @@ func (s *HeartbeatStreams) SendErr(errType pdpb.ErrorType, errMsg string, target
 	}
 
 	select {
-	case s.msgCh <- msg:
+	case s.msgCh <- heartbeatMessage{response: msg}:
 	case <-s.hbStreamCtx.Done():
 	}
 }

--- a/pkg/schedule/operator/operator.go
+++ b/pkg/schedule/operator/operator.go
@@ -51,6 +51,8 @@ var (
 	AdminStop CancelReasonType = "admin stop"
 	// UnsafeRecovery is the cancel reason when the operator is stopped by unsafe recovery.
 	UnsafeRecovery CancelReasonType = "unsafe recovery"
+	// SchedulingHalted is the cancel reason when scheduling is halted.
+	SchedulingHalted CancelReasonType = "scheduling halted"
 	// NotInRunningState is the cancel reason when the operator is not in running state.
 	NotInRunningState CancelReasonType = "not in running state"
 	// Timeout is the cancel reason when the operator is timeout.

--- a/pkg/schedule/operator/operator.go
+++ b/pkg/schedule/operator/operator.go
@@ -49,6 +49,8 @@ var (
 	AlreadyExist CancelReasonType = "already exist"
 	// AdminStop is the cancel reason when the operator is stopped by admin.
 	AdminStop CancelReasonType = "admin stop"
+	// UnsafeRecovery is the cancel reason when the operator is stopped by unsafe recovery.
+	UnsafeRecovery CancelReasonType = "unsafe recovery"
 	// NotInRunningState is the cancel reason when the operator is not in running state.
 	NotInRunningState CancelReasonType = "not in running state"
 	// Timeout is the cancel reason when the operator is timeout.

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -272,6 +272,9 @@ func (oc *Controller) pollNeedDispatchRegion() (r *core.RegionInfo, next bool) {
 		return nil, true
 	}
 	op := opi.(*Operator)
+	if op != item.op {
+		return nil, true
+	}
 	// Check the operator lightly. It cant't dispatch the op for some scenario.
 	var reason CancelReasonType
 	r, reason = oc.checkOperatorLightly(op)
@@ -702,6 +705,7 @@ func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 		}
 		oc.buryOperator(op)
 	}
+	oc.opNotifierQueue.clear()
 	oc.dispatchWg.Wait()
 }
 

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -89,8 +90,9 @@ type Controller struct {
 	hbStreams *hbstream.HeartbeatStreams
 
 	// operatorLock serializes bulk cancellation with operator addition, promotion,
-	// and dispatch registration.
-	operatorLock syncutil.Mutex
+	// and the final dispatch enqueue.
+	operatorLock       syncutil.Mutex
+	operatorGeneration atomic.Uint64
 
 	// fast path, TTLUint64 is safe for concurrent.
 	fastOperators *cache.TTLUint64
@@ -325,12 +327,17 @@ func (oc *Controller) AddWaitingOperator(ops ...*Operator) int {
 	return oc.addWaitingOperatorLocked(ops...)
 }
 
-// AddWaitingOperatorWithGuard adds waiting operators if the guard still passes
-// while the operator lock is held.
-func (oc *Controller) AddWaitingOperatorWithGuard(guard func() bool, reason CancelReasonType, ops ...*Operator) int {
+// GetOperatorGeneration returns the current bulk-cancellation generation.
+func (oc *Controller) GetOperatorGeneration() uint64 {
+	return oc.operatorGeneration.Load()
+}
+
+// AddWaitingOperatorWithGeneration adds waiting operators if no bulk
+// cancellation has happened since generation was captured.
+func (oc *Controller) AddWaitingOperatorWithGeneration(generation uint64, reason CancelReasonType, ops ...*Operator) int {
 	oc.operatorLock.Lock()
 	defer oc.operatorLock.Unlock()
-	if guard != nil && !guard() {
+	if generation != oc.operatorGeneration.Load() {
 		oc.cancelAndBuryCreatedOperators(reason, ops...)
 		return 0
 	}
@@ -400,12 +407,12 @@ func (oc *Controller) AddOperator(ops ...*Operator) bool {
 	return oc.addOperatorLocked(ops...)
 }
 
-// AddOperatorWithGuard adds operators if the guard still passes while the
-// operator lock is held.
-func (oc *Controller) AddOperatorWithGuard(guard func() bool, reason CancelReasonType, ops ...*Operator) bool {
+// AddOperatorWithGeneration adds operators if no bulk cancellation has
+// happened since generation was captured.
+func (oc *Controller) AddOperatorWithGeneration(generation uint64, reason CancelReasonType, ops ...*Operator) bool {
 	oc.operatorLock.Lock()
 	defer oc.operatorLock.Unlock()
-	if guard != nil && !guard() {
+	if generation != oc.operatorGeneration.Load() {
 		oc.cancelAndBuryCreatedOperators(reason, ops...)
 		return false
 	}
@@ -713,6 +720,7 @@ func (oc *Controller) cancelAndBuryCreatedOperators(reason CancelReasonType, ops
 func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 	oc.operatorLock.Lock()
 	defer oc.operatorLock.Unlock()
+	oc.operatorGeneration.Add(1)
 	removed := oc.removeOperatorsWithoutBury()
 	oc.cancelAndBuryOperators(removed, reasons...)
 
@@ -742,16 +750,15 @@ func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 		oc.buryOperator(op)
 	}
 	oc.opNotifierQueue.clear()
-	if oc.hbStreams != nil {
-		oc.hbStreams.ClearPendingScheduleCommands()
-	}
 }
 
 func (oc *Controller) removeOperatorsWithoutBury() []*Operator {
 	var removed []*Operator
 	oc.operators.Range(func(regionID, value any) bool {
 		op := value.(*Operator)
-		oc.operators.Delete(regionID)
+		if !oc.operators.CompareAndDelete(regionID, op) {
+			return true
+		}
 		oc.counts.dec(op.SchedulerKind())
 		operatorCounter.WithLabelValues(op.Desc(), "remove").Inc()
 		oc.ack(op)

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -88,6 +88,10 @@ type Controller struct {
 	cluster   *core.BasicCluster
 	hbStreams *hbstream.HeartbeatStreams
 
+	// operatorLock serializes bulk cancellation with operator addition, promotion,
+	// and active push queue updates.
+	operatorLock syncutil.Mutex
+
 	// fast path, TTLUint64 is safe for concurrent.
 	fastOperators *cache.TTLUint64
 
@@ -255,10 +259,13 @@ func getNextPushOperatorTime(step OpStep, now time.Time) time.Time {
 // "next" is true to indicate that it may exist in next attempt,
 // and false is the end for the poll.
 func (oc *Controller) pollNeedDispatchRegion() (r *core.RegionInfo, next bool) {
-	if oc.opNotifierQueue.len() == 0 {
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+
+	item, ok := oc.opNotifierQueue.pop()
+	if !ok || item == nil || item.op == nil {
 		return nil, false
 	}
-	item, _ := oc.opNotifierQueue.pop()
 	regionID := item.op.RegionID()
 	opi, ok := oc.operators.Load(regionID)
 	if !ok || opi.(*Operator) == nil {
@@ -312,6 +319,12 @@ func (oc *Controller) PushOperators(recordOpStepWithTTL func(regionID uint64)) {
 
 // AddWaitingOperator adds operators to waiting operators.
 func (oc *Controller) AddWaitingOperator(ops ...*Operator) int {
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	return oc.addWaitingOperatorLocked(ops...)
+}
+
+func (oc *Controller) addWaitingOperatorLocked(ops ...*Operator) int {
 	added := 0
 	needPromoted := 0
 
@@ -362,13 +375,19 @@ func (oc *Controller) AddWaitingOperator(ops ...*Operator) int {
 	}
 	operatorCounter.WithLabelValues(ops[0].Desc(), "promote-add").Add(float64(needPromoted))
 	for range needPromoted {
-		oc.PromoteWaitingOperator()
+		oc.promoteWaitingOperatorLocked()
 	}
 	return added
 }
 
 // AddOperator adds operators to the running operators.
 func (oc *Controller) AddOperator(ops ...*Operator) bool {
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	return oc.addOperatorLocked(ops...)
+}
+
+func (oc *Controller) addOperatorLocked(ops ...*Operator) bool {
 	// note: checkAddOperator uses false param for `isPromoting`.
 	// This is used to keep check logic before fixing issue #4946,
 	// but maybe user want to add operator when waiting queue is busy
@@ -397,6 +416,12 @@ func (oc *Controller) AddOperator(ops ...*Operator) bool {
 
 // PromoteWaitingOperator promotes operators from waiting operators.
 func (oc *Controller) PromoteWaitingOperator() {
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	oc.promoteWaitingOperatorLocked()
+}
+
+func (oc *Controller) promoteWaitingOperatorLocked() {
 	var ops []*Operator
 	for {
 		// GetOperator returns one operator or two merge operators
@@ -632,6 +657,12 @@ func (oc *Controller) ack(op *Operator) {
 
 // RemoveOperators removes all operators from the running operators.
 func (oc *Controller) RemoveOperators(reasons ...CancelReasonType) {
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	oc.removeOperatorsLocked(reasons...)
+}
+
+func (oc *Controller) removeOperatorsLocked(reasons ...CancelReasonType) {
 	removed := oc.removeOperatorsWithoutBury()
 	var cancelReason CancelReasonType
 	if len(reasons) > 0 {
@@ -650,7 +681,9 @@ func (oc *Controller) RemoveOperators(reasons ...CancelReasonType) {
 
 // CancelAllOperators cancels all running and waiting operators and clears pending notifications.
 func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
-	oc.RemoveOperators(reasons...)
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	oc.removeOperatorsLocked(reasons...)
 
 	var cancelReason CancelReasonType
 	if len(reasons) > 0 {

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -88,8 +88,7 @@ type Controller struct {
 	cluster   *core.BasicCluster
 	hbStreams *hbstream.HeartbeatStreams
 
-	// operatorLock serializes bulk cancellation with operator addition, promotion,
-	// and active push queue updates.
+	// operatorLock serializes bulk cancellation with operator addition and promotion.
 	operatorLock syncutil.Mutex
 
 	// fast path, TTLUint64 is safe for concurrent.
@@ -259,9 +258,6 @@ func getNextPushOperatorTime(step OpStep, now time.Time) time.Time {
 // "next" is true to indicate that it may exist in next attempt,
 // and false is the end for the poll.
 func (oc *Controller) pollNeedDispatchRegion() (r *core.RegionInfo, next bool) {
-	oc.operatorLock.Lock()
-	defer oc.operatorLock.Unlock()
-
 	item, ok := oc.opNotifierQueue.pop()
 	if !ok || item == nil || item.op == nil {
 		return nil, false
@@ -657,18 +653,16 @@ func (oc *Controller) ack(op *Operator) {
 
 // RemoveOperators removes all operators from the running operators.
 func (oc *Controller) RemoveOperators(reasons ...CancelReasonType) {
-	oc.operatorLock.Lock()
-	defer oc.operatorLock.Unlock()
-	oc.removeOperatorsLocked(reasons...)
+	removed := oc.removeOperatorsWithoutBury()
+	oc.cancelAndBuryOperators(removed, reasons...)
 }
 
-func (oc *Controller) removeOperatorsLocked(reasons ...CancelReasonType) {
-	removed := oc.removeOperatorsWithoutBury()
+func (oc *Controller) cancelAndBuryOperators(ops []*Operator, reasons ...CancelReasonType) {
 	var cancelReason CancelReasonType
 	if len(reasons) > 0 {
 		cancelReason = reasons[0]
 	}
-	for _, op := range removed {
+	for _, op := range ops {
 		if op.Cancel(cancelReason) {
 			log.Info("operator removed",
 				zap.Uint64("region-id", op.RegionID()),
@@ -679,11 +673,12 @@ func (oc *Controller) removeOperatorsLocked(reasons ...CancelReasonType) {
 	}
 }
 
-// CancelAllOperators cancels all running and waiting operators and clears pending notifications.
+// CancelAllOperators cancels all running and waiting operators.
 func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 	oc.operatorLock.Lock()
 	defer oc.operatorLock.Unlock()
-	oc.removeOperatorsLocked(reasons...)
+	removed := oc.removeOperatorsWithoutBury()
+	oc.cancelAndBuryOperators(removed, reasons...)
 
 	var cancelReason CancelReasonType
 	if len(reasons) > 0 {
@@ -703,7 +698,6 @@ func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 		}
 		oc.buryOperator(op)
 	}
-	oc.opNotifierQueue.clear()
 }
 
 func (oc *Controller) removeOperatorsWithoutBury() []*Operator {

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -167,7 +167,8 @@ func (oc *Controller) Dispatch(region *core.RegionInfo, source string, recordOpS
 			if source == DispatchFromHeartBeat && oc.checkStaleOperator(op, step, region) {
 				return
 			}
-			oc.SendScheduleCommand(region, step, source)
+			failpoint.InjectCall("cancelOperatorBeforeDispatch")
+			oc.sendScheduleCommandIfCurrent(region, op, step, source)
 		case SUCCESS:
 			if op.ContainNonWitnessStep() {
 				recordOpStepWithTTL(op.RegionID())
@@ -872,6 +873,16 @@ func (oc *Controller) GetOperatorsOfKind(mask OpKind) []*Operator {
 			return true
 		})
 	return operators
+}
+
+func (oc *Controller) sendScheduleCommandIfCurrent(region *core.RegionInfo, op *Operator, step OpStep, source string) {
+	// Keep the final current-operator check and send serialized with bulk cancellation.
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	if oc.GetOperator(region.GetID()) != op || op.Status() != STARTED {
+		return
+	}
+	oc.SendScheduleCommand(region, step, source)
 }
 
 // SendScheduleCommand sends a command to the region.

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -91,7 +91,6 @@ type Controller struct {
 	// operatorLock serializes bulk cancellation with operator addition, promotion,
 	// and dispatch registration.
 	operatorLock syncutil.Mutex
-	dispatchWg   *sync.WaitGroup
 
 	// fast path, TTLUint64 is safe for concurrent.
 	fastOperators *cache.TTLUint64
@@ -118,7 +117,6 @@ func NewController(ctx context.Context, cluster *core.BasicCluster, config confi
 		cluster:         cluster,
 		config:          config,
 		hbStreams:       hbStreams,
-		dispatchWg:      &sync.WaitGroup{},
 		fastOperators:   cache.NewIDTTL(ctx, time.Minute, FastOperatorFinishTime),
 		opNotifierQueue: newConcurrentHeapOpQueue(),
 
@@ -327,6 +325,18 @@ func (oc *Controller) AddWaitingOperator(ops ...*Operator) int {
 	return oc.addWaitingOperatorLocked(ops...)
 }
 
+// AddWaitingOperatorWithGuard adds waiting operators if the guard still passes
+// while the operator lock is held.
+func (oc *Controller) AddWaitingOperatorWithGuard(guard func() bool, reason CancelReasonType, ops ...*Operator) int {
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	if guard != nil && !guard() {
+		oc.cancelAndBuryCreatedOperators(reason, ops...)
+		return 0
+	}
+	return oc.addWaitingOperatorLocked(ops...)
+}
+
 func (oc *Controller) addWaitingOperatorLocked(ops ...*Operator) int {
 	added := 0
 	needPromoted := 0
@@ -387,6 +397,18 @@ func (oc *Controller) addWaitingOperatorLocked(ops ...*Operator) int {
 func (oc *Controller) AddOperator(ops ...*Operator) bool {
 	oc.operatorLock.Lock()
 	defer oc.operatorLock.Unlock()
+	return oc.addOperatorLocked(ops...)
+}
+
+// AddOperatorWithGuard adds operators if the guard still passes while the
+// operator lock is held.
+func (oc *Controller) AddOperatorWithGuard(guard func() bool, reason CancelReasonType, ops ...*Operator) bool {
+	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
+	if guard != nil && !guard() {
+		oc.cancelAndBuryCreatedOperators(reason, ops...)
+		return false
+	}
 	return oc.addOperatorLocked(ops...)
 }
 
@@ -680,6 +702,13 @@ func (oc *Controller) cancelAndBuryOperators(ops []*Operator, reasons ...CancelR
 	}
 }
 
+func (oc *Controller) cancelAndBuryCreatedOperators(reason CancelReasonType, ops ...*Operator) {
+	for _, op := range ops {
+		_ = op.Cancel(reason)
+		oc.buryOperator(op)
+	}
+}
+
 // CancelAllOperators cancels all running and waiting operators.
 func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 	oc.operatorLock.Lock()
@@ -691,7 +720,14 @@ func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 	if len(reasons) > 0 {
 		cancelReason = reasons[0]
 	}
-	waitingOps := oc.wop.Drain()
+	var waitingOps []*Operator
+	for {
+		ops := oc.wop.GetOperator()
+		if ops == nil {
+			break
+		}
+		waitingOps = append(waitingOps, ops...)
+	}
 	oc.wopStatus.reset()
 	for _, op := range waitingOps {
 		if op == nil || op.IsEnd() {
@@ -706,7 +742,9 @@ func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
 		oc.buryOperator(op)
 	}
 	oc.opNotifierQueue.clear()
-	oc.dispatchWg.Wait()
+	if oc.hbStreams != nil {
+		oc.hbStreams.ClearPendingScheduleCommands()
+	}
 }
 
 func (oc *Controller) removeOperatorsWithoutBury() []*Operator {
@@ -885,13 +923,10 @@ func (oc *Controller) GetOperatorsOfKind(mask OpKind) []*Operator {
 
 func (oc *Controller) sendScheduleCommandIfCurrent(region *core.RegionInfo, op *Operator, step OpStep, source string) {
 	oc.operatorLock.Lock()
+	defer oc.operatorLock.Unlock()
 	if oc.GetOperator(region.GetID()) != op || op.Status() != STARTED {
-		oc.operatorLock.Unlock()
 		return
 	}
-	oc.dispatchWg.Add(1)
-	oc.operatorLock.Unlock()
-	defer oc.dispatchWg.Done()
 	oc.SendScheduleCommand(region, step, source)
 }
 
@@ -907,7 +942,12 @@ func (oc *Controller) SendScheduleCommand(region *core.RegionInfo, step OpStep, 
 	if cmd == nil {
 		return
 	}
-	oc.hbStreams.SendMsg(region, cmd)
+	if !oc.hbStreams.SendScheduleCommand(region, cmd) {
+		log.Debug("drop schedule command because heartbeat stream channel is full or closed",
+			zap.Uint64("region-id", region.GetID()),
+			zap.Stringer("step", step),
+			zap.String("source", source))
+	}
 }
 
 func (oc *Controller) pushFastOperator(op *Operator) {

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -648,6 +648,31 @@ func (oc *Controller) RemoveOperators(reasons ...CancelReasonType) {
 	}
 }
 
+// CancelAllOperators cancels all running and waiting operators and clears pending notifications.
+func (oc *Controller) CancelAllOperators(reasons ...CancelReasonType) {
+	oc.RemoveOperators(reasons...)
+
+	var cancelReason CancelReasonType
+	if len(reasons) > 0 {
+		cancelReason = reasons[0]
+	}
+	waitingOps := oc.wop.Drain()
+	oc.wopStatus.reset()
+	for _, op := range waitingOps {
+		if op == nil || op.IsEnd() {
+			continue
+		}
+		if op.Cancel(cancelReason) {
+			log.Info("waiting operator removed",
+				zap.Uint64("region-id", op.RegionID()),
+				zap.Duration("lives", op.ElapsedTime()),
+				zap.Reflect("operator", op))
+		}
+		oc.buryOperator(op)
+	}
+	oc.opNotifierQueue.clear()
+}
+
 func (oc *Controller) removeOperatorsWithoutBury() []*Operator {
 	var removed []*Operator
 	oc.operators.Range(func(regionID, value any) bool {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -977,8 +977,6 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 	re.NotNil(controller.GetOperator(runningOp.RegionID()))
 	re.Equal(uint64(1), controller.OperatorCount(OpLeader))
 	re.Equal(1, controller.opNotifierQueue.len())
-	stream.SendMsg(cluster.GetRegion(1), &hbstream.Operation{ChangeSplit: &pdpb.ChangeSplit{AutoSplitEnabled: false}})
-	re.Equal(2, stream.MsgLength())
 
 	waitingOp1 := newTransferLeaderOp(2)
 	waitingOp2 := newTransferLeaderOp(3)
@@ -1007,8 +1005,6 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 	region, next := controller.pollNeedDispatchRegion()
 	re.Nil(region)
 	re.False(next)
-	re.Equal(1, stream.MsgLength())
-	re.NoError(stream.Drain(1))
 
 	newWaitingOp := newTransferLeaderOp(2)
 	added := controller.AddWaitingOperator(newWaitingOp)
@@ -1084,6 +1080,42 @@ func (suite *operatorControllerTestSuite) TestPollNeedDispatchRegionDropsStaleNo
 	re.Equal(0, controller.opNotifierQueue.len())
 }
 
+func (suite *operatorControllerTestSuite) TestCancelAllOperatorsRejectsStaleGeneration() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLeaderStore(1, 3)
+	cluster.AddLeaderStore(2, 0)
+	for i := uint64(1); i <= 3; i++ {
+		cluster.AddLeaderRegion(i, 1, 2)
+	}
+
+	newTransferLeaderOp := func(regionID uint64) *Operator {
+		region := cluster.GetRegion(regionID)
+		return NewTestOperator(regionID, region.GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+	}
+
+	generation := controller.GetOperatorGeneration()
+	controller.CancelAllOperators(AdminStop)
+
+	waitingOp := newTransferLeaderOp(1)
+	re.Zero(controller.AddWaitingOperatorWithGeneration(generation, SchedulingHalted, waitingOp))
+	directOp := newTransferLeaderOp(2)
+	re.False(controller.AddOperatorWithGeneration(generation, SchedulingHalted, directOp))
+	for _, op := range []*Operator{waitingOp, directOp} {
+		re.Equal(CANCELED, op.Status())
+		reason, ok := op.GetAdditionalInfo(cancelReason)
+		re.True(ok)
+		re.Equal(string(SchedulingHalted), reason)
+	}
+
+	freshOp := newTransferLeaderOp(3)
+	re.True(controller.AddOperatorWithGeneration(controller.GetOperatorGeneration(), SchedulingHalted, freshOp))
+	re.Equal(freshOp, controller.GetOperator(freshOp.RegionID()))
+}
+
 func (suite *operatorControllerTestSuite) TestCancelAllOperatorsReturnsWhenScheduleQueueIsFull() {
 	re := suite.Require()
 	opts := mockconfig.NewTestOptions()
@@ -1122,7 +1154,49 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperatorsReturnsWhenSched
 		re.FailNow("cancel all operators did not return")
 	}
 	re.Equal(CANCELED, op.Status())
-	re.Zero(stream.MsgLength())
+	re.Equal(1024, stream.MsgLength())
+}
+
+func (suite *operatorControllerTestSuite) TestCancelAllOperatorsWaitsPromotingOperator() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	region := suite.newRegionInfo(1, "1a", "1b", 1, 1, []uint64{101, 1}, []uint64{101, 1})
+	cluster.PutRegion(region)
+	op := NewTestOperator(1, region.GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+	controller.wop.PutOperator(op)
+	controller.wopStatus.incCount(op.Desc())
+
+	promoteStarted := make(chan struct{})
+	promoteFinished := make(chan struct{})
+	controller.operatorLock.Lock()
+	go func() {
+		defer close(promoteFinished)
+		ops := controller.wop.GetOperator()
+		re.Len(ops, 1)
+		controller.wopStatus.decCount(ops[0].Desc())
+		close(promoteStarted)
+		time.Sleep(20 * time.Millisecond)
+		re.True(controller.addOperatorLocked(ops...))
+		controller.operatorLock.Unlock()
+	}()
+
+	<-promoteStarted
+	cancelFinished := make(chan struct{})
+	go func() {
+		defer close(cancelFinished)
+		controller.CancelAllOperators(AdminStop)
+	}()
+
+	<-promoteFinished
+	<-cancelFinished
+	re.Empty(controller.GetOperators())
+	re.Equal(CANCELED, op.Status())
+	re.NotNil(controller.GetOperatorStatus(op.RegionID()))
 }
 
 func (suite *operatorControllerTestSuite) TestAddWaitingOperator() {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -1009,6 +1010,51 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 	added := controller.AddWaitingOperator(newWaitingOp)
 	re.Equal(1, added)
 	re.NotNil(controller.GetOperator(newWaitingOp.RegionID()))
+}
+
+func (suite *operatorControllerTestSuite) TestCancelAllOperatorsPreventsStaleDispatch() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLeaderStore(1, 1)
+	cluster.AddLeaderStore(2, 0)
+	region := cluster.AddLeaderRegion(1, 1, 2)
+	op := NewTestOperator(1, region.GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+	re.True(op.Start())
+	controller.SetOperator(op)
+
+	dispatchReady := make(chan struct{})
+	continueDispatch := make(chan struct{})
+	re.NoError(failpoint.EnableCall("github.com/tikv/pd/pkg/schedule/operator/cancelOperatorBeforeDispatch", func() {
+		close(dispatchReady)
+		<-continueDispatch
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/operator/cancelOperatorBeforeDispatch"))
+	}()
+
+	dispatchFinished := make(chan struct{})
+	go func() {
+		defer close(dispatchFinished)
+		controller.Dispatch(region, DispatchFromHeartBeat, nil)
+	}()
+
+	select {
+	case <-dispatchReady:
+	case <-time.After(time.Second):
+		re.FailNow("dispatch did not reach the pre-send failpoint")
+	}
+	controller.CancelAllOperators(AdminStop)
+	close(continueDispatch)
+	select {
+	case <-dispatchFinished:
+	case <-time.After(time.Second):
+		re.FailNow("dispatch did not finish")
+	}
+	re.Equal(CANCELED, op.Status())
+	re.Zero(reflect.ValueOf(stream).Elem().FieldByName("msgCh").Len())
 }
 
 func (suite *operatorControllerTestSuite) TestCancelAllOperatorsWaitsPromotingOperator() {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -992,7 +992,6 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 	re.Empty(controller.GetOperators())
 	re.Empty(controller.GetWaitingOperators())
 	re.Equal(uint64(0), controller.OperatorCount(OpLeader))
-	re.Equal(0, controller.opNotifierQueue.len())
 	re.Equal(uint64(0), controller.wopStatus.getCount(waitingOp1.Desc()))
 	for _, op := range []*Operator{runningOp, waitingOp1, waitingOp2} {
 		re.True(op.IsEnd())
@@ -1002,29 +1001,14 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 		re.True(ok)
 		re.Equal(string(AdminStop), reason)
 	}
+	region, next := controller.pollNeedDispatchRegion()
+	re.Nil(region)
+	re.True(next)
 
 	newWaitingOp := newTransferLeaderOp(2)
 	added := controller.AddWaitingOperator(newWaitingOp)
 	re.Equal(1, added)
 	re.NotNil(controller.GetOperator(newWaitingOp.RegionID()))
-}
-
-func (suite *operatorControllerTestSuite) TestPollNeedDispatchRegionAfterNotifierQueueClear() {
-	re := suite.Require()
-	opts := mockconfig.NewTestOptions()
-	cluster := mockcluster.NewCluster(suite.ctx, opts)
-	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
-	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
-
-	controller.opNotifierQueue.push(&operatorWithTime{
-		op:   NewTestOperator(1, &metapb.RegionEpoch{}, OpLeader),
-		time: time.Now(),
-	})
-	controller.opNotifierQueue.clear()
-
-	region, next := controller.pollNeedDispatchRegion()
-	re.Nil(region)
-	re.False(next)
 }
 
 func (suite *operatorControllerTestSuite) TestCancelAllOperatorsWaitsPromotingOperator() {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -1002,14 +1002,16 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 		re.True(ok)
 		re.Equal(string(AdminStop), reason)
 	}
+	re.Equal(0, controller.opNotifierQueue.len())
 	region, next := controller.pollNeedDispatchRegion()
 	re.Nil(region)
-	re.True(next)
+	re.False(next)
 
 	newWaitingOp := newTransferLeaderOp(2)
 	added := controller.AddWaitingOperator(newWaitingOp)
 	re.Equal(1, added)
 	re.NotNil(controller.GetOperator(newWaitingOp.RegionID()))
+	re.Equal(1, controller.opNotifierQueue.len())
 }
 
 func (suite *operatorControllerTestSuite) TestCancelAllOperatorsPreventsStaleDispatch() {
@@ -1055,6 +1057,28 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperatorsPreventsStaleDis
 	}
 	re.Equal(CANCELED, op.Status())
 	re.Zero(reflect.ValueOf(stream).Elem().FieldByName("msgCh").Len())
+}
+
+func (suite *operatorControllerTestSuite) TestPollNeedDispatchRegionDropsStaleNotifierEntry() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLeaderStore(1, 1)
+	cluster.AddLeaderStore(2, 0)
+	region := cluster.AddLeaderRegion(1, 1, 2)
+
+	oldOp := NewTestOperator(1, region.GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+	newOp := NewTestOperator(1, region.GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+	re.True(newOp.Start())
+	controller.SetOperator(newOp)
+	controller.opNotifierQueue.push(&operatorWithTime{op: oldOp, time: time.Now()})
+
+	region, next := controller.pollNeedDispatchRegion()
+	re.Nil(region)
+	re.True(next)
+	re.Equal(0, controller.opNotifierQueue.len())
 }
 
 func (suite *operatorControllerTestSuite) TestCancelAllOperatorsWaitsPromotingOperator() {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -978,6 +977,8 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 	re.NotNil(controller.GetOperator(runningOp.RegionID()))
 	re.Equal(uint64(1), controller.OperatorCount(OpLeader))
 	re.Equal(1, controller.opNotifierQueue.len())
+	stream.SendMsg(cluster.GetRegion(1), &hbstream.Operation{ChangeSplit: &pdpb.ChangeSplit{AutoSplitEnabled: false}})
+	re.Equal(2, stream.MsgLength())
 
 	waitingOp1 := newTransferLeaderOp(2)
 	waitingOp2 := newTransferLeaderOp(3)
@@ -1006,6 +1007,8 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 	region, next := controller.pollNeedDispatchRegion()
 	re.Nil(region)
 	re.False(next)
+	re.Equal(1, stream.MsgLength())
+	re.NoError(stream.Drain(1))
 
 	newWaitingOp := newTransferLeaderOp(2)
 	added := controller.AddWaitingOperator(newWaitingOp)
@@ -1056,7 +1059,7 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperatorsPreventsStaleDis
 		re.FailNow("dispatch did not finish")
 	}
 	re.Equal(CANCELED, op.Status())
-	re.Zero(reflect.ValueOf(stream).Elem().FieldByName("msgCh").Len())
+	re.Zero(stream.MsgLength())
 }
 
 func (suite *operatorControllerTestSuite) TestPollNeedDispatchRegionDropsStaleNotifierEntry() {
@@ -1081,46 +1084,45 @@ func (suite *operatorControllerTestSuite) TestPollNeedDispatchRegionDropsStaleNo
 	re.Equal(0, controller.opNotifierQueue.len())
 }
 
-func (suite *operatorControllerTestSuite) TestCancelAllOperatorsWaitsPromotingOperator() {
+func (suite *operatorControllerTestSuite) TestCancelAllOperatorsReturnsWhenScheduleQueueIsFull() {
 	re := suite.Require()
 	opts := mockconfig.NewTestOptions()
 	cluster := mockcluster.NewCluster(suite.ctx, opts)
 	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
 	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
-	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
-	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
-	region := suite.newRegionInfo(1, "1a", "1b", 1, 1, []uint64{101, 1}, []uint64{101, 1})
-	cluster.PutRegion(region)
+	cluster.AddLeaderStore(1, 1)
+	cluster.AddLeaderStore(2, 0)
+	region := cluster.AddLeaderRegion(1, 1, 2)
+	cmd := TransferLeader{FromStore: 1, ToStore: 2}.GetCmd(region, false)
+	for range 1024 {
+		re.True(stream.SendScheduleCommand(region, cmd))
+	}
+	re.Equal(1024, stream.MsgLength())
+
 	op := NewTestOperator(1, region.GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
-	controller.wop.PutOperator(op)
-	controller.wopStatus.incCount(op.Desc())
-
-	promoteStarted := make(chan struct{})
-	promoteFinished := make(chan struct{})
-	controller.operatorLock.Lock()
+	addFinished := make(chan bool)
 	go func() {
-		defer close(promoteFinished)
-		ops := controller.wop.GetOperator()
-		re.Len(ops, 1)
-		controller.wopStatus.decCount(ops[0].Desc())
-		close(promoteStarted)
-		time.Sleep(20 * time.Millisecond)
-		re.True(controller.addOperatorLocked(ops...))
-		controller.operatorLock.Unlock()
+		addFinished <- controller.AddOperator(op)
 	}()
+	select {
+	case added := <-addFinished:
+		re.True(added)
+	case <-time.After(time.Second):
+		re.FailNow("add operator did not return")
+	}
 
-	<-promoteStarted
 	cancelFinished := make(chan struct{})
 	go func() {
 		defer close(cancelFinished)
 		controller.CancelAllOperators(AdminStop)
 	}()
-
-	<-promoteFinished
-	<-cancelFinished
-	re.Empty(controller.GetOperators())
+	select {
+	case <-cancelFinished:
+	case <-time.After(time.Second):
+		re.FailNow("cancel all operators did not return")
+	}
 	re.Equal(CANCELED, op.Status())
-	re.NotNil(controller.GetOperatorStatus(op.RegionID()))
+	re.Zero(stream.MsgLength())
 }
 
 func (suite *operatorControllerTestSuite) TestAddWaitingOperator() {

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -1009,6 +1009,66 @@ func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
 	re.NotNil(controller.GetOperator(newWaitingOp.RegionID()))
 }
 
+func (suite *operatorControllerTestSuite) TestPollNeedDispatchRegionAfterNotifierQueueClear() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+
+	controller.opNotifierQueue.push(&operatorWithTime{
+		op:   NewTestOperator(1, &metapb.RegionEpoch{}, OpLeader),
+		time: time.Now(),
+	})
+	controller.opNotifierQueue.clear()
+
+	region, next := controller.pollNeedDispatchRegion()
+	re.Nil(region)
+	re.False(next)
+}
+
+func (suite *operatorControllerTestSuite) TestCancelAllOperatorsWaitsPromotingOperator() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	region := suite.newRegionInfo(1, "1a", "1b", 1, 1, []uint64{101, 1}, []uint64{101, 1})
+	cluster.PutRegion(region)
+	op := NewTestOperator(1, region.GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+	controller.wop.PutOperator(op)
+	controller.wopStatus.incCount(op.Desc())
+
+	promoteStarted := make(chan struct{})
+	promoteFinished := make(chan struct{})
+	controller.operatorLock.Lock()
+	go func() {
+		defer close(promoteFinished)
+		ops := controller.wop.GetOperator()
+		re.Len(ops, 1)
+		controller.wopStatus.decCount(ops[0].Desc())
+		close(promoteStarted)
+		time.Sleep(20 * time.Millisecond)
+		re.True(controller.addOperatorLocked(ops...))
+		controller.operatorLock.Unlock()
+	}()
+
+	<-promoteStarted
+	cancelFinished := make(chan struct{})
+	go func() {
+		defer close(cancelFinished)
+		controller.CancelAllOperators(AdminStop)
+	}()
+
+	<-promoteFinished
+	<-cancelFinished
+	re.Empty(controller.GetOperators())
+	re.Equal(CANCELED, op.Status())
+	re.NotNil(controller.GetOperatorStatus(op.RegionID()))
+}
+
 func (suite *operatorControllerTestSuite) TestAddWaitingOperator() {
 	re := suite.Require()
 	opts := mockconfig.NewTestOptions()

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -953,6 +953,62 @@ func checkRemoveOperatorSuccess(re *require.Assertions, oc *Controller, op *Oper
 	re.Equal(op, oc.GetOperatorStatus(op.RegionID()).Operator)
 }
 
+func (suite *operatorControllerTestSuite) TestCancelAllOperators() {
+	re := suite.Require()
+	opts := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(suite.ctx, opts)
+	stream := hbstream.NewTestHeartbeatStreams(suite.ctx, cluster, false /* no need to run */)
+	controller := NewController(suite.ctx, cluster.GetBasicCluster(), cluster.GetSharedConfig(), stream)
+	cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+
+	for i := uint64(1); i <= 3; i++ {
+		region := suite.newRegionInfo(i, fmt.Sprintf("%da", i), fmt.Sprintf("%db", i), 1, 1, []uint64{100 + i, 1}, []uint64{100 + i, 1})
+		cluster.PutRegion(region)
+	}
+
+	newTransferLeaderOp := func(regionID uint64) *Operator {
+		return NewTestOperator(regionID, cluster.GetRegion(regionID).GetRegionEpoch(), OpLeader, TransferLeader{FromStore: 1, ToStore: 2})
+	}
+
+	runningOp := newTransferLeaderOp(1)
+	re.True(controller.AddOperator(runningOp))
+	re.NotNil(controller.GetOperator(runningOp.RegionID()))
+	re.Equal(uint64(1), controller.OperatorCount(OpLeader))
+	re.Equal(1, controller.opNotifierQueue.len())
+
+	waitingOp1 := newTransferLeaderOp(2)
+	waitingOp2 := newTransferLeaderOp(3)
+	controller.wop.PutOperator(waitingOp1)
+	controller.wop.PutOperator(waitingOp2)
+	controller.wopStatus.incCount(waitingOp1.Desc())
+	controller.wopStatus.incCount(waitingOp2.Desc())
+	re.Len(controller.GetWaitingOperators(), 2)
+	re.Equal(uint64(2), controller.wopStatus.getCount(waitingOp1.Desc()))
+
+	controller.CancelAllOperators(AdminStop)
+
+	re.Empty(controller.GetOperators())
+	re.Empty(controller.GetWaitingOperators())
+	re.Equal(uint64(0), controller.OperatorCount(OpLeader))
+	re.Equal(0, controller.opNotifierQueue.len())
+	re.Equal(uint64(0), controller.wopStatus.getCount(waitingOp1.Desc()))
+	for _, op := range []*Operator{runningOp, waitingOp1, waitingOp2} {
+		re.True(op.IsEnd())
+		re.Equal(CANCELED, op.Status())
+		re.NotNil(controller.GetOperatorStatus(op.RegionID()))
+		reason, ok := op.GetAdditionalInfo(cancelReason)
+		re.True(ok)
+		re.Equal(string(AdminStop), reason)
+	}
+
+	newWaitingOp := newTransferLeaderOp(2)
+	added := controller.AddWaitingOperator(newWaitingOp)
+	re.Equal(1, added)
+	re.NotNil(controller.GetOperator(newWaitingOp.RegionID()))
+}
+
 func (suite *operatorControllerTestSuite) TestAddWaitingOperator() {
 	re := suite.Require()
 	opts := mockconfig.NewTestOptions()

--- a/pkg/schedule/operator/operator_queue.go
+++ b/pkg/schedule/operator/operator_queue.go
@@ -89,3 +89,12 @@ func (ch *concurrentHeapOpQueue) pop() (*operatorWithTime, bool) {
 	x := heap.Pop(&ch.heap).(*operatorWithTime)
 	return x, true
 }
+
+func (ch *concurrentHeapOpQueue) clear() {
+	ch.Lock()
+	defer ch.Unlock()
+	for i := range ch.heap {
+		ch.heap[i] = nil
+	}
+	ch.heap = ch.heap[:0]
+}

--- a/pkg/schedule/operator/operator_queue.go
+++ b/pkg/schedule/operator/operator_queue.go
@@ -89,12 +89,3 @@ func (ch *concurrentHeapOpQueue) pop() (*operatorWithTime, bool) {
 	x := heap.Pop(&ch.heap).(*operatorWithTime)
 	return x, true
 }
-
-func (ch *concurrentHeapOpQueue) clear() {
-	ch.Lock()
-	defer ch.Unlock()
-	for i := range ch.heap {
-		ch.heap[i] = nil
-	}
-	ch.heap = ch.heap[:0]
-}

--- a/pkg/schedule/operator/waiting_operator.go
+++ b/pkg/schedule/operator/waiting_operator.go
@@ -174,7 +174,9 @@ func (s *waitingOperatorStatus) incCount(kind string) {
 func (s *waitingOperatorStatus) decCount(kind string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ops[kind]--
+	if count := s.ops[kind]; count > 0 {
+		s.ops[kind] = count - 1
+	}
 }
 
 // getCount returns the count of the given operator kind.

--- a/pkg/schedule/operator/waiting_operator.go
+++ b/pkg/schedule/operator/waiting_operator.go
@@ -29,7 +29,6 @@ type WaitingOperator interface {
 	PutMergeOperators(op []*Operator)
 	GetOperator() []*Operator
 	ListOperator() []*Operator
-	Drain() []*Operator
 }
 
 // bucket is used to maintain the operators created by a specific scheduler.
@@ -92,23 +91,6 @@ func (b *randBuckets) ListOperator() []*Operator {
 		bucket := b.buckets[i]
 		ops = append(ops, bucket.ops...)
 	}
-	return ops
-}
-
-// Drain removes and returns all operators in the random buckets.
-func (b *randBuckets) Drain() []*Operator {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	var ops []*Operator
-	for i := range b.buckets {
-		bucket := b.buckets[i]
-		ops = append(ops, bucket.ops...)
-		for j := range bucket.ops {
-			bucket.ops[j] = nil // avoid memory leak
-		}
-		bucket.ops = nil
-	}
-	b.totalWeight = 0
 	return ops
 }
 

--- a/pkg/schedule/operator/waiting_operator.go
+++ b/pkg/schedule/operator/waiting_operator.go
@@ -29,6 +29,7 @@ type WaitingOperator interface {
 	PutMergeOperators(op []*Operator)
 	GetOperator() []*Operator
 	ListOperator() []*Operator
+	Drain() []*Operator
 }
 
 // bucket is used to maintain the operators created by a specific scheduler.
@@ -91,6 +92,23 @@ func (b *randBuckets) ListOperator() []*Operator {
 		bucket := b.buckets[i]
 		ops = append(ops, bucket.ops...)
 	}
+	return ops
+}
+
+// Drain removes and returns all operators in the random buckets.
+func (b *randBuckets) Drain() []*Operator {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var ops []*Operator
+	for i := range b.buckets {
+		bucket := b.buckets[i]
+		ops = append(ops, bucket.ops...)
+		for j := range bucket.ops {
+			bucket.ops[j] = nil // avoid memory leak
+		}
+		bucket.ops = nil
+	}
+	b.totalWeight = 0
 	return ops
 }
 
@@ -164,4 +182,11 @@ func (s *waitingOperatorStatus) getCount(kind string) uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.ops[kind]
+}
+
+// reset clears all waiting operator status counters.
+func (s *waitingOperatorStatus) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ops = make(map[string]uint64)
 }

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -386,7 +386,15 @@ func (c *Controller) runScheduler(s *ScheduleController) {
 				continue
 			}
 			if op := s.Schedule(diagnosable); len(op) > 0 {
-				added := c.opController.AddWaitingOperator(op...)
+				added := c.opController.AddWaitingOperatorWithGuard(func() bool {
+					if c.cluster.GetSharedConfig().IsSchedulingHalted() {
+						if diagnosable {
+							s.diagnosticRecorder.SetResultFromStatus(Halted)
+						}
+						return false
+					}
+					return true
+				}, operator.SchedulingHalted, op...)
 				log.Debug("add operator", zap.Int("added", added), zap.Int("total", len(op)), zap.String("scheduler", s.GetName()))
 			}
 			// Note: we reset the ticker here to support updating configuration dynamically.

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -382,19 +382,12 @@ func (c *Controller) runScheduler(s *ScheduleController) {
 		select {
 		case <-ticker.C:
 			diagnosable := s.IsDiagnosticAllowed()
+			generation := c.opController.GetOperatorGeneration()
 			if !s.AllowSchedule(diagnosable) {
 				continue
 			}
 			if op := s.Schedule(diagnosable); len(op) > 0 {
-				added := c.opController.AddWaitingOperatorWithGuard(func() bool {
-					if c.cluster.GetSharedConfig().IsSchedulingHalted() {
-						if diagnosable {
-							s.diagnosticRecorder.SetResultFromStatus(Halted)
-						}
-						return false
-					}
-					return true
-				}, operator.SchedulingHalted, op...)
+				added := c.opController.AddWaitingOperatorWithGeneration(generation, operator.SchedulingHalted, op...)
 				log.Debug("add operator", zap.Int("added", added), zap.Int("total", len(op)), zap.String("scheduler", s.GetName()))
 			}
 			// Note: we reset the ticker here to support updating configuration dynamically.

--- a/pkg/unsaferecovery/unsafe_recovery_controller.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller.go
@@ -112,6 +112,7 @@ type cluster interface {
 	ResetRegionCache()
 	AllocID(uint32) (uint64, uint32, error)
 	BuryStore(storeID uint64, forceBury bool) error
+	CancelAllOperators()
 	GetSchedulerConfig() sc.SchedulerConfigProvider
 }
 
@@ -545,7 +546,7 @@ func (u *Controller) changeStage(stage stage) {
 	switch u.stage {
 	case Idle:
 	case CollectReport:
-		// TODO: clean up existing operators
+		u.cluster.CancelAllOperators()
 		output.Info = "Unsafe recovery enters collect report stage"
 		if u.autoDetect {
 			output.Details = append(output.Details, "auto detect mode with no specified Failed stores")

--- a/pkg/unsaferecovery/unsafe_recovery_controller_test.go
+++ b/pkg/unsaferecovery/unsafe_recovery_controller_test.go
@@ -162,6 +162,31 @@ func TestRemoveFailedStoresWithOptions(t *testing.T) {
 	re.WithinDuration(time.Now().Add(5*time.Minute), recoveryController.storePlanExpires[1], time.Second)
 }
 
+type trackingCancelCluster struct {
+	*mockcluster.Cluster
+	cancelAllOperatorsCalled int
+}
+
+func (c *trackingCancelCluster) CancelAllOperators() {
+	c.cancelAllOperatorsCalled++
+}
+
+func TestRemoveFailedStoresCancelsOperators(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := mockconfig.NewTestOptions()
+	cluster := &trackingCancelCluster{Cluster: mockcluster.NewCluster(ctx, opts)}
+	for _, store := range newTestStores(1, "6.0.0") {
+		cluster.PutStore(store)
+	}
+
+	recoveryController := NewController(cluster)
+	re.NoError(recoveryController.RemoveFailedStores(nil, 60, true))
+	re.Equal(1, cluster.cancelAllOperatorsCalled)
+}
+
 func TestCreateEmptyRegionDisableParanoidCheck(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/unrolled/render"
 
+	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/unsaferecovery"
 	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
@@ -57,6 +58,10 @@ func newUnsafeOperationHandler(svr *server.Server, rd *render.Render) *unsafeOpe
 //	@Router		/admin/unsafe/remove-failed-stores [post]
 func (h *unsafeOperationHandler) RemoveFailedStores(w http.ResponseWriter, r *http.Request) {
 	rc := getCluster(r)
+	if rc.IsServiceIndependent(constant.SchedulingServiceName) {
+		h.rd.JSON(w, http.StatusNotImplemented, "online unsafe recovery is not supported when scheduling service is enabled")
+		return
+	}
 	var input map[string]any
 	if err := apiutil.ReadJSONRespondError(h.rd, w, r.Body, &input); err != nil {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())

--- a/server/api/unsafe_operation.go
+++ b/server/api/unsafe_operation.go
@@ -56,6 +56,7 @@ func newUnsafeOperationHandler(svr *server.Server, rd *render.Render) *unsafeOpe
 //
 // Success 200 {string} string "Request has been accepted."
 // Failure 400 {string} string "The input is invalid."
+// Failure 501 {string} string "Online unsafe recovery is not supported when scheduling service is enabled."
 // Failure 500 {string} string "PD server failed to proceed the request."
 //
 //	@Router		/admin/unsafe/remove-failed-stores [post]

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -321,9 +321,6 @@ func (sc *schedulingController) GetOperatorController() *operator.Controller {
 func (sc *schedulingController) CancelAllOperators() {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
-	if sc.coordinator == nil {
-		return
-	}
 	sc.coordinator.GetOperatorController().CancelAllOperators(operator.UnsafeRecovery)
 }
 

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -317,6 +317,16 @@ func (sc *schedulingController) GetOperatorController() *operator.Controller {
 	return sc.coordinator.GetOperatorController()
 }
 
+// CancelAllOperators cancels all running and waiting operators.
+func (sc *schedulingController) CancelAllOperators() {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	if sc.coordinator == nil {
+		return
+	}
+	sc.coordinator.GetOperatorController().CancelAllOperators(operator.UnsafeRecovery)
+}
+
 // GetRegionScatterer returns the region scatter.
 func (sc *schedulingController) GetRegionScatterer() *scatter.RegionScatterer {
 	sc.mu.RLock()

--- a/tests/server/api/unsafe_operation_test.go
+++ b/tests/server/api/unsafe_operation_test.go
@@ -17,6 +17,7 @@ package api
 import (
 	"encoding/json"
 	"math"
+	"net/http"
 	"testing"
 	"time"
 
@@ -50,6 +51,20 @@ func (suite *unsafeOperationTestSuite) TearDownTest() {
 
 func (suite *unsafeOperationTestSuite) TestRemoveFailedStores() {
 	suite.env.RunTestInNonMicroserviceEnv(suite.checkRemoveFailedStores)
+}
+
+func (suite *unsafeOperationTestSuite) TestRemoveFailedStoresInMicroserviceEnv() {
+	suite.env.RunTestInMicroserviceEnv(func(cluster *tests.TestCluster) {
+		re := suite.Require()
+		leader := cluster.GetLeaderServer()
+		urlPrefix := leader.GetAddr() + "/pd/api/v1/admin/unsafe"
+		data, err := json.Marshal(map[string]any{"auto-detect": true})
+		re.NoError(err)
+		err = testutil.CheckPostJSON(tests.TestDialClient, urlPrefix+"/remove-failed-stores", data,
+			testutil.Status(re, http.StatusNotImplemented),
+			testutil.StringContain(re, "online unsafe recovery is not supported when scheduling service is enabled"))
+		re.NoError(err)
+	})
 }
 
 func (suite *unsafeOperationTestSuite) checkRemoveFailedStores(cluster *tests.TestCluster) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10908

### What is changed and how does it work?

```commit-message
Cancel existing scheduling operators before online unsafe recovery starts
collecting store reports.
```

When online unsafe recovery enters `CollectReport`, this PR:

- cancels running and waiting operators and resets their accounting;
- clears operator notifier entries and rejects stale notifier items;
- serializes bulk cancellation with operator addition, promotion, and the final
  dispatch enqueue;
- rejects automatic scheduler/checker results that started computing before the
  cancellation by comparing an operator generation under `operatorLock`;
- avoids duplicate accounting if bulk cancellation races with a concurrent
  single-operator removal.

The generation is captured before each automatic producer checks whether
scheduling is halted and before it computes operators. This covers schedulers,
region checkers, and internal split-scatter dispatch without calling
`RaftCluster.IsSchedulingHalted()` while holding `operatorLock`, which would
invert the unsafe-recovery/controller lock order.

This PR does not drain or invalidate messages already accepted by the heartbeat
stream. Those messages retain the existing asynchronous delivery semantics.
Operator schedule commands use a nonblocking enqueue for the final serialized
dispatch boundary, so a full heartbeat queue cannot block operator cancellation;
the existing notifier and heartbeat paths retry the current operator step.

When the independent scheduling service is enabled, online unsafe recovery
returns `501 Not Implemented`, because the remote scheduling primary owns the
operators and there is no cross-service cancellation protocol yet.

### Check List

Tests

- Unit test
- `make check`

### Release note

```release-note
Cancel running and waiting scheduling operators before online unsafe recovery
starts collecting store reports. Online unsafe recovery with the independent
scheduling service remains unsupported and returns 501.
```
