### PR TITLE
Fix the URL for the TSO split and merge finish request

### DIFF
--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -74,15 +74,8 @@ const (
 	keyspaceGroupMetricsSyncInterval = 15 * time.Second
 )
 
-// finishKeyspaceGroupOverallTimeout is the overall deadline for one finish split/merge
-// request across all backend PD endpoints. It is set to 3 * per-endpoint timeout so
-// each of the three PD backends can use a full per-endpoint budget before the cap.
-var finishKeyspaceGroupOverallTimeout = 9 * time.Second
-
 // finishKeyspaceGroupPerEndpointTimeout is the deadline for each backend endpoint attempt.
-// It is nested under finishKeyspaceGroupOverallTimeout so a hanging endpoint does not
-// block fallback to later healthy endpoints.
-var finishKeyspaceGroupPerEndpointTimeout = 3 * time.Second
+var finishKeyspaceGroupPerEndpointTimeout = 2 * time.Second
 
 // getBootstrapKeyspaceID returns the keyspace ID used for bootstrapping.
 // It mirrors keyspace.GetBootstrapKeyspaceID() to avoid importing pkg/keyspace (which would
@@ -1255,17 +1248,11 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
-	overallCtx, overallCancel := context.WithTimeout(parentCtx, finishKeyspaceGroupOverallTimeout)
-	defer overallCancel()
 
 	var lastErr error
 	var lastResp *http.Response
 	var lastParseErr error
 	for _, endpoint := range strings.Split(kgm.cfg.GetBackendEndpoints(), ",") {
-		if err := overallCtx.Err(); err != nil {
-			lastErr = err
-			break
-		}
 		endpoint = strings.TrimSpace(endpoint)
 		if endpoint == "" {
 			continue
@@ -1289,7 +1276,7 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 			continue
 		}
 		requestURL := strings.TrimRight(endpoint, "/") + keyspaceGroupsAPIPrefix + suffix
-		reqCtx, reqCancel := context.WithTimeout(overallCtx, finishKeyspaceGroupPerEndpointTimeout)
+		reqCtx, reqCancel := context.WithTimeout(parentCtx, finishKeyspaceGroupPerEndpointTimeout)
 		resp, err := apiutil.DoDeleteWithContext(reqCtx, kgm.httpClient, requestURL)
 		reqCancel()
 		if err == nil && resp.StatusCode == http.StatusOK {

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -1275,7 +1275,13 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 			continue
 		}
 		requestURL := strings.TrimRight(endpoint, "/") + keyspaceGroupsAPIPrefix + suffix
-		reqCtx, reqCancel := context.WithTimeout(parentCtx, finishKeyspaceGroupPerEndpointTimeout)
+		perEndpointTimeout := finishKeyspaceGroupPerEndpointTimeout
+		failpoint.Inject("finishKeyspaceGroupPerEndpointTimeout", func(val failpoint.Value) {
+			if ms, ok := val.(int); ok {
+				perEndpointTimeout = time.Duration(ms) * time.Millisecond
+			}
+		})
+		reqCtx, reqCancel := context.WithTimeout(parentCtx, perEndpointTimeout)
 		resp, err := apiutil.DoDeleteWithContext(reqCtx, kgm.httpClient, requestURL)
 		reqCancel()
 		if err == nil && resp.StatusCode == http.StatusOK {

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -76,7 +76,7 @@ const (
 
 // finishKeyspaceGroupRequestTimeout is the overall deadline for finish split/merge
 // HTTP requests to backend PD endpoints.
-var finishKeyspaceGroupRequestTimeout = etcdutil.DefaultRequestTimeout
+var finishKeyspaceGroupRequestTimeout = 3 * time.Second
 
 // getBootstrapKeyspaceID returns the keyspace ID used for bootstrapping.
 // It mirrors keyspace.GetBootstrapKeyspaceID() to avoid importing pkg/keyspace (which would

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -77,12 +77,12 @@ const (
 // finishKeyspaceGroupOverallTimeout is the overall deadline for one finish split/merge
 // request across all backend PD endpoints. It is set to 3 * per-endpoint timeout so
 // each of the three PD backends can use a full per-endpoint budget before the cap.
-var finishKeyspaceGroupOverallTimeout = 6 * time.Second
+var finishKeyspaceGroupOverallTimeout = 9 * time.Second
 
 // finishKeyspaceGroupPerEndpointTimeout is the deadline for each backend endpoint attempt.
 // It is nested under finishKeyspaceGroupOverallTimeout so a hanging endpoint does not
 // block fallback to later healthy endpoints.
-var finishKeyspaceGroupPerEndpointTimeout = 2 * time.Second
+var finishKeyspaceGroupPerEndpointTimeout = 3 * time.Second
 
 // getBootstrapKeyspaceID returns the keyspace ID used for bootstrapping.
 // It mirrors keyspace.GetBootstrapKeyspaceID() to avoid importing pkg/keyspace (which would

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -1238,23 +1239,48 @@ func (kgm *KeyspaceGroupManager) checkTSOSplit(
 
 const keyspaceGroupsAPIPrefix = "/pd/api/v2/tso/keyspace-groups"
 
-func (kgm *KeyspaceGroupManager) sendDeleteRequestToBackend(path string) (*http.Response, error) {
+func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix string) (*http.Response, error) {
 	var lastErr error
+	var lastResp *http.Response
 	for _, endpoint := range strings.Split(kgm.cfg.GetBackendEndpoints(), ",") {
 		endpoint = strings.TrimSpace(endpoint)
-		if len(endpoint) == 0 {
+		if endpoint == "" {
 			continue
 		}
-		resp, err := apiutil.DoDelete(kgm.httpClient, strings.TrimRight(endpoint, "/")+path)
-		if err == nil {
+		parsedURL, err := url.Parse(endpoint)
+		if err != nil {
+			continue
+		}
+		if parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+			continue
+		}
+		requestURL := strings.TrimRight(endpoint, "/") + keyspaceGroupsAPIPrefix + suffix
+		resp, err := apiutil.DoDelete(kgm.httpClient, requestURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			if lastResp != nil {
+				lastResp.Body.Close()
+			}
 			return resp, nil
 		}
-		lastErr = err
+		if err != nil {
+			if resp != nil {
+				resp.Body.Close()
+			}
+			lastErr = err
+			continue
+		}
+		if lastResp != nil {
+			lastResp.Body.Close()
+		}
+		lastResp = resp
+	}
+	if lastResp != nil {
+		return lastResp, nil
 	}
 	if lastErr != nil {
 		return nil, lastErr
 	}
-	return nil, perrors.New("empty backend endpoints")
+	return nil, errs.ErrURLParse.FastGenByArgs()
 }
 
 // Put the code below into the critical section to prevent from sending too many HTTP requests.
@@ -1272,7 +1298,7 @@ func (kgm *KeyspaceGroupManager) finishSplitKeyspaceGroup(id uint32) error {
 		return nil
 	}
 	startRequest := time.Now()
-	resp, err := kgm.sendDeleteRequestToBackend(keyspaceGroupsAPIPrefix + fmt.Sprintf("/%d/split", id))
+	resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI(fmt.Sprintf("/%d/split", id))
 	if err != nil {
 		return err
 	}
@@ -1309,7 +1335,7 @@ func (kgm *KeyspaceGroupManager) finishMergeKeyspaceGroup(id uint32) error {
 		return nil
 	}
 	startRequest := time.Now()
-	resp, err := kgm.sendDeleteRequestToBackend(keyspaceGroupsAPIPrefix + fmt.Sprintf("/%d/merge", id))
+	resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI(fmt.Sprintf("/%d/merge", id))
 	if err != nil {
 		return err
 	}

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -72,10 +72,9 @@ const (
 	groupPatrolInterval                 = time.Minute
 	// keyspaceGroupMetricsSyncInterval is the interval for syncing keyspace list length metrics from kgm.kgs.
 	keyspaceGroupMetricsSyncInterval = 15 * time.Second
+	// finishKeyspaceGroupPerEndpointTimeout is the deadline for each backend endpoint attempt.
+	finishKeyspaceGroupPerEndpointTimeout = 3 * time.Second
 )
-
-// finishKeyspaceGroupPerEndpointTimeout is the deadline for each backend endpoint attempt.
-var finishKeyspaceGroupPerEndpointTimeout = 3 * time.Second
 
 // getBootstrapKeyspaceID returns the keyspace ID used for bootstrapping.
 // It mirrors keyspace.GetBootstrapKeyspaceID() to avoid importing pkg/keyspace (which would

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -1242,6 +1242,7 @@ const keyspaceGroupsAPIPrefix = "/pd/api/v2/tso/keyspace-groups"
 func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix string) (*http.Response, error) {
 	var lastErr error
 	var lastResp *http.Response
+	var lastParseErr error
 	for _, endpoint := range strings.Split(kgm.cfg.GetBackendEndpoints(), ",") {
 		endpoint = strings.TrimSpace(endpoint)
 		if endpoint == "" {
@@ -1249,9 +1250,20 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 		}
 		parsedURL, err := url.Parse(endpoint)
 		if err != nil {
+			log.Warn("skip invalid backend endpoint",
+				zap.String("endpoint", endpoint),
+				zap.Error(err))
+			lastParseErr = err
 			continue
 		}
 		if parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+			validationErr := perrors.Errorf("invalid backend endpoint %q: host=%q scheme=%q",
+				endpoint, parsedURL.Host, parsedURL.Scheme)
+			log.Warn("skip unsupported backend endpoint",
+				zap.String("endpoint", endpoint),
+				zap.String("host", parsedURL.Host),
+				zap.String("scheme", parsedURL.Scheme))
+			lastParseErr = validationErr
 			continue
 		}
 		requestURL := strings.TrimRight(endpoint, "/") + keyspaceGroupsAPIPrefix + suffix
@@ -1280,7 +1292,10 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 	if lastErr != nil {
 		return nil, lastErr
 	}
-	return nil, errs.ErrURLParse.FastGenByArgs()
+	if lastParseErr != nil {
+		return nil, errs.ErrURLParse.Wrap(lastParseErr).GenWithStackByCause()
+	}
+	return nil, errs.ErrURLParse.FastGenByArgs("no valid backend endpoint configured")
 }
 
 // Put the code below into the critical section to prevent from sending too many HTTP requests.

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -1238,6 +1238,25 @@ func (kgm *KeyspaceGroupManager) checkTSOSplit(
 
 const keyspaceGroupsAPIPrefix = "/pd/api/v2/tso/keyspace-groups"
 
+func (kgm *KeyspaceGroupManager) sendDeleteRequestToBackend(path string) (*http.Response, error) {
+	var lastErr error
+	for _, endpoint := range strings.Split(kgm.cfg.GetBackendEndpoints(), ",") {
+		endpoint = strings.TrimSpace(endpoint)
+		if len(endpoint) == 0 {
+			continue
+		}
+		resp, err := apiutil.DoDelete(kgm.httpClient, strings.TrimRight(endpoint, "/")+path)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, perrors.New("empty backend endpoints")
+}
+
 // Put the code below into the critical section to prevent from sending too many HTTP requests.
 func (kgm *KeyspaceGroupManager) finishSplitKeyspaceGroup(id uint32) error {
 	start := time.Now()
@@ -1253,9 +1272,7 @@ func (kgm *KeyspaceGroupManager) finishSplitKeyspaceGroup(id uint32) error {
 		return nil
 	}
 	startRequest := time.Now()
-	resp, err := apiutil.DoDelete(
-		kgm.httpClient,
-		kgm.cfg.GetBackendEndpoints()+keyspaceGroupsAPIPrefix+fmt.Sprintf("/%d/split", id))
+	resp, err := kgm.sendDeleteRequestToBackend(keyspaceGroupsAPIPrefix + fmt.Sprintf("/%d/split", id))
 	if err != nil {
 		return err
 	}
@@ -1292,9 +1309,7 @@ func (kgm *KeyspaceGroupManager) finishMergeKeyspaceGroup(id uint32) error {
 		return nil
 	}
 	startRequest := time.Now()
-	resp, err := apiutil.DoDelete(
-		kgm.httpClient,
-		kgm.cfg.GetBackendEndpoints()+keyspaceGroupsAPIPrefix+fmt.Sprintf("/%d/merge", id))
+	resp, err := kgm.sendDeleteRequestToBackend(keyspaceGroupsAPIPrefix + fmt.Sprintf("/%d/merge", id))
 	if err != nil {
 		return err
 	}

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -17,6 +17,7 @@ package tso
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -72,6 +73,10 @@ const (
 	// keyspaceGroupMetricsSyncInterval is the interval for syncing keyspace list length metrics from kgm.kgs.
 	keyspaceGroupMetricsSyncInterval = 15 * time.Second
 )
+
+// finishKeyspaceGroupRequestTimeout is the overall deadline for finish split/merge
+// HTTP requests to backend PD endpoints.
+var finishKeyspaceGroupRequestTimeout = etcdutil.DefaultRequestTimeout
 
 // getBootstrapKeyspaceID returns the keyspace ID used for bootstrapping.
 // It mirrors keyspace.GetBootstrapKeyspaceID() to avoid importing pkg/keyspace (which would
@@ -1240,10 +1245,21 @@ func (kgm *KeyspaceGroupManager) checkTSOSplit(
 const keyspaceGroupsAPIPrefix = "/pd/api/v2/tso/keyspace-groups"
 
 func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix string) (*http.Response, error) {
+	parentCtx := kgm.ctx
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, finishKeyspaceGroupRequestTimeout)
+	defer cancel()
+
 	var lastErr error
 	var lastResp *http.Response
 	var lastParseErr error
 	for _, endpoint := range strings.Split(kgm.cfg.GetBackendEndpoints(), ",") {
+		if err := ctx.Err(); err != nil {
+			lastErr = err
+			break
+		}
 		endpoint = strings.TrimSpace(endpoint)
 		if endpoint == "" {
 			continue
@@ -1267,7 +1283,7 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 			continue
 		}
 		requestURL := strings.TrimRight(endpoint, "/") + keyspaceGroupsAPIPrefix + suffix
-		resp, err := apiutil.DoDelete(kgm.httpClient, requestURL)
+		resp, err := apiutil.DoDeleteWithContext(ctx, kgm.httpClient, requestURL)
 		if err == nil && resp.StatusCode == http.StatusOK {
 			if lastResp != nil {
 				lastResp.Body.Close()
@@ -1277,6 +1293,12 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 		if err != nil {
 			if resp != nil {
 				resp.Body.Close()
+			}
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				log.Warn("finish keyspace group request timed out",
+					zap.String("endpoint", endpoint),
+					zap.String("suffix", suffix),
+					zap.Error(err))
 			}
 			lastErr = err
 			continue

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -74,9 +74,15 @@ const (
 	keyspaceGroupMetricsSyncInterval = 15 * time.Second
 )
 
-// finishKeyspaceGroupRequestTimeout is the overall deadline for finish split/merge
-// HTTP requests to backend PD endpoints.
-var finishKeyspaceGroupRequestTimeout = 3 * time.Second
+// finishKeyspaceGroupOverallTimeout is the overall deadline for one finish split/merge
+// request across all backend PD endpoints. It is set to 3 * per-endpoint timeout so
+// each of the three PD backends can use a full per-endpoint budget before the cap.
+var finishKeyspaceGroupOverallTimeout = 6 * time.Second
+
+// finishKeyspaceGroupPerEndpointTimeout is the deadline for each backend endpoint attempt.
+// It is nested under finishKeyspaceGroupOverallTimeout so a hanging endpoint does not
+// block fallback to later healthy endpoints.
+var finishKeyspaceGroupPerEndpointTimeout = 2 * time.Second
 
 // getBootstrapKeyspaceID returns the keyspace ID used for bootstrapping.
 // It mirrors keyspace.GetBootstrapKeyspaceID() to avoid importing pkg/keyspace (which would
@@ -1249,14 +1255,14 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
-	ctx, cancel := context.WithTimeout(parentCtx, finishKeyspaceGroupRequestTimeout)
-	defer cancel()
+	overallCtx, overallCancel := context.WithTimeout(parentCtx, finishKeyspaceGroupOverallTimeout)
+	defer overallCancel()
 
 	var lastErr error
 	var lastResp *http.Response
 	var lastParseErr error
 	for _, endpoint := range strings.Split(kgm.cfg.GetBackendEndpoints(), ",") {
-		if err := ctx.Err(); err != nil {
+		if err := overallCtx.Err(); err != nil {
 			lastErr = err
 			break
 		}
@@ -1283,7 +1289,9 @@ func (kgm *KeyspaceGroupManager) sendDeleteRequestToKeyspaceGroupsAPI(suffix str
 			continue
 		}
 		requestURL := strings.TrimRight(endpoint, "/") + keyspaceGroupsAPIPrefix + suffix
-		resp, err := apiutil.DoDeleteWithContext(ctx, kgm.httpClient, requestURL)
+		reqCtx, reqCancel := context.WithTimeout(overallCtx, finishKeyspaceGroupPerEndpointTimeout)
+		resp, err := apiutil.DoDeleteWithContext(reqCtx, kgm.httpClient, requestURL)
+		reqCancel()
 		if err == nil && resp.StatusCode == http.StatusOK {
 			if lastResp != nil {
 				lastResp.Body.Close()

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -75,7 +75,7 @@ const (
 )
 
 // finishKeyspaceGroupPerEndpointTimeout is the deadline for each backend endpoint attempt.
-var finishKeyspaceGroupPerEndpointTimeout = 2 * time.Second
+var finishKeyspaceGroupPerEndpointTimeout = 3 * time.Second
 
 // getBootstrapKeyspaceID returns the keyspace ID used for bootstrapping.
 // It mirrors keyspace.GetBootstrapKeyspaceID() to avoid importing pkg/keyspace (which would

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1580,12 +1580,9 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
 				oldPerEndpoint := finishKeyspaceGroupPerEndpointTimeout
-				oldOverall := finishKeyspaceGroupOverallTimeout
 				finishKeyspaceGroupPerEndpointTimeout = 50 * time.Millisecond
-				finishKeyspaceGroupOverallTimeout = 500 * time.Millisecond
 				defer func() {
 					finishKeyspaceGroupPerEndpointTimeout = oldPerEndpoint
-					finishKeyspaceGroupOverallTimeout = oldOverall
 				}()
 
 				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
@@ -1617,12 +1614,9 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
 				oldPerEndpoint := finishKeyspaceGroupPerEndpointTimeout
-				oldOverall := finishKeyspaceGroupOverallTimeout
 				finishKeyspaceGroupPerEndpointTimeout = 50 * time.Millisecond
-				finishKeyspaceGroupOverallTimeout = 50 * time.Millisecond
 				defer func() {
 					finishKeyspaceGroupPerEndpointTimeout = oldPerEndpoint
-					finishKeyspaceGroupOverallTimeout = oldOverall
 				}()
 
 				start := time.Now()

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1526,6 +1526,28 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/2/merge",
 			},
 		},
+		{
+			name: "invalid-endpoints",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				return &KeyspaceGroupManager{
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "://bad,ftp://127.0.0.1:2379",
+					},
+				}
+			},
+			handler: func(_ *require.Assertions, _ *http.Request) (*http.Response, error) {
+				return nil, nil
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				re.Error(err)
+				re.Nil(resp)
+				re.Contains(err.Error(), "parse url error")
+				re.Contains(err.Error(), "ftp://127.0.0.1:2379")
+			},
+			wantURLs: []string{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 
+	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	mcs "github.com/tikv/pd/pkg/mcs/utils/constant"
@@ -1543,8 +1544,9 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
 				re.Error(err)
 				re.Nil(resp)
-				re.Contains(err.Error(), "parse url error")
+				re.True(errors.Is(err, errs.ErrURLParse))
 				re.Contains(err.Error(), "ftp://127.0.0.1:2379")
+				re.Contains(err.Error(), `scheme="ftp"`)
 			},
 			wantURLs: []string{},
 		},
@@ -1587,7 +1589,7 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			re := suite.Require()
-			var requestedURLs []string
+			requestedURLs := make([]string, 0)
 			client := &http.Client{
 				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 					requestedURLs = append(requestedURLs, req.URL.String())

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1541,10 +1541,9 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				return nil, nil
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
-				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				_, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
 				re.Error(err)
-				re.Nil(resp)
-				re.True(errors.Is(err, errs.ErrURLParse))
+				re.ErrorIs(err, errs.ErrURLParse)
 				re.Contains(err.Error(), "ftp://127.0.0.1:2379")
 				re.Contains(err.Error(), `scheme="ftp"`)
 			},
@@ -1573,10 +1572,9 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				defer func() { finishKeyspaceGroupRequestTimeout = oldTimeout }()
 
 				start := time.Now()
-				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				_, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
 				elapsed := time.Since(start)
 				re.Error(err)
-				re.Nil(resp)
 				re.ErrorIs(err, context.DeadlineExceeded)
 				re.Less(elapsed, time.Second)
 			},

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1553,6 +1553,52 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 			wantURLs: []string{},
 		},
 		{
+			name: "timeout-fallback",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				return &KeyspaceGroupManager{
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379,http://127.0.0.1:2382",
+					},
+				}
+			},
+			handler: func(re *require.Assertions, req *http.Request) (*http.Response, error) {
+				requestPath := keyspaceGroupsAPIPrefix + "/1/split"
+				switch req.URL.String() {
+				case "http://127.0.0.1:2379" + requestPath:
+					<-req.Context().Done()
+					return nil, req.Context().Err()
+				case "http://127.0.0.1:2382" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       http.NoBody,
+					}, nil
+				default:
+					re.FailNow("unexpected request url", req.URL.String())
+					return nil, nil
+				}
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				oldPerEndpoint := finishKeyspaceGroupPerEndpointTimeout
+				oldOverall := finishKeyspaceGroupOverallTimeout
+				finishKeyspaceGroupPerEndpointTimeout = 50 * time.Millisecond
+				finishKeyspaceGroupOverallTimeout = 500 * time.Millisecond
+				defer func() {
+					finishKeyspaceGroupPerEndpointTimeout = oldPerEndpoint
+					finishKeyspaceGroupOverallTimeout = oldOverall
+				}()
+
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				re.NoError(err)
+				re.NotNil(resp)
+				re.NoError(resp.Body.Close())
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/1/split",
+				"http://127.0.0.1:2382" + keyspaceGroupsAPIPrefix + "/1/split",
+			},
+		},
+		{
 			name: "request-timeout",
 			setup: func(client *http.Client) *KeyspaceGroupManager {
 				return &KeyspaceGroupManager{
@@ -1570,9 +1616,14 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				return nil, req.Context().Err()
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
-				oldTimeout := finishKeyspaceGroupRequestTimeout
-				finishKeyspaceGroupRequestTimeout = 50 * time.Millisecond
-				defer func() { finishKeyspaceGroupRequestTimeout = oldTimeout }()
+				oldPerEndpoint := finishKeyspaceGroupPerEndpointTimeout
+				oldOverall := finishKeyspaceGroupOverallTimeout
+				finishKeyspaceGroupPerEndpointTimeout = 50 * time.Millisecond
+				finishKeyspaceGroupOverallTimeout = 50 * time.Millisecond
+				defer func() {
+					finishKeyspaceGroupPerEndpointTimeout = oldPerEndpoint
+					finishKeyspaceGroupOverallTimeout = oldOverall
+				}()
 
 				start := time.Now()
 				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1318,9 +1318,89 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				}
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
-				resp, err := kgm.sendDeleteRequestToBackend(keyspaceGroupsAPIPrefix + "/1/split")
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
 				re.NoError(err)
 				re.NotNil(resp)
+				re.NoError(resp.Body.Close())
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/1/split",
+				"http://127.0.0.1:2382" + keyspaceGroupsAPIPrefix + "/1/split",
+			},
+		},
+		{
+			name: "status-code-fallback",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				return &KeyspaceGroupManager{
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379,http://127.0.0.1:2382",
+					},
+				}
+			},
+			handler: func(re *require.Assertions, req *http.Request) (*http.Response, error) {
+				requestPath := keyspaceGroupsAPIPrefix + "/1/split"
+				switch req.URL.String() {
+				case "http://127.0.0.1:2379" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusInternalServerError,
+						Body:       http.NoBody,
+					}, nil
+				case "http://127.0.0.1:2382" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       http.NoBody,
+					}, nil
+				default:
+					re.FailNow("unexpected request url", req.URL.String())
+					return nil, nil
+				}
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				re.NoError(err)
+				re.NotNil(resp)
+				re.Equal(http.StatusOK, resp.StatusCode)
+				re.NoError(resp.Body.Close())
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/1/split",
+				"http://127.0.0.1:2382" + keyspaceGroupsAPIPrefix + "/1/split",
+			},
+		},
+		{
+			name: "all-status-codes-fail",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				return &KeyspaceGroupManager{
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379,http://127.0.0.1:2382",
+					},
+				}
+			},
+			handler: func(re *require.Assertions, req *http.Request) (*http.Response, error) {
+				requestPath := keyspaceGroupsAPIPrefix + "/1/split"
+				switch req.URL.String() {
+				case "http://127.0.0.1:2379" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusBadGateway,
+						Body:       http.NoBody,
+					}, nil
+				case "http://127.0.0.1:2382" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusServiceUnavailable,
+						Body:       http.NoBody,
+					}, nil
+				default:
+					re.FailNow("unexpected request url", req.URL.String())
+					return nil, nil
+				}
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				re.NoError(err)
+				re.NotNil(resp)
+				re.Equal(http.StatusServiceUnavailable, resp.StatusCode)
 				re.NoError(resp.Body.Close())
 			},
 			wantURLs: []string{
@@ -1361,6 +1441,54 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 			},
 			wantURLs: []string{
 				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/2/split",
+			},
+		},
+		{
+			name: "finish-split-status-code-fallback",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				kgm := &KeyspaceGroupManager{
+					state:      state{},
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379,http://127.0.0.1:2382",
+					},
+					metrics: newKeyspaceGroupMetrics(),
+				}
+				kgm.initialize()
+				kgm.kgs[2] = &endpoint.KeyspaceGroup{
+					ID:         2,
+					SplitState: &endpoint.SplitState{SplitSource: 1},
+				}
+				return kgm
+			},
+			handler: func(re *require.Assertions, req *http.Request) (*http.Response, error) {
+				requestPath := keyspaceGroupsAPIPrefix + "/2/split"
+				switch req.URL.String() {
+				case "http://127.0.0.1:2379" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusBadGateway,
+						Body:       http.NoBody,
+					}, nil
+				case "http://127.0.0.1:2382" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       http.NoBody,
+					}, nil
+				default:
+					re.FailNow("unexpected request url", req.URL.String())
+					return nil, nil
+				}
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				re.NoError(kgm.finishSplitKeyspaceGroup(2))
+			},
+			assert: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				re.NotNil(kgm.kgs[2])
+				re.Nil(kgm.kgs[2].SplitState)
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/2/split",
+				"http://127.0.0.1:2382" + keyspaceGroupsAPIPrefix + "/2/split",
 			},
 		},
 		{

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1548,6 +1548,40 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 			},
 			wantURLs: []string{},
 		},
+		{
+			name: "request-timeout",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				return &KeyspaceGroupManager{
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379",
+					},
+				}
+			},
+			handler: func(re *require.Assertions, req *http.Request) (*http.Response, error) {
+				re.NotZero(req.Context())
+				_, ok := req.Context().Deadline()
+				re.True(ok)
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				oldTimeout := finishKeyspaceGroupRequestTimeout
+				finishKeyspaceGroupRequestTimeout = 50 * time.Millisecond
+				defer func() { finishKeyspaceGroupRequestTimeout = oldTimeout }()
+
+				start := time.Now()
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				elapsed := time.Since(start)
+				re.Error(err)
+				re.Nil(resp)
+				re.ErrorIs(err, context.DeadlineExceeded)
+				re.Less(elapsed, time.Second)
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/1/split",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1401,7 +1401,6 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		suite.Run(tc.name, func() {
 			re := suite.Require()
 			var requestedURLs []string

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1541,7 +1541,10 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				return nil, nil
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
-				_, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				if resp != nil {
+					re.NoError(resp.Body.Close())
+				}
 				re.Error(err)
 				re.ErrorIs(err, errs.ErrURLParse)
 				re.Contains(err.Error(), "ftp://127.0.0.1:2379")
@@ -1572,7 +1575,10 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				defer func() { finishKeyspaceGroupRequestTimeout = oldTimeout }()
 
 				start := time.Now()
-				_, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
+				if resp != nil {
+					re.NoError(resp.Body.Close())
+				}
 				elapsed := time.Since(start)
 				re.Error(err)
 				re.ErrorIs(err, context.DeadlineExceeded)

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -17,8 +17,10 @@ package tso
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand/v2"
+	"net/http"
 	"reflect"
 	"sort"
 	"strconv"
@@ -74,6 +76,12 @@ func TestKeyspaceGroupPrimaryElectionPurposeIncludesGroupID(t *testing.T) {
 	re.Equal("keyspace group primary election 00000", keyspaceGroupPrimaryElectionPurpose(0))
 	re.Equal("keyspace group primary election 00012", keyspaceGroupPrimaryElectionPurpose(12))
 	re.Equal("keyspace group primary election 12345", keyspaceGroupPrimaryElectionPurpose(12345))
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func (suite *keyspaceGroupManagerTestSuite) SetupSuite() {
@@ -1273,6 +1281,145 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteKeyspaceGroupClearsListLen
 	mfs, err = prometheus.DefaultGatherer.Gather()
 	re.NoError(err)
 	re.False(metricExists(mfs, groupID), "deleteKeyspaceGroup should trigger DeleteKeyspaceListLengthMetric and remove metric")
+}
+
+func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoints() {
+	testCases := []struct {
+		name     string
+		setup    func(client *http.Client) *KeyspaceGroupManager
+		handler  func(re *require.Assertions, req *http.Request) (*http.Response, error)
+		run      func(re *require.Assertions, kgm *KeyspaceGroupManager)
+		assert   func(re *require.Assertions, kgm *KeyspaceGroupManager)
+		wantURLs []string
+	}{
+		{
+			name: "fallback",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				return &KeyspaceGroupManager{
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384",
+					},
+				}
+			},
+			handler: func(re *require.Assertions, req *http.Request) (*http.Response, error) {
+				requestPath := keyspaceGroupsAPIPrefix + "/1/split"
+				switch req.URL.String() {
+				case "http://127.0.0.1:2379" + requestPath:
+					return nil, errors.New("first endpoint unavailable")
+				case "http://127.0.0.1:2382" + requestPath:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       http.NoBody,
+					}, nil
+				default:
+					re.FailNow("unexpected request url", req.URL.String())
+					return nil, nil
+				}
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				resp, err := kgm.sendDeleteRequestToBackend(keyspaceGroupsAPIPrefix + "/1/split")
+				re.NoError(err)
+				re.NotNil(resp)
+				re.NoError(resp.Body.Close())
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/1/split",
+				"http://127.0.0.1:2382" + keyspaceGroupsAPIPrefix + "/1/split",
+			},
+		},
+		{
+			name: "finish-split",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				kgm := &KeyspaceGroupManager{
+					state:      state{},
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379,http://127.0.0.1:2382",
+					},
+					metrics: newKeyspaceGroupMetrics(),
+				}
+				kgm.initialize()
+				kgm.kgs[2] = &endpoint.KeyspaceGroup{
+					ID:         2,
+					SplitState: &endpoint.SplitState{SplitSource: 1},
+				}
+				return kgm
+			},
+			handler: func(_ *require.Assertions, _ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       http.NoBody,
+				}, nil
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				re.NoError(kgm.finishSplitKeyspaceGroup(2))
+			},
+			assert: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				re.NotNil(kgm.kgs[2])
+				re.Nil(kgm.kgs[2].SplitState)
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/2/split",
+			},
+		},
+		{
+			name: "finish-merge",
+			setup: func(client *http.Client) *KeyspaceGroupManager {
+				kgm := &KeyspaceGroupManager{
+					state:      state{},
+					httpClient: client,
+					cfg: &TestServiceConfig{
+						BackendEndpoints: "http://127.0.0.1:2379,http://127.0.0.1:2382",
+					},
+					metrics: newKeyspaceGroupMetrics(),
+				}
+				kgm.initialize()
+				kgm.kgs[2] = &endpoint.KeyspaceGroup{
+					ID:         2,
+					MergeState: &endpoint.MergeState{MergeList: []uint32{1}},
+				}
+				return kgm
+			},
+			handler: func(_ *require.Assertions, _ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       http.NoBody,
+				}, nil
+			},
+			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				re.NoError(kgm.finishMergeKeyspaceGroup(2))
+			},
+			assert: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
+				re.NotNil(kgm.kgs[2])
+				re.Nil(kgm.kgs[2].MergeState)
+			},
+			wantURLs: []string{
+				"http://127.0.0.1:2379" + keyspaceGroupsAPIPrefix + "/2/merge",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		suite.Run(tc.name, func() {
+			re := suite.Require()
+			var requestedURLs []string
+			client := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					requestedURLs = append(requestedURLs, req.URL.String())
+					return tc.handler(re, req)
+				}),
+			}
+			kgm := tc.setup(client)
+
+			tc.run(re, kgm)
+			re.Equal(tc.wantURLs, requestedURLs)
+			if tc.assert != nil {
+				tc.assert(re, kgm)
+			}
+		})
+	}
 }
 
 // Register TSO server.

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -1579,10 +1579,11 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				}
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
-				oldPerEndpoint := finishKeyspaceGroupPerEndpointTimeout
-				finishKeyspaceGroupPerEndpointTimeout = 50 * time.Millisecond
+				re.NoError(failpoint.Enable(
+					"github.com/tikv/pd/pkg/tso/finishKeyspaceGroupPerEndpointTimeout", "return(50)"))
 				defer func() {
-					finishKeyspaceGroupPerEndpointTimeout = oldPerEndpoint
+					re.NoError(failpoint.Disable(
+						"github.com/tikv/pd/pkg/tso/finishKeyspaceGroupPerEndpointTimeout"))
 				}()
 
 				resp, err := kgm.sendDeleteRequestToKeyspaceGroupsAPI("/1/split")
@@ -1613,10 +1614,11 @@ func (suite *keyspaceGroupManagerTestSuite) TestDeleteRequestsUseBackendEndpoint
 				return nil, req.Context().Err()
 			},
 			run: func(re *require.Assertions, kgm *KeyspaceGroupManager) {
-				oldPerEndpoint := finishKeyspaceGroupPerEndpointTimeout
-				finishKeyspaceGroupPerEndpointTimeout = 50 * time.Millisecond
+				re.NoError(failpoint.Enable(
+					"github.com/tikv/pd/pkg/tso/finishKeyspaceGroupPerEndpointTimeout", "return(50)"))
 				defer func() {
-					finishKeyspaceGroupPerEndpointTimeout = oldPerEndpoint
+					re.NoError(failpoint.Disable(
+						"github.com/tikv/pd/pkg/tso/finishKeyspaceGroupPerEndpointTimeout"))
 				}()
 
 				start := time.Now()

--- a/pkg/utils/apiutil/apiutil.go
+++ b/pkg/utils/apiutil/apiutil.go
@@ -17,6 +17,7 @@ package apiutil
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -276,6 +277,15 @@ func PostJSONIgnoreResp(client *http.Client, url string, data []byte) error {
 // DoDelete is used to send delete request and return http response code.
 func DoDelete(client *http.Client, url string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodDelete, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+// DoDeleteWithContext is used to send delete request with context and return http response.
+func DoDeleteWithContext(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -188,15 +188,14 @@ func (s *tsoTestSuite) checkLogicalOverflow(cluster *tests.TestCluster) {
 	}()
 
 	var (
-		lastTimestamp      *pdpb.Timestamp
-		sawPhysicalAdvance bool
+		maxDuration   time.Duration
+		lastTimestamp *pdpb.Timestamp
 	)
 	// Since the max logical count is 2 << 18 (262144), we request 20 times with 26214 count each time.
 	// This ensures that the logical part will definitely overflow once within the `updateInterval`.
-	// When overflow happens, the current implementation advances the physical part in the request path
-	// instead of necessarily waiting for the periodic update ticker.
 	count := (1 << 18) / 10
 	for range 20 {
+		begin := time.Now()
 		req := &pdpb.TsoRequest{
 			Header: testutil.NewRequestHeader(clusterID),
 			Count:  uint32(count),
@@ -204,15 +203,17 @@ func (s *tsoTestSuite) checkLogicalOverflow(cluster *tests.TestCluster) {
 		re.NoError(tsoClient.Send(req))
 		resp, err := tsoClient.Recv()
 		re.NoError(err)
+		// Record the max duration to validate whether the overflow is triggered later.
+		duration := time.Since(begin)
+		if duration > maxDuration {
+			maxDuration = duration
+		}
 		// Check the monotonicity of the timestamp.
 		timestamp := checkAndReturnTimestampResponse(re, req, resp)
 		re.NotNil(timestamp)
 		if lastTimestamp != nil {
 			lastPhysical, curPhysical := lastTimestamp.GetPhysical(), timestamp.GetPhysical()
 			re.GreaterOrEqual(curPhysical, lastPhysical)
-			if curPhysical > lastPhysical {
-				sawPhysicalAdvance = true
-			}
 			// If the physical time is the same, the logical time must be strictly increasing.
 			if curPhysical == lastPhysical {
 				re.Greater(timestamp.GetLogical(), lastTimestamp.GetLogical())
@@ -220,6 +221,6 @@ func (s *tsoTestSuite) checkLogicalOverflow(cluster *tests.TestCluster) {
 		}
 		lastTimestamp = timestamp
 	}
-	// Logical overflow should force the physical part to advance within the request loop.
-	re.True(sawPhysicalAdvance)
+	// Due to the overflow triggered, there at least one request duration greater than the `updateInterval`.
+	re.Greater(maxDuration, s.updateInterval)
 }

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -188,14 +188,15 @@ func (s *tsoTestSuite) checkLogicalOverflow(cluster *tests.TestCluster) {
 	}()
 
 	var (
-		maxDuration   time.Duration
-		lastTimestamp *pdpb.Timestamp
+		lastTimestamp      *pdpb.Timestamp
+		sawPhysicalAdvance bool
 	)
 	// Since the max logical count is 2 << 18 (262144), we request 20 times with 26214 count each time.
 	// This ensures that the logical part will definitely overflow once within the `updateInterval`.
+	// When overflow happens, the current implementation advances the physical part in the request path
+	// instead of necessarily waiting for the periodic update ticker.
 	count := (1 << 18) / 10
 	for range 20 {
-		begin := time.Now()
 		req := &pdpb.TsoRequest{
 			Header: testutil.NewRequestHeader(clusterID),
 			Count:  uint32(count),
@@ -203,17 +204,15 @@ func (s *tsoTestSuite) checkLogicalOverflow(cluster *tests.TestCluster) {
 		re.NoError(tsoClient.Send(req))
 		resp, err := tsoClient.Recv()
 		re.NoError(err)
-		// Record the max duration to validate whether the overflow is triggered later.
-		duration := time.Since(begin)
-		if duration > maxDuration {
-			maxDuration = duration
-		}
 		// Check the monotonicity of the timestamp.
 		timestamp := checkAndReturnTimestampResponse(re, req, resp)
 		re.NotNil(timestamp)
 		if lastTimestamp != nil {
 			lastPhysical, curPhysical := lastTimestamp.GetPhysical(), timestamp.GetPhysical()
 			re.GreaterOrEqual(curPhysical, lastPhysical)
+			if curPhysical > lastPhysical {
+				sawPhysicalAdvance = true
+			}
 			// If the physical time is the same, the logical time must be strictly increasing.
 			if curPhysical == lastPhysical {
 				re.Greater(timestamp.GetLogical(), lastTimestamp.GetLogical())
@@ -221,6 +220,6 @@ func (s *tsoTestSuite) checkLogicalOverflow(cluster *tests.TestCluster) {
 		}
 		lastTimestamp = timestamp
 	}
-	// Due to the overflow triggered, there at least one request duration greater than the `updateInterval`.
-	re.Greater(maxDuration, s.updateInterval)
+	// Logical overflow should force the physical part to advance within the request loop.
+	re.True(sawPhysicalAdvance)
 }


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/10917

### What is changed and how does it work?


<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
 This PR fixes the HTTP DELETE request used to finish TSO keyspace-group split/merge. Previously, the code built the request URL directly from BackendEndpoints, which could be a comma-separated multi-PD list
  and produce an invalid URL. The fix sends the request to one valid backend endpoint at a time, falls back if one endpoint is unavailable, and adds regression tests for fallback, split finish, and merge
  finish.
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
Fix the URL for the TSO split and merge finish request
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of keyspace group split/merge completion by retrying backend DELETE requests across the configured backend endpoints until a successful response is received.
  * Split/merge completion now uses request timeouts and better endpoint validation when issuing backend DELETE calls.

* **Tests**
  * Added unit tests covering backend endpoint routing, retry/failover on transport errors and non-success HTTP statuses, handling of invalid backend endpoints, and request-timeout behavior. Also verifies split/merge state is cleared after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->