### PR TITLE
schedule, metrics: add region label status

### DIFF
--- a/metrics/grafana/pd.json
+++ b/metrics/grafana/pd.json
@@ -1157,7 +1157,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 6,
-        "w": 8,
+        "w": 4,
         "x": 16,
         "y": 13
       },
@@ -1209,6 +1209,109 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Placement Rules Status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_TEST-CLUSTER}",
+      "description": "The current region label rule and range count of the cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 115,
+      "interval": null,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxDataPoints": 100,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(pd_region_label_status{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}) by (type)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "A",
+          "step": 4
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Region Label Status",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -218,36 +218,21 @@ func (l *RegionLabeler) GetAllLabelRules() []*LabelRule {
 	return rules
 }
 
-// GetRulesCount returns the number of effective label rules.
-func (l *RegionLabeler) GetRulesCount() int {
+// GetRuleAndKeyRangeCounts returns the number of effective label rules and key ranges.
+func (l *RegionLabeler) GetRuleAndKeyRangeCounts() (ruleCount, keyRangeCount int) {
 	l.RLock()
 	defer l.RUnlock()
 
 	now := time.Now()
-	count := 0
-	for _, rule := range l.labelRules {
-		if filterExpiredLabels(rule, now) != nil {
-			count++
-		}
-	}
-	return count
-}
-
-// GetKeyRangesCount returns the number of effective key ranges.
-func (l *RegionLabeler) GetKeyRangesCount() int {
-	l.RLock()
-	defer l.RUnlock()
-
-	now := time.Now()
-	count := 0
 	for _, rule := range l.labelRules {
 		filteredRule := filterExpiredLabels(rule, now)
 		if filteredRule == nil {
 			continue
 		}
-		count += len(filteredRule.GetKeyRanges())
+		ruleCount++
+		keyRangeCount += len(filteredRule.GetKeyRanges())
 	}
-	return count
+	return ruleCount, keyRangeCount
 }
 
 // GetLabelRules returns the rules that match the given ids.

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -218,6 +218,38 @@ func (l *RegionLabeler) GetAllLabelRules() []*LabelRule {
 	return rules
 }
 
+// GetRulesCount returns the number of effective label rules.
+func (l *RegionLabeler) GetRulesCount() int {
+	l.RLock()
+	defer l.RUnlock()
+
+	now := time.Now()
+	count := 0
+	for _, rule := range l.labelRules {
+		if filterExpiredLabels(rule, now) != nil {
+			count++
+		}
+	}
+	return count
+}
+
+// GetKeyRangesCount returns the number of effective key ranges.
+func (l *RegionLabeler) GetKeyRangesCount() int {
+	l.RLock()
+	defer l.RUnlock()
+
+	now := time.Now()
+	count := 0
+	for _, rule := range l.labelRules {
+		filteredRule := filterExpiredLabels(rule, now)
+		if filteredRule == nil {
+			continue
+		}
+		count += len(filteredRule.GetKeyRanges())
+	}
+	return count
+}
+
 // GetLabelRules returns the rules that match the given ids.
 func (l *RegionLabeler) GetLabelRules(ids []string) ([]*LabelRule, error) {
 	l.RLock()

--- a/pkg/schedule/labeler/labeler_test.go
+++ b/pkg/schedule/labeler/labeler_test.go
@@ -106,17 +106,21 @@ func TestGetSetRule(t *testing.T) {
 	defer cancel()
 	labeler, err := NewRegionLabeler(ctx, store, time.Millisecond*10)
 	re.NoError(err)
+	assertLabelerCounts := func(ruleCount, keyRangeCount int) {
+		actualRuleCount, actualKeyRangeCount := labeler.GetRuleAndKeyRangeCounts()
+		re.Equal(ruleCount, actualRuleCount)
+		re.Equal(keyRangeCount, actualKeyRangeCount)
+	}
 	rules := []*LabelRule{
 		{ID: "rule1", Labels: []RegionLabel{{Key: "k1", Value: "v1"}}, RuleType: "key-range", Data: MakeKeyRanges("1234", "5678")},
 		{ID: "rule2", Labels: []RegionLabel{{Key: "k2", Value: "v2"}}, RuleType: "key-range", Data: MakeKeyRanges("ab12", "cd12")},
-		{ID: "rule3", Labels: []RegionLabel{{Key: "k3", Value: "v3"}}, RuleType: "key-range", Data: MakeKeyRanges("abcd", "efef")},
+		{ID: "rule3", Labels: []RegionLabel{{Key: "k3", Value: "v3"}}, RuleType: "key-range", Data: MakeKeyRanges("abcd", "efef", "f000", "ffff")},
 	}
 	for _, r := range rules {
 		err := labeler.SetLabelRule(r)
 		re.NoError(err)
 	}
-	re.Equal(3, labeler.GetRulesCount())
-	re.Equal(3, labeler.GetKeyRangesCount())
+	assertLabelerCounts(3, 4)
 
 	allRules := labeler.GetAllLabelRules()
 	sort.Slice(allRules, func(i, j int) bool { return allRules[i].ID < allRules[j].ID })
@@ -129,8 +133,7 @@ func TestGetSetRule(t *testing.T) {
 	err = labeler.DeleteLabelRule("rule2")
 	re.NoError(err)
 	re.Nil(labeler.GetLabelRule("rule2"))
-	re.Equal(2, labeler.GetRulesCount())
-	re.Equal(2, labeler.GetKeyRangesCount())
+	assertLabelerCounts(2, 3)
 	byIDs, err = labeler.GetLabelRules([]string{"rule1", "rule2"})
 	re.NoError(err)
 	re.Equal([]*LabelRule{rules[0]}, byIDs)
@@ -146,8 +149,7 @@ func TestGetSetRule(t *testing.T) {
 	re.NoError(err)
 	allRules = labeler.GetAllLabelRules()
 	sort.Slice(allRules, func(i, j int) bool { return allRules[i].ID < allRules[j].ID })
-	re.Equal(2, labeler.GetRulesCount())
-	re.Equal(2, labeler.GetKeyRangesCount())
+	assertLabelerCounts(2, 3)
 	for id, rule := range allRules {
 		expectSameRules(re, rule, rules[id+1])
 	}
@@ -158,8 +160,7 @@ func TestGetSetRule(t *testing.T) {
 		re.NoError(err)
 	}
 	re.Empty(labeler.GetAllLabelRules())
-	re.Zero(labeler.GetRulesCount())
-	re.Zero(labeler.GetKeyRangesCount())
+	assertLabelerCounts(0, 0)
 }
 
 func TestTxnWithEtcd(t *testing.T) {
@@ -380,6 +381,11 @@ func TestLabelerRuleTTL(t *testing.T) {
 	defer cancel()
 	labeler, err := NewRegionLabeler(ctx, store, time.Minute)
 	re.NoError(err)
+	assertLabelerCounts := func(ruleCount, keyRangeCount int) {
+		actualRuleCount, actualKeyRangeCount := labeler.GetRuleAndKeyRangeCounts()
+		re.Equal(ruleCount, actualRuleCount)
+		re.Equal(keyRangeCount, actualKeyRangeCount)
+	}
 	rules := []*LabelRule{
 		{
 			ID: "rule1",
@@ -417,8 +423,7 @@ func TestLabelerRuleTTL(t *testing.T) {
 		err := labeler.SetLabelRule(r)
 		re.NoError(err)
 	}
-	re.Equal(3, labeler.GetRulesCount())
-	re.Equal(3, labeler.GetKeyRangesCount())
+	assertLabelerCounts(3, 3)
 	// get rule with "rule2".
 	re.NotNil(labeler.GetLabelRule("rule2"))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/labeler/regionLabelExpireSub1Minute", "return(true)"))
@@ -428,8 +433,7 @@ func TestLabelerRuleTTL(t *testing.T) {
 		labels := labeler.GetRegionLabels(region)
 		return len(labels) == 2
 	})
-	re.Equal(2, labeler.GetRulesCount())
-	re.Equal(2, labeler.GetKeyRangesCount())
+	assertLabelerCounts(2, 2)
 
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/labeler/regionLabelExpireSub1Minute"))
 	// rule2 should be existed since `GetRegionLabels` won't clear it physically.

--- a/pkg/schedule/labeler/labeler_test.go
+++ b/pkg/schedule/labeler/labeler_test.go
@@ -115,6 +115,8 @@ func TestGetSetRule(t *testing.T) {
 		err := labeler.SetLabelRule(r)
 		re.NoError(err)
 	}
+	re.Equal(3, labeler.GetRulesCount())
+	re.Equal(3, labeler.GetKeyRangesCount())
 
 	allRules := labeler.GetAllLabelRules()
 	sort.Slice(allRules, func(i, j int) bool { return allRules[i].ID < allRules[j].ID })
@@ -127,6 +129,8 @@ func TestGetSetRule(t *testing.T) {
 	err = labeler.DeleteLabelRule("rule2")
 	re.NoError(err)
 	re.Nil(labeler.GetLabelRule("rule2"))
+	re.Equal(2, labeler.GetRulesCount())
+	re.Equal(2, labeler.GetKeyRangesCount())
 	byIDs, err = labeler.GetLabelRules([]string{"rule1", "rule2"})
 	re.NoError(err)
 	re.Equal([]*LabelRule{rules[0]}, byIDs)
@@ -142,6 +146,8 @@ func TestGetSetRule(t *testing.T) {
 	re.NoError(err)
 	allRules = labeler.GetAllLabelRules()
 	sort.Slice(allRules, func(i, j int) bool { return allRules[i].ID < allRules[j].ID })
+	re.Equal(2, labeler.GetRulesCount())
+	re.Equal(2, labeler.GetKeyRangesCount())
 	for id, rule := range allRules {
 		expectSameRules(re, rule, rules[id+1])
 	}
@@ -152,6 +158,8 @@ func TestGetSetRule(t *testing.T) {
 		re.NoError(err)
 	}
 	re.Empty(labeler.GetAllLabelRules())
+	re.Zero(labeler.GetRulesCount())
+	re.Zero(labeler.GetKeyRangesCount())
 }
 
 func TestTxnWithEtcd(t *testing.T) {
@@ -409,6 +417,8 @@ func TestLabelerRuleTTL(t *testing.T) {
 		err := labeler.SetLabelRule(r)
 		re.NoError(err)
 	}
+	re.Equal(3, labeler.GetRulesCount())
+	re.Equal(3, labeler.GetKeyRangesCount())
 	// get rule with "rule2".
 	re.NotNil(labeler.GetLabelRule("rule2"))
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/labeler/regionLabelExpireSub1Minute", "return(true)"))
@@ -418,6 +428,8 @@ func TestLabelerRuleTTL(t *testing.T) {
 		labels := labeler.GetRegionLabels(region)
 		return len(labels) == 2
 	})
+	re.Equal(2, labeler.GetRulesCount())
+	re.Equal(2, labeler.GetKeyRangesCount())
 
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/labeler/regionLabelExpireSub1Minute"))
 	// rule2 should be existed since `GetRegionLabels` won't clear it physically.

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -163,6 +163,14 @@ var (
 			Help:      "Status of the rule.",
 		}, []string{"type"})
 
+	regionLabelStatusGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "region_label",
+			Name:      "status",
+			Help:      "Status of the region labeler.",
+		}, []string{"type"})
+
 	balanceRangeGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "pd",
@@ -182,6 +190,7 @@ var (
 func init() {
 	prometheus.MustRegister(schedulerStatusGauge)
 	prometheus.MustRegister(ruleStatusGauge)
+	prometheus.MustRegister(regionLabelStatusGauge)
 	prometheus.MustRegister(schedulerCounter)
 	prometheus.MustRegister(balanceWitnessCounter)
 	prometheus.MustRegister(hotSchedulerResultCounter)

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -124,19 +124,26 @@ func (c *Controller) CollectSchedulerMetrics() {
 	}
 	c.RUnlock()
 	ruleMgr := c.cluster.GetRuleManager()
-	if ruleMgr == nil {
+	if ruleMgr != nil {
+		ruleCnt := ruleMgr.GetRulesCount()
+		groupCnt := ruleMgr.GetGroupsCount()
+		ruleStatusGauge.WithLabelValues("rule_count").Set(float64(ruleCnt))
+		ruleStatusGauge.WithLabelValues("group_count").Set(float64(groupCnt))
+	}
+
+	labelerMgr := c.cluster.GetRegionLabeler()
+	if labelerMgr == nil {
 		return
 	}
-	ruleCnt := ruleMgr.GetRulesCount()
-	groupCnt := ruleMgr.GetGroupsCount()
-	ruleStatusGauge.WithLabelValues("rule_count").Set(float64(ruleCnt))
-	ruleStatusGauge.WithLabelValues("group_count").Set(float64(groupCnt))
+	regionLabelStatusGauge.WithLabelValues("rule_count").Set(float64(labelerMgr.GetRulesCount()))
+	regionLabelStatusGauge.WithLabelValues("range_count").Set(float64(labelerMgr.GetKeyRangesCount()))
 }
 
 // ResetSchedulerMetrics resets metrics of all schedulers.
 func ResetSchedulerMetrics() {
 	schedulerStatusGauge.Reset()
 	ruleStatusGauge.Reset()
+	regionLabelStatusGauge.Reset()
 }
 
 // AddSchedulerHandler adds the HTTP handler for a scheduler.

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -135,8 +135,9 @@ func (c *Controller) CollectSchedulerMetrics() {
 	if labelerMgr == nil {
 		return
 	}
-	regionLabelStatusGauge.WithLabelValues("rule_count").Set(float64(labelerMgr.GetRulesCount()))
-	regionLabelStatusGauge.WithLabelValues("range_count").Set(float64(labelerMgr.GetKeyRangesCount()))
+	ruleCnt, keyRangeCnt := labelerMgr.GetRuleAndKeyRangeCounts()
+	regionLabelStatusGauge.WithLabelValues("rule_count").Set(float64(ruleCnt))
+	regionLabelStatusGauge.WithLabelValues("range_count").Set(float64(keyRangeCnt))
 }
 
 // ResetSchedulerMetrics resets metrics of all schedulers.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10961

### What is changed and how does it work?

```commit-message
Add pd_region_label_status to report the number of effective region label
rules and key ranges.

Collect the metric with scheduler metrics and add a Region Label Status panel
to the PD Grafana dashboard.
```

### Check List

Tests

- Unit test
- Manual test (add detailed scripts or steps below)

Manual test:

- `go test ./pkg/schedule/labeler -run 'TestGetSetRule|TestLabelerRuleTTL' -count=1`
- `go test ./pkg/schedule/schedulers -run '^$'`
- `python3 -m json.tool metrics/grafana/pd.json >/dev/null`
- `git diff --check`

Note: `go test ./pkg/schedule/labeler ./pkg/schedule/schedulers` was also
attempted. The `labeler` package passed, but `pkg/schedule/schedulers` failed
at the existing `TestPersistFail` case in `balance_range_test.go:505`; the same
test failed when run alone.

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Region Label Status** Grafana dashboard panel and refined the layout of the **Placement Rules Status** panel.
  * Added new **region label** Prometheus metrics to track **effective rule counts** and **key range counts**.
* **Bug Fixes**
  * Improved scheduler metric collection so region-label metrics are still updated when rule data is unavailable.
  * Extended metric reset behavior to include the new region-label metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->