### PR TITLE
core, server/cluster: isolate preparing range size scans

### DIFF
--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -108,6 +108,36 @@ var (
 	queryRegionPrevKeysCount = queryRegionCount.WithLabelValues("prev-keys")
 	queryRegionIDsCount      = queryRegionCount.WithLabelValues("ids")
 
+	regionSizeTreeReadyGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "core",
+			Name:      "region_size_tree_ready",
+			Help:      "Whether the eventually consistent Region size tree is ready for queries.",
+		})
+	regionSizeTreePendingGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "core",
+			Name:      "region_size_tree_pending",
+			Help:      "Number of Region IDs queued or being reconciled by the Region size tree.",
+		})
+	regionSizeTreeOldestPendingDurationGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "pd",
+			Subsystem: "core",
+			Name:      "region_size_tree_oldest_pending_duration_seconds",
+			Help:      "Age in seconds of the oldest Region size tree update awaiting reconciliation.",
+		})
+	regionSizeTreeRebuildDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "pd",
+			Subsystem: "core",
+			Name:      "region_size_tree_rebuild_duration_seconds",
+			Help:      "Bucketed histogram of Region size tree rebuild attempt durations in seconds.",
+			Buckets:   prometheus.ExponentialBuckets(0.1, 2, 16),
+		})
+
 	bucketEventCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "pd",
@@ -133,7 +163,17 @@ func init() {
 	prometheus.MustRegister(AcquireRegionsLockWaitCount)
 	prometheus.MustRegister(queryRegionDuration)
 	prometheus.MustRegister(queryRegionCount)
+	prometheus.MustRegister(regionSizeTreeReadyGauge)
+	prometheus.MustRegister(regionSizeTreePendingGauge)
+	prometheus.MustRegister(regionSizeTreeOldestPendingDurationGauge)
+	prometheus.MustRegister(regionSizeTreeRebuildDuration)
 	prometheus.MustRegister(bucketEventCounter)
+}
+
+func resetRegionSizeTreeMetrics() {
+	regionSizeTreeReadyGauge.Set(0)
+	regionSizeTreePendingGauge.Set(0)
+	regionSizeTreeOldestPendingDurationGauge.Set(0)
 }
 
 var tracerPool = &sync.Pool{

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1059,6 +1059,10 @@ type RegionsInfo struct {
 	pendingPeers map[uint64]*regionTree // storeID -> sub regionTree
 	// This tree is used to check the overlaps among all the subtrees.
 	overlapTree *regionTree
+	// sizeTree is enabled only by the primary PD service. It never holds the
+	// root-tree or subtree lock while updating the size index.
+	sizeTreeMu syncutil.Mutex
+	sizeTree   atomic.Pointer[regionSizeTree]
 }
 
 // NewRegionsInfo creates RegionsInfo with tree, regions, leaders and followers
@@ -1073,6 +1077,78 @@ func NewRegionsInfo() *RegionsInfo {
 		witnesses:    make(map[uint64]*regionTree),
 		pendingPeers: make(map[uint64]*regionTree),
 		overlapTree:  newRegionTreeWithCountRef(),
+	}
+}
+
+// StartRegionSizeTree starts the eventually consistent range-size index.
+func (r *RegionsInfo) StartRegionSizeTree(ctx context.Context) {
+	if r.sizeTree.Load() != nil {
+		return
+	}
+	r.sizeTreeMu.Lock()
+	defer r.sizeTreeMu.Unlock()
+	if r.sizeTree.Load() != nil {
+		return
+	}
+	sizeTree := newRegionSizeTree(ctx, r)
+	resetRegionSizeTreeMetrics()
+	r.sizeTree.Store(sizeTree)
+	sizeTree.requestRebuild()
+	sizeTree.start()
+}
+
+// StopRegionSizeTree stops the range-size index and waits for its worker.
+func (r *RegionsInfo) StopRegionSizeTree() {
+	r.sizeTreeMu.Lock()
+	defer r.sizeTreeMu.Unlock()
+	if sizeTree := r.sizeTree.Swap(nil); sizeTree != nil {
+		sizeTree.stop()
+		resetRegionSizeTreeMetrics()
+	}
+}
+
+func (r *RegionsInfo) notifyRegionSizeTree(regionIDs ...uint64) {
+	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
+		sizeTree.notify(regionIDs...)
+	}
+}
+
+func (r *RegionsInfo) notifyRegionSizeTreeIfChanged(
+	origin, region *RegionInfo,
+	overlaps []*RegionInfo,
+	rangeChanged bool,
+) {
+	sizeTree := r.sizeTree.Load()
+	if sizeTree == nil {
+		return
+	}
+	sizeChanged := origin == nil || rangeChanged ||
+		origin.GetApproximateSize() != region.GetApproximateSize()
+	if len(overlaps) == 0 {
+		if sizeChanged {
+			sizeTree.notify(region.GetID())
+		}
+		return
+	}
+	capacity := len(overlaps)
+	if sizeChanged {
+		capacity++
+	}
+	regionIDs := make([]uint64, 0, capacity)
+	if sizeChanged {
+		regionIDs = append(regionIDs, region.GetID())
+	}
+	for _, overlap := range overlaps {
+		if overlap.GetID() != region.GetID() {
+			regionIDs = append(regionIDs, overlap.GetID())
+		}
+	}
+	sizeTree.notify(regionIDs...)
+}
+
+func (r *RegionsInfo) resetRegionSizeTree() {
+	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
+		sizeTree.requestReset()
 	}
 }
 
@@ -1108,6 +1184,7 @@ func (r *RegionsInfo) CheckAndPutRegion(region *RegionInfo) []*RegionInfo {
 	}
 	origin, overlaps, rangeChanged := r.setRegionLocked(region, true, ols...)
 	r.t.Unlock()
+	r.notifyRegionSizeTreeIfChanged(origin, region, overlaps, rangeChanged)
 	r.UpdateSubTree(region, origin, overlaps, rangeChanged)
 	return overlaps
 }
@@ -1146,6 +1223,7 @@ func (r *RegionsInfo) AtomicCheckAndPutRegion(ctx *MetaProcessContext, region *R
 	origin, overlaps, rangeChanged := r.setRegionLocked(region, true, ols...)
 	r.t.Unlock()
 	tracer.OnSetRegionFinished()
+	r.notifyRegionSizeTreeIfChanged(origin, region, overlaps, rangeChanged)
 	r.UpdateSubTree(region, origin, overlaps, rangeChanged)
 	tracer.OnUpdateSubTreeFinished()
 	return overlaps, nil
@@ -1169,9 +1247,10 @@ func (r *RegionsInfo) CheckAndPutRootTree(ctx *MetaProcessContext, region *Regio
 		return nil, err
 	}
 	tracer.OnValidateRegionFinished()
-	_, overlaps, _ := r.setRegionLocked(region, true, ols...)
+	origin, overlaps, rangeChanged := r.setRegionLocked(region, true, ols...)
 	r.t.Unlock()
 	tracer.OnSetRegionFinished()
+	r.notifyRegionSizeTreeIfChanged(origin, region, overlaps, rangeChanged)
 	return overlaps, nil
 }
 
@@ -1342,8 +1421,10 @@ func check(region, origin *RegionInfo, overlaps []*RegionInfo) error {
 // SetRegion sets the RegionInfo to regionTree and regionMap and return the update info of subtree.
 func (r *RegionsInfo) SetRegion(region *RegionInfo) (*RegionInfo, []*RegionInfo, bool) {
 	r.t.Lock()
-	defer r.t.Unlock()
-	return r.setRegionLocked(region, false)
+	origin, overlaps, rangeChanged := r.setRegionLocked(region, false)
+	r.t.Unlock()
+	r.notifyRegionSizeTreeIfChanged(origin, region, overlaps, rangeChanged)
+	return origin, overlaps, rangeChanged
 }
 
 func (r *RegionsInfo) setRegionLocked(region *RegionInfo, withOverlaps bool, ol ...*RegionInfo) (*RegionInfo, []*RegionInfo, bool) {
@@ -1455,10 +1536,11 @@ func (r *RegionsInfo) GetOverlaps(region *RegionInfo) []*RegionInfo {
 // RemoveRegion removes RegionInfo from regionTree and regionMap
 func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
 	r.t.Lock()
-	defer r.t.Unlock()
 	// Remove from tree and regions.
 	r.tree.remove(region)
 	delete(r.regions, region.GetID())
+	r.t.Unlock()
+	r.notifyRegionSizeTree(region.GetID())
 }
 
 // ResetRegionCache resets the regions info.
@@ -1466,6 +1548,7 @@ func (r *RegionsInfo) ResetRegionCache() {
 	r.t.Lock()
 	r.tree = newRegionTreeWithCountRef()
 	r.regions = make(map[uint64]*regionItem)
+	r.resetRegionSizeTree()
 	r.t.Unlock()
 	r.st.Lock()
 	defer r.st.Unlock()
@@ -2263,11 +2346,25 @@ func (r *RegionsInfo) GetRegionSizeByRange(startKey, endKey []byte) int64 {
 	return size
 }
 
+// GetRegionSizeByRangeFromSizeTree returns the approximate total size of
+// Regions intersecting [startKey, endKey) and whether the eventually
+// consistent index is ready.
+func (r *RegionsInfo) GetRegionSizeByRangeFromSizeTree(startKey, endKey []byte) (int64, bool) {
+	if sizeTree := r.sizeTree.Load(); sizeTree != nil && sizeTree.isReady() {
+		return sizeTree.getRegionSizeByRange(startKey, endKey), true
+	}
+	return 0, false
+}
+
 // metrics default poll interval
 const defaultPollInterval = 15 * time.Second
 
 // CollectWaitLockMetrics collects the metrics of waiting time for lock
 func (r *RegionsInfo) CollectWaitLockMetrics() {
+	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
+		sizeTree.collectMetrics()
+	}
+
 	regionsLockTotalWaitTime := atomic.LoadInt64(&r.t.totalWaitTime)
 	regionsLockCount := atomic.LoadInt64(&r.t.lockCount)
 

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1091,9 +1091,7 @@ func (r *RegionsInfo) StartRegionSizeTree(ctx context.Context) {
 		return
 	}
 	sizeTree := newRegionSizeTree(ctx, r)
-	resetRegionSizeTreeMetrics()
 	r.sizeTree.Store(sizeTree)
-	sizeTree.requestRebuild()
 	sizeTree.start()
 }
 

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -2337,8 +2337,8 @@ func (r *RegionsInfo) GetRegionSizeByRange(startKey, endKey []byte) int64 {
 // Regions intersecting [startKey, endKey) and whether the eventually
 // consistent index is ready.
 func (r *RegionsInfo) GetRegionSizeByRangeFromSizeTree(startKey, endKey []byte) (int64, bool) {
-	if sizeTree := r.sizeTree.Load(); sizeTree != nil && sizeTree.isReady() {
-		return sizeTree.getRegionSizeByRange(startKey, endKey), true
+	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
+		return sizeTree.getRegionSizeByRange(startKey, endKey)
 	}
 	return 0, false
 }

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -1082,9 +1082,6 @@ func NewRegionsInfo() *RegionsInfo {
 
 // StartRegionSizeTree starts the eventually consistent range-size index.
 func (r *RegionsInfo) StartRegionSizeTree(ctx context.Context) {
-	if r.sizeTree.Load() != nil {
-		return
-	}
 	r.sizeTreeMu.Lock()
 	defer r.sizeTreeMu.Unlock()
 	if r.sizeTree.Load() != nil {
@@ -1102,12 +1099,6 @@ func (r *RegionsInfo) StopRegionSizeTree() {
 	if sizeTree := r.sizeTree.Swap(nil); sizeTree != nil {
 		sizeTree.stop()
 		resetRegionSizeTreeMetrics()
-	}
-}
-
-func (r *RegionsInfo) notifyRegionSizeTree(regionIDs ...uint64) {
-	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
-		sizeTree.notify(regionIDs...)
 	}
 }
 
@@ -1142,12 +1133,6 @@ func (r *RegionsInfo) notifyRegionSizeTreeIfChanged(
 		}
 	}
 	sizeTree.notify(regionIDs...)
-}
-
-func (r *RegionsInfo) resetRegionSizeTree() {
-	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
-		sizeTree.requestReset()
-	}
 }
 
 // GetRegion returns the RegionInfo with regionID
@@ -1538,7 +1523,9 @@ func (r *RegionsInfo) RemoveRegion(region *RegionInfo) {
 	r.tree.remove(region)
 	delete(r.regions, region.GetID())
 	r.t.Unlock()
-	r.notifyRegionSizeTree(region.GetID())
+	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
+		sizeTree.notify(region.GetID())
+	}
 }
 
 // ResetRegionCache resets the regions info.
@@ -1546,7 +1533,9 @@ func (r *RegionsInfo) ResetRegionCache() {
 	r.t.Lock()
 	r.tree = newRegionTreeWithCountRef()
 	r.regions = make(map[uint64]*regionItem)
-	r.resetRegionSizeTree()
+	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
+		sizeTree.requestReset()
+	}
 	r.t.Unlock()
 	r.st.Lock()
 	defer r.st.Unlock()

--- a/pkg/core/region.go
+++ b/pkg/core/region.go
@@ -2359,12 +2359,15 @@ func (r *RegionsInfo) GetRegionSizeByRangeFromSizeTree(startKey, endKey []byte) 
 // metrics default poll interval
 const defaultPollInterval = 15 * time.Second
 
-// CollectWaitLockMetrics collects the metrics of waiting time for lock
-func (r *RegionsInfo) CollectWaitLockMetrics() {
+// CollectRegionSizeTreeMetrics collects the Region size tree metrics.
+func (r *RegionsInfo) CollectRegionSizeTreeMetrics() {
 	if sizeTree := r.sizeTree.Load(); sizeTree != nil {
 		sizeTree.collectMetrics()
 	}
+}
 
+// CollectWaitLockMetrics collects the metrics of waiting time for lock
+func (r *RegionsInfo) CollectWaitLockMetrics() {
 	regionsLockTotalWaitTime := atomic.LoadInt64(&r.t.totalWaitTime)
 	regionsLockCount := atomic.LoadInt64(&r.t.lockCount)
 

--- a/pkg/core/region_size_tree.go
+++ b/pkg/core/region_size_tree.go
@@ -1,0 +1,468 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tikv/pd/pkg/btree"
+	"github.com/tikv/pd/pkg/utils/logutil"
+	"github.com/tikv/pd/pkg/utils/syncutil"
+)
+
+type regionSizeTreeUpdate struct {
+	regionID uint64
+	region   *RegionInfo
+}
+
+type regionSizeItem struct {
+	regionID uint64
+	startKey []byte
+	endKey   []byte
+	size     int64
+}
+
+// Less reports whether this item starts before the other item.
+func (i *regionSizeItem) Less(other *regionSizeItem) bool {
+	return bytes.Compare(i.startKey, other.startKey) < 0
+}
+
+func (i *regionSizeItem) contains(key []byte) bool {
+	return bytes.Compare(i.startKey, key) <= 0 &&
+		(len(i.endKey) == 0 || bytes.Compare(key, i.endKey) < 0)
+}
+
+// regionSizeTree is an eventually consistent range-size index. Producers only
+// enqueue Region IDs; its single worker reloads the latest root-tree state and
+// is the only writer of the independent tree.
+type regionSizeTree struct {
+	cancel context.CancelFunc
+	done   <-chan struct{}
+	wg     *sync.WaitGroup
+	owner  *RegionsInfo
+	ready  atomic.Bool
+
+	mu        syncutil.RWMutex
+	tree      *btree.BTreeG[*regionSizeItem]
+	regions   map[uint64]*regionSizeItem
+	totalSize int64
+
+	pendingMu      syncutil.Mutex
+	pending        map[uint64]struct{}
+	pendingSince   time.Time
+	activePending  int
+	activeSince    time.Time
+	resetPending   bool
+	rebuildPending bool
+	notifyCh       chan struct{}
+}
+
+func newRegionSizeTree(ctx context.Context, owner *RegionsInfo) *regionSizeTree {
+	workerCtx, cancel := context.WithCancel(ctx)
+	return &regionSizeTree{
+		cancel:   cancel,
+		done:     workerCtx.Done(),
+		wg:       &sync.WaitGroup{},
+		owner:    owner,
+		tree:     btree.NewG[*regionSizeItem](defaultBTreeDegree),
+		regions:  make(map[uint64]*regionSizeItem),
+		pending:  make(map[uint64]struct{}),
+		notifyCh: make(chan struct{}, 1),
+	}
+}
+
+func (t *regionSizeTree) start() {
+	t.wg.Add(1)
+	go t.run()
+}
+
+func (t *regionSizeTree) stop() {
+	t.pendingMu.Lock()
+	t.cancel()
+	t.ready.Store(false)
+	t.pendingMu.Unlock()
+	t.wg.Wait()
+}
+
+func (t *regionSizeTree) notify(regionIDs ...uint64) {
+	if len(regionIDs) == 0 {
+		return
+	}
+	t.pendingMu.Lock()
+	for _, regionID := range regionIDs {
+		if _, ok := t.pending[regionID]; ok {
+			continue
+		}
+		if len(t.pending) == 0 {
+			t.pendingSince = time.Now()
+		}
+		t.pending[regionID] = struct{}{}
+	}
+	t.pendingMu.Unlock()
+	t.wake()
+}
+
+func (t *regionSizeTree) requestReset() {
+	t.pendingMu.Lock()
+	t.ready.Store(false)
+	t.resetPending = true
+	t.pendingMu.Unlock()
+	t.wake()
+}
+
+func (t *regionSizeTree) requestRebuild() {
+	t.pendingMu.Lock()
+	t.ready.Store(false)
+	t.rebuildPending = true
+	t.pendingMu.Unlock()
+	t.wake()
+}
+
+func (t *regionSizeTree) wake() {
+	select {
+	case t.notifyCh <- struct{}{}:
+	default:
+	}
+}
+
+func (t *regionSizeTree) takePending() (reset, rebuild bool, pending map[uint64]struct{}) {
+	t.pendingMu.Lock()
+	defer t.pendingMu.Unlock()
+	reset, rebuild = t.resetPending, t.rebuildPending
+	t.resetPending, t.rebuildPending = false, false
+	if len(t.pending) > 0 {
+		pending = t.pending
+		t.activePending = len(pending)
+		t.activeSince = t.pendingSince
+		t.pending = make(map[uint64]struct{})
+		t.pendingSince = time.Time{}
+	}
+	return reset, rebuild, pending
+}
+
+func (t *regionSizeTree) finishPending() {
+	t.pendingMu.Lock()
+	t.activePending = 0
+	t.activeSince = time.Time{}
+	t.pendingMu.Unlock()
+}
+
+func (t *regionSizeTree) run() {
+	defer t.wg.Done()
+	defer logutil.LogPanic()
+	defer t.ready.Store(false)
+	for {
+		select {
+		case <-t.done:
+			return
+		case <-t.notifyCh:
+			t.drain()
+		}
+	}
+}
+
+func (t *regionSizeTree) drain() {
+	for {
+		select {
+		case <-t.done:
+			return
+		default:
+		}
+
+		reset, rebuild, pending := t.takePending()
+		if !reset && !rebuild && len(pending) == 0 {
+			return
+		}
+		if rebuild {
+			t.reset()
+			start := time.Now()
+			rebuilt := t.rebuild()
+			regionSizeTreeRebuildDuration.Observe(time.Since(start).Seconds())
+			if !rebuilt {
+				t.finishPending()
+				return
+			}
+			// The full rebuild already covers notifications taken before it
+			// started. Updates that arrive during the scan are in the new pending
+			// map and will be reconciled by the next drain iteration.
+			pending = nil
+		} else if reset {
+			t.reset()
+		}
+		if !t.reconcilePending(pending) {
+			t.finishPending()
+			continue
+		}
+		t.finishPending()
+		if rebuild || reset {
+			t.markReadyIfCurrent()
+		}
+	}
+}
+
+func (t *regionSizeTree) markReadyIfCurrent() {
+	t.pendingMu.Lock()
+	defer t.pendingMu.Unlock()
+	if !t.isStopped() && !t.resetPending && !t.rebuildPending {
+		t.ready.Store(true)
+	}
+}
+
+func (t *regionSizeTree) isReady() bool {
+	return !t.isStopped() && t.ready.Load()
+}
+
+func (t *regionSizeTree) isStopped() bool {
+	select {
+	case <-t.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t *regionSizeTree) rebuild() bool {
+	var startKey []byte
+	for {
+		if t.shouldInterruptReconcile() {
+			return false
+		}
+
+		regions := t.owner.ScanRegions(startKey, nil, ScanRegionLimit)
+		if t.shouldInterruptReconcile() {
+			return false
+		}
+		if len(regions) == 0 {
+			return true
+		}
+		t.reconcileRegions(regions)
+		if t.shouldInterruptReconcile() {
+			return false
+		}
+
+		endKey := regions[len(regions)-1].GetEndKey()
+		if len(endKey) == 0 || bytes.Equal(startKey, endKey) {
+			return true
+		}
+		startKey = endKey
+	}
+}
+
+func (t *regionSizeTree) reconcilePending(pending map[uint64]struct{}) bool {
+	regionIDs := make([]uint64, 0, min(len(pending), ScanRegionLimit))
+	for regionID := range pending {
+		regionIDs = append(regionIDs, regionID)
+		if len(regionIDs) == ScanRegionLimit {
+			if t.shouldInterruptReconcile() {
+				return false
+			}
+			t.reconcileIDs(regionIDs)
+			regionIDs = regionIDs[:0]
+		}
+	}
+	if t.shouldInterruptReconcile() {
+		return false
+	}
+	t.reconcileIDs(regionIDs)
+	return true
+}
+
+func (t *regionSizeTree) shouldInterruptReconcile() bool {
+	if t.isStopped() {
+		return true
+	}
+	t.pendingMu.Lock()
+	defer t.pendingMu.Unlock()
+	return t.resetPending || t.rebuildPending
+}
+
+func (t *regionSizeTree) collectMetrics() {
+	t.pendingMu.Lock()
+	pending := len(t.pending) + t.activePending
+	oldest := t.pendingSince
+	if oldest.IsZero() || (!t.activeSince.IsZero() && t.activeSince.Before(oldest)) {
+		oldest = t.activeSince
+	}
+	t.pendingMu.Unlock()
+
+	ready := 0.0
+	if t.isReady() {
+		ready = 1
+	}
+	regionSizeTreeReadyGauge.Set(ready)
+	regionSizeTreePendingGauge.Set(float64(pending))
+	oldestPendingDuration := 0.0
+	if !oldest.IsZero() {
+		oldestPendingDuration = time.Since(oldest).Seconds()
+	}
+	regionSizeTreeOldestPendingDurationGauge.Set(oldestPendingDuration)
+}
+
+func (t *regionSizeTree) reconcileIDs(regionIDs []uint64) {
+	if len(regionIDs) == 0 {
+		return
+	}
+	regions := t.owner.getRegionsByIDs(regionIDs)
+	updates := make([]regionSizeTreeUpdate, len(regionIDs))
+	for i, regionID := range regionIDs {
+		updates[i] = regionSizeTreeUpdate{regionID: regionID, region: regions[i]}
+	}
+	t.reconcile(updates)
+}
+
+func (t *regionSizeTree) reconcile(updates []regionSizeTreeUpdate) {
+	if len(updates) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, update := range updates {
+		t.reconcileLocked(update.regionID, update.region)
+	}
+}
+
+func (t *regionSizeTree) reconcileRegions(regions []*RegionInfo) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, region := range regions {
+		t.reconcileLocked(region.GetID(), region)
+	}
+}
+
+func (t *regionSizeTree) reconcileLocked(regionID uint64, region *RegionInfo) {
+	origin := t.regions[regionID]
+	if region == nil {
+		if origin != nil {
+			t.tree.Delete(origin)
+			t.totalSize -= origin.size
+			delete(t.regions, regionID)
+		}
+		return
+	}
+
+	if origin != nil && bytes.Equal(origin.startKey, region.GetStartKey()) &&
+		bytes.Equal(origin.endKey, region.GetEndKey()) {
+		if origin.size == region.GetApproximateSize() {
+			return
+		}
+		t.totalSize += region.GetApproximateSize() - origin.size
+		origin.size = region.GetApproximateSize()
+		return
+	}
+
+	if origin != nil {
+		t.tree.Delete(origin)
+		t.totalSize -= origin.size
+		delete(t.regions, regionID)
+	}
+	// Region ranges are immutable after insertion into the root B-tree, so the
+	// compact index can share their key bytes without retaining RegionInfo.
+	item := &regionSizeItem{
+		regionID: regionID,
+		startKey: region.GetStartKey(),
+		endKey:   region.GetEndKey(),
+		size:     region.GetApproximateSize(),
+	}
+	for _, overlap := range t.overlapsLocked(item) {
+		t.tree.Delete(overlap)
+		t.totalSize -= overlap.size
+		delete(t.regions, overlap.regionID)
+	}
+	t.tree.ReplaceOrInsert(item)
+	t.totalSize += item.size
+	t.regions[regionID] = item
+}
+
+func (t *regionSizeTree) findLocked(item *regionSizeItem) *regionSizeItem {
+	var result *regionSizeItem
+	t.tree.DescendLessOrEqual(item, func(current *regionSizeItem) bool {
+		result = current
+		return false
+	})
+	if result == nil || !result.contains(item.startKey) {
+		return nil
+	}
+	return result
+}
+
+func (t *regionSizeTree) overlapsLocked(item *regionSizeItem) []*regionSizeItem {
+	start := t.findLocked(item)
+	if start == nil {
+		start = item
+	}
+	var overlaps []*regionSizeItem
+	t.tree.AscendGreaterOrEqual(start, func(current *regionSizeItem) bool {
+		if len(item.endKey) > 0 && bytes.Compare(item.endKey, current.startKey) <= 0 {
+			return false
+		}
+		overlaps = append(overlaps, current)
+		return true
+	})
+	return overlaps
+}
+
+func (t *regionSizeTree) reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tree = btree.NewG[*regionSizeItem](defaultBTreeDegree)
+	t.regions = make(map[uint64]*regionSizeItem)
+	t.totalSize = 0
+}
+
+func (t *regionSizeTree) getRegionSizeByRange(startKey, endKey []byte) int64 {
+	if len(startKey) == 0 && len(endKey) == 0 {
+		t.mu.RLock()
+		defer t.mu.RUnlock()
+		return t.totalSize
+	}
+
+	var size int64
+	for {
+		t.mu.RLock()
+		var count int
+		start := &regionSizeItem{startKey: startKey}
+		startItem := t.findLocked(start)
+		if startItem == nil {
+			startItem = start
+		}
+		t.tree.AscendGreaterOrEqual(startItem, func(item *regionSizeItem) bool {
+			if len(endKey) > 0 && bytes.Compare(item.startKey, endKey) >= 0 {
+				return false
+			}
+			if count >= ScanRegionLimit {
+				return false
+			}
+			count++
+			startKey = item.endKey
+			size += item.size
+			return true
+		})
+		t.mu.RUnlock()
+		if count == 0 || len(startKey) == 0 {
+			break
+		}
+	}
+	return size
+}
+
+func (t *regionSizeTree) length() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.tree.Len()
+}

--- a/pkg/core/region_size_tree.go
+++ b/pkg/core/region_size_tree.go
@@ -26,11 +26,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/syncutil"
 )
 
-type regionSizeTreeUpdate struct {
-	regionID uint64
-	region   *RegionInfo
-}
-
 type regionSizeItem struct {
 	regionID uint64
 	startKey []byte
@@ -58,10 +53,9 @@ type regionSizeTree struct {
 	owner  *RegionsInfo
 	ready  atomic.Bool
 
-	mu        syncutil.RWMutex
-	tree      *btree.BTreeG[*regionSizeItem]
-	regions   map[uint64]*regionSizeItem
-	totalSize int64
+	mu      syncutil.RWMutex
+	tree    *btree.BTreeG[*regionSizeItem]
+	regions map[uint64]*regionSizeItem
 
 	pendingMu      syncutil.Mutex
 	pending        map[uint64]struct{}
@@ -88,8 +82,12 @@ func newRegionSizeTree(ctx context.Context, owner *RegionsInfo) *regionSizeTree 
 }
 
 func (t *regionSizeTree) start() {
+	t.pendingMu.Lock()
+	t.rebuildPending = true
+	t.pendingMu.Unlock()
 	t.wg.Add(1)
 	go t.run()
+	t.wake()
 }
 
 func (t *regionSizeTree) stop() {
@@ -122,14 +120,6 @@ func (t *regionSizeTree) requestReset() {
 	t.pendingMu.Lock()
 	t.ready.Store(false)
 	t.resetPending = true
-	t.pendingMu.Unlock()
-	t.wake()
-}
-
-func (t *regionSizeTree) requestRebuild() {
-	t.pendingMu.Lock()
-	t.ready.Store(false)
-	t.rebuildPending = true
 	t.pendingMu.Unlock()
 	t.wake()
 }
@@ -319,21 +309,10 @@ func (t *regionSizeTree) reconcileIDs(regionIDs []uint64) {
 		return
 	}
 	regions := t.owner.getRegionsByIDs(regionIDs)
-	updates := make([]regionSizeTreeUpdate, len(regionIDs))
-	for i, regionID := range regionIDs {
-		updates[i] = regionSizeTreeUpdate{regionID: regionID, region: regions[i]}
-	}
-	t.reconcile(updates)
-}
-
-func (t *regionSizeTree) reconcile(updates []regionSizeTreeUpdate) {
-	if len(updates) == 0 {
-		return
-	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for _, update := range updates {
-		t.reconcileLocked(update.regionID, update.region)
+	for i, regionID := range regionIDs {
+		t.reconcileLocked(regionID, regions[i])
 	}
 }
 
@@ -350,7 +329,6 @@ func (t *regionSizeTree) reconcileLocked(regionID uint64, region *RegionInfo) {
 	if region == nil {
 		if origin != nil {
 			t.tree.Delete(origin)
-			t.totalSize -= origin.size
 			delete(t.regions, regionID)
 		}
 		return
@@ -358,17 +336,12 @@ func (t *regionSizeTree) reconcileLocked(regionID uint64, region *RegionInfo) {
 
 	if origin != nil && bytes.Equal(origin.startKey, region.GetStartKey()) &&
 		bytes.Equal(origin.endKey, region.GetEndKey()) {
-		if origin.size == region.GetApproximateSize() {
-			return
-		}
-		t.totalSize += region.GetApproximateSize() - origin.size
 		origin.size = region.GetApproximateSize()
 		return
 	}
 
 	if origin != nil {
 		t.tree.Delete(origin)
-		t.totalSize -= origin.size
 		delete(t.regions, regionID)
 	}
 	// Region ranges are immutable. The compact index retains the key slices
@@ -383,11 +356,9 @@ func (t *regionSizeTree) reconcileLocked(regionID uint64, region *RegionInfo) {
 	}
 	for _, overlap := range t.overlapsLocked(item) {
 		t.tree.Delete(overlap)
-		t.totalSize -= overlap.size
 		delete(t.regions, overlap.regionID)
 	}
 	t.tree.ReplaceOrInsert(item)
-	t.totalSize += item.size
 	t.regions[regionID] = item
 }
 
@@ -424,16 +395,9 @@ func (t *regionSizeTree) reset() {
 	defer t.mu.Unlock()
 	t.tree = btree.NewG[*regionSizeItem](defaultBTreeDegree)
 	t.regions = make(map[uint64]*regionSizeItem)
-	t.totalSize = 0
 }
 
 func (t *regionSizeTree) getRegionSizeByRange(startKey, endKey []byte) int64 {
-	if len(startKey) == 0 && len(endKey) == 0 {
-		t.mu.RLock()
-		defer t.mu.RUnlock()
-		return t.totalSize
-	}
-
 	var size int64
 	for {
 		t.mu.RLock()
@@ -461,10 +425,4 @@ func (t *regionSizeTree) getRegionSizeByRange(startKey, endKey []byte) int64 {
 		}
 	}
 	return size
-}
-
-func (t *regionSizeTree) length() int {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.tree.Len()
 }

--- a/pkg/core/region_size_tree.go
+++ b/pkg/core/region_size_tree.go
@@ -371,8 +371,10 @@ func (t *regionSizeTree) reconcileLocked(regionID uint64, region *RegionInfo) {
 		t.totalSize -= origin.size
 		delete(t.regions, regionID)
 	}
-	// Region ranges are immutable after insertion into the root B-tree, so the
-	// compact index can share their key bytes without retaining RegionInfo.
+	// Region ranges are immutable. The compact index retains the key slices
+	// captured from the root state without retaining the complete RegionInfo. A
+	// later same-range heartbeat may replace the root RegionInfo and its backing
+	// arrays without refreshing these slices.
 	item := &regionSizeItem{
 		regionID: regionID,
 		startKey: region.GetStartKey(),

--- a/pkg/core/region_size_tree.go
+++ b/pkg/core/region_size_tree.go
@@ -400,6 +400,8 @@ func (t *regionSizeTree) getRegionSizeByRange(startKey, endKey []byte) int64 {
 			size += item.size
 			return true
 		})
+		// Let reconciliations proceed between chunks. A query can therefore observe
+		// multiple index versions, which is acceptable for approximate statistics.
 		t.mu.RUnlock()
 		if count == 0 || len(startKey) == 0 {
 			break

--- a/pkg/core/region_size_tree.go
+++ b/pkg/core/region_size_tree.go
@@ -378,34 +378,32 @@ func (t *regionSizeTree) reset() {
 	t.regions = make(map[uint64]*regionSizeItem)
 }
 
-func (t *regionSizeTree) getRegionSizeByRange(startKey, endKey []byte) int64 {
-	var size int64
-	for {
-		t.mu.RLock()
-		var count int
-		start := &regionSizeItem{startKey: startKey}
-		startItem := t.findLocked(start)
-		if startItem == nil {
-			startItem = start
-		}
-		t.tree.AscendGreaterOrEqual(startItem, func(item *regionSizeItem) bool {
-			if len(endKey) > 0 && bytes.Compare(item.startKey, endKey) >= 0 {
-				return false
-			}
-			if count >= ScanRegionLimit {
-				return false
-			}
-			count++
-			startKey = item.endKey
-			size += item.size
-			return true
-		})
-		// Let reconciliations proceed between chunks. A query can therefore observe
-		// multiple index versions, which is acceptable for approximate statistics.
-		t.mu.RUnlock()
-		if count == 0 || len(startKey) == 0 {
-			break
-		}
+func (t *regionSizeTree) getRegionSizeByRange(startKey, endKey []byte) (int64, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if !t.isReady() {
+		return 0, false
 	}
+	size := t.getRegionSizeByRangeLocked(startKey, endKey)
+	if !t.isReady() {
+		return 0, false
+	}
+	return size, true
+}
+
+func (t *regionSizeTree) getRegionSizeByRangeLocked(startKey, endKey []byte) int64 {
+	var size int64
+	start := &regionSizeItem{startKey: startKey}
+	startItem := t.findLocked(start)
+	if startItem == nil {
+		startItem = start
+	}
+	t.tree.AscendGreaterOrEqual(startItem, func(item *regionSizeItem) bool {
+		if len(endKey) > 0 && bytes.Compare(item.startKey, endKey) >= 0 {
+			return false
+		}
+		size += item.size
+		return true
+	})
 	return size
 }

--- a/pkg/core/region_size_tree.go
+++ b/pkg/core/region_size_tree.go
@@ -57,14 +57,13 @@ type regionSizeTree struct {
 	tree    *btree.BTreeG[*regionSizeItem]
 	regions map[uint64]*regionSizeItem
 
-	pendingMu      syncutil.Mutex
-	pending        map[uint64]struct{}
-	pendingSince   time.Time
-	activePending  int
-	activeSince    time.Time
-	resetPending   bool
-	rebuildPending bool
-	notifyCh       chan struct{}
+	pendingMu     syncutil.Mutex
+	pending       map[uint64]struct{}
+	pendingSince  time.Time
+	activePending int
+	activeSince   time.Time
+	resetPending  bool
+	notifyCh      chan struct{}
 }
 
 func newRegionSizeTree(ctx context.Context, owner *RegionsInfo) *regionSizeTree {
@@ -82,26 +81,16 @@ func newRegionSizeTree(ctx context.Context, owner *RegionsInfo) *regionSizeTree 
 }
 
 func (t *regionSizeTree) start() {
-	t.pendingMu.Lock()
-	t.rebuildPending = true
-	t.pendingMu.Unlock()
 	t.wg.Add(1)
 	go t.run()
-	t.wake()
 }
 
 func (t *regionSizeTree) stop() {
-	t.pendingMu.Lock()
 	t.cancel()
-	t.ready.Store(false)
-	t.pendingMu.Unlock()
 	t.wg.Wait()
 }
 
 func (t *regionSizeTree) notify(regionIDs ...uint64) {
-	if len(regionIDs) == 0 {
-		return
-	}
 	t.pendingMu.Lock()
 	for _, regionID := range regionIDs {
 		if _, ok := t.pending[regionID]; ok {
@@ -131,11 +120,11 @@ func (t *regionSizeTree) wake() {
 	}
 }
 
-func (t *regionSizeTree) takePending() (reset, rebuild bool, pending map[uint64]struct{}) {
+func (t *regionSizeTree) takePending() (reset bool, pending map[uint64]struct{}) {
 	t.pendingMu.Lock()
 	defer t.pendingMu.Unlock()
-	reset, rebuild = t.resetPending, t.rebuildPending
-	t.resetPending, t.rebuildPending = false, false
+	reset = t.resetPending
+	t.resetPending = false
 	if len(t.pending) > 0 {
 		pending = t.pending
 		t.activePending = len(pending)
@@ -143,7 +132,7 @@ func (t *regionSizeTree) takePending() (reset, rebuild bool, pending map[uint64]
 		t.pending = make(map[uint64]struct{})
 		t.pendingSince = time.Time{}
 	}
-	return reset, rebuild, pending
+	return reset, pending
 }
 
 func (t *regionSizeTree) finishPending() {
@@ -157,6 +146,11 @@ func (t *regionSizeTree) run() {
 	defer t.wg.Done()
 	defer logutil.LogPanic()
 	defer t.ready.Store(false)
+	start := time.Now()
+	if t.rebuild() {
+		t.markReadyIfCurrent()
+	}
+	regionSizeTreeRebuildDuration.Observe(time.Since(start).Seconds())
 	for {
 		select {
 		case <-t.done:
@@ -175,24 +169,11 @@ func (t *regionSizeTree) drain() {
 		default:
 		}
 
-		reset, rebuild, pending := t.takePending()
-		if !reset && !rebuild && len(pending) == 0 {
+		reset, pending := t.takePending()
+		if !reset && len(pending) == 0 {
 			return
 		}
-		if rebuild {
-			t.reset()
-			start := time.Now()
-			rebuilt := t.rebuild()
-			regionSizeTreeRebuildDuration.Observe(time.Since(start).Seconds())
-			if !rebuilt {
-				t.finishPending()
-				return
-			}
-			// The full rebuild already covers notifications taken before it
-			// started. Updates that arrive during the scan are in the new pending
-			// map and will be reconciled by the next drain iteration.
-			pending = nil
-		} else if reset {
+		if reset {
 			t.reset()
 		}
 		if !t.reconcilePending(pending) {
@@ -200,7 +181,7 @@ func (t *regionSizeTree) drain() {
 			continue
 		}
 		t.finishPending()
-		if rebuild || reset {
+		if reset {
 			t.markReadyIfCurrent()
 		}
 	}
@@ -209,7 +190,7 @@ func (t *regionSizeTree) drain() {
 func (t *regionSizeTree) markReadyIfCurrent() {
 	t.pendingMu.Lock()
 	defer t.pendingMu.Unlock()
-	if !t.isStopped() && !t.resetPending && !t.rebuildPending {
+	if !t.isStopped() && !t.resetPending {
 		t.ready.Store(true)
 	}
 }
@@ -279,7 +260,7 @@ func (t *regionSizeTree) shouldInterruptReconcile() bool {
 	}
 	t.pendingMu.Lock()
 	defer t.pendingMu.Unlock()
-	return t.resetPending || t.rebuildPending
+	return t.resetPending
 }
 
 func (t *regionSizeTree) collectMetrics() {

--- a/pkg/core/region_size_tree_test.go
+++ b/pkg/core/region_size_tree_test.go
@@ -123,29 +123,6 @@ func TestRegionSizeTreeRebuildsAndScansInBatches(t *testing.T) {
 	require.Nil(t, regions.sizeTree.Load())
 }
 
-func TestRegionSizeTreeRebuildDoesNotReplayTakenPending(t *testing.T) {
-	regions := NewRegionsInfo()
-	regions.PutRegion(newRegionSizeTreeTestRegion(1, "a", "m", 1, 10))
-	regions.PutRegion(newRegionSizeTreeTestRegion(2, "m", "", 1, 20))
-
-	// Keep the worker stopped so rebuild and both notifications are taken in
-	// the same drain iteration.
-	tree := newRegionSizeTree(context.Background(), regions)
-	regions.sizeTree.Store(tree)
-	t.Cleanup(regions.StopRegionSizeTree)
-	tree.notify(1, 2)
-	tree.pendingMu.Lock()
-	tree.rebuildPending = true
-	tree.pendingMu.Unlock()
-
-	atomic.StoreInt64(&regions.t.lockCount, 0)
-	tree.drain()
-	// The rebuild scans the root once. Replaying the two already-covered IDs
-	// would acquire the root lock a second time.
-	require.Equal(t, int64(1), atomic.LoadInt64(&regions.t.lockCount))
-	require.Equal(t, int64(30), getRegionSizeFromReadyTree(t, regions, nil, nil))
-}
-
 func TestRegionSizeTreeCanceledRebuildIsNeverReady(t *testing.T) {
 	regions := NewRegionsInfo()
 	regionCount := ScanRegionLimit + 1
@@ -289,49 +266,6 @@ func TestRegionSizeTreePendingReconcileCanBeInterrupted(t *testing.T) {
 	}
 }
 
-func TestRegionSizeTreeEventuallyReconcilesLatestRootState(t *testing.T) {
-	re := require.New(t)
-	regions := NewRegionsInfo()
-	startRegionSizeTreeForTest(t, regions)
-	peer1 := &metapb.Peer{Id: 1, StoreId: 1}
-	peer2 := &metapb.Peer{Id: 2, StoreId: 1}
-	region1 := NewRegionInfo(&metapb.Region{
-		Id:       1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("m"),
-		Peers:    []*metapb.Peer{peer1},
-	}, peer1, SetApproximateSize(10))
-	region2 := NewRegionInfo(&metapb.Region{
-		Id:       2,
-		StartKey: []byte("m"),
-		Peers:    []*metapb.Peer{peer2},
-	}, peer2, SetApproximateSize(20))
-	regions.PutRegion(region1)
-	regions.PutRegion(region2)
-	requireTotalRegionSizeEventually(t, regions, 30)
-	re.Equal(int64(10), getRegionSizeFromReadyTree(t, regions, []byte("b"), []byte("m")))
-
-	tree := regions.sizeTree.Load()
-	tree.mu.RLock()
-	updated := region1.Clone(SetApproximateSize(40))
-	_, err := regions.CheckAndPutRootTree(ContextTODO(), updated)
-	re.NoError(err)
-	re.Equal(int64(60), regions.GetRegionSizeByRange(nil, nil))
-	// The root update only enqueues the ID and does not wait for the size tree.
-	re.Equal(int64(10), tree.regions[region1.GetID()].size)
-	tree.mu.RUnlock()
-
-	// The size tree converges even if the corresponding subtree task is dropped.
-	requireTotalRegionSizeEventually(t, regions, 60)
-	re.Equal(int64(40), getRegionSizeFromReadyTree(t, regions, []byte("b"), []byte("m")))
-	re.Equal(int32(1), updated.GetRef())
-	regions.CheckAndPutSubTree(updated)
-	re.Equal(int32(2), updated.GetRef())
-
-	regions.RemoveRegionIfExist(region2.GetID())
-	requireTotalRegionSizeEventually(t, regions, 40)
-}
-
 func TestRegionSizeTreeQueryDoesNotBlockSubTreeUpdate(t *testing.T) {
 	re := require.New(t)
 	regions := NewRegionsInfo()
@@ -412,7 +346,7 @@ func TestRegionSizeTreeDelayedChildNotificationsDoNotRemoveMergedRegion(t *testi
 	regions.sizeTree.Store(tree)
 	t.Cleanup(regions.StopRegionSizeTree)
 
-	regions.notifyRegionSizeTree(1, 2)
+	tree.notify(1, 2)
 	tree.pendingMu.Lock()
 	pendingCount := len(tree.pending)
 	tree.pendingMu.Unlock()

--- a/pkg/core/region_size_tree_test.go
+++ b/pkg/core/region_size_tree_test.go
@@ -1,0 +1,661 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+)
+
+func TestRegionSizeTreeStructuralUpdates(t *testing.T) {
+	re := require.New(t)
+	tree := newRegionSizeTree(context.Background(), NewRegionsInfo())
+	t.Cleanup(tree.cancel)
+	merged := newRegionSizeTreeTestRegion(1, "a", "z", 1, 100)
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: merged.GetID(), region: merged}})
+	re.Equal(int64(100), tree.getRegionSizeByRange(nil, nil))
+	re.Equal(int64(100), tree.getRegionSizeByRange([]byte("b"), []byte("m")))
+
+	left := newRegionSizeTreeTestRegion(1, "a", "m", 2, 40)
+	right := newRegionSizeTreeTestRegion(2, "m", "z", 2, 60)
+	// Apply the right side first to cover out-of-order split notifications.
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: right.GetID(), region: right}})
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: left.GetID(), region: left}})
+	re.Equal(2, tree.length())
+	re.Equal(int64(100), tree.getRegionSizeByRange(nil, nil))
+	re.Equal(int64(40), tree.getRegionSizeByRange([]byte("b"), []byte("m")))
+	re.Equal(int64(60), tree.getRegionSizeByRange([]byte("m"), []byte("z")))
+
+	left = newRegionSizeTreeTestRegion(1, "a", "m", 2, 50)
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: left.GetID(), region: left}})
+	re.Equal(int64(110), tree.getRegionSizeByRange(nil, nil))
+
+	merged = newRegionSizeTreeTestRegion(3, "a", "z", 3, 120)
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: merged.GetID(), region: merged}})
+	re.Equal(1, tree.length())
+	re.Equal(int64(120), tree.getRegionSizeByRange(nil, nil))
+
+	// A delayed child removal deletes by ID and cannot remove the merged Region.
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: right.GetID()}})
+	re.Equal(1, tree.length())
+	re.Equal(int64(120), tree.getRegionSizeByRange(nil, nil))
+
+	tree.reset()
+	re.Zero(tree.length())
+	re.Zero(tree.getRegionSizeByRange(nil, nil))
+}
+
+func TestRegionSizeTreeIsOptInAndRebuilds(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	region := newRegionSizeTreeTestRegion(1, "a", "z", 1, 10)
+	regions.PutRegion(region)
+
+	re.Nil(regions.sizeTree.Load())
+	_, ready := regions.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
+	re.False(ready)
+
+	startRegionSizeTreeForTest(t, regions)
+	requireRegionSizeEventually(t, regions, []byte("a"), []byte("z"), 10)
+	regions.StopRegionSizeTree()
+	re.Nil(regions.sizeTree.Load())
+}
+
+func TestRegionSizeTreeMetrics(t *testing.T) {
+	tree := newRegionSizeTree(context.Background(), NewRegionsInfo())
+	t.Cleanup(func() {
+		tree.cancel()
+		resetRegionSizeTreeMetrics()
+	})
+
+	tree.notify(1, 2)
+	tree.pendingMu.Lock()
+	tree.pendingSince = time.Now().Add(-time.Second)
+	tree.pendingMu.Unlock()
+	tree.ready.Store(true)
+	tree.collectMetrics()
+	require.Equal(t, 1.0, testutil.ToFloat64(regionSizeTreeReadyGauge))
+	require.Equal(t, 2.0, testutil.ToFloat64(regionSizeTreePendingGauge))
+	require.GreaterOrEqual(t,
+		testutil.ToFloat64(regionSizeTreeOldestPendingDurationGauge), 1.0,
+	)
+
+	tree.drain()
+	tree.collectMetrics()
+	require.Zero(t, testutil.ToFloat64(regionSizeTreePendingGauge))
+	require.Zero(t, testutil.ToFloat64(regionSizeTreeOldestPendingDurationGauge))
+}
+
+func TestRegionSizeTreeIsNotReadyAfterContextCanceled(t *testing.T) {
+	regions := NewRegionsInfo()
+	regions.PutRegion(newRegionSizeTreeTestRegion(1, "a", "z", 1, 10))
+	ctx, cancel := context.WithCancel(context.Background())
+	regions.StartRegionSizeTree(ctx)
+	t.Cleanup(regions.StopRegionSizeTree)
+
+	tree := regions.sizeTree.Load()
+	require.NotNil(t, tree)
+	require.Eventually(t, tree.isReady, 5*time.Second, 10*time.Millisecond)
+	cancel()
+
+	// Queries must stop using the index as soon as its parent lifecycle ends,
+	// even before StopRegionSizeTree removes the pointer.
+	require.False(t, tree.isReady())
+	_, ready := regions.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
+	require.False(t, ready)
+	tree.wg.Wait()
+	require.False(t, tree.ready.Load())
+}
+
+func TestRegionSizeTreeRebuildsAndScansInBatches(t *testing.T) {
+	regions := NewRegionsInfo()
+	regionCount := ScanRegionLimit + 2
+	for i := range regionCount {
+		endKey := fmt.Sprintf("%04d", i+1)
+		if i == regionCount-1 {
+			endKey = ""
+		}
+		regions.PutRegion(newRegionSizeTreeTestRegion(
+			uint64(i+1), fmt.Sprintf("%04d", i), endKey, 1, 1,
+		))
+	}
+
+	atomic.StoreInt64(&regions.t.lockCount, 0)
+	startRegionSizeTreeForTest(t, regions)
+	// Rebuild scans 1000 Regions at a time and does not reload every ID.
+	require.Equal(t, int64(2), atomic.LoadInt64(&regions.t.lockCount))
+	requireRegionSizeEventually(t, regions, nil, nil, int64(regionCount))
+	require.Equal(t, int64(regionCount), getRegionSizeFromReadyTree(t, regions,
+		[]byte("0000"), []byte("9999"),
+	))
+
+	// Placement-rule split keys produce single-ended ranges. Verify both forms
+	// across the scan limit through the public size-tree query path.
+	for _, keyRange := range []struct {
+		name     string
+		startKey []byte
+		endKey   []byte
+	}{
+		{name: "prefix", endKey: []byte("1001")},
+		{name: "suffix", startKey: []byte("0001")},
+	} {
+		t.Run(keyRange.name, func(t *testing.T) {
+			rootSize := regions.GetRegionSizeByRange(keyRange.startKey, keyRange.endKey)
+			require.Equal(t, int64(ScanRegionLimit+1), rootSize)
+			require.Equal(t, rootSize, getRegionSizeFromReadyTree(
+				t, regions, keyRange.startKey, keyRange.endKey,
+			))
+		})
+	}
+}
+
+func TestRegionSizeTreeRebuildDoesNotReplayTakenPending(t *testing.T) {
+	regions := NewRegionsInfo()
+	regions.PutRegion(newRegionSizeTreeTestRegion(1, "a", "m", 1, 10))
+	regions.PutRegion(newRegionSizeTreeTestRegion(2, "m", "", 1, 20))
+
+	// Keep the worker stopped so rebuild and both notifications are taken in
+	// the same drain iteration.
+	tree := newRegionSizeTree(context.Background(), regions)
+	regions.sizeTree.Store(tree)
+	t.Cleanup(regions.StopRegionSizeTree)
+	tree.notify(1, 2)
+	tree.requestRebuild()
+
+	atomic.StoreInt64(&regions.t.lockCount, 0)
+	tree.drain()
+	// The rebuild scans the root once. Replaying the two already-covered IDs
+	// would acquire the root lock a second time.
+	require.Equal(t, int64(1), atomic.LoadInt64(&regions.t.lockCount))
+	require.Equal(t, int64(30), getRegionSizeFromReadyTree(t, regions, nil, nil))
+}
+
+func TestRegionSizeTreeCanceledRebuildIsNeverReady(t *testing.T) {
+	regions := NewRegionsInfo()
+	regionCount := ScanRegionLimit + 1
+	for i := range regionCount {
+		endKey := fmt.Sprintf("%04d", i+1)
+		if i == regionCount-1 {
+			endKey = ""
+		}
+		regions.PutRegion(newRegionSizeTreeTestRegion(
+			uint64(i+1), fmt.Sprintf("%04d", i), endKey, 1, 1,
+		))
+	}
+
+	tree := newRegionSizeTree(context.Background(), regions)
+	tree.reset()
+	tree.mu.RLock()
+	atomic.StoreInt64(&regions.t.lockCount, 0)
+	rebuildDone := make(chan bool, 1)
+	go func() {
+		rebuildDone <- tree.rebuild()
+	}()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&regions.t.lockCount) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Cancel while the first batch is blocked on the size-tree lock. The first
+	// batch may be applied after the lock is released, but it must not be
+	// published as a complete index.
+	tree.cancel()
+	tree.mu.RUnlock()
+	require.False(t, <-rebuildDone)
+	tree.markReadyIfCurrent()
+	require.False(t, tree.isReady())
+	require.Less(t, tree.length(), regionCount)
+}
+
+func TestRegionSizeTreeResetDuringRebuildPublishesResetState(t *testing.T) {
+	regions := NewRegionsInfo()
+	regionCount := ScanRegionLimit + 1
+	for i := range regionCount {
+		endKey := fmt.Sprintf("%04d", i+1)
+		if i == regionCount-1 {
+			endKey = ""
+		}
+		regions.PutRegion(newRegionSizeTreeTestRegion(
+			uint64(i+1), fmt.Sprintf("%04d", i), endKey, 1, 1,
+		))
+	}
+	tree := newRegionSizeTree(context.Background(), regions)
+	regions.sizeTree.Store(tree)
+	t.Cleanup(regions.StopRegionSizeTree)
+
+	tree.reset()
+	tree.mu.RLock()
+	atomic.StoreInt64(&regions.t.lockCount, 0)
+	rebuildDone := make(chan bool, 1)
+	go func() {
+		rebuildDone <- tree.rebuild()
+	}()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&regions.t.lockCount) > 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	regions.ResetRegionCache()
+	regions.PutRegion(newRegionSizeTreeTestRegion(uint64(regionCount+1), "a", "z", 2, 40))
+	require.False(t, tree.isReady())
+	rootLockCount := atomic.LoadInt64(&regions.t.lockCount)
+	tree.mu.RUnlock()
+	require.False(t, <-rebuildDone)
+	require.Equal(t, rootLockCount, atomic.LoadInt64(&regions.t.lockCount))
+	require.Less(t, tree.length(), regionCount)
+	tree.markReadyIfCurrent()
+	require.False(t, tree.isReady())
+
+	tree.start()
+	requireRegionSizeEventually(t, regions, nil, nil, 40)
+	require.Equal(t, 1, tree.length())
+}
+
+func TestRegionSizeTreeReconcilesPendingInRootBatches(t *testing.T) {
+	regions := NewRegionsInfo()
+	regionCount := ScanRegionLimit
+	pending := make(map[uint64]struct{}, regionCount)
+	for i := range regionCount {
+		regionID := uint64(i + 1)
+		regions.PutRegion(newRegionSizeTreeTestRegion(
+			regionID, fmt.Sprintf("%04d", i), fmt.Sprintf("%04d", i+1), 1, 1,
+		))
+		pending[regionID] = struct{}{}
+	}
+
+	tree := newRegionSizeTree(context.Background(), regions)
+	t.Cleanup(tree.cancel)
+	atomic.StoreInt64(&regions.t.lockCount, 0)
+	require.True(t, tree.reconcilePending(pending))
+	require.Equal(t, int64((regionCount+batchSearchSize-1)/batchSearchSize),
+		atomic.LoadInt64(&regions.t.lockCount))
+	require.Equal(t, regionCount, tree.length())
+}
+
+func TestRegionSizeTreePendingReconcileCanBeInterrupted(t *testing.T) {
+	tests := []struct {
+		name      string
+		interrupt func(*regionSizeTree)
+	}{
+		{
+			name: "cancel",
+			interrupt: func(tree *regionSizeTree) {
+				tree.cancel()
+			},
+		},
+		{
+			name: "reset",
+			interrupt: func(tree *regionSizeTree) {
+				tree.requestReset()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			regions := NewRegionsInfo()
+			regionCount := 2 * ScanRegionLimit
+			pending := make(map[uint64]struct{}, regionCount)
+			for i := range regionCount {
+				regionID := uint64(i + 1)
+				regions.PutRegion(newRegionSizeTreeTestRegion(
+					regionID, fmt.Sprintf("%05d", i), fmt.Sprintf("%05d", i+1), 1, 1,
+				))
+				pending[regionID] = struct{}{}
+			}
+
+			tree := newRegionSizeTree(context.Background(), regions)
+			defer tree.cancel()
+			tree.mu.RLock()
+			atomic.StoreInt64(&regions.t.lockCount, 0)
+			reconcileDone := make(chan bool, 1)
+			go func() {
+				reconcileDone <- tree.reconcilePending(pending)
+			}()
+
+			deadline := time.Now().Add(5 * time.Second)
+			for atomic.LoadInt64(&regions.t.lockCount) == 0 && time.Now().Before(deadline) {
+				time.Sleep(10 * time.Millisecond)
+			}
+			if atomic.LoadInt64(&regions.t.lockCount) == 0 {
+				tree.cancel()
+				tree.mu.RUnlock()
+				<-reconcileDone
+				t.Fatal("pending reconciliation did not start")
+			}
+
+			// The first group has loaded its root state and is blocked on the
+			// size-tree lock. Interrupt it before allowing that group to commit.
+			test.interrupt(tree)
+			tree.mu.RUnlock()
+			require.False(t, <-reconcileDone)
+			require.Equal(t, ScanRegionLimit, tree.length())
+			require.Equal(t, int64((ScanRegionLimit+batchSearchSize-1)/batchSearchSize),
+				atomic.LoadInt64(&regions.t.lockCount))
+		})
+	}
+}
+
+func TestRegionSizeTreeEventuallyReconcilesLatestRootState(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	startRegionSizeTreeForTest(t, regions)
+	peer1 := &metapb.Peer{Id: 1, StoreId: 1}
+	peer2 := &metapb.Peer{Id: 2, StoreId: 1}
+	region1 := NewRegionInfo(&metapb.Region{
+		Id:       1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("m"),
+		Peers:    []*metapb.Peer{peer1},
+	}, peer1, SetApproximateSize(10))
+	region2 := NewRegionInfo(&metapb.Region{
+		Id:       2,
+		StartKey: []byte("m"),
+		Peers:    []*metapb.Peer{peer2},
+	}, peer2, SetApproximateSize(20))
+	regions.PutRegion(region1)
+	regions.PutRegion(region2)
+	requireRegionSizeEventually(t, regions, nil, nil, 30)
+	re.Equal(int64(10), getRegionSizeFromReadyTree(t, regions, []byte("b"), []byte("m")))
+
+	tree := regions.sizeTree.Load()
+	tree.mu.RLock()
+	updated := region1.Clone(SetApproximateSize(40))
+	_, err := regions.CheckAndPutRootTree(ContextTODO(), updated)
+	re.NoError(err)
+	re.Equal(int64(60), regions.GetRegionSizeByRange(nil, nil))
+	// The root update only enqueues the ID and does not wait for the size tree.
+	re.Equal(int64(30), tree.totalSize)
+	tree.mu.RUnlock()
+
+	// The size tree converges even if the corresponding subtree task is dropped.
+	requireRegionSizeEventually(t, regions, nil, nil, 60)
+	re.Equal(int64(40), getRegionSizeFromReadyTree(t, regions, []byte("b"), []byte("m")))
+	re.Equal(int32(1), updated.GetRef())
+	regions.CheckAndPutSubTree(updated)
+	re.Equal(int32(2), updated.GetRef())
+
+	regions.RemoveRegionIfExist(region2.GetID())
+	requireRegionSizeEventually(t, regions, nil, nil, 40)
+}
+
+func TestRegionSizeTreeQueryDoesNotBlockSubTreeUpdate(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	tree := startRegionSizeTreeForTest(t, regions)
+	region := newRegionSizeTreeTestRegion(1, "a", "z", 1, 10)
+	regions.PutRegion(region)
+	requireRegionSizeEventually(t, regions, nil, nil, 10)
+
+	// Simulate a long range query. The synchronous root/subtree path must only
+	// enqueue the ID and must not wait for the size-tree writer lock.
+	tree.mu.RLock()
+	updated := newRegionSizeTreeTestRegion(1, "a", "z", 1, 20)
+	updateDone := make(chan struct{})
+	go func() {
+		regions.PutRegion(updated)
+		close(updateDone)
+	}()
+
+	completed := false
+	select {
+	case <-updateDone:
+		completed = true
+	case <-time.After(time.Second):
+	}
+	tree.mu.RUnlock()
+	re.True(completed, "subtree update waited for the size-tree query")
+	re.Equal(int64(20), regions.GetRegionSizeByRange(nil, nil))
+	requireRegionSizeEventually(t, regions, nil, nil, 20)
+}
+
+func TestRegionSizeTreeSplitMerge(t *testing.T) {
+	for _, rightFirst := range []bool{false, true} {
+		regions := NewRegionsInfo()
+		startRegionSizeTreeForTest(t, regions)
+		original := newRegionSizeTreeTestRegion(1, "a", "z", 1, 100)
+		regions.PutRegion(original)
+		requireRegionSizeEventually(t, regions, nil, nil, 100)
+
+		left := newRegionSizeTreeTestRegion(1, "a", "m", 2, 40)
+		right := newRegionSizeTreeTestRegion(2, "m", "z", 2, 60)
+		if rightFirst {
+			regions.PutRegion(right)
+			regions.PutRegion(left)
+		} else {
+			regions.PutRegion(left)
+			regions.PutRegion(right)
+		}
+		require.Eventually(t, func() bool {
+			tree := regions.sizeTree.Load()
+			size, ready := regions.GetRegionSizeByRangeFromSizeTree(nil, nil)
+			return tree != nil && tree.length() == 2 &&
+				ready && size == 100
+		}, 5*time.Second, 10*time.Millisecond)
+
+		merged := newRegionSizeTreeTestRegion(3, "a", "z", 3, 120)
+		regions.PutRegion(merged)
+		require.Eventually(t, func() bool {
+			tree := regions.sizeTree.Load()
+			size, ready := regions.GetRegionSizeByRangeFromSizeTree(nil, nil)
+			return tree != nil && tree.length() == 1 &&
+				ready && size == 120
+		}, 5*time.Second, 10*time.Millisecond)
+
+		regions.StopRegionSizeTree()
+	}
+}
+
+func TestRegionSizeTreeDelayedChildNotificationsDoNotRemoveMergedRegion(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	merged := newRegionSizeTreeTestRegion(3, "a", "z", 3, 120)
+	regions.PutRegion(merged)
+
+	// Keep the worker stopped so both delayed child notifications are present
+	// before reconciliation reloads their latest root state.
+	tree := newRegionSizeTree(context.Background(), regions)
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: merged.GetID(), region: merged}})
+	regions.sizeTree.Store(tree)
+	t.Cleanup(regions.StopRegionSizeTree)
+
+	regions.notifyRegionSizeTree(1, 2)
+	tree.pendingMu.Lock()
+	pendingCount := len(tree.pending)
+	tree.pendingMu.Unlock()
+	re.Equal(2, pendingCount)
+	tree.drain()
+
+	re.Equal(1, tree.length())
+	re.Equal(int64(120), tree.getRegionSizeByRange(nil, nil))
+}
+
+func TestRegionSizeTreeCoalescesRemoveAndSameIDReplacement(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	original := newRegionSizeTreeTestRegion(1, "a", "z", 1, 10)
+	regions.PutRegion(original)
+
+	// Keep the worker stopped so remove and replacement deterministically
+	// coalesce into one pending ID before the latest root state is loaded.
+	tree := newRegionSizeTree(context.Background(), regions)
+	tree.reconcile([]regionSizeTreeUpdate{{regionID: original.GetID(), region: original}})
+	regions.sizeTree.Store(tree)
+	t.Cleanup(regions.StopRegionSizeTree)
+
+	regions.RemoveRegionIfExist(original.GetID())
+	replacement := newRegionSizeTreeTestRegion(1, "a", "z", 2, 40)
+	regions.PutRegion(replacement)
+	tree.pendingMu.Lock()
+	pendingCount := len(tree.pending)
+	_, pending := tree.pending[replacement.GetID()]
+	tree.pendingMu.Unlock()
+	re.Equal(1, pendingCount)
+	re.True(pending)
+	tree.drain()
+
+	re.Equal(1, tree.length())
+	re.Equal(int64(40), tree.getRegionSizeByRange(nil, nil))
+}
+
+func TestRegionSizeTreeConvergesAfterCoalescedOverlapReplacementRemoval(t *testing.T) {
+	tests := []struct {
+		name      string
+		putRegion func(*RegionsInfo, *RegionInfo) ([]*RegionInfo, error)
+	}{
+		{
+			name: "check-and-put-region",
+			putRegion: func(regions *RegionsInfo, region *RegionInfo) ([]*RegionInfo, error) {
+				return regions.CheckAndPutRegion(region), nil
+			},
+		},
+		{
+			name: "atomic-check-and-put-region",
+			putRegion: func(regions *RegionsInfo, region *RegionInfo) ([]*RegionInfo, error) {
+				return regions.AtomicCheckAndPutRegion(ContextTODO(), region)
+			},
+		},
+		{
+			name: "check-and-put-root-tree",
+			putRegion: func(regions *RegionsInfo, region *RegionInfo) ([]*RegionInfo, error) {
+				return regions.CheckAndPutRootTree(ContextTODO(), region)
+			},
+		},
+		{
+			name: "set-region",
+			putRegion: func(regions *RegionsInfo, region *RegionInfo) ([]*RegionInfo, error) {
+				_, overlaps, _ := regions.SetRegion(region)
+				return overlaps, nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			re := require.New(t)
+			regions := NewRegionsInfo()
+			original := newRegionSizeTreeTestRegion(1, "a", "z", 1, 10)
+			regions.PutRegion(original)
+
+			// Install a populated index without starting its worker so the replace
+			// and remove notifications deterministically coalesce before loading
+			// the latest root state.
+			tree := newRegionSizeTree(context.Background(), regions)
+			tree.reconcile([]regionSizeTreeUpdate{{regionID: original.GetID(), region: original}})
+			regions.sizeTree.Store(tree)
+			t.Cleanup(regions.StopRegionSizeTree)
+
+			replacement := newRegionSizeTreeTestRegion(2, "a", "z", 2, 20)
+			overlaps, err := test.putRegion(regions, replacement)
+			re.NoError(err)
+			re.Len(overlaps, 1)
+			re.Equal(original.GetID(), overlaps[0].GetID())
+			regions.RemoveRegion(replacement)
+
+			re.Nil(regions.GetRegion(original.GetID()))
+			re.Nil(regions.GetRegion(replacement.GetID()))
+			tree.drain()
+			re.Zero(tree.length())
+			re.Zero(tree.getRegionSizeByRange(nil, nil))
+		})
+	}
+}
+
+func TestRegionSizeTreeResetDoesNotBlockRootOrSubTree(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	tree := startRegionSizeTreeForTest(t, regions)
+	regions.PutRegion(newRegionSizeTreeTestRegion(1, "a", "m", 1, 10))
+	regions.PutRegion(newRegionSizeTreeTestRegion(2, "m", "z", 1, 20))
+	requireRegionSizeEventually(t, regions, nil, nil, 30)
+
+	tree.mu.RLock()
+	resetDone := make(chan struct{})
+	go func() {
+		regions.ResetRegionCache()
+		close(resetDone)
+	}()
+	resetCompleted := false
+	select {
+	case <-resetDone:
+		resetCompleted = true
+	case <-time.After(time.Second):
+	}
+
+	newRegion := newRegionSizeTreeTestRegion(3, "a", "z", 2, 40)
+	updateDone := make(chan struct{})
+	go func() {
+		regions.PutRegion(newRegion)
+		close(updateDone)
+	}()
+	updateCompleted := false
+	select {
+	case <-updateDone:
+		updateCompleted = true
+	case <-time.After(time.Second):
+	}
+	tree.mu.RUnlock()
+
+	re.True(resetCompleted, "reset waited for the size-tree query")
+	re.True(updateCompleted, "post-reset update waited for the size-tree query")
+	require.Eventually(t, func() bool {
+		size, ready := regions.GetRegionSizeByRangeFromSizeTree(nil, nil)
+		return tree.length() == 1 && ready && size == 40
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func startRegionSizeTreeForTest(t *testing.T, regions *RegionsInfo) *regionSizeTree {
+	ctx, cancel := context.WithCancel(context.Background())
+	regions.StartRegionSizeTree(ctx)
+	t.Cleanup(func() {
+		regions.StopRegionSizeTree()
+		cancel()
+	})
+	tree := regions.sizeTree.Load()
+	require.NotNil(t, tree)
+	require.Eventually(t, tree.isReady, 5*time.Second, 10*time.Millisecond)
+	return tree
+}
+
+func requireRegionSizeEventually(t *testing.T, regions *RegionsInfo, startKey, endKey []byte, expected int64) {
+	require.Eventually(t, func() bool {
+		size, ready := regions.GetRegionSizeByRangeFromSizeTree(startKey, endKey)
+		return ready && size == expected
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func getRegionSizeFromReadyTree(t *testing.T, regions *RegionsInfo, startKey, endKey []byte) int64 {
+	size, ready := regions.GetRegionSizeByRangeFromSizeTree(startKey, endKey)
+	require.True(t, ready)
+	return size
+}
+
+func newRegionSizeTreeTestRegion(id uint64, startKey, endKey string, version uint64, size int64) *RegionInfo {
+	return NewRegionInfo(&metapb.Region{
+		Id:       id,
+		StartKey: []byte(startKey),
+		EndKey:   []byte(endKey),
+		RegionEpoch: &metapb.RegionEpoch{
+			Version: version,
+			ConfVer: 2,
+		},
+	}, nil, SetApproximateSize(size))
+}

--- a/pkg/core/region_size_tree_test.go
+++ b/pkg/core/region_size_tree_test.go
@@ -123,6 +123,29 @@ func TestRegionSizeTreeRebuildsAndScansInBatches(t *testing.T) {
 	require.Nil(t, regions.sizeTree.Load())
 }
 
+func TestRegionSizeTreeResetInvalidatesLockedQuery(t *testing.T) {
+	re := require.New(t)
+	regions := NewRegionsInfo()
+	regions.PutRegion(newRegionSizeTreeTestRegion(1, "a", "z", 1, 10))
+	tree := startRegionSizeTreeForTest(t, regions)
+
+	// Model a query that has acquired the size-tree read lock and passed its
+	// initial readiness check. Reset invalidates the result immediately, but the
+	// worker cannot clear the tree until the query releases its read lock.
+	tree.mu.RLock()
+	re.True(tree.isReady())
+	resetDone := make(chan struct{})
+	go func() {
+		regions.ResetRegionCache()
+		close(resetDone)
+	}()
+	re.Eventually(func() bool { return !tree.isReady() }, 5*time.Second, 10*time.Millisecond)
+	re.Equal(int64(10), tree.getRegionSizeByRangeLocked([]byte("a"), []byte("z")))
+	re.False(tree.isReady())
+	tree.mu.RUnlock()
+	<-resetDone
+}
+
 func TestRegionSizeTreeCanceledRebuildIsNeverReady(t *testing.T) {
 	regions := NewRegionsInfo()
 	regionCount := ScanRegionLimit + 1
@@ -354,7 +377,7 @@ func TestRegionSizeTreeDelayedChildNotificationsDoNotRemoveMergedRegion(t *testi
 	tree.drain()
 
 	re.Equal(1, regionSizeTreeLengthForTest(tree))
-	re.Equal(int64(120), tree.getRegionSizeByRange(nil, nil))
+	re.Equal(int64(120), regionSizeTreeSizeForTest(tree))
 }
 
 func TestRegionSizeTreeCoalescesRemoveAndSameIDReplacement(t *testing.T) {
@@ -382,7 +405,7 @@ func TestRegionSizeTreeCoalescesRemoveAndSameIDReplacement(t *testing.T) {
 	tree.drain()
 
 	re.Equal(1, regionSizeTreeLengthForTest(tree))
-	re.Equal(int64(40), tree.getRegionSizeByRange(nil, nil))
+	re.Equal(int64(40), regionSizeTreeSizeForTest(tree))
 }
 
 func TestRegionSizeTreeConvergesAfterCoalescedOverlapReplacementRemoval(t *testing.T) {
@@ -443,7 +466,7 @@ func TestRegionSizeTreeConvergesAfterCoalescedOverlapReplacementRemoval(t *testi
 			re.Nil(regions.GetRegion(replacement.GetID()))
 			tree.drain()
 			re.Zero(regionSizeTreeLengthForTest(tree))
-			re.Zero(tree.getRegionSizeByRange(nil, nil))
+			re.Zero(regionSizeTreeSizeForTest(tree))
 		})
 	}
 }
@@ -521,6 +544,12 @@ func regionSizeTreeLengthForTest(tree *regionSizeTree) int {
 	tree.mu.RLock()
 	defer tree.mu.RUnlock()
 	return tree.tree.Len()
+}
+
+func regionSizeTreeSizeForTest(tree *regionSizeTree) int64 {
+	tree.mu.RLock()
+	defer tree.mu.RUnlock()
+	return tree.getRegionSizeByRangeLocked(nil, nil)
 }
 
 func newRegionSizeTreeTestRegion(id uint64, startKey, endKey string, version uint64, size int64) *RegionInfo {

--- a/pkg/core/region_size_tree_test.go
+++ b/pkg/core/region_size_tree_test.go
@@ -27,60 +27,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 )
 
-func TestRegionSizeTreeStructuralUpdates(t *testing.T) {
-	re := require.New(t)
-	tree := newRegionSizeTree(context.Background(), NewRegionsInfo())
-	t.Cleanup(tree.cancel)
-	merged := newRegionSizeTreeTestRegion(1, "a", "z", 1, 100)
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: merged.GetID(), region: merged}})
-	re.Equal(int64(100), tree.getRegionSizeByRange(nil, nil))
-	re.Equal(int64(100), tree.getRegionSizeByRange([]byte("b"), []byte("m")))
-
-	left := newRegionSizeTreeTestRegion(1, "a", "m", 2, 40)
-	right := newRegionSizeTreeTestRegion(2, "m", "z", 2, 60)
-	// Apply the right side first to cover out-of-order split notifications.
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: right.GetID(), region: right}})
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: left.GetID(), region: left}})
-	re.Equal(2, tree.length())
-	re.Equal(int64(100), tree.getRegionSizeByRange(nil, nil))
-	re.Equal(int64(40), tree.getRegionSizeByRange([]byte("b"), []byte("m")))
-	re.Equal(int64(60), tree.getRegionSizeByRange([]byte("m"), []byte("z")))
-
-	left = newRegionSizeTreeTestRegion(1, "a", "m", 2, 50)
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: left.GetID(), region: left}})
-	re.Equal(int64(110), tree.getRegionSizeByRange(nil, nil))
-
-	merged = newRegionSizeTreeTestRegion(3, "a", "z", 3, 120)
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: merged.GetID(), region: merged}})
-	re.Equal(1, tree.length())
-	re.Equal(int64(120), tree.getRegionSizeByRange(nil, nil))
-
-	// A delayed child removal deletes by ID and cannot remove the merged Region.
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: right.GetID()}})
-	re.Equal(1, tree.length())
-	re.Equal(int64(120), tree.getRegionSizeByRange(nil, nil))
-
-	tree.reset()
-	re.Zero(tree.length())
-	re.Zero(tree.getRegionSizeByRange(nil, nil))
-}
-
-func TestRegionSizeTreeIsOptInAndRebuilds(t *testing.T) {
-	re := require.New(t)
-	regions := NewRegionsInfo()
-	region := newRegionSizeTreeTestRegion(1, "a", "z", 1, 10)
-	regions.PutRegion(region)
-
-	re.Nil(regions.sizeTree.Load())
-	_, ready := regions.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
-	re.False(ready)
-
-	startRegionSizeTreeForTest(t, regions)
-	requireRegionSizeEventually(t, regions, []byte("a"), []byte("z"), 10)
-	regions.StopRegionSizeTree()
-	re.Nil(regions.sizeTree.Load())
-}
-
 func TestRegionSizeTreeMetrics(t *testing.T) {
 	regions := NewRegionsInfo()
 	tree := newRegionSizeTree(context.Background(), regions)
@@ -143,11 +89,14 @@ func TestRegionSizeTreeRebuildsAndScansInBatches(t *testing.T) {
 		))
 	}
 
+	require.Nil(t, regions.sizeTree.Load())
+	_, ready := regions.GetRegionSizeByRangeFromSizeTree([]byte("0000"), []byte("9999"))
+	require.False(t, ready)
 	atomic.StoreInt64(&regions.t.lockCount, 0)
 	startRegionSizeTreeForTest(t, regions)
 	// Rebuild scans 1000 Regions at a time and does not reload every ID.
 	require.Equal(t, int64(2), atomic.LoadInt64(&regions.t.lockCount))
-	requireRegionSizeEventually(t, regions, nil, nil, int64(regionCount))
+	requireTotalRegionSizeEventually(t, regions, int64(regionCount))
 	require.Equal(t, int64(regionCount), getRegionSizeFromReadyTree(t, regions,
 		[]byte("0000"), []byte("9999"),
 	))
@@ -170,6 +119,8 @@ func TestRegionSizeTreeRebuildsAndScansInBatches(t *testing.T) {
 			))
 		})
 	}
+	regions.StopRegionSizeTree()
+	require.Nil(t, regions.sizeTree.Load())
 }
 
 func TestRegionSizeTreeRebuildDoesNotReplayTakenPending(t *testing.T) {
@@ -183,7 +134,9 @@ func TestRegionSizeTreeRebuildDoesNotReplayTakenPending(t *testing.T) {
 	regions.sizeTree.Store(tree)
 	t.Cleanup(regions.StopRegionSizeTree)
 	tree.notify(1, 2)
-	tree.requestRebuild()
+	tree.pendingMu.Lock()
+	tree.rebuildPending = true
+	tree.pendingMu.Unlock()
 
 	atomic.StoreInt64(&regions.t.lockCount, 0)
 	tree.drain()
@@ -226,7 +179,7 @@ func TestRegionSizeTreeCanceledRebuildIsNeverReady(t *testing.T) {
 	require.False(t, <-rebuildDone)
 	tree.markReadyIfCurrent()
 	require.False(t, tree.isReady())
-	require.Less(t, tree.length(), regionCount)
+	require.Less(t, regionSizeTreeLengthForTest(tree), regionCount)
 }
 
 func TestRegionSizeTreeResetDuringRebuildPublishesResetState(t *testing.T) {
@@ -263,34 +216,13 @@ func TestRegionSizeTreeResetDuringRebuildPublishesResetState(t *testing.T) {
 	tree.mu.RUnlock()
 	require.False(t, <-rebuildDone)
 	require.Equal(t, rootLockCount, atomic.LoadInt64(&regions.t.lockCount))
-	require.Less(t, tree.length(), regionCount)
+	require.Less(t, regionSizeTreeLengthForTest(tree), regionCount)
 	tree.markReadyIfCurrent()
 	require.False(t, tree.isReady())
 
-	tree.start()
-	requireRegionSizeEventually(t, regions, nil, nil, 40)
-	require.Equal(t, 1, tree.length())
-}
-
-func TestRegionSizeTreeReconcilesPendingInRootBatches(t *testing.T) {
-	regions := NewRegionsInfo()
-	regionCount := ScanRegionLimit
-	pending := make(map[uint64]struct{}, regionCount)
-	for i := range regionCount {
-		regionID := uint64(i + 1)
-		regions.PutRegion(newRegionSizeTreeTestRegion(
-			regionID, fmt.Sprintf("%04d", i), fmt.Sprintf("%04d", i+1), 1, 1,
-		))
-		pending[regionID] = struct{}{}
-	}
-
-	tree := newRegionSizeTree(context.Background(), regions)
-	t.Cleanup(tree.cancel)
-	atomic.StoreInt64(&regions.t.lockCount, 0)
-	require.True(t, tree.reconcilePending(pending))
-	require.Equal(t, int64((regionCount+batchSearchSize-1)/batchSearchSize),
-		atomic.LoadInt64(&regions.t.lockCount))
-	require.Equal(t, regionCount, tree.length())
+	tree.drain()
+	require.Equal(t, int64(40), getRegionSizeFromReadyTree(t, regions, nil, nil))
+	require.Equal(t, 1, regionSizeTreeLengthForTest(tree))
 }
 
 func TestRegionSizeTreePendingReconcileCanBeInterrupted(t *testing.T) {
@@ -350,7 +282,7 @@ func TestRegionSizeTreePendingReconcileCanBeInterrupted(t *testing.T) {
 			test.interrupt(tree)
 			tree.mu.RUnlock()
 			require.False(t, <-reconcileDone)
-			require.Equal(t, ScanRegionLimit, tree.length())
+			require.Equal(t, ScanRegionLimit, regionSizeTreeLengthForTest(tree))
 			require.Equal(t, int64((ScanRegionLimit+batchSearchSize-1)/batchSearchSize),
 				atomic.LoadInt64(&regions.t.lockCount))
 		})
@@ -376,7 +308,7 @@ func TestRegionSizeTreeEventuallyReconcilesLatestRootState(t *testing.T) {
 	}, peer2, SetApproximateSize(20))
 	regions.PutRegion(region1)
 	regions.PutRegion(region2)
-	requireRegionSizeEventually(t, regions, nil, nil, 30)
+	requireTotalRegionSizeEventually(t, regions, 30)
 	re.Equal(int64(10), getRegionSizeFromReadyTree(t, regions, []byte("b"), []byte("m")))
 
 	tree := regions.sizeTree.Load()
@@ -386,18 +318,18 @@ func TestRegionSizeTreeEventuallyReconcilesLatestRootState(t *testing.T) {
 	re.NoError(err)
 	re.Equal(int64(60), regions.GetRegionSizeByRange(nil, nil))
 	// The root update only enqueues the ID and does not wait for the size tree.
-	re.Equal(int64(30), tree.totalSize)
+	re.Equal(int64(10), tree.regions[region1.GetID()].size)
 	tree.mu.RUnlock()
 
 	// The size tree converges even if the corresponding subtree task is dropped.
-	requireRegionSizeEventually(t, regions, nil, nil, 60)
+	requireTotalRegionSizeEventually(t, regions, 60)
 	re.Equal(int64(40), getRegionSizeFromReadyTree(t, regions, []byte("b"), []byte("m")))
 	re.Equal(int32(1), updated.GetRef())
 	regions.CheckAndPutSubTree(updated)
 	re.Equal(int32(2), updated.GetRef())
 
 	regions.RemoveRegionIfExist(region2.GetID())
-	requireRegionSizeEventually(t, regions, nil, nil, 40)
+	requireTotalRegionSizeEventually(t, regions, 40)
 }
 
 func TestRegionSizeTreeQueryDoesNotBlockSubTreeUpdate(t *testing.T) {
@@ -406,7 +338,7 @@ func TestRegionSizeTreeQueryDoesNotBlockSubTreeUpdate(t *testing.T) {
 	tree := startRegionSizeTreeForTest(t, regions)
 	region := newRegionSizeTreeTestRegion(1, "a", "z", 1, 10)
 	regions.PutRegion(region)
-	requireRegionSizeEventually(t, regions, nil, nil, 10)
+	requireTotalRegionSizeEventually(t, regions, 10)
 
 	// Simulate a long range query. The synchronous root/subtree path must only
 	// enqueue the ID and must not wait for the size-tree writer lock.
@@ -427,7 +359,7 @@ func TestRegionSizeTreeQueryDoesNotBlockSubTreeUpdate(t *testing.T) {
 	tree.mu.RUnlock()
 	re.True(completed, "subtree update waited for the size-tree query")
 	re.Equal(int64(20), regions.GetRegionSizeByRange(nil, nil))
-	requireRegionSizeEventually(t, regions, nil, nil, 20)
+	requireTotalRegionSizeEventually(t, regions, 20)
 }
 
 func TestRegionSizeTreeSplitMerge(t *testing.T) {
@@ -436,7 +368,7 @@ func TestRegionSizeTreeSplitMerge(t *testing.T) {
 		startRegionSizeTreeForTest(t, regions)
 		original := newRegionSizeTreeTestRegion(1, "a", "z", 1, 100)
 		regions.PutRegion(original)
-		requireRegionSizeEventually(t, regions, nil, nil, 100)
+		requireTotalRegionSizeEventually(t, regions, 100)
 
 		left := newRegionSizeTreeTestRegion(1, "a", "m", 2, 40)
 		right := newRegionSizeTreeTestRegion(2, "m", "z", 2, 60)
@@ -450,7 +382,7 @@ func TestRegionSizeTreeSplitMerge(t *testing.T) {
 		require.Eventually(t, func() bool {
 			tree := regions.sizeTree.Load()
 			size, ready := regions.GetRegionSizeByRangeFromSizeTree(nil, nil)
-			return tree != nil && tree.length() == 2 &&
+			return tree != nil && regionSizeTreeLengthForTest(tree) == 2 &&
 				ready && size == 100
 		}, 5*time.Second, 10*time.Millisecond)
 
@@ -459,7 +391,7 @@ func TestRegionSizeTreeSplitMerge(t *testing.T) {
 		require.Eventually(t, func() bool {
 			tree := regions.sizeTree.Load()
 			size, ready := regions.GetRegionSizeByRangeFromSizeTree(nil, nil)
-			return tree != nil && tree.length() == 1 &&
+			return tree != nil && regionSizeTreeLengthForTest(tree) == 1 &&
 				ready && size == 120
 		}, 5*time.Second, 10*time.Millisecond)
 
@@ -476,7 +408,7 @@ func TestRegionSizeTreeDelayedChildNotificationsDoNotRemoveMergedRegion(t *testi
 	// Keep the worker stopped so both delayed child notifications are present
 	// before reconciliation reloads their latest root state.
 	tree := newRegionSizeTree(context.Background(), regions)
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: merged.GetID(), region: merged}})
+	tree.reconcileIDs([]uint64{merged.GetID()})
 	regions.sizeTree.Store(tree)
 	t.Cleanup(regions.StopRegionSizeTree)
 
@@ -487,7 +419,7 @@ func TestRegionSizeTreeDelayedChildNotificationsDoNotRemoveMergedRegion(t *testi
 	re.Equal(2, pendingCount)
 	tree.drain()
 
-	re.Equal(1, tree.length())
+	re.Equal(1, regionSizeTreeLengthForTest(tree))
 	re.Equal(int64(120), tree.getRegionSizeByRange(nil, nil))
 }
 
@@ -500,7 +432,7 @@ func TestRegionSizeTreeCoalescesRemoveAndSameIDReplacement(t *testing.T) {
 	// Keep the worker stopped so remove and replacement deterministically
 	// coalesce into one pending ID before the latest root state is loaded.
 	tree := newRegionSizeTree(context.Background(), regions)
-	tree.reconcile([]regionSizeTreeUpdate{{regionID: original.GetID(), region: original}})
+	tree.reconcileIDs([]uint64{original.GetID()})
 	regions.sizeTree.Store(tree)
 	t.Cleanup(regions.StopRegionSizeTree)
 
@@ -515,7 +447,7 @@ func TestRegionSizeTreeCoalescesRemoveAndSameIDReplacement(t *testing.T) {
 	re.True(pending)
 	tree.drain()
 
-	re.Equal(1, tree.length())
+	re.Equal(1, regionSizeTreeLengthForTest(tree))
 	re.Equal(int64(40), tree.getRegionSizeByRange(nil, nil))
 }
 
@@ -562,7 +494,7 @@ func TestRegionSizeTreeConvergesAfterCoalescedOverlapReplacementRemoval(t *testi
 			// and remove notifications deterministically coalesce before loading
 			// the latest root state.
 			tree := newRegionSizeTree(context.Background(), regions)
-			tree.reconcile([]regionSizeTreeUpdate{{regionID: original.GetID(), region: original}})
+			tree.reconcileIDs([]uint64{original.GetID()})
 			regions.sizeTree.Store(tree)
 			t.Cleanup(regions.StopRegionSizeTree)
 
@@ -576,7 +508,7 @@ func TestRegionSizeTreeConvergesAfterCoalescedOverlapReplacementRemoval(t *testi
 			re.Nil(regions.GetRegion(original.GetID()))
 			re.Nil(regions.GetRegion(replacement.GetID()))
 			tree.drain()
-			re.Zero(tree.length())
+			re.Zero(regionSizeTreeLengthForTest(tree))
 			re.Zero(tree.getRegionSizeByRange(nil, nil))
 		})
 	}
@@ -588,7 +520,7 @@ func TestRegionSizeTreeResetDoesNotBlockRootOrSubTree(t *testing.T) {
 	tree := startRegionSizeTreeForTest(t, regions)
 	regions.PutRegion(newRegionSizeTreeTestRegion(1, "a", "m", 1, 10))
 	regions.PutRegion(newRegionSizeTreeTestRegion(2, "m", "z", 1, 20))
-	requireRegionSizeEventually(t, regions, nil, nil, 30)
+	requireTotalRegionSizeEventually(t, regions, 30)
 
 	tree.mu.RLock()
 	resetDone := make(chan struct{})
@@ -621,7 +553,7 @@ func TestRegionSizeTreeResetDoesNotBlockRootOrSubTree(t *testing.T) {
 	re.True(updateCompleted, "post-reset update waited for the size-tree query")
 	require.Eventually(t, func() bool {
 		size, ready := regions.GetRegionSizeByRangeFromSizeTree(nil, nil)
-		return tree.length() == 1 && ready && size == 40
+		return regionSizeTreeLengthForTest(tree) == 1 && ready && size == 40
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
@@ -638,9 +570,9 @@ func startRegionSizeTreeForTest(t *testing.T, regions *RegionsInfo) *regionSizeT
 	return tree
 }
 
-func requireRegionSizeEventually(t *testing.T, regions *RegionsInfo, startKey, endKey []byte, expected int64) {
+func requireTotalRegionSizeEventually(t *testing.T, regions *RegionsInfo, expected int64) {
 	require.Eventually(t, func() bool {
-		size, ready := regions.GetRegionSizeByRangeFromSizeTree(startKey, endKey)
+		size, ready := regions.GetRegionSizeByRangeFromSizeTree(nil, nil)
 		return ready && size == expected
 	}, 5*time.Second, 10*time.Millisecond)
 }
@@ -649,6 +581,12 @@ func getRegionSizeFromReadyTree(t *testing.T, regions *RegionsInfo, startKey, en
 	size, ready := regions.GetRegionSizeByRangeFromSizeTree(startKey, endKey)
 	require.True(t, ready)
 	return size
+}
+
+func regionSizeTreeLengthForTest(tree *regionSizeTree) int {
+	tree.mu.RLock()
+	defer tree.mu.RUnlock()
+	return tree.tree.Len()
 }
 
 func newRegionSizeTreeTestRegion(id uint64, startKey, endKey string, version uint64, size int64) *RegionInfo {

--- a/pkg/core/region_size_tree_test.go
+++ b/pkg/core/region_size_tree_test.go
@@ -82,8 +82,11 @@ func TestRegionSizeTreeIsOptInAndRebuilds(t *testing.T) {
 }
 
 func TestRegionSizeTreeMetrics(t *testing.T) {
-	tree := newRegionSizeTree(context.Background(), NewRegionsInfo())
+	regions := NewRegionsInfo()
+	tree := newRegionSizeTree(context.Background(), regions)
+	regions.sizeTree.Store(tree)
 	t.Cleanup(func() {
+		regions.sizeTree.Store(nil)
 		tree.cancel()
 		resetRegionSizeTreeMetrics()
 	})
@@ -93,7 +96,7 @@ func TestRegionSizeTreeMetrics(t *testing.T) {
 	tree.pendingSince = time.Now().Add(-time.Second)
 	tree.pendingMu.Unlock()
 	tree.ready.Store(true)
-	tree.collectMetrics()
+	regions.CollectRegionSizeTreeMetrics()
 	require.Equal(t, 1.0, testutil.ToFloat64(regionSizeTreeReadyGauge))
 	require.Equal(t, 2.0, testutil.ToFloat64(regionSizeTreePendingGauge))
 	require.GreaterOrEqual(t,
@@ -101,7 +104,7 @@ func TestRegionSizeTreeMetrics(t *testing.T) {
 	)
 
 	tree.drain()
-	tree.collectMetrics()
+	regions.CollectRegionSizeTreeMetrics()
 	require.Zero(t, testutil.ToFloat64(regionSizeTreePendingGauge))
 	require.Zero(t, testutil.ToFloat64(regionSizeTreeOldestPendingDurationGauge))
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1022,6 +1022,7 @@ func (c *RaftCluster) Stop() {
 	}
 
 	c.wg.Wait()
+	c.StopRegionSizeTree()
 	log.Info("raft cluster is stopped")
 }
 
@@ -1919,31 +1920,82 @@ type regionSizeCacheKey struct {
 	endKey   string
 }
 
-// regionSizeCache is scoped to one checkStores round and is refreshed on the next round.
-type regionSizeCache struct {
-	loader func(startKey, endKey []byte) int64
-	sizes  map[regionSizeCacheKey]int64
+type regionSizeCacheValue struct {
+	size              int64
+	available         bool
+	needsConfirmation bool
 }
 
-func newRegionSizeCache(loader func(startKey, endKey []byte) int64) regionSizeCache {
-	return regionSizeCache{
-		loader: loader,
-		sizes:  make(map[regionSizeCacheKey]int64),
+// regionSizeCache is scoped to one checkStores round and is refreshed on the next round.
+type regionSizeCache struct {
+	loader func(startKey, endKey []byte) regionSizeCacheValue
+	sizes  map[regionSizeCacheKey]regionSizeCacheValue
+
+	available         bool
+	needsConfirmation bool
+}
+
+func newRegionSizeCache(loader func(startKey, endKey []byte) int64) *regionSizeCache {
+	return newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
+		return regionSizeCacheValue{size: loader(startKey, endKey), available: true}
+	})
+}
+
+func newRegionSizeCacheWithResult(
+	loader func(startKey, endKey []byte) regionSizeCacheValue,
+) *regionSizeCache {
+	return &regionSizeCache{
+		loader:    loader,
+		sizes:     make(map[regionSizeCacheKey]regionSizeCacheValue),
+		available: true,
 	}
 }
 
-func (c regionSizeCache) getRegionSize(startKey, endKey []byte) int64 {
+func (c *regionSizeCache) beginUse() {
+	c.available = true
+	c.needsConfirmation = false
+}
+
+func (c *regionSizeCache) getRegionSizeResult(startKey, endKey []byte) regionSizeCacheValue {
 	key := regionSizeCacheKey{
 		startKey: string(startKey),
 		endKey:   string(endKey),
 	}
-	if size, ok := c.sizes[key]; ok {
-		return size
+	result, ok := c.sizes[key]
+	if !ok {
+		result = c.loader(startKey, endKey)
+		c.sizes[key] = result
 	}
+	c.available = c.available && result.available
+	c.needsConfirmation = c.needsConfirmation || result.needsConfirmation
+	return result
+}
 
-	size := c.loader(startKey, endKey)
-	c.sizes[key] = size
-	return size
+func (c *regionSizeCache) getRegionSize(startKey, endKey []byte) int64 {
+	return c.getRegionSizeResult(startKey, endKey).size
+}
+
+func (c *RaftCluster) getPreparingRegionSize(
+	startKey, endKey []byte,
+	rootSizes *regionSizeCache,
+) regionSizeCacheValue {
+	if len(startKey) == 0 && len(endKey) == 0 {
+		// The root tree already maintains the full-range total in O(1).
+		return rootSizes.getRegionSizeResult(startKey, endKey)
+	}
+	// Most clusters only use the full-range total. Build the additional index
+	// lazily when a placement-rule boundary first needs a non-empty range.
+	if c.ctx == nil {
+		return rootSizes.getRegionSizeResult(startKey, endKey)
+	}
+	c.StartRegionSizeTree(c.ctx)
+	if size, ready := c.GetRegionSizeByRangeFromSizeTree(startKey, endKey); ready {
+		return regionSizeCacheValue{size: size, available: true, needsConfirmation: true}
+	}
+	// Avoid scanning the root tree while the initial full-tree rebuild is doing
+	// the same work. Preparing can safely defer this one-way state transition
+	// until the independently maintained index is ready.
+	return regionSizeCacheValue{}
 }
 
 func (c *RaftCluster) checkStores() {
@@ -1951,12 +2003,15 @@ func (c *RaftCluster) checkStores() {
 		offlineStores []*metapb.Store
 		upStoreCount  int
 		stores        = c.GetStores()
-		regionSizes   = newRegionSizeCache(c.GetRegionSizeByRange)
 	)
+	rootSizes := newRegionSizeCache(c.GetRegionSizeByRange)
+	approxSizes := newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
+		return c.getPreparingRegionSize(startKey, endKey, rootSizes)
+	})
 
 	for _, store := range stores {
 		storeID := store.GetID()
-		isInUp, isInOffline := c.checkStore(storeID, regionSizes)
+		isInUp, isInOffline := c.checkStore(storeID, approxSizes)
 		if isInUp {
 			upStoreCount++
 		}
@@ -1973,7 +2028,10 @@ func (c *RaftCluster) checkStores() {
 	}
 }
 
-func (c *RaftCluster) checkStore(storeID uint64, regionSizes regionSizeCache) (isInUp, isInOffline bool) {
+func (c *RaftCluster) checkStore(
+	storeID uint64,
+	approxSizes *regionSizeCache,
+) (isInUp, isInOffline bool) {
 	c.storeStateLock.Lock(uint32(storeID))
 	defer c.storeStateLock.Unlock(uint32(storeID))
 
@@ -1984,8 +2042,9 @@ func (c *RaftCluster) checkStore(storeID uint64, regionSizes regionSizeCache) (i
 	}
 
 	var (
-		regionSize = float64(store.GetRegionSize())
-		threshold  float64
+		regionSize         = float64(store.GetRegionSize())
+		threshold          float64
+		thresholdAvailable = true
 	)
 	switch store.GetNodeState() {
 	case metapb.NodeState_Preparing:
@@ -1993,11 +2052,22 @@ func (c *RaftCluster) checkStore(storeID uint64, regionSizes regionSizeCache) (i
 			c.GetTotalRegionCount() < core.InitClusterRegionThreshold
 		if !readyToServe && (c.IsPrepared() || (c.IsServiceIndependent(constant.SchedulingServiceName) && c.isStorePrepared())) {
 			kr := keyutil.NewKeyRange("", "")
-			threshold = c.getThreshold(c.GetStores(), store, &kr, regionSizes)
-			log.Debug("store preparing threshold", zap.Uint64("store-id", storeID),
-				zap.Float64("threshold", threshold),
-				zap.Float64("region-size", regionSize))
-			readyToServe = regionSize >= threshold
+			stores := c.GetStores()
+			approxSizes.beginUse()
+			threshold = c.getThreshold(stores, store, &kr, approxSizes)
+			thresholdAvailable = approxSizes.available
+			if thresholdAvailable {
+				if approxSizes.needsConfirmation && regionSize >= threshold {
+					// The size tree can lag behind the root tree. Confirm the one-way
+					// Preparing-to-Serving transition with a fresh per-store root cache.
+					rootSizes := newRegionSizeCache(c.GetRegionSizeByRange)
+					threshold = c.getThreshold(stores, store, &kr, rootSizes)
+				}
+				log.Debug("store preparing threshold", zap.Uint64("store-id", storeID),
+					zap.Float64("threshold", threshold),
+					zap.Float64("region-size", regionSize))
+				readyToServe = regionSize >= threshold
+			}
 		}
 		if readyToServe {
 			if err := c.ReadyToServeLocked(storeID); err != nil {
@@ -2038,7 +2108,9 @@ func (c *RaftCluster) checkStore(storeID uint64, regionSizes regionSizeCache) (i
 			log.Info("auto gc the tombstone store success", zap.Stringer("store", store.GetMeta()), zap.Duration("down-time", store.DownTime()))
 		}
 	}
-	c.progressManager.UpdateProgress(store, regionSize, threshold)
+	if thresholdAvailable {
+		c.progressManager.UpdateProgress(store, regionSize, threshold)
+	}
 	// When store is preparing or serving, we think it is in up.
 	// `checkStore` only may change store state from preparing to serving.
 	// So we don't need to get store again.
@@ -2050,7 +2122,7 @@ func (c *RaftCluster) getThreshold(
 	stores []*core.StoreInfo,
 	store *core.StoreInfo,
 	kr *keyutil.KeyRange,
-	regionSizes regionSizeCache,
+	regionSizes *regionSizeCache,
 ) float64 {
 	start := time.Now()
 	if !c.opt.IsPlacementRulesEnabled() {
@@ -2081,7 +2153,7 @@ func (c *RaftCluster) calculateRange(
 	stores []*core.StoreInfo,
 	store *core.StoreInfo,
 	startKey, endKey []byte,
-	regionSizes regionSizeCache,
+	regionSizes *regionSizeCache,
 ) float64 {
 	rules := c.ruleManager.GetRulesForApplyRange(startKey, endKey)
 	var (

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2011,7 +2011,7 @@ func (c *RaftCluster) checkStores() {
 
 	for _, store := range stores {
 		storeID := store.GetID()
-		isInUp, isInOffline := c.checkStore(storeID, approxSizes)
+		isInUp, isInOffline := c.checkStore(storeID, approxSizes, rootSizes)
 		if isInUp {
 			upStoreCount++
 		}
@@ -2030,7 +2030,7 @@ func (c *RaftCluster) checkStores() {
 
 func (c *RaftCluster) checkStore(
 	storeID uint64,
-	approxSizes *regionSizeCache,
+	approxSizes, rootSizes *regionSizeCache,
 ) (isInUp, isInOffline bool) {
 	c.storeStateLock.Lock(uint32(storeID))
 	defer c.storeStateLock.Unlock(uint32(storeID))
@@ -2059,8 +2059,7 @@ func (c *RaftCluster) checkStore(
 			if thresholdAvailable {
 				if approxSizes.needsConfirmation && regionSize >= threshold {
 					// The size tree can lag behind the root tree. Confirm the one-way
-					// Preparing-to-Serving transition with a fresh per-store root cache.
-					rootSizes := newRegionSizeCache(c.GetRegionSizeByRange)
+					// Preparing-to-Serving transition with this round's root cache.
 					threshold = c.getThreshold(stores, store, &kr, rootSizes)
 				}
 				log.Debug("store preparing threshold", zap.Uint64("store-id", storeID),
@@ -2241,6 +2240,7 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 }
 
 func (c *RaftCluster) collectMetrics() {
+	c.CollectRegionSizeTreeMetrics()
 	c.collectHealthStatus()
 }
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1985,9 +1985,6 @@ func (c *RaftCluster) getPreparingRegionSize(
 	}
 	// Most clusters only use the full-range total. Build the additional index
 	// lazily when a placement-rule boundary first needs a non-empty range.
-	if c.ctx == nil {
-		return rootSizes.getRegionSizeResult(startKey, endKey)
-	}
 	c.StartRegionSizeTree(c.ctx)
 	if size, ready := c.GetRegionSizeByRangeFromSizeTree(startKey, endKey); ready {
 		return regionSizeCacheValue{size: size, available: true, needsConfirmation: true}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -462,6 +462,7 @@ func (c *RaftCluster) Start(s Server, bootstrap bool) (err error) {
 	c.checkSchedulingService()
 	checkSchedulingDuration := time.Since(checkSchedulingStart)
 	log.Info("check scheduling service completed", zap.Duration("cost", checkSchedulingDuration))
+	c.StartRegionSizeTree(c.ctx)
 	backgroundJobsStart := time.Now()
 	c.wg.Add(11)
 	go c.runServiceCheckJob()
@@ -1921,21 +1922,17 @@ type regionSizeCacheKey struct {
 }
 
 type regionSizeCacheValue struct {
-	size              int64
-	available         bool
-	needsConfirmation bool
+	size      int64
+	available bool
 }
 
 // regionSizeCache is scoped to one checkStores round and is refreshed on the next round.
 type regionSizeCache struct {
 	loader func(startKey, endKey []byte) regionSizeCacheValue
 	sizes  map[regionSizeCacheKey]regionSizeCacheValue
-
-	available         bool
-	needsConfirmation bool
 }
 
-func newRegionSizeCache(loader func(startKey, endKey []byte) int64) *regionSizeCache {
+func newRegionSizeCache(loader func(startKey, endKey []byte) int64) regionSizeCache {
 	return newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
 		return regionSizeCacheValue{size: loader(startKey, endKey), available: true}
 	})
@@ -1943,20 +1940,14 @@ func newRegionSizeCache(loader func(startKey, endKey []byte) int64) *regionSizeC
 
 func newRegionSizeCacheWithResult(
 	loader func(startKey, endKey []byte) regionSizeCacheValue,
-) *regionSizeCache {
-	return &regionSizeCache{
-		loader:    loader,
-		sizes:     make(map[regionSizeCacheKey]regionSizeCacheValue),
-		available: true,
+) regionSizeCache {
+	return regionSizeCache{
+		loader: loader,
+		sizes:  make(map[regionSizeCacheKey]regionSizeCacheValue),
 	}
 }
 
-func (c *regionSizeCache) beginUse() {
-	c.available = true
-	c.needsConfirmation = false
-}
-
-func (c *regionSizeCache) getRegionSizeResult(startKey, endKey []byte) regionSizeCacheValue {
+func (c regionSizeCache) getRegionSize(startKey, endKey []byte) regionSizeCacheValue {
 	key := regionSizeCacheKey{
 		startKey: string(startKey),
 		endKey:   string(endKey),
@@ -1966,32 +1957,22 @@ func (c *regionSizeCache) getRegionSizeResult(startKey, endKey []byte) regionSiz
 		result = c.loader(startKey, endKey)
 		c.sizes[key] = result
 	}
-	c.available = c.available && result.available
-	c.needsConfirmation = c.needsConfirmation || result.needsConfirmation
 	return result
 }
 
-func (c *regionSizeCache) getRegionSize(startKey, endKey []byte) int64 {
-	return c.getRegionSizeResult(startKey, endKey).size
-}
-
-func (c *RaftCluster) getPreparingRegionSize(
-	startKey, endKey []byte,
-	rootSizes *regionSizeCache,
-) regionSizeCacheValue {
+func (c *RaftCluster) getPreparingRegionSize(startKey, endKey []byte) regionSizeCacheValue {
 	if len(startKey) == 0 && len(endKey) == 0 {
 		// The root tree already maintains the full-range total in O(1).
-		return rootSizes.getRegionSizeResult(startKey, endKey)
+		return regionSizeCacheValue{
+			size:      c.GetRegionSizeByRange(startKey, endKey),
+			available: true,
+		}
 	}
-	// Most clusters only use the full-range total. Build the additional index
-	// lazily when a placement-rule boundary first needs a non-empty range.
-	c.StartRegionSizeTree(c.ctx)
 	if size, ready := c.GetRegionSizeByRangeFromSizeTree(startKey, endKey); ready {
-		return regionSizeCacheValue{size: size, available: true, needsConfirmation: true}
+		return regionSizeCacheValue{size: size, available: true}
 	}
-	// Avoid scanning the root tree while the initial full-tree rebuild is doing
-	// the same work. Preparing can safely defer this one-way state transition
-	// until the independently maintained index is ready.
+	// Avoid reading a partially built index. Preparing can safely defer this
+	// state transition until the independently maintained index is ready.
 	return regionSizeCacheValue{}
 }
 
@@ -2001,14 +1982,11 @@ func (c *RaftCluster) checkStores() {
 		upStoreCount  int
 		stores        = c.GetStores()
 	)
-	rootSizes := newRegionSizeCache(c.GetRegionSizeByRange)
-	approxSizes := newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
-		return c.getPreparingRegionSize(startKey, endKey, rootSizes)
-	})
+	regionSizes := newRegionSizeCacheWithResult(c.getPreparingRegionSize)
 
 	for _, store := range stores {
 		storeID := store.GetID()
-		isInUp, isInOffline := c.checkStore(storeID, approxSizes, rootSizes)
+		isInUp, isInOffline := c.checkStore(storeID, regionSizes)
 		if isInUp {
 			upStoreCount++
 		}
@@ -2027,7 +2005,7 @@ func (c *RaftCluster) checkStores() {
 
 func (c *RaftCluster) checkStore(
 	storeID uint64,
-	approxSizes, rootSizes *regionSizeCache,
+	regionSizes regionSizeCache,
 ) (isInUp, isInOffline bool) {
 	c.storeStateLock.Lock(uint32(storeID))
 	defer c.storeStateLock.Unlock(uint32(storeID))
@@ -2050,15 +2028,8 @@ func (c *RaftCluster) checkStore(
 		if !readyToServe && (c.IsPrepared() || (c.IsServiceIndependent(constant.SchedulingServiceName) && c.isStorePrepared())) {
 			kr := keyutil.NewKeyRange("", "")
 			stores := c.GetStores()
-			approxSizes.beginUse()
-			threshold = c.getThreshold(stores, store, &kr, approxSizes)
-			thresholdAvailable = approxSizes.available
+			threshold, thresholdAvailable = c.getThreshold(stores, store, &kr, regionSizes)
 			if thresholdAvailable {
-				if approxSizes.needsConfirmation && regionSize >= threshold {
-					// The size tree can lag behind the root tree. Confirm the one-way
-					// Preparing-to-Serving transition with this round's root cache.
-					threshold = c.getThreshold(stores, store, &kr, rootSizes)
-				}
 				log.Debug("store preparing threshold", zap.Uint64("store-id", storeID),
 					zap.Float64("threshold", threshold),
 					zap.Float64("region-size", regionSize))
@@ -2118,39 +2089,52 @@ func (c *RaftCluster) getThreshold(
 	stores []*core.StoreInfo,
 	store *core.StoreInfo,
 	kr *keyutil.KeyRange,
-	regionSizes *regionSizeCache,
-) float64 {
+	regionSizes regionSizeCache,
+) (float64, bool) {
 	start := time.Now()
 	if !c.opt.IsPlacementRulesEnabled() {
-		regionSize := regionSizes.getRegionSize(kr.StartKey, kr.EndKey) * int64(c.opt.GetMaxReplicas())
+		result := regionSizes.getRegionSize(kr.StartKey, kr.EndKey)
+		if !result.available {
+			return 0, false
+		}
+		regionSize := result.size * int64(c.opt.GetMaxReplicas())
 		weight := core.GetStoreTopoWeight(store, stores, c.opt.GetLocationLabels(), c.opt.GetMaxReplicas())
-		return float64(regionSize) * weight * 0.9
+		return float64(regionSize) * weight * 0.9, true
 	}
 
 	keys := c.ruleManager.GetSplitKeys(kr.StartKey, kr.EndKey)
 	if len(keys) == 0 {
-		return c.calculateRange(stores, store, kr.StartKey, kr.EndKey, regionSizes) * 0.9
+		storeSize, available := c.calculateRange(stores, store, kr.StartKey, kr.EndKey, regionSizes)
+		return storeSize * 0.9, available
 	}
 
 	storeSize := 0.0
 	startKey := kr.StartKey
 	for _, key := range keys {
 		endKey := key
-		storeSize += c.calculateRange(stores, store, startKey, endKey, regionSizes)
+		rangeSize, available := c.calculateRange(stores, store, startKey, endKey, regionSizes)
+		if !available {
+			return 0, false
+		}
+		storeSize += rangeSize
 		startKey = endKey
 	}
 	// the range from the last split key to the last key
-	storeSize += c.calculateRange(stores, store, startKey, kr.EndKey, regionSizes)
+	rangeSize, available := c.calculateRange(stores, store, startKey, kr.EndKey, regionSizes)
+	if !available {
+		return 0, false
+	}
+	storeSize += rangeSize
 	log.Debug("threshold calculation time", zap.Duration("cost", time.Since(start)))
-	return storeSize * 0.9
+	return storeSize * 0.9, true
 }
 
 func (c *RaftCluster) calculateRange(
 	stores []*core.StoreInfo,
 	store *core.StoreInfo,
 	startKey, endKey []byte,
-	regionSizes *regionSizeCache,
-) float64 {
+	regionSizes regionSizeCache,
+) (float64, bool) {
 	rules := c.ruleManager.GetRulesForApplyRange(startKey, endKey)
 	var (
 		regionSize       int64
@@ -2162,7 +2146,11 @@ func (c *RaftCluster) calculateRange(
 			continue
 		}
 		if !regionSizeLoaded {
-			regionSize = regionSizes.getRegionSize(startKey, endKey)
+			result := regionSizes.getRegionSize(startKey, endKey)
+			if !result.available {
+				return 0, false
+			}
+			regionSize = result.size
 			regionSizeLoaded = true
 		}
 
@@ -2188,7 +2176,7 @@ func (c *RaftCluster) calculateRange(
 			zap.Float64("store-size", storeSize),
 		)
 	}
-	return storeSize
+	return storeSize, true
 }
 
 // RemoveTombStoneRecords removes the tombStone Records.

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1941,6 +1941,181 @@ func TestRegionSizeCacheAcrossStoresAndRules(t *testing.T) {
 	re.Equal(2, loadCounts[regionSizeCacheKey{startKey: "a", endKey: "m"}])
 }
 
+func TestPreparingRegionSizeLazilyStartsSizeTree(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster := &RaftCluster{ctx: ctx, BasicCluster: core.NewBasicCluster()}
+	defer cluster.StopRegionSizeTree()
+	peer := &metapb.Peer{Id: 1, StoreId: 1}
+	region := core.NewRegionInfo(&metapb.Region{
+		Id:       1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Peers:    []*metapb.Peer{peer},
+	}, peer, core.SetApproximateSize(10))
+	cluster.PutRegion(region)
+	rootSizes := newRegionSizeCache(cluster.GetRegionSizeByRange)
+	_, ready := cluster.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
+	re.False(ready)
+	result := cluster.getPreparingRegionSize(nil, nil, rootSizes)
+	re.Equal(int64(10), result.size)
+	re.True(result.available)
+	re.False(result.needsConfirmation)
+	_, ready = cluster.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
+	re.False(ready)
+
+	// The first bounded query starts the index and defers the decision instead of
+	// scanning the root tree while the full rebuild is doing the same work.
+	result = cluster.getPreparingRegionSize([]byte("a"), []byte("z"), rootSizes)
+	re.False(result.available)
+	re.Eventually(func() bool {
+		_, ready := cluster.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
+		return ready
+	}, 5*time.Second, 10*time.Millisecond)
+
+	updated := region.Clone(core.SetApproximateSize(40))
+	_, err := cluster.CheckAndPutRootTree(core.ContextTODO(), updated)
+	re.NoError(err)
+	re.Equal(int64(40), cluster.GetRegionSizeByRange(nil, nil))
+	rootSizes = newRegionSizeCache(cluster.GetRegionSizeByRange)
+	result = cluster.getPreparingRegionSize(nil, nil, rootSizes)
+	re.Equal(int64(40), result.size)
+	re.True(result.available)
+	re.False(result.needsConfirmation)
+	re.Eventually(func() bool {
+		result := cluster.getPreparingRegionSize([]byte("a"), []byte("z"), rootSizes)
+		return result.size == 40 && result.available && result.needsConfirmation
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestPreparingRegionSizeDoesNotFallbackWhileIndexBuilds(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cluster := &RaftCluster{ctx: ctx, BasicCluster: core.NewBasicCluster()}
+	defer cluster.StopRegionSizeTree()
+	cluster.PutRegion(core.NewRegionInfo(&metapb.Region{
+		Id:       1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+	}, nil, core.SetApproximateSize(10)))
+
+	loadCount := 0
+	rootSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
+		loadCount++
+		return cluster.GetRegionSizeByRange(startKey, endKey)
+	})
+	approxSizes := newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
+		return cluster.getPreparingRegionSize(startKey, endKey, rootSizes)
+	})
+
+	// A canceled context keeps the lazy index unready. The approximate lookup
+	// must not scan the root while an initial rebuild would normally be running.
+	result := approxSizes.getRegionSizeResult([]byte("a"), []byte("z"))
+	re.False(result.available)
+	re.False(result.needsConfirmation)
+	re.Zero(loadCount)
+}
+
+func TestCheckStoreOnlyConfirmsAsyncPreparingThresholdWithRootTree(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	opt.SetPlacementRuleEnabled(true)
+	opt.SetMaxReplicas(1)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	re.NoError(cluster.ruleManager.SetRule(&placement.Rule{
+		GroupID:     placement.DefaultGroupID,
+		ID:          "bounded",
+		StartKeyHex: "00",
+		EndKeyHex:   "ff",
+		Role:        placement.Voter,
+		Count:       1,
+	}))
+	cluster.coordinator = schedule.NewCoordinator(ctx, cluster, nil)
+	cluster.SetPrepared()
+	cluster.progressManager = progress.NewManager(cluster.GetCoordinator().GetCheckerController(),
+		nodeStateCheckJobInterval)
+
+	now := time.Now()
+	stores := newTestStores(3, "8.5.0")
+	for i, store := range stores {
+		if i < 2 {
+			store = store.Clone(
+				core.SetNodeState(metapb.NodeState_Preparing),
+				core.SetStoreStartTime(now.Unix()),
+			)
+		}
+		re.NoError(cluster.PutMetaStore(store.GetMeta()))
+		cluster.PutStore(cluster.GetStore(store.GetID()).Clone(
+			core.SetLastHeartbeatTS(now),
+			core.SetRegionCount(10),
+			core.SetRegionSize(190),
+		))
+	}
+
+	for i := range core.InitClusterRegionThreshold {
+		peer := &metapb.Peer{Id: uint64(i + 1), StoreId: stores[2].GetID()}
+		region := core.NewRegionInfo(&metapb.Region{
+			Id:       uint64(i + 1),
+			StartKey: []byte(fmt.Sprintf("%04d", i)),
+			EndKey:   []byte(fmt.Sprintf("%04d", i+1)),
+			Peers:    []*metapb.Peer{peer},
+		}, peer, core.SetApproximateSize(3))
+		cluster.PutRegion(region)
+	}
+
+	loadedRanges := make(map[regionSizeCacheKey]int)
+	staleSizes := newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
+		key := regionSizeCacheKey{startKey: string(startKey), endKey: string(endKey)}
+		loadedRanges[key]++
+		size := int64(0)
+		if key == (regionSizeCacheKey{startKey: "\x00", endKey: "\xff"}) {
+			size = 300
+		}
+		return regionSizeCacheValue{size: size, available: true, needsConfirmation: true}
+	})
+
+	// An unavailable lazy index defers both the state decision and this round's
+	// progress sample instead of treating an unknown threshold as zero.
+	unavailableSizes := newRegionSizeCacheWithResult(func([]byte, []byte) regionSizeCacheValue {
+		return regionSizeCacheValue{}
+	})
+	cluster.checkStore(stores[0].GetID(), unavailableSizes)
+	re.Equal(metapb.NodeState_Preparing, cluster.GetStore(stores[0].GetID()).GetNodeState())
+	re.Nil(cluster.progressManager.GetProgressByStoreID(stores[0].GetID()))
+
+	// Both the default and bounded rules contribute: 300 * 2 rules / 3 stores
+	// * 0.9 = 180, so the first store can serve after root confirmation.
+	cluster.checkStore(stores[0].GetID(), staleSizes)
+	re.Equal(metapb.NodeState_Serving, cluster.GetStore(stores[0].GetID()).GetNodeState())
+
+	// Grow the authoritative range to 600 while the asynchronous value remains
+	// 300. A fresh confirmation for the second store must use threshold 360,
+	// rather than a root result cached while checking the first store.
+	region := cluster.GetRegion(1).Clone(core.SetApproximateSize(303))
+	cluster.PutRegion(region)
+	cluster.checkStore(stores[1].GetID(), staleSizes)
+	re.Equal(metapb.NodeState_Preparing, cluster.GetStore(stores[1].GetID()).GetNodeState())
+	re.Zero(loadedRanges[regionSizeCacheKey{}])
+	re.Equal(1, loadedRanges[regionSizeCacheKey{startKey: "\x00", endKey: "\xff"}])
+
+	// The same stale value marked exact skips root confirmation and is used
+	// directly, proving confirmation is limited to asynchronous results.
+	exactSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
+		if string(startKey) == "\x00" && string(endKey) == "\xff" {
+			return 300
+		}
+		return 0
+	})
+	cluster.checkStore(stores[1].GetID(), exactSizes)
+	re.Equal(metapb.NodeState_Serving, cluster.GetStore(stores[1].GetID()).GetNodeState())
+}
+
 func TestStatsRegions(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1959,7 +1959,10 @@ func TestPreparingRegionSizeUsesRegionSizeTree(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cluster := &RaftCluster{ctx: ctx, BasicCluster: core.NewBasicCluster()}
+	_, opt, err := newTestScheduleConfig()
+	re.NoError(err)
+	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
+	cluster.SetServiceIndependent(mcsconstant.SchedulingServiceName)
 	peer := &metapb.Peer{Id: 1, StoreId: 1}
 	region := core.NewRegionInfo(&metapb.Region{
 		Id:       1,
@@ -1967,7 +1970,7 @@ func TestPreparingRegionSizeUsesRegionSizeTree(t *testing.T) {
 		EndKey:   []byte("z"),
 		Peers:    []*metapb.Peer{peer},
 	}, peer, core.SetApproximateSize(10))
-	cluster.PutRegion(region)
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), region))
 	result := cluster.getPreparingRegionSize(nil, nil)
 	re.Equal(int64(10), result.size)
 	re.True(result.available)
@@ -1980,8 +1983,7 @@ func TestPreparingRegionSizeUsesRegionSizeTree(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 
 	updated := region.Clone(core.SetApproximateSize(40))
-	_, err := cluster.CheckAndPutRootTree(core.ContextTODO(), updated)
-	re.NoError(err)
+	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), updated))
 	re.Equal(int64(40), cluster.GetRegionSizeByRange(nil, nil))
 	result = cluster.getPreparingRegionSize(nil, nil)
 	re.Equal(int64(40), result.size)

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -1878,13 +1878,17 @@ func TestCalculateStoreSize1(t *testing.T) {
 	kr := keyutil.NewKeyRange("", "")
 	regionSizes := newRegionSizeCache(cluster.GetRegionSizeByRange)
 	// 100 * 100 * 2 (placement rule) / 4 (host) * 0.9 = 4500
-	re.Equal(4500.0, cluster.getThreshold(stores, store, &kr, regionSizes))
+	threshold, available := cluster.getThreshold(stores, store, &kr, regionSizes)
+	re.True(available)
+	re.Equal(4500.0, threshold)
 
 	cluster.opt.SetPlacementRuleEnabled(false)
 	cluster.opt.SetLocationLabels([]string{"zone", "rack", "host"})
 	regionSizes = newRegionSizeCache(cluster.GetRegionSizeByRange)
 	// 30000 (total region size) / 3 (zone) / 4 (host) * 0.9 = 2250
-	re.Equal(2250.0, cluster.getThreshold(stores, store, &kr, regionSizes))
+	threshold, available = cluster.getThreshold(stores, store, &kr, regionSizes)
+	re.True(available)
+	re.Equal(2250.0, threshold)
 }
 
 func TestRegionSizeCacheAcrossStoresAndRules(t *testing.T) {
@@ -1929,28 +1933,33 @@ func TestRegionSizeCacheAcrossStoresAndRules(t *testing.T) {
 	regionSizes := newRegionSizeCache(loader)
 
 	stores := cluster.GetStores()
-	threshold1 := cluster.getThreshold(stores, cluster.GetStore(1), &kr, regionSizes)
-	threshold2 := cluster.getThreshold(stores, cluster.GetStore(2), &kr, regionSizes)
+	threshold1, available := cluster.getThreshold(stores, cluster.GetStore(1), &kr, regionSizes)
+	re.True(available)
+	threshold2, available := cluster.getThreshold(stores, cluster.GetStore(2), &kr, regionSizes)
+	re.True(available)
 	// (100 * 3 replicas / 2 stores + 100 * 1 learner / 2 stores) * 0.9 = 180.
 	re.Equal(180.0, threshold1)
 	re.Equal(180.0, threshold2)
 	re.Equal(1, loadCounts[regionSizeCacheKey{startKey: "a", endKey: "m"}])
 
 	// A different range is loaded separately, then shared by all rules.
-	re.Equal(360.0, cluster.getThreshold(stores, cluster.GetStore(1), &otherKR, regionSizes))
+	threshold, available := cluster.getThreshold(stores, cluster.GetStore(1), &otherKR, regionSizes)
+	re.True(available)
+	re.Equal(360.0, threshold)
 	re.Equal(1, loadCounts[regionSizeCacheKey{startKey: "m", endKey: "z"}])
 
 	nextRoundRegionSizes := newRegionSizeCache(loader)
-	re.Equal(threshold1, cluster.getThreshold(stores, cluster.GetStore(1), &kr, nextRoundRegionSizes))
+	threshold, available = cluster.getThreshold(stores, cluster.GetStore(1), &kr, nextRoundRegionSizes)
+	re.True(available)
+	re.Equal(threshold1, threshold)
 	re.Equal(2, loadCounts[regionSizeCacheKey{startKey: "a", endKey: "m"}])
 }
 
-func TestPreparingRegionSizeLazilyStartsSizeTree(t *testing.T) {
+func TestPreparingRegionSizeUsesRegionSizeTree(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cluster := &RaftCluster{ctx: ctx, BasicCluster: core.NewBasicCluster()}
-	defer cluster.StopRegionSizeTree()
 	peer := &metapb.Peer{Id: 1, StoreId: 1}
 	region := core.NewRegionInfo(&metapb.Region{
 		Id:       1,
@@ -1959,70 +1968,31 @@ func TestPreparingRegionSizeLazilyStartsSizeTree(t *testing.T) {
 		Peers:    []*metapb.Peer{peer},
 	}, peer, core.SetApproximateSize(10))
 	cluster.PutRegion(region)
-	rootSizes := newRegionSizeCache(cluster.GetRegionSizeByRange)
-	_, ready := cluster.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
-	re.False(ready)
-	result := cluster.getPreparingRegionSize(nil, nil, rootSizes)
+	result := cluster.getPreparingRegionSize(nil, nil)
 	re.Equal(int64(10), result.size)
 	re.True(result.available)
-	re.False(result.needsConfirmation)
-	_, ready = cluster.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
-	re.False(ready)
 
-	// The first bounded query starts the index and defers the decision instead of
-	// scanning the root tree while the full rebuild is doing the same work.
-	result = cluster.getPreparingRegionSize([]byte("a"), []byte("z"), rootSizes)
-	re.False(result.available)
+	cluster.StartRegionSizeTree(ctx)
+	t.Cleanup(cluster.StopRegionSizeTree)
 	re.Eventually(func() bool {
-		_, ready := cluster.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
-		return ready
+		result := cluster.getPreparingRegionSize([]byte("a"), []byte("z"))
+		return result.size == 10 && result.available
 	}, 5*time.Second, 10*time.Millisecond)
 
 	updated := region.Clone(core.SetApproximateSize(40))
 	_, err := cluster.CheckAndPutRootTree(core.ContextTODO(), updated)
 	re.NoError(err)
 	re.Equal(int64(40), cluster.GetRegionSizeByRange(nil, nil))
-	rootSizes = newRegionSizeCache(cluster.GetRegionSizeByRange)
-	result = cluster.getPreparingRegionSize(nil, nil, rootSizes)
+	result = cluster.getPreparingRegionSize(nil, nil)
 	re.Equal(int64(40), result.size)
 	re.True(result.available)
-	re.False(result.needsConfirmation)
 	re.Eventually(func() bool {
-		result := cluster.getPreparingRegionSize([]byte("a"), []byte("z"), rootSizes)
-		return result.size == 40 && result.available && result.needsConfirmation
+		result := cluster.getPreparingRegionSize([]byte("a"), []byte("z"))
+		return result.size == 40 && result.available
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
-func TestPreparingRegionSizeDoesNotFallbackWhileIndexBuilds(t *testing.T) {
-	re := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	cluster := &RaftCluster{ctx: ctx, BasicCluster: core.NewBasicCluster()}
-	defer cluster.StopRegionSizeTree()
-	cluster.PutRegion(core.NewRegionInfo(&metapb.Region{
-		Id:       1,
-		StartKey: []byte("a"),
-		EndKey:   []byte("z"),
-	}, nil, core.SetApproximateSize(10)))
-
-	loadCount := 0
-	rootSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
-		loadCount++
-		return cluster.GetRegionSizeByRange(startKey, endKey)
-	})
-	approxSizes := newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
-		return cluster.getPreparingRegionSize(startKey, endKey, rootSizes)
-	})
-
-	// A canceled context keeps the lazy index unready. The approximate lookup
-	// must not scan the root while an initial rebuild would normally be running.
-	result := approxSizes.getRegionSizeResult([]byte("a"), []byte("z"))
-	re.False(result.available)
-	re.False(result.needsConfirmation)
-	re.Zero(loadCount)
-}
-
-func TestCheckStoreOnlyConfirmsAsyncPreparingThresholdWithRootTree(t *testing.T) {
+func TestCheckStoreDefersPreparingWhenRegionSizeTreeIsUnavailable(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2045,27 +2015,20 @@ func TestCheckStoreOnlyConfirmsAsyncPreparingThresholdWithRootTree(t *testing.T)
 	cluster.progressManager = progress.NewManager(cluster.GetCoordinator().GetCheckerController(),
 		nodeStateCheckJobInterval)
 
-	const confirmedStoreCount = 50
 	now := time.Now()
-	// Keep one additional Preparing store below the approximate threshold so it
-	// can verify that the next check round reloads root sizes.
-	stores := newTestStores(confirmedStoreCount+2, "8.5.0")
+	stores := newTestStores(2, "8.5.0")
 	for i, store := range stores {
-		if i <= confirmedStoreCount {
+		if i == 0 {
 			store = store.Clone(
 				core.SetNodeState(metapb.NodeState_Preparing),
 				core.SetStoreStartTime(now.Unix()),
 			)
 		}
 		re.NoError(cluster.PutMetaStore(store.GetMeta()))
-		regionSize := int64(15)
-		if i == confirmedStoreCount {
-			regionSize = 5
-		}
 		cluster.PutStore(cluster.GetStore(store.GetID()).Clone(
 			core.SetLastHeartbeatTS(now),
 			core.SetRegionCount(10),
-			core.SetRegionSize(regionSize),
+			core.SetRegionSize(15),
 		))
 	}
 
@@ -2080,78 +2043,16 @@ func TestCheckStoreOnlyConfirmsAsyncPreparingThresholdWithRootTree(t *testing.T)
 		cluster.PutRegion(region)
 	}
 
-	loadedRanges := make(map[regionSizeCacheKey]int)
-	staleSizes := newRegionSizeCacheWithResult(func(startKey, endKey []byte) regionSizeCacheValue {
-		key := regionSizeCacheKey{startKey: string(startKey), endKey: string(endKey)}
-		loadedRanges[key]++
-		size := int64(0)
-		if key == (regionSizeCacheKey{startKey: "\x00", endKey: "\xff"}) {
-			size = 300
-		}
-		return regionSizeCacheValue{size: size, available: true, needsConfirmation: true}
-	})
-	rootLoadedRanges := make(map[regionSizeCacheKey]int)
-	rootSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
-		key := regionSizeCacheKey{startKey: string(startKey), endKey: string(endKey)}
-		rootLoadedRanges[key]++
-		return cluster.GetRegionSizeByRange(startKey, endKey)
-	})
+	indexCtx, stopIndex := context.WithCancel(ctx)
+	stopIndex()
+	cluster.StartRegionSizeTree(indexCtx)
+	t.Cleanup(cluster.StopRegionSizeTree)
 
-	// An unavailable lazy index defers both the state decision and this round's
-	// progress sample instead of treating an unknown threshold as zero.
-	unavailableSizes := newRegionSizeCacheWithResult(func([]byte, []byte) regionSizeCacheValue {
-		return regionSizeCacheValue{}
-	})
-	cluster.checkStore(stores[0].GetID(), unavailableSizes, rootSizes)
+	// The unavailable bounded index neither falls back to a root range scan nor
+	// treats the unknown threshold as zero.
+	cluster.checkStores()
 	re.Equal(metapb.NodeState_Preparing, cluster.GetStore(stores[0].GetID()).GetNodeState())
 	re.Nil(cluster.progressManager.GetProgressByStoreID(stores[0].GetID()))
-
-	// Both the default and bounded rules contribute. All 50 candidates share
-	// the same root cache, so each placement interval is scanned only once.
-	for i := range confirmedStoreCount {
-		cluster.checkStore(stores[i].GetID(), staleSizes, rootSizes)
-		re.Equal(metapb.NodeState_Serving, cluster.GetStore(stores[i].GetID()).GetNodeState())
-	}
-	re.Len(rootLoadedRanges, 3)
-	for _, count := range rootLoadedRanges {
-		re.Equal(1, count)
-	}
-	re.Len(loadedRanges, 3)
-	for _, count := range loadedRanges {
-		re.Equal(1, count)
-	}
-
-	// Grow the authoritative range to 600 while the asynchronous value remains
-	// 300. The next round uses a new root cache and keeps the remaining store in
-	// Preparing because its current size is below the refreshed threshold.
-	region := cluster.GetRegion(1).Clone(core.SetApproximateSize(303))
-	cluster.PutRegion(region)
-	remainingStoreID := stores[confirmedStoreCount].GetID()
-	cluster.PutStore(cluster.GetStore(remainingStoreID).Clone(core.SetRegionSize(15)))
-	nextRoundRootLoadedRanges := make(map[regionSizeCacheKey]int)
-	nextRoundRootSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
-		key := regionSizeCacheKey{startKey: string(startKey), endKey: string(endKey)}
-		nextRoundRootLoadedRanges[key]++
-		return cluster.GetRegionSizeByRange(startKey, endKey)
-	})
-	cluster.checkStore(remainingStoreID, staleSizes, nextRoundRootSizes)
-	re.Equal(metapb.NodeState_Preparing, cluster.GetStore(remainingStoreID).GetNodeState())
-	re.Len(nextRoundRootLoadedRanges, 3)
-	for _, count := range nextRoundRootLoadedRanges {
-		re.Equal(1, count)
-	}
-	re.Zero(loadedRanges[regionSizeCacheKey{}])
-
-	// The same stale value marked exact skips root confirmation and is used
-	// directly, proving confirmation is limited to asynchronous results.
-	exactSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
-		if string(startKey) == "\x00" && string(endKey) == "\xff" {
-			return 300
-		}
-		return 0
-	})
-	cluster.checkStore(remainingStoreID, exactSizes, nextRoundRootSizes)
-	re.Equal(metapb.NodeState_Serving, cluster.GetStore(remainingStoreID).GetNodeState())
 }
 
 func TestClusterMetricsCollectRegionSizeTreeInIndependentSchedulingMode(t *testing.T) {
@@ -2291,7 +2192,9 @@ func TestCalculateStoreSize2(t *testing.T) {
 	kr := keyutil.NewKeyRange("", "")
 	regionSizes := newRegionSizeCache(cluster.GetRegionSizeByRange)
 	// 100 * 100 * 4 (total region size) / 2 (dc) / 2 (logic) / 3 (host) * 0.9 = 3000
-	re.Equal(3000.0, cluster.getThreshold(stores, store, &kr, regionSizes))
+	threshold, available := cluster.getThreshold(stores, store, &kr, regionSizes)
+	re.True(available)
+	re.Equal(3000.0, threshold)
 }
 
 func TestStores(t *testing.T) {
@@ -4488,7 +4391,7 @@ func TestCheckStoresUpCountWithLowSpace(t *testing.T) {
 	upStoreCount := 0
 	regionSizes := newRegionSizeCache(cluster.GetRegionSizeByRange)
 	for _, s := range cluster.GetStores() {
-		isUp, _ := cluster.checkStore(s.GetID(), regionSizes, regionSizes)
+		isUp, _ := cluster.checkStore(s.GetID(), regionSizes)
 		if isUp {
 			upStoreCount++
 		}
@@ -4509,7 +4412,7 @@ func TestCheckStoresUpCountWithLowSpace(t *testing.T) {
 	}
 	regionSizes = newRegionSizeCache(cluster.GetRegionSizeByRange)
 	for _, s := range cluster.GetStores() {
-		isUp, _ := cluster.checkStore(s.GetID(), regionSizes, regionSizes)
+		isUp, _ := cluster.checkStore(s.GetID(), regionSizes)
 		if isUp {
 			upStoreCount++
 		}

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -23,11 +23,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
+	prometheus_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
@@ -44,6 +47,7 @@ import (
 	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/id"
+	mcsconstant "github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/mock/mockhbstream"
 	"github.com/tikv/pd/pkg/mock/mockid"
 	"github.com/tikv/pd/pkg/progress"
@@ -2041,25 +2045,32 @@ func TestCheckStoreOnlyConfirmsAsyncPreparingThresholdWithRootTree(t *testing.T)
 	cluster.progressManager = progress.NewManager(cluster.GetCoordinator().GetCheckerController(),
 		nodeStateCheckJobInterval)
 
+	const confirmedStoreCount = 50
 	now := time.Now()
-	stores := newTestStores(3, "8.5.0")
+	// Keep one additional Preparing store below the approximate threshold so it
+	// can verify that the next check round reloads root sizes.
+	stores := newTestStores(confirmedStoreCount+2, "8.5.0")
 	for i, store := range stores {
-		if i < 2 {
+		if i <= confirmedStoreCount {
 			store = store.Clone(
 				core.SetNodeState(metapb.NodeState_Preparing),
 				core.SetStoreStartTime(now.Unix()),
 			)
 		}
 		re.NoError(cluster.PutMetaStore(store.GetMeta()))
+		regionSize := int64(15)
+		if i == confirmedStoreCount {
+			regionSize = 5
+		}
 		cluster.PutStore(cluster.GetStore(store.GetID()).Clone(
 			core.SetLastHeartbeatTS(now),
 			core.SetRegionCount(10),
-			core.SetRegionSize(190),
+			core.SetRegionSize(regionSize),
 		))
 	}
 
 	for i := range core.InitClusterRegionThreshold {
-		peer := &metapb.Peer{Id: uint64(i + 1), StoreId: stores[2].GetID()}
+		peer := &metapb.Peer{Id: uint64(i + 1), StoreId: stores[len(stores)-1].GetID()}
 		region := core.NewRegionInfo(&metapb.Region{
 			Id:       uint64(i + 1),
 			StartKey: []byte(fmt.Sprintf("%04d", i)),
@@ -2079,30 +2090,57 @@ func TestCheckStoreOnlyConfirmsAsyncPreparingThresholdWithRootTree(t *testing.T)
 		}
 		return regionSizeCacheValue{size: size, available: true, needsConfirmation: true}
 	})
+	rootLoadedRanges := make(map[regionSizeCacheKey]int)
+	rootSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
+		key := regionSizeCacheKey{startKey: string(startKey), endKey: string(endKey)}
+		rootLoadedRanges[key]++
+		return cluster.GetRegionSizeByRange(startKey, endKey)
+	})
 
 	// An unavailable lazy index defers both the state decision and this round's
 	// progress sample instead of treating an unknown threshold as zero.
 	unavailableSizes := newRegionSizeCacheWithResult(func([]byte, []byte) regionSizeCacheValue {
 		return regionSizeCacheValue{}
 	})
-	cluster.checkStore(stores[0].GetID(), unavailableSizes)
+	cluster.checkStore(stores[0].GetID(), unavailableSizes, rootSizes)
 	re.Equal(metapb.NodeState_Preparing, cluster.GetStore(stores[0].GetID()).GetNodeState())
 	re.Nil(cluster.progressManager.GetProgressByStoreID(stores[0].GetID()))
 
-	// Both the default and bounded rules contribute: 300 * 2 rules / 3 stores
-	// * 0.9 = 180, so the first store can serve after root confirmation.
-	cluster.checkStore(stores[0].GetID(), staleSizes)
-	re.Equal(metapb.NodeState_Serving, cluster.GetStore(stores[0].GetID()).GetNodeState())
+	// Both the default and bounded rules contribute. All 50 candidates share
+	// the same root cache, so each placement interval is scanned only once.
+	for i := range confirmedStoreCount {
+		cluster.checkStore(stores[i].GetID(), staleSizes, rootSizes)
+		re.Equal(metapb.NodeState_Serving, cluster.GetStore(stores[i].GetID()).GetNodeState())
+	}
+	re.Len(rootLoadedRanges, 3)
+	for _, count := range rootLoadedRanges {
+		re.Equal(1, count)
+	}
+	re.Len(loadedRanges, 3)
+	for _, count := range loadedRanges {
+		re.Equal(1, count)
+	}
 
 	// Grow the authoritative range to 600 while the asynchronous value remains
-	// 300. A fresh confirmation for the second store must use threshold 360,
-	// rather than a root result cached while checking the first store.
+	// 300. The next round uses a new root cache and keeps the remaining store in
+	// Preparing because its current size is below the refreshed threshold.
 	region := cluster.GetRegion(1).Clone(core.SetApproximateSize(303))
 	cluster.PutRegion(region)
-	cluster.checkStore(stores[1].GetID(), staleSizes)
-	re.Equal(metapb.NodeState_Preparing, cluster.GetStore(stores[1].GetID()).GetNodeState())
+	remainingStoreID := stores[confirmedStoreCount].GetID()
+	cluster.PutStore(cluster.GetStore(remainingStoreID).Clone(core.SetRegionSize(15)))
+	nextRoundRootLoadedRanges := make(map[regionSizeCacheKey]int)
+	nextRoundRootSizes := newRegionSizeCache(func(startKey, endKey []byte) int64 {
+		key := regionSizeCacheKey{startKey: string(startKey), endKey: string(endKey)}
+		nextRoundRootLoadedRanges[key]++
+		return cluster.GetRegionSizeByRange(startKey, endKey)
+	})
+	cluster.checkStore(remainingStoreID, staleSizes, nextRoundRootSizes)
+	re.Equal(metapb.NodeState_Preparing, cluster.GetStore(remainingStoreID).GetNodeState())
+	re.Len(nextRoundRootLoadedRanges, 3)
+	for _, count := range nextRoundRootLoadedRanges {
+		re.Equal(1, count)
+	}
 	re.Zero(loadedRanges[regionSizeCacheKey{}])
-	re.Equal(1, loadedRanges[regionSizeCacheKey{startKey: "\x00", endKey: "\xff"}])
 
 	// The same stale value marked exact skips root confirmation and is used
 	// directly, proving confirmation is limited to asynchronous results.
@@ -2112,8 +2150,37 @@ func TestCheckStoreOnlyConfirmsAsyncPreparingThresholdWithRootTree(t *testing.T)
 		}
 		return 0
 	})
-	cluster.checkStore(stores[1].GetID(), exactSizes)
-	re.Equal(metapb.NodeState_Serving, cluster.GetStore(stores[1].GetID()).GetNodeState())
+	cluster.checkStore(remainingStoreID, exactSizes, nextRoundRootSizes)
+	re.Equal(metapb.NodeState_Serving, cluster.GetStore(remainingStoreID).GetNodeState())
+}
+
+func TestClusterMetricsCollectRegionSizeTreeInIndependentSchedulingMode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster := &RaftCluster{BasicCluster: core.NewBasicCluster()}
+	cluster.PutRegion(core.NewRegionInfo(&metapb.Region{
+		Id:       1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+	}, nil, core.SetApproximateSize(10)))
+	cluster.StartRegionSizeTree(ctx)
+	t.Cleanup(cluster.StopRegionSizeTree)
+	require.Eventually(t, func() bool {
+		_, ready := cluster.GetRegionSizeByRangeFromSizeTree([]byte("a"), []byte("z"))
+		return ready
+	}, 5*time.Second, 10*time.Millisecond)
+
+	cluster.SetServiceIndependent(mcsconstant.SchedulingServiceName)
+	cluster.collectMetrics()
+	require.NoError(t, prometheus_testutil.GatherAndCompare(
+		prometheus.DefaultGatherer,
+		strings.NewReader(`# HELP pd_core_region_size_tree_ready Whether the eventually consistent Region size tree is ready for queries.
+# TYPE pd_core_region_size_tree_ready gauge
+pd_core_region_size_tree_ready 1
+`),
+		"pd_core_region_size_tree_ready",
+	))
 }
 
 func TestStatsRegions(t *testing.T) {
@@ -4421,7 +4488,7 @@ func TestCheckStoresUpCountWithLowSpace(t *testing.T) {
 	upStoreCount := 0
 	regionSizes := newRegionSizeCache(cluster.GetRegionSizeByRange)
 	for _, s := range cluster.GetStores() {
-		isUp, _ := cluster.checkStore(s.GetID(), regionSizes)
+		isUp, _ := cluster.checkStore(s.GetID(), regionSizes, regionSizes)
 		if isUp {
 			upStoreCount++
 		}
@@ -4442,7 +4509,7 @@ func TestCheckStoresUpCountWithLowSpace(t *testing.T) {
 	}
 	regionSizes = newRegionSizeCache(cluster.GetRegionSizeByRange)
 	for _, s := range cluster.GetStores() {
-		isUp, _ := cluster.checkStore(s.GetID(), regionSizes)
+		isUp, _ := cluster.checkStore(s.GetID(), regionSizes, regionSizes)
 		if isUp {
 			upStoreCount++
 		}


### PR DESCRIPTION
### What problem does this PR solve?

After #11072 removes duplicate scans, each unique non-empty Preparing range still scans the root Region tree. Region heartbeats update the same tree under its write lock, so a large range query can delay routing metadata updates.

Using the existing `overlapTree` would move contention away from the root tree, but would make range queries contend with all subtree readers and writers under `st`.

Issue Number: ref #9574, ref #11082

### What is changed and how does it work?

```commit-message
Start an eventually consistent `regionSizeTree` with the primary RaftCluster. Its dedicated worker performs the initial full-tree build asynchronously and maintains a compact, independently locked B-tree for approximate range-size queries. Active followers and the independent Scheduling Service do not start or query this index.

After a successful root-tree mutation releases `t`, enqueue the accepted Region ID and any Region IDs removed as overlaps when the range or approximate size changed. A capacity-one notifier wakes the single worker, while a pending-ID map coalesces repeated updates. The worker reloads current root state in batches, so delayed update/delete notifications, split, merge, overlap replacement, and reset converge without applying stale event payloads.

Keep the O(1) full-range Preparing lookup on the root Region tree. Read non-empty ranges from the independent size tree while holding its own read lock for the duration of the query. This lock is independent from both the root and subtree locks, so a range query can delay only the size-tree worker. While the initial build is not ready, defer bounded Preparing threshold and progress evaluation rather than reading a partial index or falling back to a root range scan.

Once ready, Preparing uses the eventually consistent size-tree value directly. Preparing progress and threshold calculations are approximate and do not require a point-in-time root-tree snapshot, so this path does not perform a second root-tree confirmation scan.
```

The size tree stores compact ID/start/end/size entries rather than retaining full `RegionInfo` objects. It retains immutable range-key slices captured from root state; a later same-range heartbeat may replace the root `RegionInfo` without refreshing those slices, so the index can retain one older key pair per Region until a range change, reset, or stop. Repeated same-range heartbeats do not accumulate additional copies.

No size-tree operation waits for its lock while holding the root-tree lock `t` or subtree lock `st`. A range query can delay the size-tree worker for the duration of that query, but cannot delay the authoritative root or subtree heartbeat update.

Observability is provided by:

- `pd_core_region_size_tree_ready`
- `pd_core_region_size_tree_pending`
- `pd_core_region_size_tree_oldest_pending_duration_seconds`
- `pd_core_region_size_tree_rebuild_duration_seconds`

The gauges are sampled by the primary RaftCluster's periodic metrics collector, including when Scheduling Service is independent, rather than updated on the Region-heartbeat path.

### Check List

Tests

- Unit test
  - `make gotest GOTEST_ARGS='./pkg/core ./server/cluster'`
  - `make gotest GOTEST_ARGS='./pkg/core ./server/cluster -run "TestRegionSizeTree|TestPreparingRegionSize|TestCheckStoreDefersPreparing" -race -count=3'`
  - `make gotest GOTEST_ARGS='./pkg/core ./server/cluster -tags=nextgen -run "TestRegionSizeTree|TestPreparingRegionSize|TestCheckStoreDefersPreparing" -count=1'`
- Static analysis
  - `make check`

The tests cover initial build and readiness, batched root access, range-query semantics, context cancellation, reset/rebuild interleavings, bounded pending cancellation, root/subtree lock isolation, pending coalescing, split/merge, delayed notifications, overlap replacement across all root mutation entry points, unavailable Preparing thresholds, and primary-PD metric collection in independent Scheduling Service mode.

### Preliminary benchmark

Temporary local benchmark on an AMD Ryzen 7 7840S. The rebuild measurement uses the real batched root `ScanRegions` path and was taken immediately after rebuild, while captured range-key slices still shared backing arrays with the then-current root `RegionInfo`.

| Regions | Index memory | Initial full rebuild | Bounded scan covering all Regions |
| ---: | ---: | ---: | ---: |
| 100K | 107.7 B/Region | 51.3 ms | 1.63 ms |
| 1M | 121.8 B/Region | 748 ms | 23.8 ms |

The 1M memory result is about 116 MiB. A linear 10M extrapolation is about 1.13 GiB. After ordinary same-range heartbeats replace root `RegionInfo` objects, the index may additionally retain one previous start/end key backing pair per Region. Production-scale heartbeat p99 and churn-inclusive memory benchmarks remain useful for quantifying the total benefit and cost.

### Side effects and scope

- Primary lifecycle: every primary RaftCluster builds and maintains one size tree until it stops. Active followers retain only the nil optional pointer and do not run the worker.
- Additional memory: one compact item, one Region-ID map entry, and B-tree storage per Region, plus coalesced pending IDs and at most one retained start/end key backing pair per Region.
- Additional updates: changed Region ranges or approximate sizes enqueue one coalesced ID and cause one asynchronous O(log N) tree reconciliation. Unchanged primary heartbeats perform the optional-index check and size comparison but do not enqueue; followers return after the nil-index check.
- Initial readiness: bounded Preparing threshold and progress evaluation are deferred until the asynchronous initial build completes. The Preparing timeout path is unchanged.
- Consistency: after readiness, range sizes are eventually consistent. Temporary stale-low or stale-high values can advance or delay the approximate Preparing transition until later updates or the existing timeout.
- Query complexity: this PR isolates bounded O(N) scans from root/subtree locks; it does not make arbitrary range aggregation O(log N). Augmented aggregate indexes and reusable multi-statistics support remain follow-up work in #11082.

Related change: this builds on the per-round range cache merged in #11072.

### Release note

```release-note
Reduce Region heartbeat delays during store preparation by moving non-empty range-size scans to an independently maintained Region size tree.
```
