### PR TITLE
tso, etcdutil: fence keyspace group discovery during watch recovery

### DIFF
--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -1182,6 +1182,9 @@ func (m *GroupManager) MergeKeyspaceGroups(mergeTargetID uint32, mergeList []uin
 	if slice.Contains(mergeList, constant.DefaultKeyspaceGroupID) {
 		return errs.ErrModifyDefaultKeyspaceGroup
 	}
+	if slice.Contains(mergeList, mergeTargetID) {
+		return errors.Errorf("keyspace group %d cannot be both merge target and source", mergeTargetID)
+	}
 	var (
 		groups        = make(map[uint32]*endpoint.KeyspaceGroup, mergeListNum+1)
 		mergeTargetKg *endpoint.KeyspaceGroup

--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -443,6 +443,9 @@ func (m *GroupManager) GetKeyspaceGroupByID(id uint32) (*endpoint.KeyspaceGroup,
 
 // DeleteKeyspaceGroupByID deletes the keyspace group by ID.
 func (m *GroupManager) DeleteKeyspaceGroupByID(id uint32) (*endpoint.KeyspaceGroup, error) {
+	if id == constant.DefaultKeyspaceGroupID {
+		return nil, errs.ErrModifyDefaultKeyspaceGroup
+	}
 	var (
 		kg  *endpoint.KeyspaceGroup
 		err error
@@ -461,9 +464,24 @@ func (m *GroupManager) DeleteKeyspaceGroupByID(id uint32) (*endpoint.KeyspaceGro
 		if kg.IsSplitting() {
 			return errs.ErrKeyspaceGroupInSplit.FastGenByArgs(id)
 		}
-		return m.store.DeleteKeyspaceGroup(txn, id)
+		defaultKG, err := m.store.LoadKeyspaceGroup(txn, constant.DefaultKeyspaceGroupID)
+		if err != nil {
+			return err
+		}
+		if defaultKG == nil {
+			return errs.ErrKeyspaceGroupNotExists.FastGenByArgs(constant.DefaultKeyspaceGroupID)
+		}
+		if err := m.store.DeleteKeyspaceGroup(txn, id); err != nil {
+			return err
+		}
+		// Refresh a surviving membership key so snapshot reloads retain the
+		// deletion's comparable revision.
+		return m.store.SaveKeyspaceGroup(txn, defaultKG)
 	}); err != nil {
 		return nil, err
+	}
+	if kg == nil {
+		return nil, nil
 	}
 
 	userKind := endpoint.StringUserKind(kg.UserKind)

--- a/pkg/keyspace/tso_keyspace_group.go
+++ b/pkg/keyspace/tso_keyspace_group.go
@@ -474,8 +474,8 @@ func (m *GroupManager) DeleteKeyspaceGroupByID(id uint32) (*endpoint.KeyspaceGro
 		if err := m.store.DeleteKeyspaceGroup(txn, id); err != nil {
 			return err
 		}
-		// Refresh a surviving membership key so snapshot reloads retain the
-		// deletion's comparable revision.
+		// Refresh a surviving membership key so readers that observe this
+		// transaction retain the deletion's comparable revision.
 		return m.store.SaveKeyspaceGroup(txn, defaultKG)
 	}); err != nil {
 		return nil, err

--- a/pkg/keyspace/tso_keyspace_group_test.go
+++ b/pkg/keyspace/tso_keyspace_group_test.go
@@ -608,6 +608,12 @@ func (suite *keyspaceGroupTestSuite) TestKeyspaceGroupMerge() {
 	// merge the default keyspace group
 	err = suite.kgm.MergeKeyspaceGroups(1, []uint32{constant.DefaultKeyspaceGroupID})
 	re.ErrorIs(err, errs.ErrModifyDefaultKeyspaceGroup)
+	// merge target cannot also be deleted as a merge source
+	err = suite.kgm.MergeKeyspaceGroups(1, []uint32{1})
+	re.ErrorContains(err, "cannot be both merge target and source")
+	kg1, err = suite.kgm.GetKeyspaceGroupByID(1)
+	re.NoError(err)
+	re.NotNil(kg1)
 }
 
 func TestBuildSplitKeyspaces(t *testing.T) {

--- a/pkg/keyspace/tso_keyspace_group_test.go
+++ b/pkg/keyspace/tso_keyspace_group_test.go
@@ -40,11 +40,13 @@ var errSaveKeyspaceGroup = errors.New("save keyspace group error")
 
 type errorKeyspaceGroupStorage struct {
 	*endpoint.StorageEndpoint
-	failOnSaveID uint32
+	failOnSaveID      uint32
+	failOnDefaultSave bool
 }
 
 func (s *errorKeyspaceGroupStorage) SaveKeyspaceGroup(txn kv.Txn, kg *endpoint.KeyspaceGroup) error {
-	if s.failOnSaveID != 0 && kg.ID == s.failOnSaveID {
+	if (s.failOnDefaultSave && kg.ID == constant.DefaultKeyspaceGroupID) ||
+		(s.failOnSaveID != 0 && kg.ID == s.failOnSaveID) {
 		return errSaveKeyspaceGroup
 	}
 	return s.StorageEndpoint.SaveKeyspaceGroup(txn, kg)
@@ -111,6 +113,9 @@ func (suite *keyspaceGroupTestSuite) TestKeyspaceGroupOperations() {
 	re.Equal(uint32(0), kg.ID)
 	re.Equal(endpoint.Basic.String(), kg.UserKind)
 	re.False(kg.IsSplitting())
+	kg, err = suite.kgm.DeleteKeyspaceGroupByID(constant.DefaultKeyspaceGroupID)
+	re.Nil(kg)
+	re.ErrorIs(err, errs.ErrModifyDefaultKeyspaceGroup)
 	// get the keyspace group 3
 	kg, err = suite.kgm.GetKeyspaceGroupByID(3)
 	re.NoError(err)
@@ -125,10 +130,47 @@ func (suite *keyspaceGroupTestSuite) TestKeyspaceGroupOperations() {
 	kg, err = suite.kgm.GetKeyspaceGroupByID(3)
 	re.NoError(err)
 	re.Empty(kg)
+	kg, err = suite.kgm.DeleteKeyspaceGroupByID(3)
+	re.NoError(err)
+	re.Nil(kg)
 	// create an existing keyspace group
 	keyspaceGroups = []*endpoint.KeyspaceGroup{{ID: uint32(1), UserKind: endpoint.Standard.String()}}
 	err = suite.kgm.CreateKeyspaceGroups(keyspaceGroups)
 	re.Error(err)
+}
+
+func (suite *keyspaceGroupTestSuite) TestDeleteKeyspaceGroupPublishesRevisionAtomically() {
+	re := suite.Require()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := endpoint.NewStorageEndpoint(kv.NewMemoryKV(), nil)
+	errorStore := &errorKeyspaceGroupStorage{StorageEndpoint: store}
+	kgm := NewKeyspaceGroupManager(ctx, errorStore, nil)
+	re.NoError(kgm.Bootstrap(ctx))
+	re.NoError(kgm.CreateKeyspaceGroups([]*endpoint.KeyspaceGroup{{
+		ID:       1,
+		UserKind: endpoint.Standard.String(),
+	}}))
+
+	errorStore.failOnDefaultSave = true
+	kg, err := kgm.DeleteKeyspaceGroupByID(1)
+	re.Nil(kg)
+	re.ErrorIs(err, errSaveKeyspaceGroup)
+	kg, err = kgm.GetKeyspaceGroupByID(1)
+	re.NoError(err)
+	re.NotNil(kg)
+
+	errorStore.failOnDefaultSave = false
+	kg, err = kgm.DeleteKeyspaceGroupByID(1)
+	re.NoError(err)
+	re.Equal(uint32(1), kg.ID)
+	kg, err = kgm.GetKeyspaceGroupByID(1)
+	re.NoError(err)
+	re.Nil(kg)
+	defaultKG, err := kgm.GetKeyspaceGroupByID(constant.DefaultKeyspaceGroupID)
+	re.NoError(err)
+	re.NotNil(defaultKG)
 }
 
 func (suite *keyspaceGroupTestSuite) TestKeyspaceAssignment() {

--- a/pkg/mcs/tso/server/grpc_service.go
+++ b/pkg/mcs/tso/server/grpc_service.go
@@ -147,10 +147,8 @@ func (s *Service) FindGroupByKeyspaceID(
 	}
 
 	keyspaceID := request.GetKeyspaceId()
-	snapshotRevision := s.keyspaceGroupManager.GetSnapshotRevision()
 	allocator, keyspaceGroup, keyspaceGroupID, modRevision, err := s.keyspaceGroupManager.FindGroupByKeyspaceID(keyspaceID)
-	modRevision, revisionLoaded := resolveServingRevision(request.GetModRevision(), modRevision, snapshotRevision)
-	if !revisionLoaded {
+	if request.GetModRevision() > modRevision || errs.ErrKeyspaceGroupModRevisionStale.Equal(err) {
 		return &tsopb.FindGroupByKeyspaceIDResponse{
 			Header: wrapErrorToHeader(tsopb.ErrorType_INVALID_VALUE, errs.ErrKeyspaceGroupModRevisionStale.Error(), respKeyspaceGroup),
 		}, nil
@@ -196,13 +194,6 @@ func (s *Service) FindGroupByKeyspaceID(
 		},
 		ModRevision: modRevision,
 	}, nil
-}
-
-func resolveServingRevision(requestRevision, modRevision, snapshotRevision uint64) (uint64, bool) {
-	if requestRevision > max(modRevision, snapshotRevision) {
-		return modRevision, false
-	}
-	return max(requestRevision, modRevision), true
 }
 
 // GetMinTS gets the minimum timestamp across all keyspace groups served by the TSO server

--- a/pkg/mcs/tso/server/grpc_service.go
+++ b/pkg/mcs/tso/server/grpc_service.go
@@ -147,8 +147,10 @@ func (s *Service) FindGroupByKeyspaceID(
 	}
 
 	keyspaceID := request.GetKeyspaceId()
+	snapshotRevision := s.keyspaceGroupManager.GetSnapshotRevision()
 	allocator, keyspaceGroup, keyspaceGroupID, modRevision, err := s.keyspaceGroupManager.FindGroupByKeyspaceID(keyspaceID)
-	if request.GetModRevision() > modRevision {
+	modRevision, revisionLoaded := resolveServingRevision(request.GetModRevision(), modRevision, snapshotRevision)
+	if !revisionLoaded {
 		return &tsopb.FindGroupByKeyspaceIDResponse{
 			Header: wrapErrorToHeader(tsopb.ErrorType_INVALID_VALUE, errs.ErrKeyspaceGroupModRevisionStale.Error(), respKeyspaceGroup),
 		}, nil
@@ -194,6 +196,13 @@ func (s *Service) FindGroupByKeyspaceID(
 		},
 		ModRevision: modRevision,
 	}, nil
+}
+
+func resolveServingRevision(requestRevision, modRevision, snapshotRevision uint64) (uint64, bool) {
+	if requestRevision > max(modRevision, snapshotRevision) {
+		return modRevision, false
+	}
+	return max(requestRevision, modRevision), true
 }
 
 // GetMinTS gets the minimum timestamp across all keyspace groups served by the TSO server

--- a/pkg/mcs/tso/server/grpc_service_test.go
+++ b/pkg/mcs/tso/server/grpc_service_test.go
@@ -59,3 +59,17 @@ func TestUnaryRPCsReturnUnavailableWhenServerIsNotRunning(t *testing.T) {
 	require.Nil(t, minTS)
 	require.Equal(t, codes.Unavailable, status.Code(err))
 }
+
+func TestResolveServingRevision(t *testing.T) {
+	revision, loaded := resolveServingRevision(10, 12, 8)
+	require.Equal(t, uint64(12), revision)
+	require.True(t, loaded)
+
+	revision, loaded = resolveServingRevision(10, 8, 12)
+	require.Equal(t, uint64(10), revision)
+	require.True(t, loaded)
+
+	revision, loaded = resolveServingRevision(12, 8, 10)
+	require.Equal(t, uint64(8), revision)
+	require.False(t, loaded)
+}

--- a/pkg/mcs/tso/server/grpc_service_test.go
+++ b/pkg/mcs/tso/server/grpc_service_test.go
@@ -59,17 +59,3 @@ func TestUnaryRPCsReturnUnavailableWhenServerIsNotRunning(t *testing.T) {
 	require.Nil(t, minTS)
 	require.Equal(t, codes.Unavailable, status.Code(err))
 }
-
-func TestResolveServingRevision(t *testing.T) {
-	revision, loaded := resolveServingRevision(10, 12, 8)
-	require.Equal(t, uint64(12), revision)
-	require.True(t, loaded)
-
-	revision, loaded = resolveServingRevision(10, 8, 12)
-	require.Equal(t, uint64(10), revision)
-	require.True(t, loaded)
-
-	revision, loaded = resolveServingRevision(12, 8, 10)
-	require.Equal(t, uint64(8), revision)
-	require.False(t, loaded)
-}

--- a/pkg/mcs/tso/server/server.go
+++ b/pkg/mcs/tso/server/server.go
@@ -221,8 +221,7 @@ func (s *Server) IsKeyspaceServingByGroup(keyspaceID, keyspaceGroupID uint32) bo
 	}
 	// We need to check if the keyspace group ID is expected for the given keyspace ID.
 	// It is necessary because checkKeyspaceGroupLeadership will correct the keyspace group ID automatically if keyspace serves.
-	_, _, expected, _, err := s.keyspaceGroupManager.FindGroupByKeyspaceID(keyspaceID)
-	if keyspaceGroupID != expected || err != nil {
+	if !s.keyspaceGroupManager.IsKeyspaceAssignedToGroup(keyspaceID, keyspaceGroupID) {
 		return false
 	}
 	return s.checkKeyspaceGroupLeadership(keyspaceID, keyspaceGroupID)

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -117,8 +117,10 @@ type state struct {
 	// modRevision is the modification revision of keyspace space.
 	// It is used to indicate that server must return the newer keyspace infos avoid to tso fallback the older keyspace.
 	modRevision uint64
-	// snapshotRevision is the latest etcd revision fully covered by the loaded keyspace group snapshot.
-	snapshotRevision uint64
+	// revisionPending prevents publishing changed membership before its revision.
+	revisionPending bool
+	// pendingRevision is the newest applied membership revision waiting to be published.
+	pendingRevision uint64
 }
 
 func (s *state) initialize() {
@@ -180,18 +182,23 @@ func (s *state) getModRevision() uint64 {
 	return s.modRevision
 }
 
-func (s *state) setSnapshotRevision(snapshotRevision uint64) {
+func (s *state) beginRevisionUpdate(modRevision uint64) {
 	s.Lock()
 	defer s.Unlock()
-	s.snapshotRevision = max(s.snapshotRevision, snapshotRevision)
+	s.revisionPending = true
+	s.pendingRevision = max(s.pendingRevision, modRevision)
 }
 
-// GetSnapshotRevision returns the latest etcd revision fully covered by the loaded keyspace group snapshot.
-// Read it before the group state so a newly published revision cannot be paired with an older snapshot.
-func (s *state) GetSnapshotRevision() uint64 {
-	s.RLock()
-	defer s.RUnlock()
-	return s.snapshotRevision
+func (s *state) finishRevisionUpdate(modRevision uint64) bool {
+	s.Lock()
+	defer s.Unlock()
+	if s.modRevision >= modRevision || s.pendingRevision > modRevision {
+		return false
+	}
+	s.modRevision = modRevision
+	s.revisionPending = false
+	s.pendingRevision = 0
+	return true
 }
 
 // getSplittingGroups returns the IDs of the splitting keyspace groups.
@@ -304,7 +311,12 @@ func (s *state) getKeyspaceGroupMetaWithCheck(
 ) (*Allocator, *endpoint.KeyspaceGroup, uint32, uint64, error) {
 	s.RLock()
 	defer s.RUnlock()
+	return s.getKeyspaceGroupMetaWithCheckLocked(keyspaceID, keyspaceGroupID)
+}
 
+func (s *state) getKeyspaceGroupMetaWithCheckLocked(
+	keyspaceID, keyspaceGroupID uint32,
+) (*Allocator, *endpoint.KeyspaceGroup, uint32, uint64, error) {
 	if allocator := s.allocators[keyspaceGroupID]; allocator != nil {
 		kg := s.kgs[keyspaceGroupID]
 		if kg != nil {
@@ -561,15 +573,16 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	defaultKGConfigured := false
 	maxLoadedModRevision := uint64(0)
 	loadedModRevision := uint64(0)
+	membershipChanged := false
 	putFn := func(kv *mvccpb.KeyValue) error {
 		modRevision := uint64(kv.ModRevision)
-		if loadedModRevision > 0 && modRevision <= loadedModRevision {
-			maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
-			return nil
-		}
 		group := &endpoint.KeyspaceGroup{}
 		if err := json.Unmarshal(kv.Value, group); err != nil {
 			return errs.ErrJSONUnmarshal.Wrap(err)
+		}
+		if loadedModRevision > 0 && modRevision <= loadedModRevision {
+			maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
+			return nil
 		}
 		failpoint.Inject("SkipKeyspaceWatch", func(val failpoint.Value) {
 			addr, ok := val.(string)
@@ -578,6 +591,9 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 			}
 		})
 		maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
+		delete(kgm.groupUpdateRetryList, group.ID)
+		kgm.beginRevisionUpdate(modRevision)
+		membershipChanged = true
 		kgm.updateKeyspaceGroup(group)
 		if group.ID == constant.DefaultKeyspaceGroupID {
 			defaultKGConfigured = true
@@ -589,29 +605,50 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		if err != nil {
 			return err
 		}
+		delete(kgm.groupUpdateRetryList, groupID)
+		kgm.beginRevisionUpdate(uint64(kv.ModRevision))
+		membershipChanged = true
 		kgm.deleteKeyspaceGroup(groupID)
 		return nil
 	}
-	postEventsFn := func(event []*clientv3.Event) error {
+	retryGroups := func() {
 		// Retry the groups that are not initialized successfully before.
 		for id, group := range kgm.groupUpdateRetryList {
 			delete(kgm.groupUpdateRetryList, id)
+			kgm.beginRevisionUpdate(0)
+			membershipChanged = true
 			kgm.updateKeyspaceGroup(group)
 		}
+	}
+	postEventsFn := func(event []*clientv3.Event) error {
+		if len(event) == 0 {
+			return nil
+		}
+		retryGroups()
 		failpoint.Inject("SkipKeyspaceWatch", func(val failpoint.Value) {
 			addr, ok := val.(string)
 			if ok && addr == kgm.electionNamePrefix {
 				failpoint.Return(nil)
 			}
 		})
-		if len(event) > 0 {
-			last := event[len(event)-1]
-			if !kgm.SetModRevision(uint64(last.Kv.ModRevision)) {
-				log.Warn("watch keyspace group met mod revision not increased",
-					zap.Uint32("current-mod-revision", uint32(kgm.modRevision)),
-					zap.Uint64("new-mod-revision", uint64(last.Kv.ModRevision)),
-				)
-			}
+		if len(kgm.groupUpdateRetryList) > 0 {
+			log.Warn("keyspace group revision remains pending while updates need retry",
+				zap.Int("retry-group-count", len(kgm.groupUpdateRetryList)))
+			return nil
+		}
+		last := event[len(event)-1]
+		modRevision := uint64(last.Kv.ModRevision)
+		var updated bool
+		if membershipChanged {
+			updated = kgm.finishRevisionUpdate(modRevision)
+		} else {
+			updated = kgm.SetModRevision(modRevision)
+		}
+		if !updated {
+			log.Warn("watch keyspace group met mod revision not increased",
+				zap.Uint64("current-mod-revision", kgm.getModRevision()),
+				zap.Uint64("new-mod-revision", modRevision),
+			)
 		}
 		return nil
 	}
@@ -625,6 +662,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		func([]*clientv3.Event) error {
 			maxLoadedModRevision = 0
 			loadedModRevision = kgm.getModRevision()
+			membershipChanged = false
 			return nil
 		},
 		putFn,
@@ -633,13 +671,23 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		true, /* withPrefix */
 	)
 	kgm.groupWatcher.SetReconcileDeletedKeys()
-	kgm.groupWatcher.SetLoadSuccessFn(func(snapshotRevision int64) {
-		if maxLoadedModRevision > 0 {
-			kgm.SetModRevision(maxLoadedModRevision)
+	kgm.groupWatcher.SetLoadSuccessFn(func() {
+		retryGroups()
+		if !membershipChanged {
+			return
 		}
-		if snapshotRevision > 0 {
-			kgm.setSnapshotRevision(uint64(snapshotRevision))
+		if len(kgm.groupUpdateRetryList) > 0 {
+			log.Warn("keyspace group revision remains pending while updates need retry",
+				zap.Int("retry-group-count", len(kgm.groupUpdateRetryList)))
+			return
 		}
+		if maxLoadedModRevision > loadedModRevision {
+			kgm.finishRevisionUpdate(maxLoadedModRevision)
+			return
+		}
+		log.Warn("keyspace group snapshot changed without a newer membership revision",
+			zap.Uint64("current-mod-revision", loadedModRevision),
+			zap.Uint64("loaded-mod-revision", maxLoadedModRevision))
 	})
 	if kgm.loadFromEtcdMaxRetryTimes > 0 {
 		kgm.groupWatcher.SetLoadRetryTimes(kgm.loadFromEtcdMaxRetryTimes)
@@ -1109,12 +1157,21 @@ func (kgm *KeyspaceGroupManager) GetAllocator(keyspaceGroupID uint32) (*Allocato
 func (kgm *KeyspaceGroupManager) FindGroupByKeyspaceID(
 	keyspaceID uint32,
 ) (*Allocator, *endpoint.KeyspaceGroup, uint32, uint64, error) {
-	curAllocator, curKeyspaceGroup, curKeyspaceGroupID, modRevision, err :=
-		kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, constant.DefaultKeyspaceGroupID)
-	if err != nil {
-		return nil, curKeyspaceGroup, curKeyspaceGroupID, modRevision, err
+	kgm.RLock()
+	defer kgm.RUnlock()
+	if kgm.revisionPending {
+		return nil, nil, constant.DefaultKeyspaceGroupID, kgm.modRevision, errs.ErrKeyspaceGroupModRevisionStale
 	}
-	return curAllocator, curKeyspaceGroup, curKeyspaceGroupID, modRevision, nil
+	return kgm.getKeyspaceGroupMetaWithCheckLocked(keyspaceID, constant.DefaultKeyspaceGroupID)
+}
+
+// IsKeyspaceAssignedToGroup reports whether the current local state assigns a keyspace to a group.
+func (kgm *KeyspaceGroupManager) IsKeyspaceAssignedToGroup(keyspaceID, keyspaceGroupID uint32) bool {
+	if err := checkKeySpaceGroupID(keyspaceGroupID); err != nil {
+		return false
+	}
+	_, _, currentGroupID, _, err := kgm.getKeyspaceGroupMetaWithCheck(keyspaceID, keyspaceGroupID)
+	return err == nil && currentGroupID == keyspaceGroupID
 }
 
 // GetMember returns the member of the keyspace group serving the given keyspace.

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -117,10 +117,10 @@ type state struct {
 	// modRevision is the modification revision of keyspace space.
 	// It is used to indicate that server must return the newer keyspace infos avoid to tso fallback the older keyspace.
 	modRevision uint64
-	// revisionPending prevents publishing changed membership before its revision.
-	revisionPending bool
-	// pendingRevision is the newest applied membership revision waiting to be published.
-	pendingRevision uint64
+	// revisionFence is the minimum revision that can publish the current membership.
+	// Zero means no unpublished change. Synthetic changes use one because real etcd
+	// revisions are always positive.
+	revisionFence uint64
 }
 
 func (s *state) initialize() {
@@ -169,22 +169,21 @@ func (s *state) getModRevision() uint64 {
 	return s.modRevision
 }
 
-func (s *state) beginRevisionUpdate(modRevision uint64) {
+func (s *state) fenceRevision(modRevision uint64) {
 	s.Lock()
 	defer s.Unlock()
-	s.revisionPending = true
-	s.pendingRevision = max(s.pendingRevision, modRevision)
+	modRevision = max(modRevision, 1)
+	s.revisionFence = max(s.revisionFence, modRevision)
 }
 
-func (s *state) finishRevisionUpdate(modRevision uint64) bool {
+func (s *state) publishRevision(modRevision uint64) bool {
 	s.Lock()
 	defer s.Unlock()
-	if s.pendingRevision > modRevision {
+	if s.revisionFence > modRevision {
 		return false
 	}
 	s.modRevision = max(s.modRevision, modRevision)
-	s.revisionPending = false
-	s.pendingRevision = 0
+	s.revisionFence = 0
 	return true
 }
 
@@ -560,18 +559,13 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	defaultKGConfigured := false
 	maxLoadedModRevision := uint64(0)
 	loadedModRevision := uint64(0)
-	membershipChanged := false
-	// A snapshot cannot recover a missing key's deletion revision. Keep this
-	// fence across reloads until a later watch event provides a comparable one.
-	unversionedDeletionPending := false
 	putFn := func(kv *mvccpb.KeyValue) error {
 		modRevision := uint64(kv.ModRevision)
 		if loadedModRevision > 0 && modRevision <= loadedModRevision {
 			maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 			return nil
 		}
-		kgm.beginRevisionUpdate(modRevision)
-		membershipChanged = true
+		kgm.fenceRevision(modRevision)
 		group := &endpoint.KeyspaceGroup{}
 		if err := json.Unmarshal(kv.Value, group); err != nil {
 			return errs.ErrJSONUnmarshal.Wrap(err)
@@ -596,9 +590,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 			return err
 		}
 		delete(kgm.groupUpdateRetryList, groupID)
-		kgm.beginRevisionUpdate(uint64(kv.ModRevision))
-		membershipChanged = true
-		unversionedDeletionPending = unversionedDeletionPending || kv.ModRevision == 0
+		kgm.fenceRevision(uint64(kv.ModRevision))
 		kgm.deleteKeyspaceGroup(groupID)
 		return nil
 	}
@@ -606,8 +598,6 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		// Retry the groups that are not initialized successfully before.
 		for id, group := range kgm.groupUpdateRetryList {
 			delete(kgm.groupUpdateRetryList, id)
-			kgm.beginRevisionUpdate(0)
-			membershipChanged = true
 			kgm.updateKeyspaceGroup(group)
 		}
 	}
@@ -629,13 +619,11 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		}
 		last := event[len(event)-1]
 		modRevision := uint64(last.Kv.ModRevision)
-		if !kgm.finishRevisionUpdate(modRevision) {
+		if !kgm.publishRevision(modRevision) {
 			log.Warn("watch keyspace group met mod revision not increased",
 				zap.Uint64("current-mod-revision", kgm.getModRevision()),
 				zap.Uint64("new-mod-revision", modRevision),
 			)
-		} else {
-			unversionedDeletionPending = false
 		}
 		return nil
 	}
@@ -649,9 +637,8 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		func(events []*clientv3.Event) error {
 			maxLoadedModRevision = 0
 			loadedModRevision = kgm.getModRevision()
-			membershipChanged = false
 			if len(events) > 0 {
-				kgm.beginRevisionUpdate(uint64(events[len(events)-1].Kv.ModRevision))
+				kgm.fenceRevision(uint64(events[len(events)-1].Kv.ModRevision))
 			}
 			return nil
 		},
@@ -663,26 +650,14 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	kgm.groupWatcher.SetReconcileDeletedKeys()
 	kgm.groupWatcher.SetLoadSuccessFn(func() {
 		retryGroups()
-		if !membershipChanged {
-			return
-		}
 		if len(kgm.groupUpdateRetryList) > 0 {
 			log.Warn("keyspace group revision remains pending while updates need retry",
 				zap.Int("retry-group-count", len(kgm.groupUpdateRetryList)))
 			return
 		}
-		if unversionedDeletionPending {
-			log.Warn("keyspace group snapshot reconciled a deletion without its revision",
-				zap.Uint64("current-mod-revision", loadedModRevision))
-			return
-		}
 		if maxLoadedModRevision > loadedModRevision {
-			kgm.finishRevisionUpdate(maxLoadedModRevision)
-			return
+			kgm.publishRevision(maxLoadedModRevision)
 		}
-		log.Warn("keyspace group snapshot changed without a newer membership revision",
-			zap.Uint64("current-mod-revision", loadedModRevision),
-			zap.Uint64("loaded-mod-revision", maxLoadedModRevision))
 	})
 	if kgm.loadFromEtcdMaxRetryTimes > 0 {
 		kgm.groupWatcher.SetLoadRetryTimes(kgm.loadFromEtcdMaxRetryTimes)
@@ -1154,7 +1129,7 @@ func (kgm *KeyspaceGroupManager) FindGroupByKeyspaceID(
 ) (*Allocator, *endpoint.KeyspaceGroup, uint32, uint64, error) {
 	kgm.RLock()
 	defer kgm.RUnlock()
-	if kgm.revisionPending {
+	if kgm.revisionFence != 0 {
 		return nil, nil, constant.DefaultKeyspaceGroupID, kgm.modRevision, errs.ErrKeyspaceGroupModRevisionStale
 	}
 	return kgm.getKeyspaceGroupMetaWithCheckLocked(keyspaceID, constant.DefaultKeyspaceGroupID)

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -163,19 +163,6 @@ func (s *state) getKeyspaceGroupMeta(
 	return s.allocators[groupID], s.kgs[groupID]
 }
 
-// SetModRevision sets the modification revision of the keyspace group state.
-// return true if the mod revision is updated.
-// It only allows increasing the mod revision.
-func (s *state) SetModRevision(modRevision uint64) bool {
-	s.Lock()
-	defer s.Unlock()
-	if s.modRevision < modRevision {
-		s.modRevision = modRevision
-		return true
-	}
-	return false
-}
-
 func (s *state) getModRevision() uint64 {
 	s.RLock()
 	defer s.RUnlock()
@@ -192,10 +179,10 @@ func (s *state) beginRevisionUpdate(modRevision uint64) {
 func (s *state) finishRevisionUpdate(modRevision uint64) bool {
 	s.Lock()
 	defer s.Unlock()
-	if s.modRevision >= modRevision || s.pendingRevision > modRevision {
+	if s.pendingRevision > modRevision {
 		return false
 	}
-	s.modRevision = modRevision
+	s.modRevision = max(s.modRevision, modRevision)
 	s.revisionPending = false
 	s.pendingRevision = 0
 	return true
@@ -574,15 +561,20 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	maxLoadedModRevision := uint64(0)
 	loadedModRevision := uint64(0)
 	membershipChanged := false
+	// A snapshot cannot recover a missing key's deletion revision. Keep this
+	// fence across reloads until a later watch event provides a comparable one.
+	unversionedDeletionPending := false
 	putFn := func(kv *mvccpb.KeyValue) error {
 		modRevision := uint64(kv.ModRevision)
-		group := &endpoint.KeyspaceGroup{}
-		if err := json.Unmarshal(kv.Value, group); err != nil {
-			return errs.ErrJSONUnmarshal.Wrap(err)
-		}
 		if loadedModRevision > 0 && modRevision <= loadedModRevision {
 			maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 			return nil
+		}
+		kgm.beginRevisionUpdate(modRevision)
+		membershipChanged = true
+		group := &endpoint.KeyspaceGroup{}
+		if err := json.Unmarshal(kv.Value, group); err != nil {
+			return errs.ErrJSONUnmarshal.Wrap(err)
 		}
 		failpoint.Inject("SkipKeyspaceWatch", func(val failpoint.Value) {
 			addr, ok := val.(string)
@@ -592,8 +584,6 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		})
 		maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 		delete(kgm.groupUpdateRetryList, group.ID)
-		kgm.beginRevisionUpdate(modRevision)
-		membershipChanged = true
 		kgm.updateKeyspaceGroup(group)
 		if group.ID == constant.DefaultKeyspaceGroupID {
 			defaultKGConfigured = true
@@ -608,6 +598,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		delete(kgm.groupUpdateRetryList, groupID)
 		kgm.beginRevisionUpdate(uint64(kv.ModRevision))
 		membershipChanged = true
+		unversionedDeletionPending = unversionedDeletionPending || kv.ModRevision == 0
 		kgm.deleteKeyspaceGroup(groupID)
 		return nil
 	}
@@ -638,17 +629,13 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		}
 		last := event[len(event)-1]
 		modRevision := uint64(last.Kv.ModRevision)
-		var updated bool
-		if membershipChanged {
-			updated = kgm.finishRevisionUpdate(modRevision)
-		} else {
-			updated = kgm.SetModRevision(modRevision)
-		}
-		if !updated {
+		if !kgm.finishRevisionUpdate(modRevision) {
 			log.Warn("watch keyspace group met mod revision not increased",
 				zap.Uint64("current-mod-revision", kgm.getModRevision()),
 				zap.Uint64("new-mod-revision", modRevision),
 			)
+		} else {
+			unversionedDeletionPending = false
 		}
 		return nil
 	}
@@ -659,10 +646,13 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		"keyspace-watcher",
 		// To keep the consistency with the previous code, we should trim the suffix `/`.
 		strings.TrimSuffix(keypath.KeyspaceGroupIDPrefix(), "/"),
-		func([]*clientv3.Event) error {
+		func(events []*clientv3.Event) error {
 			maxLoadedModRevision = 0
 			loadedModRevision = kgm.getModRevision()
 			membershipChanged = false
+			if len(events) > 0 {
+				kgm.beginRevisionUpdate(uint64(events[len(events)-1].Kv.ModRevision))
+			}
 			return nil
 		},
 		putFn,
@@ -679,6 +669,11 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		if len(kgm.groupUpdateRetryList) > 0 {
 			log.Warn("keyspace group revision remains pending while updates need retry",
 				zap.Int("retry-group-count", len(kgm.groupUpdateRetryList)))
+			return
+		}
+		if unversionedDeletionPending {
+			log.Warn("keyspace group snapshot reconciled a deletion without its revision",
+				zap.Uint64("current-mod-revision", loadedModRevision))
 			return
 		}
 		if maxLoadedModRevision > loadedModRevision {

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -117,6 +117,8 @@ type state struct {
 	// modRevision is the modification revision of keyspace space.
 	// It is used to indicate that server must return the newer keyspace infos avoid to tso fallback the older keyspace.
 	modRevision uint64
+	// snapshotRevision is the latest etcd revision fully covered by the loaded keyspace group snapshot.
+	snapshotRevision uint64
 }
 
 func (s *state) initialize() {
@@ -176,6 +178,20 @@ func (s *state) getModRevision() uint64 {
 	s.RLock()
 	defer s.RUnlock()
 	return s.modRevision
+}
+
+func (s *state) setSnapshotRevision(snapshotRevision uint64) {
+	s.Lock()
+	defer s.Unlock()
+	s.snapshotRevision = max(s.snapshotRevision, snapshotRevision)
+}
+
+// GetSnapshotRevision returns the latest etcd revision fully covered by the loaded keyspace group snapshot.
+// Read it before the group state so a newly published revision cannot be paired with an older snapshot.
+func (s *state) GetSnapshotRevision() uint64 {
+	s.RLock()
+	defer s.RUnlock()
+	return s.snapshotRevision
 }
 
 // getSplittingGroups returns the IDs of the splitting keyspace groups.
@@ -543,10 +559,12 @@ func (kgm *KeyspaceGroupManager) InitializeTSOServerWatchLoop() error {
 // Value: endpoint.KeyspaceGroup
 func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	defaultKGConfigured := false
+	maxLoadedModRevision := uint64(0)
 	loadedModRevision := uint64(0)
 	putFn := func(kv *mvccpb.KeyValue) error {
 		modRevision := uint64(kv.ModRevision)
 		if loadedModRevision > 0 && modRevision <= loadedModRevision {
+			maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 			return nil
 		}
 		group := &endpoint.KeyspaceGroup{}
@@ -559,6 +577,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 				failpoint.Return(nil)
 			}
 		})
+		maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 		kgm.updateKeyspaceGroup(group)
 		if group.ID == constant.DefaultKeyspaceGroupID {
 			defaultKGConfigured = true
@@ -604,6 +623,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		// To keep the consistency with the previous code, we should trim the suffix `/`.
 		strings.TrimSuffix(keypath.KeyspaceGroupIDPrefix(), "/"),
 		func([]*clientv3.Event) error {
+			maxLoadedModRevision = 0
 			loadedModRevision = kgm.getModRevision()
 			return nil
 		},
@@ -614,8 +634,11 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	)
 	kgm.groupWatcher.SetReconcileDeletedKeys()
 	kgm.groupWatcher.SetLoadSuccessFn(func(snapshotRevision int64) {
+		if maxLoadedModRevision > 0 {
+			kgm.SetModRevision(maxLoadedModRevision)
+		}
 		if snapshotRevision > 0 {
-			kgm.SetModRevision(uint64(snapshotRevision))
+			kgm.setSnapshotRevision(uint64(snapshotRevision))
 		}
 	})
 	if kgm.loadFromEtcdMaxRetryTimes > 0 {

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -172,6 +172,12 @@ func (s *state) SetModRevision(modRevision uint64) bool {
 	return false
 }
 
+func (s *state) getModRevision() uint64 {
+	s.RLock()
+	defer s.RUnlock()
+	return s.modRevision
+}
+
 // getSplittingGroups returns the IDs of the splitting keyspace groups.
 func (s *state) getSplittingGroups() []uint32 {
 	s.RLock()
@@ -538,7 +544,13 @@ func (kgm *KeyspaceGroupManager) InitializeTSOServerWatchLoop() error {
 func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	defaultKGConfigured := false
 	maxLoadedModRevision := uint64(0)
+	loadedModRevision := uint64(0)
 	putFn := func(kv *mvccpb.KeyValue) error {
+		modRevision := uint64(kv.ModRevision)
+		if loadedModRevision > 0 && modRevision <= loadedModRevision {
+			maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
+			return nil
+		}
 		group := &endpoint.KeyspaceGroup{}
 		if err := json.Unmarshal(kv.Value, group); err != nil {
 			return errs.ErrJSONUnmarshal.Wrap(err)
@@ -549,7 +561,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 				failpoint.Return(nil)
 			}
 		})
-		maxLoadedModRevision = max(maxLoadedModRevision, uint64(kv.ModRevision))
+		maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 		kgm.updateKeyspaceGroup(group)
 		if group.ID == constant.DefaultKeyspaceGroupID {
 			defaultKGConfigured = true
@@ -596,6 +608,7 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		strings.TrimSuffix(keypath.KeyspaceGroupIDPrefix(), "/"),
 		func([]*clientv3.Event) error {
 			maxLoadedModRevision = 0
+			loadedModRevision = kgm.getModRevision()
 			return nil
 		},
 		putFn,
@@ -603,8 +616,8 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		postEventsFn,
 		true, /* withPrefix */
 	)
-	kgm.groupWatcher.SetConsistentLoad()
-	kgm.groupWatcher.SetInitialLoadSuccessFn(func() {
+	kgm.groupWatcher.SetReconcileDeletedKeys()
+	kgm.groupWatcher.SetLoadSuccessFn(func() {
 		if maxLoadedModRevision > 0 {
 			kgm.SetModRevision(maxLoadedModRevision)
 		}
@@ -1014,12 +1027,8 @@ func (kgm *KeyspaceGroupManager) deleteKeyspaceGroup(groupID uint32) {
 	kg := kgm.kgs[groupID]
 	if kg != nil {
 		for _, kid := range kg.Keyspaces {
-			// if kid == kg.ID, it means the keyspace still belongs to this keyspace group,
-			//     so we decouple the relationship in the global keyspace lookup table.
-			// if kid != kg.ID, it means the keyspace has been moved to another keyspace group
-			//     which has already declared the ownership of the keyspace, so we don't need
-			//     delete it from the global keyspace lookup table and overwrite the ownership.
-			if kid == kg.ID {
+			// Preserve ownership that a newer group update has already claimed.
+			if currentGroupID, ok := kgm.keyspaceLookupTable[kid]; ok && currentGroupID == groupID {
 				delete(kgm.keyspaceLookupTable, kid)
 			}
 		}

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -121,6 +121,9 @@ type state struct {
 	// Zero means no unpublished change. Synthetic changes use one because real etcd
 	// revisions are always positive.
 	revisionFence uint64
+	// reloadPending is true while a full membership reload is in progress. It
+	// prevents discovery from serving state that may predate a compacted watch.
+	reloadPending bool
 }
 
 func (s *state) initialize() {
@@ -185,6 +188,18 @@ func (s *state) publishRevision(modRevision uint64) bool {
 	s.modRevision = max(s.modRevision, modRevision)
 	s.revisionFence = 0
 	return true
+}
+
+func (s *state) beginReload() {
+	s.Lock()
+	defer s.Unlock()
+	s.reloadPending = true
+}
+
+func (s *state) finishReload() {
+	s.Lock()
+	defer s.Unlock()
+	s.reloadPending = false
 }
 
 // getSplittingGroups returns the IDs of the splitting keyspace groups.
@@ -648,7 +663,9 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		true, /* withPrefix */
 	)
 	kgm.groupWatcher.SetReconcileDeletedKeys()
+	kgm.groupWatcher.SetReloadStartFn(kgm.beginReload)
 	kgm.groupWatcher.SetLoadSuccessFn(func() {
+		defer kgm.finishReload()
 		retryGroups()
 		if len(kgm.groupUpdateRetryList) > 0 {
 			log.Warn("keyspace group revision remains pending while updates need retry",
@@ -1129,7 +1146,7 @@ func (kgm *KeyspaceGroupManager) FindGroupByKeyspaceID(
 ) (*Allocator, *endpoint.KeyspaceGroup, uint32, uint64, error) {
 	kgm.RLock()
 	defer kgm.RUnlock()
-	if kgm.revisionFence != 0 {
+	if kgm.reloadPending || kgm.revisionFence != 0 {
 		return nil, nil, constant.DefaultKeyspaceGroupID, kgm.modRevision, errs.ErrKeyspaceGroupModRevisionStale
 	}
 	return kgm.getKeyspaceGroupMetaWithCheckLocked(keyspaceID, constant.DefaultKeyspaceGroupID)

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -543,12 +543,10 @@ func (kgm *KeyspaceGroupManager) InitializeTSOServerWatchLoop() error {
 // Value: endpoint.KeyspaceGroup
 func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 	defaultKGConfigured := false
-	maxLoadedModRevision := uint64(0)
 	loadedModRevision := uint64(0)
 	putFn := func(kv *mvccpb.KeyValue) error {
 		modRevision := uint64(kv.ModRevision)
 		if loadedModRevision > 0 && modRevision <= loadedModRevision {
-			maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 			return nil
 		}
 		group := &endpoint.KeyspaceGroup{}
@@ -561,7 +559,6 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 				failpoint.Return(nil)
 			}
 		})
-		maxLoadedModRevision = max(maxLoadedModRevision, modRevision)
 		kgm.updateKeyspaceGroup(group)
 		if group.ID == constant.DefaultKeyspaceGroupID {
 			defaultKGConfigured = true
@@ -607,7 +604,6 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		// To keep the consistency with the previous code, we should trim the suffix `/`.
 		strings.TrimSuffix(keypath.KeyspaceGroupIDPrefix(), "/"),
 		func([]*clientv3.Event) error {
-			maxLoadedModRevision = 0
 			loadedModRevision = kgm.getModRevision()
 			return nil
 		},
@@ -617,9 +613,9 @@ func (kgm *KeyspaceGroupManager) InitializeGroupWatchLoop() error {
 		true, /* withPrefix */
 	)
 	kgm.groupWatcher.SetReconcileDeletedKeys()
-	kgm.groupWatcher.SetLoadSuccessFn(func() {
-		if maxLoadedModRevision > 0 {
-			kgm.SetModRevision(maxLoadedModRevision)
+	kgm.groupWatcher.SetLoadSuccessFn(func(snapshotRevision int64) {
+		if snapshotRevision > 0 {
+			kgm.SetModRevision(uint64(snapshotRevision))
 		}
 	})
 	if kgm.loadFromEtcdMaxRetryTimes > 0 {

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -270,20 +270,16 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 
 	const watchBlockFailpoint = "github.com/tikv/pd/pkg/utils/etcdutil/watchChanBlock"
 	re.NoError(failpoint.Enable(watchBlockFailpoint, "return(true)"))
-	watchBlocked := true
 	defer func() {
-		if watchBlocked {
-			re.NoError(failpoint.Disable(watchBlockFailpoint))
-		}
+		re.NoError(failpoint.Disable(watchBlockFailpoint))
 	}()
-	loadedRevision := mgr.getModRevision()
 	updatedGroup, err := json.Marshal(&endpoint.KeyspaceGroup{
 		ID:        2,
 		Members:   []endpoint.KeyspaceGroupMember{{Address: mgr.tsoServiceID.ServiceAddr}},
 		Keyspaces: []uint32{203},
 	})
 	re.NoError(err)
-	_, err = suite.etcdClient.Txn(suite.ctx).Then(
+	updateResp, err := suite.etcdClient.Txn(suite.ctx).Then(
 		clientv3.OpDelete(keypath.KeyspaceGroupIDPath(1)),
 		clientv3.OpPut(keypath.KeyspaceGroupIDPath(2), string(updatedGroup)),
 	).Commit()
@@ -302,72 +298,42 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 		mgr.RUnlock()
 		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(203)
 		return updated &&
-			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
-			revision == loadedRevision
+			findErr == nil &&
+			revision == uint64(updateResp.Header.Revision)
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 
-	// A later full load must not use an unrelated surviving PUT to clear the
-	// unversioned deletion fence.
-	re.NoError(addKeyspaceGroupAssignment(
-		suite.ctx,
-		suite.etcdClient,
-		4,
-		[]string{mgr.tsoServiceID.ServiceAddr},
-		[]int{mcs.DefaultKeyspaceGroupReplicaPriority},
-		[]uint32{404},
-	))
-	testutil.Eventually(re, func() bool {
-		mgr.groupWatcher.ForceLoad()
-		mgr.RLock()
-		loaded := mgr.kgs[4] != nil
-		mgr.RUnlock()
-		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(404)
-		return loaded &&
-			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
-			revision == loadedRevision
-	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
-
-	re.NoError(failpoint.Disable(watchBlockFailpoint))
-	watchBlocked = false
 	defaultResp, err := suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID))
 	re.NoError(err)
 	re.Len(defaultResp.Kvs, 1)
-	checkpointResp, err := suite.etcdClient.Put(
-		suite.ctx,
-		keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID),
-		string(defaultResp.Kvs[0].Value),
-	)
-	re.NoError(err)
-	testutil.Eventually(re, func() bool {
-		_, _, groupID, revision, findErr := mgr.FindGroupByKeyspaceID(203)
-		return findErr == nil &&
-			groupID == 2 &&
-			revision == uint64(checkpointResp.Header.Revision)
-	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
-
-	re.NoError(failpoint.Enable(watchBlockFailpoint, "return(true)"))
-	watchBlocked = true
-	staleRevision := mgr.getModRevision()
-	defaultResp, err = suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID))
-	re.NoError(err)
-	re.Len(defaultResp.Kvs, 1)
-	_, err = suite.etcdClient.Put(
-		suite.ctx,
-		keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID),
-		string(defaultResp.Kvs[0].Value),
-	)
-	re.NoError(err)
-	_, err = suite.etcdClient.Delete(suite.ctx, keypath.KeyspaceGroupIDPath(3))
+	deleteResp, err := suite.etcdClient.Txn(suite.ctx).Then(
+		clientv3.OpDelete(keypath.KeyspaceGroupIDPath(3)),
+		clientv3.OpPut(keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID), string(defaultResp.Kvs[0].Value)),
+	).Commit()
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		mgr.groupWatcher.ForceLoad()
 		mgr.RLock()
 		removed := mgr.kgs[3] == nil
 		mgr.RUnlock()
-		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(303)
+		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(203)
+		return removed &&
+			findErr == nil &&
+			revision == uint64(deleteResp.Header.Revision)
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+
+	// Without a surviving membership revision, reconciliation stays fenced.
+	loadedRevision := mgr.getModRevision()
+	_, err = suite.etcdClient.Delete(suite.ctx, keypath.KeyspaceGroupIDPath(2))
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		mgr.groupWatcher.ForceLoad()
+		mgr.RLock()
+		removed := mgr.kgs[2] == nil
+		mgr.RUnlock()
+		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(203)
 		return removed &&
 			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
-			revision == staleRevision
+			revision == loadedRevision
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 }
 
@@ -434,17 +400,17 @@ func (suite *keyspaceGroupManagerTestSuite) TestPendingGroupRevisionOnlyFencesDi
 	re.NoError(mgr.Initialize())
 
 	modRevision := mgr.getModRevision()
-	mgr.beginRevisionUpdate(modRevision + 1)
+	mgr.fenceRevision(modRevision + 1)
 	_, _, _, _, err := mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
 	re.ErrorIs(err, errs.ErrKeyspaceGroupModRevisionStale)
 	re.True(mgr.IsKeyspaceAssignedToGroup(getBootstrapKeyspaceID(), constant.DefaultKeyspaceGroupID))
 	_, err = mgr.GetMember(getBootstrapKeyspaceID(), constant.DefaultKeyspaceGroupID)
 	re.NoError(err)
 
-	re.False(mgr.finishRevisionUpdate(modRevision))
+	re.False(mgr.publishRevision(modRevision))
 	_, _, _, _, err = mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
 	re.ErrorIs(err, errs.ErrKeyspaceGroupModRevisionStale)
-	re.True(mgr.finishRevisionUpdate(modRevision + 1))
+	re.True(mgr.publishRevision(modRevision + 1))
 	_, group, groupID, loadedRevision, err := mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
 	re.NoError(err)
 	re.NotNil(group)

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -268,17 +268,22 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 	mgr.RUnlock()
 	re.NotNil(unchangedGroup)
 
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/utils/etcdutil/watchChanBlock", "return(true)"))
+	const watchBlockFailpoint = "github.com/tikv/pd/pkg/utils/etcdutil/watchChanBlock"
+	re.NoError(failpoint.Enable(watchBlockFailpoint, "return(true)"))
+	watchBlocked := true
 	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/watchChanBlock"))
+		if watchBlocked {
+			re.NoError(failpoint.Disable(watchBlockFailpoint))
+		}
 	}()
+	loadedRevision := mgr.getModRevision()
 	updatedGroup, err := json.Marshal(&endpoint.KeyspaceGroup{
 		ID:        2,
 		Members:   []endpoint.KeyspaceGroupMember{{Address: mgr.tsoServiceID.ServiceAddr}},
 		Keyspaces: []uint32{203},
 	})
 	re.NoError(err)
-	resp, err := suite.etcdClient.Txn(suite.ctx).Then(
+	_, err = suite.etcdClient.Txn(suite.ctx).Then(
 		clientv3.OpDelete(keypath.KeyspaceGroupIDPath(1)),
 		clientv3.OpPut(keypath.KeyspaceGroupIDPath(2), string(updatedGroup)),
 	).Commit()
@@ -287,40 +292,71 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 	testutil.Eventually(re, func() bool {
 		mgr.groupWatcher.ForceLoad()
 		mgr.RLock()
-		defer mgr.RUnlock()
 		_, oldDeletedKeyspaceExists := mgr.keyspaceLookupTable[101]
 		_, oldUpdatedKeyspaceExists := mgr.keyspaceLookupTable[202]
-		return mgr.kgs[1] == nil &&
+		updated := mgr.kgs[1] == nil &&
 			!oldDeletedKeyspaceExists &&
 			!oldUpdatedKeyspaceExists &&
 			mgr.keyspaceLookupTable[203] == 2 &&
-			mgr.kgs[3] == unchangedGroup &&
-			mgr.modRevision == uint64(resp.Header.Revision)
+			mgr.kgs[3] == unchangedGroup
+		mgr.RUnlock()
+		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(203)
+		return updated &&
+			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
+			revision == loadedRevision
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 
-	defaultResp, err := suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID))
-	re.NoError(err)
-	re.Len(defaultResp.Kvs, 1)
-	deleteResp, err := suite.etcdClient.Txn(suite.ctx).Then(
-		clientv3.OpDelete(keypath.KeyspaceGroupIDPath(2)),
-		clientv3.OpPut(
-			keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID),
-			string(defaultResp.Kvs[0].Value),
-		),
-	).Commit()
-	re.NoError(err)
+	// A later full load must not use an unrelated surviving PUT to clear the
+	// unversioned deletion fence.
+	re.NoError(addKeyspaceGroupAssignment(
+		suite.ctx,
+		suite.etcdClient,
+		4,
+		[]string{mgr.tsoServiceID.ServiceAddr},
+		[]int{mcs.DefaultKeyspaceGroupReplicaPriority},
+		[]uint32{404},
+	))
 	testutil.Eventually(re, func() bool {
 		mgr.groupWatcher.ForceLoad()
 		mgr.RLock()
-		defer mgr.RUnlock()
-		_, keyspaceExists := mgr.keyspaceLookupTable[203]
-		return mgr.kgs[2] == nil &&
-			!keyspaceExists &&
-			mgr.kgs[3] == unchangedGroup &&
-			mgr.modRevision == uint64(deleteResp.Header.Revision)
+		loaded := mgr.kgs[4] != nil
+		mgr.RUnlock()
+		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(404)
+		return loaded &&
+			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
+			revision == loadedRevision
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 
+	re.NoError(failpoint.Disable(watchBlockFailpoint))
+	watchBlocked = false
+	defaultResp, err := suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID))
+	re.NoError(err)
+	re.Len(defaultResp.Kvs, 1)
+	checkpointResp, err := suite.etcdClient.Put(
+		suite.ctx,
+		keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID),
+		string(defaultResp.Kvs[0].Value),
+	)
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		_, _, groupID, revision, findErr := mgr.FindGroupByKeyspaceID(203)
+		return findErr == nil &&
+			groupID == 2 &&
+			revision == uint64(checkpointResp.Header.Revision)
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+
+	re.NoError(failpoint.Enable(watchBlockFailpoint, "return(true)"))
+	watchBlocked = true
 	staleRevision := mgr.getModRevision()
+	defaultResp, err = suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID))
+	re.NoError(err)
+	re.Len(defaultResp.Kvs, 1)
+	_, err = suite.etcdClient.Put(
+		suite.ctx,
+		keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID),
+		string(defaultResp.Kvs[0].Value),
+	)
+	re.NoError(err)
 	_, err = suite.etcdClient.Delete(suite.ctx, keypath.KeyspaceGroupIDPath(3))
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
@@ -332,6 +368,62 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 		return removed &&
 			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
 			revision == staleRevision
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+}
+
+func (suite *keyspaceGroupManagerTestSuite) TestWatchCallbackFailureKeepsRevisionPendingUntilReload() {
+	re := suite.Require()
+	mgr := suite.newUniqueKeyspaceGroupManager(1)
+	defer mgr.Close()
+
+	re.NoError(addKeyspaceGroupAssignment(
+		suite.ctx,
+		suite.etcdClient,
+		constant.DefaultKeyspaceGroupID,
+		[]string{mgr.tsoServiceID.ServiceAddr},
+		[]int{mcs.DefaultKeyspaceGroupReplicaPriority},
+		[]uint32{getBootstrapKeyspaceID()},
+	))
+	re.NoError(mgr.Initialize())
+	loadedRevision := mgr.getModRevision()
+
+	validGroup, err := json.Marshal(&endpoint.KeyspaceGroup{
+		ID:        1,
+		Members:   []endpoint.KeyspaceGroupMember{{Address: mgr.tsoServiceID.ServiceAddr}},
+		Keyspaces: []uint32{101},
+	})
+	re.NoError(err)
+	_, err = suite.etcdClient.Txn(suite.ctx).Then(
+		clientv3.OpPut(keypath.KeyspaceGroupIDPath(1), string(validGroup)),
+		clientv3.OpPut(keypath.KeyspaceGroupIDPath(2), "invalid"),
+	).Commit()
+	re.NoError(err)
+
+	testutil.Eventually(re, func() bool {
+		mgr.RLock()
+		validGroupApplied := mgr.kgs[1] != nil
+		mgr.RUnlock()
+		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(101)
+		return validGroupApplied &&
+			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
+			revision == loadedRevision
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(10*time.Millisecond))
+
+	recoveredGroup, err := json.Marshal(&endpoint.KeyspaceGroup{
+		ID:        2,
+		Members:   []endpoint.KeyspaceGroupMember{{Address: mgr.tsoServiceID.ServiceAddr}},
+		Keyspaces: []uint32{202},
+	})
+	re.NoError(err)
+	recoveryResp, err := suite.etcdClient.Put(
+		suite.ctx,
+		keypath.KeyspaceGroupIDPath(2),
+		string(recoveredGroup),
+	)
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		_, _, groupID, revision, findErr := mgr.FindGroupByKeyspaceID(101)
+		return findErr == nil && groupID == 1 && revision == uint64(recoveryResp.Header.Revision)
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 }
 

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -230,12 +230,16 @@ func (suite *keyspaceGroupManagerTestSuite) TestInitialLoadSetsModRevision() {
 	resp, err := suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(groupID))
 	re.NoError(err)
 	re.Len(resp.Kvs, 1)
+	advanceResp, err := suite.etcdClient.Put(suite.ctx, fmt.Sprintf("/tso-test-revision/%d", rand.Uint64()), "")
+	re.NoError(err)
+	re.Greater(advanceResp.Header.Revision, resp.Kvs[0].ModRevision)
 
 	re.NoError(mgr.Initialize())
 	_, _, loadedGroupID, loadedRevision, err := mgr.FindGroupByKeyspaceID(keyspaceID)
 	re.NoError(err)
 	re.Equal(groupID, loadedGroupID)
 	re.Equal(uint64(resp.Kvs[0].ModRevision), loadedRevision)
+	re.GreaterOrEqual(mgr.GetSnapshotRevision(), uint64(advanceResp.Header.Revision))
 }
 
 func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMembership() {
@@ -300,7 +304,8 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 		return mgr.kgs[2] == nil &&
 			!keyspaceExists &&
 			mgr.kgs[3] == unchangedGroup &&
-			mgr.modRevision == uint64(deleteResp.Header.Revision)
+			mgr.modRevision == uint64(resp.Header.Revision) &&
+			mgr.snapshotRevision >= uint64(deleteResp.Header.Revision)
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 }
 

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -238,6 +238,59 @@ func (suite *keyspaceGroupManagerTestSuite) TestInitialLoadSetsModRevision() {
 	re.Equal(uint64(resp.Kvs[0].ModRevision), loadedRevision)
 }
 
+func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMembership() {
+	re := suite.Require()
+	mgr := suite.newUniqueKeyspaceGroupManager(1)
+	defer mgr.Close()
+
+	for groupID, keyspaceID := range map[uint32]uint32{1: 101, 2: 202, 3: 303} {
+		re.NoError(addKeyspaceGroupAssignment(
+			suite.ctx,
+			suite.etcdClient,
+			groupID,
+			[]string{mgr.tsoServiceID.ServiceAddr},
+			[]int{mcs.DefaultKeyspaceGroupReplicaPriority},
+			[]uint32{keyspaceID},
+		))
+	}
+	re.NoError(mgr.Initialize())
+
+	mgr.RLock()
+	unchangedGroup := mgr.kgs[3]
+	mgr.RUnlock()
+	re.NotNil(unchangedGroup)
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/utils/etcdutil/watchChanBlock", "return(true)"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/utils/etcdutil/watchChanBlock"))
+	}()
+	updatedGroup, err := json.Marshal(&endpoint.KeyspaceGroup{
+		ID:        2,
+		Members:   []endpoint.KeyspaceGroupMember{{Address: mgr.tsoServiceID.ServiceAddr}},
+		Keyspaces: []uint32{203},
+	})
+	re.NoError(err)
+	resp, err := suite.etcdClient.Txn(suite.ctx).Then(
+		clientv3.OpDelete(keypath.KeyspaceGroupIDPath(1)),
+		clientv3.OpPut(keypath.KeyspaceGroupIDPath(2), string(updatedGroup)),
+	).Commit()
+	re.NoError(err)
+
+	testutil.Eventually(re, func() bool {
+		mgr.groupWatcher.ForceLoad()
+		mgr.RLock()
+		defer mgr.RUnlock()
+		_, oldDeletedKeyspaceExists := mgr.keyspaceLookupTable[101]
+		_, oldUpdatedKeyspaceExists := mgr.keyspaceLookupTable[202]
+		return mgr.kgs[1] == nil &&
+			!oldDeletedKeyspaceExists &&
+			!oldUpdatedKeyspaceExists &&
+			mgr.keyspaceLookupTable[203] == 2 &&
+			mgr.kgs[3] == unchangedGroup &&
+			mgr.modRevision == uint64(resp.Header.Revision)
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+}
+
 // TestLoadWithDifferentBatchSize tests the loading of the keyspace group assignment with the different batch size.
 func (suite *keyspaceGroupManagerTestSuite) TestLoadWithDifferentBatchSize() {
 	re := suite.Require()

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -289,6 +289,19 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 			mgr.kgs[3] == unchangedGroup &&
 			mgr.modRevision == uint64(resp.Header.Revision)
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+
+	deleteResp, err := suite.etcdClient.Delete(suite.ctx, keypath.KeyspaceGroupIDPath(2))
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		mgr.groupWatcher.ForceLoad()
+		mgr.RLock()
+		defer mgr.RUnlock()
+		_, keyspaceExists := mgr.keyspaceLookupTable[203]
+		return mgr.kgs[2] == nil &&
+			!keyspaceExists &&
+			mgr.kgs[3] == unchangedGroup &&
+			mgr.modRevision == uint64(deleteResp.Header.Revision)
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 }
 
 // TestLoadWithDifferentBatchSize tests the loading of the keyspace group assignment with the different batch size.

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -418,6 +418,29 @@ func (suite *keyspaceGroupManagerTestSuite) TestPendingGroupRevisionOnlyFencesDi
 	re.Equal(modRevision+1, loadedRevision)
 }
 
+func (suite *keyspaceGroupManagerTestSuite) TestPendingGroupReloadOnlyFencesDiscovery() {
+	re := suite.Require()
+	mgr := suite.newUniqueKeyspaceGroupManager(1)
+	defer mgr.Close()
+	re.NoError(mgr.Initialize())
+
+	modRevision := mgr.getModRevision()
+	mgr.beginReload()
+	_, _, _, loadedRevision, err := mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
+	re.ErrorIs(err, errs.ErrKeyspaceGroupModRevisionStale)
+	re.Equal(modRevision, loadedRevision)
+	re.True(mgr.IsKeyspaceAssignedToGroup(getBootstrapKeyspaceID(), constant.DefaultKeyspaceGroupID))
+	_, err = mgr.GetMember(getBootstrapKeyspaceID(), constant.DefaultKeyspaceGroupID)
+	re.NoError(err)
+
+	mgr.finishReload()
+	_, group, groupID, loadedRevision, err := mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
+	re.NoError(err)
+	re.NotNil(group)
+	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
+	re.Equal(modRevision, loadedRevision)
+}
+
 // TestLoadWithDifferentBatchSize tests the loading of the keyspace group assignment with the different batch size.
 func (suite *keyspaceGroupManagerTestSuite) TestLoadWithDifferentBatchSize() {
 	re := suite.Require()

--- a/pkg/tso/keyspace_group_manager_test.go
+++ b/pkg/tso/keyspace_group_manager_test.go
@@ -230,16 +230,12 @@ func (suite *keyspaceGroupManagerTestSuite) TestInitialLoadSetsModRevision() {
 	resp, err := suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(groupID))
 	re.NoError(err)
 	re.Len(resp.Kvs, 1)
-	advanceResp, err := suite.etcdClient.Put(suite.ctx, fmt.Sprintf("/tso-test-revision/%d", rand.Uint64()), "")
-	re.NoError(err)
-	re.Greater(advanceResp.Header.Revision, resp.Kvs[0].ModRevision)
 
 	re.NoError(mgr.Initialize())
 	_, _, loadedGroupID, loadedRevision, err := mgr.FindGroupByKeyspaceID(keyspaceID)
 	re.NoError(err)
 	re.Equal(groupID, loadedGroupID)
 	re.Equal(uint64(resp.Kvs[0].ModRevision), loadedRevision)
-	re.GreaterOrEqual(mgr.GetSnapshotRevision(), uint64(advanceResp.Header.Revision))
 }
 
 func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMembership() {
@@ -247,6 +243,14 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 	mgr := suite.newUniqueKeyspaceGroupManager(1)
 	defer mgr.Close()
 
+	re.NoError(addKeyspaceGroupAssignment(
+		suite.ctx,
+		suite.etcdClient,
+		constant.DefaultKeyspaceGroupID,
+		[]string{mgr.tsoServiceID.ServiceAddr},
+		[]int{mcs.DefaultKeyspaceGroupReplicaPriority},
+		[]uint32{getBootstrapKeyspaceID()},
+	))
 	for groupID, keyspaceID := range map[uint32]uint32{1: 101, 2: 202, 3: 303} {
 		re.NoError(addKeyspaceGroupAssignment(
 			suite.ctx,
@@ -294,7 +298,16 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 			mgr.modRevision == uint64(resp.Header.Revision)
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
 
-	deleteResp, err := suite.etcdClient.Delete(suite.ctx, keypath.KeyspaceGroupIDPath(2))
+	defaultResp, err := suite.etcdClient.Get(suite.ctx, keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID))
+	re.NoError(err)
+	re.Len(defaultResp.Kvs, 1)
+	deleteResp, err := suite.etcdClient.Txn(suite.ctx).Then(
+		clientv3.OpDelete(keypath.KeyspaceGroupIDPath(2)),
+		clientv3.OpPut(
+			keypath.KeyspaceGroupIDPath(constant.DefaultKeyspaceGroupID),
+			string(defaultResp.Kvs[0].Value),
+		),
+	).Commit()
 	re.NoError(err)
 	testutil.Eventually(re, func() bool {
 		mgr.groupWatcher.ForceLoad()
@@ -304,9 +317,47 @@ func (suite *keyspaceGroupManagerTestSuite) TestGroupSnapshotReloadReconcilesMem
 		return mgr.kgs[2] == nil &&
 			!keyspaceExists &&
 			mgr.kgs[3] == unchangedGroup &&
-			mgr.modRevision == uint64(resp.Header.Revision) &&
-			mgr.snapshotRevision >= uint64(deleteResp.Header.Revision)
+			mgr.modRevision == uint64(deleteResp.Header.Revision)
 	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+
+	staleRevision := mgr.getModRevision()
+	_, err = suite.etcdClient.Delete(suite.ctx, keypath.KeyspaceGroupIDPath(3))
+	re.NoError(err)
+	testutil.Eventually(re, func() bool {
+		mgr.groupWatcher.ForceLoad()
+		mgr.RLock()
+		removed := mgr.kgs[3] == nil
+		mgr.RUnlock()
+		_, _, _, revision, findErr := mgr.FindGroupByKeyspaceID(303)
+		return removed &&
+			errors.Is(findErr, errs.ErrKeyspaceGroupModRevisionStale) &&
+			revision == staleRevision
+	}, testutil.WithWaitFor(5*time.Second), testutil.WithTickInterval(100*time.Millisecond))
+}
+
+func (suite *keyspaceGroupManagerTestSuite) TestPendingGroupRevisionOnlyFencesDiscovery() {
+	re := suite.Require()
+	mgr := suite.newUniqueKeyspaceGroupManager(1)
+	defer mgr.Close()
+	re.NoError(mgr.Initialize())
+
+	modRevision := mgr.getModRevision()
+	mgr.beginRevisionUpdate(modRevision + 1)
+	_, _, _, _, err := mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
+	re.ErrorIs(err, errs.ErrKeyspaceGroupModRevisionStale)
+	re.True(mgr.IsKeyspaceAssignedToGroup(getBootstrapKeyspaceID(), constant.DefaultKeyspaceGroupID))
+	_, err = mgr.GetMember(getBootstrapKeyspaceID(), constant.DefaultKeyspaceGroupID)
+	re.NoError(err)
+
+	re.False(mgr.finishRevisionUpdate(modRevision))
+	_, _, _, _, err = mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
+	re.ErrorIs(err, errs.ErrKeyspaceGroupModRevisionStale)
+	re.True(mgr.finishRevisionUpdate(modRevision + 1))
+	_, group, groupID, loadedRevision, err := mgr.FindGroupByKeyspaceID(getBootstrapKeyspaceID())
+	re.NoError(err)
+	re.NotNil(group)
+	re.Equal(constant.DefaultKeyspaceGroupID, groupID)
+	re.Equal(modRevision+1, loadedRevision)
 }
 
 // TestLoadWithDifferentBatchSize tests the loading of the keyspace group assignment with the different batch size.

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -403,6 +403,8 @@ type LoopWatcher struct {
 	preEventsFn func([]*clientv3.Event) error
 	// initialLoadSuccessFn is called after the initial load succeeds and before watching starts.
 	initialLoadSuccessFn func()
+	// loadSuccessFn is called after a revision-consistent full load succeeds.
+	loadSuccessFn func()
 	// forceLoadMu is used to ensure two force loads have minimal interval.
 	forceLoadMu syncutil.RWMutex
 	// lastTimeForceLoad is used to record the last time force loading data from etcd.
@@ -765,11 +767,19 @@ func (lw *LoopWatcher) load(ctx context.Context) (nextRevision int64, err error)
 			}
 			return
 		}
-		if preErr != nil || !lw.reconcileDeletedKeys {
+		if preErr != nil {
 			return
 		}
 		if loadCompleted && callbackErr == nil {
-			lw.loadedKeys = snapshotKeys
+			if lw.reconcileDeletedKeys {
+				lw.loadedKeys = snapshotKeys
+			}
+			if lw.loadSuccessFn != nil {
+				lw.loadSuccessFn()
+			}
+			return
+		}
+		if !lw.reconcileDeletedKeys {
 			return
 		}
 		// Some callbacks may have succeeded before another callback failed. The
@@ -991,6 +1001,12 @@ func (lw *LoopWatcher) SetConsistentLoad() {
 // It must be called before StartWatchLoop.
 func (lw *LoopWatcher) SetInitialLoadSuccessFn(fn func()) {
 	lw.initialLoadSuccessFn = fn
+}
+
+// SetLoadSuccessFn sets a callback that runs after every revision-consistent
+// full load succeeds. It must be called before StartWatchLoop.
+func (lw *LoopWatcher) SetLoadSuccessFn(fn func()) {
+	lw.loadSuccessFn = fn
 }
 
 // SetReloadOnCompaction enables a full, revision-consistent snapshot reload

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -404,7 +404,7 @@ type LoopWatcher struct {
 	// initialLoadSuccessFn is called after the initial load succeeds and before watching starts.
 	initialLoadSuccessFn func()
 	// loadSuccessFn is called after a revision-consistent full load succeeds.
-	loadSuccessFn func()
+	loadSuccessFn func(int64)
 	// forceLoadMu is used to ensure two force loads have minimal interval.
 	forceLoadMu syncutil.RWMutex
 	// lastTimeForceLoad is used to record the last time force loading data from etcd.
@@ -775,7 +775,7 @@ func (lw *LoopWatcher) load(ctx context.Context) (nextRevision int64, err error)
 				lw.loadedKeys = snapshotKeys
 			}
 			if lw.loadSuccessFn != nil {
-				lw.loadSuccessFn()
+				lw.loadSuccessFn(snapshotRevision)
 			}
 			return
 		}
@@ -1005,7 +1005,7 @@ func (lw *LoopWatcher) SetInitialLoadSuccessFn(fn func()) {
 
 // SetLoadSuccessFn sets a callback that runs after every revision-consistent
 // full load succeeds. It must be called before StartWatchLoop.
-func (lw *LoopWatcher) SetLoadSuccessFn(fn func()) {
+func (lw *LoopWatcher) SetLoadSuccessFn(fn func(int64)) {
 	lw.loadSuccessFn = fn
 }
 

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -404,7 +404,7 @@ type LoopWatcher struct {
 	// initialLoadSuccessFn is called after the initial load succeeds and before watching starts.
 	initialLoadSuccessFn func()
 	// loadSuccessFn is called after a revision-consistent full load succeeds.
-	loadSuccessFn func(int64)
+	loadSuccessFn func()
 	// forceLoadMu is used to ensure two force loads have minimal interval.
 	forceLoadMu syncutil.RWMutex
 	// lastTimeForceLoad is used to record the last time force loading data from etcd.
@@ -775,7 +775,7 @@ func (lw *LoopWatcher) load(ctx context.Context) (nextRevision int64, err error)
 				lw.loadedKeys = snapshotKeys
 			}
 			if lw.loadSuccessFn != nil {
-				lw.loadSuccessFn(snapshotRevision)
+				lw.loadSuccessFn()
 			}
 			return
 		}
@@ -1005,7 +1005,7 @@ func (lw *LoopWatcher) SetInitialLoadSuccessFn(fn func()) {
 
 // SetLoadSuccessFn sets a callback that runs after every revision-consistent
 // full load succeeds. It must be called before StartWatchLoop.
-func (lw *LoopWatcher) SetLoadSuccessFn(fn func(int64)) {
+func (lw *LoopWatcher) SetLoadSuccessFn(fn func()) {
 	lw.loadSuccessFn = fn
 }
 

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -405,6 +405,8 @@ type LoopWatcher struct {
 	initialLoadSuccessFn func()
 	// loadSuccessFn is called after a revision-consistent full load succeeds.
 	loadSuccessFn func()
+	// reloadStartFn is called before a retrying full reload starts.
+	reloadStartFn func()
 	// forceLoadMu is used to ensure two force loads have minimal interval.
 	forceLoadMu syncutil.RWMutex
 	// lastTimeForceLoad is used to record the last time force loading data from etcd.
@@ -637,6 +639,7 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 					revision = wresp.CompactRevision
 					continue
 				}
+				lw.notifyReloadStart()
 				log.Warn("required revision has been compacted, reload from etcd in watch loop",
 					zap.Int64("required-revision", revision), zap.Int64("compact-revision", wresp.CompactRevision),
 					zap.String("name", lw.name), zap.String("key", lw.key))
@@ -723,6 +726,7 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 				callbackErr = postErr
 			}
 			if callbackErr != nil && lw.reloadOnCompaction {
+				lw.notifyReloadStart()
 				loadedRevision, shouldContinue := lw.reloadWithRetry(ctx)
 				if !shouldContinue {
 					return max(revision, loadedRevision), nil
@@ -763,6 +767,12 @@ func (lw *LoopWatcher) reloadWithRetry(ctx context.Context) (int64, bool) {
 		case <-retryTimer.C:
 		}
 		retryInterval = min(retryInterval*2, maxCompactionReloadRetryInterval)
+	}
+}
+
+func (lw *LoopWatcher) notifyReloadStart() {
+	if lw.reloadStartFn != nil {
+		lw.reloadStartFn()
 	}
 }
 
@@ -1034,6 +1044,13 @@ func (lw *LoopWatcher) SetInitialLoadSuccessFn(fn func()) {
 // full load succeeds. It must be called before StartWatchLoop.
 func (lw *LoopWatcher) SetLoadSuccessFn(fn func()) {
 	lw.loadSuccessFn = fn
+}
+
+// SetReloadStartFn sets a callback that runs before a retrying full reload
+// starts after compaction or a failed watch callback. It must be called before
+// StartWatchLoop.
+func (lw *LoopWatcher) SetReloadStartFn(fn func()) {
+	lw.reloadStartFn = fn
 }
 
 // SetReloadOnCompaction enables a full, revision-consistent snapshot reload

--- a/pkg/utils/etcdutil/etcdutil.go
+++ b/pkg/utils/etcdutil/etcdutil.go
@@ -640,7 +640,7 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 				log.Warn("required revision has been compacted, reload from etcd in watch loop",
 					zap.Int64("required-revision", revision), zap.Int64("compact-revision", wresp.CompactRevision),
 					zap.String("name", lw.name), zap.String("key", lw.key))
-				loadedRevision, shouldContinue := lw.reloadAfterCompaction(ctx)
+				loadedRevision, shouldContinue := lw.reloadWithRetry(ctx)
 				if !shouldContinue {
 					return max(revision, loadedRevision), nil
 				}
@@ -656,16 +656,22 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
 				goto watchChanLoop
 			}
-			if err := lw.preEventsFn(wresp.Events); err != nil {
-				log.Error("run pre event failed in watch loop", zap.Error(err),
+			callbackErr := lw.preEventsFn(wresp.Events)
+			if callbackErr != nil {
+				log.Error("run pre event failed in watch loop", zap.Error(callbackErr),
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
 			}
 			var appliedEvents []*clientv3.Event
 			for _, event := range wresp.Events {
+				if callbackErr != nil && lw.reloadOnCompaction {
+					break
+				}
+				var eventErr error
 				switch event.Type {
 				case clientv3.EventTypePut:
-					if err := lw.putFn(event.Kv); err != nil {
-						log.Error("put failed in watch loop", zap.Error(err),
+					eventErr = lw.putFn(event.Kv)
+					if eventErr != nil {
+						log.Error("put failed in watch loop", zap.Error(eventErr),
 							zap.Int64("revision", revision), zap.String("name", lw.name),
 							zap.String("watch-key", lw.key), zap.ByteString("event-kv-key", event.Kv.Key))
 					} else {
@@ -677,8 +683,9 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 							zap.ByteString("value", event.Kv.Value))
 					}
 				case clientv3.EventTypeDelete:
-					if err := lw.deleteFn(event.Kv); err != nil {
-						log.Error("delete failed in watch loop", zap.Error(err),
+					eventErr = lw.deleteFn(event.Kv)
+					if eventErr != nil {
+						log.Error("delete failed in watch loop", zap.Error(eventErr),
 							zap.Int64("revision", revision), zap.String("name", lw.name),
 							zap.String("watch-key", lw.key), zap.ByteString("event-kv-key", event.Kv.Key))
 					} else {
@@ -689,9 +696,19 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 							zap.ByteString("key", event.Kv.Key))
 					}
 				}
+				if callbackErr == nil {
+					callbackErr = eventErr
+				}
 			}
-			if err := lw.postEventsFn(wresp.Events); err != nil {
-				log.Error("run post event failed in watch loop", zap.Error(err),
+			postEvents := wresp.Events
+			if callbackErr != nil && lw.reloadOnCompaction {
+				// The batch may share one transaction revision, so publishing even
+				// its successfully applied subset could expose incomplete state.
+				postEvents = nil
+			}
+			postErr := lw.postEventsFn(postEvents)
+			if postErr != nil {
+				log.Error("run post event failed in watch loop", zap.Error(postErr),
 					zap.Int64("revision", revision), zap.String("name", lw.name), zap.String("key", lw.key))
 			} else {
 				for _, event := range appliedEvents {
@@ -702,19 +719,29 @@ func (lw *LoopWatcher) watch(ctx context.Context, revision int64) (nextRevision 
 					}
 				}
 			}
+			if callbackErr == nil {
+				callbackErr = postErr
+			}
+			if callbackErr != nil && lw.reloadOnCompaction {
+				loadedRevision, shouldContinue := lw.reloadWithRetry(ctx)
+				if !shouldContinue {
+					return max(revision, loadedRevision), nil
+				}
+				revision = loadedRevision
+				continue
+			}
 			revision = wresp.Header.Revision + 1
 		}
 		goto watchChanLoop // Use goto to avoid creating a new watchChan
 	}
 }
 
-// reloadAfterCompaction rebuilds the watched state before a new watch is
-// created. A compacted watch cannot resume from its previous revision, so keep
-// the retry state local to this resync attempt and retry until it succeeds or
-// the watcher is stopped. The returned revision is the next revision after a
-// successful reload, even when the boolean is false; zero means no reload
+// reloadWithRetry rebuilds the watched state before a new watch is created.
+// Keep the retry state local to this resync attempt and retry until it succeeds
+// or the watcher is stopped. The returned revision is the next revision after
+// a successful reload, even when the boolean is false; zero means no reload
 // completed. The boolean reports whether watching should continue.
-func (lw *LoopWatcher) reloadAfterCompaction(ctx context.Context) (int64, bool) {
+func (lw *LoopWatcher) reloadWithRetry(ctx context.Context) (int64, bool) {
 	retryInterval := lw.watchChangeRetryInterval
 	for {
 		loadedRevision, err := lw.load(ctx)
@@ -725,7 +752,7 @@ func (lw *LoopWatcher) reloadAfterCompaction(ctx context.Context) (int64, bool) 
 			return 0, false
 		}
 
-		log.Warn("failed to reload compacted watcher state, retrying",
+		log.Warn("failed to reload watcher state, retrying",
 			zap.String("name", lw.name), zap.String("key", lw.key),
 			zap.Duration("retry-interval", retryInterval), zap.Error(err))
 		retryTimer := time.NewTimer(retryInterval)
@@ -1010,11 +1037,11 @@ func (lw *LoopWatcher) SetLoadSuccessFn(fn func()) {
 }
 
 // SetReloadOnCompaction enables a full, revision-consistent snapshot reload
-// after compaction without retaining watched keys or reconciling deletions.
-// Load callback errors are propagated in this mode so a failed reload cannot
-// advance the watch revision. It must be called before StartWatchLoop. Callers
-// must tolerate partial application and replay; batch-publishing consumers must
-// keep failed loads private.
+// after compaction or a failed watch callback without retaining watched keys or
+// reconciling deletions. Callback errors are propagated in this mode so failed
+// application cannot advance the watch revision. It must be called before
+// StartWatchLoop. Callers must tolerate partial application and replay;
+// batch-publishing consumers must keep failed loads private.
 func (lw *LoopWatcher) SetReloadOnCompaction() {
 	lw.reloadOnCompaction = true
 }

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -858,7 +858,7 @@ func (suite *loopWatcherTestSuite) TestWatcherLoadPreservesFirstCallbackError() 
 				true, /* withPrefix */
 			)
 			watcher.SetReloadOnCompaction()
-			watcher.SetLoadSuccessFn(func(int64) { loadSuccessCalls++ })
+			watcher.SetLoadSuccessFn(func() { loadSuccessCalls++ })
 			watcher.SetLoadBatchSize(test.batchSize)
 			_, err := watcher.load(suite.ctx)
 			re.ErrorIs(err, firstErr)
@@ -885,7 +885,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 
 	values := make(map[string]string)
 	updated := false
-	loadedRevision := int64(0)
+	loadSuccessCalls := 0
 	watcher := NewLoopWatcher(
 		suite.ctx,
 		&suite.wg,
@@ -912,7 +912,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 		true, /* withPrefix */
 	)
 	watcher.SetConsistentLoad()
-	watcher.SetLoadSuccessFn(func(revision int64) { loadedRevision = revision })
+	watcher.SetLoadSuccessFn(func() { loadSuccessCalls++ })
 	watcher.SetLoadBatchSize(1)
 	revision, err := watcher.load(suite.ctx)
 	re.NoError(err)
@@ -920,7 +920,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 	re.Equal("old", values[prefix+"a"])
 	re.Equal("old", values[prefix+"b"])
 	re.Equal("old", values[prefix+"c"])
-	re.Equal(snapshotRevision, loadedRevision)
+	re.Equal(1, loadSuccessCalls)
 }
 
 func (suite *loopWatcherTestSuite) TestWatcherLoadKeepsDefaultPaginationAcrossCompaction() {

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -1243,6 +1243,8 @@ func (suite *loopWatcherTestSuite) TestWatcherReloadsAfterCompactionWhenEnabled(
 	re.NoError(err)
 
 	loadedValues := make(chan string, 1)
+	reloadStarted := make(chan struct{})
+	continueReload := make(chan struct{})
 	watcher := NewLoopWatcher(
 		ctx,
 		&sync.WaitGroup{},
@@ -1260,6 +1262,13 @@ func (suite *loopWatcherTestSuite) TestWatcherReloadsAfterCompactionWhenEnabled(
 		false, /* withPrefix */
 	)
 	watcher.SetReloadOnCompaction()
+	watcher.SetReloadStartFn(func() {
+		close(reloadStarted)
+		select {
+		case <-continueReload:
+		case <-ctx.Done():
+		}
+	})
 
 	type watchResult struct {
 		revision int64
@@ -1270,6 +1279,18 @@ func (suite *loopWatcherTestSuite) TestWatcherReloadsAfterCompactionWhenEnabled(
 		revision, watchErr := watcher.watch(ctx, initialResp.Header.Revision)
 		watchDone <- watchResult{revision: revision, err: watchErr}
 	}()
+
+	select {
+	case <-reloadStarted:
+	case <-time.After(3 * time.Second):
+		suite.T().Fatal("watcher did not announce the compaction reload")
+	}
+	select {
+	case value := <-loadedValues:
+		suite.T().Fatalf("watcher loaded %q before the reload-start callback completed", value)
+	default:
+	}
+	close(continueReload)
 
 	select {
 	case value := <-loadedValues:

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -838,6 +838,7 @@ func (suite *loopWatcherTestSuite) TestWatcherLoadPreservesFirstCallbackError() 
 			firstErr := fmt.Errorf("callback failed at index %d", test.errorIndex)
 			errorKey := fmt.Sprintf("%s%d", prefix, test.errorIndex)
 			processed := make([]string, 0, 3)
+			loadSuccessCalls := 0
 			watcher := NewLoopWatcher(
 				suite.ctx,
 				&suite.wg,
@@ -857,10 +858,12 @@ func (suite *loopWatcherTestSuite) TestWatcherLoadPreservesFirstCallbackError() 
 				true, /* withPrefix */
 			)
 			watcher.SetReloadOnCompaction()
+			watcher.SetLoadSuccessFn(func() { loadSuccessCalls++ })
 			watcher.SetLoadBatchSize(test.batchSize)
 			_, err := watcher.load(suite.ctx)
 			re.ErrorIs(err, firstErr)
 			re.Len(processed, 3)
+			re.Zero(loadSuccessCalls)
 		})
 	}
 }
@@ -882,6 +885,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 
 	values := make(map[string]string)
 	updated := false
+	loadSuccessCalls := 0
 	watcher := NewLoopWatcher(
 		suite.ctx,
 		&suite.wg,
@@ -908,6 +912,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 		true, /* withPrefix */
 	)
 	watcher.SetConsistentLoad()
+	watcher.SetLoadSuccessFn(func() { loadSuccessCalls++ })
 	watcher.SetLoadBatchSize(1)
 	revision, err := watcher.load(suite.ctx)
 	re.NoError(err)
@@ -915,6 +920,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 	re.Equal("old", values[prefix+"a"])
 	re.Equal("old", values[prefix+"b"])
 	re.Equal("old", values[prefix+"c"])
+	re.Equal(1, loadSuccessCalls)
 }
 
 func (suite *loopWatcherTestSuite) TestWatcherLoadKeepsDefaultPaginationAcrossCompaction() {

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -858,7 +858,7 @@ func (suite *loopWatcherTestSuite) TestWatcherLoadPreservesFirstCallbackError() 
 				true, /* withPrefix */
 			)
 			watcher.SetReloadOnCompaction()
-			watcher.SetLoadSuccessFn(func() { loadSuccessCalls++ })
+			watcher.SetLoadSuccessFn(func(int64) { loadSuccessCalls++ })
 			watcher.SetLoadBatchSize(test.batchSize)
 			_, err := watcher.load(suite.ctx)
 			re.ErrorIs(err, firstErr)
@@ -885,7 +885,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 
 	values := make(map[string]string)
 	updated := false
-	loadSuccessCalls := 0
+	loadedRevision := int64(0)
 	watcher := NewLoopWatcher(
 		suite.ctx,
 		&suite.wg,
@@ -912,7 +912,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 		true, /* withPrefix */
 	)
 	watcher.SetConsistentLoad()
-	watcher.SetLoadSuccessFn(func() { loadSuccessCalls++ })
+	watcher.SetLoadSuccessFn(func(revision int64) { loadedRevision = revision })
 	watcher.SetLoadBatchSize(1)
 	revision, err := watcher.load(suite.ctx)
 	re.NoError(err)
@@ -920,7 +920,7 @@ func (suite *loopWatcherTestSuite) TestWatcherConsistentLoadUsesSingleRevision()
 	re.Equal("old", values[prefix+"a"])
 	re.Equal("old", values[prefix+"b"])
 	re.Equal("old", values[prefix+"c"])
-	re.Equal(1, loadSuccessCalls)
+	re.Equal(snapshotRevision, loadedRevision)
 }
 
 func (suite *loopWatcherTestSuite) TestWatcherLoadKeepsDefaultPaginationAcrossCompaction() {

--- a/pkg/utils/etcdutil/etcdutil_test.go
+++ b/pkg/utils/etcdutil/etcdutil_test.go
@@ -1316,13 +1316,13 @@ func (suite *loopWatcherTestSuite) TestWatcherStopsCompactionReloadWhenContextCa
 	)
 	watcher.SetReloadOnCompaction()
 
-	revision, shouldContinue := watcher.reloadAfterCompaction(ctx)
+	revision, shouldContinue := watcher.reloadWithRetry(ctx)
 	re.False(shouldContinue)
 	re.GreaterOrEqual(revision, putResp.Header.Revision+1)
 	re.Equal(1, putCalls)
 	re.Equal(1, postCalls)
 
-	revision, shouldContinue = watcher.reloadAfterCompaction(ctx)
+	revision, shouldContinue = watcher.reloadWithRetry(ctx)
 	re.False(shouldContinue)
 	re.Zero(revision)
 	re.Equal(1, putCalls)
@@ -1496,6 +1496,103 @@ func (suite *loopWatcherTestSuite) TestWatcherRetriesWatchDeleteAfterPostCallbac
 	_, err = watcher.load(suite.ctx)
 	re.NoError(err)
 	re.Empty(cache)
+}
+
+func (suite *loopWatcherTestSuite) TestWatcherReloadsAfterWatchCallbackFailure() {
+	re := suite.Require()
+	const prefix = "TestWatcherReloadsAfterWatchCallbackFailure/"
+	validKey := prefix + "a-valid"
+	invalidKey := prefix + "b-invalid"
+	suite.put(re, validKey, "initial")
+	suite.put(re, invalidKey, "initial")
+
+	ctx, cancel := context.WithCancel(suite.ctx)
+	defer cancel()
+	callbackErr := errors.New("invalid value")
+	postEventCounts := make(chan int, 8)
+	reloadDone := make(chan struct{})
+	var loadSuccessCalls atomic.Int32
+	cache := struct {
+		sync.RWMutex
+		values map[string]string
+	}{values: make(map[string]string)}
+	watcher := NewLoopWatcher(
+		ctx,
+		&suite.wg,
+		suite.client,
+		"test",
+		prefix,
+		func([]*clientv3.Event) error { return nil },
+		func(kv *mvccpb.KeyValue) error {
+			if string(kv.Value) == "invalid" {
+				return callbackErr
+			}
+			cache.Lock()
+			cache.values[string(kv.Key)] = string(kv.Value)
+			cache.Unlock()
+			return nil
+		},
+		func(kv *mvccpb.KeyValue) error {
+			cache.Lock()
+			delete(cache.values, string(kv.Key))
+			cache.Unlock()
+			return nil
+		},
+		func(events []*clientv3.Event) error {
+			select {
+			case postEventCounts <- len(events):
+			default:
+			}
+			return nil
+		},
+		true, /* withPrefix */
+	)
+	watcher.SetReconcileDeletedKeys()
+	watcher.SetLoadSuccessFn(func() {
+		if loadSuccessCalls.Add(1) == 2 {
+			close(reloadDone)
+		}
+	})
+	watcher.watchChangeRetryInterval = 10 * time.Millisecond
+
+	revision, err := watcher.load(ctx)
+	re.NoError(err)
+	re.Zero(<-postEventCounts)
+
+	type watchResult struct {
+		revision int64
+		err      error
+	}
+	watchDone := make(chan watchResult, 1)
+	go func() {
+		nextRevision, watchErr := watcher.watch(ctx, revision)
+		watchDone <- watchResult{revision: nextRevision, err: watchErr}
+	}()
+
+	_, err = suite.client.Txn(suite.ctx).Then(
+		clientv3.OpPut(validKey, "updated"),
+		clientv3.OpPut(invalidKey, "invalid"),
+	).Commit()
+	re.NoError(err)
+	// Both events share one transaction revision. The successfully applied
+	// subset must not be passed to postEventsFn as a publishable batch.
+	re.Zero(<-postEventCounts)
+
+	recoveryResp, err := suite.client.Put(suite.ctx, invalidKey, "recovered")
+	re.NoError(err)
+	select {
+	case <-reloadDone:
+	case <-time.After(3 * time.Second):
+		suite.T().Fatal("watcher did not recover the failed batch from a snapshot")
+	}
+	cache.RLock()
+	re.Equal(map[string]string{validKey: "updated", invalidKey: "recovered"}, cache.values)
+	cache.RUnlock()
+
+	cancel()
+	result := <-watchDone
+	re.NoError(result.err)
+	re.GreaterOrEqual(result.revision, recoveryResp.Header.Revision+1)
 }
 
 func (suite *loopWatcherTestSuite) TestWatcherRetriesFailedCompactionReloadWithBackoff() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11032

After watch compaction or callback failures, TSO keyspace group discovery may
retain deleted groups or publish partially applied membership under an
incorrect revision.

### What is changed and how does it work?

- Recover opted-in `LoopWatcher` consumers from callback failures with a
  revision-consistent full reload.
- Reconcile keyspace groups missing from a full snapshot.
- Use one revision fence to prevent discovery from publishing incomplete
  membership, while established TSO serving remains available.
- Make standalone deletion atomically delete the target and rewrite the
  unchanged default group at the same revision.
- Keep merge targets as the surviving revision source and reject requests that
  also include the target in the source list.
- Reject deletion of the default group and make deletion of an absent group
  idempotent.
- Preserve ownership already claimed by a newer group during reconciliation.

No marker key, protobuf field, or storage format is added.

### Compatibility

A legacy reader cannot repair a deletion it missed before compaction, and a
legacy deletion-only writer does not update a surviving membership key.

During a mixed-version rollout, pause keyspace group mutations, drain legacy
writers and readers, refresh the default group after upgraded readers are
watching, and then resume mutations.

### Performance

The normal TSO serving path adds no storage I/O. A standalone delete adds one
default-group read and one same-value `Put` in the existing transaction.
Snapshot reloads skip decoding values already covered by the published
revision.

### Tests

Added coverage for callback failure recovery, witnessed and unwitnessed
snapshot deletions, merge validation, atomic deletion, and continued TSO
serving while discovery is fenced.

### Release note

```release-note
Prevent TSO keyspace group discovery from returning stale or partially applied membership after watch compaction or callback failures.
```
