### PR TITLE
server, member, election: document and test the election client pinning

### DIFF
--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -60,9 +60,7 @@ func GetLeader(c *clientv3.Client, leaderPath string) (*pdpb.Member, int64, erro
 type Leadership struct {
 	// purpose is used to show what this election for
 	purpose string
-	// name identifies the member campaigning for this leadership. It is handed
-	// to every lease this leadership creates so that a test can single out one
-	// member of a cluster; see Lease.matchesFailpointTarget.
+	// name scopes test failpoints to one member.
 	name string
 	// The lease which is used to get this leadership
 	lease  atomic.Value // stored as *lease
@@ -79,8 +77,7 @@ type Leadership struct {
 	campaignTimes []time.Time
 }
 
-// NewLeadership creates a new Leadership. `name` identifies the member that owns
-// it, and is only used to tell members of the same election apart.
+// NewLeadership creates a new Leadership for the named member.
 func NewLeadership(client *clientv3.Client, leaderKey, purpose, name string) *Leadership {
 	leadership := &Leadership{
 		purpose:       purpose,

--- a/pkg/election/leadership.go
+++ b/pkg/election/leadership.go
@@ -60,6 +60,10 @@ func GetLeader(c *clientv3.Client, leaderPath string) (*pdpb.Member, int64, erro
 type Leadership struct {
 	// purpose is used to show what this election for
 	purpose string
+	// name identifies the member campaigning for this leadership. It is handed
+	// to every lease this leadership creates so that a test can single out one
+	// member of a cluster; see Lease.matchesFailpointTarget.
+	name string
 	// The lease which is used to get this leadership
 	lease  atomic.Value // stored as *lease
 	client *clientv3.Client
@@ -75,10 +79,12 @@ type Leadership struct {
 	campaignTimes []time.Time
 }
 
-// NewLeadership creates a new Leadership.
-func NewLeadership(client *clientv3.Client, leaderKey, purpose string) *Leadership {
+// NewLeadership creates a new Leadership. `name` identifies the member that owns
+// it, and is only used to tell members of the same election apart.
+func NewLeadership(client *clientv3.Client, leaderKey, purpose, name string) *Leadership {
 	leadership := &Leadership{
 		purpose:       purpose,
+		name:          name,
 		client:        client,
 		leaderKey:     leaderKey,
 		campaignTimes: make([]time.Time, 0, defaultCampaignTimesSlot),
@@ -167,7 +173,7 @@ func (ls *Leadership) AddCampaignTimes() {
 func (ls *Leadership) Campaign(leaseTimeout int64, leaderData string, cmps ...clientv3.Cmp) error {
 	ls.leaderValue.Store(leaderData)
 	// Create a new lease to campaign
-	newLease := NewLease(ls.client, ls.purpose)
+	newLease := NewLease(ls.client, ls.purpose, ls.name)
 	ls.SetLease(newLease)
 
 	failpoint.Inject("skipGrantLeader", func(val failpoint.Value) {

--- a/pkg/election/leadership_test.go
+++ b/pkg/election/leadership_test.go
@@ -44,8 +44,8 @@ func TestLeadership(t *testing.T) {
 	defer clean()
 
 	// Campaign the same leadership
-	leadership1 := NewLeadership(client, "/test_leader", "test_leader_1")
-	leadership2 := NewLeadership(client, "/test_leader", "test_leader_2")
+	leadership1 := NewLeadership(client, "/test_leader", "test_leader_1", "test_leader_1")
+	leadership2 := NewLeadership(client, "/test_leader", "test_leader_2", "test_leader_2")
 
 	// leadership1 starts first and get the leadership
 	err := leadership1.Campaign(defaultLeaseTimeout, "test_leader_1")
@@ -122,8 +122,8 @@ func TestDeleteLeaderKeyByRevisionDoesNotDeleteChangedLeader(t *testing.T) {
 	defer clean()
 
 	leaderKey := "/test_leader"
-	leadership1 := NewLeadership(client, leaderKey, "test_leader_1")
-	leadership2 := NewLeadership(client, leaderKey, "test_leader_2")
+	leadership1 := NewLeadership(client, leaderKey, "test_leader_1", "test_leader_1")
+	leadership2 := NewLeadership(client, leaderKey, "test_leader_2", "test_leader_2")
 
 	err := leadership1.Campaign(defaultLeaseTimeout, "test_leader_1")
 	re.NoError(err)
@@ -260,8 +260,8 @@ func checkExitWatch(t *testing.T, leaderKey string, injectFunc func(server *embe
 	re.NoError(err)
 	defer client2.Close()
 
-	leadership1 := NewLeadership(client1, leaderKey, "test_leader_1")
-	leadership2 := NewLeadership(client2, leaderKey, "test_leader_2")
+	leadership1 := NewLeadership(client1, leaderKey, "test_leader_1", "test_leader_1")
+	leadership2 := NewLeadership(client2, leaderKey, "test_leader_2", "test_leader_2")
 	err = leadership1.Campaign(defaultLeaseTimeout, "test_leader_1")
 	re.NoError(err)
 	resp, err := client2.Get(context.Background(), leaderKey)
@@ -297,8 +297,8 @@ func TestRequestProgress(t *testing.T) {
 		defer client2.Close()
 
 		leaderKey := "/test_leader"
-		leadership1 := NewLeadership(client1, leaderKey, "test_leader_1")
-		leadership2 := NewLeadership(client2, leaderKey, "test_leader_2")
+		leadership1 := NewLeadership(client1, leaderKey, "test_leader_1", "test_leader_1")
+		leadership2 := NewLeadership(client2, leaderKey, "test_leader_2", "test_leader_2")
 		err = leadership1.Campaign(defaultLeaseTimeout, "test_leader_1")
 		re.NoError(err)
 
@@ -336,7 +336,7 @@ func TestCampaignTimes(t *testing.T) {
 	re := require.New(t)
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
 	defer clean()
-	leadership := NewLeadership(client, "test_leader", "test_leader")
+	leadership := NewLeadership(client, "test_leader", "test_leader", "test_leader")
 
 	// all the campaign times are within the timeout.
 	campaignTimesRecordTimeout = 10 * time.Second

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -317,7 +317,7 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 					// isolate. Injecting ahead of the request instead would let
 					// the key really expire and prove something weaker.
 					if l.matchesFailpointTarget(val) {
-						res, err = nil, errors.New("keepAliveFailed")
+						res, err = nil, errors.New("keep alive failed")
 					}
 				})
 

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -44,10 +44,7 @@ const (
 type Lease struct {
 	// purpose is used to show what this election for
 	purpose string
-	// name identifies the member this lease belongs to. Every member in an
-	// election shares the same purpose, so purpose alone cannot tell them apart;
-	// the failpoints below need to single out one member of a cluster that runs
-	// several of them in a single process.
+	// name scopes test failpoints to one member.
 	name string
 	// etcd client and lease
 	client *clientv3.Client
@@ -65,9 +62,7 @@ type Lease struct {
 	metrics leaseMetrics
 }
 
-// NewLease creates a new Lease instance. `name` identifies the member the lease
-// belongs to; it is not part of the metrics labels, which stay keyed on purpose
-// alone so that the label cardinality does not grow with the cluster.
+// NewLease creates a new Lease instance.
 func NewLease(client *clientv3.Client, purpose, name string) *Lease {
 	return &Lease{
 		purpose: purpose,
@@ -78,12 +73,7 @@ func NewLease(client *clientv3.Client, purpose, name string) *Lease {
 	}
 }
 
-// matchesFailpointTarget reports whether a failpoint value of the form
-// "<purpose>@<name>" refers to this lease. Scoping on the member name as well as
-// the purpose matters because `failpoint.Enable` arms an injection point for the
-// whole process, while the integration tests run every member of a cluster
-// inside one process: a purpose-only match would degrade the members that are
-// supposed to stay healthy and take over.
+// matchesFailpointTarget matches "<purpose>@<name>" for member-scoped failpoints.
 func (l *Lease) matchesFailpointTarget(val failpoint.Value) bool {
 	target, ok := val.(string)
 	if !ok {
@@ -308,14 +298,8 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 				lastRequestStart, _ := lastTime.Swap(requestStart).(time.Time)
 				res, err := l.lease.KeepAliveOnce(ctx1, l.GetID())
 				failpoint.Inject("keepAliveFailed", func(val failpoint.Value) {
-					// Falsify only this caller's view of the renewal. The
-					// request above has already reached etcd and succeeded, so
-					// the lease is still being renewed server side and the
-					// leader key never expires on its own. That is deliberate:
-					// it leaves the local deadline as the only thing that can
-					// end the term, which is what the renewal tests need to
-					// isolate. Injecting ahead of the request instead would let
-					// the key really expire and prove something weaker.
+					// Inject after the request so etcd keeps the lease alive while
+					// the caller observes renewal failure.
 					if l.matchesFailpointTarget(val) {
 						res, err = nil, errors.New("keep alive failed")
 					}

--- a/pkg/election/lease.go
+++ b/pkg/election/lease.go
@@ -16,12 +16,15 @@ package election
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/errs"
@@ -41,6 +44,11 @@ const (
 type Lease struct {
 	// purpose is used to show what this election for
 	purpose string
+	// name identifies the member this lease belongs to. Every member in an
+	// election shares the same purpose, so purpose alone cannot tell them apart;
+	// the failpoints below need to single out one member of a cluster that runs
+	// several of them in a single process.
+	name string
 	// etcd client and lease
 	client *clientv3.Client
 	lease  clientv3.Lease
@@ -57,14 +65,35 @@ type Lease struct {
 	metrics leaseMetrics
 }
 
-// NewLease creates a new Lease instance.
-func NewLease(client *clientv3.Client, purpose string) *Lease {
+// NewLease creates a new Lease instance. `name` identifies the member the lease
+// belongs to; it is not part of the metrics labels, which stay keyed on purpose
+// alone so that the label cardinality does not grow with the cluster.
+func NewLease(client *clientv3.Client, purpose, name string) *Lease {
 	return &Lease{
 		purpose: purpose,
+		name:    name,
 		client:  client,
 		lease:   clientv3.NewLease(client),
 		metrics: newLeaseMetrics(purpose),
 	}
+}
+
+// matchesFailpointTarget reports whether a failpoint value of the form
+// "<purpose>@<name>" refers to this lease. Scoping on the member name as well as
+// the purpose matters because `failpoint.Enable` arms an injection point for the
+// whole process, while the integration tests run every member of a cluster
+// inside one process: a purpose-only match would degrade the members that are
+// supposed to stay healthy and take over.
+func (l *Lease) matchesFailpointTarget(val failpoint.Value) bool {
+	target, ok := val.(string)
+	if !ok {
+		return false
+	}
+	purpose, name, found := strings.Cut(target, "@")
+	if !found {
+		return false
+	}
+	return purpose == l.purpose && name == l.name
 }
 
 func (l *Lease) setID(id clientv3.LeaseID) {
@@ -278,6 +307,19 @@ func (l *Lease) keepAliveWorker(ctx context.Context, interval time.Duration) <-c
 				requestStart := time.Now()
 				lastRequestStart, _ := lastTime.Swap(requestStart).(time.Time)
 				res, err := l.lease.KeepAliveOnce(ctx1, l.GetID())
+				failpoint.Inject("keepAliveFailed", func(val failpoint.Value) {
+					// Falsify only this caller's view of the renewal. The
+					// request above has already reached etcd and succeeded, so
+					// the lease is still being renewed server side and the
+					// leader key never expires on its own. That is deliberate:
+					// it leaves the local deadline as the only thing that can
+					// end the term, which is what the renewal tests need to
+					// isolate. Injecting ahead of the request instead would let
+					// the key really expire and prove something weaker.
+					if l.matchesFailpointTarget(val) {
+						res, err = nil, errors.New("keepAliveFailed")
+					}
+				})
 
 				// Record the duration of the `KeepAliveOnce` request.
 				l.metrics.observeKeepAliveRequestDurationMetrics(time.Since(requestStart), err)

--- a/pkg/election/lease_test.go
+++ b/pkg/election/lease_test.go
@@ -50,8 +50,8 @@ func TestLease(t *testing.T) {
 	defer clean()
 
 	// Create the lease.
-	lease1 := NewLease(client, "test_lease_1")
-	lease2 := NewLease(client, "test_lease_2")
+	lease1 := NewLease(client, "test_lease_1", "test_lease_1")
+	lease2 := NewLease(client, "test_lease_2", "test_lease_2")
 	re.True(lease1.IsExpired())
 	re.True(lease2.IsExpired())
 	re.NoError(lease1.Close())
@@ -109,7 +109,7 @@ func TestLeaseKeepAlive(t *testing.T) {
 	defer clean()
 
 	// Create the lease.
-	lease := NewLease(client, "test_lease")
+	lease := NewLease(client, "test_lease", "test_lease")
 
 	re.NoError(lease.Grant(defaultLeaseTimeout))
 	ch := lease.keepAliveWorker(ctx, 2*time.Second)

--- a/pkg/encryption/key_manager_test.go
+++ b/pkg/encryption/key_manager_test.go
@@ -77,7 +77,7 @@ func newTestKeyFile(t *testing.T, re *require.Assertions, key ...string) (keyFil
 }
 
 func newTestLeader(re *require.Assertions, client *clientv3.Client) *election.Leadership {
-	leader := election.NewLeadership(client, "test_leader", "test")
+	leader := election.NewLeadership(client, "test_leader", "test", "test_member")
 	timeout := int64(30000000) // about a year.
 	err := leader.Campaign(timeout, "")
 	re.NoError(err)

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -321,47 +321,12 @@ func (m *Member) MoveEtcdLeader(ctx context.Context, old, new uint64) error {
 	return nil
 }
 
-// GetEtcdLeader returns the embedded etcd server's view of the current etcd
-// leader ID, or 0 when it does not know one.
-//
-// The value is best effort and may be arbitrarily stale. `EtcdServer.lead` has a
-// single writer, `updateLead` inside the etcd Ready consumption loop, and that
-// loop persists every Ready synchronously before it consumes the next one. A
-// member whose storage stops completing writes therefore keeps reporting the
-// last leader it saw for as long as the stall lasts. That is what tikv/pd#7780
-// describes, and what tikv/pd#10671 and tikv/pd#10746 ran into.
-//
-// It must therefore never be the only thing a member consults to decide whether
-// it may keep serving as the PD leader. That decision belongs to the leader
-// lease behind `Member.IsServing`: a renewal has to be answered by this member's
-// own etcd server, which answers only after proving its own leadership, so the
-// lease cannot stay valid on a member that has stopped making progress. The two
-// signals do not share a failure mode, which is the point.
-//
-// The current callers are all consistent with that rule:
-//
-//   - `Server.campaignLeader` evaluates `Member.IsServing` first in the same
-//     tick, so this check only makes a step-down that would happen anyway
-//     happen sooner;
-//   - `Server.leaderLoop` uses it to avoid campaigning while another member is
-//     the etcd leader. That is a liveness heuristic: a campaign started on a
-//     stale value still cannot take leadership from anyone, because the campaign
-//     transaction requires the leader key to be absent;
-//   - `Member.preCheckLeader` and the members HTTP handler only compare it
-//     against 0;
-//   - `Member.CheckPriority` uses it to pick an etcd leader transfer target, and
-//     `GetMembers` reports it to clients. Both are best effort by nature;
-//   - `Server.leaderLoop` also passes it as the `old` argument to
-//     `MoveEtcdLeader`. That is an action rather than a guard, but it is only
-//     reached on the fail-safe side of the check, where the value says the
-//     leader is somebody else.
-//
-// A new caller that turns this value into a safety decision would turn
-// tikv/pd#7780 from a detection delay back into a correctness bug.
+// GetEtcdLeader returns the embedded etcd server's cached leader ID, or 0.
+// The value can remain stale while the Ready loop is blocked on storage, so it
+// must not be used alone to decide whether this member may serve (tikv/pd#7780).
 func (m *Member) GetEtcdLeader() uint64 {
 	failpoint.Inject("staleEtcdLeaderView", func(val failpoint.Value) {
-		// Reproduce the frozen cache of tikv/pd#7780: this member keeps
-		// believing that it is the etcd leader, whatever else happens.
+		// Simulate a stale local leader view.
 		if name, ok := val.(string); ok && name == m.Name() {
 			failpoint.Return(m.ID())
 		}

--- a/pkg/member/member.go
+++ b/pkg/member/member.go
@@ -321,8 +321,51 @@ func (m *Member) MoveEtcdLeader(ctx context.Context, old, new uint64) error {
 	return nil
 }
 
-// GetEtcdLeader returns the etcd leader ID.
+// GetEtcdLeader returns the embedded etcd server's view of the current etcd
+// leader ID, or 0 when it does not know one.
+//
+// The value is best effort and may be arbitrarily stale. `EtcdServer.lead` has a
+// single writer, `updateLead` inside the etcd Ready consumption loop, and that
+// loop persists every Ready synchronously before it consumes the next one. A
+// member whose storage stops completing writes therefore keeps reporting the
+// last leader it saw for as long as the stall lasts. That is what tikv/pd#7780
+// describes, and what tikv/pd#10671 and tikv/pd#10746 ran into.
+//
+// It must therefore never be the only thing a member consults to decide whether
+// it may keep serving as the PD leader. That decision belongs to the leader
+// lease behind `Member.IsServing`: a renewal has to be answered by this member's
+// own etcd server, which answers only after proving its own leadership, so the
+// lease cannot stay valid on a member that has stopped making progress. The two
+// signals do not share a failure mode, which is the point.
+//
+// The current callers are all consistent with that rule:
+//
+//   - `Server.campaignLeader` evaluates `Member.IsServing` first in the same
+//     tick, so this check only makes a step-down that would happen anyway
+//     happen sooner;
+//   - `Server.leaderLoop` uses it to avoid campaigning while another member is
+//     the etcd leader. That is a liveness heuristic: a campaign started on a
+//     stale value still cannot take leadership from anyone, because the campaign
+//     transaction requires the leader key to be absent;
+//   - `Member.preCheckLeader` and the members HTTP handler only compare it
+//     against 0;
+//   - `Member.CheckPriority` uses it to pick an etcd leader transfer target, and
+//     `GetMembers` reports it to clients. Both are best effort by nature;
+//   - `Server.leaderLoop` also passes it as the `old` argument to
+//     `MoveEtcdLeader`. That is an action rather than a guard, but it is only
+//     reached on the fail-safe side of the check, where the value says the
+//     leader is somebody else.
+//
+// A new caller that turns this value into a safety decision would turn
+// tikv/pd#7780 from a detection delay back into a correctness bug.
 func (m *Member) GetEtcdLeader() uint64 {
+	failpoint.Inject("staleEtcdLeaderView", func(val failpoint.Value) {
+		// Reproduce the frozen cache of tikv/pd#7780: this member keeps
+		// believing that it is the etcd leader, whatever else happens.
+		if name, ok := val.(string); ok && name == m.Name() {
+			failpoint.Return(m.ID())
+		}
+	})
 	return m.etcd.Server.Lead()
 }
 
@@ -347,7 +390,7 @@ func (m *Member) InitMemberInfo(advertiseClientUrls, advertisePeerUrls, name str
 	}
 	m.member = member
 	m.memberValue = string(data)
-	m.leadership = election.NewLeadership(m.client, m.GetElectionPath(), "leader election")
+	m.leadership = election.NewLeadership(m.client, m.GetElectionPath(), "leader election", member.GetName())
 	log.Info("member joining election", zap.Stringer("member-info", m.member))
 }
 

--- a/pkg/member/participant.go
+++ b/pkg/member/participant.go
@@ -83,7 +83,7 @@ func (p *Participant) InitInfo(participant participant, purpose string) {
 	}
 	p.participant = participant
 	p.participantValue = string(data)
-	p.leadership = election.NewLeadership(p.client, p.GetElectionPath(), purpose)
+	p.leadership = election.NewLeadership(p.client, p.GetElectionPath(), purpose, participant.GetName())
 	log.Info("participant joining election", zap.String("participant-info", participant.String()), zap.String("primary-path", p.GetElectionPath()))
 }
 

--- a/pkg/storage/storage_tso_test.go
+++ b/pkg/storage/storage_tso_test.go
@@ -39,7 +39,7 @@ var defaultContext = context.Background()
 func prepare(t *testing.T) (storage Storage, clean func(), leadership *election.Leadership) {
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
 	storage = NewStorageWithEtcdBackend(client)
-	leadership = election.NewLeadership(client, testLeaderKey, "storage_tso_test")
+	leadership = election.NewLeadership(client, testLeaderKey, "storage_tso_test", "test_member")
 	err := leadership.Campaign(60, testLeaderValue)
 	require.NoError(t, err)
 	return storage, clean, leadership

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -300,15 +300,6 @@ func newClient(tlsConfig *tls.Config, endpoints []string, opts ...CreateEtcdClie
 	}
 	lgc := zap.NewProductionConfig()
 	lgc.Encoding = log.ZapEncodingName
-	// AutoSyncInterval is deliberately left unset, and nothing in this
-	// repository calls client.Sync(). Together with the health checker being
-	// disabled for it, that is what keeps the election client talking only to
-	// its own member's etcd: a client that rediscovers the cluster would let a
-	// member whose own etcd has stopped making progress keep renewing its leader
-	// lease through a healthy peer, which is the failure tikv/pd#7780 and
-	// tikv/pd#10671 describe. Setting it here, or passing an opt that does,
-	// silently reintroduces that. Note that TestElectionClientStaysOnLocalMember
-	// only catches a sync interval short enough to fire during the test.
 	cfg := clientv3.Config{
 		Endpoints:            endpoints,
 		DialTimeout:          defaultEtcdClientTimeout,

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -300,6 +300,15 @@ func newClient(tlsConfig *tls.Config, endpoints []string, opts ...CreateEtcdClie
 	}
 	lgc := zap.NewProductionConfig()
 	lgc.Encoding = log.ZapEncodingName
+	// AutoSyncInterval is deliberately left unset, and nothing in this
+	// repository calls client.Sync(). Together with the health checker being
+	// disabled for it, that is what keeps the election client talking only to
+	// its own member's etcd: a client that rediscovers the cluster would let a
+	// member whose own etcd has stopped making progress keep renewing its leader
+	// lease through a healthy peer, which is the failure tikv/pd#7780 and
+	// tikv/pd#10671 describe. Setting it here, or passing an opt that does,
+	// silently reintroduces that. Note that TestElectionClientStaysOnLocalMember
+	// only catches a sync interval short enough to fire during the test.
 	cfg := clientv3.Config{
 		Endpoints:            endpoints,
 		DialTimeout:          defaultEtcdClientTimeout,

--- a/server/server.go
+++ b/server/server.go
@@ -442,6 +442,29 @@ func (s *Server) startClient() error {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()
 	}
 	// This etcd client will only be used to read and write the election-related data, such as leader key.
+	//
+	// Its health checker is disabled on purpose, and that must stay that way. The
+	// client is built from this member's own advertise client URLs and only the
+	// health checker ever rewrites that endpoint list, so leaving the checker off
+	// pins the client to the local etcd server for the lifetime of the process.
+	//
+	// That is what makes the leader lease a statement about *this* member.
+	// Renewing it has to be answered here, and when the local server still
+	// believes it is the etcd leader - which is exactly when the colocation check
+	// in `campaignLeader` is fooled too, since both read the same cached value -
+	// etcd answers only after proving that leadership with a linearizable read.
+	// A member that has stopped making progress cannot pass that, so the two
+	// signals cannot fail together. (When the local server knows it is not the
+	// leader, etcd instead forwards the renewal to the real one and the colocation
+	// check is the signal that fires.)
+	//
+	// With the checker enabled the client follows the healthy members instead, so
+	// a member whose own etcd has stopped making progress keeps renewing its
+	// leader lease through a peer and never gives up a leadership it can no
+	// longer serve. In tikv/pd#10671 that also blocked every other member from
+	// taking over, because the leader key hangs off the same lease.
+	//
+	// `TestElectionClientStaysOnLocalMember` guards this.
 	s.electionClient, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.AdvertiseClientUrls, etcdutil.ElectionEtcdClientPurpose, false)
 	if err != nil {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()

--- a/server/server.go
+++ b/server/server.go
@@ -441,30 +441,9 @@ func (s *Server) startClient() error {
 	if err != nil {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()
 	}
-	// This etcd client will only be used to read and write the election-related data, such as leader key.
-	//
-	// Its health checker is disabled on purpose, and that must stay that way. The
-	// client is built from this member's own advertise client URLs and only the
-	// health checker ever rewrites that endpoint list, so leaving the checker off
-	// pins the client to the local etcd server for the lifetime of the process.
-	//
-	// That is what makes the leader lease a statement about *this* member.
-	// Renewing it has to be answered here, and when the local server still
-	// believes it is the etcd leader - which is exactly when the colocation check
-	// in `campaignLeader` is fooled too, since both read the same cached value -
-	// etcd answers only after proving that leadership with a linearizable read.
-	// A member that has stopped making progress cannot pass that, so the two
-	// signals cannot fail together. (When the local server knows it is not the
-	// leader, etcd instead forwards the renewal to the real one and the colocation
-	// check is the signal that fires.)
-	//
-	// With the checker enabled the client follows the healthy members instead, so
-	// a member whose own etcd has stopped making progress keeps renewing its
-	// leader lease through a peer and never gives up a leadership it can no
-	// longer serve. In tikv/pd#10671 that also blocked every other member from
-	// taking over, because the leader key hangs off the same lease.
-	//
-	// `TestElectionClientStaysOnLocalMember` guards this.
+	// Keep this client pinned to local etcd. Local lease renewal verifies this
+	// member's etcd leadership, preventing a stalled member from renewing through
+	// a healthy peer (tikv/pd#10671).
 	s.electionClient, err = etcdutil.CreateEtcdClient(tlsConfig, etcdCfg.AdvertiseClientUrls, etcdutil.ElectionEtcdClientPurpose, false)
 	if err != nil {
 		return errs.ErrNewEtcdClient.Wrap(err).GenWithStackByCause()

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -429,22 +429,9 @@ func sendRequest(re *require.Assertions, wg *sync.WaitGroup, done <-chan bool, a
 	}
 }
 
-// TestElectionClientStaysOnLocalMember pins down the property that the PD
-// leader's ability to notice its own failure rests on: the election client must
-// only ever talk to this member's own etcd server.
-//
-// It is built from the local advertise client URLs, and only the health checker
-// ever rewrites that list, so the property holds exactly as long as the checker
-// stays disabled for this client. If it were enabled - as it is for the general
-// server client, which this test also exercises so that a checker that never ran
-// cannot make the assertion pass by accident - the client would follow the
-// healthy members, and a member whose own etcd had stopped making progress would
-// keep renewing its leader lease through a peer. See tikv/pd#7780, tikv/pd#10671
-// and tikv/pd#10746.
 func TestElectionClientStaysOnLocalMember(t *testing.T) {
 	re := require.New(t)
-	// Without this the health checker only ticks every 10s, which is longer than
-	// the test is willing to wait for the contrast assertion below.
+	// Speed up endpoint discovery.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/utils/etcdutil/fastTick", "return(true)"))
 	defer func() {
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/fastTick"))
@@ -461,34 +448,14 @@ func TestElectionClientStaysOnLocalMember(t *testing.T) {
 	for name, svr := range cluster.GetServers() {
 		s := svr.GetServer()
 		localURLs := strings.Split(s.GetConfig().AdvertiseClientUrls, ",")
-		// The general server client is health checked, so it discovers its peers
-		// and ends up with more endpoints than the member started with.
+		// Confirm discovery is active before checking the election client.
 		testutil.Eventually(re, func() bool {
 			return len(s.GetClient().Endpoints()) > len(localURLs)
 		})
-		// The election client must not have moved.
 		re.Equal(localURLs, s.GetMember().Client().Endpoints(), name)
 	}
 }
 
-// TestPDLeaderStepsDownWhenLeaseIsLostWithStaleEtcdLeaderView reproduces the
-// shape of tikv/pd#10671 and pins down the property that keeps tikv/pd#7780 from
-// being a correctness bug: a PD leader that has lost etcd leadership gives up
-// because its lease is gone, not because it noticed the change.
-//
-// The test runs in two phases. First it blinds the member with the
-// `staleEtcdLeaderView` failpoint - which freezes its cached etcd leader ID on
-// itself, the defect tikv/pd#7780 describes - and moves etcd leadership away for
-// real. That is the incident: a member holding a PD leadership it can no longer
-// justify, with the colocation check in `campaignLeader` unable to notice. It
-// must keep serving, which is what makes the second phase meaningful. Then the
-// leader lease is taken away, standing in for the renewals a member with stuck
-// storage can no longer complete, and the member must step down and let the new
-// etcd leader take over.
-//
-// Several lease derived paths can be the proximate trigger, and the test
-// deliberately does not care which: what is guarded is that losing the lease is
-// sufficient on its own, with the etcd leader view offering no help at all.
 func TestPDLeaderStepsDownWhenLeaseIsLostWithStaleEtcdLeaderView(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -502,17 +469,16 @@ func TestPDLeaderStepsDownWhenLeaseIsLostWithStaleEtcdLeaderView(t *testing.T) {
 	re.NotEmpty(oldLeaderName)
 	oldLeaderServer := cluster.GetServer(oldLeaderName)
 	oldLeader := oldLeaderServer.GetServer()
-	var peer *tests.TestServer
+	var newEtcdLeaderServer *tests.TestServer
 	for name, svr := range cluster.GetServers() {
 		if name != oldLeaderName {
-			peer = svr
+			newEtcdLeaderServer = svr
 			break
 		}
 	}
-	re.NotNil(peer)
+	re.NotNil(newEtcdLeaderServer)
 
-	// Blind the member before anything else changes, so that its own colocation
-	// check cannot be what makes it step down later.
+	// Keep the colocation check stale so lease loss is the only step-down signal.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/staleEtcdLeaderView",
 		fmt.Sprintf("return(\"%s\")", oldLeaderName)))
 	defer func() {
@@ -520,45 +486,29 @@ func TestPDLeaderStepsDownWhenLeaseIsLostWithStaleEtcdLeaderView(t *testing.T) {
 	}()
 	re.Equal(oldLeader.GetMember().ID(), oldLeader.GetMember().GetEtcdLeader())
 
-	// Now really move etcd leadership away. The member cannot see this, exactly
-	// as it could not in the incident, and it also has to be true for a peer to
-	// be allowed to campaign at all.
+	// Move etcd leadership while the old member still observes itself as leader.
 	testutil.Eventually(re, func() bool {
-		return oldLeaderServer.MoveEtcdLeader(oldLeaderServer.GetServerID(), peer.GetServerID()) == nil
+		return oldLeaderServer.MoveEtcdLeader(oldLeaderServer.GetServerID(), newEtcdLeaderServer.GetServerID()) == nil
 	})
 
-	// Control: while the lease is alive and the view is blinded, nothing makes
-	// the member give up, however wrong holding on has become. This is the state
-	// tikv/pd#10671 was stuck in, and it is what the lease has to break out of -
-	// without it the assertions below would pass for the wrong reason.
+	// Negative control: a stale view alone must not end a term with a valid lease.
 	time.Sleep(2 * time.Second)
 	re.True(oldLeader.IsServing())
 	re.Equal(oldLeaderName, cluster.GetLeader())
 
-	// Take the lease away through the peer's client, leaving the old leader's own
-	// code path untouched.
 	lease := oldLeader.GetMember().GetLeadership().GetLease()
 	re.NotNil(lease)
 	leaseID := lease.GetID()
 	re.NotEqual(clientv3.NoLease, leaseID)
-	_, err = peer.GetServer().GetClient().Revoke(ctx, leaseID)
+	_, err = newEtcdLeaderServer.GetServer().GetClient().Revoke(ctx, leaseID)
 	re.NoError(err)
 
-	// The lease is the only signal left, and it must be enough.
 	testutil.Eventually(re, func() bool {
 		return !oldLeader.IsServing() && oldLeader.GetRaftCluster() == nil
 	}, testutil.WithWaitFor(30*time.Second))
 	re.NotEqual(oldLeaderName, waitLeaderChange(re, cluster, oldLeaderName))
 }
 
-// TestPDLeaderStepsDownWhenRenewalsFail covers the step the other tests skip:
-// that the lease deadline itself is what ends the term. The lease is left in
-// place and only its renewals are made to fail, so the member has to notice
-// through `expireTime` elapsing rather than through the key disappearing.
-//
-// The etcd leader view is frozen on the member for the whole test, so the
-// colocation check in `campaignLeader` cannot be the thing that fires. That
-// leaves the lease as the only remaining signal, which is the point.
 func TestPDLeaderStepsDownWhenRenewalsFail(t *testing.T) {
 	re := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -573,7 +523,7 @@ func TestPDLeaderStepsDownWhenRenewalsFail(t *testing.T) {
 	oldLeaderServer := cluster.GetServer(oldLeaderName)
 	oldLeader := oldLeaderServer.GetServer()
 
-	// Blind the colocation check so it cannot be what ends the term.
+	// Disable the colocation signal.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/staleEtcdLeaderView",
 		fmt.Sprintf("return(\"%s\")", oldLeaderName)))
 	defer func() {
@@ -581,15 +531,7 @@ func TestPDLeaderStepsDownWhenRenewalsFail(t *testing.T) {
 	}()
 	re.True(oldLeader.IsServing())
 
-	// Stand in for a local etcd that can no longer answer a renewal, on this
-	// member only. The renewal really does reach etcd and succeed, so nothing
-	// revokes the lease and the leader key stays where it is: the local deadline
-	// is the only thing left that can end the term, which is the point.
-	//
-	// The target is named because `failpoint.Enable` arms the injection point for
-	// the whole process and every member of this cluster runs in it. Without the
-	// name the successor's renewals would fail too and the cluster would never
-	// settle on a new leader.
+	// Keep the etcd lease alive while only the old leader observes renewal failures.
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/keepAliveFailed",
 		fmt.Sprintf("return(\"leader election@%s\")", oldLeaderName)))
 	defer func() {

--- a/tests/server/member/member_test.go
+++ b/tests/server/member/member_test.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/goleak"
 
 	"github.com/pingcap/errors"
@@ -425,4 +427,177 @@ func sendRequest(re *require.Assertions, wg *sync.WaitGroup, done <-chan bool, a
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+// TestElectionClientStaysOnLocalMember pins down the property that the PD
+// leader's ability to notice its own failure rests on: the election client must
+// only ever talk to this member's own etcd server.
+//
+// It is built from the local advertise client URLs, and only the health checker
+// ever rewrites that list, so the property holds exactly as long as the checker
+// stays disabled for this client. If it were enabled - as it is for the general
+// server client, which this test also exercises so that a checker that never ran
+// cannot make the assertion pass by accident - the client would follow the
+// healthy members, and a member whose own etcd had stopped making progress would
+// keep renewing its leader lease through a peer. See tikv/pd#7780, tikv/pd#10671
+// and tikv/pd#10746.
+func TestElectionClientStaysOnLocalMember(t *testing.T) {
+	re := require.New(t)
+	// Without this the health checker only ticks every 10s, which is longer than
+	// the test is willing to wait for the contrast assertion below.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/utils/etcdutil/fastTick", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/fastTick"))
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 3)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+
+	for name, svr := range cluster.GetServers() {
+		s := svr.GetServer()
+		localURLs := strings.Split(s.GetConfig().AdvertiseClientUrls, ",")
+		// The general server client is health checked, so it discovers its peers
+		// and ends up with more endpoints than the member started with.
+		testutil.Eventually(re, func() bool {
+			return len(s.GetClient().Endpoints()) > len(localURLs)
+		})
+		// The election client must not have moved.
+		re.Equal(localURLs, s.GetMember().Client().Endpoints(), name)
+	}
+}
+
+// TestPDLeaderStepsDownWhenLeaseIsLostWithStaleEtcdLeaderView reproduces the
+// shape of tikv/pd#10671 and pins down the property that keeps tikv/pd#7780 from
+// being a correctness bug: a PD leader that has lost etcd leadership gives up
+// because its lease is gone, not because it noticed the change.
+//
+// The test runs in two phases. First it blinds the member with the
+// `staleEtcdLeaderView` failpoint - which freezes its cached etcd leader ID on
+// itself, the defect tikv/pd#7780 describes - and moves etcd leadership away for
+// real. That is the incident: a member holding a PD leadership it can no longer
+// justify, with the colocation check in `campaignLeader` unable to notice. It
+// must keep serving, which is what makes the second phase meaningful. Then the
+// leader lease is taken away, standing in for the renewals a member with stuck
+// storage can no longer complete, and the member must step down and let the new
+// etcd leader take over.
+//
+// Several lease derived paths can be the proximate trigger, and the test
+// deliberately does not care which: what is guarded is that losing the lease is
+// sufficient on its own, with the etcd leader view offering no help at all.
+func TestPDLeaderStepsDownWhenLeaseIsLostWithStaleEtcdLeaderView(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 3)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+
+	oldLeaderName := cluster.WaitLeader()
+	re.NotEmpty(oldLeaderName)
+	oldLeaderServer := cluster.GetServer(oldLeaderName)
+	oldLeader := oldLeaderServer.GetServer()
+	var peer *tests.TestServer
+	for name, svr := range cluster.GetServers() {
+		if name != oldLeaderName {
+			peer = svr
+			break
+		}
+	}
+	re.NotNil(peer)
+
+	// Blind the member before anything else changes, so that its own colocation
+	// check cannot be what makes it step down later.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/staleEtcdLeaderView",
+		fmt.Sprintf("return(\"%s\")", oldLeaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/staleEtcdLeaderView"))
+	}()
+	re.Equal(oldLeader.GetMember().ID(), oldLeader.GetMember().GetEtcdLeader())
+
+	// Now really move etcd leadership away. The member cannot see this, exactly
+	// as it could not in the incident, and it also has to be true for a peer to
+	// be allowed to campaign at all.
+	testutil.Eventually(re, func() bool {
+		return oldLeaderServer.MoveEtcdLeader(oldLeaderServer.GetServerID(), peer.GetServerID()) == nil
+	})
+
+	// Control: while the lease is alive and the view is blinded, nothing makes
+	// the member give up, however wrong holding on has become. This is the state
+	// tikv/pd#10671 was stuck in, and it is what the lease has to break out of -
+	// without it the assertions below would pass for the wrong reason.
+	time.Sleep(2 * time.Second)
+	re.True(oldLeader.IsServing())
+	re.Equal(oldLeaderName, cluster.GetLeader())
+
+	// Take the lease away through the peer's client, leaving the old leader's own
+	// code path untouched.
+	lease := oldLeader.GetMember().GetLeadership().GetLease()
+	re.NotNil(lease)
+	leaseID := lease.GetID()
+	re.NotEqual(clientv3.NoLease, leaseID)
+	_, err = peer.GetServer().GetClient().Revoke(ctx, leaseID)
+	re.NoError(err)
+
+	// The lease is the only signal left, and it must be enough.
+	testutil.Eventually(re, func() bool {
+		return !oldLeader.IsServing() && oldLeader.GetRaftCluster() == nil
+	}, testutil.WithWaitFor(30*time.Second))
+	re.NotEqual(oldLeaderName, waitLeaderChange(re, cluster, oldLeaderName))
+}
+
+// TestPDLeaderStepsDownWhenRenewalsFail covers the step the other tests skip:
+// that the lease deadline itself is what ends the term. The lease is left in
+// place and only its renewals are made to fail, so the member has to notice
+// through `expireTime` elapsing rather than through the key disappearing.
+//
+// The etcd leader view is frozen on the member for the whole test, so the
+// colocation check in `campaignLeader` cannot be the thing that fires. That
+// leaves the lease as the only remaining signal, which is the point.
+func TestPDLeaderStepsDownWhenRenewalsFail(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := tests.NewTestCluster(ctx, 3)
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+
+	oldLeaderName := cluster.WaitLeader()
+	re.NotEmpty(oldLeaderName)
+	oldLeaderServer := cluster.GetServer(oldLeaderName)
+	oldLeader := oldLeaderServer.GetServer()
+
+	// Blind the colocation check so it cannot be what ends the term.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/member/staleEtcdLeaderView",
+		fmt.Sprintf("return(\"%s\")", oldLeaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/member/staleEtcdLeaderView"))
+	}()
+	re.True(oldLeader.IsServing())
+
+	// Stand in for a local etcd that can no longer answer a renewal, on this
+	// member only. The renewal really does reach etcd and succeed, so nothing
+	// revokes the lease and the leader key stays where it is: the local deadline
+	// is the only thing left that can end the term, which is the point.
+	//
+	// The target is named because `failpoint.Enable` arms the injection point for
+	// the whole process and every member of this cluster runs in it. Without the
+	// name the successor's renewals would fail too and the cluster would never
+	// settle on a new leader.
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/election/keepAliveFailed",
+		fmt.Sprintf("return(\"leader election@%s\")", oldLeaderName)))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/keepAliveFailed"))
+	}()
+
+	testutil.Eventually(re, func() bool {
+		return !oldLeader.IsServing()
+	}, testutil.WithWaitFor(30*time.Second))
+	re.NotEqual(oldLeaderName, waitLeaderChange(re, cluster, oldLeaderName))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11106, ref #10671, ref #10746, ref #7780

#9986 made the etcd client health checker optional and created the election client with it disabled. The election client is built from the member's own advertise client URLs, and only the health checker rewrites that endpoint list, so leaving it off confines leader lease renewals to the local etcd server.

This PR records the constraint and adds regression tests for it. It changes no production behavior. It merged on 2026-09-02; #11147 handles identity ordering and #11177 handles early RaftCluster cancellation.

### What is changed and how does it work?

```commit-message
Record why the election client's health checker must stay disabled: at the call
site, and in newClient, where AutoSyncInterval must remain unset. Document on
GetEtcdLeader what may and may not depend on it, describing its safe-use boundary.

Add three integration tests. The first asserts that the election client's
endpoints stay equal to the local advertise URLs while the health checked
server client discovers its peers. The other two assert that a member ends its
term when its renewals fail locally, and when its lease is revoked, in both
cases with the colocation check blinded so that it cannot be what fires.

Two failpoints support them: staleEtcdLeaderView on Member.GetEtcdLeader,
matched by member name, and keepAliveFailed in the lease keepalive worker,
matched as "<purpose>@<name>" so that enabling it affects a single member of an
in-process cluster.

No behaviour change.
```

### Check List

Tests

- Integration test

### Release note

```release-note
None.
```
