### PR TITLE
This is an automated cherry-pick of #10292

### DIFF
--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -846,6 +846,9 @@ type OpInfluenceOption func(region *core.RegionInfo) bool
 // WithRangeOption returns an OpInfluenceOption that filters the region by the key ranges.
 func WithRangeOption(ranges []keyutil.KeyRange) OpInfluenceOption {
 	return func(region *core.RegionInfo) bool {
+		if region == nil {
+			return false
+		}
 		kr := keyutil.NewKeyRange(string(region.GetStartKey()), string(region.GetEndKey()))
 		for _, r := range ranges {
 			// exclude the continued range
@@ -868,17 +871,23 @@ func (oc *Controller) GetOpInfluence(cluster *core.BasicCluster, opts ...OpInflu
 	influence := OpInfluence{
 		StoresInfluence: make(map[uint64]*StoreInfluence),
 	}
+	if cluster == nil {
+		return influence
+	}
 	oc.operators.Range(
 		func(_, value any) bool {
 			op := value.(*Operator)
 			if !op.CheckTimeout() && !op.CheckSuccess() {
 				region := cluster.GetRegion(op.RegionID())
-				for _, opt := range opts {
-					if !opt(region) {
-						return true
-					}
-				}
 				if region != nil {
+					for _, opt := range opts {
+						if opt == nil {
+							continue
+						}
+						if !opt(region) {
+							return true
+						}
+					}
 					op.UnfinishedInfluence(influence, region)
 				}
 			}

--- a/pkg/schedule/operator/operator_controller_test.go
+++ b/pkg/schedule/operator/operator_controller_test.go
@@ -718,6 +718,8 @@ func (suite *operatorControllerTestSuite) TestInfluenceOpt() {
 	op.Start()
 	inf := controller.GetOpInfluence(cluster.GetBasicCluster())
 	re.Len(inf.StoresInfluence, 1)
+	inf = controller.GetOpInfluence(cluster.GetBasicCluster(), nil)
+	re.Len(inf.StoresInfluence, 1)
 	inf = controller.GetOpInfluence(cluster.GetBasicCluster(), WithRangeOption([]keyutil.KeyRange{{StartKey: []byte("300"), EndKey: []byte("400")}}))
 	re.Empty(inf.StoresInfluence)
 	inf = controller.GetOpInfluence(cluster.GetBasicCluster(), WithRangeOption([]keyutil.KeyRange{{StartKey: []byte("100"), EndKey: []byte("199")}}))
@@ -730,6 +732,13 @@ func (suite *operatorControllerTestSuite) TestInfluenceOpt() {
 	re.Len(inf.StoresInfluence, 1)
 	inf = controller.GetOpInfluence(cluster.GetBasicCluster(), WithRangeOption([]keyutil.KeyRange{{StartKey: []byte("200"), EndKey: []byte("299")}}))
 	re.Len(inf.StoresInfluence, 1)
+	cluster.ResetRegionCache()
+	inf = controller.GetOpInfluence(cluster.GetBasicCluster(), WithRangeOption([]keyutil.KeyRange{{StartKey: []byte("100"), EndKey: []byte("400")}}))
+	re.Empty(inf.StoresInfluence)
+	inf = controller.GetOpInfluence(nil, WithRangeOption([]keyutil.KeyRange{{StartKey: []byte("100"), EndKey: []byte("400")}}))
+	re.Empty(inf.StoresInfluence)
+	opt := WithRangeOption([]keyutil.KeyRange{{StartKey: []byte("100"), EndKey: []byte("400")}})
+	re.False(opt(nil))
 }
 
 func (suite *operatorControllerTestSuite) TestCalcInfluence() {


### PR DESCRIPTION
close tikv/pd#10293

<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
