### PR TITLE
schedule/labeler: preserve legacy keyspace range matching

### DIFF
--- a/pkg/schedule/labeler/keyspace_index.go
+++ b/pkg/schedule/labeler/keyspace_index.go
@@ -344,19 +344,25 @@ func (i *keyspaceRuleIndex) matchRule(start, end []byte) (*LabelRule, bool) {
 		return nil, false
 	}
 	mode, id, ok := codec.DecodeKeyspaceKey(start)
+	hasCompletePrefix := ok
 	if !ok {
-		return nil, false
+		mode, id, ok = keyspaceIntervalForKey(start)
+		if !ok {
+			return nil, false
+		}
 	}
 	set := i.ruleSet(mode)
 	if set == nil {
 		return nil, false
 	}
 	rule := set.get(id)
-	if len(end) >= codec.KeyspacePrefixLen && bytes.Equal(start[:codec.KeyspacePrefixLen], end[:codec.KeyspacePrefixLen]) {
+	if hasCompletePrefix &&
+		len(end) >= codec.KeyspacePrefixLen &&
+		bytes.Equal(start[:codec.KeyspacePrefixLen], end[:codec.KeyspacePrefixLen]) {
 		return rule, true
 	}
 	right := keyspaceBoundary(mode, id+1)
-	// DecodeKeyspaceKey guarantees that start is not below this ID's boundary.
+	// Both decoding paths guarantee that start is not below this ID's boundary.
 	if bytes.Compare(end, right[:]) > 0 {
 		return nil, false
 	}
@@ -483,6 +489,18 @@ func keyspaceBoundary(mode byte, id uint32) [9]byte {
 func keyspaceBoundaryBytes(mode byte, id uint32) []byte {
 	key := keyspaceBoundary(mode, id)
 	return key[:]
+}
+
+// keyspaceIntervalForKey finds the canonical keyspace interval containing a
+// lexicographic key that does not carry a complete decodable prefix.
+func keyspaceIntervalForKey(key []byte) (byte, uint32, bool) {
+	for _, mode := range codec.KeyspaceModes() {
+		upper := keyspaceBoundaryBound(mode, key, true)
+		if upper > 0 && upper < keyspaceBoundaryCount {
+			return mode, uint32(upper - 1), true
+		}
+	}
+	return 0, 0, false
 }
 
 func keyspaceBoundaryRange(mode byte, start, end []byte) (lo, hi int) {

--- a/pkg/schedule/labeler/keyspace_index_test.go
+++ b/pkg/schedule/labeler/keyspace_index_test.go
@@ -151,6 +151,72 @@ func TestKeyspaceRuleIndexBoundaries(t *testing.T) {
 	re.Equal(expected, index.GetSplitKeys(nil, nil))
 }
 
+func TestKeyspaceRuleIndexMatchesIncompletePrefix(t *testing.T) {
+	re := require.New(t)
+	rule255 := makeKeyspaceRuleForTest(255, codec.TxnKeyspaceModePrefix)
+	rule256 := makeKeyspaceRuleForTest(256, codec.TxnKeyspaceModePrefix)
+	maxRule := makeKeyspaceRuleForTest(
+		constant.MaxValidKeyspaceID,
+		codec.RawKeyspaceModePrefix,
+		codec.TxnKeyspaceModePrefix,
+	)
+
+	var index keyspaceRuleIndex
+	for _, rule := range []*LabelRule{rule255, rule256, maxRule} {
+		re.NoError(rule.checkAndAdjust())
+		re.True(index.Add(rule))
+	}
+
+	b256 := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 256)
+	b257 := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 257)
+	below256 := append([]byte(nil), b256...)
+	below256[len(below256)-1]--
+	above256Malformed := append([]byte(nil), b256...)
+	above256Malformed[4] = 1
+	above256Malformed[len(above256Malformed)-1]--
+	inside256 := codec.EncodeBytes([]byte{codec.TxnKeyspaceModePrefix, 0, 1, 0, 'a'})
+	rawFence := keyspaceBoundaryBytes(codec.RawKeyspaceModePrefix, constant.MaxValidKeyspaceID+1)
+	txnFirst := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 0)
+	txnFence := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, constant.MaxValidKeyspaceID+1)
+
+	for _, testCase := range []struct {
+		name       string
+		start      []byte
+		end        []byte
+		want       *LabelRule
+		withinMode bool
+	}{
+		{name: "incomplete-marker-before-boundary", start: below256, end: b256, want: rule255, withinMode: true},
+		{name: "short-boundary-prefix", start: b256[:codec.KeyspacePrefixLen], end: b256, want: rule255, withinMode: true},
+		{name: "incomplete-prefix-crosses-boundary", start: below256, end: inside256},
+		{name: "malformed-marker-after-boundary", start: above256Malformed, end: b257, want: rule256, withinMode: true},
+		{name: "raw-fence-prefix", start: rawFence[:1], end: rawFence, want: maxRule, withinMode: true},
+		{name: "txn-fence-prefix", start: txnFence[:8], end: txnFence, want: maxRule, withinMode: true},
+		{name: "before-first-boundary", start: txnFirst[:codec.KeyspacePrefixLen], end: txnFirst},
+		{name: "at-fence", start: txnFence, end: []byte{'z'}},
+		{name: "unbounded-end", start: below256},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			re := require.New(t)
+			got, withinMode := index.matchRule(testCase.start, testCase.end)
+			if testCase.want == nil {
+				re.Nil(got)
+			} else {
+				re.Same(testCase.want, got)
+			}
+			re.Equal(testCase.withinMode, withinMode)
+		})
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		got, withinMode := index.matchRule(below256, b256)
+		if got != rule255 || !withinMode {
+			panic("incomplete keyspace prefix did not match")
+		}
+	})
+	re.Zero(allocs)
+}
+
 func TestKeyspaceRuleIndexSparseGap(t *testing.T) {
 	re := require.New(t)
 	rule := makeKeyspaceRuleForTest(constant.MaxValidKeyspaceID, codec.TxnKeyspaceModePrefix)
@@ -336,7 +402,7 @@ func TestKeyspaceRuleIndexPreservesLegacyResults(t *testing.T) {
 	re.NoError(err)
 
 	var rules []*LabelRule
-	for _, id := range []uint32{0, 1, 63, 64, 1023, 1024, constant.MaxValidKeyspaceID} {
+	for _, id := range []uint32{0, 1, 63, 64, 255, 256, 1023, 1024, 65535, constant.MaxValidKeyspaceID} {
 		rule := makeKeyspaceRuleForTest(id, codec.RawKeyspaceModePrefix, codec.TxnKeyspaceModePrefix)
 		rules = append(rules, rule)
 		re.NoError(regionLabeler.SetLabelRule(rule))
@@ -378,6 +444,15 @@ func TestKeyspaceRuleIndexPreservesLegacyResults(t *testing.T) {
 			regions = append(regions, core.NewTestRegionInfo(2, 1, left.GetStartKey(), right.GetEndKey()))
 		}
 	}
+	b256 := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, 256)
+	incomplete256 := codec.EncodeBytes([]byte{codec.TxnKeyspaceModePrefix, 0, 1})
+	inside256 := codec.EncodeBytes([]byte{codec.TxnKeyspaceModePrefix, 0, 1, 0, 'a'})
+	txnFence := keyspaceBoundaryBytes(codec.TxnKeyspaceModePrefix, constant.MaxValidKeyspaceID+1)
+	regions = append(regions,
+		core.NewTestRegionInfo(3, 1, incomplete256, b256),
+		core.NewTestRegionInfo(4, 1, incomplete256, inside256),
+		core.NewTestRegionInfo(5, 1, txnFence[:1], txnFence),
+	)
 	for _, region := range regions {
 		want := getLegacyRegionLabels(legacy, region)
 		got := make(map[string]string)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #11030

The specialized keyspace rule index currently rejects a region when its start
key does not contain a complete decodable keyspace prefix. Region boundaries
can use incomplete or otherwise noncanonical encoded keys that still fall
lexicographically inside a canonical keyspace interval. The former generic
range-list lookup matched those ranges, so the specialized index can otherwise
drop their keyspace label.

### What is changed and how does it work?

- Fall back to keyspace-boundary arithmetic when decoding the region start key
  fails, and identify the canonical interval that contains it.
- Keep the complete-prefix fast path unchanged and validate fallback matches
  against the interval's right boundary.
- Add focused regression and legacy differential coverage for incomplete
  prefixes, the 255/256 boundary, malformed marker bytes, and maximum-ID
  fences.

```commit-message
Preserve generic range-list behavior for region boundaries that do not contain
a complete decodable keyspace prefix. Use keyspace-boundary arithmetic only
when decoding fails, leaving the normal indexed lookup path unchanged.
```

### Check List

Tests

- Unit test coverage added; not run locally.
- Benchmarks not run locally.
- `gofmt` and `git diff --check` passed.

Code changes

- No configuration, HTTP API, or persistent-data format changes.

Side effects

- The normal complete-prefix lookup path remains unchanged.
- The decode-failure fallback checks only the supported keyspace modes and
  does not allocate.

Related changes

- Companion downstream fix: https://github.com/tidbcloud/pd-cse/pull/568

### Release note

```release-note
Fix missing keyspace region labels for ranges with incomplete or otherwise
noncanonical encoded start keys.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rule matching for incomplete, malformed, sparse, and unbounded keyspace boundaries.
  * Ensured lookups remain accurate when region boundaries contain partial key prefixes or fence values.
  * Preserved existing results for legacy and irregular keyspace configurations.
  * Maintained efficient lookup behavior without additional memory allocation in representative cases.

* **Tests**
  * Added coverage for incomplete-prefix, malformed-boundary, fence, unbounded, and sparse keyspace scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->