### PR TITLE
pd-ctl: check target readiness before leader transfer

### DIFF
--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -190,7 +190,7 @@ func doRequestSingleEndpointWithContext(ctx context.Context, cmd *cobra.Command,
 	var resp string
 	header := buildNoProxyHeader(cmd, customHeader)
 
-	err := requestURL(cmd, endpoint, func(endpoint string) error {
+	err := requestURL(endpoint, func(endpoint string) error {
 		return doWithContext(ctx, endpoint, prefix, method, &resp, header, b)
 	})
 	return resp, err
@@ -262,11 +262,10 @@ func tryURLs(cmd *cobra.Command, endpoints []string, f DoFunc) error {
 	return err
 }
 
-func requestURL(cmd *cobra.Command, endpoint string, f DoFunc) error {
+func requestURL(endpoint string, f DoFunc) error {
 	endpoint, err := checkURL(endpoint)
 	if err != nil {
-		cmd.Println(err.Error())
-		os.Exit(1)
+		return err
 	}
 	return f(endpoint)
 }

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -203,6 +203,8 @@ func buildNoProxyHeader(cmd *cobra.Command, customHeader http.Header) http.Heade
 }
 
 func dial(req *http.Request) (string, error) {
+	// pd-ctl sends requests only to operator-configured endpoints or client URLs advertised by PD.
+	// #nosec G704
 	resp, err := dialClient.Do(req)
 	if err != nil {
 		return "", err

--- a/tools/pd-ctl/pdctl/command/global.go
+++ b/tools/pd-ctl/pdctl/command/global.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io"
@@ -177,6 +178,11 @@ func doRequest(cmd *cobra.Command, prefix string, method string, customHeader ht
 
 func doRequestSingleEndpoint(cmd *cobra.Command, endpoint, prefix, method string, customHeader http.Header,
 	opts ...BodyOption) (string, error) {
+	return doRequestSingleEndpointWithContext(context.Background(), cmd, endpoint, prefix, method, customHeader, opts...)
+}
+
+func doRequestSingleEndpointWithContext(ctx context.Context, cmd *cobra.Command, endpoint, prefix, method string, customHeader http.Header,
+	opts ...BodyOption) (string, error) {
 	b := &bodyOption{}
 	for _, o := range opts {
 		o(b)
@@ -185,7 +191,7 @@ func doRequestSingleEndpoint(cmd *cobra.Command, endpoint, prefix, method string
 	header := buildNoProxyHeader(cmd, customHeader)
 
 	err := requestURL(cmd, endpoint, func(endpoint string) error {
-		return do(endpoint, prefix, method, &resp, header, b)
+		return doWithContext(ctx, endpoint, prefix, method, &resp, header, b)
 	})
 	return resp, err
 }
@@ -330,6 +336,10 @@ func patchJSON(cmd *cobra.Command, prefix string, input map[string]any) {
 
 // do send a request to server. Default is Get.
 func do(endpoint, prefix, method string, resp *string, customHeader http.Header, b *bodyOption) error {
+	return doWithContext(context.Background(), endpoint, prefix, method, resp, customHeader, b)
+}
+
+func doWithContext(ctx context.Context, endpoint, prefix, method string, resp *string, customHeader http.Header, b *bodyOption) error {
 	var err error
 	url := endpoint + "/" + prefix
 	if method == "" {
@@ -337,7 +347,7 @@ func do(endpoint, prefix, method string, resp *string, customHeader http.Header,
 	}
 	var req *http.Request
 
-	req, err = http.NewRequest(method, url, b.body)
+	req, err = http.NewRequestWithContext(ctx, method, url, b.body)
 	if err != nil {
 		return err
 	}

--- a/tools/pd-ctl/pdctl/command/member_command.go
+++ b/tools/pd-ctl/pdctl/command/member_command.go
@@ -15,17 +15,23 @@
 package command
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/spf13/cobra"
+
+	pd "github.com/tikv/pd/client/http"
+	"github.com/tikv/pd/pkg/utils/apiutil"
 )
 
 var (
 	membersPrefix      = "pd/api/v1/members"
 	leaderMemberPrefix = "pd/api/v1/leader"
+	readyPrefix        = "pd/api/v2/ready"
 )
 
 // NewMemberCommand return a member subcommand of rootCmd
@@ -81,11 +87,13 @@ func NewLeaderMemberCommand() *cobra.Command {
 		Short: "resign current leader pd's leadership",
 		Run:   resignLeaderCommandFunc,
 	})
-	d.AddCommand(&cobra.Command{
+	transfer := &cobra.Command{
 		Use:   "transfer <member_name>",
 		Short: "transfer leadership to another pd",
 		Run:   transferPDLeaderCommandFunc,
-	})
+	}
+	transfer.Flags().BoolP("force", "f", false, "transfer leadership without checking target PD readiness")
+	d.AddCommand(transfer)
 	return d
 }
 
@@ -150,13 +158,79 @@ func transferPDLeaderCommandFunc(cmd *cobra.Command, args []string) {
 		cmd.Println("Usage: leader transfer <member_name>")
 		return
 	}
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		cmd.Printf("Failed to read force flag: %s\n", err)
+		return
+	}
+	if !force {
+		found, err := checkPDMemberReady(cmd, args[0])
+		if err != nil {
+			if !confirmTransferToUnreadyPD(cmd, args[0], err) {
+				return
+			}
+		} else if !found {
+			cmd.Printf("Failed to transfer leadership: target PD member %q was not found\n", args[0])
+			return
+		}
+	}
 	prefix := leaderMemberPrefix + "/transfer/" + args[0]
-	_, err := doRequest(cmd, prefix, http.MethodPost, http.Header{})
+	_, err = doRequest(cmd, prefix, http.MethodPost, http.Header{})
 	if err != nil {
 		cmd.Printf("Failed to transfer leadership: %s\n", err)
 		return
 	}
 	cmd.Println("Success!")
+}
+
+func checkPDMemberReady(cmd *cobra.Command, memberName string) (found bool, err error) {
+	resp, err := doRequest(cmd, membersPrefix, http.MethodGet, http.Header{})
+	if err != nil {
+		return false, fmt.Errorf("get PD members: %w", err)
+	}
+
+	members := &pd.MembersInfo{}
+	if err := json.Unmarshal([]byte(resp), members); err != nil {
+		return false, fmt.Errorf("decode PD members: %w", err)
+	}
+
+	for _, member := range members.Members {
+		if member.GetName() != memberName {
+			continue
+		}
+		if len(member.GetClientUrls()) == 0 {
+			return true, fmt.Errorf("target PD member %q has no client URLs", memberName)
+		}
+
+		var lastErr error
+		header := http.Header{apiutil.PDAllowFollowerHandleHeader: {"true"}}
+		for _, endpoint := range member.GetClientUrls() {
+			_, err := doRequestSingleEndpoint(cmd, endpoint, readyPrefix, http.MethodGet, header)
+			if err == nil {
+				return true, nil
+			}
+			lastErr = err
+		}
+		return true, fmt.Errorf("target PD member %q is not ready: %w", memberName, lastErr)
+	}
+
+	return false, nil
+}
+
+func confirmTransferToUnreadyPD(cmd *cobra.Command, memberName string, readyErr error) bool {
+	cmd.Printf("Warning: target PD member %q is not ready or its readiness cannot be verified: %s\n", memberName, readyErr)
+	cmd.Println("Transferring leadership may cause the PD leader to be unable to serve requests for an extended period.")
+	cmd.Print("Enter Y to continue: ")
+
+	scanner := bufio.NewScanner(cmd.InOrStdin())
+	if !scanner.Scan() || scanner.Text() != "Y" {
+		if err := scanner.Err(); err != nil {
+			cmd.Printf("Failed to read confirmation: %s\n", err)
+		}
+		cmd.Println("Leader transfer aborted.")
+		return false
+	}
+	return true
 }
 
 func setLeaderPriorityFunc(cmd *cobra.Command, args []string) {

--- a/tools/pd-ctl/pdctl/command/member_command.go
+++ b/tools/pd-ctl/pdctl/command/member_command.go
@@ -17,10 +17,12 @@ package command
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -33,6 +35,8 @@ var (
 	leaderMemberPrefix = "pd/api/v1/leader"
 	readyPrefix        = "pd/api/v2/ready"
 )
+
+const readyRequestTimeout = 5 * time.Second
 
 // NewMemberCommand return a member subcommand of rootCmd
 func NewMemberCommand() *cobra.Command {
@@ -205,7 +209,9 @@ func checkPDMemberReady(cmd *cobra.Command, memberName string) (found bool, err 
 		var lastErr error
 		header := http.Header{apiutil.PDAllowFollowerHandleHeader: {"true"}}
 		for _, endpoint := range member.GetClientUrls() {
-			_, err := doRequestSingleEndpoint(cmd, endpoint, readyPrefix, http.MethodGet, header)
+			ctx, cancel := context.WithTimeout(cmd.Context(), readyRequestTimeout)
+			_, err := doRequestSingleEndpointWithContext(ctx, cmd, endpoint, readyPrefix, http.MethodGet, header)
+			cancel()
 			if err == nil {
 				return true, nil
 			}

--- a/tools/pd-ctl/pdctl/command/member_command_test.go
+++ b/tools/pd-ctl/pdctl/command/member_command_test.go
@@ -38,34 +38,29 @@ const (
 )
 
 type transferLeaderRoundTripper struct {
-	memberName             string
-	clientURLs             []string
-	membersStatusCode      int
-	invalidMembersResponse bool
-	noClientURLs           bool
-	readyErrors            []error
-	readyStatusCode        int
-	targetIsLeader         bool
+	memberName      string
+	clientURLs      []string
+	readyErrors     []error
+	readyStatusCode int
+	targetIsLeader  bool
 
 	membersRequests  int
 	readyRequests    int
 	transferRequests int
-	readyMethod      string
 	readyHosts       []string
 	readyTimeouts    []time.Duration
-	readyHeader      http.Header
-	transferMethod   string
+	allowFollower    string
 	transferHost     string
 }
 
 func (rt *transferLeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	statusCode := http.StatusOK
 	body := ""
-	switch req.URL.Path {
-	case "/" + membersPrefix:
+	switch {
+	case req.Method == http.MethodGet && req.URL.Path == "/"+membersPrefix:
 		rt.membersRequests++
 		clientURLs := rt.clientURLs
-		if len(clientURLs) == 0 && !rt.noClientURLs {
+		if len(clientURLs) == 0 {
 			clientURLs = []string{targetPDURL}
 		}
 		members := &pdpb.GetMembersResponse{
@@ -77,34 +72,25 @@ func (rt *transferLeaderRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 		if rt.targetIsLeader {
 			members.EtcdLeader = members.Members[0]
 		}
-		if rt.invalidMembersResponse {
-			body = "{"
-		} else {
-			data, err := json.Marshal(members)
-			if err != nil {
-				return nil, err
-			}
-			body = string(data)
+		data, err := json.Marshal(members)
+		if err != nil {
+			return nil, err
 		}
-		if rt.membersStatusCode != 0 {
-			statusCode = rt.membersStatusCode
-		}
-	case "/" + readyPrefix:
+		body = string(data)
+	case req.Method == http.MethodGet && req.URL.Path == "/"+readyPrefix:
 		rt.readyRequests++
-		rt.readyMethod = req.Method
 		rt.readyHosts = append(rt.readyHosts, req.URL.Host)
 		if deadline, ok := req.Context().Deadline(); ok {
 			rt.readyTimeouts = append(rt.readyTimeouts, time.Until(deadline))
 		}
-		rt.readyHeader = req.Header.Clone()
+		rt.allowFollower = req.Header.Get(apiutil.PDAllowFollowerHandleHeader)
 		requestIndex := rt.readyRequests - 1
 		if requestIndex < len(rt.readyErrors) && rt.readyErrors[requestIndex] != nil {
 			return nil, rt.readyErrors[requestIndex]
 		}
 		statusCode = rt.readyStatusCode
-	case "/" + leaderMemberPrefix + "/transfer/" + rt.memberName:
+	case req.Method == http.MethodPost && req.URL.Path == "/"+leaderMemberPrefix+"/transfer/"+rt.memberName:
 		rt.transferRequests++
-		rt.transferMethod = req.Method
 		rt.transferHost = req.URL.Host
 	default:
 		statusCode = http.StatusNotFound
@@ -138,18 +124,20 @@ func executeTransferLeaderCommand(
 	return out.String()
 }
 
-func TestTransferPDLeaderChecksTargetReadiness(t *testing.T) {
+func TestTransferPDLeaderSubmitsWhenTargetIsReportedAsLeader(t *testing.T) {
 	re := require.New(t)
-	rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusOK}
+	rt := &transferLeaderRoundTripper{
+		memberName:      targetPDName,
+		readyStatusCode: http.StatusOK,
+		targetIsLeader:  true,
+	}
 
 	output := executeTransferLeaderCommand(re, rt, "")
 	re.Equal(1, rt.membersRequests)
 	re.Equal(1, rt.readyRequests)
-	re.Equal(http.MethodGet, rt.readyMethod)
 	re.Equal([]string{"target-pd:2379"}, rt.readyHosts)
-	re.Equal("true", rt.readyHeader.Get(apiutil.PDAllowFollowerHandleHeader))
+	re.Equal("true", rt.allowFollower)
 	re.Equal(1, rt.transferRequests)
-	re.Equal(http.MethodPost, rt.transferMethod)
 	re.Equal("mock-pd:2379", rt.transferHost)
 	re.Contains(output, "Success!")
 }
@@ -157,82 +145,16 @@ func TestTransferPDLeaderChecksTargetReadiness(t *testing.T) {
 func TestTransferPDLeaderRequiresExactConfirmation(t *testing.T) {
 	re := require.New(t)
 
-	for _, input := range []string{"N\n", "y\n", "Y yes\n", "\n", ""} {
-		rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusInternalServerError}
-		output := executeTransferLeaderCommand(re, rt, input)
-		re.Equal(1, rt.readyRequests, "input %q", input)
-		re.Equal(0, rt.transferRequests, "input %q", input)
-		re.Contains(output, "may cause the PD leader to be unable to serve requests for an extended period", "input %q", input)
-		re.Contains(output, "Enter Y to continue", "input %q", input)
-		re.Contains(output, "Leader transfer aborted", "input %q", input)
-	}
-}
-
-func TestTransferPDLeaderContinuesAfterExplicitConfirmation(t *testing.T) {
-	re := require.New(t)
 	rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusInternalServerError}
+	output := executeTransferLeaderCommand(re, rt, "y\n")
+	re.Equal(0, rt.transferRequests)
+	re.Contains(output, "may cause the PD leader to be unable to serve requests for an extended period")
+	re.Contains(output, "Enter Y to continue")
+	re.Contains(output, "Leader transfer aborted")
 
-	output := executeTransferLeaderCommand(re, rt, "Y\n")
-	re.Equal(1, rt.readyRequests)
+	rt = &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusInternalServerError}
+	output = executeTransferLeaderCommand(re, rt, "Y\n")
 	re.Equal(1, rt.transferRequests)
-	re.Contains(output, "Success!")
-}
-
-func TestTransferPDLeaderConfirmsWhenReadinessCannotBeVerified(t *testing.T) {
-	re := require.New(t)
-	rt := &transferLeaderRoundTripper{
-		memberName:  targetPDName,
-		clientURLs:  []string{"http://target-pd-1:2379", "http://target-pd-2:2379"},
-		readyErrors: []error{context.DeadlineExceeded, context.DeadlineExceeded},
-	}
-
-	output := executeTransferLeaderCommand(re, rt, "Y\n")
-	re.Equal(1, rt.membersRequests)
-	re.Equal(2, rt.readyRequests)
-	re.Equal(1, rt.transferRequests)
-	re.Contains(output, "readiness cannot be verified")
-	re.Contains(output, "Success!")
-}
-
-func TestTransferPDLeaderConfirmsWhenMemberDiscoveryFails(t *testing.T) {
-	tests := []struct {
-		name                   string
-		membersStatusCode      int
-		invalidMembersResponse bool
-		expectedError          string
-	}{
-		{name: "request fails", membersStatusCode: http.StatusInternalServerError, expectedError: "get PD members"},
-		{name: "response is invalid", invalidMembersResponse: true, expectedError: "decode PD members"},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			re := require.New(t)
-			rt := &transferLeaderRoundTripper{
-				memberName:             targetPDName,
-				membersStatusCode:      test.membersStatusCode,
-				invalidMembersResponse: test.invalidMembersResponse,
-			}
-
-			output := executeTransferLeaderCommand(re, rt, "Y\n")
-			re.Equal(1, rt.membersRequests)
-			re.Equal(0, rt.readyRequests)
-			re.Equal(1, rt.transferRequests)
-			re.Contains(output, test.expectedError)
-			re.Contains(output, "readiness cannot be verified")
-			re.Contains(output, "Success!")
-		})
-	}
-}
-
-func TestTransferPDLeaderConfirmsWhenTargetHasNoClientURLs(t *testing.T) {
-	re := require.New(t)
-	rt := &transferLeaderRoundTripper{memberName: targetPDName, noClientURLs: true}
-
-	output := executeTransferLeaderCommand(re, rt, "Y\n")
-	re.Equal(1, rt.membersRequests)
-	re.Equal(0, rt.readyRequests)
-	re.Equal(1, rt.transferRequests)
-	re.Contains(output, "has no client URLs")
 	re.Contains(output, "Success!")
 }
 
@@ -250,7 +172,7 @@ func TestCheckPDMemberReadyTriesNextURLAfterTimeout(t *testing.T) {
 
 	cmd := NewMemberCommand()
 	cmd.Flags().String("pd", mockPDURL, "")
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	found, err := checkPDMemberReady(cmd, targetPDName)
 	re.NoError(err)
@@ -276,7 +198,7 @@ func TestCheckPDMemberReadyTriesNextURLAfterInvalidURL(t *testing.T) {
 
 	cmd := NewMemberCommand()
 	cmd.Flags().String("pd", mockPDURL, "")
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	found, err := checkPDMemberReady(cmd, targetPDName)
 	re.NoError(err)
@@ -288,13 +210,11 @@ func TestTransferPDLeaderForceSkipsReadinessPreflight(t *testing.T) {
 	re := require.New(t)
 
 	for _, forceFlag := range []string{"--force", "-f"} {
-		rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusInternalServerError}
-		output := executeTransferLeaderCommand(re, rt, "", forceFlag)
+		rt := &transferLeaderRoundTripper{memberName: targetPDName}
+		executeTransferLeaderCommand(re, rt, "", forceFlag)
 		re.Equal(0, rt.membersRequests, forceFlag)
 		re.Equal(0, rt.readyRequests, forceFlag)
 		re.Equal(1, rt.transferRequests, forceFlag)
-		re.NotContains(output, "Enter Y to continue", forceFlag)
-		re.Contains(output, "Success!", forceFlag)
 	}
 }
 
@@ -307,21 +227,4 @@ func TestTransferPDLeaderRejectsUnknownMember(t *testing.T) {
 	re.Equal(0, rt.readyRequests)
 	re.Equal(0, rt.transferRequests)
 	re.Contains(output, `target PD member "missing" was not found`)
-	re.NotContains(output, "Enter Y to continue")
-}
-
-func TestTransferPDLeaderStillSubmitsWhenTargetWasLeader(t *testing.T) {
-	re := require.New(t)
-	rt := &transferLeaderRoundTripper{
-		memberName:      targetPDName,
-		readyStatusCode: http.StatusOK,
-		targetIsLeader:  true,
-	}
-
-	// The leader can change after the member list is returned, so the transfer must still be submitted.
-	output := executeTransferLeaderCommand(re, rt, "")
-	re.Equal(1, rt.membersRequests)
-	re.Equal(1, rt.readyRequests)
-	re.Equal(1, rt.transferRequests)
-	re.Contains(output, "Success!")
 }

--- a/tools/pd-ctl/pdctl/command/member_command_test.go
+++ b/tools/pd-ctl/pdctl/command/member_command_test.go
@@ -201,14 +201,35 @@ func TestCheckPDMemberReadyTriesNextURLAfterTimeout(t *testing.T) {
 	cmd.SetContext(context.Background())
 
 	found, err := checkPDMemberReady(cmd, targetPDName)
-	re.True(found)
 	re.NoError(err)
+	re.True(found)
 	re.Equal([]string{"target-pd-1:2379", "target-pd-2:2379"}, rt.readyHosts)
 	re.Len(rt.readyTimeouts, 2)
 	for _, timeout := range rt.readyTimeouts {
 		re.Greater(timeout, readyRequestTimeout-time.Second)
 		re.LessOrEqual(timeout, readyRequestTimeout)
 	}
+}
+
+func TestCheckPDMemberReadyTriesNextURLAfterInvalidURL(t *testing.T) {
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{
+		memberName:      targetPDName,
+		clientURLs:      []string{"http://[::1", "http://target-pd-2:2379"},
+		readyStatusCode: http.StatusOK,
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	cmd := NewMemberCommand()
+	cmd.Flags().String("pd", mockPDURL, "")
+	cmd.SetContext(context.Background())
+
+	found, err := checkPDMemberReady(cmd, targetPDName)
+	re.NoError(err)
+	re.True(found)
+	re.Equal([]string{"target-pd-2:2379"}, rt.readyHosts)
 }
 
 func TestTransferPDLeaderForceSkipsReadinessPreflight(t *testing.T) {

--- a/tools/pd-ctl/pdctl/command/member_command_test.go
+++ b/tools/pd-ctl/pdctl/command/member_command_test.go
@@ -38,11 +38,14 @@ const (
 )
 
 type transferLeaderRoundTripper struct {
-	memberName      string
-	clientURLs      []string
-	readyErrors     []error
-	readyStatusCode int
-	targetIsLeader  bool
+	memberName             string
+	clientURLs             []string
+	membersStatusCode      int
+	invalidMembersResponse bool
+	noClientURLs           bool
+	readyErrors            []error
+	readyStatusCode        int
+	targetIsLeader         bool
 
 	membersRequests  int
 	readyRequests    int
@@ -62,7 +65,7 @@ func (rt *transferLeaderRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 	case "/" + membersPrefix:
 		rt.membersRequests++
 		clientURLs := rt.clientURLs
-		if len(clientURLs) == 0 {
+		if len(clientURLs) == 0 && !rt.noClientURLs {
 			clientURLs = []string{targetPDURL}
 		}
 		members := &pdpb.GetMembersResponse{
@@ -74,11 +77,18 @@ func (rt *transferLeaderRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 		if rt.targetIsLeader {
 			members.EtcdLeader = members.Members[0]
 		}
-		data, err := json.Marshal(members)
-		if err != nil {
-			return nil, err
+		if rt.invalidMembersResponse {
+			body = "{"
+		} else {
+			data, err := json.Marshal(members)
+			if err != nil {
+				return nil, err
+			}
+			body = string(data)
 		}
-		body = string(data)
+		if rt.membersStatusCode != 0 {
+			statusCode = rt.membersStatusCode
+		}
 	case "/" + readyPrefix:
 		rt.readyRequests++
 		rt.readyMethod = req.Method
@@ -181,6 +191,48 @@ func TestTransferPDLeaderConfirmsWhenReadinessCannotBeVerified(t *testing.T) {
 	re.Equal(2, rt.readyRequests)
 	re.Equal(1, rt.transferRequests)
 	re.Contains(output, "readiness cannot be verified")
+	re.Contains(output, "Success!")
+}
+
+func TestTransferPDLeaderConfirmsWhenMemberDiscoveryFails(t *testing.T) {
+	tests := []struct {
+		name                   string
+		membersStatusCode      int
+		invalidMembersResponse bool
+		expectedError          string
+	}{
+		{name: "request fails", membersStatusCode: http.StatusInternalServerError, expectedError: "get PD members"},
+		{name: "response is invalid", invalidMembersResponse: true, expectedError: "decode PD members"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			re := require.New(t)
+			rt := &transferLeaderRoundTripper{
+				memberName:             targetPDName,
+				membersStatusCode:      test.membersStatusCode,
+				invalidMembersResponse: test.invalidMembersResponse,
+			}
+
+			output := executeTransferLeaderCommand(re, rt, "Y\n")
+			re.Equal(1, rt.membersRequests)
+			re.Equal(0, rt.readyRequests)
+			re.Equal(1, rt.transferRequests)
+			re.Contains(output, test.expectedError)
+			re.Contains(output, "readiness cannot be verified")
+			re.Contains(output, "Success!")
+		})
+	}
+}
+
+func TestTransferPDLeaderConfirmsWhenTargetHasNoClientURLs(t *testing.T) {
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{memberName: targetPDName, noClientURLs: true}
+
+	output := executeTransferLeaderCommand(re, rt, "Y\n")
+	re.Equal(1, rt.membersRequests)
+	re.Equal(0, rt.readyRequests)
+	re.Equal(1, rt.transferRequests)
+	re.Contains(output, "has no client URLs")
 	re.Contains(output, "Success!")
 }
 

--- a/tools/pd-ctl/pdctl/command/member_command_test.go
+++ b/tools/pd-ctl/pdctl/command/member_command_test.go
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package command_test
+package command
 
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,161 +27,169 @@ import (
 	"github.com/pingcap/kvproto/pkg/pdpb"
 
 	"github.com/tikv/pd/pkg/utils/apiutil"
-	ctl "github.com/tikv/pd/tools/pd-ctl/pdctl"
 )
 
-type transferCommandResult struct {
-	output           string
-	membersRequests  int32
-	readyRequests    int32
-	transferRequests int32
+const (
+	mockPDURL    = "http://mock-pd:2379"
+	targetPDURL  = "http://target-pd:2379"
+	targetPDName = "pd2"
+)
+
+type transferLeaderRoundTripper struct {
+	memberName      string
+	readyStatusCode int
+	targetIsLeader  bool
+
+	membersRequests  int
+	readyRequests    int
+	transferRequests int
+	readyMethod      string
+	readyHost        string
+	readyHeader      http.Header
+	transferMethod   string
+	transferHost     string
 }
 
-func runTransferCommand(
-	t *testing.T,
-	readyStatus int,
-	input string,
-	additionalArgs ...string,
-) transferCommandResult {
-	return runTransferCommandForMember(t, readyStatus, input, "pd2", false, additionalArgs...)
-}
-
-func runTransferCommandForMember(
-	t *testing.T,
-	readyStatus int,
-	input string,
-	memberName string,
-	targetIsLeader bool,
-	additionalArgs ...string,
-) transferCommandResult {
-	t.Helper()
-
-	var readyRequests atomic.Int32
-	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/pd/api/v2/ready" || r.Method != http.MethodGet {
-			t.Errorf("unexpected readiness request %s %s", r.Method, r.URL.Path)
-			http.NotFound(w, r)
-			return
+func (rt *transferLeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	statusCode := http.StatusOK
+	body := ""
+	switch req.URL.Path {
+	case "/" + membersPrefix:
+		rt.membersRequests++
+		members := &pdpb.GetMembersResponse{
+			Members: []*pdpb.Member{{
+				Name:       targetPDName,
+				ClientUrls: []string{targetPDURL},
+			}},
 		}
-		if got := r.Header.Get(apiutil.PDAllowFollowerHandleHeader); got != "true" {
-			t.Errorf("expected %s header to be true, got %q", apiutil.PDAllowFollowerHandleHeader, got)
+		if rt.targetIsLeader {
+			members.EtcdLeader = members.Members[0]
 		}
-		readyRequests.Add(1)
-		w.WriteHeader(readyStatus)
-	}))
-	t.Cleanup(target.Close)
-
-	var membersRequests atomic.Int32
-	var transferRequests atomic.Int32
-	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/pd/api/v1/members":
-			membersRequests.Add(1)
-			members := &pdpb.GetMembersResponse{
-				Members: []*pdpb.Member{{
-					Name:       "pd2",
-					ClientUrls: []string{target.URL},
-				}},
-			}
-			if targetIsLeader {
-				members.EtcdLeader = members.Members[0]
-			}
-			if err := json.NewEncoder(w).Encode(members); err != nil {
-				t.Errorf("encode members response: %v", err)
-			}
-		case "/pd/api/v1/leader/transfer/" + memberName:
-			if r.Method != http.MethodPost {
-				t.Errorf("expected POST transfer request, got %s", r.Method)
-			}
-			transferRequests.Add(1)
-		default:
-			t.Errorf("unexpected control request path %q", r.URL.Path)
-			http.NotFound(w, r)
+		data, err := json.Marshal(members)
+		if err != nil {
+			return nil, err
 		}
-	}))
-	t.Cleanup(control.Close)
-
-	cmd := ctl.GetRootCmd()
-	var output bytes.Buffer
-	cmd.SetIn(strings.NewReader(input))
-	cmd.SetOut(&output)
-	cmd.SetErr(&output)
-	args := []string{"-u", control.URL, "member", "leader", "transfer", memberName}
-	cmd.SetArgs(append(args, additionalArgs...))
-	require.NoError(t, cmd.Execute())
-
-	return transferCommandResult{
-		output:           output.String(),
-		membersRequests:  membersRequests.Load(),
-		readyRequests:    readyRequests.Load(),
-		transferRequests: transferRequests.Load(),
+		body = string(data)
+	case "/" + readyPrefix:
+		rt.readyRequests++
+		rt.readyMethod = req.Method
+		rt.readyHost = req.URL.Host
+		rt.readyHeader = req.Header.Clone()
+		statusCode = rt.readyStatusCode
+	case "/" + leaderMemberPrefix + "/transfer/" + rt.memberName:
+		rt.transferRequests++
+		rt.transferMethod = req.Method
+		rt.transferHost = req.URL.Host
+	default:
+		statusCode = http.StatusNotFound
 	}
+
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func executeTransferLeaderCommand(
+	re *require.Assertions,
+	rt *transferLeaderRoundTripper,
+	input string,
+	additionalArgs ...string,
+) string {
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	cmd := NewMemberCommand()
+	cmd.PersistentFlags().String("pd", mockPDURL, "")
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetArgs(append([]string{"leader", "transfer", rt.memberName}, additionalArgs...))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	re.NoError(cmd.Execute())
+	return out.String()
 }
 
 func TestTransferPDLeaderChecksTargetReadiness(t *testing.T) {
-	result := runTransferCommand(t, http.StatusOK, "")
-	require.Equal(t, int32(1), result.membersRequests)
-	require.Equal(t, int32(1), result.readyRequests)
-	require.Equal(t, int32(1), result.transferRequests)
-	require.Contains(t, result.output, "Success!")
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusOK}
+
+	output := executeTransferLeaderCommand(re, rt, "")
+	re.Equal(1, rt.membersRequests)
+	re.Equal(1, rt.readyRequests)
+	re.Equal(http.MethodGet, rt.readyMethod)
+	re.Equal("target-pd:2379", rt.readyHost)
+	re.Equal("true", rt.readyHeader.Get(apiutil.PDAllowFollowerHandleHeader))
+	re.Equal(1, rt.transferRequests)
+	re.Equal(http.MethodPost, rt.transferMethod)
+	re.Equal("mock-pd:2379", rt.transferHost)
+	re.Contains(output, "Success!")
 }
 
 func TestTransferPDLeaderRequiresExactConfirmation(t *testing.T) {
-	for _, test := range []struct {
-		name  string
-		input string
-	}{
-		{name: "declined", input: "N\n"},
-		{name: "lowercase", input: "y\n"},
-		{name: "extra input", input: "Y yes\n"},
-		{name: "empty input", input: "\n"},
-		{name: "EOF"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			result := runTransferCommand(t, http.StatusInternalServerError, test.input)
-			require.Equal(t, int32(1), result.readyRequests)
-			require.Equal(t, int32(0), result.transferRequests)
-			require.Contains(t, result.output, "may cause the PD leader to be unable to serve requests for an extended period")
-			require.Contains(t, result.output, "Enter Y to continue")
-			require.Contains(t, result.output, "Leader transfer aborted")
-		})
+	re := require.New(t)
+
+	for _, input := range []string{"N\n", "y\n", "Y yes\n", "\n", ""} {
+		rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusInternalServerError}
+		output := executeTransferLeaderCommand(re, rt, input)
+		re.Equal(1, rt.readyRequests, "input %q", input)
+		re.Equal(0, rt.transferRequests, "input %q", input)
+		re.Contains(output, "may cause the PD leader to be unable to serve requests for an extended period", "input %q", input)
+		re.Contains(output, "Enter Y to continue", "input %q", input)
+		re.Contains(output, "Leader transfer aborted", "input %q", input)
 	}
 }
 
 func TestTransferPDLeaderContinuesAfterExplicitConfirmation(t *testing.T) {
-	result := runTransferCommand(t, http.StatusInternalServerError, "Y\n")
-	require.Equal(t, int32(1), result.readyRequests)
-	require.Equal(t, int32(1), result.transferRequests)
-	require.Contains(t, result.output, "Success!")
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusInternalServerError}
+
+	output := executeTransferLeaderCommand(re, rt, "Y\n")
+	re.Equal(1, rt.readyRequests)
+	re.Equal(1, rt.transferRequests)
+	re.Contains(output, "Success!")
 }
 
 func TestTransferPDLeaderForceSkipsReadinessPreflight(t *testing.T) {
+	re := require.New(t)
+
 	for _, forceFlag := range []string{"--force", "-f"} {
-		t.Run(forceFlag, func(t *testing.T) {
-			result := runTransferCommand(t, http.StatusInternalServerError, "", forceFlag)
-			require.Equal(t, int32(0), result.membersRequests)
-			require.Equal(t, int32(0), result.readyRequests)
-			require.Equal(t, int32(1), result.transferRequests)
-			require.NotContains(t, result.output, "Enter Y to continue")
-			require.Contains(t, result.output, "Success!")
-		})
+		rt := &transferLeaderRoundTripper{memberName: targetPDName, readyStatusCode: http.StatusInternalServerError}
+		output := executeTransferLeaderCommand(re, rt, "", forceFlag)
+		re.Equal(0, rt.membersRequests, forceFlag)
+		re.Equal(0, rt.readyRequests, forceFlag)
+		re.Equal(1, rt.transferRequests, forceFlag)
+		re.NotContains(output, "Enter Y to continue", forceFlag)
+		re.Contains(output, "Success!", forceFlag)
 	}
 }
 
 func TestTransferPDLeaderRejectsUnknownMember(t *testing.T) {
-	result := runTransferCommandForMember(t, http.StatusOK, "", "missing", false)
-	require.Equal(t, int32(1), result.membersRequests)
-	require.Equal(t, int32(0), result.readyRequests)
-	require.Equal(t, int32(0), result.transferRequests)
-	require.Contains(t, result.output, `target PD member "missing" was not found`)
-	require.NotContains(t, result.output, "Enter Y to continue")
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{memberName: "missing", readyStatusCode: http.StatusOK}
+
+	output := executeTransferLeaderCommand(re, rt, "")
+	re.Equal(1, rt.membersRequests)
+	re.Equal(0, rt.readyRequests)
+	re.Equal(0, rt.transferRequests)
+	re.Contains(output, `target PD member "missing" was not found`)
+	re.NotContains(output, "Enter Y to continue")
 }
 
 func TestTransferPDLeaderStillSubmitsWhenTargetWasLeader(t *testing.T) {
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{
+		memberName:      targetPDName,
+		readyStatusCode: http.StatusOK,
+		targetIsLeader:  true,
+	}
+
 	// The leader can change after the member list is returned, so the transfer must still be submitted.
-	result := runTransferCommandForMember(t, http.StatusOK, "", "pd2", true)
-	require.Equal(t, int32(1), result.membersRequests)
-	require.Equal(t, int32(1), result.readyRequests)
-	require.Equal(t, int32(1), result.transferRequests)
-	require.Contains(t, result.output, "Success!")
+	output := executeTransferLeaderCommand(re, rt, "")
+	re.Equal(1, rt.membersRequests)
+	re.Equal(1, rt.readyRequests)
+	re.Equal(1, rt.transferRequests)
+	re.Contains(output, "Success!")
 }

--- a/tools/pd-ctl/pdctl/command/member_command_test.go
+++ b/tools/pd-ctl/pdctl/command/member_command_test.go
@@ -16,11 +16,13 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -37,6 +39,8 @@ const (
 
 type transferLeaderRoundTripper struct {
 	memberName      string
+	clientURLs      []string
+	readyErrors     []error
 	readyStatusCode int
 	targetIsLeader  bool
 
@@ -44,7 +48,8 @@ type transferLeaderRoundTripper struct {
 	readyRequests    int
 	transferRequests int
 	readyMethod      string
-	readyHost        string
+	readyHosts       []string
+	readyTimeouts    []time.Duration
 	readyHeader      http.Header
 	transferMethod   string
 	transferHost     string
@@ -56,10 +61,14 @@ func (rt *transferLeaderRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 	switch req.URL.Path {
 	case "/" + membersPrefix:
 		rt.membersRequests++
+		clientURLs := rt.clientURLs
+		if len(clientURLs) == 0 {
+			clientURLs = []string{targetPDURL}
+		}
 		members := &pdpb.GetMembersResponse{
 			Members: []*pdpb.Member{{
 				Name:       targetPDName,
-				ClientUrls: []string{targetPDURL},
+				ClientUrls: clientURLs,
 			}},
 		}
 		if rt.targetIsLeader {
@@ -73,8 +82,15 @@ func (rt *transferLeaderRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 	case "/" + readyPrefix:
 		rt.readyRequests++
 		rt.readyMethod = req.Method
-		rt.readyHost = req.URL.Host
+		rt.readyHosts = append(rt.readyHosts, req.URL.Host)
+		if deadline, ok := req.Context().Deadline(); ok {
+			rt.readyTimeouts = append(rt.readyTimeouts, time.Until(deadline))
+		}
 		rt.readyHeader = req.Header.Clone()
+		requestIndex := rt.readyRequests - 1
+		if requestIndex < len(rt.readyErrors) && rt.readyErrors[requestIndex] != nil {
+			return nil, rt.readyErrors[requestIndex]
+		}
 		statusCode = rt.readyStatusCode
 	case "/" + leaderMemberPrefix + "/transfer/" + rt.memberName:
 		rt.transferRequests++
@@ -120,7 +136,7 @@ func TestTransferPDLeaderChecksTargetReadiness(t *testing.T) {
 	re.Equal(1, rt.membersRequests)
 	re.Equal(1, rt.readyRequests)
 	re.Equal(http.MethodGet, rt.readyMethod)
-	re.Equal("target-pd:2379", rt.readyHost)
+	re.Equal([]string{"target-pd:2379"}, rt.readyHosts)
 	re.Equal("true", rt.readyHeader.Get(apiutil.PDAllowFollowerHandleHeader))
 	re.Equal(1, rt.transferRequests)
 	re.Equal(http.MethodPost, rt.transferMethod)
@@ -150,6 +166,49 @@ func TestTransferPDLeaderContinuesAfterExplicitConfirmation(t *testing.T) {
 	re.Equal(1, rt.readyRequests)
 	re.Equal(1, rt.transferRequests)
 	re.Contains(output, "Success!")
+}
+
+func TestTransferPDLeaderConfirmsWhenReadinessCannotBeVerified(t *testing.T) {
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{
+		memberName:  targetPDName,
+		clientURLs:  []string{"http://target-pd-1:2379", "http://target-pd-2:2379"},
+		readyErrors: []error{context.DeadlineExceeded, context.DeadlineExceeded},
+	}
+
+	output := executeTransferLeaderCommand(re, rt, "Y\n")
+	re.Equal(1, rt.membersRequests)
+	re.Equal(2, rt.readyRequests)
+	re.Equal(1, rt.transferRequests)
+	re.Contains(output, "readiness cannot be verified")
+	re.Contains(output, "Success!")
+}
+
+func TestCheckPDMemberReadyTriesNextURLAfterTimeout(t *testing.T) {
+	re := require.New(t)
+	rt := &transferLeaderRoundTripper{
+		memberName:      targetPDName,
+		clientURLs:      []string{"http://target-pd-1:2379", "http://target-pd-2:2379"},
+		readyErrors:     []error{context.DeadlineExceeded},
+		readyStatusCode: http.StatusOK,
+	}
+	oldClient := dialClient
+	dialClient = &http.Client{Transport: rt}
+	defer func() { dialClient = oldClient }()
+
+	cmd := NewMemberCommand()
+	cmd.Flags().String("pd", mockPDURL, "")
+	cmd.SetContext(context.Background())
+
+	found, err := checkPDMemberReady(cmd, targetPDName)
+	re.True(found)
+	re.NoError(err)
+	re.Equal([]string{"target-pd-1:2379", "target-pd-2:2379"}, rt.readyHosts)
+	re.Len(rt.readyTimeouts, 2)
+	for _, timeout := range rt.readyTimeouts {
+		re.Greater(timeout, readyRequestTimeout-time.Second)
+		re.LessOrEqual(timeout, readyRequestTimeout)
+	}
 }
 
 func TestTransferPDLeaderForceSkipsReadinessPreflight(t *testing.T) {

--- a/tools/pd-ctl/pdctl/command/member_command_test.go
+++ b/tools/pd-ctl/pdctl/command/member_command_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 TiKV Project Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/kvproto/pkg/pdpb"
+
+	"github.com/tikv/pd/pkg/utils/apiutil"
+	ctl "github.com/tikv/pd/tools/pd-ctl/pdctl"
+)
+
+type transferCommandResult struct {
+	output           string
+	membersRequests  int32
+	readyRequests    int32
+	transferRequests int32
+}
+
+func runTransferCommand(
+	t *testing.T,
+	readyStatus int,
+	input string,
+	additionalArgs ...string,
+) transferCommandResult {
+	return runTransferCommandForMember(t, readyStatus, input, "pd2", false, additionalArgs...)
+}
+
+func runTransferCommandForMember(
+	t *testing.T,
+	readyStatus int,
+	input string,
+	memberName string,
+	targetIsLeader bool,
+	additionalArgs ...string,
+) transferCommandResult {
+	t.Helper()
+
+	var readyRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pd/api/v2/ready" || r.Method != http.MethodGet {
+			t.Errorf("unexpected readiness request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get(apiutil.PDAllowFollowerHandleHeader); got != "true" {
+			t.Errorf("expected %s header to be true, got %q", apiutil.PDAllowFollowerHandleHeader, got)
+		}
+		readyRequests.Add(1)
+		w.WriteHeader(readyStatus)
+	}))
+	t.Cleanup(target.Close)
+
+	var membersRequests atomic.Int32
+	var transferRequests atomic.Int32
+	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/pd/api/v1/members":
+			membersRequests.Add(1)
+			members := &pdpb.GetMembersResponse{
+				Members: []*pdpb.Member{{
+					Name:       "pd2",
+					ClientUrls: []string{target.URL},
+				}},
+			}
+			if targetIsLeader {
+				members.EtcdLeader = members.Members[0]
+			}
+			if err := json.NewEncoder(w).Encode(members); err != nil {
+				t.Errorf("encode members response: %v", err)
+			}
+		case "/pd/api/v1/leader/transfer/" + memberName:
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST transfer request, got %s", r.Method)
+			}
+			transferRequests.Add(1)
+		default:
+			t.Errorf("unexpected control request path %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(control.Close)
+
+	cmd := ctl.GetRootCmd()
+	var output bytes.Buffer
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	args := []string{"-u", control.URL, "member", "leader", "transfer", memberName}
+	cmd.SetArgs(append(args, additionalArgs...))
+	require.NoError(t, cmd.Execute())
+
+	return transferCommandResult{
+		output:           output.String(),
+		membersRequests:  membersRequests.Load(),
+		readyRequests:    readyRequests.Load(),
+		transferRequests: transferRequests.Load(),
+	}
+}
+
+func TestTransferPDLeaderChecksTargetReadiness(t *testing.T) {
+	result := runTransferCommand(t, http.StatusOK, "")
+	require.Equal(t, int32(1), result.membersRequests)
+	require.Equal(t, int32(1), result.readyRequests)
+	require.Equal(t, int32(1), result.transferRequests)
+	require.Contains(t, result.output, "Success!")
+}
+
+func TestTransferPDLeaderRequiresExactConfirmation(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input string
+	}{
+		{name: "declined", input: "N\n"},
+		{name: "lowercase", input: "y\n"},
+		{name: "extra input", input: "Y yes\n"},
+		{name: "empty input", input: "\n"},
+		{name: "EOF"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := runTransferCommand(t, http.StatusInternalServerError, test.input)
+			require.Equal(t, int32(1), result.readyRequests)
+			require.Equal(t, int32(0), result.transferRequests)
+			require.Contains(t, result.output, "may cause the PD leader to be unable to serve requests for an extended period")
+			require.Contains(t, result.output, "Enter Y to continue")
+			require.Contains(t, result.output, "Leader transfer aborted")
+		})
+	}
+}
+
+func TestTransferPDLeaderContinuesAfterExplicitConfirmation(t *testing.T) {
+	result := runTransferCommand(t, http.StatusInternalServerError, "Y\n")
+	require.Equal(t, int32(1), result.readyRequests)
+	require.Equal(t, int32(1), result.transferRequests)
+	require.Contains(t, result.output, "Success!")
+}
+
+func TestTransferPDLeaderForceSkipsReadinessPreflight(t *testing.T) {
+	for _, forceFlag := range []string{"--force", "-f"} {
+		t.Run(forceFlag, func(t *testing.T) {
+			result := runTransferCommand(t, http.StatusInternalServerError, "", forceFlag)
+			require.Equal(t, int32(0), result.membersRequests)
+			require.Equal(t, int32(0), result.readyRequests)
+			require.Equal(t, int32(1), result.transferRequests)
+			require.NotContains(t, result.output, "Enter Y to continue")
+			require.Contains(t, result.output, "Success!")
+		})
+	}
+}
+
+func TestTransferPDLeaderRejectsUnknownMember(t *testing.T) {
+	result := runTransferCommandForMember(t, http.StatusOK, "", "missing", false)
+	require.Equal(t, int32(1), result.membersRequests)
+	require.Equal(t, int32(0), result.readyRequests)
+	require.Equal(t, int32(0), result.transferRequests)
+	require.Contains(t, result.output, `target PD member "missing" was not found`)
+	require.NotContains(t, result.output, "Enter Y to continue")
+}
+
+func TestTransferPDLeaderStillSubmitsWhenTargetWasLeader(t *testing.T) {
+	// The leader can change after the member list is returned, so the transfer must still be submitted.
+	result := runTransferCommandForMember(t, http.StatusOK, "", "pd2", true)
+	require.Equal(t, int32(1), result.membersRequests)
+	require.Equal(t, int32(1), result.readyRequests)
+	require.Equal(t, int32(1), result.transferRequests)
+	require.Contains(t, result.output, "Success!")
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #11129

`pd-ctl member leader transfer` can transfer leadership to a PD member before it finishes loading Region metadata, which may leave the new leader unable to serve requests for an extended period.

### What is changed and how does it work?

```commit-message
Check the target member's local `/pd/api/v2/ready` endpoint through its advertised client URL before transferring leadership. Submit the transfer when the target is ready, including when the member snapshot reports the target as the current etcd leader, require an exact uppercase `Y` confirmation when readiness fails or cannot be verified, and reject unknown targets. Bound each direct readiness request to five seconds and try all advertised client URLs before prompting. Add `--force` and `-f` to bypass member discovery, readiness checks, and confirmation.
```

### Check List

Tests

- Unit test
- Integration test

### Release note

```release-note
Add a readiness preflight and confirmation prompt to pd-ctl PD leader transfers, with `--force` and `-f` to bypass the check.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added readiness checks to `pd-ctl member leader transfer`.
  * Transfers to unavailable or unready members now require explicit confirmation.
  * Added `--force`/`-f` to bypass readiness checks when necessary.
  * Improved handling for unknown targets and transfers involving the current leader.

* **Bug Fixes**
  * Improved validation, timeout handling, and recovery when checking transfer targets.
  * Added support for cancelling requests and honoring request deadlines.
  * Prevented unsafe or invalid transfers from proceeding without confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
