### PR TITLE
metrics: clean up inactive gRPC stream target series

### DIFF
--- a/pkg/mcs/metastorage/server/grpc_service.go
+++ b/pkg/mcs/metastorage/server/grpc_service.go
@@ -84,7 +84,8 @@ func (s *Service) checkServing() error {
 
 // Watch watches the key with a given prefix and revision.
 func (s *Service) Watch(req *meta_storagepb.WatchRequest, server meta_storagepb.MetaStorage_WatchServer) error {
-	server = newWatchMetricsStream(server)
+	server, closeMetrics := newWatchMetricsStream(server)
+	defer closeMetrics()
 	if err := s.checkServing(); err != nil {
 		return err
 	}

--- a/pkg/mcs/metastorage/server/metrics.go
+++ b/pkg/mcs/metastorage/server/metrics.go
@@ -33,6 +33,7 @@ func init() {
 	prometheus.MustRegister(grpcStreamSendDuration)
 }
 
-func newWatchMetricsStream(server meta_storagepb.MetaStorage_WatchServer) meta_storagepb.MetaStorage_WatchServer {
-	return grpcutil.NewMetricsStream[*meta_storagepb.WatchResponse, any](server, server.Send, nil, grpcStreamSendDuration, "watch")
+func newWatchMetricsStream(server meta_storagepb.MetaStorage_WatchServer) (meta_storagepb.MetaStorage_WatchServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup[*meta_storagepb.WatchResponse, any](server, server.Send, nil, grpcStreamSendDuration, "watch")
+	return metricsStream, metricsStream.Close
 }

--- a/pkg/mcs/resourcemanager/server/grpc_service.go
+++ b/pkg/mcs/resourcemanager/server/grpc_service.go
@@ -188,7 +188,8 @@ func (s *Service) ModifyResourceGroup(_ context.Context, req *rmpb.PutResourceGr
 
 // AcquireTokenBuckets implements ResourceManagerServer.AcquireTokenBuckets.
 func (s *Service) AcquireTokenBuckets(stream rmpb.ResourceManager_AcquireTokenBucketsServer) error {
-	stream = newAcquireTokenBucketsMetricsStream(stream)
+	stream, closeMetrics := newAcquireTokenBucketsMetricsStream(stream)
+	defer closeMetrics()
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/pkg/mcs/resourcemanager/server/metrics.go
+++ b/pkg/mcs/resourcemanager/server/metrics.go
@@ -622,6 +622,7 @@ func (t *maxPerSecCostTracker) flushMetrics() {
 	}
 }
 
-func newAcquireTokenBucketsMetricsStream(stream rmpb.ResourceManager_AcquireTokenBucketsServer) rmpb.ResourceManager_AcquireTokenBucketsServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "acquire-token-buckets")
+func newAcquireTokenBucketsMetricsStream(stream rmpb.ResourceManager_AcquireTokenBucketsServer) (rmpb.ResourceManager_AcquireTokenBucketsServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "acquire-token-buckets")
+	return metricsStream, metricsStream.Close
 }

--- a/pkg/mcs/router/server/grpc_service.go
+++ b/pkg/mcs/router/server/grpc_service.go
@@ -129,7 +129,8 @@ func (s *Service) GetRegionByID(_ctx context.Context, request *pdpb.GetRegionByI
 
 // QueryRegion implements the QueryRegion RPC method.
 func (s *Service) QueryRegion(stream routerpb.Router_QueryRegionServer) error {
-	stream = newQueryRegionMetricsStream(stream)
+	stream, closeMetrics := newQueryRegionMetricsStream(stream)
+	defer closeMetrics()
 	for {
 		request, err := stream.Recv()
 		if err == io.EOF {

--- a/pkg/mcs/router/server/metrics.go
+++ b/pkg/mcs/router/server/metrics.go
@@ -63,6 +63,7 @@ func init() {
 	prometheus.MustRegister(regionSyncerStatus)
 }
 
-func newQueryRegionMetricsStream(stream routerpb.Router_QueryRegionServer) routerpb.Router_QueryRegionServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "query-region")
+func newQueryRegionMetricsStream(stream routerpb.Router_QueryRegionServer) (routerpb.Router_QueryRegionServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "query-region")
+	return metricsStream, metricsStream.Close
 }

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -116,7 +116,8 @@ func (s *heartbeatServer) recv() (*schedulingpb.RegionHeartbeatRequest, error) {
 
 // RegionHeartbeat implements gRPC SchedulingServer.
 func (s *Service) RegionHeartbeat(stream schedulingpb.Scheduling_RegionHeartbeatServer) error {
-	wrappedStream := newRegionHeartbeatMetricsStream(stream)
+	wrappedStream, closeMetrics := newRegionHeartbeatMetricsStream(stream)
+	defer closeMetrics()
 	var (
 		server   = &heartbeatServer{stream: wrappedStream}
 		cancel   context.CancelFunc
@@ -183,7 +184,8 @@ func (s *Service) RegionHeartbeat(stream schedulingpb.Scheduling_RegionHeartbeat
 
 // RegionBuckets implements gRPC SchedulingServer.
 func (s *Service) RegionBuckets(stream schedulingpb.Scheduling_RegionBucketsServer) error {
-	stream = newRegionBucketsMetricsStream(stream)
+	stream, closeMetrics := newRegionBucketsMetricsStream(stream)
+	defer closeMetrics()
 	var cancel context.CancelFunc
 	defer func() {
 		// cancel the forward stream

--- a/pkg/mcs/scheduling/server/metrics.go
+++ b/pkg/mcs/scheduling/server/metrics.go
@@ -104,10 +104,12 @@ func init() {
 	prometheus.MustRegister(regionBucketsReportInterval)
 }
 
-func newRegionHeartbeatMetricsStream(stream schedulingpb.Scheduling_RegionHeartbeatServer) schedulingpb.Scheduling_RegionHeartbeatServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "region-heartbeat")
+func newRegionHeartbeatMetricsStream(stream schedulingpb.Scheduling_RegionHeartbeatServer) (schedulingpb.Scheduling_RegionHeartbeatServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "region-heartbeat")
+	return metricsStream, metricsStream.Close
 }
 
-func newRegionBucketsMetricsStream(stream schedulingpb.Scheduling_RegionBucketsServer) schedulingpb.Scheduling_RegionBucketsServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "region-buckets")
+func newRegionBucketsMetricsStream(stream schedulingpb.Scheduling_RegionBucketsServer) (schedulingpb.Scheduling_RegionBucketsServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "region-buckets")
+	return metricsStream, metricsStream.Close
 }

--- a/pkg/mcs/tso/server/grpc_service.go
+++ b/pkg/mcs/tso/server/grpc_service.go
@@ -79,7 +79,8 @@ func (s *Service) RegisterRESTHandler(userDefineHandlers map[string]http.Handler
 
 // Tso returns a stream of timestamps
 func (s *Service) Tso(stream tsopb.TSO_TsoServer) error {
-	stream = newTsoMetricsStream(stream)
+	stream, closeMetrics := newTsoMetricsStream(stream)
+	defer closeMetrics()
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 	for {

--- a/pkg/mcs/tso/server/metrics.go
+++ b/pkg/mcs/tso/server/metrics.go
@@ -60,6 +60,7 @@ func init() {
 	prometheus.MustRegister(tsoHandleDuration)
 }
 
-func newTsoMetricsStream(stream tsopb.TSO_TsoServer) tsopb.TSO_TsoServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "tso")
+func newTsoMetricsStream(stream tsopb.TSO_TsoServer) (tsopb.TSO_TsoServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "tso")
+	return metricsStream, metricsStream.Close
 }

--- a/pkg/utils/grpcutil/stream.go
+++ b/pkg/utils/grpcutil/stream.go
@@ -16,6 +16,7 @@ package grpcutil
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,6 +25,19 @@ import (
 
 	"github.com/tikv/pd/pkg/errs"
 )
+
+type streamMetricLabels struct {
+	hist    *prometheus.HistogramVec
+	request string
+	target  string
+}
+
+var streamMetrics = struct {
+	sync.Mutex
+	activeStreams map[streamMetricLabels]int
+}{
+	activeStreams: make(map[streamMetricLabels]int),
+}
 
 // NewGRPCStreamSendDuration creates a HistogramVec for measuring gRPC stream
 // Send operation durations, using consistent bucket settings across services.
@@ -36,6 +50,29 @@ func NewGRPCStreamSendDuration(namespace, subsystem string) *prometheus.Histogra
 			Help:      "Bucketed histogram of duration (s) of gRPC stream Send operations.",
 			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20), // 0.1ms ~ 52s
 		}, []string{"request", "target"})
+}
+
+func acquireStreamMetric(hist *prometheus.HistogramVec, stream grpc.ServerStream, request string) (prometheus.Observer, func()) {
+	labels := streamMetricLabels{hist: hist, request: request, target: targetIP(stream)}
+
+	streamMetrics.Lock()
+	observer := hist.WithLabelValues(labels.request, labels.target)
+	streamMetrics.activeStreams[labels]++
+	streamMetrics.Unlock()
+
+	var once sync.Once
+	return observer, func() {
+		once.Do(func() {
+			streamMetrics.Lock()
+			defer streamMetrics.Unlock()
+			if streamMetrics.activeStreams[labels] > 1 {
+				streamMetrics.activeStreams[labels]--
+				return
+			}
+			delete(streamMetrics.activeStreams, labels)
+			hist.DeleteLabelValues(labels.request, labels.target)
+		})
+	}
 }
 
 // targetIP extracts the target IP (without port) from a gRPC server stream's peer info.
@@ -69,6 +106,7 @@ type MetricsStream[SendT any, RecvT any] struct {
 	sendFn  func(SendT) error
 	recvFn  func() (RecvT, error)
 	sendObs prometheus.Observer
+	release func()
 }
 
 // NewMetricsStream creates a MetricsStream wrapping the given gRPC server stream.
@@ -91,6 +129,30 @@ func NewMetricsStream[SendT any, RecvT any](
 		sendFn:       sendFn,
 		recvFn:       recvFn,
 		sendObs:      obs,
+	}
+}
+
+// NewMetricsStreamWithCleanup creates a MetricsStream that removes the metric
+// labels after the last active stream for the same request and target closes.
+// Close must be called when the stream handler exits.
+func NewMetricsStreamWithCleanup[SendT any, RecvT any](
+	stream grpc.ServerStream,
+	sendFn func(SendT) error,
+	recvFn func() (RecvT, error),
+	hist *prometheus.HistogramVec,
+	requestLabel string,
+) *MetricsStream[SendT, RecvT] {
+	metricsStream := NewMetricsStream(stream, sendFn, recvFn, nil, requestLabel)
+	if hist != nil {
+		metricsStream.sendObs, metricsStream.release = acquireStreamMetric(hist, stream, requestLabel)
+	}
+	return metricsStream
+}
+
+// Close releases the stream's metric labels. It is safe to call more than once.
+func (s *MetricsStream[SendT, RecvT]) Close() {
+	if s.release != nil {
+		s.release()
 	}
 }
 

--- a/pkg/utils/grpcutil/stream_test.go
+++ b/pkg/utils/grpcutil/stream_test.go
@@ -56,7 +56,7 @@ func TestMetricsStream(t *testing.T) {
 
 		var sent []string
 		fake := newFakeStreamWithPeer()
-		s := NewMetricsStream[string, string](
+		s := NewMetricsStreamWithCleanup[string, string](
 			fake,
 			func(m string) error { sent = append(sent, m); return nil },
 			func() (string, error) { return "data", nil },
@@ -78,6 +78,53 @@ func TestMetricsStream(t *testing.T) {
 		re.Len(mfs, 1)
 		re.Equal("test_stream_grpc_stream_send_duration_seconds", mfs[0].GetName())
 		re.Equal(uint64(3), mfs[0].GetMetric()[0].GetHistogram().GetSampleCount())
+
+		s.Close()
+		mfs, err = reg.Gather()
+		re.NoError(err)
+		re.Empty(mfs)
+	})
+
+	t.Run("SharedTargetLifecycle", func(t *testing.T) {
+		re := require.New(t)
+		reg := prometheus.NewRegistry()
+		h := NewGRPCStreamSendDuration("test", "stream")
+		re.NoError(reg.Register(h))
+
+		fake := newFakeStreamWithPeer()
+		first := NewMetricsStreamWithCleanup[string, string](fake, func(string) error { return nil }, nil, h, "my-rpc")
+		second := NewMetricsStreamWithCleanup[string, string](fake, func(string) error { return nil }, nil, h, "my-rpc")
+		re.NoError(first.Send("first"))
+		re.NoError(second.Send("second"))
+
+		first.Close()
+		mfs, err := reg.Gather()
+		re.NoError(err)
+		re.Len(mfs, 1)
+		re.Equal(uint64(2), mfs[0].GetMetric()[0].GetHistogram().GetSampleCount())
+
+		second.Close()
+		second.Close()
+		mfs, err = reg.Gather()
+		re.NoError(err)
+		re.Empty(mfs)
+	})
+
+	t.Run("PersistentMetricLifecycle", func(t *testing.T) {
+		re := require.New(t)
+		reg := prometheus.NewRegistry()
+		h := NewGRPCStreamSendDuration("test", "stream")
+		re.NoError(reg.Register(h))
+
+		fake := newFakeStreamWithPeer()
+		s := NewMetricsStream[string, string](fake, func(string) error { return nil }, nil, h, "my-rpc")
+		re.NoError(s.Send("message"))
+		s.Close()
+
+		mfs, err := reg.Gather()
+		re.NoError(err)
+		re.Len(mfs, 1)
+		re.Equal(uint64(1), mfs[0].GetMetric()[0].GetHistogram().GetSampleCount())
 	})
 
 	t.Run("ErrorPropagation", func(t *testing.T) {

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -487,7 +487,8 @@ func findLeadersInMembers(members []*pdpb.Member, etcdLeaderID uint64, leader *p
 
 // Tso implements gRPC PDServer.
 func (s *GrpcServer) Tso(stream pdpb.PD_TsoServer) error {
-	stream = newTsoMetricsStream(stream)
+	stream, closeMetrics := newTsoMetricsStream(stream)
+	defer closeMetrics()
 	done, err := s.rateLimitCheck()
 	if err != nil {
 		return err
@@ -1252,7 +1253,8 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 
 // RegionHeartbeat implements gRPC PDServer.
 func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error {
-	stream = newRegionHeartbeatMetricsStream(stream)
+	stream, closeMetrics := newRegionHeartbeatMetricsStream(stream)
+	defer closeMetrics()
 	var (
 		server                      = &heartbeatServer{stream: stream}
 		flowRoundDivisor            = core.GetFlowRoundDivisorByDigit(s.persistOptions.GetPDServerConfig().FlowRoundByDigit)
@@ -1566,7 +1568,8 @@ func (s *GrpcServer) GetRegionByID(ctx context.Context, request *pdpb.GetRegionB
 
 // QueryRegion provides a stream processing of the region query.
 func (s *GrpcServer) QueryRegion(stream pdpb.PD_QueryRegionServer) error {
-	stream = newQueryRegionMetricsStream(stream)
+	stream, closeMetrics := newQueryRegionMetricsStream(stream)
+	defer closeMetrics()
 	done, err := s.rateLimitCheck()
 	if err != nil {
 		return err
@@ -2041,7 +2044,8 @@ func (s *GrpcServer) ScatterRegion(ctx context.Context, request *pdpb.ScatterReg
 
 // SyncRegions syncs the regions.
 func (s *GrpcServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
-	stream = newSyncRegionsMetricsStream(stream)
+	stream, closeMetrics := newSyncRegionsMetricsStream(stream)
+	defer closeMetrics()
 	if s.IsClosed() || s.cluster == nil {
 		return errs.ErrNotStarted
 	}
@@ -2478,7 +2482,8 @@ func (s *GrpcServer) LoadGlobalConfig(ctx context.Context, request *pdpb.LoadGlo
 // by Etcd.Watch() as long as the context has not been canceled or timed out.
 // Watch on revision which greater than or equal to the required revision.
 func (s *GrpcServer) WatchGlobalConfig(req *pdpb.WatchGlobalConfigRequest, server pdpb.PD_WatchGlobalConfigServer) error {
-	server = newWatchGlobalConfigMetricsStream(server)
+	server, closeMetrics := newWatchGlobalConfigMetricsStream(server)
+	defer closeMetrics()
 	if s.client == nil {
 		return errs.ErrEtcdNotStarted
 	}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -246,29 +246,34 @@ func init() {
 	prometheus.MustRegister(regionRequestCounter)
 }
 
-func newTsoMetricsStream(stream pdpb.PD_TsoServer) pdpb.PD_TsoServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "tso")
+func newTsoMetricsStream(stream pdpb.PD_TsoServer) (pdpb.PD_TsoServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "tso")
+	return metricsStream, metricsStream.Close
 }
 
-func newRegionHeartbeatMetricsStream(stream pdpb.PD_RegionHeartbeatServer) pdpb.PD_RegionHeartbeatServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "region-heartbeat")
+func newRegionHeartbeatMetricsStream(stream pdpb.PD_RegionHeartbeatServer) (pdpb.PD_RegionHeartbeatServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "region-heartbeat")
+	return metricsStream, metricsStream.Close
 }
 
 func newReportBucketsMetricsStream(stream pdpb.PD_ReportBucketsServer) pdpb.PD_ReportBucketsServer {
 	return grpcutil.NewMetricsStream(stream, stream.SendAndClose, stream.Recv, grpcStreamSendDuration, "report-buckets")
 }
 
-func newQueryRegionMetricsStream(stream pdpb.PD_QueryRegionServer) pdpb.PD_QueryRegionServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "query-region")
+func newQueryRegionMetricsStream(stream pdpb.PD_QueryRegionServer) (pdpb.PD_QueryRegionServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "query-region")
+	return metricsStream, metricsStream.Close
 }
 
-func newSyncRegionsMetricsStream(stream pdpb.PD_SyncRegionsServer) pdpb.PD_SyncRegionsServer {
-	return grpcutil.NewMetricsStream(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "sync-regions")
+func newSyncRegionsMetricsStream(stream pdpb.PD_SyncRegionsServer) (pdpb.PD_SyncRegionsServer, func()) {
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup(stream, stream.Send, stream.Recv, grpcStreamSendDuration, "sync-regions")
+	return metricsStream, metricsStream.Close
 }
 
-func newWatchGlobalConfigMetricsStream(stream pdpb.PD_WatchGlobalConfigServer) pdpb.PD_WatchGlobalConfigServer {
+func newWatchGlobalConfigMetricsStream(stream pdpb.PD_WatchGlobalConfigServer) (pdpb.PD_WatchGlobalConfigServer, func()) {
 	if stream == nil {
-		return stream
+		return stream, func() {}
 	}
-	return grpcutil.NewMetricsStream[*pdpb.WatchGlobalConfigResponse, any](stream, stream.Send, nil, grpcStreamSendDuration, "watch-global-config")
+	metricsStream := grpcutil.NewMetricsStreamWithCleanup[*pdpb.WatchGlobalConfigResponse, any](stream, stream.Send, nil, grpcStreamSendDuration, "watch-global-config")
+	return metricsStream, metricsStream.Close
 }


### PR DESCRIPTION
### What problem does this PR solve?

gRPC stream metrics retain `target` label series after clients disconnect, causing `/metrics` to grow continuously.

Issue Number: Close #11044 

### What is changed and how does it work?

Track the number of active streams for each `(request, target)` label pair and delete the corresponding Histogram series when the last stream exits.

Reference counting prevents one connection from deleting metrics still used by another connection from the same target.

```commit-message
Track active gRPC streams and clean up metrics for disconnected targets.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix unbounded PD metrics growth caused by stale gRPC stream target series.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of metrics for streaming operations across services.
  - Prevented stale monitoring data and unnecessary resource retention after streams close.
  - Ensured shared stream metrics remain available until all related streams are finished.
  - Added safer handling for streams without metrics instrumentation.

- **Monitoring**
  - Improved accuracy and lifecycle management of gRPC stream performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->