### PR TITLE
codec, checker: fix enable-cross-table-merge for keyspace keys

### DIFF
--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -106,6 +106,8 @@ func (k Key) TableIdentity() TableIdentity {
 	key, keyspaceID, hasKeyspace := unwrapKeyspace(key)
 	identity := TableIdentity{KeyspaceID: keyspaceID, HasKeyspace: hasKeyspace}
 	if bytes.HasPrefix(key, tablePrefix) {
+		// A truncated table key fails to decode and keeps TableID 0, i.e. it
+		// is treated as a non-table key, matching the historical semantics.
 		_, identity.TableID, _ = DecodeInt(key[len(tablePrefix):])
 	}
 	return identity

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -35,11 +35,12 @@ const (
 	encMarker    = byte(0xFF)
 	encPad       = byte(0x0)
 
-	// Keyspace mode prefixes match pkg/keyspace. They are duplicated here to
-	// avoid an import cycle (keyspace already depends on codec).
-	rawKeyspaceModePrefix = byte('r')
-	txnKeyspaceModePrefix = byte('x')
-	keyspacePrefixLen     = 4
+	// RawKeyspaceModePrefix is the raw keyspace prefix mode byte.
+	RawKeyspaceModePrefix = byte('r')
+	// TxnKeyspaceModePrefix is the txn keyspace prefix mode byte.
+	TxnKeyspaceModePrefix = byte('x')
+	// KeyspacePrefixLen is the raw keyspace prefix length before memcomparable encoding.
+	KeyspacePrefixLen = 4
 )
 
 // Key represents high-level Key type.
@@ -49,14 +50,14 @@ type Key []byte
 // remainder is a TiDB meta/table key. Classic keys and raw keys that only
 // happen to start with 'x'/'r' are left unchanged.
 func stripKeyspacePrefixIfPresent(key []byte) []byte {
-	if len(key) <= keyspacePrefixLen {
+	if len(key) <= KeyspacePrefixLen {
 		return key
 	}
 	mode := key[0]
-	if mode != rawKeyspaceModePrefix && mode != txnKeyspaceModePrefix {
+	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
 		return key
 	}
-	rest := key[keyspacePrefixLen:]
+	rest := key[KeyspacePrefixLen:]
 	if bytes.HasPrefix(rest, tablePrefix) || bytes.HasPrefix(rest, metaPrefix) {
 		return rest
 	}

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -46,30 +46,50 @@ const (
 // Key represents high-level Key type.
 type Key []byte
 
+// MakeKeyspacePrefix constructs the raw keyspace prefix for the given mode and keyspace ID.
+// Keyspace keys encode the lower 24 bits of the keyspace ID after the mode byte.
+func MakeKeyspacePrefix(mode byte, id uint32) []byte {
+	prefix := make([]byte, KeyspacePrefixLen)
+	binary.BigEndian.PutUint32(prefix, id)
+	prefix[0] = mode
+	return prefix
+}
+
+// ParseKeyspacePrefix parses a raw keyspace prefix from key.
+// It returns false for keys that do not start with a known keyspace mode byte.
+func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
+	if len(key) < KeyspacePrefixLen {
+		return 0, 0, false
+	}
+	mode = key[0]
+	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
+		return 0, 0, false
+	}
+	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
+	id = binary.BigEndian.Uint32(idBytes[:])
+	return mode, id, true
+}
+
 // unwrapKeyspace strips the API v2 keyspace prefix (mode byte + 24-bit id)
 // when the remainder is a TiDB meta/table key. Classic keys and raw keys that
 // only happen to start with 'x'/'r' are left unchanged with hasKeyspace false.
 func unwrapKeyspace(key []byte) (payload []byte, keyspaceID uint32, hasKeyspace bool) {
-	if len(key) <= KeyspacePrefixLen {
-		return key, 0, false
-	}
-	mode := key[0]
-	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
+	_, keyspaceID, ok := ParseKeyspacePrefix(key)
+	if !ok {
 		return key, 0, false
 	}
 	rest := key[KeyspacePrefixLen:]
 	if !bytes.HasPrefix(rest, tablePrefix) && !bytes.HasPrefix(rest, metaPrefix) {
 		return key, 0, false
 	}
-	// Lower 24 bits of the keyspace id are encoded after the mode byte.
-	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
-	return rest, binary.BigEndian.Uint32(idBytes[:]), true
+	return rest, keyspaceID, true
 }
 
 // TableIdentity identifies the logical table a key belongs to. HasKeyspace is
 // false for classic TiDB keys, distinguishing them from keyspace 0. TableID is
-// 0 when the key is not a table key (including meta keys). Two keys belong to
-// the same logical table iff their TableIdentity values are equal.
+// 0 when the key is not a table key (including meta keys), so all non-table
+// keys of one keyspace share a single identity. Two table keys belong to the
+// same logical table iff their TableIdentity values are equal.
 type TableIdentity struct {
 	KeyspaceID  uint32
 	TableID     int64

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -70,12 +70,14 @@ func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
 	return mode, id, true
 }
 
-// unwrapKeyspace strips the API v2 keyspace prefix (mode byte + 24-bit id)
-// when the remainder is a TiDB meta/table key. Classic keys and raw keys that
-// only happen to start with 'x'/'r' are left unchanged with hasKeyspace false.
+// unwrapKeyspace strips the API v2 txn keyspace prefix (mode byte + 24-bit id)
+// when the remainder is a TiDB meta/table key. TiDB data only lives under the
+// txn ('x') mode; raw-mode payloads are arbitrary user bytes, so raw keys and
+// keys that only happen to start with 'x' are left unchanged with hasKeyspace
+// false.
 func unwrapKeyspace(key []byte) (payload []byte, keyspaceID uint32, hasKeyspace bool) {
-	_, keyspaceID, ok := ParseKeyspacePrefix(key)
-	if !ok {
+	mode, keyspaceID, ok := ParseKeyspacePrefix(key)
+	if !ok || mode != TxnKeyspaceModePrefix {
 		return key, 0, false
 	}
 	rest := key[KeyspacePrefixLen:]

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -34,18 +34,44 @@ const (
 	encGroupSize = 8
 	encMarker    = byte(0xFF)
 	encPad       = byte(0x0)
+
+	// Keyspace mode prefixes match pkg/keyspace. They are duplicated here to
+	// avoid an import cycle (keyspace already depends on codec).
+	rawKeyspaceModePrefix = byte('r')
+	txnKeyspaceModePrefix = byte('x')
+	keyspacePrefixLen     = 4
 )
 
 // Key represents high-level Key type.
 type Key []byte
 
+// stripKeyspacePrefixIfPresent removes the API v2 keyspace prefix when the
+// remainder is a TiDB meta/table key. Classic keys and raw keys that only
+// happen to start with 'x'/'r' are left unchanged.
+func stripKeyspacePrefixIfPresent(key []byte) []byte {
+	if len(key) <= keyspacePrefixLen {
+		return key
+	}
+	mode := key[0]
+	if mode != rawKeyspaceModePrefix && mode != txnKeyspaceModePrefix {
+		return key
+	}
+	rest := key[keyspacePrefixLen:]
+	if bytes.HasPrefix(rest, tablePrefix) || bytes.HasPrefix(rest, metaPrefix) {
+		return rest
+	}
+	return key
+}
+
 // TableID returns the table ID of the key, if the key is not table key, returns 0.
+// It supports both classic TiDB keys and API v2 keyspace-prefixed keys.
 func (k Key) TableID() int64 {
 	_, key, err := DecodeBytes(k)
 	if err != nil {
 		// should never happen
 		return 0
 	}
+	key = stripKeyspacePrefixIfPresent(key)
 	if !bytes.HasPrefix(key, tablePrefix) {
 		return 0
 	}
@@ -59,11 +85,13 @@ func (k Key) TableID() int64 {
 // If the key is a meta key, it returns true and 0.
 // If the key is a table key, it returns false and table ID.
 // Otherwise, it returns false and 0.
+// It supports both classic TiDB keys and API v2 keyspace-prefixed keys.
 func (k Key) MetaOrTable() (bool, int64) {
 	_, key, err := DecodeBytes(k)
 	if err != nil {
 		return false, 0
 	}
+	key = stripKeyspacePrefixIfPresent(key)
 	if bytes.HasPrefix(key, metaPrefix) {
 		return true, 0
 	}

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -46,39 +46,56 @@ const (
 // Key represents high-level Key type.
 type Key []byte
 
-// stripKeyspacePrefixIfPresent removes the API v2 keyspace prefix when the
-// remainder is a TiDB meta/table key. Classic keys and raw keys that only
-// happen to start with 'x'/'r' are left unchanged.
-func stripKeyspacePrefixIfPresent(key []byte) []byte {
+// unwrapKeyspace removes the API v2 keyspace prefix when the remainder is a
+// TiDB meta/table key. Classic keys and raw keys that only happen to start
+// with 'x'/'r' are left unchanged.
+//
+// hasKeyspace is true only when the prefix is treated as a real keyspace
+// header (mode byte + 24-bit id) and the payload is a TiDB meta/table key.
+// This matches how NextGen encodes tenant data while avoiding false positives
+// on arbitrary raw user keys.
+func unwrapKeyspace(key []byte) (payload []byte, keyspaceID uint32, hasKeyspace bool) {
 	if len(key) <= KeyspacePrefixLen {
-		return key
+		return key, 0, false
 	}
 	mode := key[0]
 	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
-		return key
+		return key, 0, false
 	}
 	rest := key[KeyspacePrefixLen:]
-	if bytes.HasPrefix(rest, tablePrefix) || bytes.HasPrefix(rest, metaPrefix) {
-		return rest
+	if !bytes.HasPrefix(rest, tablePrefix) && !bytes.HasPrefix(rest, metaPrefix) {
+		return key, 0, false
 	}
-	return key
+	// Lower 24 bits of the keyspace id are encoded after the mode byte.
+	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
+	return rest, binary.BigEndian.Uint32(idBytes[:]), true
+}
+
+// TableIdentity returns the keyspace (if any) and table ID of an encoded key.
+// hasKeyspace is false for classic TiDB keys. tableID is 0 when the key is not
+// a table key (including meta keys).
+//
+// Callers that need tenant-safe equality should compare both hasKeyspace/keyspaceID
+// and tableID; TableID() alone is not sufficient across keyspaces.
+func (k Key) TableIdentity() (keyspaceID uint32, tableID int64, hasKeyspace bool) {
+	_, key, err := DecodeBytes(k)
+	if err != nil {
+		// should never happen for region boundary keys produced by TiKV
+		return 0, 0, false
+	}
+	key, keyspaceID, hasKeyspace = unwrapKeyspace(key)
+	if !bytes.HasPrefix(key, tablePrefix) {
+		return keyspaceID, 0, hasKeyspace
+	}
+	_, tableID, _ = DecodeInt(key[len(tablePrefix):])
+	return keyspaceID, tableID, hasKeyspace
 }
 
 // TableID returns the table ID of the key, if the key is not table key, returns 0.
 // It supports both classic TiDB keys and API v2 keyspace-prefixed keys.
+// For equality across tenants, use TableIdentity instead.
 func (k Key) TableID() int64 {
-	_, key, err := DecodeBytes(k)
-	if err != nil {
-		// should never happen
-		return 0
-	}
-	key = stripKeyspacePrefixIfPresent(key)
-	if !bytes.HasPrefix(key, tablePrefix) {
-		return 0
-	}
-	key = key[len(tablePrefix):]
-
-	_, tableID, _ := DecodeInt(key)
+	_, tableID, _ := k.TableIdentity()
 	return tableID
 }
 
@@ -92,13 +109,12 @@ func (k Key) MetaOrTable() (bool, int64) {
 	if err != nil {
 		return false, 0
 	}
-	key = stripKeyspacePrefixIfPresent(key)
+	key, _, _ = unwrapKeyspace(key)
 	if bytes.HasPrefix(key, metaPrefix) {
 		return true, 0
 	}
 	if bytes.HasPrefix(key, tablePrefix) {
-		key = key[len(tablePrefix):]
-		_, tableID, _ := DecodeInt(key)
+		_, tableID, _ := DecodeInt(key[len(tablePrefix):])
 		return false, tableID
 	}
 	return false, 0

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -91,12 +91,6 @@ func (k Key) TableIdentity() TableIdentity {
 	return identity
 }
 
-// TableID returns the table ID of the key, if the key is not table key, returns 0.
-// It supports both classic TiDB keys and API v2 keyspace-prefixed keys.
-func (k Key) TableID() int64 {
-	return k.TableIdentity().TableID
-}
-
 // MetaOrTable checks if the key is a meta key or table key.
 // If the key is a meta key, it returns true and 0.
 // If the key is a table key, it returns false and table ID.

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -46,14 +46,9 @@ const (
 // Key represents high-level Key type.
 type Key []byte
 
-// unwrapKeyspace removes the API v2 keyspace prefix when the remainder is a
-// TiDB meta/table key. Classic keys and raw keys that only happen to start
-// with 'x'/'r' are left unchanged.
-//
-// hasKeyspace is true only when the prefix is treated as a real keyspace
-// header (mode byte + 24-bit id) and the payload is a TiDB meta/table key.
-// This matches how NextGen encodes tenant data while avoiding false positives
-// on arbitrary raw user keys.
+// unwrapKeyspace strips the API v2 keyspace prefix (mode byte + 24-bit id)
+// when the remainder is a TiDB meta/table key. Classic keys and raw keys that
+// only happen to start with 'x'/'r' are left unchanged with hasKeyspace false.
 func unwrapKeyspace(key []byte) (payload []byte, keyspaceID uint32, hasKeyspace bool) {
 	if len(key) <= KeyspacePrefixLen {
 		return key, 0, false
@@ -71,32 +66,35 @@ func unwrapKeyspace(key []byte) (payload []byte, keyspaceID uint32, hasKeyspace 
 	return rest, binary.BigEndian.Uint32(idBytes[:]), true
 }
 
-// TableIdentity returns the keyspace (if any) and table ID of an encoded key.
-// hasKeyspace is false for classic TiDB keys. tableID is 0 when the key is not
-// a table key (including meta keys).
-//
-// Callers that need tenant-safe equality should compare both hasKeyspace/keyspaceID
-// and tableID; TableID() alone is not sufficient across keyspaces.
-func (k Key) TableIdentity() (keyspaceID uint32, tableID int64, hasKeyspace bool) {
+// TableIdentity identifies the logical table a key belongs to. HasKeyspace is
+// false for classic TiDB keys, distinguishing them from keyspace 0. TableID is
+// 0 when the key is not a table key (including meta keys). Two keys belong to
+// the same logical table iff their TableIdentity values are equal.
+type TableIdentity struct {
+	KeyspaceID  uint32
+	TableID     int64
+	HasKeyspace bool
+}
+
+// TableIdentity returns the keyspace-qualified table identity of an encoded key.
+func (k Key) TableIdentity() TableIdentity {
 	_, key, err := DecodeBytes(k)
 	if err != nil {
 		// should never happen for region boundary keys produced by TiKV
-		return 0, 0, false
+		return TableIdentity{}
 	}
-	key, keyspaceID, hasKeyspace = unwrapKeyspace(key)
-	if !bytes.HasPrefix(key, tablePrefix) {
-		return keyspaceID, 0, hasKeyspace
+	key, keyspaceID, hasKeyspace := unwrapKeyspace(key)
+	identity := TableIdentity{KeyspaceID: keyspaceID, HasKeyspace: hasKeyspace}
+	if bytes.HasPrefix(key, tablePrefix) {
+		_, identity.TableID, _ = DecodeInt(key[len(tablePrefix):])
 	}
-	_, tableID, _ = DecodeInt(key[len(tablePrefix):])
-	return keyspaceID, tableID, hasKeyspace
+	return identity
 }
 
 // TableID returns the table ID of the key, if the key is not table key, returns 0.
 // It supports both classic TiDB keys and API v2 keyspace-prefixed keys.
-// For equality across tenants, use TableIdentity instead.
 func (k Key) TableID() int64 {
-	_, tableID, _ := k.TableIdentity()
-	return tableID
+	return k.TableIdentity().TableID
 }
 
 // MetaOrTable checks if the key is a meta key or table key.

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -15,7 +15,6 @@
 package codec
 
 import (
-	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,7 +63,7 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 	re.Equal(TableIdentity{TableID: tableID}, classic.TableIdentity())
 
 	for _, mode := range []byte{TxnKeyspaceModePrefix, RawKeyspaceModePrefix} {
-		prefix := makeKeyspacePrefix(mode, keyspaceID)
+		prefix := MakeKeyspacePrefix(mode, keyspaceID)
 		identity := TableIdentity{KeyspaceID: keyspaceID, TableID: tableID, HasKeyspace: true}
 		encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
 		re.Equal(identity, encoded.TableIdentity(), "mode=%q", mode)
@@ -81,8 +80,8 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 	}
 
 	// Same numeric table id under different keyspaces is a different identity.
-	ks1 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 1), GenerateTableKey(tableID)...))
-	ks2 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 2), GenerateTableKey(tableID)...))
+	ks1 := EncodeBytes(append(MakeKeyspacePrefix(TxnKeyspaceModePrefix, 1), GenerateTableKey(tableID)...))
+	ks2 := EncodeBytes(append(MakeKeyspacePrefix(TxnKeyspaceModePrefix, 2), GenerateTableKey(tableID)...))
 	re.Equal(ks1.TableIdentity().TableID, ks2.TableIdentity().TableID)
 	re.NotEqual(ks1.TableIdentity(), ks2.TableIdentity())
 
@@ -96,7 +95,7 @@ func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {
 	re := require.New(t)
 	tableID := int64(55)
 	keyspaceID := uint32(7)
-	prefix := makeKeyspacePrefix(TxnKeyspaceModePrefix, keyspaceID)
+	prefix := MakeKeyspacePrefix(TxnKeyspaceModePrefix, keyspaceID)
 
 	isMeta, id := EncodeBytes(append(append([]byte{}, prefix...), metaPrefix...)).MetaOrTable()
 	re.True(isMeta)
@@ -111,11 +110,32 @@ func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {
 	re.Equal(int64(0), id)
 }
 
-func makeKeyspacePrefix(mode byte, id uint32) []byte {
-	prefix := make([]byte, KeyspacePrefixLen)
-	binary.BigEndian.PutUint32(prefix, id)
-	prefix[0] = mode
-	return prefix
+func TestMakeKeyspacePrefix(t *testing.T) {
+	re := require.New(t)
+	re.Equal([]byte{'r', 0x01, 0x02, 0x03}, MakeKeyspacePrefix(RawKeyspaceModePrefix, 0x010203))
+	// Only the lower 24 bits of the keyspace ID are encoded.
+	re.Equal([]byte{'x', 0xff, 0xff, 0xff}, MakeKeyspacePrefix(TxnKeyspaceModePrefix, 0xffffff))
+}
+
+func TestParseKeyspacePrefix(t *testing.T) {
+	re := require.New(t)
+
+	mode, id, ok := ParseKeyspacePrefix([]byte{'r', 0x01, 0x02, 0x03})
+	re.True(ok)
+	re.Equal(RawKeyspaceModePrefix, mode)
+	re.Equal(uint32(0x010203), id)
+
+	mode, id, ok = ParseKeyspacePrefix([]byte{'x', 0xff, 0xff, 0xff, 't'})
+	re.True(ok)
+	re.Equal(TxnKeyspaceModePrefix, mode)
+	re.Equal(uint32(0xffffff), id)
+
+	// Too short.
+	_, _, ok = ParseKeyspacePrefix([]byte{'x', 0x01, 0x02})
+	re.False(ok)
+	// Unknown mode byte.
+	_, _, ok = ParseKeyspacePrefix([]byte{'t', 0x01, 0x02, 0x03})
+	re.False(ok)
 }
 
 func TestGenerateRecordAndIndexKeys(t *testing.T) {

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -63,7 +63,7 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 	classic := EncodeBytes(GenerateTableKey(tableID))
 	re.Equal(tableID, classic.TableID())
 
-	for _, mode := range []byte{txnKeyspaceModePrefix, rawKeyspaceModePrefix} {
+	for _, mode := range []byte{TxnKeyspaceModePrefix, RawKeyspaceModePrefix} {
 		prefix := makeKeyspacePrefix(mode, keyspaceID)
 		encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
 		re.Equal(tableID, encoded.TableID(), "mode=%q", mode)
@@ -89,7 +89,7 @@ func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {
 	re := require.New(t)
 	tableID := int64(55)
 	keyspaceID := uint32(7)
-	prefix := makeKeyspacePrefix(txnKeyspaceModePrefix, keyspaceID)
+	prefix := makeKeyspacePrefix(TxnKeyspaceModePrefix, keyspaceID)
 
 	isMeta, id := EncodeBytes(append(append([]byte{}, prefix...), metaPrefix...)).MetaOrTable()
 	re.True(isMeta)
@@ -105,7 +105,7 @@ func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {
 }
 
 func makeKeyspacePrefix(mode byte, id uint32) []byte {
-	prefix := make([]byte, keyspacePrefixLen)
+	prefix := make([]byte, KeyspacePrefixLen)
 	binary.BigEndian.PutUint32(prefix, id)
 	prefix[0] = mode
 	return prefix

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -62,27 +62,49 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 
 	classic := EncodeBytes(GenerateTableKey(tableID))
 	re.Equal(tableID, classic.TableID())
+	ks, tid, hasKS := classic.TableIdentity()
+	re.False(hasKS)
+	re.Equal(uint32(0), ks)
+	re.Equal(tableID, tid)
 
 	for _, mode := range []byte{TxnKeyspaceModePrefix, RawKeyspaceModePrefix} {
 		prefix := makeKeyspacePrefix(mode, keyspaceID)
 		encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
 		re.Equal(tableID, encoded.TableID(), "mode=%q", mode)
+		ks, tid, hasKS = encoded.TableIdentity()
+		re.True(hasKS, "mode=%q", mode)
+		re.Equal(keyspaceID, ks, "mode=%q", mode)
+		re.Equal(tableID, tid, "mode=%q", mode)
 
 		other := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(otherTableID)...))
 		re.Equal(otherTableID, other.TableID(), "mode=%q", mode)
 		re.NotEqual(encoded.TableID(), other.TableID(), "mode=%q", mode)
 
-		// Same table: record and index keys must still resolve to the same table ID.
+		// Same table: record and index keys must still resolve to the same identity.
 		record := EncodeBytes(append(append([]byte{}, prefix...), GenerateRowKey(tableID, 1)...))
 		index := EncodeBytes(append(append([]byte{}, prefix...), GenerateIndexKey(tableID, 7)...))
 		re.Equal(tableID, record.TableID(), "mode=%q", mode)
 		re.Equal(tableID, index.TableID(), "mode=%q", mode)
+		_, _, hasKS = record.TableIdentity()
+		re.True(hasKS, "mode=%q", mode)
 	}
+
+	// Same numeric table id under different keyspaces is a different identity.
+	ks1 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 1), GenerateTableKey(tableID)...))
+	ks2 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 2), GenerateTableKey(tableID)...))
+	re.Equal(ks1.TableID(), ks2.TableID())
+	ksA, tA, hasA := ks1.TableIdentity()
+	ksB, tB, hasB := ks2.TableIdentity()
+	re.True(hasA && hasB)
+	re.Equal(tA, tB)
+	re.NotEqual(ksA, ksB)
 
 	// A raw key that only happens to start with the keyspace mode byte but is
 	// not followed by a TiDB table/meta payload must not be treated as a table key.
 	ambiguous := EncodeBytes([]byte{'x', 0x00, 0x00, 0x2a, 'u', 's', 'e', 'r'})
 	re.Equal(int64(0), ambiguous.TableID())
+	_, _, hasKS = ambiguous.TableIdentity()
+	re.False(hasKS)
 }
 
 func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -39,19 +39,19 @@ func TestDecodeBytes(t *testing.T) {
 func TestTableID(t *testing.T) {
 	re := require.New(t)
 	key := EncodeBytes([]byte("t\x80\x00\x00\x00\x00\x00\x00\xff"))
-	re.Equal(int64(0xff), key.TableID())
+	re.Equal(int64(0xff), key.TableIdentity().TableID)
 
 	key = EncodeBytes([]byte("t\x80\x00\x00\x00\x00\x00\x00\xff_i\x01\x02"))
-	re.Equal(int64(0xff), key.TableID())
+	re.Equal(int64(0xff), key.TableIdentity().TableID)
 
 	key = []byte("t\x80\x00\x00\x00\x00\x00\x00\xff")
-	re.Equal(int64(0), key.TableID())
+	re.Equal(int64(0), key.TableIdentity().TableID)
 
 	key = EncodeBytes([]byte("T\x00\x00\x00\x00\x00\x00\x00\xff"))
-	re.Equal(int64(0), key.TableID())
+	re.Equal(int64(0), key.TableIdentity().TableID)
 
 	key = EncodeBytes([]byte("t\x80\x00\x00\x00\x00\x00\xff"))
-	re.Equal(int64(0), key.TableID())
+	re.Equal(int64(0), key.TableIdentity().TableID)
 }
 
 func TestTableIDWithKeyspacePrefix(t *testing.T) {
@@ -61,18 +61,16 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 	keyspaceID := uint32(42)
 
 	classic := EncodeBytes(GenerateTableKey(tableID))
-	re.Equal(tableID, classic.TableID())
 	re.Equal(TableIdentity{TableID: tableID}, classic.TableIdentity())
 
 	for _, mode := range []byte{TxnKeyspaceModePrefix, RawKeyspaceModePrefix} {
 		prefix := makeKeyspacePrefix(mode, keyspaceID)
 		identity := TableIdentity{KeyspaceID: keyspaceID, TableID: tableID, HasKeyspace: true}
 		encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
-		re.Equal(tableID, encoded.TableID(), "mode=%q", mode)
 		re.Equal(identity, encoded.TableIdentity(), "mode=%q", mode)
 
 		other := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(otherTableID)...))
-		re.Equal(otherTableID, other.TableID(), "mode=%q", mode)
+		re.Equal(otherTableID, other.TableIdentity().TableID, "mode=%q", mode)
 		re.NotEqual(encoded.TableIdentity(), other.TableIdentity(), "mode=%q", mode)
 
 		// Same table: record and index keys must still resolve to the same identity.
@@ -85,7 +83,7 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 	// Same numeric table id under different keyspaces is a different identity.
 	ks1 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 1), GenerateTableKey(tableID)...))
 	ks2 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 2), GenerateTableKey(tableID)...))
-	re.Equal(ks1.TableID(), ks2.TableID())
+	re.Equal(ks1.TableIdentity().TableID, ks2.TableIdentity().TableID)
 	re.NotEqual(ks1.TableIdentity(), ks2.TableIdentity())
 
 	// A raw key that only happens to start with the keyspace mode byte but is
@@ -128,11 +126,11 @@ func TestGenerateRecordAndIndexKeys(t *testing.T) {
 	rowKeyPrefix := GenerateRecordKeyPrefix(tableID)
 	rowKey := GenerateRowKey(tableID, 1)
 	re.Equal(rowKeyPrefix, rowKey[:len(rowKeyPrefix)])
-	re.Equal(tableID, EncodeBytes(rowKey).TableID())
+	re.Equal(tableID, EncodeBytes(rowKey).TableIdentity().TableID)
 
 	indexKey := GenerateIndexKey(tableID, indexID)
 	_, decodedIndexKey, err := DecodeBytes(EncodeBytes(indexKey))
 	re.NoError(err)
 	re.Equal(indexKey, decodedIndexKey)
-	re.Equal(tableID, EncodeBytes(indexKey).TableID())
+	re.Equal(tableID, EncodeBytes(indexKey).TableIdentity().TableID)
 }

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -15,6 +15,7 @@
 package codec
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,63 @@ func TestTableID(t *testing.T) {
 
 	key = EncodeBytes([]byte("t\x80\x00\x00\x00\x00\x00\xff"))
 	re.Equal(int64(0), key.TableID())
+}
+
+func TestTableIDWithKeyspacePrefix(t *testing.T) {
+	re := require.New(t)
+	tableID := int64(100)
+	otherTableID := int64(200)
+	keyspaceID := uint32(42)
+
+	classic := EncodeBytes(GenerateTableKey(tableID))
+	re.Equal(tableID, classic.TableID())
+
+	for _, mode := range []byte{txnKeyspaceModePrefix, rawKeyspaceModePrefix} {
+		prefix := makeKeyspacePrefix(mode, keyspaceID)
+		encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
+		re.Equal(tableID, encoded.TableID(), "mode=%q", mode)
+
+		other := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(otherTableID)...))
+		re.Equal(otherTableID, other.TableID(), "mode=%q", mode)
+		re.NotEqual(encoded.TableID(), other.TableID(), "mode=%q", mode)
+
+		// Same table: record and index keys must still resolve to the same table ID.
+		record := EncodeBytes(append(append([]byte{}, prefix...), GenerateRowKey(tableID, 1)...))
+		index := EncodeBytes(append(append([]byte{}, prefix...), GenerateIndexKey(tableID, 7)...))
+		re.Equal(tableID, record.TableID(), "mode=%q", mode)
+		re.Equal(tableID, index.TableID(), "mode=%q", mode)
+	}
+
+	// A raw key that only happens to start with the keyspace mode byte but is
+	// not followed by a TiDB table/meta payload must not be treated as a table key.
+	ambiguous := EncodeBytes([]byte{'x', 0x00, 0x00, 0x2a, 'u', 's', 'e', 'r'})
+	re.Equal(int64(0), ambiguous.TableID())
+}
+
+func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {
+	re := require.New(t)
+	tableID := int64(55)
+	keyspaceID := uint32(7)
+	prefix := makeKeyspacePrefix(txnKeyspaceModePrefix, keyspaceID)
+
+	isMeta, id := EncodeBytes(append(append([]byte{}, prefix...), metaPrefix...)).MetaOrTable()
+	re.True(isMeta)
+	re.Equal(int64(0), id)
+
+	isMeta, id = EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...)).MetaOrTable()
+	re.False(isMeta)
+	re.Equal(tableID, id)
+
+	isMeta, id = EncodeBytes([]byte("hello")).MetaOrTable()
+	re.False(isMeta)
+	re.Equal(int64(0), id)
+}
+
+func makeKeyspacePrefix(mode byte, id uint32) []byte {
+	prefix := make([]byte, keyspacePrefixLen)
+	binary.BigEndian.PutUint32(prefix, id)
+	prefix[0] = mode
+	return prefix
 }
 
 func TestGenerateRecordAndIndexKeys(t *testing.T) {

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -62,22 +62,20 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 	classic := EncodeBytes(GenerateTableKey(tableID))
 	re.Equal(TableIdentity{TableID: tableID}, classic.TableIdentity())
 
-	for _, mode := range []byte{TxnKeyspaceModePrefix, RawKeyspaceModePrefix} {
-		prefix := MakeKeyspacePrefix(mode, keyspaceID)
-		identity := TableIdentity{KeyspaceID: keyspaceID, TableID: tableID, HasKeyspace: true}
-		encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
-		re.Equal(identity, encoded.TableIdentity(), "mode=%q", mode)
+	prefix := MakeKeyspacePrefix(TxnKeyspaceModePrefix, keyspaceID)
+	identity := TableIdentity{KeyspaceID: keyspaceID, TableID: tableID, HasKeyspace: true}
+	encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
+	re.Equal(identity, encoded.TableIdentity())
 
-		other := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(otherTableID)...))
-		re.Equal(otherTableID, other.TableIdentity().TableID, "mode=%q", mode)
-		re.NotEqual(encoded.TableIdentity(), other.TableIdentity(), "mode=%q", mode)
+	other := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(otherTableID)...))
+	re.Equal(otherTableID, other.TableIdentity().TableID)
+	re.NotEqual(encoded.TableIdentity(), other.TableIdentity())
 
-		// Same table: record and index keys must still resolve to the same identity.
-		record := EncodeBytes(append(append([]byte{}, prefix...), GenerateRowKey(tableID, 1)...))
-		index := EncodeBytes(append(append([]byte{}, prefix...), GenerateIndexKey(tableID, 7)...))
-		re.Equal(identity, record.TableIdentity(), "mode=%q", mode)
-		re.Equal(identity, index.TableIdentity(), "mode=%q", mode)
-	}
+	// Same table: record and index keys must still resolve to the same identity.
+	record := EncodeBytes(append(append([]byte{}, prefix...), GenerateRowKey(tableID, 1)...))
+	index := EncodeBytes(append(append([]byte{}, prefix...), GenerateIndexKey(tableID, 7)...))
+	re.Equal(identity, record.TableIdentity())
+	re.Equal(identity, index.TableIdentity())
 
 	// Same numeric table id under different keyspaces is a different identity.
 	ks1 := EncodeBytes(append(MakeKeyspacePrefix(TxnKeyspaceModePrefix, 1), GenerateTableKey(tableID)...))
@@ -85,10 +83,15 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 	re.Equal(ks1.TableIdentity().TableID, ks2.TableIdentity().TableID)
 	re.NotEqual(ks1.TableIdentity(), ks2.TableIdentity())
 
-	// A raw key that only happens to start with the keyspace mode byte but is
-	// not followed by a TiDB table/meta payload must not be treated as a table key.
+	// A raw key that only happens to start with the txn mode byte but is not
+	// followed by a TiDB table/meta payload must not be treated as a table key.
 	ambiguous := EncodeBytes([]byte{'x', 0x00, 0x00, 0x2a, 'u', 's', 'e', 'r'})
 	re.Equal(TableIdentity{}, ambiguous.TableIdentity())
+
+	// TiDB data only lives under the txn mode: a raw-mode keyspace key whose
+	// payload happens to look like a table key gets no table identity.
+	rawMode := EncodeBytes(append(MakeKeyspacePrefix(RawKeyspaceModePrefix, keyspaceID), GenerateTableKey(tableID)...))
+	re.Equal(TableIdentity{}, rawMode.TableIdentity())
 }
 
 func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -62,49 +62,36 @@ func TestTableIDWithKeyspacePrefix(t *testing.T) {
 
 	classic := EncodeBytes(GenerateTableKey(tableID))
 	re.Equal(tableID, classic.TableID())
-	ks, tid, hasKS := classic.TableIdentity()
-	re.False(hasKS)
-	re.Equal(uint32(0), ks)
-	re.Equal(tableID, tid)
+	re.Equal(TableIdentity{TableID: tableID}, classic.TableIdentity())
 
 	for _, mode := range []byte{TxnKeyspaceModePrefix, RawKeyspaceModePrefix} {
 		prefix := makeKeyspacePrefix(mode, keyspaceID)
+		identity := TableIdentity{KeyspaceID: keyspaceID, TableID: tableID, HasKeyspace: true}
 		encoded := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(tableID)...))
 		re.Equal(tableID, encoded.TableID(), "mode=%q", mode)
-		ks, tid, hasKS = encoded.TableIdentity()
-		re.True(hasKS, "mode=%q", mode)
-		re.Equal(keyspaceID, ks, "mode=%q", mode)
-		re.Equal(tableID, tid, "mode=%q", mode)
+		re.Equal(identity, encoded.TableIdentity(), "mode=%q", mode)
 
 		other := EncodeBytes(append(append([]byte{}, prefix...), GenerateTableKey(otherTableID)...))
 		re.Equal(otherTableID, other.TableID(), "mode=%q", mode)
-		re.NotEqual(encoded.TableID(), other.TableID(), "mode=%q", mode)
+		re.NotEqual(encoded.TableIdentity(), other.TableIdentity(), "mode=%q", mode)
 
 		// Same table: record and index keys must still resolve to the same identity.
 		record := EncodeBytes(append(append([]byte{}, prefix...), GenerateRowKey(tableID, 1)...))
 		index := EncodeBytes(append(append([]byte{}, prefix...), GenerateIndexKey(tableID, 7)...))
-		re.Equal(tableID, record.TableID(), "mode=%q", mode)
-		re.Equal(tableID, index.TableID(), "mode=%q", mode)
-		_, _, hasKS = record.TableIdentity()
-		re.True(hasKS, "mode=%q", mode)
+		re.Equal(identity, record.TableIdentity(), "mode=%q", mode)
+		re.Equal(identity, index.TableIdentity(), "mode=%q", mode)
 	}
 
 	// Same numeric table id under different keyspaces is a different identity.
 	ks1 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 1), GenerateTableKey(tableID)...))
 	ks2 := EncodeBytes(append(makeKeyspacePrefix(TxnKeyspaceModePrefix, 2), GenerateTableKey(tableID)...))
 	re.Equal(ks1.TableID(), ks2.TableID())
-	ksA, tA, hasA := ks1.TableIdentity()
-	ksB, tB, hasB := ks2.TableIdentity()
-	re.True(hasA && hasB)
-	re.Equal(tA, tB)
-	re.NotEqual(ksA, ksB)
+	re.NotEqual(ks1.TableIdentity(), ks2.TableIdentity())
 
 	// A raw key that only happens to start with the keyspace mode byte but is
 	// not followed by a TiDB table/meta payload must not be treated as a table key.
 	ambiguous := EncodeBytes([]byte{'x', 0x00, 0x00, 0x2a, 'u', 's', 'e', 'r'})
-	re.Equal(int64(0), ambiguous.TableID())
-	_, _, hasKS = ambiguous.TableIdentity()
-	re.False(hasKS)
+	re.Equal(TableIdentity{}, ambiguous.TableIdentity())
 }
 
 func TestMetaOrTableWithKeyspacePrefix(t *testing.T) {

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -42,15 +42,6 @@ const (
 	namePattern = "^[-A-Za-z0-9_]{1,20}$"
 )
 
-const (
-	// RawKeyspaceModePrefix is the raw keyspace prefix mode byte.
-	RawKeyspaceModePrefix = byte('r')
-	// TxnKeyspaceModePrefix is the txn keyspace prefix mode byte.
-	TxnKeyspaceModePrefix = byte('x')
-	// KeyspacePrefixLen is the raw keyspace prefix length before memcomparable encoding.
-	KeyspacePrefixLen = 4
-)
-
 var (
 	errNoAvailableMetaServiceGroups = errors.New("no available meta-service groups")
 
@@ -120,7 +111,7 @@ func MaskKeyspaceID(id uint32) uint32 {
 // MakeKeyspacePrefix constructs the raw keyspace prefix for the given mode and keyspace ID.
 // Keyspace keys encode the lower 24 bits of the keyspace ID after the mode byte.
 func MakeKeyspacePrefix(mode byte, id uint32) []byte {
-	prefix := make([]byte, KeyspacePrefixLen)
+	prefix := make([]byte, codec.KeyspacePrefixLen)
 	binary.BigEndian.PutUint32(prefix, id)
 	prefix[0] = mode
 	return prefix
@@ -129,14 +120,14 @@ func MakeKeyspacePrefix(mode byte, id uint32) []byte {
 // ParseKeyspacePrefix parses a raw keyspace prefix from key.
 // It returns false for keys that do not start with a known keyspace mode byte.
 func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
-	if len(key) < KeyspacePrefixLen {
+	if len(key) < codec.KeyspacePrefixLen {
 		return 0, 0, false
 	}
 	mode = key[0]
-	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
+	if mode != codec.RawKeyspaceModePrefix && mode != codec.TxnKeyspaceModePrefix {
 		return 0, 0, false
 	}
-	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
+	idBytes := [codec.KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
 	id = binary.BigEndian.Uint32(idBytes[:])
 	return mode, id, true
 }
@@ -194,10 +185,10 @@ func keyTypeStringToRegionBoundType(keyType string) regionBoundType {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	rawLeftBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id)
-	rawRightBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id+1)
-	txnLeftBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id)
-	txnRightBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id+1)
+	rawLeftBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id)
+	rawRightBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id+1)
+	txnLeftBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id)
+	txnRightBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id+1)
 	if id == constant.MaxValidKeyspaceID {
 		// The right bound is an exclusive fencepost, not a real keyspace prefix.
 		rawRightBound = []byte{'s', 0, 0, 0}

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -40,6 +40,15 @@ const (
 	// numbers (0-9), hyphens (-), and underscores (_).
 	// currently, we enforce this rule to keyspace_name.
 	namePattern = "^[-A-Za-z0-9_]{1,20}$"
+
+	// Keyspace key-format constants live in pkg/codec (single source of truth).
+	// Re-export here so existing keyspace callers keep a stable import path.
+	// RawKeyspaceModePrefix is the raw keyspace prefix mode byte.
+	RawKeyspaceModePrefix = codec.RawKeyspaceModePrefix
+	// TxnKeyspaceModePrefix is the txn keyspace prefix mode byte.
+	TxnKeyspaceModePrefix = codec.TxnKeyspaceModePrefix
+	// KeyspacePrefixLen is the raw keyspace prefix length before memcomparable encoding.
+	KeyspacePrefixLen = codec.KeyspacePrefixLen
 )
 
 var (
@@ -111,7 +120,7 @@ func MaskKeyspaceID(id uint32) uint32 {
 // MakeKeyspacePrefix constructs the raw keyspace prefix for the given mode and keyspace ID.
 // Keyspace keys encode the lower 24 bits of the keyspace ID after the mode byte.
 func MakeKeyspacePrefix(mode byte, id uint32) []byte {
-	prefix := make([]byte, codec.KeyspacePrefixLen)
+	prefix := make([]byte, KeyspacePrefixLen)
 	binary.BigEndian.PutUint32(prefix, id)
 	prefix[0] = mode
 	return prefix
@@ -120,14 +129,14 @@ func MakeKeyspacePrefix(mode byte, id uint32) []byte {
 // ParseKeyspacePrefix parses a raw keyspace prefix from key.
 // It returns false for keys that do not start with a known keyspace mode byte.
 func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
-	if len(key) < codec.KeyspacePrefixLen {
+	if len(key) < KeyspacePrefixLen {
 		return 0, 0, false
 	}
 	mode = key[0]
-	if mode != codec.RawKeyspaceModePrefix && mode != codec.TxnKeyspaceModePrefix {
+	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
 		return 0, 0, false
 	}
-	idBytes := [codec.KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
+	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
 	id = binary.BigEndian.Uint32(idBytes[:])
 	return mode, id, true
 }
@@ -185,10 +194,10 @@ func keyTypeStringToRegionBoundType(keyType string) regionBoundType {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	rawLeftBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id)
-	rawRightBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id+1)
-	txnLeftBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id)
-	txnRightBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id+1)
+	rawLeftBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id)
+	rawRightBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id+1)
+	txnLeftBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id)
+	txnRightBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id+1)
 	if id == constant.MaxValidKeyspaceID {
 		// The right bound is an exclusive fencepost, not a real keyspace prefix.
 		rawRightBound = []byte{'s', 0, 0, 0}

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -16,7 +16,6 @@ package keyspace
 
 import (
 	"container/heap"
-	"encoding/binary"
 	"encoding/hex"
 	"regexp"
 	"strconv"
@@ -108,30 +107,6 @@ func MaskKeyspaceID(id uint32) uint32 {
 	return id & 0xFF
 }
 
-// MakeKeyspacePrefix constructs the raw keyspace prefix for the given mode and keyspace ID.
-// Keyspace keys encode the lower 24 bits of the keyspace ID after the mode byte.
-func MakeKeyspacePrefix(mode byte, id uint32) []byte {
-	prefix := make([]byte, codec.KeyspacePrefixLen)
-	binary.BigEndian.PutUint32(prefix, id)
-	prefix[0] = mode
-	return prefix
-}
-
-// ParseKeyspacePrefix parses a raw keyspace prefix from key.
-// It returns false for keys that do not start with a known keyspace mode byte.
-func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
-	if len(key) < codec.KeyspacePrefixLen {
-		return 0, 0, false
-	}
-	mode = key[0]
-	if mode != codec.RawKeyspaceModePrefix && mode != codec.TxnKeyspaceModePrefix {
-		return 0, 0, false
-	}
-	idBytes := [codec.KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
-	id = binary.BigEndian.Uint32(idBytes[:])
-	return mode, id, true
-}
-
 // RegionBound represents the region boundary of the given keyspace.
 // For a keyspace with id ['a', 'b', 'c'], it has four boundaries:
 //
@@ -185,10 +160,10 @@ func keyTypeStringToRegionBoundType(keyType string) regionBoundType {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	rawLeftBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id)
-	rawRightBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id+1)
-	txnLeftBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id)
-	txnRightBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id+1)
+	rawLeftBound := codec.MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id)
+	rawRightBound := codec.MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id+1)
+	txnLeftBound := codec.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id)
+	txnRightBound := codec.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id+1)
 	if id == constant.MaxValidKeyspaceID {
 		// The right bound is an exclusive fencepost, not a real keyspace prefix.
 		rawRightBound = []byte{'s', 0, 0, 0}

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -40,15 +40,6 @@ const (
 	// numbers (0-9), hyphens (-), and underscores (_).
 	// currently, we enforce this rule to keyspace_name.
 	namePattern = "^[-A-Za-z0-9_]{1,20}$"
-
-	// Keyspace key-format constants live in pkg/codec (single source of truth).
-	// Re-export here so existing keyspace callers keep a stable import path.
-	// RawKeyspaceModePrefix is the raw keyspace prefix mode byte.
-	RawKeyspaceModePrefix = codec.RawKeyspaceModePrefix
-	// TxnKeyspaceModePrefix is the txn keyspace prefix mode byte.
-	TxnKeyspaceModePrefix = codec.TxnKeyspaceModePrefix
-	// KeyspacePrefixLen is the raw keyspace prefix length before memcomparable encoding.
-	KeyspacePrefixLen = codec.KeyspacePrefixLen
 )
 
 var (
@@ -120,7 +111,7 @@ func MaskKeyspaceID(id uint32) uint32 {
 // MakeKeyspacePrefix constructs the raw keyspace prefix for the given mode and keyspace ID.
 // Keyspace keys encode the lower 24 bits of the keyspace ID after the mode byte.
 func MakeKeyspacePrefix(mode byte, id uint32) []byte {
-	prefix := make([]byte, KeyspacePrefixLen)
+	prefix := make([]byte, codec.KeyspacePrefixLen)
 	binary.BigEndian.PutUint32(prefix, id)
 	prefix[0] = mode
 	return prefix
@@ -129,14 +120,14 @@ func MakeKeyspacePrefix(mode byte, id uint32) []byte {
 // ParseKeyspacePrefix parses a raw keyspace prefix from key.
 // It returns false for keys that do not start with a known keyspace mode byte.
 func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
-	if len(key) < KeyspacePrefixLen {
+	if len(key) < codec.KeyspacePrefixLen {
 		return 0, 0, false
 	}
 	mode = key[0]
-	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
+	if mode != codec.RawKeyspaceModePrefix && mode != codec.TxnKeyspaceModePrefix {
 		return 0, 0, false
 	}
-	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
+	idBytes := [codec.KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}
 	id = binary.BigEndian.Uint32(idBytes[:])
 	return mode, id, true
 }
@@ -194,10 +185,10 @@ func keyTypeStringToRegionBoundType(keyType string) regionBoundType {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	rawLeftBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id)
-	rawRightBound := MakeKeyspacePrefix(RawKeyspaceModePrefix, id+1)
-	txnLeftBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id)
-	txnRightBound := MakeKeyspacePrefix(TxnKeyspaceModePrefix, id+1)
+	rawLeftBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id)
+	rawRightBound := MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id+1)
+	txnLeftBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id)
+	txnRightBound := MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id+1)
 	if id == constant.MaxValidKeyspaceID {
 		// The right bound is an exclusive fencepost, not a real keyspace prefix.
 		rawRightBound = []byte{'s', 0, 0, 0}

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -100,13 +100,13 @@ func TestMakeKeyspacePrefix(t *testing.T) {
 	}{
 		{
 			name:       "raw",
-			mode:       codec.RawKeyspaceModePrefix,
+			mode:       RawKeyspaceModePrefix,
 			id:         0x010203,
 			wantPrefix: []byte{'r', 0x01, 0x02, 0x03},
 		},
 		{
 			name:       "txn",
-			mode:       codec.TxnKeyspaceModePrefix,
+			mode:       TxnKeyspaceModePrefix,
 			id:         constant.MaxValidKeyspaceID,
 			wantPrefix: []byte{'x', 0xff, 0xff, 0xff},
 		},
@@ -151,13 +151,13 @@ func TestParseKeyspacePrefix(t *testing.T) {
 		{
 			name: "raw",
 			key:  []byte{'r', 0x01, 0x02, 0x03},
-			mode: codec.RawKeyspaceModePrefix,
+			mode: RawKeyspaceModePrefix,
 			id:   0x010203,
 		},
 		{
 			name: "txn with suffix",
 			key:  []byte{'x', 0xff, 0xff, 0xff, 't'},
-			mode: codec.TxnKeyspaceModePrefix,
+			mode: TxnKeyspaceModePrefix,
 			id:   constant.MaxValidKeyspaceID,
 		},
 	}

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -100,13 +100,13 @@ func TestMakeKeyspacePrefix(t *testing.T) {
 	}{
 		{
 			name:       "raw",
-			mode:       RawKeyspaceModePrefix,
+			mode:       codec.RawKeyspaceModePrefix,
 			id:         0x010203,
 			wantPrefix: []byte{'r', 0x01, 0x02, 0x03},
 		},
 		{
 			name:       "txn",
-			mode:       TxnKeyspaceModePrefix,
+			mode:       codec.TxnKeyspaceModePrefix,
 			id:         constant.MaxValidKeyspaceID,
 			wantPrefix: []byte{'x', 0xff, 0xff, 0xff},
 		},
@@ -151,13 +151,13 @@ func TestParseKeyspacePrefix(t *testing.T) {
 		{
 			name: "raw",
 			key:  []byte{'r', 0x01, 0x02, 0x03},
-			mode: RawKeyspaceModePrefix,
+			mode: codec.RawKeyspaceModePrefix,
 			id:   0x010203,
 		},
 		{
 			name: "txn with suffix",
 			key:  []byte{'x', 0xff, 0xff, 0xff, 't'},
-			mode: TxnKeyspaceModePrefix,
+			mode: codec.TxnKeyspaceModePrefix,
 			id:   constant.MaxValidKeyspaceID,
 		},
 	}

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -89,36 +89,6 @@ func TestMakeRegionBound(t *testing.T) {
 	re.Equal(encodeKey([]byte{'y', 0x00, 0x00, 0x00}), maxRegionBound.TxnRightBound)
 }
 
-func TestMakeKeyspacePrefix(t *testing.T) {
-	re := require.New(t)
-
-	testCases := []struct {
-		name       string
-		mode       byte
-		id         uint32
-		wantPrefix []byte
-	}{
-		{
-			name:       "raw",
-			mode:       codec.RawKeyspaceModePrefix,
-			id:         0x010203,
-			wantPrefix: []byte{'r', 0x01, 0x02, 0x03},
-		},
-		{
-			name:       "txn",
-			mode:       codec.TxnKeyspaceModePrefix,
-			id:         constant.MaxValidKeyspaceID,
-			wantPrefix: []byte{'x', 0xff, 0xff, 0xff},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(_ *testing.T) {
-			re.Equal(testCase.wantPrefix, MakeKeyspacePrefix(testCase.mode, testCase.id))
-		})
-	}
-}
-
 func TestMaxKeyspaceLabelRuleSplitKeys(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -137,44 +107,6 @@ func TestMaxKeyspaceLabelRuleSplitKeys(t *testing.T) {
 		},
 		regionLabeler.GetSplitKeys(nil, nil),
 	)
-}
-
-func TestParseKeyspacePrefix(t *testing.T) {
-	re := require.New(t)
-
-	testCases := []struct {
-		name string
-		key  []byte
-		mode byte
-		id   uint32
-	}{
-		{
-			name: "raw",
-			key:  []byte{'r', 0x01, 0x02, 0x03},
-			mode: codec.RawKeyspaceModePrefix,
-			id:   0x010203,
-		},
-		{
-			name: "txn with suffix",
-			key:  []byte{'x', 0xff, 0xff, 0xff, 't'},
-			mode: codec.TxnKeyspaceModePrefix,
-			id:   constant.MaxValidKeyspaceID,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(_ *testing.T) {
-			mode, id, ok := ParseKeyspacePrefix(testCase.key)
-			re.True(ok)
-			re.Equal(testCase.mode, mode)
-			re.Equal(testCase.id, id)
-		})
-	}
-
-	_, _, ok := ParseKeyspacePrefix([]byte{'x', 0x01, 0x02})
-	re.False(ok)
-	_, _, ok = ParseKeyspacePrefix([]byte{'t', 0x01, 0x02, 0x03})
-	re.False(ok)
 }
 
 func TestValidateName(t *testing.T) {

--- a/pkg/mock/mockcluster/config.go
+++ b/pkg/mock/mockcluster/config.go
@@ -47,6 +47,11 @@ func (mc *Cluster) SetEnableOneWayMerge(v bool) {
 	mc.updateScheduleConfig(func(s *sc.ScheduleConfig) { s.EnableOneWayMerge = v })
 }
 
+// SetEnableCrossTableMerge updates the EnableCrossTableMerge configuration.
+func (mc *Cluster) SetEnableCrossTableMerge(v bool) {
+	mc.updateScheduleConfig(func(s *sc.ScheduleConfig) { s.EnableCrossTableMerge = v })
+}
+
 // SetMaxSnapshotCount updates the MaxSnapshotCount configuration.
 func (mc *Cluster) SetMaxSnapshotCount(v int) {
 	mc.updateScheduleConfig(func(s *sc.ScheduleConfig) { s.MaxSnapshotCount = uint64(v) })

--- a/pkg/schedule/checker/merge_checker.go
+++ b/pkg/schedule/checker/merge_checker.go
@@ -279,15 +279,11 @@ func AllowMerge(cluster sche.SharedCluster, region, adjacent *core.RegionInfo) b
 	}
 }
 
-// isTableIDSame reports whether two regions belong to the same logical table.
-// On classic clusters this is table-id equality. On NextGen / keyspace clusters
-// the identity is (keyspaceID, tableID): the same numeric table id in two
-// keyspaces must not be treated as the same table when cross-table merge is
-// disabled.
+// isTableIDSame reports whether two regions belong to the same logical table,
+// i.e. the same table ID within the same keyspace (if any).
 func isTableIDSame(region, adjacent *core.RegionInfo) bool {
-	ks1, table1, hasKS1 := codec.Key(region.GetStartKey()).TableIdentity()
-	ks2, table2, hasKS2 := codec.Key(adjacent.GetStartKey()).TableIdentity()
-	return hasKS1 == hasKS2 && ks1 == ks2 && table1 == table2
+	return codec.Key(region.GetStartKey()).TableIdentity() ==
+		codec.Key(adjacent.GetStartKey()).TableIdentity()
 }
 
 // Check whether there is a peer of the adjacent region on an offline store,

--- a/pkg/schedule/checker/merge_checker.go
+++ b/pkg/schedule/checker/merge_checker.go
@@ -279,8 +279,15 @@ func AllowMerge(cluster sche.SharedCluster, region, adjacent *core.RegionInfo) b
 	}
 }
 
+// isTableIDSame reports whether two regions belong to the same logical table.
+// On classic clusters this is table-id equality. On NextGen / keyspace clusters
+// the identity is (keyspaceID, tableID): the same numeric table id in two
+// keyspaces must not be treated as the same table when cross-table merge is
+// disabled.
 func isTableIDSame(region, adjacent *core.RegionInfo) bool {
-	return codec.Key(region.GetStartKey()).TableID() == codec.Key(adjacent.GetStartKey()).TableID()
+	ks1, table1, hasKS1 := codec.Key(region.GetStartKey()).TableIdentity()
+	ks2, table2, hasKS2 := codec.Key(adjacent.GetStartKey()).TableIdentity()
+	return hasKS1 == hasKS2 && ks1 == ks2 && table1 == table2
 }
 
 // Check whether there is a peer of the adjacent region on an offline store,

--- a/pkg/schedule/checker/merge_checker.go
+++ b/pkg/schedule/checker/merge_checker.go
@@ -269,19 +269,19 @@ func AllowMerge(cluster sche.SharedCluster, region, adjacent *core.RegionInfo) b
 		if cluster.GetSharedConfig().IsCrossTableMergeEnabled() {
 			return true
 		}
-		return isTableIDSame(region, adjacent)
+		return isSameTableIdentity(region, adjacent)
 	case constant.Raw:
 		return true
 	case constant.Txn:
 		return true
 	default:
-		return isTableIDSame(region, adjacent)
+		return isSameTableIdentity(region, adjacent)
 	}
 }
 
-// isTableIDSame reports whether two regions belong to the same logical table,
-// i.e. the same table ID within the same keyspace (if any).
-func isTableIDSame(region, adjacent *core.RegionInfo) bool {
+// isSameTableIdentity reports whether two regions belong to the same logical
+// table, i.e. the same table ID within the same keyspace (if any).
+func isSameTableIdentity(region, adjacent *core.RegionInfo) bool {
 	return codec.Key(region.GetStartKey()).TableIdentity() ==
 		codec.Key(adjacent.GetStartKey()).TableIdentity()
 }

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
-	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/schedule/config"
@@ -686,7 +685,7 @@ func TestAllowMergeCrossTable(t *testing.T) {
 }
 
 func encodeKeyspaceRawKey(keyspaceID uint32, rawKey []byte) []byte {
-	prefix := keyspace.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, keyspaceID)
+	prefix := codec.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, keyspaceID)
 	return codec.EncodeBytes(append(prefix, rawKey...))
 }
 

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -20,13 +20,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 
+	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/storelimit"
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/mock/mockconfig"
 	"github.com/tikv/pd/pkg/schedule/config"
@@ -588,5 +591,109 @@ func newRegionInfo(id uint64, startKey, endKey string, size, keys int64, leader 
 		&metapb.Peer{Id: leader[0], StoreId: leader[1]},
 		core.SetApproximateSize(size),
 		core.SetApproximateKeys(keys),
+	)
+}
+
+func TestAllowMergeCrossTable(t *testing.T) {
+	ctx := t.Context()
+	cfg := mockconfig.NewTestOptions()
+	cluster := mockcluster.NewCluster(ctx, cfg)
+	// Disable placement rules so AllowMerge is decided only by key type / table ID.
+	cluster.SetEnablePlacementRules(false)
+
+	const (
+		keyspaceID = uint32(42)
+		tableA     = int64(100)
+		tableB     = int64(101)
+		indexID    = int64(1)
+	)
+
+	classicTableA := codec.EncodeBytes(codec.GenerateTableKey(tableA))
+	classicTableB := codec.EncodeBytes(codec.GenerateTableKey(tableB))
+	classicIndexA := codec.EncodeBytes(codec.GenerateIndexKey(tableA, indexID))
+	classicRecordA := codec.EncodeBytes(codec.GenerateRowKey(tableA, 1))
+
+	ksTableA := encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableA))
+	ksTableB := encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableB))
+	ksIndexA := encodeKeyspaceRawKey(keyspaceID, codec.GenerateIndexKey(tableA, indexID))
+	ksRecordA := encodeKeyspaceRawKey(keyspaceID, codec.GenerateRowKey(tableA, 1))
+
+	cases := []struct {
+		name            string
+		startA, endA    []byte
+		startB, endB    []byte
+		crossTableMerge bool
+		expectAllow     bool
+	}{
+		{
+			name:   "classic different tables cross-table enabled",
+			startA: classicTableA, endA: classicTableB,
+			startB: classicTableB, endB: codec.EncodeBytes(codec.GenerateTableKey(tableB + 1)),
+			crossTableMerge: true,
+			expectAllow:     true,
+		},
+		{
+			name:   "classic different tables cross-table disabled",
+			startA: classicTableA, endA: classicTableB,
+			startB: classicTableB, endB: codec.EncodeBytes(codec.GenerateTableKey(tableB + 1)),
+			crossTableMerge: false,
+			expectAllow:     false,
+		},
+		{
+			name:   "classic same table index and record cross-table disabled",
+			startA: classicIndexA, endA: classicRecordA,
+			startB: classicRecordA, endB: classicTableB,
+			crossTableMerge: false,
+			expectAllow:     true,
+		},
+		{
+			name:   "keyspace different tables cross-table enabled",
+			startA: ksTableA, endA: ksTableB,
+			startB: ksTableB, endB: encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableB+1)),
+			crossTableMerge: true,
+			expectAllow:     true,
+		},
+		{
+			name:   "keyspace different tables cross-table disabled",
+			startA: ksTableA, endA: ksTableB,
+			startB: ksTableB, endB: encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableB+1)),
+			crossTableMerge: false,
+			expectAllow:     false,
+		},
+		{
+			name:   "keyspace same table index and record cross-table disabled",
+			startA: ksIndexA, endA: ksRecordA,
+			startB: ksRecordA, endB: ksTableB,
+			crossTableMerge: false,
+			expectAllow:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			re := require.New(t)
+			cluster.SetEnableCrossTableMerge(tc.crossTableMerge)
+			regionA := newRegionInfoWithBytes(1, tc.startA, tc.endA)
+			regionB := newRegionInfoWithBytes(2, tc.startB, tc.endB)
+			re.Equal(tc.expectAllow, AllowMerge(cluster, regionA, regionB))
+		})
+	}
+}
+
+func encodeKeyspaceRawKey(keyspaceID uint32, rawKey []byte) []byte {
+	prefix := keyspace.MakeKeyspacePrefix(keyspace.TxnKeyspaceModePrefix, keyspaceID)
+	return codec.EncodeBytes(append(prefix, rawKey...))
+}
+
+func newRegionInfoWithBytes(id uint64, startKey, endKey []byte) *core.RegionInfo {
+	peer := &metapb.Peer{Id: id * 10, StoreId: 1}
+	return core.NewRegionInfo(
+		&metapb.Region{
+			Id:       id,
+			StartKey: startKey,
+			EndKey:   endKey,
+			Peers:    []*metapb.Peer{peer},
+		},
+		peer,
 	)
 }

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -630,10 +630,8 @@ func TestAllowMergeCrossTable(t *testing.T) {
 	ks2TableB := encodeKeyspaceRawKey(keyspace2, codec.GenerateTableKey(tableB))
 	ks2TableC := encodeKeyspaceRawKey(keyspace2, codec.GenerateTableKey(tableB+1))
 
-	// Matrix:
-	//   layout × same/diff table ID × enable-cross-table-merge on/off
-	// Expectations follow current isTableIDSame semantics: only table IDs are
-	// compared, keyspace IDs are ignored.
+	// Matrix: layout × same/diff table identity × enable-cross-table-merge.
+	// Logical table identity is (keyspaceID, tableID); classic has no keyspace.
 	type adjacentPair struct {
 		startA, endA []byte
 		startB, endB []byte
@@ -642,9 +640,8 @@ func TestAllowMergeCrossTable(t *testing.T) {
 	classicSameTable := adjacentPair{classicIndexA, classicRecordA, classicRecordA, classicTableB}
 	sameKSDiffTable := adjacentPair{ks1TableA, ks1TableB, ks1TableB, ks1TableC}
 	sameKSSameTable := adjacentPair{ks1IndexA, ks1RecordA, ks1RecordA, ks1TableB}
-	// Different keyspace, same table ID on both start keys.
+	// Different keyspaces with the same numeric table id are still different tables.
 	diffKSSameTable := adjacentPair{ks1TableA, ks2TableA, ks2TableA, ks2TableB}
-	// Different keyspace, different table IDs on start keys.
 	diffKSDiffTable := adjacentPair{ks1TableA, ks2TableB, ks2TableB, ks2TableC}
 
 	cases := []struct {
@@ -667,10 +664,11 @@ func TestAllowMergeCrossTable(t *testing.T) {
 		{"same-keyspace/same-table/cross-enabled", sameKSSameTable, true, true},
 		{"same-keyspace/same-table/cross-disabled", sameKSSameTable, false, true},
 
-		// Different keyspaces: same table ID → allow even when cross-table is
-		// disabled, because isTableIDSame only compares table IDs.
+		// Different keyspaces: same numeric table ID is not the same logical table.
+		// With cross-table enabled, merge is still allowed by policy (split keys
+		// from keyspace labels normally block this path in production).
 		{"diff-keyspace/same-table/cross-enabled", diffKSSameTable, true, true},
-		{"diff-keyspace/same-table/cross-disabled", diffKSSameTable, false, true},
+		{"diff-keyspace/same-table/cross-disabled", diffKSSameTable, false, false},
 		// Different keyspaces: different table IDs.
 		{"diff-keyspace/diff-table/cross-enabled", diffKSDiffTable, true, true},
 		{"diff-keyspace/diff-table/cross-disabled", diffKSDiffTable, false, false},

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -602,79 +602,86 @@ func TestAllowMergeCrossTable(t *testing.T) {
 	cluster.SetEnablePlacementRules(false)
 
 	const (
-		keyspaceID = uint32(42)
-		tableA     = int64(100)
-		tableB     = int64(101)
-		indexID    = int64(1)
+		keyspace1 = uint32(42)
+		keyspace2 = uint32(43)
+		tableA    = int64(100)
+		tableB    = int64(101)
+		indexID   = int64(1)
 	)
 
+	// Classic keys.
 	classicTableA := codec.EncodeBytes(codec.GenerateTableKey(tableA))
 	classicTableB := codec.EncodeBytes(codec.GenerateTableKey(tableB))
+	classicTableC := codec.EncodeBytes(codec.GenerateTableKey(tableB + 1))
 	classicIndexA := codec.EncodeBytes(codec.GenerateIndexKey(tableA, indexID))
 	classicRecordA := codec.EncodeBytes(codec.GenerateRowKey(tableA, 1))
 
-	ksTableA := encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableA))
-	ksTableB := encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableB))
-	ksIndexA := encodeKeyspaceRawKey(keyspaceID, codec.GenerateIndexKey(tableA, indexID))
-	ksRecordA := encodeKeyspaceRawKey(keyspaceID, codec.GenerateRowKey(tableA, 1))
+	// Same-keyspace keys.
+	ks1TableA := encodeKeyspaceRawKey(keyspace1, codec.GenerateTableKey(tableA))
+	ks1TableB := encodeKeyspaceRawKey(keyspace1, codec.GenerateTableKey(tableB))
+	ks1TableC := encodeKeyspaceRawKey(keyspace1, codec.GenerateTableKey(tableB+1))
+	ks1IndexA := encodeKeyspaceRawKey(keyspace1, codec.GenerateIndexKey(tableA, indexID))
+	ks1RecordA := encodeKeyspaceRawKey(keyspace1, codec.GenerateRowKey(tableA, 1))
+
+	// Different-keyspace keys. Adjacent ranges are constructed artificially so
+	// AllowMerge can reach the table-ID check; production keyspaces are usually
+	// separated by fence regions and would not be merge candidates.
+	ks2TableA := encodeKeyspaceRawKey(keyspace2, codec.GenerateTableKey(tableA))
+	ks2TableB := encodeKeyspaceRawKey(keyspace2, codec.GenerateTableKey(tableB))
+	ks2TableC := encodeKeyspaceRawKey(keyspace2, codec.GenerateTableKey(tableB+1))
+
+	// Matrix:
+	//   layout × same/diff table ID × enable-cross-table-merge on/off
+	// Expectations follow current isTableIDSame semantics: only table IDs are
+	// compared, keyspace IDs are ignored.
+	type adjacentPair struct {
+		startA, endA []byte
+		startB, endB []byte
+	}
+	classicDiffTable := adjacentPair{classicTableA, classicTableB, classicTableB, classicTableC}
+	classicSameTable := adjacentPair{classicIndexA, classicRecordA, classicRecordA, classicTableB}
+	sameKSDiffTable := adjacentPair{ks1TableA, ks1TableB, ks1TableB, ks1TableC}
+	sameKSSameTable := adjacentPair{ks1IndexA, ks1RecordA, ks1RecordA, ks1TableB}
+	// Different keyspace, same table ID on both start keys.
+	diffKSSameTable := adjacentPair{ks1TableA, ks2TableA, ks2TableA, ks2TableB}
+	// Different keyspace, different table IDs on start keys.
+	diffKSDiffTable := adjacentPair{ks1TableA, ks2TableB, ks2TableB, ks2TableC}
 
 	cases := []struct {
 		name            string
-		startA, endA    []byte
-		startB, endB    []byte
+		pair            adjacentPair
 		crossTableMerge bool
 		expectAllow     bool
 	}{
-		{
-			name:   "classic different tables cross-table enabled",
-			startA: classicTableA, endA: classicTableB,
-			startB: classicTableB, endB: codec.EncodeBytes(codec.GenerateTableKey(tableB + 1)),
-			crossTableMerge: true,
-			expectAllow:     true,
-		},
-		{
-			name:   "classic different tables cross-table disabled",
-			startA: classicTableA, endA: classicTableB,
-			startB: classicTableB, endB: codec.EncodeBytes(codec.GenerateTableKey(tableB + 1)),
-			crossTableMerge: false,
-			expectAllow:     false,
-		},
-		{
-			name:   "classic same table index and record cross-table disabled",
-			startA: classicIndexA, endA: classicRecordA,
-			startB: classicRecordA, endB: classicTableB,
-			crossTableMerge: false,
-			expectAllow:     true,
-		},
-		{
-			name:   "keyspace different tables cross-table enabled",
-			startA: ksTableA, endA: ksTableB,
-			startB: ksTableB, endB: encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableB+1)),
-			crossTableMerge: true,
-			expectAllow:     true,
-		},
-		{
-			name:   "keyspace different tables cross-table disabled",
-			startA: ksTableA, endA: ksTableB,
-			startB: ksTableB, endB: encodeKeyspaceRawKey(keyspaceID, codec.GenerateTableKey(tableB+1)),
-			crossTableMerge: false,
-			expectAllow:     false,
-		},
-		{
-			name:   "keyspace same table index and record cross-table disabled",
-			startA: ksIndexA, endA: ksRecordA,
-			startB: ksRecordA, endB: ksTableB,
-			crossTableMerge: false,
-			expectAllow:     true,
-		},
+		// Classic: different table IDs.
+		{"classic/diff-table/cross-enabled", classicDiffTable, true, true},
+		{"classic/diff-table/cross-disabled", classicDiffTable, false, false},
+		// Classic: same table ID (index + record).
+		{"classic/same-table/cross-enabled", classicSameTable, true, true},
+		{"classic/same-table/cross-disabled", classicSameTable, false, true},
+
+		// Same keyspace: different table IDs.
+		{"same-keyspace/diff-table/cross-enabled", sameKSDiffTable, true, true},
+		{"same-keyspace/diff-table/cross-disabled", sameKSDiffTable, false, false},
+		// Same keyspace: same table ID (index + record).
+		{"same-keyspace/same-table/cross-enabled", sameKSSameTable, true, true},
+		{"same-keyspace/same-table/cross-disabled", sameKSSameTable, false, true},
+
+		// Different keyspaces: same table ID → allow even when cross-table is
+		// disabled, because isTableIDSame only compares table IDs.
+		{"diff-keyspace/same-table/cross-enabled", diffKSSameTable, true, true},
+		{"diff-keyspace/same-table/cross-disabled", diffKSSameTable, false, true},
+		// Different keyspaces: different table IDs.
+		{"diff-keyspace/diff-table/cross-enabled", diffKSDiffTable, true, true},
+		{"diff-keyspace/diff-table/cross-disabled", diffKSDiffTable, false, false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			re := require.New(t)
 			cluster.SetEnableCrossTableMerge(tc.crossTableMerge)
-			regionA := newRegionInfoWithBytes(1, tc.startA, tc.endA)
-			regionB := newRegionInfoWithBytes(2, tc.startB, tc.endB)
+			regionA := newRegionInfoWithBytes(1, tc.pair.startA, tc.pair.endA)
+			regionB := newRegionInfoWithBytes(2, tc.pair.startB, tc.pair.endB)
 			re.Equal(tc.expectAllow, AllowMerge(cluster, regionA, regionB))
 		})
 	}

--- a/pkg/schedule/checker/merge_checker_test.go
+++ b/pkg/schedule/checker/merge_checker_test.go
@@ -681,7 +681,7 @@ func TestAllowMergeCrossTable(t *testing.T) {
 }
 
 func encodeKeyspaceRawKey(keyspaceID uint32, rawKey []byte) []byte {
-	prefix := keyspace.MakeKeyspacePrefix(keyspace.TxnKeyspaceModePrefix, keyspaceID)
+	prefix := keyspace.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, keyspaceID)
 	return codec.EncodeBytes(append(prefix, rawKey...))
 }
 

--- a/pkg/schedule/checker/split_scatter_group.go
+++ b/pkg/schedule/checker/split_scatter_group.go
@@ -105,7 +105,7 @@ func decodeSplitScatterRegionKey(
 	}
 	decodedKey := splitScatterDecodedKey{rawKey: rawKey}
 	mode, keyspaceID, ok := keyspace.ParseKeyspacePrefix(rawKey)
-	if !ok || mode != keyspace.TxnKeyspaceModePrefix {
+	if !ok || mode != codec.TxnKeyspaceModePrefix {
 		return decodedKey, nil
 	}
 
@@ -116,7 +116,7 @@ func decodeSplitScatterRegionKey(
 	if validateKeyspace == nil || !validateKeyspace(keyspaceID) {
 		return decodedKey, nil
 	}
-	decodedKey.rawKey = rawKey[keyspace.KeyspacePrefixLen:]
+	decodedKey.rawKey = rawKey[codec.KeyspacePrefixLen:]
 	decodedKey.keyspacePrefix = keyspace.MakeKeyspacePrefix(mode, keyspaceID)
 	decodedKey.keyspaceID = keyspaceID
 	return decodedKey, nil

--- a/pkg/schedule/checker/split_scatter_group.go
+++ b/pkg/schedule/checker/split_scatter_group.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/core"
-	"github.com/tikv/pd/pkg/keyspace"
 )
 
 var (
@@ -104,7 +103,7 @@ func decodeSplitScatterRegionKey(
 		return splitScatterDecodedKey{}, err
 	}
 	decodedKey := splitScatterDecodedKey{rawKey: rawKey}
-	mode, keyspaceID, ok := keyspace.ParseKeyspacePrefix(rawKey)
+	mode, keyspaceID, ok := codec.ParseKeyspacePrefix(rawKey)
 	if !ok || mode != codec.TxnKeyspaceModePrefix {
 		return decodedKey, nil
 	}
@@ -117,7 +116,7 @@ func decodeSplitScatterRegionKey(
 		return decodedKey, nil
 	}
 	decodedKey.rawKey = rawKey[codec.KeyspacePrefixLen:]
-	decodedKey.keyspacePrefix = keyspace.MakeKeyspacePrefix(mode, keyspaceID)
+	decodedKey.keyspacePrefix = codec.MakeKeyspacePrefix(mode, keyspaceID)
 	decodedKey.keyspaceID = keyspaceID
 	return decodedKey, nil
 }

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -1056,6 +1056,6 @@ func newSplitScatterTableBoundaryKey(tableID int64) []byte {
 }
 
 func newSplitScatterKeyspaceKey(keyspaceID uint32, mode byte, rawKey []byte) []byte {
-	key := keyspace.MakeKeyspacePrefix(mode, keyspaceID)
+	key := codec.MakeKeyspacePrefix(mode, keyspaceID)
 	return codec.EncodeBytes(append(key, rawKey...))
 }

--- a/pkg/schedule/checker/split_scatter_test.go
+++ b/pkg/schedule/checker/split_scatter_test.go
@@ -1010,14 +1010,14 @@ func splitScatterIndexKeyPrefix() []byte {
 }
 
 func splitScatterKeyspacePrefixRange(keyspaceID uint32, rawPrefix []byte) splitScatterRangeHint {
-	startKey := newSplitScatterKeyspaceKey(keyspaceID, keyspace.TxnKeyspaceModePrefix, rawPrefix)
+	startKey := newSplitScatterKeyspaceKey(keyspaceID, codec.TxnKeyspaceModePrefix, rawPrefix)
 	endRawPrefix := splitScatterNextPrefix(rawPrefix)
 	if len(endRawPrefix) == 0 {
 		return splitScatterRangeHint{startKey: startKey}
 	}
 	return splitScatterRangeHint{
 		startKey: startKey,
-		endKey:   newSplitScatterKeyspaceKey(keyspaceID, keyspace.TxnKeyspaceModePrefix, endRawPrefix),
+		endKey:   newSplitScatterKeyspaceKey(keyspaceID, codec.TxnKeyspaceModePrefix, endRawPrefix),
 	}
 }
 
@@ -1030,7 +1030,7 @@ func newSplitScatterIndexKey(suffix string) []byte {
 func newSplitScatterKeyspaceIndexKey(keyspaceID uint32, suffix string) []byte {
 	key := append([]byte(nil), splitScatterIndexKeyPrefix()...)
 	key = append(key, suffix...)
-	return newSplitScatterKeyspaceKey(keyspaceID, keyspace.TxnKeyspaceModePrefix, key)
+	return newSplitScatterKeyspaceKey(keyspaceID, codec.TxnKeyspaceModePrefix, key)
 }
 
 func newSplitScatterRecordKey(tableID int64, suffix string) []byte {
@@ -1042,13 +1042,13 @@ func newSplitScatterRecordKey(tableID int64, suffix string) []byte {
 func newSplitScatterKeyspaceRecordKey(keyspaceID uint32, suffix string) []byte {
 	key := append([]byte(nil), codec.GenerateRecordKeyPrefix(splitScatterTestTableID)...)
 	key = append(key, suffix...)
-	return newSplitScatterKeyspaceKey(keyspaceID, keyspace.TxnKeyspaceModePrefix, key)
+	return newSplitScatterKeyspaceKey(keyspaceID, codec.TxnKeyspaceModePrefix, key)
 }
 
 func newSplitScatterRawKeyspaceRecordKey(keyspaceID uint32, tableID int64, suffix string) []byte {
 	key := append([]byte(nil), codec.GenerateRecordKeyPrefix(tableID)...)
 	key = append(key, suffix...)
-	return newSplitScatterKeyspaceKey(keyspaceID, keyspace.RawKeyspaceModePrefix, key)
+	return newSplitScatterKeyspaceKey(keyspaceID, codec.RawKeyspaceModePrefix, key)
 }
 
 func newSplitScatterTableBoundaryKey(tableID int64) []byte {

--- a/tests/server/cluster/cross_table_merge_test.go
+++ b/tests/server/cluster/cross_table_merge_test.go
@@ -58,8 +58,8 @@ func TestCrossTableMergeWithKeyspace(t *testing.T) {
 	replication.MaxReplicas = 1
 	re.NoError(svr.SetReplicationConfig(replication))
 
-	// Keyspace 42, txn mode: 'x' + big-endian lower 24 bits of the keyspace id.
-	keyspacePrefix := []byte{'x', 0x00, 0x00, 0x2a}
+	// Keyspace 42, txn mode.
+	keyspacePrefix := codec.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, 42)
 	tableKey := func(tableID int64) []byte {
 		return codec.EncodeBytes(append(append([]byte{}, keyspacePrefix...), codec.GenerateTableKey(tableID)...))
 	}

--- a/tests/server/cluster/cross_table_merge_test.go
+++ b/tests/server/cluster/cross_table_merge_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
+	"github.com/tikv/pd/tests"
+)
+
+// TestCrossTableMergeWithKeyspace verifies through a real pd-server that
+// enable-cross-table-merge=false blocks merging adjacent regions of different
+// tables under a keyspace, while same-table regions still merge. See #10991.
+func TestCrossTableMergeWithKeyspace(t *testing.T) {
+	re := require.New(t)
+	tc, err := tests.NewTestCluster(t.Context(), 1)
+	defer tc.Destroy()
+	re.NoError(err)
+	re.NoError(tc.RunInitialServers())
+	tc.WaitLeader()
+	leaderServer := tc.GetLeaderServer()
+	re.NoError(leaderServer.BootstrapCluster())
+	tests.MustPutStore(re, tc, &metapb.Store{
+		Id:            1,
+		State:         metapb.StoreState_Up,
+		NodeState:     metapb.NodeState_Serving,
+		LastHeartbeat: time.Now().UnixNano(),
+	})
+
+	// Mirror the issue reproduction: pd-ctl config set enable-cross-table-merge false.
+	svr := leaderServer.GetServer()
+	schedule := leaderServer.GetConfig().Schedule
+	schedule.EnableCrossTableMerge = false
+	schedule.SplitMergeInterval = typeutil.NewDuration(time.Second)
+	re.NoError(svr.SetScheduleConfig(schedule))
+	replication := leaderServer.GetConfig().Replication
+	replication.MaxReplicas = 1
+	re.NoError(svr.SetReplicationConfig(replication))
+
+	// Keyspace 42, txn mode: 'x' + big-endian lower 24 bits of the keyspace id.
+	keyspacePrefix := []byte{'x', 0x00, 0x00, 0x2a}
+	tableKey := func(tableID int64) []byte {
+		return codec.EncodeBytes(append(append([]byte{}, keyspacePrefix...), codec.GenerateTableKey(tableID)...))
+	}
+	rowKey := func(tableID, rowID int64) []byte {
+		return codec.EncodeBytes(append(append([]byte{}, keyspacePrefix...), codec.GenerateRowKey(tableID, rowID)...))
+	}
+
+	// Five contiguous regions inside keyspace 42: three empty single-table
+	// regions (tables 100..102), then table 103 split at a row key so its two
+	// halves form a same-table merge control pair.
+	regions := []struct {
+		id         uint64
+		start, end []byte
+	}{
+		{10, tableKey(100), tableKey(101)},
+		{11, tableKey(101), tableKey(102)},
+		{12, tableKey(102), tableKey(103)},
+		{13, tableKey(103), rowKey(103, 500)},
+		{14, rowKey(103, 500), tableKey(104)},
+	}
+	for _, r := range regions {
+		tests.MustPutRegion(re, tc, r.id, 1, r.start, r.end,
+			core.SetApproximateSize(1), core.SetApproximateKeys(1))
+	}
+
+	oc := leaderServer.GetRaftCluster().GetOperatorController()
+	// The same-table pair must merge: proves the whole merge pipeline
+	// (patrol -> merge checker -> operator) is live in this setup.
+	testutil.Eventually(re, func() bool {
+		op13, op14 := oc.GetOperator(13), oc.GetOperator(14)
+		return op13 != nil && op14 != nil
+	})
+	// Regions of different tables under the same keyspace must never be
+	// merged while enable-cross-table-merge is false.
+	for range 20 {
+		for _, id := range []uint64{10, 11, 12} {
+			re.Nil(oc.GetOperator(id), "unexpected operator on cross-table region %d", id)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10991

On NextGen / keyspace clusters (e.g. TiDB Cloud Premium), `enable-cross-table-merge=false` did not prevent cross-table region merges. `codec.Key.TableID()` only recognized classic TiDB keys starting with `'t'`, so keyspace-prefixed keys (`x|r` + keyspace id + table key) always returned table ID `0`. Merge checker then treated every pair of regions as the same table and merged empty tables together after `split-merge-interval`.

### What is changed and how does it work?

```commit-message
Add Key.TableIdentity returning a comparable (keyspace, table) identity and
make MetaOrTable strip the API v2 txn-mode keyspace prefix when the remainder
is a TiDB table/meta key, so enable-cross-table-merge=false can distinguish
different tables under a keyspace. Raw-mode keyspace keys are never treated
as table keys. Remove the keyspace-blind Key.TableID, which has no remaining
callers. Classic keys are unchanged.
Consolidate all keyspace key-format knowledge in pkg/codec: the mode-byte
constants and MakeKeyspacePrefix/ParseKeyspacePrefix move from pkg/keyspace
into pkg/codec, and unwrapKeyspace reuses the shared parser.
Add codec unit tests and AllowMerge coverage for classic and keyspace cases.
```

### Check List

Tests

- Unit test
- Integration test (`tests/server/cluster/TestCrossTableMergeWithKeyspace`: real pd-server, keyspace-encoded regions; also fails on unfixed master, reproducing the bug)
- Manual test (tiup playground: patched pd-server + TiKV v8.5.6 `api-version=2` + TiDB v8.5.6 `keyspace-name`; 20 empty tables kept their own regions for 150s with `enable-cross-table-merge=false`, then merged 83→4 regions within 90s after flipping it to `true`)

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Fix enable-cross-table-merge=false being ineffective on keyspace-encoded (NextGen) clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyspace-prefixed key handling with shared prefix construction/parsing and a new table identity abstraction.
  * Added a configuration setter/toggle to enable or disable cross-table merges.

* **Bug Fixes**
  * Correctly determines table vs meta keys when a keyspace prefix is present.
  * Improves cross-table merge identity checks by comparing keyspace-aware table identity (not just table ID).

* **Tests**
  * Expanded unit and integration coverage for keyspace-prefixed decoding and cross-table merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



