### PR TITLE
mcs: reject registration reusing another instance's address

### DIFF
--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -16,6 +16,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -31,6 +32,14 @@ import (
 
 // DefaultLeaseInSeconds is the default lease time in seconds.
 const DefaultLeaseInSeconds = 5
+
+// registerRetryInterval is the interval to retry the registration when the
+// registry key is occupied by a stale entry that has not expired yet.
+const registerRetryInterval = time.Second
+
+// errServiceAddrOccupied indicates that the registry key of the advertised
+// address is already claimed by another live instance.
+var errServiceAddrOccupied = errors.New("service registry key is occupied by another live instance")
 
 // ServiceRegister is used to register the service to etcd.
 type ServiceRegister struct {
@@ -58,7 +67,28 @@ func NewServiceRegister(ctx context.Context, cli *clientv3.Client, serviceName, 
 
 // Register registers the service to etcd.
 func (sr *ServiceRegister) Register() error {
-	id, err := sr.putWithTTL()
+	var (
+		id  clientv3.LeaseID
+		err error
+	)
+	// A stale registry entry left by a crashed instance with the same advertised
+	// address will be removed automatically once its lease expires, so retry
+	// within the lease TTL before giving up.
+	deadline := time.Now().Add(time.Duration(sr.ttl+1) * time.Second)
+	for {
+		id, err = sr.putWithTTL()
+		if err == nil || !errors.Is(err, errServiceAddrOccupied) || time.Now().After(deadline) {
+			break
+		}
+		log.Warn("the service registry key is occupied, retrying",
+			zap.String("key", sr.key), zap.Error(err))
+		select {
+		case <-sr.ctx.Done():
+			sr.cancel()
+			return fmt.Errorf("register the key %s canceled: %w", sr.key, sr.ctx.Err())
+		case <-time.After(registerRetryInterval):
+		}
+	}
 	if err != nil {
 		sr.cancel()
 		return fmt.Errorf("put the key with lease %s failed: %v", sr.key, err)
@@ -111,10 +141,65 @@ func (sr *ServiceRegister) renewKeepalive() <-chan *clientv3.LeaseKeepAliveRespo
 	}
 }
 
+// putWithTTL claims the registry key with a new lease. To prevent an instance
+// that advertises a duplicate address from overwriting the registry entry of
+// another live instance (and further joining the primary election with the
+// same identity), the key is only claimed when it does not exist yet, or when
+// it still holds this instance's own value.
 func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	ctx, cancel := context.WithTimeout(sr.ctx, etcdutil.DefaultRequestTimeout)
 	defer cancel()
-	return etcdutil.EtcdKVPutWithTTL(ctx, sr.cli, sr.key, sr.value, sr.ttl)
+	grantResp, err := sr.cli.Grant(ctx, sr.ttl)
+	if err != nil {
+		return 0, err
+	}
+	leaseID := grantResp.ID
+	put := clientv3.OpPut(sr.key, sr.value, clientv3.WithLease(leaseID))
+	resp, err := sr.cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.CreateRevision(sr.key), "=", 0)).
+		Then(put).
+		Else(clientv3.OpGet(sr.key)).
+		Commit()
+	if err != nil {
+		sr.revokeLease(ctx, leaseID)
+		return 0, err
+	}
+	if resp.Succeeded {
+		return leaseID, nil
+	}
+	// The key already exists. If it holds a different value, it is claimed by
+	// another live instance, so reject the registration instead of overwriting
+	// the entry.
+	kvs := resp.Responses[0].GetResponseRange().Kvs
+	if len(kvs) > 0 && string(kvs[0].Value) != sr.value {
+		sr.revokeLease(ctx, leaseID)
+		return 0, fmt.Errorf("key %s, existing value %s: %w", sr.key, string(kvs[0].Value), errServiceAddrOccupied)
+	}
+	// The key still holds this instance's own value (e.g. re-registering after
+	// a keepalive failure while the previous lease has not expired yet), take
+	// it over with the new lease.
+	takeoverResp, err := sr.cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.Value(sr.key), "=", sr.value)).
+		Then(put).
+		Commit()
+	if err != nil {
+		sr.revokeLease(ctx, leaseID)
+		return 0, err
+	}
+	if !takeoverResp.Succeeded {
+		// The key changed in between, let the caller retry.
+		sr.revokeLease(ctx, leaseID)
+		return 0, fmt.Errorf("key %s changed during the takeover: %w", sr.key, errServiceAddrOccupied)
+	}
+	return leaseID, nil
+}
+
+// revokeLease revokes the lease in a best-effort manner to avoid leaking it
+// when the registration fails.
+func (sr *ServiceRegister) revokeLease(ctx context.Context, leaseID clientv3.LeaseID) {
+	if _, err := sr.cli.Revoke(ctx, leaseID); err != nil {
+		log.Warn("revoke the lease failed", zap.String("key", sr.key), zap.Error(err))
+	}
 }
 
 // Deregister deregisters the service from etcd.

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -37,6 +37,13 @@ const DefaultLeaseInSeconds = 5
 // registry key is occupied by a stale entry that has not expired yet.
 const registerRetryInterval = time.Second
 
+// registerRetryMargin is added on top of the lease TTL when computing the
+// retry deadline. An etcd leader change extends every lease's expiry by up
+// to the cluster's election timeout (see (*lessor).Promote and Lease.refresh
+// in etcd's lease package), so a stale entry can outlive its raw TTL; retry
+// long enough to cover that instead of giving up early.
+const registerRetryMargin = 5 * time.Second
+
 // errServiceAddrOccupied indicates that the registry key of the advertised
 // address is already claimed by another live instance.
 var errServiceAddrOccupied = errors.New("service registry key is occupied by another live instance")
@@ -49,6 +56,11 @@ type ServiceRegister struct {
 	key    string
 	value  string
 	ttl    int64
+	// leaseID is the lease this instance most recently registered the key
+	// with, used to prove ownership of an existing entry on re-registration.
+	// Zero (clientv3.NoLease) until the first successful put, so a freshly
+	// started process can never match an existing key's lease by accident.
+	leaseID clientv3.LeaseID
 }
 
 // NewServiceRegister creates a new ServiceRegister.
@@ -74,7 +86,7 @@ func (sr *ServiceRegister) Register() error {
 	// A stale registry entry left by a crashed instance with the same advertised
 	// address will be removed automatically once its lease expires, so retry
 	// within the lease TTL before giving up.
-	deadline := time.Now().Add(time.Duration(sr.ttl+1) * time.Second)
+	deadline := time.Now().Add(time.Duration(sr.ttl)*time.Second + registerRetryMargin)
 	for {
 		id, err = sr.putWithTTL()
 		if err == nil || !errors.Is(err, errServiceAddrOccupied) || time.Now().After(deadline) {
@@ -145,7 +157,8 @@ func (sr *ServiceRegister) renewKeepalive() <-chan *clientv3.LeaseKeepAliveRespo
 // that advertises a duplicate address from overwriting the registry entry of
 // another live instance (and further joining the primary election with the
 // same identity), the key is only claimed when it does not exist yet, or when
-// it still holds this instance's own value.
+// it is still backed by the lease this instance previously registered it
+// with.
 func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	ctx, cancel := context.WithTimeout(sr.ctx, etcdutil.DefaultRequestTimeout)
 	defer cancel()
@@ -165,21 +178,30 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 		return 0, err
 	}
 	if resp.Succeeded {
+		sr.leaseID = leaseID
 		return leaseID, nil
 	}
-	// The key already exists. If it holds a different value, it is claimed by
-	// another live instance, so reject the registration instead of overwriting
-	// the entry.
+	// The key already exists. Its value alone cannot prove it is this
+	// instance's own prior registration: ServiceRegistryEntry.StartTimestamp
+	// only has second precision, so two distinct instances started within
+	// the same second at the same address can serialize identically. Only
+	// take the key over when it is still backed by the lease this instance
+	// itself previously registered; otherwise treat it as claimed by another
+	// live instance (or a not-yet-expired entry from a prior process) and
+	// let the caller's retry loop wait for it to expire.
 	kvs := resp.Responses[0].GetResponseRange().Kvs
-	if len(kvs) > 0 && string(kvs[0].Value) != sr.value {
+	if len(kvs) == 0 || clientv3.LeaseID(kvs[0].Lease) != sr.leaseID {
+		existingValue := ""
+		if len(kvs) > 0 {
+			existingValue = string(kvs[0].Value)
+		}
 		sr.revokeLease(ctx, leaseID)
-		return 0, fmt.Errorf("key %s, existing value %s: %w", sr.key, string(kvs[0].Value), errServiceAddrOccupied)
+		return 0, fmt.Errorf("key %s, existing value %s: %w", sr.key, existingValue, errServiceAddrOccupied)
 	}
-	// The key still holds this instance's own value (e.g. re-registering after
-	// a keepalive failure while the previous lease has not expired yet), take
-	// it over with the new lease.
+	// Re-registering after a keepalive failure while the previous lease has
+	// not expired yet: take it over with the new lease.
 	takeoverResp, err := sr.cli.Txn(ctx).
-		If(clientv3.Compare(clientv3.Value(sr.key), "=", sr.value)).
+		If(clientv3.Compare(clientv3.LeaseValue(sr.key), "=", sr.leaseID)).
 		Then(put).
 		Commit()
 	if err != nil {
@@ -191,6 +213,7 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 		sr.revokeLease(ctx, leaseID)
 		return 0, fmt.Errorf("key %s changed during the takeover: %w", sr.key, errServiceAddrOccupied)
 	}
+	sr.leaseID = leaseID
 	return leaseID, nil
 }
 

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -190,7 +190,7 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	// live instance (or a not-yet-expired entry from a prior process) and
 	// let the caller's retry loop wait for it to expire.
 	kvs := resp.Responses[0].GetResponseRange().Kvs
-	if len(kvs) == 0 || clientv3.LeaseID(kvs[0].Lease) != sr.leaseID {
+	if len(kvs) == 0 || sr.leaseID == clientv3.NoLease || clientv3.LeaseID(kvs[0].Lease) != sr.leaseID {
 		existingValue := ""
 		if len(kvs) > 0 {
 			existingValue = string(kvs[0].Value)

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -37,11 +37,10 @@ const DefaultLeaseInSeconds = 5
 // registry key is occupied by a stale entry that has not expired yet.
 const registerRetryInterval = time.Second
 
-// registerRetryMargin is added on top of the lease TTL when computing the
-// retry deadline. An etcd leader change extends every lease's expiry by up
-// to the cluster's election timeout (see (*lessor).Promote and Lease.refresh
-// in etcd's lease package), so a stale entry can outlive its raw TTL; retry
-// long enough to cover that instead of giving up early.
+// registerRetryMargin is added on top of a lease's TTL when computing the
+// retry deadline, to cover a single etcd leader change extending the lease's
+// expiry beyond its granted TTL (see (*lessor).Promote and Lease.refresh in
+// etcd's lease package) that happens after we last measured it.
 const registerRetryMargin = 5 * time.Second
 
 // errServiceAddrOccupied indicates that the registry key of the advertised
@@ -61,6 +60,16 @@ type ServiceRegister struct {
 	// Zero (clientv3.NoLease) until the first successful put, so a freshly
 	// started process can never match an existing key's lease by accident.
 	leaseID clientv3.LeaseID
+	// contendedLease and retryDeadline cache a one-time measurement of the
+	// lease currently occupying the key while Register is retrying: the
+	// first time a given lease ID is observed as occupying it, its actual
+	// GrantedTTL (which already reflects etcd's minimum-lease-TTL floor) is
+	// used to compute how long it could still take to expire, instead of
+	// guessing. They are deliberately not refreshed on every retry against
+	// the same lease ID, so a lease kept alive by a genuinely live owner
+	// does not push the deadline out indefinitely.
+	contendedLease clientv3.LeaseID
+	retryDeadline  time.Time
 }
 
 // NewServiceRegister creates a new ServiceRegister.
@@ -85,11 +94,20 @@ func (sr *ServiceRegister) Register() error {
 	)
 	// A stale registry entry left by a crashed instance with the same advertised
 	// address will be removed automatically once its lease expires, so retry
-	// within the lease TTL before giving up.
+	// within the lease TTL before giving up. This starting deadline is a
+	// fallback for before putWithTTL has measured the actual contending
+	// lease; once it has, sr.retryDeadline (based on that lease's real
+	// GrantedTTL) takes over if it implies a later deadline.
 	deadline := time.Now().Add(time.Duration(sr.ttl)*time.Second + registerRetryMargin)
 	for {
 		id, err = sr.putWithTTL()
-		if err == nil || !errors.Is(err, errServiceAddrOccupied) || time.Now().After(deadline) {
+		if err == nil || !errors.Is(err, errServiceAddrOccupied) {
+			break
+		}
+		if sr.retryDeadline.After(deadline) {
+			deadline = sr.retryDeadline
+		}
+		if time.Now().After(deadline) {
 			break
 		}
 		log.Warn("the service registry key is occupied, retrying",
@@ -194,6 +212,7 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 		existingValue := ""
 		if len(kvs) > 0 {
 			existingValue = string(kvs[0].Value)
+			sr.observeContendedLease(ctx, clientv3.LeaseID(kvs[0].Lease))
 		}
 		sr.revokeLease(ctx, leaseID)
 		return 0, fmt.Errorf("key %s, existing value %s: %w", sr.key, existingValue, errServiceAddrOccupied)
@@ -215,6 +234,28 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	}
 	sr.leaseID = leaseID
 	return leaseID, nil
+}
+
+// observeContendedLease records how long the lease currently occupying the
+// key could still take to expire, the first time this specific lease ID is
+// observed as occupying it. It deliberately does not re-measure on every
+// call against the same lease ID, so a lease kept alive by a genuinely live
+// owner does not push the retry deadline out indefinitely; only a change in
+// which lease is occupying the key (a new registration event) triggers a
+// fresh measurement. It uses GrantedTTL rather than the live, continuously
+// renewed TTL: GrantedTTL is fixed for the life of the lease and already
+// reflects etcd's own minimum-lease-TTL floor, so deriving the deadline from
+// it is correct for any configured election timeout without guessing.
+func (sr *ServiceRegister) observeContendedLease(ctx context.Context, existingLease clientv3.LeaseID) {
+	if existingLease == clientv3.NoLease || existingLease == sr.contendedLease {
+		return
+	}
+	ttlResp, err := sr.cli.TimeToLive(ctx, existingLease)
+	if err != nil || ttlResp.GrantedTTL <= 0 {
+		return
+	}
+	sr.contendedLease = existingLease
+	sr.retryDeadline = time.Now().Add(time.Duration(ttlResp.GrantedTTL)*time.Second + registerRetryMargin)
 }
 
 // revokeLease revokes the lease in a best-effort manner to avoid leaking it

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -242,20 +242,23 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 // call against the same lease ID, so a lease kept alive by a genuinely live
 // owner does not push the retry deadline out indefinitely; only a change in
 // which lease is occupying the key (a new registration event) triggers a
-// fresh measurement. It uses GrantedTTL rather than the live, continuously
-// renewed TTL: GrantedTTL is fixed for the life of the lease and already
-// reflects etcd's own minimum-lease-TTL floor, so deriving the deadline from
-// it is correct for any configured election timeout without guessing.
+// fresh measurement. It uses the observed remaining TTL rather than
+// GrantedTTL (the lease's original, unchanging duration): TimeToLive's TTL
+// reflects time.Until(expiry), which already includes any etcd leader
+// promotion that refreshed this lease's expiry before this measurement, on
+// top of the minimum-lease-TTL floor. registerRetryMargin then only needs to
+// cover a promotion that happens after this measurement, not one already
+// baked into GrantedTTL's ignorance of expiry updates.
 func (sr *ServiceRegister) observeContendedLease(ctx context.Context, existingLease clientv3.LeaseID) {
 	if existingLease == clientv3.NoLease || existingLease == sr.contendedLease {
 		return
 	}
 	ttlResp, err := sr.cli.TimeToLive(ctx, existingLease)
-	if err != nil || ttlResp.GrantedTTL <= 0 {
+	if err != nil || ttlResp.TTL <= 0 {
 		return
 	}
 	sr.contendedLease = existingLease
-	sr.retryDeadline = time.Now().Add(time.Duration(ttlResp.GrantedTTL)*time.Second + registerRetryMargin)
+	sr.retryDeadline = time.Now().Add(time.Duration(ttlResp.TTL)*time.Second + registerRetryMargin)
 }
 
 // revokeLease revokes the lease in a best-effort manner to avoid leaking it

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -47,6 +48,13 @@ const registerRetryMargin = 5 * time.Second
 // address is already claimed by another live instance.
 var errServiceAddrOccupied = errors.New("service registry key is occupied by another live instance")
 
+// errServiceAddrOccupiedPermanently indicates the registry key is held by an
+// entry with no lease attached. Such an entry is never cleaned up by etcd on
+// its own, so it is deliberately not classified as errServiceAddrOccupied:
+// Register's retry loop only retries the latter, since retrying against a
+// leaseless entry can never succeed.
+var errServiceAddrOccupiedPermanently = errors.New("service registry key is occupied by an entry with no lease and will never expire")
+
 // ServiceRegister is used to register the service to etcd.
 type ServiceRegister struct {
 	ctx    context.Context
@@ -72,6 +80,12 @@ type ServiceRegister struct {
 	contendedLease   clientv3.LeaseID
 	lastObservedTerm uint64
 	retryDeadline    time.Time
+	// wg tracks the background keepalive-renewal goroutine started by
+	// Register, so Deregister can wait for it to fully exit before reading
+	// leaseID: leaseID is otherwise only ever touched by that single
+	// goroutine once it starts, and reading it from Deregister's caller
+	// without waiting would race with it.
+	wg sync.WaitGroup
 }
 
 // NewServiceRegister creates a new ServiceRegister.
@@ -131,8 +145,10 @@ func (sr *ServiceRegister) Register() error {
 		sr.cancel()
 		return fmt.Errorf("keepalive failed: %v", err)
 	}
+	sr.wg.Add(1)
 	go func() {
 		defer logutil.LogPanic()
+		defer sr.wg.Done()
 		for {
 			select {
 			case <-sr.ctx.Done():
@@ -259,12 +275,17 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 
 // leaseOwnership reports whether an existing key backed by lease (read at
 // raft term term) is still backed by the lease this instance itself
-// previously registered it with. When it is not, it records a fresh
-// contended-lease measurement and returns the occupied error to propagate
-// to the caller.
+// previously registered it with. When it is not, it returns the occupied
+// error to propagate to the caller: errServiceAddrOccupiedPermanently when
+// the key has no lease attached (it will never expire on its own, so
+// retrying is pointless), otherwise errServiceAddrOccupied after recording
+// a fresh contended-lease measurement.
 func (sr *ServiceRegister) leaseOwnership(ctx context.Context, lease int64, value []byte, term uint64) (owned bool, err error) {
 	if sr.leaseID != clientv3.NoLease && clientv3.LeaseID(lease) == sr.leaseID {
 		return true, nil
+	}
+	if clientv3.LeaseID(lease) == clientv3.NoLease {
+		return false, fmt.Errorf("key %s, existing value %s: %w", sr.key, string(value), errServiceAddrOccupiedPermanently)
 	}
 	sr.observeContendedLease(ctx, clientv3.LeaseID(lease), term)
 	return false, fmt.Errorf("key %s, existing value %s: %w", sr.key, string(value), errServiceAddrOccupied)
@@ -312,11 +333,26 @@ func (sr *ServiceRegister) revokeLease(ctx context.Context, leaseID clientv3.Lea
 	}
 }
 
-// Deregister deregisters the service from etcd.
+// Deregister deregisters the service from etcd. It only deletes the key
+// while it is still backed by the lease this instance itself registered it
+// with: if that lease already expired and a different instance has since
+// claimed the same address, this instance may be shutting down long after
+// losing ownership, and must not delete the replacement's live
+// registration.
 func (sr *ServiceRegister) Deregister() error {
 	sr.cancel()
+	// Wait for the background keepalive-renewal goroutine to fully exit
+	// before reading leaseID: it is the only other thing that ever writes
+	// leaseID, and only while running.
+	sr.wg.Wait()
+	if sr.leaseID == clientv3.NoLease {
+		return nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(sr.ttl)*time.Second)
 	defer cancel()
-	_, err := sr.cli.Delete(ctx, sr.key)
+	_, err := sr.cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.LeaseValue(sr.key), "=", sr.leaseID)).
+		Then(clientv3.OpDelete(sr.key)).
+		Commit()
 	return err
 }

--- a/pkg/mcs/discovery/register.go
+++ b/pkg/mcs/discovery/register.go
@@ -60,16 +60,18 @@ type ServiceRegister struct {
 	// Zero (clientv3.NoLease) until the first successful put, so a freshly
 	// started process can never match an existing key's lease by accident.
 	leaseID clientv3.LeaseID
-	// contendedLease and retryDeadline cache a one-time measurement of the
-	// lease currently occupying the key while Register is retrying: the
-	// first time a given lease ID is observed as occupying it, its actual
-	// GrantedTTL (which already reflects etcd's minimum-lease-TTL floor) is
-	// used to compute how long it could still take to expire, instead of
-	// guessing. They are deliberately not refreshed on every retry against
-	// the same lease ID, so a lease kept alive by a genuinely live owner
-	// does not push the deadline out indefinitely.
-	contendedLease clientv3.LeaseID
-	retryDeadline  time.Time
+	// contendedLease, lastObservedTerm, and retryDeadline cache a
+	// measurement of the lease currently occupying the key while Register
+	// is retrying: it is (re-)measured when a different lease starts
+	// occupying the key, or when the etcd raft term has advanced since the
+	// last measurement (an etcd leader change, which is exactly when
+	// (*lessor).Promote can refresh a lease's expiry beyond what was last
+	// observed). A lease kept alive purely by a genuinely live owner's
+	// keepalive never changes the raft term, so this does not push the
+	// retry deadline out indefinitely for that case.
+	contendedLease   clientv3.LeaseID
+	lastObservedTerm uint64
+	retryDeadline    time.Time
 }
 
 // NewServiceRegister creates a new ServiceRegister.
@@ -96,8 +98,9 @@ func (sr *ServiceRegister) Register() error {
 	// address will be removed automatically once its lease expires, so retry
 	// within the lease TTL before giving up. This starting deadline is a
 	// fallback for before putWithTTL has measured the actual contending
-	// lease; once it has, sr.retryDeadline (based on that lease's real
-	// GrantedTTL) takes over if it implies a later deadline.
+	// lease; once it has, sr.retryDeadline (based on that lease's observed
+	// remaining TTL, see observeContendedLease) takes over if it implies a
+	// later deadline.
 	deadline := time.Now().Add(time.Duration(sr.ttl)*time.Second + registerRetryMargin)
 	for {
 		id, err = sr.putWithTTL()
@@ -180,6 +183,25 @@ func (sr *ServiceRegister) renewKeepalive() <-chan *clientv3.LeaseKeepAliveRespo
 func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	ctx, cancel := context.WithTimeout(sr.ctx, etcdutil.DefaultRequestTimeout)
 	defer cancel()
+
+	// Check first, without granting a lease: Grant and Revoke are both raft
+	// writes, so retrying every registerRetryInterval against a key that is
+	// still occupied by someone else would otherwise churn an unused lease
+	// through etcd on every single retry while waiting for it to expire.
+	// The actual claim below is still atomic, so a race between this check
+	// and that claim cannot cause incorrect behavior -- at worst it costs
+	// one wasted Grant/Revoke, exactly like every retry did before this
+	// check existed.
+	getResp, err := sr.cli.Get(ctx, sr.key)
+	if err != nil {
+		return 0, err
+	}
+	if len(getResp.Kvs) > 0 {
+		if owned, occupiedErr := sr.leaseOwnership(ctx, getResp.Kvs[0].Lease, getResp.Kvs[0].Value, getResp.Header.RaftTerm); !owned {
+			return 0, occupiedErr
+		}
+	}
+
 	grantResp, err := sr.cli.Grant(ctx, sr.ttl)
 	if err != nil {
 		return 0, err
@@ -208,14 +230,13 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	// live instance (or a not-yet-expired entry from a prior process) and
 	// let the caller's retry loop wait for it to expire.
 	kvs := resp.Responses[0].GetResponseRange().Kvs
-	if len(kvs) == 0 || sr.leaseID == clientv3.NoLease || clientv3.LeaseID(kvs[0].Lease) != sr.leaseID {
-		existingValue := ""
-		if len(kvs) > 0 {
-			existingValue = string(kvs[0].Value)
-			sr.observeContendedLease(ctx, clientv3.LeaseID(kvs[0].Lease))
-		}
+	if len(kvs) == 0 {
 		sr.revokeLease(ctx, leaseID)
-		return 0, fmt.Errorf("key %s, existing value %s: %w", sr.key, existingValue, errServiceAddrOccupied)
+		return 0, fmt.Errorf("key %s, existing value : %w", sr.key, errServiceAddrOccupied)
+	}
+	if owned, occupiedErr := sr.leaseOwnership(ctx, kvs[0].Lease, kvs[0].Value, resp.Header.RaftTerm); !owned {
+		sr.revokeLease(ctx, leaseID)
+		return 0, occupiedErr
 	}
 	// Re-registering after a keepalive failure while the previous lease has
 	// not expired yet: take it over with the new lease.
@@ -236,21 +257,42 @@ func (sr *ServiceRegister) putWithTTL() (clientv3.LeaseID, error) {
 	return leaseID, nil
 }
 
+// leaseOwnership reports whether an existing key backed by lease (read at
+// raft term term) is still backed by the lease this instance itself
+// previously registered it with. When it is not, it records a fresh
+// contended-lease measurement and returns the occupied error to propagate
+// to the caller.
+func (sr *ServiceRegister) leaseOwnership(ctx context.Context, lease int64, value []byte, term uint64) (owned bool, err error) {
+	if sr.leaseID != clientv3.NoLease && clientv3.LeaseID(lease) == sr.leaseID {
+		return true, nil
+	}
+	sr.observeContendedLease(ctx, clientv3.LeaseID(lease), term)
+	return false, fmt.Errorf("key %s, existing value %s: %w", sr.key, string(value), errServiceAddrOccupied)
+}
+
 // observeContendedLease records how long the lease currently occupying the
-// key could still take to expire, the first time this specific lease ID is
-// observed as occupying it. It deliberately does not re-measure on every
-// call against the same lease ID, so a lease kept alive by a genuinely live
-// owner does not push the retry deadline out indefinitely; only a change in
-// which lease is occupying the key (a new registration event) triggers a
-// fresh measurement. It uses the observed remaining TTL rather than
-// GrantedTTL (the lease's original, unchanging duration): TimeToLive's TTL
-// reflects time.Until(expiry), which already includes any etcd leader
-// promotion that refreshed this lease's expiry before this measurement, on
-// top of the minimum-lease-TTL floor. registerRetryMargin then only needs to
-// cover a promotion that happens after this measurement, not one already
-// baked into GrantedTTL's ignorance of expiry updates.
-func (sr *ServiceRegister) observeContendedLease(ctx context.Context, existingLease clientv3.LeaseID) {
-	if existingLease == clientv3.NoLease || existingLease == sr.contendedLease {
+// key could still take to expire. It (re-)measures only when the key is now
+// occupied by a different lease than last observed, or when term (the raft
+// term seen on the response that reported this occupation) has advanced
+// since the last measurement: a raft term only advances on an etcd leader
+// election, which is exactly when (*lessor).Promote can refresh a lease's
+// expiry beyond what was last observed, so this catches every such refresh
+// regardless of how many occur while waiting. It uses the observed
+// remaining TTL rather than GrantedTTL (the lease's original, unchanging
+// duration): TimeToLive's TTL reflects time.Until(expiry), which already
+// includes any such refresh that happened before this measurement, on top
+// of the minimum-lease-TTL floor. registerRetryMargin then only needs to
+// cover a refresh that happens after this specific measurement, before the
+// next one.
+//
+// A lease kept alive purely by a genuinely live owner's keepalive traffic
+// never advances the raft term, so this does not re-measure — and cannot
+// push the retry deadline out indefinitely — for that case.
+func (sr *ServiceRegister) observeContendedLease(ctx context.Context, existingLease clientv3.LeaseID, term uint64) {
+	if existingLease == clientv3.NoLease {
+		return
+	}
+	if existingLease == sr.contendedLease && term <= sr.lastObservedTerm {
 		return
 	}
 	ttlResp, err := sr.cli.TimeToLive(ctx, existingLease)
@@ -258,6 +300,7 @@ func (sr *ServiceRegister) observeContendedLease(ctx context.Context, existingLe
 		return
 	}
 	sr.contendedLease = existingLease
+	sr.lastObservedTerm = term
 	sr.retryDeadline = time.Now().Add(time.Duration(ttlResp.TTL)*time.Second + registerRetryMargin)
 }
 

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -93,6 +93,40 @@ func TestRegister(t *testing.T) {
 	etcd.Close()
 }
 
+func TestRegisterConflict(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Register the first instance.
+	sr1 := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "instance-1", 2)
+	re.NoError(sr1.Register())
+	// A second live instance with the same advertised address must not
+	// overwrite the registry entry of the first one.
+	sr2 := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "instance-2", 2)
+	err := sr2.Register()
+	re.Error(err)
+	re.Contains(err.Error(), "occupied")
+	resp, err := client.Get(ctx, sr1.key)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	re.Equal("instance-1", string(resp.Kvs[0].Value))
+
+	// After the first instance stops the keepalive (simulating a crash), the
+	// stale entry expires with its lease and a new instance with the same
+	// address can register within the retry window.
+	sr1.cancel()
+	sr3 := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "instance-3", 2)
+	re.NoError(sr3.Register())
+	resp, err = client.Get(ctx, sr3.key)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	re.Equal("instance-3", string(resp.Kvs[0].Value))
+	re.NoError(sr3.Deregister())
+}
+
 func getKeyAfterLeaseExpired(ctx context.Context, re *require.Assertions, client *clientv3.Client, key string) string {
 	time.Sleep(DefaultLeaseInSeconds * time.Second) // ensure that the lease is expired
 	time.Sleep(500 * time.Millisecond)              // wait for the etcd to clean up the expired keys

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -127,6 +127,34 @@ func TestRegisterConflict(t *testing.T) {
 	re.NoError(sr3.Deregister())
 }
 
+func TestRegisterConflictSameSerializedValue(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Two distinct instances that happen to serialize an identical registry
+	// entry (e.g. same address, started within the same StartTimestamp
+	// second) must not be able to take over each other's live registration:
+	// ownership must be proven by the lease actually held, not by value
+	// equality alone.
+	sr1 := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "same-value", 2)
+	re.NoError(sr1.Register())
+	sr2 := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "same-value", 2)
+	err := sr2.Register()
+	re.Error(err)
+	re.Contains(err.Error(), "occupied")
+
+	resp, err := client.Get(ctx, sr1.key)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	re.Equal("same-value", string(resp.Kvs[0].Value))
+	re.Equal(int64(sr1.leaseID), resp.Kvs[0].Lease)
+
+	re.NoError(sr1.Deregister())
+}
+
 func getKeyAfterLeaseExpired(ctx context.Context, re *require.Assertions, client *clientv3.Client, key string) string {
 	time.Sleep(DefaultLeaseInSeconds * time.Second) // ensure that the lease is expired
 	time.Sleep(500 * time.Millisecond)              // wait for the etcd to clean up the expired keys

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -213,6 +213,50 @@ func TestRegisterRetriesUntilExistingLeaseExpires(t *testing.T) {
 	re.NoError(replacement.Deregister())
 }
 
+func TestRegisterRetriesAfterLeaderPromotion(t *testing.T) {
+	re := require.New(t)
+	// A leader promotion refreshes a lease's expiry (Lessor.Promote /
+	// Lease.refresh) to beyond its original GrantedTTL; the retry deadline
+	// must reflect that when it has already happened before the first
+	// measurement, not just the lease's unchanging granted duration.
+	servers, client, clean := etcdutil.NewTestEtcdCluster(t, 1, &etcdutil.TestEtcdClusterOptions{
+		ServerCfgModifier: func(cfg *embed.Config) {
+			cfg.TickMs = 100
+			cfg.ElectionMs = 10000
+		},
+	})
+	defer clean()
+
+	etcd, cfg := servers[0], servers[0].Config()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	old := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "old", DefaultLeaseInSeconds)
+	re.NoError(old.Register())
+	resp, err := client.Get(ctx, old.key)
+	re.NoError(err)
+	oldLease := clientv3.LeaseID(resp.Kvs[0].Lease)
+	old.cancel()
+
+	// Restarting the single-member cluster forces a new leader election,
+	// triggering Promote on the surviving lease.
+	etcd.Server.HardStop()
+	etcd.Close()
+	etcd, err = embed.StartEtcd(&cfg)
+	re.NoError(err)
+	defer etcd.Close()
+	<-etcd.Server.ReadyNotify()
+
+	ttl, err := client.TimeToLive(ctx, oldLease)
+	re.NoError(err)
+	// The promotion pushed the actual remaining TTL past GrantedTTL+margin.
+	re.Greater(ttl.TTL, ttl.GrantedTTL+int64(registerRetryMargin/time.Second))
+
+	replacement := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "replacement", DefaultLeaseInSeconds)
+	re.NoError(replacement.Register())
+	re.NoError(replacement.Deregister())
+}
+
 func getKeyAfterLeaseExpired(ctx context.Context, re *require.Assertions, client *clientv3.Client, key string) string {
 	time.Sleep(DefaultLeaseInSeconds * time.Second) // ensure that the lease is expired
 	time.Sleep(500 * time.Millisecond)              // wait for the etcd to clean up the expired keys

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -175,6 +175,44 @@ func TestRegisterRejectsUnleasedExistingKey(t *testing.T) {
 	re.Contains(err.Error(), "occupied")
 }
 
+func TestRegisterRetriesUntilExistingLeaseExpires(t *testing.T) {
+	re := require.New(t)
+	// A larger election timeout than the registry TTL raises etcd's
+	// minimum-lease-TTL floor above the requested TTL, so the stale key's
+	// actual lease outlives a retry deadline computed from the raw TTL alone.
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, &etcdutil.TestEtcdClusterOptions{
+		ServerCfgModifier: func(cfg *embed.Config) {
+			cfg.TickMs = 100
+			cfg.ElectionMs = 10000
+		},
+	})
+	defer clean()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	old := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "old", DefaultLeaseInSeconds)
+	re.NoError(old.Register())
+	resp, err := client.Get(ctx, old.key)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	oldLease := clientv3.LeaseID(resp.Kvs[0].Lease)
+	old.cancel()
+
+	ttl, err := client.TimeToLive(ctx, oldLease)
+	re.NoError(err)
+	// The actual stale lease outlives the fixed 5s+5s deadline this
+	// regression guards against.
+	re.Greater(ttl.TTL, int64(10))
+
+	replacement := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "replacement", DefaultLeaseInSeconds)
+	re.NoError(replacement.Register())
+	resp, err = client.Get(ctx, replacement.key)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	re.Equal("replacement", string(resp.Kvs[0].Value))
+	re.NoError(replacement.Deregister())
+}
+
 func getKeyAfterLeaseExpired(ctx context.Context, re *require.Assertions, client *clientv3.Client, key string) string {
 	time.Sleep(DefaultLeaseInSeconds * time.Second) // ensure that the lease is expired
 	time.Sleep(500 * time.Millisecond)              // wait for the etcd to clean up the expired keys

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -155,6 +155,26 @@ func TestRegisterConflictSameSerializedValue(t *testing.T) {
 	re.NoError(sr1.Deregister())
 }
 
+func TestRegisterRejectsUnleasedExistingKey(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sr := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "some-value", 2)
+	// Simulate a pre-existing registry key written without a lease. A fresh
+	// instance's leaseID is also the zero value (clientv3.NoLease), so
+	// comparing lease IDs alone could mistake this for its own prior
+	// registration and let it overwrite the key.
+	_, err := client.Put(ctx, sr.key, "some-value")
+	re.NoError(err)
+
+	err = sr.Register()
+	re.Error(err)
+	re.Contains(err.Error(), "occupied")
+}
+
 func getKeyAfterLeaseExpired(ctx context.Context, re *require.Assertions, client *clientv3.Client, key string) string {
 	time.Sleep(DefaultLeaseInSeconds * time.Second) // ensure that the lease is expired
 	time.Sleep(500 * time.Millisecond)              // wait for the etcd to clean up the expired keys

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -175,28 +175,55 @@ func TestRegisterRejectsUnleasedExistingKey(t *testing.T) {
 	re.Contains(err.Error(), "occupied")
 }
 
-func TestRegisterRetriesUntilExistingLeaseExpires(t *testing.T) {
-	re := require.New(t)
-	// A larger election timeout than the registry TTL raises etcd's
-	// minimum-lease-TTL floor above the requested TTL, so the stale key's
-	// actual lease outlives a retry deadline computed from the raw TTL alone.
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, &etcdutil.TestEtcdClusterOptions{
+// newLongElectionTestEtcdCluster starts a single-member test cluster whose
+// election timeout (10s) is longer than DefaultLeaseInSeconds, so etcd's
+// minimum-lease-TTL floor (roughly 1.5x the election timeout) and
+// leader-promotion lease refreshes are both exercised by the caller's test.
+func newLongElectionTestEtcdCluster(t *testing.T) ([]*embed.Etcd, *clientv3.Client, func()) {
+	return etcdutil.NewTestEtcdCluster(t, 1, &etcdutil.TestEtcdClusterOptions{
 		ServerCfgModifier: func(cfg *embed.Config) {
 			cfg.TickMs = 100
 			cfg.ElectionMs = 10000
 		},
 	})
-	defer clean()
+}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	old := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "old", DefaultLeaseInSeconds)
+// registerStaleEntry registers "old" at addr and then stops it without
+// deregistering (simulating a crash), leaving behind a stale-but-not-yet-
+// expired registry entry. It returns that entry's lease ID.
+func registerStaleEntry(ctx context.Context, re *require.Assertions, client *clientv3.Client, addr string) clientv3.LeaseID {
+	old := NewServiceRegister(ctx, client, "test_service", addr, "old", DefaultLeaseInSeconds)
 	re.NoError(old.Register())
 	resp, err := client.Get(ctx, old.key)
 	re.NoError(err)
 	re.Len(resp.Kvs, 1)
-	oldLease := clientv3.LeaseID(resp.Kvs[0].Lease)
 	old.cancel()
+	return clientv3.LeaseID(resp.Kvs[0].Lease)
+}
+
+// restartSingleMemberEtcd forces a new leader election on a single-member
+// test cluster by hard-stopping and restarting it, triggering
+// (*lessor).Promote on any surviving leases.
+func restartSingleMemberEtcd(re *require.Assertions, etcd *embed.Etcd, cfg embed.Config) *embed.Etcd {
+	etcd.Server.HardStop()
+	etcd.Close()
+	etcd, err := embed.StartEtcd(&cfg)
+	re.NoError(err)
+	<-etcd.Server.ReadyNotify()
+	return etcd
+}
+
+func TestRegisterRetriesUntilExistingLeaseExpires(t *testing.T) {
+	re := require.New(t)
+	// A larger election timeout than the registry TTL raises etcd's
+	// minimum-lease-TTL floor above the requested TTL, so the stale key's
+	// actual lease outlives a retry deadline computed from the raw TTL alone.
+	_, client, clean := newLongElectionTestEtcdCluster(t)
+	defer clean()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	oldLease := registerStaleEntry(ctx, re, client, "127.0.0.1:1")
 
 	ttl, err := client.TimeToLive(ctx, oldLease)
 	re.NoError(err)
@@ -206,7 +233,7 @@ func TestRegisterRetriesUntilExistingLeaseExpires(t *testing.T) {
 
 	replacement := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "replacement", DefaultLeaseInSeconds)
 	re.NoError(replacement.Register())
-	resp, err = client.Get(ctx, replacement.key)
+	resp, err := client.Get(ctx, replacement.key)
 	re.NoError(err)
 	re.Len(resp.Kvs, 1)
 	re.Equal("replacement", string(resp.Kvs[0].Value))
@@ -219,33 +246,19 @@ func TestRegisterRetriesAfterLeaderPromotion(t *testing.T) {
 	// Lease.refresh) to beyond its original GrantedTTL; the retry deadline
 	// must reflect that when it has already happened before the first
 	// measurement, not just the lease's unchanging granted duration.
-	servers, client, clean := etcdutil.NewTestEtcdCluster(t, 1, &etcdutil.TestEtcdClusterOptions{
-		ServerCfgModifier: func(cfg *embed.Config) {
-			cfg.TickMs = 100
-			cfg.ElectionMs = 10000
-		},
-	})
+	servers, client, clean := newLongElectionTestEtcdCluster(t)
 	defer clean()
 
 	etcd, cfg := servers[0], servers[0].Config()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	old := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "old", DefaultLeaseInSeconds)
-	re.NoError(old.Register())
-	resp, err := client.Get(ctx, old.key)
-	re.NoError(err)
-	oldLease := clientv3.LeaseID(resp.Kvs[0].Lease)
-	old.cancel()
+	oldLease := registerStaleEntry(ctx, re, client, "127.0.0.1:1")
 
 	// Restarting the single-member cluster forces a new leader election,
 	// triggering Promote on the surviving lease.
-	etcd.Server.HardStop()
-	etcd.Close()
-	etcd, err = embed.StartEtcd(&cfg)
-	re.NoError(err)
+	etcd = restartSingleMemberEtcd(re, etcd, cfg)
 	defer etcd.Close()
-	<-etcd.Server.ReadyNotify()
 
 	ttl, err := client.TimeToLive(ctx, oldLease)
 	re.NoError(err)
@@ -254,6 +267,49 @@ func TestRegisterRetriesAfterLeaderPromotion(t *testing.T) {
 
 	replacement := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "replacement", DefaultLeaseInSeconds)
 	re.NoError(replacement.Register())
+	re.NoError(replacement.Deregister())
+}
+
+func TestRegisterRetriesAfterPromotionFollowingTTLObservation(t *testing.T) {
+	re := require.New(t)
+	// A leader promotion that happens *after* the first TTL measurement of a
+	// contended lease must still be picked up: the retry deadline is a
+	// snapshot taken at measurement time, so without re-measuring on a
+	// later raft term change, a promotion occurring after that snapshot
+	// would otherwise stay invisible for the rest of the retry loop.
+	servers, client, clean := newLongElectionTestEtcdCluster(t)
+	defer clean()
+
+	etcd, cfg := servers[0], servers[0].Config()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	oldLease := registerStaleEntry(ctx, re, client, "127.0.0.1:1")
+
+	// Take the first measurement of the contended lease before any leader
+	// change has happened.
+	replacement := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "replacement", DefaultLeaseInSeconds)
+	_, err := replacement.putWithTTL()
+	re.Error(err)
+	re.Equal(oldLease, replacement.contendedLease)
+	cachedDeadline := replacement.retryDeadline
+	re.False(cachedDeadline.IsZero())
+	termAtFirstMeasurement := replacement.lastObservedTerm
+
+	// Restarting the single-member cluster forces a new leader election (a
+	// higher raft term), triggering Promote on the surviving lease -- after
+	// replacement's first measurement above.
+	etcd = restartSingleMemberEtcd(re, etcd, cfg)
+	defer etcd.Close()
+
+	ttl, err := client.TimeToLive(ctx, oldLease)
+	re.NoError(err)
+	// The promotion pushed the actual remaining TTL past the cached deadline.
+	re.Greater(ttl.TTL, int64(time.Until(cachedDeadline)/time.Second))
+
+	re.NoError(replacement.Register())
+	// A fresh measurement was taken, keyed off the advanced raft term.
+	re.Greater(replacement.lastObservedTerm, termAtFirstMeasurement)
 	re.NoError(replacement.Deregister())
 }
 

--- a/pkg/mcs/discovery/register_test.go
+++ b/pkg/mcs/discovery/register_test.go
@@ -127,6 +127,38 @@ func TestRegisterConflict(t *testing.T) {
 	re.NoError(sr3.Deregister())
 }
 
+func TestDeregisterDoesNotDeleteReplacementRegistration(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sr1 := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "instance-1", 2)
+	re.NoError(sr1.Register())
+	// sr1 stops renewing (simulating a lost connection) without ever
+	// deregistering, leaving a stale-but-not-yet-expired entry.
+	sr1.cancel()
+
+	// A different instance later claims the same address once the stale
+	// lease naturally expires.
+	sr2 := NewServiceRegister(ctx, client, "test_service", "127.0.0.1:1", "instance-2", 2)
+	re.NoError(sr2.Register())
+
+	// sr1 has no way of knowing it lost ownership; deregistering it now
+	// (e.g. a delayed shutdown call arriving after the fact) must not
+	// delete sr2's live registration.
+	re.NoError(sr1.Deregister())
+
+	resp, err := client.Get(ctx, sr1.key)
+	re.NoError(err)
+	re.Len(resp.Kvs, 1)
+	re.Equal("instance-2", string(resp.Kvs[0].Value))
+
+	re.NoError(sr2.Deregister())
+}
+
 func TestRegisterConflictSameSerializedValue(t *testing.T) {
 	re := require.New(t)
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
@@ -170,7 +202,12 @@ func TestRegisterRejectsUnleasedExistingKey(t *testing.T) {
 	_, err := client.Put(ctx, sr.key, "some-value")
 	re.NoError(err)
 
+	start := time.Now()
 	err = sr.Register()
+	// An unleased key can never expire on its own, so this must fail
+	// immediately instead of retrying until the ttl+registerRetryMargin
+	// fallback deadline (7s here).
+	re.Less(time.Since(start), 2*time.Second)
 	re.Error(err)
 	re.Contains(err.Error(), "occupied")
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11001, Close #10998

A microservice instance (TSO / Scheduling) started with an `--advertise-listen-addr` already used by another live instance could blindly overwrite that instance's etcd registry entry and then join the primary election with the same participant identity.

### What is changed and how does it work?

Validate the registry key at registration time in `pkg/mcs/discovery`:

- `putWithTTL` now claims the registry key with an atomic create-if-absent etcd transaction instead of an unconditional `Put`, so a duplicate advertised address can no longer overwrite another live instance's entry.
- If the key already exists with this instance's own value (e.g. re-registering after a keepalive failure while the previous lease is still alive), it is taken over with the new lease via a value-guarded transaction; otherwise the registration is rejected with a clear error and the granted lease is revoked.
- `Register` retries the claim within the lease TTL window, so a stale entry left by a crashed instance with the same address expires and the restart succeeds without manual intervention, while a genuine duplicate live instance keeps its lease refreshed and the orphan fails startup before ever entering the primary election (all MCS servers call `Register` before `startServer`).

### Check List

Tests

- Unit test: `TestRegisterConflict` verifies a duplicate live registration is rejected without overwriting the existing entry, and that a new instance can register after the stale lease expires.
- Integration test: `tests/integrations/mcs/discovery` passes.

### Release note

```release-note
Reject microservice registration when the advertised address is already claimed by another live instance, preventing registry overwrite and unintended primary election takeover.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service registration when another live instance is using the same address.
  * Prevented duplicate registrations from replacing active service entries, including entries with identical values.
  * Rejects conflicts with registry entries that are not associated with a valid lease.
  * Retries registration until the existing lease expires or the operation is canceled.
  * Adjusts retry timing for longer-lived leases, allowing registration to succeed after stale entries expire.
  * Allows registration to succeed after a stale service entry expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->