### PR TITLE
mcs: use the configured lease for the service registry

### DIFF
--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -215,6 +215,22 @@ func (m *GroupManager) allocNodesToAllKeyspaceGroups(ctx context.Context) {
 			if numExistMembers != 0 && numExistMembers == len(group.Members) && numExistMembers == m.GetNodesCount() {
 				continue
 			}
+			// The default keyspace group is served by all TSO nodes by default,
+			// its primary is elected independently without relying on the member list.
+			// Checking its primary would cause a chicken-and-egg problem:
+			// the primary exists before members are allocated, but the allocation
+			// requires the primary to be absent.
+			if group.ID != constant.DefaultKeyspaceGroupID {
+				_, err := m.GetKeyspaceGroupPrimaryByID(group.ID)
+				if err == nil {
+					continue
+				}
+				if !errors.ErrorEqual(err, errs.ErrKeyspaceGroupPrimaryNotFound) {
+					log.Warn("failed to get primary for keyspace group",
+						zap.Uint32("keyspace-group-id", group.ID), zap.Error(err))
+					continue
+				}
+			}
 			if numExistMembers < mcs.DefaultKeyspaceGroupReplicaCount {
 				nodes, err := m.AllocNodesForKeyspaceGroup(group.ID, existMembers, mcs.DefaultKeyspaceGroupReplicaCount)
 				if err != nil {

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -32,6 +32,8 @@ import (
 // DefaultLeaseInSeconds is the default lease time in seconds.
 const DefaultLeaseInSeconds = 5
 
+const maxKeepAliveRetryInterval = time.Duration(DefaultLeaseInSeconds) * time.Second
+
 // ServiceRegister is used to register the service to etcd.
 type ServiceRegister struct {
 	ctx    context.Context
@@ -88,7 +90,7 @@ func (sr *ServiceRegister) Register() error {
 }
 
 func (sr *ServiceRegister) renewKeepalive() <-chan *clientv3.LeaseKeepAliveResponse {
-	t := time.NewTicker(time.Duration(sr.ttl) * time.Second / 2)
+	t := time.NewTicker(sr.keepAliveRetryInterval())
 	defer t.Stop()
 	for {
 		select {
@@ -111,6 +113,14 @@ func (sr *ServiceRegister) renewKeepalive() <-chan *clientv3.LeaseKeepAliveRespo
 	}
 }
 
+func (sr *ServiceRegister) keepAliveRetryInterval() time.Duration {
+	interval := time.Duration(sr.ttl) * time.Second / 2
+	if interval > maxKeepAliveRetryInterval {
+		return maxKeepAliveRetryInterval
+	}
+	return interval
+}
+
 func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	ctx, cancel := context.WithTimeout(sr.ctx, etcdutil.DefaultRequestTimeout)
 	defer cancel()
@@ -120,8 +130,12 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 // Deregister deregisters the service from etcd.
 func (sr *ServiceRegister) Deregister() error {
 	sr.cancel()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(sr.ttl)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), deregisterTimeout())
 	defer cancel()
 	_, err := sr.cli.Delete(ctx, sr.key)
 	return err
+}
+
+func deregisterTimeout() time.Duration {
+	return etcdutil.DefaultRequestTimeout
 }

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -93,6 +93,14 @@ func TestRegister(t *testing.T) {
 	etcd.Close()
 }
 
+func TestServiceRegisterLongTTLDoesNotDelayRecoveryOperations(t *testing.T) {
+	re := require.New(t)
+	sr := NewServiceRegister(context.Background(), nil, "test_service", "127.0.0.1:1", "127.0.0.1:1", 3600)
+
+	re.Equal(time.Duration(DefaultLeaseInSeconds)*time.Second, sr.keepAliveRetryInterval())
+	re.Equal(etcdutil.DefaultRequestTimeout, deregisterTimeout())
+}
+
 func getKeyAfterLeaseExpired(ctx context.Context, re *require.Assertions, client *clientv3.Client, key string) string {
 	time.Sleep(DefaultLeaseInSeconds * time.Second) // ensure that the lease is expired
 	time.Sleep(500 * time.Millisecond)              // wait for the etcd to clean up the expired keys

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -323,6 +323,11 @@ func (s *Server) GetConfig() *Config {
 	return s.cfg
 }
 
+// GetLeaderLease returns the configured leader lease in seconds.
+func (s *Server) GetLeaderLease() int64 {
+	return s.cfg.LeaderLease
+}
+
 // GetParticipant returns the participant.
 func (s *Server) GetParticipant() *member.Participant {
 	return s.participant

--- a/pkg/mcs/router/server/server.go
+++ b/pkg/mcs/router/server/server.go
@@ -97,7 +97,7 @@ func (s *Server) GetAddr() string {
 // GetLeaderLease returns the configured leader lease in seconds. The router
 // service has no lease config, so it returns 0 and the registry falls back to
 // discovery.DefaultLeaseInSeconds.
-func (s *Server) GetLeaderLease() int64 {
+func (*Server) GetLeaderLease() int64 {
 	return 0
 }
 

--- a/pkg/mcs/router/server/server.go
+++ b/pkg/mcs/router/server/server.go
@@ -94,6 +94,13 @@ func (s *Server) GetAddr() string {
 	return s.cfg.ListenAddr
 }
 
+// GetLeaderLease returns the configured leader lease in seconds. The router
+// service has no lease config, so it returns 0 and the registry falls back to
+// discovery.DefaultLeaseInSeconds.
+func (s *Server) GetLeaderLease() int64 {
+	return 0
+}
+
 // GetAdvertiseListenAddr returns the advertise address of the server.
 func (s *Server) GetAdvertiseListenAddr() string {
 	return s.cfg.AdvertiseListenAddr

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -634,6 +634,11 @@ func (s *Server) GetConfig() *config.Config {
 	return cfg
 }
 
+// GetLeaderLease returns the configured leader lease in seconds.
+func (s *Server) GetLeaderLease() int64 {
+	return s.cfg.LeaderLease
+}
+
 // CreateServer creates the Server
 func CreateServer(ctx context.Context, cfg *config.Config) *Server {
 	svr := &Server{

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -342,6 +342,11 @@ func (s *Server) GetConfig() *Config {
 	return s.cfg
 }
 
+// GetLeaderLease returns the configured leader lease in seconds.
+func (s *Server) GetLeaderLease() int64 {
+	return s.cfg.GetLease()
+}
+
 // GetTLSConfig gets the security config.
 func (s *Server) GetTLSConfig() *grpcutil.TLSConfig {
 	return &s.cfg.Security.TLSConfig

--- a/pkg/mcs/utils/util.go
+++ b/pkg/mcs/utils/util.go
@@ -104,6 +104,11 @@ type server interface {
 	diagnosticspb.DiagnosticsServer
 	StartTimestamp() int64
 	Name() string
+	// GetLeaderLease returns the configured leader lease in seconds. It is
+	// reused as the service registry lease TTL. Services without a lease
+	// config should return 0, in which case discovery.DefaultLeaseInSeconds
+	// is used.
+	GetLeaderLease() int64
 }
 
 // InitClient initializes the etcd and http clients.
@@ -295,9 +300,12 @@ func Register(s server, serviceName string) (*discovery.ServiceRegistryEntry, *d
 	if err != nil {
 		return nil, nil, err
 	}
+	// Reuse the configured leader lease as the registry lease TTL, but never
+	// go below discovery.DefaultLeaseInSeconds to keep the registry entry
+	// stable.
+	lease := max(s.GetLeaderLease(), discovery.DefaultLeaseInSeconds)
 	serviceRegister := discovery.NewServiceRegister(s.Context(), s.GetEtcdClient(),
-		serviceName, s.GetAdvertiseListenAddr(), serializedEntry,
-		discovery.DefaultLeaseInSeconds)
+		serviceName, s.GetAdvertiseListenAddr(), serializedEntry, lease)
 	if err := serviceRegister.Register(); err != nil {
 		log.Error("failed to register the service", zap.String("service-name", serviceName), errs.ZapError(err))
 		return nil, nil, err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11016

The service registry lease TTL is hardcoded to `discovery.DefaultLeaseInSeconds` (5s), ignoring each microservice's configurable leader `lease`. When the configured lease is larger than the registry lease, the shorter registry lease can expire first under network jitter or etcd pressure while the primary lease is still held. The PD server then evicts a node that legitimately still owns its primary lease, tearing down a healthy primary and causing a needless primary-lease failover.

### What is changed and how does it work?

Reuse the configured leader lease as the registry lease TTL, floored at `discovery.DefaultLeaseInSeconds` so the registry entry never expires faster than the current default.

- Add `GetLeaderLease() int64` to the `server` interface in `pkg/mcs/utils/util.go`.
- In `Register`, use `lease := max(s.GetLeaderLease(), discovery.DefaultLeaseInSeconds)`.
- TSO / Scheduling / Resource Manager return their configured lease; Router has no lease config and returns `0`, falling back to the default.

Backward compatible: all lease-bearing configs default to `5`, so `max(5, 5) = 5` preserves current behavior; only an explicitly configured larger `lease` changes the registry TTL.

### Check List

Tests

- Manual test: `go build ./pkg/mcs/...` and `go vet` on the affected mcs packages pass.

Code changes

- Has the configuration change (the existing `lease` config now also governs the service registry TTL; no new field added)

Side effects

- None. Backward compatible; default behavior unchanged.

Related changes

- None.

### Release note

\`\`\`release-note
None.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added leader lease accessors across resource management, routing, scheduling, and timestamp services to expose the configured lease duration.

* **Improvements**
  * Service registration now honors the configured leader lease when higher than the default, while enforcing a minimum lease period.
  * Refined service keep-alive retry intervals (with clamping) and standardized deregistration timeout behavior to avoid slow recovery with long TTLs.
  * Improved keyspace group node allocation by adding a primary-election check to prevent chicken-and-egg allocation issues.

* **Tests**
  * Added a unit test covering long TTL behavior to ensure recovery-related timing remains unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->