### PR TITLE
[release-nextgen-202603] client: remove successful token wait logs

### DIFF
--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -163,14 +163,6 @@ func initMetrics(oldName, name string) *groupMetricsCollection {
 	}
 }
 
-func (gmc *groupMetricsCollection) recordSuccessfulRequestWaitMetrics(
-	accumulatedWaitDuration, reservationWaitDuration time.Duration,
-) time.Duration {
-	totalWaitDuration := accumulatedWaitDuration + reservationWaitDuration
-	gmc.successfulRequestDuration.Observe(totalWaitDuration.Seconds())
-	return totalWaitDuration
-}
-
 type tokenCounter struct {
 	fillRate uint64
 
@@ -801,7 +793,8 @@ func (gc *groupCostController) onRequestWaitImpl(
 			}
 			return nil, nil, waitDuration, 0, err
 		}
-		waitDuration = gc.metrics.recordSuccessfulRequestWaitMetrics(waitDuration, d)
+		waitDuration += d
+		gc.metrics.successfulRequestDuration.Observe(waitDuration.Seconds())
 	}
 	gc.observeConsumption(delta)
 	gc.observeComponentConsumption(delta)
@@ -881,7 +874,8 @@ func (gc *groupCostController) onResponseWaitImpl(
 			}
 			return nil, waitDuration, err
 		}
-		waitDuration = gc.metrics.recordSuccessfulRequestWaitMetrics(waitDuration, d)
+		waitDuration += d
+		gc.metrics.successfulRequestDuration.Observe(waitDuration.Seconds())
 	}
 	gc.observeConsumption(delta)
 	gc.observeComponentConsumption(delta)

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -793,8 +793,8 @@ func (gc *groupCostController) onRequestWaitImpl(
 			}
 			return nil, nil, waitDuration, 0, err
 		}
+		gc.metrics.successfulRequestDuration.Observe(d.Seconds())
 		waitDuration += d
-		gc.metrics.successfulRequestDuration.Observe(waitDuration.Seconds())
 	}
 	gc.observeConsumption(delta)
 	gc.observeComponentConsumption(delta)
@@ -874,8 +874,8 @@ func (gc *groupCostController) onResponseWaitImpl(
 			}
 			return nil, waitDuration, err
 		}
+		gc.metrics.successfulRequestDuration.Observe(d.Seconds())
 		waitDuration += d
-		gc.metrics.successfulRequestDuration.Observe(waitDuration.Seconds())
 	}
 	gc.observeConsumption(delta)
 	gc.observeComponentConsumption(delta)

--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -163,6 +163,14 @@ func initMetrics(oldName, name string) *groupMetricsCollection {
 	}
 }
 
+func (gmc *groupMetricsCollection) recordSuccessfulRequestWaitMetrics(
+	accumulatedWaitDuration, reservationWaitDuration time.Duration,
+) time.Duration {
+	totalWaitDuration := accumulatedWaitDuration + reservationWaitDuration
+	gmc.successfulRequestDuration.Observe(totalWaitDuration.Seconds())
+	return totalWaitDuration
+}
+
 type tokenCounter struct {
 	fillRate uint64
 
@@ -793,11 +801,7 @@ func (gc *groupCostController) onRequestWaitImpl(
 			}
 			return nil, nil, waitDuration, 0, err
 		}
-		gc.metrics.successfulRequestDuration.Observe(d.Seconds())
-		waitDuration += d
-		if waitDuration > slowNotifyFilterDuration {
-			log.Warn("[resource group controller] waited for tokens", gc.logFields(waitDuration, nil)...)
-		}
+		waitDuration = gc.metrics.recordSuccessfulRequestWaitMetrics(waitDuration, d)
 	}
 	gc.observeConsumption(delta)
 	gc.observeComponentConsumption(delta)
@@ -877,11 +881,7 @@ func (gc *groupCostController) onResponseWaitImpl(
 			}
 			return nil, waitDuration, err
 		}
-		gc.metrics.successfulRequestDuration.Observe(d.Seconds())
-		waitDuration += d
-		if waitDuration > slowNotifyFilterDuration {
-			log.Warn("[resource group controller] response waited for tokens", gc.logFields(waitDuration, nil)...)
-		}
+		waitDuration = gc.metrics.recordSuccessfulRequestWaitMetrics(waitDuration, d)
 	}
 	gc.observeConsumption(delta)
 	gc.observeComponentConsumption(delta)

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -34,47 +34,6 @@ import (
 	"github.com/tikv/pd/client/resource_group/controller/metrics"
 )
 
-func TestRecordSuccessfulRequestWaitMetrics(t *testing.T) {
-	testCases := []struct {
-		name                    string
-		accumulatedWaitDuration time.Duration
-		reservationWaitDuration time.Duration
-		expectedWaitDuration    time.Duration
-	}{
-		{
-			name:                    "reservation wait only",
-			reservationWaitDuration: 25 * time.Millisecond,
-			expectedWaitDuration:    25 * time.Millisecond,
-		},
-		{
-			name:                    "retry and reservation wait",
-			accumulatedWaitDuration: 20 * time.Millisecond,
-			reservationWaitDuration: 30 * time.Millisecond,
-			expectedWaitDuration:    50 * time.Millisecond,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			re := require.New(t)
-			var observedSeconds float64
-			metrics := &groupMetricsCollection{
-				successfulRequestDuration: prometheus.ObserverFunc(func(value float64) {
-					observedSeconds = value
-				}),
-			}
-
-			waitDuration := metrics.recordSuccessfulRequestWaitMetrics(
-				testCase.accumulatedWaitDuration,
-				testCase.reservationWaitDuration,
-			)
-
-			re.Equal(testCase.expectedWaitDuration, waitDuration)
-			re.InDelta(testCase.expectedWaitDuration.Seconds(), observedSeconds, 1e-9)
-		})
-	}
-}
-
 func createTestGroupCostController(re *require.Assertions, names ...string) *groupCostController {
 	name := "test"
 	if len(names) > 0 {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -34,6 +34,47 @@ import (
 	"github.com/tikv/pd/client/resource_group/controller/metrics"
 )
 
+func TestRecordSuccessfulRequestWaitMetrics(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		accumulatedWaitDuration time.Duration
+		reservationWaitDuration time.Duration
+		expectedWaitDuration    time.Duration
+	}{
+		{
+			name:                    "reservation wait only",
+			reservationWaitDuration: 25 * time.Millisecond,
+			expectedWaitDuration:    25 * time.Millisecond,
+		},
+		{
+			name:                    "retry and reservation wait",
+			accumulatedWaitDuration: 20 * time.Millisecond,
+			reservationWaitDuration: 30 * time.Millisecond,
+			expectedWaitDuration:    50 * time.Millisecond,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			var observedSeconds float64
+			metrics := &groupMetricsCollection{
+				successfulRequestDuration: prometheus.ObserverFunc(func(value float64) {
+					observedSeconds = value
+				}),
+			}
+
+			waitDuration := metrics.recordSuccessfulRequestWaitMetrics(
+				testCase.accumulatedWaitDuration,
+				testCase.reservationWaitDuration,
+			)
+
+			re.Equal(testCase.expectedWaitDuration, waitDuration)
+			re.InDelta(testCase.expectedWaitDuration.Seconds(), observedSeconds, 1e-9)
+		})
+	}
+}
+
 func createTestGroupCostController(re *require.Assertions, names ...string) *groupCostController {
 	name := "test"
 	if len(names) > 0 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10488

#10866 logs every successful client-side Resource Control token wait longer
than 10ms at WARN level. Successful waits are expected while requests are
throttled, so high-QPS workloads can produce excessive TiDB warning logs even
when all waits complete successfully.

### What is changed and how does it work?

```commit-message
client/resource_group: remove successful token wait logs
```

- Remove per-request WARN logs after successful request-side and response-side token waits.
- Keep WARN logs for failed token waits.
- Preserve the existing successful-request histogram and its metric semantics.

### Check List

Tests

- Unit test
  - `cd client && make gotest GOTEST_ARGS="./resource_group/controller/... -count=1"`
  - `cd client && make static`

Related changes

- Follow-up fix for #10866.
- Apply the same fix to #10604 after this PR merges.

### Release note

```release-note
Reduce excessive TiDB warning logs for successful Resource Control token waits
while preserving wait-duration metrics.
```