### PR TITLE
server: avoid health API panic before etcd starts

### DIFF
--- a/server/api/health.go
+++ b/server/api/health.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 
 	"github.com/unrolled/render"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/tikv/pd/server"
 	"github.com/tikv/pd/server/cluster"
@@ -50,11 +52,16 @@ func newHealthHandler(svr *server.Server, rd *render.Render) *healthHandler {
 //	@Produce	json
 //	@Success	200	{array}		Health
 //	@Failure	500	{string}	string	"PD server failed to proceed the request."
+//	@Failure	503	{string}	string	"PD server is not ready."
 //	@Router		/health [get]
 func (h *healthHandler) GetHealthStatus(w http.ResponseWriter, _ *http.Request) {
 	client := h.svr.GetClient()
 	members, err := cluster.GetMembers(client)
 	if err != nil {
+		if status.Code(err) == codes.Unavailable {
+			h.rd.JSON(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
 		h.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/server/api/health_test.go
+++ b/server/api/health_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unrolled/render"
+
+	"github.com/tikv/pd/server"
+)
+
+func TestGetHealthStatusReturnsUnavailableWhenEtcdClientNotStarted(t *testing.T) {
+	re := require.New(t)
+	h := newHealthHandler(&server.Server{}, render.New())
+	w := httptest.NewRecorder()
+
+	h.GetHealthStatus(w, httptest.NewRequest(http.MethodGet, "/pd/api/v1/health", http.NoBody))
+
+	re.Equal(http.StatusServiceUnavailable, w.Code)
+	re.Contains(w.Body.String(), "server is started, but etcd not started")
+}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2629,6 +2629,9 @@ func CheckHealth(client *http.Client, members []*pdpb.Member) map[uint64]*pdpb.M
 
 // GetMembers return a slice of Members.
 func GetMembers(etcdClient *clientv3.Client) ([]*pdpb.Member, error) {
+	if etcdClient == nil {
+		return nil, errs.ErrEtcdNotStarted
+	}
 	listResp, err := etcdutil.ListEtcdMembers(etcdClient.Ctx(), etcdClient)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10978

### What is changed and how does it work?

```commit-message
The PD health API can be called while PD is serving HTTP requests but the etcd client is not ready yet. In that state, member lookup could dereference a nil etcd client and panic.

This change makes member lookup return ErrEtcdNotStarted when the etcd client is nil, and makes the health API return HTTP 503 for unavailable startup state instead of HTTP 500 or a process-level panic. It also documents the 503 response in the API annotation.
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

```release-note
Fix a PD health API panic that could happen during cluster startup or restart.
```
