### PR TITLE
keyspace: unassign tombstone keyspace from meta service group

### DIFF
--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -1109,8 +1109,15 @@ func (manager *Manager) UpdateKeyspaceStateByID(id uint32, newState keyspacepb.K
 // meta-service group manager is configured, decrements the persisted assignment
 // count. Once the config key is removed and persisted, a subsequent call is a
 // no-op, so the removal and tombstone paths can both invoke it without
-// double-counting. Callers must hold the keyspace metaLock so meta is not
-// mutated concurrently.
+// double-counting.
+//
+// Callers already hold the keyspace metaLock (so meta is not mutated
+// concurrently). This deliberately does NOT take mgm.RLock: the config-update
+// path acquires mgm.RLock before metaLock (via runTxnWithMetaGroupLock), so
+// grabbing mgm.RLock here while holding metaLock would invert the lock order and
+// deadlock once UpdateGroupsSafely is waiting on mgm.Lock. The lock is
+// unnecessary anyway — updateAssignmentTxn only touches the store, and the
+// group delete guard relies on the authoritative keyspace scan, not this count.
 func (manager *Manager) unassignKeyspaceFromMetaServiceGroup(txn kv.Txn, meta *keyspacepb.KeyspaceMeta) error {
 	groupID := meta.GetConfig()[MetaServiceGroupIDKey]
 	if groupID == "" {
@@ -1120,8 +1127,6 @@ func (manager *Manager) unassignKeyspaceFromMetaServiceGroup(txn kv.Txn, meta *k
 	if manager.mgm == nil {
 		return nil
 	}
-	manager.mgm.RLock()
-	defer manager.mgm.RUnlock()
 	return manager.mgm.updateAssignmentTxn(txn, groupID, "")
 }
 

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -1005,7 +1005,7 @@ func (manager *Manager) UpdateKeyspaceState(name string, newState keyspacepb.Key
 			return errs.ErrKeyspaceNotFound
 		}
 		// Update keyspace meta.
-		if err = manager.transformKeyspaceState(meta, newState, now); err != nil {
+		if err = manager.transformKeyspaceState(txn, meta, newState, now); err != nil {
 			return err
 		}
 		return manager.store.SaveKeyspaceMeta(txn, meta)
@@ -1056,14 +1056,7 @@ func (manager *Manager) RemoveKeyspace(txn kv.Txn, id uint32) error {
 	// persisted counter stays in sync with the keyspaces actually referencing the
 	// group. Without this, removed keyspaces leak count and could permanently
 	// block deleting an otherwise-empty group.
-	if manager.mgm != nil {
-		if groupID := meta.GetConfig()[MetaServiceGroupIDKey]; groupID != "" {
-			if err := manager.mgm.updateAssignmentTxn(txn, groupID, ""); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return manager.unassignKeyspaceFromMetaServiceGroup(txn, meta)
 }
 
 // UpdateKeyspaceStateByID updates target keyspace to the given state if it's not already in that state.
@@ -1088,7 +1081,7 @@ func (manager *Manager) UpdateKeyspaceStateByID(id uint32, newState keyspacepb.K
 			return errs.ErrKeyspaceNotFound
 		}
 		// Update keyspace meta.
-		if err = manager.transformKeyspaceState(meta, newState, now); err != nil {
+		if err = manager.transformKeyspaceState(txn, meta, newState, now); err != nil {
 			return err
 		}
 		return manager.store.SaveKeyspaceMeta(txn, meta)
@@ -1112,8 +1105,22 @@ func (manager *Manager) UpdateKeyspaceStateByID(id uint32, newState keyspacepb.K
 	return meta, nil
 }
 
+func (manager *Manager) unassignKeyspaceFromMetaServiceGroup(txn kv.Txn, meta *keyspacepb.KeyspaceMeta) error {
+	groupID := meta.GetConfig()[MetaServiceGroupIDKey]
+	if groupID == "" {
+		return nil
+	}
+	delete(meta.Config, MetaServiceGroupIDKey)
+	if manager.mgm == nil {
+		return nil
+	}
+	manager.mgm.RLock()
+	defer manager.mgm.RUnlock()
+	return manager.mgm.updateAssignmentTxn(txn, groupID, "")
+}
+
 // transformKeyspaceState transforms the keyspace state to the target state and record the update time.
-func (manager *Manager) transformKeyspaceState(meta *keyspacepb.KeyspaceMeta, newState keyspacepb.KeyspaceState, now int64) error {
+func (manager *Manager) transformKeyspaceState(txn kv.Txn, meta *keyspacepb.KeyspaceMeta, newState keyspacepb.KeyspaceState, now int64) error {
 	// If already in the target state, do nothing and return.
 	if meta.GetState() == newState {
 		return nil
@@ -1121,6 +1128,11 @@ func (manager *Manager) transformKeyspaceState(meta *keyspacepb.KeyspaceMeta, ne
 	// Consult state transition table to check if the operation is legal.
 	if !slice.Contains(stateTransitionTable[meta.GetState()], newState) {
 		return errors.Errorf("cannot change keyspace state from %s to %s", meta.GetState().String(), newState.String())
+	}
+	if newState == keyspacepb.KeyspaceState_TOMBSTONE {
+		if err := manager.unassignKeyspaceFromMetaServiceGroup(txn, meta); err != nil {
+			return err
+		}
 	}
 	// If the operation is legal, update keyspace state and change time.
 	meta.State = newState

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -1127,8 +1127,14 @@ func (manager *Manager) unassignKeyspaceFromMetaServiceGroup(txn kv.Txn, meta *k
 
 // transformKeyspaceState transforms the keyspace state to the target state and record the update time.
 func (manager *Manager) transformKeyspaceState(txn kv.Txn, meta *keyspacepb.KeyspaceMeta, newState keyspacepb.KeyspaceState, now int64) error {
-	// If already in the target state, do nothing and return.
+	// If already in the target state, do nothing and return. A TOMBSTONE keyspace
+	// still carrying a meta-service group binding (e.g. one tombstoned before this
+	// cleanup existed) is repaired here by re-applying the TOMBSTONE update; the
+	// unassignment is idempotent, so it is a no-op once the binding is cleared.
 	if meta.GetState() == newState {
+		if newState == keyspacepb.KeyspaceState_TOMBSTONE {
+			return manager.unassignKeyspaceFromMetaServiceGroup(txn, meta)
+		}
 		return nil
 	}
 	// Consult state transition table to check if the operation is legal.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -1052,10 +1052,9 @@ func (manager *Manager) RemoveKeyspace(txn kv.Txn, id uint32) error {
 	}
 	manager.keyspaceNameLookup.Delete(id)
 	manager.keyspaceStateLookup.Delete(id)
-	// Decrement the meta-service group assignment count in the same txn so the
-	// persisted counter stays in sync with the keyspaces actually referencing the
-	// group. Without this, removed keyspaces leak count and could permanently
-	// block deleting an otherwise-empty group.
+	// Keep the meta-service group assignment accounting in sync within the same
+	// txn. Without this, removed keyspaces leak count and could permanently block
+	// deleting an otherwise-empty group.
 	return manager.unassignKeyspaceFromMetaServiceGroup(txn, meta)
 }
 
@@ -1105,6 +1104,13 @@ func (manager *Manager) UpdateKeyspaceStateByID(id uint32, newState keyspacepb.K
 	return meta, nil
 }
 
+// unassignKeyspaceFromMetaServiceGroup removes the keyspace's meta-service group
+// binding within txn: it drops MetaServiceGroupIDKey from the config and, when a
+// meta-service group manager is configured, decrements the persisted assignment
+// count. Once the config key is removed and persisted, a subsequent call is a
+// no-op, so the removal and tombstone paths can both invoke it without
+// double-counting. Callers must hold the keyspace metaLock so meta is not
+// mutated concurrently.
 func (manager *Manager) unassignKeyspaceFromMetaServiceGroup(txn kv.Txn, meta *keyspacepb.KeyspaceMeta) error {
 	groupID := meta.GetConfig()[MetaServiceGroupIDKey]
 	if groupID == "" {

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -1113,3 +1113,42 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 	re.NoError(managerWithGroup.assignGroupAndSaveKeyspace(true, &cfg2, ks2))
 	re.Equal("g1", ks2.GetConfig()[MetaServiceGroupIDKey])
 }
+
+func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup() {
+	re := suite.Require()
+	manager := suite.manager
+	groupID := "etcd-group-0"
+	metaServiceGroupStore, ok := manager.store.(endpoint.MetaServiceGroupStorage)
+	re.True(ok)
+	manager.mgm = NewMetaServiceGroupManager(metaServiceGroupStore, map[string]string{
+		groupID: "etcd-group-0.tidb-serverless.cluster.svc.local",
+	})
+	manager.mgm.SetKeyspaceAssignmentCounter(manager.CountKeyspacesByMetaServiceGroup)
+
+	created, err := manager.CreateKeyspace(&CreateKeyspaceRequest{
+		Name:       "test_ks_msg",
+		Config:     map[string]string{},
+		CreateTime: time.Now().Unix(),
+	})
+	re.NoError(err)
+	re.Equal(groupID, created.GetConfig()[MetaServiceGroupIDKey])
+
+	counts, err := manager.mgm.GetAssignmentCounts(suite.ctx)
+	re.NoError(err)
+	re.Equal(1, counts[groupID])
+
+	_, err = manager.UpdateKeyspaceState(created.GetName(), keyspacepb.KeyspaceState_DISABLED, time.Now().Unix())
+	re.NoError(err)
+	_, err = manager.UpdateKeyspaceState(created.GetName(), keyspacepb.KeyspaceState_ARCHIVED, time.Now().Unix())
+	re.NoError(err)
+	updated, err := manager.UpdateKeyspaceState(created.GetName(), keyspacepb.KeyspaceState_TOMBSTONE, time.Now().Unix())
+	re.NoError(err)
+	re.NotContains(updated.GetConfig(), MetaServiceGroupIDKey)
+
+	loaded, err := manager.LoadKeyspace(created.GetName())
+	re.NoError(err)
+	re.NotContains(loaded.GetConfig(), MetaServiceGroupIDKey)
+	counts, err = manager.mgm.GetAssignmentCounts(suite.ctx)
+	re.NoError(err)
+	re.Equal(0, counts[groupID])
+}

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -1151,4 +1151,14 @@ func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup()
 	counts, err = manager.mgm.GetAssignmentCounts(suite.ctx)
 	re.NoError(err)
 	re.Equal(0, counts[groupID])
+
+	// Removing the already-tombstoned keyspace must not decrement the counter
+	// again: the group binding was cleared and persisted during the tombstone
+	// transition, so unassignment is a no-op and the count stays at zero.
+	re.NoError(manager.store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+		return manager.RemoveKeyspace(txn, updated.GetId())
+	}))
+	counts, err = manager.mgm.GetAssignmentCounts(suite.ctx)
+	re.NoError(err)
+	re.Equal(0, counts[groupID])
 }

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -1118,11 +1118,12 @@ func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup()
 	re := suite.Require()
 	manager := suite.manager
 	groupID := "etcd-group-0"
+	groupEndpoint := "etcd-group-0.tidb-serverless.cluster.svc.local"
 	metaServiceGroupStore, ok := manager.store.(endpoint.MetaServiceGroupStorage)
 	re.True(ok)
-	manager.mgm = NewMetaServiceGroupManager(metaServiceGroupStore, map[string]string{
-		groupID: "etcd-group-0.tidb-serverless.cluster.svc.local",
-	})
+	// Start without any group so creation never auto-assigns: meta-service groups
+	// are disabled by default, and this keeps the test independent of that.
+	manager.mgm = NewMetaServiceGroupManager(metaServiceGroupStore, map[string]string{})
 	manager.mgm.SetKeyspaceAssignmentCounter(manager.CountKeyspacesByMetaServiceGroup)
 
 	created, err := manager.CreateKeyspace(&CreateKeyspaceRequest{
@@ -1131,7 +1132,28 @@ func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup()
 		CreateTime: time.Now().Unix(),
 	})
 	re.NoError(err)
-	re.Equal(groupID, created.GetConfig()[MetaServiceGroupIDKey])
+	re.NotContains(created.GetConfig(), MetaServiceGroupIDKey)
+
+	// Make the group available and assign the keyspace to it explicitly, mirroring
+	// what a meta-service-group-enabled cluster persists.
+	assignKeyspaceToGroup := func(id uint32) {
+		re.NoError(manager.store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+			meta, err := manager.store.LoadKeyspaceMeta(txn, id)
+			if err != nil {
+				return err
+			}
+			if meta.Config == nil {
+				meta.Config = map[string]string{}
+			}
+			meta.Config[MetaServiceGroupIDKey] = groupID
+			if err := manager.store.SaveKeyspaceMeta(txn, meta); err != nil {
+				return err
+			}
+			return manager.mgm.updateAssignmentTxn(txn, "", groupID)
+		}))
+	}
+	manager.mgm.updateGroups(map[string]string{groupID: groupEndpoint})
+	assignKeyspaceToGroup(created.GetId())
 
 	counts, err := manager.mgm.GetAssignmentCounts(suite.ctx)
 	re.NoError(err)
@@ -1148,6 +1170,20 @@ func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup()
 	loaded, err := manager.LoadKeyspace(created.GetName())
 	re.NoError(err)
 	re.NotContains(loaded.GetConfig(), MetaServiceGroupIDKey)
+	counts, err = manager.mgm.GetAssignmentCounts(suite.ctx)
+	re.NoError(err)
+	re.Equal(0, counts[groupID])
+
+	// A keyspace tombstoned before this cleanup existed still carries the group
+	// binding and an inflated counter. Re-applying the TOMBSTONE state (a
+	// same-state update) must repair it rather than being skipped.
+	assignKeyspaceToGroup(updated.GetId())
+	counts, err = manager.mgm.GetAssignmentCounts(suite.ctx)
+	re.NoError(err)
+	re.Equal(1, counts[groupID])
+	repaired, err := manager.UpdateKeyspaceState(created.GetName(), keyspacepb.KeyspaceState_TOMBSTONE, time.Now().Unix())
+	re.NoError(err)
+	re.NotContains(repaired.GetConfig(), MetaServiceGroupIDKey)
 	counts, err = manager.mgm.GetAssignmentCounts(suite.ctx)
 	re.NoError(err)
 	re.Equal(0, counts[groupID])


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10891

This is a cherry-pick of <https://github.com/tikv/pd/commit/60279efd68c61fc61ff470e3b4f902f45dfaf304> from the PD microservices branch.

Original author: @ystaticy

Problem Summary:

When a keyspace is moved to `TOMBSTONE`, it could still keep `meta_service_group_id` in its config and the meta service group assignment counter could remain inflated. That stale assignment can block deleting an otherwise-empty meta service group.

### What is changed and how does it work?

- Unassign a keyspace from its meta service group in the same transaction when the keyspace transitions to `TOMBSTONE`.
- Remove `meta_service_group_id` from the keyspace config and decrement the persisted assignment count through the meta service group manager.
- Reuse the same unassignment helper from `RemoveKeyspace` so removal and tombstone paths keep assignment accounting consistent.
- Adapt the cherry-pick to current master, which keeps the existing `UpdateKeyspaceState` API.
- Add regression coverage for tombstoning an assigned keyspace and verifying both metadata cleanup and assignment count decrement.

### Check List

Tests

- Unit test

Code changes

- Has persistent data change

Side effects

- No compatibility impact

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Unassign keyspace from meta service group when setting it to tombstone.
```

### Validation

- `GOFLAGS=-buildvcs=false make gotest GOTEST_ARGS='./pkg/keyspace -run TestKeyspaceTestSuite/TestTombstoneKeyspaceUnassignsMetaServiceGroup -count=1 -timeout=5m'`
- `GOFLAGS=-buildvcs=false make gotest GOTEST_ARGS='./pkg/keyspace -run TestKeyspaceTestSuite/TestUpdateKeyspaceState -count=1 -timeout=5m'`
- `git diff --check && git diff --cached --check`
- `GOFLAGS=-buildvcs=false make check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyspaces transitioned to **TOMBSTONE** now unbind their MetaServiceGroup configuration and clear the persisted assignment, preventing stale counter effects.
  * MetaServiceGroup assignment updates are now applied transaction-scope with keyspace meta updates to keep metrics consistent across state changes.
  * **RemoveKeyspace** no longer over-decrements the MetaServiceGroup assignment counter for already-tombstoned keyspaces.
* **Tests**
  * Added coverage for **DISABLED/ARCHIVED → TOMBSTONE**, idempotent TOMBSTONE re-application “repair,” and counter correctness after removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->