### PR TITLE
syncer: harden full sync recovery

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,10 +16,12 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -163,6 +165,67 @@ func TryLoadRegionsOnce(ctx context.Context, s Storage, f func(region *core.Regi
 		ps.regionLoaded = fromLeveldb
 	}
 	return nil
+}
+
+// TryLoadRegionsFromLocalStorageOnce switches a core storage to its local
+// Region storage and loads those Regions into memory once. It is used before
+// leader promotion when the normal configuration reload cannot run without an
+// existing PD leader.
+func TryLoadRegionsFromLocalStorageOnce(
+	ctx context.Context,
+	s Storage,
+	f func(region *core.RegionInfo) []*core.RegionInfo,
+) error {
+	ps, ok := s.(*coreStorage)
+	if !ok {
+		return s.LoadRegions(ctx, f)
+	}
+
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.useRegionStorage.Store(true)
+	if ps.regionLoaded == fromLeveldb {
+		return nil
+	}
+	if err := ps.regionStorage.LoadRegions(ctx, f); err != nil {
+		return err
+	}
+	ps.regionLoaded = fromLeveldb
+	return nil
+}
+
+// ClearRegionStorage removes all persisted Region metadata from the active
+// Region storage without touching non-Region keys.
+func ClearRegionStorage(ctx context.Context, s Storage) error {
+	regionStorage := RetrieveRegionStorage(s)
+	regionKV, ok := regionStorage.(kv.Base)
+	if !ok {
+		return errors.New("region storage does not support range scan")
+	}
+	startKey := keypath.RegionPath(0)
+	endKey := keypath.RegionPath(^uint64(0)) + "\x00"
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		keys, _, err := regionKV.LoadRange(startKey, endKey, endpoint.MaxKVRangeLimit)
+		if err != nil {
+			return fmt.Errorf("load regions from local storage: %w", err)
+		}
+		if len(keys) == 0 {
+			return nil
+		}
+		if err := regionKV.RunInTxn(ctx, func(txn kv.Txn) error {
+			for _, key := range keys {
+				if err := txn.Remove(key); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("delete regions from local storage: %w", err)
+		}
+	}
 }
 
 // LoadRegion loads one region from storage.

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -243,6 +243,27 @@ func TestLoadRegionsToCache(t *testing.T) {
 	re.Equal(n, cache.GetTotalRegionCount())
 }
 
+func TestLoadRegionsFromLocalStorageOnce(t *testing.T) {
+	re := require.New(t)
+	defaultStorage := NewStorageWithMemoryBackend()
+	localStorage := NewStorageWithMemoryBackend()
+	defaultRegion := newTestRegionMeta(1)
+	localRegion := newTestRegionMeta(2)
+	re.NoError(defaultStorage.SaveRegion(defaultRegion))
+	re.NoError(localStorage.SaveRegion(localRegion))
+	coreStorage := NewCoreStorage(defaultStorage, localStorage)
+	cache := core.NewBasicCluster()
+
+	re.NoError(TryLoadRegionsFromLocalStorageOnce(
+		context.Background(),
+		coreStorage,
+		cache.CheckAndPutRegion,
+	))
+	re.Nil(cache.GetRegion(defaultRegion.GetId()))
+	re.NotNil(cache.GetRegion(localRegion.GetId()))
+	re.True(AreRegionsLoaded(coreStorage))
+}
+
 func TestLoadRegionsExceedRangeLimit(t *testing.T) {
 	re := require.New(t)
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/storage/kv/withRangeLimit", "return(500)"))
@@ -289,6 +310,25 @@ func TestTrySwitchRegionStorage(t *testing.T) {
 	for _, region := range localCache.GetMetaRegions() {
 		re.Equal(regions20[region.GetId()], region)
 	}
+}
+
+func TestClearRegionStoragePreservesOtherKeys(t *testing.T) {
+	re := require.New(t)
+	s := NewStorageWithMemoryBackend()
+	re.NoError(s.Save("keep", "value"))
+	re.NoError(s.SaveRegion(&metapb.Region{Id: 1}))
+	re.NoError(s.SaveRegion(&metapb.Region{Id: 2}))
+
+	re.NoError(ClearRegionStorage(context.Background(), s))
+	for _, regionID := range []uint64{1, 2} {
+		region := &metapb.Region{}
+		ok, err := s.LoadRegion(regionID, region)
+		re.NoError(err)
+		re.False(ok)
+	}
+	value, err := s.Load("keep")
+	re.NoError(err)
+	re.Equal("value", value)
 }
 
 const (

--- a/pkg/syncer/client.go
+++ b/pkg/syncer/client.go
@@ -43,31 +43,83 @@ import (
 )
 
 const (
-	keepaliveTime    = 10 * time.Second
-	keepaliveTimeout = 3 * time.Second
-	msgSize          = 8 * units.MiB
-	retryInterval    = time.Second
+	keepaliveTime           = 10 * time.Second
+	keepaliveTimeout        = 3 * time.Second
+	fullSyncProgressTimeout = 30 * time.Second
+	msgSize                 = 8 * units.MiB
+	retryInterval           = time.Second
 )
 
-// StopSyncWithLeader stop to sync the region with leader.
+// StopSyncWithLeader stops Region synchronization with the leader.
 func (s *RegionSyncer) StopSyncWithLeader() {
-	s.reset()
-	s.wg.Wait()
-}
-
-func (s *RegionSyncer) reset() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.mu.clientCancel != nil {
 		s.mu.clientCancel()
 	}
 	s.mu.clientCancel, s.mu.clientCtx = nil, nil
+	s.mu.Unlock()
+	s.wg.Wait()
 }
 
-// ResetHistoryIndex resets and persists the next region sync history index.
-func (s *RegionSyncer) ResetHistoryIndex(index uint64) {
-	s.history.resetWithIndexAndPersist(index)
+// MarkHistoryIncomplete resets the durable Region sync state before a full
+// synchronization starts.
+func (s *RegionSyncer) MarkHistoryIncomplete() error {
+	if err := s.history.saveSynced(false); err != nil {
+		return errors.Wrap(err, "clear region sync completion marker")
+	}
+	s.historySynced.Store(false)
+	s.streamingRunning.Store(false)
+	s.initialFollowerSyncCompleted.Store(false)
+	return s.history.resetWithIndexAndPersist(0)
+}
+
+// IsHistorySynced reports whether this member has durably completed at least
+// one region history synchronization.
+func (s *RegionSyncer) IsHistorySynced() bool {
+	return s.historySynced.Load()
+}
+
+// MarkHistorySynced flushes the local region data before durably recording
+// that this member has completed Region synchronization.
+func (s *RegionSyncer) MarkHistorySynced() error {
+	if err := s.server.GetStorage().Flush(); err != nil {
+		return errors.Wrap(err, "flush region storage before marking sync complete")
+	}
+	if err := s.history.persist(); err != nil {
+		return errors.Wrap(err, "persist completed region sync index")
+	}
+	if err := s.history.saveSynced(true); err != nil {
+		return errors.Wrap(err, "persist region sync completion marker")
+	}
+	s.historySynced.Store(true)
+	return nil
+}
+
+func (s *RegionSyncer) syncRegionStartIndex() uint64 {
+	if !s.initialFollowerSyncCompleted.Load() || !s.IsHistorySynced() {
+		return 0
+	}
+	return s.history.getNextIndex()
+}
+
+func (s *RegionSyncer) loadRegions(ctx context.Context) error {
+	s.regionLoadMu.Lock()
+	defer s.regionLoadMu.Unlock()
+	if s.initialRegionLoadCompleted.Load() {
+		return nil
+	}
+	log.Info("region syncer start load region")
+	start := time.Now()
+	if err := storage.TryLoadRegionsFromLocalStorageOnce(
+		ctx,
+		s.server.GetStorage(),
+		s.server.GetBasicCluster().CheckAndPutRegion,
+	); err != nil {
+		return err
+	}
+	s.initialRegionLoadCompleted.Store(true)
+	log.Info("region syncer finished load regions", zap.Duration("time-cost", time.Since(start)))
+	return nil
 }
 
 func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (ClientStream, error) {
@@ -76,10 +128,11 @@ func (s *RegionSyncer) syncRegion(ctx context.Context, conn *grpc.ClientConn) (C
 	if err != nil {
 		return nil, err
 	}
+	startIndex := s.syncRegionStartIndex()
 	err = syncStream.Send(&pdpb.SyncRegionRequest{
 		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
 		Member:     s.server.GetMemberInfo(),
-		StartIndex: s.history.getNextIndex(),
+		StartIndex: startIndex,
 	})
 	if err != nil {
 		return nil, err
@@ -110,8 +163,33 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 	regions := resp.GetRegions()
 	buckets := resp.GetBuckets()
 	regionLeaders := resp.GetRegionLeaders()
-	startFullSync := !fullSyncing && !s.IsRunning() && resp.GetStartIndex() == 0 && len(regions) > 0
-	inFullSync := fullSyncing || startFullSync
+	startFullSync, startEmptyFullSync := s.isFullSyncStartResponse(resp, fullSyncing)
+	if startFullSync || startEmptyFullSync {
+		s.streamingRunning.Store(false)
+		if err := s.MarkHistoryIncomplete(); err != nil {
+			log.Warn("region syncer failed to reset history before full synchronization",
+				zap.String("server", s.server.Name()), errs.ZapError(err))
+			return false, false
+		}
+		// RegionStorage buffers SaveRegion calls in memory. Flush before
+		// scanning the underlying store so a destructive clear cannot
+		// resurrect an older batch on the next flush.
+		if err := regionStorage.Flush(); err != nil {
+			log.Warn("region syncer failed to flush pending Region writes before full synchronization",
+				zap.String("server", s.server.Name()), errs.ZapError(err))
+			return false, false
+		}
+		if err := storage.ClearRegionStorage(ctx, regionStorage); err != nil {
+			log.Warn("region syncer failed to clear Region storage before full synchronization",
+				zap.String("server", s.server.Name()), errs.ZapError(err))
+			return false, false
+		}
+		if err := ctx.Err(); err != nil {
+			return false, false
+		}
+		bc.ResetRegionCache()
+	}
+	inFullSync := fullSyncing || startFullSync || startEmptyFullSync
 	// During a full sync, intermediate data frames carry a positional
 	// offset, not a reusable history index.
 	isPositionalBatch := inFullSync && !startFullSync && len(regions) > 0
@@ -127,6 +205,9 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 	hasStats := len(stats) == len(regions)
 	hasBuckets := len(buckets) == len(regions)
 	for i, r := range regions {
+		if err := ctx.Err(); err != nil {
+			return false, false
+		}
 		var (
 			region       *core.RegionInfo
 			regionLeader *metapb.Peer
@@ -147,7 +228,7 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 		}
 		region = core.NewRegionInfo(r, regionLeader, opts...)
 
-		origin, _, err := bc.PreCheckPutRegion(region)
+		origin, overlaps, err := bc.PreCheckPutRegion(region)
 		if err != nil {
 			log.Debug("region is stale", zap.Stringer("origin", origin.GetMeta()), errs.ZapError(err))
 			continue
@@ -159,29 +240,65 @@ func (s *RegionSyncer) handleRegionSyncResponse(
 			// no limit for followers.
 		}
 		saveKV, _, _, _ := regionGuide(cctx, region, origin)
-		overlaps := bc.PutRegion(region)
-
 		if saveKV {
-			err = regionStorage.SaveRegion(r)
-		}
-		if err == nil && !inFullSync {
-			s.history.record(region)
+			if err = regionStorage.SaveRegion(r); err != nil {
+				s.streamingRunning.Store(false)
+				log.Warn("region syncer failed to save Region",
+					zap.String("server", s.server.Name()),
+					zap.Uint64("region-id", region.GetID()),
+					errs.ZapError(err))
+				return false, false
+			}
 		}
 		for _, old := range overlaps {
-			_ = regionStorage.DeleteRegion(old.GetMeta())
+			if err = regionStorage.DeleteRegion(old.GetMeta()); err != nil {
+				s.streamingRunning.Store(false)
+				log.Warn("region syncer failed to delete overlapping Region",
+					zap.String("server", s.server.Name()),
+					zap.Uint64("region-id", old.GetID()),
+					errs.ZapError(err))
+				return false, false
+			}
+		}
+		bc.PutRegion(region)
+		if !inFullSync {
+			s.history.record(region)
 		}
 	}
-	nextFullSyncing = inFullSync && len(regions) > 0
-	if !nextFullSyncing {
-		// mark the client as running status when it finished the first history region sync.
+	nextFullSyncing = startEmptyFullSync || (inFullSync && len(regions) > 0)
+	if !nextFullSyncing && len(regions) == 0 {
+		if err := s.MarkHistorySynced(); err != nil {
+			s.streamingRunning.Store(false)
+			log.Warn("region syncer failed to persist completed synchronization",
+				zap.String("server", s.server.Name()), errs.ZapError(err))
+			return false, nextFullSyncing
+		}
+		s.initialFollowerSyncCompleted.Store(true)
+		// Mark the client as running only after the initial history phase is
+		// complete and the received regions are durable.
 		s.streamingRunning.Store(true)
 	}
 	return true, nextFullSyncing
 }
 
+func (s *RegionSyncer) isFullSyncStartResponse(
+	resp *pdpb.SyncRegionResponse,
+	fullSyncing bool,
+) (startFullSync, startEmptyFullSync bool) {
+	if fullSyncing || resp.GetStartIndex() != 0 {
+		return false, false
+	}
+	regions := resp.GetRegions()
+	startFullSync = !s.IsRunning() && len(regions) > 0
+	startEmptyFullSync = len(regions) == 0 &&
+		(!s.IsRunning() || !s.initialFollowerSyncCompleted.Load() ||
+			!s.IsHistorySynced() || s.history.getNextIndex() != 0)
+	return startFullSync, startEmptyFullSync
+}
+
 // IsRunning returns whether the region syncer client is running.
 func (s *RegionSyncer) IsRunning() bool {
-	return s.streamingRunning.Load()
+	return s.streamingRunning.Load() && s.IsHistorySynced()
 }
 
 // StartSyncWithLeader starts to sync with leader.
@@ -197,16 +314,36 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 		defer logutil.LogPanic()
 		defer s.wg.Done()
 		defer s.streamingRunning.Store(false)
+		// Fail closed before receiving historical records. This prevents a
+		// partial catch-up from being mistaken for legacy completed state after
+		// a process restart.
+		for !s.historySynced.Load() {
+			err := s.history.saveSynced(false)
+			if err == nil {
+				break
+			}
+			log.Warn("persist incomplete region sync marker failed",
+				zap.String("server", s.server.Name()), errs.ZapError(err))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(retryInterval):
+			}
+		}
 		// used to load region from kv storage to cache storage.
 		bc := s.server.GetBasicCluster()
 		regionStorage := s.server.GetStorage()
-		log.Info("region syncer start load region")
-		start := time.Now()
-		err := storage.TryLoadRegionsOnce(ctx, regionStorage, bc.CheckAndPutRegion)
-		if err != nil {
-			log.Warn("region syncer failed to load regions", errs.ZapError(err), zap.Duration("time-cost", time.Since(start)))
-		} else {
-			log.Info("region syncer finished load regions", zap.Duration("time-cost", time.Since(start)))
+		for {
+			start := time.Now()
+			err := s.loadRegions(ctx)
+			if err == nil {
+				break
+			}
+			log.Warn("region syncer failed to load regions; synchronization remains blocked",
+				errs.ZapError(err), zap.Duration("time-cost", time.Since(start)))
+			if !s.waitRegionSyncRetryInterval(ctx) {
+				return
+			}
 		}
 		// establish client.
 		conn := grpcutil.CreateClientConn(ctx, addr, s.tlsConfig,
@@ -233,7 +370,6 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 			return
 		}
 		defer conn.Close()
-
 		// Start syncing data.
 		for {
 			select {
@@ -242,11 +378,13 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 			default:
 			}
 
-			stream, err := s.syncRegion(ctx, conn)
+			streamCtx, streamCancel := context.WithCancel(ctx)
+			stream, err := s.syncRegion(streamCtx, conn)
 			failpoint.Inject("disableClientStreaming", func() {
 				err = errors.Errorf("no stream")
 			})
 			if err != nil {
+				streamCancel()
 				if ev, ok := status.FromError(err); ok {
 					if ev.Code() == codes.Canceled {
 						return
@@ -261,39 +399,116 @@ func (s *RegionSyncer) StartSyncWithLeader(addr string) {
 				}
 				continue
 			}
-			log.Info("server starts to synchronize with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), zap.Uint64("request-index", s.history.getNextIndex()))
+			log.Info("server starts to synchronize with leader", zap.String("server", s.server.Name()), zap.String("leader", s.server.GetLeader().GetName()), zap.Uint64("request-index", s.syncRegionStartIndex()))
 			fullSyncing := false
+			var (
+				fullSyncProgress     chan<- struct{}
+				fullSyncTimedOut     <-chan struct{}
+				stopFullSyncWatchdog context.CancelFunc
+			)
+			finishStream := func() bool {
+				timedOut := false
+				if fullSyncTimedOut != nil {
+					select {
+					case <-fullSyncTimedOut:
+						timedOut = true
+					default:
+					}
+				}
+				if stopFullSyncWatchdog != nil {
+					stopFullSyncWatchdog()
+				}
+				streamCancel()
+				s.streamingRunning.Store(false)
+				if err := stream.CloseSend(); err != nil {
+					log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
+				}
+				if timedOut {
+					log.Warn("Region full synchronization made no progress; reconnecting",
+						zap.String("server", s.server.Name()),
+						zap.Duration("timeout", s.fullSyncProgressTimeout))
+				}
+				return s.waitRegionSyncRetryInterval(ctx)
+			}
 			for {
 				resp, err := stream.Recv()
-				if err == io.EOF {
-					log.Info("server region sync with leader meets EOF, stop syncing", zap.String("server", s.server.Name()))
-					return
-				}
 				if err != nil {
-					s.streamingRunning.Store(false)
-					log.Warn("region sync with leader meet error", errs.ZapError(errs.ErrGRPCRecv, err))
-					if err = stream.CloseSend(); err != nil {
-						log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
+					if err == io.EOF {
+						log.Info("server region sync with leader reached EOF; reconnecting",
+							zap.String("server", s.server.Name()))
+					} else {
+						log.Warn("region sync with leader meet error", errs.ZapError(errs.ErrGRPCRecv, err))
 					}
-					if !s.waitRegionSyncRetryInterval(ctx) {
+					if !finishStream() {
 						return
 					}
 					break
 				}
-				handled, nextFullSyncing := s.handleRegionSyncResponse(ctx, resp, bc, regionStorage, fullSyncing)
+				if fullSyncProgress == nil {
+					startFullSync, startEmptyFullSync := s.isFullSyncStartResponse(resp, fullSyncing)
+					if startFullSync || startEmptyFullSync {
+						fullSyncProgress, fullSyncTimedOut, stopFullSyncWatchdog =
+							watchFullSyncProgress(streamCtx, s.fullSyncProgressTimeout, streamCancel)
+					}
+				}
+				handled, nextFullSyncing := s.handleRegionSyncResponse(
+					streamCtx, resp, bc, regionStorage, fullSyncing,
+				)
 				fullSyncing = nextFullSyncing
 				if !handled {
-					if err = stream.CloseSend(); err != nil {
-						log.Warn("failed to terminate client stream", errs.ZapError(errs.ErrGRPCCloseSend, err))
-					}
-					if !s.waitRegionSyncRetryInterval(ctx) {
+					if !finishStream() {
 						return
 					}
 					break
+				}
+				if fullSyncing {
+					select {
+					case fullSyncProgress <- struct{}{}:
+					default:
+					}
+				} else if stopFullSyncWatchdog != nil {
+					stopFullSyncWatchdog()
+					stopFullSyncWatchdog = nil
+					fullSyncProgress = nil
+					fullSyncTimedOut = nil
 				}
 			}
 		}
 	}()
+}
+
+func watchFullSyncProgress(
+	ctx context.Context,
+	timeout time.Duration,
+	cancelStream context.CancelFunc,
+) (chan<- struct{}, <-chan struct{}, context.CancelFunc) {
+	watchdogCtx, stopWatchdog := context.WithCancel(ctx)
+	progress := make(chan struct{}, 1)
+	timedOut := make(chan struct{})
+	go func() {
+		defer logutil.LogPanic()
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-watchdogCtx.Done():
+				return
+			case <-progress:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(timeout)
+			case <-timer.C:
+				close(timedOut)
+				cancelStream()
+				return
+			}
+		}
+	}()
+	return progress, timedOut, stopWatchdog
 }
 
 func (s *RegionSyncer) waitRegionSyncRetryInterval(ctx context.Context) bool {

--- a/pkg/syncer/client_test.go
+++ b/pkg/syncer/client_test.go
@@ -16,11 +16,15 @@ package syncer
 
 import (
 	"context"
+	"errors"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -31,6 +35,7 @@ import (
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/mock/mockserver"
 	"github.com/tikv/pd/pkg/storage"
+	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -117,4 +122,855 @@ func TestHandleRegionSyncResponseSkipsErrorResponse(t *testing.T) {
 	re.False(fullSyncing)
 	re.Equal(uint64(10), syncer.history.getNextIndex())
 	re.False(syncer.IsRunning())
+}
+
+func TestHistorySyncCompletionMarkerLifecycle(t *testing.T) {
+	re := require.New(t)
+	regionStorage := storage.NewStorageWithMemoryBackend()
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		regionStorage,
+		core.NewBasicCluster(),
+	)
+	syncer := NewRegionSyncer(server)
+	re.False(syncer.IsHistorySynced())
+
+	handled, fullSyncing := syncer.handleRegionSyncResponse(
+		context.Background(),
+		newTestSyncRegionResponse(10),
+		core.NewBasicCluster(),
+		regionStorage,
+		false,
+	)
+	re.True(handled)
+	re.False(fullSyncing)
+	re.True(syncer.IsHistorySynced())
+
+	restarted := NewRegionSyncer(server)
+	re.True(restarted.IsHistorySynced())
+	re.NoError(restarted.MarkHistoryIncomplete())
+	re.False(restarted.IsHistorySynced())
+	re.False(NewRegionSyncer(server).IsHistorySynced())
+}
+
+func TestPartialHistoryDoesNotMigrateToCompletedSync(t *testing.T) {
+	re := require.New(t)
+	regionStorage := storage.NewStorageWithMemoryBackend()
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		regionStorage,
+		core.NewBasicCluster(),
+	)
+	syncer := NewRegionSyncer(server)
+	re.False(syncer.IsHistorySynced())
+	for i := range defaultFlushCount {
+		syncer.history.record(newTestSyncRegion(uint64(i+1), uint64(i+101)))
+	}
+	re.Equal(uint64(defaultFlushCount), syncer.history.getNextIndex())
+
+	restarted := NewRegionSyncer(server)
+	re.False(restarted.IsHistorySynced())
+}
+
+func TestIncompleteMarkerAlwaysRequestsFullSnapshot(t *testing.T) {
+	re := require.New(t)
+	syncer, _ := newTestRegionSyncer(t)
+	syncer.history.resetWithIndex(42)
+	syncer.initialFollowerSyncCompleted.Store(true)
+	syncer.streamingRunning.Store(true)
+	re.NoError(syncer.history.saveSynced(false))
+	syncer.historySynced.Store(false)
+
+	re.Zero(syncer.syncRegionStartIndex())
+	re.False(syncer.IsRunning())
+}
+
+func TestHistoryIndexPersistenceFailureKeepsFollowerNotReady(t *testing.T) {
+	re := require.New(t)
+	syncer, _ := newTestRegionSyncer(t)
+	syncer.history.kv = &saveFailKV{
+		Base:    syncer.history.kv,
+		failKey: historyKey,
+	}
+
+	re.Error(syncer.MarkHistoryIncomplete())
+	re.False(syncer.IsHistorySynced())
+	re.Error(syncer.MarkHistorySynced())
+	re.False(syncer.IsHistorySynced())
+}
+
+func TestInitialFollowerSyncRequestsFullSnapshotWithoutClearingCompletedState(t *testing.T) {
+	re := require.New(t)
+	pdServer := &captureSyncRequestServer{
+		requestCh: make(chan *pdpb.SyncRegionRequest, 1),
+	}
+	leaderURL := startTestPDServer(t, pdServer)
+
+	serverCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	regionStorage := storage.NewStorageWithMemoryBackend()
+	cluster := core.NewBasicCluster()
+	staleRegion := newTestSyncRegion(9, 19)
+	cluster.PutRegion(staleRegion)
+	re.NoError(regionStorage.SaveRegion(staleRegion.GetMeta()))
+	syncer := newFollowerTestSyncer(serverCtx, regionStorage, cluster)
+	syncer.history.resetWithIndex(42)
+	re.NoError(syncer.MarkHistorySynced())
+
+	syncer.StartSyncWithLeader(leaderURL)
+	t.Cleanup(func() {
+		syncer.StopSyncWithLeader()
+	})
+	request := mustRecvWithin(
+		t, pdServer.requestCh, 3*time.Second, "initial follower sync request was not received",
+	)
+	re.Zero(request.GetStartIndex())
+	re.True(syncer.IsHistorySynced())
+	re.Equal(uint64(42), syncer.history.getNextIndex())
+	synced, exists, err := syncer.history.loadSynced()
+	re.NoError(err)
+	re.True(exists)
+	re.True(synced)
+	re.NotNil(cluster.GetRegion(staleRegion.GetID()))
+	stored := &metapb.Region{}
+	ok, err := regionStorage.LoadRegion(staleRegion.GetID(), stored)
+	re.NoError(err)
+	re.True(ok)
+}
+
+func TestInitialRegionLoadFailureBlocksSynchronizationUntilRetrySucceeds(t *testing.T) {
+	re := require.New(t)
+	pdServer := &captureSyncRequestServer{
+		requestCh: make(chan *pdpb.SyncRegionRequest, 1),
+	}
+	leaderURL := startTestPDServer(t, pdServer)
+
+	serverCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	defaultStorage := storage.NewStorageWithMemoryBackend()
+	localStorage := &loadRegionsFailOnceStorage{
+		Storage: storage.NewStorageWithMemoryBackend(),
+	}
+	persisted := newTestSyncRegion(9, 19)
+	re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
+	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
+	cluster := core.NewBasicCluster()
+	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
+	syncer.history.resetWithIndex(42)
+	re.NoError(syncer.MarkHistorySynced())
+
+	syncer.StartSyncWithLeader(leaderURL)
+	t.Cleanup(func() {
+		syncer.StopSyncWithLeader()
+	})
+	select {
+	case <-pdServer.requestCh:
+		re.FailNow("synchronization started before persisted Regions were loaded")
+	case <-time.After(300 * time.Millisecond):
+	}
+	request := mustRecvWithin(
+		t, pdServer.requestCh, 3*time.Second,
+		"synchronization did not start after persisted Regions were loaded",
+	)
+	re.Zero(request.GetStartIndex())
+	re.True(syncer.initialRegionLoadCompleted.Load())
+	re.NotNil(cluster.GetRegion(persisted.GetID()))
+	re.True(syncer.IsHistorySynced())
+}
+
+func TestFullSyncWatchdogCoversFirstDestructiveResponse(t *testing.T) {
+	re := require.New(t)
+	pdServer := &firstSnapshotThenBlockPDServer{
+		requestCh:    make(chan int, 2),
+		startIndexCh: make(chan uint64, 2),
+		response:     newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
+	}
+	leaderURL := startTestPDServer(t, pdServer)
+
+	serverCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	defaultStorage := storage.NewStorageWithMemoryBackend()
+	localStorage := &blockFirstTxnUntilCanceledStorage{
+		Storage: storage.NewStorageWithMemoryBackend(),
+		entered: make(chan struct{}),
+	}
+	persisted := newTestSyncRegion(7, 17)
+	re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
+	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
+	cluster := core.NewBasicCluster()
+	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
+	syncer.history.resetWithIndex(42)
+	re.NoError(syncer.MarkHistorySynced())
+	syncer.fullSyncProgressTimeout = 50 * time.Millisecond
+
+	syncer.StartSyncWithLeader(leaderURL)
+	t.Cleanup(func() {
+		syncer.StopSyncWithLeader()
+	})
+	mustRecvWithin(
+		t,
+		localStorage.entered,
+		3*time.Second,
+		"first destructive Region storage transaction was not reached",
+	)
+	for expectedRequest := 1; expectedRequest <= 2; expectedRequest++ {
+		request := mustRecvWithin(
+			t,
+			pdServer.requestCh,
+			3*time.Second,
+			"full sync did not reconnect after first-frame timeout",
+		)
+		re.Equal(expectedRequest, request)
+		re.Zero(mustRecvWithin(
+			t,
+			pdServer.startIndexCh,
+			3*time.Second,
+			"full sync retry did not request a full snapshot",
+		))
+	}
+	re.Eventually(func() bool {
+		synced, exists, err := syncer.history.loadSynced()
+		return err == nil && exists && !synced &&
+			!syncer.IsHistorySynced() &&
+			syncer.history.getNextIndex() == 0
+	}, time.Second, 10*time.Millisecond)
+	re.False(syncer.IsRunning())
+}
+
+func TestStopDuringFullSyncKeepsFollowerIncomplete(t *testing.T) {
+	re := require.New(t)
+	pdServer := &firstSnapshotThenBlockPDServer{
+		requestCh:    make(chan int, 1),
+		startIndexCh: make(chan uint64, 1),
+		response:     newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
+	}
+	leaderURL := startTestPDServer(t, pdServer)
+
+	serverCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	defaultStorage := storage.NewStorageWithMemoryBackend()
+	localStorage := storage.NewStorageWithMemoryBackend()
+	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
+	cluster := core.NewBasicCluster()
+	persisted := newTestSyncRegion(7, 17)
+	cluster.PutRegion(persisted)
+	re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
+	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
+	syncer.history.resetWithIndex(42)
+	re.NoError(syncer.MarkHistorySynced())
+
+	syncer.StartSyncWithLeader(leaderURL)
+	mustRecvWithin(t, pdServer.requestCh, 3*time.Second, "full sync request was not received")
+	re.Zero(mustRecvWithin(
+		t,
+		pdServer.startIndexCh,
+		3*time.Second,
+		"full sync did not start from zero",
+	))
+	re.Eventually(func() bool {
+		return !syncer.IsHistorySynced() &&
+			syncer.history.getNextIndex() == 0 &&
+			cluster.GetRegion(9) != nil
+	}, 3*time.Second, 10*time.Millisecond)
+
+	syncer.StopSyncWithLeader()
+	re.False(syncer.IsHistorySynced())
+	re.False(syncer.IsRunning())
+	re.Zero(syncer.syncRegionStartIndex())
+	re.Nil(cluster.GetRegion(persisted.GetID()))
+
+	stored := &metapb.Region{}
+	ok, err := localStorage.LoadRegion(persisted.GetID(), stored)
+	re.NoError(err)
+	re.False(ok)
+	synced, exists, err := syncer.history.loadSynced()
+	re.NoError(err)
+	re.True(exists)
+	re.False(synced)
+
+	restartedCluster := core.NewBasicCluster()
+	restartedServer := mockserver.NewMockServer(
+		context.Background(),
+		&pdpb.Member{Name: "pd-follower", MemberId: 2},
+		nil,
+		coreStorage,
+		restartedCluster,
+	)
+	restarted := NewRegionSyncer(restartedServer)
+	re.False(restarted.IsHistorySynced())
+	re.Zero(restarted.syncRegionStartIndex())
+}
+
+func TestFullSyncEOFReconnectsInsteadOfStopping(t *testing.T) {
+	re := require.New(t)
+	pdServer := &firstSnapshotThenBlockPDServer{
+		requestCh:    make(chan int, 2),
+		startIndexCh: make(chan uint64, 2),
+		response:     newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
+		closeFirst:   true,
+	}
+	leaderURL := startTestPDServer(t, pdServer)
+
+	serverCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	defaultStorage := storage.NewStorageWithMemoryBackend()
+	localStorage := storage.NewStorageWithMemoryBackend()
+	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
+	cluster := core.NewBasicCluster()
+	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
+	syncer.StartSyncWithLeader(leaderURL)
+	t.Cleanup(func() {
+		syncer.StopSyncWithLeader()
+	})
+	for expectedRequest := 1; expectedRequest <= 2; expectedRequest++ {
+		request := mustRecvWithin(
+			t, pdServer.requestCh, 3*time.Second, "full sync did not reconnect after EOF",
+		)
+		re.Equal(expectedRequest, request)
+		re.Zero(mustRecvWithin(
+			t,
+			pdServer.startIndexCh,
+			3*time.Second,
+			"full sync retry after EOF did not start from zero",
+		))
+	}
+	re.False(syncer.IsHistorySynced())
+	re.False(syncer.IsRunning())
+	re.Zero(syncer.history.getNextIndex())
+}
+
+func TestFullSyncStorageFailureRetriesFromIncomplete(t *testing.T) {
+	tests := []struct {
+		name                 string
+		failSave             bool
+		failDelete           bool
+		failFlushCall        int
+		failCompletionMarker bool
+		regions              []*metapb.Region
+	}{
+		{
+			name:     "save",
+			failSave: true,
+			regions:  []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+		},
+		{
+			name:          "flush-before-clear",
+			failFlushCall: 1,
+			regions:       []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+		},
+		{
+			name:          "flush-before-complete",
+			failFlushCall: 2,
+			regions:       []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+		},
+		{
+			name:                 "completion-marker",
+			failCompletionMarker: true,
+			regions:              []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+		},
+		{
+			name:       "delete",
+			failDelete: true,
+			regions: []*metapb.Region{
+				{
+					Id:       9,
+					StartKey: []byte{1},
+					EndKey:   []byte{3},
+					RegionEpoch: &metapb.RegionEpoch{
+						ConfVer: 1,
+						Version: 1,
+					},
+					Peers: []*metapb.Peer{{Id: 19, StoreId: 1}},
+				},
+				{
+					Id:       10,
+					StartKey: []byte{1},
+					EndKey:   []byte{3},
+					RegionEpoch: &metapb.RegionEpoch{
+						ConfVer: 1,
+						Version: 2,
+					},
+					Peers: []*metapb.Peer{{Id: 20, StoreId: 1}},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			re := require.New(t)
+			pdServer := &retryFullSyncPDServer{
+				requestCh:     make(chan *pdpb.SyncRegionRequest, 2),
+				response:      newTestSyncRegionResponse(0, test.regions...),
+				completeFirst: test.failFlushCall == 2 || test.failCompletionMarker,
+			}
+			leaderURL := startTestPDServer(t, pdServer)
+
+			serverCtx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			defaultStorage := storage.NewStorageWithMemoryBackend()
+			localStorage := &regionWriteFailOnceStorage{
+				Storage: storage.NewStorageWithMemoryBackend(),
+				failed:  make(chan struct{}, 1),
+			}
+			persisted := newTestSyncRegion(7, 17)
+			re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
+			coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
+			cluster := core.NewBasicCluster()
+			syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
+			syncer.history.resetWithIndex(42)
+			re.NoError(syncer.MarkHistorySynced())
+			localStorage.flushCalls = 0
+			localStorage.failSave = test.failSave
+			localStorage.failDelete = test.failDelete
+			localStorage.failFlushCall = test.failFlushCall
+			localStorage.failCompletionMarker = test.failCompletionMarker
+
+			syncer.StartSyncWithLeader(leaderURL)
+			t.Cleanup(func() {
+				syncer.StopSyncWithLeader()
+			})
+			request := mustRecvWithin(
+				t,
+				pdServer.requestCh,
+				3*time.Second,
+				"initial full sync request was not received",
+			)
+			re.Zero(request.GetStartIndex())
+			mustRecvWithin(
+				t,
+				localStorage.failed,
+				3*time.Second,
+				"Region storage failure was not injected",
+			)
+			synced, exists, err := syncer.history.loadSynced()
+			re.NoError(err)
+			re.True(exists)
+			re.False(synced)
+			re.False(syncer.IsHistorySynced())
+			re.False(syncer.IsRunning())
+
+			request = mustRecvWithin(
+				t,
+				pdServer.requestCh,
+				3*time.Second,
+				"full sync did not retry after Region write failure",
+			)
+			re.Zero(request.GetStartIndex())
+			re.Eventually(func() bool {
+				return syncer.IsHistorySynced() &&
+					syncer.IsRunning() &&
+					syncer.history.getNextIndex() == uint64(len(test.regions))
+			}, 3*time.Second, 10*time.Millisecond)
+			re.Nil(cluster.GetRegion(persisted.GetID()))
+			stored := &metapb.Region{}
+			ok, err := localStorage.LoadRegion(persisted.GetID(), stored)
+			re.NoError(err)
+			re.False(ok)
+
+			authoritative := test.regions[len(test.regions)-1]
+			re.NotNil(cluster.GetRegion(authoritative.GetId()))
+			ok, err = localStorage.LoadRegion(authoritative.GetId(), stored)
+			re.NoError(err)
+			re.True(ok)
+			re.Equal(authoritative, stored)
+		})
+	}
+}
+
+func TestFullSyncClearDoesNotResurrectPendingLevelDBBatch(t *testing.T) {
+	re := require.New(t)
+	regionStorage, err := storage.NewRegionStorageWithLevelDBBackend(
+		context.Background(), t.TempDir(), nil,
+	)
+	re.NoError(err)
+	t.Cleanup(func() {
+		re.NoError(regionStorage.Close())
+	})
+	defaultStorage := storage.NewStorageWithMemoryBackend()
+	coreStorage := storage.NewCoreStorage(defaultStorage, regionStorage)
+	re.NotNil(storage.TrySwitchRegionStorage(coreStorage, true))
+	cluster := core.NewBasicCluster()
+	syncer := newFollowerTestSyncer(context.Background(), coreStorage, cluster)
+	re.NoError(syncer.history.resetWithIndexAndPersist(42))
+	re.NoError(syncer.history.saveSynced(true))
+	syncer.historySynced.Store(true)
+	syncer.initialFollowerSyncCompleted.Store(true)
+
+	persisted := newTestSyncRegion(7, 17)
+	cluster.PutRegion(persisted)
+	// Keep the completed follower's latest Region update in the LevelDB
+	// in-memory batch to exercise the production storage ordering.
+	re.NoError(coreStorage.SaveRegion(persisted.GetMeta()))
+	partial := newTestSyncRegion(9, 19)
+	handled, fullSyncing := syncer.handleRegionSyncResponse(
+		context.Background(),
+		newTestSyncRegionResponse(0, partial.GetMeta()),
+		cluster,
+		coreStorage,
+		false,
+	)
+	re.True(handled)
+	re.True(fullSyncing)
+
+	handled, fullSyncing = syncer.handleRegionSyncResponse(
+		context.Background(),
+		newTestSyncRegionResponse(1),
+		cluster,
+		coreStorage,
+		true,
+	)
+	re.True(handled)
+	re.False(fullSyncing)
+	stored := &metapb.Region{}
+	ok, err := regionStorage.LoadRegion(persisted.GetID(), stored)
+	re.NoError(err)
+	re.False(ok)
+	ok, err = regionStorage.LoadRegion(partial.GetID(), stored)
+	re.NoError(err)
+	re.True(ok)
+	re.Equal(partial.GetMeta(), stored)
+	re.True(syncer.IsHistorySynced())
+	re.Equal(uint64(1), syncer.history.getNextIndex())
+}
+
+func newFollowerTestSyncer(
+	ctx context.Context,
+	clientStorage storage.Storage,
+	cluster *core.BasicCluster,
+) *RegionSyncer {
+	server := mockserver.NewMockServer(
+		ctx,
+		&pdpb.Member{Name: "pd-follower", MemberId: 2},
+		&pdpb.Member{Name: "pd-leader", MemberId: 1},
+		clientStorage,
+		cluster,
+	)
+	return NewRegionSyncer(server)
+}
+
+func startTestPDServer(t *testing.T, pdServer pdpb.PDServer) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	grpcServer := grpc.NewServer()
+	pdpb.RegisterPDServer(grpcServer, pdServer)
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- grpcServer.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		err := <-serveDone
+		if err != nil {
+			require.ErrorIs(t, err, grpc.ErrServerStopped)
+		}
+	})
+	return "http://" + listener.Addr().String()
+}
+
+func newTestSyncRegionResponse(
+	startIndex uint64,
+	regions ...*metapb.Region,
+) *pdpb.SyncRegionResponse {
+	return &pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		Regions:    regions,
+		StartIndex: startIndex,
+	}
+}
+
+func mustRecvWithin[T any](
+	t *testing.T,
+	ch <-chan T,
+	timeout time.Duration,
+	message string,
+) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(timeout):
+		require.FailNow(t, message)
+		var zero T
+		return zero
+	}
+}
+
+type loadRegionsFailOnceStorage struct {
+	storage.Storage
+	mu     sync.Mutex
+	failed bool
+}
+
+func (s *loadRegionsFailOnceStorage) LoadRegions(
+	ctx context.Context,
+	f func(region *core.RegionInfo) []*core.RegionInfo,
+) error {
+	s.mu.Lock()
+	if !s.failed {
+		s.failed = true
+		s.mu.Unlock()
+		return errors.New("injected Region load failure")
+	}
+	s.mu.Unlock()
+	return s.Storage.LoadRegions(ctx, f)
+}
+
+type blockFirstTxnUntilCanceledStorage struct {
+	storage.Storage
+	entered chan struct{}
+	once    sync.Once
+}
+
+type regionWriteFailOnceStorage struct {
+	storage.Storage
+	mu                   sync.Mutex
+	failSave             bool
+	failDelete           bool
+	failFlushCall        int
+	flushCalls           int
+	failCompletionMarker bool
+	failed               chan struct{}
+}
+
+func (s *regionWriteFailOnceStorage) SaveRegion(region *metapb.Region) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failSave {
+		s.failSave = false
+		s.failed <- struct{}{}
+		return errors.New("injected Region save failure")
+	}
+	return s.Storage.SaveRegion(region)
+}
+
+func (s *regionWriteFailOnceStorage) DeleteRegion(region *metapb.Region) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failDelete {
+		s.failDelete = false
+		s.failed <- struct{}{}
+		return errors.New("injected Region delete failure")
+	}
+	return s.Storage.DeleteRegion(region)
+}
+
+func (s *regionWriteFailOnceStorage) Flush() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.flushCalls++
+	if s.failFlushCall == s.flushCalls {
+		s.failed <- struct{}{}
+		return errors.New("injected Region flush failure")
+	}
+	return s.Storage.Flush()
+}
+
+func (s *regionWriteFailOnceStorage) Save(key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failCompletionMarker && key == historySyncedKey && value == "true" {
+		s.failCompletionMarker = false
+		s.failed <- struct{}{}
+		return errors.New("injected completion marker failure")
+	}
+	return s.Storage.Save(key, value)
+}
+
+func (s *blockFirstTxnUntilCanceledStorage) RunInTxn(
+	ctx context.Context,
+	f func(kv.Txn) error,
+) error {
+	blocked := false
+	s.once.Do(func() {
+		blocked = true
+		close(s.entered)
+	})
+	if blocked {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return s.Storage.RunInTxn(ctx, f)
+}
+
+type captureSyncRequestServer struct {
+	pdpb.UnimplementedPDServer
+	requestCh chan *pdpb.SyncRegionRequest
+}
+
+type firstSnapshotThenBlockPDServer struct {
+	pdpb.UnimplementedPDServer
+	mu           sync.Mutex
+	requests     int
+	requestCh    chan int
+	startIndexCh chan uint64
+	response     *pdpb.SyncRegionResponse
+	closeFirst   bool
+}
+
+type retryFullSyncPDServer struct {
+	pdpb.UnimplementedPDServer
+	mu            sync.Mutex
+	requests      int
+	requestCh     chan *pdpb.SyncRegionRequest
+	response      *pdpb.SyncRegionResponse
+	completeFirst bool
+}
+
+func (s *firstSnapshotThenBlockPDServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
+	requestMessage, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.requests++
+	request := s.requests
+	s.mu.Unlock()
+	s.requestCh <- request
+	if s.startIndexCh != nil {
+		s.startIndexCh <- requestMessage.GetStartIndex()
+	}
+	if request == 1 {
+		if err := stream.Send(s.response); err != nil {
+			return err
+		}
+		if s.closeFirst {
+			return nil
+		}
+	}
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (s *retryFullSyncPDServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
+	request, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.requests++
+	attempt := s.requests
+	s.mu.Unlock()
+	s.requestCh <- request
+	if err := stream.Send(s.response); err != nil {
+		return err
+	}
+	if attempt == 1 && !s.completeFirst {
+		<-stream.Context().Done()
+		return stream.Context().Err()
+	}
+	if err := stream.Send(newTestSyncRegionResponse(uint64(len(s.response.GetRegions())))); err != nil {
+		return err
+	}
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (s *captureSyncRequestServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
+	request, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	s.requestCh <- request
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func TestLegacyPersistedHistoryMigratesToCompletedSync(t *testing.T) {
+	re := require.New(t)
+	regionStorage := storage.NewStorageWithMemoryBackend()
+	re.NoError(regionStorage.Save(historyKey, "42"))
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		regionStorage,
+		core.NewBasicCluster(),
+	)
+
+	syncer := NewRegionSyncer(server)
+	re.True(syncer.IsHistorySynced())
+	synced, exists, err := syncer.history.loadSynced()
+	re.NoError(err)
+	re.True(exists)
+	re.True(synced)
+}
+
+func TestLegacyHistoryMarkerSaveFailureKeepsFollowerNotReady(t *testing.T) {
+	re := require.New(t)
+	baseStorage := storage.NewStorageWithMemoryBackend()
+	re.NoError(baseStorage.Save(historyKey, "42"))
+	regionStorage := &regionWriteFailOnceStorage{
+		Storage:              baseStorage,
+		failCompletionMarker: true,
+		failed:               make(chan struct{}, 1),
+	}
+	server := mockserver.NewMockServer(
+		context.Background(),
+		nil,
+		nil,
+		regionStorage,
+		core.NewBasicCluster(),
+	)
+
+	syncer := NewRegionSyncer(server)
+
+	mustRecvWithin(t, regionStorage.failed, time.Second, "legacy marker failure was not injected")
+	re.False(syncer.IsHistorySynced())
+	synced, exists, err := syncer.history.loadSynced()
+	re.NoError(err)
+	re.False(exists)
+	re.False(synced)
+}
+
+type saveFailKV struct {
+	kv.Base
+	failKey string
+}
+
+func (s *saveFailKV) Save(key, value string) error {
+	if key == s.failKey {
+		return errors.New("injected save failure")
+	}
+	return s.Base.Save(key, value)
+}
+
+func TestFullSyncReplacesNewerCacheAndOlderStorage(t *testing.T) {
+	re := require.New(t)
+	regionStorage := storage.NewStorageWithMemoryBackend()
+	stored := newTestSyncRegion(1, 11).GetMeta()
+	stored.RegionEpoch.Version = 1
+	re.NoError(regionStorage.SaveRegion(stored))
+
+	cached := newTestSyncRegion(1, 11)
+	cached.GetMeta().RegionEpoch.Version = 3
+	bc := core.NewBasicCluster()
+	bc.PutRegion(cached)
+	server := mockserver.NewMockServer(context.Background(), nil, nil, regionStorage, bc)
+	syncer := NewRegionSyncer(server)
+	syncer.history.resetWithIndex(42)
+	re.NoError(syncer.MarkHistorySynced())
+
+	leader := newTestSyncRegion(1, 11).GetMeta()
+	leader.RegionEpoch.Version = 2
+	handled, fullSyncing := syncer.handleRegionSyncResponse(
+		context.Background(),
+		newTestSyncRegionResponse(0, leader),
+		bc,
+		regionStorage,
+		false,
+	)
+	re.True(handled)
+	re.True(fullSyncing)
+	re.Equal(uint64(2), bc.GetRegion(1).GetRegionEpoch().GetVersion())
+
+	persisted := &metapb.Region{}
+	ok, err := regionStorage.LoadRegion(1, persisted)
+	re.NoError(err)
+	re.True(ok)
+	re.Equal(uint64(2), persisted.GetRegionEpoch().GetVersion())
 }

--- a/pkg/syncer/client_test.go
+++ b/pkg/syncer/client_test.go
@@ -210,21 +210,14 @@ func TestInitialFollowerSyncRequestsFullSnapshotWithoutClearingCompletedState(t 
 	}
 	leaderURL := startTestPDServer(t, pdServer)
 
-	serverCtx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	regionStorage := storage.NewStorageWithMemoryBackend()
-	cluster := core.NewBasicCluster()
+	syncer, cluster := newFollowerTestSyncer(t, regionStorage)
 	staleRegion := newTestSyncRegion(9, 19)
 	cluster.PutRegion(staleRegion)
 	re.NoError(regionStorage.SaveRegion(staleRegion.GetMeta()))
-	syncer := newFollowerTestSyncer(serverCtx, regionStorage, cluster)
-	syncer.history.resetWithIndex(42)
-	re.NoError(syncer.MarkHistorySynced())
+	markHistorySynced(t, syncer)
 
 	syncer.StartSyncWithLeader(leaderURL)
-	t.Cleanup(func() {
-		syncer.StopSyncWithLeader()
-	})
 	request := mustRecvWithin(
 		t, pdServer.requestCh, 3*time.Second, "initial follower sync request was not received",
 	)
@@ -249,8 +242,6 @@ func TestInitialRegionLoadFailureBlocksSynchronizationUntilRetrySucceeds(t *test
 	}
 	leaderURL := startTestPDServer(t, pdServer)
 
-	serverCtx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	defaultStorage := storage.NewStorageWithMemoryBackend()
 	localStorage := &loadRegionsFailOnceStorage{
 		Storage: storage.NewStorageWithMemoryBackend(),
@@ -258,15 +249,10 @@ func TestInitialRegionLoadFailureBlocksSynchronizationUntilRetrySucceeds(t *test
 	persisted := newTestSyncRegion(9, 19)
 	re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
 	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
-	cluster := core.NewBasicCluster()
-	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
-	syncer.history.resetWithIndex(42)
-	re.NoError(syncer.MarkHistorySynced())
+	syncer, cluster := newFollowerTestSyncer(t, coreStorage)
+	markHistorySynced(t, syncer)
 
 	syncer.StartSyncWithLeader(leaderURL)
-	t.Cleanup(func() {
-		syncer.StopSyncWithLeader()
-	})
 	select {
 	case <-pdServer.requestCh:
 		re.FailNow("synchronization started before persisted Regions were loaded")
@@ -284,15 +270,12 @@ func TestInitialRegionLoadFailureBlocksSynchronizationUntilRetrySucceeds(t *test
 
 func TestFullSyncWatchdogCoversFirstDestructiveResponse(t *testing.T) {
 	re := require.New(t)
-	pdServer := &firstSnapshotThenBlockPDServer{
-		requestCh:    make(chan int, 2),
-		startIndexCh: make(chan uint64, 2),
-		response:     newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
+	pdServer := &scriptedSyncPDServer{
+		requestCh: make(chan syncRequestEvent, 2),
+		response:  newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
 	}
 	leaderURL := startTestPDServer(t, pdServer)
 
-	serverCtx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	defaultStorage := storage.NewStorageWithMemoryBackend()
 	localStorage := &blockFirstTxnUntilCanceledStorage{
 		Storage: storage.NewStorageWithMemoryBackend(),
@@ -301,16 +284,11 @@ func TestFullSyncWatchdogCoversFirstDestructiveResponse(t *testing.T) {
 	persisted := newTestSyncRegion(7, 17)
 	re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
 	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
-	cluster := core.NewBasicCluster()
-	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
-	syncer.history.resetWithIndex(42)
-	re.NoError(syncer.MarkHistorySynced())
+	syncer, _ := newFollowerTestSyncer(t, coreStorage)
+	markHistorySynced(t, syncer)
 	syncer.fullSyncProgressTimeout = 50 * time.Millisecond
 
 	syncer.StartSyncWithLeader(leaderURL)
-	t.Cleanup(func() {
-		syncer.StopSyncWithLeader()
-	})
 	mustRecvWithin(
 		t,
 		localStorage.entered,
@@ -324,13 +302,8 @@ func TestFullSyncWatchdogCoversFirstDestructiveResponse(t *testing.T) {
 			3*time.Second,
 			"full sync did not reconnect after first-frame timeout",
 		)
-		re.Equal(expectedRequest, request)
-		re.Zero(mustRecvWithin(
-			t,
-			pdServer.startIndexCh,
-			3*time.Second,
-			"full sync retry did not request a full snapshot",
-		))
+		re.Equal(expectedRequest, request.attempt)
+		re.Zero(request.startIndex)
 	}
 	re.Eventually(func() bool {
 		synced, exists, err := syncer.history.loadSynced()
@@ -343,34 +316,26 @@ func TestFullSyncWatchdogCoversFirstDestructiveResponse(t *testing.T) {
 
 func TestStopDuringFullSyncKeepsFollowerIncomplete(t *testing.T) {
 	re := require.New(t)
-	pdServer := &firstSnapshotThenBlockPDServer{
-		requestCh:    make(chan int, 1),
-		startIndexCh: make(chan uint64, 1),
-		response:     newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
+	pdServer := &scriptedSyncPDServer{
+		requestCh: make(chan syncRequestEvent, 1),
+		response:  newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
 	}
 	leaderURL := startTestPDServer(t, pdServer)
 
-	serverCtx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	defaultStorage := storage.NewStorageWithMemoryBackend()
 	localStorage := storage.NewStorageWithMemoryBackend()
 	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
-	cluster := core.NewBasicCluster()
+	syncer, cluster := newFollowerTestSyncer(t, coreStorage)
 	persisted := newTestSyncRegion(7, 17)
 	cluster.PutRegion(persisted)
 	re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
-	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
-	syncer.history.resetWithIndex(42)
-	re.NoError(syncer.MarkHistorySynced())
+	markHistorySynced(t, syncer)
 
 	syncer.StartSyncWithLeader(leaderURL)
-	mustRecvWithin(t, pdServer.requestCh, 3*time.Second, "full sync request was not received")
-	re.Zero(mustRecvWithin(
-		t,
-		pdServer.startIndexCh,
-		3*time.Second,
-		"full sync did not start from zero",
-	))
+	request := mustRecvWithin(
+		t, pdServer.requestCh, 3*time.Second, "full sync request was not received",
+	)
+	re.Zero(request.startIndex)
 	re.Eventually(func() bool {
 		return !syncer.IsHistorySynced() &&
 			syncer.history.getNextIndex() == 0 &&
@@ -407,36 +372,24 @@ func TestStopDuringFullSyncKeepsFollowerIncomplete(t *testing.T) {
 
 func TestFullSyncEOFReconnectsInsteadOfStopping(t *testing.T) {
 	re := require.New(t)
-	pdServer := &firstSnapshotThenBlockPDServer{
-		requestCh:    make(chan int, 2),
-		startIndexCh: make(chan uint64, 2),
-		response:     newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
-		closeFirst:   true,
+	pdServer := &scriptedSyncPDServer{
+		requestCh:  make(chan syncRequestEvent, 2),
+		response:   newTestSyncRegionResponse(0, newTestSyncRegion(9, 19).GetMeta()),
+		closeFirst: true,
 	}
 	leaderURL := startTestPDServer(t, pdServer)
 
-	serverCtx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 	defaultStorage := storage.NewStorageWithMemoryBackend()
 	localStorage := storage.NewStorageWithMemoryBackend()
 	coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
-	cluster := core.NewBasicCluster()
-	syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
+	syncer, _ := newFollowerTestSyncer(t, coreStorage)
 	syncer.StartSyncWithLeader(leaderURL)
-	t.Cleanup(func() {
-		syncer.StopSyncWithLeader()
-	})
 	for expectedRequest := 1; expectedRequest <= 2; expectedRequest++ {
 		request := mustRecvWithin(
 			t, pdServer.requestCh, 3*time.Second, "full sync did not reconnect after EOF",
 		)
-		re.Equal(expectedRequest, request)
-		re.Zero(mustRecvWithin(
-			t,
-			pdServer.startIndexCh,
-			3*time.Second,
-			"full sync retry after EOF did not start from zero",
-		))
+		re.Equal(expectedRequest, request.attempt)
+		re.Zero(request.startIndex)
 	}
 	re.False(syncer.IsHistorySynced())
 	re.False(syncer.IsRunning())
@@ -445,72 +398,56 @@ func TestFullSyncEOFReconnectsInsteadOfStopping(t *testing.T) {
 
 func TestFullSyncStorageFailureRetriesFromIncomplete(t *testing.T) {
 	tests := []struct {
-		name                 string
-		failSave             bool
-		failDelete           bool
-		failFlushCall        int
-		failCompletionMarker bool
-		regions              []*metapb.Region
+		name    string
+		failure regionWriteFailure
+		regions []*metapb.Region
 	}{
 		{
-			name:     "save",
-			failSave: true,
-			regions:  []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+			name:    "save",
+			failure: failRegionSave,
+			regions: []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
 		},
 		{
-			name:          "flush-before-clear",
-			failFlushCall: 1,
-			regions:       []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+			name:    "flush-before-clear",
+			failure: failFirstFlush,
+			regions: []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
 		},
 		{
-			name:          "flush-before-complete",
-			failFlushCall: 2,
-			regions:       []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+			name:    "flush-before-complete",
+			failure: failSecondFlush,
+			regions: []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
 		},
 		{
-			name:                 "completion-marker",
-			failCompletionMarker: true,
-			regions:              []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
+			name:    "completion-marker",
+			failure: failCompletionMarker,
+			regions: []*metapb.Region{newTestSyncRegion(9, 19).GetMeta()},
 		},
 		{
-			name:       "delete",
-			failDelete: true,
+			name:    "delete",
+			failure: failRegionDelete,
 			regions: []*metapb.Region{
-				{
-					Id:       9,
-					StartKey: []byte{1},
-					EndKey:   []byte{3},
-					RegionEpoch: &metapb.RegionEpoch{
-						ConfVer: 1,
-						Version: 1,
-					},
-					Peers: []*metapb.Peer{{Id: 19, StoreId: 1}},
-				},
-				{
-					Id:       10,
-					StartKey: []byte{1},
-					EndKey:   []byte{3},
-					RegionEpoch: &metapb.RegionEpoch{
-						ConfVer: 1,
-						Version: 2,
-					},
-					Peers: []*metapb.Peer{{Id: 20, StoreId: 1}},
-				},
+				core.NewTestRegionInfo(
+					9, 1, []byte{1}, []byte{3}, core.WithNewPeerIDs(19),
+				).GetMeta(),
+				core.NewTestRegionInfo(
+					10, 1, []byte{1}, []byte{3},
+					core.WithNewPeerIDs(20), core.SetRegionVersion(2),
+				).GetMeta(),
 			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			re := require.New(t)
-			pdServer := &retryFullSyncPDServer{
-				requestCh:     make(chan *pdpb.SyncRegionRequest, 2),
-				response:      newTestSyncRegionResponse(0, test.regions...),
-				completeFirst: test.failFlushCall == 2 || test.failCompletionMarker,
+			pdServer := &scriptedSyncPDServer{
+				requestCh:            make(chan syncRequestEvent, 2),
+				response:             newTestSyncRegionResponse(0, test.regions...),
+				snapshotEveryAttempt: true,
+				completeFirst: test.failure == failSecondFlush ||
+					test.failure == failCompletionMarker,
 			}
 			leaderURL := startTestPDServer(t, pdServer)
 
-			serverCtx, cancel := context.WithCancel(context.Background())
-			t.Cleanup(cancel)
 			defaultStorage := storage.NewStorageWithMemoryBackend()
 			localStorage := &regionWriteFailOnceStorage{
 				Storage: storage.NewStorageWithMemoryBackend(),
@@ -519,27 +456,18 @@ func TestFullSyncStorageFailureRetriesFromIncomplete(t *testing.T) {
 			persisted := newTestSyncRegion(7, 17)
 			re.NoError(localStorage.SaveRegion(persisted.GetMeta()))
 			coreStorage := storage.NewCoreStorage(defaultStorage, localStorage)
-			cluster := core.NewBasicCluster()
-			syncer := newFollowerTestSyncer(serverCtx, coreStorage, cluster)
-			syncer.history.resetWithIndex(42)
-			re.NoError(syncer.MarkHistorySynced())
-			localStorage.flushCalls = 0
-			localStorage.failSave = test.failSave
-			localStorage.failDelete = test.failDelete
-			localStorage.failFlushCall = test.failFlushCall
-			localStorage.failCompletionMarker = test.failCompletionMarker
+			syncer, cluster := newFollowerTestSyncer(t, coreStorage)
+			markHistorySynced(t, syncer)
+			localStorage.setFailure(test.failure)
 
 			syncer.StartSyncWithLeader(leaderURL)
-			t.Cleanup(func() {
-				syncer.StopSyncWithLeader()
-			})
 			request := mustRecvWithin(
 				t,
 				pdServer.requestCh,
 				3*time.Second,
 				"initial full sync request was not received",
 			)
-			re.Zero(request.GetStartIndex())
+			re.Zero(request.startIndex)
 			mustRecvWithin(
 				t,
 				localStorage.failed,
@@ -559,7 +487,7 @@ func TestFullSyncStorageFailureRetriesFromIncomplete(t *testing.T) {
 				3*time.Second,
 				"full sync did not retry after Region write failure",
 			)
-			re.Zero(request.GetStartIndex())
+			re.Zero(request.startIndex)
 			re.Eventually(func() bool {
 				return syncer.IsHistorySynced() &&
 					syncer.IsRunning() &&
@@ -593,8 +521,7 @@ func TestFullSyncClearDoesNotResurrectPendingLevelDBBatch(t *testing.T) {
 	defaultStorage := storage.NewStorageWithMemoryBackend()
 	coreStorage := storage.NewCoreStorage(defaultStorage, regionStorage)
 	re.NotNil(storage.TrySwitchRegionStorage(coreStorage, true))
-	cluster := core.NewBasicCluster()
-	syncer := newFollowerTestSyncer(context.Background(), coreStorage, cluster)
+	syncer, cluster := newFollowerTestSyncer(t, coreStorage)
 	re.NoError(syncer.history.resetWithIndexAndPersist(42))
 	re.NoError(syncer.history.saveSynced(true))
 	syncer.historySynced.Store(true)
@@ -638,18 +565,27 @@ func TestFullSyncClearDoesNotResurrectPendingLevelDBBatch(t *testing.T) {
 }
 
 func newFollowerTestSyncer(
-	ctx context.Context,
+	t *testing.T,
 	clientStorage storage.Storage,
-	cluster *core.BasicCluster,
-) *RegionSyncer {
+) (*RegionSyncer, *core.BasicCluster) {
+	t.Helper()
+	cluster := core.NewBasicCluster()
 	server := mockserver.NewMockServer(
-		ctx,
+		t.Context(),
 		&pdpb.Member{Name: "pd-follower", MemberId: 2},
 		&pdpb.Member{Name: "pd-leader", MemberId: 1},
 		clientStorage,
 		cluster,
 	)
-	return NewRegionSyncer(server)
+	syncer := NewRegionSyncer(server)
+	t.Cleanup(syncer.StopSyncWithLeader)
+	return syncer, cluster
+}
+
+func markHistorySynced(t *testing.T, syncer *RegionSyncer) {
+	t.Helper()
+	syncer.history.resetWithIndex(42)
+	require.NoError(t, syncer.MarkHistorySynced())
 }
 
 func startTestPDServer(t *testing.T, pdServer pdpb.PDServer) string {
@@ -726,59 +662,74 @@ type blockFirstTxnUntilCanceledStorage struct {
 	once    sync.Once
 }
 
+type regionWriteFailure uint8
+
+const (
+	noRegionWriteFailure regionWriteFailure = iota
+	failRegionSave
+	failRegionDelete
+	failFirstFlush
+	failSecondFlush
+	failCompletionMarker
+)
+
 type regionWriteFailOnceStorage struct {
 	storage.Storage
-	mu                   sync.Mutex
-	failSave             bool
-	failDelete           bool
-	failFlushCall        int
-	flushCalls           int
-	failCompletionMarker bool
-	failed               chan struct{}
+	failure    regionWriteFailure
+	flushCalls int
+	failed     chan struct{}
 }
 
 func (s *regionWriteFailOnceStorage) SaveRegion(region *metapb.Region) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.failSave {
-		s.failSave = false
-		s.failed <- struct{}{}
-		return errors.New("injected Region save failure")
+	if err := s.failOnce(failRegionSave); err != nil {
+		return err
 	}
 	return s.Storage.SaveRegion(region)
 }
 
 func (s *regionWriteFailOnceStorage) DeleteRegion(region *metapb.Region) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.failDelete {
-		s.failDelete = false
-		s.failed <- struct{}{}
-		return errors.New("injected Region delete failure")
+	if err := s.failOnce(failRegionDelete); err != nil {
+		return err
 	}
 	return s.Storage.DeleteRegion(region)
 }
 
 func (s *regionWriteFailOnceStorage) Flush() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.flushCalls++
-	if s.failFlushCall == s.flushCalls {
-		s.failed <- struct{}{}
-		return errors.New("injected Region flush failure")
+	failure := noRegionWriteFailure
+	switch s.flushCalls {
+	case 1:
+		failure = failFirstFlush
+	case 2:
+		failure = failSecondFlush
+	}
+	if err := s.failOnce(failure); err != nil {
+		return err
 	}
 	return s.Storage.Flush()
 }
 
 func (s *regionWriteFailOnceStorage) Save(key, value string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.failCompletionMarker && key == historySyncedKey && value == "true" {
-		s.failCompletionMarker = false
-		s.failed <- struct{}{}
-		return errors.New("injected completion marker failure")
+	if key == historySyncedKey && value == "true" {
+		if err := s.failOnce(failCompletionMarker); err != nil {
+			return err
+		}
 	}
 	return s.Storage.Save(key, value)
+}
+
+func (s *regionWriteFailOnceStorage) setFailure(failure regionWriteFailure) {
+	s.failure = failure
+	s.flushCalls = 0
+}
+
+func (s *regionWriteFailOnceStorage) failOnce(failure regionWriteFailure) error {
+	if failure == noRegionWriteFailure || s.failure != failure {
+		return nil
+	}
+	s.failure = noRegionWriteFailure
+	s.failed <- struct{}{}
+	return errors.New("injected Region storage failure")
 }
 
 func (s *blockFirstTxnUntilCanceledStorage) RunInTxn(
@@ -802,51 +753,23 @@ type captureSyncRequestServer struct {
 	requestCh chan *pdpb.SyncRegionRequest
 }
 
-type firstSnapshotThenBlockPDServer struct {
+type syncRequestEvent struct {
+	attempt    int
+	startIndex uint64
+}
+
+type scriptedSyncPDServer struct {
 	pdpb.UnimplementedPDServer
-	mu           sync.Mutex
-	requests     int
-	requestCh    chan int
-	startIndexCh chan uint64
-	response     *pdpb.SyncRegionResponse
-	closeFirst   bool
+	mu                   sync.Mutex
+	requests             int
+	requestCh            chan syncRequestEvent
+	response             *pdpb.SyncRegionResponse
+	snapshotEveryAttempt bool
+	completeFirst        bool
+	closeFirst           bool
 }
 
-type retryFullSyncPDServer struct {
-	pdpb.UnimplementedPDServer
-	mu            sync.Mutex
-	requests      int
-	requestCh     chan *pdpb.SyncRegionRequest
-	response      *pdpb.SyncRegionResponse
-	completeFirst bool
-}
-
-func (s *firstSnapshotThenBlockPDServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
-	requestMessage, err := stream.Recv()
-	if err != nil {
-		return err
-	}
-	s.mu.Lock()
-	s.requests++
-	request := s.requests
-	s.mu.Unlock()
-	s.requestCh <- request
-	if s.startIndexCh != nil {
-		s.startIndexCh <- requestMessage.GetStartIndex()
-	}
-	if request == 1 {
-		if err := stream.Send(s.response); err != nil {
-			return err
-		}
-		if s.closeFirst {
-			return nil
-		}
-	}
-	<-stream.Context().Done()
-	return stream.Context().Err()
-}
-
-func (s *retryFullSyncPDServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
+func (s *scriptedSyncPDServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
 	request, err := stream.Recv()
 	if err != nil {
 		return err
@@ -855,16 +778,22 @@ func (s *retryFullSyncPDServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) er
 	s.requests++
 	attempt := s.requests
 	s.mu.Unlock()
-	s.requestCh <- request
-	if err := stream.Send(s.response); err != nil {
-		return err
+	select {
+	case s.requestCh <- syncRequestEvent{attempt: attempt, startIndex: request.GetStartIndex()}:
+	default:
 	}
-	if attempt == 1 && !s.completeFirst {
-		<-stream.Context().Done()
-		return stream.Context().Err()
+	if attempt == 1 || s.snapshotEveryAttempt {
+		if err := stream.Send(s.response); err != nil {
+			return err
+		}
 	}
-	if err := stream.Send(newTestSyncRegionResponse(uint64(len(s.response.GetRegions())))); err != nil {
-		return err
+	if attempt == 1 && s.closeFirst {
+		return nil
+	}
+	if s.snapshotEveryAttempt && (attempt > 1 || s.completeFirst) {
+		if err := stream.Send(newTestSyncRegionResponse(uint64(len(s.response.GetRegions())))); err != nil {
+			return err
+		}
 	}
 	<-stream.Context().Done()
 	return stream.Context().Err()
@@ -905,9 +834,9 @@ func TestLegacyHistoryMarkerSaveFailureKeepsFollowerNotReady(t *testing.T) {
 	baseStorage := storage.NewStorageWithMemoryBackend()
 	re.NoError(baseStorage.Save(historyKey, "42"))
 	regionStorage := &regionWriteFailOnceStorage{
-		Storage:              baseStorage,
-		failCompletionMarker: true,
-		failed:               make(chan struct{}, 1),
+		Storage: baseStorage,
+		failure: failCompletionMarker,
+		failed:  make(chan struct{}, 1),
 	}
 	server := mockserver.NewMockServer(
 		context.Background(),
@@ -942,21 +871,17 @@ func (s *saveFailKV) Save(key, value string) error {
 func TestFullSyncReplacesNewerCacheAndOlderStorage(t *testing.T) {
 	re := require.New(t)
 	regionStorage := storage.NewStorageWithMemoryBackend()
-	stored := newTestSyncRegion(1, 11).GetMeta()
-	stored.RegionEpoch.Version = 1
+	stored := newTestSyncRegion(1, 11).Clone(core.SetRegionVersion(1)).GetMeta()
 	re.NoError(regionStorage.SaveRegion(stored))
 
-	cached := newTestSyncRegion(1, 11)
-	cached.GetMeta().RegionEpoch.Version = 3
+	cached := newTestSyncRegion(1, 11).Clone(core.SetRegionVersion(3))
 	bc := core.NewBasicCluster()
 	bc.PutRegion(cached)
 	server := mockserver.NewMockServer(context.Background(), nil, nil, regionStorage, bc)
 	syncer := NewRegionSyncer(server)
-	syncer.history.resetWithIndex(42)
-	re.NoError(syncer.MarkHistorySynced())
+	markHistorySynced(t, syncer)
 
-	leader := newTestSyncRegion(1, 11).GetMeta()
-	leader.RegionEpoch.Version = 2
+	leader := newTestSyncRegion(1, 11).Clone(core.SetRegionVersion(2)).GetMeta()
 	handled, fullSyncing := syncer.handleRegionSyncResponse(
 		context.Background(),
 		newTestSyncRegionResponse(0, leader),

--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	historyKey                = "historyIndex"
+	historySyncedKey          = "historySynced"
 	defaultFlushCount         = 100
 	historyBufferCapacityUnit = 10000
 	historyBufferShrinkRounds = 3
@@ -144,7 +145,10 @@ func (h *historyBuffer) recordLocked(r *core.RegionInfo) {
 	h.index++
 	h.flushCount--
 	if h.flushCount <= 0 {
-		h.persist()
+		if err := h.persist(); err != nil {
+			log.Warn("persist history index failed",
+				zap.Uint64("persist-index", h.nextIndex()), errs.ZapError(err))
+		}
 		h.flushCount = defaultFlushCount
 	}
 }
@@ -314,11 +318,11 @@ func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	}
 }
 
-func (h *historyBuffer) resetWithIndexAndPersist(index uint64) {
+func (h *historyBuffer) resetWithIndexAndPersist(index uint64) error {
 	h.Lock()
 	defer h.Unlock()
 	h.resetWithIndexLocked(index)
-	h.persist()
+	return h.persist()
 }
 
 func (h *historyBuffer) getNextIndex() uint64 {
@@ -353,13 +357,26 @@ func (h *historyBuffer) reload() {
 	log.Info("start from history index", zap.Uint64("start-index", h.firstIndex()))
 }
 
-func (h *historyBuffer) persist() {
+func (h *historyBuffer) persist() error {
 	firstIndexGauge.Set(float64(h.firstIndex()))
 	lastIndexGauge.Set(float64(h.nextIndex()))
-	err := h.kv.Save(historyKey, strconv.FormatUint(h.nextIndex(), 10))
+	return h.kv.Save(historyKey, strconv.FormatUint(h.nextIndex(), 10))
+}
+
+func (h *historyBuffer) loadSynced() (synced, exists bool, err error) {
+	value, err := h.kv.Load(historySyncedKey)
 	if err != nil {
-		log.Warn("persist history index failed", zap.Uint64("persist-index", h.nextIndex()), errs.ZapError(err))
+		return false, false, err
 	}
+	if value == "" {
+		return false, false, nil
+	}
+	synced, err = strconv.ParseBool(value)
+	return synced, true, err
+}
+
+func (h *historyBuffer) saveSynced(synced bool) error {
+	return h.kv.Save(historySyncedKey, strconv.FormatBool(synced))
 }
 
 func (h *historyBuffer) growForWindowLocked(window uint64) {

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -96,7 +96,7 @@ func TestHistoryBufferRecordsAndFlushes(t *testing.T) {
 	}
 	re.Equal(6, h1.len())
 	re.Equal(uint64(6), h1.nextIndex())
-	h1.persist()
+	re.NoError(h1.persist())
 
 	h2 := newHistoryBufferWithConfig(100, 100, 100, kvMem)
 	re.Equal(uint64(6), h2.nextIndex())
@@ -131,7 +131,7 @@ func TestHistoryBufferPersistsNextIndexOnly(t *testing.T) {
 		h1.record(newHistoryBufferTestRegion(uint64(i)))
 	}
 	re.Equal(3, h1.len())
-	h1.persist()
+	re.NoError(h1.persist())
 
 	h2 := newHistoryBufferWithConfig(4, 8, 1, kvMem)
 	re.Equal(uint64(3), h2.nextIndex())

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -164,9 +164,22 @@ type RegionSyncer struct {
 	history     *historyBuffer
 	limit       *ratelimit.RateLimiter
 	sendTimeout time.Duration
-	tlsConfig   *grpcutil.TLSConfig
+	// fullSyncProgressTimeout bounds a full-sync stream that stops making
+	// durable progress. Tests shorten it to exercise the recovery path.
+	fullSyncProgressTimeout time.Duration
+	tlsConfig               *grpcutil.TLSConfig
 	// status when as client
 	streamingRunning atomic.Bool
+	// historySynced is a durable, sticky signal that this member has completed
+	// at least one region history synchronization.
+	historySynced atomic.Bool
+	// initialFollowerSyncCompleted is set only after volatile Region state has
+	// been rebuilt successfully following this process start.
+	initialFollowerSyncCompleted atomic.Bool
+	// initialRegionLoadCompleted is set after persisted Region metadata has
+	// been loaded into the in-memory cache for this process.
+	initialRegionLoadCompleted atomic.Bool
+	regionLoadMu               syncutil.Mutex
 }
 
 // NewRegionSyncer returns a region syncer that ensures final consistency through the heartbeat,
@@ -178,14 +191,42 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 	}
 	historyBufferMaxSize := historyBufferMaxSizeFromMemory(memory.GetMemTotalIgnoreErr())
 	syncer := &RegionSyncer{
-		server:      s,
-		history:     newHistoryBuffer(defaultHistoryBufferSize, historyBufferMaxSize, regionStorage.(kv.Base)),
-		limit:       ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
-		sendTimeout: syncerKeepAliveInterval,
-		tlsConfig:   s.GetTLSConfig(),
+		server:                  s,
+		history:                 newHistoryBuffer(defaultHistoryBufferSize, historyBufferMaxSize, regionStorage.(kv.Base)),
+		limit:                   ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
+		sendTimeout:             syncerKeepAliveInterval,
+		fullSyncProgressTimeout: fullSyncProgressTimeout,
+		tlsConfig:               s.GetTLSConfig(),
 	}
 	syncer.mu.streams = make(map[string]*regionSyncStream)
+	syncer.reloadHistorySynced()
 	return syncer
+}
+
+func (s *RegionSyncer) reloadHistorySynced() {
+	synced, exists, err := s.history.loadSynced()
+	if err != nil {
+		log.Warn("load region sync completion marker failed", errs.ZapError(err))
+		return
+	}
+	// Before the completion marker existed, a persisted non-zero history
+	// index was only reachable after a follower had completed its first full
+	// sync and then received live updates. Preserve that upgrade path.
+	if !exists && s.history.getNextIndex() > 0 {
+		if err := s.history.saveSynced(true); err != nil {
+			log.Warn("persist migrated region sync completion marker failed", errs.ZapError(err))
+		} else {
+			synced = true
+		}
+	} else if !exists {
+		// Persist the negative state before any historical records can advance
+		// historyIndex. After a crash, a partial catch-up must not look like a
+		// completed sync to the upgrade compatibility fallback above.
+		if err := s.history.saveSynced(false); err != nil {
+			log.Warn("persist initial region sync completion marker failed", errs.ZapError(err))
+		}
+	}
+	s.historySynced.Store(synced)
 }
 
 func historyBufferMaxSizeFromMemory(totalMemory uint64) int {
@@ -440,7 +481,15 @@ func (s *RegionSyncer) syncHistoryRegionLocked(
 		zap.Uint64("from-index", startIndex),
 		zap.Uint64("last-index", endIndex),
 		zap.Int("records-length", len(records)))
-	return s.syncHistoryRecordsLocked(startIndex, records, syncStream)
+	if err := s.syncHistoryRecordsLocked(startIndex, records, syncStream); err != nil {
+		return err
+	}
+	// Explicitly delimit the historical catch-up so the follower can mark the
+	// synchronization as complete after applying this marker durably.
+	return syncStream.sendStreamIfOpen(&pdpb.SyncRegionResponse{
+		Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+		StartIndex: endIndex,
+	})
 }
 
 func buildSyncRegionResponse(startIndex uint64, records []*core.RegionInfo) *pdpb.SyncRegionResponse {
@@ -498,6 +547,17 @@ func (s *RegionSyncer) syncFullRegionsLocked(ctx context.Context, name string, s
 	stats := make([]*pdpb.RegionStat, 0, maxSyncRegionBatchSize)
 	leaders := make([]*metapb.Peer, 0, maxSyncRegionBatchSize)
 	buckets := make([]*metapb.Buckets, 0, maxSyncRegionBatchSize)
+	if len(regions) == 0 {
+		// An empty full snapshot needs an explicit frame before the completion
+		// response. Otherwise, a follower cannot distinguish it from an
+		// incremental catch-up that has no records and may retain stale Regions.
+		if err := syncStream.sendStreamIfOpen(&pdpb.SyncRegionResponse{
+			Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+			StartIndex: 0,
+		}); err != nil {
+			return err
+		}
+	}
 	for syncedIndex, r := range regions {
 		select {
 		case <-ctx.Done():

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -112,29 +112,6 @@ func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	re.Len(responses[0].GetRegions(), maxSyncRegionBatchSize)
 }
 
-func TestSyncHistoryRegionEndsWithCompletionMarker(t *testing.T) {
-	re := require.New(t)
-	syncer, _ := newTestRegionSyncer(t)
-	syncer.history.resetWithIndex(10)
-	syncer.history.record(newHistoryBufferTestRegion(1))
-	stream := newMockSyncRegionsServer()
-	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
-	syncStream := newRegionSyncStream(stream, 11)
-
-	re.NoError(syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
-		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
-		Member:     &pdpb.Member{Name: "pd-follower", ClientUrls: []string{"http://127.0.0.1:2379"}},
-		StartIndex: 10,
-	}, syncStream, 11))
-
-	history := <-stream.sendCh
-	re.Equal(uint64(10), history.GetStartIndex())
-	re.Len(history.GetRegions(), 1)
-	completion := <-stream.sendCh
-	re.Equal(uint64(11), completion.GetStartIndex())
-	re.Empty(completion.GetRegions())
-}
-
 func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	re := require.New(t)
 	syncer, _ := newTestRegionSyncer(t, newHistoryBufferTestRegion(1))
@@ -1479,13 +1456,13 @@ func newTestSyncRegion(regionID, peerID uint64) *core.RegionInfo {
 }
 
 func newTestSyncRegionWithRange(regionID, peerID uint64) *core.RegionInfo {
-	return core.NewRegionInfo(&metapb.Region{
-		Id:          regionID,
-		StartKey:    []byte{byte(regionID >> 8), byte(regionID)},
-		EndKey:      []byte{byte((regionID + 1) >> 8), byte(regionID + 1)},
-		RegionEpoch: &metapb.RegionEpoch{ConfVer: 1, Version: 1},
-		Peers:       []*metapb.Peer{{Id: peerID, StoreId: 1}},
-	}, &metapb.Peer{Id: peerID, StoreId: 1})
+	return core.NewTestRegionInfo(
+		regionID,
+		1,
+		[]byte{byte(regionID >> 8), byte(regionID)},
+		[]byte{byte((regionID + 1) >> 8), byte(regionID + 1)},
+		core.WithNewPeerIDs(peerID),
+	)
 }
 
 func startTestRegionSync(ctx context.Context, syncer *RegionSyncer, stream *mockSyncRegionsServer) chan error {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -112,6 +112,29 @@ func TestSyncHistoryRecordsSplitBatches(t *testing.T) {
 	re.Len(responses[0].GetRegions(), maxSyncRegionBatchSize)
 }
 
+func TestSyncHistoryRegionEndsWithCompletionMarker(t *testing.T) {
+	re := require.New(t)
+	syncer, _ := newTestRegionSyncer(t)
+	syncer.history.resetWithIndex(10)
+	syncer.history.record(newHistoryBufferTestRegion(1))
+	stream := newMockSyncRegionsServer()
+	stream.sendCh = make(chan *pdpb.SyncRegionResponse, 2)
+	syncStream := newRegionSyncStream(stream, 11)
+
+	re.NoError(syncer.syncHistoryRegion(context.Background(), &pdpb.SyncRegionRequest{
+		Header:     &pdpb.RequestHeader{ClusterId: keypath.ClusterID()},
+		Member:     &pdpb.Member{Name: "pd-follower", ClientUrls: []string{"http://127.0.0.1:2379"}},
+		StartIndex: 10,
+	}, syncStream, 11))
+
+	history := <-stream.sendCh
+	re.Equal(uint64(10), history.GetStartIndex())
+	re.Len(history.GetRegions(), 1)
+	completion := <-stream.sendCh
+	re.Equal(uint64(11), completion.GetStartIndex())
+	re.Empty(completion.GetRegions())
+}
+
 func TestSyncFullRegionsBuffersLiveRecords(t *testing.T) {
 	re := require.New(t)
 	syncer, _ := newTestRegionSyncer(t, newHistoryBufferTestRegion(1))
@@ -984,8 +1007,12 @@ func TestSyncHistoryRegionStopsAtSyncStartIndex(t *testing.T) {
 	err := syncer.syncHistoryRegion(context.Background(), request, syncStream, syncStartIndex)
 
 	re.NoError(err)
-	re.Equal(uint64(10), stream.lastResponse().GetStartIndex())
-	re.Equal([]*metapb.Region{{Id: 1}}, stream.lastResponse().GetRegions())
+	responses := stream.sentResponses()
+	re.Len(responses, 2)
+	re.Equal(uint64(10), responses[0].GetStartIndex())
+	re.Equal([]*metapb.Region{{Id: 1}}, responses[0].GetRegions())
+	re.Equal(syncStartIndex, responses[1].GetStartIndex())
+	re.Empty(responses[1].GetRegions())
 }
 
 type testServerStream struct {
@@ -1279,6 +1306,9 @@ func TestClientWaitsForEmptySnapshotCatchUpCompletion(t *testing.T) {
 	syncStream := newRegionSyncStream(stream, syncStartIndex)
 
 	re.NoError(syncFullRegionsForTest(context.Background(), leaderSyncer, syncStream, syncStartIndex))
+	marker := mustRecvSyncRegionResponse(t, stream, "expected empty full sync marker")
+	re.Zero(marker.GetStartIndex())
+	re.Empty(marker.GetRegions())
 	first := mustRecvSyncRegionResponse(t, stream, "expected first catch-up response")
 	re.Equal(uint64(0), first.GetStartIndex())
 	re.Len(first.GetRegions(), maxSyncRegionBatchSize)
@@ -1301,7 +1331,12 @@ func TestClientWaitsForEmptySnapshotCatchUpCompletion(t *testing.T) {
 	clientSyncer.history.resetWithIndex(syncStartIndex)
 	bc := core.NewBasicCluster()
 
-	handled, fullSyncing := clientSyncer.handleRegionSyncResponse(context.Background(), first, bc, regionStorage, false)
+	handled, fullSyncing := clientSyncer.handleRegionSyncResponse(context.Background(), marker, bc, regionStorage, false)
+	re.True(handled)
+	re.True(fullSyncing)
+	re.False(clientSyncer.IsRunning())
+
+	handled, fullSyncing = clientSyncer.handleRegionSyncResponse(context.Background(), first, bc, regionStorage, fullSyncing)
 	re.True(handled)
 	re.True(fullSyncing)
 	re.False(clientSyncer.IsRunning())
@@ -1316,6 +1351,98 @@ func TestClientWaitsForEmptySnapshotCatchUpCompletion(t *testing.T) {
 	re.False(fullSyncing)
 	re.True(clientSyncer.IsRunning())
 	re.Equal(syncStartIndex+uint64(maxSyncRegionBatchSize)+1, clientSyncer.history.getNextIndex())
+}
+
+func TestEmptyFullSyncSendsSnapshotMarkerBeforeCompletion(t *testing.T) {
+	re := require.New(t)
+	leaderSyncer, _ := newTestRegionSyncer(t)
+	syncStartIndex := uint64(42)
+	leaderSyncer.history.resetWithIndex(syncStartIndex)
+	stream := newMockSyncRegionsServer()
+	syncStream := newRegionSyncStream(stream, syncStartIndex)
+
+	re.NoError(syncFullRegionsForTest(context.Background(), leaderSyncer, syncStream, syncStartIndex))
+	marker := mustRecvSyncRegionResponse(t, stream, "expected empty full sync marker")
+	re.Zero(marker.GetStartIndex())
+	re.Empty(marker.GetRegions())
+	completion := mustRecvSyncRegionResponse(t, stream, "expected empty full sync completion response")
+	re.Equal(syncStartIndex, completion.GetStartIndex())
+	re.Empty(completion.GetRegions())
+}
+
+func TestClientWaitsForEmptySnapshotCompletionAndClearsStaleState(t *testing.T) {
+	syncStartIndex := uint64(42)
+	testCases := []struct {
+		name    string
+		prepare func(*RegionSyncer) error
+	}{
+		{
+			name: "synced follower with non-zero history index",
+			prepare: func(syncer *RegionSyncer) error {
+				syncer.history.resetWithIndex(syncStartIndex)
+				return syncer.MarkHistorySynced()
+			},
+		},
+		{
+			name: "synced follower with zero history index",
+			prepare: func(syncer *RegionSyncer) error {
+				syncer.history.resetWithIndex(0)
+				if err := syncer.MarkHistorySynced(); err != nil {
+					return err
+				}
+				syncer.initialFollowerSyncCompleted.Store(true)
+				return nil
+			},
+		},
+		{
+			name: "restarted follower with reset history index",
+			prepare: func(syncer *RegionSyncer) error {
+				return syncer.MarkHistoryIncomplete()
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			regionStorage := storage.NewStorageWithMemoryBackend()
+			server := mockserver.NewMockServer(
+				context.Background(),
+				nil,
+				nil,
+				regionStorage,
+				core.NewBasicCluster(),
+			)
+			clientSyncer := NewRegionSyncer(server)
+			bc := core.NewBasicCluster()
+			staleRegion := newTestSyncRegion(1, 11)
+			bc.PutRegion(staleRegion)
+			re.NoError(regionStorage.SaveRegion(staleRegion.GetMeta()))
+			re.NoError(testCase.prepare(clientSyncer))
+
+			handled, fullSyncing := clientSyncer.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+				Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+				StartIndex: 0,
+			}, bc, regionStorage, false)
+			re.True(handled)
+			re.True(fullSyncing)
+			re.False(clientSyncer.IsRunning())
+			re.Zero(clientSyncer.history.getNextIndex())
+			re.Zero(bc.GetTotalRegionCount())
+			stored := &metapb.Region{}
+			ok, err := regionStorage.LoadRegion(staleRegion.GetID(), stored)
+			re.NoError(err)
+			re.False(ok)
+
+			handled, fullSyncing = clientSyncer.handleRegionSyncResponse(context.Background(), &pdpb.SyncRegionResponse{
+				Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
+				StartIndex: syncStartIndex,
+			}, bc, regionStorage, fullSyncing)
+			re.True(handled)
+			re.False(fullSyncing)
+			re.True(clientSyncer.IsRunning())
+			re.Equal(syncStartIndex, clientSyncer.history.getNextIndex())
+		})
+	}
 }
 
 func newTestRegionSyncer(t *testing.T, regions ...*core.RegionInfo) (*RegionSyncer, *core.BasicCluster) {

--- a/server/server.go
+++ b/server/server.go
@@ -827,13 +827,19 @@ func (s *Server) bootstrapCluster(req *pdpb.BootstrapRequest) (*pdpb.BootstrapRe
 	}
 
 	log.Info("bootstrap cluster ok", zap.Uint64("cluster-id", clusterID))
-	err = s.storage.SaveRegion(req.GetRegion())
-	if err != nil {
+	regionStorageReady := true
+	if err = s.storage.SaveRegion(req.GetRegion()); err != nil {
+		regionStorageReady = false
 		log.Warn("save the bootstrap region failed", errs.ZapError(err))
 	}
-	err = s.storage.Flush()
-	if err != nil {
+	if err = s.storage.Flush(); err != nil {
+		regionStorageReady = false
 		log.Warn("flush the bootstrap region failed", errs.ZapError(err))
+	}
+	if regionStorageReady && s.persistOptions.IsUseRegionStorage() {
+		if err = s.cluster.GetRegionSyncer().MarkHistorySynced(); err != nil {
+			log.Warn("mark bootstrap region sync complete failed", errs.ZapError(err))
+		}
 	}
 
 	if err := s.cluster.Start(s, true); err != nil {
@@ -965,16 +971,20 @@ func (s *Server) ResetFollowerRegionCache(regionIDs ...uint64) error {
 	}
 
 	syncer := s.cluster.GetRegionSyncer()
-	syncer.StopSyncWithLeader()
-	// Keep the follower connected even when the reset returns an error.
+	// StopSyncWithLeader cancels the active stream before resetting the local
+	// completion marker. Restart it even if the reset returns an error.
 	defer syncer.StartSyncWithLeader(leaderURLs[0])
+	syncer.StopSyncWithLeader()
+	if err := syncer.MarkHistoryIncomplete(); err != nil {
+		return errors.Wrap(err, "clear follower region sync state")
+	}
 
 	var resetErr error
 	if err := s.storage.Flush(); err != nil {
 		resetErr = errors.Wrap(err, "flush follower region storage")
 	}
 	if len(regionIDs) == 0 {
-		if err := s.deleteFollowerRegionStorage(); resetErr == nil && err != nil {
+		if err := storage.ClearRegionStorage(s.ctx, s.storage); resetErr == nil && err != nil {
 			resetErr = err
 		}
 		s.basicCluster.ResetRegionCache()
@@ -988,10 +998,6 @@ func (s *Server) ResetFollowerRegionCache(regionIDs ...uint64) error {
 	if err := s.storage.Flush(); err != nil && resetErr == nil {
 		resetErr = errors.Wrap(err, "flush follower region storage")
 	}
-	// Force a full sync after the local reset attempt so the follower can
-	// rebuild any cache entries that were removed before an error happened.
-	syncer.ResetHistoryIndex(0)
-
 	log.Info("reset follower region cache and restart region syncer",
 		zap.String("server", s.Name()),
 		zap.String("leader", leader.GetName()),
@@ -1020,58 +1026,6 @@ func (s *Server) deleteFollowerRegion(regionID uint64) error {
 	return nil
 }
 
-func (s *Server) deleteFollowerRegionStorage() error {
-	regionStorage := storage.RetrieveRegionStorage(s.storage)
-	regionKV, ok := regionStorage.(kv.Base)
-	if !ok {
-		return errors.New("region storage does not support range scan")
-	}
-
-	startID := uint64(0)
-	endKey := keypath.RegionPath(math.MaxUint64)
-	for {
-		select {
-		case <-s.ctx.Done():
-			return s.ctx.Err()
-		default:
-		}
-
-		keys, _, err := regionKV.LoadRange(keypath.RegionPath(startID), endKey, endpoint.MaxKVRangeLimit)
-		if err != nil {
-			return errors.Wrap(err, "load follower regions from local storage")
-		}
-		var lastRegionID uint64
-		for _, key := range keys {
-			regionID, err := parseRegionIDFromStorageKey(key)
-			if err != nil {
-				return err
-			}
-			lastRegionID = regionID
-		}
-		if err := deleteFollowerRegionStorageKeys(s.ctx, regionKV, keys); err != nil {
-			return errors.Wrap(err, "delete follower regions from local storage")
-		}
-		if len(keys) < endpoint.MaxKVRangeLimit {
-			return nil
-		}
-		if lastRegionID == math.MaxUint64 {
-			return nil
-		}
-		startID = lastRegionID + 1
-	}
-}
-
-func deleteFollowerRegionStorageKeys(ctx context.Context, regionKV kv.Base, keys []string) error {
-	return regionKV.RunInTxn(ctx, func(txn kv.Txn) error {
-		for _, key := range keys {
-			if err := txn.Remove(key); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-}
-
 func (s *Server) deleteFollowerRegionMeta(region *metapb.Region) error {
 	if err := s.storage.DeleteRegion(region); err != nil {
 		log.Warn("failed to delete follower region from local storage",
@@ -1081,18 +1035,6 @@ func (s *Server) deleteFollowerRegionMeta(region *metapb.Region) error {
 		return errors.Wrap(err, "delete follower region from local storage")
 	}
 	return nil
-}
-
-func parseRegionIDFromStorageKey(key string) (uint64, error) {
-	idx := strings.LastIndexByte(key, '/')
-	if idx < 0 || idx == len(key)-1 {
-		return 0, errors.Errorf("invalid region storage key %q", key)
-	}
-	regionID, err := strconv.ParseUint(key[idx+1:], 10, 64)
-	if err != nil {
-		return 0, errors.Wrap(err, "parse region storage key")
-	}
-	return regionID, nil
 }
 
 // GetPersistOptions returns the schedule option.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,17 +17,25 @@ package server
 import (
 	"context"
 	stderrors "errors"
+	"net"
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/member"
 	"github.com/tikv/pd/pkg/storage"
-	"github.com/tikv/pd/pkg/storage/kv"
+	"github.com/tikv/pd/pkg/syncer"
 	"github.com/tikv/pd/pkg/utils/keypath"
+	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/server/cluster"
 	"github.com/tikv/pd/server/config"
 )
 
@@ -46,6 +54,74 @@ func TestResetFollowerRegionCacheRequiresRegionStorage(t *testing.T) {
 	s.persistOptions = config.NewPersistOptions(cfg)
 	s.member = member.NewMember(nil, nil, 1)
 	re.Error(s.ResetFollowerRegionCache())
+}
+
+func TestResetFollowerRegionCacheRestartsSyncAfterError(t *testing.T) {
+	re := require.New(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	re.NoError(err)
+	grpcServer := grpc.NewServer()
+	pdpb.RegisterPDServer(grpcServer, &testFollowerRegionSyncServer{})
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- grpcServer.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		err := <-serveDone
+		if err != nil {
+			re.ErrorIs(err, grpc.ErrServerStopped)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cfg := config.NewConfig()
+	cfg.Name = "pd-follower"
+	cfg.PDServerCfg.UseRegionStorage = true
+	testStorage := &testFollowerRegionStorage{
+		Storage: storage.NewStorageWithMemoryBackend(),
+	}
+	member := member.NewMember(nil, nil, 2)
+	leaderURL := "http://" + listener.Addr().String()
+	member.InitMemberInfo(leaderURL, leaderURL, cfg.Name)
+	member.PromoteSelf()
+	basicCluster := core.NewBasicCluster()
+	server := &Server{
+		ctx:            ctx,
+		serverLoopCtx:  ctx,
+		cfg:            cfg,
+		persistOptions: config.NewPersistOptions(cfg),
+		storage:        testStorage,
+		basicCluster:   basicCluster,
+		member:         member,
+	}
+	regionSyncer := syncer.NewRegionSyncer(server)
+	re.NotNil(regionSyncer)
+	server.cluster = cluster.NewRaftCluster(
+		ctx,
+		member,
+		basicCluster,
+		testStorage,
+		regionSyncer,
+		nil,
+		http.DefaultClient,
+		nil,
+	)
+	re.NoError(regionSyncer.MarkHistorySynced())
+	regionSyncer.StartSyncWithLeader(leaderURL)
+	t.Cleanup(func() {
+		regionSyncer.StopSyncWithLeader()
+	})
+	testutil.Eventually(re, regionSyncer.IsRunning,
+		testutil.WithWaitFor(3*time.Second),
+		testutil.WithTickInterval(20*time.Millisecond))
+
+	testStorage.failNextRegionScan()
+	re.ErrorContains(server.ResetFollowerRegionCache(), "load regions from local storage")
+	testutil.Eventually(re, regionSyncer.IsRunning,
+		testutil.WithWaitFor(3*time.Second),
+		testutil.WithTickInterval(20*time.Millisecond))
 }
 
 func TestDeleteFollowerRegion(t *testing.T) {
@@ -125,161 +201,6 @@ func TestDeleteFollowerRegion(t *testing.T) {
 	}
 }
 
-func TestDeleteFollowerRegionStorage(t *testing.T) {
-	tests := []struct {
-		name        string
-		ctx         context.Context
-		setup       func(*require.Assertions, *Server) func(*require.Assertions, *Server)
-		errIs       error
-		errContains string
-	}{
-		{
-			name: "deletes all region storage keys",
-			setup: func(re *require.Assertions, s *Server) func(*require.Assertions, *Server) {
-				regions := []*metapb.Region{
-					newTestFollowerRegionMeta(10),
-					newTestFollowerRegionMeta(11),
-				}
-				for _, region := range regions {
-					re.NoError(s.storage.SaveRegion(region))
-				}
-				return func(re *require.Assertions, s *Server) {
-					for _, region := range regions {
-						assertTestFollowerRegionDeleted(re, s, region.GetId())
-					}
-				}
-			},
-		},
-		{
-			name: "deletes by key without loading region meta",
-			setup: func(re *require.Assertions, s *Server) func(*require.Assertions, *Server) {
-				region := newTestFollowerRegionMeta(12)
-				re.NoError(s.storage.SaveRegion(region))
-				regionStorage := s.storage
-				s.storage = &testFollowerRegionStorage{
-					Storage:       regionStorage,
-					loadRegionErr: errTestFollowerRegionStorage,
-				}
-				return func(re *require.Assertions, s *Server) {
-					s.storage = regionStorage
-					assertTestFollowerRegionDeleted(re, s, region.GetId())
-				}
-			},
-		},
-		{
-			name: "context canceled",
-			ctx: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				return ctx
-			}(),
-			errIs: context.Canceled,
-		},
-		{
-			name: "load range error",
-			setup: func(_ *require.Assertions, s *Server) func(*require.Assertions, *Server) {
-				s.storage = &testFollowerRegionStorage{
-					Storage:      s.storage,
-					loadRangeErr: errTestFollowerRegionStorage,
-				}
-				return nil
-			},
-			errContains: "load follower regions from local storage",
-		},
-		{
-			name: "delete transaction error",
-			setup: func(re *require.Assertions, s *Server) func(*require.Assertions, *Server) {
-				region := newTestFollowerRegionMeta(21)
-				re.NoError(s.storage.SaveRegion(region))
-				s.storage = &testFollowerRegionStorage{
-					Storage:     s.storage,
-					runInTxnErr: errTestFollowerRegionStorage,
-				}
-				return nil
-			},
-			errContains: "delete follower regions from local storage",
-		},
-		{
-			name: "invalid region storage key",
-			setup: func(_ *require.Assertions, s *Server) func(*require.Assertions, *Server) {
-				s.storage = &testFollowerRegionStorage{
-					Storage:       s.storage,
-					loadRangeKeys: []string{"invalid-region-key"},
-				}
-				return nil
-			},
-			errContains: "invalid region storage key",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			re := require.New(t)
-			ctx := test.ctx
-			if ctx == nil {
-				ctx = context.Background()
-			}
-			s := newTestFollowerRegionResetServer(ctx)
-			var check func(*require.Assertions, *Server)
-			if test.setup != nil {
-				check = test.setup(re, s)
-			}
-
-			err := s.deleteFollowerRegionStorage()
-			switch {
-			case test.errIs != nil:
-				re.ErrorIs(err, test.errIs)
-				return
-			case test.errContains != "":
-				re.ErrorContains(err, test.errContains)
-				return
-			default:
-				re.NoError(err)
-			}
-			if check != nil {
-				check(re, s)
-			}
-		})
-	}
-}
-
-func TestParseRegionIDFromStorageKey(t *testing.T) {
-	tests := []struct {
-		name        string
-		key         string
-		regionID    uint64
-		errContains string
-	}{
-		{
-			name:     "valid region key",
-			key:      keypath.RegionPath(123),
-			regionID: 123,
-		},
-		{
-			name:        "missing region id",
-			key:         "invalid-region-key",
-			errContains: "invalid region storage key",
-		},
-		{
-			name:        "invalid region id",
-			key:         "/pd/0/raft/r/not-a-number",
-			errContains: "parse region storage key",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			re := require.New(t)
-			regionID, err := parseRegionIDFromStorageKey(test.key)
-			if test.errContains != "" {
-				re.ErrorContains(err, test.errContains)
-				return
-			}
-			re.NoError(err)
-			re.Equal(test.regionID, regionID)
-		})
-	}
-}
-
 func newTestFollowerRegionResetServer(ctx context.Context) *Server {
 	cfg := config.NewConfig()
 	return &Server{
@@ -312,19 +233,27 @@ func assertTestFollowerRegionDeleted(re *require.Assertions, s *Server, regionID
 
 type testFollowerRegionStorage struct {
 	storage.Storage
+	mu              sync.Mutex
+	failRegionScan  bool
 	loadRegionErr   error
 	deleteRegionErr error
-	loadRangeErr    error
-	runInTxnErr     error
-	loadRangeKeys   []string
 }
 
-func (s *testFollowerRegionStorage) LoadRange(key, endKey string, limit int) (keys []string, values []string, err error) {
-	if s.loadRangeErr != nil {
-		return nil, nil, s.loadRangeErr
-	}
-	if s.loadRangeKeys != nil {
-		return s.loadRangeKeys, nil, nil
+func (s *testFollowerRegionStorage) failNextRegionScan() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failRegionScan = true
+}
+
+func (s *testFollowerRegionStorage) LoadRange(
+	key, endKey string,
+	limit int,
+) (keys, values []string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failRegionScan {
+		s.failRegionScan = false
+		return nil, nil, errTestFollowerRegionStorage
 	}
 	return s.Storage.LoadRange(key, endKey, limit)
 }
@@ -343,9 +272,27 @@ func (s *testFollowerRegionStorage) DeleteRegion(region *metapb.Region) error {
 	return s.Storage.DeleteRegion(region)
 }
 
-func (s *testFollowerRegionStorage) RunInTxn(ctx context.Context, f func(txn kv.Txn) error) error {
-	if s.runInTxnErr != nil {
-		return s.runInTxnErr
+type testFollowerRegionSyncServer struct {
+	pdpb.UnimplementedPDServer
+}
+
+func (*testFollowerRegionSyncServer) SyncRegions(stream pdpb.PD_SyncRegionsServer) error {
+	if _, err := stream.Recv(); err != nil {
+		return err
 	}
-	return s.Storage.RunInTxn(ctx, f)
+	header := &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()}
+	if err := stream.Send(&pdpb.SyncRegionResponse{
+		Header:     header,
+		StartIndex: 0,
+	}); err != nil {
+		return err
+	}
+	if err := stream.Send(&pdpb.SyncRegionResponse{
+		Header:     header,
+		StartIndex: 1,
+	}); err != nil {
+		return err
+	}
+	<-stream.Context().Done()
+	return stream.Context().Err()
 }

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -285,6 +285,59 @@ func TestRegionSyncerReconnectsAfterLeaderSendFailure(t *testing.T) {
 	waitRegionSynced(re, followerServer, nextRegion)
 }
 
+func TestFollowerRestartRestoresVolatileRegionState(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/storage/levelDBStorageFastFlush", `return(true)`))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/storage/levelDBStorageFastFlush"))
+	}()
+
+	cluster, err := tests.NewTestCluster(ctx, 3, func(conf *config.Config, _ string) {
+		conf.PDServerCfg.UseRegionStorage = true
+	})
+	defer cluster.Destroy()
+	re.NoError(err)
+
+	re.NoError(cluster.RunInitialServers())
+	leaderName := cluster.WaitLeader()
+	re.NotEmpty(leaderName)
+	leaderServer := cluster.GetServer(leaderName)
+	re.NoError(leaderServer.BootstrapCluster())
+	re.True(cluster.WaitRegionSyncerClientsReady(2))
+
+	regions := tests.InitRegions(110)
+	rc := leaderServer.GetServer().GetRaftCluster()
+	for i, region := range regions {
+		regions[i] = region.Clone(
+			core.SetWrittenBytes(uint64(i+1)),
+			core.SetWrittenKeys(uint64(i+2)),
+			core.SetReadBytes(uint64(i+3)),
+			core.SetReadKeys(uint64(i+4)),
+		)
+		re.NoError(rc.HandleRegionHeartbeat(regions[i]))
+	}
+
+	followerName := cluster.GetFollower()
+	re.NotEmpty(followerName)
+	followerServer := cluster.GetServer(followerName)
+	waitRegionSynced(re, followerServer, regions[0])
+	waitRegionSynced(re, followerServer, regions[len(regions)-1])
+
+	re.NoError(followerServer.Stop())
+	re.Equal(leaderName, cluster.WaitLeader())
+	re.NoError(followerServer.Run())
+	re.Equal(leaderName, cluster.WaitLeader())
+	testutil.Eventually(re, func() bool {
+		syncer := followerServer.GetServer().DirectlyGetRaftCluster().GetRegionSyncer()
+		return syncer != nil && syncer.IsRunning()
+	})
+
+	waitRegionSynced(re, followerServer, regions[0])
+	waitRegionSynced(re, followerServer, regions[len(regions)-1])
+}
+
 func waitRegionSynced(re *require.Assertions, followerServer *tests.TestServer, region *core.RegionInfo) {
 	testutil.Eventually(re, func() bool {
 		r := followerServer.GetServer().GetBasicCluster().GetRegion(region.GetID())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10719

A RegionSync full snapshot was applied as incremental Region updates instead of an authoritative replacement. Regions absent from the leader snapshot could remain in follower storage, and an empty snapshot could leave the entire old cache intact.

An interrupted full sync also lacked a durable completion state. After EOF, timeout, storage failure, or restart, a follower could retain partial Region data without a reliable signal that it must restart full sync from the beginning.

### What is changed and how does it work?

```commit-message
Persist whether a PD member has completed Region synchronization and mark it incomplete before replacing local Region state.

Treat a full snapshot as an authoritative replacement, including empty snapshots. Clear follower Region storage and cache before applying the snapshot, then persist the history index and completion marker only after the snapshot and catch-up records are durable.

On EOF, stalled progress, storage failure, or persistence failure, keep the follower incomplete, reconnect to the leader, and request a new full snapshot from index zero.

Reload persisted Regions during process startup and keep retrying when the initial load fails. Preserve compatibility with legacy members that have a valid non-zero persisted history index.
```

This PR intentionally does not change PD leader eligibility or add a cluster-wide full-sync owner. Leader eligibility remains tracked separately by #10843.

### Check List

Tests

- Unit test
- Integration test
- Manual test

Manual test:

- Verified initial sync, history-gap recovery, and authoritative empty snapshots.
- Verified recovery from EOF, stream timeout, storage write/load failure, follower reset, and restart.
- Verified a follower remains incomplete after an interrupted full sync and requests a new snapshot from index zero.
- Verified cold restart recovery with 1,000,000 Regions and matching checksums on all three PD members.

Code changes

- Has persistent data change

Side effects

- Increased code complexity

### Release note

```release-note
Prevent PD followers from serving incomplete Region data after an interrupted full synchronization and retry recovery safely.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved region synchronization stability across restarts, reconnects, and cache reset errors.
  * Full synchronization now includes a progress watchdog and automatically retries after stalled or failed sync states.
  * Synchronization stays blocked until sync completion is durably recorded, ensuring consistent startup after failures.
* **Bug Fixes**
  * Region reset now clears only region metadata while preserving unrelated persisted data.
  * Correct handling of empty snapshots and historical sync completion to prevent followers from misinterpreting sync state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->