### PR TITLE
client: centralize client initialization

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -238,15 +238,15 @@ func createClientWithKeyspace(
 	keyspaceID uint32, svrAddrs []string,
 	security SecurityOption, opts ...opt.ClientOption,
 ) (Client, error) {
-	c, err := newClient(ctx, callerComponent, keyspaceID, svrAddrs, security, opts...)
+	c, err := createClient(ctx, callerComponent, keyspaceID, svrAddrs, security, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return c, c.inner.init(nil)
 }
 
-// newClient creates the client state shared by all initialization paths.
-func newClient(
+// createClient creates the client state shared by all initialization paths.
+func createClient(
 	ctx context.Context,
 	callerComponent caller.Component,
 	keyspaceID uint32, svrAddrs []string,
@@ -372,7 +372,7 @@ func newClientWithKeyspaceName(
 ) (Client, error) {
 	// Create a service discovery with null keyspace id, then query the real id with the keyspace name,
 	// finally update the keyspace id to the service discovery for the following interactions.
-	c, err := newClient(ctx, callerComponent, constants.NullKeyspaceID, svrAddrs, security, opts...)
+	c, err := createClient(ctx, callerComponent, constants.NullKeyspaceID, svrAddrs, security, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -238,6 +238,20 @@ func createClientWithKeyspace(
 	keyspaceID uint32, svrAddrs []string,
 	security SecurityOption, opts ...opt.ClientOption,
 ) (Client, error) {
+	c, err := newClient(ctx, callerComponent, keyspaceID, svrAddrs, security, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return c, c.inner.init(nil)
+}
+
+// newClient creates the client state shared by all initialization paths.
+func newClient(
+	ctx context.Context,
+	callerComponent caller.Component,
+	keyspaceID uint32, svrAddrs []string,
+	security SecurityOption, opts ...opt.ClientOption,
+) (*client, error) {
 	tlsCfg, err := tlsutil.TLSConfig{
 		CAPath:   security.CAPath,
 		CertPath: security.CertPath,
@@ -269,7 +283,7 @@ func createClientWithKeyspace(
 		opt(c.inner.option)
 	}
 
-	return c, c.inner.init(nil)
+	return c, nil
 }
 
 // APIVersion is the API version the server and the client is using.
@@ -356,41 +370,15 @@ func newClientWithKeyspaceName(
 	keyspaceName string, svrAddrs []string,
 	security SecurityOption, opts ...opt.ClientOption,
 ) (Client, error) {
-	tlsCfg, err := tlsutil.TLSConfig{
-		CAPath:   security.CAPath,
-		CertPath: security.CertPath,
-		KeyPath:  security.KeyPath,
-
-		SSLCABytes:   security.SSLCABytes,
-		SSLCertBytes: security.SSLCertBytes,
-		SSLKEYBytes:  security.SSLKEYBytes,
-	}.ToTLSConfig()
+	// Create a service discovery with null keyspace id, then query the real id with the keyspace name,
+	// finally update the keyspace id to the service discovery for the following interactions.
+	c, err := newClient(ctx, callerComponent, constants.NullKeyspaceID, svrAddrs, security, opts...)
 	if err != nil {
 		return nil, err
 	}
-	clientCtx, clientCancel := context.WithCancel(ctx)
-	c := &client{
-		callerComponent: adjustCallerComponent(callerComponent),
-		inner: &innerClient{
-			// Create a service discovery with null keyspace id, then query the real id with the keyspace name,
-			// finally update the keyspace id to the service discovery for the following interactions.
-			keyspaceID:              constants.NullKeyspaceID,
-			updateTokenConnectionCh: make(chan struct{}, 1),
-			ctx:                     clientCtx,
-			cancel:                  clientCancel,
-			svrUrls:                 svrAddrs,
-			tlsCfg:                  tlsCfg,
-			option:                  opt.NewOption(),
-		},
-	}
-
-	// Inject the client options.
-	for _, opt := range opts {
-		opt(c.inner.option)
-	}
 
 	updateKeyspaceIDFunc := func() error {
-		keyspaceMeta, err := c.LoadKeyspace(clientCtx, keyspaceName)
+		keyspaceMeta, err := c.LoadKeyspace(c.inner.ctx, keyspaceName)
 		if err != nil {
 			return err
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -78,7 +78,7 @@ func TestNewClientInitialization(t *testing.T) {
 	defer cancel()
 	serverURLs := []string{"http://127.0.0.1:2379"}
 
-	cli, err := newClient(
+	cli, err := createClient(
 		ctx,
 		caller.TestComponent,
 		42,
@@ -106,7 +106,7 @@ func TestNewClientInitialization(t *testing.T) {
 }
 
 func TestNewClientInitializationWithInvalidTLSConfig(t *testing.T) {
-	cli, err := newClient(
+	cli, err := createClient(
 		context.Background(),
 		caller.TestComponent,
 		constants.NullKeyspaceID,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 
+	"github.com/tikv/pd/client/constants"
 	"github.com/tikv/pd/client/errs"
 	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/caller"
@@ -69,6 +70,55 @@ func TestClientWithRetry(t *testing.T) {
 	re.Error(err)
 	defer cli.Close()
 	re.Less(time.Since(start), time.Second*10)
+}
+
+func TestNewClientInitialization(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serverURLs := []string{"http://127.0.0.1:2379"}
+
+	cli, err := newClient(
+		ctx,
+		caller.TestComponent,
+		42,
+		serverURLs,
+		SecurityOption{},
+		opt.WithMaxErrorRetry(5),
+		opt.WithCustomTimeoutOption(2*time.Second),
+	)
+	re.NoError(err)
+	t.Cleanup(cli.inner.cancel)
+	re.Equal(caller.TestComponent, cli.callerComponent)
+	re.Equal(uint32(42), cli.inner.keyspaceID)
+	re.Equal(serverURLs, cli.inner.svrUrls)
+	re.NotNil(cli.inner.updateTokenConnectionCh)
+	re.Nil(cli.inner.tlsCfg)
+	re.Equal(5, cli.inner.option.MaxRetryTimes)
+	re.Equal(2*time.Second, cli.inner.option.Timeout)
+
+	cancel()
+	select {
+	case <-cli.inner.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("client context was not canceled with its parent")
+	}
+}
+
+func TestNewClientInitializationWithInvalidTLSConfig(t *testing.T) {
+	cli, err := newClient(
+		context.Background(),
+		caller.TestComponent,
+		constants.NullKeyspaceID,
+		nil,
+		SecurityOption{
+			SSLCABytes:   []byte("invalid"),
+			SSLCertBytes: []byte("invalid"),
+			SSLKEYBytes:  []byte("invalid"),
+		},
+	)
+	require.Error(t, err)
+	require.Nil(t, cli)
 }
 
 func TestIsRetryableGetTSError(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -126,7 +126,7 @@ func TestNewClientWithKeyspaceInvalidTLSConfig(t *testing.T) {
 		context.Background(),
 		caller.TestComponent,
 		42,
-		nil,
+		[]string{testClientURL},
 		SecurityOption{
 			SSLCABytes:   []byte("invalid"),
 			SSLCertBytes: []byte("invalid"),
@@ -135,6 +135,7 @@ func TestNewClientWithKeyspaceInvalidTLSConfig(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Nil(t, cli)
+	require.ErrorIs(t, err, errs.ErrCryptoX509KeyPair)
 }
 
 func TestNewClientWithKeyspaceNameInvalidTLSConfig(t *testing.T) {
@@ -142,7 +143,7 @@ func TestNewClientWithKeyspaceNameInvalidTLSConfig(t *testing.T) {
 		context.Background(),
 		NewAPIContextV2("test-keyspace"),
 		caller.TestComponent,
-		nil,
+		[]string{testClientURL},
 		SecurityOption{
 			SSLCABytes:   []byte("invalid"),
 			SSLCertBytes: []byte("invalid"),
@@ -151,6 +152,7 @@ func TestNewClientWithKeyspaceNameInvalidTLSConfig(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Nil(t, cli)
+	require.ErrorIs(t, err, errs.ErrCryptoX509KeyPair)
 }
 
 func TestIsRetryableGetTSError(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -121,6 +121,38 @@ func TestNewClientInitializationWithInvalidTLSConfig(t *testing.T) {
 	require.Nil(t, cli)
 }
 
+func TestNewClientWithKeyspaceInvalidTLSConfig(t *testing.T) {
+	cli, err := NewClientWithKeyspace(
+		context.Background(),
+		caller.TestComponent,
+		42,
+		nil,
+		SecurityOption{
+			SSLCABytes:   []byte("invalid"),
+			SSLCertBytes: []byte("invalid"),
+			SSLKEYBytes:  []byte("invalid"),
+		},
+	)
+	require.Error(t, err)
+	require.Nil(t, cli)
+}
+
+func TestNewClientWithKeyspaceNameInvalidTLSConfig(t *testing.T) {
+	cli, err := NewClientWithAPIContext(
+		context.Background(),
+		NewAPIContextV2("test-keyspace"),
+		caller.TestComponent,
+		nil,
+		SecurityOption{
+			SSLCABytes:   []byte("invalid"),
+			SSLCertBytes: []byte("invalid"),
+			SSLKEYBytes:  []byte("invalid"),
+		},
+	)
+	require.Error(t, err)
+	require.Nil(t, cli)
+}
+
 func TestIsRetryableGetTSError(t *testing.T) {
 	re := require.New(t)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10989

The fixed-keyspace-ID and keyspace-name client constructors duplicate TLS, context, `innerClient`, and option initialization. Adding another initialization path on top of this duplication would make it easier for constructor behavior to drift.

### What is changed and how does it work?

```commit-message
Extract the client state shared by the fixed-keyspace-ID and keyspace-name
initialization paths into one internal helper.

Keep service discovery initialization, the keyspace-name callback, logging,
and error handling in their existing paths.
```

This PR:

- centralizes TLS, context, `innerClient`, and client option initialization;
- keeps the fixed-keyspace-ID path using `inner.init(nil)`;
- keeps keyspace-name resolution and its initialization callback unchanged;
- adds unit tests for the shared state, options, context, and TLS error path;
- does not add API V3 types or change public APIs.

### Check List

Tests

- Unit test

Code changes

- None

Side effects

- None

Related changes

- None

### Release note

```release-note
None.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency across supported client connection methods.
  * Client settings, options, TLS configuration, and context handling are now applied consistently.
  * Invalid TLS configuration is rejected with an error instead of creating a client.

* **Tests**
  * Added coverage for successful initialization, propagated settings, context handling, TLS validation, and invalid certificate material across supported client creation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->