### PR TITLE
tools: add region meta consistency checker

### DIFF
--- a/tools/pd-ctl/main.go
+++ b/tools/pd-ctl/main.go
@@ -15,10 +15,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
-	"syscall"
 
 	"go.uber.org/zap/zapcore"
 
@@ -34,26 +34,7 @@ func main() {
 		os.Args = append(os.Args, "-u", pdAddr)
 	}
 
-	sc := make(chan os.Signal, 1)
-	signal.Notify(sc,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
-
-	go func() {
-		sig := <-sc
-		fmt.Printf("\nGot signal [%v] to exit.\n", sig)
-		switch sig {
-		case syscall.SIGTERM:
-			os.Exit(0)
-		default:
-			os.Exit(1)
-		}
-		if command.PDCli != nil {
-			command.PDCli.Close()
-		}
-	}()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 
 	log.SetLevel(zapcore.FatalLevel)
 	var inputs []string
@@ -66,5 +47,13 @@ func main() {
 		}
 		inputs = in
 	}
-	pdctl.MainStart(append(os.Args[1:], inputs...))
+	exitCode := pdctl.MainStartContext(ctx, append(os.Args[1:], inputs...))
+	if ctx.Err() != nil {
+		exitCode = 130
+	}
+	stop()
+	if command.PDCli != nil {
+		command.PDCli.Close()
+	}
+	os.Exit(exitCode)
 }

--- a/tools/pd-ctl/pdctl/command/exit_error.go
+++ b/tools/pd-ctl/pdctl/command/exit_error.go
@@ -1,0 +1,51 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"errors"
+	"fmt"
+)
+
+type commandExitError struct {
+	code   int
+	err    error
+	silent bool
+}
+
+func (e *commandExitError) Error() string {
+	if e.err == nil {
+		return fmt.Sprintf("command exited with status %d", e.code)
+	}
+	return e.err.Error()
+}
+
+func (e *commandExitError) Unwrap() error {
+	return e.err
+}
+
+func newCommandExitError(code int, err error, silent bool) error {
+	return &commandExitError{code: code, err: err, silent: silent}
+}
+
+// ExitCode returns a command-specific process exit code and whether the error
+// has already been represented in the command output.
+func ExitCode(err error) (code int, silent bool) {
+	var exitErr *commandExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.code, exitErr.silent
+	}
+	return 1, false
+}

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io"
@@ -170,7 +171,7 @@ func doRequest(cmd *cobra.Command, prefix string, method string, customHeader ht
 
 	endpoints := getEndpoints(cmd)
 	err := tryURLs(cmd, endpoints, func(endpoint string) error {
-		return do(endpoint, prefix, method, &resp, header, b)
+		return do(cmd.Context(), endpoint, prefix, method, &resp, header, b)
 	})
 	return resp, err
 }
@@ -185,7 +186,7 @@ func doRequestSingleEndpoint(cmd *cobra.Command, endpoint, prefix, method string
 	header := buildNoProxyHeader(cmd, customHeader)
 
 	err := requestURL(cmd, endpoint, func(endpoint string) error {
-		return do(endpoint, prefix, method, &resp, header, b)
+		return do(cmd.Context(), endpoint, prefix, method, &resp, header, b)
 	})
 	return resp, err
 }
@@ -287,7 +288,7 @@ func requestJSON(cmd *cobra.Command, method, prefix string, input map[string]any
 		url := endpoint + "/" + prefix
 		switch method {
 		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodGet:
-			req, err = http.NewRequest(method, url, bytes.NewBuffer(data))
+			req, err = http.NewRequestWithContext(cmd.Context(), method, url, bytes.NewBuffer(data))
 			if err != nil {
 				return err
 			}
@@ -327,7 +328,7 @@ func patchJSON(cmd *cobra.Command, prefix string, input map[string]any) {
 }
 
 // do send a request to server. Default is Get.
-func do(endpoint, prefix, method string, resp *string, customHeader http.Header, b *bodyOption) error {
+func do(ctx context.Context, endpoint, prefix, method string, resp *string, customHeader http.Header, b *bodyOption) error {
 	var err error
 	url := endpoint + "/" + prefix
 	if method == "" {
@@ -335,7 +336,7 @@ func do(endpoint, prefix, method string, resp *string, customHeader http.Header,
 	}
 	var req *http.Request
 
-	req, err = http.NewRequest(method, url, b.body)
+	req, err = http.NewRequestWithContext(ctx, method, url, b.body)
 	if err != nil {
 		return err
 	}

--- a/tools/pd-ctl/pdctl/command/global_test.go
+++ b/tools/pd-ctl/pdctl/command/global_test.go
@@ -15,14 +15,42 @@
 package command
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRequestUsesCommandContext(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		var response string
+		result <- do(ctx, server.URL, "", http.MethodGet, &response, nil, &bodyOption{})
+	}()
+	<-started
+	cancel()
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("request did not stop after context cancellation")
+	}
+}
 
 func TestParseTLSConfig(t *testing.T) {
 	re := require.New(t)

--- a/tools/pd-ctl/pdctl/command/region_command.go
+++ b/tools/pd-ctl/pdctl/command/region_command.go
@@ -80,6 +80,7 @@ func NewRegionCommand() *cobra.Command {
 	r.AddCommand(NewRegionsByKeysCommand())
 	r.AddCommand(NewRangesWithRangeHolesCommand())
 	r.AddCommand(NewInvalidTiFlashKeyCommand())
+	r.AddCommand(NewRegionMetaConsistencyCommand())
 
 	topRead := &cobra.Command{
 		Use:   `topread [byte|query] <limit> [--jq="<query string>"]`,

--- a/tools/pd-ctl/pdctl/command/region_meta_consistency_command.go
+++ b/tools/pd-ctl/pdctl/command/region_meta_consistency_command.go
@@ -1,0 +1,118 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tikv/pd/tools/pd-ctl/pdctl/command/regionmeta"
+)
+
+// NewRegionMetaConsistencyCommand returns the region meta consistency command.
+func NewRegionMetaConsistencyCommand() *cobra.Command {
+	defaults := regionmeta.DefaultConfig()
+	var (
+		batchSize           int
+		interval            time.Duration
+		timeout             time.Duration
+		maxRuntime          time.Duration
+		retries             int
+		scanRetries         int
+		confirmLimit        int
+		workDir             string
+		maxTemporaryDiskMiB int64
+		maxOutputMiB        int64
+		output              string
+		authorizationFile   string
+	)
+	command := &cobra.Command{
+		Use:   "meta-consistency",
+		Short: "compare region meta across all PD members",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				cmd.Root().SilenceUsage = true
+				return newCommandExitError(2, err, false)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.Root().SilenceUsage = true
+			if maxTemporaryDiskMiB <= 0 || maxOutputMiB <= 0 ||
+				maxTemporaryDiskMiB > math.MaxInt64/(1024*1024) || maxOutputMiB > math.MaxInt64/(1024*1024) {
+				return newCommandExitError(2, errors.New("temporary disk and output limits must be positive MiB values"), false)
+			}
+			pdAddress, err := cmd.Flags().GetString("pd")
+			if err != nil {
+				return newCommandExitError(2, err, false)
+			}
+			tlsConfig, err := parseTLSConfig(cmd)
+			if err != nil {
+				return newCommandExitError(2, err, false)
+			}
+			cfg := regionmeta.Config{
+				Endpoints:             strings.Split(pdAddress, ","),
+				TLSConfig:             tlsConfig,
+				AuthorizationFile:     authorizationFile,
+				BatchSize:             batchSize,
+				Interval:              interval,
+				Timeout:               timeout,
+				MaxRuntime:            maxRuntime,
+				Retries:               retries,
+				ScanRetries:           scanRetries,
+				ConfirmLimit:          confirmLimit,
+				ConfirmationDelay:     time.Second,
+				WorkDir:               workDir,
+				MaxTemporaryDiskBytes: maxTemporaryDiskMiB * 1024 * 1024,
+				MaxOutputBytes:        maxOutputMiB * 1024 * 1024,
+				Output:                output,
+			}
+			outcome, err := regionmeta.Run(cmd.Context(), cfg, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			if err != nil {
+				return newCommandExitError(2, err, false)
+			}
+			switch outcome.Status {
+			case regionmeta.StatusConsistent:
+				return nil
+			case regionmeta.StatusInconsistent:
+				return newCommandExitError(1, nil, true)
+			default:
+				return newCommandExitError(2, nil, true)
+			}
+		},
+	}
+	command.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		cmd.Root().SilenceUsage = true
+		return newCommandExitError(2, err, false)
+	})
+	flags := command.Flags()
+	flags.IntVar(&batchSize, "batch-size", defaults.BatchSize, "maximum Regions per HTTP request")
+	flags.DurationVar(&interval, "interval", defaults.Interval, "global interval per HTTP request")
+	flags.DurationVar(&timeout, "timeout", defaults.Timeout, "timeout per HTTP request")
+	flags.DurationVar(&maxRuntime, "max-runtime", defaults.MaxRuntime, "wall-clock limit for the complete check")
+	flags.IntVar(&retries, "retries", defaults.Retries, "additional retries per HTTP request")
+	flags.IntVar(&scanRetries, "scan-retries", defaults.ScanRetries, "whole-cluster retries after an unstable scan")
+	flags.IntVar(&confirmLimit, "confirm-limit", defaults.ConfirmLimit, "maximum differing Regions to recheck")
+	flags.StringVar(&workDir, "work-dir", defaults.WorkDir, "directory for temporary files")
+	flags.Int64Var(&maxTemporaryDiskMiB, "max-temporary-disk-mib", defaults.MaxTemporaryDiskBytes/(1024*1024), "temporary JSON hard limit in MiB")
+	flags.Int64Var(&maxOutputMiB, "max-output-mib", defaults.MaxOutputBytes/(1024*1024), "JSON report hard limit in MiB")
+	flags.StringVar(&output, "output", defaults.Output, "JSON report path, or '-' for stdout")
+	flags.StringVar(&authorizationFile, "authorization-file", "", "file containing one complete Authorization header value")
+	return command
+}

--- a/tools/pd-ctl/pdctl/command/regionmeta/README.md
+++ b/tools/pd-ctl/pdctl/command/regionmeta/README.md
@@ -1,14 +1,14 @@
 # PD region meta consistency check
 
-`pd-ctl region meta-consistency` 检查同一 PD 集群中 Leader 与各 Follower 本地缓存的 region meta 是否一致。命令直接访问每个 PD 实例，以小批量、同批跨实例并发、单实例串行和全局限速方式扫描，输出一个 JSON 报告。
+`pd-ctl region meta-consistency` compares the region meta cached locally by the PD leader and every follower in the same cluster. It scans each PD instance directly in small batches, starts the same batch concurrently across instances, keeps requests serial per instance, applies a global rate limit, and produces one JSON report.
 
-本命令使用 `/members`、`/regions/count`、`/regions/key` 和 `/region/id/{id}` API，并依赖 Follower 本地读取 Header。兼容性测试覆盖当前 master 和 [`v8.5.4-20260625-8b1b130`](https://github.com/tikv/pd/releases/tag/v8.5.4-20260625-8b1b130)；用于其他版本前，应确认这些接口的行为兼容。
+The command uses the `/members`, `/regions/count`, `/regions/key`, and `/region/id/{id}` APIs and depends on follower-local read headers. Compatibility tests cover current master and [`v8.5.4-20260625-8b1b130`](https://github.com/tikv/pd/releases/tag/v8.5.4-20260625-8b1b130). Verify these API semantics before using the command with another PD version.
 
-> 全量检查会增加 PD 的 HTTP 处理、JSON 序列化、网络流量和短时 Region tree 读锁开销。默认参数用于限制这些开销；如果生产要求严格零扰动，不应执行本命令。
+> A full scan adds PD HTTP processing, JSON serialization, network traffic, and short-lived Region tree read-lock work. The defaults bound these costs. Do not run this command when any production impact is unacceptable.
 
-## 快速执行
+## Quick start
 
-建议从同 VPC 的独立运维机执行，并为每轮检查使用新的输出文件：
+Run the command from a separate operations host in the same VPC and use a new output file for every check:
 
 ```bash
 report="region-meta-report-$(date -u +%Y%m%dT%H%M%SZ).json"
@@ -22,79 +22,79 @@ printf 'exit_code=%s report=%s\n' "$rc" "$report"
 test ! -s "$report" || jq '{status, summary, confirmation, nodes}' "$report"
 ```
 
-一个 URL 仅作为 seed。命令通过 `/pd/api/v1/members` 发现成员，并直连每个成员公布的 `client_urls`；不要使用负载均衡地址代替成员直连地址。
+The supplied URL is only a seed. The command discovers the cluster through `/pd/api/v1/members` and connects directly to each advertised `client_urls` address. Do not use a load balancer address in place of direct member addresses.
 
-| 退出码 | 状态 | 含义 |
+| Exit code | Status | Meaning |
 | ---: | --- | --- |
-| `0` | `consistent` | 本轮没有保留差异。 |
-| `1` | `inconsistent` | 检查成功，并确认至少一个稳定差异。 |
-| `2` | `incomplete` 或无新报告 | 证据不足或执行失败；检查 stderr，不要沿用旧报告。 |
-| `130` | 无新报告 | 用户通过 Ctrl-C 中断。 |
+| `0` | `consistent` | No difference remained in this observation. |
+| `1` | `inconsistent` | The check completed and confirmed at least one stable difference. |
+| `2` | `incomplete` or no new report | The evidence was insufficient or execution failed. Inspect stderr and do not reuse an older report. |
+| `130` | No new report | The user interrupted the command with Ctrl-C. |
 
-退出码 `1` 表示发现不一致，不是命令执行失败。
+Exit code `1` means that the command found an inconsistency; it does not mean that command execution failed.
 
-## 执行条件
+## Prerequisites
 
-- 集群至少有两个 PD 成员；执行机能直连所有成员公布的 `client_urls`。
-- Follower Region Syncer 正常，能够处理携带 `PD-Allow-Follower-Handle: true` 的本地读取请求。
-- 在业务低峰执行，PD CPU、内存、业务延迟和现有告警均有明确余量。
-- 扫描期间不安排 PD 重启、扩缩容或主动 Leader 切换。
-- `--work-dir` 与输出目录已存在、可写且空间充足；报告按内部诊断数据保护。
+- The cluster has at least two PD members, and the execution host can connect directly to every advertised `client_urls` address.
+- The follower Region Syncer is healthy and follower-local reads with `PD-Allow-Follower-Handle: true` are available.
+- PD CPU, memory, request latency, and existing alerts have clear headroom. Run the check during an off-peak window.
+- No PD restart, scale operation, or planned PD leader transfer occurs during the scan.
+- The `--work-dir` and output directories already exist, are writable, and have enough free space. Treat the report as internal diagnostic data.
 
-推荐独立检查机至少为 `1 vCPU / 512 MiB RAM / 3 GiB 可用磁盘 / 100 Mbps`；建议配置为 `2 vCPU / 1 GiB RAM / 5 GiB 可用磁盘`。
+The minimum recommended independent checker host is `1 vCPU / 512 MiB RAM / 3 GiB free disk / 100 Mbps`. Prefer `2 vCPU / 1 GiB RAM / 5 GiB free disk`.
 
-## 检查内容
+## Compared fields
 
-| 类别 | 比较字段 |
+| Category | Fields |
 | --- | --- |
 | Region | Region ID |
-| Key Range | `start_key`、`end_key` |
-| Epoch | `conf_ver`、`version` |
-| Peers | `id`、`store_id`、`role`、`is_witness` |
-| Region Leader Peer | `id`、`store_id`、`role`、`is_witness` |
+| Key range | `start_key`, `end_key` |
+| Epoch | `conf_ver`, `version` |
+| Peers | `id`, `store_id`, `role`, `is_witness` |
+| Region leader peer | `id`, `store_id`, `role`, `is_witness` |
 
-流量、大小、`pending_peers`、`down_peers`、Buckets 等心跳统计字段不参与比较；Peer 数组顺序也不参与比较。报告中的 `reference` 只是扫描开始时的 PD Leader 身份，不代表该节点的数据必然正确。`leader_peer` 表示 Region Leader Peer，与 PD Leader 是两个概念。
+Heartbeat statistics such as traffic, size, `pending_peers`, `down_peers`, and buckets are not compared. Peer array order is also ignored. The report's `reference` identifies the PD leader at the start of the scan; it does not assert that this member's data is correct. `leader_peer` means the Region leader peer, not the PD leader.
 
-## 工作流程与结论边界
+## Workflow and result boundaries
 
-1. 读取成员、PD Leader 和 cluster ID，为每个 PD 实例建立直接 HTTP 连接。
-2. 同时读取各实例 Region 数，通过 `/pd/api/v1/regions/key` 按 Key Range 分页；同一批请求尽量同时开始。
-3. 每个实例最多有一个在途请求。所有实例共享请求预算：一组包含 N 个请求时消耗 N 份预算，因此默认长期总速率不超过 20 requests/s。
-4. 请求携带 `PD-Allow-Follower-Handle: true`、`PD-Redirector: pd-ctl-region-meta-consistency` 和 `X-Caller-ID: pd-ctl`，直接读取目标实例的本地 Region cache。
-5. 相同数据比较后立即释放；只有差异写入有界临时 JSONL，并按 Region ID 外部归并排序。
-6. 对 Region ID 最小的前 `--confirm-limit` 个差异等待 1 秒后并发复查。结束时再次核对 PD Leader、cluster ID 和成员身份。
+1. Read the member list, PD leader, and cluster ID, then establish a direct HTTP connection to every PD instance.
+2. Read Region counts from all instances and page through `/pd/api/v1/regions/key` by key range. Requests for the same batch start as close together as possible.
+3. Keep at most one request in flight per instance. All instances share one request budget: a group containing N requests consumes N budget units, so the default long-term aggregate rate does not exceed 20 requests/s.
+4. Send `PD-Allow-Follower-Handle: true`, `PD-Redirector: pd-ctl-region-meta-consistency`, and `X-Caller-ID: pd-ctl` so each target instance serves its local Region cache.
+5. Release matching data immediately. Write only differences to bounded temporary JSONL files and externally merge-sort them by Region ID.
+6. Wait one second and concurrently recheck up to `--confirm-limit` differences with the smallest Region IDs. Verify the PD leader, cluster ID, and membership again before producing the result.
 
-只有某节点的扫描前数量、实际扫描数量、扫描后数量相等，本轮扫描才会被接受。默认不自动重扫，避免在 Region 持续变化时放大负载。
+A member scan is accepted only when its Region count before the scan, number of scanned Regions, and Region count after the scan are equal. The default does not retry the full scan, which avoids multiplying load while Region metadata is changing continuously.
 
-多个独立 HTTP 请求不能组成分布式原子快照：
+Independent HTTP requests cannot form a distributed atomic snapshot:
 
-- `consistent` 表示本轮观察没有留下差异，不等价于线性一致性证明。
-- `inconsistent` 表示至少一个已复查差异保持相同，是较强的不一致证据。
-- `incomplete` 表示证据不足，不能解释为一致。
+- `consistent` means that no difference remained in this observation. It is not proof of linearizable equality.
+- `inconsistent` means that at least one rechecked difference remained unchanged, which is strong evidence of divergence.
+- `incomplete` means that the evidence is insufficient and must not be interpreted as consistency.
 
-## 参数
+## Parameters
 
-完整参数以 `pd-ctl region meta-consistency --help` 为准。
+Run `pd-ctl region meta-consistency --help` for the authoritative parameter list.
 
-| 参数 | 默认值（含单位） | 说明 |
+| Parameter | Default with unit | Description |
 | --- | ---: | --- |
-| `-u, --pd` | `http://127.0.0.1:2379`（URL） | 一个 seed URL；不能包含用户名、密码、Path、Query 或 Fragment。 |
-| `--batch-size` | `128 Region/请求` | 每次最多读取的 Region 数，范围 `1..1024 Region/请求`。 |
-| `--interval` | `50ms/请求` | 每份全局 HTTP 请求预算的间隔；必须使用 Go duration，如 `100ms`、`1s`。三实例同批请求的最小组间隔为 `150ms`。 |
-| `--timeout` | `10s/请求` | 单个 HTTP 请求的超时。 |
-| `--max-runtime` | `4h/整轮` | 整轮检查的 wall-clock 硬上限。 |
-| `--retries` | `0 次/请求` | 单请求额外重试次数，范围 `0..10 次`。 |
-| `--scan-retries` | `0 次/整轮` | Region 数变化时的整集群重扫次数，范围 `0..3 次`。 |
-| `--confirm-limit` | `128 Region/整轮` | 二次确认上限，范围 `0..1024 Region`；`0` 禁用确认。 |
-| `--work-dir` | 系统临时目录（路径） | 临时差异和 stdout 临时报告所在目录。 |
-| `--max-temporary-disk-mib` | `1024 MiB` | 差异排序与归并临时数据硬上限。 |
-| `--max-output-mib` | `1024 MiB` | 最终 JSON 报告硬上限。 |
-| `--output` | `-`（stdout 或路径） | `-` 输出到 stdout；文件路径采用完整写入后原子替换。 |
-| `--cacert` | 系统 CA（路径） | HTTPS CA bundle。 |
-| `--cert`、`--key` | 未设置（路径） | mTLS 客户端证书与私钥，必须同时提供。 |
-| `--authorization-file` | 未设置（路径） | 包含一行完整 Authorization Header 值的文件，只允许通过 HTTPS 发送。 |
+| `-u, --pd` | `http://127.0.0.1:2379` (URL) | One seed URL. User information, path, query, and fragment are rejected. |
+| `--batch-size` | `128 Regions/request` | Maximum Regions per request; range `1..1024 Regions/request`. |
+| `--interval` | `50ms/request` | Interval for each global HTTP request budget unit. Use a Go duration such as `100ms` or `1s`. A three-member batch has a minimum group interval of `150ms`. |
+| `--timeout` | `10s/request` | Timeout for one HTTP request. |
+| `--max-runtime` | `4h/check` | Wall-clock hard limit for the complete check. |
+| `--retries` | `0 retries/request` | Additional retries for one request; range `0..10`. |
+| `--scan-retries` | `0 retries/check` | Full-cluster retries after a Region count change; range `0..3`. |
+| `--confirm-limit` | `128 Regions/check` | Maximum differences to recheck; range `0..1024`. Set to `0` to disable confirmation. |
+| `--work-dir` | System temporary directory (path) | Directory for temporary differences and a temporary stdout report. |
+| `--max-temporary-disk-mib` | `1024 MiB` | Hard limit for temporary difference sorting and merging. |
+| `--max-output-mib` | `1024 MiB` | Hard limit for the final JSON report. |
+| `--output` | `-` (stdout or path) | `-` writes to stdout. A file path is atomically replaced after the complete report is written. |
+| `--cacert` | System CA (path) | HTTPS CA bundle. |
+| `--cert`, `--key` | Unset (path) | mTLS client certificate and private key. Both must be supplied together. |
+| `--authorization-file` | Unset (path) | File containing one complete Authorization header value. Authorization is sent only over HTTPS. |
 
-`--interval 0` 只用于无业务隔离测试，不能用于生产。集群负载较高但仍允许受控诊断时，可进一步降低单次和长期负载：
+`--interval 0` is only for isolated test environments with no production traffic and must not be used in production. If controlled diagnosis is permitted but cluster load is elevated, reduce both per-request and sustained load:
 
 ```bash
 pd-ctl -u http://10.0.0.1:2379 region meta-consistency \
@@ -103,23 +103,23 @@ pd-ctl -u http://10.0.0.1:2379 region meta-consistency \
   --output region-meta-report.json
 ```
 
-## 输出
+## Output
 
-报告为单行紧凑 JSON。关键字段如下：
+The report is compact single-line JSON.
 
-| 字段 | 含义 |
+| Field | Meaning |
 | --- | --- |
-| `status` | `consistent`、`inconsistent` 或 `incomplete`。 |
-| `reference` | 扫描开始时的 PD Leader 名称、ID 和 URL。 |
-| `settings` | 限速、并发、硬上限、HTTP 请求数、Response Body 字节数和临时磁盘峰值。 |
-| `nodes` | 各 PD 的名称、地址、角色、Region 数、批次数、扫描次数和时间。 |
-| `confirmation` | 差异复查范围、稳定/消失/变化的 Region ID 和未复查数量。 |
-| `summary` | 不同 Region 总数和按字段计数。 |
-| `differences` | 按 Region ID 排序的全部保留差异。 |
+| `status` | `consistent`, `inconsistent`, or `incomplete`. |
+| `reference` | Name, ID, and URL of the PD leader at scan start. |
+| `settings` | Rate limit, concurrency, hard limits, HTTP request count, response body bytes, and peak temporary disk usage. |
+| `nodes` | Name, address, role, Region count, batch count, scan attempts, and timestamps for every PD member. |
+| `confirmation` | Recheck scope, stable/resolved/changed Region IDs, and the number of unconfirmed Regions. |
+| `summary` | Total differing Regions and counts by differing field. |
+| `differences` | Every retained difference, sorted by Region ID. |
 
-每个差异包含 `region_id`，并且只输出真正不同的字段：`missing_on`、`key_range`、`epoch`、`peers`、`leader_peer`。实例使用 `<PD member name>@<host:port>` 标识；Peer `role` 数值为 `0=Voter`、`1=Learner`、`2=IncomingVoter`、`3=DemotingVoter`。
+Every difference contains `region_id` and only fields that actually differ: `missing_on`, `key_range`, `epoch`, `peers`, and `leader_peer`. Instances use `<PD member name>@<host:port>`. Peer role values are `0=Voter`, `1=Learner`, `2=IncomingVoter`, and `3=DemotingVoter`.
 
-一致结果的关键字段：
+Key fields in a consistent report:
 
 ```json
 {
@@ -130,7 +130,7 @@ pd-ctl -u http://10.0.0.1:2379 region meta-consistency \
 }
 ```
 
-不一致结果的关键字段：
+Key fields in an inconsistent report:
 
 ```json
 {
@@ -155,7 +155,7 @@ pd-ctl -u http://10.0.0.1:2379 region meta-consistency \
 }
 ```
 
-常用查询：
+Common queries:
 
 ```bash
 jq '{status, summary, confirmation}' region-meta-report.json
@@ -164,62 +164,62 @@ jq '.differences[] | select(has("missing_on") or has("key_range") or has("epoch"
 jq '.differences[] | select(has("peers") or has("leader_peer"))' region-meta-report.json
 ```
 
-## 资源与容量
+## Resources and capacity
 
-命令每个 PD 最多保留一个当前响应，每个响应有 8 MiB 硬上限。差异排序使用固定 8 MiB 缓冲，二次确认只保留 `--confirm-limit` 个候选，报告逐条写入。因此内存主要由 PD 节点数、批量、当前响应和确认上限决定，不随 Region 总数线性增长。Region 数增加主要表现为请求数、累计网络流量和运行时间增加。
+The command retains at most one current response per PD member, with an 8 MiB hard limit for each response. Difference sorting uses a fixed 8 MiB buffer, confirmation retains at most `--confirm-limit` candidates, and the report is written incrementally. Memory usage therefore depends mainly on the number of PD members, batch size, current responses, and confirmation limit; it does not grow linearly with the total Region count. More Regions primarily increase request count, cumulative network traffic, and runtime.
 
-| 资源 | 最低配置 | 建议配置 | 说明 |
+| Resource | Minimum | Recommended | Notes |
 | --- | ---: | ---: | --- |
-| CPU | 1 vCPU | 2 vCPU | 网络读取最多与 PD 实例数相同，比较与报告写入在主进程完成。 |
-| 内存 | 512 MiB | 1 GiB | 覆盖三实例并发当前页、JSON 解码和固定排序缓冲。 |
-| 可用磁盘 | 3 GiB | 5 GiB | 覆盖默认 1 GiB 临时上限、1 GiB 报告上限和文件系统余量。 |
-| 网络 | 100 Mbps | 与 PD 同 VPC/可用区 | 必须直连所有 PD 地址。 |
-| 任务窗口 | 4 h | 大于 4 h | 默认硬上限为 4 h。 |
+| CPU | 1 vCPU | 2 vCPU | Network reads can match the PD member count; comparison and report generation run in the main process. |
+| Memory | 512 MiB | 1 GiB | Covers three concurrent current pages, JSON decoding, and the fixed sorting buffer. |
+| Free disk | 3 GiB | 5 GiB | Covers the default 1 GiB temporary limit, 1 GiB report limit, and filesystem headroom. |
+| Network | 100 Mbps | Same VPC or Availability Zone as PD | Must reach every PD address directly. |
+| Task window | 4 h | More than 4 h | The default runtime hard limit is 4 h. |
 
-若 `--work-dir` 与输出目录位于不同文件系统，两处都应分别按对应上限预留空间。
+If `--work-dir` and the output directory are on different filesystems, reserve the corresponding capacity on each filesystem.
 
-### 百万 Region 实测
+### Million-Region benchmark
 
-以下容量数据使用 [`v8.5.4-20260625-8b1b130`](https://github.com/tikv/pd/releases/tag/v8.5.4-20260625-8b1b130) 的 PD API。测试环境为 AWS EC2 `r7i.4xlarge`（16 vCPU、123 GiB 可见内存、无 swap）和 Ubuntu 22.04.5。三个 PD、三个模拟 Store、每 Region 三个 Peer；每档使用全新数据目录，在心跳停止、三个节点 Region 数相等且 Region Syncer 索引追平后执行。`pd-ctl` 使用 Go 1.26.5 构建自 commit `ecbbc0cea2ee8507512a7384e1e015e349e911ab`，测试二进制 SHA-256 为 `248cba827138361ecaa6cf8456a0e90492dcd0bfe2edf2a1b4624643a0b95d05`。其他 PD 版本和数据模型应按等价环境重新测量。
+The capacity data below uses the PD API from [`v8.5.4-20260625-8b1b130`](https://github.com/tikv/pd/releases/tag/v8.5.4-20260625-8b1b130). The test host was an AWS EC2 `r7i.4xlarge` with 16 vCPUs, 123 GiB visible memory, no swap, and Ubuntu 22.04.5. The topology contained three PD members and three simulated stores, with three peers per Region. Every scale used a fresh data directory. Heartbeats were stopped before each check, all three members had equal Region counts, and Region Syncer indexes had caught up. The `pd-ctl` binary was built with Go 1.26.5 from commit `ecbbc0cea2ee8507512a7384e1e015e349e911ab`; its SHA-256 was `248cba827138361ecaa6cf8456a0e90492dcd0bfe2edf2a1b4624643a0b95d05`. Re-measure other PD versions and data models in an equivalent environment.
 
-| 每个 PD 的 Region 数 | HTTP 请求数 | Response Body | 默认限速时间下界 | `interval=0` Wall time | 检查器最大 RSS |
+| Regions per PD | HTTP requests | Response body | Default rate-limit lower bound | `interval=0` wall time | Checker peak RSS |
 | ---: | ---: | ---: | ---: | ---: | ---: |
 | 1,000,000 | 23,447 | 1.24 GiB | 19 min 32 s | 15.187 s | 42.25 MiB |
 | 2,000,000 | 46,883 | 2.48 GiB | 39 min 04 s | 29.729 s | 42.25 MiB |
 | 4,000,000 | 93,758 | 4.99 GiB | 1 h 18 min 08 s | 59.849 s | 43.84 MiB |
 | 8,000,000 | 187,508 | 10.02 GiB | 2 h 36 min 15 s | 123.029 s | 43.02 MiB |
 
-| 每个 PD 的 Region 数 | 三台 PD CPU 增量合计 | 单台 PD RSS 最大值（扫描前 → 扫描后） | 报告大小 |
+| Regions per PD | Combined PD CPU time | Maximum per-PD RSS (before to after) | Report size |
 | ---: | ---: | ---: | ---: |
-| 1,000,000 | 21.08 s | 2.21 GiB → 2.67 GiB | 1,567 B |
-| 2,000,000 | 32.91 s | 4.50 GiB → 5.41 GiB | 1,569 B |
-| 4,000,000 | 63.80 s | 9.78 GiB → 11.20 GiB | 1,571 B |
-| 8,000,000 | 196.51 s | 16.15 GiB → 18.30 GiB | 1,572 B |
+| 1,000,000 | 21.08 s | 2.21 GiB to 2.67 GiB | 1,567 B |
+| 2,000,000 | 32.91 s | 4.50 GiB to 5.41 GiB | 1,569 B |
+| 4,000,000 | 63.80 s | 9.78 GiB to 11.20 GiB | 1,571 B |
+| 8,000,000 | 196.51 s | 16.15 GiB to 18.30 GiB | 1,572 B |
 
-四档均为 `consistent`，每个节点只扫描一次，没有请求重试或整轮重扫；`differences` 为空，临时差异磁盘为 `0`。`interval=0` 仅用于无业务隔离环境的极限测量，不能作为生产运行参数；生产时间由默认全局请求预算控制。8,000,000 Region 在默认预算下的三个 PD 合计平均 Body 流量约为 1.10 MiB/s。
+All four scales returned `consistent`. Every member completed one scan without request retries or full-scan retries, `differences` was empty, and temporary difference disk usage was `0`. `interval=0` measures the isolated upper-throughput case and must not be used as a production setting. Production runtime is governed by the default global request budget. With 8,000,000 Regions, aggregate average response body traffic across the three PD members was approximately 1.10 MiB/s under the default budget.
 
-检查器 RSS 保持稳定，是因为 `http_response_bytes` 是整轮累计值，而内存中只保留各节点当前页、固定排序缓冲和有限确认候选。PD 侧仍要为每次请求执行 Region tree 扫描和 JSON 序列化；无主动限速测试中，单个 PD 的最大 RSS 增量达到 3.76 GiB。因此优先从独立运维机执行；必须与 PD 同机时，除检查器资源外，还应至少保留一个空闲逻辑 CPU、6 GiB `MemAvailable` 和 3 GiB 非 PD 数据盘空间。对于本测试的 8,000,000 Region 数据模型，PD 主机至少使用 32 GiB 内存；真实 Key 长度、Peer 数、业务负载和 PD 配置不同，执行前必须按等价环境重新确认余量。
+Checker RSS remains stable because `http_response_bytes` is cumulative for the complete run, while memory holds only each member's current page, the fixed sorting buffer, and bounded confirmation candidates. PD still scans the Region tree and serializes JSON for every request. In the unthrottled test, peak RSS for one PD increased by as much as 3.76 GiB. Prefer a separate operations host. If the checker must share a PD host, reserve at least one idle logical CPU, 6 GiB `MemAvailable`, and 3 GiB on a non-PD data disk in addition to checker resources. The 8,000,000-Region test model requires at least 32 GiB on a PD host. Real key lengths, peer counts, workload, and PD configuration can change these requirements; validate headroom in an equivalent environment before execution.
 
-## 生产运行守则
+## Production safeguards
 
-- 使用生产默认参数；不要为了缩短时间而增大批量、取消限速或首先启用整轮重扫。
-- 监控现有生产阈值下的 PD CPU、Go heap/GC、业务请求延迟，以及 `pd_region_syncer_status{type="sync_index"}` 和 `{type="last_index"}`。
-- 任一现有 SLO、告警或资源阈值触发时立即 Ctrl-C，不临时放宽阈值。
-- 报告包含 PD 地址、Region ID、Key Range、Peer ID 和 Store ID，不要发布到公开渠道。
-- Authorization 文件仅限当前用户读取，通过 HTTPS 发送，并按组织安全规范保管。
+- Use the production defaults. Do not increase the batch size, remove rate limiting, or enable full-scan retries first merely to shorten runtime.
+- Monitor PD CPU, Go heap and GC, request latency, existing alerts, `pd_region_syncer_status{type="sync_index"}`, and `pd_region_syncer_status{type="last_index"}` against existing production thresholds.
+- Press Ctrl-C immediately if any existing SLO, alert, or resource threshold is reached. Do not relax thresholds during the check.
+- The report contains PD addresses, Region IDs, key ranges, Peer IDs, and Store IDs. Do not publish it.
+- Restrict the Authorization file to the current user, transmit it only over HTTPS, and handle it according to organizational security requirements.
 
-每 100 个扫描批次会向 stderr 输出一次进度，不会污染 JSON stdout。
+Progress is written to stderr every 100 scan batches and never contaminates JSON stdout.
 
-## 测试
+## Tests
 
-核心测试覆盖一致、Region 缺失、Key Range、Epoch、Peers、Region Leader Peer、Role、Witness、uint64、瞬时差异、扫描期间数量增长与重试、成员变化、同批并发、全局请求预算、响应/磁盘/输出硬上限和外部排序：
+Core tests cover consistent metadata, missing Regions, key range, epoch, peers, Region leader peers, role, witness state, `uint64` values, transient differences, Region count growth and retry, membership changes, concurrent same-batch requests, global request budgeting, response/disk/output limits, and external sorting:
 
 ```bash
 make -C tools gotest \
   GOTEST_ARGS='./pd-ctl/pdctl/command/regionmeta -count=1'
 ```
 
-三 PD 集成测试会灌入 Region 心跳，直接改写一个 Follower 的本地缓存，并验证命令能报告具体 Epoch 差异和 Region 缺失：
+The three-PD integration test injects Region heartbeats, mutates one follower's local cache, and verifies exact epoch and missing-Region differences:
 
 ```bash
 make -C tools gotest \

--- a/tools/pd-ctl/pdctl/command/regionmeta/README.md
+++ b/tools/pd-ctl/pdctl/command/regionmeta/README.md
@@ -1,0 +1,227 @@
+# PD region meta consistency check
+
+`pd-ctl region meta-consistency` 检查同一 PD 集群中 Leader 与各 Follower 本地缓存的 region meta 是否一致。命令直接访问每个 PD 实例，以小批量、同批跨实例并发、单实例串行和全局限速方式扫描，输出一个 JSON 报告。
+
+本命令使用 `/members`、`/regions/count`、`/regions/key` 和 `/region/id/{id}` API，并依赖 Follower 本地读取 Header。兼容性测试覆盖当前 master 和 [`v8.5.4-20260625-8b1b130`](https://github.com/tikv/pd/releases/tag/v8.5.4-20260625-8b1b130)；用于其他版本前，应确认这些接口的行为兼容。
+
+> 全量检查会增加 PD 的 HTTP 处理、JSON 序列化、网络流量和短时 Region tree 读锁开销。默认参数用于限制这些开销；如果生产要求严格零扰动，不应执行本命令。
+
+## 快速执行
+
+建议从同 VPC 的独立运维机执行，并为每轮检查使用新的输出文件：
+
+```bash
+report="region-meta-report-$(date -u +%Y%m%dT%H%M%SZ).json"
+set +e
+pd-ctl -u http://10.0.0.1:2379 region meta-consistency \
+  --output "$report"
+rc=$?
+set -e
+
+printf 'exit_code=%s report=%s\n' "$rc" "$report"
+test ! -s "$report" || jq '{status, summary, confirmation, nodes}' "$report"
+```
+
+一个 URL 仅作为 seed。命令通过 `/pd/api/v1/members` 发现成员，并直连每个成员公布的 `client_urls`；不要使用负载均衡地址代替成员直连地址。
+
+| 退出码 | 状态 | 含义 |
+| ---: | --- | --- |
+| `0` | `consistent` | 本轮没有保留差异。 |
+| `1` | `inconsistent` | 检查成功，并确认至少一个稳定差异。 |
+| `2` | `incomplete` 或无新报告 | 证据不足或执行失败；检查 stderr，不要沿用旧报告。 |
+| `130` | 无新报告 | 用户通过 Ctrl-C 中断。 |
+
+退出码 `1` 表示发现不一致，不是命令执行失败。
+
+## 执行条件
+
+- 集群至少有两个 PD 成员；执行机能直连所有成员公布的 `client_urls`。
+- Follower Region Syncer 正常，能够处理携带 `PD-Allow-Follower-Handle: true` 的本地读取请求。
+- 在业务低峰执行，PD CPU、内存、业务延迟和现有告警均有明确余量。
+- 扫描期间不安排 PD 重启、扩缩容或主动 Leader 切换。
+- `--work-dir` 与输出目录已存在、可写且空间充足；报告按内部诊断数据保护。
+
+推荐独立检查机至少为 `1 vCPU / 512 MiB RAM / 3 GiB 可用磁盘 / 100 Mbps`；建议配置为 `2 vCPU / 1 GiB RAM / 5 GiB 可用磁盘`。
+
+## 检查内容
+
+| 类别 | 比较字段 |
+| --- | --- |
+| Region | Region ID |
+| Key Range | `start_key`、`end_key` |
+| Epoch | `conf_ver`、`version` |
+| Peers | `id`、`store_id`、`role`、`is_witness` |
+| Region Leader Peer | `id`、`store_id`、`role`、`is_witness` |
+
+流量、大小、`pending_peers`、`down_peers`、Buckets 等心跳统计字段不参与比较；Peer 数组顺序也不参与比较。报告中的 `reference` 只是扫描开始时的 PD Leader 身份，不代表该节点的数据必然正确。`leader_peer` 表示 Region Leader Peer，与 PD Leader 是两个概念。
+
+## 工作流程与结论边界
+
+1. 读取成员、PD Leader 和 cluster ID，为每个 PD 实例建立直接 HTTP 连接。
+2. 同时读取各实例 Region 数，通过 `/pd/api/v1/regions/key` 按 Key Range 分页；同一批请求尽量同时开始。
+3. 每个实例最多有一个在途请求。所有实例共享请求预算：一组包含 N 个请求时消耗 N 份预算，因此默认长期总速率不超过 20 requests/s。
+4. 请求携带 `PD-Allow-Follower-Handle: true`、`PD-Redirector: pd-ctl-region-meta-consistency` 和 `X-Caller-ID: pd-ctl`，直接读取目标实例的本地 Region cache。
+5. 相同数据比较后立即释放；只有差异写入有界临时 JSONL，并按 Region ID 外部归并排序。
+6. 对 Region ID 最小的前 `--confirm-limit` 个差异等待 1 秒后并发复查。结束时再次核对 PD Leader、cluster ID 和成员身份。
+
+只有某节点的扫描前数量、实际扫描数量、扫描后数量相等，本轮扫描才会被接受。默认不自动重扫，避免在 Region 持续变化时放大负载。
+
+多个独立 HTTP 请求不能组成分布式原子快照：
+
+- `consistent` 表示本轮观察没有留下差异，不等价于线性一致性证明。
+- `inconsistent` 表示至少一个已复查差异保持相同，是较强的不一致证据。
+- `incomplete` 表示证据不足，不能解释为一致。
+
+## 参数
+
+完整参数以 `pd-ctl region meta-consistency --help` 为准。
+
+| 参数 | 默认值（含单位） | 说明 |
+| --- | ---: | --- |
+| `-u, --pd` | `http://127.0.0.1:2379`（URL） | 一个 seed URL；不能包含用户名、密码、Path、Query 或 Fragment。 |
+| `--batch-size` | `128 Region/请求` | 每次最多读取的 Region 数，范围 `1..1024 Region/请求`。 |
+| `--interval` | `50ms/请求` | 每份全局 HTTP 请求预算的间隔；必须使用 Go duration，如 `100ms`、`1s`。三实例同批请求的最小组间隔为 `150ms`。 |
+| `--timeout` | `10s/请求` | 单个 HTTP 请求的超时。 |
+| `--max-runtime` | `4h/整轮` | 整轮检查的 wall-clock 硬上限。 |
+| `--retries` | `0 次/请求` | 单请求额外重试次数，范围 `0..10 次`。 |
+| `--scan-retries` | `0 次/整轮` | Region 数变化时的整集群重扫次数，范围 `0..3 次`。 |
+| `--confirm-limit` | `128 Region/整轮` | 二次确认上限，范围 `0..1024 Region`；`0` 禁用确认。 |
+| `--work-dir` | 系统临时目录（路径） | 临时差异和 stdout 临时报告所在目录。 |
+| `--max-temporary-disk-mib` | `1024 MiB` | 差异排序与归并临时数据硬上限。 |
+| `--max-output-mib` | `1024 MiB` | 最终 JSON 报告硬上限。 |
+| `--output` | `-`（stdout 或路径） | `-` 输出到 stdout；文件路径采用完整写入后原子替换。 |
+| `--cacert` | 系统 CA（路径） | HTTPS CA bundle。 |
+| `--cert`、`--key` | 未设置（路径） | mTLS 客户端证书与私钥，必须同时提供。 |
+| `--authorization-file` | 未设置（路径） | 包含一行完整 Authorization Header 值的文件，只允许通过 HTTPS 发送。 |
+
+`--interval 0` 只用于无业务隔离测试，不能用于生产。集群负载较高但仍允许受控诊断时，可进一步降低单次和长期负载：
+
+```bash
+pd-ctl -u http://10.0.0.1:2379 region meta-consistency \
+  --batch-size 64 \
+  --interval 100ms \
+  --output region-meta-report.json
+```
+
+## 输出
+
+报告为单行紧凑 JSON。关键字段如下：
+
+| 字段 | 含义 |
+| --- | --- |
+| `status` | `consistent`、`inconsistent` 或 `incomplete`。 |
+| `reference` | 扫描开始时的 PD Leader 名称、ID 和 URL。 |
+| `settings` | 限速、并发、硬上限、HTTP 请求数、Response Body 字节数和临时磁盘峰值。 |
+| `nodes` | 各 PD 的名称、地址、角色、Region 数、批次数、扫描次数和时间。 |
+| `confirmation` | 差异复查范围、稳定/消失/变化的 Region ID 和未复查数量。 |
+| `summary` | 不同 Region 总数和按字段计数。 |
+| `differences` | 按 Region ID 排序的全部保留差异。 |
+
+每个差异包含 `region_id`，并且只输出真正不同的字段：`missing_on`、`key_range`、`epoch`、`peers`、`leader_peer`。实例使用 `<PD member name>@<host:port>` 标识；Peer `role` 数值为 `0=Voter`、`1=Learner`、`2=IncomingVoter`、`3=DemotingVoter`。
+
+一致结果的关键字段：
+
+```json
+{
+  "status": "consistent",
+  "summary": {"different_regions": 0, "by_field": {}},
+  "confirmation": {"result": "not_needed", "final_differences": 0},
+  "differences": []
+}
+```
+
+不一致结果的关键字段：
+
+```json
+{
+  "status": "inconsistent",
+  "summary": {"different_regions": 2, "by_field": {"missing_on": 1, "epoch": 1}},
+  "confirmation": {
+    "result": "stable",
+    "checked_regions": 2,
+    "stable_regions": [42, 43],
+    "final_differences": 2
+  },
+  "differences": [
+    {
+      "region_id": 42,
+      "epoch": {
+        "pd-0@10.0.0.1:2379": {"conf_ver": 3, "version": 8},
+        "pd-1@10.0.0.2:2379": {"conf_ver": 3, "version": 7}
+      }
+    },
+    {"region_id": 43, "missing_on": ["pd-1@10.0.0.2:2379"]}
+  ]
+}
+```
+
+常用查询：
+
+```bash
+jq '{status, summary, confirmation}' region-meta-report.json
+jq -r '.differences[].region_id' region-meta-report.json
+jq '.differences[] | select(has("missing_on") or has("key_range") or has("epoch"))' region-meta-report.json
+jq '.differences[] | select(has("peers") or has("leader_peer"))' region-meta-report.json
+```
+
+## 资源与容量
+
+命令每个 PD 最多保留一个当前响应，每个响应有 8 MiB 硬上限。差异排序使用固定 8 MiB 缓冲，二次确认只保留 `--confirm-limit` 个候选，报告逐条写入。因此内存主要由 PD 节点数、批量、当前响应和确认上限决定，不随 Region 总数线性增长。Region 数增加主要表现为请求数、累计网络流量和运行时间增加。
+
+| 资源 | 最低配置 | 建议配置 | 说明 |
+| --- | ---: | ---: | --- |
+| CPU | 1 vCPU | 2 vCPU | 网络读取最多与 PD 实例数相同，比较与报告写入在主进程完成。 |
+| 内存 | 512 MiB | 1 GiB | 覆盖三实例并发当前页、JSON 解码和固定排序缓冲。 |
+| 可用磁盘 | 3 GiB | 5 GiB | 覆盖默认 1 GiB 临时上限、1 GiB 报告上限和文件系统余量。 |
+| 网络 | 100 Mbps | 与 PD 同 VPC/可用区 | 必须直连所有 PD 地址。 |
+| 任务窗口 | 4 h | 大于 4 h | 默认硬上限为 4 h。 |
+
+若 `--work-dir` 与输出目录位于不同文件系统，两处都应分别按对应上限预留空间。
+
+### 百万 Region 实测
+
+以下容量数据使用 [`v8.5.4-20260625-8b1b130`](https://github.com/tikv/pd/releases/tag/v8.5.4-20260625-8b1b130) 的 PD API。测试环境为 AWS EC2 `r7i.4xlarge`（16 vCPU、123 GiB 可见内存、无 swap）和 Ubuntu 22.04.5。三个 PD、三个模拟 Store、每 Region 三个 Peer；每档使用全新数据目录，在心跳停止、三个节点 Region 数相等且 Region Syncer 索引追平后执行。`pd-ctl` 使用 Go 1.26.5 构建自 commit `ecbbc0cea2ee8507512a7384e1e015e349e911ab`，测试二进制 SHA-256 为 `248cba827138361ecaa6cf8456a0e90492dcd0bfe2edf2a1b4624643a0b95d05`。其他 PD 版本和数据模型应按等价环境重新测量。
+
+| 每个 PD 的 Region 数 | HTTP 请求数 | Response Body | 默认限速时间下界 | `interval=0` Wall time | 检查器最大 RSS |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000,000 | 23,447 | 1.24 GiB | 19 min 32 s | 15.187 s | 42.25 MiB |
+| 2,000,000 | 46,883 | 2.48 GiB | 39 min 04 s | 29.729 s | 42.25 MiB |
+| 4,000,000 | 93,758 | 4.99 GiB | 1 h 18 min 08 s | 59.849 s | 43.84 MiB |
+| 8,000,000 | 187,508 | 10.02 GiB | 2 h 36 min 15 s | 123.029 s | 43.02 MiB |
+
+| 每个 PD 的 Region 数 | 三台 PD CPU 增量合计 | 单台 PD RSS 最大值（扫描前 → 扫描后） | 报告大小 |
+| ---: | ---: | ---: | ---: |
+| 1,000,000 | 21.08 s | 2.21 GiB → 2.67 GiB | 1,567 B |
+| 2,000,000 | 32.91 s | 4.50 GiB → 5.41 GiB | 1,569 B |
+| 4,000,000 | 63.80 s | 9.78 GiB → 11.20 GiB | 1,571 B |
+| 8,000,000 | 196.51 s | 16.15 GiB → 18.30 GiB | 1,572 B |
+
+四档均为 `consistent`，每个节点只扫描一次，没有请求重试或整轮重扫；`differences` 为空，临时差异磁盘为 `0`。`interval=0` 仅用于无业务隔离环境的极限测量，不能作为生产运行参数；生产时间由默认全局请求预算控制。8,000,000 Region 在默认预算下的三个 PD 合计平均 Body 流量约为 1.10 MiB/s。
+
+检查器 RSS 保持稳定，是因为 `http_response_bytes` 是整轮累计值，而内存中只保留各节点当前页、固定排序缓冲和有限确认候选。PD 侧仍要为每次请求执行 Region tree 扫描和 JSON 序列化；无主动限速测试中，单个 PD 的最大 RSS 增量达到 3.76 GiB。因此优先从独立运维机执行；必须与 PD 同机时，除检查器资源外，还应至少保留一个空闲逻辑 CPU、6 GiB `MemAvailable` 和 3 GiB 非 PD 数据盘空间。对于本测试的 8,000,000 Region 数据模型，PD 主机至少使用 32 GiB 内存；真实 Key 长度、Peer 数、业务负载和 PD 配置不同，执行前必须按等价环境重新确认余量。
+
+## 生产运行守则
+
+- 使用生产默认参数；不要为了缩短时间而增大批量、取消限速或首先启用整轮重扫。
+- 监控现有生产阈值下的 PD CPU、Go heap/GC、业务请求延迟，以及 `pd_region_syncer_status{type="sync_index"}` 和 `{type="last_index"}`。
+- 任一现有 SLO、告警或资源阈值触发时立即 Ctrl-C，不临时放宽阈值。
+- 报告包含 PD 地址、Region ID、Key Range、Peer ID 和 Store ID，不要发布到公开渠道。
+- Authorization 文件仅限当前用户读取，通过 HTTPS 发送，并按组织安全规范保管。
+
+每 100 个扫描批次会向 stderr 输出一次进度，不会污染 JSON stdout。
+
+## 测试
+
+核心测试覆盖一致、Region 缺失、Key Range、Epoch、Peers、Region Leader Peer、Role、Witness、uint64、瞬时差异、扫描期间数量增长与重试、成员变化、同批并发、全局请求预算、响应/磁盘/输出硬上限和外部排序：
+
+```bash
+make -C tools gotest \
+  GOTEST_ARGS='./pd-ctl/pdctl/command/regionmeta -count=1'
+```
+
+三 PD 集成测试会灌入 Region 心跳，直接改写一个 Follower 的本地缓存，并验证命令能报告具体 Epoch 差异和 Region 缺失：
+
+```bash
+make -C tools gotest \
+  GOTEST_ARGS='-tags=without_dashboard ./pd-ctl/tests/region -run TestRegionMetaConsistencyUsesFollowerLocalCache -count=1'
+```

--- a/tools/pd-ctl/pdctl/command/regionmeta/checker.go
+++ b/tools/pd-ctl/pdctl/command/regionmeta/checker.go
@@ -1,0 +1,602 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regionmeta
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"time"
+)
+
+type summary struct {
+	DifferentRegions int            `json:"different_regions"`
+	ByField          map[string]int `json:"by_field"`
+}
+
+type confirmation struct {
+	Result             string   `json:"result"`
+	InitialDifferences int      `json:"initial_differences"`
+	Limit              int      `json:"limit"`
+	DelaySeconds       float64  `json:"delay_seconds"`
+	CheckedRegions     int      `json:"checked_regions,omitempty"`
+	UnconfirmedRegions int      `json:"unconfirmed_regions,omitempty"`
+	StableRegions      []uint64 `json:"stable_regions,omitempty"`
+	ResolvedRegions    []uint64 `json:"resolved_regions,omitempty"`
+	ChangedRegions     []uint64 `json:"changed_regions,omitempty"`
+	FinalDifferences   int      `json:"final_differences"`
+}
+
+type replacement struct {
+	Difference *difference
+}
+
+type referenceReport struct {
+	Name     string `json:"name"`
+	MemberID uint64 `json:"member_id"`
+	URL      string `json:"url"`
+}
+
+type settingsReport struct {
+	BatchSize              int     `json:"batch_size"`
+	RequestIntervalSeconds float64 `json:"request_interval_seconds"`
+	RequestTimeoutSeconds  float64 `json:"request_timeout_seconds"`
+	MaxRuntimeSeconds      float64 `json:"max_runtime_seconds"`
+	GlobalConcurrency      int     `json:"global_concurrency"`
+	PerNodeConcurrency     int     `json:"per_node_concurrency"`
+	ConfirmationLimit      int     `json:"confirmation_limit"`
+	TemporaryDiskLimitMiB  int64   `json:"temporary_disk_limit_mib"`
+	OutputLimitMiB         int64   `json:"output_limit_mib"`
+	HTTPRequests           int64   `json:"http_requests"`
+	HTTPResponseBytes      int64   `json:"http_response_bytes"`
+	TemporaryDiskPeakBytes int64   `json:"temporary_disk_peak_bytes"`
+	SnapshotSemantics      string  `json:"snapshot_semantics"`
+}
+
+type nodeReport struct {
+	Name         string `json:"name"`
+	MemberID     uint64 `json:"member_id"`
+	URL          string `json:"url"`
+	Role         string `json:"role"`
+	RegionCount  int    `json:"region_count"`
+	Batches      int    `json:"batches"`
+	ScanAttempts int    `json:"scan_attempts"`
+	StartedAt    string `json:"started_at"`
+	FinishedAt   string `json:"finished_at"`
+}
+
+type reportBase struct {
+	Status       Status          `json:"status"`
+	GeneratedAt  string          `json:"generated_at"`
+	ClusterID    uint64          `json:"cluster_id"`
+	Reference    referenceReport `json:"reference"`
+	Settings     settingsReport  `json:"settings"`
+	Nodes        []nodeReport    `json:"nodes"`
+	Confirmation confirmation    `json:"confirmation"`
+	Summary      summary         `json:"summary"`
+}
+
+// Run checks region meta from every discovered PD member and writes one JSON report.
+func Run(ctx context.Context, cfg Config, stdout, stderr io.Writer) (Outcome, error) {
+	if err := cfg.validate(); err != nil {
+		return Outcome{}, err
+	}
+	supplied := make([]string, 0, len(cfg.Endpoints))
+	seenEndpoints := make(map[string]struct{}, len(cfg.Endpoints))
+	for _, raw := range cfg.Endpoints {
+		endpoint, err := normalizeURL(raw)
+		if err != nil {
+			return Outcome{}, err
+		}
+		if _, exists := seenEndpoints[endpoint]; exists {
+			return Outcome{}, fmt.Errorf("duplicate PD endpoint was supplied: %s", endpoint)
+		}
+		seenEndpoints[endpoint] = struct{}{}
+		supplied = append(supplied, endpoint)
+	}
+	authorization, err := readAuthorization(cfg.AuthorizationFile)
+	if err != nil {
+		return Outcome{}, err
+	}
+	if authorization != "" && !allHTTPS(supplied) {
+		return Outcome{}, errors.New("authorization requires HTTPS for every supplied PD URL")
+	}
+	if cfg.WorkDir != "" {
+		info, err := os.Stat(cfg.WorkDir)
+		if err != nil || !info.IsDir() {
+			return Outcome{}, fmt.Errorf("work directory does not exist: %s", cfg.WorkDir)
+		}
+	}
+	directory, err := os.MkdirTemp(cfg.WorkDir, "pd-region-meta-consistency-")
+	if err != nil {
+		return Outcome{}, err
+	}
+	defer os.RemoveAll(directory)
+
+	runtimeCtx, cancel := context.WithTimeout(ctx, cfg.MaxRuntime)
+	defer cancel()
+	limiter := &rateLimiter{interval: cfg.Interval}
+	sharedClient := newSharedHTTPClient(cfg.TLSConfig)
+	defer sharedClient.CloseIdleConnections()
+	seed := &httpClient{
+		endpoint: supplied[0], client: sharedClient, limiter: limiter, timeout: cfg.Timeout,
+		retries: cfg.Retries, authorization: authorization,
+	}
+	nodes, membershipStart, err := discoverNodes(runtimeCtx, seed, supplied)
+	if err != nil {
+		return Outcome{}, runtimeError(runtimeCtx, err)
+	}
+	memberEndpoints := make([]string, 0, len(nodes))
+	for _, current := range nodes {
+		memberEndpoints = append(memberEndpoints, current.URL)
+	}
+	if authorization != "" && !allHTTPS(memberEndpoints) {
+		return Outcome{}, errors.New("authorization requires HTTPS for every PD member URL")
+	}
+	clients := make([]*httpClient, 0, len(nodes))
+	for _, current := range nodes {
+		clients = append(clients, &httpClient{
+			endpoint: current.URL, client: sharedClient, limiter: limiter, timeout: cfg.Timeout,
+			retries: cfg.Retries, authorization: authorization,
+		})
+	}
+	requester := &batchRequester{limiter: limiter}
+	budget := newDiskBudget(cfg.MaxTemporaryDiskBytes)
+	states, rows, err := collectRegions(
+		runtimeCtx, nodes, clients, cfg.BatchSize, cfg.ScanRetries, directory, budget, requester, stderr,
+	)
+	if err != nil {
+		return Outcome{}, runtimeError(runtimeCtx, err)
+	}
+	defer rows.cleanup()
+	initialSummary, candidates, err := summarizeDifferences(rows, nodes, cfg.ConfirmLimit)
+	if err != nil {
+		return Outcome{}, err
+	}
+	confirmationResult, replacements, err := recheckDifferences(
+		runtimeCtx, candidates, initialSummary.DifferentRegions, cfg, nodes, clients, requester, stderr,
+	)
+	if err != nil {
+		return Outcome{}, runtimeError(runtimeCtx, err)
+	}
+	var membershipEnd membership
+	if err := seed.getJSON(runtimeCtx, "/pd/api/v1/members", nil, true, false, &membershipEnd); err != nil {
+		return Outcome{}, runtimeError(runtimeCtx, err)
+	}
+	startSignature, err := membershipStart.signature()
+	if err != nil {
+		return Outcome{}, err
+	}
+	endSignature, err := membershipEnd.signature()
+	if err != nil {
+		return Outcome{}, err
+	}
+	if startSignature.ClusterID != endSignature.ClusterID || startSignature.LeaderID != endSignature.LeaderID ||
+		!slices.Equal(startSignature.Members, endSignature.Members) {
+		return Outcome{}, errors.New("membership or PD leader changed during the scan")
+	}
+	finalSummary := adjustSummary(initialSummary, candidates, replacements)
+	confirmationResult.FinalDifferences = finalSummary.DifferentRegions
+	status := finalStatus(confirmationResult, finalSummary)
+	reference := nodes[0]
+	report := reportBase{
+		Status:      status,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		ClusterID:   membershipStart.Header.ClusterID,
+		Reference: referenceReport{
+			Name: reference.Name, MemberID: reference.MemberID, URL: reference.URL,
+		},
+		Settings: settingsReport{
+			BatchSize: cfg.BatchSize, RequestIntervalSeconds: cfg.Interval.Seconds(),
+			RequestTimeoutSeconds: cfg.Timeout.Seconds(), MaxRuntimeSeconds: cfg.MaxRuntime.Seconds(),
+			GlobalConcurrency: len(nodes), PerNodeConcurrency: 1, ConfirmationLimit: cfg.ConfirmLimit,
+			TemporaryDiskLimitMiB:  cfg.MaxTemporaryDiskBytes / (1024 * 1024),
+			OutputLimitMiB:         cfg.MaxOutputBytes / (1024 * 1024),
+			HTTPRequests:           seed.requests.Load() + sumRequests(clients),
+			HTTPResponseBytes:      seed.responseBytes.Load() + sumResponseBytes(clients),
+			TemporaryDiskPeakBytes: budget.peak,
+			SnapshotSemantics: "bounded parallel batch scans; differences are rechecked, " +
+				"but the result is not an atomic snapshot",
+		},
+		Confirmation: confirmationResult,
+		Summary:      finalSummary,
+	}
+	for _, state := range states {
+		report.Nodes = append(report.Nodes, nodeReport{
+			Name: state.Node.Name, MemberID: state.Node.MemberID, URL: state.Node.URL,
+			Role: state.Node.Role, RegionCount: state.Scanned, Batches: state.Pages,
+			ScanAttempts: state.Attempts, StartedAt: state.StartedAt, FinishedAt: state.FinishedAt,
+		})
+	}
+	if err := writeReport(runtimeCtx, cfg.Output, report, rows, nodes, replacements, directory, cfg.MaxOutputBytes, stdout); err != nil {
+		return Outcome{}, runtimeError(runtimeCtx, err)
+	}
+	return Outcome{Status: status}, nil
+}
+
+func runtimeError(ctx context.Context, err error) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("maximum runtime exceeded: %w", ctx.Err())
+	}
+	return err
+}
+
+func allHTTPS(endpoints []string) bool {
+	for _, endpoint := range endpoints {
+		u, _ := url.Parse(endpoint)
+		if u.Scheme != "https" {
+			return false
+		}
+	}
+	return true
+}
+
+func sumRequests(clients []*httpClient) int64 {
+	var total int64
+	for _, client := range clients {
+		total += client.requests.Load()
+	}
+	return total
+}
+
+func sumResponseBytes(clients []*httpClient) int64 {
+	var total int64
+	for _, client := range clients {
+		total += client.responseBytes.Load()
+	}
+	return total
+}
+
+func iterateDifferences(rows *sortedRows, nodes []node, visit func(difference) error) error {
+	var currentID uint64
+	var currentRows []*regionMeta
+	flush := func() error {
+		if currentRows == nil {
+			return nil
+		}
+		value := makeDifference(currentID, currentRows, nodes)
+		if value == nil {
+			return nil
+		}
+		return visit(*value)
+	}
+	err := rows.iterate(func(row diskRow) error {
+		if currentRows == nil || row.RegionID != currentID {
+			if err := flush(); err != nil {
+				return err
+			}
+			currentID = row.RegionID
+			currentRows = make([]*regionMeta, len(nodes))
+		}
+		if row.Node < 0 || row.Node >= len(nodes) {
+			return fmt.Errorf("invalid node index %d in difference rows", row.Node)
+		}
+		if currentRows[row.Node] != nil {
+			return fmt.Errorf("%s: duplicate region id during scan", nodes[row.Node].Name)
+		}
+		meta := row.Meta
+		currentRows[row.Node] = &meta
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return flush()
+}
+
+func summarizeDifferences(rows *sortedRows, nodes []node, limit int) (summary, []difference, error) {
+	result := summary{ByField: make(map[string]int)}
+	candidates := make([]difference, 0, limit)
+	err := iterateDifferences(rows, nodes, func(value difference) error {
+		result.DifferentRegions++
+		addFields(result.ByField, value, 1)
+		if len(candidates) < limit {
+			candidates = append(candidates, value)
+		}
+		return nil
+	})
+	return result, candidates, err
+}
+
+func addFields(counts map[string]int, value difference, delta int) {
+	if len(value.MissingOn) > 0 {
+		counts["missing_on"] += delta
+	}
+	if len(value.KeyRange) > 0 {
+		counts["key_range"] += delta
+	}
+	if len(value.Epoch) > 0 {
+		counts["epoch"] += delta
+	}
+	if len(value.Peers) > 0 {
+		counts["peers"] += delta
+	}
+	if len(value.LeaderPeer) > 0 {
+		counts["leader_peer"] += delta
+	}
+}
+
+func recheckDifferences(
+	ctx context.Context,
+	initial []difference,
+	differenceCount int,
+	cfg Config,
+	nodes []node,
+	clients []*httpClient,
+	requester *batchRequester,
+	progress io.Writer,
+) (confirmation, map[uint64]replacement, error) {
+	result := confirmation{
+		InitialDifferences: differenceCount,
+		Limit:              cfg.ConfirmLimit,
+		DelaySeconds:       cfg.ConfirmationDelay.Seconds(),
+	}
+	replacements := make(map[uint64]replacement, len(initial))
+	if differenceCount == 0 {
+		result.Result = "not_needed"
+		return result, replacements, nil
+	}
+	if cfg.ConfirmLimit == 0 {
+		result.Result = "confirmation_disabled"
+		result.UnconfirmedRegions = differenceCount
+		return result, replacements, nil
+	}
+	result.CheckedRegions = len(initial)
+	result.UnconfirmedRegions = differenceCount - len(initial)
+	_, _ = fmt.Fprintf(progress, "rechecking %d differing Regions after %s\n", len(initial), cfg.ConfirmationDelay)
+	if err := waitContext(ctx, cfg.ConfirmationDelay); err != nil {
+		return confirmation{}, nil, err
+	}
+	initialByID := make(map[uint64]difference, len(initial))
+	for _, original := range initial {
+		initialByID[original.RegionID] = original
+		raw := make([]json.RawMessage, len(nodes))
+		calls := make([]requestCall, 0, len(nodes))
+		for i := range nodes {
+			calls = append(calls, requestCall{
+				client: clients[i], path: "/pd/api/v1/region/id/" + strconv.FormatUint(original.RegionID, 10),
+				local: true, allowNotFound: true, destination: &raw[i],
+			})
+		}
+		if err := requester.getJSON(ctx, calls); err != nil {
+			return confirmation{}, nil, err
+		}
+		metas := make([]*regionMeta, len(nodes))
+		for i, payload := range raw {
+			trimmed := bytes.TrimSpace(payload)
+			if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) || bytes.Equal(trimmed, []byte("{}")) {
+				continue
+			}
+			var wire wireRegion
+			if err := json.Unmarshal(trimmed, &wire); err != nil {
+				return confirmation{}, nil, fmt.Errorf("%s: invalid /region/id/%d response: %w",
+					nodes[i].Name, original.RegionID, err)
+			}
+			// Some supported PD versions encode a missing Region as a zero-value RegionInfo.
+			if wire.ID == 0 {
+				continue
+			}
+			if wire.ID != original.RegionID {
+				return confirmation{}, nil, fmt.Errorf("%s: invalid /region/id/%d response", nodes[i].Name, original.RegionID)
+			}
+			record, err := normalizeRegion(wire)
+			if err != nil {
+				return confirmation{}, nil, err
+			}
+			meta := record.Meta
+			metas[i] = &meta
+		}
+		rechecked := makeDifference(original.RegionID, metas, nodes)
+		replacements[original.RegionID] = replacement{Difference: rechecked}
+	}
+	for regionID, original := range initialByID {
+		current := replacements[regionID].Difference
+		switch {
+		case current == nil:
+			result.ResolvedRegions = append(result.ResolvedRegions, regionID)
+		case original.equal(*current):
+			result.StableRegions = append(result.StableRegions, regionID)
+		default:
+			result.ChangedRegions = append(result.ChangedRegions, regionID)
+		}
+	}
+	slices.Sort(result.StableRegions)
+	slices.Sort(result.ResolvedRegions)
+	slices.Sort(result.ChangedRegions)
+	if len(result.StableRegions) > 0 {
+		result.Result = "stable"
+	} else if len(initial) == differenceCount && len(result.ResolvedRegions) == len(initial) {
+		result.Result = "resolved"
+	} else {
+		result.Result = "changed_during_recheck"
+	}
+	return result, replacements, nil
+}
+
+func adjustSummary(initial summary, candidates []difference, replacements map[uint64]replacement) summary {
+	result := summary{DifferentRegions: initial.DifferentRegions, ByField: make(map[string]int, len(initial.ByField))}
+	for field, count := range initial.ByField {
+		result.ByField[field] = count
+	}
+	for _, original := range candidates {
+		replacement, exists := replacements[original.RegionID]
+		if !exists {
+			continue
+		}
+		addFields(result.ByField, original, -1)
+		if replacement.Difference == nil {
+			result.DifferentRegions--
+		} else {
+			addFields(result.ByField, *replacement.Difference, 1)
+		}
+	}
+	for field, count := range result.ByField {
+		if count == 0 {
+			delete(result.ByField, field)
+		}
+	}
+	return result
+}
+
+func finalStatus(value confirmation, result summary) Status {
+	if value.Result == "confirmation_disabled" || value.Result == "changed_during_recheck" {
+		return StatusIncomplete
+	}
+	if result.DifferentRegions == 0 {
+		return StatusConsistent
+	}
+	return StatusInconsistent
+}
+
+func iterateFinalDifferences(
+	rows *sortedRows,
+	nodes []node,
+	replacements map[uint64]replacement,
+	visit func(difference) error,
+) error {
+	return iterateDifferences(rows, nodes, func(value difference) error {
+		if replacement, exists := replacements[value.RegionID]; exists {
+			if replacement.Difference == nil {
+				return nil
+			}
+			return visit(*replacement.Difference)
+		}
+		return visit(value)
+	})
+}
+
+type limitedWriter struct {
+	writer  io.Writer
+	limit   int64
+	written int64
+}
+
+func (w *limitedWriter) Write(payload []byte) (int, error) {
+	if w.written+int64(len(payload)) > w.limit {
+		return 0, fmt.Errorf("report JSON exceeds %d MiB", w.limit/(1024*1024))
+	}
+	n, err := w.writer.Write(payload)
+	w.written += int64(n)
+	return n, err
+}
+
+func writeReport(
+	ctx context.Context,
+	outputPath string,
+	report reportBase,
+	rows *sortedRows,
+	nodes []node,
+	replacements map[uint64]replacement,
+	workDirectory string,
+	maxBytes int64,
+	stdout io.Writer,
+) (returnErr error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	directory := workDirectory
+	var target string
+	if outputPath != "-" {
+		absolute, err := filepath.Abs(outputPath)
+		if err != nil {
+			return err
+		}
+		target = absolute
+		directory = filepath.Dir(target)
+		if info, err := os.Stat(directory); err != nil || !info.IsDir() {
+			return fmt.Errorf("output directory does not exist: %s", directory)
+		}
+	}
+	temporary, err := os.CreateTemp(directory, "region-meta-report-*.json")
+	if err != nil {
+		return err
+	}
+	path := temporary.Name()
+	defer func() {
+		if returnErr != nil {
+			_ = temporary.Close()
+			_ = os.Remove(path)
+		}
+	}()
+	buffered := bufio.NewWriter(temporary)
+	writer := &limitedWriter{writer: buffered, limit: maxBytes}
+	header, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	if len(header) == 0 || header[len(header)-1] != '}' {
+		return errors.New("internal report JSON header is invalid")
+	}
+	if _, err := writer.Write(header[:len(header)-1]); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(writer, `,"differences":[`); err != nil {
+		return err
+	}
+	first := true
+	if err := iterateFinalDifferences(rows, nodes, replacements, func(value difference) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !first {
+			if _, err := io.WriteString(writer, ","); err != nil {
+				return err
+			}
+		}
+		first = false
+		payload, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		_, err = writer.Write(payload)
+		return err
+	}); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(writer, "]}\n"); err != nil {
+		return err
+	}
+	if err := buffered.Flush(); err != nil {
+		return err
+	}
+	if target != "" {
+		if err := temporary.Sync(); err != nil {
+			return err
+		}
+		if err := temporary.Close(); err != nil {
+			return err
+		}
+		return os.Rename(path, target)
+	}
+	if _, err := temporary.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := io.Copy(stdout, temporary); err != nil {
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Remove(path)
+}

--- a/tools/pd-ctl/pdctl/command/regionmeta/checker_test.go
+++ b/tools/pd-ctl/pdctl/command/regionmeta/checker_test.go
@@ -1,0 +1,599 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regionmeta
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakePeer struct {
+	ID        uint64 `json:"id"`
+	StoreID   uint64 `json:"store_id"`
+	Role      uint32 `json:"role,omitempty"`
+	IsWitness bool   `json:"is_witness,omitempty"`
+}
+
+type fakeEpoch struct {
+	ConfVer uint64 `json:"conf_ver"`
+	Version uint64 `json:"version"`
+}
+
+type fakeRegion struct {
+	ID           uint64     `json:"id"`
+	StartKey     string     `json:"start_key"`
+	EndKey       string     `json:"end_key"`
+	Epoch        fakeEpoch  `json:"epoch"`
+	Peers        []fakePeer `json:"peers"`
+	Leader       *fakePeer  `json:"leader,omitempty"`
+	WrittenBytes uint64     `json:"written_bytes,omitempty"`
+	PendingPeers []fakePeer `json:"pending_peers,omitempty"`
+	Buckets      []string   `json:"buckets,omitempty"`
+}
+
+func newFakeRegion(id uint64, startKey, endKey string) fakeRegion {
+	peer := fakePeer{ID: id * 10, StoreID: 1}
+	return fakeRegion{
+		ID:       id,
+		StartKey: startKey,
+		EndKey:   endKey,
+		Epoch:    fakeEpoch{ConfVer: 1, Version: 1},
+		Peers:    []fakePeer{peer},
+		Leader:   &peer,
+	}
+}
+
+type fakePD struct {
+	name       string
+	memberID   uint64
+	server     *httptest.Server
+	mu         sync.Mutex
+	regions    []fakeRegion
+	membership any
+	local      [][3]string
+	scanCalls  int
+	countCalls int
+	regionGets int
+	scanHook   func(int)
+	countHook  func(int)
+	getHook    func(int)
+	firstPage  func()
+}
+
+func (p *fakePD) start() {
+	p.server = httptest.NewServer(http.HandlerFunc(p.serveHTTP))
+}
+
+func (p *fakePD) close() {
+	p.server.Close()
+}
+
+func (p *fakePD) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/pd/api/v1/members":
+		value := p.membership
+		if function, ok := value.(membershipFunc); ok {
+			value = function()
+		}
+		p.writeJSON(w, value)
+	case r.URL.Path == "/pd/api/v1/regions/count":
+		p.recordLocal(r)
+		p.mu.Lock()
+		p.countCalls++
+		call := p.countCalls
+		hook := p.countHook
+		p.mu.Unlock()
+		if hook != nil {
+			hook(call)
+		}
+		p.mu.Lock()
+		count := len(p.regions)
+		p.mu.Unlock()
+		p.writeJSON(w, map[string]any{"count": count})
+	case r.URL.Path == "/pd/api/v1/regions/key":
+		p.recordLocal(r)
+		p.mu.Lock()
+		p.scanCalls++
+		call := p.scanCalls
+		hook := p.scanHook
+		firstPage := p.firstPage
+		p.mu.Unlock()
+		if call == 1 && firstPage != nil {
+			firstPage()
+		}
+		if hook != nil {
+			hook(call)
+		}
+		start := strings.ToUpper(r.URL.Query().Get("key"))
+		limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+		if err != nil || limit < 1 {
+			http.Error(w, "bad limit", http.StatusBadRequest)
+			return
+		}
+		p.mu.Lock()
+		regions := make([]fakeRegion, 0, limit)
+		for _, region := range p.regions {
+			if region.EndKey == "" || region.EndKey > start {
+				regions = append(regions, region)
+				if len(regions) == limit {
+					break
+				}
+			}
+		}
+		p.mu.Unlock()
+		p.writeJSON(w, map[string]any{"count": len(regions), "regions": regions})
+	case strings.HasPrefix(r.URL.Path, "/pd/api/v1/region/id/"):
+		p.recordLocal(r)
+		id, err := strconv.ParseUint(strings.TrimPrefix(r.URL.Path, "/pd/api/v1/region/id/"), 10, 64)
+		if err != nil {
+			http.Error(w, "bad region id", http.StatusBadRequest)
+			return
+		}
+		p.mu.Lock()
+		p.regionGets++
+		call := p.regionGets
+		hook := p.getHook
+		p.mu.Unlock()
+		if hook != nil {
+			hook(call)
+		}
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		for _, region := range p.regions {
+			if region.ID == id {
+				p.writeJSON(w, region)
+				return
+			}
+		}
+		http.Error(w, "region not found", http.StatusNotFound)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (p *fakePD) recordLocal(r *http.Request) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.local = append(p.local, [3]string{
+		r.Header.Get("PD-Allow-Follower-Handle"),
+		r.Header.Get("X-Caller-ID"),
+		r.Header.Get("PD-Redirector"),
+	})
+}
+
+func (*fakePD) writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+type fakeCluster struct {
+	nodes []*fakePD
+}
+
+func newFakeCluster(t *testing.T) *fakeCluster {
+	t.Helper()
+	base := []fakeRegion{
+		newFakeRegion(1, "", "10"),
+		newFakeRegion(2, "10", "20"),
+		newFakeRegion(3, "20", "30"),
+		newFakeRegion(4, "30", "40"),
+		newFakeRegion(5, "40", ""),
+	}
+	nodes := []*fakePD{
+		{name: "pd-leader", memberID: 1},
+		{name: "pd-follower", memberID: 2},
+		{name: "pd-follower-2", memberID: 3},
+	}
+	for _, node := range nodes {
+		node.regions = cloneRegions(t, base)
+		node.start()
+	}
+	members := make([]map[string]any, 0, len(nodes))
+	for _, node := range nodes {
+		members = append(members, map[string]any{
+			"name": node.name, "member_id": node.memberID, "client_urls": []string{node.server.URL},
+		})
+	}
+	membership := map[string]any{
+		"header":  map[string]any{"cluster_id": uint64(123)},
+		"members": members,
+		"leader":  members[0],
+	}
+	for _, node := range nodes {
+		node.membership = membership
+	}
+	cluster := &fakeCluster{nodes: nodes}
+	t.Cleanup(cluster.close)
+	return cluster
+}
+
+func cloneRegions(t *testing.T, regions []fakeRegion) []fakeRegion {
+	t.Helper()
+	payload, err := json.Marshal(regions)
+	require.NoError(t, err)
+	var cloned []fakeRegion
+	require.NoError(t, json.Unmarshal(payload, &cloned))
+	return cloned
+}
+
+func (c *fakeCluster) close() {
+	for _, node := range c.nodes {
+		node.close()
+	}
+}
+
+func (c *fakeCluster) instance(index int) string {
+	u, _ := url.Parse(c.nodes[index].server.URL)
+	return c.nodes[index].name + "@" + u.Host
+}
+
+func runFakeCheck(t *testing.T, cluster *fakeCluster, mutate func(*Config)) (Outcome, map[string]any, string, error) {
+	t.Helper()
+	outcome, payload, stderr, err := runFakeCheckRaw(t, cluster, mutate)
+	if err != nil {
+		return outcome, nil, stderr, err
+	}
+	var report map[string]any
+	require.NoError(t, json.Unmarshal(payload, &report))
+	return outcome, report, stderr, nil
+}
+
+func runFakeCheckRaw(t *testing.T, cluster *fakeCluster, mutate func(*Config)) (Outcome, []byte, string, error) {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Endpoints = []string{cluster.nodes[0].server.URL}
+	cfg.BatchSize = 2
+	cfg.Interval = 0
+	cfg.Timeout = 2 * time.Second
+	cfg.ConfirmationDelay = 0
+	cfg.WorkDir = t.TempDir()
+	cfg.Output = "-"
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	var stdout, stderr bytes.Buffer
+	outcome, err := Run(context.Background(), cfg, &stdout, &stderr)
+	return outcome, stdout.Bytes(), stderr.String(), err
+}
+
+func TestConsistentClusterUsesConcurrentLocalBatches(t *testing.T) {
+	cluster := newFakeCluster(t)
+	var arrived atomic.Int32
+	release := make(chan struct{})
+	for _, node := range cluster.nodes {
+		node.firstPage = func() {
+			if arrived.Add(1) == int32(len(cluster.nodes)) {
+				close(release)
+			}
+			select {
+			case <-release:
+			case <-time.After(2 * time.Second):
+				t.Error("first Region page was not fetched concurrently")
+			}
+		}
+	}
+
+	outcome, report, _, err := runFakeCheck(t, cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusConsistent, outcome.Status)
+	require.Equal(t, float64(0), report["summary"].(map[string]any)["different_regions"])
+	require.Empty(t, report["differences"])
+	settings := report["settings"].(map[string]any)
+	require.Equal(t, float64(17), settings["http_requests"])
+	require.Equal(t, float64(3), settings["global_concurrency"])
+	require.Equal(t, float64(1), settings["per_node_concurrency"])
+	require.Equal(t, float64(0), settings["temporary_disk_peak_bytes"])
+
+	for _, node := range cluster.nodes {
+		node.mu.Lock()
+		require.NotEmpty(t, node.local)
+		for _, headers := range node.local {
+			require.Equal(t, [3]string{"true", "pd-ctl", "pd-ctl-region-meta-consistency"}, headers)
+		}
+		node.mu.Unlock()
+	}
+}
+
+func TestReportsEveryRegionMetaDifference(t *testing.T) {
+	cluster := newFakeCluster(t)
+	follower := cluster.nodes[1]
+	follower.regions[0].Epoch.Version = 2
+	follower.regions[1].StartKey = "11"
+	follower.regions[2].Leader = &fakePeer{ID: 31, StoreID: 2}
+	follower.regions[3].Peers = append(follower.regions[3].Peers, fakePeer{ID: 41, StoreID: 2})
+	follower.regions = follower.regions[:4]
+
+	outcome, report, _, err := runFakeCheck(t, cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusInconsistent, outcome.Status)
+	summary := report["summary"].(map[string]any)
+	require.Equal(t, float64(5), summary["different_regions"])
+	require.Equal(t, map[string]any{
+		"missing_on": float64(1), "key_range": float64(1), "epoch": float64(1),
+		"peers": float64(1), "leader_peer": float64(1),
+	}, summary["by_field"])
+
+	differences := make(map[uint64]map[string]any)
+	for _, value := range report["differences"].([]any) {
+		difference := value.(map[string]any)
+		differences[uint64(difference["region_id"].(float64))] = difference
+	}
+	require.Equal(t, float64(2), differences[1]["epoch"].(map[string]any)[cluster.instance(1)].(map[string]any)["version"])
+	require.Equal(t, "11", differences[2]["key_range"].(map[string]any)[cluster.instance(1)].(map[string]any)["start_key"])
+	require.Equal(t, float64(31), differences[3]["leader_peer"].(map[string]any)[cluster.instance(1)].(map[string]any)["id"])
+	require.Equal(t, float64(41), differences[4]["peers"].(map[string]any)[cluster.instance(1)].([]any)[1].(map[string]any)["id"])
+	require.Equal(t, []any{cluster.instance(1)}, differences[5]["missing_on"])
+}
+
+func TestIgnoresPeerOrderAndHeartbeatStatistics(t *testing.T) {
+	cluster := newFakeCluster(t)
+	for _, node := range cluster.nodes[1:] {
+		node.regions[2].Peers = []fakePeer{{ID: 31, StoreID: 2}, {ID: 30, StoreID: 1}}
+		node.regions[2].Leader = &fakePeer{ID: 30, StoreID: 1}
+		node.regions[0].WrittenBytes = 999
+		node.regions[0].PendingPeers = []fakePeer{{ID: 999, StoreID: 9}}
+		node.regions[0].Buckets = []string{"10"}
+	}
+	cluster.nodes[0].regions[2].Peers = []fakePeer{{ID: 30, StoreID: 1}, {ID: 31, StoreID: 2}}
+	cluster.nodes[0].regions[2].Leader = &fakePeer{ID: 30, StoreID: 1}
+
+	outcome, report, _, err := runFakeCheck(t, cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusConsistent, outcome.Status)
+	require.Empty(t, report["differences"])
+}
+
+func TestReportsPeerRoleWitnessAndUint64Values(t *testing.T) {
+	cluster := newFakeCluster(t)
+	maxID := ^uint64(0)
+	for _, node := range cluster.nodes {
+		node.regions[0].ID = maxID
+		node.regions[0].Epoch = fakeEpoch{ConfVer: maxID, Version: maxID}
+		node.regions[0].Peers = []fakePeer{{ID: maxID, StoreID: maxID}}
+		node.regions[0].Leader = &fakePeer{ID: maxID, StoreID: maxID}
+	}
+	cluster.nodes[1].regions[0].Epoch.Version--
+	cluster.nodes[1].regions[0].Peers[0].StoreID--
+	cluster.nodes[1].regions[2].Peers[0].Role = 1
+	cluster.nodes[2].regions[2].Peers[0].IsWitness = true
+
+	outcome, payload, _, err := runFakeCheckRaw(t, cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusInconsistent, outcome.Status)
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var report map[string]any
+	require.NoError(t, decoder.Decode(&report))
+	differences := report["differences"].([]any)
+	require.Len(t, differences, 2)
+	large := differences[1].(map[string]any)
+	require.Equal(t, strconv.FormatUint(maxID, 10), large["region_id"].(json.Number).String())
+	require.Equal(t, strconv.FormatUint(maxID, 10),
+		large["epoch"].(map[string]any)[cluster.instance(0)].(map[string]any)["version"].(json.Number).String())
+	require.Equal(t, strconv.FormatUint(maxID, 10),
+		large["peers"].(map[string]any)[cluster.instance(0)].([]any)[0].(map[string]any)["id"].(json.Number).String())
+	peers := differences[0].(map[string]any)["peers"].(map[string]any)
+	require.Equal(t, "1", peers[cluster.instance(1)].([]any)[0].(map[string]any)["role"].(json.Number).String())
+	require.Equal(t, true, peers[cluster.instance(2)].([]any)[0].(map[string]any)["is_witness"])
+}
+
+func TestRechecksTransientDifferences(t *testing.T) {
+	cluster := newFakeCluster(t)
+	cluster.nodes[1].regions[0].Epoch.Version = 2
+	for _, node := range cluster.nodes {
+		node.getHook = func(call int) {
+			if call == 1 {
+				cluster.nodes[1].mu.Lock()
+				cluster.nodes[1].regions[0].Epoch.Version = 1
+				cluster.nodes[1].mu.Unlock()
+			}
+		}
+	}
+
+	outcome, report, _, err := runFakeCheck(t, cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusConsistent, outcome.Status)
+	require.Empty(t, report["differences"])
+	confirmation := report["confirmation"].(map[string]any)
+	require.Equal(t, "resolved", confirmation["result"])
+}
+
+func TestIncompleteWhenConfirmationIsDisabled(t *testing.T) {
+	cluster := newFakeCluster(t)
+	cluster.nodes[1].regions[0].Epoch.Version = 2
+
+	outcome, report, _, err := runFakeCheck(t, cluster, func(cfg *Config) { cfg.ConfirmLimit = 0 })
+	require.NoError(t, err)
+	require.Equal(t, StatusIncomplete, outcome.Status)
+	require.Equal(t, "confirmation_disabled", report["confirmation"].(map[string]any)["result"])
+	require.Len(t, report["differences"], 1)
+}
+
+func TestRejectsUnstableRegionCountAndMembershipChange(t *testing.T) {
+	t.Run("count", func(t *testing.T) {
+		cluster := newFakeCluster(t)
+		cluster.nodes[1].countHook = func(call int) {
+			if call == 2 {
+				cluster.nodes[1].mu.Lock()
+				cluster.nodes[1].regions = cluster.nodes[1].regions[:4]
+				cluster.nodes[1].mu.Unlock()
+			}
+		}
+		_, _, _, err := runFakeCheck(t, cluster, nil)
+		require.ErrorContains(t, err, "unstable region set")
+	})
+
+	t.Run("membership", func(t *testing.T) {
+		cluster := newFakeCluster(t)
+		initial := cluster.nodes[0].membership
+		var memberCalls atomic.Int32
+		cluster.nodes[0].membership = membershipFunc(func() any {
+			if memberCalls.Add(1) == 1 {
+				return initial
+			}
+			changed := cloneJSON[map[string]any](t, initial)
+			changed["leader"] = changed["members"].([]any)[1]
+			return changed
+		})
+		_, _, _, err := runFakeCheck(t, cluster, nil)
+		require.ErrorContains(t, err, "membership or PD leader changed")
+	})
+}
+
+func TestScanRetryHandlesGrowthBeyondOneBatch(t *testing.T) {
+	cluster := newFakeCluster(t)
+	follower := cluster.nodes[1]
+	original := cloneRegions(t, follower.regions)
+	grown := cloneRegions(t, original[:4])
+	grown = append(grown,
+		newFakeRegion(5, "40", "50"),
+		newFakeRegion(6, "50", "60"),
+		newFakeRegion(7, "60", "70"),
+		newFakeRegion(8, "70", ""),
+	)
+	follower.firstPage = func() {
+		follower.mu.Lock()
+		follower.regions = grown
+		follower.mu.Unlock()
+	}
+	follower.countHook = func(call int) {
+		if call == 3 {
+			follower.mu.Lock()
+			follower.regions = original
+			follower.mu.Unlock()
+		}
+	}
+
+	outcome, report, stderr, err := runFakeCheck(t, cluster, func(cfg *Config) { cfg.ScanRetries = 1 })
+	require.NoError(t, err)
+	require.Equal(t, StatusConsistent, outcome.Status)
+	require.Empty(t, report["differences"])
+	require.Contains(t, stderr, "region count changed during scan; retrying")
+}
+
+type membershipFunc func() any
+
+func cloneJSON[T any](t *testing.T, value any) T {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	require.NoError(t, err)
+	var cloned T
+	require.NoError(t, json.Unmarshal(payload, &cloned))
+	return cloned
+}
+
+func TestValidationAndOutputLimit(t *testing.T) {
+	cluster := newFakeCluster(t)
+	_, _, _, err := runFakeCheck(t, cluster, func(cfg *Config) { cfg.BatchSize = 0 })
+	require.ErrorContains(t, err, "batch size")
+
+	cluster.nodes[1].regions[0].Epoch.Version = 2
+	_, _, _, err = runFakeCheck(t, cluster, func(cfg *Config) { cfg.MaxOutputBytes = 16 })
+	require.ErrorContains(t, err, "report JSON exceeds")
+}
+
+func TestDifferenceOrdering(t *testing.T) {
+	cluster := newFakeCluster(t)
+	cluster.nodes[1].regions[4].Epoch.Version = 2
+	cluster.nodes[1].regions[0].Epoch.Version = 2
+	outcome, report, _, err := runFakeCheck(t, cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusInconsistent, outcome.Status)
+	values := report["differences"].([]any)
+	ids := make([]uint64, 0, len(values))
+	for _, value := range values {
+		ids = append(ids, uint64(value.(map[string]any)["region_id"].(float64)))
+	}
+	require.True(t, slices.IsSorted(ids), "Region IDs are not sorted: %v", ids)
+}
+
+func TestMatchesRegionIDsAcrossDivergentKeySegments(t *testing.T) {
+	cluster := newFakeCluster(t)
+	moved := cluster.nodes[1].regions[0]
+	moved.StartKey = "10"
+	moved.EndKey = "20"
+	replacement := newFakeRegion(9, "", "10")
+	cluster.nodes[1].regions = append([]fakeRegion{replacement, moved}, cluster.nodes[1].regions[2:]...)
+
+	outcome, report, _, err := runFakeCheck(t, cluster, nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusInconsistent, outcome.Status)
+	differences := make(map[uint64]map[string]any)
+	for _, value := range report["differences"].([]any) {
+		difference := value.(map[string]any)
+		differences[uint64(difference["region_id"].(float64))] = difference
+	}
+	ids := make([]uint64, 0, len(differences))
+	for id := range differences {
+		ids = append(ids, id)
+	}
+	require.ElementsMatch(t, []uint64{1, 2, 9}, ids)
+	require.Equal(t, []any{cluster.instance(1)}, differences[2]["missing_on"])
+	require.Equal(t, []any{cluster.instance(0), cluster.instance(2)}, differences[9]["missing_on"])
+}
+
+func TestConfirmationLimitDoesNotTruncateDifferences(t *testing.T) {
+	cluster := newFakeCluster(t)
+	for i := range cluster.nodes[1].regions {
+		cluster.nodes[1].regions[i].Epoch.Version++
+	}
+	outcome, report, _, err := runFakeCheck(t, cluster, func(cfg *Config) { cfg.ConfirmLimit = 2 })
+	require.NoError(t, err)
+	require.Equal(t, StatusInconsistent, outcome.Status)
+	require.Len(t, report["differences"], 5)
+	confirmation := report["confirmation"].(map[string]any)
+	require.Equal(t, float64(2), confirmation["checked_regions"])
+	require.Equal(t, float64(3), confirmation["unconfirmed_regions"])
+	for _, node := range cluster.nodes {
+		node.mu.Lock()
+		require.Equal(t, 2, node.regionGets)
+		node.mu.Unlock()
+	}
+}
+
+func TestAuthorizationRequiresHTTPS(t *testing.T) {
+	cluster := newFakeCluster(t)
+	path := filepath.Join(t.TempDir(), "authorization")
+	require.NoError(t, os.WriteFile(path, []byte("Bearer secret\n"), 0o600))
+	_, _, _, err := runFakeCheck(t, cluster, func(cfg *Config) { cfg.AuthorizationFile = path })
+	require.ErrorContains(t, err, "authorization requires HTTPS")
+	for _, node := range cluster.nodes {
+		node.mu.Lock()
+		require.Empty(t, node.local)
+		node.mu.Unlock()
+	}
+}
+
+func TestTemporaryDifferenceLimit(t *testing.T) {
+	cluster := newFakeCluster(t)
+	cluster.nodes[1].regions[0].Epoch.Version++
+	_, _, _, err := runFakeCheck(t, cluster, func(cfg *Config) { cfg.MaxTemporaryDiskBytes = 32 })
+	require.ErrorContains(t, err, "temporary JSON data exceeds")
+}

--- a/tools/pd-ctl/pdctl/command/regionmeta/http.go
+++ b/tools/pd-ctl/pdctl/command/regionmeta/http.go
@@ -1,0 +1,469 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regionmeta
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tikv/pd/pkg/utils/apiutil"
+)
+
+const (
+	callerID       = "pd-ctl"
+	redirectorName = "pd-ctl-region-meta-consistency"
+)
+
+type rateLimiter struct {
+	mu       sync.Mutex
+	interval time.Duration
+	next     time.Time
+}
+
+func (l *rateLimiter) wait(ctx context.Context, cost int) error {
+	if cost < 1 {
+		return nil
+	}
+	l.mu.Lock()
+	now := time.Now()
+	start := now
+	if l.next.After(start) {
+		start = l.next
+	}
+	l.next = start.Add(time.Duration(cost) * l.interval)
+	l.mu.Unlock()
+	if !start.After(now) {
+		return nil
+	}
+	timer := time.NewTimer(start.Sub(now))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type httpClient struct {
+	endpoint      string
+	client        *http.Client
+	limiter       *rateLimiter
+	timeout       time.Duration
+	retries       int
+	authorization string
+	requests      atomic.Int64
+	responseBytes atomic.Int64
+}
+
+type httpStatusError struct {
+	status  int
+	message string
+}
+
+func (e *httpStatusError) Error() string {
+	return e.message
+}
+
+func isHTTPStatus(err error, status int) bool {
+	var statusErr *httpStatusError
+	return errors.As(err, &statusErr) && statusErr.status == status
+}
+
+func newSharedHTTPClient(tlsConfig *tls.Config) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if tlsConfig != nil {
+		transport.TLSClientConfig = tlsConfig.Clone()
+	}
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func (c *httpClient) getJSON(
+	ctx context.Context,
+	path string,
+	query url.Values,
+	local bool,
+	rateLimitReserved bool,
+	destination any,
+) error {
+	target := c.endpoint + path
+	if len(query) > 0 {
+		target += "?" + query.Encode()
+	}
+	var lastErr error
+	for attempt := 0; attempt <= c.retries; attempt++ {
+		if attempt > 0 || !rateLimitReserved {
+			if err := c.limiter.wait(ctx, 1); err != nil {
+				return err
+			}
+		}
+		requestCtx, cancel := context.WithTimeout(ctx, c.timeout)
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, target, nil)
+		if err != nil {
+			cancel()
+			return err
+		}
+		req.Header.Set(apiutil.XCallerIDHeader, callerID)
+		if local {
+			req.Header.Set(apiutil.PDAllowFollowerHandleHeader, "true")
+			req.Header.Set(apiutil.PDRedirectorHeader, redirectorName)
+		}
+		if c.authorization != "" {
+			req.Header.Set("Authorization", c.authorization)
+		}
+		c.requests.Add(1)
+		resp, err := c.client.Do(req)
+		if err != nil {
+			cancel()
+			lastErr = fmt.Errorf("%s%s: %w", c.endpoint, path, err)
+		} else {
+			payload, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+			_ = resp.Body.Close()
+			cancel()
+			c.responseBytes.Add(int64(len(payload)))
+			if readErr != nil {
+				lastErr = fmt.Errorf("%s%s: %w", c.endpoint, path, readErr)
+			} else if len(payload) > maxResponseBytes {
+				return fmt.Errorf("%s%s: response exceeds 8 MiB", c.endpoint, path)
+			} else if resp.StatusCode == http.StatusOK {
+				if err := json.Unmarshal(payload, destination); err != nil {
+					return fmt.Errorf("%s%s: invalid JSON: %w", c.endpoint, path, err)
+				}
+				return nil
+			} else {
+				message := strings.TrimSpace(string(payload))
+				if len(message) > 512 {
+					message = message[:512]
+				}
+				lastErr = &httpStatusError{
+					status: resp.StatusCode,
+					message: fmt.Sprintf("%s%s: unexpected HTTP %d%s",
+						c.endpoint, path, resp.StatusCode, errorSuffix(message)),
+				}
+				if !retryableStatus(resp.StatusCode) {
+					return lastErr
+				}
+				if seconds, err := strconv.Atoi(resp.Header.Get("Retry-After")); err == nil && seconds > 0 {
+					if err := waitContext(ctx, min(time.Duration(seconds)*time.Second, 5*time.Second)); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		if attempt < c.retries {
+			if err := waitContext(ctx, min(100*time.Millisecond<<attempt, time.Second)); err != nil {
+				return err
+			}
+		}
+	}
+	return lastErr
+}
+
+func errorSuffix(message string) string {
+	if message == "" {
+		return ""
+	}
+	return ": " + message
+}
+
+func retryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusInternalServerError ||
+		status == http.StatusBadGateway || status == http.StatusServiceUnavailable ||
+		status == http.StatusGatewayTimeout
+}
+
+func waitContext(ctx context.Context, duration time.Duration) error {
+	if duration <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type requestCall struct {
+	client        *httpClient
+	path          string
+	query         url.Values
+	local         bool
+	allowNotFound bool
+	destination   any
+}
+
+type batchRequester struct {
+	limiter *rateLimiter
+}
+
+func (r *batchRequester) getJSON(ctx context.Context, calls []requestCall) error {
+	if len(calls) == 0 {
+		return nil
+	}
+	seen := make(map[*httpClient]struct{}, len(calls))
+	for _, call := range calls {
+		if _, ok := seen[call.client]; ok {
+			return errors.New("a PD member cannot receive concurrent checker requests")
+		}
+		seen[call.client] = struct{}{}
+	}
+	if err := r.limiter.wait(ctx, len(calls)); err != nil {
+		return err
+	}
+	if len(calls) == 1 {
+		call := calls[0]
+		err := call.client.getJSON(ctx, call.path, call.query, call.local, true, call.destination)
+		if call.allowNotFound && isHTTPStatus(err, http.StatusNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	groupCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	start := make(chan struct{})
+	ready := sync.WaitGroup{}
+	ready.Add(len(calls))
+	errorsByIndex := make([]error, len(calls))
+	wg := sync.WaitGroup{}
+	for i, call := range calls {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ready.Done()
+			select {
+			case <-start:
+			case <-groupCtx.Done():
+				errorsByIndex[i] = groupCtx.Err()
+				return
+			}
+			err := call.client.getJSON(groupCtx, call.path, call.query, call.local, true, call.destination)
+			if call.allowNotFound && isHTTPStatus(err, http.StatusNotFound) {
+				err = nil
+			}
+			errorsByIndex[i] = err
+			if err != nil {
+				cancel()
+			}
+		}()
+	}
+	ready.Wait()
+	close(start)
+	wg.Wait()
+	for _, err := range errorsByIndex {
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+	}
+	if err := groupCtx.Err(); err != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return nil
+}
+
+type wireMember struct {
+	Name       string   `json:"name"`
+	MemberID   uint64   `json:"member_id"`
+	ClientURLs []string `json:"client_urls"`
+}
+
+type wireHeader struct {
+	ClusterID uint64 `json:"cluster_id"`
+}
+
+type membership struct {
+	Header  wireHeader   `json:"header"`
+	Members []wireMember `json:"members"`
+	Leader  wireMember   `json:"leader"`
+}
+
+type memberSignature struct {
+	ClusterID uint64
+	LeaderID  uint64
+	Members   []string
+}
+
+func (m membership) signature() (memberSignature, error) {
+	if len(m.Members) < 2 || m.Leader.MemberID == 0 {
+		return memberSignature{}, errors.New("members response does not identify at least two members and the PD leader")
+	}
+	values := make([]string, 0, len(m.Members))
+	leaderFound := false
+	for _, member := range m.Members {
+		if member.MemberID == 0 || len(member.ClientURLs) == 0 {
+			return memberSignature{}, errors.New("/members contains a member without id or client_urls")
+		}
+		if member.MemberID == m.Leader.MemberID {
+			leaderFound = true
+		}
+		urls := make([]string, 0, len(member.ClientURLs))
+		for _, raw := range member.ClientURLs {
+			value, err := normalizeURL(raw)
+			if err != nil {
+				return memberSignature{}, err
+			}
+			urls = append(urls, value)
+		}
+		slices.Sort(urls)
+		values = append(values, fmt.Sprintf("%d\x00%s\x00%s", member.MemberID, member.Name, strings.Join(urls, "\x00")))
+	}
+	if !leaderFound {
+		return memberSignature{}, errors.New("current PD leader is not present in the member list")
+	}
+	slices.Sort(values)
+	return memberSignature{ClusterID: m.Header.ClusterID, LeaderID: m.Leader.MemberID, Members: values}, nil
+}
+
+func normalizeURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" {
+		return "", fmt.Errorf("invalid PD URL %q", raw)
+	}
+	if u.User != nil || (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("supplied PD URL must not include credentials, path, query, or fragment: %q", raw)
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	} else if value, err := strconv.ParseUint(port, 10, 16); err != nil || value == 0 {
+		return "", fmt.Errorf("invalid PD URL port in %q", raw)
+	}
+	return strings.ToLower(u.Scheme) + "://" + net.JoinHostPort(strings.ToLower(u.Hostname()), port), nil
+}
+
+func readAuthorization(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(string(payload))
+	if value == "" || strings.ContainsAny(value, "\r\n") {
+		return "", errors.New("authorization file must contain exactly one non-empty line")
+	}
+	return value, nil
+}
+
+func discoverNodes(
+	ctx context.Context,
+	seed *httpClient,
+	supplied []string,
+) ([]node, membership, error) {
+	var current membership
+	if err := seed.getJSON(ctx, "/pd/api/v1/members", nil, true, false, &current); err != nil {
+		return nil, membership{}, err
+	}
+	if _, err := current.signature(); err != nil {
+		return nil, membership{}, err
+	}
+	chosen := make(map[uint64]string, len(current.Members))
+	if len(supplied) == 1 {
+		for _, member := range current.Members {
+			endpoint, err := normalizeURL(member.ClientURLs[0])
+			if err != nil {
+				return nil, membership{}, err
+			}
+			chosen[member.MemberID] = endpoint
+		}
+	} else {
+		for _, member := range current.Members {
+			matches := make([]string, 0, 1)
+			for _, raw := range member.ClientURLs {
+				endpoint, err := normalizeURL(raw)
+				if err != nil {
+					return nil, membership{}, err
+				}
+				if slices.Contains(supplied, endpoint) {
+					matches = append(matches, endpoint)
+				}
+			}
+			if len(matches) != 1 {
+				return nil, membership{}, fmt.Errorf("direct endpoint for PD member %q is missing or ambiguous", member.Name)
+			}
+			chosen[member.MemberID] = matches[0]
+		}
+		advertised := make(map[string]struct{}, len(chosen))
+		for _, endpoint := range chosen {
+			advertised[endpoint] = struct{}{}
+		}
+		for _, endpoint := range supplied {
+			if _, ok := advertised[endpoint]; !ok {
+				return nil, membership{}, fmt.Errorf("supplied endpoint is not a PD member client URL: %s", endpoint)
+			}
+		}
+	}
+	members := slices.Clone(current.Members)
+	slices.SortFunc(members, func(a, b wireMember) int {
+		if (a.MemberID == current.Leader.MemberID) != (b.MemberID == current.Leader.MemberID) {
+			if a.MemberID == current.Leader.MemberID {
+				return -1
+			}
+			return 1
+		}
+		return compareUint64(a.MemberID, b.MemberID)
+	})
+	names := make(map[string]struct{}, len(members))
+	endpoints := make(map[string]struct{}, len(members))
+	nodes := make([]node, 0, len(members))
+	for _, member := range members {
+		name := member.Name
+		if name == "" {
+			name = fmt.Sprintf("member-%d", member.MemberID)
+		}
+		if _, exists := names[name]; exists {
+			return nil, membership{}, errors.New("member names in the PD response must be unique")
+		}
+		names[name] = struct{}{}
+		endpoint := chosen[member.MemberID]
+		if _, exists := endpoints[endpoint]; exists {
+			return nil, membership{}, errors.New("members in the PD response must advertise distinct client URLs")
+		}
+		endpoints[endpoint] = struct{}{}
+		role := "follower"
+		if member.MemberID == current.Leader.MemberID {
+			role = "leader"
+		}
+		nodes = append(nodes, node{MemberID: member.MemberID, Name: name, URL: endpoint, Role: role})
+	}
+	return nodes, current, nil
+}

--- a/tools/pd-ctl/pdctl/command/regionmeta/resource_test.go
+++ b/tools/pd-ctl/pdctl/command/regionmeta/resource_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regionmeta
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPResponseAndRedirectLimits(t *testing.T) {
+	limiter := &rateLimiter{}
+	t.Run("response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"padding":"`))
+			_, _ = w.Write([]byte(strings.Repeat("x", maxResponseBytes)))
+			_, _ = w.Write([]byte(`"}`))
+		}))
+		defer server.Close()
+		client := &httpClient{
+			endpoint: server.URL, client: newSharedHTTPClient(nil), limiter: limiter, timeout: time.Second,
+		}
+		var destination any
+		err := client.getJSON(context.Background(), "/", nil, true, false, &destination)
+		require.ErrorContains(t, err, "response exceeds 8 MiB")
+	})
+
+	t.Run("redirect", func(t *testing.T) {
+		var followed bool
+		target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { followed = true }))
+		defer target.Close()
+		server := httptest.NewServer(http.RedirectHandler(target.URL, http.StatusTemporaryRedirect))
+		defer server.Close()
+		client := &httpClient{
+			endpoint: server.URL, client: newSharedHTTPClient(nil), limiter: limiter, timeout: time.Second,
+		}
+		var destination any
+		err := client.getJSON(context.Background(), "/", nil, true, false, &destination)
+		require.ErrorContains(t, err, "unexpected HTTP 307")
+		require.False(t, followed)
+	})
+}
+
+func TestRateLimiterChargesEveryConcurrentRequest(t *testing.T) {
+	limiter := &rateLimiter{interval: 20 * time.Millisecond}
+	require.NoError(t, limiter.wait(context.Background(), 3))
+	started := time.Now()
+	require.NoError(t, limiter.wait(context.Background(), 1))
+	require.GreaterOrEqual(t, time.Since(started), 45*time.Millisecond)
+}
+
+func TestBatchRequesterPreservesRequestErrorAfterCancel(t *testing.T) {
+	blocked := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer blocked.Close()
+	failed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "failed", http.StatusInternalServerError)
+	}))
+	defer failed.Close()
+
+	limiter := &rateLimiter{}
+	client := newSharedHTTPClient(nil)
+	defer client.CloseIdleConnections()
+	clients := []*httpClient{
+		{endpoint: blocked.URL, client: client, limiter: limiter, timeout: time.Second},
+		{endpoint: failed.URL, client: client, limiter: limiter, timeout: time.Second},
+	}
+	destinations := make([]any, len(clients))
+	calls := make([]requestCall, 0, len(clients))
+	for i := range clients {
+		calls = append(calls, requestCall{client: clients[i], path: "/", destination: &destinations[i]})
+	}
+	err := (&batchRequester{limiter: limiter}).getJSON(context.Background(), calls)
+	require.ErrorContains(t, err, failed.URL)
+	require.ErrorContains(t, err, "unexpected HTTP 500")
+}
+
+func TestSortedRowsUseBoundedExternalMerge(t *testing.T) {
+	directory := t.TempDir()
+	budget := newDiskBudget(128 * 1024 * 1024)
+	rows := newSortedRows(directory, budget)
+	largeKey := strings.Repeat("AA", 512)
+	for id := uint64(20000); id > 0; id-- {
+		err := rows.add(id, int(id%3), regionMeta{StartKey: largeKey, EndKey: largeKey})
+		require.NoError(t, err)
+	}
+	require.NoError(t, rows.finish())
+	require.Greater(t, budget.peak, int64(sortBufferBytes))
+	var previous uint64
+	count := 0
+	require.NoError(t, rows.iterate(func(row diskRow) error {
+		if count > 0 {
+			require.GreaterOrEqual(t, row.RegionID, previous)
+		}
+		previous = row.RegionID
+		count++
+		return nil
+	}))
+	require.Equal(t, 20000, count)
+	rows.cleanup()
+	require.Zero(t, budget.current)
+}

--- a/tools/pd-ctl/pdctl/command/regionmeta/scan.go
+++ b/tools/pd-ctl/pdctl/command/regionmeta/scan.go
@@ -1,0 +1,663 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regionmeta
+
+import (
+	"bufio"
+	"bytes"
+	"container/heap"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type diskRow struct {
+	RegionID uint64     `json:"r"`
+	Node     int        `json:"n"`
+	Meta     regionMeta `json:"m"`
+}
+
+type bufferedDiskRow struct {
+	row     diskRow
+	payload []byte
+}
+
+type diskBudget struct {
+	limit   int64
+	current int64
+	peak    int64
+	sizes   map[string]int64
+}
+
+func newDiskBudget(limit int64) *diskBudget {
+	return &diskBudget{limit: limit, sizes: make(map[string]int64)}
+}
+
+func (b *diskBudget) write(writer io.Writer, path string, payload []byte) error {
+	if b.current+int64(len(payload)) > b.limit {
+		return fmt.Errorf("temporary JSON data exceeds %d MiB", b.limit/(1024*1024))
+	}
+	n, err := writer.Write(payload)
+	if err != nil {
+		return err
+	}
+	if n != len(payload) {
+		return io.ErrShortWrite
+	}
+	b.current += int64(n)
+	b.sizes[path] += int64(n)
+	if b.current > b.peak {
+		b.peak = b.current
+	}
+	return nil
+}
+
+func (b *diskBudget) remove(path string) {
+	b.current -= b.sizes[path]
+	delete(b.sizes, path)
+	_ = os.Remove(path)
+}
+
+type sortedRows struct {
+	directory   string
+	budget      *diskBudget
+	buffer      []bufferedDiskRow
+	bufferBytes int
+	chunks      []string
+}
+
+func newSortedRows(directory string, budget *diskBudget) *sortedRows {
+	return &sortedRows{directory: directory, budget: budget}
+}
+
+func (s *sortedRows) add(regionID uint64, nodeIndex int, meta regionMeta) error {
+	row := diskRow{RegionID: regionID, Node: nodeIndex, Meta: meta}
+	payload, err := json.Marshal(row)
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	s.buffer = append(s.buffer, bufferedDiskRow{row: row, payload: payload})
+	s.bufferBytes += len(payload)
+	if s.bufferBytes >= sortBufferBytes {
+		return s.flush()
+	}
+	return nil
+}
+
+func (s *sortedRows) flush() (returnErr error) {
+	if len(s.buffer) == 0 {
+		return nil
+	}
+	slices.SortFunc(s.buffer, func(a, b bufferedDiskRow) int {
+		return compareDiskRow(a.row, b.row)
+	})
+	file, err := os.CreateTemp(s.directory, "region-meta-*.jsonl")
+	if err != nil {
+		return err
+	}
+	path := file.Name()
+	defer func() {
+		if returnErr != nil {
+			_ = file.Close()
+			s.budget.remove(path)
+		}
+	}()
+	writer := bufio.NewWriter(file)
+	for _, row := range s.buffer {
+		if err := s.budget.write(writer, path, row.payload); err != nil {
+			return err
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	s.chunks = append(s.chunks, path)
+	s.buffer = nil
+	s.bufferBytes = 0
+	return nil
+}
+
+func (s *sortedRows) finish() error {
+	if err := s.flush(); err != nil {
+		return err
+	}
+	for len(s.chunks) > 1 {
+		original := s.chunks
+		merged := make([]string, 0, (len(original)+mergeFanIn-1)/mergeFanIn)
+		for start := 0; start < len(original); start += mergeFanIn {
+			end := min(start+mergeFanIn, len(original))
+			group := original[start:end]
+			if len(group) == 1 {
+				merged = append(merged, group[0])
+				continue
+			}
+			path, err := s.merge(group)
+			if err != nil {
+				s.chunks = append(merged, original[start:]...)
+				return err
+			}
+			merged = append(merged, path)
+		}
+		s.chunks = merged
+	}
+	return nil
+}
+
+func (s *sortedRows) merge(paths []string) (mergedPath string, returnErr error) {
+	file, err := os.CreateTemp(s.directory, "region-meta-*.jsonl")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	defer func() {
+		if returnErr != nil {
+			_ = file.Close()
+			s.budget.remove(path)
+		}
+	}()
+	writer := bufio.NewWriter(file)
+	err = iterateMergedRows(paths, func(row diskRow) error {
+		payload, err := json.Marshal(row)
+		if err != nil {
+			return err
+		}
+		payload = append(payload, '\n')
+		return s.budget.write(writer, path, payload)
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := writer.Flush(); err != nil {
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	for _, source := range paths {
+		s.budget.remove(source)
+	}
+	return path, nil
+}
+
+func (s *sortedRows) iterate(visit func(diskRow) error) error {
+	if len(s.chunks) == 0 {
+		return nil
+	}
+	if len(s.chunks) != 1 {
+		return errors.New("internal difference rows were not fully merged")
+	}
+	return iterateMergedRows(s.chunks, visit)
+}
+
+func (s *sortedRows) cleanup() {
+	for _, path := range s.chunks {
+		s.budget.remove(path)
+	}
+	s.chunks = nil
+	s.buffer = nil
+	s.bufferBytes = 0
+}
+
+func compareDiskRow(a, b diskRow) int {
+	if a.RegionID != b.RegionID {
+		return compareUint64(a.RegionID, b.RegionID)
+	}
+	return a.Node - b.Node
+}
+
+type rowSource struct {
+	file   *os.File
+	reader *bufio.Reader
+}
+
+type heapRow struct {
+	row    diskRow
+	source int
+}
+
+type rowHeap []heapRow
+
+func (h *rowHeap) Len() int           { return len(*h) }
+func (h *rowHeap) Less(i, j int) bool { return compareDiskRow((*h)[i].row, (*h)[j].row) < 0 }
+func (h *rowHeap) Swap(i, j int)      { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }
+
+// Push adds a row to the heap.
+func (h *rowHeap) Push(value any) { *h = append(*h, value.(heapRow)) }
+
+// Pop removes the final row from the heap.
+func (h *rowHeap) Pop() any {
+	old := *h
+	last := old[len(old)-1]
+	*h = old[:len(old)-1]
+	return last
+}
+
+func iterateMergedRows(paths []string, visit func(diskRow) error) error {
+	sources := make([]rowSource, 0, len(paths))
+	for _, path := range paths {
+		file, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			for _, source := range sources {
+				_ = source.file.Close()
+			}
+			return err
+		}
+		sources = append(sources, rowSource{file: file, reader: bufio.NewReader(file)})
+	}
+	defer func() {
+		for _, source := range sources {
+			_ = source.file.Close()
+		}
+	}()
+	rows := &rowHeap{}
+	heap.Init(rows)
+	for i := range sources {
+		row, err := readDiskRow(sources[i].reader)
+		if err == nil {
+			heap.Push(rows, heapRow{row: row, source: i})
+		} else if !errors.Is(err, io.EOF) {
+			return err
+		}
+	}
+	for rows.Len() > 0 {
+		value := heap.Pop(rows).(heapRow)
+		if err := visit(value.row); err != nil {
+			return err
+		}
+		next, err := readDiskRow(sources[value.source].reader)
+		if err == nil {
+			heap.Push(rows, heapRow{row: next, source: value.source})
+		} else if !errors.Is(err, io.EOF) {
+			return err
+		}
+	}
+	return nil
+}
+
+func readDiskRow(reader *bufio.Reader) (diskRow, error) {
+	payload, err := reader.ReadBytes('\n')
+	if errors.Is(err, io.EOF) && len(payload) > 0 {
+		err = nil
+	}
+	if err != nil {
+		return diskRow{}, err
+	}
+	var row diskRow
+	if err := json.Unmarshal(bytes.TrimSpace(payload), &row); err != nil {
+		return diskRow{}, err
+	}
+	return row, nil
+}
+
+type scanState struct {
+	Node        node
+	CountBefore int
+	CountAfter  int
+	Scanned     int
+	Pages       int
+	Attempts    int
+	Cursor      string
+	StartedAt   string
+	FinishedAt  string
+}
+
+func (s scanState) stable() bool {
+	return s.CountBefore == s.Scanned && s.Scanned == s.CountAfter
+}
+
+type regionStream struct {
+	state        *scanState
+	client       *httpClient
+	batchSize    int
+	buffer       []regionRecord
+	lastEndKey   *string
+	terminalPage bool
+}
+
+func (s *regionStream) needsPage() bool {
+	return len(s.buffer) == 0 && !s.terminalPage
+}
+
+func (s *regionStream) acceptPage(payload wireRegions, pageCounter *int, progress io.Writer) error {
+	if payload.Count == nil || *payload.Count != len(payload.Regions) || len(payload.Regions) > s.batchSize {
+		return errors.New("/regions/key response count or batch limit is invalid")
+	}
+	s.state.Pages++
+	*pageCounter++
+	if *pageCounter%100 == 0 {
+		_, _ = fmt.Fprintf(progress, "scanned %d batches\n", *pageCounter)
+	}
+	if len(payload.Regions) == 0 {
+		s.terminalPage = true
+		return nil
+	}
+	for _, raw := range payload.Regions {
+		record, err := normalizeRegion(raw)
+		if err != nil {
+			return err
+		}
+		endKey := record.Meta.EndKey
+		if s.lastEndKey != nil && *s.lastEndKey == "" {
+			return fmt.Errorf("%s: region found after the unbounded key", s.state.Node.Name)
+		}
+		if s.lastEndKey != nil && endKey != "" && compareHexKeys(endKey, *s.lastEndKey) <= 0 {
+			return fmt.Errorf("%s: region scan key did not advance", s.state.Node.Name)
+		}
+		s.lastEndKey = &endKey
+		s.buffer = append(s.buffer, record)
+	}
+	if *s.lastEndKey == "" {
+		s.terminalPage = true
+	} else {
+		if compareHexKeys(*s.lastEndKey, s.state.Cursor) <= 0 {
+			return fmt.Errorf("%s: region scan cursor did not advance", s.state.Node.Name)
+		}
+		s.state.Cursor = *s.lastEndKey
+	}
+	return nil
+}
+
+func (s *regionStream) next() (*regionRecord, error) {
+	if s.needsPage() {
+		return nil, errors.New("internal region page was not prefetched")
+	}
+	if len(s.buffer) == 0 {
+		if s.state.FinishedAt == "" {
+			s.state.FinishedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		}
+		return nil, nil
+	}
+	record := s.buffer[0]
+	s.buffer = s.buffer[1:]
+	s.state.Scanned++
+	if len(s.buffer) == 0 && s.terminalPage {
+		s.state.FinishedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	return &record, nil
+}
+
+func prefetchPages(
+	ctx context.Context,
+	streams []*regionStream,
+	requester *batchRequester,
+	pageCounter *int,
+	progress io.Writer,
+) error {
+	pending := make([]*regionStream, 0, len(streams))
+	pages := make([]*wireRegions, 0, len(streams))
+	calls := make([]requestCall, 0, len(streams))
+	for _, stream := range streams {
+		if !stream.needsPage() {
+			continue
+		}
+		page := &wireRegions{}
+		pending = append(pending, stream)
+		pages = append(pages, page)
+		query := url.Values{
+			"format":  {"hex"},
+			"key":     {stream.state.Cursor},
+			"end_key": {""},
+			"limit":   {strconv.Itoa(stream.batchSize)},
+		}
+		calls = append(calls, requestCall{
+			client: stream.client, path: "/pd/api/v1/regions/key", query: query,
+			local: true, destination: page,
+		})
+	}
+	if err := requester.getJSON(ctx, calls); err != nil {
+		return err
+	}
+	for i, stream := range pending {
+		if err := stream.acceptPage(*pages[i], pageCounter, progress); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func scanStreams(
+	ctx context.Context,
+	states []*scanState,
+	clients []*httpClient,
+	batchSize int,
+	differences *sortedRows,
+	requester *batchRequester,
+	progress io.Writer,
+) error {
+	pageCounter := 0
+	streams := make([]*regionStream, 0, len(states))
+	for i, state := range states {
+		state.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		streams = append(streams, &regionStream{
+			state: state, client: clients[i], batchSize: batchSize,
+		})
+	}
+	for {
+		if err := prefetchPages(ctx, streams, requester, &pageCounter, progress); err != nil {
+			return err
+		}
+		records := make([]*regionRecord, len(streams))
+		allNil := true
+		for i, stream := range streams {
+			record, err := stream.next()
+			if err != nil {
+				return err
+			}
+			records[i] = record
+			allNil = allNil && record == nil
+		}
+		if allNil {
+			return nil
+		}
+		if !recordsEqual(records) {
+			for i, record := range records {
+				if record != nil {
+					if err := differences.add(record.ID, i, record.Meta); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		boundaries := recordBoundaries(records)
+		for !allBoundariesEqual(boundaries) {
+			boundary := minimumBoundary(boundaries)
+			indexes := make([]int, 0, len(boundaries))
+			selected := make([]*regionStream, 0, len(boundaries))
+			for i, current := range boundaries {
+				if current == boundary {
+					indexes = append(indexes, i)
+					selected = append(selected, streams[i])
+				}
+			}
+			if err := prefetchPages(ctx, selected, requester, &pageCounter, progress); err != nil {
+				return err
+			}
+			for _, i := range indexes {
+				record, err := streams[i].next()
+				if err != nil {
+					return err
+				}
+				if record == nil {
+					boundaries[i] = ""
+					continue
+				}
+				boundaries[i] = record.Meta.EndKey
+				if err := differences.add(record.ID, i, record.Meta); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func recordsEqual(records []*regionRecord) bool {
+	for i := 1; i < len(records); i++ {
+		if (records[0] == nil) != (records[i] == nil) ||
+			(records[0] != nil && !records[0].equal(*records[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+func recordBoundaries(records []*regionRecord) []string {
+	result := make([]string, len(records))
+	for i, record := range records {
+		if record != nil {
+			result[i] = record.Meta.EndKey
+		}
+	}
+	return result
+}
+
+func allBoundariesEqual(boundaries []string) bool {
+	for i := 1; i < len(boundaries); i++ {
+		if boundaries[i] != boundaries[0] {
+			return false
+		}
+	}
+	return true
+}
+
+func minimumBoundary(boundaries []string) string {
+	minimum := boundaries[0]
+	for _, value := range boundaries[1:] {
+		if compareBoundary(value, minimum) < 0 {
+			minimum = value
+		}
+	}
+	return minimum
+}
+
+func compareBoundary(a, b string) int {
+	if a == "" {
+		if b == "" {
+			return 0
+		}
+		return 1
+	}
+	if b == "" {
+		return -1
+	}
+	return compareHexKeys(a, b)
+}
+
+func compareHexKeys(a, b string) int {
+	aBytes, _ := hex.DecodeString(a)
+	bBytes, _ := hex.DecodeString(b)
+	return bytes.Compare(aBytes, bBytes)
+}
+
+type countResponse struct {
+	Count *int `json:"count"`
+}
+
+func collectRegions(
+	ctx context.Context,
+	nodes []node,
+	clients []*httpClient,
+	batchSize int,
+	scanRetries int,
+	directory string,
+	budget *diskBudget,
+	requester *batchRequester,
+	progress io.Writer,
+) ([]*scanState, *sortedRows, error) {
+	var lastStates []*scanState
+	for attempt := 1; attempt <= scanRetries+1; attempt++ {
+		states := make([]*scanState, 0, len(nodes))
+		for _, current := range nodes {
+			states = append(states, &scanState{Node: current, Attempts: attempt})
+		}
+		before := make([]*countResponse, len(nodes))
+		calls := make([]requestCall, 0, len(nodes))
+		for i := range nodes {
+			before[i] = &countResponse{}
+			calls = append(calls, requestCall{
+				client: clients[i], path: "/pd/api/v1/regions/count", local: true, destination: before[i],
+			})
+		}
+		if err := requester.getJSON(ctx, calls); err != nil {
+			return nil, nil, err
+		}
+		for i := range states {
+			if before[i].Count == nil || *before[i].Count < 0 {
+				return nil, nil, errors.New("/regions/count response does not contain a valid count")
+			}
+			states[i].CountBefore = *before[i].Count
+		}
+		differences := newSortedRows(directory, budget)
+		if err := scanStreams(ctx, states, clients, batchSize, differences, requester, progress); err != nil {
+			differences.cleanup()
+			return nil, nil, err
+		}
+		after := make([]*countResponse, len(nodes))
+		calls = calls[:0]
+		for i := range nodes {
+			after[i] = &countResponse{}
+			calls = append(calls, requestCall{
+				client: clients[i], path: "/pd/api/v1/regions/count", local: true, destination: after[i],
+			})
+		}
+		if err := requester.getJSON(ctx, calls); err != nil {
+			differences.cleanup()
+			return nil, nil, err
+		}
+		stable := true
+		for i := range states {
+			if after[i].Count == nil || *after[i].Count < 0 {
+				differences.cleanup()
+				return nil, nil, errors.New("/regions/count response does not contain a valid count")
+			}
+			states[i].CountAfter = *after[i].Count
+			stable = stable && states[i].stable()
+		}
+		if stable {
+			if err := differences.finish(); err != nil {
+				differences.cleanup()
+				return nil, nil, err
+			}
+			return states, differences, nil
+		}
+		differences.cleanup()
+		lastStates = states
+		if attempt <= scanRetries {
+			_, _ = fmt.Fprintln(progress, "region count changed during scan; retrying every PD member")
+		}
+	}
+	details := make([]string, 0, len(lastStates))
+	for _, state := range lastStates {
+		if !state.stable() {
+			details = append(details, fmt.Sprintf("%s: before=%d, scanned=%d, after=%d",
+				state.Node.Name, state.CountBefore, state.Scanned, state.CountAfter))
+		}
+	}
+	return nil, nil, fmt.Errorf("unstable region set after %d cluster-wide scan attempt(s) (%s)",
+		scanRetries+1, strings.Join(details, "; "))
+}

--- a/tools/pd-ctl/pdctl/command/regionmeta/types.go
+++ b/tools/pd-ctl/pdctl/command/regionmeta/types.go
@@ -1,0 +1,389 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regionmeta
+
+import (
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	maxResponseBytes = 8 * 1024 * 1024
+	sortBufferBytes  = 8 * 1024 * 1024
+	mergeFanIn       = 8
+)
+
+// Status is the conclusion of a completed region meta check.
+type Status string
+
+const (
+	// StatusConsistent means no difference remains after confirmation.
+	StatusConsistent Status = "consistent"
+	// StatusInconsistent means at least one stable difference was confirmed.
+	StatusInconsistent Status = "inconsistent"
+	// StatusIncomplete means the observations are insufficient for a conclusion.
+	StatusIncomplete Status = "incomplete"
+)
+
+// Outcome contains the process-relevant result of a completed check.
+type Outcome struct {
+	Status Status
+}
+
+// Config controls one region meta check.
+type Config struct {
+	Endpoints             []string
+	TLSConfig             *tls.Config
+	AuthorizationFile     string
+	BatchSize             int
+	Interval              time.Duration
+	Timeout               time.Duration
+	MaxRuntime            time.Duration
+	Retries               int
+	ScanRetries           int
+	ConfirmLimit          int
+	ConfirmationDelay     time.Duration
+	WorkDir               string
+	MaxTemporaryDiskBytes int64
+	MaxOutputBytes        int64
+	Output                string
+}
+
+// DefaultConfig returns conservative production defaults.
+func DefaultConfig() Config {
+	return Config{
+		BatchSize:             128,
+		Interval:              50 * time.Millisecond,
+		Timeout:               10 * time.Second,
+		MaxRuntime:            4 * time.Hour,
+		ConfirmLimit:          128,
+		ConfirmationDelay:     time.Second,
+		MaxTemporaryDiskBytes: 1024 * 1024 * 1024,
+		MaxOutputBytes:        1024 * 1024 * 1024,
+		Output:                "-",
+	}
+}
+
+func (c Config) validate() error {
+	if len(c.Endpoints) == 0 {
+		return errors.New("at least one PD endpoint is required")
+	}
+	if c.BatchSize < 1 || c.BatchSize > 1024 {
+		return errors.New("batch size must be in [1, 1024]")
+	}
+	if c.Interval < 0 || c.Timeout <= 0 || c.MaxRuntime <= 0 || c.ConfirmationDelay < 0 {
+		return errors.New("interval must be non-negative and timeout and max runtime must be positive")
+	}
+	if c.Retries < 0 || c.Retries > 10 || c.ScanRetries < 0 || c.ScanRetries > 3 {
+		return errors.New("retries must be in [0, 10] and scan retries must be in [0, 3]")
+	}
+	if c.ConfirmLimit < 0 || c.ConfirmLimit > 1024 {
+		return errors.New("confirmation limit must be in [0, 1024]")
+	}
+	if c.MaxTemporaryDiskBytes <= 0 || c.MaxOutputBytes <= 0 {
+		return errors.New("temporary disk and output limits must be positive")
+	}
+	if c.Output == "" {
+		return errors.New("output must be '-' or a file path")
+	}
+	return nil
+}
+
+type node struct {
+	MemberID uint64
+	Name     string
+	URL      string
+	Role     string
+}
+
+func (n node) instance() string {
+	u, _ := url.Parse(n.URL)
+	return n.Name + "@" + u.Host
+}
+
+type peer struct {
+	ID        uint64 `json:"id"`
+	StoreID   uint64 `json:"store_id"`
+	Role      uint32 `json:"role"`
+	IsWitness bool   `json:"is_witness"`
+}
+
+type regionMeta struct {
+	StartKey string `json:"s"`
+	EndKey   string `json:"e"`
+	ConfVer  uint64 `json:"c"`
+	Version  uint64 `json:"v"`
+	Peers    []peer `json:"p"`
+	Leader   *peer  `json:"l"`
+}
+
+func (m regionMeta) equal(other regionMeta) bool {
+	return m.StartKey == other.StartKey && m.EndKey == other.EndKey &&
+		m.ConfVer == other.ConfVer && m.Version == other.Version &&
+		slices.Equal(m.Peers, other.Peers) && sameLeader(m.Leader, other.Leader)
+}
+
+type regionRecord struct {
+	ID   uint64
+	Meta regionMeta
+}
+
+func (r regionRecord) equal(other regionRecord) bool {
+	return r.ID == other.ID && r.Meta.equal(other.Meta)
+}
+
+type wirePeer struct {
+	ID        uint64 `json:"id"`
+	StoreID   uint64 `json:"store_id"`
+	Role      uint32 `json:"role"`
+	IsLearner bool   `json:"is_learner"`
+	IsWitness bool   `json:"is_witness"`
+}
+
+type wireEpoch struct {
+	ConfVer uint64 `json:"conf_ver"`
+	Version uint64 `json:"version"`
+}
+
+type wireRegion struct {
+	ID       uint64     `json:"id"`
+	StartKey string     `json:"start_key"`
+	EndKey   string     `json:"end_key"`
+	Epoch    wireEpoch  `json:"epoch"`
+	Peers    []wirePeer `json:"peers"`
+	Leader   *wirePeer  `json:"leader"`
+}
+
+type wireRegions struct {
+	Count   *int         `json:"count"`
+	Regions []wireRegion `json:"regions"`
+}
+
+func normalizeRegion(raw wireRegion) (regionRecord, error) {
+	if raw.ID == 0 {
+		return regionRecord{}, errors.New("region response contains an invalid uint64 id")
+	}
+	startKey, err := normalizeHexKey(raw.StartKey, "start_key", raw.ID)
+	if err != nil {
+		return regionRecord{}, err
+	}
+	endKey, err := normalizeHexKey(raw.EndKey, "end_key", raw.ID)
+	if err != nil {
+		return regionRecord{}, err
+	}
+	peers := make([]peer, 0, len(raw.Peers))
+	for _, value := range raw.Peers {
+		peers = append(peers, normalizePeer(value))
+	}
+	slices.SortFunc(peers, comparePeer)
+	var leader *peer
+	if raw.Leader != nil {
+		value := normalizePeer(*raw.Leader)
+		if value.ID != 0 || value.StoreID != 0 {
+			leader = &value
+		}
+	}
+	return regionRecord{ID: raw.ID, Meta: regionMeta{
+		StartKey: startKey, EndKey: endKey, ConfVer: raw.Epoch.ConfVer,
+		Version: raw.Epoch.Version, Peers: peers, Leader: leader,
+	}}, nil
+}
+
+func normalizePeer(raw wirePeer) peer {
+	role := raw.Role
+	if raw.IsLearner && role == 0 {
+		role = 1
+	}
+	return peer{ID: raw.ID, StoreID: raw.StoreID, Role: role, IsWitness: raw.IsWitness}
+}
+
+func comparePeer(a, b peer) int {
+	if a.ID != b.ID {
+		return compareUint64(a.ID, b.ID)
+	}
+	if a.StoreID != b.StoreID {
+		return compareUint64(a.StoreID, b.StoreID)
+	}
+	if a.Role != b.Role {
+		return int(a.Role) - int(b.Role)
+	}
+	if a.IsWitness == b.IsWitness {
+		return 0
+	}
+	if !a.IsWitness {
+		return -1
+	}
+	return 1
+}
+
+func compareUint64(a, b uint64) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+func normalizeHexKey(value, field string, regionID uint64) (string, error) {
+	value = strings.ToUpper(value)
+	if len(value)%2 != 0 {
+		return "", fmt.Errorf("region %d has invalid hexadecimal %s", regionID, field)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return "", fmt.Errorf("region %d has invalid hexadecimal %s: %w", regionID, field, err)
+	}
+	return value, nil
+}
+
+type keyRange struct {
+	StartKey string `json:"start_key"`
+	EndKey   string `json:"end_key"`
+}
+
+type epoch struct {
+	ConfVer uint64 `json:"conf_ver"`
+	Version uint64 `json:"version"`
+}
+
+type difference struct {
+	RegionID   uint64              `json:"region_id"`
+	MissingOn  []string            `json:"missing_on,omitempty"`
+	KeyRange   map[string]keyRange `json:"key_range,omitempty"`
+	Epoch      map[string]epoch    `json:"epoch,omitempty"`
+	Peers      map[string][]peer   `json:"peers,omitempty"`
+	LeaderPeer map[string]*peer    `json:"leader_peer,omitempty"`
+}
+
+func (d difference) equal(other difference) bool {
+	return d.RegionID == other.RegionID && slices.Equal(d.MissingOn, other.MissingOn) &&
+		mapsEqual(d.KeyRange, other.KeyRange) && mapsEqual(d.Epoch, other.Epoch) &&
+		peerMapsEqual(d.Peers, other.Peers) && leaderMapsEqual(d.LeaderPeer, other.LeaderPeer)
+}
+
+func mapsEqual[K comparable, V comparable](a, b map[K]V) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if other, ok := b[key]; !ok || value != other {
+			return false
+		}
+	}
+	return true
+}
+
+func peerMapsEqual(a, b map[string][]peer) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if other, ok := b[key]; !ok || !slices.Equal(value, other) {
+			return false
+		}
+	}
+	return true
+}
+
+func leaderMapsEqual(a, b map[string]*peer) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		other, ok := b[key]
+		if !ok || (value == nil) != (other == nil) || (value != nil && *value != *other) {
+			return false
+		}
+	}
+	return true
+}
+
+func makeDifference(regionID uint64, rows []*regionMeta, nodes []node) *difference {
+	missing := false
+	var firstPresent *regionMeta
+	for _, row := range rows {
+		if row == nil {
+			missing = true
+		} else if firstPresent == nil {
+			firstPresent = row
+		}
+	}
+	if firstPresent == nil {
+		return nil
+	}
+	d := &difference{RegionID: regionID}
+	if missing {
+		for i, row := range rows {
+			if row == nil {
+				d.MissingOn = append(d.MissingOn, nodes[i].instance())
+			}
+		}
+	}
+	keyRangeDiff, epochDiff, peersDiff, leaderDiff := false, false, false, false
+	for _, row := range rows {
+		if row == nil {
+			continue
+		}
+		keyRangeDiff = keyRangeDiff || row.StartKey != firstPresent.StartKey || row.EndKey != firstPresent.EndKey
+		epochDiff = epochDiff || row.ConfVer != firstPresent.ConfVer || row.Version != firstPresent.Version
+		peersDiff = peersDiff || !slices.Equal(row.Peers, firstPresent.Peers)
+		leaderDiff = leaderDiff || !sameLeader(row.Leader, firstPresent.Leader)
+	}
+	if keyRangeDiff {
+		d.KeyRange = make(map[string]keyRange)
+	}
+	if epochDiff {
+		d.Epoch = make(map[string]epoch)
+	}
+	if peersDiff {
+		d.Peers = make(map[string][]peer)
+	}
+	if leaderDiff {
+		d.LeaderPeer = make(map[string]*peer)
+	}
+	for i, row := range rows {
+		if row == nil {
+			continue
+		}
+		instance := nodes[i].instance()
+		if keyRangeDiff {
+			d.KeyRange[instance] = keyRange{StartKey: row.StartKey, EndKey: row.EndKey}
+		}
+		if epochDiff {
+			d.Epoch[instance] = epoch{ConfVer: row.ConfVer, Version: row.Version}
+		}
+		if peersDiff {
+			d.Peers[instance] = row.Peers
+		}
+		if leaderDiff {
+			d.LeaderPeer[instance] = row.Leader
+		}
+	}
+	if len(d.MissingOn) == 0 && !keyRangeDiff && !epochDiff && !peersDiff && !leaderDiff {
+		return nil
+	}
+	return d
+}
+
+func sameLeader(a, b *peer) bool {
+	return (a == nil && b == nil) || (a != nil && b != nil && *a == *b)
+}

--- a/tools/pd-ctl/pdctl/ctl.go
+++ b/tools/pd-ctl/pdctl/ctl.go
@@ -15,6 +15,7 @@
 package pdctl
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -82,9 +83,15 @@ func GetRootCmd() *cobra.Command {
 	return rootCmd
 }
 
-// MainStart start main command
-func MainStart(args []string) {
+// MainStart starts the main command and returns its process exit code.
+func MainStart(args []string) int {
+	return MainStartContext(context.Background(), args)
+}
+
+// MainStartContext starts the main command with a cancelable context.
+func MainStartContext(ctx context.Context, args []string) int {
 	rootCmd := GetRootCmd()
+	rootCmd.SetContext(ctx)
 
 	rootCmd.Flags().BoolP("interact", "i", false, "Run pdctl with readline.")
 	rootCmd.Flags().BoolP("version", "V", false, "Print version information and exit.")
@@ -105,10 +112,19 @@ func MainStart(args []string) {
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.SetErr(os.Stderr)
 
-	if err := rootCmd.Execute(); err != nil {
-		rootCmd.Println(err)
-		os.Exit(1)
+	return execute(rootCmd)
+}
+
+func execute(rootCmd *cobra.Command) int {
+	err := rootCmd.Execute()
+	if err == nil {
+		return 0
 	}
+	code, silent := command.ExitCode(err)
+	if !silent {
+		rootCmd.PrintErrln(err)
+	}
+	return code
 }
 
 func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoCompleter) {
@@ -162,9 +178,7 @@ func loop(persistentFlags *pflag.FlagSet, readlineCompleter readline.AutoComplet
 		rootCmd := getREPLCmd()
 		rootCmd.SetArgs(args)
 		rootCmd.ParseFlags(args)
-		if err := rootCmd.Execute(); err != nil {
-			rootCmd.Println(err)
-		}
+		_ = execute(rootCmd)
 	}
 }
 

--- a/tools/pd-ctl/pdctl/ctl_test.go
+++ b/tools/pd-ctl/pdctl/ctl_test.go
@@ -15,6 +15,7 @@
 package pdctl
 
 import (
+	"bytes"
 	"io"
 	"strings"
 	"testing"
@@ -90,5 +91,27 @@ func TestReadStdin(t *testing.T) {
 		for i, target := range v.targets {
 			re.Equal(target, in[i])
 		}
+	}
+}
+
+func TestRegionMetaConsistencyInvalidArgumentsExitWithStatusTwo(t *testing.T) {
+	tests := [][]string{
+		{"region", "meta-consistency", "extra"},
+		{"region", "meta-consistency", "--batch-size=invalid"},
+		{"region", "meta-consistency", "--unknown-flag"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			root := GetRootCmd()
+			var stdout, stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(args)
+
+			require.Equal(t, 2, execute(root))
+			require.Empty(t, stdout.String())
+			require.NotContains(t, stderr.String(), "Usage:")
+			require.NotEmpty(t, stderr.String())
+		})
 	}
 }

--- a/tools/pd-ctl/tests/region/meta_consistency_test.go
+++ b/tools/pd-ctl/tests/region/meta_consistency_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package region_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/server/config"
+	pdTests "github.com/tikv/pd/tests"
+	ctl "github.com/tikv/pd/tools/pd-ctl/pdctl"
+	"github.com/tikv/pd/tools/pd-ctl/pdctl/command"
+)
+
+func TestRegionMetaConsistencyUsesFollowerLocalCache(t *testing.T) {
+	re := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cluster, err := pdTests.NewTestCluster(ctx, 3, func(conf *config.Config, _ string) {
+		conf.PDServerCfg.UseRegionStorage = true
+	})
+	re.NoError(err)
+	defer cluster.Destroy()
+	re.NoError(cluster.RunInitialServers())
+	re.NotEmpty(cluster.WaitLeader())
+	leader := cluster.GetLeaderServer()
+	re.NoError(leader.BootstrapCluster())
+	re.True(cluster.WaitRegionSyncerClientsReady(2))
+
+	regions := []*core.RegionInfo{
+		pdTests.MustPutRegion(re, cluster, 1, 1, []byte{}, []byte("a"), core.SetRegionVersion(1)),
+		pdTests.MustPutRegion(re, cluster, 2, 1, []byte("a"), []byte("b"), core.SetRegionVersion(1)),
+		pdTests.MustPutRegion(re, cluster, 3, 1, []byte("b"), []byte{}, core.SetRegionVersion(1)),
+	}
+	for _, server := range cluster.GetServers() {
+		re.Eventually(func() bool {
+			return len(server.GetServer().GetBasicCluster().GetRegions()) == len(regions)
+		}, 5*time.Second, 20*time.Millisecond)
+	}
+
+	seed := cluster.GetConfig().GetClientURL()
+	status, report, stderr, err := executeMetaConsistency(seed, t.TempDir())
+	re.NoError(err, stderr)
+	re.Equal(0, status)
+	re.Equal("consistent", report["status"])
+
+	followerName := cluster.GetFollower()
+	re.NotEmpty(followerName)
+	follower := cluster.GetServer(followerName)
+	stale := regions[1].Clone(core.WithIncVersion())
+	follower.GetServer().GetBasicCluster().PutRegion(stale)
+	re.Equal(stale.GetRegionEpoch().GetVersion(),
+		follower.GetServer().GetBasicCluster().GetRegion(stale.GetID()).GetRegionEpoch().GetVersion())
+
+	status, report, stderr, err = executeMetaConsistency(seed, t.TempDir())
+	re.Error(err, stderr)
+	re.Equal(1, status)
+	if report == nil {
+		t.Fatalf("missing report: err=%v stderr=%q", err, stderr)
+	}
+	re.Equal("inconsistent", report["status"])
+	re.Equal(float64(1), report["summary"].(map[string]any)["different_regions"])
+	difference := report["differences"].([]any)[0].(map[string]any)
+	re.Equal(float64(stale.GetID()), difference["region_id"])
+	re.Contains(difference, "epoch")
+
+	follower.GetServer().GetBasicCluster().PutRegion(regions[1])
+	status, report, stderr, err = executeMetaConsistency(seed, t.TempDir())
+	re.NoError(err, stderr)
+	re.Equal(0, status)
+	re.Equal("consistent", report["status"])
+
+	follower.GetServer().GetBasicCluster().RemoveRegionIfExist(regions[1].GetID())
+	status, report, stderr, err = executeMetaConsistency(seed, t.TempDir())
+	re.Error(err, stderr)
+	re.Equal(1, status)
+	re.Equal("inconsistent", report["status"])
+	difference = report["differences"].([]any)[0].(map[string]any)
+	re.Equal(float64(regions[1].GetID()), difference["region_id"])
+	missingOn := difference["missing_on"].([]any)
+	re.Len(missingOn, 1)
+	re.Contains(missingOn[0], followerName+"@")
+
+	follower.GetServer().GetBasicCluster().PutRegion(regions[1])
+}
+
+func executeMetaConsistency(seed, workDir string) (int, map[string]any, string, error) {
+	root := ctl.GetRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"-u", seed, "region", "meta-consistency", "--batch-size", "2", "--interval", "0s",
+		"--timeout", "2s", "--max-runtime", "30s", "--confirm-limit", "8", "--work-dir", workDir,
+	})
+	err := root.Execute()
+	status := 0
+	if err != nil {
+		status, _ = command.ExitCode(err)
+	}
+	var report map[string]any
+	if unmarshalErr := json.Unmarshal(stdout.Bytes(), &report); unmarshalErr != nil {
+		err = fmt.Errorf("command error: %v; decode report: %w; stdout: %q", err, unmarshalErr, stdout.String())
+	}
+	return status, report, stderr.String(), err
+}


### PR DESCRIPTION
### What problem does this PR solve?

PD followers maintain local region metadata through the region syncer, but synchronization gaps can leave a follower with stale or missing region metadata. Operators currently lack a native, production-conscious way to compare the local region metadata held by every PD member.

Issue Number: close #11092

### What is changed and how does it work?

```commit-message
Add a native `pd-ctl region meta-consistency` command that discovers every PD member and queries each member's local region cache directly.

Scan region metadata in small, globally rate-limited batches. Requests for the same batch are issued concurrently across members while each member receives at most one in-flight request.

Normalize and compare Region IDs, key ranges, epochs, peers, and Region leader peers. Spill only differing records to bounded temporary storage, recheck a bounded set of differences, and stream the complete JSON report without retaining the full cluster metadata in memory.

Return distinct exit codes for consistent, inconsistent, and incomplete results, and propagate command cancellation to in-flight HTTP requests.
```

### Check List

Tests

- Unit test
  - `make -C tools gotest GOTEST_ARGS='./pd-ctl/pdctl/command/regionmeta ./pd-ctl/pdctl/command ./pd-ctl/pdctl -count=1'`
- Integration test
  - `make -C tools gotest GOTEST_ARGS='-tags=without_dashboard ./pd-ctl/tests/region -count=1'`

Side effects

- Possible performance regression: an explicitly invoked full scan consumes PD HTTP, JSON serialization, network, and short-lived Region tree read resources; conservative global rate limiting is enabled by default.
- Increased code complexity

### Release note

```release-note
Add the `pd-ctl region meta-consistency` command to compare region metadata across all PD members and report stable differences.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pd-ctl region meta-consistency` to compare region metadata across PD members.
  * Supports JSON reports, retries, confirmation checks, resource limits, TLS, authorization, and configurable scanning options.
  * Provides clear exit statuses for consistent, inconsistent, and incomplete or invalid results.

* **Bug Fixes**
  * Interrupting commands now cancels ongoing requests and exits cleanly.
  * HTTP operations now respect command cancellation and deadlines.

* **Documentation**
  * Added comprehensive usage and operational guidance for the new command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->