### PR TITLE
resource_group client: prevent NaN in calcAvg when elapsed duration is zero

### DIFF
--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -320,11 +320,11 @@ func (gc *groupCostController) updateAvgRequestResourcePerSec() {
 	if counter.limiter.GetBurst() >= 0 {
 		isBurstable = false
 	}
+	gc.burstable.Store(isBurstable)
 	if !gc.calcAvg(counter, getRUValueFromConsumption(gc.run.consumption)) {
 		return
 	}
 	logControllerTrace("[resource group controller] update avg ru per sec", zap.String("name", gc.name), zap.Float64("avg-ru-per-sec", counter.avgRUPerSec), zap.Bool("is-throttled", gc.isThrottled.Load()))
-	gc.burstable.Store(isBurstable)
 }
 
 func (gc *groupCostController) resetEmergencyTokenAcquisition() {
@@ -366,6 +366,14 @@ func (gc *groupCostController) calcAvg(counter *tokenCounter, new float64) bool 
 	failpoint.Inject("acceleratedReportingPeriod", func() {
 		deltaDuration = 100 * time.Millisecond
 	})
+	// A freshly created controller might be published between the `updateRunState`
+	// and `updateAvgRequestResourcePerSec` passes of the same tick. In that case,
+	// `gc.run.now` still equals the `avgLastTime` set by `initRunState`, and the
+	// division below would be 0/0 = NaN, permanently poisoning `avgRUPerSec`.
+	// Skip the sample until the run state actually advances.
+	if deltaDuration <= 0 {
+		return false
+	}
 	delta := (new - counter.avgRUPerSecLastRU) / deltaDuration.Seconds()
 	counter.avgRUPerSec = movingAvgFactor*counter.avgRUPerSec + (1-movingAvgFactor)*delta
 	failpoint.Inject("acceleratedSpeedTrend", func() {

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -86,6 +87,31 @@ func TestGroupControlBurstable(t *testing.T) {
 	gc.run.requestUnitTokens.limiter.Reconfigure(time.Now(), args)
 	gc.updateAvgRequestResourcePerSec()
 	re.True(gc.burstable.Load())
+}
+
+func TestCalcAvgSkipsNonPositiveDeltaDuration(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re)
+	counter := gc.run.requestUnitTokens
+	// Simulate a controller that is published between the `updateRunState` and
+	// `updateAvgRequestResourcePerSec` passes of the same tick: `gc.run.now`
+	// still equals the `avgLastTime` set by `initRunState`, so the elapsed
+	// duration is exactly zero and the sample must be skipped instead of
+	// computing 0/0 = NaN.
+	re.Equal(gc.run.now, counter.avgLastTime)
+	gc.updateAvgRequestResourcePerSec()
+	re.False(math.IsNaN(counter.avgRUPerSec))
+	re.Zero(counter.avgRUPerSec)
+	// The skipped sample must not advance the accounting state.
+	re.Equal(gc.run.now, counter.avgLastTime)
+	re.Zero(counter.avgRUPerSecLastRU)
+
+	// Once the run state advances, sampling resumes as usual.
+	gc.run.consumption.RRU = 100
+	gc.run.now = gc.run.now.Add(time.Second)
+	gc.updateAvgRequestResourcePerSec()
+	re.False(math.IsNaN(counter.avgRUPerSec))
+	re.Positive(counter.avgRUPerSec)
 }
 
 func TestSmallPositiveConsumptionDoesNotBypassThreshold(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11022, ref #9455

### What is changed and how does it work?

```commit-message
A freshly created `groupCostController` can be published to the controller
map between the `updateRunState` and `updateAvgRequestResourcePerSec` passes
of the same tick. In that case `gc.run.now` still equals the `avgLastTime`
set by `initRunState` (the same `time.Now()` value), so `calcAvg` computes
`(0-0)/0 = NaN`, permanently poisoning `avgRUPerSec` (the moving average
keeps NaN forever) and making every subsequent token-bucket request carry
`required-token=NaN` until the idle cleanup deletes the controller.

Skip the sample when the elapsed duration is non-positive, and update the
`burstable` flag before sampling so a skipped sample does not delay it.
A regression test reproduces the exact scenario and verifies `avgRUPerSec`
stays finite and sampling resumes once the run state advances.
```

### Check List

Tests

- Unit test

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
Fix the issue that the resource group client might permanently send `NaN` token requests when a newly created resource group controller races with the periodic state update.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request-rate tracking when no time has elapsed between measurements.
  * Prevented invalid rate values from affecting resource usage calculations.
  * Ensured burst handling state is updated consistently during request-rate updates.

* **Tests**
  * Added coverage for skipped measurements and resumed tracking after time advances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->