### PR TITLE
server, pd-ctl: support batched keyspace Region scans

### DIFF
--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -2112,13 +2112,9 @@ func (r *RegionsInfo) GetRegionCount(startKey, endKey []byte) int {
 	return r.tree.GetCountByRange(startKey, endKey)
 }
 
-// ScanRegions scans regions intersecting [start key, end key), returns at most
-// `limit` regions. limit <= 0 means no limit.
-func (r *RegionsInfo) ScanRegions(startKey, endKey []byte, limit int) []*RegionInfo {
-	r.t.RLock()
-	defer r.t.RUnlock()
+func scanRegions(tree *regionTree, startKey, endKey []byte, limit int) []*RegionInfo {
 	var res []*RegionInfo
-	r.tree.scanRange(startKey, func(region *RegionInfo) bool {
+	tree.scanRange(startKey, func(region *RegionInfo) bool {
 		if len(endKey) > 0 && bytes.Compare(region.GetStartKey(), endKey) >= 0 {
 			return false
 		}
@@ -2129,6 +2125,35 @@ func (r *RegionsInfo) ScanRegions(startKey, endKey []byte, limit int) []*RegionI
 		return true
 	})
 	return res
+}
+
+// ScanRegions scans regions intersecting [start key, end key), returns at most
+// `limit` regions. limit <= 0 means no limit.
+func (r *RegionsInfo) ScanRegions(startKey, endKey []byte, limit int) []*RegionInfo {
+	r.t.RLock()
+	defer r.t.RUnlock()
+	return scanRegions(r.tree, startKey, endKey, limit)
+}
+
+// RegionTreeSnapshot is an immutable, lazy copy-on-write view of the Region tree.
+type RegionTreeSnapshot struct {
+	tree *regionTree
+}
+
+// GetRegionTreeSnapshot returns a snapshot that can be scanned concurrently
+// with updates to the source RegionsInfo.
+func (r *RegionsInfo) GetRegionTreeSnapshot() *RegionTreeSnapshot {
+	// btree.Clone updates the source tree's copy-on-write context, so clone it
+	// under the exclusive tree lock. The clone itself is O(1).
+	r.t.Lock()
+	defer r.t.Unlock()
+	return &RegionTreeSnapshot{tree: r.tree.clone()}
+}
+
+// ScanRegions scans the snapshot for Regions intersecting [startKey, endKey),
+// returning at most limit Regions. limit <= 0 means no limit.
+func (s *RegionTreeSnapshot) ScanRegions(startKey, endKey []byte, limit int) []*RegionInfo {
+	return scanRegions(s.tree, startKey, endKey, limit)
 }
 
 // BatchScanRegions scans regions in given key pairs, returns at most `limit` regions.

--- a/pkg/core/region_test.go
+++ b/pkg/core/region_test.go
@@ -1459,6 +1459,41 @@ func TestRegionCount(t *testing.T) {
 	}
 }
 
+func TestRegionTreeSnapshot(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	regions.PutRegion(NewTestRegionInfo(1, 1, []byte("a"), []byte("b")))
+	regions.PutRegion(NewTestRegionInfo(2, 1, []byte("b"), []byte("c")))
+
+	snapshot := regions.GetRegionTreeSnapshot()
+	firstBatch := snapshot.ScanRegions([]byte("a"), []byte("c"), 1)
+	regions.PutRegion(NewTestRegionInfo(3, 1, []byte("a"), []byte("c")))
+
+	secondBatch := snapshot.ScanRegions(firstBatch[0].GetEndKey(), []byte("c"), 1)
+	re.Equal([]uint64{1, 2}, []uint64{firstBatch[0].GetID(), secondBatch[0].GetID()})
+	got := regions.ScanRegions([]byte("a"), []byte("c"), 0)
+	re.Equal([]uint64{3}, []uint64{got[0].GetID()})
+}
+
+func BenchmarkRegionTreeSnapshot(b *testing.B) {
+	regions := NewRegionsInfo()
+	const regionCount = 100000
+	for i := range regionCount {
+		regions.PutRegion(NewTestRegionInfo(
+			uint64(i+1), 1,
+			[]byte(fmt.Sprintf("%09d", i)),
+			[]byte(fmt.Sprintf("%09d", i+1)),
+		))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		snapshot := regions.GetRegionTreeSnapshot()
+		_ = snapshot.ScanRegions(nil, nil, 1)
+	}
+}
+
 func TestResetRegionCache(t *testing.T) {
 	re := require.New(t)
 	regions := NewRegionsInfo()

--- a/pkg/core/region_tree.go
+++ b/pkg/core/region_tree.go
@@ -92,6 +92,12 @@ func newRegionTreeWithCountRef() *regionTree {
 	}
 }
 
+func (t *regionTree) clone() *regionTree {
+	clone := *t
+	clone.tree = t.tree.Clone()
+	return &clone
+}
+
 // GetCountByRange returns the number of regions in the range [startKey, endKey).
 func (t *regionTree) GetCountByRange(startKey, endKey []byte) int {
 	start := &regionItem{&RegionInfo{meta: &metapb.Region{StartKey: startKey}}}

--- a/server/api/region.go
+++ b/server/api/region.go
@@ -15,8 +15,11 @@
 package api
 
 import (
+	"bytes"
 	"container/heap"
+	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -27,8 +30,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/unrolled/render"
 
+	"github.com/pingcap/errcode"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
@@ -36,6 +42,7 @@ import (
 	"github.com/tikv/pd/pkg/response"
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/utils/apiutil"
+	"github.com/tikv/pd/pkg/utils/keyutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server"
 )
@@ -284,6 +291,7 @@ func (h *regionsHandler) GetStoreRegions(w http.ResponseWriter, r *http.Request)
 //	@Summary	List regions belongs to the given keyspace ID.
 //	@Param		keyspace_id	query	string	true	"Keyspace ID"
 //	@Param		limit		query	integer	false	"Limit count"	default(16)
+//	@Param		batch		query	integer	false	"Maximum Regions processed per internal scan/write batch; does not change the result limit or schema"
 //	@Produce	json
 //	@Success	200	{object}	response.RegionsInfo
 //	@Failure	400	{string}	string	"The input is invalid."
@@ -309,12 +317,33 @@ func (h *regionsHandler) GetKeyspaceRegions(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	limit, err := h.AdjustLimit(r.URL.Query().Get("limit"))
+	query := r.URL.Query()
+	limit, err := h.AdjustLimit(query.Get("limit"))
 	if err != nil {
 		h.rd.JSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	regionBound := keyspace.MakeRegionBound(keyspaceID)
+	if query.Has("batch") {
+		batchStr := query.Get("batch")
+		if batchStr == "" {
+			apiutil.ErrorResp(h.rd, w, errcode.NewInvalidInputErr(errors.New("batch should be a positive number")))
+			return
+		}
+		batch, err := h.AdjustLimit(batchStr)
+		if err != nil {
+			apiutil.ErrorResp(h.rd, w, errcode.NewInvalidInputErr(err))
+			return
+		}
+		if batch <= 0 {
+			apiutil.ErrorResp(h.rd, w, errcode.NewInvalidInputErr(errors.New("batch should be a positive number")))
+			return
+		}
+		snapshot := rc.GetBasicCluster().GetRegionTreeSnapshot()
+		h.writeKeyspaceRegionsInBatches(r.Context(), w, snapshot.ScanRegions, regionBound, limit, batch)
+		return
+	}
+
 	regions := rc.ScanRegions(regionBound.RawLeftBound, regionBound.RawRightBound, limit)
 	if limit <= 0 || limit > len(regions) {
 		txnRegion := rc.ScanRegions(regionBound.TxnLeftBound, regionBound.TxnRightBound, limit-len(regions))
@@ -326,6 +355,80 @@ func (h *regionsHandler) GetKeyspaceRegions(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	h.rd.Data(w, http.StatusOK, b)
+}
+
+func (*regionsHandler) writeKeyspaceRegionsInBatches(
+	ctx context.Context,
+	w http.ResponseWriter,
+	scanRegions func(startKey, endKey []byte, limit int) []*core.RegionInfo,
+	regionBound *keyspace.RegionBound,
+	limit, batch int,
+) {
+	if ctx.Err() != nil {
+		return
+	}
+	w.Header().Set(render.ContentType, render.ContentBinary)
+	w.WriteHeader(http.StatusOK)
+	if _, err := io.WriteString(w, `{"regions":[`); err != nil {
+		return
+	}
+
+	count := 0
+	defer func() {
+		// Keep the response structurally valid when a server-side cancellation
+		// happens after writing starts. A disconnected client will reject writes.
+		if _, err := io.WriteString(w, `],"count":`+strconv.Itoa(count)+"}"); err != nil {
+			log.Debug("failed to finish keyspace regions response", zap.Error(err))
+		}
+	}()
+	keyRanges := []keyutil.KeyRange{
+		{StartKey: regionBound.RawLeftBound, EndKey: regionBound.RawRightBound},
+		{StartKey: regionBound.TxnLeftBound, EndKey: regionBound.TxnRightBound},
+	}
+	for _, keyRange := range keyRanges {
+		startKey, endKey := keyRange.StartKey, keyRange.EndKey
+		for limit <= 0 || count < limit {
+			if ctx.Err() != nil {
+				return
+			}
+			scanLimit := batch
+			if limit > 0 && scanLimit > limit-count {
+				scanLimit = limit - count
+			}
+			regions := scanRegions(startKey, endKey, scanLimit)
+			if len(regions) == 0 {
+				break
+			}
+			for _, region := range regions {
+				b, err := response.MarshalRegionInfoJSON(ctx, region)
+				if err != nil {
+					return
+				}
+				if count > 0 {
+					if _, err := io.WriteString(w, ","); err != nil {
+						return
+					}
+				}
+				if _, err := w.Write(b); err != nil {
+					return
+				}
+				count++
+			}
+			failpoint.InjectCall("afterKeyspaceRegionsBatch")
+
+			nextKey := regions[len(regions)-1].GetEndKey()
+			if len(nextKey) == 0 || bytes.Compare(nextKey, endKey) >= 0 {
+				break
+			}
+			if bytes.Compare(nextKey, startKey) <= 0 {
+				break
+			}
+			startKey = nextKey
+		}
+		if limit > 0 && count >= limit {
+			break
+		}
+	}
 }
 
 // GetMissPeerRegions returns all regions that miss peer.

--- a/server/api/region_test.go
+++ b/server/api/region_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"math/rand/v2"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +28,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/keyspace"
+	keyspaceconstant "github.com/tikv/pd/pkg/keyspace/constant"
 	"github.com/tikv/pd/pkg/response"
 	statutils "github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -149,6 +152,60 @@ func TestRegionsInfoMarshal(t *testing.T) {
 		err = json.Unmarshal(b, regionsInfo)
 		re.NoError(err)
 	}
+}
+
+func TestWriteKeyspaceRegionsInBatches(t *testing.T) {
+	re := require.New(t)
+	bound := keyspace.MakeRegionBound(keyspaceconstant.MaxValidKeyspaceID)
+	regions := core.NewRegionsInfo()
+	rawMiddle := append(append([]byte(nil), bound.RawLeftBound...), 1)
+	txnMiddle := append(append([]byte(nil), bound.TxnLeftBound...), 1)
+	for _, region := range []*core.RegionInfo{
+		core.NewTestRegionInfo(1, 1, bound.RawLeftBound, rawMiddle),
+		core.NewTestRegionInfo(2, 1, rawMiddle, bound.RawRightBound),
+		core.NewTestRegionInfo(3, 1, bound.TxnLeftBound, txnMiddle),
+		core.NewTestRegionInfo(4, 1, txnMiddle, bound.TxnRightBound),
+	} {
+		regions.PutRegion(region)
+	}
+
+	var scanLimits []int
+	scanRegions := func(startKey, endKey []byte, limit int) []*core.RegionInfo {
+		scanLimits = append(scanLimits, limit)
+		return regions.ScanRegions(startKey, endKey, limit)
+	}
+	w := httptest.NewRecorder()
+	(&regionsHandler{}).writeKeyspaceRegionsInBatches(
+		context.Background(), w, scanRegions, bound, 0, 1)
+
+	got := &response.RegionsInfo{}
+	re.NoError(json.Unmarshal(w.Body.Bytes(), got))
+	re.Equal(4, got.Count)
+	re.Equal([]uint64{1, 2, 3, 4}, []uint64{
+		got.Regions[0].ID, got.Regions[1].ID, got.Regions[2].ID, got.Regions[3].ID,
+	})
+	re.Equal([]int{1, 1, 1, 1}, scanLimits)
+}
+
+func TestWriteKeyspaceRegionsInBatchesStopsOnCancellation(t *testing.T) {
+	re := require.New(t)
+	bound := keyspace.MakeRegionBound(keyspaceconstant.MaxValidKeyspaceID)
+	ctx, cancel := context.WithCancel(context.Background())
+	scanCount := 0
+	scanRegions := func(_, _ []byte, _ int) []*core.RegionInfo {
+		scanCount++
+		cancel()
+		return []*core.RegionInfo{
+			core.NewTestRegionInfo(1, 1, bound.RawLeftBound, bound.RawRightBound),
+		}
+	}
+
+	w := httptest.NewRecorder()
+	(&regionsHandler{}).writeKeyspaceRegionsInBatches(ctx, w, scanRegions, bound, 0, 1)
+	re.Equal(1, scanCount)
+	got := &response.RegionsInfo{}
+	re.NoError(json.Unmarshal(w.Body.Bytes(), got))
+	re.Zero(got.Count)
 }
 
 func BenchmarkHexRegionKey(b *testing.B) {

--- a/tests/server/api/region_test.go
+++ b/tests/server/api/region_test.go
@@ -19,11 +19,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
 	"sort"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,6 +38,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/response"
 	"github.com/tikv/pd/pkg/schedule/checker"
 	"github.com/tikv/pd/pkg/schedule/placement"
@@ -65,6 +68,82 @@ func (suite *regionTestSuite) TearDownSuite() {
 func (suite *regionTestSuite) TearDownTest() {
 	re := suite.Require()
 	suite.env.Reset(re)
+}
+
+func (suite *regionTestSuite) TestGetKeyspaceRegionsInBatches() {
+	suite.env.RunTest(suite.checkGetKeyspaceRegionsInBatches)
+}
+
+func (suite *regionTestSuite) checkGetKeyspaceRegionsInBatches(cluster *tests.TestCluster) {
+	re := suite.Require()
+	leader := cluster.GetLeaderServer()
+	keyspaceID := keyspace.GetBootstrapKeyspaceID()
+	bound := keyspace.MakeRegionBound(keyspaceID)
+	rawMiddle := append(append([]byte(nil), bound.RawLeftBound...), 1)
+	txnMiddle := append(append([]byte(nil), bound.TxnLeftBound...), 1)
+
+	regions := []*core.RegionInfo{
+		tests.MustPutRegion(re, cluster, 9001, 1, bound.RawLeftBound, rawMiddle),
+		tests.MustPutRegion(re, cluster, 9002, 1, rawMiddle, bound.RawRightBound),
+		tests.MustPutRegion(re, cluster, 9003, 1, bound.TxnLeftBound, txnMiddle),
+		tests.MustPutRegion(re, cluster, 9004, 1, txnMiddle, bound.TxnRightBound),
+	}
+	urlPrefix := fmt.Sprintf("%s/pd/api/v1/regions/keyspace/id/%d", leader.GetAddr(), keyspaceID)
+
+	getRegions := func(query string) *response.RegionsInfo {
+		got := &response.RegionsInfo{}
+		re.NoError(testutil.ReadGetJSON(re, tests.TestDialClient, urlPrefix+query, got))
+		return got
+	}
+
+	want := getRegions("?limit=0")
+	got := getRegions("?limit=0&batch=1")
+	re.Equal(want, got)
+	re.Equal(len(regions), got.Count)
+	for i, region := range regions {
+		re.Equal(region.GetID(), got.Regions[i].ID)
+	}
+
+	got = getRegions("?limit=3&batch=2")
+	re.Equal(3, got.Count)
+	re.Equal([]uint64{9001, 9002, 9003}, []uint64{got.Regions[0].ID, got.Regions[1].ID, got.Regions[2].ID})
+
+	rc := leader.GetRaftCluster().GetBasicCluster()
+	runWithTopologyChange := func(change func()) (got *response.RegionsInfo) {
+		var changed atomic.Bool
+		re.NoError(failpoint.EnableCall("github.com/tikv/pd/server/api/afterKeyspaceRegionsBatch", func() {
+			if changed.CompareAndSwap(false, true) {
+				change()
+			}
+		}))
+		defer func() {
+			re.NoError(failpoint.Disable("github.com/tikv/pd/server/api/afterKeyspaceRegionsBatch"))
+		}()
+		got = getRegions("?limit=0&batch=1")
+		re.True(changed.Load())
+		return got
+	}
+
+	got = runWithTopologyChange(func() {
+		rc.PutRegion(core.NewTestRegionInfo(9010, 1, bound.RawLeftBound, bound.RawRightBound))
+	})
+	re.Equal(got.Count, len(got.Regions))
+	re.Equal([]uint64{9001, 9002, 9003, 9004}, []uint64{got.Regions[0].ID, got.Regions[1].ID, got.Regions[2].ID, got.Regions[3].ID})
+
+	rc.PutRegion(core.NewTestRegionInfo(9001, 1, bound.RawLeftBound, rawMiddle))
+	rc.PutRegion(core.NewTestRegionInfo(9002, 1, rawMiddle, bound.RawRightBound))
+	rawMiddle2 := append(append([]byte(nil), bound.RawLeftBound...), 2)
+	got = runWithTopologyChange(func() {
+		rc.PutRegion(core.NewTestRegionInfo(9011, 1, rawMiddle, rawMiddle2))
+		rc.PutRegion(core.NewTestRegionInfo(9012, 1, rawMiddle2, bound.RawRightBound))
+	})
+	re.Equal(got.Count, len(got.Regions))
+	re.Equal([]uint64{9001, 9002, 9003, 9004}, []uint64{got.Regions[0].ID, got.Regions[1].ID, got.Regions[2].ID, got.Regions[3].ID})
+
+	for _, batch := range []string{"", "invalid", "0", "-1"} {
+		url := urlPrefix + "?limit=0&batch=" + batch
+		re.NoError(testutil.CheckGetJSON(tests.TestDialClient, url, nil, testutil.Status(re, http.StatusBadRequest)))
+	}
 }
 
 func (suite *regionTestSuite) TestAccelerateRegionsScheduleInRanges() {
@@ -829,5 +908,41 @@ func BenchmarkGetRegions(b *testing.B) {
 		resp, err := apiutil.GetJSON(tests.TestDialClient, url, nil)
 		re.NoError(err)
 		resp.Body.Close()
+	}
+}
+
+func BenchmarkGetKeyspaceRegionsInBatches(b *testing.B) {
+	re := require.New(b)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 1)
+	re.NoError(err)
+	defer cluster.Destroy()
+
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+	leaderServer := cluster.GetLeaderServer()
+	re.NoError(leaderServer.BootstrapCluster())
+	bound := keyspace.MakeRegionBound(keyspace.GetBootstrapKeyspaceID())
+	const regionCount = 100000
+	startKey := bound.RawLeftBound
+	for i := range regionCount {
+		endKey := bound.RawRightBound
+		if i < regionCount-1 {
+			endKey = append(append([]byte(nil), bound.RawLeftBound...), fmt.Appendf(nil, "%09d", i+1)...)
+		}
+		tests.MustPutRegion(re, cluster, uint64(i+100), 1, startKey, endKey)
+		startKey = endKey
+	}
+	url := fmt.Sprintf("%s/pd/api/v1/regions/keyspace/id/%d?limit=0&batch=1024", leaderServer.GetAddr(), keyspace.GetBootstrapKeyspaceID())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		resp, err := apiutil.GetJSON(tests.TestDialClient, url, nil)
+		re.NoError(err)
+		_, err = io.Copy(io.Discard, resp.Body)
+		re.NoError(err)
+		re.NoError(resp.Body.Close())
 	}
 }

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -537,11 +537,14 @@ func NewRegionWithKeyspaceCommand() *cobra.Command {
 		Use:   "keyspace <subcommand>",
 		Short: "show region information of the given keyspace",
 	}
-	r.AddCommand(&cobra.Command{
-		Use:   "id <keyspace_id> [table-id <table_id>] [<limit>]",
-		Short: "show region information for the given keyspace id, optionally filtered by table id",
-		Run:   showRegionWithKeyspaceCommandFunc,
-	})
+	idCommand := &cobra.Command{
+		Use:     "id <keyspace_id> [table-id <table_id>] [<limit>] [--batch <size>]",
+		Short:   "show region information for the given keyspace id, optionally filtered by table id",
+		Example: "pd-ctl region keyspace id 42 0 --batch 1024 > regions.json",
+		Run:     showRegionWithKeyspaceCommandFunc,
+	}
+	idCommand.Flags().Int("batch", 0, "server-side scan/write batch size; does not change the result limit or schema")
+	r.AddCommand(idCommand)
 	return r
 }
 
@@ -564,12 +567,13 @@ func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 	}
 
 	prefix := regionsKeyspacePrefix + "/id/" + args[0]
+	query := make(url.Values)
 	if len(args) == 2 {
 		if _, err := strconv.Atoi(args[1]); err != nil {
 			cmd.Println("limit should be a number")
 			return
 		}
-		prefix += "?limit=" + args[1]
+		query.Set("limit", args[1])
 	} else if len(args) >= 3 {
 		if args[1] != "table-id" {
 			cmd.Println("the second argument should be table-id")
@@ -580,7 +584,6 @@ func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 			cmd.Println("table-id should be a number")
 			return
 		}
-		query := make(url.Values)
 		startKey, endKey := makeTableRangeInKeyspace(keyspaceID, tableID)
 		query.Set("key", string(startKey))
 		query.Set("end_key", string(endKey))
@@ -591,7 +594,23 @@ func showRegionWithKeyspaceCommandFunc(cmd *cobra.Command, args []string) {
 			}
 			query.Set("limit", args[3])
 		}
-		prefix = regionsKeyPrefix + "?" + query.Encode()
+		prefix = regionsKeyPrefix
+	}
+
+	if flag := cmd.Flag("batch"); flag != nil && flag.Changed {
+		if len(args) >= 3 {
+			cmd.Println("--batch is not supported with table-id")
+			return
+		}
+		batch, err := cmd.Flags().GetInt("batch")
+		if err != nil || batch <= 0 {
+			cmd.Println("batch should be a positive number")
+			return
+		}
+		query.Set("batch", strconv.Itoa(batch))
+	}
+	if len(query) > 0 {
+		prefix += "?" + query.Encode()
 	}
 
 	r, err := doRequest(cmd, prefix, http.MethodGet, http.Header{})

--- a/tools/pd-ctl/pdctl/command/region_command_test.go
+++ b/tools/pd-ctl/pdctl/command/region_command_test.go
@@ -112,6 +112,26 @@ func TestRegionKeyspaceIDPathWithLimit(t *testing.T) {
 	re.Contains(out.String(), `{"ok":true}`)
 }
 
+func TestRegionKeyspaceIDPathWithBatch(t *testing.T) {
+	re := require.New(t)
+	rt := &captureRegionRoundTripper{body: `{"ok":true}`}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "0", "--batch", "1024"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Equal("/pd/api/v1/regions/keyspace/id/1", rt.path)
+	re.Equal("batch=1024&limit=0", rt.rawQuery)
+	re.Contains(out.String(), `{"ok":true}`)
+}
+
 func TestRegionKeyspaceIDTableIDPathWithLimit(t *testing.T) {
 	re := require.New(t)
 	rt := &captureRegionRoundTripper{body: `{"ok":true}`}
@@ -136,6 +156,25 @@ func TestRegionKeyspaceIDTableIDPathWithLimit(t *testing.T) {
 	re.Equal("/pd/api/v1/regions/key", rt.path)
 	re.Equal(query.Encode(), rt.rawQuery)
 	re.Contains(out.String(), `{"ok":true}`)
+}
+
+func TestRegionKeyspaceIDTableIDRejectsBatch(t *testing.T) {
+	re := require.New(t)
+	rt := &captureRegionRoundTripper{body: `{"ok":true}`}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "table-id", "100", "--batch", "1024"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Empty(rt.path)
+	re.Contains(out.String(), "--batch is not supported with table-id")
 }
 
 func TestRegionKeyspaceIDInvalidKeyspaceID(t *testing.T) {
@@ -192,6 +231,20 @@ func TestRegionKeyspaceIDInvalidLimit(t *testing.T) {
 
 	re.NoError(cmd.Execute())
 	re.Contains(out.String(), "limit should be a number")
+}
+
+func TestRegionKeyspaceIDInvalidBatch(t *testing.T) {
+	re := require.New(t)
+
+	cmd := NewRegionWithKeyspaceCommand()
+	cmd.PersistentFlags().String("pd", "http://mock-pd:2379", "")
+	cmd.SetArgs([]string{"id", "1", "--batch", "0"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	re.NoError(cmd.Execute())
+	re.Contains(out.String(), "batch should be a positive number")
 }
 
 func TestRegionKeyspaceIDWrongTableIDLiteral(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

The keyspace Region endpoint cannot return all Regions while bounding per-scan work. With `limit=0`, it scans and materializes all RawKV and TxnKV Regions in one pass, which can hold the Region-tree read lock and build a large in-memory response; using a smaller `limit` only truncates the result.

Issue Number: Close #11090

### What is changed and how does it work?

```commit-message
Add an optional `batch` query parameter to the keyspace Region API and a matching `--batch` pd-ctl flag.

When batching is enabled, take a request-scoped copy-on-write Region-tree snapshot, scan RawKV and TxnKV Region ranges in batches, and stream the existing response format incrementally.

Keep `limit` as the total result limit and preserve the existing behavior when `batch` is omitted.
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has HTTP APIs changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))

### Release note

```release-note
Support configurable batching for keyspace Region scans in the HTTP API and pd-ctl.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched retrieval for keyspace regions through the API and `pd-ctl`, with configurable batch sizes.
  * Added validation and clear errors for invalid batch values and unsupported option combinations.
  * Added stable region snapshots for consistent scanning during concurrent updates.
* **Bug Fixes**
  * Improved cancellation handling and response streaming during large region scans.
  * Preserved ordering, limits, and range filtering across batched requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->