### PR TITLE
grpcutil: bound stream metrics peer IP label lifecycle

### DIFF
--- a/pkg/utils/grpcutil/stream.go
+++ b/pkg/utils/grpcutil/stream.go
@@ -122,27 +122,26 @@ type MetricsStream[SendT any, RecvT any] struct {
 
 // NewMetricsStream creates a MetricsStream wrapping the given gRPC server stream.
 // It automatically extracts the target IP from the stream's peer info and combines
-// it with requestLabel to create the prometheus observer from hist.
-// If hist or stream is nil, no metrics are recorded.
+// it with requestLabel to create the prometheus observer from collector.
+// If collector or stream is nil, no metrics are recorded.
 func NewMetricsStream[SendT any, RecvT any](
 	stream grpc.ServerStream,
 	sendFn func(SendT) error,
 	recvFn func() (RecvT, error),
-	hist *StreamSendDurationCollector,
+	collector *StreamSendDurationCollector,
 	requestLabel string,
 ) *MetricsStream[SendT, RecvT] {
-	var obs prometheus.Observer
-	if hist != nil && stream != nil {
-		var release func()
-		obs, release = hist.acquire(requestLabel, targetIP(stream))
-		context.AfterFunc(stream.Context(), release)
-	}
-	return &MetricsStream[SendT, RecvT]{
+	ms := &MetricsStream[SendT, RecvT]{
 		ServerStream: stream,
 		sendFn:       sendFn,
 		recvFn:       recvFn,
-		sendObs:      obs,
 	}
+	if collector != nil && stream != nil {
+		var release func()
+		ms.sendObs, release = collector.acquire(requestLabel, targetIP(stream))
+		context.AfterFunc(stream.Context(), release)
+	}
+	return ms
 }
 
 // Send delegates to the underlying stream's Send and records the duration.

--- a/pkg/utils/grpcutil/stream.go
+++ b/pkg/utils/grpcutil/stream.go
@@ -15,7 +15,9 @@
 package grpcutil
 
 import (
+	"context"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,17 +27,64 @@ import (
 	"github.com/tikv/pd/pkg/errs"
 )
 
-// NewGRPCStreamSendDuration creates a HistogramVec for measuring gRPC stream
+// StreamSendDurationCollector measures gRPC stream Send durations and owns the
+// lifecycle of HistogramVec children whose target label is derived from peer IPs.
+type StreamSendDurationCollector struct {
+	hist     *prometheus.HistogramVec
+	mu       sync.Mutex
+	children map[streamChildKey]int
+}
+
+type streamChildKey struct {
+	request string
+	target  string
+}
+
+// NewGRPCStreamSendDuration creates a histogram for measuring gRPC stream
 // Send operation durations, using consistent bucket settings across services.
-func NewGRPCStreamSendDuration(namespace, subsystem string) *prometheus.HistogramVec {
-	return prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+func NewGRPCStreamSendDuration(namespace, subsystem string) *StreamSendDurationCollector {
+	return &StreamSendDurationCollector{
+		hist: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "grpc_stream_send_duration_seconds",
 			Help:      "Bucketed histogram of duration (s) of gRPC stream Send operations.",
 			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20), // 0.1ms ~ 52s
-		}, []string{"request", "target"})
+		}, []string{"request", "target"}),
+		children: make(map[streamChildKey]int),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (d *StreamSendDurationCollector) Describe(ch chan<- *prometheus.Desc) {
+	d.hist.Describe(ch)
+}
+
+// Collect implements prometheus.Collector.
+func (d *StreamSendDurationCollector) Collect(ch chan<- prometheus.Metric) {
+	d.hist.Collect(ch)
+}
+
+func (d *StreamSendDurationCollector) acquire(request, target string) (prometheus.Observer, func()) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	key := streamChildKey{request: request, target: target}
+	d.children[key]++
+	obs := d.hist.WithLabelValues(key.request, key.target)
+	return obs, func() { d.release(key) }
+}
+
+func (d *StreamSendDurationCollector) release(key streamChildKey) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.children[key]--
+	if d.children[key] > 0 {
+		return
+	}
+	delete(d.children, key)
+	d.hist.DeleteLabelValues(key.request, key.target)
 }
 
 // targetIP extracts the target IP (without port) from a gRPC server stream's peer info.
@@ -74,17 +123,19 @@ type MetricsStream[SendT any, RecvT any] struct {
 // NewMetricsStream creates a MetricsStream wrapping the given gRPC server stream.
 // It automatically extracts the target IP from the stream's peer info and combines
 // it with requestLabel to create the prometheus observer from hist.
-// If hist is nil, no metrics are recorded.
+// If hist or stream is nil, no metrics are recorded.
 func NewMetricsStream[SendT any, RecvT any](
 	stream grpc.ServerStream,
 	sendFn func(SendT) error,
 	recvFn func() (RecvT, error),
-	hist *prometheus.HistogramVec,
+	hist *StreamSendDurationCollector,
 	requestLabel string,
 ) *MetricsStream[SendT, RecvT] {
 	var obs prometheus.Observer
-	if hist != nil {
-		obs = hist.WithLabelValues(requestLabel, targetIP(stream))
+	if hist != nil && stream != nil {
+		var release func()
+		obs, release = hist.acquire(requestLabel, targetIP(stream))
+		context.AfterFunc(stream.Context(), release)
 	}
 	return &MetricsStream[SendT, RecvT]{
 		ServerStream: stream,

--- a/pkg/utils/grpcutil/stream_test.go
+++ b/pkg/utils/grpcutil/stream_test.go
@@ -17,8 +17,11 @@ package grpcutil
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -26,12 +29,15 @@ import (
 	"google.golang.org/grpc/peer"
 
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
 // fakeServerStream implements grpc.ServerStream for testing.
 type fakeServerStream struct {
 	ctx context.Context
 }
+
+const testTarget = "10.0.1.5"
 
 func (*fakeServerStream) SetHeader(metadata.MD) error  { return nil }
 func (*fakeServerStream) SendHeader(metadata.MD) error { return nil }
@@ -41,10 +47,241 @@ func (*fakeServerStream) SendMsg(any) error            { return nil }
 func (*fakeServerStream) RecvMsg(any) error            { return nil }
 
 func newFakeStreamWithPeer() *fakeServerStream {
-	ctx := peer.NewContext(context.Background(), &peer.Peer{
-		Addr: &net.TCPAddr{IP: net.ParseIP("10.0.1.5"), Port: 34567},
+	return newFakeStreamWithPeerContext(context.Background(), testTarget)
+}
+
+func newFakeStreamWithPeerContext(ctx context.Context, ip string) *fakeServerStream {
+	ctx = peer.NewContext(ctx, &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP(ip), Port: 34567},
 	})
 	return &fakeServerStream{ctx: ctx}
+}
+
+func newTestStreamMetrics(t *testing.T) (*prometheus.Registry, *StreamSendDurationCollector) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	h := NewGRPCStreamSendDuration("test", "stream")
+	require.NoError(t, reg.Register(h))
+	return reg, h
+}
+
+func newTestMetricsStream(
+	ctx context.Context,
+	hist *StreamSendDurationCollector,
+	request, target string,
+) *MetricsStream[string, string] {
+	return NewMetricsStream[string, string](
+		newFakeStreamWithPeerContext(ctx, target),
+		func(string) error { return nil },
+		nil,
+		hist, request,
+	)
+}
+
+func streamMetricCount(reg prometheus.Gatherer) (int, error) {
+	mfs, err := reg.Gather()
+	if err != nil {
+		return 0, err
+	}
+	if len(mfs) == 0 {
+		return 0, nil
+	}
+	return len(mfs[0].GetMetric()), nil
+}
+
+func streamMetricSampleCount(reg prometheus.Gatherer, request string) (uint64, bool, error) {
+	mfs, err := reg.Gather()
+	if err != nil {
+		return 0, false, err
+	}
+	for _, mf := range mfs {
+		for _, metric := range mf.GetMetric() {
+			var metricRequest, metricTarget string
+			for _, label := range metric.GetLabel() {
+				switch label.GetName() {
+				case "request":
+					metricRequest = label.GetValue()
+				case "target":
+					metricTarget = label.GetValue()
+				}
+			}
+			if metricRequest == request && metricTarget == testTarget {
+				return metric.GetHistogram().GetSampleCount(), true, nil
+			}
+		}
+	}
+	return 0, false, nil
+}
+
+func waitForNoStreamMetrics(t *testing.T, reg prometheus.Gatherer) {
+	t.Helper()
+	var gatherErr error
+	testutil.Eventually(
+		require.New(t),
+		func() bool {
+			var count int
+			count, err := streamMetricCount(reg)
+			if err != nil {
+				gatherErr = err
+				return true
+			}
+			return count == 0
+		},
+		testutil.WithWaitFor(time.Second),
+		testutil.WithTickInterval(time.Millisecond),
+	)
+	require.NoError(t, gatherErr)
+}
+
+func TestMetricsStreamLifecycle(t *testing.T) {
+	re := require.New(t)
+	reg, h := newTestStreamMetrics(t)
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	stream1 := newTestMetricsStream(ctx1, h, "my-rpc", testTarget)
+	stream2 := newTestMetricsStream(ctx2, h, "my-rpc", testTarget)
+	re.NoError(stream1.Send("first"))
+	re.NoError(stream2.Send("second"))
+	metricCount, err := streamMetricCount(reg)
+	re.NoError(err)
+	re.Equal(1, metricCount)
+
+	key := streamChildKey{request: "my-rpc", target: testTarget}
+	h.mu.Lock()
+	refs := h.children[key]
+	h.mu.Unlock()
+	re.Equal(2, refs)
+
+	cancel1()
+	testutil.Eventually(
+		re,
+		func() bool {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			return h.children[key] == 1
+		},
+		testutil.WithWaitFor(time.Second),
+		testutil.WithTickInterval(time.Millisecond),
+	)
+	metricCount, err = streamMetricCount(reg)
+	re.NoError(err)
+	re.Equal(1, metricCount)
+	re.NoError(stream2.Send("still-active"))
+	count, ok, err := streamMetricSampleCount(reg, "my-rpc")
+	re.NoError(err)
+	re.True(ok)
+	re.Equal(uint64(3), count)
+
+	cancel2()
+	waitForNoStreamMetrics(t, reg)
+}
+
+func TestMetricsStreamReconnect(t *testing.T) {
+	re := require.New(t)
+	reg, h := newTestStreamMetrics(t)
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	stream1 := newTestMetricsStream(ctx1, h, "my-rpc", testTarget)
+	re.NoError(stream1.Send("first"))
+	re.NoError(stream1.Send("second"))
+	count, ok, err := streamMetricSampleCount(reg, "my-rpc")
+	re.NoError(err)
+	re.True(ok)
+	re.Equal(uint64(2), count)
+
+	cancel1()
+	waitForNoStreamMetrics(t, reg)
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	stream2 := newTestMetricsStream(ctx2, h, "my-rpc", testTarget)
+	re.NoError(stream2.Send("reconnected"))
+	count, ok, err = streamMetricSampleCount(reg, "my-rpc")
+	re.NoError(err)
+	re.True(ok)
+	re.Equal(uint64(1), count)
+
+	cancel2()
+	waitForNoStreamMetrics(t, reg)
+}
+
+func TestMetricsStreamLabelIsolation(t *testing.T) {
+	re := require.New(t)
+	reg, h := newTestStreamMetrics(t)
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	stream1 := newTestMetricsStream(ctx1, h, "first-rpc", testTarget)
+	stream2 := newTestMetricsStream(ctx2, h, "second-rpc", testTarget)
+	re.NoError(stream1.Send("first"))
+	re.NoError(stream2.Send("second"))
+	metricCount, err := streamMetricCount(reg)
+	re.NoError(err)
+	re.Equal(2, metricCount)
+
+	cancel1()
+	var gatherErr error
+	testutil.Eventually(
+		re,
+		func() bool {
+			_, firstExists, err := streamMetricSampleCount(reg, "first-rpc")
+			if err != nil {
+				gatherErr = err
+				return true
+			}
+			secondCount, secondExists, err := streamMetricSampleCount(reg, "second-rpc")
+			if err != nil {
+				gatherErr = err
+				return true
+			}
+			return !firstExists && secondExists && secondCount == 1
+		},
+		testutil.WithWaitFor(time.Second),
+		testutil.WithTickInterval(time.Millisecond),
+	)
+	re.NoError(gatherErr)
+
+	cancel2()
+	waitForNoStreamMetrics(t, reg)
+}
+
+func TestMetricsStreamAlreadyCanceled(t *testing.T) {
+	reg, h := newTestStreamMetrics(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	newTestMetricsStream(ctx, h, "my-rpc", testTarget)
+
+	waitForNoStreamMetrics(t, reg)
+}
+
+func TestMetricsStreamConcurrentLifecycle(t *testing.T) {
+	reg, h := newTestStreamMetrics(t)
+
+	const streamCount = 128
+	var wg sync.WaitGroup
+	wg.Add(streamCount)
+	for i := range streamCount {
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithCancel(context.Background())
+			newTestMetricsStream(
+				ctx,
+				h,
+				fmt.Sprintf("rpc-%d", i%4),
+				fmt.Sprintf("10.0.1.%d", i%8+1),
+			)
+			cancel()
+		}()
+	}
+	wg.Wait()
+
+	waitForNoStreamMetrics(t, reg)
 }
 
 func TestMetricsStream(t *testing.T) {
@@ -124,6 +361,21 @@ func TestMetricsStream(t *testing.T) {
 		re.NoError(err)
 		re.Equal("ok", v)
 	})
+
+	t.Run("NilStream", func(t *testing.T) {
+		re := require.New(t)
+		reg, h := newTestStreamMetrics(t)
+		s := NewMetricsStream[string, string](
+			nil,
+			func(string) error { return nil },
+			nil,
+			h, "my-rpc",
+		)
+		re.NoError(s.Send("no-stream"))
+		metricCount, err := streamMetricCount(reg)
+		re.NoError(err)
+		re.Equal(0, metricCount)
+	})
 }
 
 func TestTargetIP(t *testing.T) {
@@ -138,5 +390,5 @@ func TestTargetIP(t *testing.T) {
 
 	// With peer addr, returns IP only (without port).
 	s = newFakeStreamWithPeer()
-	re.Equal("10.0.1.5", targetIP(s))
+	re.Equal(testTarget, targetIP(s))
 }

--- a/pkg/utils/grpcutil/stream_test.go
+++ b/pkg/utils/grpcutil/stream_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
@@ -60,118 +61,103 @@ func newFakeStreamWithPeerContext(ctx context.Context, ip string) *fakeServerStr
 func newTestStreamMetrics(t *testing.T) (*prometheus.Registry, *StreamSendDurationCollector) {
 	t.Helper()
 	reg := prometheus.NewRegistry()
-	h := NewGRPCStreamSendDuration("test", "stream")
-	require.NoError(t, reg.Register(h))
-	return reg, h
+	collector := NewGRPCStreamSendDuration("test", "stream")
+	require.NoError(t, reg.Register(collector))
+	return reg, collector
 }
 
 func newTestMetricsStream(
 	ctx context.Context,
-	hist *StreamSendDurationCollector,
+	collector *StreamSendDurationCollector,
 	request, target string,
 ) *MetricsStream[string, string] {
 	return NewMetricsStream[string, string](
 		newFakeStreamWithPeerContext(ctx, target),
 		func(string) error { return nil },
 		nil,
-		hist, request,
+		collector, request,
 	)
 }
 
-func streamMetricCount(reg prometheus.Gatherer) (int, error) {
+func gatherStreamMetrics(t *testing.T, reg prometheus.Gatherer) []*dto.Metric {
+	t.Helper()
 	mfs, err := reg.Gather()
-	if err != nil {
-		return 0, err
-	}
+	require.NoError(t, err)
 	if len(mfs) == 0 {
-		return 0, nil
+		return nil
 	}
-	return len(mfs[0].GetMetric()), nil
+	return mfs[0].GetMetric()
 }
 
-func streamMetricSampleCount(reg prometheus.Gatherer, request string) (uint64, bool, error) {
-	mfs, err := reg.Gather()
-	if err != nil {
-		return 0, false, err
-	}
-	for _, mf := range mfs {
-		for _, metric := range mf.GetMetric() {
-			var metricRequest, metricTarget string
-			for _, label := range metric.GetLabel() {
-				switch label.GetName() {
-				case "request":
-					metricRequest = label.GetValue()
-				case "target":
-					metricTarget = label.GetValue()
-				}
-			}
-			if metricRequest == request && metricTarget == testTarget {
-				return metric.GetHistogram().GetSampleCount(), true, nil
+func streamMetricCount(t *testing.T, reg prometheus.Gatherer) int {
+	t.Helper()
+	return len(gatherStreamMetrics(t, reg))
+}
+
+func streamMetricSampleCount(t *testing.T, reg prometheus.Gatherer, request string) (uint64, bool) {
+	t.Helper()
+	for _, metric := range gatherStreamMetrics(t, reg) {
+		var metricRequest, metricTarget string
+		for _, label := range metric.GetLabel() {
+			switch label.GetName() {
+			case "request":
+				metricRequest = label.GetValue()
+			case "target":
+				metricTarget = label.GetValue()
 			}
 		}
+		if metricRequest == request && metricTarget == testTarget {
+			return metric.GetHistogram().GetSampleCount(), true
+		}
 	}
-	return 0, false, nil
+	return 0, false
+}
+
+func childRefs(collector *StreamSendDurationCollector, request, target string) int {
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+	return collector.children[streamChildKey{request: request, target: target}]
+}
+
+func waitForStreamMetrics(t *testing.T, condition func() bool) {
+	t.Helper()
+	testutil.Eventually(
+		require.New(t),
+		condition,
+		testutil.WithWaitFor(time.Second),
+		testutil.WithTickInterval(time.Millisecond),
+	)
 }
 
 func waitForNoStreamMetrics(t *testing.T, reg prometheus.Gatherer) {
 	t.Helper()
-	var gatherErr error
-	testutil.Eventually(
-		require.New(t),
-		func() bool {
-			var count int
-			count, err := streamMetricCount(reg)
-			if err != nil {
-				gatherErr = err
-				return true
-			}
-			return count == 0
-		},
-		testutil.WithWaitFor(time.Second),
-		testutil.WithTickInterval(time.Millisecond),
-	)
-	require.NoError(t, gatherErr)
+	waitForStreamMetrics(t, func() bool {
+		return streamMetricCount(t, reg) == 0
+	})
 }
 
 func TestMetricsStreamLifecycle(t *testing.T) {
 	re := require.New(t)
-	reg, h := newTestStreamMetrics(t)
+	reg, collector := newTestStreamMetrics(t)
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
-	stream1 := newTestMetricsStream(ctx1, h, "my-rpc", testTarget)
-	stream2 := newTestMetricsStream(ctx2, h, "my-rpc", testTarget)
+	stream1 := newTestMetricsStream(ctx1, collector, "my-rpc", testTarget)
+	stream2 := newTestMetricsStream(ctx2, collector, "my-rpc", testTarget)
 	re.NoError(stream1.Send("first"))
 	re.NoError(stream2.Send("second"))
-	metricCount, err := streamMetricCount(reg)
-	re.NoError(err)
-	re.Equal(1, metricCount)
-
-	key := streamChildKey{request: "my-rpc", target: testTarget}
-	h.mu.Lock()
-	refs := h.children[key]
-	h.mu.Unlock()
-	re.Equal(2, refs)
+	re.Equal(1, streamMetricCount(t, reg))
+	re.Equal(2, childRefs(collector, "my-rpc", testTarget))
 
 	cancel1()
-	testutil.Eventually(
-		re,
-		func() bool {
-			h.mu.Lock()
-			defer h.mu.Unlock()
-			return h.children[key] == 1
-		},
-		testutil.WithWaitFor(time.Second),
-		testutil.WithTickInterval(time.Millisecond),
-	)
-	metricCount, err = streamMetricCount(reg)
-	re.NoError(err)
-	re.Equal(1, metricCount)
+	waitForStreamMetrics(t, func() bool {
+		return childRefs(collector, "my-rpc", testTarget) == 1
+	})
+	re.Equal(1, streamMetricCount(t, reg))
 	re.NoError(stream2.Send("still-active"))
-	count, ok, err := streamMetricSampleCount(reg, "my-rpc")
-	re.NoError(err)
+	count, ok := streamMetricSampleCount(t, reg, "my-rpc")
 	re.True(ok)
 	re.Equal(uint64(3), count)
 
@@ -181,14 +167,13 @@ func TestMetricsStreamLifecycle(t *testing.T) {
 
 func TestMetricsStreamReconnect(t *testing.T) {
 	re := require.New(t)
-	reg, h := newTestStreamMetrics(t)
+	reg, collector := newTestStreamMetrics(t)
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	stream1 := newTestMetricsStream(ctx1, h, "my-rpc", testTarget)
+	stream1 := newTestMetricsStream(ctx1, collector, "my-rpc", testTarget)
 	re.NoError(stream1.Send("first"))
 	re.NoError(stream1.Send("second"))
-	count, ok, err := streamMetricSampleCount(reg, "my-rpc")
-	re.NoError(err)
+	count, ok := streamMetricSampleCount(t, reg, "my-rpc")
 	re.True(ok)
 	re.Equal(uint64(2), count)
 
@@ -197,10 +182,9 @@ func TestMetricsStreamReconnect(t *testing.T) {
 
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
-	stream2 := newTestMetricsStream(ctx2, h, "my-rpc", testTarget)
+	stream2 := newTestMetricsStream(ctx2, collector, "my-rpc", testTarget)
 	re.NoError(stream2.Send("reconnected"))
-	count, ok, err = streamMetricSampleCount(reg, "my-rpc")
-	re.NoError(err)
+	count, ok = streamMetricSampleCount(t, reg, "my-rpc")
 	re.True(ok)
 	re.Equal(uint64(1), count)
 
@@ -210,58 +194,41 @@ func TestMetricsStreamReconnect(t *testing.T) {
 
 func TestMetricsStreamLabelIsolation(t *testing.T) {
 	re := require.New(t)
-	reg, h := newTestStreamMetrics(t)
+	reg, collector := newTestStreamMetrics(t)
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
-	stream1 := newTestMetricsStream(ctx1, h, "first-rpc", testTarget)
-	stream2 := newTestMetricsStream(ctx2, h, "second-rpc", testTarget)
+	stream1 := newTestMetricsStream(ctx1, collector, "first-rpc", testTarget)
+	stream2 := newTestMetricsStream(ctx2, collector, "second-rpc", testTarget)
 	re.NoError(stream1.Send("first"))
 	re.NoError(stream2.Send("second"))
-	metricCount, err := streamMetricCount(reg)
-	re.NoError(err)
-	re.Equal(2, metricCount)
+	re.Equal(2, streamMetricCount(t, reg))
 
 	cancel1()
-	var gatherErr error
-	testutil.Eventually(
-		re,
-		func() bool {
-			_, firstExists, err := streamMetricSampleCount(reg, "first-rpc")
-			if err != nil {
-				gatherErr = err
-				return true
-			}
-			secondCount, secondExists, err := streamMetricSampleCount(reg, "second-rpc")
-			if err != nil {
-				gatherErr = err
-				return true
-			}
-			return !firstExists && secondExists && secondCount == 1
-		},
-		testutil.WithWaitFor(time.Second),
-		testutil.WithTickInterval(time.Millisecond),
-	)
-	re.NoError(gatherErr)
+	waitForStreamMetrics(t, func() bool {
+		_, firstExists := streamMetricSampleCount(t, reg, "first-rpc")
+		secondCount, secondExists := streamMetricSampleCount(t, reg, "second-rpc")
+		return !firstExists && secondExists && secondCount == 1
+	})
 
 	cancel2()
 	waitForNoStreamMetrics(t, reg)
 }
 
 func TestMetricsStreamAlreadyCanceled(t *testing.T) {
-	reg, h := newTestStreamMetrics(t)
+	reg, collector := newTestStreamMetrics(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	newTestMetricsStream(ctx, h, "my-rpc", testTarget)
+	newTestMetricsStream(ctx, collector, "my-rpc", testTarget)
 
 	waitForNoStreamMetrics(t, reg)
 }
 
 func TestMetricsStreamConcurrentLifecycle(t *testing.T) {
-	reg, h := newTestStreamMetrics(t)
+	reg, collector := newTestStreamMetrics(t)
 
 	const streamCount = 128
 	var wg sync.WaitGroup
@@ -272,7 +239,7 @@ func TestMetricsStreamConcurrentLifecycle(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			newTestMetricsStream(
 				ctx,
-				h,
+				collector,
 				fmt.Sprintf("rpc-%d", i%4),
 				fmt.Sprintf("10.0.1.%d", i%8+1),
 			)
@@ -287,17 +254,14 @@ func TestMetricsStreamConcurrentLifecycle(t *testing.T) {
 func TestMetricsStream(t *testing.T) {
 	t.Run("SendAndRecv", func(t *testing.T) {
 		re := require.New(t)
-		reg := prometheus.NewRegistry()
-		h := NewGRPCStreamSendDuration("test", "stream")
-		re.NoError(reg.Register(h))
+		reg, collector := newTestStreamMetrics(t)
 
 		var sent []string
-		fake := newFakeStreamWithPeer()
 		s := NewMetricsStream[string, string](
-			fake,
+			newFakeStreamWithPeer(),
 			func(m string) error { sent = append(sent, m); return nil },
 			func() (string, error) { return "data", nil },
-			h, "my-rpc",
+			collector, "my-rpc",
 		)
 
 		re.NoError(s.Send("a"))
@@ -321,10 +285,9 @@ func TestMetricsStream(t *testing.T) {
 		re := require.New(t)
 		sendErr := errors.New("send failed")
 		recvErr := errors.New("recv failed")
-		fake := newFakeStreamWithPeer()
 
 		s := NewMetricsStream[string, string](
-			fake,
+			newFakeStreamWithPeer(),
 			func(string) error { return sendErr },
 			func() (string, error) { return "", recvErr },
 			nil, "",
@@ -364,17 +327,15 @@ func TestMetricsStream(t *testing.T) {
 
 	t.Run("NilStream", func(t *testing.T) {
 		re := require.New(t)
-		reg, h := newTestStreamMetrics(t)
+		reg, collector := newTestStreamMetrics(t)
 		s := NewMetricsStream[string, string](
 			nil,
 			func(string) error { return nil },
 			nil,
-			h, "my-rpc",
+			collector, "my-rpc",
 		)
 		re.NoError(s.Send("no-stream"))
-		metricCount, err := streamMetricCount(reg)
-		re.NoError(err)
-		re.Equal(0, metricCount)
+		re.Equal(0, streamMetricCount(t, reg))
 	})
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11040

gRPC stream duration metrics retain a histogram child for every historical `(request, peer IP)` label pair until the process restarts, causing stale series to accumulate in `/metrics` after clients disconnect.

### What is changed and how does it work?

```commit-message
Replace the raw HistogramVec with a lifecycle-aware collector that tracks active streams by request and peer IP.

Acquire the histogram child and increment its reference count under one lock. Register context.AfterFunc on the server stream context to decrement the count and delete the child after the last matching stream ends.

Keep the HistogramVec private so child creation and deletion cannot bypass the lifecycle lock. Preserve the existing metric names, labels, and Send hot path.
```

### Performance

These are package-level microbenchmarks of the metrics wrapper, not end-to-end gRPC benchmarks.

**Environment:** Apple M4 (10 cores, 24 GiB), macOS 27.0 (`darwin/arm64`), Go 1.26.5, `GOMAXPROCS=10`. The base revision is `f7db42521` and the PR revision is `033149448`. Each benchmark used a fixed iteration count and 10 independent runs, summarized with `benchstat`. The common benchmark body was identical between revisions; revision-specific adapters only account for the base revision having no release state to await.

| Operation | Iterations per run | Base | PR | Difference |
| --- | ---: | ---: | ---: | ---: |
| Steady-state `Send` | 5,000,000 | 64.51 ns/op ±2%, 0 B/op, 0 allocs/op | 65.00 ns/op ±2%, 0 B/op, 0 allocs/op | No significant difference (`p=0.190`) |
| Shared-label `NewMetricsStream` | 100,000 | 126.6 ns/op ±5%, 80 B/op, 4 allocs/op | 373.5 ns/op ±4%, 624 B/op, 10 allocs/op | +246.9 ns/op, +544 B/op, +6 allocs/op |
| Shared-label cancel -> asynchronous refcount release | 100,000 | 31.01 ns/op ±5%, 0 B/op, 0 allocs/op | 571.05 ns/op ±1%, 0 B/op, 0 allocs/op | +540.0 ns/op |
| Single-owner create -> cancel -> delete/recreate | 10,000 | 138.7 ns/op ±7%, 80 B/op, 4 allocs/op | 2,125.5 ns/op ±2%, 2,184 B/op, 26 allocs/op | +1.987 µs/op, +2,104 B/op, +22 allocs/op |

The steady-state `Send` path has no measurable regression, which is consistent with its source code being unchanged. The shared-label setup and release benchmarks isolate lifecycle bookkeeping: all streams use the same `(request, target)` key, and only the final cancellation deletes the histogram child. Their combined incremental cost is approximately 0.79 µs and 544 B with 6 allocations per stream lifecycle.

The single-owner benchmark represents short-lived stream churn: every PR iteration transitions the refcount from 1 to 0, deletes the child, and recreates it on the next iteration. Its additional cost is approximately 1.99 µs, 2.1 KiB, and 22 allocations per complete stream lifecycle. This remains a one-time lifecycle cost rather than a per-message cost.

For the PR revision, cancellation benchmarks wait for the asynchronous `context.AfterFunc` release to complete, so the reported values include goroutine scheduling and cleanup completion. The gRPC teardown path itself does not synchronously wait for this cleanup.

**Limitations:** These microbenchmarks do not measure complete RPC latency or throughput, concurrent reconnect storms, Prometheus scrape contention, or the expected memory and scrape-size reduction from removing stale series.

<details>
<summary>Benchmark semantics and commands</summary>

- `Send`: the wrapper and observer are initialized before timing; the timed region only calls `Send`.
- Shared-label setup: cancellable contexts and stream stubs are prepared before timing; the timed region only calls `NewMetricsStream`.
- Shared-label cancellation: 100,000 streams share one label key; the PR benchmark waits for each refcount decrement, and only the final iteration calls `DeleteLabelValues`.
- Single-owner lifecycle: each iteration creates the only stream for one label key, cancels it, and waits for refcount 1 -> 0; the PR deletes and recreates the child on every iteration, while the base retains and reuses it.
- The temporary benchmark harness was applied to detached worktrees for both revisions and removed afterward.

```bash
GOMAXPROCS=10 go test ./pkg/utils/grpcutil -run '^$' -bench '^BenchmarkMetricsStreamSend$' -benchmem -benchtime=5000000x -count=10
GOMAXPROCS=10 go test ./pkg/utils/grpcutil -run '^$' -bench '^BenchmarkNewMetricsStream$' -benchmem -benchtime=100000x -count=10
GOMAXPROCS=10 go test ./pkg/utils/grpcutil -run '^$' -bench '^BenchmarkMetricsStreamCancel$' -benchmem -benchtime=100000x -count=10
GOMAXPROCS=10 go test ./pkg/utils/grpcutil -run '^$' -bench '^BenchmarkMetricsStreamSingleOwnerLifecycle$' -benchmem -benchtime=10000x -count=10
```

Results were compared with `golang.org/x/perf/cmd/benchstat` at `v0.0.0-20260709024250-82a0b07e230d`.

</details>

### Check List

Tests

- Unit test

Side effects

- Increased code complexity
- Breaking backward compatibility: `NewGRPCStreamSendDuration` now returns `*StreamSendDurationCollector`, and `NewMetricsStream` accepts that collector instead of `*prometheus.HistogramVec`.

Related changes

- Need to cherry-pick to `release-nextgen-202603`

### Release note

```release-note
Prevent disconnected gRPC clients from leaving stale peer IP label series in PD and microservice metrics endpoints.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Upgraded gRPC stream send-duration metrics to use a dedicated collector that tracks active label sets and automatically removes stale series.
  * Metrics are now tied to stream context lifecycle for reliable cleanup across cancellation, reconnection, and concurrent streams.
  * Nil streams no longer create stream metrics.

* **Tests**
  * Expanded coverage for stream lifecycle, concurrent initialization/reference counting, metrics cleanup on cancellation, label isolation across concurrent streams, reconnect behavior, already-canceled contexts, and concurrent stress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
