### PR TITLE
schedule/labeler: skip empty keyspace index chunks

### DIFF
--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -41,7 +41,60 @@ const (
 	TxnKeyspaceModePrefix = byte('x')
 	// KeyspacePrefixLen is the raw keyspace prefix length before memcomparable encoding.
 	KeyspacePrefixLen = 4
+
+	encodedKeyspacePrefixLen = encGroupSize + 1
+	keyspacePrefixMarker     = encMarker - byte(encGroupSize-KeyspacePrefixLen)
 )
+
+// KeyspaceModes returns all supported keyspace API modes.
+func KeyspaceModes() [2]byte {
+	return [2]byte{RawKeyspaceModePrefix, TxnKeyspaceModePrefix}
+}
+
+func parseKeyspaceMode(prefix byte) (byte, bool) {
+	switch prefix {
+	case RawKeyspaceModePrefix:
+		return RawKeyspaceModePrefix, true
+	case TxnKeyspaceModePrefix:
+		return TxnKeyspaceModePrefix, true
+	default:
+		return 0, false
+	}
+}
+
+// EncodeKeyspaceBoundary returns the fixed-width memcomparable boundary for a
+// keyspace ID. An ID beyond the 24-bit keyspace prefix is encoded as the
+// mode's exclusive fencepost.
+func EncodeKeyspaceBoundary(mode byte, id uint32) [encodedKeyspacePrefixLen]byte {
+	if id >= 1<<(8*(KeyspacePrefixLen-1)) {
+		// The next prefix byte is the exclusive upper bound of this mode's
+		// keyspace range.
+		mode++
+		id = 0
+	}
+	return [encodedKeyspacePrefixLen]byte{
+		mode,
+		byte(id >> 16),
+		byte(id >> 8),
+		byte(id),
+		0, 0, 0, 0,
+		keyspacePrefixMarker,
+	}
+}
+
+// DecodeKeyspaceKey extracts the API mode and keyspace ID from a
+// memcomparable key that contains the complete four-byte keyspace prefix.
+func DecodeKeyspaceKey(key []byte) (byte, uint32, bool) {
+	if len(key) < encodedKeyspacePrefixLen || key[encGroupSize] < keyspacePrefixMarker {
+		return 0, 0, false
+	}
+	mode, ok := parseKeyspaceMode(key[0])
+	if !ok {
+		return 0, 0, false
+	}
+	id := uint32(key[1])<<16 | uint32(key[2])<<8 | uint32(key[3])
+	return mode, id, true
+}
 
 // Key represents high-level Key type.
 type Key []byte
@@ -61,8 +114,8 @@ func ParseKeyspacePrefix(key []byte) (mode byte, id uint32, ok bool) {
 	if len(key) < KeyspacePrefixLen {
 		return 0, 0, false
 	}
-	mode = key[0]
-	if mode != RawKeyspaceModePrefix && mode != TxnKeyspaceModePrefix {
+	mode, ok = parseKeyspaceMode(key[0])
+	if !ok {
 		return 0, 0, false
 	}
 	idBytes := [KeyspacePrefixLen]byte{0, key[1], key[2], key[3]}

--- a/pkg/codec/codec_test.go
+++ b/pkg/codec/codec_test.go
@@ -35,6 +35,38 @@ func TestDecodeBytes(t *testing.T) {
 	}
 }
 
+func TestKeyspaceBoundaryCodec(t *testing.T) {
+	re := require.New(t)
+	for _, mode := range KeyspaceModes() {
+		prefix := mode
+		boundary := EncodeKeyspaceBoundary(mode, 0x010203)
+		re.Equal(EncodeBytes([]byte{prefix, 0x01, 0x02, 0x03}), Key(boundary[:]))
+
+		decodedMode, id, ok := DecodeKeyspaceKey(boundary[:])
+		re.True(ok)
+		re.Equal(mode, decodedMode)
+		re.Equal(uint32(0x010203), id)
+
+		key := EncodeBytes([]byte{prefix, 0x01, 0x02, 0x03, 'k'})
+		decodedMode, id, ok = DecodeKeyspaceKey(key)
+		re.True(ok)
+		re.Equal(mode, decodedMode)
+		re.Equal(uint32(0x010203), id)
+	}
+
+	rawFence := EncodeKeyspaceBoundary(RawKeyspaceModePrefix, 1<<(8*(KeyspacePrefixLen-1)))
+	txnFence := EncodeKeyspaceBoundary(TxnKeyspaceModePrefix, 1<<(8*(KeyspacePrefixLen-1)))
+	re.Equal(EncodeBytes([]byte{'s', 0, 0, 0}), Key(rawFence[:]))
+	re.Equal(EncodeBytes([]byte{'y', 0, 0, 0}), Key(txnFence[:]))
+
+	_, _, ok := DecodeKeyspaceKey(nil)
+	re.False(ok)
+	_, _, ok = DecodeKeyspaceKey([]byte{'z', 0, 0, 0, 0, 0, 0, 0, keyspacePrefixMarker})
+	re.False(ok)
+	_, _, ok = DecodeKeyspaceKey([]byte{'r', 0, 0, 0, 0, 0, 0, 0, keyspacePrefixMarker - 1})
+	re.False(ok)
+}
+
 func TestTableID(t *testing.T) {
 	re := require.New(t)
 	key := EncodeBytes([]byte("t\x80\x00\x00\x00\x00\x00\x00\xff"))

--- a/pkg/keyspace/constant/constant.go
+++ b/pkg/keyspace/constant/constant.go
@@ -29,6 +29,10 @@ const (
 	// Valid keyspace id range is [0, 0xFFFFFF](uint24max, or 16777215)
 	// In kv encode, the first byte is represented by r/x, which means txn kv/raw kv, so there are 24 bits left.
 	MaxValidKeyspaceID = uint32(0xFFFFFF)
+	// RegionLabelIDPrefix is the prefix of keyspace region label rule IDs.
+	RegionLabelIDPrefix = "keyspaces/"
+	// RegionLabelKey is the label key that stores the keyspace ID.
+	RegionLabelKey = "id"
 
 	// ValidKeyspaceIDMask is the mask of valid bits for keyspace ID. If any bit outside the mask is set, the keyspace
 	// ID is considered invalid and regarded as the same as NullKeyspaceID.

--- a/pkg/keyspace/keyspace.go
+++ b/pkg/keyspace/keyspace.go
@@ -47,10 +47,6 @@ const (
 	// AllocStep set idAllocator's step when write persistent window boundary.
 	// Use a lower value for denser idAllocation in the event of frequent pd leader change.
 	AllocStep = uint64(100)
-	// regionLabelIDPrefix is used to prefix the keyspace region label.
-	regionLabelIDPrefix = "keyspaces/"
-	// regionLabelKey is the key for keyspace id in keyspace region label.
-	regionLabelKey = "id"
 	// UserKindKey is the key for user kind in keyspace config.
 	UserKindKey = "user_kind"
 	// TSOKeyspaceGroupIDKey is the key for tso keyspace group id in keyspace config.

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -206,7 +206,7 @@ func buildKeyRanges(id uint32, boundType regionBoundType) []any {
 
 // getRegionLabelID returns the region label id of the target keyspace.
 func getRegionLabelID(id uint32) string {
-	return regionLabelIDPrefix + strconv.FormatUint(uint64(id), endpoint.SpaceIDBase)
+	return constant.RegionLabelIDPrefix + strconv.FormatUint(uint64(id), endpoint.SpaceIDBase)
 }
 
 // MakeTxnLabelRule makes the label rule for the given keyspace id, only for test
@@ -220,7 +220,7 @@ func buildLabelRule(id uint32, boundType regionBoundType) *labeler.LabelRule {
 		Index: 0,
 		Labels: []labeler.RegionLabel{
 			{
-				Key:   regionLabelKey,
+				Key:   constant.RegionLabelKey,
 				Value: strconv.FormatUint(uint64(id), endpoint.SpaceIDBase),
 			},
 		},
@@ -234,12 +234,16 @@ func buildLabelRule(id uint32, boundType regionBoundType) *labeler.LabelRule {
 // rule is a keyspace label rule.
 func ParseKeyspaceIDFromLabelRule(rule *labeler.LabelRule) (uint32, bool) {
 	// Validate the ID matches the expected format "keyspaces/<id>".
-	if rule == nil || !strings.HasPrefix(rule.ID, regionLabelIDPrefix) {
+	if rule == nil {
+		return 0, false
+	}
+	idText, ok := strings.CutPrefix(rule.ID, constant.RegionLabelIDPrefix)
+	if !ok {
 		return 0, false
 	}
 	// Retrieve the keyspace ID.
 	keyspaceID, err := strconv.ParseUint(
-		strings.TrimPrefix(rule.ID, regionLabelIDPrefix),
+		idText,
 		endpoint.SpaceIDBase, 32,
 	)
 	if err != nil {
@@ -248,7 +252,7 @@ func ParseKeyspaceIDFromLabelRule(rule *labeler.LabelRule) (uint32, bool) {
 	// Double check the keyspace ID from the label rule.
 	var idFromLabel uint64
 	for _, label := range rule.Labels {
-		if label.Key == regionLabelKey {
+		if label.Key == constant.RegionLabelKey {
 			idFromLabel, err = strconv.ParseUint(label.Value, endpoint.SpaceIDBase, 32)
 			if err != nil {
 				return 0, false

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -241,10 +241,8 @@ func ParseKeyspaceIDFromLabelRule(rule *labeler.LabelRule) (uint32, bool) {
 		idText,
 		endpoint.SpaceIDBase, 32,
 	)
-	nonCanonicalID := len(idText) == 0 || idText[0] == '+' || len(idText) > 1 && idText[0] == '0'
-	if err != nil ||
-		keyspaceID > uint64(constant.MaxValidKeyspaceID) ||
-		nonCanonicalID {
+	hasLeadingZero := len(idText) > 1 && idText[0] == '0'
+	if err != nil || keyspaceID > uint64(constant.MaxValidKeyspaceID) || hasLeadingZero {
 		return 0, false
 	}
 	// Double check the keyspace ID from the label rule.

--- a/pkg/keyspace/util.go
+++ b/pkg/keyspace/util.go
@@ -160,20 +160,15 @@ func keyTypeStringToRegionBoundType(keyType string) regionBoundType {
 
 // MakeRegionBound constructs the correct region boundaries of the given keyspace.
 func MakeRegionBound(id uint32) *RegionBound {
-	rawLeftBound := codec.MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id)
-	rawRightBound := codec.MakeKeyspacePrefix(codec.RawKeyspaceModePrefix, id+1)
-	txnLeftBound := codec.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id)
-	txnRightBound := codec.MakeKeyspacePrefix(codec.TxnKeyspaceModePrefix, id+1)
-	if id == constant.MaxValidKeyspaceID {
-		// The right bound is an exclusive fencepost, not a real keyspace prefix.
-		rawRightBound = []byte{'s', 0, 0, 0}
-		txnRightBound = []byte{'y', 0, 0, 0}
-	}
+	rawLeftBound := codec.EncodeKeyspaceBoundary(codec.RawKeyspaceModePrefix, id)
+	rawRightBound := codec.EncodeKeyspaceBoundary(codec.RawKeyspaceModePrefix, id+1)
+	txnLeftBound := codec.EncodeKeyspaceBoundary(codec.TxnKeyspaceModePrefix, id)
+	txnRightBound := codec.EncodeKeyspaceBoundary(codec.TxnKeyspaceModePrefix, id+1)
 	return &RegionBound{
-		RawLeftBound:  codec.EncodeBytes(rawLeftBound),
-		RawRightBound: codec.EncodeBytes(rawRightBound),
-		TxnLeftBound:  codec.EncodeBytes(txnLeftBound),
-		TxnRightBound: codec.EncodeBytes(txnRightBound),
+		RawLeftBound:  rawLeftBound[:],
+		RawRightBound: rawRightBound[:],
+		TxnLeftBound:  txnLeftBound[:],
+		TxnRightBound: txnRightBound[:],
 	}
 }
 
@@ -246,13 +241,20 @@ func ParseKeyspaceIDFromLabelRule(rule *labeler.LabelRule) (uint32, bool) {
 		idText,
 		endpoint.SpaceIDBase, 32,
 	)
-	if err != nil {
+	nonCanonicalID := len(idText) == 0 || idText[0] == '+' || len(idText) > 1 && idText[0] == '0'
+	if err != nil ||
+		keyspaceID > uint64(constant.MaxValidKeyspaceID) ||
+		nonCanonicalID {
 		return 0, false
 	}
 	// Double check the keyspace ID from the label rule.
-	var idFromLabel uint64
+	var (
+		idFromLabel  uint64
+		foundIDLabel bool
+	)
 	for _, label := range rule.Labels {
 		if label.Key == constant.RegionLabelKey {
+			foundIDLabel = true
 			idFromLabel, err = strconv.ParseUint(label.Value, endpoint.SpaceIDBase, 32)
 			if err != nil {
 				return 0, false
@@ -260,7 +262,7 @@ func ParseKeyspaceIDFromLabelRule(rule *labeler.LabelRule) (uint32, bool) {
 			break
 		}
 	}
-	if keyspaceID != idFromLabel {
+	if !foundIDLabel || keyspaceID != idFromLabel {
 		return 0, false
 	}
 	return uint32(keyspaceID), true

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -328,6 +329,29 @@ func TestParseKeyspaceIDFromLabelRule(t *testing.T) {
 			expectedID: 0,
 			expectedOK: false,
 		},
+		// Invalid keyspace label ID - non-canonical keyspace ID.
+		{
+			labelRule: &labeler.LabelRule{
+				ID:     "keyspaces/+1",
+				Labels: []labeler.RegionLabel{{Key: constant.RegionLabelKey, Value: "+1"}},
+			},
+			expectedID: 0,
+			expectedOK: false,
+		},
+		// Invalid keyspace label ID - out of valid keyspace range.
+		{
+			labelRule: &labeler.LabelRule{
+				ID: "keyspaces/" + strconv.FormatUint(uint64(constant.MaxValidKeyspaceID)+1, 10),
+				Labels: []labeler.RegionLabel{
+					{
+						Key:   constant.RegionLabelKey,
+						Value: strconv.FormatUint(uint64(constant.MaxValidKeyspaceID)+1, 10),
+					},
+				},
+			},
+			expectedID: 0,
+			expectedOK: false,
+		},
 		// Invalid keyspace label ID - invalid keyspace ID label rule.
 		{
 			labelRule: &labeler.LabelRule{
@@ -337,6 +361,20 @@ func TestParseKeyspaceIDFromLabelRule(t *testing.T) {
 					{
 						Key:   "not-id",
 						Value: "1",
+					},
+				},
+			},
+			expectedID: 0,
+			expectedOK: false,
+		},
+		// Invalid keyspace zero label rule - missing keyspace ID label.
+		{
+			labelRule: &labeler.LabelRule{
+				ID: getRegionLabelID(0),
+				Labels: []labeler.RegionLabel{
+					{
+						Key:   "not-id",
+						Value: "0",
 					},
 				},
 			},

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -291,7 +291,7 @@ func TestParseKeyspaceIDFromLabelRule(t *testing.T) {
 				Index: 0,
 				Labels: []labeler.RegionLabel{
 					{
-						Key:   regionLabelKey,
+						Key:   constant.RegionLabelKey,
 						Value: "1",
 					},
 				},
@@ -306,7 +306,7 @@ func TestParseKeyspaceIDFromLabelRule(t *testing.T) {
 				Index: 0,
 				Labels: []labeler.RegionLabel{
 					{
-						Key:   regionLabelKey,
+						Key:   constant.RegionLabelKey,
 						Value: "1",
 					},
 				},
@@ -320,7 +320,7 @@ func TestParseKeyspaceIDFromLabelRule(t *testing.T) {
 				Index: 0,
 				Labels: []labeler.RegionLabel{
 					{
-						Key:   regionLabelKey,
+						Key:   constant.RegionLabelKey,
 						Value: "1",
 					},
 				},

--- a/pkg/keyspace/util_test.go
+++ b/pkg/keyspace/util_test.go
@@ -332,8 +332,8 @@ func TestParseKeyspaceIDFromLabelRule(t *testing.T) {
 		// Invalid keyspace label ID - non-canonical keyspace ID.
 		{
 			labelRule: &labeler.LabelRule{
-				ID:     "keyspaces/+1",
-				Labels: []labeler.RegionLabel{{Key: constant.RegionLabelKey, Value: "+1"}},
+				ID:     "keyspaces/01",
+				Labels: []labeler.RegionLabel{{Key: constant.RegionLabelKey, Value: "01"}},
 			},
 			expectedID: 0,
 			expectedOK: false,

--- a/pkg/mcs/scheduling/server/rule/watcher.go
+++ b/pkg/mcs/scheduling/server/rule/watcher.go
@@ -253,7 +253,6 @@ func (rw *Watcher) initializeRegionLabelWatcher() error {
 	}
 	postEventsFn := func([]*clientv3.Event) error {
 		defer rw.regionLabeler.Unlock()
-		rw.regionLabeler.BuildRangeListLocked()
 		if rw.checkerController == nil {
 			return errors.New("checker controller is nil")
 		}

--- a/pkg/schedule/labeler/keyspace_index.go
+++ b/pkg/schedule/labeler/keyspace_index.go
@@ -17,7 +17,6 @@ package labeler
 import (
 	"bytes"
 	"math/bits"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -223,6 +222,10 @@ type keyspaceRuleIndex struct {
 	txn keyspaceRuleSet
 }
 
+func (i *keyspaceRuleIndex) isEmpty() bool {
+	return len(i.raw.chunks) == 0 && len(i.txn.chunks) == 0
+}
+
 func (i *keyspaceRuleIndex) ruleSet(mode byte) *keyspaceRuleSet {
 	switch mode {
 	case codec.RawKeyspaceModePrefix:
@@ -332,34 +335,39 @@ func (i *keyspaceRuleIndex) Contains(rule *LabelRule) bool {
 
 // GetRule returns the keyspace rule covering the whole range.
 func (i *keyspaceRuleIndex) GetRule(start, end []byte) *LabelRule {
+	rule, _ := i.matchRule(start, end)
+	return rule
+}
+
+func (i *keyspaceRuleIndex) matchRule(start, end []byte) (*LabelRule, bool) {
 	if len(end) == 0 {
-		return nil
+		return nil, false
 	}
 	mode, id, ok := codec.DecodeKeyspaceKey(start)
 	if !ok {
-		return nil
+		return nil, false
 	}
 	set := i.ruleSet(mode)
 	if set == nil {
-		return nil
+		return nil, false
 	}
 	rule := set.get(id)
-	if rule == nil {
-		return nil
+	if len(end) >= codec.KeyspacePrefixLen && bytes.Equal(start[:codec.KeyspacePrefixLen], end[:codec.KeyspacePrefixLen]) {
+		return rule, true
 	}
-	left := keyspaceBoundary(mode, id)
 	right := keyspaceBoundary(mode, id+1)
-	if bytes.Compare(start, left[:]) < 0 || bytes.Compare(end, right[:]) > 0 {
-		return nil
+	// DecodeKeyspaceKey guarantees that start is not below this ID's boundary.
+	if bytes.Compare(end, right[:]) > 0 {
+		return nil, false
 	}
-	return rule
+	return rule, true
 }
 
 // HasSplitKey reports whether a keyspace boundary exists in (start, end).
 func (i *keyspaceRuleIndex) HasSplitKey(start, end []byte) bool {
 	for _, mode := range codec.KeyspaceModes() {
 		set := i.ruleSet(mode)
-		if len(set.chunks) == 0 {
+		if len(set.chunks) == 0 || !keyspaceModeOverlapsRange(mode, start, end) {
 			continue
 		}
 		lo, hi := keyspaceBoundaryRange(mode, start, end)
@@ -380,7 +388,7 @@ func (i *keyspaceRuleIndex) GetSplitKeys(start, end []byte) [][]byte {
 	var keys [][]byte
 	for _, mode := range codec.KeyspaceModes() {
 		set := i.ruleSet(mode)
-		if len(set.chunks) == 0 {
+		if len(set.chunks) == 0 || !keyspaceModeOverlapsRange(mode, start, end) {
 			continue
 		}
 		lo, hi := keyspaceBoundaryRange(mode, start, end)
@@ -478,18 +486,80 @@ func keyspaceBoundaryBytes(mode byte, id uint32) []byte {
 }
 
 func keyspaceBoundaryRange(mode byte, start, end []byte) (lo, hi int) {
-	lo = sort.Search(keyspaceBoundaryCount, func(id int) bool {
-		key := keyspaceBoundary(mode, uint32(id))
-		return bytes.Compare(key[:], start) > 0
-	})
+	lo = keyspaceBoundaryBound(mode, start, true)
 	hi = keyspaceBoundaryCount
 	if len(end) > 0 {
-		hi = sort.Search(keyspaceBoundaryCount, func(id int) bool {
-			key := keyspaceBoundary(mode, uint32(id))
-			return bytes.Compare(key[:], end) >= 0
-		})
+		hi = keyspaceBoundaryBound(mode, end, false)
 	}
 	return lo, hi
+}
+
+func keyspaceModeOverlapsRange(mode byte, start, end []byte) bool {
+	first := keyspaceBoundary(mode, 0)
+	if len(end) > 0 && bytes.Compare(end, first[:]) <= 0 {
+		return false
+	}
+	fence := keyspaceBoundary(mode, uint32(keyspaceBoundaryCount-1))
+	return bytes.Compare(start, fence[:]) < 0
+}
+
+func keyspaceModesOverlapRange(start, end []byte) bool {
+	if len(end) > 0 {
+		switch {
+		case end[0] < codec.RawKeyspaceModePrefix:
+			return false
+		case end[0] == codec.RawKeyspaceModePrefix:
+			first := keyspaceBoundary(codec.RawKeyspaceModePrefix, 0)
+			if bytes.Compare(end, first[:]) <= 0 {
+				return false
+			}
+		}
+	}
+	if len(start) == 0 || start[0] < codec.TxnKeyspaceModePrefix+1 {
+		return true
+	}
+	if start[0] > codec.TxnKeyspaceModePrefix+1 {
+		return false
+	}
+	fence := keyspaceBoundary(codec.TxnKeyspaceModePrefix, uint32(keyspaceBoundaryCount-1))
+	return bytes.Compare(start, fence[:]) < 0
+}
+
+func keyspaceBoundaryBound(mode byte, key []byte, upper bool) int {
+	first := keyspaceBoundary(mode, 0)
+	if cmp := bytes.Compare(first[:], key); cmp > 0 || cmp == 0 && !upper {
+		return 0
+	}
+
+	fenceID := uint32(keyspaceBoundaryCount - 1)
+	fence := keyspaceBoundary(mode, fenceID)
+	if cmp := bytes.Compare(fence[:], key); cmp < 0 || cmp == 0 && upper {
+		return keyspaceBoundaryCount
+	} else if cmp == 0 {
+		return int(fenceID)
+	}
+
+	// A key between the last boundary of this mode and its fence belongs at
+	// the fence. This also handles a fence prefix shorter than the boundary.
+	if key[0] != mode {
+		return int(fenceID)
+	}
+
+	var id uint32
+	if len(key) > 1 {
+		id |= uint32(key[1]) << 16
+	}
+	if len(key) > 2 {
+		id |= uint32(key[2]) << 8
+	}
+	if len(key) > 3 {
+		id |= uint32(key[3])
+	}
+	boundary := keyspaceBoundary(mode, id)
+	if cmp := bytes.Compare(boundary[:], key); cmp > 0 || cmp == 0 && !upper {
+		return int(id)
+	}
+	return int(id) + 1
 }
 
 func mergeSplitKeys(left, right [][]byte) [][]byte {

--- a/pkg/schedule/labeler/keyspace_index.go
+++ b/pkg/schedule/labeler/keyspace_index.go
@@ -20,24 +20,21 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/tikv/pd/pkg/codec"
+	"github.com/tikv/pd/pkg/keyspace/constant"
 )
 
 const (
-	keyspaceRuleIDPrefix = "keyspaces/"
-	keyspaceIDLabelKey   = "id"
-	keyspaceRawMode      = byte('r')
-	keyspaceTxnMode      = byte('x')
-	keyspaceMaxID        = uint32(1<<24 - 1)
-
 	keyspaceChunkBits  = 10
 	keyspaceChunkSize  = 1 << keyspaceChunkBits
 	keyspaceChunkMask  = keyspaceChunkSize - 1
 	keyspaceChunkWords = keyspaceChunkSize / 64
 
-	keyspaceChunkCount           = (int(keyspaceMaxID) + 1 + keyspaceChunkSize - 1) / keyspaceChunkSize
-	keyspaceChunkMapWords        = (keyspaceChunkCount + 63) / 64
-	keyspaceChunkMapSummaryWords = (keyspaceChunkMapWords + 63) / 64
-	keyspaceBoundCount           = int(keyspaceMaxID) + 2
+	keyspaceChunkCount              = (int(constant.MaxValidKeyspaceID) + 1 + keyspaceChunkSize - 1) / keyspaceChunkSize
+	keyspaceChunkBitmapWords        = (keyspaceChunkCount + 63) / 64
+	keyspaceChunkBitmapSummaryWords = (keyspaceChunkBitmapWords + 63) / 64
+	keyspaceBoundaryCount           = int(constant.MaxValidKeyspaceID) + 2
 )
 
 // A keyspace rule has one fixed-width range per enabled API mode. Keeping
@@ -52,13 +49,13 @@ type keyspaceRuleChunk struct {
 }
 
 type keyspaceRuleSet struct {
-	chunks                []*keyspaceRuleChunk
-	nonEmptyChunks        [keyspaceChunkMapWords]uint64
-	nonEmptyChunkMapWords [keyspaceChunkMapSummaryWords]uint64
+	chunks                     []*keyspaceRuleChunk
+	nonEmptyChunkBitmap        [keyspaceChunkBitmapWords]uint64
+	nonEmptyChunkBitmapSummary [keyspaceChunkBitmapSummaryWords]uint64
 }
 
 func (s *keyspaceRuleSet) get(id uint32) *LabelRule {
-	if len(s.chunks) == 0 || id > keyspaceMaxID {
+	if len(s.chunks) == 0 || id > constant.MaxValidKeyspaceID {
 		return nil
 	}
 	chunkID := int(id) >> keyspaceChunkBits
@@ -81,10 +78,10 @@ func (s *keyspaceRuleSet) set(id uint32, rule *LabelRule) {
 	if s.chunks[chunkID] == nil {
 		s.chunks[chunkID] = new(keyspaceRuleChunk)
 		word := chunkID >> 6
-		if s.nonEmptyChunks[word] == 0 {
-			s.nonEmptyChunkMapWords[word>>6] |= uint64(1) << (word & 63)
+		if s.nonEmptyChunkBitmap[word] == 0 {
+			s.nonEmptyChunkBitmapSummary[word>>6] |= uint64(1) << (word & 63)
 		}
-		s.nonEmptyChunks[word] |= uint64(1) << (chunkID & 63)
+		s.nonEmptyChunkBitmap[word] |= uint64(1) << (chunkID & 63)
 	}
 	chunk := s.chunks[chunkID]
 	slot := int(id) & keyspaceChunkMask
@@ -100,7 +97,7 @@ func (s *keyspaceRuleSet) replace(id uint32, rule *LabelRule) {
 
 func (s *keyspaceRuleSet) clear(id uint32) {
 	// Remove checks that the target slot is owned before calling clear.
-	if len(s.chunks) == 0 || id > keyspaceMaxID {
+	if len(s.chunks) == 0 || id > constant.MaxValidKeyspaceID {
 		return
 	}
 	chunkID := int(id) >> keyspaceChunkBits
@@ -118,9 +115,9 @@ func (s *keyspaceRuleSet) clear(id uint32) {
 	if chunk.count == 0 {
 		s.chunks[chunkID] = nil
 		word := chunkID >> 6
-		s.nonEmptyChunks[word] &^= uint64(1) << (chunkID & 63)
-		if s.nonEmptyChunks[word] == 0 {
-			s.nonEmptyChunkMapWords[word>>6] &^= uint64(1) << (word & 63)
+		s.nonEmptyChunkBitmap[word] &^= uint64(1) << (chunkID & 63)
+		if s.nonEmptyChunkBitmap[word] == 0 {
+			s.nonEmptyChunkBitmapSummary[word>>6] &^= uint64(1) << (word & 63)
 		}
 		for len(s.chunks) > 0 && s.chunks[len(s.chunks)-1] == nil {
 			s.chunks = s.chunks[:len(s.chunks)-1]
@@ -133,7 +130,7 @@ func (s *keyspaceRuleSet) forEachSlot(lo, hi int, fn func(id uint32) bool) {
 		return
 	}
 	lo = max(lo, 0)
-	hi = min(hi, int(keyspaceMaxID)+1)
+	hi = min(hi, int(constant.MaxValidKeyspaceID)+1)
 	if lo >= hi {
 		return
 	}
@@ -142,7 +139,7 @@ func (s *keyspaceRuleSet) forEachSlot(lo, hi int, fn func(id uint32) bool) {
 	firstChunkWord, lastChunkWord := firstChunk>>6, lastChunk>>6
 	firstSummaryWord, lastSummaryWord := firstChunkWord>>6, lastChunkWord>>6
 	for summaryWord := firstSummaryWord; summaryWord <= lastSummaryWord; summaryWord++ {
-		chunkWords := s.nonEmptyChunkMapWords[summaryWord]
+		chunkWords := s.nonEmptyChunkBitmapSummary[summaryWord]
 		if offset := firstChunkWord & 63; summaryWord == firstSummaryWord && offset != 0 {
 			chunkWords &= ^uint64(0) << offset
 		}
@@ -152,7 +149,7 @@ func (s *keyspaceRuleSet) forEachSlot(lo, hi int, fn func(id uint32) bool) {
 		for chunkWords != 0 {
 			chunkWordBit := bits.TrailingZeros64(chunkWords)
 			chunkWord := (summaryWord << 6) + chunkWordBit
-			chunks := s.nonEmptyChunks[chunkWord]
+			chunks := s.nonEmptyChunkBitmap[chunkWord]
 			if offset := firstChunk & 63; chunkWord == firstChunkWord && offset != 0 {
 				chunks &= ^uint64(0) << offset
 			}
@@ -196,7 +193,7 @@ func (s *keyspaceRuleSet) forEachBoundary(lo, hi int, fn func(id uint32) bool) {
 		return
 	}
 	lo = max(lo, 0)
-	hi = min(hi, keyspaceBoundCount)
+	hi = min(hi, keyspaceBoundaryCount)
 	lastBoundary := -1
 	emit := func(boundary int) bool {
 		if boundary < lo || boundary >= hi || boundary == lastBoundary {
@@ -226,9 +223,9 @@ type keyspaceRuleIndex struct {
 
 func (i *keyspaceRuleIndex) ruleSet(mode byte) *keyspaceRuleSet {
 	switch mode {
-	case keyspaceRawMode:
+	case codec.RawKeyspaceModePrefix:
 		return &i.raw
-	case keyspaceTxnMode:
+	case codec.TxnKeyspaceModePrefix:
 		return &i.txn
 	default:
 		return nil
@@ -263,7 +260,7 @@ func (i *keyspaceRuleIndex) Replace(old, rule *LabelRule) bool {
 	}
 	id := ranges[0].id
 	owned := false
-	for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 		if i.ruleSet(mode).get(id) == old {
 			owned = true
 		}
@@ -277,7 +274,7 @@ func (i *keyspaceRuleIndex) Replace(old, rule *LabelRule) bool {
 		}
 	}
 
-	for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 		set := i.ruleSet(mode)
 		current := set.get(id)
 		wanted := false
@@ -307,7 +304,7 @@ func (i *keyspaceRuleIndex) Remove(ruleID string, rule *LabelRule) bool {
 		return false
 	}
 	removed := false
-	for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 		set := i.ruleSet(mode)
 		if set.get(id) == rule {
 			set.clear(id)
@@ -356,7 +353,7 @@ func (i *keyspaceRuleIndex) GetRule(start, end []byte) *LabelRule {
 
 // HasSplitKey reports whether a keyspace boundary exists in (start, end).
 func (i *keyspaceRuleIndex) HasSplitKey(start, end []byte) bool {
-	for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 		set := i.ruleSet(mode)
 		if len(set.chunks) == 0 {
 			continue
@@ -377,7 +374,7 @@ func (i *keyspaceRuleIndex) HasSplitKey(start, end []byte) bool {
 // GetSplitKeys returns all indexed keyspace boundaries in (start, end).
 func (i *keyspaceRuleIndex) GetSplitKeys(start, end []byte) [][]byte {
 	var keys [][]byte
-	for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 		set := i.ruleSet(mode)
 		if len(set.chunks) == 0 {
 			continue
@@ -397,7 +394,7 @@ func keyspaceRanges(rule *LabelRule) ([2]keyspaceRuleRange, int, bool) {
 		return ranges, 0, false
 	}
 	label := rule.Labels[0]
-	if label.Key != keyspaceIDLabelKey || label.TTL != "" || label.StartAt != "" || label.expire != nil {
+	if label.Key != constant.RegionLabelKey || label.TTL != "" || label.StartAt != "" || label.expire != nil {
 		return ranges, 0, false
 	}
 	id, idText, ok := parseKeyspaceRuleID(rule.ID)
@@ -416,12 +413,12 @@ func keyspaceRanges(rule *LabelRule) ([2]keyspaceRuleRange, int, bool) {
 			return ranges, 0, false
 		}
 		switch mode {
-		case keyspaceRawMode:
+		case codec.RawKeyspaceModePrefix:
 			if seenRaw {
 				return ranges, 0, false
 			}
 			seenRaw = true
-		case keyspaceTxnMode:
+		case codec.TxnKeyspaceModePrefix:
 			if seenTxn {
 				return ranges, 0, false
 			}
@@ -441,13 +438,13 @@ func keyspaceRanges(rule *LabelRule) ([2]keyspaceRuleRange, int, bool) {
 }
 
 func parseKeyspaceRuleID(ruleID string) (uint32, string, bool) {
-	if !strings.HasPrefix(ruleID, keyspaceRuleIDPrefix) {
+	idText, ok := strings.CutPrefix(ruleID, constant.RegionLabelIDPrefix)
+	if !ok {
 		return 0, "", false
 	}
-	idText := strings.TrimPrefix(ruleID, keyspaceRuleIDPrefix)
 	id64, err := strconv.ParseUint(idText, 10, 32)
 	hasLeadingZero := len(idText) > 1 && idText[0] == '0'
-	if err != nil || id64 > uint64(keyspaceMaxID) || hasLeadingZero {
+	if err != nil || id64 > uint64(constant.MaxValidKeyspaceID) || hasLeadingZero {
 		return 0, "", false
 	}
 	return uint32(id64), idText, true
@@ -457,7 +454,7 @@ func canonicalKeyspaceRange(keyRange *KeyRangeRule, id uint32) (byte, bool) {
 	if keyRange == nil {
 		return 0, false
 	}
-	for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 		start := keyspaceBoundary(mode, id)
 		end := keyspaceBoundary(mode, id+1)
 		if bytes.Equal(keyRange.StartKey, start[:]) && bytes.Equal(keyRange.EndKey, end[:]) {
@@ -471,7 +468,7 @@ func canonicalKeyspaceRange(keyRange *KeyRangeRule, id uint32) (byte, bool) {
 // always four bytes, so its memcomparable encoding is a fixed nine-byte value.
 // max-id+1 is the exclusive fencepost in the next mode byte.
 func keyspaceBoundary(mode byte, id uint32) [9]byte {
-	if id > keyspaceMaxID {
+	if id > constant.MaxValidKeyspaceID {
 		mode++
 		id = 0
 	}
@@ -491,13 +488,13 @@ func keyspaceBoundaryBytes(mode byte, id uint32) []byte {
 }
 
 func keyspaceBoundaryRange(mode byte, start, end []byte) (lo, hi int) {
-	lo = sort.Search(keyspaceBoundCount, func(id int) bool {
+	lo = sort.Search(keyspaceBoundaryCount, func(id int) bool {
 		key := keyspaceBoundary(mode, uint32(id))
 		return bytes.Compare(key[:], start) > 0
 	})
-	hi = keyspaceBoundCount
+	hi = keyspaceBoundaryCount
 	if len(end) > 0 {
-		hi = sort.Search(keyspaceBoundCount, func(id int) bool {
+		hi = sort.Search(keyspaceBoundaryCount, func(id int) bool {
 			key := keyspaceBoundary(mode, uint32(id))
 			return bytes.Compare(key[:], end) >= 0
 		})

--- a/pkg/schedule/labeler/keyspace_index.go
+++ b/pkg/schedule/labeler/keyspace_index.go
@@ -33,15 +33,18 @@ const (
 	keyspaceChunkSize  = 1 << keyspaceChunkBits
 	keyspaceChunkMask  = keyspaceChunkSize - 1
 	keyspaceChunkWords = keyspaceChunkSize / 64
-	keyspaceSlotWords  = (int(keyspaceMaxID) + 1) / 64
-	keyspaceBoundCount = int(keyspaceMaxID) + 2
+
+	keyspaceChunkCount           = (int(keyspaceMaxID) + 1 + keyspaceChunkSize - 1) / keyspaceChunkSize
+	keyspaceChunkMapWords        = (keyspaceChunkCount + 63) / 64
+	keyspaceChunkMapSummaryWords = (keyspaceChunkMapWords + 63) / 64
+	keyspaceBoundCount           = int(keyspaceMaxID) + 2
 )
 
 // A keyspace rule has one fixed-width range per enabled API mode. Keeping
 // these ranges in sparse slots avoids materializing two split points and a
-// segment for every keyspace. Presence bits live with their sparse chunks so
-// small keyspace counts don't allocate a bitset for the entire ID space. The
-// rule remains owned by RegionLabeler's labelRules map.
+// segment for every keyspace. Slot presence bits live with their sparse chunks,
+// while a compact two-level chunk bitmap lets range scans skip unallocated ID
+// spans. The rule remains owned by RegionLabeler's labelRules map.
 type keyspaceRuleChunk struct {
 	rules [keyspaceChunkSize]*LabelRule
 	bits  [keyspaceChunkWords]uint64
@@ -49,7 +52,9 @@ type keyspaceRuleChunk struct {
 }
 
 type keyspaceRuleSet struct {
-	chunks []*keyspaceRuleChunk
+	chunks                []*keyspaceRuleChunk
+	nonEmptyChunks        [keyspaceChunkMapWords]uint64
+	nonEmptyChunkMapWords [keyspaceChunkMapSummaryWords]uint64
 }
 
 func (s *keyspaceRuleSet) get(id uint32) *LabelRule {
@@ -75,6 +80,11 @@ func (s *keyspaceRuleSet) set(id uint32, rule *LabelRule) {
 	}
 	if s.chunks[chunkID] == nil {
 		s.chunks[chunkID] = new(keyspaceRuleChunk)
+		word := chunkID >> 6
+		if s.nonEmptyChunks[word] == 0 {
+			s.nonEmptyChunkMapWords[word>>6] |= uint64(1) << (word & 63)
+		}
+		s.nonEmptyChunks[word] |= uint64(1) << (chunkID & 63)
 	}
 	chunk := s.chunks[chunkID]
 	slot := int(id) & keyspaceChunkMask
@@ -107,35 +117,78 @@ func (s *keyspaceRuleSet) clear(id uint32) {
 	chunk.count--
 	if chunk.count == 0 {
 		s.chunks[chunkID] = nil
+		word := chunkID >> 6
+		s.nonEmptyChunks[word] &^= uint64(1) << (chunkID & 63)
+		if s.nonEmptyChunks[word] == 0 {
+			s.nonEmptyChunkMapWords[word>>6] &^= uint64(1) << (word & 63)
+		}
 		for len(s.chunks) > 0 && s.chunks[len(s.chunks)-1] == nil {
 			s.chunks = s.chunks[:len(s.chunks)-1]
 		}
 	}
 }
 
-func (s *keyspaceRuleSet) slotWord(word int) uint64 {
-	if word < 0 || word >= keyspaceSlotWords {
-		return 0
+func (s *keyspaceRuleSet) forEachSlot(lo, hi int, fn func(id uint32) bool) {
+	if len(s.chunks) == 0 || lo >= hi {
+		return
 	}
-	chunkID := word / keyspaceChunkWords
-	if chunkID >= len(s.chunks) || s.chunks[chunkID] == nil {
-		return 0
+	lo = max(lo, 0)
+	hi = min(hi, int(keyspaceMaxID)+1)
+	if lo >= hi {
+		return
 	}
-	return s.chunks[chunkID].bits[word%keyspaceChunkWords]
-}
 
-// boundaryWord returns the boundaries contributed by the slots in word.
-// A slot at ID n contributes both boundary n and boundary n+1.
-func (s *keyspaceRuleSet) boundaryWord(word int) uint64 {
-	if len(s.chunks) == 0 || word < 0 || word > keyspaceSlotWords {
-		return 0
+	firstChunk, lastChunk := lo>>keyspaceChunkBits, (hi-1)>>keyspaceChunkBits
+	firstChunkWord, lastChunkWord := firstChunk>>6, lastChunk>>6
+	firstSummaryWord, lastSummaryWord := firstChunkWord>>6, lastChunkWord>>6
+	for summaryWord := firstSummaryWord; summaryWord <= lastSummaryWord; summaryWord++ {
+		chunkWords := s.nonEmptyChunkMapWords[summaryWord]
+		if offset := firstChunkWord & 63; summaryWord == firstSummaryWord && offset != 0 {
+			chunkWords &= ^uint64(0) << offset
+		}
+		if offset := (lastChunkWord & 63) + 1; summaryWord == lastSummaryWord && offset != 64 {
+			chunkWords &= (uint64(1) << offset) - 1
+		}
+		for chunkWords != 0 {
+			chunkWordBit := bits.TrailingZeros64(chunkWords)
+			chunkWord := (summaryWord << 6) + chunkWordBit
+			chunks := s.nonEmptyChunks[chunkWord]
+			if offset := firstChunk & 63; chunkWord == firstChunkWord && offset != 0 {
+				chunks &= ^uint64(0) << offset
+			}
+			if offset := (lastChunk & 63) + 1; chunkWord == lastChunkWord && offset != 64 {
+				chunks &= (uint64(1) << offset) - 1
+			}
+			for chunks != 0 {
+				chunkBit := bits.TrailingZeros64(chunks)
+				chunkID := (chunkWord << 6) + chunkBit
+				chunk := s.chunks[chunkID]
+				chunkStart := chunkID << keyspaceChunkBits
+				localLo := max(lo-chunkStart, 0)
+				localHi := min(hi-chunkStart, keyspaceChunkSize)
+				firstWord, lastWord := localLo>>6, (localHi-1)>>6
+				for word := firstWord; word <= lastWord; word++ {
+					slots := chunk.bits[word]
+					if offset := localLo & 63; word == firstWord && offset != 0 {
+						slots &= ^uint64(0) << offset
+					}
+					if offset := localHi & 63; word == lastWord && offset != 0 {
+						slots &= (uint64(1) << offset) - 1
+					}
+					for slots != 0 {
+						bit := bits.TrailingZeros64(slots)
+						id := chunkStart + (word << 6) + bit
+						if !fn(uint32(id)) {
+							return
+						}
+						slots &= slots - 1
+					}
+				}
+				chunks &= chunks - 1
+			}
+			chunkWords &= chunkWords - 1
+		}
 	}
-	current := s.slotWord(word)
-	boundaries := current | current<<1
-	if word > 0 && s.slotWord(word-1)&(uint64(1)<<63) != 0 {
-		boundaries |= 1
-	}
-	return boundaries
 }
 
 func (s *keyspaceRuleSet) forEachBoundary(lo, hi int, fn func(id uint32) bool) {
@@ -144,36 +197,18 @@ func (s *keyspaceRuleSet) forEachBoundary(lo, hi int, fn func(id uint32) bool) {
 	}
 	lo = max(lo, 0)
 	hi = min(hi, keyspaceBoundCount)
-	firstWord, lastWord := lo>>6, (hi-1)>>6
-	firstChunk := firstWord / keyspaceChunkWords
-	lastChunk := min(lastWord/keyspaceChunkWords, len(s.chunks))
-	for chunkID := firstChunk; chunkID <= lastChunk; chunkID++ {
-		chunkFirstWord := chunkID * keyspaceChunkWords
-		wordStart := max(firstWord, chunkFirstWord)
-		wordEnd := min(lastWord, chunkFirstWord+keyspaceChunkWords-1)
-		var chunk *keyspaceRuleChunk
-		if chunkID < len(s.chunks) {
-			chunk = s.chunks[chunkID]
+	lastBoundary := -1
+	emit := func(boundary int) bool {
+		if boundary < lo || boundary >= hi || boundary == lastBoundary {
+			return true
 		}
-		hasCarry := wordStart == chunkFirstWord && s.slotWord(wordStart-1)&(uint64(1)<<63) != 0
-		if chunk == nil && !hasCarry {
-			continue
-		}
-		for word := wordStart; word <= wordEnd; word++ {
-			boundaries := s.boundaryWord(word)
-			if offset := lo & 63; word == firstWord && offset != 0 {
-				boundaries &= ^uint64(0) << offset
-			}
-			for boundaries != 0 {
-				bit := bits.TrailingZeros64(boundaries)
-				id := word<<6 + bit
-				if id >= hi || !fn(uint32(id)) {
-					return
-				}
-				boundaries &= boundaries - 1
-			}
-		}
+		lastBoundary = boundary
+		return fn(uint32(boundary))
 	}
+	s.forEachSlot(lo-1, hi, func(id uint32) bool {
+		boundary := int(id)
+		return emit(boundary) && emit(boundary+1)
+	})
 }
 
 type keyspaceRuleRange struct {

--- a/pkg/schedule/labeler/keyspace_index.go
+++ b/pkg/schedule/labeler/keyspace_index.go
@@ -447,10 +447,8 @@ func parseKeyspaceRuleID(ruleID string) (uint32, string, bool) {
 		return 0, "", false
 	}
 	id64, err := strconv.ParseUint(idText, 10, 32)
-	nonCanonicalID := len(idText) == 0 || idText[0] == '+' || len(idText) > 1 && idText[0] == '0'
-	if err != nil ||
-		id64 > uint64(constant.MaxValidKeyspaceID) ||
-		nonCanonicalID {
+	hasLeadingZero := len(idText) > 1 && idText[0] == '0'
+	if err != nil || id64 > uint64(constant.MaxValidKeyspaceID) || hasLeadingZero {
 		return 0, "", false
 	}
 	return uint32(id64), idText, true

--- a/pkg/schedule/labeler/keyspace_index.go
+++ b/pkg/schedule/labeler/keyspace_index.go
@@ -41,7 +41,7 @@ const (
 // these ranges in sparse slots avoids materializing two split points and a
 // segment for every keyspace. Slot presence bits live with their sparse chunks,
 // while a compact two-level chunk bitmap lets range scans skip unallocated ID
-// spans. The rule remains owned by RegionLabeler's labelRules map.
+// spans. The rule remains owned by labelRuleIndex's authoritative map.
 type keyspaceRuleChunk struct {
 	rules [keyspaceChunkSize]*LabelRule
 	bits  [keyspaceChunkWords]uint64
@@ -125,6 +125,8 @@ func (s *keyspaceRuleSet) clear(id uint32) {
 	}
 }
 
+// forEachSlot visits populated keyspace IDs in ascending order within [lo, hi),
+// stopping early when fn returns false.
 func (s *keyspaceRuleSet) forEachSlot(lo, hi int, fn func(id uint32) bool) {
 	if len(s.chunks) == 0 || lo >= hi {
 		return
@@ -260,7 +262,7 @@ func (i *keyspaceRuleIndex) Replace(old, rule *LabelRule) bool {
 	}
 	id := ranges[0].id
 	owned := false
-	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+	for _, mode := range codec.KeyspaceModes() {
 		if i.ruleSet(mode).get(id) == old {
 			owned = true
 		}
@@ -274,7 +276,7 @@ func (i *keyspaceRuleIndex) Replace(old, rule *LabelRule) bool {
 		}
 	}
 
-	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+	for _, mode := range codec.KeyspaceModes() {
 		set := i.ruleSet(mode)
 		current := set.get(id)
 		wanted := false
@@ -304,7 +306,7 @@ func (i *keyspaceRuleIndex) Remove(ruleID string, rule *LabelRule) bool {
 		return false
 	}
 	removed := false
-	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+	for _, mode := range codec.KeyspaceModes() {
 		set := i.ruleSet(mode)
 		if set.get(id) == rule {
 			set.clear(id)
@@ -330,15 +332,17 @@ func (i *keyspaceRuleIndex) Contains(rule *LabelRule) bool {
 
 // GetRule returns the keyspace rule covering the whole range.
 func (i *keyspaceRuleIndex) GetRule(start, end []byte) *LabelRule {
-	if len(start) < 9 || start[8] < 0xfb || len(end) == 0 {
+	if len(end) == 0 {
 		return nil
 	}
-	mode := start[0]
+	mode, id, ok := codec.DecodeKeyspaceKey(start)
+	if !ok {
+		return nil
+	}
 	set := i.ruleSet(mode)
 	if set == nil {
 		return nil
 	}
-	id := uint32(start[1])<<16 | uint32(start[2])<<8 | uint32(start[3])
 	rule := set.get(id)
 	if rule == nil {
 		return nil
@@ -353,7 +357,7 @@ func (i *keyspaceRuleIndex) GetRule(start, end []byte) *LabelRule {
 
 // HasSplitKey reports whether a keyspace boundary exists in (start, end).
 func (i *keyspaceRuleIndex) HasSplitKey(start, end []byte) bool {
-	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+	for _, mode := range codec.KeyspaceModes() {
 		set := i.ruleSet(mode)
 		if len(set.chunks) == 0 {
 			continue
@@ -374,7 +378,7 @@ func (i *keyspaceRuleIndex) HasSplitKey(start, end []byte) bool {
 // GetSplitKeys returns all indexed keyspace boundaries in (start, end).
 func (i *keyspaceRuleIndex) GetSplitKeys(start, end []byte) [][]byte {
 	var keys [][]byte
-	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+	for _, mode := range codec.KeyspaceModes() {
 		set := i.ruleSet(mode)
 		if len(set.chunks) == 0 {
 			continue
@@ -443,8 +447,10 @@ func parseKeyspaceRuleID(ruleID string) (uint32, string, bool) {
 		return 0, "", false
 	}
 	id64, err := strconv.ParseUint(idText, 10, 32)
-	hasLeadingZero := len(idText) > 1 && idText[0] == '0'
-	if err != nil || id64 > uint64(constant.MaxValidKeyspaceID) || hasLeadingZero {
+	nonCanonicalID := len(idText) == 0 || idText[0] == '+' || len(idText) > 1 && idText[0] == '0'
+	if err != nil ||
+		id64 > uint64(constant.MaxValidKeyspaceID) ||
+		nonCanonicalID {
 		return 0, "", false
 	}
 	return uint32(id64), idText, true
@@ -454,7 +460,7 @@ func canonicalKeyspaceRange(keyRange *KeyRangeRule, id uint32) (byte, bool) {
 	if keyRange == nil {
 		return 0, false
 	}
-	for _, mode := range [2]byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+	for _, mode := range codec.KeyspaceModes() {
 		start := keyspaceBoundary(mode, id)
 		end := keyspaceBoundary(mode, id+1)
 		if bytes.Equal(keyRange.StartKey, start[:]) && bytes.Equal(keyRange.EndKey, end[:]) {
@@ -464,22 +470,8 @@ func canonicalKeyspaceRange(keyRange *KeyRangeRule, id uint32) (byte, bool) {
 	return 0, false
 }
 
-// keyspaceBoundary returns codec.EncodeBytes([mode, keyspace-id]). The input is
-// always four bytes, so its memcomparable encoding is a fixed nine-byte value.
-// max-id+1 is the exclusive fencepost in the next mode byte.
 func keyspaceBoundary(mode byte, id uint32) [9]byte {
-	if id > constant.MaxValidKeyspaceID {
-		mode++
-		id = 0
-	}
-	return [9]byte{
-		mode,
-		byte(id >> 16),
-		byte(id >> 8),
-		byte(id),
-		0, 0, 0, 0,
-		0xfb,
-	}
+	return codec.EncodeKeyspaceBoundary(mode, id)
 }
 
 func keyspaceBoundaryBytes(mode byte, id uint32) []byte {

--- a/pkg/schedule/labeler/keyspace_index_test.go
+++ b/pkg/schedule/labeler/keyspace_index_test.go
@@ -111,8 +111,8 @@ func TestKeyspaceRuleIndex(t *testing.T) {
 func TestKeyspaceRuleIndexRejectsNonCanonicalID(t *testing.T) {
 	re := require.New(t)
 	rule := makeKeyspaceRuleForTest(1, codec.TxnKeyspaceModePrefix)
-	rule.ID = constant.RegionLabelIDPrefix + "+1"
-	rule.Labels[0].Value = "+1"
+	rule.ID = constant.RegionLabelIDPrefix + "01"
+	rule.Labels[0].Value = "01"
 	re.NoError(rule.checkAndAdjust())
 
 	var index keyspaceRuleIndex
@@ -391,9 +391,24 @@ func TestRegionLabelerUpdatesKeyspaceRulesIncrementally(t *testing.T) {
 	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix), constant.RegionLabelKey))
 	re.Equal("42", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), constant.RegionLabelKey))
 
-	re.NoError(regionLabeler.DeleteLabelRule(updated.ID))
-	re.False(regionLabeler.ruleIndex.rangesDirty)
+	// Moving a rule between the canonical and generic indexes keeps the two
+	// derived views in sync with the authoritative map.
+	genericReplacement := makeKeyspaceRuleForTest(42, codec.TxnKeyspaceModePrefix)
+	genericReplacement.Labels[0].Key = "generic-replacement"
+	re.NoError(regionLabeler.SetLabelRule(genericReplacement))
 	re.False(regionLabeler.ruleIndex.keyspaces.Contains(updated))
+	re.Contains(regionLabeler.ruleIndex.generic, genericReplacement.ID)
+	re.Equal("42", regionLabeler.GetRegionLabel(
+		makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), "generic-replacement"))
+
+	restored := makeKeyspaceRuleForTest(42, codec.TxnKeyspaceModePrefix)
+	re.NoError(regionLabeler.SetLabelRule(restored))
+	re.True(regionLabeler.ruleIndex.keyspaces.Contains(restored))
+	re.NotContains(regionLabeler.ruleIndex.generic, restored.ID)
+
+	re.NoError(regionLabeler.DeleteLabelRule(restored.ID))
+	re.False(regionLabeler.ruleIndex.rangesDirty)
+	re.False(regionLabeler.ruleIndex.keyspaces.Contains(restored))
 	re.Equal("yes", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), "generic"))
 }
 

--- a/pkg/schedule/labeler/keyspace_index_test.go
+++ b/pkg/schedule/labeler/keyspace_index_test.go
@@ -15,6 +15,7 @@
 package labeler
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -157,10 +158,61 @@ func TestKeyspaceRuleIndexSparseGap(t *testing.T) {
 
 	var index keyspaceRuleIndex
 	re.True(index.Add(rule))
+	gapRegion := makeRegionForKeyspace(1, codec.TxnKeyspaceModePrefix)
+	matched, withinKeyspace := index.matchRule(gapRegion.GetStartKey(), gapRegion.GetEndKey())
+	re.Nil(matched)
+	re.True(withinKeyspace)
+	labelIndex := newLabelRuleIndex(map[string]*LabelRule{rule.ID: rule})
+	rangeRules, keyspaceRule, ok := labelIndex.getRangeRules(gapRegion.GetStartKey(), gapRegion.GetEndKey())
+	re.True(ok)
+	re.Empty(rangeRules)
+	re.Nil(keyspaceRule)
+	rangeRules, keyspaceRule, ok = labelIndex.getRangeRules([]byte{'a'}, []byte{'b'})
+	re.True(ok)
+	re.Empty(rangeRules)
+	re.Nil(keyspaceRule)
 	start := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 0)
 	end := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, constant.MaxValidKeyspaceID)
 	re.Empty(index.GetSplitKeys(start, end))
 	re.False(index.HasSplitKey(start, end))
+	afterFence := []byte{'z'}
+	re.Empty(index.GetSplitKeys(afterFence, nil))
+	re.False(index.HasSplitKey(afterFence, nil))
+}
+
+func TestKeyspaceBoundaryBoundMatchesBinarySearch(t *testing.T) {
+	re := require.New(t)
+	keys := [][]byte{nil, {'a'}, {'z'}, {0xff}}
+	for _, mode := range codec.KeyspaceModes() {
+		keys = append(keys, []byte{mode}, []byte{mode, 1}, []byte{mode + 1})
+		for _, id := range []uint32{0, 1, 63, 64, 1023, 1024, constant.MaxValidKeyspaceID, constant.MaxValidKeyspaceID + 1} {
+			boundary := keyspaceBoundary(mode, id)
+			exact := append([]byte(nil), boundary[:]...)
+			before := append([]byte(nil), boundary[:]...)
+			before[len(before)-1]--
+			after := append([]byte(nil), boundary[:]...)
+			after[len(after)-1]++
+			keys = append(keys, exact, before, after)
+			for length := 1; length < len(boundary); length++ {
+				keys = append(keys, append([]byte(nil), boundary[:length]...))
+			}
+		}
+	}
+
+	for _, mode := range codec.KeyspaceModes() {
+		for _, key := range keys {
+			lower := sort.Search(keyspaceBoundaryCount, func(id int) bool {
+				boundary := keyspaceBoundary(mode, uint32(id))
+				return bytes.Compare(boundary[:], key) >= 0
+			})
+			upper := sort.Search(keyspaceBoundaryCount, func(id int) bool {
+				boundary := keyspaceBoundary(mode, uint32(id))
+				return bytes.Compare(boundary[:], key) > 0
+			})
+			re.Equal(lower, keyspaceBoundaryBound(mode, key, false), "lower bound for %x", key)
+			re.Equal(upper, keyspaceBoundaryBound(mode, key, true), "upper bound for %x", key)
+		}
+	}
 }
 
 func TestKeyspaceRuleSetUsesSparseChunks(t *testing.T) {
@@ -498,6 +550,39 @@ func BenchmarkKeyspaceRuleIndexSparse(b *testing.B) {
 			}
 		}
 	})
+}
+
+func BenchmarkRegionLabelerNegativeLookup(b *testing.B) {
+	keyspaceRegion := makeRegionForKeyspace(1, codec.TxnKeyspaceModePrefix)
+	classicRegion := core.NewTestRegionInfo(1, 1, []byte{'a'}, []byte{'b'})
+	for _, testCase := range []struct {
+		name         string
+		withHighRule bool
+		region       *core.RegionInfo
+	}{
+		{name: "empty-keyspace", region: keyspaceRegion},
+		{name: "empty-classic", region: classicRegion},
+		{name: "sparse-high-keyspace-gap", withHighRule: true, region: keyspaceRegion},
+		{name: "sparse-high-classic-gap", withHighRule: true, region: classicRegion},
+	} {
+		b.Run(testCase.name, func(b *testing.B) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			regionLabeler, err := NewRegionLabeler(ctx, endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil), time.Hour)
+			require.NoError(b, err)
+			if testCase.withHighRule {
+				rule := makeKeyspaceRuleForTest(constant.MaxValidKeyspaceID, codec.TxnKeyspaceModePrefix)
+				require.NoError(b, regionLabeler.SetLabelRule(rule))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if value := regionLabeler.GetRegionLabel(testCase.region, constant.RegionLabelKey); value != "" {
+					b.Fatalf("unexpected label %q", value)
+				}
+			}
+		})
+	}
 }
 
 // The startup/1000000 benchmark has a 3-second readiness target. It includes

--- a/pkg/schedule/labeler/keyspace_index_test.go
+++ b/pkg/schedule/labeler/keyspace_index_test.go
@@ -108,6 +108,17 @@ func TestKeyspaceRuleIndex(t *testing.T) {
 	re.Empty(index.GetSplitKeys(rawStart[:], rawEnd[:]))
 }
 
+func TestKeyspaceRuleIndexRejectsNonCanonicalID(t *testing.T) {
+	re := require.New(t)
+	rule := makeKeyspaceRuleForTest(1, codec.TxnKeyspaceModePrefix)
+	rule.ID = constant.RegionLabelIDPrefix + "+1"
+	rule.Labels[0].Value = "+1"
+	re.NoError(rule.checkAndAdjust())
+
+	var index keyspaceRuleIndex
+	re.False(index.Add(rule))
+}
+
 func TestKeyspaceRuleIndexBoundaries(t *testing.T) {
 	re := require.New(t)
 	ids := []uint32{0, 63, 64, 1023, 1024, constant.MaxValidKeyspaceID}
@@ -305,12 +316,12 @@ func TestKeyspaceRuleIndexPreservesLegacyResults(t *testing.T) {
 	legacy := buildLegacyRangeList(rules)
 	var regions []*core.RegionInfo
 	for _, id := range []uint32{0, 1, 42, 63, 64, 1023, 1024, constant.MaxValidKeyspaceID} {
-		for _, mode := range []byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+		for _, mode := range codec.KeyspaceModes() {
 			regions = append(regions, makeRegionForKeyspace(id, mode))
 		}
 	}
 	for _, id := range []uint32{0, 63, 1023} {
-		for _, mode := range []byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+		for _, mode := range codec.KeyspaceModes() {
 			left, right := makeRegionForKeyspace(id, mode), makeRegionForKeyspace(id+1, mode)
 			regions = append(regions, core.NewTestRegionInfo(2, 1, left.GetStartKey(), right.GetEndKey()))
 		}
@@ -354,15 +365,15 @@ func TestRegionLabelerUpdatesKeyspaceRulesIncrementally(t *testing.T) {
 		Data:     MakeKeyRanges("", ""),
 	}
 	re.NoError(regionLabeler.SetLabelRule(genericRule))
-	re.Len(regionLabeler.genericRules, 1)
+	re.Len(regionLabeler.ruleIndex.generic, 1)
 
 	rule := makeKeyspaceRuleForTest(42, codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix)
 	re.NoError(regionLabeler.SetLabelRule(rule))
-	re.False(regionLabeler.rangeListDirty)
-	re.Len(regionLabeler.genericRules, 1)
-	re.True(regionLabeler.keyspaceRules.Contains(rule))
+	re.False(regionLabeler.ruleIndex.rangesDirty)
+	re.Len(regionLabeler.ruleIndex.generic, 1)
+	re.True(regionLabeler.ruleIndex.keyspaces.Contains(rule))
 
-	for _, mode := range []byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
+	for _, mode := range codec.KeyspaceModes() {
 		region := makeRegionForKeyspace(42, mode)
 		re.Equal("42", regionLabeler.GetRegionLabel(region, constant.RegionLabelKey))
 		re.Equal("yes", regionLabeler.GetRegionLabel(region, "generic"))
@@ -376,13 +387,13 @@ func TestRegionLabelerUpdatesKeyspaceRulesIncrementally(t *testing.T) {
 	// Changing the deterministic rule only touches its old and new slots.
 	updated := makeKeyspaceRuleForTest(42, codec.TxnKeyspaceModePrefix)
 	re.NoError(regionLabeler.SetLabelRule(updated))
-	re.False(regionLabeler.rangeListDirty)
+	re.False(regionLabeler.ruleIndex.rangesDirty)
 	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix), constant.RegionLabelKey))
 	re.Equal("42", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), constant.RegionLabelKey))
 
 	re.NoError(regionLabeler.DeleteLabelRule(updated.ID))
-	re.False(regionLabeler.rangeListDirty)
-	re.False(regionLabeler.keyspaceRules.Contains(updated))
+	re.False(regionLabeler.ruleIndex.rangesDirty)
+	re.False(regionLabeler.ruleIndex.keyspaces.Contains(updated))
 	re.Equal("yes", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), "generic"))
 }
 
@@ -406,6 +417,29 @@ func TestRegionLabelerUpdatesMutatedKeyspaceRule(t *testing.T) {
 	fetched.Labels[0].Value = "mutated"
 	re.NoError(regionLabeler.DeleteLabelRule(fetched.ID))
 	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix), constant.RegionLabelKey))
+}
+
+func TestNewLabelRuleIndexBuildsAuthoritativeSnapshot(t *testing.T) {
+	re := require.New(t)
+	rule := makeKeyspaceRuleForTest(42, codec.TxnKeyspaceModePrefix)
+	re.NoError(rule.checkAndAdjust())
+	stale := makeKeyspaceRuleForTest(41, codec.TxnKeyspaceModePrefix)
+	re.NoError(stale.checkAndAdjust())
+
+	index := newLabelRuleIndex(map[string]*LabelRule{stale.ID: stale})
+	re.True(index.keyspaces.Contains(stale))
+	index = newLabelRuleIndex(map[string]*LabelRule{rule.ID: rule})
+	re.False(index.keyspaces.Contains(stale))
+	re.True(index.keyspaces.Contains(rule))
+	re.Empty(index.generic)
+
+	regionLabeler := &RegionLabeler{ruleIndex: index}
+	regionLabeler.Lock()
+	regionLabeler.ruleIndex.delete(rule.ID)
+	regionLabeler.Unlock()
+	region := makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix)
+	re.Empty(regionLabeler.GetRegionLabel(region, constant.RegionLabelKey))
+	re.Empty(regionLabeler.GetSplitKeys(region.GetStartKey(), region.GetEndKey()))
 }
 
 func BenchmarkKeyspaceRuleIndexSparse(b *testing.B) {
@@ -459,57 +493,44 @@ func BenchmarkRegionLabelerKeyspaceIndex(b *testing.B) {
 		b.Run(fmt.Sprintf("startup/%d", count), func(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
-				regionLabeler := &RegionLabeler{
-					labelRules:     make(map[string]*LabelRule, count),
-					genericRules:   make(map[string]*LabelRule),
-					rangeListDirty: true,
-				}
+				rules := make(map[string]*LabelRule, count)
 				for id := range count {
 					rule := makeKeyspaceRuleForTest(uint32(id), codec.TxnKeyspaceModePrefix)
 					require.NoError(b, rule.checkAndAdjust())
-					regionLabeler.labelRules[rule.ID] = rule
+					rules[rule.ID] = rule
 				}
-				regionLabeler.BuildRangeListLocked()
+				_ = newLabelRuleIndex(rules)
 			}
 		})
 
 		b.Run(fmt.Sprintf("single-rule-update/%d", count), func(b *testing.B) {
-			regionLabeler := &RegionLabeler{
-				labelRules:     make(map[string]*LabelRule, count),
-				genericRules:   make(map[string]*LabelRule),
-				rangeListDirty: true,
-			}
+			rulesByID := make(map[string]*LabelRule, count)
 			rules := make([]*LabelRule, 0, count)
 			for id := range count {
 				rule := makeKeyspaceRuleForTest(uint32(id), codec.TxnKeyspaceModePrefix)
 				require.NoError(b, rule.checkAndAdjust())
-				regionLabeler.labelRules[rule.ID] = rule
+				rulesByID[rule.ID] = rule
 				rules = append(rules, rule)
 			}
-			regionLabeler.BuildRangeListLocked()
+			regionLabeler := &RegionLabeler{ruleIndex: newLabelRuleIndex(rulesByID)}
 			target := rules[len(rules)/2]
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
 				regionLabeler.Lock()
-				regionLabeler.setLabelRuleInMemoryLocked(target)
-				regionLabeler.BuildRangeListLocked()
+				regionLabeler.ruleIndex.set(target)
 				regionLabeler.Unlock()
 			}
 		})
 
 		b.Run(fmt.Sprintf("lookup/%d", count), func(b *testing.B) {
-			regionLabeler := &RegionLabeler{
-				labelRules:     make(map[string]*LabelRule, count),
-				genericRules:   make(map[string]*LabelRule),
-				rangeListDirty: true,
-			}
+			rules := make(map[string]*LabelRule, count)
 			for id := range count {
 				rule := makeKeyspaceRuleForTest(uint32(id), codec.TxnKeyspaceModePrefix)
 				require.NoError(b, rule.checkAndAdjust())
-				regionLabeler.labelRules[rule.ID] = rule
+				rules[rule.ID] = rule
 			}
-			regionLabeler.BuildRangeListLocked()
+			regionLabeler := &RegionLabeler{ruleIndex: newLabelRuleIndex(rules)}
 			region := makeRegionForKeyspace(uint32(count/2), codec.TxnKeyspaceModePrefix)
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/pkg/schedule/labeler/keyspace_index_test.go
+++ b/pkg/schedule/labeler/keyspace_index_test.go
@@ -138,6 +138,19 @@ func TestKeyspaceRuleIndexBoundaries(t *testing.T) {
 	re.Equal(expected, index.GetSplitKeys(nil, nil))
 }
 
+func TestKeyspaceRuleIndexSparseGap(t *testing.T) {
+	re := require.New(t)
+	rule := makeKeyspaceRuleForTest(keyspaceMaxID, keyspaceTxnMode)
+	re.NoError(rule.checkAndAdjust())
+
+	var index keyspaceRuleIndex
+	re.True(index.Add(rule))
+	start := keyspaceBoundaryBytes(keyspaceTxnMode, 0)
+	end := keyspaceBoundaryBytes(keyspaceTxnMode, keyspaceMaxID)
+	re.Empty(index.GetSplitKeys(start, end))
+	re.False(index.HasSplitKey(start, end))
+}
+
 func TestKeyspaceRuleSetUsesSparseChunks(t *testing.T) {
 	re := require.New(t)
 	var set keyspaceRuleSet
@@ -158,6 +171,8 @@ func TestKeyspaceRuleSetUsesSparseChunks(t *testing.T) {
 	re.Len(set.chunks, 1)
 	set.clear(1)
 	re.Empty(set.chunks)
+	re.Zero(set.nonEmptyChunks)
+	re.Zero(set.nonEmptyChunkMapWords)
 }
 
 func TestKeyspaceRuleIndexReplaceReusesSparseStorage(t *testing.T) {
@@ -383,6 +398,22 @@ func BenchmarkKeyspaceRuleIndexSparse(b *testing.B) {
 		for range b.N {
 			if keys := index.GetSplitKeys(nil, nil); len(keys) != 2 {
 				b.Fatalf("expected 2 split keys, got %d", len(keys))
+			}
+		}
+	})
+
+	b.Run("high-id-negative-split", func(b *testing.B) {
+		highRule := makeKeyspaceRuleForTest(keyspaceMaxID, keyspaceTxnMode)
+		require.NoError(b, highRule.checkAndAdjust())
+		var index keyspaceRuleIndex
+		require.True(b, index.Add(highRule))
+		start := keyspaceBoundaryBytes(keyspaceTxnMode, 0)
+		end := keyspaceBoundaryBytes(keyspaceTxnMode, keyspaceMaxID)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			if keys := index.GetSplitKeys(start, end); len(keys) != 0 {
+				b.Fatalf("expected no split keys, got %d", len(keys))
 			}
 		}
 	})

--- a/pkg/schedule/labeler/keyspace_index_test.go
+++ b/pkg/schedule/labeler/keyspace_index_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/tikv/pd/pkg/codec"
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/schedule/rangelist"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
@@ -43,8 +44,8 @@ func makeKeyspaceRuleForTest(id uint32, modes ...byte) *LabelRule {
 		})
 	}
 	return &LabelRule{
-		ID:       fmt.Sprintf("keyspaces/%d", id),
-		Labels:   []RegionLabel{{Key: "id", Value: strconv.FormatUint(uint64(id), 10)}},
+		ID:       fmt.Sprintf("%s%d", constant.RegionLabelIDPrefix, id),
+		Labels:   []RegionLabel{{Key: constant.RegionLabelKey, Value: strconv.FormatUint(uint64(id), 10)}},
 		RuleType: KeyRange,
 		Data:     ranges,
 	}
@@ -58,47 +59,47 @@ func makeRegionForKeyspace(id uint32, mode byte) *core.RegionInfo {
 
 func TestKeyspaceRuleIndex(t *testing.T) {
 	re := require.New(t)
-	rule := makeKeyspaceRuleForTest(42, keyspaceRawMode, keyspaceTxnMode)
+	rule := makeKeyspaceRuleForTest(42, codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix)
 	re.NoError(rule.checkAndAdjust())
 
 	var index keyspaceRuleIndex
 	re.True(index.Add(rule))
 	re.True(index.Contains(rule))
 	re.Same(rule, index.GetRule(
-		makeRegionForKeyspace(42, keyspaceRawMode).GetStartKey(),
-		makeRegionForKeyspace(42, keyspaceRawMode).GetEndKey(),
+		makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix).GetStartKey(),
+		makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix).GetEndKey(),
 	))
 	re.Same(rule, index.GetRule(
-		makeRegionForKeyspace(42, keyspaceTxnMode).GetStartKey(),
-		makeRegionForKeyspace(42, keyspaceTxnMode).GetEndKey(),
+		makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix).GetStartKey(),
+		makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix).GetEndKey(),
 	))
 
-	rawStart := keyspaceBoundary(keyspaceRawMode, 41)
-	rawEnd := keyspaceBoundary(keyspaceRawMode, 44)
+	rawStart := keyspaceBoundary(codec.RawKeyspaceModePrefix, 41)
+	rawEnd := keyspaceBoundary(codec.RawKeyspaceModePrefix, 44)
 	splitKeys := index.GetSplitKeys(rawStart[:], rawEnd[:])
 	re.Equal([][]byte{
-		keyspaceBoundaryBytes(keyspaceRawMode, 42),
-		keyspaceBoundaryBytes(keyspaceRawMode, 43),
+		keyspaceBoundaryBytes(codec.RawKeyspaceModePrefix, 42),
+		keyspaceBoundaryBytes(codec.RawKeyspaceModePrefix, 43),
 	}, splitKeys)
 	re.True(index.HasSplitKey(rawStart[:], rawEnd[:]))
 
 	// A rejected multi-range add must not populate its free slot before it
 	// discovers a collision in another slot.
-	txnOwner := makeKeyspaceRuleForTest(43, keyspaceTxnMode)
+	txnOwner := makeKeyspaceRuleForTest(43, codec.TxnKeyspaceModePrefix)
 	re.NoError(txnOwner.checkAndAdjust())
 	re.True(index.Add(txnOwner))
-	collision := makeKeyspaceRuleForTest(43, keyspaceRawMode, keyspaceTxnMode)
+	collision := makeKeyspaceRuleForTest(43, codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix)
 	re.NoError(collision.checkAndAdjust())
 	re.False(index.Add(collision))
 	re.True(index.Contains(txnOwner))
 	re.False(index.Contains(collision))
 	re.Nil(index.GetRule(
-		makeRegionForKeyspace(43, keyspaceRawMode).GetStartKey(),
-		makeRegionForKeyspace(43, keyspaceRawMode).GetEndKey(),
+		makeRegionForKeyspace(43, codec.RawKeyspaceModePrefix).GetStartKey(),
+		makeRegionForKeyspace(43, codec.RawKeyspaceModePrefix).GetEndKey(),
 	))
 	re.Same(txnOwner, index.GetRule(
-		makeRegionForKeyspace(43, keyspaceTxnMode).GetStartKey(),
-		makeRegionForKeyspace(43, keyspaceTxnMode).GetEndKey(),
+		makeRegionForKeyspace(43, codec.TxnKeyspaceModePrefix).GetStartKey(),
+		makeRegionForKeyspace(43, codec.TxnKeyspaceModePrefix).GetEndKey(),
 	))
 	re.True(index.Remove(txnOwner.ID, txnOwner))
 
@@ -109,22 +110,22 @@ func TestKeyspaceRuleIndex(t *testing.T) {
 
 func TestKeyspaceRuleIndexBoundaries(t *testing.T) {
 	re := require.New(t)
-	ids := []uint32{0, 63, 64, 1023, 1024, keyspaceMaxID}
+	ids := []uint32{0, 63, 64, 1023, 1024, constant.MaxValidKeyspaceID}
 	var index keyspaceRuleIndex
 	expectedByKey := make(map[string][]byte)
 	for _, id := range ids {
-		rule := makeKeyspaceRuleForTest(id, keyspaceTxnMode)
+		rule := makeKeyspaceRuleForTest(id, codec.TxnKeyspaceModePrefix)
 		re.NoError(rule.checkAndAdjust())
 		re.True(index.Add(rule))
 		for _, boundaryID := range []uint32{id, id + 1} {
-			key := keyspaceBoundaryBytes(keyspaceTxnMode, boundaryID)
+			key := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, boundaryID)
 			expectedByKey[string(key)] = key
 		}
 
-		left := keyspaceBoundary(keyspaceTxnMode, id)
-		right := keyspaceBoundary(keyspaceTxnMode, id+1)
+		left := keyspaceBoundary(codec.TxnKeyspaceModePrefix, id)
+		right := keyspaceBoundary(codec.TxnKeyspaceModePrefix, id+1)
 		re.Same(rule, index.GetRule(left[:], right[:]))
-		region := makeRegionForKeyspace(id, keyspaceTxnMode)
+		region := makeRegionForKeyspace(id, codec.TxnKeyspaceModePrefix)
 		re.Same(rule, index.GetRule(region.GetStartKey(), region.GetEndKey()))
 	}
 
@@ -140,13 +141,13 @@ func TestKeyspaceRuleIndexBoundaries(t *testing.T) {
 
 func TestKeyspaceRuleIndexSparseGap(t *testing.T) {
 	re := require.New(t)
-	rule := makeKeyspaceRuleForTest(keyspaceMaxID, keyspaceTxnMode)
+	rule := makeKeyspaceRuleForTest(constant.MaxValidKeyspaceID, codec.TxnKeyspaceModePrefix)
 	re.NoError(rule.checkAndAdjust())
 
 	var index keyspaceRuleIndex
 	re.True(index.Add(rule))
-	start := keyspaceBoundaryBytes(keyspaceTxnMode, 0)
-	end := keyspaceBoundaryBytes(keyspaceTxnMode, keyspaceMaxID)
+	start := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 0)
+	end := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, constant.MaxValidKeyspaceID)
 	re.Empty(index.GetSplitKeys(start, end))
 	re.False(index.HasSplitKey(start, end))
 }
@@ -162,25 +163,56 @@ func TestKeyspaceRuleSetUsesSparseChunks(t *testing.T) {
 	set.set(keyspaceChunkSize, rules[1])
 	re.Len(set.chunks, 2)
 
-	set.set(keyspaceMaxID, rules[2])
-	re.Len(set.chunks, (int(keyspaceMaxID)>>keyspaceChunkBits)+1)
+	set.set(constant.MaxValidKeyspaceID, rules[2])
+	re.Len(set.chunks, (int(constant.MaxValidKeyspaceID)>>keyspaceChunkBits)+1)
 
-	set.clear(keyspaceMaxID)
+	set.clear(constant.MaxValidKeyspaceID)
 	re.Len(set.chunks, 2)
 	set.clear(keyspaceChunkSize)
 	re.Len(set.chunks, 1)
 	set.clear(1)
 	re.Empty(set.chunks)
-	re.Zero(set.nonEmptyChunks)
-	re.Zero(set.nonEmptyChunkMapWords)
+	re.Zero(set.nonEmptyChunkBitmap)
+	re.Zero(set.nonEmptyChunkBitmapSummary)
+}
+
+func TestKeyspaceRuleSetIteratesChunkBitmapBoundaries(t *testing.T) {
+	re := require.New(t)
+	ids := []uint32{
+		0,
+		63 << keyspaceChunkBits,
+		64 << keyspaceChunkBits,
+		4095 << keyspaceChunkBits,
+		4096 << keyspaceChunkBits,
+		constant.MaxValidKeyspaceID,
+	}
+	var set keyspaceRuleSet
+	for _, id := range ids {
+		set.set(id, &LabelRule{ID: strconv.FormatUint(uint64(id), 10)})
+	}
+
+	collect := func(lo, hi int) []uint32 {
+		var got []uint32
+		set.forEachSlot(lo, hi, func(id uint32) bool {
+			got = append(got, id)
+			return true
+		})
+		return got
+	}
+
+	re.Equal(ids, collect(0, int(constant.MaxValidKeyspaceID)+1))
+	re.Equal(ids[2:5], collect(int(ids[1])+1, int(ids[4])+1))
+	set.clear(ids[2])
+	set.clear(ids[4])
+	re.Equal([]uint32{ids[1], ids[3]}, collect(int(ids[1]), int(ids[4])+1))
 }
 
 func TestKeyspaceRuleIndexReplaceReusesSparseStorage(t *testing.T) {
-	for _, id := range []uint32{1, keyspaceMaxID} {
+	for _, id := range []uint32{1, constant.MaxValidKeyspaceID} {
 		t.Run(strconv.FormatUint(uint64(id), 10), func(t *testing.T) {
 			re := require.New(t)
-			first := makeKeyspaceRuleForTest(id, keyspaceTxnMode)
-			second := makeKeyspaceRuleForTest(id, keyspaceTxnMode)
+			first := makeKeyspaceRuleForTest(id, codec.TxnKeyspaceModePrefix)
+			second := makeKeyspaceRuleForTest(id, codec.TxnKeyspaceModePrefix)
 			re.NoError(first.checkAndAdjust())
 			re.NoError(second.checkAndAdjust())
 
@@ -241,8 +273,8 @@ func TestKeyspaceRuleIndexPreservesLegacyResults(t *testing.T) {
 	re.NoError(err)
 
 	var rules []*LabelRule
-	for _, id := range []uint32{0, 1, 63, 64, 1023, 1024, keyspaceMaxID} {
-		rule := makeKeyspaceRuleForTest(id, keyspaceRawMode, keyspaceTxnMode)
+	for _, id := range []uint32{0, 1, 63, 64, 1023, 1024, constant.MaxValidKeyspaceID} {
+		rule := makeKeyspaceRuleForTest(id, codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix)
 		rules = append(rules, rule)
 		re.NoError(regionLabeler.SetLabelRule(rule))
 	}
@@ -255,12 +287,12 @@ func TestKeyspaceRuleIndexPreservesLegacyResults(t *testing.T) {
 	}
 	rules = append(rules, genericRule)
 	re.NoError(regionLabeler.SetLabelRule(genericRule))
-	overlayStart := keyspaceBoundary(keyspaceTxnMode, 64)
-	overlayEnd := keyspaceBoundary(keyspaceTxnMode, 65)
+	overlayStart := keyspaceBoundary(codec.TxnKeyspaceModePrefix, 64)
+	overlayEnd := keyspaceBoundary(codec.TxnKeyspaceModePrefix, 65)
 	overlayRule := &LabelRule{
 		ID:       "generic-overlay",
 		Index:    2,
-		Labels:   []RegionLabel{{Key: "id", Value: "override"}},
+		Labels:   []RegionLabel{{Key: constant.RegionLabelKey, Value: "override"}},
 		RuleType: KeyRange,
 		Data: MakeKeyRanges(
 			hex.EncodeToString(overlayStart[:]),
@@ -272,13 +304,13 @@ func TestKeyspaceRuleIndexPreservesLegacyResults(t *testing.T) {
 
 	legacy := buildLegacyRangeList(rules)
 	var regions []*core.RegionInfo
-	for _, id := range []uint32{0, 1, 42, 63, 64, 1023, 1024, keyspaceMaxID} {
-		for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, id := range []uint32{0, 1, 42, 63, 64, 1023, 1024, constant.MaxValidKeyspaceID} {
+		for _, mode := range []byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 			regions = append(regions, makeRegionForKeyspace(id, mode))
 		}
 	}
 	for _, id := range []uint32{0, 63, 1023} {
-		for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+		for _, mode := range []byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 			left, right := makeRegionForKeyspace(id, mode), makeRegionForKeyspace(id+1, mode)
 			regions = append(regions, core.NewTestRegionInfo(2, 1, left.GetStartKey(), right.GetEndKey()))
 		}
@@ -294,10 +326,10 @@ func TestKeyspaceRuleIndexPreservesLegacyResults(t *testing.T) {
 
 	for _, keyRange := range [][2][]byte{
 		{nil, nil},
-		{keyspaceBoundaryBytes(keyspaceRawMode, 0), keyspaceBoundaryBytes(keyspaceRawMode, 65)},
-		{keyspaceBoundaryBytes(keyspaceTxnMode, 62), keyspaceBoundaryBytes(keyspaceTxnMode, 65)},
-		{keyspaceBoundaryBytes(keyspaceTxnMode, 1023), keyspaceBoundaryBytes(keyspaceTxnMode, 1025)},
-		{keyspaceBoundaryBytes(keyspaceTxnMode, keyspaceMaxID), nil},
+		{keyspaceBoundaryBytes(codec.RawKeyspaceModePrefix, 0), keyspaceBoundaryBytes(codec.RawKeyspaceModePrefix, 65)},
+		{keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 62), keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 65)},
+		{keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 1023), keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 1025)},
+		{keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, constant.MaxValidKeyspaceID), nil},
 	} {
 		re.Equal(
 			legacy.GetSplitKeys(keyRange[0], keyRange[1]),
@@ -324,34 +356,34 @@ func TestRegionLabelerUpdatesKeyspaceRulesIncrementally(t *testing.T) {
 	re.NoError(regionLabeler.SetLabelRule(genericRule))
 	re.Len(regionLabeler.genericRules, 1)
 
-	rule := makeKeyspaceRuleForTest(42, keyspaceRawMode, keyspaceTxnMode)
+	rule := makeKeyspaceRuleForTest(42, codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix)
 	re.NoError(regionLabeler.SetLabelRule(rule))
 	re.False(regionLabeler.rangeListDirty)
 	re.Len(regionLabeler.genericRules, 1)
 	re.True(regionLabeler.keyspaceRules.Contains(rule))
 
-	for _, mode := range []byte{keyspaceRawMode, keyspaceTxnMode} {
+	for _, mode := range []byte{codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix} {
 		region := makeRegionForKeyspace(42, mode)
-		re.Equal("42", regionLabeler.GetRegionLabel(region, "id"))
+		re.Equal("42", regionLabeler.GetRegionLabel(region, constant.RegionLabelKey))
 		re.Equal("yes", regionLabeler.GetRegionLabel(region, "generic"))
 	}
-	startRegion := makeRegionForKeyspace(42, keyspaceTxnMode)
-	endRegion := makeRegionForKeyspace(43, keyspaceTxnMode)
+	startRegion := makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix)
+	endRegion := makeRegionForKeyspace(43, codec.TxnKeyspaceModePrefix)
 	crossingRegion := core.NewTestRegionInfo(2, 1, startRegion.GetStartKey(), endRegion.GetEndKey())
-	re.Empty(regionLabeler.GetRegionLabel(crossingRegion, "id"))
+	re.Empty(regionLabeler.GetRegionLabel(crossingRegion, constant.RegionLabelKey))
 	re.Empty(regionLabeler.GetRegionLabel(crossingRegion, "generic"))
 
 	// Changing the deterministic rule only touches its old and new slots.
-	updated := makeKeyspaceRuleForTest(42, keyspaceTxnMode)
+	updated := makeKeyspaceRuleForTest(42, codec.TxnKeyspaceModePrefix)
 	re.NoError(regionLabeler.SetLabelRule(updated))
 	re.False(regionLabeler.rangeListDirty)
-	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, keyspaceRawMode), "id"))
-	re.Equal("42", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, keyspaceTxnMode), "id"))
+	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix), constant.RegionLabelKey))
+	re.Equal("42", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), constant.RegionLabelKey))
 
 	re.NoError(regionLabeler.DeleteLabelRule(updated.ID))
 	re.False(regionLabeler.rangeListDirty)
 	re.False(regionLabeler.keyspaceRules.Contains(updated))
-	re.Equal("yes", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, keyspaceTxnMode), "generic"))
+	re.Equal("yes", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), "generic"))
 }
 
 func TestRegionLabelerUpdatesMutatedKeyspaceRule(t *testing.T) {
@@ -362,22 +394,22 @@ func TestRegionLabelerUpdatesMutatedKeyspaceRule(t *testing.T) {
 	regionLabeler, err := NewRegionLabeler(ctx, store, time.Hour)
 	re.NoError(err)
 
-	rule := makeKeyspaceRuleForTest(42, keyspaceTxnMode)
+	rule := makeKeyspaceRuleForTest(42, codec.TxnKeyspaceModePrefix)
 	re.NoError(regionLabeler.SetLabelRule(rule))
 
 	fetched := regionLabeler.GetLabelRule(rule.ID)
-	fetched.Data = makeKeyspaceRuleForTest(42, keyspaceRawMode).Data
+	fetched.Data = makeKeyspaceRuleForTest(42, codec.RawKeyspaceModePrefix).Data
 	re.NoError(regionLabeler.SetLabelRule(fetched))
-	re.Equal("42", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, keyspaceRawMode), "id"))
-	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, keyspaceTxnMode), "id"))
+	re.Equal("42", regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix), constant.RegionLabelKey))
+	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.TxnKeyspaceModePrefix), constant.RegionLabelKey))
 
 	fetched.Labels[0].Value = "mutated"
 	re.NoError(regionLabeler.DeleteLabelRule(fetched.ID))
-	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, keyspaceRawMode), "id"))
+	re.Empty(regionLabeler.GetRegionLabel(makeRegionForKeyspace(42, codec.RawKeyspaceModePrefix), constant.RegionLabelKey))
 }
 
 func BenchmarkKeyspaceRuleIndexSparse(b *testing.B) {
-	rule := makeKeyspaceRuleForTest(0, keyspaceTxnMode)
+	rule := makeKeyspaceRuleForTest(0, codec.TxnKeyspaceModePrefix)
 	require.NoError(b, rule.checkAndAdjust())
 
 	b.Run("add-one", func(b *testing.B) {
@@ -403,12 +435,12 @@ func BenchmarkKeyspaceRuleIndexSparse(b *testing.B) {
 	})
 
 	b.Run("high-id-negative-split", func(b *testing.B) {
-		highRule := makeKeyspaceRuleForTest(keyspaceMaxID, keyspaceTxnMode)
+		highRule := makeKeyspaceRuleForTest(constant.MaxValidKeyspaceID, codec.TxnKeyspaceModePrefix)
 		require.NoError(b, highRule.checkAndAdjust())
 		var index keyspaceRuleIndex
 		require.True(b, index.Add(highRule))
-		start := keyspaceBoundaryBytes(keyspaceTxnMode, 0)
-		end := keyspaceBoundaryBytes(keyspaceTxnMode, keyspaceMaxID)
+		start := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 0)
+		end := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, constant.MaxValidKeyspaceID)
 		b.ReportAllocs()
 		b.ResetTimer()
 		for range b.N {
@@ -433,7 +465,7 @@ func BenchmarkRegionLabelerKeyspaceIndex(b *testing.B) {
 					rangeListDirty: true,
 				}
 				for id := range count {
-					rule := makeKeyspaceRuleForTest(uint32(id), keyspaceTxnMode)
+					rule := makeKeyspaceRuleForTest(uint32(id), codec.TxnKeyspaceModePrefix)
 					require.NoError(b, rule.checkAndAdjust())
 					regionLabeler.labelRules[rule.ID] = rule
 				}
@@ -449,7 +481,7 @@ func BenchmarkRegionLabelerKeyspaceIndex(b *testing.B) {
 			}
 			rules := make([]*LabelRule, 0, count)
 			for id := range count {
-				rule := makeKeyspaceRuleForTest(uint32(id), keyspaceTxnMode)
+				rule := makeKeyspaceRuleForTest(uint32(id), codec.TxnKeyspaceModePrefix)
 				require.NoError(b, rule.checkAndAdjust())
 				regionLabeler.labelRules[rule.ID] = rule
 				rules = append(rules, rule)
@@ -473,16 +505,16 @@ func BenchmarkRegionLabelerKeyspaceIndex(b *testing.B) {
 				rangeListDirty: true,
 			}
 			for id := range count {
-				rule := makeKeyspaceRuleForTest(uint32(id), keyspaceTxnMode)
+				rule := makeKeyspaceRuleForTest(uint32(id), codec.TxnKeyspaceModePrefix)
 				require.NoError(b, rule.checkAndAdjust())
 				regionLabeler.labelRules[rule.ID] = rule
 			}
 			regionLabeler.BuildRangeListLocked()
-			region := makeRegionForKeyspace(uint32(count/2), keyspaceTxnMode)
+			region := makeRegionForKeyspace(uint32(count/2), codec.TxnKeyspaceModePrefix)
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
-				if value := regionLabeler.GetRegionLabel(region, keyspaceIDLabelKey); value == "" {
+				if value := regionLabeler.GetRegionLabel(region, constant.RegionLabelKey); value == "" {
 					b.Fatal("keyspace label not found")
 				}
 			}

--- a/pkg/schedule/labeler/labeler.go
+++ b/pkg/schedule/labeler/labeler.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
-	"github.com/tikv/pd/pkg/schedule/rangelist"
 	"github.com/tikv/pd/pkg/storage/endpoint"
 	"github.com/tikv/pd/pkg/storage/kv"
 	"github.com/tikv/pd/pkg/utils/logutil"
@@ -36,14 +35,15 @@ import (
 type RegionLabeler struct {
 	storage endpoint.RuleStorage
 	syncutil.RWMutex
-	labelRules      map[string]*LabelRule
-	genericRules    map[string]*LabelRule
-	keyspaceRules   keyspaceRuleIndex
-	rangeList       rangelist.List // sorted generic LabelRules of the type `KeyRange`
-	rangeListDirty  bool
-	rangeIndexReady bool
-	ctx             context.Context
-	minExpire       *time.Time
+	ruleIndex labelRuleIndex
+	ctx       context.Context
+}
+
+// Unlock publishes all derived rule-index updates before releasing the write
+// lock. This keeps a dirty index private to the write-side critical section.
+func (l *RegionLabeler) Unlock() {
+	defer l.RWMutex.Unlock()
+	l.ruleIndex.buildRanges()
 }
 
 // NewRegionLabeler creates a Labeler instance.
@@ -54,18 +54,14 @@ func NewRegionLabeler(ctx context.Context, storage endpoint.RuleStorage, gcInter
 	}()
 
 	l := &RegionLabeler{
-		storage:        storage,
-		labelRules:     make(map[string]*LabelRule),
-		genericRules:   make(map[string]*LabelRule),
-		rangeListDirty: true,
-		ctx:            ctx,
-		minExpire:      nil,
+		storage: storage,
+		ctx:     ctx,
 	}
 
 	if err := l.loadRules(); err != nil {
 		return nil, err
 	}
-	log.Info("new region labeler created", zap.Int("label-rules-count", len(l.labelRules)))
+	log.Info("new region labeler created", zap.Int("label-rules-count", len(l.ruleIndex.rules)))
 	go l.doGC(gcInterval)
 	return l, nil
 }
@@ -92,21 +88,17 @@ func (l *RegionLabeler) checkAndClearExpiredLabels() {
 	l.Lock()
 	defer l.Unlock()
 
-	if l.minExpire == nil || l.minExpire.After(now) {
+	if l.ruleIndex.minExpire == nil || l.ruleIndex.minExpire.After(now) {
 		return
 	}
 	var err error
-	deleted := false
 
-	for key, rule := range l.labelRules {
-		if !rule.checkAndRemoveExpireLabels(now) {
+	for key, rule := range l.ruleIndex.rules {
+		if !l.ruleIndex.removeExpiredLabels(rule, now) {
 			continue
 		}
 		if len(rule.Labels) == 0 {
 			err = l.DeleteLabelRuleLocked(key)
-			if err == nil {
-				deleted = true
-			}
 		} else {
 			err = l.storage.RunInTxn(l.ctx, func(txn kv.Txn) error {
 				return l.storage.SaveRegionRule(txn, rule.ID, rule)
@@ -116,13 +108,11 @@ func (l *RegionLabeler) checkAndClearExpiredLabels() {
 			log.Error("failed to save rule expired label rule", zap.String("rule-key", key), zap.Error(err))
 		}
 	}
-	if deleted {
-		l.BuildRangeListLocked()
-	}
 }
 
 func (l *RegionLabeler) loadRules() error {
 	var toDelete []string
+	loadedRules := make(map[string]*LabelRule)
 	err := l.storage.LoadRegionRules(func(k, v string) {
 		r, err := NewLabelRuleFromJSON([]byte(v))
 		if err != nil {
@@ -134,7 +124,7 @@ func (l *RegionLabeler) loadRules() error {
 			toDelete = append(toDelete, k)
 			return
 		}
-		l.labelRules[r.ID] = r
+		loadedRules[r.ID] = r
 	})
 	if err != nil {
 		return err
@@ -146,51 +136,21 @@ func (l *RegionLabeler) loadRules() error {
 			return err
 		}
 	}
-	l.BuildRangeListLocked()
+	l.ruleIndex = newLabelRuleIndex(loadedRules)
 	return nil
 }
 
-// BuildRangeListLocked builds the generic range list when necessary. Canonical
-// keyspace rules are indexed separately and updated incrementally.
+// BuildRangeListLocked publishes pending derived rule-index updates.
+// Deprecated: Unlock publishes them automatically.
 func (l *RegionLabeler) BuildRangeListLocked() {
-	if !l.rangeIndexReady {
-		for _, rule := range l.labelRules {
-			if !l.keyspaceRules.Add(rule) {
-				l.genericRules[rule.ID] = rule
-			}
-		}
-		l.rangeIndexReady = true
-		l.rangeListDirty = true
-	}
-	if !l.rangeListDirty {
-		return
-	}
-
-	builder := rangelist.NewBuilder()
-	l.minExpire = nil
-	for _, rule := range l.genericRules {
-		if l.minExpire == nil || rule.expireBefore(*l.minExpire) {
-			l.minExpire = rule.minExpire
-		}
-		if rule.RuleType == KeyRange {
-			rs := rule.Data.([]*KeyRangeRule)
-			for _, r := range rs {
-				builder.AddItem(r.StartKey, r.EndKey, rule)
-			}
-		}
-	}
-	l.rangeList = builder.Build()
-	l.rangeListDirty = false
+	l.ruleIndex.buildRanges()
 }
 
 // GetSplitKeys returns all split keys in the range (start, end).
 func (l *RegionLabeler) GetSplitKeys(start, end []byte) [][]byte {
 	l.RLock()
 	defer l.RUnlock()
-	return mergeSplitKeys(
-		l.rangeList.GetSplitKeys(start, end),
-		l.keyspaceRules.GetSplitKeys(start, end),
-	)
+	return l.ruleIndex.getSplitKeys(start, end)
 }
 
 func filterExpiredLabels(rule *LabelRule, now time.Time) *LabelRule {
@@ -233,8 +193,8 @@ func (l *RegionLabeler) GetAllLabelRules() []*LabelRule {
 	defer l.RUnlock()
 
 	now := time.Now()
-	rules := make([]*LabelRule, 0, len(l.labelRules))
-	for _, rule := range l.labelRules {
+	rules := make([]*LabelRule, 0, len(l.ruleIndex.rules))
+	for _, rule := range l.ruleIndex.rules {
 		if filteredRule := filterExpiredLabels(rule, now); filteredRule != nil {
 			rules = append(rules, filteredRule)
 		}
@@ -248,7 +208,7 @@ func (l *RegionLabeler) GetRuleAndKeyRangeCounts() (ruleCount, keyRangeCount int
 	defer l.RUnlock()
 
 	now := time.Now()
-	for _, rule := range l.labelRules {
+	for _, rule := range l.ruleIndex.rules {
 		filteredRule := filterExpiredLabels(rule, now)
 		if filteredRule == nil {
 			continue
@@ -267,7 +227,7 @@ func (l *RegionLabeler) GetLabelRules(ids []string) ([]*LabelRule, error) {
 	now := time.Now()
 	rules := make([]*LabelRule, 0, len(ids))
 	for _, id := range ids {
-		if rule, ok := l.labelRules[id]; ok {
+		if rule, ok := l.ruleIndex.rules[id]; ok {
 			if filteredRule := filterExpiredLabels(rule, now); filteredRule != nil {
 				rules = append(rules, filteredRule)
 			}
@@ -285,7 +245,7 @@ func (l *RegionLabeler) GetLabelRule(id string) *LabelRule {
 
 // GetLabelRuleLocked returns the Rule with the same ID.
 func (l *RegionLabeler) GetLabelRuleLocked(id string) *LabelRule {
-	rule, ok := l.labelRules[id]
+	rule, ok := l.ruleIndex.rules[id]
 	if !ok {
 		return nil
 	}
@@ -306,12 +266,12 @@ func (l *RegionLabeler) SetLabelRule(rule *LabelRule) error {
 	// only Lock for in-memory update
 	l.Lock()
 	defer l.Unlock()
-	l.setLabelRuleInMemoryLocked(rule)
-	l.BuildRangeListLocked()
+	l.ruleIndex.set(rule)
 	return nil
 }
 
-// SetLabelRuleLocked inserts or updates a LabelRule but not buildRangeList.
+// SetLabelRuleLocked inserts or updates a LabelRule. The enclosing Unlock
+// publishes derived index updates.
 // It updates the in-memory states and storage at the same time.
 // Callers must have already validated/adjusted the rule (checkAndAdjust or
 // NewLabelRuleFromJSON), because this method does not re-validate.
@@ -322,7 +282,7 @@ func (l *RegionLabeler) SetLabelRuleLocked(rule *LabelRule) error {
 	}); err != nil {
 		return err
 	}
-	l.setLabelRuleInMemoryLocked(rule)
+	l.ruleIndex.set(rule)
 	return nil
 }
 
@@ -337,15 +297,15 @@ func (l *RegionLabeler) DeleteLabelRule(id string) error {
 	// only Lock for in-memory update
 	l.Lock()
 	defer l.Unlock()
-	if _, ok := l.labelRules[id]; !ok {
+	if _, ok := l.ruleIndex.rules[id]; !ok {
 		return errs.ErrRegionRuleNotFound.FastGenByArgs(id)
 	}
-	l.deleteLabelRuleInMemoryLocked(id)
-	l.BuildRangeListLocked()
+	l.ruleIndex.delete(id)
 	return nil
 }
 
-// DeleteLabelRuleLocked removes a LabelRule but not buildRangeList.
+// DeleteLabelRuleLocked removes a LabelRule. The enclosing Unlock publishes
+// derived index updates.
 // It updates the in-memory states and storage at the same time.
 // It should be used in watcher.
 func (l *RegionLabeler) DeleteLabelRuleLocked(id string) error {
@@ -354,38 +314,8 @@ func (l *RegionLabeler) DeleteLabelRuleLocked(id string) error {
 	}); err != nil {
 		return err
 	}
-	l.deleteLabelRuleInMemoryLocked(id)
+	l.ruleIndex.delete(id)
 	return nil
-}
-
-func (l *RegionLabeler) setLabelRuleInMemoryLocked(rule *LabelRule) {
-	if old, ok := l.labelRules[rule.ID]; ok {
-		if l.keyspaceRules.Replace(old, rule) {
-			l.labelRules[rule.ID] = rule
-			return
-		}
-		if !l.keyspaceRules.Remove(rule.ID, old) {
-			delete(l.genericRules, old.ID)
-			l.rangeListDirty = true
-		}
-	}
-	l.labelRules[rule.ID] = rule
-	if !l.keyspaceRules.Add(rule) {
-		l.genericRules[rule.ID] = rule
-		l.rangeListDirty = true
-	}
-}
-
-func (l *RegionLabeler) deleteLabelRuleInMemoryLocked(id string) {
-	rule, ok := l.labelRules[id]
-	if !ok {
-		return
-	}
-	if !l.keyspaceRules.Remove(id, rule) {
-		delete(l.genericRules, id)
-		l.rangeListDirty = true
-	}
-	delete(l.labelRules, id)
 }
 
 // Patch updates multiple region rules in a batch.
@@ -428,12 +358,11 @@ func (l *RegionLabeler) Patch(patch LabelRulePatch) error {
 	defer l.Unlock()
 
 	for _, key := range patch.DeleteRules {
-		l.deleteLabelRuleInMemoryLocked(key)
+		l.ruleIndex.delete(key)
 	}
 	for _, rule := range setRulesMap {
-		l.setLabelRuleInMemoryLocked(rule)
+		l.ruleIndex.set(rule)
 	}
-	l.BuildRangeListLocked()
 	return nil
 }
 
@@ -445,7 +374,7 @@ func (l *RegionLabeler) GetRegionLabel(region *core.RegionInfo, key string) stri
 	now := time.Now()
 	value, index := "", -1
 	// search ranges
-	rules, keyspaceRule, ok := l.getRangeRulesLocked(region.GetStartKey(), region.GetEndKey())
+	rules, keyspaceRule, ok := l.ruleIndex.getRangeRules(region.GetStartKey(), region.GetEndKey())
 	if !ok {
 		return ""
 	}
@@ -489,7 +418,7 @@ func (l *RegionLabeler) GetRegionLabels(region *core.RegionInfo) []*RegionLabel 
 	labels := make(map[string]valueIndex)
 	now := time.Now()
 	// search ranges
-	rules, keyspaceRule, ok := l.getRangeRulesLocked(region.GetStartKey(), region.GetEndKey())
+	rules, keyspaceRule, ok := l.ruleIndex.getRangeRules(region.GetStartKey(), region.GetEndKey())
 	if ok {
 		applyRule := func(r *LabelRule) {
 			for _, label := range r.Labels {
@@ -518,18 +447,6 @@ func (l *RegionLabeler) GetRegionLabels(region *core.RegionInfo) []*RegionLabel 
 	return result
 }
 
-func (l *RegionLabeler) getRangeRulesLocked(start, end []byte) ([]any, *LabelRule, bool) {
-	rules, ok := l.rangeList.GetDataByRange(start, end)
-	if !ok {
-		return nil, nil, false
-	}
-	keyspaceRule := l.keyspaceRules.GetRule(start, end)
-	if keyspaceRule == nil && l.keyspaceRules.HasSplitKey(start, end) {
-		return nil, nil, false
-	}
-	return rules, keyspaceRule, true
-}
-
 // MakeKeyRanges is a helper function to make key ranges.
 func MakeKeyRanges(keys ...string) []any {
 	var res []any
@@ -543,7 +460,7 @@ func MakeKeyRanges(keys ...string) []any {
 func (l *RegionLabeler) IterateLabelRules(iterator func(rule *LabelRule) bool) {
 	l.RLock()
 	defer l.RUnlock()
-	for _, rule := range l.labelRules {
+	for _, rule := range l.ruleIndex.rules {
 		if !iterator(rule) {
 			return
 		}

--- a/pkg/schedule/labeler/labeler_test.go
+++ b/pkg/schedule/labeler/labeler_test.go
@@ -449,8 +449,31 @@ func TestLabelerRuleTTL(t *testing.T) {
 	re.NotNil(labeler.GetLabelRule("rule1"))
 }
 
+func TestExpiredRuleRemovalPublishesRangeIndex(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	labeler, err := NewRegionLabeler(ctx, endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil), time.Hour)
+	re.NoError(err)
+	re.NoError(labeler.SetLabelRule(&LabelRule{
+		ID:       "expiring-rule",
+		Labels:   []RegionLabel{{Key: "k", Value: "v", TTL: "1s"}},
+		RuleType: KeyRange,
+		Data:     MakeKeyRanges("1234", "5678"),
+	}))
+	re.NotEmpty(labeler.GetSplitKeys(nil, nil))
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/schedule/labeler/regionLabelExpireSub1Minute", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/labeler/regionLabelExpireSub1Minute"))
+	}()
+	re.Nil(labeler.GetLabelRule("expiring-rule"))
+	labeler.checkAndClearExpiredLabels()
+	re.Empty(labeler.GetSplitKeys(nil, nil))
+}
+
 func checkRuleInMemoryAndStorage(re *require.Assertions, labeler *RegionLabeler, ruleID string, exist bool) {
-	re.Equal(exist, labeler.labelRules[ruleID] != nil)
+	re.Equal(exist, labeler.ruleIndex.rules[ruleID] != nil)
 	existInStorage := false
 	err := labeler.storage.LoadRegionRules(func(k, _ string) {
 		if k == ruleID {
@@ -490,7 +513,7 @@ func TestGC(t *testing.T) {
 		re.NoError(err)
 	}
 
-	re.Len(labeler.labelRules, len(ttls))
+	re.Len(labeler.ruleIndex.rules, len(ttls))
 
 	// check all rules until some rule expired.
 	for {
@@ -502,12 +525,12 @@ func TestGC(t *testing.T) {
 	}
 
 	// no rule was cleared because the gc interval is big.
-	re.Len(labeler.labelRules, len(ttls))
+	re.Len(labeler.ruleIndex.rules, len(ttls))
 
 	labeler.checkAndClearExpiredLabels()
 
 	labeler.RLock()
-	currentRuleLen := len(labeler.labelRules)
+	currentRuleLen := len(labeler.ruleIndex.rules)
 	labeler.RUnlock()
 	re.LessOrEqual(currentRuleLen, 5)
 }

--- a/pkg/schedule/labeler/plan.go
+++ b/pkg/schedule/labeler/plan.go
@@ -51,7 +51,7 @@ func (p *Plan) SetLabelRule(rule *LabelRule) error {
 		return p.labeler.storage.SaveRegionRule(txn, rule.ID, rule)
 	})
 	p.applyLockedOps = append(p.applyLockedOps, func() {
-		p.labeler.setLabelRuleInMemoryLocked(rule)
+		p.labeler.ruleIndex.set(rule)
 	})
 	return nil
 }
@@ -66,7 +66,7 @@ func (p *Plan) DeleteLabelRule(id string) error {
 		return p.labeler.storage.DeleteRegionRule(txn, id)
 	})
 	p.applyLockedOps = append(p.applyLockedOps, func() {
-		p.labeler.deleteLabelRuleInMemoryLocked(id)
+		p.labeler.ruleIndex.delete(id)
 	})
 	return nil
 }
@@ -90,5 +90,4 @@ func (p *Plan) Apply() {
 	for _, op := range p.applyLockedOps {
 		op()
 	}
-	p.labeler.BuildRangeListLocked()
 }

--- a/pkg/schedule/labeler/plan_test.go
+++ b/pkg/schedule/labeler/plan_test.go
@@ -201,6 +201,12 @@ func TestPlanApply(t *testing.T) {
 	re.NotNil(labeler.GetLabelRule("rule1"))
 	re.NotNil(labeler.GetLabelRule("rule2"))
 	re.Nil(labeler.GetLabelRule("existing"))
+	re.Equal([][]byte{
+		{0x12, 0x34},
+		{0x56, 0x78},
+		{0xab, 0xcd},
+		{0xef, 0xef},
+	}, labeler.GetSplitKeys(nil, nil))
 }
 
 func TestPlanApplyWithError(t *testing.T) {

--- a/pkg/schedule/labeler/rule_index.go
+++ b/pkg/schedule/labeler/rule_index.go
@@ -122,9 +122,18 @@ func (i *labelRuleIndex) getRangeRules(start, end []byte) ([]any, *LabelRule, bo
 	if !ok {
 		return nil, nil, false
 	}
-	keyspaceRule := i.keyspaces.GetRule(start, end)
-	if keyspaceRule == nil && i.keyspaces.HasSplitKey(start, end) {
+	if i.keyspaces.isEmpty() {
+		return rules, nil, true
+	}
+	if !keyspaceModesOverlapRange(start, end) {
+		return rules, nil, true
+	}
+	keyspaceRule, withinKeyspace := i.keyspaces.matchRule(start, end)
+	if withinKeyspace {
+		return rules, keyspaceRule, true
+	}
+	if i.keyspaces.HasSplitKey(start, end) {
 		return nil, nil, false
 	}
-	return rules, keyspaceRule, true
+	return rules, nil, true
 }

--- a/pkg/schedule/labeler/rule_index.go
+++ b/pkg/schedule/labeler/rule_index.go
@@ -1,0 +1,130 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labeler
+
+import (
+	"time"
+
+	"github.com/tikv/pd/pkg/schedule/rangelist"
+)
+
+// labelRuleIndex owns all in-memory views of label rules. rules is the
+// authoritative map, generic and keyspaces partition it, and ranges is derived
+// from generic. Its caller must hold RegionLabeler's lock while mutating it.
+type labelRuleIndex struct {
+	rules       map[string]*LabelRule
+	generic     map[string]*LabelRule
+	keyspaces   keyspaceRuleIndex
+	ranges      rangelist.List
+	rangesDirty bool
+	minExpire   *time.Time
+}
+
+func newLabelRuleIndex(rules map[string]*LabelRule) labelRuleIndex {
+	if rules == nil {
+		rules = make(map[string]*LabelRule)
+	}
+	index := labelRuleIndex{
+		rules:       rules,
+		generic:     make(map[string]*LabelRule),
+		rangesDirty: true,
+	}
+	for _, rule := range rules {
+		if !index.keyspaces.Add(rule) {
+			index.generic[rule.ID] = rule
+		}
+	}
+	index.buildRanges()
+	return index
+}
+
+func (i *labelRuleIndex) set(rule *LabelRule) {
+	if old, ok := i.rules[rule.ID]; ok {
+		if i.keyspaces.Replace(old, rule) {
+			i.rules[rule.ID] = rule
+			return
+		}
+		if !i.keyspaces.Remove(rule.ID, old) {
+			delete(i.generic, old.ID)
+			i.rangesDirty = true
+		}
+	}
+	i.rules[rule.ID] = rule
+	if !i.keyspaces.Add(rule) {
+		i.generic[rule.ID] = rule
+		i.rangesDirty = true
+	}
+}
+
+func (i *labelRuleIndex) delete(id string) {
+	rule, ok := i.rules[id]
+	if !ok {
+		return
+	}
+	if !i.keyspaces.Remove(id, rule) {
+		delete(i.generic, id)
+		i.rangesDirty = true
+	}
+	delete(i.rules, id)
+}
+
+func (i *labelRuleIndex) removeExpiredLabels(rule *LabelRule, now time.Time) bool {
+	if !rule.checkAndRemoveExpireLabels(now) {
+		return false
+	}
+	// Rebuild on publish to refresh minExpire together with the range view.
+	i.rangesDirty = true
+	return true
+}
+
+func (i *labelRuleIndex) buildRanges() {
+	if !i.rangesDirty {
+		return
+	}
+
+	builder := rangelist.NewBuilder()
+	i.minExpire = nil
+	for _, rule := range i.generic {
+		if i.minExpire == nil || rule.expireBefore(*i.minExpire) {
+			i.minExpire = rule.minExpire
+		}
+		if rule.RuleType == KeyRange {
+			for _, r := range rule.Data.([]*KeyRangeRule) {
+				builder.AddItem(r.StartKey, r.EndKey, rule)
+			}
+		}
+	}
+	i.ranges = builder.Build()
+	i.rangesDirty = false
+}
+
+func (i *labelRuleIndex) getSplitKeys(start, end []byte) [][]byte {
+	return mergeSplitKeys(
+		i.ranges.GetSplitKeys(start, end),
+		i.keyspaces.GetSplitKeys(start, end),
+	)
+}
+
+func (i *labelRuleIndex) getRangeRules(start, end []byte) ([]any, *LabelRule, bool) {
+	rules, ok := i.ranges.GetDataByRange(start, end)
+	if !ok {
+		return nil, nil, false
+	}
+	keyspaceRule := i.keyspaces.GetRule(start, end)
+	if keyspaceRule == nil && i.keyspaces.HasSplitKey(start, end) {
+		return nil, nil, false
+	}
+	return rules, keyspaceRule, true
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11087

The incremental keyspace rule index allocates sparse chunks up to the
highest keyspace ID. Split-key lookups currently scan every chunk in the
numeric query range, including unallocated chunks. With only a maximum-ID
rule, an empty full-range lookup takes about 55 microseconds.

### What is changed and how does it work?

```commit-message
Track non-empty keyspace rule chunks in a compact two-level bitmap.
Use the bitmap to skip empty ID spans while preserving ordered,
de-duplicated split boundaries.
Add sparse-gap regression coverage and a benchmark.
```

### Check List

Tests

- Unit test
- Manual test:
  - `make gotest GOTEST_ARGS="./pkg/schedule/labeler ./pkg/schedule/rangelist -count=1"`
  - Sparse high-ID benchmark before and after the change

Side effects

- Increased code complexity

### Release note

```release-note
Improve split-key lookup performance for sparse high-ID keyspace label rules.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sparse, high-ID, and non-canonical keyspace rules.
  * Ensured split-key searches return no results across gaps.
  * Strengthened boundary validation, mode checks, and expired-rule cleanup.
  * Improved consistency when adding, replacing, or deleting label rules.

* **Performance**
  * Faster searches and boundary detection in sparse keyspaces.
  * Reduced unnecessary recalculation during label rule updates.
  * Improved reliability across keyspace boundaries and high-ID lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->