### PR TITLE
keyspace: load persisted metadata by ID through gRPC (#10911, #11050)

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427
+	github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/client/go.sum
+++ b/client/go.sum
@@ -55,8 +55,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c h1:xpW9bvK+HuuTm
 github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427 h1:fnagXtVQTLmi2sLH7QgvH1vHlFohDeQtRASxzXVk2ss=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d h1:NyyKos+kknw0UZO4zirO1xZdc9+45DnMbRrXuNbpAOA=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -41,6 +41,8 @@ const (
 type KeyspaceClient interface {
 	// LoadKeyspace load and return target keyspace's metadata.
 	LoadKeyspace(ctx context.Context, name string) (*keyspacepb.KeyspaceMeta, error)
+	// LoadKeyspaceByID loads and returns target keyspace's metadata by ID.
+	LoadKeyspaceByID(ctx context.Context, id uint32) (*keyspacepb.KeyspaceMeta, error)
 	// UpdateKeyspaceState updates target keyspace's state.
 	UpdateKeyspaceState(ctx context.Context, id uint32, state keyspacepb.KeyspaceState) (*keyspacepb.KeyspaceMeta, error)
 	// WatchKeyspaces watches keyspace meta changes.
@@ -108,6 +110,41 @@ func (c *client) LoadKeyspace(ctx context.Context, name string) (*keyspacepb.Key
 	if resp.Header.GetError() != nil {
 		metrics.CmdFailedDurationLoadKeyspace.Observe(time.Since(start).Seconds())
 		return nil, errors.Errorf("Load keyspace %s failed: %s", name, resp.Header.GetError().String())
+	}
+
+	return resp.Keyspace, nil
+}
+
+// LoadKeyspaceByID loads and returns target keyspace's metadata by ID.
+func (c *client) LoadKeyspaceByID(ctx context.Context, id uint32) (*keyspacepb.KeyspaceMeta, error) {
+	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
+		span = span.Tracer().StartSpan("keyspaceClient.LoadKeyspaceByID", opentracing.ChildOf(span.Context()))
+		defer span.Finish()
+	}
+	start := time.Now()
+	defer func() { metrics.CmdDurationLoadKeyspaceByID.Observe(time.Since(start).Seconds()) }()
+	ctx, cancel := context.WithTimeout(ctx, c.inner.option.Timeout)
+	req := &keyspacepb.LoadKeyspaceByIDRequest{
+		Header: c.requestHeader(),
+		Id:     id,
+	}
+	protoClient := c.keyspaceClient()
+	if protoClient == nil {
+		cancel()
+		return nil, errs.ErrClientGetProtoClient
+	}
+	resp, err := protoClient.LoadKeyspaceByID(ctx, req)
+	cancel()
+
+	if err != nil {
+		metrics.CmdFailedDurationLoadKeyspaceByID.Observe(time.Since(start).Seconds())
+		c.inner.serviceDiscovery.ScheduleCheckMemberChanged()
+		return nil, err
+	}
+
+	if resp.Header.GetError() != nil {
+		metrics.CmdFailedDurationLoadKeyspaceByID.Observe(time.Since(start).Seconds())
+		return nil, errors.Errorf("Load keyspace id %d failed: %s", id, resp.Header.GetError().String())
 	}
 
 	return resp.Keyspace, nil

--- a/client/keyspace_client.go
+++ b/client/keyspace_client.go
@@ -41,7 +41,8 @@ const (
 type KeyspaceClient interface {
 	// LoadKeyspace load and return target keyspace's metadata.
 	LoadKeyspace(ctx context.Context, name string) (*keyspacepb.KeyspaceMeta, error)
-	// LoadKeyspaceByID loads and returns target keyspace's metadata by ID.
+	// LoadKeyspaceByID loads and returns target keyspace's persisted metadata by ID.
+	// Unlike LoadKeyspace, a successful call does not guarantee that the keyspace region bounds are ready.
 	LoadKeyspaceByID(ctx context.Context, id uint32) (*keyspacepb.KeyspaceMeta, error)
 	// UpdateKeyspaceState updates target keyspace's state.
 	UpdateKeyspaceState(ctx context.Context, id uint32, state keyspacepb.KeyspaceState) (*keyspacepb.KeyspaceMeta, error)
@@ -115,7 +116,8 @@ func (c *client) LoadKeyspace(ctx context.Context, name string) (*keyspacepb.Key
 	return resp.Keyspace, nil
 }
 
-// LoadKeyspaceByID loads and returns target keyspace's metadata by ID.
+// LoadKeyspaceByID loads and returns target keyspace's persisted metadata by ID.
+// Unlike LoadKeyspace, a successful call does not guarantee that the keyspace region bounds are ready.
 func (c *client) LoadKeyspaceByID(ctx context.Context, id uint32) (*keyspacepb.KeyspaceMeta, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span = span.Tracer().StartSpan("keyspaceClient.LoadKeyspaceByID", opentracing.ChildOf(span.Context()))

--- a/client/keyspace_client_test.go
+++ b/client/keyspace_client_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	clienterrs "github.com/tikv/pd/client/errs"
+	"github.com/tikv/pd/client/opt"
+	"github.com/tikv/pd/client/pkg/utils/grpcutil"
+)
+
+type testKeyspaceServer struct {
+	keyspacepb.UnimplementedKeyspaceServer
+
+	meta     *keyspacepb.KeyspaceMeta
+	respType pdpb.ErrorType
+	respMsg  string
+	rpcErr   error
+	lastID   atomic.Uint32
+}
+
+func (s *testKeyspaceServer) LoadKeyspaceByID(
+	_ context.Context,
+	req *keyspacepb.LoadKeyspaceByIDRequest,
+) (*keyspacepb.LoadKeyspaceResponse, error) {
+	s.lastID.Store(req.GetId())
+	if s.rpcErr != nil {
+		return nil, s.rpcErr
+	}
+	resp := &keyspacepb.LoadKeyspaceResponse{
+		Header: &pdpb.ResponseHeader{},
+	}
+	if s.respMsg != "" {
+		resp.Header.Error = &pdpb.Error{
+			Type:    s.respType,
+			Message: s.respMsg,
+		}
+		return resp, nil
+	}
+	resp.Keyspace = s.meta
+	return resp, nil
+}
+
+func startTestKeyspaceServer(t *testing.T, keyspaceServer *testKeyspaceServer) (string, func()) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	keyspacepb.RegisterKeyspaceServer(server, keyspaceServer)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		defer close(serveErr)
+		if err := server.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			serveErr <- err
+		}
+	}()
+
+	addr := "http://" + listener.Addr().String()
+	cleanup := func() {
+		server.Stop()
+		require.NoError(t, <-serveErr)
+	}
+	return addr, cleanup
+}
+
+func newTestKeyspaceClient(t *testing.T, ctx context.Context, addr string) *client {
+	t.Helper()
+
+	conn, err := grpcutil.GetClientConn(ctx, addr, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	option := opt.NewOption()
+	option.InitMetrics = false
+	return &client{
+		inner: &innerClient{
+			serviceDiscovery: newTestServiceDiscovery(addr, conn),
+			ctx:              ctx,
+			option:           option,
+		},
+	}
+}
+
+func TestLoadKeyspaceByID(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	expected := &keyspacepb.KeyspaceMeta{
+		Id:    42,
+		Name:  "test-keyspace",
+		State: keyspacepb.KeyspaceState_ENABLED,
+	}
+	keyspaceServer := &testKeyspaceServer{meta: expected}
+	addr, cleanup := startTestKeyspaceServer(t, keyspaceServer)
+	t.Cleanup(cleanup)
+
+	client := newTestKeyspaceClient(t, ctx, addr)
+	span, tracedCtx := opentracing.StartSpanFromContext(ctx, "test-load-keyspace-by-id")
+	defer span.Finish()
+	loaded, err := client.LoadKeyspaceByID(tracedCtx, expected.GetId())
+	re.NoError(err)
+	re.Equal(expected, loaded)
+	re.Equal(expected.GetId(), keyspaceServer.lastID.Load())
+}
+
+func TestLoadKeyspaceByIDReturnsHeaderError(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	keyspaceServer := &testKeyspaceServer{
+		respType: pdpb.ErrorType_ENTRY_NOT_FOUND,
+		respMsg:  "keyspace does not exist",
+	}
+	addr, cleanup := startTestKeyspaceServer(t, keyspaceServer)
+	t.Cleanup(cleanup)
+
+	client := newTestKeyspaceClient(t, ctx, addr)
+	loaded, err := client.LoadKeyspaceByID(ctx, 42)
+	re.Nil(loaded)
+	re.ErrorContains(err, "Load keyspace id 42 failed")
+	re.ErrorContains(err, "keyspace does not exist")
+	re.Equal(uint32(42), keyspaceServer.lastID.Load())
+}
+
+func TestLoadKeyspaceByIDReturnsProtoClientError(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	option := opt.NewOption()
+	client := &client{
+		inner: &innerClient{
+			serviceDiscovery: &testServiceDiscovery{},
+			ctx:              ctx,
+			option:           option,
+		},
+	}
+
+	loaded, err := client.LoadKeyspaceByID(ctx, 42)
+	re.Nil(loaded)
+	re.True(clienterrs.ErrClientGetProtoClient.Equal(err))
+}
+
+func TestLoadKeyspaceByIDReturnsRPCError(t *testing.T) {
+	re := require.New(t)
+	ctx := context.Background()
+	keyspaceServer := &testKeyspaceServer{
+		rpcErr: errors.New("load keyspace by id failed"),
+	}
+	addr, cleanup := startTestKeyspaceServer(t, keyspaceServer)
+	t.Cleanup(cleanup)
+
+	client := newTestKeyspaceClient(t, ctx, addr)
+	loaded, err := client.LoadKeyspaceByID(ctx, 42)
+	re.Nil(loaded)
+	re.ErrorContains(err, "load keyspace by id failed")
+	re.Equal(uint32(42), keyspaceServer.lastID.Load())
+}

--- a/client/metrics/metrics.go
+++ b/client/metrics/metrics.go
@@ -275,6 +275,7 @@ var (
 	CmdDurationSplitRegions             prometheus.Observer
 	CmdDurationSplitAndScatterRegions   prometheus.Observer
 	CmdDurationLoadKeyspace             prometheus.Observer
+	CmdDurationLoadKeyspaceByID         prometheus.Observer
 	CmdDurationUpdateKeyspaceState      prometheus.Observer
 	CmdDurationGetAllKeyspaces          prometheus.Observer
 	CmdDurationGet                      prometheus.Observer
@@ -306,6 +307,7 @@ var (
 	CmdFailedDurationUpdateGCSafePoint        prometheus.Observer
 	CmdFailedDurationUpdateServiceGCSafePoint prometheus.Observer
 	CmdFailedDurationLoadKeyspace             prometheus.Observer
+	CmdFailedDurationLoadKeyspaceByID         prometheus.Observer
 	CmdFailedDurationUpdateKeyspaceState      prometheus.Observer
 	CmdFailedDurationGet                      prometheus.Observer
 	CmdFailedDurationPut                      prometheus.Observer
@@ -365,6 +367,7 @@ func initLabelValues() {
 	CmdDurationSplitRegions = cmdDuration.WithLabelValues("split_regions")
 	CmdDurationSplitAndScatterRegions = cmdDuration.WithLabelValues("split_and_scatter_regions")
 	CmdDurationLoadKeyspace = cmdDuration.WithLabelValues("load_keyspace")
+	CmdDurationLoadKeyspaceByID = cmdDuration.WithLabelValues("load_keyspace_by_id")
 	CmdDurationUpdateKeyspaceState = cmdDuration.WithLabelValues("update_keyspace_state")
 	CmdDurationGetAllKeyspaces = cmdDuration.WithLabelValues("get_all_keyspaces")
 	CmdDurationGet = cmdDuration.WithLabelValues("get")
@@ -396,6 +399,7 @@ func initLabelValues() {
 	CmdFailedDurationUpdateGCSafePoint = cmdFailedDuration.WithLabelValues("update_gc_safe_point")
 	CmdFailedDurationUpdateServiceGCSafePoint = cmdFailedDuration.WithLabelValues("update_service_gc_safe_point")
 	CmdFailedDurationLoadKeyspace = cmdFailedDuration.WithLabelValues("load_keyspace")
+	CmdFailedDurationLoadKeyspaceByID = cmdFailedDuration.WithLabelValues("load_keyspace_by_id")
 	CmdFailedDurationUpdateKeyspaceState = cmdFailedDuration.WithLabelValues("update_keyspace_state")
 	CmdFailedDurationGet = cmdFailedDuration.WithLabelValues("get")
 	CmdFailedDurationPut = cmdFailedDuration.WithLabelValues("put")

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pingcap/errcode v0.3.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427
+	github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pingcap/metering_sdk v0.0.0-20260203082503-b9f282339654
 	github.com/pingcap/sysutil v1.0.1-0.20230407040306-fb007c5aff21

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427 h1:fnagXtVQTLmi2sLH7QgvH1vHlFohDeQtRASxzXVk2ss=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d h1:NyyKos+kknw0UZO4zirO1xZdc9+45DnMbRrXuNbpAOA=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/server/keyspace_service.go
+++ b/server/keyspace_service.go
@@ -81,6 +81,38 @@ func (s *KeyspaceServer) LoadKeyspace(_ context.Context, request *keyspacepb.Loa
 	}, nil
 }
 
+// LoadKeyspaceByID loads and returns target keyspace metadata.
+// Request must specify keyspace ID.
+// On Error, keyspaceMeta in response will be nil,
+// error information will be encoded in response header with corresponding error type.
+func (s *KeyspaceServer) LoadKeyspaceByID(_ context.Context, request *keyspacepb.LoadKeyspaceByIDRequest) (*keyspacepb.LoadKeyspaceResponse, error) {
+	if err := s.validateRequest(request.GetHeader()); err != nil {
+		return nil, err
+	}
+
+	manager := s.GetKeyspaceManager()
+	meta, err := manager.LoadKeyspaceByID(request.GetId())
+	if err != nil {
+		return &keyspacepb.LoadKeyspaceResponse{Header: getErrorHeader(err)}, nil
+	}
+	failpoint.Inject("skipKeyspaceRegionCheck", func() {
+		failpoint.Return(&keyspacepb.LoadKeyspaceResponse{
+			Header:   grpcutil.WrapHeader(),
+			Keyspace: meta,
+		}, nil)
+	})
+	if !manager.CheckKeyspaceRegionBound(meta.GetId()) {
+		// If the keyspace region is not split yet, we treat it as not found.
+		// To avoid clients using the keyspace before region split is done.
+		err = errs.ErrKeyspaceNotFound
+		return &keyspacepb.LoadKeyspaceResponse{Header: getErrorHeader(err)}, nil
+	}
+	return &keyspacepb.LoadKeyspaceResponse{
+		Header:   grpcutil.WrapHeader(),
+		Keyspace: meta,
+	}, nil
+}
+
 // WatchKeyspaces captures and sends keyspace metadata changes to the client via gRPC stream.
 // Note: It sends all existing keyspaces as it's first package to the client.
 func (s *KeyspaceServer) WatchKeyspaces(request *keyspacepb.WatchKeyspacesRequest, stream keyspacepb.Keyspace_WatchKeyspacesServer) error {

--- a/server/keyspace_service.go
+++ b/server/keyspace_service.go
@@ -95,18 +95,9 @@ func (s *KeyspaceServer) LoadKeyspaceByID(_ context.Context, request *keyspacepb
 	if err != nil {
 		return &keyspacepb.LoadKeyspaceResponse{Header: getErrorHeader(err)}, nil
 	}
-	failpoint.Inject("skipKeyspaceRegionCheck", func() {
-		failpoint.Return(&keyspacepb.LoadKeyspaceResponse{
-			Header:   grpcutil.WrapHeader(),
-			Keyspace: meta,
-		}, nil)
-	})
-	if !manager.CheckKeyspaceRegionBound(meta.GetId()) {
-		// If the keyspace region is not split yet, we treat it as not found.
-		// To avoid clients using the keyspace before region split is done.
-		err = errs.ErrKeyspaceNotFound
-		return &keyspacepb.LoadKeyspaceResponse{Header: getErrorHeader(err)}, nil
-	}
+	// TiKV needs keyspace metadata, including encryption settings, before it can
+	// split the keyspace regions. Checking the region bounds here would create a
+	// circular dependency between loading the metadata and splitting the regions.
 	return &keyspacepb.LoadKeyspaceResponse{
 		Header:   grpcutil.WrapHeader(),
 		Keyspace: meta,

--- a/tests/integrations/go.mod
+++ b/tests/integrations/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427
+	github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/tests/integrations/go.sum
+++ b/tests/integrations/go.sum
@@ -473,8 +473,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427 h1:fnagXtVQTLmi2sLH7QgvH1vHlFohDeQtRASxzXVk2ss=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d h1:NyyKos+kknw0UZO4zirO1xZdc9+45DnMbRrXuNbpAOA=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=

--- a/tests/server/keyspace/keyspace_service_test.go
+++ b/tests/server/keyspace/keyspace_service_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyspace
+
+import (
+	"context"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	keyspacepkg "github.com/tikv/pd/pkg/keyspace"
+	"github.com/tikv/pd/pkg/utils/testutil"
+	"github.com/tikv/pd/server"
+	pdtests "github.com/tikv/pd/tests"
+)
+
+func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
+	re := suite.Require()
+	service := &server.KeyspaceServer{
+		GrpcServer: &server.GrpcServer{Server: suite.server.GetServer()},
+	}
+	ctx := context.Background()
+
+	created, err := suite.manager.CreateKeyspace(&keyspacepkg.CreateKeyspaceRequest{
+		Name: "grpc_load_by_id",
+	})
+	re.NoError(err)
+
+	_, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID() + 1),
+		Id:     created.GetId(),
+	})
+	re.Error(err)
+
+	resp, err := service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
+		Id:     created.GetId() + 1000,
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
+	re.Nil(resp.GetKeyspace())
+
+	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
+		Id:     created.GetId(),
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
+	re.Nil(resp.GetKeyspace())
+
+	regionBound := keyspacepkg.MakeRegionBound(created.GetId())
+	regionID := uint64(created.GetId()) * 10
+	pdtests.MustPutRegion(re, suite.cluster, regionID+1, 1, regionBound.RawLeftBound, regionBound.RawRightBound)
+	pdtests.MustPutRegion(re, suite.cluster, regionID+2, 1, regionBound.RawRightBound, regionBound.TxnLeftBound)
+	pdtests.MustPutRegion(re, suite.cluster, regionID+3, 1, regionBound.TxnLeftBound, regionBound.TxnRightBound)
+	pdtests.MustPutRegion(re, suite.cluster, regionID+4, 1, regionBound.TxnRightBound, []byte{})
+	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
+		Id:     created.GetId(),
+	})
+	re.NoError(err)
+	re.Nil(resp.GetHeader().GetError())
+	re.Equal(created, resp.GetKeyspace())
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
+	skipRegionCheckKeyspace, err := suite.manager.CreateKeyspace(&keyspacepkg.CreateKeyspaceRequest{
+		Name: "grpc_skip_region",
+	})
+	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
+	re.NoError(err)
+	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
+		Id:     skipRegionCheckKeyspace.GetId(),
+	})
+	re.NoError(err)
+	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
+	re.Nil(resp.GetKeyspace())
+
+	re.NoError(failpoint.Enable("github.com/tikv/pd/server/skipKeyspaceRegionCheck", "return"))
+	defer func() {
+		re.NoError(failpoint.Disable("github.com/tikv/pd/server/skipKeyspaceRegionCheck"))
+	}()
+	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
+		Id:     skipRegionCheckKeyspace.GetId(),
+	})
+	re.NoError(err)
+	re.Nil(resp.GetHeader().GetError())
+	re.Equal(skipRegionCheckKeyspace, resp.GetKeyspace())
+}

--- a/tests/server/keyspace/keyspace_service_test.go
+++ b/tests/server/keyspace/keyspace_service_test.go
@@ -17,14 +17,12 @@ package keyspace
 import (
 	"context"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	keyspacepkg "github.com/tikv/pd/pkg/keyspace"
 	"github.com/tikv/pd/pkg/utils/testutil"
 	"github.com/tikv/pd/server"
-	pdtests "github.com/tikv/pd/tests"
 )
 
 func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
@@ -33,9 +31,16 @@ func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
 		GrpcServer: &server.GrpcServer{Server: suite.server.GetServer()},
 	}
 	ctx := context.Background()
+	const (
+		keyspaceName     = "grpc_load_by_id"
+		encryptionConfig = "test-encryption-config"
+	)
 
 	created, err := suite.manager.CreateKeyspace(&keyspacepkg.CreateKeyspaceRequest{
-		Name: "grpc_load_by_id",
+		Name: keyspaceName,
+		Config: map[string]string{
+			"encryption": encryptionConfig,
+		},
 	})
 	re.NoError(err)
 
@@ -53,51 +58,26 @@ func (suite *keyspaceTestSuite) TestLoadKeyspaceByIDGRPC() {
 	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
 	re.Nil(resp.GetKeyspace())
 
+	disabled, err := suite.manager.UpdateKeyspaceStateByID(
+		created.GetId(), keyspacepb.KeyspaceState_DISABLED, 1,
+	)
+	re.NoError(err)
+	re.False(suite.manager.CheckKeyspaceRegionBound(disabled.GetId()))
 	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
 		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     created.GetId(),
+		Id:     disabled.GetId(),
+	})
+	re.NoError(err)
+	re.Nil(resp.GetHeader().GetError())
+	re.Equal(disabled, resp.GetKeyspace())
+	re.Equal(keyspacepb.KeyspaceState_DISABLED, resp.GetKeyspace().GetState())
+	re.Equal(encryptionConfig, resp.GetKeyspace().GetConfig()["encryption"])
+
+	resp, err = service.LoadKeyspace(ctx, &keyspacepb.LoadKeyspaceRequest{
+		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
+		Name:   keyspaceName,
 	})
 	re.NoError(err)
 	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
 	re.Nil(resp.GetKeyspace())
-
-	regionBound := keyspacepkg.MakeRegionBound(created.GetId())
-	regionID := uint64(created.GetId()) * 10
-	pdtests.MustPutRegion(re, suite.cluster, regionID+1, 1, regionBound.RawLeftBound, regionBound.RawRightBound)
-	pdtests.MustPutRegion(re, suite.cluster, regionID+2, 1, regionBound.RawRightBound, regionBound.TxnLeftBound)
-	pdtests.MustPutRegion(re, suite.cluster, regionID+3, 1, regionBound.TxnLeftBound, regionBound.TxnRightBound)
-	pdtests.MustPutRegion(re, suite.cluster, regionID+4, 1, regionBound.TxnRightBound, []byte{})
-	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
-		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     created.GetId(),
-	})
-	re.NoError(err)
-	re.Nil(resp.GetHeader().GetError())
-	re.Equal(created, resp.GetKeyspace())
-
-	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion", "return(true)"))
-	skipRegionCheckKeyspace, err := suite.manager.CreateKeyspace(&keyspacepkg.CreateKeyspaceRequest{
-		Name: "grpc_skip_region",
-	})
-	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/keyspace/skipSplitRegion"))
-	re.NoError(err)
-	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
-		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     skipRegionCheckKeyspace.GetId(),
-	})
-	re.NoError(err)
-	re.Equal(pdpb.ErrorType_ENTRY_NOT_FOUND, resp.GetHeader().GetError().GetType())
-	re.Nil(resp.GetKeyspace())
-
-	re.NoError(failpoint.Enable("github.com/tikv/pd/server/skipKeyspaceRegionCheck", "return"))
-	defer func() {
-		re.NoError(failpoint.Disable("github.com/tikv/pd/server/skipKeyspaceRegionCheck"))
-	}()
-	resp, err = service.LoadKeyspaceByID(ctx, &keyspacepb.LoadKeyspaceByIDRequest{
-		Header: testutil.NewRequestHeader(suite.server.GetClusterID()),
-		Id:     skipRegionCheckKeyspace.GetId(),
-	})
-	re.NoError(err)
-	re.Nil(resp.GetHeader().GetError())
-	re.Equal(skipRegionCheckKeyspace, resp.GetKeyspace())
 }

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427
+	github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.20.5

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -478,8 +478,8 @@ github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c/go.mod h1:X2r9ue
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427 h1:fnagXtVQTLmi2sLH7QgvH1vHlFohDeQtRASxzXVk2ss=
-github.com/pingcap/kvproto v0.0.0-20260703015547-e800f9e5a427/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d h1:NyyKos+kknw0UZO4zirO1xZdc9+45DnMbRrXuNbpAOA=
+github.com/pingcap/kvproto v0.0.0-20260804071546-93fe539c508d/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=


### PR DESCRIPTION
### What problem does this PR solve?

This manually cherry-picks #10911 and #11050 to `release-nextgen-202603`.

Issue Number: ref #10912

TiKV needs persisted keyspace metadata, such as encryption settings, before it
can split the keyspace regions. Without the ID-based RPC, this creates a
circular dependency or requires scanning `GetAllKeyspaces`.

### What is changed and how does it work?

```commit-message
Backport LoadKeyspaceByID to the gRPC keyspace service and Go PD client.

Return persisted keyspace metadata by ID without requiring region-bound
readiness, while keeping the name-based LoadKeyspace behavior unchanged.

Update kvproto to the merged release-nextgen-202603 backport in
pingcap/kvproto#1509.
```

The backport keeps the target branch's `CheckKeyspaceRegionBound` API and uses
the nextgen kvproto lineage instead of downgrading to the master dependency.

### Check List

Tests

- Unit test
  - `go test . -run '^TestLoadKeyspaceByID' -count=1` in `client`.
  - `go test -tags without_dashboard ./tests/server/keyspace -run '^TestKeyspaceTestSuite/TestLoadKeyspaceByIDGRPC$' -count=1`.
- Compile and module checks
  - `make tidy`.
  - `go build ./server`.
  - `go build .` in `client`.

Related changes

- kvproto backport: https://github.com/pingcap/kvproto/pull/1509

### Release note

```release-note
Support loading persisted keyspace metadata by keyspace ID through gRPC before region splitting completes.
```
