### PR TITLE
memory: apply cgroup limit immediately

### DIFF
--- a/pkg/memory/meminfo.go
+++ b/pkg/memory/meminfo.go
@@ -207,8 +207,7 @@ func InitMemoryHook() {
 		return
 	}
 	if physicalValue > cgroupValue && cgroupValue != 0 {
-		MemTotal = MemTotalCGroup
-		MemUsed = MemUsedCGroup
+		useCgroupMemoryHook(cgroupValue)
 		sysutil.RegisterGetMemoryCapacity(MemTotalCGroup)
 		log.Info("use cgroup memory hook", zap.Int64("cgroup-memory-size", int64(cgroupValue)), zap.Int64("physical-memory-size", int64(physicalValue)))
 	} else {
@@ -218,6 +217,16 @@ func InitMemoryHook() {
 	mustNil(err)
 	_, err = MemUsed()
 	mustNil(err)
+}
+
+func useCgroupMemoryHook(cgroupValue uint64) {
+	MemTotal = MemTotalCGroup
+	MemUsed = MemUsedCGroup
+	// The package initializer populated these shared caches through the
+	// physical-memory hooks. Replace the total immediately and invalidate the
+	// usage cache before the cgroup hooks are used.
+	memLimit.set(cgroupValue, time.Now())
+	memUsage.set(0, time.Time{})
 }
 
 // InstanceMemUsed returns the memory usage of this process

--- a/pkg/memory/meminfo_test.go
+++ b/pkg/memory/meminfo_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestUseCgroupMemoryHookReplacesPhysicalMemoryCache(t *testing.T) {
+	originalMemTotal := MemTotal
+	originalMemUsed := MemUsed
+	originalTotal, originalTotalTime := memLimit.get()
+	originalUsage, originalUsageTime := memUsage.get()
+	t.Cleanup(func() {
+		MemTotal = originalMemTotal
+		MemUsed = originalMemUsed
+		memLimit.set(originalTotal, originalTotalTime)
+		memUsage.set(originalUsage, originalUsageTime)
+	})
+
+	const (
+		physicalMemory = 32 << 30
+		cgroupMemory   = 2 << 30
+	)
+	memLimit.set(physicalMemory, time.Now())
+	memUsage.set(physicalMemory/2, time.Now())
+
+	useCgroupMemoryHook(cgroupMemory)
+
+	require.Equal(t, uint64(cgroupMemory), GetMemTotalIgnoreErr())
+	_, usageTime := memUsage.get()
+	require.True(t, usageTime.IsZero())
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10719

When PD is started by systemd under a cgroup, package initialization can cache the host physical memory before `InitMemoryHook` selects the cgroup memory hooks.

Because the total-memory cache remains valid for 60 seconds, RegionSyncer can size its history buffer using the host memory and retain an oversized limit for the process lifetime.

### What is changed and how does it work?

```commit-message
When InitMemoryHook selects cgroup memory hooks, immediately replace the cached total memory with the detected cgroup limit and invalidate the cached memory usage.

Add a regression test that verifies stale physical-memory cache entries are replaced during the hook switch.
```

### Check List

Tests

- Unit test
- Manual test

Manual test:

- Verified PD startup with 2, 4, 8, 16, and 32 GiB cgroup limits.
- Verified the corresponding RegionSync history capacities were 10k, 10k, 20k, 40k, and 80k.

### Release note

```release-note
Fix PD memory-aware sizing to use the cgroup memory limit immediately at startup.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory reporting in cgroup environments by using the detected cgroup memory limit and current usage.
  * Ensured cached memory values refresh correctly when cgroup-based limits are applied.

* **Tests**
  * Added coverage to verify accurate memory totals and cache invalidation when switching to cgroup memory data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->