### PR TITLE
*: delete per-store metrics when a store is tombstoned

### DIFF
--- a/pkg/core/basic_cluster.go
+++ b/pkg/core/basic_cluster.go
@@ -54,12 +54,17 @@ func (bc *BasicCluster) GetLeaderStoreByRegionID(regionID uint64) *StoreInfo {
 func (bc *BasicCluster) getWriteRate(
 	f func(storeID uint64) (bytesRate, keysRate float64),
 ) (storeIDs []uint64, bytesRates, keysRates []float64) {
-	storeIDs = bc.GetStoreIDs()
-	count := len(storeIDs)
-	bytesRates = make([]float64, 0, count)
-	keysRates = make([]float64, 0, count)
-	for _, id := range storeIDs {
+	stores := bc.GetStores()
+	storeIDs = make([]uint64, 0, len(stores))
+	bytesRates = make([]float64, 0, len(stores))
+	keysRates = make([]float64, 0, len(stores))
+	for _, store := range stores {
+		if store.IsRemoved() {
+			continue
+		}
+		id := store.GetID()
 		bytesRate, keysRate := f(id)
+		storeIDs = append(storeIDs, id)
 		bytesRates = append(bytesRates, bytesRate)
 		keysRates = append(keysRates, keysRate)
 	}

--- a/pkg/mcs/router/server/meta/watcher.go
+++ b/pkg/mcs/router/server/meta/watcher.go
@@ -82,7 +82,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 
 		if store.GetNodeState() == metapb.NodeState_Removed {
-			statistics.ResetStoreStatistics(store.GetAddress(), strconv.FormatUint(store.GetId(), 10))
+			statistics.ResetStoreStatistics(strconv.FormatUint(store.GetId(), 10))
 			// TODO: remove hot stats
 		}
 

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -911,22 +911,27 @@ func (c *Cluster) processRegionHeartbeat(ctx *core.MetaProcessContext, region *c
 
 // HandleRegionBuckets processes region buckets from client
 func (c *Cluster) HandleRegionBuckets(b *metapb.Buckets) error {
-	if err := c.processRegionBuckets(b); err != nil {
+	applied, err := c.processRegionBuckets(b)
+	if err != nil {
 		return err
 	}
-
-	c.hotStat.CheckAsync(buckets.NewCheckPeerTask(b))
+	if applied {
+		c.hotStat.CheckAsync(buckets.NewCheckPeerTask(b))
+	}
 	return nil
 }
 
-// processRegionBuckets update the bucket information.
-func (c *Cluster) processRegionBuckets(buckets *metapb.Buckets) error {
+// processRegionBuckets updates the bucket information. The first return
+// value reports whether the report was actually applied, so callers don't
+// enqueue hot-bucket work for a report that was ignored because its leader
+// is tombstoned.
+func (c *Cluster) processRegionBuckets(buckets *metapb.Buckets) (bool, error) {
 	region := c.GetRegion(buckets.GetRegionId())
 	if region == nil {
-		return errors.Errorf("region %v not found", buckets.GetRegionId())
+		return false, errors.Errorf("region %v not found", buckets.GetRegionId())
 	}
 	if store := c.GetStore(region.GetLeader().GetStoreId()); store != nil && store.IsRemoved() {
-		return nil
+		return false, nil
 	}
 	// use CAS to update the bucket information.
 	// the two request(A:3,B:2) get the same region and need to update the buckets.
@@ -934,10 +939,10 @@ func (c *Cluster) processRegionBuckets(buckets *metapb.Buckets) error {
 	// the retry should keep the old version and the new version will be set to the region.bucket, like two requests (A:2,B:3).
 	for range 3 {
 		if success := region.CompareAndSetReportBuckets(buckets); success {
-			return nil
+			return true, nil
 		}
 	}
-	return nil
+	return true, nil
 }
 
 // IsPrepared return true if the prepare checker is ready.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -753,7 +753,7 @@ func resetMetrics() {
 	schedule.ResetHotSpotMetrics()
 	filter.ResetFilterMetrics()
 	hbstream.ResetHeartbeatStreamMetrics()
-	ResetMetrics()
+	ResetStoreMetrics()
 }
 
 // StartBackgroundJobs starts background jobs.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -95,13 +95,6 @@ type Cluster struct {
 	pdLeader          atomic.Value
 	running           atomic.Bool
 
-	// recentlyTombstonedStores is the set of store IDs collectMetrics saw tombstoned
-	// on its last tick, needed to catch a store that gets fully removed between two
-	// ticks so its filter counters still get one final delete. Only collectMetrics,
-	// via runMetricsCollectionJob's single-goroutine ticker, touches it, so it needs
-	// no lock.
-	recentlyTombstonedStores map[uint64]struct{}
-
 	backendAddress string
 	httpClient     *http.Client
 
@@ -735,29 +728,10 @@ func (c *Cluster) runMetricsCollectionJob() {
 func (c *Cluster) collectMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(c.persistConfig)
 	stores := c.GetStores()
-	// Filter counters need repeated cleanup: schedulers keep rejecting a
-	// tombstoned-but-known store via StoreStateFilter every cycle, so a one-shot
-	// delete at bury time doesn't stick. Deleting already-gone labels is a cheap
-	// no-op, so repeating it every tick is safe.
-	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
-		if s.IsRemoved() {
-			storeID := s.GetID()
-			current[storeID] = struct{}{}
-			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
-		}
 	}
-	// A store fully removed between two ticks drops out of GetStores() before this
-	// sweep can catch it there; delete once more for anything recentlyTombstonedStores
-	// still remembers but current no longer has.
-	for storeID := range c.recentlyTombstonedStores {
-		if _, stillKnown := current[storeID]; !stillKnown {
-			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
-		}
-	}
-	c.recentlyTombstonedStores = current
 	statsMap.Collect()
 
 	c.coordinator.GetSchedulersController().CollectSchedulerMetrics()

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -725,6 +726,9 @@ func (c *Cluster) collectMetrics() {
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
+		if s.IsRemoved() {
+			DeleteStoreMetrics(s.GetAddress(), strconv.FormatUint(s.GetID(), 10))
+		}
 	}
 	statsMap.Collect()
 

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -94,6 +94,16 @@ type Cluster struct {
 	pdLeader          atomic.Value
 	running           atomic.Bool
 
+	// cleanedRemovedStoreMetrics tracks store IDs whose per-store heartbeat/bucket
+	// metrics (defined in this package, see metrics.go) have already been deleted by
+	// collectMetrics after the store was tombstoned. Only collectMetrics's own
+	// goroutine (via runMetricsCollectionJob's ticker) touches this map, so it needs
+	// no lock. Without it, DeleteStoreMetrics would DeletePartialMatch-scan every
+	// per-store metric vector on every tick for as long as the store stays
+	// tombstoned-but-not-yet-removed (up to the tombstone GC interval), even though
+	// there is nothing left to delete after the first pass.
+	cleanedRemovedStoreMetrics map[uint64]struct{}
+
 	backendAddress string
 	httpClient     *http.Client
 
@@ -146,22 +156,23 @@ func NewCluster(
 		return nil, err
 	}
 	c := &Cluster{
-		ctx:               ctx,
-		cancel:            cancel,
-		BasicCluster:      basicCluster,
-		ruleManager:       ruleManager,
-		keyRangeManager:   keyrange.NewManager(),
-		labelerManager:    labelerManager,
-		affinityManager:   affinityManager,
-		persistConfig:     persistConfig,
-		hotStat:           statistics.NewHotStat(ctx, basicCluster),
-		labelStats:        statistics.NewLabelStatistics(),
-		regionStats:       statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
-		storage:           storage,
-		hbStreams:         hbStreams,
-		checkMembershipCh: checkMembershipCh,
-		httpClient:        httpClient,
-		backendAddress:    backendAddress,
+		ctx:                        ctx,
+		cancel:                     cancel,
+		BasicCluster:               basicCluster,
+		ruleManager:                ruleManager,
+		keyRangeManager:            keyrange.NewManager(),
+		labelerManager:             labelerManager,
+		affinityManager:            affinityManager,
+		persistConfig:              persistConfig,
+		hotStat:                    statistics.NewHotStat(ctx, basicCluster),
+		labelStats:                 statistics.NewLabelStatistics(),
+		regionStats:                statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
+		storage:                    storage,
+		hbStreams:                  hbStreams,
+		checkMembershipCh:          checkMembershipCh,
+		httpClient:                 httpClient,
+		backendAddress:             backendAddress,
+		cleanedRemovedStoreMetrics: make(map[uint64]struct{}),
 
 		heartbeatRunner: ratelimit.NewConcurrentRunner(heartbeatTaskRunner, ratelimit.NewConcurrencyLimiter(uint64(runtime.NumCPU()*2)), time.Minute),
 		miscRunner:      ratelimit.NewConcurrentRunner(miscTaskRunner, ratelimit.NewConcurrencyLimiter(uint64(runtime.NumCPU()*2)), time.Minute),
@@ -723,11 +734,24 @@ func (c *Cluster) runMetricsCollectionJob() {
 func (c *Cluster) collectMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(c.persistConfig)
 	stores := c.GetStores()
+	// Stores still tombstoned this tick; anything in cleanedRemovedStoreMetrics but
+	// not in this set has been fully removed, so its tracking entry can be dropped.
+	removed := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
 		if s.IsRemoved() {
-			DeleteStoreMetrics(s.GetAddress(), strconv.FormatUint(s.GetID(), 10))
+			storeID := s.GetID()
+			removed[storeID] = struct{}{}
+			if _, cleaned := c.cleanedRemovedStoreMetrics[storeID]; !cleaned {
+				DeleteStoreMetrics(s.GetAddress(), strconv.FormatUint(storeID, 10))
+				c.cleanedRemovedStoreMetrics[storeID] = struct{}{}
+			}
+		}
+	}
+	for storeID := range c.cleanedRemovedStoreMetrics {
+		if _, stillTombstoned := removed[storeID]; !stillTombstoned {
+			delete(c.cleanedRemovedStoreMetrics, storeID)
 		}
 	}
 	statsMap.Collect()

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -753,6 +753,7 @@ func resetMetrics() {
 	schedule.ResetHotSpotMetrics()
 	filter.ResetFilterMetrics()
 	hbstream.ResetHeartbeatStreamMetrics()
+	ResetMetrics()
 }
 
 // StartBackgroundJobs starts background jobs.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -943,7 +943,7 @@ func (c *Cluster) processRegionBuckets(buckets *metapb.Buckets) (bool, error) {
 			return true, nil
 		}
 	}
-	return true, nil
+	return false, nil
 }
 
 // IsPrepared return true if the prepare checker is ready.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -48,6 +48,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/affinity"
 	sc "github.com/tikv/pd/pkg/schedule/config"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/keyrange"
 	"github.com/tikv/pd/pkg/schedule/labeler"
@@ -727,15 +728,22 @@ func (c *Cluster) collectMetrics() {
 	// already cleaned: a region heartbeat for an already-tombstoned store can still
 	// land here and recreate a series. RegionHeartbeat (grpc_service.go) only checks
 	// store == nil, not store.IsRemoved(), before recording regionHeartbeat* metrics.
-	// If cleanup only ran once per store, such a late write would never get swept
-	// again for as long as the store stays tombstoned-but-not-yet-removed.
-	// DeletePartialMatch on labels that no longer exist is a cheap no-op, so
-	// repeating it every tick is safe.
+	// The same is true of filter and heartbeat-stream metrics: every scheduler's
+	// Schedule() still runs StoreStateFilter against every known store each cycle
+	// (that rejection is what increments the filter counters), and the heartbeat
+	// stream keepalive ticker keeps touching a tombstoned store as long as its
+	// stream is still bound. If cleanup only ran once per store, such late writes
+	// would never get swept again for as long as the store stays
+	// tombstoned-but-not-yet-removed. DeletePartialMatch on labels that no longer
+	// exist is a cheap no-op, so repeating it every tick is safe.
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
 		if s.IsRemoved() {
-			DeleteStoreMetrics(s.GetAddress(), strconv.FormatUint(s.GetID(), 10))
+			storeIDStr := strconv.FormatUint(s.GetID(), 10)
+			DeleteStoreMetrics(s.GetAddress(), storeIDStr)
+			filter.DeleteStoreMetrics(storeIDStr)
+			hbstream.DeleteStoreMetrics(storeIDStr)
 		}
 	}
 	statsMap.Collect()

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -97,7 +97,14 @@ type Cluster struct {
 
 	// recentlyTombstonedStores is the set of store IDs collectMetrics saw tombstoned
 	// on its last tick. Only that method, driven by runMetricsCollectionJob's own
-	// single-goroutine ticker, touches it, so it needs no lock.
+	// single-goroutine ticker, touches it, so it needs no lock. Filter counters are
+	// the only metrics that still need this: every scheduler's Schedule() keeps
+	// running StoreStateFilter against a tombstoned-but-known store every cycle,
+	// which is what increments them, so a one-shot delete at bury time gets undone
+	// almost immediately. Heartbeat, heartbeat-stream, and store-status metrics no
+	// longer need it -- writes to them stop at bury time (see the store-tombstoned
+	// callback wired in SetRuntimeResources and the IsRemoved checks in
+	// grpc_service.go/heartbeat_streams.go).
 	recentlyTombstonedStores map[uint64]struct{}
 
 	backendAddress string
@@ -331,6 +338,10 @@ func (c *Cluster) SetRuntimeResources(
 	c.configWatcher = configWatcher
 	c.ruleWatcher = ruleWatcher
 	c.affinityWatcher = affinityWatcher
+	metaWatcher.SetOnStoreTombstoned(func(storeID uint64) {
+		c.hotStat.RemoveRollingStoreStats(storeID)
+		DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
+	})
 }
 
 func (c *Cluster) stopCluster() {
@@ -726,33 +737,14 @@ func (c *Cluster) runMetricsCollectionJob() {
 	}
 }
 
-// deleteTombstonedStoreMetrics deletes every per-store metric this package knows
-// about (heartbeat/bucket metrics, storeStatusGauge/clusterStatusGauge, filter
-// counters, and heartbeat-stream counters) for a tombstoned store.
-func deleteTombstonedStoreMetrics(storeID string) {
-	statistics.ResetStoreStatistics(storeID)
-	DeleteStoreMetrics(storeID)
-	filter.DeleteStoreMetrics(storeID)
-	hbstream.DeleteStoreMetrics(storeID)
-}
-
 func (c *Cluster) collectMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(c.persistConfig)
 	stores := c.GetStores()
-	// Delete unconditionally on every tick rather than tracking which stores were
-	// already cleaned: a region heartbeat for an already-tombstoned store can still
-	// land here and recreate a series. RegionHeartbeat (grpc_service.go) only checks
-	// store == nil, not store.IsRemoved(), before recording regionHeartbeat* metrics.
-	// The same is true of filter and heartbeat-stream metrics: every scheduler's
-	// Schedule() still runs StoreStateFilter against every known store each cycle
-	// (that rejection is what increments the filter counters), and the heartbeat
-	// stream keepalive ticker keeps touching a tombstoned store as long as its
-	// stream is still bound. ObserveHotStat above can likewise recreate
-	// storeStatusGauge from rolling stats that were never retired. If cleanup only
-	// ran once per store, such late writes would never get swept again for as long
-	// as the store stays tombstoned-but-not-yet-removed. DeletePartialMatch on
-	// labels that no longer exist is a cheap no-op, so repeating it every tick is
-	// safe.
+	// Filter counters are the only ones that need repeated cleanup here: every
+	// scheduler's Schedule() still runs StoreStateFilter against every known store
+	// each cycle, and that rejection is what increments them, so a one-shot delete
+	// at bury time gets undone almost immediately. DeletePartialMatch on labels that
+	// no longer exist is a cheap no-op, so repeating it every tick is safe.
 	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
@@ -760,7 +752,7 @@ func (c *Cluster) collectMetrics() {
 		if s.IsRemoved() {
 			storeID := s.GetID()
 			current[storeID] = struct{}{}
-			deleteTombstonedStoreMetrics(strconv.FormatUint(storeID, 10))
+			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 		}
 	}
 	// A store that was tombstoned as of the last sweep but isn't known at all this
@@ -771,7 +763,7 @@ func (c *Cluster) collectMetrics() {
 	// it's a no-op if nothing was actually rewritten.
 	for storeID := range c.recentlyTombstonedStores {
 		if _, stillKnown := current[storeID]; !stillKnown {
-			deleteTombstonedStoreMetrics(strconv.FormatUint(storeID, 10))
+			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 		}
 	}
 	c.recentlyTombstonedStores = current

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -765,6 +765,8 @@ func resetMetrics() {
 	statistics.Reset()
 	schedulers.ResetSchedulerMetrics()
 	schedule.ResetHotSpotMetrics()
+	filter.ResetFilterMetrics()
+	hbstream.ResetHeartbeatStreamMetrics()
 }
 
 // StartBackgroundJobs starts background jobs.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -925,6 +925,9 @@ func (c *Cluster) processRegionBuckets(buckets *metapb.Buckets) error {
 	if region == nil {
 		return errors.Errorf("region %v not found", buckets.GetRegionId())
 	}
+	if store := c.GetStore(region.GetLeader().GetStoreId()); store != nil && store.IsRemoved() {
+		return nil
+	}
 	// use CAS to update the bucket information.
 	// the two request(A:3,B:2) get the same region and need to update the buckets.
 	// the A will pass the check and set the version to 3, the B will fail because the region.bucket has changed.

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -743,6 +743,19 @@ func (c *Cluster) collectMetrics() {
 		}
 	}
 	statsMap.Collect()
+	// statsMap.Collect() writes statistics.StoreLimitGauge from its own
+	// GetStoresLimit() snapshot, taken independently of stores above and with
+	// no cluster reference of its own to re-check against. Reuse the stores
+	// snapshot already captured here to catch and undo it for any store
+	// that's gone by now, the same way the loop above does for the other
+	// per-store metrics.
+	for _, s := range stores {
+		if c.GetStore(s.GetID()) == nil {
+			id := strconv.FormatUint(s.GetID(), 10)
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
+		}
+	}
 
 	c.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	c.coordinator.CollectHotSpotMetrics()

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -96,15 +96,10 @@ type Cluster struct {
 	running           atomic.Bool
 
 	// recentlyTombstonedStores is the set of store IDs collectMetrics saw tombstoned
-	// on its last tick. Only that method, driven by runMetricsCollectionJob's own
-	// single-goroutine ticker, touches it, so it needs no lock. Filter counters are
-	// the only metrics that still need this: every scheduler's Schedule() keeps
-	// running StoreStateFilter against a tombstoned-but-known store every cycle,
-	// which is what increments them, so a one-shot delete at bury time gets undone
-	// almost immediately. Heartbeat, heartbeat-stream, and store-status metrics no
-	// longer need it -- writes to them stop at bury time (see the store-tombstoned
-	// callback wired in SetRuntimeResources and the IsRemoved checks in
-	// grpc_service.go/heartbeat_streams.go).
+	// on its last tick, needed to catch a store that gets fully removed between two
+	// ticks so its filter counters still get one final delete. Only collectMetrics,
+	// via runMetricsCollectionJob's single-goroutine ticker, touches it, so it needs
+	// no lock.
 	recentlyTombstonedStores map[uint64]struct{}
 
 	backendAddress string
@@ -740,11 +735,10 @@ func (c *Cluster) runMetricsCollectionJob() {
 func (c *Cluster) collectMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(c.persistConfig)
 	stores := c.GetStores()
-	// Filter counters are the only ones that need repeated cleanup here: every
-	// scheduler's Schedule() still runs StoreStateFilter against every known store
-	// each cycle, and that rejection is what increments them, so a one-shot delete
-	// at bury time gets undone almost immediately. DeletePartialMatch on labels that
-	// no longer exist is a cheap no-op, so repeating it every tick is safe.
+	// Filter counters need repeated cleanup: schedulers keep rejecting a
+	// tombstoned-but-known store via StoreStateFilter every cycle, so a one-shot
+	// delete at bury time doesn't stick. Deleting already-gone labels is a cheap
+	// no-op, so repeating it every tick is safe.
 	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
@@ -755,12 +749,9 @@ func (c *Cluster) collectMetrics() {
 			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 		}
 	}
-	// A store that was tombstoned as of the last sweep but isn't known at all this
-	// tick was fully removed in between. The loop above only reaches stores
-	// GetStores() currently returns, so a write landing in that gap -- after the
-	// last sweep saw it tombstoned but before removal completed -- would otherwise
-	// be unreachable by any future sweep. One more delete call closes that window;
-	// it's a no-op if nothing was actually rewritten.
+	// A store fully removed between two ticks drops out of GetStores() before this
+	// sweep can catch it there; delete once more for anything recentlyTombstonedStores
+	// still remembers but current no longer has.
 	for storeID := range c.recentlyTombstonedStores {
 		if _, stillKnown := current[storeID]; !stillKnown {
 			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -95,6 +95,11 @@ type Cluster struct {
 	pdLeader          atomic.Value
 	running           atomic.Bool
 
+	// recentlyTombstonedStores is the set of store IDs collectMetrics saw tombstoned
+	// on its last tick. Only that method, driven by runMetricsCollectionJob's own
+	// single-goroutine ticker, touches it, so it needs no lock.
+	recentlyTombstonedStores map[uint64]struct{}
+
 	backendAddress string
 	httpClient     *http.Client
 
@@ -721,6 +726,16 @@ func (c *Cluster) runMetricsCollectionJob() {
 	}
 }
 
+// deleteTombstonedStoreMetrics deletes every per-store metric this package knows
+// about (heartbeat/bucket metrics, storeStatusGauge/clusterStatusGauge, filter
+// counters, and heartbeat-stream counters) for a tombstoned store.
+func deleteTombstonedStoreMetrics(storeID string) {
+	statistics.ResetStoreStatistics(storeID)
+	DeleteStoreMetrics(storeID)
+	filter.DeleteStoreMetrics(storeID)
+	hbstream.DeleteStoreMetrics(storeID)
+}
+
 func (c *Cluster) collectMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(c.persistConfig)
 	stores := c.GetStores()
@@ -732,20 +747,34 @@ func (c *Cluster) collectMetrics() {
 	// Schedule() still runs StoreStateFilter against every known store each cycle
 	// (that rejection is what increments the filter counters), and the heartbeat
 	// stream keepalive ticker keeps touching a tombstoned store as long as its
-	// stream is still bound. If cleanup only ran once per store, such late writes
-	// would never get swept again for as long as the store stays
-	// tombstoned-but-not-yet-removed. DeletePartialMatch on labels that no longer
-	// exist is a cheap no-op, so repeating it every tick is safe.
+	// stream is still bound. ObserveHotStat above can likewise recreate
+	// storeStatusGauge from rolling stats that were never retired. If cleanup only
+	// ran once per store, such late writes would never get swept again for as long
+	// as the store stays tombstoned-but-not-yet-removed. DeletePartialMatch on
+	// labels that no longer exist is a cheap no-op, so repeating it every tick is
+	// safe.
+	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
 		if s.IsRemoved() {
-			storeIDStr := strconv.FormatUint(s.GetID(), 10)
-			DeleteStoreMetrics(s.GetAddress(), storeIDStr)
-			filter.DeleteStoreMetrics(storeIDStr)
-			hbstream.DeleteStoreMetrics(storeIDStr)
+			storeID := s.GetID()
+			current[storeID] = struct{}{}
+			deleteTombstonedStoreMetrics(strconv.FormatUint(storeID, 10))
 		}
 	}
+	// A store that was tombstoned as of the last sweep but isn't known at all this
+	// tick was fully removed in between. The loop above only reaches stores
+	// GetStores() currently returns, so a write landing in that gap -- after the
+	// last sweep saw it tombstoned but before removal completed -- would otherwise
+	// be unreachable by any future sweep. One more delete call closes that window;
+	// it's a no-op if nothing was actually rewritten.
+	for storeID := range c.recentlyTombstonedStores {
+		if _, stillKnown := current[storeID]; !stillKnown {
+			deleteTombstonedStoreMetrics(strconv.FormatUint(storeID, 10))
+		}
+	}
+	c.recentlyTombstonedStores = current
 	statsMap.Collect()
 
 	c.coordinator.GetSchedulersController().CollectSchedulerMetrics()

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -731,6 +731,16 @@ func (c *Cluster) collectMetrics() {
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
+		// Observe/ObserveHotStat write from this snapshot unconditionally, so a
+		// concurrent final removal of s between GetStores() above and this write
+		// can have its own metric cleanup undone by it. Since final removal only
+		// happens once and never re-adds the store, re-checking right after the
+		// write and redoing the cleanup if it's now gone closes that race without
+		// needing synchronization with the removal path.
+		if c.GetStore(s.GetID()) == nil {
+			statistics.DeleteClusterStatusMetrics(s)
+			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
+		}
 	}
 	statsMap.Collect()
 

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -94,16 +94,6 @@ type Cluster struct {
 	pdLeader          atomic.Value
 	running           atomic.Bool
 
-	// cleanedRemovedStoreMetrics tracks store IDs whose per-store heartbeat/bucket
-	// metrics (defined in this package, see metrics.go) have already been deleted by
-	// collectMetrics after the store was tombstoned. Only collectMetrics's own
-	// goroutine (via runMetricsCollectionJob's ticker) touches this map, so it needs
-	// no lock. Without it, DeleteStoreMetrics would DeletePartialMatch-scan every
-	// per-store metric vector on every tick for as long as the store stays
-	// tombstoned-but-not-yet-removed (up to the tombstone GC interval), even though
-	// there is nothing left to delete after the first pass.
-	cleanedRemovedStoreMetrics map[uint64]struct{}
-
 	backendAddress string
 	httpClient     *http.Client
 
@@ -156,23 +146,22 @@ func NewCluster(
 		return nil, err
 	}
 	c := &Cluster{
-		ctx:                        ctx,
-		cancel:                     cancel,
-		BasicCluster:               basicCluster,
-		ruleManager:                ruleManager,
-		keyRangeManager:            keyrange.NewManager(),
-		labelerManager:             labelerManager,
-		affinityManager:            affinityManager,
-		persistConfig:              persistConfig,
-		hotStat:                    statistics.NewHotStat(ctx, basicCluster),
-		labelStats:                 statistics.NewLabelStatistics(),
-		regionStats:                statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
-		storage:                    storage,
-		hbStreams:                  hbStreams,
-		checkMembershipCh:          checkMembershipCh,
-		httpClient:                 httpClient,
-		backendAddress:             backendAddress,
-		cleanedRemovedStoreMetrics: make(map[uint64]struct{}),
+		ctx:               ctx,
+		cancel:            cancel,
+		BasicCluster:      basicCluster,
+		ruleManager:       ruleManager,
+		keyRangeManager:   keyrange.NewManager(),
+		labelerManager:    labelerManager,
+		affinityManager:   affinityManager,
+		persistConfig:     persistConfig,
+		hotStat:           statistics.NewHotStat(ctx, basicCluster),
+		labelStats:        statistics.NewLabelStatistics(),
+		regionStats:       statistics.NewRegionStatistics(basicCluster, persistConfig, ruleManager),
+		storage:           storage,
+		hbStreams:         hbStreams,
+		checkMembershipCh: checkMembershipCh,
+		httpClient:        httpClient,
+		backendAddress:    backendAddress,
 
 		heartbeatRunner: ratelimit.NewConcurrentRunner(heartbeatTaskRunner, ratelimit.NewConcurrencyLimiter(uint64(runtime.NumCPU()*2)), time.Minute),
 		miscRunner:      ratelimit.NewConcurrentRunner(miscTaskRunner, ratelimit.NewConcurrencyLimiter(uint64(runtime.NumCPU()*2)), time.Minute),
@@ -734,24 +723,19 @@ func (c *Cluster) runMetricsCollectionJob() {
 func (c *Cluster) collectMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(c.persistConfig)
 	stores := c.GetStores()
-	// Stores still tombstoned this tick; anything in cleanedRemovedStoreMetrics but
-	// not in this set has been fully removed, so its tracking entry can be dropped.
-	removed := make(map[uint64]struct{})
+	// Delete unconditionally on every tick rather than tracking which stores were
+	// already cleaned: a region heartbeat for an already-tombstoned store can still
+	// land here and recreate a series. RegionHeartbeat (grpc_service.go) only checks
+	// store == nil, not store.IsRemoved(), before recording regionHeartbeat* metrics.
+	// If cleanup only ran once per store, such a late write would never get swept
+	// again for as long as the store stays tombstoned-but-not-yet-removed.
+	// DeletePartialMatch on labels that no longer exist is a cheap no-op, so
+	// repeating it every tick is safe.
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
 		if s.IsRemoved() {
-			storeID := s.GetID()
-			removed[storeID] = struct{}{}
-			if _, cleaned := c.cleanedRemovedStoreMetrics[storeID]; !cleaned {
-				DeleteStoreMetrics(s.GetAddress(), strconv.FormatUint(storeID, 10))
-				c.cleanedRemovedStoreMetrics[storeID] = struct{}{}
-			}
-		}
-	}
-	for storeID := range c.cleanedRemovedStoreMetrics {
-		if _, stillTombstoned := removed[storeID]; !stillTombstoned {
-			delete(c.cleanedRemovedStoreMetrics, storeID)
+			DeleteStoreMetrics(s.GetAddress(), strconv.FormatUint(s.GetID(), 10))
 		}
 	}
 	statsMap.Collect()

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -732,13 +732,25 @@ func (c *Cluster) collectMetrics() {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, c.hotStat.StoresStats)
 		// Observe/ObserveHotStat write from this snapshot unconditionally, so a
-		// concurrent final removal of s between GetStores() above and this write
-		// can have its own metric cleanup undone by it. Since final removal only
-		// happens once and never re-adds the store, re-checking right after the
-		// write and redoing the cleanup if it's now gone closes that race without
-		// needing synchronization with the removal path.
-		if c.GetStore(s.GetID()) == nil {
+		// concurrent bury or final removal of s between GetStores() above and
+		// this write can have its own metric cleanup undone by it. Re-checking
+		// right after the write and redoing the cleanup closes that race
+		// without needing synchronization with the bury/removal path.
+		current := c.GetStore(s.GetID())
+		// DeleteClusterStatusMetrics only covers the clusterStatusGauge fields
+		// observe() keeps refreshing unconditionally while a store stays
+		// tombstoned (store_tombstone_count and friends, self-healing by
+		// design); only clean those up once the store is gone for good, or
+		// they'd flicker off every tick during a legitimate tombstone period.
+		if current == nil {
 			statistics.DeleteClusterStatusMetrics(s)
+		}
+		// ResetStoreStatistics covers storeStatusGauge/storeStats, which
+		// observe() itself stops writing as soon as it sees a tombstoned
+		// store -- so, unlike the fields above, there's no legitimate write to
+		// preserve here once the store is IsRemoved(), not just once it's
+		// gone entirely.
+		if current == nil || current.IsRemoved() {
 			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
 		}
 	}
@@ -746,11 +758,12 @@ func (c *Cluster) collectMetrics() {
 	// statsMap.Collect() writes statistics.StoreLimitGauge from its own
 	// GetStoresLimit() snapshot, taken independently of stores above and with
 	// no cluster reference of its own to re-check against. Reuse the stores
-	// snapshot already captured here to catch and undo it for any store
-	// that's gone by now, the same way the loop above does for the other
-	// per-store metrics.
+	// snapshot already captured here to catch and undo it. Like
+	// ResetStoreStatistics above, a store limit has no legitimate reason to
+	// still be configured once the store is tombstoned, so this also checks
+	// IsRemoved(), not just full removal.
 	for _, s := range stores {
-		if c.GetStore(s.GetID()) == nil {
+		if store := c.GetStore(s.GetID()); store == nil || store.IsRemoved() {
 			id := strconv.FormatUint(s.GetID(), 10)
 			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
 			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -749,8 +749,14 @@ func (c *Cluster) collectMetrics() {
 		// observe() itself stops writing as soon as it sees a tombstoned
 		// store -- so, unlike the fields above, there's no legitimate write to
 		// preserve here once the store is IsRemoved(), not just once it's
-		// gone entirely.
-		if current == nil || current.IsRemoved() {
+		// gone entirely. But storeStatusGauge's cleanup is a DeletePartialMatch
+		// full-vector scan, so only pay for it when this iteration's own s was
+		// still live (observe(s) could then have written using stale data);
+		// once a snapshot correctly shows IsRemoved(), observe() already
+		// skipped writing these fields and there's nothing to undo, so a
+		// tombstoned store sitting in GetStores() for up to 30 days doesn't
+		// cost a scan on every 10s tick.
+		if !s.IsRemoved() && (current == nil || current.IsRemoved()) {
 			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
 		}
 	}

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -150,7 +150,8 @@ func (s *Service) RegionHeartbeat(stream schedulingpb.Scheduling_RegionHeartbeat
 			return errors.Errorf("invalid store ID %d, not found", storeID)
 		}
 		if store.IsRemoved() {
-			return errors.Errorf("store ID %d is tombstone", storeID)
+			log.Debug("skip region heartbeat from tombstone store", zap.Uint64("store-id", storeID))
+			continue
 		}
 
 		storeAddress := store.GetAddress()

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -149,6 +149,9 @@ func (s *Service) RegionHeartbeat(stream schedulingpb.Scheduling_RegionHeartbeat
 		if store == nil {
 			return errors.Errorf("invalid store ID %d, not found", storeID)
 		}
+		if store.IsRemoved() {
+			return errors.Errorf("store ID %d is tombstone", storeID)
+		}
 
 		storeAddress := store.GetAddress()
 		storeLabel := strconv.FormatUint(storeID, 10)
@@ -220,6 +223,8 @@ func (s *Service) RegionBuckets(stream schedulingpb.Scheduling_RegionBucketsServ
 			// As TiKV report buckets just after the region heartbeat, for new created region, PD may receive buckets report before the first region heartbeat is handled.
 			// So we should not return error here.
 			log.Debug("the store of the bucket in region is not found", zap.Uint64("region-id", buckets.GetRegionId()))
+		} else if store.IsRemoved() {
+			log.Debug("the store of the bucket in region is tombstone", zap.Uint64("region-id", buckets.GetRegionId()), zap.Uint64("store-id", store.GetID()))
 		} else {
 			storeLabel = strconv.FormatUint(store.GetID(), 10)
 			storeAddress = store.GetAddress()

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -226,7 +226,7 @@ func (s *Service) RegionBuckets(stream schedulingpb.Scheduling_RegionBucketsServ
 			// So we should not return error here.
 			log.Debug("the store of the bucket in region is not found", zap.Uint64("region-id", buckets.GetRegionId()))
 		} else if store.IsRemoved() {
-			log.Debug("the store of the bucket in region is tombstone", zap.Uint64("region-id", buckets.GetRegionId()), zap.Uint64("store-id", store.GetID()))
+			continue
 		} else {
 			storeLabel = strconv.FormatUint(store.GetID(), 10)
 			storeAddress = store.GetAddress()

--- a/pkg/mcs/scheduling/server/grpc_service.go
+++ b/pkg/mcs/scheduling/server/grpc_service.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -263,17 +264,25 @@ func (s *Service) StoreHeartbeat(_ context.Context, request *schedulingpb.StoreH
 		return &schedulingpb.StoreHeartbeatResponse{Header: notBootstrappedHeader()}, nil
 	}
 
-	start := time.Now()
-	if c.GetStore(request.GetStats().GetStoreId()) == nil {
+	storeID := request.GetStats().GetStoreId()
+	if c.GetStore(storeID) == nil {
 		metaWatcher.GetStoreWatcher().ForceLoad()
 	}
 
-	storeID := request.GetStats().GetStoreId()
 	store := c.GetStore(storeID)
-	storeAddress := ""
-	if store != nil {
-		storeAddress = store.GetAddress()
+	if store == nil {
+		return &schedulingpb.StoreHeartbeatResponse{
+			Header: wrapErrorToHeader(schedulingpb.ErrorType_UNKNOWN, fmt.Sprintf("store %v not found", storeID)),
+		}, nil
 	}
+	if store.IsRemoved() {
+		return &schedulingpb.StoreHeartbeatResponse{
+			Header: wrapErrorToHeader(schedulingpb.ErrorType_UNKNOWN, fmt.Sprintf("store %v is tombstone", storeID)),
+		}, nil
+	}
+
+	start := time.Now()
+	storeAddress := store.GetAddress()
 	storeLabel := strconv.FormatUint(storeID, 10)
 	if err := c.HandleStoreHeartbeat(request); err != nil {
 		storeHeartbeatCounter.WithLabelValues(storeAddress, storeLabel, "error").Inc()

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -119,6 +119,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 		if origin != nil {
 			storeIDStr := strconv.FormatUint(storeID, 10)
 			statistics.DeleteClusterStatusMetrics(origin)
+			statistics.ResetStoreStatistics(storeIDStr)
 			filter.DeleteStoreMetrics(storeIDStr)
 			hbstream.DeleteStoreMetrics(storeIDStr)
 			schedulers.DeleteStoreMetrics(storeIDStr)

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/scatter"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
@@ -100,6 +101,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 			hbstream.DeleteStoreMetrics(storeIDStr)
 			schedulers.DeleteStoreMetrics(storeIDStr)
 			schedule.DeleteStoreMetrics(storeIDStr)
+			scatter.DeleteStoreMetrics(storeIDStr)
 			if fn := w.onStoreTombstoned.Load(); fn != nil {
 				(*fn)(store.GetId())
 			}
@@ -121,6 +123,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 			hbstream.DeleteStoreMetrics(storeIDStr)
 			schedulers.DeleteStoreMetrics(storeIDStr)
 			schedule.DeleteStoreMetrics(storeIDStr)
+			scatter.DeleteStoreMetrics(storeIDStr)
 			if fn := w.onStoreTombstoned.Load(); fn != nil {
 				(*fn)(storeID)
 			}

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -117,6 +117,10 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 		origin := w.basicCluster.GetStore(storeID)
 		if origin != nil {
+			// Remove the store before the metric cleanup below, not after: see
+			// the matching comment on RaftCluster.deleteStore for why the order
+			// matters for a concurrently-running metrics collection tick.
+			w.basicCluster.DeleteStore(origin)
 			storeIDStr := strconv.FormatUint(storeID, 10)
 			statistics.DeleteClusterStatusMetrics(origin)
 			statistics.ResetStoreStatistics(storeIDStr)
@@ -128,7 +132,6 @@ func (w *Watcher) initializeStoreWatcher() error {
 			if fn := w.onStoreTombstoned.Load(); fn != nil {
 				(*fn)(storeID)
 			}
-			w.basicCluster.DeleteStore(origin)
 			log.Info("delete store meta", zap.Uint64("store-id", storeID))
 		}
 		return nil

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -86,7 +86,7 @@ func (w *Watcher) initializeStoreWatcher() error {
 
 		if store.GetNodeState() == metapb.NodeState_Removed {
 			storeIDStr := strconv.FormatUint(store.GetId(), 10)
-			statistics.ResetStoreStatistics(store.GetAddress(), storeIDStr)
+			statistics.ResetStoreStatistics(storeIDStr)
 			filter.DeleteStoreMetrics(storeIDStr)
 			hbstream.DeleteStoreMetrics(storeIDStr)
 			schedulers.DeleteStoreMetrics(storeIDStr)

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gogo/protobuf/proto"
 	"go.etcd.io/etcd/api/v3/mvccpb"
@@ -28,6 +29,7 @@ import (
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/schedulers"
@@ -45,6 +47,13 @@ type Watcher struct {
 	etcdClient   *clientv3.Client
 	basicCluster *core.BasicCluster
 	storeWatcher *etcdutil.LoopWatcher
+
+	// onStoreTombstoned is late-bound via SetOnStoreTombstoned once the parent
+	// Cluster (which owns hotStat and the scheduling-server-only metrics that this
+	// package can't import without a cycle) finishes construction. The watcher
+	// itself starts watching before that point, so it's read through an atomic
+	// pointer to stay safe against a store event racing the setup.
+	onStoreTombstoned atomic.Pointer[func(storeID uint64)]
 }
 
 // NewWatcher creates a new watcher to watch the meta change from PD.
@@ -90,7 +99,10 @@ func (w *Watcher) initializeStoreWatcher() error {
 			filter.DeleteStoreMetrics(storeIDStr)
 			hbstream.DeleteStoreMetrics(storeIDStr)
 			schedulers.DeleteStoreMetrics(storeIDStr)
-			// TODO: remove hot stats
+			schedule.DeleteStoreMetrics(storeIDStr)
+			if fn := w.onStoreTombstoned.Load(); fn != nil {
+				(*fn)(store.GetId())
+			}
 		}
 
 		return nil
@@ -103,7 +115,15 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 		origin := w.basicCluster.GetStore(storeID)
 		if origin != nil {
+			storeIDStr := strconv.FormatUint(storeID, 10)
 			statistics.DeleteClusterStatusMetrics(origin)
+			filter.DeleteStoreMetrics(storeIDStr)
+			hbstream.DeleteStoreMetrics(storeIDStr)
+			schedulers.DeleteStoreMetrics(storeIDStr)
+			schedule.DeleteStoreMetrics(storeIDStr)
+			if fn := w.onStoreTombstoned.Load(); fn != nil {
+				(*fn)(storeID)
+			}
 			w.basicCluster.DeleteStore(origin)
 			log.Info("delete store meta", zap.Uint64("store-id", storeID))
 		}
@@ -122,6 +142,22 @@ func (w *Watcher) initializeStoreWatcher() error {
 	)
 	w.storeWatcher.StartWatchLoop()
 	return w.storeWatcher.WaitLoad()
+}
+
+// SetOnStoreTombstoned sets the callback invoked (at least once) when a store
+// transitions to tombstone, for cleanup that only the parent Cluster can do
+// without an import cycle (removing rolling hot stats, resetting the
+// scheduling-server-owned heartbeat metrics). NewWatcher's initial load runs
+// before the caller has a chance to install this callback, so a store already
+// tombstoned at startup would otherwise never get it invoked; reconcile against
+// whatever the watcher has already loaded here to close that gap.
+func (w *Watcher) SetOnStoreTombstoned(fn func(storeID uint64)) {
+	w.onStoreTombstoned.Store(&fn)
+	for _, store := range w.basicCluster.GetStores() {
+		if store.IsRemoved() {
+			fn(store.GetID())
+		}
+	}
 }
 
 // Close closes the watcher.

--- a/pkg/mcs/scheduling/server/meta/watcher.go
+++ b/pkg/mcs/scheduling/server/meta/watcher.go
@@ -28,6 +28,9 @@ import (
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/schedule/filter"
+	"github.com/tikv/pd/pkg/schedule/hbstream"
+	"github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/utils/etcdutil"
 	"github.com/tikv/pd/pkg/utils/keypath"
@@ -82,7 +85,11 @@ func (w *Watcher) initializeStoreWatcher() error {
 		}
 
 		if store.GetNodeState() == metapb.NodeState_Removed {
-			statistics.ResetStoreStatistics(store.GetAddress(), strconv.FormatUint(store.GetId(), 10))
+			storeIDStr := strconv.FormatUint(store.GetId(), 10)
+			statistics.ResetStoreStatistics(store.GetAddress(), storeIDStr)
+			filter.DeleteStoreMetrics(storeIDStr)
+			hbstream.DeleteStoreMetrics(storeIDStr)
+			schedulers.DeleteStoreMetrics(storeIDStr)
 			// TODO: remove hot stats
 		}
 

--- a/pkg/mcs/scheduling/server/metrics.go
+++ b/pkg/mcs/scheduling/server/metrics.go
@@ -96,8 +96,12 @@ func init() {
 }
 
 // DeleteStoreMetrics deletes the per-store heartbeat/bucket metrics of a store.
-func DeleteStoreMetrics(storeAddress, id string) {
-	labels := prometheus.Labels{"address": storeAddress, "store": id}
+// Matches on the store label alone, not address: PD allows an existing store ID to
+// change address (e.g. after a TiKV restart with a new IP), so requiring the current
+// address to match as well would permanently leak any series recorded under a
+// previous address.
+func DeleteStoreMetrics(id string) {
+	labels := prometheus.Labels{"store": id}
 	storeHeartbeatHandleDuration.DeletePartialMatch(labels)
 	storeHeartbeatCounter.DeletePartialMatch(labels)
 	regionHeartbeatHandleDuration.DeletePartialMatch(labels)

--- a/pkg/mcs/scheduling/server/metrics.go
+++ b/pkg/mcs/scheduling/server/metrics.go
@@ -111,12 +111,13 @@ func DeleteStoreMetrics(id string) {
 	regionBucketsReportInterval.DeletePartialMatch(labels)
 }
 
-// ResetMetrics resets the per-store heartbeat/bucket metrics declared in this
-// file. DeleteStoreMetrics only ever removes one store's series at a time, so
-// on a primary handoff or cluster shutdown it can't be used to clear every
-// store still known to the outgoing Cluster instance; this wipes the vectors
-// wholesale instead, the same way the other packages' ResetXxxMetrics do.
-func ResetMetrics() {
+// ResetStoreMetrics resets the per-store heartbeat/bucket metrics declared in
+// this file. DeleteStoreMetrics only ever removes one store's series at a
+// time, so on a primary handoff or cluster shutdown it can't be used to
+// clear every store still known to the outgoing Cluster instance; this wipes
+// the vectors wholesale instead, the same way the other packages'
+// ResetXxxMetrics do.
+func ResetStoreMetrics() {
 	storeHeartbeatHandleDuration.Reset()
 	storeHeartbeatCounter.Reset()
 	regionHeartbeatHandleDuration.Reset()

--- a/pkg/mcs/scheduling/server/metrics.go
+++ b/pkg/mcs/scheduling/server/metrics.go
@@ -110,3 +110,18 @@ func DeleteStoreMetrics(id string) {
 	regionBucketsCounter.DeletePartialMatch(labels)
 	regionBucketsReportInterval.DeletePartialMatch(labels)
 }
+
+// ResetMetrics resets the per-store heartbeat/bucket metrics declared in this
+// file. DeleteStoreMetrics only ever removes one store's series at a time, so
+// on a primary handoff or cluster shutdown it can't be used to clear every
+// store still known to the outgoing Cluster instance; this wipes the vectors
+// wholesale instead, the same way the other packages' ResetXxxMetrics do.
+func ResetMetrics() {
+	storeHeartbeatHandleDuration.Reset()
+	storeHeartbeatCounter.Reset()
+	regionHeartbeatHandleDuration.Reset()
+	regionHeartbeatCounter.Reset()
+	regionBucketsHandleDuration.Reset()
+	regionBucketsCounter.Reset()
+	regionBucketsReportInterval.Reset()
+}

--- a/pkg/mcs/scheduling/server/metrics.go
+++ b/pkg/mcs/scheduling/server/metrics.go
@@ -94,3 +94,15 @@ func init() {
 	prometheus.MustRegister(regionBucketsCounter)
 	prometheus.MustRegister(regionBucketsReportInterval)
 }
+
+// DeleteStoreMetrics deletes the per-store heartbeat/bucket metrics of a store.
+func DeleteStoreMetrics(storeAddress, id string) {
+	labels := prometheus.Labels{"address": storeAddress, "store": id}
+	storeHeartbeatHandleDuration.DeletePartialMatch(labels)
+	storeHeartbeatCounter.DeletePartialMatch(labels)
+	regionHeartbeatHandleDuration.DeletePartialMatch(labels)
+	regionHeartbeatCounter.DeletePartialMatch(labels)
+	regionBucketsHandleDuration.DeletePartialMatch(labels)
+	regionBucketsCounter.DeletePartialMatch(labels)
+	regionBucketsReportInterval.DeletePartialMatch(labels)
+}

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -570,6 +570,15 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 				schedulers.HotPendingSum.DeleteLabelValues(storeLabel, rwTy.String(), utils.DimToString(dim))
 			})
 		}
+
+		// stores is a snapshot taken before this loop; if s was fully removed
+		// concurrently, this write can recreate a series DeleteStoreMetrics
+		// already deleted for it, with no later event able to find and remove
+		// it again. Re-checking and redoing the cleanup here closes that race
+		// the same way the per-store statistics collection loop does.
+		if cluster.GetStore(storeID) == nil {
+			DeleteStoreMetrics(storeLabel)
+		}
 	}
 }
 

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -572,13 +572,16 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 		}
 
 		// stores is a snapshot taken before this loop; if s was buried or fully
-		// removed concurrently, this write can recreate a series
-		// DeleteStoreMetrics already deleted for it. Unlike clusterStatusGauge's
-		// self-healing tombstone fields, hot-spot activity for a tombstoned
-		// store has no legitimate reason to keep being published, so check
-		// IsRemoved() here too, not just full removal.
-		if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
-			DeleteStoreMetrics(storeLabel)
+		// removed concurrently, the writes above can recreate a series
+		// DeleteStoreMetrics already deleted for it. DeleteStoreMetrics is a
+		// DeletePartialMatch full-vector scan, so only pay for it when this
+		// iteration's own s was still live: once a snapshot correctly shows
+		// IsRemoved(), a tombstoned store sitting in GetStores() for up to 30
+		// days doesn't cost a scan on every tick.
+		if !s.IsRemoved() {
+			if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
+				DeleteStoreMetrics(storeLabel)
+			}
 		}
 	}
 }

--- a/pkg/schedule/coordinator.go
+++ b/pkg/schedule/coordinator.go
@@ -571,12 +571,13 @@ func collectHotMetrics(cluster sche.ClusterInformer, stores []*core.StoreInfo, t
 			})
 		}
 
-		// stores is a snapshot taken before this loop; if s was fully removed
-		// concurrently, this write can recreate a series DeleteStoreMetrics
-		// already deleted for it, with no later event able to find and remove
-		// it again. Re-checking and redoing the cleanup here closes that race
-		// the same way the per-store statistics collection loop does.
-		if cluster.GetStore(storeID) == nil {
+		// stores is a snapshot taken before this loop; if s was buried or fully
+		// removed concurrently, this write can recreate a series
+		// DeleteStoreMetrics already deleted for it. Unlike clusterStatusGauge's
+		// self-healing tombstone fields, hot-spot activity for a tombstoned
+		// store has no legitimate reason to keep being published, so check
+		// IsRemoved() here too, not just full removal.
+		if store := cluster.GetStore(storeID); store == nil || store.IsRemoved() {
 			DeleteStoreMetrics(storeLabel)
 		}
 	}

--- a/pkg/schedule/filter/counter.go
+++ b/pkg/schedule/filter/counter.go
@@ -16,6 +16,8 @@ package filter
 
 import (
 	"strconv"
+
+	"github.com/tikv/pd/pkg/core"
 )
 
 type action int
@@ -143,14 +145,25 @@ func (c *Counter) inc(action action, filterType filterType, storeID uint64) {
 	c.counter[action][filterType][storeID]++
 }
 
-// Flush flushes the counter to the metrics.
-func (c *Counter) Flush() {
+// Flush flushes the counter to the metrics. storeInformer is used to drop
+// counts for a store that was tombstoned after being counted but before this
+// flush: inc() only sees the store's state at selection time, so without this
+// re-check a store buried in between would have its just-deleted series
+// recreated here. It may be nil (e.g. in tests), in which case no re-check is
+// performed.
+func (c *Counter) Flush(storeInformer core.StoreSetInformer) {
 	for i, actions := range c.counter {
 		actionType := action(i)
 		for j, counters := range actions {
 			filterName := filterType(j).String()
 			for storeID, value := range counters {
 				if value > 0 {
+					counters[storeID] = 0
+					if storeInformer != nil {
+						if store := storeInformer.GetStore(storeID); store == nil || store.IsRemoved() {
+							continue
+						}
+					}
 					storeIDStr := strconv.FormatUint(storeID, 10)
 					switch actionType {
 					case source:
@@ -158,7 +171,6 @@ func (c *Counter) Flush() {
 					case target:
 						filterTargetCounter.WithLabelValues(c.scope, filterName, storeIDStr).Add(float64(value))
 					}
-					counters[storeID] = 0
 				}
 			}
 		}

--- a/pkg/schedule/filter/counter_test.go
+++ b/pkg/schedule/filter/counter_test.go
@@ -48,7 +48,7 @@ func TestCounter(t *testing.T) {
 	re.Equal(1, counter.counter[source][storeStateTombstone][1])
 	// For target action, we only care about targetID (2)
 	re.Equal(1, counter.counter[target][storeStateTombstone][2])
-	counter.Flush()
+	counter.Flush(nil)
 	re.Zero(counter.counter[source][storeStateTombstone][1])
 	re.Zero(counter.counter[target][storeStateTombstone][2])
 }

--- a/pkg/schedule/filter/filters.go
+++ b/pkg/schedule/filter/filters.go
@@ -145,9 +145,12 @@ func Target(conf config.SharedConfigProvider, store *core.StoreInfo, filters []F
 	for _, filter := range filters {
 		status := filter.Target(conf, store)
 		if !status.IsOK() {
-			if status != statusStoreRemoved {
-				targetID := storeID
-				filterTargetCounter.WithLabelValues(filter.Scope(), filter.Type().String(), targetID).Inc()
+			// Check the store itself rather than this filter's own status: an
+			// earlier filter in the chain (e.g. an exclusion filter) can reject
+			// a tombstoned store for a reason other than statusStoreRemoved,
+			// which would otherwise still recreate the deleted series.
+			if !store.IsRemoved() {
+				filterTargetCounter.WithLabelValues(filter.Scope(), filter.Type().String(), storeID).Inc()
 			}
 			return false
 		}

--- a/pkg/schedule/filter/filters.go
+++ b/pkg/schedule/filter/filters.go
@@ -39,12 +39,19 @@ func SelectSourceStores(stores []*core.StoreInfo, filters []Filter, conf config.
 		return slice.AllOf(filters, func(i int) bool {
 			status := filters[i].Source(conf, s)
 			if !status.IsOK() {
-				if counter != nil {
-					counter.inc(source, filters[i].Type(), s.GetID())
-				} else {
-					sourceID := strconv.FormatUint(s.GetID(), 10)
-					// TODO: pre-allocate gauge metrics
-					filterSourceCounter.WithLabelValues(filters[i].Scope(), filters[i].Type().String(), sourceID).Inc()
+				// A tombstoned store is rejected here on every scheduling cycle for as
+				// long as it stays known, so counting it would either leak (nothing
+				// ever calls Counter.Flush again to zero it) or fight with tombstone
+				// cleanup deleting the series between Flush calls. It's not an
+				// actionable rejection reason for an operator either way.
+				if !s.IsRemoved() {
+					if counter != nil {
+						counter.inc(source, filters[i].Type(), s.GetID())
+					} else {
+						sourceID := strconv.FormatUint(s.GetID(), 10)
+						// TODO: pre-allocate gauge metrics
+						filterSourceCounter.WithLabelValues(filters[i].Scope(), filters[i].Type().String(), sourceID).Inc()
+					}
 				}
 				if collector != nil {
 					collector.Collect(plan.SetResource(s), plan.SetStatus(status))
@@ -64,10 +71,12 @@ func SelectUnavailableTargetStores(stores []*core.StoreInfo, filters []Filter, c
 		return slice.AnyOf(filters, func(i int) bool {
 			status := filters[i].Target(conf, s)
 			if !status.IsOK() {
-				if counter != nil {
-					counter.inc(target, filters[i].Type(), s.GetID())
-				} else {
-					filterTargetCounter.WithLabelValues(filters[i].Scope(), filters[i].Type().String(), targetID).Inc()
+				if !s.IsRemoved() {
+					if counter != nil {
+						counter.inc(target, filters[i].Type(), s.GetID())
+					} else {
+						filterTargetCounter.WithLabelValues(filters[i].Scope(), filters[i].Type().String(), targetID).Inc()
+					}
 				}
 
 				if collector != nil {
@@ -92,11 +101,13 @@ func SelectTargetStores(stores []*core.StoreInfo, filters []Filter, conf config.
 			filter := filters[i]
 			status := filter.Target(conf, s)
 			if !status.IsOK() {
-				if counter != nil {
-					counter.inc(target, filter.Type(), s.GetID())
-				} else {
-					targetIDStr := strconv.FormatUint(s.GetID(), 10)
-					filterTargetCounter.WithLabelValues(filter.Scope(), filter.Type().String(), targetIDStr).Inc()
+				if !s.IsRemoved() {
+					if counter != nil {
+						counter.inc(target, filter.Type(), s.GetID())
+					} else {
+						targetIDStr := strconv.FormatUint(s.GetID(), 10)
+						filterTargetCounter.WithLabelValues(filter.Scope(), filter.Type().String(), targetIDStr).Inc()
+					}
 				}
 				if collector != nil {
 					collector.Collect(plan.SetResource(s), plan.SetStatus(status))

--- a/pkg/schedule/filter/metrics.go
+++ b/pkg/schedule/filter/metrics.go
@@ -37,3 +37,9 @@ func init() {
 	prometheus.MustRegister(filterSourceCounter)
 	prometheus.MustRegister(filterTargetCounter)
 }
+
+// DeleteStoreMetrics deletes the filter metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	filterSourceCounter.DeletePartialMatch(prometheus.Labels{"source": storeID})
+	filterTargetCounter.DeletePartialMatch(prometheus.Labels{"target": storeID})
+}

--- a/pkg/schedule/filter/metrics.go
+++ b/pkg/schedule/filter/metrics.go
@@ -43,3 +43,9 @@ func DeleteStoreMetrics(storeID string) {
 	filterSourceCounter.DeletePartialMatch(prometheus.Labels{"source": storeID})
 	filterTargetCounter.DeletePartialMatch(prometheus.Labels{"target": storeID})
 }
+
+// ResetFilterMetrics resets the filter metrics.
+func ResetFilterMetrics() {
+	filterSourceCounter.Reset()
+	filterTargetCounter.Reset()
+}

--- a/pkg/schedule/hbstream/heartbeat_streams.go
+++ b/pkg/schedule/hbstream/heartbeat_streams.go
@@ -148,6 +148,10 @@ func (s *HeartbeatStreams) run() {
 				delete(s.streams, storeID)
 				continue
 			}
+			if store.IsRemoved() {
+				delete(s.streams, storeID)
+				continue
+			}
 			storeAddress := store.GetAddress()
 			if stream, ok := s.streams[storeID]; ok {
 				if err := stream.Send(msg); err != nil {
@@ -169,6 +173,10 @@ func (s *HeartbeatStreams) run() {
 				store := s.storeInformer.GetStore(storeID)
 				if store == nil {
 					log.Warn("failed to get store", zap.Uint64("store-id", storeID), errs.ZapError(errs.ErrGetSourceStore))
+					delete(s.streams, storeID)
+					continue
+				}
+				if store.IsRemoved() {
 					delete(s.streams, storeID)
 					continue
 				}

--- a/pkg/schedule/hbstream/heartbeat_streams.go
+++ b/pkg/schedule/hbstream/heartbeat_streams.go
@@ -154,7 +154,17 @@ func (s *HeartbeatStreams) run() {
 			}
 			storeAddress := store.GetAddress()
 			if stream, ok := s.streams[storeID]; ok {
-				if err := stream.Send(msg); err != nil {
+				err := stream.Send(msg)
+				// Send can block; re-fetch the store so bury/removal that
+				// happened while it was blocked doesn't recreate a series
+				// DeleteStoreMetrics already deleted for this store.
+				if store = s.storeInformer.GetStore(storeID); store == nil || store.IsRemoved() {
+					if err != nil {
+						delete(s.streams, storeID)
+					}
+					continue
+				}
+				if err != nil {
 					log.Warn("send heartbeat message fail",
 						zap.Uint64("region-id", msg.GetRegionId()), errs.ZapError(errs.ErrGRPCSend, err))
 					delete(s.streams, storeID)
@@ -182,7 +192,15 @@ func (s *HeartbeatStreams) run() {
 				}
 				storeAddress := store.GetAddress()
 				storeLabel := strconv.FormatUint(storeID, 10)
-				if err := stream.Send(keepAlive); err != nil {
+				err := stream.Send(keepAlive)
+				// Same re-fetch as the msg case above: Send can block across a bury.
+				if store = s.storeInformer.GetStore(storeID); store == nil || store.IsRemoved() {
+					if err != nil {
+						delete(s.streams, storeID)
+					}
+					continue
+				}
+				if err != nil {
 					log.Warn("send keepalive message fail, store maybe disconnected",
 						zap.Uint64("target-store-id", storeID),
 						errs.ZapError(err))

--- a/pkg/schedule/hbstream/metric.go
+++ b/pkg/schedule/hbstream/metric.go
@@ -30,3 +30,8 @@ var (
 func init() {
 	prometheus.MustRegister(heartbeatStreamCounter)
 }
+
+// DeleteStoreMetrics deletes the heartbeat stream metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	heartbeatStreamCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}

--- a/pkg/schedule/hbstream/metric.go
+++ b/pkg/schedule/hbstream/metric.go
@@ -35,3 +35,8 @@ func init() {
 func DeleteStoreMetrics(storeID string) {
 	heartbeatStreamCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
 }
+
+// ResetHeartbeatStreamMetrics resets the heartbeat stream metrics.
+func ResetHeartbeatStreamMetrics() {
+	heartbeatStreamCounter.Reset()
+}

--- a/pkg/schedule/metrics.go
+++ b/pkg/schedule/metrics.go
@@ -29,3 +29,8 @@ var (
 func init() {
 	prometheus.MustRegister(hotSpotStatusGauge)
 }
+
+// DeleteStoreMetrics deletes the hotspot status metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	hotSpotStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}

--- a/pkg/schedule/scatter/metrics.go
+++ b/pkg/schedule/scatter/metrics.go
@@ -38,3 +38,8 @@ func init() {
 	prometheus.MustRegister(scatterCounter)
 	prometheus.MustRegister(scatterDistributionCounter)
 }
+
+// DeleteStoreMetrics deletes the scatter distribution metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	scatterDistributionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}

--- a/pkg/schedule/scatter/region_scatterer.go
+++ b/pkg/schedule/scatter/region_scatterer.go
@@ -1014,25 +1014,35 @@ func (r *RegionScatterer) Put(peers map[uint64]*metapb.Peer, leaderStoreID uint6
 		}
 		if engineFilter.Target(r.cluster.GetSharedConfig(), store).IsOK() {
 			r.ordinaryEngine.selectedPeer.Put(storeID, group)
-			scatterDistributionCounter.WithLabelValues(
-				strconv.FormatUint(storeID, 10),
-				strconv.FormatBool(false),
-				core.EngineTiKV).Inc()
+			// A force-buried store can still show up in a region's existing
+			// placement; skip the metric so DeleteStoreMetrics' one-shot
+			// cleanup at bury time isn't undone by a later scatter that keeps
+			// or falls back to that placement.
+			if !store.IsRemoved() {
+				scatterDistributionCounter.WithLabelValues(
+					strconv.FormatUint(storeID, 10),
+					strconv.FormatBool(false),
+					core.EngineTiKV).Inc()
+			}
 			continue
 		}
 		engine := store.GetLabelValue(core.EngineKey)
 		ctx := r.getOrCreateSpecialEngineContext(engine)
 		ctx.selectedPeer.Put(storeID, group)
-		scatterDistributionCounter.WithLabelValues(
-			strconv.FormatUint(storeID, 10),
-			strconv.FormatBool(false),
-			engine).Inc()
+		if !store.IsRemoved() {
+			scatterDistributionCounter.WithLabelValues(
+				strconv.FormatUint(storeID, 10),
+				strconv.FormatBool(false),
+				engine).Inc()
+		}
 	}
 	r.ordinaryEngine.selectedLeader.Put(leaderStoreID, group)
-	scatterDistributionCounter.WithLabelValues(
-		strconv.FormatUint(leaderStoreID, 10),
-		strconv.FormatBool(true),
-		core.EngineTiKV).Inc()
+	if leaderStore := r.cluster.GetStore(leaderStoreID); leaderStore != nil && !leaderStore.IsRemoved() {
+		scatterDistributionCounter.WithLabelValues(
+			strconv.FormatUint(leaderStoreID, 10),
+			strconv.FormatBool(true),
+			core.EngineTiKV).Inc()
+	}
 }
 
 // applyScatterStateDelta records a local scatter state change after scattering a
@@ -1068,11 +1078,16 @@ func (r *RegionScatterer) applyScatterStateDelta(state *scatterState, region *co
 	for _, peer := range targetPeers {
 		storeID := peer.GetStoreId()
 		engine := classifyStore(storeID, &ordinaryNewStores, specialNewStores)
+		// Same as Put: don't let a force-buried store still present in the
+		// target placement recreate a series DeleteStoreMetrics already
+		// deleted at bury time.
 		if recordMetrics && engine != "" {
-			scatterDistributionCounter.WithLabelValues(
-				strconv.FormatUint(storeID, 10),
-				strconv.FormatBool(false),
-				engine).Inc()
+			if store := r.cluster.GetStore(storeID); store != nil && !store.IsRemoved() {
+				scatterDistributionCounter.WithLabelValues(
+					strconv.FormatUint(storeID, 10),
+					strconv.FormatBool(false),
+					engine).Inc()
+			}
 		}
 	}
 
@@ -1092,9 +1107,11 @@ func (r *RegionScatterer) applyScatterStateDelta(state *scatterState, region *co
 	oldLeaderStoreID := region.GetLeader().GetStoreId()
 	state.ordinaryEngine.selectedLeader.Update(group, []uint64{oldLeaderStoreID}, []uint64{targetLeader})
 	if recordMetrics {
-		scatterDistributionCounter.WithLabelValues(
-			strconv.FormatUint(targetLeader, 10),
-			strconv.FormatBool(true),
-			core.EngineTiKV).Inc()
+		if store := r.cluster.GetStore(targetLeader); store != nil && !store.IsRemoved() {
+			scatterDistributionCounter.WithLabelValues(
+				strconv.FormatUint(targetLeader, 10),
+				strconv.FormatBool(true),
+				core.EngineTiKV).Inc()
+		}
 	}
 }

--- a/pkg/schedule/schedulers/balance_leader.go
+++ b/pkg/schedule/schedulers/balance_leader.go
@@ -332,7 +332,7 @@ func (s *balanceLeaderScheduler) Schedule(cluster sche.SchedulerCluster, dryRun 
 	if dryRun {
 		collector = plan.NewCollector(basePlan)
 	}
-	defer s.filterCounter.Flush()
+	defer s.filterCounter.Flush(cluster)
 	batch := s.conf.getBatch()
 	balanceLeaderScheduleCounter.Inc()
 

--- a/pkg/schedule/schedulers/balance_range.go
+++ b/pkg/schedule/schedulers/balance_range.go
@@ -536,7 +536,7 @@ func newBalanceRangeScheduler(opController *operator.Controller, conf *balanceRa
 func (s *balanceRangeScheduler) Schedule(cluster sche.SchedulerCluster, _ bool) ([]*operator.Operator, []plan.Plan) {
 	balanceRangeCounter.Inc()
 	job := s.job
-	defer s.filterCounter.Flush()
+	defer s.filterCounter.Flush(cluster)
 
 	faultStores := filter.SelectUnavailableTargetStores(s.stores, s.filters, cluster.GetSchedulerConfig(), nil, s.filterCounter)
 	sources := filter.SelectSourceStores(s.stores, s.filters, cluster.GetSchedulerConfig(), nil, s.filterCounter)

--- a/pkg/schedule/schedulers/balance_region.go
+++ b/pkg/schedule/schedulers/balance_region.go
@@ -96,7 +96,7 @@ func (s *balanceRegionScheduler) IsScheduleAllowed(cluster sche.SchedulerCluster
 // Schedule implements the Scheduler interface.
 func (s *balanceRegionScheduler) Schedule(cluster sche.SchedulerCluster, dryRun bool) ([]*operator.Operator, []plan.Plan) {
 	basePlan := plan.NewBalanceSchedulerPlan()
-	defer s.filterCounter.Flush()
+	defer s.filterCounter.Flush(cluster)
 	var collector *plan.Collector
 	if dryRun {
 		collector = plan.NewCollector(basePlan)

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -210,6 +210,21 @@ func init() {
 	prometheus.MustRegister(balanceRangeJobGauge)
 }
 
+// DeleteStoreMetrics deletes the per-store scheduler metrics of a store.
+func DeleteStoreMetrics(storeID string) {
+	opInfluenceStatus.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	balanceWitnessCounter.DeleteLabelValues("move-witness", storeID+"-out")
+	balanceWitnessCounter.DeleteLabelValues("move-witness", storeID+"-in")
+	hotSchedulerResultCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	balanceDirectionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	hotDirectionCounter.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	evictedSlowStoreStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	evictedStoppingStoreStatusGauge.DeleteLabelValues(storeID)
+	slowStoreTriggerLimitGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	storeSlowTrendEvictedStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	balanceRangeGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+}
+
 func balanceLeaderCounterWithEvent(event string) prometheus.Counter {
 	return schedulerCounter.WithLabelValues(types.BalanceLeaderScheduler.String(), event)
 }

--- a/pkg/schedule/schedulers/metrics.go
+++ b/pkg/schedule/schedulers/metrics.go
@@ -223,6 +223,7 @@ func DeleteStoreMetrics(storeID string) {
 	slowStoreTriggerLimitGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
 	storeSlowTrendEvictedStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
 	balanceRangeGauge.DeletePartialMatch(prometheus.Labels{"store": storeID})
+	HotPendingSum.DeletePartialMatch(prometheus.Labels{"store": storeID})
 }
 
 func balanceLeaderCounterWithEvent(event string) prometheus.Counter {

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -145,6 +145,15 @@ func ResetSchedulerMetrics() {
 	schedulerStatusGauge.Reset()
 	ruleStatusGauge.Reset()
 	regionLabelStatusGauge.Reset()
+	opInfluenceStatus.Reset()
+	hotSchedulerResultCounter.Reset()
+	balanceDirectionCounter.Reset()
+	hotDirectionCounter.Reset()
+	evictedSlowStoreStatusGauge.Reset()
+	evictedStoppingStoreStatusGauge.Reset()
+	slowStoreTriggerLimitGauge.Reset()
+	storeSlowTrendEvictedStatusGauge.Reset()
+	balanceRangeGauge.Reset()
 }
 
 // AddSchedulerHandler adds the HTTP handler for a scheduler.

--- a/pkg/schedule/schedulers/scheduler_controller.go
+++ b/pkg/schedule/schedulers/scheduler_controller.go
@@ -147,6 +147,7 @@ func ResetSchedulerMetrics() {
 	regionLabelStatusGauge.Reset()
 	opInfluenceStatus.Reset()
 	hotSchedulerResultCounter.Reset()
+	balanceWitnessCounter.Reset()
 	balanceDirectionCounter.Reset()
 	hotDirectionCounter.Reset()
 	evictedSlowStoreStatusGauge.Reset()

--- a/pkg/statistics/hot_cache.go
+++ b/pkg/statistics/hot_cache.go
@@ -154,9 +154,16 @@ func (w *HotCache) GetHotPeerStat(kind utils.RWType, regionID, storeID uint64) *
 func (w *HotCache) CollectMetrics() {
 	w.CheckWriteAsync(func(cache *HotPeerCache) {
 		cache.collectMetrics()
+		// gc() is otherwise only triggered from UpdateStat, so a store removed while
+		// the cluster is idle (or was the only store still receiving updates) would
+		// never have its hotCacheStatusGauge series cleaned up. Piggyback on this
+		// periodic, activity-independent tick instead; gc() already self-throttles
+		// via topNTTL, so calling it every tick is cheap.
+		cache.gc()
 	})
 	w.CheckReadAsync(func(cache *HotPeerCache) {
 		cache.collectMetrics()
+		cache.gc()
 	})
 }
 

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -549,10 +549,16 @@ func (f *HotPeerCache) gc() {
 		return
 	}
 	f.lastGCTime = time.Now()
-	// remove tombstone stores
+	// remove tombstone stores. GetStores() still returns a tombstoned store
+	// until it's fully removed, so treat IsRemoved() the same as absent here
+	// -- nothing writes region heartbeats for it anymore, so there's no
+	// reason to wait for full removal before cleaning it up.
 	stores := make(map[uint64]struct{})
-	for _, storeID := range f.cluster.GetStores() {
-		stores[storeID.GetID()] = struct{}{}
+	for _, store := range f.cluster.GetStores() {
+		if store.IsRemoved() {
+			continue
+		}
+		stores[store.GetID()] = struct{}{}
 	}
 	// calcHotThresholds can populate thresholdsOfStore for a store that never becomes
 	// hot enough to enter peersOfStore, so peersOfStore alone can miss it; check the

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -560,6 +560,7 @@ func (f *HotPeerCache) gc() {
 			delete(f.regionsOfStore, storeID)
 			delete(f.thresholdsOfStore, storeID)
 			delete(f.metrics, storeID)
+			hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(storeID), "type": f.kind.String()})
 		}
 	}
 	// remove expired items

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -177,6 +177,15 @@ func (f *HotPeerCache) CheckPeerFlow(region *core.RegionInfo, peers []*metapb.Pe
 	stats := make([]*HotPeerStat, 0, len(peers))
 	for _, peer := range peers {
 		storeID := peer.GetStoreId()
+		// A tombstoned store can still show up as a peer here: the leader reporting
+		// this region may not have caught up with a raft config change removing it
+		// yet. Skip it so gc() cleaning up its entries at bury time doesn't get
+		// undone by the very next heartbeat from this region's (live) leader. A
+		// store the cluster doesn't know about yet is a different case (e.g. a
+		// target store for an in-flight add-peer) and isn't skipped here.
+		if store := f.cluster.GetStore(storeID); store != nil && store.IsRemoved() {
+			continue
+		}
 		oldItem := f.getOldHotPeerStat(regionID, storeID)
 
 		// check whether the peer is allowed to be inherited

--- a/pkg/statistics/hot_peer_cache.go
+++ b/pkg/statistics/hot_peer_cache.go
@@ -554,14 +554,26 @@ func (f *HotPeerCache) gc() {
 	for _, storeID := range f.cluster.GetStores() {
 		stores[storeID.GetID()] = struct{}{}
 	}
+	// calcHotThresholds can populate thresholdsOfStore for a store that never becomes
+	// hot enough to enter peersOfStore, so peersOfStore alone can miss it; check the
+	// union of both.
+	removed := make(map[uint64]struct{})
 	for storeID := range f.peersOfStore {
 		if _, ok := stores[storeID]; !ok {
-			delete(f.peersOfStore, storeID)
-			delete(f.regionsOfStore, storeID)
-			delete(f.thresholdsOfStore, storeID)
-			delete(f.metrics, storeID)
-			hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(storeID), "type": f.kind.String()})
+			removed[storeID] = struct{}{}
 		}
+	}
+	for storeID := range f.thresholdsOfStore {
+		if _, ok := stores[storeID]; !ok {
+			removed[storeID] = struct{}{}
+		}
+	}
+	for storeID := range removed {
+		delete(f.peersOfStore, storeID)
+		delete(f.regionsOfStore, storeID)
+		delete(f.thresholdsOfStore, storeID)
+		delete(f.metrics, storeID)
+		hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(storeID), "type": f.kind.String()})
 	}
 	// remove expired items
 	for _, peers := range f.peersOfStore {

--- a/pkg/statistics/hot_peer_cache_test.go
+++ b/pkg/statistics/hot_peer_cache_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -822,16 +823,24 @@ func TestRemoveExpireItems(t *testing.T) {
 	re.NotEmpty(cache.storesOfRegion[region2.GetID()])
 	time.Sleep(cache.topNTTL)
 	// case2: remove items when the store is not exist
-	re.NotNil(cache.peersOfStore[region1.GetLeader().GetStoreId()])
-	re.NotNil(cache.peersOfStore[region2.GetLeader().GetStoreId()])
+	store1ID := region1.GetLeader().GetStoreId()
+	store2ID := region2.GetLeader().GetStoreId()
+	re.NotNil(cache.peersOfStore[store1ID])
+	re.NotNil(cache.peersOfStore[store2ID])
+	// the hotcache status gauge should be populated for the removed stores before gc.
+	re.NotZero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store1ID), cache.kind.String())))
+	re.NotZero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store2ID), cache.kind.String())))
 	cluster.ResetStores()
 	re.Empty(cluster.GetStores())
 	region3, err := buildRegion(cluster, utils.Write, 3, 10)
 	re.NoError(err)
 	checkAndUpdate(re, cache, region3)
-	re.Nil(cache.peersOfStore[region1.GetLeader().GetStoreId()])
-	re.Nil(cache.peersOfStore[region2.GetLeader().GetStoreId()])
+	re.Nil(cache.peersOfStore[store1ID])
+	re.Nil(cache.peersOfStore[store2ID])
 	re.NotEmpty(cache.regionsOfStore[region3.GetLeader().GetStoreId()])
+	// gc should also delete the hotcache status gauge series of the removed stores, not just the in-memory map entries.
+	re.Zero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store1ID), cache.kind.String())))
+	re.Zero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store2ID), cache.kind.String())))
 }
 
 func TestDifferentReportInterval(t *testing.T) {

--- a/pkg/statistics/hot_peer_cache_test.go
+++ b/pkg/statistics/hot_peer_cache_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
@@ -838,9 +839,13 @@ func TestRemoveExpireItems(t *testing.T) {
 	re.Nil(cache.peersOfStore[store1ID])
 	re.Nil(cache.peersOfStore[store2ID])
 	re.NotEmpty(cache.regionsOfStore[region3.GetLeader().GetStoreId()])
-	// gc should also delete the hotcache status gauge series of the removed stores, not just the in-memory map entries.
-	re.Zero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store1ID), cache.kind.String())))
-	re.Zero(testutil.ToFloat64(hotCacheStatusGauge.WithLabelValues("add_item", storeTag(store2ID), cache.kind.String())))
+	// gc should also delete the hotcache status gauge series of the removed stores, not
+	// just the in-memory map entries. DeletePartialMatch returns how many series it
+	// found and removed, so a zero return proves nothing is left -- unlike checking
+	// WithLabelValues' value, which would recreate a fresh (zero-valued) series on
+	// every call regardless of whether gc() actually deleted the old one.
+	re.Zero(hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(store1ID), "type": cache.kind.String()}))
+	re.Zero(hotCacheStatusGauge.DeletePartialMatch(prometheus.Labels{"store": storeTag(store2ID), "type": cache.kind.String()}))
 }
 
 func TestDifferentReportInterval(t *testing.T) {

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -292,8 +290,12 @@ func (s *storeStatistics) collect() {
 }
 
 // ResetStoreStatistics resets the metrics of store.
-func ResetStoreStatistics(storeAddress string, id string) {
-	storeStatusGauge.DeletePartialMatch(prometheus.Labels{"address": storeAddress, "store": id})
+// Matches on the store label alone, not address: PD allows an existing store ID to
+// change address (e.g. after a TiKV restart with a new IP), so requiring the current
+// address to match as well would permanently leak any series recorded under a
+// previous address.
+func ResetStoreStatistics(id string) {
+	storeStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
 	clusterStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
 }
 

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"
@@ -291,36 +292,7 @@ func (s *storeStatistics) collect() {
 
 // ResetStoreStatistics resets the metrics of store.
 func ResetStoreStatistics(storeAddress string, id string) {
-	metrics := []string{
-		"region_score",
-		"leader_score",
-		"region_size",
-		"region_count",
-		"leader_size",
-		"leader_count",
-		"witness_count",
-		"learner_count",
-		"store_available",
-		"store_used",
-		"store_capacity",
-		"store_write_rate_bytes",
-		"store_read_rate_bytes",
-		"store_write_rate_keys",
-		"store_read_rate_keys",
-		"store_write_query_rate",
-		"store_read_query_rate",
-		"store_read_cpu_usage",
-		"store_read_cpu_usage_instant",
-		"store_regions_write_rate_bytes",
-		"store_regions_write_rate_keys",
-		"store_slow_trend_cause_value",
-		"store_slow_trend_cause_rate",
-		"store_slow_trend_result_value",
-		"store_slow_trend_result_rate",
-	}
-	for _, m := range metrics {
-		storeStatusGauge.DeleteLabelValues(storeAddress, id, m)
-	}
+	storeStatusGauge.DeletePartialMatch(prometheus.Labels{"address": storeAddress, "store": id})
 	clusterStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
 }
 

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/core/constant"

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -315,8 +313,14 @@ func (s *storeStatistics) collect() {
 // previous address.
 func ResetStoreStatistics(id string) {
 	storeStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
+	// clusterStatusGauge's complete label tuples are bounded by the two
+	// possible core.StoreInfo.Engine() outputs, so an exact DeleteLabelValues
+	// per (type, engine) is enough to cover every series for this store --
+	// unlike DeletePartialMatch, it doesn't lock and scan the whole vector,
+	// which matters when many stores are tombstoned around the same time.
 	for _, m := range storeStats {
-		clusterStatusGauge.DeletePartialMatch(prometheus.Labels{"type": m, "store": id})
+		clusterStatusGauge.DeleteLabelValues(m, core.EngineTiKV, id)
+		clusterStatusGauge.DeleteLabelValues(m, core.EngineTiFlash, id)
 	}
 }
 

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 
 	"github.com/tikv/pd/pkg/core"
@@ -65,6 +67,23 @@ var storeStatuses = []string{
 	clusterStatusStoreServingCount,
 	clusterStatusStoreRemovingCount,
 	clusterStatusStoreRemovedCount,
+}
+
+// storeStats are the clusterStatusGauge sub-metrics that observe() stops
+// refreshing once a store is tombstoned (it returns before reaching them), so
+// they'd otherwise keep showing their last pre-tombstone value indefinitely.
+// storeStatuses above is deliberately not included here: those are refreshed
+// unconditionally on every observe() regardless of tombstone state, and
+// deleting store_tombstone_count/store_removed_count at bury time would only
+// make them vanish from dashboards until the next collection tick -- ops
+// needs to see how many stores are currently tombstoned without that gap.
+var storeStats = []string{
+	clusterStatusRegionCount,
+	clusterStatusLeaderCount,
+	clusterStatusWitnessCount,
+	clusterStatusLearnerCount,
+	clusterStatusStorageSize,
+	clusterStatusStorageCapacity,
 }
 
 type storeStatistics struct {
@@ -296,7 +315,9 @@ func (s *storeStatistics) collect() {
 // previous address.
 func ResetStoreStatistics(id string) {
 	storeStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
-	clusterStatusGauge.DeletePartialMatch(utils.SingleLabel("store", id))
+	for _, m := range storeStats {
+		clusterStatusGauge.DeletePartialMatch(prometheus.Labels{"type": m, "store": id})
+	}
 }
 
 type storeStatisticsMap struct {

--- a/pkg/statistics/store_collection.go
+++ b/pkg/statistics/store_collection.go
@@ -322,6 +322,13 @@ func ResetStoreStatistics(id string) {
 		clusterStatusGauge.DeleteLabelValues(m, core.EngineTiKV, id)
 		clusterStatusGauge.DeleteLabelValues(m, core.EngineTiFlash, id)
 	}
+	// mcs never cleaned StoreLimitGauge on its own: unlike the classic path's
+	// RemoveStoreLimit, the mcs scheduling service has no store-limit config
+	// of its own to persist a removal for. Deleting it here, alongside
+	// everything else this function already covers, closes that gap for
+	// both classic (redundant with RemoveStoreLimit, harmless) and mcs.
+	StoreLimitGauge.DeleteLabelValues(id, "add-peer")
+	StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
 }
 
 type storeStatisticsMap struct {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1298,6 +1298,9 @@ func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) error {
 		core.RegionCacheMissCounter.Inc()
 		return errors.Errorf("region %v not found", buckets.GetRegionId())
 	}
+	if store := c.GetStore(region.GetLeader().GetStoreId()); store != nil && store.IsRemoved() {
+		return nil
+	}
 	// use CAS to update the bucket information.
 	// the two request(A:3,B:2) get the same region and need to update the buckets.
 	// the A will pass the check and set the version to 3, the B will fail because the region.bucket has changed.

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -63,6 +63,8 @@ import (
 	"github.com/tikv/pd/pkg/schedule/keyrange"
 	"github.com/tikv/pd/pkg/schedule/labeler"
 	"github.com/tikv/pd/pkg/schedule/placement"
+	"github.com/tikv/pd/pkg/schedule/scatter"
+	"github.com/tikv/pd/pkg/schedule/schedulers"
 	"github.com/tikv/pd/pkg/statistics"
 	"github.com/tikv/pd/pkg/statistics/utils"
 	"github.com/tikv/pd/pkg/storage"
@@ -2204,9 +2206,12 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 	}
 	storeIDStr := strconv.FormatUint(store.GetID(), 10)
 	statistics.DeleteClusterStatusMetrics(store)
+	statistics.ResetStoreStatistics(storeIDStr)
 	filter.DeleteStoreMetrics(storeIDStr)
 	hbstream.DeleteStoreMetrics(storeIDStr)
 	schedule.DeleteStoreMetrics(storeIDStr)
+	schedulers.DeleteStoreMetrics(storeIDStr)
+	scatter.DeleteStoreMetrics(storeIDStr)
 	if fn := c.onStoreBuried.Load(); fn != nil {
 		(*fn)(storeIDStr)
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1291,15 +1291,18 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 	return nil
 }
 
-// processRegionBuckets update the bucket information.
-func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) error {
+// processRegionBuckets updates the bucket information. The first return value
+// reports whether the report was actually applied, so callers don't enqueue
+// hot-bucket work for a report that was ignored because its leader is
+// tombstoned.
+func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) (bool, error) {
 	region := c.GetRegion(buckets.GetRegionId())
 	if region == nil {
 		core.RegionCacheMissCounter.Inc()
-		return errors.Errorf("region %v not found", buckets.GetRegionId())
+		return false, errors.Errorf("region %v not found", buckets.GetRegionId())
 	}
 	if store := c.GetStore(region.GetLeader().GetStoreId()); store != nil && store.IsRemoved() {
-		return nil
+		return false, nil
 	}
 	// use CAS to update the bucket information.
 	// the two request(A:3,B:2) get the same region and need to update the buckets.
@@ -1308,11 +1311,11 @@ func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) error {
 	for range 3 {
 		if success := region.CompareAndSetReportBuckets(buckets); success {
 			core.UpdateSuccessCounter.Inc()
-			return nil
+			return true, nil
 		}
 	}
 	core.UpdateFailedCounter.Inc()
-	return nil
+	return true, nil
 }
 
 var regionGuide = core.GenerateRegionGuideFunc(true)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1793,6 +1793,7 @@ func (c *RaftCluster) BuryStoreLocked(storeID uint64, forceBury bool) error {
 		filter.DeleteStoreMetrics(storeIDStr)
 		hbstream.DeleteStoreMetrics(storeIDStr)
 		schedule.DeleteStoreMetrics(storeIDStr)
+		storeTriggerNetworkSlowEvict.DeleteLabelValues(storeIDStr)
 		if !c.IsServiceIndependent(constant.SchedulingServiceName) {
 			c.removeStoreStatistics(storeID)
 		}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2212,6 +2212,7 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 	schedule.DeleteStoreMetrics(storeIDStr)
 	schedulers.DeleteStoreMetrics(storeIDStr)
 	scatter.DeleteStoreMetrics(storeIDStr)
+	storeTriggerNetworkSlowEvict.DeleteLabelValues(storeIDStr)
 	if fn := c.onStoreBuried.Load(); fn != nil {
 		(*fn)(storeIDStr)
 	}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1315,7 +1315,7 @@ func (c *RaftCluster) processRegionBuckets(buckets *metapb.Buckets) (bool, error
 		}
 	}
 	core.UpdateFailedCounter.Inc()
-	return true, nil
+	return false, nil
 }
 
 var regionGuide = core.GenerateRegionGuideFunc(true)

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1768,9 +1768,8 @@ func (c *RaftCluster) BuryStoreLocked(storeID uint64, forceBury bool) error {
 		// clean up the residual information.
 		c.prevStoreLimit.Delete(storeID)
 		c.RemoveStoreLimit(storeID)
-		addr := store.GetAddress()
 		storeIDStr := strconv.FormatUint(storeID, 10)
-		statistics.ResetStoreStatistics(addr, storeIDStr)
+		statistics.ResetStoreStatistics(storeIDStr)
 		filter.DeleteStoreMetrics(storeIDStr)
 		hbstream.DeleteStoreMetrics(storeIDStr)
 		if !c.IsServiceIndependent(constant.SchedulingServiceName) {

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1771,6 +1771,8 @@ func (c *RaftCluster) BuryStoreLocked(storeID uint64, forceBury bool) error {
 		addr := store.GetAddress()
 		storeIDStr := strconv.FormatUint(storeID, 10)
 		statistics.ResetStoreStatistics(addr, storeIDStr)
+		filter.DeleteStoreMetrics(storeIDStr)
+		hbstream.DeleteStoreMetrics(storeIDStr)
 		if !c.IsServiceIndependent(constant.SchedulingServiceName) {
 			c.removeStoreStatistics(storeID)
 		}

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -2204,6 +2204,14 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 			return err
 		}
 	}
+	// Remove the store before the metric cleanup below, not after: a metrics
+	// collection tick observing this store concurrently re-checks GetStore
+	// right after it writes and undoes its own write if the store is already
+	// gone. If DeleteStore ran last, that re-check could still see the
+	// (already fully cleaned) tombstone entry and skip its own cleanup,
+	// leaving a series this cleanup just deleted with no later event able to
+	// find and remove it again.
+	c.DeleteStore(store)
 	storeIDStr := strconv.FormatUint(store.GetID(), 10)
 	statistics.DeleteClusterStatusMetrics(store)
 	statistics.ResetStoreStatistics(storeIDStr)
@@ -2216,7 +2224,6 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 	if fn := c.onStoreBuried.Load(); fn != nil {
 		(*fn)(storeIDStr)
 	}
-	c.DeleteStore(store)
 	return nil
 }
 

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -218,9 +218,7 @@ type RaftCluster struct {
 	onStoreBuried atomic.Pointer[func(storeID string)]
 }
 
-// SetOnStoreBuried sets the callback invoked when a store is buried
-// (transitions to tombstone), for per-store cleanup owned by a package that
-// server/cluster cannot import.
+// SetOnStoreBuried sets the callback invoked when a store is buried.
 func (c *RaftCluster) SetOnStoreBuried(fn func(storeID string)) {
 	c.onStoreBuried.Store(&fn)
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -55,6 +55,7 @@ import (
 	"github.com/tikv/pd/pkg/progress"
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/replication"
+	"github.com/tikv/pd/pkg/schedule"
 	"github.com/tikv/pd/pkg/schedule/affinity"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/schedule/filter"
@@ -207,6 +208,21 @@ type RaftCluster struct {
 	syncRegionRunner ratelimit.Runner
 
 	stopGCStateManager func()
+
+	// onStoreBuried is an optional callback invoked (at least once) with a store's
+	// ID right after it's buried, for cleanup that only the owning package can do
+	// without an import cycle -- e.g. the server package's own heartbeat/bucket
+	// metrics, which server/cluster cannot import directly. Set via
+	// SetOnStoreBuried; read through an atomic pointer since BuryStoreLocked can run
+	// before the owner has had a chance to install it.
+	onStoreBuried atomic.Pointer[func(storeID string)]
+}
+
+// SetOnStoreBuried sets the callback invoked when a store is buried
+// (transitions to tombstone), for per-store cleanup owned by a package that
+// server/cluster cannot import.
+func (c *RaftCluster) SetOnStoreBuried(fn func(storeID string)) {
+	c.onStoreBuried.Store(&fn)
 }
 
 // Status saves some state information.
@@ -1772,8 +1788,12 @@ func (c *RaftCluster) BuryStoreLocked(storeID uint64, forceBury bool) error {
 		statistics.ResetStoreStatistics(storeIDStr)
 		filter.DeleteStoreMetrics(storeIDStr)
 		hbstream.DeleteStoreMetrics(storeIDStr)
+		schedule.DeleteStoreMetrics(storeIDStr)
 		if !c.IsServiceIndependent(constant.SchedulingServiceName) {
 			c.removeStoreStatistics(storeID)
+		}
+		if fn := c.onStoreBuried.Load(); fn != nil {
+			(*fn)(storeIDStr)
 		}
 	}
 	return err
@@ -2177,7 +2197,14 @@ func (c *RaftCluster) deleteStore(store *core.StoreInfo) error {
 			return err
 		}
 	}
+	storeIDStr := strconv.FormatUint(store.GetID(), 10)
 	statistics.DeleteClusterStatusMetrics(store)
+	filter.DeleteStoreMetrics(storeIDStr)
+	hbstream.DeleteStoreMetrics(storeIDStr)
+	schedule.DeleteStoreMetrics(storeIDStr)
+	if fn := c.onStoreBuried.Load(); fn != nil {
+		(*fn)(storeIDStr)
+	}
 	c.DeleteStore(store)
 	return nil
 }

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -874,7 +874,8 @@ func TestBucketCompatibility(t *testing.T) {
 		Version:  3,
 		Keys:     [][]byte{{'a'}, {'d'}},
 	}
-	re.NoError(cluster.processRegionBuckets(bucket2))
+	_, err = cluster.processRegionBuckets(bucket2)
+	re.NoError(err)
 	re.Equal(bucket2, cluster.GetRegion(1).GetBuckets())
 
 	region3 := region2.Clone(core.WithIncVersion())
@@ -895,7 +896,8 @@ func TestBucketCompatibility(t *testing.T) {
 		Version:  5,
 		Keys:     [][]byte{{'a'}, {'e'}},
 	}
-	re.NoError(cluster.processRegionBuckets(bucket4))
+	_, err = cluster.processRegionBuckets(bucket4)
+	re.NoError(err)
 	re.Equal(bucket3, cluster.GetRegion(1).GetBuckets())
 	re.Equal(bucket4, cluster.GetRegion(1).GetReportBuckets())
 }
@@ -1022,7 +1024,8 @@ func TestBucketHeartbeat(t *testing.T) {
 		Version:  1,
 		Keys:     [][]byte{{'1'}, {'2'}},
 	}
-	re.Error(cluster.processRegionBuckets(buckets))
+	_, err = cluster.processRegionBuckets(buckets)
+	re.Error(err)
 
 	// case2: bucket can be processed after the region update.
 	stores := newTestStores(3, "2.0.0")
@@ -1035,18 +1038,21 @@ func TestBucketHeartbeat(t *testing.T) {
 	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), regions[0].Clone()))
 	re.NoError(cluster.processRegionHeartbeat(core.ContextTODO(), regions[1].Clone()))
 	re.Nil(cluster.GetRegion(uint64(1)).GetBuckets())
-	re.NoError(cluster.processRegionBuckets(buckets))
+	_, err = cluster.processRegionBuckets(buckets)
+	re.NoError(err)
 	re.Equal(buckets, cluster.GetRegion(uint64(1)).GetBuckets())
 
 	// case3: the bucket version is same.
-	re.NoError(cluster.processRegionBuckets(buckets))
+	_, err = cluster.processRegionBuckets(buckets)
+	re.NoError(err)
 	// case4: the bucket version is changed.
 	newBuckets := &metapb.Buckets{
 		RegionId: 1,
 		Version:  3,
 		Keys:     [][]byte{{'1'}, {'2'}},
 	}
-	re.NoError(cluster.processRegionBuckets(newBuckets))
+	_, err = cluster.processRegionBuckets(newBuckets)
+	re.NoError(err)
 	re.Equal(newBuckets, cluster.GetRegion(uint64(1)).GetBuckets())
 
 	// case5: region update should inherit buckets.
@@ -1412,12 +1418,13 @@ func TestConcurrentReportBucket(t *testing.T) {
 	re.NoError(failpoint.Enable("github.com/tikv/pd/pkg/core/concurrentBucketHeartbeat", "return(true)"))
 	go func() {
 		defer wg.Done()
-		err := cluster.processRegionBuckets(bucket1)
+		_, err := cluster.processRegionBuckets(bucket1)
 		re.NoError(err)
 	}()
 	time.Sleep(100 * time.Millisecond)
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/core/concurrentBucketHeartbeat"))
-	re.NoError(cluster.processRegionBuckets(bucket2))
+	_, err = cluster.processRegionBuckets(bucket2)
+	re.NoError(err)
 	wg.Wait()
 	re.Equal(bucket1, cluster.GetRegion(1).GetBuckets())
 }

--- a/server/cluster/cluster_worker.go
+++ b/server/cluster/cluster_worker.go
@@ -276,10 +276,11 @@ func (*RaftCluster) HandleBatchReportSplit(request *pdpb.ReportBatchSplitRequest
 
 // HandleRegionBuckets processes region buckets from client
 func (c *RaftCluster) HandleRegionBuckets(b *metapb.Buckets) error {
-	if err := c.processRegionBuckets(b); err != nil {
+	applied, err := c.processRegionBuckets(b)
+	if err != nil {
 		return err
 	}
-	if !c.IsServiceIndependent(constant.SchedulingServiceName) {
+	if applied && !c.IsServiceIndependent(constant.SchedulingServiceName) {
 		c.hotStat.CheckAsync(buckets.NewCheckPeerTask(b))
 	}
 	return nil

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tikv/pd/pkg/schedule/checker"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	sche "github.com/tikv/pd/pkg/schedule/core"
+	"github.com/tikv/pd/pkg/schedule/filter"
 	"github.com/tikv/pd/pkg/schedule/hbstream"
 	"github.com/tikv/pd/pkg/schedule/operator"
 	"github.com/tikv/pd/pkg/schedule/placement"
@@ -185,6 +186,19 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, sc.hotStat.StoresStats)
+		if s.IsRemoved() {
+			// Unlike the other per-store cleanup called once from BuryStoreLocked, filter
+			// and heartbeat-stream metrics for a tombstoned store keep getting rewritten by
+			// unrelated, ongoing activity for as long as the store stays known: every
+			// scheduler's Schedule() still runs StoreStateFilter against it every cycle
+			// (that rejection is what increments the filter counters), and the heartbeat
+			// stream keepalive ticker keeps touching it as long as its stream is still
+			// bound. A one-shot delete at bury time gets undone almost immediately, so
+			// delete unconditionally here on every tick instead.
+			storeIDStr := strconv.FormatUint(s.GetID(), 10)
+			filter.DeleteStoreMetrics(storeIDStr)
+			hbstream.DeleteStoreMetrics(storeIDStr)
+		}
 	}
 	statsMap.Collect()
 	sc.coordinator.GetSchedulersController().CollectSchedulerMetrics()

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -208,7 +208,9 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 func (sc *schedulingController) removeStoreStatistics(storeID uint64) {
 	sc.hotStat.RemoveRollingStoreStats(storeID)
 	sc.slowStat.RemoveSlowStoreStatus(storeID)
-	schedulers.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
+	storeIDStr := strconv.FormatUint(storeID, 10)
+	schedulers.DeleteStoreMetrics(storeIDStr)
+	scatter.DeleteStoreMetrics(storeIDStr)
 }
 
 func (sc *schedulingController) updateStoreStatistics(storeID uint64, isSlow bool) {

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -208,8 +208,14 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 		// observe() itself stops writing as soon as it sees a tombstoned
 		// store -- so, unlike the fields above, there's no legitimate write to
 		// preserve here once the store is IsRemoved(), not just once it's
-		// gone entirely.
-		if current == nil || current.IsRemoved() {
+		// gone entirely. But storeStatusGauge's cleanup is a DeletePartialMatch
+		// full-vector scan, so only pay for it when this iteration's own s was
+		// still live (observe(s) could then have written using stale data);
+		// once a snapshot correctly shows IsRemoved(), observe() already
+		// skipped writing these fields and there's nothing to undo, so a
+		// tombstoned store sitting in GetStores() for up to 30 days doesn't
+		// cost a scan on every 10s tick.
+		if !s.IsRemoved() && (current == nil || current.IsRemoved()) {
 			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
 		}
 	}

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -61,14 +61,10 @@ type schedulingController struct {
 	running     bool
 
 	// recentlyTombstonedStores is the set of store IDs collectSchedulingMetrics saw
-	// tombstoned on its last tick. Only that method, driven by
-	// runSchedulingMetricsCollectionJob's own single-goroutine ticker, touches it, so
-	// it needs no lock. Filter counters are the only metrics that still need this:
-	// every scheduler's Schedule() keeps running StoreStateFilter against a
-	// tombstoned-but-known store every cycle, which is what increments them, so a
-	// one-shot delete at bury time gets undone almost immediately. Heartbeat-stream
-	// metrics no longer need it -- BuryStoreLocked's cleanup plus the IsRemoved
-	// check in heartbeat_streams.go's run loop stop those writes at bury time.
+	// tombstoned on its last tick, needed to catch a store that gets fully removed
+	// between two ticks so its filter counters still get one final delete. Only
+	// collectSchedulingMetrics, via runSchedulingMetricsCollectionJob's
+	// single-goroutine ticker, touches it, so it needs no lock.
 	recentlyTombstonedStores map[uint64]struct{}
 }
 
@@ -144,8 +140,10 @@ func (sc *schedulingController) runStatsBackgroundJobs() {
 	defer ticker.Stop()
 
 	for _, store := range sc.GetStores() {
-		storeID := store.GetID()
-		sc.hotStat.GetOrCreateRollingStoreStats(storeID)
+		if store.IsRemoved() {
+			continue
+		}
+		sc.hotStat.GetOrCreateRollingStoreStats(store.GetID())
 	}
 	for {
 		select {
@@ -196,13 +194,10 @@ func resetSchedulingMetrics() {
 func (sc *schedulingController) collectSchedulingMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(sc.opt)
 	stores := sc.GetStores()
-	// Unlike the other per-store cleanup called once from BuryStoreLocked, filter
-	// metrics for a tombstoned store keep getting rewritten by unrelated, ongoing
-	// activity for as long as the store stays known: every scheduler's Schedule()
-	// still runs StoreStateFilter against it every cycle, and that rejection is
-	// what increments the filter counters. A one-shot delete at bury time gets
-	// undone almost immediately, so delete unconditionally here on every tick
-	// instead.
+	// Filter counters need repeated cleanup: schedulers keep rejecting a
+	// tombstoned-but-known store via StoreStateFilter every cycle, so a one-shot
+	// delete at bury time doesn't stick. Deleting already-gone labels is a cheap
+	// no-op, so repeating it every tick is safe.
 	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
@@ -213,12 +208,9 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 		}
 	}
-	// A store that was tombstoned as of the last sweep but isn't known at all this
-	// tick was fully removed in between. The loop above only reaches stores
-	// GetStores() currently returns, so a write landing in that gap -- after the
-	// last sweep saw it tombstoned but before removal completed -- would otherwise
-	// be unreachable by any future sweep. One more delete call closes that window;
-	// it's a no-op if nothing was actually rewritten.
+	// A store fully removed between two ticks drops out of GetStores() before this
+	// sweep can catch it there; delete once more for anything recentlyTombstonedStores
+	// still remembers but current no longer has.
 	for storeID := range sc.recentlyTombstonedStores {
 		if _, stillKnown := current[storeID]; !stillKnown {
 			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -178,6 +178,8 @@ func resetSchedulingMetrics() {
 	statistics.ResetLabelStatsMetrics()
 	// reset hot cache metrics
 	statistics.ResetHotCacheStatusMetrics()
+	filter.ResetFilterMetrics()
+	hbstream.ResetHeartbeatStreamMetrics()
 }
 
 func (sc *schedulingController) collectSchedulingMetrics() {

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -59,13 +59,6 @@ type schedulingController struct {
 	hotStat     *statistics.HotStat
 	slowStat    *statistics.SlowStat
 	running     bool
-
-	// recentlyTombstonedStores is the set of store IDs collectSchedulingMetrics saw
-	// tombstoned on its last tick, needed to catch a store that gets fully removed
-	// between two ticks so its filter counters still get one final delete. Only
-	// collectSchedulingMetrics, via runSchedulingMetricsCollectionJob's
-	// single-goroutine ticker, touches it, so it needs no lock.
-	recentlyTombstonedStores map[uint64]struct{}
 }
 
 // newSchedulingController creates a new scheduling controller.
@@ -194,29 +187,10 @@ func resetSchedulingMetrics() {
 func (sc *schedulingController) collectSchedulingMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(sc.opt)
 	stores := sc.GetStores()
-	// Filter counters need repeated cleanup: schedulers keep rejecting a
-	// tombstoned-but-known store via StoreStateFilter every cycle, so a one-shot
-	// delete at bury time doesn't stick. Deleting already-gone labels is a cheap
-	// no-op, so repeating it every tick is safe.
-	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, sc.hotStat.StoresStats)
-		if s.IsRemoved() {
-			storeID := s.GetID()
-			current[storeID] = struct{}{}
-			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
-		}
 	}
-	// A store fully removed between two ticks drops out of GetStores() before this
-	// sweep can catch it there; delete once more for anything recentlyTombstonedStores
-	// still remembers but current no longer has.
-	for storeID := range sc.recentlyTombstonedStores {
-		if _, stillKnown := current[storeID]; !stillKnown {
-			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
-		}
-	}
-	sc.recentlyTombstonedStores = current
 	statsMap.Collect()
 	sc.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	sc.coordinator.CollectHotSpotMetrics()

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -191,13 +191,25 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, sc.hotStat.StoresStats)
 		// Observe/ObserveHotStat write from this snapshot unconditionally, so a
-		// concurrent final removal of s between GetStores() above and this write
-		// can have its own metric cleanup undone by it. Since final removal only
-		// happens once and never re-adds the store, re-checking right after the
-		// write and redoing the cleanup if it's now gone closes that race without
-		// needing synchronization with the removal path.
-		if sc.GetStore(s.GetID()) == nil {
+		// concurrent bury or final removal of s between GetStores() above and
+		// this write can have its own metric cleanup undone by it. Re-checking
+		// right after the write and redoing the cleanup closes that race
+		// without needing synchronization with the bury/removal path.
+		current := sc.GetStore(s.GetID())
+		// DeleteClusterStatusMetrics only covers the clusterStatusGauge fields
+		// observe() keeps refreshing unconditionally while a store stays
+		// tombstoned (store_tombstone_count and friends, self-healing by
+		// design); only clean those up once the store is gone for good, or
+		// they'd flicker off every tick during a legitimate tombstone period.
+		if current == nil {
 			statistics.DeleteClusterStatusMetrics(s)
+		}
+		// ResetStoreStatistics covers storeStatusGauge/storeStats, which
+		// observe() itself stops writing as soon as it sees a tombstoned
+		// store -- so, unlike the fields above, there's no legitimate write to
+		// preserve here once the store is IsRemoved(), not just once it's
+		// gone entirely.
+		if current == nil || current.IsRemoved() {
 			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
 		}
 	}
@@ -205,11 +217,13 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 	// statsMap.Collect() writes statistics.StoreLimitGauge from its own
 	// GetStoresLimit() snapshot, taken independently of stores above and with
 	// no cluster reference of its own to re-check against. Reuse the stores
-	// snapshot already captured here to catch and undo it for any store
-	// that's gone by now, the same way the loop above does for the other
-	// per-store metrics.
+	// snapshot already captured here to catch and undo it. Like
+	// ResetStoreStatistics above, a store limit has no legitimate reason to
+	// still be configured once the store is tombstoned (RemoveStoreLimit
+	// already clears it at bury time), so this also checks IsRemoved(), not
+	// just full removal.
 	for _, s := range stores {
-		if sc.GetStore(s.GetID()) == nil {
+		if store := sc.GetStore(s.GetID()); store == nil || store.IsRemoved() {
 			id := strconv.FormatUint(s.GetID(), 10)
 			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
 			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -202,6 +202,19 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 		}
 	}
 	statsMap.Collect()
+	// statsMap.Collect() writes statistics.StoreLimitGauge from its own
+	// GetStoresLimit() snapshot, taken independently of stores above and with
+	// no cluster reference of its own to re-check against. Reuse the stores
+	// snapshot already captured here to catch and undo it for any store
+	// that's gone by now, the same way the loop above does for the other
+	// per-store metrics.
+	for _, s := range stores {
+		if sc.GetStore(s.GetID()) == nil {
+			id := strconv.FormatUint(s.GetID(), 10)
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "add-peer")
+			statistics.StoreLimitGauge.DeleteLabelValues(id, "remove-peer")
+		}
+	}
 	sc.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	sc.coordinator.CollectHotSpotMetrics()
 	if sc.regionStats == nil {

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -190,6 +190,16 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, sc.hotStat.StoresStats)
+		// Observe/ObserveHotStat write from this snapshot unconditionally, so a
+		// concurrent final removal of s between GetStores() above and this write
+		// can have its own metric cleanup undone by it. Since final removal only
+		// happens once and never re-adds the store, re-checking right after the
+		// write and redoing the cleanup if it's now gone closes that race without
+		// needing synchronization with the removal path.
+		if sc.GetStore(s.GetID()) == nil {
+			statistics.DeleteClusterStatusMetrics(s)
+			statistics.ResetStoreStatistics(strconv.FormatUint(s.GetID(), 10))
+		}
 	}
 	statsMap.Collect()
 	sc.coordinator.GetSchedulersController().CollectSchedulerMetrics()

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -17,6 +17,7 @@ package cluster
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -202,6 +203,7 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 func (sc *schedulingController) removeStoreStatistics(storeID uint64) {
 	sc.hotStat.RemoveRollingStoreStats(storeID)
 	sc.slowStat.RemoveSlowStoreStatus(storeID)
+	schedulers.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 }
 
 func (sc *schedulingController) updateStoreStatistics(storeID uint64, isSlow bool) {

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -59,6 +59,12 @@ type schedulingController struct {
 	hotStat     *statistics.HotStat
 	slowStat    *statistics.SlowStat
 	running     bool
+
+	// recentlyTombstonedStores is the set of store IDs collectSchedulingMetrics saw
+	// tombstoned on its last tick. Only that method, driven by
+	// runSchedulingMetricsCollectionJob's own single-goroutine ticker, touches it, so
+	// it needs no lock.
+	recentlyTombstonedStores map[uint64]struct{}
 }
 
 // newSchedulingController creates a new scheduling controller.
@@ -185,23 +191,40 @@ func resetSchedulingMetrics() {
 func (sc *schedulingController) collectSchedulingMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(sc.opt)
 	stores := sc.GetStores()
+	// Unlike the other per-store cleanup called once from BuryStoreLocked, filter
+	// and heartbeat-stream metrics for a tombstoned store keep getting rewritten by
+	// unrelated, ongoing activity for as long as the store stays known: every
+	// scheduler's Schedule() still runs StoreStateFilter against it every cycle
+	// (that rejection is what increments the filter counters), and the heartbeat
+	// stream keepalive ticker keeps touching it as long as its stream is still
+	// bound. A one-shot delete at bury time gets undone almost immediately, so
+	// delete unconditionally here on every tick instead.
+	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
 		statistics.ObserveHotStat(s, sc.hotStat.StoresStats)
 		if s.IsRemoved() {
-			// Unlike the other per-store cleanup called once from BuryStoreLocked, filter
-			// and heartbeat-stream metrics for a tombstoned store keep getting rewritten by
-			// unrelated, ongoing activity for as long as the store stays known: every
-			// scheduler's Schedule() still runs StoreStateFilter against it every cycle
-			// (that rejection is what increments the filter counters), and the heartbeat
-			// stream keepalive ticker keeps touching it as long as its stream is still
-			// bound. A one-shot delete at bury time gets undone almost immediately, so
-			// delete unconditionally here on every tick instead.
-			storeIDStr := strconv.FormatUint(s.GetID(), 10)
+			storeID := s.GetID()
+			current[storeID] = struct{}{}
+			storeIDStr := strconv.FormatUint(storeID, 10)
 			filter.DeleteStoreMetrics(storeIDStr)
 			hbstream.DeleteStoreMetrics(storeIDStr)
 		}
 	}
+	// A store that was tombstoned as of the last sweep but isn't known at all this
+	// tick was fully removed in between. The loop above only reaches stores
+	// GetStores() currently returns, so a write landing in that gap -- after the
+	// last sweep saw it tombstoned but before removal completed -- would otherwise
+	// be unreachable by any future sweep. One more delete call closes that window;
+	// it's a no-op if nothing was actually rewritten.
+	for storeID := range sc.recentlyTombstonedStores {
+		if _, stillKnown := current[storeID]; !stillKnown {
+			storeIDStr := strconv.FormatUint(storeID, 10)
+			filter.DeleteStoreMetrics(storeIDStr)
+			hbstream.DeleteStoreMetrics(storeIDStr)
+		}
+	}
+	sc.recentlyTombstonedStores = current
 	statsMap.Collect()
 	sc.coordinator.GetSchedulersController().CollectSchedulerMetrics()
 	sc.coordinator.CollectHotSpotMetrics()

--- a/server/cluster/scheduling_controller.go
+++ b/server/cluster/scheduling_controller.go
@@ -63,7 +63,12 @@ type schedulingController struct {
 	// recentlyTombstonedStores is the set of store IDs collectSchedulingMetrics saw
 	// tombstoned on its last tick. Only that method, driven by
 	// runSchedulingMetricsCollectionJob's own single-goroutine ticker, touches it, so
-	// it needs no lock.
+	// it needs no lock. Filter counters are the only metrics that still need this:
+	// every scheduler's Schedule() keeps running StoreStateFilter against a
+	// tombstoned-but-known store every cycle, which is what increments them, so a
+	// one-shot delete at bury time gets undone almost immediately. Heartbeat-stream
+	// metrics no longer need it -- BuryStoreLocked's cleanup plus the IsRemoved
+	// check in heartbeat_streams.go's run loop stop those writes at bury time.
 	recentlyTombstonedStores map[uint64]struct{}
 }
 
@@ -192,13 +197,12 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 	statsMap := statistics.NewStoreStatisticsMap(sc.opt)
 	stores := sc.GetStores()
 	// Unlike the other per-store cleanup called once from BuryStoreLocked, filter
-	// and heartbeat-stream metrics for a tombstoned store keep getting rewritten by
-	// unrelated, ongoing activity for as long as the store stays known: every
-	// scheduler's Schedule() still runs StoreStateFilter against it every cycle
-	// (that rejection is what increments the filter counters), and the heartbeat
-	// stream keepalive ticker keeps touching it as long as its stream is still
-	// bound. A one-shot delete at bury time gets undone almost immediately, so
-	// delete unconditionally here on every tick instead.
+	// metrics for a tombstoned store keep getting rewritten by unrelated, ongoing
+	// activity for as long as the store stays known: every scheduler's Schedule()
+	// still runs StoreStateFilter against it every cycle, and that rejection is
+	// what increments the filter counters. A one-shot delete at bury time gets
+	// undone almost immediately, so delete unconditionally here on every tick
+	// instead.
 	current := make(map[uint64]struct{})
 	for _, s := range stores {
 		statsMap.Observe(s)
@@ -206,9 +210,7 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 		if s.IsRemoved() {
 			storeID := s.GetID()
 			current[storeID] = struct{}{}
-			storeIDStr := strconv.FormatUint(storeID, 10)
-			filter.DeleteStoreMetrics(storeIDStr)
-			hbstream.DeleteStoreMetrics(storeIDStr)
+			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 		}
 	}
 	// A store that was tombstoned as of the last sweep but isn't known at all this
@@ -219,9 +221,7 @@ func (sc *schedulingController) collectSchedulingMetrics() {
 	// it's a no-op if nothing was actually rewritten.
 	for storeID := range sc.recentlyTombstonedStores {
 		if _, stillKnown := current[storeID]; !stillKnown {
-			storeIDStr := strconv.FormatUint(storeID, 10)
-			filter.DeleteStoreMetrics(storeIDStr)
-			hbstream.DeleteStoreMetrics(storeIDStr)
+			filter.DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 		}
 	}
 	sc.recentlyTombstonedStores = current

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1189,6 +1189,8 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 			// As TiKV report buckets just after the region heartbeat, for new created region, PD may receive buckets report before the first region heartbeat is handled.
 			// So we should not return error here.
 			log.Debug("the store of the bucket in region is not found", zap.Uint64("region-id", buckets.GetRegionId()))
+		} else if store.IsRemoved() {
+			log.Debug("the store of the bucket in region is tombstone", zap.Uint64("region-id", buckets.GetRegionId()), zap.Uint64("store-id", store.GetID()))
 		} else {
 			storeLabel = strconv.FormatUint(store.GetID(), 10)
 			storeAddress = store.GetAddress()
@@ -1370,6 +1372,9 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 		store := rc.GetStore(storeID)
 		if store == nil {
 			return errors.Errorf("invalid store ID %d, not found", storeID)
+		}
+		if store.IsRemoved() {
+			return errors.Errorf("store ID %d is tombstone", storeID)
 		}
 		storeAddress := store.GetAddress()
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1374,7 +1374,8 @@ func (s *GrpcServer) RegionHeartbeat(stream pdpb.PD_RegionHeartbeatServer) error
 			return errors.Errorf("invalid store ID %d, not found", storeID)
 		}
 		if store.IsRemoved() {
-			return errors.Errorf("store ID %d is tombstone", storeID)
+			log.Debug("skip region heartbeat from tombstone store", zap.Uint64("store-id", storeID))
+			continue
 		}
 		storeAddress := store.GetAddress()
 

--- a/server/grpc_service.go
+++ b/server/grpc_service.go
@@ -1190,7 +1190,7 @@ func (s *GrpcServer) ReportBuckets(stream pdpb.PD_ReportBucketsServer) error {
 			// So we should not return error here.
 			log.Debug("the store of the bucket in region is not found", zap.Uint64("region-id", buckets.GetRegionId()))
 		} else if store.IsRemoved() {
-			log.Debug("the store of the bucket in region is tombstone", zap.Uint64("region-id", buckets.GetRegionId()), zap.Uint64("store-id", store.GetID()))
+			continue
 		} else {
 			storeLabel = strconv.FormatUint(store.GetID(), 10)
 			storeAddress = store.GetAddress()

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -240,8 +240,12 @@ func init() {
 }
 
 // DeleteStoreMetrics deletes the per-store heartbeat/bucket-report metrics of a store.
-func DeleteStoreMetrics(storeAddress, id string) {
-	labels := prometheus.Labels{"address": storeAddress, "store": id}
+// Matches on the store label alone, not address: PD allows an existing store ID to
+// change address (e.g. after a TiKV restart with a new IP), so requiring the current
+// address to match as well would permanently leak any series recorded under a
+// previous address.
+func DeleteStoreMetrics(id string) {
+	labels := prometheus.Labels{"store": id}
 	regionHeartbeatCounter.DeletePartialMatch(labels)
 	regionHeartbeatLatency.DeletePartialMatch(labels)
 	regionHeartbeatHandleDuration.DeletePartialMatch(labels)

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -238,3 +238,15 @@ func init() {
 	prometheus.MustRegister(forwardTsoDuration)
 	prometheus.MustRegister(regionRequestCounter)
 }
+
+// DeleteStoreMetrics deletes the per-store heartbeat/bucket-report metrics of a store.
+func DeleteStoreMetrics(storeAddress, id string) {
+	labels := prometheus.Labels{"address": storeAddress, "store": id}
+	regionHeartbeatCounter.DeletePartialMatch(labels)
+	regionHeartbeatLatency.DeletePartialMatch(labels)
+	regionHeartbeatHandleDuration.DeletePartialMatch(labels)
+	storeHeartbeatHandleDuration.DeletePartialMatch(labels)
+	bucketReportCounter.DeletePartialMatch(labels)
+	bucketReportLatency.DeletePartialMatch(labels)
+	bucketReportInterval.DeletePartialMatch(labels)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -744,10 +744,28 @@ func (s *Server) serverMetricsLoop() {
 		select {
 		case <-ticker.C:
 			s.collectEtcdStateMetrics()
+			s.cleanupRemovedStoreMetrics()
 		case <-ctx.Done():
 			log.Info("server is closed, exit metrics loop")
 			return
 		}
+	}
+}
+
+// cleanupRemovedStoreMetrics deletes the per-store heartbeat/bucket-report metrics
+// of stores that have been tombstoned. These metrics are recorded directly in this
+// package (not in pkg/statistics or pkg/schedule), so they cannot be cleaned up from
+// within RaftCluster's bury path and are instead swept periodically here.
+func (s *Server) cleanupRemovedStoreMetrics() {
+	rc := s.GetRaftCluster()
+	if rc == nil {
+		return
+	}
+	for _, store := range rc.GetStores() {
+		if !store.IsRemoved() {
+			continue
+		}
+		DeleteStoreMetrics(store.GetAddress(), strconv.FormatUint(store.GetID(), 10))
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -246,6 +246,16 @@ type Server struct {
 
 	// Cgroup Monitor
 	cgMonitor cgroup.Monitor
+
+	// cleanedRemovedStoreMetrics tracks store IDs whose per-store heartbeat/bucket
+	// report metrics (defined in server/metrics.go) have already been deleted by
+	// cleanupRemovedStoreMetrics after the store was tombstoned. Only that method,
+	// driven by serverMetricsLoop's own single-goroutine ticker, touches this map,
+	// so it needs no lock. Without it, DeleteStoreMetrics would DeletePartialMatch-
+	// scan every per-store metric vector on every tick for as long as the store
+	// stays tombstoned-but-not-yet-removed (up to the tombstone GC interval), even
+	// though there is nothing left to delete after the first pass.
+	cleanedRemovedStoreMetrics map[uint64]struct{}
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -761,11 +771,27 @@ func (s *Server) cleanupRemovedStoreMetrics() {
 	if rc == nil {
 		return
 	}
+	if s.cleanedRemovedStoreMetrics == nil {
+		s.cleanedRemovedStoreMetrics = make(map[uint64]struct{})
+	}
+	// Stores still tombstoned this tick; anything in cleanedRemovedStoreMetrics but
+	// not in this set has been fully removed, so its tracking entry can be dropped.
+	removed := make(map[uint64]struct{})
 	for _, store := range rc.GetStores() {
 		if !store.IsRemoved() {
 			continue
 		}
-		DeleteStoreMetrics(store.GetAddress(), strconv.FormatUint(store.GetID(), 10))
+		storeID := store.GetID()
+		removed[storeID] = struct{}{}
+		if _, cleaned := s.cleanedRemovedStoreMetrics[storeID]; !cleaned {
+			DeleteStoreMetrics(store.GetAddress(), strconv.FormatUint(storeID, 10))
+			s.cleanedRemovedStoreMetrics[storeID] = struct{}{}
+		}
+	}
+	for storeID := range s.cleanedRemovedStoreMetrics {
+		if _, stillTombstoned := removed[storeID]; !stillTombstoned {
+			delete(s.cleanedRemovedStoreMetrics, storeID)
+		}
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -246,6 +246,11 @@ type Server struct {
 
 	// Cgroup Monitor
 	cgMonitor cgroup.Monitor
+
+	// recentlyTombstonedStores is the set of store IDs cleanupRemovedStoreMetrics saw
+	// tombstoned on its last tick. Only that method, driven by serverMetricsLoop's own
+	// single-goroutine ticker, touches it, so it needs no lock.
+	recentlyTombstonedStores map[uint64]struct{}
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -770,12 +775,27 @@ func (s *Server) cleanupRemovedStoreMetrics() {
 	// late write would never get swept again for as long as the store stays
 	// tombstoned-but-not-yet-removed. DeletePartialMatch on labels that no longer
 	// exist is a cheap no-op, so repeating it every tick is safe.
+	current := make(map[uint64]struct{})
 	for _, store := range rc.GetStores() {
 		if !store.IsRemoved() {
 			continue
 		}
-		DeleteStoreMetrics(store.GetAddress(), strconv.FormatUint(store.GetID(), 10))
+		storeID := store.GetID()
+		current[storeID] = struct{}{}
+		DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
 	}
+	// A store that was tombstoned as of the last sweep but isn't known at all this
+	// tick was fully removed in between. This loop only reaches stores GetStores()
+	// currently returns, so a write landing in that gap -- after the last sweep saw
+	// it tombstoned but before removal completed -- would otherwise be unreachable
+	// by any future sweep. One more delete call closes that window; it's a no-op if
+	// nothing was actually rewritten.
+	for storeID := range s.recentlyTombstonedStores {
+		if _, stillKnown := current[storeID]; !stillKnown {
+			DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
+		}
+	}
+	s.recentlyTombstonedStores = current
 }
 
 // encryptionKeyManagerLoop is used to start monitor encryption key changes.

--- a/server/server.go
+++ b/server/server.go
@@ -246,16 +246,6 @@ type Server struct {
 
 	// Cgroup Monitor
 	cgMonitor cgroup.Monitor
-
-	// cleanedRemovedStoreMetrics tracks store IDs whose per-store heartbeat/bucket
-	// report metrics (defined in server/metrics.go) have already been deleted by
-	// cleanupRemovedStoreMetrics after the store was tombstoned. Only that method,
-	// driven by serverMetricsLoop's own single-goroutine ticker, touches this map,
-	// so it needs no lock. Without it, DeleteStoreMetrics would DeletePartialMatch-
-	// scan every per-store metric vector on every tick for as long as the store
-	// stays tombstoned-but-not-yet-removed (up to the tombstone GC interval), even
-	// though there is nothing left to delete after the first pass.
-	cleanedRemovedStoreMetrics map[uint64]struct{}
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -771,27 +761,20 @@ func (s *Server) cleanupRemovedStoreMetrics() {
 	if rc == nil {
 		return
 	}
-	if s.cleanedRemovedStoreMetrics == nil {
-		s.cleanedRemovedStoreMetrics = make(map[uint64]struct{})
-	}
-	// Stores still tombstoned this tick; anything in cleanedRemovedStoreMetrics but
-	// not in this set has been fully removed, so its tracking entry can be dropped.
-	removed := make(map[uint64]struct{})
+	// Delete unconditionally on every tick rather than tracking which stores were
+	// already cleaned: a region heartbeat for an already-tombstoned store can still
+	// land here and recreate a series. HandleRegionHeartbeat only checks
+	// store == nil, not store.IsRemoved(), before recording regionHeartbeat*/
+	// bucketReport* metrics -- unlike HandleStoreHeartbeat, which rejects tombstoned
+	// stores up front via checkStore(). If cleanup only ran once per store, such a
+	// late write would never get swept again for as long as the store stays
+	// tombstoned-but-not-yet-removed. DeletePartialMatch on labels that no longer
+	// exist is a cheap no-op, so repeating it every tick is safe.
 	for _, store := range rc.GetStores() {
 		if !store.IsRemoved() {
 			continue
 		}
-		storeID := store.GetID()
-		removed[storeID] = struct{}{}
-		if _, cleaned := s.cleanedRemovedStoreMetrics[storeID]; !cleaned {
-			DeleteStoreMetrics(store.GetAddress(), strconv.FormatUint(storeID, 10))
-			s.cleanedRemovedStoreMetrics[storeID] = struct{}{}
-		}
-	}
-	for storeID := range s.cleanedRemovedStoreMetrics {
-		if _, stillTombstoned := removed[storeID]; !stillTombstoned {
-			delete(s.cleanedRemovedStoreMetrics, storeID)
-		}
+		DeleteStoreMetrics(store.GetAddress(), strconv.FormatUint(store.GetID(), 10))
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -246,11 +246,6 @@ type Server struct {
 
 	// Cgroup Monitor
 	cgMonitor cgroup.Monitor
-
-	// recentlyTombstonedStores is the set of store IDs cleanupRemovedStoreMetrics saw
-	// tombstoned on its last tick. Only that method, driven by serverMetricsLoop's own
-	// single-goroutine ticker, touches it, so it needs no lock.
-	recentlyTombstonedStores map[uint64]struct{}
 }
 
 // HandlerBuilder builds a server HTTP handler.
@@ -530,6 +525,10 @@ func (s *Server) startServer(ctx context.Context) error {
 	s.tsoAllocator = tso.NewAllocator(s.ctx, constant.DefaultKeyspaceGroupID, s.member, tsoStorage, s)
 	s.basicCluster = core.NewBasicCluster()
 	s.cluster = cluster.NewRaftCluster(ctx, s.GetMember(), s.GetBasicCluster(), s.GetStorage(), syncer.NewRegionSyncer(s), s.client, s.httpClient, s.tsoAllocator)
+	// This package's own heartbeat/bucket-report metrics can't be cleaned up from
+	// within RaftCluster's bury path without an import cycle, so RaftCluster invokes
+	// this callback instead.
+	s.cluster.SetOnStoreBuried(DeleteStoreMetrics)
 	keyspaceIDAllocator := id.NewAllocator(&id.AllocatorParams{
 		Client: s.client,
 		Label:  id.KeyspaceLabel,
@@ -749,53 +748,11 @@ func (s *Server) serverMetricsLoop() {
 		select {
 		case <-ticker.C:
 			s.collectEtcdStateMetrics()
-			s.cleanupRemovedStoreMetrics()
 		case <-ctx.Done():
 			log.Info("server is closed, exit metrics loop")
 			return
 		}
 	}
-}
-
-// cleanupRemovedStoreMetrics deletes the per-store heartbeat/bucket-report metrics
-// of stores that have been tombstoned. These metrics are recorded directly in this
-// package (not in pkg/statistics or pkg/schedule), so they cannot be cleaned up from
-// within RaftCluster's bury path and are instead swept periodically here.
-func (s *Server) cleanupRemovedStoreMetrics() {
-	rc := s.GetRaftCluster()
-	if rc == nil {
-		return
-	}
-	// Delete unconditionally on every tick rather than tracking which stores were
-	// already cleaned: a region heartbeat for an already-tombstoned store can still
-	// land here and recreate a series. HandleRegionHeartbeat only checks
-	// store == nil, not store.IsRemoved(), before recording regionHeartbeat*/
-	// bucketReport* metrics -- unlike HandleStoreHeartbeat, which rejects tombstoned
-	// stores up front via checkStore(). If cleanup only ran once per store, such a
-	// late write would never get swept again for as long as the store stays
-	// tombstoned-but-not-yet-removed. DeletePartialMatch on labels that no longer
-	// exist is a cheap no-op, so repeating it every tick is safe.
-	current := make(map[uint64]struct{})
-	for _, store := range rc.GetStores() {
-		if !store.IsRemoved() {
-			continue
-		}
-		storeID := store.GetID()
-		current[storeID] = struct{}{}
-		DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
-	}
-	// A store that was tombstoned as of the last sweep but isn't known at all this
-	// tick was fully removed in between. This loop only reaches stores GetStores()
-	// currently returns, so a write landing in that gap -- after the last sweep saw
-	// it tombstoned but before removal completed -- would otherwise be unreachable
-	// by any future sweep. One more delete call closes that window; it's a no-op if
-	// nothing was actually rewritten.
-	for storeID := range s.recentlyTombstonedStores {
-		if _, stillKnown := current[storeID]; !stillKnown {
-			DeleteStoreMetrics(strconv.FormatUint(storeID, 10))
-		}
-	}
-	s.recentlyTombstonedStores = current
 }
 
 // encryptionKeyManagerLoop is used to start monitor encryption key changes.

--- a/tests/integrations/client/client_test.go
+++ b/tests/integrations/client/client_test.go
@@ -1268,7 +1268,11 @@ func (suite *clientStatelessTestSuite) TestGetStore() {
 	re := suite.Require()
 	cluster := suite.srv.GetRaftCluster()
 	re.NotNil(cluster)
-	store := stores[0]
+	// Use stores[3]: this test destructively transitions it through
+	// offline -> tombstone, and stores[0..2] are the ones other tests in
+	// this suite heartbeat regions through (peers[0..2]) and expect to
+	// stay live for the rest of the suite.
+	store := stores[3]
 
 	// Get an up store should be OK.
 	n, err := suite.client.GetStore(context.Background(), store.GetId())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11126

### What is changed and how does it work?

```commit-message
Several per-store Prometheus metrics were never cleaned up on store
removal, leaking stale time series until the next PD leader election
forced a full Reset(). Most visibly, pd_hotcache_status entries in
HotPeerCache.gc() were only removed from the in-memory map, never
from the GaugeVec itself.

Replace the ad hoc, partial cleanup with an event-driven design used
consistently across classic and mcs (microservice) modes:

- Bury-time one-shot cleanup: RaftCluster.BuryStoreLocked (classic)
  and the mcs meta watcher's tombstone handler each call
  DeleteStoreMetrics/ResetStoreStatistics for every per-store metric
  family owned by that process (filter, hbstream, schedulers,
  hotspot, scatter, statistics, and the heartbeat/bucket-report
  metrics in server/pkg-mcs-scheduling-server).
- Final-removal-time one-shot cleanup: the same helpers run again
  from deleteStore (classic) and the watcher's remove-tombstone
  handler (mcs), catching any store that only entered peersOfStore-
  style caches after the bury-time sweep.
- Write-side guards at the source: RegionHeartbeat, StoreHeartbeat,
  region-buckets handlers, HotPeerCache.CheckPeerFlow, the filter
  package's Select*Stores helpers, and RegionScatterer now check
  IsRemoved() before recording a metric for a store, so a late
  heartbeat or scatter decision for an already-buried store can't
  recreate a series that was just deleted.
- The previous periodic full-vector sweep (recentlyTombstonedStores
  + DeletePartialMatch every ~10s) was removed: with the guards
  above in place it was redundant, and it made metric cleanup
  O(tombstoned stores x series) per tick, which showed up as real
  contention at 1k+ stores.

Also switch storeStatusGauge/clusterStatusGauge cleanup in
ResetStoreStatistics from DeletePartialMatch (which locks and scans
the whole vector) to exact DeleteLabelValues lookups bounded by the
two known StoreInfo.Engine() outputs, avoiding that same O(stores x
series) cost during bulk tombstoning.

### Known limitation (best effort, not airtight)

This is deliberately a best-effort cleanup, not a formally guaranteed
one.

A few of the write-side guards check IsRemoved() on a *StoreInfo
pointer the caller already holds (e.g. a scheduler's snapshot of
live stores taken at the start of a scheduling round), not on a
fresh cluster lookup. BasicCluster.PutStore replaces the map entry
with a new pointer on a state change rather than mutating it in
place, so a store buried concurrently with that round can leave the
caller holding a stale pointer that still reports IsRemoved() ==
false. If that stale-snapshot metric write happens to land after
both the bury-time and the final-removal cleanup passes have already
run for that store, there is no third event left to discover and
delete the recreated series: remove-tombstone deletes the store from
StoresInfo entirely, so that ID can never be encountered again by
any later heartbeat, scheduling round, or watcher event, and the
series stays until the next full metrics Reset() (a PD leader
election) instead of self-healing on the store's next selection --
a removed store has no next selection.

In practice this window is not reachable through the normal,
automatic path: a tombstoned store is only auto-GC'd 30 days after
it goes down (gcTombstoneInterval in server/cluster/cluster.go), so
no in-flight scheduling round -- which finishes in well under a
second -- can span from before the bury to after that automatic
final removal. The window only exists on the manual/scripted path:
RemoveTombStoneRecords (the remove-tombstone API/pd-ctl command) has
no minimum-delay check, so an operator or decommission automation
that calls it immediately after a store reaches tombstone state can
compress bury and final removal into a window narrow enough for a
concurrently-running scheduling round's stale snapshot to still land
inside it. This is rare in practice -- it requires an unlucky race
between a live scheduling round and an immediate manual removal --
but is not impossible, and a deterministic unit test can construct
it directly without needing that timing.

This affects a small number of guards that only had the caller's
snapshot available and not a live cluster lookup (notably
filter.Target and the nil-Counter path of the filter package's
Select*Stores helpers); the buffered-Counter path is not affected,
since Counter.Flush re-checks the current store state right before
writing.

Closing this completely would mean either re-checking cluster state
synchronously on every metric write across all of these call sites,
or reintroducing some form of periodic reconciliation, which was
deliberately removed above for its cost at scale. Given how narrow
and operator-dependent the window is, and how much this would spread
the diff across the filter/scatter/scheduler call sites, this
tradeoff was accepted for now rather than adding either of those
costs back.
```

### Check List

Tests

- Unit test

### Release note

```release-note
Fix per-store Prometheus metrics (hotcache, scheduler, filter, heartbeat-stream, scatter, and heartbeat/bucket-report metrics) not being removed after a store is tombstoned, which previously left stale time series in `/metrics` until the next PD leader election. Cleanup is best-effort: a rare race between an in-flight scheduling round and a store's removal can still leave a stale series until the next leader election.
```
