### PR TITLE
keyspace: make load by ID return persisted metadata

### DIFF
--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -41,7 +41,8 @@ const (
 type KeyspaceClient interface {
 	// LoadKeyspace load and return target keyspace's metadata.
 	LoadKeyspace(ctx context.Context, name string) (*keyspacepb.KeyspaceMeta, error)
-	// LoadKeyspaceByID loads and returns target keyspace's metadata by ID.
+	// LoadKeyspaceByID loads and returns target keyspace's persisted metadata by ID.
+	// Unlike LoadKeyspace, a successful call does not guarantee that the keyspace region bounds are ready.
 	LoadKeyspaceByID(ctx context.Context, id uint32) (*keyspacepb.KeyspaceMeta, error)
 	// UpdateKeyspaceState updates target keyspace's state.
 	UpdateKeyspaceState(ctx context.Context, id uint32, state keyspacepb.KeyspaceState) (*keyspacepb.KeyspaceMeta, error)
@@ -115,7 +116,8 @@ func (c *client) LoadKeyspace(ctx context.Context, name string) (*keyspacepb.Key
 	return resp.Keyspace, nil
 }
 
-// LoadKeyspaceByID loads and returns target keyspace's metadata by ID.
+// LoadKeyspaceByID loads and returns target keyspace's persisted metadata by ID.
+// Unlike LoadKeyspace, a successful call does not guarantee that the keyspace region bounds are ready.
 func (c *client) LoadKeyspaceByID(ctx context.Context, id uint32) (*keyspacepb.KeyspaceMeta, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span = span.Tracer().StartSpan("keyspaceClient.LoadKeyspaceByID", opentracing.ChildOf(span.Context()))

--- a/server/keyspace_service.go
+++ b/server/keyspace_service.go
@@ -95,6 +95,9 @@ func (s *KeyspaceServer) LoadKeyspaceByID(_ context.Context, request *keyspacepb
 	if err != nil {
 		return &keyspacepb.LoadKeyspaceResponse{Header: getErrorHeader(err)}, nil
 	}
+	// TiKV needs keyspace metadata, including encryption settings, before it can
+	// split the keyspace regions. Checking the region bounds here would create a
+	// circular dependency between loading the metadata and splitting the regions.
 	return &keyspacepb.LoadKeyspaceResponse{
 		Header:   grpcutil.WrapHeader(),
 		Keyspace: meta,

--- a/server/keyspace_service.go
+++ b/server/keyspace_service.go
@@ -95,18 +95,6 @@ func (s *KeyspaceServer) LoadKeyspaceByID(_ context.Context, request *keyspacepb
 	if err != nil {
 		return &keyspacepb.LoadKeyspaceResponse{Header: getErrorHeader(err)}, nil
 	}
-	failpoint.Inject("skipKeyspaceRegionCheck", func() {
-		failpoint.Return(&keyspacepb.LoadKeyspaceResponse{
-			Header:   grpcutil.WrapHeader(),
-			Keyspace: meta,
-		}, nil)
-	})
-	if !manager.CheckKeyspaceRegionBound(meta) {
-		// If the keyspace region is not split yet, we treat it as not found.
-		// To avoid clients using the keyspace before region split is done.
-		err = errs.ErrKeyspaceNotFound
-		return &keyspacepb.LoadKeyspaceResponse{Header: getErrorHeader(err)}, nil
-	}
 	return &keyspacepb.LoadKeyspaceResponse{
 		Header:   grpcutil.WrapHeader(),
 		Keyspace: meta,

--- a/tests/server/keyspace/keyspace_service_test.go
+++ b/tests/server/keyspace/keyspace_service_test.go
@@ -17,14 +17,12 @@ package keyspace
 import (
 	"context"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	keyspacepkg "github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server"
-	pdtests "github.com/tikv/pd/tests"
 )
 
 func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
@@ -53,20 +51,7 @@ func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
 	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
 	re.Nil(resp.GetKeyspace())
 
-	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
-		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     created.GetId(),
-	})
-	re.NoError(err)
-	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
-	re.Nil(resp.GetKeyspace())
-
-	regionBound := keyspacepkg.MakeRegionBound(created.GetId())
-	regionID := uint64(created.GetId()) * 10
-	pdtests.MustPutRegion(re, suite.cluster, regionID+1, 1, regionBound.RawLeftBound, regionBound.RawRightBound)
-	pdtests.MustPutRegion(re, suite.cluster, regionID+2, 1, regionBound.RawRightBound, regionBound.TxnLeftBound)
-	pdtests.MustPutRegion(re, suite.cluster, regionID+3, 1, regionBound.TxnLeftBound, regionBound.TxnRightBound)
-	pdtests.MustPutRegion(re, suite.cluster, regionID+4, 1, regionBound.TxnRightBound, []byte{})
+	re.False(suite.manager.CheckKeyspaceRegionBound(created))
 	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
 		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
 		Id:     created.GetId(),
@@ -74,30 +59,4 @@ func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
 	re.NoError(err)
 	re.Nil(resp.GetHeader().GetError())
 	re.Equal(created, resp.GetKeyspace())
-
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
-	skipRegionCheckKeyspace, err := suite.manager.CreateKeyspace(&keyspacepkg.CreateKeyspaceRequest{
-		Name: "grpc_skip_region",
-	})
-	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
-	re.NoError(err)
-	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
-		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     skipRegionCheckKeyspace.GetId(),
-	})
-	re.NoError(err)
-	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
-	re.Nil(resp.GetKeyspace())
-
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/skipKeyspaceRegionCheck", "return"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/server/skipKeyspaceRegionCheck"))
-	}()
-	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
-		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     skipRegionCheckKeyspace.GetId(),
-	})
-	re.NoError(err)
-	re.Nil(resp.GetHeader().GetError())
-	re.Equal(skipRegionCheckKeyspace, resp.GetKeyspace())
 }

--- a/tests/server/keyspace/keyspace_service_test.go
+++ b/tests/server/keyspace/keyspace_service_test.go
@@ -31,9 +31,16 @@ func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
 		GrpcServer: &server.GrpcServer{Server: suite.server.GetServer()},
 	}
 	ctx := context.Background()
+	const (
+		keyspaceName     = "grpc_load_by_id"
+		encryptionConfig = "test-encryption-config"
+	)
 
 	created, err := suite.manager.CreateKeyspace(&keyspacepkg.CreateKeyspaceRequest{
-		Name: "grpc_load_by_id",
+		Name: keyspaceName,
+		Config: map[string]string{
+			"encryption": encryptionConfig,
+		},
 	})
 	re.NoError(err)
 
@@ -51,12 +58,26 @@ func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
 	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
 	re.Nil(resp.GetKeyspace())
 
-	re.False(suite.manager.CheckKeyspaceRegionBound(created))
+	disabled, err := suite.manager.UpdateKeyspaceStateByID(
+		created.GetId(), keyspacepb.KeyspaceState_DISABLED, 1,
+	)
+	re.NoError(err)
+	re.False(suite.manager.CheckKeyspaceRegionBound(disabled))
 	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
 		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     created.GetId(),
+		Id:     disabled.GetId(),
 	})
 	re.NoError(err)
 	re.Nil(resp.GetHeader().GetError())
-	re.Equal(created, resp.GetKeyspace())
+	re.Equal(disabled, resp.GetKeyspace())
+	re.Equal(keyspacepb.KeyspaceState_DISABLED, resp.GetKeyspace().GetState())
+	re.Equal(encryptionConfig, resp.GetKeyspace().GetConfig()["encryption"])
+
+	resp, err = service.LoadKeyspace(ctx, &keyspacepb.LoadKeyspaceRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
+		Name:   keyspaceName,
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
+	re.Nil(resp.GetKeyspace())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10912

`LoadKeyspaceByID` currently treats an existing keyspace as not found until its region boundaries are split. TiKV may need persisted keyspace metadata, such as the encryption configuration, before it can perform the initial split. This creates a circular dependency and otherwise requires scanning `GetAllKeyspaces`.

### What is changed and how does it work?

```commit-message
Make LoadKeyspaceByID return persisted keyspace metadata without checking region-bound readiness.

Keep the name-based LoadKeyspace readiness behavior unchanged, and update the server test to verify that ID-based lookup succeeds before keyspace region boundaries are split while missing IDs still return ENTRY_NOT_FOUND.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix LoadKeyspaceByID to return existing keyspace metadata before region splitting completes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Loading an existing keyspace by ID now consistently returns the persisted keyspace metadata even if the region has not yet been split or is not region-bound.
  * Requests for nonexistent keyspaces continue to return the appropriate not-found response.
* **Tests**
  * Updated keyspace service test coverage to match the revised LoadKeyspaceByID behavior and streamlined setup.
* **Documentation**
  * Clarified in client docs that LoadKeyspaceByID does not guarantee region-bound readiness, unlike LoadKeyspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->