### PR TITLE
tso: ignore stale allocator update failures

### DIFF
--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -61,6 +61,10 @@ type Allocator struct {
 	// for election use
 	member          member.Election
 	timestampOracle *timestampOracle
+	// lifecycleMu serializes allocator initialization and reset. lifecycleVersion
+	// changes whenever the timestamp in memory is initialized or reset.
+	lifecycleMu      sync.Mutex
+	lifecycleVersion uint64
 
 	// observability
 	tsoAllocatorRoleGauge prometheus.Gauge
@@ -126,10 +130,20 @@ func (a *Allocator) allocatorUpdater() {
 			if !a.isServing() || !a.IsInitialize() {
 				continue
 			}
+			a.lifecycleMu.Lock()
+			lifecycleVersion := a.lifecycleVersion
+			a.lifecycleMu.Unlock()
 			if err := a.UpdateTSO(); err != nil {
-				log.Warn("failed to update allocator's timestamp, resetting the TSO allocator with leadership resignation",
-					append(a.logFields, errs.ZapError(err))...)
-				a.Reset(true)
+				a.lifecycleMu.Lock()
+				if lifecycleVersion == a.lifecycleVersion {
+					log.Warn("failed to update allocator's timestamp, resetting the TSO allocator with leadership resignation",
+						append(a.logFields, errs.ZapError(err))...)
+					a.resetLocked(true)
+				} else {
+					log.Warn("ignored a stale allocator update failure after reinitialization",
+						append(a.logFields, errs.ZapError(err))...)
+				}
+				a.lifecycleMu.Unlock()
 				// To wait for the allocator to be re-initialized next time.
 				continue
 			}
@@ -152,8 +166,14 @@ func (a *Allocator) Close() {
 
 // Initialize will initialize the created TSO allocator.
 func (a *Allocator) Initialize() error {
+	a.lifecycleMu.Lock()
+	defer a.lifecycleMu.Unlock()
 	a.tsoAllocatorRoleGauge.Set(1)
-	return a.timestampOracle.syncTimestamp()
+	if err := a.timestampOracle.syncTimestamp(); err != nil {
+		return err
+	}
+	a.lifecycleVersion++
+	return nil
 }
 
 // IsInitialize is used to indicates whether this allocator is initialized.
@@ -198,6 +218,14 @@ func (a *Allocator) GenerateTSO(ctx context.Context, count uint32) (pdpb.Timesta
 
 // Reset is used to reset the TSO allocator, it will also reset the leadership if the `resetLeadership` flag is true.
 func (a *Allocator) Reset(resetLeadership bool) {
+	a.lifecycleMu.Lock()
+	defer a.lifecycleMu.Unlock()
+	a.resetLocked(resetLeadership)
+}
+
+// resetLocked resets the allocator while lifecycleMu is held.
+func (a *Allocator) resetLocked(resetLeadership bool) {
+	a.lifecycleVersion++
 	a.tsoAllocatorRoleGauge.Set(0)
 	a.timestampOracle.resetTimestamp()
 	// Reset if it still has the leadership. Otherwise the data race may occur because of the re-campaigning.

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -61,10 +61,11 @@ type Allocator struct {
 	// for election use
 	member          member.Election
 	timestampOracle *timestampOracle
-	// lifecycleMu serializes allocator initialization and reset. lifecycleVersion
-	// changes whenever the timestamp in memory is initialized or reset.
-	lifecycleMu      sync.Mutex
-	lifecycleVersion uint64
+	// timestampStateMu serializes timestamp initialization and reset.
+	// timestampStateID changes after each successful initialization and every reset,
+	// so an UpdateTSO failure can only reset the state it started with.
+	timestampStateMu sync.Mutex
+	timestampStateID uint64
 
 	// observability
 	tsoAllocatorRoleGauge prometheus.Gauge
@@ -130,22 +131,9 @@ func (a *Allocator) allocatorUpdater() {
 			if !a.isServing() || !a.IsInitialize() {
 				continue
 			}
-			a.lifecycleMu.Lock()
-			lifecycleVersion := a.lifecycleVersion
-			a.lifecycleMu.Unlock()
+			stateIDBeforeUpdate := a.captureTimestampStateID()
 			if err := a.UpdateTSO(); err != nil {
-				a.lifecycleMu.Lock()
-				if lifecycleVersion == a.lifecycleVersion {
-					log.Warn("failed to update allocator's timestamp, resetting the TSO allocator with leadership resignation",
-						append(a.logFields, errs.ZapError(err))...)
-					a.resetLocked(true)
-				} else {
-					log.Warn("ignored a stale allocator update failure after reinitialization",
-						append(a.logFields, errs.ZapError(err))...)
-				}
-				a.lifecycleMu.Unlock()
-				// To wait for the allocator to be re-initialized next time.
-				continue
+				a.handleTSOUpdateFailure(stateIDBeforeUpdate, err)
 			}
 		case <-a.ctx.Done():
 			a.Reset(false)
@@ -166,13 +154,13 @@ func (a *Allocator) Close() {
 
 // Initialize will initialize the created TSO allocator.
 func (a *Allocator) Initialize() error {
-	a.lifecycleMu.Lock()
-	defer a.lifecycleMu.Unlock()
+	a.timestampStateMu.Lock()
+	defer a.timestampStateMu.Unlock()
 	a.tsoAllocatorRoleGauge.Set(1)
 	if err := a.timestampOracle.syncTimestamp(); err != nil {
 		return err
 	}
-	a.lifecycleVersion++
+	a.timestampStateID++
 	return nil
 }
 
@@ -199,6 +187,26 @@ func (a *Allocator) UpdateTSO() (err error) {
 	return err
 }
 
+func (a *Allocator) captureTimestampStateID() uint64 {
+	a.timestampStateMu.Lock()
+	defer a.timestampStateMu.Unlock()
+	return a.timestampStateID
+}
+
+func (a *Allocator) handleTSOUpdateFailure(stateIDBeforeUpdate uint64, err error) {
+	a.timestampStateMu.Lock()
+	defer a.timestampStateMu.Unlock()
+
+	if stateIDBeforeUpdate != a.timestampStateID {
+		log.Warn("ignored a stale allocator update failure because the timestamp state has changed",
+			append(a.logFields, errs.ZapError(err))...)
+		return
+	}
+	log.Warn("failed to update allocator's timestamp, resetting the TSO allocator with leadership resignation",
+		append(a.logFields, errs.ZapError(err))...)
+	a.resetAllocatorLocked(true)
+}
+
 // SetTSO sets the physical part with given TSO.
 func (a *Allocator) SetTSO(tso uint64, ignoreSmaller, skipUpperBoundCheck bool) error {
 	return a.timestampOracle.resetUserTimestamp(tso, ignoreSmaller, skipUpperBoundCheck)
@@ -218,14 +226,14 @@ func (a *Allocator) GenerateTSO(ctx context.Context, count uint32) (pdpb.Timesta
 
 // Reset is used to reset the TSO allocator, it will also reset the leadership if the `resetLeadership` flag is true.
 func (a *Allocator) Reset(resetLeadership bool) {
-	a.lifecycleMu.Lock()
-	defer a.lifecycleMu.Unlock()
-	a.resetLocked(resetLeadership)
+	a.timestampStateMu.Lock()
+	defer a.timestampStateMu.Unlock()
+	a.resetAllocatorLocked(resetLeadership)
 }
 
-// resetLocked resets the allocator while lifecycleMu is held.
-func (a *Allocator) resetLocked(resetLeadership bool) {
-	a.lifecycleVersion++
+// resetAllocatorLocked resets the allocator. The caller must hold timestampStateMu.
+func (a *Allocator) resetAllocatorLocked(resetLeadership bool) {
+	a.timestampStateID++
 	a.tsoAllocatorRoleGauge.Set(0)
 	a.timestampOracle.resetTimestamp()
 	// Reset if it still has the leadership. Otherwise the data race may occur because of the re-campaigning.

--- a/pkg/tso/allocator_test.go
+++ b/pkg/tso/allocator_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tso
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/election"
+	"github.com/tikv/pd/pkg/utils/typeutil"
+)
+
+type staleUpdateElection struct {
+	mockElection
+	serving  atomic.Bool
+	resigned chan struct{}
+}
+
+func (m *staleUpdateElection) IsServing() bool { return m.serving.Load() }
+func (m *staleUpdateElection) PromoteSelf()    { m.serving.Store(true) }
+func (m *staleUpdateElection) Resign() {
+	m.serving.Store(false)
+	close(m.resigned)
+}
+
+type staleUpdateStorage struct {
+	failing     atomic.Bool
+	calls       atomic.Int32
+	thirdFailed chan struct{}
+}
+
+func (*staleUpdateStorage) LoadTimestamp(uint32) (time.Time, error) {
+	return typeutil.ZeroTime, nil
+}
+
+func (s *staleUpdateStorage) SaveTimestamp(context.Context, uint32, time.Time, *election.Leadership) error {
+	if !s.failing.Load() {
+		return nil
+	}
+	if s.calls.Add(1) == maxUpdateTSORetryCount {
+		close(s.thirdFailed)
+	}
+	return errors.New("tso update failed")
+}
+
+func (*staleUpdateStorage) DeleteTimestamp(context.Context, uint32) error { return nil }
+
+func (s *staleUpdateStorage) startFailures() <-chan struct{} {
+	s.calls.Store(0)
+	s.thirdFailed = make(chan struct{})
+	s.failing.Store(true)
+	return s.thirdFailed
+}
+
+func (s *staleUpdateStorage) stopFailures() {
+	s.failing.Store(false)
+}
+
+// TestAllocatorIgnoresStaleUpdateFailure is a regression test for #11086.
+func TestAllocatorIgnoresStaleUpdateFailure(t *testing.T) {
+	re := require.New(t)
+	previousProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previousProcs)
+
+	member := &staleUpdateElection{
+		resigned: make(chan struct{}),
+	}
+	member.serving.Store(true)
+	storage := &staleUpdateStorage{}
+	allocator := NewAllocator(context.Background(), 11086, member, storage, &TestServiceConfig{
+		TSOUpdatePhysicalInterval: time.Millisecond,
+		TSOSaveInterval:           2 * time.Millisecond,
+		MaxResetTSGap:             time.Hour,
+	})
+	defer allocator.Close()
+
+	re.NoError(allocator.Initialize())
+	staleFailure := storage.startFailures()
+	select {
+	case <-staleFailure:
+	case <-time.After(2 * time.Second):
+		t.Fatal("old UpdateTSO did not reach its final failure")
+	}
+
+	member.serving.Store(false)
+	storage.stopFailures()
+	re.NoError(allocator.Initialize())
+	time.Sleep(2 * updateTSORetryInterval)
+	re.True(allocator.IsInitialize(), "a stale failure reset the new lease's timestamp")
+
+	member.PromoteSelf()
+	_, err := allocator.GenerateTSO(context.Background(), 1)
+	re.NoError(err)
+
+	currentFailure := storage.startFailures()
+	select {
+	case <-currentFailure:
+	case <-time.After(2 * time.Second):
+		t.Fatal("current UpdateTSO did not reach its final failure")
+	}
+	select {
+	case <-member.resigned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("current lease was not resigned after UpdateTSO failed")
+	}
+	re.False(allocator.IsInitialize())
+}

--- a/pkg/tso/allocator_test.go
+++ b/pkg/tso/allocator_test.go
@@ -104,7 +104,7 @@ func TestAllocatorIgnoresStaleUpdateFailure(t *testing.T) {
 	storage.stopFailures()
 	re.NoError(allocator.Initialize())
 	time.Sleep(2 * updateTSORetryInterval)
-	re.True(allocator.IsInitialize(), "a stale failure reset the new lease's timestamp")
+	re.True(allocator.IsInitialize(), "a stale update failure reset the reinitialized timestamp")
 
 	member.PromoteSelf()
 	_, err := allocator.GenerateTSO(context.Background(), 1)

--- a/pkg/tso/allocator_test.go
+++ b/pkg/tso/allocator_test.go
@@ -17,7 +17,7 @@ package tso
 import (
 	"context"
 	"errors"
-	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tikv/pd/pkg/election"
+	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/pkg/utils/typeutil"
 )
 
@@ -42,9 +43,13 @@ func (m *staleUpdateElection) Resign() {
 }
 
 type staleUpdateStorage struct {
-	failing     atomic.Bool
-	calls       atomic.Int32
-	thirdFailed chan struct{}
+	failing atomic.Bool
+	calls   atomic.Int32
+
+	mu                  sync.Mutex
+	finalFailureReached chan struct{}
+	releaseFinalFailure <-chan struct{}
+	nextSuccessfulSave  chan struct{}
 }
 
 func (*staleUpdateStorage) LoadTimestamp(uint32) (time.Time, error) {
@@ -53,32 +58,64 @@ func (*staleUpdateStorage) LoadTimestamp(uint32) (time.Time, error) {
 
 func (s *staleUpdateStorage) SaveTimestamp(context.Context, uint32, time.Time, *election.Leadership) error {
 	if !s.failing.Load() {
+		s.mu.Lock()
+		nextSuccessfulSave := s.nextSuccessfulSave
+		s.nextSuccessfulSave = nil
+		s.mu.Unlock()
+		if nextSuccessfulSave != nil {
+			close(nextSuccessfulSave)
+		}
 		return nil
 	}
 	if s.calls.Add(1) == maxUpdateTSORetryCount {
-		close(s.thirdFailed)
+		s.mu.Lock()
+		finalFailureReached := s.finalFailureReached
+		releaseFinalFailure := s.releaseFinalFailure
+		s.mu.Unlock()
+		close(finalFailureReached)
+		if releaseFinalFailure != nil {
+			<-releaseFinalFailure
+		}
 	}
 	return errors.New("tso update failed")
 }
 
 func (*staleUpdateStorage) DeleteTimestamp(context.Context, uint32) error { return nil }
 
-func (s *staleUpdateStorage) startFailures() <-chan struct{} {
+func (s *staleUpdateStorage) startFailures(releaseFinalFailure <-chan struct{}) <-chan struct{} {
+	s.mu.Lock()
+	s.finalFailureReached = make(chan struct{})
+	s.releaseFinalFailure = releaseFinalFailure
+	finalFailureReached := s.finalFailureReached
+	s.mu.Unlock()
 	s.calls.Store(0)
-	s.thirdFailed = make(chan struct{})
 	s.failing.Store(true)
-	return s.thirdFailed
+	return finalFailureReached
 }
 
 func (s *staleUpdateStorage) stopFailures() {
 	s.failing.Store(false)
 }
 
+func (s *staleUpdateStorage) notifyOnNextSuccessfulSave() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextSuccessfulSave = make(chan struct{})
+	return s.nextSuccessfulSave
+}
+
+func isSignaled(signal <-chan struct{}) bool {
+	select {
+	case <-signal:
+		return true
+	default:
+		return false
+	}
+}
+
 // TestAllocatorIgnoresStaleUpdateFailure is a regression test for #11086.
 func TestAllocatorIgnoresStaleUpdateFailure(t *testing.T) {
 	re := require.New(t)
-	previousProcs := runtime.GOMAXPROCS(1)
-	defer runtime.GOMAXPROCS(previousProcs)
 
 	member := &staleUpdateElection{
 		resigned: make(chan struct{}),
@@ -93,33 +130,30 @@ func TestAllocatorIgnoresStaleUpdateFailure(t *testing.T) {
 	defer allocator.Close()
 
 	re.NoError(allocator.Initialize())
-	staleFailure := storage.startFailures()
-	select {
-	case <-staleFailure:
-	case <-time.After(2 * time.Second):
-		t.Fatal("old UpdateTSO did not reach its final failure")
-	}
+	releaseStaleFailure := make(chan struct{}, 1)
+	defer close(releaseStaleFailure)
+	staleFailure := storage.startFailures(releaseStaleFailure)
+	testutil.Eventually(re, func() bool { return isSignaled(staleFailure) })
 
+	// Reinitialize and promote before the old UpdateTSO returns its final error.
 	member.serving.Store(false)
 	storage.stopFailures()
 	re.NoError(allocator.Initialize())
-	time.Sleep(2 * updateTSORetryInterval)
+	nextSuccessfulSave := storage.notifyOnNextSuccessfulSave()
+	member.PromoteSelf()
+	releaseStaleFailure <- struct{}{}
+	// The updater must handle the stale error before it can perform this save.
+	testutil.Eventually(re, func() bool {
+		return isSignaled(nextSuccessfulSave) || isSignaled(member.resigned)
+	})
+	re.False(isSignaled(member.resigned), "a stale update failure resigned the reinitialized allocator")
 	re.True(allocator.IsInitialize(), "a stale update failure reset the reinitialized timestamp")
 
-	member.PromoteSelf()
 	_, err := allocator.GenerateTSO(context.Background(), 1)
 	re.NoError(err)
 
-	currentFailure := storage.startFailures()
-	select {
-	case <-currentFailure:
-	case <-time.After(2 * time.Second):
-		t.Fatal("current UpdateTSO did not reach its final failure")
-	}
-	select {
-	case <-member.resigned:
-	case <-time.After(2 * time.Second):
-		t.Fatal("current lease was not resigned after UpdateTSO failed")
-	}
+	currentFailure := storage.startFailures(nil)
+	testutil.Eventually(re, func() bool { return isSignaled(currentFailure) })
+	testutil.Eventually(re, func() bool { return isSignaled(member.resigned) })
 	re.False(allocator.IsInitialize())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11086

An in-flight `UpdateTSO` call from an earlier allocator lifecycle can fail after a new TSO primary initializes its timestamp. The unconditional `Reset(true)` then clears the new timestamp and leaves the reported primary unable to serve TSO requests.

### What is changed and how does it work?

```commit-message
Serialize timestamp initialization and reset with a timestamp state lock. Each successful initialization and every reset advances the timestamp state ID. The allocator captures that ID before UpdateTSO, and handleTSOUpdateFailure only resets the allocator when the captured ID is still current; failures that started with an older timestamp state are ignored.

Add a regression test that reproduces the stale failure ordering, verifies TSO generation remains available after reinitialization, and verifies a failure from the current timestamp state still resets and resigns the allocator.
```

### Check List

Tests

- Unit test
  - `make gotest GOTEST_ARGS='./pkg/tso -run TestAllocatorIgnoresStaleUpdateFailure -count=20'`
  - `make gotest GOTEST_ARGS='./pkg/tso -run TestAllocatorIgnoresStaleUpdateFailure -count=10 -race'`
  - `make gotest GOTEST_ARGS='./pkg/tso -count=1'`
  - `golangci-lint run ./pkg/tso`

### Release note

```release-note
Fix a race that could clear the external TSO allocator's initialized timestamp during PD restart recovery.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved allocator lifecycle handling during initialization, reset, and timestamp updates.
  - Prevented outdated update failures from disrupting a newer allocator lease.
  - Ensured current-lease failures still trigger appropriate leadership and initialization cleanup.

- **Tests**
  - Added regression coverage for stale update failures and allocator reinitialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->