### PR TITLE
tools: increase pd-ut race timeout

### DIFF
--- a/tools/pd-ut/ut.go
+++ b/tools/pd-ut/ut.go
@@ -711,7 +711,7 @@ func (*numa) testCommand(pkg string, fn string) *exec.Cmd {
 		args = append(args, []string{"-test.timeout", "2m"}...)
 	} else {
 		// it takes a longer when race is enabled. so it is set more timeout value.
-		args = append(args, []string{"-test.timeout", "5m"}...)
+		args = append(args, []string{"-test.timeout", "10m"}...)
 	}
 
 	// core.test -test.run TestClusteredPrefixColum


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #9806

### What is changed and how does it work?

```commit-message
Increase the pd-ut test timeout from 5 minutes to 10 minutes when running tests with the race detector enabled.
```

### Check List

Tests

- Manual test (add detailed scripts or steps below)

```bash
make pd-ut
```

### Release note

```release-note
None.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the test timeout when race detection is enabled, helping reduce premature test failures on slower runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->