### PR TITLE
core, mcs: fix region heartbeat tracer panic on non-monotonic clock (#10902)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,8 @@ require (
 	gotest.tools/gotestsum v1.7.0
 )
 
+require github.com/kylelemons/godebug v1.1.0 // indirect
+
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect

--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 )
 
 var (
@@ -97,15 +96,6 @@ var tracerPool = &sync.Pool{
 	},
 }
 
-type saveCacheStats struct {
-	startTime              time.Time
-	lastCheckTime          time.Time
-	checkOverlapsDuration  time.Duration
-	validateRegionDuration time.Duration
-	setRegionDuration      time.Duration
-	updateSubTreeDuration  time.Duration
-}
-
 // RegionHeartbeatProcessTracer is used to trace the process of handling region heartbeat.
 type RegionHeartbeatProcessTracer interface {
 	// Begin starts the tracing.
@@ -132,8 +122,6 @@ type RegionHeartbeatProcessTracer interface {
 	OnCollectRegionStatsFinished()
 	// OnAllStageFinished will be called when all stages are finished.
 	OnAllStageFinished()
-	// LogFields returns the log fields.
-	LogFields() []zap.Field
 	// Release releases the tracer.
 	Release()
 }
@@ -181,22 +169,15 @@ func (*noopHeartbeatProcessTracer) OnCollectRegionStatsFinished() {}
 // OnAllStageFinished implements the RegionHeartbeatProcessTracer interface.
 func (*noopHeartbeatProcessTracer) OnAllStageFinished() {}
 
-// LogFields implements the RegionHeartbeatProcessTracer interface.
-func (*noopHeartbeatProcessTracer) LogFields() []zap.Field {
-	return nil
-}
-
 // Release implements the RegionHeartbeatProcessTracer interface.
 func (*noopHeartbeatProcessTracer) Release() {}
 
+// regionHeartbeatProcessTracer measures the duration of each region-heartbeat
+// processing stage and reports it to the breakdown metrics. It keeps a single
+// checkpoint: a stage's duration is the time elapsed since the previous stage
+// advanced the checkpoint.
 type regionHeartbeatProcessTracer struct {
-	startTime             time.Time
-	lastCheckTime         time.Time
-	preCheckDuration      time.Duration
-	asyncHotStatsDuration time.Duration
-	regionGuideDuration   time.Duration
-	saveCacheStats        saveCacheStats
-	OtherDuration         time.Duration
+	lastCheckTime time.Time
 }
 
 // NewHeartbeatProcessTracer returns a heartbeat process tracer.
@@ -206,116 +187,91 @@ func NewHeartbeatProcessTracer() RegionHeartbeatProcessTracer {
 
 // Begin implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) Begin() {
+	h.lastCheckTime = time.Now()
+}
+
+// measure records one processing stage: it reads the clock once, computes the
+// duration since the previous checkpoint, advances the checkpoint, and updates
+// the stage's duration-sum and count counters.
+//
+// A non-positive duration is not added to the sum counter. time.Now() normally
+// carries a monotonic reading, so two consecutive reads never go backwards; but
+// on some virtualized hosts the OS monotonic clock (CLOCK_MONOTONIC) can briefly
+// regress -- e.g. an unsynchronized TSC across vCPUs, or a live migration.
+// Without this guard the negative value would reach prometheus.Counter.Add,
+// which panics with "counter cannot decrease in value" and crashes pd-server.
+// Guarding turns that rare, external clock glitch into a negligibly
+// under-counted metric instead of a fatal panic.
+func (h *regionHeartbeatProcessTracer) measure(durationSum, count prometheus.Counter) {
 	now := time.Now()
-	h.startTime = now
+	duration := now.Sub(h.lastCheckTime)
 	h.lastCheckTime = now
+	if duration > 0 {
+		durationSum.Add(duration.Seconds())
+	}
+	count.Inc()
+}
+
+// resetCheckpoint starts a fresh measurement window at the current time. It is
+// used at the SaveCache boundaries, whose enclosed sub-stages are timed on their
+// own and should not be attributed to the surrounding stages.
+func (h *regionHeartbeatProcessTracer) resetCheckpoint() {
+	h.lastCheckTime = time.Now()
 }
 
 // OnPreCheckFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnPreCheckFinished() {
-	now := time.Now()
-	h.preCheckDuration = now.Sub(h.lastCheckTime)
-	h.lastCheckTime = now
-	preCheckDurationSum.Add(h.preCheckDuration.Seconds())
-	preCheckCount.Inc()
+	h.measure(preCheckDurationSum, preCheckCount)
 }
 
 // OnAsyncHotStatsFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnAsyncHotStatsFinished() {
-	now := time.Now()
-	h.asyncHotStatsDuration = now.Sub(h.lastCheckTime)
-	h.lastCheckTime = now
-	asyncHotStatsDurationSum.Add(h.preCheckDuration.Seconds())
-	asyncHotStatsCount.Inc()
+	h.measure(asyncHotStatsDurationSum, asyncHotStatsCount)
 }
 
 // OnRegionGuideFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnRegionGuideFinished() {
-	now := time.Now()
-	h.regionGuideDuration = now.Sub(h.lastCheckTime)
-	h.lastCheckTime = now
-	regionGuideDurationSum.Add(h.regionGuideDuration.Seconds())
-	regionGuideCount.Inc()
+	h.measure(regionGuideDurationSum, regionGuideCount)
 }
 
 // OnSaveCacheBegin implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnSaveCacheBegin() {
-	now := time.Now()
-	h.saveCacheStats.startTime = now
-	h.saveCacheStats.lastCheckTime = now
-	h.lastCheckTime = now
+	h.resetCheckpoint()
 }
 
 // OnSaveCacheFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnSaveCacheFinished() {
-	// update the outer checkpoint time
-	h.lastCheckTime = time.Now()
-}
-
-// OnCollectRegionStatsFinished implements the RegionHeartbeatProcessTracer interface.
-func (h *regionHeartbeatProcessTracer) OnCollectRegionStatsFinished() {
-	now := time.Now()
-	regionCollectDurationSum.Add(now.Sub(h.lastCheckTime).Seconds())
-	regionCollectCount.Inc()
-	h.lastCheckTime = now
+	h.resetCheckpoint()
 }
 
 // OnCheckOverlapsFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnCheckOverlapsFinished() {
-	now := time.Now()
-	h.saveCacheStats.checkOverlapsDuration = now.Sub(h.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	checkOverlapsDurationSum.Add(h.saveCacheStats.checkOverlapsDuration.Seconds())
-	checkOverlapsCount.Inc()
+	h.measure(checkOverlapsDurationSum, checkOverlapsCount)
 }
 
 // OnValidateRegionFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnValidateRegionFinished() {
-	now := time.Now()
-	h.saveCacheStats.validateRegionDuration = now.Sub(h.saveCacheStats.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	validateRegionDurationSum.Add(h.saveCacheStats.validateRegionDuration.Seconds())
-	validateRegionCount.Inc()
+	h.measure(validateRegionDurationSum, validateRegionCount)
 }
 
 // OnSetRegionFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnSetRegionFinished() {
-	now := time.Now()
-	h.saveCacheStats.setRegionDuration = now.Sub(h.saveCacheStats.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	setRegionDurationSum.Add(h.saveCacheStats.setRegionDuration.Seconds())
-	setRegionCount.Inc()
+	h.measure(setRegionDurationSum, setRegionCount)
 }
 
 // OnUpdateSubTreeFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnUpdateSubTreeFinished() {
-	now := time.Now()
-	h.saveCacheStats.updateSubTreeDuration = now.Sub(h.saveCacheStats.lastCheckTime)
-	h.saveCacheStats.lastCheckTime = now
-	updateSubTreeDurationSum.Add(h.saveCacheStats.updateSubTreeDuration.Seconds())
-	updateSubTreeCount.Inc()
+	h.measure(updateSubTreeDurationSum, updateSubTreeCount)
+}
+
+// OnCollectRegionStatsFinished implements the RegionHeartbeatProcessTracer interface.
+func (h *regionHeartbeatProcessTracer) OnCollectRegionStatsFinished() {
+	h.measure(regionCollectDurationSum, regionCollectCount)
 }
 
 // OnAllStageFinished implements the RegionHeartbeatProcessTracer interface.
 func (h *regionHeartbeatProcessTracer) OnAllStageFinished() {
-	now := time.Now()
-	h.OtherDuration = now.Sub(h.lastCheckTime)
-	otherDurationSum.Add(h.OtherDuration.Seconds())
-	otherCount.Inc()
-}
-
-// LogFields implements the RegionHeartbeatProcessTracer interface.
-func (h *regionHeartbeatProcessTracer) LogFields() []zap.Field {
-	return []zap.Field{
-		zap.Duration("pre-check-duration", h.preCheckDuration),
-		zap.Duration("async-hot-stats-duration", h.asyncHotStatsDuration),
-		zap.Duration("region-guide-duration", h.regionGuideDuration),
-		zap.Duration("check-overlaps-duration", h.saveCacheStats.checkOverlapsDuration),
-		zap.Duration("validate-region-duration", h.saveCacheStats.validateRegionDuration),
-		zap.Duration("set-region-duration", h.saveCacheStats.setRegionDuration),
-		zap.Duration("update-sub-tree-duration", h.saveCacheStats.updateSubTreeDuration),
-		zap.Duration("other-duration", h.OtherDuration),
-	}
+	h.measure(otherDurationSum, otherCount)
 }
 
 // Release implements the RegionHeartbeatProcessTracer interface.

--- a/pkg/core/metrics_test.go
+++ b/pkg/core/metrics_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingStage couples a tracer stage method with the counters it feeds, so a
+// single table can drive the tests over every measuring stage uniformly.
+type recordingStage struct {
+	name   string
+	finish func(*regionHeartbeatProcessTracer)
+	sum    prometheus.Counter
+	count  prometheus.Counter
+}
+
+func recordingStages() []recordingStage {
+	return []recordingStage{
+		{"PreCheck", (*regionHeartbeatProcessTracer).OnPreCheckFinished, preCheckDurationSum, preCheckCount},
+		{"AsyncHotStats", (*regionHeartbeatProcessTracer).OnAsyncHotStatsFinished, asyncHotStatsDurationSum, asyncHotStatsCount},
+		{"RegionGuide", (*regionHeartbeatProcessTracer).OnRegionGuideFinished, regionGuideDurationSum, regionGuideCount},
+		{"CheckOverlaps", (*regionHeartbeatProcessTracer).OnCheckOverlapsFinished, checkOverlapsDurationSum, checkOverlapsCount},
+		{"ValidateRegion", (*regionHeartbeatProcessTracer).OnValidateRegionFinished, validateRegionDurationSum, validateRegionCount},
+		{"SetRegion", (*regionHeartbeatProcessTracer).OnSetRegionFinished, setRegionDurationSum, setRegionCount},
+		{"UpdateSubTree", (*regionHeartbeatProcessTracer).OnUpdateSubTreeFinished, updateSubTreeDurationSum, updateSubTreeCount},
+		{"CollectRegionStats", (*regionHeartbeatProcessTracer).OnCollectRegionStatsFinished, regionCollectDurationSum, regionCollectCount},
+		{"Other", (*regionHeartbeatProcessTracer).OnAllStageFinished, otherDurationSum, otherCount},
+	}
+}
+
+// TestRegionHeartbeatTracerToleratesNonMonotonicClock checks the tracer is
+// robust to a backwards jump of the OS monotonic clock, which can happen on
+// virtualized hosts (an unsynchronized TSC across vCPUs, or a live migration).
+// For every stage, a checkpoint left in the future must not make the stage panic
+// or push a negative value into its duration counter (prometheus.Counter.Add
+// panics on a negative value).
+func TestRegionHeartbeatTracerToleratesNonMonotonicClock(t *testing.T) {
+	re := require.New(t)
+	for _, s := range recordingStages() {
+		h := &regionHeartbeatProcessTracer{}
+		h.lastCheckTime = time.Now().Add(time.Hour) // the clock appears to run backwards
+		before := testutil.ToFloat64(s.sum)
+		re.NotPanics(func() { s.finish(h) }, s.name)
+		re.GreaterOrEqual(testutil.ToFloat64(s.sum), before, s.name) // the counter never decreases
+	}
+}
+
+// TestRegionHeartbeatTracerRecordsEachStageIndependently checks that every stage
+// reports the time spent in that stage -- and only that stage -- into its own
+// counters, exactly once. Each stage is given a distinct, controlled interval by
+// rewinding the checkpoint, then matched against its own sum and count counters.
+func TestRegionHeartbeatTracerRecordsEachStageIndependently(t *testing.T) {
+	re := require.New(t)
+	h := &regionHeartbeatProcessTracer{}
+	for i, s := range recordingStages() {
+		interval := time.Duration(i+1) * 100 * time.Millisecond // distinct per stage
+		sumBefore := testutil.ToFloat64(s.sum)
+		countBefore := testutil.ToFloat64(s.count)
+		// No real time is spent: rewinding the checkpoint makes the stage measure
+		// exactly `interval`.
+		h.lastCheckTime = time.Now().Add(-interval)
+		s.finish(h)
+		re.InDelta(interval.Seconds(), testutil.ToFloat64(s.sum)-sumBefore, 0.05, s.name)
+		re.Equal(1.0, testutil.ToFloat64(s.count)-countBefore, s.name)
+	}
+}

--- a/pkg/core/metrics_test.go
+++ b/pkg/core/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 TiKV Project Authors.
+// Copyright 2026 TiKV Project Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/mcs/resourcemanager/server/manager.go
+++ b/pkg/mcs/resourcemanager/server/manager.go
@@ -422,7 +422,9 @@ func (m *Manager) backgroundMetricsFlush(ctx context.Context) {
 					sqlLayerRuMetrics.Add(consumption.SqlLayerCpuTimeMs * m.controllerConfig.RequestUnit.CPUMsCost)
 					sqlCPUMetrics.Add(consumption.SqlLayerCpuTimeMs)
 				}
-				kvCPUMetrics.Add(consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs)
+				if kvCPUTimeMs := consumption.TotalCpuTimeMs - consumption.SqlLayerCpuTimeMs; kvCPUTimeMs > 0 {
+					kvCPUMetrics.Add(kvCPUTimeMs)
+				}
 			}
 			// RPC count info.
 			if consumption.KvReadRpcCount > 0 {

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -588,6 +588,7 @@ func (c *Cluster) HandleRegionHeartbeat(region *core.RegionInfo) error {
 	if c.persistConfig.GetScheduleConfig().EnableHeartbeatBreakdownMetrics {
 		tracer = core.NewHeartbeatProcessTracer()
 	}
+	defer tracer.Release()
 	var taskRunner, miscRunner, logRunner ratelimit.Runner
 	taskRunner, miscRunner, logRunner = syncRunner, syncRunner, syncRunner
 	if c.persistConfig.GetScheduleConfig().EnableHeartbeatConcurrentRunner {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/schedule/types"
-	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/storage"
@@ -958,10 +957,6 @@ func TestRegionHeartbeat(t *testing.T) {
 		ctx.Tracer = tracer
 		re.NoError(cluster.processRegionHeartbeat(ctx, overlapRegion))
 		tracer.OnAllStageFinished()
-		re.Condition(func() bool {
-			fields := tracer.LogFields()
-			return slice.AllOf(fields, func(i int) bool { return fields[i].Integer > 0 })
-		}, "should have stats")
 		region = &metapb.Region{}
 		ok, err = storage.LoadRegion(regions[n-1].GetID(), region)
 		re.False(ok)


### PR DESCRIPTION
This is a cherry-pick of #10902 to `release-8.5-20251204-v8.5.4`.

### What problem does this PR solve?

Issue Number: Close #10901

### What is changed and how does it work?

```commit-message
Rework the region heartbeat breakdown tracer around a single measure() primitive and a single checkpoint. measure() reads the clock, advances the checkpoint, drops a non-positive delta so the duration counters never receive a negative value, and updates the stage's sum/count counters.

This also fixes the async-hot-stats stage recording the pre-check duration, removes a redundant SaveCache checkpoint, drops the unused LogFields method and its per-stage duration fields, and adds the missing defer tracer.Release() in the scheduling service's HandleRegionHeartbeat.
```

Release branch adjustment:

- The KV CPU metric guard is applied in `pkg/mcs/resourcemanager/server/manager.go`, where this release branch still records the metric.
- `go.mod` is synced for the new `pkg/core` test dependency.

Verification:

- `make failpoint-enable`
- `go test -tags=without_dashboard ./pkg/core -run 'TestRegionHeartbeatTracer' -count=1 -v`
- `go test -tags=without_dashboard ./server/cluster -run TestRegionHeartbeat -count=1 -v`
- `go test -tags=without_dashboard ./pkg/mcs/resourcemanager/server -run '^$' -count=1`
- `go test -tags=without_dashboard ./pkg/mcs/scheduling/server -run '^$' -count=1`
- `make failpoint-disable`

### Check List

Tests

- Unit test
- Manual test

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Fix a pd-server panic ("counter cannot decrease in value") raised by the region heartbeat breakdown metrics when the host's monotonic clock briefly moves backwards.
```
