### PR TITLE
server: verify etcd leadership before renewing PD leader lease

### DIFF
--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -213,22 +213,21 @@ func (ls *Leadership) Keep(ctx context.Context) {
 	ls.startKeepAlive(ctx, nil)
 }
 
-// KeepWithLeaseGuard keeps the leadership available while guard confirms that
-// the caller is still allowed to renew it. The guard is checked immediately
-// before every lease keepalive request. It must be safe for concurrent calls
-// and should not block.
-func (ls *Leadership) KeepWithLeaseGuard(ctx context.Context, guard func() bool) {
-	ls.startKeepAlive(ctx, guard)
+// KeepWithLeaseGuard keeps the leadership available while canRenew returns true.
+// Returning false stops this keepalive run before the next lease renewal request.
+// canRenew must be safe for concurrent calls and should not block.
+func (ls *Leadership) KeepWithLeaseGuard(ctx context.Context, canRenew func() bool) {
+	ls.startKeepAlive(ctx, canRenew)
 }
 
-func (ls *Leadership) startKeepAlive(ctx context.Context, guard func() bool) {
+func (ls *Leadership) startKeepAlive(ctx context.Context, canRenew func() bool) {
 	if ls == nil {
 		return
 	}
 	ls.keepAliveCancelFuncLock.Lock()
 	ls.keepAliveCtx, ls.keepAliveCancelFunc = context.WithCancel(ctx)
 	ls.keepAliveCancelFuncLock.Unlock()
-	go ls.GetLease().runKeepAlive(ls.keepAliveCtx, guard)
+	go ls.GetLease().runKeepAlive(ls.keepAliveCtx, canRenew)
 }
 
 // Check returns whether the leadership is still available.

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -210,13 +210,24 @@ func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...cl
 
 // Keep will keep the leadership available by update the lease's expired time continuously
 func (ls *Leadership) Keep(ctx context.Context) {
+	ls.startKeepAlive(ctx, nil)
+}
+
+// KeepWithLeaseGuard keeps the leadership available while guard confirms that
+// the caller is still allowed to renew it. The guard is checked immediately
+// before every lease keepalive request.
+func (ls *Leadership) KeepWithLeaseGuard(ctx context.Context, guard func() bool) {
+	ls.startKeepAlive(ctx, guard)
+}
+
+func (ls *Leadership) startKeepAlive(ctx context.Context, guard func() bool) {
 	if ls == nil {
 		return
 	}
 	ls.keepAliveCancelFuncLock.Lock()
 	ls.keepAliveCtx, ls.keepAliveCancelFunc = context.WithCancel(ctx)
 	ls.keepAliveCancelFuncLock.Unlock()
-	go ls.GetLease().KeepAlive(ls.keepAliveCtx)
+	go ls.GetLease().runKeepAlive(ls.keepAliveCtx, guard)
 }
 
 // Check returns whether the leadership is still available.

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -215,7 +215,8 @@ func (ls *Leadership) Keep(ctx context.Context) {
 
 // KeepWithLeaseGuard keeps the leadership available while guard confirms that
 // the caller is still allowed to renew it. The guard is checked immediately
-// before every lease keepalive request.
+// before every lease keepalive request. It must be safe for concurrent calls
+// and should not block.
 func (ls *Leadership) KeepWithLeaseGuard(ctx context.Context, guard func() bool) {
 	ls.startKeepAlive(ctx, guard)
 }

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -213,21 +213,22 @@ func (ls *Leadership) Keep(ctx context.Context) {
 	ls.startKeepAlive(ctx, nil)
 }
 
-// KeepWithLeaseGuard keeps the leadership available while canRenew returns true.
-// Returning false stops this keepalive run before the next lease renewal request.
-// canRenew must be safe for concurrent calls and should not block.
-func (ls *Leadership) KeepWithLeaseGuard(ctx context.Context, canRenew func() bool) {
-	ls.startKeepAlive(ctx, canRenew)
+// KeepWhile keeps the leadership available while shouldContinueKeepAlive returns true.
+// Returning false permanently stops the current keepalive run, invalidates the
+// local lease, and prevents another lease renewal request. The callback must be
+// safe for concurrent calls and should not block.
+func (ls *Leadership) KeepWhile(ctx context.Context, shouldContinueKeepAlive func() bool) {
+	ls.startKeepAlive(ctx, shouldContinueKeepAlive)
 }
 
-func (ls *Leadership) startKeepAlive(ctx context.Context, canRenew func() bool) {
+func (ls *Leadership) startKeepAlive(ctx context.Context, shouldContinueKeepAlive func() bool) {
 	if ls == nil {
 		return
 	}
 	ls.keepAliveCancelFuncLock.Lock()
 	ls.keepAliveCtx, ls.keepAliveCancelFunc = context.WithCancel(ctx)
 	ls.keepAliveCancelFuncLock.Unlock()
-	go ls.GetLease().runKeepAlive(ls.keepAliveCtx, canRenew)
+	go ls.GetLease().runKeepAlive(ls.keepAliveCtx, shouldContinueKeepAlive)
 }
 
 // Check returns whether the leadership is still available.

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -185,10 +185,13 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var guardRejected atomic.Bool
-	if guard != nil {
-		check := guard
-		guard = func() bool {
-			if check() {
+	var guardedRenewal func() bool
+	if renewalGuard := guard; renewalGuard != nil {
+		guardedRenewal = func() bool {
+			if guardRejected.Load() {
+				return false
+			}
+			if renewalGuard() {
 				return true
 			}
 			if guardRejected.CompareAndSwap(false, true) {
@@ -198,7 +201,7 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 			return false
 		}
 	}
-	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3, guard)
+	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3, guardedRenewal)
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -228,10 +231,10 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 					l.metrics.contextCanceled.Inc()
 					return
 				default:
-					// A guard rejection can race with this response after the
-					// context check above. Make the rejection terminal for the
-					// local lease state even if this response stores last.
-					if !l.storeExpireTime(t, &guardRejected) {
+					// A zero expiration is terminal for this lease grant. Update
+					// with CAS so an in-flight response cannot overwrite a
+					// concurrent guard rejection or reset.
+					if !l.tryStoreExpireTime(t) {
 						return
 					}
 				}
@@ -273,13 +276,16 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 	}
 }
 
-func (l *Lease) storeExpireTime(t time.Time, guardRejected *atomic.Bool) bool {
-	l.expireTime.Store(t)
-	if !guardRejected.Load() {
-		return true
+func (l *Lease) tryStoreExpireTime(t time.Time) bool {
+	for {
+		oldExpireTime := l.loadExpireTime()
+		if oldExpireTime.IsZero() {
+			return false
+		}
+		if l.expireTime.CompareAndSwap(oldExpireTime, t) {
+			return true
+		}
 	}
-	l.expireTime.Store(typeutil.ZeroTime)
-	return false
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -173,6 +173,10 @@ func (l *Lease) loadExpireTime() time.Time {
 
 // KeepAlive auto renews the lease and update expireTime.
 func (l *Lease) KeepAlive(ctx context.Context) {
+	l.runKeepAlive(ctx, nil)
+}
+
+func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 	defer logutil.LogPanic()
 
 	if l == nil {
@@ -180,7 +184,21 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3)
+	var guardRejected atomic.Bool
+	if guard != nil {
+		check := guard
+		guard = func() bool {
+			if check() {
+				return true
+			}
+			if guardRejected.CompareAndSwap(false, true) {
+				l.expireTime.Store(typeutil.ZeroTime)
+				cancel()
+			}
+			return false
+		}
+	}
+	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3, guard)
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -235,6 +253,12 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 				zap.String("purpose", l.purpose))
 			return
 		case <-ctx.Done():
+			if guardRejected.Load() {
+				log.Info("lease keep alive stopped because its guard rejected the renewal",
+					zap.String("purpose", l.purpose),
+					zap.Int64("lease-id", int64(l.GetID())))
+				return
+			}
 			log.Info("lease keep alive canceled by caller",
 				zap.String("purpose", l.purpose),
 				zap.Error(ctx.Err()))
@@ -245,7 +269,7 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.
-func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-chan time.Time {
+func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration, guard func() bool) <-chan time.Time {
 	ch := make(chan time.Time)
 
 	go func() {
@@ -271,6 +295,9 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 			go func() {
 				defer logutil.LogPanic()
 
+				if guard != nil && !guard() {
+					return
+				}
 				ctx1, cancel := context.WithTimeout(ctx, l.leaseTimeout)
 				defer cancel()
 				// Record the start time of the `KeepAliveOnce` request to track the request duration

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -22,6 +22,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/errs"
@@ -282,6 +283,7 @@ func (l *Lease) tryStoreExpireTime(t time.Time) bool {
 		if oldExpireTime.IsZero() {
 			return false
 		}
+		failpoint.InjectCall("beforeCompareAndSwapExpireTime")
 		if l.expireTime.CompareAndSwap(oldExpireTime, t) {
 			return true
 		}

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -185,8 +185,10 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	var guardRejected atomic.Bool
-	var guardedRenewal func() bool
+	var (
+		guardRejected  atomic.Bool
+		guardedRenewal func() bool
+	)
 	if renewalGuard := guard; renewalGuard != nil {
 		guardedRenewal = func() bool {
 			if guardRejected.Load() {

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -228,7 +228,12 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 					l.metrics.contextCanceled.Inc()
 					return
 				default:
-					l.expireTime.Store(t)
+					// A guard rejection can race with this response after the
+					// context check above. Make the rejection terminal for the
+					// local lease state even if this response stores last.
+					if !l.storeExpireTime(t, &guardRejected) {
+						return
+					}
 				}
 			}
 			timer.Reset(l.leaseTimeout)
@@ -266,6 +271,15 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 			return
 		}
 	}
+}
+
+func (l *Lease) storeExpireTime(t time.Time, guardRejected *atomic.Bool) bool {
+	l.expireTime.Store(t)
+	if !guardRejected.Load() {
+		return true
+	}
+	l.expireTime.Store(typeutil.ZeroTime)
+	return false
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -177,7 +177,7 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	l.runKeepAlive(ctx, nil)
 }
 
-func (l *Lease) runKeepAlive(ctx context.Context, canRenew func() bool) {
+func (l *Lease) runKeepAlive(ctx context.Context, shouldContinueKeepAlive func() bool) {
 	defer logutil.LogPanic()
 
 	if l == nil {
@@ -186,25 +186,25 @@ func (l *Lease) runKeepAlive(ctx context.Context, canRenew func() bool) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var (
-		guardRejected       atomic.Bool
-		checkRenewalAllowed func() bool
+		renewalStopped   atomic.Bool
+		shouldRenewLease func() bool
 	)
-	if canRenew != nil {
-		checkRenewalAllowed = func() bool {
-			if guardRejected.Load() {
+	if shouldContinueKeepAlive != nil {
+		shouldRenewLease = func() bool {
+			if renewalStopped.Load() {
 				return false
 			}
-			if canRenew() {
+			if shouldContinueKeepAlive() {
 				return true
 			}
-			if guardRejected.CompareAndSwap(false, true) {
+			if renewalStopped.CompareAndSwap(false, true) {
 				l.expireTime.Store(typeutil.ZeroTime)
 				cancel()
 			}
 			return false
 		}
 	}
-	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3, checkRenewalAllowed)
+	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3, shouldRenewLease)
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -236,7 +236,7 @@ func (l *Lease) runKeepAlive(ctx context.Context, canRenew func() bool) {
 				default:
 					// A zero expiration is terminal for this lease grant. Update
 					// with CAS so an in-flight response cannot overwrite a
-					// concurrent guard rejection or reset.
+					// concurrent keepalive stop or reset.
 					if !l.tryStoreExpireTime(t) {
 						return
 					}
@@ -264,8 +264,8 @@ func (l *Lease) runKeepAlive(ctx context.Context, canRenew func() bool) {
 				zap.String("purpose", l.purpose))
 			return
 		case <-ctx.Done():
-			if guardRejected.Load() {
-				log.Info("lease keep alive stopped because its guard rejected the renewal",
+			if renewalStopped.Load() {
+				log.Info("lease keep alive stopped because renewal is no longer allowed",
 					zap.String("purpose", l.purpose),
 					zap.Int64("lease-id", int64(l.GetID())))
 				return
@@ -293,7 +293,7 @@ func (l *Lease) tryStoreExpireTime(t time.Time) bool {
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.
-func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration, canRenew func() bool) <-chan time.Time {
+func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration, shouldRenewLease func() bool) <-chan time.Time {
 	ch := make(chan time.Time)
 
 	go func() {
@@ -319,7 +319,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration, can
 			go func() {
 				defer logutil.LogPanic()
 
-				if canRenew != nil && !canRenew() {
+				if shouldRenewLease != nil && !shouldRenewLease() {
 					return
 				}
 				ctx1, cancel := context.WithTimeout(ctx, l.leaseTimeout)

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -177,7 +177,7 @@ func (l *Lease) KeepAlive(ctx context.Context) {
 	l.runKeepAlive(ctx, nil)
 }
 
-func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
+func (l *Lease) runKeepAlive(ctx context.Context, canRenew func() bool) {
 	defer logutil.LogPanic()
 
 	if l == nil {
@@ -186,15 +186,15 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var (
-		guardRejected  atomic.Bool
-		guardedRenewal func() bool
+		guardRejected       atomic.Bool
+		checkRenewalAllowed func() bool
 	)
-	if renewalGuard := guard; renewalGuard != nil {
-		guardedRenewal = func() bool {
+	if canRenew != nil {
+		checkRenewalAllowed = func() bool {
 			if guardRejected.Load() {
 				return false
 			}
-			if renewalGuard() {
+			if canRenew() {
 				return true
 			}
 			if guardRejected.CompareAndSwap(false, true) {
@@ -204,7 +204,7 @@ func (l *Lease) runKeepAlive(ctx context.Context, guard func() bool) {
 			return false
 		}
 	}
-	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3, guardedRenewal)
+	timeCh := l.keepAliveWorker(ctx, l.leaseTimeout/3, checkRenewalAllowed)
 	defer log.Info("lease keep alive stopped", zap.String("purpose", l.purpose))
 
 	var (
@@ -293,7 +293,7 @@ func (l *Lease) tryStoreExpireTime(t time.Time) bool {
 }
 
 // Periodically call `lease.KeepAliveOnce` and post back latest received expire time into the channel.
-func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration, guard func() bool) <-chan time.Time {
+func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration, canRenew func() bool) <-chan time.Time {
 	ch := make(chan time.Time)
 
 	go func() {
@@ -319,7 +319,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration, gua
 			go func() {
 				defer logutil.LogPanic()
 
-				if guard != nil && !guard() {
+				if canRenew != nil && !canRenew() {
 					return
 				}
 				ctx1, cancel := context.WithTimeout(ctx, l.leaseTimeout)

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
@@ -123,19 +124,55 @@ func TestLeaseKeepAliveGuard(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
-	defer clean()
 
-	lease := NewLease(client, "test_lease_guard")
-	re.NoError(lease.Grant(defaultLeaseTimeout))
+	clientLease := &keepAliveOnceCountingLease{}
+	lease := &Lease{
+		purpose:      "test_lease_guard",
+		lease:        clientLease,
+		leaseTimeout: time.Second,
+	}
+	lease.setID(1)
+	lease.expireTime.Store(time.Now().Add(time.Second))
 	re.False(lease.IsExpired())
 
 	var guardCalls atomic.Int32
-	go lease.runKeepAlive(ctx, func() bool {
-		guardCalls.Add(1)
-		return false
-	})
-	re.Eventually(lease.IsExpired, time.Second, 10*time.Millisecond)
-	re.Equal(int32(1), guardCalls.Load())
-	re.NoError(lease.Close())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lease.runKeepAlive(ctx, func() bool {
+			guardCalls.Add(1)
+			return false
+		})
+	}()
+	re.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	re.True(lease.IsExpired())
+	re.Positive(guardCalls.Load())
+	re.Zero(clientLease.calls.Load())
+}
+
+func TestStoreExpireTimeAfterGuardRejected(t *testing.T) {
+	lease := &Lease{}
+	lease.expireTime.Store(typeutil.ZeroTime)
+	var guardRejected atomic.Bool
+	guardRejected.Store(true)
+
+	require.False(t, lease.storeExpireTime(time.Now().Add(time.Minute), &guardRejected))
+	require.True(t, lease.IsExpired())
+}
+
+type keepAliveOnceCountingLease struct {
+	clientv3.Lease
+	calls atomic.Int32
+}
+
+func (l *keepAliveOnceCountingLease) KeepAliveOnce(context.Context, clientv3.LeaseID) (*clientv3.LeaseKeepAliveResponse, error) {
+	l.calls.Add(1)
+	return &clientv3.LeaseKeepAliveResponse{TTL: 1}, nil
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -122,14 +122,14 @@ func TestLeaseKeepAlive(t *testing.T) {
 	re.NoError(lease.Close())
 }
 
-func TestLeaseKeepAliveGuard(t *testing.T) {
+func TestLeaseKeepAliveStopsWhenConditionReturnsFalse(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	clientLease := &keepAliveOnceCountingLease{}
 	lease := &Lease{
-		purpose:      "test_lease_guard",
+		purpose:      "test_lease_keepalive_condition",
 		lease:        clientLease,
 		leaseTimeout: time.Second,
 	}
@@ -137,12 +137,12 @@ func TestLeaseKeepAliveGuard(t *testing.T) {
 	lease.expireTime.Store(time.Now().Add(time.Second))
 	re.False(lease.IsExpired())
 
-	var guardCalls atomic.Int32
+	var conditionChecks atomic.Int32
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		lease.runKeepAlive(ctx, func() bool {
-			guardCalls.Add(1)
+			conditionChecks.Add(1)
 			return false
 		})
 	}()
@@ -155,27 +155,27 @@ func TestLeaseKeepAliveGuard(t *testing.T) {
 		}
 	}, time.Second, 10*time.Millisecond)
 	re.True(lease.IsExpired())
-	re.Positive(guardCalls.Load())
+	re.Positive(conditionChecks.Load())
 	re.Zero(clientLease.calls.Load())
 }
 
-func TestLeaseKeepAliveGuardStopsAfterRenewal(t *testing.T) {
+func TestLeaseKeepAliveConditionStopsAfterRenewal(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	clientLease := &keepAliveOnceCountingLease{}
 	lease := &Lease{
-		purpose:      "test_lease_guard_transition",
+		purpose:      "test_lease_keepalive_transition",
 		lease:        clientLease,
 		leaseTimeout: 900 * time.Millisecond,
-		metrics:      newLeaseMetrics("test_lease_guard_transition"),
+		metrics:      newLeaseMetrics("test_lease_keepalive_transition"),
 	}
 	lease.setID(1)
 	initialExpireTime := time.Now().Add(100 * time.Millisecond)
 	lease.expireTime.Store(initialExpireTime)
 
-	var guardCalls atomic.Int32
+	var conditionChecks atomic.Int32
 	rejectRenewal := make(chan struct{})
 	var rejectOnce sync.Once
 	reject := func() {
@@ -189,7 +189,7 @@ func TestLeaseKeepAliveGuardStopsAfterRenewal(t *testing.T) {
 	go func() {
 		defer close(done)
 		lease.runKeepAlive(ctx, func() bool {
-			if guardCalls.Add(1) == 1 {
+			if conditionChecks.Add(1) == 1 {
 				return true
 			}
 			<-rejectRenewal
@@ -197,7 +197,7 @@ func TestLeaseKeepAliveGuardStopsAfterRenewal(t *testing.T) {
 		})
 	}()
 
-	// Confirm that the lease was renewed before changing the guard result.
+	// Confirm that the lease was renewed before changing the condition result.
 	re.Eventually(func() bool {
 		return clientLease.calls.Load() == 1 && lease.loadExpireTime().After(initialExpireTime)
 	}, time.Second, 10*time.Millisecond)
@@ -213,7 +213,7 @@ func TestLeaseKeepAliveGuardStopsAfterRenewal(t *testing.T) {
 
 	re.True(lease.IsExpired())
 	re.True(lease.loadExpireTime().IsZero())
-	re.GreaterOrEqual(guardCalls.Load(), int32(2))
+	re.GreaterOrEqual(conditionChecks.Load(), int32(2))
 	re.Equal(int32(1), clientLease.calls.Load())
 }
 

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -211,6 +211,7 @@ func TestLeaseKeepAliveGuardStopsAfterRenewal(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	re.True(lease.IsExpired())
+	re.True(lease.loadExpireTime().IsZero())
 	re.GreaterOrEqual(guardCalls.Load(), int32(2))
 	re.Equal(int32(1), clientLease.calls.Load())
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -118,7 +118,6 @@ func TestLeaseKeepAlive(t *testing.T) {
 
 	re.NoError(lease.Grant(defaultLeaseTimeout))
 	ch := lease.keepAliveWorker(ctx, 2*time.Second, nil)
-	time.Sleep(2 * time.Second)
 	<-ch
 	re.NoError(lease.Close())
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -158,6 +158,63 @@ func TestLeaseKeepAliveGuard(t *testing.T) {
 	re.Zero(clientLease.calls.Load())
 }
 
+func TestLeaseKeepAliveGuardStopsAfterRenewal(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientLease := &keepAliveOnceCountingLease{}
+	lease := &Lease{
+		purpose:      "test_lease_guard_transition",
+		lease:        clientLease,
+		leaseTimeout: 900 * time.Millisecond,
+		metrics:      newLeaseMetrics("test_lease_guard_transition"),
+	}
+	lease.setID(1)
+	initialExpireTime := time.Now().Add(100 * time.Millisecond)
+	lease.expireTime.Store(initialExpireTime)
+
+	var guardCalls atomic.Int32
+	rejectRenewal := make(chan struct{})
+	var rejectOnce sync.Once
+	reject := func() {
+		rejectOnce.Do(func() {
+			close(rejectRenewal)
+		})
+	}
+	defer reject()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lease.runKeepAlive(ctx, func() bool {
+			if guardCalls.Add(1) == 1 {
+				return true
+			}
+			<-rejectRenewal
+			return false
+		})
+	}()
+
+	// Confirm that the lease was renewed before changing the guard result.
+	re.Eventually(func() bool {
+		return clientLease.calls.Load() == 1 && lease.loadExpireTime().After(initialExpireTime)
+	}, time.Second, 10*time.Millisecond)
+	reject()
+	re.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	re.True(lease.IsExpired())
+	re.GreaterOrEqual(guardCalls.Load(), int32(2))
+	re.Equal(int32(1), clientLease.calls.Load())
+}
+
 func TestTryStoreExpireTimeDoesNotReviveResetLease(t *testing.T) {
 	const attempts = 1000
 	re := require.New(t)

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -16,6 +16,7 @@ package election
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -112,8 +113,29 @@ func TestLeaseKeepAlive(t *testing.T) {
 	lease := NewLease(client, "test_lease")
 
 	re.NoError(lease.Grant(defaultLeaseTimeout))
-	ch := lease.keepAliveWorker(ctx, 2*time.Second)
+	ch := lease.keepAliveWorker(ctx, 2*time.Second, nil)
 	time.Sleep(2 * time.Second)
 	<-ch
+	re.NoError(lease.Close())
+}
+
+func TestLeaseKeepAliveGuard(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	lease := NewLease(client, "test_lease_guard")
+	re.NoError(lease.Grant(defaultLeaseTimeout))
+	re.False(lease.IsExpired())
+
+	var guardCalls atomic.Int32
+	go lease.runKeepAlive(ctx, func() bool {
+		guardCalls.Add(1)
+		return false
+	})
+	re.Eventually(lease.IsExpired, time.Second, 10*time.Millisecond)
+	re.Equal(int32(1), guardCalls.Load())
 	re.NoError(lease.Close())
 }

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -16,6 +16,7 @@ package election
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -157,14 +158,29 @@ func TestLeaseKeepAliveGuard(t *testing.T) {
 	re.Zero(clientLease.calls.Load())
 }
 
-func TestStoreExpireTimeAfterGuardRejected(t *testing.T) {
+func TestTryStoreExpireTimeDoesNotReviveResetLease(t *testing.T) {
+	const attempts = 1000
+	re := require.New(t)
 	lease := &Lease{}
-	lease.expireTime.Store(typeutil.ZeroTime)
-	var guardRejected atomic.Bool
-	guardRejected.Store(true)
-
-	require.False(t, lease.storeExpireTime(time.Now().Add(time.Minute), &guardRejected))
-	require.True(t, lease.IsExpired())
+	for range attempts {
+		lease.expireTime.Store(time.Now().Add(time.Minute))
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			lease.expireTime.Store(typeutil.ZeroTime)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			lease.tryStoreExpireTime(time.Now().Add(time.Minute))
+		}()
+		close(start)
+		wg.Wait()
+		re.True(lease.IsExpired())
+	}
 }
 
 type keepAliveOnceCountingLease struct {

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"github.com/pingcap/failpoint"
+
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 )
@@ -216,29 +218,71 @@ func TestLeaseKeepAliveGuardStopsAfterRenewal(t *testing.T) {
 	re.Equal(int32(1), clientLease.calls.Load())
 }
 
-func TestTryStoreExpireTimeDoesNotReviveResetLease(t *testing.T) {
-	const attempts = 1000
+func TestKeepAliveResponseDoesNotReviveResetLease(t *testing.T) {
 	re := require.New(t)
-	lease := &Lease{}
-	for range attempts {
-		lease.expireTime.Store(time.Now().Add(time.Minute))
-		start := make(chan struct{})
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			<-start
-			lease.expireTime.Store(typeutil.ZeroTime)
-		}()
-		go func() {
-			defer wg.Done()
-			<-start
-			lease.tryStoreExpireTime(time.Now().Add(time.Minute))
-		}()
-		close(start)
-		wg.Wait()
-		re.True(lease.IsExpired())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientLease := &keepAliveOnceCountingLease{}
+	lease := &Lease{
+		purpose:      "test_keepalive_response_after_reset",
+		lease:        clientLease,
+		leaseTimeout: 30 * time.Second,
+		metrics:      newLeaseMetrics("test_keepalive_response_after_reset"),
 	}
+	lease.setID(1)
+	lease.expireTime.Store(time.Now().Add(time.Minute))
+
+	loadedOldExpireTime := make(chan struct{})
+	resumeStore := make(chan struct{})
+	var injectOnce sync.Once
+	var resumeOnce sync.Once
+	resume := func() {
+		resumeOnce.Do(func() {
+			close(resumeStore)
+		})
+	}
+	defer resume()
+
+	failpointName := "github.com/tikv/pd/pkg/election/beforeCompareAndSwapExpireTime"
+	re.NoError(failpoint.EnableCall(failpointName, func() {
+		injectOnce.Do(func() {
+			close(loadedOldExpireTime)
+			<-resumeStore
+		})
+	}))
+	defer func() {
+		re.NoError(failpoint.Disable(failpointName))
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		lease.runKeepAlive(ctx, nil)
+	}()
+
+	re.Eventually(func() bool {
+		select {
+		case <-loadedOldExpireTime:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	lease.expireTime.Store(typeutil.ZeroTime)
+	resume()
+	re.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	re.True(lease.IsExpired())
+	re.True(lease.loadExpireTime().IsZero())
+	re.Equal(int32(1), clientLease.calls.Load())
 }
 
 type keepAliveOnceCountingLease struct {

--- a/pkg/utils/apiutil/serverapi/middleware.go
+++ b/pkg/utils/apiutil/serverapi/middleware.go
@@ -245,15 +245,14 @@ func (h *redirector) ServeHTTP(w http.ResponseWriter, r *http.Request, next http
 		// Add a header to the response, it is used to mark whether the request has been forwarded to the microservice.
 		w.Header().Add(apiutil.XForwardedToMicroserviceHeader, "true")
 	} else if name := r.Header.Get(apiutil.PDRedirectorHeader); len(name) == 0 {
-		leader := h.waitForLeader(r)
+		leader, serveLocally := h.waitForLeader(r)
+		if serveLocally {
+			next(w, r)
+			return
+		}
 		// The leader has not been elected yet.
 		if leader == nil {
 			http.Error(w, errs.ErrRedirectNoLeader.FastGenByArgs().Error(), http.StatusServiceUnavailable)
-			return
-		}
-		// If the leader is the current server now, we can handle the request directly.
-		if h.s.GetMember().IsServing() || leader.GetName() == h.s.Name() {
-			next(w, r)
 			return
 		}
 		clientUrls = leader.GetClientUrls()
@@ -284,32 +283,40 @@ const (
 	backoffInterval = 100 * time.Millisecond
 )
 
-// If current server does not have a leader, backoff to increase the chance of success.
-func (h *redirector) waitForLeader(r *http.Request) (leader *pdpb.Member) {
+// If the current server is not serving and does not know another leader, backoff to increase the chance of success.
+func (h *redirector) waitForLeader(r *http.Request) (*pdpb.Member, bool) {
 	var (
 		interval = backoffInterval
 		maxDelay = backoffMaxDelay
 		curDelay = time.Duration(0)
 	)
 	for {
-		leader = h.s.GetMember().GetLeader()
-		if leader != nil {
-			return
+		if h.s.GetMember().IsServing() {
+			return nil, true
+		}
+		leader := h.s.GetMember().GetLeader()
+		if leader != nil && leader.GetMemberId() != h.s.GetMember().ID() {
+			// The local server may have become the leader after the cached leader
+			// was loaded. Prefer serving locally when that transition completes.
+			if h.s.GetMember().IsServing() {
+				return nil, true
+			}
+			return leader, false
 		}
 		select {
 		case <-time.After(interval):
 			curDelay += interval
 			if curDelay >= maxDelay {
-				return
+				return nil, false
 			}
 			interval *= 2
 			if curDelay+interval > maxDelay {
 				interval = maxDelay - curDelay
 			}
 		case <-r.Context().Done():
-			return
+			return nil, false
 		case <-h.s.Context().Done():
-			return
+			return nil, false
 		}
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1981,7 +1981,6 @@ func (s *Server) campaignLeader() {
 	//   2. load region could be slow. Based on lease we can recover TSO service faster.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
 	var resetLeaderOnce sync.Once
-	var leaseGuardRejectedOnce sync.Once
 	defer resetLeaderOnce.Do(func() {
 		cancel()
 		s.member.Resign()
@@ -1991,16 +1990,7 @@ func (s *Server) campaignLeader() {
 	log.Info("start to keep leader lease")
 	keepLeaderStart := time.Now()
 	s.member.GetLeadership().KeepWithLeaseGuard(ctx, func() bool {
-		etcdLeader := s.member.GetEtcdLeader()
-		if etcdLeader == s.member.ID() {
-			return true
-		}
-		leaseGuardRejectedOnce.Do(func() {
-			log.Info("stop keeping PD leader lease because embedded etcd leadership changed",
-				zap.Uint64("member-id", s.member.ID()),
-				zap.Uint64("etcd-leader-id", etcdLeader))
-		})
-		return false
+		return s.member.GetEtcdLeader() == s.member.ID()
 	})
 	keepLeaderDuration := time.Since(keepLeaderStart)
 	log.Info("keep leader lease completed", zap.Duration("cost", keepLeaderDuration), zap.String("campaign-leader-name", s.Name()))

--- a/server/server.go
+++ b/server/server.go
@@ -1989,7 +1989,7 @@ func (s *Server) campaignLeader() {
 	// maintain the PD leadership, after this, TSO can be service.
 	log.Info("start to keep leader lease")
 	keepLeaderStart := time.Now()
-	s.member.GetLeadership().KeepWithLeaseGuard(ctx, func() bool {
+	s.member.GetLeadership().KeepWhile(ctx, func() bool {
 		return s.member.GetEtcdLeader() == s.member.ID()
 	})
 	keepLeaderDuration := time.Since(keepLeaderStart)

--- a/server/server.go
+++ b/server/server.go
@@ -1981,6 +1981,7 @@ func (s *Server) campaignLeader() {
 	//   2. load region could be slow. Based on lease we can recover TSO service faster.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
 	var resetLeaderOnce sync.Once
+	var leaseGuardRejectedOnce sync.Once
 	defer resetLeaderOnce.Do(func() {
 		cancel()
 		s.member.Resign()
@@ -1989,7 +1990,18 @@ func (s *Server) campaignLeader() {
 	// maintain the PD leadership, after this, TSO can be service.
 	log.Info("start to keep leader lease")
 	keepLeaderStart := time.Now()
-	s.member.GetLeadership().Keep(ctx)
+	s.member.GetLeadership().KeepWithLeaseGuard(ctx, func() bool {
+		etcdLeader := s.member.GetEtcdLeader()
+		if etcdLeader == s.member.ID() {
+			return true
+		}
+		leaseGuardRejectedOnce.Do(func() {
+			log.Info("stop keeping PD leader lease because embedded etcd leadership changed",
+				zap.Uint64("member-id", s.member.ID()),
+				zap.Uint64("etcd-leader-id", etcdLeader))
+		})
+		return false
+	})
 	keepLeaderDuration := time.Since(keepLeaderStart)
 	log.Info("keep leader lease completed", zap.Duration("cost", keepLeaderDuration), zap.String("campaign-leader-name", s.Name()))
 
@@ -2087,6 +2099,11 @@ func (s *Server) campaignLeader() {
 			})
 
 			etcdLeader := s.member.GetEtcdLeader()
+			failpoint.Inject("skipCampaignLeaderEtcdLeaderCheck", func(val failpoint.Value) {
+				if memberFailpointEnabled(val, s.member.ID()) {
+					etcdLeader = s.member.ID()
+				}
+			})
 			if etcdLeader != s.member.ID() {
 				log.Info("etcd leader changed, resigns pd leadership", zap.String("old-pd-leader-name", s.Name()))
 				return

--- a/server/server.go
+++ b/server/server.go
@@ -2076,7 +2076,13 @@ func (s *Server) campaignLeader() {
 	for {
 		select {
 		case <-leaderTicker.C:
-			if !s.member.IsServing() {
+			isServing := s.member.IsServing()
+			failpoint.Inject("skipCampaignLeaderServingCheck", func(val failpoint.Value) {
+				if memberFailpointEnabled(val, s.member.ID()) {
+					isServing = true
+				}
+			})
+			if !isServing {
 				log.Info("no longer a leader because lease has expired, PD leader will step down")
 				return
 			}

--- a/tests/server/api/api_test.go
+++ b/tests/server/api/api_test.go
@@ -714,6 +714,66 @@ func (suite *redirectorTestSuite) TestRedirect() {
 	}
 }
 
+func TestRedirectorRejectsStaleSelfWhenCampaignDoesNotExit(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 2, func(conf *config.Config, _ string) {
+		conf.TickInterval = typeutil.Duration{Duration: 50 * time.Millisecond}
+		conf.ElectionInterval = typeutil.Duration{Duration: 250 * time.Millisecond}
+	})
+	re.NoError(err)
+	defer cluster.Destroy()
+
+	re.NoError(cluster.RunInitialServers())
+	oldLeaderName := cluster.WaitLeader()
+	re.NotEmpty(oldLeaderName)
+	oldLeader := cluster.GetServer(oldLeaderName)
+	re.NotNil(oldLeader)
+
+	var newLeader *tests.TestServer
+	for name, svr := range cluster.GetServers() {
+		if name != oldLeaderName {
+			newLeader = svr
+			break
+		}
+	}
+	re.NotNil(newLeader)
+
+	memberID := oldLeader.GetServerID()
+	servingCheckFailpoint := "github.com/tikv/pd/server/skipCampaignLeaderServingCheck"
+	etcdLeaderCheckFailpoint := "github.com/tikv/pd/server/skipCampaignLeaderEtcdLeaderCheck"
+	re.NoError(failpoint.Enable(servingCheckFailpoint, fmt.Sprintf("return(\"%d\")", memberID)))
+	defer func() {
+		re.NoError(failpoint.Disable(servingCheckFailpoint))
+	}()
+	re.NoError(failpoint.Enable(etcdLeaderCheckFailpoint, fmt.Sprintf("return(\"%d\")", memberID)))
+	defer func() {
+		re.NoError(failpoint.Disable(etcdLeaderCheckFailpoint))
+	}()
+
+	testutil.Eventually(re, func() bool {
+		return oldLeader.MoveEtcdLeader(oldLeader.GetServerID(), newLeader.GetServerID()) == nil
+	})
+	testutil.Eventually(re, func() bool {
+		leaderID, err := oldLeader.GetEtcdLeaderID()
+		return err == nil && leaderID == newLeader.GetServerID()
+	})
+	testutil.Eventually(re, newLeader.IsLeader)
+	re.False(oldLeader.IsLeader())
+	re.Equal(oldLeaderName, oldLeader.GetLeader().GetName())
+
+	resp, err := tests.TestDialClient.Get(oldLeader.GetAddr() + "/pd/api/v1/leader")
+	re.NoError(err)
+	defer resp.Body.Close()
+	re.Equal(http.StatusServiceUnavailable, resp.StatusCode)
+
+	resp, err = tests.TestDialClient.Get(newLeader.GetAddr() + "/pd/api/v1/leader")
+	re.NoError(err)
+	defer resp.Body.Close()
+	re.Equal(http.StatusOK, resp.StatusCode)
+}
+
 func (suite *redirectorTestSuite) TestAllowFollowerHandle() {
 	re := suite.Require()
 	follower := suite.cluster.GetServer(suite.cluster.GetFollower())

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -303,7 +303,9 @@ func TestPDLeaderLeaseStopsWhenEtcdLeaderChanges(t *testing.T) {
 		re.NoError(failpoint.Disable(failpointName))
 	}()
 
-	re.NoError(oldLeader.MoveEtcdLeader(oldLeader.GetServerID(), newEtcdLeader.GetServerID()))
+	testutil.Eventually(re, func() bool {
+		return oldLeader.MoveEtcdLeader(oldLeader.GetServerID(), newEtcdLeader.GetServerID()) == nil
+	})
 	testutil.Eventually(re, func() bool {
 		leaderID, err := oldLeader.GetEtcdLeaderID()
 		return err == nil && leaderID == newEtcdLeader.GetServerID()

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -311,6 +311,8 @@ func TestPDLeaderLeaseStopsWhenEtcdLeaderChanges(t *testing.T) {
 
 	newLeaderName := waitLeaderChange(re, cluster, oldLeaderName)
 	re.NotEqual(oldLeaderName, newLeaderName)
+	re.False(oldLeader.IsLeader())
+	re.Equal(newLeaderName, cluster.WaitLeader())
 }
 
 func waitLeaderChange(re *require.Assertions, cluster *tests.TestCluster, old string) string {

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -272,6 +272,47 @@ func TestPDLeaderLostWhileEtcdLeaderIntact(t *testing.T) {
 	re.NoError(failpoint.Disable("github.com/tikv/pd/server/timeoutWaitPDLeader"))
 }
 
+func TestPDLeaderLeaseStopsWhenEtcdLeaderChanges(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 2)
+	defer cluster.Destroy()
+	re.NoError(err)
+
+	re.NoError(cluster.RunInitialServers())
+	oldLeaderName := cluster.WaitLeader()
+	re.NotEmpty(oldLeaderName)
+	oldLeader := cluster.GetServer(oldLeaderName)
+	re.NotNil(oldLeader)
+
+	var newEtcdLeader *tests.TestServer
+	for _, cfg := range cluster.GetConfig().InitialServers {
+		if cfg.Name != oldLeaderName {
+			newEtcdLeader = cluster.GetServer(cfg.Name)
+			break
+		}
+	}
+	re.NotNil(newEtcdLeader)
+
+	// Mask only campaignLeader's periodic etcd-leader check. The lease keepalive
+	// must independently stop after the embedded-etcd leadership moves away.
+	failpointName := "github.com/tikv/pd/server/skipCampaignLeaderEtcdLeaderCheck"
+	re.NoError(failpoint.Enable(failpointName, fmt.Sprintf("return(\"%d\")", oldLeader.GetServerID())))
+	defer func() {
+		re.NoError(failpoint.Disable(failpointName))
+	}()
+
+	re.NoError(oldLeader.MoveEtcdLeader(oldLeader.GetServerID(), newEtcdLeader.GetServerID()))
+	testutil.Eventually(re, func() bool {
+		leaderID, err := oldLeader.GetEtcdLeaderID()
+		return err == nil && leaderID == newEtcdLeader.GetServerID()
+	})
+
+	newLeaderName := waitLeaderChange(re, cluster, oldLeaderName)
+	re.NotEqual(oldLeaderName, newLeaderName)
+}
+
 func waitLeaderChange(re *require.Assertions, cluster *tests.TestCluster, old string) string {
 	var leader string
 	testutil.Eventually(re, func() bool {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11101, ref #10671

PD logical leadership is represented by a lease-backed etcd key. In the current design, a PD member should renew this lease only while its local embedded-etcd leader view identifies the same member as leader.

This condition is checked periodically by `campaignLeader`, but the lease renewal path does not enforce it. If the outer check does not make progress after the local leader view has changed, the old lease can continue to be renewed and prevent the current embedded-etcd leader from campaigning for PD leadership.

This PR covers only the case where the old member's local embedded-etcd leader view has already changed. It does not diagnose why the outer control path stopped progressing or cover a persistently stale local leader view.

### What is changed and how does it work?

```commit-message
Add an optional guard to the election lease renewal path and evaluate it immediately before each KeepAliveOnce request.

Use the guard for the PD leader lease to verify that the local embedded-etcd leader ID matches the current PD member ID.

When the guard rejects a renewal, invalidate the local lease expiration state and cancel the keepalive context. Keep the existing unguarded behavior for other election lease users.

Add unit and integration tests that isolate the renewal guard and verify PD leader transfer after embedded-etcd leadership changes.
```

### Check List

Tests

- Unit test
  - `make gotest GOTEST_ARGS='./pkg/election -count=1'`
  - `go test ./pkg/election -run 'TestLeaseKeepAliveGuard|TestStoreExpireTimeAfterGuardRejected' -count=100`
- Integration test
  - `make gotest GOTEST_ARGS='-race -tags without_dashboard ./tests/server/member -run TestPDLeaderLeaseStopsWhenEtcdLeaderChanges -count=1'`

Side effects

- Possible performance regression: adds one local atomic leader-ID read before each PD leader lease renewal; it adds no etcd KV or network request.

### Release note

```release-note
Stop renewing the PD leader lease when the local embedded-etcd leader view shows that the member no longer owns embedded-etcd leadership.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guarded leadership keepalive support, allowing lease renewal only while a condition remains valid.
  - Leadership leases now stop renewing when the server loses embedded etcd leadership.

- **Bug Fixes**
  - Prevented rejected or outdated renewals from restoring expired leadership leases.
  - Improved handling of concurrent lease expiration updates to prevent stale leadership state.

- **Tests**
  - Added coverage for guarded keepalive behavior and leadership changes after etcd leader transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->