### PR TITLE
client: sample member update failure logs with a shared budget

### DIFF
--- a/client/pkg/utils/logutil/log.go
+++ b/client/pkg/utils/logutil/log.go
@@ -24,7 +24,9 @@ import (
 	"github.com/pingcap/log"
 )
 
-// SampleLoggerFactory returns a factory that lazily creates one sampled logger.
+var sampleLoggerFactory = getSampleLoggerFactory(time.Minute, 5)
+
+// getSampleLoggerFactory returns a factory that lazily creates one sampled logger.
 // The logger writes the first `first` entries with the same level and message
 // in each tick and drops the remaining matching entries until the next tick.
 // Zap hashes messages into 4096 counters per level, so distinct messages may
@@ -33,7 +35,7 @@ import (
 // is captured lazily on the returned factory's first invocation. The created
 // logger stays pinned to that global logger, so later log.ReplaceGlobals calls
 // do not retarget it.
-func SampleLoggerFactory(tick time.Duration, first int, fields ...zap.Field) func() *zap.Logger {
+func getSampleLoggerFactory(tick time.Duration, first int, fields ...zap.Field) func() *zap.Logger {
 	var (
 		once   sync.Once
 		logger *zap.Logger
@@ -47,4 +49,9 @@ func SampleLoggerFactory(tick time.Duration, first int, fields ...zap.Field) fun
 		})
 		return logger
 	}
+}
+
+// SamplerLogger returns the shared sampled logger for the PD client.
+func SamplerLogger() *zap.Logger {
+	return sampleLoggerFactory()
 }

--- a/client/pkg/utils/logutil/log.go
+++ b/client/pkg/utils/logutil/log.go
@@ -1,0 +1,50 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/pingcap/log"
+)
+
+// SampleLoggerFactory returns a factory that lazily creates one sampled logger.
+// The logger writes the first `first` entries with the same level and message
+// in each tick and drops the remaining matching entries until the next tick.
+// Zap hashes messages into 4096 counters per level, so distinct messages may
+// share a sampling counter if their hashes collide.
+// Callers must pass positive values for `tick` and `first`. The current log.L()
+// is captured lazily on the returned factory's first invocation. The created
+// logger stays pinned to that global logger, so later log.ReplaceGlobals calls
+// do not retarget it.
+func SampleLoggerFactory(tick time.Duration, first int, fields ...zap.Field) func() *zap.Logger {
+	var (
+		once   sync.Once
+		logger *zap.Logger
+	)
+	return func() *zap.Logger {
+		once.Do(func() {
+			sampleCore := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+				return zapcore.NewSamplerWithOptions(core, tick, first, 0)
+			})
+			logger = log.L().With(fields...).With(zap.String("sampled", "")).WithOptions(sampleCore)
+		})
+		return logger
+	}
+}

--- a/client/pkg/utils/logutil/log_test.go
+++ b/client/pkg/utils/logutil/log_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestSampleLoggerFactory(t *testing.T) {
-	factory := SampleLoggerFactory(time.Minute, 5)
+	factory := getSampleLoggerFactory(time.Minute, 5)
 
 	firstCore, firstObserved := observer.New(zapcore.InfoLevel)
 	restoreFirst := log.ReplaceGlobals(zap.New(firstCore), nil)

--- a/client/pkg/utils/logutil/log_test.go
+++ b/client/pkg/utils/logutil/log_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/pingcap/log"
+
+	"github.com/tikv/pd/client/pkg/utils/testutil"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestSampleLoggerFactory(t *testing.T) {
+	factory := SampleLoggerFactory(time.Minute, 5)
+
+	firstCore, firstObserved := observer.New(zapcore.InfoLevel)
+	restoreFirst := log.ReplaceGlobals(zap.New(firstCore), nil)
+	t.Cleanup(restoreFirst)
+	logger := factory()
+	require.Same(t, logger, factory())
+
+	secondCore, secondObserved := observer.New(zapcore.InfoLevel)
+	restoreSecond := log.ReplaceGlobals(zap.New(secondCore), nil)
+	t.Cleanup(restoreSecond)
+
+	const sampledMessage = "sampled member update"
+	urls := []string{"http://pd-1:2379", "http://pd-2:2379"}
+	for i := range 10 {
+		logger.Info(sampledMessage, zap.String("url", urls[i%len(urls)]))
+	}
+
+	sampledEntries := firstObserved.FilterMessage(sampledMessage)
+	require.Equal(t, 5, sampledEntries.Len())
+	require.Equal(t, 5, sampledEntries.FilterField(zap.String("sampled", "")).Len())
+	require.Equal(t, 3, sampledEntries.FilterField(zap.String("url", urls[0])).Len())
+	require.Equal(t, 2, sampledEntries.FilterField(zap.String("url", urls[1])).Len())
+
+	const otherMessage = "another sampled message"
+	for range 10 {
+		logger.Info(otherMessage)
+	}
+	require.Equal(t, 5, firstObserved.FilterMessage(otherMessage).Len())
+	require.Equal(t, 0, secondObserved.Len())
+}

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -890,6 +890,7 @@ func (c *serviceDiscovery) checkServiceModeChanged() error {
 }
 
 func (c *serviceDiscovery) updateMember() error {
+	var lastErr error
 	for _, url := range c.GetServiceURLs() {
 		members, err := c.getMembers(c.ctx, url, UpdateMemberTimeout)
 		// Check the cluster ID.
@@ -905,6 +906,7 @@ func (c *serviceDiscovery) updateMember() error {
 		}
 		// Failed to get members
 		if err != nil {
+			lastErr = err
 			logutil.SamplerLogger().Info("[pd] cannot update member from this url",
 				zap.String("url", url),
 				errs.ZapError(err))
@@ -918,6 +920,9 @@ func (c *serviceDiscovery) updateMember() error {
 		c.updateURLs(members.GetMembers())
 
 		return c.updateServiceClient(members.GetMembers(), members.GetLeader())
+	}
+	if lastErr != nil {
+		return lastErr
 	}
 	return errs.ErrClientGetMember.FastGenByArgs()
 }

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -44,6 +44,7 @@ import (
 	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/retry"
 	"github.com/tikv/pd/client/pkg/utils/grpcutil"
+	"github.com/tikv/pd/client/pkg/utils/logutil"
 	"github.com/tikv/pd/client/pkg/utils/tlsutil"
 )
 
@@ -452,6 +453,8 @@ type serviceDiscovery struct {
 	// Client option.
 	option *opt.Option
 
+	cannotUpdateMemberLogger func() *zap.Logger
+
 	flight singleflight.Group
 }
 
@@ -474,17 +477,18 @@ func NewServiceDiscovery(
 	urls []string, tlsCfg *tls.Config, option *opt.Option,
 ) ServiceDiscovery {
 	pdsd := &serviceDiscovery{
-		checkMembershipCh:    make(chan struct{}, 1),
-		ctx:                  ctx,
-		cancel:               cancel,
-		wg:                   wg,
-		apiCandidateNodes:    [apiKindCount]*serviceBalancer{newServiceBalancer(emptyErrorFn), newServiceBalancer(regionAPIErrorFn)},
-		callbacks:            newServiceCallbacks(),
-		updateKeyspaceIDFunc: updateKeyspaceIDFunc,
-		keyspaceID:           keyspaceID,
-		tlsCfg:               tlsCfg,
-		option:               option,
-		flight:               singleflight.Group{},
+		checkMembershipCh:        make(chan struct{}, 1),
+		ctx:                      ctx,
+		cancel:                   cancel,
+		wg:                       wg,
+		apiCandidateNodes:        [apiKindCount]*serviceBalancer{newServiceBalancer(emptyErrorFn), newServiceBalancer(regionAPIErrorFn)},
+		callbacks:                newServiceCallbacks(),
+		updateKeyspaceIDFunc:     updateKeyspaceIDFunc,
+		keyspaceID:               keyspaceID,
+		tlsCfg:                   tlsCfg,
+		option:                   option,
+		cannotUpdateMemberLogger: logutil.SampleLoggerFactory(time.Minute, 5),
+		flight:                   singleflight.Group{},
 	}
 	pdsd.callbacks.setServiceModeUpdateCallback(serviceModeUpdateCb)
 	urls = tlsutil.AddrsToURLs(urls, tlsCfg)
@@ -888,6 +892,16 @@ func (c *serviceDiscovery) checkServiceModeChanged() error {
 	return nil
 }
 
+func (c *serviceDiscovery) logCannotUpdateMember(url string, err error) {
+	logger := log.L()
+	if c.cannotUpdateMemberLogger != nil {
+		logger = c.cannotUpdateMemberLogger()
+	}
+	logger.Info("[pd] cannot update member from this url",
+		zap.String("url", url),
+		errs.ZapError(err))
+}
+
 func (c *serviceDiscovery) updateMember() error {
 	for _, url := range c.GetServiceURLs() {
 		members, err := c.getMembers(c.ctx, url, UpdateMemberTimeout)
@@ -904,9 +918,7 @@ func (c *serviceDiscovery) updateMember() error {
 		}
 		// Failed to get members
 		if err != nil {
-			log.Info("[pd] cannot update member from this url",
-				zap.String("url", url),
-				errs.ZapError(err))
+			c.logCannotUpdateMember(url, err)
 			select {
 			case <-c.ctx.Done():
 				return errors.WithStack(err)

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -453,7 +453,7 @@ type serviceDiscovery struct {
 	// Client option.
 	option *opt.Option
 
-	cannotUpdateMemberLogger *zap.Logger
+	sampleLogger *zap.Logger
 
 	flight singleflight.Group
 }
@@ -477,18 +477,18 @@ func NewServiceDiscovery(
 	urls []string, tlsCfg *tls.Config, option *opt.Option,
 ) ServiceDiscovery {
 	pdsd := &serviceDiscovery{
-		checkMembershipCh:        make(chan struct{}, 1),
-		ctx:                      ctx,
-		cancel:                   cancel,
-		wg:                       wg,
-		apiCandidateNodes:        [apiKindCount]*serviceBalancer{newServiceBalancer(emptyErrorFn), newServiceBalancer(regionAPIErrorFn)},
-		callbacks:                newServiceCallbacks(),
-		updateKeyspaceIDFunc:     updateKeyspaceIDFunc,
-		keyspaceID:               keyspaceID,
-		tlsCfg:                   tlsCfg,
-		option:                   option,
-		cannotUpdateMemberLogger: logutil.SampleLoggerFactory(time.Minute, 5)(),
-		flight:                   singleflight.Group{},
+		checkMembershipCh:    make(chan struct{}, 1),
+		ctx:                  ctx,
+		cancel:               cancel,
+		wg:                   wg,
+		apiCandidateNodes:    [apiKindCount]*serviceBalancer{newServiceBalancer(emptyErrorFn), newServiceBalancer(regionAPIErrorFn)},
+		callbacks:            newServiceCallbacks(),
+		updateKeyspaceIDFunc: updateKeyspaceIDFunc,
+		keyspaceID:           keyspaceID,
+		tlsCfg:               tlsCfg,
+		option:               option,
+		sampleLogger:         logutil.SampleLoggerFactory(time.Minute, 5)(),
+		flight:               singleflight.Group{},
 	}
 	pdsd.callbacks.setServiceModeUpdateCallback(serviceModeUpdateCb)
 	urls = tlsutil.AddrsToURLs(urls, tlsCfg)
@@ -908,7 +908,7 @@ func (c *serviceDiscovery) updateMember() error {
 		}
 		// Failed to get members
 		if err != nil {
-			c.cannotUpdateMemberLogger.Info("[pd] cannot update member from this url",
+			c.sampleLogger.Info("[pd] cannot update member from this url",
 				zap.String("url", url),
 				errs.ZapError(err))
 			select {

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -453,7 +453,7 @@ type serviceDiscovery struct {
 	// Client option.
 	option *opt.Option
 
-	cannotUpdateMemberLogger func() *zap.Logger
+	cannotUpdateMemberLogger *zap.Logger
 
 	flight singleflight.Group
 }
@@ -487,7 +487,7 @@ func NewServiceDiscovery(
 		keyspaceID:               keyspaceID,
 		tlsCfg:                   tlsCfg,
 		option:                   option,
-		cannotUpdateMemberLogger: logutil.SampleLoggerFactory(time.Minute, 5),
+		cannotUpdateMemberLogger: logutil.SampleLoggerFactory(time.Minute, 5)(),
 		flight:                   singleflight.Group{},
 	}
 	pdsd.callbacks.setServiceModeUpdateCallback(serviceModeUpdateCb)
@@ -892,16 +892,6 @@ func (c *serviceDiscovery) checkServiceModeChanged() error {
 	return nil
 }
 
-func (c *serviceDiscovery) logCannotUpdateMember(url string, err error) {
-	logger := log.L()
-	if c.cannotUpdateMemberLogger != nil {
-		logger = c.cannotUpdateMemberLogger()
-	}
-	logger.Info("[pd] cannot update member from this url",
-		zap.String("url", url),
-		errs.ZapError(err))
-}
-
 func (c *serviceDiscovery) updateMember() error {
 	for _, url := range c.GetServiceURLs() {
 		members, err := c.getMembers(c.ctx, url, UpdateMemberTimeout)
@@ -918,7 +908,9 @@ func (c *serviceDiscovery) updateMember() error {
 		}
 		// Failed to get members
 		if err != nil {
-			c.logCannotUpdateMember(url, err)
+			c.cannotUpdateMemberLogger.Info("[pd] cannot update member from this url",
+				zap.String("url", url),
+				errs.ZapError(err))
 			select {
 			case <-c.ctx.Done():
 				return errors.WithStack(err)

--- a/client/servicediscovery/service_discovery.go
+++ b/client/servicediscovery/service_discovery.go
@@ -453,8 +453,6 @@ type serviceDiscovery struct {
 	// Client option.
 	option *opt.Option
 
-	sampleLogger *zap.Logger
-
 	flight singleflight.Group
 }
 
@@ -487,7 +485,6 @@ func NewServiceDiscovery(
 		keyspaceID:           keyspaceID,
 		tlsCfg:               tlsCfg,
 		option:               option,
-		sampleLogger:         logutil.SampleLoggerFactory(time.Minute, 5)(),
 		flight:               singleflight.Group{},
 	}
 	pdsd.callbacks.setServiceModeUpdateCallback(serviceModeUpdateCb)
@@ -908,7 +905,7 @@ func (c *serviceDiscovery) updateMember() error {
 		}
 		// Failed to get members
 		if err != nil {
-			c.sampleLogger.Info("[pd] cannot update member from this url",
+			logutil.SamplerLogger().Info("[pd] cannot update member from this url",
 				zap.String("url", url),
 				errs.ZapError(err))
 			select {

--- a/client/servicediscovery/service_discovery_test.go
+++ b/client/servicediscovery/service_discovery_test.go
@@ -29,11 +29,13 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -451,4 +453,43 @@ func TestGRPCDialOption(t *testing.T) {
 	err := cli.updateMember()
 	re.Error(err)
 	re.Greater(time.Since(start), 500*time.Millisecond)
+}
+
+type failedGetMembersServer struct {
+	pdpb.UnimplementedPDServer
+}
+
+func (*failedGetMembersServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb.GetMembersResponse, error) {
+	return nil, status.Error(codes.Unavailable, "distinct get members failure")
+}
+
+func TestUpdateMemberReturnsDetailedError(t *testing.T) {
+	re := require.New(t)
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	re.NoError(err)
+
+	grpcServer := grpc.NewServer()
+	pdpb.RegisterPDServer(grpcServer, &failedGetMembersServer{})
+	serveDone := make(chan struct{})
+	go func() {
+		_ = grpcServer.Serve(lis)
+		close(serveDone)
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		<-serveDone
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cli := &serviceDiscovery{
+		ctx:    ctx,
+		option: opt.NewOption(),
+	}
+	cli.urls.Store([]string{tlsutil.ModifyURLScheme(lis.Addr().String(), nil)})
+	t.Cleanup(cli.Close)
+
+	err = cli.updateMember()
+	re.ErrorIs(err, errs.ErrClientGetMember)
+	re.ErrorContains(err, "distinct get members failure")
 }

--- a/client/servicediscovery/service_discovery_test.go
+++ b/client/servicediscovery/service_discovery_test.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"net"
 	"net/url"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -29,9 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
@@ -41,7 +37,6 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	pingcaplog "github.com/pingcap/log"
 
 	"github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/opt"
@@ -438,49 +433,6 @@ func TestUpdateURLs(t *testing.T) {
 	re.Equal(getURLs([]*pdpb.Member{members[3]}), cli.GetServiceURLs())
 }
 
-func TestCannotUpdateMemberLogIsSampled(t *testing.T) {
-	core, observed := observer.New(zapcore.InfoLevel)
-	restore := pingcaplog.ReplaceGlobals(zap.New(core), nil)
-	t.Cleanup(restore)
-
-	newClient := func(url string) *serviceDiscovery {
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-		var wg sync.WaitGroup
-		return NewServiceDiscovery(
-			ctx, cancel, &wg, nil, nil, 0, []string{url}, nil, opt.NewOption(),
-		).(*serviceDiscovery)
-	}
-
-	const (
-		firstURL  = "http://pd-1:2379"
-		secondURL = "http://pd-2:2379"
-	)
-	firstClient := newClient(firstURL)
-	secondClient := newClient(secondURL)
-	const sampledMessage = "[pd] cannot update member from this url"
-	err := errors.New("pd unavailable")
-	for range 6 {
-		firstClient.sampleLogger.Info(sampledMessage,
-			zap.String("url", firstURL),
-			errs.ZapError(err))
-		secondClient.sampleLogger.Info(sampledMessage,
-			zap.String("url", secondURL),
-			errs.ZapError(err))
-	}
-
-	sampledEntries := observed.FilterMessage(sampledMessage)
-	require.Equal(t, 10, sampledEntries.Len())
-	require.Equal(t, 5, sampledEntries.FilterField(zap.String("url", firstURL)).Len())
-	require.Equal(t, 5, sampledEntries.FilterField(zap.String("url", secondURL)).Len())
-
-	const batchWarning = "[pd] failed to update member"
-	for range 6 {
-		pingcaplog.Warn(batchWarning)
-	}
-	require.Equal(t, 6, observed.FilterMessage(batchWarning).Len())
-}
-
 func TestGRPCDialOption(t *testing.T) {
 	re := require.New(t)
 	start := time.Now()
@@ -493,7 +445,6 @@ func TestGRPCDialOption(t *testing.T) {
 		cancel:            cancel,
 		tlsCfg:            nil,
 		option:            opt.NewOption(),
-		sampleLogger:      zap.NewNop(),
 	}
 	cli.urls.Store([]string{"tmp://test.url:5255"})
 	cli.option.GRPCDialOptions = []grpc.DialOption{grpc.WithBlock()} //nolint:staticcheck

--- a/client/servicediscovery/service_discovery_test.go
+++ b/client/servicediscovery/service_discovery_test.go
@@ -461,10 +461,10 @@ func TestCannotUpdateMemberLogIsSampled(t *testing.T) {
 	const sampledMessage = "[pd] cannot update member from this url"
 	err := errors.New("pd unavailable")
 	for range 6 {
-		firstClient.cannotUpdateMemberLogger.Info(sampledMessage,
+		firstClient.sampleLogger.Info(sampledMessage,
 			zap.String("url", firstURL),
 			errs.ZapError(err))
-		secondClient.cannotUpdateMemberLogger.Info(sampledMessage,
+		secondClient.sampleLogger.Info(sampledMessage,
 			zap.String("url", secondURL),
 			errs.ZapError(err))
 	}
@@ -487,13 +487,13 @@ func TestGRPCDialOption(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 500*time.Millisecond)
 	defer cancel()
 	cli := &serviceDiscovery{
-		callbacks:                newServiceCallbacks(),
-		checkMembershipCh:        make(chan struct{}, 1),
-		ctx:                      ctx,
-		cancel:                   cancel,
-		tlsCfg:                   nil,
-		option:                   opt.NewOption(),
-		cannotUpdateMemberLogger: zap.NewNop(),
+		callbacks:         newServiceCallbacks(),
+		checkMembershipCh: make(chan struct{}, 1),
+		ctx:               ctx,
+		cancel:            cancel,
+		tlsCfg:            nil,
+		option:            opt.NewOption(),
+		sampleLogger:      zap.NewNop(),
 	}
 	cli.urls.Store([]string{"tmp://test.url:5255"})
 	cli.option.GRPCDialOptions = []grpc.DialOption{grpc.WithBlock()} //nolint:staticcheck

--- a/client/servicediscovery/service_discovery_test.go
+++ b/client/servicediscovery/service_discovery_test.go
@@ -458,13 +458,17 @@ func TestCannotUpdateMemberLogIsSampled(t *testing.T) {
 	)
 	firstClient := newClient(firstURL)
 	secondClient := newClient(secondURL)
+	const sampledMessage = "[pd] cannot update member from this url"
 	err := errors.New("pd unavailable")
 	for range 6 {
-		firstClient.logCannotUpdateMember(firstURL, err)
-		secondClient.logCannotUpdateMember(secondURL, err)
+		firstClient.cannotUpdateMemberLogger.Info(sampledMessage,
+			zap.String("url", firstURL),
+			errs.ZapError(err))
+		secondClient.cannotUpdateMemberLogger.Info(sampledMessage,
+			zap.String("url", secondURL),
+			errs.ZapError(err))
 	}
 
-	const sampledMessage = "[pd] cannot update member from this url"
 	sampledEntries := observed.FilterMessage(sampledMessage)
 	require.Equal(t, 10, sampledEntries.Len())
 	require.Equal(t, 5, sampledEntries.FilterField(zap.String("url", firstURL)).Len())
@@ -483,12 +487,13 @@ func TestGRPCDialOption(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 500*time.Millisecond)
 	defer cancel()
 	cli := &serviceDiscovery{
-		callbacks:         newServiceCallbacks(),
-		checkMembershipCh: make(chan struct{}, 1),
-		ctx:               ctx,
-		cancel:            cancel,
-		tlsCfg:            nil,
-		option:            opt.NewOption(),
+		callbacks:                newServiceCallbacks(),
+		checkMembershipCh:        make(chan struct{}, 1),
+		ctx:                      ctx,
+		cancel:                   cancel,
+		tlsCfg:                   nil,
+		option:                   opt.NewOption(),
+		cannotUpdateMemberLogger: zap.NewNop(),
 	}
 	cli.urls.Store([]string{"tmp://test.url:5255"})
 	cli.option.GRPCDialOptions = []grpc.DialOption{grpc.WithBlock()} //nolint:staticcheck

--- a/client/servicediscovery/service_discovery_test.go
+++ b/client/servicediscovery/service_discovery_test.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
@@ -37,6 +41,7 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	pingcaplog "github.com/pingcap/log"
 
 	"github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/opt"
@@ -431,6 +436,45 @@ func TestUpdateURLs(t *testing.T) {
 	re.Equal(getURLs([]*pdpb.Member{members[3], members[2]}), cli.GetServiceURLs())
 	cli.updateURLs(members[3:])
 	re.Equal(getURLs([]*pdpb.Member{members[3]}), cli.GetServiceURLs())
+}
+
+func TestCannotUpdateMemberLogIsSampled(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+	restore := pingcaplog.ReplaceGlobals(zap.New(core), nil)
+	t.Cleanup(restore)
+
+	newClient := func(url string) *serviceDiscovery {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		var wg sync.WaitGroup
+		return NewServiceDiscovery(
+			ctx, cancel, &wg, nil, nil, 0, []string{url}, nil, opt.NewOption(),
+		).(*serviceDiscovery)
+	}
+
+	const (
+		firstURL  = "http://pd-1:2379"
+		secondURL = "http://pd-2:2379"
+	)
+	firstClient := newClient(firstURL)
+	secondClient := newClient(secondURL)
+	err := errors.New("pd unavailable")
+	for range 6 {
+		firstClient.logCannotUpdateMember(firstURL, err)
+		secondClient.logCannotUpdateMember(secondURL, err)
+	}
+
+	const sampledMessage = "[pd] cannot update member from this url"
+	sampledEntries := observed.FilterMessage(sampledMessage)
+	require.Equal(t, 10, sampledEntries.Len())
+	require.Equal(t, 5, sampledEntries.FilterField(zap.String("url", firstURL)).Len())
+	require.Equal(t, 5, sampledEntries.FilterField(zap.String("url", secondURL)).Len())
+
+	const batchWarning = "[pd] failed to update member"
+	for range 6 {
+		pingcaplog.Warn(batchWarning)
+	}
+	require.Equal(t, 6, observed.FilterMessage(batchWarning).Len())
 }
 
 func TestGRPCDialOption(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

When TiDB cannot connect to PD, each PD client service-discovery loop repeatedly
logs every failed membership refresh attempt. Multiple PD client instances can
multiply these messages. During prolonged PD unavailability or network failures,
the repeated messages can cause a process-wide log storm and obscure more useful
diagnostic information.

Issue Number: Close #11020

### What is changed and how does it work?

```commit-message
Add a reusable sampled logger backed by the Zap sampler core.

Create the logger lazily once per process and share its sampling budget across PD
client instances. For each log level and message, retain the first five matching
entries per minute and suppress the remaining entries until the next sampling
window. Mark retained entries with the sampled field.

Use the shared logger for per-attempt member update failures while leaving
membership refresh retries, returned errors, and the batch-level failure warning
unchanged.

Add unit tests for lazy singleton initialization, message-based sampling,
retained log fields, sampling limits, and logger lifetime.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Reduce excessive PD client logs during PD unavailability by sampling repeated member update failures with a process-wide shared budget.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared sampled logger utility for the client to help control high-volume logging.
* **Bug Fixes**
  * Reduced repetitive service-discovery warning messages by sampling repeated member-update failures.
  * When member updates fail, returned errors now preserve the most relevant underlying details after trying service URLs.
* **Tests**
  * Added coverage for sampled logging behavior and improved error detail handling in service discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->