### PR TITLE
schedule: skip slow/evicted stores in hot region scheduling

### DIFF
--- a/pkg/schedule/filter/counter.go
+++ b/pkg/schedule/filter/counter.go
@@ -52,6 +52,7 @@ const (
 	engine
 	specialUse
 	isolation
+	leaderEvicted
 
 	storeStateOK
 	storeStateTombstone
@@ -82,6 +83,7 @@ var filters = [filtersLen]string{
 	"engine-filter",
 	"special-use-filter",
 	"isolation-filter",
+	"leader-evicted-filter",
 
 	"store-state-ok-filter",
 	"store-state-tombstone-filter",

--- a/pkg/schedule/filter/filters.go
+++ b/pkg/schedule/filter/filters.go
@@ -569,6 +569,37 @@ func (f *StoreStateFilter) Target(conf config.SharedConfigProvider, store *core.
 	return statusOK
 }
 
+type hotRegionEvictedTargetFilter struct{ scope string }
+
+// NewHotRegionEvictedTargetFilter creates a filter that rejects stores already
+// marked as unsuitable hot-region targets.
+func NewHotRegionEvictedTargetFilter(scope string) Filter {
+	return &hotRegionEvictedTargetFilter{scope: scope}
+}
+
+// Scope returns the scheduler or the checker which the filter acts on.
+func (f *hotRegionEvictedTargetFilter) Scope() string {
+	return f.scope
+}
+
+// Type returns the type of the filter.
+func (*hotRegionEvictedTargetFilter) Type() filterType {
+	return leaderEvicted
+}
+
+// Source filters stores when select them as schedule source.
+func (*hotRegionEvictedTargetFilter) Source(config.SharedConfigProvider, *core.StoreInfo) *plan.Status {
+	return statusOK
+}
+
+// Target filters stores when select them as schedule target.
+func (*hotRegionEvictedTargetFilter) Target(_ config.SharedConfigProvider, store *core.StoreInfo) *plan.Status {
+	if store.EvictedAsSlowStore() || store.EvictedAsStoppingStore() || store.IsEvictedAsSlowTrend() {
+		return statusStoreRejectLeader
+	}
+	return statusOK
+}
+
 // labelConstraintFilter is a filter that selects stores satisfy the constraints.
 type labelConstraintFilter struct {
 	scope       string

--- a/pkg/schedule/filter/filters_test.go
+++ b/pkg/schedule/filter/filters_test.go
@@ -301,6 +301,28 @@ func TestStoreStateFilter(t *testing.T) {
 	check(store, testCases)
 }
 
+func TestHotRegionEvictedTargetFilter(t *testing.T) {
+	re := require.New(t)
+	filter := NewHotRegionEvictedTargetFilter("")
+	opt := mockconfig.NewTestOptions()
+
+	testCases := []struct {
+		name      string
+		store     *core.StoreInfo
+		targetRes plan.StatusCode
+	}{
+		{name: "normal", store: core.NewStoreInfoWithLabel(1, map[string]string{}), targetRes: plan.StatusOK},
+		{name: "slow-store", store: core.NewStoreInfoWithLabel(1, map[string]string{}).Clone(core.SlowStoreEvicted()), targetRes: plan.StatusStoreRejectLeader},
+		{name: "stopping-store", store: core.NewStoreInfoWithLabel(1, map[string]string{}).Clone(core.StoppingStoreEvicted()), targetRes: plan.StatusStoreRejectLeader},
+		{name: "slow-trend", store: core.NewStoreInfoWithLabel(1, map[string]string{}).Clone(core.SlowTrendEvicted()), targetRes: plan.StatusStoreRejectLeader},
+	}
+
+	for _, testCase := range testCases {
+		re.Equal(plan.StatusOK, filter.Source(opt, testCase.store).StatusCode, testCase.name)
+		re.Equal(testCase.targetRes, filter.Target(opt, testCase.store).StatusCode, testCase.name)
+	}
+}
+
 func TestStoreStateFilterReason(t *testing.T) {
 	re := require.New(t)
 	filters := []Filter{

--- a/pkg/schedule/schedulers/grant_hot_region.go
+++ b/pkg/schedule/schedulers/grant_hot_region.go
@@ -300,6 +300,7 @@ func (s *grantHotRegionScheduler) transfer(cluster sche.SchedulerCluster, region
 		candidate = []uint64{s.conf.getStoreLeaderID()}
 	} else {
 		filters = append(filters, &filter.StoreStateFilter{ActionScope: s.GetName(), MoveRegion: true, OperatorLevel: constant.High},
+			filter.NewHotRegionEvictedTargetFilter(s.GetName()),
 			filter.NewExcludedFilter(s.GetName(), srcRegion.GetStoreIDs(), srcRegion.GetStoreIDs()))
 		candidate = storeIDs
 	}

--- a/pkg/schedule/schedulers/hot_region_solver.go
+++ b/pkg/schedule/schedulers/hot_region_solver.go
@@ -563,6 +563,7 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 		}
 		filters = []filter.Filter{
 			&filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true, OperatorLevel: constant.High},
+			filter.NewHotRegionEvictedTargetFilter(bs.sche.GetName()),
 			filter.NewExcludedFilter(bs.sche.GetName(), bs.cur.region.GetStoreIDs(), bs.cur.region.GetStoreIDs()),
 			filter.NewSpecialUseFilter(bs.sche.GetName(), filter.SpecialUseHotRegion),
 			filter.NewPlacementSafeguard(bs.sche.GetName(), bs.GetSchedulerConfig(), bs.GetBasicCluster(), bs.GetRuleManager(), bs.cur.region, srcStore, nil),
@@ -581,7 +582,10 @@ func (bs *balanceSolver) filterDstStores() map[uint64]*statistics.StoreLoadDetai
 		}
 		if bs.rwTy == utils.Read {
 			peers := bs.cur.region.GetPeers()
-			moveLeaderFilters := []filter.Filter{&filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true, OperatorLevel: constant.High}}
+			moveLeaderFilters := []filter.Filter{
+				&filter.StoreStateFilter{ActionScope: bs.sche.GetName(), MoveRegion: true, OperatorLevel: constant.High},
+				filter.NewHotRegionEvictedTargetFilter(bs.sche.GetName()),
+			}
 			if leaderFilter := filter.NewPlacementLeaderSafeguard(bs.sche.GetName(), bs.GetSchedulerConfig(), bs.GetBasicCluster(), bs.GetRuleManager(), bs.cur.region, srcStore, true /*allowMoveLeader*/); leaderFilter != nil {
 				filters = append(filters, leaderFilter)
 			}

--- a/pkg/schedule/schedulers/hot_region_test.go
+++ b/pkg/schedule/schedulers/hot_region_test.go
@@ -1330,6 +1330,97 @@ func TestHotReadRegionScheduleByteRateOnly(t *testing.T) {
 	clearPendingInfluence(hb)
 }
 
+func TestHotReadRegionScheduleSkipsLeaderEvictedMoveLeaderTarget(t *testing.T) {
+	testCases := []struct {
+		name string
+		opt  core.StoreCreateOption
+	}{
+		{name: "slow-store", opt: core.SlowStoreEvicted()},
+		{name: "stopping-store", opt: core.StoppingStoreEvicted()},
+		{name: "slow-trend", opt: core.SlowTrendEvicted()},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			cancel, _, tc, oc := prepareSchedulersTest()
+			defer cancel()
+			tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
+			scheduler, err := CreateScheduler(readType, oc, storage.NewStorageWithMemoryBackend(), nil)
+			re.NoError(err)
+			hb := scheduler.(*hotScheduler)
+			hb.conf.ReadPriorities = []string{utils.BytePriority, utils.KeyPriority}
+			hb.conf.setHistorySampleDuration(0)
+
+			tc.AddRegionStore(1, 3)
+			tc.AddRegionStore(2, 2)
+			tc.AddRegionStore(3, 2)
+			tc.AddRegionStore(4, 2)
+			tc.AddRegionStore(5, 0)
+
+			tc.UpdateStorageReadBytes(1, 7.5*units.MiB*utils.StoreHeartBeatReportInterval)
+			tc.UpdateStorageReadBytes(2, 4.9*units.MiB*utils.StoreHeartBeatReportInterval)
+			tc.UpdateStorageReadBytes(3, 3.7*units.MiB*utils.StoreHeartBeatReportInterval)
+			tc.UpdateStorageReadBytes(4, 6*units.MiB*utils.StoreHeartBeatReportInterval)
+			tc.UpdateStorageReadBytes(5, 0)
+			tc.PutStore(tc.GetStore(5).Clone(testCase.opt))
+
+			addRegionInfo(tc, utils.Read, []testRegionInfo{
+				{1, []uint64{1, 2, 3}, 512 * units.KiB, 0, 0},
+				{2, []uint64{2, 1, 3}, 511 * units.KiB, 0, 0},
+				{3, []uint64{1, 2, 3}, 510 * units.KiB, 0, 0},
+				{11, []uint64{1, 2, 3}, 7 * units.KiB, 0, 0},
+			})
+
+			testutil.Eventually(re, func() bool {
+				return tc.IsRegionHot(tc.GetRegion(1)) && !tc.IsRegionHot(tc.GetRegion(11))
+			})
+
+			ops, _ := hb.Schedule(tc, false)
+			re.Len(ops, 1)
+			operatorutil.CheckTransferLeader(re, ops[0], operator.OpHotRegion, 1, 3)
+		})
+	}
+}
+
+func TestHotReadPeerScheduleSkipsLeaderEvictedTarget(t *testing.T) {
+	testCases := []struct {
+		name string
+		opt  core.StoreCreateOption
+	}{
+		{name: "slow-store", opt: core.SlowStoreEvicted()},
+		{name: "stopping-store", opt: core.StoppingStoreEvicted()},
+		{name: "slow-trend", opt: core.SlowTrendEvicted()},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			cancel, _, tc, oc := prepareSchedulersTest()
+			defer cancel()
+			tc.SetClusterVersion(versioninfo.MinSupportedVersion(versioninfo.Version4_0))
+			for id := uint64(1); id <= 6; id++ {
+				tc.PutStoreWithLabels(id)
+			}
+
+			sche, err := CreateScheduler(readType, oc, storage.NewStorageWithMemoryBackend(), ConfigJSONDecoder([]byte("null")))
+			re.NoError(err)
+			hb := sche.(*hotScheduler)
+			hb.conf.ReadPriorities = []string{utils.BytePriority, utils.KeyPriority}
+			tc.PutStore(tc.GetStore(4).Clone(testCase.opt))
+
+			tc.UpdateStorageReadStats(1, 20*units.MiB, 20*units.MiB)
+			tc.UpdateStorageReadStats(2, 19*units.MiB, 19*units.MiB)
+			tc.UpdateStorageReadStats(3, 19*units.MiB, 19*units.MiB)
+			tc.UpdateStorageReadStats(4, 0*units.MiB, 0*units.MiB)
+			tc.AddRegionWithPeerReadInfo(1, 3, 1, uint64(0.9*units.KiB*float64(10)), uint64(0.9*units.KiB*float64(10)), 10, []uint64{1, 2}, 3)
+
+			ops, _ := hb.Schedule(tc, false)
+			re.Empty(ops)
+		})
+	}
+}
+
 func TestHotReadRegionScheduleWithQuery(t *testing.T) {
 	re := require.New(t)
 

--- a/pkg/schedule/schedulers/shuffle_hot_region.go
+++ b/pkg/schedule/schedulers/shuffle_hot_region.go
@@ -155,6 +155,7 @@ func (s *shuffleHotRegionScheduler) randomSchedule(cluster sche.SchedulerCluster
 
 		filters := []filter.Filter{
 			&filter.StoreStateFilter{ActionScope: s.GetName(), MoveRegion: true, OperatorLevel: constant.Low},
+			filter.NewHotRegionEvictedTargetFilter(s.GetName()),
 			filter.NewExcludedFilter(s.GetName(), srcRegion.GetStoreIDs(), srcRegion.GetStoreIDs()),
 			filter.NewPlacementSafeguard(s.GetName(), cluster.GetSchedulerConfig(), cluster.GetBasicCluster(), cluster.GetRuleManager(), srcRegion, srcStore, nil),
 		}


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10936

Hot-region scheduling can still choose a destination store that has already
been marked as unsuitable for hot traffic, such as slow stores, stopping
stores, or stores evicted by slow-trend detection.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
add a hot-region-specific target filter that rejects stores evicted as
slow-store, stopping-store, or slow-trend

apply the filter to hot-region destination selection in the balance-hot-region
solver, grant-hot-region scheduler, and shuffle-hot-region scheduler

add unit tests for the new filter and scheduler regressions covering hot-read
move-leader fallback and hot-read peer scheduling
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
Hot-region schedulers now skip stores evicted by slow-store, stopping-store,
or slow-trend checks when selecting scheduling targets.
```

### Deep Review

#### Problem Summary
- Issue `#10936` is about hot-region scheduling still selecting destination stores that PD has already marked as unsuitable for receiving hot-region traffic.
- The practical requirement is narrower than generic region movement: hot-region schedulers should not move hot peers or hot leaders onto stores evicted due to slow-store, stopping-store, or slow-trend signals.
- The earlier broader fix path was risky because putting this policy into shared `StoreStateFilter` `regionTarget` logic would also change unrelated `MoveRegion` users such as replica repair and generic balance-region flows.

#### Solution Walkthrough
- `pkg/schedule/filter/filters.go:572-600` adds `NewHotRegionEvictedTargetFilter`, a target-only filter that rejects stores when any of these store-state flags are set:
  - `store.EvictedAsSlowStore()`
  - `store.EvictedAsStoppingStore()`
  - `store.IsEvictedAsSlowTrend()`
- `pkg/schedule/schedulers/hot_region_solver.go:564-569` wires the new filter into the hot-region `movePeer` destination path, which covers hot peer relocation.
- `pkg/schedule/schedulers/hot_region_solver.go:585-588` also adds the filter to the hot-read move-leader fallback candidate set, which is the non-obvious path that can still materialize as a `MoveLeader`-style choice inside hot scheduling.
- `pkg/schedule/schedulers/grant_hot_region.go:301-304` applies the same filter to `grant-hot-region` destination selection.
- `pkg/schedule/schedulers/shuffle_hot_region.go:156-160` applies it to `shuffle-hot-region` destination selection.
- `pkg/schedule/filter/filters_test.go:304-323` adds direct coverage for the new filter and verifies all three eviction states.
- `pkg/schedule/schedulers/hot_region_test.go:1333-1422` adds scheduler regressions for:
  - hot-read move-leader fallback skipping evicted targets
  - hot-read peer scheduling skipping evicted targets
- Importantly, the patch does not modify shared `StoreStateFilter` `regionTarget` behavior, so non-hot `MoveRegion` callers keep their previous semantics.

#### Findings (ordered by severity)
- No concrete correctness, compatibility, or robustness bugs found in the current scoped implementation.

#### Costs and Negative Impacts
- Correctness:
  - The current patch fixes the hot-region scheduling gap without changing global `MoveRegion` behavior.
  - Coverage is broader than the original practical suggestion because it consistently honors `slow-store`, `stopping-store`, and `slow-trend` eviction states, not only `slowStoreEvicted`.
- Security:
  - None found.
- Compatibility:
  - The behavioral change is intentionally limited to hot-region schedulers and should not affect replica checker, balance-region, or other non-hot placement flows.
- Robustness:
  - The main hot-region target-selection paths are covered in code and tests.
  - Residual risk is mostly future regression from missed filter wiring in less-direct hot schedulers, not a currently observed logic hole.
- Cognitive Load:
  - Slight increase from introducing one hot-region-specific filter.
  - There is also a small naming mismatch in the internal filter counter: the new filter reports `leaderEvicted` / `"leader-evicted-filter"` in `pkg/schedule/filter/counter.go:55-86`, while the exported constructor name is now `NewHotRegionEvictedTargetFilter`. This is a maintainability and observability clarity cost, not a correctness bug.
- CPU:
  - Negligible. The filter adds a few boolean checks per hot-region target candidate.
- Memory:
  - Negligible.
- Log Volume:
  - No meaningful change.

#### Engineering Rules Check
- None.

#### Questions and Assumptions
- Assumed the intended scope is exactly the hot-region scheduler family, based on the issue context and the user’s requested practical fix direction.
- Assumed the current worktree diff is the authoritative patch under review.

#### Suggested Tests / Validation
- The added unit coverage in `pkg/schedule/filter/filters_test.go:304-323` and `pkg/schedule/schedulers/hot_region_test.go:1333-1422` is directionally correct and exercises the two highest-risk solver paths.
- Residual test gap: add a scheduler-level negative test for `grant-hot-region` rejecting an evicted destination store.
- Residual test gap: add a scheduler-level negative test for `shuffle-hot-region` rejecting an evicted destination store.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for avoiding destination stores that have been marked for hot-region eviction during hot leader and region scheduling.
  * Expanded scheduling logic so these stores are skipped when selecting target stores.

* **Bug Fixes**
  * Improved hot read scheduling to prevent transfers to stores that should no longer receive leadership or peer moves.
  * Added coverage to verify scheduling behaves correctly across multiple eviction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->