### PR TITLE
cluster: serialize PutStore uniqueness check with store write

### DIFF
--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -156,7 +156,11 @@ type Server interface {
 type RaftCluster struct {
 	syncutil.RWMutex
 	storeStateLock *syncutil.LockGroup
-	wg             sync.WaitGroup
+	// putStoreLock serializes uniqueness checks and store writes in putStoreImpl
+	// so concurrent PutStore requests with different store IDs cannot both pass
+	// an address / peer-address conflict check against a stale GetStores() snapshot.
+	putStoreLock syncutil.Mutex
+	wg           sync.WaitGroup
 
 	serverCtx context.Context
 	ctx       context.Context
@@ -1522,6 +1526,11 @@ func (c *RaftCluster) putStoreImpl(store *metapb.Store, force bool) error {
 	if err := c.checkStoreVersion(store); err != nil {
 		return err
 	}
+
+	// Serialize uniqueness checks with the store write so concurrent PutStore
+	// requests cannot both pass against a stale GetStores() snapshot (ref #11096).
+	c.putStoreLock.Lock()
+	defer c.putStoreLock.Unlock()
 
 	// Store address and peer address can not collide across stores.
 	// TiFlash uses peer address for Raft replication, so a non-empty peer

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -669,6 +670,109 @@ func TestReusePeerAddress(t *testing.T) {
 		Version:     "2.0.0",
 		DeployPath:  getTestDeployPath(4003),
 	}))
+}
+
+func TestConcurrentPutStoreAddressUniqueness(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+
+	const (
+		rounds      = 20
+		concurrency = 16
+		peerAddress = "mock://tiflash-peer-concurrent:20170"
+	)
+
+	for round := range rounds {
+		cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+		cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
+
+		var (
+			wg       sync.WaitGroup
+			success  atomic.Int32
+			failures atomic.Int32
+		)
+		wg.Add(concurrency)
+		for i := range concurrency {
+			go func(i int) {
+				defer wg.Done()
+				storeID := uint64(1000*round + i + 1)
+				err := cluster.PutMetaStore(&metapb.Store{
+					Id:          storeID,
+					Address:     fmt.Sprintf("mock://tiflash-%d-%d:3930", round, i),
+					PeerAddress: peerAddress,
+					State:       metapb.StoreState_Up,
+					Version:     "2.0.0",
+					DeployPath:  getTestDeployPath(storeID),
+				})
+				if err == nil {
+					success.Add(1)
+					return
+				}
+				failures.Add(1)
+				re.Contains(err.Error(), "duplicated store peer address")
+			}(i)
+		}
+		wg.Wait()
+
+		re.Equal(int32(1), success.Load(), "round %d: exactly one PutStore should succeed", round)
+		re.Equal(int32(concurrency-1), failures.Load(), "round %d: the rest should fail", round)
+
+		matched := 0
+		for _, store := range cluster.GetStores() {
+			if store.IsRemoved() || store.IsPhysicallyDestroyed() {
+				continue
+			}
+			if store.GetMeta().GetPeerAddress() == peerAddress {
+				matched++
+			}
+		}
+		re.Equal(1, matched, "round %d: only one live store should own the peer address", round)
+	}
+
+	// Concurrent cross-collision: address equals an existing peer address.
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
+	re.NoError(cluster.PutMetaStore(&metapb.Store{
+		Id:          1,
+		Address:     "mock://tiflash-a:3930",
+		PeerAddress: peerAddress,
+		State:       metapb.StoreState_Up,
+		Version:     "2.0.0",
+		DeployPath:  getTestDeployPath(1),
+	}))
+
+	var (
+		wg       sync.WaitGroup
+		success  atomic.Int32
+		failures atomic.Int32
+	)
+	wg.Add(concurrency)
+	for i := range concurrency {
+		go func(i int) {
+			defer wg.Done()
+			storeID := uint64(2000 + i)
+			err := cluster.PutMetaStore(&metapb.Store{
+				Id:         storeID,
+				Address:    peerAddress,
+				State:      metapb.StoreState_Up,
+				Version:    "2.0.0",
+				DeployPath: getTestDeployPath(storeID),
+			})
+			if err == nil {
+				success.Add(1)
+				return
+			}
+			failures.Add(1)
+			re.Contains(err.Error(), "duplicated store address")
+		}(i)
+	}
+	wg.Wait()
+	re.Equal(int32(0), success.Load())
+	re.Equal(int32(concurrency), failures.Load())
 }
 
 func TestUpStore(t *testing.T) {


### PR DESCRIPTION
<!--
PR draft for: cluster/serialize-put-store-uniqueness-check
Suggested title: cluster: serialize PutStore uniqueness check with store write
-->

### What problem does this PR solve?

Issue Number: Close #11096

`putStoreImpl` validates store `address` / `peer_address` uniqueness against `GetStores()`, then writes via `setStore`. That check-then-write window is not atomic: two concurrent `PutStore` requests with different store IDs can both observe a clean snapshot, both pass validation, and both persist, leaving live stores with colliding Raft-facing addresses.

This race already existed for the main-address check and was called out on #11007; #11096 tracks fixing it.

**Dependency:** This PR depends on #11007. Please do not merge it before #11007 lands. After #11007 is merged, this branch will be rebased onto `master` so the final diff only contains the serialization fix.

### What is changed and how does it work?

```commit-message
Add putStoreLock around uniqueness validation and setStore in putStoreImpl
so concurrent PutStore / label-update paths cannot both pass against a stale
GetStores() snapshot.
```

`putStoreLock` deliberately covers the full critical section:

1. in-memory uniqueness comparison (`GetStores()`)
2. etcd persistence (`SaveStoreMeta`)
3. in-memory cache update (`PutStore`)

Holding the lock only for the memory comparison would still leave a TOCTOU window before persistence / cache update. Covering all three steps is required to close the race.

**Performance / contention notes**

- StoreHeartbeat and RegionHeartbeat do **not** take this lock.
- Contention only shows up when many nodes register at the same time (large-scale expand or rolling restart / re-bootstrap). That path is infrequent.
- Critical-section latency is dominated by the existing etcd write and is typically on the order of milliseconds; the mutex itself is not the bottleneck.
- Given the above, the cost is acceptable for the correctness gain.

### Check List

Tests

- Unit test

Side effects

- Possible performance regression

Related changes

- Need to cherry-pick to the release branch

### Release note

```release-note
PD serializes store address uniqueness checks with PutStore writes to avoid concurrent conflicting store registrations.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved store address validation to prevent duplicate main and peer addresses.
  * Prevented conflicts between a store’s main address and another store’s peer address.
  * Allowed empty peer addresses and safe reuse after a store is removed.
  * Improved consistency when multiple stores are registered concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->