### PR TITLE
test: stabilize flaky TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestBasicResourceGroupCURD

### DIFF
--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -1419,8 +1420,14 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 		}
 
 		// Get Resource Group
-		gresp, err := cli.GetResourceGroup(suite.ctx, tcase.name)
-		re.NoError(err)
+		var gresp *rmpb.ResourceGroup
+		testutil.Eventually(re, func() bool {
+			gresp, err = cli.GetResourceGroup(suite.ctx, tcase.name)
+			if err != nil || gresp.GetName() != tcase.name {
+				return false
+			}
+			return !tcase.modifySuccess || reflect.DeepEqual(group, gresp)
+		}, testutil.WithTickInterval(50*time.Millisecond))
 		re.Equal(tcase.name, gresp.Name)
 		if tcase.modifySuccess {
 			re.Equal(group, gresp)
@@ -1442,8 +1449,12 @@ func (suite *resourceManagerClientTestSuite) TestBasicResourceGroupCURD() {
 				}
 				re.NoError(err)
 				re.Contains(dresp, "Success!")
-				_, err = cli.GetResourceGroup(suite.ctx, g.Name)
-				re.EqualError(err, fmt.Sprintf("get resource group %v failed, rpc error: code = Unknown desc = [PD:resourcemanager:ErrGroupNotExists]the %v resource group does not exist", g.Name, g.Name))
+				expectedErr := fmt.Sprintf("get resource group %v failed, rpc error: code = Unknown desc = [PD:resourcemanager:ErrGroupNotExists]the %v resource group does not exist", g.Name, g.Name)
+				testutil.Eventually(re, func() bool {
+					_, err = cli.GetResourceGroup(suite.ctx, g.Name)
+					return err != nil && err.Error() == expectedErr
+				}, testutil.WithTickInterval(50*time.Millisecond))
+				re.EqualError(err, expectedErr)
 			}
 
 			// to test the deletion of persistence


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10934

Problem Summary:
Flaky test `TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestBasicResourceGroupCURD` in `github.com/tikv/pd/tests/integrations/mcs/resourcemanager` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

The test assumed synchronous standalone RM cache visibility after PD-handled resource group metadata writes/deletes.

#### Fix

Waiting for the cache to reflect accepted modify/delete operations matches the actual contract while preserving exact final assertions.

#### Verification

Spec:
- target: `github.com/tikv/pd/tests/integrations/mcs/resourcemanager :: TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestBasicResourceGroupCURD`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target-flaky-corrected passed.
build passed.

Gate checklist:
- target-flaky-corrected: PASS
- prompt-target-path: SKIPPED
- build: PASS

Commands:
- `cd tests/integrations && go test -json -tags without_dashboard ./mcs/resourcemanager -run 'TestResourceManagerClientTestSuite/standalone-resource-manager-with-client-discovery/TestBasicResourceGroupCURD' -count=1`
- `make build`

### Release note

```release-note
None
```

Fixes #10934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of resource group integration tests by adding deeper object comparisons when updates are expected.
  * Updated “Get Resource Group” verification to use retry logic for eventual consistency, validating either full equality or name-only matches based on the scenario.
  * Enhanced deletion cleanup assertions by retrying until the expected error message is returned exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->