### PR TITLE
test: stabilize flaky TestConfigTTLAfterTransferLeader

### DIFF
--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -953,7 +953,7 @@ func TestConfigTTLAfterTransferLeader(t *testing.T) {
 			options.GetMaxSnapshotCount() == 999 &&
 			!options.IsLocationReplacementEnabled()
 	})
-	re.NoError(cluster.GetServer(leaderName).ResignLeader())
+	re.NoError(cluster.GetServer(leaderName).ResignLeaderWithRetry())
 	newLeaderName := cluster.WaitLeader()
 	re.NotEmpty(newLeaderName)
 	re.NotEqual(leaderName, newLeaderName)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/pd/issues/10957

Problem Summary:
Flaky test `TestConfigTTLAfterTransferLeader` in `github.com/tikv/pd/tests/integrations/client` intermittently fails, so this PR stabilizes that path.

### What changed and how does it work?
#### Root Cause

One-shot etcd leader transfer made a TTL config test fail on transient setup timeout before TTL assertions.

#### Fix

`ResignLeaderWithRetry` is the existing helper for transient etcd leader movement timeout and preserves the intended leader-change setup.

#### Verification

Spec:
- target: `github.com/tikv/pd/tests/integrations/client :: TestConfigTTLAfterTransferLeader`
- strategy: `pd.issue_scoped.v1`
- plan mode: `BASELINE_ONLY`
- requirements: required case must execute; no skip; repeat count = 1
- baseline gates: required_flaky_gate, build_safety_gate, intent_guard_gate
- feedback surface source: `baseline_only`

Observed result:
- status: passed
- submission decision: ALLOWED
- note: repo_correct_target passed.
build passed.

Gate checklist:
- timing_repro: SKIPPED
- runtime_path_mismatch_target: SKIPPED
- runtime_path_mismatch_package: SKIPPED
- repo_correct_target: PASS
- build: PASS
- prow_next_gen: SKIPPED

Commands:
- `make -C tests/integrations gotest GOTEST_ARGS='./client -tags without_dashboard -run ^TestConfigTTLAfterTransferLeader$$ -count=1'`
- `make build`

### Release note

```release-note
None
```

Fixes #10957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved a leadership-transfer test by switching the leader resignation step to a retry-based approach, making the transition more reliable before verifying configuration persistence on the newly elected leader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->