### PR TITLE
tests: keep initial cluster URLs consistent on retry

### DIFF
--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -46,7 +46,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/syncutil"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/api"
 	"github.com/tikv/pd/server/apiv2"
@@ -738,14 +737,12 @@ func (c *TestCluster) runInitialServersWithRetry(maxRetries int) error {
 				_ = s.Destroy()
 			}
 
+			// Regenerate all ports before building any server configs. Generate reads
+			// every initial server's peer URL when composing the initial cluster.
+			c.config.regenerateInitialServerURLs()
+
 			// Recreate servers with new ports
 			for _, conf := range c.config.InitialServers {
-				// Regenerate config to get new ports
-				conf.ClientURLs = tempurl.Alloc()
-				conf.PeerURLs = tempurl.Alloc()
-				conf.AdvertiseClientURLs = conf.ClientURLs
-				conf.AdvertisePeerURLs = conf.PeerURLs
-
 				// Use the original opts passed during cluster creation
 				allOpts := append([]ConfigOption{WithGCTuner(false)}, c.opts...)
 				serverConf, err := conf.Generate(allOpts...)

--- a/tests/cluster.go
+++ b/tests/cluster.go
@@ -702,6 +702,21 @@ func (c *TestCluster) RunInitialServers() error {
 	return c.runInitialServersWithRetry(defaultMaxRetryTimes)
 }
 
+func (c *TestCluster) regenerateInitialServerConfigs() ([]*config.Config, error) {
+	c.config.regenerateInitialServerURLs()
+
+	serverConfs := make([]*config.Config, 0, len(c.config.InitialServers))
+	allOpts := append([]ConfigOption{WithGCTuner(false)}, c.opts...)
+	for _, conf := range c.config.InitialServers {
+		serverConf, err := conf.Generate(allOpts...)
+		if err != nil {
+			return nil, err
+		}
+		serverConfs = append(serverConfs, serverConf)
+	}
+	return serverConfs, nil
+}
+
 // runInitialServersWithRetry starts to run servers with port conflict handling.
 func (c *TestCluster) runInitialServersWithRetry(maxRetries int) error {
 	if maxRetries <= 0 {
@@ -739,22 +754,19 @@ func (c *TestCluster) runInitialServersWithRetry(maxRetries int) error {
 
 			// Regenerate all ports before building any server configs. Generate reads
 			// every initial server's peer URL when composing the initial cluster.
-			c.config.regenerateInitialServerURLs()
+			serverConfs, err := c.regenerateInitialServerConfigs()
+			if err != nil {
+				return err
+			}
 
 			// Recreate servers with new ports
-			for _, conf := range c.config.InitialServers {
-				// Use the original opts passed during cluster creation
-				allOpts := append([]ConfigOption{WithGCTuner(false)}, c.opts...)
-				serverConf, err := conf.Generate(allOpts...)
-				if err != nil {
-					return err
-				}
-
+			for i, serverConf := range serverConfs {
 				// Use the original services passed during cluster creation
 				s, err := NewTestServer(c.ctx, serverConf, c.services)
 				if err != nil {
 					return err
 				}
+				conf := c.config.InitialServers[i]
 				c.servers[conf.Name] = s
 			}
 

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,7 +23,9 @@ import (
 
 	"github.com/pingcap/errors"
 
+	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
+	serverconfig "github.com/tikv/pd/server/config"
 )
 
 func TestMain(m *testing.M) {
@@ -60,23 +63,52 @@ func TestRegenerateInitialServerURLsKeepsInitialClusterConsistent(t *testing.T) 
 
 	re := require.New(t)
 	config := newClusterConfig(3)
-	oldPeerURLs := []string{
-		"http://127.0.0.1:1",
-		"http://127.0.0.1:2",
-		"http://127.0.0.1:3",
-	}
-	for i, server := range config.InitialServers {
-		server.PeerURLs = oldPeerURLs[i]
+	cleanupClusterConfig(t, config)
+	cluster := &TestCluster{
+		config: config,
+		opts: []ConfigOption{
+			func(conf *serverconfig.Config, _ string) {
+				conf.InitialClusterToken = "retry-token"
+			},
+		},
 	}
 
-	config.regenerateInitialServerURLs()
-	initialCluster := config.getServerAddrs()
-	for i, server := range config.InitialServers {
-		re.NotEqual(oldPeerURLs[i], server.PeerURLs)
+	regenerateServerURLs := func(server *serverConfig) {
+		server.ClientURLs = tempurl.Alloc()
+		server.PeerURLs = tempurl.Alloc()
+		server.AdvertiseClientURLs = server.ClientURLs
+		server.AdvertisePeerURLs = server.PeerURLs
 	}
+
+	regenerateServerURLs(config.InitialServers[0])
+	firstConf, err := config.InitialServers[0].Generate(WithGCTuner(false))
+	re.NoError(err)
+	regenerateServerURLs(config.InitialServers[1])
+	secondConf, err := config.InitialServers[1].Generate(WithGCTuner(false))
+	re.NoError(err)
+	re.NotEqual(firstConf.InitialCluster, secondConf.InitialCluster)
+
+	serverConfs, err := cluster.regenerateInitialServerConfigs()
+	re.NoError(err)
+	re.Len(serverConfs, len(config.InitialServers))
+
+	expectedInitialCluster := config.getServerAddrs()
 	for _, server := range config.InitialServers {
-		conf, err := server.Generate()
-		re.NoError(err)
-		re.Equal(initialCluster, conf.InitialCluster)
+		re.Contains(expectedInitialCluster, server.PeerURLs)
+	}
+	for _, conf := range serverConfs {
+		re.Equal(expectedInitialCluster, conf.InitialCluster)
+		re.Equal("retry-token", conf.InitialClusterToken)
+		re.False(conf.PDServerCfg.EnableGOGCTuner)
+	}
+}
+
+func cleanupClusterConfig(t *testing.T, config *clusterConfig) {
+	t.Helper()
+	for _, server := range config.InitialServers {
+		dataDir := server.DataDir
+		t.Cleanup(func() {
+			require.NoError(t, os.RemoveAll(dataDir))
+		})
 	}
 }

--- a/tests/cluster_test.go
+++ b/tests/cluster_test.go
@@ -54,3 +54,29 @@ func TestClassifyInitialServersError(t *testing.T) {
 	re.Equal(startServersNoRetry, classifyInitialServersError(errors.New("some other error")))
 	re.Equal(startServersNoRetry, classifyInitialServersError(nil))
 }
+
+func TestRegenerateInitialServerURLsKeepsInitialClusterConsistent(t *testing.T) {
+	t.Parallel()
+
+	re := require.New(t)
+	config := newClusterConfig(3)
+	oldPeerURLs := []string{
+		"http://127.0.0.1:1",
+		"http://127.0.0.1:2",
+		"http://127.0.0.1:3",
+	}
+	for i, server := range config.InitialServers {
+		server.PeerURLs = oldPeerURLs[i]
+	}
+
+	config.regenerateInitialServerURLs()
+	initialCluster := config.getServerAddrs()
+	for i, server := range config.InitialServers {
+		re.NotEqual(oldPeerURLs[i], server.PeerURLs)
+	}
+	for _, server := range config.InitialServers {
+		conf, err := server.Generate()
+		re.NoError(err)
+		re.Equal(initialCluster, conf.InitialCluster)
+	}
+}

--- a/tests/config.go
+++ b/tests/config.go
@@ -118,6 +118,15 @@ func (c *clusterConfig) join() *serverConfig {
 	return sc
 }
 
+func (c *clusterConfig) regenerateInitialServerURLs() {
+	for _, s := range c.InitialServers {
+		s.ClientURLs = tempurl.Alloc()
+		s.PeerURLs = tempurl.Alloc()
+		s.AdvertiseClientURLs = s.ClientURLs
+		s.AdvertisePeerURLs = s.PeerURLs
+	}
+}
+
 func (c *clusterConfig) nextServerName() string {
 	return fmt.Sprintf("pd%d", len(c.InitialServers)+len(c.JoinServers)+1)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10954

### What is changed and how does it work?

```commit-message
Regenerate all initial server URLs before rebuilding any server configs
during initial server startup retry. This keeps every recreated server's
initial-cluster value consistent and prevents a retry from mixing old
and new peer URLs, which can trigger etcd cluster ID mismatch errors.
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when restarting or recreating initial cluster servers.
  * Reduced the chance of inconsistent client/peer and advertise URLs during cluster setup and recovery by refreshing them in a consistent, coordinated way.
  * Ensured regenerated initial server settings preserve the configured initial cluster token and stay aligned on the same initial cluster membership.
* **Tests**
  * Added coverage to verify initial cluster consistency after regenerating initial server configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->