### PR TITLE
keyspace: cache meta-service group status

### DIFF
--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -329,7 +329,7 @@ func (manager *Manager) CreateKeyspace(request *CreateKeyspaceRequest) (*keyspac
 	}
 	// Assign a meta-service group (if any exist) and save the keyspace atomically
 	// with respect to group deletion. The assignment is reflected in request.Config.
-	assignToMetaServiceGroup := manager.mgm != nil && len(manager.mgm.GetGroups()) > 0
+	assignToMetaServiceGroup := manager.mgm != nil && manager.mgm.HasGroups()
 	if err = manager.assignGroupAndSaveKeyspace(assignToMetaServiceGroup, &request.Config, keyspace); err != nil {
 		log.Warn("[create-keyspace] failed to save keyspace before split",
 			zap.Uint32("keyspace-id", keyspace.GetId()),
@@ -476,7 +476,7 @@ func (manager *Manager) CreateKeyspaceByID(request *CreateKeyspaceByIDRequest) (
 	}
 	// Assign a meta-service group (if any exist) and save the keyspace atomically
 	// with respect to group deletion. The assignment is reflected in request.Config.
-	assignToMetaServiceGroup := manager.mgm != nil && len(manager.mgm.GetGroups()) > 0
+	assignToMetaServiceGroup := manager.mgm != nil && manager.mgm.HasGroups()
 	if err = manager.assignGroupAndSaveKeyspace(assignToMetaServiceGroup, &request.Config, keyspace); err != nil {
 		log.Warn("[keyspace] failed to save keyspace before split",
 			zap.Uint32("keyspace-id", keyspace.GetId()),

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -589,7 +589,7 @@ func (manager *Manager) assignGroupAndSaveKeyspace(assign bool, config *map[stri
 	if !manager.mgm.hasGroupsLocked() {
 		return manager.saveNewKeyspace(keyspace)
 	}
-	groupID, err := manager.mgm.pickGroupLocked(manager.ctx)
+	groupID, err := manager.mgm.pickGroupLocked()
 	if err != nil {
 		if goerrors.Is(err, errNoAvailableMetaServiceGroups) {
 			// Groups exist but none are enabled: create the keyspace without a
@@ -605,7 +605,9 @@ func (manager *Manager) assignGroupAndSaveKeyspace(assign bool, config *map[stri
 	(*config)[MetaServiceGroupIDKey] = groupID
 	keyspace.Config = *config
 	if err := manager.saveNewKeyspace(keyspace); err != nil {
-		// Roll back the reservation made by pickGroupLocked. This only performs
+		// Roll back the reservation made by pickGroupLocked. This only mutates the
+		// cached count and does not re-take the mgm lock, so it is safe to call
+		// while still holding the lock acquired above.
 		if rollbackErr := manager.mgm.updateAssignmentLockedTxn(nil, groupID, ""); rollbackErr != nil {
 			log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))
 		}

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -965,20 +965,29 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 	}
 	err := manager.runTxnWithMetaGroupLock(txnFunc)
 	if err != nil {
-		// The txn can fail at commit after txnFunc returned nil, leaving the
-		// immediately-persisted TSO keyspace group move applied while the keyspace
-		// meta was rolled back. keyspaceGroupMoved stays true only when the inner
-		// error branch did not already revert it, so revert it here.
-		if keyspaceGroupMoved {
-			if rollbackErr := manager.kgm.UpdateKeyspaceGroup(newTSOGroupID, oldTSOGroupID, newTSOUserKind, oldTSOUserKind, meta.GetId()); rollbackErr != nil {
-				log.Error("failed to revert keyspace group", zap.Error(rollbackErr))
+		// Roll back side effects that were persisted immediately (and so are not
+		// undone by the failed txn): the TSO keyspace group move and the cached
+		// meta-service assignment. A commit-time failure after txnFunc returned nil
+		// leaves the move applied while the keyspace meta was rolled back;
+		// keyspaceGroupMoved stays true only when the inner branch did not already
+		// revert it. Hold the mgm lock across both undos so they are atomic with
+		// respect to UpdateGroupsSafely, mirroring runTxnWithMetaGroupLock.
+		func() {
+			if manager.mgm != nil {
+				manager.mgm.Lock()
+				defer manager.mgm.Unlock()
 			}
-		}
-		if metaServiceGroupReassigned {
-			if rollbackErr := manager.mgm.updateAssignmentTxn(nil, newMetaServiceGroup, oldMetaServiceGroup); rollbackErr != nil {
-				log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))
+			if keyspaceGroupMoved {
+				if rollbackErr := manager.kgm.UpdateKeyspaceGroup(newTSOGroupID, oldTSOGroupID, newTSOUserKind, oldTSOUserKind, meta.GetId()); rollbackErr != nil {
+					log.Error("failed to revert keyspace group", zap.Error(rollbackErr))
+				}
 			}
-		}
+			if metaServiceGroupReassigned {
+				if rollbackErr := manager.mgm.updateAssignmentTxn(nil, newMetaServiceGroup, oldMetaServiceGroup); rollbackErr != nil {
+					log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))
+				}
+			}
+		}()
 		log.Warn("[keyspace] failed to update keyspace config",
 			zap.Uint32("keyspace-id", meta.GetId()),
 			zap.String("name", meta.GetName()),

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -867,12 +867,16 @@ func applyKeyspaceConfigMutations(config map[string]string, mutations []*Mutatio
 // keyspace assignment validation and the cached assignment count update
 // atomic with respect to MetaServiceGroupManager.UpdateGroupsSafely, which takes
 // the write lock before deleting a group.
-func (manager *Manager) runTxnWithMetaGroupLock(f func(txn kv.Txn) error) error {
+func (manager *Manager) runTxnWithMetaGroupLock(f func(txn kv.Txn) error, rollback func()) error {
 	if manager.mgm != nil {
 		manager.mgm.Lock()
 		defer manager.mgm.Unlock()
 	}
-	return manager.store.RunInTxn(manager.ctx, f)
+	err := manager.store.RunInTxn(manager.ctx, f)
+	if err != nil && rollback != nil {
+		rollback()
+	}
+	return err
 }
 
 func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *keyspacepb.KeyspaceMeta) error) (*keyspacepb.KeyspaceMeta, error) {
@@ -952,43 +956,22 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 			keyspaceGroupMoved = true
 		}
 		// Save the updated keyspace meta.
-		if err := manager.store.SaveKeyspaceMeta(txn, meta); err != nil {
-			if keyspaceGroupMoved {
-				if err := manager.kgm.UpdateKeyspaceGroup(newID, oldID, newUserKind, oldUserKind, meta.GetId()); err != nil {
-					log.Error("failed to revert keyspace group", zap.Error(err))
-				} else {
-					keyspaceGroupMoved = false
-				}
-			}
-			return err
-		}
-		return nil
+		return manager.store.SaveKeyspaceMeta(txn, meta)
 	}
-	err := manager.runTxnWithMetaGroupLock(txnFunc)
+	rollback := func() {
+		if keyspaceGroupMoved {
+			if rollbackErr := manager.kgm.UpdateKeyspaceGroup(newTSOGroupID, oldTSOGroupID, newTSOUserKind, oldTSOUserKind, meta.GetId()); rollbackErr != nil {
+				log.Error("failed to revert keyspace group", zap.Error(rollbackErr))
+			}
+		}
+		if metaServiceGroupReassigned {
+			if rollbackErr := manager.mgm.updateAssignmentTxn(nil, newMetaServiceGroup, oldMetaServiceGroup); rollbackErr != nil {
+				log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))
+			}
+		}
+	}
+	err := manager.runTxnWithMetaGroupLock(txnFunc, rollback)
 	if err != nil {
-		// Roll back side effects that were persisted immediately (and so are not
-		// undone by the failed txn): the TSO keyspace group move and the cached
-		// meta-service assignment. A commit-time failure after txnFunc returned nil
-		// leaves the move applied while the keyspace meta was rolled back;
-		// keyspaceGroupMoved stays true only when the inner branch did not already
-		// revert it. Hold the mgm lock across both undos so they are atomic with
-		// respect to UpdateGroupsSafely, mirroring runTxnWithMetaGroupLock.
-		func() {
-			if manager.mgm != nil {
-				manager.mgm.Lock()
-				defer manager.mgm.Unlock()
-			}
-			if keyspaceGroupMoved {
-				if rollbackErr := manager.kgm.UpdateKeyspaceGroup(newTSOGroupID, oldTSOGroupID, newTSOUserKind, oldTSOUserKind, meta.GetId()); rollbackErr != nil {
-					log.Error("failed to revert keyspace group", zap.Error(rollbackErr))
-				}
-			}
-			if metaServiceGroupReassigned {
-				if rollbackErr := manager.mgm.updateAssignmentTxn(nil, newMetaServiceGroup, oldMetaServiceGroup); rollbackErr != nil {
-					log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))
-				}
-			}
-		}()
 		log.Warn("[keyspace] failed to update keyspace config",
 			zap.Uint32("keyspace-id", meta.GetId()),
 			zap.String("name", meta.GetName()),

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -1207,7 +1207,7 @@ func (manager *Manager) LoadRangeKeyspace(startID uint32, limit int) ([]*keyspac
 // authoritative source for the meta-service group delete guard: a stale
 // assignment counter must never permanently block removing a group that has no
 // keyspaces actually referencing it.
-func (manager *Manager) CountKeyspacesByMetaServiceGroup(groupIDs map[string]struct{}) (map[string]int, error) {
+func (manager *Manager) CountKeyspacesByMetaServiceGroup(ctx context.Context, groupIDs map[string]struct{}) (map[string]int, error) {
 	counts := make(map[string]int, len(groupIDs))
 	if len(groupIDs) == 0 {
 		return counts, nil
@@ -1218,7 +1218,7 @@ func (manager *Manager) CountKeyspacesByMetaServiceGroup(groupIDs map[string]str
 		// latter calls mgm.AttachEndpoints which takes the mgm read lock, and this
 		// is invoked while the mgm write lock is held, which would deadlock.
 		var keyspaces []*keyspacepb.KeyspaceMeta
-		if err := manager.store.RunInTxn(manager.ctx, func(txn kv.Txn) error {
+		if err := manager.store.RunInTxn(ctx, func(txn kv.Txn) error {
 			var err error
 			keyspaces, err = manager.store.LoadRangeKeyspace(txn, startID, etcdutil.MaxEtcdTxnOps)
 			return err

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -880,6 +880,12 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 	oldConfig := make(map[string]string)
 	var oldMetaServiceGroup, newMetaServiceGroup string
 	metaServiceGroupReassigned := false
+	// Captured for the outer rollback below: UpdateKeyspaceGroup persists the TSO
+	// keyspace group move immediately, so a commit failure after txnFunc returns
+	// nil leaves it applied while the keyspace meta was not saved.
+	var oldTSOGroupID, newTSOGroupID string
+	var oldTSOUserKind, newTSOUserKind endpoint.UserKind
+	keyspaceGroupMoved := false
 	txnFunc := func(txn kv.Txn) error {
 		// First get KeyspaceID from Name.
 		loaded, id, err := manager.store.LoadKeyspaceID(txn, name)
@@ -940,12 +946,17 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 			if err := manager.kgm.UpdateKeyspaceGroup(oldID, newID, oldUserKind, newUserKind, meta.GetId()); err != nil {
 				return err
 			}
+			oldTSOGroupID, newTSOGroupID = oldID, newID
+			oldTSOUserKind, newTSOUserKind = oldUserKind, newUserKind
+			keyspaceGroupMoved = true
 		}
 		// Save the updated keyspace meta.
 		if err := manager.store.SaveKeyspaceMeta(txn, meta); err != nil {
-			if needUpdate {
+			if keyspaceGroupMoved {
 				if err := manager.kgm.UpdateKeyspaceGroup(newID, oldID, newUserKind, oldUserKind, meta.GetId()); err != nil {
 					log.Error("failed to revert keyspace group", zap.Error(err))
+				} else {
+					keyspaceGroupMoved = false
 				}
 			}
 			return err
@@ -954,6 +965,15 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 	}
 	err := manager.runTxnWithMetaGroupLock(txnFunc)
 	if err != nil {
+		// The txn can fail at commit after txnFunc returned nil, leaving the
+		// immediately-persisted TSO keyspace group move applied while the keyspace
+		// meta was rolled back. keyspaceGroupMoved stays true only when the inner
+		// error branch did not already revert it, so revert it here.
+		if keyspaceGroupMoved {
+			if rollbackErr := manager.kgm.UpdateKeyspaceGroup(newTSOGroupID, oldTSOGroupID, newTSOUserKind, oldTSOUserKind, meta.GetId()); rollbackErr != nil {
+				log.Error("failed to revert keyspace group", zap.Error(rollbackErr))
+			}
+		}
 		if metaServiceGroupReassigned {
 			if rollbackErr := manager.mgm.updateAssignmentTxn(nil, newMetaServiceGroup, oldMetaServiceGroup); rollbackErr != nil {
 				log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -569,26 +569,10 @@ func (manager *Manager) saveNewKeyspace(keyspace *keyspacepb.KeyspaceMeta) error
 	})
 }
 
-// rollbackMetaServiceGroupAssignment decrements the assignment count that
-// PickGroup incremented for a keyspace whose creation failed before its metadata
-// was persisted, keeping the persisted counter in sync with actual keyspaces.
-func (manager *Manager) rollbackMetaServiceGroupAssignment(groupID string) {
-	if manager.mgm == nil || groupID == "" {
-		return
-	}
-	if err := manager.mgm.store.RunInTxn(manager.ctx, func(txn kv.Txn) error {
-		return manager.mgm.updateAssignmentTxn(txn, groupID, "")
-	}); err != nil {
-		log.Warn("[keyspace] failed to roll back meta-service group assignment count",
-			zap.String("meta-service-group", groupID),
-			zap.Error(err))
-	}
-}
-
 // assignGroupAndSaveKeyspace assigns a meta-service group to the keyspace (when
 // assign is true) and persists the keyspace metadata while holding the
-// meta-service group manager's read lock across both steps. This keeps the
-// selection and the persisted assignment atomic with respect to group deletion:
+// meta-service group manager's lock across both steps. This keeps the
+// selection and the cached assignment atomic with respect to group deletion:
 // UpdateGroupsSafely takes the write lock, so a group cannot be removed in the
 // window between assignment and the keyspace being saved, which would otherwise
 // leave the keyspace referencing a non-existent group. config must point to
@@ -597,8 +581,8 @@ func (manager *Manager) assignGroupAndSaveKeyspace(assign bool, config *map[stri
 	if !assign {
 		return manager.saveNewKeyspace(keyspace)
 	}
-	manager.mgm.RLock()
-	defer manager.mgm.RUnlock()
+	manager.mgm.Lock()
+	defer manager.mgm.Unlock()
 	// Re-check under the lock: the pre-lock check may be stale if a concurrent
 	// PATCH deleted the last group in the meantime. In that case create the
 	// keyspace without a meta-service group instead of failing the creation.
@@ -622,9 +606,9 @@ func (manager *Manager) assignGroupAndSaveKeyspace(assign bool, config *map[stri
 	keyspace.Config = *config
 	if err := manager.saveNewKeyspace(keyspace); err != nil {
 		// Roll back the reservation made by pickGroupLocked. This only performs
-		// store operations and does not take the mgm lock, so it is safe to call
-		// while still holding the read lock.
-		manager.rollbackMetaServiceGroupAssignment(groupID)
+		if rollbackErr := manager.mgm.updateAssignmentLockedTxn(nil, groupID, ""); rollbackErr != nil {
+			log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))
+		}
 		return err
 	}
 	return nil
@@ -877,14 +861,14 @@ func applyKeyspaceConfigMutations(config map[string]string, mutations []*Mutatio
 }
 
 // runTxnWithMetaGroupLock runs f inside a storage transaction while holding the
-// meta-service group manager's read lock for the whole transaction. This keeps
-// keyspace assignment validation and the persisted assignment count update
+// meta-service group manager's lock for the whole transaction. This keeps
+// keyspace assignment validation and the cached assignment count update
 // atomic with respect to MetaServiceGroupManager.UpdateGroupsSafely, which takes
 // the write lock before deleting a group.
 func (manager *Manager) runTxnWithMetaGroupLock(f func(txn kv.Txn) error) error {
 	if manager.mgm != nil {
-		manager.mgm.RLock()
-		defer manager.mgm.RUnlock()
+		manager.mgm.Lock()
+		defer manager.mgm.Unlock()
 	}
 	return manager.store.RunInTxn(manager.ctx, f)
 }
@@ -892,6 +876,8 @@ func (manager *Manager) runTxnWithMetaGroupLock(f func(txn kv.Txn) error) error 
 func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *keyspacepb.KeyspaceMeta) error) (*keyspacepb.KeyspaceMeta, error) {
 	var meta *keyspacepb.KeyspaceMeta
 	oldConfig := make(map[string]string)
+	var oldMetaServiceGroup, newMetaServiceGroup string
+	metaServiceGroupReassigned := false
 	txnFunc := func(txn kv.Txn) error {
 		// First get KeyspaceID from Name.
 		loaded, id, err := manager.store.LoadKeyspaceID(txn, name)
@@ -933,14 +919,15 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 		// txn doesn't commit), while UpdateKeyspaceGroup persists immediately. Doing
 		// the fallible meta-service validation first avoids leaving the TSO group move
 		// persisted but unreverted when the meta-service reassignment fails.
-		oldMetaServiceGroup := oldConfig[MetaServiceGroupIDKey]
-		newMetaServiceGroup := newConfig[MetaServiceGroupIDKey]
+		oldMetaServiceGroup = oldConfig[MetaServiceGroupIDKey]
+		newMetaServiceGroup = newConfig[MetaServiceGroupIDKey]
 		if manager.mgm != nil && oldMetaServiceGroup != newMetaServiceGroup {
-			// The read lock held by runTxnWithMetaGroupLock keeps this validation and
+			// The lock held by runTxnWithMetaGroupLock keeps this validation and
 			// the assignment update atomic with respect to UpdateGroupsSafely.
 			if err := manager.mgm.reassignKeyspaceLocked(txn, oldMetaServiceGroup, newMetaServiceGroup); err != nil {
 				return err
 			}
+			metaServiceGroupReassigned = true
 		}
 		oldUserKind := endpoint.StringUserKind(oldConfig[UserKindKey])
 		newUserKind := endpoint.StringUserKind(newConfig[UserKindKey])
@@ -965,6 +952,11 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 	}
 	err := manager.runTxnWithMetaGroupLock(txnFunc)
 	if err != nil {
+		if metaServiceGroupReassigned {
+			if rollbackErr := manager.mgm.updateAssignmentTxn(nil, newMetaServiceGroup, oldMetaServiceGroup); rollbackErr != nil {
+				log.Error("failed to revert meta-service group assignment", zap.Error(rollbackErr))
+			}
+		}
 		log.Warn("[keyspace] failed to update keyspace config",
 			zap.Uint32("keyspace-id", meta.GetId()),
 			zap.String("name", meta.GetName()),
@@ -1059,10 +1051,10 @@ func (manager *Manager) RemoveKeyspace(txn kv.Txn, id uint32) error {
 	}
 	manager.keyspaceNameLookup.Delete(id)
 	manager.keyspaceStateLookup.Delete(id)
-	// Decrement the meta-service group assignment count in the same txn so the
-	// persisted counter stays in sync with the keyspaces actually referencing the
-	// group. Without this, removed keyspaces leak count and could permanently
-	// block deleting an otherwise-empty group.
+	// Decrement the meta-service group assignment count so the cached counter
+	// stays in sync with the keyspaces actually referencing the group. Without
+	// this, removed keyspaces leak count and could permanently block deleting an
+	// otherwise-empty group in tests without the authoritative keyspace scanner.
 	if manager.mgm != nil {
 		if groupID := meta.GetConfig()[MetaServiceGroupIDKey]; groupID != "" {
 			if err := manager.mgm.updateAssignmentTxn(txn, groupID, ""); err != nil {

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -923,10 +923,11 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 		delete(meta.Config, MetaServiceGroupAddressesKey)
 		newConfig := meta.GetConfig()
 		// Reassign the meta-service group before moving the TSO keyspace group.
-		// reassignKeyspaceLocked only stages its changes in txn (discarded if the
-		// txn doesn't commit), while UpdateKeyspaceGroup persists immediately. Doing
-		// the fallible meta-service validation first avoids leaving the TSO group move
-		// persisted but unreverted when the meta-service reassignment fails.
+		// reassignKeyspaceLocked validates the target and updates the in-memory
+		// assignment hint (it does not write storage), while UpdateKeyspaceGroup
+		// persists immediately. Doing the fallible meta-service validation first
+		// avoids leaving the TSO group move persisted but unreverted when the
+		// meta-service reassignment fails.
 		oldMetaServiceGroup = oldConfig[MetaServiceGroupIDKey]
 		newMetaServiceGroup = newConfig[MetaServiceGroupIDKey]
 		if manager.mgm != nil && oldMetaServiceGroup != newMetaServiceGroup {

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -571,18 +571,22 @@ func (manager *Manager) saveNewKeyspace(keyspace *keyspacepb.KeyspaceMeta) error
 
 // assignGroupAndSaveKeyspace assigns a meta-service group to the keyspace (when
 // assign is true) and persists the keyspace metadata while holding the
-// meta-service group manager's lock across both steps. This keeps the
+// meta-service group manager's read lock across both steps. This keeps the
 // selection and the cached assignment atomic with respect to group deletion:
 // UpdateGroupsSafely takes the write lock, so a group cannot be removed in the
 // window between assignment and the keyspace being saved, which would otherwise
-// leave the keyspace referencing a non-existent group. config must point to
+// leave the keyspace referencing a non-existent group. The read lock is enough
+// because pickGroupLocked already serializes the select-and-reserve step under
+// statusMu; using it (rather than the write lock) lets concurrent keyspace
+// creations run their independent, possibly slow, saves in parallel instead of
+// queueing behind one another's storage latency. config must point to
 // request.Config so the assigned group ID is visible to later create steps.
 func (manager *Manager) assignGroupAndSaveKeyspace(assign bool, config *map[string]string, keyspace *keyspacepb.KeyspaceMeta) error {
 	if !assign {
 		return manager.saveNewKeyspace(keyspace)
 	}
-	manager.mgm.Lock()
-	defer manager.mgm.Unlock()
+	manager.mgm.RLock()
+	defer manager.mgm.RUnlock()
 	// Re-check under the lock: the pre-lock check may be stale if a concurrent
 	// PATCH deleted the last group in the meantime. In that case create the
 	// keyspace without a meta-service group instead of failing the creation.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -1236,6 +1236,14 @@ func (manager *Manager) CountKeyspacesByMetaServiceGroup(ctx context.Context, gr
 	}
 	startID := constant.StartKeyspaceID
 	for {
+		// The etcd backend's LoadRangeKeyspaceAtRevision/CurrentRevision don't
+		// honor ctx themselves, so check it explicitly between pages: without
+		// this, a rebuild whose leader-term context is canceled mid-scan (e.g.
+		// on leadership loss) would keep paging through the rest of a
+		// multi-million-keyspace scan even though the result is discarded.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		// Load directly from the store rather than via LoadRangeKeyspace: the
 		// latter calls mgm.AttachEndpoints which takes the mgm read lock, and this
 		// is invoked while the mgm write lock is held, which would deadlock.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -867,14 +867,18 @@ func applyKeyspaceConfigMutations(config map[string]string, mutations []*Mutatio
 }
 
 // runTxnWithMetaGroupLock runs f inside a storage transaction while holding the
-// meta-service group manager's lock for the whole transaction. This keeps
+// meta-service group manager's read lock for the whole transaction. This keeps
 // keyspace assignment validation and the cached assignment count update
 // atomic with respect to MetaServiceGroupManager.UpdateGroupsSafely, which takes
-// the write lock before deleting a group.
+// the write lock before deleting a group. The read lock is enough because the
+// actual cache mutation is further serialized by reassignKeyspaceLocked/
+// updateAssignmentTxn under the leaf statusMu lock, so concurrent config-update
+// transactions (and concurrent keyspace creations, which also only take the read
+// lock) are not needlessly queued behind one another's storage latency.
 func (manager *Manager) runTxnWithMetaGroupLock(f func(txn kv.Txn) error, rollback func()) error {
 	if manager.mgm != nil {
-		manager.mgm.Lock()
-		defer manager.mgm.Unlock()
+		manager.mgm.RLock()
+		defer manager.mgm.RUnlock()
 	}
 	err := manager.store.RunInTxn(manager.ctx, f)
 	if err != nil && rollback != nil {
@@ -939,8 +943,8 @@ func (manager *Manager) updateKeyspaceConfigTxn(name string, update func(meta *k
 		oldMetaServiceGroup = oldConfig[MetaServiceGroupIDKey]
 		newMetaServiceGroup = newConfig[MetaServiceGroupIDKey]
 		if manager.mgm != nil && oldMetaServiceGroup != newMetaServiceGroup {
-			// The lock held by runTxnWithMetaGroupLock keeps this validation and
-			// the assignment update atomic with respect to UpdateGroupsSafely.
+			// The read lock held by runTxnWithMetaGroupLock keeps this validation
+			// and the assignment update atomic with respect to UpdateGroupsSafely.
 			if err := manager.mgm.reassignKeyspaceLocked(txn, oldMetaServiceGroup, newMetaServiceGroup); err != nil {
 				return err
 			}
@@ -1211,22 +1215,34 @@ func (manager *Manager) LoadRangeKeyspace(startID uint32, limit int) ([]*keyspac
 // authoritative source for the meta-service group delete guard: a stale
 // assignment counter must never permanently block removing a group that has no
 // keyspaces actually referencing it.
+//
+// The scan pages through keyspaces in a series of separate batches, so without
+// pinning it to a single revision, a keyspace reassigned mid-scan could be
+// observed under its new group by a batch that hasn't reached it yet, on top of
+// the concurrent in-memory delta the reassignment records for that same move
+// (see MetaServiceGroupManager.recordRebuildDeltaLocked), double-counting it.
+// Pinning every batch to the revision observed before the scan starts removes
+// that inconsistency: any reassignment whose commit is ordered after this call
+// is guaranteed a revision past the pin and is therefore covered only by the
+// delta, never by the scan itself.
 func (manager *Manager) CountKeyspacesByMetaServiceGroup(ctx context.Context, groupIDs map[string]struct{}) (map[string]int, error) {
 	counts := make(map[string]int, len(groupIDs))
 	if len(groupIDs) == 0 {
 		return counts, nil
+	}
+	revision, err := manager.store.CurrentRevision(ctx)
+	if err != nil {
+		return nil, err
 	}
 	startID := constant.StartKeyspaceID
 	for {
 		// Load directly from the store rather than via LoadRangeKeyspace: the
 		// latter calls mgm.AttachEndpoints which takes the mgm read lock, and this
 		// is invoked while the mgm write lock is held, which would deadlock.
-		var keyspaces []*keyspacepb.KeyspaceMeta
-		if err := manager.store.RunInTxn(ctx, func(txn kv.Txn) error {
-			var err error
-			keyspaces, err = manager.store.LoadRangeKeyspace(txn, startID, etcdutil.MaxEtcdTxnOps)
-			return err
-		}); err != nil {
+		// LoadRangeKeyspaceAtRevision also intentionally bypasses RunInTxn: see its
+		// doc for why a pinned-revision read must not go through a Txn.
+		keyspaces, err := manager.store.LoadRangeKeyspaceAtRevision(startID, etcdutil.MaxEtcdTxnOps, revision)
+		if err != nil {
 			return nil, err
 		}
 		for _, ks := range keyspaces {

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -1095,7 +1095,8 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 	kgm := NewKeyspaceGroupManager(ctx, store, nil)
 
 	// No groups available: assign=true (stale pre-check) must not fail creation.
-	emptyMgm := NewMetaServiceGroupManager(store, map[string]string{})
+	emptyMgm, err := NewMetaServiceGroupManager(ctx, store, map[string]string{})
+	re.NoError(err)
 	managerNoGroup := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, kgm, emptyMgm)
 	cfg := map[string]string{}
 	ks := &keyspacepb.KeyspaceMeta{Id: 100, Name: "ks-stale-precheck", Config: cfg}
@@ -1107,7 +1108,8 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 
 	// A present, enabled group is still assigned. Groups are disabled by
 	// default, so it must be enabled before it is eligible for assignment.
-	mgm := NewMetaServiceGroupManager(store, map[string]string{"g1": "addr1"})
+	mgm, err := NewMetaServiceGroupManager(ctx, store, map[string]string{"g1": "addr1"})
+	re.NoError(err)
 	enabled := true
 	re.NoError(mgm.PatchStatus(ctx, "g1", &MetaServiceGroupStatusPatch{Enabled: &enabled}))
 	managerWithGroup := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, kgm, mgm)
@@ -1118,7 +1120,8 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 
 	// A group that exists but is disabled must not fail creation: the keyspace is
 	// created without a meta-service group assignment instead.
-	disabledMgm := NewMetaServiceGroupManager(store, map[string]string{"g2": "addr2"})
+	disabledMgm, err := NewMetaServiceGroupManager(ctx, store, map[string]string{"g2": "addr2"})
+	re.NoError(err)
 	managerDisabled := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, kgm, disabledMgm)
 	cfg3 := map[string]string{}
 	ks3 := &keyspacepb.KeyspaceMeta{Id: 102, Name: "ks-disabled-group", Config: cfg3}

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -16,6 +16,7 @@ package keyspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -41,6 +42,8 @@ import (
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/pkg/versioninfo/kerneltype"
 )
+
+var errInjectedTxnFailure = errors.New("injected txn failure")
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
@@ -1127,6 +1130,47 @@ func TestAssignGroupAndSaveKeyspace(t *testing.T) {
 	ks3 := &keyspacepb.KeyspaceMeta{Id: 102, Name: "ks-disabled-group", Config: cfg3}
 	re.NoError(managerDisabled.assignGroupAndSaveKeyspace(true, &cfg3, ks3))
 	re.NotContains(ks3.GetConfig(), MetaServiceGroupIDKey)
+}
+
+func TestRunTxnWithMetaGroupLockRollsBackBeforeUnlock(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	mgm, err := NewMetaServiceGroupManager(ctx, store, map[string]string{})
+	re.NoError(err)
+	manager := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, nil, mgm)
+
+	lockAttempted := make(chan struct{})
+	lockAcquired := make(chan struct{})
+	err = manager.runTxnWithMetaGroupLock(func(kv.Txn) error {
+		go func() {
+			close(lockAttempted)
+			manager.mgm.Lock()
+			defer manager.mgm.Unlock()
+			close(lockAcquired)
+		}()
+		<-lockAttempted
+		return errInjectedTxnFailure
+	}, func() {
+		re.Never(func() bool {
+			select {
+			case <-lockAcquired:
+				return true
+			default:
+				return false
+			}
+		}, 50*time.Millisecond, time.Millisecond)
+	})
+	re.ErrorIs(err, errInjectedTxnFailure)
+	re.Eventually(func() bool {
+		select {
+		case <-lockAcquired:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
 }
 
 func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup() {

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -1259,3 +1259,48 @@ func (suite *keyspaceTestSuite) TestTombstoneKeyspaceUnassignsMetaServiceGroup()
 	re.NoError(err)
 	re.Equal(0, counts[groupID])
 }
+
+// cancelAfterFirstRevisionPageStorage cancels ctx as soon as its first page of
+// results is produced, to check that CountKeyspacesByMetaServiceGroup notices
+// the cancellation before requesting the next page instead of paging through
+// to the end regardless.
+type cancelAfterFirstRevisionPageStorage struct {
+	endpoint.KeyspaceStorage
+	cancel     context.CancelFunc
+	rangeCalls int
+}
+
+func (s *cancelAfterFirstRevisionPageStorage) LoadRangeKeyspaceAtRevision(
+	_ uint32, limit int, _ int64,
+) ([]*keyspacepb.KeyspaceMeta, error) {
+	s.rangeCalls++
+	if s.rangeCalls > 1 {
+		return nil, nil
+	}
+	keyspaces := make([]*keyspacepb.KeyspaceMeta, limit)
+	for i := range keyspaces {
+		keyspaces[i] = &keyspacepb.KeyspaceMeta{Id: uint32(i + 1)}
+	}
+	s.cancel()
+	return keyspaces, nil
+}
+
+// TestCountKeyspacesByMetaServiceGroupStopsPagingWhenContextIsCanceled guards
+// against a former leader's abandoned rebuild continuing to page through a
+// full keyspace scan after its leader-term context is canceled: the scan
+// result is discarded either way (termGen no longer matches), so paging on
+// is pure wasted storage load.
+func (suite *keyspaceTestSuite) TestCountKeyspacesByMetaServiceGroupStopsPagingWhenContextIsCanceled() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(suite.ctx)
+	defer cancel()
+	store := &cancelAfterFirstRevisionPageStorage{
+		KeyspaceStorage: endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
+		cancel:          cancel,
+	}
+	manager := NewKeyspaceManager(ctx, store, nil, mockid.NewIDAllocator(), &mockConfig{}, nil, nil)
+
+	_, err := manager.CountKeyspacesByMetaServiceGroup(ctx, map[string]struct{}{"group": {}})
+	re.Equal(1, store.rangeCalls)
+	re.ErrorIs(err, context.Canceled)
+}

--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -1277,9 +1277,12 @@ func (s *cancelAfterFirstRevisionPageStorage) LoadRangeKeyspaceAtRevision(
 	if s.rangeCalls > 1 {
 		return nil, nil
 	}
+	// The entries' content doesn't matter to this test, only that a full page
+	// is returned; leave every field at its zero value so this doesn't depend
+	// on the field kvproto currently uses to represent the keyspace ID.
 	keyspaces := make([]*keyspacepb.KeyspaceMeta, limit)
 	for i := range keyspaces {
-		keyspaces[i] = &keyspacepb.KeyspaceMeta{Id: uint32(i + 1)}
+		keyspaces[i] = &keyspacepb.KeyspaceMeta{}
 	}
 	s.cancel()
 	return keyspaces, nil

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -184,9 +184,6 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	if patch.AssignmentCount != nil {
 		return ErrAssignmentCountPatchUnsupported
 	}
-	if patch.AssignmentCount != nil && *patch.AssignmentCount < 0 {
-		return ErrInvalidAssignmentCount
-	}
 	m.Lock()
 	defer m.Unlock()
 	if _, ok := m.metaServiceGroups[groupID]; !ok {

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -128,31 +128,43 @@ func (m *MetaServiceGroupManager) flushLoop() {
 }
 
 func (m *MetaServiceGroupManager) flushToStorage() error {
+	// Snapshot the dirty state under the lock and reset the dirty counter
+	// optimistically, then release the lock before the storage transaction so a
+	// slow etcd write does not block concurrent assignment operations. The
+	// snapshot is a deep copy, so later cache mutations are not observed by this
+	// flush. On failure the dirty count is restored so the next tick retries.
 	m.Lock()
-	defer m.Unlock()
 	if m.isLeader != nil && !m.isLeader() {
+		m.Unlock()
 		return nil
 	}
 	if m.dirtyCount == 0 {
+		m.Unlock()
 		return nil
 	}
+	snapshot := copyStatusMap(m.cachedStatus)
+	flushed := m.dirtyCount
+	m.dirtyCount = 0
+	m.Unlock()
+
 	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
-		for id, status := range m.cachedStatus {
+		for id, status := range snapshot {
 			if err := m.store.SaveMetaServiceGroupStatus(txn, id, status); err != nil {
 				return err
 			}
 		}
 		return nil
 	}); err != nil {
+		m.Lock()
+		m.dirtyCount += flushed
+		m.Unlock()
 		return err
 	}
-	m.dirtyCount = 0
 	return nil
 }
 
 // GetStatus returns the status of each meta-service group.
-func (m *MetaServiceGroupManager) GetStatus(ctx context.Context) (map[string]*endpoint.MetaServiceGroupStatus, error) {
-	_ = ctx
+func (m *MetaServiceGroupManager) GetStatus(_ context.Context) (map[string]*endpoint.MetaServiceGroupStatus, error) {
 	m.RLock()
 	defer m.RUnlock()
 	return copyStatusMap(m.cachedStatus), nil
@@ -239,11 +251,10 @@ func (m *MetaServiceGroupManager) findMinMetaGroupLocked() (string, error) {
 
 // PickGroup returns the meta-service group with the least assigned keyspaces
 // and updates the cached assignment count.
-func (m *MetaServiceGroupManager) PickGroup(ctx context.Context) (string, error) {
-	_ = ctx
+func (m *MetaServiceGroupManager) PickGroup(_ context.Context) (string, error) {
 	m.Lock()
 	defer m.Unlock()
-	return m.pickGroupLocked(ctx)
+	return m.pickGroupLocked()
 }
 
 // hasGroupsLocked reports whether any meta-service group is currently available.
@@ -256,8 +267,7 @@ func (m *MetaServiceGroupManager) hasGroupsLocked() bool {
 // Callers that need group selection and the subsequent keyspace metadata save to
 // be atomic with respect to group deletion (which takes the write lock) must
 // hold the lock across both, e.g. via Manager.assignGroupAndSaveKeyspace.
-func (m *MetaServiceGroupManager) pickGroupLocked(ctx context.Context) (string, error) {
-	_ = ctx
+func (m *MetaServiceGroupManager) pickGroupLocked() (string, error) {
 	assignedGroup, err := m.findMinMetaGroupLocked()
 	if err != nil {
 		return "", err
@@ -271,8 +281,7 @@ func (m *MetaServiceGroupManager) pickGroupLocked(ctx context.Context) (string, 
 // AssignToGroup increments count of the meta-service group with least assigned keyspaces.
 // It returns the assigned meta-service group and an error if any.
 // only used for testing now, as it doesn't guarantee the atomicity of select and update. UpdateAssignment should be used in production code instead.
-func (m *MetaServiceGroupManager) AssignToGroup(ctx context.Context, count int) (string, error) {
-	_ = ctx
+func (m *MetaServiceGroupManager) AssignToGroup(_ context.Context, count int) (string, error) {
 	if count < 0 {
 		return "", ErrInvalidAssignmentCount
 	}
@@ -306,14 +315,25 @@ func (m *MetaServiceGroupManager) reassignKeyspaceLocked(txn kv.Txn, oldGroupID,
 	return m.updateAssignmentLockedTxn(txn, oldGroupID, newGroupID)
 }
 
+// updateAssignmentTxn is updateAssignmentLockedTxn with the mgm lock acquired
+// for the caller. The txn is accepted for call-site symmetry with the storage
+// transaction the caller runs, but see updateAssignmentLockedTxn: the count
+// change is applied to the in-memory cache and is NOT part of txn, so it is not
+// rolled back if txn fails to commit.
 func (m *MetaServiceGroupManager) updateAssignmentTxn(txn kv.Txn, oldGroupID, newGroupID string) error {
 	m.Lock()
 	defer m.Unlock()
 	return m.updateAssignmentLockedTxn(txn, oldGroupID, newGroupID)
 }
 
-func (m *MetaServiceGroupManager) updateAssignmentLockedTxn(txn kv.Txn, oldGroupID, newGroupID string) error {
-	_ = txn
+// updateAssignmentLockedTxn moves one assignment from oldGroupID to newGroupID in
+// the cached status and marks it dirty for the flush loop to persist later. The
+// txn parameter is intentionally unused: unlike the pre-cache implementation the
+// count is no longer written inside the caller's storage transaction, so callers
+// must not assume the count update is atomic with their txn. Counts are
+// best-effort load-balancing hints; the delete guard uses the authoritative
+// keyspace scan, and RefreshCache reconciles any drift on the next leader term.
+func (m *MetaServiceGroupManager) updateAssignmentLockedTxn(_ kv.Txn, oldGroupID, newGroupID string) error {
 	dirtyCount := 0
 	if oldGroupID != "" {
 		if status := m.cachedStatus[oldGroupID]; status != nil && status.AssignmentCount > 0 {

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -173,15 +173,17 @@ func copyStatusMap(statusMap map[string]*endpoint.MetaServiceGroupStatus) map[st
 // MetaServiceGroupStatusPatch represents a patch operation for a meta-service group.
 // NOTE: This type is exported by HTTP API. Please pay more attention when modifying it.
 type MetaServiceGroupStatusPatch struct {
-	AssignmentCount *int  `json:"assignment_count,omitempty"` // nil means no change, 0 means reset to 0
+	AssignmentCount *int  `json:"assignment_count,omitempty"` // unsupported; assignment count is derived
 	Enabled         *bool `json:"enabled,omitempty"`          // nil means no change, true means enable, false means disable
 }
 
 // PatchStatus applies a patch to the status of a meta-service group. Only the
-// Enabled flag is persisted; a patched AssignmentCount is applied to the derived
-// in-memory hint and is superseded by the next RefreshCache, kept for API
-// compatibility.
+// Enabled flag can be patched and persisted; AssignmentCount is derived from
+// authoritative keyspace metadata and cannot be patched.
 func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID string, patch *MetaServiceGroupStatusPatch) error {
+	if patch.AssignmentCount != nil {
+		return ErrAssignmentCountPatchUnsupported
+	}
 	if patch.AssignmentCount != nil && *patch.AssignmentCount < 0 {
 		return ErrInvalidAssignmentCount
 	}
@@ -205,9 +207,6 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	if status == nil {
 		status = &endpoint.MetaServiceGroupStatus{}
 		m.cachedStatus[groupID] = status
-	}
-	if patch.AssignmentCount != nil {
-		status.AssignmentCount = *patch.AssignmentCount
 	}
 	if patch.Enabled != nil {
 		status.Enabled = *patch.Enabled

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -477,21 +477,10 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	if err := persist(); err != nil {
 		return err
 	}
-	m.metaServiceGroups = metaServiceGroups
-	// Sync the cache to the new group set. Clearing deleted groups here (and the
-	// persisted status below) keeps re-adding a group with the same ID from
-	// inheriting a stale assignment count or enabled state, which would skew list
-	// output and PickGroup balancing.
-	m.statusMu.Lock()
-	for groupID := range metaServiceGroups {
-		if m.cachedStatus[groupID] == nil {
-			m.cachedStatus[groupID] = &endpoint.MetaServiceGroupStatus{}
-		}
-	}
-	for _, id := range deletedGroups {
-		delete(m.cachedStatus, id)
-	}
-	m.statusMu.Unlock()
+	// Clear the persisted status for deleted groups before touching memory, so all
+	// storage writes complete before the in-memory view changes. This keeps
+	// re-adding a group with the same ID from inheriting a stale assignment count
+	// or enabled state, which would skew list output and PickGroup balancing.
 	// Best-effort: the config deletion is already persisted and the delete guard
 	// relies on actual keyspace scans, not this counter.
 	if len(deletedGroups) > 0 {
@@ -507,6 +496,18 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 				zap.Strings("deleted-groups", deletedGroups), zap.Error(err))
 		}
 	}
+	// Apply the change to the in-memory view only after the storage writes above.
+	m.metaServiceGroups = metaServiceGroups
+	m.statusMu.Lock()
+	for groupID := range metaServiceGroups {
+		if m.cachedStatus[groupID] == nil {
+			m.cachedStatus[groupID] = &endpoint.MetaServiceGroupStatus{}
+		}
+	}
+	for _, id := range deletedGroups {
+		delete(m.cachedStatus, id)
+	}
+	m.statusMu.Unlock()
 	return nil
 }
 

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -565,6 +565,7 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	// an earlier best-effort deletion that failed), which would skew list output
 	// and PickGroup balancing. Best-effort: the config change is already persisted
 	// and the delete guard relies on actual keyspace scans, not this counter.
+	reconcileFailed := false
 	if len(deletedGroups) > 0 || len(addedGroups) > 0 {
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 			for _, id := range deletedGroups {
@@ -582,6 +583,7 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 			log.Warn("[keyspace] failed to reconcile status for meta-service group changes",
 				zap.Strings("deleted-groups", deletedGroups),
 				zap.Strings("added-groups", addedGroups), zap.Error(err))
+			reconcileFailed = true
 		}
 	}
 	// Apply the change to the in-memory view only after the storage writes above.
@@ -594,6 +596,12 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	}
 	for _, id := range deletedGroups {
 		delete(m.cachedStatus, id)
+	}
+	// If the synchronous reset above failed, mark the zeroed added groups dirty so a
+	// later flush re-persists their zero status; otherwise the stale value left in
+	// storage would be resurrected by the next RefreshCache, breaking the reset.
+	if reconcileFailed && len(addedGroups) > 0 {
+		m.markDirtyStatusLocked(len(addedGroups))
 	}
 	m.statusMu.Unlock()
 	return nil

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -29,8 +30,14 @@ import (
 	"github.com/tikv/pd/server/config"
 )
 
+const (
+	flushInterval  = 5 * time.Minute
+	flushThreshold = 1000
+)
+
 // MetaServiceGroupManager manages external meta-service groups.
 type MetaServiceGroupManager struct {
+	ctx   context.Context
 	store endpoint.MetaServiceGroupStorage
 	syncutil.RWMutex
 	// metaServiceGroups is the available external meta-service groups.
@@ -41,6 +48,10 @@ type MetaServiceGroupManager struct {
 	// the authoritative source for the delete guard so a stale persisted counter
 	// cannot permanently block removing an actually-empty group.
 	keyspaceAssignmentCounter func(groupIDs map[string]struct{}) (map[string]int, error)
+	cachedStatus              map[string]*endpoint.MetaServiceGroupStatus
+	dirtyCount                int
+	flushCh                   chan struct{}
+	isLeader                  func() bool
 }
 
 // SetKeyspaceAssignmentCounter sets the authoritative keyspace assignment
@@ -50,30 +61,101 @@ func (m *MetaServiceGroupManager) SetKeyspaceAssignmentCounter(counter func(grou
 	m.keyspaceAssignmentCounter = counter
 }
 
-// NewMetaServiceGroupManager creates a new MetaServiceGroupManager.
-func NewMetaServiceGroupManager(
-	store endpoint.MetaServiceGroupStorage,
-	metaServiceGroups map[string]string,
-) *MetaServiceGroupManager {
-	return &MetaServiceGroupManager{
-		store:             store,
-		metaServiceGroups: metaServiceGroups,
-	}
+// SetLeaderChecker sets a function to determine leader ownership.
+func (m *MetaServiceGroupManager) SetLeaderChecker(isLeader func() bool) {
+	m.Lock()
+	defer m.Unlock()
+	m.isLeader = isLeader
 }
 
-// GetStatus returns the status of each meta-service group.
-func (m *MetaServiceGroupManager) GetStatus(ctx context.Context) (map[string]*endpoint.MetaServiceGroupStatus, error) {
-	m.RLock()
-	defer m.RUnlock()
+// NewMetaServiceGroupManager creates a new MetaServiceGroupManager.
+func NewMetaServiceGroupManager(
+	ctx context.Context,
+	store endpoint.MetaServiceGroupStorage,
+	metaServiceGroups map[string]string,
+) (*MetaServiceGroupManager, error) {
+	m := &MetaServiceGroupManager{
+		ctx:               ctx,
+		store:             store,
+		metaServiceGroups: metaServiceGroups,
+		flushCh:           make(chan struct{}, 1),
+	}
+	if err := m.RefreshCache(); err != nil {
+		return nil, err
+	}
+	go m.flushLoop()
+	return m, nil
+}
+
+// RefreshCache loads the current status from storage into memory.
+func (m *MetaServiceGroupManager) RefreshCache() error {
+	m.Lock()
+	defer m.Unlock()
 	var (
 		err       error
 		statusMap map[string]*endpoint.MetaServiceGroupStatus
 	)
-	err = m.store.RunInTxn(ctx, func(txn kv.Txn) error {
+	if err = m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
 		statusMap, err = m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
 		return err
-	})
-	return statusMap, err
+	}); err != nil {
+		log.Error("[keyspace] failed to load meta-service group status from storage", zap.Error(err))
+		return err
+	}
+	m.cachedStatus = statusMap
+	m.dirtyCount = 0
+	log.Info("[keyspace] meta-service group status loaded from storage", zap.Any("meta-service-group-status", statusMap))
+	return nil
+}
+
+func (m *MetaServiceGroupManager) flushLoop() {
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := m.flushToStorage(); err != nil {
+				log.Error("[keyspace] failed to flush meta-service group status to storage", zap.Error(err))
+			}
+		case <-m.flushCh:
+			if err := m.flushToStorage(); err != nil {
+				log.Error("[keyspace] failed to flush meta-service group status to storage", zap.Error(err))
+			}
+		}
+	}
+}
+
+func (m *MetaServiceGroupManager) flushToStorage() error {
+	m.Lock()
+	defer m.Unlock()
+	if m.isLeader != nil && !m.isLeader() {
+		return nil
+	}
+	if m.dirtyCount == 0 {
+		return nil
+	}
+	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
+		for id, status := range m.cachedStatus {
+			if err := m.store.SaveMetaServiceGroupStatus(txn, id, status); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	m.dirtyCount = 0
+	return nil
+}
+
+// GetStatus returns the status of each meta-service group.
+func (m *MetaServiceGroupManager) GetStatus(ctx context.Context) (map[string]*endpoint.MetaServiceGroupStatus, error) {
+	_ = ctx
+	m.RLock()
+	defer m.RUnlock()
+	return copyStatusMap(m.cachedStatus), nil
 }
 
 // GetAssignmentCounts returns the count of each meta-service group.
@@ -90,6 +172,19 @@ func (m *MetaServiceGroupManager) GetAssignmentCounts(ctx context.Context) (map[
 	return counts, nil
 }
 
+func copyStatusMap(statusMap map[string]*endpoint.MetaServiceGroupStatus) map[string]*endpoint.MetaServiceGroupStatus {
+	statuses := make(map[string]*endpoint.MetaServiceGroupStatus, len(statusMap))
+	for groupID, status := range statusMap {
+		if status == nil {
+			statuses[groupID] = &endpoint.MetaServiceGroupStatus{}
+			continue
+		}
+		copiedStatus := *status
+		statuses[groupID] = &copiedStatus
+	}
+	return statuses
+}
+
 // MetaServiceGroupStatusPatch represents a patch operation for a meta-service group.
 // NOTE: This type is exported by HTTP API. Please pay more attention when modifying it.
 type MetaServiceGroupStatusPatch struct {
@@ -102,38 +197,35 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	if patch.AssignmentCount != nil && *patch.AssignmentCount < 0 {
 		return ErrInvalidAssignmentCount
 	}
-	m.RLock()
-	defer m.RUnlock()
-	// Validate existence against the in-memory group set under the lock, then
-	// touch only the target group's status in the txn. Loading every group would
-	// widen the etcd compare set so an unrelated concurrent assignment could make
-	// this patch fail with a spurious txn conflict.
+	m.Lock()
+	defer m.Unlock()
 	if _, ok := m.metaServiceGroups[groupID]; !ok {
 		return ErrUnknownMetaServiceGroup
 	}
-	return m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		status, err := m.loadGroupStatus(txn, groupID)
-		if err != nil {
-			return err
-		}
-		if patch.AssignmentCount != nil {
-			status.AssignmentCount = *patch.AssignmentCount
-		}
-		if patch.Enabled != nil {
-			status.Enabled = *patch.Enabled
-		}
-		return m.store.SaveMetaServiceGroupStatus(txn, groupID, status)
-	})
+	currentStatus := m.cachedStatus[groupID]
+	if currentStatus == nil {
+		currentStatus = &endpoint.MetaServiceGroupStatus{}
+	}
+	newStatus := *currentStatus
+	if patch.AssignmentCount != nil {
+		newStatus.AssignmentCount = *patch.AssignmentCount
+	}
+	if patch.Enabled != nil {
+		newStatus.Enabled = *patch.Enabled
+	}
+	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
+		return m.store.SaveMetaServiceGroupStatus(txn, groupID, &newStatus)
+	}); err != nil {
+		return err
+	}
+	m.cachedStatus[groupID] = &newStatus
+	return nil
 }
 
-func (m *MetaServiceGroupManager) findMinMetaGroup(txn kv.Txn) (string, error) {
-	statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
-	if err != nil {
-		return "", err
-	}
+func (m *MetaServiceGroupManager) findMinMetaGroupLocked() (string, error) {
 	minCount := math.MaxInt
 	var assignedGroup string
-	for currentGroup, status := range statusMap {
+	for currentGroup, status := range m.cachedStatus {
 		if status.Enabled && status.AssignmentCount < minCount {
 			minCount = status.AssignmentCount
 			assignedGroup = currentGroup
@@ -146,32 +238,31 @@ func (m *MetaServiceGroupManager) findMinMetaGroup(txn kv.Txn) (string, error) {
 }
 
 // PickGroup returns the meta-service group with the least assigned keyspaces
-// without updating the persisted assignment count.
+// and updates the cached assignment count.
 func (m *MetaServiceGroupManager) PickGroup(ctx context.Context) (string, error) {
-	m.RLock()
-	defer m.RUnlock()
+	_ = ctx
+	m.Lock()
+	defer m.Unlock()
 	return m.pickGroupLocked(ctx)
 }
 
 // hasGroupsLocked reports whether any meta-service group is currently available.
-// The caller must hold the read lock.
+// The caller must hold the lock.
 func (m *MetaServiceGroupManager) hasGroupsLocked() bool {
 	return len(m.metaServiceGroups) > 0
 }
 
-// pickGroupLocked is PickGroup with the read lock already held by the caller.
+// pickGroupLocked is PickGroup with the lock already held by the caller.
 // Callers that need group selection and the subsequent keyspace metadata save to
 // be atomic with respect to group deletion (which takes the write lock) must
-// hold the read lock across both, e.g. via Manager.assignGroupAndSaveKeyspace.
+// hold the lock across both, e.g. via Manager.assignGroupAndSaveKeyspace.
 func (m *MetaServiceGroupManager) pickGroupLocked(ctx context.Context) (string, error) {
-	var assignedGroup string
-	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		var err error
-		if assignedGroup, err = m.findMinMetaGroup(txn); err != nil {
-			return err
-		}
-		return m.updateAssignmentTxn(txn, "", assignedGroup)
-	}); err != nil {
+	_ = ctx
+	assignedGroup, err := m.findMinMetaGroupLocked()
+	if err != nil {
+		return "", err
+	}
+	if err := m.updateAssignmentLockedTxn(nil, "", assignedGroup); err != nil {
 		return "", err
 	}
 	return assignedGroup, nil
@@ -181,36 +272,26 @@ func (m *MetaServiceGroupManager) pickGroupLocked(ctx context.Context) (string, 
 // It returns the assigned meta-service group and an error if any.
 // only used for testing now, as it doesn't guarantee the atomicity of select and update. UpdateAssignment should be used in production code instead.
 func (m *MetaServiceGroupManager) AssignToGroup(ctx context.Context, count int) (string, error) {
+	_ = ctx
 	if count < 0 {
 		return "", ErrInvalidAssignmentCount
 	}
-	m.RLock()
-	defer m.RUnlock()
-	var assignedGroup string
-	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		var err error
-		assignedGroup, err = m.findMinMetaGroup(txn)
-		if err != nil {
-			return err
-		}
-		statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
-		if err != nil {
-			return err
-		}
-		status := statusMap[assignedGroup]
-		status.AssignmentCount += count
-		return m.store.SaveMetaServiceGroupStatus(txn, assignedGroup, status)
-	}); err != nil {
+	m.Lock()
+	defer m.Unlock()
+	assignedGroup, err := m.findMinMetaGroupLocked()
+	if err != nil {
 		return "", err
 	}
+	m.cachedStatus[assignedGroup].AssignmentCount += count
+	m.markDirtyLocked(count)
 	return assignedGroup, nil
 }
 
 // reassignKeyspaceLocked validates that newGroupID (if any) still exists and
 // moves a single keyspace assignment from oldGroupID to newGroupID within txn.
-// The caller must hold the read lock for the whole enclosing transaction so a
+// The caller must hold the lock for the whole enclosing transaction so a
 // concurrent UpdateGroupsSafely cannot delete a group between this validation
-// and the persisted assignment count update.
+// and the cached assignment count update.
 func (m *MetaServiceGroupManager) reassignKeyspaceLocked(txn kv.Txn, oldGroupID, newGroupID string) error {
 	if newGroupID != "" {
 		if _, ok := m.metaServiceGroups[newGroupID]; !ok {
@@ -218,60 +299,51 @@ func (m *MetaServiceGroupManager) reassignKeyspaceLocked(txn kv.Txn, oldGroupID,
 		}
 		// Disabled groups are skipped by automatic assignment, so reject moving a
 		// keyspace into one to keep manual reassignment consistent with it.
-		statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, map[string]string{newGroupID: ""})
-		if err != nil {
-			return err
-		}
-		if status := statusMap[newGroupID]; status == nil || !status.Enabled {
+		if status := m.cachedStatus[newGroupID]; status == nil || !status.Enabled {
 			return ErrMetaServiceGroupDisabled
 		}
 	}
-	return m.updateAssignmentTxn(txn, oldGroupID, newGroupID)
+	return m.updateAssignmentLockedTxn(txn, oldGroupID, newGroupID)
 }
 
 func (m *MetaServiceGroupManager) updateAssignmentTxn(txn kv.Txn, oldGroupID, newGroupID string) error {
-	// Load only the affected groups instead of the whole m.metaServiceGroups map:
-	// some callers (e.g. RemoveKeyspace) reach this without holding the
-	// meta-service group lock, so reading the shared map here would race with
-	// UpdateGroupsSafely.
+	m.Lock()
+	defer m.Unlock()
+	return m.updateAssignmentLockedTxn(txn, oldGroupID, newGroupID)
+}
+
+func (m *MetaServiceGroupManager) updateAssignmentLockedTxn(txn kv.Txn, oldGroupID, newGroupID string) error {
+	_ = txn
+	dirtyCount := 0
 	if oldGroupID != "" {
-		status, err := m.loadGroupStatus(txn, oldGroupID)
-		if err != nil {
-			return err
-		}
-		// Only persist a decrement when the group still has assignments. A deleted
-		// group's status key is already removed, so skipping avoids recreating a
-		// stale zero-value status; a count of 0 needs no change anyway. This also
-		// guards against underflow after a manual reset via PatchStatus, which
-		// would otherwise make findMinMetaGroup prefer the group.
-		if status.AssignmentCount > 0 {
+		if status := m.cachedStatus[oldGroupID]; status != nil && status.AssignmentCount > 0 {
 			status.AssignmentCount--
-			if err := m.store.SaveMetaServiceGroupStatus(txn, oldGroupID, status); err != nil {
-				return err
-			}
+			dirtyCount++
 		}
 	}
 	if newGroupID != "" {
-		status, err := m.loadGroupStatus(txn, newGroupID)
-		if err != nil {
-			return err
+		status := m.cachedStatus[newGroupID]
+		if status == nil {
+			return ErrUnknownMetaServiceGroup
 		}
 		status.AssignmentCount++
-		if err := m.store.SaveMetaServiceGroupStatus(txn, newGroupID, status); err != nil {
-			return err
-		}
+		dirtyCount++
+	}
+	if dirtyCount > 0 {
+		m.markDirtyLocked(dirtyCount)
 	}
 	return nil
 }
 
-// loadGroupStatus loads the persisted status of a single meta-service group
-// within txn, without touching the shared m.metaServiceGroups map.
-func (m *MetaServiceGroupManager) loadGroupStatus(txn kv.Txn, groupID string) (*endpoint.MetaServiceGroupStatus, error) {
-	statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, map[string]string{groupID: ""})
-	if err != nil {
-		return nil, err
+func (m *MetaServiceGroupManager) markDirtyLocked(count int) {
+	m.dirtyCount += count
+	if m.dirtyCount < flushThreshold {
+		return
 	}
-	return statusMap[groupID], nil
+	select {
+	case m.flushCh <- struct{}{}:
+	default:
+	}
 }
 
 // AttachEndpoints append potential meta-service group endpoint to the given keyspace config map.
@@ -321,7 +393,7 @@ func (m *MetaServiceGroupManager) UpdateGroupsSafely(
 
 // persistGroupsLocked performs the delete-guard check and persists the new
 // groups while holding the write lock, which blocks concurrent keyspace
-// assignment (AssignToGroup/PickGroup/reassign all take the read lock).
+// assignment (AssignToGroup/PickGroup/reassign all take the lock).
 func (m *MetaServiceGroupManager) persistGroupsLocked(
 	ctx context.Context,
 	metaServiceGroups map[string]string,
@@ -345,12 +417,20 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 		return err
 	}
 	m.metaServiceGroups = metaServiceGroups
+	for groupID := range metaServiceGroups {
+		if m.cachedStatus[groupID] == nil {
+			m.cachedStatus[groupID] = &endpoint.MetaServiceGroupStatus{}
+		}
+	}
 	// Clear the persisted status for deleted groups so re-adding a group with
 	// the same ID does not inherit a stale assignment count or enabled state,
 	// which would skew list output and PickGroup balancing. Best-effort: the
 	// config deletion is already persisted and the delete guard relies on
 	// actual keyspace scans, not this counter.
 	if len(deletedGroups) > 0 {
+		for _, id := range deletedGroups {
+			delete(m.cachedStatus, id)
+		}
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 			for _, id := range deletedGroups {
 				if err := m.store.RemoveMetaServiceGroupStatus(txn, id); err != nil {
@@ -368,9 +448,9 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 
 // assignedKeyspaceCounts returns the number of keyspaces assigned to each of the
 // given groups. It prefers the authoritative keyspace scan (immune to counter
-// drift) and falls back to the persisted counter when no scanner is configured,
+// drift) and falls back to the cached counter when no scanner is configured,
 // e.g. in unit tests without a keyspace manager.
-func (m *MetaServiceGroupManager) assignedKeyspaceCounts(ctx context.Context, groupIDs []string) (map[string]int, error) {
+func (m *MetaServiceGroupManager) assignedKeyspaceCounts(_ context.Context, groupIDs []string) (map[string]int, error) {
 	if m.keyspaceAssignmentCounter != nil {
 		set := make(map[string]struct{}, len(groupIDs))
 		for _, id := range groupIDs {
@@ -378,22 +458,14 @@ func (m *MetaServiceGroupManager) assignedKeyspaceCounts(ctx context.Context, gr
 		}
 		return m.keyspaceAssignmentCounter(set)
 	}
-	// Fallback path: derive counts from the persisted status. The caller holds
+	// Fallback path: derive counts from the cached status. The caller holds
 	// the write lock, so m.metaServiceGroups is accessed without an extra read
 	// lock (which would deadlock against the held write lock).
-	var counts map[string]int
-	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		statusMap, err := m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
-		if err != nil {
-			return err
-		}
-		counts = make(map[string]int, len(statusMap))
-		for id, status := range statusMap {
+	counts := make(map[string]int, len(groupIDs))
+	for _, id := range groupIDs {
+		if status := m.cachedStatus[id]; status != nil {
 			counts[id] = status.AssignmentCount
 		}
-		return nil
-	}); err != nil {
-		return nil, err
 	}
 	return counts, nil
 }
@@ -403,4 +475,14 @@ func (m *MetaServiceGroupManager) updateGroups(metaServiceGroups map[string]stri
 	m.Lock()
 	defer m.Unlock()
 	m.metaServiceGroups = metaServiceGroups
+	for groupID := range metaServiceGroups {
+		if m.cachedStatus[groupID] == nil {
+			m.cachedStatus[groupID] = &endpoint.MetaServiceGroupStatus{}
+		}
+	}
+	for groupID := range m.cachedStatus {
+		if _, ok := metaServiceGroups[groupID]; !ok {
+			delete(m.cachedStatus, groupID)
+		}
+	}
 }

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -262,8 +262,22 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	}); err != nil {
 		return err
 	}
+	// Apply only the patched fields to the live cached status instead of replacing
+	// it wholesale: an assignment-count update (updateAssignmentTxn, statusMu only)
+	// may have mutated the count during the I/O above, and overwriting with the
+	// pre-I/O snapshot would drop it.
 	m.statusMu.Lock()
-	m.cachedStatus[groupID] = &newStatus
+	status := m.cachedStatus[groupID]
+	if status == nil {
+		status = &endpoint.MetaServiceGroupStatus{}
+		m.cachedStatus[groupID] = status
+	}
+	if patch.AssignmentCount != nil {
+		status.AssignmentCount = *patch.AssignmentCount
+	}
+	if patch.Enabled != nil {
+		status.Enabled = *patch.Enabled
+	}
 	m.statusMu.Unlock()
 	return nil
 }

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -431,6 +431,15 @@ func (m *MetaServiceGroupManager) GetGroups() map[string]string {
 	return groups
 }
 
+// HasGroups reports whether any meta-service group is currently available. It
+// avoids the map copy of GetGroups for callers that only need the existence
+// check, e.g. the keyspace creation path.
+func (m *MetaServiceGroupManager) HasGroups() bool {
+	m.RLock()
+	defer m.RUnlock()
+	return m.hasGroupsLocked()
+}
+
 // UpdateGroupsSafely persists and applies meta-service group changes while
 // blocking concurrent keyspace assignments.
 func (m *MetaServiceGroupManager) UpdateGroupsSafely(

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -143,21 +143,28 @@ func (m *MetaServiceGroupManager) flushLoop() {
 }
 
 func (m *MetaServiceGroupManager) flushToStorage() error {
-	// Only the serving leader persists; a stale read here is benign because the
-	// next leader reloads the authoritative status via RefreshCache.
-	m.RLock()
-	skip := m.isLeader != nil && !m.isLeader()
-	m.RUnlock()
-	if skip {
+	// Hold the mgm write lock for the whole flush, including the storage write, so
+	// it serializes with PatchStatus and persistGroupsLocked (both take the mgm
+	// lock). Without that, the snapshot below could overwrite a status those paths
+	// persisted synchronously in the meantime, or recreate a status key that
+	// persistGroupsLocked just deleted. This cannot deadlock: the metaLock-holding
+	// paths (RemoveKeyspace, tombstone unassignment) only take statusMu, never the
+	// mgm lock, so nothing waits on the mgm lock while holding metaLock, and flush
+	// never takes metaLock.
+	m.Lock()
+	defer m.Unlock()
+	// Only the serving leader persists; a follower's next leader term reloads the
+	// authoritative status via RefreshCache.
+	if m.isLeader != nil && !m.isLeader() {
 		return nil
 	}
-	// Snapshot the dirty state under statusMu and reset the dirty counter
-	// optimistically, then release the lock before the storage transaction so a
-	// slow etcd write does not block concurrent assignment operations. The
-	// snapshot is a deep copy, so later cache mutations are not observed by this
-	// flush. On failure the dirty count is restored so the next tick retries.
-	// Only flushLoop calls this, so there is no concurrent flush to race the
-	// reset/restore.
+	// Snapshot the dirty state under statusMu (a deep copy) and reset the dirty
+	// counter, without holding statusMu across the storage write. The snapshot
+	// keeps the write from reading cachedStatus while a concurrent statusMu holder
+	// (an assignment-count update under metaLock) mutates it; such updates re-mark
+	// the counter dirty and are flushed on the next tick. On failure the dirty
+	// count is restored. Only flushLoop calls this, so no concurrent flush races
+	// the reset/restore.
 	m.statusMu.Lock()
 	if m.dirtyCount == 0 {
 		m.statusMu.Unlock()

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -37,18 +37,27 @@ const (
 
 // MetaServiceGroupManager manages external meta-service groups.
 //
-// Locking: the embedded RWMutex guards metaServiceGroups and isLeader, while
-// statusMu is a dedicated leaf lock guarding cachedStatus and dirtyCount only.
-// statusMu must always be the innermost lock: never acquire the RWMutex or the
-// keyspace metaLock, and never perform storage I/O, while holding it. This lets
-// the assignment-count update paths that already hold the keyspace metaLock
-// (RemoveKeyspace, tombstone unassignment) mutate the cache without taking the
-// RWMutex, which would otherwise invert the RWMutex->metaLock order used by the
-// create/config paths and deadlock. Allowed orders are RWMutex->statusMu and
-// metaLock->statusMu; both are safe because statusMu wraps nothing.
+// Locking hierarchy, outermost to innermost: persistMu -> RWMutex -> statusMu.
+//   - persistMu serializes the storage writers (flushToStorage, PatchStatus,
+//     persistGroupsLocked, RefreshCache) so their status writes cannot clobber
+//     each other, without taking the RWMutex write lock across storage I/O. That
+//     keeps a slow flush from blocking RWMutex read paths (AttachEndpoints,
+//     GetGroups) or assignment operations.
+//   - the embedded RWMutex guards metaServiceGroups, isLeader and leaderCtx.
+//   - statusMu is a leaf lock guarding cachedStatus and dirtyCount only: never
+//     acquire the RWMutex, the keyspace metaLock or persistMu, and never perform
+//     storage I/O, while holding it. This lets the assignment-count update paths
+//     that already hold the keyspace metaLock (RemoveKeyspace, tombstone
+//     unassignment) mutate the cache without taking the RWMutex, which would
+//     otherwise invert the RWMutex->metaLock order used by the create/config
+//     paths and deadlock. Allowed orders are RWMutex->statusMu and
+//     metaLock->statusMu; both are safe because statusMu wraps nothing.
 type MetaServiceGroupManager struct {
 	ctx   context.Context
 	store endpoint.MetaServiceGroupStorage
+	// persistMu serializes storage writers; see the type comment. It is the
+	// outermost lock, taken before the RWMutex.
+	persistMu syncutil.Mutex
 	syncutil.RWMutex
 	// metaServiceGroups is the available external meta-service groups.
 	// The key is the meta-service group name, and the value is the corresponding endpoint.
@@ -59,6 +68,10 @@ type MetaServiceGroupManager struct {
 	// cannot permanently block removing an actually-empty group.
 	keyspaceAssignmentCounter func(groupIDs map[string]struct{}) (map[string]int, error)
 	isLeader                  func() bool
+	// leaderCtx is the current leadership term's context, canceled when this PD
+	// loses its lease. flushToStorage uses it so a lost-leadership PD does not keep
+	// writing status with the server-lifetime context. Guarded by the RWMutex.
+	leaderCtx context.Context
 	// statusMu guards cachedStatus and dirtyCount. See the type comment for the
 	// leaf-lock discipline it must follow.
 	statusMu     syncutil.Mutex
@@ -79,6 +92,15 @@ func (m *MetaServiceGroupManager) SetLeaderChecker(isLeader func() bool) {
 	m.Lock()
 	defer m.Unlock()
 	m.isLeader = isLeader
+}
+
+// SetLeaderContext sets the current leadership term's context, so flushToStorage
+// stops writing once the term ends. It is called from the service-ready callback
+// on each leadership acquisition with that term's context.
+func (m *MetaServiceGroupManager) SetLeaderContext(ctx context.Context) {
+	m.Lock()
+	defer m.Unlock()
+	m.leaderCtx = ctx
 }
 
 // NewMetaServiceGroupManager creates a new MetaServiceGroupManager.
@@ -102,6 +124,10 @@ func NewMetaServiceGroupManager(
 
 // RefreshCache loads the current status from storage into memory.
 func (m *MetaServiceGroupManager) RefreshCache() error {
+	// Serialize with flush/PatchStatus so the reload does not race an in-flight
+	// status write and load a half-applied view.
+	m.persistMu.Lock()
+	defer m.persistMu.Unlock()
 	m.Lock()
 	defer m.Unlock()
 	var (
@@ -143,20 +169,24 @@ func (m *MetaServiceGroupManager) flushLoop() {
 }
 
 func (m *MetaServiceGroupManager) flushToStorage() error {
-	// Hold the mgm write lock for the whole flush, including the storage write, so
-	// it serializes with PatchStatus and persistGroupsLocked (both take the mgm
-	// lock). Without that, the snapshot below could overwrite a status those paths
-	// persisted synchronously in the meantime, or recreate a status key that
-	// persistGroupsLocked just deleted. This cannot deadlock: the metaLock-holding
-	// paths (RemoveKeyspace, tombstone unassignment) only take statusMu, never the
-	// mgm lock, so nothing waits on the mgm lock while holding metaLock, and flush
-	// never takes metaLock.
-	m.Lock()
-	defer m.Unlock()
-	// Only the serving leader persists; a follower's next leader term reloads the
-	// authoritative status via RefreshCache.
-	if m.isLeader != nil && !m.isLeader() {
+	// Serialize the storage write with PatchStatus/persistGroupsLocked/RefreshCache
+	// on persistMu (not the mgm write lock), so a slow flush does not block mgm read
+	// paths (AttachEndpoints/GetGroups) or assignment operations, while still keeping
+	// the snapshot from clobbering a synchronous write or recreating a deleted key.
+	m.persistMu.Lock()
+	defer m.persistMu.Unlock()
+	// Only the serving leader persists, fenced to the current term: skip when not
+	// leader, and use the leadership context (canceled when the lease is lost) so a
+	// former leader's write is canceled instead of landing after the new leader.
+	m.RLock()
+	notLeader := m.isLeader != nil && !m.isLeader()
+	ctx := m.leaderCtx
+	m.RUnlock()
+	if notLeader {
 		return nil
+	}
+	if ctx == nil {
+		ctx = m.ctx
 	}
 	// Snapshot the dirty state under statusMu (a deep copy) and reset the dirty
 	// counter, without holding statusMu across the storage write. The snapshot
@@ -175,7 +205,7 @@ func (m *MetaServiceGroupManager) flushToStorage() error {
 	m.dirtyCount = 0
 	m.statusMu.Unlock()
 
-	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
+	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 		for id, status := range snapshot {
 			if err := m.store.SaveMetaServiceGroupStatus(txn, id, status); err != nil {
 				return err
@@ -237,9 +267,16 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	if patch.AssignmentCount != nil && *patch.AssignmentCount < 0 {
 		return ErrInvalidAssignmentCount
 	}
-	m.Lock()
-	defer m.Unlock()
-	if _, ok := m.metaServiceGroups[groupID]; !ok {
+	// Serialize with flush/persistGroupsLocked on persistMu so this synchronous
+	// write is not clobbered by a concurrent flush, without holding the mgm write
+	// lock across the storage I/O. persistMu also blocks persistGroupsLocked, so
+	// the group cannot be deleted between the existence check and the write.
+	m.persistMu.Lock()
+	defer m.persistMu.Unlock()
+	m.RLock()
+	_, known := m.metaServiceGroups[groupID]
+	m.RUnlock()
+	if !known {
 		return ErrUnknownMetaServiceGroup
 	}
 	m.statusMu.Lock()
@@ -256,7 +293,7 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	}
 	// Persist synchronously so API updates are immediately durable, then reflect
 	// them in the cache. The store I/O runs without statusMu (it is never held
-	// across I/O); the enclosing mgm write lock serializes concurrent patches.
+	// across I/O); persistMu serializes concurrent patches and flushes.
 	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 		return m.store.SaveMetaServiceGroupStatus(txn, groupID, &newStatus)
 	}); err != nil {
@@ -491,6 +528,10 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	deletedGroups []string,
 	persist func() error,
 ) error {
+	// Take persistMu (outermost) so the status reconcile writes below serialize
+	// with flush/PatchStatus and are not clobbered or resurrected by a flush.
+	m.persistMu.Lock()
+	defer m.persistMu.Unlock()
 	m.Lock()
 	defer m.Unlock()
 	if len(deletedGroups) > 0 {

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -493,23 +493,40 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	if err := persist(); err != nil {
 		return err
 	}
-	// Clear the persisted status for deleted groups before touching memory, so all
-	// storage writes complete before the in-memory view changes. This keeps
-	// re-adding a group with the same ID from inheriting a stale assignment count
-	// or enabled state, which would skew list output and PickGroup balancing.
-	// Best-effort: the config deletion is already persisted and the delete guard
-	// relies on actual keyspace scans, not this counter.
-	if len(deletedGroups) > 0 {
+	// Collect the groups that have no cached status yet (newly added or re-added)
+	// before mutating the cache, so their persisted status can be reset below.
+	m.statusMu.Lock()
+	var addedGroups []string
+	for groupID := range metaServiceGroups {
+		if m.cachedStatus[groupID] == nil {
+			addedGroups = append(addedGroups, groupID)
+		}
+	}
+	m.statusMu.Unlock()
+	// Reconcile persisted status before touching memory, so all storage writes
+	// complete before the in-memory view changes. Clearing deleted groups and
+	// resetting added ones to a zero status keeps re-adding a group with the same
+	// ID from inheriting a stale assignment count or enabled state (e.g. left by
+	// an earlier best-effort deletion that failed), which would skew list output
+	// and PickGroup balancing. Best-effort: the config change is already persisted
+	// and the delete guard relies on actual keyspace scans, not this counter.
+	if len(deletedGroups) > 0 || len(addedGroups) > 0 {
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 			for _, id := range deletedGroups {
 				if err := m.store.RemoveMetaServiceGroupStatus(txn, id); err != nil {
 					return err
 				}
 			}
+			for _, id := range addedGroups {
+				if err := m.store.SaveMetaServiceGroupStatus(txn, id, &endpoint.MetaServiceGroupStatus{}); err != nil {
+					return err
+				}
+			}
 			return nil
 		}); err != nil {
-			log.Warn("[keyspace] failed to clear status for deleted meta-service groups",
-				zap.Strings("deleted-groups", deletedGroups), zap.Error(err))
+			log.Warn("[keyspace] failed to reconcile status for meta-service group changes",
+				zap.Strings("deleted-groups", deletedGroups),
+				zap.Strings("added-groups", addedGroups), zap.Error(err))
 		}
 	}
 	// Apply the change to the in-memory view only after the storage writes above.

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -30,77 +29,49 @@ import (
 	"github.com/tikv/pd/server/config"
 )
 
-const (
-	flushInterval  = 5 * time.Minute
-	flushThreshold = 1000
-)
-
 // MetaServiceGroupManager manages external meta-service groups.
 //
-// Locking hierarchy, outermost to innermost: persistMu -> RWMutex -> statusMu.
-//   - persistMu serializes the storage writers (flushToStorage, PatchStatus,
-//     persistGroupsLocked, RefreshCache) so their status writes cannot clobber
-//     each other, without taking the RWMutex write lock across storage I/O. That
-//     keeps a slow flush from blocking RWMutex read paths (AttachEndpoints,
-//     GetGroups) or assignment operations.
-//   - the embedded RWMutex guards metaServiceGroups, isLeader and leaderCtx.
-//   - statusMu is a leaf lock guarding cachedStatus and dirtyCount only: never
-//     acquire the RWMutex, the keyspace metaLock or persistMu, and never perform
-//     storage I/O, while holding it. This lets the assignment-count update paths
-//     that already hold the keyspace metaLock (RemoveKeyspace, tombstone
-//     unassignment) mutate the cache without taking the RWMutex, which would
-//     otherwise invert the RWMutex->metaLock order used by the create/config
-//     paths and deadlock. Allowed orders are RWMutex->statusMu and
-//     metaLock->statusMu; both are safe because statusMu wraps nothing.
+// Persistence model: only the administrative Enabled flag of each group is
+// persisted. AssignmentCount is a derived, best-effort load-balancing hint, not a
+// source of truth: it is rebuilt from the authoritative keyspace metadata
+// (keyspaceAssignmentCounter) on every leader term via RefreshCache, and
+// maintained purely in memory during the term as keyspaces are created, removed
+// or reassigned. Nothing writes the count to storage, so there is no async flush
+// to fence against leadership changes and no stale count to reconcile; a lost
+// in-memory delta self-heals on the next term's rebuild.
+//
+// Locking: the embedded RWMutex guards metaServiceGroups; statusMu is a leaf lock
+// guarding cachedStatus only. statusMu must be the innermost lock: never acquire
+// the RWMutex or the keyspace metaLock, and never perform storage I/O, while
+// holding it. This lets the count-update paths that already hold the keyspace
+// metaLock (RemoveKeyspace, tombstone unassignment) mutate the cache without
+// taking the RWMutex, which would otherwise invert the RWMutex->metaLock order
+// used by the create/config paths and deadlock. Allowed orders are
+// RWMutex->statusMu and metaLock->statusMu; both are safe because statusMu wraps
+// nothing.
 type MetaServiceGroupManager struct {
 	ctx   context.Context
 	store endpoint.MetaServiceGroupStorage
-	// persistMu serializes storage writers; see the type comment. It is the
-	// outermost lock, taken before the RWMutex.
-	persistMu syncutil.Mutex
 	syncutil.RWMutex
 	// metaServiceGroups is the available external meta-service groups.
 	// The key is the meta-service group name, and the value is the corresponding endpoint.
 	metaServiceGroups map[string]string
-	// keyspaceAssignmentCounter, when set, returns the actual number of keyspaces
-	// assigned to each of the given groups by scanning keyspace metadata. It is
-	// the authoritative source for the delete guard so a stale persisted counter
-	// cannot permanently block removing an actually-empty group.
+	// keyspaceAssignmentCounter returns the actual number of keyspaces assigned to
+	// each of the given groups by scanning keyspace metadata. It is the
+	// authoritative source for both the delete guard and the derived assignment
+	// counts rebuilt by RefreshCache.
 	keyspaceAssignmentCounter func(groupIDs map[string]struct{}) (map[string]int, error)
-	isLeader                  func() bool
-	// leaderCtx is the current leadership term's context, canceled when this PD
-	// loses its lease. flushToStorage uses it so a lost-leadership PD does not keep
-	// writing status with the server-lifetime context. Guarded by the RWMutex.
-	leaderCtx context.Context
-	// statusMu guards cachedStatus and dirtyCount. See the type comment for the
-	// leaf-lock discipline it must follow.
+	// statusMu guards cachedStatus. See the type comment for the leaf-lock
+	// discipline it must follow.
 	statusMu     syncutil.Mutex
 	cachedStatus map[string]*endpoint.MetaServiceGroupStatus
-	dirtyCount   int
-	flushCh      chan struct{}
 }
 
 // SetKeyspaceAssignmentCounter sets the authoritative keyspace assignment
-// counter used by the delete guard. It must be called during initialization,
-// before any concurrent group update.
+// counter. It must be called during initialization, before any concurrent group
+// update.
 func (m *MetaServiceGroupManager) SetKeyspaceAssignmentCounter(counter func(groupIDs map[string]struct{}) (map[string]int, error)) {
 	m.keyspaceAssignmentCounter = counter
-}
-
-// SetLeaderChecker sets a function to determine leader ownership.
-func (m *MetaServiceGroupManager) SetLeaderChecker(isLeader func() bool) {
-	m.Lock()
-	defer m.Unlock()
-	m.isLeader = isLeader
-}
-
-// SetLeaderContext sets the current leadership term's context, so flushToStorage
-// stops writing once the term ends. It is called from the service-ready callback
-// on each leadership acquisition with that term's context.
-func (m *MetaServiceGroupManager) SetLeaderContext(ctx context.Context) {
-	m.Lock()
-	defer m.Unlock()
-	m.leaderCtx = ctx
 }
 
 // NewMetaServiceGroupManager creates a new MetaServiceGroupManager.
@@ -113,111 +84,56 @@ func NewMetaServiceGroupManager(
 		ctx:               ctx,
 		store:             store,
 		metaServiceGroups: metaServiceGroups,
-		flushCh:           make(chan struct{}, 1),
 	}
 	if err := m.RefreshCache(); err != nil {
 		return nil, err
 	}
-	go m.flushLoop()
 	return m, nil
 }
 
-// RefreshCache loads the current status from storage into memory.
+// RefreshCache rebuilds the in-memory status of every current group: the Enabled
+// flag from storage and the AssignmentCount from the authoritative keyspace scan.
+// It is called at construction and on each leadership acquisition, so every leader
+// term starts from counts derived from actual keyspace metadata rather than a
+// persisted value that could have drifted or been lost.
 func (m *MetaServiceGroupManager) RefreshCache() error {
-	// Serialize with flush/PatchStatus so the reload does not race an in-flight
-	// status write and load a half-applied view.
-	m.persistMu.Lock()
-	defer m.persistMu.Unlock()
 	m.Lock()
 	defer m.Unlock()
-	var (
-		err       error
-		statusMap map[string]*endpoint.MetaServiceGroupStatus
-	)
-	if err = m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
-		statusMap, err = m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
+	var stored map[string]*endpoint.MetaServiceGroupStatus
+	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
+		var err error
+		stored, err = m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
 		return err
 	}); err != nil {
 		log.Error("[keyspace] failed to load meta-service group status from storage", zap.Error(err))
 		return err
 	}
-	m.statusMu.Lock()
-	m.cachedStatus = statusMap
-	m.dirtyCount = 0
-	m.statusMu.Unlock()
-	log.Info("[keyspace] meta-service group status loaded from storage", zap.Any("meta-service-group-status", statusMap))
-	return nil
-}
-
-func (m *MetaServiceGroupManager) flushLoop() {
-	ticker := time.NewTicker(flushInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-m.ctx.Done():
-			return
-		case <-ticker.C:
-			if err := m.flushToStorage(); err != nil {
-				log.Error("[keyspace] failed to flush meta-service group status to storage", zap.Error(err))
-			}
-		case <-m.flushCh:
-			if err := m.flushToStorage(); err != nil {
-				log.Error("[keyspace] failed to flush meta-service group status to storage", zap.Error(err))
-			}
+	// Rebuild counts from keyspace metadata. The counter is nil before the keyspace
+	// manager wires it (e.g. at construction) and in unit tests without one; counts
+	// then start at zero and are corrected on the next RefreshCache.
+	counts := map[string]int{}
+	if m.keyspaceAssignmentCounter != nil {
+		set := make(map[string]struct{}, len(m.metaServiceGroups))
+		for id := range m.metaServiceGroups {
+			set[id] = struct{}{}
+		}
+		var err error
+		if counts, err = m.keyspaceAssignmentCounter(set); err != nil {
+			return err
 		}
 	}
-}
-
-func (m *MetaServiceGroupManager) flushToStorage() error {
-	// Serialize the storage write with PatchStatus/persistGroupsLocked/RefreshCache
-	// on persistMu (not the mgm write lock), so a slow flush does not block mgm read
-	// paths (AttachEndpoints/GetGroups) or assignment operations, while still keeping
-	// the snapshot from clobbering a synchronous write or recreating a deleted key.
-	m.persistMu.Lock()
-	defer m.persistMu.Unlock()
-	// Only the serving leader persists, fenced to the current term: skip when not
-	// leader, and use the leadership context (canceled when the lease is lost) so a
-	// former leader's write is canceled instead of landing after the new leader.
-	m.RLock()
-	notLeader := m.isLeader != nil && !m.isLeader()
-	ctx := m.leaderCtx
-	m.RUnlock()
-	if notLeader {
-		return nil
-	}
-	if ctx == nil {
-		ctx = m.ctx
-	}
-	// Snapshot the dirty state under statusMu (a deep copy) and reset the dirty
-	// counter, without holding statusMu across the storage write. The snapshot
-	// keeps the write from reading cachedStatus while a concurrent statusMu holder
-	// (an assignment-count update under metaLock) mutates it; such updates re-mark
-	// the counter dirty and are flushed on the next tick. On failure the dirty
-	// count is restored. Only flushLoop calls this, so no concurrent flush races
-	// the reset/restore.
-	m.statusMu.Lock()
-	if m.dirtyCount == 0 {
-		m.statusMu.Unlock()
-		return nil
-	}
-	snapshot := copyStatusMap(m.cachedStatus)
-	flushed := m.dirtyCount
-	m.dirtyCount = 0
-	m.statusMu.Unlock()
-
-	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		for id, status := range snapshot {
-			if err := m.store.SaveMetaServiceGroupStatus(txn, id, status); err != nil {
-				return err
-			}
+	cache := make(map[string]*endpoint.MetaServiceGroupStatus, len(m.metaServiceGroups))
+	for id := range m.metaServiceGroups {
+		enabled := false
+		if s := stored[id]; s != nil {
+			enabled = s.Enabled
 		}
-		return nil
-	}); err != nil {
-		m.statusMu.Lock()
-		m.dirtyCount += flushed
-		m.statusMu.Unlock()
-		return err
+		cache[id] = &endpoint.MetaServiceGroupStatus{AssignmentCount: counts[id], Enabled: enabled}
 	}
+	m.statusMu.Lock()
+	m.cachedStatus = cache
+	m.statusMu.Unlock()
+	log.Info("[keyspace] meta-service group status rebuilt", zap.Any("meta-service-group-status", cache))
 	return nil
 }
 
@@ -229,7 +145,6 @@ func (m *MetaServiceGroupManager) GetStatus(_ context.Context) (map[string]*endp
 }
 
 // GetAssignmentCounts returns the count of each meta-service group.
-// todo: optimize by caching the counts and watching the changes of meta-service groups.
 func (m *MetaServiceGroupManager) GetAssignmentCounts(ctx context.Context) (map[string]int, error) {
 	statusMap, err := m.GetStatus(ctx)
 	if err != nil {
@@ -262,47 +177,29 @@ type MetaServiceGroupStatusPatch struct {
 	Enabled         *bool `json:"enabled,omitempty"`          // nil means no change, true means enable, false means disable
 }
 
-// PatchStatus applies a patch to the status of a meta-service group.
+// PatchStatus applies a patch to the status of a meta-service group. Only the
+// Enabled flag is persisted; a patched AssignmentCount is applied to the derived
+// in-memory hint and is superseded by the next RefreshCache, kept for API
+// compatibility.
 func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID string, patch *MetaServiceGroupStatusPatch) error {
 	if patch.AssignmentCount != nil && *patch.AssignmentCount < 0 {
 		return ErrInvalidAssignmentCount
 	}
-	// Serialize with flush/persistGroupsLocked on persistMu so this synchronous
-	// write is not clobbered by a concurrent flush, without holding the mgm write
-	// lock across the storage I/O. persistMu also blocks persistGroupsLocked, so
-	// the group cannot be deleted between the existence check and the write.
-	m.persistMu.Lock()
-	defer m.persistMu.Unlock()
-	m.RLock()
-	_, known := m.metaServiceGroups[groupID]
-	m.RUnlock()
-	if !known {
+	m.Lock()
+	defer m.Unlock()
+	if _, ok := m.metaServiceGroups[groupID]; !ok {
 		return ErrUnknownMetaServiceGroup
 	}
-	m.statusMu.Lock()
-	newStatus := endpoint.MetaServiceGroupStatus{}
-	if currentStatus := m.cachedStatus[groupID]; currentStatus != nil {
-		newStatus = *currentStatus
-	}
-	m.statusMu.Unlock()
-	if patch.AssignmentCount != nil {
-		newStatus.AssignmentCount = *patch.AssignmentCount
-	}
+	// Persist the Enabled flag (the only persisted field) synchronously when it
+	// changes. The mgm write lock serializes this with persistGroupsLocked, so the
+	// group cannot be deleted between the existence check and the write.
 	if patch.Enabled != nil {
-		newStatus.Enabled = *patch.Enabled
+		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
+			return m.store.SaveMetaServiceGroupStatus(txn, groupID, &endpoint.MetaServiceGroupStatus{Enabled: *patch.Enabled})
+		}); err != nil {
+			return err
+		}
 	}
-	// Persist synchronously so API updates are immediately durable, then reflect
-	// them in the cache. The store I/O runs without statusMu (it is never held
-	// across I/O); persistMu serializes concurrent patches and flushes.
-	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-		return m.store.SaveMetaServiceGroupStatus(txn, groupID, &newStatus)
-	}); err != nil {
-		return err
-	}
-	// Apply only the patched fields to the live cached status instead of replacing
-	// it wholesale: an assignment-count update (updateAssignmentTxn, statusMu only)
-	// may have mutated the count during the I/O above, and overwriting with the
-	// pre-I/O snapshot would drop it.
 	m.statusMu.Lock()
 	status := m.cachedStatus[groupID]
 	if status == nil {
@@ -336,8 +233,8 @@ func (m *MetaServiceGroupManager) findMinMetaGroupStatusLocked() (string, error)
 	return assignedGroup, nil
 }
 
-// PickGroup returns the meta-service group with the least assigned keyspaces
-// and updates the cached assignment count.
+// PickGroup returns the meta-service group with the least assigned keyspaces and
+// increments its in-memory assignment count.
 func (m *MetaServiceGroupManager) PickGroup(_ context.Context) (string, error) {
 	m.Lock()
 	defer m.Unlock()
@@ -352,8 +249,8 @@ func (m *MetaServiceGroupManager) hasGroupsLocked() bool {
 
 // pickGroupLocked is PickGroup with the mgm lock already held by the caller.
 // Callers that need group selection and the subsequent keyspace metadata save to
-// be atomic with respect to group deletion (which takes the write lock) must
-// hold the mgm lock across both, e.g. via Manager.assignGroupAndSaveKeyspace. The
+// be atomic with respect to group deletion (which takes the write lock) must hold
+// the mgm lock across both, e.g. via Manager.assignGroupAndSaveKeyspace. The
 // selection and the reservation are done together under statusMu so a concurrent
 // assignment cannot pick the same minimum twice.
 func (m *MetaServiceGroupManager) pickGroupLocked() (string, error) {
@@ -385,7 +282,6 @@ func (m *MetaServiceGroupManager) AssignToGroup(_ context.Context, count int) (s
 		return "", err
 	}
 	m.cachedStatus[assignedGroup].AssignmentCount += count
-	m.markDirtyStatusLocked(count)
 	return assignedGroup, nil
 }
 
@@ -411,16 +307,15 @@ func (m *MetaServiceGroupManager) reassignKeyspaceLocked(_ kv.Txn, oldGroupID, n
 	return m.applyAssignmentDeltaStatusLocked(oldGroupID, newGroupID)
 }
 
-// updateAssignmentTxn applies an assignment count delta to the cache. It takes
-// only statusMu (the leaf lock), deliberately NOT the mgm lock: callers such as
-// RemoveKeyspace and the tombstone unassignment already hold the keyspace
+// updateAssignmentTxn moves an assignment count delta in the in-memory cache. It
+// takes only statusMu (the leaf lock), deliberately NOT the mgm lock: callers
+// such as RemoveKeyspace and the tombstone unassignment already hold the keyspace
 // metaLock, and the create/config paths take the mgm lock before metaLock, so
 // acquiring the mgm lock here would invert that order and deadlock. The txn
-// parameter is intentionally unused: unlike the pre-cache implementation the
-// count is no longer written inside the caller's storage transaction, so callers
-// must not assume the count update is atomic with their txn. Counts are
-// best-effort load-balancing hints; the delete guard uses the authoritative
-// keyspace scan, and RefreshCache reconciles any drift on the next leader term.
+// parameter is unused: the count is a derived hint kept only in memory, not
+// written to storage, so it is not tied to the caller's storage transaction. Any
+// drift from a caller txn that fails to commit self-heals on the next RefreshCache,
+// and the delete guard relies on the authoritative keyspace scan, not this count.
 func (m *MetaServiceGroupManager) updateAssignmentTxn(_ kv.Txn, oldGroupID, newGroupID string) error {
 	m.statusMu.Lock()
 	defer m.statusMu.Unlock()
@@ -428,14 +323,11 @@ func (m *MetaServiceGroupManager) updateAssignmentTxn(_ kv.Txn, oldGroupID, newG
 }
 
 // applyAssignmentDeltaStatusLocked moves one assignment from oldGroupID to
-// newGroupID in the cached status and marks it dirty for the flush loop to
-// persist later. The caller must hold statusMu.
+// newGroupID in the cached status. The caller must hold statusMu.
 func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, newGroupID string) error {
-	dirtyCount := 0
 	if oldGroupID != "" {
 		if status := m.cachedStatus[oldGroupID]; status != nil && status.AssignmentCount > 0 {
 			status.AssignmentCount--
-			dirtyCount++
 		}
 	}
 	if newGroupID != "" {
@@ -444,25 +336,8 @@ func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, n
 			return ErrUnknownMetaServiceGroup
 		}
 		status.AssignmentCount++
-		dirtyCount++
-	}
-	if dirtyCount > 0 {
-		m.markDirtyStatusLocked(dirtyCount)
 	}
 	return nil
-}
-
-// markDirtyStatusLocked accumulates dirty count and signals the flush loop once
-// the threshold is reached. The caller must hold statusMu.
-func (m *MetaServiceGroupManager) markDirtyStatusLocked(count int) {
-	m.dirtyCount += count
-	if m.dirtyCount < flushThreshold {
-		return
-	}
-	select {
-	case m.flushCh <- struct{}{}:
-	default:
-	}
 }
 
 // AttachEndpoints append potential meta-service group endpoint to the given keyspace config map.
@@ -528,14 +403,10 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	deletedGroups []string,
 	persist func() error,
 ) error {
-	// Take persistMu (outermost) so the status reconcile writes below serialize
-	// with flush/PatchStatus and are not clobbered or resurrected by a flush.
-	m.persistMu.Lock()
-	defer m.persistMu.Unlock()
 	m.Lock()
 	defer m.Unlock()
 	if len(deletedGroups) > 0 {
-		counts, err := m.assignedKeyspaceCounts(ctx, deletedGroups)
+		counts, err := m.assignedKeyspaceCounts(deletedGroups)
 		if err != nil {
 			return err
 		}
@@ -548,60 +419,46 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	if err := persist(); err != nil {
 		return err
 	}
-	// Collect the groups that have no cached status yet (newly added or re-added)
-	// before mutating the cache, so their persisted status can be reset below.
+	// Clear the persisted Enabled flag for groups leaving the set and for groups
+	// entering it, so a re-added group starts disabled instead of inheriting a
+	// stale Enabled left in storage. This is done before mutating memory and fails
+	// hard on error (the operation is idempotent on retry), so the reset invariant
+	// always holds rather than being best-effort.
 	m.statusMu.Lock()
 	var addedGroups []string
-	for groupID := range metaServiceGroups {
-		if m.cachedStatus[groupID] == nil {
-			addedGroups = append(addedGroups, groupID)
+	for id := range metaServiceGroups {
+		if m.cachedStatus[id] == nil {
+			addedGroups = append(addedGroups, id)
 		}
 	}
 	m.statusMu.Unlock()
-	// Reconcile persisted status before touching memory, so all storage writes
-	// complete before the in-memory view changes. Clearing deleted groups and
-	// resetting added ones to a zero status keeps re-adding a group with the same
-	// ID from inheriting a stale assignment count or enabled state (e.g. left by
-	// an earlier best-effort deletion that failed), which would skew list output
-	// and PickGroup balancing. Best-effort: the config change is already persisted
-	// and the delete guard relies on actual keyspace scans, not this counter.
-	reconcileFailed := false
-	if len(deletedGroups) > 0 || len(addedGroups) > 0 {
+	clearGroups := make([]string, 0, len(deletedGroups)+len(addedGroups))
+	clearGroups = append(clearGroups, deletedGroups...)
+	clearGroups = append(clearGroups, addedGroups...)
+	if len(clearGroups) > 0 {
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-			for _, id := range deletedGroups {
+			for _, id := range clearGroups {
 				if err := m.store.RemoveMetaServiceGroupStatus(txn, id); err != nil {
-					return err
-				}
-			}
-			for _, id := range addedGroups {
-				if err := m.store.SaveMetaServiceGroupStatus(txn, id, &endpoint.MetaServiceGroupStatus{}); err != nil {
 					return err
 				}
 			}
 			return nil
 		}); err != nil {
-			log.Warn("[keyspace] failed to reconcile status for meta-service group changes",
-				zap.Strings("deleted-groups", deletedGroups),
-				zap.Strings("added-groups", addedGroups), zap.Error(err))
-			reconcileFailed = true
+			return err
 		}
 	}
 	// Apply the change to the in-memory view only after the storage writes above.
+	// Added groups start at zero: a new group has no keyspaces, and the delete guard
+	// guarantees a removed (hence re-addable) group had none either.
 	m.metaServiceGroups = metaServiceGroups
 	m.statusMu.Lock()
-	for groupID := range metaServiceGroups {
-		if m.cachedStatus[groupID] == nil {
-			m.cachedStatus[groupID] = &endpoint.MetaServiceGroupStatus{}
+	for id := range metaServiceGroups {
+		if m.cachedStatus[id] == nil {
+			m.cachedStatus[id] = &endpoint.MetaServiceGroupStatus{}
 		}
 	}
 	for _, id := range deletedGroups {
 		delete(m.cachedStatus, id)
-	}
-	// If the synchronous reset above failed, mark the zeroed added groups dirty so a
-	// later flush re-persists their zero status; otherwise the stale value left in
-	// storage would be resurrected by the next RefreshCache, breaking the reset.
-	if reconcileFailed && len(addedGroups) > 0 {
-		m.markDirtyStatusLocked(len(addedGroups))
 	}
 	m.statusMu.Unlock()
 	return nil
@@ -611,7 +468,7 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 // given groups. It prefers the authoritative keyspace scan (immune to counter
 // drift) and falls back to the cached counter when no scanner is configured,
 // e.g. in unit tests without a keyspace manager.
-func (m *MetaServiceGroupManager) assignedKeyspaceCounts(_ context.Context, groupIDs []string) (map[string]int, error) {
+func (m *MetaServiceGroupManager) assignedKeyspaceCounts(groupIDs []string) (map[string]int, error) {
 	if m.keyspaceAssignmentCounter != nil {
 		set := make(map[string]struct{}, len(groupIDs))
 		for _, id := range groupIDs {

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -29,16 +30,18 @@ import (
 	"github.com/tikv/pd/server/config"
 )
 
+const assignmentCountRebuildRetryInterval = time.Second
+
 // MetaServiceGroupManager manages external meta-service groups.
 //
 // Persistence model: only the administrative Enabled flag of each group is
 // persisted. AssignmentCount is a derived, best-effort load-balancing hint, not a
 // source of truth: it is rebuilt from the authoritative keyspace metadata
-// (keyspaceAssignmentCounter) on every leader term via RefreshCache, and
-// maintained purely in memory during the term as keyspaces are created, removed
-// or reassigned. Nothing writes the count to storage, so there is no async flush
-// to fence against leadership changes and no stale count to reconcile; a lost
-// in-memory delta self-heals on the next term's rebuild.
+// (keyspaceAssignmentCounter) asynchronously on every leader term, and maintained
+// purely in memory during the term as keyspaces are created, removed or
+// reassigned. Nothing writes the count to storage, so there is no async flush to
+// fence against leadership changes and no stale count to reconcile; a lost
+// in-memory delta self-heals on the next successful rebuild.
 //
 // Locking: the embedded RWMutex guards metaServiceGroups; statusMu is a leaf lock
 // guarding cachedStatus only. statusMu must be the innermost lock: never acquire
@@ -60,17 +63,20 @@ type MetaServiceGroupManager struct {
 	// each of the given groups by scanning keyspace metadata. It is the
 	// authoritative source for both the delete guard and the derived assignment
 	// counts rebuilt by RefreshCache.
-	keyspaceAssignmentCounter func(groupIDs map[string]struct{}) (map[string]int, error)
+	keyspaceAssignmentCounter func(ctx context.Context, groupIDs map[string]struct{}) (map[string]int, error)
 	// statusMu guards cachedStatus. See the type comment for the leaf-lock
 	// discipline it must follow.
-	statusMu     syncutil.Mutex
-	cachedStatus map[string]*endpoint.MetaServiceGroupStatus
+	statusMu         syncutil.Mutex
+	cachedStatus     map[string]*endpoint.MetaServiceGroupStatus
+	assignmentEpoch  uint64
+	countsReady      bool
+	countsRefreshing bool
 }
 
 // SetKeyspaceAssignmentCounter sets the authoritative keyspace assignment
 // counter. It must be called during initialization, before any concurrent group
 // update.
-func (m *MetaServiceGroupManager) SetKeyspaceAssignmentCounter(counter func(groupIDs map[string]struct{}) (map[string]int, error)) {
+func (m *MetaServiceGroupManager) SetKeyspaceAssignmentCounter(counter func(ctx context.Context, groupIDs map[string]struct{}) (map[string]int, error)) {
 	m.keyspaceAssignmentCounter = counter
 }
 
@@ -118,7 +124,7 @@ func (m *MetaServiceGroupManager) RefreshCache() error {
 			set[id] = struct{}{}
 		}
 		var err error
-		if counts, err = m.keyspaceAssignmentCounter(set); err != nil {
+		if counts, err = m.keyspaceAssignmentCounter(m.ctx, set); err != nil {
 			return err
 		}
 	}
@@ -132,9 +138,143 @@ func (m *MetaServiceGroupManager) RefreshCache() error {
 	}
 	m.statusMu.Lock()
 	m.cachedStatus = cache
+	m.assignmentEpoch++
+	m.countsReady = true
+	m.countsRefreshing = false
 	m.statusMu.Unlock()
 	log.Info("[keyspace] meta-service group status rebuilt", zap.Any("meta-service-group-status", cache))
 	return nil
+}
+
+// RefreshPersistedStatus reloads the persisted administrative status only. It is
+// intentionally lightweight for the leader-ready path; assignment counts are
+// rebuilt asynchronously by StartAssignmentCountRebuild.
+func (m *MetaServiceGroupManager) RefreshPersistedStatus() error {
+	m.Lock()
+	defer m.Unlock()
+	var stored map[string]*endpoint.MetaServiceGroupStatus
+	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
+		var err error
+		stored, err = m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
+		return err
+	}); err != nil {
+		log.Error("[keyspace] failed to load meta-service group status from storage", zap.Error(err))
+		return err
+	}
+
+	m.statusMu.Lock()
+	cache := make(map[string]*endpoint.MetaServiceGroupStatus, len(m.metaServiceGroups))
+	for id := range m.metaServiceGroups {
+		count := 0
+		if current := m.cachedStatus[id]; current != nil {
+			count = current.AssignmentCount
+		}
+		enabled := false
+		if s := stored[id]; s != nil {
+			enabled = s.Enabled
+		}
+		cache[id] = &endpoint.MetaServiceGroupStatus{AssignmentCount: count, Enabled: enabled}
+	}
+	m.cachedStatus = cache
+	m.assignmentEpoch++
+	m.countsReady = false
+	m.countsRefreshing = false
+	m.statusMu.Unlock()
+	log.Info("[keyspace] meta-service group persisted status loaded", zap.Any("meta-service-group-status", cache))
+	return nil
+}
+
+// IsAssignmentCountReady reports whether the current cached assignment counts
+// have completed an authoritative rebuild in this leader term.
+func (m *MetaServiceGroupManager) IsAssignmentCountReady() bool {
+	m.statusMu.Lock()
+	defer m.statusMu.Unlock()
+	return m.countsReady
+}
+
+// StartAssignmentCountRebuild asynchronously rebuilds assignment counts from
+// authoritative keyspace metadata. If serving traffic changes counts during the
+// scan, the result is discarded and another rebuild is scheduled.
+func (m *MetaServiceGroupManager) StartAssignmentCountRebuild(ctx context.Context) {
+	m.RLock()
+	groupIDs := make(map[string]struct{}, len(m.metaServiceGroups))
+	for id := range m.metaServiceGroups {
+		groupIDs[id] = struct{}{}
+	}
+	m.statusMu.Lock()
+	if m.countsRefreshing {
+		m.statusMu.Unlock()
+		m.RUnlock()
+		return
+	}
+	m.countsRefreshing = true
+	m.countsReady = false
+	startEpoch := m.assignmentEpoch
+	m.statusMu.Unlock()
+	m.RUnlock()
+
+	go m.rebuildAssignmentCounts(ctx, groupIDs, startEpoch)
+}
+
+func (m *MetaServiceGroupManager) rebuildAssignmentCounts(ctx context.Context, groupIDs map[string]struct{}, startEpoch uint64) {
+	if m.keyspaceAssignmentCounter == nil {
+		m.statusMu.Lock()
+		m.countsReady = true
+		m.countsRefreshing = false
+		m.statusMu.Unlock()
+		return
+	}
+	select {
+	case <-ctx.Done():
+		m.statusMu.Lock()
+		m.countsRefreshing = false
+		m.countsReady = false
+		m.statusMu.Unlock()
+		return
+	default:
+	}
+	counts, err := m.keyspaceAssignmentCounter(ctx, groupIDs)
+	if err != nil {
+		log.Warn("[keyspace] failed to rebuild meta-service group assignment counts", zap.Error(err))
+		m.statusMu.Lock()
+		m.countsRefreshing = false
+		m.countsReady = false
+		m.statusMu.Unlock()
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(assignmentCountRebuildRetryInterval):
+			m.StartAssignmentCountRebuild(ctx)
+		}
+		return
+	}
+	select {
+	case <-ctx.Done():
+		m.statusMu.Lock()
+		m.countsRefreshing = false
+		m.countsReady = false
+		m.statusMu.Unlock()
+		return
+	default:
+	}
+
+	shouldRetry := false
+	m.statusMu.Lock()
+	if m.assignmentEpoch == startEpoch {
+		for id, status := range m.cachedStatus {
+			status.AssignmentCount = counts[id]
+		}
+		m.countsReady = true
+		m.countsRefreshing = false
+	} else {
+		m.countsReady = false
+		m.countsRefreshing = false
+		shouldRetry = true
+	}
+	m.statusMu.Unlock()
+	if shouldRetry {
+		m.StartAssignmentCountRebuild(ctx)
+	}
 }
 
 // GetStatus returns the status of each meta-service group.
@@ -278,6 +418,7 @@ func (m *MetaServiceGroupManager) AssignToGroup(_ context.Context, count int) (s
 		return "", err
 	}
 	m.cachedStatus[assignedGroup].AssignmentCount += count
+	m.assignmentEpoch++
 	return assignedGroup, nil
 }
 
@@ -321,9 +462,11 @@ func (m *MetaServiceGroupManager) updateAssignmentTxn(_ kv.Txn, oldGroupID, newG
 // applyAssignmentDeltaStatusLocked moves one assignment from oldGroupID to
 // newGroupID in the cached status. The caller must hold statusMu.
 func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, newGroupID string) error {
+	changed := false
 	if oldGroupID != "" {
 		if status := m.cachedStatus[oldGroupID]; status != nil && status.AssignmentCount > 0 {
 			status.AssignmentCount--
+			changed = true
 		}
 	}
 	if newGroupID != "" {
@@ -332,6 +475,10 @@ func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, n
 			return ErrUnknownMetaServiceGroup
 		}
 		status.AssignmentCount++
+		changed = true
+	}
+	if changed {
+		m.assignmentEpoch++
 	}
 	return nil
 }
@@ -402,7 +549,7 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	m.Lock()
 	defer m.Unlock()
 	if len(deletedGroups) > 0 {
-		counts, err := m.assignedKeyspaceCounts(deletedGroups)
+		counts, err := m.assignedKeyspaceCounts(ctx, deletedGroups)
 		if err != nil {
 			return err
 		}
@@ -478,13 +625,13 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 // given groups. It prefers the authoritative keyspace scan (immune to counter
 // drift) and falls back to the cached counter when no scanner is configured,
 // e.g. in unit tests without a keyspace manager.
-func (m *MetaServiceGroupManager) assignedKeyspaceCounts(groupIDs []string) (map[string]int, error) {
+func (m *MetaServiceGroupManager) assignedKeyspaceCounts(ctx context.Context, groupIDs []string) (map[string]int, error) {
 	if m.keyspaceAssignmentCounter != nil {
 		set := make(map[string]struct{}, len(groupIDs))
 		for _, id := range groupIDs {
 			set[id] = struct{}{}
 		}
-		return m.keyspaceAssignmentCounter(set)
+		return m.keyspaceAssignmentCounter(ctx, set)
 	}
 	// Fallback path: derive counts from the cached status under statusMu.
 	counts := make(map[string]int, len(groupIDs))

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -416,14 +416,11 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 			}
 		}
 	}
-	if err := persist(); err != nil {
-		return err
-	}
-	// Clear the persisted Enabled flag for groups leaving the set and for groups
-	// entering it, so a re-added group starts disabled instead of inheriting a
-	// stale Enabled left in storage. This is done before mutating memory and fails
-	// hard on error (the operation is idempotent on retry), so the reset invariant
-	// always holds rather than being best-effort.
+	// Reset the persisted Enabled flag of groups entering the set BEFORE persisting
+	// the config, so a re-added group starts disabled instead of inheriting a stale
+	// flag left in storage. Failing hard here keeps the reset invariant without
+	// leaving the config and the in-memory view diverged: nothing below has changed
+	// yet, so the operation is a clean, retryable no-op on error.
 	m.statusMu.Lock()
 	var addedGroups []string
 	for id := range metaServiceGroups {
@@ -432,12 +429,9 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 		}
 	}
 	m.statusMu.Unlock()
-	clearGroups := make([]string, 0, len(deletedGroups)+len(addedGroups))
-	clearGroups = append(clearGroups, deletedGroups...)
-	clearGroups = append(clearGroups, addedGroups...)
-	if len(clearGroups) > 0 {
+	if len(addedGroups) > 0 {
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-			for _, id := range clearGroups {
+			for _, id := range addedGroups {
 				if err := m.store.RemoveMetaServiceGroupStatus(txn, id); err != nil {
 					return err
 				}
@@ -447,9 +441,13 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 			return err
 		}
 	}
-	// Apply the change to the in-memory view only after the storage writes above.
-	// Added groups start at zero: a new group has no keyspaces, and the delete guard
-	// guarantees a removed (hence re-addable) group had none either.
+	if err := persist(); err != nil {
+		return err
+	}
+	// Apply the change to the in-memory view only after the config is persisted, so
+	// the two never diverge. Added groups start at zero: a new group has no
+	// keyspaces, and the delete guard guarantees a removed (hence re-addable) group
+	// had none either.
 	m.metaServiceGroups = metaServiceGroups
 	m.statusMu.Lock()
 	for id := range metaServiceGroups {
@@ -461,6 +459,22 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 		delete(m.cachedStatus, id)
 	}
 	m.statusMu.Unlock()
+	// Best-effort cleanup of the deleted groups' now-orphan persisted status. It is
+	// safe if this fails: RefreshCache only loads status for current groups, so an
+	// orphan key is never read, and a future re-add clears it via the reset above.
+	if len(deletedGroups) > 0 {
+		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
+			for _, id := range deletedGroups {
+				if err := m.store.RemoveMetaServiceGroupStatus(txn, id); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			log.Warn("[keyspace] failed to clear status for deleted meta-service groups",
+				zap.Strings("deleted-groups", deletedGroups), zap.Error(err))
+		}
+	}
 	return nil
 }
 

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -51,7 +51,9 @@ const assignmentCountRebuildRetryInterval = time.Second
 // taking the RWMutex, which would otherwise invert the RWMutex->metaLock order
 // used by the create/config paths and deadlock. Allowed orders are
 // RWMutex->statusMu and metaLock->statusMu; both are safe because statusMu wraps
-// nothing.
+// nothing. patchMu sits between the two: RWMutex(RLock)->patchMu->statusMu. It
+// is held only by PatchStatus, across storage I/O, so it must never be taken
+// while already holding statusMu.
 type MetaServiceGroupManager struct {
 	store endpoint.MetaServiceGroupStorage
 	syncutil.RWMutex
@@ -67,6 +69,13 @@ type MetaServiceGroupManager struct {
 	// discipline it must follow.
 	statusMu     syncutil.Mutex
 	cachedStatus map[string]*endpoint.MetaServiceGroupStatus
+	// patchMu serializes PatchStatus's persist-then-publish sequence (storage
+	// write followed by the cachedStatus update) end to end, across concurrent
+	// PatchStatus calls on this instance. Without it, two concurrent calls can
+	// commit to storage in one order but publish to cachedStatus in the
+	// other, leaving the cache holding an already-superseded value. It is
+	// acquired around, and therefore outermost relative to, statusMu.
+	patchMu syncutil.Mutex
 	// termGen is the leader-term generation. It is bumped only at term boundaries
 	// (RefreshCache at construction, RefreshPersistedStatus on leadership change),
 	// never by assignment deltas. A rebuild worker snapshots it when scheduled and,
@@ -215,6 +224,20 @@ func (m *MetaServiceGroupManager) IsAssignmentCountReady() bool {
 // while loading counts are preserved. The scan is discarded only when the leader
 // term changes (which bumps termGen), so under steady traffic a rebuild converges
 // in a single scan. At most one scan runs at a time.
+//
+// AssignmentCount is a best-effort load-balancing hint, not a strictly
+// consistent counter: rebuildDeltas starts recording here (rebuilding=true),
+// but the scan's revision anchor isn't captured until later, inside
+// CountKeyspacesByMetaServiceGroup. An assignment mutation that lands in that
+// gap can be counted by both the scan and the delta, over-counting by one.
+// This is a narrow, self-limiting window (it does not compound across
+// mutations) and it self-heals on the next successful rebuild in a later
+// term, so it is accepted rather than fixed here.
+// TODO: close it by tagging each recorded delta with its own commit
+// revision (would need RunInTxn to expose the committed revision, which it
+// currently discards) and, in finishRebuild, only applying deltas whose
+// revision is greater than the scan's pinned revision instead of applying
+// every delta recorded while rebuilding was true.
 func (m *MetaServiceGroupManager) StartAssignmentCountRebuild(ctx context.Context) {
 	m.RLock()
 	groupIDs := make(map[string]struct{}, len(m.metaServiceGroups))
@@ -280,6 +303,9 @@ func (m *MetaServiceGroupManager) finishRebuild(startTerm uint64, counts map[str
 		m.rebuildDeltas = nil
 		return true
 	}
+	// See the rebuilding-window note on StartAssignmentCountRebuild: a delta
+	// recorded here may already be reflected in counts[id] too, over-counting
+	// by one. Accepted best-effort tradeoff, not fixed here.
 	for id, status := range m.cachedStatus {
 		status.AssignmentCount = max(0, counts[id]+m.rebuildDeltas[id])
 	}
@@ -332,7 +358,7 @@ type MetaServiceGroupStatusPatch struct {
 // PatchStatus applies a patch to the status of a meta-service group. Only the
 // Enabled flag can be patched and persisted; AssignmentCount is derived from
 // authoritative keyspace metadata and cannot be patched.
-func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID string, patch *MetaServiceGroupStatusPatch) error {
+func (m *MetaServiceGroupManager) PatchStatus(_ context.Context, groupID string, patch *MetaServiceGroupStatusPatch) error {
 	if patch.AssignmentCount != nil {
 		return ErrAssignmentCountPatchUnsupported
 	}
@@ -341,23 +367,39 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	if _, ok := m.metaServiceGroups[groupID]; !ok {
 		return ErrUnknownMetaServiceGroup
 	}
+	// patchMu holds the persist-then-publish sequence below together as one
+	// unit across concurrent PatchStatus calls: without it, two concurrent
+	// calls can commit to storage in one order but publish to cachedStatus in
+	// the other, leaving the cache stuck on an already-superseded value.
+	m.patchMu.Lock()
+	defer m.patchMu.Unlock()
 	// Persist the Enabled flag (the only persisted field) synchronously when it
 	// changes. persistGroupsLocked (group deletion) takes the write lock, so
 	// holding the read lock here is enough to keep the group from being deleted
 	// between the existence check and the write.
 	if patch.Enabled != nil {
-		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-			// Load before saving so the txn carries an implicit compare on the
-			// status key's current value. Without it this is a blind put: a
-			// write from a leader that has since lost its term can still commit
-			// after a newer leader's write, silently reverting it. The loaded
-			// value itself is unused; only the CAS side effect matters here.
-			if _, err := m.store.LoadMetaServiceGroupStatus(txn, map[string]string{groupID: ""}); err != nil {
-				return err
-			}
-			return m.store.SaveMetaServiceGroupStatus(txn, groupID, &endpoint.MetaServiceGroupStatus{Enabled: *patch.Enabled})
-		}); err != nil {
+		// CAS on the status key's modification revision, not its value: a
+		// value-only compare cannot fence a leader whose term has already
+		// ended, because it can't distinguish a key that was never touched
+		// from one that changed and changed back to the same value (ABA) in
+		// between this read and this write. The modification revision
+		// advances on every write regardless of value, so a stale revision
+		// here reliably fails the compare instead of silently reverting a
+		// newer write.
+		current, modRevision, err := m.store.LoadMetaServiceGroupStatusModRevision(groupID)
+		if err != nil {
 			return err
+		}
+		if current == nil {
+			current = &endpoint.MetaServiceGroupStatus{}
+		}
+		current.Enabled = *patch.Enabled
+		committed, err := m.store.CASMetaServiceGroupStatus(groupID, modRevision, current)
+		if err != nil {
+			return err
+		}
+		if !committed {
+			return ErrMetaServiceGroupStatusConflict
 		}
 	}
 	m.statusMu.Lock()

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -55,6 +55,15 @@ const assignmentCountRebuildRetryInterval = time.Second
 // nothing. patchMu sits between the two: RWMutex(RLock)->patchMu->statusMu. It
 // is held only by PatchStatus, across storage I/O, so it must never be taken
 // while already holding statusMu.
+// TODO: MetaServiceGroupManager is currently a server-lifetime singleton,
+// constructed once at server startup and never rebuilt across leader terms;
+// term validity is tracked ad hoc via termGen and termCtxFunc below. Once
+// RaftCluster owns it (constructed fresh in RaftCluster.Start, torn down in
+// Stop, like ruleManager/regionLabeler/affinityManager already are), a stale
+// instance simply stops being reachable and most of that bookkeeping goes
+// away. See the PR discussion for why this is deferred rather than done here:
+// it requires KeyspaceManager.mgm to stop being a fixed pointer set once at
+// construction, which touches ~20 call sites across keyspace.go.
 type MetaServiceGroupManager struct {
 	store endpoint.MetaServiceGroupStorage
 	syncutil.RWMutex
@@ -94,6 +103,15 @@ type MetaServiceGroupManager struct {
 	// current rebuild scan is in flight. When the scan completes, the committed
 	// count is scan result plus these deltas so writes during loading are not lost.
 	rebuildDeltas map[string]int
+	// termCtxFunc, when set, returns the context of the current PD leader term:
+	// canceled once this server's leadership ends. It is queried lazily (called
+	// fresh at each check, never cached) by casMetaServiceGroupStatusLocked, so
+	// every write always observes the live signal rather than a term snapshot
+	// taken earlier that could itself be stale by the time it's used. Nil
+	// before it's wired (e.g. in unit tests without a real cluster), in which
+	// case no additional leadership constraint is applied beyond the caller's
+	// own context and the modification-revision CAS.
+	termCtxFunc func() context.Context
 }
 
 // SetKeyspaceAssignmentCounter sets the authoritative keyspace assignment
@@ -101,6 +119,13 @@ type MetaServiceGroupManager struct {
 // update.
 func (m *MetaServiceGroupManager) SetKeyspaceAssignmentCounter(counter func(ctx context.Context, groupIDs map[string]struct{}) (map[string]int, error)) {
 	m.keyspaceAssignmentCounter = counter
+}
+
+// SetTermContextFunc wires the PD leader term context source. See the
+// termCtxFunc field doc for what it's used for and why it's a function rather
+// than a captured context.
+func (m *MetaServiceGroupManager) SetTermContextFunc(termCtxFunc func() context.Context) {
+	m.termCtxFunc = termCtxFunc
 }
 
 // NewMetaServiceGroupManager creates a new MetaServiceGroupManager.
@@ -391,28 +416,11 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	// holding the read lock here is enough to keep the group from being deleted
 	// between the existence check and the write.
 	if patch.Enabled != nil {
-		// CAS on the status key's modification revision, not its value: a
-		// value-only compare cannot fence a leader whose term has already
-		// ended, because it can't distinguish a key that was never touched
-		// from one that changed and changed back to the same value (ABA) in
-		// between this read and this write. The modification revision
-		// advances on every write regardless of value, so a stale revision
-		// here reliably fails the compare instead of silently reverting a
-		// newer write.
-		current, modRevision, err := m.store.LoadMetaServiceGroupStatusModRevision(groupID)
-		if err != nil {
+		enabled := *patch.Enabled
+		if err := m.casMetaServiceGroupStatusLocked(groupID, func(status *endpoint.MetaServiceGroupStatus) {
+			status.Enabled = enabled
+		}); err != nil {
 			return err
-		}
-		if current == nil {
-			current = &endpoint.MetaServiceGroupStatus{}
-		}
-		current.Enabled = *patch.Enabled
-		committed, err := m.store.CASMetaServiceGroupStatus(groupID, modRevision, current)
-		if err != nil {
-			return err
-		}
-		if !committed {
-			return ErrMetaServiceGroupStatusConflict
 		}
 	}
 	m.statusMu.Lock()
@@ -636,6 +644,12 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 ) error {
 	m.Lock()
 	defer m.Unlock()
+	// Checked once, up front: everything below (the delete guard's storage
+	// scan, the added-group reset, persist(), the deleted-group cleanup) is
+	// meaningless work if the request that asked for it is already gone.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if len(deletedGroups) > 0 {
 		counts, err := m.assignedKeyspaceCounts(ctx, deletedGroups)
 		if err != nil {
@@ -727,11 +741,45 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 // PatchStatus uses. Returns ErrMetaServiceGroupStatusConflict if the key
 // changed between the read and the write.
 func (m *MetaServiceGroupManager) resetMetaServiceGroupStatus(id string) error {
-	_, modRevision, err := m.store.LoadMetaServiceGroupStatusModRevision(id)
+	return m.casMetaServiceGroupStatusLocked(id, func(status *endpoint.MetaServiceGroupStatus) {
+		*status = endpoint.MetaServiceGroupStatus{}
+	})
+}
+
+// casMetaServiceGroupStatusLocked loads id's persisted status, applies mutate
+// to it, and writes the result back guarded by a modification-revision CAS
+// against the value just loaded. The caller must hold the mgm lock (RLock or
+// Lock; both PatchStatus and persistGroupsLocked's callers do).
+//
+// Before reading, it checks termCtxFunc (when wired): a value-only or
+// modification-revision CAS alone fences changes that happen between this
+// read and this write, but not a write whose *read* itself was delayed past
+// the point its premise stopped holding. A former leader paused before ever
+// calling LoadMetaServiceGroupStatusModRevision, then resumed after a newer
+// leader's legitimate write, would read a fresh revision that already
+// reflects that write and CAS successfully against it — the read-write
+// window it captures is internally consistent, it's just anchored too late.
+// Checking termCtxFunc first closes that: by the time a stale leader's
+// goroutine resumes from any such pause, its own term context is already
+// canceled, because a newer leader acting at all requires this leader's term
+// to have ended first.
+func (m *MetaServiceGroupManager) casMetaServiceGroupStatusLocked(id string, mutate func(*endpoint.MetaServiceGroupStatus)) error {
+	if m.termCtxFunc != nil {
+		if termCtx := m.termCtxFunc(); termCtx != nil {
+			if err := termCtx.Err(); err != nil {
+				return err
+			}
+		}
+	}
+	current, modRevision, err := m.store.LoadMetaServiceGroupStatusModRevision(id)
 	if err != nil {
 		return err
 	}
-	committed, err := m.store.CASMetaServiceGroupStatus(id, modRevision, &endpoint.MetaServiceGroupStatus{})
+	if current == nil {
+		current = &endpoint.MetaServiceGroupStatus{}
+	}
+	mutate(current)
+	committed, err := m.store.CASMetaServiceGroupStatus(id, modRevision, current)
 	if err != nil {
 		return err
 	}

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -358,7 +358,7 @@ type MetaServiceGroupStatusPatch struct {
 // PatchStatus applies a patch to the status of a meta-service group. Only the
 // Enabled flag can be patched and persisted; AssignmentCount is derived from
 // authoritative keyspace metadata and cannot be patched.
-func (m *MetaServiceGroupManager) PatchStatus(_ context.Context, groupID string, patch *MetaServiceGroupStatusPatch) error {
+func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID string, patch *MetaServiceGroupStatusPatch) error {
 	if patch.AssignmentCount != nil {
 		return ErrAssignmentCountPatchUnsupported
 	}
@@ -373,6 +373,12 @@ func (m *MetaServiceGroupManager) PatchStatus(_ context.Context, groupID string,
 	// the other, leaving the cache stuck on an already-superseded value.
 	m.patchMu.Lock()
 	defer m.patchMu.Unlock()
+	// Re-check after acquiring patchMu: the storage calls below don't take a
+	// context themselves (see their docs), so a request canceled while queued
+	// behind patchMu would otherwise persist and publish anyway.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// Persist the Enabled flag (the only persisted field) synchronously when it
 	// changes. persistGroupsLocked (group deletion) takes the write lock, so
 	// holding the read lock here is enough to keep the group from being deleted
@@ -639,6 +645,16 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	// flag left in storage. Failing hard here keeps the reset invariant without
 	// leaving the config and the in-memory view diverged: nothing below has changed
 	// yet, so the operation is a clean, retryable no-op on error.
+	//
+	// This overwrites the status key rather than removing it, unlike a plain
+	// reset would: PatchStatus's modification-revision CAS relies on the key's
+	// modification revision never repeating a value it held before. A removed
+	// key's absence compares as modification revision 0 regardless of how
+	// many times it has been created and removed, so a delete here would let
+	// a stale-term PatchStatus that observed a still-earlier absence commit
+	// again after this reset, the same ABA hole by another name. Overwriting
+	// instead of removing keeps the revision strictly increasing across the
+	// group's entire lifetime.
 	m.statusMu.Lock()
 	var addedGroups []string
 	for id := range metaServiceGroups {
@@ -650,7 +666,7 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	if len(addedGroups) > 0 {
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 			for _, id := range addedGroups {
-				if err := m.store.RemoveMetaServiceGroupStatus(txn, id); err != nil {
+				if err := m.store.SaveMetaServiceGroupStatus(txn, id, &endpoint.MetaServiceGroupStatus{}); err != nil {
 					return err
 				}
 			}
@@ -680,10 +696,13 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	// Best-effort cleanup of the deleted groups' now-orphan persisted status. It is
 	// safe if this fails: RefreshCache only loads status for current groups, so an
 	// orphan key is never read, and a future re-add clears it via the reset above.
+	// Overwritten rather than removed, for the same modification-revision reason
+	// as the reset above: removing it would let the key's absence repeat, which
+	// breaks the ABA guarantee PatchStatus's CAS depends on.
 	if len(deletedGroups) > 0 {
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 			for _, id := range deletedGroups {
-				if err := m.store.RemoveMetaServiceGroupStatus(txn, id); err != nil {
+				if err := m.store.SaveMetaServiceGroupStatus(txn, id, &endpoint.MetaServiceGroupStatus{}); err != nil {
 					return err
 				}
 			}

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -16,6 +16,7 @@ package keyspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -298,7 +299,13 @@ func (m *MetaServiceGroupManager) finishRebuild(startTerm uint64, counts map[str
 		return false
 	}
 	if scanErr != nil {
-		log.Warn("[keyspace] failed to rebuild meta-service group assignment counts", zap.Error(scanErr))
+		// A canceled or deadline-exceeded context is an expected leadership
+		// transition (the caller's leader-term context observed the lease
+		// being lost), not a scan failure: warn only for anything else, so a
+		// routine leadership change doesn't look like a rebuild problem.
+		if !errors.Is(scanErr, context.Canceled) && !errors.Is(scanErr, context.DeadlineExceeded) {
+			log.Warn("[keyspace] failed to rebuild meta-service group assignment counts", zap.Error(scanErr))
+		}
 		m.rebuilding = false
 		m.rebuildDeltas = nil
 		return true

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -128,8 +128,10 @@ func (m *MetaServiceGroupManager) RefreshCache(ctx context.Context) error {
 	}
 	// Rebuild counts from keyspace metadata. The counter is nil before the keyspace
 	// manager wires it (e.g. at construction) and in unit tests without one; counts
-	// then start at zero and are corrected on the next RefreshCache.
+	// then start at zero and countsReady stays false until the counter is wired and
+	// a real rebuild (StartAssignmentCountRebuild) completes.
 	counts := map[string]int{}
+	scanned := false
 	if m.keyspaceAssignmentCounter != nil {
 		set := make(map[string]struct{}, len(m.metaServiceGroups))
 		for id := range m.metaServiceGroups {
@@ -139,6 +141,7 @@ func (m *MetaServiceGroupManager) RefreshCache(ctx context.Context) error {
 		if counts, err = m.keyspaceAssignmentCounter(ctx, set); err != nil {
 			return err
 		}
+		scanned = true
 	}
 	cache := make(map[string]*endpoint.MetaServiceGroupStatus, len(m.metaServiceGroups))
 	for id := range m.metaServiceGroups {
@@ -151,7 +154,7 @@ func (m *MetaServiceGroupManager) RefreshCache(ctx context.Context) error {
 	m.statusMu.Lock()
 	m.cachedStatus = cache
 	m.termGen++
-	m.countsReady = true
+	m.countsReady = scanned
 	m.rebuilding = false
 	m.rebuildDeltas = nil
 	m.statusMu.Unlock()
@@ -333,16 +336,25 @@ func (m *MetaServiceGroupManager) PatchStatus(ctx context.Context, groupID strin
 	if patch.AssignmentCount != nil {
 		return ErrAssignmentCountPatchUnsupported
 	}
-	m.Lock()
-	defer m.Unlock()
+	m.RLock()
+	defer m.RUnlock()
 	if _, ok := m.metaServiceGroups[groupID]; !ok {
 		return ErrUnknownMetaServiceGroup
 	}
 	// Persist the Enabled flag (the only persisted field) synchronously when it
-	// changes. The mgm write lock serializes this with persistGroupsLocked, so the
-	// group cannot be deleted between the existence check and the write.
+	// changes. persistGroupsLocked (group deletion) takes the write lock, so
+	// holding the read lock here is enough to keep the group from being deleted
+	// between the existence check and the write.
 	if patch.Enabled != nil {
 		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
+			// Load before saving so the txn carries an implicit compare on the
+			// status key's current value. Without it this is a blind put: a
+			// write from a leader that has since lost its term can still commit
+			// after a newer leader's write, silently reverting it. The loaded
+			// value itself is unused; only the CAS side effect matters here.
+			if _, err := m.store.LoadMetaServiceGroupStatus(txn, map[string]string{groupID: ""}); err != nil {
+				return err
+			}
 			return m.store.SaveMetaServiceGroupStatus(txn, groupID, &endpoint.MetaServiceGroupStatus{Enabled: *patch.Enabled})
 		}); err != nil {
 			return err
@@ -469,8 +481,16 @@ func (m *MetaServiceGroupManager) updateAssignmentTxn(_ kv.Txn, oldGroupID, newG
 }
 
 // applyAssignmentDeltaStatusLocked moves one assignment from oldGroupID to
-// newGroupID in the cached status. The caller must hold statusMu.
+// newGroupID in the cached status. The caller must hold statusMu. newGroupID's
+// existence is checked before either side is mutated, so a missing target
+// leaves the decrement side untouched instead of losing a count with no
+// matching increment.
 func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, newGroupID string) error {
+	if newGroupID != "" {
+		if _, ok := m.cachedStatus[newGroupID]; !ok {
+			return ErrUnknownMetaServiceGroup
+		}
+	}
 	if oldGroupID != "" {
 		if status := m.cachedStatus[oldGroupID]; status != nil {
 			if status.AssignmentCount > 0 {
@@ -480,11 +500,7 @@ func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, n
 		}
 	}
 	if newGroupID != "" {
-		status := m.cachedStatus[newGroupID]
-		if status == nil {
-			return ErrUnknownMetaServiceGroup
-		}
-		status.AssignmentCount++
+		m.cachedStatus[newGroupID].AssignmentCount++
 		m.recordRebuildDeltaLocked(newGroupID, 1)
 	}
 	return nil

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -662,6 +662,11 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	// again after this reset, the same ABA hole by another name. Overwriting
 	// instead of removing keeps the revision strictly increasing across the
 	// group's entire lifetime.
+	//
+	// The overwrite itself goes through the same modification-revision CAS as
+	// PatchStatus, not a blind Save: a blind write here would itself be an
+	// unfenced stale-term write, able to land after (and silently undo) a
+	// newer leader's legitimate patch to the same, since-recreated group.
 	m.statusMu.Lock()
 	var addedGroups []string
 	for id := range metaServiceGroups {
@@ -670,15 +675,8 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 		}
 	}
 	m.statusMu.Unlock()
-	if len(addedGroups) > 0 {
-		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-			for _, id := range addedGroups {
-				if err := m.store.SaveMetaServiceGroupStatus(txn, id, &endpoint.MetaServiceGroupStatus{}); err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+	for _, id := range addedGroups {
+		if err := m.resetMetaServiceGroupStatus(id); err != nil {
 			return err
 		}
 	}
@@ -706,18 +704,39 @@ func (m *MetaServiceGroupManager) persistGroupsLocked(
 	// Overwritten rather than removed, for the same modification-revision reason
 	// as the reset above: removing it would let the key's absence repeat, which
 	// breaks the ABA guarantee PatchStatus's CAS depends on.
-	if len(deletedGroups) > 0 {
-		if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
-			for _, id := range deletedGroups {
-				if err := m.store.SaveMetaServiceGroupStatus(txn, id, &endpoint.MetaServiceGroupStatus{}); err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
-			log.Warn("[keyspace] failed to clear status for deleted meta-service groups",
-				zap.Strings("deleted-groups", deletedGroups), zap.Error(err))
+	//
+	// Also CAS'd rather than a blind Save, and for a reason beyond ABA this
+	// time: this cleanup runs after persist() has already committed the
+	// deletion, so it can be delayed (goroutine scheduling, a slow prior
+	// commit) well past that point. If the group was re-added and patched in
+	// the meantime, a blind write here would silently overwrite that patch on
+	// no evidence beyond "this ID used to be deleted". CAS turns that into a
+	// conflict instead: the failure is expected and exactly what "best
+	// effort" already covers, not a new failure mode.
+	for _, id := range deletedGroups {
+		if err := m.resetMetaServiceGroupStatus(id); err != nil {
+			log.Warn("[keyspace] failed to clear status for deleted meta-service group",
+				zap.String("deleted-group", id), zap.Error(err))
 		}
+	}
+	return nil
+}
+
+// resetMetaServiceGroupStatus overwrites id's persisted status to the zero
+// value (disabled, zero count), guarded by the same modification-revision CAS
+// PatchStatus uses. Returns ErrMetaServiceGroupStatusConflict if the key
+// changed between the read and the write.
+func (m *MetaServiceGroupManager) resetMetaServiceGroupStatus(id string) error {
+	_, modRevision, err := m.store.LoadMetaServiceGroupStatusModRevision(id)
+	if err != nil {
+		return err
+	}
+	committed, err := m.store.CASMetaServiceGroupStatus(id, modRevision, &endpoint.MetaServiceGroupStatus{})
+	if err != nil {
+		return err
+	}
+	if !committed {
+		return ErrMetaServiceGroupStatusConflict
 	}
 	return nil
 }

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -53,7 +53,6 @@ const assignmentCountRebuildRetryInterval = time.Second
 // RWMutex->statusMu and metaLock->statusMu; both are safe because statusMu wraps
 // nothing.
 type MetaServiceGroupManager struct {
-	ctx   context.Context
 	store endpoint.MetaServiceGroupStorage
 	syncutil.RWMutex
 	// metaServiceGroups is the available external meta-service groups.
@@ -66,11 +65,25 @@ type MetaServiceGroupManager struct {
 	keyspaceAssignmentCounter func(ctx context.Context, groupIDs map[string]struct{}) (map[string]int, error)
 	// statusMu guards cachedStatus. See the type comment for the leaf-lock
 	// discipline it must follow.
-	statusMu         syncutil.Mutex
-	cachedStatus     map[string]*endpoint.MetaServiceGroupStatus
-	assignmentEpoch  uint64
-	countsReady      bool
-	countsRefreshing bool
+	statusMu     syncutil.Mutex
+	cachedStatus map[string]*endpoint.MetaServiceGroupStatus
+	// termGen is the leader-term generation. It is bumped only at term boundaries
+	// (RefreshCache at construction, RefreshPersistedStatus on leadership change),
+	// never by assignment deltas. A rebuild worker snapshots it when scheduled and,
+	// on completion, only commits its scan while termGen is unchanged. A worker left
+	// over from a previous term finds termGen advanced and exits without touching
+	// cachedStatus, countsReady or rebuilding, which the current term's worker owns.
+	termGen uint64
+	// countsReady reports whether an authoritative scan has completed in the current
+	// term. It is exposed via the status API (assignment_count_ready).
+	countsReady bool
+	// rebuilding ensures at most one rebuild scan is in flight, so serving traffic
+	// cannot pile up concurrent keyspace scans against storage.
+	rebuilding bool
+	// rebuildDeltas records assignment deltas applied to cachedStatus while the
+	// current rebuild scan is in flight. When the scan completes, the committed
+	// count is scan result plus these deltas so writes during loading are not lost.
+	rebuildDeltas map[string]int
 }
 
 // SetKeyspaceAssignmentCounter sets the authoritative keyspace assignment
@@ -87,11 +100,10 @@ func NewMetaServiceGroupManager(
 	metaServiceGroups map[string]string,
 ) (*MetaServiceGroupManager, error) {
 	m := &MetaServiceGroupManager{
-		ctx:               ctx,
 		store:             store,
 		metaServiceGroups: metaServiceGroups,
 	}
-	if err := m.RefreshCache(); err != nil {
+	if err := m.RefreshCache(ctx); err != nil {
 		return nil, err
 	}
 	return m, nil
@@ -102,11 +114,11 @@ func NewMetaServiceGroupManager(
 // It is called at construction and on each leadership acquisition, so every leader
 // term starts from counts derived from actual keyspace metadata rather than a
 // persisted value that could have drifted or been lost.
-func (m *MetaServiceGroupManager) RefreshCache() error {
+func (m *MetaServiceGroupManager) RefreshCache(ctx context.Context) error {
 	m.Lock()
 	defer m.Unlock()
 	var stored map[string]*endpoint.MetaServiceGroupStatus
-	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
+	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 		var err error
 		stored, err = m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
 		return err
@@ -124,7 +136,7 @@ func (m *MetaServiceGroupManager) RefreshCache() error {
 			set[id] = struct{}{}
 		}
 		var err error
-		if counts, err = m.keyspaceAssignmentCounter(m.ctx, set); err != nil {
+		if counts, err = m.keyspaceAssignmentCounter(ctx, set); err != nil {
 			return err
 		}
 	}
@@ -138,9 +150,10 @@ func (m *MetaServiceGroupManager) RefreshCache() error {
 	}
 	m.statusMu.Lock()
 	m.cachedStatus = cache
-	m.assignmentEpoch++
+	m.termGen++
 	m.countsReady = true
-	m.countsRefreshing = false
+	m.rebuilding = false
+	m.rebuildDeltas = nil
 	m.statusMu.Unlock()
 	log.Info("[keyspace] meta-service group status rebuilt", zap.Any("meta-service-group-status", cache))
 	return nil
@@ -149,11 +162,11 @@ func (m *MetaServiceGroupManager) RefreshCache() error {
 // RefreshPersistedStatus reloads the persisted administrative status only. It is
 // intentionally lightweight for the leader-ready path; assignment counts are
 // rebuilt asynchronously by StartAssignmentCountRebuild.
-func (m *MetaServiceGroupManager) RefreshPersistedStatus() error {
+func (m *MetaServiceGroupManager) RefreshPersistedStatus(ctx context.Context) error {
 	m.Lock()
 	defer m.Unlock()
 	var stored map[string]*endpoint.MetaServiceGroupStatus
-	if err := m.store.RunInTxn(m.ctx, func(txn kv.Txn) error {
+	if err := m.store.RunInTxn(ctx, func(txn kv.Txn) error {
 		var err error
 		stored, err = m.store.LoadMetaServiceGroupStatus(txn, m.metaServiceGroups)
 		return err
@@ -176,9 +189,10 @@ func (m *MetaServiceGroupManager) RefreshPersistedStatus() error {
 		cache[id] = &endpoint.MetaServiceGroupStatus{AssignmentCount: count, Enabled: enabled}
 	}
 	m.cachedStatus = cache
-	m.assignmentEpoch++
+	m.termGen++
 	m.countsReady = false
-	m.countsRefreshing = false
+	m.rebuilding = false
+	m.rebuildDeltas = nil
 	m.statusMu.Unlock()
 	log.Info("[keyspace] meta-service group persisted status loaded", zap.Any("meta-service-group-status", cache))
 	return nil
@@ -193,8 +207,11 @@ func (m *MetaServiceGroupManager) IsAssignmentCountReady() bool {
 }
 
 // StartAssignmentCountRebuild asynchronously rebuilds assignment counts from
-// authoritative keyspace metadata. If serving traffic changes counts during the
-// scan, the result is discarded and another rebuild is scheduled.
+// authoritative keyspace metadata. Assignment deltas applied during the scan
+// window are recorded separately and merged with the scan result, so writes made
+// while loading counts are preserved. The scan is discarded only when the leader
+// term changes (which bumps termGen), so under steady traffic a rebuild converges
+// in a single scan. At most one scan runs at a time.
 func (m *MetaServiceGroupManager) StartAssignmentCountRebuild(ctx context.Context) {
 	m.RLock()
 	groupIDs := make(map[string]struct{}, len(m.metaServiceGroups))
@@ -202,79 +219,71 @@ func (m *MetaServiceGroupManager) StartAssignmentCountRebuild(ctx context.Contex
 		groupIDs[id] = struct{}{}
 	}
 	m.statusMu.Lock()
-	if m.countsRefreshing {
+	if m.rebuilding {
 		m.statusMu.Unlock()
 		m.RUnlock()
 		return
 	}
-	m.countsRefreshing = true
+	m.rebuilding = true
 	m.countsReady = false
-	startEpoch := m.assignmentEpoch
+	m.rebuildDeltas = make(map[string]int, len(groupIDs))
+	startTerm := m.termGen
 	m.statusMu.Unlock()
 	m.RUnlock()
 
-	go m.rebuildAssignmentCounts(ctx, groupIDs, startEpoch)
+	go m.rebuildAssignmentCounts(ctx, groupIDs, startTerm)
 }
 
-func (m *MetaServiceGroupManager) rebuildAssignmentCounts(ctx context.Context, groupIDs map[string]struct{}, startEpoch uint64) {
+func (m *MetaServiceGroupManager) rebuildAssignmentCounts(ctx context.Context, groupIDs map[string]struct{}, startTerm uint64) {
+	// Without a counter (before the keyspace manager wires it, or in unit tests)
+	// there is no authoritative source, so mark ready without overwriting counts.
 	if m.keyspaceAssignmentCounter == nil {
 		m.statusMu.Lock()
-		m.countsReady = true
-		m.countsRefreshing = false
+		if m.termGen == startTerm {
+			m.countsReady = true
+			m.rebuilding = false
+			m.rebuildDeltas = nil
+		}
 		m.statusMu.Unlock()
 		return
-	}
-	select {
-	case <-ctx.Done():
-		m.statusMu.Lock()
-		m.countsRefreshing = false
-		m.countsReady = false
-		m.statusMu.Unlock()
-		return
-	default:
 	}
 	counts, err := m.keyspaceAssignmentCounter(ctx, groupIDs)
-	if err != nil {
-		log.Warn("[keyspace] failed to rebuild meta-service group assignment counts", zap.Error(err))
-		m.statusMu.Lock()
-		m.countsRefreshing = false
-		m.countsReady = false
-		m.statusMu.Unlock()
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(assignmentCountRebuildRetryInterval):
-			m.StartAssignmentCountRebuild(ctx)
-		}
+	if !m.finishRebuild(startTerm, counts, err) {
 		return
 	}
+	// The scan failed within the current term; back off and retry so a transient
+	// storage error does not leave counts underived for the rest of the term.
 	select {
 	case <-ctx.Done():
-		m.statusMu.Lock()
-		m.countsRefreshing = false
-		m.countsReady = false
-		m.statusMu.Unlock()
-		return
-	default:
-	}
-
-	shouldRetry := false
-	m.statusMu.Lock()
-	if m.assignmentEpoch == startEpoch {
-		for id, status := range m.cachedStatus {
-			status.AssignmentCount = counts[id]
-		}
-		m.countsReady = true
-		m.countsRefreshing = false
-	} else {
-		m.countsReady = false
-		m.countsRefreshing = false
-		shouldRetry = true
-	}
-	m.statusMu.Unlock()
-	if shouldRetry {
+	case <-time.After(assignmentCountRebuildRetryInterval):
 		m.StartAssignmentCountRebuild(ctx)
 	}
+}
+
+// finishRebuild applies a rebuild scan result under statusMu and reports whether
+// the caller should schedule a retry. A worker whose startTerm no longer matches
+// termGen is a leftover from a previous leader term: the current term owns the
+// rebuilding/countsReady/cachedStatus state, so the stale worker exits without
+// touching any of it and without retrying.
+func (m *MetaServiceGroupManager) finishRebuild(startTerm uint64, counts map[string]int, scanErr error) (retry bool) {
+	m.statusMu.Lock()
+	defer m.statusMu.Unlock()
+	if m.termGen != startTerm {
+		return false
+	}
+	if scanErr != nil {
+		log.Warn("[keyspace] failed to rebuild meta-service group assignment counts", zap.Error(scanErr))
+		m.rebuilding = false
+		m.rebuildDeltas = nil
+		return true
+	}
+	for id, status := range m.cachedStatus {
+		status.AssignmentCount = max(0, counts[id]+m.rebuildDeltas[id])
+	}
+	m.countsReady = true
+	m.rebuilding = false
+	m.rebuildDeltas = nil
+	return false
 }
 
 // GetStatus returns the status of each meta-service group.
@@ -418,7 +427,7 @@ func (m *MetaServiceGroupManager) AssignToGroup(_ context.Context, count int) (s
 		return "", err
 	}
 	m.cachedStatus[assignedGroup].AssignmentCount += count
-	m.assignmentEpoch++
+	m.recordRebuildDeltaLocked(assignedGroup, count)
 	return assignedGroup, nil
 }
 
@@ -462,11 +471,12 @@ func (m *MetaServiceGroupManager) updateAssignmentTxn(_ kv.Txn, oldGroupID, newG
 // applyAssignmentDeltaStatusLocked moves one assignment from oldGroupID to
 // newGroupID in the cached status. The caller must hold statusMu.
 func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, newGroupID string) error {
-	changed := false
 	if oldGroupID != "" {
-		if status := m.cachedStatus[oldGroupID]; status != nil && status.AssignmentCount > 0 {
-			status.AssignmentCount--
-			changed = true
+		if status := m.cachedStatus[oldGroupID]; status != nil {
+			if status.AssignmentCount > 0 {
+				status.AssignmentCount--
+			}
+			m.recordRebuildDeltaLocked(oldGroupID, -1)
 		}
 	}
 	if newGroupID != "" {
@@ -475,12 +485,19 @@ func (m *MetaServiceGroupManager) applyAssignmentDeltaStatusLocked(oldGroupID, n
 			return ErrUnknownMetaServiceGroup
 		}
 		status.AssignmentCount++
-		changed = true
-	}
-	if changed {
-		m.assignmentEpoch++
+		m.recordRebuildDeltaLocked(newGroupID, 1)
 	}
 	return nil
+}
+
+func (m *MetaServiceGroupManager) recordRebuildDeltaLocked(groupID string, delta int) {
+	if !m.rebuilding || groupID == "" {
+		return
+	}
+	if m.rebuildDeltas == nil {
+		m.rebuildDeltas = make(map[string]int)
+	}
+	m.rebuildDeltas[groupID] += delta
 }
 
 // AttachEndpoints append potential meta-service group endpoint to the given keyspace config map.

--- a/pkg/keyspace/meta_service_group.go
+++ b/pkg/keyspace/meta_service_group.go
@@ -765,10 +765,18 @@ func (m *MetaServiceGroupManager) resetMetaServiceGroupStatus(id string) error {
 // to have ended first.
 func (m *MetaServiceGroupManager) casMetaServiceGroupStatusLocked(id string, mutate func(*endpoint.MetaServiceGroupStatus)) error {
 	if m.termCtxFunc != nil {
-		if termCtx := m.termCtxFunc(); termCtx != nil {
-			if err := termCtx.Err(); err != nil {
-				return err
-			}
+		// A nil context (e.g. RaftCluster.Context() once the cluster has
+		// stopped) means "no term is currently held", not "no constraint
+		// applies": a wired but currently-nil source must reject the write,
+		// the same as an explicitly canceled one, or the fence silently goes
+		// dark for every write issued after this server stops being leader
+		// but before whatever wired the func is rebuilt for a new term.
+		termCtx := m.termCtxFunc()
+		if termCtx == nil {
+			return context.Canceled
+		}
+		if err := termCtx.Err(); err != nil {
+			return err
 		}
 	}
 	current, modRevision, err := m.store.LoadMetaServiceGroupStatusModRevision(id)

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -232,7 +233,7 @@ func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyUsesAuthoritativeC
 
 	// Authoritative scanner reports the real assignments.
 	actual := map[string]int{}
-	suite.manager.SetKeyspaceAssignmentCounter(func(ids map[string]struct{}) (map[string]int, error) {
+	suite.manager.SetKeyspaceAssignmentCounter(func(_ context.Context, ids map[string]struct{}) (map[string]int, error) {
 		res := make(map[string]int, len(ids))
 		for id := range ids {
 			res[id] = actual[id]
@@ -366,7 +367,7 @@ func (suite *metaServiceGroupTestSuite) TestRefreshCacheRebuildsFromStorageAndSc
 	})
 	re.NoError(err)
 	// The authoritative counter reports the real assignment count.
-	suite.manager.SetKeyspaceAssignmentCounter(func(ids map[string]struct{}) (map[string]int, error) {
+	suite.manager.SetKeyspaceAssignmentCounter(func(_ context.Context, ids map[string]struct{}) (map[string]int, error) {
 		res := make(map[string]int, len(ids))
 		if _, ok := ids["etcd-group-0"]; ok {
 			res["etcd-group-0"] = 3
@@ -379,6 +380,71 @@ func (suite *metaServiceGroupTestSuite) TestRefreshCacheRebuildsFromStorageAndSc
 	re.NoError(err)
 	re.True(statusMap["etcd-group-0"].Enabled)             // from storage
 	re.Equal(3, statusMap["etcd-group-0"].AssignmentCount) // from the scan, not the stale 10
+}
+
+func (suite *metaServiceGroupTestSuite) TestRefreshPersistedStatusDoesNotScanAssignmentCounts() {
+	re := suite.Require()
+	called := false
+	suite.manager.SetKeyspaceAssignmentCounter(func(context.Context, map[string]struct{}) (map[string]int, error) {
+		called = true
+		return map[string]int{"etcd-group-0": 3}, nil
+	})
+
+	re.NoError(suite.manager.RefreshPersistedStatus())
+	re.False(called)
+	re.False(suite.manager.IsAssignmentCountReady())
+}
+
+func (suite *metaServiceGroupTestSuite) TestStartAssignmentCountRebuildMarksReadyAfterAsyncScan() {
+	re := suite.Require()
+	suite.manager.SetKeyspaceAssignmentCounter(func(_ context.Context, ids map[string]struct{}) (map[string]int, error) {
+		res := make(map[string]int, len(ids))
+		if _, ok := ids["etcd-group-0"]; ok {
+			res["etcd-group-0"] = 3
+		}
+		return res, nil
+	})
+
+	suite.manager.StartAssignmentCountRebuild(suite.ctx)
+	re.Eventually(suite.manager.IsAssignmentCountReady, time.Second, time.Millisecond)
+	statusMap, err := suite.manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.Equal(3, statusMap["etcd-group-0"].AssignmentCount)
+}
+
+func (suite *metaServiceGroupTestSuite) TestAssignmentCountRebuildRetriesWhenEpochChanges() {
+	re := suite.Require()
+	suite.enableAllGroups()
+	suite.manager.statusMu.Lock()
+	suite.manager.cachedStatus["etcd-group-1"].AssignmentCount = 10
+	suite.manager.cachedStatus["etcd-group-2"].AssignmentCount = 10
+	suite.manager.statusMu.Unlock()
+	scanStarted := make(chan struct{})
+	resumeScan := make(chan struct{})
+	firstScan := true
+	suite.manager.SetKeyspaceAssignmentCounter(func(_ context.Context, ids map[string]struct{}) (map[string]int, error) {
+		res := make(map[string]int, len(ids))
+		if firstScan {
+			firstScan = false
+			close(scanStarted)
+			<-resumeScan
+			res["etcd-group-0"] = 0
+			return res, nil
+		}
+		res["etcd-group-0"] = 1
+		return res, nil
+	})
+
+	suite.manager.StartAssignmentCountRebuild(suite.ctx)
+	<-scanStarted
+	_, err := suite.manager.PickGroup(suite.ctx)
+	re.NoError(err)
+	close(resumeScan)
+
+	re.Eventually(suite.manager.IsAssignmentCountReady, time.Second, time.Millisecond)
+	statusMap, err := suite.manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.Equal(1, statusMap["etcd-group-0"].AssignmentCount)
 }
 
 func (suite *metaServiceGroupTestSuite) enableAllGroups() {

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -16,11 +16,8 @@ package keyspace
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/tikv/pd/pkg/storage/endpoint"
@@ -268,10 +265,10 @@ func (suite *metaServiceGroupTestSuite) TestAssignToGroupRejectsNegativeCount() 
 	re.ErrorIs(err, ErrInvalidAssignmentCount)
 }
 
-// TestUpdateGroupsSafelyResetsStatusForReaddedGroup verifies that adding a group
-// whose status still lingers in storage (e.g. from an earlier best-effort delete
-// that failed) resets that persisted status to zero, so RefreshCache does not
-// resurrect the stale count/enabled state.
+// TestUpdateGroupsSafelyResetsStatusForReaddedGroup verifies that re-adding a
+// group whose Enabled flag still lingers in storage resets it, so RefreshCache
+// starts the group disabled instead of resurrecting the stale flag. The count is
+// derived from keyspace metadata, so it starts at zero.
 func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyResetsStatusForReaddedGroup() {
 	re := suite.Require()
 	const groupID = "etcd-group-readded"
@@ -286,7 +283,7 @@ func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyResetsStatusForRea
 	re.NoError(suite.manager.UpdateGroupsSafely(suite.ctx, groups, nil,
 		func() error { return nil }, nil))
 
-	// Reloading from storage must see a zero status, not the stale one.
+	// Reloading must see a disabled group with a zero derived count, not the stale one.
 	re.NoError(suite.manager.RefreshCache())
 	statusMap, err := suite.manager.GetStatus(suite.ctx)
 	re.NoError(err)
@@ -316,40 +313,31 @@ func (suite *metaServiceGroupTestSuite) TestReassignRejectsDisabledGroup() {
 	re.NoError(err)
 }
 
-func (suite *metaServiceGroupTestSuite) TestRefreshCacheLoadsFromStorage() {
+// TestRefreshCacheRebuildsFromStorageAndScan verifies that RefreshCache takes the
+// Enabled flag from storage (authoritative for that field) but rebuilds
+// AssignmentCount from the keyspace scan, ignoring any stale persisted count.
+func (suite *metaServiceGroupTestSuite) TestRefreshCacheRebuildsFromStorageAndScan() {
 	re := suite.Require()
-	status := &endpoint.MetaServiceGroupStatus{
-		AssignmentCount: 10,
-		Enabled:         true,
-	}
+	// Persist a stale status: the persisted count must be ignored, the flag kept.
 	err := suite.manager.store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
-		return suite.manager.store.SaveMetaServiceGroupStatus(txn, "etcd-group-0", status)
+		return suite.manager.store.SaveMetaServiceGroupStatus(txn, "etcd-group-0",
+			&endpoint.MetaServiceGroupStatus{AssignmentCount: 10, Enabled: true})
 	})
 	re.NoError(err)
+	// The authoritative counter reports the real assignment count.
+	suite.manager.SetKeyspaceAssignmentCounter(func(ids map[string]struct{}) (map[string]int, error) {
+		res := make(map[string]int, len(ids))
+		if _, ok := ids["etcd-group-0"]; ok {
+			res["etcd-group-0"] = 3
+		}
+		return res, nil
+	})
 
 	re.NoError(suite.manager.RefreshCache())
 	statusMap, err := suite.manager.GetStatus(suite.ctx)
 	re.NoError(err)
-	re.Equal(10, statusMap["etcd-group-0"].AssignmentCount)
-	re.True(statusMap["etcd-group-0"].Enabled)
-}
-
-func (suite *metaServiceGroupTestSuite) TestFlushAfterWriteThreshold() {
-	re := suite.Require()
-	suite.enableAllGroups()
-	assigned, err := suite.manager.AssignToGroup(suite.ctx, flushThreshold)
-	re.NoError(err)
-	re.NotEmpty(assigned)
-
-	re.Eventually(func() bool {
-		var statusMap map[string]*endpoint.MetaServiceGroupStatus
-		err := suite.manager.store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
-			var err error
-			statusMap, err = suite.manager.store.LoadMetaServiceGroupStatus(txn, mockMetaServiceGroups())
-			return err
-		})
-		return err == nil && statusMap[assigned] != nil && statusMap[assigned].AssignmentCount == flushThreshold
-	}, 5*time.Second, 100*time.Millisecond)
+	re.True(statusMap["etcd-group-0"].Enabled)             // from storage
+	re.Equal(3, statusMap["etcd-group-0"].AssignmentCount) // from the scan, not the stale 10
 }
 
 func (suite *metaServiceGroupTestSuite) enableAllGroups() {
@@ -360,71 +348,4 @@ func (suite *metaServiceGroupTestSuite) enableAllGroups() {
 			Enabled: &enabled,
 		}))
 	}
-}
-
-// blockingMetaServiceGroupStorage pauses the first SaveMetaServiceGroupStatus so
-// a flush can be held mid-write to exercise its concurrency with PatchStatus.
-type blockingMetaServiceGroupStorage struct {
-	*endpoint.StorageEndpoint
-	blockNextSave atomic.Bool
-	saveStarted   chan struct{}
-	unblockSave   chan struct{}
-}
-
-func (s *blockingMetaServiceGroupStorage) SaveMetaServiceGroupStatus(txn kv.Txn, id string, status *endpoint.MetaServiceGroupStatus) error {
-	if s.blockNextSave.CompareAndSwap(true, false) {
-		close(s.saveStarted)
-		<-s.unblockSave
-	}
-	return s.StorageEndpoint.SaveMetaServiceGroupStatus(txn, id, status)
-}
-
-// TestFlushDoesNotOverwriteConcurrentPatchStatus verifies that an in-flight flush
-// cannot clobber a status persisted by a concurrent PatchStatus. flushToStorage
-// holds the mgm lock across its storage write, so PatchStatus serializes after it
-// and its value is the persisted winner.
-func TestFlushDoesNotOverwriteConcurrentPatchStatus(t *testing.T) {
-	re := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	store := &blockingMetaServiceGroupStorage{
-		StorageEndpoint: endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
-		saveStarted:     make(chan struct{}),
-		unblockSave:     make(chan struct{}),
-	}
-	manager, err := NewMetaServiceGroupManager(ctx, store, mockMetaServiceGroups())
-	re.NoError(err)
-
-	const groupID = "etcd-group-0"
-	manager.statusMu.Lock()
-	manager.cachedStatus[groupID] = &endpoint.MetaServiceGroupStatus{AssignmentCount: 1, Enabled: true}
-	manager.dirtyCount = 1
-	manager.statusMu.Unlock()
-
-	// Start a flush and pause it inside the storage write, holding the mgm lock.
-	store.blockNextSave.Store(true)
-	flushErr := make(chan error, 1)
-	go func() { flushErr <- manager.flushToStorage() }()
-	<-store.saveStarted
-
-	// PatchStatus blocks on the mgm lock the paused flush holds, so run it in a
-	// goroutine; it can only complete once the flush releases the lock.
-	const newCount = 99
-	patchErr := make(chan error, 1)
-	go func() {
-		c := newCount
-		patchErr <- manager.PatchStatus(ctx, groupID, &MetaServiceGroupStatusPatch{AssignmentCount: &c})
-	}()
-
-	// Let the flush finish; PatchStatus then serializes strictly after it.
-	close(store.unblockSave)
-	re.NoError(<-flushErr)
-	re.NoError(<-patchErr)
-
-	// The patch applied after the flush must be the persisted winner.
-	re.NoError(manager.RefreshCache())
-	statusMap, err := manager.GetStatus(ctx)
-	re.NoError(err)
-	re.Equal(newCount, statusMap[groupID].AssignmentCount)
 }

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -17,6 +17,7 @@ package keyspace
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -46,7 +47,9 @@ func mockMetaServiceGroups() map[string]string {
 func (suite *metaServiceGroupTestSuite) SetupTest() {
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
-	suite.manager = NewMetaServiceGroupManager(store, mockMetaServiceGroups())
+	var err error
+	suite.manager, err = NewMetaServiceGroupManager(suite.ctx, store, mockMetaServiceGroups())
+	suite.Require().NoError(err)
 }
 
 func (suite *metaServiceGroupTestSuite) TearDownTest() {
@@ -282,6 +285,42 @@ func (suite *metaServiceGroupTestSuite) TestReassignRejectsDisabledGroup() {
 		return suite.manager.reassignKeyspaceLocked(txn, "", "etcd-group-0")
 	})
 	re.NoError(err)
+}
+
+func (suite *metaServiceGroupTestSuite) TestRefreshCacheLoadsFromStorage() {
+	re := suite.Require()
+	status := &endpoint.MetaServiceGroupStatus{
+		AssignmentCount: 10,
+		Enabled:         true,
+	}
+	err := suite.manager.store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+		return suite.manager.store.SaveMetaServiceGroupStatus(txn, "etcd-group-0", status)
+	})
+	re.NoError(err)
+
+	re.NoError(suite.manager.RefreshCache())
+	statusMap, err := suite.manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.Equal(10, statusMap["etcd-group-0"].AssignmentCount)
+	re.True(statusMap["etcd-group-0"].Enabled)
+}
+
+func (suite *metaServiceGroupTestSuite) TestFlushAfterWriteThreshold() {
+	re := suite.Require()
+	suite.enableAllGroups()
+	assigned, err := suite.manager.AssignToGroup(suite.ctx, flushThreshold)
+	re.NoError(err)
+	re.NotEmpty(assigned)
+
+	re.Eventually(func() bool {
+		var statusMap map[string]*endpoint.MetaServiceGroupStatus
+		err := suite.manager.store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+			var err error
+			statusMap, err = suite.manager.store.LoadMetaServiceGroupStatus(txn, mockMetaServiceGroups())
+			return err
+		})
+		return err == nil && statusMap[assigned] != nil && statusMap[assigned].AssignmentCount == flushThreshold
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func (suite *metaServiceGroupTestSuite) enableAllGroups() {

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -16,6 +16,7 @@ package keyspace
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -23,6 +24,16 @@ import (
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
 )
+
+var errInjectedStatusCleanup = errors.New("injected status cleanup failure")
+
+type cleanupFailingMetaServiceGroupStorage struct {
+	*endpoint.StorageEndpoint
+}
+
+func (*cleanupFailingMetaServiceGroupStorage) RemoveMetaServiceGroupStatus(kv.Txn, string) error {
+	return errInjectedStatusCleanup
+}
 
 type metaServiceGroupTestSuite struct {
 	suite.Suite
@@ -265,6 +276,13 @@ func (suite *metaServiceGroupTestSuite) TestAssignToGroupRejectsNegativeCount() 
 	re.ErrorIs(err, ErrInvalidAssignmentCount)
 }
 
+func (suite *metaServiceGroupTestSuite) TestPatchStatusRejectsAssignmentCount() {
+	re := suite.Require()
+	count := 7
+	err := suite.manager.PatchStatus(suite.ctx, "etcd-group-0", &MetaServiceGroupStatusPatch{AssignmentCount: &count})
+	re.ErrorIs(err, ErrAssignmentCountPatchUnsupported)
+}
+
 // TestUpdateGroupsSafelyResetsStatusForReaddedGroup verifies that re-adding a
 // group whose Enabled flag still lingers in storage resets it, so RefreshCache
 // starts the group disabled instead of resurrecting the stale flag. The count is
@@ -290,6 +308,29 @@ func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyResetsStatusForRea
 	re.NotNil(statusMap[groupID])
 	re.Equal(0, statusMap[groupID].AssignmentCount)
 	re.False(statusMap[groupID].Enabled)
+}
+
+func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyDoesNotCommitConfigWhenAddedStatusResetFails() {
+	re := suite.Require()
+	store := &cleanupFailingMetaServiceGroupStorage{
+		StorageEndpoint: endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
+	}
+	manager, err := NewMetaServiceGroupManager(suite.ctx, store, mockMetaServiceGroups())
+	re.NoError(err)
+
+	groups := mockMetaServiceGroups()
+	groups["etcd-group-readded"] = "etcd-group-readded.tidb-serverless.cluster.svc.local"
+	configPersisted := false
+	err = manager.UpdateGroupsSafely(suite.ctx, groups, nil, func() error {
+		configPersisted = true
+		return nil
+	}, nil)
+	re.ErrorIs(err, errInjectedStatusCleanup)
+	re.False(configPersisted)
+	re.NotContains(manager.GetGroups(), "etcd-group-readded")
+	statusMap, err := manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.NotContains(statusMap, "etcd-group-readded")
 }
 
 func (suite *metaServiceGroupTestSuite) TestReassignRejectsDisabledGroup() {

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -16,9 +16,11 @@ package keyspace
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/tikv/pd/pkg/storage/endpoint"
@@ -331,4 +333,71 @@ func (suite *metaServiceGroupTestSuite) enableAllGroups() {
 			Enabled: &enabled,
 		}))
 	}
+}
+
+// blockingMetaServiceGroupStorage pauses the first SaveMetaServiceGroupStatus so
+// a flush can be held mid-write to exercise its concurrency with PatchStatus.
+type blockingMetaServiceGroupStorage struct {
+	*endpoint.StorageEndpoint
+	blockNextSave atomic.Bool
+	saveStarted   chan struct{}
+	unblockSave   chan struct{}
+}
+
+func (s *blockingMetaServiceGroupStorage) SaveMetaServiceGroupStatus(txn kv.Txn, id string, status *endpoint.MetaServiceGroupStatus) error {
+	if s.blockNextSave.CompareAndSwap(true, false) {
+		close(s.saveStarted)
+		<-s.unblockSave
+	}
+	return s.StorageEndpoint.SaveMetaServiceGroupStatus(txn, id, status)
+}
+
+// TestFlushDoesNotOverwriteConcurrentPatchStatus verifies that an in-flight flush
+// cannot clobber a status persisted by a concurrent PatchStatus. flushToStorage
+// holds the mgm lock across its storage write, so PatchStatus serializes after it
+// and its value is the persisted winner.
+func TestFlushDoesNotOverwriteConcurrentPatchStatus(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := &blockingMetaServiceGroupStorage{
+		StorageEndpoint: endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
+		saveStarted:     make(chan struct{}),
+		unblockSave:     make(chan struct{}),
+	}
+	manager, err := NewMetaServiceGroupManager(ctx, store, mockMetaServiceGroups())
+	re.NoError(err)
+
+	const groupID = "etcd-group-0"
+	manager.statusMu.Lock()
+	manager.cachedStatus[groupID] = &endpoint.MetaServiceGroupStatus{AssignmentCount: 1, Enabled: true}
+	manager.dirtyCount = 1
+	manager.statusMu.Unlock()
+
+	// Start a flush and pause it inside the storage write, holding the mgm lock.
+	store.blockNextSave.Store(true)
+	flushErr := make(chan error, 1)
+	go func() { flushErr <- manager.flushToStorage() }()
+	<-store.saveStarted
+
+	// PatchStatus blocks on the mgm lock the paused flush holds, so run it in a
+	// goroutine; it can only complete once the flush releases the lock.
+	const newCount = 99
+	patchErr := make(chan error, 1)
+	go func() {
+		c := newCount
+		patchErr <- manager.PatchStatus(ctx, groupID, &MetaServiceGroupStatusPatch{AssignmentCount: &c})
+	}()
+
+	// Let the flush finish; PatchStatus then serializes strictly after it.
+	close(store.unblockSave)
+	re.NoError(<-flushErr)
+	re.NoError(<-patchErr)
+
+	// The patch applied after the flush must be the persisted winner.
+	re.NoError(manager.RefreshCache())
+	statusMap, err := manager.GetStatus(ctx)
+	re.NoError(err)
+	re.Equal(newCount, statusMap[groupID].AssignmentCount)
 }

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -268,6 +268,33 @@ func (suite *metaServiceGroupTestSuite) TestAssignToGroupRejectsNegativeCount() 
 	re.ErrorIs(err, ErrInvalidAssignmentCount)
 }
 
+// TestUpdateGroupsSafelyResetsStatusForReaddedGroup verifies that adding a group
+// whose status still lingers in storage (e.g. from an earlier best-effort delete
+// that failed) resets that persisted status to zero, so RefreshCache does not
+// resurrect the stale count/enabled state.
+func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyResetsStatusForReaddedGroup() {
+	re := suite.Require()
+	const groupID = "etcd-group-readded"
+	// Simulate a stale persisted status for a group the manager does not know yet.
+	re.NoError(suite.manager.store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+		return suite.manager.store.SaveMetaServiceGroupStatus(txn, groupID,
+			&endpoint.MetaServiceGroupStatus{AssignmentCount: 5, Enabled: true})
+	}))
+
+	groups := mockMetaServiceGroups()
+	groups[groupID] = "etcd-group-readded.tidb-serverless.cluster.svc.local"
+	re.NoError(suite.manager.UpdateGroupsSafely(suite.ctx, groups, nil,
+		func() error { return nil }, nil))
+
+	// Reloading from storage must see a zero status, not the stale one.
+	re.NoError(suite.manager.RefreshCache())
+	statusMap, err := suite.manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.NotNil(statusMap[groupID])
+	re.Equal(0, statusMap[groupID].AssignmentCount)
+	re.False(statusMap[groupID].Enabled)
+}
+
 func (suite *metaServiceGroupTestSuite) TestReassignRejectsDisabledGroup() {
 	re := suite.Require()
 	// Groups are disabled by default, so reassigning a keyspace into one must be

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -357,6 +357,16 @@ func (suite *metaServiceGroupTestSuite) TestReassignRejectsDisabledGroup() {
 }
 
 // TestRefreshCacheRebuildsFromStorageAndScan verifies that RefreshCache takes the
+// TestNewManagerCountsNotReadyUntilCounterWired verifies that RefreshCache at
+// construction time (before SetKeyspaceAssignmentCounter has been called by the
+// keyspace manager) does not mark assignment counts ready: a zero count derived
+// from a nil counter is not an authoritative scan result, so callers relying on
+// assignment_count_ready must keep waiting for the real rebuild.
+func (suite *metaServiceGroupTestSuite) TestNewManagerCountsNotReadyUntilCounterWired() {
+	re := suite.Require()
+	re.False(suite.manager.IsAssignmentCountReady())
+}
+
 // Enabled flag from storage (authoritative for that field) but rebuilds
 // AssignmentCount from the keyspace scan, ignoring any stale persisted count.
 func (suite *metaServiceGroupTestSuite) TestRefreshCacheRebuildsFromStorageAndScan() {

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -17,6 +17,7 @@ package keyspace
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -303,7 +304,7 @@ func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyResetsStatusForRea
 		func() error { return nil }, nil))
 
 	// Reloading must see a disabled group with a zero derived count, not the stale one.
-	re.NoError(suite.manager.RefreshCache())
+	re.NoError(suite.manager.RefreshCache(suite.ctx))
 	statusMap, err := suite.manager.GetStatus(suite.ctx)
 	re.NoError(err)
 	re.NotNil(statusMap[groupID])
@@ -375,7 +376,7 @@ func (suite *metaServiceGroupTestSuite) TestRefreshCacheRebuildsFromStorageAndSc
 		return res, nil
 	})
 
-	re.NoError(suite.manager.RefreshCache())
+	re.NoError(suite.manager.RefreshCache(suite.ctx))
 	statusMap, err := suite.manager.GetStatus(suite.ctx)
 	re.NoError(err)
 	re.True(statusMap["etcd-group-0"].Enabled)             // from storage
@@ -390,7 +391,7 @@ func (suite *metaServiceGroupTestSuite) TestRefreshPersistedStatusDoesNotScanAss
 		return map[string]int{"etcd-group-0": 3}, nil
 	})
 
-	re.NoError(suite.manager.RefreshPersistedStatus())
+	re.NoError(suite.manager.RefreshPersistedStatus(suite.ctx))
 	re.False(called)
 	re.False(suite.manager.IsAssignmentCountReady())
 }
@@ -412,7 +413,12 @@ func (suite *metaServiceGroupTestSuite) TestStartAssignmentCountRebuildMarksRead
 	re.Equal(3, statusMap["etcd-group-0"].AssignmentCount)
 }
 
-func (suite *metaServiceGroupTestSuite) TestAssignmentCountRebuildRetriesWhenEpochChanges() {
+// TestAssignmentCountRebuildMergesInFlightDeltas verifies the termGen + delta
+// merge semantics: an assignment applied while a rebuild scan is in flight does
+// not discard the scan and is not clobbered by the scan result. The scan
+// completes in a single pass, then applies the in-flight delta on top of its
+// authoritative result.
+func (suite *metaServiceGroupTestSuite) TestAssignmentCountRebuildMergesInFlightDeltas() {
 	re := suite.Require()
 	suite.enableAllGroups()
 	suite.manager.statusMu.Lock()
@@ -421,22 +427,20 @@ func (suite *metaServiceGroupTestSuite) TestAssignmentCountRebuildRetriesWhenEpo
 	suite.manager.statusMu.Unlock()
 	scanStarted := make(chan struct{})
 	resumeScan := make(chan struct{})
-	firstScan := true
+	var scanCount int32
 	suite.manager.SetKeyspaceAssignmentCounter(func(_ context.Context, ids map[string]struct{}) (map[string]int, error) {
 		res := make(map[string]int, len(ids))
-		if firstScan {
-			firstScan = false
+		if atomic.AddInt32(&scanCount, 1) == 1 {
 			close(scanStarted)
 			<-resumeScan
-			res["etcd-group-0"] = 0
-			return res, nil
 		}
-		res["etcd-group-0"] = 1
+		res["etcd-group-0"] = 5
 		return res, nil
 	})
 
 	suite.manager.StartAssignmentCountRebuild(suite.ctx)
 	<-scanStarted
+	// Apply a delta (min group is etcd-group-0 at 0) while the scan is in flight.
 	_, err := suite.manager.PickGroup(suite.ctx)
 	re.NoError(err)
 	close(resumeScan)
@@ -444,7 +448,78 @@ func (suite *metaServiceGroupTestSuite) TestAssignmentCountRebuildRetriesWhenEpo
 	re.Eventually(suite.manager.IsAssignmentCountReady, time.Second, time.Millisecond)
 	statusMap, err := suite.manager.GetStatus(suite.ctx)
 	re.NoError(err)
-	re.Equal(1, statusMap["etcd-group-0"].AssignmentCount)
+	// The scan is merged with the in-flight increment, and only a single scan ran
+	// (no discard-and-retry).
+	re.Equal(6, statusMap["etcd-group-0"].AssignmentCount)
+	re.Equal(int32(1), atomic.LoadInt32(&scanCount))
+}
+
+func (suite *metaServiceGroupTestSuite) TestAssignmentCountRebuildMergesInFlightMoveDeltas() {
+	re := suite.Require()
+	suite.enableAllGroups()
+	suite.manager.statusMu.Lock()
+	suite.manager.cachedStatus["etcd-group-0"].AssignmentCount = 0
+	suite.manager.cachedStatus["etcd-group-1"].AssignmentCount = 0
+	suite.manager.cachedStatus["etcd-group-2"].AssignmentCount = 0
+	suite.manager.statusMu.Unlock()
+	scanStarted := make(chan struct{})
+	resumeScan := make(chan struct{})
+	var scanCount int32
+	suite.manager.SetKeyspaceAssignmentCounter(func(_ context.Context, ids map[string]struct{}) (map[string]int, error) {
+		res := make(map[string]int, len(ids))
+		if atomic.AddInt32(&scanCount, 1) == 1 {
+			close(scanStarted)
+			<-resumeScan
+		}
+		res["etcd-group-0"] = 10
+		res["etcd-group-1"] = 10
+		return res, nil
+	})
+
+	suite.manager.StartAssignmentCountRebuild(suite.ctx)
+	<-scanStarted
+	suite.manager.Lock()
+	err := suite.manager.reassignKeyspaceLocked(nil, "etcd-group-0", "etcd-group-1")
+	suite.manager.Unlock()
+	re.NoError(err)
+	close(resumeScan)
+
+	re.Eventually(suite.manager.IsAssignmentCountReady, time.Second, time.Millisecond)
+	statusMap, err := suite.manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.Equal(9, statusMap["etcd-group-0"].AssignmentCount)
+	re.Equal(11, statusMap["etcd-group-1"].AssignmentCount)
+	re.Equal(int32(1), atomic.LoadInt32(&scanCount))
+}
+
+func (suite *metaServiceGroupTestSuite) TestAssignmentCountRebuildMergesInFlightAssignToGroupDelta() {
+	re := suite.Require()
+	suite.enableAllGroups()
+	suite.manager.statusMu.Lock()
+	suite.manager.cachedStatus["etcd-group-1"].AssignmentCount = 10
+	suite.manager.cachedStatus["etcd-group-2"].AssignmentCount = 10
+	suite.manager.statusMu.Unlock()
+	scanStarted := make(chan struct{})
+	resumeScan := make(chan struct{})
+	suite.manager.SetKeyspaceAssignmentCounter(func(_ context.Context, ids map[string]struct{}) (map[string]int, error) {
+		res := make(map[string]int, len(ids))
+		close(scanStarted)
+		<-resumeScan
+		res["etcd-group-0"] = 5
+		return res, nil
+	})
+
+	suite.manager.StartAssignmentCountRebuild(suite.ctx)
+	<-scanStarted
+	assigned, err := suite.manager.AssignToGroup(suite.ctx, 3)
+	re.NoError(err)
+	re.Equal("etcd-group-0", assigned)
+	close(resumeScan)
+
+	re.Eventually(suite.manager.IsAssignmentCountReady, time.Second, time.Millisecond)
+	statusMap, err := suite.manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.Equal(8, statusMap["etcd-group-0"].AssignmentCount)
 }
 
 func (suite *metaServiceGroupTestSuite) enableAllGroups() {

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -35,7 +35,7 @@ type cleanupFailingMetaServiceGroupStorage struct {
 	*endpoint.StorageEndpoint
 }
 
-func (*cleanupFailingMetaServiceGroupStorage) RemoveMetaServiceGroupStatus(kv.Txn, string) error {
+func (*cleanupFailingMetaServiceGroupStorage) SaveMetaServiceGroupStatus(kv.Txn, string, *endpoint.MetaServiceGroupStatus) error {
 	return errInjectedStatusCleanup
 }
 
@@ -285,6 +285,25 @@ func (suite *metaServiceGroupTestSuite) TestPatchStatusRejectsAssignmentCount() 
 	count := 7
 	err := suite.manager.PatchStatus(suite.ctx, "etcd-group-0", &MetaServiceGroupStatusPatch{AssignmentCount: &count})
 	re.ErrorIs(err, ErrAssignmentCountPatchUnsupported)
+}
+
+// TestPatchStatusHonorsCanceledContext guards against PatchStatus silently
+// persisting and publishing a patch whose request context was already
+// canceled: the CAS helpers it calls don't take a context themselves, so
+// without an explicit check a canceled request would still land.
+func (suite *metaServiceGroupTestSuite) TestPatchStatusHonorsCanceledContext() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(suite.ctx)
+	cancel()
+
+	enabled := true
+	err := suite.manager.PatchStatus(ctx, "etcd-group-0", &MetaServiceGroupStatusPatch{Enabled: &enabled})
+	re.ErrorIs(err, context.Canceled)
+
+	re.NoError(suite.manager.RefreshCache(suite.ctx))
+	status, err := suite.manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.False(status["etcd-group-0"].Enabled, "a canceled patch must not be persisted or published")
 }
 
 // postCommitBlockingMetaServiceGroupStorage pauses RunInTxn after the
@@ -719,4 +738,59 @@ func TestPatchStatusModRevisionCASRejectsFormerLeaderAfterABA(t *testing.T) {
 	status, err := current.GetStatus(context.Background())
 	re.NoError(err)
 	re.False(status["group"].Enabled)
+}
+
+// TestPatchStatusModRevisionCASRejectsFormerLeaderAcrossDeleteRecreateCycle
+// guards against a second-order ABA the modification-revision CAS alone
+// doesn't close: etcd compares a missing key's modification revision as a
+// constant 0 no matter how many times it has been created and removed, so a
+// former leader that observed a missing key can still commit after the key
+// went missing again through an intervening delete-and-recreate cycle.
+// persistGroupsLocked closes this by overwriting the status key on both the
+// added-group reset and the deleted-group cleanup instead of removing it, so
+// the revision keeps climbing across the group's whole lifetime and a
+// deleted-then-recreated key never compares as "still absent" again.
+func TestPatchStatusModRevisionCASRejectsFormerLeaderAcrossDeleteRecreateCycle(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	base := kv.NewEtcdKVBase(client)
+	currentStore := endpoint.NewStorageEndpoint(base, nil)
+	groups := map[string]string{"group": "addr"}
+
+	formerStore := &preCommitBlockingMetaServiceGroupStorage{
+		StorageEndpoint: endpoint.NewStorageEndpoint(base, nil),
+		casPrepared:     make(chan struct{}),
+		resumeCAS:       make(chan struct{}),
+	}
+	former, err := NewMetaServiceGroupManager(context.Background(), formerStore, groups)
+	re.NoError(err)
+	current, err := NewMetaServiceGroupManager(context.Background(), currentStore, groups)
+	re.NoError(err)
+
+	enabled := true
+	formerStore.blockNextCAS.Store(true)
+	done := make(chan error, 1)
+	go func() {
+		done <- former.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled})
+	}()
+	<-formerStore.casPrepared
+
+	// The former leader observed a missing key (modification revision 0).
+	// Leave it missing again after an intervening create, delete, and
+	// group re-add.
+	re.NoError(current.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled}))
+	re.NoError(current.UpdateGroupsSafely(context.Background(), map[string]string{}, []string{"group"}, func() error { return nil }, nil))
+	re.NoError(current.UpdateGroupsSafely(context.Background(), groups, nil, func() error { return nil }, nil))
+	close(formerStore.resumeCAS)
+
+	// The former leader's stale CAS must still be rejected, not silently
+	// accepted because the key is absent again.
+	re.ErrorIs(<-done, ErrMetaServiceGroupStatusConflict)
+
+	re.NoError(current.RefreshCache(context.Background()))
+	status, err := current.GetStatus(context.Background())
+	re.NoError(err)
+	re.False(status["group"].Enabled, "a former leader must not enable a re-added group")
 }

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/etcdutil"
 )
 
 var errInjectedStatusCleanup = errors.New("injected status cleanup failure")
@@ -283,6 +285,75 @@ func (suite *metaServiceGroupTestSuite) TestPatchStatusRejectsAssignmentCount() 
 	count := 7
 	err := suite.manager.PatchStatus(suite.ctx, "etcd-group-0", &MetaServiceGroupStatusPatch{AssignmentCount: &count})
 	re.ErrorIs(err, ErrAssignmentCountPatchUnsupported)
+}
+
+// postCommitBlockingMetaServiceGroupStorage pauses RunInTxn after the
+// underlying transaction has committed, once, the next time blockNextTxn is
+// armed. It lets a test hold a PatchStatus call open between "storage write
+// committed" and "PatchStatus returns", to probe what a concurrent
+// PatchStatus observes during that window.
+type postCommitBlockingMetaServiceGroupStorage struct {
+	*endpoint.StorageEndpoint
+	blockNextTxn atomic.Bool
+	txnCommitted chan struct{}
+	resumeTxn    chan struct{}
+}
+
+func (s *postCommitBlockingMetaServiceGroupStorage) CASMetaServiceGroupStatus(
+	id string, expectedModRevision int64, status *endpoint.MetaServiceGroupStatus,
+) (bool, error) {
+	committed, err := s.StorageEndpoint.CASMetaServiceGroupStatus(id, expectedModRevision, status)
+	if err == nil && s.blockNextTxn.CompareAndSwap(true, false) {
+		close(s.txnCommitted)
+		<-s.resumeTxn
+	}
+	return committed, err
+}
+
+// TestConcurrentPatchStatusKeepsCacheAtLastPersistedValue guards against
+// PatchStatus publishing an out-of-order value to cachedStatus: without
+// patchMu serializing the persist-then-publish sequence, a PatchStatus call
+// paused between its storage commit and its cache update can resume after a
+// later, already-published PatchStatus call and overwrite cachedStatus with
+// its own, now-stale value, so storage and cache disagree indefinitely.
+func (suite *metaServiceGroupTestSuite) TestConcurrentPatchStatusKeepsCacheAtLastPersistedValue() {
+	re := suite.Require()
+	store := &postCommitBlockingMetaServiceGroupStorage{
+		StorageEndpoint: endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
+		txnCommitted:    make(chan struct{}),
+		resumeTxn:       make(chan struct{}),
+	}
+	manager, err := NewMetaServiceGroupManager(suite.ctx, store, mockMetaServiceGroups())
+	re.NoError(err)
+
+	enabled, disabled := true, false
+	store.blockNextTxn.Store(true)
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- manager.PatchStatus(suite.ctx, "etcd-group-0", &MetaServiceGroupStatusPatch{Enabled: &enabled})
+	}()
+	<-store.txnCommitted
+
+	// patchMu should keep this call blocked until the first one fully
+	// releases it below, so run it in its own goroutine rather than inline.
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- manager.PatchStatus(suite.ctx, "etcd-group-0", &MetaServiceGroupStatusPatch{Enabled: &disabled})
+	}()
+	close(store.resumeTxn)
+	re.NoError(<-firstDone)
+	re.NoError(<-secondDone)
+
+	var persisted map[string]*endpoint.MetaServiceGroupStatus
+	re.NoError(store.RunInTxn(suite.ctx, func(txn kv.Txn) error {
+		var err error
+		persisted, err = store.LoadMetaServiceGroupStatus(txn, map[string]string{"etcd-group-0": ""})
+		return err
+	}))
+	cached, err := manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.False(persisted["etcd-group-0"].Enabled)
+	re.False(cached["etcd-group-0"].Enabled)
 }
 
 // TestUpdateGroupsSafelyResetsStatusForReaddedGroup verifies that re-adding a
@@ -572,4 +643,80 @@ func (suite *metaServiceGroupTestSuite) enableAllGroups() {
 			Enabled: &enabled,
 		}))
 	}
+}
+
+// preCommitBlockingMetaServiceGroupStorage pauses CASMetaServiceGroupStatus,
+// once, the next time blockNextCAS is armed, right before it delegates to the
+// real implementation. That lets a test hold a PatchStatus call open between
+// "read the status key's modification revision" and "commit the CAS against
+// it", to simulate a leader whose term ends while a patch request is already
+// in flight against it.
+type preCommitBlockingMetaServiceGroupStorage struct {
+	*endpoint.StorageEndpoint
+	blockNextCAS atomic.Bool
+	casPrepared  chan struct{}
+	resumeCAS    chan struct{}
+}
+
+func (s *preCommitBlockingMetaServiceGroupStorage) CASMetaServiceGroupStatus(
+	id string, expectedModRevision int64, status *endpoint.MetaServiceGroupStatus,
+) (bool, error) {
+	if s.blockNextCAS.CompareAndSwap(true, false) {
+		close(s.casPrepared)
+		<-s.resumeCAS
+	}
+	return s.StorageEndpoint.CASMetaServiceGroupStatus(id, expectedModRevision, status)
+}
+
+// TestPatchStatusModRevisionCASRejectsFormerLeaderAfterABA guards against the
+// ABA hole a value-only CAS has: a former leader reads Enabled=false, a
+// current leader writes true and then back to false, and the former leader's
+// write then sees "the value is still what I read" and would wrongly commit.
+// Comparing the modification revision instead of the value closes it, since
+// the revision keeps advancing across the intervening writes even though the
+// value returns to what the former leader saw.
+func TestPatchStatusModRevisionCASRejectsFormerLeaderAfterABA(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	base := kv.NewEtcdKVBase(client)
+	currentStore := endpoint.NewStorageEndpoint(base, nil)
+	groups := map[string]string{"group": "addr"}
+	disabled, enabled := false, true
+	re.NoError(currentStore.RunInTxn(context.Background(), func(txn kv.Txn) error {
+		return currentStore.SaveMetaServiceGroupStatus(txn, "group", &endpoint.MetaServiceGroupStatus{Enabled: false})
+	}))
+
+	formerStore := &preCommitBlockingMetaServiceGroupStorage{
+		StorageEndpoint: endpoint.NewStorageEndpoint(base, nil),
+		casPrepared:     make(chan struct{}),
+		resumeCAS:       make(chan struct{}),
+	}
+	former, err := NewMetaServiceGroupManager(context.Background(), formerStore, groups)
+	re.NoError(err)
+	current, err := NewMetaServiceGroupManager(context.Background(), currentStore, groups)
+	re.NoError(err)
+
+	formerStore.blockNextCAS.Store(true)
+	done := make(chan error, 1)
+	go func() {
+		done <- former.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled})
+	}()
+	<-formerStore.casPrepared
+
+	// The current leader writes true, then back to false: an ABA on the
+	// value, but the modification revision has advanced twice.
+	re.NoError(current.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled}))
+	re.NoError(current.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &disabled}))
+	close(formerStore.resumeCAS)
+
+	// The former leader's stale-revision CAS must be rejected, not silently
+	// committed just because the value happens to match again.
+	re.ErrorIs(<-done, ErrMetaServiceGroupStatusConflict)
+
+	re.NoError(current.RefreshCache(context.Background()))
+	status, err := current.GetStatus(context.Background())
+	re.NoError(err)
+	re.False(status["group"].Enabled)
 }

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -35,8 +35,8 @@ type cleanupFailingMetaServiceGroupStorage struct {
 	*endpoint.StorageEndpoint
 }
 
-func (*cleanupFailingMetaServiceGroupStorage) SaveMetaServiceGroupStatus(kv.Txn, string, *endpoint.MetaServiceGroupStatus) error {
-	return errInjectedStatusCleanup
+func (*cleanupFailingMetaServiceGroupStorage) CASMetaServiceGroupStatus(string, int64, *endpoint.MetaServiceGroupStatus) (bool, error) {
+	return false, errInjectedStatusCleanup
 }
 
 type metaServiceGroupTestSuite struct {
@@ -793,4 +793,54 @@ func TestPatchStatusModRevisionCASRejectsFormerLeaderAcrossDeleteRecreateCycle(t
 	status, err := current.GetStatus(context.Background())
 	re.NoError(err)
 	re.False(status["group"].Enabled, "a former leader must not enable a re-added group")
+}
+
+// TestFormerLeaderDeletedGroupCleanupDoesNotOverwriteReaddedGroupPatch guards
+// against persistGroupsLocked's deleted-group status cleanup itself being an
+// unfenced stale-term write: it runs after persist() has already committed
+// the deletion, so it can be arbitrarily delayed. Without routing it through
+// the same modification-revision CAS PatchStatus uses, a former leader's
+// delayed cleanup could silently overwrite a newer leader's legitimate patch
+// to the same, since-recreated group with no evidence beyond "this ID used to
+// be deleted".
+func TestFormerLeaderDeletedGroupCleanupDoesNotOverwriteReaddedGroupPatch(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	base := kv.NewEtcdKVBase(client)
+	groups := map[string]string{"group": "addr"}
+
+	formerStore := &preCommitBlockingMetaServiceGroupStorage{
+		StorageEndpoint: endpoint.NewStorageEndpoint(base, nil),
+		casPrepared:     make(chan struct{}),
+		resumeCAS:       make(chan struct{}),
+	}
+	former, err := NewMetaServiceGroupManager(context.Background(), formerStore, groups)
+	re.NoError(err)
+
+	formerStore.blockNextCAS.Store(true)
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- former.UpdateGroupsSafely(context.Background(), map[string]string{},
+			[]string{"group"}, func() error { return nil }, nil)
+	}()
+	<-formerStore.casPrepared // The deletion config is already persisted; only the best-effort cleanup CAS is paused.
+
+	currentStore := endpoint.NewStorageEndpoint(base, nil)
+	current, err := NewMetaServiceGroupManager(context.Background(), currentStore, map[string]string{})
+	re.NoError(err)
+	re.NoError(current.UpdateGroupsSafely(context.Background(), groups, nil, func() error { return nil }, nil))
+	enabled := true
+	re.NoError(current.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled}))
+
+	close(formerStore.resumeCAS)
+	// The cleanup is best-effort: losing its CAS must not fail the delete
+	// that already committed.
+	re.NoError(<-deleteDone)
+
+	re.NoError(current.RefreshCache(context.Background()))
+	status, err := current.GetStatus(context.Background())
+	re.NoError(err)
+	re.True(status["group"].Enabled, "a former leader's delayed cleanup must not overwrite the re-added group's patch")
 }

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -958,3 +958,56 @@ func TestFormerLeaderRejectedByTermContextBeforeReadingDeletedGroupStatus(t *tes
 	re.True(status["group"].Enabled,
 		"a former leader rejected by its term context must not overwrite the re-added group's patch")
 }
+
+// TestFormerLeaderReturningNilTermContextDoesNotOverwriteReaddedGroupStatus
+// guards against a wired-but-currently-nil term source (RaftCluster.Context()
+// returns nil once the cluster has stopped, since running is set false before
+// the old context is even canceled) being treated as "no constraint applies"
+// instead of "no term is held, reject". A nil check that falls through would
+// disable the fence for every write between a stop and whatever eventually
+// rebuilds the source for a new term.
+func TestFormerLeaderReturningNilTermContextDoesNotOverwriteReaddedGroupStatus(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	base := kv.NewEtcdKVBase(client)
+	groups := map[string]string{"group": "addr"}
+	former, err := NewMetaServiceGroupManager(context.Background(), endpoint.NewStorageEndpoint(base, nil), groups)
+	re.NoError(err)
+	formerTermCtx, cancelFormerTerm := context.WithCancel(context.Background())
+	blocking := &blockingTermContext{
+		checkStarted: make(chan struct{}),
+		resumeCheck:  make(chan struct{}),
+	}
+	blocking.setCtx(formerTermCtx)
+	former.SetTermContextFunc(blocking.get)
+
+	blocking.blockNext.Store(true)
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- former.UpdateGroupsSafely(context.Background(), map[string]string{},
+			[]string{"group"}, func() error { return nil }, nil)
+	}()
+	<-blocking.checkStarted
+
+	current, err := NewMetaServiceGroupManager(context.Background(), endpoint.NewStorageEndpoint(base, nil), map[string]string{})
+	re.NoError(err)
+	re.NoError(current.UpdateGroupsSafely(context.Background(), groups, nil, func() error { return nil }, nil))
+	enabled := true
+	re.NoError(current.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled}))
+
+	// RaftCluster.Stop sets running=false before canceling the old context;
+	// Context returns nil from this point onward, which is exactly the
+	// production value being simulated here, not a caller mistake.
+	blocking.setCtx(nil) //nolint:staticcheck
+	cancelFormerTerm()
+	close(blocking.resumeCheck)
+	re.NoError(<-deleteDone)
+
+	re.NoError(current.RefreshCache(context.Background()))
+	status, err := current.GetStatus(context.Background())
+	re.NoError(err)
+	re.True(status["group"].Enabled,
+		"a nil context from a stopped former leader must not disable the term fence")
+}

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -17,6 +17,7 @@ package keyspace
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -843,4 +844,117 @@ func TestFormerLeaderDeletedGroupCleanupDoesNotOverwriteReaddedGroupPatch(t *tes
 	status, err := current.GetStatus(context.Background())
 	re.NoError(err)
 	re.True(status["group"].Enabled, "a former leader's delayed cleanup must not overwrite the re-added group's patch")
+}
+
+// blockingTermContext pauses the first call to get(), once armed, right
+// before returning the context it currently holds. It lets a test hold a
+// casMetaServiceGroupStatusLocked call open at its term check, i.e. before
+// the call has read the status key at all, to simulate a leader delayed
+// before its read rather than between its read and its write.
+type blockingTermContext struct {
+	mu           sync.Mutex
+	ctx          context.Context
+	blockNext    atomic.Bool
+	checkStarted chan struct{}
+	resumeCheck  chan struct{}
+}
+
+func (b *blockingTermContext) setCtx(ctx context.Context) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.ctx = ctx
+}
+
+func (b *blockingTermContext) get() context.Context {
+	if b.blockNext.CompareAndSwap(true, false) {
+		close(b.checkStarted)
+		<-b.resumeCheck
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.ctx
+}
+
+// TestCASMetaServiceGroupStatusLockedRejectsAlreadyCanceledTerm is a direct,
+// non-concurrent check that the term-context gate in
+// casMetaServiceGroupStatusLocked actually fires: a canceled term context
+// must reject the write before it ever reads storage.
+func TestCASMetaServiceGroupStatusLockedRejectsAlreadyCanceledTerm(t *testing.T) {
+	re := require.New(t)
+	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	manager, err := NewMetaServiceGroupManager(context.Background(), store, map[string]string{"group": "addr"})
+	re.NoError(err)
+
+	termCtx, cancelTerm := context.WithCancel(context.Background())
+	cancelTerm()
+	manager.SetTermContextFunc(func() context.Context { return termCtx })
+
+	enabled := true
+	err = manager.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled})
+	re.ErrorIs(err, context.Canceled)
+
+	status, err := manager.GetStatus(context.Background())
+	re.NoError(err)
+	re.False(status["group"].Enabled, "a patch rejected by an already-ended term must not be published to the cache")
+}
+
+// TestFormerLeaderRejectedByTermContextBeforeReadingDeletedGroupStatus closes
+// the gap the modification-revision CAS alone cannot: a former leader paused
+// before it ever reads the status key (not just before it commits) would
+// otherwise resume, read a revision that already reflects a newer leader's
+// legitimate re-add-and-patch, and CAS a stale reset against it successfully,
+// because that read-write window is internally consistent even though it's
+// anchored on stale premises. Checking the term context before the read
+// closes it: a newer leader acting at all requires this leader's term to
+// have already ended, so by the time this leader's paused goroutine resumes,
+// its own term context is already canceled.
+func TestFormerLeaderRejectedByTermContextBeforeReadingDeletedGroupStatus(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	base := kv.NewEtcdKVBase(client)
+	groups := map[string]string{"group": "addr"}
+
+	formerStore := endpoint.NewStorageEndpoint(base, nil)
+	former, err := NewMetaServiceGroupManager(context.Background(), formerStore, groups)
+	re.NoError(err)
+	formerTermCtx, cancelFormerTerm := context.WithCancel(context.Background())
+	blocking := &blockingTermContext{
+		checkStarted: make(chan struct{}),
+		resumeCheck:  make(chan struct{}),
+	}
+	blocking.setCtx(formerTermCtx)
+	former.SetTermContextFunc(blocking.get)
+
+	blocking.blockNext.Store(true)
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- former.UpdateGroupsSafely(context.Background(), map[string]string{},
+			[]string{"group"}, func() error { return nil }, nil)
+	}()
+	<-blocking.checkStarted // Config deletion is persisted; the cleanup is about to check its term, before reading the status key.
+
+	currentStore := endpoint.NewStorageEndpoint(base, nil)
+	current, err := NewMetaServiceGroupManager(context.Background(), currentStore, map[string]string{})
+	re.NoError(err)
+	re.NoError(current.UpdateGroupsSafely(context.Background(), groups, nil, func() error { return nil }, nil))
+	enabled := true
+	re.NoError(current.PatchStatus(context.Background(), "group", &MetaServiceGroupStatusPatch{Enabled: &enabled}))
+
+	// Former's term actually ends now (e.g. its lease was lost), which is
+	// exactly what must have already happened for current's actions above to
+	// be legitimate in the first place.
+	cancelFormerTerm()
+	close(blocking.resumeCheck)
+
+	// The cleanup is best-effort: being rejected by the term check must not
+	// fail the delete that already committed.
+	re.NoError(<-deleteDone)
+
+	re.NoError(current.RefreshCache(context.Background()))
+	status, err := current.GetStatus(context.Background())
+	re.NoError(err)
+	re.True(status["group"].Enabled,
+		"a former leader rejected by its term context must not overwrite the re-added group's patch")
 }

--- a/pkg/keyspace/meta_service_group_test.go
+++ b/pkg/keyspace/meta_service_group_test.go
@@ -335,6 +335,38 @@ func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyDoesNotCommitConfi
 	re.NotContains(statusMap, "etcd-group-readded")
 }
 
+// TestUpdateGroupsSafelyCommitsConfigEvenWhenDeletedStatusCleanupFails documents
+// a deliberate asymmetry with the added-group case above: cleaning up a deleted
+// group's now-orphan persisted status runs after persist() and is best-effort,
+// not rolled back on failure. This is safe because the deleted group is removed
+// from metaServiceGroups (hence unreachable for new assignment) in the same call
+// regardless of cleanup outcome, and a future re-add resets any leftover status
+// (see TestUpdateGroupsSafelyResetsStatusForReaddedGroup). Making this atomic
+// would instead make an unrelated group deletion hostage to cleaning up a status
+// key nothing will ever read again.
+func (suite *metaServiceGroupTestSuite) TestUpdateGroupsSafelyCommitsConfigEvenWhenDeletedStatusCleanupFails() {
+	re := suite.Require()
+	store := &cleanupFailingMetaServiceGroupStorage{
+		StorageEndpoint: endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
+	}
+	manager, err := NewMetaServiceGroupManager(suite.ctx, store, mockMetaServiceGroups())
+	re.NoError(err)
+
+	groups := mockMetaServiceGroups()
+	delete(groups, "etcd-group-0")
+	configPersisted := false
+	err = manager.UpdateGroupsSafely(suite.ctx, groups, []string{"etcd-group-0"}, func() error {
+		configPersisted = true
+		return nil
+	}, nil)
+	re.NoError(err)
+	re.True(configPersisted)
+	re.NotContains(manager.GetGroups(), "etcd-group-0")
+	statusMap, err := manager.GetStatus(suite.ctx)
+	re.NoError(err)
+	re.NotContains(statusMap, "etcd-group-0")
+}
+
 func (suite *metaServiceGroupTestSuite) TestReassignRejectsDisabledGroup() {
 	re := suite.Require()
 	// Groups are disabled by default, so reassigning a keyspace into one must be

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -58,6 +58,8 @@ var (
 	ErrUnknownMetaServiceGroup = errors.New("unknown meta-service group")
 	// ErrInvalidAssignmentCount is returned when the patched assignment count is negative.
 	ErrInvalidAssignmentCount = errors.New("assignment count must be non-negative")
+	// ErrAssignmentCountPatchUnsupported is returned when patching the derived assignment count.
+	ErrAssignmentCountPatchUnsupported = errors.New("assignment count patch is unsupported")
 	// ErrMetaServiceGroupDisabled is returned when assigning a keyspace to a
 	// disabled meta-service group, which is not eligible for assignment.
 	ErrMetaServiceGroupDisabled = errors.New("meta-service group is disabled")

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -56,7 +56,7 @@ var (
 
 	// ErrUnknownMetaServiceGroup is returned when the specified meta-service group does not exist.
 	ErrUnknownMetaServiceGroup = errors.New("unknown meta-service group")
-	// ErrInvalidAssignmentCount is returned when the patched assignment count is negative.
+	// ErrInvalidAssignmentCount is returned when an assignment count is negative.
 	ErrInvalidAssignmentCount = errors.New("assignment count must be non-negative")
 	// ErrAssignmentCountPatchUnsupported is returned when patching the derived assignment count.
 	ErrAssignmentCountPatchUnsupported = errors.New("assignment count patch is unsupported")

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -67,6 +67,13 @@ var (
 	// that still has keyspaces assigned to it. It is exported so HTTP handlers can
 	// map it to a 400 Bad Request via errors.Is.
 	ErrGroupHasAssignedKeyspaces = errors.New("cannot delete meta-service group with assigned keyspaces")
+	// ErrMetaServiceGroupStatusConflict is returned when PatchStatus's
+	// modification-revision compare-and-swap fails: the persisted status
+	// changed between the read and the write, most likely because a leader
+	// whose term has since ended raced this request. Retrying against the
+	// current leader picks up the fresh revision and does not repeat the
+	// conflict.
+	ErrMetaServiceGroupStatusConflict = errors.New("meta-service group status changed concurrently")
 
 	// stateTransitionTable lists all allowed next state for the given current state.
 	// Note that transit from any state to itself is allowed for idempotence.

--- a/pkg/storage/endpoint/keyspace.go
+++ b/pkg/storage/endpoint/keyspace.go
@@ -47,7 +47,17 @@ type KeyspaceStorage interface {
 	RemoveKeyspace(txn kv.Txn, id uint32, name string) error
 	// LoadRangeKeyspace loads no more than limit keyspaces starting at startID.
 	LoadRangeKeyspace(txn kv.Txn, startID uint32, limit int) ([]*keyspacepb.KeyspaceMeta, error)
+	// LoadRangeKeyspaceAtRevision is LoadRangeKeyspace pinned to a specific
+	// MVCC revision, read directly against the backend rather than through
+	// RunInTxn. It's meant for multi-batch scans that must see one consistent
+	// point in time across all batches; going through RunInTxn instead would
+	// make every batch's implicit read-conflict check race against any
+	// unrelated key written elsewhere while the scan is still in progress.
+	LoadRangeKeyspaceAtRevision(startID uint32, limit int, revision int64) ([]*keyspacepb.KeyspaceMeta, error)
 	RunInTxn(ctx context.Context, f func(txn kv.Txn) error) error
+	// CurrentRevision returns the storage backend's current MVCC revision, for
+	// use with LoadRangeKeyspaceAtRevision.
+	CurrentRevision(ctx context.Context) (int64, error)
 }
 
 var _ KeyspaceStorage = (*StorageEndpoint)(nil)
@@ -122,13 +132,29 @@ func (*StorageEndpoint) LoadRangeKeyspace(txn kv.Txn, startID uint32, limit int)
 	if err != nil {
 		return nil, err
 	}
+	return unmarshalKeyspaces(keys, values)
+}
+
+// LoadRangeKeyspaceAtRevision is LoadRangeKeyspace pinned to a specific MVCC
+// revision. See the KeyspaceStorage interface doc for why it bypasses RunInTxn.
+func (se *StorageEndpoint) LoadRangeKeyspaceAtRevision(startID uint32, limit int, revision int64) ([]*keyspacepb.KeyspaceMeta, error) {
+	startKey := keypath.KeyspaceMetaPath(startID)
+	endKey := clientv3.GetPrefixRangeEnd(keypath.KeyspaceMetaPrefix())
+	keys, values, err := se.LoadRange(startKey, endKey, limit, kv.WithRevision(revision))
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalKeyspaces(keys, values)
+}
+
+func unmarshalKeyspaces(keys, values []string) ([]*keyspacepb.KeyspaceMeta, error) {
 	if len(keys) == 0 {
 		return []*keyspacepb.KeyspaceMeta{}, nil
 	}
 	keyspaces := make([]*keyspacepb.KeyspaceMeta, 0, len(keys))
 	for _, value := range values {
 		keyspace := &keyspacepb.KeyspaceMeta{}
-		if err = proto.Unmarshal([]byte(value), keyspace); err != nil {
+		if err := proto.Unmarshal([]byte(value), keyspace); err != nil {
 			return nil, err
 		}
 		keyspaces = append(keyspaces, keyspace)

--- a/pkg/storage/endpoint/meta_service_group.go
+++ b/pkg/storage/endpoint/meta_service_group.go
@@ -26,7 +26,6 @@ import (
 type MetaServiceGroupStorage interface {
 	SaveMetaServiceGroupStatus(txn kv.Txn, id string, status *MetaServiceGroupStatus) error
 	LoadMetaServiceGroupStatus(txn kv.Txn, ids map[string]string) (map[string]*MetaServiceGroupStatus, error)
-	RemoveMetaServiceGroupStatus(txn kv.Txn, id string) error
 	RunInTxn(ctx context.Context, f func(txn kv.Txn) error) error
 	// LoadMetaServiceGroupStatusModRevision loads a single meta-service
 	// group's status along with its modification revision, for use with
@@ -67,13 +66,6 @@ func (*StorageEndpoint) LoadMetaServiceGroupStatus(txn kv.Txn, ids map[string]st
 		statusMap[id] = status
 	}
 	return statusMap, nil
-}
-
-// RemoveMetaServiceGroupStatus removes the persisted status of the designated
-// meta-service group, so re-adding a group with the same ID later starts fresh
-// instead of inheriting a stale status.
-func (*StorageEndpoint) RemoveMetaServiceGroupStatus(txn kv.Txn, id string) error {
-	return txn.Remove(keypath.MetaServiceGroupStatusPath(id))
 }
 
 func loadMetaServiceGroupStatus(txn kv.Txn, id string) (*MetaServiceGroupStatus, error) {

--- a/pkg/storage/endpoint/meta_service_group.go
+++ b/pkg/storage/endpoint/meta_service_group.go
@@ -28,6 +28,15 @@ type MetaServiceGroupStorage interface {
 	LoadMetaServiceGroupStatus(txn kv.Txn, ids map[string]string) (map[string]*MetaServiceGroupStatus, error)
 	RemoveMetaServiceGroupStatus(txn kv.Txn, id string) error
 	RunInTxn(ctx context.Context, f func(txn kv.Txn) error) error
+	// LoadMetaServiceGroupStatusModRevision loads a single meta-service
+	// group's status along with its modification revision, for use with
+	// CASMetaServiceGroupStatus.
+	LoadMetaServiceGroupStatusModRevision(id string) (status *MetaServiceGroupStatus, modRevision int64, err error)
+	// CASMetaServiceGroupStatus persists status for id, guarded by a
+	// modification-revision compare-and-swap against expectedModRevision.
+	// See the StorageEndpoint implementation's doc for why this is needed
+	// instead of a value-based compare.
+	CASMetaServiceGroupStatus(id string, expectedModRevision int64, status *MetaServiceGroupStatus) (committed bool, err error)
 }
 
 // MetaServiceGroupStatus represents the status of a meta-service group.
@@ -68,17 +77,91 @@ func (*StorageEndpoint) RemoveMetaServiceGroupStatus(txn kv.Txn, id string) erro
 }
 
 func loadMetaServiceGroupStatus(txn kv.Txn, id string) (*MetaServiceGroupStatus, error) {
-	statusPath := keypath.MetaServiceGroupStatusPath(id)
-	statusVal, err := txn.Load(statusPath)
+	statusVal, err := txn.Load(keypath.MetaServiceGroupStatusPath(id))
 	if err != nil {
 		return nil, err
 	}
+	return unmarshalMetaServiceGroupStatus(statusVal)
+}
+
+func unmarshalMetaServiceGroupStatus(statusVal string) (*MetaServiceGroupStatus, error) {
 	status := &MetaServiceGroupStatus{}
 	if statusVal == "" {
 		return status, nil
 	}
-	if err = json.Unmarshal([]byte(statusVal), status); err != nil {
+	if err := json.Unmarshal([]byte(statusVal), status); err != nil {
 		return nil, err
 	}
 	return status, nil
+}
+
+// LoadMetaServiceGroupStatusModRevision loads a single meta-service group's
+// status along with its modification revision, for use with
+// CASMetaServiceGroupStatus. The revision is 0 on backends without MVCC
+// (LevelDB, the in-memory KV) and for a group with no persisted status yet.
+func (se *StorageEndpoint) LoadMetaServiceGroupStatusModRevision(id string) (*MetaServiceGroupStatus, int64, error) {
+	statusPath := keypath.MetaServiceGroupStatusPath(id)
+	reader, ok := se.Base.(kv.ModRevisionReader)
+	if !ok {
+		status, err := se.loadMetaServiceGroupStatusNoTxn(statusPath)
+		return status, 0, err
+	}
+	statusVal, modRevision, err := reader.LoadModRevision(statusPath)
+	if err != nil {
+		return nil, 0, err
+	}
+	status, err := unmarshalMetaServiceGroupStatus(statusVal)
+	return status, modRevision, err
+}
+
+func (se *StorageEndpoint) loadMetaServiceGroupStatusNoTxn(statusPath string) (*MetaServiceGroupStatus, error) {
+	statusVal, err := se.Load(statusPath)
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalMetaServiceGroupStatus(statusVal)
+}
+
+// CASMetaServiceGroupStatus persists status for id, guarded by a
+// modification-revision compare-and-swap against expectedModRevision when the
+// backend supports raw transactions (etcd). This fences a write from a leader
+// whose term has already ended: a value-only compare can't tell a key that
+// was never touched apart from one that changed and changed back to the same
+// value (ABA), but the modification revision advances on every write
+// regardless of the value, so a stale expectedModRevision reliably fails the
+// compare. Returns committed=false with a nil error when the compare fails;
+// the caller should reload and decide whether to retry or surface a
+// conflict.
+//
+// Backends without raw-transaction support (LevelDB, the in-memory KV used in
+// unit tests) can't be fenced this way and always commit: they're
+// single-process, so there is no concurrent stale-term writer to guard
+// against there.
+func (se *StorageEndpoint) CASMetaServiceGroupStatus(id string, expectedModRevision int64, status *MetaServiceGroupStatus) (committed bool, err error) {
+	statusPath := keypath.MetaServiceGroupStatusPath(id)
+	statusVal, err := json.Marshal(status)
+	if err != nil {
+		return false, err
+	}
+	rawTxn, err := se.createRawTxn()
+	if err != nil {
+		if err := se.Save(statusPath, string(statusVal)); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	resp, err := rawTxn.If(kv.RawTxnCondition{
+		Key:      statusPath,
+		CmpType:  kv.RawTxnCmpEqual,
+		Target:   kv.RawTxnCmpTargetModRevision,
+		Revision: expectedModRevision,
+	}).Then(kv.RawTxnOp{
+		Key:    statusPath,
+		OpType: kv.RawTxnOpPut,
+		Value:  string(statusVal),
+	}).Commit()
+	if err != nil {
+		return false, err
+	}
+	return resp.Succeeded, nil
 }

--- a/pkg/storage/kv/etcd_kv.go
+++ b/pkg/storage/kv/etcd_kv.go
@@ -66,6 +66,23 @@ func (kv *etcdKVBase) Load(key string) (string, error) {
 	return string(resp.Kvs[0].Value), nil
 }
 
+// LoadModRevision loads the value and modification revision of the key from
+// etcd. A missing key returns an empty value and a modification revision of
+// 0, matching how a RawTxnCmpTargetModRevision condition compares a key that
+// doesn't exist.
+func (kv *etcdKVBase) LoadModRevision(key string) (string, int64, error) {
+	resp, err := etcdutil.EtcdKVGet(kv.client, key)
+	if err != nil {
+		return "", 0, err
+	}
+	if n := len(resp.Kvs); n == 0 {
+		return "", 0, nil
+	} else if n > 1 {
+		return "", 0, errs.ErrEtcdKVGetResponse.GenWithStackByArgs(resp.Kvs)
+	}
+	return string(resp.Kvs[0].Value), resp.Kvs[0].ModRevision, nil
+}
+
 // LoadRange loads a range of keys [key, endKey) from etcd.
 func (kv *etcdKVBase) LoadRange(key, endKey string, limit int, opts ...RangeOption) (keys, values []string, err error) {
 	var options RangeOptions
@@ -344,7 +361,12 @@ func (l *rawTxnWrapper) If(conditions ...RawTxnCondition) RawTxn {
 			default:
 				panic(fmt.Sprintf("unknown cmp type %v", c.CmpType))
 			}
-			cmpList = append(cmpList, clientv3.Compare(clientv3.Value(c.Key), cmpOp, c.Value))
+			switch c.Target {
+			case RawTxnCmpTargetModRevision:
+				cmpList = append(cmpList, clientv3.Compare(clientv3.ModRevision(c.Key), cmpOp, c.Revision))
+			default:
+				cmpList = append(cmpList, clientv3.Compare(clientv3.Value(c.Key), cmpOp, c.Value))
+			}
 		}
 	}
 	l.inner = l.inner.If(cmpList...)

--- a/pkg/storage/kv/etcd_kv.go
+++ b/pkg/storage/kv/etcd_kv.go
@@ -67,7 +67,11 @@ func (kv *etcdKVBase) Load(key string) (string, error) {
 }
 
 // LoadRange loads a range of keys [key, endKey) from etcd.
-func (kv *etcdKVBase) LoadRange(key, endKey string, limit int) (keys, values []string, err error) {
+func (kv *etcdKVBase) LoadRange(key, endKey string, limit int, opts ...RangeOption) (keys, values []string, err error) {
+	var options RangeOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	var OpOption []clientv3.OpOption
 	// If endKey is "\x00", it means to scan with prefix.
 	// If the key is empty and endKey is "\x00", it means to scan all keys.
@@ -78,6 +82,9 @@ func (kv *etcdKVBase) LoadRange(key, endKey string, limit int) (keys, values []s
 	}
 
 	OpOption = append(OpOption, clientv3.WithLimit(int64(limit)))
+	if options.Revision != 0 {
+		OpOption = append(OpOption, clientv3.WithRev(options.Revision))
+	}
 	resp, err := etcdutil.EtcdKVGet(kv.client, key, OpOption...)
 	if err != nil {
 		return nil, nil, err
@@ -89,6 +96,17 @@ func (kv *etcdKVBase) LoadRange(key, endKey string, limit int) (keys, values []s
 		values = append(values, string(item.Value))
 	}
 	return keys, values, nil
+}
+
+// CurrentRevision returns etcd's current MVCC revision, observed via a
+// linearizable read. Any write that etcd starts processing after this call
+// returns is guaranteed a revision greater than the one returned here.
+func (kv *etcdKVBase) CurrentRevision(_ context.Context) (int64, error) {
+	resp, err := etcdutil.EtcdKVGet(kv.client, "\x00", clientv3.WithLimit(1))
+	if err != nil {
+		return 0, err
+	}
+	return resp.Header.GetRevision(), nil
 }
 
 // Save puts a key-value pair to etcd.
@@ -266,8 +284,8 @@ func (txn *etcdTxn) Load(key string) (string, error) {
 
 // LoadRange loads the target range from etcd,
 // Then for each value loaded, it puts a comparator into conditions.
-func (txn *etcdTxn) LoadRange(key, endKey string, limit int) (keys []string, values []string, err error) {
-	keys, values, err = txn.kv.LoadRange(key, endKey, limit)
+func (txn *etcdTxn) LoadRange(key, endKey string, limit int, opts ...RangeOption) (keys []string, values []string, err error) {
+	keys, values, err = txn.kv.LoadRange(key, endKey, limit, opts...)
 	// If LoadRange failed, preserve the failure behavior of base LoadRange.
 	if err != nil {
 		return keys, values, err

--- a/pkg/storage/kv/kv.go
+++ b/pkg/storage/kv/kv.go
@@ -102,12 +102,38 @@ type RawTxnCapable interface {
 	CreateRawTxn() RawTxn
 }
 
+// RangeOptions carries optional, backend-specific behavior for LoadRange.
+type RangeOptions struct {
+	// Revision, if non-zero, pins the read to a specific historical MVCC
+	// revision instead of the latest value. Backends without MVCC (LevelDB,
+	// the in-memory KV) have no notion of revision and ignore it.
+	Revision int64
+}
+
+// RangeOption configures a RangeOptions.
+type RangeOption func(*RangeOptions)
+
+// WithRevision pins a LoadRange call to a specific historical MVCC revision,
+// so a caller issuing multiple LoadRange calls (e.g. to page through a large
+// range) sees one consistent point in time across all of them instead of a
+// mix of before/after states for keys mutated while paging.
+//
+// Avoid using it on a Txn obtained from RunInTxn: on the etcd backend, LoadRange
+// inside a transaction also adds a condition comparing each returned key's
+// current value against the value just read (see RunInTxn's doc), which is
+// checked at commit time against the latest value, not the pinned revision. A
+// revision pinned to the past will then spuriously fail that condition as soon
+// as any returned key changes before commit. Call it on Base directly instead.
+func WithRevision(revision int64) RangeOption {
+	return func(o *RangeOptions) { o.Revision = revision }
+}
+
 // BaseReadWrite is the API set, shared by Base and Txn interfaces, that provides basic KV read and write operations.
 type BaseReadWrite interface {
 	Save(key, value string) error
 	Remove(key string) error
 	Load(key string) (string, error)
-	LoadRange(key, endKey string, limit int) (keys []string, values []string, err error)
+	LoadRange(key, endKey string, limit int, opts ...RangeOption) (keys []string, values []string, err error)
 }
 
 // Txn bundles multiple operations into a single executable unit.
@@ -147,4 +173,8 @@ type Base interface {
 	// 2. Only when storage is etcd, does RunInTxn checks that
 	// values loaded during transaction has not been modified before commit.
 	RunInTxn(ctx context.Context, f func(txn Txn) error) error
+	// CurrentRevision returns the backend's current MVCC revision, for use
+	// with WithRevision. Backends without MVCC (LevelDB, the in-memory KV)
+	// return 0, which WithRevision treats as "unpinned".
+	CurrentRevision(ctx context.Context) (int64, error)
 }

--- a/pkg/storage/kv/kv.go
+++ b/pkg/storage/kv/kv.go
@@ -41,12 +41,35 @@ const (
 	RawTxnOpGetRange
 )
 
+// RawTxnCmpTarget selects which attribute of a key a RawTxnCondition compares.
+type RawTxnCmpTarget int
+
+// nolint:revive
+const (
+	// RawTxnCmpTargetValue compares the key's value. It is the default and is
+	// used when CmpType is RawTxnCmpExists or RawTxnCmpNotExists too.
+	RawTxnCmpTargetValue RawTxnCmpTarget = iota
+	// RawTxnCmpTargetModRevision compares the key's modification revision,
+	// which changes on every write regardless of whether the value returns to
+	// one it held before. Prefer it over RawTxnCmpTargetValue to guard against
+	// ABA: a value-only compare cannot tell a key that was never touched
+	// apart from one that changed and changed back to the same value.
+	RawTxnCmpTargetModRevision
+)
+
 // RawTxnCondition represents a condition in a RawTxn.
 type RawTxnCondition struct {
 	Key     string
 	CmpType RawTxnCmpType
-	// The value to compare with. It's not used when CmpType is RawTxnCmpExists or RawTxnCmpNotExists.
+	// Target selects what CmpType compares against. Defaults to
+	// RawTxnCmpTargetValue.
+	Target RawTxnCmpTarget
+	// The value to compare with, used when Target is RawTxnCmpTargetValue.
+	// It's not used when CmpType is RawTxnCmpExists or RawTxnCmpNotExists.
 	Value string
+	// The modification revision to compare with, used when Target is
+	// RawTxnCmpTargetModRevision.
+	Revision int64
 }
 
 // RawTxnOp represents an operation in a RawTxn's `Then` or `Else` branch and will be executed according to
@@ -100,6 +123,16 @@ type RawTxn interface {
 // RawTxnCapable is implemented by KV backends that support creating raw transactions.
 type RawTxnCapable interface {
 	CreateRawTxn() RawTxn
+}
+
+// ModRevisionReader is implemented by KV backends that can report a key's
+// modification revision alongside its value, for use as the anchor of a
+// RawTxnCmpTargetModRevision condition. Backends without MVCC (LevelDB, the
+// in-memory KV) don't implement it.
+type ModRevisionReader interface {
+	// LoadModRevision loads key's value and modification revision. A missing
+	// key returns an empty value and a modification revision of 0.
+	LoadModRevision(key string) (value string, modRevision int64, err error)
 }
 
 // RangeOptions carries optional, backend-specific behavior for LoadRange.

--- a/pkg/storage/kv/kv_test.go
+++ b/pkg/storage/kv/kv_test.go
@@ -43,6 +43,7 @@ func TestEtcd(t *testing.T) {
 	testSaveMultiple(re, kv, 20)
 	testLoadConflict(re, kv)
 	testRawTxn(re, kv)
+	testCurrentRevision(re, kv)
 }
 
 func TestLevelDB(t *testing.T) {
@@ -54,6 +55,7 @@ func TestLevelDB(t *testing.T) {
 	testReadWrite(re, kv)
 	testRange(re, kv)
 	testSaveMultiple(re, kv, 20)
+	testCurrentRevision(re, kv)
 	re.NoError(kv.Close())
 }
 
@@ -63,6 +65,7 @@ func TestMemKV(t *testing.T) {
 	testReadWrite(re, kv)
 	testRange(re, kv)
 	testSaveMultiple(re, kv, 20)
+	testCurrentRevision(re, kv)
 }
 
 func testReadWrite(re *require.Assertions, kv Base) {
@@ -169,6 +172,32 @@ func testLoadConflict(re *require.Assertions, kv Base) {
 	}
 	// When other writer exists, loader must error.
 	re.Error(kv.RunInTxn(context.Background(), conflictLoader))
+}
+
+// testCurrentRevision checks that on etcd, a LoadRange pinned via WithRevision
+// to a revision captured before a write does not observe that write, while an
+// unpinned LoadRange always sees the latest value. LevelDB and the in-memory KV
+// have no MVCC revision concept, so CurrentRevision is always 0 and
+// WithRevision is a no-op: every read there sees the latest value regardless.
+func testCurrentRevision(re *require.Assertions, kv Base) {
+	re.NoError(kv.Save("rev-key", "before"))
+	rev, err := kv.CurrentRevision(context.Background())
+	re.NoError(err)
+	re.NoError(kv.Save("rev-key", "after"))
+
+	prefix, end := "rev-key", clientv3.GetPrefixRangeEnd("rev-key")
+	_, values, err := kv.LoadRange(prefix, end, 0, WithRevision(rev))
+	re.NoError(err)
+	if _, isEtcd := kv.(*etcdKVBase); isEtcd {
+		re.Equal([]string{"before"}, values)
+	} else {
+		re.Equal(int64(0), rev)
+		re.Equal([]string{"after"}, values)
+	}
+
+	_, values, err = kv.LoadRange(prefix, end, 0)
+	re.NoError(err)
+	re.Equal([]string{"after"}, values)
 }
 
 // nolint:unparam

--- a/pkg/storage/kv/levedb_kv.go
+++ b/pkg/storage/kv/levedb_kv.go
@@ -52,8 +52,9 @@ func (kv *LevelDBKV) Load(key string) (string, error) {
 	return string(v), err
 }
 
-// LoadRange gets a range of value for a given key range.
-func (kv *LevelDBKV) LoadRange(startKey, endKey string, limit int) (keys, values []string, err error) {
+// LoadRange gets a range of value for a given key range. LevelDB has no MVCC
+// revision concept, so any RangeOption (e.g. WithRevision) is ignored.
+func (kv *LevelDBKV) LoadRange(startKey, endKey string, limit int, _ ...RangeOption) (keys, values []string, err error) {
 	iter := kv.NewIterator(&util.Range{Start: []byte(startKey), Limit: []byte(endKey)}, nil)
 	keys = make([]string, 0, limit)
 	values = make([]string, 0, limit)
@@ -129,8 +130,13 @@ func (txn *levelDBTxn) Load(key string) (string, error) {
 }
 
 // LoadRange executes base's load range.
-func (txn *levelDBTxn) LoadRange(key, endKey string, limit int) (keys []string, values []string, err error) {
-	return txn.kv.LoadRange(key, endKey, limit)
+func (txn *levelDBTxn) LoadRange(key, endKey string, limit int, opts ...RangeOption) (keys []string, values []string, err error) {
+	return txn.kv.LoadRange(key, endKey, limit, opts...)
+}
+
+// CurrentRevision returns 0: LevelDB has no MVCC revision concept.
+func (*LevelDBKV) CurrentRevision(_ context.Context) (int64, error) {
+	return 0, nil
 }
 
 // commit writes the batch constructed into levelDB.

--- a/pkg/storage/kv/mem_kv.go
+++ b/pkg/storage/kv/mem_kv.go
@@ -59,8 +59,9 @@ func (kv *memoryKV) Load(key string) (string, error) {
 	return item.value, nil
 }
 
-// LoadRange loads the keys in the range of [key, endKey).
-func (kv *memoryKV) LoadRange(key, endKey string, limit int) (keys, values []string, err error) {
+// LoadRange loads the keys in the range of [key, endKey). The in-memory KV has
+// no MVCC revision concept, so any RangeOption (e.g. WithRevision) is ignored.
+func (kv *memoryKV) LoadRange(key, endKey string, limit int, _ ...RangeOption) (keys, values []string, err error) {
 	failpoint.Inject("withRangeLimit", func(val failpoint.Value) {
 		rangeLimit, ok := val.(int)
 		if ok && limit > rangeLimit {
@@ -167,8 +168,13 @@ func (txn *memTxn) Load(key string) (string, error) {
 }
 
 // LoadRange executes base's load range directly.
-func (txn *memTxn) LoadRange(key, endKey string, limit int) (keys []string, values []string, err error) {
-	return txn.kv.LoadRange(key, endKey, limit)
+func (txn *memTxn) LoadRange(key, endKey string, limit int, opts ...RangeOption) (keys []string, values []string, err error) {
+	return txn.kv.LoadRange(key, endKey, limit, opts...)
+}
+
+// CurrentRevision returns 0: the in-memory KV has no MVCC revision concept.
+func (*memoryKV) CurrentRevision(_ context.Context) (int64, error) {
+	return 0, nil
 }
 
 // commit executes operations in ops.

--- a/server/apiv2/handlers/meta_service_group.go
+++ b/server/apiv2/handlers/meta_service_group.go
@@ -55,6 +55,9 @@ type MetaServiceGroupStatus struct {
 	// AssignedKeyspaces is kept for backward compatibility with existing
 	// clients. It mirrors Status.AssignmentCount; prefer Status going forward.
 	AssignedKeyspaces int `json:"assigned_keyspaces"`
+	// AssignmentCountReady indicates whether assignment count has completed an
+	// authoritative keyspace metadata rebuild in this leader term.
+	AssignmentCountReady bool `json:"assignment_count_ready"`
 }
 
 // PatchMetaServiceGroups applies a JSON Merge Patch to the meta-service groups.
@@ -243,6 +246,7 @@ func buildMetaServiceGroupStatus(c *gin.Context, manager *keyspace.MetaServiceGr
 	if err != nil {
 		return nil, err
 	}
+	assignmentCountReady := manager.IsAssignmentCountReady()
 
 	status := make([]MetaServiceGroupStatus, 0, len(currentGroups))
 	for id, addresses := range currentGroups {
@@ -255,10 +259,11 @@ func buildMetaServiceGroupStatus(c *gin.Context, manager *keyspace.MetaServiceGr
 			s = &endpoint.MetaServiceGroupStatus{}
 		}
 		status = append(status, MetaServiceGroupStatus{
-			ID:                id,
-			Addresses:         addresses,
-			Status:            s,
-			AssignedKeyspaces: s.AssignmentCount,
+			ID:                   id,
+			Addresses:            addresses,
+			Status:               s,
+			AssignedKeyspaces:    s.AssignmentCount,
+			AssignmentCountReady: assignmentCountReady,
 		})
 	}
 	// sort for deterministic output

--- a/server/apiv2/handlers/meta_service_group.go
+++ b/server/apiv2/handlers/meta_service_group.go
@@ -50,7 +50,7 @@ type MetaServiceGroupStatus struct {
 	ID string `json:"id"`
 	// Addresses is a comma-separated list of addresses for the meta-service group.
 	Addresses string `json:"addresses"`
-	// Status is the persisted status (assignment count and enabled state).
+	// Status contains the persisted enabled state and the derived assignment count.
 	Status *endpoint.MetaServiceGroupStatus `json:"status,omitempty"`
 	// AssignedKeyspaces is kept for backward compatibility with existing
 	// clients. It mirrors Status.AssignmentCount; prefer Status going forward.
@@ -185,7 +185,7 @@ func GetMetaServiceGroups(c *gin.Context) {
 	c.IndentedJSON(http.StatusOK, status)
 }
 
-// PatchMetaServiceGroupStatus patches the status of a specific meta-service group.
+// PatchMetaServiceGroupStatus patches the persisted enabled status of a specific meta-service group.
 //
 // @Tags     meta-service-groups
 // @Summary  Patch meta-service groups status.
@@ -216,7 +216,7 @@ func PatchMetaServiceGroupStatus(c *gin.Context) {
 			c.AbortWithStatusJSON(http.StatusNotFound, err.Error())
 			return
 		}
-		if errors.Is(err, keyspace.ErrInvalidAssignmentCount) {
+		if errors.Is(err, keyspace.ErrInvalidAssignmentCount) || errors.Is(err, keyspace.ErrAssignmentCountPatchUnsupported) {
 			c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
 			return
 		}

--- a/server/apiv2/handlers/meta_service_group.go
+++ b/server/apiv2/handlers/meta_service_group.go
@@ -146,9 +146,11 @@ func PatchMetaServiceGroups(c *gin.Context) {
 			c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
 			return
 		}
-		if errors.Is(err, errs.ErrEtcdTxnConflict) {
-			// A concurrent group update or assignment lost the etcd txn compare;
-			// this is a retryable conflict rather than an internal error.
+		if errors.Is(err, errs.ErrEtcdTxnConflict) || errors.Is(err, keyspace.ErrMetaServiceGroupStatusConflict) {
+			// A concurrent group update or assignment lost the etcd txn
+			// compare, or an added group's pre-persist status reset lost its
+			// modification-revision CAS; either is a retryable conflict, not
+			// an internal error.
 			c.AbortWithStatusJSON(http.StatusConflict, err.Error())
 			return
 		}

--- a/server/apiv2/handlers/meta_service_group.go
+++ b/server/apiv2/handlers/meta_service_group.go
@@ -223,9 +223,11 @@ func PatchMetaServiceGroupStatus(c *gin.Context) {
 			c.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
 			return
 		}
-		if errors.Is(err, errs.ErrEtcdTxnConflict) {
-			// A concurrent status patch or assignment lost the etcd txn compare;
-			// this is a retryable conflict rather than an internal error.
+		if errors.Is(err, errs.ErrEtcdTxnConflict) || errors.Is(err, keyspace.ErrMetaServiceGroupStatusConflict) {
+			// A concurrent status patch or assignment lost the etcd txn compare,
+			// or PatchStatus's own modification-revision CAS lost a race with a
+			// concurrent patch; either is a retryable conflict, not an internal
+			// error.
 			c.AbortWithStatusJSON(http.StatusConflict, err.Error())
 			return
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -538,14 +538,12 @@ func (s *Server) startServer(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.metaServiceGroupManager.SetLeaderChecker(s.IsServing)
-	s.AddServiceReadyCallback(func(ctx context.Context) error {
+	s.AddServiceReadyCallback(func(_ context.Context) error {
 		if s.metaServiceGroupManager == nil {
 			return nil
 		}
-		// ctx is this leadership term's context (canceled when the lease is lost),
-		// so status flushes stop writing once the term ends.
-		s.metaServiceGroupManager.SetLeaderContext(ctx)
+		// Rebuild the derived assignment counts from keyspace metadata at the start
+		// of every leadership term.
 		return s.metaServiceGroupManager.RefreshCache()
 	})
 	s.keyspaceManager = keyspace.NewKeyspaceManager(

--- a/server/server.go
+++ b/server/server.go
@@ -534,7 +534,17 @@ func (s *Server) startServer(ctx context.Context) error {
 	if s.IsKeyspaceGroupEnabled() {
 		s.keyspaceGroupManager = keyspace.NewKeyspaceGroupManager(s.ctx, s.storage, s.client)
 	}
-	s.metaServiceGroupManager = keyspace.NewMetaServiceGroupManager(s.storage, s.cfg.Keyspace.GetMetaServiceGroups())
+	s.metaServiceGroupManager, err = keyspace.NewMetaServiceGroupManager(s.ctx, s.storage, s.cfg.Keyspace.GetMetaServiceGroups())
+	if err != nil {
+		return err
+	}
+	s.metaServiceGroupManager.SetLeaderChecker(s.IsServing)
+	s.AddServiceReadyCallback(func(_ context.Context) error {
+		if s.metaServiceGroupManager == nil {
+			return nil
+		}
+		return s.metaServiceGroupManager.RefreshCache()
+	})
 	s.keyspaceManager = keyspace.NewKeyspaceManager(
 		s.ctx,
 		s.storage,

--- a/server/server.go
+++ b/server/server.go
@@ -538,13 +538,18 @@ func (s *Server) startServer(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.AddServiceReadyCallback(func(_ context.Context) error {
+	s.AddServiceReadyCallback(func(ctx context.Context) error {
 		if s.metaServiceGroupManager == nil {
 			return nil
 		}
-		// Rebuild the derived assignment counts from keyspace metadata at the start
-		// of every leadership term.
-		return s.metaServiceGroupManager.RefreshCache()
+		// Load persisted administrative status synchronously, then rebuild derived
+		// assignment counts in the background so leader readiness is not blocked by a
+		// full keyspace scan.
+		if err := s.metaServiceGroupManager.RefreshPersistedStatus(); err != nil {
+			return err
+		}
+		s.metaServiceGroupManager.StartAssignmentCountRebuild(ctx)
+		return nil
 	})
 	s.keyspaceManager = keyspace.NewKeyspaceManager(
 		s.ctx,

--- a/server/server.go
+++ b/server/server.go
@@ -539,10 +539,13 @@ func (s *Server) startServer(ctx context.Context) error {
 		return err
 	}
 	s.metaServiceGroupManager.SetLeaderChecker(s.IsServing)
-	s.AddServiceReadyCallback(func(_ context.Context) error {
+	s.AddServiceReadyCallback(func(ctx context.Context) error {
 		if s.metaServiceGroupManager == nil {
 			return nil
 		}
+		// ctx is this leadership term's context (canceled when the lease is lost),
+		// so status flushes stop writing once the term ends.
+		s.metaServiceGroupManager.SetLeaderContext(ctx)
 		return s.metaServiceGroupManager.RefreshCache()
 	})
 	s.keyspaceManager = keyspace.NewKeyspaceManager(

--- a/server/server.go
+++ b/server/server.go
@@ -545,7 +545,7 @@ func (s *Server) startServer(ctx context.Context) error {
 		// Load persisted administrative status synchronously, then rebuild derived
 		// assignment counts in the background so leader readiness is not blocked by a
 		// full keyspace scan.
-		if err := s.metaServiceGroupManager.RefreshPersistedStatus(); err != nil {
+		if err := s.metaServiceGroupManager.RefreshPersistedStatus(ctx); err != nil {
 			return err
 		}
 		s.metaServiceGroupManager.StartAssignmentCountRebuild(ctx)

--- a/server/server.go
+++ b/server/server.go
@@ -538,6 +538,11 @@ func (s *Server) startServer(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// s.cluster.Context() is RaftCluster's per-term context: fresh on every
+	// Start() (leadership won), canceled on Stop() (leadership lost). Queried
+	// lazily by the manager (see termCtxFunc's doc) rather than captured once,
+	// so a write always checks the live signal.
+	s.metaServiceGroupManager.SetTermContextFunc(s.cluster.Context)
 	s.AddServiceReadyCallback(func(ctx context.Context) error {
 		if s.metaServiceGroupManager == nil {
 			return nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -319,14 +319,14 @@ type testFollowerRegionStorage struct {
 	loadRangeKeys   []string
 }
 
-func (s *testFollowerRegionStorage) LoadRange(key, endKey string, limit int) (keys []string, values []string, err error) {
+func (s *testFollowerRegionStorage) LoadRange(key, endKey string, limit int, opts ...kv.RangeOption) (keys []string, values []string, err error) {
 	if s.loadRangeErr != nil {
 		return nil, nil, s.loadRangeErr
 	}
 	if s.loadRangeKeys != nil {
 		return s.loadRangeKeys, nil, nil
 	}
-	return s.Storage.LoadRange(key, endKey, limit)
+	return s.Storage.LoadRange(key, endKey, limit, opts...)
 }
 
 func (s *testFollowerRegionStorage) LoadRegion(regionID uint64, region *metapb.Region) (bool, error) {

--- a/tests/server/apiv2/handlers/meta_service_group_test.go
+++ b/tests/server/apiv2/handlers/meta_service_group_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -158,7 +159,17 @@ func (suite *metaServiceGroupTestSuite) TestMetaServiceGroupOperations() {
 	re.NotContains(defaultKeyspace.GetConfig(), keyspace.MetaServiceGroupIDKey)
 	re.NotContains(defaultKeyspace.GetConfig(), keyspace.MetaServiceGroupAddressesKey)
 	// Meta-service groups are disabled by default and must be enabled before assignment.
-	for _, group := range mustLoadMetaServiceGroups(re, suite.server) {
+	var groups []*handlers.MetaServiceGroupStatus
+	re.Eventually(func() bool {
+		groups = mustLoadMetaServiceGroups(re, suite.server)
+		for _, group := range groups {
+			if !group.AssignmentCountReady {
+				return false
+			}
+		}
+		return true
+	}, time.Second, time.Millisecond)
+	for _, group := range groups {
 		re.False(group.Status.Enabled)
 		mustEnableMetaServiceGroup(re, suite.server, group.ID)
 	}
@@ -166,7 +177,7 @@ func (suite *metaServiceGroupTestSuite) TestMetaServiceGroupOperations() {
 	keyspaces := mustMakeTestKeyspaces(re, suite.server, 20)
 	collectedGroups := collectStatus(re, keyspaces)
 	// Make sure result collected from keyspace config and load meta-service group api matches.
-	groups := mustLoadMetaServiceGroups(re, suite.server)
+	groups = mustLoadMetaServiceGroups(re, suite.server)
 	re.Len(groups, len(collectedGroups))
 	for _, group := range groups {
 		collectedStatus := collectedGroups[group.ID]

--- a/tests/server/apiv2/handlers/meta_service_group_test.go
+++ b/tests/server/apiv2/handlers/meta_service_group_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +33,7 @@ import (
 
 	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/server/apiv2/handlers"
 	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/tests"
@@ -275,4 +278,61 @@ func (suite *metaServiceGroupTestSuite) TestMetaServiceGroupOperations() {
 	for _, group := range groups {
 		re.NotEqual("etcd-group-unused", group.ID)
 	}
+}
+
+// TestPatchMetaServiceGroupStatusConflictReturns409 guards against
+// PatchStatus's modification-revision CAS conflict (ErrMetaServiceGroupStatusConflict)
+// falling through the handler's error mapping to a 500: the endpoint
+// documents retryable conflicts as 409, so the new conflict error needs the
+// same treatment as the pre-existing errs.ErrEtcdTxnConflict case. Raw
+// writers race the status key's modification revision in the background so
+// an in-flight PATCH is very likely to lose its CAS at least once.
+func (suite *metaServiceGroupTestSuite) TestPatchMetaServiceGroupStatusConflictReturns409() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := suite.server.GetEtcdClient()
+	statusPath := keypath.MetaServiceGroupStatusPath("etcd-group-0")
+	var ready, wg sync.WaitGroup
+	ready.Add(8)
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			first := true
+			for ctx.Err() == nil {
+				_, err := client.Put(ctx, statusPath, `{"assignment_count":0,"enabled":false}`)
+				if err != nil {
+					return
+				}
+				if first {
+					ready.Done()
+					first = false
+				}
+			}
+		}()
+	}
+	ready.Wait()
+
+	for range 100 {
+		req, err := http.NewRequest(http.MethodPatch,
+			suite.server.GetAddr()+metaServiceGroupsPrefix+"/etcd-group-0/status",
+			bytes.NewBufferString(`{"enabled":true}`))
+		re.NoError(err)
+		resp, err := tests.TestDialClient.Do(req)
+		re.NoError(err)
+		body, err := io.ReadAll(resp.Body)
+		re.NoError(err)
+		re.NoError(resp.Body.Close())
+		if strings.Contains(string(body), keyspace.ErrMetaServiceGroupStatusConflict.Error()) {
+			cancel()
+			wg.Wait()
+			re.Equal(http.StatusConflict, resp.StatusCode, string(body))
+			return
+		}
+	}
+	cancel()
+	wg.Wait()
+	re.Fail("failed to trigger a meta-service group status conflict")
 }

--- a/tools/pd-ctl/pdctl/command/meta_service_group_command.go
+++ b/tools/pd-ctl/pdctl/command/meta_service_group_command.go
@@ -42,7 +42,6 @@ func NewMetaServiceGroupCommand() *cobra.Command {
 	cmd.AddCommand(newUpsertMetaServiceGroupCommand())
 	cmd.AddCommand(newDeleteMetaServiceGroupCommand())
 	cmd.AddCommand(newSetMetaServiceGroupEnabledCommand())
-	cmd.AddCommand(newSetMetaServiceGroupAssignmentCountCommand())
 	return cmd
 }
 
@@ -196,40 +195,6 @@ func newSetMetaServiceGroupEnabledFunc(cmd *cobra.Command, args []string) {
 		http.Header{"Content-Type": {"application/json"}}, WithBody(bytes.NewBuffer(body)))
 	if err != nil {
 		cmd.PrintErrln("Failed to set meta-service group enabled status:", err)
-		return
-	}
-	cmd.Println(resp)
-}
-
-func newSetMetaServiceGroupAssignmentCountCommand() *cobra.Command {
-	r := &cobra.Command{
-		Use:   "set-assignment-count <id> <count>",
-		Short: "set the assignment count for a meta-service group",
-		Args:  cobra.ExactArgs(2),
-		Run:   newSetMetaServiceGroupAssignmentCountFunc,
-	}
-	return r
-}
-
-func newSetMetaServiceGroupAssignmentCountFunc(cmd *cobra.Command, args []string) {
-	groupID := strings.TrimSpace(args[0])
-	assignmentCount, err := strconv.Atoi(args[1])
-	if err != nil {
-		cmd.PrintErrln("Invalid value for assignment count, must be an integer:", err)
-		return
-	}
-	patch := &keyspace.MetaServiceGroupStatusPatch{
-		AssignmentCount: &assignmentCount,
-	}
-	body, err := json.Marshal(patch)
-	if err != nil {
-		cmd.PrintErrln("Failed to marshal request:", err)
-		return
-	}
-	resp, err := doRequest(cmd, metaServiceGroupPrefix+"/"+url.PathEscape(groupID)+"/status", http.MethodPatch,
-		http.Header{"Content-Type": {"application/json"}}, WithBody(bytes.NewBuffer(body)))
-	if err != nil {
-		cmd.PrintErrln("Failed to set meta-service group assignment count:", err)
 		return
 	}
 	cmd.Println(resp)

--- a/tools/pd-ctl/tests/meta_service_group/meta_service_group_test.go
+++ b/tools/pd-ctl/tests/meta_service_group/meta_service_group_test.go
@@ -202,22 +202,6 @@ func (suite *metaServiceGroupCLITestSuite) TestSetEnabled() {
 	re.False(findGroup(groups, "group-0").Status.Enabled)
 }
 
-func (suite *metaServiceGroupCLITestSuite) TestSetAssignmentCount() {
-	re := suite.Require()
-
-	// Enable the group first, then set its assignment count.
-	_, err := tests.ExecuteCommand(ctl.GetRootCmd(), "-u", suite.pdAddr, "meta-service-group", "set-enabled", "group-0", "true")
-	re.NoError(err)
-	output, err := tests.ExecuteCommand(ctl.GetRootCmd(), "-u", suite.pdAddr, "meta-service-group", "set-assignment-count", "group-0", "10")
-	re.NoError(err)
-	var groups []*handlers.MetaServiceGroupStatus
-	re.NoError(json.Unmarshal(output, &groups))
-	g := findGroup(groups, "group-0")
-	re.Equal(10, g.Status.AssignmentCount)
-	// Enabled state is preserved across an assignment-count patch.
-	re.True(g.Status.Enabled)
-}
-
 func (suite *metaServiceGroupCLITestSuite) TestSetStatusInvalidInput() {
 	re := suite.Require()
 
@@ -225,16 +209,6 @@ func (suite *metaServiceGroupCLITestSuite) TestSetStatusInvalidInput() {
 	output, err := tests.ExecuteCommand(ctl.GetRootCmd(), "-u", suite.pdAddr, "meta-service-group", "set-enabled", "group-0", "notabool")
 	re.NoError(err)
 	re.Contains(string(output), "Invalid value for enabled flag")
-
-	// Invalid integer for set-assignment-count is reported by the CLI.
-	output, err = tests.ExecuteCommand(ctl.GetRootCmd(), "-u", suite.pdAddr, "meta-service-group", "set-assignment-count", "group-0", "notanint")
-	re.NoError(err)
-	re.Contains(string(output), "Invalid value for assignment count")
-
-	// Negative assignment count is rejected by the server (HTTP 400).
-	output, err = tests.ExecuteCommand(ctl.GetRootCmd(), "-u", suite.pdAddr, "meta-service-group", "set-assignment-count", "--", "group-0", "-1")
-	re.NoError(err)
-	re.Contains(string(output), "assignment count must be non-negative")
 
 	// Patching an unknown group is rejected by the server (HTTP 404).
 	output, err = tests.ExecuteCommand(ctl.GetRootCmd(), "-u", suite.pdAddr, "meta-service-group", "set-enabled", "nonexistent-group", "true")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10892

This is a cherry-pick of <https://github.com/tikv/pd/commit/2baf2a502b864633cd6198a90094033fd28caff4> from the PD microservices branch.

Original author: @AmoebaProtozoa

Problem Summary:

Meta service group status was loaded and persisted through storage on assignment paths. This adds an in-memory status cache and flush loop so assignment count updates can be handled locally and persisted in batches by the serving leader.

### What is changed and how does it work?

- Cache meta-service group status in `MetaServiceGroupManager` and refresh it from storage on initialization/service readiness.
- Update assignment counts in the cached status for group selection, reassignment, rollback, and removal paths.
- Flush dirty cached status to storage periodically or when the dirty threshold is reached, guarded by a leader checker.
- Keep `PatchStatus` synchronous with storage and cache so API updates are immediately visible.
- Adapt the cherry-pick to current master after PR #10904, preserving the current `UpdateGroupsSafely` delete guard and authoritative keyspace assignment scanner.
- Add regression coverage for cache refresh and threshold-triggered flush.

### Check List

Tests

- Unit test

Code changes

- Has persistent data change

Side effects

- No compatibility impact

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Cache meta-service group status and flush assignment count updates to storage in batches.
```

### Validation

- `GOFLAGS=-buildvcs=false make gotest GOTEST_ARGS='./pkg/keyspace -run TestMetaServiceGroupTestSuite -count=1 -timeout=5m'`
- `GOFLAGS=-buildvcs=false make gotest GOTEST_ARGS='./pkg/keyspace -run "TestMetaServiceGroupTestSuite|TestAssignGroupAndSaveKeyspace|TestKeyspaceTestSuite/(TestUpdateKeyspaceState|TestTombstoneKeyspaceUnassignsMetaServiceGroup)" -count=1 -timeout=5m'`
- `GOFLAGS=-buildvcs=false make gotest GOTEST_ARGS='./pkg/keyspace -count=1 -timeout=5m'`
- `GOFLAGS=-buildvcs=false make gotest GOTEST_ARGS='./server -run TestNonExistent -count=0 -timeout=5m'`
- `git diff --check && git diff --cached --check`
- `GOFLAGS=-buildvcs=false make check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cached in-memory meta-service group status with batched persistence and leader-aware flushing.
  * Added the ability to refresh group status from storage and expose whether groups are available.
* **Bug Fixes**
  * Tightened assignment/config concurrency handling to avoid races during group changes, including safer rollback when updates fail after reassignment.
* **Tests**
  * Updated manager initialization to use context/error handling.
  * Added coverage for cache refresh and batched persistence after reaching write thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->