### PR TITLE
test: stabilize flaky TestLoadLargeRules

### DIFF
--- a/pkg/mcs/scheduling/server/rule/watcher_test.go
+++ b/pkg/mcs/scheduling/server/rule/watcher_test.go
@@ -87,6 +87,7 @@ func prepare(t require.TestingT) (context.Context, *clientv3.Client, func()) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cfg := etcdutil.NewTestEtcdConfig()
+	cfg.UnsafeNoFsync = true
 	var err error
 	cfg.Dir, err = os.MkdirTemp("", "pd_tests")
 	re.NoError(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10346

Problem Summary:
Flaky test `TestLoadLargeRules` in `github.com/tikv/pd/pkg/mcs/scheduling/server/rule` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

Durable embedded-etcd setup writes could consume the test budget before the watcher load assertion was reached.

#### Fix

Setting `UnsafeNoFsync` removes irrelevant unit-test disk durability cost while preserving etcd-backed bulk setup and watcher loading.

#### Verification

Spec:
- target: `github.com/tikv/pd/pkg/mcs/scheduling/server/rule :: TestLoadLargeRules`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- required case executed: yes
- submission decision: ALLOWED
- note: Required flaky case executed during validation.
Required flaky case was not skipped.
target_flaky_corrected passed.

Gate checklist:
- diagnostic_timing_repro: SKIPPED
- target_flaky_corrected: PASS
- supplied_path_mismatch: SKIPPED
- package_surface: SKIPPED
- build: SKIPPED
- external_ci: SKIPPED

Commands:
- `go test -json ./pkg/mcs/scheduling/server/rule -run '^TestLoadLargeRules$' -count=1`

### Release note

```release-note
None
```

Fixes #10346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the in-process test storage configuration for watcher-related checks to run faster by changing the durability setting.
  * No user-facing behavior or product functionality was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->