### PR TITLE
syncer: add region syncer observability

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -13901,6 +13901,608 @@
               "show": true
             }
           ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 220
+          },
+          "id": 1503,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pd_region_syncer_client_ready{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Region syncer client ready",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 220
+          },
+          "id": 1504,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(increase(pd_region_syncer_full_sync_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (result, reason)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{result}}-{{reason}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Region syncer full sync count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 227
+          },
+          "id": 1505,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pd_region_syncer_full_sync_last_duration_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-{{result}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Region syncer full sync last duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 227
+          },
+          "id": 1506,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pd_region_syncer_history_buffer_length{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "length-{{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "pd_region_syncer_history_buffer_capacity{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "capacity-{{instance}}",
+              "refId": "B"
+            },
+            {
+              "expr": "pd_region_syncer_history_buffer_max_capacity{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "max-capacity-{{instance}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Region syncer history buffer",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 234
+          },
+          "id": 1507,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(increase(pd_region_syncer_history_buffer_resize_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (direction)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "resize-{{direction}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(increase(pd_region_syncer_history_buffer_miss_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (phase)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "miss-{{phase}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Region syncer history buffer events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 234
+          },
+          "id": 1508,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pd_region_syncer_downstream_lag{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-{{downstream}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Region syncer downstream lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 241
+          },
+          "id": 1509,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(increase(pd_region_syncer_stream_events_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (event)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{event}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Region syncer stream events",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
         }
       ],
       "repeat": null,

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -14202,13 +14202,6 @@
               "intervalFactor": 2,
               "legendFormat": "capacity-{{instance}}",
               "refId": "B"
-            },
-            {
-              "expr": "pd_region_syncer_history_buffer_max_capacity_records{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "max-capacity-{{instance}}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -14287,18 +14280,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(pd_region_syncer_history_buffer_resize_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (direction)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "resize-{{direction}}",
-              "refId": "A"
-            },
-            {
               "expr": "sum(increase(pd_region_syncer_history_buffer_miss_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (phase)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "miss-{{phase}}",
-              "refId": "B"
+              "refId": "A"
             }
           ],
           "thresholds": [],

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -14024,10 +14024,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(pd_region_syncer_full_sync_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (result, reason)",
+              "expr": "sum(increase(pd_region_syncer_full_sync_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (result, trigger, failure_reason)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{result}}-{{reason}}",
+              "legendFormat": "{{result}}-{{trigger}}-{{failure_reason}}",
               "refId": "A"
             }
           ],
@@ -14190,21 +14190,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_region_syncer_history_buffer_length{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "expr": "pd_region_syncer_history_buffer_length_records{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "length-{{instance}}",
               "refId": "A"
             },
             {
-              "expr": "pd_region_syncer_history_buffer_capacity{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "expr": "pd_region_syncer_history_buffer_capacity_records{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "capacity-{{instance}}",
               "refId": "B"
             },
             {
-              "expr": "pd_region_syncer_history_buffer_max_capacity{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "expr": "pd_region_syncer_history_buffer_max_capacity_records{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "max-capacity-{{instance}}",
@@ -14377,7 +14377,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_region_syncer_downstream_lag{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "expr": "pd_region_syncer_downstream_lag_records{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}-{{downstream}}",

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -13941,7 +13941,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_region_syncer_client_ready{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "expr": "pd_region_syncer_client_ready{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"} unless on(instance) (service_member_role{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", service=\"PD\"} == 1)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -14024,18 +14024,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(pd_region_syncer_full_sync_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (result, trigger, failure_reason)",
+              "expr": "sum(increase(pd_region_syncer_full_sync_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (instance, trigger, outcome)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{result}}-{{trigger}}-{{failure_reason}}",
+              "legendFormat": "{{instance}}-{{trigger}}-{{outcome}}",
               "refId": "A"
+            },
+            {
+              "expr": "pd_region_syncer_full_sync_in_progress{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}-in-progress",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Region syncer full sync count",
+          "title": "Region syncer full sync activity",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -14280,10 +14287,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(pd_region_syncer_history_buffer_miss_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (phase)",
+              "expr": "sum(increase(pd_region_syncer_history_buffer_live_drain_miss_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "miss-{{phase}}",
+              "legendFormat": "{{instance}}-live-drain-miss",
               "refId": "A"
             }
           ],
@@ -14291,7 +14298,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Region syncer history buffer events",
+          "title": "Region syncer history buffer live-drain misses",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -14446,10 +14453,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(pd_region_syncer_stream_events_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (event)",
+              "expr": "sum(increase(pd_region_syncer_stream_events_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[1m])) by (instance, event)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{event}}",
+              "legendFormat": "{{instance}}-{{event}}",
               "refId": "A"
             }
           ],

--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -14018,7 +14018,12 @@
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/.*-in-progress/",
+              "yaxis": 2
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
@@ -14059,7 +14064,7 @@
           "yaxes": [
             {
               "format": "short",
-              "label": null,
+              "label": "events/min",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -14067,7 +14072,7 @@
             },
             {
               "format": "short",
-              "label": null,
+              "label": "in progress",
               "logBase": 1,
               "max": null,
               "min": null,

--- a/pkg/mcs/router/server/sync.go
+++ b/pkg/mcs/router/server/sync.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
-	"github.com/tikv/pd/pkg/syncer"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
@@ -357,7 +356,7 @@ func (s *RegionSyncer) sync(ctx context.Context, leaderAddr string) {
 	}
 }
 
-func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (syncer.ClientStream, error) {
+func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (pdpb.PD_SyncRegionsClient, error) {
 	cli := pdpb.NewPDClient(conn)
 	syncStream, err := cli.SyncRegions(ctx)
 	if err != nil {

--- a/pkg/mock/mockserver/mockserver.go
+++ b/pkg/mock/mockserver/mockserver.go
@@ -28,6 +28,7 @@ import (
 type MockServer struct {
 	ctx            context.Context
 	member, leader *pdpb.Member
+	members        []*pdpb.Member
 	storage        storage.Storage
 	bc             *core.BasicCluster
 }
@@ -56,6 +57,16 @@ func (*MockServer) ClusterID() uint64 {
 // GetMemberInfo returns the member info of the server.
 func (s *MockServer) GetMemberInfo() *pdpb.Member {
 	return s.member
+}
+
+// GetMembers returns the members of the mock PD cluster.
+func (s *MockServer) GetMembers() ([]*pdpb.Member, error) {
+	return s.members, nil
+}
+
+// SetMembers sets the members of the mock PD cluster.
+func (s *MockServer) SetMembers(members []*pdpb.Member) {
+	s.members = members
 }
 
 // GetLeader returns the leader of the server.

--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -63,6 +63,7 @@ func (s *RegionSyncer) reset() {
 		s.mu.clientCancel()
 	}
 	s.mu.clientCancel, s.mu.clientCtx = nil, nil
+	setRegionSyncerClientReadyMetrics(false)
 }
 
 // ResetHistoryIndex resets and persists the next region sync history index.
@@ -100,6 +101,7 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 	nextFullSyncing = fullSyncing
 	if syncErr := resp.GetHeader().GetError(); syncErr != nil {
 		s.streamingRunning.Store(false)
+		setRegionSyncerClientReadyMetrics(false)
 		log.Warn("region sync with leader received error response",
 			zap.String("server", s.server.Name()),
 			zap.String("error-type", syncErr.GetType().String()),
@@ -175,6 +177,7 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 	if !nextFullSyncing {
 		// mark the client as running status when it finished the first history region sync.
 		s.streamingRunning.Store(true)
+		setRegionSyncerClientReadyMetrics(true)
 	}
 	return true, nextFullSyncing
 }
@@ -192,11 +195,15 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 	defer s.mu.Unlock()
 	s.mu.clientCtx, s.mu.clientCancel = context.WithCancel(s.server.LoopContext())
 	ctx := s.mu.clientCtx
+	setRegionSyncerClientReadyMetrics(false)
 
 	go func() {
 		defer logutil.LogPanic()
 		defer s.wg.Done()
-		defer s.streamingRunning.Store(false)
+		defer func() {
+			s.streamingRunning.Store(false)
+			setRegionSyncerClientReadyMetrics(false)
+		}()
 		// used to load region from kv storage to cache storage.
 		bc := s.server.GetBasicCluster()
 		regionStorage := s.server.GetStorage()
@@ -271,6 +278,7 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 				}
 				if err != nil {
 					s.streamingRunning.Store(false)
+					setRegionSyncerClientReadyMetrics(false)
 					log.Warn("region sync with leader meet error", errs.ZapError(errs.ErrGRPCRecv, err))
 					if err = stream.CloseSend(); err != nil {
 						log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))

--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -128,6 +128,10 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 	}
 	hasStats := len(stats) == len(regions)
 	hasBuckets := len(buckets) == len(regions)
+	var historyRecords []*core.RegionInfo
+	if !inFullSync {
+		historyRecords = make([]*core.RegionInfo, 0, len(regions))
+	}
 	for i, r := range regions {
 		var (
 			region       *core.RegionInfo
@@ -167,12 +171,13 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 			err = regionStorage.SaveRegion(r)
 		}
 		if err == nil && !inFullSync {
-			s.history.record(region)
+			historyRecords = append(historyRecords, region)
 		}
 		for _, old := range overlaps {
 			_ = regionStorage.DeleteRegion(old.GetMeta())
 		}
 	}
+	s.history.record(historyRecords...)
 	nextFullSyncing = inFullSync && len(regions) > 0
 	if !nextFullSyncing {
 		// mark the client as running status when it finished the first history region sync.

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -85,6 +85,7 @@ func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv 
 		flushCount:   defaultFlushCount,
 	}
 	h.reload()
+	h.observeMetricsLocked()
 	return h
 }
 
@@ -142,6 +143,7 @@ func (h *historyBuffer) recordLocked(r *core.RegionInfo) {
 		h.head = (h.head + 1) % h.size
 	}
 	h.index++
+	h.observeMetricsLocked()
 	h.flushCount--
 	if h.flushCount <= 0 {
 		h.persist()
@@ -312,6 +314,7 @@ func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	if h.capacity() > h.baseCapacity {
 		h.resizeLocked(h.baseCapacity)
 	}
+	h.observeMetricsLocked()
 }
 
 func (h *historyBuffer) resetWithIndexAndPersist(index uint64) {
@@ -373,6 +376,7 @@ func (h *historyBuffer) growForWindowLocked(window uint64) {
 }
 
 func (h *historyBuffer) resizeLocked(newCapacity int) {
+	oldCapacity := h.capacity()
 	newCapacity = normalizeHistoryBufferCapacity(newCapacity, h.capacityUnit)
 	if newCapacity < h.baseCapacity {
 		newCapacity = h.baseCapacity
@@ -396,6 +400,12 @@ func (h *historyBuffer) resizeLocked(newCapacity int) {
 	h.size = newCapacity + 1
 	h.head = 0
 	h.tail = keep % h.size
+	if newCapacity > oldCapacity {
+		incHistoryBufferResizeMetrics(historyBufferResizeGrow)
+	} else {
+		incHistoryBufferResizeMetrics(historyBufferResizeShrink)
+	}
+	h.observeMetricsLocked()
 }
 
 func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
@@ -404,4 +414,8 @@ func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
 		return h.records[pos]
 	}
 	return nil
+}
+
+func (h *historyBuffer) observeMetricsLocked() {
+	observeHistoryBufferMetrics(h.len(), h.capacity(), h.maxCapacity)
 }

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -379,7 +379,6 @@ func (h *historyBuffer) growForWindowLocked(window uint64) {
 }
 
 func (h *historyBuffer) resizeLocked(newCapacity int) {
-	oldCapacity := h.capacity()
 	newCapacity = normalizeHistoryBufferCapacity(newCapacity, h.capacityUnit)
 	if newCapacity < h.baseCapacity {
 		newCapacity = h.baseCapacity
@@ -403,11 +402,6 @@ func (h *historyBuffer) resizeLocked(newCapacity int) {
 	h.size = newCapacity + 1
 	h.head = 0
 	h.tail = keep % h.size
-	if newCapacity > oldCapacity {
-		incHistoryBufferResizeMetrics(historyBufferResizeGrow)
-	} else {
-		incHistoryBufferResizeMetrics(historyBufferResizeShrink)
-	}
 	h.observeMetricsLocked()
 }
 
@@ -420,5 +414,5 @@ func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
 }
 
 func (h *historyBuffer) observeMetricsLocked() {
-	observeHistoryBufferMetrics(h.len(), h.capacity(), h.maxCapacity)
+	observeHistoryBufferMetrics(h.len(), h.capacity())
 }

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -129,9 +129,13 @@ func (h *historyBuffer) record(records ...*core.RegionInfo) {
 	}
 	h.Lock()
 	defer h.Unlock()
+	oldLength := h.len()
 	h.prepareRequiredWindowLocked(uint64(len(records)))
 	for _, r := range records {
 		h.recordLocked(r)
+	}
+	if h.len() != oldLength {
+		observeHistoryBufferLengthMetrics(h.len())
 	}
 }
 
@@ -143,7 +147,6 @@ func (h *historyBuffer) recordLocked(r *core.RegionInfo) {
 		h.head = (h.head + 1) % h.size
 	}
 	h.index++
-	h.observeMetricsLocked()
 	h.flushCount--
 	if h.flushCount <= 0 {
 		h.persist()

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -17,6 +17,7 @@ package syncer
 import (
 	"testing"
 
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -211,6 +212,36 @@ func TestHistoryBufferFullSyncRetainTakesPriorityOverRequiredWindow(t *testing.T
 	re.Equal(uint64(5), records[4].GetID())
 	re.Equal(uint64(10), h.getFirstIndex())
 	re.Equal(8, h.capacity())
+}
+
+func TestHistoryBufferMetrics(t *testing.T) {
+	re := require.New(t)
+	growCounter := regionSyncerHistoryBufferResizeCounters[historyBufferResizeGrow]
+	shrinkCounter := regionSyncerHistoryBufferResizeCounters[historyBufferResizeShrink]
+	growBefore := promtestutil.ToFloat64(growCounter)
+	shrinkBefore := promtestutil.ToFloat64(shrinkCounter)
+
+	h := newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
+	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerHistoryBufferLengthGauge))
+	re.Equal(2.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
+	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferMaxCapacityGauge))
+
+	h.resetWithIndex(10)
+	h.record(newHistoryBufferTestRegion(1))
+	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerHistoryBufferLengthGauge))
+	re.Equal(2.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
+
+	h.observeRequiredWindow(3)
+	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
+	re.Equal(growBefore+1, promtestutil.ToFloat64(growCounter))
+	h.maybeShrink()
+
+	for range historyBufferShrinkRounds {
+		h.observeRequiredWindow(1)
+		h.maybeShrink()
+	}
+	re.Equal(4.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
+	re.Equal(shrinkBefore+1, promtestutil.ToFloat64(shrinkCounter))
 }
 
 func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -222,17 +222,17 @@ func TestHistoryBufferMetrics(t *testing.T) {
 	shrinkBefore := promtestutil.ToFloat64(shrinkCounter)
 
 	h := newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
-	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerHistoryBufferLengthGauge))
-	re.Equal(2.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
-	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferMaxCapacityGauge))
+	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerHistoryBufferLengthRecordsGauge))
+	re.Equal(2.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityRecordsGauge))
+	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferMaxCapacityRecordsGauge))
 
 	h.resetWithIndex(10)
 	h.record(newHistoryBufferTestRegion(1))
-	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerHistoryBufferLengthGauge))
-	re.Equal(2.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
+	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerHistoryBufferLengthRecordsGauge))
+	re.Equal(2.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityRecordsGauge))
 
 	h.observeRequiredWindow(3)
-	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
+	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityRecordsGauge))
 	re.Equal(growBefore+1, promtestutil.ToFloat64(growCounter))
 	h.maybeShrink()
 
@@ -240,7 +240,7 @@ func TestHistoryBufferMetrics(t *testing.T) {
 		h.observeRequiredWindow(1)
 		h.maybeShrink()
 	}
-	re.Equal(4.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityGauge))
+	re.Equal(4.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityRecordsGauge))
 	re.Equal(shrinkBefore+1, promtestutil.ToFloat64(shrinkCounter))
 }
 

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -216,15 +216,9 @@ func TestHistoryBufferFullSyncRetainTakesPriorityOverRequiredWindow(t *testing.T
 
 func TestHistoryBufferMetrics(t *testing.T) {
 	re := require.New(t)
-	growCounter := regionSyncerHistoryBufferResizeCounters[historyBufferResizeGrow]
-	shrinkCounter := regionSyncerHistoryBufferResizeCounters[historyBufferResizeShrink]
-	growBefore := promtestutil.ToFloat64(growCounter)
-	shrinkBefore := promtestutil.ToFloat64(shrinkCounter)
-
 	h := newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
 	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerHistoryBufferLengthRecordsGauge))
 	re.Equal(2.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityRecordsGauge))
-	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferMaxCapacityRecordsGauge))
 
 	h.resetWithIndex(10)
 	h.record(newHistoryBufferTestRegion(1))
@@ -233,7 +227,6 @@ func TestHistoryBufferMetrics(t *testing.T) {
 
 	h.observeRequiredWindow(3)
 	re.Equal(8.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityRecordsGauge))
-	re.Equal(growBefore+1, promtestutil.ToFloat64(growCounter))
 	h.maybeShrink()
 
 	for range historyBufferShrinkRounds {
@@ -241,7 +234,6 @@ func TestHistoryBufferMetrics(t *testing.T) {
 		h.maybeShrink()
 	}
 	re.Equal(4.0, promtestutil.ToFloat64(regionSyncerHistoryBufferCapacityRecordsGauge))
-	re.Equal(shrinkBefore+1, promtestutil.ToFloat64(shrinkCounter))
 }
 
 func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {

--- a/pkg/syncer/metrics.go
+++ b/pkg/syncer/metrics.go
@@ -14,7 +14,39 @@
 
 package syncer
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	fullSyncResultSuccess = "success"
+	fullSyncResultFailure = "failure"
+
+	fullSyncReasonInitial            = "initial"
+	fullSyncReasonHistoryGap         = "history_gap"
+	fullSyncReasonStartIndexAhead    = "start_index_ahead"
+	fullSyncReasonMaxHistoryExceeded = "max_history_exceeded"
+	fullSyncReasonSendError          = "send_error"
+	fullSyncReasonContextCanceled    = "context_canceled"
+	fullSyncReasonStreamClosed       = "stream_closed"
+	fullSyncReasonUnknown            = "unknown"
+
+	historyBufferResizeGrow   = "grow"
+	historyBufferResizeShrink = "shrink"
+
+	historyBufferMissHistorySync     = "history_sync"
+	historyBufferMissLiveDrain       = "live_drain"
+	historyBufferMissFullSyncCatchUp = "full_sync_catch_up"
+
+	streamEventBind            = "bind"
+	streamEventUnbind          = "unbind"
+	streamEventSendError       = "send_error"
+	streamEventSendTimeout     = "send_timeout"
+	streamEventContextCanceled = "context_canceled"
+	streamEventStreamClosed    = "stream_closed"
+)
 
 var regionSyncerStatus = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
@@ -24,6 +56,189 @@ var regionSyncerStatus = prometheus.NewGaugeVec(
 		Help:      "Inner status of the region syncer.",
 	}, []string{"type"})
 
+var (
+	regionSyncerClientReadyGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "client_ready",
+			Help:      "Whether the region syncer client has completed synchronization and can serve follower region reads.",
+		})
+
+	regionSyncerFullSyncCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "full_sync_total",
+			Help:      "Counter of region syncer full synchronization attempts by result and reason.",
+		}, []string{"result", "reason"})
+
+	regionSyncerFullSyncLastDurationGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "full_sync_last_duration_seconds",
+			Help:      "Duration in seconds of the latest region syncer full synchronization attempt by result.",
+		}, []string{"result"})
+
+	regionSyncerHistoryBufferCapacityGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "history_buffer_capacity",
+			Help:      "Current capacity of the region syncer history buffer.",
+		})
+
+	regionSyncerHistoryBufferLengthGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "history_buffer_length",
+			Help:      "Current number of records retained in the region syncer history buffer.",
+		})
+
+	regionSyncerHistoryBufferMaxCapacityGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "history_buffer_max_capacity",
+			Help:      "Maximum capacity allowed for the region syncer history buffer.",
+		})
+
+	regionSyncerHistoryBufferResizeCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "history_buffer_resize_total",
+			Help:      "Counter of region syncer history buffer resize events.",
+		}, []string{"direction"})
+
+	regionSyncerHistoryBufferMissCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "history_buffer_miss_total",
+			Help:      "Counter of region syncer history buffer misses by phase.",
+		}, []string{"phase"})
+
+	regionSyncerDownstreamLagGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "downstream_lag",
+			Help:      "Number of history records each downstream stream lags behind the leader-side region syncer history index.",
+		}, []string{"downstream"})
+
+	regionSyncerStreamEventsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "stream_events_total",
+			Help:      "Counter of region syncer downstream stream lifecycle and send events.",
+		}, []string{"event"})
+)
+
+var (
+	regionSyncerFullSyncCounters            map[string]prometheus.Counter
+	regionSyncerFullSyncLastDurationGauges  map[string]prometheus.Gauge
+	regionSyncerHistoryBufferResizeCounters map[string]prometheus.Counter
+	regionSyncerHistoryBufferMissCounters   map[string]prometheus.Counter
+	regionSyncerStreamEventCounters         map[string]prometheus.Counter
+)
+
 func init() {
 	prometheus.MustRegister(regionSyncerStatus)
+	prometheus.MustRegister(regionSyncerClientReadyGauge)
+	prometheus.MustRegister(regionSyncerFullSyncCounter)
+	prometheus.MustRegister(regionSyncerFullSyncLastDurationGauge)
+	prometheus.MustRegister(regionSyncerHistoryBufferCapacityGauge)
+	prometheus.MustRegister(regionSyncerHistoryBufferLengthGauge)
+	prometheus.MustRegister(regionSyncerHistoryBufferMaxCapacityGauge)
+	prometheus.MustRegister(regionSyncerHistoryBufferResizeCounter)
+	prometheus.MustRegister(regionSyncerHistoryBufferMissCounter)
+	prometheus.MustRegister(regionSyncerDownstreamLagGauge)
+	prometheus.MustRegister(regionSyncerStreamEventsCounter)
+
+	initRegionSyncerMetrics()
+}
+
+func initRegionSyncerMetrics() {
+	results := []string{fullSyncResultSuccess, fullSyncResultFailure}
+	reasons := []string{
+		fullSyncReasonInitial,
+		fullSyncReasonHistoryGap,
+		fullSyncReasonStartIndexAhead,
+		fullSyncReasonMaxHistoryExceeded,
+		fullSyncReasonSendError,
+		fullSyncReasonContextCanceled,
+		fullSyncReasonStreamClosed,
+		fullSyncReasonUnknown,
+	}
+	regionSyncerFullSyncCounters = make(map[string]prometheus.Counter, len(results)*len(reasons))
+	for _, result := range results {
+		for _, reason := range reasons {
+			regionSyncerFullSyncCounters[fullSyncMetricKey(result, reason)] =
+				regionSyncerFullSyncCounter.WithLabelValues(result, reason)
+		}
+	}
+	regionSyncerFullSyncLastDurationGauges = map[string]prometheus.Gauge{
+		fullSyncResultSuccess: regionSyncerFullSyncLastDurationGauge.WithLabelValues(fullSyncResultSuccess),
+		fullSyncResultFailure: regionSyncerFullSyncLastDurationGauge.WithLabelValues(fullSyncResultFailure),
+	}
+	regionSyncerHistoryBufferResizeCounters = map[string]prometheus.Counter{
+		historyBufferResizeGrow:   regionSyncerHistoryBufferResizeCounter.WithLabelValues(historyBufferResizeGrow),
+		historyBufferResizeShrink: regionSyncerHistoryBufferResizeCounter.WithLabelValues(historyBufferResizeShrink),
+	}
+	regionSyncerHistoryBufferMissCounters = map[string]prometheus.Counter{
+		historyBufferMissHistorySync:     regionSyncerHistoryBufferMissCounter.WithLabelValues(historyBufferMissHistorySync),
+		historyBufferMissLiveDrain:       regionSyncerHistoryBufferMissCounter.WithLabelValues(historyBufferMissLiveDrain),
+		historyBufferMissFullSyncCatchUp: regionSyncerHistoryBufferMissCounter.WithLabelValues(historyBufferMissFullSyncCatchUp),
+	}
+	regionSyncerStreamEventCounters = map[string]prometheus.Counter{
+		streamEventBind:            regionSyncerStreamEventsCounter.WithLabelValues(streamEventBind),
+		streamEventUnbind:          regionSyncerStreamEventsCounter.WithLabelValues(streamEventUnbind),
+		streamEventSendError:       regionSyncerStreamEventsCounter.WithLabelValues(streamEventSendError),
+		streamEventSendTimeout:     regionSyncerStreamEventsCounter.WithLabelValues(streamEventSendTimeout),
+		streamEventContextCanceled: regionSyncerStreamEventsCounter.WithLabelValues(streamEventContextCanceled),
+		streamEventStreamClosed:    regionSyncerStreamEventsCounter.WithLabelValues(streamEventStreamClosed),
+	}
+}
+
+func fullSyncMetricKey(result, reason string) string {
+	return result + "/" + reason
+}
+
+func setRegionSyncerClientReadyMetrics(ready bool) {
+	if ready {
+		regionSyncerClientReadyGauge.Set(1)
+		return
+	}
+	regionSyncerClientReadyGauge.Set(0)
+}
+
+func observeFullSyncMetrics(result, reason string, duration time.Duration) {
+	counter, ok := regionSyncerFullSyncCounters[fullSyncMetricKey(result, reason)]
+	if !ok {
+		counter = regionSyncerFullSyncCounters[fullSyncMetricKey(result, fullSyncReasonUnknown)]
+	}
+	counter.Inc()
+	regionSyncerFullSyncLastDurationGauges[result].Set(duration.Seconds())
+}
+
+func observeHistoryBufferMetrics(length, capacity, maxCapacity int) {
+	regionSyncerHistoryBufferLengthGauge.Set(float64(length))
+	regionSyncerHistoryBufferCapacityGauge.Set(float64(capacity))
+	regionSyncerHistoryBufferMaxCapacityGauge.Set(float64(maxCapacity))
+}
+
+func incHistoryBufferResizeMetrics(direction string) {
+	regionSyncerHistoryBufferResizeCounters[direction].Inc()
+}
+
+func incHistoryBufferMissMetrics(phase string) {
+	regionSyncerHistoryBufferMissCounters[phase].Inc()
+}
+
+func incStreamEventMetrics(event string) {
+	regionSyncerStreamEventCounters[event].Inc()
 }

--- a/pkg/syncer/metrics.go
+++ b/pkg/syncer/metrics.go
@@ -15,6 +15,7 @@
 package syncer
 
 import (
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -128,6 +129,7 @@ var (
 	regionSyncerFullSyncCounters           map[fullSyncMetricLabels]prometheus.Counter
 	regionSyncerFullSyncLastDurationGauges map[string]prometheus.Gauge
 	regionSyncerStreamEventCounters        map[string]prometheus.Counter
+	registerRegionSyncerMetricsOnce        sync.Once
 )
 
 type fullSyncMetricLabels struct {
@@ -137,17 +139,21 @@ type fullSyncMetricLabels struct {
 
 func init() {
 	prometheus.MustRegister(regionSyncerStatus)
-	prometheus.MustRegister(regionSyncerClientReadyGauge)
-	prometheus.MustRegister(regionSyncerFullSyncCounter)
-	prometheus.MustRegister(regionSyncerFullSyncInProgressGauge)
-	prometheus.MustRegister(regionSyncerFullSyncLastDurationGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferCapacityRecordsGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferLengthRecordsGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferLiveDrainMissCounter)
-	prometheus.MustRegister(regionSyncerDownstreamLagRecordsGauge)
-	prometheus.MustRegister(regionSyncerStreamEventsCounter)
-
 	initRegionSyncerMetrics()
+}
+
+func registerRegionSyncerMetrics() {
+	registerRegionSyncerMetricsOnce.Do(func() {
+		prometheus.MustRegister(regionSyncerClientReadyGauge)
+		prometheus.MustRegister(regionSyncerFullSyncCounter)
+		prometheus.MustRegister(regionSyncerFullSyncInProgressGauge)
+		prometheus.MustRegister(regionSyncerFullSyncLastDurationGauge)
+		prometheus.MustRegister(regionSyncerHistoryBufferCapacityRecordsGauge)
+		prometheus.MustRegister(regionSyncerHistoryBufferLengthRecordsGauge)
+		prometheus.MustRegister(regionSyncerHistoryBufferLiveDrainMissCounter)
+		prometheus.MustRegister(regionSyncerDownstreamLagRecordsGauge)
+		prometheus.MustRegister(regionSyncerStreamEventsCounter)
+	})
 }
 
 func initRegionSyncerMetrics() {

--- a/pkg/syncer/metrics.go
+++ b/pkg/syncer/metrics.go
@@ -24,14 +24,17 @@ const (
 	fullSyncResultSuccess = "success"
 	fullSyncResultFailure = "failure"
 
-	fullSyncReasonInitial            = "initial"
-	fullSyncReasonHistoryGap         = "history_gap"
-	fullSyncReasonStartIndexAhead    = "start_index_ahead"
-	fullSyncReasonMaxHistoryExceeded = "max_history_exceeded"
-	fullSyncReasonSendError          = "send_error"
-	fullSyncReasonContextCanceled    = "context_canceled"
-	fullSyncReasonStreamClosed       = "stream_closed"
-	fullSyncReasonUnknown            = "unknown"
+	fullSyncTriggerInitial         = "initial"
+	fullSyncTriggerHistoryGap      = "history_gap"
+	fullSyncTriggerStartIndexAhead = "start_index_ahead"
+	fullSyncTriggerUnknown         = "unknown"
+
+	fullSyncFailureNone               = "none"
+	fullSyncFailureMaxHistoryExceeded = "max_history_exceeded"
+	fullSyncFailureSendError          = "send_error"
+	fullSyncFailureContextCanceled    = "context_canceled"
+	fullSyncFailureStreamClosed       = "stream_closed"
+	fullSyncFailureUnknown            = "unknown"
 
 	historyBufferResizeGrow   = "grow"
 	historyBufferResizeShrink = "shrink"
@@ -70,8 +73,8 @@ var (
 			Namespace: "pd",
 			Subsystem: "region_syncer",
 			Name:      "full_sync_total",
-			Help:      "Counter of region syncer full synchronization attempts by result and reason.",
-		}, []string{"result", "reason"})
+			Help:      "Counter of region syncer full synchronization attempts by result, trigger, and failure reason.",
+		}, []string{"result", "trigger", "failure_reason"})
 
 	regionSyncerFullSyncLastDurationGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -81,28 +84,28 @@ var (
 			Help:      "Duration in seconds of the latest region syncer full synchronization attempt by result.",
 		}, []string{"result"})
 
-	regionSyncerHistoryBufferCapacityGauge = prometheus.NewGauge(
+	regionSyncerHistoryBufferCapacityRecordsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
 			Subsystem: "region_syncer",
-			Name:      "history_buffer_capacity",
-			Help:      "Current capacity of the region syncer history buffer.",
+			Name:      "history_buffer_capacity_records",
+			Help:      "Current capacity in records of the region syncer history buffer.",
 		})
 
-	regionSyncerHistoryBufferLengthGauge = prometheus.NewGauge(
+	regionSyncerHistoryBufferLengthRecordsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
 			Subsystem: "region_syncer",
-			Name:      "history_buffer_length",
+			Name:      "history_buffer_length_records",
 			Help:      "Current number of records retained in the region syncer history buffer.",
 		})
 
-	regionSyncerHistoryBufferMaxCapacityGauge = prometheus.NewGauge(
+	regionSyncerHistoryBufferMaxCapacityRecordsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
 			Subsystem: "region_syncer",
-			Name:      "history_buffer_max_capacity",
-			Help:      "Maximum capacity allowed for the region syncer history buffer.",
+			Name:      "history_buffer_max_capacity_records",
+			Help:      "Maximum capacity in records allowed for the region syncer history buffer.",
 		})
 
 	regionSyncerHistoryBufferResizeCounter = prometheus.NewCounterVec(
@@ -121,11 +124,11 @@ var (
 			Help:      "Counter of region syncer history buffer misses by phase.",
 		}, []string{"phase"})
 
-	regionSyncerDownstreamLagGauge = prometheus.NewGaugeVec(
+	regionSyncerDownstreamLagRecordsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
 			Subsystem: "region_syncer",
-			Name:      "downstream_lag",
+			Name:      "downstream_lag_records",
 			Help:      "Number of history records each downstream stream lags behind the leader-side region syncer history index.",
 		}, []string{"downstream"})
 
@@ -139,46 +142,58 @@ var (
 )
 
 var (
-	regionSyncerFullSyncCounters            map[string]prometheus.Counter
+	regionSyncerFullSyncCounters            map[fullSyncMetricLabels]prometheus.Counter
 	regionSyncerFullSyncLastDurationGauges  map[string]prometheus.Gauge
 	regionSyncerHistoryBufferResizeCounters map[string]prometheus.Counter
 	regionSyncerHistoryBufferMissCounters   map[string]prometheus.Counter
 	regionSyncerStreamEventCounters         map[string]prometheus.Counter
 )
 
+type fullSyncMetricLabels struct {
+	result        string
+	trigger       string
+	failureReason string
+}
+
 func init() {
 	prometheus.MustRegister(regionSyncerStatus)
 	prometheus.MustRegister(regionSyncerClientReadyGauge)
 	prometheus.MustRegister(regionSyncerFullSyncCounter)
 	prometheus.MustRegister(regionSyncerFullSyncLastDurationGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferCapacityGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferLengthGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferMaxCapacityGauge)
+	prometheus.MustRegister(regionSyncerHistoryBufferCapacityRecordsGauge)
+	prometheus.MustRegister(regionSyncerHistoryBufferLengthRecordsGauge)
+	prometheus.MustRegister(regionSyncerHistoryBufferMaxCapacityRecordsGauge)
 	prometheus.MustRegister(regionSyncerHistoryBufferResizeCounter)
 	prometheus.MustRegister(regionSyncerHistoryBufferMissCounter)
-	prometheus.MustRegister(regionSyncerDownstreamLagGauge)
+	prometheus.MustRegister(regionSyncerDownstreamLagRecordsGauge)
 	prometheus.MustRegister(regionSyncerStreamEventsCounter)
 
 	initRegionSyncerMetrics()
 }
 
 func initRegionSyncerMetrics() {
-	results := []string{fullSyncResultSuccess, fullSyncResultFailure}
-	reasons := []string{
-		fullSyncReasonInitial,
-		fullSyncReasonHistoryGap,
-		fullSyncReasonStartIndexAhead,
-		fullSyncReasonMaxHistoryExceeded,
-		fullSyncReasonSendError,
-		fullSyncReasonContextCanceled,
-		fullSyncReasonStreamClosed,
-		fullSyncReasonUnknown,
+	triggers := []string{
+		fullSyncTriggerInitial,
+		fullSyncTriggerHistoryGap,
+		fullSyncTriggerStartIndexAhead,
+		fullSyncTriggerUnknown,
 	}
-	regionSyncerFullSyncCounters = make(map[string]prometheus.Counter, len(results)*len(reasons))
-	for _, result := range results {
-		for _, reason := range reasons {
-			regionSyncerFullSyncCounters[fullSyncMetricKey(result, reason)] =
-				regionSyncerFullSyncCounter.WithLabelValues(result, reason)
+	failureReasons := []string{
+		fullSyncFailureMaxHistoryExceeded,
+		fullSyncFailureSendError,
+		fullSyncFailureContextCanceled,
+		fullSyncFailureStreamClosed,
+		fullSyncFailureUnknown,
+	}
+	regionSyncerFullSyncCounters = make(map[fullSyncMetricLabels]prometheus.Counter, len(triggers)*(len(failureReasons)+1))
+	for _, trigger := range triggers {
+		successKey := fullSyncMetricKey(fullSyncResultSuccess, trigger, fullSyncFailureNone)
+		regionSyncerFullSyncCounters[successKey] =
+			regionSyncerFullSyncCounter.WithLabelValues(fullSyncResultSuccess, trigger, fullSyncFailureNone)
+		for _, failureReason := range failureReasons {
+			failureKey := fullSyncMetricKey(fullSyncResultFailure, trigger, failureReason)
+			regionSyncerFullSyncCounters[failureKey] =
+				regionSyncerFullSyncCounter.WithLabelValues(fullSyncResultFailure, trigger, failureReason)
 		}
 	}
 	regionSyncerFullSyncLastDurationGauges = map[string]prometheus.Gauge{
@@ -204,8 +219,12 @@ func initRegionSyncerMetrics() {
 	}
 }
 
-func fullSyncMetricKey(result, reason string) string {
-	return result + "/" + reason
+func fullSyncMetricKey(result, trigger, failureReason string) fullSyncMetricLabels {
+	return fullSyncMetricLabels{
+		result:        result,
+		trigger:       trigger,
+		failureReason: failureReason,
+	}
 }
 
 func setRegionSyncerClientReadyMetrics(ready bool) {
@@ -216,19 +235,35 @@ func setRegionSyncerClientReadyMetrics(ready bool) {
 	regionSyncerClientReadyGauge.Set(0)
 }
 
-func observeFullSyncMetrics(result, reason string, duration time.Duration) {
-	counter, ok := regionSyncerFullSyncCounters[fullSyncMetricKey(result, reason)]
+func observeFullSyncMetrics(result, trigger, failureReason string, duration time.Duration) {
+	counter, ok := regionSyncerFullSyncCounters[fullSyncMetricKey(result, trigger, failureReason)]
 	if !ok {
-		counter = regionSyncerFullSyncCounters[fullSyncMetricKey(result, fullSyncReasonUnknown)]
+		if result == fullSyncResultSuccess {
+			counter = regionSyncerFullSyncCounters[fullSyncMetricKey(
+				fullSyncResultSuccess,
+				fullSyncTriggerUnknown,
+				fullSyncFailureNone,
+			)]
+		} else {
+			counter = regionSyncerFullSyncCounters[fullSyncMetricKey(
+				fullSyncResultFailure,
+				fullSyncTriggerUnknown,
+				fullSyncFailureUnknown,
+			)]
+		}
 	}
 	counter.Inc()
 	regionSyncerFullSyncLastDurationGauges[result].Set(duration.Seconds())
 }
 
 func observeHistoryBufferMetrics(length, capacity, maxCapacity int) {
-	regionSyncerHistoryBufferLengthGauge.Set(float64(length))
-	regionSyncerHistoryBufferCapacityGauge.Set(float64(capacity))
-	regionSyncerHistoryBufferMaxCapacityGauge.Set(float64(maxCapacity))
+	observeHistoryBufferLengthMetrics(length)
+	regionSyncerHistoryBufferCapacityRecordsGauge.Set(float64(capacity))
+	regionSyncerHistoryBufferMaxCapacityRecordsGauge.Set(float64(maxCapacity))
+}
+
+func observeHistoryBufferLengthMetrics(length int) {
+	regionSyncerHistoryBufferLengthRecordsGauge.Set(float64(length))
 }
 
 func incHistoryBufferResizeMetrics(direction string) {

--- a/pkg/syncer/metrics.go
+++ b/pkg/syncer/metrics.go
@@ -27,18 +27,12 @@ const (
 	fullSyncTriggerInitial         = "initial"
 	fullSyncTriggerHistoryGap      = "history_gap"
 	fullSyncTriggerStartIndexAhead = "start_index_ahead"
-	fullSyncTriggerUnknown         = "unknown"
 
-	fullSyncFailureNone               = "none"
-	fullSyncFailureMaxHistoryExceeded = "max_history_exceeded"
-	fullSyncFailureSendError          = "send_error"
-	fullSyncFailureContextCanceled    = "context_canceled"
-	fullSyncFailureStreamClosed       = "stream_closed"
-	fullSyncFailureUnknown            = "unknown"
-
-	historyBufferMissHistorySync     = "history_sync"
-	historyBufferMissLiveDrain       = "live_drain"
-	historyBufferMissFullSyncCatchUp = "full_sync_catch_up"
+	fullSyncOutcomeSuccess            = "success"
+	fullSyncOutcomeMaxHistoryExceeded = "max_history_exceeded"
+	fullSyncOutcomeSendError          = "send_error"
+	fullSyncOutcomeContextCanceled    = "context_canceled"
+	fullSyncOutcomeStreamClosed       = "stream_closed"
 
 	streamEventBind            = "bind"
 	streamEventUnbind          = "unbind"
@@ -70,8 +64,16 @@ var (
 			Namespace: "pd",
 			Subsystem: "region_syncer",
 			Name:      "full_sync_total",
-			Help:      "Counter of region syncer full synchronization attempts by result, trigger, and failure reason.",
-		}, []string{"result", "trigger", "failure_reason"})
+			Help:      "Counter of region syncer full synchronization attempts by trigger and outcome.",
+		}, []string{"trigger", "outcome"})
+
+	regionSyncerFullSyncInProgressGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_syncer",
+			Name:      "full_sync_in_progress",
+			Help:      "Current number of region syncer full synchronizations in progress.",
+		})
 
 	regionSyncerFullSyncLastDurationGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -97,13 +99,13 @@ var (
 			Help:      "Current number of records retained in the region syncer history buffer.",
 		})
 
-	regionSyncerHistoryBufferMissCounter = prometheus.NewCounterVec(
+	regionSyncerHistoryBufferLiveDrainMissCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "pd",
 			Subsystem: "region_syncer",
-			Name:      "history_buffer_miss_total",
-			Help:      "Counter of region syncer history buffer misses by phase.",
-		}, []string{"phase"})
+			Name:      "history_buffer_live_drain_miss_total",
+			Help:      "Counter of region syncer history buffer misses while draining live updates to a downstream.",
+		})
 
 	regionSyncerDownstreamLagRecordsGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -125,24 +127,23 @@ var (
 var (
 	regionSyncerFullSyncCounters           map[fullSyncMetricLabels]prometheus.Counter
 	regionSyncerFullSyncLastDurationGauges map[string]prometheus.Gauge
-	regionSyncerHistoryBufferMissCounters  map[string]prometheus.Counter
 	regionSyncerStreamEventCounters        map[string]prometheus.Counter
 )
 
 type fullSyncMetricLabels struct {
-	result        string
-	trigger       string
-	failureReason string
+	trigger string
+	outcome string
 }
 
 func init() {
 	prometheus.MustRegister(regionSyncerStatus)
 	prometheus.MustRegister(regionSyncerClientReadyGauge)
 	prometheus.MustRegister(regionSyncerFullSyncCounter)
+	prometheus.MustRegister(regionSyncerFullSyncInProgressGauge)
 	prometheus.MustRegister(regionSyncerFullSyncLastDurationGauge)
 	prometheus.MustRegister(regionSyncerHistoryBufferCapacityRecordsGauge)
 	prometheus.MustRegister(regionSyncerHistoryBufferLengthRecordsGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferMissCounter)
+	prometheus.MustRegister(regionSyncerHistoryBufferLiveDrainMissCounter)
 	prometheus.MustRegister(regionSyncerDownstreamLagRecordsGauge)
 	prometheus.MustRegister(regionSyncerStreamEventsCounter)
 
@@ -154,34 +155,25 @@ func initRegionSyncerMetrics() {
 		fullSyncTriggerInitial,
 		fullSyncTriggerHistoryGap,
 		fullSyncTriggerStartIndexAhead,
-		fullSyncTriggerUnknown,
 	}
-	failureReasons := []string{
-		fullSyncFailureMaxHistoryExceeded,
-		fullSyncFailureSendError,
-		fullSyncFailureContextCanceled,
-		fullSyncFailureStreamClosed,
-		fullSyncFailureUnknown,
+	outcomes := []string{
+		fullSyncOutcomeSuccess,
+		fullSyncOutcomeMaxHistoryExceeded,
+		fullSyncOutcomeSendError,
+		fullSyncOutcomeContextCanceled,
+		fullSyncOutcomeStreamClosed,
 	}
-	regionSyncerFullSyncCounters = make(map[fullSyncMetricLabels]prometheus.Counter, len(triggers)*(len(failureReasons)+1))
+	regionSyncerFullSyncCounters = make(map[fullSyncMetricLabels]prometheus.Counter, len(triggers)*len(outcomes))
 	for _, trigger := range triggers {
-		successKey := fullSyncMetricKey(fullSyncResultSuccess, trigger, fullSyncFailureNone)
-		regionSyncerFullSyncCounters[successKey] =
-			regionSyncerFullSyncCounter.WithLabelValues(fullSyncResultSuccess, trigger, fullSyncFailureNone)
-		for _, failureReason := range failureReasons {
-			failureKey := fullSyncMetricKey(fullSyncResultFailure, trigger, failureReason)
-			regionSyncerFullSyncCounters[failureKey] =
-				regionSyncerFullSyncCounter.WithLabelValues(fullSyncResultFailure, trigger, failureReason)
+		for _, outcome := range outcomes {
+			key := fullSyncMetricKey(trigger, outcome)
+			regionSyncerFullSyncCounters[key] =
+				regionSyncerFullSyncCounter.WithLabelValues(trigger, outcome)
 		}
 	}
 	regionSyncerFullSyncLastDurationGauges = map[string]prometheus.Gauge{
 		fullSyncResultSuccess: regionSyncerFullSyncLastDurationGauge.WithLabelValues(fullSyncResultSuccess),
 		fullSyncResultFailure: regionSyncerFullSyncLastDurationGauge.WithLabelValues(fullSyncResultFailure),
-	}
-	regionSyncerHistoryBufferMissCounters = map[string]prometheus.Counter{
-		historyBufferMissHistorySync:     regionSyncerHistoryBufferMissCounter.WithLabelValues(historyBufferMissHistorySync),
-		historyBufferMissLiveDrain:       regionSyncerHistoryBufferMissCounter.WithLabelValues(historyBufferMissLiveDrain),
-		historyBufferMissFullSyncCatchUp: regionSyncerHistoryBufferMissCounter.WithLabelValues(historyBufferMissFullSyncCatchUp),
 	}
 	regionSyncerStreamEventCounters = map[string]prometheus.Counter{
 		streamEventBind:            regionSyncerStreamEventsCounter.WithLabelValues(streamEventBind),
@@ -193,11 +185,10 @@ func initRegionSyncerMetrics() {
 	}
 }
 
-func fullSyncMetricKey(result, trigger, failureReason string) fullSyncMetricLabels {
+func fullSyncMetricKey(trigger, outcome string) fullSyncMetricLabels {
 	return fullSyncMetricLabels{
-		result:        result,
-		trigger:       trigger,
-		failureReason: failureReason,
+		trigger: trigger,
+		outcome: outcome,
 	}
 }
 
@@ -209,24 +200,12 @@ func setRegionSyncerClientReadyMetrics(ready bool) {
 	regionSyncerClientReadyGauge.Set(0)
 }
 
-func observeFullSyncMetrics(result, trigger, failureReason string, duration time.Duration) {
-	counter, ok := regionSyncerFullSyncCounters[fullSyncMetricKey(result, trigger, failureReason)]
-	if !ok {
-		if result == fullSyncResultSuccess {
-			counter = regionSyncerFullSyncCounters[fullSyncMetricKey(
-				fullSyncResultSuccess,
-				fullSyncTriggerUnknown,
-				fullSyncFailureNone,
-			)]
-		} else {
-			counter = regionSyncerFullSyncCounters[fullSyncMetricKey(
-				fullSyncResultFailure,
-				fullSyncTriggerUnknown,
-				fullSyncFailureUnknown,
-			)]
-		}
+func observeFullSyncMetrics(trigger, outcome string, duration time.Duration) {
+	regionSyncerFullSyncCounters[fullSyncMetricKey(trigger, outcome)].Inc()
+	result := fullSyncResultFailure
+	if outcome == fullSyncOutcomeSuccess {
+		result = fullSyncResultSuccess
 	}
-	counter.Inc()
 	regionSyncerFullSyncLastDurationGauges[result].Set(duration.Seconds())
 }
 
@@ -239,8 +218,8 @@ func observeHistoryBufferLengthMetrics(length int) {
 	regionSyncerHistoryBufferLengthRecordsGauge.Set(float64(length))
 }
 
-func incHistoryBufferMissMetrics(phase string) {
-	regionSyncerHistoryBufferMissCounters[phase].Inc()
+func incHistoryBufferLiveDrainMissMetrics() {
+	regionSyncerHistoryBufferLiveDrainMissCounter.Inc()
 }
 
 func incStreamEventMetrics(event string) {

--- a/pkg/syncer/metrics.go
+++ b/pkg/syncer/metrics.go
@@ -201,12 +201,18 @@ func setRegionSyncerClientReadyMetrics(ready bool) {
 }
 
 func observeFullSyncMetrics(trigger, outcome string, duration time.Duration) {
-	regionSyncerFullSyncCounters[fullSyncMetricKey(trigger, outcome)].Inc()
+	counter, ok := regionSyncerFullSyncCounters[fullSyncMetricKey(trigger, outcome)]
+	if !ok {
+		return
+	}
+	counter.Inc()
 	result := fullSyncResultFailure
 	if outcome == fullSyncOutcomeSuccess {
 		result = fullSyncResultSuccess
 	}
-	regionSyncerFullSyncLastDurationGauges[result].Set(duration.Seconds())
+	if gauge, ok := regionSyncerFullSyncLastDurationGauges[result]; ok {
+		gauge.Set(duration.Seconds())
+	}
 }
 
 func observeHistoryBufferMetrics(length, capacity int) {
@@ -223,5 +229,7 @@ func incHistoryBufferLiveDrainMissMetrics() {
 }
 
 func incStreamEventMetrics(event string) {
-	regionSyncerStreamEventCounters[event].Inc()
+	if counter, ok := regionSyncerStreamEventCounters[event]; ok {
+		counter.Inc()
+	}
 }

--- a/pkg/syncer/metrics.go
+++ b/pkg/syncer/metrics.go
@@ -36,9 +36,6 @@ const (
 	fullSyncFailureStreamClosed       = "stream_closed"
 	fullSyncFailureUnknown            = "unknown"
 
-	historyBufferResizeGrow   = "grow"
-	historyBufferResizeShrink = "shrink"
-
 	historyBufferMissHistorySync     = "history_sync"
 	historyBufferMissLiveDrain       = "live_drain"
 	historyBufferMissFullSyncCatchUp = "full_sync_catch_up"
@@ -100,22 +97,6 @@ var (
 			Help:      "Current number of records retained in the region syncer history buffer.",
 		})
 
-	regionSyncerHistoryBufferMaxCapacityRecordsGauge = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "pd",
-			Subsystem: "region_syncer",
-			Name:      "history_buffer_max_capacity_records",
-			Help:      "Maximum capacity in records allowed for the region syncer history buffer.",
-		})
-
-	regionSyncerHistoryBufferResizeCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "pd",
-			Subsystem: "region_syncer",
-			Name:      "history_buffer_resize_total",
-			Help:      "Counter of region syncer history buffer resize events.",
-		}, []string{"direction"})
-
 	regionSyncerHistoryBufferMissCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "pd",
@@ -142,11 +123,10 @@ var (
 )
 
 var (
-	regionSyncerFullSyncCounters            map[fullSyncMetricLabels]prometheus.Counter
-	regionSyncerFullSyncLastDurationGauges  map[string]prometheus.Gauge
-	regionSyncerHistoryBufferResizeCounters map[string]prometheus.Counter
-	regionSyncerHistoryBufferMissCounters   map[string]prometheus.Counter
-	regionSyncerStreamEventCounters         map[string]prometheus.Counter
+	regionSyncerFullSyncCounters           map[fullSyncMetricLabels]prometheus.Counter
+	regionSyncerFullSyncLastDurationGauges map[string]prometheus.Gauge
+	regionSyncerHistoryBufferMissCounters  map[string]prometheus.Counter
+	regionSyncerStreamEventCounters        map[string]prometheus.Counter
 )
 
 type fullSyncMetricLabels struct {
@@ -162,8 +142,6 @@ func init() {
 	prometheus.MustRegister(regionSyncerFullSyncLastDurationGauge)
 	prometheus.MustRegister(regionSyncerHistoryBufferCapacityRecordsGauge)
 	prometheus.MustRegister(regionSyncerHistoryBufferLengthRecordsGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferMaxCapacityRecordsGauge)
-	prometheus.MustRegister(regionSyncerHistoryBufferResizeCounter)
 	prometheus.MustRegister(regionSyncerHistoryBufferMissCounter)
 	prometheus.MustRegister(regionSyncerDownstreamLagRecordsGauge)
 	prometheus.MustRegister(regionSyncerStreamEventsCounter)
@@ -199,10 +177,6 @@ func initRegionSyncerMetrics() {
 	regionSyncerFullSyncLastDurationGauges = map[string]prometheus.Gauge{
 		fullSyncResultSuccess: regionSyncerFullSyncLastDurationGauge.WithLabelValues(fullSyncResultSuccess),
 		fullSyncResultFailure: regionSyncerFullSyncLastDurationGauge.WithLabelValues(fullSyncResultFailure),
-	}
-	regionSyncerHistoryBufferResizeCounters = map[string]prometheus.Counter{
-		historyBufferResizeGrow:   regionSyncerHistoryBufferResizeCounter.WithLabelValues(historyBufferResizeGrow),
-		historyBufferResizeShrink: regionSyncerHistoryBufferResizeCounter.WithLabelValues(historyBufferResizeShrink),
 	}
 	regionSyncerHistoryBufferMissCounters = map[string]prometheus.Counter{
 		historyBufferMissHistorySync:     regionSyncerHistoryBufferMissCounter.WithLabelValues(historyBufferMissHistorySync),
@@ -256,18 +230,13 @@ func observeFullSyncMetrics(result, trigger, failureReason string, duration time
 	regionSyncerFullSyncLastDurationGauges[result].Set(duration.Seconds())
 }
 
-func observeHistoryBufferMetrics(length, capacity, maxCapacity int) {
+func observeHistoryBufferMetrics(length, capacity int) {
 	observeHistoryBufferLengthMetrics(length)
 	regionSyncerHistoryBufferCapacityRecordsGauge.Set(float64(capacity))
-	regionSyncerHistoryBufferMaxCapacityRecordsGauge.Set(float64(maxCapacity))
 }
 
 func observeHistoryBufferLengthMetrics(length int) {
 	regionSyncerHistoryBufferLengthRecordsGauge.Set(float64(length))
-}
-
-func incHistoryBufferResizeMetrics(direction string) {
-	regionSyncerHistoryBufferResizeCounters[direction].Inc()
 }
 
 func incHistoryBufferMissMetrics(phase string) {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -81,6 +82,9 @@ type regionSyncStream struct {
 	notifyCh  chan bool
 	done      chan struct{}
 	once      sync.Once
+
+	downstream         string
+	downstreamLagGauge prometheus.Gauge
 }
 
 func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStream {
@@ -102,11 +106,52 @@ func (s *regionSyncStream) getSendIndex() uint64 {
 	return s.sendIndex.Load()
 }
 
+func (s *regionSyncStream) getSendIndexLocked() uint64 {
+	return s.sendIndex.Load()
+}
+
+func (s *regionSyncStream) advanceSendIndexLocked(count int) {
+	s.sendIndex.Add(uint64(count))
+}
+
 func (s *regionSyncStream) notify(keepAlive bool) {
 	select {
 	case s.notifyCh <- keepAlive:
 	default:
 	}
+}
+
+func (s *regionSyncStream) setDownstreamMetrics(name string, leaderNextIndex uint64) {
+	s.downstream = name
+	s.downstreamLagGauge = regionSyncerDownstreamLagGauge.WithLabelValues(name)
+	s.observeDownstreamLagMetrics(leaderNextIndex)
+}
+
+func (s *regionSyncStream) observeDownstreamLagMetrics(leaderNextIndex uint64) {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	s.observeDownstreamLagMetricsLocked(leaderNextIndex)
+}
+
+func (s *regionSyncStream) observeDownstreamLagMetricsLocked(leaderNextIndex uint64) {
+	if s.downstreamLagGauge == nil {
+		return
+	}
+	sendIndex := s.getSendIndexLocked()
+	if sendIndex >= leaderNextIndex {
+		s.downstreamLagGauge.Set(0)
+		return
+	}
+	s.downstreamLagGauge.Set(float64(leaderNextIndex - sendIndex))
+}
+
+func (s *regionSyncStream) deleteDownstreamMetrics() {
+	if s.downstream == "" {
+		return
+	}
+	regionSyncerDownstreamLagGauge.DeleteLabelValues(s.downstream)
+	s.downstream = ""
+	s.downstreamLagGauge = nil
 }
 
 func (s *regionSyncStream) close() {
@@ -214,8 +259,11 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 		keepAliveTicker.Stop()
 		shrinkTicker.Stop()
 		s.mu.Lock()
-		for _, stream := range s.mu.streams {
+		for name, stream := range s.mu.streams {
 			stream.close()
+			stream.deleteDownstreamMetrics()
+			incStreamEventMetrics(streamEventUnbind)
+			log.Info("region syncer delete the stream", zap.String("stream", name))
 		}
 		s.mu.streams = make(map[string]*regionSyncStream)
 		s.mu.Unlock()
@@ -405,7 +453,11 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
 	if startIndex == 0 || startIndex > endIndex {
-		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
+		reason := fullSyncReasonInitial
+		if startIndex > endIndex {
+			reason = fullSyncReasonStartIndexAhead
+		}
+		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, reason)
 	}
 	if startIndex < endIndex {
 		s.history.observeRequiredWindow(endIndex - startIndex)
@@ -427,13 +479,15 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 			return syncStream.sendStreamIfOpen(resp)
 		}
 		if startIndex < endIndex {
-			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
+			incHistoryBufferMissMetrics(historyBufferMissHistorySync)
+			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncReasonHistoryGap)
 		}
 		log.Warn("no history regions from index, the leader may be restarted", zap.Uint64("index", startIndex))
 		return nil
 	}
 	if len(records) != int(endIndex-startIndex) {
-		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex)
+		incHistoryBufferMissMetrics(historyBufferMissHistorySync)
+		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncReasonHistoryGap)
 	}
 	log.Info("sync the history regions with server",
 		zap.String("server", name),
@@ -488,11 +542,22 @@ func (*RegionSyncer) syncHistoryRecordsLocked(startIndex uint64, records []*core
 	return nil
 }
 
-func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, syncStream *regionSyncStream, syncStartIndex uint64) error {
+func (s *RegionSyncer) syncFullRegionsLocked(
+	ctx context.Context,
+	name string,
+	syncStream *regionSyncStream,
+	syncStartIndex uint64,
+	reason string,
+) error {
+	start := time.Now()
+	result := fullSyncResultSuccess
+	metricReason := reason
+	defer func() {
+		observeFullSyncMetrics(result, metricReason, time.Since(start))
+	}()
 	releaseRetain := s.history.retainFrom(syncStartIndex)
 	defer releaseRetain()
 	regions := s.server.GetRegions()
-	start := time.Now()
 	lastIndex := 0
 	metas := make([]*metapb.Region, 0, maxSyncRegionBatchSize)
 	stats := make([]*pdpb.RegionStat, 0, maxSyncRegionBatchSize)
@@ -501,6 +566,8 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 	for syncedIndex, r := range regions {
 		select {
 		case <-ctx.Done():
+			result = fullSyncResultFailure
+			metricReason = fullSyncReasonContextCanceled
 			log.Info("discontinue sending sync region response")
 			failpoint.Inject("noFastExitSync", func() {
 				failpoint.Goto("doSync")
@@ -533,14 +600,20 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 			Buckets:       buckets,
 		}
 		if err := syncStream.checkOpen(); err != nil {
+			result = fullSyncResultFailure
+			metricReason = fullSyncReasonStreamClosed
 			return err
 		}
 		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
+			result = fullSyncResultFailure
+			metricReason = fullSyncReasonContextCanceled
 			log.Error("failed to wait rate limit", errs.ZapError(err))
 			return err
 		}
 		lastIndex += len(metas)
 		if err := syncStream.sendStreamIfOpen(resp); err != nil {
+			result = fullSyncResultFailure
+			metricReason = fullSyncReasonSendError
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}
@@ -553,6 +626,9 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 		zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))
 	records, nextIndex, ok := s.history.retainedRecordsFrom(syncStartIndex)
 	if !ok {
+		result = fullSyncResultFailure
+		metricReason = fullSyncReasonMaxHistoryExceeded
+		incHistoryBufferMissMetrics(historyBufferMissFullSyncCatchUp)
 		return status.Errorf(codes.ResourceExhausted,
 			"history records from full sync start index %d to %d are no longer available",
 			syncStartIndex, nextIndex)
@@ -563,15 +639,20 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 			catchUpStartIndex = 0
 		}
 		if err := s.syncHistoryRecordsLocked(catchUpStartIndex, records, syncStream); err != nil {
+			result = fullSyncResultFailure
+			metricReason = fullSyncReasonSendError
 			return err
 		}
-		syncStream.sendIndex.Add(uint64(len(records)))
+		syncStream.advanceSendIndexLocked(len(records))
+		syncStream.observeDownstreamLagMetricsLocked(nextIndex)
 	}
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 		StartIndex: nextIndex,
 	}
 	if err := syncStream.sendStreamIfOpen(resp); err != nil {
+		result = fullSyncResultFailure
+		metricReason = fullSyncReasonSendError
 		log.Warn("failed to send sync region completion response", errs.ZapError(errs.ErrGRPCSend, err))
 		return err
 	}
@@ -583,15 +664,19 @@ func (s *RegionSyncer) bindStreamForSync(name string, stream ServerStream) (*reg
 	defer s.mu.Unlock()
 	startIndex := s.history.getNextIndex()
 	syncStream := newRegionSyncStream(stream, startIndex)
-	s.bindStreamLocked(name, syncStream)
+	s.bindStreamLocked(name, syncStream, startIndex)
 	return syncStream, startIndex
 }
 
-func (s *RegionSyncer) bindStreamLocked(name string, syncStream *regionSyncStream) {
+func (s *RegionSyncer) bindStreamLocked(name string, syncStream *regionSyncStream, leaderNextIndex uint64) {
 	if oldStream := s.mu.streams[name]; oldStream != nil {
 		oldStream.close()
+		oldStream.deleteDownstreamMetrics()
+		incStreamEventMetrics(streamEventUnbind)
 	}
+	syncStream.setDownstreamMetrics(name, leaderNextIndex)
 	s.mu.streams[name] = syncStream
+	incStreamEventMetrics(streamEventBind)
 }
 
 func (s *RegionSyncer) unbindStream(name string, stream *regionSyncStream) {
@@ -599,6 +684,8 @@ func (s *RegionSyncer) unbindStream(name string, stream *regionSyncStream) {
 	defer s.mu.Unlock()
 	if s.mu.streams[name] == stream {
 		delete(s.mu.streams, name)
+		stream.deleteDownstreamMetrics()
+		incStreamEventMetrics(streamEventUnbind)
 	}
 	stream.close()
 }
@@ -659,9 +746,11 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		sendIndex := stream.getSendIndex()
 		firstIndex := s.history.getFirstIndex()
 		if sendIndex < firstIndex {
+			incHistoryBufferMissMetrics(historyBufferMissLiveDrain)
 			return sentRecords, errors.Errorf("region syncer buffered records from index %d overflow, first available index is %d", sendIndex, firstIndex)
 		}
 		bufferNextIndex := s.history.getNextIndex()
+		stream.observeDownstreamLagMetricsLocked(bufferNextIndex)
 		if sendIndex > bufferNextIndex {
 			return sentRecords, errors.Errorf("region syncer buffered records index %d exceeds next index %d", sendIndex, bufferNextIndex)
 		}
@@ -674,13 +763,15 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		}
 		records := s.history.recordsBetween(sendIndex, endIndex)
 		if len(records) == 0 {
+			incHistoryBufferMissMetrics(historyBufferMissLiveDrain)
 			return sentRecords, errors.Errorf("region syncer has no buffered records from index %d to %d", sendIndex, endIndex)
 		}
 		resp := buildSyncRegionResponse(sendIndex, records)
 		if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
 			return sentRecords, errors.Errorf("send region sync response failed")
 		}
-		stream.sendIndex.Add(uint64(len(records)))
+		stream.advanceSendIndexLocked(len(records))
+		stream.observeDownstreamLagMetricsLocked(bufferNextIndex)
 		sentRecords = true
 	}
 }
@@ -729,6 +820,7 @@ func (s *RegionSyncer) sendRegionSyncResponseWithOptions(
 	if sendErr != nil {
 		log.Warn("region syncer send data meet error", zap.String("name", name),
 			errs.ZapError(errs.ErrGRPCSend, sendErr))
+		incStreamEventMetrics(streamEventSendError)
 		return false
 	}
 
@@ -737,6 +829,7 @@ func (s *RegionSyncer) sendRegionSyncResponseWithOptions(
 		doneCh = sender.done
 		select {
 		case <-doneCh:
+			incStreamEventMetrics(streamEventStreamClosed)
 			return false
 		default:
 		}
@@ -759,6 +852,7 @@ func (s *RegionSyncer) sendRegionSyncResponseWithOptions(
 		if err != nil {
 			log.Warn("region syncer send data meet error", zap.String("name", name),
 				errs.ZapError(errs.ErrGRPCSend, err))
+			incStreamEventMetrics(streamEventSendError)
 			return false
 		}
 		return true
@@ -766,13 +860,16 @@ func (s *RegionSyncer) sendRegionSyncResponseWithOptions(
 		sender.close()
 		log.Warn("region syncer send data canceled", zap.String("name", name),
 			errs.ZapError(errs.ErrGRPCSend, ctx.Err()))
+		incStreamEventMetrics(streamEventContextCanceled)
 		return false
 	case <-doneCh:
 		log.Warn("region syncer send data canceled because stream is closed", zap.String("name", name))
+		incStreamEventMetrics(streamEventStreamClosed)
 		return false
 	case <-timer.C:
 		sender.close()
 		log.Warn("region syncer send data timeout", zap.String("name", name), zap.Duration("timeout", timeout))
+		incStreamEventMetrics(streamEventSendTimeout)
 		return false
 	}
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -417,7 +417,7 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 		if clusterID != keypath.ClusterID() {
 			return errs.ErrMismatchClusterID(keypath.ClusterID(), clusterID)
 		}
-		member, err := s.validateDownstreamMember(request.GetMember())
+		member, collectMetrics, err := s.validateDownstreamMember(request.GetMember())
 		if err != nil {
 			return err
 		}
@@ -426,7 +426,9 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 			zap.Strings("urls", member.GetClientUrls()))
 
 		name := member.GetName()
-		syncStream, syncStartIndex := s.bindStreamForSync(name, stream, request.GetStartIndex())
+		syncStream, syncStartIndex := s.bindStreamForSync(
+			name, stream, request.GetStartIndex(), collectMetrics,
+		)
 		err = s.syncHistoryRegion(ctx, request, syncStream, syncStartIndex)
 		if err != nil {
 			s.unbindStream(name, syncStream)
@@ -447,24 +449,29 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 	}
 }
 
-func (s *RegionSyncer) validateDownstreamMember(requested *pdpb.Member) (*pdpb.Member, error) {
-	if requested == nil || requested.GetMemberId() == 0 || requested.GetName() == "" {
-		return nil, status.Error(codes.InvalidArgument, "region syncer downstream member is incomplete")
+func (s *RegionSyncer) validateDownstreamMember(requested *pdpb.Member) (*pdpb.Member, bool, error) {
+	if requested == nil || requested.GetName() == "" {
+		return nil, false, status.Error(codes.InvalidArgument, "region syncer downstream member is incomplete")
+	}
+	// Router microservices also consume RegionSync without being PD members.
+	// Keep serving them, but do not create a caller-controlled metric label.
+	if requested.GetMemberId() == 0 {
+		return requested, false, nil
 	}
 	members, err := s.server.GetMembers()
 	if err != nil {
-		return nil, status.Error(codes.Unavailable, "failed to load PD members")
+		return nil, false, status.Error(codes.Unavailable, "failed to load PD members")
 	}
 	for _, member := range members {
 		if member.GetMemberId() != requested.GetMemberId() {
 			continue
 		}
 		if member.GetName() != requested.GetName() {
-			return nil, status.Error(codes.PermissionDenied, "region syncer downstream member does not match PD membership")
+			return nil, false, status.Error(codes.PermissionDenied, "region syncer downstream member does not match PD membership")
 		}
-		return member, nil
+		return member, true, nil
 	}
-	return nil, status.Error(codes.PermissionDenied, "region syncer downstream member is not in PD membership")
+	return nil, false, status.Error(codes.PermissionDenied, "region syncer downstream member is not in PD membership")
 }
 
 type syncRegionRequestResult struct {
@@ -727,12 +734,13 @@ func (s *RegionSyncer) bindStreamForSync(
 	name string,
 	stream ServerStream,
 	downstreamStartIndex uint64,
+	collectMetrics bool,
 ) (*regionSyncStream, uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	startIndex := s.history.getNextIndex()
 	syncStream := newRegionSyncStream(stream, startIndex)
-	s.bindStreamLocked(name, syncStream, downstreamStartIndex, startIndex)
+	s.bindStreamLocked(name, syncStream, downstreamStartIndex, startIndex, collectMetrics)
 	return syncStream, startIndex
 }
 
@@ -741,13 +749,16 @@ func (s *RegionSyncer) bindStreamLocked(
 	syncStream *regionSyncStream,
 	downstreamStartIndex,
 	leaderNextIndex uint64,
+	collectMetrics bool,
 ) {
 	if oldStream := s.mu.streams[name]; oldStream != nil {
 		oldStream.close()
 		oldStream.deleteDownstreamMetrics()
 		incStreamEventMetrics(streamEventUnbind)
 	}
-	syncStream.setDownstreamMetrics(name, downstreamStartIndex, leaderNextIndex)
+	if collectMetrics {
+		syncStream.setDownstreamMetrics(name, downstreamStartIndex, leaderNextIndex)
+	}
 	s.mu.streams[name] = syncStream
 	incStreamEventMetrics(streamEventBind)
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -265,6 +265,7 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 	if regionStorage == nil {
 		return nil
 	}
+	registerRegionSyncerMetrics()
 	historyBufferMaxSize := historyBufferMaxSizeFromMemory(memory.GetMemTotalIgnoreErr())
 	syncer := &RegionSyncer{
 		server:      s,

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -460,18 +460,18 @@ func (s *RegionSyncer) validateDownstreamMember(requested *pdpb.Member) (*pdpb.M
 	}
 	members, err := s.server.GetMembers()
 	if err != nil {
-		return nil, false, status.Error(codes.Unavailable, "failed to load PD members")
+		return requested, false, nil
 	}
 	for _, member := range members {
 		if member.GetMemberId() != requested.GetMemberId() {
 			continue
 		}
-		if member.GetName() != requested.GetName() {
-			return nil, false, status.Error(codes.PermissionDenied, "region syncer downstream member does not match PD membership")
-		}
+		// Use the canonical member name for metrics and stream bookkeeping.
 		return member, true, nil
 	}
-	return nil, false, status.Error(codes.PermissionDenied, "region syncer downstream member is not in PD membership")
+	// A freshly joined member may not be visible yet. Keep RegionSync
+	// available, but do not create a caller-controlled metric label.
+	return requested, false, nil
 }
 
 type syncRegionRequestResult struct {

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -111,7 +111,7 @@ func (s *regionSyncStream) getSendIndex() uint64 {
 	return s.sendIndex.Load()
 }
 
-func (s *regionSyncStream) advanceSendIndexLocked(count int) {
+func (s *regionSyncStream) advanceSendIndex(count int) {
 	s.sendIndex.Add(uint64(count))
 }
 
@@ -714,7 +714,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 			outcome = syncStream.fullSyncFailureOutcome(err)
 			return err
 		}
-		syncStream.advanceSendIndexLocked(len(records))
+		syncStream.advanceSendIndex(len(records))
 	}
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
@@ -854,7 +854,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		if !s.sendRegionSyncResponse(ctx, name, stream, resp) {
 			return sentRecords, errors.Errorf("send region sync response failed")
 		}
-		stream.advanceSendIndexLocked(len(records))
+		stream.advanceSendIndex(len(records))
 		stream.setDownstreamSyncIndex(stream.getSendIndex())
 		stream.observeDownstreamLagMetrics(bufferNextIndex)
 		sentRecords = true
@@ -863,8 +863,8 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 
 func (s *RegionSyncer) broadcast(ctx context.Context, records []*core.RegionInfo, keepAlive bool) {
 	defer logutil.LogPanic()
-	leaderNextIndex := s.history.getNextIndex()
 	s.mu.RLock()
+	leaderNextIndex := s.history.getNextIndex()
 	for _, sender := range s.mu.streams {
 		if ctx.Err() != nil {
 			break

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -50,6 +50,7 @@ const (
 	defaultBucketCapacity       = 20 * units.MiB // 20MB
 	maxSyncRegionBatchSize      = 1000
 	syncerKeepAliveInterval     = 10 * time.Second
+	downstreamMetricsRetryDelay = time.Second
 	historyBufferShrinkInterval = 5 * time.Minute
 	defaultHistoryBufferSize    = 10000
 	historyBufferMemoryStep     = 4 * 1024 * 1024 * 1024
@@ -126,20 +127,20 @@ func (s *regionSyncStream) notify(keepAlive bool) {
 	}
 }
 
-func (s *regionSyncStream) setDownstreamMetrics(name string, downstreamStartIndex, leaderNextIndex uint64) {
-	if downstreamStartIndex > leaderNextIndex {
-		downstreamStartIndex = leaderNextIndex
-	}
-	s.setDownstreamSyncIndex(downstreamStartIndex)
+func (s *regionSyncStream) setDownstreamMetrics(name string, leaderNextIndex uint64) bool {
 	s.metrics.Lock()
+	defer s.metrics.Unlock()
+	if s.checkOpen() != nil {
+		return false
+	}
 	if s.metrics.initialized && s.metrics.downstream != name {
 		regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(s.metrics.downstream)
 	}
 	s.metrics.initialized = true
 	s.metrics.downstream = name
 	s.metrics.downstreamLagGauge = regionSyncerDownstreamLagRecordsGauge.WithLabelValues(name)
-	s.metrics.Unlock()
-	s.observeDownstreamLagMetrics(leaderNextIndex)
+	setDownstreamLagMetrics(s.metrics.downstreamLagGauge, s.downstreamSyncIndex.Load(), leaderNextIndex)
+	return true
 }
 
 func (s *regionSyncStream) observeDownstreamLagMetrics(leaderNextIndex uint64) {
@@ -148,12 +149,15 @@ func (s *regionSyncStream) observeDownstreamLagMetrics(leaderNextIndex uint64) {
 	if s.metrics.downstreamLagGauge == nil {
 		return
 	}
-	downstreamSyncIndex := s.downstreamSyncIndex.Load()
+	setDownstreamLagMetrics(s.metrics.downstreamLagGauge, s.downstreamSyncIndex.Load(), leaderNextIndex)
+}
+
+func setDownstreamLagMetrics(gauge prometheus.Gauge, downstreamSyncIndex, leaderNextIndex uint64) {
 	if downstreamSyncIndex >= leaderNextIndex {
-		s.metrics.downstreamLagGauge.Set(0)
+		gauge.Set(0)
 		return
 	}
-	s.metrics.downstreamLagGauge.Set(float64(leaderNextIndex - downstreamSyncIndex))
+	gauge.Set(float64(leaderNextIndex - downstreamSyncIndex))
 }
 
 func (s *regionSyncStream) deleteDownstreamMetrics() {
@@ -171,6 +175,7 @@ func (s *regionSyncStream) deleteDownstreamMetrics() {
 func (s *regionSyncStream) close() {
 	s.once.Do(func() {
 		close(s.done)
+		s.deleteDownstreamMetrics()
 	})
 }
 
@@ -194,12 +199,16 @@ func (s *regionSyncStream) sendStreamIfOpen(regions *pdpb.SyncRegionResponse) er
 	if err == nil {
 		return nil
 	}
+	incStreamSendErrorMetrics(err)
+	return err
+}
+
+func incStreamSendErrorMetrics(err error) {
 	if status.Code(err) == codes.Canceled {
 		incStreamEventMetrics(streamEventContextCanceled)
-	} else {
-		incStreamEventMetrics(streamEventSendError)
+		return
 	}
-	return err
+	incStreamEventMetrics(streamEventSendError)
 }
 
 func (s *regionSyncStream) fullSyncFailureOutcome(err error) string {
@@ -296,7 +305,6 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 		s.mu.Lock()
 		for name, stream := range s.mu.streams {
 			stream.close()
-			stream.deleteDownstreamMetrics()
 			incStreamEventMetrics(streamEventUnbind)
 			log.Info("region syncer delete the stream", zap.String("stream", name))
 		}
@@ -417,7 +425,7 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 		if clusterID != keypath.ClusterID() {
 			return errs.ErrMismatchClusterID(keypath.ClusterID(), clusterID)
 		}
-		member, collectMetrics, err := s.validateDownstreamMember(request.GetMember())
+		member, err := validateDownstreamMember(request.GetMember())
 		if err != nil {
 			return err
 		}
@@ -427,8 +435,9 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 
 		name := member.GetName()
 		syncStream, syncStartIndex := s.bindStreamForSync(
-			name, stream, request.GetStartIndex(), collectMetrics,
+			name, stream, request.GetStartIndex(), false,
 		)
+		s.startDownstreamMetrics(ctx, member, syncStream)
 		err = s.syncHistoryRegion(ctx, request, syncStream, syncStartIndex)
 		if err != nil {
 			s.unbindStream(name, syncStream)
@@ -449,29 +458,61 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 	}
 }
 
-func (s *RegionSyncer) validateDownstreamMember(requested *pdpb.Member) (*pdpb.Member, bool, error) {
+func validateDownstreamMember(requested *pdpb.Member) (*pdpb.Member, error) {
 	if requested == nil || requested.GetName() == "" {
-		return nil, false, status.Error(codes.InvalidArgument, "region syncer downstream member is incomplete")
+		return nil, status.Error(codes.InvalidArgument, "region syncer downstream member is incomplete")
 	}
-	// Router microservices also consume RegionSync without being PD members.
-	// Keep serving them, but do not create a caller-controlled metric label.
-	if requested.GetMemberId() == 0 {
-		return requested, false, nil
+	return requested, nil
+}
+
+func (s *RegionSyncer) startDownstreamMetrics(
+	ctx context.Context,
+	requested *pdpb.Member,
+	stream *regionSyncStream,
+) {
+	memberID := requested.GetMemberId()
+	if memberID == 0 {
+		return
 	}
-	members, err := s.server.GetMembers()
-	if err != nil {
-		return requested, false, nil
-	}
-	for _, member := range members {
-		if member.GetMemberId() != requested.GetMemberId() {
-			continue
+	requestedName := requested.GetName()
+	go func() {
+		defer logutil.LogPanic()
+		ticker := time.NewTicker(downstreamMetricsRetryDelay)
+		defer ticker.Stop()
+		for {
+			members, err := s.server.GetMembers()
+			if err == nil {
+				for _, member := range members {
+					if member.GetMemberId() != memberID {
+						continue
+					}
+					// Only a canonical member name is safe as a metric label. Keep
+					// serving a stream that used a stale or incorrect name, but do
+					// not let it share another stream's metric series.
+					if member.GetName() == requestedName {
+						s.setDownstreamMetricsIfCurrent(requestedName, stream)
+					}
+					return
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-stream.done:
+				return
+			case <-ticker.C:
+			}
 		}
-		// Use the canonical member name for metrics and stream bookkeeping.
-		return member, true, nil
+	}()
+}
+
+func (s *RegionSyncer) setDownstreamMetricsIfCurrent(name string, stream *regionSyncStream) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.mu.streams[name] != stream {
+		return false
 	}
-	// A freshly joined member may not be visible yet. Keep RegionSync
-	// available, but do not create a caller-controlled metric label.
-	return requested, false, nil
+	return stream.setDownstreamMetrics(name, s.history.getNextIndex())
 }
 
 type syncRegionRequestResult struct {
@@ -740,24 +781,26 @@ func (s *RegionSyncer) bindStreamForSync(
 	defer s.mu.Unlock()
 	startIndex := s.history.getNextIndex()
 	syncStream := newRegionSyncStream(stream, startIndex)
-	s.bindStreamLocked(name, syncStream, downstreamStartIndex, startIndex, collectMetrics)
+	if downstreamStartIndex > startIndex {
+		downstreamStartIndex = startIndex
+	}
+	syncStream.setDownstreamSyncIndex(downstreamStartIndex)
+	s.bindStreamLocked(name, syncStream, startIndex, collectMetrics)
 	return syncStream, startIndex
 }
 
 func (s *RegionSyncer) bindStreamLocked(
 	name string,
 	syncStream *regionSyncStream,
-	downstreamStartIndex,
 	leaderNextIndex uint64,
 	collectMetrics bool,
 ) {
 	if oldStream := s.mu.streams[name]; oldStream != nil {
 		oldStream.close()
-		oldStream.deleteDownstreamMetrics()
 		incStreamEventMetrics(streamEventUnbind)
 	}
 	if collectMetrics {
-		syncStream.setDownstreamMetrics(name, downstreamStartIndex, leaderNextIndex)
+		syncStream.setDownstreamMetrics(name, leaderNextIndex)
 	}
 	s.mu.streams[name] = syncStream
 	incStreamEventMetrics(streamEventBind)
@@ -768,7 +811,6 @@ func (s *RegionSyncer) unbindStream(name string, stream *regionSyncStream) {
 	defer s.mu.Unlock()
 	if s.mu.streams[name] == stream {
 		delete(s.mu.streams, name)
-		stream.deleteDownstreamMetrics()
 		incStreamEventMetrics(streamEventUnbind)
 	}
 	stream.close()
@@ -907,7 +949,7 @@ func (s *RegionSyncer) sendRegionSyncResponseWithOptions(
 	if sendErr != nil {
 		log.Warn("region syncer send data meet error", zap.String("name", name),
 			errs.ZapError(errs.ErrGRPCSend, sendErr))
-		incStreamEventMetrics(streamEventSendError)
+		incStreamSendErrorMetrics(sendErr)
 		return false
 	}
 
@@ -939,7 +981,7 @@ func (s *RegionSyncer) sendRegionSyncResponseWithOptions(
 		if err != nil {
 			log.Warn("region syncer send data meet error", zap.String("name", name),
 				errs.ZapError(errs.ErrGRPCSend, err))
-			incStreamEventMetrics(streamEventSendError)
+			incStreamSendErrorMetrics(err)
 			return false
 		}
 		return true

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -78,13 +78,18 @@ type regionSyncStream struct {
 	sendMu struct {
 		sync.Mutex
 	}
-	sendIndex atomic.Uint64
-	notifyCh  chan bool
-	done      chan struct{}
-	once      sync.Once
+	sendIndex           atomic.Uint64
+	downstreamSyncIndex atomic.Uint64
+	notifyCh            chan bool
+	done                chan struct{}
+	once                sync.Once
 
-	downstream         string
-	downstreamLagGauge prometheus.Gauge
+	metrics struct {
+		sync.RWMutex
+		initialized        bool
+		downstream         string
+		downstreamLagGauge prometheus.Gauge
+	}
 }
 
 func newRegionSyncStream(stream ServerStream, startIndex uint64) *regionSyncStream {
@@ -106,12 +111,12 @@ func (s *regionSyncStream) getSendIndex() uint64 {
 	return s.sendIndex.Load()
 }
 
-func (s *regionSyncStream) getSendIndexLocked() uint64 {
-	return s.sendIndex.Load()
-}
-
 func (s *regionSyncStream) advanceSendIndexLocked(count int) {
 	s.sendIndex.Add(uint64(count))
+}
+
+func (s *regionSyncStream) setDownstreamSyncIndex(index uint64) {
+	s.downstreamSyncIndex.Store(index)
 }
 
 func (s *regionSyncStream) notify(keepAlive bool) {
@@ -121,37 +126,46 @@ func (s *regionSyncStream) notify(keepAlive bool) {
 	}
 }
 
-func (s *regionSyncStream) setDownstreamMetrics(name string, leaderNextIndex uint64) {
-	s.downstream = name
-	s.downstreamLagGauge = regionSyncerDownstreamLagGauge.WithLabelValues(name)
+func (s *regionSyncStream) setDownstreamMetrics(name string, downstreamStartIndex, leaderNextIndex uint64) {
+	if downstreamStartIndex > leaderNextIndex {
+		downstreamStartIndex = leaderNextIndex
+	}
+	s.setDownstreamSyncIndex(downstreamStartIndex)
+	s.metrics.Lock()
+	if s.metrics.initialized && s.metrics.downstream != name {
+		regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(s.metrics.downstream)
+	}
+	s.metrics.initialized = true
+	s.metrics.downstream = name
+	s.metrics.downstreamLagGauge = regionSyncerDownstreamLagRecordsGauge.WithLabelValues(name)
+	s.metrics.Unlock()
 	s.observeDownstreamLagMetrics(leaderNextIndex)
 }
 
 func (s *regionSyncStream) observeDownstreamLagMetrics(leaderNextIndex uint64) {
-	s.sendMu.Lock()
-	defer s.sendMu.Unlock()
-	s.observeDownstreamLagMetricsLocked(leaderNextIndex)
-}
-
-func (s *regionSyncStream) observeDownstreamLagMetricsLocked(leaderNextIndex uint64) {
-	if s.downstreamLagGauge == nil {
+	s.metrics.RLock()
+	defer s.metrics.RUnlock()
+	if s.metrics.downstreamLagGauge == nil {
 		return
 	}
-	sendIndex := s.getSendIndexLocked()
-	if sendIndex >= leaderNextIndex {
-		s.downstreamLagGauge.Set(0)
+	downstreamSyncIndex := s.downstreamSyncIndex.Load()
+	if downstreamSyncIndex >= leaderNextIndex {
+		s.metrics.downstreamLagGauge.Set(0)
 		return
 	}
-	s.downstreamLagGauge.Set(float64(leaderNextIndex - sendIndex))
+	s.metrics.downstreamLagGauge.Set(float64(leaderNextIndex - downstreamSyncIndex))
 }
 
 func (s *regionSyncStream) deleteDownstreamMetrics() {
-	if s.downstream == "" {
+	s.metrics.Lock()
+	defer s.metrics.Unlock()
+	if !s.metrics.initialized {
 		return
 	}
-	regionSyncerDownstreamLagGauge.DeleteLabelValues(s.downstream)
-	s.downstream = ""
-	s.downstreamLagGauge = nil
+	regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(s.metrics.downstream)
+	s.metrics.initialized = false
+	s.metrics.downstream = ""
+	s.metrics.downstreamLagGauge = nil
 }
 
 func (s *regionSyncStream) close() {
@@ -173,9 +187,29 @@ func (s *regionSyncStream) sendStreamIfOpen(regions *pdpb.SyncRegionResponse) er
 	s.stream.Lock()
 	defer s.stream.Unlock()
 	if err := s.checkOpen(); err != nil {
+		incStreamEventMetrics(streamEventStreamClosed)
 		return err
 	}
-	return s.stream.Send(regions)
+	err := s.stream.Send(regions)
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) == codes.Canceled {
+		incStreamEventMetrics(streamEventContextCanceled)
+	} else {
+		incStreamEventMetrics(streamEventSendError)
+	}
+	return err
+}
+
+func (s *regionSyncStream) fullSyncFailureReason(err error) string {
+	if status.Code(err) == codes.Canceled {
+		return fullSyncFailureContextCanceled
+	}
+	if s.checkOpen() != nil {
+		return fullSyncFailureStreamClosed
+	}
+	return fullSyncFailureSendError
 }
 
 func (s *regionSyncStream) sendStream(regions *pdpb.SyncRegionResponse) error {
@@ -387,7 +421,7 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 			zap.String("url", request.GetMember().GetClientUrls()[0]))
 
 		name := request.GetMember().GetName()
-		syncStream, syncStartIndex := s.bindStreamForSync(name, stream)
+		syncStream, syncStartIndex := s.bindStreamForSync(name, stream, request.GetStartIndex())
 		err = s.syncHistoryRegion(ctx, request, syncStream, syncStartIndex)
 		if err != nil {
 			s.unbindStream(name, syncStream)
@@ -453,11 +487,11 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 	startIndex := request.GetStartIndex()
 	name := request.GetMember().GetName()
 	if startIndex == 0 || startIndex > endIndex {
-		reason := fullSyncReasonInitial
+		trigger := fullSyncTriggerInitial
 		if startIndex > endIndex {
-			reason = fullSyncReasonStartIndexAhead
+			trigger = fullSyncTriggerStartIndexAhead
 		}
-		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, reason)
+		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, trigger)
 	}
 	if startIndex < endIndex {
 		s.history.observeRequiredWindow(endIndex - startIndex)
@@ -476,25 +510,35 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 				RegionLeaders: nil,
 				Buckets:       nil,
 			}
-			return syncStream.sendStreamIfOpen(resp)
+			if err := syncStream.sendStreamIfOpen(resp); err != nil {
+				return err
+			}
+			syncStream.setDownstreamSyncIndex(endIndex)
+			syncStream.observeDownstreamLagMetrics(s.history.getNextIndex())
+			return nil
 		}
 		if startIndex < endIndex {
 			incHistoryBufferMissMetrics(historyBufferMissHistorySync)
-			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncReasonHistoryGap)
+			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncTriggerHistoryGap)
 		}
 		log.Warn("no history regions from index, the leader may be restarted", zap.Uint64("index", startIndex))
 		return nil
 	}
 	if len(records) != int(endIndex-startIndex) {
 		incHistoryBufferMissMetrics(historyBufferMissHistorySync)
-		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncReasonHistoryGap)
+		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncTriggerHistoryGap)
 	}
 	log.Info("sync the history regions with server",
 		zap.String("server", name),
 		zap.Uint64("from-index", startIndex),
 		zap.Uint64("last-index", endIndex),
 		zap.Int("records-length", len(records)))
-	return s.syncHistoryRecordsLocked(startIndex, records, syncStream)
+	if err := s.syncHistoryRecordsLocked(startIndex, records, syncStream); err != nil {
+		return err
+	}
+	syncStream.setDownstreamSyncIndex(endIndex)
+	syncStream.observeDownstreamLagMetrics(s.history.getNextIndex())
+	return nil
 }
 
 func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdpb.SyncRegionResponse {
@@ -547,13 +591,13 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 	name string,
 	syncStream *regionSyncStream,
 	syncStartIndex uint64,
-	reason string,
+	trigger string,
 ) error {
 	start := time.Now()
 	result := fullSyncResultSuccess
-	metricReason := reason
+	failureReason := fullSyncFailureNone
 	defer func() {
-		observeFullSyncMetrics(result, metricReason, time.Since(start))
+		observeFullSyncMetrics(result, trigger, failureReason, time.Since(start))
 	}()
 	releaseRetain := s.history.retainFrom(syncStartIndex)
 	defer releaseRetain()
@@ -567,7 +611,8 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 		select {
 		case <-ctx.Done():
 			result = fullSyncResultFailure
-			metricReason = fullSyncReasonContextCanceled
+			failureReason = fullSyncFailureContextCanceled
+			incStreamEventMetrics(streamEventContextCanceled)
 			log.Info("discontinue sending sync region response")
 			failpoint.Inject("noFastExitSync", func() {
 				failpoint.Goto("doSync")
@@ -601,19 +646,21 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 		}
 		if err := syncStream.checkOpen(); err != nil {
 			result = fullSyncResultFailure
-			metricReason = fullSyncReasonStreamClosed
+			failureReason = fullSyncFailureStreamClosed
+			incStreamEventMetrics(streamEventStreamClosed)
 			return err
 		}
 		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
 			result = fullSyncResultFailure
-			metricReason = fullSyncReasonContextCanceled
+			failureReason = fullSyncFailureContextCanceled
+			incStreamEventMetrics(streamEventContextCanceled)
 			log.Error("failed to wait rate limit", errs.ZapError(err))
 			return err
 		}
 		lastIndex += len(metas)
 		if err := syncStream.sendStreamIfOpen(resp); err != nil {
 			result = fullSyncResultFailure
-			metricReason = fullSyncReasonSendError
+			failureReason = syncStream.fullSyncFailureReason(err)
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}
@@ -627,7 +674,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 	records, nextIndex, ok := s.history.retainedRecordsFrom(syncStartIndex)
 	if !ok {
 		result = fullSyncResultFailure
-		metricReason = fullSyncReasonMaxHistoryExceeded
+		failureReason = fullSyncFailureMaxHistoryExceeded
 		incHistoryBufferMissMetrics(historyBufferMissFullSyncCatchUp)
 		return status.Errorf(codes.ResourceExhausted,
 			"history records from full sync start index %d to %d are no longer available",
@@ -640,11 +687,10 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 		}
 		if err := s.syncHistoryRecordsLocked(catchUpStartIndex, records, syncStream); err != nil {
 			result = fullSyncResultFailure
-			metricReason = fullSyncReasonSendError
+			failureReason = syncStream.fullSyncFailureReason(err)
 			return err
 		}
 		syncStream.advanceSendIndexLocked(len(records))
-		syncStream.observeDownstreamLagMetricsLocked(nextIndex)
 	}
 	resp := &pdpb.SyncRegionResponse{
 		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
@@ -652,29 +698,40 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 	}
 	if err := syncStream.sendStreamIfOpen(resp); err != nil {
 		result = fullSyncResultFailure
-		metricReason = fullSyncReasonSendError
+		failureReason = syncStream.fullSyncFailureReason(err)
 		log.Warn("failed to send sync region completion response", errs.ZapError(errs.ErrGRPCSend, err))
 		return err
 	}
+	syncStream.setDownstreamSyncIndex(nextIndex)
+	syncStream.observeDownstreamLagMetrics(s.history.getNextIndex())
 	return nil
 }
 
-func (s *RegionSyncer) bindStreamForSync(name string, stream ServerStream) (*regionSyncStream, uint64) {
+func (s *RegionSyncer) bindStreamForSync(
+	name string,
+	stream ServerStream,
+	downstreamStartIndex uint64,
+) (*regionSyncStream, uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	startIndex := s.history.getNextIndex()
 	syncStream := newRegionSyncStream(stream, startIndex)
-	s.bindStreamLocked(name, syncStream, startIndex)
+	s.bindStreamLocked(name, syncStream, downstreamStartIndex, startIndex)
 	return syncStream, startIndex
 }
 
-func (s *RegionSyncer) bindStreamLocked(name string, syncStream *regionSyncStream, leaderNextIndex uint64) {
+func (s *RegionSyncer) bindStreamLocked(
+	name string,
+	syncStream *regionSyncStream,
+	downstreamStartIndex,
+	leaderNextIndex uint64,
+) {
 	if oldStream := s.mu.streams[name]; oldStream != nil {
 		oldStream.close()
 		oldStream.deleteDownstreamMetrics()
 		incStreamEventMetrics(streamEventUnbind)
 	}
-	syncStream.setDownstreamMetrics(name, leaderNextIndex)
+	syncStream.setDownstreamMetrics(name, downstreamStartIndex, leaderNextIndex)
 	s.mu.streams[name] = syncStream
 	incStreamEventMetrics(streamEventBind)
 }
@@ -750,7 +807,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 			return sentRecords, errors.Errorf("region syncer buffered records from index %d overflow, first available index is %d", sendIndex, firstIndex)
 		}
 		bufferNextIndex := s.history.getNextIndex()
-		stream.observeDownstreamLagMetricsLocked(bufferNextIndex)
+		stream.observeDownstreamLagMetrics(bufferNextIndex)
 		if sendIndex > bufferNextIndex {
 			return sentRecords, errors.Errorf("region syncer buffered records index %d exceeds next index %d", sendIndex, bufferNextIndex)
 		}
@@ -771,18 +828,21 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 			return sentRecords, errors.Errorf("send region sync response failed")
 		}
 		stream.advanceSendIndexLocked(len(records))
-		stream.observeDownstreamLagMetricsLocked(bufferNextIndex)
+		stream.setDownstreamSyncIndex(stream.getSendIndex())
+		stream.observeDownstreamLagMetrics(bufferNextIndex)
 		sentRecords = true
 	}
 }
 
 func (s *RegionSyncer) broadcast(ctx context.Context, records []*core.RegionInfo, keepAlive bool) {
 	defer logutil.LogPanic()
+	leaderNextIndex := s.history.getNextIndex()
 	s.mu.RLock()
 	for _, sender := range s.mu.streams {
 		if ctx.Err() != nil {
 			break
 		}
+		sender.observeDownstreamLagMetrics(leaderNextIndex)
 		if len(records) != 0 || keepAlive {
 			sender.notify(keepAlive)
 		}

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -202,14 +202,14 @@ func (s *regionSyncStream) sendStreamIfOpen(regions *pdpb.SyncRegionResponse) er
 	return err
 }
 
-func (s *regionSyncStream) fullSyncFailureReason(err error) string {
+func (s *regionSyncStream) fullSyncFailureOutcome(err error) string {
 	if status.Code(err) == codes.Canceled {
-		return fullSyncFailureContextCanceled
+		return fullSyncOutcomeContextCanceled
 	}
 	if s.checkOpen() != nil {
-		return fullSyncFailureStreamClosed
+		return fullSyncOutcomeStreamClosed
 	}
-	return fullSyncFailureSendError
+	return fullSyncOutcomeSendError
 }
 
 func (s *regionSyncStream) sendStream(regions *pdpb.SyncRegionResponse) error {
@@ -222,6 +222,7 @@ func (s *regionSyncStream) sendStream(regions *pdpb.SyncRegionResponse) error {
 type Server interface {
 	LoopContext() context.Context
 	GetMemberInfo() *pdpb.Member
+	GetMembers() ([]*pdpb.Member, error)
 	GetLeader() *pdpb.Member
 	GetStorage() storage.Storage
 	Name() string
@@ -416,11 +417,15 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 		if clusterID != keypath.ClusterID() {
 			return errs.ErrMismatchClusterID(keypath.ClusterID(), clusterID)
 		}
+		member, err := s.validateDownstreamMember(request.GetMember())
+		if err != nil {
+			return err
+		}
 		log.Info("establish sync region stream",
-			zap.String("requested-server", request.GetMember().GetName()),
-			zap.String("url", request.GetMember().GetClientUrls()[0]))
+			zap.String("requested-server", member.GetName()),
+			zap.Strings("urls", member.GetClientUrls()))
 
-		name := request.GetMember().GetName()
+		name := member.GetName()
 		syncStream, syncStartIndex := s.bindStreamForSync(name, stream, request.GetStartIndex())
 		err = s.syncHistoryRegion(ctx, request, syncStream, syncStartIndex)
 		if err != nil {
@@ -440,6 +445,26 @@ func (s *RegionSyncer) Sync(ctx context.Context, stream pdpb.PD_SyncRegionsServe
 			return status.Error(codes.Unavailable, "region syncer stream closed")
 		}
 	}
+}
+
+func (s *RegionSyncer) validateDownstreamMember(requested *pdpb.Member) (*pdpb.Member, error) {
+	if requested == nil || requested.GetMemberId() == 0 || requested.GetName() == "" {
+		return nil, status.Error(codes.InvalidArgument, "region syncer downstream member is incomplete")
+	}
+	members, err := s.server.GetMembers()
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, "failed to load PD members")
+	}
+	for _, member := range members {
+		if member.GetMemberId() != requested.GetMemberId() {
+			continue
+		}
+		if member.GetName() != requested.GetName() {
+			return nil, status.Error(codes.PermissionDenied, "region syncer downstream member does not match PD membership")
+		}
+		return member, nil
+	}
+	return nil, status.Error(codes.PermissionDenied, "region syncer downstream member is not in PD membership")
 }
 
 type syncRegionRequestResult struct {
@@ -518,14 +543,12 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 			return nil
 		}
 		if startIndex < endIndex {
-			incHistoryBufferMissMetrics(historyBufferMissHistorySync)
 			return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncTriggerHistoryGap)
 		}
 		log.Warn("no history regions from index, the leader may be restarted", zap.Uint64("index", startIndex))
 		return nil
 	}
 	if len(records) != int(endIndex-startIndex) {
-		incHistoryBufferMissMetrics(historyBufferMissHistorySync)
 		return s.syncFullRegionsLocked(ctx, name, syncStream, endIndex, fullSyncTriggerHistoryGap)
 	}
 	log.Info("sync the history regions with server",
@@ -594,10 +617,11 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 	trigger string,
 ) error {
 	start := time.Now()
-	result := fullSyncResultSuccess
-	failureReason := fullSyncFailureNone
+	outcome := fullSyncOutcomeSuccess
+	regionSyncerFullSyncInProgressGauge.Inc()
 	defer func() {
-		observeFullSyncMetrics(result, trigger, failureReason, time.Since(start))
+		regionSyncerFullSyncInProgressGauge.Dec()
+		observeFullSyncMetrics(trigger, outcome, time.Since(start))
 	}()
 	releaseRetain := s.history.retainFrom(syncStartIndex)
 	defer releaseRetain()
@@ -610,8 +634,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 	for syncedIndex, r := range regions {
 		select {
 		case <-ctx.Done():
-			result = fullSyncResultFailure
-			failureReason = fullSyncFailureContextCanceled
+			outcome = fullSyncOutcomeContextCanceled
 			incStreamEventMetrics(streamEventContextCanceled)
 			log.Info("discontinue sending sync region response")
 			failpoint.Inject("noFastExitSync", func() {
@@ -645,22 +668,19 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 			Buckets:       buckets,
 		}
 		if err := syncStream.checkOpen(); err != nil {
-			result = fullSyncResultFailure
-			failureReason = fullSyncFailureStreamClosed
+			outcome = fullSyncOutcomeStreamClosed
 			incStreamEventMetrics(streamEventStreamClosed)
 			return err
 		}
 		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
-			result = fullSyncResultFailure
-			failureReason = fullSyncFailureContextCanceled
+			outcome = fullSyncOutcomeContextCanceled
 			incStreamEventMetrics(streamEventContextCanceled)
 			log.Error("failed to wait rate limit", errs.ZapError(err))
 			return err
 		}
 		lastIndex += len(metas)
 		if err := syncStream.sendStreamIfOpen(resp); err != nil {
-			result = fullSyncResultFailure
-			failureReason = syncStream.fullSyncFailureReason(err)
+			outcome = syncStream.fullSyncFailureOutcome(err)
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
 			return err
 		}
@@ -673,9 +693,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 		zap.String("requested-server", name), zap.String("server", s.server.Name()), zap.Duration("cost", time.Since(start)))
 	records, nextIndex, ok := s.history.retainedRecordsFrom(syncStartIndex)
 	if !ok {
-		result = fullSyncResultFailure
-		failureReason = fullSyncFailureMaxHistoryExceeded
-		incHistoryBufferMissMetrics(historyBufferMissFullSyncCatchUp)
+		outcome = fullSyncOutcomeMaxHistoryExceeded
 		return status.Errorf(codes.ResourceExhausted,
 			"history records from full sync start index %d to %d are no longer available",
 			syncStartIndex, nextIndex)
@@ -686,8 +704,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 			catchUpStartIndex = 0
 		}
 		if err := s.syncHistoryRecordsLocked(catchUpStartIndex, records, syncStream); err != nil {
-			result = fullSyncResultFailure
-			failureReason = syncStream.fullSyncFailureReason(err)
+			outcome = syncStream.fullSyncFailureOutcome(err)
 			return err
 		}
 		syncStream.advanceSendIndexLocked(len(records))
@@ -697,8 +714,7 @@ func (s *RegionSyncer) syncFullRegionsLocked(
 		StartIndex: nextIndex,
 	}
 	if err := syncStream.sendStreamIfOpen(resp); err != nil {
-		result = fullSyncResultFailure
-		failureReason = syncStream.fullSyncFailureReason(err)
+		outcome = syncStream.fullSyncFailureOutcome(err)
 		log.Warn("failed to send sync region completion response", errs.ZapError(errs.ErrGRPCSend, err))
 		return err
 	}
@@ -803,7 +819,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		sendIndex := stream.getSendIndex()
 		firstIndex := s.history.getFirstIndex()
 		if sendIndex < firstIndex {
-			incHistoryBufferMissMetrics(historyBufferMissLiveDrain)
+			incHistoryBufferLiveDrainMissMetrics()
 			return sentRecords, errors.Errorf("region syncer buffered records from index %d overflow, first available index is %d", sendIndex, firstIndex)
 		}
 		bufferNextIndex := s.history.getNextIndex()
@@ -820,7 +836,7 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 		}
 		records := s.history.recordsBetween(sendIndex, endIndex)
 		if len(records) == 0 {
-			incHistoryBufferMissMetrics(historyBufferMissLiveDrain)
+			incHistoryBufferLiveDrainMissMetrics()
 			return sentRecords, errors.Errorf("region syncer has no buffered records from index %d to %d", sendIndex, endIndex)
 		}
 		resp := buildSyncRegionResponse(sendIndex, records)

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -178,7 +179,7 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 func syncFullRegionsForTest(ctx context.Context, syncer *RegionSyncer, syncStream *regionSyncStream, syncStartIndex uint64) error {
 	syncStream.sendMu.Lock()
 	defer syncStream.sendMu.Unlock()
-	return syncer.syncFullRegionsLocked(ctx, "pd-follower", syncStream, syncStartIndex)
+	return syncer.syncFullRegionsLocked(ctx, "pd-follower", syncStream, syncStartIndex, fullSyncReasonInitial)
 }
 
 func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
@@ -259,6 +260,95 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	re.Len(fullResp.GetRegions(), 1)
 
 	re.Equal(codes.ResourceExhausted, status.Code(<-done))
+}
+
+func TestFullSyncMetrics(t *testing.T) {
+	re := require.New(t)
+	successCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(fullSyncResultSuccess, fullSyncReasonInitial)]
+	failureCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(fullSyncResultFailure, fullSyncReasonMaxHistoryExceeded)]
+	missCounter := regionSyncerHistoryBufferMissCounters[historyBufferMissFullSyncCatchUp]
+	successBefore := promtestutil.ToFloat64(successCounter)
+	failureBefore := promtestutil.ToFloat64(failureCounter)
+	missBefore := promtestutil.ToFloat64(missCounter)
+
+	successSyncer, _ := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
+	successSyncer.history.resetWithIndex(10)
+	successStream := &testServerStream{}
+	successSyncStream := newRegionSyncStream(successStream, 10)
+
+	re.NoError(syncFullRegionsForTest(context.Background(), successSyncer, successSyncStream, 10))
+	re.Equal(successBefore+1, promtestutil.ToFloat64(successCounter))
+	re.Greater(promtestutil.ToFloat64(regionSyncerFullSyncLastDurationGauges[fullSyncResultSuccess]), 0.0)
+
+	failureSyncer, bc := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
+	failureSyncer.history = newHistoryBufferWithConfig(1, 1, 1, storage.NewStorageWithMemoryBackend())
+	failureSyncer.history.resetWithIndex(100)
+	failureStream := newMockSyncRegionsServer()
+	failureSyncStream, startIndex := failureSyncer.bindStreamForSync("pd-follower", failureStream)
+	defer failureSyncer.unbindStream("pd-follower", failureSyncStream)
+	unblockSend := failureStream.blockSend()
+	done := make(chan error, 1)
+	go func() {
+		done <- syncFullRegionsForTest(context.Background(), failureSyncer, failureSyncStream, startIndex)
+	}()
+	testutil.Eventually(re, failureStream.isSendBlocked)
+
+	for _, region := range []*core.RegionInfo{
+		newTestSyncRegion(2, 12),
+		newTestSyncRegion(3, 13),
+	} {
+		bc.PutRegion(region)
+		failureSyncer.history.record(region)
+	}
+	close(unblockSend)
+	<-failureStream.sendCh
+
+	re.Equal(codes.ResourceExhausted, status.Code(<-done))
+	re.Equal(failureBefore+1, promtestutil.ToFloat64(failureCounter))
+	re.Equal(missBefore+1, promtestutil.ToFloat64(missCounter))
+	re.Greater(promtestutil.ToFloat64(regionSyncerFullSyncLastDurationGauges[fullSyncResultFailure]), 0.0)
+}
+
+func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
+	re := require.New(t)
+	const downstream = "pd-metrics-follower"
+	bindCounter := regionSyncerStreamEventCounters[streamEventBind]
+	unbindCounter := regionSyncerStreamEventCounters[streamEventUnbind]
+	timeoutCounter := regionSyncerStreamEventCounters[streamEventSendTimeout]
+	bindBefore := promtestutil.ToFloat64(bindCounter)
+	unbindBefore := promtestutil.ToFloat64(unbindCounter)
+	timeoutBefore := promtestutil.ToFloat64(timeoutCounter)
+
+	syncer, _ := newTestRegionSyncer(t)
+	syncer.history.resetWithIndex(10)
+	stream := &testServerStream{}
+	syncStream, _ := syncer.bindStreamForSync(downstream, stream)
+
+	re.Equal(bindBefore+1, promtestutil.ToFloat64(bindCounter))
+	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagGauge.WithLabelValues(downstream)))
+
+	syncer.history.record(newTestRegion(1))
+	syncStream.observeDownstreamLagMetrics(syncer.history.getNextIndex())
+	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerDownstreamLagGauge.WithLabelValues(downstream)))
+
+	re.NoError(syncer.sendDownstream(context.Background(), downstream, syncStream, false))
+	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagGauge.WithLabelValues(downstream)))
+
+	syncer.unbindStream(downstream, syncStream)
+	re.Equal(unbindBefore+1, promtestutil.ToFloat64(unbindCounter))
+	re.False(regionSyncerDownstreamLagGauge.DeleteLabelValues(downstream))
+
+	timeoutSyncer, _ := newTestRegionSyncer(t)
+	timeoutSyncer.sendTimeout = 10 * time.Millisecond
+	timeoutSyncer.history.resetWithIndex(10)
+	blockingStream := newBlockingSendStream(1)
+	timeoutSyncStream, _ := timeoutSyncer.bindStreamForSync("pd-timeout-follower", blockingStream)
+	defer timeoutSyncer.unbindStream("pd-timeout-follower", timeoutSyncStream)
+	timeoutSyncer.history.record(newTestRegion(2))
+
+	re.Error(timeoutSyncer.sendDownstream(context.Background(), "pd-timeout-follower", timeoutSyncStream, false))
+	re.Equal(timeoutBefore+1, promtestutil.ToFloat64(timeoutCounter))
+	blockingStream.unblockSend()
 }
 
 func TestIncrementalHistoryReplayOverflowDisconnectsStream(t *testing.T) {
@@ -1180,6 +1270,7 @@ func TestFullSyncDisconnectsWhenHistoryBufferOverflowsDuringCatchUp(t *testing.T
 
 func TestClientWaitsForFullSyncCompletionBeforeRunning(t *testing.T) {
 	re := require.New(t)
+	setRegionSyncerClientReadyMetrics(false)
 	regionStorage := storage.NewStorageWithMemoryBackend()
 	server := mockserver.NewMockServer(
 		context.Background(),
@@ -1206,6 +1297,7 @@ func TestClientWaitsForFullSyncCompletionBeforeRunning(t *testing.T) {
 	re.True(handled)
 	re.True(fullSyncing)
 	re.False(syncer.IsRunning())
+	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerClientReadyGauge))
 	re.Equal(uint64(0), syncer.history.getNextIndex())
 
 	handled, fullSyncing = syncer.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
@@ -1215,6 +1307,7 @@ func TestClientWaitsForFullSyncCompletionBeforeRunning(t *testing.T) {
 	re.True(handled)
 	re.False(fullSyncing)
 	re.True(syncer.IsRunning())
+	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerClientReadyGauge))
 	re.Equal(uint64(1), syncer.history.getNextIndex())
 }
 

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -77,7 +77,7 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 
 	stream := newMockSyncRegionsServer()
 	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
-	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
+	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream, 0, true)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	err := syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
 		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
@@ -169,7 +169,7 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newMockSyncRegionsServer()
-	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0, true)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	lagGauge := regionSyncerDownstreamLagRecordsGauge.WithLabelValues("pd-follower")
 	re.Equal(10.0, promtestutil.ToFloat64(lagGauge))
@@ -250,7 +250,7 @@ func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newBlockingSendStream(2)
-	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0, true)
 	defer syncer.unbindStream("pd-follower", syncStream)
 
 	catchUpRecords := []*core.RegionInfo{
@@ -296,7 +296,7 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	syncer.history.resetWithIndex(100)
 
 	stream := newMockSyncRegionsServer()
-	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0, true)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	unblockSend := stream.blockSend()
 	done := make(chan error, 1)
@@ -350,7 +350,7 @@ func TestFullSyncMetrics(t *testing.T) {
 	failureSyncer.history = newHistoryBufferWithConfig(1, 1, 1, storage.NewStorageWithMemoryBackend())
 	failureSyncer.history.resetWithIndex(100)
 	failureStream := newMockSyncRegionsServer()
-	failureSyncStream, startIndex := failureSyncer.bindStreamForSync("pd-follower", failureStream, 0)
+	failureSyncStream, startIndex := failureSyncer.bindStreamForSync("pd-follower", failureStream, 0, true)
 	defer failureSyncer.unbindStream("pd-follower", failureSyncStream)
 	unblockSend := failureStream.blockSend()
 	done := make(chan error, 1)
@@ -391,7 +391,7 @@ func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	syncer, _ := newTestRegionSyncer(t)
 	syncer.history.resetWithIndex(10)
 	stream := &testServerStream{}
-	syncStream, _ := syncer.bindStreamForSync(downstream, stream, 10)
+	syncStream, _ := syncer.bindStreamForSync(downstream, stream, 10, true)
 
 	re.Equal(bindBefore+1, promtestutil.ToFloat64(bindCounter))
 	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagRecordsGauge.WithLabelValues(downstream)))
@@ -411,7 +411,7 @@ func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	timeoutSyncer.sendTimeout = 10 * time.Millisecond
 	timeoutSyncer.history.resetWithIndex(10)
 	blockingStream := newBlockingSendStream(1)
-	timeoutSyncStream, _ := timeoutSyncer.bindStreamForSync("pd-timeout-follower", blockingStream, 10)
+	timeoutSyncStream, _ := timeoutSyncer.bindStreamForSync("pd-timeout-follower", blockingStream, 10, true)
 	defer timeoutSyncer.unbindStream("pd-timeout-follower", timeoutSyncStream)
 	timeoutSyncer.history.record(newTestRegion(2))
 
@@ -485,7 +485,7 @@ func TestIncrementalHistoryReplayOverflowDisconnectsStream(t *testing.T) {
 	syncer.history.record(newHistoryBufferTestRegion(10))
 
 	stream := newMockSyncRegionsServer()
-	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream, 10)
+	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream, 10, true)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	unblockSend := stream.blockSend()
 	replayDone := make(chan error, 1)
@@ -583,6 +583,40 @@ func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 		return ok && st.Code() == codes.Unavailable
 	})
 	re.Empty(syncer.GetAllDownstreamNames())
+}
+
+func TestSyncAllowsNonPDDownstreamWithoutCreatingMetrics(t *testing.T) {
+	re := require.New(t)
+	const downstream = "router-service"
+	syncer, _ := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
+	stream := newMockSyncRegionsServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := startTestRegionSync(ctx, syncer, stream)
+	re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(downstream))
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: &pdpb.Member{
+			Name:       downstream,
+			ClientUrls: []string{"http://127.0.0.1:3379"},
+		},
+	}
+
+	select {
+	case response := <-stream.sendCh:
+		re.NotNil(response)
+	case err := <-done:
+		re.NoError(err)
+	}
+	testutil.Eventually(re, func() bool {
+		names := syncer.GetAllDownstreamNames()
+		return len(names) == 1 && names[0] == downstream
+	})
+	re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(downstream))
+
+	cancel()
+	waitTestRegionSyncerUnavailable(re, done)
 }
 
 func TestSyncRejectsUnknownDownstreamBeforeCreatingMetrics(t *testing.T) {
@@ -1057,7 +1091,7 @@ func TestBindStreamWaitsForAppendHistoryRecordsBoundary(t *testing.T) {
 	bindDoneCh := make(chan struct{})
 	go func() {
 		defer close(bindDoneCh)
-		syncStream, syncStartIndex := syncer.bindStreamForSync("pd2", stream, 13)
+		syncStream, syncStartIndex := syncer.bindStreamForSync("pd2", stream, 13, true)
 		defer syncer.unbindStream("pd2", syncStream)
 		bindResultCh <- syncStartIndex
 	}()

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -376,6 +376,21 @@ func TestFullSyncMetrics(t *testing.T) {
 	re.Greater(promtestutil.ToFloat64(regionSyncerFullSyncLastDurationGauges[fullSyncResultFailure]), 0.0)
 }
 
+func TestUnknownMetricLabelsAreIgnored(t *testing.T) {
+	const unknown = "unknown"
+	re := require.New(t)
+	re.False(regionSyncerFullSyncCounter.DeleteLabelValues(unknown, unknown))
+	re.False(regionSyncerStreamEventsCounter.DeleteLabelValues(unknown))
+
+	re.NotPanics(func() {
+		observeFullSyncMetrics(unknown, unknown, time.Second)
+		incStreamEventMetrics(unknown)
+	})
+
+	re.False(regionSyncerFullSyncCounter.DeleteLabelValues(unknown, unknown))
+	re.False(regionSyncerStreamEventsCounter.DeleteLabelValues(unknown))
+}
+
 func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	re := require.New(t)
 	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -619,10 +634,12 @@ func TestSyncAllowsNonPDDownstreamWithoutCreatingMetrics(t *testing.T) {
 	waitTestRegionSyncerUnavailable(re, done)
 }
 
-func TestSyncRejectsUnknownDownstreamBeforeCreatingMetrics(t *testing.T) {
+func TestSyncMemberValidationDoesNotBlockStreams(t *testing.T) {
 	testCases := []struct {
-		name   string
-		member *pdpb.Member
+		name          string
+		member        *pdpb.Member
+		expectedName  string
+		collectMetric bool
 	}{
 		{
 			name: "unknown-member-id",
@@ -630,6 +647,7 @@ func TestSyncRejectsUnknownDownstreamBeforeCreatingMetrics(t *testing.T) {
 				MemberId: 999,
 				Name:     "untrusted-downstream-id",
 			},
+			expectedName: "untrusted-downstream-id",
 		},
 		{
 			name: "mismatched-member-name",
@@ -637,6 +655,8 @@ func TestSyncRejectsUnknownDownstreamBeforeCreatingMetrics(t *testing.T) {
 				MemberId: testDownstreamMemberID,
 				Name:     "untrusted-downstream-name",
 			},
+			expectedName:  "pd-follower",
+			collectMetric: true,
 		},
 	}
 	for _, testCase := range testCases {
@@ -644,7 +664,7 @@ func TestSyncRejectsUnknownDownstreamBeforeCreatingMetrics(t *testing.T) {
 			re := require.New(t)
 			syncer, _ := newTestRegionSyncer(t)
 			stream := newMockSyncRegionsServer()
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			done := startTestRegionSync(ctx, syncer, stream)
 			re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(testCase.member.GetName()))
@@ -654,11 +674,47 @@ func TestSyncRejectsUnknownDownstreamBeforeCreatingMetrics(t *testing.T) {
 				Member: testCase.member,
 			}
 
-			re.Equal(codes.PermissionDenied, status.Code(<-done))
-			re.Empty(syncer.GetAllDownstreamNames())
+			re.NotNil(<-stream.sendCh)
+			testutil.Eventually(re, func() bool {
+				names := syncer.GetAllDownstreamNames()
+				return len(names) == 1 && names[0] == testCase.expectedName
+			})
 			re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(testCase.member.GetName()))
+			if testCase.collectMetric {
+				re.True(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(testCase.expectedName))
+			}
+
+			cancel()
+			waitTestRegionSyncerUnavailable(re, done)
 		})
 	}
+}
+
+func TestSyncContinuesWhenMemberListIsUnavailable(t *testing.T) {
+	re := require.New(t)
+	syncer, _ := newTestRegionSyncer(t)
+	syncer.server = &getMembersErrorServer{Server: syncer.server}
+	stream := newMockSyncRegionsServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := startTestRegionSync(ctx, syncer, stream)
+	member := newTestDownstreamMember()
+	re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(member.GetName()))
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: member,
+	}
+
+	re.NotNil(<-stream.sendCh)
+	testutil.Eventually(re, func() bool {
+		names := syncer.GetAllDownstreamNames()
+		return len(names) == 1 && names[0] == member.GetName()
+	})
+	re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(member.GetName()))
+
+	cancel()
+	waitTestRegionSyncerUnavailable(re, done)
 }
 
 func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
@@ -1708,6 +1764,14 @@ type mockSyncRegionsServer struct {
 	blockCh chan struct{}
 	blocked chan struct{}
 	once    sync.Once
+}
+
+type getMembersErrorServer struct {
+	Server
+}
+
+func (*getMembersErrorServer) GetMembers() ([]*pdpb.Member, error) {
+	return nil, errors.New("failed to load members")
 }
 
 func newMockSyncRegionsServer() *mockSyncRegionsServer {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -323,8 +323,6 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 
 func TestFullSyncMetrics(t *testing.T) {
 	re := require.New(t)
-	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	successCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(
 		fullSyncTriggerInitial,
 		fullSyncOutcomeSuccess,
@@ -342,7 +340,7 @@ func TestFullSyncMetrics(t *testing.T) {
 	successStream := &testServerStream{}
 	successSyncStream := newRegionSyncStream(successStream, 10)
 
-	re.NoError(syncFullRegionsForTest(testCtx, successSyncer, successSyncStream, 10))
+	re.NoError(syncFullRegionsForTest(context.Background(), successSyncer, successSyncStream, 10))
 	re.Equal(successBefore+1, promtestutil.ToFloat64(successCounter))
 	re.Greater(promtestutil.ToFloat64(regionSyncerFullSyncLastDurationGauges[fullSyncResultSuccess]), 0.0)
 
@@ -355,7 +353,7 @@ func TestFullSyncMetrics(t *testing.T) {
 	unblockSend := failureStream.blockSend()
 	done := make(chan error, 1)
 	go func() {
-		done <- syncFullRegionsForTest(testCtx, failureSyncer, failureSyncStream, startIndex)
+		done <- syncFullRegionsForTest(context.Background(), failureSyncer, failureSyncStream, startIndex)
 	}()
 	testutil.Eventually(re, failureStream.isSendBlocked)
 	re.Equal(inProgressBefore+1, promtestutil.ToFloat64(regionSyncerFullSyncInProgressGauge))
@@ -393,8 +391,6 @@ func TestUnknownMetricLabelsAreIgnored(t *testing.T) {
 
 func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	re := require.New(t)
-	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	const downstream = "pd-metrics-follower"
 	bindCounter := regionSyncerStreamEventCounters[streamEventBind]
 	unbindCounter := regionSyncerStreamEventCounters[streamEventUnbind]
@@ -415,7 +411,7 @@ func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	syncStream.observeDownstreamLagMetrics(syncer.history.getNextIndex())
 	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerDownstreamLagRecordsGauge.WithLabelValues(downstream)))
 
-	re.NoError(syncer.sendDownstream(testCtx, downstream, syncStream, false))
+	re.NoError(syncer.sendDownstream(context.Background(), downstream, syncStream, false))
 	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagRecordsGauge.WithLabelValues(downstream)))
 
 	syncer.unbindStream(downstream, syncStream)
@@ -430,7 +426,7 @@ func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	defer timeoutSyncer.unbindStream("pd-timeout-follower", timeoutSyncStream)
 	timeoutSyncer.history.record(newTestRegion(2))
 
-	re.Error(timeoutSyncer.sendDownstream(testCtx, "pd-timeout-follower", timeoutSyncStream, false))
+	re.Error(timeoutSyncer.sendDownstream(context.Background(), "pd-timeout-follower", timeoutSyncStream, false))
 	re.Equal(timeoutBefore+1, promtestutil.ToFloat64(timeoutCounter))
 	blockingStream.unblockSend()
 }

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -67,7 +67,7 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 
 	stream := newMockSyncRegionsServer()
 	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
-	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream)
+	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	err := syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
 		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
@@ -81,6 +81,8 @@ func TestSyncHistoryRegionStartIndexZeroDoesNotGrowHistoryWindow(t *testing.T) {
 
 func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	re := require.New(t)
+	streamClosedCounter := regionSyncerStreamEventCounters[streamEventStreamClosed]
+	streamClosedBefore := promtestutil.ToFloat64(streamClosedCounter)
 	syncer, _ := newTestRegionSyncer(t)
 	records := make([]*core.RegionInfo, 0, maxSyncRegionBatchSize+1)
 	for i := range maxSyncRegionBatchSize + 1 {
@@ -111,6 +113,43 @@ func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	re.Len(responses, 1)
 	re.Equal(uint64(10), responses[0].GetStartIndex())
 	re.Len(responses[0].GetRegions(), maxSyncRegionBatchSize)
+	re.Equal(streamClosedBefore+1, promtestutil.ToFloat64(streamClosedCounter))
+}
+
+func TestDirectSyncSendLifecycleMetrics(t *testing.T) {
+	testCases := []struct {
+		name   string
+		err    error
+		event  string
+		status codes.Code
+	}{
+		{
+			name:   "send-error",
+			err:    errors.New("send failed"),
+			event:  streamEventSendError,
+			status: codes.Unknown,
+		},
+		{
+			name:   "context-canceled",
+			err:    status.Error(codes.Canceled, "send canceled"),
+			event:  streamEventContextCanceled,
+			status: codes.Canceled,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			counter := regionSyncerStreamEventCounters[testCase.event]
+			before := promtestutil.ToFloat64(counter)
+			syncer, _ := newTestRegionSyncer(t)
+			syncStream := newRegionSyncStream(&testServerStream{sendErr: testCase.err}, 10)
+
+			err := syncer.syncHistoryRecords(10, []*core.RegionInfo{newHistoryBufferTestRegion(1)}, syncStream)
+
+			require.Error(t, err)
+			require.Equal(t, testCase.status, status.Code(err))
+			require.Equal(t, before+1, promtestutil.ToFloat64(counter))
+		})
+	}
 }
 
 func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
@@ -120,8 +159,10 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newMockSyncRegionsServer()
-	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream)
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
 	defer syncer.unbindStream("pd-follower", syncStream)
+	lagGauge := regionSyncerDownstreamLagRecordsGauge.WithLabelValues("pd-follower")
+	re.Equal(10.0, promtestutil.ToFloat64(lagGauge))
 	unblockSend := stream.blockSend()
 	done := make(chan error, 1)
 	go func() {
@@ -136,11 +177,13 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 		syncer.history.record(record)
 	}
 	syncer.broadcast(context.Background(), records, false)
+	re.Equal(15.0, promtestutil.ToFloat64(lagGauge))
 
 	close(unblockSend)
 	fullResp := <-stream.sendCh
 	catchUpResp := <-stream.sendCh
 	re.NoError(<-done)
+	re.Equal(0.0, promtestutil.ToFloat64(lagGauge))
 	re.Len(fullResp.GetRegions(), 1)
 	re.Equal(startIndex, catchUpResp.GetStartIndex())
 	re.Len(catchUpResp.GetRegions(), 5)
@@ -164,6 +207,12 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	closedSyncer.history.resetWithIndex(10)
 	closedStream := &testServerStream{}
 	closedSyncStream := newRegionSyncStream(closedStream, 10)
+	fullSyncStreamClosedCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(
+		fullSyncResultFailure,
+		fullSyncTriggerInitial,
+		fullSyncFailureStreamClosed,
+	)]
+	fullSyncStreamClosedBefore := promtestutil.ToFloat64(fullSyncStreamClosedCounter)
 	closedStream.onSend = func(*pdpb.SyncRegionResponse) {
 		closedSyncStream.close()
 	}
@@ -174,12 +223,13 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	closedResponses := closedStream.sentResponses()
 	re.Len(closedResponses, 1)
 	re.Len(closedResponses[0].GetRegions(), maxSyncRegionBatchSize)
+	re.Equal(fullSyncStreamClosedBefore+1, promtestutil.ToFloat64(fullSyncStreamClosedCounter))
 }
 
 func syncFullRegionsForTest(ctx context.Context, syncer *RegionSyncer, syncStream *regionSyncStream, syncStartIndex uint64) error {
 	syncStream.sendMu.Lock()
 	defer syncStream.sendMu.Unlock()
-	return syncer.syncFullRegionsLocked(ctx, "pd-follower", syncStream, syncStartIndex, fullSyncReasonInitial)
+	return syncer.syncFullRegionsLocked(ctx, "pd-follower", syncStream, syncStartIndex, fullSyncTriggerInitial)
 }
 
 func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
@@ -191,7 +241,7 @@ func TestSyncFullRegionsKeepsLiveRecordsAppendedDuringCatchUp(t *testing.T) {
 	syncer.history.resetWithIndex(10)
 
 	stream := newBlockingSendStream(2)
-	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream)
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
 	defer syncer.unbindStream("pd-follower", syncStream)
 
 	catchUpRecords := []*core.RegionInfo{
@@ -237,7 +287,7 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 	syncer.history.resetWithIndex(100)
 
 	stream := newMockSyncRegionsServer()
-	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream)
+	syncStream, startIndex := syncer.bindStreamForSync("pd-follower", stream, 0)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	unblockSend := stream.blockSend()
 	done := make(chan error, 1)
@@ -264,8 +314,18 @@ func TestSyncFullRegionsFailsWhenCatchUpHistoryExceedsMax(t *testing.T) {
 
 func TestFullSyncMetrics(t *testing.T) {
 	re := require.New(t)
-	successCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(fullSyncResultSuccess, fullSyncReasonInitial)]
-	failureCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(fullSyncResultFailure, fullSyncReasonMaxHistoryExceeded)]
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	successCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(
+		fullSyncResultSuccess,
+		fullSyncTriggerInitial,
+		fullSyncFailureNone,
+	)]
+	failureCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(
+		fullSyncResultFailure,
+		fullSyncTriggerInitial,
+		fullSyncFailureMaxHistoryExceeded,
+	)]
 	missCounter := regionSyncerHistoryBufferMissCounters[historyBufferMissFullSyncCatchUp]
 	successBefore := promtestutil.ToFloat64(successCounter)
 	failureBefore := promtestutil.ToFloat64(failureCounter)
@@ -276,7 +336,7 @@ func TestFullSyncMetrics(t *testing.T) {
 	successStream := &testServerStream{}
 	successSyncStream := newRegionSyncStream(successStream, 10)
 
-	re.NoError(syncFullRegionsForTest(context.Background(), successSyncer, successSyncStream, 10))
+	re.NoError(syncFullRegionsForTest(testCtx, successSyncer, successSyncStream, 10))
 	re.Equal(successBefore+1, promtestutil.ToFloat64(successCounter))
 	re.Greater(promtestutil.ToFloat64(regionSyncerFullSyncLastDurationGauges[fullSyncResultSuccess]), 0.0)
 
@@ -284,12 +344,12 @@ func TestFullSyncMetrics(t *testing.T) {
 	failureSyncer.history = newHistoryBufferWithConfig(1, 1, 1, storage.NewStorageWithMemoryBackend())
 	failureSyncer.history.resetWithIndex(100)
 	failureStream := newMockSyncRegionsServer()
-	failureSyncStream, startIndex := failureSyncer.bindStreamForSync("pd-follower", failureStream)
+	failureSyncStream, startIndex := failureSyncer.bindStreamForSync("pd-follower", failureStream, 0)
 	defer failureSyncer.unbindStream("pd-follower", failureSyncStream)
 	unblockSend := failureStream.blockSend()
 	done := make(chan error, 1)
 	go func() {
-		done <- syncFullRegionsForTest(context.Background(), failureSyncer, failureSyncStream, startIndex)
+		done <- syncFullRegionsForTest(testCtx, failureSyncer, failureSyncStream, startIndex)
 	}()
 	testutil.Eventually(re, failureStream.isSendBlocked)
 
@@ -311,6 +371,8 @@ func TestFullSyncMetrics(t *testing.T) {
 
 func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	re := require.New(t)
+	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	const downstream = "pd-metrics-follower"
 	bindCounter := regionSyncerStreamEventCounters[streamEventBind]
 	unbindCounter := regionSyncerStreamEventCounters[streamEventUnbind]
@@ -322,33 +384,90 @@ func TestDownstreamLagAndStreamEventMetrics(t *testing.T) {
 	syncer, _ := newTestRegionSyncer(t)
 	syncer.history.resetWithIndex(10)
 	stream := &testServerStream{}
-	syncStream, _ := syncer.bindStreamForSync(downstream, stream)
+	syncStream, _ := syncer.bindStreamForSync(downstream, stream, 10)
 
 	re.Equal(bindBefore+1, promtestutil.ToFloat64(bindCounter))
-	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagGauge.WithLabelValues(downstream)))
+	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagRecordsGauge.WithLabelValues(downstream)))
 
 	syncer.history.record(newTestRegion(1))
 	syncStream.observeDownstreamLagMetrics(syncer.history.getNextIndex())
-	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerDownstreamLagGauge.WithLabelValues(downstream)))
+	re.Equal(1.0, promtestutil.ToFloat64(regionSyncerDownstreamLagRecordsGauge.WithLabelValues(downstream)))
 
-	re.NoError(syncer.sendDownstream(context.Background(), downstream, syncStream, false))
-	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagGauge.WithLabelValues(downstream)))
+	re.NoError(syncer.sendDownstream(testCtx, downstream, syncStream, false))
+	re.Equal(0.0, promtestutil.ToFloat64(regionSyncerDownstreamLagRecordsGauge.WithLabelValues(downstream)))
 
 	syncer.unbindStream(downstream, syncStream)
 	re.Equal(unbindBefore+1, promtestutil.ToFloat64(unbindCounter))
-	re.False(regionSyncerDownstreamLagGauge.DeleteLabelValues(downstream))
+	re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(downstream))
 
 	timeoutSyncer, _ := newTestRegionSyncer(t)
 	timeoutSyncer.sendTimeout = 10 * time.Millisecond
 	timeoutSyncer.history.resetWithIndex(10)
 	blockingStream := newBlockingSendStream(1)
-	timeoutSyncStream, _ := timeoutSyncer.bindStreamForSync("pd-timeout-follower", blockingStream)
+	timeoutSyncStream, _ := timeoutSyncer.bindStreamForSync("pd-timeout-follower", blockingStream, 10)
 	defer timeoutSyncer.unbindStream("pd-timeout-follower", timeoutSyncStream)
 	timeoutSyncer.history.record(newTestRegion(2))
 
-	re.Error(timeoutSyncer.sendDownstream(context.Background(), "pd-timeout-follower", timeoutSyncStream, false))
+	re.Error(timeoutSyncer.sendDownstream(testCtx, "pd-timeout-follower", timeoutSyncStream, false))
 	re.Equal(timeoutBefore+1, promtestutil.ToFloat64(timeoutCounter))
 	blockingStream.unblockSend()
+}
+
+func TestDownstreamMetricsLifecycleIsConcurrentSafe(t *testing.T) {
+	const (
+		downstream = "pd-concurrent-metrics-follower"
+		iterations = 1000
+	)
+	syncStream := newRegionSyncStream(&testServerStream{}, 10)
+	t.Cleanup(syncStream.deleteDownstreamMetrics)
+	start := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			syncStream.setDownstreamMetrics(downstream, 10, 11)
+			syncStream.deleteDownstreamMetrics()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			syncStream.observeDownstreamLagMetrics(11)
+		}
+	}()
+	close(start)
+	wg.Wait()
+}
+
+func TestSetDownstreamMetricsDoesNotWaitForSendLock(t *testing.T) {
+	syncStream := newRegionSyncStream(&testServerStream{}, 10)
+	syncStream.sendMu.Lock()
+	done := make(chan struct{})
+	go func() {
+		syncStream.setDownstreamMetrics("pd-lock-order-follower", 10, 11)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		syncStream.sendMu.Unlock()
+	case <-time.After(time.Second):
+		syncStream.sendMu.Unlock()
+		<-done
+		t.Fatal("setting downstream metrics waited for the send lock")
+	}
+	syncStream.deleteDownstreamMetrics()
+}
+
+func TestEmptyDownstreamNameMetricsAreDeleted(t *testing.T) {
+	syncStream := newRegionSyncStream(&testServerStream{}, 10)
+	syncStream.setDownstreamMetrics("", 10, 11)
+	syncStream.deleteDownstreamMetrics()
+
+	require.False(t, regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(""))
 }
 
 func TestIncrementalHistoryReplayOverflowDisconnectsStream(t *testing.T) {
@@ -359,7 +478,7 @@ func TestIncrementalHistoryReplayOverflowDisconnectsStream(t *testing.T) {
 	syncer.history.record(newHistoryBufferTestRegion(10))
 
 	stream := newMockSyncRegionsServer()
-	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream)
+	syncStream, syncStartIndex := syncer.bindStreamForSync("pd-follower", stream, 10)
 	defer syncer.unbindStream("pd-follower", syncStream)
 	unblockSend := stream.blockSend()
 	replayDone := make(chan error, 1)
@@ -897,7 +1016,7 @@ func TestBindStreamWaitsForAppendHistoryRecordsBoundary(t *testing.T) {
 	bindDoneCh := make(chan struct{})
 	go func() {
 		defer close(bindDoneCh)
-		syncStream, syncStartIndex := syncer.bindStreamForSync("pd2", stream)
+		syncStream, syncStartIndex := syncer.bindStreamForSync("pd2", stream, 13)
 		defer syncer.unbindStream("pd2", syncStream)
 		bindResultCh <- syncStartIndex
 	}()

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -18,10 +18,13 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"os/exec"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -45,6 +48,38 @@ func newTestDownstreamMember() *pdpb.Member {
 		MemberId:   testDownstreamMemberID,
 		Name:       "pd-follower",
 		ClientUrls: []string{"http://127.0.0.1:2379"},
+	}
+}
+
+func TestRegionSyncerMetricsRegistrationIsLazy(t *testing.T) {
+	const testModeEnv = "PD_REGION_SYNCER_METRICS_TEST_MODE"
+	testMode := os.Getenv(testModeEnv)
+	if testMode != "" {
+		if testMode == "registered" {
+			registerRegionSyncerMetrics()
+		}
+		metricFamilies, err := prometheus.DefaultGatherer.Gather()
+		require.NoError(t, err)
+		registered := false
+		for _, metricFamily := range metricFamilies {
+			if metricFamily.GetName() == "pd_region_syncer_client_ready" {
+				registered = true
+				break
+			}
+		}
+		require.Equal(t, testMode == "registered", registered)
+		return
+	}
+
+	for _, testMode := range []string{"import-only", "registered"} {
+		t.Run(testMode, func(t *testing.T) {
+			// os.Args[0] is the current Go test binary, not external input.
+			//nolint:gosec
+			cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestRegionSyncerMetricsRegistrationIsLazy$")
+			cmd.Env = append(os.Environ(), testModeEnv+"="+testMode)
+			output, err := cmd.CombinedOutput()
+			require.NoError(t, err, string(output))
+		})
 	}
 }
 

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -38,6 +38,16 @@ import (
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
+const testDownstreamMemberID = 2
+
+func newTestDownstreamMember() *pdpb.Member {
+	return &pdpb.Member{
+		MemberId:   testDownstreamMemberID,
+		Name:       "pd-follower",
+		ClientUrls: []string{"http://127.0.0.1:2379"},
+	}
+}
+
 func TestHistoryBufferMaxSizeFromMemory(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -208,9 +218,8 @@ func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	closedStream := &testServerStream{}
 	closedSyncStream := newRegionSyncStream(closedStream, 10)
 	fullSyncStreamClosedCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(
-		fullSyncResultFailure,
 		fullSyncTriggerInitial,
-		fullSyncFailureStreamClosed,
+		fullSyncOutcomeStreamClosed,
 	)]
 	fullSyncStreamClosedBefore := promtestutil.ToFloat64(fullSyncStreamClosedCounter)
 	closedStream.onSend = func(*pdpb.SyncRegionResponse) {
@@ -317,19 +326,16 @@ func TestFullSyncMetrics(t *testing.T) {
 	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	successCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(
-		fullSyncResultSuccess,
 		fullSyncTriggerInitial,
-		fullSyncFailureNone,
+		fullSyncOutcomeSuccess,
 	)]
 	failureCounter := regionSyncerFullSyncCounters[fullSyncMetricKey(
-		fullSyncResultFailure,
 		fullSyncTriggerInitial,
-		fullSyncFailureMaxHistoryExceeded,
+		fullSyncOutcomeMaxHistoryExceeded,
 	)]
-	missCounter := regionSyncerHistoryBufferMissCounters[historyBufferMissFullSyncCatchUp]
 	successBefore := promtestutil.ToFloat64(successCounter)
 	failureBefore := promtestutil.ToFloat64(failureCounter)
-	missBefore := promtestutil.ToFloat64(missCounter)
+	inProgressBefore := promtestutil.ToFloat64(regionSyncerFullSyncInProgressGauge)
 
 	successSyncer, _ := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
 	successSyncer.history.resetWithIndex(10)
@@ -352,6 +358,7 @@ func TestFullSyncMetrics(t *testing.T) {
 		done <- syncFullRegionsForTest(testCtx, failureSyncer, failureSyncStream, startIndex)
 	}()
 	testutil.Eventually(re, failureStream.isSendBlocked)
+	re.Equal(inProgressBefore+1, promtestutil.ToFloat64(regionSyncerFullSyncInProgressGauge))
 
 	for _, region := range []*core.RegionInfo{
 		newTestSyncRegion(2, 12),
@@ -365,7 +372,7 @@ func TestFullSyncMetrics(t *testing.T) {
 
 	re.Equal(codes.ResourceExhausted, status.Code(<-done))
 	re.Equal(failureBefore+1, promtestutil.ToFloat64(failureCounter))
-	re.Equal(missBefore+1, promtestutil.ToFloat64(missCounter))
+	re.Equal(inProgressBefore, promtestutil.ToFloat64(regionSyncerFullSyncInProgressGauge))
 	re.Greater(promtestutil.ToFloat64(regionSyncerFullSyncLastDurationGauges[fullSyncResultFailure]), 0.0)
 }
 
@@ -543,6 +550,7 @@ func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
 		core.NewBasicCluster(),
 	)
+	server.SetMembers([]*pdpb.Member{newTestDownstreamMember()})
 	syncer := NewRegionSyncer(server)
 	ctx, cancel := context.WithCancel(context.Background())
 	stream := newMockSyncRegionsServer()
@@ -553,10 +561,7 @@ func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 
 	stream.recvCh <- &pdpb.SyncRegionRequest{
 		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
-		Member: &pdpb.Member{
-			Name:       "pd-follower",
-			ClientUrls: []string{"http://127.0.0.1:2379"},
-		},
+		Member: newTestDownstreamMember(),
 	}
 	re.NotNil(<-stream.sendCh)
 	testutil.Eventually(re, func() bool {
@@ -580,6 +585,48 @@ func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 	re.Empty(syncer.GetAllDownstreamNames())
 }
 
+func TestSyncRejectsUnknownDownstreamBeforeCreatingMetrics(t *testing.T) {
+	testCases := []struct {
+		name   string
+		member *pdpb.Member
+	}{
+		{
+			name: "unknown-member-id",
+			member: &pdpb.Member{
+				MemberId: 999,
+				Name:     "untrusted-downstream-id",
+			},
+		},
+		{
+			name: "mismatched-member-name",
+			member: &pdpb.Member{
+				MemberId: testDownstreamMemberID,
+				Name:     "untrusted-downstream-name",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			syncer, _ := newTestRegionSyncer(t)
+			stream := newMockSyncRegionsServer()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			done := startTestRegionSync(ctx, syncer, stream)
+			re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(testCase.member.GetName()))
+
+			stream.recvCh <- &pdpb.SyncRegionRequest{
+				Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+				Member: testCase.member,
+			}
+
+			re.Equal(codes.PermissionDenied, status.Code(<-done))
+			re.Empty(syncer.GetAllDownstreamNames())
+			re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(testCase.member.GetName()))
+		})
+	}
+}
+
 func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 	re := require.New(t)
 	tempDir := t.TempDir()
@@ -596,6 +643,7 @@ func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
 		core.NewBasicCluster(),
 	)
+	server.SetMembers([]*pdpb.Member{newTestDownstreamMember()})
 	syncer := NewRegionSyncer(server)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -607,10 +655,7 @@ func TestSyncExitsWhenBroadcastSendFails(t *testing.T) {
 
 	stream.recvCh <- &pdpb.SyncRegionRequest{
 		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
-		Member: &pdpb.Member{
-			Name:       "pd-follower",
-			ClientUrls: []string{"http://127.0.0.1:2379"},
-		},
+		Member: newTestDownstreamMember(),
 	}
 	re.NotNil(<-stream.sendCh)
 	testutil.Eventually(re, func() bool {
@@ -652,6 +697,7 @@ func TestCloseAllClientTimesOutBlockedSend(t *testing.T) {
 		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
 		core.NewBasicCluster(),
 	)
+	server.SetMembers([]*pdpb.Member{newTestDownstreamMember()})
 	syncer := NewRegionSyncer(server)
 	syncer.sendTimeout = 10 * time.Millisecond
 	ctx, cancel := context.WithCancel(context.Background())
@@ -664,10 +710,7 @@ func TestCloseAllClientTimesOutBlockedSend(t *testing.T) {
 
 	stream.recvCh <- &pdpb.SyncRegionRequest{
 		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
-		Member: &pdpb.Member{
-			Name:       "pd-follower",
-			ClientUrls: []string{"http://127.0.0.1:2379"},
-		},
+		Member: newTestDownstreamMember(),
 	}
 	re.NotNil(<-stream.sendCh)
 	testutil.Eventually(re, func() bool {
@@ -725,6 +768,7 @@ func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {
 		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
 		core.NewBasicCluster(),
 	)
+	server.SetMembers([]*pdpb.Member{newTestDownstreamMember()})
 	syncer := NewRegionSyncer(server)
 	syncer.sendTimeout = 10 * time.Millisecond
 	ctx, cancel := context.WithCancel(context.Background())
@@ -737,10 +781,7 @@ func TestBroadcastClosesStreamWhenSendBlocks(t *testing.T) {
 
 	stream.recvCh <- &pdpb.SyncRegionRequest{
 		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
-		Member: &pdpb.Member{
-			Name:       "pd-follower",
-			ClientUrls: []string{"http://127.0.0.1:2379"},
-		},
+		Member: newTestDownstreamMember(),
 	}
 	re.NotNil(<-stream.sendCh)
 	testutil.Eventually(re, func() bool {
@@ -1556,6 +1597,7 @@ func newTestRegionSyncerWithBasicCluster(t *testing.T, bc *core.BasicCluster) *R
 		storage.NewCoreStorage(storage.NewStorageWithMemoryBackend(), regionStorage),
 		bc,
 	)
+	server.SetMembers([]*pdpb.Member{newTestDownstreamMember()})
 	return NewRegionSyncer(server)
 }
 
@@ -1585,10 +1627,7 @@ func sendTestSyncRegionRequest(stream *mockSyncRegionsServer, startIndex uint64)
 	stream.recvCh <- &pdpb.SyncRegionRequest{
 		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
 		StartIndex: startIndex,
-		Member: &pdpb.Member{
-			Name:       "pd-follower",
-			ClientUrls: []string{"http://127.0.0.1:2379"},
-		},
+		Member:     newTestDownstreamMember(),
 	}
 }
 

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -162,6 +162,28 @@ func TestDirectSyncSendLifecycleMetrics(t *testing.T) {
 	}
 }
 
+func TestLiveSyncSendLifecycleMetrics(t *testing.T) {
+	re := require.New(t)
+	canceledCounter := regionSyncerStreamEventCounters[streamEventContextCanceled]
+	sendErrorCounter := regionSyncerStreamEventCounters[streamEventSendError]
+	canceledBefore := promtestutil.ToFloat64(canceledCounter)
+	sendErrorBefore := promtestutil.ToFloat64(sendErrorCounter)
+	syncStream := newRegionSyncStream(&testServerStream{
+		sendErr: status.Error(codes.Canceled, "send canceled"),
+	}, 10)
+	syncer := newTestRegionSyncerWithStreams(t, map[string]*regionSyncStream{
+		"pd-follower": syncStream,
+	})
+	syncer.history.resetWithIndex(10)
+	syncer.history.record(newHistoryBufferTestRegion(1))
+
+	err := syncer.sendDownstream(context.Background(), "pd-follower", syncStream, false)
+
+	re.Error(err)
+	re.Equal(canceledBefore+1, promtestutil.ToFloat64(canceledCounter))
+	re.Equal(sendErrorBefore, promtestutil.ToFloat64(sendErrorCounter))
+}
+
 func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	re := require.New(t)
 	syncer, _ := newTestRegionSyncer(t, newHistoryBufferTestRegion(1))
@@ -445,7 +467,7 @@ func TestDownstreamMetricsLifecycleIsConcurrentSafe(t *testing.T) {
 		defer wg.Done()
 		<-start
 		for range iterations {
-			syncStream.setDownstreamMetrics(downstream, 10, 11)
+			syncStream.setDownstreamMetrics(downstream, 11)
 			syncStream.deleteDownstreamMetrics()
 		}
 	}()
@@ -465,7 +487,7 @@ func TestSetDownstreamMetricsDoesNotWaitForSendLock(t *testing.T) {
 	syncStream.sendMu.Lock()
 	done := make(chan struct{})
 	go func() {
-		syncStream.setDownstreamMetrics("pd-lock-order-follower", 10, 11)
+		syncStream.setDownstreamMetrics("pd-lock-order-follower", 11)
 		close(done)
 	}()
 
@@ -482,7 +504,7 @@ func TestSetDownstreamMetricsDoesNotWaitForSendLock(t *testing.T) {
 
 func TestEmptyDownstreamNameMetricsAreDeleted(t *testing.T) {
 	syncStream := newRegionSyncStream(&testServerStream{}, 10)
-	syncStream.setDownstreamMetrics("", 10, 11)
+	syncStream.setDownstreamMetrics("", 11)
 	syncStream.deleteDownstreamMetrics()
 
 	require.False(t, regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(""))
@@ -632,10 +654,8 @@ func TestSyncAllowsNonPDDownstreamWithoutCreatingMetrics(t *testing.T) {
 
 func TestSyncMemberValidationDoesNotBlockStreams(t *testing.T) {
 	testCases := []struct {
-		name          string
-		member        *pdpb.Member
-		expectedName  string
-		collectMetric bool
+		name   string
+		member *pdpb.Member
 	}{
 		{
 			name: "unknown-member-id",
@@ -643,7 +663,6 @@ func TestSyncMemberValidationDoesNotBlockStreams(t *testing.T) {
 				MemberId: 999,
 				Name:     "untrusted-downstream-id",
 			},
-			expectedName: "untrusted-downstream-id",
 		},
 		{
 			name: "mismatched-member-name",
@@ -651,8 +670,6 @@ func TestSyncMemberValidationDoesNotBlockStreams(t *testing.T) {
 				MemberId: testDownstreamMemberID,
 				Name:     "untrusted-downstream-name",
 			},
-			expectedName:  "pd-follower",
-			collectMetric: true,
 		},
 	}
 	for _, testCase := range testCases {
@@ -673,17 +690,97 @@ func TestSyncMemberValidationDoesNotBlockStreams(t *testing.T) {
 			re.NotNil(<-stream.sendCh)
 			testutil.Eventually(re, func() bool {
 				names := syncer.GetAllDownstreamNames()
-				return len(names) == 1 && names[0] == testCase.expectedName
+				return len(names) == 1 && names[0] == testCase.member.GetName()
 			})
 			re.False(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(testCase.member.GetName()))
-			if testCase.collectMetric {
-				re.True(regionSyncerDownstreamLagRecordsGauge.DeleteLabelValues(testCase.expectedName))
-			}
+			_, initialized := downstreamMetricsState(getDownstreamStream(syncer, testCase.member.GetName()))
+			re.False(initialized)
 
 			cancel()
 			waitTestRegionSyncerUnavailable(re, done)
 		})
 	}
+}
+
+func TestSyncMemberLookupDoesNotBlockStream(t *testing.T) {
+	re := require.New(t)
+	syncer, _ := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
+	server := &blockingGetMembersServer{
+		Server:  syncer.server,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		members: []*pdpb.Member{newTestDownstreamMember()},
+	}
+	syncer.server = server
+	stream := newMockSyncRegionsServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := startTestRegionSync(ctx, syncer, stream)
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: newTestDownstreamMember(),
+	}
+	<-server.started
+	re.NotNil(mustRecvSyncRegionResponse(t, stream, "member lookup blocked RegionSync"))
+	waitTestRegionSyncerBound(re, syncer)
+	close(server.release)
+	testutil.Eventually(re, func() bool {
+		name, initialized := downstreamMetricsState(getDownstreamStream(syncer, "pd-follower"))
+		return initialized && name == "pd-follower"
+	})
+
+	cancel()
+	waitTestRegionSyncerUnavailable(re, done)
+}
+
+func TestDownstreamMetricsInitializeWhenMemberBecomesAvailable(t *testing.T) {
+	re := require.New(t)
+	syncer, _ := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
+	server := &mutableGetMembersServer{Server: syncer.server}
+	syncer.server = server
+	stream := newMockSyncRegionsServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := startTestRegionSync(ctx, syncer, stream)
+	syncer.history.resetWithIndex(10)
+
+	stream.recvCh <- &pdpb.SyncRegionRequest{
+		Header: &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member: newTestDownstreamMember(),
+	}
+	re.NotNil(mustRecvSyncRegionResponse(t, stream, "initial RegionSync response was not sent"))
+	waitTestRegionSyncerBound(re, syncer)
+	_, initialized := downstreamMetricsState(getDownstreamStream(syncer, "pd-follower"))
+	re.False(initialized)
+	syncStream := getDownstreamStream(syncer, "pd-follower")
+	syncStream.setDownstreamSyncIndex(7)
+
+	server.setMembers([]*pdpb.Member{newTestDownstreamMember()})
+	testutil.Eventually(re, func() bool {
+		name, initialized := downstreamMetricsState(syncStream)
+		return initialized && name == "pd-follower" &&
+			promtestutil.ToFloat64(regionSyncerDownstreamLagRecordsGauge.WithLabelValues(name)) == 3
+	})
+
+	cancel()
+	waitTestRegionSyncerUnavailable(re, done)
+}
+
+func TestStaleMemberLookupDoesNotInitializeReplacedStreamMetrics(t *testing.T) {
+	re := require.New(t)
+	syncer, _ := newTestRegionSyncer(t)
+	oldStream, _ := syncer.bindStreamForSync("pd-follower", &testServerStream{}, 0, false)
+	newStream, _ := syncer.bindStreamForSync("pd-follower", &testServerStream{}, 0, false)
+
+	re.False(syncer.setDownstreamMetricsIfCurrent("pd-follower", oldStream))
+	_, initialized := downstreamMetricsState(oldStream)
+	re.False(initialized)
+	re.True(syncer.setDownstreamMetricsIfCurrent("pd-follower", newStream))
+	_, initialized = downstreamMetricsState(newStream)
+	re.True(initialized)
+
+	syncer.unbindStream("pd-follower", newStream)
 }
 
 func TestSyncContinuesWhenMemberListIsUnavailable(t *testing.T) {
@@ -1768,6 +1865,55 @@ type getMembersErrorServer struct {
 
 func (*getMembersErrorServer) GetMembers() ([]*pdpb.Member, error) {
 	return nil, errors.New("failed to load members")
+}
+
+type blockingGetMembersServer struct {
+	Server
+	once    sync.Once
+	started chan struct{}
+	release chan struct{}
+	members []*pdpb.Member
+}
+
+func (s *blockingGetMembersServer) GetMembers() ([]*pdpb.Member, error) {
+	s.once.Do(func() {
+		close(s.started)
+	})
+	<-s.release
+	return s.members, nil
+}
+
+type mutableGetMembersServer struct {
+	Server
+	mu      sync.RWMutex
+	members []*pdpb.Member
+}
+
+func (s *mutableGetMembersServer) GetMembers() ([]*pdpb.Member, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.members, nil
+}
+
+func (s *mutableGetMembersServer) setMembers(members []*pdpb.Member) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.members = members
+}
+
+func getDownstreamStream(syncer *RegionSyncer, name string) *regionSyncStream {
+	syncer.mu.RLock()
+	defer syncer.mu.RUnlock()
+	return syncer.mu.streams[name]
+}
+
+func downstreamMetricsState(stream *regionSyncStream) (string, bool) {
+	if stream == nil {
+		return "", false
+	}
+	stream.metrics.RLock()
+	defer stream.metrics.RUnlock()
+	return stream.metrics.downstream, stream.metrics.initialized
 }
 
 func newMockSyncRegionsServer() *mockSyncRegionsServer {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10719

### What is changed and how does it work?

```commit-message
Add RegionSyncer metrics for follower readiness, full sync attempts and in-progress state, history buffer state and live-drain misses, downstream lag, and stream lifecycle events.

Keep downstream lag accurate during initial and full sync, record bounded full-sync trigger/outcome signals, and update the PD Grafana dashboard with the new signals without adding alerts.
```

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Manual test:

- `make gotest GOTEST_ARGS="-race -tags=deadlock ./pkg/syncer -count=3"`
- `make gotest GOTEST_ARGS="-race -tags=deadlock ./tests/server/api -run TestFollowerRegionAPIWithNoForward -count=3"`
- `NEXT_GEN=1 make gotest GOTEST_ARGS="-race -tags=nextgen,deadlock ./pkg/syncer ./tests/server/api -run Test(SyncFullRegionsBuffersLiveRecords|DirectSyncSendLifecycleMetrics|DownstreamMetricsLifecycleIsConcurrentSafe|SetDownstreamMetricsDoesNotWaitForSendLock|FollowerRegionAPIWithNoForward) -count=2"`
- `make check`
- Parse `metrics/grafana/pd.json`, verify panel IDs are unique, and verify dashboard queries use exported metric names.

### Release note

```release-note
None.
```