### PR TITLE
server: allow forwarded leader URL scheme mismatch

### DIFF
--- a/server/forward.go
+++ b/server/forward.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"io"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -39,6 +40,7 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
+	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server/cluster"
 )
 
@@ -463,7 +465,7 @@ func (s *GrpcServer) validatePDForwardedHost(forwardedHost string) error {
 		return status.Error(codes.Unavailable, "PD leader is not available")
 	}
 	for _, clientURL := range leader.GetClientUrls() {
-		if clientURL == forwardedHost {
+		if isSamePDClientURL(clientURL, forwardedHost) {
 			return nil
 		}
 	}
@@ -488,11 +490,20 @@ func (s *GrpcServer) isLocalRequest(host string) bool {
 	}
 	memberAddrs := s.GetMember().Member().GetClientUrls()
 	for _, addr := range memberAddrs {
-		if addr == host {
+		if isSamePDClientURL(addr, host) {
 			return true
 		}
 	}
 	return false
+}
+
+// isSamePDClientURL checks whether two HTTP(S) client URLs differ only in
+// scheme. PD clients may rewrite the scheme to match their TLS configuration,
+// while gRPC uses the URL host and the TLS configuration independently.
+func isSamePDClientURL(first, second string) bool {
+	firstHasValidScheme := strings.HasPrefix(first, "http://") || strings.HasPrefix(first, "https://")
+	secondHasValidScheme := strings.HasPrefix(second, "http://") || strings.HasPrefix(second, "https://")
+	return firstHasValidScheme && secondHasValidScheme && typeutil.EqualBaseURLs(first, second)
 }
 
 func (s *GrpcServer) getGlobalTSO(ctx context.Context) (pdpb.Timestamp, error) {

--- a/server/forward.go
+++ b/server/forward.go
@@ -462,14 +462,17 @@ func (s *GrpcServer) getDelegateClient(ctx context.Context, forwardedHost string
 func (s *GrpcServer) validatePDForwardedHost(forwardedHost string) error {
 	leader := s.GetLeader()
 	if leader == nil || len(leader.GetClientUrls()) == 0 {
-		return status.Error(codes.Unavailable, "PD leader is not available")
+		return errs.ErrNotLeader
 	}
 	for _, clientURL := range leader.GetClientUrls() {
 		if isSamePDClientURL(clientURL, forwardedHost) {
 			return nil
 		}
 	}
-	return status.Errorf(codes.InvalidArgument, "forwarded host %q is not a client URL of the PD leader", forwardedHost)
+	// Preserve the not-leader marker because PD clients use it to
+	// synchronously refresh membership when their forwarded host becomes stale.
+	return status.Errorf(codes.InvalidArgument,
+		"forwarded host %q is not a client URL of the PD leader: pd %s of cluster", forwardedHost, errs.NotLeaderErr)
 }
 
 func (s *GrpcServer) closeDelegateClient(forwardedHost string) {

--- a/server/forward.go
+++ b/server/forward.go
@@ -40,7 +40,6 @@ import (
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/logutil"
 	"github.com/tikv/pd/pkg/utils/tsoutil"
-	"github.com/tikv/pd/pkg/utils/typeutil"
 	"github.com/tikv/pd/server/cluster"
 )
 
@@ -504,9 +503,16 @@ func (s *GrpcServer) isLocalRequest(host string) bool {
 // scheme. PD clients may rewrite the scheme to match their TLS configuration,
 // while gRPC uses the URL host and the TLS configuration independently.
 func isSamePDClientURL(first, second string) bool {
-	firstHasValidScheme := strings.HasPrefix(first, "http://") || strings.HasPrefix(first, "https://")
-	secondHasValidScheme := strings.HasPrefix(second, "http://") || strings.HasPrefix(second, "https://")
-	return firstHasValidScheme && secondHasValidScheme && typeutil.EqualBaseURLs(first, second)
+	firstBaseURL, firstHasValidScheme := trimPDClientURLScheme(first)
+	secondBaseURL, secondHasValidScheme := trimPDClientURLScheme(second)
+	return firstHasValidScheme && secondHasValidScheme && firstBaseURL == secondBaseURL
+}
+
+func trimPDClientURLScheme(url string) (string, bool) {
+	if baseURL, ok := strings.CutPrefix(url, "http://"); ok {
+		return baseURL, true
+	}
+	return strings.CutPrefix(url, "https://")
 }
 
 func (s *GrpcServer) getGlobalTSO(ctx context.Context) (pdpb.Timestamp, error) {

--- a/server/grpc_service_test.go
+++ b/server/grpc_service_test.go
@@ -58,6 +58,7 @@ func TestIsSamePDClientURL(t *testing.T) {
 		{name: "different port", first: "http://127.0.0.1:2379", second: "https://127.0.0.1:2380"},
 		{name: "different path", first: "http://127.0.0.1:2379", second: "https://127.0.0.1:2379/path"},
 		{name: "different query", first: "http://127.0.0.1:2379", second: "https://127.0.0.1:2379?query=value"},
+		{name: "nested scheme", first: "http://127.0.0.1:2379", second: "https://http://127.0.0.1:2379"},
 		{name: "missing scheme", first: "http://127.0.0.1:2379", second: "127.0.0.1:2379"},
 		{name: "unsupported scheme", first: "http://127.0.0.1:2379", second: "ftp://127.0.0.1:2379"},
 		{name: "same unsupported URL", first: "ftp://127.0.0.1:2379", second: "ftp://127.0.0.1:2379"},

--- a/server/grpc_service_test.go
+++ b/server/grpc_service_test.go
@@ -31,6 +31,35 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
 }
 
+func TestIsSamePDClientURL(t *testing.T) {
+	testCases := []struct {
+		name   string
+		first  string
+		second string
+		same   bool
+	}{
+		{name: "same HTTP URL", first: "http://127.0.0.1:2379", second: "http://127.0.0.1:2379", same: true},
+		{name: "same HTTPS URL", first: "https://127.0.0.1:2379", second: "https://127.0.0.1:2379", same: true},
+		{name: "HTTP to HTTPS", first: "http://127.0.0.1:2379", second: "https://127.0.0.1:2379", same: true},
+		{name: "HTTPS to HTTP", first: "https://127.0.0.1:2379", second: "http://127.0.0.1:2379", same: true},
+		{name: "uppercase scheme", first: "HTTP://127.0.0.1:2379", second: "https://127.0.0.1:2379"},
+		{name: "different host", first: "http://127.0.0.1:2379", second: "https://127.0.0.2:2379"},
+		{name: "different port", first: "http://127.0.0.1:2379", second: "https://127.0.0.1:2380"},
+		{name: "different path", first: "http://127.0.0.1:2379", second: "https://127.0.0.1:2379/path"},
+		{name: "different query", first: "http://127.0.0.1:2379", second: "https://127.0.0.1:2379?query=value"},
+		{name: "missing scheme", first: "http://127.0.0.1:2379", second: "127.0.0.1:2379"},
+		{name: "unsupported scheme", first: "http://127.0.0.1:2379", second: "ftp://127.0.0.1:2379"},
+		{name: "same unsupported URL", first: "ftp://127.0.0.1:2379", second: "ftp://127.0.0.1:2379"},
+		{name: "empty URLs"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.same, isSamePDClientURL(testCase.first, testCase.second))
+		})
+	}
+}
+
 func TestNewSchedulingAskBatchSplitRequestPreservesReason(t *testing.T) {
 	re := require.New(t)
 	req := newSchedulingAskBatchSplitRequest(&pdpb.AskBatchSplitRequest{

--- a/server/grpc_service_test.go
+++ b/server/grpc_service_test.go
@@ -19,16 +19,27 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/kvproto/pkg/schedulingpb"
 
+	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/member"
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m, testutil.LeakOptions...)
+}
+
+func TestValidatePDForwardedHostWithoutLeader(t *testing.T) {
+	grpcServer := &GrpcServer{Server: &Server{member: member.NewMember(nil, nil, 1)}}
+	err := grpcServer.validatePDForwardedHost("http://127.0.0.1:2379")
+	require.ErrorIs(t, err, errs.ErrNotLeader)
+	require.Equal(t, codes.Unavailable, status.Code(err))
 }
 
 func TestIsSamePDClientURL(t *testing.T) {

--- a/tests/integrations/mcs/resourcemanager/redirector_test.go
+++ b/tests/integrations/mcs/resourcemanager/redirector_test.go
@@ -376,7 +376,10 @@ func (suite *resourceManagerRedirectorTestSuite) TestGRPCMetadataWritesForwardFr
 	re.Equal(uint64(320), unmodifiedResp.GetGroup().GetRUSettings().GetRU().GetSettings().GetFillRate())
 	re.Equal(int64(480), unmodifiedResp.GetGroup().GetRUSettings().GetRU().GetSettings().GetBurstLimit())
 
-	modifyResp, err := followerClient.ModifyResourceGroup(ctx, &rmpb.PutResourceGroupRequest{Group: group})
+	forwardedHost := strings.Replace(suite.pdLeader.GetAddr(), "http://", "https://", 1)
+	re.NotEqual(suite.pdLeader.GetAddr(), forwardedHost)
+	forwardedCtx = grpcutil.BuildForwardContext(ctx, forwardedHost)
+	modifyResp, err := followerClient.ModifyResourceGroup(forwardedCtx, &rmpb.PutResourceGroupRequest{Group: group})
 	re.NoError(err)
 	re.Equal("Success!", modifyResp.GetBody())
 

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -148,6 +149,31 @@ func (s *tsoProxyTestSuite) TestRejectFollowerForwardedHost() {
 
 	s.verifyForwardedHostRejected(client, s.follower.GetAddr())
 	s.verifyForwardedHostRejected(s.pdClient, s.follower.GetAddr())
+}
+
+func (s *tsoProxyTestSuite) TestAcceptLeaderForwardedHostWithDifferentScheme() {
+	re := s.Require()
+	forwardedHost := strings.Replace(s.leader.GetAddr(), "http://", "https://", 1)
+	re.NotEqual(s.leader.GetAddr(), forwardedHost)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = grpcutil.BuildForwardContext(ctx, forwardedHost)
+
+	resp, err := s.pdClient.GetAllStores(ctx, &pdpb.GetAllStoresRequest{Header: s.defaultReq.GetHeader()})
+	re.NoError(err)
+	re.NotNil(resp)
+	re.Equal(s.defaultReq.GetHeader().GetClusterId(), resp.GetHeader().GetClusterId())
+
+	client, err := s.pdClient.Tso(ctx)
+	re.NoError(err)
+	defer func() {
+		err := client.CloseSend()
+		if err != nil && err != io.EOF {
+			re.NoError(err)
+		}
+	}()
+	s.verifyProxyIsHealthyWith(client)
 }
 
 func (s *tsoProxyTestSuite) verifyForwardedHostRejected(client pdpb.PDClient, forwardedHost string) {

--- a/tests/server/tso/tso_proxy_test.go
+++ b/tests/server/tso/tso_proxy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
+	"github.com/tikv/pd/pkg/errs"
 	"github.com/tikv/pd/pkg/utils/grpcutil"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/tests"
@@ -184,6 +185,7 @@ func (s *tsoProxyTestSuite) verifyForwardedHostRejected(client pdpb.PDClient, fo
 	_, err := client.GetAllStores(ctx, &pdpb.GetAllStoresRequest{Header: s.defaultReq.GetHeader()})
 	re.Error(err)
 	re.Equal(codes.InvalidArgument, status.Code(err))
+	re.ErrorContains(err, errs.NotLeaderErr)
 
 	tsoClient, err := client.Tso(ctx)
 	re.NoError(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11070

Follow-up to #11069. PD clients may rewrite an advertised leader URL's
scheme to match their TLS configuration. Exact URL comparison therefore
rejects a valid `pd-forwarded-host` when only `http` and `https` differ.

### What is changed and how does it work?

```commit-message
server: allow forwarded leader URL scheme mismatch
```

Treat HTTP and HTTPS client URLs as equivalent only when everything after
the scheme is identical.

- Require both URLs to use an HTTP(S) scheme.
- Apply the comparison consistently to validation and local-request detection.
- Keep rejecting different hosts, ports, paths, queries, and unsupported schemes.
- Verify unary, TSO, and Resource Manager forwarding responses.

### Check List

Tests

- [x] Unit test
- [x] Integration test

Code changes

- [ ] Has the configuration change
- [ ] Has HTTP APIs changed
- [ ] Has persistent data change

Side effects

- [ ] Possible performance regression
- [ ] Increased code complexity
- [ ] Breaking backward compatibility

### Release note

```release-note
Accept `pd-forwarded-host` leader URLs when only the HTTP or HTTPS scheme differs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forwarded-host validation to recognize equivalent HTTP and HTTPS PD endpoints.
  * Requests forwarded to the cluster leader continue to work when only the URL scheme differs.
  * Requests now return the appropriate not-leader error when no leader is available.
  * Invalid or unsupported endpoint URLs are rejected consistently while preserving the not-leader indication.

* **Tests**
  * Added coverage for valid, invalid, malformed, and unsupported endpoint comparisons.
  * Verified unary and streaming requests succeed with HTTPS leader forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->