### PR TITLE
test: clean up keyspace kernel mode tests

### DIFF
--- a/pkg/keyspace/keyspace_test.go
+++ b/pkg/keyspace/keyspace_test.go
@@ -33,6 +33,8 @@ import (
 
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/keyspace/constant"
+	"github.com/tikv/pd/pkg/mock/mockcluster"
+	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
@@ -102,7 +104,8 @@ func (suite *keyspaceTestSuite) SetupTest() {
 	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 	allocator := mockid.NewIDAllocator()
 	kgm := NewKeyspaceGroupManager(suite.ctx, store, nil)
-	suite.manager = NewKeyspaceManager(suite.ctx, store, nil, allocator, &mockConfig{}, kgm, nil)
+	cluster := mockcluster.NewCluster(suite.ctx, mockconfig.NewTestOptions())
+	suite.manager = NewKeyspaceManager(suite.ctx, store, cluster, allocator, &mockConfig{}, kgm, nil)
 	re.NoError(kgm.Bootstrap(suite.ctx))
 	re.NoError(suite.manager.Bootstrap())
 }
@@ -250,28 +253,21 @@ func (suite *keyspaceTestSuite) TestGCManagementTypeDefaultValue() {
 	manager := suite.manager
 
 	now := time.Now().Unix()
-	const classic = `return(false)`
-	const nextGen = `return(true)`
-
 	type testCase struct {
-		nextGenFlag      string
 		gcManagementType string
 		expect           string
 	}
 
-	cases := []testCase{
-		{classic, "", ""},
-		{classic, UnifiedGC, UnifiedGC},
-		{classic, KeyspaceLevelGC, KeyspaceLevelGC},
-		{nextGen, "", KeyspaceLevelGC},
-		{nextGen, UnifiedGC, UnifiedGC},
-		{classic, KeyspaceLevelGC, KeyspaceLevelGC},
+	defaultGCManagementType := ""
+	if kerneltype.IsNextGen() {
+		defaultGCManagementType = KeyspaceLevelGC
 	}
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/versioninfo/kerneltype/mockNextGenBuildFlag"))
-	}()
+	cases := []testCase{
+		{"", defaultGCManagementType},
+		{UnifiedGC, UnifiedGC},
+		{KeyspaceLevelGC, KeyspaceLevelGC},
+	}
 	for idx, tc := range cases {
-		re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/versioninfo/kerneltype/mockNextGenBuildFlag", tc.nextGenFlag))
 		cfg := make(map[string]string)
 		if tc.gcManagementType != "" {
 			cfg[GCManagementType] = tc.gcManagementType
@@ -958,7 +954,8 @@ func TestIterateKeyspaces(t *testing.T) {
 		store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
 		allocator := mockid.NewIDAllocator()
 		kgm := NewKeyspaceGroupManager(ctx, store, nil)
-		manager := NewKeyspaceManager(ctx, store, nil, allocator, &mockConfig{}, kgm, nil)
+		cluster := mockcluster.NewCluster(ctx, mockconfig.NewTestOptions())
+		manager := NewKeyspaceManager(ctx, store, cluster, allocator, &mockConfig{}, kgm, nil)
 
 		re.NoError(kgm.Bootstrap(ctx))
 		re.NoError(manager.Bootstrap())

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/pingcap/failpoint"
-
 	"github.com/tikv/pd/pkg/codec"
 	coreconstant "github.com/tikv/pd/pkg/core/constant"
 	"github.com/tikv/pd/pkg/keyspace/constant"
@@ -207,37 +205,23 @@ func TestValidateName(t *testing.T) {
 
 func TestProtectedKeyspaceValidation(t *testing.T) {
 	re := require.New(t)
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/versioninfo/kerneltype/mockNextGenBuildFlag"))
-	}()
-	const classic = `return(false)`
-	const nextGen = `return(true)`
 
 	cases := []struct {
 		name          string
-		nextGenFlag   string
 		idToTest      uint32
 		nameToTest    string
 		expectErrID   bool
 		expectErrName bool
 	}{
-		// classic
-		{"classic_default_id", classic, constant.DefaultKeyspaceID, "", true, false},
-		{"classic_default_name", classic, 1, constant.DefaultKeyspaceName, false, true},
-		{"classic_system_id_allowed", classic, constant.SystemKeyspaceID, "", false, false},
-		{"classic_system_name_allowed", classic, 1, constant.SystemKeyspaceName, false, false},
-		{"classic_normal_case", classic, 100, "normal_keyspace", false, false},
-		// next-gen
-		{"nextgen_system_id", nextGen, constant.SystemKeyspaceID, "", true, false},
-		{"nextgen_system_name", nextGen, 1, constant.SystemKeyspaceName, false, true},
-		{"nextgen_default_id_allowed", nextGen, constant.DefaultKeyspaceID, "", false, false},
-		{"nextgen_default_name_allowed", nextGen, 1, constant.DefaultKeyspaceName, false, false},
-		{"nextgen_normal_case", nextGen, 100, "normal_keyspace", false, false},
+		{"default_id", constant.DefaultKeyspaceID, "", !kerneltype.IsNextGen(), false},
+		{"default_name", 1, constant.DefaultKeyspaceName, false, !kerneltype.IsNextGen()},
+		{"system_id", constant.SystemKeyspaceID, "", kerneltype.IsNextGen(), false},
+		{"system_name", 1, constant.SystemKeyspaceName, false, kerneltype.IsNextGen()},
+		{"normal_case", 100, "normal_keyspace", false, false},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(_ *testing.T) {
-			re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/versioninfo/kerneltype/mockNextGenBuildFlag", c.nextGenFlag))
 			errID := validateID(c.idToTest)
 			if c.expectErrID {
 				re.Error(errID)

--- a/tests/integrations/mcs/keyspace/tso_keyspace_group_test.go
+++ b/tests/integrations/mcs/keyspace/tso_keyspace_group_test.go
@@ -396,6 +396,10 @@ func (suite *keyspaceGroupTestSuite) TestDefaultKeyspaceGroup() {
 	re.Equal(constant.DefaultKeyspaceGroupID, kg.ID)
 	// the allocNodesToAllKeyspaceGroups loop will run every 100ms.
 	testutil.Eventually(re, func() bool {
+		kg, code = suite.tryGetKeyspaceGroup(re, constant.DefaultKeyspaceGroupID)
+		if code != http.StatusOK || kg == nil {
+			return false
+		}
 		return len(kg.Members) == mcs.DefaultKeyspaceGroupReplicaCount
 	})
 	for _, member := range kg.Members {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10989

This PR splits out the keyspace test cleanup portion from the API V3 PD
client work, so later API and TSO routing changes can stay focused.

### What is changed and how does it work?

```commit-message
test: clean up keyspace kernel mode tests

Remove test-only kernel mode failpoint toggles from keyspace tests and derive
the expected behavior from the current kernel type instead. This also wires a
mock cluster into keyspace manager test setup and refreshes keyspace group
state inside an async wait loop to avoid stale test objects.
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- None

Side effects

- None

Related changes

- None

### Release note

```release-note
None.
```
