### PR TITLE
scheduler, evict-slow-store allow draining multiple store from AZ

### DIFF
--- a/pkg/schedule/placement/rule.go
+++ b/pkg/schedule/placement/rule.go
@@ -17,6 +17,7 @@ package placement
 import (
 	"encoding/hex"
 	"encoding/json"
+	"slices"
 	"sort"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -99,6 +100,23 @@ func (r *Rule) Clone() *Rule {
 // Key returns (groupID, ID) as the global unique key of a rule.
 func (r *Rule) Key() [2]string {
 	return [2]string{r.GroupID, r.ID}
+}
+
+// isolationPrefix returns the rule's location labels up to and including its isolation
+// level, which is the granularity replicas are actually isolated at (see NewIsolationFilter):
+// with location labels ["zone","rack","host"] and isolation level "rack", replicas are forced
+// into distinct "zone,rack" domains, so that prefix names one isolation domain.
+// It reports false when the rule enforces no isolation level, or when the isolation level is
+// not one of the rule's location labels, because then the domain is undefined.
+func (r *Rule) isolationPrefix() ([]string, bool) {
+	if r.IsolationLevel == "" {
+		return nil, false
+	}
+	idx := slices.Index(r.LocationLabels, r.IsolationLevel)
+	if idx < 0 {
+		return nil, false
+	}
+	return r.LocationLabels[:idx+1], true
 }
 
 // StoreKey returns the rule's key for persistent store.

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -362,30 +362,37 @@ func (m *RuleManager) GetAllRules() []*Rule {
 }
 
 // GetIsolationPrefix returns the location labels up to the isolation level that every
-// rule agrees on, which names one isolation domain (see Rule.isolationPrefix). It reports
-// false when any rule enforces no isolation level, when a rule's isolation level is not one
-// of its location labels, when rules disagree, or when there are no rules at all.
+// effective rule agrees on, which names one isolation domain (see Rule.isolationPrefix). It
+// reports false when any effective rule enforces no isolation level, when a rule's isolation
+// level is not one of its location labels, when rules disagree, or when no rule applies.
+//
+// It walks the per-range applyRules rather than the persisted rule set, so a rule that is
+// overridden everywhere cannot veto the result. Every range has to agree because a caller
+// acting on this drains one domain for all regions at once, so a prefix that holds for only
+// part of the key space is not enough.
 //
 // Unlike GetAllRules this neither clones nor sorts, so callers on a hot path (schedulers run
 // as often as every 10ms) do not pay a JSON round-trip per rule, and the read lock is held
 // only for a few field reads. Reading rule fields directly is safe because every mutation
-// path takes the write lock and replaces map entries rather than editing rules in place.
+// path takes the write lock and rebuilds ruleList rather than editing rules in place.
 func (m *RuleManager) GetIsolationPrefix() ([]string, bool) {
 	m.RLock()
 	defer m.RUnlock()
 	var labels []string
 	found := false
-	for _, r := range m.ruleConfig.rules {
-		prefix, ok := r.isolationPrefix()
-		if !ok {
-			return nil, false
-		}
-		if !found {
-			labels, found = prefix, true
-			continue
-		}
-		if !slices.Equal(labels, prefix) {
-			return nil, false
+	for _, rr := range m.ruleList.ranges {
+		for _, r := range rr.applyRules {
+			prefix, ok := r.isolationPrefix()
+			if !ok {
+				return nil, false
+			}
+			if !found {
+				labels, found = prefix, true
+				continue
+			}
+			if !slices.Equal(labels, prefix) {
+				return nil, false
+			}
 		}
 	}
 	if !found {

--- a/pkg/schedule/placement/rule_manager.go
+++ b/pkg/schedule/placement/rule_manager.go
@@ -361,6 +361,40 @@ func (m *RuleManager) GetAllRules() []*Rule {
 	return rules
 }
 
+// GetIsolationPrefix returns the location labels up to the isolation level that every
+// rule agrees on, which names one isolation domain (see Rule.isolationPrefix). It reports
+// false when any rule enforces no isolation level, when a rule's isolation level is not one
+// of its location labels, when rules disagree, or when there are no rules at all.
+//
+// Unlike GetAllRules this neither clones nor sorts, so callers on a hot path (schedulers run
+// as often as every 10ms) do not pay a JSON round-trip per rule, and the read lock is held
+// only for a few field reads. Reading rule fields directly is safe because every mutation
+// path takes the write lock and replaces map entries rather than editing rules in place.
+func (m *RuleManager) GetIsolationPrefix() ([]string, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	var labels []string
+	found := false
+	for _, r := range m.ruleConfig.rules {
+		prefix, ok := r.isolationPrefix()
+		if !ok {
+			return nil, false
+		}
+		if !found {
+			labels, found = prefix, true
+			continue
+		}
+		if !slices.Equal(labels, prefix) {
+			return nil, false
+		}
+	}
+	if !found {
+		return nil, false
+	}
+	// Copy: labels aliases a live rule's LocationLabels.
+	return slices.Clone(labels), true
+}
+
 // GetRulesCount returns the number of rules.
 func (m *RuleManager) GetRulesCount() int {
 	m.RLock()

--- a/pkg/schedule/placement/rule_manager_test.go
+++ b/pkg/schedule/placement/rule_manager_test.go
@@ -334,6 +334,52 @@ func TestRangeGap(t *testing.T) {
 	re.Error(err)
 }
 
+func TestGetIsolationPrefix(t *testing.T) {
+	re := require.New(t)
+
+	rule := func(group, id, isolationLevel string, locationLabels ...string) *Rule {
+		return &Rule{
+			GroupID:        group,
+			ID:             id,
+			Role:           Voter,
+			Count:          3,
+			LocationLabels: locationLabels,
+			IsolationLevel: isolationLevel,
+		}
+	}
+
+	// The default rule carries no isolation level, so nothing is isolated yet.
+	_, manager := newTestManager(t, false)
+	_, ok := manager.GetIsolationPrefix()
+	re.False(ok)
+
+	// A single rule yields the prefix up to its isolation level.
+	re.NoError(manager.SetRule(rule(DefaultGroupID, DefaultRuleID, "rack", "zone", "rack", "host")))
+	labels, ok := manager.GetIsolationPrefix()
+	re.True(ok)
+	re.Equal([]string{"zone", "rack"}, labels)
+
+	// A second rule that disagrees vetoes the result.
+	re.NoError(manager.SetRule(rule(DefaultGroupID, "conflict", "zone", "zone", "rack", "host")))
+	_, ok = manager.GetIsolationPrefix()
+	re.False(ok)
+
+	// The same conflicting rule stays persisted but is overridden by a higher-index group,
+	// so it no longer applies to any range and must not affect the prefix.
+	re.NoError(manager.SetRuleGroup(&RuleGroup{ID: "override", Index: 100, Override: true}))
+	re.NoError(manager.SetRule(rule("override", "1", "rack", "zone", "rack", "host")))
+	re.NotNil(manager.GetRule(DefaultGroupID, "conflict"))
+	labels, ok = manager.GetIsolationPrefix()
+	re.True(ok)
+	re.Equal([]string{"zone", "rack"}, labels)
+
+	// Mutating the returned slice must not corrupt the rule it was derived from.
+	labels[0] = "mutated"
+	labels, ok = manager.GetIsolationPrefix()
+	re.True(ok)
+	re.Equal([]string{"zone", "rack"}, labels)
+}
+
 func TestGroupConfig(t *testing.T) {
 	re := require.New(t)
 	_, manager := newTestManager(t, false)

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
 	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/plan"
 	"github.com/tikv/pd/pkg/schedule/types"
@@ -913,16 +914,41 @@ func sameLocation(ref, store *core.StoreInfo, labels []string) bool {
 	return hasAllLabels(store, labels) && ref.CompareLocation(store, labels) == -1
 }
 
+// eligibleHealthyLeaderTargets returns the stores that could actually receive leaders,
+// applying the same target-store checks as a leader transfer (StoreStateFilter with
+// TransferLeader set) so the domain counting matches what the operator layer will accept.
+// It additionally drops disk-slow stores, which the leader-target filter does not reject.
+func eligibleHealthyLeaderTargets(cluster sche.SchedulerCluster, stores []*core.StoreInfo) []*core.StoreInfo {
+	candidates := filter.NewCandidates(stores).
+		FilterTarget(
+			cluster.GetSchedulerConfig(),
+			nil,
+			nil,
+			&filter.StoreStateFilter{
+				ActionScope:    types.EvictSlowStoreScheduler.String(),
+				TransferLeader: true,
+				OperatorLevel:  constant.Urgent,
+			},
+		).
+		PickAll()
+
+	healthy := candidates[:0]
+	for _, store := range candidates {
+		if store.IsSlow() {
+			continue
+		}
+		healthy = append(healthy, store)
+	}
+	return healthy
+}
+
 // hasEnoughHealthyDomains reports whether at least minRemainingHealthyDomains distinct
 // failure domains (by all configured labels) other than the drained store's domain still
 // have a store able to host leaders. Domains are deduplicated with CompareLocation so the
 // counting stays consistent with the grouping decision.
 func hasEnoughHealthyDomains(cluster sche.SchedulerCluster, labels []string, drained *core.StoreInfo) bool {
 	reps := make([]*core.StoreInfo, 0, minRemainingHealthyDomains)
-	for _, store := range cluster.GetStores() {
-		if !store.IsUp() || store.IsSlow() || store.EvictedAsSlowStore() || !store.AllowLeaderTransferIn() {
-			continue
-		}
+	for _, store := range eligibleHealthyLeaderTargets(cluster, cluster.GetStores()) {
 		if !hasAllLabels(store, labels) || drained.CompareLocation(store, labels) == -1 {
 			continue
 		}

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -86,7 +87,12 @@ type evictSlowStoreSchedulerConfig struct {
 	// Duration gap for recovering the candidate, unit: s.
 	RecoverySec uint64 `json:"recovery-duration"`
 	// EvictedStores is only used by disk slow store scheduler
-	EvictedStores            []uint64 `json:"evict-stores"`
+	EvictedStores []uint64 `json:"evict-stores"`
+	// GroupEvictionLabels are the location labels (e.g. ["zone"] or ["zone","rack"]) that
+	// define a drainable failure domain. When set, the disk slow store scheduler evicts
+	// leaders from all slow stores that share these label values. Empty disables grouping
+	// and falls back to single-store eviction.
+	GroupEvictionLabels      []string `json:"group-eviction-labels"`
 	EnableNetworkSlowStore   bool     `json:"enable-network-slow-store"`
 	PausedNetworkSlowStores  []uint64 `json:"paused-network-slow-stores"`
 	EvictedNetworkSlowStores []uint64 `json:"evicted-network-slow-stores"`
@@ -101,6 +107,7 @@ func initEvictSlowStoreSchedulerConfig() *evictSlowStoreSchedulerConfig {
 		lastSlowStoreCaptureTS:          time.Time{},
 		RecoverySec:                     defaultRecoverySec,
 		EvictedStores:                   make([]uint64, 0),
+		GroupEvictionLabels:             make([]string, 0),
 		Batch:                           EvictLeaderBatchSize,
 		EnableNetworkSlowStore:          false,
 		PausedNetworkSlowStores:         make([]uint64, 0),
@@ -115,6 +122,7 @@ func (conf *evictSlowStoreSchedulerConfig) persistLocked(updateFn func()) error 
 		oldNetworkSlowStoreRecoverStartAts = make(map[uint64]*time.Time)
 		oldIsRecovered                     = conf.isRecovered
 		oldEvictedStores                   = conf.EvictedStores
+		oldGroupEvictionLabels             = conf.GroupEvictionLabels
 		oldPausedNetworkSlowStores         = conf.PausedNetworkSlowStores
 		oldEvictedNetworkSlowStores        = conf.EvictedNetworkSlowStores
 		oldRecoverySec                     = conf.RecoverySec
@@ -129,6 +137,7 @@ func (conf *evictSlowStoreSchedulerConfig) persistLocked(updateFn func()) error 
 		conf.networkSlowStoreRecoverStartAts = oldNetworkSlowStoreRecoverStartAts
 		conf.isRecovered = oldIsRecovered
 		conf.EvictedStores = oldEvictedStores
+		conf.GroupEvictionLabels = oldGroupEvictionLabels
 		conf.PausedNetworkSlowStores = oldPausedNetworkSlowStores
 		conf.EvictedNetworkSlowStores = oldEvictedNetworkSlowStores
 		conf.RecoverySec = oldRecoverySec
@@ -169,6 +178,13 @@ func (conf *evictSlowStoreSchedulerConfig) isEvictingDiskSlowStore() bool {
 	conf.RLock()
 	defer conf.RUnlock()
 	return len(conf.EvictedStores) > 0
+}
+
+// getGroupEvictionLabels returns a copy of the configured failure-domain labels.
+func (conf *evictSlowStoreSchedulerConfig) getGroupEvictionLabels() []string {
+	conf.RLock()
+	defer conf.RUnlock()
+	return slices.Clone(conf.GroupEvictionLabels)
 }
 
 func (conf *evictSlowStoreSchedulerConfig) getPausedNetworkSlowStores() []uint64 {
@@ -339,6 +355,18 @@ func newEvictSlowStoreHandler(config *evictSlowStoreSchedulerConfig) http.Handle
 	return router
 }
 
+// parseGroupEvictionLabels splits a comma-separated label string (e.g. "zone,rack") into a
+// trimmed, non-empty label slice. An empty/blank string yields an empty slice (disabled).
+func parseGroupEvictionLabels(s string) []string {
+	labels := make([]string, 0)
+	for _, part := range strings.Split(s, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			labels = append(labels, part)
+		}
+	}
+	return labels
+}
+
 func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *http.Request) {
 	var input map[string]any
 	if err := apiutil.ReadJSONRespondError(handler.rd, w, r.Body, &input); err != nil {
@@ -368,6 +396,13 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		return
 	}
 
+	groupEvictionLabelsStr, inputGroupEvictionLabels := input["group-eviction-labels"].(string)
+	if input["group-eviction-labels"] != nil && !inputGroupEvictionLabels {
+		handler.rd.JSON(w, http.StatusBadRequest, perrors.New("invalid argument for 'group-eviction-labels'").Error())
+		return
+	}
+	groupEvictionLabels := parseGroupEvictionLabels(groupEvictionLabelsStr)
+
 	handler.config.Lock()
 	defer handler.config.Unlock()
 	recoverySec := uint64(recoveryDurationGapFloat)
@@ -382,6 +417,9 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		if inputEnableNetworkSlowStore {
 			handler.config.EnableNetworkSlowStore = enableNetworkSlowStore
 		}
+		if inputGroupEvictionLabels {
+			handler.config.GroupEvictionLabels = groupEvictionLabels
+		}
 	}); err != nil {
 		handler.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
@@ -390,6 +428,7 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		zap.Uint64("cur-recovery-duration", recoverySec),
 		zap.Float64("cur-batch", batchFloat),
 		zap.Bool("cur-enable-network-slow-store", enableNetworkSlowStore),
+		zap.Strings("cur-group-eviction-labels", groupEvictionLabels),
 	)
 
 	handler.rd.JSON(w, http.StatusOK, "Config updated.")
@@ -402,6 +441,7 @@ func (handler *evictSlowStoreHandler) listConfig(w http.ResponseWriter, _ *http.
 		RecoverySec:              handler.config.RecoverySec,
 		Batch:                    handler.config.Batch,
 		EvictedStores:            handler.config.EvictedStores,
+		GroupEvictionLabels:      handler.config.GroupEvictionLabels,
 		EnableNetworkSlowStore:   handler.config.EnableNetworkSlowStore,
 		PausedNetworkSlowStores:  handler.config.PausedNetworkSlowStores,
 		EvictedNetworkSlowStores: handler.config.EvictedNetworkSlowStores,
@@ -454,6 +494,7 @@ func (s *evictSlowStoreScheduler) ReloadConfig() error {
 	pauseAndResumeLeaderTransfer(s.conf.cluster, constant.In, old, new)
 	s.conf.RecoverySec = newCfg.RecoverySec
 	s.conf.EvictedStores = newCfg.EvictedStores
+	s.conf.GroupEvictionLabels = newCfg.GroupEvictionLabels
 	s.conf.PausedNetworkSlowStores = newCfg.PausedNetworkSlowStores
 	s.conf.EvictedNetworkSlowStores = newCfg.EvictedNetworkSlowStores
 	s.conf.EnableNetworkSlowStore = newCfg.EnableNetworkSlowStore
@@ -826,11 +867,11 @@ func filterNetworkSlowScores(
 	return filteredScores
 }
 
-// minRemainingHealthyZones is the number of distinct isolation zones (besides the
-// one being drained) that must still be able to host leaders before PD will evict
-// leaders from a whole zone. It prevents draining a zone on a too-small topology
-// where all leaders would pile onto a single survivor.
-const minRemainingHealthyZones = 2
+// minRemainingHealthyDomains is the number of distinct failure domains (by the broadest
+// configured label, besides the one being drained) that must still be able to host leaders
+// before PD will group-evict. It prevents draining a domain on a too-small topology where
+// all leaders would pile onto a single survivor.
+const minRemainingHealthyDomains = 2
 
 // collectDiskSlowStores returns the serving/preparing stores that are currently slow.
 func collectDiskSlowStores(cluster sche.SchedulerCluster) []*core.StoreInfo {
@@ -854,38 +895,52 @@ func storeIDs(stores []*core.StoreInfo) []uint64 {
 	return ids
 }
 
-// groupIsolationKey returns the label key to group slow stores by. Group eviction
-// is only allowed when every placement rule enforces the same non-empty isolation
-// level, so draining a single zone is known to be safe for every region.
-func groupIsolationKey(cluster sche.SchedulerCluster) (string, bool) {
-	rules := cluster.GetRuleManager().GetAllRules() // includes default one
-	if len(rules) == 0 || rules[0].IsolationLevel == "" {
-		return "", false
-	}
-	level := rules[0].IsolationLevel
-	for _, r := range rules[1:] {
-		if r.IsolationLevel != level {
-			return "", false
+// hasAllLabels reports whether the store has a non-empty value for every label.
+func hasAllLabels(store *core.StoreInfo, labels []string) bool {
+	for _, l := range labels {
+		if store.GetLabelValue(l) == "" {
+			return false
 		}
 	}
-	return level, true
+	return true
 }
 
-// hasEnoughHealthyZones reports whether at least minRemainingHealthyZones distinct
-// zones other than drainedZone each have a store able to host leaders.
-func hasEnoughHealthyZones(cluster sche.SchedulerCluster, key, drainedZone string) bool {
-	zones := make(map[string]struct{})
+// sameLocation reports whether store is in the same failure domain as ref for the
+// configured labels. It requires store to have all labels set, so an unlabeled store is
+// never treated as co-located (CompareLocation alone would treat a missing label as a
+// wildcard match).
+func sameLocation(ref, store *core.StoreInfo, labels []string) bool {
+	return hasAllLabels(store, labels) && ref.CompareLocation(store, labels) == -1
+}
+
+// hasEnoughHealthyDomains reports whether at least minRemainingHealthyDomains distinct
+// failure domains (by all configured labels) other than the drained store's domain still
+// have a store able to host leaders. Domains are deduplicated with CompareLocation so the
+// counting stays consistent with the grouping decision.
+func hasEnoughHealthyDomains(cluster sche.SchedulerCluster, labels []string, drained *core.StoreInfo) bool {
+	reps := make([]*core.StoreInfo, 0, minRemainingHealthyDomains)
 	for _, store := range cluster.GetStores() {
 		if !store.IsUp() || store.IsSlow() || store.EvictedAsSlowStore() || !store.AllowLeaderTransferIn() {
 			continue
 		}
-		zone := store.GetLabelValue(key)
-		if zone == "" || zone == drainedZone {
+		if !hasAllLabels(store, labels) || drained.CompareLocation(store, labels) == -1 {
 			continue
 		}
-		zones[zone] = struct{}{}
+		isNewDomain := true
+		for _, rep := range reps {
+			if rep.CompareLocation(store, labels) == -1 {
+				isNewDomain = false
+				break
+			}
+		}
+		if isNewDomain {
+			reps = append(reps, store)
+			if len(reps) >= minRemainingHealthyDomains {
+				return true
+			}
+		}
 	}
-	return len(zones) >= minRemainingHealthyZones
+	return false
 }
 
 // startEvictDiskSlowStores marks the given stores as evicted and records their status.
@@ -922,25 +977,26 @@ func (s *evictSlowStoreScheduler) scheduleDiskSlowStore(cluster sche.SchedulerCl
 		return
 	}
 
-	// Multiple slow stores: only proceed when they all live in the same isolation
-	// zone and the topology can still absorb draining that zone.
-	key, ok := groupIsolationKey(cluster)
-	if !ok {
-		// Placement rules do not uniformly enforce an isolation level; fall back to
-		// the conservative behavior (do nothing for more than one slow store).
+	// Multiple slow stores: group eviction only when group-eviction-labels is configured and
+	// every slow store shares that failure domain.
+	labels := s.conf.getGroupEvictionLabels()
+	if len(labels) == 0 {
+		// Grouping disabled; keep the conservative behavior (do nothing for 2+ slow stores).
 		return
 	}
-	zone := slowStores[0].GetLabelValue(key)
-	if zone == "" {
+	ref := slowStores[0]
+	if !hasAllLabels(ref, labels) {
+		// Reference store is missing a configured label; cannot determine its domain.
 		return
 	}
-	for _, store := range slowStores {
-		if store.GetLabelValue(key) != zone {
-			// Slow stores span more than one zone; never drain across failure domains.
+	for _, store := range slowStores[1:] {
+		if !sameLocation(ref, store, labels) {
+			// Slow stores span more than one domain (or one lacks the labels); never
+			// drain across failure domains.
 			return
 		}
 	}
-	if !hasEnoughHealthyZones(cluster, key, zone) {
+	if !hasEnoughHealthyDomains(cluster, labels, ref) {
 		return
 	}
 
@@ -951,29 +1007,28 @@ func (s *evictSlowStoreScheduler) scheduleDiskSlowStore(cluster sche.SchedulerCl
 		}
 	}
 	if len(toEvict) == 0 {
-		// All same-zone slow stores are still below the evict threshold; wait.
+		// All same-domain slow stores are still below the evict threshold; wait.
 		return
 	}
-	log.Info("detected slow stores in a single isolation zone, start to evict leaders",
-		zap.String("isolation-level", key), zap.String("zone", zone),
+	log.Info("detected slow stores in a single failure domain, start to evict leaders",
+		zap.Strings("group-eviction-labels", labels),
 		zap.Uint64s("store-ids", storeIDs(toEvict)))
 	s.startEvictDiskSlowStores(cluster, toEvict)
 }
 
-// reconcileDiskSlowStoreGroup runs each cycle while a zone is being drained: it
+// reconcileDiskSlowStoreGroup runs each cycle while a domain is being drained: it
 // releases stores that left the cluster, releases the whole group once every
 // evicted store has recovered for the recovery duration, and (unless a slow store
-// has appeared outside the locked zone) adds newly-slow same-zone stores.
+// has appeared outside the locked domain) adds newly-slow same-domain stores.
 func (s *evictSlowStoreScheduler) reconcileDiskSlowStoreGroup(cluster sche.SchedulerCluster, slowStores []*core.StoreInfo) {
 	evicted := s.conf.evictedStores()
 
-	// Single pass: drop stores that have left the cluster; compute maxScore and
-	// the locked-zone value (all survivors share one zone by construction) from
-	// the same iteration so we only call GetStore once per evicted id.
+	// Single pass: drop stores that have left the cluster; compute maxScore and pick a
+	// surviving store as the locked-domain reference (all survivors share one domain by
+	// construction) so we only call GetStore once per evicted id.
 	var (
 		gone       []uint64
 		maxScore   uint64
-		lockedZone string
 		survivorID uint64
 	)
 	for _, id := range evicted {
@@ -1023,36 +1078,34 @@ func (s *evictSlowStoreScheduler) reconcileDiskSlowStoreGroup(cluster sche.Sched
 		return
 	}
 
-	// Resolve the locked zone from a surviving evicted store. If the grouping key
-	// is no longer well-defined (rules changed), keep draining but do not expand.
-	// survivorID is always set here because isEvictingDiskSlowStore returned true
-	// and every surviving store was visited in the loop above.
-	key, ok := groupIsolationKey(cluster)
-	if !ok {
+	// Expansion is config-driven. If group-eviction-labels was cleared (or the locked store no
+	// longer carries the labels), keep draining the current group but do not expand.
+	// survivorID is always set here because isEvictingDiskSlowStore returned true and
+	// every surviving store was visited in the loop above.
+	labels := s.conf.getGroupEvictionLabels()
+	if len(labels) == 0 {
 		return
 	}
-	if survivor := cluster.GetStore(survivorID); survivor != nil {
-		lockedZone = survivor.GetLabelValue(key)
-	}
-	if lockedZone == "" {
+	lockedRef := cluster.GetStore(survivorID)
+	if lockedRef == nil || !hasAllLabels(lockedRef, labels) {
 		return
 	}
 
-	// Freeze brake: if any slow store sits outside the locked zone, stop expanding
-	// the eviction set (we never start draining a second zone).
+	// Freeze brake: if any slow store sits outside the locked domain, stop expanding
+	// the eviction set (we never start draining a second domain).
 	for _, store := range slowStores {
-		if store.GetLabelValue(key) != lockedZone {
+		if !sameLocation(lockedRef, store, labels) {
 			return
 		}
 	}
 
-	// Only expand if the topology can still absorb draining the locked zone.
-	// This prevents the single-store → reconcile-add bypass of the zone guard.
-	if !hasEnoughHealthyZones(cluster, key, lockedZone) {
+	// Only expand if the topology can still absorb draining the locked domain.
+	// This prevents the single-store → reconcile-add bypass of the domain guard.
+	if !hasEnoughHealthyDomains(cluster, labels, lockedRef) {
 		return
 	}
 
-	// Reconcile: add newly-slow same-zone stores that reached the evict threshold.
+	// Reconcile: add newly-slow same-domain stores that reached the evict threshold.
 	// EvictedAsSlowStore() is the authoritative "already marked" check; it covers
 	// both disk- and network-evicted stores, so no separate set is needed.
 	var toAdd []*core.StoreInfo
@@ -1060,13 +1113,13 @@ func (s *evictSlowStoreScheduler) reconcileDiskSlowStoreGroup(cluster sche.Sched
 		if store.EvictedAsSlowStore() {
 			continue
 		}
-		if store.GetLabelValue(key) == lockedZone && store.GetSlowScore() >= slowStoreEvictThreshold {
+		if sameLocation(lockedRef, store, labels) && store.GetSlowScore() >= slowStoreEvictThreshold {
 			toAdd = append(toAdd, store)
 		}
 	}
 	if len(toAdd) > 0 {
-		log.Info("adding newly-slow stores in the locked zone to eviction",
-			zap.String("zone", lockedZone), zap.Uint64s("store-ids", storeIDs(toAdd)))
+		log.Info("adding newly-slow stores in the locked domain to eviction",
+			zap.Strings("group-eviction-labels", labels), zap.Uint64s("store-ids", storeIDs(toAdd)))
 		s.startEvictDiskSlowStores(cluster, toAdd)
 	}
 }

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -155,13 +155,20 @@ func (conf *evictSlowStoreSchedulerConfig) getBatch() int {
 	return conf.Batch
 }
 
-func (conf *evictSlowStoreSchedulerConfig) evictStore() uint64 {
+// evictedStores returns a copy of the disk slow stores currently being evicted.
+func (conf *evictSlowStoreSchedulerConfig) evictedStores() []uint64 {
 	conf.RLock()
 	defer conf.RUnlock()
-	if len(conf.EvictedStores) == 0 {
-		return 0
-	}
-	return conf.EvictedStores[0]
+	res := make([]uint64, len(conf.EvictedStores))
+	copy(res, conf.EvictedStores)
+	return res
+}
+
+// isEvictingDiskSlowStore reports whether any disk slow store is being evicted.
+func (conf *evictSlowStoreSchedulerConfig) isEvictingDiskSlowStore() bool {
+	conf.RLock()
+	defer conf.RUnlock()
+	return len(conf.EvictedStores) > 0
 }
 
 func (conf *evictSlowStoreSchedulerConfig) getPausedNetworkSlowStores() []uint64 {
@@ -239,13 +246,45 @@ func (conf *evictSlowStoreSchedulerConfig) readyForRecovery() bool {
 	return uint64(time.Since(conf.lastSlowStoreCaptureTS).Seconds()) >= recoverySec
 }
 
-func (conf *evictSlowStoreSchedulerConfig) setStoreAndPersist(id uint64) error {
+// setEvictedStoresAndPersist replaces the disk slow store eviction set with ids
+// and resets the capture timestamp (the group is freshly slow).
+func (conf *evictSlowStoreSchedulerConfig) setEvictedStoresAndPersist(ids []uint64) error {
 	conf.Lock()
 	defer conf.Unlock()
 	return conf.persistLocked(func() {
-		conf.EvictedStores = []uint64{id}
+		conf.EvictedStores = ids
+		// Reset the recovery clock so as for multi store issues we need to wait whole zone is stable
 		conf.lastSlowStoreCaptureTS = time.Now()
 	})
+}
+
+// removeEvictedAndPersist drops the given ids from the eviction set (only those
+// actually present) and returns the ids removed. Used when an evicted store
+// leaves the cluster mid-drain; the remaining group keeps its recovery clock.
+func (conf *evictSlowStoreSchedulerConfig) removeEvictedAndPersist(ids []uint64) (removed []uint64, err error) {
+	conf.Lock()
+	defer conf.Unlock()
+	drop := make(map[uint64]struct{}, len(ids))
+	for _, id := range ids {
+		drop[id] = struct{}{}
+	}
+	kept := make([]uint64, 0, len(conf.EvictedStores))
+	for _, id := range conf.EvictedStores {
+		if _, ok := drop[id]; ok {
+			removed = append(removed, id)
+			continue
+		}
+		kept = append(kept, id)
+	}
+	if len(removed) == 0 {
+		return nil, nil
+	}
+	if err = conf.persistLocked(func() {
+		conf.EvictedStores = kept
+	}); err != nil {
+		return nil, err
+	}
+	return removed, nil
 }
 
 func (conf *evictSlowStoreSchedulerConfig) tryUpdateRecoverStatus(isRecovered bool) error {
@@ -264,17 +303,24 @@ func (conf *evictSlowStoreSchedulerConfig) tryUpdateRecoverStatus(isRecovered bo
 	})
 }
 
-func (conf *evictSlowStoreSchedulerConfig) clearEvictedAndPersist() (oldID uint64, err error) {
-	oldID = conf.evictStore()
+// clearEvictedAndPersist releases the whole disk slow store eviction set and
+// returns the ids that were evicted.
+func (conf *evictSlowStoreSchedulerConfig) clearEvictedAndPersist() (oldIDs []uint64, err error) {
 	conf.Lock()
 	defer conf.Unlock()
-	if oldID > 0 {
-		err = conf.persistLocked(func() {
-			conf.EvictedStores = []uint64{}
-			conf.lastSlowStoreCaptureTS = time.Time{}
-		})
+	if len(conf.EvictedStores) == 0 {
+		return nil, nil
 	}
-	return
+	oldIDs = make([]uint64, len(conf.EvictedStores))
+	copy(oldIDs, conf.EvictedStores)
+	err = conf.persistLocked(func() {
+		conf.EvictedStores = []uint64{}
+		conf.lastSlowStoreCaptureTS = time.Time{}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return oldIDs, nil
 }
 
 type evictSlowStoreHandler struct {
@@ -419,8 +465,7 @@ func (s *evictSlowStoreScheduler) ReloadConfig() error {
 func (s *evictSlowStoreScheduler) PrepareConfig(cluster sche.SchedulerCluster) error {
 	errs := make([]error, 0)
 
-	evictStore := s.conf.evictStore()
-	if evictStore != 0 {
+	for _, evictStore := range s.conf.evictedStores() {
 		if err := cluster.SlowStoreEvicted(evictStore); err != nil {
 			errs = append(errs, err)
 		}
@@ -450,15 +495,32 @@ func (s *evictSlowStoreScheduler) CleanConfig(cluster sche.SchedulerCluster) {
 	}
 }
 
-func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster sche.SchedulerCluster, storeID uint64) error {
-	if err := cluster.SlowStoreEvicted(storeID); err != nil {
-		log.Info("failed to evict slow store", zap.Uint64("store-id", storeID), zap.Error(err))
-		return err
+// prepareEvictLeader marks the given newly-detected stores as evicted (each is
+// expected to not already be evicted) and persists the resulting set. On any
+// failure it rolls back the marks it added so the slow-evicted counter stays
+// balanced.
+func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster sche.SchedulerCluster, addIDs []uint64) error {
+	if len(addIDs) == 0 {
+		return nil
+	}
+	marked := make([]uint64, 0, len(addIDs))
+	for _, storeID := range addIDs {
+		if err := cluster.SlowStoreEvicted(storeID); err != nil {
+			log.Info("failed to evict slow store", zap.Uint64("store-id", storeID), zap.Error(err))
+			for _, id := range marked {
+				cluster.SlowStoreRecovered(id)
+			}
+			return err
+		}
+		marked = append(marked, storeID)
 	}
 
-	if err := s.conf.setStoreAndPersist(storeID); err != nil {
-		log.Info("failed to persist evicted slow store", zap.Uint64("store-id", storeID), zap.Error(err))
-		cluster.SlowStoreRecovered(storeID)
+	newSet := append(s.conf.evictedStores(), addIDs...)
+	if err := s.conf.setEvictedStoresAndPersist(newSet); err != nil {
+		log.Info("failed to persist evicted slow store", zap.Uint64s("store-ids", addIDs), zap.Error(err))
+		for _, id := range addIDs {
+			cluster.SlowStoreRecovered(id)
+		}
 		return err
 	}
 
@@ -466,14 +528,14 @@ func (s *evictSlowStoreScheduler) prepareEvictLeader(cluster sche.SchedulerClust
 }
 
 func (s *evictSlowStoreScheduler) cleanupEvictLeader(cluster sche.SchedulerCluster) {
-	evictSlowStore, err := s.conf.clearEvictedAndPersist()
+	evictSlowStores, err := s.conf.clearEvictedAndPersist()
 	if err != nil {
-		log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64("store-id", evictSlowStore))
+		log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64s("store-ids", evictSlowStores))
 	}
-	if evictSlowStore == 0 {
-		return
+	for _, storeID := range evictSlowStores {
+		cluster.SlowStoreRecovered(storeID)
+		evictedSlowStoreStatusGauge.DeleteLabelValues(strconv.FormatUint(storeID, 10), string(diskSlowStore))
 	}
-	cluster.SlowStoreRecovered(evictSlowStore)
 }
 
 func (s *evictSlowStoreScheduler) schedulerEvictLeader(cluster sche.SchedulerCluster) []*operator.Operator {
@@ -482,7 +544,7 @@ func (s *evictSlowStoreScheduler) schedulerEvictLeader(cluster sche.SchedulerClu
 
 // IsScheduleAllowed implements the Scheduler interface.
 func (s *evictSlowStoreScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster) bool {
-	if s.conf.evictStore() != 0 {
+	if s.conf.isEvictingDiskSlowStore() {
 		allowed := s.OpController.OperatorCount(operator.OpLeader) < cluster.GetSchedulerConfig().GetLeaderScheduleLimit()
 		if !allowed {
 			operator.IncOperatorLimitCounter(s.GetType(), operator.OpLeader)
@@ -764,75 +826,249 @@ func filterNetworkSlowScores(
 	return filteredScores
 }
 
-func (s *evictSlowStoreScheduler) scheduleDiskSlowStore(cluster sche.SchedulerCluster) {
-	if s.conf.evictStore() != 0 {
-		store := cluster.GetStore(s.conf.evictStore())
-		storeIDStr := strconv.FormatUint(store.GetID(), 10)
-		if store == nil || store.IsRemoved() {
-			// Previous slow store had been removed, remove the scheduler and check
-			// slow node next time.
-			log.Info("slow store has been removed",
-				zap.Uint64("store-id", store.GetID()))
-			evictedSlowStoreStatusGauge.DeleteLabelValues(storeIDStr, string(diskSlowStore))
-			s.cleanupEvictLeader(cluster)
-			return
-		}
-		// recover slow store if its score is below the threshold.
-		if store.GetSlowScore() <= slowStoreRecoverThreshold {
-			if err := s.conf.tryUpdateRecoverStatus(true); err != nil {
-				log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64("store-id", store.GetID()), zap.Error(err))
-				return
-			}
+// minRemainingHealthyZones is the number of distinct isolation zones (besides the
+// one being drained) that must still be able to host leaders before PD will evict
+// leaders from a whole zone. It prevents draining a zone on a too-small topology
+// where all leaders would pile onto a single survivor.
+const minRemainingHealthyZones = 2
 
-			if !s.conf.readyForRecovery() {
-				return
-			}
-
-			log.Info("slow store has been recovered",
-				zap.Uint64("store-id", store.GetID()))
-			evictedSlowStoreStatusGauge.DeleteLabelValues(storeIDStr, string(diskSlowStore))
-			s.cleanupEvictLeader(cluster)
-			return
-		}
-		// If the slow store is still slow or slow again, we can continue to evict leaders from it.
-		if err := s.conf.tryUpdateRecoverStatus(false); err != nil {
-			log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64("store-id", store.GetID()), zap.Error(err))
-			return
-		}
-		return
-	}
-
-	var slowStore *core.StoreInfo
-
+// collectDiskSlowStores returns the serving/preparing stores that are currently slow.
+func collectDiskSlowStores(cluster sche.SchedulerCluster) []*core.StoreInfo {
+	var slowStores []*core.StoreInfo
 	for _, store := range cluster.GetStores() {
 		if store.IsRemoved() {
 			continue
 		}
-
 		if (store.IsPreparing() || store.IsServing()) && store.IsSlow() {
-			// Do nothing if there is more than one slow store.
-			if slowStore != nil {
-				return
-			}
-			slowStore = store
+			slowStores = append(slowStores, store)
+		}
+	}
+	return slowStores
+}
+
+func storeIDs(stores []*core.StoreInfo) []uint64 {
+	ids := make([]uint64, 0, len(stores))
+	for _, store := range stores {
+		ids = append(ids, store.GetID())
+	}
+	return ids
+}
+
+// groupIsolationKey returns the label key to group slow stores by. Group eviction
+// is only allowed when every placement rule enforces the same non-empty isolation
+// level, so draining a single zone is known to be safe for every region.
+func groupIsolationKey(cluster sche.SchedulerCluster) (string, bool) {
+	rules := cluster.GetRuleManager().GetAllRules() // includes default one
+	if len(rules) == 0 || rules[0].IsolationLevel == "" {
+		return "", false
+	}
+	level := rules[0].IsolationLevel
+	for _, r := range rules[1:] {
+		if r.IsolationLevel != level {
+			return "", false
+		}
+	}
+	return level, true
+}
+
+// hasEnoughHealthyZones reports whether at least minRemainingHealthyZones distinct
+// zones other than drainedZone each have a store able to host leaders.
+func hasEnoughHealthyZones(cluster sche.SchedulerCluster, key, drainedZone string) bool {
+	zones := make(map[string]struct{})
+	for _, store := range cluster.GetStores() {
+		if !store.IsUp() || store.IsSlow() || store.EvictedAsSlowStore() || !store.AllowLeaderTransferIn() {
+			continue
+		}
+		zone := store.GetLabelValue(key)
+		if zone == "" || zone == drainedZone {
+			continue
+		}
+		zones[zone] = struct{}{}
+	}
+	return len(zones) >= minRemainingHealthyZones
+}
+
+// startEvictDiskSlowStores marks the given stores as evicted and records their status.
+func (s *evictSlowStoreScheduler) startEvictDiskSlowStores(cluster sche.SchedulerCluster, stores []*core.StoreInfo) {
+	ids := storeIDs(stores)
+	if err := s.prepareEvictLeader(cluster, ids); err != nil {
+		log.Info("prepare for evicting leader failed", zap.Error(err), zap.Uint64s("store-ids", ids))
+		return
+	}
+	for _, id := range ids {
+		evictedSlowStoreStatusGauge.WithLabelValues(strconv.FormatUint(id, 10), string(diskSlowStore)).Set(1)
+	}
+}
+
+func (s *evictSlowStoreScheduler) scheduleDiskSlowStore(cluster sche.SchedulerCluster) {
+	slowStores := collectDiskSlowStores(cluster)
+
+	if s.conf.isEvictingDiskSlowStore() {
+		s.reconcileDiskSlowStoreGroup(cluster, slowStores)
+		return
+	}
+
+	// Detection: nothing is being evicted yet.
+	if len(slowStores) == 0 {
+		return
+	}
+	if len(slowStores) == 1 {
+		// Single slow store: unchanged behavior.
+		if slowStores[0].GetSlowScore() >= slowStoreEvictThreshold {
+			log.Info("detected slow store, start to evict leaders",
+				zap.Uint64("store-id", slowStores[0].GetID()))
+			s.startEvictDiskSlowStores(cluster, slowStores[:1])
+		}
+		return
+	}
+
+	// Multiple slow stores: only proceed when they all live in the same isolation
+	// zone and the topology can still absorb draining that zone.
+	key, ok := groupIsolationKey(cluster)
+	if !ok {
+		// Placement rules do not uniformly enforce an isolation level; fall back to
+		// the conservative behavior (do nothing for more than one slow store).
+		return
+	}
+	zone := slowStores[0].GetLabelValue(key)
+	if zone == "" {
+		return
+	}
+	for _, store := range slowStores {
+		if store.GetLabelValue(key) != zone {
+			// Slow stores span more than one zone; never drain across failure domains.
+			return
+		}
+	}
+	if !hasEnoughHealthyZones(cluster, key, zone) {
+		return
+	}
+
+	var toEvict []*core.StoreInfo
+	for _, store := range slowStores {
+		if store.GetSlowScore() >= slowStoreEvictThreshold {
+			toEvict = append(toEvict, store)
+		}
+	}
+	if len(toEvict) == 0 {
+		// All same-zone slow stores are still below the evict threshold; wait.
+		return
+	}
+	log.Info("detected slow stores in a single isolation zone, start to evict leaders",
+		zap.String("isolation-level", key), zap.String("zone", zone),
+		zap.Uint64s("store-ids", storeIDs(toEvict)))
+	s.startEvictDiskSlowStores(cluster, toEvict)
+}
+
+// reconcileDiskSlowStoreGroup runs each cycle while a zone is being drained: it
+// releases stores that left the cluster, releases the whole group once every
+// evicted store has recovered for the recovery duration, and (unless a slow store
+// has appeared outside the locked zone) adds newly-slow same-zone stores.
+func (s *evictSlowStoreScheduler) reconcileDiskSlowStoreGroup(cluster sche.SchedulerCluster, slowStores []*core.StoreInfo) {
+	evicted := s.conf.evictedStores()
+
+	// Single pass: drop stores that have left the cluster; compute maxScore and
+	// the locked-zone value (all survivors share one zone by construction) from
+	// the same iteration so we only call GetStore once per evicted id.
+	var (
+		gone       []uint64
+		maxScore   uint64
+		lockedZone string
+		survivorID uint64
+	)
+	for _, id := range evicted {
+		store := cluster.GetStore(id)
+		if store == nil || store.IsRemoved() {
+			gone = append(gone, id)
+			continue
+		}
+		if score := store.GetSlowScore(); score > maxScore {
+			maxScore = score
+		}
+		survivorID = id
+	}
+	if len(gone) > 0 {
+		removed, err := s.conf.removeEvictedAndPersist(gone)
+		if err != nil {
+			log.Info("evict-slow-store-scheduler persist config failed", zap.Uint64s("store-ids", gone), zap.Error(err))
+			return
+		}
+		for _, id := range removed {
+			log.Info("evicted slow store has been removed", zap.Uint64("store-id", id))
+			cluster.SlowStoreRecovered(id)
+			evictedSlowStoreStatusGauge.DeleteLabelValues(strconv.FormatUint(id, 10), string(diskSlowStore))
+		}
+	}
+	if !s.conf.isEvictingDiskSlowStore() {
+		// All evicted stores have left the cluster.
+		return
+	}
+
+	// Group recovery: release the whole group only when every evicted store has
+	// recovered below the threshold for the recovery duration.
+	if maxScore <= slowStoreRecoverThreshold {
+		if err := s.conf.tryUpdateRecoverStatus(true); err != nil {
+			log.Info("evict-slow-store-scheduler persist config failed", zap.Error(err))
+			return
+		}
+		if !s.conf.readyForRecovery() {
+			return
+		}
+		log.Info("slow store group has been recovered", zap.Uint64s("store-ids", s.conf.evictedStores()))
+		s.cleanupEvictLeader(cluster)
+		return
+	}
+	if err := s.conf.tryUpdateRecoverStatus(false); err != nil {
+		log.Info("evict-slow-store-scheduler persist config failed", zap.Error(err))
+		return
+	}
+
+	// Resolve the locked zone from a surviving evicted store. If the grouping key
+	// is no longer well-defined (rules changed), keep draining but do not expand.
+	// survivorID is always set here because isEvictingDiskSlowStore returned true
+	// and every surviving store was visited in the loop above.
+	key, ok := groupIsolationKey(cluster)
+	if !ok {
+		return
+	}
+	if survivor := cluster.GetStore(survivorID); survivor != nil {
+		lockedZone = survivor.GetLabelValue(key)
+	}
+	if lockedZone == "" {
+		return
+	}
+
+	// Freeze brake: if any slow store sits outside the locked zone, stop expanding
+	// the eviction set (we never start draining a second zone).
+	for _, store := range slowStores {
+		if store.GetLabelValue(key) != lockedZone {
+			return
 		}
 	}
 
-	if slowStore == nil || slowStore.GetSlowScore() < slowStoreEvictThreshold {
+	// Only expand if the topology can still absorb draining the locked zone.
+	// This prevents the single-store → reconcile-add bypass of the zone guard.
+	if !hasEnoughHealthyZones(cluster, key, lockedZone) {
 		return
 	}
 
-	// If there is only one slow store, evict leaders from that store.
-	log.Info("detected slow store, start to evict leaders",
-		zap.Uint64("store-id", slowStore.GetID()))
-	err := s.prepareEvictLeader(cluster, slowStore.GetID())
-	if err != nil {
-		log.Info("prepare for evicting leader failed", zap.Error(err), zap.Uint64("store-id", slowStore.GetID()))
-		return
+	// Reconcile: add newly-slow same-zone stores that reached the evict threshold.
+	// EvictedAsSlowStore() is the authoritative "already marked" check; it covers
+	// both disk- and network-evicted stores, so no separate set is needed.
+	var toAdd []*core.StoreInfo
+	for _, store := range slowStores {
+		if store.EvictedAsSlowStore() {
+			continue
+		}
+		if store.GetLabelValue(key) == lockedZone && store.GetSlowScore() >= slowStoreEvictThreshold {
+			toAdd = append(toAdd, store)
+		}
 	}
-	// Record the slow store evicted status.
-	storeIDStr := strconv.FormatUint(slowStore.GetID(), 10)
-	evictedSlowStoreStatusGauge.WithLabelValues(storeIDStr, string(diskSlowStore)).Set(1)
+	if len(toAdd) > 0 {
+		log.Info("adding newly-slow stores in the locked zone to eviction",
+			zap.String("zone", lockedZone), zap.Uint64s("store-ids", storeIDs(toAdd)))
+		s.startEvictDiskSlowStores(cluster, toAdd)
+	}
 }
 
 // newEvictSlowStoreScheduler creates a scheduler that detects and evicts slow stores.

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -92,7 +92,7 @@ type evictSlowStoreSchedulerConfig struct {
 	// EnableGroupEviction allows the disk slow store scheduler to evict leaders from every
 	// slow store that shares one isolation domain, instead of only a single store. The
 	// domain is derived from the placement rules (see groupIsolationLabels), so this switch
-	// only turns the behavior off; it never widens what counts as one domain. Enabled by
+	// only opts into the behavior; it never widens what counts as one domain. Disabled by
 	// default.
 	EnableGroupEviction      bool     `json:"enable-group-eviction"`
 	EnableNetworkSlowStore   bool     `json:"enable-network-slow-store"`
@@ -109,7 +109,7 @@ func initEvictSlowStoreSchedulerConfig() *evictSlowStoreSchedulerConfig {
 		lastSlowStoreCaptureTS:          time.Time{},
 		RecoverySec:                     defaultRecoverySec,
 		EvictedStores:                   make([]uint64, 0),
-		EnableGroupEviction:             true,
+		EnableGroupEviction:             false,
 		Batch:                           EvictLeaderBatchSize,
 		EnableNetworkSlowStore:          false,
 		PausedNetworkSlowStores:         make([]uint64, 0),
@@ -459,9 +459,7 @@ func (s *evictSlowStoreScheduler) ReloadConfig() error {
 	s.conf.Lock()
 	defer s.conf.Unlock()
 
-	// Seed the defaults that differ from the zero value so a persisted config written
-	// before the field existed keeps the default instead of silently reading as false.
-	newCfg := &evictSlowStoreSchedulerConfig{EnableGroupEviction: true}
+	newCfg := &evictSlowStoreSchedulerConfig{}
 	if err := s.conf.load(newCfg); err != nil {
 		return err
 	}

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -35,6 +34,7 @@ import (
 	sche "github.com/tikv/pd/pkg/schedule/core"
 	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/plan"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/utils/apiutil"
@@ -89,11 +89,12 @@ type evictSlowStoreSchedulerConfig struct {
 	RecoverySec uint64 `json:"recovery-duration"`
 	// EvictedStores is only used by disk slow store scheduler
 	EvictedStores []uint64 `json:"evict-stores"`
-	// GroupEvictionLabels are the location labels (e.g. ["zone"] or ["zone","rack"]) that
-	// define a drainable failure domain. When set, the disk slow store scheduler evicts
-	// leaders from all slow stores that share these label values. Empty disables grouping
-	// and falls back to single-store eviction.
-	GroupEvictionLabels      []string `json:"group-eviction-labels"`
+	// EnableGroupEviction allows the disk slow store scheduler to evict leaders from every
+	// slow store that shares one isolation domain, instead of only a single store. The
+	// domain is derived from the placement rules (see groupIsolationLabels), so this switch
+	// only turns the behavior off; it never widens what counts as one domain. Enabled by
+	// default.
+	EnableGroupEviction      bool     `json:"enable-group-eviction"`
 	EnableNetworkSlowStore   bool     `json:"enable-network-slow-store"`
 	PausedNetworkSlowStores  []uint64 `json:"paused-network-slow-stores"`
 	EvictedNetworkSlowStores []uint64 `json:"evicted-network-slow-stores"`
@@ -108,7 +109,7 @@ func initEvictSlowStoreSchedulerConfig() *evictSlowStoreSchedulerConfig {
 		lastSlowStoreCaptureTS:          time.Time{},
 		RecoverySec:                     defaultRecoverySec,
 		EvictedStores:                   make([]uint64, 0),
-		GroupEvictionLabels:             make([]string, 0),
+		EnableGroupEviction:             true,
 		Batch:                           EvictLeaderBatchSize,
 		EnableNetworkSlowStore:          false,
 		PausedNetworkSlowStores:         make([]uint64, 0),
@@ -123,7 +124,7 @@ func (conf *evictSlowStoreSchedulerConfig) persistLocked(updateFn func()) error 
 		oldNetworkSlowStoreRecoverStartAts = make(map[uint64]*time.Time)
 		oldIsRecovered                     = conf.isRecovered
 		oldEvictedStores                   = conf.EvictedStores
-		oldGroupEvictionLabels             = conf.GroupEvictionLabels
+		oldEnableGroupEviction             = conf.EnableGroupEviction
 		oldPausedNetworkSlowStores         = conf.PausedNetworkSlowStores
 		oldEvictedNetworkSlowStores        = conf.EvictedNetworkSlowStores
 		oldRecoverySec                     = conf.RecoverySec
@@ -138,7 +139,7 @@ func (conf *evictSlowStoreSchedulerConfig) persistLocked(updateFn func()) error 
 		conf.networkSlowStoreRecoverStartAts = oldNetworkSlowStoreRecoverStartAts
 		conf.isRecovered = oldIsRecovered
 		conf.EvictedStores = oldEvictedStores
-		conf.GroupEvictionLabels = oldGroupEvictionLabels
+		conf.EnableGroupEviction = oldEnableGroupEviction
 		conf.PausedNetworkSlowStores = oldPausedNetworkSlowStores
 		conf.EvictedNetworkSlowStores = oldEvictedNetworkSlowStores
 		conf.RecoverySec = oldRecoverySec
@@ -181,11 +182,11 @@ func (conf *evictSlowStoreSchedulerConfig) isEvictingDiskSlowStore() bool {
 	return len(conf.EvictedStores) > 0
 }
 
-// getGroupEvictionLabels returns a copy of the configured failure-domain labels.
-func (conf *evictSlowStoreSchedulerConfig) getGroupEvictionLabels() []string {
+// isGroupEvictionEnabled reports whether same-domain group eviction is turned on.
+func (conf *evictSlowStoreSchedulerConfig) isGroupEvictionEnabled() bool {
 	conf.RLock()
 	defer conf.RUnlock()
-	return slices.Clone(conf.GroupEvictionLabels)
+	return conf.EnableGroupEviction
 }
 
 func (conf *evictSlowStoreSchedulerConfig) getPausedNetworkSlowStores() []uint64 {
@@ -356,18 +357,6 @@ func newEvictSlowStoreHandler(config *evictSlowStoreSchedulerConfig) http.Handle
 	return router
 }
 
-// parseGroupEvictionLabels splits a comma-separated label string (e.g. "zone,rack") into a
-// trimmed, non-empty label slice. An empty/blank string yields an empty slice (disabled).
-func parseGroupEvictionLabels(s string) []string {
-	labels := make([]string, 0)
-	for _, part := range strings.Split(s, ",") {
-		if part = strings.TrimSpace(part); part != "" {
-			labels = append(labels, part)
-		}
-	}
-	return labels
-}
-
 func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *http.Request) {
 	var input map[string]any
 	if err := apiutil.ReadJSONRespondError(handler.rd, w, r.Body, &input); err != nil {
@@ -397,12 +386,11 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		return
 	}
 
-	groupEvictionLabelsStr, inputGroupEvictionLabels := input["group-eviction-labels"].(string)
-	if input["group-eviction-labels"] != nil && !inputGroupEvictionLabels {
-		handler.rd.JSON(w, http.StatusBadRequest, perrors.New("invalid argument for 'group-eviction-labels'").Error())
+	enableGroupEviction, inputEnableGroupEviction := input["enable-group-eviction"].(bool)
+	if input["enable-group-eviction"] != nil && !inputEnableGroupEviction {
+		handler.rd.JSON(w, http.StatusBadRequest, perrors.New("invalid argument for 'enable-group-eviction'").Error())
 		return
 	}
-	groupEvictionLabels := parseGroupEvictionLabels(groupEvictionLabelsStr)
 
 	handler.config.Lock()
 	defer handler.config.Unlock()
@@ -418,8 +406,8 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		if inputEnableNetworkSlowStore {
 			handler.config.EnableNetworkSlowStore = enableNetworkSlowStore
 		}
-		if inputGroupEvictionLabels {
-			handler.config.GroupEvictionLabels = groupEvictionLabels
+		if inputEnableGroupEviction {
+			handler.config.EnableGroupEviction = enableGroupEviction
 		}
 	}); err != nil {
 		handler.rd.JSON(w, http.StatusInternalServerError, err.Error())
@@ -429,7 +417,7 @@ func (handler *evictSlowStoreHandler) updateConfig(w http.ResponseWriter, r *htt
 		zap.Uint64("cur-recovery-duration", recoverySec),
 		zap.Float64("cur-batch", batchFloat),
 		zap.Bool("cur-enable-network-slow-store", enableNetworkSlowStore),
-		zap.Strings("cur-group-eviction-labels", groupEvictionLabels),
+		zap.Bool("cur-enable-group-eviction", enableGroupEviction),
 	)
 
 	handler.rd.JSON(w, http.StatusOK, "Config updated.")
@@ -442,7 +430,7 @@ func (handler *evictSlowStoreHandler) listConfig(w http.ResponseWriter, _ *http.
 		RecoverySec:              handler.config.RecoverySec,
 		Batch:                    handler.config.Batch,
 		EvictedStores:            handler.config.EvictedStores,
-		GroupEvictionLabels:      handler.config.GroupEvictionLabels,
+		EnableGroupEviction:      handler.config.EnableGroupEviction,
 		EnableNetworkSlowStore:   handler.config.EnableNetworkSlowStore,
 		PausedNetworkSlowStores:  handler.config.PausedNetworkSlowStores,
 		EvictedNetworkSlowStores: handler.config.EvictedNetworkSlowStores,
@@ -471,7 +459,9 @@ func (s *evictSlowStoreScheduler) ReloadConfig() error {
 	s.conf.Lock()
 	defer s.conf.Unlock()
 
-	newCfg := &evictSlowStoreSchedulerConfig{}
+	// Seed the defaults that differ from the zero value so a persisted config written
+	// before the field existed keeps the default instead of silently reading as false.
+	newCfg := &evictSlowStoreSchedulerConfig{EnableGroupEviction: true}
 	if err := s.conf.load(newCfg); err != nil {
 		return err
 	}
@@ -495,7 +485,7 @@ func (s *evictSlowStoreScheduler) ReloadConfig() error {
 	pauseAndResumeLeaderTransfer(s.conf.cluster, constant.In, old, new)
 	s.conf.RecoverySec = newCfg.RecoverySec
 	s.conf.EvictedStores = newCfg.EvictedStores
-	s.conf.GroupEvictionLabels = newCfg.GroupEvictionLabels
+	s.conf.EnableGroupEviction = newCfg.EnableGroupEviction
 	s.conf.PausedNetworkSlowStores = newCfg.PausedNetworkSlowStores
 	s.conf.EvictedNetworkSlowStores = newCfg.EvictedNetworkSlowStores
 	s.conf.EnableNetworkSlowStore = newCfg.EnableNetworkSlowStore
@@ -868,11 +858,49 @@ func filterNetworkSlowScores(
 	return filteredScores
 }
 
-// minRemainingHealthyDomains is the number of distinct failure domains (by the broadest
-// configured label, besides the one being drained) that must still be able to host leaders
-// before PD will group-evict. It prevents draining a domain on a too-small topology where
-// all leaders would pile onto a single survivor.
+// minRemainingHealthyDomains is the number of distinct isolation domains (besides the one
+// being drained) that must still be able to host leaders before PD will group-evict. It
+// prevents draining a domain on a too-small topology where all leaders would pile onto a
+// single survivor.
 const minRemainingHealthyDomains = 2
+
+// isolationPrefix returns the rule's location labels up to and including its isolation
+// level, which is the granularity PD actually isolates replicas at (see NewIsolationFilter):
+// with location-labels ["zone","rack","host"] and isolation-level "rack", replicas are forced
+// into distinct "zone,rack" domains, so that prefix names one drainable domain.
+// It reports false when the rule enforces no isolation level, or when the isolation level is
+// not one of the rule's location labels (then the domain is undefined and we must not group).
+func isolationPrefix(rule *placement.Rule) ([]string, bool) {
+	if rule.IsolationLevel == "" {
+		return nil, false
+	}
+	idx := slices.Index(rule.LocationLabels, rule.IsolationLevel)
+	if idx < 0 {
+		return nil, false
+	}
+	return rule.LocationLabels[:idx+1], true
+}
+
+// groupIsolationLabels returns the labels that identify a drainable failure domain. Group
+// eviction is only allowed when every placement rule enforces the same non-empty isolation
+// prefix, so draining a single domain is known to be safe for every region.
+func groupIsolationLabels(cluster sche.SchedulerCluster) ([]string, bool) {
+	rules := cluster.GetRuleManager().GetAllRules() // includes default one
+	if len(rules) == 0 {
+		return nil, false
+	}
+	labels, ok := isolationPrefix(rules[0])
+	if !ok {
+		return nil, false
+	}
+	for _, r := range rules[1:] {
+		other, ok := isolationPrefix(r)
+		if !ok || !slices.Equal(labels, other) {
+			return nil, false
+		}
+	}
+	return labels, true
+}
 
 // collectDiskSlowStores returns the serving/preparing stores that are currently slow.
 func collectDiskSlowStores(cluster sche.SchedulerCluster) []*core.StoreInfo {
@@ -907,7 +935,7 @@ func hasAllLabels(store *core.StoreInfo, labels []string) bool {
 }
 
 // sameLocation reports whether store is in the same failure domain as ref for the
-// configured labels. It requires store to have all labels set, so an unlabeled store is
+// isolation labels. It requires store to have all labels set, so an unlabeled store is
 // never treated as co-located (CompareLocation alone would treat a missing label as a
 // wildcard match).
 func sameLocation(ref, store *core.StoreInfo, labels []string) bool {
@@ -943,7 +971,7 @@ func eligibleHealthyLeaderTargets(cluster sche.SchedulerCluster, stores []*core.
 }
 
 // hasEnoughHealthyDomains reports whether at least minRemainingHealthyDomains distinct
-// failure domains (by all configured labels) other than the drained store's domain still
+// failure domains (by all isolation labels) other than the drained store's domain still
 // have a store able to host leaders. Domains are deduplicated with CompareLocation so the
 // counting stays consistent with the grouping decision.
 func hasEnoughHealthyDomains(cluster sche.SchedulerCluster, labels []string, drained *core.StoreInfo) bool {
@@ -1003,16 +1031,21 @@ func (s *evictSlowStoreScheduler) scheduleDiskSlowStore(cluster sche.SchedulerCl
 		return
 	}
 
-	// Multiple slow stores: group eviction only when group-eviction-labels is configured and
-	// every slow store shares that failure domain.
-	labels := s.conf.getGroupEvictionLabels()
-	if len(labels) == 0 {
+	// Multiple slow stores: group eviction only when it is enabled, the placement rules
+	// define one isolation domain, and every slow store shares that domain.
+	if !s.conf.isGroupEvictionEnabled() {
 		// Grouping disabled; keep the conservative behavior (do nothing for 2+ slow stores).
+		return
+	}
+	labels, ok := groupIsolationLabels(cluster)
+	if !ok {
+		// Placement rules do not uniformly enforce an isolation level; fall back to the
+		// conservative behavior (do nothing for more than one slow store).
 		return
 	}
 	ref := slowStores[0]
 	if !hasAllLabels(ref, labels) {
-		// Reference store is missing a configured label; cannot determine its domain.
+		// Reference store is missing an isolation label; cannot determine its domain.
 		return
 	}
 	for _, store := range slowStores[1:] {
@@ -1036,8 +1069,8 @@ func (s *evictSlowStoreScheduler) scheduleDiskSlowStore(cluster sche.SchedulerCl
 		// All same-domain slow stores are still below the evict threshold; wait.
 		return
 	}
-	log.Info("detected slow stores in a single failure domain, start to evict leaders",
-		zap.Strings("group-eviction-labels", labels),
+	log.Info("detected slow stores in a single isolation domain, start to evict leaders",
+		zap.Strings("isolation-labels", labels),
 		zap.Uint64s("store-ids", storeIDs(toEvict)))
 	s.startEvictDiskSlowStores(cluster, toEvict)
 }
@@ -1104,12 +1137,16 @@ func (s *evictSlowStoreScheduler) reconcileDiskSlowStoreGroup(cluster sche.Sched
 		return
 	}
 
-	// Expansion is config-driven. If group-eviction-labels was cleared (or the locked store no
-	// longer carries the labels), keep draining the current group but do not expand.
+	// Resolve the locked domain from a surviving evicted store. If grouping was turned off,
+	// the isolation prefix is no longer well-defined (rules changed), or the locked store no
+	// longer carries the labels, keep draining the current group but do not expand.
 	// survivorID is always set here because isEvictingDiskSlowStore returned true and
 	// every surviving store was visited in the loop above.
-	labels := s.conf.getGroupEvictionLabels()
-	if len(labels) == 0 {
+	if !s.conf.isGroupEvictionEnabled() {
+		return
+	}
+	labels, ok := groupIsolationLabels(cluster)
+	if !ok {
 		return
 	}
 	lockedRef := cluster.GetStore(survivorID)
@@ -1145,7 +1182,7 @@ func (s *evictSlowStoreScheduler) reconcileDiskSlowStoreGroup(cluster sche.Sched
 	}
 	if len(toAdd) > 0 {
 		log.Info("adding newly-slow stores in the locked domain to eviction",
-			zap.Strings("group-eviction-labels", labels), zap.Uint64s("store-ids", storeIDs(toAdd)))
+			zap.Strings("isolation-labels", labels), zap.Uint64s("store-ids", storeIDs(toAdd)))
 		s.startEvictDiskSlowStores(cluster, toAdd)
 	}
 }

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -943,7 +943,11 @@ func sameLocation(ref, store *core.StoreInfo, labels []string) bool {
 // eligibleHealthyLeaderTargets returns the stores that could actually receive leaders,
 // applying the same target-store checks as a leader transfer (StoreStateFilter with
 // TransferLeader set) so the domain counting matches what the operator layer will accept.
-// It additionally drops disk-slow stores, which the leader-target filter does not reject.
+// It additionally drops:
+//   - non-TiKV stores: a leader can only move to a voter, and TiFlash keeps learners only,
+//     so those stores never appear in the per-region follower candidates that
+//     scheduleEvictLeaderOnce picks from. StoreStateFilter does not check the engine.
+//   - disk-slow stores, which the leader-target filter does not reject either.
 func eligibleHealthyLeaderTargets(cluster sche.SchedulerCluster, stores []*core.StoreInfo) []*core.StoreInfo {
 	candidates := filter.NewCandidates(stores).
 		FilterTarget(
@@ -960,7 +964,7 @@ func eligibleHealthyLeaderTargets(cluster sche.SchedulerCluster, stores []*core.
 
 	healthy := candidates[:0]
 	for _, store := range candidates {
-		if store.IsSlow() {
+		if !store.IsTiKV() || store.IsSlow() {
 			continue
 		}
 		healthy = append(healthy, store)

--- a/pkg/schedule/schedulers/evict_slow_store.go
+++ b/pkg/schedule/schedulers/evict_slow_store.go
@@ -15,7 +15,6 @@
 package schedulers
 
 import (
-	"errors"
 	"net/http"
 	"slices"
 	"strconv"
@@ -34,7 +33,6 @@ import (
 	sche "github.com/tikv/pd/pkg/schedule/core"
 	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/operator"
-	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/plan"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/utils/apiutil"
@@ -492,26 +490,51 @@ func (s *evictSlowStoreScheduler) ReloadConfig() error {
 }
 
 // PrepareConfig implements the Scheduler interface.
+//
+// It is atomic: on any failure it undoes the marks it already applied and returns the error,
+// so a caller that aborts (Controller.AddScheduler does not start the scheduler, and hence
+// never runs CleanConfig) cannot leave a store excluded from leader transfers with nothing
+// left to recover it. This matters because slowStoreEvicted is a balanced counter, not a
+// flag: a leaked increment is never cleared by a later evict/recover round trip.
 func (s *evictSlowStoreScheduler) PrepareConfig(cluster sche.SchedulerCluster) error {
-	errs := make([]error, 0)
-
-	for _, evictStore := range s.conf.evictedStores() {
-		if err := cluster.SlowStoreEvicted(evictStore); err != nil {
-			errs = append(errs, err)
+	var (
+		evicted []uint64 // stores marked as slow-evicted
+		paused  []uint64 // stores whose inbound leader transfer was paused
+	)
+	rollback := func() {
+		for _, storeID := range paused {
+			cluster.ResumeLeaderTransfer(storeID, constant.In)
+			delete(s.conf.networkSlowStoreRecoverStartAts, storeID)
 		}
+		for _, storeID := range evicted {
+			cluster.SlowStoreRecovered(storeID)
+		}
+	}
+
+	for _, storeID := range s.conf.evictedStores() {
+		if err := cluster.SlowStoreEvicted(storeID); err != nil {
+			rollback()
+			return err
+		}
+		evicted = append(evicted, storeID)
 	}
 	for _, storeID := range s.conf.getPausedNetworkSlowStores() {
 		s.conf.networkSlowStoreRecoverStartAts[storeID] = nil
 		if err := cluster.PauseLeaderTransfer(storeID, constant.In); err != nil {
-			errs = append(errs, err)
+			delete(s.conf.networkSlowStoreRecoverStartAts, storeID)
+			rollback()
+			return err
 		}
+		paused = append(paused, storeID)
 	}
 	for _, storeID := range s.conf.getEvictNetworkSlowStores() {
 		if err := cluster.SlowStoreEvicted(storeID); err != nil {
-			errs = append(errs, err)
+			rollback()
+			return err
 		}
+		evicted = append(evicted, storeID)
 	}
-	return errors.Join(errs...)
+	return nil
 }
 
 // CleanConfig implements the Scheduler interface.
@@ -862,42 +885,15 @@ func filterNetworkSlowScores(
 // single survivor.
 const minRemainingHealthyDomains = 2
 
-// isolationPrefix returns the rule's location labels up to and including its isolation
-// level, which is the granularity PD actually isolates replicas at (see NewIsolationFilter):
-// with location-labels ["zone","rack","host"] and isolation-level "rack", replicas are forced
-// into distinct "zone,rack" domains, so that prefix names one drainable domain.
-// It reports false when the rule enforces no isolation level, or when the isolation level is
-// not one of the rule's location labels (then the domain is undefined and we must not group).
-func isolationPrefix(rule *placement.Rule) ([]string, bool) {
-	if rule.IsolationLevel == "" {
-		return nil, false
-	}
-	idx := slices.Index(rule.LocationLabels, rule.IsolationLevel)
-	if idx < 0 {
-		return nil, false
-	}
-	return rule.LocationLabels[:idx+1], true
-}
-
 // groupIsolationLabels returns the labels that identify a drainable failure domain. Group
 // eviction is only allowed when every placement rule enforces the same non-empty isolation
 // prefix, so draining a single domain is known to be safe for every region.
+//
+// This runs on every detection and reconciliation cycle, so it must stay cheap: it delegates
+// to GetIsolationPrefix rather than GetAllRules, which would clone every rule through JSON
+// and sort the result on each call.
 func groupIsolationLabels(cluster sche.SchedulerCluster) ([]string, bool) {
-	rules := cluster.GetRuleManager().GetAllRules() // includes default one
-	if len(rules) == 0 {
-		return nil, false
-	}
-	labels, ok := isolationPrefix(rules[0])
-	if !ok {
-		return nil, false
-	}
-	for _, r := range rules[1:] {
-		other, ok := isolationPrefix(r)
-		if !ok || !slices.Equal(labels, other) {
-			return nil, false
-		}
-	}
-	return labels, true
+	return cluster.GetRuleManager().GetIsolationPrefix()
 }
 
 // collectDiskSlowStores returns the serving/preparing stores that are currently slow.

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -23,11 +23,13 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
@@ -115,7 +117,7 @@ func (suite *evictSlowStoreTestSuite) TestEvictSlowStore() {
 
 	es2, ok := suite.es.(*evictSlowStoreScheduler)
 	re.True(ok)
-	re.Zero(es2.conf.evictStore())
+	re.Empty(es2.conf.evictedStores())
 
 	// check the value from storage.
 	var persistValue evictSlowStoreSchedulerConfig
@@ -123,7 +125,7 @@ func (suite *evictSlowStoreTestSuite) TestEvictSlowStore() {
 	re.NoError(err)
 
 	re.Equal(es2.conf.EvictedStores, persistValue.EvictedStores)
-	re.Zero(persistValue.evictStore())
+	re.Empty(persistValue.evictedStores())
 	re.True(persistValue.readyForRecovery())
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
 }
@@ -601,14 +603,13 @@ func (suite *evictSlowStoreTestSuite) TestEvictSlowStorePrepare() {
 	re := suite.Require()
 	es2, ok := suite.es.(*evictSlowStoreScheduler)
 	re.True(ok)
-	re.Zero(es2.conf.evictStore())
+	re.Empty(es2.conf.evictedStores())
 	// prepare with no evict store.
 	err := suite.es.PrepareConfig(suite.tc)
 	re.NoError(err)
 
-	err = es2.conf.setStoreAndPersist(1)
-	re.NoError(err)
-	re.Equal(uint64(1), es2.conf.evictStore())
+	re.NoError(es2.conf.setEvictedStoresAndPersist([]uint64{1}))
+	re.ElementsMatch([]uint64{1}, es2.conf.evictedStores())
 	re.False(es2.conf.readyForRecovery())
 	// prepare with evict store.
 	err = suite.es.PrepareConfig(suite.tc)
@@ -680,7 +681,7 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 
 	es2, ok := es.(*evictSlowStoreScheduler)
 	re.True(ok)
-	re.Zero(es2.conf.evictStore())
+	re.Empty(es2.conf.evictedStores())
 
 	// check the value from storage.
 	var persistValue evictSlowStoreSchedulerConfig
@@ -688,7 +689,7 @@ func TestEvictSlowStoreBatch(t *testing.T) {
 	re.NoError(err)
 
 	re.Equal(es2.conf.EvictedStores, persistValue.EvictedStores)
-	re.Zero(persistValue.evictStore())
+	re.Empty(persistValue.evictedStores())
 	re.True(persistValue.readyForRecovery())
 	re.Equal(5, persistValue.Batch)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
@@ -732,7 +733,7 @@ func TestRecoveryTime(t *testing.T) {
 	ops, _ := es.Schedule(tc, false)
 	re.NotEmpty(ops)
 	re.Equal(types.EvictSlowStoreScheduler.String(), ops[0].Desc())
-	re.Equal(uint64(1), es.(*evictSlowStoreScheduler).conf.evictStore())
+	re.ElementsMatch([]uint64{1}, es.(*evictSlowStoreScheduler).conf.evictedStores())
 
 	// Store recovers from being slow
 	time.Sleep(recoveryTime)
@@ -747,7 +748,7 @@ func TestRecoveryTime(t *testing.T) {
 		es.Schedule(tc, false)
 		ops, _ = bs.Schedule(tc, false)
 		re.Empty(ops)
-		re.Equal(uint64(1), es.(*evictSlowStoreScheduler).conf.evictStore())
+		re.ElementsMatch([]uint64{1}, es.(*evictSlowStoreScheduler).conf.evictedStores())
 	}
 
 	// Store is slow again before recovery time is over
@@ -763,7 +764,7 @@ func TestRecoveryTime(t *testing.T) {
 		es.Schedule(tc, false)
 		ops, _ = bs.Schedule(tc, false)
 		re.Empty(ops)
-		re.Equal(uint64(1), es.(*evictSlowStoreScheduler).conf.evictStore())
+		re.ElementsMatch([]uint64{1}, es.(*evictSlowStoreScheduler).conf.evictedStores())
 	}
 
 	// Store recovers from being slow
@@ -779,7 +780,7 @@ func TestRecoveryTime(t *testing.T) {
 		es.Schedule(tc, false)
 		ops, _ = bs.Schedule(tc, false)
 		re.Empty(ops)
-		re.Equal(uint64(1), es.(*evictSlowStoreScheduler).conf.evictStore())
+		re.ElementsMatch([]uint64{1}, es.(*evictSlowStoreScheduler).conf.evictedStores())
 	}
 
 	// Should now recover
@@ -789,13 +790,13 @@ func TestRecoveryTime(t *testing.T) {
 
 	ops, _ = bs.Schedule(tc, false)
 	re.Empty(ops)
-	re.Empty(es.(*evictSlowStoreScheduler).conf.evictStore())
+	re.Empty(es.(*evictSlowStoreScheduler).conf.evictedStores())
 
 	// Verify persistence
 	var persistValue evictSlowStoreSchedulerConfig
 	err = es.(*evictSlowStoreScheduler).conf.load(&persistValue)
 	re.NoError(err)
-	re.Zero(persistValue.evictStore())
+	re.Empty(persistValue.evictedStores())
 	re.True(persistValue.readyForRecovery())
 }
 
@@ -809,4 +810,341 @@ func TestCalculateAvgScore(t *testing.T) {
 	re.Equal(uint64(5), calculateAvgScore(map[uint64]uint64{1: 2, 2: 5, 3: 8}))
 	// All zeros
 	re.Equal(uint64(0), calculateAvgScore(map[uint64]uint64{1: 0, 2: 0}))
+}
+
+// setZoneIsolationRule overwrites the default placement rule so every rule
+// enforces zone isolation, enabling same-zone group eviction.
+func setZoneIsolationRule(re *require.Assertions, tc *mockcluster.Cluster) {
+	re.NoError(tc.SetRule(&placement.Rule{
+		GroupID:        placement.DefaultGroupID,
+		ID:             placement.DefaultRuleID,
+		Role:           placement.Voter,
+		Count:          3,
+		LocationLabels: []string{"zone", "host"},
+		IsolationLevel: "zone",
+	}))
+}
+
+func setStoreSlowScore(tc *mockcluster.Cluster, id uint64, score uint64) {
+	tc.PutStore(tc.GetStore(id).Clone(func(store *core.StoreInfo) {
+		store.GetStoreStats().SlowScore = score
+	}))
+}
+
+func createTestEvictSlowStoreScheduler(re *require.Assertions, oc *operator.Controller) Scheduler {
+	es, err := CreateScheduler(types.EvictSlowStoreScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictSlowStoreScheduler, []string{}), nil)
+	re.NoError(err)
+	return es
+}
+
+// TestEvictSlowStoreSameZoneGroup: two slow stores sharing a zone are both evicted.
+func TestEvictSlowStoreSameZoneGroup(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Len(ops, 2)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+	re.True(tc.GetStore(1).EvictedAsSlowStore())
+	re.True(tc.GetStore(2).EvictedAsSlowStore())
+}
+
+// TestEvictSlowStoreCrossZoneNoEvict: slow stores spanning two zones evict nothing.
+func TestEvictSlowStoreCrossZoneNoEvict(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 3, 1, 4)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	// One slow store in z1, another in z2.
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 3, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+	re.False(tc.GetStore(1).EvictedAsSlowStore())
+	re.False(tc.GetStore(3).EvictedAsSlowStore())
+}
+
+// TestEvictSlowStoreNoIsolationRule: without uniform rule isolation, 2+ slow stores
+// fall back to the conservative do-nothing behavior.
+func TestEvictSlowStoreNoIsolationRule(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+	// Note: no zone isolation rule set; the default rule has an empty isolation level.
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+}
+
+// TestEvictSlowStoreInsufficientHealthyZones: a topology with too few zones to
+// absorb a zone drain blocks group eviction.
+func TestEvictSlowStoreInsufficientHealthyZones(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	// Only z1 (slow) and z2 exist; draining z1 leaves a single healthy zone.
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLeaderRegion(1, 1, 3)
+	tc.AddLeaderRegion(2, 2, 3)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+}
+
+// TestEvictSlowStoreReconcileAndFreeze: while draining a zone, newly-slow same-zone
+// stores are added, but a slow store appearing in another zone freezes expansion.
+func TestEvictSlowStoreReconcileAndFreeze(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(5, 0, map[string]string{"zone": "z1", "host": "h5"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+	tc.AddLeaderRegion(5, 5, 3, 4)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	// Step 1: only store 1 slow → single-store eviction.
+	setStoreSlowScore(tc, 1, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1}, conf.evictedStores())
+
+	// Step 2: store 2 (same zone) becomes slow → reconcile adds it.
+	setStoreSlowScore(tc, 2, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+
+	// Step 3: a store in another zone goes slow → freeze; a new z1 store is NOT added.
+	setStoreSlowScore(tc, 3, 100)
+	setStoreSlowScore(tc, 5, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+	re.False(tc.GetStore(5).EvictedAsSlowStore())
+}
+
+// TestEvictSlowStoreGroupRecovery: the group is released only once every evicted
+// store has recovered.
+func TestEvictSlowStoreGroupRecovery(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+
+	// Only store 1 recovers: the group keeps draining (store 1 stays evicted).
+	setStoreSlowScore(tc, 1, 0)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+	re.True(tc.GetStore(1).EvictedAsSlowStore())
+
+	// Store 2 recovers too: the whole group is released.
+	setStoreSlowScore(tc, 2, 0)
+	es.Schedule(tc, false)
+	re.Empty(conf.evictedStores())
+	re.False(tc.GetStore(1).EvictedAsSlowStore())
+	re.False(tc.GetStore(2).EvictedAsSlowStore())
+}
+
+// TestEvictSlowStoreReconcileInsufficientZones: when a group forms via single-store
+// eviction followed by reconcile, the zone guard must still block expansion if the
+// topology has too few healthy zones to absorb the whole zone being drained.
+func TestEvictSlowStoreReconcileInsufficientZones(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	// Only two zones: z1 (slow) and z2. Draining all of z1 leaves a single healthy zone.
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLeaderRegion(1, 1, 3)
+	tc.AddLeaderRegion(2, 2, 3)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	// Store 1 slow → single-store path evicts it (no zone guard on single-store path,
+	// matching the pre-existing behavior).
+	setStoreSlowScore(tc, 1, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1}, conf.evictedStores())
+
+	// Store 2 (same zone) becomes slow → reconcile must NOT add it because the
+	// topology only has 1 other zone (z2), which is below minRemainingHealthyZones=2.
+	setStoreSlowScore(tc, 2, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1}, conf.evictedStores())
+	re.False(tc.GetStore(2).EvictedAsSlowStore())
+}
+
+// TestEvictSlowStoreRemovedMidDrain: a store that leaves the cluster while being
+// evicted is dropped from the group; the remaining stores keep draining.
+func TestEvictSlowStoreRemovedMidDrain(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+
+	// Store 1 is physically removed from the cluster mid-drain.
+	tc.PutStore(tc.GetStore(1).Clone(func(store *core.StoreInfo) {
+		store.GetMeta().NodeState = metapb.NodeState_Removed
+	}))
+
+	// Next cycle: store 1 is dropped from the eviction set; store 2 keeps draining.
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{2}, conf.evictedStores())
+	re.False(tc.GetStore(1).EvictedAsSlowStore())
+	re.True(tc.GetStore(2).EvictedAsSlowStore())
+}
+
+// TestEvictSlowStoreGroupIdempotent: repeated reconcile cycles never double-mark a
+// store, so a single recovery fully clears the slow-evicted state.
+func TestEvictSlowStoreGroupIdempotent(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+	setZoneIsolationRule(re, tc)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+
+	// Several reconcile cycles with no change must not re-mark the stores.
+	for range 5 {
+		es.Schedule(tc, false)
+	}
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+
+	// A single recovery must fully clear the evicted mark (counter back to zero).
+	setStoreSlowScore(tc, 1, 0)
+	setStoreSlowScore(tc, 2, 0)
+	es.Schedule(tc, false)
+	re.Empty(conf.evictedStores())
+	re.False(tc.GetStore(1).EvictedAsSlowStore())
+	re.False(tc.GetStore(2).EvictedAsSlowStore())
 }

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/operator"
-	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
@@ -812,19 +811,6 @@ func TestCalculateAvgScore(t *testing.T) {
 	re.Equal(uint64(0), calculateAvgScore(map[uint64]uint64{1: 0, 2: 0}))
 }
 
-// setZoneIsolationRule overwrites the default placement rule so every rule
-// enforces zone isolation, enabling same-zone group eviction.
-func setZoneIsolationRule(re *require.Assertions, tc *mockcluster.Cluster) {
-	re.NoError(tc.SetRule(&placement.Rule{
-		GroupID:        placement.DefaultGroupID,
-		ID:             placement.DefaultRuleID,
-		Role:           placement.Voter,
-		Count:          3,
-		LocationLabels: []string{"zone", "host"},
-		IsolationLevel: "zone",
-	}))
-}
-
 func setStoreSlowScore(tc *mockcluster.Cluster, id uint64, score uint64) {
 	tc.PutStore(tc.GetStore(id).Clone(func(store *core.StoreInfo) {
 		store.GetStoreStats().SlowScore = score
@@ -835,6 +821,11 @@ func createTestEvictSlowStoreScheduler(re *require.Assertions, oc *operator.Cont
 	es, err := CreateScheduler(types.EvictSlowStoreScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictSlowStoreScheduler, []string{}), nil)
 	re.NoError(err)
 	return es
+}
+
+// setGroupEvictionLabels configures the failure-domain labels that enable group eviction.
+func setGroupEvictionLabels(es Scheduler, labels ...string) {
+	es.(*evictSlowStoreScheduler).conf.GroupEvictionLabels = labels
 }
 
 // TestEvictSlowStoreSameZoneGroup: two slow stores sharing a zone are both evicted.
@@ -853,9 +844,9 @@ func TestEvictSlowStoreSameZoneGroup(t *testing.T) {
 	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 2, 3, 4)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -880,9 +871,9 @@ func TestEvictSlowStoreCrossZoneNoEvict(t *testing.T) {
 	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 3, 1, 4)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// One slow store in z1, another in z2.
@@ -896,9 +887,9 @@ func TestEvictSlowStoreCrossZoneNoEvict(t *testing.T) {
 	re.False(tc.GetStore(3).EvictedAsSlowStore())
 }
 
-// TestEvictSlowStoreNoIsolationRule: without uniform rule isolation, 2+ slow stores
+// TestEvictSlowStoreDefaultNoGroup: with no group-eviction-labels configured, 2+ slow stores
 // fall back to the conservative do-nothing behavior.
-func TestEvictSlowStoreNoIsolationRule(t *testing.T) {
+func TestEvictSlowStoreDefaultNoGroup(t *testing.T) {
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
@@ -909,9 +900,89 @@ func TestEvictSlowStoreNoIsolationRule(t *testing.T) {
 	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 2, 3, 4)
-	// Note: no zone isolation rule set; the default rule has an empty isolation level.
+	// group-eviction-labels left at its default (empty).
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+}
+
+// TestEvictSlowStoreMultiLevelMatch: group-eviction-labels "zone,rack"; two stores sharing both
+// zone and rack are evicted together.
+func TestEvictSlowStoreMultiLevelMatch(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/schedulers/transientRecoveryGap"))
+	}()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "rack": "r1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "rack": "r2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "rack": "r3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone", "rack")
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+}
+
+// TestEvictSlowStoreMultiLevelDiffer: group-eviction-labels "zone,rack"; stores in the same zone
+// but different racks are NOT a single domain, so no group eviction.
+func TestEvictSlowStoreMultiLevelDiffer(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "rack": "r2", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "rack": "r3", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "rack": "r4", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone", "rack")
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+}
+
+// TestEvictSlowStoreMissingLabel: a slow store missing a configured label is never grouped.
+func TestEvictSlowStoreMissingLabel(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"host": "h2"}) // no zone label
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -935,9 +1006,9 @@ func TestEvictSlowStoreInsufficientHealthyZones(t *testing.T) {
 	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
 	tc.AddLeaderRegion(1, 1, 3)
 	tc.AddLeaderRegion(2, 2, 3)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -967,9 +1038,9 @@ func TestEvictSlowStoreReconcileAndFreeze(t *testing.T) {
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 2, 3, 4)
 	tc.AddLeaderRegion(5, 5, 3, 4)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// Step 1: only store 1 slow → single-store eviction.
@@ -1007,9 +1078,9 @@ func TestEvictSlowStoreGroupRecovery(t *testing.T) {
 	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 2, 3, 4)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1032,7 +1103,7 @@ func TestEvictSlowStoreGroupRecovery(t *testing.T) {
 }
 
 // TestEvictSlowStoreReconcileInsufficientZones: when a group forms via single-store
-// eviction followed by reconcile, the zone guard must still block expansion if the
+// eviction followed by reconcile, the domain guard must still block expansion if the
 // topology has too few healthy zones to absorb the whole zone being drained.
 func TestEvictSlowStoreReconcileInsufficientZones(t *testing.T) {
 	re := require.New(t)
@@ -1049,19 +1120,19 @@ func TestEvictSlowStoreReconcileInsufficientZones(t *testing.T) {
 	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
 	tc.AddLeaderRegion(1, 1, 3)
 	tc.AddLeaderRegion(2, 2, 3)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
-	// Store 1 slow → single-store path evicts it (no zone guard on single-store path,
+	// Store 1 slow → single-store path evicts it (no domain guard on single-store path,
 	// matching the pre-existing behavior).
 	setStoreSlowScore(tc, 1, 100)
 	es.Schedule(tc, false)
 	re.ElementsMatch([]uint64{1}, conf.evictedStores())
 
 	// Store 2 (same zone) becomes slow → reconcile must NOT add it because the
-	// topology only has 1 other zone (z2), which is below minRemainingHealthyZones=2.
+	// topology only has 1 other zone (z2), below minRemainingHealthyDomains=2.
 	setStoreSlowScore(tc, 2, 100)
 	es.Schedule(tc, false)
 	re.ElementsMatch([]uint64{1}, conf.evictedStores())
@@ -1085,9 +1156,9 @@ func TestEvictSlowStoreRemovedMidDrain(t *testing.T) {
 	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 2, 3, 4)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1124,9 +1195,9 @@ func TestEvictSlowStoreGroupIdempotent(t *testing.T) {
 	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 2, 3, 4)
-	setZoneIsolationRule(re, tc)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
+	setGroupEvictionLabels(es, "zone")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -616,6 +616,27 @@ func (suite *evictSlowStoreTestSuite) TestEvictSlowStorePrepare() {
 	re.NoError(err)
 }
 
+func (suite *evictSlowStoreTestSuite) TestEvictSlowStorePrepareAtomic() {
+	re := suite.Require()
+	es2, ok := suite.es.(*evictSlowStoreScheduler)
+	re.True(ok)
+
+	// Store 5 is not in the cluster, so marking it fails. Store 1 is marked first and must
+	// be rolled back: PrepareConfig's caller does not start the scheduler on error, so a
+	// leaked mark would exclude store 1 from leader transfers with nothing left to clear it.
+	re.NoError(es2.conf.setEvictedStoresAndPersist([]uint64{1, 5}))
+	re.Error(suite.es.PrepareConfig(suite.tc))
+	re.False(suite.tc.GetStore(1).EvictedAsSlowStore())
+
+	// The mark is a balanced counter, so a leak would also survive a later evict/recover
+	// round trip. Verify a subsequent successful prepare/clean cycle leaves it at zero.
+	re.NoError(es2.conf.setEvictedStoresAndPersist([]uint64{1}))
+	re.NoError(suite.es.PrepareConfig(suite.tc))
+	re.True(suite.tc.GetStore(1).EvictedAsSlowStore())
+	es2.cleanupEvictLeader(suite.tc)
+	re.False(suite.tc.GetStore(1).EvictedAsSlowStore())
+}
+
 func (suite *evictSlowStoreTestSuite) TestEvictSlowStorePersistFail() {
 	re := suite.Require()
 	persisFail := "github.com/tikv/pd/pkg/schedule/schedulers/persistFail"

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -1187,6 +1187,40 @@ func TestEvictSlowStoreInsufficientHealthyZones(t *testing.T) {
 	re.Empty(conf.evictedStores())
 }
 
+// TestEvictSlowStoreTiFlashNotAHealthyDomain: a TiFlash store must not count as a domain
+// that can host leaders. TiFlash only carries learners, so it never appears in the per-region
+// follower candidates a leader can move to, and counting its zone would let the guard approve
+// draining z1 while only one real TiKV domain survives.
+func TestEvictSlowStoreTiFlashNotAHealthyDomain(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	// z1 is slow, z2 has a healthy TiKV store, z3 has only a TiFlash store.
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4", core.EngineKey: core.EngineTiFlash})
+	tc.AddLeaderRegion(1, 1, 3)
+	tc.AddLeaderRegion(2, 2, 3)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+
+	// Making z3 a real TiKV zone gives two surviving domains, so the drain is allowed.
+	tc.AddLabelsStore(5, 0, map[string]string{"zone": "z3", "host": "h5"})
+	es.Schedule(tc, false)
+	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
+}
+
 // TestEvictSlowStoreReconcileAndFreeze: while draining a zone, newly-slow same-zone
 // stores are added, but a slow store appearing in another zone freezes expansion.
 func TestEvictSlowStoreReconcileAndFreeze(t *testing.T) {

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/operator"
+	"github.com/tikv/pd/pkg/schedule/placement"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
@@ -823,9 +824,17 @@ func createTestEvictSlowStoreScheduler(re *require.Assertions, oc *operator.Cont
 	return es
 }
 
-// setGroupEvictionLabels configures the failure-domain labels that enable group eviction.
-func setGroupEvictionLabels(es Scheduler, labels ...string) {
-	es.(*evictSlowStoreScheduler).conf.GroupEvictionLabels = labels
+// setIsolationRule overwrites the default placement rule so every rule enforces the given
+// isolation level over the given location labels, which is what enables group eviction.
+func setIsolationRule(re *require.Assertions, tc *mockcluster.Cluster, isolationLevel string, locationLabels ...string) {
+	re.NoError(tc.SetRule(&placement.Rule{
+		GroupID:        placement.DefaultGroupID,
+		ID:             placement.DefaultRuleID,
+		Role:           placement.Voter,
+		Count:          3,
+		LocationLabels: locationLabels,
+		IsolationLevel: isolationLevel,
+	}))
 }
 
 // TestEvictSlowStoreSameZoneGroup: two slow stores sharing a zone are both evicted.
@@ -846,7 +855,7 @@ func TestEvictSlowStoreSameZoneGroup(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -873,7 +882,7 @@ func TestEvictSlowStoreCrossZoneNoEvict(t *testing.T) {
 	tc.AddLeaderRegion(2, 3, 1, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// One slow store in z1, another in z2.
@@ -887,9 +896,9 @@ func TestEvictSlowStoreCrossZoneNoEvict(t *testing.T) {
 	re.False(tc.GetStore(3).EvictedAsSlowStore())
 }
 
-// TestEvictSlowStoreDefaultNoGroup: with no group-eviction-labels configured, 2+ slow stores
+// TestEvictSlowStoreNoIsolationRule: without uniform rule isolation, 2+ slow stores
 // fall back to the conservative do-nothing behavior.
-func TestEvictSlowStoreDefaultNoGroup(t *testing.T) {
+func TestEvictSlowStoreNoIsolationRule(t *testing.T) {
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()
 	defer cancel()
@@ -900,7 +909,7 @@ func TestEvictSlowStoreDefaultNoGroup(t *testing.T) {
 	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
 	tc.AddLeaderRegion(1, 1, 3, 4)
 	tc.AddLeaderRegion(2, 2, 3, 4)
-	// group-eviction-labels left at its default (empty).
+	// Note: no isolation rule set; the default rule has an empty isolation level.
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
 	conf := es.(*evictSlowStoreScheduler).conf
@@ -913,8 +922,61 @@ func TestEvictSlowStoreDefaultNoGroup(t *testing.T) {
 	re.Empty(conf.evictedStores())
 }
 
-// TestEvictSlowStoreMultiLevelMatch: group-eviction-labels "zone,rack"; two stores sharing both
-// zone and rack are evicted together.
+// TestEvictSlowStoreGroupEvictionDisabled: even with uniform zone isolation, turning
+// enable-group-eviction off restores the single-store behavior.
+func TestEvictSlowStoreGroupEvictionDisabled(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	setIsolationRule(re, tc, "zone", "zone", "host")
+	conf := es.(*evictSlowStoreScheduler).conf
+	re.True(conf.isGroupEvictionEnabled()) // enabled by default
+	conf.EnableGroupEviction = false
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+}
+
+// TestEvictSlowStoreGroupEvictionDefault: a config persisted before enable-group-eviction
+// existed must keep the enabled default instead of reading back as the false zero value,
+// both when the scheduler is created and when its config is reloaded.
+func TestEvictSlowStoreGroupEvictionDefault(t *testing.T) {
+	re := require.New(t)
+	cancel, _, _, oc := prepareSchedulersTest()
+	defer cancel()
+
+	legacyConfig := []byte(`{"recovery-duration":600,"batch":5}`)
+	st := storage.NewStorageWithMemoryBackend()
+	es, err := CreateScheduler(types.EvictSlowStoreScheduler, oc, st, ConfigJSONDecoder(legacyConfig), nil)
+	re.NoError(err)
+	conf := es.(*evictSlowStoreScheduler).conf
+	re.True(conf.isGroupEvictionEnabled())
+
+	re.NoError(st.SaveSchedulerConfig(es.GetName(), legacyConfig))
+	re.NoError(es.ReloadConfig())
+	re.True(conf.isGroupEvictionEnabled())
+
+	// An explicitly persisted false still wins.
+	re.NoError(st.SaveSchedulerConfig(es.GetName(), []byte(`{"enable-group-eviction":false}`)))
+	re.NoError(es.ReloadConfig())
+	re.False(conf.isGroupEvictionEnabled())
+}
+
+// TestEvictSlowStoreMultiLevelMatch: isolation-level "rack" over location-labels
+// "zone,rack,host" makes "zone,rack" the domain; two stores sharing both are evicted together.
 func TestEvictSlowStoreMultiLevelMatch(t *testing.T) {
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()
@@ -932,7 +994,7 @@ func TestEvictSlowStoreMultiLevelMatch(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone", "rack")
+	setIsolationRule(re, tc, "rack", "zone", "rack", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -942,7 +1004,7 @@ func TestEvictSlowStoreMultiLevelMatch(t *testing.T) {
 	re.ElementsMatch([]uint64{1, 2}, conf.evictedStores())
 }
 
-// TestEvictSlowStoreMultiLevelDiffer: group-eviction-labels "zone,rack"; stores in the same zone
+// TestEvictSlowStoreMultiLevelDiffer: with the "zone,rack" domain, stores in the same zone
 // but different racks are NOT a single domain, so no group eviction.
 func TestEvictSlowStoreMultiLevelDiffer(t *testing.T) {
 	re := require.New(t)
@@ -957,7 +1019,7 @@ func TestEvictSlowStoreMultiLevelDiffer(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone", "rack")
+	setIsolationRule(re, tc, "rack", "zone", "rack", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -968,7 +1030,108 @@ func TestEvictSlowStoreMultiLevelDiffer(t *testing.T) {
 	re.Empty(conf.evictedStores())
 }
 
-// TestEvictSlowStoreMissingLabel: a slow store missing a configured label is never grouped.
+// TestEvictSlowStoreSameIsolationValueDifferentPrefix: with isolation-level "rack" over
+// location-labels "zone,rack,host", two stores that share the rack *value* but sit in
+// different zones are different domains, because PD isolates on the whole "zone,rack"
+// prefix. Comparing only the isolation-level label would wrongly group them.
+func TestEvictSlowStoreSameIsolationValueDifferentPrefix(t *testing.T) {
+	re := require.New(t)
+	cancel, _, tc, oc := prepareSchedulersTest()
+	defer cancel()
+
+	// Stores 1 and 2 both have rack=r1 but live in different zones.
+	tc.AddLabelsStore(1, 0, map[string]string{"zone": "z1", "rack": "r1", "host": "h1"})
+	tc.AddLabelsStore(2, 0, map[string]string{"zone": "z2", "rack": "r1", "host": "h2"})
+	tc.AddLabelsStore(3, 0, map[string]string{"zone": "z3", "rack": "r2", "host": "h3"})
+	tc.AddLabelsStore(4, 0, map[string]string{"zone": "z4", "rack": "r3", "host": "h4"})
+	tc.AddLeaderRegion(1, 1, 3, 4)
+	tc.AddLeaderRegion(2, 2, 3, 4)
+
+	es := createTestEvictSlowStoreScheduler(re, oc)
+	setIsolationRule(re, tc, "rack", "zone", "rack", "host")
+	conf := es.(*evictSlowStoreScheduler).conf
+
+	setStoreSlowScore(tc, 1, 100)
+	setStoreSlowScore(tc, 2, 100)
+
+	ops, _ := es.Schedule(tc, false)
+	re.Empty(ops)
+	re.Empty(conf.evictedStores())
+}
+
+// TestGroupIsolationLabels covers how the drainable domain is derived from placement rules.
+func TestGroupIsolationLabels(t *testing.T) {
+	re := require.New(t)
+
+	rule := func(id, isolationLevel string, locationLabels ...string) *placement.Rule {
+		return &placement.Rule{
+			GroupID:        placement.DefaultGroupID,
+			ID:             id,
+			Role:           placement.Voter,
+			Count:          3,
+			LocationLabels: locationLabels,
+			IsolationLevel: isolationLevel,
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		rules    []*placement.Rule
+		expected []string
+		ok       bool
+	}{
+		{
+			name:  "no isolation level",
+			rules: []*placement.Rule{rule(placement.DefaultRuleID, "", "zone", "host")},
+		},
+		{
+			name:  "isolation level not in location labels",
+			rules: []*placement.Rule{rule(placement.DefaultRuleID, "zone", "rack", "host")},
+		},
+		{
+			name:     "prefix up to the isolation level",
+			rules:    []*placement.Rule{rule(placement.DefaultRuleID, "rack", "zone", "rack", "host")},
+			expected: []string{"zone", "rack"},
+			ok:       true,
+		},
+		{
+			name: "all rules agree",
+			rules: []*placement.Rule{
+				rule(placement.DefaultRuleID, "zone", "zone", "host"),
+				rule("extra", "zone", "zone", "host"),
+			},
+			expected: []string{"zone"},
+			ok:       true,
+		},
+		{
+			name: "one rule enforces no isolation",
+			rules: []*placement.Rule{
+				rule(placement.DefaultRuleID, "zone", "zone", "host"),
+				rule("extra", "", "zone", "host"),
+			},
+		},
+		{
+			name: "rules disagree on the prefix",
+			rules: []*placement.Rule{
+				rule(placement.DefaultRuleID, "zone", "zone", "host"),
+				rule("extra", "rack", "zone", "rack", "host"),
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		cancel, _, tc, _ := prepareSchedulersTest()
+		for _, r := range testCase.rules {
+			re.NoError(tc.SetRule(r), testCase.name)
+		}
+		labels, ok := groupIsolationLabels(tc)
+		re.Equal(testCase.ok, ok, testCase.name)
+		re.Equal(testCase.expected, labels, testCase.name)
+		cancel()
+	}
+}
+
+// TestEvictSlowStoreMissingLabel: a slow store missing an isolation label is never grouped.
 func TestEvictSlowStoreMissingLabel(t *testing.T) {
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()
@@ -982,7 +1145,7 @@ func TestEvictSlowStoreMissingLabel(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1008,7 +1171,7 @@ func TestEvictSlowStoreInsufficientHealthyZones(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1040,7 +1203,7 @@ func TestEvictSlowStoreReconcileAndFreeze(t *testing.T) {
 	tc.AddLeaderRegion(5, 5, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// Step 1: only store 1 slow → single-store eviction.
@@ -1080,7 +1243,7 @@ func TestEvictSlowStoreGroupRecovery(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1122,7 +1285,7 @@ func TestEvictSlowStoreReconcileInsufficientZones(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// Store 1 slow → single-store path evicts it (no domain guard on single-store path,
@@ -1158,7 +1321,7 @@ func TestEvictSlowStoreRemovedMidDrain(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1197,7 +1360,7 @@ func TestEvictSlowStoreGroupIdempotent(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setGroupEvictionLabels(es, "zone")
+	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)

--- a/pkg/schedule/schedulers/evict_slow_store_test.go
+++ b/pkg/schedule/schedulers/evict_slow_store_test.go
@@ -825,7 +825,7 @@ func createTestEvictSlowStoreScheduler(re *require.Assertions, oc *operator.Cont
 }
 
 // setIsolationRule overwrites the default placement rule so every rule enforces the given
-// isolation level over the given location labels, which is what enables group eviction.
+// isolation level over the given location labels, which is what defines the drainable domain.
 func setIsolationRule(re *require.Assertions, tc *mockcluster.Cluster, isolationLevel string, locationLabels ...string) {
 	re.NoError(tc.SetRule(&placement.Rule{
 		GroupID:        placement.DefaultGroupID,
@@ -835,6 +835,13 @@ func setIsolationRule(re *require.Assertions, tc *mockcluster.Cluster, isolation
 		LocationLabels: locationLabels,
 		IsolationLevel: isolationLevel,
 	}))
+}
+
+// enableGroupEviction turns group eviction on (it is off by default) and defines the drainable
+// domain through the placement rules, which are the two preconditions for grouping.
+func enableGroupEviction(re *require.Assertions, tc *mockcluster.Cluster, es Scheduler, isolationLevel string, locationLabels ...string) {
+	setIsolationRule(re, tc, isolationLevel, locationLabels...)
+	es.(*evictSlowStoreScheduler).conf.EnableGroupEviction = true
 }
 
 // TestEvictSlowStoreSameZoneGroup: two slow stores sharing a zone are both evicted.
@@ -855,7 +862,7 @@ func TestEvictSlowStoreSameZoneGroup(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -882,7 +889,7 @@ func TestEvictSlowStoreCrossZoneNoEvict(t *testing.T) {
 	tc.AddLeaderRegion(2, 3, 1, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// One slow store in z1, another in z2.
@@ -922,8 +929,8 @@ func TestEvictSlowStoreNoIsolationRule(t *testing.T) {
 	re.Empty(conf.evictedStores())
 }
 
-// TestEvictSlowStoreGroupEvictionDisabled: even with uniform zone isolation, turning
-// enable-group-eviction off restores the single-store behavior.
+// TestEvictSlowStoreGroupEvictionDisabled: group eviction is off by default, so even with
+// uniform zone isolation 2+ slow stores keep the conservative do-nothing behavior.
 func TestEvictSlowStoreGroupEvictionDisabled(t *testing.T) {
 	re := require.New(t)
 	cancel, _, tc, oc := prepareSchedulersTest()
@@ -939,8 +946,7 @@ func TestEvictSlowStoreGroupEvictionDisabled(t *testing.T) {
 	es := createTestEvictSlowStoreScheduler(re, oc)
 	setIsolationRule(re, tc, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
-	re.True(conf.isGroupEvictionEnabled()) // enabled by default
-	conf.EnableGroupEviction = false
+	re.False(conf.isGroupEvictionEnabled()) // disabled by default
 
 	setStoreSlowScore(tc, 1, 100)
 	setStoreSlowScore(tc, 2, 100)
@@ -950,10 +956,9 @@ func TestEvictSlowStoreGroupEvictionDisabled(t *testing.T) {
 	re.Empty(conf.evictedStores())
 }
 
-// TestEvictSlowStoreGroupEvictionDefault: a config persisted before enable-group-eviction
-// existed must keep the enabled default instead of reading back as the false zero value,
-// both when the scheduler is created and when its config is reloaded.
-func TestEvictSlowStoreGroupEvictionDefault(t *testing.T) {
+// TestEvictSlowStoreGroupEvictionPersisted: the switch survives a config reload, and a config
+// persisted before the field existed reads back as the disabled default.
+func TestEvictSlowStoreGroupEvictionPersisted(t *testing.T) {
 	re := require.New(t)
 	cancel, _, _, oc := prepareSchedulersTest()
 	defer cancel()
@@ -963,16 +968,16 @@ func TestEvictSlowStoreGroupEvictionDefault(t *testing.T) {
 	es, err := CreateScheduler(types.EvictSlowStoreScheduler, oc, st, ConfigJSONDecoder(legacyConfig), nil)
 	re.NoError(err)
 	conf := es.(*evictSlowStoreScheduler).conf
-	re.True(conf.isGroupEvictionEnabled())
+	re.False(conf.isGroupEvictionEnabled())
 
 	re.NoError(st.SaveSchedulerConfig(es.GetName(), legacyConfig))
 	re.NoError(es.ReloadConfig())
-	re.True(conf.isGroupEvictionEnabled())
-
-	// An explicitly persisted false still wins.
-	re.NoError(st.SaveSchedulerConfig(es.GetName(), []byte(`{"enable-group-eviction":false}`)))
-	re.NoError(es.ReloadConfig())
 	re.False(conf.isGroupEvictionEnabled())
+
+	// An explicitly persisted true is picked up.
+	re.NoError(st.SaveSchedulerConfig(es.GetName(), []byte(`{"enable-group-eviction":true}`)))
+	re.NoError(es.ReloadConfig())
+	re.True(conf.isGroupEvictionEnabled())
 }
 
 // TestEvictSlowStoreMultiLevelMatch: isolation-level "rack" over location-labels
@@ -994,7 +999,7 @@ func TestEvictSlowStoreMultiLevelMatch(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "rack", "zone", "rack", "host")
+	enableGroupEviction(re, tc, es, "rack", "zone", "rack", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1019,7 +1024,7 @@ func TestEvictSlowStoreMultiLevelDiffer(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "rack", "zone", "rack", "host")
+	enableGroupEviction(re, tc, es, "rack", "zone", "rack", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1048,7 +1053,7 @@ func TestEvictSlowStoreSameIsolationValueDifferentPrefix(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "rack", "zone", "rack", "host")
+	enableGroupEviction(re, tc, es, "rack", "zone", "rack", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1145,7 +1150,7 @@ func TestEvictSlowStoreMissingLabel(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1171,7 +1176,7 @@ func TestEvictSlowStoreInsufficientHealthyZones(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1203,7 +1208,7 @@ func TestEvictSlowStoreReconcileAndFreeze(t *testing.T) {
 	tc.AddLeaderRegion(5, 5, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// Step 1: only store 1 slow → single-store eviction.
@@ -1243,7 +1248,7 @@ func TestEvictSlowStoreGroupRecovery(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1285,7 +1290,7 @@ func TestEvictSlowStoreReconcileInsufficientZones(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	// Store 1 slow → single-store path evicts it (no domain guard on single-store path,
@@ -1321,7 +1326,7 @@ func TestEvictSlowStoreRemovedMidDrain(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)
@@ -1360,7 +1365,7 @@ func TestEvictSlowStoreGroupIdempotent(t *testing.T) {
 	tc.AddLeaderRegion(2, 2, 3, 4)
 
 	es := createTestEvictSlowStoreScheduler(re, oc)
-	setIsolationRule(re, tc, "zone", "zone", "host")
+	enableGroupEviction(re, tc, es, "zone", "zone", "host")
 	conf := es.(*evictSlowStoreScheduler).conf
 
 	setStoreSlowScore(tc, 1, 100)

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -2594,15 +2594,13 @@ func (c *testCluster) addLeaderStore(storeID uint64, leaderCount int) error {
 	return c.setStore(newStore)
 }
 
-func (c *testCluster) addLabelsStore(storeID uint64, leaderCount int, labels map[string]string) error {
+func (c *testCluster) addLabelsStore(storeID uint64, labels map[string]string) error {
 	storeLabels := make([]*metapb.StoreLabel, 0, len(labels))
 	for k, v := range labels {
 		storeLabels = append(storeLabels, &metapb.StoreLabel{Key: k, Value: v})
 	}
 	newStore := core.NewStoreInfo(&metapb.Store{Id: storeID, Labels: storeLabels, NodeState: metapb.NodeState_Serving},
 		core.SetStoreStats(&pdpb.StoreStats{}),
-		core.SetLeaderCount(leaderCount),
-		core.SetLeaderSize(int64(leaderCount)*10),
 		core.SetLastHeartbeatTS(time.Now()),
 	)
 	if err := c.SetStoreLimit(storeID, storelimit.AddPeer, 60); err != nil {
@@ -3534,12 +3532,12 @@ func TestEvictSlowStoreGroupEviction(t *testing.T) {
 	updateSchedulerConfig(re, controller, types.EvictSlowStoreScheduler.String(), `{"recovery-duration":0}`)
 
 	// Topology: zone z1 = {1,2,3}, z2 = {4,5}, z3 = {6}. Leaders on the z1 stores.
-	re.NoError(tc.addLabelsStore(1, 6, map[string]string{"zone": "z1"}))
-	re.NoError(tc.addLabelsStore(2, 6, map[string]string{"zone": "z1"}))
-	re.NoError(tc.addLabelsStore(3, 6, map[string]string{"zone": "z1"}))
-	re.NoError(tc.addLabelsStore(10, 6, map[string]string{"zone": "z2"}))
-	re.NoError(tc.addLabelsStore(20, 6, map[string]string{"zone": "z2"}))
-	re.NoError(tc.addLabelsStore(100, 6, map[string]string{"zone": "z3"}))
+	re.NoError(tc.addLabelsStore(1, map[string]string{"zone": "z1"}))
+	re.NoError(tc.addLabelsStore(2, map[string]string{"zone": "z1"}))
+	re.NoError(tc.addLabelsStore(3, map[string]string{"zone": "z1"}))
+	re.NoError(tc.addLabelsStore(10, map[string]string{"zone": "z2"}))
+	re.NoError(tc.addLabelsStore(20, map[string]string{"zone": "z2"}))
+	re.NoError(tc.addLabelsStore(100, map[string]string{"zone": "z3"}))
 
 	// markSlow feeds a disk slow score through the real store-heartbeat path.
 	var interval uint64

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2593,6 +2594,28 @@ func (c *testCluster) addLeaderStore(storeID uint64, leaderCount int) error {
 	return c.setStore(newStore)
 }
 
+func (c *testCluster) addLabelsStore(storeID uint64, leaderCount int, labels map[string]string) error {
+	storeLabels := make([]*metapb.StoreLabel, 0, len(labels))
+	for k, v := range labels {
+		storeLabels = append(storeLabels, &metapb.StoreLabel{Key: k, Value: v})
+	}
+	newStore := core.NewStoreInfo(&metapb.Store{Id: storeID, Labels: storeLabels, NodeState: metapb.NodeState_Serving},
+		core.SetStoreStats(&pdpb.StoreStats{}),
+		core.SetLeaderCount(leaderCount),
+		core.SetLeaderSize(int64(leaderCount)*10),
+		core.SetLastHeartbeatTS(time.Now()),
+	)
+	if err := c.SetStoreLimit(storeID, storelimit.AddPeer, 60); err != nil {
+		return err
+	}
+	if err := c.SetStoreLimit(storeID, storelimit.RemovePeer, 60); err != nil {
+		return err
+	}
+	c.Lock()
+	defer c.Unlock()
+	return c.setStore(newStore)
+}
+
 func (c *testCluster) setStoreDown(storeID uint64) error {
 	store := c.GetStore(storeID)
 	newStore := store.Clone(
@@ -3482,6 +3505,108 @@ func TestAddScheduler(t *testing.T) {
 	region3 = waitTransferLeader(re, stream, region3, 1)
 	re.NoError(dispatchHeartbeat(co, region3, stream))
 	waitNoResponse(re, stream)
+}
+
+// updateSchedulerConfig reconfigures a running scheduler in place through its HTTP config
+// handler — the same path pd-ctl and the API use — and asserts the update was accepted.
+func updateSchedulerConfig(re *require.Assertions, controller *schedulers.Controller, name, config string) {
+	handler := controller.GetSchedulerHandlers()[name]
+	re.NotNil(handler)
+	req := httptest.NewRequest(http.MethodPost, "/config", strings.NewReader(config))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	re.Equal(http.StatusOK, recorder.Code)
+}
+
+// TestEvictSlowStoreGroupEviction is an end-to-end test driving the real coordinator:
+// when several stores in the same failure domain (zone) report a high disk slow score and
+// evict-slow-store is configured with group-eviction-labels, the scheduler evicts leaders
+// from all of them, leaves other zones untouched, and releases the whole group on recovery.
+func TestEvictSlowStoreGroupEviction(t *testing.T) {
+	re := require.New(t)
+
+	tc, co, cleanup := prepare(nil, nil, func(co *schedule.Coordinator) { co.Run() }, re)
+	defer cleanup()
+	controller := co.GetSchedulersController()
+
+	// Reconfigure the already-running evict-slow-store scheduler in place
+	// with instant recovery (recovery-duration:0) so the test need not wait out the window.
+	updateSchedulerConfig(re, controller, types.EvictSlowStoreScheduler.String(), `{"recovery-duration":0}`)
+
+	// Topology: zone z1 = {1,2,3}, z2 = {4,5}, z3 = {6}. Leaders on the z1 stores.
+	re.NoError(tc.addLabelsStore(1, 6, map[string]string{"zone": "z1"}))
+	re.NoError(tc.addLabelsStore(2, 6, map[string]string{"zone": "z1"}))
+	re.NoError(tc.addLabelsStore(3, 6, map[string]string{"zone": "z1"}))
+	re.NoError(tc.addLabelsStore(10, 6, map[string]string{"zone": "z2"}))
+	re.NoError(tc.addLabelsStore(20, 6, map[string]string{"zone": "z2"}))
+	re.NoError(tc.addLabelsStore(100, 6, map[string]string{"zone": "z3"}))
+
+	// markSlow feeds a disk slow score through the real store-heartbeat path.
+	var interval uint64
+	markSlow := func(storeID, score uint64) {
+		interval += 10
+		req := &pdpb.StoreHeartbeatRequest{Stats: &pdpb.StoreStats{
+			StoreId:     storeID,
+			Capacity:    100 * units.GiB,
+			Available:   50 * units.GiB,
+			RegionCount: 1,
+			PeerStats:   []*pdpb.PeerStat{},
+			Interval:    &pdpb.TimeInterval{StartTimestamp: interval - 10, EndTimestamp: interval},
+			SlowScore:   score,
+		}}
+		re.NoError(tc.HandleStoreHeartbeat(req, &pdpb.StoreHeartbeatResponse{}))
+	}
+
+	// one node in zone 1 becomes slow
+	markSlow(1, 100)
+	testutil.Eventually(re, func() bool {
+		return tc.GetStore(1).EvictedAsSlowStore()
+	})
+	// second node in zone 1 becomes slow
+	markSlow(2, 100)
+	re.Never(func() bool { // default behavior
+		return tc.GetStore(2).EvictedAsSlowStore()
+	}, time.Second, time.Millisecond*100)
+
+	// enabling group-eviction
+	updateSchedulerConfig(re, controller, types.EvictSlowStoreScheduler.String(),
+		`{"group-eviction-labels":"zone", "recovery-duration":0}`)
+	// now second store gets evicted as well
+	testutil.Eventually(re, func() bool {
+		return tc.GetStore(1).EvictedAsSlowStore() && tc.GetStore(2).EvictedAsSlowStore()
+	})
+
+	// a node outside the first zone becomes slow
+	markSlow(10, 100)
+	// then node in the first zone becomes slow
+	markSlow(3, 100)
+	re.Never(func() bool { // default behavior
+		return tc.GetStore(10).EvictedAsSlowStore() || tc.GetStore(3).EvictedAsSlowStore()
+	}, time.Second, time.Millisecond*100)
+
+	// a node outside the first zone recovers
+	markSlow(10, 0)
+	// third node in the first zone is evicted
+	testutil.Eventually(re, func() bool {
+		return tc.GetStore(1).EvictedAsSlowStore() && tc.GetStore(2).EvictedAsSlowStore() && tc.GetStore(3).EvictedAsSlowStore()
+	})
+
+	// Stores in other zones are never evicted.
+	re.False(tc.GetStore(10).EvictedAsSlowStore())
+	re.False(tc.GetStore(20).EvictedAsSlowStore())
+	re.False(tc.GetStore(100).EvictedAsSlowStore())
+
+	// A full groups should recover before leaders are back
+	markSlow(1, 0)
+	re.Never(func() bool { // default behavior
+		return !tc.GetStore(1).EvictedAsSlowStore()
+	}, time.Second, time.Millisecond*100)
+	// the rest is recovered
+	markSlow(2, 0)
+	markSlow(3, 0)
+	testutil.Eventually(re, func() bool {
+		return !tc.GetStore(1).EvictedAsSlowStore() && !tc.GetStore(2).EvictedAsSlowStore() && !tc.GetStore(3).EvictedAsSlowStore()
+	})
 }
 
 func TestPersistScheduler(t *testing.T) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3528,10 +3528,10 @@ func TestEvictSlowStoreGroupEviction(t *testing.T) {
 	controller := co.GetSchedulersController()
 
 	// Reconfigure the already-running evict-slow-store scheduler in place with instant
-	// recovery (recovery-duration:0) so the test need not wait out the window, and with
-	// group eviction off so the single-store behavior can be observed first.
+	// recovery (recovery-duration:0) so the test need not wait out the window. Group
+	// eviction stays at its disabled default, so the single-store behavior comes first.
 	updateSchedulerConfig(re, controller, types.EvictSlowStoreScheduler.String(),
-		`{"recovery-duration":0, "enable-group-eviction":false}`)
+		`{"recovery-duration":0}`)
 
 	// Every rule enforces zone isolation, so a whole zone is a drainable domain.
 	re.NoError(tc.GetRuleManager().SetRule(&placement.Rule{
@@ -3574,7 +3574,7 @@ func TestEvictSlowStoreGroupEviction(t *testing.T) {
 	})
 	// second node in zone 1 becomes slow
 	markSlow(2, 100)
-	re.Never(func() bool { // group eviction is disabled
+	re.Never(func() bool { // group eviction is disabled by default
 		return tc.GetStore(2).EvictedAsSlowStore()
 	}, time.Second, time.Millisecond*100)
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -3517,9 +3517,9 @@ func updateSchedulerConfig(re *require.Assertions, controller *schedulers.Contro
 }
 
 // TestEvictSlowStoreGroupEviction is an end-to-end test driving the real coordinator:
-// when several stores in the same failure domain (zone) report a high disk slow score and
-// evict-slow-store is configured with group-eviction-labels, the scheduler evicts leaders
-// from all of them, leaves other zones untouched, and releases the whole group on recovery.
+// when several stores in the same isolation domain (zone) report a high disk slow score and
+// the placement rules uniformly enforce zone isolation, the scheduler evicts leaders from all
+// of them, leaves other zones untouched, and releases the whole group on recovery.
 func TestEvictSlowStoreGroupEviction(t *testing.T) {
 	re := require.New(t)
 
@@ -3527,9 +3527,21 @@ func TestEvictSlowStoreGroupEviction(t *testing.T) {
 	defer cleanup()
 	controller := co.GetSchedulersController()
 
-	// Reconfigure the already-running evict-slow-store scheduler in place
-	// with instant recovery (recovery-duration:0) so the test need not wait out the window.
-	updateSchedulerConfig(re, controller, types.EvictSlowStoreScheduler.String(), `{"recovery-duration":0}`)
+	// Reconfigure the already-running evict-slow-store scheduler in place with instant
+	// recovery (recovery-duration:0) so the test need not wait out the window, and with
+	// group eviction off so the single-store behavior can be observed first.
+	updateSchedulerConfig(re, controller, types.EvictSlowStoreScheduler.String(),
+		`{"recovery-duration":0, "enable-group-eviction":false}`)
+
+	// Every rule enforces zone isolation, so a whole zone is a drainable domain.
+	re.NoError(tc.GetRuleManager().SetRule(&placement.Rule{
+		GroupID:        placement.DefaultGroupID,
+		ID:             placement.DefaultRuleID,
+		Role:           placement.Voter,
+		Count:          3,
+		LocationLabels: []string{"zone", "host"},
+		IsolationLevel: "zone",
+	}))
 
 	// Topology: zone z1 = {1,2,3}, z2 = {4,5}, z3 = {6}. Leaders on the z1 stores.
 	re.NoError(tc.addLabelsStore(1, map[string]string{"zone": "z1"}))
@@ -3562,13 +3574,13 @@ func TestEvictSlowStoreGroupEviction(t *testing.T) {
 	})
 	// second node in zone 1 becomes slow
 	markSlow(2, 100)
-	re.Never(func() bool { // default behavior
+	re.Never(func() bool { // group eviction is disabled
 		return tc.GetStore(2).EvictedAsSlowStore()
 	}, time.Second, time.Millisecond*100)
 
-	// enabling group-eviction
+	// enabling group eviction
 	updateSchedulerConfig(re, controller, types.EvictSlowStoreScheduler.String(),
-		`{"group-eviction-labels":"zone", "recovery-duration":0}`)
+		`{"enable-group-eviction":true, "recovery-duration":0}`)
 	// now second store gets evicted as well
 	testutil.Eventually(re, func() bool {
 		return tc.GetStore(1).EvictedAsSlowStore() && tc.GetStore(2).EvictedAsSlowStore()

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -581,7 +581,8 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 	conf1 = make(map[string]any)
 	testutil.Eventually(re, func() bool {
 		tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler", "show"}, &conf)
-		return conf["batch"] == 3. && conf["enable-network-slow-store"] == false && conf["recovery-duration"] == 1800.
+		return conf["batch"] == 3. && conf["enable-network-slow-store"] == false &&
+			conf["enable-group-eviction"] == true && conf["recovery-duration"] == 1800.
 	})
 	echo = tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler", "set", "batch", "10"}, nil)
 	re.Contains(echo, "Success!")
@@ -594,6 +595,12 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 	testutil.Eventually(re, func() bool {
 		tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler"}, &conf1)
 		return conf1["batch"] == 10. && conf1["enable-network-slow-store"] == true && conf["recovery-duration"] == 1800.
+	})
+	echo = tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler", "set", "enable-group-eviction", "false"}, nil)
+	re.Contains(echo, "Success!")
+	testutil.Eventually(re, func() bool {
+		tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler"}, &conf1)
+		return conf1["enable-group-eviction"] == false
 	})
 }
 

--- a/tools/pd-ctl/tests/scheduler/scheduler_test.go
+++ b/tools/pd-ctl/tests/scheduler/scheduler_test.go
@@ -582,7 +582,7 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 	testutil.Eventually(re, func() bool {
 		tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler", "show"}, &conf)
 		return conf["batch"] == 3. && conf["enable-network-slow-store"] == false &&
-			conf["enable-group-eviction"] == true && conf["recovery-duration"] == 1800.
+			conf["enable-group-eviction"] == false && conf["recovery-duration"] == 1800.
 	})
 	echo = tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler", "set", "batch", "10"}, nil)
 	re.Contains(echo, "Success!")
@@ -596,11 +596,11 @@ func (suite *schedulerTestSuite) checkSchedulerConfig(cluster *pdTests.TestClust
 		tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler"}, &conf1)
 		return conf1["batch"] == 10. && conf1["enable-network-slow-store"] == true && conf["recovery-duration"] == 1800.
 	})
-	echo = tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler", "set", "enable-group-eviction", "false"}, nil)
+	echo = tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler", "set", "enable-group-eviction", "true"}, nil)
 	re.Contains(echo, "Success!")
 	testutil.Eventually(re, func() bool {
 		tests.MustExec(re, cmd, []string{"-u", pdAddr, "scheduler", "config", "evict-slow-store-scheduler"}, &conf1)
-		return conf1["enable-group-eviction"] == false
+		return conf1["enable-group-eviction"] == true
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close https://github.com/tikv/pd/issues/10742
This is to address the comment for PR https://github.com/tikv/pd/pull/10743 while the original author is away. 
Please reference the original PR for previous discussions. 

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Please see https://github.com/tikv/pd/pull/10743 
- No code

Code changes

- Has the configuration change
- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grouped disk slow-store eviction based on configurable isolation-domain labels.
  * Group eviction is disabled by default and can be explicitly enabled through scheduler configuration.
  * Recovery waits for all stores in an affected group to become healthy.
  * Single-store eviction remains available when grouping is disabled or topology cannot be safely determined.

* **Bug Fixes**
  * Configuration failures now roll back eviction and pause changes atomically.
  * Improved handling of store removal, topology changes, unhealthy domains, and recovery.
  * Non-TiKV stores are no longer treated as healthy evacuation targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->