### PR TITLE
tests: avoid test port conflicts

### DIFF
--- a/pkg/mcs/resourcemanager/server/listener_test.go
+++ b/pkg/mcs/resourcemanager/server/listener_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitListenerAndUpdateConfigWithKernelSelectedPort(t *testing.T) {
+	re := require.New(t)
+	cfg := NewConfig()
+	cfg.BackendEndpoints = "http://127.0.0.1:2379"
+	cfg.ListenAddr = "http://127.0.0.1:0"
+	cfg.AdvertiseListenAddr = "http://10.0.0.5:0"
+	cfg.Name = cfg.ListenAddr
+
+	cfg, err := GenerateConfig(cfg)
+	re.NoError(err)
+	svr := CreateServer(context.Background(), cfg)
+	re.NoError(svr.initListenerAndUpdateConfig())
+	defer func() {
+		re.NoError(svr.GetListener().Close())
+	}()
+
+	actualURL, err := url.Parse(svr.GetActualListenAddr())
+	re.NoError(err)
+	re.Equal("127.0.0.1", actualURL.Hostname())
+	re.NotEmpty(actualURL.Port())
+	re.NotEqual("0", actualURL.Port())
+	re.Equal(svr.GetActualListenAddr(), cfg.ListenAddr)
+
+	advertiseURL, err := url.Parse(cfg.AdvertiseListenAddr)
+	re.NoError(err)
+	re.Equal("10.0.0.5", advertiseURL.Hostname())
+	re.Equal(actualURL.Port(), advertiseURL.Port())
+	re.Equal(cfg.AdvertiseListenAddr, cfg.Name)
+}

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -143,7 +143,9 @@ func (s *Server) Run() (err error) {
 			}
 		}
 		if err != nil && s.GetListener() != nil {
-			_ = s.GetListener().Close()
+			if closeErr := s.GetListener().Close(); closeErr != nil {
+				log.Warn("failed to close listener", errs.ZapError(closeErr))
+			}
 		}
 	}()
 

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -133,6 +133,19 @@ func (s *Server) Run() (err error) {
 	if err = utils.InitClient(s); err != nil {
 		return err
 	}
+	if err = s.initListenerAndUpdateConfig(); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && s.serviceRegister != nil {
+			if deregisterErr := s.serviceRegister.Deregister(); deregisterErr != nil {
+				log.Warn("failed to deregister the service", errs.ZapError(deregisterErr))
+			}
+		}
+		if err != nil && s.GetListener() != nil {
+			_ = s.GetListener().Close()
+		}
+	}()
 
 	if s.serviceID, s.serviceRegister, err = utils.Register(s, constant.ResourceManagerServiceName); err != nil {
 		return err
@@ -386,6 +399,23 @@ func (s *Server) GetTLSConfig() *grpcutil.TLSConfig {
 	return &s.cfg.Security.TLSConfig
 }
 
+func (s *Server) initListenerAndUpdateConfig() error {
+	oldListenAddr := s.cfg.ListenAddr
+	if err := s.InitListener(s.GetTLSConfig(), s.cfg.GetListenAddr()); err != nil {
+		return err
+	}
+	actualListenAddr := s.GetActualListenAddr()
+	if actualListenAddr == "" {
+		return nil
+	}
+	s.cfg.ListenAddr = server.ResolveListenAddr(s.cfg.ListenAddr, actualListenAddr)
+	s.cfg.AdvertiseListenAddr = server.ResolveAdvertiseListenAddr(s.cfg.AdvertiseListenAddr, actualListenAddr)
+	if s.cfg.Name == "" || s.cfg.Name == oldListenAddr {
+		s.cfg.Name = s.cfg.AdvertiseListenAddr
+	}
+	return nil
+}
+
 // GetServingUrls gets service endpoints from the leader in election group.
 func (s *Server) GetServingUrls() []string {
 	return s.participant.GetServingUrls()
@@ -416,9 +446,6 @@ func (s *Server) startServer() (err error) {
 		rejectMetadataWritesViaGRPC: s.ShouldRejectMetadataWritesViaGRPC(),
 	}
 
-	if err := s.InitListener(s.GetTLSConfig(), s.cfg.GetListenAddr()); err != nil {
-		return err
-	}
 	// Only start the metering writer if a valid metering config is provided.
 	if len(s.cfg.Metering.Type) > 0 {
 		s.meteringWriter, err = metering.NewWriter(s.Context(), &s.cfg.Metering, fmt.Sprintf("pd%d", s.participant.ID()))

--- a/pkg/mcs/router/server/listener_test.go
+++ b/pkg/mcs/router/server/listener_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/mcs/router/server/config"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestInitListenerAndUpdateConfigWithKernelSelectedPort(t *testing.T) {
+	re := require.New(t)
+	cfg := config.NewConfig()
+	cfg.BackendEndpoints = "http://127.0.0.1:2379"
+	cfg.ListenAddr = "http://127.0.0.1:0"
+	cfg.AdvertiseListenAddr = "http://10.0.0.5:0"
+	cfg.Name = cfg.ListenAddr
+
+	cfg, err := GenerateConfig(cfg)
+	re.NoError(err)
+	svr := CreateServer(context.Background(), cfg)
+	re.NoError(svr.initListenerAndUpdateConfig())
+	defer func() {
+		re.NoError(svr.GetListener().Close())
+	}()
+
+	actualURL, err := url.Parse(svr.GetActualListenAddr())
+	re.NoError(err)
+	re.Equal("127.0.0.1", actualURL.Hostname())
+	re.NotEmpty(actualURL.Port())
+	re.NotEqual("0", actualURL.Port())
+	re.Equal(svr.GetActualListenAddr(), cfg.ListenAddr)
+
+	advertiseURL, err := url.Parse(cfg.AdvertiseListenAddr)
+	re.NoError(err)
+	re.Equal("10.0.0.5", advertiseURL.Hostname())
+	re.Equal(actualURL.Port(), advertiseURL.Port())
+	re.Equal(cfg.AdvertiseListenAddr, cfg.Name)
+}

--- a/pkg/mcs/router/server/server.go
+++ b/pkg/mcs/router/server/server.go
@@ -120,6 +120,19 @@ func (s *Server) Run() (err error) {
 	if err = utils.InitClient(s); err != nil {
 		return err
 	}
+	if err = s.initListenerAndUpdateConfig(); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && s.serviceRegister != nil {
+			if deregisterErr := s.serviceRegister.Deregister(); deregisterErr != nil {
+				log.Warn("failed to deregister the service", errs.ZapError(deregisterErr))
+			}
+		}
+		if err != nil && s.GetListener() != nil {
+			_ = s.GetListener().Close()
+		}
+	}()
 
 	if s.serviceID, s.serviceRegister, err = utils.Register(s, constant.RouterServiceName); err != nil {
 		return err
@@ -181,6 +194,23 @@ func (s *Server) GetTLSConfig() *grpcutil.TLSConfig {
 	return &s.cfg.Security.TLSConfig
 }
 
+func (s *Server) initListenerAndUpdateConfig() error {
+	oldListenAddr := s.cfg.ListenAddr
+	if err := s.InitListener(s.GetTLSConfig(), s.cfg.GetListenAddr()); err != nil {
+		return err
+	}
+	actualListenAddr := s.GetActualListenAddr()
+	if actualListenAddr == "" {
+		return nil
+	}
+	s.cfg.ListenAddr = server.ResolveListenAddr(s.cfg.ListenAddr, actualListenAddr)
+	s.cfg.AdvertiseListenAddr = server.ResolveAdvertiseListenAddr(s.cfg.AdvertiseListenAddr, actualListenAddr)
+	if s.cfg.Name == "" || s.cfg.Name == oldListenAddr {
+		s.cfg.Name = s.cfg.AdvertiseListenAddr
+	}
+	return nil
+}
+
 // GetCluster returns the cluster.
 func (s *Server) GetCluster() *Cluster {
 	return s.cluster
@@ -235,9 +265,6 @@ func (s *Server) startServer() (err error) {
 	bs.ServerMaxProcsGauge.Set(float64(runtime.GOMAXPROCS(0)))
 
 	s.service = &Service{Server: s}
-	if err := s.InitListener(s.GetTLSConfig(), s.cfg.GetListenAddr()); err != nil {
-		return err
-	}
 
 	serverReadyChan := make(chan struct{})
 	defer close(serverReadyChan)

--- a/pkg/mcs/router/server/server.go
+++ b/pkg/mcs/router/server/server.go
@@ -130,7 +130,9 @@ func (s *Server) Run() (err error) {
 			}
 		}
 		if err != nil && s.GetListener() != nil {
-			_ = s.GetListener().Close()
+			if closeErr := s.GetListener().Close(); closeErr != nil {
+				log.Warn("failed to close listener", errs.ZapError(closeErr))
+			}
 		}
 	}()
 

--- a/pkg/mcs/scheduling/server/listener_test.go
+++ b/pkg/mcs/scheduling/server/listener_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
+)
+
+func TestInitListenerAndUpdateConfigWithKernelSelectedPort(t *testing.T) {
+	re := require.New(t)
+	cfg := config.NewConfig()
+	cfg.BackendEndpoints = "http://127.0.0.1:2379"
+	cfg.ListenAddr = "http://127.0.0.1:0"
+	cfg.AdvertiseListenAddr = "http://10.0.0.5:0"
+	cfg.Name = cfg.ListenAddr
+
+	cfg, err := GenerateConfig(cfg)
+	re.NoError(err)
+	svr := CreateServer(context.Background(), cfg)
+	re.NoError(svr.initListenerAndUpdateConfig())
+	defer func() {
+		re.NoError(svr.GetListener().Close())
+	}()
+
+	actualURL, err := url.Parse(svr.GetActualListenAddr())
+	re.NoError(err)
+	re.Equal("127.0.0.1", actualURL.Hostname())
+	re.NotEmpty(actualURL.Port())
+	re.NotEqual("0", actualURL.Port())
+	re.Equal(svr.GetActualListenAddr(), cfg.ListenAddr)
+
+	advertiseURL, err := url.Parse(cfg.AdvertiseListenAddr)
+	re.NoError(err)
+	re.Equal("10.0.0.5", advertiseURL.Hostname())
+	re.Equal(actualURL.Port(), advertiseURL.Port())
+	re.Equal(cfg.AdvertiseListenAddr, cfg.Name)
+}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -154,6 +154,19 @@ func (s *Server) Run() (err error) {
 	if err = utils.InitClient(s); err != nil {
 		return err
 	}
+	if err = s.initListenerAndUpdateConfig(); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && s.serviceRegister != nil {
+			if deregisterErr := s.serviceRegister.Deregister(); deregisterErr != nil {
+				log.Warn("failed to deregister the service", errs.ZapError(deregisterErr))
+			}
+		}
+		if err != nil && s.GetListener() != nil {
+			_ = s.GetListener().Close()
+		}
+	}()
 
 	if s.serviceID, s.serviceRegister, err = utils.Register(s, constant.SchedulingServiceName); err != nil {
 		return err
@@ -406,6 +419,23 @@ func (s *Server) GetTLSConfig() *grpcutil.TLSConfig {
 	return &s.cfg.Security.TLSConfig
 }
 
+func (s *Server) initListenerAndUpdateConfig() error {
+	oldListenAddr := s.cfg.ListenAddr
+	if err := s.InitListener(s.GetTLSConfig(), s.cfg.GetListenAddr()); err != nil {
+		return err
+	}
+	actualListenAddr := s.GetActualListenAddr()
+	if actualListenAddr == "" {
+		return nil
+	}
+	s.cfg.ListenAddr = server.ResolveListenAddr(s.cfg.ListenAddr, actualListenAddr)
+	s.cfg.AdvertiseListenAddr = server.ResolveAdvertiseListenAddr(s.cfg.AdvertiseListenAddr, actualListenAddr)
+	if s.cfg.Name == "" || s.cfg.Name == oldListenAddr {
+		s.cfg.Name = s.cfg.AdvertiseListenAddr
+	}
+	return nil
+}
+
 // GetCluster returns the cluster.
 func (s *Server) GetCluster() *Cluster {
 	cluster := s.cluster.Load()
@@ -478,9 +508,6 @@ func (s *Server) startServer() (err error) {
 	s.service = &Service{Server: s}
 	s.AddServiceReadyCallback(s.startCluster)
 	s.AddServiceExitCallback(s.stopCluster)
-	if err := s.InitListener(s.GetTLSConfig(), s.cfg.GetListenAddr()); err != nil {
-		return err
-	}
 
 	serverReadyChan := make(chan struct{})
 	defer close(serverReadyChan)

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -164,7 +164,9 @@ func (s *Server) Run() (err error) {
 			}
 		}
 		if err != nil && s.GetListener() != nil {
-			_ = s.GetListener().Close()
+			if closeErr := s.GetListener().Close(); closeErr != nil {
+				log.Warn("failed to close listener", errs.ZapError(closeErr))
+			}
 		}
 	}()
 

--- a/pkg/mcs/server/server.go
+++ b/pkg/mcs/server/server.go
@@ -186,10 +186,14 @@ func ResolveListenAddr(listenAddr, actualListenAddr string) string {
 }
 
 // ResolveAdvertiseListenAddr returns actualListenAddr when advertiseAddr was left
-// unspecified or still points at a kernel-selected port.
+// unspecified. If advertiseAddr points at a kernel-selected port, it preserves
+// the explicit advertise host and replaces only the port.
 func ResolveAdvertiseListenAddr(advertiseAddr, actualListenAddr string) string {
-	if advertiseAddr == "" || hasZeroPort(advertiseAddr) {
+	if advertiseAddr == "" {
 		return actualListenAddr
+	}
+	if hasZeroPort(advertiseAddr) {
+		return replacePort(advertiseAddr, actualListenAddr)
 	}
 	return advertiseAddr
 }
@@ -237,11 +241,43 @@ func buildActualListenAddr(listenURL *url.URL, addr net.Addr) string {
 }
 
 func hasZeroPort(addr string) bool {
+	_, port, ok := splitHostPort(addr)
+	return ok && port == "0"
+}
+
+func replacePort(addr, actualListenAddr string) string {
+	_, actualPort, ok := splitHostPort(actualListenAddr)
+	if !ok {
+		return actualListenAddr
+	}
+
+	parsed, err := url.Parse(addr)
+	if err == nil && parsed.Host != "" {
+		host, _, ok := splitHostPort(parsed.Host)
+		if !ok {
+			return actualListenAddr
+		}
+		parsed.Host = net.JoinHostPort(host, actualPort)
+		return parsed.String()
+	}
+
+	host, _, ok := splitHostPort(addr)
+	if !ok {
+		return actualListenAddr
+	}
+	return net.JoinHostPort(host, actualPort)
+}
+
+func splitHostPort(addr string) (string, string, bool) {
 	parsed, err := url.Parse(addr)
 	host := addr
 	if err == nil && parsed.Host != "" {
 		host = parsed.Host
 	}
 	_, port, err := net.SplitHostPort(host)
-	return err == nil && port == "0"
+	if err != nil {
+		return "", "", false
+	}
+	host, _, err = net.SplitHostPort(host)
+	return host, port, err == nil
 }

--- a/pkg/mcs/server/server.go
+++ b/pkg/mcs/server/server.go
@@ -45,6 +45,7 @@ type BaseServer struct {
 	clientConns sync.Map
 	secure      bool
 	muxListener net.Listener
+	listenAddr  string
 	// Callback functions for different stages
 	// startCallbacks will be called after the server is started.
 	startCallbacks []func()
@@ -158,12 +159,39 @@ func (bs *BaseServer) InitListener(tlsCfg *grpcutil.TLSConfig, listenAddr string
 	} else {
 		bs.muxListener, err = net.Listen(constant.TCPNetworkStr, listenURL.Host)
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	bs.listenAddr = buildActualListenAddr(listenURL, bs.muxListener.Addr())
+	return nil
 }
 
 // GetListener returns the listener.
 func (bs *BaseServer) GetListener() net.Listener {
 	return bs.muxListener
+}
+
+// GetActualListenAddr returns the listener address after binding.
+func (bs *BaseServer) GetActualListenAddr() string {
+	return bs.listenAddr
+}
+
+// ResolveListenAddr returns actualListenAddr only when listenAddr points at a
+// kernel-selected port.
+func ResolveListenAddr(listenAddr, actualListenAddr string) string {
+	if hasZeroPort(listenAddr) {
+		return actualListenAddr
+	}
+	return listenAddr
+}
+
+// ResolveAdvertiseListenAddr returns actualListenAddr when advertiseAddr was left
+// unspecified or still points at a kernel-selected port.
+func ResolveAdvertiseListenAddr(advertiseAddr, actualListenAddr string) string {
+	if advertiseAddr == "" || hasZeroPort(advertiseAddr) {
+		return actualListenAddr
+	}
+	return advertiseAddr
 }
 
 // IsSecure checks if the server enable TLS.
@@ -185,4 +213,31 @@ func (bs *BaseServer) CloseClientConns() {
 		}
 		return true
 	})
+}
+
+func buildActualListenAddr(listenURL *url.URL, addr net.Addr) string {
+	host, _, err := net.SplitHostPort(listenURL.Host)
+	if err != nil || host == "" {
+		host, _, _ = net.SplitHostPort(addr.String())
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		host = "127.0.0.1"
+	}
+	_, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return listenURL.String()
+	}
+	actualURL := *listenURL
+	actualURL.Host = net.JoinHostPort(host, port)
+	return actualURL.String()
+}
+
+func hasZeroPort(addr string) bool {
+	parsed, err := url.Parse(addr)
+	host := addr
+	if err == nil && parsed.Host != "" {
+		host = parsed.Host
+	}
+	_, port, err := net.SplitHostPort(host)
+	return err == nil && port == "0"
 }

--- a/pkg/mcs/server/server.go
+++ b/pkg/mcs/server/server.go
@@ -221,7 +221,11 @@ func buildActualListenAddr(listenURL *url.URL, addr net.Addr) string {
 		host, _, _ = net.SplitHostPort(addr.String())
 	}
 	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
-		host = "127.0.0.1"
+		if ip.To4() == nil {
+			host = "::1"
+		} else {
+			host = "127.0.0.1"
+		}
 	}
 	_, port, err := net.SplitHostPort(addr.String())
 	if err != nil {

--- a/pkg/mcs/server/server.go
+++ b/pkg/mcs/server/server.go
@@ -268,13 +268,13 @@ func replacePort(addr, actualListenAddr string) string {
 	return net.JoinHostPort(host, actualPort)
 }
 
-func splitHostPort(addr string) (string, string, bool) {
+func splitHostPort(addr string) (host, port string, ok bool) {
 	parsed, err := url.Parse(addr)
-	host := addr
+	host = addr
 	if err == nil && parsed.Host != "" {
 		host = parsed.Host
 	}
-	_, port, err := net.SplitHostPort(host)
+	_, port, err = net.SplitHostPort(host)
 	if err != nil {
 		return "", "", false
 	}

--- a/pkg/mcs/server/server_test.go
+++ b/pkg/mcs/server/server_test.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"net"
 	"net/url"
 	"testing"
 
@@ -34,7 +35,9 @@ func TestInitListenerWithKernelSelectedPort(t *testing.T) {
 	re := require.New(t)
 	svr := NewBaseServer(context.Background())
 	re.NoError(svr.InitListener(&grpcutil.TLSConfig{}, "http://127.0.0.1:0"))
-	defer svr.GetListener().Close()
+	defer func() {
+		re.NoError(svr.GetListener().Close())
+	}()
 
 	actual := svr.GetActualListenAddr()
 	u, err := url.Parse(actual)
@@ -54,4 +57,22 @@ func TestResolveAdvertiseListenAddr(t *testing.T) {
 	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("http://127.0.0.1:0", actualAddr))
 	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("127.0.0.1:0", actualAddr))
 	require.Equal(t, "http://127.0.0.1:23456", ResolveAdvertiseListenAddr("http://127.0.0.1:23456", actualAddr))
+}
+
+func TestBuildActualListenAddrPreservesUnspecifiedAddressFamily(t *testing.T) {
+	re := require.New(t)
+
+	listenURL, err := url.Parse("http://0.0.0.0:0")
+	re.NoError(err)
+	re.Equal("http://127.0.0.1:12345", buildActualListenAddr(listenURL, &net.TCPAddr{
+		IP:   net.ParseIP("0.0.0.0"),
+		Port: 12345,
+	}))
+
+	listenURL, err = url.Parse("http://[::]:0")
+	re.NoError(err)
+	re.Equal("http://[::1]:12345", buildActualListenAddr(listenURL, &net.TCPAddr{
+		IP:   net.ParseIP("::"),
+		Port: 12345,
+	}))
 }

--- a/pkg/mcs/server/server_test.go
+++ b/pkg/mcs/server/server_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/utils/grpcutil"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestInitListenerWithKernelSelectedPort(t *testing.T) {
+	re := require.New(t)
+	svr := NewBaseServer(context.Background())
+	re.NoError(svr.InitListener(&grpcutil.TLSConfig{}, "http://127.0.0.1:0"))
+	defer svr.GetListener().Close()
+
+	actual := svr.GetActualListenAddr()
+	u, err := url.Parse(actual)
+	re.NoError(err)
+	re.Equal("http", u.Scheme)
+	re.Equal("127.0.0.1", u.Hostname())
+	re.NotEmpty(u.Port())
+	re.NotEqual("0", u.Port())
+}
+
+func TestResolveAdvertiseListenAddr(t *testing.T) {
+	actualAddr := "http://127.0.0.1:12345"
+	require.Equal(t, actualAddr, ResolveListenAddr("http://127.0.0.1:0", actualAddr))
+	require.Equal(t, "http://127.0.0.1:23456", ResolveListenAddr("http://127.0.0.1:23456", actualAddr))
+
+	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("", actualAddr))
+	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("http://127.0.0.1:0", actualAddr))
+	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("127.0.0.1:0", actualAddr))
+	require.Equal(t, "http://127.0.0.1:23456", ResolveAdvertiseListenAddr("http://127.0.0.1:23456", actualAddr))
+}

--- a/pkg/mcs/server/server_test.go
+++ b/pkg/mcs/server/server_test.go
@@ -55,7 +55,8 @@ func TestResolveAdvertiseListenAddr(t *testing.T) {
 
 	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("", actualAddr))
 	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("http://127.0.0.1:0", actualAddr))
-	require.Equal(t, actualAddr, ResolveAdvertiseListenAddr("127.0.0.1:0", actualAddr))
+	require.Equal(t, "http://10.0.0.5:12345", ResolveAdvertiseListenAddr("http://10.0.0.5:0", actualAddr))
+	require.Equal(t, "127.0.0.1:12345", ResolveAdvertiseListenAddr("127.0.0.1:0", actualAddr))
 	require.Equal(t, "http://127.0.0.1:23456", ResolveAdvertiseListenAddr("http://127.0.0.1:23456", actualAddr))
 }
 

--- a/pkg/mcs/tso/server/listener_test.go
+++ b/pkg/mcs/tso/server/listener_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitListenerAndUpdateConfigWithKernelSelectedPort(t *testing.T) {
+	re := require.New(t)
+	cfg := NewConfig()
+	cfg.BackendEndpoints = "http://127.0.0.1:2379"
+	cfg.ListenAddr = "http://127.0.0.1:0"
+	cfg.AdvertiseListenAddr = "http://10.0.0.5:0"
+	cfg.Name = cfg.ListenAddr
+
+	cfg, err := GenerateConfig(cfg)
+	re.NoError(err)
+	svr := CreateServer(context.Background(), cfg)
+	re.NoError(svr.initListenerAndUpdateConfig())
+	defer func() {
+		re.NoError(svr.GetListener().Close())
+	}()
+
+	actualURL, err := url.Parse(svr.GetActualListenAddr())
+	re.NoError(err)
+	re.Equal("127.0.0.1", actualURL.Hostname())
+	re.NotEmpty(actualURL.Port())
+	re.NotEqual("0", actualURL.Port())
+	re.Equal(svr.GetActualListenAddr(), cfg.ListenAddr)
+
+	advertiseURL, err := url.Parse(cfg.AdvertiseListenAddr)
+	re.NoError(err)
+	re.Equal("10.0.0.5", advertiseURL.Hostname())
+	re.Equal(actualURL.Port(), advertiseURL.Port())
+	re.Equal(cfg.AdvertiseListenAddr, cfg.Name)
+	re.Equal(net.JoinHostPort("10.0.0.5", actualURL.Port()), svr.advertiseListenHost)
+}

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -175,7 +175,9 @@ func (s *Server) Run() (err error) {
 			}
 		}
 		if err != nil && s.GetListener() != nil {
-			_ = s.GetListener().Close()
+			if closeErr := s.GetListener().Close(); closeErr != nil {
+				log.Warn("failed to close listener", errs.ZapError(closeErr))
+			}
 		}
 	}()
 

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -165,6 +165,19 @@ func (s *Server) Run() (err error) {
 	if err = utils.InitClient(s); err != nil {
 		return err
 	}
+	if err = s.initListenerAndUpdateConfig(); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil && s.serviceRegister != nil {
+			if deregisterErr := s.serviceRegister.Deregister(); deregisterErr != nil {
+				log.Warn("failed to deregister the service", errs.ZapError(deregisterErr))
+			}
+		}
+		if err != nil && s.GetListener() != nil {
+			_ = s.GetListener().Close()
+		}
+	}()
 
 	if s.serviceID, s.serviceRegister, err = utils.Register(s, mcs.TSOServiceName); err != nil {
 		return err
@@ -347,6 +360,24 @@ func (s *Server) GetTLSConfig() *grpcutil.TLSConfig {
 	return &s.cfg.Security.TLSConfig
 }
 
+func (s *Server) initListenerAndUpdateConfig() error {
+	oldListenAddr := s.cfg.ListenAddr
+	if err := s.InitListener(s.GetTLSConfig(), s.cfg.ListenAddr); err != nil {
+		return err
+	}
+	actualListenAddr := s.GetActualListenAddr()
+	if actualListenAddr == "" {
+		return nil
+	}
+	s.cfg.ListenAddr = server.ResolveListenAddr(s.cfg.ListenAddr, actualListenAddr)
+	s.cfg.AdvertiseListenAddr = server.ResolveAdvertiseListenAddr(s.cfg.AdvertiseListenAddr, actualListenAddr)
+	if s.cfg.Name == "" || s.cfg.Name == oldListenAddr {
+		s.cfg.Name = s.cfg.AdvertiseListenAddr
+	}
+	s.advertiseListenHost = parseAdvertiseListenHost(s.cfg.AdvertiseListenAddr)
+	return nil
+}
+
 func (s *Server) startServer() (err error) {
 	clusterID := keypath.ClusterID()
 	// It may lose accuracy if use float64 to store uint64. So we store the cluster id in label.
@@ -368,10 +399,6 @@ func (s *Server) startServer() (err error) {
 	s.tsoProtoFactory = &tsoutil.TSOProtoFactory{}
 	s.service = &Service{Server: s}
 
-	if err := s.InitListener(s.GetTLSConfig(), s.cfg.ListenAddr); err != nil {
-		return err
-	}
-
 	serverReadyChan := make(chan struct{})
 	defer close(serverReadyChan)
 	s.serverLoopWg.Add(1)
@@ -390,22 +417,7 @@ func (s *Server) startServer() (err error) {
 
 // CreateServer creates the Server
 func CreateServer(ctx context.Context, cfg *Config) *Server {
-	addr := cfg.GetAdvertiseListenAddr()
-	parsed, err := url.Parse(addr)
-	advertiseListenHost := ""
-	if err != nil {
-		if _, _, splitErr := net.SplitHostPort(addr); splitErr != nil {
-			panic(fmt.Sprintf("invalid advertise listen address: %s", addr))
-		}
-		advertiseListenHost = addr
-	} else {
-		advertiseListenHost = parsed.Host
-		if advertiseListenHost == "" {
-			if _, _, splitErr := net.SplitHostPort(addr); splitErr == nil {
-				advertiseListenHost = addr
-			}
-		}
-	}
+	advertiseListenHost := parseAdvertiseListenHost(cfg.GetAdvertiseListenAddr())
 	svr := &Server{
 		BaseServer:          server.NewBaseServer(ctx),
 		DiagnosticsServer:   sysutil.NewDiagnosticsServer(cfg.Log.File.Filename),
@@ -413,6 +425,23 @@ func CreateServer(ctx context.Context, cfg *Config) *Server {
 		advertiseListenHost: advertiseListenHost,
 	}
 	return svr
+}
+
+func parseAdvertiseListenHost(addr string) string {
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		if _, _, splitErr := net.SplitHostPort(addr); splitErr != nil {
+			panic(fmt.Sprintf("invalid advertise listen address: %s", addr))
+		}
+		return addr
+	}
+	advertiseListenHost := parsed.Host
+	if advertiseListenHost == "" {
+		if _, _, splitErr := net.SplitHostPort(addr); splitErr == nil {
+			advertiseListenHost = addr
+		}
+	}
+	return advertiseListenHost
 }
 
 // CreateServerWrapper encapsulates the configuration/log/metrics initialization and create the server

--- a/tests/integrations/mcs/discovery/register_test.go
+++ b/tests/integrations/mcs/discovery/register_test.go
@@ -26,7 +26,6 @@ import (
 	bs "github.com/tikv/pd/pkg/basicserver"
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/tests"
 )
@@ -158,11 +157,11 @@ func (suite *serverRegisterTestSuite) addServer(serviceName string) (bs.Server, 
 	re := suite.Require()
 	switch serviceName {
 	case constant.TSOServiceName:
-		return tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		return tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 	case constant.ResourceManagerServiceName:
-		return tests.StartSingleResourceManagerTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		return tests.StartSingleResourceManagerTestServer(suite.ctx, re, suite.backendEndpoints, "")
 	case constant.RouterServiceName:
-		server, cleanup, err := tests.StartSingleRouterServerWithoutCheck(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		server, cleanup, err := tests.StartSingleRouterServerWithoutCheck(suite.ctx, re, suite.backendEndpoints, "")
 		re.NoError(err)
 		return server, cleanup
 	default:

--- a/tests/integrations/mcs/keyspace/tso_keyspace_group_test.go
+++ b/tests/integrations/mcs/keyspace/tso_keyspace_group_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	mcs "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/storage/endpoint"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
 	"github.com/tikv/pd/server/apiv2/handlers"
@@ -157,7 +156,7 @@ func (suite *keyspaceGroupTestSuite) TestAllocNodesUpdate() {
 		}
 	}()
 	for range mcs.DefaultKeyspaceGroupReplicaCount + 1 {
-		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		cleanups = append(cleanups, cleanup)
 		nodes[s.GetAddr()] = s
 	}
@@ -213,7 +212,7 @@ func (suite *keyspaceGroupTestSuite) TestAllocReplica() {
 		}
 	}()
 	for range mcs.DefaultKeyspaceGroupReplicaCount {
-		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		cleanups = append(cleanups, cleanup)
 		nodes[s.GetAddr()] = s
 	}
@@ -266,7 +265,7 @@ func (suite *keyspaceGroupTestSuite) TestAllocReplica() {
 	re.Equal(http.StatusBadRequest, code)
 
 	// the keyspace group is exist, the new replica is more than the old replica.
-	s2, cleanup2 := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+	s2, cleanup2 := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 	defer cleanup2()
 	nodes[s2.GetAddr()] = s2
 	tests.WaitForPrimaryServing(re, nodes)
@@ -313,7 +312,7 @@ func (suite *keyspaceGroupTestSuite) TestSetNodes() {
 		}
 	}()
 	for range mcs.DefaultKeyspaceGroupReplicaCount {
-		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		cleanups = append(cleanups, cleanup)
 		nodes[s.GetAddr()] = s
 		nodesList = append(nodesList, s.GetAddr())
@@ -380,7 +379,7 @@ func (suite *keyspaceGroupTestSuite) TestDefaultKeyspaceGroup() {
 		}
 	}()
 	for range mcs.DefaultKeyspaceGroupReplicaCount {
-		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		cleanups = append(cleanups, cleanup)
 		nodes[s.GetAddr()] = s
 	}
@@ -414,7 +413,7 @@ func (suite *keyspaceGroupTestSuite) TestAllocNodes() {
 		}
 	}()
 	for range mcs.DefaultKeyspaceGroupReplicaCount + 1 {
-		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		cleanups = append(cleanups, cleanup)
 		nodes[s.GetAddr()] = s
 	}
@@ -456,7 +455,7 @@ func (suite *keyspaceGroupTestSuite) TestAllocOneNode() {
 	re := suite.Require()
 	// add one tso server
 	nodes := make(map[string]bs.Server)
-	oldTSOServer, cleanupOldTSOserver := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+	oldTSOServer, cleanupOldTSOserver := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 	defer cleanupOldTSOserver()
 	nodes[oldTSOServer.GetAddr()] = oldTSOServer
 
@@ -483,7 +482,7 @@ func (suite *keyspaceGroupTestSuite) TestAllocOneNode() {
 	nodes[stopNode].Close()
 
 	// create a new tso server
-	newTSOServer, cleanupNewTSOServer := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+	newTSOServer, cleanupNewTSOServer := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 	defer cleanupNewTSOServer()
 	nodes[newTSOServer.GetAddr()] = newTSOServer
 
@@ -574,7 +573,7 @@ func (suite *keyspaceGroupTestSuite) setupTSONodesAndClient(re *require.Assertio
 
 	// Start TSO servers
 	for range nodeCount {
-		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		cleanups = append(cleanups, cleanup)
 		nodes[s.GetAddr()] = s
 	}

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/tikv/pd/pkg/mcs/tso/server/apis/v1"
 	mcs "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/storage/endpoint"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server/apiv2/handlers"
 	"github.com/tikv/pd/tests"
@@ -89,7 +88,7 @@ func (suite *memberTestSuite) SetupTest() {
 	nodes := make(map[string]bs.Server)
 	// mock 3 tso nodes, which is more than the default replica count(DefaultKeyspaceGroupReplicaCount).
 	for range 3 {
-		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		nodes[s.GetAddr()] = s
 		suite.cleanupFunc = append(suite.cleanupFunc, func() {
 			cleanup()
@@ -109,7 +108,7 @@ func (suite *memberTestSuite) SetupTest() {
 	// Scheduling
 	nodes = make(map[string]bs.Server)
 	for range 3 {
-		s, cleanup := tests.StartSingleSchedulingTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleSchedulingTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		nodes[s.GetAddr()] = s
 		suite.cleanupFunc = append(suite.cleanupFunc, func() {
 			cleanup()
@@ -121,7 +120,7 @@ func (suite *memberTestSuite) SetupTest() {
 	// resource manager
 	nodes = make(map[string]bs.Server)
 	for range 3 {
-		s, cleanup := tests.StartSingleResourceManagerTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+		s, cleanup := tests.StartSingleResourceManagerTestServer(suite.ctx, re, suite.backendEndpoints, "")
 		nodes[s.GetAddr()] = s
 		suite.cleanupFunc = append(suite.cleanupFunc, func() {
 			cleanup()

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -51,7 +51,6 @@ import (
 	"github.com/tikv/pd/pkg/mcs/resourcemanager/server"
 	mcsconstant "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/storage/kv"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	srvconfig "github.com/tikv/pd/server/config"
@@ -162,12 +161,12 @@ func (suite *resourceManagerClientTestSuite) startMicroservicesForDiscovery(re *
 	backendEndpoints := leader.GetAddr()
 
 	// Start Resource Manager microservice and wait it is serving.
-	rmServer, cleanup := tests.StartSingleResourceManagerTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
+	rmServer, cleanup := tests.StartSingleResourceManagerTestServer(suite.ctx, re, backendEndpoints, "")
 	_ = tests.WaitForPrimaryServing(re, map[string]bs.Server{rmServer.GetAddr(): rmServer})
 	suite.rmCleanup = cleanup
 
 	// Start TSO microservice and wait it is serving.
-	tsoServer, tsoCleanup := tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
+	tsoServer, tsoCleanup := tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, "")
 	_ = tests.WaitForPrimaryServing(re, map[string]bs.Server{tsoServer.GetAddr(): tsoServer})
 	suite.tsoCleanup = tsoCleanup
 }
@@ -365,11 +364,11 @@ func TestSwitchModeDuringWorkload(t *testing.T) {
 
 			startMicroservices := func() (rmCleanup func(), tsoCleanup func()) {
 				backendEndpoints := leader.GetAddr()
-				rmServer, cleanup := tests.StartSingleResourceManagerTestServer(ctx, re, backendEndpoints, tempurl.Alloc())
+				rmServer, cleanup := tests.StartSingleResourceManagerTestServer(ctx, re, backendEndpoints, "")
 				_ = tests.WaitForPrimaryServing(re, map[string]bs.Server{rmServer.GetAddr(): rmServer})
 				rmCleanup = cleanup
 
-				tsoServer, cleanupTSO := tests.StartSingleTSOTestServer(ctx, re, backendEndpoints, tempurl.Alloc())
+				tsoServer, cleanupTSO := tests.StartSingleTSOTestServer(ctx, re, backendEndpoints, "")
 				_ = tests.WaitForPrimaryServing(re, map[string]bs.Server{tsoServer.GetAddr(): tsoServer})
 				tsoCleanup = cleanupTSO
 				return rmCleanup, tsoCleanup

--- a/tests/integrations/mcs/resourcemanager/server_test.go
+++ b/tests/integrations/mcs/resourcemanager/server_test.go
@@ -28,7 +28,6 @@ import (
 
 	bs "github.com/tikv/pd/pkg/basicserver"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/versioninfo"
 	"github.com/tikv/pd/tests"
 )
@@ -49,7 +48,7 @@ func TestResourceManagerServer(t *testing.T) {
 	re.NotEmpty(leaderName)
 	leader := cluster.GetServer(leaderName)
 
-	s, cleanup := tests.StartSingleResourceManagerTestServer(ctx, re, leader.GetAddr(), tempurl.Alloc())
+	s, cleanup := tests.StartSingleResourceManagerTestServer(ctx, re, leader.GetAddr(), "")
 	addr := s.GetAddr()
 	defer cleanup()
 	tests.WaitForPrimaryServing(re, map[string]bs.Server{addr: s})

--- a/tests/integrations/mcs/router/server_test.go
+++ b/tests/integrations/mcs/router/server_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/tikv/pd/client/pkg/caller"
 	"github.com/tikv/pd/pkg/core"
 	rs "github.com/tikv/pd/pkg/mcs/router/server"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/versioninfo"
 	"github.com/tikv/pd/tests"
@@ -78,7 +77,7 @@ func (suite *serverTestSuite) SetupSuite() {
 	suite.backendEndpoints = suite.pdLeader.GetAddr()
 	re.NoError(suite.pdLeader.BootstrapCluster())
 	// make pd client can work
-	_, suite.tsoCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+	_, suite.tsoCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 
 	regions := tests.InitRegions(10)
 	for _, region := range regions {
@@ -116,7 +115,7 @@ func (suite *serverTestSuite) SetupTest() {
 	re := suite.Require()
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/mcs/router/server/speedUpMemberLoop", `return(true)`))
 	var err error
-	suite.routerServer, suite.routerCleanup, err = tests.StartSingleRouterServerWithoutCheck(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+	suite.routerServer, suite.routerCleanup, err = tests.StartSingleRouterServerWithoutCheck(suite.ctx, re, suite.backendEndpoints, "")
 	re.NoError(err)
 	// check sync work well
 	testutil.Eventually(re, func() bool {

--- a/tests/integrations/mcs/tso/server_test.go
+++ b/tests/integrations/mcs/tso/server_test.go
@@ -104,7 +104,7 @@ func (suite *tsoServerTestSuite) TestTSOServerStartAndStopNormally() {
 	}()
 
 	re := suite.Require()
-	s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, tempurl.Alloc())
+	s, cleanup := tests.StartSingleTSOTestServer(suite.ctx, re, suite.backendEndpoints, "")
 
 	defer cleanup()
 	testutil.Eventually(re, func() bool {
@@ -135,7 +135,7 @@ func (suite *tsoServerTestSuite) TestParticipantStartWithAdvertiseListenAddr() {
 
 	cfg := tso.NewConfig()
 	cfg.BackendEndpoints = suite.backendEndpoints
-	cfg.ListenAddr = tempurl.Alloc()
+	cfg.ListenAddr = "http://127.0.0.1:0"
 	cfg.AdvertiseListenAddr = tempurl.Alloc()
 	cfg, err := tso.GenerateConfig(cfg)
 	re.NoError(err)
@@ -196,7 +196,7 @@ func checkTSOPath(re *require.Assertions, isKeyspaceGroupEnabled bool) {
 		re.Equal(1, getEtcdTimestampKeyNum(re, client))
 	}
 
-	_, cleanup := tests.StartSingleTSOTestServer(ctx, re, backendEndpoints, tempurl.Alloc())
+	_, cleanup := tests.StartSingleTSOTestServer(ctx, re, backendEndpoints, "")
 	defer cleanup()
 
 	if !kerneltype.IsNextGen() {

--- a/tests/integrations/tso/client_test.go
+++ b/tests/integrations/tso/client_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/storage/endpoint"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
 	"github.com/tikv/pd/server/apiv2/handlers"
@@ -608,7 +607,7 @@ func (suite *tsoClientTestSuite) TestTSOServiceDiscovery() {
 	re.NotEmpty(ts)
 	checkServiceDiscovery(re, pdClient, 3)
 
-	_, cleanup2 := tests.StartSingleTSOTestServer(suite.ctx, re, suite.pdLeaderServer.GetAddr(), tempurl.Alloc())
+	_, cleanup2 := tests.StartSingleTSOTestServer(suite.ctx, re, suite.pdLeaderServer.GetAddr(), "")
 	checkServiceDiscovery(re, pdClient, 4)
 	cleanup2()
 	checkServiceDiscovery(re, pdClient, 3)
@@ -644,7 +643,7 @@ func TestMixedTSODeployment(t *testing.T) {
 	err = pdSvr.Run()
 	re.NoError(err)
 
-	s, cleanup := tests.StartSingleTSOTestServer(ctx, re, backendEndpoints, tempurl.Alloc())
+	s, cleanup := tests.StartSingleTSOTestServer(ctx, re, backendEndpoints, "")
 	defer cleanup()
 	tests.WaitForPrimaryServing(re, map[string]bs.Server{s.GetAddr(): s})
 

--- a/tests/integrations/tso/consistency_test.go
+++ b/tests/integrations/tso/consistency_test.go
@@ -29,7 +29,6 @@ import (
 
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
 	"github.com/tikv/pd/pkg/utils/keypath"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
 	"github.com/tikv/pd/tests"
@@ -90,7 +89,7 @@ func (suite *tsoConsistencyTestSuite) SetupSuite() {
 	if suite.legacy {
 		suite.pdClient, suite.conn = testutil.MustNewGrpcClient(re, backendEndpoints)
 	} else {
-		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
+		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, "")
 		suite.tsoClientConn, suite.tsoClient = tso.MustNewGrpcClient(re, suite.tsoServer.GetAddr())
 	}
 }

--- a/tests/integrations/tso/server_test.go
+++ b/tests/integrations/tso/server_test.go
@@ -29,7 +29,6 @@ import (
 
 	tso "github.com/tikv/pd/pkg/mcs/tso/server"
 	"github.com/tikv/pd/pkg/utils/keypath"
-	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/tests"
 )
@@ -89,7 +88,7 @@ func (suite *tsoServerTestSuite) SetupSuite() {
 	if suite.legacy {
 		suite.pdClient, suite.conn = testutil.MustNewGrpcClient(re, backendEndpoints)
 	} else {
-		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, tempurl.Alloc())
+		suite.tsoServer, suite.tsoServerCleanup = tests.StartSingleTSOTestServer(suite.ctx, re, backendEndpoints, "")
 		suite.tsoClientConn, suite.tsoClient = tso.MustNewGrpcClient(re, suite.tsoServer.GetAddr())
 	}
 	// Ensure the TSO is ready to serve before running the tests.

--- a/tests/server/server_test.go
+++ b/tests/server/server_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
-	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/goleak"
 
 	"github.com/pingcap/failpoint"
@@ -469,6 +468,7 @@ func TestCheckClusterID(t *testing.T) {
 
 	leaderA := clusterA.WaitLeader()
 	re.NotEmpty(leaderA)
+	clusterAID := clusterA.GetServer(leaderA).GetServer().GetMember().Etcd().Server.Cluster().ID()
 
 	// Close cluster A
 	err = clusterA.StopAll()
@@ -487,27 +487,16 @@ func TestCheckClusterID(t *testing.T) {
 
 	// Now try to check if cluster A's cluster ID matches cluster B
 	// This should fail because they have different cluster IDs
-	cfgA := clusterA.GetServer(leaderA).GetConfig()
 	cfgB := clusterB.GetServer(leaderB).GetConfig()
-
-	mockHandler := createMockHandler(re, "127.0.0.1")
-	svr, err := server.CreateServer(ctx, cfgA, nil, mockHandler)
-	re.NoError(err)
-
-	etcdCfg, err := svr.GetConfig().GenEmbedEtcdConfig()
-	re.NoError(err)
-	etcd, err := embed.StartEtcd(etcdCfg)
-	re.NoError(err)
-	defer etcd.Close()
 
 	// Try to check cluster A's ID against cluster B's URLs
 	// This should fail because the cluster IDs don't match
 	urlsMap, err := etcdtypes.NewURLsMap(cfgB.InitialCluster)
 	re.NoError(err)
-	tlsConfig, err := svr.GetConfig().Security.ToClientTLSConfig()
+	tlsConfig, err := cfgB.Security.ToClientTLSConfig()
 	re.NoError(err)
-	err = etcdutil.CheckClusterID(etcd.Server.Cluster().ID(), urlsMap, tlsConfig)
-	re.Error(err)
+	err = etcdutil.CheckClusterID(clusterAID, urlsMap, tlsConfig)
+	re.ErrorContains(err, "Etcd cluster ID mismatch")
 }
 
 func TestMeteringWriter(t *testing.T) {

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -104,6 +104,8 @@ func SetRangePort(start, end int) {
 
 var once sync.Once
 
+const mcsTestListenAddr = "http://127.0.0.1:0"
+
 // InitLogger initializes the logger for test.
 func InitLogger(logConfig log.Config, logger *zap.Logger, logProps *log.ZapProperties, redactInfoLog logutil.RedactInfoLogType) (err error) {
 	once.Do(func() {
@@ -123,7 +125,7 @@ func InitLogger(logConfig log.Config, logger *zap.Logger, logProps *log.ZapPrope
 func StartSingleResourceManagerTestServer(ctx context.Context, re *require.Assertions, backendEndpoints, listenAddrs string) (*rm.Server, func()) {
 	cfg := rm.NewConfig()
 	cfg.BackendEndpoints = backendEndpoints
-	cfg.ListenAddr = listenAddrs
+	cfg.ListenAddr = normalizeMCSTestListenAddr(listenAddrs)
 	cfg.Name = cfg.ListenAddr
 	cfg, err := rm.GenerateConfig(cfg)
 	re.NoError(err)
@@ -141,7 +143,7 @@ func StartSingleResourceManagerTestServer(ctx context.Context, re *require.Asser
 func StartSingleRouterServerWithoutCheck(ctx context.Context, re *require.Assertions, backendEndpoints, listenAddrs string) (*router.Server, func(), error) {
 	cfg := rc.NewConfig()
 	cfg.BackendEndpoints = backendEndpoints
-	cfg.ListenAddr = listenAddrs
+	cfg.ListenAddr = normalizeMCSTestListenAddr(listenAddrs)
 	cfg.Name = cfg.ListenAddr
 	cfg, err := router.GenerateConfig(cfg)
 	re.NoError(err)
@@ -158,7 +160,7 @@ func StartSingleRouterServerWithoutCheck(ctx context.Context, re *require.Assert
 func StartSingleTSOTestServerWithoutCheck(ctx context.Context, re *require.Assertions, backendEndpoints, listenAddrs string) (*tso.Server, func(), error) {
 	cfg := tso.NewConfig()
 	cfg.BackendEndpoints = backendEndpoints
-	cfg.ListenAddr = listenAddrs
+	cfg.ListenAddr = normalizeMCSTestListenAddr(listenAddrs)
 	cfg.Name = cfg.ListenAddr
 	cfg, err := tso.GenerateConfig(cfg)
 	re.NoError(err)
@@ -195,7 +197,7 @@ func NewTSOTestServer(ctx context.Context, cfg *tso.Config) (*tso.Server, testut
 func StartSingleSchedulingTestServer(ctx context.Context, re *require.Assertions, backendEndpoints, listenAddrs string) (*scheduling.Server, func()) {
 	cfg := sc.NewConfig()
 	cfg.BackendEndpoints = backendEndpoints
-	cfg.ListenAddr = listenAddrs
+	cfg.ListenAddr = normalizeMCSTestListenAddr(listenAddrs)
 	cfg.Name = cfg.ListenAddr
 	cfg, err := scheduling.GenerateConfig(cfg)
 	re.NoError(err)
@@ -207,6 +209,13 @@ func StartSingleSchedulingTestServer(ctx context.Context, re *require.Assertions
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(50*time.Millisecond))
 
 	return s, cleanup
+}
+
+func normalizeMCSTestListenAddr(listenAddrs string) string {
+	if listenAddrs == "" {
+		return mcsTestListenAddr
+	}
+	return listenAddrs
 }
 
 // NewSchedulingTestServer creates a scheduling server with given config for testing.

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tikv/pd/pkg/response"
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
+	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server/config"
 	pdTests "github.com/tikv/pd/tests"
 	ctl "github.com/tikv/pd/tools/pd-ctl/pdctl"
@@ -285,9 +286,11 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	re.NoError(leaderServer.Run())
 
 	re.NotEmpty(cluster.WaitLeader())
-	storesLimit := leaderServer.GetPersistOptions().GetAllStoresLimit()
-	re.Equal(float64(20), storesLimit[1].AddPeer)
-	re.Equal(float64(20), storesLimit[1].RemovePeer)
+	testutil.Eventually(re, func() bool {
+		storesLimit := leaderServer.GetPersistOptions().GetAllStoresLimit()
+		limit, ok := storesLimit[1]
+		return ok && limit.AddPeer == float64(20) && limit.RemovePeer == float64(20)
+	})
 
 	// store limit all <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Fix flaky test failures like:

```text
listen tcp 127.0.0.1:<port>: bind: address already in use
```

One observed case was `pull-unit-test-next-gen-2` for PR #10943, where `TestCheckClusterID` restarted an embedded etcd instance with cluster A's old listen URLs after another test cluster had already been started. More generally, several MCS integration helpers allocated a free port with `tempurl.Alloc()` and only bound it later, leaving a TOCTOU window.

### What is changed and how does it work?

```commit-message
tests: avoid test port conflicts

Avoid restarting TestCheckClusterID with cluster A's old listen URLs. The
test now captures cluster A's etcd cluster ID while it is running and
checks that ID against cluster B's peer URLs.

Allow MCS BaseServer to listen on http://127.0.0.1:0 and expose the
actual bound listen address. Initialize MCS listeners before service
registration, then register the actual advertise address and server name.

Make MCS test helpers default to http://127.0.0.1:0 for new test servers,
while preserving explicit listen addresses for tests that intentionally
restart on a fixed address.
```

### Check List

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Code changes

- None

Side effects

- None

Related changes

- None

Test details:

- `go test ./tests/server -run '^TestCheckClusterID$' -count=1`
- `go test ./pkg/mcs/server ./pkg/mcs/tso/server ./pkg/mcs/scheduling/server ./pkg/mcs/router/server`
- `cd tests/integrations && go test ./mcs/router ./mcs/tso ./mcs/members ./mcs/discovery ./mcs/keyspace ./mcs/resourcemanager ./tso -run '^$'`
- `cd tests/integrations && go test ./mcs/resourcemanager -run '^TestResourceManagerServer$' -count=1`
- `cd tests/integrations && go test ./mcs/tso -run '^TestTSOServerTestSuite/TestTSOServerStartAndStopNormally$' -count=1`

Note: `go test ./pkg/mcs/resourcemanager/server -run '^TestCleanUpTicker$' -count=1` still fails locally with the existing stale-record count assertion; that failure is unrelated to this port-conflict change.

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by initializing listener/address configuration earlier and reconciling advertised addresses with the actual bound address (including consistent naming and advertise host derivation).
  * Added safer startup failure cleanup to deregister services and close listeners when startup fails.
  * Improved handling of kernel-selected ports so listen/advertise resolution remains consistent at runtime.
* **Tests**
  * Added leak-checked unit tests covering actual listen address resolution, advertise resolution, and unspecified-address-family behavior.
* **Chores**
  * Simplified integration test server startup by removing temp URL allocations and normalizing test listen addresses when empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->