### PR TITLE
cluster: reject duplicated store peer address on put

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1523,7 +1523,7 @@ func (c *RaftCluster) putStoreImpl(store *metapb.Store, force bool) error {
 		return err
 	}
 
-	// Store address can not be the same as other stores.
+	// Store address and peer address can not be the same as other stores.
 	for _, s := range c.GetStores() {
 		// It's OK to start a new store on the same address if the old store has been removed or physically destroyed.
 		if s.IsRemoved() || s.IsPhysicallyDestroyed() {
@@ -1531,6 +1531,12 @@ func (c *RaftCluster) putStoreImpl(store *metapb.Store, force bool) error {
 		}
 		if s.GetID() != store.GetId() && s.GetAddress() == store.GetAddress() {
 			return errors.Errorf("duplicated store address: %v, already registered by %v", store, s.GetMeta())
+		}
+		// Add unique peer address check. TiFlash uses peer address for Raft replication.
+		// Empty peer address is common for TiKV and should not participate in conflict checks.
+		if store.GetPeerAddress() != "" && s.GetID() != store.GetId() &&
+			s.GetMeta().GetPeerAddress() == store.GetPeerAddress() {
+			return errors.Errorf("duplicated store peer address: %v, already registered by %v", store, s.GetMeta())
 		}
 	}
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1523,19 +1523,26 @@ func (c *RaftCluster) putStoreImpl(store *metapb.Store, force bool) error {
 		return err
 	}
 
-	// Store address and peer address can not be the same as other stores.
+	// Store address and peer address can not collide across stores.
+	// TiFlash uses peer address for Raft replication, so a non-empty peer
+	// address must also not collide with any other store's address (and vice versa).
+	// Empty peer address is common for TiKV and should not participate in conflict checks.
 	for _, s := range c.GetStores() {
 		// It's OK to start a new store on the same address if the old store has been removed or physically destroyed.
 		if s.IsRemoved() || s.IsPhysicallyDestroyed() {
 			continue
 		}
-		if s.GetID() != store.GetId() && s.GetAddress() == store.GetAddress() {
+		if s.GetID() == store.GetId() {
+			continue
+		}
+		existingAddr := s.GetAddress()
+		existingPeerAddr := s.GetMeta().GetPeerAddress()
+		if store.GetAddress() == existingAddr ||
+			(existingPeerAddr != "" && store.GetAddress() == existingPeerAddr) {
 			return errors.Errorf("duplicated store address: %v, already registered by %v", store, s.GetMeta())
 		}
-		// Add unique peer address check. TiFlash uses peer address for Raft replication.
-		// Empty peer address is common for TiKV and should not participate in conflict checks.
-		if store.GetPeerAddress() != "" && s.GetID() != store.GetId() &&
-			s.GetMeta().GetPeerAddress() == store.GetPeerAddress() {
+		if store.GetPeerAddress() != "" &&
+			(store.GetPeerAddress() == existingAddr || store.GetPeerAddress() == existingPeerAddr) {
 			return errors.Errorf("duplicated store peer address: %v, already registered by %v", store, s.GetMeta())
 		}
 	}

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -639,6 +639,36 @@ func TestReusePeerAddress(t *testing.T) {
 		Version:     "2.0.0",
 		DeployPath:  getTestDeployPath(3002),
 	}))
+
+	// Cross collision: new peer address equals an existing store address.
+	re.Error(cluster.PutMetaStore(&metapb.Store{
+		Id:          4001,
+		Address:     "mock://tiflash-c:3930",
+		PeerAddress: cluster.GetStore(100).GetAddress(),
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(4001),
+	}))
+
+	// Cross collision: new address equals an existing non-empty peer address.
+	re.Error(cluster.PutMetaStore(&metapb.Store{
+		Id:         4002,
+		Address:    cluster.GetStore(1).GetMeta().GetPeerAddress(),
+		State:      metapb.StoreState_Up,
+		Version:    "2.0.0",
+		DeployPath: getTestDeployPath(4002),
+	}))
+
+	// Cross reuse is allowed after the conflicting store is physically destroyed.
+	re.NoError(cluster.RemoveStore(100, true))
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:          4003,
+		Address:     "mock://tiflash-d:3930",
+		PeerAddress: "mock://tikv-1:20160",
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(4003),
+	}))
 }
 
 func TestUpStore(t *testing.T) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -533,6 +533,114 @@ func getTestDeployPath(storeID uint64) string {
 	return fmt.Sprintf("test/store%d", storeID)
 }
 
+func TestReusePeerAddress(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
+
+	// Put 4 stores with unique main addresses but the same non-empty peer address pattern per store.
+	for _, store := range newTestStores(4, "2.0.0") {
+		meta := store.GetMeta()
+		meta.PeerAddress = fmt.Sprintf("mock://tiflash-peer-%d:20170", store.GetID())
+		re.NoError(cluster.PutMetaStore(meta))
+	}
+
+	// Empty peer addresses should not conflict with each other.
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:         100,
+		Address:    "mock://tikv-1:20160",
+		State:      metapb.StoreState_Up,
+		Version:    "2.0.0",
+		DeployPath: getTestDeployPath(100),
+	}))
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:         101,
+		Address:    "mock://tikv-2:20160",
+		State:      metapb.StoreState_Up,
+		Version:    "2.0.0",
+		DeployPath: getTestDeployPath(101),
+	}))
+
+	// Same store ID updating with the same peer address should succeed.
+	store1 := cluster.GetStore(1).GetMeta()
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:          store1.GetId(),
+		Address:     store1.GetAddress(),
+		PeerAddress: store1.GetPeerAddress(),
+		State:       metapb.StoreState_Up,
+		Version:     store1.GetVersion(),
+		DeployPath:  getTestDeployPath(store1.GetId()),
+	}))
+
+	// Different main address with a duplicated peer address should fail when old store is up.
+	re.Error(cluster.PutMetaStore(&metapb.Store{
+		Id:          2001,
+		Address:     "mock://tikv-new-1:20160",
+		PeerAddress: cluster.GetStore(1).GetMeta().GetPeerAddress(),
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(2001),
+	}))
+
+	// store 2: offline — duplicated peer address should still fail.
+	re.NoError(cluster.RemoveStore(2, false))
+	re.Error(cluster.PutMetaStore(&metapb.Store{
+		Id:          2002,
+		Address:     "mock://tikv-new-2:20160",
+		PeerAddress: cluster.GetStore(2).GetMeta().GetPeerAddress(),
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(2002),
+	}))
+
+	// store 3: offline and physically destroyed — reuse peer address should succeed.
+	re.NoError(cluster.RemoveStore(3, true))
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:          2003,
+		Address:     "mock://tikv-new-3:20160",
+		PeerAddress: cluster.GetStore(3).GetMeta().GetPeerAddress(),
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(2003),
+	}))
+
+	// store 4: tombstone — reuse peer address should succeed.
+	re.NoError(cluster.RemoveStore(4, true))
+	re.NoError(cluster.BuryStore(4, false))
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:          2004,
+		Address:     "mock://tikv-new-4:20160",
+		PeerAddress: cluster.GetStore(4).GetMeta().GetPeerAddress(),
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(2004),
+	}))
+
+	// Two stores with different main addresses but the same non-empty peer address.
+	const peerAddress = "mock://tiflash-peer:20170"
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:          3001,
+		Address:     "mock://tiflash-a:3930",
+		PeerAddress: peerAddress,
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(3001),
+	}))
+	re.Error(cluster.PutMetaStore(&metapb.Store{
+		Id:          3002,
+		Address:     "mock://tiflash-b:3930",
+		PeerAddress: peerAddress,
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(3002),
+	}))
+}
+
 func TestUpStore(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11002

PD only enforced uniqueness of a store's main `address` during registration.
A new store could still be accepted with a unique main address but a
`peer_address` already used by another live store (or colliding with another
store's address). Raft prefers `peer_address`, so messages can be misrouted
and cause `StoreNotMatch`, stuck placement operators, and unavailable
TiFlash replicas.

### What is changed and how does it work?

```commit-message
Reject store registration when a non-empty peer_address collides with
another live store's peer_address or address, and when address collides
with another live store's non-empty peer_address. Tombstone and physically
destroyed stores are still allowed to be replaced, matching the existing
main-address reuse rules. Empty peer_address (common for TiKV) is ignored.
```

### Check List

Tests

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
PD now rejects store registration when peer_address collides with another live store's address or peer_address.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented store registrations from using addresses that conflict with existing store or peer addresses.
  * Added validation for both main and peer address collisions, including cross-collisions.
  * Allowed address reuse after the previous store has been physically removed or tombstoned.
  * Preserved valid updates for the same store and allowed empty peer addresses without conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->