### PR TITLE
server/join: reject join reusing another member's client URL

### DIFF
--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -118,7 +118,7 @@ func AddEtcdMember(client *clientv3.Client, urls []string) (*clientv3.MemberAddR
 // contacted server's local data (not linearizable), so an isolated or lagging
 // endpoint may return a stale view.
 func ListEtcdMembers(ctx context.Context, client *clientv3.Client) (*clientv3.MemberListResponse, error) {
-	return listEtcdMembers(ctx, client, false)
+	return queryEtcdMembers(ctx, client, false)
 }
 
 // ListEtcdMembersLinearizable returns a list of internal etcd members with a
@@ -126,10 +126,10 @@ func ListEtcdMembers(ctx context.Context, client *clientv3.Client) (*clientv3.Me
 // server is disconnected from quorum. Use it when the membership view must
 // reflect the latest committed state, e.g. join admission decisions.
 func ListEtcdMembersLinearizable(ctx context.Context, client *clientv3.Client) (*clientv3.MemberListResponse, error) {
-	return listEtcdMembers(ctx, client, true)
+	return queryEtcdMembers(ctx, client, true)
 }
 
-func listEtcdMembers(ctx context.Context, client *clientv3.Client, linearizable bool) (*clientv3.MemberListResponse, error) {
+func queryEtcdMembers(ctx context.Context, client *clientv3.Client, linearizable bool) (*clientv3.MemberListResponse, error) {
 	failpoint.Inject("SlowEtcdMemberList", func(val failpoint.Value) {
 		d := val.(int)
 		time.Sleep(time.Duration(d) * time.Second)

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -114,8 +114,22 @@ func AddEtcdMember(client *clientv3.Client, urls []string) (*clientv3.MemberAddR
 	return addResp, errors.WithStack(err)
 }
 
-// ListEtcdMembers returns a list of internal etcd members.
+// ListEtcdMembers returns a list of internal etcd members. It is served from the
+// contacted server's local data (not linearizable), so an isolated or lagging
+// endpoint may return a stale view.
 func ListEtcdMembers(ctx context.Context, client *clientv3.Client) (*clientv3.MemberListResponse, error) {
+	return listEtcdMembers(ctx, client, false)
+}
+
+// ListEtcdMembersLinearizable returns a list of internal etcd members with a
+// linearizable guarantee (served through quorum). It fails if the contacted
+// server is disconnected from quorum. Use it when the membership view must
+// reflect the latest committed state, e.g. join admission decisions.
+func ListEtcdMembersLinearizable(ctx context.Context, client *clientv3.Client) (*clientv3.MemberListResponse, error) {
+	return listEtcdMembers(ctx, client, true)
+}
+
+func listEtcdMembers(ctx context.Context, client *clientv3.Client, linearizable bool) (*clientv3.MemberListResponse, error) {
 	failpoint.Inject("SlowEtcdMemberList", func(val failpoint.Value) {
 		d := val.(int)
 		time.Sleep(time.Duration(d) * time.Second)
@@ -126,7 +140,7 @@ func ListEtcdMembers(ctx context.Context, client *clientv3.Client) (*clientv3.Me
 	// If Linearizable is set to false, the member list will be returned with server's local data.
 	// If Linearizable is set to true, it is served with linearizable guarantee. If the server is disconnected from quorum, `MemberList` call will fail.
 	c := clientv3.RetryClusterClient(client)
-	resp, err := c.MemberList(newCtx, &etcdserverpb.MemberListRequest{Linearizable: false})
+	resp, err := c.MemberList(newCtx, &etcdserverpb.MemberListRequest{Linearizable: linearizable})
 	cancel()
 	if err != nil {
 		return (*clientv3.MemberListResponse)(resp), errs.ErrEtcdMemberList.Wrap(err).GenWithStackByCause()

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -15,48 +15,31 @@
 package join
 
 import (
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/zap"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/slice"
-	"github.com/tikv/pd/pkg/storage/kv"
 )
-
-// clientURLOwner identifies the member that has claimed a client URL. Peer URLs
-// are globally unique per member (etcd enforces peer-URL uniqueness) and stable
-// across restarts, so they — not the name — decide whether a registry entry
-// belongs to "me". This closes the gap where two nodes sharing a name would
-// otherwise both accept a claim keyed only by name.
-type clientURLOwner struct {
-	Name     string   `json:"name"`
-	PeerURLs []string `json:"peer_urls"`
-}
-
-// clientURLRegistryPath returns the etcd key that records which member owns a
-// given advertised client URL. The URL is hex-encoded so it forms a single,
-// slash-free key segment.
-func clientURLRegistryPath(clusterID uint64, clientURL string) string {
-	return fmt.Sprintf("/pd/%d/member/client-urls/%s", clusterID, hex.EncodeToString([]byte(clientURL)))
-}
 
 // checkClientURLConflict rejects the member if any *other* member in the current
 // member list already advertises one of advertiseClientURLs. "Other" is decided
 // by peer URLs (unique per member), not name, so a different member that happens
-// to share our name is still checked. This catches the common case where an
-// existing, live member owns the URL — e.g. issue #10999.
+// to share our name is still checked. This catches the case where an existing,
+// published member already owns the URL — e.g. a joining or restarting member
+// reusing another member's client URL (issue #10999).
 //
-// It is read-only (no etcd write, no quorum requirement), so it runs on every
-// startup — fresh join and a restart that changed its advertise-client-urls
-// alike — without ever blocking a member that needs to restart to *restore*
-// quorum.
+// It is read-only (no etcd write, no quorum requirement), so it can run on the
+// join and restart-with-data paths without ever blocking a member that needs to
+// restart to *restore* quorum.
+//
+// Scope / follow-ups: this only detects a conflict against members that have
+// already published their client URLs, so it does not by itself close the
+// window between two concurrent joiners/restarts before either publishes, nor
+// does it cover a member bootstrapped with --initial-cluster (which never
+// reaches this path). Making membership uniqueness authoritative (an atomic
+// reservation bound to the member lifecycle) and verifying responder identity in
+// health checks are tracked separately.
 func checkClientURLConflict(
 	advertiseClientURLs []string,
 	advertisePeerURLs []string,
@@ -77,65 +60,6 @@ func checkClientURLConflict(
 				}
 			}
 		}
-	}
-	return nil
-}
-
-// claimClientURLs atomically claims each advertised client URL in an etcd
-// registry via a create-if-absent transaction. Because the transaction is
-// serialized through raft, two concurrent joiners cannot both take the same
-// client URL: the first wins and a later joiner — even one sharing the same name
-// — finds a different peer URL in the owner record and is rejected.
-//
-// The registry entry is keyed by URL and valued by the owner's identity (name +
-// peer URLs). This writes to etcd (needs quorum) and is therefore only used on
-// the fresh-join path, where quorum is required anyway for MemberAdd; a restart
-// relies on the read-only checkClientURLConflict instead.
-//
-// Known limitation: the claim is persistent, so if a member is removed and a
-// *different* member later wants to reuse its client URL, the stale entry must
-// be cleaned up first. Cleanup on member removal is tracked as follow-up work.
-func claimClientURLs(
-	client *clientv3.Client,
-	clusterID uint64,
-	name string,
-	advertiseClientURLs []string,
-	advertisePeerURLs []string,
-) error {
-	self := clientURLOwner{Name: name, PeerURLs: advertisePeerURLs}
-	value, err := json.Marshal(self)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	for _, url := range advertiseClientURLs {
-		key := clientURLRegistryPath(clusterID, url)
-		resp, err := kv.NewSlowLogTxn(client).
-			If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0)).
-			Then(clientv3.OpPut(key, string(value))).
-			Else(clientv3.OpGet(key)).
-			Commit()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		if resp.Succeeded {
-			continue // freshly claimed
-		}
-		// The key already exists; make sure the owner is this member (matched by
-		// peer URLs), otherwise reject.
-		kvs := resp.Responses[0].GetResponseRange().Kvs
-		if len(kvs) == 0 {
-			return errors.Errorf("failed to claim advertise-client-urls %q, please retry", url)
-		}
-		var owner clientURLOwner
-		if err := json.Unmarshal(kvs[0].Value, &owner); err != nil {
-			return errors.Errorf("advertise-client-urls %q is claimed by an unrecognized owner", url)
-		}
-		if !slice.EqualWithoutOrder(owner.PeerURLs, advertisePeerURLs) {
-			return errors.Errorf(
-				"advertise-client-urls %q is already claimed by member %q", url, owner.Name)
-		}
-		log.Info("re-claimed an advertised client URL owned by this member",
-			zap.String("name", name), zap.String("client-url", url))
 	}
 	return nil
 }

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -1,0 +1,112 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+
+	"github.com/tikv/pd/pkg/storage/kv"
+)
+
+// clientURLRegistryPath returns the etcd key that records which member owns a
+// given advertised client URL. The URL is hex-encoded so it forms a single,
+// slash-free key segment.
+func clientURLRegistryPath(clusterID uint64, clientURL string) string {
+	return fmt.Sprintf("/pd/%d/member/client-urls/%s", clusterID, hex.EncodeToString([]byte(clientURL)))
+}
+
+// checkAndClaimClientURLs makes sure none of advertiseClientURLs is already
+// owned by another member, then atomically claims each URL in an etcd registry.
+//
+// It is intentionally a standalone function (not folded into the join member
+// loop) so the same logic can be reused on any startup path. It has two layers:
+//
+//  1. Reject if any *other* member in the current member list already advertises
+//     one of these client URLs. This catches the common case where an existing,
+//     live member owns the URL — e.g. a joining member reusing a Service URL
+//     while pointing --join elsewhere (issue #10999).
+//  2. Atomically claim each URL via an etcd transaction (create-if-absent). This
+//     guards against concurrent joiners that have not published their client
+//     URLs yet: the first claimer wins; a later joiner finds the key already
+//     owned by another member and is rejected.
+//
+// The registry entry is keyed by URL and valued by member name; a restart or a
+// previous failed-start incarnation keeps the same name and therefore re-claims
+// its own URL without error.
+//
+// Known limitation: the claim is persistent, so if a member is removed and a
+// *different* member later wants to reuse its client URL, the stale entry must
+// be cleaned up first. Cleanup on member removal is tracked as follow-up work.
+func checkAndClaimClientURLs(
+	client *clientv3.Client,
+	clusterID uint64,
+	name string,
+	advertiseClientURLs []string,
+	members []*etcdserverpb.Member,
+) error {
+	// Layer 1: reject against the current member list.
+	for _, url := range advertiseClientURLs {
+		for _, m := range members {
+			// Skip our own entry (a normal restart or a previous failed-start
+			// incarnation keeps the same name).
+			if m.Name == name {
+				continue
+			}
+			for _, owned := range m.ClientURLs {
+				if owned == url {
+					return errors.Errorf(
+						"advertise-client-urls %q is already used by member %q (id %d)",
+						url, m.Name, m.ID)
+				}
+			}
+		}
+	}
+
+	// Layer 2: atomically claim each URL.
+	for _, url := range advertiseClientURLs {
+		key := clientURLRegistryPath(clusterID, url)
+		resp, err := kv.NewSlowLogTxn(client).
+			If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0)).
+			Then(clientv3.OpPut(key, name)).
+			Else(clientv3.OpGet(key)).
+			Commit()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if resp.Succeeded {
+			continue // freshly claimed
+		}
+		// The key already exists; make sure we are the owner.
+		kvs := resp.Responses[0].GetResponseRange().Kvs
+		if len(kvs) == 0 {
+			return errors.Errorf("failed to claim advertise-client-urls %q, please retry", url)
+		}
+		if owner := string(kvs[0].Value); owner != name {
+			return errors.Errorf(
+				"advertise-client-urls %q is already claimed by member %q", url, owner)
+		}
+		log.Info("re-claimed an advertised client URL owned by this member",
+			zap.String("name", name), zap.String("client-url", url))
+	}
+	return nil
+}

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -17,6 +17,7 @@ package join
 import (
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -32,11 +33,11 @@ import (
 // (notably IPv6) are reduced to their canonical form. If the input cannot be
 // parsed it is returned trimmed but otherwise unchanged, so comparison degrades
 // to the raw string rather than silently treating a bad URL as matching.
-func canonicalizeURL(raw string) string {
+func canonicalizeURL(raw string) (string, error) {
 	s := strings.TrimSpace(raw)
 	u, err := url.Parse(s)
 	if err != nil || u.Host == "" {
-		return s
+		return s, err
 	}
 	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
 	if ip := net.ParseIP(host); ip != nil {
@@ -44,18 +45,30 @@ func canonicalizeURL(raw string) string {
 	}
 	hostport := host
 	if port := u.Port(); port != "" {
-		hostport = net.JoinHostPort(host, port)
+		// Convert forms such as "02379" to "2379".
+		portNum, err := strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			return s, err
+		}
+		hostport = net.JoinHostPort(
+			host,
+			strconv.FormatUint(portNum, 10),
+		)
 	}
-	return strings.ToLower(u.Scheme) + "://" + hostport
+	return strings.ToLower(u.Scheme) + "://" + hostport, nil
 }
 
 // canonicalizeURLs canonicalizes each URL in the slice.
-func canonicalizeURLs(raws []string) []string {
+func canonicalizeURLs(raws []string) ([]string, error) {
 	out := make([]string, len(raws))
 	for i, raw := range raws {
-		out[i] = canonicalizeURL(raw)
+		var err error
+		out[i], err = canonicalizeURL(raw)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid URL %q", raw)
+		}
 	}
-	return out
+	return out, nil
 }
 
 // checkClientURLConflict rejects the member if any *other* member in the current
@@ -84,20 +97,35 @@ func checkClientURLConflict(
 	advertisePeerURLs []string,
 	members []*etcdserverpb.Member,
 ) error {
-	selfPeers := canonicalizeURLs(advertisePeerURLs)
+	selfPeers, err := canonicalizeURLs(advertisePeerURLs)
+	if err != nil {
+		return err
+	}
 	// canonical client URL -> the original string, for a readable error.
 	self := make(map[string]string, len(advertiseClientURLs))
 	for _, raw := range advertiseClientURLs {
-		self[canonicalizeURL(raw)] = raw
+		canon, err := canonicalizeURL(raw)
+		if err != nil {
+			return err
+		}
+		self[canon] = raw
 	}
 	for _, m := range members {
 		// Skip only our own entry, matched by peer URLs so a different member
 		// sharing our name is still checked.
-		if slice.EqualWithoutOrder(canonicalizeURLs(m.PeerURLs), selfPeers) {
+		canonPeerURLs, err := canonicalizeURLs(m.PeerURLs)
+		if err != nil {
+			return err
+		}
+		if slice.EqualWithoutOrder(canonPeerURLs, selfPeers) {
 			continue
 		}
 		for _, owned := range m.ClientURLs {
-			if orig, ok := self[canonicalizeURL(owned)]; ok {
+			canonOwned, err := canonicalizeURL(owned)
+			if err != nil {
+				return err
+			}
+			if orig, ok := self[canonOwned]; ok {
 				return errors.Errorf(
 					"advertise-client-urls %q is already used by member %q (id %d)",
 					orig, m.Name, m.ID)

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -16,6 +16,7 @@ package join
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -25,8 +26,19 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 
+	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/storage/kv"
 )
+
+// clientURLOwner identifies the member that has claimed a client URL. Peer URLs
+// are globally unique per member (etcd enforces peer-URL uniqueness) and stable
+// across restarts, so they — not the name — decide whether a registry entry
+// belongs to "me". This closes the gap where two nodes sharing a name would
+// otherwise both accept a claim keyed only by name.
+type clientURLOwner struct {
+	Name     string   `json:"name"`
+	PeerURLs []string `json:"peer_urls"`
+}
 
 // clientURLRegistryPath returns the etcd key that records which member owns a
 // given advertised client URL. The URL is hex-encoded so it forms a single,
@@ -39,20 +51,22 @@ func clientURLRegistryPath(clusterID uint64, clientURL string) string {
 // owned by another member, then atomically claims each URL in an etcd registry.
 //
 // It is intentionally a standalone function (not folded into the join member
-// loop) so the same logic can be reused on any startup path. It has two layers:
+// loop) so the same logic runs on every startup path — fresh join and a restart
+// that changed its advertise-client-urls alike. It has two layers:
 //
 //  1. Reject if any *other* member in the current member list already advertises
-//     one of these client URLs. This catches the common case where an existing,
-//     live member owns the URL — e.g. a joining member reusing a Service URL
-//     while pointing --join elsewhere (issue #10999).
+//     one of these client URLs. "Other" is decided by peer URLs (unique per
+//     member), not name, so a different member that happens to share our name is
+//     still checked. This catches the common case where an existing, live member
+//     owns the URL — e.g. issue #10999.
 //  2. Atomically claim each URL via an etcd transaction (create-if-absent). This
-//     guards against concurrent joiners that have not published their client
-//     URLs yet: the first claimer wins; a later joiner finds the key already
-//     owned by another member and is rejected.
+//     makes concurrent joiners race-safe: the transaction is serialized through
+//     raft, so the first claimer wins and a later joiner — even one sharing the
+//     same name — finds a different peer URL in the owner record and is rejected.
 //
-// The registry entry is keyed by URL and valued by member name; a restart or a
-// previous failed-start incarnation keeps the same name and therefore re-claims
-// its own URL without error.
+// The registry entry is keyed by URL and valued by the owner's identity (name +
+// peer URLs); a restart keeps the same peer URLs and therefore re-claims its own
+// URL without error.
 //
 // Known limitation: the claim is persistent, so if a member is removed and a
 // *different* member later wants to reuse its client URL, the stale entry must
@@ -62,14 +76,15 @@ func checkAndClaimClientURLs(
 	clusterID uint64,
 	name string,
 	advertiseClientURLs []string,
+	advertisePeerURLs []string,
 	members []*etcdserverpb.Member,
 ) error {
-	// Layer 1: reject against the current member list.
+	// Layer 1: reject against the current member list. Skip only our own entry,
+	// matched by peer URLs so a different member sharing our name is still
+	// checked.
 	for _, url := range advertiseClientURLs {
 		for _, m := range members {
-			// Skip our own entry (a normal restart or a previous failed-start
-			// incarnation keeps the same name).
-			if m.Name == name {
+			if slice.EqualWithoutOrder(m.PeerURLs, advertisePeerURLs) {
 				continue
 			}
 			for _, owned := range m.ClientURLs {
@@ -83,11 +98,16 @@ func checkAndClaimClientURLs(
 	}
 
 	// Layer 2: atomically claim each URL.
+	self := clientURLOwner{Name: name, PeerURLs: advertisePeerURLs}
+	value, err := json.Marshal(self)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	for _, url := range advertiseClientURLs {
 		key := clientURLRegistryPath(clusterID, url)
 		resp, err := kv.NewSlowLogTxn(client).
 			If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0)).
-			Then(clientv3.OpPut(key, name)).
+			Then(clientv3.OpPut(key, string(value))).
 			Else(clientv3.OpGet(key)).
 			Commit()
 		if err != nil {
@@ -96,14 +116,19 @@ func checkAndClaimClientURLs(
 		if resp.Succeeded {
 			continue // freshly claimed
 		}
-		// The key already exists; make sure we are the owner.
+		// The key already exists; make sure the owner is this member (matched by
+		// peer URLs), otherwise reject.
 		kvs := resp.Responses[0].GetResponseRange().Kvs
 		if len(kvs) == 0 {
 			return errors.Errorf("failed to claim advertise-client-urls %q, please retry", url)
 		}
-		if owner := string(kvs[0].Value); owner != name {
+		var owner clientURLOwner
+		if err := json.Unmarshal(kvs[0].Value, &owner); err != nil {
+			return errors.Errorf("advertise-client-urls %q is claimed by an unrecognized owner", url)
+		}
+		if !slice.EqualWithoutOrder(owner.PeerURLs, advertisePeerURLs) {
 			return errors.Errorf(
-				"advertise-client-urls %q is already claimed by member %q", url, owner)
+				"advertise-client-urls %q is already claimed by member %q", url, owner.Name)
 		}
 		log.Info("re-claimed an advertised client URL owned by this member",
 			zap.String("name", name), zap.String("client-url", url))

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -15,6 +15,10 @@
 package join
 
 import (
+	"net"
+	"net/url"
+	"strings"
+
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 
 	"github.com/pingcap/errors"
@@ -22,12 +26,48 @@ import (
 	"github.com/tikv/pd/pkg/slice"
 )
 
+// canonicalizeURL normalizes a URL so that semantically equivalent endpoints
+// compare equal: the scheme and hostname are lower-cased (DNS is
+// case-insensitive), a trailing dot on the hostname is dropped, and IP literals
+// (notably IPv6) are reduced to their canonical form. If the input cannot be
+// parsed it is returned trimmed but otherwise unchanged, so comparison degrades
+// to the raw string rather than silently treating a bad URL as matching.
+func canonicalizeURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		return s
+	}
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	}
+	hostport := host
+	if port := u.Port(); port != "" {
+		hostport = net.JoinHostPort(host, port)
+	}
+	return strings.ToLower(u.Scheme) + "://" + hostport
+}
+
+// canonicalizeURLs canonicalizes each URL in the slice.
+func canonicalizeURLs(raws []string) []string {
+	out := make([]string, len(raws))
+	for i, raw := range raws {
+		out[i] = canonicalizeURL(raw)
+	}
+	return out
+}
+
 // checkClientURLConflict rejects the member if any *other* member in the current
 // member list already advertises one of advertiseClientURLs. "Other" is decided
 // by peer URLs (unique per member), not name, so a different member that happens
 // to share our name is still checked. This catches the case where an existing,
 // published member already owns the URL — e.g. a joining or restarting member
 // reusing another member's client URL (issue #10999).
+//
+// URLs are compared after canonicalization, so case-only or format-only
+// differences (e.g. http://pd.example:2379 vs http://PD.EXAMPLE:2379) are still
+// detected as the same endpoint.
 //
 // It is read-only (no etcd write, no quorum requirement), so it can run on the
 // join and restart-with-data paths without ever blocking a member that needs to
@@ -45,19 +85,23 @@ func checkClientURLConflict(
 	advertisePeerURLs []string,
 	members []*etcdserverpb.Member,
 ) error {
-	for _, url := range advertiseClientURLs {
-		for _, m := range members {
-			// Skip only our own entry, matched by peer URLs so a different
-			// member sharing our name is still checked.
-			if slice.EqualWithoutOrder(m.PeerURLs, advertisePeerURLs) {
-				continue
-			}
-			for _, owned := range m.ClientURLs {
-				if owned == url {
-					return errors.Errorf(
-						"advertise-client-urls %q is already used by member %q (id %d)",
-						url, m.Name, m.ID)
-				}
+	selfPeers := canonicalizeURLs(advertisePeerURLs)
+	// canonical client URL -> the original string, for a readable error.
+	self := make(map[string]string, len(advertiseClientURLs))
+	for _, raw := range advertiseClientURLs {
+		self[canonicalizeURL(raw)] = raw
+	}
+	for _, m := range members {
+		// Skip only our own entry, matched by peer URLs so a different member
+		// sharing our name is still checked.
+		if slice.EqualWithoutOrder(canonicalizeURLs(m.PeerURLs), selfPeers) {
+			continue
+		}
+		for _, owned := range m.ClientURLs {
+			if orig, ok := self[canonicalizeURL(owned)]; ok {
+				return errors.Errorf(
+					"advertise-client-urls %q is already used by member %q (id %d)",
+					orig, m.Name, m.ID)
 			}
 		}
 	}

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -47,43 +47,25 @@ func clientURLRegistryPath(clusterID uint64, clientURL string) string {
 	return fmt.Sprintf("/pd/%d/member/client-urls/%s", clusterID, hex.EncodeToString([]byte(clientURL)))
 }
 
-// checkAndClaimClientURLs makes sure none of advertiseClientURLs is already
-// owned by another member, then atomically claims each URL in an etcd registry.
+// checkClientURLConflict rejects the member if any *other* member in the current
+// member list already advertises one of advertiseClientURLs. "Other" is decided
+// by peer URLs (unique per member), not name, so a different member that happens
+// to share our name is still checked. This catches the common case where an
+// existing, live member owns the URL — e.g. issue #10999.
 //
-// It is intentionally a standalone function (not folded into the join member
-// loop) so the same logic runs on every startup path — fresh join and a restart
-// that changed its advertise-client-urls alike. It has two layers:
-//
-//  1. Reject if any *other* member in the current member list already advertises
-//     one of these client URLs. "Other" is decided by peer URLs (unique per
-//     member), not name, so a different member that happens to share our name is
-//     still checked. This catches the common case where an existing, live member
-//     owns the URL — e.g. issue #10999.
-//  2. Atomically claim each URL via an etcd transaction (create-if-absent). This
-//     makes concurrent joiners race-safe: the transaction is serialized through
-//     raft, so the first claimer wins and a later joiner — even one sharing the
-//     same name — finds a different peer URL in the owner record and is rejected.
-//
-// The registry entry is keyed by URL and valued by the owner's identity (name +
-// peer URLs); a restart keeps the same peer URLs and therefore re-claims its own
-// URL without error.
-//
-// Known limitation: the claim is persistent, so if a member is removed and a
-// *different* member later wants to reuse its client URL, the stale entry must
-// be cleaned up first. Cleanup on member removal is tracked as follow-up work.
-func checkAndClaimClientURLs(
-	client *clientv3.Client,
-	clusterID uint64,
-	name string,
+// It is read-only (no etcd write, no quorum requirement), so it runs on every
+// startup — fresh join and a restart that changed its advertise-client-urls
+// alike — without ever blocking a member that needs to restart to *restore*
+// quorum.
+func checkClientURLConflict(
 	advertiseClientURLs []string,
 	advertisePeerURLs []string,
 	members []*etcdserverpb.Member,
 ) error {
-	// Layer 1: reject against the current member list. Skip only our own entry,
-	// matched by peer URLs so a different member sharing our name is still
-	// checked.
 	for _, url := range advertiseClientURLs {
 		for _, m := range members {
+			// Skip only our own entry, matched by peer URLs so a different
+			// member sharing our name is still checked.
 			if slice.EqualWithoutOrder(m.PeerURLs, advertisePeerURLs) {
 				continue
 			}
@@ -96,8 +78,30 @@ func checkAndClaimClientURLs(
 			}
 		}
 	}
+	return nil
+}
 
-	// Layer 2: atomically claim each URL.
+// claimClientURLs atomically claims each advertised client URL in an etcd
+// registry via a create-if-absent transaction. Because the transaction is
+// serialized through raft, two concurrent joiners cannot both take the same
+// client URL: the first wins and a later joiner — even one sharing the same name
+// — finds a different peer URL in the owner record and is rejected.
+//
+// The registry entry is keyed by URL and valued by the owner's identity (name +
+// peer URLs). This writes to etcd (needs quorum) and is therefore only used on
+// the fresh-join path, where quorum is required anyway for MemberAdd; a restart
+// relies on the read-only checkClientURLConflict instead.
+//
+// Known limitation: the claim is persistent, so if a member is removed and a
+// *different* member later wants to reuse its client URL, the stale entry must
+// be cleaned up first. Cleanup on member removal is tracked as follow-up work.
+func claimClientURLs(
+	client *clientv3.Client,
+	clusterID uint64,
+	name string,
+	advertiseClientURLs []string,
+	advertisePeerURLs []string,
+) error {
 	self := clientURLOwner{Name: name, PeerURLs: advertisePeerURLs}
 	value, err := json.Marshal(self)
 	if err != nil {

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -69,14 +69,16 @@ func canonicalizeURLs(raws []string) []string {
 // differences (e.g. http://pd.example:2379 vs http://PD.EXAMPLE:2379) are still
 // detected as the same endpoint.
 //
-// Scope / follow-ups: the caller runs this only on the fresh-join path (against
-// a linearizable member list). It detects a conflict only against members that
+// Scope / follow-ups: the caller runs this on the no-data join paths — a
+// genuinely new member (against a linearizable member list) and a recovery
+// re-join after a failed start (against the non-linearizable list, so recovery
+// is not blocked on quorum). It detects a conflict only against members that
 // have already published their client URLs, so it does not by itself close the
 // window between two concurrent joiners before either publishes, nor does it
-// cover a restart or a member bootstrapped with --initial-cluster (which never
-// reach this path). Making membership uniqueness authoritative (an atomic
-// reservation bound to the member lifecycle) and verifying responder identity in
-// health checks are tracked separately.
+// cover a restart-with-data or a member bootstrapped with --initial-cluster
+// (which never reach this path). Making membership uniqueness authoritative (an
+// atomic reservation bound to the member lifecycle) and verifying responder
+// identity in health checks are tracked separately.
 func checkClientURLConflict(
 	advertiseClientURLs []string,
 	advertisePeerURLs []string,

--- a/server/join/client_url.go
+++ b/server/join/client_url.go
@@ -69,15 +69,12 @@ func canonicalizeURLs(raws []string) []string {
 // differences (e.g. http://pd.example:2379 vs http://PD.EXAMPLE:2379) are still
 // detected as the same endpoint.
 //
-// It is read-only (no etcd write, no quorum requirement), so it can run on the
-// join and restart-with-data paths without ever blocking a member that needs to
-// restart to *restore* quorum.
-//
-// Scope / follow-ups: this only detects a conflict against members that have
-// already published their client URLs, so it does not by itself close the
-// window between two concurrent joiners/restarts before either publishes, nor
-// does it cover a member bootstrapped with --initial-cluster (which never
-// reaches this path). Making membership uniqueness authoritative (an atomic
+// Scope / follow-ups: the caller runs this only on the fresh-join path (against
+// a linearizable member list). It detects a conflict only against members that
+// have already published their client URLs, so it does not by itself close the
+// window between two concurrent joiners before either publishes, nor does it
+// cover a restart or a member bootstrapped with --initial-cluster (which never
+// reach this path). Making membership uniqueness authoritative (an atomic
 // reservation bound to the member lifecycle) and verifying responder identity in
 // health checks are tracked separately.
 func checkClientURLConflict(

--- a/server/join/client_url_test.go
+++ b/server/join/client_url_test.go
@@ -19,7 +19,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.uber.org/goleak"
+
+	"github.com/tikv/pd/pkg/utils/testutil"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
 
 func TestCanonicalizeURL(t *testing.T) {
 	re := require.New(t)
@@ -35,10 +42,13 @@ func TestCanonicalizeURL(t *testing.T) {
 		{"http://[2001:0db8:0000:0000:0000:0000:0000:0001]:2379", "http://[2001:db8::1]:2379"}, // IPv6 canonical form
 		{"http://[2001:DB8::1]:2379", "http://[2001:db8::1]:2379"},                             // IPv6 case
 		{"https://10.0.0.1:2379", "https://10.0.0.1:2379"},
+		{"https://10.0.0.1:02379", "https://10.0.0.1:2379"},
 		{"not a url", "not a url"}, // unparsable, returned as-is (trimmed)
 	}
 	for _, tc := range testCases {
-		re.Equal(tc.want, canonicalizeURL(tc.in), tc.in)
+		u, err := canonicalizeURL(tc.in)
+		re.NoError(err)
+		re.Equal(tc.want, u, tc.in)
 	}
 }
 

--- a/server/join/client_url_test.go
+++ b/server/join/client_url_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeURL(t *testing.T) {
+	re := require.New(t)
+	testCases := []struct {
+		in   string
+		want string
+	}{
+		{"http://pd.example:2379", "http://pd.example:2379"},
+		{"http://PD.EXAMPLE:2379", "http://pd.example:2379"},                                   // case-insensitive host
+		{"HTTP://pd.example:2379", "http://pd.example:2379"},                                   // case-insensitive scheme
+		{"http://pd.example.:2379", "http://pd.example:2379"},                                  // trailing DNS dot
+		{" http://pd.example:2379 ", "http://pd.example:2379"},                                 // surrounding spaces
+		{"http://[2001:0db8:0000:0000:0000:0000:0000:0001]:2379", "http://[2001:db8::1]:2379"}, // IPv6 canonical form
+		{"http://[2001:DB8::1]:2379", "http://[2001:db8::1]:2379"},                             // IPv6 case
+		{"https://10.0.0.1:2379", "https://10.0.0.1:2379"},
+		{"not a url", "not a url"}, // unparsable, returned as-is (trimmed)
+	}
+	for _, tc := range testCases {
+		re.Equal(tc.want, canonicalizeURL(tc.in), tc.in)
+	}
+}
+
+func TestCheckClientURLConflict(t *testing.T) {
+	re := require.New(t)
+	members := []*etcdserverpb.Member{
+		{
+			ID:         1,
+			Name:       "pd1",
+			PeerURLs:   []string{"http://10.0.0.1:2380"},
+			ClientURLs: []string{"http://pd.example:2379"},
+		},
+		{
+			ID:         2,
+			Name:       "pd2",
+			PeerURLs:   []string{"http://10.0.0.2:2380"},
+			ClientURLs: []string{"http://[2001:db8::1]:2379"},
+		},
+	}
+	testCases := []struct {
+		name       string
+		clientURLs []string
+		peerURLs   []string
+		conflict   bool
+	}{
+		{"exact duplicate", []string{"http://pd.example:2379"}, []string{"http://10.0.0.9:2380"}, true},
+		{"case-insensitive host", []string{"http://PD.EXAMPLE:2379"}, []string{"http://10.0.0.9:2380"}, true},
+		{"case-insensitive scheme", []string{"HTTP://pd.example:2379"}, []string{"http://10.0.0.9:2380"}, true},
+		{"trailing dot", []string{"http://pd.example.:2379"}, []string{"http://10.0.0.9:2380"}, true},
+		{"ipv6 equivalent", []string{"http://[2001:0db8:0000::0001]:2379"}, []string{"http://10.0.0.9:2380"}, true},
+		{"different host", []string{"http://pd.other:2379"}, []string{"http://10.0.0.9:2380"}, false},
+		{"different port", []string{"http://pd.example:2380"}, []string{"http://10.0.0.9:2380"}, false},
+		// The member's own entry is skipped (matched by peer URL, canonicalized),
+		// so its unchanged client URL is not a self-conflict.
+		{"self excluded by peer url", []string{"http://pd.example:2379"}, []string{"http://10.0.0.1:2380"}, false},
+		{"self excluded case-insensitive peer", []string{"http://pd.example:2379"}, []string{"http://10.0.0.1:2380/"}, false},
+	}
+	for _, tc := range testCases {
+		err := checkClientURLConflict(tc.clientURLs, tc.peerURLs, members)
+		if tc.conflict {
+			re.Error(err, tc.name)
+		} else {
+			re.NoError(err, tc.name)
+		}
+	}
+}

--- a/server/join/client_url_test.go
+++ b/server/join/client_url_test.go
@@ -17,9 +17,8 @@ package join
 import (
 	"testing"
 
-	"go.etcd.io/etcd/api/v3/etcdserverpb"
-
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
 func TestCanonicalizeURL(t *testing.T) {

--- a/server/join/join.go
+++ b/server/join/join.go
@@ -43,39 +43,6 @@ const (
 // listMemberRetryTimes is the retry times of list member.
 var listMemberRetryTimes = 20
 
-var (
-	// restartListMemberRetryTimes is how many times a restarting member retries
-	// listing cluster members (with exponential backoff) before skipping the
-	// best-effort advertise-client-urls uniqueness check.
-	restartListMemberRetryTimes = 3
-	// restartListMemberBackoff is the initial backoff between those retries; it
-	// doubles each time (2s, 4s, 8s), which together with the per-request
-	// timeouts spans roughly 20s before giving up.
-	restartListMemberBackoff = 2 * time.Second
-)
-
-// retryListEtcdMembers retries ListEtcdMembers with exponential backoff. It is
-// used on the restart path so a transient failure does not immediately skip the
-// client-URL uniqueness check; it returns the last error if all retries fail.
-func retryListEtcdMembers(client *clientv3.Client) (*clientv3.MemberListResponse, error) {
-	var (
-		listResp *clientv3.MemberListResponse
-		err      error
-	)
-	backoff := restartListMemberBackoff
-	for i := range restartListMemberRetryTimes {
-		time.Sleep(backoff)
-		backoff *= 2
-		listResp, err = etcdutil.ListEtcdMembers(client.Ctx(), client)
-		if err == nil {
-			return listResp, nil
-		}
-		log.Warn("retry listing members on restart failed",
-			zap.Int("retry", i+1), errs.ZapError(err))
-	}
-	return nil, err
-}
-
 // PrepareJoinCluster sends MemberAdd command to PD cluster,
 // and returns the initial configuration of the PD cluster.
 //
@@ -130,10 +97,19 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	}
 
 	initialCluster := ""
-	dataExists := isDataExist(filepath.Join(cfg.DataDir, "member"))
+	// Cases with data directory: the local etcd reads its configuration from the
+	// data directory, so return immediately without any remote call. A restart is
+	// therefore never delayed or blocked (e.g. during a quorum outage). As a
+	// result the advertise-client-urls uniqueness check below only covers fresh
+	// joins; enforcing it authoritatively on restart is a follow-up (it needs the
+	// persisted member ID and a pre-publish check point).
+	if isDataExist(filepath.Join(cfg.DataDir, "member")) {
+		cfg.InitialCluster = initialCluster
+		cfg.InitialClusterState = embed.ClusterStateFlagExisting
+		return nil
+	}
 
-	// A client to the target cluster is needed both to verify the advertised
-	// client URL is unique and, for a fresh join, to run MemberAdd.
+	// Below are cases without a data directory (a fresh join or a re-join).
 	tlsConfig, err := cfg.Security.ToClientTLSConfig()
 	if err != nil {
 		return err
@@ -147,64 +123,18 @@ func PrepareJoinCluster(cfg *config.Config) error {
 		LogConfig:   &lgc,
 	})
 	if err != nil {
-		// A restart (data already exists) must not be blocked when the cluster
-		// is unreachable; the member starts from its local data directory, so
-		// the client-URL check is best-effort in that case.
-		if dataExists {
-			log.Warn("skip advertise-client-urls uniqueness check on restart: failed to create etcd client",
-				errs.ZapError(err))
-			cfg.InitialCluster = initialCluster
-			cfg.InitialClusterState = embed.ClusterStateFlagExisting
-			return nil
-		}
 		return errors.WithStack(err)
 	}
 	defer client.Close()
 
+	// A non-linearizable list is enough to determine this member's own state
+	// (existed / joinedFailedToStart / abnormal); it must not require quorum so a
+	// member re-joining after a failed start can still recover.
 	listResp, err := etcdutil.ListEtcdMembers(client.Ctx(), client)
 	if err != nil {
-		if !dataExists {
-			return err
-		}
-		// Restart: a transient failure should not silently skip the check.
-		// Retry with exponential backoff, and only skip (best-effort) if the
-		// cluster is still unreachable afterwards — the member must still be
-		// able to start from its local data directory.
-		listResp, err = retryListEtcdMembers(client)
-		if err != nil {
-			log.Warn("skip advertise-client-urls uniqueness check on restart: failed to list members after retries",
-				errs.ZapError(err))
-			cfg.InitialCluster = initialCluster
-			cfg.InitialClusterState = embed.ClusterStateFlagExisting
-			return nil
-		}
-	}
-
-	// Reject a member — whether joining fresh or restarting with a modified
-	// advertise-client-urls — whose advertised client URL is already used by
-	// another published member. This is read-only (no quorum needed) and runs
-	// before the local etcd (re)starts and republishes its attributes. See issue
-	// #10999. Concurrent (pre-publish) races and initial-cluster nodes are not
-	// covered here; see checkClientURLConflict for scope.
-	if err := checkClientURLConflict(
-		strings.Split(cfg.AdvertiseClientUrls, ","),
-		strings.Split(cfg.AdvertisePeerUrls, ","),
-		listResp.Members,
-	); err != nil {
 		return err
 	}
 
-	// Cases with data directory: the local etcd reads its configuration from the
-	// data directory, nothing more to prepare here. The registry claim is
-	// intentionally skipped on this path — it writes to etcd (needs quorum), and
-	// a restart must not depend on quorum.
-	if dataExists {
-		cfg.InitialCluster = initialCluster
-		cfg.InitialClusterState = embed.ClusterStateFlagExisting
-		return nil
-	}
-
-	// Below are cases without data directory.
 	existed := false
 	joinedFailedToStart := false
 	advertisePeerURLs := strings.Split(cfg.AdvertisePeerUrls, ",")
@@ -242,6 +172,23 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	{
 		// No need to add member if the PD is already in the cluster.
 		if !joinedFailedToStart {
+			// Admission for a genuinely new member: reject if its advertised
+			// client URL is already used by another member. Use a linearizable
+			// member list so a stale/lagging local view cannot miss a conflict
+			// that has already been published; a genuine join needs quorum for
+			// MemberAdd anyway. The joinedFailedToStart recovery path skips this,
+			// so it never depends on quorum. See issue #10999.
+			linResp, lerr := etcdutil.ListEtcdMembersLinearizable(client.Ctx(), client)
+			if lerr != nil {
+				return lerr
+			}
+			if cerr := checkClientURLConflict(
+				strings.Split(cfg.AdvertiseClientUrls, ","),
+				strings.Split(cfg.AdvertisePeerUrls, ","),
+				linResp.Members,
+			); cerr != nil {
+				return cerr
+			}
 			// First adds member through the API
 			addResp, err = etcdutil.AddEtcdMember(client, []string{cfg.AdvertisePeerUrls})
 			if err != nil {

--- a/server/join/join.go
+++ b/server/join/join.go
@@ -43,6 +43,39 @@ const (
 // listMemberRetryTimes is the retry times of list member.
 var listMemberRetryTimes = 20
 
+var (
+	// restartListMemberRetryTimes is how many times a restarting member retries
+	// listing cluster members (with exponential backoff) before skipping the
+	// best-effort advertise-client-urls uniqueness check.
+	restartListMemberRetryTimes = 3
+	// restartListMemberBackoff is the initial backoff between those retries; it
+	// doubles each time (2s, 4s, 8s), which together with the per-request
+	// timeouts spans roughly 20s before giving up.
+	restartListMemberBackoff = 2 * time.Second
+)
+
+// retryListEtcdMembers retries ListEtcdMembers with exponential backoff. It is
+// used on the restart path so a transient failure does not immediately skip the
+// client-URL uniqueness check; it returns the last error if all retries fail.
+func retryListEtcdMembers(client *clientv3.Client) (*clientv3.MemberListResponse, error) {
+	var (
+		listResp *clientv3.MemberListResponse
+		err      error
+	)
+	backoff := restartListMemberBackoff
+	for i := range restartListMemberRetryTimes {
+		time.Sleep(backoff)
+		backoff *= 2
+		listResp, err = etcdutil.ListEtcdMembers(client.Ctx(), client)
+		if err == nil {
+			return listResp, nil
+		}
+		log.Warn("retry listing members on restart failed",
+			zap.Int("retry", i+1), errs.ZapError(err))
+	}
+	return nil, err
+}
+
 // PrepareJoinCluster sends MemberAdd command to PD cluster,
 // and returns the initial configuration of the PD cluster.
 //
@@ -130,25 +163,29 @@ func PrepareJoinCluster(cfg *config.Config) error {
 
 	listResp, err := etcdutil.ListEtcdMembers(client.Ctx(), client)
 	if err != nil {
-		if dataExists {
-			log.Warn("skip advertise-client-urls uniqueness check on restart: failed to list members",
+		if !dataExists {
+			return err
+		}
+		// Restart: a transient failure should not silently skip the check.
+		// Retry with exponential backoff, and only skip (best-effort) if the
+		// cluster is still unreachable afterwards — the member must still be
+		// able to start from its local data directory.
+		listResp, err = retryListEtcdMembers(client)
+		if err != nil {
+			log.Warn("skip advertise-client-urls uniqueness check on restart: failed to list members after retries",
 				errs.ZapError(err))
 			cfg.InitialCluster = initialCluster
 			cfg.InitialClusterState = embed.ClusterStateFlagExisting
 			return nil
 		}
-		return err
 	}
 
-	// Reject (and atomically claim) a member — whether joining fresh or
-	// restarting with a modified advertise-client-urls — whose advertised client
-	// URL is already owned by another member. This runs before the local etcd
-	// (re)starts and republishes its attributes, so a duplicate never enters the
-	// member list. See issue #10999.
-	if err := checkAndClaimClientURLs(
-		client,
-		listResp.Header.GetClusterId(),
-		cfg.Name,
+	// Reject a member — whether joining fresh or restarting with a modified
+	// advertise-client-urls — whose advertised client URL is already owned by
+	// another member. This is read-only (no quorum needed) and runs before the
+	// local etcd (re)starts and republishes its attributes, so a duplicate never
+	// enters the member list. See issue #10999.
+	if err := checkClientURLConflict(
 		strings.Split(cfg.AdvertiseClientUrls, ","),
 		strings.Split(cfg.AdvertisePeerUrls, ","),
 		listResp.Members,
@@ -157,7 +194,9 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	}
 
 	// Cases with data directory: the local etcd reads its configuration from the
-	// data directory, nothing more to prepare here.
+	// data directory, nothing more to prepare here. The registry claim is
+	// intentionally skipped on this path — it writes to etcd (needs quorum), and
+	// a restart must not depend on quorum.
 	if dataExists {
 		cfg.InitialCluster = initialCluster
 		cfg.InitialClusterState = embed.ClusterStateFlagExisting
@@ -189,6 +228,19 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	// - A failed PD re-joins the previous cluster.
 	if existed {
 		return errors.New("missing data or join a duplicated pd")
+	}
+
+	// Atomically claim the advertised client URLs before MemberAdd so two
+	// concurrent joiners cannot both take the same client URL. Only the
+	// fresh-join path reaches here, where quorum is required anyway.
+	if err := claimClientURLs(
+		client,
+		listResp.Header.GetClusterId(),
+		cfg.Name,
+		strings.Split(cfg.AdvertiseClientUrls, ","),
+		strings.Split(cfg.AdvertisePeerUrls, ","),
+	); err != nil {
+		return err
 	}
 
 	var addResp *clientv3.MemberAddResponse

--- a/server/join/join.go
+++ b/server/join/join.go
@@ -97,14 +97,10 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	}
 
 	initialCluster := ""
-	// Cases with data directory.
-	if isDataExist(filepath.Join(cfg.DataDir, "member")) {
-		cfg.InitialCluster = initialCluster
-		cfg.InitialClusterState = embed.ClusterStateFlagExisting
-		return nil
-	}
+	dataExists := isDataExist(filepath.Join(cfg.DataDir, "member"))
 
-	// Below are cases without data directory.
+	// A client to the target cluster is needed both to verify the advertised
+	// client URL is unique and, for a fresh join, to run MemberAdd.
 	tlsConfig, err := cfg.Security.ToClientTLSConfig()
 	if err != nil {
 		return err
@@ -118,15 +114,57 @@ func PrepareJoinCluster(cfg *config.Config) error {
 		LogConfig:   &lgc,
 	})
 	if err != nil {
+		// A restart (data already exists) must not be blocked when the cluster
+		// is unreachable; the member starts from its local data directory, so
+		// the client-URL check is best-effort in that case.
+		if dataExists {
+			log.Warn("skip advertise-client-urls uniqueness check on restart: failed to create etcd client",
+				errs.ZapError(err))
+			cfg.InitialCluster = initialCluster
+			cfg.InitialClusterState = embed.ClusterStateFlagExisting
+			return nil
+		}
 		return errors.WithStack(err)
 	}
 	defer client.Close()
 
 	listResp, err := etcdutil.ListEtcdMembers(client.Ctx(), client)
 	if err != nil {
+		if dataExists {
+			log.Warn("skip advertise-client-urls uniqueness check on restart: failed to list members",
+				errs.ZapError(err))
+			cfg.InitialCluster = initialCluster
+			cfg.InitialClusterState = embed.ClusterStateFlagExisting
+			return nil
+		}
 		return err
 	}
 
+	// Reject (and atomically claim) a member — whether joining fresh or
+	// restarting with a modified advertise-client-urls — whose advertised client
+	// URL is already owned by another member. This runs before the local etcd
+	// (re)starts and republishes its attributes, so a duplicate never enters the
+	// member list. See issue #10999.
+	if err := checkAndClaimClientURLs(
+		client,
+		listResp.Header.GetClusterId(),
+		cfg.Name,
+		strings.Split(cfg.AdvertiseClientUrls, ","),
+		strings.Split(cfg.AdvertisePeerUrls, ","),
+		listResp.Members,
+	); err != nil {
+		return err
+	}
+
+	// Cases with data directory: the local etcd reads its configuration from the
+	// data directory, nothing more to prepare here.
+	if dataExists {
+		cfg.InitialCluster = initialCluster
+		cfg.InitialClusterState = embed.ClusterStateFlagExisting
+		return nil
+	}
+
+	// Below are cases without data directory.
 	existed := false
 	joinedFailedToStart := false
 	advertisePeerURLs := strings.Split(cfg.AdvertisePeerUrls, ",")
@@ -151,19 +189,6 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	// - A failed PD re-joins the previous cluster.
 	if existed {
 		return errors.New("missing data or join a duplicated pd")
-	}
-
-	// Reject (and atomically claim) a joining member whose advertised client URL
-	// is already owned by another member. This runs before MemberAdd so a bad
-	// join never enters the member list. See issue #10999.
-	if err := checkAndClaimClientURLs(
-		client,
-		listResp.Header.GetClusterId(),
-		cfg.Name,
-		strings.Split(cfg.AdvertiseClientUrls, ","),
-		listResp.Members,
-	); err != nil {
-		return err
 	}
 
 	var addResp *clientv3.MemberAddResponse

--- a/server/join/join.go
+++ b/server/join/join.go
@@ -181,10 +181,11 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	}
 
 	// Reject a member — whether joining fresh or restarting with a modified
-	// advertise-client-urls — whose advertised client URL is already owned by
-	// another member. This is read-only (no quorum needed) and runs before the
-	// local etcd (re)starts and republishes its attributes, so a duplicate never
-	// enters the member list. See issue #10999.
+	// advertise-client-urls — whose advertised client URL is already used by
+	// another published member. This is read-only (no quorum needed) and runs
+	// before the local etcd (re)starts and republishes its attributes. See issue
+	// #10999. Concurrent (pre-publish) races and initial-cluster nodes are not
+	// covered here; see checkClientURLConflict for scope.
 	if err := checkClientURLConflict(
 		strings.Split(cfg.AdvertiseClientUrls, ","),
 		strings.Split(cfg.AdvertisePeerUrls, ","),
@@ -228,19 +229,6 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	// - A failed PD re-joins the previous cluster.
 	if existed {
 		return errors.New("missing data or join a duplicated pd")
-	}
-
-	// Atomically claim the advertised client URLs before MemberAdd so two
-	// concurrent joiners cannot both take the same client URL. Only the
-	// fresh-join path reaches here, where quorum is required anyway.
-	if err := claimClientURLs(
-		client,
-		listResp.Header.GetClusterId(),
-		cfg.Name,
-		strings.Split(cfg.AdvertiseClientUrls, ","),
-		strings.Split(cfg.AdvertisePeerUrls, ","),
-	); err != nil {
-		return err
 	}
 
 	var addResp *clientv3.MemberAddResponse

--- a/server/join/join.go
+++ b/server/join/join.go
@@ -153,6 +153,19 @@ func PrepareJoinCluster(cfg *config.Config) error {
 		return errors.New("missing data or join a duplicated pd")
 	}
 
+	// Reject (and atomically claim) a joining member whose advertised client URL
+	// is already owned by another member. This runs before MemberAdd so a bad
+	// join never enters the member list. See issue #10999.
+	if err := checkAndClaimClientURLs(
+		client,
+		listResp.Header.GetClusterId(),
+		cfg.Name,
+		strings.Split(cfg.AdvertiseClientUrls, ","),
+		listResp.Members,
+	); err != nil {
+		return err
+	}
+
 	var addResp *clientv3.MemberAddResponse
 
 	failpoint.Inject("addMemberFailed", func() {

--- a/server/join/join.go
+++ b/server/join/join.go
@@ -161,6 +161,31 @@ func PrepareJoinCluster(cfg *config.Config) error {
 		return errors.New("missing data or join a duplicated pd")
 	}
 
+	// Reject a member whose advertised client URL is already used by another
+	// member, before MemberAdd and before the local etcd publishes its
+	// attributes, so a duplicate never enters the member list. See issue #10999.
+	advertiseClientURLs := strings.Split(cfg.AdvertiseClientUrls, ",")
+	if joinedFailedToStart {
+		// Recovery re-join: this member's peer was already added but never
+		// started, so the cluster may be at 1/2 quorum. Reuse the
+		// non-linearizable list already fetched instead of issuing a
+		// quorum-dependent linearizable read, so recovery is never blocked.
+		if cerr := checkClientURLConflict(advertiseClientURLs, advertisePeerURLs, listResp.Members); cerr != nil {
+			return cerr
+		}
+	} else {
+		// Genuinely new member: use a linearizable list so a stale/lagging local
+		// view cannot miss a conflict that has already been published; a genuine
+		// join needs quorum for MemberAdd anyway.
+		linResp, lerr := etcdutil.ListEtcdMembersLinearizable(client.Ctx(), client)
+		if lerr != nil {
+			return lerr
+		}
+		if cerr := checkClientURLConflict(advertiseClientURLs, advertisePeerURLs, linResp.Members); cerr != nil {
+			return cerr
+		}
+	}
+
 	var addResp *clientv3.MemberAddResponse
 
 	failpoint.Inject("addMemberFailed", func() {
@@ -172,23 +197,6 @@ func PrepareJoinCluster(cfg *config.Config) error {
 	{
 		// No need to add member if the PD is already in the cluster.
 		if !joinedFailedToStart {
-			// Admission for a genuinely new member: reject if its advertised
-			// client URL is already used by another member. Use a linearizable
-			// member list so a stale/lagging local view cannot miss a conflict
-			// that has already been published; a genuine join needs quorum for
-			// MemberAdd anyway. The joinedFailedToStart recovery path skips this,
-			// so it never depends on quorum. See issue #10999.
-			linResp, lerr := etcdutil.ListEtcdMembersLinearizable(client.Ctx(), client)
-			if lerr != nil {
-				return lerr
-			}
-			if cerr := checkClientURLConflict(
-				strings.Split(cfg.AdvertiseClientUrls, ","),
-				strings.Split(cfg.AdvertisePeerUrls, ","),
-				linResp.Members,
-			); cerr != nil {
-				return cerr
-			}
 			// First adds member through the API
 			addResp, err = etcdutil.AddEtcdMember(client, []string{cfg.AdvertisePeerUrls})
 			if err != nil {

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -162,12 +162,12 @@ func TestFailedPDJoinsPreviousCluster(t *testing.T) {
 	re.Error(join.PrepareJoinCluster(pd2.GetConfig()))
 }
 
-// Reproduces https://github.com/tikv/pd/issues/10999: a new member can join
-// and start up with a unique peer URL while advertising a client URL already
-// owned by an existing member. Because --join points to a different string
-// than the duplicated client URL, the self-join check is bypassed and etcd
-// accepts the unique peer URL, so the member list ends up with two logical
-// members sharing one client URL.
+// Regression test for https://github.com/tikv/pd/issues/10999: a member that
+// tries to join while advertising a client URL already owned by another member
+// must be rejected before it can corrupt membership — even though its peer URL
+// is unique and --join points to a different string than the duplicated client
+// URL, so the `cfg.Join == cfg.AdvertiseClientUrls` self-join check does not
+// trigger.
 func TestJoinWithDuplicateClientURL(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -184,34 +184,18 @@ func TestJoinWithDuplicateClientURL(t *testing.T) {
 	client := pd1.GetEtcdClient()
 	dupClientURL := pd1.GetConfig().AdvertiseClientUrls
 
-	// Join a new member whose advertise-client-urls duplicates pd1's, while its
-	// peer URL stays unique. --join points to pd1's peer URL, a different string
-	// than the duplicated client URL, so the `cfg.Join == cfg.AdvertiseClientUrls`
-	// self-join check does not trigger.
-	orphan, err := cluster.Join(ctx, func(conf *config.Config, _ string) {
+	// PrepareJoinCluster (run inside cluster.Join) detects that dupClientURL is
+	// already owned by pd1 and refuses the join before MemberAdd.
+	_, err = cluster.Join(ctx, func(conf *config.Config, _ string) {
 		conf.AdvertiseClientUrls = dupClientURL
 	})
-	re.NoError(err)
+	re.Error(err)
+	re.Contains(err.Error(), "already used by member")
 
-	// The joining member starts successfully today — this is the bug. After a
-	// fix it should be rejected before it can corrupt membership.
-	re.NoError(orphan.Run())
-	re.NotEmpty(cluster.WaitLeader())
-
-	// Membership is now corrupted: two members advertise the same client URL.
+	// Membership is untouched: the orphan never entered the member list.
 	members, err := etcdutil.ListEtcdMembers(ctx, client)
 	re.NoError(err)
-	re.Len(members.Members, 2)
-	dupOwners := make([]uint64, 0, 2)
-	for _, m := range members.Members {
-		for _, u := range m.ClientURLs {
-			if u == dupClientURL {
-				dupOwners = append(dupOwners, m.ID)
-			}
-		}
-	}
-	// Exactly one member should ever own a given client URL; here two do.
-	re.Len(dupOwners, 2, "client URL %s is owned by members %v", dupClientURL, dupOwners)
+	re.Len(members.Members, 1)
 }
 
 // A PD joins itself.

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/server"
+	"github.com/tikv/pd/server/config"
 	"github.com/tikv/pd/server/join"
 	"github.com/tikv/pd/tests"
 )
@@ -159,6 +160,58 @@ func TestFailedPDJoinsPreviousCluster(t *testing.T) {
 	re.NoError(pd2.Stop())
 	re.NoError(pd2.Destroy())
 	re.Error(join.PrepareJoinCluster(pd2.GetConfig()))
+}
+
+// Reproduces https://github.com/tikv/pd/issues/10999: a new member can join
+// and start up with a unique peer URL while advertising a client URL already
+// owned by an existing member. Because --join points to a different string
+// than the duplicated client URL, the self-join check is bypassed and etcd
+// accepts the unique peer URL, so the member list ends up with two logical
+// members sharing one client URL.
+func TestJoinWithDuplicateClientURL(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	defer cluster.Destroy()
+	re.NoError(err)
+
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+
+	pd1 := cluster.GetServer("pd1")
+	client := pd1.GetEtcdClient()
+	dupClientURL := pd1.GetConfig().AdvertiseClientUrls
+
+	// Join a new member whose advertise-client-urls duplicates pd1's, while its
+	// peer URL stays unique. --join points to pd1's peer URL, a different string
+	// than the duplicated client URL, so the `cfg.Join == cfg.AdvertiseClientUrls`
+	// self-join check does not trigger.
+	orphan, err := cluster.Join(ctx, func(conf *config.Config, _ string) {
+		conf.AdvertiseClientUrls = dupClientURL
+	})
+	re.NoError(err)
+
+	// The joining member starts successfully today — this is the bug. After a
+	// fix it should be rejected before it can corrupt membership.
+	re.NoError(orphan.Run())
+	re.NotEmpty(cluster.WaitLeader())
+
+	// Membership is now corrupted: two members advertise the same client URL.
+	members, err := etcdutil.ListEtcdMembers(ctx, client)
+	re.NoError(err)
+	re.Len(members.Members, 2)
+	dupOwners := make([]uint64, 0, 2)
+	for _, m := range members.Members {
+		for _, u := range m.ClientURLs {
+			if u == dupClientURL {
+				dupOwners = append(dupOwners, m.ID)
+			}
+		}
+	}
+	// Exactly one member should ever own a given client URL; here two do.
+	re.Len(dupOwners, 2, "client URL %s is owned by members %v", dupClientURL, dupOwners)
 }
 
 // A PD joins itself.

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -198,6 +198,41 @@ func TestJoinWithDuplicateClientURL(t *testing.T) {
 	re.Len(members.Members, 1)
 }
 
+// Regression test for the failed-start recovery path of issue #10999: a member
+// whose peer was already added but never started (joinedFailedToStart) re-joins
+// with another member's advertised client URL. It must still be rejected — the
+// read-only conflict check runs on the recovery path too, using the
+// non-linearizable member list so recovery is never blocked on quorum.
+func TestFailedStartRecoveryRejectsDuplicateClientURL(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+
+	pd1 := cluster.GetServer("pd1")
+	dupClientURL := pd1.GetConfig().AdvertiseClientUrls
+
+	// First join succeeds through MemberAdd but the new PD never starts, leaving
+	// an unnamed etcd member with pd2's peer URL (the failed-start recovery
+	// state). The cluster is now at 1/2 quorum.
+	pd2, err := cluster.Join(ctx)
+	re.NoError(err)
+	pd2Cfg := pd2.GetConfig().Clone()
+	re.NoError(pd2.Destroy())
+
+	// Re-joining the same peer while advertising pd1's client URL must be
+	// rejected before startup, even on the joinedFailedToStart path.
+	pd2Cfg.AdvertiseClientUrls = dupClientURL
+	_, err = tests.NewTestServer(ctx, pd2Cfg, nil)
+	re.Error(err)
+	re.Contains(err.Error(), "already used by member")
+}
+
 // A PD joins itself.
 func TestPDJoinsItself(t *testing.T) {
 	re := require.New(t)

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -174,8 +174,8 @@ func TestJoinWithDuplicateClientURL(t *testing.T) {
 	defer cancel()
 
 	cluster, err := tests.NewTestCluster(ctx, 1)
-	defer cluster.Destroy()
 	re.NoError(err)
+	defer cluster.Destroy()
 
 	re.NoError(cluster.RunInitialServers())
 	re.NotEmpty(cluster.WaitLeader())
@@ -201,16 +201,17 @@ func TestJoinWithDuplicateClientURL(t *testing.T) {
 // Regression test for the restart path of https://github.com/tikv/pd/issues/10999:
 // a member that restarts (its data directory already exists) after its
 // advertise-client-urls was changed to a value owned by another member must
-// still be rejected. The uniqueness check runs on every startup, not only on a
-// fresh join, and before the local etcd republishes its attributes.
+// still be rejected. The read-only conflict check runs on the restart-with-data
+// path too, before the local etcd republishes its attributes — not only on a
+// fresh join.
 func TestRestartWithModifiedDuplicateClientURL(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	cluster, err := tests.NewTestCluster(ctx, 1)
-	defer cluster.Destroy()
 	re.NoError(err)
+	defer cluster.Destroy()
 	re.NoError(cluster.RunInitialServers())
 	re.NotEmpty(cluster.WaitLeader())
 

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -198,43 +198,6 @@ func TestJoinWithDuplicateClientURL(t *testing.T) {
 	re.Len(members.Members, 1)
 }
 
-// Regression test for the restart path of https://github.com/tikv/pd/issues/10999:
-// a member that restarts (its data directory already exists) after its
-// advertise-client-urls was changed to a value owned by another member must
-// still be rejected. The read-only conflict check runs on the restart-with-data
-// path too, before the local etcd republishes its attributes — not only on a
-// fresh join.
-func TestRestartWithModifiedDuplicateClientURL(t *testing.T) {
-	re := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cluster, err := tests.NewTestCluster(ctx, 1)
-	re.NoError(err)
-	defer cluster.Destroy()
-	re.NoError(cluster.RunInitialServers())
-	re.NotEmpty(cluster.WaitLeader())
-
-	// Bring up a legitimate second member with its own unique client URL so it
-	// has a data directory, then stop it to simulate a restart.
-	pd2, err := cluster.Join(ctx)
-	re.NoError(err)
-	re.NoError(pd2.Run())
-	re.NotEmpty(cluster.WaitLeader())
-	re.NoError(pd2.Stop())
-
-	dupClientURL := cluster.GetServer("pd1").GetConfig().AdvertiseClientUrls
-
-	// Restart pd2 with its advertise-client-urls changed to pd1's. Its data
-	// directory still exists, so PrepareJoinCluster takes the "data exists"
-	// path — which must still run the uniqueness check and reject the restart.
-	cfg := pd2.GetConfig()
-	cfg.AdvertiseClientUrls = dupClientURL
-	err = join.PrepareJoinCluster(cfg)
-	re.Error(err)
-	re.Contains(err.Error(), "already used by member")
-}
-
 // A PD joins itself.
 func TestPDJoinsItself(t *testing.T) {
 	re := require.New(t)

--- a/tests/server/join/join_test.go
+++ b/tests/server/join/join_test.go
@@ -198,6 +198,42 @@ func TestJoinWithDuplicateClientURL(t *testing.T) {
 	re.Len(members.Members, 1)
 }
 
+// Regression test for the restart path of https://github.com/tikv/pd/issues/10999:
+// a member that restarts (its data directory already exists) after its
+// advertise-client-urls was changed to a value owned by another member must
+// still be rejected. The uniqueness check runs on every startup, not only on a
+// fresh join, and before the local etcd republishes its attributes.
+func TestRestartWithModifiedDuplicateClientURL(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	defer cluster.Destroy()
+	re.NoError(err)
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+
+	// Bring up a legitimate second member with its own unique client URL so it
+	// has a data directory, then stop it to simulate a restart.
+	pd2, err := cluster.Join(ctx)
+	re.NoError(err)
+	re.NoError(pd2.Run())
+	re.NotEmpty(cluster.WaitLeader())
+	re.NoError(pd2.Stop())
+
+	dupClientURL := cluster.GetServer("pd1").GetConfig().AdvertiseClientUrls
+
+	// Restart pd2 with its advertise-client-urls changed to pd1's. Its data
+	// directory still exists, so PrepareJoinCluster takes the "data exists"
+	// path — which must still run the uniqueness check and reject the restart.
+	cfg := pd2.GetConfig()
+	cfg.AdvertiseClientUrls = dupClientURL
+	err = join.PrepareJoinCluster(cfg)
+	re.Error(err)
+	re.Contains(err.Error(), "already used by member")
+}
+
 // A PD joins itself.
 func TestPDJoinsItself(t *testing.T) {
 	re := require.New(t)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10999

A PD member could join a cluster while advertising a `--advertise-client-urls`
value **already used by another member**, because `MemberAdd` carries only peer
URLs and etcd does not enforce client-URL uniqueness, while the self-join guard
only compares `--join` against the member's *own* advertised client URL. When
`--join` points to a different string (e.g. a Kubernetes Service URL instead of
the duplicated per-Pod client URL), the guard is bypassed and etcd accepts the
unique peer URL. The member list then contained two members sharing one client
URL, corrupting membership and health semantics (an orphan member could still
appear healthy because its client URL routes to the healthy original PD).

### What is changed and how does it work?

Add a standalone, **read-only** `checkClientURLConflict`
(`server/join/client_url.go`), invoked from `PrepareJoinCluster` on the **no-data
join paths**, before `MemberAdd` and before the local etcd publishes its
attributes. It rejects the startup if this member's advertised client URL is
already used by any *other* member. "Other" is matched by peer URL (unique per
member), so a member that happens to share our name is still checked. URLs are
compared after canonicalization (lower-cased scheme/host, trailing DNS dot
stripped, IP literals — notably IPv6 — and numeric ports normalized), so
case-only or format-only spellings of the same endpoint are still detected.

Two entry points, chosen so a recovery never depends on quorum:

- **Genuinely new member** — checked against a **linearizable** member list, so a
  stale/lagging local view cannot miss an already-published conflict. A genuine
  join needs quorum for `MemberAdd` anyway.
- **Failed-start recovery re-join** (`joinedFailedToStart`, i.e. the peer was
  added but never started, so the cluster may be at 1/2 quorum) — checked against
  the **non-linearizable** list already fetched, issuing no quorum-dependent
  call, so recovery is never blocked.

The check itself issues no etcd write. A genuinely new join still requires
quorum — both the linearizable member list and `MemberAdd` fail without it — but
the failed-start recovery re-join adds no quorum-dependent operation, so a member
recovering at 1/2 quorum is never blocked by this check.

### Scope / follow-ups (why `ref`, not `close`)

`PrepareJoinCluster` returns immediately when the data directory exists, so this
PR covers only the **no-data join paths**. The following are **not** covered here
and are tracked separately:

- A **restart with existing data** — it makes no remote `MemberList` call and
  does not re-validate `advertise-client-urls`.
- Members bootstrapped with **`--initial-cluster`** (`--join` empty), which return
  before this check.
- **Concurrency**: two joiners racing before either publishes its client URL —
  needs an authoritative reservation bound to the member lifecycle (atomic
  reserve around `MemberAdd`, rollback on failure, reconcile on removal).
- **Health checks** verifying the responding member's identity, so an orphan
  sharing a live URL is not reported healthy.

### Tests

- `TestJoinWithDuplicateClientURL` — a fresh join reusing a live member's client
  URL is rejected; membership is untouched.
- `TestFailedStartRecoveryRejectsDuplicateClientURL` — a failed-start recovery
  re-join reusing another member's client URL is rejected (non-linearizable,
  works at 1/2 quorum).
- `TestCanonicalizeURL` / `TestCheckClientURLConflict` — table-driven unit tests
  for case, trailing dot, IPv6, and numeric-port (e.g. `02379`) equivalence, and
  peer-URL self-exclusion.
- `TestSimpleJoin` / `TestFailedToStartPDAfterSuccessfulJoin` — legitimate joins
  and the low-quorum recovery path are unaffected.

```commit-message
server/join: reject join reusing another member's client URL

Add a read-only member-list conflict check on the no-data join paths
(a new member against a linearizable list; a failed-start recovery
re-join against the non-linearizable list), run before MemberAdd and
before the local etcd publishes, so a member reusing another published
member's advertised client URL is rejected without any quorum-dependent
write. URLs are compared after canonicalization.

Issue Number: ref #10999
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- No persistent data change

Side effects

- None

Related changes

- None

### Release note

```release-note
Reject a PD member from joining the cluster when its advertised client URL is already used by another member, preventing membership and health corruption.
```
