### PR TITLE
server: cache PD member list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.20.0
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 // indirect
 	golang.org/x/term v0.40.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 // indirect
 	golang.org/x/term v0.40.0 // indirect

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -65,6 +65,9 @@ func (h *memberHandler) GetMembers(w http.ResponseWriter, _ *http.Request) {
 }
 
 func getMembers(svr *server.Server) (*pdpb.GetMembersResponse, error) {
+	if _, err := svr.ReloadMembers(); err != nil {
+		return nil, errors.WithStack(err)
+	}
 	req := &pdpb.GetMembersRequest{Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()}}
 	grpcServer := &server.GrpcServer{Server: svr}
 	members, err := grpcServer.GetMembers(context.Background(), req)

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -56,7 +56,9 @@ func newMemberHandler(svr *server.Server, rd *render.Render) *memberHandler {
 //	@Failure	500	{string}	string	"PD server failed to proceed the request."
 //	@Router		/members [get]
 func (h *memberHandler) GetMembers(w http.ResponseWriter, _ *http.Request) {
-	members, err := getMembers(h.svr, false)
+	// Keep the HTTP admin API fresh because external controllers use it for
+	// membership management decisions.
+	members, err := getMembers(h.svr, true)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/server/api/member.go
+++ b/server/api/member.go
@@ -56,7 +56,7 @@ func newMemberHandler(svr *server.Server, rd *render.Render) *memberHandler {
 //	@Failure	500	{string}	string	"PD server failed to proceed the request."
 //	@Router		/members [get]
 func (h *memberHandler) GetMembers(w http.ResponseWriter, _ *http.Request) {
-	members, err := getMembers(h.svr)
+	members, err := getMembers(h.svr, false)
 	if err != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -64,9 +64,11 @@ func (h *memberHandler) GetMembers(w http.ResponseWriter, _ *http.Request) {
 	h.rd.JSON(w, http.StatusOK, members)
 }
 
-func getMembers(svr *server.Server) (*pdpb.GetMembersResponse, error) {
-	if _, err := svr.ReloadMembers(); err != nil {
-		return nil, errors.WithStack(err)
+func getMembers(svr *server.Server, forceRefresh bool) (*pdpb.GetMembersResponse, error) {
+	if forceRefresh {
+		if _, err := svr.ReloadMembers(); err != nil {
+			return nil, errors.WithStack(err)
+		}
 	}
 	req := &pdpb.GetMembersRequest{Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()}}
 	grpcServer := &server.GrpcServer{Server: svr}
@@ -205,7 +207,7 @@ func (h *memberHandler) DeleteMemberByID(w http.ResponseWriter, r *http.Request)
 //	@Failure	500	{string}	string	"PD server failed to proceed the request."
 //	@Router		/members/name/{name} [post]
 func (h *memberHandler) SetMemberPropertyByName(w http.ResponseWriter, r *http.Request) {
-	members, membersErr := getMembers(h.svr)
+	members, membersErr := getMembers(h.svr, true)
 	if membersErr != nil {
 		h.rd.JSON(w, http.StatusInternalServerError, membersErr.Error())
 		return

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -442,7 +442,7 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 			Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, errs.ErrServerNotStarted.FastGenByArgs().Error()),
 		}, nil
 	}
-	members, err := cluster.GetMembers(s.GetClient())
+	members, err := s.Server.GetMembers()
 	if err != nil {
 		return &pdpb.GetMembersResponse{
 			Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
@@ -451,19 +451,16 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 
 	var etcdLeader, pdLeader *pdpb.Member
 	leaderID := s.member.GetEtcdLeader()
-	for _, m := range members {
-		if m.MemberId == leaderID {
-			etcdLeader = m
-			break
-		}
-	}
-
 	leader := s.member.GetLeader()
-	for _, m := range members {
-		if m.MemberId == leader.GetMemberId() {
-			pdLeader = m
-			break
+	etcdLeader, pdLeader = findLeadersInMembers(members, leaderID, leader)
+	if (pdLeader == nil && leader != nil) || (etcdLeader == nil && leaderID != 0) {
+		members, err = s.ReloadMembers()
+		if err != nil {
+			return &pdpb.GetMembersResponse{
+				Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
+			}, nil
 		}
+		etcdLeader, pdLeader = findLeadersInMembers(members, leaderID, leader)
 	}
 
 	return &pdpb.GetMembersResponse{
@@ -472,6 +469,19 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 		Leader:     pdLeader,
 		EtcdLeader: etcdLeader,
 	}, nil
+}
+
+func findLeadersInMembers(members []*pdpb.Member, etcdLeaderID uint64, leader *pdpb.Member) (*pdpb.Member, *pdpb.Member) {
+	var etcdLeader, pdLeader *pdpb.Member
+	for _, m := range members {
+		if m.GetMemberId() == etcdLeaderID {
+			etcdLeader = m
+		}
+		if leader != nil && m.GetMemberId() == leader.GetMemberId() {
+			pdLeader = m
+		}
+	}
+	return etcdLeader, pdLeader
 }
 
 // Tso implements gRPC PDServer.

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -460,6 +460,8 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 				Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
 			}, nil
 		}
+		leaderID = s.member.GetEtcdLeader()
+		leader = s.member.GetLeader()
 		etcdLeader, pdLeader = findLeadersInMembers(members, leaderID, leader)
 	}
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -471,8 +471,7 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	}, nil
 }
 
-func findLeadersInMembers(members []*pdpb.Member, etcdLeaderID uint64, leader *pdpb.Member) (*pdpb.Member, *pdpb.Member) {
-	var etcdLeader, pdLeader *pdpb.Member
+func findLeadersInMembers(members []*pdpb.Member, etcdLeaderID uint64, leader *pdpb.Member) (etcdLeader, pdLeader *pdpb.Member) {
 	for _, m := range members {
 		if m.GetMemberId() == etcdLeaderID {
 			etcdLeader = m

--- a/server/member_cache.go
+++ b/server/member_cache.go
@@ -15,31 +15,32 @@
 package server
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"golang.org/x/sync/singleflight"
-
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/tikv/pd/pkg/utils/syncutil"
 )
 
 const membersCacheTTL = time.Second
-const (
-	membersCacheLoadKey      = "members"
-	membersCacheForceLoadKey = "members-force"
-)
 
 type membersCache struct {
-	mu         sync.RWMutex
-	ttl        time.Duration
-	members    []*pdpb.Member
-	expireAt   time.Time
-	refreshSeq uint64
-	flight     singleflight.Group
+	mu              sync.RWMutex
+	ttl             time.Duration
+	members         []*pdpb.Member
+	expireAt        time.Time
+	refreshSeq      uint64
+	loadFlight      *syncutil.OrderedSingleFlight[[]*pdpb.Member]
+	forceLoadFlight *syncutil.OrderedSingleFlight[[]*pdpb.Member]
 }
 
 func newMembersCache(ttl time.Duration) *membersCache {
-	return &membersCache{ttl: ttl}
+	return &membersCache{
+		ttl:             ttl,
+		loadFlight:      syncutil.NewOrderedSingleFlight[[]*pdpb.Member](),
+		forceLoadFlight: syncutil.NewOrderedSingleFlight[[]*pdpb.Member](),
+	}
 }
 
 func (c *membersCache) get(forceRefresh bool, load func() ([]*pdpb.Member, error)) ([]*pdpb.Member, error) {
@@ -49,11 +50,11 @@ func (c *membersCache) get(forceRefresh bool, load func() ([]*pdpb.Member, error
 		}
 	}
 
-	key := membersCacheLoadKey
+	flight := c.loadFlight
 	if forceRefresh {
-		key = membersCacheForceLoadKey
+		flight = c.forceLoadFlight
 	}
-	value, err, _ := c.flight.Do(key, func() (any, error) {
+	members, err := flight.Do(context.Background(), func(context.Context) ([]*pdpb.Member, error) {
 		if !forceRefresh {
 			if members, ok := c.getFresh(); ok {
 				return members, nil
@@ -65,7 +66,7 @@ func (c *membersCache) get(forceRefresh bool, load func() ([]*pdpb.Member, error
 	if err != nil {
 		return nil, err
 	}
-	return cloneMembers(value.([]*pdpb.Member)), nil
+	return cloneMembers(members), nil
 }
 
 func (c *membersCache) loadAndStore(load func() ([]*pdpb.Member, error)) ([]*pdpb.Member, error) {

--- a/server/member_cache.go
+++ b/server/member_cache.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/pdpb"
+
 	"github.com/tikv/pd/pkg/utils/syncutil"
 )
 

--- a/server/member_cache.go
+++ b/server/member_cache.go
@@ -1,0 +1,99 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+const membersCacheTTL = time.Second
+
+type membersCache struct {
+	mu       sync.RWMutex
+	ttl      time.Duration
+	members  []*pdpb.Member
+	expireAt time.Time
+	flight   singleflight.Group
+}
+
+func newMembersCache(ttl time.Duration) *membersCache {
+	return &membersCache{ttl: ttl}
+}
+
+func (c *membersCache) get(forceRefresh bool, load func() ([]*pdpb.Member, error)) ([]*pdpb.Member, error) {
+	if !forceRefresh {
+		if members, ok := c.getFresh(); ok {
+			return members, nil
+		}
+	}
+
+	value, err, _ := c.flight.Do("members", func() (any, error) {
+		if !forceRefresh {
+			if members, ok := c.getFresh(); ok {
+				return members, nil
+			}
+		}
+
+		members, err := load()
+		if err != nil {
+			return nil, err
+		}
+		cachedMembers := cloneMembers(members)
+		c.mu.Lock()
+		c.members = cachedMembers
+		c.expireAt = time.Now().Add(c.ttl)
+		c.mu.Unlock()
+		return cachedMembers, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cloneMembers(value.([]*pdpb.Member)), nil
+}
+
+func (c *membersCache) getFresh() ([]*pdpb.Member, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.members == nil || !time.Now().Before(c.expireAt) {
+		return nil, false
+	}
+	return cloneMembers(c.members), true
+}
+
+func cloneMembers(members []*pdpb.Member) []*pdpb.Member {
+	if members == nil {
+		return nil
+	}
+	cloned := make([]*pdpb.Member, 0, len(members))
+	for _, member := range members {
+		cloned = append(cloned, cloneMember(member))
+	}
+	return cloned
+}
+
+func cloneMember(member *pdpb.Member) *pdpb.Member {
+	if member == nil {
+		return nil
+	}
+	cloned := *member
+	cloned.PeerUrls = append([]string(nil), member.GetPeerUrls()...)
+	cloned.ClientUrls = append([]string(nil), member.GetClientUrls()...)
+	return &cloned
+}

--- a/server/member_cache.go
+++ b/server/member_cache.go
@@ -24,13 +24,18 @@ import (
 )
 
 const membersCacheTTL = time.Second
+const (
+	membersCacheLoadKey      = "members"
+	membersCacheForceLoadKey = "members-force"
+)
 
 type membersCache struct {
-	mu       sync.RWMutex
-	ttl      time.Duration
-	members  []*pdpb.Member
-	expireAt time.Time
-	flight   singleflight.Group
+	mu         sync.RWMutex
+	ttl        time.Duration
+	members    []*pdpb.Member
+	expireAt   time.Time
+	refreshSeq uint64
+	flight     singleflight.Group
 }
 
 func newMembersCache(ttl time.Duration) *membersCache {
@@ -44,28 +49,51 @@ func (c *membersCache) get(forceRefresh bool, load func() ([]*pdpb.Member, error
 		}
 	}
 
-	value, err, _ := c.flight.Do("members", func() (any, error) {
+	key := membersCacheLoadKey
+	if forceRefresh {
+		key = membersCacheForceLoadKey
+	}
+	value, err, _ := c.flight.Do(key, func() (any, error) {
 		if !forceRefresh {
 			if members, ok := c.getFresh(); ok {
 				return members, nil
 			}
 		}
 
-		members, err := load()
-		if err != nil {
-			return nil, err
-		}
-		cachedMembers := cloneMembers(members)
-		c.mu.Lock()
-		c.members = cachedMembers
-		c.expireAt = time.Now().Add(c.ttl)
-		c.mu.Unlock()
-		return cachedMembers, nil
+		return c.loadAndStore(load)
 	})
 	if err != nil {
 		return nil, err
 	}
 	return cloneMembers(value.([]*pdpb.Member)), nil
+}
+
+func (c *membersCache) loadAndStore(load func() ([]*pdpb.Member, error)) ([]*pdpb.Member, error) {
+	seq := c.beginRefresh()
+	members, err := load()
+	if err != nil {
+		return nil, err
+	}
+	cachedMembers := cloneMembers(members)
+	c.storeIfLatest(seq, cachedMembers)
+	return cachedMembers, nil
+}
+
+func (c *membersCache) beginRefresh() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refreshSeq++
+	return c.refreshSeq
+}
+
+func (c *membersCache) storeIfLatest(seq uint64, members []*pdpb.Member) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if seq != c.refreshSeq {
+		return
+	}
+	c.members = members
+	c.expireAt = time.Now().Add(c.ttl)
 }
 
 func (c *membersCache) getFresh() ([]*pdpb.Member, bool) {

--- a/server/member_cache_test.go
+++ b/server/member_cache_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -78,6 +79,56 @@ func TestMembersCacheForceRefresh(t *testing.T) {
 	re.Equal(int32(2), loadCount.Load())
 }
 
+func TestMembersCacheForceRefreshDoesNotShareNormalRefresh(t *testing.T) {
+	re := require.New(t)
+	cache := newMembersCache(time.Hour)
+	var loadCount atomic.Int32
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	load := func() ([]*pdpb.Member, error) {
+		id := loadCount.Add(1)
+		switch id {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case 2:
+		default:
+			return nil, errors.New("unexpected member load")
+		}
+		return []*pdpb.Member{{MemberId: uint64(id)}}, nil
+	}
+
+	normalCh := make(chan struct {
+		members []*pdpb.Member
+		err     error
+	}, 1)
+	go func() {
+		members, err := cache.get(false, load)
+		normalCh <- struct {
+			members []*pdpb.Member
+			err     error
+		}{members: members, err: err}
+	}()
+	<-firstStarted
+
+	forceMembers, err := cache.get(true, load)
+	re.NoError(err)
+	re.Equal(uint64(2), forceMembers[0].GetMemberId())
+	re.Equal(int32(2), loadCount.Load())
+
+	close(releaseFirst)
+	normalResult := <-normalCh
+	re.NoError(normalResult.err)
+	re.Equal(uint64(1), normalResult.members[0].GetMemberId())
+
+	cachedMembers, err := cache.get(false, func() ([]*pdpb.Member, error) {
+		return nil, errors.New("cache should keep the forced refresh result")
+	})
+	re.NoError(err)
+	re.Equal(uint64(2), cachedMembers[0].GetMemberId())
+	re.Equal(int32(2), loadCount.Load())
+}
+
 func TestMembersCacheSingleflight(t *testing.T) {
 	re := require.New(t)
 	cache := newMembersCache(time.Hour)
@@ -86,7 +137,9 @@ func TestMembersCacheSingleflight(t *testing.T) {
 	release := make(chan struct{})
 	var once sync.Once
 	load := func() ([]*pdpb.Member, error) {
-		loadCount.Add(1)
+		if loadCount.Add(1) > 1 {
+			return nil, errors.New("duplicate member load")
+		}
 		once.Do(func() { close(started) })
 		<-release
 		return []*pdpb.Member{{MemberId: 1}}, nil

--- a/server/member_cache_test.go
+++ b/server/member_cache_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/pdpb"
+)
+
+func TestMembersCacheReturnsClonedMembers(t *testing.T) {
+	re := require.New(t)
+	cache := newMembersCache(time.Hour)
+	var loadCount atomic.Int32
+
+	members, err := cache.get(false, func() ([]*pdpb.Member, error) {
+		loadCount.Add(1)
+		return []*pdpb.Member{{
+			Name:       "pd-1",
+			MemberId:   1,
+			ClientUrls: []string{"http://127.0.0.1:2379"},
+			PeerUrls:   []string{"http://127.0.0.1:2380"},
+		}}, nil
+	})
+	re.NoError(err)
+	members[0].Name = "mutated"
+	members[0].ClientUrls[0] = "mutated"
+	members[0].PeerUrls[0] = "mutated"
+
+	members, err = cache.get(false, func() ([]*pdpb.Member, error) {
+		re.FailNow("cache should serve fresh members without loading")
+		return nil, nil
+	})
+	re.NoError(err)
+	re.Equal(int32(1), loadCount.Load())
+	re.Equal("pd-1", members[0].GetName())
+	re.Equal([]string{"http://127.0.0.1:2379"}, members[0].GetClientUrls())
+	re.Equal([]string{"http://127.0.0.1:2380"}, members[0].GetPeerUrls())
+}
+
+func TestMembersCacheForceRefresh(t *testing.T) {
+	re := require.New(t)
+	cache := newMembersCache(time.Hour)
+	var loadCount atomic.Int32
+	load := func() ([]*pdpb.Member, error) {
+		id := uint64(loadCount.Add(1))
+		return []*pdpb.Member{{MemberId: id}}, nil
+	}
+
+	members, err := cache.get(false, load)
+	re.NoError(err)
+	re.Equal(uint64(1), members[0].GetMemberId())
+
+	members, err = cache.get(false, load)
+	re.NoError(err)
+	re.Equal(uint64(1), members[0].GetMemberId())
+
+	members, err = cache.get(true, load)
+	re.NoError(err)
+	re.Equal(uint64(2), members[0].GetMemberId())
+	re.Equal(int32(2), loadCount.Load())
+}
+
+func TestMembersCacheSingleflight(t *testing.T) {
+	re := require.New(t)
+	cache := newMembersCache(time.Hour)
+	var loadCount atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	load := func() ([]*pdpb.Member, error) {
+		loadCount.Add(1)
+		once.Do(func() { close(started) })
+		<-release
+		return []*pdpb.Member{{MemberId: 1}}, nil
+	}
+
+	const concurrency = 16
+	var wg sync.WaitGroup
+	errCh := make(chan error, concurrency)
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := cache.get(false, load)
+			errCh <- err
+		}()
+	}
+	<-started
+	close(release)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		re.NoError(err)
+	}
+	re.Equal(int32(1), loadCount.Load())
+}

--- a/server/server.go
+++ b/server/server.go
@@ -242,6 +242,7 @@ type Server struct {
 	resourceManagerPrimaryWatcher    *etcdutil.LoopWatcher
 	resourceGroupMetadataManager     *rm_server.Manager
 	resourceGroupMetadataManagerOnce sync.Once
+	membersCache                     *membersCache
 
 	// Cgroup Monitor
 	cgMonitor cgroup.Monitor
@@ -274,6 +275,7 @@ func CreateServer(ctx context.Context, cfg *config.Config, services []string, le
 		startTimestamp:                  time.Now().Unix(),
 		DiagnosticsServer:               sysutil.NewDiagnosticsServer(cfg.Log.File.Filename),
 		isKeyspaceGroupEnabled:          isKeyspaceGroupEnabled,
+		membersCache:                    newMembersCache(membersCacheTTL),
 		tsoClientPool: struct {
 			syncutil.RWMutex
 			clients map[string]*streamWrapper
@@ -1162,8 +1164,22 @@ func (s *Server) StartTimestamp() int64 {
 
 // GetMembers returns PD server list.
 func (s *Server) GetMembers() ([]*pdpb.Member, error) {
+	return s.loadMembers(false)
+}
+
+// ReloadMembers reloads PD server list and updates the cache.
+func (s *Server) ReloadMembers() ([]*pdpb.Member, error) {
+	return s.loadMembers(true)
+}
+
+func (s *Server) loadMembers(forceRefresh bool) ([]*pdpb.Member, error) {
 	if s.IsClosed() {
 		return nil, errs.ErrServerNotStarted.FastGenByArgs()
+	}
+	if s.membersCache != nil {
+		return s.membersCache.get(forceRefresh, func() ([]*pdpb.Member, error) {
+			return cluster.GetMembers(s.GetClient())
+		})
 	}
 	return cluster.GetMembers(s.GetClient())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10927

When many TiDB instances start at the same time, each client initializes service discovery by calling `GetMembers`. The current PD server path lists etcd members for every request, which can amplify etcd `MemberList` pressure during startup storms.

### What is changed and how does it work?

```commit-message
server: cache PD member list

Cache the etcd member list on the PD server side with a short TTL and
singleflight refresh. `GetMembers` still resolves the current PD leader and
etcd leader while building each response, so client routing does not depend on
a cached full response.

The cached members are cloned before returning to callers. This prevents HTTP
`/members` response enrichment fields, such as binary version and deploy path,
from mutating cached member objects.
```

### Check List

Tests

- Unit test

Code changes

- None

Side effects

- Increased code complexity

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn): N/A
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup): N/A
- Need to cherry-pick to the release branch: No

### Release note

```release-note
Reduce PD etcd member list pressure during TiDB startup storms by caching PD member list responses on the server side.
```

### Tests

```bash
go test -count=1 ./server ./server/api
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a TTL-based in-memory cache for member list retrieval to reduce repeated lookups.
  * Added an on-demand refresh to reload the cached member list, now used by admin endpoints before fetching members.
* **Bug Fixes**
  * Improved leader resolution by deriving PD and etcd leaders from the same member snapshot, automatically reloading when leader details are incomplete.
* **Tests**
  * Added coverage for cloned (non-mutable) cached results, force-refresh isolation vs normal refresh, and singleflight deduplication for concurrent refresh calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->