### PR TITLE
server, client: expose store scheduling state in GetStore

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -62,10 +62,6 @@ type RPCClient interface {
 	// The store may expire later. Caller is responsible for caching and taking care
 	// of store change.
 	GetStore(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*metapb.Store, error)
-	// GetStoreResponse gets the complete GetStore response. It retains PD's
-	// optional store scheduling state for callers that need scheduling decisions
-	// in addition to store metadata.
-	GetStoreResponse(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*pdpb.GetStoreResponse, error)
 	// GetAllStores gets all stores from pd.
 	// The store may expire later. Caller is responsible for caching and taking care
 	// of store change.
@@ -119,6 +115,14 @@ type RPCClient interface {
 	KeyspaceClient
 	// ResourceManagerClient manages resource group metadata and token assignment.
 	ResourceManagerClient
+}
+
+// RPCClientExt is an optional extension for callers that need fields carried
+// by complete RPC responses in addition to the existing RPCClient methods. It
+// is deliberately separate from RPCClient so new optional response APIs do not
+// break existing pd.Client implementations and mocks.
+type RPCClientExt interface {
+	GetStoreResponse(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*pdpb.GetStoreResponse, error)
 }
 
 // Client is a PD (Placement Driver) RPC client.
@@ -1044,7 +1048,7 @@ func (c *client) GetStore(ctx context.Context, storeID uint64, opts ...opt.GetSt
 	return handleStoreResponse(resp)
 }
 
-// GetStoreResponse implements the RPCClient interface.
+// GetStoreResponse implements the RPCClientExt interface.
 func (c *client) GetStoreResponse(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*pdpb.GetStoreResponse, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span = span.Tracer().StartSpan("pdclient.GetStore", opentracing.ChildOf(span.Context()))

--- a/client/client.go
+++ b/client/client.go
@@ -62,6 +62,10 @@ type RPCClient interface {
 	// The store may expire later. Caller is responsible for caching and taking care
 	// of store change.
 	GetStore(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*metapb.Store, error)
+	// GetStoreResponse gets the complete GetStore response. It retains PD's
+	// optional store scheduling state for callers that need scheduling decisions
+	// in addition to store metadata.
+	GetStoreResponse(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*pdpb.GetStoreResponse, error)
 	// GetAllStores gets all stores from pd.
 	// The store may expire later. Caller is responsible for caching and taking care
 	// of store change.
@@ -1033,6 +1037,15 @@ func handleRegionsResponse(resp *pdpb.ScanRegionsResponse) []*router.Region {
 
 // GetStore implements the RPCClient interface.
 func (c *client) GetStore(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*metapb.Store, error) {
+	resp, err := c.GetStoreResponse(ctx, storeID, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return handleStoreResponse(resp)
+}
+
+// GetStoreResponse implements the RPCClient interface.
+func (c *client) GetStoreResponse(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*pdpb.GetStoreResponse, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span = span.Tracer().StartSpan("pdclient.GetStore", opentracing.ChildOf(span.Context()))
 		defer span.Finish()
@@ -1077,7 +1090,7 @@ func (c *client) GetStore(ctx context.Context, storeID uint64, opts ...opt.GetSt
 	if err = c.respForErr(metrics.CmdFailedDurationGetStore, start, err, resp.GetHeader()); err != nil {
 		return nil, err
 	}
-	return handleStoreResponse(resp)
+	return resp, nil
 }
 
 func handleStoreResponse(resp *pdpb.GetStoreResponse) (*metapb.Store, error) {

--- a/client/go.mod
+++ b/client/go.mod
@@ -2,6 +2,9 @@ module github.com/tikv/pd/client
 
 go 1.25.10
 
+// Temporary replacement for kvproto PR #1503. Remove it after the PR merges.
+replace github.com/pingcap/kvproto => github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5

--- a/client/go.sum
+++ b/client/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0 h1:W1he+VK7QW2ZrVt8GiDK4u1yUF7FsQbi95XRT/pJZrs=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -53,8 +55,6 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
-github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0 h1:MalBpLjhK/cS9ndCoSAg2C7aBzVojAqFVfzTKmuy0ho=
-github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.10
 // When you modify PD cooperatively with kvproto, this will be useful to submit the PR to PD and the PR to
 // kvproto at the same time. You can run `go mod tidy` to make it replaced with go-mod style specification.
 // After the PR to kvproto is merged, remember to comment this out and run `go mod tidy`.
-// replace github.com/pingcap/kvproto => github.com/$YourPrivateRepo $YourPrivateBranch
+replace github.com/pingcap/kvproto => github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0
 
 require (
 	github.com/AlekSi/gocov-xml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -479,6 +479,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0 h1:W1he+VK7QW2ZrVt8GiDK4u1yUF7FsQbi95XRT/pJZrs=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0 h1:MalBpLjhK/cS9ndCoSAg2C7aBzVojAqFVfzTKmuy0ho=
 github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=

--- a/pkg/utils/grpcutil/cluster_test.go
+++ b/pkg/utils/grpcutil/cluster_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -215,4 +216,19 @@ func (suite *clusterSuite) TestGetRegionByPreKey() {
 			}
 		})
 	}
+}
+
+func (suite *clusterSuite) TestGetStoreDoesNotReportSchedulingState() {
+	re := suite.Require()
+	suite.rc.PutStore(core.NewStoreInfo(
+		&metapb.Store{Id: 1, Address: "tikv-1"},
+		core.SlowStoreEvicted(),
+	))
+
+	resp, err := GetStore(suite.rc, &pdpb.GetStoreRequest{StoreId: 1})
+	re.NoError(err)
+	re.NotNil(resp.GetStore())
+	// BasicCluster is used by the router and does not retain dynamic PD leader
+	// scheduling decisions. Returning nil preserves the unknown state.
+	re.Nil(resp.GetSchedulingState())
 }

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -786,6 +786,9 @@ func (s *GrpcServer) GetStore(ctx context.Context, request *pdpb.GetStoreRequest
 		Header: grpcutil.WrapHeader(),
 		Store:  store.GetMeta(),
 		Stats:  store.GetStoreStats(),
+		SchedulingState: &pdpb.StoreSchedulingState{
+			EvictedAsSlowStore: store.EvictedAsSlowStore(),
+		},
 	}, nil
 }
 

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -1276,6 +1276,18 @@ func (suite *clientStatelessTestSuite) TestGetStore() {
 	store.LastHeartbeat = n.LastHeartbeat
 	re.Equal(store, n)
 
+	// GetStoreResponse retains PD's dynamic scheduling state, which is not part
+	// of the store metadata returned by GetStore.
+	err = cluster.SlowStoreEvicted(store.GetId())
+	re.NoError(err)
+	storeResp, err := suite.client.GetStoreResponse(context.Background(), store.GetId())
+	re.NoError(err)
+	re.True(storeResp.GetSchedulingState().GetEvictedAsSlowStore())
+	cluster.SlowStoreRecovered(store.GetId())
+	storeResp, err = suite.client.GetStoreResponse(context.Background(), store.GetId())
+	re.NoError(err)
+	re.False(storeResp.GetSchedulingState().GetEvictedAsSlowStore())
+
 	actualStores, err := suite.client.GetAllStores(context.Background())
 	re.NoError(err)
 	re.Len(actualStores, len(stores))

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -3,6 +3,8 @@ module github.com/tikv/pd/tests/integrations
 go 1.25.10
 
 replace (
+	// Temporary replacement for kvproto PR #1503. Remove it after the PR merges.
+	github.com/pingcap/kvproto => github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0
 	github.com/tikv/pd => ../../
 	github.com/tikv/pd/client => ../../client
 	github.com/tikv/pd/tests/integrations/mcs => ./mcs

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -472,6 +472,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0 h1:W1he+VK7QW2ZrVt8GiDK4u1yUF7FsQbi95XRT/pJZrs=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0 h1:MalBpLjhK/cS9ndCoSAg2C7aBzVojAqFVfzTKmuy0ho=
 github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,6 +3,8 @@ module github.com/tikv/pd/tools
 go 1.25.10
 
 replace (
+	// Temporary replacement for kvproto PR #1503. Remove it after the PR merges.
+	github.com/pingcap/kvproto => github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0
 	github.com/tikv/pd => ../
 	github.com/tikv/pd/client => ../client
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -25,6 +25,8 @@ github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0 h1:W1he+VK7QW2ZrVt8GiDK4u1yUF7FsQbi95XRT/pJZrs=
+github.com/LykxSassinator/kvproto v0.0.0-20260723025057-6a82baebdef0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Ref https://github.com/tikv/client-go/issues/2012

PD owns the slow-store eviction and recovery-time policy, but the existing
`GetStore` path only exposes `metapb.Store` and drops fields carried by the
full `GetStoreResponse`. Consequently, downstream clients cannot distinguish a
locally recovered Store from one that PD still keeps evicted as slow.

This PR exposes PD's scheduling decision through `GetStoreResponse`, enabling
client-go proposal 3 to keep non-leader replica reads excluded until PD
explicitly re-admits the Store.

Depends on https://github.com/pingcap/kvproto/pull/1503.

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

- PD leader's `GetStore` response now populates
  `StoreSchedulingState.evicted_as_slow_store` from
  `core.StoreInfo.EvictedAsSlowStore()`.
- Adds optional `pd.RPCClientExt.GetStoreResponse`, which returns the complete
  protobuf response while keeping the existing `RPCClient` and
  `Client.GetStore` APIs source-compatible.
- Keeps `GetStore` behavior unchanged by implementing it on top of
  `GetStoreResponse` and retaining existing response validation.
- Router responses deliberately leave `SchedulingState` unset: Router's
  metadata cache does not retain PD leader's dynamic scheduling decision, and
  reporting a default `false` value would incorrectly imply that the Store is
  eligible.
- Adds coverage for PD leader state exposure and Router's `unknown` semantics.

The `kvproto` dependency is temporarily replaced with the branch for PR #1503.
The replacement should be removed and dependencies tidied after that PR merges.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
PD client now exposes Store scheduling state in the full GetStore response so
clients can honor PD slow-store recovery decisions.
```
