### PR TITLE
mcs, tso: replace expected-primary keepalive with transient marker

### DIFF
--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -73,9 +73,6 @@ type Leadership struct {
 	// campaignTimes is used to record the campaign times of the leader within `campaignTimesRecordTimeout`.
 	// It is ordered by time to prevent the leader from campaigning too frequently.
 	campaignTimes []time.Time
-	// primaryWatch is for the primary watch only,
-	// which is used to reuse `Watch` interface in `Leadership`.
-	primaryWatch atomic.Bool
 }
 
 // NewLeadership creates a new Leadership.
@@ -130,16 +127,6 @@ func (ls *Leadership) GetLeaderValue() string {
 		return ""
 	}
 	return leaderValue.(string)
-}
-
-// SetPrimaryWatch sets the primary watch flag.
-func (ls *Leadership) SetPrimaryWatch(val bool) {
-	ls.primaryWatch.Store(val)
-}
-
-// IsPrimary gets the primary watch flag.
-func (ls *Leadership) IsPrimary() bool {
-	return ls.primaryWatch.Load()
 }
 
 // GetCampaignTimesNum is used to get the campaign times of the leader within `campaignTimesRecordTimeout`.
@@ -421,13 +408,6 @@ func (ls *Leadership) Watch(serverCtx context.Context, revision int64) {
 						zap.Int64("revision", wresp.Header.Revision), zap.String("leader-key", ls.leaderKey), zap.String("purpose", ls.purpose))
 					return
 				}
-				// ONLY `{service}/primary/transfer` API update primary will meet this condition.
-				if ev.Type == mvccpb.PUT && ls.IsPrimary() {
-					log.Info("current leadership is updated", zap.Int64("revision", wresp.Header.Revision),
-						zap.String("leader-key", ls.leaderKey), zap.ByteString("cur-value", ev.Kv.Value),
-						zap.String("purpose", ls.purpose))
-					return
-				}
 			}
 			revision = wresp.Header.Revision + 1
 		}
@@ -449,6 +429,5 @@ func (ls *Leadership) Reset() {
 	if err != nil {
 		log.Error("close lease failed", zap.String("purpose", ls.purpose), errs.ZapError(err))
 	}
-	ls.SetPrimaryWatch(false)
 	ls.leaderValue.Store("")
 }

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -48,7 +48,13 @@ type Lease struct {
 	// leaseTimeout and expireTime are used to control the lease's lifetime
 	leaseTimeout time.Duration
 	expireTime   atomic.Value
-	metrics      leaseMetrics
+	// closed guards Close against being run more than once. A leadership can be
+	// resigned concurrently from more than one path (e.g. a transfer API call and the
+	// election loop stepping down), and a lease is single-use, so the second Close
+	// must be a no-op instead of revoking an already-revoked lease and logging a
+	// spurious error.
+	closed  atomic.Bool
+	metrics leaseMetrics
 }
 
 // NewLease creates a new Lease instance.
@@ -106,12 +112,19 @@ func (l *Lease) Grant(leaseTimeout int64) error {
 	l.leaseTimeout = time.Duration(leaseTimeout) * time.Second
 	l.expireTime.Store(start.Add(time.Duration(leaseResp.TTL) * time.Second))
 	localTTLRemaining.register(l)
+	// A lease may be re-granted after being closed; clear the close guard so the
+	// next Close revokes this new grant.
+	l.closed.Store(false)
 	return nil
 }
 
-// Close releases the lease.
+// Close releases the lease. It is idempotent: only the first call revokes the lease
+// and tears down the client, subsequent calls are no-ops.
 func (l *Lease) Close() error {
 	if l == nil {
+		return nil
+	}
+	if !l.closed.CompareAndSwap(false, true) {
 		return nil
 	}
 	localTTLRemaining.unregister(l)
@@ -128,6 +141,17 @@ func (l *Lease) Close() error {
 			errs.ZapError(err))
 	}
 	return l.lease.Close()
+}
+
+// GetTimeoutSeconds returns the configured lease timeout in seconds, i.e. the
+// `leaseTimeout` the lease was granted with. It returns 0 when the lease is nil or
+// not granted yet; the caller is responsible for supplying a sensible default so a
+// non-positive timeout is never fed into an etcd lease grant.
+func (l *Lease) GetTimeoutSeconds() int64 {
+	if l == nil {
+		return 0
+	}
+	return int64(l.leaseTimeout / time.Second)
 }
 
 // IsExpired checks if the lease is expired. If it returns true,

--- a/pkg/mcs/resourcemanager/server/apis/v1/api.go
+++ b/pkg/mcs/resourcemanager/server/apis/v1/api.go
@@ -361,7 +361,7 @@ func transferPrimary(c *gin.Context) {
 		newPrimary = v
 	}
 
-	if err := utils.TransferPrimary(svr.GetClient(), svr.GetParticipant().GetExpectedPrimaryLease(),
+	if err := utils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
 		constant.ResourceManagerServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -29,6 +28,7 @@ import (
 
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/spf13/cobra"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -172,10 +172,17 @@ func (s *Server) primaryElectionLoop() {
 		}
 
 		// To make sure the expected primary(if existed) and new primary are on the same server.
-		expectedPrimary := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
-		// Skip campaign if the expected primary is not empty and not equal to the current memberValue.
+		expectedPrimary, err := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
+		if err != nil {
+			// Do not campaign on a read failure: an empty flag would be treated as
+			// "no transfer" and skip the affinity guard, so retry instead.
+			log.Warn("failed to get expected primary flag, retry later", errs.ZapError(err))
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		// Skip campaign if the expected primary is not empty and not this member.
 		// Expected primary ONLY SET BY `{service}/primary/transfer` API.
-		if len(expectedPrimary) > 0 && !strings.Contains(s.participant.MemberValue(), expectedPrimary) {
+		if len(expectedPrimary) > 0 && !s.participant.IsExpectedPrimary(expectedPrimary) {
 			log.Info("skip campaigning of resource manager primary and check later",
 				zap.String("server-name", s.Name()),
 				zap.String("expected-primary-id", expectedPrimary),
@@ -185,7 +192,7 @@ func (s *Server) primaryElectionLoop() {
 			continue
 		}
 
-		if s.campaignLeader() {
+		if s.campaignLeader(expectedPrimary) {
 			log.Warn("backing off before retrying resource manager primary campaign after callback failure",
 				zap.Duration("retry-after", primaryCallbackFailureRetryInterval))
 			timer := time.NewTimer(primaryCallbackFailureRetryInterval)
@@ -202,9 +209,16 @@ func (s *Server) primaryElectionLoop() {
 // campaignLeader campaigns the primary/leader.
 // It returns true only when the server won the campaign but service-ready
 // callbacks failed, so the caller should back off before retrying.
-func (s *Server) campaignLeader() bool {
+// expectedPrimary is the value of the expected primary flag observed before
+// campaigning (empty when no transfer is in progress); it binds the campaign to the
+// transfer target atomically and is cleaned up once this server wins.
+func (s *Server) campaignLeader(expectedPrimary string) bool {
 	log.Info("start to campaign the primary/leader", zap.String("campaign-resource-manager-primary-name", s.participant.Name()))
-	if err := s.participant.Campaign(s.Context(), s.cfg.LeaderLease); err != nil {
+	var cmps []clientv3.Cmp
+	if cmp := utils.ExpectedPrimaryCmp(&s.participant.MsParam, expectedPrimary); cmp != nil {
+		cmps = append(cmps, *cmp)
+	}
+	if err := s.participant.CampaignWithCmps(s.Context(), s.cfg.LeaderLease, cmps...); err != nil {
 		if err.Error() == errs.ErrEtcdTxnConflict.Error() {
 			log.Info("campaign resource manager primary meets error due to txn conflict, another server may campaign successfully",
 				zap.String("campaign-resource-manager-primary-name", s.participant.Name()))
@@ -229,6 +243,11 @@ func (s *Server) campaignLeader() bool {
 	s.participant.GetLeadership().Keep(ctx)
 	log.Info("campaign resource manager primary ok", zap.String("campaign-resource-manager-primary-name", s.participant.Name()))
 
+	// We have won the campaign, so the expected primary flag (if any) has served its
+	// purpose as the affinity guard. Delete it so steady state is clean and a later
+	// failure re-elects immediately instead of waiting for the flag's TTL.
+	utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary)
+
 	log.Info("triggering the primary callback functions")
 	for _, cb := range s.primaryCallbacks {
 		if err := cb(ctx); err != nil {
@@ -239,16 +258,6 @@ func (s *Server) campaignLeader() bool {
 			return true
 		}
 	}
-	// Check expected primary and watch the primary.
-	exitPrimary := make(chan struct{})
-	lease, err := utils.KeepExpectedPrimaryAlive(ctx, s.GetClient(), exitPrimary,
-		s.cfg.LeaderLease, &keypath.MsParam{ServiceName: constant.ResourceManagerServiceName}, s.participant)
-	if err != nil {
-		log.Error("prepare resource manager primary watch error", errs.ZapError(err))
-		return false
-	}
-	s.participant.SetExpectedPrimaryLease(lease)
-
 	s.participant.PromoteSelf()
 	member.ServiceMemberGauge.WithLabelValues(serviceName).Set(1)
 	log.Info("resource manager primary is ready to serve", zap.String("resource-manager-primary-name", s.participant.Name()))
@@ -259,16 +268,16 @@ func (s *Server) campaignLeader() bool {
 	for {
 		select {
 		case <-leaderTicker.C:
+			// Step down once the leader lease is gone. This covers both lease
+			// expiration and a `{service}/primary/transfer` API call, which resigns
+			// this primary by revoking its leader lease.
 			if !s.participant.IsServing() {
-				log.Info("no longer a primary/leader because lease has expired, the resource manager primary/leader will step down")
+				log.Info("no longer a primary/leader because lease has expired or transferred, the resource manager primary/leader will step down")
 				return false
 			}
 		case <-ctx.Done():
 			// Server is closed and it should return nil.
 			log.Info("server is closed")
-			return false
-		case <-exitPrimary:
-			log.Info("no longer be primary because primary have been updated, the resource manager primary/leader will step down")
 			return false
 		}
 	}

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -1646,7 +1646,7 @@ func transferPrimary(c *gin.Context) {
 		newPrimary = v
 	}
 
-	if err := mcsutils.TransferPrimary(svr.GetClient(), svr.GetParticipant().GetExpectedPrimaryLease(),
+	if err := mcsutils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
 		constant.SchedulingServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -21,7 +21,6 @@ import (
 	"os/signal"
 	"runtime"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -29,6 +28,7 @@ import (
 
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/spf13/cobra"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -257,10 +257,17 @@ func (s *Server) primaryElectionLoop() {
 		}
 
 		// To make sure the expected primary(if existed) and new primary are on the same server.
-		expectedPrimary := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
-		// skip campaign the primary if the expected primary is not empty and not equal to the current memberValue.
+		expectedPrimary, err := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
+		if err != nil {
+			// Do not campaign on a read failure: an empty flag would be treated as
+			// "no transfer" and skip the affinity guard, so retry instead.
+			log.Warn("failed to get expected primary flag, retry later", errs.ZapError(err))
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		// skip campaign the primary if the expected primary is not empty and not this member.
 		// expected primary ONLY SET BY `{service}/primary/transfer` API.
-		if len(expectedPrimary) > 0 && !strings.Contains(s.participant.MemberValue(), expectedPrimary) {
+		if len(expectedPrimary) > 0 && !s.participant.IsExpectedPrimary(expectedPrimary) {
 			log.Info("skip campaigning of scheduling primary and check later",
 				zap.String("server-name", s.Name()),
 				zap.String("expected-primary-id", expectedPrimary),
@@ -270,13 +277,21 @@ func (s *Server) primaryElectionLoop() {
 			continue
 		}
 
-		s.campaignPrimary()
+		s.campaignPrimary(expectedPrimary)
 	}
 }
 
-func (s *Server) campaignPrimary() {
+// campaignPrimary campaigns the scheduling primary. expectedPrimary is the value of
+// the expected primary flag observed before campaigning (empty when no transfer is
+// in progress); it is used to bind the campaign to the transfer target atomically
+// and to clean the flag up once this server wins.
+func (s *Server) campaignPrimary(expectedPrimary string) {
 	log.Info("start to campaign the primary", zap.String("campaign-scheduling-primary-name", s.participant.Name()))
-	if err := s.participant.Campaign(s.Context(), s.cfg.LeaderLease); err != nil {
+	var cmps []clientv3.Cmp
+	if cmp := utils.ExpectedPrimaryCmp(&s.participant.MsParam, expectedPrimary); cmp != nil {
+		cmps = append(cmps, *cmp)
+	}
+	if err := s.participant.CampaignWithCmps(s.Context(), s.cfg.LeaderLease, cmps...); err != nil {
 		if err.Error() == errs.ErrEtcdTxnConflict.Error() {
 			log.Info("campaign scheduling primary meets error due to txn conflict, another server may campaign successfully",
 				zap.String("campaign-scheduling-primary-name", s.participant.Name()))
@@ -301,6 +316,11 @@ func (s *Server) campaignPrimary() {
 	s.participant.GetLeadership().Keep(ctx)
 	log.Info("campaign scheduling primary ok", zap.String("campaign-scheduling-primary-name", s.participant.Name()))
 
+	// We have won the campaign, so the expected primary flag (if any) has served its
+	// purpose as the affinity guard. Delete it so steady state is clean and a later
+	// failure re-elects immediately instead of waiting for the flag's TTL.
+	utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary)
+
 	log.Info("triggering the primary callback functions")
 	for _, cb := range s.primaryCallbacks {
 		if err := cb(ctx); err != nil {
@@ -313,17 +333,6 @@ func (s *Server) campaignPrimary() {
 			cb()
 		}
 	}()
-	// check expected primary and watch the primary.
-	exitPrimary := make(chan struct{})
-	lease, err := utils.KeepExpectedPrimaryAlive(ctx, s.GetClient(), exitPrimary,
-		s.cfg.LeaderLease, &keypath.MsParam{
-			ServiceName: constant.SchedulingServiceName,
-		}, s.participant)
-	if err != nil {
-		log.Error("prepare scheduling primary watch error", errs.ZapError(err))
-		return
-	}
-	s.participant.SetExpectedPrimaryLease(lease)
 	s.participant.PromoteSelf()
 
 	member.ServiceMemberGauge.WithLabelValues(serviceName).Set(1)
@@ -335,16 +344,16 @@ func (s *Server) campaignPrimary() {
 	for {
 		select {
 		case <-primaryTicker.C:
+			// Step down once the leader lease is gone. This covers both lease
+			// expiration and a `{service}/primary/transfer` API call, which resigns
+			// this primary by revoking its leader lease.
 			if !s.participant.IsServing() {
-				log.Info("no longer a primary because lease has expired, the scheduling primary will step down")
+				log.Info("no longer a primary because lease has expired or transferred, the scheduling primary will step down")
 				return
 			}
 		case <-ctx.Done():
 			// Server is closed and it should return nil.
 			log.Info("server is closed")
-			return
-		case <-exitPrimary:
-			log.Info("no longer be primary because primary have been updated, the scheduling primary will step down")
 			return
 		}
 	}

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -364,7 +364,11 @@ func transferPrimary(c *gin.Context) {
 		forwardToGroupPrimary(c, svr, keyspaceGroupID, allocator.GetPrimaryAddr(), body)
 		return
 	}
-	lease := allocator.GetExpectedPrimaryLease()
+	participant, ok := allocator.GetMember().(*member.Participant)
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, "the tso member is not a participant")
+		return
+	}
 
 	// only members of specific group are valid primary candidates.
 	memberMap := make(map[string]bool, len(group.Members))
@@ -372,7 +376,7 @@ func transferPrimary(c *gin.Context) {
 		memberMap[member.Address] = true
 	}
 
-	if err := utils.TransferPrimary(svr.GetClient(), lease,
+	if err := utils.TransferPrimary(svr.GetClient(), participant,
 		mcs.TSOServiceName, svr.Name(), input.NewPrimary, keyspaceGroupID, memberMap); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/utils/constant/constant.go
+++ b/pkg/mcs/utils/constant/constant.go
@@ -38,6 +38,13 @@ const (
 	DefaultDisableErrorVerbose = true
 	// DefaultLease is the default value of lease
 	DefaultLease = int64(5)
+	// TransferPrimaryLeaseMultiplier scales the leader lease to derive the TTL of the
+	// expected primary flag written by the `{service}/primary/transfer` API. The flag
+	// only needs to outlive the re-election window so the target member can win the
+	// campaign; if the target never comes up within this window the flag expires and
+	// the cluster falls back to a free election. Tying it to the leader lease keeps the
+	// window proportional to how fast leadership turns over.
+	TransferPrimaryLeaseMultiplier = int64(3)
 	// PrimaryTickInterval is the interval to check primary
 	PrimaryTickInterval = 50 * time.Millisecond
 	// LeaderTickInterval is the interval to check leader

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	"context"
-	"fmt"
 	"math/rand/v2"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -25,7 +24,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 
-	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
@@ -35,16 +33,20 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 )
 
-// GetExpectedPrimaryFlag gets the expected primary flag.
-func GetExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam) string {
+// GetExpectedPrimaryFlag gets the expected primary flag. A read failure is
+// returned as an error rather than collapsed into an empty flag: callers treat an
+// empty flag as "no transfer in progress" and campaign without the affinity guard,
+// so a failed read must NOT be mistaken for "no marker" — otherwise a non-target
+// member could win while a transfer marker actually exists.
+func GetExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam) (string, error) {
 	path := keypath.ExpectedPrimaryPath(msParam)
 	primary, err := etcdutil.GetValue(client, path)
 	if err != nil {
 		log.Error("get expected primary flag error", errs.ZapError(err), zap.String("primary-path", path))
-		return ""
+		return "", err
 	}
 
-	return string(primary)
+	return string(primary), nil
 }
 
 // primaryData is used to store the primary data.
@@ -55,7 +57,7 @@ type primaryData struct {
 }
 
 // markExpectedPrimaryFlag marks the expected primary flag when the primary is specified.
-func markExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, primary *primaryData, leaseID clientv3.LeaseID) (int64, error) {
+func markExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, primary *primaryData, leaseID clientv3.LeaseID) error {
 	path := keypath.ExpectedPrimaryPath(msParam)
 	log.Info("set expected primary flag", zap.String("primary-path", path), zap.String("primary", primary.output))
 	// write a flag to indicate the expected primary.
@@ -64,92 +66,97 @@ func markExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, 
 		Commit()
 	if err != nil {
 		log.Error("mark expected primary error", errs.ZapError(err), zap.String("primary-path", path))
-		return 0, err
+		return err
 	}
 	if !resp.Succeeded {
 		log.Error("mark expected primary error", zap.String("primary-path", path))
-		return 0, errors.New("mark expected primary txn did not succeed")
+		return errors.New("mark expected primary txn did not succeed")
 	}
-	return resp.Header.Revision, nil
+	return nil
 }
 
-// KeepExpectedPrimaryAlive keeps the expected primary alive.
-// We use lease to keep `expected primary` healthy.
-// ONLY reset by the following conditions:
-// - changed by `{service}/primary/transfer` API.
-// - primary lease expired.
-// ONLY primary called this function.
-func KeepExpectedPrimaryAlive(
-	ctx context.Context,
-	cli *clientv3.Client,
-	exitPrimary chan<- struct{},
-	leaseTimeout int64,
-	msParam *keypath.MsParam,
-	m *member.Participant) (*election.Lease, error) {
-	log.Info("primary start to watch the expected primary",
-		zap.String("service", msParam.ServiceName),
-		zap.Uint32("group-id", msParam.GroupID),
-		zap.String("primary-value", m.ParticipantString()))
-	// For TSO, include msParam.GroupID in the purpose so per-keyspace-group
-	// expected primary leases get distinct Prometheus labels and distinct slots
-	// in localTTLRemainingCollector. A single TSO process can be primary for
-	// multiple keyspace groups; without the GroupID suffix their leases all
-	// collapse onto one series. Non-TSO services only ever have one expected
-	// primary lease, so the GroupID suffix would just be noise (0).
-	service := fmt.Sprintf("%s expected primary", msParam.ServiceName)
-	if msParam.ServiceName == constant.TSOServiceName {
-		service = fmt.Sprintf("%s %05d", service, msParam.GroupID)
+// DeleteExpectedPrimaryFlag deletes the expected primary flag once the target has
+// won the campaign, so that in steady state the flag is absent and a subsequent
+// failure of the new primary triggers a free re-election immediately instead of
+// waiting for the flag's TTL to expire.
+//
+// The delete is conditional on the flag still holding `expectedValue` (the value
+// the winner campaigned with). This prevents clobbering a newer transfer that may
+// have already rewritten the flag to a different target while this primary was
+// winning. It is best-effort: the flag's TTL is the backstop, so a failure here is
+// only logged and never blocks serving.
+//
+// The flag is bound to an etcd lease, so after deleting the key we also revoke that
+// lease. Otherwise we would leave the key gone but the lease alive — exactly the
+// inconsistent state that issue #10875 is about — and leak a lease until its TTL
+// expires.
+func DeleteExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, expectedValue string) {
+	if expectedValue == "" {
+		// Normal election without a transfer in progress, nothing to clean up.
+		return
 	}
-	lease := election.NewLease(cli, service)
-	if err := lease.Grant(leaseTimeout); err != nil {
-		return nil, err
-	}
-	primary := &primaryData{
-		raw:    m.MemberValue(),
-		output: m.ParticipantString(),
-	}
-	revision, err := markExpectedPrimaryFlag(cli, msParam, primary, lease.GetID())
+	path := keypath.ExpectedPrimaryPath(msParam)
+	// Read the key (to capture its lease) and delete it in the same conditional txn.
+	resp, err := kv.NewSlowLogTxn(client).
+		If(clientv3.Compare(clientv3.Value(path), "=", expectedValue)).
+		Then(clientv3.OpGet(path), clientv3.OpDelete(path)).
+		Commit()
 	if err != nil {
-		log.Error("mark expected primary error", errs.ZapError(err))
-		if closeErr := lease.Close(); closeErr != nil {
-			log.Warn("failed to revoke expected primary lease", zap.Error(closeErr))
-		}
-		return nil, err
+		log.Warn("failed to delete expected primary flag", zap.String("primary-path", path), errs.ZapError(err))
+		return
 	}
-	// Keep alive the current expected primary leadership to indicate that the server is still alive.
-	// Watch the expected primary path to check whether the expected primary has changed by `{service}/primary/transfer` API.
-	expectedPrimary := election.NewLeadership(cli, keypath.ExpectedPrimaryPath(msParam), service)
-	expectedPrimary.SetLease(lease)
-	expectedPrimary.Keep(ctx)
-
-	go watchExpectedPrimary(ctx, expectedPrimary, revision+1, exitPrimary)
-	return lease, nil
-}
-
-// watchExpectedPrimary watches `{service}/primary/transfer` API whether changed the expected primary.
-func watchExpectedPrimary(ctx context.Context,
-	expectedPrimary *election.Leadership, revision int64, exitPrimary chan<- struct{}) {
-	expectedPrimary.SetPrimaryWatch(true)
-	// ONLY exited watch by the following conditions:
-	// - changed by `{service}/primary/transfer` API.
-	// - primary lease expired.
-	expectedPrimary.Watch(ctx, revision)
-	expectedPrimary.Reset()
-	defer log.Info("primary exit the primary watch loop")
-	select {
-	case <-ctx.Done():
+	if !resp.Succeeded {
+		log.Info("skip deleting expected primary flag, it has been changed or already gone",
+			zap.String("primary-path", path), zap.String("expected-value", expectedValue))
 		return
-	case exitPrimary <- struct{}{}:
+	}
+	log.Info("delete expected primary flag", zap.String("primary-path", path))
+	// Revoke the lease the flag was bound to, if any, so no lease is leaked.
+	kvs := resp.Responses[0].GetResponseRange().GetKvs()
+	if len(kvs) == 0 || kvs[0].Lease == 0 {
 		return
+	}
+	leaseID := clientv3.LeaseID(kvs[0].Lease)
+	// Bound the revoke: this runs on the campaign path before the primary is promoted
+	// to serving, and the cleanup is best-effort, so a hung RPC must not block serving.
+	ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+	defer cancel()
+	if _, err := client.Revoke(ctx, leaseID); err != nil {
+		log.Warn("failed to revoke expected primary flag lease",
+			zap.String("primary-path", path), zap.Int64("lease-id", int64(leaseID)), errs.ZapError(err))
 	}
 }
 
-// TransferPrimary transfers the primary of the specified service.
-// keyspaceGroupID is optional, only used for TSO service.
-func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName,
+// ExpectedPrimaryCmp returns an etcd comparison asserting the expected primary flag
+// still equals `expectedValue`. The caller appends it to the campaign transaction so
+// that winning the leader key and "I am still the expected primary" become atomic:
+// if a concurrent transfer rewrote the flag after it was read, the campaign txn
+// fails and this member does not become primary. It returns nil when expectedValue
+// is empty (normal election, no transfer in progress), in which case the campaign
+// must not be constrained.
+func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) *clientv3.Cmp {
+	if expectedValue == "" {
+		return nil
+	}
+	cmp := clientv3.Compare(clientv3.Value(keypath.ExpectedPrimaryPath(msParam)), "=", expectedValue)
+	return &cmp
+}
+
+// TransferPrimary transfers the primary of the specified service to a target member.
+//
+// It writes the expected primary flag pointing at the target (with a TTL of a few
+// leader leases, see constant.TransferPrimaryLeaseMultiplier) and then resigns the
+// current primary by revoking its leader lease, so the re-election picks up the
+// target. The flag write
+// happens before the resignation on purpose: it guarantees the affinity guard is in
+// place before the leader key is released, so no other member can win the gap.
+//
+// keyspaceGroupID is optional, only used for TSO service. p must be the participant
+// of the current serving primary (the API ensures the request runs on the primary).
+func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName,
 	oldPrimary, newPrimary string, keyspaceGroupID uint32, tsoMembersMap map[string]bool) error {
-	if lease == nil {
-		return errors.New("current lease is nil, please check leadership")
+	if p == nil || !p.IsServing() {
+		return errors.New("current member is not serving as primary, please check leadership")
 	}
 	log.Info("try to transfer primary", zap.String("service", serviceName), zap.String("from", oldPrimary), zap.String("to", newPrimary))
 	entries, err := discovery.GetMSMembers(serviceName, client)
@@ -192,15 +199,18 @@ func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName
 
 	nextPrimaryID := rand.IntN(len(primaryIDs))
 
-	// update expected primary flag
-	grantResp, err := client.Grant(client.Ctx(), constant.DefaultLease)
+	// Grant a fresh lease for the expected primary flag, sized to a few leader
+	// leases so it outlives the re-election window. It is not kept alive by anyone:
+	// the target deletes the flag once it wins, otherwise the TTL expires and the
+	// cluster falls back to a free election.
+	leaderLease := p.GetLeadership().GetLease().GetTimeoutSeconds()
+	if leaderLease <= 0 {
+		leaderLease = constant.DefaultLease
+	}
+	expectedLease := constant.TransferPrimaryLeaseMultiplier * leaderLease
+	grantResp, err := client.Grant(client.Ctx(), expectedLease)
 	if err != nil {
 		return errors.Errorf("failed to grant lease for expected primary, err: %v", err)
-	}
-
-	// revoke current primary's lease to ensure keepalive goroutine of primary exits.
-	if err := lease.Close(); err != nil {
-		return errors.Errorf("failed to revoke current primary's lease: %v", err)
 	}
 
 	msParam := &keypath.MsParam{
@@ -211,10 +221,16 @@ func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName
 		raw:    primaryIDs[nextPrimaryID],
 		output: primaryIDs[nextPrimaryID],
 	}
-	_, err = markExpectedPrimaryFlag(client, msParam, primary, grantResp.ID)
-	if err != nil {
+	// Mark the expected primary first so the affinity guard is in place before the
+	// current primary releases the leader key below.
+	if err = markExpectedPrimaryFlag(client, msParam, primary, grantResp.ID); err != nil {
 		return errors.Errorf("failed to mark expected primary flag for %s, err: %v", serviceName, err)
 	}
+
+	// Resign the current primary by revoking its leader lease. This makes the local
+	// IsServing() flip to false immediately, so the primary election loop steps down
+	// and re-campaigns, where the affinity guard routes the leadership to the target.
+	p.Resign()
 	return nil
 }
 

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -12,20 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils_test
+package utils
 
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/goleak"
 
-	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/mcs/discovery"
-	mcsutils "github.com/tikv/pd/pkg/mcs/utils"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
@@ -36,164 +32,88 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
 }
 
-const (
-	testPrimaryName   = "tso-primary"
-	testPrimaryAddr   = "http://127.0.0.1:10001"
-	testSecondaryName = "tso-secondary"
-	testSecondaryAddr = "http://127.0.0.1:10002"
-)
-
-func TestTransferPrimary(t *testing.T) {
-	tests := []struct {
-		name                string
-		oldPrimary          string
-		newPrimary          string
-		expectedPrimary     string
-		keepExpectedPrimary bool
-	}{
-		{
-			name:                "self transfer by name keeps expected primary lease",
-			oldPrimary:          testPrimaryName,
-			newPrimary:          testPrimaryName,
-			expectedPrimary:     testPrimaryAddr,
-			keepExpectedPrimary: true,
-		},
-		{
-			name:                "self transfer by address keeps expected primary lease",
-			oldPrimary:          testPrimaryName,
-			newPrimary:          testPrimaryAddr,
-			expectedPrimary:     testPrimaryAddr,
-			keepExpectedPrimary: true,
-		},
-		{
-			name:            "random transfer excludes old primary by name",
-			oldPrimary:      testPrimaryName,
-			expectedPrimary: testSecondaryAddr,
-		},
-		{
-			name:            "random transfer excludes old primary by address",
-			oldPrimary:      testPrimaryAddr,
-			expectedPrimary: testSecondaryAddr,
-		},
-		{
-			name:            "explicit transfer selects target by name",
-			oldPrimary:      testPrimaryName,
-			newPrimary:      testSecondaryName,
-			expectedPrimary: testSecondaryAddr,
-		},
-		{
-			name:            "explicit transfer selects target by address",
-			oldPrimary:      testPrimaryName,
-			newPrimary:      testSecondaryAddr,
-			expectedPrimary: testSecondaryAddr,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			env := newTransferPrimaryTestEnv(t)
-			before := env.getExpectedPrimary(t)
-			re := require.New(t)
-			re.Equal(testPrimaryAddr, before.value)
-			re.Equal(int64(env.lease.GetID()), before.lease)
-
-			err := mcsutils.TransferPrimary(env.client, env.lease, constant.TSOServiceName,
-				tt.oldPrimary, tt.newPrimary, 0, map[string]bool{
-					testPrimaryAddr:   true,
-					testSecondaryAddr: true,
-				})
-			re.NoError(err)
-
-			after := env.getExpectedPrimary(t)
-			re.Equal(tt.expectedPrimary, after.value)
-			if tt.keepExpectedPrimary {
-				re.Equal(before.modRevision, after.modRevision)
-				re.Equal(before.lease, after.lease)
-				return
-			}
-			re.NotEqual(before.modRevision, after.modRevision)
-			re.NotEqual(before.lease, after.lease)
-		})
-	}
-}
-
-type transferPrimaryTestEnv struct {
-	ctx                 context.Context
-	client              *clientv3.Client
-	lease               *election.Lease
-	expectedPrimaryPath string
-}
-
-type expectedPrimary struct {
-	value       string
-	modRevision int64
-	lease       int64
-}
-
-func newTransferPrimaryTestEnv(t *testing.T) *transferPrimaryTestEnv {
-	t.Helper()
+// TestDeleteExpectedPrimaryFlagRevokesLease reconstructs the corner case from issue
+// #10875. The expected primary flag is bound to an etcd lease; if the key were
+// deleted while its lease lingered, a later campaign would read an empty flag, skip
+// the affinity guard, and then fail with ErrEtcdTxnConflict against the still-present
+// leader key. DeleteExpectedPrimaryFlag must therefore remove both the key and its
+// lease, so the "key deleted but lease persists" state can never exist.
+func TestDeleteExpectedPrimaryFlagRevokesLease(t *testing.T) {
 	re := require.New(t)
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
-	t.Cleanup(clean)
+	defer clean()
 
-	keypath.SetClusterID(uint64(time.Now().UnixNano()))
-	t.Cleanup(keypath.ResetClusterID)
+	ctx := context.Background()
+	msParam := &keypath.MsParam{ServiceName: constant.SchedulingServiceName}
+	path := keypath.ExpectedPrimaryPath(msParam)
+	const value = "http://127.0.0.1:2379"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
-
-	putRegistryEntry(t, ctx, client, testPrimaryName, testPrimaryAddr)
-	putRegistryEntry(t, ctx, client, testSecondaryName, testSecondaryAddr)
-
-	lease := election.NewLease(client, "tso expected primary 00000")
-	re.NoError(lease.Grant(constant.DefaultLease))
-	t.Cleanup(func() {
-		_ = lease.Close()
-	})
-
-	expectedPrimaryPath := keypath.ExpectedPrimaryPath(&keypath.MsParam{
-		ServiceName: constant.TSOServiceName,
-		GroupID:     0,
-	})
-	_, err := client.Put(ctx, expectedPrimaryPath, testPrimaryAddr, clientv3.WithLease(lease.GetID()))
+	// Mark the flag bound to a fresh lease, exactly as TransferPrimary does.
+	grantResp, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
 	re.NoError(err)
+	leaseID := grantResp.ID
+	re.NoError(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: value, output: value}, leaseID))
 
-	return &transferPrimaryTestEnv{
-		ctx:                 ctx,
-		client:              client,
-		lease:               lease,
-		expectedPrimaryPath: expectedPrimaryPath,
-	}
+	// Sanity: the key exists and is bound to the lease.
+	getResp, err := client.Get(ctx, path)
+	re.NoError(err)
+	re.Len(getResp.Kvs, 1)
+	re.Equal(int64(leaseID), getResp.Kvs[0].Lease)
+
+	// The newly elected primary cleans up the flag once it wins.
+	DeleteExpectedPrimaryFlag(client, msParam, value)
+
+	// The key is gone...
+	getResp, err = client.Get(ctx, path)
+	re.NoError(err)
+	re.Empty(getResp.Kvs)
+	// ...and so is its lease: TimeToLive returns -1 for a revoked/expired lease, which
+	// is the guarantee that the #10875 "key deleted but lease persists" state is gone.
+	ttlResp, err := client.TimeToLive(ctx, leaseID)
+	re.NoError(err)
+	re.Equal(int64(-1), ttlResp.TTL)
 }
 
-func (env *transferPrimaryTestEnv) getExpectedPrimary(t *testing.T) expectedPrimary {
-	t.Helper()
+// TestDeleteExpectedPrimaryFlagSkipsOnValueMismatch ensures the conditional delete
+// does not clobber a newer transfer. If a second transfer has already rewritten the
+// flag (with its own lease) while this primary was winning, the stale winner must
+// leave both the key and the newer lease intact.
+func TestDeleteExpectedPrimaryFlagSkipsOnValueMismatch(t *testing.T) {
 	re := require.New(t)
-	resp, err := env.client.Get(env.ctx, env.expectedPrimaryPath)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx := context.Background()
+	msParam := &keypath.MsParam{ServiceName: constant.SchedulingServiceName}
+	path := keypath.ExpectedPrimaryPath(msParam)
+
+	// A newer transfer points the flag at "newer" with its own lease.
+	grantResp, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
 	re.NoError(err)
-	re.Len(resp.Kvs, 1)
-	kv := resp.Kvs[0]
-	return expectedPrimary{
-		value:       string(kv.Value),
-		modRevision: kv.ModRevision,
-		lease:       kv.Lease,
-	}
+	leaseID := grantResp.ID
+	re.NoError(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: "newer", output: "newer"}, leaseID))
+
+	// A primary that campaigned for the older value tries to clean up; it must not.
+	DeleteExpectedPrimaryFlag(client, msParam, "older")
+
+	getResp, err := client.Get(ctx, path)
+	re.NoError(err)
+	re.Len(getResp.Kvs, 1)
+	re.Equal("newer", string(getResp.Kvs[0].Value))
+	ttlResp, err := client.TimeToLive(ctx, leaseID)
+	re.NoError(err)
+	re.Positive(ttlResp.TTL)
 }
 
-func putRegistryEntry(
-	t *testing.T,
-	ctx context.Context,
-	client *clientv3.Client,
-	name string,
-	serviceAddr string,
-) {
-	t.Helper()
-	entry := discovery.ServiceRegistryEntry{
-		Name:        name,
-		ServiceAddr: serviceAddr,
-	}
-	serializedValue, err := entry.Serialize()
-	require.NoError(t, err)
-	_, err = client.Put(ctx, keypath.RegistryPath(constant.TSOServiceName, serviceAddr), serializedValue)
-	require.NoError(t, err)
+// TestIsSamePrimary covers the matching used by TransferPrimary to skip a
+// self-transfer (#10970): a member matches by either its name or its service
+// address, and an empty target never matches.
+func TestIsSamePrimary(t *testing.T) {
+	re := require.New(t)
+	entry := discovery.ServiceRegistryEntry{Name: "tso-1", ServiceAddr: "http://127.0.0.1:2379"}
+	re.True(isSamePrimary(entry, "tso-1"))                  // match by name
+	re.True(isSamePrimary(entry, "http://127.0.0.1:2379"))  // match by service address
+	re.False(isSamePrimary(entry, "tso-2"))                 // different name
+	re.False(isSamePrimary(entry, "http://127.0.0.1:2380")) // different address
+	re.False(isSamePrimary(entry, ""))                      // empty target never matches
 }

--- a/pkg/member/participant.go
+++ b/pkg/member/participant.go
@@ -16,6 +16,7 @@ package member
 
 import (
 	"context"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -63,8 +64,6 @@ type Participant struct {
 	// campaignChecker is used to check whether the additional constraints for a
 	// campaign are satisfied. If it returns false, the campaign will fail.
 	campaignChecker atomic.Value // Store as leadershipCheckFunc
-	// expectedPrimaryLease is the expected lease for the primary.
-	expectedPrimaryLease atomic.Value // stored as *election.Lease
 }
 
 // NewParticipant create a new Participant.
@@ -114,6 +113,18 @@ func (p *Participant) ParticipantString() string {
 		return ""
 	}
 	return p.participant.String()
+}
+
+// IsExpectedPrimary reports whether expectedValue (an expected primary transfer
+// marker, which holds a member's advertise address) exactly matches one of this
+// participant's listen URLs. The match is exact list membership rather than a
+// substring search of the serialized member value, so one member's address being a
+// substring of another's value cannot misroute a transfer.
+func (p *Participant) IsExpectedPrimary(expectedValue string) bool {
+	if p.participant == nil {
+		return false
+	}
+	return slices.Contains(p.participant.GetListenUrls(), expectedValue)
 }
 
 // Client returns the etcd client.
@@ -178,11 +189,19 @@ func (p *Participant) GetLeadership() *election.Leadership {
 }
 
 // Campaign is used to campaign the leadership and make it become a primary.
-func (p *Participant) Campaign(_ context.Context, leaseTimeout int64) error {
+func (p *Participant) Campaign(ctx context.Context, leaseTimeout int64) error {
+	return p.CampaignWithCmps(ctx, leaseTimeout)
+}
+
+// CampaignWithCmps campaigns the leadership with extra etcd comparisons appended to
+// the leader-key transaction. The caller can use it to make the campaign conditional,
+// e.g. asserting the expected primary flag still points to this member, so that
+// acquiring the leader key and the affinity check happen atomically.
+func (p *Participant) CampaignWithCmps(_ context.Context, leaseTimeout int64, cmps ...clientv3.Cmp) error {
 	if !p.campaignCheck() {
 		return errs.ErrCheckCampaign
 	}
-	return p.leadership.Campaign(leaseTimeout, p.MemberValue())
+	return p.leadership.Campaign(leaseTimeout, p.MemberValue(), cmps...)
 }
 
 // getPersistentPrimary gets the corresponding primary from etcd by given electionPath (as the key).
@@ -268,20 +287,6 @@ func (p *Participant) campaignCheck() bool {
 // SetCampaignChecker sets the pre-campaign checker.
 func (p *Participant) SetCampaignChecker(checker leadershipCheckFunc) {
 	p.campaignChecker.Store(checker)
-}
-
-// SetExpectedPrimaryLease sets the expected lease for the primary.
-func (p *Participant) SetExpectedPrimaryLease(lease *election.Lease) {
-	p.expectedPrimaryLease.Store(lease)
-}
-
-// GetExpectedPrimaryLease gets the expected lease for the primary.
-func (p *Participant) GetExpectedPrimaryLease() *election.Lease {
-	l := p.expectedPrimaryLease.Load()
-	if l == nil {
-		return nil
-	}
-	return l.(*election.Lease)
 }
 
 // NewParticipantByService creates a new participant by service name.

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -20,19 +20,17 @@ import (
 	"fmt"
 	"runtime/trace"
 	"strconv"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
 
-	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
 	mcsutils "github.com/tikv/pd/pkg/mcs/utils"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
@@ -61,10 +59,8 @@ type Allocator struct {
 	// keyspaceGroupID is the keyspace group ID of the allocator.
 	keyspaceGroupID uint32
 	// for election use
-	member member.Election
-	// expectedPrimaryLease is used to store the expected primary lease.
-	expectedPrimaryLease atomic.Value // store as *election.LeaderLease
-	timestampOracle      *timestampOracle
+	member          member.Election
+	timestampOracle *timestampOracle
 
 	// observability
 	tsoAllocatorRoleGauge prometheus.Gauge
@@ -246,13 +242,20 @@ func (a *Allocator) primaryElectionLoop() {
 		}
 
 		// To make sure the expected primary(if existed) and new primary are on the same server.
-		expectedPrimary := mcsutils.GetExpectedPrimaryFlag(a.member.Client(), &keypath.MsParam{
+		expectedPrimary, err := mcsutils.GetExpectedPrimaryFlag(a.member.Client(), &keypath.MsParam{
 			ServiceName: constant.TSOServiceName,
 			GroupID:     a.keyspaceGroupID,
 		})
-		// skip campaign the primary if the expected primary is not empty and not equal to the current memberValue.
+		if err != nil {
+			// Do not campaign on a read failure: an empty flag would be treated as
+			// "no transfer" and skip the affinity guard, so retry instead.
+			log.Warn("failed to get expected primary flag, retry later", append(a.logFields, errs.ZapError(err))...)
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		// skip campaign the primary if the expected primary is not empty and not this member.
 		// expected primary ONLY SET BY `{service}/primary/transfer` API.
-		if len(expectedPrimary) > 0 && !strings.Contains(a.member.MemberValue(), expectedPrimary) {
+		if len(expectedPrimary) > 0 && !m.IsExpectedPrimary(expectedPrimary) {
 			log.Info("skip campaigning of tso primary and check later", append(a.logFields,
 				zap.String("expected-primary-id", expectedPrimary),
 				zap.String("cur-member-value", m.ParticipantString()))...)
@@ -260,14 +263,27 @@ func (a *Allocator) primaryElectionLoop() {
 			continue
 		}
 
-		a.campaignPrimary()
+		a.campaignPrimary(expectedPrimary)
 	}
 }
 
-func (a *Allocator) campaignPrimary() {
+// campaignPrimary campaigns the TSO primary for this keyspace group. expectedPrimary
+// is the value of the expected primary flag observed before campaigning (empty when
+// no transfer is in progress); it binds the campaign to the transfer target
+// atomically and is cleaned up once this member wins.
+func (a *Allocator) campaignPrimary(expectedPrimary string) {
 	log.Info("start to campaign the primary", a.logFields...)
 	lease := a.cfg.GetLease()
-	if err := a.member.Campaign(a.ctx, lease); err != nil {
+	msParam := &keypath.MsParam{
+		ServiceName: constant.TSOServiceName,
+		GroupID:     a.keyspaceGroupID,
+	}
+	m := a.member.(*member.Participant)
+	var cmps []clientv3.Cmp
+	if cmp := mcsutils.ExpectedPrimaryCmp(msParam, expectedPrimary); cmp != nil {
+		cmps = append(cmps, *cmp)
+	}
+	if err := m.CampaignWithCmps(a.ctx, lease, cmps...); err != nil {
 		if errors.Is(err, errs.ErrEtcdTxnConflict) {
 			log.Info("campaign tso primary meets error due to txn conflict, another tso server may campaign successfully",
 				a.logFields...)
@@ -295,6 +311,11 @@ func (a *Allocator) campaignPrimary() {
 	a.member.GetLeadership().Keep(ctx)
 	log.Info("campaign tso primary ok", a.logFields...)
 
+	// We have won the campaign, so the expected primary flag (if any) has served its
+	// purpose as the affinity guard. Delete it so steady state is clean and a later
+	// failure re-elects immediately instead of waiting for the flag's TTL.
+	mcsutils.DeleteExpectedPrimaryFlag(a.member.Client(), msParam, expectedPrimary)
+
 	log.Info("initializing the tso allocator")
 	if err := a.Initialize(); err != nil {
 		log.Error("failed to initialize the tso allocator", append(a.logFields, errs.ZapError(err))...)
@@ -305,18 +326,6 @@ func (a *Allocator) campaignPrimary() {
 		a.Reset(false)
 	}()
 
-	// check expected primary and watch the primary.
-	exitPrimary := make(chan struct{})
-	primaryLease, err := mcsutils.KeepExpectedPrimaryAlive(ctx, a.member.Client(), exitPrimary,
-		lease, &keypath.MsParam{
-			ServiceName: constant.TSOServiceName,
-			GroupID:     a.keyspaceGroupID,
-		}, a.member.(*member.Participant))
-	if err != nil {
-		log.Error("prepare tso primary watch error", append(a.logFields, errs.ZapError(err))...)
-		return
-	}
-	a.expectedPrimaryLease.Store(primaryLease)
 	a.member.PromoteSelf()
 
 	tsoLabel := fmt.Sprintf("TSO Service Group %d", a.keyspaceGroupID)
@@ -335,16 +344,16 @@ func (a *Allocator) campaignPrimary() {
 	for {
 		select {
 		case <-primaryTicker.C:
+			// Step down once the leader lease is gone. This covers both lease
+			// expiration and a `{service}/primary/transfer` API call, which resigns
+			// this primary by revoking its leader lease.
 			if !a.isServing() {
-				log.Info("no longer a primary because lease has expired, the tso primary will step down", a.logFields...)
+				log.Info("no longer a primary because lease has expired or transferred, the tso primary will step down", a.logFields...)
 				return
 			}
 		case <-ctx.Done():
 			// Server is closed and it should return nil.
 			log.Info("exit primary campaign", a.logFields...)
-			return
-		case <-exitPrimary:
-			log.Info("no longer be primary because primary have been updated, the TSO primary will step down", a.logFields...)
 			return
 		}
 	}
@@ -382,15 +391,6 @@ func (a *Allocator) isPrimaryElected() bool {
 		return false
 	}
 	return a.member.(*member.Participant).IsPrimaryElected()
-}
-
-// GetExpectedPrimaryLease returns the expected primary lease.
-func (a *Allocator) GetExpectedPrimaryLease() *election.Lease {
-	l := a.expectedPrimaryLease.Load()
-	if l == nil {
-		return nil
-	}
-	return l.(*election.Lease)
 }
 
 func (a *Allocator) getMetrics() *tsoMetrics {

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -639,8 +639,8 @@ func (kgm *KeyspaceGroupManager) primaryPriorityCheckLoop() {
 			return
 		case <-ticker.C:
 			// Every primaryPriorityCheckInterval, we only reset the primary of one keyspace group
-			member, kg, localPriority, nextGroupID := kgm.getNextPrimaryToReset(groupID, kgm.tsoServiceID.ServiceAddr)
-			if member != nil {
+			electedMember, kg, localPriority, nextGroupID := kgm.getNextPrimaryToReset(groupID, kgm.tsoServiceID.ServiceAddr)
+			if electedMember != nil {
 				aliveTSONodes := make(map[string]struct{})
 				kgm.tsoNodes.Range(func(key, _ any) bool {
 					aliveTSONodes[typeutil.TrimScheme(key.(string))] = struct{}{}
@@ -682,7 +682,13 @@ func (kgm *KeyspaceGroupManager) primaryPriorityCheckLoop() {
 							zap.String("local-address", kgm.tsoServiceID.ServiceAddr),
 							zap.Uint32("keyspace-group-id", kg.ID),
 							zap.Int("local-priority", localPriority))
-						if err := utils.TransferPrimary(kgm.etcdClient, allocator.GetExpectedPrimaryLease(),
+						participant, ok := allocator.GetMember().(*member.Participant)
+						if !ok {
+							log.Warn("the tso member is not a participant, skip transferring primary",
+								zap.Uint32("keyspace-group-id", kg.ID))
+							continue
+						}
+						if err := utils.TransferPrimary(kgm.etcdClient, participant,
 							mcs.TSOServiceName, kgm.GetServiceConfig().GetName(), "", kg.ID, memberMap); err != nil {
 							log.Error("failed to transfer primary", zap.Error(err))
 							continue

--- a/pkg/utils/keypath/absolute_key_path.go
+++ b/pkg/utils/keypath/absolute_key_path.go
@@ -106,10 +106,12 @@ const (
 	msTsoDefaultPrimaryPathFormat = "/ms/%d/tso/00000/primary"                         // "/ms/{cluster_id}/tso/00000/primary"
 	msTsoKespacePrimaryPathFormat = "/ms/%d/tso/keyspace_groups/election/%05d/primary" // "/ms/{cluster_id}/tso/keyspace_groups/election/{group_id}/primary"
 
-	// `expected_primary` is the flag to indicate the expected primary.
-	// 1. When the primary was campaigned successfully, it will set the `expected_primary` flag.
-	// 2. Using `{service}/primary/transfer` API will revoke the previous lease and set a new `expected_primary` flag.
-	// This flag used to help new primary to campaign successfully while other secondaries can skip the campaign.
+	// `expected_primary` is a transient flag to indicate the expected primary.
+	// It is ONLY written by the `{service}/primary/transfer` API (with a TTL), which
+	// then resigns the current primary; the target member wins the campaign only if
+	// the flag still names it, and deletes the flag (and revokes its lease) once it
+	// wins. In steady state the flag is absent. It lets the transfer target campaign
+	// successfully while other secondaries skip the campaign.
 	msExpectedPrimaryPathFormat            = "/ms/%d/%s/primary/expected_primary"                                // "/ms/{cluster_id}/{service_name}/primary/expected_primary"
 	msTsoDefaultExpectedPrimaryPathFormat  = "/ms/%d/tso/00000/primary/expected_primary"                         // "/ms/{cluster_id}/tso/00000/primary"
 	msTsoKeyspaceExpectedPrimaryPathFormat = "/ms/%d/tso/keyspace_groups/election/%05d/primary/expected_primary" // "/ms/{cluster_id}/tso/keyspace_groups/election/{group_id}/primary"

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -439,8 +439,11 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 		}
 		// Mock the new primary can not grant leader which means the lease will expire
 		re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/skipGrantLeader", `return()`))
+		// Transfer to `newPrimary` explicitly (not a random target), so the expected
+		// primary flag deterministically points at the node we close below. This is
+		// what makes this test actually exercise the marker-TTL-expiry recovery path.
 		newPrimaryData := make(map[string]any)
-		newPrimaryData["new_primary"] = ""
+		newPrimaryData["new_primary"] = newPrimary
 		data, err := json.Marshal(newPrimaryData)
 		re.NoError(err)
 		resp, err := tests.TestDialClient.Post(fmt.Sprintf("%s/%s/api/v1/primary/transfer", primary, strings.ReplaceAll(service, "_", "-")),
@@ -456,15 +459,28 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 		}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 
 		// TODO: Add campaign times check in mcs to avoid frequent campaign
-		// for now, close the current primary to mock the server down
+		// for now, close the transfer target to mock the server down
 		nodes[newPrimary].Close()
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/skipGrantLeader"))
 
-		tests.WaitForPrimaryServing(re, nodes)
-		// Primary should be different with before
-		onlyPrimary, err := suite.pdClient.GetMicroservicePrimary(suite.ctx, service)
-		re.NoError(err)
-		re.NotEqual(newPrimary, onlyPrimary)
+		// The transfer target (which we just closed) is the one named in the expected
+		// primary flag, so the other replicas back off until the flag's TTL (a few
+		// leader leases) expires, after which a free re-election elects a live primary.
+		// Wait long enough to cover that worst case.
+		recoverWait := time.Duration(mcs.TransferPrimaryLeaseMultiplier*mcs.DefaultLease)*time.Second + 10*time.Second
+		serving := make([]string, 0, len(nodes))
+		testutil.Eventually(re, func() bool {
+			serving = serving[:0]
+			for name, s := range nodes {
+				if s.IsServing() {
+					serving = append(serving, name)
+				}
+			}
+			return len(serving) == 1 && serving[0] != newPrimary
+		}, testutil.WithWaitFor(recoverWait), testutil.WithTickInterval(50*time.Millisecond))
+		// Exactly one node serves and it is not the one we closed.
+		re.Len(serving, 1)
+		re.NotEqual(newPrimary, serving[0])
 	}
 }
 
@@ -665,6 +681,83 @@ func (suite *memberTestSuite) TestTransferPrimaryWithKeyspaceGroup() {
 	re.NoError(err)
 	re.Equal(http.StatusBadRequest, resp.StatusCode)
 	resp.Body.Close()
+}
+
+// TestTransferPrimaryWhileLeaseExpiredAndServerDownWithKeyspaceGroup covers the
+// marker-TTL-expiry recovery path for a NON-default keyspace group (the default
+// group is covered by TestTransferPrimaryWhileLeaseExpiredAndServerDown): transfer
+// the group's primary to a specific member, take that member down before it can
+// win, and verify the group recovers a live primary once the flag TTL expires.
+func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDownWithKeyspaceGroup() {
+	re := suite.Require()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
+	}()
+
+	const testGroupID = uint32(1)
+	groupPrimary := suite.mustSetupKeyspaceGroupWithoutKeyspaces(re, testGroupID)
+
+	// Pick a non-primary member of the group as the explicit transfer target.
+	var target, targetAddr string
+	for _, s := range suite.tsoNodes {
+		tsoSvr := s.(*tso.Server)
+		members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+		if m, ok := members[testGroupID]; ok && !m.IsPrimary {
+			target, targetAddr = tsoSvr.Name(), tsoSvr.GetAddr()
+			break
+		}
+	}
+	re.NotEmpty(target)
+
+	// Prevent anyone from granting leadership so the transfer target cannot win.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/skipGrantLeader", `return()`))
+	data, err := json.Marshal(map[string]any{"new_primary": target, "keyspace_group_id": testGroupID})
+	re.NoError(err)
+	resp, err := tests.TestDialClient.Post(
+		fmt.Sprintf("%s/tso/api/v1/primary/transfer", groupPrimary),
+		"application/json", bytes.NewBuffer(data))
+	re.NoError(err)
+	re.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Wait until the old group primary steps down (group temporarily has no primary).
+	testutil.Eventually(re, func() bool {
+		for _, s := range suite.tsoNodes {
+			tsoSvr := s.(*tso.Server)
+			members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+			if m, ok := members[testGroupID]; ok && m.IsPrimary {
+				return false
+			}
+		}
+		return true
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+
+	// Take the transfer target (the node named in the expected primary flag) down,
+	// then allow campaigns again. The remaining group member backs off until the
+	// flag TTL expires, after which a free re-election elects a live primary.
+	suite.tsoNodes[targetAddr].Close()
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/skipGrantLeader"))
+
+	recoverWait := time.Duration(mcs.TransferPrimaryLeaseMultiplier*mcs.DefaultLease)*time.Second + 10*time.Second
+	var recovered string
+	testutil.Eventually(re, func() bool {
+		recovered = ""
+		for addr, s := range suite.tsoNodes {
+			if addr == targetAddr {
+				continue
+			}
+			tsoSvr := s.(*tso.Server)
+			members := mustGetKeyspaceGroupMembers(re, tsoSvr)
+			if m, ok := members[testGroupID]; ok && m.IsPrimary {
+				recovered = tsoSvr.Name()
+				return true
+			}
+		}
+		return false
+	}, testutil.WithWaitFor(recoverWait), testutil.WithTickInterval(100*time.Millisecond))
+	re.NotEmpty(recovered)
+	re.NotEqual(target, recovered)
 }
 
 // TestTransferPrimaryToDefaultGroupFollower verifies that the transfer primary

--- a/tests/integrations/realcluster/etcd_key_test.go
+++ b/tests/integrations/realcluster/etcd_key_test.go
@@ -81,13 +81,15 @@ var (
 		"/pd/cluster_id",
 	}
 	// The keys that prefix is `/ms`.
+	// Note: `expected_primary` is no longer present in steady state. It is only
+	// written transiently by the `{service}/primary/transfer` API and is deleted
+	// once the target wins the campaign (or expires via its TTL), so it must not be
+	// listed as an always-present key here.
 	msKeys = []string{
 		"",
 		"/ms//scheduling/primary",
-		"/ms//scheduling/primary/expected_primary",
 		"/ms//scheduling/registry/http://...:",
 		"/ms//tso//primary",
-		"/ms//tso//primary/expected_primary",
 		"/ms//tso/registry/http://...:",
 	}
 	// These keys with `/pd` are only in `ms` mode.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10875

The microservice primary used to keep an `expected_primary` etcd key alive
with a dedicated lease for its whole tenure and run a watch goroutine
(`KeepExpectedPrimaryAlive`) to learn about a transfer. That second lease
could desync from the leader key: when the key was deleted while its lease
persisted, the next campaign read an empty flag, bypassed the guard, and
then failed with `ErrEtcdTxnConflict` because the old primary's leader key
still existed — disrupting the election (#10875).

### What is changed and how does it work?

Replace the persistent keepalive + watch with a transient, self-cleaning flow:

```commit-message
- `expected_primary` is only written by the `{service}/primary/transfer`
  API now, with a TTL of a few leader leases (`TransferPrimaryLeaseMultiplier`
  times the leader lease); it is no longer kept alive for the primary's whole
  tenure.
- `TransferPrimary` marks the target first, then resigns the current primary
  by revoking its leader lease. `IsServing()` flips to false immediately, so
  the existing primary ticker steps the old primary down — the watch
  goroutine is gone.
- The campaign is made atomic via `CampaignWithCmps`: when a marker is
  observed, `expected_primary == observed-value` is appended to the
  leader-key txn, so the target wins only if the marker still names it.
- The affinity guard matches the marker against the participant's listen URLs
  exactly (`Participant.IsExpectedPrimary`) instead of a substring search of
  the serialized member value, so one member's address being a substring of
  another's value cannot misroute a transfer.
- The new primary CAS-deletes the marker once it wins and revokes the
  marker's lease, leaving neither the key nor a dangling lease (avoiding the
  "key deleted but lease persists" state from #10875).
- `Lease.GetTimeoutSeconds` falls back to `constant.DefaultLease` for a
  nil/ungranted lease, and `Lease.Close` is idempotent so resigning from both
  the transfer path and the election loop does not double-revoke or log
  spurious errors.
- Remove the now-dead `primaryWatch` / `IsPrimary` / `SetPrimaryWatch` and
  the PUT branch in `Leadership.Watch`, plus the `expectedPrimaryLease` field
  and accessors on `Participant` and the TSO `Allocator`.
```

Behavior note: if a transfer target dies before winning the campaign, the
cluster has no primary until the flag TTL (a few leader leases) expires and a
free election takes over (covered by the updated server-down test).

#### Upgrade compatibility

This is not a hard backward-incompatible change; a mixed old/new cluster
stays available and transfers still converge:

- A transfer is always executed by the node that is currently primary, using
  its own binary, so the "mark + step-down" path is never split across
  versions.
- The `expected_primary` value is the member's advertise address; both the old
  substring guard and the new exact guard accept it, so the formats interoperate.
- No double primary (both versions campaign with `CreateRevision(leaderKey)
  == 0`) and no permanent leaderless state (every marker has a finite TTL).
- An empty marker (new steady state) and a lingering kept-alive marker (old
  steady state) are both handled correctly by the other version.

The only things that require the whole cluster to be on the new version are
the strict "only the named target wins under racing transfers" guarantee and
the leader-lease-proportional fallback TTL. Recommendation: avoid invoking
`primary/transfer` during the rolling upgrade window; use it once the upgrade
completes.

### Check List

Tests

- Unit test
- Integration test
[transfer-primary-test.md](https://github.com/user-attachments/files/29686224/transfer-primary-test.md)


### Release note

```release-note
Fix a corner case where a microservice (TSO/scheduling/resource_manager)
primary election could be disrupted by an etcd transaction conflict when the
expected primary key was deleted while its lease still persisted.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Primary transfers now use a transient “expected primary” affinity window to conditionally allow campaigning for smoother leadership handoffs.
- **Bug Fixes**
  - Removed stale expected-primary keepalive/watch behavior and clear the affinity guard after a successful campaign.
  - Leadership step-down now relies on actual serving/lease state rather than a separate auxiliary signal.
  - Updated expected-primary transfer/eligibility handling, including the TTL/timeout calculation behavior.
- **Tests**
  - Updated primary-transfer integration assertions and recovery timing for the new transient affinity behavior.
  - Adjusted real-cluster etcd key expectations to reflect expected-primary being transient only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->