### PR TITLE
client: use batch-level runtime trace regions

### DIFF
--- a/client/clients/router/client.go
+++ b/client/clients/router/client.go
@@ -730,23 +730,24 @@ type sendFn func(*pdpb.QueryRegionRequest) error
 
 func (c *Cli) processRequestsInner(send sendFn, recv recvFn) error {
 	var (
-		requests     = c.batchController.GetCollectedRequests()
-		traceRegions = make([]*trace.Region, 0, len(requests))
-		spans        = make([]opentracing.Span, 0, len(requests))
+		requests = c.batchController.GetCollectedRequests()
+		spans    = make([]opentracing.Span, 0, len(requests))
 	)
+	traceCtx := context.Background()
+	if len(requests) > 0 {
+		traceCtx = requests[0].requestCtx
+	}
+	traceRegion := trace.StartRegion(traceCtx, "pdclient.regionReqSendBatch")
 	for _, req := range requests {
-		traceRegions = append(traceRegions, trace.StartRegion(req.requestCtx, "pdclient.regionReqSend"))
 		if span := opentracing.SpanFromContext(req.requestCtx); span != nil && span.Tracer() != nil {
 			spans = append(spans, span.Tracer().StartSpan("pdclient.processRegionRequests", opentracing.ChildOf(span.Context())))
 		}
 	}
 	defer func() {
-		for i := range spans {
+		for i := len(spans) - 1; i >= 0; i-- {
 			spans[i].Finish()
 		}
-		for i := range traceRegions {
-			traceRegions[i].End()
-		}
+		traceRegion.End()
 	}()
 
 	queryReq := &pdpb.QueryRegionRequest{

--- a/client/clients/tso/dispatcher.go
+++ b/client/clients/tso/dispatcher.go
@@ -403,12 +403,15 @@ func (td *tsoDispatcher) processRequests(
 ) error {
 	// `done` must be guaranteed to be eventually called.
 	var (
-		requests     = tbc.GetCollectedRequests()
-		traceRegions = make([]*trace.Region, 0, len(requests))
-		spans        = make([]opentracing.Span, 0, len(requests))
+		requests = tbc.GetCollectedRequests()
+		spans    = make([]opentracing.Span, 0, len(requests))
 	)
+	traceCtx := context.Background()
+	if len(requests) > 0 {
+		traceCtx = requests[0].requestCtx
+	}
+	traceRegion := trace.StartRegion(traceCtx, "pdclient.tsoReqSendBatch")
 	for _, req := range requests {
-		traceRegions = append(traceRegions, trace.StartRegion(req.requestCtx, "pdclient.tsoReqSend"))
 		if span := opentracing.SpanFromContext(req.requestCtx); span != nil && span.Tracer() != nil {
 			spans = append(spans, span.Tracer().StartSpan("pdclient.processRequests", opentracing.ChildOf(span.Context())))
 		}
@@ -417,9 +420,7 @@ func (td *tsoDispatcher) processRequests(
 		for i := len(spans) - 1; i >= 0; i-- {
 			spans[i].Finish()
 		}
-		for i := len(traceRegions) - 1; i >= 0; i-- {
-			traceRegions[i].End()
-		}
+		traceRegion.End()
 	}()
 
 	var (


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10964

Batched PD client requests currently start one Go runtime trace region per request on the same dispatcher goroutine. Runtime trace regions are goroutine-local and must be nested in LIFO order, so representing batched requests as overlapping per-request regions can make `go tool trace` fail with errors like:

```text
misuse of region in goroutine 400: region end {898020 pdclient.tsoReqSend} when the inner-most active region start event is {898021 pdclient.tsoReqSend}
```

This can make Go trace timeline and derived pprof outputs unusable during production diagnosis.

### What is changed and how does it work?

Use one batch-level runtime trace region for each batched send path, while preserving per-request opentracing spans:

- Replace per-request `pdclient.tsoReqSend` runtime regions with one `pdclient.tsoReqSendBatch` region in the TSO dispatcher.
- Replace per-request `pdclient.regionReqSend` runtime regions with one `pdclient.regionReqSendBatch` region in the region router client.
- Keep the per-request opentracing spans unchanged, so request-level tracing remains available through opentracing.

```commit-message
client: use batch-level runtime trace regions

Runtime trace regions are goroutine-local execution intervals and must be
nested in LIFO order. The PD client batch send paths started one runtime trace
region per request on the same dispatcher goroutine, which can make batched
requests appear as overlapping/nonnested regions and break Go trace parsing.

Use a single batch-level runtime trace region for each batched send path and
keep per-request detail in opentracing spans.
```

### Check List

Tests

- Unit test

Code changes

- None

Side effects

- None

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn): None
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup): None
- Need to cherry-pick to the release branch: No

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracing consistency for batched request processing across router and TSO dispatch flows.
  * Reduced tracing overhead by using a single batch-level trace for grouped requests rather than creating multiple per-request traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->