### PR TITLE
tests: avoid setting reserved engine label

### DIFF
--- a/tests/integrations/realcluster/reboot_pd_test.go
+++ b/tests/integrations/realcluster/reboot_pd_test.go
@@ -50,9 +50,12 @@ func (s *rebootPDSuite) TestReloadLabel() {
 		"zone": "zone1",
 	}
 	expectedLabels := make(map[string]string, len(firstStore.Store.Labels)+len(storeLabels))
+	originalZone, hasOriginalZone := "", false
 	for _, label := range firstStore.Store.Labels {
-		re.NotNil(label)
 		expectedLabels[label.Key] = label.Value
+		if label.Key == "zone" {
+			originalZone, hasOriginalZone = label.Value, true
+		}
 	}
 	for key, value := range storeLabels {
 		expectedLabels[key] = value
@@ -61,8 +64,16 @@ func (s *rebootPDSuite) TestReloadLabel() {
 	// back in the request because "engine" is reserved for TiKV/TiFlash.
 	re.NoError(pdHTTPCli.SetStoreLabels(ctx, firstStore.Store.ID, storeLabels))
 	defer func() {
+		// The restarted client is closed before this cleanup runs because defers
+		// run in LIFO order, so use a fresh client to restore the store labels.
 		cleanupCli := http.NewClient("pd-real-cluster-test", getPDEndpoints(re))
 		defer cleanupCli.Close()
+		if hasOriginalZone {
+			re.NoError(cleanupCli.SetStoreLabels(ctx, firstStore.Store.ID, map[string]string{
+				"zone": originalZone,
+			}))
+			return
+		}
 		re.NoError(cleanupCli.DeleteStoreLabel(ctx, firstStore.Store.ID, "zone"))
 	}()
 
@@ -72,7 +83,6 @@ func (s *rebootPDSuite) TestReloadLabel() {
 
 		labelsMap := make(map[string]string)
 		for _, label := range resp.Store.Labels {
-			re.NotNil(label)
 			labelsMap[label.Key] = label.Value
 		}
 

--- a/tests/integrations/realcluster/reboot_pd_test.go
+++ b/tests/integrations/realcluster/reboot_pd_test.go
@@ -16,6 +16,7 @@ package realcluster
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -46,19 +47,24 @@ func (s *rebootPDSuite) TestReloadLabel() {
 	re.NoError(err)
 	re.NotEmpty(resp.Stores)
 	firstStore := resp.Stores[0]
+	const zoneLabelKey = "zone"
 	storeLabels := map[string]string{
-		"zone": "zone1",
+		zoneLabelKey: "zone1",
 	}
 	expectedLabels := make(map[string]string, len(firstStore.Store.Labels)+len(storeLabels))
-	originalZone, hasOriginalZone := "", false
+	originalZoneKey, originalZone, hasOriginalZone := "", "", false
 	for _, label := range firstStore.Store.Labels {
 		expectedLabels[label.Key] = label.Value
-		if label.Key == "zone" {
-			originalZone, hasOriginalZone = label.Value, true
+		if !hasOriginalZone && strings.EqualFold(label.Key, zoneLabelKey) {
+			originalZoneKey, originalZone, hasOriginalZone = label.Key, label.Value, true
 		}
 	}
 	for key, value := range storeLabels {
-		expectedLabels[key] = value
+		expectedKey := key
+		if hasOriginalZone && strings.EqualFold(key, zoneLabelKey) {
+			expectedKey = originalZoneKey
+		}
+		expectedLabels[expectedKey] = value
 	}
 	// SetStoreLabels merges labels server-side. Do not echo existing labels
 	// back in the request because "engine" is reserved for TiKV/TiFlash.
@@ -70,11 +76,11 @@ func (s *rebootPDSuite) TestReloadLabel() {
 		defer cleanupCli.Close()
 		if hasOriginalZone {
 			re.NoError(cleanupCli.SetStoreLabels(ctx, firstStore.Store.ID, map[string]string{
-				"zone": originalZone,
+				originalZoneKey: originalZone,
 			}))
 			return
 		}
-		re.NoError(cleanupCli.DeleteStoreLabel(ctx, firstStore.Store.ID, "zone"))
+		re.NoError(cleanupCli.DeleteStoreLabel(ctx, firstStore.Store.ID, zoneLabelKey))
 	}()
 
 	checkLabelsAreEqual := func() {

--- a/tests/integrations/realcluster/reboot_pd_test.go
+++ b/tests/integrations/realcluster/reboot_pd_test.go
@@ -46,17 +46,24 @@ func (s *rebootPDSuite) TestReloadLabel() {
 	re.NoError(err)
 	re.NotEmpty(resp.Stores)
 	firstStore := resp.Stores[0]
-	// TiFlash labels will be ["engine": "tiflash"]
-	// So we need to merge the labels
 	storeLabels := map[string]string{
 		"zone": "zone1",
 	}
+	expectedLabels := make(map[string]string, len(firstStore.Store.Labels)+len(storeLabels))
 	for _, label := range firstStore.Store.Labels {
-		storeLabels[label.Key] = label.Value
+		re.NotNil(label)
+		expectedLabels[label.Key] = label.Value
 	}
+	for key, value := range storeLabels {
+		expectedLabels[key] = value
+	}
+	// SetStoreLabels merges labels server-side. Do not echo existing labels
+	// back in the request because "engine" is reserved for TiKV/TiFlash.
 	re.NoError(pdHTTPCli.SetStoreLabels(ctx, firstStore.Store.ID, storeLabels))
 	defer func() {
-		re.NoError(pdHTTPCli.DeleteStoreLabel(ctx, firstStore.Store.ID, "zone"))
+		cleanupCli := http.NewClient("pd-real-cluster-test", getPDEndpoints(re))
+		defer cleanupCli.Close()
+		re.NoError(cleanupCli.DeleteStoreLabel(ctx, firstStore.Store.ID, "zone"))
 	}()
 
 	checkLabelsAreEqual := func() {
@@ -69,7 +76,7 @@ func (s *rebootPDSuite) TestReloadLabel() {
 			labelsMap[label.Key] = label.Value
 		}
 
-		for key, value := range storeLabels {
+		for key, value := range expectedLabels {
 			re.Equal(value, labelsMap[key])
 		}
 	}
@@ -78,5 +85,6 @@ func (s *rebootPDSuite) TestReloadLabel() {
 	// Restart to reload the label
 	s.cluster.restart()
 	pdHTTPCli = http.NewClient("pd-real-cluster-test", getPDEndpoints(re))
+	defer pdHTTPCli.Close()
 	checkLabelsAreEqual()
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8389

### What is changed and how does it work?

```commit-message
Avoid sending existing store labels back through SetStoreLabels in TestReloadLabel. Keep the expected label set separate from the update payload so reserved labels such as engine are only validated after PD merges labels server-side, and close the HTTP client created after restart.
```

### Check List

Tests

- Unit test
- Integration test

Run locally:

- `git diff --check upstream/master..HEAD`
- `cd tests/integrations/realcluster && go test ./... -run '^$' -count=1`
- `cd tests/integrations/client && go test ./... -run 'TestHTTPClientTestSuite/TestSetStoreLabelsRejectEngineKey' -count=1`

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved a cluster restart test to validate that label updates persist and match expected values after reloading.
  * Refined cleanup to restore the original label state, or remove the label if it wasn’t previously set.
  * Ensured the restarted connection used for verification is properly reopened and closed during the test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->