### PR TITLE
client/resource_group: expose runtime state

### DIFF
--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -818,11 +818,11 @@ type ResourceGroupRuntimeState struct {
 // local state for the group.
 func (c *ResourceGroupsController) GetResourceGroupRuntimeState(resourceGroupName string) (ResourceGroupRuntimeState, bool) {
 	gc, ok := c.loadGroupController(resourceGroupName)
-	if !ok || gc.tombstone.Load() || !gc.run.initialRequestCompleted.Load() || gc.run.requestUnitTokens == nil || gc.run.requestUnitTokens.limiter == nil {
+	if !ok || gc.tombstone.Load() || !gc.initialRequestCompleted.Load() {
 		return ResourceGroupRuntimeState{}, false
 	}
 	return ResourceGroupRuntimeState{
-		HasLimitedBurst: gc.run.requestUnitTokens.limiter.GetBurst() >= 0,
+		HasLimitedBurst: !gc.burstable.Load(),
 	}, true
 }
 

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -805,6 +805,27 @@ func (c *ResourceGroupsController) GetResourceGroup(resourceGroupName string) (*
 	return gc.getMeta(), nil
 }
 
+// ResourceGroupRuntimeState describes generic local runtime signals derived
+// from token bucket responses.
+type ResourceGroupRuntimeState struct {
+	// HasLimitedBurst is true when the request-unit token bucket has a finite
+	// burst limit instead of unlimited burst.
+	HasLimitedBurst bool
+}
+
+// GetResourceGroupRuntimeState returns the resource group's local runtime
+// state. The second return value is false when the controller has no usable
+// local state for the group.
+func (c *ResourceGroupsController) GetResourceGroupRuntimeState(resourceGroupName string) (ResourceGroupRuntimeState, bool) {
+	gc, ok := c.loadGroupController(resourceGroupName)
+	if !ok || gc.tombstone.Load() || !gc.run.initialRequestCompleted.Load() || gc.run.requestUnitTokens == nil || gc.run.requestUnitTokens.limiter == nil {
+		return ResourceGroupRuntimeState{}, false
+	}
+	return ResourceGroupRuntimeState{
+		HasLimitedBurst: gc.run.requestUnitTokens.limiter.GetBurst() >= 0,
+	}, true
+}
+
 // ReportConsumption is used to report ru consumption directly.
 //
 // Currently, this interface is used to report the consumption for TiFlash MPP cost

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -385,7 +385,6 @@ func TestGetResourceGroup(t *testing.T) {
 func TestGetResourceGroupRuntimeState(t *testing.T) {
 	testCases := []struct {
 		name                            string
-		initialBurstLimit               int64
 		responseBurstLimit              int64
 		sendResponse                    bool
 		resourceGroupName               string
@@ -394,12 +393,10 @@ func TestGetResourceGroupRuntimeState(t *testing.T) {
 	}{
 		{
 			name:              "unknown before first token response",
-			initialBurstLimit: -1,
 			resourceGroupName: "test-group",
 		},
 		{
 			name:               "unlimited response remains burstable",
-			initialBurstLimit:  -1,
 			responseBurstLimit: -1,
 			sendResponse:       true,
 			resourceGroupName:  "test-group",
@@ -407,7 +404,6 @@ func TestGetResourceGroupRuntimeState(t *testing.T) {
 		},
 		{
 			name:               "override limited burst from token response",
-			initialBurstLimit:  -1,
 			responseBurstLimit: 100,
 			sendResponse:       true,
 			resourceGroupName:  "test-group",
@@ -418,7 +414,6 @@ func TestGetResourceGroupRuntimeState(t *testing.T) {
 		},
 		{
 			name:               "unknown resource group",
-			initialBurstLimit:  -1,
 			responseBurstLimit: 100,
 			sendResponse:       true,
 			resourceGroupName:  "unknown",
@@ -436,7 +431,7 @@ func TestGetResourceGroupRuntimeState(t *testing.T) {
 					RU: &rmpb.TokenBucket{
 						Settings: &rmpb.TokenLimitSettings{
 							FillRate:   1000,
-							BurstLimit: tc.initialBurstLimit,
+							BurstLimit: -1,
 						},
 					},
 				},
@@ -464,6 +459,10 @@ func TestGetResourceGroupRuntimeState(t *testing.T) {
 						},
 					},
 				})
+				// Mirror the main loop, which refreshes the derived state
+				// (e.g. burstable) after handling token bucket responses.
+				gc.updateRunState()
+				gc.updateAvgRequestResourcePerSec()
 			}
 
 			state, ok := controller.GetResourceGroupRuntimeState(tc.resourceGroupName)

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -382,6 +382,97 @@ func TestGetResourceGroup(t *testing.T) {
 	re.Nil(gc02)
 }
 
+func TestGetResourceGroupRuntimeState(t *testing.T) {
+	testCases := []struct {
+		name                            string
+		initialBurstLimit               int64
+		responseBurstLimit              int64
+		sendResponse                    bool
+		resourceGroupName               string
+		expectOK                        bool
+		expectResourceGroupRuntimeState ResourceGroupRuntimeState
+	}{
+		{
+			name:              "unknown before first token response",
+			initialBurstLimit: -1,
+			resourceGroupName: "test-group",
+		},
+		{
+			name:               "unlimited response remains burstable",
+			initialBurstLimit:  -1,
+			responseBurstLimit: -1,
+			sendResponse:       true,
+			resourceGroupName:  "test-group",
+			expectOK:           true,
+		},
+		{
+			name:               "override limited burst from token response",
+			initialBurstLimit:  -1,
+			responseBurstLimit: 100,
+			sendResponse:       true,
+			resourceGroupName:  "test-group",
+			expectOK:           true,
+			expectResourceGroupRuntimeState: ResourceGroupRuntimeState{
+				HasLimitedBurst: true,
+			},
+		},
+		{
+			name:               "unknown resource group",
+			initialBurstLimit:  -1,
+			responseBurstLimit: 100,
+			sendResponse:       true,
+			resourceGroupName:  "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			re := require.New(t)
+
+			group := &rmpb.ResourceGroup{
+				Name: "test-group",
+				Mode: rmpb.GroupMode_RUMode,
+				RUSettings: &rmpb.GroupRequestUnitSettings{
+					RU: &rmpb.TokenBucket{
+						Settings: &rmpb.TokenLimitSettings{
+							FillRate:   1000,
+							BurstLimit: tc.initialBurstLimit,
+						},
+					},
+				},
+			}
+			gc, err := newGroupCostController(group, DefaultRUConfig(), make(chan notifyMsg), make(chan *groupCostController))
+			re.NoError(err)
+
+			controller := &ResourceGroupsController{}
+			controller.groupsController.Store(group.Name, gc)
+
+			if tc.sendResponse {
+				controller.handleTokenBucketResponse([]*rmpb.TokenBucketResponse{
+					{
+						ResourceGroupName: group.Name,
+						GrantedRUTokens: []*rmpb.GrantedRUTokenBucket{
+							{
+								GrantedTokens: &rmpb.TokenBucket{
+									Settings: &rmpb.TokenLimitSettings{
+										FillRate:   1000,
+										BurstLimit: tc.responseBurstLimit,
+									},
+									Tokens: 1000,
+								},
+							},
+						},
+					},
+				})
+			}
+
+			state, ok := controller.GetResourceGroupRuntimeState(tc.resourceGroupName)
+			re.Equal(tc.expectOK, ok)
+			re.Equal(tc.expectResourceGroupRuntimeState, state)
+		})
+	}
+}
+
 func TestTokenBucketsRequestWithKeyspaceID(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -84,13 +84,12 @@ type groupCostController struct {
 		// lastResourceConsumptions    []*rmpb.ResourceItem
 		lastRequestConsumption *rmpb.Consumption
 
-		// initialRequestCompleted is set to true when the first token bucket
-		// request completes successfully.
-		initialRequestCompleted atomic.Bool
-
 		requestUnitTokens *tokenCounter
 	}
 
+	// initialRequestCompleted is set to true when the first token bucket
+	// request completes successfully.
+	initialRequestCompleted atomic.Bool
 	// tombstone is set to true when the resource group is deleted.
 	tombstone atomic.Bool
 	// inactive is set to true when the resource group has not been updated for a long time.
@@ -331,7 +330,7 @@ func (gc *groupCostController) calcAvg(counter *tokenCounter, new float64) bool 
 }
 
 func (gc *groupCostController) shouldReportConsumption() bool {
-	if !gc.run.initialRequestCompleted.Load() {
+	if !gc.initialRequestCompleted.Load() {
 		return true
 	}
 	timeSinceLastRequest := gc.run.now.Sub(gc.run.lastRequestTime)
@@ -355,7 +354,7 @@ func (gc *groupCostController) shouldReportConsumption() bool {
 func (gc *groupCostController) handleTokenBucketResponse(resp *rmpb.TokenBucketResponse) {
 	gc.run.requestInProgress = false
 	gc.handleRUTokenResponse(resp)
-	gc.run.initialRequestCompleted.Store(true)
+	gc.initialRequestCompleted.Store(true)
 }
 
 func (gc *groupCostController) handleRUTokenResponse(resp *rmpb.TokenBucketResponse) {

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -86,7 +86,7 @@ type groupCostController struct {
 
 		// initialRequestCompleted is set to true when the first token bucket
 		// request completes successfully.
-		initialRequestCompleted bool
+		initialRequestCompleted atomic.Bool
 
 		requestUnitTokens *tokenCounter
 	}
@@ -331,7 +331,7 @@ func (gc *groupCostController) calcAvg(counter *tokenCounter, new float64) bool 
 }
 
 func (gc *groupCostController) shouldReportConsumption() bool {
-	if !gc.run.initialRequestCompleted {
+	if !gc.run.initialRequestCompleted.Load() {
 		return true
 	}
 	timeSinceLastRequest := gc.run.now.Sub(gc.run.lastRequestTime)
@@ -355,7 +355,7 @@ func (gc *groupCostController) shouldReportConsumption() bool {
 func (gc *groupCostController) handleTokenBucketResponse(resp *rmpb.TokenBucketResponse) {
 	gc.run.requestInProgress = false
 	gc.handleRUTokenResponse(resp)
-	gc.run.initialRequestCompleted = true
+	gc.run.initialRequestCompleted.Store(true)
 }
 
 func (gc *groupCostController) handleRUTokenResponse(resp *rmpb.TokenBucketResponse) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10612

### What is changed and how does it work?

```commit-message
Expose resource group runtime state from the PD client.

The runtime state currently reports whether the local effective request-unit
token bucket has a finite burst limit (`HasLimitedBurst`), based on token bucket
responses. This lets callers observe Resource Control runtime signals without
changing resource group metadata semantics.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```
