### PR TITLE
client: recognize v2 keyspace-level GC

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -128,3 +128,32 @@ func TestIsKeyspaceUsingKeyspaceLevelGC(t *testing.T) {
 	}
 	re.False(IsKeyspaceUsingKeyspaceLevelGC(meta))
 }
+
+func TestIsCESKeyspaceLevelGC(t *testing.T) {
+	tests := []struct {
+		name string
+		meta *keyspacepb.KeyspaceMeta
+		want bool
+	}{
+		{name: "nil metadata", meta: nil, want: false},
+		{name: "nil config", meta: &keyspacepb.KeyspaceMeta{}, want: false},
+		{name: "missing safe point version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{}}, want: false},
+		{name: "safe point version v2", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "v2"}}, want: true},
+		{name: "uppercase safe point version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "V2"}}, want: false},
+		{name: "padded safe point version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": " v2 "}}, want: false},
+		{name: "native keyspace level GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "keyspace_level"}}, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given
+			meta := test.meta
+
+			// When
+			got := IsCESKeyspaceLevelGC(meta)
+
+			// Then
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -115,6 +115,7 @@ func TestIsKeyspaceUsingKeyspaceLevelGC(t *testing.T) {
 		{name: "empty config", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{}}, want: false},
 		{name: "native keyspace level GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "keyspace_level"}}, want: true},
 		{name: "unified GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "unified"}}, want: false},
+		{name: "unified GC overrides safe point version v2", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "unified", "safe_point_version": "v2"}}, want: false},
 		{name: "invalid GC management type", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "111111"}}, want: false},
 		{name: "safe point version v2", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "v2"}}, want: true},
 		{name: "uppercase safe point version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "V2"}}, want: false},

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -105,31 +105,6 @@ func TestSaturatingStdDurationFromSeconds(t *testing.T) {
 }
 
 func TestIsKeyspaceUsingKeyspaceLevelGC(t *testing.T) {
-	re := require.New(t)
-
-	// Default to false when the meta or the config map is nil.
-	re.False(IsKeyspaceUsingKeyspaceLevelGC(nil))
-	meta := &keyspacepb.KeyspaceMeta{}
-	re.False(IsKeyspaceUsingKeyspaceLevelGC(meta))
-
-	meta = &keyspacepb.KeyspaceMeta{
-		Config: map[string]string{"gc_management_type": "keyspace_level"},
-	}
-	re.True(IsKeyspaceUsingKeyspaceLevelGC(meta))
-
-	meta = &keyspacepb.KeyspaceMeta{
-		Config: map[string]string{"gc_management_type": "unified"},
-	}
-	re.False(IsKeyspaceUsingKeyspaceLevelGC(meta))
-
-	// Invalid values interpreted as false.
-	meta = &keyspacepb.KeyspaceMeta{
-		Config: map[string]string{"gc_management_type": "111111"},
-	}
-	re.False(IsKeyspaceUsingKeyspaceLevelGC(meta))
-}
-
-func TestIsCSEKeyspaceLevelGC(t *testing.T) {
 	tests := []struct {
 		name string
 		meta *keyspacepb.KeyspaceMeta
@@ -137,11 +112,13 @@ func TestIsCSEKeyspaceLevelGC(t *testing.T) {
 	}{
 		{name: "nil metadata", meta: nil, want: false},
 		{name: "nil config", meta: &keyspacepb.KeyspaceMeta{}, want: false},
-		{name: "missing safe point version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{}}, want: false},
+		{name: "empty config", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{}}, want: false},
+		{name: "native keyspace level GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "keyspace_level"}}, want: true},
+		{name: "unified GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "unified"}}, want: false},
+		{name: "invalid GC management type", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "111111"}}, want: false},
 		{name: "safe point version v2", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "v2"}}, want: true},
 		{name: "uppercase safe point version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "V2"}}, want: false},
 		{name: "padded safe point version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": " v2 "}}, want: false},
-		{name: "native keyspace level GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"gc_management_type": "keyspace_level"}}, want: false},
 	}
 
 	for _, test := range tests {
@@ -150,7 +127,7 @@ func TestIsCSEKeyspaceLevelGC(t *testing.T) {
 			meta := test.meta
 
 			// When
-			got := IsCSEKeyspaceLevelGC(meta)
+			got := IsKeyspaceUsingKeyspaceLevelGC(meta)
 
 			// Then
 			require.Equal(t, test.want, got)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -129,7 +129,7 @@ func TestIsKeyspaceUsingKeyspaceLevelGC(t *testing.T) {
 	re.False(IsKeyspaceUsingKeyspaceLevelGC(meta))
 }
 
-func TestIsCESKeyspaceLevelGC(t *testing.T) {
+func TestIsCSEKeyspaceLevelGC(t *testing.T) {
 	tests := []struct {
 		name string
 		meta *keyspacepb.KeyspaceMeta
@@ -150,7 +150,7 @@ func TestIsCESKeyspaceLevelGC(t *testing.T) {
 			meta := test.meta
 
 			// When
-			got := IsCESKeyspaceLevelGC(meta)
+			got := IsCSEKeyspaceLevelGC(meta)
 
 			// Then
 			require.Equal(t, test.want, got)

--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -251,6 +251,10 @@ func IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool 
 	if keyspaceMeta == nil || keyspaceMeta.Config == nil {
 		return false
 	}
-	return keyspaceMeta.Config[KeyspaceConfigGCManagementType] == KeyspaceConfigGCManagementTypeKeyspaceLevel ||
-		keyspaceMeta.Config[keyspaceConfigSafePointVersion] == keyspaceConfigSafePointVersionV2
+	// Treat gc_management_type as authoritative when present, and fall back to safe_point_version
+	// only for compatibility with legacy keyspace metadata.
+	if gcManagementType, ok := keyspaceMeta.Config[KeyspaceConfigGCManagementType]; ok {
+		return gcManagementType == KeyspaceConfigGCManagementTypeKeyspaceLevel
+	}
+	return keyspaceMeta.Config[keyspaceConfigSafePointVersion] == keyspaceConfigSafePointVersionV2
 }

--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -35,6 +35,8 @@ const (
 	KeyspaceConfigGCManagementTypeKeyspaceLevel = "keyspace_level"
 	// KeyspaceConfigGCManagementTypeUnified is the value representing unified GC in keyspace config.
 	KeyspaceConfigGCManagementTypeUnified = "unified"
+	keyspaceConfigSafePointVersion        = "safe_point_version"
+	keyspaceConfigSafePointVersionV2      = "v2"
 )
 
 // KeyspaceClient manages keyspace metadata.
@@ -247,4 +249,9 @@ func (c *client) GetAllKeyspaces(ctx context.Context, startID uint32, limit uint
 // case.
 func IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
 	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config[KeyspaceConfigGCManagementType] == KeyspaceConfigGCManagementTypeKeyspaceLevel
+}
+
+// IsCESKeyspaceLevelGC reports whether a keyspace uses the CES keyspace-level GC metadata format.
+func IsCESKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
+	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config[keyspaceConfigSafePointVersion] == keyspaceConfigSafePointVersionV2
 }

--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -248,10 +248,9 @@ func (c *client) GetAllKeyspaces(ctx context.Context, startID uint32, limit uint
 // Nil value, which may occur for the null keyspace, are considered unified GC and this function returns false for this
 // case.
 func IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
-	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config[KeyspaceConfigGCManagementType] == KeyspaceConfigGCManagementTypeKeyspaceLevel
-}
-
-// IsCSEKeyspaceLevelGC reports whether a keyspace uses the CSE keyspace-level GC metadata format.
-func IsCSEKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
-	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config[keyspaceConfigSafePointVersion] == keyspaceConfigSafePointVersionV2
+	if keyspaceMeta == nil || keyspaceMeta.Config == nil {
+		return false
+	}
+	return keyspaceMeta.Config[KeyspaceConfigGCManagementType] == KeyspaceConfigGCManagementTypeKeyspaceLevel ||
+		keyspaceMeta.Config[keyspaceConfigSafePointVersion] == keyspaceConfigSafePointVersionV2
 }

--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -251,7 +251,7 @@ func IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool 
 	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config[KeyspaceConfigGCManagementType] == KeyspaceConfigGCManagementTypeKeyspaceLevel
 }
 
-// IsCESKeyspaceLevelGC reports whether a keyspace uses the CES keyspace-level GC metadata format.
-func IsCESKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
+// IsCSEKeyspaceLevelGC reports whether a keyspace uses the CSE keyspace-level GC metadata format.
+func IsCSEKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
 	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config[keyspaceConfigSafePointVersion] == keyspaceConfigSafePointVersionV2
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11108

Downstream issue: pingcap/ticdc#5785

TiDB Cloud Essential v1 keyspaces use `safe_point_version=v2` to indicate keyspace-level GC. Existing downstream code already relies on `IsKeyspaceUsingKeyspaceLevelGC`, but that predicate only recognizes `gc_management_type=keyspace_level`.

### What is changed and how does it work?

Extend `IsKeyspaceUsingKeyspaceLevelGC` to recognize either native keyspace-level GC metadata or the exact `safe_point_version=v2` setting. This keeps PD terminology deployment-agnostic and lets existing client-go and TiDB callers select the correct keyspace-scoped metadata without component-specific helpers.

```commit-message
client: recognize v2 keyspace-level GC
```

### Check List

Tests

- Unit test: `make basic-test` in `client/`
- Focused test: `make gotest GOTEST_ARGS='./... -run TestIsKeyspaceUsingKeyspaceLevelGC -count=1'` in `client/`
- Manual test: imported the PD client from a standalone driver and verified native metadata returns true, `safe_point_version=v2` returns true, and malformed `V2` returns false

Related changes

- tikv/client-go#2040 and pingcap/tidb#70322 were closed as superseded because their existing API v3 bases already call this predicate.
- tikv/client-go#2024, pingcap/tidb#69942, and pingcap/ticdc#5870 remain the API v3 dependency stack.

### Release note

```release-note
Recognize version 2 safe-point metadata as keyspace-level GC.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyspace garbage-collection detection for missing or empty configurations.
  * Added support for uppercase and padded configuration values.
  * Ensured explicit garbage-collection management settings take precedence over fallback safe-point version settings.
  * Added validation for supported safe-point versions and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->