### PR TITLE
client: use batch-level runtime trace regions

### DIFF
--- a/client/tso_dispatcher.go
+++ b/client/tso_dispatcher.go
@@ -547,12 +547,15 @@ func (td *tsoDispatcher) processRequests(
 ) error {
 	// `done` must be guaranteed to be eventually called.
 	var (
-		requests     = tbc.getCollectedRequests()
-		traceRegions = make([]*trace.Region, 0, len(requests))
-		spans        = make([]opentracing.Span, 0, len(requests))
+		requests = tbc.getCollectedRequests()
+		spans    = make([]opentracing.Span, 0, len(requests))
 	)
+	traceCtx := context.Background()
+	if len(requests) > 0 {
+		traceCtx = requests[0].requestCtx
+	}
+	traceRegion := trace.StartRegion(traceCtx, "pdclient.tsoReqSendBatch")
 	for _, req := range requests {
-		traceRegions = append(traceRegions, trace.StartRegion(req.requestCtx, "pdclient.tsoReqSend"))
 		if span := opentracing.SpanFromContext(req.requestCtx); span != nil && span.Tracer() != nil {
 			spans = append(spans, span.Tracer().StartSpan("pdclient.processRequests", opentracing.ChildOf(span.Context())))
 		}
@@ -561,9 +564,7 @@ func (td *tsoDispatcher) processRequests(
 		for i := range spans {
 			spans[i].Finish()
 		}
-		for i := range traceRegions {
-			traceRegions[i].End()
-		}
+		traceRegion.End()
 	}()
 
 	var (


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/tikv/pd/pull/10965

Cherry-pick https://github.com/tikv/pd/pull/10965 to `release-8.5-20260323-v8.5.5`. This reduces Go runtime trace region overhead by using a batch-level TSO request send region.

### What is changed and how does it work?

This backport changes TSO dispatcher tracing from one `pdclient.tsoReqSend` region per request to one `pdclient.tsoReqSendBatch` region per processed batch.

Conflict note: the original master PR also touched `client/clients/router/client.go`, but that router client path does not exist in this release branch, so that part is not applicable here. The final backport only changes `client/tso_dispatcher.go`.

### Check List

Tests:

- [x] `git diff --check origin/release-8.5-20260323-v8.5.5...HEAD`
- [x] `cd client && go test ./... -run '^$' -count=1`
- [x] `cd client && go test . -run 'TestTSODispatcherTestSuite/TestBasic' -count=1`
- [x] `cd client && go test . -run 'TestTSODispatcherTestSuite/TestBatchDelaying' -count=1`
- [x] `cd client && go test . -run 'TestTSODispatcherTestSuite/TestBatchDelaying' -count=1 -trace /tmp/pdclient-tso-batch-20260323.trace` and verified the trace contains `pdclient.tsoReqSendBatch`

### Release note

```release-note
None
```
