### PR TITLE
server/join: add unit and integration test coverage

### DIFF
--- a/server/join/join_test.go
+++ b/server/join/join_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/server/v3/embed"
+
+	"github.com/tikv/pd/server/config"
+)
+
+// TestIsDataExist covers all three branches of the isDataExist helper:
+// directory does not exist, exists but is empty, and exists with contents.
+func TestIsDataExist(t *testing.T) {
+	re := require.New(t)
+
+	// Non-existent path must return false.
+	re.False(isDataExist("/nonexistent/path/that/does/not/exist"))
+
+	// An existing but empty directory must return false.
+	emptyDir := t.TempDir()
+	re.False(isDataExist(emptyDir))
+
+	// An existing directory that contains at least one entry must return true.
+	nonEmptyDir := t.TempDir()
+	f, err := os.Create(filepath.Join(nonEmptyDir, "test-file"))
+	re.NoError(err)
+	re.NoError(f.Close())
+	re.True(isDataExist(nonEmptyDir))
+}
+
+// TestPrepareJoinClusterEmptyJoin verifies that when cfg.Join is empty the
+// function is a no-op: it returns nil without contacting any cluster.
+func TestPrepareJoinClusterEmptyJoin(t *testing.T) {
+	re := require.New(t)
+	cfg := &config.Config{}
+	re.NoError(PrepareJoinCluster(cfg))
+}
+
+// TestPrepareJoinClusterJoinSelf verifies that a node is not allowed to join
+// itself (Join == AdvertiseClientUrls).
+func TestPrepareJoinClusterJoinSelf(t *testing.T) {
+	re := require.New(t)
+	cfg := &config.Config{}
+	cfg.Join = "http://127.0.0.1:2379"
+	cfg.AdvertiseClientUrls = "http://127.0.0.1:2379"
+
+	err := PrepareJoinCluster(cfg)
+	re.Error(err)
+	re.Contains(err.Error(), "join self is forbidden")
+}
+
+// TestPrepareJoinClusterWithExistingDataDir verifies that when the member data
+// directory already contains data the function immediately sets the cluster
+// state to "existing" with an empty initial-cluster string and returns nil,
+// without dialling the join address.
+func TestPrepareJoinClusterWithExistingDataDir(t *testing.T) {
+	re := require.New(t)
+
+	// Populate <tmpDir>/member/ with a file to simulate an existing data store.
+	tmpDir := t.TempDir()
+	memberDir := filepath.Join(tmpDir, "member")
+	re.NoError(os.MkdirAll(memberDir, privateDirMode))
+	f, err := os.Create(filepath.Join(memberDir, "wal-file"))
+	re.NoError(err)
+	re.NoError(f.Close())
+
+	cfg := &config.Config{}
+	cfg.Join = "http://127.0.0.1:2379"
+	cfg.AdvertiseClientUrls = "http://127.0.0.1:2380"
+	cfg.DataDir = tmpDir
+
+	re.NoError(PrepareJoinCluster(cfg))
+	// etcd reads cluster membership from the data directory, so the initial
+	// cluster string must be empty and the state flag must be "existing".
+	re.Equal("", cfg.InitialCluster)
+	re.Equal(embed.ClusterStateFlagExisting, cfg.InitialClusterState)
+}

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tikv/pd/pkg/utils/etcdutil"
+	"github.com/tikv/pd/pkg/utils/tempurl"
 	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/join"
 	"github.com/tikv/pd/tests"
 )
@@ -159,6 +161,49 @@ func TestFailedPDJoinsPreviousCluster(t *testing.T) {
 	re.NoError(pd2.Stop())
 	re.NoError(pd2.Destroy())
 	re.Error(join.PrepareJoinCluster(pd2.GetConfig()))
+}
+
+// TestJoinWithAbnormalExistingMember verifies that PrepareJoinCluster returns
+// an error when the member list contains a member with an empty Name (MemberAdd
+// succeeded but the node never started) whose peer URLs differ from the peer
+// URLs of the new PD that is trying to join.
+func TestJoinWithAbnormalExistingMember(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	defer cluster.Destroy()
+	re.NoError(err)
+
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+
+	// Add a member but never start it.  It will appear in the member list with
+	// an empty Name — an "abnormal" joined member.
+	pd1 := cluster.GetServer("pd1")
+	client := pd1.GetEtcdClient()
+	abnormalPeerURL := tempurl.Alloc()
+	addResp, err := client.MemberAdd(ctx, []string{abnormalPeerURL})
+	re.NoError(err)
+	re.Len(addResp.Members, 2)
+	defer func() {
+		// Remove the stale member so it does not affect other tests.
+		_, _ = client.MemberRemove(ctx, addResp.Member.ID)
+	}()
+
+	// Build a config that tries to join using a *different* peer URL than the
+	// abnormal member.  PrepareJoinCluster must detect the mismatch and fail.
+	pd1Cfg := pd1.GetConfig()
+	joinerCfg := &config.Config{}
+	joinerCfg.Join = pd1Cfg.AdvertiseClientUrls
+	joinerCfg.AdvertisePeerUrls = tempurl.Alloc() // different from abnormalPeerURL
+	joinerCfg.AdvertiseClientUrls = tempurl.Alloc()
+	joinerCfg.DataDir = t.TempDir()
+
+	err = join.PrepareJoinCluster(joinerCfg)
+	re.Error(err)
+	re.Contains(err.Error(), "that has not joined successfully")
 }
 
 // A PD joins itself.


### PR DESCRIPTION
Add server/join/join_test.go with white-box unit tests for the two previously untested code paths:

- TestIsDataExist: covers all three branches of the isDataExist helper (non-existent directory, empty directory, directory with content).
- TestPrepareJoinClusterEmptyJoin: verifies the no-op path when Join is empty (new initial leader).
- TestPrepareJoinClusterJoinSelf: verifies the 'join self is forbidden' guard.
- TestPrepareJoinClusterWithExistingDataDir: verifies that when the member data directory already has content the function sets InitialCluster to "" and InitialClusterState to "existing" without dialling the join address.

Also add TestJoinWithAbnormalExistingMember to the existing integration test suite (tests/server/join/join_test.go).  It exercises the error path where the member list contains an entry with an empty Name (a node that completed MemberAdd but never started) whose peer URLs differ from those of the new PD attempting to join.

Issue Number: ref #2288

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
