### PR TITLE
client: use batch-level runtime trace regions (release-8.5)

### DIFF
--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -547,12 +547,15 @@ func (td *tsoDispatcher) processRequests(
 ) error {
 	// `done` must be guaranteed to be eventually called.
 	var (
-		requests     = tbc.getCollectedRequests()
-		traceRegions = make([]*trace.Region, 0, len(requests))
-		spans        = make([]opentracing.Span, 0, len(requests))
+		requests = tbc.getCollectedRequests()
+		spans    = make([]opentracing.Span, 0, len(requests))
 	)
+	traceCtx := context.Background()
+	if len(requests) > 0 {
+		traceCtx = requests[0].requestCtx
+	}
+	traceRegion := trace.StartRegion(traceCtx, "pdclient.tsoReqSendBatch")
 	for _, req := range requests {
-		traceRegions = append(traceRegions, trace.StartRegion(req.requestCtx, "pdclient.tsoReqSend"))
 		if span := opentracing.SpanFromContext(req.requestCtx); span != nil && span.Tracer() != nil {
 			spans = append(spans, span.Tracer().StartSpan("pdclient.processRequests", opentracing.ChildOf(span.Context())))
 		}
@@ -561,9 +564,7 @@ func (td *tsoDispatcher) processRequests(
 		for i := range spans {
 			spans[i].Finish()
 		}
-		for i := range traceRegions {
-			traceRegions[i].End()
-		}
+		traceRegion.End()
 	}()
 
 	var (


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10964

Backport #10965 to `release-8.5-20260709-v8.5.5`.

The original PR fixes invalid Go runtime trace region nesting in PD client batched request paths. Per-request runtime trace regions on one dispatcher goroutine can overlap and make `go tool trace` fail to parse the trace.

### What is changed and how does it work?

Use one batch-level runtime trace region for the TSO dispatcher send path:

- Replace per-request `pdclient.tsoReqSend` runtime regions with one `pdclient.tsoReqSendBatch` region.
- Keep per-request opentracing spans unchanged.

Backport note: the upstream PR also changes `client/clients/router/client.go`, but that router client path does not exist in `release-8.5-20260709-v8.5.5`, so only the TSO dispatcher part applies to this branch.

```commit-message
client: use batch-level runtime trace regions

Use a batch-level runtime trace region for the TSO dispatcher send path to avoid overlapping per-request runtime trace regions on the same goroutine.
```

### Check List

Tests

- Unit test
  - `cd client && go test . -run 'TestTSODispatcherTestSuite/TestBasic' -count=1`
- Manual test (add detailed scripts or steps below)
  - `cd client && go test ./... -run '^$' -count=1`
  - `git diff --check`

Known local baseline note:

- `cd client && go test . -run 'TestTSODispatcherTestSuite/TestConcurrentRPC' -count=1` fails locally with `expected: 4, actual: 1` on both this backport branch and a clean `origin/release-8.5-20260709-v8.5.5` baseline, so this is not introduced by this backport.
- `cd client && go test . -count=1` also has a baseline local failure in `TestServiceClientClientTestSuite/TestServiceClient`.

Code changes

- None

Side effects

- None

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn): None
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup): None
- Need to cherry-pick to the release branch: No

### Release note

```release-note
None.
```
