### PR TITLE
server: return unavailable when PD is not serving

### DIFF
--- a/pkg/mcs/tso/server/grpc_service.go
+++ b/pkg/mcs/tso/server/grpc_service.go
@@ -136,6 +136,9 @@ func (s *Service) Tso(stream tsopb.TSO_TsoServer) error {
 func (s *Service) FindGroupByKeyspaceID(
 	_ context.Context, request *tsopb.FindGroupByKeyspaceIDRequest,
 ) (*tsopb.FindGroupByKeyspaceIDResponse, error) {
+	if s.IsClosed() {
+		return nil, errs.ErrNotStarted
+	}
 	respKeyspaceGroup := request.GetHeader().GetKeyspaceGroupId()
 	if errorType, err := s.validRequest(request.GetHeader()); err != nil {
 		return &tsopb.FindGroupByKeyspaceIDResponse{
@@ -198,6 +201,9 @@ func (s *Service) FindGroupByKeyspaceID(
 func (s *Service) GetMinTS(
 	_ context.Context, request *tsopb.GetMinTSRequest,
 ) (*tsopb.GetMinTSResponse, error) {
+	if s.IsClosed() {
+		return nil, errs.ErrNotStarted
+	}
 	respKeyspaceGroup := request.GetHeader().GetKeyspaceGroupId()
 	if errorType, err := s.validRequest(request.GetHeader()); err != nil {
 		return &tsopb.GetMinTSResponse{
@@ -225,7 +231,7 @@ func (s *Service) GetMinTS(
 }
 
 func (s *Service) validRequest(header *tsopb.RequestHeader) (tsopb.ErrorType, error) {
-	if s.IsClosed() || s.keyspaceGroupManager == nil {
+	if s.keyspaceGroupManager == nil {
 		return tsopb.ErrorType_NOT_BOOTSTRAPPED, errs.ErrNotStarted
 	}
 	if header == nil || header.GetClusterId() != keypath.ClusterID() {

--- a/pkg/mcs/tso/server/grpc_service_test.go
+++ b/pkg/mcs/tso/server/grpc_service_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/pingcap/kvproto/pkg/tsopb"
+)
+
+func TestUnaryRPCsReturnUnavailableWhenServerIsNotRunning(t *testing.T) {
+	service := &Service{Server: &Server{}}
+	listener := bufconn.Listen(1024 * 1024)
+	transport := grpc.NewServer()
+	tsopb.RegisterTSOServer(transport, service)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- transport.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		transport.Stop()
+		require.NoError(t, <-serveErr)
+	})
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return listener.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := tsopb.NewTSOClient(conn)
+
+	group, err := client.FindGroupByKeyspaceID(context.Background(), &tsopb.FindGroupByKeyspaceIDRequest{})
+	require.Nil(t, group)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	minTS, err := client.GetMinTS(context.Background(), &tsopb.GetMinTSRequest{})
+	require.Nil(t, minTS)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -249,9 +249,7 @@ func (s *GrpcServer) GetClusterInfo(context.Context, *pdpb.GetClusterInfoRequest
 	// Here we purposely do not check the cluster ID because the client does not know the correct cluster ID
 	// at startup and needs to get the cluster ID with the first request (i.e. GetMembers).
 	if s.IsClosed() {
-		return &pdpb.GetClusterInfoResponse{
-			Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, errs.ErrServerNotStarted.FastGenByArgs().Error()),
-		}, nil
+		return nil, errs.ErrNotStarted
 	}
 
 	var tsoServiceAddrs []string
@@ -428,6 +426,11 @@ func (s *GrpcServer) getMinTSFromSingleServer(
 
 // GetMembers implements gRPC PDServer.
 func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb.GetMembersResponse, error) {
+	// Here we purposely do not check the cluster ID because the client does not know the correct cluster ID
+	// at startup and needs to get the cluster ID with the first request (i.e. GetMembers).
+	if s.IsClosed() {
+		return nil, errs.ErrNotStarted
+	}
 	done, err := s.rateLimitCheck()
 	if err != nil {
 		return nil, err
@@ -435,18 +438,9 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	if done != nil {
 		defer done()
 	}
-	// Here we purposely do not check the cluster ID because the client does not know the correct cluster ID
-	// at startup and needs to get the cluster ID with the first request (i.e. GetMembers).
-	if s.IsClosed() {
-		return &pdpb.GetMembersResponse{
-			Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, errs.ErrServerNotStarted.FastGenByArgs().Error()),
-		}, nil
-	}
 	members, err := s.Server.GetMembers()
 	if err != nil {
-		return &pdpb.GetMembersResponse{
-			Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
-		}, nil
+		return getMembersErrorResult(err)
 	}
 
 	var etcdLeader, pdLeader *pdpb.Member
@@ -456,9 +450,7 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 	if (pdLeader == nil && leader != nil) || (etcdLeader == nil && leaderID != 0) {
 		members, err = s.ReloadMembers()
 		if err != nil {
-			return &pdpb.GetMembersResponse{
-				Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
-			}, nil
+			return getMembersErrorResult(err)
 		}
 		leaderID = s.member.GetEtcdLeader()
 		leader = s.member.GetLeader()
@@ -470,6 +462,17 @@ func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb
 		Members:    members,
 		Leader:     pdLeader,
 		EtcdLeader: etcdLeader,
+	}, nil
+}
+
+func getMembersErrorResult(err error) (*pdpb.GetMembersResponse, error) {
+	if errors.ErrorEqual(err, errs.ErrServerNotStarted.FastGenByArgs()) {
+		return nil, errs.ErrNotStarted
+	}
+	// Keep other server-side failures in the response header so clients don't
+	// mistake them for service or transport availability failures.
+	return &pdpb.GetMembersResponse{
+		Header: grpcutil.WrapErrorToHeader(pdpb.ErrorType_UNKNOWN, err.Error()),
 	}, nil
 }
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -426,17 +426,17 @@ func (s *GrpcServer) getMinTSFromSingleServer(
 
 // GetMembers implements gRPC PDServer.
 func (s *GrpcServer) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb.GetMembersResponse, error) {
-	// Here we purposely do not check the cluster ID because the client does not know the correct cluster ID
-	// at startup and needs to get the cluster ID with the first request (i.e. GetMembers).
-	if s.IsClosed() {
-		return nil, errs.ErrNotStarted
-	}
 	done, err := s.rateLimitCheck()
 	if err != nil {
 		return nil, err
 	}
 	if done != nil {
 		defer done()
+	}
+	// Here we purposely do not check the cluster ID because the client does not know the correct cluster ID
+	// at startup and needs to get the cluster ID with the first request (i.e. GetMembers).
+	if s.IsClosed() {
+		return nil, errs.ErrNotStarted
 	}
 	members, err := s.Server.GetMembers()
 	if err != nil {

--- a/server/grpc_service_test.go
+++ b/server/grpc_service_test.go
@@ -15,15 +15,24 @@
 package server
 
 import (
+	"context"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/schedulingpb"
 
+	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
@@ -93,4 +102,48 @@ func TestConvertSchedulingHeaderPreservesError(t *testing.T) {
 			re.Equal(testCase.want, header.GetError())
 		})
 	}
+}
+
+func TestServiceDiscoveryRPCsReturnUnavailableWhenServerIsNotRunning(t *testing.T) {
+	grpcServer := &GrpcServer{Server: &Server{}}
+	listener := bufconn.Listen(1024 * 1024)
+	transport := grpc.NewServer()
+	pdpb.RegisterPDServer(transport, grpcServer)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- transport.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		transport.Stop()
+		require.NoError(t, <-serveErr)
+	})
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return listener.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := pdpb.NewPDClient(conn)
+
+	members, err := client.GetMembers(context.Background(), &pdpb.GetMembersRequest{})
+	require.Nil(t, members)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	clusterInfo, err := client.GetClusterInfo(context.Background(), &pdpb.GetClusterInfoRequest{})
+	require.Nil(t, clusterInfo)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestGetMembersErrorResult(t *testing.T) {
+	notStarted := errors.WithStack(errs.ErrServerNotStarted.FastGenByArgs())
+	response, err := getMembersErrorResult(notStarted)
+	require.Nil(t, response)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	internalErr := errors.New("failed to load members")
+	response, err = getMembersErrorResult(internalErr)
+	require.NoError(t, err)
+	require.Equal(t, pdpb.ErrorType_UNKNOWN, response.GetHeader().GetError().GetType())
+	require.Equal(t, internalErr.Error(), response.GetHeader().GetError().GetMessage())
 }

--- a/server/grpc_service_test.go
+++ b/server/grpc_service_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/server/config"
 )
 
 func TestMain(m *testing.M) {
@@ -105,7 +106,9 @@ func TestConvertSchedulingHeaderPreservesError(t *testing.T) {
 }
 
 func TestServiceDiscoveryRPCsReturnUnavailableWhenServerIsNotRunning(t *testing.T) {
-	grpcServer := &GrpcServer{Server: &Server{}}
+	grpcServer := &GrpcServer{Server: &Server{
+		serviceMiddlewarePersistOptions: config.NewServiceMiddlewarePersistOptions(&config.ServiceMiddlewareConfig{}),
+	}}
 	listener := bufconn.Listen(1024 * 1024)
 	transport := grpc.NewServer()
 	pdpb.RegisterPDServer(transport, grpcServer)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11020

`GetMembers` and `GetClusterInfo` returned a successful gRPC response with an
`ErrorType_UNKNOWN` header when the local PD server was not running. During a
graceful shutdown, this made a transient service-availability condition look
like an unclassified application error while the gRPC connection was still
`READY`.

### What is changed and how does it work?

Return the existing gRPC `Unavailable` error for these service-discovery RPCs
when the local PD server is not running. Also convert `ErrServerNotStarted`
returned when member loading races with shutdown to the same gRPC status.

Other member-loading failures remain response-header errors, so unrelated
server-side failures are not reclassified as availability failures. `GetMembers`
continues to apply rate limiting before checking the running state; admitted
requests report `Unavailable` during shutdown.

This does not change kvproto. The affected RPCs are read-only and clients can
safely retry them against another PD endpoint.

```commit-message
Return gRPC Unavailable from service-discovery RPCs when the local PD
server is not running. Preserve response-header errors for unrelated
member-loading failures.
```

### Check List

Tests

- Unit test
- Manual test
  - `make gotest GOTEST_ARGS="./server -run Test\(ServiceDiscoveryRPCsReturnUnavailableWhenServerIsNotRunning\|GetMembersErrorResult\) -count=1"`
  - `make gotest GOTEST_ARGS="./server -count=1"`
  - `.tools/bin/golangci-lint run ./server --allow-parallel-runners`
  - `make pd-server-basic`
  - On `10.2.8.101`, an identical shutdown probe against base
    `fad3ff991802633a8de432ad1aa9e2ef2940f824` observed
    `response UNKNOWN / READY` before the transport closed.
  - The same probe against this change observed `rpc Unavailable / READY`, then
    `rpc Unavailable / TRANSIENT_FAILURE`, with no response-header `UNKNOWN`.

### Release note

```release-note
Fix PD service-discovery RPCs to return gRPC `Unavailable` instead of a response-header `UNKNOWN` error when PD is not serving.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service discovery gRPC calls now return a consistent “Unavailable” status when the service is closed; closed-state handling is prioritized correctly (e.g., rate-limit failures take precedence).
  * TSO gRPC unary RPCs (`FindGroupByKeyspaceID`, `GetMinTS`) now immediately return “Unavailable” when the service is closed.
* **Tests**
  * Added/updated in-memory gRPC tests to verify “Unavailable” responses for closed-server scenarios and validate error-mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
