### PR TITLE
tso, pd-ctl: support evicting all keyspace group primaries on a node

### DIFF
--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -146,6 +146,10 @@ func (s *Service) RegisterPrimaryRouter() {
 	// transferPrimary forwards the request to the primary of the target keyspace
 	// group itself (see forwardToGroupPrimary).
 	router.POST("transfer", transferPrimary)
+	// evictPrimary transfers away every keyspace group primary currently held by
+	// this node. It only acts on groups this node is serving as primary, so there
+	// is nothing to forward.
+	router.POST("evict", evictPrimary)
 }
 
 func changeLogLevel(c *gin.Context) {
@@ -382,6 +386,108 @@ func transferPrimary(c *gin.Context) {
 		return
 	}
 	c.IndentedJSON(http.StatusOK, "success")
+}
+
+// evictPrimary transfers away every keyspace group primary currently held by this
+// node, moving each to another member of the same group. It is a best-effort,
+// node-local operation: groups that this node is not serving as primary are
+// skipped, and a failure on one group does not stop the others.
+//
+// The request is rejected as a whole if this node is the primary of any
+// splitting keyspace group: a split target must campaign on the same TSO node as
+// its split source, but eviction transfers each group to an independently chosen
+// member, which could break that invariant and leave the target keyspaces
+// without a primary. A single TransferPrimary is not atomic and the groups are
+// iterated in no particular order, so the split state is checked for every
+// candidate group up front before transferring anything; otherwise a normal
+// group could be moved before a later splitting group aborts the loop, leaving
+// partial side effects. Since splitting is transient, the caller should retry
+// once it finishes.
+// @Tags     primary
+// @Summary  Evict all keyspace group primaries held by this node.
+// @Produce  json
+// @Success  200  {object}  map[string]string
+// @Failure  500  {object}  map[string]string
+// @Router   /primary/evict [post]
+func evictPrimary(c *gin.Context) {
+	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*tsoserver.Service)
+	kgm := svr.GetKeyspaceGroupManager()
+
+	// Collect the keyspace groups this node is currently the primary of. There is
+	// nothing to transfer away for the others.
+	primaryGroupIDs := make([]uint32, 0, len(kgm.GetServingKeyspaceGroups()))
+	for keyspaceGroupID := range kgm.GetServingKeyspaceGroups() {
+		allocator, err := svr.GetTSOAllocator(keyspaceGroupID)
+		if err != nil || !allocator.GetMember().IsServing() {
+			continue
+		}
+		primaryGroupIDs = append(primaryGroupIDs, keyspaceGroupID)
+	}
+
+	// Pre-check every candidate group before transferring anything so the
+	// operation is all-or-nothing: reject the whole request if any of them is
+	// splitting, instead of moving some groups first and only then aborting.
+	for _, keyspaceGroupID := range primaryGroupIDs {
+		if group := kgm.GetKeyspaceGroupByID(keyspaceGroupID); group != nil && group.IsSplitting() {
+			c.AbortWithStatusJSON(http.StatusInternalServerError,
+				errs.ErrKeyspaceGroupInSplit.FastGenByArgs(keyspaceGroupID).Error())
+			return
+		}
+	}
+
+	// results maps a keyspace group ID to the transfer outcome ("success" or the
+	// error message), so the caller can see the per-group result.
+	results := make(map[uint32]string)
+	failed := false
+	for _, keyspaceGroupID := range primaryGroupIDs {
+		allocator, err := svr.GetTSOAllocator(keyspaceGroupID)
+		if err != nil {
+			continue
+		}
+		// Re-check the split state against the latest meta right before the
+		// transfer: a split can still start after the pre-check above. This
+		// narrows, but cannot fully close, the window.
+		group := kgm.GetKeyspaceGroupByID(keyspaceGroupID)
+		if group == nil {
+			continue
+		}
+		if group.IsSplitting() {
+			c.AbortWithStatusJSON(http.StatusInternalServerError,
+				errs.ErrKeyspaceGroupInSplit.FastGenByArgs(keyspaceGroupID).Error())
+			return
+		}
+
+		// only members of the specific group are valid primary candidates.
+		memberMap := make(map[string]bool, len(group.Members))
+		for _, member := range group.Members {
+			memberMap[member.Address] = true
+		}
+
+		participant, ok := allocator.GetMember().(*member.Participant)
+		if !ok {
+			continue
+		}
+		// TODO: consider priority here. This is a one-shot transfer; if this node
+		// has a higher priority for the group, the priority checker will move the
+		// primary back to it, so the eviction does not durably drain the node.
+		// Priority handling is being reworked, so revisit this when needed.
+		// An empty new primary lets TransferPrimary pick a random other member.
+		if err := utils.TransferPrimary(svr.GetClient(), participant,
+			mcs.TSOServiceName, svr.Name(), "", keyspaceGroupID, memberMap); err != nil {
+			log.Warn("failed to evict keyspace group primary",
+				zap.Uint32("keyspace-group-id", keyspaceGroupID), errs.ZapError(err))
+			results[keyspaceGroupID] = err.Error()
+			failed = true
+			continue
+		}
+		results[keyspaceGroupID] = "success"
+	}
+
+	if failed {
+		c.IndentedJSON(http.StatusInternalServerError, results)
+		return
+	}
+	c.IndentedJSON(http.StatusOK, results)
 }
 
 // forwardToGroupPrimary forwards the transfer primary request to the primary of

--- a/server/apiv2/handlers/microservice.go
+++ b/server/apiv2/handlers/microservice.go
@@ -15,20 +15,31 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/tikv/pd/pkg/mcs/discovery"
+	mcs "github.com/tikv/pd/pkg/mcs/utils/constant"
+	"github.com/tikv/pd/pkg/utils/apiutil"
+	"github.com/tikv/pd/pkg/utils/grpcutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/apiv2/middlewares"
 )
+
+// tsoPrimaryEvictPath is the tso-node-local endpoint that transfers away every
+// keyspace group primary held by the node.
+const tsoPrimaryEvictPath = "/tso/api/v1/primary/evict"
 
 // RegisterMicroservice registers microservice handler to the router.
 func RegisterMicroservice(r *gin.RouterGroup) {
 	router := r.Group("ms")
 	router.GET("members/:service", GetMembers)
 	router.GET("primary/:service", GetPrimary)
+	router.POST("tso/primary/evict", EvictTSOPrimary)
 }
 
 // GetMembers gets all members of the cluster for the specified service.
@@ -79,4 +90,85 @@ func GetPrimary(c *gin.Context) {
 	}
 
 	c.AbortWithStatusJSON(http.StatusInternalServerError, "please specify service")
+}
+
+// EvictTSOPrimary forwards a request that evicts all keyspace group primaries
+// held by the given tso node to that node. The eviction is node-local, so the
+// caller only needs to reach PD, which proxies the request to the target node.
+//
+//	@Tags		primary
+//	@Summary	Evict all keyspace group primaries held by the given tso node.
+//	@Param		node	query	string	true	"the target tso node address"
+//	@Produce	json
+//	@Success	200	{object}	map[string]string
+//	@Failure	400	{string}	string	"The input is invalid."
+//	@Failure	500	{string}	string	"PD server failed to proceed the request."
+//	@Router		/ms/tso/primary/evict [post]
+func EvictTSOPrimary(c *gin.Context) {
+	svr := c.MustGet(middlewares.ServerContextKey).(*server.Server)
+	if !svr.IsKeyspaceGroupEnabled() {
+		c.AbortWithStatusJSON(http.StatusNotFound, "not support microservice")
+		return
+	}
+	node := c.Query("node")
+	if len(node) == 0 {
+		c.AbortWithStatusJSON(http.StatusBadRequest, "please specify the tso node")
+		return
+	}
+	// Only forward to a node that is a known tso member so that PD is not turned
+	// into an open proxy to an arbitrary address.
+	entries, err := discovery.GetMSMembers(mcs.TSOServiceName, svr.GetClient())
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+	// Match by base URL so that a scheme (http/https) or advertise-listen-addr
+	// difference does not cause a false negative, and forward to the member's
+	// canonical address rather than the raw client input.
+	target := ""
+	for _, entry := range entries {
+		if typeutil.EqualBaseURLs(entry.ServiceAddr, node) {
+			target = entry.ServiceAddr
+			break
+		}
+	}
+	if target == "" {
+		c.AbortWithStatusJSON(http.StatusBadRequest, fmt.Sprintf("%s is not a tso node", node))
+		return
+	}
+	// The registered address may be a bare advertise-listen-addr without a scheme
+	// (e.g. 127.0.0.1:3379), which url.Parse cannot turn into a usable proxy
+	// target, so default a missing scheme from the server's TLS setup.
+	u, err := resolveProxyURL(target, httpSchemeFromTLS(svr.GetTLSConfig()))
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+	// NewCustomReverseProxies keeps the request path, so rewrite it to the tso
+	// node's evict endpoint and drop the query before forwarding.
+	c.Request.URL.Path = tsoPrimaryEvictPath
+	c.Request.URL.RawQuery = ""
+	apiutil.NewCustomReverseProxies(svr.GetHTTPClient(), []url.URL{*u}).ServeHTTP(c.Writer, c.Request)
+	c.Abort()
+}
+
+// httpSchemeFromTLS returns the URL scheme PD uses to reach its microservice
+// nodes: "https" when TLS is configured, "http" otherwise.
+func httpSchemeFromTLS(tls *grpcutil.TLSConfig) string {
+	if tls != nil && len(tls.CertPath) != 0 {
+		return "https"
+	}
+	return "http"
+}
+
+// resolveProxyURL turns a registry service address into a URL usable by the
+// reverse proxy. A registered address may be stored without a scheme (a bare
+// advertise-listen-addr such as 127.0.0.1:3379), in which case url.Parse yields
+// an empty Host; the given default scheme is applied so the proxy target is
+// valid. An address that already carries a scheme is kept as-is.
+func resolveProxyURL(serviceAddr, defaultScheme string) (*url.URL, error) {
+	if u, err := url.Parse(serviceAddr); err == nil && u.Host != "" {
+		return u, nil
+	}
+	return url.Parse(defaultScheme + "://" + typeutil.TrimScheme(serviceAddr))
 }

--- a/server/apiv2/handlers/microservice_test.go
+++ b/server/apiv2/handlers/microservice_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/utils/grpcutil"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestHTTPSchemeFromTLS(t *testing.T) {
+	re := require.New(t)
+	re.Equal("http", httpSchemeFromTLS(nil))
+	re.Equal("http", httpSchemeFromTLS(&grpcutil.TLSConfig{}))
+	re.Equal("https", httpSchemeFromTLS(&grpcutil.TLSConfig{CertPath: "/path/to/cert.pem"}))
+}
+
+func TestResolveProxyURL(t *testing.T) {
+	re := require.New(t)
+	testCases := []struct {
+		serviceAddr   string
+		defaultScheme string
+		expected      string
+	}{
+		// A registered address without a scheme (a bare advertise-listen-addr)
+		// takes the default scheme.
+		{"127.0.0.1:3379", "http", "http://127.0.0.1:3379"},
+		{"localhost:3379", "http", "http://localhost:3379"},
+		{"127.0.0.1:3379", "https", "https://127.0.0.1:3379"},
+		// An address that already carries a scheme is kept as-is.
+		{"http://127.0.0.1:3379", "http", "http://127.0.0.1:3379"},
+		{"https://127.0.0.1:3379", "http", "https://127.0.0.1:3379"},
+	}
+	for _, tc := range testCases {
+		u, err := resolveProxyURL(tc.serviceAddr, tc.defaultScheme)
+		re.NoError(err)
+		re.Equal(tc.expected, u.String())
+	}
+}

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -294,6 +294,250 @@ func (suite *memberTestSuite) TestTransferPrimary() {
 	}
 }
 
+// TestEvictPrimary verifies that the tso-only /primary/evict endpoint transfers
+// away every keyspace group primary held by the target node. It creates many
+// keyspace groups replicated on all tso nodes and exercises every node as the
+// eviction target in turn.
+func (suite *memberTestSuite) TestEvictPrimary() {
+	re := suite.Require()
+
+	// Every created group is replicated on all three tso nodes, so each node can
+	// be exercised as the eviction target and always has a destination to move
+	// its primaries to.
+	nodeList := make([]bs.Server, 0, len(suite.tsoNodes))
+	members := make([]endpoint.KeyspaceGroupMember, 0, len(suite.tsoNodes))
+	for _, node := range suite.tsoNodes {
+		nodeList = append(nodeList, node)
+		members = append(members, endpoint.KeyspaceGroupMember{
+			Address:  node.GetAddr(),
+			Priority: mcs.DefaultKeyspaceGroupReplicaPriority,
+		})
+	}
+	re.Len(nodeList, 3)
+
+	// Create 12 non-default keyspace groups with equal member priority, so that
+	// an eviction is not undone by the priority checker moving the primary back
+	// to a higher-priority member.
+	const groupCount = 12
+	groupIDs := make([]uint32, 0, groupCount)
+	for i := range groupCount {
+		id := uint32(i + 1)
+		groupIDs = append(groupIDs, id)
+		handlersutil.MustCreateKeyspaceGroup(re, suite.server, &handlers.CreateKeyspaceGroupParams{
+			KeyspaceGroups: []*endpoint.KeyspaceGroup{
+				{
+					ID:        id,
+					UserKind:  endpoint.Standard.String(),
+					Members:   members,
+					Keyspaces: []uint32{uint32(90001 + i)},
+				},
+			},
+		})
+	}
+
+	for _, target := range nodeList {
+		tsoTarget := target.(*tso.Server)
+
+		// Concentrate every group's primary on the target node so it holds
+		// multiple keyspace group primaries at once. Retry the transfer, since a
+		// group may not have elected a primary yet right after creation or after
+		// a previous eviction.
+		for _, id := range groupIDs {
+			transferData, err := json.Marshal(map[string]any{
+				"new_primary":       target.Name(),
+				"keyspace_group_id": id,
+			})
+			re.NoError(err)
+			testutil.Eventually(re, func() bool {
+				resp, err := tests.TestDialClient.Post(target.GetAddr()+"/tso/api/v1/primary/transfer",
+					"application/json", bytes.NewBuffer(transferData))
+				if err != nil {
+					return false
+				}
+				defer resp.Body.Close()
+				return resp.StatusCode == http.StatusOK
+			}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+		}
+
+		// Wait until the target node is the primary of all created groups.
+		testutil.Eventually(re, func() bool {
+			serving := mustGetKeyspaceGroupMembers(re, tsoTarget)
+			for _, id := range groupIDs {
+				if serving[id] == nil || !serving[id].IsPrimary {
+					return false
+				}
+			}
+			return true
+		}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+
+		// Evict all keyspace group primaries held by the target node.
+		resp, err := tests.TestDialClient.Post(target.GetAddr()+"/tso/api/v1/primary/evict",
+			"application/json", nil)
+		re.NoError(err)
+		re.Equal(http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		re.NoError(err)
+		resp.Body.Close()
+
+		// The response body carries the per-group eviction result. Every group the
+		// target held must be reported, and each must have transferred
+		// successfully. Since the target was concentrated as the primary of all
+		// created groups, they must all appear here.
+		results := make(map[uint32]string)
+		re.NoError(json.Unmarshal(body, &results), string(body))
+		for _, id := range groupIDs {
+			re.Equalf("success", results[id], "group %d result: %q", id, results[id])
+		}
+		for id, status := range results {
+			re.Equalf("success", status, "group %d result: %q", id, status)
+		}
+
+		// The target node should no longer be primary of any keyspace group it
+		// serves.
+		testutil.Eventually(re, func() bool {
+			serving := mustGetKeyspaceGroupMembers(re, tsoTarget)
+			for _, member := range serving {
+				if member.IsPrimary {
+					return false
+				}
+			}
+			return true
+		}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+
+		// Every created group should have a serving primary on one of the other
+		// nodes.
+		testutil.Eventually(re, func() bool {
+			served := make(map[uint32]bool, len(groupIDs))
+			for _, node := range nodeList {
+				if node.GetAddr() == target.GetAddr() {
+					continue
+				}
+				serving := mustGetKeyspaceGroupMembers(re, node.(*tso.Server))
+				for _, id := range groupIDs {
+					if serving[id] != nil && serving[id].IsPrimary {
+						served[id] = true
+					}
+				}
+			}
+			return len(served) == len(groupIDs)
+		}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+	}
+}
+
+// TestEvictPrimaryRejectedWhileSplitting verifies that /primary/evict refuses to
+// drain a node while it is the primary of a splitting keyspace group, because a
+// split target must campaign on the same node as its split source and eviction
+// would break that invariant. It also asserts the rejection happens before any
+// transfer: a normal group co-located on the node must not be moved. It runs in
+// the member suite so each case gets a fresh cluster, keeping this disruptive
+// eviction isolated.
+func (suite *memberTestSuite) TestEvictPrimaryRejectedWhileSplitting() {
+	re := suite.Require()
+
+	// Hold the split in progress so /evict observes a splitting group.
+	const pauseFinishSplit = "github.com/tikv/pd/pkg/keyspace/pauseFinishSplitBeforeTxn"
+	re.NoError(failpoint.Enable(pauseFinishSplit, `pause`))
+	defer func() {
+		re.NoError(failpoint.Disable(pauseFinishSplit))
+	}()
+
+	members := make([]endpoint.KeyspaceGroupMember, 0, len(suite.tsoNodes))
+	for _, node := range suite.tsoNodes {
+		members = append(members, endpoint.KeyspaceGroupMember{
+			Address:  node.GetAddr(),
+			Priority: mcs.DefaultKeyspaceGroupReplicaPriority,
+		})
+	}
+	const (
+		srcID    = uint32(1)
+		dstID    = uint32(2)
+		normalID = uint32(3)
+	)
+	// A normal (non-splitting) group, used to prove the eviction is rejected
+	// before any transfer side effect.
+	handlersutil.MustCreateKeyspaceGroup(re, suite.server, &handlers.CreateKeyspaceGroupParams{
+		KeyspaceGroups: []*endpoint.KeyspaceGroup{
+			{
+				ID:        normalID,
+				UserKind:  endpoint.Standard.String(),
+				Members:   members,
+				Keyspaces: []uint32{2000},
+			},
+		},
+	})
+	// Create a keyspace group on all tso nodes, then split it. Both source and
+	// target stay in the splitting state while the failpoint is active.
+	handlersutil.MustCreateKeyspaceGroup(re, suite.server, &handlers.CreateKeyspaceGroupParams{
+		KeyspaceGroups: []*endpoint.KeyspaceGroup{
+			{
+				ID:        srcID,
+				UserKind:  endpoint.Standard.String(),
+				Members:   members,
+				Keyspaces: []uint32{1000, 1001, 1002},
+			},
+		},
+	})
+	handlersutil.MustSplitKeyspaceGroup(re, suite.server, srcID, &handlers.SplitKeyspaceGroupByIDParams{
+		NewID:     dstID,
+		Keyspaces: []uint32{1001, 1002},
+	})
+	kg := handlersutil.MustLoadKeyspaceGroupByID(re, suite.server, dstID)
+	re.True(kg.IsSplitTarget())
+
+	// Wait until a tso node both is the primary of the split source and observes
+	// it as splitting; that node is the eviction target.
+	var target bs.Server
+	testutil.Eventually(re, func() bool {
+		for _, node := range suite.tsoNodes {
+			m := mustGetKeyspaceGroupMembers(re, node.(*tso.Server))
+			if g, ok := m[srcID]; ok && g.IsPrimary && g.Group.IsSplitting() {
+				target = node
+				return true
+			}
+		}
+		return false
+	}, testutil.WithWaitFor(30*time.Second), testutil.WithTickInterval(200*time.Millisecond))
+	re.NotNil(target)
+	tsoTarget := target.(*tso.Server)
+
+	// Concentrate the normal group's primary on the same node, so it is the
+	// primary of both a normal and a splitting group.
+	transferData, err := json.Marshal(map[string]any{
+		"new_primary":       target.Name(),
+		"keyspace_group_id": normalID,
+	})
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		resp, err := tests.TestDialClient.Post(target.GetAddr()+"/tso/api/v1/primary/transfer",
+			"application/json", bytes.NewBuffer(transferData))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+	testutil.Eventually(re, func() bool {
+		g, ok := mustGetKeyspaceGroupMembers(re, tsoTarget)[normalID]
+		return ok && g.IsPrimary
+	}, testutil.WithWaitFor(10*time.Second), testutil.WithTickInterval(50*time.Millisecond))
+
+	// Evicting the node is rejected because it is the primary of a splitting group.
+	resp, err := tests.TestDialClient.Post(target.GetAddr()+"/tso/api/v1/primary/evict",
+		"application/json", nil)
+	re.NoError(err)
+	re.Equal(http.StatusInternalServerError, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	re.NoError(err)
+	resp.Body.Close()
+	re.Contains(string(body), "is in split state")
+
+	// The rejection must happen before any transfer, so the normal group is still
+	// the primary on this node (not moved by a partial eviction).
+	g, ok := mustGetKeyspaceGroupMembers(re, tsoTarget)[normalID]
+	re.True(ok)
+	re.True(g.IsPrimary)
+}
+
 func (suite *memberTestSuite) TestCampaignPrimaryAfterTransfer() {
 	re := suite.Require()
 	supportedServices := []string{"tso", "scheduling", "resource_manager"}

--- a/tools/pd-ctl/pdctl/command/microservice_command.go
+++ b/tools/pd-ctl/pdctl/command/microservice_command.go
@@ -17,6 +17,7 @@ package command
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,11 @@ import (
 var (
 	msPrimaryPrefix = "/pd/api/v2/ms/primary/%s"
 	msMembersPrefix = "/pd/api/v2/ms/members/%s"
+	// msTSOEvictPrimaryPrefix is the PD endpoint that forwards an eviction of all
+	// keyspace group primaries to the given tso node. It intentionally has no
+	// leading slash: doRequest joins it to the endpoint with a "/", and a POST to
+	// the resulting double-slash path would not be redirected the way GETs are.
+	msTSOEvictPrimaryPrefix = "pd/api/v2/ms/tso/primary/evict?node=%s"
 )
 
 // NewMicroServicesCommand return a microservice subcommand of rootCmd
@@ -40,7 +46,7 @@ func NewMicroServicesCommand() *cobra.Command {
 
 func newMSTsoCommand() *cobra.Command {
 	d := &cobra.Command{
-		Use:   "tso <primary|members>",
+		Use:   "tso <primary|members|evict-primary>",
 		Short: "tso microservice commands",
 	}
 	d.AddCommand(&cobra.Command{
@@ -53,7 +59,16 @@ func newMSTsoCommand() *cobra.Command {
 		Short: "show the tso members status",
 		Run:   getMembersCommandFunc,
 	})
+	d.AddCommand(newEvictTSOPrimaryCommand())
 	return d
+}
+
+func newEvictTSOPrimaryCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "evict-primary <tso_node_address>",
+		Short: "evict all keyspace group primaries held by the given tso node",
+		Run:   evictTSOPrimaryCommandFunc,
+	}
 }
 
 func newMSSchedulingCommand() *cobra.Command {
@@ -93,6 +108,22 @@ func getMembersCommandFunc(cmd *cobra.Command, _ []string) {
 	r, err := doRequest(cmd, uri, http.MethodGet, http.Header{})
 	if err != nil {
 		cmd.Printf("Failed to get the %s microservice members: %s\n", parent, err)
+		return
+	}
+	cmd.Println(r)
+}
+
+func evictTSOPrimaryCommandFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Println(cmd.UsageString())
+		return
+	}
+	// The request goes to PD, which forwards it to the given tso node. The
+	// eviction only drains the primaries held by that node.
+	uri := fmt.Sprintf(msTSOEvictPrimaryPrefix, url.QueryEscape(args[0]))
+	r, err := doRequest(cmd, uri, http.MethodPost, http.Header{})
+	if err != nil {
+		cmd.Printf("Failed to evict the tso primaries on %s: %s\n", args[0], err)
 		return
 	}
 	cmd.Println(r)

--- a/tools/pd-ctl/tests/microservice/microservice_test.go
+++ b/tools/pd-ctl/tests/microservice/microservice_test.go
@@ -74,6 +74,26 @@ func (suite *microServiceSuite) TestMicroService() {
 		v := make([]any, 0)
 		tests.MustExec(re, cmd, []string{"-u", pdAddr, "microservice", "tso", "members"}, &v)
 		re.Len(v, 2)
+
+		// PD rejects an unknown node before forwarding anything.
+		errRes := tests.MustExec(re, cmd, []string{"-u", pdAddr, "microservice", "tso", "evict-primary", "http://127.0.0.1:1"}, nil)
+		re.Contains(errRes, "is not a tso node")
+
+		// Evict all keyspace group primaries on the current tso primary node. The
+		// request goes to PD, which forwards it to that node. The node address is
+		// passed without a scheme to exercise the address normalization on the PD
+		// side. Retry until the default keyspace group has a second replica to
+		// receive the transfer; a failed eviction transfers nothing, so retrying
+		// is safe. Keep this last: it moves the tso primary away.
+		testutil.Eventually(re, func() bool {
+			primary := cluster.GetDefaultTSOPrimaryServer()
+			if primary == nil {
+				return false
+			}
+			node := strings.TrimPrefix(primary.GetAddr(), "http://")
+			out, err := tests.ExecuteCommand(cmd, "-u", pdAddr, "microservice", "tso", "evict-primary", node)
+			return err == nil && strings.Contains(string(out), "success")
+		})
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10967

A TSO node exposes `POST /tso/api/v1/primary/transfer` to move a single
keyspace group primary away. Draining a node (restart/upgrade/decommission)
requires moving *all* keyspace group primaries off it, which today means
calling `transfer` once per group — tedious and error-prone.

### What is changed and how does it work?

Add a node-local endpoint and a pd-ctl command to evict every keyspace group
primary held by a node in one step.

```commit-message
Add POST /tso/api/v1/primary/evict, which transfers away every keyspace
group primary currently held by the target TSO node. It iterates over the
groups this node is serving as primary and transfers each to another member
of the same group. It is best-effort: groups the node does not serve as
primary are skipped, a failure on one group does not abort the others, and a
per-group result map is returned.

Expose it through pd-ctl as `microservice tso evict-primary <address>`, which
sends the request directly to the target node since the operation is
node-local.
```

### Check List

Tests

- Integration test

Code changes

- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

```release-note
Support evicting all keyspace group primaries held by a TSO node via the new `POST /tso/api/v1/primary/evict` endpoint and the `pd-ctl microservice tso evict-primary` command.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TSO primary eviction endpoint (`POST /tso/api/v1/primary/evict`) to trigger best-effort eviction of eligible keyspace-group primaries served by the target node.
  * Added a `pd-ctl microservice tso evict-primary <tso_node_address>` command to invoke the endpoint and display per-group outcomes.
* **Behavior Updates**
  * The response includes per–keyspace-group result details; HTTP 500 if any group fails, otherwise HTTP 200.
* **Tests**
  * Added an integration test to validate primary reassignment end-to-end.
  * Added unit tests for the new `pd-ctl` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->