### PR TITLE
resource_group client: narrow degraded fallback conditions for GetResourceGroup

### DIFF
--- a/client/errs/errno.go
+++ b/client/errs/errno.go
@@ -109,10 +109,23 @@ var (
 type ErrClientGetResourceGroup struct {
 	ResourceGroupName string
 	Cause             string
+	Err               error
 }
 
 func (e *ErrClientGetResourceGroup) Error() string {
-	return fmt.Sprintf("get resource group %s failed, %s", e.ResourceGroupName, e.Cause)
+	cause := e.Cause
+	if cause == "" && e.Err != nil {
+		cause = e.Err.Error()
+	}
+	if cause == "" {
+		cause = "unknown error"
+	}
+	return fmt.Sprintf("get resource group %s failed, %s", e.ResourceGroupName, cause)
+}
+
+// Unwrap returns the underlying error so callers can inspect the original gRPC or context error.
+func (e *ErrClientGetResourceGroup) Unwrap() error {
+	return e.Err
 }
 
 // scheduler errors

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -551,10 +551,6 @@ func normalizeGetResourceGroupError(err error) error {
 		return context.Canceled
 	case goerrors.Is(err, context.DeadlineExceeded):
 		return context.DeadlineExceeded
-	case status.Code(err) == codes.Canceled:
-		return context.Canceled
-	case status.Code(err) == codes.DeadlineExceeded:
-		return context.DeadlineExceeded
 	default:
 		return err
 	}

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -576,7 +576,7 @@ func (c *ResourceGroupsController) shouldUseDegradedResourceGroup(err error) boo
 	if isResourceGroupNotFoundError(err) {
 		return false
 	}
-	if normalizedErr := normalizeGetResourceGroupError(err); normalizedErr == context.Canceled || normalizedErr == context.DeadlineExceeded {
+	if goerrors.Is(err, context.Canceled) || goerrors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
 	causeErr := unwrapGetResourceGroupError(err)
@@ -584,6 +584,8 @@ func (c *ResourceGroupsController) shouldUseDegradedResourceGroup(err error) boo
 		return true
 	}
 	switch status.Code(causeErr) {
+	case codes.Canceled:
+		return false
 	case codes.Unavailable, codes.DeadlineExceeded:
 		return true
 	default:

--- a/client/resource_group/controller/global_controller.go
+++ b/client/resource_group/controller/global_controller.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	goerrors "errors"
 	"slices"
 	"strings"
 	"sync"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -531,6 +534,63 @@ func NewResourceGroupNotExistErr(name string) error {
 	return &errs.ErrClientGetResourceGroup{ResourceGroupName: name, Cause: "resource group does not exist"}
 }
 
+func unwrapGetResourceGroupError(err error) error {
+	for err != nil {
+		var groupErr *errs.ErrClientGetResourceGroup
+		if !goerrors.As(err, &groupErr) || groupErr.Err == nil || groupErr.Err == err {
+			return err
+		}
+		err = groupErr.Err
+	}
+	return nil
+}
+
+func normalizeGetResourceGroupError(err error) error {
+	switch {
+	case goerrors.Is(err, context.Canceled):
+		return context.Canceled
+	case goerrors.Is(err, context.DeadlineExceeded):
+		return context.DeadlineExceeded
+	case status.Code(err) == codes.Canceled:
+		return context.Canceled
+	case status.Code(err) == codes.DeadlineExceeded:
+		return context.DeadlineExceeded
+	default:
+		return err
+	}
+}
+
+func isResourceGroupNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "PD:resourcemanager:ErrGroupNotExists") ||
+		strings.Contains(msg, "resource group does not exist")
+}
+
+func (c *ResourceGroupsController) shouldUseDegradedResourceGroup(err error) bool {
+	if c.degradedRUSettings == nil || err == nil {
+		return false
+	}
+	if isResourceGroupNotFoundError(err) {
+		return false
+	}
+	if normalizedErr := normalizeGetResourceGroupError(err); normalizedErr == context.Canceled || normalizedErr == context.DeadlineExceeded {
+		return false
+	}
+	causeErr := unwrapGetResourceGroupError(err)
+	if errs.IsLeaderChange(causeErr) {
+		return true
+	}
+	switch status.Code(causeErr) {
+	case codes.Unavailable, codes.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *ResourceGroupsController) getDegradedResourceGroup(resourceGroupName string) *rmpb.ResourceGroup {
 	group := &rmpb.ResourceGroup{
 		Name:       resourceGroupName,
@@ -559,11 +619,11 @@ func (c *ResourceGroupsController) tryGetResourceGroupController(
 	// Call gRPC to fetch the resource group info.
 	group, err := c.provider.GetResourceGroup(ctx, name)
 	if err != nil {
-		if c.degradedRUSettings != nil {
+		if c.shouldUseDegradedResourceGroup(err) {
 			isUseDegradedResourceGroup = true
 			group = c.getDegradedResourceGroup(name)
 		} else {
-			return nil, err
+			return nil, normalizeGetResourceGroupError(err)
 		}
 	}
 	if group == nil {

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -428,6 +428,42 @@ func TestGetResourceGroup(t *testing.T) {
 		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
 	})
 
+	t.Run("server-grpc-status-without-degraded-settings-preserves-original-error", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			code codes.Code
+		}{
+			{name: "canceled", code: codes.Canceled},
+			{name: "deadline-exceeded", code: codes.DeadlineExceeded},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				re := require.New(t)
+				activeCtx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+
+				mockProvider := newMockResourceGroupProvider()
+				controller := newController(t, mockProvider)
+
+				serverErr := status.Error(tc.code, "resource manager returned an error")
+				wrappedErr := &errs.ErrClientGetResourceGroup{
+					ResourceGroupName: "test-group",
+					Cause:             serverErr.Error(),
+					Err:               serverErr,
+				}
+				mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+					Return((*rmpb.ResourceGroup)(nil), wrappedErr).
+					Once()
+
+				gc, err := controller.tryGetResourceGroupController(activeCtx, "test-group", false)
+				re.Nil(gc)
+				re.Same(wrappedErr, err)
+				re.Same(serverErr, wrappedErr.Err)
+				re.Equal(tc.code, status.Code(err))
+				mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+			})
+		}
+	})
+
 	t.Run("grpc-deadline-exceeded-uses-degraded-group", func(t *testing.T) {
 		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -65,11 +67,15 @@ func (m *MockResourceGroupProvider) GetResourceGroup(ctx context.Context, resour
 		err = errors.New("fake get resource group error")
 	})
 	if err != nil {
-		return nil, &errs.ErrClientGetResourceGroup{ResourceGroupName: resourceGroupName, Cause: err.Error()}
+		return nil, &errs.ErrClientGetResourceGroup{ResourceGroupName: resourceGroupName, Cause: err.Error(), Err: err}
 	}
 
 	args := m.Called(ctx, resourceGroupName, opts)
-	return args.Get(0).(*rmpb.ResourceGroup), args.Error(1)
+	var group *rmpb.ResourceGroup
+	if ret := args.Get(0); ret != nil {
+		group = ret.(*rmpb.ResourceGroup)
+	}
+	return group, args.Error(1)
 }
 
 func (m *MockResourceGroupProvider) ListResourceGroups(ctx context.Context, opts ...pd.GetResourceGroupOption) ([]*rmpb.ResourceGroup, error) {
@@ -309,77 +315,163 @@ func TestGetResourceGroup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Enable the failpoint to simulate an error when getting the resource group.
-	re.NoError(failpoint.Enable("github.com/tikv/pd/client/resource_group/controller/gerResourceGroupError", `return()`))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/gerResourceGroupError"))
-	}()
-
-	mockProvider := newMockResourceGroupProvider()
-
-	expectResourceGroupName := "test-group"
-	expectRUSettings := &rmpb.GroupRequestUnitSettings{
-		RU: &rmpb.TokenBucket{
-			Settings: &rmpb.TokenLimitSettings{
-				FillRate:   uint64(50),
-				BurstLimit: int64(100),
-			},
-		},
-	}
-	expectResourceGroup := &rmpb.ResourceGroup{
-		Name:       expectResourceGroupName,
-		Mode:       rmpb.GroupMode_RUMode,
-		RUSettings: expectRUSettings,
-	}
-
-	opts := []ResourceControlCreateOption{WithDegradedRUSettings(expectRUSettings)}
-
-	controller, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID, opts...)
-	re.NoError(err)
-	controller.Start(ctx)
-
-	testResourceGroup := &rmpb.ResourceGroup{
-		Name: "test-group",
-		Mode: rmpb.GroupMode_RUMode,
-		RUSettings: &rmpb.GroupRequestUnitSettings{
-			RU: &rmpb.TokenBucket{
-				Settings: &rmpb.TokenLimitSettings{
-					FillRate: 1000000,
+	newResourceGroup := func(name string, fillRate uint64, burstLimit int64) *rmpb.ResourceGroup {
+		return &rmpb.ResourceGroup{
+			Name: name,
+			Mode: rmpb.GroupMode_RUMode,
+			RUSettings: &rmpb.GroupRequestUnitSettings{
+				RU: &rmpb.TokenBucket{
+					Settings: &rmpb.TokenLimitSettings{
+						FillRate:   fillRate,
+						BurstLimit: burstLimit,
+					},
 				},
 			},
+		}
+	}
+	wrapGetResourceGroupErr := func(name string, err error) error {
+		if err == nil {
+			return nil
+		}
+		return &errs.ErrClientGetResourceGroup{
+			ResourceGroupName: name,
+			Cause:             err.Error(),
+			Err:               err,
+		}
+	}
+	newController := func(provider *MockResourceGroupProvider, opts ...ResourceControlCreateOption) *ResourceGroupsController {
+		controller, err := NewResourceGroupController(ctx, 1, provider, nil, constants.NullKeyspaceID, opts...)
+		re.NoError(err)
+		return controller
+	}
+
+	degradedRUSettings := &rmpb.GroupRequestUnitSettings{
+		RU: &rmpb.TokenBucket{
+			Settings: &rmpb.TokenLimitSettings{
+				FillRate:   50,
+				BurstLimit: 100,
+			},
 		},
 	}
-	mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).Return(testResourceGroup, nil)
+	degradedResourceGroup := newResourceGroup("test-group", 50, 100)
 
-	// case1: when GetResourceGroup return error, it should return the expectResourceGroup.
-	gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
-	re.NoError(err)
-	re.Equal(expectResourceGroup, gc.getMeta())
+	t.Run("transient-rm-unavailability-uses-degraded-and-recovers", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
-	// case2: when GetResourceGroup return error again, It should still return the expectResourceGroup.
-	gc, err = controller.tryGetResourceGroupController(ctx, "test-group", false)
-	re.NoError(err)
-	re.Equal(expectResourceGroup, gc.getMeta())
+		realGroup := newResourceGroup("test-group", 1000000, 0)
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), wrapGetResourceGroupErr("test-group", status.Error(codes.Unavailable, "resource manager unavailable"))).
+			Once()
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return(realGroup, nil).
+			Once()
 
-	// case3: If `GetResourceGroup` returns no error (`nil`), it should return the testResourceGroup.
-	re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/gerResourceGroupError"))
-	gc, err = controller.tryGetResourceGroupController(ctx, "test-group", false)
-	re.NoError(err)
-	re.Equal(testResourceGroup, gc.getMeta())
+		gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.NoError(err)
+		re.Equal(degradedResourceGroup, gc.getMeta())
 
-	// case4: when we don't set degradedRUSettings and GetResourceGroup return error, tryGetResourceGroupController will return err.
-	re.NoError(failpoint.Enable("github.com/tikv/pd/client/resource_group/controller/gerResourceGroupError", `return()`))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/client/resource_group/controller/gerResourceGroupError"))
-	}()
+		gc, err = controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.NoError(err)
+		re.Equal(realGroup, gc.getMeta())
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 2)
+	})
 
-	controller02, err := NewResourceGroupController(ctx, 1, mockProvider, nil, constants.NullKeyspaceID)
-	re.NoError(err)
-	controller02.Start(ctx)
+	t.Run("resource-group-not-found-returns-original-error", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
-	gc02, err := controller02.tryGetResourceGroupController(ctx, "test-group", false)
-	re.Error(err)
-	re.Nil(gc02)
+		notFoundErr := wrapGetResourceGroupErr("test-group",
+			status.Error(codes.Unknown, "[PD:resourcemanager:ErrGroupNotExists]the test-group resource group does not exist"))
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), notFoundErr).
+			Once()
+
+		gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.Error(err)
+		re.Same(notFoundErr, err)
+		re.Nil(gc)
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+	})
+
+	t.Run("caller-cancellation-returns-context-canceled", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), wrapGetResourceGroupErr("test-group", context.Canceled)).
+			Once()
+
+		gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.ErrorIs(err, context.Canceled)
+		re.Equal(context.Canceled, err)
+		re.Nil(gc)
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+	})
+
+	t.Run("caller-deadline-returns-context-deadline-exceeded", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), wrapGetResourceGroupErr("test-group", context.DeadlineExceeded)).
+			Once()
+
+		gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.ErrorIs(err, context.DeadlineExceeded)
+		re.Equal(context.DeadlineExceeded, err)
+		re.Nil(gc)
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+	})
+
+	t.Run("generic-non-retryable-error-returns-original-error", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+
+		permissionErr := wrapGetResourceGroupErr("test-group", status.Error(codes.PermissionDenied, "permission denied"))
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), permissionErr).
+			Once()
+
+		gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.Error(err)
+		re.Same(permissionErr, err)
+		re.Nil(gc)
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+	})
+
+	t.Run("nonexistent-switch-group-target-does-not-switch", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+
+		switchTargetErr := wrapGetResourceGroupErr("switch-target",
+			status.Error(codes.Unknown, "[PD:resourcemanager:ErrGroupNotExists]the switch-target resource group does not exist"))
+		mockProvider.On("GetResourceGroup", mock.Anything, "switch-target", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), switchTargetErr).
+			Once()
+
+		gc, err := controller.tryGetResourceGroupController(ctx, "switch-target", false)
+		re.Error(err)
+		re.Same(switchTargetErr, err)
+		re.Nil(gc)
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+	})
+
+	t.Run("without-degraded-settings-propagates-transient-error", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider)
+
+		unavailableErr := wrapGetResourceGroupErr("test-group", status.Error(codes.Unavailable, "resource manager unavailable"))
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), unavailableErr).
+			Once()
+
+		gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.Error(err)
+		re.Same(unavailableErr, err)
+		re.Nil(gc)
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+	})
 }
 
 func TestTokenBucketsRequestWithKeyspaceID(t *testing.T) {

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -424,6 +424,20 @@ func TestGetResourceGroup(t *testing.T) {
 		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
 	})
 
+	t.Run("grpc-deadline-exceeded-uses-degraded-group", func(t *testing.T) {
+		mockProvider := newMockResourceGroupProvider()
+		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+
+		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
+			Return((*rmpb.ResourceGroup)(nil), wrapGetResourceGroupErr("test-group", status.Error(codes.DeadlineExceeded, "rpc deadline exceeded"))).
+			Once()
+
+		gc, err := controller.tryGetResourceGroupController(ctx, "test-group", false)
+		re.NoError(err)
+		re.Equal(degradedResourceGroup, gc.getMeta())
+		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
+	})
+
 	t.Run("generic-non-retryable-error-returns-original-error", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -460,24 +460,6 @@ func TestGetResourceGroup(t *testing.T) {
 		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
 	})
 
-	t.Run("nonexistent-switch-group-target-does-not-switch", func(t *testing.T) {
-		re := require.New(t)
-		mockProvider := newMockResourceGroupProvider()
-		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
-
-		switchTargetErr := wrapGetResourceGroupErr("switch-target",
-			status.Error(codes.Unknown, "[PD:resourcemanager:ErrGroupNotExists]the switch-target resource group does not exist"))
-		mockProvider.On("GetResourceGroup", mock.Anything, "switch-target", mock.Anything).
-			Return((*rmpb.ResourceGroup)(nil), switchTargetErr).
-			Once()
-
-		gc, err := controller.tryGetResourceGroupController(ctx, "switch-target", false)
-		re.Error(err)
-		re.Same(switchTargetErr, err)
-		re.Nil(gc)
-		mockProvider.AssertNumberOfCalls(t, "GetResourceGroup", 1)
-	})
-
 	t.Run("without-degraded-settings-propagates-transient-error", func(t *testing.T) {
 		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -339,7 +339,8 @@ func TestGetResourceGroup(t *testing.T) {
 			Err:               err,
 		}
 	}
-	newController := func(provider *MockResourceGroupProvider, opts ...ResourceControlCreateOption) *ResourceGroupsController {
+	newController := func(t *testing.T, provider *MockResourceGroupProvider, opts ...ResourceControlCreateOption) *ResourceGroupsController {
+		re := require.New(t)
 		controller, err := NewResourceGroupController(ctx, 1, provider, nil, constants.NullKeyspaceID, opts...)
 		re.NoError(err)
 		return controller
@@ -357,7 +358,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("transient-rm-unavailability-uses-degraded-and-recovers", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
 		realGroup := newResourceGroup("test-group", 1000000, 0)
 		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
@@ -379,7 +380,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("resource-group-not-found-returns-original-error", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
 		notFoundErr := wrapGetResourceGroupErr("test-group",
 			status.Error(codes.Unknown, "[PD:resourcemanager:ErrGroupNotExists]the test-group resource group does not exist"))
@@ -396,7 +397,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("caller-cancellation-returns-context-canceled", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
 		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
 			Return((*rmpb.ResourceGroup)(nil), wrapGetResourceGroupErr("test-group", context.Canceled)).
@@ -411,7 +412,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("caller-deadline-returns-context-deadline-exceeded", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
 		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
 			Return((*rmpb.ResourceGroup)(nil), wrapGetResourceGroupErr("test-group", context.DeadlineExceeded)).
@@ -426,7 +427,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("grpc-deadline-exceeded-uses-degraded-group", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
 		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
 			Return((*rmpb.ResourceGroup)(nil), wrapGetResourceGroupErr("test-group", status.Error(codes.DeadlineExceeded, "rpc deadline exceeded"))).
@@ -440,7 +441,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("generic-non-retryable-error-returns-original-error", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
 		permissionErr := wrapGetResourceGroupErr("test-group", status.Error(codes.PermissionDenied, "permission denied"))
 		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).
@@ -456,7 +457,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("nonexistent-switch-group-target-does-not-switch", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider, WithDegradedRUSettings(degradedRUSettings))
+		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
 		switchTargetErr := wrapGetResourceGroupErr("switch-target",
 			status.Error(codes.Unknown, "[PD:resourcemanager:ErrGroupNotExists]the switch-target resource group does not exist"))
@@ -473,7 +474,7 @@ func TestGetResourceGroup(t *testing.T) {
 
 	t.Run("without-degraded-settings-propagates-transient-error", func(t *testing.T) {
 		mockProvider := newMockResourceGroupProvider()
-		controller := newController(mockProvider)
+		controller := newController(t, mockProvider)
 
 		unavailableErr := wrapGetResourceGroupErr("test-group", status.Error(codes.Unavailable, "resource manager unavailable"))
 		mockProvider.On("GetResourceGroup", mock.Anything, "test-group", mock.Anything).

--- a/client/resource_group/controller/global_controller_test.go
+++ b/client/resource_group/controller/global_controller_test.go
@@ -311,7 +311,6 @@ func TestTryGetController(t *testing.T) {
 }
 
 func TestGetResourceGroup(t *testing.T) {
-	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -357,6 +356,7 @@ func TestGetResourceGroup(t *testing.T) {
 	degradedResourceGroup := newResourceGroup("test-group", 50, 100)
 
 	t.Run("transient-rm-unavailability-uses-degraded-and-recovers", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
@@ -379,6 +379,7 @@ func TestGetResourceGroup(t *testing.T) {
 	})
 
 	t.Run("resource-group-not-found-returns-original-error", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
@@ -396,6 +397,7 @@ func TestGetResourceGroup(t *testing.T) {
 	})
 
 	t.Run("caller-cancellation-returns-context-canceled", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
@@ -411,6 +413,7 @@ func TestGetResourceGroup(t *testing.T) {
 	})
 
 	t.Run("caller-deadline-returns-context-deadline-exceeded", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
@@ -426,6 +429,7 @@ func TestGetResourceGroup(t *testing.T) {
 	})
 
 	t.Run("grpc-deadline-exceeded-uses-degraded-group", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
@@ -440,6 +444,7 @@ func TestGetResourceGroup(t *testing.T) {
 	})
 
 	t.Run("generic-non-retryable-error-returns-original-error", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
@@ -456,6 +461,7 @@ func TestGetResourceGroup(t *testing.T) {
 	})
 
 	t.Run("nonexistent-switch-group-target-does-not-switch", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider, WithDegradedRUSettings(degradedRUSettings))
 
@@ -473,6 +479,7 @@ func TestGetResourceGroup(t *testing.T) {
 	})
 
 	t.Run("without-degraded-settings-propagates-transient-error", func(t *testing.T) {
+		re := require.New(t)
 		mockProvider := newMockResourceGroupProvider()
 		controller := newController(t, mockProvider)
 

--- a/client/resource_manager_client.go
+++ b/client/resource_manager_client.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/errors"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -160,11 +158,9 @@ func (c *client) GetResourceGroup(ctx context.Context, resourceGroupName string,
 		c.inner.gRPCErrorHandler(err)
 		c.inner.resourceManagerErrorHandler(err)
 		causeErr := err
-		switch status.Code(err) {
-		case codes.Canceled:
-			causeErr = context.Canceled
-		case codes.DeadlineExceeded:
-			causeErr = context.DeadlineExceeded
+		switch ctxErr := ctx.Err(); ctxErr {
+		case context.Canceled, context.DeadlineExceeded:
+			causeErr = ctxErr
 		}
 		return nil, &errs.ErrClientGetResourceGroup{
 			ResourceGroupName: resourceGroupName,

--- a/client/resource_manager_client.go
+++ b/client/resource_manager_client.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/errors"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -157,7 +159,18 @@ func (c *client) GetResourceGroup(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		c.inner.gRPCErrorHandler(err)
 		c.inner.resourceManagerErrorHandler(err)
-		return nil, &errs.ErrClientGetResourceGroup{ResourceGroupName: resourceGroupName, Cause: err.Error()}
+		causeErr := err
+		switch status.Code(err) {
+		case codes.Canceled:
+			causeErr = context.Canceled
+		case codes.DeadlineExceeded:
+			causeErr = context.DeadlineExceeded
+		}
+		return nil, &errs.ErrClientGetResourceGroup{
+			ResourceGroupName: resourceGroupName,
+			Cause:             err.Error(),
+			Err:               causeErr,
+		}
 	}
 	resErr := resp.GetError()
 	if resErr != nil {

--- a/client/resource_manager_client_test.go
+++ b/client/resource_manager_client_test.go
@@ -317,6 +317,32 @@ func TestResourceManagerWritesUsePDAndReadsUseRM(t *testing.T) {
 	require.EqualValues(t, 0, rmServer.deleteCount.Load())
 }
 
+func TestGetResourceGroupPreservesContextErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	pdAddr, _, pdCleanup := startTestRMServer(t, "pd")
+	t.Cleanup(pdCleanup)
+	rmAddr, _, rmCleanup := startTestRMServer(t, "rm")
+	t.Cleanup(rmCleanup)
+
+	inner := newInnerClientForRMRouteTest(t, ctx, pdAddr)
+	inner.resourceManagerDiscovery = newTestResourceManagerDiscovery(t, ctx, rmAddr)
+	t.Cleanup(inner.resourceManagerDiscovery.Close)
+
+	cli := &client{inner: inner}
+
+	canceledCtx, cancelRequest := context.WithCancel(ctx)
+	cancelRequest()
+	_, err := cli.GetResourceGroup(canceledCtx, "test-group")
+	require.ErrorIs(t, err, context.Canceled)
+
+	expiredCtx, cancelDeadline := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	defer cancelDeadline()
+	_, err = cli.GetResourceGroup(expiredCtx, "test-group")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestTryResourceManagerConnectUsesRMForTokenAndFallbackToPD(t *testing.T) {
 	t.Run("prefer-rm-when-available", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/client/resource_manager_client_test.go
+++ b/client/resource_manager_client_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/kvproto/pkg/meta_storagepb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
@@ -131,6 +133,7 @@ type testRMServer struct {
 	modifyCount atomic.Int32
 	deleteCount atomic.Int32
 	tokenCount  atomic.Int32
+	getErr      error
 }
 
 func (s *testRMServer) ListResourceGroups(context.Context, *rmpb.ListResourceGroupsRequest) (*rmpb.ListResourceGroupsResponse, error) {
@@ -144,6 +147,9 @@ func (s *testRMServer) ListResourceGroups(context.Context, *rmpb.ListResourceGro
 
 func (s *testRMServer) GetResourceGroup(context.Context, *rmpb.GetResourceGroupRequest) (*rmpb.GetResourceGroupResponse, error) {
 	s.getCount.Add(1)
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
 	return &rmpb.GetResourceGroupResponse{
 		Group: &rmpb.ResourceGroup{
 			Name: s.id,
@@ -323,7 +329,7 @@ func TestGetResourceGroupPreservesContextErrors(t *testing.T) {
 
 	pdAddr, _, pdCleanup := startTestRMServer(t, "pd")
 	t.Cleanup(pdCleanup)
-	rmAddr, _, rmCleanup := startTestRMServer(t, "rm")
+	rmAddr, rmServer, rmCleanup := startTestRMServer(t, "rm")
 	t.Cleanup(rmCleanup)
 
 	inner := newInnerClientForRMRouteTest(t, ctx, pdAddr)
@@ -341,6 +347,11 @@ func TestGetResourceGroupPreservesContextErrors(t *testing.T) {
 	defer cancelDeadline()
 	_, err = cli.GetResourceGroup(expiredCtx, "test-group")
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	rmServer.getErr = status.Error(codes.DeadlineExceeded, "rm deadline exceeded")
+	_, err = cli.GetResourceGroup(ctx, "test-group")
+	require.NotErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, codes.DeadlineExceeded, status.Code(errors.Unwrap(err)))
 }
 
 func TestTryResourceManagerConnectUsesRMForTokenAndFallbackToPD(t *testing.T) {

--- a/tests/integrations/mcs/resourcemanager/resource_manager_test.go
+++ b/tests/integrations/mcs/resourcemanager/resource_manager_test.go
@@ -791,6 +791,14 @@ func (suite *resourceManagerClientTestSuite) TestWatchWithSingleGroupByKeyspace(
 	resp, err := cli.AddResourceGroup(suite.ctx, group)
 	re.NoError(err)
 	re.Contains(resp, "Success!")
+	// In standalone RM mode, writes go through the PD proxy and the standalone
+	// RM observes persisted metadata asynchronously. Wait until the read path
+	// can see the group before the controller lazily loads it.
+	var getErr error
+	testutil.Eventually(re, func() bool {
+		_, getErr = cli.GetResourceGroup(suite.ctx, group.Name)
+		return getErr == nil
+	}, testutil.WithTickInterval(50*time.Millisecond))
 
 	tcs := tokenConsumptionPerSecond{rruTokensAtATime: 100}
 	_, _, _, _, err = controller.OnRequestWait(suite.ctx, group.Name, tcs.makeReadRequest())


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: ref https://github.com/tikv/pd/issues/11010

### What is changed and how does it work?

  Refine the degraded fallback behavior of `GetResourceGroup` when `degradedRUSettings` is configured.

  Currently, degraded fallback is too broad and may hide original errors from RM. We should only use degraded fallback for transient RM failures, while preserving original errors for non-retryable cases.

  Expected behavior:
  - transient RM unavailability -> degraded group
  - RM recovery -> real group
  - resource group not found -> original error
  - caller cancellation/deadline -> original context error
  - generic non-retryable error -> original error
  - nonexistent `SwitchGroup` target -> do not switch

  It is also helpful to preserve the underlying error from `ErrClientGetResourceGroup` so upper layers can correctly inspect errors such as `context.Canceled` and `context.DeadlineExceeded`.

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource group error reporting by surfacing the most relevant underlying failure cause.
  - Reliably preserved caller `Canceled` and `DeadlineExceeded` errors, even when the server reports gRPC deadline failures.
  - Refined degraded-mode fallback to apply only to retryable scenarios, with better “not found” and permission-denied handling.

- **Tests**
  - Expanded unit test coverage for degraded fallback and error classification.
  - Updated an integration test to wait for resource group readiness before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->