### PR TITLE
resource_group client: prevent NaN in zero-duration calcAvg (#11023)

### DIFF
--- a/client/resource_group/controller/group_controller.go
+++ b/client/resource_group/controller/group_controller.go
@@ -391,6 +391,7 @@ func (gc *groupCostController) updateAvgRequestResourcePerSec() {
 	if counter.limiter.GetBurst() >= 0 {
 		isBurstable = false
 	}
+	gc.burstable.Store(isBurstable)
 	avgRUPerSec, demandRUPerSec, avgOK, demandOK := gc.calcAvgAndDemand(counter, getRUValueFromConsumption(gc.run.consumption))
 	if demandOK {
 		gc.metrics.demandRUPerSecGauge.Set(demandRUPerSec)
@@ -398,7 +399,6 @@ func (gc *groupCostController) updateAvgRequestResourcePerSec() {
 	if avgOK {
 		gc.metrics.avgRUPerSecGauge.Set(avgRUPerSec)
 		logControllerTrace("[resource group controller] update avg ru per sec", zap.String("name", gc.name), zap.Float64("avg-ru-per-sec", avgRUPerSec), zap.Bool("is-throttled", gc.isThrottled.Load()))
-		gc.burstable.Store(isBurstable)
 	}
 }
 
@@ -467,6 +467,11 @@ func calcMovingAvgAt(now time.Time, avg *float64, lastRU *float64, lastTime *tim
 	failpoint.Inject("acceleratedReportingPeriod", func() {
 		deltaDuration = 100 * time.Millisecond
 	})
+	// A freshly created controller might be published between the `updateRunState`
+	// and `updateAvgRequestResourcePerSec` passes of the same tick. In that case,
+	// `gc.run.now` still equals the `avgLastTime` set by `initRunState`, and the
+	// division below would be 0/0 = NaN, permanently poisoning `avgRUPerSec`.
+	// Skip the sample until the run state actually advances.
 	if deltaDuration <= 0 {
 		return false
 	}

--- a/client/resource_group/controller/group_controller_test.go
+++ b/client/resource_group/controller/group_controller_test.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"strings"
 	"sync"
@@ -112,6 +113,37 @@ func TestGroupControlBurstable(t *testing.T) {
 	gc.run.requestUnitTokens.avgLastTime = gc.run.now.Add(-time.Second)
 	gc.updateAvgRequestResourcePerSec()
 	re.True(gc.burstable.Load())
+}
+
+func TestCalcAvgSkipsNonPositiveDeltaDuration(t *testing.T) {
+	re := require.New(t)
+	gc := createTestGroupCostController(re, t.Name())
+	counter := gc.run.requestUnitTokens
+	counter.limiter.Reconfigure(gc.run.now, tokenBucketReconfigureArgs{
+		newFillRate: 1000,
+		newBurst:    -1,
+	})
+	re.False(gc.burstable.Load())
+	// Simulate a controller that is published between the `updateRunState` and
+	// `updateAvgRequestResourcePerSec` passes of the same tick: `gc.run.now`
+	// still equals the `avgLastTime` set by `initRunState`, so the elapsed
+	// duration is exactly zero and the sample must be skipped instead of
+	// computing 0/0 = NaN.
+	re.Equal(gc.run.now, counter.avgLastTime)
+	gc.updateAvgRequestResourcePerSec()
+	re.False(math.IsNaN(counter.avgRUPerSec))
+	re.Zero(counter.avgRUPerSec)
+	re.True(gc.burstable.Load())
+	// The skipped sample must not advance the accounting state.
+	re.Equal(gc.run.now, counter.avgLastTime)
+	re.Zero(counter.avgRUPerSecLastRU)
+
+	// Once the run state advances, sampling resumes as usual.
+	gc.run.consumption.RRU = 100
+	gc.run.now = gc.run.now.Add(time.Second)
+	gc.updateAvgRequestResourcePerSec()
+	re.False(math.IsNaN(counter.avgRUPerSec))
+	re.Positive(counter.avgRUPerSec)
 }
 
 func TestSmallPositiveConsumptionDoesNotBypassThreshold(t *testing.T) {


### PR DESCRIPTION
This is a cherry-pick of #11023 to `release-nextgen-202603`.

### What problem does this PR solve?

Issue Number: ref #11022, ref #9455

### What is changed and how does it work?

The target branch already contains the non-positive duration guard from #10866.
This cherry-pick preserves that shared implementation and applies the remaining
source behavior plus regression coverage.

```commit-message
Update the burstable state before sampling so a zero-duration sample does not
delay it. Add a regression test covering the creation race, finite
moving-average values, resumed sampling, and the burstable state update.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix the issue that the resource group client might permanently send `NaN` token requests when a newly created resource group controller races with the periodic state update.
```