### PR TITLE
Revert "schedulers: increase leader batch limit"

### DIFF
--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -45,13 +45,11 @@ const (
 	// If you want to increase balance speed more, please increase above-mentioned param.
 	BalanceLeaderBatchSize = 4
 	// MaxBalanceLeaderBatchSize is maximum of balance leader batch size
-	MaxBalanceLeaderBatchSize = 100
+	MaxBalanceLeaderBatchSize = 10
 
 	transferIn  = "transfer-in"
 	transferOut = "transfer-out"
 )
-
-var invalidBalanceLeaderBatchSizeMsg = "invalid batch size which should be an integer between 1 and " + strconv.Itoa(MaxBalanceLeaderBatchSize)
 
 type balanceLeaderSchedulerParam struct {
 	Ranges []keyutil.KeyRange `json:"ranges"`
@@ -80,7 +78,7 @@ func (conf *balanceLeaderSchedulerConfig) update(data []byte) (int, any) {
 			if err := json.Unmarshal(oldConfig, param); err != nil {
 				return http.StatusInternalServerError, err.Error()
 			}
-			return http.StatusBadRequest, invalidBalanceLeaderBatchSizeMsg
+			return http.StatusBadRequest, "invalid batch size which should be an integer between 1 and 10"
 		}
 		conf.balanceLeaderSchedulerParam = *param
 		if err := conf.save(); err != nil {
@@ -101,7 +99,7 @@ func (conf *balanceLeaderSchedulerConfig) update(data []byte) (int, any) {
 }
 
 func (conf *balanceLeaderSchedulerParam) validateLocked() bool {
-	return conf.Batch >= 1 && conf.Batch <= MaxBalanceLeaderBatchSize
+	return conf.Batch >= 1 && conf.Batch <= 10
 }
 
 func (conf *balanceLeaderSchedulerConfig) clone() *balanceLeaderSchedulerParam {

--- a/pkg/schedule/schedulers/balance_leader_test.go
+++ b/pkg/schedule/schedulers/balance_leader_test.go
@@ -15,13 +15,9 @@
 package schedulers
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
-	"net/http"
-	"net/http/httptest"
 	"sort"
 	"testing"
 
@@ -38,7 +34,6 @@ import (
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/utils/operatorutil"
-	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/versioninfo"
 )
 
@@ -59,31 +54,6 @@ func TestBalanceLeaderSchedulerConfigClone(t *testing.T) {
 	// update conf2
 	conf2.Ranges[1] = keyRanges2[1]
 	re.NotEqual(conf.Ranges, conf2.Ranges)
-}
-
-func TestBalanceLeaderBatchLimit(t *testing.T) {
-	re := require.New(t)
-	cancel, _, _, oc := prepareSchedulersTest()
-	defer cancel()
-
-	lb, err := CreateScheduler(types.BalanceLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{"", ""}))
-	re.NoError(err)
-
-	body, err := json.Marshal(map[string]any{"batch": MaxBalanceLeaderBatchSize})
-	re.NoError(err)
-	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp := httptest.NewRecorder()
-	lb.ServeHTTP(resp, req)
-	re.Equal(http.StatusOK, resp.Code)
-	re.Equal(MaxBalanceLeaderBatchSize, lb.(*balanceLeaderScheduler).conf.getBatch())
-
-	body, err = json.Marshal(map[string]any{"batch": MaxBalanceLeaderBatchSize + 1})
-	re.NoError(err)
-	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp = httptest.NewRecorder()
-	lb.ServeHTTP(resp, req)
-	re.Equal(http.StatusBadRequest, resp.Code)
-	re.Equal(MaxBalanceLeaderBatchSize, lb.(*balanceLeaderScheduler).conf.getBatch())
 }
 
 type balanceLeaderSchedulerTestSuite struct {
@@ -550,28 +520,6 @@ func (suite *balanceLeaderRangeSchedulerTestSuite) TestBatchBalance() {
 		regions[op.RegionID()] = struct{}{}
 	}
 	re.Len(regions, 4)
-}
-
-func TestBalanceLeaderMaxBatchSchedule(t *testing.T) {
-	re := require.New(t)
-	cancel, _, tc, oc := prepareSchedulersTest()
-	defer cancel()
-
-	tc.AddLeaderStore(1, MaxBalanceLeaderBatchSize*10)
-	tc.AddLeaderStore(2, 0)
-	tc.AddLeaderStore(3, 0)
-	for i := 1; i <= MaxBalanceLeaderBatchSize*20; i++ {
-		tc.AddLeaderRegion(uint64(i), 1, 2, 3)
-	}
-
-	lb, err := CreateScheduler(types.BalanceLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.BalanceLeaderScheduler, []string{"", ""}))
-	re.NoError(err)
-	lb.(*balanceLeaderScheduler).conf.Batch = MaxBalanceLeaderBatchSize
-
-	testutil.Eventually(re, func() bool {
-		ops, _ := lb.Schedule(tc, false)
-		return len(ops) == MaxBalanceLeaderBatchSize
-	})
 }
 
 func (suite *balanceLeaderRangeSchedulerTestSuite) TestReSortStores() {

--- a/pkg/schedule/schedulers/evict_leader.go
+++ b/pkg/schedule/schedulers/evict_leader.go
@@ -15,7 +15,6 @@
 package schedulers
 
 import (
-	"fmt"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -41,18 +40,9 @@ import (
 const (
 	// EvictLeaderBatchSize is the number of operators to transfer
 	// leaders by one scheduling
-	EvictLeaderBatchSize    = 3
-	maxEvictLeaderBatchSize = 100
-	lastStoreDeleteInfo     = "The last store has been deleted"
+	EvictLeaderBatchSize = 3
+	lastStoreDeleteInfo  = "The last store has been deleted"
 )
-
-var invalidEvictLeaderBatchSizeMsg = "batch must be an integer in [1, " + strconv.Itoa(maxEvictLeaderBatchSize) + "]"
-
-func isValidEvictLeaderBatchSize(batchFloat float64) bool {
-	return batchFloat >= 1 &&
-		batchFloat <= maxEvictLeaderBatchSize &&
-		batchFloat == float64(int(batchFloat))
-}
 
 type evictLeaderSchedulerConfig struct {
 	syncutil.RWMutex
@@ -186,15 +176,13 @@ func (conf *evictLeaderSchedulerConfig) pauseLeaderTransferIfStoreNotExist(id ui
 		if err := conf.cluster.PauseLeaderTransfer(id); err != nil {
 			return exist, err
 		}
-		return false, nil
 	}
 	return true, nil
 }
 
-func (conf *evictLeaderSchedulerConfig) resumeLeaderTransferIfPaused(id uint64, paused bool) {
-	if !paused {
-		return
-	}
+func (conf *evictLeaderSchedulerConfig) resumeLeaderTransferIfExist(id uint64) {
+	conf.RLock()
+	defer conf.RUnlock()
 	conf.cluster.ResumeLeaderTransfer(id)
 }
 
@@ -412,11 +400,10 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 		return
 	}
 	var (
-		exist                bool
-		err                  error
-		id                   uint64
-		leaderTransferPaused bool
-		newRanges            []keyutil.KeyRange
+		exist     bool
+		err       error
+		id        uint64
+		newRanges []keyutil.KeyRange
 	)
 	idFloat, inputHasStoreID := input["store_id"].(float64)
 	if inputHasStoreID {
@@ -426,20 +413,14 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 			handler.rd.JSON(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		leaderTransferPaused = !exist
 	}
 
 	batch := handler.config.getBatch()
-	batchFloat, inputBatch := input["batch"].(float64)
-	if input["batch"] != nil && !inputBatch {
-		handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
-		handler.rd.JSON(w, http.StatusBadRequest, fmt.Sprintf("invalid argument for 'batch': expected a number, got %T", input["batch"]))
-		return
-	}
-	if inputBatch {
-		if !isValidEvictLeaderBatchSize(batchFloat) {
-			handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
-			handler.rd.JSON(w, http.StatusBadRequest, invalidEvictLeaderBatchSizeMsg)
+	batchFloat, ok := input["batch"].(float64)
+	if ok {
+		if batchFloat < 1 || batchFloat > 10 {
+			handler.config.resumeLeaderTransferIfExist(id)
+			handler.rd.JSON(w, http.StatusBadRequest, "batch is invalid, it should be in [1, 10]")
 			return
 		}
 		batch = (int)(batchFloat)
@@ -448,8 +429,8 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 	ranges, ok := (input["ranges"]).([]string)
 	if ok {
 		if !inputHasStoreID {
-			handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
-			handler.rd.JSON(w, http.StatusBadRequest, errs.ErrSchedulerConfig.FastGenByArgs("id"))
+			handler.config.resumeLeaderTransferIfExist(id)
+			handler.rd.JSON(w, http.StatusInternalServerError, errs.ErrSchedulerConfig.FastGenByArgs("id"))
 			return
 		}
 	} else if exist {
@@ -458,8 +439,8 @@ func (handler *evictLeaderHandler) updateConfig(w http.ResponseWriter, r *http.R
 
 	newRanges, err = getKeyRanges(ranges)
 	if err != nil {
-		handler.config.resumeLeaderTransferIfPaused(id, leaderTransferPaused)
-		handler.rd.JSON(w, http.StatusBadRequest, err.Error())
+		handler.config.resumeLeaderTransferIfExist(id)
+		handler.rd.JSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/pkg/schedule/schedulers/evict_leader_test.go
+++ b/pkg/schedule/schedulers/evict_leader_test.go
@@ -17,19 +17,12 @@ package schedulers
 import (
 	"bytes"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
-
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/log"
-
+	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/core"
-	"github.com/tikv/pd/pkg/mock/mockcluster"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/storage"
@@ -143,172 +136,6 @@ func TestBatchEvict(t *testing.T) {
 		ops, _ := sl.Schedule(tc, false)
 		return len(ops) == 5
 	})
-	sl.(*evictLeaderScheduler).conf.Batch = maxEvictLeaderBatchSize
-	testutil.Eventually(re, func() bool {
-		ops, _ := sl.Schedule(tc, false)
-		return len(ops) == maxEvictLeaderBatchSize
-	})
-}
-
-func TestEvictLeaderBatchLimit(t *testing.T) {
-	re := require.New(t)
-	cancel, _, _, oc := prepareSchedulersTest()
-	defer cancel()
-
-	sl, err := CreateScheduler(types.EvictLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictLeaderScheduler, []string{"1"}), func(string) error { return nil })
-	re.NoError(err)
-
-	body, err := json.Marshal(map[string]any{"batch": maxEvictLeaderBatchSize})
-	re.NoError(err)
-	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp := httptest.NewRecorder()
-	sl.ServeHTTP(resp, req)
-	re.Equal(http.StatusOK, resp.Code)
-	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
-
-	body, err = json.Marshal(map[string]any{"batch": maxEvictLeaderBatchSize + 1})
-	re.NoError(err)
-	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp = httptest.NewRecorder()
-	sl.ServeHTTP(resp, req)
-	re.Equal(http.StatusBadRequest, resp.Code)
-	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
-
-	body, err = json.Marshal(map[string]any{"batch": 1.5})
-	re.NoError(err)
-	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp = httptest.NewRecorder()
-	sl.ServeHTTP(resp, req)
-	re.Equal(http.StatusBadRequest, resp.Code)
-	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
-
-	body, err = json.Marshal(map[string]any{"batch": "abc"})
-	re.NoError(err)
-	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp = httptest.NewRecorder()
-	sl.ServeHTTP(resp, req)
-	re.Equal(http.StatusBadRequest, resp.Code)
-	re.Equal("\"invalid argument for 'batch': expected a number, got string\"\n", resp.Body.String())
-	re.Equal(maxEvictLeaderBatchSize, sl.(*evictLeaderScheduler).conf.getBatch())
-}
-
-func TestEvictLeaderInvalidBatchKeepsLeaderTransferState(t *testing.T) {
-	re := require.New(t)
-	cancel, _, tc, oc := prepareSchedulersTest()
-	defer cancel()
-
-	tc.AddLeaderStore(1, 0)
-	tc.AddLeaderStore(2, 0)
-
-	sl, err := CreateScheduler(types.EvictLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictLeaderScheduler, []string{"1"}), func(string) error { return nil })
-	re.NoError(err)
-	re.NoError(sl.PrepareConfig(tc))
-	re.False(tc.GetStore(1).AllowLeaderTransfer())
-
-	body, err := json.Marshal(map[string]any{"store_id": 1, "batch": "abc"})
-	re.NoError(err)
-	req := httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp := httptest.NewRecorder()
-	sl.ServeHTTP(resp, req)
-	re.Equal(http.StatusBadRequest, resp.Code)
-	re.Equal("\"invalid argument for 'batch': expected a number, got string\"\n", resp.Body.String())
-	re.False(tc.GetStore(1).AllowLeaderTransfer())
-
-	body, err = json.Marshal(map[string]any{"store_id": 2, "batch": "abc"})
-	re.NoError(err)
-	req = httptest.NewRequest(http.MethodPost, "/config", bytes.NewReader(body))
-	resp = httptest.NewRecorder()
-	sl.ServeHTTP(resp, req)
-	re.Equal(http.StatusBadRequest, resp.Code)
-	re.Equal("\"invalid argument for 'batch': expected a number, got string\"\n", resp.Body.String())
-	re.True(tc.GetStore(2).AllowLeaderTransfer())
-}
-
-func TestEvictLeaderAddWaitingOperatorLimit(t *testing.T) {
-	for _, tc := range []struct {
-		name       string
-		maxWaiting int
-		expected   int
-	}{
-		{name: "default-waiting-limit", maxWaiting: 0, expected: 5},
-		{name: "batch-sized-waiting-limit", maxWaiting: maxEvictLeaderBatchSize, expected: maxEvictLeaderBatchSize},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			re := require.New(t)
-			cancel, opt, cluster, oc := prepareSchedulersTest(false)
-			t.Cleanup(cancel)
-			if tc.maxWaiting > 0 {
-				cfg := opt.GetScheduleConfig().Clone()
-				cfg.SchedulerMaxWaitingOperator = uint64(tc.maxWaiting)
-				opt.SetScheduleConfig(cfg)
-			}
-
-			cluster.AddLeaderStore(1, 0)
-			cluster.AddLeaderStore(2, 0)
-			cluster.AddLeaderStore(3, 0)
-			ops := newEvictLeaderOperators(t, cluster, maxEvictLeaderBatchSize)
-			re.Equal(tc.expected, oc.AddWaitingOperator(ops...))
-		})
-	}
-}
-
-func newEvictLeaderOperators(tb testing.TB, cluster *mockcluster.Cluster, count int) []*operator.Operator {
-	tb.Helper()
-	ops := make([]*operator.Operator, 0, count)
-	for i := range count {
-		region := cluster.AddLeaderRegion(uint64(i+1), 1, 2, 3)
-		op, err := operator.CreateTransferLeaderOperator(types.EvictLeaderScheduler.String(), cluster, region, 2, []uint64{2, 3}, operator.OpLeader)
-		if err != nil {
-			tb.Fatal(err)
-		}
-		ops = append(ops, op)
-	}
-	return ops
-}
-
-func BenchmarkEvictLeaderScheduleBatch(b *testing.B) {
-	tc, _, sl := prepareEvictLeaderBatchScenario(b, 0)
-
-	totalOps := 0
-	b.ResetTimer()
-	for range b.N {
-		ops, _ := sl.Schedule(tc, false)
-		if len(ops) == 0 {
-			b.Fatal("expected evict leader operators")
-		}
-		totalOps += len(ops)
-	}
-	elapsed := b.Elapsed().Seconds()
-	b.ReportMetric(float64(totalOps)/elapsed, "ops/s")
-	b.ReportMetric(float64(totalOps)*60/elapsed, "ops/min")
-}
-
-func prepareEvictLeaderBatchScenario(tb testing.TB, maxWaiting int) (*mockcluster.Cluster, *operator.Controller, Scheduler) {
-	restoreLogger := log.ReplaceGlobals(zap.NewNop(), nil)
-	tb.Cleanup(restoreLogger)
-
-	cancel, opt, tc, oc := prepareSchedulersTest(false)
-	tb.Cleanup(cancel)
-	if maxWaiting > 0 {
-		cfg := opt.GetScheduleConfig().Clone()
-		cfg.SchedulerMaxWaitingOperator = uint64(maxWaiting)
-		opt.SetScheduleConfig(cfg)
-	}
-
-	tc.AddLeaderStore(1, 0)
-	tc.AddLeaderStore(2, 0)
-	tc.AddLeaderStore(3, 0)
-	regionCount := maxEvictLeaderBatchSize * 100
-	for i := range regionCount {
-		tc.AddLeaderRegion(uint64(i+1), 1, 2, 3)
-	}
-
-	sl, err := CreateScheduler(types.EvictLeaderScheduler, oc, storage.NewStorageWithMemoryBackend(), ConfigSliceDecoder(types.EvictLeaderScheduler, []string{"1"}), func(string) error { return nil })
-	if err != nil {
-		tb.Fatal(err)
-	}
-	sl.(*evictLeaderScheduler).conf.Batch = maxEvictLeaderBatchSize
-	return tc, oc, sl
 }
 
 func TestEvictLeaderSchedulerCompatibility(t *testing.T) {

--- a/tests/server/api/scheduler_test.go
+++ b/tests/server/api/scheduler_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	sc "github.com/tikv/pd/pkg/schedule/config"
-	schedulerpkg "github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/schedule/types"
 	"github.com/tikv/pd/pkg/slice"
 	"github.com/tikv/pd/pkg/utils/apiutil"
@@ -198,12 +197,12 @@ func (suite *scheduleTestSuite) checkAPI(cluster *tests.TestCluster) {
 				re.NoError(err)
 				// update invalidate batch
 				dataMap = map[string]any{}
-				dataMap["batch"] = schedulerpkg.MaxBalanceLeaderBatchSize + 1
+				dataMap["batch"] = 100
 				body, err = json.Marshal(dataMap)
 				re.NoError(err)
 				err = tu.CheckPostJSON(tests.TestDialClient, updateURL, body,
 					tu.Status(re, http.StatusBadRequest),
-					tu.StringEqual(re, fmt.Sprintf("\"invalid batch size which should be an integer between 1 and %d\"\n", schedulerpkg.MaxBalanceLeaderBatchSize)))
+					tu.StringEqual(re, "\"invalid batch size which should be an integer between 1 and 10\"\n"))
 				re.NoError(err)
 				resp = make(map[string]any)
 				tu.Eventually(re, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10974

The leader scheduler batch-size increase introduced by #10974 needs to be reverted from `release-8.5-20251204-v8.5.4`.

### What is changed and how does it work?

This PR reverts #10974 and restores:

- The maximum configurable batch size of `evict-leader-scheduler` and `balance-leader-scheduler` from 100 to 10.
- The previous evict-leader configuration validation and leader-transfer handling behavior.
- The test coverage and API expectations that existed before #10974.

```commit-message
Revert "schedulers: increase leader batch limit (#10974)"
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Revert the leader scheduler batch-size increase and restore the maximum configurable batch size of evict-leader-scheduler and balance-leader-scheduler from 100 to 10.
```