### PR TITLE
client: remove prefix watch for resource group config

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -343,7 +343,7 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 			}
 		}
 
-		watchConfigChannel, err = c.provider.Watch(ctx, pd.ControllerConfigPathPrefixBytes, opt.WithRev(cfgRevision), opt.WithPrefix())
+		watchConfigChannel, err = c.provider.Watch(ctx, pd.ControllerConfigPathPrefixBytes, opt.WithRev(cfgRevision))
 		if err != nil {
 			log.Warn("watch resource group config failed", zap.Error(err))
 		}
@@ -375,7 +375,7 @@ func (c *ResourceGroupsController) Start(ctx context.Context) {
 					}
 				}
 				if watchConfigChannel == nil {
-					watchConfigChannel, err = c.provider.Watch(ctx, pd.ControllerConfigPathPrefixBytes, opt.WithRev(cfgRevision), opt.WithPrefix())
+					watchConfigChannel, err = c.provider.Watch(ctx, pd.ControllerConfigPathPrefixBytes, opt.WithRev(cfgRevision))
 					if err != nil {
 						log.Warn("watch resource group config failed", zap.Error(err))
 						watchRetryTimer.Reset(watchRetryInterval)

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -599,7 +599,7 @@ func (suite *resourceManagerClientTestSuite) TestKeyspaceResourceGroupController
 	configBytes, err := json.Marshal(config)
 	re.NoError(err)
 	// trigger resource group controller to watch config changes.
-	_, err = suite.client.Put(ctx, fmt.Appendf(nil, "%s/%d", pd.ControllerConfigPathPrefixBytes, 1), configBytes)
+	_, err = suite.client.Put(ctx, pd.ControllerConfigPathPrefixBytes, configBytes)
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		return rgController.GetRUVersion() == controller.RUVersionV2

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -565,6 +565,8 @@ func (suite *resourceManagerClientTestSuite) TestKeyspaceResourceGroupController
 	re.NoError(err)
 	defer func() {
 		if len(originalConfig.GetKvs()) == 0 {
+			_, err := suite.client.Put(suite.ctx, pd.ControllerConfigPathPrefixBytes, []byte("{}"))
+			re.NoError(err)
 			return
 		}
 		// Use suite.ctx because the test-scoped ctx is canceled by earlier defers.

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -559,6 +559,19 @@ func (suite *resourceManagerClientTestSuite) TestKeyspaceResourceGroupController
 	re := suite.Require()
 	ctx, cancel := context.WithCancel(suite.ctx)
 
+	// This test overwrites the shared controller config key, so save the
+	// original value and restore it afterwards to avoid polluting other tests.
+	originalConfig, err := suite.client.Get(ctx, pd.ControllerConfigPathPrefixBytes)
+	re.NoError(err)
+	defer func() {
+		if len(originalConfig.GetKvs()) == 0 {
+			return
+		}
+		// Use suite.ctx because the test-scoped ctx is canceled by earlier defers.
+		_, err := suite.client.Put(suite.ctx, pd.ControllerConfigPathPrefixBytes, originalConfig.GetKvs()[0].GetValue())
+		re.NoError(err)
+	}()
+
 	minRevision := int64(0)
 	maxRevision := int64(0)
 	for i := range 3 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10919

The resource group controller config watcher only needs to watch the controller config key, but it currently also passes `opt.WithPrefix()`. This makes the watch range broader than necessary.

### What is changed and how does it work?

```commit-message
Remove `opt.WithPrefix()` from resource group controller config watch creation and retry paths.

Keep prefix watching unchanged for resource group metadata watches because those still need to watch metadata under a key prefix.
```

### Check List

Tests

- Manual test (code compiles through gofmt/diff check only; no full test run in this step)

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of controller RU configuration updates by adjusting the controller metadata watch behavior so changes are consistently received and processed during startup and retry recovery.

* **Tests**
  * Updated the integration test to store controller configuration at the correct location and to preserve/restore any pre-existing value, preventing cross-test side effects while keeping watch-count and RU-version polling checks the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->