### PR TITLE
client/tso: encapsulate request metadata

### DIFF
--- a/client/clients/tso/dispatcher.go
+++ b/client/clients/tso/dispatcher.go
@@ -427,11 +427,13 @@ func (td *tsoDispatcher) processRequests(
 	}()
 
 	var (
-		count              = int64(len(requests))
-		svcDiscovery       = td.provider.getServiceDiscovery()
-		clusterID          = svcDiscovery.GetClusterID()
-		keyspaceID         = svcDiscovery.GetKeyspaceID()
-		reqKeyspaceGroupID = svcDiscovery.GetKeyspaceGroupID()
+		count        = int64(len(requests))
+		svcDiscovery = td.provider.getServiceDiscovery()
+		metadata     = tsoRequestMetadata{
+			clusterID:       svcDiscovery.GetClusterID(),
+			keyspaceID:      svcDiscovery.GetKeyspaceID(),
+			keyspaceGroupID: svcDiscovery.GetKeyspaceGroupID(),
+		}
 	)
 
 	// Load latest allocated ts for monotonicity assertion.
@@ -465,7 +467,7 @@ func (td *tsoDispatcher) processRequests(
 	}
 
 	err := stream.processRequests(
-		clusterID, keyspaceID, reqKeyspaceGroupID,
+		metadata,
 		count, tbc.GetExtraBatchingStartTime(), cb)
 	if err != nil {
 		close(done)

--- a/client/clients/tso/stream.go
+++ b/client/clients/tso/stream.go
@@ -123,8 +123,14 @@ type tsoRequestResult struct {
 	respKeyspaceGroupID uint32
 }
 
+type tsoRequestMetadata struct {
+	clusterID       uint64
+	keyspaceID      uint32
+	keyspaceGroupID uint32
+}
+
 type grpcTSOStreamAdapter interface {
-	Send(clusterID uint64, keyspaceID, keyspaceGroupID uint32, count int64) error
+	Send(metadata tsoRequestMetadata, count int64) error
 	Recv() (tsoRequestResult, error)
 }
 
@@ -133,10 +139,10 @@ type pdTSOStreamAdapter struct {
 }
 
 // Send implements the grpcTSOStreamAdapter interface.
-func (s pdTSOStreamAdapter) Send(clusterID uint64, _, _ uint32, count int64) error {
+func (s pdTSOStreamAdapter) Send(metadata tsoRequestMetadata, count int64) error {
 	req := &pdpb.TsoRequest{
 		Header: &pdpb.RequestHeader{
-			ClusterId: clusterID,
+			ClusterId: metadata.clusterID,
 		},
 		Count: uint32(count),
 	}
@@ -163,14 +169,14 @@ type tsoTSOStreamAdapter struct {
 }
 
 // Send implements the grpcTSOStreamAdapter interface.
-func (s tsoTSOStreamAdapter) Send(clusterID uint64, keyspaceID, keyspaceGroupID uint32, count int64) error {
+func (s tsoTSOStreamAdapter) Send(metadata tsoRequestMetadata, count int64) error {
 	req := &tsopb.TsoRequest{
 		Header: &tsopb.RequestHeader{
-			ClusterId: clusterID,
+			ClusterId: metadata.clusterID,
 			Keyspace: &tsopb.RequestHeader_KeyspaceId{
-				KeyspaceId: keyspaceID,
+				KeyspaceId: metadata.keyspaceID,
 			},
-			KeyspaceGroupId: keyspaceGroupID,
+			KeyspaceGroupId: metadata.keyspaceGroupID,
 			CalleeId:        s.calleeID,
 		},
 		Count: uint32(count),
@@ -276,7 +282,7 @@ func (s *tsoStream) getServerURL() string {
 // It's guaranteed that the `callback` will be called, but when the request is failed to be scheduled, the callback
 // will be ignored.
 func (s *tsoStream) processRequests(
-	clusterID uint64, keyspaceID, keyspaceGroupID uint32, count int64, batchStartTime time.Time, callback onFinishedCallback,
+	metadata tsoRequestMetadata, count int64, batchStartTime time.Time, callback onFinishedCallback,
 ) error {
 	start := time.Now()
 
@@ -304,7 +310,7 @@ func (s *tsoStream) processRequests(
 	case s.pendingRequests <- batchedRequests{
 		startTime:          start,
 		count:              count,
-		reqKeyspaceGroupID: keyspaceGroupID,
+		reqKeyspaceGroupID: metadata.keyspaceGroupID,
 		callback:           callback,
 	}:
 	default:
@@ -314,7 +320,7 @@ func (s *tsoStream) processRequests(
 	s.state.Store(prevState)
 
 	failpoint.InjectCall("pauseAfterTSORequestAttachedToStream")
-	if err := s.stream.Send(clusterID, keyspaceID, keyspaceGroupID, count); err != nil {
+	if err := s.stream.Send(metadata, count); err != nil {
 		// As the request is already put into `pendingRequests`, the request should finally be canceled by the recvLoop.
 		// So skip returning error here to avoid
 		// if err == io.EOF {

--- a/client/clients/tso/stream_test.go
+++ b/client/clients/tso/stream_test.go
@@ -24,15 +24,109 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/kvproto/pkg/tsopb"
 	"github.com/pingcap/log"
 
+	"github.com/tikv/pd/client/constants"
 	"github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/pkg/utils/testutil"
 )
 
 const mockStreamURL = "mock:///"
+
+type legacyPDTSOClient struct {
+	grpc.ClientStream
+	sent     *pdpb.TsoRequest
+	response *pdpb.TsoResponse
+}
+
+func (c *legacyPDTSOClient) Send(request *pdpb.TsoRequest) error {
+	c.sent = request
+	return nil
+}
+
+func (c *legacyPDTSOClient) Recv() (*pdpb.TsoResponse, error) {
+	return c.response, nil
+}
+
+type legacyTSOClient struct {
+	grpc.ClientStream
+	sent     *tsopb.TsoRequest
+	response *tsopb.TsoResponse
+}
+
+func (c *legacyTSOClient) Send(request *tsopb.TsoRequest) error {
+	c.sent = request
+	return nil
+}
+
+func (c *legacyTSOClient) Recv() (*tsopb.TsoResponse, error) {
+	return c.response, nil
+}
+
+func TestPDTSOStreamAdapterLegacyProtocol(t *testing.T) {
+	re := require.New(t)
+	client := &legacyPDTSOClient{
+		response: &pdpb.TsoResponse{
+			Timestamp: &pdpb.Timestamp{Physical: 10, Logical: 20},
+			Count:     3,
+		},
+	}
+	adapter := pdTSOStreamAdapter{stream: client}
+
+	re.NoError(adapter.Send(1, 2, 3, 4))
+	re.Equal(&pdpb.TsoRequest{
+		Header: &pdpb.RequestHeader{ClusterId: 1},
+		Count:  4,
+	}, client.sent)
+
+	result, err := adapter.Recv()
+	re.NoError(err)
+	re.Equal(tsoRequestResult{
+		physical:            10,
+		logical:             20,
+		count:               3,
+		respKeyspaceGroupID: constants.DefaultKeyspaceGroupID,
+	}, result)
+}
+
+func TestTSOStreamAdapterLegacyProtocol(t *testing.T) {
+	re := require.New(t)
+	client := &legacyTSOClient{
+		response: &tsopb.TsoResponse{
+			Header:    &tsopb.ResponseHeader{KeyspaceGroupId: 3},
+			Timestamp: &pdpb.Timestamp{Physical: 10, Logical: 20},
+			Count:     4,
+		},
+	}
+	adapter := tsoTSOStreamAdapter{stream: client, calleeID: "tso-1"}
+
+	re.NoError(adapter.Send(1, 2, 3, 4))
+	re.Equal(&tsopb.TsoRequest{
+		Header: &tsopb.RequestHeader{
+			ClusterId: 1,
+			Keyspace: &tsopb.RequestHeader_KeyspaceId{
+				KeyspaceId: 2,
+			},
+			KeyspaceGroupId: 3,
+			CalleeId:        "tso-1",
+		},
+		Count: 4,
+	}, client.sent)
+
+	result, err := adapter.Recv()
+	re.NoError(err)
+	re.Equal(tsoRequestResult{
+		physical:            10,
+		logical:             20,
+		count:               4,
+		respKeyspaceGroupID: 3,
+	}, result)
+}
 
 type requestMsg struct {
 	clusterID       uint64

--- a/client/clients/tso/stream_test.go
+++ b/client/clients/tso/stream_test.go
@@ -78,7 +78,11 @@ func TestPDTSOStreamAdapterLegacyProtocol(t *testing.T) {
 	}
 	adapter := pdTSOStreamAdapter{stream: client}
 
-	re.NoError(adapter.Send(1, 2, 3, 4))
+	re.NoError(adapter.Send(tsoRequestMetadata{
+		clusterID:       1,
+		keyspaceID:      2,
+		keyspaceGroupID: 3,
+	}, 4))
 	re.Equal(&pdpb.TsoRequest{
 		Header: &pdpb.RequestHeader{ClusterId: 1},
 		Count:  4,
@@ -105,7 +109,11 @@ func TestTSOStreamAdapterLegacyProtocol(t *testing.T) {
 	}
 	adapter := tsoTSOStreamAdapter{stream: client, calleeID: "tso-1"}
 
-	re.NoError(adapter.Send(1, 2, 3, 4))
+	re.NoError(adapter.Send(tsoRequestMetadata{
+		clusterID:       1,
+		keyspaceID:      2,
+		keyspaceGroupID: 3,
+	}, 4))
 	re.Equal(&tsopb.TsoRequest{
 		Header: &tsopb.RequestHeader{
 			ClusterId: 1,
@@ -173,15 +181,15 @@ func newMockTSOStreamImpl(ctx context.Context, resultMode resultMode) *mockTSOSt
 	}
 }
 
-func (s *mockTSOStreamImpl) Send(clusterID uint64, _keyspaceID, keyspaceGroupID uint32, count int64) error {
+func (s *mockTSOStreamImpl) Send(metadata tsoRequestMetadata, count int64) error {
 	select {
 	case <-s.ctx.Done():
 		return s.ctx.Err()
 	default:
 	}
 	s.requestCh <- requestMsg{
-		clusterID:       clusterID,
-		keyspaceGroupID: keyspaceGroupID,
+		clusterID:       metadata.clusterID,
+		keyspaceGroupID: metadata.keyspaceGroupID,
 		count:           count,
 	}
 	return nil
@@ -400,7 +408,11 @@ func (s *testTSOStreamSuite) getResult(ch <-chan callbackInvocation) callbackInv
 
 func (s *testTSOStreamSuite) processRequestWithResultCh(count int64) (<-chan callbackInvocation, error) {
 	ch := make(chan callbackInvocation, 1)
-	err := s.stream.processRequests(1, 2, 3, count, time.Now(), func(result tsoRequestResult, reqKeyspaceGroupID uint32, err error) {
+	err := s.stream.processRequests(tsoRequestMetadata{
+		clusterID:       1,
+		keyspaceID:      2,
+		keyspaceGroupID: 3,
+	}, count, time.Now(), func(result tsoRequestResult, reqKeyspaceGroupID uint32, err error) {
 		if err == nil {
 			s.re.Equal(uint32(3), reqKeyspaceGroupID)
 		}
@@ -452,7 +464,11 @@ func (s *testTSOStreamSuite) TestTSOStreamBasic() {
 	// After an error from the (simulated) RPC stream, the tsoStream should be in a broken status and can't accept
 	// new request anymore.
 	testutil.Eventually(s.re, func() bool {
-		return s.stream.processRequests(1, 2, 3, 1, time.Now(), func(_result tsoRequestResult, _reqKeyspaceGroupID uint32, err error) {
+		return s.stream.processRequests(tsoRequestMetadata{
+			clusterID:       1,
+			keyspaceID:      2,
+			keyspaceGroupID: 3,
+		}, 1, time.Now(), func(_result tsoRequestResult, _reqKeyspaceGroupID uint32, err error) {
 			s.re.Error(err)
 		}) != nil
 	})
@@ -716,7 +732,11 @@ func BenchmarkTSOStreamSendRecv(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		err := stream.processRequests(1, 1, 1, 1, now, func(result tsoRequestResult, _ uint32, err error) {
+		err := stream.processRequests(tsoRequestMetadata{
+			clusterID:       1,
+			keyspaceID:      1,
+			keyspaceGroupID: 1,
+		}, 1, now, func(result tsoRequestResult, _ uint32, err error) {
 			if err != nil {
 				panic(err)
 			}

--- a/client/servicediscovery/tso_service_discovery_test.go
+++ b/client/servicediscovery/tso_service_discovery_test.go
@@ -16,6 +16,7 @@ package servicediscovery
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -63,10 +64,17 @@ func startLegacyFindGroupServer(t *testing.T, response *tsopb.FindGroupByKeyspac
 		err:      err,
 	}
 	tsopb.RegisterTSOServer(grpcServer, server)
+	serveErr := make(chan error, 1)
 	go func() {
-		_ = grpcServer.Serve(listener)
+		defer close(serveErr)
+		if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			serveErr <- err
+		}
 	}()
-	t.Cleanup(grpcServer.Stop)
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		require.NoError(t, <-serveErr)
+	})
 	return "http://" + listener.Addr().String(), listener.Addr().String(), server
 }
 

--- a/client/servicediscovery/tso_service_discovery_test.go
+++ b/client/servicediscovery/tso_service_discovery_test.go
@@ -15,13 +15,170 @@
 package servicediscovery
 
 import (
+	"context"
+	"net"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/kvproto/pkg/tsopb"
+
+	"github.com/tikv/pd/client/constants"
+	"github.com/tikv/pd/client/errs"
+	"github.com/tikv/pd/client/opt"
 )
+
+type legacyFindGroupServer struct {
+	tsopb.UnimplementedTSOServer
+	requests chan *tsopb.FindGroupByKeyspaceIDRequest
+	response *tsopb.FindGroupByKeyspaceIDResponse
+	err      error
+}
+
+func (s *legacyFindGroupServer) FindGroupByKeyspaceID(
+	_ context.Context,
+	request *tsopb.FindGroupByKeyspaceIDRequest,
+) (*tsopb.FindGroupByKeyspaceIDResponse, error) {
+	s.requests <- request
+	return s.response, s.err
+}
+
+func startLegacyFindGroupServer(t *testing.T, response *tsopb.FindGroupByKeyspaceIDResponse, err error) (
+	serverURL string,
+	calleeID string,
+	server *legacyFindGroupServer,
+) {
+	t.Helper()
+	listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, listenErr)
+	grpcServer := grpc.NewServer()
+	server = &legacyFindGroupServer{
+		requests: make(chan *tsopb.FindGroupByKeyspaceIDRequest, 1),
+		response: response,
+		err:      err,
+	}
+	tsopb.RegisterTSOServer(grpcServer, server)
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+	t.Cleanup(grpcServer.Stop)
+	return "http://" + listener.Addr().String(), listener.Addr().String(), server
+}
+
+func newLegacyTSOServiceDiscovery(t *testing.T, clusterID uint64) *tsoServiceDiscovery {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	discovery := &tsoServiceDiscovery{
+		ctx:       ctx,
+		cancel:    cancel,
+		clusterID: clusterID,
+		option:    opt.NewOption(),
+	}
+	t.Cleanup(discovery.Close)
+	return discovery
+}
+
+func TestFindGroupByKeyspaceIDLegacyProtocol(t *testing.T) {
+	const (
+		clusterID   = uint64(1)
+		keyspaceID  = uint32(2)
+		modRevision = uint64(10)
+	)
+	tests := []struct {
+		name                  string
+		response              *tsopb.FindGroupByKeyspaceIDResponse
+		rpcErr                error
+		wantGroup             *tsopb.KeyspaceGroup
+		wantRevision          uint64
+		wantErr               string
+		wantConnectionRemoved bool
+	}{
+		{
+			name: "success",
+			response: &tsopb.FindGroupByKeyspaceIDResponse{
+				Header:        &tsopb.ResponseHeader{},
+				KeyspaceGroup: &tsopb.KeyspaceGroup{Id: 3},
+				ModRevision:   11,
+			},
+			wantGroup:    &tsopb.KeyspaceGroup{Id: 3},
+			wantRevision: 11,
+		},
+		{
+			name:    "rpc error",
+			rpcErr:  status.Error(codes.Unavailable, "tso unavailable"),
+			wantErr: "tso unavailable",
+		},
+		{
+			name: "callee mismatch",
+			response: &tsopb.FindGroupByKeyspaceIDResponse{
+				Header: &tsopb.ResponseHeader{
+					Error: &tsopb.Error{Message: errs.MismatchCalleeIDErr},
+				},
+			},
+			wantErr:               errs.MismatchCalleeIDErr,
+			wantConnectionRemoved: true,
+		},
+		{
+			name: "missing keyspace group",
+			response: &tsopb.FindGroupByKeyspaceIDResponse{
+				Header:      &tsopb.ResponseHeader{},
+				ModRevision: modRevision,
+			},
+			wantErr: "no keyspace group found",
+		},
+		{
+			name: "stale revision",
+			response: &tsopb.FindGroupByKeyspaceIDResponse{
+				Header:        &tsopb.ResponseHeader{},
+				KeyspaceGroup: &tsopb.KeyspaceGroup{Id: 3},
+				ModRevision:   modRevision - 1,
+			},
+			wantErr: "response mod revision less than the given mod revision",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			re := require.New(t)
+			serverURL, calleeID, server := startLegacyFindGroupServer(t, test.response, test.rpcErr)
+			discovery := newLegacyTSOServiceDiscovery(t, clusterID)
+
+			group, revision, err := discovery.findGroupByKeyspaceID(
+				keyspaceID,
+				serverURL,
+				time.Second,
+				modRevision,
+			)
+
+			request := <-server.requests
+			re.Equal(clusterID, request.GetHeader().GetClusterId())
+			re.IsType(&tsopb.RequestHeader_KeyspaceId{}, request.GetHeader().GetKeyspace())
+			re.Equal(keyspaceID, request.GetHeader().GetKeyspaceId())
+			re.Equal(constants.DefaultKeyspaceGroupID, request.GetHeader().GetKeyspaceGroupId())
+			re.Equal(calleeID, request.GetHeader().GetCalleeId())
+			re.IsType(&tsopb.FindGroupByKeyspaceIDRequest_KeyspaceId{}, request.GetKeyspace())
+			re.Equal(keyspaceID, request.GetKeyspaceId())
+			re.Equal(modRevision, request.GetModRevision())
+
+			if test.wantErr == "" {
+				re.NoError(err)
+				re.Equal(test.wantGroup, group)
+				re.Equal(test.wantRevision, revision)
+			} else {
+				re.ErrorContains(err, test.wantErr)
+				re.Nil(group)
+				re.Zero(revision)
+			}
+			_, connectionExists := discovery.clientConns.Load(serverURL)
+			re.Equal(!test.wantConnectionRemoved, connectionExists)
+		})
+	}
+}
 
 func TestKeyspaceGroupSvcDiscoveryUpdateKeepsPrimary(t *testing.T) {
 	re := require.New(t)

--- a/client/servicediscovery/tso_service_discovery_test.go
+++ b/client/servicediscovery/tso_service_discovery_test.go
@@ -163,7 +163,12 @@ func TestFindGroupByKeyspaceIDLegacyProtocol(t *testing.T) {
 				modRevision,
 			)
 
-			request := <-server.requests
+			var request *tsopb.FindGroupByKeyspaceIDRequest
+			select {
+			case request = <-server.requests:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for FindGroupByKeyspaceID request")
+			}
 			re.Equal(clusterID, request.GetHeader().GetClusterId())
 			re.IsType(&tsopb.RequestHeader_KeyspaceId{}, request.GetHeader().GetKeyspace())
 			re.Equal(keyspaceID, request.GetHeader().GetKeyspaceId())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10989

The API V3 client work needs to extend the metadata carried by TSO requests. Before adding new identity fields, the existing keyspace-ID path should be covered by characterization tests and represented as one internal value so later changes remain focused and reviewable.

### What is changed and how does it work?

```commit-message
Add characterization tests for the existing PD and standalone TSO stream
adapters and keyspace-group lookup behavior.

Group the existing cluster ID, keyspace ID, and keyspace group ID into an
internal request metadata value. The generated protobuf requests and response
handling remain unchanged.
```

This PR:

- tests the exact legacy requests and responses for both TSO stream adapters;
- tests the current keyspace-group lookup request and error handling;
- introduces an internal `tsoRequestMetadata` value for the existing request fields;
- does not add API V3 types or change protocol behavior.

### Check List

Tests

- Unit test

Code changes

- None

Side effects

- None

Related changes

- None

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when routing timestamp requests through legacy and modern service protocols.
  * Preserved keyspace-group information throughout timestamp request processing.
  * Strengthened handling of service discovery errors, stale data, missing groups, and connection changes.

* **Tests**
  * Expanded coverage for timestamp request conversion and legacy service discovery scenarios.
  * Added validation for successful responses, failures, revision checks, and connection cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->