### PR TITLE
mcs, tso: fix expected-primary transient marker races

### DIFF
--- a/pkg/mcs/resourcemanager/server/apis/v1/api.go
+++ b/pkg/mcs/resourcemanager/server/apis/v1/api.go
@@ -361,7 +361,7 @@ func transferPrimary(c *gin.Context) {
 		newPrimary = v
 	}
 
-	if err := utils.TransferPrimary(c.Request.Context(), svr.GetClient(), svr.GetParticipant(),
+	if err := utils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
 		constant.ResourceManagerServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/resourcemanager/server/apis/v1/api.go
+++ b/pkg/mcs/resourcemanager/server/apis/v1/api.go
@@ -361,7 +361,7 @@ func transferPrimary(c *gin.Context) {
 		newPrimary = v
 	}
 
-	if err := utils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
+	if err := utils.TransferPrimary(c.Request.Context(), svr.GetClient(), svr.GetParticipant(),
 		constant.ResourceManagerServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/resourcemanager/server/apis/v1/api.go
+++ b/pkg/mcs/resourcemanager/server/apis/v1/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/log"
 
@@ -363,6 +364,8 @@ func transferPrimary(c *gin.Context) {
 
 	if err := utils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
 		constant.ResourceManagerServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
+		log.Warn("failed to transfer resource manager primary",
+			zap.String("new-primary", newPrimary), errs.ZapError(err))
 		c.String(http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -152,6 +152,11 @@ func (s *Server) primaryElectionLoop() {
 	defer logutil.LogPanic()
 	defer s.serverLoopWg.Done()
 
+	// Tracks consecutive GetExpectedPrimaryFlag read failures across loop iterations,
+	// so a short run of failures retries the cheap read instead of immediately
+	// escalating to a full guarded campaign - see the read-failure branch below.
+	readFailureStreak := 0
+
 	for {
 		select {
 		case <-s.serverLoopCtx.Done():
@@ -173,16 +178,29 @@ func (s *Server) primaryElectionLoop() {
 
 		// To make sure the expected primary(if existed) and new primary are on the same server.
 		expectedPrimary, err := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
-		readFailed := err != nil
-		if readFailed {
+		if err != nil {
+			readFailureStreak++
+			if readFailureStreak < constant.MinConsecutiveReadFailuresForCampaign {
+				// A short run of read failures is usually a transient blip; keep
+				// retrying the cheap read instead of immediately escalating to a full
+				// guarded campaign (lease grant + txn commit, heavier than the read
+				// that just failed).
+				log.Warn("failed to get expected primary flag, retrying the read before campaigning",
+					zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))
+				time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
+				continue
+			}
 			// ExpectedPrimaryCmp("") still atomically requires the marker to be
 			// absent at commit time, so campaigning with an empty flag here cannot
 			// let this member win over a real transfer target - it can only fail
-			// closed if a marker actually exists. Skipping campaigning on every read
-			// failure would otherwise leave the service leaderless for as long as
-			// the reads keep failing, even when no transfer is in progress.
-			log.Warn("failed to get expected primary flag, campaign without affinity guard", errs.ZapError(err))
+			// closed if a marker actually exists. Skipping campaigning forever would
+			// otherwise leave the service leaderless for as long as the reads keep
+			// failing, even when no transfer is in progress.
+			log.Warn("expected primary flag read kept failing, campaign without affinity guard",
+				zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))
 			expectedPrimary = ""
+		} else {
+			readFailureStreak = 0
 		}
 		// Skip campaign if the expected primary is not empty and not this member.
 		// Expected primary ONLY SET BY `{service}/primary/transfer` API.
@@ -197,13 +215,13 @@ func (s *Server) primaryElectionLoop() {
 		}
 
 		won := s.campaignLeader(expectedPrimary)
-		if readFailed {
+		if readFailureStreak >= constant.MinConsecutiveReadFailuresForCampaign {
 			// The read failure usually means etcd itself is degraded, and
 			// campaigning (lease grant + txn commit) is heavier than the read that
-			// just failed - keep the same backoff the old skip-and-retry path used
-			// so a run of failing reads cannot turn into a tight retry loop against
-			// an already struggling etcd.
-			time.Sleep(200 * time.Millisecond)
+			// just failed - back off with growing delay so a sustained run of
+			// failures does not turn into a tight, fixed-rate retry loop against an
+			// already struggling etcd.
+			time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
 		}
 		if won {
 			log.Warn("backing off before retrying resource manager primary campaign after callback failure",
@@ -243,11 +261,12 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 	// Start keepalive the leadership and enable Resource Manager service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
 	var resetLeaderOnce sync.Once
-	defer resetLeaderOnce.Do(func() {
+	resetLeader := func() {
 		cancel()
 		s.participant.Resign()
 		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
-	})
+	}
+	defer resetLeaderOnce.Do(resetLeader)
 
 	// maintain the leadership, after this, Resource Manager could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -261,6 +280,13 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 	if utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary, s.participant) {
 		log.Info("the expected primary has been changed to another member, stepping down",
 			zap.String("server-name", s.Name()))
+		// Release the leader key now, before the backoff sleep, instead of leaving it to
+		// the deferred reset above: that defer only runs once this function actually
+		// returns, so without this the keepalive goroutine started by Keep(ctx) would
+		// keep renewing the leader key for the whole sleep, needlessly delaying the
+		// actual target's takeover. resetLeaderOnce makes the deferred call below a
+		// no-op once this has run.
+		resetLeaderOnce.Do(resetLeader)
 		time.Sleep(200 * time.Millisecond)
 		return false
 	}

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -173,12 +173,16 @@ func (s *Server) primaryElectionLoop() {
 
 		// To make sure the expected primary(if existed) and new primary are on the same server.
 		expectedPrimary, err := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
-		if err != nil {
-			// Do not campaign on a read failure: an empty flag would be treated as
-			// "no transfer" and skip the affinity guard, so retry instead.
-			log.Warn("failed to get expected primary flag, retry later", errs.ZapError(err))
-			time.Sleep(200 * time.Millisecond)
-			continue
+		readFailed := err != nil
+		if readFailed {
+			// ExpectedPrimaryCmp("") still atomically requires the marker to be
+			// absent at commit time, so campaigning with an empty flag here cannot
+			// let this member win over a real transfer target - it can only fail
+			// closed if a marker actually exists. Skipping campaigning on every read
+			// failure would otherwise leave the service leaderless for as long as
+			// the reads keep failing, even when no transfer is in progress.
+			log.Warn("failed to get expected primary flag, campaign without affinity guard", errs.ZapError(err))
+			expectedPrimary = ""
 		}
 		// Skip campaign if the expected primary is not empty and not this member.
 		// Expected primary ONLY SET BY `{service}/primary/transfer` API.
@@ -192,7 +196,16 @@ func (s *Server) primaryElectionLoop() {
 			continue
 		}
 
-		if s.campaignLeader(expectedPrimary) {
+		won := s.campaignLeader(expectedPrimary)
+		if readFailed {
+			// The read failure usually means etcd itself is degraded, and
+			// campaigning (lease grant + txn commit) is heavier than the read that
+			// just failed - keep the same backoff the old skip-and-retry path used
+			// so a run of failing reads cannot turn into a tight retry loop against
+			// an already struggling etcd.
+			time.Sleep(200 * time.Millisecond)
+		}
+		if won {
 			log.Warn("backing off before retrying resource manager primary campaign after callback failure",
 				zap.Duration("retry-after", primaryCallbackFailureRetryInterval))
 			timer := time.NewTimer(primaryCallbackFailureRetryInterval)

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -261,6 +261,7 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 	if utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary, s.participant) {
 		log.Info("the expected primary has been changed to another member, stepping down",
 			zap.String("server-name", s.Name()))
+		time.Sleep(200 * time.Millisecond)
 		return false
 	}
 

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -214,10 +214,7 @@ func (s *Server) primaryElectionLoop() {
 // transfer target atomically and is cleaned up once this server wins.
 func (s *Server) campaignLeader(expectedPrimary string) bool {
 	log.Info("start to campaign the primary/leader", zap.String("campaign-resource-manager-primary-name", s.participant.Name()))
-	var cmps []clientv3.Cmp
-	if cmp := utils.ExpectedPrimaryCmp(&s.participant.MsParam, expectedPrimary); cmp != nil {
-		cmps = append(cmps, *cmp)
-	}
+	cmps := []clientv3.Cmp{utils.ExpectedPrimaryCmp(&s.participant.MsParam, expectedPrimary)}
 	if err := s.participant.CampaignWithCmps(s.Context(), s.cfg.LeaderLease, cmps...); err != nil {
 		if err.Error() == errs.ErrEtcdTxnConflict.Error() {
 			log.Info("campaign resource manager primary meets error due to txn conflict, another server may campaign successfully",
@@ -245,8 +242,14 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 
 	// We have won the campaign, so the expected primary flag (if any) has served its
 	// purpose as the affinity guard. Delete it so steady state is clean and a later
-	// failure re-elects immediately instead of waiting for the flag's TTL.
-	utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary)
+	// failure re-elects immediately instead of waiting for the flag's TTL. If a newer
+	// transfer rewrote the flag to another member while we were winning, step down so
+	// the re-election routes leadership to that target.
+	if utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary, s.participant) {
+		log.Info("the expected primary has been changed to another member, stepping down",
+			zap.String("server-name", s.Name()))
+		return false
+	}
 
 	log.Info("triggering the primary callback functions")
 	for _, cb := range s.primaryCallbacks {

--- a/pkg/mcs/resourcemanager/server/server.go
+++ b/pkg/mcs/resourcemanager/server/server.go
@@ -187,7 +187,7 @@ func (s *Server) primaryElectionLoop() {
 				// that just failed).
 				log.Warn("failed to get expected primary flag, retrying the read before campaigning",
 					zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))
-				time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
+				utils.SleepUnlessDone(s.serverLoopCtx, utils.ReadFailureBackoff(readFailureStreak))
 				continue
 			}
 			// ExpectedPrimaryCmp("") still atomically requires the marker to be
@@ -210,7 +210,7 @@ func (s *Server) primaryElectionLoop() {
 				zap.String("expected-primary-id", expectedPrimary),
 				zap.Uint64("participant-id", s.participant.ID()),
 				zap.String("cur-participant-value", s.participant.ParticipantString()))
-			time.Sleep(200 * time.Millisecond)
+			utils.SleepUnlessDone(s.serverLoopCtx, 200*time.Millisecond)
 			continue
 		}
 
@@ -221,18 +221,14 @@ func (s *Server) primaryElectionLoop() {
 			// just failed - back off with growing delay so a sustained run of
 			// failures does not turn into a tight, fixed-rate retry loop against an
 			// already struggling etcd.
-			time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
+			utils.SleepUnlessDone(s.serverLoopCtx, utils.ReadFailureBackoff(readFailureStreak))
 		}
 		if won {
 			log.Warn("backing off before retrying resource manager primary campaign after callback failure",
 				zap.Duration("retry-after", primaryCallbackFailureRetryInterval))
-			timer := time.NewTimer(primaryCallbackFailureRetryInterval)
-			select {
-			case <-s.serverLoopCtx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
+			// Shutdown is caught on the next iteration's top-of-loop check
+			// (s.serverLoopCtx.Done()), so no separate early-return is needed here.
+			utils.SleepUnlessDone(s.serverLoopCtx, primaryCallbackFailureRetryInterval)
 		}
 	}
 }
@@ -287,7 +283,7 @@ func (s *Server) campaignLeader(expectedPrimary string) bool {
 		// actual target's takeover. resetLeaderOnce makes the deferred call below a
 		// no-op once this has run.
 		resetLeaderOnce.Do(resetLeader)
-		time.Sleep(200 * time.Millisecond)
+		utils.SleepUnlessDone(s.serverLoopCtx, 200*time.Millisecond)
 		return false
 	}
 

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -1646,7 +1646,7 @@ func transferPrimary(c *gin.Context) {
 		newPrimary = v
 	}
 
-	if err := mcsutils.TransferPrimary(c.Request.Context(), svr.GetClient(), svr.GetParticipant(),
+	if err := mcsutils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
 		constant.SchedulingServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -1646,7 +1646,7 @@ func transferPrimary(c *gin.Context) {
 		newPrimary = v
 	}
 
-	if err := mcsutils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
+	if err := mcsutils.TransferPrimary(c.Request.Context(), svr.GetClient(), svr.GetParticipant(),
 		constant.SchedulingServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/mcs/scheduling/server/apis/v1/api.go
+++ b/pkg/mcs/scheduling/server/apis/v1/api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
 	"github.com/unrolled/render"
+	"go.uber.org/zap"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
@@ -1648,6 +1649,8 @@ func transferPrimary(c *gin.Context) {
 
 	if err := mcsutils.TransferPrimary(svr.GetClient(), svr.GetParticipant(),
 		constant.SchedulingServiceName, svr.Name(), newPrimary, 0, nil); err != nil {
+		log.Warn("failed to transfer scheduling primary",
+			zap.String("new-primary", newPrimary), errs.ZapError(err))
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -237,6 +237,11 @@ func (s *Server) primaryElectionLoop() {
 	defer logutil.LogPanic()
 	defer s.serverLoopWg.Done()
 
+	// Tracks consecutive GetExpectedPrimaryFlag read failures across loop iterations,
+	// so a short run of failures retries the cheap read instead of immediately
+	// escalating to a full guarded campaign - see the read-failure branch below.
+	readFailureStreak := 0
+
 	for {
 		select {
 		case <-s.serverLoopCtx.Done():
@@ -258,16 +263,29 @@ func (s *Server) primaryElectionLoop() {
 
 		// To make sure the expected primary(if existed) and new primary are on the same server.
 		expectedPrimary, err := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
-		readFailed := err != nil
-		if readFailed {
+		if err != nil {
+			readFailureStreak++
+			if readFailureStreak < constant.MinConsecutiveReadFailuresForCampaign {
+				// A short run of read failures is usually a transient blip; keep
+				// retrying the cheap read instead of immediately escalating to a full
+				// guarded campaign (lease grant + txn commit, heavier than the read
+				// that just failed).
+				log.Warn("failed to get expected primary flag, retrying the read before campaigning",
+					zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))
+				time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
+				continue
+			}
 			// ExpectedPrimaryCmp("") still atomically requires the marker to be
 			// absent at commit time, so campaigning with an empty flag here cannot
 			// let this member win over a real transfer target - it can only fail
-			// closed if a marker actually exists. Skipping campaigning on every read
-			// failure would otherwise leave the service leaderless for as long as
-			// the reads keep failing, even when no transfer is in progress.
-			log.Warn("failed to get expected primary flag, campaign without affinity guard", errs.ZapError(err))
+			// closed if a marker actually exists. Skipping campaigning forever would
+			// otherwise leave the service leaderless for as long as the reads keep
+			// failing, even when no transfer is in progress.
+			log.Warn("expected primary flag read kept failing, campaign without affinity guard",
+				zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))
 			expectedPrimary = ""
+		} else {
+			readFailureStreak = 0
 		}
 		// skip campaign the primary if the expected primary is not empty and not this member.
 		// expected primary ONLY SET BY `{service}/primary/transfer` API.
@@ -282,13 +300,13 @@ func (s *Server) primaryElectionLoop() {
 		}
 
 		s.campaignPrimary(expectedPrimary)
-		if readFailed {
+		if readFailureStreak >= constant.MinConsecutiveReadFailuresForCampaign {
 			// The read failure usually means etcd itself is degraded, and
 			// campaigning (lease grant + txn commit) is heavier than the read that
-			// just failed - keep the same backoff the old skip-and-retry path used
-			// so a run of failing reads cannot turn into a tight retry loop against
-			// an already struggling etcd.
-			time.Sleep(200 * time.Millisecond)
+			// just failed - back off with growing delay so a sustained run of
+			// failures does not turn into a tight, fixed-rate retry loop against an
+			// already struggling etcd.
+			time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
 		}
 	}
 }
@@ -315,11 +333,12 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 	// Start keepalive the leadership and enable Scheduling service.
 	ctx, cancel := context.WithCancel(s.serverLoopCtx)
 	var resetPrimaryOnce sync.Once
-	defer resetPrimaryOnce.Do(func() {
+	resetPrimary := func() {
 		cancel()
 		s.participant.Resign()
 		member.ServiceMemberGauge.WithLabelValues(serviceName).Set(0)
-	})
+	}
+	defer resetPrimaryOnce.Do(resetPrimary)
 
 	// maintain the leadership, after this, Scheduling could be ready to provide service.
 	s.participant.GetLeadership().Keep(ctx)
@@ -333,6 +352,13 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 	if utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary, s.participant) {
 		log.Info("the expected primary has been changed to another member, stepping down",
 			zap.String("server-name", s.Name()))
+		// Release the leader key now, before the backoff sleep, instead of leaving it to
+		// the deferred reset above: that defer only runs once this function actually
+		// returns, so without this the keepalive goroutine started by Keep(ctx) would
+		// keep renewing the leader key for the whole sleep, needlessly delaying the
+		// actual target's takeover. resetPrimaryOnce makes the deferred call below a
+		// no-op once this has run.
+		resetPrimaryOnce.Do(resetPrimary)
 		time.Sleep(200 * time.Millisecond)
 		return
 	}

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -333,6 +333,7 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 	if utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary, s.participant) {
 		log.Info("the expected primary has been changed to another member, stepping down",
 			zap.String("server-name", s.Name()))
+		time.Sleep(200 * time.Millisecond)
 		return
 	}
 

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -287,10 +287,7 @@ func (s *Server) primaryElectionLoop() {
 // and to clean the flag up once this server wins.
 func (s *Server) campaignPrimary(expectedPrimary string) {
 	log.Info("start to campaign the primary", zap.String("campaign-scheduling-primary-name", s.participant.Name()))
-	var cmps []clientv3.Cmp
-	if cmp := utils.ExpectedPrimaryCmp(&s.participant.MsParam, expectedPrimary); cmp != nil {
-		cmps = append(cmps, *cmp)
-	}
+	cmps := []clientv3.Cmp{utils.ExpectedPrimaryCmp(&s.participant.MsParam, expectedPrimary)}
 	if err := s.participant.CampaignWithCmps(s.Context(), s.cfg.LeaderLease, cmps...); err != nil {
 		if err.Error() == errs.ErrEtcdTxnConflict.Error() {
 			log.Info("campaign scheduling primary meets error due to txn conflict, another server may campaign successfully",
@@ -318,8 +315,14 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 
 	// We have won the campaign, so the expected primary flag (if any) has served its
 	// purpose as the affinity guard. Delete it so steady state is clean and a later
-	// failure re-elects immediately instead of waiting for the flag's TTL.
-	utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary)
+	// failure re-elects immediately instead of waiting for the flag's TTL. If a newer
+	// transfer rewrote the flag to another member while we were winning, step down so
+	// the re-election routes leadership to that target.
+	if utils.DeleteExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam, expectedPrimary, s.participant) {
+		log.Info("the expected primary has been changed to another member, stepping down",
+			zap.String("server-name", s.Name()))
+		return
+	}
 
 	log.Info("triggering the primary callback functions")
 	for _, cb := range s.primaryCallbacks {

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -258,12 +258,16 @@ func (s *Server) primaryElectionLoop() {
 
 		// To make sure the expected primary(if existed) and new primary are on the same server.
 		expectedPrimary, err := utils.GetExpectedPrimaryFlag(s.GetClient(), &s.participant.MsParam)
-		if err != nil {
-			// Do not campaign on a read failure: an empty flag would be treated as
-			// "no transfer" and skip the affinity guard, so retry instead.
-			log.Warn("failed to get expected primary flag, retry later", errs.ZapError(err))
-			time.Sleep(200 * time.Millisecond)
-			continue
+		readFailed := err != nil
+		if readFailed {
+			// ExpectedPrimaryCmp("") still atomically requires the marker to be
+			// absent at commit time, so campaigning with an empty flag here cannot
+			// let this member win over a real transfer target - it can only fail
+			// closed if a marker actually exists. Skipping campaigning on every read
+			// failure would otherwise leave the service leaderless for as long as
+			// the reads keep failing, even when no transfer is in progress.
+			log.Warn("failed to get expected primary flag, campaign without affinity guard", errs.ZapError(err))
+			expectedPrimary = ""
 		}
 		// skip campaign the primary if the expected primary is not empty and not this member.
 		// expected primary ONLY SET BY `{service}/primary/transfer` API.
@@ -278,6 +282,14 @@ func (s *Server) primaryElectionLoop() {
 		}
 
 		s.campaignPrimary(expectedPrimary)
+		if readFailed {
+			// The read failure usually means etcd itself is degraded, and
+			// campaigning (lease grant + txn commit) is heavier than the read that
+			// just failed - keep the same backoff the old skip-and-retry path used
+			// so a run of failing reads cannot turn into a tight retry loop against
+			// an already struggling etcd.
+			time.Sleep(200 * time.Millisecond)
+		}
 	}
 }
 

--- a/pkg/mcs/scheduling/server/server.go
+++ b/pkg/mcs/scheduling/server/server.go
@@ -272,7 +272,7 @@ func (s *Server) primaryElectionLoop() {
 				// that just failed).
 				log.Warn("failed to get expected primary flag, retrying the read before campaigning",
 					zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))
-				time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
+				utils.SleepUnlessDone(s.serverLoopCtx, utils.ReadFailureBackoff(readFailureStreak))
 				continue
 			}
 			// ExpectedPrimaryCmp("") still atomically requires the marker to be
@@ -295,7 +295,7 @@ func (s *Server) primaryElectionLoop() {
 				zap.String("expected-primary-id", expectedPrimary),
 				zap.Uint64("participant-id", s.participant.ID()),
 				zap.String("cur-participant-value", s.participant.ParticipantString()))
-			time.Sleep(200 * time.Millisecond)
+			utils.SleepUnlessDone(s.serverLoopCtx, 200*time.Millisecond)
 			continue
 		}
 
@@ -306,7 +306,7 @@ func (s *Server) primaryElectionLoop() {
 			// just failed - back off with growing delay so a sustained run of
 			// failures does not turn into a tight, fixed-rate retry loop against an
 			// already struggling etcd.
-			time.Sleep(utils.ReadFailureBackoff(readFailureStreak))
+			utils.SleepUnlessDone(s.serverLoopCtx, utils.ReadFailureBackoff(readFailureStreak))
 		}
 	}
 }
@@ -359,7 +359,7 @@ func (s *Server) campaignPrimary(expectedPrimary string) {
 		// actual target's takeover. resetPrimaryOnce makes the deferred call below a
 		// no-op once this has run.
 		resetPrimaryOnce.Do(resetPrimary)
-		time.Sleep(200 * time.Millisecond)
+		utils.SleepUnlessDone(s.serverLoopCtx, 200*time.Millisecond)
 		return
 	}
 

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -380,7 +380,7 @@ func transferPrimary(c *gin.Context) {
 		memberMap[member.Address] = true
 	}
 
-	if err := utils.TransferPrimary(svr.GetClient(), participant,
+	if err := utils.TransferPrimary(c.Request.Context(), svr.GetClient(), participant,
 		mcs.TSOServiceName, svr.Name(), input.NewPrimary, keyspaceGroupID, memberMap); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
@@ -472,7 +472,7 @@ func evictPrimary(c *gin.Context) {
 		// primary back to it, so the eviction does not durably drain the node.
 		// Priority handling is being reworked, so revisit this when needed.
 		// An empty new primary lets TransferPrimary pick a random other member.
-		if err := utils.TransferPrimary(svr.GetClient(), participant,
+		if err := utils.TransferPrimary(c.Request.Context(), svr.GetClient(), participant,
 			mcs.TSOServiceName, svr.Name(), "", keyspaceGroupID, memberMap); err != nil {
 			log.Warn("failed to evict keyspace group primary",
 				zap.Uint32("keyspace-group-id", keyspaceGroupID), errs.ZapError(err))

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -380,7 +380,7 @@ func transferPrimary(c *gin.Context) {
 		memberMap[member.Address] = true
 	}
 
-	if err := utils.TransferPrimary(c.Request.Context(), svr.GetClient(), participant,
+	if err := utils.TransferPrimary(svr.GetClient(), participant,
 		mcs.TSOServiceName, svr.Name(), input.NewPrimary, keyspaceGroupID, memberMap); err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
@@ -472,7 +472,7 @@ func evictPrimary(c *gin.Context) {
 		// primary back to it, so the eviction does not durably drain the node.
 		// Priority handling is being reworked, so revisit this when needed.
 		// An empty new primary lets TransferPrimary pick a random other member.
-		if err := utils.TransferPrimary(c.Request.Context(), svr.GetClient(), participant,
+		if err := utils.TransferPrimary(svr.GetClient(), participant,
 			mcs.TSOServiceName, svr.Name(), "", keyspaceGroupID, memberMap); err != nil {
 			log.Warn("failed to evict keyspace group primary",
 				zap.Uint32("keyspace-group-id", keyspaceGroupID), errs.ZapError(err))

--- a/pkg/mcs/tso/server/apis/v1/api.go
+++ b/pkg/mcs/tso/server/apis/v1/api.go
@@ -382,6 +382,8 @@ func transferPrimary(c *gin.Context) {
 
 	if err := utils.TransferPrimary(svr.GetClient(), participant,
 		mcs.TSOServiceName, svr.Name(), input.NewPrimary, keyspaceGroupID, memberMap); err != nil {
+		log.Warn("failed to transfer tso primary",
+			zap.Uint32("keyspace-group-id", keyspaceGroupID), zap.String("new-primary", input.NewPrimary), errs.ZapError(err))
 		c.AbortWithStatusJSON(http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/pkg/mcs/utils/constant/constant.go
+++ b/pkg/mcs/utils/constant/constant.go
@@ -44,7 +44,15 @@ const (
 	// campaign; if the target never comes up within this window the flag expires and
 	// the cluster falls back to a free election. Tying it to the leader lease keeps the
 	// window proportional to how fast leadership turns over.
-	TransferPrimaryLeaseMultiplier = int64(3)
+	//
+	// Kept at 1 (rather than a larger margin) on purpose: this multiplier directly
+	// bounds the cluster's worst-case unavailable window after a transfer whose target
+	// never wins a single campaign (down, unreachable, or stuck) - see TransferPrimary's
+	// doc comment. A bigger multiplier buys the target more slack but linearly extends
+	// that worst case; 1 lease already matches how long the cluster tolerates a primary
+	// being unreachable everywhere else (losing its own leader lease), so there is no
+	// reason for a transfer-induced outage to be allowed to run longer than that.
+	TransferPrimaryLeaseMultiplier = int64(1)
 	// PrimaryTickInterval is the interval to check primary
 	PrimaryTickInterval = 50 * time.Millisecond
 	// LeaderTickInterval is the interval to check leader

--- a/pkg/mcs/utils/constant/constant.go
+++ b/pkg/mcs/utils/constant/constant.go
@@ -53,6 +53,23 @@ const (
 	// being unreachable everywhere else (losing its own leader lease), so there is no
 	// reason for a transfer-induced outage to be allowed to run longer than that.
 	TransferPrimaryLeaseMultiplier = int64(1)
+	// MinConsecutiveReadFailuresForCampaign is how many expected-primary-flag reads
+	// must fail in a row before an election loop falls back to campaigning without
+	// having read the marker. A short run of failures is usually a transient blip;
+	// requiring several in a row avoids escalating every glitch into a full guarded
+	// campaign (a lease grant plus a txn commit, heavier than the read that just
+	// failed) - this matters most where a node runs many independent election loops
+	// (one per TSO keyspace group, up to MaxKeyspaceGroupCountInUse of them), where
+	// escalating on every failed read can turn a real etcd degradation into a
+	// fleet-wide write storm against the same already-struggling etcd.
+	MinConsecutiveReadFailuresForCampaign = 3
+	// InitialReadFailureBackoff and MaxReadFailureBackoff bound the backoff an
+	// election loop sleeps after a run of expected-primary-flag read failures: it
+	// doubles from the initial value and caps at the max, so a sustained run of
+	// failures backs off instead of retrying at a fixed rate against an etcd that is
+	// already struggling.
+	InitialReadFailureBackoff = 200 * time.Millisecond
+	MaxReadFailureBackoff     = 6400 * time.Millisecond
 	// PrimaryTickInterval is the interval to check primary
 	PrimaryTickInterval = 50 * time.Millisecond
 	// LeaderTickInterval is the interval to check leader

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -218,6 +218,20 @@ func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) clientv3
 	return clientv3.Compare(clientv3.Value(path), "=", expectedValue)
 }
 
+// leaderKeyClearPollTimeout bounds how long verifyLeaderKeyCleared waits for the old
+// leader key to clear before concluding the revoke failed. A concurrent Resign() on
+// the same participant (e.g. TSO's primaryPriorityCheckLoop racing an HTTP transfer)
+// returns immediately without waiting, because Lease.Close is idempotent via a
+// CompareAndSwap guard - so a single check right after Resign() can see a stale "not
+// yet cleared" state from a revoke that some other, concurrent caller triggered and is
+// genuinely still in flight. This must be at least as long as that revoke's own bound
+// (pkg/election/lease.go's unexported revokeLeaseTimeout, currently 1s) so a
+// legitimately in-flight concurrent revoke has time to land.
+const (
+	leaderKeyClearPollTimeout  = 2 * time.Second
+	leaderKeyClearPollInterval = 100 * time.Millisecond
+)
+
 // verifyLeaderKeyCleared checks whether the old leader key actually cleared after
 // Resign(). Resign() revokes the leader key's lease but is best-effort and swallows
 // its own error internally (see Leadership.Reset), so this is the only way the caller
@@ -229,8 +243,10 @@ func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) clientv3
 // ExpectedPrimaryCmp guard makes any other candidate's campaign transaction fail
 // atomically alongside the very same CreateRevision(leaderKey)==0 check (see
 // ExpectedPrimaryCmp and Leadership.Campaign) - so that case is success, not failure.
-// Only a leader key present with the same CreateRevision means the revoke genuinely
-// failed and the old key is still there.
+// A leader key present with the same CreateRevision means the revoke has not
+// completed yet - either this call's own, or (per leaderKeyClearPollTimeout's doc
+// comment) a concurrent caller's still in flight - so this polls instead of failing
+// on the first observation, and only reports failure once the poll budget is spent.
 //
 // This matters because the marker's own TTL clock starts at the lease Grant, before
 // Resign() even runs, while the old leader key - if its revoke fails - only starts
@@ -239,16 +255,22 @@ func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) clientv3
 // let the marker expire before the old leader key does, silently losing the transfer's
 // affinity guarantee even though the caller already reported success.
 func verifyLeaderKeyCleared(client *clientv3.Client, leaderKeyPath string, oldRevision int64) error {
-	ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
-	resp, err := client.Get(ctx, leaderKeyPath)
-	cancel()
-	if err != nil {
-		return errors.Annotate(err, "failed to verify the old leader key cleared after resign")
+	deadline := time.Now().Add(leaderKeyClearPollTimeout)
+	for {
+		ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+		resp, err := client.Get(ctx, leaderKeyPath)
+		cancel()
+		if err != nil {
+			return errors.Annotate(err, "failed to verify the old leader key cleared after resign")
+		}
+		if len(resp.Kvs) == 0 || resp.Kvs[0].CreateRevision != oldRevision {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.New("the old leader key did not clear after resign, etcd may be degraded; please retry the transfer")
+		}
+		time.Sleep(leaderKeyClearPollInterval)
 	}
-	if len(resp.Kvs) > 0 && resp.Kvs[0].CreateRevision == oldRevision {
-		return errors.New("the old leader key did not clear after resign, etcd may be degraded; please retry the transfer")
-	}
-	return nil
 }
 
 // TransferPrimary transfers the primary of the specified service to a target member.

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -276,13 +276,14 @@ func TransferPrimary(ctx context.Context, client *clientv3.Client, p *member.Par
 		return errors.Errorf("failed to grant lease for expected primary, err: %v", err)
 	}
 
+	primaryID := primaryIDs[nextPrimaryID]
 	msParam := &keypath.MsParam{
 		ServiceName: serviceName,
 		GroupID:     keyspaceGroupID,
 	}
 	primary := &primaryData{
-		raw:    primaryIDs[nextPrimaryID],
-		output: primaryIDs[nextPrimaryID],
+		raw:    primaryID,
+		output: primaryID,
 	}
 	// Mark the expected primary first so the affinity guard is in place before the
 	// current primary releases the leader key below. leaderKeyGuard was built from the
@@ -302,75 +303,97 @@ func TransferPrimary(ctx context.Context, client *clientv3.Client, p *member.Par
 	// and re-campaigns, where the affinity guard routes the leadership to the target.
 	p.Resign()
 
-	// Verify the transfer actually landed on newPrimary before reporting success. A
+	// Verify the transfer actually landed on primaryID before reporting success. A
 	// member that predates this marker mechanism (e.g. a not-yet-upgraded replica
 	// during a rolling upgrade) does not read the marker and can win the now-vacated
 	// leader key through its own unguarded campaign, so a caller-specified target is
 	// not otherwise guaranteed. newPrimary == "" (pick any valid secondary) has no
 	// fixed target to verify against, so it is skipped.
 	//
+	// primaryID - not newPrimary - is what gets compared: newPrimary is whatever the
+	// caller passed (registry name or address; the default config gives services a
+	// name distinct from their advertise address), but primaryID is always the
+	// resolved ServiceAddr, the one identity the marker mechanism itself already
+	// relies on (Participant.IsExpectedPrimary matches a marker value against this
+	// same member's ListenUrls). Comparing against newPrimary directly would silently
+	// never match whenever it was supplied as a name, since a target's own proto Name
+	// (e.g. TSO's "address-groupID") isn't the registry name either.
+	//
 	// The timeout matches the marker's own TTL (expectedLease), not a short fixed
 	// value: such a pre-marker member never cleans the marker up on winning, so if it
 	// is itself cycled out again within this window - e.g. as the rolling upgrade
-	// continues - the still-valid marker lets newPrimary's own guarded campaign
+	// continues - the still-valid marker lets primaryID's own guarded campaign
 	// recover the transfer. Failure is only reported once that whole recovery window
 	// has actually elapsed.
 	if newPrimary != "" {
 		verifyCtx, cancel := context.WithTimeout(ctx, time.Duration(expectedLease)*time.Second)
 		defer cancel()
-		return waitForPrimaryTransfer(verifyCtx, client, leaderKeyPath, serviceName, newPrimary)
+		return waitForPrimaryTransfer(verifyCtx, client, leaderKeyPath, serviceName, newPrimary, primaryID)
 	}
 	return nil
 }
 
-// primaryTransferStableChecks is the number of consecutive polls that must observe
-// newPrimary holding the leader key before waitForPrimaryTransfer reports success.
-// A single matching read is not enough: the winner of a campaign still runs its own
-// post-campaign steps (reconciling the expected-primary marker, running
-// primaryCallbacks) before it is durably promoted, and any of those can make it step
-// back down again. Requiring the match to hold across a second poll narrows - it
-// cannot eliminate - the window where a transient, soon-to-be-reverted win would
-// otherwise be reported as a confirmed success.
-const primaryTransferStableChecks = 2
+// primaryTransferStableWindow is how long the leader key must continuously show the
+// target's identity before waitForPrimaryTransfer reports success. A single matching
+// read - or even a couple of them a few hundred milliseconds apart - is not enough:
+// the leader key is written as soon as the campaign transaction commits, well before
+// the winner is durably promoted. Between those two points it still runs its own
+// post-campaign steps - reconciling the expected-primary marker, running
+// primaryCallbacks, and for TSO initializing the allocator (which syncs the
+// timestamp oracle and does real I/O) - and a failure in any of them makes it step
+// back down again. Requiring the match to hold continuously for this long narrows -
+// it cannot eliminate - the window where a transient, soon-to-be-reverted win would
+// otherwise be reported as a confirmed success: it only helps if the failure surfaces
+// (and is reflected back to the leader key via the loser's own cleanup) within this
+// window. There's no empirical measurement behind this specific value; it's a
+// judgment call sized to comfortably outlast the post-campaign steps above under
+// normal conditions, not a proof they always finish by then.
+const primaryTransferStableWindow = 2 * time.Second
 
-// waitForPrimaryTransfer polls the leader key until its holder's identity (name or
-// listen URL) matches newPrimary on primaryTransferStableChecks consecutive polls, or
-// ctx is done. It reports success purely by identity, with no notion of which member
-// version won: the leader key's value is the same participant proto regardless of
-// which binary wrote it, so a pre-marker member's win is read exactly like any other
-// and simply fails to match unless it happens to be newPrimary itself - which is a
+// waitForPrimaryTransfer polls the leader key until its holder's identity has
+// continuously matched expectedIdentity for at least primaryTransferStableWindow, or
+// ctx is done. requestedPrimary is only used for the error messages below - it's
+// whatever identity form the caller originally supplied (registry name or address),
+// kept around purely so a failure message reads naturally to whoever issued the
+// request; expectedIdentity (see TransferPrimary) is what's actually compared.
+//
+// This reports success purely by identity, with no notion of which member version
+// won: the leader key's value is the same participant proto regardless of which
+// binary wrote it, so a pre-marker member's win is read exactly like any other and
+// simply fails to match unless it happens to be expectedIdentity itself - which is a
 // legitimate outcome, not a special case to detect.
 //
 // ctx bounds when this returns: it carries the caller's own timeout (see
 // TransferPrimary) and, when derived from an HTTP request's context, also lets an
 // abandoned request stop this from polling for the rest of that timeout regardless.
-func waitForPrimaryTransfer(ctx context.Context, client *clientv3.Client, leaderKeyPath, serviceName, newPrimary string) error {
+func waitForPrimaryTransfer(ctx context.Context, client *clientv3.Client, leaderKeyPath, serviceName, requestedPrimary, expectedIdentity string) error {
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 	var currentPrimary string
-	matchStreak := 0
+	var matchSince time.Time
 	for {
 		target := member.NewParticipantByService(serviceName)
 		if ok, _, err := etcdutil.GetProtoMsgWithModRev(client, leaderKeyPath, target); err == nil && ok {
-			if target.GetName() == newPrimary || slices.Contains(target.GetListenUrls(), newPrimary) {
-				matchStreak++
-				if matchStreak >= primaryTransferStableChecks {
+			if slices.Contains(target.GetListenUrls(), expectedIdentity) {
+				if matchSince.IsZero() {
+					matchSince = time.Now()
+				} else if time.Since(matchSince) >= primaryTransferStableWindow {
 					return nil
 				}
 			} else {
-				matchStreak = 0
+				matchSince = time.Time{}
 			}
 			currentPrimary = target.GetName()
 		} else {
-			matchStreak = 0
+			matchSince = time.Time{}
 			currentPrimary = ""
 		}
 		select {
 		case <-ctx.Done():
 			if currentPrimary == "" {
-				return errors.Errorf("transfer requested to %s, but no primary was elected: %v", newPrimary, ctx.Err())
+				return errors.Errorf("transfer requested to %s, but no primary was elected: %v", requestedPrimary, ctx.Err())
 			}
-			return errors.Errorf("transfer requested to %s, but %s is currently primary: %v", newPrimary, currentPrimary, ctx.Err())
+			return errors.Errorf("transfer requested to %s, but %s is currently primary: %v", requestedPrimary, currentPrimary, ctx.Err())
 		case <-ticker.C:
 		}
 	}

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -17,8 +17,6 @@ package utils
 import (
 	"context"
 	"math/rand/v2"
-	"slices"
-	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -183,20 +181,30 @@ func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) clientv3
 
 // TransferPrimary transfers the primary of the specified service to a target member.
 //
-// It writes the expected primary flag pointing at the target (with a TTL of a few
-// leader leases, see constant.TransferPrimaryLeaseMultiplier) and then resigns the
+// It writes the expected primary flag pointing at the target (with a TTL of
+// constant.TransferPrimaryLeaseMultiplier leader leases) and then resigns the
 // current primary by revoking its leader lease, so the re-election picks up the
-// target. The flag write
-// happens before the resignation on purpose: it guarantees the affinity guard is in
-// place before the leader key is released, so no other member can win the gap.
+// target. The flag write happens before the resignation on purpose: it guarantees
+// the affinity guard is in place before the leader key is released, so no other
+// member can win the gap.
+//
+// TransferPrimary reports success as soon as the flag is written and the current
+// primary has resigned - it does NOT wait for the target to actually win the
+// campaign or finish initializing. The worst-case unavailability this can leave
+// behind, if the target never wins a single campaign (down, unreachable, or stuck),
+// is bounded by the flag's TTL: TransferPrimaryLeaseMultiplier * leaderLease, i.e.
+// one leader lease. Once any member wins a campaign - the target or, after the TTL,
+// any other live member via free election - the flag is cleared immediately
+// (DeleteExpectedPrimaryFlag) regardless of whether that member goes on to
+// initialize successfully, so a failure after winning does not extend this window;
+// see DeleteExpectedPrimaryFlag and campaignPrimary's ordering. This is a deliberate
+// trade-off: reporting success without waiting keeps the API call itself fast and
+// independent of the caller's own timeout, at the cost of not confirming the
+// transfer actually reached the requested target before returning.
 //
 // keyspaceGroupID is optional, only used for TSO service. p must be the participant
 // of the current serving primary (the API ensures the request runs on the primary).
-// ctx bounds the post-transfer verification below (see waitForPrimaryTransfer):
-// callers driven by an HTTP request should pass the request's context so a client
-// that gives up does not leave the verification polling for the full timeout
-// regardless.
-func TransferPrimary(ctx context.Context, client *clientv3.Client, p *member.Participant, serviceName,
+func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName,
 	oldPrimary, newPrimary string, keyspaceGroupID uint32, tsoMembersMap map[string]bool) error {
 	if p == nil || !p.IsServing() {
 		return errors.New("current member is not serving as primary, please check leadership")
@@ -303,111 +311,21 @@ func TransferPrimary(ctx context.Context, client *clientv3.Client, p *member.Par
 	// and re-campaigns, where the affinity guard routes the leadership to the target.
 	p.Resign()
 
-	// Verify the transfer actually landed on primaryID before reporting success. A
-	// member that predates this marker mechanism (e.g. a not-yet-upgraded replica
-	// during a rolling upgrade) does not read the marker and can win the now-vacated
-	// leader key through its own unguarded campaign, so a caller-specified target is
-	// not otherwise guaranteed. newPrimary == "" (pick any valid secondary) has no
-	// fixed target to verify against, so it is skipped.
-	//
-	// primaryID - not newPrimary - is what gets compared: newPrimary is whatever the
-	// caller passed (registry name or address; the default config gives services a
-	// name distinct from their advertise address), but primaryID is always the
-	// resolved ServiceAddr, the one identity the marker mechanism itself already
-	// relies on (Participant.IsExpectedPrimary matches a marker value against this
-	// same member's ListenUrls). Comparing against newPrimary directly would silently
-	// never match whenever it was supplied as a name, since a target's own proto Name
-	// (e.g. TSO's "address-groupID") isn't the registry name either.
-	//
-	// The timeout matches the marker's own TTL (expectedLease), not a short fixed
-	// value: such a pre-marker member never cleans the marker up on winning, so if it
-	// is itself cycled out again within this window - e.g. as the rolling upgrade
-	// continues - the still-valid marker lets primaryID's own guarded campaign
-	// recover the transfer. Failure is only reported once that whole recovery window
-	// has actually elapsed.
-	if newPrimary != "" {
-		verifyCtx, cancel := context.WithTimeout(ctx, time.Duration(expectedLease)*time.Second)
-		defer cancel()
-		return waitForPrimaryTransfer(verifyCtx, client, leaderKeyPath, serviceName, newPrimary, primaryID)
-	}
+	// Report success here without waiting for primaryID to actually win the campaign
+	// or finish initializing. This means the worst-case unavailability window this
+	// call can leave behind - if primaryID never wins a single campaign at all (down,
+	// unreachable, or stuck) - is bounded by expectedLease, i.e. exactly one leader
+	// lease (TransferPrimaryLeaseMultiplier == 1): that is how long the marker written
+	// above stays valid and keeps every other candidate skipping campaigns in favor of
+	// primaryID (see the affinity check next to GetExpectedPrimaryFlag in each
+	// service's election loop). Once the TTL lapses the marker disappears and any live
+	// member is free to win instead, so a completely absent target costs at most one
+	// lease of downtime, never longer. A target that does win - even if it
+	// subsequently fails to initialize and steps back down - clears the marker
+	// immediately on winning (see DeleteExpectedPrimaryFlag, called before
+	// initialization in campaignPrimary), so that path recovers well before the TTL
+	// and does not compound with this bound.
 	return nil
-}
-
-// primaryTransferStableWindow is how long the leader key must continuously show the
-// target's identity before waitForPrimaryTransfer reports success. A single matching
-// read - or even a couple of them a few hundred milliseconds apart - is not enough:
-// the leader key is written as soon as the campaign transaction commits, well before
-// the winner is durably promoted. Between those two points it still runs its own
-// post-campaign steps - reconciling the expected-primary marker, running
-// primaryCallbacks, and for TSO initializing the allocator (which syncs the
-// timestamp oracle and does real I/O) - and a failure in any of them makes it step
-// back down again. Requiring the match to hold continuously for this long narrows -
-// it cannot eliminate - the window where a transient, soon-to-be-reverted win would
-// otherwise be reported as a confirmed success: it only helps if the failure surfaces
-// (and is reflected back to the leader key via the loser's own cleanup) within this
-// window. There's no empirical measurement behind this specific value; it's a
-// judgment call sized to comfortably outlast the post-campaign steps above under
-// normal conditions, not a proof they always finish by then.
-const primaryTransferStableWindow = 2 * time.Second
-
-// waitForPrimaryTransfer polls the leader key until its holder's identity has
-// continuously matched expectedIdentity, on the same election term, for at least
-// primaryTransferStableWindow, or ctx is done. requestedPrimary is only used for the
-// error messages below - it's
-// whatever identity form the caller originally supplied (registry name or address),
-// kept around purely so a failure message reads naturally to whoever issued the
-// request; expectedIdentity (see TransferPrimary) is what's actually compared.
-//
-// This reports success purely by identity, with no notion of which member version
-// won: the leader key's value is the same participant proto regardless of which
-// binary wrote it, so a pre-marker member's win is read exactly like any other and
-// simply fails to match unless it happens to be expectedIdentity itself - which is a
-// legitimate outcome, not a special case to detect.
-//
-// ctx bounds when this returns: it carries the caller's own timeout (see
-// TransferPrimary) and, when derived from an HTTP request's context, also lets an
-// abandoned request stop this from polling for the rest of that timeout regardless.
-func waitForPrimaryTransfer(ctx context.Context, client *clientv3.Client, leaderKeyPath, serviceName, requestedPrimary, expectedIdentity string) error {
-	ticker := time.NewTicker(200 * time.Millisecond)
-	defer ticker.Stop()
-	var currentPrimary string
-	var matchSince time.Time
-	// matchedRevision pins the stability window to a single election term. The
-	// leader key is deleted on every step-down/expiry and recreated on the next
-	// win (Leadership.Campaign requires CreateRevision(leaderKey) == 0), so its
-	// ModRevision changes on every fresh term. Without this, a target that loses
-	// and re-wins the key between two polls - invisible to us if both polls land
-	// on a "matched" state - would keep the timer running across that gap and
-	// could report success on a term that has barely started, still mid
-	// primaryCallbacks/TSO initialization.
-	var matchedRevision int64
-	for {
-		target := member.NewParticipantByService(serviceName)
-		if ok, modRevision, err := etcdutil.GetProtoMsgWithModRev(client, leaderKeyPath, target); err == nil && ok {
-			if slices.Contains(target.GetListenUrls(), expectedIdentity) {
-				if matchSince.IsZero() || modRevision != matchedRevision {
-					matchSince = time.Now()
-					matchedRevision = modRevision
-				} else if time.Since(matchSince) >= primaryTransferStableWindow {
-					return nil
-				}
-			} else {
-				matchSince = time.Time{}
-			}
-			currentPrimary = target.GetName()
-		} else {
-			matchSince = time.Time{}
-			currentPrimary = ""
-		}
-		select {
-		case <-ctx.Done():
-			if currentPrimary == "" {
-				return errors.Errorf("transfer requested to %s, but no primary was elected: %v", requestedPrimary, ctx.Err())
-			}
-			return errors.Errorf("transfer requested to %s, but %s is currently primary: %v", requestedPrimary, currentPrimary, ctx.Err())
-		case <-ticker.C:
-		}
-	}
 }
 
 // revokeExpectedPrimaryLease revokes a lease granted for an expected-primary

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -95,14 +95,26 @@ func markExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, 
 //     caller must step down so the re-election routes leadership to that target.
 func DeleteExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, expectedValue string, p *member.Participant) (superseded bool) {
 	path := keypath.ExpectedPrimaryPath(msParam)
-	current, deleted := deleteMarkerIfEquals(client, path, expectedValue)
+	current, deleted, err := deleteMarkerIfEquals(client, path, expectedValue)
 	if deleted {
 		log.Info("delete expected primary flag", zap.String("primary-path", path))
 		return false
 	}
+	if err != nil {
+		// The reconciliation transaction itself failed (a real RPC/etcd error, not a
+		// value mismatch), so it is unknown whether a newer transfer rewrote the
+		// marker while this member was winning. A serving primary never watches the
+		// marker again (see the doc comment above), so silently assuming "no rewrite"
+		// here could strand that newer transfer forever. Fail closed instead: step
+		// down so the caller re-enters the election loop and this gets re-checked
+		// fresh on the next campaign attempt - a spurious step-down on a transient
+		// blip is far cheaper than a transfer that silently never takes effect.
+		log.Warn("failed to reconcile expected primary flag, stepping down to be safe",
+			zap.String("primary-path", path), errs.ZapError(err))
+		return true
+	}
 	if current == "" {
-		// The marker is already gone (deleted, expired, or it never existed), or the
-		// transaction failed; in the latter case the marker TTL bounds the staleness.
+		// The marker is confirmed absent: deleted, expired, or it never existed.
 		return false
 	}
 	// The marker was rewritten by a newer transfer while this member was winning.
@@ -110,7 +122,7 @@ func DeleteExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam
 		// The newer transfer also targets this member, which is already serving.
 		// Clean the marker up so it does not linger until its TTL. Best effort:
 		// on failure the TTL applies.
-		if _, deleted := deleteMarkerIfEquals(client, path, current); deleted {
+		if _, deleted, _ := deleteMarkerIfEquals(client, path, current); deleted {
 			log.Info("delete expected primary flag rewritten by a newer transfer to this member",
 				zap.String("primary-path", path))
 		}
@@ -124,10 +136,13 @@ func DeleteExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam
 
 // deleteMarkerIfEquals atomically deletes the expected primary marker and revokes
 // its lease when its value equals want. It returns the marker value observed by the
-// transaction ("" when the marker does not exist or the transaction failed) and
-// whether the marker was deleted. Note that etcd value comparisons always fail on a
-// missing key, so want == "" never deletes anything and reports the current value.
-func deleteMarkerIfEquals(client *clientv3.Client, path, want string) (current string, deleted bool) {
+// transaction ("" when the marker does not exist), whether the marker was deleted,
+// and a non-nil err when the transaction itself failed (as opposed to succeeding
+// with a value mismatch) - callers must not conflate the two: an err means the
+// marker's actual state is unknown, not that it is absent. Note that etcd value
+// comparisons always fail on a missing key, so want == "" never deletes anything
+// and reports the current value.
+func deleteMarkerIfEquals(client *clientv3.Client, path, want string) (current string, deleted bool, err error) {
 	resp, err := kv.NewSlowLogTxn(client).
 		If(clientv3.Compare(clientv3.Value(path), "=", want)).
 		Then(clientv3.OpGet(path), clientv3.OpDelete(path)).
@@ -135,14 +150,14 @@ func deleteMarkerIfEquals(client *clientv3.Client, path, want string) (current s
 		Commit()
 	if err != nil {
 		log.Warn("failed to delete expected primary flag", zap.String("primary-path", path), errs.ZapError(err))
-		return "", false
+		return "", false, err
 	}
 	kvs := resp.Responses[0].GetResponseRange().GetKvs()
 	if !resp.Succeeded {
 		if len(kvs) == 0 {
-			return "", false
+			return "", false, nil
 		}
-		return string(kvs[0].Value), false
+		return string(kvs[0].Value), false, nil
 	}
 	// Deleted. Revoke the lease the marker was bound to, so the "key deleted but
 	// lease persists" state can never exist (#10875).
@@ -158,7 +173,7 @@ func deleteMarkerIfEquals(client *clientv3.Client, path, want string) (current s
 				zap.String("primary-path", path), zap.Int64("lease-id", int64(leaseID)), errs.ZapError(err))
 		}
 	}
-	return want, true
+	return want, true, nil
 }
 
 // ExpectedPrimaryCmp returns an etcd comparison that guards a primary campaign
@@ -220,7 +235,9 @@ func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName
 	// ties the write to the exact leadership session IsServing() just checked for the
 	// whole duration of this function, not just its tail end.
 	leaderKeyPath := p.GetLeadership().GetLeaderKey()
-	leaderResp, err := client.Get(client.Ctx(), leaderKeyPath)
+	getCtx, getCancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+	leaderResp, err := client.Get(getCtx, leaderKeyPath)
+	getCancel()
 	if err != nil {
 		return errors.Annotate(err, "failed to read leader key for transfer guard")
 	}

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -17,6 +17,8 @@ package utils
 import (
 	"context"
 	"math/rand/v2"
+	"slices"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -190,7 +192,11 @@ func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) clientv3
 //
 // keyspaceGroupID is optional, only used for TSO service. p must be the participant
 // of the current serving primary (the API ensures the request runs on the primary).
-func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName,
+// ctx bounds the post-transfer verification below (see waitForPrimaryTransfer):
+// callers driven by an HTTP request should pass the request's context so a client
+// that gives up does not leave the verification polling for the full timeout
+// regardless.
+func TransferPrimary(ctx context.Context, client *clientv3.Client, p *member.Participant, serviceName,
 	oldPrimary, newPrimary string, keyspaceGroupID uint32, tsoMembersMap map[string]bool) error {
 	if p == nil || !p.IsServing() {
 		return errors.New("current member is not serving as primary, please check leadership")
@@ -295,7 +301,79 @@ func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName
 	// IsServing() flip to false immediately, so the primary election loop steps down
 	// and re-campaigns, where the affinity guard routes the leadership to the target.
 	p.Resign()
+
+	// Verify the transfer actually landed on newPrimary before reporting success. A
+	// member that predates this marker mechanism (e.g. a not-yet-upgraded replica
+	// during a rolling upgrade) does not read the marker and can win the now-vacated
+	// leader key through its own unguarded campaign, so a caller-specified target is
+	// not otherwise guaranteed. newPrimary == "" (pick any valid secondary) has no
+	// fixed target to verify against, so it is skipped.
+	//
+	// The timeout matches the marker's own TTL (expectedLease), not a short fixed
+	// value: such a pre-marker member never cleans the marker up on winning, so if it
+	// is itself cycled out again within this window - e.g. as the rolling upgrade
+	// continues - the still-valid marker lets newPrimary's own guarded campaign
+	// recover the transfer. Failure is only reported once that whole recovery window
+	// has actually elapsed.
+	if newPrimary != "" {
+		verifyCtx, cancel := context.WithTimeout(ctx, time.Duration(expectedLease)*time.Second)
+		defer cancel()
+		return waitForPrimaryTransfer(verifyCtx, client, leaderKeyPath, serviceName, newPrimary)
+	}
 	return nil
+}
+
+// primaryTransferStableChecks is the number of consecutive polls that must observe
+// newPrimary holding the leader key before waitForPrimaryTransfer reports success.
+// A single matching read is not enough: the winner of a campaign still runs its own
+// post-campaign steps (reconciling the expected-primary marker, running
+// primaryCallbacks) before it is durably promoted, and any of those can make it step
+// back down again. Requiring the match to hold across a second poll narrows - it
+// cannot eliminate - the window where a transient, soon-to-be-reverted win would
+// otherwise be reported as a confirmed success.
+const primaryTransferStableChecks = 2
+
+// waitForPrimaryTransfer polls the leader key until its holder's identity (name or
+// listen URL) matches newPrimary on primaryTransferStableChecks consecutive polls, or
+// ctx is done. It reports success purely by identity, with no notion of which member
+// version won: the leader key's value is the same participant proto regardless of
+// which binary wrote it, so a pre-marker member's win is read exactly like any other
+// and simply fails to match unless it happens to be newPrimary itself - which is a
+// legitimate outcome, not a special case to detect.
+//
+// ctx bounds when this returns: it carries the caller's own timeout (see
+// TransferPrimary) and, when derived from an HTTP request's context, also lets an
+// abandoned request stop this from polling for the rest of that timeout regardless.
+func waitForPrimaryTransfer(ctx context.Context, client *clientv3.Client, leaderKeyPath, serviceName, newPrimary string) error {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	var currentPrimary string
+	matchStreak := 0
+	for {
+		target := member.NewParticipantByService(serviceName)
+		if ok, _, err := etcdutil.GetProtoMsgWithModRev(client, leaderKeyPath, target); err == nil && ok {
+			if target.GetName() == newPrimary || slices.Contains(target.GetListenUrls(), newPrimary) {
+				matchStreak++
+				if matchStreak >= primaryTransferStableChecks {
+					return nil
+				}
+			} else {
+				matchStreak = 0
+			}
+			currentPrimary = target.GetName()
+		} else {
+			matchStreak = 0
+			currentPrimary = ""
+		}
+		select {
+		case <-ctx.Done():
+			if currentPrimary == "" {
+				return errors.Errorf("transfer requested to %s, but no primary was elected: %v", newPrimary, ctx.Err())
+			}
+			return errors.Errorf("transfer requested to %s, but %s is currently primary: %v", newPrimary, currentPrimary, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 // revokeExpectedPrimaryLease revokes a lease granted for an expected-primary

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -351,8 +351,9 @@ func TransferPrimary(ctx context.Context, client *clientv3.Client, p *member.Par
 const primaryTransferStableWindow = 2 * time.Second
 
 // waitForPrimaryTransfer polls the leader key until its holder's identity has
-// continuously matched expectedIdentity for at least primaryTransferStableWindow, or
-// ctx is done. requestedPrimary is only used for the error messages below - it's
+// continuously matched expectedIdentity, on the same election term, for at least
+// primaryTransferStableWindow, or ctx is done. requestedPrimary is only used for the
+// error messages below - it's
 // whatever identity form the caller originally supplied (registry name or address),
 // kept around purely so a failure message reads naturally to whoever issued the
 // request; expectedIdentity (see TransferPrimary) is what's actually compared.
@@ -371,12 +372,22 @@ func waitForPrimaryTransfer(ctx context.Context, client *clientv3.Client, leader
 	defer ticker.Stop()
 	var currentPrimary string
 	var matchSince time.Time
+	// matchedRevision pins the stability window to a single election term. The
+	// leader key is deleted on every step-down/expiry and recreated on the next
+	// win (Leadership.Campaign requires CreateRevision(leaderKey) == 0), so its
+	// ModRevision changes on every fresh term. Without this, a target that loses
+	// and re-wins the key between two polls - invisible to us if both polls land
+	// on a "matched" state - would keep the timer running across that gap and
+	// could report success on a term that has barely started, still mid
+	// primaryCallbacks/TSO initialization.
+	var matchedRevision int64
 	for {
 		target := member.NewParticipantByService(serviceName)
-		if ok, _, err := etcdutil.GetProtoMsgWithModRev(client, leaderKeyPath, target); err == nil && ok {
+		if ok, modRevision, err := etcdutil.GetProtoMsgWithModRev(client, leaderKeyPath, target); err == nil && ok {
 			if slices.Contains(target.GetListenUrls(), expectedIdentity) {
-				if matchSince.IsZero() {
+				if matchSince.IsZero() || modRevision != matchedRevision {
 					matchSince = time.Now()
+					matchedRevision = modRevision
 				} else if time.Since(matchSince) >= primaryTransferStableWindow {
 					return nil
 				}

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"context"
 	"math/rand/v2"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -47,6 +48,29 @@ func GetExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam) (
 	}
 
 	return string(primary), nil
+}
+
+// ReadFailureBackoff returns how long an election loop should sleep after the nth
+// (1-indexed) consecutive GetExpectedPrimaryFlag read failure. It doubles from
+// constant.InitialReadFailureBackoff and caps at constant.MaxReadFailureBackoff, so a
+// sustained run of failures backs off instead of retrying at a fixed rate against an
+// etcd that is already struggling. consecutiveFailures <= 1 returns the initial value.
+func ReadFailureBackoff(consecutiveFailures int) time.Duration {
+	shift := consecutiveFailures - 1
+	if shift < 0 {
+		shift = 0
+	}
+	// Cap the shift itself (not just the result) so the left shift below never
+	// overflows for a pathologically large streak.
+	const maxShift = 5 // constant.InitialReadFailureBackoff << 5 == constant.MaxReadFailureBackoff
+	if shift > maxShift {
+		shift = maxShift
+	}
+	backoff := constant.InitialReadFailureBackoff << shift
+	if backoff > constant.MaxReadFailureBackoff {
+		return constant.MaxReadFailureBackoff
+	}
+	return backoff
 }
 
 // primaryData is used to store the primary data.
@@ -194,6 +218,39 @@ func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) clientv3
 	return clientv3.Compare(clientv3.Value(path), "=", expectedValue)
 }
 
+// verifyLeaderKeyCleared checks whether the old leader key actually cleared after
+// Resign(). Resign() revokes the leader key's lease but is best-effort and swallows
+// its own error internally (see Leadership.Reset), so this is the only way the caller
+// can tell whether that revoke actually happened.
+//
+// The check compares CreateRevision, not mere presence: a leader key present with a
+// CreateRevision different from oldRevision means a fresh campaign already won it -
+// which can only be the transfer target, since the still-valid marker's
+// ExpectedPrimaryCmp guard makes any other candidate's campaign transaction fail
+// atomically alongside the very same CreateRevision(leaderKey)==0 check (see
+// ExpectedPrimaryCmp and Leadership.Campaign) - so that case is success, not failure.
+// Only a leader key present with the same CreateRevision means the revoke genuinely
+// failed and the old key is still there.
+//
+// This matters because the marker's own TTL clock starts at the lease Grant, before
+// Resign() even runs, while the old leader key - if its revoke fails - only starts
+// decaying towards its own natural expiry once Resign() cancels its keepalive; that
+// decay can take up to a full leader lease. A slow or failed revoke could therefore
+// let the marker expire before the old leader key does, silently losing the transfer's
+// affinity guarantee even though the caller already reported success.
+func verifyLeaderKeyCleared(client *clientv3.Client, leaderKeyPath string, oldRevision int64) error {
+	ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+	resp, err := client.Get(ctx, leaderKeyPath)
+	cancel()
+	if err != nil {
+		return errors.Annotate(err, "failed to verify the old leader key cleared after resign")
+	}
+	if len(resp.Kvs) > 0 && resp.Kvs[0].CreateRevision == oldRevision {
+		return errors.New("the old leader key did not clear after resign, etcd may be degraded; please retry the transfer")
+	}
+	return nil
+}
+
 // TransferPrimary transfers the primary of the specified service to a target member.
 //
 // It writes the expected primary flag pointing at the target (with a TTL of
@@ -296,7 +353,15 @@ func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName
 		leaderLease = constant.DefaultLease
 	}
 	expectedLease := constant.TransferPrimaryLeaseMultiplier * leaderLease
-	grantResp, err := client.Grant(client.Ctx(), expectedLease)
+	// Bound the grant: client.Ctx() is the shared etcd client's lifetime context, with
+	// no deadline of its own and not tied to this call. A hung Grant on an unbounded
+	// context would block for the client's whole lifetime instead of just failing this
+	// transfer - and since some callers (e.g. TSO's primaryPriorityCheckLoop) invoke
+	// TransferPrimary synchronously and are themselves waited on during shutdown, that
+	// hang can prevent the server from ever closing its etcd client.
+	grantCtx, grantCancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+	grantResp, err := client.Grant(grantCtx, expectedLease)
+	grantCancel()
 	if err != nil {
 		return errors.Errorf("failed to grant lease for expected primary, err: %v", err)
 	}
@@ -327,6 +392,13 @@ func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName
 	// IsServing() flip to false immediately, so the primary election loop steps down
 	// and re-campaigns, where the affinity guard routes the leadership to the target.
 	p.Resign()
+
+	// Confirm the resign actually cleared the old leader key rather than trusting it
+	// silently - see verifyLeaderKeyCleared's doc comment for why this check exists and
+	// what it distinguishes.
+	if err := verifyLeaderKeyCleared(client, leaderKeyPath, leaderResp.Kvs[0].CreateRevision); err != nil {
+		return err
+	}
 
 	// Report success here without waiting for primaryID to actually win the campaign
 	// or finish initializing. This means the worst-case unavailability window this

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -56,12 +56,19 @@ type primaryData struct {
 	output string
 }
 
-// markExpectedPrimaryFlag marks the expected primary flag when the primary is specified.
-func markExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, primary *primaryData, leaseID clientv3.LeaseID) error {
+// markExpectedPrimaryFlag marks the expected primary flag when the primary is
+// specified. Extra cmps are folded into the same transaction as the Put, so a
+// leader-key ownership guard built by the caller makes the marker write atomic
+// with still holding leadership: if the caller lost leadership between its own
+// IsServing() check and this call, the guard no longer holds and the Put is
+// rejected instead of silently publishing a marker that the new, already-serving
+// primary will never look at.
+func markExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, primary *primaryData, leaseID clientv3.LeaseID, cmps ...clientv3.Cmp) error {
 	path := keypath.ExpectedPrimaryPath(msParam)
 	log.Info("set expected primary flag", zap.String("primary-path", path), zap.String("primary", primary.output))
 	// write a flag to indicate the expected primary.
 	resp, err := kv.NewSlowLogTxn(client).
+		If(cmps...).
 		Then(clientv3.OpPut(path, primary.raw, clientv3.WithLease(leaseID))).
 		Commit()
 	if err != nil {
@@ -75,71 +82,101 @@ func markExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, 
 	return nil
 }
 
-// DeleteExpectedPrimaryFlag deletes the expected primary flag once the target has
-// won the campaign, so that in steady state the flag is absent and a subsequent
-// failure of the new primary triggers a free re-election immediately instead of
-// waiting for the flag's TTL to expire.
-//
-// The delete is conditional on the flag still holding `expectedValue` (the value
-// the winner campaigned with). This prevents clobbering a newer transfer that may
-// have already rewritten the flag to a different target while this primary was
-// winning. It is best-effort: the flag's TTL is the backstop, so a failure here is
-// only logged and never blocks serving.
-//
-// The flag is bound to an etcd lease, so after deleting the key we also revoke that
-// lease. Otherwise we would leave the key gone but the lease alive — exactly the
-// inconsistent state that issue #10875 is about — and leak a lease until its TTL
-// expires.
-func DeleteExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, expectedValue string) {
-	if expectedValue == "" {
-		// Normal election without a transfer in progress, nothing to clean up.
-		return
-	}
+// DeleteExpectedPrimaryFlag reconciles the expected primary flag after this member
+// has won the campaign. In the common case the flag still holds expectedValue (or
+// is already gone) and is deleted together with its lease, so steady state has no
+// marker and later failures re-elect immediately instead of waiting for the marker
+// TTL. The flag can also have been rewritten by a newer transfer while this member
+// was winning; since a serving primary no longer watches the marker, that transfer
+// would otherwise return success without ever taking effect. In that case:
+//   - if the newer marker still targets this member, it is deleted as well and the
+//     member keeps serving;
+//   - if it targets another member, DeleteExpectedPrimaryFlag returns true and the
+//     caller must step down so the re-election routes leadership to that target.
+func DeleteExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam, expectedValue string, p *member.Participant) (superseded bool) {
 	path := keypath.ExpectedPrimaryPath(msParam)
-	// Read the key (to capture its lease) and delete it in the same conditional txn.
+	current, deleted := deleteMarkerIfEquals(client, path, expectedValue)
+	if deleted {
+		log.Info("delete expected primary flag", zap.String("primary-path", path))
+		return false
+	}
+	if current == "" {
+		// The marker is already gone (deleted, expired, or it never existed), or the
+		// transaction failed; in the latter case the marker TTL bounds the staleness.
+		return false
+	}
+	// The marker was rewritten by a newer transfer while this member was winning.
+	if p != nil && p.IsExpectedPrimary(current) {
+		// The newer transfer also targets this member, which is already serving.
+		// Clean the marker up so it does not linger until its TTL. Best effort:
+		// on failure the TTL applies.
+		if _, deleted := deleteMarkerIfEquals(client, path, current); deleted {
+			log.Info("delete expected primary flag rewritten by a newer transfer to this member",
+				zap.String("primary-path", path))
+		}
+		return false
+	}
+	log.Info("expected primary flag was rewritten by a newer transfer while campaigning, step down",
+		zap.String("primary-path", path), zap.String("expected-value", expectedValue),
+		zap.String("current-value", current))
+	return true
+}
+
+// deleteMarkerIfEquals atomically deletes the expected primary marker and revokes
+// its lease when its value equals want. It returns the marker value observed by the
+// transaction ("" when the marker does not exist or the transaction failed) and
+// whether the marker was deleted. Note that etcd value comparisons always fail on a
+// missing key, so want == "" never deletes anything and reports the current value.
+func deleteMarkerIfEquals(client *clientv3.Client, path, want string) (current string, deleted bool) {
 	resp, err := kv.NewSlowLogTxn(client).
-		If(clientv3.Compare(clientv3.Value(path), "=", expectedValue)).
+		If(clientv3.Compare(clientv3.Value(path), "=", want)).
 		Then(clientv3.OpGet(path), clientv3.OpDelete(path)).
+		Else(clientv3.OpGet(path)).
 		Commit()
 	if err != nil {
 		log.Warn("failed to delete expected primary flag", zap.String("primary-path", path), errs.ZapError(err))
-		return
+		return "", false
 	}
-	if !resp.Succeeded {
-		log.Info("skip deleting expected primary flag, it has been changed or already gone",
-			zap.String("primary-path", path), zap.String("expected-value", expectedValue))
-		return
-	}
-	log.Info("delete expected primary flag", zap.String("primary-path", path))
-	// Revoke the lease the flag was bound to, if any, so no lease is leaked.
 	kvs := resp.Responses[0].GetResponseRange().GetKvs()
-	if len(kvs) == 0 || kvs[0].Lease == 0 {
-		return
+	if !resp.Succeeded {
+		if len(kvs) == 0 {
+			return "", false
+		}
+		return string(kvs[0].Value), false
 	}
-	leaseID := clientv3.LeaseID(kvs[0].Lease)
-	// Bound the revoke: this runs on the campaign path before the primary is promoted
-	// to serving, and the cleanup is best-effort, so a hung RPC must not block serving.
-	ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
-	defer cancel()
-	if _, err := client.Revoke(ctx, leaseID); err != nil {
-		log.Warn("failed to revoke expected primary flag lease",
-			zap.String("primary-path", path), zap.Int64("lease-id", int64(leaseID)), errs.ZapError(err))
+	// Deleted. Revoke the lease the marker was bound to, so the "key deleted but
+	// lease persists" state can never exist (#10875).
+	if len(kvs) > 0 && kvs[0].Lease != 0 {
+		leaseID := clientv3.LeaseID(kvs[0].Lease)
+		// Bound the revoke: this runs on the campaign path before the primary is
+		// promoted to serving, and the cleanup is best-effort, so a hung RPC must not
+		// block serving.
+		ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+		defer cancel()
+		if _, err := client.Revoke(ctx, leaseID); err != nil {
+			log.Warn("failed to revoke expected primary flag lease",
+				zap.String("primary-path", path), zap.Int64("lease-id", int64(leaseID)), errs.ZapError(err))
+		}
 	}
+	return want, true
 }
 
-// ExpectedPrimaryCmp returns an etcd comparison asserting the expected primary flag
-// still equals `expectedValue`. The caller appends it to the campaign transaction so
-// that winning the leader key and "I am still the expected primary" become atomic:
-// if a concurrent transfer rewrote the flag after it was read, the campaign txn
-// fails and this member does not become primary. It returns nil when expectedValue
-// is empty (normal election, no transfer in progress), in which case the campaign
-// must not be constrained.
-func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) *clientv3.Cmp {
+// ExpectedPrimaryCmp returns an etcd comparison that guards a primary campaign
+// against a concurrent transfer.
+//   - When expectedValue is non-empty, a transfer installed a marker naming this
+//     member as the target; the comparison asserts the marker still holds that
+//     value.
+//   - When expectedValue is empty, the campaigner observed no transfer in
+//     progress; the comparison asserts the marker is still absent. Without this
+//     a campaigner that paused after the read could resume after a transfer
+//     installed a target marker and released the leader key, then win the
+//     campaign and bypass the transfer affinity guard.
+func ExpectedPrimaryCmp(msParam *keypath.MsParam, expectedValue string) clientv3.Cmp {
+	path := keypath.ExpectedPrimaryPath(msParam)
 	if expectedValue == "" {
-		return nil
+		return clientv3.Compare(clientv3.CreateRevision(path), "=", 0)
 	}
-	cmp := clientv3.Compare(clientv3.Value(keypath.ExpectedPrimaryPath(msParam)), "=", expectedValue)
-	return &cmp
+	return clientv3.Compare(clientv3.Value(path), "=", expectedValue)
 }
 
 // TransferPrimary transfers the primary of the specified service to a target member.
@@ -158,6 +195,26 @@ func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName
 	if p == nil || !p.IsServing() {
 		return errors.New("current member is not serving as primary, please check leadership")
 	}
+
+	// Capture the leader key's CreateRevision right after the IsServing() check, before
+	// discovery or the lease grant below - both are network round trips during which p
+	// could lose its lease and win a fresh campaign with the same MemberValue() (which
+	// never changes for the lifetime of the participant). CreateRevision changes on
+	// every fresh campaign (Leadership.Campaign requires CreateRevision(leaderKey) == 0
+	// to win), so fencing the eventual marker write on the revision observed here - not
+	// on a value comparison, and not on a revision re-read later, closer to the write -
+	// ties the write to the exact leadership session IsServing() just checked for the
+	// whole duration of this function, not just its tail end.
+	leaderKeyPath := p.GetLeadership().GetLeaderKey()
+	leaderResp, err := client.Get(client.Ctx(), leaderKeyPath)
+	if err != nil {
+		return errors.Annotate(err, "failed to read leader key for transfer guard")
+	}
+	if len(leaderResp.Kvs) == 0 || string(leaderResp.Kvs[0].Value) != p.MemberValue() {
+		return errors.New("current member is not serving as primary, please check leadership")
+	}
+	leaderKeyGuard := clientv3.Compare(clientv3.CreateRevision(leaderKeyPath), "=", leaderResp.Kvs[0].CreateRevision)
+
 	log.Info("try to transfer primary", zap.String("service", serviceName), zap.String("from", oldPrimary), zap.String("to", newPrimary))
 	entries, err := discovery.GetMSMembers(serviceName, client)
 	if err != nil {
@@ -222,8 +279,15 @@ func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName
 		output: primaryIDs[nextPrimaryID],
 	}
 	// Mark the expected primary first so the affinity guard is in place before the
-	// current primary releases the leader key below.
-	if err = markExpectedPrimaryFlag(client, msParam, primary, grantResp.ID); err != nil {
+	// current primary releases the leader key below. leaderKeyGuard was built from the
+	// CreateRevision captured right after the IsServing() check above, before discovery
+	// and this lease grant, so it fences the write to that exact leadership session for
+	// the whole function, not just the gap between here and the commit. It is evaluated
+	// atomically with the Put inside the same etcd transaction, so anything that
+	// changed the leader key since - a fresh campaign included, even by this same
+	// participant with the same MemberValue() - is caught at commit time.
+	if err = markExpectedPrimaryFlag(client, msParam, primary, grantResp.ID, leaderKeyGuard); err != nil {
+		revokeExpectedPrimaryLease(client, grantResp.ID)
 		return errors.Errorf("failed to mark expected primary flag for %s, err: %v", serviceName, err)
 	}
 
@@ -232,6 +296,20 @@ func TransferPrimary(client *clientv3.Client, p *member.Participant, serviceName
 	// and re-campaigns, where the affinity guard routes the leadership to the target.
 	p.Resign()
 	return nil
+}
+
+// revokeExpectedPrimaryLease revokes a lease granted for an expected-primary
+// marker whose write failed or was rejected by the leadership guard, so a
+// failed/aborted transfer never leaks a lease. Best effort: a failure here is
+// logged, not propagated - the caller already has the original error to report,
+// and the lease's own TTL bounds the residual leak if revoke also fails.
+func revokeExpectedPrimaryLease(client *clientv3.Client, leaseID clientv3.LeaseID) {
+	ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+	defer cancel()
+	if _, err := client.Revoke(ctx, leaseID); err != nil {
+		log.Warn("failed to revoke expected primary lease after failed marker write",
+			zap.Int64("lease-id", int64(leaseID)), errs.ZapError(err))
+	}
 }
 
 func isSamePrimary(member discovery.ServiceRegistryEntry, primary string) bool {

--- a/pkg/mcs/utils/expected_primary.go
+++ b/pkg/mcs/utils/expected_primary.go
@@ -50,6 +50,21 @@ func GetExpectedPrimaryFlag(client *clientv3.Client, msParam *keypath.MsParam) (
 	return string(primary), nil
 }
 
+// SleepUnlessDone sleeps for d, returning early if ctx is canceled first, so a bounded
+// backoff can never delay the caller's own shutdown. Callers in an election loop must
+// pass the loop's own long-lived context (e.g. serverLoopCtx), not a per-campaign
+// context that a normal step-down (losing leadership, not shutting down) may already
+// have canceled - passing the wrong one would collapse an intended backoff into an
+// immediate return on every ordinary step-down.
+func SleepUnlessDone(ctx context.Context, d time.Duration) {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+}
+
 // ReadFailureBackoff returns how long an election loop should sleep after the nth
 // (1-indexed) consecutive GetExpectedPrimaryFlag read failure. It doubles from
 // constant.InitialReadFailureBackoff and caps at constant.MaxReadFailureBackoff, so a
@@ -254,10 +269,25 @@ const (
 // decay can take up to a full leader lease. A slow or failed revoke could therefore
 // let the marker expire before the old leader key does, silently losing the transfer's
 // affinity guarantee even though the caller already reported success.
+//
+// Each Get is bounded by whatever remains of leaderKeyClearPollTimeout, not the full
+// etcdutil.DefaultRequestTimeout: without that, a single slow-but-not-failed Get could
+// itself outlast the poll budget, so its response - even a stale, correctly-linearized
+// one from before a concurrent revoke landed - would arrive after the deadline and get
+// reported as a failure without this ever making a fresh observation, silently
+// reintroducing the false failure this polling exists to avoid.
 func verifyLeaderKeyCleared(client *clientv3.Client, leaderKeyPath string, oldRevision int64) error {
 	deadline := time.Now().Add(leaderKeyClearPollTimeout)
 	for {
-		ctx, cancel := context.WithTimeout(client.Ctx(), etcdutil.DefaultRequestTimeout)
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return errors.New("the old leader key did not clear after resign, etcd may be degraded; please retry the transfer")
+		}
+		reqTimeout := remaining
+		if reqTimeout > etcdutil.DefaultRequestTimeout {
+			reqTimeout = etcdutil.DefaultRequestTimeout
+		}
+		ctx, cancel := context.WithTimeout(client.Ctx(), reqTimeout)
 		resp, err := client.Get(ctx, leaderKeyPath)
 		cancel()
 		if err != nil {
@@ -265,9 +295,6 @@ func verifyLeaderKeyCleared(client *clientv3.Client, leaderKeyPath string, oldRe
 		}
 		if len(resp.Kvs) == 0 || resp.Kvs[0].CreateRevision != oldRevision {
 			return nil
-		}
-		if time.Now().After(deadline) {
-			return errors.New("the old leader key did not clear after resign, etcd may be degraded; please retry the transfer")
 		}
 		time.Sleep(leaderKeyClearPollInterval)
 	}

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -19,10 +19,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/goleak"
+
+	"github.com/pingcap/kvproto/pkg/schedulingpb"
 
 	"github.com/tikv/pd/pkg/mcs/discovery"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
+	"github.com/tikv/pd/pkg/member"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
 	"github.com/tikv/pd/pkg/utils/testutil"
@@ -61,7 +65,7 @@ func TestDeleteExpectedPrimaryFlagRevokesLease(t *testing.T) {
 	re.Equal(int64(leaseID), getResp.Kvs[0].Lease)
 
 	// The newly elected primary cleans up the flag once it wins.
-	DeleteExpectedPrimaryFlag(client, msParam, value)
+	re.False(DeleteExpectedPrimaryFlag(client, msParam, value, nil))
 
 	// The key is gone...
 	getResp, err = client.Get(ctx, path)
@@ -76,8 +80,9 @@ func TestDeleteExpectedPrimaryFlagRevokesLease(t *testing.T) {
 
 // TestDeleteExpectedPrimaryFlagSkipsOnValueMismatch ensures the conditional delete
 // does not clobber a newer transfer. If a second transfer has already rewritten the
-// flag (with its own lease) while this primary was winning, the stale winner must
-// leave both the key and the newer lease intact.
+// flag (with its own lease) to another member while this primary was winning, the
+// stale winner must leave both the key and the newer lease intact and report that
+// it has been superseded, so it steps down instead of defeating that transfer.
 func TestDeleteExpectedPrimaryFlagSkipsOnValueMismatch(t *testing.T) {
 	re := require.New(t)
 	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
@@ -93,8 +98,9 @@ func TestDeleteExpectedPrimaryFlagSkipsOnValueMismatch(t *testing.T) {
 	leaseID := grantResp.ID
 	re.NoError(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: "newer", output: "newer"}, leaseID))
 
-	// A primary that campaigned for the older value tries to clean up; it must not.
-	DeleteExpectedPrimaryFlag(client, msParam, "older")
+	// A primary that campaigned for the older value tries to clean up; it must not
+	// delete the newer marker, and it must learn that it has been superseded.
+	re.True(DeleteExpectedPrimaryFlag(client, msParam, "older", nil))
 
 	getResp, err := client.Get(ctx, path)
 	re.NoError(err)
@@ -103,6 +109,250 @@ func TestDeleteExpectedPrimaryFlagSkipsOnValueMismatch(t *testing.T) {
 	ttlResp, err := client.TimeToLive(ctx, leaseID)
 	re.NoError(err)
 	re.Positive(ttlResp.TTL)
+}
+
+// TestDeleteExpectedPrimaryFlagReconciliation covers the post-campaign reconcile
+// paths of DeleteExpectedPrimaryFlag beyond the plain delete/mismatch cases:
+//   - a winner of a free election (no marker observed) keeps serving when the
+//     marker is still absent, but steps down when a newer transfer installed a
+//     marker naming another member while it was winning;
+//   - when the newer marker targets the winner itself, the winner keeps serving
+//     and the marker is cleaned up together with its lease.
+func TestDeleteExpectedPrimaryFlagReconciliation(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx := context.Background()
+	msParam := &keypath.MsParam{ServiceName: constant.SchedulingServiceName}
+	path := keypath.ExpectedPrimaryPath(msParam)
+	const selfURL = "http://127.0.0.1:2379"
+
+	self := member.NewParticipant(client, *msParam)
+	self.InitInfo(&schedulingpb.Participant{
+		Name:       "self",
+		Id:         1,
+		ListenUrls: []string{selfURL},
+	}, "primary election")
+
+	// Free election, no marker: nothing to reconcile, keep serving.
+	re.False(DeleteExpectedPrimaryFlag(client, msParam, "", self))
+
+	// A transfer installs a marker naming another member after the free election
+	// was won: the winner must step down, leaving the marker and its lease intact.
+	grantResp, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
+	re.NoError(err)
+	re.NoError(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: "http://other:2379", output: "other"}, grantResp.ID))
+	re.True(DeleteExpectedPrimaryFlag(client, msParam, "", self))
+	getResp, err := client.Get(ctx, path)
+	re.NoError(err)
+	re.Len(getResp.Kvs, 1)
+
+	// The marker is rewritten to target the winner itself: keep serving, and the
+	// marker plus its lease are cleaned up.
+	grantResp2, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
+	re.NoError(err)
+	re.NoError(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: selfURL, output: "self"}, grantResp2.ID))
+	re.False(DeleteExpectedPrimaryFlag(client, msParam, "", self))
+	getResp, err = client.Get(ctx, path)
+	re.NoError(err)
+	re.Empty(getResp.Kvs)
+	ttlResp, err := client.TimeToLive(ctx, grantResp2.ID)
+	re.NoError(err)
+	re.Equal(int64(-1), ttlResp.TTL)
+}
+
+// TestExpectedPrimaryCmp verifies the campaign guard returned by ExpectedPrimaryCmp.
+// The empty-value case must assert the marker is still absent: this closes the race
+// where a campaigner that observed no transfer resumes after a transfer installed a
+// target marker and released the leader key, and would otherwise win the campaign
+// while bypassing the transfer affinity guard.
+func TestExpectedPrimaryCmp(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx := context.Background()
+	msParam := &keypath.MsParam{ServiceName: constant.SchedulingServiceName}
+	path := keypath.ExpectedPrimaryPath(msParam)
+
+	// runGuarded runs a txn gated only by the campaign guard and reports whether it
+	// committed, mirroring how CampaignWithCmps folds the guard into the campaign txn.
+	runGuarded := func(expectedValue string) bool {
+		resp, err := client.Txn(ctx).
+			If(ExpectedPrimaryCmp(msParam, expectedValue)).
+			Then(clientv3.OpGet(path)).
+			Commit()
+		re.NoError(err)
+		return resp.Succeeded
+	}
+
+	// No transfer in progress: the empty-value guard (marker still absent) holds.
+	re.True(runGuarded(""))
+
+	// A transfer installs a marker naming "target".
+	grantResp, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
+	re.NoError(err)
+	re.NoError(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: "target", output: "target"}, grantResp.ID))
+
+	// The empty-value guard must now fail: a campaigner that observed "no transfer"
+	// can no longer win once a marker exists.
+	re.False(runGuarded(""))
+	// The transfer target's own guard (value match) still holds, so it can campaign.
+	re.True(runGuarded("target"))
+	// A stale or non-target value does not match the installed marker.
+	re.False(runGuarded("other"))
+}
+
+// TestMarkExpectedPrimaryFlagGuardsAgainstLeadershipChange reconstructs the race
+// flagged in review: TransferPrimary checks IsServing() before doing discovery and
+// lease-grant work, but only writes the expected-primary marker afterwards. If this
+// instance loses leadership in that window - because it resigned, its lease
+// expired, or anything else vacated the leader key - a rival can win a fresh
+// campaign and start serving before the stale caller's marker write lands. That
+// marker write must not silently succeed once a different primary is already
+// serving: the guarded Put must be rejected by the same leader-key comparison
+// election.Leadership uses to guard its own writes, and the marker must never
+// appear in etcd.
+func TestMarkExpectedPrimaryFlagGuardsAgainstLeadershipChange(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx := context.Background()
+	msParam := &keypath.MsParam{ServiceName: constant.SchedulingServiceName}
+	path := keypath.ExpectedPrimaryPath(msParam)
+	const selfURL = "http://127.0.0.1:2379"
+	const rivalURL = "http://127.0.0.1:2380"
+
+	self := member.NewParticipant(client, *msParam)
+	self.InitInfo(&schedulingpb.Participant{
+		Name:       "self",
+		Id:         1,
+		ListenUrls: []string{selfURL},
+	}, "primary election")
+
+	// self wins the campaign and starts serving, exactly like the real election
+	// loop: CampaignWithCmps writes the leader key, then PromoteSelf marks it locally.
+	re.NoError(self.CampaignWithCmps(ctx, constant.DefaultLease))
+	self.PromoteSelf()
+	re.True(self.IsServing())
+
+	// Snapshot the guard TransferPrimary would build right after its IsServing()
+	// check, while self still legitimately owns the leader key.
+	guard := clientv3.Compare(clientv3.Value(self.GetLeadership().GetLeaderKey()), "=", self.MemberValue())
+
+	// self loses leadership in the window between the check and the marker write
+	// (resign releases the leader key and revokes its lease)...
+	self.Resign()
+
+	// ...and a rival wins a fresh campaign on the same election, becoming the new
+	// primary that will never look at a marker addressed by the stale request below.
+	rival := member.NewParticipant(client, *msParam)
+	rival.InitInfo(&schedulingpb.Participant{
+		Name:       "rival",
+		Id:         2,
+		ListenUrls: []string{rivalURL},
+	}, "primary election")
+	re.NoError(rival.CampaignWithCmps(ctx, constant.DefaultLease))
+	rival.PromoteSelf()
+	re.True(rival.IsServing())
+
+	// The stale request proceeds as TransferPrimary does after its initial check:
+	// grant a lease and attempt the guarded marker write with the snapshotted guard.
+	grantResp, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
+	re.NoError(err)
+	err = markExpectedPrimaryFlag(client, msParam, &primaryData{raw: "http://third:2379", output: "third"}, grantResp.ID, guard)
+	re.Error(err)
+
+	// The marker must never have been published: the new primary is already serving
+	// and would never react to it.
+	getResp, err := client.Get(ctx, path)
+	re.NoError(err)
+	re.Empty(getResp.Kvs)
+
+	// Mirror TransferPrimary's own cleanup on this failure path so the granted lease
+	// doesn't leak past the test.
+	_, err = client.Revoke(ctx, grantResp.ID)
+	re.NoError(err)
+}
+
+// TestMarkExpectedPrimaryFlagGuardFencesElectionTerm covers the gap flagged in
+// review on top of TestMarkExpectedPrimaryFlagGuardsAgainstLeadershipChange:
+// Participant.MemberValue() is fixed for the participant's lifetime, so a guard
+// built from Value(leaderKey) == MemberValue() cannot tell "the same leadership
+// term IsServing() observed" apart from "this member lost its lease and won a
+// fresh campaign with the same MemberValue()" while a transfer request was stalled
+// in discovery or the lease grant. TransferPrimary guards on the leader key's
+// CreateRevision instead, which changes on every fresh campaign (Campaign requires
+// CreateRevision(leaderKey) == 0 to win), so it fences to the exact etcd write
+// backing the observed term. This test reconstructs that race directly against
+// markExpectedPrimaryFlag: the same participant loses and regains leadership
+// (same MemberValue, new term), and a guard captured before the regain must be
+// rejected, while a guard captured after it must succeed.
+func TestMarkExpectedPrimaryFlagGuardFencesElectionTerm(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx := context.Background()
+	msParam := &keypath.MsParam{ServiceName: constant.SchedulingServiceName}
+	path := keypath.ExpectedPrimaryPath(msParam)
+	const selfURL = "http://127.0.0.1:2379"
+
+	self := member.NewParticipant(client, *msParam)
+	self.InitInfo(&schedulingpb.Participant{
+		Name:       "self",
+		Id:         1,
+		ListenUrls: []string{selfURL},
+	}, "primary election")
+	leaderKeyPath := self.GetLeadership().GetLeaderKey()
+
+	// self wins the first term and starts serving.
+	re.NoError(self.CampaignWithCmps(ctx, constant.DefaultLease))
+	self.PromoteSelf()
+	re.True(self.IsServing())
+
+	// Snapshot the guard the way TransferPrimary does: read the leader key live and
+	// fence on its CreateRevision, right after the IsServing() check would have run.
+	staleResp, err := client.Get(ctx, leaderKeyPath)
+	re.NoError(err)
+	re.Len(staleResp.Kvs, 1)
+	re.Equal(self.MemberValue(), string(staleResp.Kvs[0].Value))
+	staleGuard := clientv3.Compare(clientv3.CreateRevision(leaderKeyPath), "=", staleResp.Kvs[0].CreateRevision)
+
+	// self loses leadership (lease expiry, an unrelated resign, etc.) and then wins a
+	// fresh campaign - a new term, same MemberValue since it never changes after
+	// InitInfo. This is exactly the window a value-only guard cannot see through.
+	self.Resign()
+	re.NoError(self.CampaignWithCmps(ctx, constant.DefaultLease))
+	self.PromoteSelf()
+	re.True(self.IsServing())
+
+	freshResp, err := client.Get(ctx, leaderKeyPath)
+	re.NoError(err)
+	re.Len(freshResp.Kvs, 1)
+	re.Equal(self.MemberValue(), string(freshResp.Kvs[0].Value))
+	re.NotEqual(staleResp.Kvs[0].CreateRevision, freshResp.Kvs[0].CreateRevision, "re-campaigning must produce a new CreateRevision")
+
+	// The stale, pre-regain guard must be rejected even though the value matches.
+	grantResp, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
+	re.NoError(err)
+	re.Error(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: "http://third:2379", output: "third"}, grantResp.ID, staleGuard))
+	getResp, err := client.Get(ctx, path)
+	re.NoError(err)
+	re.Empty(getResp.Kvs)
+	_, err = client.Revoke(ctx, grantResp.ID)
+	re.NoError(err)
+
+	// A guard captured after the regain, against the current term, succeeds.
+	freshGuard := clientv3.Compare(clientv3.CreateRevision(leaderKeyPath), "=", freshResp.Kvs[0].CreateRevision)
+	grantResp2, err := client.Grant(ctx, constant.TransferPrimaryLeaseMultiplier*constant.DefaultLease)
+	re.NoError(err)
+	re.NoError(markExpectedPrimaryFlag(client, msParam, &primaryData{raw: "http://third:2379", output: "third"}, grantResp2.ID, freshGuard))
+	getResp, err = client.Get(ctx, path)
+	re.NoError(err)
+	re.Len(getResp.Kvs, 1)
 }
 
 // TestIsSamePrimary covers the matching used by TransferPrimary to skip a

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -380,7 +381,8 @@ func TestVerifyLeaderKeyClearedDistinguishesFailureFromSupersede(t *testing.T) {
 	re.Len(oldResp.Kvs, 1)
 	oldRevision := oldResp.Kvs[0].CreateRevision
 
-	// The revoke failed and the old key is untouched: must be reported as a failure.
+	// The revoke failed and the old key stays untouched for the whole poll budget:
+	// must be reported as a failure. This case pays the full leaderKeyClearPollTimeout.
 	re.Error(verifyLeaderKeyCleared(client, leaderKeyPath, oldRevision))
 
 	// The revoke succeeded and the key is now gone: success.
@@ -398,6 +400,38 @@ func TestVerifyLeaderKeyClearedDistinguishesFailureFromSupersede(t *testing.T) {
 	newResp, err := client.Get(ctx, leaderKeyPath)
 	re.NoError(err)
 	re.NotEqual(oldRevision, newResp.Kvs[0].CreateRevision)
+	re.NoError(verifyLeaderKeyCleared(client, leaderKeyPath, oldRevision))
+}
+
+// TestVerifyLeaderKeyClearedPollsForConcurrentRevoke reconstructs the race flagged in
+// review: Lease.Close is idempotent (a CompareAndSwap guard), so a second, concurrent
+// Resign() on the same participant (e.g. TSO's primaryPriorityCheckLoop racing an HTTP
+// transfer) returns immediately without waiting for whichever caller's revoke is
+// actually in flight. A single check right after Resign() would see the old leader key
+// still present with the same CreateRevision and wrongly report a failure even though
+// that concurrent revoke is genuinely about to succeed. verifyLeaderKeyCleared must
+// poll long enough to observe the delayed clear instead of failing on the first look.
+func TestVerifyLeaderKeyClearedPollsForConcurrentRevoke(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx := context.Background()
+	const leaderKeyPath = "/pd/test-transfer-primary/leader"
+
+	_, err := client.Put(ctx, leaderKeyPath, "old-primary")
+	re.NoError(err)
+	oldResp, err := client.Get(ctx, leaderKeyPath)
+	re.NoError(err)
+	oldRevision := oldResp.Kvs[0].CreateRevision
+
+	// Simulate a concurrent caller's in-flight revoke landing partway through the poll
+	// window, well within leaderKeyClearPollTimeout.
+	go func() {
+		time.Sleep(leaderKeyClearPollInterval * 3)
+		_, _ = client.Delete(ctx, leaderKeyPath)
+	}()
+
 	re.NoError(verifyLeaderKeyCleared(client, leaderKeyPath, oldRevision))
 }
 

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -355,9 +355,72 @@ func TestMarkExpectedPrimaryFlagGuardFencesElectionTerm(t *testing.T) {
 	re.Len(getResp.Kvs, 1)
 }
 
+// TestVerifyLeaderKeyClearedDistinguishesFailureFromSupersede exercises the decision
+// table verifyLeaderKeyCleared uses after Resign(): the old leader key genuinely gone
+// (revoke succeeded), the old leader key rewritten with a fresh CreateRevision (a
+// competing campaign already won it), and the old leader key unchanged (the revoke
+// failed and the old key is still there).
+func TestVerifyLeaderKeyClearedDistinguishesFailureFromSupersede(t *testing.T) {
+	re := require.New(t)
+	_, client, clean := etcdutil.NewTestEtcdCluster(t, 1, nil)
+	defer clean()
+
+	ctx := context.Background()
+	const leaderKeyPath = "/pd/test-transfer-primary/leader"
+
+	// No key at all (never existed) must never be mistaken for a failure to clear.
+	re.NoError(verifyLeaderKeyCleared(client, leaderKeyPath, 0))
+
+	// Install the "old" leader key and capture its CreateRevision, mirroring the
+	// revision TransferPrimary captures before Resign().
+	_, err := client.Put(ctx, leaderKeyPath, "old-primary")
+	re.NoError(err)
+	oldResp, err := client.Get(ctx, leaderKeyPath)
+	re.NoError(err)
+	re.Len(oldResp.Kvs, 1)
+	oldRevision := oldResp.Kvs[0].CreateRevision
+
+	// The revoke failed and the old key is untouched: must be reported as a failure.
+	re.Error(verifyLeaderKeyCleared(client, leaderKeyPath, oldRevision))
+
+	// The revoke succeeded and the key is now gone: success.
+	_, err = client.Delete(ctx, leaderKeyPath)
+	re.NoError(err)
+	re.NoError(verifyLeaderKeyCleared(client, leaderKeyPath, oldRevision))
+
+	// A fresh campaign already won and rewrote the key (necessarily the transfer
+	// target, since the still-valid marker guard blocks any other candidate's
+	// campaign transaction atomically alongside this same CreateRevision check - see
+	// ExpectedPrimaryCmp) - a different CreateRevision must be treated as success, not
+	// a failure to clear.
+	_, err = client.Put(ctx, leaderKeyPath, "new-primary")
+	re.NoError(err)
+	newResp, err := client.Get(ctx, leaderKeyPath)
+	re.NoError(err)
+	re.NotEqual(oldRevision, newResp.Kvs[0].CreateRevision)
+	re.NoError(verifyLeaderKeyCleared(client, leaderKeyPath, oldRevision))
+}
+
 // TestIsSamePrimary covers the matching used by TransferPrimary to skip a
 // self-transfer (#10970): a member matches by either its name or its service
 // address, and an empty target never matches.
+func TestReadFailureBackoff(t *testing.T) {
+	re := require.New(t)
+	// Non-positive streaks are treated like the first failure.
+	re.Equal(constant.InitialReadFailureBackoff, ReadFailureBackoff(0))
+	re.Equal(constant.InitialReadFailureBackoff, ReadFailureBackoff(-1))
+	re.Equal(constant.InitialReadFailureBackoff, ReadFailureBackoff(1))
+	// Doubles with each additional consecutive failure.
+	re.Equal(2*constant.InitialReadFailureBackoff, ReadFailureBackoff(2))
+	re.Equal(4*constant.InitialReadFailureBackoff, ReadFailureBackoff(3))
+	re.Equal(8*constant.InitialReadFailureBackoff, ReadFailureBackoff(4))
+	// Caps at the max instead of continuing to grow or overflowing, including for a
+	// pathologically large streak.
+	re.Equal(constant.MaxReadFailureBackoff, ReadFailureBackoff(6))
+	re.Equal(constant.MaxReadFailureBackoff, ReadFailureBackoff(7))
+	re.Equal(constant.MaxReadFailureBackoff, ReadFailureBackoff(1<<30))
+}
+
 func TestIsSamePrimary(t *testing.T) {
 	re := require.New(t)
 	entry := discovery.ServiceRegistryEntry{Name: "tso-1", ServiceAddr: "http://127.0.0.1:2379"}

--- a/pkg/mcs/utils/expected_primary_test.go
+++ b/pkg/mcs/utils/expected_primary_test.go
@@ -435,9 +435,26 @@ func TestVerifyLeaderKeyClearedPollsForConcurrentRevoke(t *testing.T) {
 	re.NoError(verifyLeaderKeyCleared(client, leaderKeyPath, oldRevision))
 }
 
-// TestIsSamePrimary covers the matching used by TransferPrimary to skip a
-// self-transfer (#10970): a member matches by either its name or its service
-// address, and an empty target never matches.
+// TestSleepUnlessDone verifies the two ways SleepUnlessDone can return: the full
+// duration when ctx is never canceled, and early - well before the duration elapses -
+// once ctx is canceled. Election loops rely on the early-return path to keep a bounded
+// backoff from delaying their own shutdown.
+func TestSleepUnlessDone(t *testing.T) {
+	re := require.New(t)
+
+	start := time.Now()
+	SleepUnlessDone(context.Background(), 20*time.Millisecond)
+	re.GreaterOrEqual(time.Since(start), 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start = time.Now()
+	SleepUnlessDone(ctx, time.Minute)
+	re.Less(time.Since(start), time.Second, "an already-canceled ctx must return immediately, not wait out the full duration")
+}
+
+// TestReadFailureBackoff covers the backoff election loops use after a run of
+// consecutive expected-primary-flag read failures.
 func TestReadFailureBackoff(t *testing.T) {
 	re := require.New(t)
 	// Non-positive streaks are treated like the first failure.
@@ -455,6 +472,9 @@ func TestReadFailureBackoff(t *testing.T) {
 	re.Equal(constant.MaxReadFailureBackoff, ReadFailureBackoff(1<<30))
 }
 
+// TestIsSamePrimary covers the matching used by TransferPrimary to skip a
+// self-transfer (#10970): a member matches by either its name or its service
+// address, and an empty target never matches.
 func TestIsSamePrimary(t *testing.T) {
 	re := require.New(t)
 	entry := discovery.ServiceRegistryEntry{Name: "tso-1", ServiceAddr: "http://127.0.0.1:2379"}

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -327,6 +327,7 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 	// the re-election routes leadership to that target.
 	if mcsutils.DeleteExpectedPrimaryFlag(a.member.Client(), msParam, expectedPrimary, m) {
 		log.Info("the expected primary has been changed to another member, stepping down", a.logFields...)
+		time.Sleep(200 * time.Millisecond)
 		return
 	}
 

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -279,10 +279,7 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 		GroupID:     a.keyspaceGroupID,
 	}
 	m := a.member.(*member.Participant)
-	var cmps []clientv3.Cmp
-	if cmp := mcsutils.ExpectedPrimaryCmp(msParam, expectedPrimary); cmp != nil {
-		cmps = append(cmps, *cmp)
-	}
+	cmps := []clientv3.Cmp{mcsutils.ExpectedPrimaryCmp(msParam, expectedPrimary)}
 	if err := m.CampaignWithCmps(a.ctx, lease, cmps...); err != nil {
 		if errors.Is(err, errs.ErrEtcdTxnConflict) {
 			log.Info("campaign tso primary meets error due to txn conflict, another tso server may campaign successfully",
@@ -313,8 +310,13 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 
 	// We have won the campaign, so the expected primary flag (if any) has served its
 	// purpose as the affinity guard. Delete it so steady state is clean and a later
-	// failure re-elects immediately instead of waiting for the flag's TTL.
-	mcsutils.DeleteExpectedPrimaryFlag(a.member.Client(), msParam, expectedPrimary)
+	// failure re-elects immediately instead of waiting for the flag's TTL. If a newer
+	// transfer rewrote the flag to another member while we were winning, step down so
+	// the re-election routes leadership to that target.
+	if mcsutils.DeleteExpectedPrimaryFlag(a.member.Client(), msParam, expectedPrimary, m) {
+		log.Info("the expected primary has been changed to another member, stepping down", a.logFields...)
+		return
+	}
 
 	log.Info("initializing the tso allocator")
 	if err := a.Initialize(); err != nil {

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -220,6 +220,15 @@ func (a *Allocator) primaryElectionLoop() {
 	defer logutil.LogPanic()
 	defer a.wg.Done()
 
+	// Tracks consecutive GetExpectedPrimaryFlag read failures across loop iterations,
+	// so a short run of failures retries the cheap read instead of immediately
+	// escalating to a full guarded campaign - see the read-failure branch below. This
+	// matters most here: a node runs one of these loops per TSO keyspace group (up to
+	// constant.MaxKeyspaceGroupCountInUse of them), so escalating on every failed read
+	// can turn a real etcd degradation into a fleet-wide write storm against the same
+	// already-struggling etcd.
+	readFailureStreak := 0
+
 	for {
 		select {
 		case <-a.ctx.Done():
@@ -246,16 +255,29 @@ func (a *Allocator) primaryElectionLoop() {
 			ServiceName: constant.TSOServiceName,
 			GroupID:     a.keyspaceGroupID,
 		})
-		readFailed := err != nil
-		if readFailed {
+		if err != nil {
+			readFailureStreak++
+			if readFailureStreak < constant.MinConsecutiveReadFailuresForCampaign {
+				// A short run of read failures is usually a transient blip; keep
+				// retrying the cheap read instead of immediately escalating to a full
+				// guarded campaign (lease grant + txn commit, heavier than the read
+				// that just failed).
+				log.Warn("failed to get expected primary flag, retrying the read before campaigning",
+					append(a.logFields, zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))...)
+				time.Sleep(mcsutils.ReadFailureBackoff(readFailureStreak))
+				continue
+			}
 			// ExpectedPrimaryCmp("") still atomically requires the marker to be
 			// absent at commit time, so campaigning with an empty flag here cannot
 			// let this member win over a real transfer target - it can only fail
-			// closed if a marker actually exists. Skipping campaigning on every read
-			// failure would otherwise leave the service leaderless for as long as
-			// the reads keep failing, even when no transfer is in progress.
-			log.Warn("failed to get expected primary flag, campaign without affinity guard", append(a.logFields, errs.ZapError(err))...)
+			// closed if a marker actually exists. Skipping campaigning forever would
+			// otherwise leave the service leaderless for as long as the reads keep
+			// failing, even when no transfer is in progress.
+			log.Warn("expected primary flag read kept failing, campaign without affinity guard",
+				append(a.logFields, zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))...)
 			expectedPrimary = ""
+		} else {
+			readFailureStreak = 0
 		}
 		// skip campaign the primary if the expected primary is not empty and not this member.
 		// expected primary ONLY SET BY `{service}/primary/transfer` API.
@@ -268,13 +290,13 @@ func (a *Allocator) primaryElectionLoop() {
 		}
 
 		a.campaignPrimary(expectedPrimary)
-		if readFailed {
+		if readFailureStreak >= constant.MinConsecutiveReadFailuresForCampaign {
 			// The read failure usually means etcd itself is degraded, and
 			// campaigning (lease grant + txn commit) is heavier than the read that
-			// just failed - keep the same backoff the old skip-and-retry path used
-			// so a run of failing reads cannot turn into a tight retry loop against
-			// an already struggling etcd.
-			time.Sleep(200 * time.Millisecond)
+			// just failed - back off with growing delay so a sustained run of
+			// failures does not turn into a tight, fixed-rate retry loop against an
+			// already struggling etcd.
+			time.Sleep(mcsutils.ReadFailureBackoff(readFailureStreak))
 		}
 	}
 }
@@ -311,10 +333,11 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 	//   2. load region could be slow. Based on lease we can recover TSO service faster.
 	ctx, cancel := context.WithCancel(a.ctx)
 	var resetPrimaryOnce sync.Once
-	defer resetPrimaryOnce.Do(func() {
+	resetPrimary := func() {
 		cancel()
 		a.member.Resign()
-	})
+	}
+	defer resetPrimaryOnce.Do(resetPrimary)
 
 	// maintain the leadership, after this, TSO can be service.
 	a.member.GetLeadership().Keep(ctx)
@@ -327,6 +350,14 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 	// the re-election routes leadership to that target.
 	if mcsutils.DeleteExpectedPrimaryFlag(a.member.Client(), msParam, expectedPrimary, m) {
 		log.Info("the expected primary has been changed to another member, stepping down", a.logFields...)
+		// Release the leader key now, before the backoff sleep, instead of leaving it to
+		// the deferred reset above: that defer only runs once this function actually
+		// returns, so without this the keepalive goroutine started by Keep(ctx) would
+		// keep renewing the leader key for the whole sleep, needlessly delaying the
+		// actual target's takeover. resetPrimaryOnce makes the deferred call below (and
+		// the later one guarding PromoteSelf, which this return never reaches) a no-op
+		// once this has run.
+		resetPrimaryOnce.Do(resetPrimary)
 		time.Sleep(200 * time.Millisecond)
 		return
 	}

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -246,12 +246,16 @@ func (a *Allocator) primaryElectionLoop() {
 			ServiceName: constant.TSOServiceName,
 			GroupID:     a.keyspaceGroupID,
 		})
-		if err != nil {
-			// Do not campaign on a read failure: an empty flag would be treated as
-			// "no transfer" and skip the affinity guard, so retry instead.
-			log.Warn("failed to get expected primary flag, retry later", append(a.logFields, errs.ZapError(err))...)
-			time.Sleep(200 * time.Millisecond)
-			continue
+		readFailed := err != nil
+		if readFailed {
+			// ExpectedPrimaryCmp("") still atomically requires the marker to be
+			// absent at commit time, so campaigning with an empty flag here cannot
+			// let this member win over a real transfer target - it can only fail
+			// closed if a marker actually exists. Skipping campaigning on every read
+			// failure would otherwise leave the service leaderless for as long as
+			// the reads keep failing, even when no transfer is in progress.
+			log.Warn("failed to get expected primary flag, campaign without affinity guard", append(a.logFields, errs.ZapError(err))...)
+			expectedPrimary = ""
 		}
 		// skip campaign the primary if the expected primary is not empty and not this member.
 		// expected primary ONLY SET BY `{service}/primary/transfer` API.
@@ -264,6 +268,14 @@ func (a *Allocator) primaryElectionLoop() {
 		}
 
 		a.campaignPrimary(expectedPrimary)
+		if readFailed {
+			// The read failure usually means etcd itself is degraded, and
+			// campaigning (lease grant + txn commit) is heavier than the read that
+			// just failed - keep the same backoff the old skip-and-retry path used
+			// so a run of failing reads cannot turn into a tight retry loop against
+			// an already struggling etcd.
+			time.Sleep(200 * time.Millisecond)
+		}
 	}
 }
 

--- a/pkg/tso/allocator.go
+++ b/pkg/tso/allocator.go
@@ -264,7 +264,7 @@ func (a *Allocator) primaryElectionLoop() {
 				// that just failed).
 				log.Warn("failed to get expected primary flag, retrying the read before campaigning",
 					append(a.logFields, zap.Int("consecutive-failures", readFailureStreak), errs.ZapError(err))...)
-				time.Sleep(mcsutils.ReadFailureBackoff(readFailureStreak))
+				mcsutils.SleepUnlessDone(a.ctx, mcsutils.ReadFailureBackoff(readFailureStreak))
 				continue
 			}
 			// ExpectedPrimaryCmp("") still atomically requires the marker to be
@@ -285,7 +285,7 @@ func (a *Allocator) primaryElectionLoop() {
 			log.Info("skip campaigning of tso primary and check later", append(a.logFields,
 				zap.String("expected-primary-id", expectedPrimary),
 				zap.String("cur-member-value", m.ParticipantString()))...)
-			time.Sleep(200 * time.Millisecond)
+			mcsutils.SleepUnlessDone(a.ctx, 200*time.Millisecond)
 			continue
 		}
 
@@ -296,7 +296,7 @@ func (a *Allocator) primaryElectionLoop() {
 			// just failed - back off with growing delay so a sustained run of
 			// failures does not turn into a tight, fixed-rate retry loop against an
 			// already struggling etcd.
-			time.Sleep(mcsutils.ReadFailureBackoff(readFailureStreak))
+			mcsutils.SleepUnlessDone(a.ctx, mcsutils.ReadFailureBackoff(readFailureStreak))
 		}
 	}
 }
@@ -358,7 +358,7 @@ func (a *Allocator) campaignPrimary(expectedPrimary string) {
 		// the later one guarding PromoteSelf, which this return never reaches) a no-op
 		// once this has run.
 		resetPrimaryOnce.Do(resetPrimary)
-		time.Sleep(200 * time.Millisecond)
+		mcsutils.SleepUnlessDone(a.ctx, 200*time.Millisecond)
 		return
 	}
 

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -688,7 +688,7 @@ func (kgm *KeyspaceGroupManager) primaryPriorityCheckLoop() {
 								zap.Uint32("keyspace-group-id", kg.ID))
 							continue
 						}
-						if err := utils.TransferPrimary(ctx, kgm.etcdClient, participant,
+						if err := utils.TransferPrimary(kgm.etcdClient, participant,
 							mcs.TSOServiceName, kgm.GetServiceConfig().GetName(), "", kg.ID, memberMap); err != nil {
 							log.Error("failed to transfer primary", zap.Error(err))
 							continue

--- a/pkg/tso/keyspace_group_manager.go
+++ b/pkg/tso/keyspace_group_manager.go
@@ -688,7 +688,7 @@ func (kgm *KeyspaceGroupManager) primaryPriorityCheckLoop() {
 								zap.Uint32("keyspace-group-id", kg.ID))
 							continue
 						}
-						if err := utils.TransferPrimary(kgm.etcdClient, participant,
+						if err := utils.TransferPrimary(ctx, kgm.etcdClient, participant,
 							mcs.TSOServiceName, kgm.GetServiceConfig().GetName(), "", kg.ID, memberMap); err != nil {
 							log.Error("failed to transfer primary", zap.Error(err))
 							continue

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -632,7 +632,11 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpired() {
 		resp, err := tests.TestDialClient.Post(fmt.Sprintf("%s/%s/api/v1/primary/transfer", primary, strings.ReplaceAll(service, "_", "-")),
 			"application/json", bytes.NewBuffer(data))
 		re.NoError(err)
-		re.Equal(http.StatusOK, resp.StatusCode)
+		// skipGrantLeader is still enabled for the whole duration of this call, so
+		// newPrimary cannot win and TransferPrimary's post-transfer verification times
+		// out - this call reports failure here, even though the cluster does recover
+		// once skipGrantLeader is disabled below.
+		re.Equal(http.StatusInternalServerError, resp.StatusCode)
 		resp.Body.Close()
 
 		// Wait for the old primary exit and new primary campaign
@@ -693,7 +697,14 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 		resp, err := tests.TestDialClient.Post(fmt.Sprintf("%s/%s/api/v1/primary/transfer", primary, strings.ReplaceAll(service, "_", "-")),
 			"application/json", bytes.NewBuffer(data))
 		re.NoError(err)
-		re.Equal(http.StatusOK, resp.StatusCode)
+		// skipGrantLeader keeps newPrimary from ever winning for as long as this call
+		// runs, so TransferPrimary's post-transfer verification (which polls for
+		// newPrimary to actually take over, bounded by the expected-primary marker's
+		// own TTL) can never observe it and must time out. This call therefore reports
+		// failure here - it genuinely could not confirm the transfer took effect - even
+		// though the marker itself is still written and the cluster does recover once
+		// the old primary steps down below; that recovery is verified separately.
+		re.Equal(http.StatusInternalServerError, resp.StatusCode)
 		resp.Body.Close()
 
 		// Wait for the old primary exit and new primary campaign
@@ -962,7 +973,11 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDownW
 		fmt.Sprintf("%s/tso/api/v1/primary/transfer", groupPrimary),
 		"application/json", bytes.NewBuffer(data))
 	re.NoError(err)
-	re.Equal(http.StatusOK, resp.StatusCode)
+	// target can never win while skipGrantLeader is enabled, so TransferPrimary's
+	// post-transfer verification times out and this call reports failure - it
+	// genuinely could not confirm the transfer took effect. The group does still
+	// recover afterwards, verified separately below.
+	re.Equal(http.StatusInternalServerError, resp.StatusCode)
 	resp.Body.Close()
 
 	// Wait until the old group primary steps down (group temporarily has no primary).

--- a/tests/integrations/mcs/members/member_test.go
+++ b/tests/integrations/mcs/members/member_test.go
@@ -632,11 +632,12 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpired() {
 		resp, err := tests.TestDialClient.Post(fmt.Sprintf("%s/%s/api/v1/primary/transfer", primary, strings.ReplaceAll(service, "_", "-")),
 			"application/json", bytes.NewBuffer(data))
 		re.NoError(err)
-		// skipGrantLeader is still enabled for the whole duration of this call, so
-		// newPrimary cannot win and TransferPrimary's post-transfer verification times
-		// out - this call reports failure here, even though the cluster does recover
-		// once skipGrantLeader is disabled below.
-		re.Equal(http.StatusInternalServerError, resp.StatusCode)
+		// TransferPrimary reports success as soon as the marker is written and the
+		// old primary resigns - it does not wait for newPrimary to actually win, so
+		// this call succeeds here even though skipGrantLeader keeps newPrimary from
+		// winning for the whole duration of this call. The cluster does recover once
+		// skipGrantLeader is disabled below.
+		re.Equal(http.StatusOK, resp.StatusCode)
 		resp.Body.Close()
 
 		// Wait for the old primary exit and new primary campaign
@@ -697,14 +698,11 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 		resp, err := tests.TestDialClient.Post(fmt.Sprintf("%s/%s/api/v1/primary/transfer", primary, strings.ReplaceAll(service, "_", "-")),
 			"application/json", bytes.NewBuffer(data))
 		re.NoError(err)
-		// skipGrantLeader keeps newPrimary from ever winning for as long as this call
-		// runs, so TransferPrimary's post-transfer verification (which polls for
-		// newPrimary to actually take over, bounded by the expected-primary marker's
-		// own TTL) can never observe it and must time out. This call therefore reports
-		// failure here - it genuinely could not confirm the transfer took effect - even
-		// though the marker itself is still written and the cluster does recover once
-		// the old primary steps down below; that recovery is verified separately.
-		re.Equal(http.StatusInternalServerError, resp.StatusCode)
+		// TransferPrimary reports success as soon as the marker is written and the
+		// old primary resigns, regardless of whether newPrimary ever actually wins -
+		// skipGrantLeader keeps it from winning for as long as this call runs, but
+		// that only affects whether the cluster later recovers, not this response.
+		re.Equal(http.StatusOK, resp.StatusCode)
 		resp.Body.Close()
 
 		// Wait for the old primary exit and new primary campaign
@@ -719,9 +717,9 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDown(
 		re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/election/skipGrantLeader"))
 
 		// The transfer target (which we just closed) is the one named in the expected
-		// primary flag, so the other replicas back off until the flag's TTL (a few
-		// leader leases) expires, after which a free re-election elects a live primary.
-		// Wait long enough to cover that worst case.
+		// primary flag, so the other replicas back off until the flag's TTL (one leader
+		// lease) expires, after which a free re-election elects a live primary. Wait
+		// long enough to cover that worst case.
 		recoverWait := time.Duration(mcs.TransferPrimaryLeaseMultiplier*mcs.DefaultLease)*time.Second + 10*time.Second
 		serving := make([]string, 0, len(nodes))
 		testutil.Eventually(re, func() bool {
@@ -973,11 +971,11 @@ func (suite *memberTestSuite) TestTransferPrimaryWhileLeaseExpiredAndServerDownW
 		fmt.Sprintf("%s/tso/api/v1/primary/transfer", groupPrimary),
 		"application/json", bytes.NewBuffer(data))
 	re.NoError(err)
-	// target can never win while skipGrantLeader is enabled, so TransferPrimary's
-	// post-transfer verification times out and this call reports failure - it
-	// genuinely could not confirm the transfer took effect. The group does still
-	// recover afterwards, verified separately below.
-	re.Equal(http.StatusInternalServerError, resp.StatusCode)
+	// TransferPrimary reports success as soon as the marker is written and the old
+	// primary resigns, regardless of whether target ever actually wins - target can
+	// never win while skipGrantLeader is enabled, but that only affects whether the
+	// group later recovers, verified separately below.
+	re.Equal(http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
 
 	// Wait until the old group primary steps down (group temporarily has no primary).


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11122

The expected-primary transient marker mechanism (introduced in aa5a98865) has four correctness gaps that let `{service}/primary/transfer` silently no-op or be bypassed under leadership churn. See #11122 for the full analysis and reproduction reasoning behind each one.

### What is changed and how does it work?

```commit-message
The expected-primary transient marker mechanism has four correctness gaps
that let `{service}/primary/transfer` silently no-op or be bypassed:

- markExpectedPrimaryFlag wrote the marker unconditionally; a caller that lost
  leadership between its IsServing() check and the write could still publish
  a marker that the real, already-serving primary never reacts to.
- DeleteExpectedPrimaryFlag could not tell "marker gone" from "marker
  overwritten by a newer transfer", so a newer transfer's target was never
  promoted when the write raced a winning campaign.
- ExpectedPrimaryCmp returned no guard for the empty-marker case, letting a
  campaigner that observed no transfer win anyway if a transfer installed a
  marker and released the leader key in the meantime.
- Guarding the marker write on the leader key's Value is not enough to fence
  a specific election term, since MemberValue() never changes for a
  participant's lifetime; guard on CreateRevision instead, captured right
  after the IsServing() check rather than right before the write.

markExpectedPrimaryFlag now takes extra etcd comparisons folded into the same
transaction as the Put. DeleteExpectedPrimaryFlag takes the campaigning
participant and returns whether it was superseded by a newer transfer, so its
three callers (scheduling, resource manager, TSO) step down instead of
silently keeping serving. ExpectedPrimaryCmp always returns a real
comparison, asserting the marker is absent (CreateRevision == 0) when no
transfer was observed. TransferPrimary now reads the leader key right after
its IsServing() check and fences the marker write on that CreateRevision, and
revokes the newly granted lease on any failure path.
```

### Update: dropped post-transfer verification, capped marker TTL at 1 lease

An earlier revision of this PR added `waitForPrimaryTransfer`: after marking
and resigning, `TransferPrimary` polled the leader key and only reported
success once the target was observed stably holding it. Review discussion
(see the thread on #11122 / the linked pd-cse PR) established that this
verification only *narrowed*, never eliminated, the gap between the leader
key being written and the target actually finishing initialization (TSO's
`syncTimestamp` in particular does real I/O and can fail well after the key
looks stable) - it could not be made airtight without querying the target's
own local serving state instead of polling etcd, which is out of scope here.
Meanwhile it made the API call block for up to the marker's TTL and could
report a false failure to a caller with a short-lived context even while the
transfer was proceeding normally in the background.

Given the verification could not be made complete anyway, this PR now drops
it: `TransferPrimary` reports success as soon as the marker is written and
the current primary has resigned, without waiting for the target to actually
win or initialize. The other correctness fixes above (mark-before-resign
ordering, the atomic leader-key guard, `DeleteExpectedPrimaryFlag` clearing
the marker as soon as any member wins a campaign) are unaffected.

Without verification, the worst-case unavailability a transfer can leave
behind - when the target never wins a single campaign at all (down,
unreachable, or stuck) - is bounded by the marker's TTL
(`TransferPrimaryLeaseMultiplier * leaderLease`), since every other candidate
backs off in its favor for as long as the marker is valid. This PR also
shrinks that multiplier from 3 to 1: a target that does win clears the marker
immediately regardless of whether it goes on to initialize successfully, so
the multiplier's only effect is on the "never wins even once" case, and there
is no reason to let that cost more than one leader lease - the same duration
the cluster already tolerates a primary being unreachable everywhere else.

### Check List

Tests

- Unit test
- Integration test

Side effects

- Possible performance regression
- Increased code complexity

### Release note

```release-note
Fix races in the primary-transfer marker mechanism that could let `{service}/primary/transfer` silently no-op or be bypassed under leadership churn.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved primary transfers with stronger safeguards against stale or superseded transfer requests.
  * Primary members now step down promptly when a transfer target changes, helping prevent conflicting leadership.
  * Transfer operations are more reliably protected during leadership changes and recovery scenarios.
  * Reduced the transfer lease window from three lease durations to one, enabling faster recovery when transfers do not complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->