### PR TITLE
tools: make pd-ut task order deterministic

### DIFF
--- a/tools/pd-ut/ut.go
+++ b/tools/pd-ut/ut.go
@@ -372,7 +372,7 @@ func cmdRun(args ...string) bool {
 		go works[i].worker(&wg, taskCh)
 	}
 
-	sortTasks(tasks)
+	orderTasks(tasks)
 
 	start = time.Now()
 	for _, task := range tasks {
@@ -911,13 +911,36 @@ func filter(input []string, f func(string) bool) []string {
 	return ret
 }
 
-func sortTasks(tasks []task) {
+func orderTasks(tasks []task) {
 	sort.Slice(tasks, func(i, j int) bool {
 		if tasks[i].pkg != tasks[j].pkg {
 			return tasks[i].pkg < tasks[j].pkg
 		}
 		return tasks[i].test < tasks[j].test
 	})
+
+	groups := make([][]task, 0)
+	for i := 0; i < len(tasks); {
+		j := i + 1
+		for j < len(tasks) && tasks[j].pkg == tasks[i].pkg {
+			j++
+		}
+		groups = append(groups, tasks[i:j])
+		i = j
+	}
+
+	ordered := make([]task, 0, len(tasks))
+	for len(groups) > 0 {
+		next := groups[:0]
+		for _, group := range groups {
+			ordered = append(ordered, group[0])
+			if len(group) > 1 {
+				next = append(next, group[1:])
+			}
+		}
+		groups = next
+	}
+	copy(tasks, ordered)
 }
 
 type errWithStack struct {

--- a/tools/pd-ut/ut.go
+++ b/tools/pd-ut/ut.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -372,7 +372,7 @@ func cmdRun(args ...string) bool {
 		go works[i].worker(&wg, taskCh)
 	}
 
-	shuffle(tasks)
+	sortTasks(tasks)
 
 	start = time.Now()
 	for _, task := range tasks {
@@ -911,11 +911,13 @@ func filter(input []string, f func(string) bool) []string {
 	return ret
 }
 
-func shuffle(tasks []task) {
-	for i := 0; i < len(tasks); i++ {
-		pos := rand.IntN(len(tasks))
-		tasks[i], tasks[pos] = tasks[pos], tasks[i]
-	}
+func sortTasks(tasks []task) {
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].pkg != tasks[j].pkg {
+			return tasks[i].pkg < tasks[j].pkg
+		}
+		return tasks[i].test < tasks[j].test
+	})
 }
 
 type errWithStack struct {

--- a/tools/pd-ut/ut_test.go
+++ b/tools/pd-ut/ut_test.go
@@ -89,3 +89,21 @@ func TestCheckDiff(t *testing.T) {
 	re.NoError(err)
 	re.Empty(diffText)
 }
+
+func TestSortTasks(t *testing.T) {
+	tasks := []task{
+		{pkg: "pkg/z", test: "TestB"},
+		{pkg: "pkg/a", test: "TestC"},
+		{pkg: "pkg/a", test: "TestA"},
+		{pkg: "pkg/z", test: "TestA"},
+	}
+
+	sortTasks(tasks)
+
+	require.Equal(t, []task{
+		{pkg: "pkg/a", test: "TestA"},
+		{pkg: "pkg/a", test: "TestC"},
+		{pkg: "pkg/z", test: "TestA"},
+		{pkg: "pkg/z", test: "TestB"},
+	}, tasks)
+}

--- a/tools/pd-ut/ut_test.go
+++ b/tools/pd-ut/ut_test.go
@@ -90,20 +90,22 @@ func TestCheckDiff(t *testing.T) {
 	re.Empty(diffText)
 }
 
-func TestSortTasks(t *testing.T) {
+func TestOrderTasks(t *testing.T) {
 	tasks := []task{
 		{pkg: "pkg/z", test: "TestB"},
 		{pkg: "pkg/a", test: "TestC"},
 		{pkg: "pkg/a", test: "TestA"},
+		{pkg: "pkg/m", test: "TestA"},
 		{pkg: "pkg/z", test: "TestA"},
 	}
 
-	sortTasks(tasks)
+	orderTasks(tasks)
 
 	require.Equal(t, []task{
 		{pkg: "pkg/a", test: "TestA"},
-		{pkg: "pkg/a", test: "TestC"},
+		{pkg: "pkg/m", test: "TestA"},
 		{pkg: "pkg/z", test: "TestA"},
+		{pkg: "pkg/a", test: "TestC"},
 		{pkg: "pkg/z", test: "TestB"},
 	}, tasks)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11113

`pd-ut` shuffled top-level test tasks with process-random `math/rand/v2`, so identical CI shards ran different concurrent task mixes. Resource-sensitive failures could not be reproduced from the job configuration alone.

### What is changed and how does it work?

```commit-message
Replace process-random task shuffling with deterministic task ordering.

Sort tasks by package and test name to normalize concurrent discovery, then interleave package queues round-robin to preserve cross-package scattering.
```

### Check List

Tests

- Unit test
  - `go test -race ./pd-ut -count=1`
  - `go test -race ./pd-ut -run '^TestOrderTasks$' -count=100`
- Integration test
  - `TestMicroserviceTSOClientSuite/TestGetMinTS` passed 20 consecutive next-gen, deadlock, race-enabled runs.
- Manual test
  - `make ut` passed all 1,105 tasks at reported parallelism 144.
  - `pd-ut` help, list, build, filtered run, multi-package run, and JUnit output were exercised.

### Review Report

| Area | Verdict | Confidence |
|---|---|---|
| Goal and constraints | PASS | High |
| Hands-on QA | PASS | High |
| Code quality | PASS | High |
| Security | PASS | No findings |
| History and context | PASS | High |

No blocking issues remain. The first review identified package clustering in the package-major sort; commit `5a2831f7a` replaced it with deterministic round-robin package ordering, and the fresh five-lane re-review passed.

### Release note

```release-note
None.
```
