### PR TITLE
server: make EtcdStartTimeout a no-progress timeout

### DIFF
--- a/server/etcd_start_test.go
+++ b/server/etcd_start_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/errors"
+
+	"github.com/tikv/pd/pkg/errs"
+)
+
+const (
+	testCheckInterval     = 5 * time.Millisecond
+	testNoProgressTimeout = 50 * time.Millisecond
+)
+
+// constApplied returns an appliedIndex getter that never advances, simulating a
+// hung etcd that makes no apply progress.
+func constApplied(v uint64) func() uint64 {
+	return func() uint64 { return v }
+}
+
+// advancingApplied returns an appliedIndex getter that advances on every call,
+// simulating a healthy etcd that keeps applying its raft log.
+func advancingApplied() func() uint64 {
+	var idx atomic.Uint64
+	return func() uint64 { return idx.Add(1) }
+}
+
+func TestWaitEtcdReadyProgress(t *testing.T) {
+	t.Run("ready immediately", func(t *testing.T) {
+		re := require.New(t)
+		ready := make(chan struct{})
+		close(ready)
+		err := waitEtcdReadyProgress(context.Background(), ready, constApplied(0),
+			testCheckInterval, testNoProgressTimeout)
+		re.NoError(err)
+	})
+
+	t.Run("keeps waiting while applied index advances", func(t *testing.T) {
+		re := require.New(t)
+		// ready only fires well after the no-progress timeout would have elapsed;
+		// a fixed deadline would have killed this, but steady apply progress must
+		// keep the wait alive.
+		ready := make(chan struct{})
+		go func() {
+			time.Sleep(4 * testNoProgressTimeout)
+			close(ready)
+		}()
+		start := time.Now()
+		err := waitEtcdReadyProgress(context.Background(), ready, advancingApplied(),
+			testCheckInterval, testNoProgressTimeout)
+		re.NoError(err)
+		// It must have outlived the no-progress window instead of bailing at it.
+		re.GreaterOrEqual(time.Since(start), 3*testNoProgressTimeout)
+	})
+
+	t.Run("gives up when no apply progress", func(t *testing.T) {
+		re := require.New(t)
+		// ready never fires and applied index is stuck: a genuine hang.
+		start := time.Now()
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), constApplied(7),
+			testCheckInterval, testNoProgressTimeout)
+		re.Error(err)
+		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
+		// It should wait roughly the whole no-progress window before giving up.
+		re.GreaterOrEqual(time.Since(start), testNoProgressTimeout-testCheckInterval)
+	})
+
+	t.Run("honors ctx cancellation", func(t *testing.T) {
+		re := require.New(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(2 * testCheckInterval)
+			cancel()
+		}()
+		start := time.Now()
+		// applied index advances, so only ctx cancellation can end the wait.
+		err := waitEtcdReadyProgress(ctx, make(chan struct{}), advancingApplied(),
+			testCheckInterval, testNoProgressTimeout)
+		re.Error(err)
+		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
+		// Cancellation returns before the no-progress timeout would trigger.
+		re.Less(time.Since(start), testNoProgressTimeout)
+	})
+}

--- a/server/etcd_start_test.go
+++ b/server/etcd_start_test.go
@@ -50,9 +50,25 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		re := require.New(t)
 		ready := make(chan struct{})
 		close(ready)
-		err := waitEtcdReadyProgress(context.Background(), ready, constApplied(0),
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, constApplied(0),
 			testCheckInterval, testNoProgressTimeout)
 		re.NoError(err)
+	})
+
+	t.Run("fails fast on async etcd error", func(t *testing.T) {
+		re := require.New(t)
+		// etcd reports a fatal startup error before ever becoming ready.
+		errCh := make(chan error, 1)
+		errCh <- errors.New("boom")
+		start := time.Now()
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), errCh, constApplied(0),
+			testCheckInterval, testNoProgressTimeout)
+		re.Error(err)
+		// The real cause is wrapped in ErrStartEtcd, not swallowed by a timeout.
+		re.ErrorContains(err, "PD:etcd:ErrStartEtcd")
+		re.ErrorContains(err, "boom")
+		// It must not wait out the whole no-progress window.
+		re.Less(time.Since(start), testNoProgressTimeout)
 	})
 
 	t.Run("keeps waiting while applied index advances", func(t *testing.T) {
@@ -66,7 +82,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 			close(ready)
 		}()
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), ready, advancingApplied(),
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, advancingApplied(),
 			testCheckInterval, testNoProgressTimeout)
 		re.NoError(err)
 		// It must have outlived the no-progress window instead of bailing at it.
@@ -77,7 +93,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		re := require.New(t)
 		// ready never fires and applied index is stuck: a genuine hang.
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), constApplied(7),
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, constApplied(7),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
@@ -94,7 +110,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		}()
 		start := time.Now()
 		// applied index advances, so only ctx cancellation can end the wait.
-		err := waitEtcdReadyProgress(ctx, make(chan struct{}), advancingApplied(),
+		err := waitEtcdReadyProgress(ctx, make(chan struct{}), nil, advancingApplied(),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))

--- a/server/etcd_start_test.go
+++ b/server/etcd_start_test.go
@@ -50,7 +50,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		re := require.New(t)
 		ready := make(chan struct{})
 		close(ready)
-		err := waitEtcdReadyProgress(context.Background(), ready, nil, constApplied(0),
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, constApplied(0),
 			testCheckInterval, testNoProgressTimeout)
 		re.NoError(err)
 	})
@@ -61,13 +61,27 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		errCh := make(chan error, 1)
 		errCh <- errors.New("boom")
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), errCh, constApplied(0),
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, errCh, constApplied(0),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		// The real cause is wrapped in ErrStartEtcd, not swallowed by a timeout.
 		re.ErrorContains(err, "PD:etcd:ErrStartEtcd")
 		re.ErrorContains(err, "boom")
 		// It must not wait out the whole no-progress window.
+		re.Less(time.Since(start), testNoProgressTimeout)
+	})
+
+	t.Run("fails fast when etcd server stops before ready", func(t *testing.T) {
+		re := require.New(t)
+		// The server terminates before becoming ready without publishing an error
+		// on errCh (e.g. an internal EtcdServer.run failure).
+		stopped := make(chan struct{})
+		close(stopped)
+		start := time.Now()
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), stopped, nil, constApplied(0),
+			testCheckInterval, testNoProgressTimeout)
+		re.Error(err)
+		re.ErrorContains(err, "PD:etcd:ErrStartEtcd")
 		re.Less(time.Since(start), testNoProgressTimeout)
 	})
 
@@ -82,7 +96,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 			close(ready)
 		}()
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), ready, nil, advancingApplied(),
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, advancingApplied(),
 			testCheckInterval, testNoProgressTimeout)
 		re.NoError(err)
 		// It must have outlived the no-progress window instead of bailing at it.
@@ -93,7 +107,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		re := require.New(t)
 		// ready never fires and applied index is stuck: a genuine hang.
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, constApplied(7),
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, nil, constApplied(7),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
@@ -104,17 +118,15 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 	t.Run("honors ctx cancellation", func(t *testing.T) {
 		re := require.New(t)
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		go func() {
 			time.Sleep(2 * testCheckInterval)
 			cancel()
 		}()
-		start := time.Now()
 		// applied index advances, so only ctx cancellation can end the wait.
-		err := waitEtcdReadyProgress(ctx, make(chan struct{}), nil, advancingApplied(),
+		err := waitEtcdReadyProgress(ctx, make(chan struct{}), nil, nil, advancingApplied(),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
-		// Cancellation returns before the no-progress timeout would trigger.
-		re.Less(time.Since(start), testNoProgressTimeout)
 	})
 }

--- a/server/etcd_start_test.go
+++ b/server/etcd_start_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/errors"
@@ -111,20 +112,63 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 
 	t.Run("keeps waiting while a raft snapshot is in progress", func(t *testing.T) {
 		re := require.New(t)
-		// applied index is stuck, as it would be while etcd is receiving or
-		// applying an incoming raft snapshot; ready only fires well after the
-		// no-progress timeout would have elapsed on applied index alone.
+		// applied index is stuck throughout, as it would be while etcd is
+		// receiving or applying an incoming raft snapshot; ready fires well
+		// inside the noProgressTimeout snapshot-credit window.
 		ready := make(chan struct{})
 		go func() {
-			time.Sleep(4 * testNoProgressTimeout)
+			time.Sleep(5 * testCheckInterval)
 			close(ready)
 		}()
 		start := time.Now()
 		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, constApplied(0), constSnapshotting(true),
 			testCheckInterval, testNoProgressTimeout)
 		re.NoError(err)
-		// It must have outlived the no-progress window instead of bailing at it.
-		re.GreaterOrEqual(time.Since(start), 3*testNoProgressTimeout)
+		re.Less(time.Since(start), testNoProgressTimeout)
+	})
+
+	t.Run("gives up when a raft snapshot install itself stalls", func(t *testing.T) {
+		re := require.New(t)
+		// snapshotting() stays true for the whole wait (as it would for a
+		// snapshot install that hangs, e.g. on stuck disk I/O) and applied
+		// index never advances. A liveness bit alone must not be treated as
+		// progress forever, or EtcdStartTimeout would never fire.
+		start := time.Now()
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, nil, constApplied(0), constSnapshotting(true),
+			testCheckInterval, testNoProgressTimeout)
+		re.Error(err)
+		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
+		// It should give up at roughly one noProgressTimeout window, not
+		// wait indefinitely or double that window.
+		re.GreaterOrEqual(time.Since(start), testNoProgressTimeout-testCheckInterval)
+		re.Less(time.Since(start), 2*testNoProgressTimeout)
+	})
+
+	t.Run("a snapshot streak ending within budget does not trip a stale timeout", func(t *testing.T) {
+		re := require.New(t)
+		// snapshotting() is true for a while (within its own credit window),
+		// then flips back to false before applied index resumes advancing.
+		// Total elapsed time exceeds one noProgressTimeout window, so this
+		// would fail if the transition were judged against a lastProgress
+		// mark left over from before the streak began instead of being
+		// refreshed at the transition.
+		var snapshotting atomic.Bool
+		snapshotting.Store(true)
+		go func() {
+			time.Sleep(5 * testCheckInterval)
+			snapshotting.Store(false)
+		}()
+		ready := make(chan struct{})
+		go func() {
+			time.Sleep(12 * testCheckInterval)
+			close(ready)
+		}()
+		start := time.Now()
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, constApplied(0),
+			func() bool { return snapshotting.Load() },
+			testCheckInterval, testNoProgressTimeout)
+		re.NoError(err)
+		re.GreaterOrEqual(time.Since(start), testNoProgressTimeout-5*testCheckInterval)
 	})
 
 	t.Run("gives up when no apply progress", func(t *testing.T) {
@@ -153,4 +197,102 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		re.Error(err)
 		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
 	})
+
+	t.Run("does not panic when errCh is closed without an error", func(t *testing.T) {
+		re := require.New(t)
+		// embed.Etcd.Err() is closed by Etcd.Close(); a receive from a closed
+		// channel yields a nil error. Wrap(nil) returns a nil *errors.Error,
+		// and calling GenWithStackByCause on that would panic if not guarded.
+		errCh := make(chan error)
+		close(errCh)
+		re.NotPanics(func() {
+			err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, errCh, constApplied(0), constSnapshotting(false),
+				testCheckInterval, testNoProgressTimeout)
+			re.Error(err)
+			re.ErrorContains(err, "PD:etcd:ErrStartEtcd")
+		})
+	})
+
+	t.Run("does not panic when stopped fires and errCh is closed without an error", func(t *testing.T) {
+		re := require.New(t)
+		stopped := make(chan struct{})
+		close(stopped)
+		errCh := make(chan error)
+		close(errCh)
+		re.NotPanics(func() {
+			err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), stopped, errCh, constApplied(0), constSnapshotting(false),
+				testCheckInterval, testNoProgressTimeout)
+			re.Error(err)
+			re.ErrorContains(err, "PD:etcd:ErrStartEtcd")
+		})
+	})
+}
+
+// gatherResult is a fixed prometheus.Gatherer stub that returns the given
+// metric families and error on every call.
+type gatherResult struct {
+	mfs []*dto.MetricFamily
+	err error
+}
+
+func (g gatherResult) Gather() ([]*dto.MetricFamily, error) {
+	return g.mfs, g.err
+}
+
+// gaugeFamily builds a single-metric GAUGE MetricFamily, mirroring the shape
+// etcd's own snapshot gauges take.
+func gaugeFamily(name string, value float64) *dto.MetricFamily {
+	typ := dto.MetricType_GAUGE
+	return &dto.MetricFamily{
+		Name: &name,
+		Type: &typ,
+		Metric: []*dto.Metric{
+			{Gauge: &dto.Gauge{Value: &value}},
+		},
+	}
+}
+
+func TestSnapshotGaugesNonzero(t *testing.T) {
+	t.Run("true when a snapshot gauge is nonzero", func(t *testing.T) {
+		re := require.New(t)
+		mfs := []*dto.MetricFamily{
+			gaugeFamily("etcd_server_snapshot_apply_in_progress_total", 1),
+		}
+		re.True(snapshotGaugesNonzero(gatherResult{mfs: mfs}))
+	})
+
+	t.Run("false when every snapshot gauge is zero", func(t *testing.T) {
+		re := require.New(t)
+		mfs := []*dto.MetricFamily{
+			gaugeFamily("etcd_network_snapshot_receive_inflights_total", 0),
+			gaugeFamily("etcd_server_snapshot_apply_in_progress_total", 0),
+			gaugeFamily("some_unrelated_metric", 1),
+		}
+		re.False(snapshotGaugesNonzero(gatherResult{mfs: mfs}))
+	})
+
+	t.Run("false when Gather returns nothing", func(t *testing.T) {
+		re := require.New(t)
+		re.False(snapshotGaugesNonzero(gatherResult{err: errors.New("boom")}))
+	})
+
+	t.Run("still scans a positive gauge alongside an unrelated collection error", func(t *testing.T) {
+		re := require.New(t)
+		// Registry.Gather can return a non-nil MultiError alongside metric
+		// families collected successfully by unaffected collectors; an
+		// unrelated collector failing here must not hide a real positive
+		// etcd snapshot gauge.
+		mfs := []*dto.MetricFamily{
+			gaugeFamily("etcd_network_snapshot_receive_inflights_total", 1),
+		}
+		re.True(snapshotGaugesNonzero(gatherResult{mfs: mfs, err: errors.New("unrelated collector failed")}))
+	})
+}
+
+func TestIsEtcdSnapshotting(t *testing.T) {
+	re := require.New(t)
+	// isEtcdSnapshotting reads the process-wide default registerer; nothing
+	// in this test process has set either snapshot gauge, so it must read
+	// false rather than error or panic.
+	re.False(isEtcdSnapshotting())
 }

--- a/server/etcd_start_test.go
+++ b/server/etcd_start_test.go
@@ -45,12 +45,18 @@ func advancingApplied() func() uint64 {
 	return func() uint64 { return idx.Add(1) }
 }
 
+// constSnapshotting returns a snapshotting getter that always reports v,
+// simulating whether etcd is currently receiving or applying a raft snapshot.
+func constSnapshotting(v bool) func() bool {
+	return func() bool { return v }
+}
+
 func TestWaitEtcdReadyProgress(t *testing.T) {
 	t.Run("ready immediately", func(t *testing.T) {
 		re := require.New(t)
 		ready := make(chan struct{})
 		close(ready)
-		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, constApplied(0),
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, constApplied(0), constSnapshotting(false),
 			testCheckInterval, testNoProgressTimeout)
 		re.NoError(err)
 	})
@@ -61,7 +67,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		errCh := make(chan error, 1)
 		errCh <- errors.New("boom")
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, errCh, constApplied(0),
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, errCh, constApplied(0), constSnapshotting(false),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		// The real cause is wrapped in ErrStartEtcd, not swallowed by a timeout.
@@ -78,7 +84,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		stopped := make(chan struct{})
 		close(stopped)
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), stopped, nil, constApplied(0),
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), stopped, nil, constApplied(0), constSnapshotting(false),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		re.ErrorContains(err, "PD:etcd:ErrStartEtcd")
@@ -96,7 +102,25 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 			close(ready)
 		}()
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, advancingApplied(),
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, advancingApplied(), constSnapshotting(false),
+			testCheckInterval, testNoProgressTimeout)
+		re.NoError(err)
+		// It must have outlived the no-progress window instead of bailing at it.
+		re.GreaterOrEqual(time.Since(start), 3*testNoProgressTimeout)
+	})
+
+	t.Run("keeps waiting while a raft snapshot is in progress", func(t *testing.T) {
+		re := require.New(t)
+		// applied index is stuck, as it would be while etcd is receiving or
+		// applying an incoming raft snapshot; ready only fires well after the
+		// no-progress timeout would have elapsed on applied index alone.
+		ready := make(chan struct{})
+		go func() {
+			time.Sleep(4 * testNoProgressTimeout)
+			close(ready)
+		}()
+		start := time.Now()
+		err := waitEtcdReadyProgress(context.Background(), ready, nil, nil, constApplied(0), constSnapshotting(true),
 			testCheckInterval, testNoProgressTimeout)
 		re.NoError(err)
 		// It must have outlived the no-progress window instead of bailing at it.
@@ -107,7 +131,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 		re := require.New(t)
 		// ready never fires and applied index is stuck: a genuine hang.
 		start := time.Now()
-		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, nil, constApplied(7),
+		err := waitEtcdReadyProgress(context.Background(), make(chan struct{}), nil, nil, constApplied(7), constSnapshotting(false),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))
@@ -124,7 +148,7 @@ func TestWaitEtcdReadyProgress(t *testing.T) {
 			cancel()
 		}()
 		// applied index advances, so only ctx cancellation can end the wait.
-		err := waitEtcdReadyProgress(ctx, make(chan struct{}), nil, nil, advancingApplied(),
+		err := waitEtcdReadyProgress(ctx, make(chan struct{}), nil, nil, advancingApplied(), constSnapshotting(false),
 			testCheckInterval, testNoProgressTimeout)
 		re.Error(err)
 		re.True(errors.ErrorEqual(err, errs.ErrCancelStartEtcd))

--- a/server/server.go
+++ b/server/server.go
@@ -115,7 +115,15 @@ const (
 )
 
 // EtcdStartTimeout the timeout of the startup etcd.
+// It is used as a no-progress timeout rather than a fixed overall deadline:
+// startEtcd only gives up when etcd makes no apply progress for this duration,
+// so a slow-but-healthy startup that keeps catching up its raft log is not
+// killed. See waitEtcdReady.
 var EtcdStartTimeout = time.Minute * 5
+
+// etcdStartProgressCheckInterval is how often startEtcd polls the embedded
+// etcd applied index to tell a slow-but-progressing startup apart from a hang.
+const etcdStartProgressCheckInterval = time.Second
 
 var (
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
@@ -345,9 +353,6 @@ func CreateServer(ctx context.Context, cfg *config.Config, services []string, le
 }
 
 func (s *Server) startEtcd(ctx context.Context) (retErr error) {
-	newCtx, cancel := context.WithTimeout(ctx, EtcdStartTimeout)
-	defer cancel()
-
 	etcd, err := embed.StartEtcd(s.etcdCfg)
 	if err != nil {
 		return errs.ErrStartEtcd.Wrap(err).GenWithStackByCause()
@@ -395,11 +400,11 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	select {
-	// Wait etcd until it is ready to use
-	case <-etcd.Server.ReadyNotify():
-	case <-newCtx.Done():
-		return errs.ErrCancelStartEtcd.FastGenByArgs()
+	// Wait until etcd is ready to use. Instead of a fixed overall deadline, only
+	// give up when etcd makes no apply progress for EtcdStartTimeout, so a slow
+	// but healthy startup that is still catching up its raft log is not killed.
+	if err = s.waitEtcdReady(ctx, etcd); err != nil {
+		return err
 	}
 
 	// Start the etcd and HTTP clients, then init the member.
@@ -407,13 +412,57 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 	if err != nil {
 		return err
 	}
-	err = s.initMember(newCtx, etcd)
+	initCtx, cancel := context.WithTimeout(ctx, EtcdStartTimeout)
+	defer cancel()
+	err = s.initMember(initCtx, etcd)
 	if err != nil {
 		return err
 	}
 
 	s.initGRPCServiceLabels()
 	return nil
+}
+
+// waitEtcdReady blocks until the embedded etcd is ready to serve requests.
+//
+// Rather than bounding the wait by a fixed deadline, it treats the etcd applied
+// index as a liveness signal: as long as the applied index keeps advancing, the
+// startup is still making progress (e.g. applying its raft log while catching
+// up) and we keep waiting. Only when there is no apply progress for
+// EtcdStartTimeout do we give up. This distinguishes a slow-but-healthy startup
+// from a genuine hang, such as a removed member that can never rejoin the
+// quorum. It also honors ctx cancellation for normal shutdown.
+func (s *Server) waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
+	ticker := time.NewTicker(etcdStartProgressCheckInterval)
+	defer ticker.Stop()
+
+	lastApplied := etcd.Server.AppliedIndex()
+	lastProgress := time.Now()
+	for {
+		select {
+		case <-etcd.Server.ReadyNotify():
+			return nil
+		case <-ctx.Done():
+			return errs.ErrCancelStartEtcd.FastGenByArgs()
+		case now := <-ticker.C:
+			applied := etcd.Server.AppliedIndex()
+			if applied > lastApplied {
+				log.Info("etcd is not ready yet but still making apply progress, keep waiting",
+					zap.Uint64("last-applied-index", lastApplied),
+					zap.Uint64("applied-index", applied))
+				lastApplied = applied
+				lastProgress = now
+				continue
+			}
+			if stalled := now.Sub(lastProgress); stalled >= EtcdStartTimeout {
+				log.Warn("etcd is not ready and made no apply progress, stop waiting",
+					zap.Uint64("applied-index", applied),
+					zap.Duration("no-progress-duration", stalled),
+					zap.Duration("timeout", EtcdStartTimeout))
+				return errs.ErrCancelStartEtcd.FastGenByArgs()
+			}
+		}
+	}
 }
 
 func (s *Server) initGRPCServiceLabels() {

--- a/server/server.go
+++ b/server/server.go
@@ -125,6 +125,10 @@ var EtcdStartTimeout = time.Minute * 5
 // etcd applied index to tell a slow-but-progressing startup apart from a hang.
 const etcdStartProgressCheckInterval = time.Second
 
+// etcdStartProgressLogInterval rate-limits the "still making progress" log, so a
+// recovery that runs for many minutes does not emit one line per poll.
+const etcdStartProgressLogInterval = 30 * time.Second
+
 var (
 	// WithLabelValues is a heavy operation, define variable to avoid call it every time.
 	etcdTermGauge           = etcdStateGauge.WithLabelValues("term")
@@ -403,7 +407,7 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 	// Wait until etcd is ready to use. Instead of a fixed overall deadline, only
 	// give up when etcd makes no apply progress for EtcdStartTimeout, so a slow
 	// but healthy startup that is still catching up its raft log is not killed.
-	if err = s.waitEtcdReady(ctx, etcd); err != nil {
+	if err = waitEtcdReady(ctx, etcd); err != nil {
 		return err
 	}
 
@@ -431,21 +435,26 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 // up) and we keep waiting. Only when there is no apply progress for
 // EtcdStartTimeout do we give up. This distinguishes a slow-but-healthy startup
 // from a genuine hang, such as a removed member that can never rejoin the
-// quorum. It also honors ctx cancellation for normal shutdown.
-func (s *Server) waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
-	return waitEtcdReadyProgress(ctx, etcd.Server.ReadyNotify(), etcd.Err(), etcd.Server.AppliedIndex,
-		etcdStartProgressCheckInterval, EtcdStartTimeout)
+// quorum. It also fails fast when etcd reports a startup error or stops before
+// becoming ready, and honors ctx cancellation for normal shutdown.
+func waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
+	return waitEtcdReadyProgress(ctx, etcd.Server.ReadyNotify(), etcd.Server.StopNotify(),
+		etcd.Err(), etcd.Server.AppliedIndex, etcdStartProgressCheckInterval, EtcdStartTimeout)
 }
 
-// waitEtcdReadyProgress is the testable core of waitEtcdReady. It blocks until
-// ready is signaled, treating appliedIndex as a liveness signal: it keeps
-// waiting while appliedIndex advances, and only returns an error when there is
-// no apply progress for noProgressTimeout, or when ctx is canceled. It also
-// fails fast if etcd reports an asynchronous startup error on errCh, which would
-// otherwise leave ready unsignaled and stall the wait for the whole timeout.
+// waitEtcdReadyProgress is the testable core of waitEtcdReady, decoupled from
+// *embed.Etcd so it can be driven without a real server. It keeps waiting while
+// appliedIndex advances and reports a no-progress failure only when appliedIndex
+// does not advance for noProgressTimeout. It fails fast when:
+//   - etcd reports an asynchronous startup error on errCh (e.g. listener or
+//     serving failures);
+//   - the etcd server stops before becoming ready (stopped), e.g. an internal
+//     EtcdServer.run failure that may not surface on errCh — the underlying
+//     error is preserved when etcd published one;
+//   - ctx is canceled (normal shutdown).
 func waitEtcdReadyProgress(
 	ctx context.Context,
-	ready <-chan struct{},
+	ready, stopped <-chan struct{},
 	errCh <-chan error,
 	appliedIndex func() uint64,
 	checkInterval, noProgressTimeout time.Duration,
@@ -455,22 +464,41 @@ func waitEtcdReadyProgress(
 
 	lastApplied := appliedIndex()
 	lastProgress := time.Now()
+	lastLog := lastProgress
 	for {
 		select {
 		case <-ready:
 			return nil
 		case err := <-errCh:
 			return errs.ErrStartEtcd.Wrap(err).GenWithStackByCause()
+		case <-stopped:
+			// The server terminated before becoming ready; surface the real
+			// cause if etcd published one, otherwise report the stop itself.
+			select {
+			case err := <-errCh:
+				return errs.ErrStartEtcd.Wrap(err).GenWithStackByCause()
+			default:
+				return errs.ErrStartEtcd.GenWithStackByArgs()
+			}
 		case <-ctx.Done():
 			return errs.ErrCancelStartEtcd.FastGenByArgs()
-		case now := <-ticker.C:
+		case <-ticker.C:
 			applied := appliedIndex()
+			// Sample the wall clock here rather than reusing the ticker's
+			// scheduled time: a tick buffered during a scheduling or GC pause
+			// carries a stale timestamp that could otherwise trip a false
+			// no-progress timeout on the following tick.
+			now := time.Now()
 			if applied > lastApplied {
-				log.Info("etcd is not ready yet but still making apply progress, keep waiting",
-					zap.Uint64("last-applied-index", lastApplied),
-					zap.Uint64("applied-index", applied))
 				lastApplied = applied
 				lastProgress = now
+				// Rate-limit: this path can run for many minutes during a slow
+				// recovery, so avoid logging on every poll.
+				if now.Sub(lastLog) >= etcdStartProgressLogInterval {
+					log.Info("etcd is not ready yet but still making apply progress, keep waiting",
+						zap.Uint64("applied-index", applied))
+					lastLog = now
+				}
 				continue
 			}
 			if stalled := now.Sub(lastProgress); stalled >= noProgressTimeout {

--- a/server/server.go
+++ b/server/server.go
@@ -114,11 +114,11 @@ const (
 	lostPDLeaderReElectionFactor = 10
 )
 
-// EtcdStartTimeout the timeout of the startup etcd.
-// It is used as a no-progress timeout rather than a fixed overall deadline:
-// startEtcd only gives up when etcd makes no apply progress for this duration,
-// so a slow-but-healthy startup that keeps catching up its raft log is not
-// killed. See waitEtcdReady.
+// EtcdStartTimeout is the timeout for starting the embedded etcd. It is used as
+// a no-progress timeout rather than a fixed overall deadline: startEtcd only
+// gives up when etcd makes no apply progress for this duration, so a
+// slow-but-healthy startup that keeps catching up its raft log is not killed.
+// See waitEtcdReady.
 var EtcdStartTimeout = time.Minute * 5
 
 // etcdStartProgressCheckInterval is how often startEtcd polls the embedded
@@ -433,17 +433,20 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 // from a genuine hang, such as a removed member that can never rejoin the
 // quorum. It also honors ctx cancellation for normal shutdown.
 func (s *Server) waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
-	return waitEtcdReadyProgress(ctx, etcd.Server.ReadyNotify(), etcd.Server.AppliedIndex,
+	return waitEtcdReadyProgress(ctx, etcd.Server.ReadyNotify(), etcd.Err(), etcd.Server.AppliedIndex,
 		etcdStartProgressCheckInterval, EtcdStartTimeout)
 }
 
 // waitEtcdReadyProgress is the testable core of waitEtcdReady. It blocks until
 // ready is signaled, treating appliedIndex as a liveness signal: it keeps
 // waiting while appliedIndex advances, and only returns an error when there is
-// no apply progress for noProgressTimeout, or when ctx is canceled.
+// no apply progress for noProgressTimeout, or when ctx is canceled. It also
+// fails fast if etcd reports an asynchronous startup error on errCh, which would
+// otherwise leave ready unsignaled and stall the wait for the whole timeout.
 func waitEtcdReadyProgress(
 	ctx context.Context,
 	ready <-chan struct{},
+	errCh <-chan error,
 	appliedIndex func() uint64,
 	checkInterval, noProgressTimeout time.Duration,
 ) error {
@@ -456,6 +459,8 @@ func waitEtcdReadyProgress(
 		select {
 		case <-ready:
 			return nil
+		case err := <-errCh:
+			return errs.ErrStartEtcd.Wrap(err).GenWithStackByCause()
 		case <-ctx.Done():
 			return errs.ErrCancelStartEtcd.FastGenByArgs()
 		case now := <-ticker.C:

--- a/server/server.go
+++ b/server/server.go
@@ -433,19 +433,33 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 // from a genuine hang, such as a removed member that can never rejoin the
 // quorum. It also honors ctx cancellation for normal shutdown.
 func (s *Server) waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
-	ticker := time.NewTicker(etcdStartProgressCheckInterval)
+	return waitEtcdReadyProgress(ctx, etcd.Server.ReadyNotify(), etcd.Server.AppliedIndex,
+		etcdStartProgressCheckInterval, EtcdStartTimeout)
+}
+
+// waitEtcdReadyProgress is the testable core of waitEtcdReady. It blocks until
+// ready is signaled, treating appliedIndex as a liveness signal: it keeps
+// waiting while appliedIndex advances, and only returns an error when there is
+// no apply progress for noProgressTimeout, or when ctx is canceled.
+func waitEtcdReadyProgress(
+	ctx context.Context,
+	ready <-chan struct{},
+	appliedIndex func() uint64,
+	checkInterval, noProgressTimeout time.Duration,
+) error {
+	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 
-	lastApplied := etcd.Server.AppliedIndex()
+	lastApplied := appliedIndex()
 	lastProgress := time.Now()
 	for {
 		select {
-		case <-etcd.Server.ReadyNotify():
+		case <-ready:
 			return nil
 		case <-ctx.Done():
 			return errs.ErrCancelStartEtcd.FastGenByArgs()
 		case now := <-ticker.C:
-			applied := etcd.Server.AppliedIndex()
+			applied := appliedIndex()
 			if applied > lastApplied {
 				log.Info("etcd is not ready yet but still making apply progress, keep waiting",
 					zap.Uint64("last-applied-index", lastApplied),
@@ -454,11 +468,11 @@ func (s *Server) waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
 				lastProgress = now
 				continue
 			}
-			if stalled := now.Sub(lastProgress); stalled >= EtcdStartTimeout {
+			if stalled := now.Sub(lastProgress); stalled >= noProgressTimeout {
 				log.Warn("etcd is not ready and made no apply progress, stop waiting",
 					zap.Uint64("applied-index", applied),
 					zap.Duration("no-progress-duration", stalled),
-					zap.Duration("timeout", EtcdStartTimeout))
+					zap.Duration("timeout", noProgressTimeout))
 				return errs.ErrCancelStartEtcd.FastGenByArgs()
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -427,6 +428,40 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 	return nil
 }
 
+// etcdSnapshotMetrics are the etcd-owned Prometheus gauges that track whether
+// this member is currently receiving or applying an incoming raft snapshot:
+//   - etcd_network_snapshot_receive_inflights_total is set while the snapshot
+//     file is being downloaded from the leader, before raft ever surfaces it.
+//   - etcd_server_snapshot_apply_in_progress_total is set while the downloaded
+//     snapshot is being applied to the storage backend.
+//
+// AppliedIndex does not move during either phase even though the member is
+// healthy, so waitEtcdReadyProgress treats a nonzero reading as progress too.
+// Both gauges are registered by etcd itself on the process-wide default
+// registerer; there is no typed API for this on *embed.Etcd.
+var etcdSnapshotMetrics = map[string]struct{}{
+	"etcd_network_snapshot_receive_inflights_total": {},
+	"etcd_server_snapshot_apply_in_progress_total":  {},
+}
+
+func isEtcdSnapshotting() bool {
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return false
+	}
+	for _, mf := range mfs {
+		if _, ok := etcdSnapshotMetrics[mf.GetName()]; !ok {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if m.GetGauge().GetValue() > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // waitEtcdReady blocks until the embedded etcd is ready to serve requests.
 //
 // Rather than bounding the wait by a fixed deadline, it treats the etcd applied
@@ -439,13 +474,15 @@ func (s *Server) startEtcd(ctx context.Context) (retErr error) {
 // becoming ready, and honors ctx cancellation for normal shutdown.
 func waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
 	return waitEtcdReadyProgress(ctx, etcd.Server.ReadyNotify(), etcd.Server.StopNotify(),
-		etcd.Err(), etcd.Server.AppliedIndex, etcdStartProgressCheckInterval, EtcdStartTimeout)
+		etcd.Err(), etcd.Server.AppliedIndex, isEtcdSnapshotting, etcdStartProgressCheckInterval, EtcdStartTimeout)
 }
 
 // waitEtcdReadyProgress is the testable core of waitEtcdReady, decoupled from
 // *embed.Etcd so it can be driven without a real server. It keeps waiting while
-// appliedIndex advances and reports a no-progress failure only when appliedIndex
-// does not advance for noProgressTimeout. It fails fast when:
+// appliedIndex advances, or while snapshotting reports that etcd is receiving
+// or applying a raft snapshot (during which appliedIndex cannot advance), and
+// reports a no-progress failure only when neither signal shows progress for
+// noProgressTimeout. It fails fast when:
 //   - etcd reports an asynchronous startup error on errCh (e.g. listener or
 //     serving failures);
 //   - the etcd server stops before becoming ready (stopped), e.g. an internal
@@ -457,6 +494,7 @@ func waitEtcdReadyProgress(
 	ready, stopped <-chan struct{},
 	errCh <-chan error,
 	appliedIndex func() uint64,
+	snapshotting func() bool,
 	checkInterval, noProgressTimeout time.Duration,
 ) error {
 	ticker := time.NewTicker(checkInterval)
@@ -496,6 +534,15 @@ func waitEtcdReadyProgress(
 				// recovery, so avoid logging on every poll.
 				if now.Sub(lastLog) >= etcdStartProgressLogInterval {
 					log.Info("etcd is not ready yet but still making apply progress, keep waiting",
+						zap.Uint64("applied-index", applied))
+					lastLog = now
+				}
+				continue
+			}
+			if snapshotting() {
+				lastProgress = now
+				if now.Sub(lastLog) >= etcdStartProgressLogInterval {
+					log.Info("etcd is not ready yet but is installing a raft snapshot, keep waiting",
 						zap.Uint64("applied-index", applied))
 					lastLog = now
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -445,8 +445,18 @@ var etcdSnapshotMetrics = map[string]struct{}{
 }
 
 func isEtcdSnapshotting() bool {
-	mfs, err := prometheus.DefaultGatherer.Gather()
-	if err != nil {
+	return snapshotGaugesNonzero(prometheus.DefaultGatherer)
+}
+
+// snapshotGaugesNonzero is the testable core of isEtcdSnapshotting, decoupled
+// from the process-wide default registerer so it can be driven with a fake
+// Gatherer.
+func snapshotGaugesNonzero(g prometheus.Gatherer) bool {
+	// Gather can return a non-nil err (e.g. an unrelated collector failed)
+	// alongside a partial but still-usable mfs; only bail out empty-handed
+	// when there is nothing to scan.
+	mfs, err := g.Gather()
+	if len(mfs) == 0 && err != nil {
 		return false
 	}
 	for _, mf := range mfs {
@@ -480,9 +490,13 @@ func waitEtcdReady(ctx context.Context, etcd *embed.Etcd) error {
 // waitEtcdReadyProgress is the testable core of waitEtcdReady, decoupled from
 // *embed.Etcd so it can be driven without a real server. It keeps waiting while
 // appliedIndex advances, or while snapshotting reports that etcd is receiving
-// or applying a raft snapshot (during which appliedIndex cannot advance), and
-// reports a no-progress failure only when neither signal shows progress for
-// noProgressTimeout. It fails fast when:
+// or applying a raft snapshot (during which appliedIndex cannot advance).
+// snapshotting is only a liveness bit, not proof the install itself is still
+// moving, so an unbroken streak of it reporting true is itself capped at
+// noProgressTimeout: a snapshot install that hangs (e.g. stuck disk I/O)
+// still eventually gives up instead of being treated as progress forever.
+// Outside of an active streak, a no-progress failure is reported once
+// appliedIndex has not advanced for noProgressTimeout. It fails fast when:
 //   - etcd reports an asynchronous startup error on errCh (e.g. listener or
 //     serving failures);
 //   - the etcd server stops before becoming ready (stopped), e.g. an internal
@@ -503,21 +517,39 @@ func waitEtcdReadyProgress(
 	lastApplied := appliedIndex()
 	lastProgress := time.Now()
 	lastLog := lastProgress
+	// snapshotSince marks the start of the current unbroken streak of
+	// snapshotting() reporting true with no AppliedIndex movement. It bounds
+	// how long a single raft snapshot install may be treated as progress: a
+	// nonzero snapshotting() signal is only a liveness bit, not proof the
+	// install itself is still moving, so without this bound a snapshot that
+	// hangs mid-install (e.g. stuck disk I/O) would refresh lastProgress on
+	// every poll forever and EtcdStartTimeout would never fire.
+	var snapshotSince time.Time
 	for {
 		select {
 		case <-ready:
 			return nil
-		case err := <-errCh:
+		case err, ok := <-errCh:
+			// errCh is closed once etcd.Close() runs (e.g. a concurrent
+			// shutdown), in which case a receive yields a nil err with
+			// ok == false; Wrap(nil) returns a nil *Error, and calling
+			// GenWithStackByCause on that would panic. Fall back to the
+			// generic cause-less error instead.
+			if !ok {
+				return errs.ErrStartEtcd.GenWithStackByArgs()
+			}
 			return errs.ErrStartEtcd.Wrap(err).GenWithStackByCause()
 		case <-stopped:
 			// The server terminated before becoming ready; surface the real
 			// cause if etcd published one, otherwise report the stop itself.
 			select {
-			case err := <-errCh:
-				return errs.ErrStartEtcd.Wrap(err).GenWithStackByCause()
+			case err, ok := <-errCh:
+				if ok {
+					return errs.ErrStartEtcd.Wrap(err).GenWithStackByCause()
+				}
 			default:
-				return errs.ErrStartEtcd.GenWithStackByArgs()
 			}
+			return errs.ErrStartEtcd.GenWithStackByArgs()
 		case <-ctx.Done():
 			return errs.ErrCancelStartEtcd.FastGenByArgs()
 		case <-ticker.C:
@@ -530,6 +562,7 @@ func waitEtcdReadyProgress(
 			if applied > lastApplied {
 				lastApplied = applied
 				lastProgress = now
+				snapshotSince = time.Time{}
 				// Rate-limit: this path can run for many minutes during a slow
 				// recovery, so avoid logging on every poll.
 				if now.Sub(lastLog) >= etcdStartProgressLogInterval {
@@ -540,13 +573,36 @@ func waitEtcdReadyProgress(
 				continue
 			}
 			if snapshotting() {
-				lastProgress = now
-				if now.Sub(lastLog) >= etcdStartProgressLogInterval {
-					log.Info("etcd is not ready yet but is installing a raft snapshot, keep waiting",
-						zap.Uint64("applied-index", applied))
-					lastLog = now
+				if snapshotSince.IsZero() {
+					snapshotSince = now
 				}
-				continue
+				// Cap the credit this streak can grant at noProgressTimeout,
+				// same as the AppliedIndex-based budget below, instead of
+				// refreshing lastProgress and extending the wait forever.
+				if now.Sub(snapshotSince) < noProgressTimeout {
+					if now.Sub(lastLog) >= etcdStartProgressLogInterval {
+						log.Info("etcd is not ready yet but is installing a raft snapshot, keep waiting",
+							zap.Uint64("applied-index", applied))
+						lastLog = now
+					}
+					continue
+				}
+				log.Warn("etcd has been installing a raft snapshot with no apply progress for too long, stop waiting",
+					zap.Uint64("applied-index", applied),
+					zap.Duration("snapshot-duration", now.Sub(snapshotSince)),
+					zap.Duration("timeout", noProgressTimeout))
+				return errs.ErrCancelStartEtcd.FastGenByArgs()
+			}
+			if !snapshotSince.IsZero() {
+				// A snapshot streak just ended (snapshotting() flipped back
+				// to false) without AppliedIndex having moved yet — e.g. the
+				// narrow gap between the network-receive gauge dropping and
+				// the apply gauge rising. Grant a fresh window from here
+				// instead of judging against a lastProgress mark from before
+				// the streak began, which would otherwise misfire on the
+				// very next tick.
+				lastProgress = now
+				snapshotSince = time.Time{}
 			}
 			if stalled := now.Sub(lastProgress); stalled >= noProgressTimeout {
 				log.Warn("etcd is not ready and made no apply progress, stop waiting",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11014

`server.EtcdStartTimeout` (default `5m`) is applied as a **fixed overall deadline** in `(*Server).startEtcd`. The deadline counts down regardless of whether etcd is making progress, so a member that restarts and has to catch up a large raft log can be killed once 5 minutes elapse even though it is healthy and steadily applying entries. Under a process supervisor it then restarts and loops forever, never coming up. The timeout also cannot tell a slow-but-healthy startup apart from a genuine hang (e.g. a removed member that can never rejoin the quorum).

### What is changed and how does it work?

Wait for etcd readiness using the etcd applied index as a liveness signal instead of a fixed deadline:

- New helper `waitEtcdReady` polls `etcd.Server.AppliedIndex()` while waiting for `ReadyNotify()`.
- As long as the applied index advances, the member is still applying its raft log, so we keep waiting.
- We give up only when there is **no apply progress for `EtcdStartTimeout`**, which still fails fast on a genuine hang.
- Parent `ctx` cancellation is still honored for normal shutdown.
- `initMember` now uses its own `EtcdStartTimeout`-bounded context.

`AppliedIndex` is used (rather than committed index) because during catch-up the committed index may already sit at the target while the state machine is still applying, which would look "stuck" while actually healthy.

Known limitation: this covers the wait after `embed.StartEtcd` returns. The bulk snapshot load / WAL replay happens inside `embed.StartEtcd`, which takes no `ctx` and runs before this wait, so that phase is out of scope here.

```commit-message
server: make EtcdStartTimeout a no-progress timeout

startEtcd previously wrapped the whole "wait until etcd is ready" in a
fixed context deadline of EtcdStartTimeout (5m). A slow-but-healthy
startup that keeps catching up its raft log would be killed once the
deadline elapsed, and on process restart it would loop forever.

Wait for readiness using the etcd applied index as a liveness signal
instead: keep waiting as long as the applied index advances, and only
give up when there is no apply progress for EtcdStartTimeout. This tells
a slow restore apart from a genuine hang (e.g. a removed member that can
never rejoin the quorum), which still fails fast. Parent ctx
cancellation is still honored for normal shutdown.
```

### Check List

Tests

- Unit test (`TestWaitEtcdReadyProgress`: ready-immediately, keeps-waiting-while-progressing, no-progress-timeout, ctx-cancellation)
- Integration test (existing `tests/server/join` suite, which exercises `EtcdStartTimeout` and the removed-member hang path, still passes)

Side effects

- The overall etcd startup wait is no longer bounded by a fixed wall-clock deadline; a startup that keeps making apply progress may take longer than `EtcdStartTimeout` to complete (intended, to avoid killing healthy slow startups).

### Release note

```release-note
Fix PD failing to start when the embedded etcd needs longer than the fixed start timeout to catch up its raft log; the start timeout is now a no-progress timeout based on etcd apply progress.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded service startup reliability by waiting for meaningful readiness progress instead of relying on a fixed timeout.
  * Startup now continues through slow recovery operations and only times out when progress stalls.
  * Failures and unexpected shutdowns are detected promptly.
  * Improved handling when startup is canceled.
* **Tests**
  * Added coverage for readiness progress, startup failures, stalled progress, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->