### PR TITLE
syncer: isolate flow-only updates from full sync

### DIFF
--- a/pkg/ratelimit/runner.go
+++ b/pkg/ratelimit/runner.go
@@ -29,13 +29,14 @@ import (
 
 // RegionHeartbeatStageName is the name of the stage of the region heartbeat.
 const (
-	HandleStatsAsync        = "HandleStatsAsync"
-	ObserveRegionStatsAsync = "ObserveRegionStatsAsync"
-	UpdateSubTree           = "UpdateSubTree"
-	HandleOverlaps          = "HandleOverlaps"
-	CollectRegionStatsAsync = "CollectRegionStatsAsync"
-	SaveRegionToKV          = "SaveRegionToKV"
-	SyncRegionToFollower    = "SyncRegionToFollower"
+	HandleStatsAsync          = "HandleStatsAsync"
+	ObserveRegionStatsAsync   = "ObserveRegionStatsAsync"
+	UpdateSubTree             = "UpdateSubTree"
+	HandleOverlaps            = "HandleOverlaps"
+	CollectRegionStatsAsync   = "CollectRegionStatsAsync"
+	SaveRegionToKV            = "SaveRegionToKV"
+	SyncRegionToFollower      = "SyncRegionToFollower"
+	SyncRegionStatsToFollower = "SyncRegionStatsToFollower"
 )
 
 const (

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -134,6 +134,46 @@ func (h *historyBuffer) record(records ...*core.RegionInfo) {
 	}
 }
 
+func (h *historyBuffer) recordUpdates(updates ...RegionUpdate) int {
+	return h.recordUpdatesFrom(0, false, updates...)
+}
+
+func (h *historyBuffer) recordUpdatesFrom(replayFrom uint64, hasDownstream bool, updates ...RegionUpdate) int {
+	if len(updates) == 0 {
+		return 0
+	}
+	h.Lock()
+	defer h.Unlock()
+	recordCount := len(updates)
+	// A full sync needs only correctness-critical changes for catch-up. Letting
+	// flow-only updates consume the retained window can otherwise exhaust the
+	// bounded history before a large snapshot finishes.
+	skipStats := len(h.retains) > 0
+	if skipStats {
+		recordCount = 0
+		for _, update := range updates {
+			if !update.StatsOnly {
+				recordCount++
+			}
+		}
+	}
+	if recordCount == 0 {
+		return 0
+	}
+	endIndex := h.index + uint64(recordCount)
+	if hasDownstream && replayFrom < endIndex {
+		h.observeRequiredWindowLocked(endIndex - replayFrom)
+	}
+	h.prepareRequiredWindowLocked(uint64(recordCount))
+	for _, update := range updates {
+		if update.StatsOnly && skipStats {
+			continue
+		}
+		h.recordLocked(update.Region)
+	}
+	return recordCount
+}
+
 func (h *historyBuffer) recordLocked(r *core.RegionInfo) {
 	syncIndexGauge.Set(float64(h.index))
 	h.records[h.tail] = r

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -168,11 +168,11 @@ func TestHistoryBufferSkipsStatsOnlyUpdatesDuringFullSync(t *testing.T) {
 	h.resetWithIndex(10)
 	release := h.retainFrom(10)
 
-	statsOnly := newHistoryBufferTestRegion(1)
-	critical := newHistoryBufferTestRegion(2)
+	critical := newHistoryBufferTestRegion(1)
+	statsOnly := critical.Clone(core.SetWrittenBytes(100))
 	re.Equal(1, h.recordUpdates(
-		RegionUpdate{Region: statsOnly, StatsOnly: true},
 		RegionUpdate{Region: critical},
+		RegionUpdate{Region: statsOnly, StatsOnly: true},
 	))
 	re.Equal(uint64(11), h.nextIndex())
 	re.Equal([]*core.RegionInfo{critical}, h.recordsFrom(10))

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -162,6 +162,27 @@ func TestHistoryBufferRetainKeepsCatchUpRecords(t *testing.T) {
 	re.Equal(8, h.capacity())
 }
 
+func TestHistoryBufferSkipsStatsOnlyUpdatesDuringFullSync(t *testing.T) {
+	re := require.New(t)
+	h := newHistoryBufferWithConfig(2, 8, 1, storage.NewStorageWithMemoryBackend())
+	h.resetWithIndex(10)
+	release := h.retainFrom(10)
+
+	statsOnly := newHistoryBufferTestRegion(1)
+	critical := newHistoryBufferTestRegion(2)
+	re.Equal(1, h.recordUpdates(
+		RegionUpdate{Region: statsOnly, StatsOnly: true},
+		RegionUpdate{Region: critical},
+	))
+	re.Equal(uint64(11), h.nextIndex())
+	re.Equal([]*core.RegionInfo{critical}, h.recordsFrom(10))
+
+	release()
+	re.Equal(1, h.recordUpdates(RegionUpdate{Region: statsOnly, StatsOnly: true}))
+	re.Equal(uint64(12), h.nextIndex())
+	re.Equal([]*core.RegionInfo{critical, statsOnly}, h.recordsFrom(10))
+}
+
 func TestHistoryBufferObservedRequiredWindowKeepsSlowDownstreamRecords(t *testing.T) {
 	re := require.New(t)
 	h := newTestHistoryBuffer(8)

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -66,6 +66,14 @@ type ServerStream interface {
 	Send(regions *pdpb.SyncRegionResponse) error
 }
 
+// RegionUpdate is a Region change waiting to be synchronized to followers.
+// StatsOnly updates contain only flow statistics and may be skipped while a
+// full sync retains history records.
+type RegionUpdate struct {
+	Region    *core.RegionInfo
+	StatsOnly bool
+}
+
 type regionSyncStream struct {
 	// stream serializes the underlying gRPC Send calls. A timed-out send may
 	// still be blocked after sendMu is released.
@@ -205,8 +213,8 @@ func historyBufferMaxSizeFromMemory(totalMemory uint64) int {
 
 // RunServer runs the server of the region syncer.
 // regionNotifier is used to get the changed regions.
-func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *core.RegionInfo) {
-	var records []*core.RegionInfo
+func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan RegionUpdate) {
+	var updates []RegionUpdate
 	keepAliveTicker := time.NewTicker(syncerKeepAliveInterval)
 	shrinkTicker := time.NewTicker(historyBufferShrinkInterval)
 
@@ -230,26 +238,33 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 		case first := <-regionNotifier:
 			failpoint.InjectCall("syncRegionChannelFull")
 
-			records = append(records, first)
+			updates = append(updates, first)
 		loop:
 			for range maxSyncRegionBatchSize {
 				select {
-				case region := <-regionNotifier:
-					records = append(records, region)
+				case update := <-regionNotifier:
+					updates = append(updates, update)
 				default:
 					break loop
 				}
 			}
-			s.appendHistoryRecords(records)
-			s.broadcast(ctx, records, false)
+			appended := s.appendHistoryUpdates(updates)
+			s.broadcastAvailable(ctx, appended > 0, false)
 		case <-shrinkTicker.C:
 			s.observeDownstreamReplayWindow(0)
 			s.history.maybeShrink()
 		case <-keepAliveTicker.C:
 			s.broadcast(ctx, nil, true)
 		}
-		records = records[:0]
+		updates = updates[:0]
 	}
+}
+
+func (s *RegionSyncer) appendHistoryUpdates(updates []RegionUpdate) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	minSendIndex, hasDownstream := s.minDownstreamSendIndexLocked()
+	return s.history.recordUpdatesFrom(minSendIndex, hasDownstream, updates...)
 }
 
 func (s *RegionSyncer) appendHistoryRecords(records []*core.RegionInfo) {
@@ -686,13 +701,17 @@ func (s *RegionSyncer) drainDownstreamLocked(ctx context.Context, name string, s
 }
 
 func (s *RegionSyncer) broadcast(ctx context.Context, records []*core.RegionInfo, keepAlive bool) {
+	s.broadcastAvailable(ctx, len(records) != 0, keepAlive)
+}
+
+func (s *RegionSyncer) broadcastAvailable(ctx context.Context, hasRecords, keepAlive bool) {
 	defer logutil.LogPanic()
 	s.mu.RLock()
 	for _, sender := range s.mu.streams {
 		if ctx.Err() != nil {
 			break
 		}
-		if len(records) != 0 || keepAlive {
+		if hasRecords || keepAlive {
 			sender.notify(keepAlive)
 		}
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1438,16 +1438,30 @@ func (c *RaftCluster) processRegionHeartbeat(ctx *core.MetaProcessContext, regio
 	}
 
 	if update, ok := c.prepareRegionUpdateForSync(region, origin, saveKV, needSync); ok {
-		ctx.SyncRegionRunner.RunTask(
-			regionID,
-			ratelimit.SyncRegionToFollower,
-			func(context.Context) {
-				c.changedRegions <- update
-			},
-			ratelimit.WithRetained(true),
-		)
+		c.runRegionUpdateSyncTask(ctx, regionID, update)
 	}
 	return nil
+}
+
+func (c *RaftCluster) runRegionUpdateSyncTask(
+	ctx *core.MetaProcessContext,
+	regionID uint64,
+	update syncer.RegionUpdate,
+) {
+	taskName := ratelimit.SyncRegionToFollower
+	if update.StatsOnly {
+		// Keep stats-only updates in a separate coalescing class so they
+		// cannot replace a pending correctness-critical update.
+		taskName = ratelimit.SyncRegionStatsToFollower
+	}
+	ctx.SyncRegionRunner.RunTask(
+		regionID,
+		taskName,
+		func(context.Context) {
+			c.changedRegions <- update
+		},
+		ratelimit.WithRetained(true),
+	)
 }
 
 func (c *RaftCluster) prepareRegionUpdateForSync(

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -191,7 +191,7 @@ type RaftCluster struct {
 	unsafeRecoveryController *unsaferecovery.Controller
 	progressManager          *progress.Manager
 	regionSyncer             *syncer.RegionSyncer
-	changedRegions           chan *core.RegionInfo
+	changedRegions           chan syncer.RegionUpdate
 	keyspaceGroupManager     *keyspace.GroupManager
 	independentServices      sync.Map
 	hbstreams                *hbstream.HeartbeatStreams
@@ -324,9 +324,9 @@ func (c *RaftCluster) InitCluster(
 	keyspaceGroupManager *keyspace.GroupManager) error {
 	c.opt, c.id = opt.(*config.PersistOptions), id
 	c.ctx, c.cancel = context.WithCancel(c.serverCtx)
-	c.changedRegions = make(chan *core.RegionInfo, defaultChangedRegionsLimit)
+	c.changedRegions = make(chan syncer.RegionUpdate, defaultChangedRegionsLimit)
 	failpoint.Inject("syncRegionChannelFull", func() {
-		c.changedRegions = make(chan *core.RegionInfo, 100)
+		c.changedRegions = make(chan syncer.RegionUpdate, 100)
 	})
 	c.unsafeRecoveryController = unsaferecovery.NewController(c)
 	c.keyspaceGroupManager = keyspaceGroupManager
@@ -1437,17 +1437,39 @@ func (c *RaftCluster) processRegionHeartbeat(ctx *core.MetaProcessContext, regio
 		}
 	}
 
-	if saveKV || needSync {
+	if update, ok := c.prepareRegionUpdateForSync(region, origin, saveKV, needSync); ok {
 		ctx.SyncRegionRunner.RunTask(
 			regionID,
 			ratelimit.SyncRegionToFollower,
 			func(context.Context) {
-				c.changedRegions <- region
+				c.changedRegions <- update
 			},
 			ratelimit.WithRetained(true),
 		)
 	}
 	return nil
+}
+
+func (c *RaftCluster) prepareRegionUpdateForSync(
+	region, origin *core.RegionInfo,
+	saveKV, needSync bool,
+) (syncer.RegionUpdate, bool) {
+	if !saveKV && !needSync {
+		return syncer.RegionUpdate{}, false
+	}
+	statsOnly := !saveKV && needSync && origin != nil &&
+		(region.GetRoundBytesWritten() != origin.GetRoundBytesWritten() ||
+			region.GetRoundBytesRead() != origin.GetRoundBytesRead() ||
+			region.GetFlowRoundDivisor() < origin.GetFlowRoundDivisor()) &&
+		region.GetLeader().GetId() == origin.GetLeader().GetId() &&
+		core.SortedPeersStatsEqual(region.GetDownPeers(), origin.GetDownPeers()) &&
+		core.SortedPeersEqual(region.GetPendingPeers(), origin.GetPendingPeers())
+	// The scheduling service receives the complete heartbeat directly, while
+	// Region Syncer followers use only routing and peer state.
+	if statsOnly && c.IsServiceIndependent(constant.SchedulingServiceName) {
+		return syncer.RegionUpdate{}, false
+	}
+	return syncer.RegionUpdate{Region: region, StatsOnly: statsOnly}, true
 }
 
 func (c *RaftCluster) putMetaLocked(meta *metapb.Cluster) error {
@@ -2181,7 +2203,7 @@ func (c *RaftCluster) OnStoreVersionChange() {
 		zap.Stringer("new-cluster-version", minVersion))
 }
 
-func (c *RaftCluster) changedRegionNotifier() <-chan *core.RegionInfo {
+func (c *RaftCluster) changedRegionNotifier() <-chan syncer.RegionUpdate {
 	return c.changedRegions
 }
 

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -77,6 +77,33 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
 }
 
+type coalescingTaskKey struct {
+	id   uint64
+	name string
+}
+
+type coalescingTaskRunner struct {
+	tasks map[coalescingTaskKey]func(context.Context)
+}
+
+func newCoalescingTaskRunner() *coalescingTaskRunner {
+	return &coalescingTaskRunner{tasks: make(map[coalescingTaskKey]func(context.Context))}
+}
+
+func (r *coalescingTaskRunner) RunTask(
+	id uint64,
+	name string,
+	f func(context.Context),
+	_ ...ratelimit.TaskOption,
+) error {
+	r.tasks[coalescingTaskKey{id: id, name: name}] = f
+	return nil
+}
+
+func (*coalescingTaskRunner) Start(context.Context) {}
+
+func (*coalescingTaskRunner) Stop() {}
+
 func TestStoreHeartbeat(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1237,6 +1264,55 @@ func TestPrepareRegionUpdateForSyncSkipsStatsInMicroserviceMode(t *testing.T) {
 	update, ok := cluster.prepareRegionUpdateForSync(withLeaderChange, origin, saveKV, needSync)
 	re.True(ok)
 	re.False(update.StatsOnly)
+}
+
+func TestSyncRegionCriticalUpdateSurvivesTaskCoalescing(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
+	meta := &metapb.Region{
+		Id:          1,
+		RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1},
+		Peers: []*metapb.Peer{
+			{Id: 1, StoreId: 1},
+			{Id: 2, StoreId: 2},
+		},
+	}
+	origin := core.NewRegionInfo(meta, meta.Peers[0], core.WithFlowRoundByDigit(2))
+	cluster.PutRegion(origin)
+
+	runner := newCoalescingTaskRunner()
+	processCtx := core.ContextTODO()
+	processCtx.SyncRegionRunner = runner
+	critical := origin.Clone(core.WithLeader(meta.Peers[1]), core.WithFlowRoundByDigit(2))
+	re.NoError(cluster.processRegionHeartbeat(processCtx, critical))
+	flowOnly := critical.Clone(core.SetWrittenBytes(200), core.WithFlowRoundByDigit(2))
+	re.NoError(cluster.processRegionHeartbeat(processCtx, flowOnly))
+
+	// ConcurrentRunner coalesces tasks with an equal region ID and task name.
+	// Critical and stats-only changes need separate keys so the latter cannot
+	// replace the former while full sync retention is active.
+	re.Len(runner.tasks, 2)
+	criticalKey := coalescingTaskKey{id: meta.Id, name: ratelimit.SyncRegionToFollower}
+	statsKey := coalescingTaskKey{id: meta.Id, name: ratelimit.SyncRegionStatsToFollower}
+	criticalTask, ok := runner.tasks[criticalKey]
+	re.True(ok)
+	statsTask, ok := runner.tasks[statsKey]
+	re.True(ok)
+	criticalTask(context.Background())
+	statsTask(context.Background())
+
+	criticalUpdate := <-cluster.changedRegions
+	re.Same(critical, criticalUpdate.Region)
+	re.False(criticalUpdate.StatsOnly)
+	statsUpdate := <-cluster.changedRegions
+	re.Same(flowOnly, statsUpdate.Region)
+	re.True(statsUpdate.StatsOnly)
 }
 
 func TestRegionFlowChanged(t *testing.T) {

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/id"
+	mcsconstant "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/mock/mockhbstream"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/progress"
@@ -1173,6 +1174,69 @@ func TestRegionHeartbeat(t *testing.T) {
 		re.NoError(err)
 		re.Equal(overlapRegion.GetMeta(), region)
 	}
+}
+
+func TestPrepareRegionUpdateForSyncClassifiesCriticalChanges(t *testing.T) {
+	re := require.New(t)
+	meta := &metapb.Region{
+		Id:          1,
+		RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1},
+		Peers: []*metapb.Peer{
+			{Id: 1, StoreId: 1},
+			{Id: 2, StoreId: 2},
+		},
+	}
+	origin := core.NewRegionInfo(meta, meta.Peers[0], core.WithFlowRoundByDigit(2))
+	cluster := &RaftCluster{}
+
+	check := func(region *core.RegionInfo, expectStatsOnly, expectSync bool) {
+		saveKV, _, needSync, _ := regionGuide(core.ContextTODO(), region, origin)
+		update, ok := cluster.prepareRegionUpdateForSync(region, origin, saveKV, needSync)
+		re.Equal(expectSync, ok)
+		if ok {
+			re.Same(region, update.Region)
+			re.Equal(expectStatsOnly, update.StatsOnly)
+		}
+	}
+
+	flowOnly := origin.Clone(core.SetWrittenBytes(200), core.WithFlowRoundByDigit(2))
+	check(flowOnly, true, true)
+	check(flowOnly.Clone(core.WithLeader(meta.Peers[1]), core.WithFlowRoundByDigit(2)), false, true)
+	check(flowOnly.Clone(core.WithDownPeers([]*pdpb.PeerStats{{Peer: meta.Peers[1], DownSeconds: 1}}), core.WithFlowRoundByDigit(2)), false, true)
+	check(flowOnly.Clone(core.WithPendingPeers([]*metapb.Peer{meta.Peers[1]}), core.WithFlowRoundByDigit(2)), false, true)
+	check(origin.Clone(core.WithIncVersion()), false, true)
+
+	// Unknown future synchronization reasons must default to critical.
+	unknownReason := origin.Clone(core.SetApproximateSize(10), core.WithFlowRoundByDigit(2))
+	update, ok := cluster.prepareRegionUpdateForSync(unknownReason, origin, false, true)
+	re.True(ok)
+	re.False(update.StatsOnly)
+}
+
+func TestPrepareRegionUpdateForSyncSkipsStatsInMicroserviceMode(t *testing.T) {
+	re := require.New(t)
+	meta := &metapb.Region{
+		Id:          1,
+		RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1},
+		Peers: []*metapb.Peer{
+			{Id: 1, StoreId: 1},
+			{Id: 2, StoreId: 2},
+		},
+	}
+	origin := core.NewRegionInfo(meta, meta.Peers[0], core.WithFlowRoundByDigit(2))
+	flowOnly := origin.Clone(core.SetWrittenBytes(200), core.WithFlowRoundByDigit(2))
+	cluster := &RaftCluster{}
+	cluster.SetServiceIndependent(mcsconstant.SchedulingServiceName)
+
+	saveKV, _, needSync, _ := regionGuide(core.ContextTODO(), flowOnly, origin)
+	_, ok := cluster.prepareRegionUpdateForSync(flowOnly, origin, saveKV, needSync)
+	re.False(ok)
+
+	withLeaderChange := flowOnly.Clone(core.WithLeader(meta.Peers[1]), core.WithFlowRoundByDigit(2))
+	saveKV, _, needSync, _ = regionGuide(core.ContextTODO(), withLeaderChange, origin)
+	update, ok := cluster.prepareRegionUpdateForSync(withLeaderChange, origin, saveKV, needSync)
+	re.True(ok)
+	re.False(update.StatsOnly)
 }
 
 func TestRegionFlowChanged(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10719

RegionSyncer retains live Region updates while sending a full snapshot. In
clusters with millions of Regions, high-rate flow-only updates can exhaust the
bounded catch-up history and repeatedly restart full sync.

This supersedes #10914.

### What is changed and how does it work?

```commit-message
Classify RegionSyncer updates as flow-only or correctness-critical. While a
full sync retains catch-up records, omit flow-only updates from the history so
they cannot displace metadata, epoch, peer, leader, down/pending peer, or
bucket changes.

When the scheduling microservice is enabled, do not enqueue flow-only updates
into PD RegionSyncer because the scheduling service receives complete Region
heartbeats directly. Outside full-sync retention, monolithic PD continues to
synchronize flow-only updates.
```

### Check List

Tests

- Unit test

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved region synchronization by distinguishing full updates from statistics-only updates, including more precise task selection and batching.
  * Reduced unnecessary synchronization by skipping statistics-only updates during full sync and in microservice mode where applicable.
  * Ensured critical changes are still synchronized reliably even with task coalescing.
* **Bug Fixes**
  * History replay/notification behavior now triggers only when history records are actually appended.
* **Tests**
  * Added coverage for stats-only skipping, critical update persistence under coalescing, and correct classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->