### PR TITLE
resource_control: delete metric children by creation-time keyspace_name

### DIFF
--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -309,7 +309,14 @@ func (m *metrics) getMaxPerSecTracker(keyspaceID uint32, keyspaceName, groupName
 }
 
 func (m *metrics) deleteMaxPerSecTracker(keyspaceID uint32, groupName string) {
-	delete(m.maxPerSecTrackerMap, trackerKey{keyspaceID, groupName})
+	key := trackerKey{keyspaceID, groupName}
+	tracker := m.maxPerSecTrackerMap[key]
+	delete(m.maxPerSecTrackerMap, key)
+	if tracker == nil {
+		return
+	}
+	readRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, tracker.keyspaceName)
+	writeRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, tracker.keyspaceName)
 }
 
 func (m *metrics) getCounterMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) *counterMetrics {
@@ -329,9 +336,21 @@ func (m *metrics) getGaugeMetrics(keyspaceID uint32, keyspaceName, groupName str
 }
 
 func (m *metrics) deleteMetrics(keyspaceID uint32, keyspaceName, groupName, ruType string) {
-	delete(m.counterMetricsMap, metricsKey{keyspaceID, groupName, ruType})
-	delete(m.gaugeMetricsMap, metricsKey{keyspaceID, groupName, ""})
-	deleteLabelValues(keyspaceName, groupName, ruType)
+	counterKey := metricsKey{keyspaceID, groupName, ruType}
+	gaugeKey := metricsKey{keyspaceID, groupName, ""}
+	counterMetrics := m.counterMetricsMap[counterKey]
+	gaugeMetrics := m.gaugeMetricsMap[gaugeKey]
+	delete(m.counterMetricsMap, counterKey)
+	delete(m.gaugeMetricsMap, gaugeKey)
+
+	deleteKeyspaceName := keyspaceName
+	if counterMetrics != nil {
+		deleteKeyspaceName = counterMetrics.keyspaceName
+	}
+	deleteLabelValues(deleteKeyspaceName, groupName, ruType)
+	if gaugeMetrics != nil && gaugeMetrics.keyspaceName != deleteKeyspaceName {
+		deleteLabelValues(gaugeMetrics.keyspaceName, groupName, ruType)
+	}
 }
 
 func (m *metrics) recordConsumption(
@@ -362,6 +381,7 @@ func (m *metrics) cleanupAllMetrics(r consumptionRecordKey, keyspaceName string)
 }
 
 type counterMetrics struct {
+	keyspaceName               string
 	RRUMetrics                 prometheus.Counter
 	WRUMetrics                 prometheus.Counter
 	ActiveRUMetrics            prometheus.Counter
@@ -382,6 +402,7 @@ type counterMetrics struct {
 
 func newCounterMetrics(keyspaceName, groupName, ruLabelType string) *counterMetrics {
 	return &counterMetrics{
+		keyspaceName:               keyspaceName,
 		RRUMetrics:                 readRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		WRUMetrics:                 writeRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
 		ActiveRUMetrics:            activeRequestUnitCost.WithLabelValues(groupName, groupName, ruLabelType, keyspaceName),
@@ -478,6 +499,7 @@ func (m *counterMetrics) add(consumption *rmpb.Consumption, controllerConfig *Co
 }
 
 type gaugeMetrics struct {
+	keyspaceName                       string
 	availableRUCounter                 prometheus.Gauge
 	priorityResourceGroupConfigGauge   prometheus.Gauge
 	ruPerSecResourceGroupConfigGauge   prometheus.Gauge
@@ -489,6 +511,7 @@ type gaugeMetrics struct {
 
 func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 	return &gaugeMetrics{
+		keyspaceName:                       keyspaceName,
 		availableRUCounter:                 availableRUCounter.WithLabelValues(groupName, groupName, keyspaceName),
 		priorityResourceGroupConfigGauge:   resourceGroupConfigGauge.WithLabelValues(groupName, priorityLabel, keyspaceName),
 		ruPerSecResourceGroupConfigGauge:   resourceGroupConfigGauge.WithLabelValues(groupName, ruPerSecLabel, keyspaceName),
@@ -499,7 +522,7 @@ func newGaugeMetrics(keyspaceName, groupName string) *gaugeMetrics {
 	}
 }
 
-func (m *gaugeMetrics) setGroup(group *ResourceGroup, keyspaceName string) {
+func (m *gaugeMetrics) setGroup(group *ResourceGroup, _keyspaceName string) {
 	// skip basic metrics for the default group.
 	if group.Name != DefaultResourceGroupName {
 		ru := math.Max(group.getRUToken(), 0)
@@ -512,13 +535,13 @@ func (m *gaugeMetrics) setGroup(group *ResourceGroup, keyspaceName string) {
 	// Set the override fill rate and burst limit and delete the metrics if the override is not set.
 	overrideFillRate := group.getOverrideFillRate()
 	if overrideFillRate == -1 {
-		overrideSettings.DeleteLabelValues(group.Name, keyspaceName, fillRateLabel)
+		overrideSettings.DeleteLabelValues(group.Name, m.keyspaceName, fillRateLabel)
 	} else {
 		m.overrideFillRateGauge.Set(overrideFillRate)
 	}
 	overrideBurstLimit := group.getOverrideBurstLimit()
 	if overrideBurstLimit == -1 {
-		overrideSettings.DeleteLabelValues(group.Name, keyspaceName, burstLimitLabel)
+		overrideSettings.DeleteLabelValues(group.Name, m.keyspaceName, burstLimitLabel)
 	} else {
 		m.overrideBurstLimitGauge.Set(float64(overrideBurstLimit))
 	}
@@ -552,8 +575,6 @@ func deleteLabelValues(keyspaceName, groupName, ruLabelType string) {
 	requestCount.DeleteLabelValues(groupName, groupName, readTypeLabel, keyspaceName)
 	requestCount.DeleteLabelValues(groupName, groupName, writeTypeLabel, keyspaceName)
 	availableRUCounter.DeleteLabelValues(groupName, groupName, keyspaceName)
-	readRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
-	writeRequestUnitMaxPerSecCost.DeleteLabelValues(groupName, keyspaceName)
 	sampledRequestUnitPerSec.DeleteLabelValues(groupName, keyspaceName)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, fillRateLabel)
 	overrideSettings.DeleteLabelValues(groupName, keyspaceName, burstLimitLabel)

--- a/pkg/mcs/resourcemanager/server/metrics_test.go
+++ b/pkg/mcs/resourcemanager/server/metrics_test.go
@@ -17,7 +17,9 @@ package server
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -113,4 +115,149 @@ func TestMaxPerSecCostTracker(t *testing.T) {
 			re.Equal(tracker.rruSum, expectedSum[period])
 		}
 	}
+}
+
+func TestMetricsCleanupUsesCreationTimeKeyspaceName(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		keyspaceID           uint32
+		creationKeyspaceName string
+		cleanupKeyspaceName  string
+		groupName            string
+	}{
+		{
+			name:                 "fallback name at creation",
+			keyspaceID:           123,
+			creationKeyspaceName: "keyspace-123",
+			cleanupKeyspaceName:  "tenant-a",
+			groupName:            "cleanup-fallback-name-group",
+		},
+		{
+			name:                 "same name at creation and cleanup",
+			keyspaceID:           124,
+			creationKeyspaceName: "tenant-b",
+			cleanupKeyspaceName:  "tenant-b",
+			groupName:            "cleanup-same-name-group",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			cleanup := func(keyspaceName string) {
+				deleteLabelValues(keyspaceName, testCase.groupName, defaultTypeLabel)
+				readRequestUnitMaxPerSecCost.DeleteLabelValues(testCase.groupName, keyspaceName)
+				writeRequestUnitMaxPerSecCost.DeleteLabelValues(testCase.groupName, keyspaceName)
+			}
+			cleanup(testCase.creationKeyspaceName)
+			cleanup(testCase.cleanupKeyspaceName)
+			t.Cleanup(func() {
+				cleanup(testCase.creationKeyspaceName)
+				cleanup(testCase.cleanupKeyspaceName)
+			})
+
+			m := newMetrics()
+			m.getCounterMetrics(
+				testCase.keyspaceID,
+				testCase.creationKeyspaceName,
+				testCase.groupName,
+				defaultTypeLabel,
+			).add(&rmpb.Consumption{
+				RRU: 1,
+				WRU: 1,
+			}, nil, testCase.keyspaceID)
+
+			tracker := m.getMaxPerSecTracker(
+				testCase.keyspaceID,
+				testCase.creationKeyspaceName,
+				testCase.groupName,
+			)
+			for range defaultCollectIntervalSec + 1 {
+				tracker.collect(&rmpb.Consumption{RRU: 1, WRU: 1})
+				tracker.flushMetrics()
+			}
+
+			m.getGaugeMetrics(
+				testCase.keyspaceID,
+				testCase.creationKeyspaceName,
+				testCase.groupName,
+			)
+
+			counterLabels := map[string]string{
+				resourceGroupNameLabel:    testCase.groupName,
+				newResourceGroupNameLabel: testCase.groupName,
+				typeLabel:                 defaultTypeLabel,
+				keyspaceNameLabel:         testCase.creationKeyspaceName,
+			}
+			maxPerSecLabels := map[string]string{
+				newResourceGroupNameLabel: testCase.groupName,
+				keyspaceNameLabel:         testCase.creationKeyspaceName,
+			}
+			gaugeLabels := map[string]string{
+				resourceGroupNameLabel:    testCase.groupName,
+				newResourceGroupNameLabel: testCase.groupName,
+				keyspaceNameLabel:         testCase.creationKeyspaceName,
+			}
+
+			re.Greater(testutil.CollectAndCount(collectorWithLabels(readRequestUnitCost, counterLabels)), 0)
+			re.Greater(testutil.CollectAndCount(collectorWithLabels(readRequestUnitMaxPerSecCost, maxPerSecLabels)), 0)
+			re.Greater(testutil.CollectAndCount(collectorWithLabels(availableRUCounter, gaugeLabels)), 0)
+
+			m.cleanupAllMetrics(consumptionRecordKey{
+				keyspaceID: testCase.keyspaceID,
+				groupName:  testCase.groupName,
+				ruType:     defaultTypeLabel,
+			}, testCase.cleanupKeyspaceName)
+
+			re.Zero(testutil.CollectAndCount(collectorWithLabels(readRequestUnitCost, counterLabels)))
+			re.Zero(testutil.CollectAndCount(collectorWithLabels(readRequestUnitMaxPerSecCost, maxPerSecLabels)))
+			re.Zero(testutil.CollectAndCount(collectorWithLabels(availableRUCounter, gaugeLabels)))
+		})
+	}
+}
+
+func collectorWithLabels(collector prometheus.Collector, labels map[string]string) prometheus.Collector {
+	return labelFilterCollector{collector: collector, labels: labels}
+}
+
+type labelFilterCollector struct {
+	collector prometheus.Collector
+	labels    map[string]string
+}
+
+func (c labelFilterCollector) Describe(chan<- *prometheus.Desc) {}
+
+func (c labelFilterCollector) Collect(ch chan<- prometheus.Metric) {
+	metricCh := make(chan prometheus.Metric)
+	go func() {
+		c.collector.Collect(metricCh)
+		close(metricCh)
+	}()
+	for metric := range metricCh {
+		if metricHasLabels(metric, c.labels) {
+			ch <- metric
+		}
+	}
+}
+
+func metricHasLabels(metric prometheus.Metric, labels map[string]string) bool {
+	dtoMetric := &dto.Metric{}
+	if err := metric.Write(dtoMetric); err != nil {
+		return false
+	}
+	for name, value := range labels {
+		if !metricHasLabel(dtoMetric, name, value) {
+			return false
+		}
+	}
+	return true
+}
+
+func metricHasLabel(metric *dto.Metric, name, value string) bool {
+	for _, label := range metric.GetLabel() {
+		if label.GetName() == name && label.GetValue() == value {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Closes #10871

Resource Control metric caches in the resource manager are keyed by keyspace ID, resource group and RU type, but the underlying Prometheus children are created and removed by their label values, which include `keyspace_name`. When a metric child is first created while the keyspace-name cache misses, it carries a fallback label such as `keyspace-123`. Later, the periodic cleanup loop resolves the real keyspace name (for example `tenant-a`) from storage and calls `DeleteLabelValues` with that real name. Because creation used `keyspace-123` but deletion uses `tenant-a`, the original child is never removed and leaks as a stale Prometheus series, leaving duplicated curves in Grafana for the same keyspace.

### What is changed and how does it work?

The cached counter, gauge and max-per-sec tracker entries now remember the `keyspace_name` label string actually used when each child was created, and cleanup deletes by that recorded value rather than a freshly resolved one. This keeps the create and delete label values symmetric so no orphaned child remains:

- `counterMetrics` and `gaugeMetrics` store the creation-time `keyspaceName`; `deleteMetrics` uses the cached value (falling back to the passed-in name only when no cache entry exists).
- `deleteMaxPerSecTracker` removes the max-per-sec gauge children using the tracker's stored `keyspaceName`; those two deletions move out of the shared `deleteLabelValues` helper so they always use the creation-time value.
- `gaugeMetrics.setGroup` deletes override-settings children by the struct's stored `keyspaceName`.

This mirrors the principle already applied to the request metrics in #10867.

```commit-message
resource_control: delete metric children by creation-time keyspace_name
```

### Check List

Tests

- Unit test

Code changes

- No configuration, API, or persistent data change

Side effects

- None

### Release note

```release-note
Fix a Resource Control metrics leak where Prometheus series created with a fallback keyspace_name label were not removed during cleanup.
```
