### PR TITLE
mcs: skip transferring primary to itself

### DIFF
--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -157,6 +157,20 @@ func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName
 		return err
 	}
 
+	if newPrimary != "" {
+		for _, member := range entries {
+			if tsoMembersMap != nil && !tsoMembersMap[member.ServiceAddr] {
+				continue
+			}
+			if isSamePrimary(member, newPrimary) && isSamePrimary(member, oldPrimary) {
+				log.Info("skip transferring primary to itself",
+					zap.String("service", serviceName),
+					zap.String("primary", oldPrimary))
+				return nil
+			}
+		}
+	}
+
 	// Do nothing when I am the only member of cluster.
 	if len(entries) == 1 {
 		return errors.Errorf("no valid secondary to transfer primary, the only member is %s", entries[0].Name)
@@ -168,7 +182,7 @@ func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName
 		if tsoMembersMap != nil && !tsoMembersMap[member.ServiceAddr] {
 			continue
 		}
-		if (newPrimary == "" && member.Name != oldPrimary) || (newPrimary != "" && member.Name == newPrimary) {
+		if (newPrimary == "" && member.Name != oldPrimary) || (newPrimary != "" && isSamePrimary(member, newPrimary)) {
 			primaryIDs = append(primaryIDs, member.ServiceAddr)
 		}
 	}
@@ -202,4 +216,8 @@ func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName
 		return errors.Errorf("failed to mark expected primary flag for %s, err: %v", serviceName, err)
 	}
 	return nil
+}
+
+func isSamePrimary(member discovery.ServiceRegistryEntry, primary string) bool {
+	return primary != "" && (member.Name == primary || member.ServiceAddr == primary)
 }

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -182,7 +182,7 @@ func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName
 		if tsoMembersMap != nil && !tsoMembersMap[member.ServiceAddr] {
 			continue
 		}
-		if (newPrimary == "" && member.Name != oldPrimary) || isSamePrimary(member, newPrimary) {
+		if (newPrimary == "" && !isSamePrimary(member, oldPrimary)) || isSamePrimary(member, newPrimary) {
 			primaryIDs = append(primaryIDs, member.ServiceAddr)
 		}
 	}

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -182,7 +182,7 @@ func TransferPrimary(client *clientv3.Client, lease *election.Lease, serviceName
 		if tsoMembersMap != nil && !tsoMembersMap[member.ServiceAddr] {
 			continue
 		}
-		if (newPrimary == "" && member.Name != oldPrimary) || (newPrimary != "" && isSamePrimary(member, newPrimary)) {
+		if (newPrimary == "" && member.Name != oldPrimary) || isSamePrimary(member, newPrimary) {
 			primaryIDs = append(primaryIDs, member.ServiceAddr)
 		}
 	}

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -144,6 +144,52 @@ func TestTransferPrimaryRandomKeepsExistingBehavior(t *testing.T) {
 	re.NotEqual(beforeResp.Kvs[0].Lease, afterResp.Kvs[0].Lease)
 }
 
+func TestTransferPrimaryRandomExcludesOldPrimaryByServiceAddress(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	keypath.SetClusterID(uint64(time.Now().UnixNano()))
+	defer keypath.ResetClusterID()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const (
+		primaryName   = "tso-primary"
+		primaryAddr   = "http://127.0.0.1:10001"
+		secondaryName = "tso-secondary"
+		secondaryAddr = "http://127.0.0.1:10002"
+	)
+	putRegistryEntry(ctx, re, client, primaryName, primaryAddr)
+	putRegistryEntry(ctx, re, client, secondaryName, secondaryAddr)
+
+	lease := election.NewLease(client, "tso expected primary 00000")
+	re.NoError(lease.Grant(constant.DefaultLease))
+	defer func() {
+		_ = lease.Close()
+	}()
+
+	expectedPrimaryPath := keypath.ExpectedPrimaryPath(&keypath.MsParam{
+		ServiceName: constant.TSOServiceName,
+		GroupID:     0,
+	})
+	_, err := client.Put(ctx, expectedPrimaryPath, primaryAddr, clientv3.WithLease(lease.GetID()))
+	re.NoError(err)
+
+	err = mcsutils.TransferPrimary(client, lease, constant.TSOServiceName,
+		primaryAddr, "", 0, map[string]bool{
+			primaryAddr:   true,
+			secondaryAddr: true,
+		})
+	re.NoError(err)
+
+	afterResp, err := client.Get(ctx, expectedPrimaryPath)
+	re.NoError(err)
+	re.Len(afterResp.Kvs, 1)
+	re.Equal(secondaryAddr, string(afterResp.Kvs[0].Value))
+}
+
 func putRegistryEntry(
 	ctx context.Context,
 	re *require.Assertions,

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -36,173 +36,164 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
 }
 
-func TestTransferPrimaryToSelfKeepsExpectedPrimaryLease(t *testing.T) {
-	re := require.New(t)
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
-	defer clean()
+const (
+	testPrimaryName   = "tso-primary"
+	testPrimaryAddr   = "http://127.0.0.1:10001"
+	testSecondaryName = "tso-secondary"
+	testSecondaryAddr = "http://127.0.0.1:10002"
+)
 
-	keypath.SetClusterID(uint64(time.Now().UnixNano()))
-	defer keypath.ResetClusterID()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	const (
-		primaryName   = "tso-primary"
-		primaryAddr   = "http://127.0.0.1:10001"
-		secondaryName = "tso-secondary"
-		secondaryAddr = "http://127.0.0.1:10002"
-	)
-	putRegistryEntry(ctx, re, client, primaryName, primaryAddr)
-	putRegistryEntry(ctx, re, client, secondaryName, secondaryAddr)
-
-	lease := election.NewLease(client, "tso expected primary 00000")
-	re.NoError(lease.Grant(constant.DefaultLease))
-	defer func() {
-		_ = lease.Close()
-	}()
-
-	msParam := &keypath.MsParam{
-		ServiceName: constant.TSOServiceName,
-		GroupID:     0,
+func TestTransferPrimary(t *testing.T) {
+	tests := []struct {
+		name                string
+		oldPrimary          string
+		newPrimary          string
+		expectedPrimary     string
+		keepExpectedPrimary bool
+	}{
+		{
+			name:                "self transfer by name keeps expected primary lease",
+			oldPrimary:          testPrimaryName,
+			newPrimary:          testPrimaryName,
+			expectedPrimary:     testPrimaryAddr,
+			keepExpectedPrimary: true,
+		},
+		{
+			name:                "self transfer by address keeps expected primary lease",
+			oldPrimary:          testPrimaryName,
+			newPrimary:          testPrimaryAddr,
+			expectedPrimary:     testPrimaryAddr,
+			keepExpectedPrimary: true,
+		},
+		{
+			name:            "random transfer excludes old primary by name",
+			oldPrimary:      testPrimaryName,
+			expectedPrimary: testSecondaryAddr,
+		},
+		{
+			name:            "random transfer excludes old primary by address",
+			oldPrimary:      testPrimaryAddr,
+			expectedPrimary: testSecondaryAddr,
+		},
+		{
+			name:            "explicit transfer selects target by name",
+			oldPrimary:      testPrimaryName,
+			newPrimary:      testSecondaryName,
+			expectedPrimary: testSecondaryAddr,
+		},
+		{
+			name:            "explicit transfer selects target by address",
+			oldPrimary:      testPrimaryName,
+			newPrimary:      testSecondaryAddr,
+			expectedPrimary: testSecondaryAddr,
+		},
 	}
-	expectedPrimaryPath := keypath.ExpectedPrimaryPath(msParam)
-	_, err := client.Put(ctx, expectedPrimaryPath, primaryAddr, clientv3.WithLease(lease.GetID()))
-	re.NoError(err)
 
-	beforeResp, err := client.Get(ctx, expectedPrimaryPath)
-	re.NoError(err)
-	re.Len(beforeResp.Kvs, 1)
-	oldExpectedPrimary := beforeResp.Kvs[0]
-	re.Equal(int64(lease.GetID()), oldExpectedPrimary.Lease)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTransferPrimaryTestEnv(t)
+			before := env.getExpectedPrimary(t)
+			re := require.New(t)
+			re.Equal(testPrimaryAddr, before.value)
+			re.Equal(int64(env.lease.GetID()), before.lease)
 
-	err = mcsutils.TransferPrimary(client, lease, constant.TSOServiceName,
-		primaryName, primaryName, 0, map[string]bool{
-			primaryAddr:   true,
-			secondaryAddr: true,
+			err := mcsutils.TransferPrimary(env.client, env.lease, constant.TSOServiceName,
+				tt.oldPrimary, tt.newPrimary, 0, map[string]bool{
+					testPrimaryAddr:   true,
+					testSecondaryAddr: true,
+				})
+			re.NoError(err)
+
+			after := env.getExpectedPrimary(t)
+			re.Equal(tt.expectedPrimary, after.value)
+			if tt.keepExpectedPrimary {
+				re.Equal(before.modRevision, after.modRevision)
+				re.Equal(before.lease, after.lease)
+				return
+			}
+			re.NotEqual(before.modRevision, after.modRevision)
+			re.NotEqual(before.lease, after.lease)
 		})
-	re.NoError(err)
-
-	afterResp, err := client.Get(ctx, expectedPrimaryPath)
-	re.NoError(err)
-	re.Len(afterResp.Kvs, 1)
-	currentExpectedPrimary := afterResp.Kvs[0]
-	re.Equal(string(oldExpectedPrimary.Value), string(currentExpectedPrimary.Value))
-	re.Equal(oldExpectedPrimary.ModRevision, currentExpectedPrimary.ModRevision)
-	re.Equal(oldExpectedPrimary.Lease, currentExpectedPrimary.Lease)
+	}
 }
 
-func TestTransferPrimaryRandomKeepsExistingBehavior(t *testing.T) {
+type transferPrimaryTestEnv struct {
+	ctx                 context.Context
+	client              *clientv3.Client
+	lease               *election.Lease
+	expectedPrimaryPath string
+}
+
+type expectedPrimary struct {
+	value       string
+	modRevision int64
+	lease       int64
+}
+
+func newTransferPrimaryTestEnv(t *testing.T) *transferPrimaryTestEnv {
+	t.Helper()
 	re := require.New(t)
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
-	defer clean()
+	t.Cleanup(clean)
 
 	keypath.SetClusterID(uint64(time.Now().UnixNano()))
-	defer keypath.ResetClusterID()
+	t.Cleanup(keypath.ResetClusterID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 
-	const (
-		primaryName   = "tso-primary"
-		primaryAddr   = "http://127.0.0.1:10001"
-		secondaryName = "tso-secondary"
-		secondaryAddr = "http://127.0.0.1:10002"
-	)
-	putRegistryEntry(ctx, re, client, primaryName, primaryAddr)
-	putRegistryEntry(ctx, re, client, secondaryName, secondaryAddr)
+	putRegistryEntry(t, ctx, client, testPrimaryName, testPrimaryAddr)
+	putRegistryEntry(t, ctx, client, testSecondaryName, testSecondaryAddr)
 
 	lease := election.NewLease(client, "tso expected primary 00000")
 	re.NoError(lease.Grant(constant.DefaultLease))
-	defer func() {
+	t.Cleanup(func() {
 		_ = lease.Close()
-	}()
+	})
 
 	expectedPrimaryPath := keypath.ExpectedPrimaryPath(&keypath.MsParam{
 		ServiceName: constant.TSOServiceName,
 		GroupID:     0,
 	})
-	_, err := client.Put(ctx, expectedPrimaryPath, primaryAddr, clientv3.WithLease(lease.GetID()))
+	_, err := client.Put(ctx, expectedPrimaryPath, testPrimaryAddr, clientv3.WithLease(lease.GetID()))
 	re.NoError(err)
 
-	beforeResp, err := client.Get(ctx, expectedPrimaryPath)
-	re.NoError(err)
-	re.Len(beforeResp.Kvs, 1)
-
-	err = mcsutils.TransferPrimary(client, lease, constant.TSOServiceName,
-		primaryName, "", 0, map[string]bool{
-			primaryAddr:   true,
-			secondaryAddr: true,
-		})
-	re.NoError(err)
-
-	afterResp, err := client.Get(ctx, expectedPrimaryPath)
-	re.NoError(err)
-	re.Len(afterResp.Kvs, 1)
-	re.Equal(secondaryAddr, string(afterResp.Kvs[0].Value))
-	re.NotEqual(beforeResp.Kvs[0].ModRevision, afterResp.Kvs[0].ModRevision)
-	re.NotEqual(beforeResp.Kvs[0].Lease, afterResp.Kvs[0].Lease)
+	return &transferPrimaryTestEnv{
+		ctx:                 ctx,
+		client:              client,
+		lease:               lease,
+		expectedPrimaryPath: expectedPrimaryPath,
+	}
 }
 
-func TestTransferPrimaryRandomExcludesOldPrimaryByServiceAddress(t *testing.T) {
+func (env *transferPrimaryTestEnv) getExpectedPrimary(t *testing.T) expectedPrimary {
+	t.Helper()
 	re := require.New(t)
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
-	defer clean()
-
-	keypath.SetClusterID(uint64(time.Now().UnixNano()))
-	defer keypath.ResetClusterID()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	const (
-		primaryName   = "tso-primary"
-		primaryAddr   = "http://127.0.0.1:10001"
-		secondaryName = "tso-secondary"
-		secondaryAddr = "http://127.0.0.1:10002"
-	)
-	putRegistryEntry(ctx, re, client, primaryName, primaryAddr)
-	putRegistryEntry(ctx, re, client, secondaryName, secondaryAddr)
-
-	lease := election.NewLease(client, "tso expected primary 00000")
-	re.NoError(lease.Grant(constant.DefaultLease))
-	defer func() {
-		_ = lease.Close()
-	}()
-
-	expectedPrimaryPath := keypath.ExpectedPrimaryPath(&keypath.MsParam{
-		ServiceName: constant.TSOServiceName,
-		GroupID:     0,
-	})
-	_, err := client.Put(ctx, expectedPrimaryPath, primaryAddr, clientv3.WithLease(lease.GetID()))
+	resp, err := env.client.Get(env.ctx, env.expectedPrimaryPath)
 	re.NoError(err)
-
-	err = mcsutils.TransferPrimary(client, lease, constant.TSOServiceName,
-		primaryAddr, "", 0, map[string]bool{
-			primaryAddr:   true,
-			secondaryAddr: true,
-		})
-	re.NoError(err)
-
-	afterResp, err := client.Get(ctx, expectedPrimaryPath)
-	re.NoError(err)
-	re.Len(afterResp.Kvs, 1)
-	re.Equal(secondaryAddr, string(afterResp.Kvs[0].Value))
+	re.Len(resp.Kvs, 1)
+	kv := resp.Kvs[0]
+	return expectedPrimary{
+		value:       string(kv.Value),
+		modRevision: kv.ModRevision,
+		lease:       kv.Lease,
+	}
 }
 
 func putRegistryEntry(
+	t *testing.T,
 	ctx context.Context,
-	re *require.Assertions,
 	client *clientv3.Client,
 	name string,
 	serviceAddr string,
 ) {
+	t.Helper()
 	entry := discovery.ServiceRegistryEntry{
 		Name:        name,
 		ServiceAddr: serviceAddr,
 	}
 	serializedValue, err := entry.Serialize()
-	re.NoError(err)
+	require.NoError(t, err)
 	_, err = client.Put(ctx, keypath.RegistryPath(constant.TSOServiceName, serviceAddr), serializedValue)
-	re.NoError(err)
+	require.NoError(t, err)
 }

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/goleak"
 
 	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/mcs/discovery"
@@ -28,7 +29,12 @@ import (
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
+	"github.com/tikv/pd/pkg/utils/testutil"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
 
 func TestTransferPrimaryToSelfKeepsExpectedPrimaryLease(t *testing.T) {
 	re := require.New(t)
@@ -47,8 +53,8 @@ func TestTransferPrimaryToSelfKeepsExpectedPrimaryLease(t *testing.T) {
 		secondaryName = "tso-secondary"
 		secondaryAddr = "http://127.0.0.1:10002"
 	)
-	putRegistryEntry(re, ctx, client, primaryName, primaryAddr)
-	putRegistryEntry(re, ctx, client, secondaryName, secondaryAddr)
+	putRegistryEntry(ctx, re, client, primaryName, primaryAddr)
+	putRegistryEntry(ctx, re, client, secondaryName, secondaryAddr)
 
 	lease := election.NewLease(client, "tso expected primary 00000")
 	re.NoError(lease.Grant(constant.DefaultLease))
@@ -103,11 +109,14 @@ func TestTransferPrimaryRandomKeepsExistingBehavior(t *testing.T) {
 		secondaryName = "tso-secondary"
 		secondaryAddr = "http://127.0.0.1:10002"
 	)
-	putRegistryEntry(re, ctx, client, primaryName, primaryAddr)
-	putRegistryEntry(re, ctx, client, secondaryName, secondaryAddr)
+	putRegistryEntry(ctx, re, client, primaryName, primaryAddr)
+	putRegistryEntry(ctx, re, client, secondaryName, secondaryAddr)
 
 	lease := election.NewLease(client, "tso expected primary 00000")
 	re.NoError(lease.Grant(constant.DefaultLease))
+	defer func() {
+		_ = lease.Close()
+	}()
 
 	expectedPrimaryPath := keypath.ExpectedPrimaryPath(&keypath.MsParam{
 		ServiceName: constant.TSOServiceName,
@@ -136,8 +145,8 @@ func TestTransferPrimaryRandomKeepsExistingBehavior(t *testing.T) {
 }
 
 func putRegistryEntry(
-	re *require.Assertions,
 	ctx context.Context,
+	re *require.Assertions,
 	client *clientv3.Client,
 	name string,
 	serviceAddr string,

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/tikv/pd/pkg/election"
+	"github.com/tikv/pd/pkg/mcs/discovery"
+	mcsutils "github.com/tikv/pd/pkg/mcs/utils"
+	"github.com/tikv/pd/pkg/mcs/utils/constant"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
+	"github.com/tikv/pd/pkg/utils/keypath"
+)
+
+func TestTransferPrimaryToSelfKeepsExpectedPrimaryLease(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	keypath.SetClusterID(uint64(time.Now().UnixNano()))
+	defer keypath.ResetClusterID()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const (
+		primaryName   = "tso-primary"
+		primaryAddr   = "http://127.0.0.1:10001"
+		secondaryName = "tso-secondary"
+		secondaryAddr = "http://127.0.0.1:10002"
+	)
+	putRegistryEntry(re, ctx, client, primaryName, primaryAddr)
+	putRegistryEntry(re, ctx, client, secondaryName, secondaryAddr)
+
+	lease := election.NewLease(client, "tso expected primary 00000")
+	re.NoError(lease.Grant(constant.DefaultLease))
+	defer func() {
+		_ = lease.Close()
+	}()
+
+	msParam := &keypath.MsParam{
+		ServiceName: constant.TSOServiceName,
+		GroupID:     0,
+	}
+	expectedPrimaryPath := keypath.ExpectedPrimaryPath(msParam)
+	_, err := client.Put(ctx, expectedPrimaryPath, primaryAddr, clientv3.WithLease(lease.GetID()))
+	re.NoError(err)
+
+	beforeResp, err := client.Get(ctx, expectedPrimaryPath)
+	re.NoError(err)
+	re.Len(beforeResp.Kvs, 1)
+	oldExpectedPrimary := beforeResp.Kvs[0]
+	re.Equal(int64(lease.GetID()), oldExpectedPrimary.Lease)
+
+	err = mcsutils.TransferPrimary(client, lease, constant.TSOServiceName,
+		primaryName, primaryName, 0, map[string]bool{
+			primaryAddr:   true,
+			secondaryAddr: true,
+		})
+	re.NoError(err)
+
+	afterResp, err := client.Get(ctx, expectedPrimaryPath)
+	re.NoError(err)
+	re.Len(afterResp.Kvs, 1)
+	currentExpectedPrimary := afterResp.Kvs[0]
+	re.Equal(string(oldExpectedPrimary.Value), string(currentExpectedPrimary.Value))
+	re.Equal(oldExpectedPrimary.ModRevision, currentExpectedPrimary.ModRevision)
+	re.Equal(oldExpectedPrimary.Lease, currentExpectedPrimary.Lease)
+}
+
+func TestTransferPrimaryRandomKeepsExistingBehavior(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	keypath.SetClusterID(uint64(time.Now().UnixNano()))
+	defer keypath.ResetClusterID()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const (
+		primaryName   = "tso-primary"
+		primaryAddr   = "http://127.0.0.1:10001"
+		secondaryName = "tso-secondary"
+		secondaryAddr = "http://127.0.0.1:10002"
+	)
+	putRegistryEntry(re, ctx, client, primaryName, primaryAddr)
+	putRegistryEntry(re, ctx, client, secondaryName, secondaryAddr)
+
+	lease := election.NewLease(client, "tso expected primary 00000")
+	re.NoError(lease.Grant(constant.DefaultLease))
+
+	expectedPrimaryPath := keypath.ExpectedPrimaryPath(&keypath.MsParam{
+		ServiceName: constant.TSOServiceName,
+		GroupID:     0,
+	})
+	_, err := client.Put(ctx, expectedPrimaryPath, primaryAddr, clientv3.WithLease(lease.GetID()))
+	re.NoError(err)
+
+	beforeResp, err := client.Get(ctx, expectedPrimaryPath)
+	re.NoError(err)
+	re.Len(beforeResp.Kvs, 1)
+
+	err = mcsutils.TransferPrimary(client, lease, constant.TSOServiceName,
+		primaryName, "", 0, map[string]bool{
+			primaryAddr:   true,
+			secondaryAddr: true,
+		})
+	re.NoError(err)
+
+	afterResp, err := client.Get(ctx, expectedPrimaryPath)
+	re.NoError(err)
+	re.Len(afterResp.Kvs, 1)
+	re.Equal(secondaryAddr, string(afterResp.Kvs[0].Value))
+	re.NotEqual(beforeResp.Kvs[0].ModRevision, afterResp.Kvs[0].ModRevision)
+	re.NotEqual(beforeResp.Kvs[0].Lease, afterResp.Kvs[0].Lease)
+}
+
+func putRegistryEntry(
+	re *require.Assertions,
+	ctx context.Context,
+	client *clientv3.Client,
+	name string,
+	serviceAddr string,
+) {
+	entry := discovery.ServiceRegistryEntry{
+		Name:        name,
+		ServiceAddr: serviceAddr,
+	}
+	serializedValue, err := entry.Serialize()
+	re.NoError(err)
+	_, err = client.Put(ctx, keypath.RegistryPath(constant.TSOServiceName, serviceAddr), serializedValue)
+	re.NoError(err)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10969

When a TSO primary transfer request specifies the current TSO primary itself as `new_primary`, the current MCS transfer logic treats it as a real transfer rather than a no-op.

That behavior is not expected. It can revoke the expected-primary lease, rewrite the expected-primary key, make the current primary exit the expected-primary watch loop, and force unnecessary primary churn.

This was observed during a TiDB Cloud TiDBX rolling-upgrade investigation. The confirmed TSO log sequence was:

1. `2026-07-02T12:18:32.177Z`: old primary `db-b5b0db46-d8u65q` started transfer: `from=db-b5b0db46-d8u65q`, `to=db-b5b0db46-bq855y`.
2. `2026-07-02T12:18:32.196Z`: `db-b5b0db46-bq855y` logged `campaign tso primary ok`.
3. `2026-07-02T12:18:32.209Z`: `db-b5b0db46-bq855y` received another transfer request: `from=db-b5b0db46-bq855y`, `to=db-b5b0db46-bq855y`.
4. `2026-07-02T12:18:32.216Z`: `db-b5b0db46-bq855y` logged `revoke lease failed`, `primary exit the primary watch loop`, and `the TSO primary will step down`.
5. `2026-07-02T12:18:33.228Z`: `db-b5b0db46-bq855y` received the same self-transfer request again.
6. `2026-07-02T12:18:33.249Z`: `db-b5b0db46-d8u65q` logged `campaign tso primary ok`.
7. `2026-07-02T12:18:33.260Z`: `db-b5b0db46-bq855y` logged `campaign tso primary meets error due to txn conflict`.

The rollout was later observed with `TSOGroup updatedReplicas=1/2`, `db-b5b0db46-d8u65q isDefaultPrimary=true`, and `db-b5b0db46-d8u65q` still on the old revision with `PodNotUpToDate`.

This PR fixes the confirmed PD-side self-transfer behavior. It does not claim that the long-term rollout stuck state was caused only by PD. TCMS artifacts available in this investigation did not include the real controller/reconcile logs. A control-plane owner pointed out a separate likely control-plane issue: after a transfer request succeeds, the rollout expects to poll and observe the leader change; if the primary changes back before polling observes the expected state, the control-plane state machine may fail to continue or retry. That poll/retry behavior should be fixed or confirmed on the control-plane/operator side.

This PR is still needed because transfer-to-current-primary should be a no-op. In this incident, the control plane/operator request was the trigger: after `bq855y` had already become primary, another transfer request targeting `bq855y` itself exposed this PD behavior. Removing this unnecessary primary churn avoids creating or amplifying that race window.

### What is changed and how does it work?

```commit-message
mcs: skip transferring primary to itself

Treat an explicit transfer request to the current primary as a no-op before
revoking the existing expected-primary lease. This keeps random transfer
(`new_primary == ""`) behavior unchanged while preventing control-plane
self-transfer requests from forcing the active primary to leave the primary role.
```

The fix detects whether `new_primary` and `oldPrimary` refer to the same registered MCS member, either by member name or service address. If they do, `TransferPrimary` returns success without changing etcd state or closing the current lease.

### Validation

Unit tests:

```bash
go test ./pkg/mcs/utils -run 'TestTransferPrimary.*' -count=1
```

TiUP real-process validation:

- Deployed a local TiUP cluster with PD microservices: 1 PD, 2 TSO, 1 Scheduling, minimal TiDB/TiKV.
- Current TSO primary: `http://127.0.0.1:13380`.
- Simulated the control-plane request:

```bash
curl -X POST http://127.0.0.1:13380/tso/api/v1/primary/transfer \
  -H 'Content-Type: application/json' \
  -d '{"new_primary":"tso-127.0.0.1-13380"}'
```

Before this fix, the request returned `HTTP 200`, but the primary performed a real self-transfer and left the primary role:

```text
try to transfer primary service=tso from=tso-127.0.0.1-13380 to=tso-127.0.0.1-13380
current leadership is deleted leader-key=.../tso/00000/primary/expected_primary
set expected primary flag primary=http://127.0.0.1:13380
revoke lease failed error="etcdserver: requested lease not found"
primary exit the primary watch loop
no longer be primary because primary have been updated, the TSO primary will step down
campaign tso primary ok name=http://127.0.0.1:13380-00000
```

After this fix, the same request returns `HTTP 200` and only logs the no-op path:

```text
try to transfer primary service=tso from=tso-127.0.0.1-13380 to=tso-127.0.0.1-13380
skip transferring primary to itself service=tso primary=tso-127.0.0.1-13380
```

No leadership delete, expected-primary rewrite, lease revoke, watch-loop exit, primary role leave, or re-campaign is observed.

### Check List

Tests

- Unit test
- Manual test (TiUP real-process validation above)

Code changes

- No configuration change
- No HTTP API change
- No persistent data format change

Side effects

- No expected performance regression
- No breaking backward compatibility

Related changes

- A separate control-plane/operator fix may still be needed to handle the transfer-poll race and continue/retry rollout if the primary changes back before polling observes the expected handoff.
- Need to cherry-pick to the affected release branch if the control-plane rolling-upgrade flow can send this self-transfer request there.

### Release note

```release-note
Fix an issue where a TSO primary transfer request targeting the current primary itself could unnecessarily make the primary leave and re-campaign for the primary role.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved primary transfer behavior: when the target primary represents the same member, the expected-primary lease and metadata are preserved (no unnecessary updates).
  * Made primary/member matching more consistent by treating both service name and service address as valid identifiers.
  * Updated secondary-candidate selection logic to use consistent matching, preventing incorrect comparisons.
* **Tests**
  * Added coverage for expected-primary lease preservation and correct updates during random/selection-based transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->