### PR TITLE
mcs/scheduling: clean primary resources on exit （#10645）

### DIFF
--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -94,7 +94,13 @@ type AffinityGroupsResponse struct {
 
 // GetCluster returns the cluster.
 func (s *server) GetCluster() sche.SchedulerCluster {
-	return s.Server.GetCluster()
+	cluster := s.Server.GetCluster()
+	if cluster == nil {
+		// Avoid converting a nil *Cluster into a non-nil SchedulerCluster interface.
+		// Otherwise, scheduling APIs can panic before the cluster is bootstrapped.
+		return nil
+	}
+	return cluster
 }
 
 func createIndentRender() *render.Render {

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 
+	pdcore "github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	scheserver "github.com/tikv/pd/pkg/mcs/scheduling/server"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
@@ -1481,13 +1482,17 @@ func checkRegionsReplicated(c *gin.Context) {
 // @Router      /stores/{id} [get]
 func getStoreByID(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*scheserver.Server)
+	basicCluster, ok := getBasicCluster(c, svr)
+	if !ok {
+		return
+	}
 	idStr := c.Param("id")
 	storeID, err := strconv.ParseUint(idStr, 10, 64)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
-	store := svr.GetBasicCluster().GetStore(storeID)
+	store := basicCluster.GetStore(storeID)
 	if store == nil {
 		c.String(http.StatusNotFound, errs.ErrStoreNotFound.FastGenByArgs(storeID).Error())
 		return
@@ -1505,14 +1510,18 @@ func getStoreByID(c *gin.Context) {
 // @Router      /stores [get]
 func getAllStores(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*scheserver.Server)
-	stores := svr.GetBasicCluster().GetMetaStores()
+	basicCluster, ok := getBasicCluster(c, svr)
+	if !ok {
+		return
+	}
+	stores := basicCluster.GetMetaStores()
 	StoresInfo := &response.StoresInfo{
 		Stores: make([]*response.StoreInfo, 0, len(stores)),
 	}
 
 	for _, s := range stores {
 		storeID := s.GetId()
-		store := svr.GetBasicCluster().GetStore(storeID)
+		store := basicCluster.GetStore(storeID)
 		if store == nil {
 			c.String(http.StatusInternalServerError, errs.ErrStoreNotFound.FastGenByArgs(storeID).Error())
 			return
@@ -1534,7 +1543,11 @@ func getAllStores(c *gin.Context) {
 // @Router   /regions [get]
 func getAllRegions(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*scheserver.Server)
-	regions := svr.GetBasicCluster().GetRegions()
+	basicCluster, ok := getBasicCluster(c, svr)
+	if !ok {
+		return
+	}
+	regions := basicCluster.GetRegions()
 	b, err := response.MarshalRegionsInfoJSON(c.Request.Context(), regions)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
@@ -1550,7 +1563,11 @@ func getAllRegions(c *gin.Context) {
 // @Router   /regions/count [get]
 func getRegionCount(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*scheserver.Server)
-	count := svr.GetBasicCluster().GetTotalRegionCount()
+	basicCluster, ok := getBasicCluster(c, svr)
+	if !ok {
+		return
+	}
+	count := basicCluster.GetTotalRegionCount()
 	c.IndentedJSON(http.StatusOK, &response.RegionsInfo{Count: count})
 }
 
@@ -1563,6 +1580,10 @@ func getRegionCount(c *gin.Context) {
 // @Router   /regions/{id} [get]
 func getRegionByID(c *gin.Context) {
 	svr := c.MustGet(multiservicesapi.ServiceContextKey).(*scheserver.Server)
+	basicCluster, ok := getBasicCluster(c, svr)
+	if !ok {
+		return
+	}
 	idStr := c.Param("id")
 	regionID, err := strconv.ParseUint(idStr, 10, 64)
 	if err != nil {
@@ -1573,7 +1594,7 @@ func getRegionByID(c *gin.Context) {
 		c.String(http.StatusBadRequest, errs.ErrRegionInvalidID.FastGenByArgs().Error())
 		return
 	}
-	regionInfo := svr.GetBasicCluster().GetRegion(regionID)
+	regionInfo := basicCluster.GetRegion(regionID)
 	if regionInfo == nil {
 		c.String(http.StatusNotFound, errs.ErrRegionNotFound.FastGenByArgs(regionID).Error())
 		return
@@ -1631,6 +1652,15 @@ func getAffinityManager(c *gin.Context) (*affinity.Manager, bool) {
 		return nil, false
 	}
 	return manager, true
+}
+
+func getBasicCluster(c *gin.Context, svr *scheserver.Server) (*pdcore.BasicCluster, bool) {
+	basicCluster := svr.GetBasicCluster()
+	if basicCluster == nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, errs.ErrNotBootstrapped.GenWithStackByArgs().Error())
+		return nil, false
+	}
+	return basicCluster, true
 }
 
 // @Tags     affinity-groups

--- a/pkg/mcs/scheduling/server/apis/v1/api_test.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apis
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	scheserver "github.com/tikv/pd/pkg/mcs/scheduling/server"
+	"github.com/tikv/pd/pkg/utils/apiutil/multiservicesapi"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestGetAllStoresReturnsNotBootstrappedWhenBasicClusterMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	re := require.New(t)
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/stores", nil)
+	ctx.Set(multiservicesapi.ServiceContextKey, &scheserver.Server{})
+
+	getAllStores(ctx)
+
+	re.Equal(http.StatusInternalServerError, resp.Code)
+	re.Contains(resp.Body.String(), "not bootstrapped")
+}

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -131,12 +131,16 @@ func NewCluster(
 	ctx, cancel := context.WithCancel(parentCtx)
 	labelerManager, err := labeler.NewRegionLabeler(ctx, storage, regionLabelGCInterval)
 	if err != nil {
+		storage.Close()
+		hbStreams.Close()
 		cancel()
 		return nil, err
 	}
 	ruleManager := placement.NewRuleManager(ctx, storage, basicCluster, persistConfig)
 	affinityManager, err := affinity.NewManager(ctx, storage, basicCluster, persistConfig, labelerManager)
 	if err != nil {
+		storage.Close()
+		hbStreams.Close()
 		cancel()
 		return nil, err
 	}
@@ -166,6 +170,8 @@ func NewCluster(
 	c.coordinator = schedule.NewCoordinator(ctx, c, hbStreams)
 	err = c.ruleManager.Initialize(persistConfig.GetMaxReplicas(), persistConfig.GetLocationLabels(), persistConfig.GetIsolationLevel(), true)
 	if err != nil {
+		storage.Close()
+		hbStreams.Close()
 		cancel()
 		return nil, err
 	}
@@ -200,6 +206,9 @@ func (c *Cluster) GetLabelStats() *statistics.LabelStatistics {
 
 // GetBasicCluster returns the basic cluster.
 func (c *Cluster) GetBasicCluster() *core.BasicCluster {
+	if c == nil {
+		return nil
+	}
 	return c.BasicCluster
 }
 
@@ -317,6 +326,11 @@ func (c *Cluster) SetRuntimeResources(
 	c.affinityWatcher = affinityWatcher
 }
 
+func (c *Cluster) stopCluster() {
+	c.StopBackgroundJobs()
+	c.cleanupRuntimeResources()
+}
+
 func (c *Cluster) cleanupRuntimeResources() {
 	c.runtimeMu.Lock()
 	affinityWatcher := c.affinityWatcher
@@ -324,6 +338,7 @@ func (c *Cluster) cleanupRuntimeResources() {
 	metaWatcher := c.metaWatcher
 	configWatcher := c.configWatcher
 	hbStreams := c.hbStreams
+	storage := c.storage
 	c.affinityWatcher = nil
 	c.ruleWatcher = nil
 	c.metaWatcher = nil
@@ -344,6 +359,9 @@ func (c *Cluster) cleanupRuntimeResources() {
 	}
 	if configWatcher != nil {
 		configWatcher.Close()
+	}
+	if storage != nil {
+		storage.Close()
 	}
 	if hbStreams != nil {
 		start := time.Now()
@@ -739,17 +757,19 @@ func (c *Cluster) StartBackgroundJobs() {
 }
 
 // StopBackgroundJobs stops background jobs, these jobs is created by NewCluster.
-func (c *Cluster) StopBackgroundJobs() bool {
+func (c *Cluster) StopBackgroundJobs() {
+	// always cancel the context to stop the background jobs, even if the cluster is not running, to avoid goroutine leak.
+	if c.cancel != nil {
+		c.cancel()
+	}
 	if !c.running.CompareAndSwap(true, false) {
-		return false
+		return
 	}
 	c.coordinator.Stop()
 	c.heartbeatRunner.Stop()
 	c.miscRunner.Stop()
 	c.logRunner.Stop()
-	c.cancel()
 	c.wg.Wait()
-	return true
 }
 
 // IsBackgroundJobsRunning returns whether the background jobs are running. Only for test purpose.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -38,7 +38,10 @@ import (
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
+	mcsaffinity "github.com/tikv/pd/pkg/mcs/scheduling/server/affinity"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
+	"github.com/tikv/pd/pkg/mcs/scheduling/server/meta"
+	"github.com/tikv/pd/pkg/mcs/scheduling/server/rule"
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/response"
 	"github.com/tikv/pd/pkg/schedule"
@@ -68,15 +71,23 @@ type Cluster struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	*core.BasicCluster
-	persistConfig     *config.PersistConfig
-	ruleManager       *placement.RuleManager
-	keyRangeManager   *keyrange.Manager
-	labelerManager    *labeler.RegionLabeler
-	affinityManager   *affinity.Manager
-	regionStats       *statistics.RegionStatistics
-	labelStats        *statistics.LabelStatistics
-	hotStat           *statistics.HotStat
+	persistConfig   *config.PersistConfig
+	ruleManager     *placement.RuleManager
+	keyRangeManager *keyrange.Manager
+	labelerManager  *labeler.RegionLabeler
+	affinityManager *affinity.Manager
+	regionStats     *statistics.RegionStatistics
+	labelStats      *statistics.LabelStatistics
+	hotStat         *statistics.HotStat
+	// runtimeMu protects the runtime resources which are created after the cluster is created,
+	// and cleaned up before the cluster is closed.
+	runtimeMu         sync.RWMutex
 	storage           storage.Storage
+	hbStreams         *hbstream.HeartbeatStreams
+	metaWatcher       *meta.Watcher
+	configWatcher     *config.Watcher
+	ruleWatcher       *rule.Watcher
+	affinityWatcher   *mcsaffinity.Watcher
 	coordinator       *schedule.Coordinator
 	checkMembershipCh chan struct{}
 	pdLeader          atomic.Value
@@ -142,6 +153,7 @@ func NewCluster(
 		labelStats:        statistics.NewLabelStatistics(),
 		regionStats:       statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
 		storage:           storage,
+		hbStreams:         hbStreams,
 		checkMembershipCh: checkMembershipCh,
 		httpClient:        httpClient,
 		backendAddress:    backendAddress,
@@ -262,7 +274,83 @@ func (c *Cluster) BucketsStats(degree int, regionIDs ...uint64) map[uint64][]*bu
 
 // GetStorage returns the storage.
 func (c *Cluster) GetStorage() storage.Storage {
+	if c == nil {
+		return nil
+	}
+	c.runtimeMu.RLock()
+	defer c.runtimeMu.RUnlock()
 	return c.storage
+}
+
+// GetHeartbeatStreams returns the heartbeat streams.
+func (c *Cluster) GetHeartbeatStreams() *hbstream.HeartbeatStreams {
+	if c == nil {
+		return nil
+	}
+	c.runtimeMu.RLock()
+	defer c.runtimeMu.RUnlock()
+	return c.hbStreams
+}
+
+// GetMetaWatcher returns the meta watcher.
+func (c *Cluster) GetMetaWatcher() *meta.Watcher {
+	if c == nil {
+		return nil
+	}
+	c.runtimeMu.RLock()
+	defer c.runtimeMu.RUnlock()
+	return c.metaWatcher
+}
+
+// SetRuntimeResources installs the cluster-scoped runtime resources after they are created.
+func (c *Cluster) SetRuntimeResources(
+	metaWatcher *meta.Watcher,
+	configWatcher *config.Watcher,
+	ruleWatcher *rule.Watcher,
+	affinityWatcher *mcsaffinity.Watcher,
+) {
+	c.runtimeMu.Lock()
+	defer c.runtimeMu.Unlock()
+	c.metaWatcher = metaWatcher
+	c.configWatcher = configWatcher
+	c.ruleWatcher = ruleWatcher
+	c.affinityWatcher = affinityWatcher
+}
+
+func (c *Cluster) cleanupRuntimeResources() {
+	c.runtimeMu.Lock()
+	affinityWatcher := c.affinityWatcher
+	ruleWatcher := c.ruleWatcher
+	metaWatcher := c.metaWatcher
+	configWatcher := c.configWatcher
+	hbStreams := c.hbStreams
+	c.affinityWatcher = nil
+	c.ruleWatcher = nil
+	c.metaWatcher = nil
+	c.configWatcher = nil
+	c.hbStreams = nil
+	c.storage = nil
+	c.runtimeMu.Unlock()
+
+	now := time.Now()
+	if affinityWatcher != nil {
+		affinityWatcher.Close()
+	}
+	if ruleWatcher != nil {
+		ruleWatcher.Close()
+	}
+	if metaWatcher != nil {
+		metaWatcher.Close()
+	}
+	if configWatcher != nil {
+		configWatcher.Close()
+	}
+	if hbStreams != nil {
+		start := time.Now()
+		hbStreams.Close()
+		log.Info("close stream takes", zap.Duration("cost", time.Since(start)))
+	}
+	log.Info("clean up runtime resources takes", zap.Duration("cost", time.Since(now)))
 }
 
 // GetCheckerConfig returns the checker config.
@@ -650,18 +738,18 @@ func (c *Cluster) StartBackgroundJobs() {
 	c.running.Store(true)
 }
 
-// StopBackgroundJobs stops background jobs.
-func (c *Cluster) StopBackgroundJobs() {
-	if !c.running.Load() {
-		return
+// StopBackgroundJobs stops background jobs, these jobs is created by NewCluster.
+func (c *Cluster) StopBackgroundJobs() bool {
+	if !c.running.CompareAndSwap(true, false) {
+		return false
 	}
-	c.running.Store(false)
 	c.coordinator.Stop()
 	c.heartbeatRunner.Stop()
 	c.miscRunner.Stop()
 	c.logRunner.Stop()
 	c.cancel()
 	c.wg.Wait()
+	return true
 }
 
 // IsBackgroundJobsRunning returns whether the background jobs are running. Only for test purpose.

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/mcs/registry"
+	"github.com/tikv/pd/pkg/mcs/scheduling/server/meta"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/utils/apiutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
@@ -154,7 +155,13 @@ func (s *Service) RegionHeartbeat(stream schedulingpb.Scheduling_RegionHeartbeat
 		storeLabel := strconv.FormatUint(storeID, 10)
 
 		if time.Since(lastBind) > time.Minute {
-			s.hbStreams.BindStream(storeID, server)
+			streams := c.GetHeartbeatStreams()
+			if streams == nil {
+				resp := &schedulingpb.RegionHeartbeatResponse{Header: notBootstrappedHeader()}
+				err := server.Send(resp)
+				return errors.WithStack(err)
+			}
+			streams.BindStream(storeID, server)
 			lastBind = time.Now()
 		}
 
@@ -244,13 +251,17 @@ func (s *Service) RegionBuckets(stream schedulingpb.Scheduling_RegionBucketsServ
 // StoreHeartbeat implements gRPC SchedulingServer.
 func (s *Service) StoreHeartbeat(_ context.Context, request *schedulingpb.StoreHeartbeatRequest) (*schedulingpb.StoreHeartbeatResponse, error) {
 	c := s.GetCluster()
-	if c == nil {
+	var metaWatcher *meta.Watcher
+	if c != nil {
+		metaWatcher = c.GetMetaWatcher()
+	}
+	if c == nil || metaWatcher == nil {
 		return &schedulingpb.StoreHeartbeatResponse{Header: notBootstrappedHeader()}, nil
 	}
 
 	start := time.Now()
 	if c.GetStore(request.GetStats().GetStoreId()) == nil {
-		s.metaWatcher.GetStoreWatcher().ForceLoad()
+		metaWatcher.GetStoreWatcher().ForceLoad()
 	}
 
 	storeID := request.GetStats().GetStoreId()

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -281,4 +281,7 @@ func (rw *Watcher) initializeRegionLabelWatcher() error {
 func (rw *Watcher) Close() {
 	rw.cancel()
 	rw.wg.Wait()
+	if rw.checkerController != nil {
+		rw.checkerController.ClearSuspectKeyRanges()
+	}
 }

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -510,20 +510,10 @@ func (s *Server) startCluster(ctx context.Context) error {
 		metaWatcher     *meta.Watcher
 		ruleWatcher     *rule.Watcher
 		affinityWatcher *affinity.Watcher
+		cluster         *Cluster
 		err             error
 	)
-	metaWatcher, configWatcher, err = s.startMetaConfWatcher(ctx, basicCluster, storage)
-	if err != nil {
-		if configWatcher != nil {
-			configWatcher.Close()
-		}
-		if metaWatcher != nil {
-			metaWatcher.Close()
-		}
-		return err
-	}
-	hbStreams = hbstream.NewHeartbeatStreams(ctx, constant.SchedulingServiceName, basicCluster)
-	cluster, err := NewCluster(ctx, s.persistConfig, storage, basicCluster, hbStreams, s.checkMembershipCh, s.GetHTTPClient(), s.GetBackendEndpoints())
+
 	var initSucceeded bool
 	defer func() {
 		if initSucceeded {
@@ -531,12 +521,7 @@ func (s *Server) startCluster(ctx context.Context) error {
 		}
 		// make sure cancel context done when some initialization step failed, to avoid goroutine leak in cluster.
 		if cluster != nil {
-			if stopped := cluster.StopBackgroundJobs(); !stopped {
-				if cluster.cancel != nil {
-					cluster.cancel()
-					cluster.cancel = nil
-				}
-			}
+			cluster.stopCluster()
 		}
 		// clean new sources
 		if hbStreams != nil {
@@ -559,15 +544,25 @@ func (s *Server) startCluster(ctx context.Context) error {
 			affinityWatcher.Close()
 			affinityWatcher = nil
 		}
-		storage.Close()
+		if storage != nil {
+			storage.Close()
+		}
 	}()
+	metaWatcher, configWatcher, err = s.startMetaConfWatcher(ctx, basicCluster, storage)
+	if err != nil {
+		return err
+	}
+	hbStreams = hbstream.NewHeartbeatStreams(ctx, constant.SchedulingServiceName, basicCluster)
+	cluster, err = NewCluster(ctx, s.persistConfig, storage, basicCluster, hbStreams, s.checkMembershipCh, s.GetHTTPClient(), s.GetBackendEndpoints())
+	storage = nil
+	hbStreams = nil
 	if err != nil {
 		return err
 	}
 
 	am := cluster.GetAffinityManager()
 	configWatcher.SetSchedulersController(cluster.GetCoordinator().GetSchedulersController())
-	ruleWatcher, err = rule.NewWatcher(ctx, s.GetClient(), storage,
+	ruleWatcher, err = rule.NewWatcher(ctx, s.GetClient(), cluster.GetStorage(),
 		cluster.GetCoordinator().GetCheckerController(), cluster.GetRuleManager(), cluster.GetRegionLabeler())
 	if err != nil {
 		return err
@@ -578,8 +573,14 @@ func (s *Server) startCluster(ctx context.Context) error {
 	}
 
 	cluster.SetRuntimeResources(metaWatcher, configWatcher, ruleWatcher, affinityWatcher)
-	s.cluster.Store(cluster)
+	// Set watchers to nil to avoid being closed in defer when cluster initialization is successful,
+	// since cluster will take over the ownership of these watchers and close them when stopping cluster.
+	metaWatcher = nil
+	configWatcher = nil
+	ruleWatcher = nil
+	affinityWatcher = nil
 	cluster.StartBackgroundJobs()
+	s.cluster.Store(cluster)
 	initSucceeded = true
 	return nil
 }
@@ -587,8 +588,7 @@ func (s *Server) startCluster(ctx context.Context) error {
 func (s *Server) stopCluster() {
 	if cluster := s.GetCluster(); cluster != nil {
 		s.cluster.Store((*Cluster)(nil))
-		cluster.StopBackgroundJobs()
-		cluster.cleanupRuntimeResources()
+		cluster.stopCluster()
 	}
 }
 

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -92,7 +92,6 @@ type Server struct {
 
 	cfg           *config.Config
 	persistConfig *config.PersistConfig
-	basicCluster  *core.BasicCluster
 
 	// for the primary election of scheduling
 	participant *member.Participant
@@ -108,15 +107,7 @@ type Server struct {
 	serviceID       *discovery.ServiceRegistryEntry
 	serviceRegister *discovery.ServiceRegister
 
-	cluster   atomic.Value // *Cluster
-	hbStreams *hbstream.HeartbeatStreams
-	storage   *endpoint.StorageEndpoint
-
-	// for watching the PD meta info updates that are related to the scheduling.
-	configWatcher   *config.Watcher
-	ruleWatcher     *rule.Watcher
-	metaWatcher     *meta.Watcher
-	affinityWatcher *affinity.Watcher
+	cluster atomic.Value // *Cluster
 
 	// Cgroup Monitor
 	cgMonitor cgroup.Monitor
@@ -426,7 +417,10 @@ func (s *Server) GetCluster() *Cluster {
 
 // GetBasicCluster returns the basic cluster.
 func (s *Server) GetBasicCluster() *core.BasicCluster {
-	return s.basicCluster
+	if cluster := s.GetCluster(); cluster != nil {
+		return cluster.GetBasicCluster()
+	}
+	return nil
 }
 
 // GetCoordinator returns the coordinator.
@@ -506,70 +500,113 @@ func (s *Server) startServer() (err error) {
 	return nil
 }
 
-func (s *Server) startCluster(context.Context) error {
-	s.basicCluster = core.NewBasicCluster()
-	s.storage = endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
-	err := s.startMetaConfWatcher()
+func (s *Server) startCluster(ctx context.Context) error {
+	basicCluster := core.NewBasicCluster()
+	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+
+	var (
+		hbStreams       *hbstream.HeartbeatStreams
+		configWatcher   *config.Watcher
+		metaWatcher     *meta.Watcher
+		ruleWatcher     *rule.Watcher
+		affinityWatcher *affinity.Watcher
+		err             error
+	)
+	metaWatcher, configWatcher, err = s.startMetaConfWatcher(ctx, basicCluster, storage)
+	if err != nil {
+		if configWatcher != nil {
+			configWatcher.Close()
+		}
+		if metaWatcher != nil {
+			metaWatcher.Close()
+		}
+		return err
+	}
+	hbStreams = hbstream.NewHeartbeatStreams(ctx, constant.SchedulingServiceName, basicCluster)
+	cluster, err := NewCluster(ctx, s.persistConfig, storage, basicCluster, hbStreams, s.checkMembershipCh, s.GetHTTPClient(), s.GetBackendEndpoints())
+	var initSucceeded bool
+	defer func() {
+		if initSucceeded {
+			return
+		}
+		// make sure cancel context done when some initialization step failed, to avoid goroutine leak in cluster.
+		if cluster != nil {
+			if stopped := cluster.StopBackgroundJobs(); !stopped {
+				if cluster.cancel != nil {
+					cluster.cancel()
+					cluster.cancel = nil
+				}
+			}
+		}
+		// clean new sources
+		if hbStreams != nil {
+			hbStreams.Close()
+			hbStreams = nil
+		}
+		if configWatcher != nil {
+			configWatcher.Close()
+			configWatcher = nil
+		}
+		if metaWatcher != nil {
+			metaWatcher.Close()
+			metaWatcher = nil
+		}
+		if ruleWatcher != nil {
+			ruleWatcher.Close()
+			ruleWatcher = nil
+		}
+		if affinityWatcher != nil {
+			affinityWatcher.Close()
+			affinityWatcher = nil
+		}
+		storage.Close()
+	}()
 	if err != nil {
 		return err
 	}
-	s.hbStreams = hbstream.NewHeartbeatStreams(s.Context(), constant.SchedulingServiceName, s.basicCluster)
-	cluster, err := NewCluster(s.Context(), s.persistConfig, s.storage, s.basicCluster, s.hbStreams, s.checkMembershipCh, s.GetHTTPClient(), s.GetBackendEndpoints())
-	if err != nil {
-		return err
-	}
-	s.cluster.Store(cluster)
-	// Inject the cluster components into the config watcher after the scheduler controller is created.
-	s.configWatcher.SetSchedulersController(cluster.GetCoordinator().GetSchedulersController())
-	// Start the rule watcher after the cluster is created.
-	s.ruleWatcher, err = rule.NewWatcher(s.Context(), s.GetClient(), s.storage,
+
+	am := cluster.GetAffinityManager()
+	configWatcher.SetSchedulersController(cluster.GetCoordinator().GetSchedulersController())
+	ruleWatcher, err = rule.NewWatcher(ctx, s.GetClient(), storage,
 		cluster.GetCoordinator().GetCheckerController(), cluster.GetRuleManager(), cluster.GetRegionLabeler())
 	if err != nil {
 		return err
 	}
-	// Start the affinity watcher after the cluster is created.
-	s.affinityWatcher, err = affinity.NewWatcher(s.Context(), s.GetClient(), cluster.GetAffinityManager())
+	affinityWatcher, err = affinity.NewWatcher(ctx, s.GetClient(), am)
 	if err != nil {
 		return err
 	}
+
+	cluster.SetRuntimeResources(metaWatcher, configWatcher, ruleWatcher, affinityWatcher)
+	s.cluster.Store(cluster)
 	cluster.StartBackgroundJobs()
+	initSucceeded = true
 	return nil
 }
 
 func (s *Server) stopCluster() {
-	cluster := s.GetCluster()
-	if cluster != nil {
+	if cluster := s.GetCluster(); cluster != nil {
 		s.cluster.Store((*Cluster)(nil))
 		cluster.StopBackgroundJobs()
+		cluster.cleanupRuntimeResources()
 	}
-	s.stopWatcher()
 }
 
-func (s *Server) startMetaConfWatcher() (err error) {
-	s.metaWatcher, err = meta.NewWatcher(s.Context(), s.GetClient(), s.basicCluster)
+func (s *Server) startMetaConfWatcher(
+	ctx context.Context,
+	basicCluster *core.BasicCluster,
+	storage *endpoint.StorageEndpoint,
+) (metaWatcher *meta.Watcher, configWatcher *config.Watcher, err error) {
+	metaWatcher, err = meta.NewWatcher(ctx, s.GetClient(), basicCluster)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	s.configWatcher, err = config.NewWatcher(s.Context(), s.GetClient(), s.persistConfig, s.storage)
+	configWatcher, err = config.NewWatcher(ctx, s.GetClient(), s.persistConfig, storage)
 	if err != nil {
-		return err
+		metaWatcher.Close()
+		return nil, nil, err
 	}
-	return err
-}
-
-func (s *Server) stopWatcher() {
-	if s.affinityWatcher != nil {
-		s.affinityWatcher.Close()
-	}
-	if s.ruleWatcher != nil {
-		s.ruleWatcher.Close()
-	}
-	if s.metaWatcher != nil {
-		s.metaWatcher.Close()
-	}
-	if s.configWatcher != nil {
-		s.configWatcher.Close()
-	}
+	return metaWatcher, configWatcher, nil
 }
 
 // GetPersistConfig returns the persist config.

--- a/pkg/mcs/scheduling/server/server_test.go
+++ b/pkg/mcs/scheduling/server/server_test.go
@@ -54,6 +54,16 @@ func TestStopCluster(t *testing.T) {
 	re.Nil(cluster.GetStorage())
 }
 
+func TestGetClusterBeforeStoredDoesNotPanic(t *testing.T) {
+	re := require.New(t)
+	s := &Server{}
+
+	re.NotPanics(func() {
+		re.Nil(s.GetCluster())
+		re.Nil(s.GetBasicCluster())
+	})
+}
+
 // TestMultipleLeaderTermsNoHbStreamGoroutineLeak is a regression test for the
 // production memory leak where each leader→follower transition left behind a
 // leaked hbstream.run() goroutine. The leaked goroutines held a strong GC root

--- a/pkg/mcs/scheduling/server/server_test.go
+++ b/pkg/mcs/scheduling/server/server_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/kvproto/pkg/schedulingpb"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/mcs/utils/constant"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/storage/endpoint"
+	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/utils/testutil"
+)
+
+func TestStopCluster(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hbStreams := hbstream.NewHeartbeatStreams(ctx, constant.SchedulingServiceName, core.NewBasicCluster())
+	storage := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	cluster := &Cluster{hbStreams: hbStreams, storage: storage}
+
+	s := &Server{}
+	s.cluster.Store(cluster)
+
+	s.stopCluster()
+
+	re.Nil(s.GetCluster())
+	re.Nil(cluster.GetHeartbeatStreams())
+	re.Nil(cluster.GetStorage())
+}
+
+// TestMultipleLeaderTermsNoHbStreamGoroutineLeak is a regression test for the
+// production memory leak where each leader→follower transition left behind a
+// leaked hbstream.run() goroutine. The leaked goroutines held a strong GC root
+// to their term's BasicCluster via the storeInformer field, preventing the
+// full region tree (~400 MB/term) from being collected. Four leaked goroutines
+// were confirmed in the follower heap profile (IDs 11227, 1829530, 3823982,
+// 9489109) with a total inuse heap of 1641 MB.
+//
+// The fix: stopCluster() calls cleanupRuntimeResources() which calls
+// hbStreams.Close(). Close() cancels hbStreamCtx and waits (wg.Wait) for
+// run() to exit before returning. The test exploits the LIFO ordering of
+// deferred calls — goleak fires before cancel() — so any goroutine still
+// blocking on ctx.Done() (instead of having been stopped by Close()) is
+// detected as a leak.
+func TestMultipleLeaderTermsNoHbStreamGoroutineLeak(t *testing.T) {
+	// Simulate the server-level root context shared across all leadership terms.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // executes LAST (registered first)
+	// goleak executes FIRST (registered second, LIFO), before cancel().
+	// Goroutines that have not yet exited via Close() are still blocked on
+	// ctx.Done() at this point and will be detected as leaks.
+	defer goleak.VerifyNone(t, testutil.LeakOptions...)
+
+	s := &Server{}
+
+	// Simulate 4 leader→follower transitions on the same server instance,
+	// matching the 4 leaked goroutines observed in the production profile.
+	for range 4 {
+		hbStreams := hbstream.NewHeartbeatStreams(ctx, constant.SchedulingServiceName, core.NewBasicCluster())
+		s.cluster.Store(&Cluster{
+			hbStreams: hbStreams,
+			storage:   endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil),
+		})
+		s.stopCluster()
+	}
+
+	// After all terms, GetCluster() must return nil so incoming heartbeat
+	// requests are rejected rather than processed by a stale cluster.
+	require.Nil(t, s.GetCluster())
+}
+
+func TestRegionHeartbeatReturnsNotBootstrappedWhenHeartbeatStreamsMissing(t *testing.T) {
+	re := require.New(t)
+	cluster := &Cluster{BasicCluster: core.NewBasicCluster()}
+	cluster.PutStore(core.NewStoreInfo(&metapb.Store{Id: 1, Address: "store-1"}))
+	service := &Service{Server: &Server{service: &Service{}}}
+	service.service = service
+	service.cluster.Store(cluster)
+
+	stream := &mockRegionHeartbeatStream{
+		recvs: []*schedulingpb.RegionHeartbeatRequest{{
+			Leader: &metapb.Peer{StoreId: 1},
+			Region: &metapb.Region{Id: 1},
+		}},
+	}
+
+	err := service.RegionHeartbeat(stream)
+	re.NoError(err)
+	re.Len(stream.sent, 1)
+	re.Equal(schedulingpb.ErrorType_NOT_BOOTSTRAPPED, stream.sent[0].GetHeader().GetError().GetType())
+}
+
+func TestStoreHeartbeatReturnsNotBootstrappedWhenMetaWatcherMissing(t *testing.T) {
+	re := require.New(t)
+	service := &Service{Server: &Server{service: &Service{}}}
+	service.service = service
+	service.cluster.Store(&Cluster{BasicCluster: core.NewBasicCluster()})
+
+	resp, err := service.StoreHeartbeat(context.Background(), &schedulingpb.StoreHeartbeatRequest{
+		Stats: &pdpb.StoreStats{StoreId: 1},
+	})
+	re.NoError(err)
+	re.Equal(schedulingpb.ErrorType_NOT_BOOTSTRAPPED, resp.GetHeader().GetError().GetType())
+}
+
+func TestRegionHeartbeatDuringCleanupDoesNotPanic(t *testing.T) {
+	re := require.New(t)
+
+	basicCluster := core.NewBasicCluster()
+	basicCluster.PutStore(core.NewStoreInfo(&metapb.Store{Id: 1, Address: "store-1"}))
+
+	s := &Server{}
+	s.cluster.Store(&Cluster{BasicCluster: basicCluster})
+
+	stream := &mockRegionHeartbeatStream{
+		recvs: []*schedulingpb.RegionHeartbeatRequest{
+			{
+				Region: &metapb.Region{
+					Id:    1,
+					Peers: []*metapb.Peer{{Id: 1, StoreId: 1}},
+				},
+				Leader: &metapb.Peer{Id: 1, StoreId: 1},
+			},
+		},
+	}
+
+	re.NotPanics(func() {
+		_ = (&Service{Server: s}).RegionHeartbeat(stream)
+	})
+	re.Nil(s.GetCluster().GetHeartbeatStreams())
+}
+
+func TestStoreHeartbeatDuringCleanupDoesNotPanic(t *testing.T) {
+	re := require.New(t)
+
+	basicCluster := core.NewBasicCluster()
+	s := &Server{}
+	s.cluster.Store(&Cluster{BasicCluster: basicCluster})
+
+	re.NotPanics(func() {
+		_, _ = (&Service{Server: s}).StoreHeartbeat(context.Background(), &schedulingpb.StoreHeartbeatRequest{
+			Stats: &pdpb.StoreStats{StoreId: 1},
+		})
+	})
+	re.Nil(s.GetCluster().GetMetaWatcher())
+}
+
+func TestClusterResourceGettersHandleNilReceiver(t *testing.T) {
+	re := require.New(t)
+
+	var cluster *Cluster
+	re.Nil(cluster.GetHeartbeatStreams())
+	re.Nil(cluster.GetMetaWatcher())
+	re.Nil(cluster.GetStorage())
+}
+
+type mockRegionHeartbeatStream struct {
+	schedulingpb.Scheduling_RegionHeartbeatServer
+	recvs []*schedulingpb.RegionHeartbeatRequest
+	sent  []*schedulingpb.RegionHeartbeatResponse
+}
+
+func (m *mockRegionHeartbeatStream) Send(resp *schedulingpb.RegionHeartbeatResponse) error {
+	m.sent = append(m.sent, resp)
+	return nil
+}
+
+func (m *mockRegionHeartbeatStream) Recv() (*schedulingpb.RegionHeartbeatRequest, error) {
+	if len(m.recvs) == 0 {
+		return nil, io.EOF
+	}
+	req := m.recvs[0]
+	m.recvs = m.recvs[1:]
+	return req, nil
+}
+
+func (*mockRegionHeartbeatStream) SetHeader(metadata.MD) error  { return nil }
+func (*mockRegionHeartbeatStream) SendHeader(metadata.MD) error { return nil }
+func (*mockRegionHeartbeatStream) SetTrailer(metadata.MD)       {}
+func (*mockRegionHeartbeatStream) Context() context.Context     { return context.Background() }
+func (*mockRegionHeartbeatStream) SendMsg(any) error            { return nil }
+func (*mockRegionHeartbeatStream) RecvMsg(any) error            { return nil }

--- a/pkg/schedule/hbstream/heartbeat_streams.go
+++ b/pkg/schedule/hbstream/heartbeat_streams.go
@@ -126,6 +126,14 @@ func (s *HeartbeatStreams) run() {
 	}
 
 	for {
+		// We need to check the context in each loop to make sure we can exit timely when the stream is closed.
+		select {
+		case <-s.hbStreamCtx.Done():
+			log.Info("heartbeat stream is closed, stop running")
+			return
+		default:
+		}
+
 		select {
 		case update := <-s.streamCh:
 			s.streams[update.storeID] = update.stream
@@ -177,6 +185,7 @@ func (s *HeartbeatStreams) run() {
 				}
 			}
 		case <-s.hbStreamCtx.Done():
+			log.Info("heartbeat stream is closed, stop running")
 			return
 		}
 	}

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -296,6 +296,12 @@ func (c *Controller) PauseOrResumeScheduler(name string, t int64) error {
 
 // ReloadSchedulerConfig reloads a scheduler's config if it exists.
 func (c *Controller) ReloadSchedulerConfig(name string) error {
+	c.RLock()
+	if c.cluster == nil {
+		c.RUnlock()
+		return errs.ErrNotBootstrapped.FastGenByArgs()
+	}
+	c.RUnlock()
 	if exist, _ := c.IsSchedulerExisted(name); !exist {
 		return errs.ErrSchedulerNotFound.FastGenByArgs()
 	}

--- a/pkg/schedule/schedulers/scheduler_test.go
+++ b/pkg/schedule/schedulers/scheduler_test.go
@@ -62,6 +62,19 @@ func prepareSchedulersTest(needToRunStream ...bool) (func(), config.SchedulerCon
 	return clean, opt, tc, oc
 }
 
+func TestReloadSchedulerConfigWithoutSchedulerDoesNotPanic(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	c := NewController(context.Background(), tc, storage.NewStorageWithMemoryBackend(), oc)
+	c.schedulerHandlers["test-scheduler"] = nil
+
+	re.NotPanics(func() {
+		re.Error(c.ReloadSchedulerConfig("test-scheduler"))
+	})
+}
+
 func TestShuffleLeader(t *testing.T) {
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #10644

### What is changed and how does it work?

```commit-message
bind scheduling primary resources to the primary campaign context so they stop when
the primary exits. add cleanup for heartbeat streams, watchers, and in-memory
cluster references, and roll back partially initialized resources on startup
failure.
```

### Check List

Tests

- Unit test

1. create 30w regions  
2.  transfer scheduler primary every 10 min utils 1 hour
<img width="1280" height="359" alt="image" src="https://github.com/user-attachments/assets/34fc5214-791a-44f5-a3d3-88146662c1f1" />


### Release note

```release-note
Fix stale in-memory scheduling state retention after scheduling primary exits.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale suspect ranges from persisting after watcher shutdown.
  * Heartbeat endpoints now return "not bootstrapped" when required stream/monitoring components or cluster state are unavailable.

* **Improvements**
  * Refined cluster start/stop flow with explicit, idempotent cleanup to avoid partial state and ensure watchers/streams are closed.
  * API handlers now validate cluster readiness and return an error when uninitialized.
  * Affinity manager starts availability checks after initialization.

* **Tests**
  * Added tests validating cleanup idempotency and safe heartbeat behavior during teardown.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/pd/pull/10645)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->