### PR TITLE
client, tso: support multi-node TSO discovery (#10455)

### DIFF
--- a/client/servicediscovery/tso_service_discovery.go
+++ b/client/servicediscovery/tso_service_discovery.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math/rand/v2"
 	"reflect"
 	"strconv"
 	"strings"
@@ -55,6 +56,10 @@ const (
 
 var _ ServiceDiscovery = (*tsoServiceDiscovery)(nil)
 
+// errNoPrimaryURL is returned when the queried TSO node knows the keyspace group meta
+// but does not serve its allocator, so no primary URL is available from that node.
+var errNoPrimaryURL = errors.New("no primary url found in the keyspace group")
+
 // keyspaceGroupSvcDiscovery is used for discovering the serving endpoints of the keyspace
 // group to which the keyspace belongs
 type keyspaceGroupSvcDiscovery struct {
@@ -78,25 +83,27 @@ func (k *keyspaceGroupSvcDiscovery) getModRevision() uint64 {
 	return k.modRevision.Load()
 }
 
+// metaChanged indicates whether the keyspace group meta has been updated,
+// it doesn't include the change of primary URLs.
 func (k *keyspaceGroupSvcDiscovery) update(
 	keyspaceGroup *tsopb.KeyspaceGroup,
 	newPrimaryURL string,
 	secondaryURLs, urls []string,
 	modRevision uint64,
-) (oldPrimaryURL string, primarySwitched, success bool) {
+) (oldPrimaryURL string, primarySwitched, metaChanged bool) {
 	k.Lock()
 	defer k.Unlock()
+	// the mod revision just ensures the member use is the latest one, and the primary can't be protected by the mod revision.
 	if k.getModRevision() > modRevision {
 		return "", false, false
 	}
-	success = true
 	// If the new primary URL is empty, we don't switch the primary URL.
 	oldPrimaryURL = k.primaryURL
 	if len(newPrimaryURL) > 0 {
 		primarySwitched = !strings.EqualFold(oldPrimaryURL, newPrimaryURL)
 		k.primaryURL = newPrimaryURL
 	}
-
+	metaChanged = true
 	if !reflect.DeepEqual(k.secondaryURLs, secondaryURLs) {
 		k.secondaryURLs = secondaryURLs
 	}
@@ -482,9 +489,31 @@ func (c *tsoServiceDiscovery) updateMember() error {
 		return err
 	}
 
+	failpoint.Inject("tsoServerURLOverride", func(val failpoint.Value) {
+		if val, ok := val.(string); ok {
+			tsoServerURL = val
+		}
+	})
+
+	err = c.updateMemberInner(tsoServerURL)
+	// the url is not one of the group members, so it can't get the primary URL but can get the keyspace meta info.
+	// If met errNoPrimaryURL error, it should try to get primary url from the member url.
+	if errors.ErrorEqual(err, errNoPrimaryURL) {
+		urls := c.getSecondaryURLs()
+		if len(urls) == 0 {
+			return err
+		}
+		url := urls[rand.IntN(len(urls))]
+		err = c.updateMemberInner(url)
+	}
+	return err
+}
+
+func (c *tsoServiceDiscovery) updateMemberInner(tsoServerURL string) error {
 	keyspaceID := c.GetKeyspaceID()
 	var keyspaceGroup *tsopb.KeyspaceGroup
 	var modRevision uint64
+	var err error
 	curModRevision := c.keyspaceGroupSD.getModRevision()
 	if len(tsoServerURL) > 0 {
 		keyspaceGroup, modRevision, err = c.findGroupByKeyspaceID(keyspaceID, tsoServerURL, UpdateMemberTimeout, c.keyspaceGroupSD.getModRevision())
@@ -579,12 +608,9 @@ func (c *tsoServiceDiscovery) updateMember() error {
 		}
 	}
 
-	oldPrimary, primarySwitched, success :=
+	oldPrimary, primarySwitched, metaChanged :=
 		c.keyspaceGroupSD.update(keyspaceGroup, primaryURL, secondaryURLs, urls, modRevision)
-	if !success {
-		log.Warn("[tso] failed to update keyspace group, met stale keyspace group info", zap.Uint64("modRevision", modRevision))
-		return errors.Errorf("keyspace group modRevision is stale, current modRevision: %d, new modRevision: %d", c.keyspaceGroupSD.getModRevision(), modRevision)
-	}
+
 	if primarySwitched {
 		log.Info("[tso] updated keyspace group service discovery info",
 			zap.Uint32("keyspace-id-in-request", keyspaceID),
@@ -598,7 +624,11 @@ func (c *tsoServiceDiscovery) updateMember() error {
 	// Even if the primary URL is empty, we still updated other returned info above, including the
 	// keyspace group info and the secondary url.
 	if len(primaryURL) == 0 {
-		return errors.New("no primary URL found")
+		return errNoPrimaryURL
+	}
+	if !metaChanged {
+		log.Warn("[tso] failed to update keyspace group, met stale keyspace group info", zap.Uint64("modRevision", modRevision))
+		return errors.Errorf("keyspace group modRevision is stale, current modRevision: %d, new modRevision: %d", c.keyspaceGroupSD.getModRevision(), modRevision)
 	}
 	return nil
 }

--- a/client/servicediscovery/tso_service_discovery_test.go
+++ b/client/servicediscovery/tso_service_discovery_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicediscovery
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/tsopb"
+)
+
+func TestKeyspaceGroupSvcDiscoveryUpdateKeepsPrimary(t *testing.T) {
+	re := require.New(t)
+	originalGroup := &tsopb.KeyspaceGroup{Id: 1}
+	newGroup := &tsopb.KeyspaceGroup{Id: 2}
+	k := &keyspaceGroupSvcDiscovery{
+		group:         originalGroup,
+		primaryURL:    "http://primary-1",
+		secondaryURLs: []string{"http://secondary-1"},
+		urls:          []string{"http://primary-1", "http://secondary-1"},
+		modRevision:   atomic.Uint64{},
+	}
+	k.modRevision.Store(10)
+
+	oldPrimaryURL, primarySwitched, metaChanged := k.update(
+		newGroup,
+		"http://primary-2",
+		[]string{"http://secondary-2"},
+		[]string{"http://primary-2", "http://secondary-2"},
+		9,
+	)
+
+	re.Empty(oldPrimaryURL)
+	re.False(primarySwitched)
+	re.False(metaChanged)
+	re.Equal("http://primary-1", k.primaryURL)
+	re.Equal([]string{"http://secondary-1"}, k.secondaryURLs)
+	re.Equal([]string{"http://primary-1", "http://secondary-1"}, k.urls)
+	re.Same(originalGroup, k.group)
+	re.Equal(uint64(10), k.getModRevision())
+}
+
+func TestKeyspaceGroupSvcDiscoveryUpdateUpdatesAllFieldsOnFreshRevision(t *testing.T) {
+	re := require.New(t)
+	newGroup := &tsopb.KeyspaceGroup{Id: 2}
+	k := &keyspaceGroupSvcDiscovery{
+		primaryURL:    "http://primary-1",
+		secondaryURLs: []string{"http://secondary-1"},
+		urls:          []string{"http://primary-1", "http://secondary-1"},
+		modRevision:   atomic.Uint64{},
+	}
+	k.modRevision.Store(10)
+
+	oldPrimaryURL, primarySwitched, metaChanged := k.update(
+		newGroup,
+		"http://primary-2",
+		[]string{"http://secondary-2"},
+		[]string{"http://primary-2", "http://secondary-2"},
+		11,
+	)
+
+	re.Equal("http://primary-1", oldPrimaryURL)
+	re.True(primarySwitched)
+	re.True(metaChanged)
+	re.Equal("http://primary-2", k.primaryURL)
+	re.Equal([]string{"http://secondary-2"}, k.secondaryURLs)
+	re.Equal([]string{"http://primary-2", "http://secondary-2"}, k.urls)
+	re.Same(newGroup, k.group)
+	re.Equal(uint64(11), k.getModRevision())
+}

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -234,6 +234,12 @@ func getHealth(c *gin.Context) {
 	}
 	allocator, err := svr.GetKeyspaceGroupManager().GetAllocator(constant.DefaultKeyspaceGroupID)
 	if err != nil {
+		// The allocator is absent on this node, e.g. it has watched the keyspace group meta
+		// but does not serve the allocator for the default keyspace group.
+		if errs.ErrGetAllocator.Equal(err) {
+			c.String(http.StatusNotFound, "allocator not found")
+			return
+		}
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/pkg/mcs/tso/server/grpc_service.go
+++ b/pkg/mcs/tso/server/grpc_service.go
@@ -140,7 +140,9 @@ func (s *Service) FindGroupByKeyspaceID(
 			Header: wrapErrorToHeader(tsopb.ErrorType_INVALID_VALUE, errs.ErrKeyspaceGroupModRevisionStale.Error(), respKeyspaceGroup),
 		}, nil
 	}
-	if err != nil {
+	// If the error is the ErrGetAllocator, it indicates the server have watched the keyspace group meta.
+	// But this node's server is not one of the members.
+	if err != nil && !errs.ErrGetAllocator.Equal(err) {
 		return &tsopb.FindGroupByKeyspaceIDResponse{
 			Header: wrapErrorToHeader(tsopb.ErrorType_UNKNOWN, err.Error(), keyspaceGroupID),
 		}, nil

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -926,7 +926,9 @@ func (kgm *KeyspaceGroupManager) updateKeyspaceGroupMembership(
 	if oldGroup != nil {
 		// SplitTarget -> !Splitting
 		if oldGroup.IsSplitTarget() && !newGroup.IsSplitting() {
-			kgm.allocators[groupID].GetMember().(*member.Participant).SetCampaignChecker(nil)
+			if allocator := kgm.allocators[groupID]; allocator != nil {
+				allocator.GetMember().(*member.Participant).SetCampaignChecker(nil)
+			}
 			splitTime := kgm.splittingGroups[groupID]
 			delete(kgm.splittingGroups, groupID)
 			kgm.metrics.splitTargetGauge.Dec()
@@ -1052,7 +1054,7 @@ func (kgm *KeyspaceGroupManager) FindGroupByKeyspaceID(
 	curAllocator, curKeyspaceGroup, curKeyspaceGroupID, modRevision, err :=
 		kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, constant.DefaultKeyspaceGroupID)
 	if err != nil {
-		return nil, nil, curKeyspaceGroupID, modRevision, err
+		return nil, curKeyspaceGroup, curKeyspaceGroupID, modRevision, err
 	}
 	return curAllocator, curKeyspaceGroup, curKeyspaceGroupID, modRevision, nil
 }

--- a/tests/integrations/mcs/tso/keyspace_group_manager_test.go
+++ b/tests/integrations/mcs/tso/keyspace_group_manager_test.go
@@ -36,6 +36,7 @@ import (
 	clierrs "github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/caller"
+	sd "github.com/tikv/pd/client/servicediscovery"
 	"github.com/tikv/pd/pkg/election"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/keyspace"
@@ -97,7 +98,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) SetupSuite() {
 	re.NotEmpty(leaderName)
 	suite.pdLeaderServer = suite.cluster.GetServer(leaderName)
 	re.NoError(suite.pdLeaderServer.BootstrapCluster())
-	suite.tsoCluster, err = tests.NewTestTSOCluster(suite.ctx, 2, suite.pdLeaderServer.GetAddr())
+	suite.tsoCluster, err = tests.NewTestTSOCluster(suite.ctx, 3, suite.pdLeaderServer.GetAddr())
 	re.NoError(err)
 	suite.allocator = mockid.NewIDAllocator()
 	err = suite.allocator.SetBase(uint64(time.Now().Second()))
@@ -126,9 +127,101 @@ func cleanupKeyspaceGroups(re *require.Assertions, server *tests.TestServer) {
 	}
 }
 
+func (suite *tsoKeyspaceGroupManagerTestSuite) TestMultiNodes() {
+	re := suite.Require()
+
+	keyspaceGroupID := suite.allocID()
+	keyspaceIDs := []uint32{suite.allocID(), suite.allocID(), suite.allocID()}
+	cli := utils.SetupClientWithKeyspaceID(suite.ctx, re, 200, []string{suite.pdLeaderServer.GetAddr()},
+		opt.WithForwardingOption(true))
+	defer cli.Close()
+	re.NotNil(cli)
+	clusterID := cli.GetClusterID(suite.ctx)
+	servers := suite.tsoCluster.GetServers()
+	serverList := make([]*tso.Server, 0)
+	for _, s := range servers {
+		serverList = append(serverList, s)
+	}
+	re.Len(serverList, 3)
+
+	handlersutil.MustCreateKeyspaceGroup(re, suite.pdLeaderServer, &handlers.CreateKeyspaceGroupParams{
+		KeyspaceGroups: []*endpoint.KeyspaceGroup{
+			{
+				ID:       keyspaceGroupID,
+				UserKind: endpoint.Standard.String(),
+				Members: []endpoint.KeyspaceGroupMember{
+					{Address: serverList[0].GetAddr(), Priority: mcs.DefaultKeyspaceGroupReplicaPriority},
+					{Address: serverList[1].GetAddr(), Priority: mcs.DefaultKeyspaceGroupReplicaPriority},
+				},
+				Keyspaces: keyspaceIDs,
+			},
+		},
+	})
+	suite.waitKeyspaceReady([]uint32{keyspaceGroupID}, keyspaceIDs)
+
+	checkFn := func(groupID, keyspaceID uint32) {
+		req := tsopb.FindGroupByKeyspaceIDRequest{
+			Header: &tsopb.RequestHeader{
+				ClusterId:       clusterID,
+				KeyspaceId:      keyspaceID,
+				KeyspaceGroupId: groupID,
+			},
+			KeyspaceId:  keyspaceID,
+			ModRevision: 0,
+		}
+		for i, server := range serverList {
+			conn, err := cli.GetServiceDiscovery().GetOrCreateGRPCConn(server.GetAddr())
+			re.NoError(err)
+			resp, err := tsopb.NewTSOClient(conn).FindGroupByKeyspaceID(suite.ctx, &req)
+			re.NoError(err)
+			re.Nil(resp.GetHeader().GetError())
+			members := resp.KeyspaceGroup.Members
+			re.Equal(groupID, resp.KeyspaceGroup.Id)
+			re.Len(resp.KeyspaceGroup.Members, 2)
+			foundLeader := false
+			for _, member := range members {
+				if member.IsPrimary {
+					foundLeader = true
+					break
+				}
+			}
+			if i < 2 {
+				re.True(foundLeader)
+			} else {
+				re.False(foundLeader)
+			}
+
+			cli := utils.SetupClientWithKeyspaceID(suite.ctx, re, keyspaceID, []string{suite.pdLeaderServer.GetAddr()},
+				opt.WithForwardingOption(true))
+			re.NotNil(cli)
+			inner, ok := cli.(interface{ GetTSOServiceDiscovery() sd.ServiceDiscovery })
+			re.True(ok)
+			point := fmt.Sprintf("return(\"%s\")", server.GetAddr())
+			re.NoError(failpoint.Enable("github.com/tikv/pd/client/servicediscovery/tsoServerURLOverride", point))
+			discovery := inner.GetTSOServiceDiscovery()
+			re.NoError(discovery.CheckMemberChanged())
+			re.NotEmpty(discovery.GetServingURL())
+			re.Equal(groupID, discovery.GetKeyspaceGroupID())
+			re.NoError(failpoint.Disable("github.com/tikv/pd/client/servicediscovery/tsoServerURLOverride"))
+			cli.Close()
+		}
+	}
+	checkFn(keyspaceGroupID, keyspaceIDs[0])
+
+	// split keyspaceID-1 and keyspaceID-2 into new keyspace group
+	newGroupID := suite.allocID()
+	handlersutil.MustSplitKeyspaceGroup(re, suite.pdLeaderServer, keyspaceGroupID, &handlers.SplitKeyspaceGroupByIDParams{
+		NewID:     newGroupID,
+		Keyspaces: []uint32{keyspaceIDs[1], keyspaceIDs[2]},
+	})
+	suite.waitKeyspaceReady([]uint32{newGroupID}, []uint32{keyspaceIDs[1], keyspaceIDs[2]})
+	handlersutil.MustFinishSplitKeyspaceGroup(re, suite.pdLeaderServer, newGroupID)
+	// keyspaceID-0 still belongs to the source group, keyspaceID-1 now belongs to the new group.
+	checkFn(keyspaceGroupID, keyspaceIDs[0])
+	checkFn(newGroupID, keyspaceIDs[1])
+}
+
 func (suite *tsoKeyspaceGroupManagerTestSuite) TestWatchFailed() {
-	// There is only default keyspace group. Any keyspace, which hasn't been assigned to
-	// a keyspace group before, will be served by the default keyspace group.
 	re := suite.Require()
 
 	keyspaceGroupID := suite.allocID()
@@ -177,7 +270,7 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) TestWatchFailed() {
 		}
 		re.NoError(err)
 		re.Nil(resp.GetHeader().GetError())
-		re.Len(resp.KeyspaceGroup.Members, 2)
+		re.Len(resp.KeyspaceGroup.Members, 3)
 		re.Equal(groupID, resp.KeyspaceGroup.Id)
 		re.GreaterOrEqual(resp.GetModRevision(), modRevision)
 		modRevision = resp.GetModRevision()
@@ -227,6 +320,59 @@ func (suite *tsoKeyspaceGroupManagerTestSuite) TestWatchFailed() {
 		Message: "[PD:keyspace:ErrKeyspaceGroupModRevisionStale]keyspace group mod revision is stale",
 	}
 	checkFn(newGroupID, keyspaceIDs[1], secondAddress, terr)
+}
+
+// ref: https://github.com/tikv/pd/issues/6770
+func (suite *tsoKeyspaceGroupManagerTestSuite) TestClientDoesNotFallbackToDefaultGroupOnUninitializedTSONode() {
+	re := suite.Require()
+	keyspaceGroupID := suite.allocID()
+	keyspaceIDs := []uint32{suite.allocID(), suite.allocID(), suite.allocID()}
+
+	servers := suite.tsoCluster.GetServers()
+	serverList := make([]*tso.Server, 0)
+	for _, s := range servers {
+		serverList = append(serverList, s)
+	}
+	point := fmt.Sprintf("return(\"%s\")", serverList[0].GetAddr())
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/tso/SkipKeyspaceWatch", point))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/tso/SkipKeyspaceWatch"))
+	}()
+
+	handlersutil.MustCreateKeyspaceGroup(re, suite.pdLeaderServer, &handlers.CreateKeyspaceGroupParams{
+		KeyspaceGroups: []*endpoint.KeyspaceGroup{
+			{
+				ID:       keyspaceGroupID,
+				UserKind: endpoint.Standard.String(),
+				Members: []endpoint.KeyspaceGroupMember{
+					{Address: serverList[0].GetAddr(), Priority: mcs.DefaultKeyspaceGroupReplicaPriority},
+					{Address: serverList[1].GetAddr(), Priority: mcs.DefaultKeyspaceGroupReplicaPriority},
+				},
+				Keyspaces: keyspaceIDs,
+			},
+		},
+	})
+	cli := utils.SetupClientWithKeyspaceID(suite.ctx, re, keyspaceIDs[0], []string{suite.pdLeaderServer.GetAddr()},
+		opt.WithForwardingOption(true))
+	defer cli.Close()
+	re.NotNil(cli)
+	inner, ok := cli.(interface{ GetTSOServiceDiscovery() sd.ServiceDiscovery })
+	re.True(ok)
+	dis := inner.GetTSOServiceDiscovery()
+	re.NoError(dis.CheckMemberChanged())
+	re.Equal(serverList[1].GetAddr(), dis.GetServingURL())
+	re.Equal(keyspaceGroupID, dis.GetKeyspaceGroupID())
+
+	// request must forward to the second server, and won't fallback to default keyspace group even if the first server is uninitialized.
+	point1 := fmt.Sprintf("return(\"%s\")", serverList[0].GetAddr())
+	re.NoError(failpoint.Enable("github.com/tikv/pd/client/servicediscovery/tsoServerURLOverride", point1))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/client/servicediscovery/tsoServerURLOverride"))
+	}()
+	// modRevision is stale
+	re.ErrorContains(dis.CheckMemberChanged(), "ErrKeyspaceGroupModRevisionStale")
+	re.Equal(serverList[1].GetAddr(), dis.GetServingURL())
+	re.Equal(keyspaceGroupID, dis.GetKeyspaceGroupID())
 }
 
 func (suite *tsoKeyspaceGroupManagerTestSuite) TestKeyspacesServedByDefaultKeyspaceGroup() {


### PR DESCRIPTION

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
tso client and server discovery now tolerate requests landing on a TSO node that has keyspace group metadata but does not serve the allocator for that group.

The server keeps returning keyspace group metadata for ErrGetAllocator cases, the client retries another TSO node when no primary is returned, the health API returns 404 when an allocator is absent, and allocator access during split-state transitions is guarded for nil cases. Integration coverage is added for
multi-node TSO discovery and split scenarios.\n\nSigned-off-by: tongjian <1045931706@qq.com>\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #10454

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
