### PR TITLE
[DNM] test scale out

### DIFF
--- a/pkg/core/storelimit/limit_test.go
+++ b/pkg/core/storelimit/limit_test.go
@@ -94,6 +94,31 @@ func TestSlidingWindow(t *testing.T) {
 	}
 }
 
+func TestSlidingWindowConfigurableSize(t *testing.T) {
+	re := require.New(t)
+	s := NewSlidingWindowsWithSize(1000)
+	re.EqualValues(1000, s.GetCap())
+	re.True(s.Take(900, SendSnapshot, constant.Low))
+	re.Equal([]int64{900, 0, 0, 0}, s.GetUsed())
+
+	// Growing or shrinking the configured window must preserve in-flight usage.
+	s.SetWindowSize(2000)
+	re.EqualValues(2000, s.GetCap())
+	re.Equal([]int64{900, 0, 0, 0}, s.GetUsed())
+	s.SetWindowSize(500)
+	re.EqualValues(500, s.GetCap())
+	re.Equal([]int64{900, 0, 0, 0}, s.GetUsed())
+	re.False(s.Available(100, SendSnapshot, constant.Low))
+	s.Ack(900, SendSnapshot)
+	re.True(s.Available(100, SendSnapshot, constant.Low))
+
+	// Reset is the generic StoreLimit hook for hot-reloading SendSnapshot.
+	s.Reset(3000, SendSnapshot)
+	re.EqualValues(3000, s.GetCap())
+	s.Reset(100, AddPeer)
+	re.EqualValues(3000, s.GetCap())
+}
+
 func TestWindow(t *testing.T) {
 	re := require.New(t)
 	capacity := int64(100 * 10)

--- a/pkg/core/storelimit/sliding_window.go
+++ b/pkg/core/storelimit/sliding_window.go
@@ -23,7 +23,7 @@ const (
 	// minSnapSize is the min value to check the windows has enough size.
 	minSnapSize = 10
 	// defaultWindowSize is the default window size.
-	defaultWindowSize = 100
+	defaultWindowSize int64 = 100
 
 	defaultProportion = 20
 	defaultIntegral   = 10
@@ -33,20 +33,36 @@ var _ StoreLimit = &SlidingWindows{}
 
 // SlidingWindows is a multi sliding windows
 type SlidingWindows struct {
-	mu      syncutil.RWMutex
-	windows []*window
-	lastSum float64
+	mu             syncutil.RWMutex
+	windows        []*window
+	baseWindowSize int64
+	lastSum        float64
 }
 
 // NewSlidingWindows is the construct of SlidingWindows.
 func NewSlidingWindows() *SlidingWindows {
+	return NewSlidingWindowsWithSize(defaultWindowSize)
+}
+
+// NewSlidingWindowsWithSize constructs SlidingWindows with the specified base
+// window size in MiB.
+func NewSlidingWindowsWithSize(windowSize int64) *SlidingWindows {
+	windowSize = normalizeWindowSize(windowSize)
 	windows := make([]*window, constant.PriorityLevelLen)
 	for i := range constant.PriorityLevelLen {
-		windows[i] = newWindow(int64(defaultWindowSize) >> i)
+		windows[i] = newWindow(windowSize >> i)
 	}
 	return &SlidingWindows{
-		windows: windows,
+		windows:        windows,
+		baseWindowSize: windowSize,
 	}
+}
+
+func normalizeWindowSize(windowSize int64) int64 {
+	if windowSize < minSnapSize {
+		return minSnapSize
+	}
+	return windowSize
 }
 
 // Version returns v2
@@ -68,16 +84,39 @@ func (s *SlidingWindows) Feedback(e float64) {
 	// In the final scene, the sum of the error should be stable and the current error should be zero.
 	cap := defaultProportion*e + defaultIntegral*s.lastSum
 	// The capacity should be at least the default window size.
-	if cap < defaultWindowSize {
-		cap = defaultWindowSize
+	if cap < float64(s.baseWindowSize) {
+		cap = float64(s.baseWindowSize)
 	}
-	s.set(cap, SendSnapshot)
+	s.setLocked(cap, SendSnapshot)
 }
 
-// Reset does nothing because the capacity depends on the feedback.
-func (*SlidingWindows) Reset(_ float64, _ Type) {}
+// Reset updates the configured base window for SendSnapshot.
+func (s *SlidingWindows) Reset(rate float64, typ Type) {
+	if typ == SendSnapshot {
+		s.SetWindowSize(int64(rate))
+	}
+}
+
+// SetWindowSize updates the base window size while preserving in-flight usage.
+func (s *SlidingWindows) SetWindowSize(windowSize int64) {
+	windowSize = normalizeWindowSize(windowSize)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.baseWindowSize == windowSize {
+		return
+	}
+	s.baseWindowSize = windowSize
+	s.lastSum = 0
+	s.setLocked(float64(windowSize), SendSnapshot)
+}
 
 func (s *SlidingWindows) set(cap float64, typ Type) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.setLocked(cap, typ)
+}
+
+func (s *SlidingWindows) setLocked(cap float64, typ Type) {
 	if typ != SendSnapshot {
 		return
 	}

--- a/pkg/mcs/scheduling/server/cluster.go
+++ b/pkg/mcs/scheduling/server/cluster.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/tikv/pd/pkg/cluster"
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/errs"
 	mcsaffinity "github.com/tikv/pd/pkg/mcs/scheduling/server/affinity"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
@@ -581,7 +582,20 @@ func (c *Cluster) HandleStoreHeartbeat(heartbeat *schedulingpb.StoreHeartbeatReq
 		return errors.Errorf("store %v not found", storeID)
 	}
 
-	c.PutStore(store, core.SetStoreStats(stats), core.SetLastHeartbeatTS(time.Now()))
+	limit := store.GetStoreLimit()
+	version := c.persistConfig.GetScheduleConfig().StoreLimitVersion
+	opts := []core.StoreCreateOption{core.SetStoreStats(stats), core.SetLastHeartbeatTS(time.Now())}
+	if limit == nil || limit.Version() != version {
+		if version == storelimit.VersionV2 {
+			limit = storelimit.NewSlidingWindowsWithSize(c.persistConfig.GetStoreLimitV2WindowSize())
+		} else {
+			limit = storelimit.NewStoreRateLimit(0)
+		}
+		opts = append(opts, core.SetStoreLimit(limit))
+	} else if slidingWindows, ok := limit.(*storelimit.SlidingWindows); ok {
+		slidingWindows.SetWindowSize(c.persistConfig.GetStoreLimitV2WindowSize())
+	}
+	c.PutStore(store, opts...)
 	c.hotStat.Observe(storeID, stats)
 	c.hotStat.FilterUnhealthyStore(c)
 	reportInterval := stats.GetInterval()

--- a/pkg/mcs/scheduling/server/config/config.go
+++ b/pkg/mcs/scheduling/server/config/config.go
@@ -518,8 +518,8 @@ func (o *PersistConfig) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitCon
 	}
 	cfg := o.GetScheduleConfig().Clone()
 	limitCfg := sc.StoreLimitConfig{
-		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		AddPeer:    cfg.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer: cfg.GetDefaultStoreLimit(storelimit.RemovePeer),
 	}
 	cfg.StoreLimit[storeID] = limitCfg
 	o.SetScheduleConfig(cfg)
@@ -540,6 +540,11 @@ func (o *PersistConfig) GetStoreLimitByType(storeID uint64, typ storelimit.Type)
 	default:
 		panic("no such limit type")
 	}
+}
+
+// GetStoreLimitV2WindowSize returns the configured v2 base window size in MiB.
+func (o *PersistConfig) GetStoreLimitV2WindowSize() int64 {
+	return o.GetScheduleConfig().GetStoreLimitV2WindowSize()
 }
 
 // GetMaxSnapshotCount returns the number of the max snapshot which is allowed to send.
@@ -597,13 +602,13 @@ func (o *PersistConfig) SetAllStoresLimit(typ storelimit.Type, ratePerMin float6
 	v := o.GetScheduleConfig().Clone()
 	switch typ {
 	case storelimit.AddPeer:
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
+		v.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
 		for storeID := range v.StoreLimit {
 			sc := sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: v.StoreLimit[storeID].RemovePeer}
 			v.StoreLimit[storeID] = sc
 		}
 	case storelimit.RemovePeer:
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
+		v.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
 		for storeID := range v.StoreLimit {
 			sc := sc.StoreLimitConfig{AddPeer: v.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
 			v.StoreLimit[storeID] = sc

--- a/pkg/mcs/scheduling/server/grpc_service_test.go
+++ b/pkg/mcs/scheduling/server/grpc_service_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/tikv/pd/pkg/cache"
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/mcs/scheduling/server/config"
 	"github.com/tikv/pd/pkg/mcs/utils/constant"
 	"github.com/tikv/pd/pkg/schedule/affinity"
@@ -161,6 +162,32 @@ func TestAskBatchSplitRecordsSplitScatterInSchedulingService(t *testing.T) {
 	re.Len(resp.GetIds(), 1)
 
 	re.Equal(float64(2), splitScatterPendingMetricValue(t))
+}
+
+func TestStoreHeartbeatUpdatesV2Window(t *testing.T) {
+	re := require.New(t)
+	_, cluster, _ := newTestSchedulingServiceForSplit(t)
+	cfg := cluster.persistConfig.GetScheduleConfig().Clone()
+	cfg.StoreLimitVersion = storelimit.VersionV2
+	cfg.StoreLimitV2WindowSize = 4096
+	cluster.persistConfig.SetScheduleConfig(cfg)
+
+	re.NoError(cluster.HandleStoreHeartbeat(&schedulingpb.StoreHeartbeatRequest{
+		Stats: &pdpb.StoreStats{StoreId: 1},
+	}))
+	limit, ok := cluster.GetStore(1).GetStoreLimit().(*storelimit.SlidingWindows)
+	re.True(ok)
+	re.EqualValues(4096, limit.GetCap())
+
+	cfg = cluster.persistConfig.GetScheduleConfig().Clone()
+	cfg.StoreLimitV2WindowSize = 8192
+	cluster.persistConfig.SetScheduleConfig(cfg)
+	re.NoError(cluster.HandleStoreHeartbeat(&schedulingpb.StoreHeartbeatRequest{
+		Stats: &pdpb.StoreStats{StoreId: 1},
+	}))
+	limit, ok = cluster.GetStore(1).GetStoreLimit().(*storelimit.SlidingWindows)
+	re.True(ok)
+	re.EqualValues(8192, limit.GetCap())
 }
 
 func newTestSchedulingServiceForSplit(

--- a/pkg/schedule/config/config.go
+++ b/pkg/schedule/config/config.go
@@ -71,6 +71,7 @@ const (
 	defaultRegionScoreFormulaVersion = "v2"
 	defaultLeaderSchedulePolicy      = "count"
 	defaultStoreLimitVersion         = "v1"
+	defaultStoreLimitV2WindowSize    = int64(100)
 	defaultPatrolRegionWorkerCount   = 1
 	maxPatrolRegionWorkerCount       = 8
 
@@ -229,6 +230,8 @@ type ScheduleConfig struct {
 	StoreBalanceRate float64 `toml:"store-balance-rate" json:"store-balance-rate,omitempty"`
 	// StoreLimit is the limit of scheduling for stores.
 	StoreLimit map[uint64]StoreLimitConfig `toml:"store-limit" json:"store-limit"`
+	// StoreLimitDefault is the default v1 limit inherited by newly registered TiKV stores.
+	StoreLimitDefault StoreLimitConfig `toml:"store-limit-default" json:"store-limit-default"`
 	// TolerantSizeRatio is the ratio of buffer size for balance scheduler.
 	TolerantSizeRatio float64 `toml:"tolerant-size-ratio" json:"tolerant-size-ratio"`
 	//
@@ -322,6 +325,8 @@ type ScheduleConfig struct {
 	// v1: which is based on the region count by rate limit.
 	// v2: which is based on region size by window size.
 	StoreLimitVersion string `toml:"store-limit-version" json:"store-limit-version,omitempty"`
+	// StoreLimitV2WindowSize is the per-store base SendSnapshot window size in MiB.
+	StoreLimitV2WindowSize int64 `toml:"store-limit-v2-window-size" json:"store-limit-v2-window-size"`
 
 	// HaltScheduling is the option to halt the scheduling. Once it's on, PD will halt the scheduling,
 	// and any other scheduling configs will be ignored.
@@ -415,6 +420,9 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 	if !meta.IsDefined("store-limit-version") {
 		configutil.AdjustString(&c.StoreLimitVersion, defaultStoreLimitVersion)
 	}
+	if !meta.IsDefined("store-limit-v2-window-size") {
+		c.StoreLimitV2WindowSize = defaultStoreLimitV2WindowSize
+	}
 	if !meta.IsDefined("patrol-region-worker-count") {
 		configutil.AdjustInt(&c.PatrolRegionWorkerCount, defaultPatrolRegionWorkerCount)
 	}
@@ -466,8 +474,14 @@ func (c *ScheduleConfig) Adjust(meta *configutil.ConfigMetaData, reloading bool)
 		*b[0], *b[1] = false, v // reset old flag false to make it ignored when marshal to JSON
 	}
 
+	if !meta.IsDefined("store-limit-default") {
+		c.StoreLimitDefault = StoreLimitConfig{
+			AddPeer:    DefaultStoreLimit.AddPeer,
+			RemovePeer: DefaultStoreLimit.RemovePeer,
+		}
+	}
 	if c.StoreBalanceRate != 0 {
-		DefaultStoreLimit = StoreLimit{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
+		c.StoreLimitDefault = StoreLimitConfig{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
 		c.StoreBalanceRate = 0
 	}
 
@@ -537,7 +551,7 @@ func parseDeprecatedFlag(meta *configutil.ConfigMetaData, name string, old, new 
 func (c *ScheduleConfig) MigrateDeprecatedFlags() {
 	c.DisableLearner = false
 	if c.StoreBalanceRate != 0 {
-		DefaultStoreLimit = StoreLimit{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
+		c.StoreLimitDefault = StoreLimitConfig{AddPeer: c.StoreBalanceRate, RemovePeer: c.StoreBalanceRate}
 		c.StoreBalanceRate = 0
 	}
 	for _, b := range c.migrateConfigurationMap() {
@@ -570,6 +584,12 @@ func (c *ScheduleConfig) Validate() error {
 	}
 	if c.PatrolRegionWorkerCount > maxPatrolRegionWorkerCount || c.PatrolRegionWorkerCount < 1 {
 		return errors.Errorf("patrol-region-worker-count should be between 1 and %d", maxPatrolRegionWorkerCount)
+	}
+	if c.StoreLimitDefault.AddPeer <= 0 || c.StoreLimitDefault.RemovePeer <= 0 {
+		return errors.New("store-limit-default should be larger than 0")
+	}
+	if c.StoreLimitV2WindowSize < minStoreLimitV2WindowSize {
+		return errors.Errorf("store-limit-v2-window-size should be at least %d", minStoreLimitV2WindowSize)
 	}
 	return nil
 }
@@ -604,6 +624,41 @@ func (c *ScheduleConfig) Deprecated() error {
 type StoreLimitConfig struct {
 	AddPeer    float64 `toml:"add-peer" json:"add-peer"`
 	RemovePeer float64 `toml:"remove-peer" json:"remove-peer"`
+}
+
+const minStoreLimitV2WindowSize = int64(10)
+
+// GetDefaultStoreLimit returns the v1 limit inherited by newly registered TiKV stores.
+func (c *ScheduleConfig) GetDefaultStoreLimit(typ storelimit.Type) float64 {
+	var rate float64
+	switch typ {
+	case storelimit.AddPeer:
+		rate = c.StoreLimitDefault.AddPeer
+	case storelimit.RemovePeer:
+		rate = c.StoreLimitDefault.RemovePeer
+	}
+	if rate > 0 {
+		return rate
+	}
+	return DefaultStoreLimit.GetDefaultStoreLimit(typ)
+}
+
+// SetDefaultStoreLimit updates the v1 limit inherited by newly registered TiKV stores.
+func (c *ScheduleConfig) SetDefaultStoreLimit(typ storelimit.Type, ratePerMin float64) {
+	switch typ {
+	case storelimit.AddPeer:
+		c.StoreLimitDefault.AddPeer = ratePerMin
+	case storelimit.RemovePeer:
+		c.StoreLimitDefault.RemovePeer = ratePerMin
+	}
+}
+
+// GetStoreLimitV2WindowSize returns the configured v2 base window size in MiB.
+func (c *ScheduleConfig) GetStoreLimitV2WindowSize() int64 {
+	if c.StoreLimitV2WindowSize == 0 {
+		return defaultStoreLimitV2WindowSize
+	}
+	return c.StoreLimitV2WindowSize
 }
 
 // SchedulerConfigs is a slice of customized scheduler configuration.

--- a/pkg/schedule/config/config_provider.go
+++ b/pkg/schedule/config/config_provider.go
@@ -115,6 +115,7 @@ type SharedConfigProvider interface {
 	GetRegionScoreFormulaVersion() string
 	GetSchedulerMaxWaitingOperator() uint64
 	GetStoreLimitByType(uint64, storelimit.Type) float64
+	GetStoreLimitV2WindowSize() int64
 	IsWitnessAllowed() bool
 	IsPlacementRulesCacheEnabled() bool
 	SetHaltScheduling(bool, string)

--- a/pkg/schedule/operator/operator_controller.go
+++ b/pkg/schedule/operator/operator_controller.go
@@ -1058,9 +1058,13 @@ func (oc *Controller) getOrCreateStoreLimit(storeID uint64, limitType storelimit
 		log.Error("invalid store ID", zap.Uint64("store-id", storeID))
 		return nil
 	}
-	// The other limits do not need to update by config exclude StoreRateLimit.
-	if limit, ok := s.GetStoreLimit().(*storelimit.StoreRateLimit); ok && limit.Rate(limitType) != ratePerSec {
-		oc.cluster.ResetStoreLimit(storeID, limitType, ratePerSec)
+	switch limit := s.GetStoreLimit().(type) {
+	case *storelimit.StoreRateLimit:
+		if limit.Rate(limitType) != ratePerSec {
+			oc.cluster.ResetStoreLimit(storeID, limitType, ratePerSec)
+		}
+	case *storelimit.SlidingWindows:
+		limit.SetWindowSize(oc.config.GetStoreLimitV2WindowSize())
 	}
 	return s.GetStoreLimit()
 }

--- a/server/cluster/cluster.go
+++ b/server/cluster/cluster.go
@@ -1155,11 +1155,13 @@ func (c *RaftCluster) HandleStoreHeartbeat(heartbeat *pdpb.StoreHeartbeatRequest
 	opts := make([]core.StoreCreateOption, 0)
 	if limit == nil || limit.Version() != version {
 		if version == storelimit.VersionV2 {
-			limit = storelimit.NewSlidingWindows()
+			limit = storelimit.NewSlidingWindowsWithSize(c.opt.GetScheduleConfig().GetStoreLimitV2WindowSize())
 		} else {
 			limit = storelimit.NewStoreRateLimit(0.0)
 		}
 		opts = append(opts, core.SetStoreLimit(limit))
+	} else if slidingWindows, ok := limit.(*storelimit.SlidingWindows); ok {
+		slidingWindows.SetWindowSize(c.opt.GetScheduleConfig().GetStoreLimitV2WindowSize())
 	}
 
 	nowTime := time.Now()
@@ -2390,8 +2392,8 @@ func (c *RaftCluster) AddStoreLimit(store *metapb.Store) {
 	}
 
 	slc := sc.StoreLimitConfig{
-		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		AddPeer:    cfg.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer: cfg.GetDefaultStoreLimit(storelimit.RemovePeer),
 	}
 	if core.IsStoreContainLabel(store, core.EngineKey, core.EngineTiFlash) {
 		slc = sc.StoreLimitConfig{
@@ -2591,14 +2593,10 @@ func (c *RaftCluster) SetStoreLimit(storeID uint64, typ storelimit.Type, ratePer
 // SetAllStoresLimit sets all store limit for a given type and rate.
 func (c *RaftCluster) SetAllStoresLimit(typ storelimit.Type, ratePerMin float64) error {
 	old := c.opt.GetScheduleConfig().Clone()
-	oldAdd := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
-	oldRemove := sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
 	c.opt.SetAllStoresLimit(typ, ratePerMin)
 	if err := c.opt.Persist(c.storage); err != nil {
 		// roll back the store limit
 		c.opt.SetScheduleConfig(old)
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, oldAdd)
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, oldRemove)
 		log.Error("persist store limit meet error", errs.ZapError(err))
 		return err
 	}

--- a/server/cluster/cluster_test.go
+++ b/server/cluster/cluster_test.go
@@ -83,6 +83,7 @@ func TestStoreHeartbeat(t *testing.T) {
 
 	_, opt, err := newTestScheduleConfig()
 	opt.GetScheduleConfig().StoreLimitVersion = "v2"
+	opt.GetScheduleConfig().StoreLimitV2WindowSize = 4096
 	re.NoError(err)
 	cluster := newTestRaftCluster(ctx, mockid.NewIDAllocator(), opt, storage.NewStorageWithMemoryBackend())
 
@@ -118,12 +119,24 @@ func TestStoreHeartbeat(t *testing.T) {
 		re.NotEqual(int64(0), s.GetLastHeartbeatTS().UnixNano())
 		re.Equal(req.GetStats(), s.GetStoreStats())
 		re.Equal("v2", cluster.GetStore(1).GetStoreLimit().Version())
+		limit, ok := s.GetStoreLimit().(*storelimit.SlidingWindows)
+		re.True(ok)
+		re.EqualValues(4096, limit.GetCap())
 		re.Equal(s.GetMeta().GetNodeState(), resp.GetState())
 
 		storeMetasAfterHeartbeat = append(storeMetasAfterHeartbeat, s.GetMeta())
 	}
 
 	re.Equal(int(n), cluster.GetStoreCount())
+
+	// An updated v2 window is applied to existing stores without changing versions.
+	scheCfg := cluster.opt.GetScheduleConfig().Clone()
+	scheCfg.StoreLimitV2WindowSize = 8192
+	cluster.opt.SetScheduleConfig(scheCfg)
+	re.NoError(cluster.HandleStoreHeartbeat(&pdpb.StoreHeartbeatRequest{Stats: &pdpb.StoreStats{StoreId: 1}}, &pdpb.StoreHeartbeatResponse{}))
+	limit, ok := cluster.GetStore(1).GetStoreLimit().(*storelimit.SlidingWindows)
+	re.True(ok)
+	re.EqualValues(8192, limit.GetCap())
 
 	for i, store := range stores {
 		tmp := &metapb.Store{}
@@ -164,7 +177,7 @@ func TestStoreHeartbeat(t *testing.T) {
 		},
 		PeerStats: []*pdpb.PeerStat{},
 	}
-	scheCfg := cluster.opt.GetScheduleConfig().Clone()
+	scheCfg = cluster.opt.GetScheduleConfig().Clone()
 	scheCfg.StoreLimitVersion = "v1"
 	cluster.opt.SetScheduleConfig(scheCfg)
 	re.NoError(cluster.HandleStoreHeartbeat(hotReq, hotResp))

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/tikv/pd/pkg/core/storelimit"
 	"github.com/tikv/pd/pkg/ratelimit"
 	sc "github.com/tikv/pd/pkg/schedule/config"
 	"github.com/tikv/pd/pkg/storage"
@@ -143,6 +144,13 @@ func TestValidation(t *testing.T) {
 	cfg.Schedule.LowSpaceRatio = 0.4
 	re.Error(cfg.Schedule.Validate())
 	cfg.Schedule.LowSpaceRatio = 0.8
+	re.NoError(cfg.Schedule.Validate())
+	cfg.Schedule.StoreLimitV2WindowSize = 9
+	re.Error(cfg.Schedule.Validate())
+	cfg.Schedule.StoreLimitV2WindowSize = 100
+	cfg.Schedule.StoreLimitDefault.AddPeer = 0
+	re.Error(cfg.Schedule.Validate())
+	cfg.Schedule.StoreLimitDefault.AddPeer = 15
 	re.NoError(cfg.Schedule.Validate())
 	cfg.Schedule.TolerantSizeRatio = -0.6
 	re.Error(cfg.Schedule.Validate())
@@ -574,6 +582,32 @@ func newTestScheduleOption() (*PersistOptions, error) {
 	}
 	opt := NewPersistOptions(cfg)
 	return opt, nil
+}
+
+func TestStoreLimitConfigPersistence(t *testing.T) {
+	re := require.New(t)
+	opt, err := newTestScheduleOption()
+	re.NoError(err)
+	re.Equal(float64(15), opt.GetScheduleConfig().GetDefaultStoreLimit(storelimit.AddPeer))
+	re.Equal(float64(15), opt.GetScheduleConfig().GetDefaultStoreLimit(storelimit.RemovePeer))
+	re.EqualValues(100, opt.GetScheduleConfig().GetStoreLimitV2WindowSize())
+
+	opt.SetAllStoresLimit(storelimit.AddPeer, 2000)
+	opt.SetAllStoresLimit(storelimit.RemovePeer, 1500)
+	cfg := opt.GetScheduleConfig().Clone()
+	cfg.StoreLimitV2WindowSize = 32768
+	opt.SetScheduleConfig(cfg)
+	re.Equal(float64(2000), opt.GetStoreLimit(100).AddPeer)
+	re.Equal(float64(1500), opt.GetStoreLimit(100).RemovePeer)
+
+	storage := storage.NewStorageWithMemoryBackend()
+	re.NoError(opt.Persist(storage))
+	reloaded, err := newTestScheduleOption()
+	re.NoError(err)
+	re.NoError(reloaded.Reload(storage))
+	re.Equal(float64(2000), reloaded.GetStoreLimit(101).AddPeer)
+	re.Equal(float64(1500), reloaded.GetStoreLimit(101).RemovePeer)
+	re.EqualValues(32768, reloaded.GetScheduleConfig().GetStoreLimitV2WindowSize())
 }
 
 func TestRateLimitClone(t *testing.T) {

--- a/server/config/persist_options.go
+++ b/server/config/persist_options.go
@@ -395,14 +395,14 @@ func (o *PersistOptions) SetStoreLimit(storeID uint64, typ storelimit.Type, rate
 	switch typ {
 	case storelimit.AddPeer:
 		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer)
+			rate = v.GetDefaultStoreLimit(storelimit.RemovePeer)
 		} else {
 			rate = v.StoreLimit[storeID].RemovePeer
 		}
 		slc = sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: rate}
 	case storelimit.RemovePeer:
 		if _, ok := v.StoreLimit[storeID]; !ok {
-			rate = sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer)
+			rate = v.GetDefaultStoreLimit(storelimit.AddPeer)
 		} else {
 			rate = v.StoreLimit[storeID].AddPeer
 		}
@@ -417,13 +417,13 @@ func (o *PersistOptions) SetAllStoresLimit(typ storelimit.Type, ratePerMin float
 	v := o.GetScheduleConfig().Clone()
 	switch typ {
 	case storelimit.AddPeer:
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
+		v.SetDefaultStoreLimit(storelimit.AddPeer, ratePerMin)
 		for storeID := range v.StoreLimit {
 			sc := sc.StoreLimitConfig{AddPeer: ratePerMin, RemovePeer: v.StoreLimit[storeID].RemovePeer}
 			v.StoreLimit[storeID] = sc
 		}
 	case storelimit.RemovePeer:
-		sc.DefaultStoreLimit.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
+		v.SetDefaultStoreLimit(storelimit.RemovePeer, ratePerMin)
 		for storeID := range v.StoreLimit {
 			sc := sc.StoreLimitConfig{AddPeer: v.StoreLimit[storeID].AddPeer, RemovePeer: ratePerMin}
 			v.StoreLimit[storeID] = sc
@@ -495,8 +495,8 @@ func (o *PersistOptions) GetStoreLimit(storeID uint64) (returnSC sc.StoreLimitCo
 	}
 	cfg := o.GetScheduleConfig().Clone()
 	limitCfg := sc.StoreLimitConfig{
-		AddPeer:    sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.AddPeer),
-		RemovePeer: sc.DefaultStoreLimit.GetDefaultStoreLimit(storelimit.RemovePeer),
+		AddPeer:    cfg.GetDefaultStoreLimit(storelimit.AddPeer),
+		RemovePeer: cfg.GetDefaultStoreLimit(storelimit.RemovePeer),
 	}
 	cfg.StoreLimit[storeID] = limitCfg
 	o.SetScheduleConfig(cfg)
@@ -527,6 +527,11 @@ func (o *PersistOptions) GetAllStoresLimit() map[uint64]sc.StoreLimitConfig {
 // GetStoreLimitVersion returns the limit version of store.
 func (o *PersistOptions) GetStoreLimitVersion() string {
 	return o.GetScheduleConfig().StoreLimitVersion
+}
+
+// GetStoreLimitV2WindowSize returns the configured v2 base window size in MiB.
+func (o *PersistOptions) GetStoreLimitV2WindowSize() int64 {
+	return o.GetScheduleConfig().GetStoreLimitV2WindowSize()
 }
 
 // GetTolerantSizeRatio gets the tolerant size ratio.

--- a/tools/pd-ctl/pdctl/command/store_command.go
+++ b/tools/pd-ctl/pdctl/command/store_command.go
@@ -37,7 +37,7 @@ var (
 	storesLimitPrefix  = "pd/api/v1/stores/limit"
 	storePrefix        = "pd/api/v1/store/%v"
 	storeUpStatePrefix = "pd/api/v1/store/%v/state?state=Up"
-	maxStoreLimit      = float64(200)
+	maxStoreLimit      = float64(2000)
 )
 
 // NewStoreCommand return a stores subcommand of rootCmd

--- a/tools/pd-ctl/tests/config/config_test.go
+++ b/tools/pd-ctl/tests/config/config_test.go
@@ -125,6 +125,12 @@ func (suite *configTestSuite) checkConfig(cluster *pdTests.TestCluster) {
 	_, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 
+	// v2 SendSnapshot window size is dynamically configurable.
+	args = []string{"-u", pdAddr, "config", "set", "store-limit-v2-window-size", "32768"}
+	_, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	re.EqualValues(32768, svr.GetScheduleConfig().StoreLimitV2WindowSize)
+
 	origin := svr.GetPDServerConfig().FlowRoundByDigit
 	args = []string{"-u", pdAddr, "config", "set", "flow-round-by-digit", "10"}
 	_, err = tests.ExecuteCommand(cmd, args...)

--- a/tools/pd-ctl/tests/store/store_test.go
+++ b/tools/pd-ctl/tests/store/store_test.go
@@ -288,6 +288,8 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	storesLimit := leaderServer.GetPersistOptions().GetAllStoresLimit()
 	re.Equal(float64(20), storesLimit[1].AddPeer)
 	re.Equal(float64(20), storesLimit[1].RemovePeer)
+	re.Equal(float64(20), leaderServer.GetPersistOptions().GetScheduleConfig().StoreLimitDefault.AddPeer)
+	re.Equal(float64(20), leaderServer.GetPersistOptions().GetScheduleConfig().StoreLimitDefault.RemovePeer)
 
 	// store limit all <rate> <type>
 	args = []string{"-u", pdAddr, "store", "limit", "all", "25", "remove-peer"}
@@ -491,14 +493,22 @@ func (s *storeTestSuite) checkStore(cluster *pdTests.TestCluster) {
 	re.NoError(err)
 	re.NotContains(string(output), "PANIC")
 
-	// store limit all 201 is invalid for all
-	args = []string{"-u", pdAddr, "store", "limit", "all", "201"}
+	// store limit all 2000 is valid for all
+	args = []string{"-u", pdAddr, "store", "limit", "all", "2000", "add-peer"}
+	_, err = tests.ExecuteCommand(cmd, args...)
+	re.NoError(err)
+	limit = leaderServer.GetRaftCluster().GetStoreLimitByType(1, storelimit.AddPeer)
+	re.Equal(float64(2000), limit)
+	re.Equal(float64(2000), leaderServer.GetPersistOptions().GetScheduleConfig().StoreLimitDefault.AddPeer)
+
+	// store limit all 2001 is invalid for all
+	args = []string{"-u", pdAddr, "store", "limit", "all", "2001"}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	re.Contains(string(output), "rate should be less than")
 
-	// store limit all 201 is invalid for label
-	args = []string{"-u", pdAddr, "store", "limit", "all", "engine", "key", "201", "add-peer"}
+	// store limit all 2001 is invalid for label
+	args = []string{"-u", pdAddr, "store", "limit", "all", "engine", "key", "2001", "add-peer"}
 	output, err = tests.ExecuteCommand(cmd, args...)
 	re.NoError(err)
 	re.Contains(string(output), "rate should be less than")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A (DNM test PR)

PD's fixed store-limit bounds make it difficult to isolate scheduling throughput during TiKV scale-out tests.

### What is changed and how does it work?

```commit-message
Make the v1 store-limit defaults configurable and persistent so existing and newly registered stores can use the configured limits.

Raise the pd-ctl v1 all-store limit bound for scale-out testing while keeping the existing default behavior unchanged.

Add a configurable v2 store-limit window size and apply updates to both PD and scheduling-service store heartbeats.
```

### Check List

Tests

- Unit test
- Integration test

Code changes

- Has the configuration change
- Has persistent data change

### Release note

```release-note
None.
```
