### PR TITLE
server/api: clone schedule config once per /stores request

### DIFF
--- a/server/api/store.go
+++ b/server/api/store.go
@@ -619,6 +619,11 @@ func (h *storesHandler) GetAllStores(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stores = urlFilter.Filter(stores)
+	// GetScheduleConfig deep-clones the schedule config (the StoreLimit map and
+	// Schedulers slice, see #3603), so hoist it out of the per-store loop:
+	// BuildStoreInfo only reads scalar fields and never mutates the config, and a
+	// single snapshot keeps all stores consistent within one response.
+	cfg := h.GetScheduleConfig()
 	for _, s := range stores {
 		storeID := s.GetId()
 		store := rc.GetStore(storeID)
@@ -627,7 +632,7 @@ func (h *storesHandler) GetAllStores(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		storeInfo := response.BuildStoreInfo(h.GetScheduleConfig(), store)
+		storeInfo := response.BuildStoreInfo(cfg, store)
 		StoresInfo.Stores = append(StoresInfo.Stores, storeInfo)
 	}
 	StoresInfo.Count = len(StoresInfo.Stores)
@@ -669,6 +674,7 @@ func (h *storesHandler) GetStoresByState(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	cfg := h.GetScheduleConfig()
 	for _, s := range stores {
 		storeID := s.GetId()
 		store := rc.GetStore(storeID)
@@ -677,7 +683,7 @@ func (h *storesHandler) GetStoresByState(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		storeInfo := response.BuildStoreInfo(h.GetScheduleConfig(), store)
+		storeInfo := response.BuildStoreInfo(cfg, store)
 		if queryStates != nil && !slice.Contains(queryStates, strings.ToLower(storeInfo.Store.StateName)) {
 			continue
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #3601

`GetAllStores` and `GetStoresByState` call `Handler.GetScheduleConfig` **inside** their per-store loop. That call deep-clones the schedule config (copies the `StoreLimit` map and `Schedulers` slice — the clone was added in #3603 to fix a data race), so a single `GET /pd/api/v1/stores` clones the whole schedule config **once per store**.

On a large cluster this dominates PD leader CPU. In a 999-store / 249-client profile (clients polling `/stores` + `/config`), `ScheduleConfig.Clone` alone accounted for **~28% of PD leader CPU**, on top of the GC churn from the per-clone map allocations (`mapassign_fast64`, map iteration, `gcDrain`/`scanobject`). The PD leader sat at ~23/32 cores with the workload otherwise idle.

### What is changed and how it works?

Hoist the `GetScheduleConfig()` call out of the per-store loop in both handlers and reuse a single snapshot. `BuildStoreInfo` only reads scalar config fields (`LeaderSchedulePolicy`, `RegionScoreFormulaVersion`, `HighSpaceRatio`, `LowSpaceRatio`, `MaxStoreDownTime`) and never mutates the config, so this is safe:

- one clone per request still returns a private deep copy → the #3603 data-race fix is preserved;
- all stores now see a consistent config snapshot within one response (previously the config could change mid-loop);
- clones per `/stores` request drop from O(#stores) to 1.

### Check List

Tests

- [x] No code logic change; covered by existing unit/API tests
- [x] Manual/profile verification: `ScheduleConfig.Clone` disappears from the PD leader CPU profile after the change

### Release note

```release-note
Reduce PD leader CPU on large clusters by cloning the schedule config only once per GET /pd/api/v1/stores request instead of once per store.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in store list responses by using a single schedule snapshot during each request.
  * Reduced the chance of store details varying within the same response when multiple stores are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->