### PR TITLE
checker: prefer missing TiFlash learner before offline peer

### DIFF
--- a/pkg/schedule/checker/metrics.go
+++ b/pkg/schedule/checker/metrics.go
@@ -210,6 +210,7 @@ var (
 	ruleCheckerPromoteWitnessCounter              = ruleCheckerCounterWithEvent("promote-witness")
 	ruleCheckerReplaceOfflineCounter              = ruleCheckerCounterWithEvent("replace-offline")
 	ruleCheckerAddRulePeerCounter                 = ruleCheckerCounterWithEvent("add-rule-peer")
+	ruleCheckerAddTiFlashLearnerCounter           = ruleCheckerCounterWithEvent("add-tiflash-learner")
 	ruleCheckerNoStoreAddCounter                  = ruleCheckerCounterWithEvent("no-store-add")
 	ruleCheckerNoStoreThenTryReplace              = ruleCheckerCounterWithEvent("no-store-then-try-replace")
 	ruleCheckerNoStoreReplaceCounter              = ruleCheckerCounterWithEvent("no-store-replace")

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -17,7 +17,6 @@ package checker
 import (
 	"context"
 	"math"
-	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -204,7 +203,8 @@ func isTiFlashLearnerRule(rule *placement.Rule) bool {
 		return false
 	}
 	for _, constraint := range rule.LabelConstraints {
-		if constraint.Key == core.EngineKey && constraint.Op == placement.In && slices.Contains(constraint.Values, core.EngineTiFlash) {
+		if constraint.Key == core.EngineKey && constraint.Op == placement.In &&
+			len(constraint.Values) == 1 && constraint.Values[0] == core.EngineTiFlash {
 			return true
 		}
 	}

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -17,6 +17,7 @@ package checker
 import (
 	"context"
 	"math"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -166,6 +167,12 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 			}
 		}
 		if c.isOfflinePeer(peer) {
+			op, err := c.fixMissingTiFlashLearnerPeer(region, fit)
+			if err != nil {
+				log.Debug("fail to fix missing TiFlash learner peer before replacing offline peer", errs.ZapError(err))
+			} else if op != nil {
+				return op, nil
+			}
 			ruleCheckerReplaceOfflineCounter.Inc()
 			return c.replaceUnexpectedRulePeer(region, rf, fit, peer, offlineStatus)
 		}
@@ -183,7 +190,32 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 	return c.fixBetterLocation(region, fit, rf)
 }
 
+func (c *RuleChecker) fixMissingTiFlashLearnerPeer(region *core.RegionInfo, fit *placement.RegionFit) (*operator.Operator, error) {
+	for _, rf := range fit.RuleFits {
+		if len(rf.Peers) < rf.Rule.Count && isTiFlashLearnerRule(rf.Rule) {
+			return c.addRulePeerWithOptions(region, fit, rf, false, false)
+		}
+	}
+	return nil, nil
+}
+
+func isTiFlashLearnerRule(rule *placement.Rule) bool {
+	if rule.Role != placement.Learner {
+		return false
+	}
+	for _, constraint := range rule.LabelConstraints {
+		if constraint.Key == core.EngineKey && constraint.Op == placement.In && slices.Contains(constraint.Values, core.EngineTiFlash) {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *RuleChecker) addRulePeer(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (*operator.Operator, error) {
+	return c.addRulePeerWithOptions(region, fit, rf, true, true)
+}
+
+func (c *RuleChecker) addRulePeerWithOptions(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit, updateFilterState, allowReplacement bool) (*operator.Operator, error) {
 	ruleCheckerAddRulePeerCounter.Inc()
 	ruleStores := getRuleFitStores(c.cluster, rf)
 	isWitness := rf.Rule.IsWitness && isWitnessEnabled(c.cluster)
@@ -191,7 +223,12 @@ func (c *RuleChecker) addRulePeer(region *core.RegionInfo, fit *placement.Region
 	store, filterByTempState := c.strategy(region, rf.Rule, isWitness).SelectStoreToAdd(ruleStores)
 	if store == 0 {
 		ruleCheckerNoStoreAddCounter.Inc()
-		c.handleFilterState(region, filterByTempState)
+		if updateFilterState {
+			c.handleFilterState(region, filterByTempState)
+		}
+		if !allowReplacement {
+			return nil, errs.ErrNoStoreToAdd
+		}
 		// try to replace an existing peer that matches the label constraints.
 		// issue: https://github.com/tikv/pd/issues/7185
 		for _, p := range region.GetPeers() {

--- a/pkg/schedule/checker/rule_checker.go
+++ b/pkg/schedule/checker/rule_checker.go
@@ -170,6 +170,7 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 			if err != nil {
 				log.Debug("fail to fix missing TiFlash learner peer before replacing offline peer", errs.ZapError(err))
 			} else if op != nil {
+				ruleCheckerAddTiFlashLearnerCounter.Inc()
 				return op, nil
 			}
 			ruleCheckerReplaceOfflineCounter.Inc()
@@ -192,7 +193,7 @@ func (c *RuleChecker) fixRulePeer(region *core.RegionInfo, fit *placement.Region
 func (c *RuleChecker) fixMissingTiFlashLearnerPeer(region *core.RegionInfo, fit *placement.RegionFit) (*operator.Operator, error) {
 	for _, rf := range fit.RuleFits {
 		if len(rf.Peers) < rf.Rule.Count && isTiFlashLearnerRule(rf.Rule) {
-			return c.addRulePeerWithOptions(region, fit, rf, false, false)
+			return c.addTiFlashLearnerPeer(region, fit, rf)
 		}
 	}
 	return nil, nil
@@ -213,6 +214,10 @@ func isTiFlashLearnerRule(rule *placement.Rule) bool {
 
 func (c *RuleChecker) addRulePeer(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (*operator.Operator, error) {
 	return c.addRulePeerWithOptions(region, fit, rf, true, true)
+}
+
+func (c *RuleChecker) addTiFlashLearnerPeer(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit) (*operator.Operator, error) {
+	return c.addRulePeerWithOptions(region, fit, rf, false, false)
 }
 
 func (c *RuleChecker) addRulePeerWithOptions(region *core.RegionInfo, fit *placement.RegionFit, rf *placement.RuleFit, updateFilterState, allowReplacement bool) (*operator.Operator, error) {

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -1867,6 +1867,89 @@ func (suite *ruleCheckerTestSuite) TestDoNotPreferWideEngineLearnerRuleOverOffli
 	re.False(exist)
 }
 
+func (suite *ruleCheckerTestSuite) TestDoNotPreferTiFlashComputeLearnerRuleOverOfflinePeer() {
+	re := suite.Require()
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4", core.EngineKey: core.EngineTiFlashCompute})
+	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+	suite.cluster.AddLeaderRegion(1, 1, 2, 3)
+	err := suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: placement.DefaultGroupID,
+		ID:      placement.DefaultRuleID,
+		Role:    placement.Voter,
+		Count:   3,
+	})
+	re.NoError(err)
+	err = suite.ruleManager.DeleteRule(placement.DefaultGroupID, "witness")
+	re.NoError(err)
+	err = suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: "tiflash-compute",
+		ID:      "learner",
+		Role:    placement.Learner,
+		Count:   1,
+		LabelConstraints: []placement.LabelConstraint{
+			{
+				Key:    core.EngineKey,
+				Op:     placement.In,
+				Values: []string{core.EngineTiFlashCompute},
+			},
+		},
+	})
+	re.NoError(err)
+
+	suite.cluster.SetStoreOffline(2)
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	re.NotNil(op)
+	re.Equal("replace-rule-offline-peer", op.Desc())
+	_, exist := suite.rc.pendingList.Get(1)
+	re.False(exist)
+}
+
+func (suite *ruleCheckerTestSuite) TestDoNotPreferTiFlashLearnerOverDownPeer() {
+	re := suite.Require()
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4", core.EngineKey: core.EngineTiFlash})
+	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+	suite.cluster.AddLeaderRegion(1, 1, 2, 3)
+	err := suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: placement.DefaultGroupID,
+		ID:      placement.DefaultRuleID,
+		Role:    placement.Voter,
+		Count:   3,
+	})
+	re.NoError(err)
+	err = suite.ruleManager.DeleteRule(placement.DefaultGroupID, "witness")
+	re.NoError(err)
+	err = suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: "tiflash",
+		ID:      "learner",
+		Role:    placement.Learner,
+		Count:   1,
+		LabelConstraints: []placement.LabelConstraint{
+			{
+				Key:    core.EngineKey,
+				Op:     placement.In,
+				Values: []string{core.EngineTiFlash},
+			},
+		},
+	})
+	re.NoError(err)
+
+	suite.cluster.SetStoreDown(2)
+	region := suite.cluster.GetRegion(1)
+	region = region.Clone(core.WithDownPeers([]*pdpb.PeerStats{
+		{Peer: region.GetStorePeer(2), DownSeconds: 60000},
+	}))
+	suite.cluster.PutRegion(region)
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	re.NotNil(op)
+	re.Equal("fast-replace-rule-down-peer", op.Desc())
+}
+
 func (suite *ruleCheckerTestSuite) TestFixOfflinePeerWithAvailableWitness() {
 	re := suite.Require()
 	suite.cluster.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -1827,6 +1827,46 @@ func (suite *ruleCheckerTestSuite) TestDoNotPreferTiFlashSwapFitOverOfflinePeer(
 	re.False(exist)
 }
 
+func (suite *ruleCheckerTestSuite) TestDoNotPreferWideEngineLearnerRuleOverOfflinePeer() {
+	re := suite.Require()
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4", core.EngineKey: core.EngineTiFlash})
+	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+	suite.cluster.AddLeaderRegion(1, 1, 2, 3)
+	err := suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: placement.DefaultGroupID,
+		ID:      placement.DefaultRuleID,
+		Role:    placement.Voter,
+		Count:   3,
+	})
+	re.NoError(err)
+	err = suite.ruleManager.DeleteRule(placement.DefaultGroupID, "witness")
+	re.NoError(err)
+	err = suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: "wide-engine",
+		ID:      "learner",
+		Role:    placement.Learner,
+		Count:   1,
+		LabelConstraints: []placement.LabelConstraint{
+			{
+				Key:    core.EngineKey,
+				Op:     placement.In,
+				Values: []string{core.EngineTiFlash, core.EngineTiKV},
+			},
+		},
+	})
+	re.NoError(err)
+
+	suite.cluster.SetStoreOffline(2)
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	re.NotNil(op)
+	re.Equal("replace-rule-offline-peer", op.Desc())
+	_, exist := suite.rc.pendingList.Get(1)
+	re.False(exist)
+}
+
 func (suite *ruleCheckerTestSuite) TestFixOfflinePeerWithAvailableWitness() {
 	re := suite.Require()
 	suite.cluster.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})

--- a/pkg/schedule/checker/rule_checker_test.go
+++ b/pkg/schedule/checker/rule_checker_test.go
@@ -1729,6 +1729,104 @@ func (suite *ruleCheckerTestSuite) TestFixOfflinePeer() {
 	re.Nil(suite.rc.Check(region))
 }
 
+func (suite *ruleCheckerTestSuite) TestPreferAddTiFlashLearnerOverOfflinePeer() {
+	re := suite.Require()
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4", "engine": "tiflash"})
+	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+	suite.cluster.AddLeaderRegion(1, 1, 2, 3)
+	err := suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: placement.DefaultGroupID,
+		ID:      placement.DefaultRuleID,
+		Role:    placement.Voter,
+		Count:   3,
+	})
+	re.NoError(err)
+	err = suite.ruleManager.DeleteRule(placement.DefaultGroupID, "witness")
+	re.NoError(err)
+	err = suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: "tiflash",
+		ID:      "learner",
+		Role:    placement.Learner,
+		Count:   1,
+		LabelConstraints: []placement.LabelConstraint{
+			{
+				Key:    "engine",
+				Op:     placement.In,
+				Values: []string{"tiflash"},
+			},
+		},
+	})
+	re.NoError(err)
+
+	suite.cluster.SetStoreOffline(2)
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	re.NotNil(op)
+	re.Equal("add-rule-peer", op.Desc())
+	addLearner := op.Step(0).(operator.AddLearner)
+	re.Equal(uint64(4), addLearner.ToStore)
+
+	region := suite.cluster.GetRegion(1).Clone(core.WithAddPeer(&metapb.Peer{
+		Id:      addLearner.PeerID,
+		StoreId: addLearner.ToStore,
+		Role:    metapb.PeerRole_Learner,
+	}))
+	suite.cluster.PutRegion(region)
+	op = suite.rc.Check(suite.cluster.GetRegion(1))
+	re.NotNil(op)
+	re.Equal("replace-rule-offline-peer", op.Desc())
+}
+
+func (suite *ruleCheckerTestSuite) TestDoNotPreferTiFlashSwapFitOverOfflinePeer() {
+	re := suite.Require()
+	suite.cluster.AddLabelsStore(1, 1, map[string]string{"host": "host1"})
+	suite.cluster.AddLabelsStore(2, 1, map[string]string{"host": "host2"})
+	suite.cluster.AddLabelsStore(3, 1, map[string]string{"host": "host3"})
+	suite.cluster.AddLabelsStore(4, 1, map[string]string{"host": "host4", "engine": "tiflash"})
+	suite.cluster.AddLabelsStore(5, 1, map[string]string{"host": "host5"})
+	suite.cluster.AddRegionWithLearner(1, 1, []uint64{2, 3}, []uint64{4})
+	err := suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: placement.DefaultGroupID,
+		ID:      placement.DefaultRuleID,
+		Role:    placement.Voter,
+		Count:   3,
+	})
+	re.NoError(err)
+	err = suite.ruleManager.DeleteRule(placement.DefaultGroupID, "witness")
+	re.NoError(err)
+	err = suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: placement.DefaultGroupID,
+		ID:      "generic-learner",
+		Index:   1,
+		Role:    placement.Learner,
+		Count:   1,
+	})
+	re.NoError(err)
+	err = suite.ruleManager.SetRule(&placement.Rule{
+		GroupID: "tiflash",
+		ID:      "learner",
+		Role:    placement.Learner,
+		Count:   1,
+		LabelConstraints: []placement.LabelConstraint{
+			{
+				Key:    "engine",
+				Op:     placement.In,
+				Values: []string{"tiflash"},
+			},
+		},
+	})
+	re.NoError(err)
+
+	suite.cluster.SetStoreOffline(2)
+	op := suite.rc.Check(suite.cluster.GetRegion(1))
+	re.NotNil(op)
+	re.Equal("replace-rule-offline-peer", op.Desc())
+	_, exist := suite.rc.pendingList.Get(1)
+	re.False(exist)
+}
+
 func (suite *ruleCheckerTestSuite) TestFixOfflinePeerWithAvailableWitness() {
 	re := suite.Require()
 	suite.cluster.AddLabelsStore(1, 1, map[string]string{"zone": "z1"})


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10924

When a region both has an offline TiKV peer and misses a TiFlash learner, rule checker may replace the offline TiKV peer first because the default TiKV placement rule is checked before the TiFlash learner rule. Since a region can only have one operator at a time, this can delay TiFlash learner creation during large offline-store operations.

### What is changed and how does it work?

Prefer directly adding a missing TiFlash learner before replacing an offline peer in rule checker.

The priority change is intentionally narrow:
- it only applies to offline peers, not down peers;
- it only applies to learner rules constrained to engine=tiflash;
- it only takes effect when a direct TiFlash learner add operator can be created;
- it does not use the existing swap-fit fallback before offline peer replacement.

After the TiFlash learner is added, the next rule-check round can still replace the offline TiKV peer.

### Check List

Tests

- Unit test

Commands:

```
go test ./pkg/schedule/checker -run 'TestRuleCheckerTestSuite/Test(PreferAddTiFlashLearnerOverOfflinePeer|DoNotPreferTiFlashSwapFitOverOfflinePeer|DoNotPreferWideEngineLearnerRuleOverOfflinePeer|FixOfflinePeer)$' -count=1
go test ./pkg/schedule/checker -count=1
```

### Release note

```release-note
Improve PD rule checker to prioritize adding missing TiFlash learner peers before replacing offline TiKV peers, reducing TiFlash learner creation delays during large offline-store operations.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved scheduling decisions to prioritize adding missing TiFlash learner replicas before replacing offline peers.
  * Added tracking for a new TiFlash learner-related scheduling event.

* **Bug Fixes**
  * Refined peer-repair behavior so offline or down peers are handled more consistently with TiFlash learner placement constraints.
  * Reduced unnecessary swap/replacement actions when TiFlash learner constraints are involved.

* **Tests**
  * Expanded coverage with new cases for TiFlash learner prioritization and down/offline peer handling, including ensuring regions aren’t added to pending lists when not needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
