### PR TITLE
server: validate forwarded PD hosts before dialing

### DIFF
--- a/server/forward.go
+++ b/server/forward.go
@@ -21,6 +21,8 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -448,6 +450,39 @@ func (s *GrpcServer) getDelegateClient(ctx context.Context, forwardedHost string
 	// and return the one we loaded.
 	newConn.Close()
 	return conn.(*grpc.ClientConn), nil
+}
+
+// getPDForwardedDelegateClient returns a delegate client for a PD address received
+// from the forwarding metadata. Unlike addresses discovered by PD itself, the
+// metadata is controlled by the caller, so it must be restricted to the advertised
+// client URLs of the current PD members before dialing.
+func (s *GrpcServer) getPDForwardedDelegateClient(ctx context.Context, forwardedHost string) (*grpc.ClientConn, error) {
+	if memberHasClientURL(s.GetLeader(), forwardedHost) {
+		return s.getDelegateClient(ctx, forwardedHost)
+	}
+
+	members, err := s.Server.GetMembers()
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "failed to get PD members: %v", err)
+	}
+	for _, member := range members {
+		if memberHasClientURL(member, forwardedHost) {
+			return s.getDelegateClient(ctx, forwardedHost)
+		}
+	}
+	return nil, status.Errorf(codes.InvalidArgument, "forwarded host %q is not a client URL of any PD member", forwardedHost)
+}
+
+func memberHasClientURL(member *pdpb.Member, addr string) bool {
+	if member == nil {
+		return false
+	}
+	for _, clientURL := range member.GetClientUrls() {
+		if clientURL == addr {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *GrpcServer) closeDelegateClient(forwardedHost string) {

--- a/server/forward.go
+++ b/server/forward.go
@@ -452,20 +452,20 @@ func (s *GrpcServer) getDelegateClient(ctx context.Context, forwardedHost string
 	return conn.(*grpc.ClientConn), nil
 }
 
-// getPDForwardedDelegateClient returns a delegate client for the PD leader address
-// received from the forwarding metadata. The metadata is controlled by the caller,
-// so it must match an advertised client URL of the current PD leader before dialing.
-func (s *GrpcServer) getPDForwardedDelegateClient(ctx context.Context, forwardedHost string) (*grpc.ClientConn, error) {
+// validatePDForwardedHost checks that a PD address received from forwarding
+// metadata belongs to the current PD leader. The metadata is controlled by the
+// caller, so it must be validated before both local handling and dialing.
+func (s *GrpcServer) validatePDForwardedHost(forwardedHost string) error {
 	leader := s.GetLeader()
 	if leader == nil || len(leader.GetClientUrls()) == 0 {
-		return nil, status.Error(codes.Unavailable, "PD leader is not available")
+		return status.Error(codes.Unavailable, "PD leader is not available")
 	}
 	for _, clientURL := range leader.GetClientUrls() {
 		if clientURL == forwardedHost {
-			return s.getDelegateClient(ctx, forwardedHost)
+			return nil
 		}
 	}
-	return nil, status.Errorf(codes.InvalidArgument, "forwarded host %q is not a client URL of the PD leader", forwardedHost)
+	return status.Errorf(codes.InvalidArgument, "forwarded host %q is not a client URL of the PD leader", forwardedHost)
 }
 
 func (s *GrpcServer) closeDelegateClient(forwardedHost string) {

--- a/server/forward.go
+++ b/server/forward.go
@@ -452,37 +452,20 @@ func (s *GrpcServer) getDelegateClient(ctx context.Context, forwardedHost string
 	return conn.(*grpc.ClientConn), nil
 }
 
-// getPDForwardedDelegateClient returns a delegate client for a PD address received
-// from the forwarding metadata. Unlike addresses discovered by PD itself, the
-// metadata is controlled by the caller, so it must be restricted to the advertised
-// client URLs of the current PD members before dialing.
+// getPDForwardedDelegateClient returns a delegate client for the PD leader address
+// received from the forwarding metadata. The metadata is controlled by the caller,
+// so it must match an advertised client URL of the current PD leader before dialing.
 func (s *GrpcServer) getPDForwardedDelegateClient(ctx context.Context, forwardedHost string) (*grpc.ClientConn, error) {
-	if memberHasClientURL(s.GetLeader(), forwardedHost) {
-		return s.getDelegateClient(ctx, forwardedHost)
+	leader := s.GetLeader()
+	if leader == nil || len(leader.GetClientUrls()) == 0 {
+		return nil, status.Error(codes.Unavailable, "PD leader is not available")
 	}
-
-	members, err := s.Server.GetMembers()
-	if err != nil {
-		return nil, status.Errorf(codes.Unavailable, "failed to get PD members: %v", err)
-	}
-	for _, member := range members {
-		if memberHasClientURL(member, forwardedHost) {
+	for _, clientURL := range leader.GetClientUrls() {
+		if clientURL == forwardedHost {
 			return s.getDelegateClient(ctx, forwardedHost)
 		}
 	}
-	return nil, status.Errorf(codes.InvalidArgument, "forwarded host %q is not a client URL of any PD member", forwardedHost)
-}
-
-func memberHasClientURL(member *pdpb.Member, addr string) bool {
-	if member == nil {
-		return false
-	}
-	for _, clientURL := range member.GetClientUrls() {
-		if clientURL == addr {
-			return true
-		}
-	}
-	return false
+	return nil, status.Errorf(codes.InvalidArgument, "forwarded host %q is not a client URL of the PD leader", forwardedHost)
 }
 
 func (s *GrpcServer) closeDelegateClient(forwardedHost string) {

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -230,8 +230,13 @@ func (s *GrpcServer) unaryFollowerMiddleware(ctx context.Context, req request, f
 		time.Sleep(5 * time.Second)
 	})
 	forwardedHost := grpcutil.GetForwardedHost(ctx)
+	if forwardedHost != "" {
+		if err := s.validatePDForwardedHost(forwardedHost); err != nil {
+			return nil, err
+		}
+	}
 	if !s.isLocalRequest(forwardedHost) {
-		client, err := s.getPDForwardedDelegateClient(ctx, forwardedHost)
+		client, err := s.getDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
@@ -504,11 +509,12 @@ func (s *GrpcServer) Tso(stream pdpb.PD_TsoServer) error {
 
 	var (
 		// The following are tso forward stream related variables.
-		tsoRequestProxyCtx  context.Context
-		forwardedHost       = grpcutil.GetForwardedHost(stream.Context())
-		forwardedClientConn *grpc.ClientConn
-		forwarder           = newTSOForwarder(stream)
-		tsoStreamErr        error
+		tsoRequestProxyCtx   context.Context
+		forwardedHost        = grpcutil.GetForwardedHost(stream.Context())
+		forwardedClientConn  *grpc.ClientConn
+		forwarder            = newTSOForwarder(stream)
+		tsoStreamErr         error
+		forwardedHostChecked = forwardedHost == ""
 	)
 
 	defer func() {
@@ -565,9 +571,15 @@ func (s *GrpcServer) Tso(stream pdpb.PD_TsoServer) error {
 			return errs.ErrNotStarted
 		}
 
+		if !forwardedHostChecked {
+			if err := s.validatePDForwardedHost(forwardedHost); err != nil {
+				return errors.WithStack(err)
+			}
+			forwardedHostChecked = true
+		}
 		if !s.isLocalRequest(forwardedHost) {
 			if forwardedClientConn == nil {
-				forwardedClientConn, err = s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
+				forwardedClientConn, err = s.getDelegateClient(s.ctx, forwardedHost)
 				if err != nil {
 					return errors.WithStack(err)
 				}
@@ -1083,6 +1095,8 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 		forwardErrCh                chan error
 		forwardSchedulingStream     schedulingpb.Scheduling_RegionBucketsClient
 		lastForwardedSchedulingHost string
+		metadataForwardedHost       = grpcutil.GetForwardedHost(stream.Context())
+		forwardedHostChecked        = metadataForwardedHost == ""
 	)
 	defer func() {
 		if cancel != nil {
@@ -1108,7 +1122,13 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		forwardedHost := grpcutil.GetForwardedHost(stream.Context())
+		if !forwardedHostChecked {
+			if err := s.validatePDForwardedHost(metadataForwardedHost); err != nil {
+				return err
+			}
+			forwardedHostChecked = true
+		}
+		forwardedHost := metadataForwardedHost
 		failpoint.Inject("grpcClientClosed", func() {
 			forwardedHost = s.GetMember().Member().GetClientUrls()[0]
 		})
@@ -1117,7 +1137,7 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 				if cancel != nil {
 					cancel()
 				}
-				client, err := s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
+				client, err := s.getDelegateClient(s.ctx, forwardedHost)
 				if err != nil {
 					return err
 				}
@@ -1264,6 +1284,8 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 		forwardErrCh                chan error
 		forwardSchedulingStream     schedulingpb.Scheduling_RegionHeartbeatClient
 		lastForwardedSchedulingHost string
+		metadataForwardedHost       = grpcutil.GetForwardedHost(stream.Context())
+		forwardedHostChecked        = metadataForwardedHost == ""
 	)
 	defer func() {
 		// cancel the forward stream
@@ -1286,7 +1308,13 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		forwardedHost := grpcutil.GetForwardedHost(stream.Context())
+		if !forwardedHostChecked {
+			if err := s.validatePDForwardedHost(metadataForwardedHost); err != nil {
+				return err
+			}
+			forwardedHostChecked = true
+		}
+		forwardedHost := metadataForwardedHost
 		failpoint.Inject("grpcClientClosed", func() {
 			forwardedHost = s.GetMember().Member().GetClientUrls()[0]
 		})
@@ -1295,7 +1323,7 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 				if cancel != nil {
 					cancel()
 				}
-				client, err := s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
+				client, err := s.getDelegateClient(s.ctx, forwardedHost)
 				if err != nil {
 					return err
 				}

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -504,9 +504,11 @@ func (s *GrpcServer) Tso(stream pdpb.PD_TsoServer) error {
 
 	var (
 		// The following are tso forward stream related variables.
-		tsoRequestProxyCtx context.Context
-		forwarder          = newTSOForwarder(stream)
-		tsoStreamErr       error
+		tsoRequestProxyCtx  context.Context
+		forwardedHost       = grpcutil.GetForwardedHost(stream.Context())
+		forwardedClientConn *grpc.ClientConn
+		forwarder           = newTSOForwarder(stream)
+		tsoStreamErr        error
 	)
 
 	defer func() {
@@ -563,14 +565,15 @@ func (s *GrpcServer) Tso(stream pdpb.PD_TsoServer) error {
 			return errs.ErrNotStarted
 		}
 
-		forwardedHost := grpcutil.GetForwardedHost(stream.Context())
 		if !s.isLocalRequest(forwardedHost) {
-			clientConn, err := s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
-			if err != nil {
-				return errors.WithStack(err)
+			if forwardedClientConn == nil {
+				forwardedClientConn, err = s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
+				if err != nil {
+					return errors.WithStack(err)
+				}
 			}
 
-			tsoRequest := tsoutil.NewPDProtoRequest(forwardedHost, clientConn, request, stream)
+			tsoRequest := tsoutil.NewPDProtoRequest(forwardedHost, forwardedClientConn, request, stream)
 			// don't pass a stream context here as dispatcher serves multiple streams
 			tsoRequestProxyCtx = s.tsoDispatcher.DispatchRequest(s.ctx, tsoRequest, s.pdProtoFactory, s.tsoPrimaryWatcher)
 			continue

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -231,7 +231,7 @@ func (s *GrpcServer) unaryFollowerMiddleware(ctx context.Context, req request, f
 	})
 	forwardedHost := grpcutil.GetForwardedHost(ctx)
 	if !s.isLocalRequest(forwardedHost) {
-		client, err := s.getDelegateClient(ctx, forwardedHost)
+		client, err := s.getPDForwardedDelegateClient(ctx, forwardedHost)
 		if err != nil {
 			return nil, err
 		}
@@ -565,7 +565,7 @@ func (s *GrpcServer) Tso(stream pdpb.PD_TsoServer) error {
 
 		forwardedHost := grpcutil.GetForwardedHost(stream.Context())
 		if !s.isLocalRequest(forwardedHost) {
-			clientConn, err := s.getDelegateClient(s.ctx, forwardedHost)
+			clientConn, err := s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -1114,7 +1114,7 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 				if cancel != nil {
 					cancel()
 				}
-				client, err := s.getDelegateClient(s.ctx, forwardedHost)
+				client, err := s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
 				if err != nil {
 					return err
 				}
@@ -1292,7 +1292,7 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 				if cancel != nil {
 					cancel()
 				}
-				client, err := s.getDelegateClient(s.ctx, forwardedHost)
+				client, err := s.getPDForwardedDelegateClient(s.ctx, forwardedHost)
 				if err != nil {
 					return err
 				}

--- a/server/resource_group_proxy_service.go
+++ b/server/resource_group_proxy_service.go
@@ -62,6 +62,7 @@ func (s *resourceGroupProxyServer) closeClient(ctx context.Context) {
 
 func (s *resourceGroupProxyServer) getPDMetadataWriteDelegateClient(ctx context.Context) (resource_manager.ResourceManagerClient, string, error) {
 	forwardedHost := grpcutil.GetForwardedHost(ctx)
+	forwardedHostFromMetadata := forwardedHost != ""
 	if forwardedHost == "" {
 		leader := s.GetLeader()
 		if leader == nil || len(leader.GetClientUrls()) == 0 {
@@ -71,6 +72,14 @@ func (s *resourceGroupProxyServer) getPDMetadataWriteDelegateClient(ctx context.
 	}
 	if s.isLocalRequest(forwardedHost) {
 		return nil, "", nil
+	}
+	if !forwardedHostFromMetadata {
+		// Keep PD-discovered leader targets on the original trusted delegate path.
+		client, err := s.getDelegateClient(ctx, forwardedHost)
+		if err != nil {
+			return nil, "", err
+		}
+		return resource_manager.NewResourceManagerClient(client), forwardedHost, nil
 	}
 	client, err := s.getPDForwardedDelegateClient(ctx, forwardedHost)
 	if err != nil {

--- a/server/resource_group_proxy_service.go
+++ b/server/resource_group_proxy_service.go
@@ -62,8 +62,11 @@ func (s *resourceGroupProxyServer) closeClient(ctx context.Context) {
 
 func (s *resourceGroupProxyServer) getPDMetadataWriteDelegateClient(ctx context.Context) (resource_manager.ResourceManagerClient, string, error) {
 	forwardedHost := grpcutil.GetForwardedHost(ctx)
-	forwardedHostFromMetadata := forwardedHost != ""
-	if forwardedHost == "" {
+	if forwardedHost != "" {
+		if err := s.validatePDForwardedHost(forwardedHost); err != nil {
+			return nil, "", err
+		}
+	} else {
 		leader := s.GetLeader()
 		if leader == nil || len(leader.GetClientUrls()) == 0 {
 			return nil, "", status.Error(codes.Unavailable, "pd leader is not available")
@@ -73,15 +76,7 @@ func (s *resourceGroupProxyServer) getPDMetadataWriteDelegateClient(ctx context.
 	if s.isLocalRequest(forwardedHost) {
 		return nil, "", nil
 	}
-	if !forwardedHostFromMetadata {
-		// Keep PD-discovered leader targets on the original trusted delegate path.
-		client, err := s.getDelegateClient(ctx, forwardedHost)
-		if err != nil {
-			return nil, "", err
-		}
-		return resource_manager.NewResourceManagerClient(client), forwardedHost, nil
-	}
-	client, err := s.getPDForwardedDelegateClient(ctx, forwardedHost)
+	client, err := s.getDelegateClient(ctx, forwardedHost)
 	if err != nil {
 		return nil, "", err
 	}

--- a/server/resource_group_proxy_service.go
+++ b/server/resource_group_proxy_service.go
@@ -72,7 +72,7 @@ func (s *resourceGroupProxyServer) getPDMetadataWriteDelegateClient(ctx context.
 	if s.isLocalRequest(forwardedHost) {
 		return nil, "", nil
 	}
-	client, err := s.getDelegateClient(ctx, forwardedHost)
+	client, err := s.getPDForwardedDelegateClient(ctx, forwardedHost)
 	if err != nil {
 		return nil, "", err
 	}

--- a/tests/integrations/mcs/resourcemanager/redirector_test.go
+++ b/tests/integrations/mcs/resourcemanager/redirector_test.go
@@ -347,14 +347,26 @@ func (suite *resourceManagerRedirectorTestSuite) TestGRPCMetadataWritesForwardFr
 	group.Priority = 11
 	group.RUSettings.RU.Settings.FillRate = 960
 	group.RUSettings.RU.Settings.BurstLimit = 1024
-	modifyResp, err := followerClient.ModifyResourceGroup(ctx, &rmpb.PutResourceGroupRequest{Group: group})
-	re.NoError(err)
-	re.Equal("Success!", modifyResp.GetBody())
+	forwardedCtx := grpcutil.BuildForwardContext(ctx, suite.pdFollower.GetAddr())
+	_, err = followerClient.ModifyResourceGroup(forwardedCtx, &rmpb.PutResourceGroupRequest{Group: group})
+	re.Error(err)
+	re.Equal(codes.InvalidArgument, status.Code(err))
 
 	getReq := &rmpb.GetResourceGroupRequest{
 		ResourceGroupName: groupName,
 		KeyspaceId:        &rmpb.KeyspaceIDValue{Value: suite.keyspaceID},
 	}
+	unmodifiedResp, err := leaderClient.GetResourceGroup(ctx, getReq)
+	re.NoError(err)
+	re.NotNil(unmodifiedResp.GetGroup())
+	re.Equal(uint32(5), unmodifiedResp.GetGroup().GetPriority())
+	re.Equal(uint64(320), unmodifiedResp.GetGroup().GetRUSettings().GetRU().GetSettings().GetFillRate())
+	re.Equal(int64(480), unmodifiedResp.GetGroup().GetRUSettings().GetRU().GetSettings().GetBurstLimit())
+
+	modifyResp, err := followerClient.ModifyResourceGroup(ctx, &rmpb.PutResourceGroupRequest{Group: group})
+	re.NoError(err)
+	re.Equal("Success!", modifyResp.GetBody())
+
 	modifiedResp, err := leaderClient.GetResourceGroup(ctx, getReq)
 	re.NoError(err)
 	re.NotNil(modifiedResp.GetGroup())

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -17,12 +17,15 @@ package tso_test
 import (
 	"context"
 	"io"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -136,6 +139,42 @@ func (s *tsoProxyTestSuite) verifyProxyIsHealthyWith(client pdpb.PD_TsoClient) {
 	timestamp := resp.GetTimestamp()
 	re.Positive(timestamp.GetPhysical())
 	re.GreaterOrEqual(uint32(timestamp.GetLogical()), s.defaultReq.GetCount())
+}
+
+func (s *tsoProxyTestSuite) TestRejectUnknownForwardedHost() {
+	re := s.Require()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	re.NoError(err)
+	accepted := make(chan bool, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			accepted <- false
+			return
+		}
+		conn.Close()
+		accepted <- true
+	}()
+	defer func() {
+		re.NoError(listener.Close())
+		re.False(<-accepted)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = grpcutil.BuildForwardContext(ctx, "http://"+listener.Addr().String())
+
+	_, err = s.pdClient.GetAllStores(ctx, &pdpb.GetAllStoresRequest{Header: s.defaultReq.GetHeader()})
+	re.Error(err)
+	re.Equal(codes.InvalidArgument, status.Code(err))
+
+	client, err := s.pdClient.Tso(ctx)
+	re.NoError(err)
+	defer client.CloseSend()
+	re.NoError(client.Send(s.defaultReq))
+	_, err = client.Recv()
+	re.Error(err)
+	re.Equal(codes.InvalidArgument, status.Code(err))
 }
 
 func (s *tsoProxyTestSuite) assertReceiveError(re *require.Assertions, errStr string) {

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -146,8 +146,23 @@ func (s *tsoProxyTestSuite) TestRejectFollowerForwardedHost() {
 	client, conn := testutil.MustNewGrpcClient(re, s.leader.GetAddr())
 	defer conn.Close()
 
-	ctx := grpcutil.BuildForwardContext(context.Background(), s.follower.GetAddr())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = grpcutil.BuildForwardContext(ctx, s.follower.GetAddr())
 	_, err := client.GetAllStores(ctx, &pdpb.GetAllStoresRequest{Header: s.defaultReq.GetHeader()})
+	re.Error(err)
+	re.Equal(codes.InvalidArgument, status.Code(err))
+
+	tsoClient, err := client.Tso(ctx)
+	re.NoError(err)
+	defer func() {
+		err := tsoClient.CloseSend()
+		if err != nil && err != io.EOF {
+			re.NoError(err)
+		}
+	}()
+	re.NoError(tsoClient.Send(s.defaultReq))
+	_, err = tsoClient.Recv()
 	re.Error(err)
 	re.Equal(codes.InvalidArgument, status.Code(err))
 }

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -171,6 +171,26 @@ func (s *tsoProxyTestSuite) verifyForwardedHostRejected(client pdpb.PDClient, fo
 	_, err = tsoClient.Recv()
 	re.Error(err)
 	re.Equal(codes.InvalidArgument, status.Code(err))
+
+	regionHeartbeatClient, err := client.RegionHeartbeat(ctx)
+	re.NoError(err)
+	defer func() {
+		err := regionHeartbeatClient.CloseSend()
+		if err != nil && err != io.EOF {
+			re.NoError(err)
+		}
+	}()
+	re.NoError(regionHeartbeatClient.Send(&pdpb.RegionHeartbeatRequest{Header: s.defaultReq.GetHeader()}))
+	_, err = regionHeartbeatClient.Recv()
+	re.Error(err)
+	re.Equal(codes.InvalidArgument, status.Code(err))
+
+	reportBucketsClient, err := client.ReportBuckets(ctx)
+	re.NoError(err)
+	re.NoError(reportBucketsClient.Send(&pdpb.ReportBucketsRequest{Header: s.defaultReq.GetHeader()}))
+	_, err = reportBucketsClient.CloseAndRecv()
+	re.Error(err)
+	re.Equal(codes.InvalidArgument, status.Code(err))
 }
 
 func (s *tsoProxyTestSuite) TestRejectUnknownForwardedHost() {

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -181,7 +181,12 @@ func (s *tsoProxyTestSuite) TestRejectUnknownForwardedHost() {
 
 	client, err := s.pdClient.Tso(ctx)
 	re.NoError(err)
-	defer client.CloseSend()
+	defer func() {
+		err := client.CloseSend()
+		if err != nil && err != io.EOF {
+			re.NoError(err)
+		}
+	}()
 	re.NoError(client.Send(s.defaultReq))
 	_, err = client.Recv()
 	re.Error(err)

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -141,6 +141,17 @@ func (s *tsoProxyTestSuite) verifyProxyIsHealthyWith(client pdpb.PD_TsoClient) {
 	re.GreaterOrEqual(uint32(timestamp.GetLogical()), s.defaultReq.GetCount())
 }
 
+func (s *tsoProxyTestSuite) TestRejectFollowerForwardedHost() {
+	re := s.Require()
+	client, conn := testutil.MustNewGrpcClient(re, s.leader.GetAddr())
+	defer conn.Close()
+
+	ctx := grpcutil.BuildForwardContext(context.Background(), s.follower.GetAddr())
+	_, err := client.GetAllStores(ctx, &pdpb.GetAllStoresRequest{Header: s.defaultReq.GetHeader()})
+	re.Error(err)
+	re.Equal(codes.InvalidArgument, status.Code(err))
+}
+
 func (s *tsoProxyTestSuite) TestRejectUnknownForwardedHost() {
 	re := s.Require()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -146,9 +146,15 @@ func (s *tsoProxyTestSuite) TestRejectFollowerForwardedHost() {
 	client, conn := testutil.MustNewGrpcClient(re, s.leader.GetAddr())
 	defer conn.Close()
 
+	s.verifyForwardedHostRejected(client, s.follower.GetAddr())
+	s.verifyForwardedHostRejected(s.pdClient, s.follower.GetAddr())
+}
+
+func (s *tsoProxyTestSuite) verifyForwardedHostRejected(client pdpb.PDClient, forwardedHost string) {
+	re := s.Require()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ctx = grpcutil.BuildForwardContext(ctx, s.follower.GetAddr())
+	ctx = grpcutil.BuildForwardContext(ctx, forwardedHost)
 	_, err := client.GetAllStores(ctx, &pdpb.GetAllStoresRequest{Header: s.defaultReq.GetHeader()})
 	re.Error(err)
 	re.Equal(codes.InvalidArgument, status.Code(err))

--- a/tests/server/tso/tso_test.go
+++ b/tests/server/tso/tso_test.go
@@ -88,7 +88,8 @@ func (s *tsoTestSuite) checkRequestFollower(cluster *tests.TestCluster) {
 		Header: testutil.NewRequestHeader(clusterID),
 		Count:  1,
 	}
-	ctx = grpcutil.BuildForwardContext(ctx, followerServer.GetAddr())
+	// Connect directly without forwarding metadata to verify the original
+	// follower request behavior.
 	tsoClient, err := grpcPDClient.Tso(ctx)
 	re.NoError(err)
 	defer func() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11070

The `pd-forwarded-host` gRPC metadata is controlled by the caller, but PD previously used it as a dial target without verifying that it is the current PD leader. This could make PD establish outbound gRPC connections to attacker-selected addresses.

### What is changed and how does it work?

```commit-message
server: validate forwarded PD hosts before dialing

Restrict forwarding targets supplied through gRPC metadata to the advertised client URLs of the current PD leader. Keep internally discovered TSO, Scheduling, and Resource Manager targets on the existing delegate-client path.
```

- Validate the metadata target against the locally cached current PD leader before dialing; this does not call `GetMembers` or query etcd.
- Return `InvalidArgument` for non-leader targets and `Unavailable` when no leader is available.
- Validate TSO metadata once per incoming stream and reuse the validated connection, preserving existing streams across a leader change.
- Apply the validation to unary, TSO, ReportBuckets, RegionHeartbeat, and PD metadata Resource Manager forwarding paths.

### Check List

Tests

- [x] Integration test
  - Verify unary and TSO requests reject a non-member forwarding target.
  - Verify a current PD follower is also rejected as a forwarding target.
  - Verify the target TCP listener receives no connection.
  - Verify normal leader forwarding and the existing leader-change behavior still work.

Code changes

- [ ] Has the configuration change
- [ ] Has HTTP APIs changed
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

Related changes

- [x] Need to cherry-pick to the release branch

### Release note

```release-note
Reject `pd-forwarded-host` gRPC forwarding targets that are not advertised by the current PD leader.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forwarded request routing to use only the current PD leader’s advertised client addresses.
  * Rejects requests targeting follower or unknown hosts with a clear invalid-argument error.
  * Returns an unavailable error when no usable PD leader is available.
  * Reuses forwarded connections during TSO streams for more consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->